### PR TITLE
fix(infra): harden deployment cleanup

### DIFF
--- a/infra/helm/tuist/templates/kura-controller.yaml
+++ b/infra/helm/tuist/templates/kura-controller.yaml
@@ -141,6 +141,10 @@ spec:
         {{- include "tuist.componentLabels" (dict "root" . "component" "kura-controller") | nindent 8 }}
     spec:
       serviceAccountName: {{ $name }}
+      {{- with .Values.kuraController.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: manager
           image: "{{ .Values.kuraController.image.repository }}:{{ $imageTag }}"

--- a/infra/helm/tuist/templates/tart-kubelet-rbac.yaml
+++ b/infra/helm/tuist/templates/tart-kubelet-rbac.yaml
@@ -24,9 +24,13 @@ rules:
   - apiGroups: [""]
     resources: [nodes, nodes/status]
     verbs: [get, list, watch, create, update, patch]
-  # Watch + status-update Pods scheduled here.
+  # Watch + status-update Pods scheduled here, and force-complete
+  # object deletion after the backing Tart VM has been torn down.
   - apiGroups: [""]
-    resources: [pods, pods/status]
+    resources: [pods]
+    verbs: [get, list, watch, update, patch, delete]
+  - apiGroups: [""]
+    resources: [pods/status]
     verbs: [get, list, watch, update, patch]
   # The pod agent adds a finalizer before starting the Tart VM and
   # removes it only after VM teardown, so stale API Pods cannot

--- a/infra/helm/tuist/values-managed-kura-region.yaml
+++ b/infra/helm/tuist/values-managed-kura-region.yaml
@@ -13,6 +13,13 @@ kuraController:
   namespace: kura
   image:
     tag: ""  # Set by CI to the commit SHA on each deploy.
+  # Some regional clusters run as single control-plane-only clusters.
+  # Tolerating the standard control-plane taint lets the controller
+  # schedule there, while worker-backed regions remain unaffected.
+  tolerations:
+    - key: node-role.kubernetes.io/control-plane
+      operator: Exists
+      effect: NoSchedule
   # ClusterIssuer that fronts the public HTTPS and gRPC LoadBalancers
   # with Let's Encrypt certificates. Must already exist on the regional
   # cluster (cert-manager + the issuer are bootstrapped via the

--- a/infra/helm/tuist/values.yaml
+++ b/infra/helm/tuist/values.yaml
@@ -12,6 +12,7 @@ kuraController:
   enabled: false
   namespace: kura
   replicaCount: 2
+  tolerations: []
   image:
     repository: ghcr.io/tuist/kura-controller
     tag: ""

--- a/infra/tart-kubelet/internal/podagent/reconciler.go
+++ b/infra/tart-kubelet/internal/podagent/reconciler.go
@@ -125,22 +125,19 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 	if !pod.DeletionTimestamp.IsZero() {
 		// Pod is being deleted. Run VM teardown, then drop our
-		// finalizer so the API server can complete deletion. Order
-		// matters: we must not remove the finalizer until the VM
-		// is gone, otherwise the Pod disappears from kubectl's view
+		// finalizer and force-complete the API object deletion. Order
+		// matters: the Pod must not disappear from kubectl's view
 		// while the VM is still running on the host.
 		if err := r.deletePod(ctx, pod); err != nil {
 			logger.Error(err, "delete failed; will retry")
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 		}
-		if controllerutil.RemoveFinalizer(pod, PodFinalizer) {
-			if err := r.CachedClient.Update(ctx, pod); err != nil {
-				if apierrors.IsConflict(err) || apierrors.IsNotFound(err) {
-					return ctrl.Result{}, nil
-				}
-				logger.Error(err, "remove finalizer; will retry")
-				return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
+		if err := r.completePodDeletion(ctx, pod); err != nil {
+			if apierrors.IsConflict(err) || apierrors.IsNotFound(err) {
+				return ctrl.Result{}, nil
 			}
+			logger.Error(err, "complete pod deletion; will retry")
+			return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 		}
 		return ctrl.Result{}, nil
 	}
@@ -368,13 +365,23 @@ func contextWithTimeout(d time.Duration) (context.Context, context.CancelFunc) {
 }
 
 func (r *Reconciler) deletePod(ctx context.Context, pod *corev1.Pod) error {
-	// VM teardown only. The caller (Reconcile, on DeletionTimestamp)
-	// removes the finalizer afterward, which lets the API server
-	// complete deletion on its own — the controller-runtime-idiomatic
-	// shape. No `client.Delete` here: the chart's tart-kubelet
-	// ClusterRole grants update/patch on Pods (the real-kubelet
-	// surface) but not delete, and we don't need it.
+	// VM teardown only. The caller removes the finalizer and force-
+	// completes the API object deletion afterward.
 	return r.deleteByKey(ctx, pod.Namespace, pod.Name)
+}
+
+func (r *Reconciler) completePodDeletion(ctx context.Context, pod *corev1.Pod) error {
+	if controllerutil.RemoveFinalizer(pod, PodFinalizer) {
+		if err := r.CachedClient.Update(ctx, pod); err != nil {
+			return err
+		}
+	}
+
+	// The API server usually removes a terminating Pod once its
+	// finalizers are gone, but a stale object can keep the hostPort and
+	// topology slot occupied indefinitely. Make deletion explicit after
+	// VM cleanup so rollouts cannot get stuck behind old Pod objects.
+	return r.CachedClient.Delete(ctx, pod, client.GracePeriodSeconds(0))
 }
 
 func (r *Reconciler) deleteByKey(ctx context.Context, namespace, name string) error {

--- a/infra/tart-kubelet/internal/podagent/reconciler_test.go
+++ b/infra/tart-kubelet/internal/podagent/reconciler_test.go
@@ -1,0 +1,85 @@
+package podagent
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestCompletePodDeletionRemovesFinalizerAndDeletesPod(t *testing.T) {
+	ctx := context.Background()
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:  "default",
+			Name:       "xcresult-processor",
+			Finalizers: []string{PodFinalizer},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "processor", Image: "ghcr.io/tuist/xcresult-processor:test"}},
+		},
+	}
+	kubeClient := newPodTestClient(t, pod)
+	storedPod := getPod(t, ctx, kubeClient, types.NamespacedName{Namespace: "default", Name: "xcresult-processor"})
+
+	reconciler := &Reconciler{CachedClient: kubeClient}
+	if err := reconciler.completePodDeletion(ctx, storedPod); err != nil {
+		t.Fatalf("completePodDeletion: %v", err)
+	}
+
+	assertPodDeleted(t, ctx, kubeClient, types.NamespacedName{Namespace: "default", Name: "xcresult-processor"})
+}
+
+func TestCompletePodDeletionDeletesPodWithoutFinalizer(t *testing.T) {
+	ctx := context.Background()
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "already-cleaned",
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "processor", Image: "ghcr.io/tuist/xcresult-processor:test"}},
+		},
+	}
+	kubeClient := newPodTestClient(t, pod)
+	storedPod := getPod(t, ctx, kubeClient, types.NamespacedName{Namespace: "default", Name: "already-cleaned"})
+
+	reconciler := &Reconciler{CachedClient: kubeClient}
+	if err := reconciler.completePodDeletion(ctx, storedPod); err != nil {
+		t.Fatalf("completePodDeletion: %v", err)
+	}
+
+	assertPodDeleted(t, ctx, kubeClient, types.NamespacedName{Namespace: "default", Name: "already-cleaned"})
+}
+
+func newPodTestClient(t *testing.T, objects ...runtime.Object) client.Client {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add core scheme: %v", err)
+	}
+	return fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objects...).Build()
+}
+
+func assertPodDeleted(t *testing.T, ctx context.Context, kubeClient client.Client, name types.NamespacedName) {
+	t.Helper()
+	pod := &corev1.Pod{}
+	if err := kubeClient.Get(ctx, name, pod); !apierrors.IsNotFound(err) {
+		t.Fatalf("pod still exists: %v", err)
+	}
+}
+
+func getPod(t *testing.T, ctx context.Context, kubeClient client.Client, name types.NamespacedName) *corev1.Pod {
+	t.Helper()
+	pod := &corev1.Pod{}
+	if err := kubeClient.Get(ctx, name, pod); err != nil {
+		t.Fatalf("get pod: %v", err)
+	}
+	return pod
+}


