### PR TITLE
fix(server): raise rolling-window MV backfill memory ceiling to 12 GiB

### DIFF
--- a/server/priv/ingest_repo/migrations/20260508130000_create_test_case_runs_recent_per_case_mv.exs
+++ b/server/priv/ingest_repo/migrations/20260508130000_create_test_case_runs_recent_per_case_mv.exs
@@ -160,9 +160,18 @@ defmodule Tuist.IngestRepo.Migrations.CreateTestCaseRunsRecentPerCaseMv do
   #
   # The `project_id IN (...)` chunking caps the size of the result the
   # query has to produce regardless of how many unique test_case_ids the
-  # selected projects accumulate, and the explicit `max_memory_usage`
-  # makes the query fail fast on a budget overshoot rather than starving
-  # other ClickHouse activity against the 18 GiB process ceiling.
+  # selected projects accumulate.
+  #
+  # `max_memory_usage = 12 GiB` is the budget per backfill INSERT. The
+  # ClickHouse server itself has no `max_memory_usage` set
+  # (verified via `system.settings`), so this is purely a self-imposed
+  # ceiling. Prior attempts at 4 GiB OOM'd at ~3.74 GiB on the heaviest
+  # `(partition, chunk-of-5)` for partition 202602; the dominant cost
+  # is not the chunk size but `groupArrayLast(1000)`'s per-state
+  # capacity-preallocation, which barely changes between chunks of 5
+  # and chunks of 20. 12 GiB gives ~3× headroom over the observed peak
+  # while leaving ~6 GiB free under the cluster's 18 GiB process
+  # ceiling for live traffic during the brief (~6 s) burst per chunk.
   defp backfill_chunk(partition, project_ids, idx) do
     Logger.debug(
       "Backfilling chunk #{idx} of partition #{partition} " <>
@@ -184,8 +193,8 @@ defmodule Tuist.IngestRepo.Migrations.CreateTestCaseRunsRecentPerCaseMv do
       SETTINGS
         optimize_aggregation_in_order = 1,
         max_threads = 1,
-        max_memory_usage = 4000000000,
-        max_bytes_before_external_group_by = 1500000000
+        max_memory_usage = 12000000000,
+        max_bytes_before_external_group_by = 5000000000
       """,
       %{partition: partition, project_ids: project_ids},
       timeout: 1_200_000


### PR DESCRIPTION
## Summary

Two consecutive production deploys (#10731 chunk_size=20, #10733 chunk_size=5) failed at the same `test_case_runs_recent_per_case` migration with `MEMORY_LIMIT_EXCEEDED` at virtually the same observed peak (3.78 GiB and 3.74 GiB respectively), both inside partition 202602. The chunk-size knob barely moved the peak, so the dominant cost isn't the per-chunk group count — it's `groupArrayLast(1000)`'s per-state capacity-preallocation, which is roughly constant across chunks. Reducing chunk size further would mostly add part-count and wall-clock without fixing the OOM.

Production ClickHouse has no server-side `max_memory_usage` configured (verified by querying `system.settings`: `max_memory_usage = 0`, `max_memory_usage_for_user = 0`), so the 3.73 GiB ceiling we kept hitting was purely the migration's own `SETTINGS max_memory_usage = 4000000000`. This PR raises that to 12 GiB.

- **Headroom**: 12 / 3.74 ≈ 3.2× margin over the worst real chunk we've observed.
- **Live-traffic safety**: each chunk runs ~6 s. With the cluster's 18 GiB process ceiling, raising the migration's per-query budget to 12 GiB still leaves ~6 GiB free during each burst.
- **Why not chunk_size=1**: prior data shows peak memory doesn't scale linearly with chunk size, so it wouldn't fix the OOM; it would 5×-multiply INSERT count into the single-partition `AggregatingMergeTree` storage table, risking `TOO_MANY_PARTS` (default thresholds 150 delay / 300 throw) and pushing wall-clock past Helm's 90 min wait.

`max_bytes_before_external_group_by` is bumped proportionally to 5 GiB so external aggregation (if `optimize_aggregation_in_order` ever fails to apply) still has room to spill before the cap.

## Test plan

- [ ] Production deploy reaches partition 202602 and beyond without `MEMORY_LIMIT_EXCEEDED`
- [ ] `kubectl -n tuist logs job/tuist-tuist-server-migrate` shows "== Migrated 20260508130000" with no transient retries

🤖 Generated with [Claude Code](https://claude.com/claude-code)