### PR TITLE
fix(server): prevent overlapping automation schedulers

### DIFF
--- a/server/lib/tuist/automations/workers/automation_scheduler.ex
+++ b/server/lib/tuist/automations/workers/automation_scheduler.ex
@@ -1,6 +1,9 @@
 defmodule Tuist.Automations.Workers.AutomationScheduler do
   @moduledoc false
-  use Oban.Worker, max_attempts: 1, queue: :default
+  use Oban.Worker,
+    max_attempts: 1,
+    queue: :default,
+    unique: [fields: [:worker], period: :infinity, states: [:available, :scheduled, :executing]]
 
   import Ecto.Query
 

--- a/server/test/tuist/automations/workers/automation_scheduler_test.exs
+++ b/server/test/tuist/automations/workers/automation_scheduler_test.exs
@@ -1,0 +1,29 @@
+defmodule Tuist.Automations.Workers.AutomationSchedulerTest do
+  use TuistTestSupport.Cases.DataCase, async: false
+
+  alias Tuist.Automations.Workers.AlertEvaluationWorker
+  alias Tuist.Automations.Workers.AutomationScheduler
+  alias TuistTestSupport.Fixtures.AutomationsFixtures
+
+  test "enqueues evaluation jobs for enabled alerts" do
+    alert = AutomationsFixtures.automation_alert_fixture()
+
+    assert :ok = AutomationScheduler.perform(%Oban.Job{args: %{}})
+
+    assert_enqueued(worker: AlertEvaluationWorker, args: %{alert_id: alert.id})
+  end
+
+  test "does not enqueue overlapping scheduler jobs" do
+    assert {:ok, %Oban.Job{conflict?: false}} =
+             %{}
+             |> AutomationScheduler.new()
+             |> Oban.insert()
+
+    assert {:ok, %Oban.Job{conflict?: true}} =
+             %{}
+             |> AutomationScheduler.new()
+             |> Oban.insert()
+
+    assert [_job] = all_enqueued(worker: AutomationScheduler)
+  end
+end


### PR DESCRIPTION
## Summary
- Make `AutomationScheduler` jobs unique while they are available, scheduled, or executing.
- Keep the existing per-alert evaluation cadence uniqueness unchanged.
- Avoid custom Oban indexes or manual incomplete-job scans; the canary table cleanup handled the bad historical backlog.

## Canary notes
- Canary had millions of stale `AlertEvaluationWorker` rows while production did not, which explains why `Oban.Met.Reporter.cache_queues/1` only failed there.
- After truncating `oban_jobs`, recent canary logs and Sentry checks stopped showing the Oban.Met timeout/connection errors.
- This PR is now just a guardrail against overlapping scheduler ticks recreating pressure.

## Tests
- `MIX_ENV=test mix test test/tuist/automations/workers/automation_scheduler_test.exs`
- `mix format --check-formatted lib/tuist/automations/workers/automation_scheduler.ex test/tuist/automations/workers/automation_scheduler_test.exs`