### PR DESCRIPTION
## Summary

This PR hardens two deployment paths that failed during the production rollout:

- regional Kura controller deployments can now schedule on single-node control-plane-only clusters
- `tart-kubelet` now force-completes Kubernetes pod object deletion after Tart VM cleanup, so stale `Terminating` macOS pods cannot keep blocking future rollouts

## What problem are we solving?

The production deploy was blocked in two separate places:

1. **Regional Kura controller rollout**

   The `us-east-1` regional Kura cluster currently has only a control-plane node. That node carries the standard Kubernetes `node-role.kubernetes.io/control-plane:NoSchedule` taint, but the Kura controller Deployment did not tolerate it. Helm waited for the Deployment to become ready, the pods stayed Pending, and the deploy failed with `context deadline exceeded`.

2. **macOS `xcresult-processor` rollout**

   During the macOS processor rollout, old `xcresult-processor` pods remained stuck in `Terminating` after VM cleanup had already happened. Those stale pod objects still occupied scheduler constraints, including host ports and topology slots, so the replacement pod could not schedule even though the backing VM work was done.

   Manually force-deleting the stale pod API objects unblocked production. This PR moves that manual cleanup into `tart-kubelet` itself.

## Why this approach?

### Kura controller toleration

The regional Kura overlay now sets a controller-specific toleration for the standard control-plane taint.

This is intentionally scoped to `kuraController.tolerations` rather than changing global chart scheduling defaults:

- it fixes the regional workload cluster shape that failed
- it does not change scheduling for the Tuist server, processor, cache, or self-hosted defaults
- it remains harmless in regions with worker nodes, because the toleration only allows scheduling on tainted control-plane nodes; it does not force placement there

The chart also exposes `kuraController.tolerations` in `values.yaml`, matching the component-level scheduling knobs already used elsewhere in the chart.

### Tart pod deletion completion

`tart-kubelet` already owns the lifecycle of pods scheduled onto the macOS nodes. It adds a finalizer before starting the Tart VM, tears the VM down when the pod is deleted, and then removes the finalizer.

In practice, removing the finalizer was not always enough to make the pod object disappear promptly. Once VM cleanup has succeeded, keeping the Kubernetes pod object around is actively harmful because it can block host ports and topology spread for the next replica.

So after VM cleanup, `tart-kubelet` now:

1. removes its VM cleanup finalizer if present
2. explicitly deletes the pod object with `gracePeriodSeconds=0`

This preserves the important safety property: the pod cannot disappear before the VM is torn down. It only force-completes the Kubernetes object deletion after the runtime cleanup has succeeded.

The RBAC change grants `delete` only on `pods`, not broader resources, because that is the exact API operation needed to complete cleanup.

## Testing

- `helm template tuist infra/helm/tuist -f infra/helm/tuist/values-managed-kura-region.yaml --set kuraController.image.tag=test --set kuraRuntime.image.tag=test`
- `helm template tuist infra/helm/tuist --set server.image.tag=test --set kuraRuntime.image.tag=test --set macosFleet.enabled=true`
- `go test ./internal/podagent`
