### PR TITLE
feat(cli): add --report-path to tuist test for structured summaries

### DIFF
--- a/cli/Sources/TuistEnvKey/EnvKey.swift
+++ b/cli/Sources/TuistEnvKey/EnvKey.swift
@@ -195,6 +195,7 @@ public enum EnvKey: String, CaseIterable {
     case testShardReference = "TUIST_SHARD_REFERENCE"
     case testShardSkipUpload = "TUIST_TEST_SHARD_SKIP_UPLOAD"
     case testShardArchivePath = "TUIST_TEST_SHARD_ARCHIVE_PATH"
+    case testReportPath = "TUIST_TEST_REPORT_PATH"
 
     // TEST SHOW
 

--- a/cli/Sources/TuistKit/Services/TestService.swift
+++ b/cli/Sources/TuistKit/Services/TestService.swift
@@ -244,7 +244,8 @@ public struct TestService { // swiftlint:disable:this type_body_length
         shardIndex: Int? = nil,
         shardSkipUpload: Bool = false,
         shardArchivePath: AbsolutePath? = nil,
-        mode: TestProcessingMode? = nil
+        mode: TestProcessingMode? = nil,
+        reportPath: AbsolutePath? = nil
     ) async throws {
         if validateTestTargetsParameters {
             try Self.validateParameters(
@@ -289,7 +290,8 @@ public struct TestService { // swiftlint:disable:this type_body_length
                 passthroughXcodeBuildArguments: passthroughXcodeBuildArguments,
                 runId: runId,
                 shardArchivePath: shardArchivePath,
-                mode: mode
+                mode: mode,
+                reportPath: reportPath
             )
             return
         }
@@ -313,7 +315,8 @@ public struct TestService { // swiftlint:disable:this type_body_length
                 testPlanConfiguration: testPlanConfiguration,
                 passthroughXcodeBuildArguments: passthroughXcodeBuildArguments,
                 runId: runId,
-                mode: mode
+                mode: mode,
+                reportPath: reportPath
             )
             return
         }
@@ -548,7 +551,8 @@ public struct TestService { // swiftlint:disable:this type_body_length
                 passthroughXcodeBuildArguments: passthroughXcodeBuildArguments,
                 config: config,
                 quarantinedTests: mutedQuarantinedTests,
-                mode: mode
+                mode: mode,
+                reportPath: reportPath
             )
         } catch {
             try await copyResultBundlePathIfNeeded(
@@ -629,7 +633,8 @@ public struct TestService { // swiftlint:disable:this type_body_length
         passthroughXcodeBuildArguments: [String],
         runId: String,
         shardArchivePath: AbsolutePath?,
-        mode: TestProcessingMode
+        mode: TestProcessingMode,
+        reportPath: AbsolutePath?
     ) async throws {
         guard let fullHandle = config.fullHandle else {
             throw TestServiceError.actionInvalid
@@ -694,9 +699,12 @@ public struct TestService { // swiftlint:disable:this type_body_length
             testError = error
         }
 
-        let summary = mode == .local
-            ? await testSummary(resultBundlePath: resultBundlePath, quarantinedTests: [])
-            : nil
+        let summary = await summaryIfNeeded(
+            resultBundlePath: resultBundlePath,
+            quarantinedTests: [],
+            mode: mode,
+            reportPath: reportPath
+        )
         await uploadResultBundleIfNeeded(
             testSummary: summary,
             resultBundlePath: resultBundlePath,
@@ -751,7 +759,8 @@ public struct TestService { // swiftlint:disable:this type_body_length
         testPlanConfiguration: TestPlanConfiguration?,
         passthroughXcodeBuildArguments: [String],
         runId: String,
-        mode: TestProcessingMode
+        mode: TestProcessingMode,
+        reportPath: AbsolutePath?
     ) async throws {
         Logger.current.notice(
             "Skipping project generation, using selective testing graph from .xctestproducts bundle...",
@@ -828,9 +837,12 @@ public struct TestService { // swiftlint:disable:this type_body_length
             testError = error
         }
 
-        let summary = mode == .local
-            ? await testSummary(resultBundlePath: resultBundlePath, quarantinedTests: [])
-            : nil
+        let summary = await summaryIfNeeded(
+            resultBundlePath: resultBundlePath,
+            quarantinedTests: [],
+            mode: mode,
+            reportPath: reportPath
+        )
         await uploadResultBundleIfNeeded(
             testSummary: summary,
             resultBundlePath: resultBundlePath,
@@ -1118,7 +1130,8 @@ public struct TestService { // swiftlint:disable:this type_body_length
         passthroughXcodeBuildArguments: [String],
         config: Tuist,
         quarantinedTests: [TestIdentifier],
-        mode: TestProcessingMode = .local
+        mode: TestProcessingMode = .local,
+        reportPath: AbsolutePath? = nil
     ) async throws {
         let timer = clock.startTimer()
         let graphTraverser = GraphTraverser(graph: graph)
@@ -1163,7 +1176,8 @@ public struct TestService { // swiftlint:disable:this type_body_length
                     passthroughXcodeBuildArguments: passthroughXcodeBuildArguments,
                     config: config,
                     quarantinedTests: quarantinedTests,
-                    mode: mode
+                    mode: mode,
+                    reportPath: reportPath
                 )
             }
         } catch {
@@ -1522,7 +1536,8 @@ public struct TestService { // swiftlint:disable:this type_body_length
         passthroughXcodeBuildArguments: [String],
         config: Tuist,
         quarantinedTests: [TestIdentifier],
-        mode: TestProcessingMode = .local
+        mode: TestProcessingMode = .local,
+        reportPath: AbsolutePath? = nil
     ) async throws {
         Logger.current.log(
             level: .notice, "\(action.description) scheme \(scheme.name)", metadata: .section
@@ -1626,9 +1641,12 @@ public struct TestService { // swiftlint:disable:this type_body_length
                 scheme: scheme.name,
                 configuration: configuration
             )
-            let summary = mode == .local
-                ? await testSummary(resultBundlePath: resultBundlePath, quarantinedTests: quarantinedTests)
-                : nil
+            let summary = await summaryIfNeeded(
+                resultBundlePath: resultBundlePath,
+                quarantinedTests: quarantinedTests,
+                mode: mode,
+                reportPath: reportPath
+            )
             await uploadResultBundleIfNeeded(
                 testSummary: summary,
                 resultBundlePath: resultBundlePath,
@@ -1648,9 +1666,12 @@ public struct TestService { // swiftlint:disable:this type_body_length
             scheme: scheme.name,
             configuration: configuration
         )
-        let summary = mode == .local
-            ? await testSummary(resultBundlePath: resultBundlePath, quarantinedTests: quarantinedTests)
-            : nil
+        let summary = await summaryIfNeeded(
+            resultBundlePath: resultBundlePath,
+            quarantinedTests: quarantinedTests,
+            mode: mode,
+            reportPath: reportPath
+        )
         await uploadResultBundleIfNeeded(
             testSummary: summary,
             resultBundlePath: resultBundlePath,
@@ -1671,6 +1692,35 @@ public struct TestService { // swiftlint:disable:this type_body_length
               let parsed = try? await xcResultService.parse(path: resultBundlePath, rootDirectory: rootDir)
         else { return nil }
         return testQuarantineService.markQuarantinedTests(testSummary: parsed, quarantinedTests: quarantinedTests)
+    }
+
+    /// Produce a `TestSummary` if the caller needs it. Local mode always needs it (for the
+    /// summary upload). Remote mode skips parsing unless `--report-path` is set. Writes the
+    /// summary to `reportPath` when provided.
+    private func summaryIfNeeded(
+        resultBundlePath: AbsolutePath?,
+        quarantinedTests: [TestIdentifier],
+        mode: TestProcessingMode,
+        reportPath: AbsolutePath?
+    ) async -> TestSummary? {
+        let needsSummary = mode == .local || reportPath != nil
+        guard needsSummary else { return nil }
+        let summary = await testSummary(resultBundlePath: resultBundlePath, quarantinedTests: quarantinedTests)
+        if let summary, let reportPath {
+            writeReport(summary: summary, to: reportPath)
+        }
+        return summary
+    }
+
+    private func writeReport(summary: TestSummary, to path: AbsolutePath) {
+        do {
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+            let data = try encoder.encode(summary)
+            try data.write(to: URL(fileURLWithPath: path.pathString), options: .atomic)
+        } catch {
+            AlertController.current.warning(.alert("Failed to write test report to \(path.pathString): \(error.localizedDescription)"))
+        }
     }
 
     private func uploadBuildRunIfNeeded(

--- a/cli/Sources/TuistKit/Services/TestService.swift
+++ b/cli/Sources/TuistKit/Services/TestService.swift
@@ -1719,7 +1719,9 @@ public struct TestService { // swiftlint:disable:this type_body_length
             let data = try encoder.encode(summary)
             try data.write(to: URL(fileURLWithPath: path.pathString), options: .atomic)
         } catch {
-            AlertController.current.warning(.alert("Failed to write test report to \(path.pathString): \(error.localizedDescription)"))
+            AlertController.current.warning(
+                .alert("Failed to write test report to \(path.pathString): \(error.localizedDescription)")
+            )
         }
     }
 

--- a/cli/Sources/TuistTestCommand/TestRunCommand.swift
+++ b/cli/Sources/TuistTestCommand/TestRunCommand.swift
@@ -50,6 +50,7 @@
         "test-without-building",
     ]
 
+    // swiftlint:disable:next type_body_length
     public struct TestRunCommand: AsyncParsableCommand, LogConfigurableCommand, TrackableParsableCommand {
         public init() {}
 

--- a/cli/Sources/TuistTestCommand/TestRunCommand.swift
+++ b/cli/Sources/TuistTestCommand/TestRunCommand.swift
@@ -50,7 +50,6 @@
         "test-without-building",
     ]
 
-    // swiftlint:disable:next type_body_length
     public struct TestRunCommand: AsyncParsableCommand, LogConfigurableCommand, TrackableParsableCommand {
         public init() {}
 

--- a/cli/Sources/TuistTestCommand/TestRunCommand.swift
+++ b/cli/Sources/TuistTestCommand/TestRunCommand.swift
@@ -158,6 +158,14 @@
         var resultBundlePath: String?
 
         @Option(
+            name: .long,
+            help: "Path where a JSON summary of test case outcomes will be written after the run. Useful for CI post-processing; parses the xcresult locally regardless of --inspect-mode.",
+            completion: .file(),
+            envKey: .testReportPath
+        )
+        var reportPath: String?
+
+        @Option(
             help:
             "[Deprecated] Overrides the folder that should be used for derived data when testing a project.",
             completion: .directory,
@@ -444,7 +452,13 @@
                     }
                     return nil
                 }(),
-                mode: inspectMode
+                mode: inspectMode,
+                reportPath: try await {
+                    if let reportPath {
+                        return try await Environment.current.pathRelativeToWorkingDirectory(reportPath)
+                    }
+                    return nil
+                }()
             )
         }
     }

--- a/cli/Tests/TuistKitTests/Services/TestServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/TestServiceTests.swift
@@ -3715,6 +3715,135 @@ final class TestServiceTests: TuistUnitTestCase {
         }
     }
 
+    func test_run_writesReportPathInLocalMode() async throws {
+        try await withMockedDependencies {
+            // Given
+            givenGenerator()
+            given(buildGraphInspector)
+                .workspaceSchemes(graphTraverser: .any)
+                .willReturn([Scheme.test(name: "ProjectScheme")])
+            given(generator)
+                .generateWithGraph(path: .any, options: .any)
+                .willProduce { path, _ in (path, .test(), MapperEnvironment()) }
+
+            let resultBundlePath = try temporaryPath().appending(component: "test.xcresult")
+            try await fileSystem.makeDirectory(at: resultBundlePath)
+            let reportPath = try temporaryPath().appending(component: "report.json")
+
+            configLoader.reset()
+            given(configLoader)
+                .loadConfig(path: .any)
+                .willReturn(
+                    .test(
+                        project: .testGeneratedProject(),
+                        fullHandle: "tuist/tuist",
+                        url: URL(string: "https://example.com")!
+                    )
+                )
+
+            xcResultService.reset()
+            given(xcResultService)
+                .parse(path: .any, rootDirectory: .any)
+                .willReturn(
+                    TestSummary(
+                        testPlanName: "RequiredTests",
+                        status: .failed,
+                        duration: 1234,
+                        testModules: []
+                    )
+                )
+
+            // When
+            try await testRun(
+                path: try temporaryPath(),
+                resultBundlePath: resultBundlePath,
+                mode: .local,
+                reportPath: reportPath
+            )
+
+            // Then
+            let reportExists = try await fileSystem.exists(reportPath)
+            XCTAssertTrue(reportExists)
+            let data = try Data(contentsOf: URL(fileURLWithPath: reportPath.pathString))
+            let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+            XCTAssertEqual(json?["test_plan_name"] as? String, "RequiredTests")
+            XCTAssertEqual(json?["status"] as? String, "failure")
+        }
+    }
+
+    func test_run_writesReportPathInRemoteMode() async throws {
+        try await withMockedDependencies {
+            // Given
+            givenGenerator()
+            given(buildGraphInspector)
+                .workspaceSchemes(graphTraverser: .any)
+                .willReturn([Scheme.test(name: "ProjectScheme")])
+            given(generator)
+                .generateWithGraph(path: .any, options: .any)
+                .willProduce { path, _ in (path, .test(), MapperEnvironment()) }
+
+            let resultBundlePath = try temporaryPath().appending(component: "test.xcresult")
+            try await fileSystem.makeDirectory(at: resultBundlePath)
+            let reportPath = try temporaryPath().appending(component: "report.json")
+
+            configLoader.reset()
+            given(configLoader)
+                .loadConfig(path: .any)
+                .willReturn(
+                    .test(
+                        project: .testGeneratedProject(),
+                        fullHandle: "tuist/tuist",
+                        url: URL(string: "https://example.com")!
+                    )
+                )
+
+            xcResultService.reset()
+            given(xcResultService)
+                .parse(path: .any, rootDirectory: .any)
+                .willReturn(
+                    TestSummary(
+                        testPlanName: "RequiredTests",
+                        status: .passed,
+                        duration: 42,
+                        testModules: []
+                    )
+                )
+
+            given(uploadResultBundleService)
+                .uploadResultBundle(
+                    resultBundlePath: .any,
+                    config: .any,
+                    quarantinedTests: .any,
+                    buildRunId: .any,
+                    shardPlanId: .any,
+                    shardIndex: .any
+                )
+                .willReturn(
+                    Components.Schemas.RunsTest(
+                        duration: 0,
+                        id: "stub",
+                        project_id: 0,
+                        test_case_runs: [],
+                        _type: .test,
+                        url: ""
+                    )
+                )
+
+            // When: remote mode still writes the report because the CLI parses the xcresult
+            // locally for the report side-effect, regardless of the upload mode.
+            try await testRun(
+                path: try temporaryPath(),
+                resultBundlePath: resultBundlePath,
+                mode: .remote,
+                reportPath: reportPath
+            )
+
+            // Then
+            let reportExists = try await fileSystem.exists(reportPath)
+            XCTAssertTrue(reportExists)
+        }
+    }
+
     func test_run_fetches_quarantined_tests_and_runs_them() async throws {
         // Given
         givenGenerator()
@@ -4928,7 +5057,8 @@ final class TestServiceTests: TuistUnitTestCase {
         shardIndex: Int? = nil,
         shardSkipUpload: Bool = false,
         shardArchivePath: AbsolutePath? = nil,
-        mode: TestProcessingMode? = .local
+        mode: TestProcessingMode? = .local,
+        reportPath: AbsolutePath? = nil
     ) async throws {
         try await RunMetadataStorage.$current.withValue(runMetadataStorage) {
             try await subject.run(
@@ -4964,7 +5094,8 @@ final class TestServiceTests: TuistUnitTestCase {
                 shardIndex: shardIndex,
                 shardSkipUpload: shardSkipUpload,
                 shardArchivePath: shardArchivePath,
-                mode: mode
+                mode: mode,
+                reportPath: reportPath
             )
         }
     }


### PR DESCRIPTION
Resolves none yet (filing alongside the PR since the maintainer convention is to describe the motivation here).

Adds a new `--report-path <path>` flag (env key `TUIST_TEST_REPORT_PATH`) to `tuist test`. When set, the CLI writes the in-memory `TestSummary` to the given path as JSON after the xcresult is parsed.

### Why

Post-run CI tooling (flake dashboards, CircleCI JUnit transforms, Datadog forwarders, custom summarizers) typically needs the structured test verdict for the run: per-test status, failures, retry repetitions, quarantine state, orphan issues. Today consumers get it via one of two paths:

1. Re-parse the xcresult themselves with `xcresultparser` or similar, losing Tuist's quarantine and orphan enrichment.
2. Query the Tuist API after upload (`tuist test show`, paginated `tuist test case run list --test-run-id`), which forces pagination (~13 pages for a ~6k-test run), races against upload completion, and duplicates parsing that Tuist just did.

Tuist already holds the enriched `TestSummary` in memory during `TestService.run()`. This flag asks Tuist to hand it to downstream tooling directly.

### Behavior

- `--report-path` is opt-in; no change if unset.
- Writes the report regardless of `--inspect-mode`. In local mode the CLI was already parsing the xcresult; in remote mode the CLI now parses it locally for the report side-effect, while the raw bundle still uploads to the server. The upload path is untouched.
- On a parse failure, the CLI logs a warning and skips the report; it does not fail the run. The run's exit code is still driven by xcodebuild.
- Sharded runs write one report per invocation (mirrors existing per-shard behavior). Aggregation is the caller's responsibility.

### JSON shape

The serialized struct is the existing `XCResultParser.TestSummary`, which already has snake-case `Encodable` conformance. No new types.

<details>
<summary>Sample output</summary>

```json
{
  "test_plan_name": "RequiredTests",
  "status": "failure",
  "duration": 399293,
  "run_destinations": [
    { "name": "iPhone 17 Pro", "platform": "iOS Simulator", "os_version": "26.2" }
  ],
  "test_modules": [
    {
      "name": "MoneyManagerUseCasesLiveTests",
      "status": "failure",
      "duration": 28,
      "test_suites": [],
      "test_cases": [
        {
          "name": "executeRebalances_partialFailure",
          "test_suite_name": "ExecuteMoneyManagerRebalancesLiveTests",
          "module": "MoneyManagerUseCasesLiveTests",
          "duration": 28,
          "status": "success",
          "is_quarantined": true,
          "failures": [
            {
              "message": "Expectation failed: (accountId → ...) == (rebalances[0].sourceAccountId → ...)",
              "line_number": 87,
              "issue_type": "assertion_failure"
            }
          ],
          "repetitions": [
            { "repetition_number": 1, "name": "executeRebalances_partialFailure", "status": "failure", "duration": 0, "failures": [/* ... */] },
            { "repetition_number": 2, "name": "executeRebalances_partialFailure", "status": "success", "duration": 28, "failures": [] }
          ],
          "arguments": [],
          "attachments": []
        }
      ]
    }
  ]
}
```

</details>

### Motivating use case

At Acorns we post-process JUnit output after every CI test job to (a) downgrade quarantined failures to `<skipped>` so CircleCI's Tests tab doesn't block the build, and (b) detach retry-pass `<failure>` entries so they don't get counted as real regressions. Today that requires the secondary Tuist API round-trips described above. With this flag the post-processor reads one file.

### How to test locally

```bash
cd path/to/a/tuist/project
tuist test --report-path /tmp/report.json
jq '.status, .test_modules[0].test_cases[0]' /tmp/report.json
```

Flip between `--inspect-mode local` and `--inspect-mode remote` to confirm the report is written in both.

### Tests

- `test_run_writesReportPathInLocalMode` — local-mode upload + report write.
- `test_run_writesReportPathInRemoteMode` — remote-mode upload still produces the report (the interesting one; validates that report emission doesn't depend on the upload mode).
