### PR TITLE
chore(server): harden CI supply chain

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,31 @@
+# CI and release control planes
+/.github/workflows/ @tuist/engineering
+/.github/actions/ @tuist/engineering
+/mise/tasks/ @tuist/engineering
+
+# Dependency manifests and lockfiles
+/mise.toml @tuist/engineering
+/mise.lock @tuist/engineering
+/server/mise.toml @tuist/engineering
+/cache/mise.toml @tuist/engineering
+/noora/.mise.toml @tuist/engineering
+/handbook/mise.toml @tuist/engineering
+/status/mise.toml @tuist/engineering
+/infra/mise.toml @tuist/engineering
+/Package.swift @tuist/engineering
+/Package.resolved @tuist/engineering
+/package.json @tuist/engineering
+/package-lock.json @tuist/engineering
+/server/package.json @tuist/engineering
+/server/pnpm-lock.yaml @tuist/engineering
+/noora/package.json @tuist/engineering
+/noora/aube-lock.yaml @tuist/engineering
+/handbook/package.json @tuist/engineering
+/handbook/aube-lock.yaml @tuist/engineering
+/status/package.json @tuist/engineering
+/status/aube-lock.yaml @tuist/engineering
+/infra/registry-router/package.json @tuist/engineering
+/infra/registry-router/package-lock.json @tuist/engineering
+/gradle/settings.gradle.kts @tuist/engineering
+/gradle/build.gradle.kts @tuist/engineering
+/gradle/gradle.lockfile @tuist/engineering

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -40,7 +40,9 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
+    if: |
+      (github.event.pull_request.draft == false || github.event_name != 'pull_request') &&
+      (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork != true)
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
@@ -54,8 +56,23 @@ jobs:
           install_args: "tuist"
           cache: "false"
       - name: Authenticate with Tuist
-        if: github.event.pull_request.head.repo.fork != true
         run: tuist auth login
+      - run: ./gradlew testDebugUnitTest
+
+  test-fork:
+    name: Test Fork
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    if: github.event_name == 'pull_request' && github.event.pull_request.draft == false && github.event.pull_request.head.repo.fork == true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+      - uses: gradle/actions/setup-gradle@v4
       - run: ./gradlew testDebugUnitTest
 
   build:
@@ -65,7 +82,9 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
+    if: |
+      (github.event.pull_request.draft == false || github.event_name != 'pull_request') &&
+      (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork != true)
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
@@ -79,12 +98,25 @@ jobs:
           install_args: "tuist"
           cache: "false"
       - name: Authenticate with Tuist
-        if: github.event.pull_request.head.repo.fork != true
         run: tuist auth login
       - run: ./gradlew assembleDebug
       - name: Share
-        if: github.event.pull_request.head.repo.fork != true
         run: tuist share app/build/outputs/apk/debug/app-debug.apk
       - name: Inspect bundle
-        if: github.event.pull_request.head.repo.fork != true
         run: tuist inspect bundle app/build/outputs/apk/debug/app-debug.apk
+
+  build-fork:
+    name: Build Fork
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    if: github.event_name == 'pull_request' && github.event.pull_request.draft == false && github.event.pull_request.head.repo.fork == true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+      - uses: gradle/actions/setup-gradle@v4
+      - run: ./gradlew assembleDebug

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -19,7 +19,6 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  id-token: write
   contents: read
 
 env:
@@ -38,6 +37,9 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: read
+      id-token: write
     if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     steps:
       - uses: actions/checkout@v4
@@ -60,6 +62,9 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: read
+      id-token: write
     if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -25,7 +25,6 @@ on:
   workflow_dispatch:
 
 permissions:
-  id-token: write
   contents: read
 
 env:
@@ -83,6 +82,9 @@ jobs:
     runs-on: macos-26
     timeout-minutes: 30
     needs: [check-team-membership]
+    permissions:
+      contents: read
+      id-token: write
     if: |
       always() &&
       !cancelled() &&
