### PR TITLE
fix(server): minimize rolling-window MV backfill chunk size

### DIFF
--- a/server/priv/ingest_repo/migrations/20260508130000_create_test_case_runs_recent_per_case_mv.exs
+++ b/server/priv/ingest_repo/migrations/20260508130000_create_test_case_runs_recent_per_case_mv.exs
@@ -44,7 +44,7 @@ defmodule Tuist.IngestRepo.Migrations.CreateTestCaseRunsRecentPerCaseMv do
   # so a small chunk keeps the worst-case aggregation memory well below
   # ClickHouse Cloud's 18 GiB process ceiling regardless of how heavy any
   # one project's test_case_id cardinality turns out to be.
-  @project_chunk_size 5
+  @project_chunk_size 1
   # Throttle between chunks to give live ClickHouse traffic (background
   # merges, MV writes, automation queries) breathing room and avoid
   # piling concurrent allocations against the global memory ceiling.


### PR DESCRIPTION
## Summary
- reduce the rolling-window MV backfill project chunk size from 5 to 1
- keep the ClickHouse query settings and retry behavior unchanged

## Context
The production deployment for commit 36ce140 still failed on partition 202602 with 5-project chunks: ClickHouse needed 3.74 GiB against a 3.73 GiB query limit. This takes the chunk-size-only approach to its minimum so each INSERT covers a single project.

## Verification
- git diff --check
- Elixir parse check for the migration file