### PR TITLE
fix(server): configure managed Kura TLS issuer

### DIFF
--- a/infra/helm/tuist/templates/kura-controller.yaml
+++ b/infra/helm/tuist/templates/kura-controller.yaml
@@ -3,8 +3,12 @@
 {{- $namespace := .Values.kuraController.namespace }}
 {{- $serverRoleName := printf "%s-server" $name }}
 {{- $imageTag := .Values.kuraController.image.tag }}
+{{- $tlsClusterIssuer := .Values.kuraController.tlsClusterIssuer | default .Values.kuraController.grpcClusterIssuer }}
 {{- if not $imageTag }}
 {{- fail "kuraController.image.tag is required — running the controller on :latest silently drifts and surfaces in production after the next push to ghcr." }}
+{{- end }}
+{{- if and .Values.kuraController.tlsClusterIssuer .Values.kuraController.grpcClusterIssuer (ne .Values.kuraController.tlsClusterIssuer .Values.kuraController.grpcClusterIssuer) }}
+{{- fail "kuraController.tlsClusterIssuer and deprecated kuraController.grpcClusterIssuer cannot both be set to different values" }}
 {{- end }}
 ---
 apiVersion: v1
@@ -146,8 +150,8 @@ spec:
             - --metrics-bind-address=:8080
             - --health-probe-bind-address=:8081
             - --watch-namespace={{ $namespace }}
-            {{- if .Values.kuraController.grpcClusterIssuer }}
-            - --grpc-cluster-issuer={{ .Values.kuraController.grpcClusterIssuer }}
+            {{- if $tlsClusterIssuer }}
+            - --grpc-cluster-issuer={{ $tlsClusterIssuer }}
             {{- end }}
           ports:
             - name: metrics

--- a/infra/helm/tuist/values-managed-common.yaml
+++ b/infra/helm/tuist/values-managed-common.yaml
@@ -17,6 +17,10 @@ kuraController:
   namespace: kura
   image:
     tag: ""  # Set by CI to the commit SHA on each deploy.
+  # Managed app clusters bootstrap this ClusterIssuer via the platform
+  # chart. The controller uses it for the per-Kura public HTTPS and gRPC
+  # certificates mounted into each runtime pod.
+  tlsClusterIssuer: "letsencrypt-cloudflare"
 
 server:
   serviceAccount:

--- a/infra/helm/tuist/values-managed-kura-region.yaml
+++ b/infra/helm/tuist/values-managed-kura-region.yaml
@@ -13,11 +13,11 @@ kuraController:
   namespace: kura
   image:
     tag: ""  # Set by CI to the commit SHA on each deploy.
-  # ClusterIssuer that fronts the gRPC public LoadBalancer with a
-  # Let's Encrypt certificate. Must already exist on the regional
+  # ClusterIssuer that fronts the public HTTPS and gRPC LoadBalancers
+  # with Let's Encrypt certificates. Must already exist on the regional
   # cluster (cert-manager + the issuer are bootstrapped via the
-  # mgmt-cluster pipeline). Leave empty to keep gRPC plaintext.
-  grpcClusterIssuer: "letsencrypt-prod"
+  # mgmt-cluster pipeline).
+  tlsClusterIssuer: "letsencrypt-prod"
   sharedSecrets:
     # In managed regions, kura-shared-secrets is populated by CI from
     # the same secret store as the Tuist server release.

--- a/infra/helm/tuist/values.yaml
+++ b/infra/helm/tuist/values.yaml
@@ -23,9 +23,12 @@ kuraController:
     limits:
       cpu: "500m"
       memory: "512Mi"
-  # cert-manager ClusterIssuer to use for the per-instance gRPC TLS
-  # Certificate. Leave empty to expose gRPC plaintext (no public LB
-  # certificate) — recommended only for kind/dev clusters.
+  # cert-manager ClusterIssuer to use for the per-instance public HTTPS
+  # and gRPC TLS Certificates. Leave empty only when the runtime does not
+  # mount public TLS certificates, for example kind/dev clusters.
+  tlsClusterIssuer: ""
+  # Deprecated alias for tlsClusterIssuer. Kept so existing overlays do
+  # not break while the controller flag is still named grpc-cluster-issuer.
   grpcClusterIssuer: ""
   sharedSecrets:
     # Renders the kura-shared-secrets Kubernetes Secret in the


### PR DESCRIPTION
## Summary

Configure the managed Tuist Helm values so the Kura controller uses the `letsencrypt-cloudflare` ClusterIssuer for managed app clusters.

## Why

New Kura runtime pods mount public HTTPS and gRPC TLS secrets. In production the controller was running without a ClusterIssuer, so it skipped the cert-manager `Certificate` resources. The runtime then started before the TLS secrets existed and crashed while reading `/etc/kura/public-tls/tls.crt` and `/etc/kura/grpc-tls/tls.crt`, leaving the deployment stuck as deploying.

## Changes

- Add `kuraController.tlsClusterIssuer` as the generic chart value for public HTTPS and gRPC runtime certificates.
- Keep `kuraController.grpcClusterIssuer` as a deprecated compatibility alias for existing overlays.
- Set the managed common values to `letsencrypt-cloudflare`.
- Update regional Kura values to use the same generic `tlsClusterIssuer` name.

## Validation

- `helm template tuist infra/helm/tuist -n tuist -f infra/helm/tuist/values-managed-common.yaml -f infra/helm/tuist/values-managed-production.yaml --set server.image.tag=sha-test --set kuraController.image.tag=sha-test`
- `helm template tuist infra/helm/tuist -n tuist --set kuraController.enabled=true --set kuraController.image.tag=sha-test --set kuraController.grpcClusterIssuer=legacy-issuer --set server.image.tag=sha-test`
- `helm lint infra/helm/tuist -f infra/helm/tuist/values-managed-common.yaml -f infra/helm/tuist/values-managed-production.yaml --set server.image.tag=sha-test --set kuraController.image.tag=sha-test`