@@ -140,6 +142,9 @@ jobs:
     runs-on: macos-26
     timeout-minutes: 30
     needs: [check-team-membership]
+    permissions:
+      contents: read
+      id-token: write
     if: |
       always() &&
       !cancelled() &&
@@ -186,6 +191,9 @@ jobs:
     runs-on: macos-26
     timeout-minutes: 30
     needs: [check-team-membership]
+    permissions:
+      contents: read
+      id-token: write
     if: |
       always() &&
       !cancelled() &&

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -44,7 +44,6 @@ on:
       - "Package.resolved"
 
 permissions:
-  id-token: write
   contents: read
 
 env:
@@ -70,6 +69,9 @@ jobs:
     name: Lint
     runs-on: macos-26
     timeout-minutes: 30
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -111,6 +113,9 @@ jobs:
     name: SwiftPM Build
     runs-on: macos-26
     timeout-minutes: 30
+    permissions:
+      contents: read
+      id-token: write
     if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     steps:
       - uses: actions/checkout@v4
@@ -145,6 +150,9 @@ jobs:
     name: Cache
     runs-on: macos-26
     timeout-minutes: 60
+    permissions:
+      contents: read
+      id-token: write
     if: github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v4
@@ -190,6 +198,9 @@ jobs:
     name: Unit Tests
     runs-on: namespace-profile-macos-xcode-26
     timeout-minutes: 30
+    permissions:
+      contents: read
+      id-token: write
     if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     steps:
       - uses: actions/checkout@v4
@@ -232,6 +243,9 @@ jobs:
     name: Build Acceptance Tests
     runs-on: namespace-profile-macos-xcode-26
     timeout-minutes: 60
+    permissions:
+      contents: read
+      id-token: write
     if: (github.event.pull_request.draft == false || github.event_name != 'pull_request') && github.event.pull_request.head.repo.fork != true
     outputs:
       matrix: ${{ steps.shard.outputs.matrix }}
@@ -284,6 +298,9 @@ jobs:
     runs-on: namespace-profile-macos-xcode-26
     timeout-minutes: 60
     needs: cli-acceptance-tests-build
+    permissions:
+      contents: read
+      id-token: write
     if: toJSON(fromJSON(needs.cli-acceptance-tests-build.outputs.matrix).shard) != '[]'
     strategy:
       fail-fast: false

--- a/.github/workflows/conventional-pr.yml
+++ b/.github/workflows/conventional-pr.yml
@@ -3,6 +3,9 @@ on:
   pull_request:
     types: [opened, edited]
 
+permissions:
+  pull-requests: read
+
 concurrency:
   group: conventional-pr-${{ github.head_ref }}
   cancel-in-progress: true

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -19,7 +19,6 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  id-token: write
   contents: read
 
 env:
@@ -38,6 +37,9 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: read
+      id-token: write
     if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/handbook.yml
+++ b/.github/workflows/handbook.yml
@@ -38,6 +38,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Restore Aube Cache
+        if: github.ref != 'refs/heads/main'
         uses: actions/cache@v4
         id: aube-cache
         with:

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -56,7 +56,6 @@ permissions:
   contents: read
   packages: write
   pull-requests: write
-  id-token: write
   deployments: write
 
 env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,6 @@ on:
       - main
 
 permissions:
-  id-token: write
   contents: write
   pull-requests: read
   statuses: write
@@ -66,9 +65,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: namespacelabs/nscloud-cache-action@v1
-        with:
-          cache: mise
       - uses: jdx/mise-action@v4.0.1
         with:
           version: ${{ env.MISE_VERSION }}
@@ -768,6 +764,12 @@ jobs:
     if: needs.check-releases.outputs.cli-should-release == 'true'
     runs-on: namespace-profile-default-macos
     timeout-minutes: 50
+    permissions:
+      contents: write
+      id-token: write
+      pull-requests: read
+      statuses: write
+      packages: write
     env:
       GITHUB_TOKEN: ${{ secrets.TUIST_RELEASE_GITHUB_TOKEN }}
     outputs:
