### PR TITLE
fix(server): redirect to pending invitation after email confirmation

### DIFF
--- a/server/lib/tuist/accounts.ex
+++ b/server/lib/tuist/accounts.ex
@@ -1231,6 +1231,16 @@ defmodule Tuist.Accounts do
     )
   end
 
+  def get_pending_invitation_by_email(invitee_email) do
+    Repo.one(
+      from(i in Invitation,
+        where: i.invitee_email == ^invitee_email,
+        order_by: [asc: i.created_at],
+        limit: 1
+      )
+    )
+  end
+
   def cancel_invitation(%Invitation{} = invitation) do
     {:ok, _} = Repo.delete(invitation)
     :ok

--- a/server/lib/tuist/accounts.ex
+++ b/server/lib/tuist/accounts.ex
@@ -1232,13 +1232,19 @@ defmodule Tuist.Accounts do
   end
 
   def get_pending_invitation_by_email(invitee_email) do
-    Repo.one(
-      from(i in Invitation,
-        where: i.invitee_email == ^invitee_email,
-        order_by: [asc: i.created_at],
-        limit: 1
+    invitation =
+      Repo.one(
+        from(i in Invitation,
+          where: i.invitee_email == ^invitee_email,
+          order_by: [asc: i.created_at],
+          limit: 1
+        )
       )
-    )
+
+    case invitation do
+      nil -> {:error, :not_found}
+      invitation -> {:ok, invitation}
+    end
   end
 
   def cancel_invitation(%Invitation{} = invitation) do

--- a/server/lib/tuist/accounts.ex
+++ b/server/lib/tuist/accounts.ex
@@ -1231,20 +1231,13 @@ defmodule Tuist.Accounts do
     )
   end
 
