### PR TITLE
fix(server): release xcresult processor image for server fixes

### DIFF
--- a/infra/helm/tuist/values-managed-common.yaml
+++ b/infra/helm/tuist/values-managed-common.yaml
@@ -197,13 +197,13 @@ xcresultProcessor:
   queueConcurrency: 4
   image:
     repository: ghcr.io/tuist/tuist-xcresult-processor
-    # Bumped automatically by the release workflow when an
-    # xcresult-processor-image-scoped conventional commit lands on
+    # Bumped automatically by the release workflow when a relevant
+    # server, xcresult NIF, or xcresult-processor-image change lands on
     # main; the workflow rebuilds the Tart VM image on the bare-metal
-    # Mac mini, pushes the matching semver tag, and rewrites this
-    # line in the same auto-commit. Until release.yml has run for
-    # this scope, pin to a known-good SHA-tagged build that the
-    # standalone xcresult-processor-image.yml workflow pushed.
+    # Mac mini, pushes the matching semver tag, and rewrites this line
+    # in the same auto-commit. Until release.yml has run for this
+    # component, pin to a known-good SHA-tagged build that the standalone
+    # xcresult-processor-image.yml workflow pushed.
     tag: "e38122ec"
 
 # Mac mini fleet provisioned declaratively via the Cluster API

--- a/infra/xcresult-processor-image/cliff.toml
+++ b/infra/xcresult-processor-image/cliff.toml
@@ -62,20 +62,21 @@ split_commits = false
 commit_preprocessors = [
     { pattern = '\((\w+\s)?#([0-9]+)\)', replace = "" },
 ]
-# Match commits scoped to xcresult-processor-image. Component covers the
-# Tart VM image (Packer template, launchd plist, env injector) plus
-# the server release pieces it bakes in (the xcresult NIF + the
-# server's release entry points run by TUIST_MODE=xcresult_processor).
+# The release workflow already passes path filters for the Tart VM image,
+# the xcresult NIF, and the server code baked into the macOS release. Match
+# any conventional commit that survives those path filters; otherwise
+# `fix(server)` changes to the worker/parser are silently ignored and the
+# deployed xcresult-processor image stays pinned to an older release.
 commit_parsers = [
-    { message = "^feat\\([^)]*\\bxcresult-processor-image\\b[^)]*\\)", group = "<!-- 0 -->⛰️  Features" },
-    { message = "^fix\\([^)]*\\bxcresult-processor-image\\b[^)]*\\)", group = "<!-- 1 -->🐛 Bug Fixes" },
-    { message = "^docs?\\([^)]*\\bxcresult-processor-image\\b[^)]*\\)", group = "<!-- 3 -->📚 Documentation" },
-    { message = "^perf\\([^)]*\\bxcresult-processor-image\\b[^)]*\\)", group = "<!-- 4 -->⚡ Performance" },
-    { message = "^refactor\\([^)]*\\bxcresult-processor-image\\b[^)]*\\)", group = "<!-- 2 -->🚜 Refactor" },
-    { message = "^style\\([^)]*\\bxcresult-processor-image\\b[^)]*\\)", group = "<!-- 5 -->🎨 Styling" },
-    { message = "^test\\([^)]*\\bxcresult-processor-image\\b[^)]*\\)", group = "<!-- 6 -->🧪 Testing" },
-    { message = "^chore\\([^)]*\\bxcresult-processor-image\\b[^)]*\\)", skip = true },
-    { message = "^ci\\([^)]*\\bxcresult-processor-image\\b[^)]*\\)", skip = true },
+    { message = "^feat(\\([^)]*\\))?", group = "<!-- 0 -->⛰️  Features" },
+    { message = "^fix(\\([^)]*\\))?", group = "<!-- 1 -->🐛 Bug Fixes" },
+    { message = "^docs?(\\([^)]*\\))?", group = "<!-- 3 -->📚 Documentation" },
+    { message = "^perf(\\([^)]*\\))?", group = "<!-- 4 -->⚡ Performance" },
+    { message = "^refactor(\\([^)]*\\))?", group = "<!-- 2 -->🚜 Refactor" },
+    { message = "^style(\\([^)]*\\))?", group = "<!-- 5 -->🎨 Styling" },
+    { message = "^test(\\([^)]*\\))?", group = "<!-- 6 -->🧪 Testing" },
+    { message = "^chore(\\([^)]*\\))?", skip = true },
+    { message = "^ci(\\([^)]*\\))?", skip = true },
     { message = "^[a-z]+\\([^)]+\\)", skip = true },
 ]
 protect_breaking_commits = false


### PR DESCRIPTION
## Summary
- Broaden xcresult-processor-image release changelog matching so relevant server/NIF fixes trigger the image release.
- Update managed Helm values comments to reflect the release behavior.

## Context
The xcresult processor image bakes in server code, but its release changelog previously only matched commits scoped directly to xcresult-processor-image. That meant relevant server or NIF fixes could be deployed to Linux server pods while the macOS xcresult workers stayed pinned to an older image.

## Testing
- git diff --check
- Local git cliff check verified the xcresult processor changelog includes recent xcresult-related server fixes