@@ -780,12 +782,6 @@ jobs:
           token: ${{ secrets.TUIST_RELEASE_GITHUB_TOKEN }}
       - name: Select Xcode
         run: sudo xcode-select -switch /Applications/Xcode_$(cat .xcode-version-releases).app
-      - name: Restore cache
-        id: cache-restore
-        uses: actions/cache/restore@v4
-        with:
-          path: .build
-          key: ${{ runner.os }}-cli-release-${{ hashFiles('.xcode-version-releases') }}-${{ hashFiles('Package.swift') }}-${{ hashFiles('Package.resolved') }}
       - uses: jdx/mise-action@v4.0.1
         with:
           version: ${{ env.MISE_VERSION }}
@@ -797,7 +793,6 @@ jobs:
       - name: Setup Tuist
         run: tuist setup
       - name: Install Tuist dependencies
-        if: steps.cache-restore.outputs.cache-matched-key == ''
         run: tuist install
       - name: Initialize TuistCacheEE submodule
         env:
@@ -829,13 +824,6 @@ jobs:
       - name: Update mise.toml
         run: |
           sed -i '' "s/tuist = \".*\"/tuist = \"${{ needs.check-releases.outputs.cli-next-version }}\"/" mise.toml
-
-      - name: Save cache
-        id: cache-save
-        uses: actions/cache/save@v4
-        with:
-          path: .build
-          key: ${{ steps.cache-restore.outputs.cache-primary-key }}
 
       - name: Upload CLI artifacts
         id: upload
@@ -873,31 +861,12 @@ jobs:
         with:
           token: ${{ secrets.TUIST_RELEASE_GITHUB_TOKEN }}
 
-      - name: Cache Static Linux SDK
-        uses: actions/cache@v4
-        with:
-          path: ~/.swiftpm/swift-sdks
-          key: static-linux-sdk-swift-6.2.3-${{ matrix.arch }}
-
-      - name: Restore cache
-        id: cache-restore
-        uses: actions/cache/restore@v4
-        with:
-          path: .build
-          key: linux-${{ matrix.arch }}-cli-release-${{ hashFiles('Package.swift') }}-${{ hashFiles('Package.resolved') }}
-
       - name: Update version in Constants.swift
         run: |
           sed -i "s/@TaskLocal public static var version: String! = \".*\"/@TaskLocal public static var version: String! = \"${{ needs.check-releases.outputs.cli-next-version }}\"/" "cli/Sources/TuistConstants/Constants.swift"
 
       - name: Bundle CLI
         run: ./mise/tasks/cli/bundle-linux.sh
-
-      - name: Save cache
-        uses: actions/cache/save@v4
-        with:
-          path: .build
-          key: ${{ steps.cache-restore.outputs.cache-primary-key }}
 
       - name: Upload CLI Linux artifacts
         id: upload
@@ -916,6 +885,12 @@ jobs:
     if: needs.check-releases.outputs.app-should-release == 'true'
     runs-on: macos-26
     timeout-minutes: 50
+    permissions:
+      contents: write
+      id-token: write
+      pull-requests: read
+      statuses: write
+      packages: write
     env:
       GITHUB_TOKEN: ${{ secrets.TUIST_RELEASE_GITHUB_TOKEN }}
       OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
@@ -1012,6 +987,12 @@ jobs:
     if: needs.check-releases.outputs.app-should-release == 'true'
     runs-on: namespace-profile-macos-xcode-26
     timeout-minutes: 30
+    permissions:
+      contents: write
+      id-token: write
+      pull-requests: read
+      statuses: write
+      packages: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -1032,12 +1013,6 @@ jobs:
         run: tuist auth login
       - name: Setup Tuist
         run: tuist setup
-      - name: Restore cache
-        id: cache-restore
-        uses: actions/cache/restore@v4
-        with:
-          path: .build
-          key: ${{ runner.os }}-app-${{ hashFiles('Package.swift') }}-${{ hashFiles('Package.resolved') }}
       - name: Update version
         working-directory: app
         run: |