-  def get_pending_invitation_by_email(invitee_email) do
-    invitation =
-      Repo.one(
-        from(i in Invitation,
-          where: i.invitee_email == ^invitee_email,
-          order_by: [asc: i.created_at],
-          limit: 1
-        )
+  def get_pending_invitations_by_email(invitee_email) do
+    Repo.all(
+      from(i in Invitation,
+        where: i.invitee_email == ^invitee_email,
+        order_by: [desc: i.created_at]
       )
-
-    case invitation do
-      nil -> {:error, :not_found}
-      invitation -> {:ok, invitation}
-    end
+    )
   end
 
   def cancel_invitation(%Invitation{} = invitation) do

--- a/server/lib/tuist_web/live/user_confirmation_live.ex
+++ b/server/lib/tuist_web/live/user_confirmation_live.ex
@@ -92,9 +92,9 @@ defmodule TuistWeb.UserConfirmationLive do
   end
 
   defp post_confirmation_path(user) do
-    case Accounts.get_pending_invitation_by_email(user.email) do
-      {:ok, invitation} -> ~p"/auth/invitations/#{invitation.token}"
-      {:error, :not_found} -> ~p"/organizations/new"
+    case Accounts.get_pending_invitations_by_email(user.email) do
+      [invitation | _] -> ~p"/auth/invitations/#{invitation.token}"
+      [] -> ~p"/organizations/new"
     end
   end
 end

--- a/server/lib/tuist_web/live/user_confirmation_live.ex
+++ b/server/lib/tuist_web/live/user_confirmation_live.ex
@@ -93,8 +93,8 @@ defmodule TuistWeb.UserConfirmationLive do
 
   defp post_confirmation_path(user) do
     case Accounts.get_pending_invitation_by_email(user.email) do
-      nil -> ~p"/organizations/new"
-      invitation -> ~p"/auth/invitations/#{invitation.token}"
+      {:ok, invitation} -> ~p"/auth/invitations/#{invitation.token}"
+      {:error, :not_found} -> ~p"/organizations/new"
     end
   end
 end

--- a/server/lib/tuist_web/live/user_confirmation_live.ex
+++ b/server/lib/tuist_web/live/user_confirmation_live.ex
@@ -75,19 +75,26 @@ defmodule TuistWeb.UserConfirmationLive do
   def mount(%{"token" => token}, _session, socket) do
     if connected?(socket) do
       case Accounts.confirm_user(token) do
-        {:ok, _} ->
+        {:ok, user} ->
           Process.send_after(self(), :redirect, 5000)
-          {:ok, assign(socket, success: true)}
+          {:ok, assign(socket, success: true, redirect_to: post_confirmation_path(user))}
 
         :error ->
-          {:ok, assign(socket, success: false)}
+          {:ok, assign(socket, success: false, redirect_to: nil)}
       end
     else
-      {:ok, assign(socket, success: true)}
+      {:ok, assign(socket, success: true, redirect_to: nil)}
     end
   end
 
   def handle_info(:redirect, socket) do
-    {:noreply, redirect(socket, to: ~p"/organizations/new")}
+    {:noreply, redirect(socket, to: socket.assigns.redirect_to || ~p"/organizations/new")}
+  end
+
+  defp post_confirmation_path(user) do
+    case Accounts.get_pending_invitation_by_email(user.email) do
+      nil -> ~p"/organizations/new"
+      invitation -> ~p"/auth/invitations/#{invitation.token}"
+    end
   end
 end

--- a/server/test/tuist/accounts_test.exs
+++ b/server/test/tuist/accounts_test.exs
@@ -981,6 +981,79 @@ defmodule Tuist.AccountsTest do
     end
   end
 
+  describe "get_pending_invitation_by_email/1" do
+    test "returns the invitation when one exists for the given email" do
+      # Given
+      user = AccountsFixtures.user_fixture()
+      organization = AccountsFixtures.organization_fixture(creator: user)
+
+      {:ok, invitation} =
+        Accounts.invite_user_to_organization("new@tuist.io", %{
+          inviter: user,
+          to: organization,
+          url: fn token -> token end
+        })
+
+      # When
+      {:ok, got} = Accounts.get_pending_invitation_by_email("new@tuist.io")
+
+      # Then
+      assert got.id == invitation.id
+    end
+
+    test "returns the oldest invitation when several exist for the same email" do
+      # Given
+      user = AccountsFixtures.user_fixture()
+
+      {:ok, older} =
+        Accounts.invite_user_to_organization("new@tuist.io", %{
+          inviter: user,
+          to: AccountsFixtures.organization_fixture(creator: user),
+          url: fn token -> token end
+        })
+
+      {:ok, _newer} =
+        Accounts.invite_user_to_organization("new@tuist.io", %{
+          inviter: user,
+          to: AccountsFixtures.organization_fixture(creator: user),
+          url: fn token -> token end
+        })
+
+      # When
+      {:ok, got} = Accounts.get_pending_invitation_by_email("new@tuist.io")
+
+      # Then
+      assert got.id == older.id
+    end
+
+    test "returns :not_found when no invitation exists for the given email" do
+      # When
+      got = Accounts.get_pending_invitation_by_email("nobody@tuist.io")
+
+      # Then
+      assert got == {:error, :not_found}
+    end
+
+    test "does not match invitations for other emails" do
+      # Given
+      user = AccountsFixtures.user_fixture()
+      organization = AccountsFixtures.organization_fixture(creator: user)
+
+      {:ok, _invitation} =
+        Accounts.invite_user_to_organization("someone@tuist.io", %{
+          inviter: user,
+          to: organization,
+          url: fn token -> token end
+        })
+
+      # When
+      got = Accounts.get_pending_invitation_by_email("other@tuist.io")
+
+      # Then
+      assert got == {:error, :not_found}
+    end
+  end
+
   describe "accept_invitation/1" do
     test "accepts an invitation" do
       # Given

--- a/server/test/tuist/accounts_test.exs
+++ b/server/test/tuist/accounts_test.exs
@@ -8,6 +8,7 @@ defmodule Tuist.AccountsTest do
   alias Tuist.Accounts
   alias Tuist.Accounts.Account
   alias Tuist.Accounts.AccountToken
+  alias Tuist.Accounts.Invitation
   alias Tuist.Accounts.Organization
   alias Tuist.Accounts.Role
   alias Tuist.Accounts.User
@@ -981,8 +982,8 @@ defmodule Tuist.AccountsTest do
     end
   end
 
-  describe "get_pending_invitation_by_email/1" do
-    test "returns the invitation when one exists for the given email" do
+  describe "get_pending_invitations_by_email/1" do
+    test "returns invitations for the given email" do
       # Given
       user = AccountsFixtures.user_fixture()
       organization = AccountsFixtures.organization_fixture(creator: user)
@@ -995,13 +996,14 @@ defmodule Tuist.AccountsTest do
         })
 
       # When
-      {:ok, got} = Accounts.get_pending_invitation_by_email("new@tuist.io")
+      got = Accounts.get_pending_invitations_by_email("new@tuist.io")
 
       # Then
-      assert got.id == invitation.id
+      assert [%{id: id}] = got
+      assert id == invitation.id
     end
 
-    test "returns the oldest invitation when several exist for the same email" do
+    test "orders invitations by most recent first" do
       # Given
       user = AccountsFixtures.user_fixture()
 
@@ -1012,29 +1014,39 @@ defmodule Tuist.AccountsTest do
           url: fn token -> token end
         })
 
