### PR TITLE
fix(server): reduce rolling-window MV backfill chunk size

### DIFF
--- a/server/priv/ingest_repo/migrations/20260508130000_create_test_case_runs_recent_per_case_mv.exs
+++ b/server/priv/ingest_repo/migrations/20260508130000_create_test_case_runs_recent_per_case_mv.exs
@@ -44,7 +44,7 @@ defmodule Tuist.IngestRepo.Migrations.CreateTestCaseRunsRecentPerCaseMv do
   # so a small chunk keeps the worst-case aggregation memory well below
   # ClickHouse Cloud's 18 GiB process ceiling regardless of how heavy any
   # one project's test_case_id cardinality turns out to be.
-  @project_chunk_size 20
+  @project_chunk_size 5
   # Throttle between chunks to give live ClickHouse traffic (background
   # merges, MV writes, automation queries) breathing room and avoid
   # piling concurrent allocations against the global memory ceiling.


### PR DESCRIPTION
## Summary
- reduce the rolling-window MV backfill project chunk size from 20 to 5
- keep the existing ClickHouse query settings and transient retry behavior unchanged

## Verification
- git diff --check
- Elixir parse check for the migration file

Note: mix format could not run normally because server deps are not installed in this worktree and the formatter imports ecto_sql.