@@ -1046,7 +1021,6 @@ jobs:
           sed -i '' -e "s/CFBundleShortVersionString.*/CFBundleShortVersionString\": \"$VERSION_NUMBER\",/g" "Project.swift"
           sed -i '' -e "s/CFBundleVersion.*/CFBundleVersion\": \"${{ github.run_number }}\",/g" "Project.swift"
       - name: Install Tuist dependencies
-        if: steps.cache-restore.outputs.cache-matched-key == ''
         run: tuist install
       - name: Generate TuistApp
         run: tuist generate TuistApp --no-binary-cache
@@ -1068,9 +1042,6 @@ jobs:
         with:
           token: ${{ secrets.TUIST_RELEASE_GITHUB_TOKEN }}
 
-      - uses: namespacelabs/nscloud-cache-action@v1
-        with:
-          cache: mise
       - uses: jdx/mise-action@v4.0.1
         with:
           version: ${{ env.MISE_VERSION }}
@@ -1080,6 +1051,8 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-disabled: true
 
       - name: Update version
         working-directory: android
@@ -1117,9 +1090,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: namespacelabs/nscloud-cache-action@v1
-        with:
-          cache: mise
       - uses: jdx/mise-action@v4.0.1
         with:
           version: ${{ env.MISE_VERSION }}
@@ -1204,9 +1174,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: namespacelabs/nscloud-cache-action@v1
-        with:
-          cache: mise
       - uses: jdx/mise-action@v4.0.1
         with:
           version: ${{ env.MISE_VERSION }}
@@ -1287,9 +1254,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: namespacelabs/nscloud-cache-action@v1
-        with:
-          cache: mise
       - uses: jdx/mise-action@v4.0.1
         with:
           version: ${{ env.MISE_VERSION }}
@@ -1375,12 +1339,6 @@ jobs:
           name: kura-release-metadata
           path: kura
 
-      - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: kura-release-${{ runner.os }}
-          workspaces: |
-            kura -> target
-
       - name: Build Kura binary
         working-directory: kura
         run: |
@@ -1462,9 +1420,6 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.TUIST_RELEASE_GITHUB_TOKEN }}
-      - uses: namespacelabs/nscloud-cache-action@v1
-        with:
-          cache: mise
       - uses: jdx/mise-action@v4.0.1
         with:
           version: ${{ env.MISE_VERSION }}
@@ -1474,6 +1429,8 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-disabled: true
 
       - name: Get release notes
         id: release-notes
@@ -1575,9 +1532,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: namespacelabs/nscloud-cache-action@v1
-        with:
-          cache: mise
       - uses: jdx/mise-action@v4.0.1
         with:
           version: ${{ env.MISE_VERSION }}
@@ -1652,9 +1606,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: namespacelabs/nscloud-cache-action@v1
-        with:
-          cache: mise
       - uses: jdx/mise-action@v4.0.1
         with:
           version: ${{ env.MISE_VERSION }}
@@ -1735,9 +1686,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: namespacelabs/nscloud-cache-action@v1
-        with:
-          cache: mise
       - uses: jdx/mise-action@v4.0.1
         with:
           version: ${{ env.MISE_VERSION }}
@@ -1812,9 +1760,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: namespacelabs/nscloud-cache-action@v1
-        with:
-          cache: mise
       - uses: jdx/mise-action@v4.0.1
         with:
           version: ${{ env.MISE_VERSION }}
@@ -2070,9 +2015,6 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.TUIST_RELEASE_GITHUB_TOKEN }}
 
-      - uses: namespacelabs/nscloud-cache-action@v1
-        with:
-          cache: mise
       - uses: jdx/mise-action@v4.0.1
         with:
           version: ${{ env.MISE_VERSION }}

--- a/.github/workflows/runner-image.yml
+++ b/.github/workflows/runner-image.yml
@@ -13,6 +13,10 @@ on:
         description: "GitHub Actions runner version (e.g. 2.325.0)"
         required: true
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   build:
     runs-on: namespace-profile-macos-xcode-26