-      {:ok, _newer} =
+      {:ok, newer} =
         Accounts.invite_user_to_organization("new@tuist.io", %{
           inviter: user,
           to: AccountsFixtures.organization_fixture(creator: user),
           url: fn token -> token end
         })
 
+      Tuist.Repo.update_all(
+        from(i in Invitation, where: i.id == ^older.id),
+        set: [created_at: ~N[2026-01-01 00:00:00]]
+      )
+
+      Tuist.Repo.update_all(
+        from(i in Invitation, where: i.id == ^newer.id),
+        set: [created_at: ~N[2026-02-01 00:00:00]]
+      )
+
       # When
-      {:ok, got} = Accounts.get_pending_invitation_by_email("new@tuist.io")
+      got = Accounts.get_pending_invitations_by_email("new@tuist.io")
 
       # Then
-      assert got.id == older.id
+      assert Enum.map(got, & &1.id) == [newer.id, older.id]
     end
 
-    test "returns :not_found when no invitation exists for the given email" do
+    test "returns an empty list when no invitations exist for the given email" do
       # When
-      got = Accounts.get_pending_invitation_by_email("nobody@tuist.io")
+      got = Accounts.get_pending_invitations_by_email("nobody@tuist.io")
 
       # Then
-      assert got == {:error, :not_found}
+      assert got == []
     end
 
-    test "does not match invitations for other emails" do
+    test "does not return invitations for other emails" do
       # Given
       user = AccountsFixtures.user_fixture()
       organization = AccountsFixtures.organization_fixture(creator: user)
@@ -1047,10 +1059,10 @@ defmodule Tuist.AccountsTest do
         })
 
       # When
-      got = Accounts.get_pending_invitation_by_email("other@tuist.io")
+      got = Accounts.get_pending_invitations_by_email("other@tuist.io")
 
       # Then
-      assert got == {:error, :not_found}
+      assert got == []
     end
   end
 

--- a/server/test/tuist_web/live/user_confirmation_live_test.exs
+++ b/server/test/tuist_web/live/user_confirmation_live_test.exs
@@ -33,5 +33,49 @@ defmodule TuistWeb.UserConfirmationLiveTest do
       assert has_element?(lv, "h1", "Confirmation failed")
       refute Accounts.get_user!(user.id).confirmed_at
     end
+
+    test "redirects to /organizations/new after confirming when no pending invitation exists", %{
+      conn: conn,
+      user: user
+    } do
+      token =
+        extract_user_token(fn url ->
+          Accounts.deliver_user_confirmation_instructions(%{
+            user: user,
+            confirmation_url: url
+          })
+        end)
+
+      {:ok, lv, _html} = live(conn, ~p"/users/confirm/#{token}")
+      send(lv.pid, :redirect)
+
+      assert_redirect(lv, ~p"/organizations/new")
+    end
+
+    test "redirects to the pending invitation when one exists for the user's email", %{conn: conn} do
+      email = "invitee-#{System.unique_integer([:positive])}@example.com"
+      user = user_fixture(email: email, confirmed_at: nil)
+      inviter = user_fixture()
+      organization = organization_fixture(creator: inviter)
+
+      {:ok, invitation} =
+        Accounts.invite_user_to_organization(
+          email,
+          %{inviter: inviter, to: organization, url: fn token -> "/auth/invitations/#{token}" end}
+        )
+
+      token =
+        extract_user_token(fn url ->
+          Accounts.deliver_user_confirmation_instructions(%{
+            user: user,
+            confirmation_url: url
+          })
+        end)
+
+      {:ok, lv, _html} = live(conn, ~p"/users/confirm/#{token}")
+      send(lv.pid, :redirect)
+
+      assert_redirect(lv, ~p"/auth/invitations/#{invitation.token}")
+    end
   end
 end


### PR DESCRIPTION
### Summary

When a user clicks **Accept invitation** in an email without an existing account, they're routed through register → email confirmation. After clicking the confirmation link, the post-confirmation redirect unconditionally sent them to `/organizations/new`, forcing them to go back to the email and click the invitation link a second time.

This change makes `UserConfirmationLive` look up a pending invitation for the just-confirmed user's email and redirect there if one exists, falling back to `/organizations/new` otherwise. The destination is derived from the user's email rather than session state, so it's robust to the confirmation link being opened in a different browser.

### How to test locally

1. As an organization admin in the dashboard, invite an email that doesn't have a Tuist account yet.
2. From the invitation email, click **Accept invitation** → you land on `/users/log_in`.
3. Follow **Sign up**, register with the invited email, and click the confirmation link from the welcome email.
4. After the 5-second auto-redirect, you should land on the invitation accept page (and after logging in, on the organization), not on `/organizations/new`.

Also covered by:

- `mix test test/tuist_web/live/user_confirmation_live_test.exs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)