### PR TITLE
fix(noora): compact select dropdown menus

### DIFF
--- a/noora/js/Select.js
+++ b/noora/js/Select.js
@@ -47,9 +47,12 @@ class Select extends Component {
   }
 
   renderItems() {
-    for (const item of this.el.querySelectorAll(
-      getPartSelector("positioner:content:item"),
-    )) {
+    const content = this.el.querySelector(
+      getPartSelector("positioner:content"),
+    );
+    if (!content) return;
+
+    for (const item of content.querySelectorAll("[data-part='item']")) {
       const value = item.dataset.value;
       const label = item.dataset.label;
       if (!value || !label) {

--- a/noora/lib/noora/select.ex
+++ b/noora/lib/noora/select.ex
@@ -85,16 +85,18 @@ defmodule Noora.Select do
       </button>
       <div data-part="positioner">
         <div class="noora-dropdown-content" data-part="content">
-          <.dropdown_item
-            :for={item <- @item}
-            data-part="item"
-            value={item.value}
-            label={item.label}
-            class="noora-dropdown-item"
-          >
-            <:left_icon :if={Map.has_key?(item, :icon)}><.icon name={item.icon} /></:left_icon>
-            {item.label}
-          </.dropdown_item>
+          <div data-part="items">
+            <.dropdown_item
+              :for={item <- @item}
+              data-part="item"
+              value={item.value}
+              label={item.label}
+              class="noora-dropdown-item"
+            >
+              <:left_icon :if={Map.has_key?(item, :icon)}><.icon name={item.icon} /></:left_icon>
+              {item.label}
+            </.dropdown_item>
+          </div>
         </div>
       </div>
       <span :if={@hint} data-part="hint">


### PR DESCRIPTION
## Summary

- Updates `Noora.Select` to render options inside the same `[data-part="items"]` wrapper used by the dropdown defaults.
- Updates the select hook to apply item props to options nested under the dropdown content.

## Why

The Kura region selector should get the default Noora dropdown spacing from the component structure instead of introducing select-specific spacing overrides.

## Validation

- `mise run noora:lint`
- `mise run noora:test`
- `mise exec -- mix compile --warnings-as-errors`
- `mise exec -- aube exec esbuild css/noora.css --bundle --minify --sourcemap --outfile=/tmp/noora.css`
- `git diff --check`