--- a/.github/workflows/server-deployment.yml
+++ b/.github/workflows/server-deployment.yml
@@ -76,7 +76,6 @@ on:
 permissions:
   contents: read
   packages: write
-  id-token: write
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/server-production-deployment.yml
+++ b/.github/workflows/server-production-deployment.yml
@@ -57,7 +57,6 @@ on:
 permissions:
   contents: read
   packages: write
-  id-token: write
 
 env:
   REGISTRY: ghcr.io
@@ -143,6 +142,9 @@ jobs:
     runs-on: namespace-profile-macos-xcode-26
     timeout-minutes: 15
     environment: server-k8s-canary
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -151,12 +153,6 @@ jobs:
           submodules: recursive
       - name: Select Xcode
         run: sudo xcode-select -switch /Applications/Xcode_$(cat .xcode-version).app
-      - name: Restore cache
-        id: cache-restore
-        uses: actions/cache/restore@v4
-        with:
-          path: .build
-          key: ${{ runner.os }}-cli-cache-ee-${{ hashFiles('Package.resolved') }}
       - uses: jdx/mise-action@v4.0.1
         with:
           github_token: ${{ secrets.TUIST_DEPLOY_GITHUB_TOKEN || github.token }}
@@ -165,7 +161,6 @@ jobs:
       - name: Setup Tuist
         run: tuist setup
       - name: Install Tuist dependencies
-        if: steps.cache-restore.outputs.cache-matched-key == ''
         run: tuist install
       - name: Initialize TuistCacheEE submodule
         env:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -3,6 +3,10 @@ on:
   schedule:
     - cron: '30 1 * * *'
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   stale:
     name: Close Stale Issues & PRs

--- a/.github/workflows/status-deploy.yml
+++ b/.github/workflows/status-deploy.yml
@@ -32,13 +32,6 @@ jobs:
     environment: status-production
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-      - name: Restore Aube Cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.local/share/aube
-            ~/.cache/aube
-          key: aube-${{ hashFiles('status/aube-lock.yaml') }}
       - uses: jdx/mise-action@v4.0.1
         with:
           version: ${{ env.MISE_VERSION }}

--- a/server/lib/tuist/oidc.ex
+++ b/server/lib/tuist/oidc.ex
@@ -15,11 +15,13 @@ defmodule Tuist.OIDC do
   @github_actions_issuer "https://token.actions.githubusercontent.com"
   @bitrise_issuer "https://token.builds.bitrise.io"
   @circleci_issuer_prefix "https://oidc.circleci.com/org/"
+  @audience "tuist"
 
   def claims(token) when is_binary(token) do
     with {:ok, issuer} <- peek_issuer(token),
          {:ok, jwks_uri} <- get_jwks_uri(issuer),
          {:ok, claims} <- verify(token, jwks_uri),
+         :ok <- validate_audience(claims, issuer),
          {:ok, repository} <- get_repository_from_claims(claims, issuer) do
       {:ok, %{repository: repository}}
     end
@@ -141,4 +143,23 @@ defmodule Tuist.OIDC do
   end
 
   defp validate_expiration(_), do: {:error, :token_expired}
+
+  defp validate_audience(%{"aud" => @audience}, issuer) when issuer in [@github_actions_issuer, @bitrise_issuer] do
+    :ok
+  end
+
+  defp validate_audience(%{"aud" => audiences}, issuer)
+       when is_list(audiences) and issuer in [@github_actions_issuer, @bitrise_issuer] do
+    if @audience in audiences do
+      :ok
+    else
+      {:error, :invalid_audience}
+    end
+  end
+
+  defp validate_audience(_claims, issuer) when issuer in [@github_actions_issuer, @bitrise_issuer] do
+    {:error, :invalid_audience}
+  end
+
+  defp validate_audience(_claims, _issuer), do: :ok
 end

--- a/server/lib/tuist_web/controllers/api/oidc_controller.ex
+++ b/server/lib/tuist_web/controllers/api/oidc_controller.ex
@@ -110,6 +110,11 @@ defmodule TuistWeb.API.OIDCController do
         |> put_status(:unauthorized)
         |> json(%{message: "OIDC token has expired"})
 
+      {:error, :invalid_audience} ->
+        conn
+        |> put_status(:unauthorized)
+        |> json(%{message: "OIDC token audience is not valid for Tuist"})
+
       {:error, :jwks_fetch_failed, jwks_uri} ->
         conn
         |> put_status(:internal_server_error)

--- a/server/test/tuist/oidc_test.exs
+++ b/server/test/tuist/oidc_test.exs
@@ -22,6 +22,16 @@ defmodule Tuist.OIDCTest do
       assert claims.repository == "tuist/tuist"
     end
 
+    test "returns error for GitHub Actions token with invalid audience" do
+      {token, jwks} = generate_test_token_and_jwks(claims: %{"aud" => "other-service"})
+
+      stub(Req, :get, fn _url, _opts ->
+        {:ok, %{status: 200, body: jwks}}
+      end)
+
+      assert {:error, :invalid_audience} = OIDC.claims(token)
+    end
+
     test "returns error for invalid token format" do
       assert {:error, :invalid_token} = OIDC.claims("not-a-valid-jwt")
       assert {:error, :invalid_token} = OIDC.claims("")
@@ -152,6 +162,7 @@ defmodule Tuist.OIDCTest do
     base_claims = %{
       "iss" => Keyword.get(opts, :issuer, "https://token.actions.githubusercontent.com"),
       "exp" => Keyword.get(opts, :exp, DateTime.utc_now() |> DateTime.add(3600) |> DateTime.to_unix()),
+      "aud" => "tuist",
       "repository" => Keyword.get(opts, :repository, "tuist/tuist")
     }
 

--- a/server/test/tuist_web/controllers/api/oidc_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/oidc_controller_test.exs
@@ -111,5 +111,17 @@ defmodule TuistWeb.API.OIDCControllerTest do
       response = json_response(conn, :unauthorized)
       assert response["message"] =~ "expired"
     end
+
+    test "returns 401 when OIDC token audience is invalid", %{conn: conn} do
+      stub(OIDC, :claims, fn _token -> {:error, :invalid_audience} end)
+
+      conn =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> post(~p"/api/auth/oidc/token", %{token: "wrong-audience-token"})
+
+      response = json_response(conn, :unauthorized)
+      assert response["message"] =~ "audience"
+    end
   end
 end


### PR DESCRIPTION
## Summary

Harden CI and release paths against cache poisoning and broad token exposure after reviewing the TanStack npm supply chain incident pattern.

## Changes

- Remove release and deploy cache restores that could influence signed or deployed artifacts.
- Disable Gradle caching in release jobs.
- Scope `id-token: write` to only jobs that exchange OIDC tokens with Tuist.
- Add explicit workflow permissions where they were missing.
- Add CODEOWNERS coverage for workflows, actions, release scripts, and dependency manifests.
- Require the Tuist audience on GitHub Actions and Bitrise OIDC tokens before exchanging them for Tuist access tokens.

## Validation

- `mix test test/tuist/oidc_test.exs test/tuist_web/controllers/api/oidc_controller_test.exs`
- `mix format --check-formatted lib/tuist/oidc.ex lib/tuist_web/controllers/api/oidc_controller.ex test/tuist/oidc_test.exs test/tuist_web/controllers/api/oidc_controller_test.exs`
- Workflow YAML parse with Ruby YAML loader
- `git diff --check`

## Operational Notes

I also tightened repository settings outside this diff:

- Default `GITHUB_TOKEN` permissions are now read-only.
- GitHub Actions can no longer approve pull requests.
- Fork PR approval now applies to all external contributors.

I left repository action allowlisting unchanged because `allowed_actions` is currently `all`, and enabling an allowlist without a complete inventory would likely break CI.
