### PR TITLE
fix(server): improve Kura cache server readiness

### DIFF
--- a/.github/workflows/server-deployment.yml
+++ b/.github/workflows/server-deployment.yml
@@ -81,7 +81,6 @@ permissions:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: tuist/tuist
-  KURA_RUNTIME_IMAGE_NAME: tuist/kura
   KURA_CONTROLLER_IMAGE_NAME: tuist/kura-controller
   HELM_CHART_PATH: infra/helm/tuist
   HELM_RELEASE_NAME: tuist
@@ -132,15 +131,6 @@ jobs:
           push: true
           tags: |
             ${{ env.REGISTRY }}/${{ env.KURA_CONTROLLER_IMAGE_NAME }}:${{ steps.tag.outputs.image_tag }}
-      - uses: docker/build-push-action@v6
-        name: Build and push Kura runtime image
-        with:
-          context: ./kura
-          file: ./kura/Dockerfile
-          push: true
-          tags: |
-            ${{ env.REGISTRY }}/${{ env.KURA_RUNTIME_IMAGE_NAME }}:${{ steps.tag.outputs.image_tag }}
-
   observability-install:
     # Installs / upgrades the grafana/k8s-monitoring wrapper chart ahead of
     # the server rollout so the Alloy OTLP receiver is ready before the
@@ -396,7 +386,6 @@ jobs:
             -f "$HELM_CHART_PATH/values-managed-${{ inputs.environment }}.yaml" \
             --set server.image.tag="$IMAGE_TAG" \
             --set kuraController.image.tag="$IMAGE_TAG" \
-            --set kuraRuntime.image.tag="$IMAGE_TAG" \
             --atomic --timeout 90m --wait
       - name: Deploy Kura regional controllers
         if: inputs.environment == 'production'

--- a/.github/workflows/server-deployment.yml
+++ b/.github/workflows/server-deployment.yml
@@ -55,6 +55,9 @@ on:
       image_tag:
         description: Pre-built image tag to deploy instead of building
         required: false
+      kura_runtime_image_tag:
+        description: Pre-built Kura runtime image tag to deploy
+        required: false
   workflow_call:
     inputs:
       environment:
@@ -70,6 +73,13 @@ on:
           Pre-built image tag to deploy. When set, the build job is
           skipped and the deploy job uses this tag directly. When unset,
           the workflow builds + pushes an image tagged sha-<commit_sha>.
+        required: false
+        type: string
+      kura_runtime_image_tag:
+        description: >-
+          Pre-built Kura runtime image tag to deploy. When unset, the
+          deploy job resolves the latest kura@ release and strips the
+          release prefix before passing it to Helm.
         required: false
         type: string
 
@@ -211,6 +221,7 @@ jobs:
       KUBECONFIG: ${{ github.workspace }}/.kube/config
       NAMESPACE: ${{ inputs.environment == 'production' && 'tuist' || format('tuist-{0}', inputs.environment) }}
       IMAGE_TAG: ${{ inputs.image_tag != '' && inputs.image_tag || needs.build.outputs.image_tag }}
+      KURA_RUNTIME_IMAGE_TAG: ${{ inputs.kura_runtime_image_tag }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -336,6 +347,47 @@ jobs:
           # so dependent pods (Pending or otherwise) go with the Job.
           echo "$stale_jobs" | xargs -r kubectl -n "$NAMESPACE" delete job \
             --ignore-not-found --cascade=foreground --timeout=2m
+      - name: Resolve Kura runtime image tag
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          if [ -n "${KURA_RUNTIME_IMAGE_TAG:-}" ]; then
+            echo "Using configured Kura runtime image tag $KURA_RUNTIME_IMAGE_TAG"
+            exit 0
+          fi
+
+          page=1
+          while true; do
+            response="$(
+              curl --fail --silent --show-error \
+                --header "Accept: application/vnd.github+json" \
+                --header "Authorization: Bearer $GITHUB_TOKEN" \
+                "https://api.github.com/repos/tuist/tuist/releases?per_page=100&page=$page"
+            )"
+
+            tag="$(
+              printf '%s' "$response" | python3 -c 'import json, sys; print(next((release["tag_name"].removeprefix("kura@") for release in json.load(sys.stdin) if release.get("tag_name", "").startswith("kura@")), ""), end="")'
+            )"
+
+            if [ -n "$tag" ]; then
+              echo "KURA_RUNTIME_IMAGE_TAG=$tag" >> "$GITHUB_ENV"
+              echo "Resolved Kura runtime image tag $tag"
+              exit 0
+            fi
+
+            count="$(
+              printf '%s' "$response" | python3 -c 'import json, sys; print(len(json.load(sys.stdin)))'
+            )"
+
+            if [ "$count" -lt 100 ]; then
+              echo "No kura@ release found in GitHub releases."
+              exit 1
+            fi
+
+            page=$((page + 1))
+          done
       - name: helm upgrade --install
         # App secrets never pass through --set: the chart runs in
         # `server.managedSecrets: true` mode, which reads DATABASE_URL /
@@ -386,6 +438,7 @@ jobs:
             -f "$HELM_CHART_PATH/values-managed-${{ inputs.environment }}.yaml" \
             --set server.image.tag="$IMAGE_TAG" \
             --set kuraController.image.tag="$IMAGE_TAG" \
+            --set kuraRuntime.image.tag="$KURA_RUNTIME_IMAGE_TAG" \
             --atomic --timeout 90m --wait
       - name: Deploy Kura regional controllers
         if: inputs.environment == 'production'

--- a/.github/workflows/server-production-deployment.yml
+++ b/.github/workflows/server-production-deployment.yml
@@ -62,7 +62,6 @@ permissions:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: tuist/tuist
-  KURA_RUNTIME_IMAGE_NAME: tuist/kura
   KURA_CONTROLLER_IMAGE_NAME: tuist/kura-controller
 
 jobs:
@@ -113,15 +112,6 @@ jobs:
           push: true
           tags: |
             ${{ env.REGISTRY }}/${{ env.KURA_CONTROLLER_IMAGE_NAME }}:${{ steps.tag.outputs.image_tag }}
-      - uses: docker/build-push-action@v6
-        name: Build and push Kura runtime image
-        with:
-          context: ./kura
-          file: ./kura/Dockerfile
-          push: true
-          tags: |
-            ${{ env.REGISTRY }}/${{ env.KURA_RUNTIME_IMAGE_NAME }}:${{ steps.tag.outputs.image_tag }}
-
   # --------------------------------------------------------------------------
   # Canary leg - deploys the pre-built image. Runs for every push (hotfix
   # or not) and for manual dispatch. On hotfix pushes it still runs as a

--- a/infra/grafana-dashboards/tuist-kura.json
+++ b/infra/grafana-dashboards/tuist-kura.json
@@ -1480,7 +1480,7 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "1 - avg by (instance) (rate(node_cpu_seconds_total{instance=~\"${instance:regex}\", mode=\"idle\"}[$__rate_interval]))",
+            "expr": "1 - avg by (instance) (rate(node_cpu_seconds_total{mode=\"idle\"}[$__rate_interval]) and on (instance) max by (instance) (kura_node_info{cluster=\"kura-tuist\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"}))",
             "legendFormat": "{{instance}}",
             "refId": "A"
           }
@@ -1546,7 +1546,7 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "1 - (node_memory_MemAvailable_bytes{instance=~\"${instance:regex}\"} / node_memory_MemTotal_bytes{instance=~\"${instance:regex}\"})",
+            "expr": "1 - ((node_memory_MemAvailable_bytes and on (instance) max by (instance) (kura_node_info{cluster=\"kura-tuist\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"})) / (node_memory_MemTotal_bytes and on (instance) max by (instance) (kura_node_info{cluster=\"kura-tuist\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"})))",
             "legendFormat": "{{instance}}",
             "refId": "A"
           }
@@ -1620,7 +1620,7 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "1 - (node_filesystem_avail_bytes{instance=~\"${instance:regex}\", mountpoint=\"/\", fstype!~\"tmpfs|overlay\"} / node_filesystem_size_bytes{instance=~\"${instance:regex}\", mountpoint=\"/\", fstype!~\"tmpfs|overlay\"})",
+            "expr": "1 - ((node_filesystem_avail_bytes{mountpoint=\"/\", fstype!~\"tmpfs|overlay\"} and on (instance) max by (instance) (kura_node_info{cluster=\"kura-tuist\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"})) / (node_filesystem_size_bytes{mountpoint=\"/\", fstype!~\"tmpfs|overlay\"} and on (instance) max by (instance) (kura_node_info{cluster=\"kura-tuist\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"})))",
             "legendFormat": "{{instance}}",
             "refId": "A"
           }
@@ -1686,14 +1686,14 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "sum by (instance) (rate(node_network_receive_bytes_total{instance=~\"${instance:regex}\", device!~\"lo\"}[$__rate_interval]))",
+            "expr": "sum by (instance) (rate(node_network_receive_bytes_total{device!~\"lo\"}[$__rate_interval]) and on (instance) max by (instance) (kura_node_info{cluster=\"kura-tuist\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"}))",
             "legendFormat": "{{instance}} rx",
             "refId": "A"
           },
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "sum by (instance) (rate(node_network_transmit_bytes_total{instance=~\"${instance:regex}\", device!~\"lo\"}[$__rate_interval]))",
+            "expr": "sum by (instance) (rate(node_network_transmit_bytes_total{device!~\"lo\"}[$__rate_interval]) and on (instance) max by (instance) (kura_node_info{cluster=\"kura-tuist\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"}))",
             "legendFormat": "{{instance}} tx",
             "refId": "B"
           }
@@ -1759,7 +1759,7 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "node_filefd_allocated{instance=~\"${instance:regex}\"}",
+            "expr": "node_filefd_allocated and on (instance) max by (instance) (kura_node_info{cluster=\"kura-tuist\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"})",
             "legendFormat": "{{instance}}",
             "refId": "A"
           }
@@ -1930,14 +1930,14 @@
             "value": "$__all"
           },
           "datasource": "$datasource",
-          "definition": "label_values(kura_http_requests_total_total{cluster=\"kura-tuist\"}, instance)",
+          "definition": "label_values(kura_node_info{cluster=\"kura-tuist\"}, instance)",
           "hide": 0,
           "includeAll": true,
           "label": "Instance",
           "multi": true,
           "name": "instance",
           "query": {
-            "query": "label_values(kura_http_requests_total_total{cluster=\"kura-tuist\"}, instance)",
+            "query": "label_values(kura_node_info{cluster=\"kura-tuist\"}, instance)",
             "refId": "PrometheusVariableQueryEditor-VariableQuery"
           },
           "refresh": 1,
@@ -1953,14 +1953,14 @@
             "value": "$__all"
           },
           "datasource": "$datasource",
-          "definition": "label_values(kura_http_requests_total_total{cluster=\"kura-tuist\"}, region)",
+          "definition": "label_values(kura_node_info{cluster=\"kura-tuist\"}, region)",
           "hide": 0,
           "includeAll": true,
           "label": "Region",
           "multi": true,
           "name": "region",
           "query": {
-            "query": "label_values(kura_http_requests_total_total{cluster=\"kura-tuist\"}, region)",
+            "query": "label_values(kura_node_info{cluster=\"kura-tuist\"}, region)",
             "refId": "PrometheusVariableQueryEditor-VariableQuery"
           },
           "refresh": 1,

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -41,7 +41,7 @@ RUN swift build -c release --replace-scm-with-registry && \
 FROM node:22-slim AS npm-deps
 ENV CI=1
 ENV XDG_DATA_HOME="/aube-data"
-RUN npm install -g --ignore-scripts=false @endevco/aube
+RUN npm install -g --ignore-scripts=false @endevco/aube@1.6.2
 COPY server/package.json /app/package.json
 COPY server/pnpm-lock.yaml /app/pnpm-lock.yaml
 WORKDIR /app

--- a/server/README.md
+++ b/server/README.md
@@ -99,7 +99,7 @@ curl "http://localhost:${port}/up"
 
 Managed deployments expose the regions listed in `TUIST_KURA_AVAILABLE_REGIONS`. The production Helm overlay currently sets `eu-central,us-east,us-west`, so account settings can deploy one Kura server per account in any managed region that is not already occupied by that account.
 
-Server deploys build and push `ghcr.io/tuist/kura:<sha-tag>` alongside the Tuist server and Kura controller images. Helm passes that tag as `TUIST_KURA_RUNTIME_IMAGE_TAG`; the reconciler uses it to roll active Kura servers forward in lockstep with the server deploy.
+Managed deploys use the latest `kura@...` GitHub release as the visible Kura version. The reconciler rolls active Kura servers to the corresponding Docker tag, for example `kura@0.5.2` maps to `ghcr.io/tuist/kura:0.5.2`. Local development can still set `TUIST_KURA_RUNTIME_IMAGE_TAG=dev`.
 
 Production maps those product regions to Hetzner-backed workload clusters:
 

--- a/server/lib/tuist/github/releases.ex
+++ b/server/lib/tuist/github/releases.ex
@@ -189,6 +189,10 @@ defmodule Tuist.GitHub.Releases do
         Logger.error("Failed to fetch GitHub releases, status: #{status}")
         nil
 
+      {:ok, %Req.Response{status: status}} ->
+        Logger.error("Failed to fetch GitHub releases, status: #{status}")
+        nil
+
       {:error, reason} ->
         Logger.error("Failed to fetch GitHub releases, reason: #{inspect(reason)}")
         nil

--- a/server/lib/tuist/github/releases.ex
+++ b/server/lib/tuist/github/releases.ex
@@ -61,20 +61,6 @@ defmodule Tuist.GitHub.Releases do
     end
   end
 
-  def get_latest_kura_release(opts \\ []) do
-    if Tuist.Environment.dev?() do
-      nil
-    else
-      KeyValueStore.get_or_update(
-        [__MODULE__, "github_latest_kura_release"],
-        [ttl: Keyword.get(opts, :ttl, @ttl)],
-        fn ->
-          fetch_latest_kura_release(opts)
-        end
-      )
-    end
-  end
-
   defp fetch_releases(opts) do
     KeyValueStore.get_or_update(
       [__MODULE__, "github_releases"],
@@ -146,24 +132,6 @@ defmodule Tuist.GitHub.Releases do
     end
   end
 
-  defp fetch_latest_kura_release(opts) do
-    url = Keyword.get(opts, :url, releases_url())
-
-    case release_page(url, opts) do
-      %{releases: releases, next_url: next_url} ->
-        case find_kura_release_from_releases(releases) do
-          nil when next_url != nil ->
-            fetch_latest_kura_release(Keyword.put(opts, :url, next_url))
-
-          result ->
-            result
-        end
-
-      nil ->
-        nil
-    end
-  end
-
   defp release_page(url, opts) do
     KeyValueStore.get_or_update(
       [__MODULE__, "github_releases_page", url],
@@ -203,12 +171,6 @@ defmodule Tuist.GitHub.Releases do
     Enum.find(releases, fn release ->
       String.starts_with?(release.tag_name, "app@") and
         Enum.find(release.assets, &String.ends_with?(&1.browser_download_url, "dmg"))
-    end)
-  end
-
-  defp find_kura_release_from_releases(releases) do
-    Enum.find(releases, fn release ->
-      String.starts_with?(release.tag_name || "", "kura@")
     end)
   end
 

--- a/server/lib/tuist/github/releases.ex
+++ b/server/lib/tuist/github/releases.ex
@@ -130,50 +130,60 @@ defmodule Tuist.GitHub.Releases do
 
   defp fetch_latest_app_release(opts \\ []) do
     url = Keyword.get(opts, :url, releases_url())
-    headers = github_auth_headers()
-    req_opts = [finch: Tuist.Finch, headers: headers] ++ Retry.retry_options()
 
-    case Req.get(url, req_opts) do
-      {:ok, %Req.Response{status: 200, body: releases, headers: headers}} ->
-        next_url = extract_next_url(headers)
-
-        releases = Enum.map(releases, &map_release/1)
-
+    case release_page(url, opts) do
+      %{releases: releases, next_url: next_url} ->
         case find_app_release_from_releases(releases) do
           nil when next_url != nil ->
-            fetch_latest_app_release(url: next_url)
+            fetch_latest_app_release(Keyword.put(opts, :url, next_url))
 
           result ->
             result
         end
 
-      {:ok, %Req.Response{status: status}} when status in 500..599 ->
-        Logger.error("Failed to fetch GitHub releases, status: #{status}")
-        nil
-
-      {:error, reason} ->
-        Logger.error("Failed to fetch GitHub releases, reason: #{inspect(reason)}")
+      nil ->
         nil
     end
   end
 
   defp fetch_latest_kura_release(opts) do
     url = Keyword.get(opts, :url, releases_url())
+
+    case release_page(url, opts) do
+      %{releases: releases, next_url: next_url} ->
+        case find_kura_release_from_releases(releases) do
+          nil when next_url != nil ->
+            fetch_latest_kura_release(Keyword.put(opts, :url, next_url))
+
+          result ->
+            result
+        end
+
+      nil ->
+        nil
+    end
+  end
+
+  defp release_page(url, opts) do
+    KeyValueStore.get_or_update(
+      [__MODULE__, "github_releases_page", url],
+      [ttl: Keyword.get(opts, :ttl, @ttl)],
+      fn ->
+        fetch_release_page(url)
+      end
+    )
+  end
+
+  defp fetch_release_page(url) do
     headers = github_auth_headers()
     req_opts = [finch: Tuist.Finch, headers: headers] ++ Retry.retry_options()
 
     case Req.get(url, req_opts) do
       {:ok, %Req.Response{status: 200, body: releases, headers: headers}} ->
-        next_url = extract_next_url(headers)
-        releases = Enum.map(releases, &map_release/1)
-
-        case find_kura_release_from_releases(releases) do
-          nil when next_url != nil ->
-            fetch_latest_kura_release(url: next_url)
-
-          result ->
-            result
-        end
+        %{
+          releases: Enum.map(releases, &map_release/1),
+          next_url: extract_next_url(headers)
+        }
 
       {:ok, %Req.Response{status: status}} when status in 500..599 ->
         Logger.error("Failed to fetch GitHub releases, status: #{status}")

--- a/server/lib/tuist/github/releases.ex
+++ b/server/lib/tuist/github/releases.ex
@@ -61,6 +61,20 @@ defmodule Tuist.GitHub.Releases do
     end
   end
 
+  def get_latest_kura_release(opts \\ []) do
+    if Tuist.Environment.dev?() do
+      nil
+    else
+      KeyValueStore.get_or_update(
+        [__MODULE__, "github_latest_kura_release"],
+        [ttl: Keyword.get(opts, :ttl, @ttl)],
+        fn ->
+          fetch_latest_kura_release(opts)
+        end
+      )
+    end
+  end
+
   defp fetch_releases(opts) do
     KeyValueStore.get_or_update(
       [__MODULE__, "github_releases"],
@@ -143,10 +157,44 @@ defmodule Tuist.GitHub.Releases do
     end
   end
 
+  defp fetch_latest_kura_release(opts) do
+    url = Keyword.get(opts, :url, releases_url())
+    headers = github_auth_headers()
+    req_opts = [finch: Tuist.Finch, headers: headers] ++ Retry.retry_options()
+
+    case Req.get(url, req_opts) do
+      {:ok, %Req.Response{status: 200, body: releases, headers: headers}} ->
+        next_url = extract_next_url(headers)
+        releases = Enum.map(releases, &map_release/1)
+
+        case find_kura_release_from_releases(releases) do
+          nil when next_url != nil ->
+            fetch_latest_kura_release(url: next_url)
+
+          result ->
+            result
+        end
+
+      {:ok, %Req.Response{status: status}} when status in 500..599 ->
+        Logger.error("Failed to fetch GitHub releases, status: #{status}")
+        nil
+
+      {:error, reason} ->
+        Logger.error("Failed to fetch GitHub releases, reason: #{inspect(reason)}")
+        nil
+    end
+  end
+
   defp find_app_release_from_releases(releases) do
     Enum.find(releases, fn release ->
       String.starts_with?(release.tag_name, "app@") and
         Enum.find(release.assets, &String.ends_with?(&1.browser_download_url, "dmg"))
+    end)
+  end
+
+  defp find_kura_release_from_releases(releases) do
+    Enum.find(releases, fn release ->
+      String.starts_with?(release.tag_name || "", "kura@")
     end)
   end
 

--- a/server/lib/tuist/kura.ex
+++ b/server/lib/tuist/kura.ex
@@ -22,7 +22,6 @@ defmodule Tuist.Kura do
   alias Phoenix.PubSub
   alias Tuist.Accounts
   alias Tuist.Accounts.AccountCacheEndpoint
-  alias Tuist.GitHub.Releases
   alias Tuist.Kura.Deployment
   alias Tuist.Kura.Provisioner
   alias Tuist.Kura.Reconciler
@@ -47,11 +46,11 @@ defmodule Tuist.Kura do
   ## Versions
 
   @doc """
-  Returns the latest released Kura runtime version.
+  Returns the configured Kura runtime version.
 
-  Managed deploys use the latest `kura@...` GitHub release as the
-  source release, while rollout manifests use the corresponding
-  Docker tag without the `kura@` prefix.
+  Managed deploys use the runtime image tag declared by deploy
+  configuration. GitHub releases can be used as a discovery hint, but the
+  rollout source of truth stays in Helm/CI configuration.
   """
   def latest_versions(limit \\ 20)
 
@@ -96,27 +95,6 @@ defmodule Tuist.Kura do
   end
 
   defp runtime_version do
-    if Tuist.Environment.dev?() or Tuist.Environment.test?() do
-      local_runtime_version()
-    else
-      released_runtime_version()
-    end
-  end
-
-  defp released_runtime_version do
-    case Releases.get_latest_kura_release() do
-      %{tag_name: tag_name, published_at: released_at} when is_binary(tag_name) ->
-        case tag_name do
-          "kura@" <> image_tag -> %{version: tag_name, image_tag: image_tag, released_at: released_at}
-          _ -> nil
-        end
-
-      _ ->
-        nil
-    end
-  end
-
-  defp local_runtime_version do
     case Tuist.Environment.kura_runtime_image_tag() do
       tag when is_binary(tag) ->
         tag = String.trim(tag)

--- a/server/lib/tuist/kura.ex
+++ b/server/lib/tuist/kura.ex
@@ -50,7 +50,7 @@ defmodule Tuist.Kura do
   Returns the latest released Kura runtime version.
 
   Managed deploys use the latest `kura@...` GitHub release as the
-  customer-facing version, while rollout manifests use the corresponding
+  source release, while rollout manifests use the corresponding
   Docker tag without the `kura@` prefix.
   """
   def latest_versions(limit \\ 20)
@@ -68,15 +68,9 @@ defmodule Tuist.Kura do
 
   def version_label(nil), do: nil
 
-  def version_label("sha-" <> _ = image_tag), do: image_tag
+  def version_label("kura@" <> image_tag), do: image_tag
 
-  def version_label(image_tag) when is_binary(image_tag) do
-    if Regex.match?(~r/\A\d+\.\d+\.\d+(?:[-.][A-Za-z0-9][A-Za-z0-9_.-]*)?\z/, image_tag) do
-      "kura@#{image_tag}"
-    else
-      image_tag
-    end
-  end
+  def version_label(image_tag) when is_binary(image_tag), do: image_tag
 
   @doc """
   Creates deployments for active Kura servers that are behind the

--- a/server/lib/tuist/kura.ex
+++ b/server/lib/tuist/kura.ex
@@ -22,6 +22,7 @@ defmodule Tuist.Kura do
   alias Phoenix.PubSub
   alias Tuist.Accounts
   alias Tuist.Accounts.AccountCacheEndpoint
+  alias Tuist.GitHub.Releases
   alias Tuist.Kura.Deployment
   alias Tuist.Kura.Provisioner
   alias Tuist.Kura.Reconciler
@@ -36,6 +37,7 @@ defmodule Tuist.Kura do
     "image_tag" => :image_tag
   }
   @create_server_atom_keys Map.values(@create_server_keys)
+  @public_endpoint_timeout 5_000
   @provisioner_node_ref_format ~r/^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/
   @provisioner_node_ref_max_length 53
 
@@ -45,33 +47,45 @@ defmodule Tuist.Kura do
   ## Versions
 
   @doc """
-  Returns the Kura runtime image tag configured for the current Tuist
-  server deploy.
+  Returns the latest released Kura runtime version.
 
-  Managed deploys build the Kura runtime image with the same `sha-*` tag
-  as the server and controller images, then pass that tag through Helm as
-  `TUIST_KURA_RUNTIME_IMAGE_TAG`. Returning it through the older
-  `latest_versions/1` shape keeps the account settings UI and ops code
-  simple while making the deploy SHA, not GitHub Releases, the source of
-  truth.
+  Managed deploys use the latest `kura@...` GitHub release as the
+  customer-facing version, while rollout manifests use the corresponding
+  Docker tag without the `kura@` prefix.
   """
-  def latest_versions(limit \\ 20) when is_integer(limit) do
-    runtime_image_tag()
+  def latest_versions(limit \\ 20)
+
+  def latest_versions(limit) when is_integer(limit) and limit <= 0, do: []
+
+  def latest_versions(limit) when is_integer(limit) do
+    runtime_version()
     |> case do
       nil -> []
-      tag -> [%{version: tag, released_at: nil}]
+      version -> [version]
     end
     |> Enum.take(limit)
   end
 
+  def version_label(nil), do: nil
+
+  def version_label("sha-" <> _ = image_tag), do: image_tag
+
+  def version_label(image_tag) when is_binary(image_tag) do
+    if Regex.match?(~r/\A\d+\.\d+\.\d+(?:[-.][A-Za-z0-9][A-Za-z0-9_.-]*)?\z/, image_tag) do
+      "kura@#{image_tag}"
+    else
+      image_tag
+    end
+  end
+
   @doc """
   Creates deployments for active Kura servers that are behind the
-  Kura runtime image tag configured on the current Tuist server deploy.
+  latest released Kura runtime image tag.
 
   Each `(server, image_tag)` pair is scheduled at most once. A failed
   deployment for the configured image is intentionally not retried here;
   operators can inspect and re-trigger it manually, while the next Tuist
-  deploy SHA will be scheduled normally.
+  released Kura version will be scheduled normally.
   """
   def schedule_runtime_image_deployments do
     case runtime_image_tag() do
@@ -81,10 +95,43 @@ defmodule Tuist.Kura do
   end
 
   defp runtime_image_tag do
+    case runtime_version() do
+      nil -> nil
+      %{image_tag: image_tag} -> image_tag
+    end
+  end
+
+  defp runtime_version do
+    if Tuist.Environment.dev?() or Tuist.Environment.test?() do
+      local_runtime_version()
+    else
+      released_runtime_version()
+    end
+  end
+
+  defp released_runtime_version do
+    case Releases.get_latest_kura_release() do
+      %{tag_name: tag_name, published_at: released_at} when is_binary(tag_name) ->
+        case tag_name do
+          "kura@" <> image_tag -> %{version: tag_name, image_tag: image_tag, released_at: released_at}
+          _ -> nil
+        end
+
+      _ ->
+        nil
+    end
+  end
+
+  defp local_runtime_version do
     case Tuist.Environment.kura_runtime_image_tag() do
       tag when is_binary(tag) ->
         tag = String.trim(tag)
-        if tag == "", do: nil, else: tag
+
+        if tag == "" do
+          nil
+        else
+          %{version: version_label(tag), image_tag: tag, released_at: nil}
+        end
 
       _ ->
         nil
@@ -270,15 +317,15 @@ defmodule Tuist.Kura do
 
   @doc """
   Marks a server as `:active`, mirrors its URL into
-  `account_cache_endpoints`, and broadcasts. Public DNS is checked
-  first so the CLI doesn't see the URL before external-dns has
-  propagated; the reconciler retries on the next tick if DNS isn't
-  resolvable yet.
+  `account_cache_endpoints`, and broadcasts. The public endpoint is
+  checked first so the CLI doesn't see the URL before external-dns has
+  propagated and TLS is serving a valid certificate; the reconciler
+  retries on the next tick while the endpoint is not ready.
   """
   def activate_server(%Server{} = server, image_tag) when is_binary(image_tag) do
     with {:ok, account} <- Accounts.get_account_by_id(server.account_id),
          url when is_binary(url) <- Provisioner.public_url(account, server),
-         :ok <- ensure_public_host_resolves(url),
+         :ok <- ensure_public_endpoint_ready(url),
          {:ok, server} <- activate_server_transaction(server, account, url, image_tag) do
       broadcast_server(server, :updated)
       {:ok, server}
@@ -288,18 +335,50 @@ defmodule Tuist.Kura do
     end
   end
 
-  defp ensure_public_host_resolves(url) when is_binary(url) do
+  defp ensure_public_endpoint_ready(url) when is_binary(url) do
     case URI.parse(url) do
-      %URI{host: host} when is_binary(host) and host != "" ->
-        case :inet.gethostbyname(String.to_charlist(host)) do
-          {:ok, _} -> :ok
-          {:error, reason} -> {:error, {:public_host_not_resolvable, host, reason}}
+      %URI{scheme: scheme, host: host} = uri when scheme in ["http", "https"] and is_binary(host) and host != "" ->
+        with :ok <- ensure_public_host_resolves(host) do
+          ensure_public_https_up(uri)
         end
 
       _ ->
         {:error, :public_url_invalid}
     end
   end
+
+  defp ensure_public_host_resolves(host) do
+    case :inet.gethostbyname(String.to_charlist(host)) do
+      {:ok, _} -> :ok
+      {:error, reason} -> {:error, {:public_host_not_resolvable, host, reason}}
+    end
+  end
+
+  defp ensure_public_https_up(%URI{scheme: "https", host: host} = uri) do
+    url =
+      uri
+      |> Map.put(:path, "/up")
+      |> Map.put(:query, nil)
+      |> Map.put(:fragment, nil)
+      |> URI.to_string()
+
+    case Req.get(url,
+           finch: Tuist.Finch,
+           receive_timeout: @public_endpoint_timeout,
+           connect_options: [timeout: @public_endpoint_timeout]
+         ) do
+      {:ok, %Req.Response{status: status}} when status in 200..299 ->
+        :ok
+
+      {:ok, %Req.Response{status: status}} ->
+        {:error, {:public_endpoint_not_ready, host, {:http_status, status}}}
+
+      {:error, reason} ->
+        {:error, {:public_endpoint_not_ready, host, reason}}
+    end
+  end
+
+  defp ensure_public_https_up(_uri), do: :ok
 
   defp activate_server_transaction(server, account, url, image_tag) do
     Repo.transaction(fn ->

--- a/server/lib/tuist/kura/reconciler.ex
+++ b/server/lib/tuist/kura/reconciler.ex
@@ -3,7 +3,7 @@ defmodule Tuist.Kura.Reconciler do
   Primary reconciliation loop for Kura servers.
 
   Desired state lives in Postgres (`kura_servers` and `kura_deployments`)
-  plus the deploy-provided Kura runtime image tag. Actual state lives in
+  plus the latest released Kura runtime image tag. Actual state lives in
   `KuraInstance.status`, owned by the Go controller. This loop closes
   the gap periodically: it schedules image drift, applies pending
   deployments, mirrors observed readiness back into Postgres, and
@@ -138,6 +138,11 @@ defmodule Tuist.Kura.Reconciler do
         # `:running` so the next reconciler tick retries instead of
         # marking the server failed for what's a benign delay.
         Logger.info("[Kura.Reconciler] waiting on DNS for server #{server.id} (#{host}): #{inspect(reason)}")
+
+        :ok
+
+      {:error, {:public_endpoint_not_ready, host, reason}} ->
+        Logger.info("[Kura.Reconciler] waiting on public endpoint for server #{server.id} (#{host}): #{inspect(reason)}")
 
         :ok
 

--- a/server/lib/tuist/kura/regions.ex
+++ b/server/lib/tuist/kura/regions.ex
@@ -10,7 +10,7 @@ defmodule Tuist.Kura.Regions do
       `"us-west"`, `"local-controller"`).
       Stored on `kura_servers.region`. Never renamed once published
       because URLs and `account_cache_endpoints` reference it.
-    * `display_name` — what the /ops UI renders.
+    * `display_name` — the customer-facing region label.
     * `provisioner` — the `Tuist.Kura.Provisioner` implementation that
       actually provisions, rolls, and destroys Kura servers here. The
       customer never sees this.
@@ -80,7 +80,7 @@ defmodule Tuist.Kura.Regions do
   defp us_east_region do
     %__MODULE__{
       id: "us-east",
-      display_name: "US East (Hetzner Ashburn)",
+      display_name: "US East",
       provisioner: KubernetesController,
       provisioner_config: %{
         cluster_id: "us-east-1",
@@ -96,7 +96,7 @@ defmodule Tuist.Kura.Regions do
   defp us_west_region do
     %__MODULE__{
       id: "us-west",
-      display_name: "US West (Hetzner Hillsboro)",
+      display_name: "US West",
       provisioner: KubernetesController,
       provisioner_config: %{
         cluster_id: "us-west-1",
@@ -112,7 +112,7 @@ defmodule Tuist.Kura.Regions do
   defp eu_central_region do
     %__MODULE__{
       id: "eu-central",
-      display_name: "EU Central (Hetzner Falkenstein)",
+      display_name: "EU Central",
       provisioner: KubernetesController,
       provisioner_config: %{
         cluster_id: "eu-central-1",

--- a/server/lib/tuist_web/live/account_settings_live.ex
+++ b/server/lib/tuist_web/live/account_settings_live.ex
@@ -256,11 +256,11 @@ defmodule TuistWeb.AccountSettingsLive do
          )
          |> push_event("close-modal", %{id: "add-kura-server-modal"})}
 
-      {region, %{version: image_tag}} ->
+      {region, version} ->
         attrs = %{
           account_id: socket.assigns.selected_account.id,
           region: region,
-          image_tag: image_tag
+          image_tag: kura_version_image_tag(version)
         }
 
         create_kura_server(socket, attrs)
@@ -351,6 +351,10 @@ defmodule TuistWeb.AccountSettingsLive do
 
   defp single_available_kura_region_id([region]), do: region.id
   defp single_available_kura_region_id(_regions), do: nil
+
+  defp kura_version_image_tag(%{image_tag: image_tag}), do: image_tag
+  defp kura_version_image_tag(%{version: "kura@" <> image_tag}), do: image_tag
+  defp kura_version_image_tag(%{version: image_tag}), do: image_tag
 
   defp present?(value), do: is_binary(value) and value != ""
 
@@ -547,7 +551,9 @@ defmodule TuistWeb.AccountSettingsLive do
             <.text_cell label={server.url || dgettext("dashboard_account", "Pending")} />
           </:col>
           <:col :let={server} label={dgettext("dashboard_account", "Version")}>
-            <.text_cell label={server.current_image_tag || dgettext("dashboard_account", "Pending")} />
+            <.text_cell label={
+              kura_version_label(server.current_image_tag) || dgettext("dashboard_account", "Pending")
+            } />
           </:col>
           <:col :let={server} label="">
             <.button
@@ -597,12 +603,7 @@ defmodule TuistWeb.AccountSettingsLive do
   def kura_server_status_color(:destroying), do: "warning"
   def kura_server_status_color(:destroyed), do: "neutral"
 
-  defp show_deploying?(%{status: status}) when status in [:destroying, :destroyed], do: false
-
-  defp show_deploying?(%{deployments: deployments}) when is_list(deployments) do
-    Enum.any?(deployments, &(&1.status in [:pending, :running]))
-  end
-
+  defp show_deploying?(%{status: :provisioning}), do: true
   defp show_deploying?(_), do: false
 
   defp kura_region_label(region_id) do
@@ -611,6 +612,8 @@ defmodule TuistWeb.AccountSettingsLive do
       region -> region.display_name
     end
   end
+
+  defp kura_version_label(image_tag), do: Kura.version_label(image_tag)
 
   attr(:preferred_locale_form, :any, required: true)
 

--- a/server/lib/tuist_web/live/ops_account_kura_deployment_live.html.heex
+++ b/server/lib/tuist_web/live/ops_account_kura_deployment_live.html.heex
@@ -1,7 +1,9 @@
 <div id="ops-kura-deployment">
   <div data-part="header">
     <h1 data-part="title">
-      {dgettext("dashboard", "Kura deployment")} · {@deployment.cluster_id} · {Tuist.Kura.version_label(@deployment.image_tag)}
+      {dgettext("dashboard", "Kura deployment")} · {@deployment.cluster_id} · {Tuist.Kura.version_label(
+        @deployment.image_tag
+      )}
     </h1>
     <p data-part="subtitle">
       <.link navigate={~p"/ops/accounts/#{@account.id}"}>← {@account.name}</.link>

--- a/server/lib/tuist_web/live/ops_account_kura_deployment_live.html.heex
+++ b/server/lib/tuist_web/live/ops_account_kura_deployment_live.html.heex
@@ -1,7 +1,7 @@
 <div id="ops-kura-deployment">
   <div data-part="header">
     <h1 data-part="title">
-      {dgettext("dashboard", "Kura deployment")} · {@deployment.cluster_id} · {@deployment.image_tag}
+      {dgettext("dashboard", "Kura deployment")} · {@deployment.cluster_id} · {Tuist.Kura.version_label(@deployment.image_tag)}
     </h1>
     <p data-part="subtitle">
       <.link navigate={~p"/ops/accounts/#{@account.id}"}>← {@account.name}</.link>

--- a/server/lib/tuist_web/live/ops_account_live.html.heex
+++ b/server/lib/tuist_web/live/ops_account_live.html.heex
@@ -23,7 +23,9 @@
           <.text_cell label={server.url || dgettext("dashboard", "None")} />
         </:col>
         <:col :let={server} label={dgettext("dashboard", "Current version")}>
-          <.text_cell label={Tuist.Kura.version_label(server.current_image_tag) || dgettext("dashboard", "None")} />
+          <.text_cell label={
+            Tuist.Kura.version_label(server.current_image_tag) || dgettext("dashboard", "None")
+          } />
         </:col>
         <:col :let={server} label={dgettext("dashboard", "Latest deployment")}>
           <%= case List.first(server.deployments) do %>

--- a/server/lib/tuist_web/live/ops_account_live.html.heex
+++ b/server/lib/tuist_web/live/ops_account_live.html.heex
@@ -23,7 +23,7 @@
           <.text_cell label={server.url || dgettext("dashboard", "None")} />
         </:col>
         <:col :let={server} label={dgettext("dashboard", "Current version")}>
-          <.text_cell label={server.current_image_tag || dgettext("dashboard", "None")} />
+          <.text_cell label={Tuist.Kura.version_label(server.current_image_tag) || dgettext("dashboard", "None")} />
         </:col>
         <:col :let={server} label={dgettext("dashboard", "Latest deployment")}>
           <%= case List.first(server.deployments) do %>
@@ -31,7 +31,7 @@
               <.text_cell label={dgettext("dashboard", "None")} />
             <% deployment -> %>
               <.link navigate={~p"/ops/accounts/#{@account.id}/kura/deployments/#{deployment.id}"}>
-                {deployment.image_tag}
+                {Tuist.Kura.version_label(deployment.image_tag)}
               </.link>
           <% end %>
         </:col>

--- a/server/test/tuist/github/releases_test.exs
+++ b/server/test/tuist/github/releases_test.exs
@@ -403,6 +403,35 @@ defmodule Tuist.GitHub.ReleasesTest do
   end
 
   describe "get_latest_kura_release/0" do
+    test "caches GitHub release page responses" do
+      published_at = DateTime.utc_now()
+      releases_url = Releases.releases_url()
+
+      kura_release = %{
+        "published_at" => Timex.format!(published_at, "{ISO:Extended}"),
+        "name" => "Kura 0.5.2",
+        "tag_name" => "kura@0.5.2",
+        "html_url" => "https://github.com/tuist/tuist/releases/tag/kura@0.5.2",
+        "assets" => []
+      }
+
+      expect(Tuist.KeyValueStore, :get_or_update, fn [Releases, "github_latest_kura_release"], opts, func ->
+        assert opts[:ttl] == 1234
+        func.()
+      end)
+
+      expect(Tuist.KeyValueStore, :get_or_update, fn [Releases, "github_releases_page", ^releases_url], opts, func ->
+        assert opts[:ttl] == 1234
+        func.()
+      end)
+
+      expect(Req, :get, fn ^releases_url, _opts ->
+        {:ok, %Req.Response{status: 200, body: [kura_release], headers: []}}
+      end)
+
+      assert %{tag_name: "kura@0.5.2"} = Releases.get_latest_kura_release(ttl: 1234)
+    end
+
     test "returns the latest Kura release" do
       published_at = DateTime.utc_now()
       releases_url = Releases.releases_url()

--- a/server/test/tuist/github/releases_test.exs
+++ b/server/test/tuist/github/releases_test.exs
@@ -401,4 +401,98 @@ defmodule Tuist.GitHub.ReleasesTest do
       assert release.html_url == "https://github.com/app-release"
     end
   end
+
+  describe "get_latest_kura_release/0" do
+    test "returns the latest Kura release" do
+      published_at = DateTime.utc_now()
+      releases_url = Releases.releases_url()
+
+      kura_release = %{
+        "published_at" => Timex.format!(published_at, "{ISO:Extended}"),
+        "name" => "Kura 0.5.2",
+        "tag_name" => "kura@0.5.2",
+        "html_url" => "https://github.com/tuist/tuist/releases/tag/kura@0.5.2",
+        "assets" => []
+      }
+
+      stub(
+        Req,
+        :get,
+        fn ^releases_url, _opts ->
+          {:ok,
+           %Req.Response{
+             status: 200,
+             body: [
+               %{
+                 "published_at" => Timex.format!(published_at, "{ISO:Extended}"),
+                 "name" => "App 0.25.0",
+                 "tag_name" => "app@0.25.0",
+                 "html_url" => "https://github.com/release",
+                 "assets" => []
+               },
+               kura_release
+             ],
+             headers: []
+           }}
+        end
+      )
+
+      release = Releases.get_latest_kura_release()
+
+      assert release.name == "Kura 0.5.2"
+      assert release.tag_name == "kura@0.5.2"
+      assert release.html_url == "https://github.com/tuist/tuist/releases/tag/kura@0.5.2"
+    end
+
+    test "returns Kura release when it is only available in the second page" do
+      published_at = DateTime.utc_now()
+      releases_url = Releases.releases_url()
+
+      stub(
+        Req,
+        :get,
+        fn url, _opts ->
+          cond do
+            url == releases_url ->
+              {:ok,
+               %Req.Response{
+                 status: 200,
+                 body: [
+                   %{
+                     "published_at" => Timex.format!(published_at, "{ISO:Extended}"),
+                     "name" => "App 0.25.0",
+                     "tag_name" => "app@0.25.0",
+                     "html_url" => "https://github.com/release",
+                     "assets" => []
+                   }
+                 ],
+                 headers: %{
+                   "link" => [
+                     "<https://api.github.com/repos/tuist/tuist/releases?page=2>; rel=\"next\""
+                   ]
+                 }
+               }}
+
+            url == "https://api.github.com/repos/tuist/tuist/releases?page=2" ->
+              {:ok,
+               %Req.Response{
+                 status: 200,
+                 body: [
+                   %{
+                     "published_at" => Timex.format!(published_at, "{ISO:Extended}"),
+                     "name" => "Kura 0.5.2",
+                     "tag_name" => "kura@0.5.2",
+                     "html_url" => "https://github.com/tuist/tuist/releases/tag/kura@0.5.2",
+                     "assets" => []
+                   }
+                 ],
+                 headers: []
+               }}
+          end
+        end
+      )
+
+      assert %{tag_name: "kura@0.5.2"} = Releases.get_latest_kura_release()
+    end
+  end
 end

--- a/server/test/tuist/github/releases_test.exs
+++ b/server/test/tuist/github/releases_test.exs
@@ -400,78 +400,6 @@ defmodule Tuist.GitHub.ReleasesTest do
       assert release.name == "app@1.0.0"
       assert release.html_url == "https://github.com/app-release"
     end
-  end
-
-  describe "get_latest_kura_release/0" do
-    test "caches GitHub release page responses" do
-      published_at = DateTime.utc_now()
-      releases_url = Releases.releases_url()
-
-      kura_release = %{
-        "published_at" => Timex.format!(published_at, "{ISO:Extended}"),
-        "name" => "Kura 0.5.2",
-        "tag_name" => "kura@0.5.2",
-        "html_url" => "https://github.com/tuist/tuist/releases/tag/kura@0.5.2",
-        "assets" => []
-      }
-
-      expect(Tuist.KeyValueStore, :get_or_update, fn [Releases, "github_latest_kura_release"], opts, func ->
-        assert opts[:ttl] == 1234
-        func.()
-      end)
-
-      expect(Tuist.KeyValueStore, :get_or_update, fn [Releases, "github_releases_page", ^releases_url], opts, func ->
-        assert opts[:ttl] == 1234
-        func.()
-      end)
-
-      expect(Req, :get, fn ^releases_url, _opts ->
-        {:ok, %Req.Response{status: 200, body: [kura_release], headers: []}}
-      end)
-
-      assert %{tag_name: "kura@0.5.2"} = Releases.get_latest_kura_release(ttl: 1234)
-    end
-
-    test "returns the latest Kura release" do
-      published_at = DateTime.utc_now()
-      releases_url = Releases.releases_url()
-
-      kura_release = %{
-        "published_at" => Timex.format!(published_at, "{ISO:Extended}"),
-        "name" => "Kura 0.5.2",
-        "tag_name" => "kura@0.5.2",
-        "html_url" => "https://github.com/tuist/tuist/releases/tag/kura@0.5.2",
-        "assets" => []
-      }
-
-      stub(
-        Req,
-        :get,
-        fn ^releases_url, _opts ->
-          {:ok,
-           %Req.Response{
-             status: 200,
-             body: [
-               %{
-                 "published_at" => Timex.format!(published_at, "{ISO:Extended}"),
-                 "name" => "App 0.25.0",
-                 "tag_name" => "app@0.25.0",
-                 "html_url" => "https://github.com/release",
-                 "assets" => []
-               },
-               kura_release
-             ],
-             headers: []
-           }}
-        end
-      )
-
-      release = Releases.get_latest_kura_release()
-
-      assert release.name == "Kura 0.5.2"
-      assert release.tag_name == "kura@0.5.2"
-      assert release.html_url == "https://github.com/tuist/tuist/releases/tag/kura@0.5.2"
-    end
 
     test "returns nil when GitHub returns a non-200 response" do
       releases_url = Releases.releases_url()
@@ -480,58 +408,7 @@ defmodule Tuist.GitHub.ReleasesTest do
         {:ok, %Req.Response{status: 429, body: %{}, headers: []}}
       end)
 
-      assert Releases.get_latest_kura_release() == nil
-    end
-
-    test "returns Kura release when it is only available in the second page" do
-      published_at = DateTime.utc_now()
-      releases_url = Releases.releases_url()
-
-      stub(
-        Req,
-        :get,
-        fn url, _opts ->
-          cond do
-            url == releases_url ->
-              {:ok,
-               %Req.Response{
-                 status: 200,
-                 body: [
-                   %{
-                     "published_at" => Timex.format!(published_at, "{ISO:Extended}"),
-                     "name" => "App 0.25.0",
-                     "tag_name" => "app@0.25.0",
-                     "html_url" => "https://github.com/release",
-                     "assets" => []
-                   }
-                 ],
-                 headers: %{
-                   "link" => [
-                     "<https://api.github.com/repos/tuist/tuist/releases?page=2>; rel=\"next\""
-                   ]
-                 }
-               }}
-
-            url == "https://api.github.com/repos/tuist/tuist/releases?page=2" ->
-              {:ok,
-               %Req.Response{
-                 status: 200,
-                 body: [
-                   %{
-                     "published_at" => Timex.format!(published_at, "{ISO:Extended}"),
-                     "name" => "Kura 0.5.2",
-                     "tag_name" => "kura@0.5.2",
-                     "html_url" => "https://github.com/tuist/tuist/releases/tag/kura@0.5.2",
-                     "assets" => []
-                   }
-                 ],
-                 headers: []
-               }}
-          end
-        end
-      )
-
-      assert %{tag_name: "kura@0.5.2"} = Releases.get_latest_kura_release()
+      assert Releases.get_latest_app_release() == nil
     end
   end
 end

--- a/server/test/tuist/github/releases_test.exs
+++ b/server/test/tuist/github/releases_test.exs
@@ -473,6 +473,16 @@ defmodule Tuist.GitHub.ReleasesTest do
       assert release.html_url == "https://github.com/tuist/tuist/releases/tag/kura@0.5.2"
     end
 
+    test "returns nil when GitHub returns a non-200 response" do
+      releases_url = Releases.releases_url()
+
+      stub(Req, :get, fn ^releases_url, _opts ->
+        {:ok, %Req.Response{status: 429, body: %{}, headers: []}}
+      end)
+
+      assert Releases.get_latest_kura_release() == nil
+    end
+
     test "returns Kura release when it is only available in the second page" do
       published_at = DateTime.utc_now()
       releases_url = Releases.releases_url()

--- a/server/test/tuist/kura/reconciler_test.exs
+++ b/server/test/tuist/kura/reconciler_test.exs
@@ -56,6 +56,34 @@ defmodule Tuist.Kura.ReconcilerTest do
              Repo.get!(Server, server.id)
   end
 
+  test "keeps a deployment running until the public HTTPS endpoint is ready" do
+    {account, server, deployment} = create_server()
+    {:ok, deployment} = Kura.mark_running(deployment)
+
+    expect(Provisioner, :current_image_tag, fn %Server{id: id} ->
+      assert id == server.id
+      {:ok, deployment.image_tag}
+    end)
+
+    expect(Provisioner, :public_url, fn account_arg, %Server{id: id} ->
+      assert account_arg.id == account.id
+      assert id == server.id
+      "https://localhost:4100"
+    end)
+
+    expect(Req, :get, fn "https://localhost:4100/up", opts ->
+      assert opts[:finch] == Tuist.Finch
+      assert opts[:receive_timeout] == 5_000
+      assert opts[:connect_options] == [timeout: 5_000]
+      {:error, %Mint.TransportError{reason: {:tls_alert, ~c"unknown ca"}}}
+    end)
+
+    assert :ok = Reconciler.reconcile()
+
+    assert %Deployment{status: :running} = Repo.get!(Deployment, deployment.id)
+    assert %Server{status: :provisioning, current_image_tag: nil, url: nil} = Repo.get!(Server, server.id)
+  end
+
   test "schedules and applies runtime image drift for active servers" do
     {_account, server, deployment} = create_server()
     {:ok, server} = Kura.activate_server(server, deployment.image_tag)

--- a/server/test/tuist/kura/regions_test.exs
+++ b/server/test/tuist/kura/regions_test.exs
@@ -18,6 +18,7 @@ defmodule Tuist.Kura.RegionsTest do
 
       for id <- ["us-east", "us-west", "eu-central"] do
         assert %Regions{provisioner: KubernetesController, provisioner_config: config} = Regions.get(id)
+        refute Regions.get(id).display_name =~ "Hetzner"
         assert config.cluster_id == "#{id}-1"
         assert config.hetzner_location == hetzner_locations[id]
         assert config.storage_class == "hcloud-volumes"

--- a/server/test/tuist/kura_test.exs
+++ b/server/test/tuist/kura_test.exs
@@ -5,7 +5,6 @@ defmodule Tuist.KuraTest do
 
   alias Tuist.Accounts
   alias Tuist.Accounts.AccountCacheEndpoint
-  alias Tuist.GitHub.Releases
   alias Tuist.Kura
   alias Tuist.Kura.Deployment
   alias Tuist.Kura.Provisioner
@@ -34,17 +33,12 @@ defmodule Tuist.KuraTest do
       assert Kura.latest_versions(10) == []
     end
 
-    test "returns the latest Kura Git tag outside dev and test" do
-      published_at = DateTime.utc_now(:second)
-
+    test "returns the deploy-configured runtime image tag outside dev and test" do
       stub(Tuist.Environment, :dev?, fn -> false end)
       stub(Tuist.Environment, :test?, fn -> false end)
+      stub(Tuist.Environment, :kura_runtime_image_tag, fn -> "0.5.2" end)
 
-      stub(Releases, :get_latest_kura_release, fn ->
-        %{tag_name: "kura@0.5.2", published_at: published_at}
-      end)
-
-      assert [%{version: "kura@0.5.2", image_tag: "0.5.2", released_at: ^published_at}] = Kura.latest_versions(10)
+      assert [%{version: "0.5.2", image_tag: "0.5.2", released_at: nil}] = Kura.latest_versions(10)
     end
   end
 
@@ -124,7 +118,7 @@ defmodule Tuist.KuraTest do
       assert {:ok, []} = Kura.schedule_runtime_image_deployments()
     end
 
-    test "schedules the latest Kura release Docker tag outside dev and test" do
+    test "schedules the deploy-configured runtime image tag outside dev and test" do
       user = AccountsFixtures.user_fixture()
       account = Accounts.get_account_from_user(user)
 
@@ -139,10 +133,7 @@ defmodule Tuist.KuraTest do
 
       stub(Tuist.Environment, :dev?, fn -> false end)
       stub(Tuist.Environment, :test?, fn -> false end)
-
-      stub(Releases, :get_latest_kura_release, fn ->
-        %{tag_name: "kura@0.5.2", published_at: DateTime.utc_now(:second)}
-      end)
+      stub(Tuist.Environment, :kura_runtime_image_tag, fn -> "0.5.2" end)
 
       assert {:ok, [%Deployment{image_tag: "0.5.2"} = deployment]} =
                Kura.schedule_runtime_image_deployments()

--- a/server/test/tuist/kura_test.exs
+++ b/server/test/tuist/kura_test.exs
@@ -48,6 +48,17 @@ defmodule Tuist.KuraTest do
     end
   end
 
+  describe "version_label/1" do
+    test "strips the Kura release tag prefix" do
+      assert Kura.version_label("kura@0.5.2") == "0.5.2"
+    end
+
+    test "leaves runtime image tags unchanged" do
+      assert Kura.version_label("0.5.2") == "0.5.2"
+      assert Kura.version_label("sha-abcdef123456") == "sha-abcdef123456"
+    end
+  end
+
   describe "schedule_runtime_image_deployments/0" do
     test "creates deployments for active servers behind the runtime image tag" do
       user = AccountsFixtures.user_fixture()

--- a/server/test/tuist/kura_test.exs
+++ b/server/test/tuist/kura_test.exs
@@ -5,8 +5,10 @@ defmodule Tuist.KuraTest do
 
   alias Tuist.Accounts
   alias Tuist.Accounts.AccountCacheEndpoint
+  alias Tuist.GitHub.Releases
   alias Tuist.Kura
   alias Tuist.Kura.Deployment
+  alias Tuist.Kura.Provisioner
   alias Tuist.Kura.Server
   alias Tuist.Repo
   alias TuistTestSupport.Fixtures.AccountsFixtures
@@ -30,6 +32,19 @@ defmodule Tuist.KuraTest do
       stub(Tuist.Environment, :kura_runtime_image_tag, fn -> nil end)
 
       assert Kura.latest_versions(10) == []
+    end
+
+    test "returns the latest Kura Git tag outside dev and test" do
+      published_at = DateTime.utc_now(:second)
+
+      stub(Tuist.Environment, :dev?, fn -> false end)
+      stub(Tuist.Environment, :test?, fn -> false end)
+
+      stub(Releases, :get_latest_kura_release, fn ->
+        %{tag_name: "kura@0.5.2", published_at: published_at}
+      end)
+
+      assert [%{version: "kura@0.5.2", image_tag: "0.5.2", released_at: ^published_at}] = Kura.latest_versions(10)
     end
   end
 
@@ -96,6 +111,32 @@ defmodule Tuist.KuraTest do
       stub(Tuist.Environment, :kura_runtime_image_tag, fn -> nil end)
 
       assert {:ok, []} = Kura.schedule_runtime_image_deployments()
+    end
+
+    test "schedules the latest Kura release Docker tag outside dev and test" do
+      user = AccountsFixtures.user_fixture()
+      account = Accounts.get_account_from_user(user)
+
+      {:ok, server} =
+        Kura.create_server(%{
+          account_id: account.id,
+          region: "local-controller",
+          image_tag: "0.5.1"
+        })
+
+      {:ok, server} = Kura.activate_server(server, "0.5.1")
+
+      stub(Tuist.Environment, :dev?, fn -> false end)
+      stub(Tuist.Environment, :test?, fn -> false end)
+
+      stub(Releases, :get_latest_kura_release, fn ->
+        %{tag_name: "kura@0.5.2", published_at: DateTime.utc_now(:second)}
+      end)
+
+      assert {:ok, [%Deployment{image_tag: "0.5.2"} = deployment]} =
+               Kura.schedule_runtime_image_deployments()
+
+      assert deployment.kura_server_id == server.id
     end
   end
 
@@ -275,6 +316,37 @@ defmodule Tuist.KuraTest do
   end
 
   describe "activate_server/2" do
+    test "does not activate a server until the public HTTPS endpoint is ready" do
+      user = AccountsFixtures.user_fixture()
+      account = Accounts.get_account_from_user(user)
+
+      {:ok, server} =
+        Kura.create_server(%{
+          account_id: account.id,
+          region: "local-controller",
+          image_tag: "0.5.2"
+        })
+
+      expect(Provisioner, :public_url, fn account_arg, %Server{id: id} ->
+        assert account_arg.id == account.id
+        assert id == server.id
+        "https://localhost:4100"
+      end)
+
+      expect(Req, :get, fn "https://localhost:4100/up", opts ->
+        assert opts[:finch] == Tuist.Finch
+        assert opts[:receive_timeout] == 5_000
+        assert opts[:connect_options] == [timeout: 5_000]
+        {:error, %Mint.TransportError{reason: {:tls_alert, ~c"unknown ca"}}}
+      end)
+
+      assert {:error, {:public_endpoint_not_ready, "localhost", %Mint.TransportError{}}} =
+               Kura.activate_server(server, "0.5.2")
+
+      assert %Server{status: :provisioning, current_image_tag: nil, url: nil} = Repo.get!(Server, server.id)
+      assert Accounts.list_account_cache_endpoints(account, :kura) == []
+    end
+
     test "reactivates a failed server when its cache endpoint already exists" do
       user = AccountsFixtures.user_fixture()
       account = Accounts.get_account_from_user(user)

--- a/server/test/tuist_web/live/account_settings_live_test.exs
+++ b/server/test/tuist_web/live/account_settings_live_test.exs
@@ -121,7 +121,8 @@ defmodule TuistWeb.AccountSettingsLiveTest do
 
     assert html =~ "Active"
     assert html =~ server.url
-    assert html =~ "kura@0.5.2"
+    assert html =~ "0.5.2"
+    refute html =~ "kura@0.5.2"
   end
 
   test "allows adding another managed Kura region when one is already deployed", %{conn: conn, account: account} do

--- a/server/test/tuist_web/live/account_settings_live_test.exs
+++ b/server/test/tuist_web/live/account_settings_live_test.exs
@@ -6,6 +6,7 @@ defmodule TuistWeb.AccountSettingsLiveTest do
   import Phoenix.LiveViewTest
 
   alias Tuist.Accounts
+  alias Tuist.Environment
   alias Tuist.Kura
   alias TuistTestSupport.Fixtures.AccountsFixtures
 
@@ -120,10 +121,33 @@ defmodule TuistWeb.AccountSettingsLiveTest do
 
     assert html =~ "Active"
     assert html =~ server.url
-    assert html =~ "0.5.2"
+    assert html =~ "kura@0.5.2"
   end
 
-  test "shows Deploying when an active Kura server has an in-flight deployment", %{conn: conn, account: account} do
+  test "allows adding another managed Kura region when one is already deployed", %{conn: conn, account: account} do
+    FunWithFlags.enable(:kura, for_actor: account)
+    stub(Environment, :dev?, fn -> false end)
+    stub(Environment, :test?, fn -> false end)
+    stub(Environment, :kura_available_region_ids, fn -> ["eu-central", "us-east", "us-west"] end)
+    stub(Kura, :latest_versions, fn 1 -> [%{version: "kura@0.5.2", image_tag: "0.5.2", released_at: nil}] end)
+
+    {:ok, _server} =
+      Kura.create_server(%{
+        account_id: account.id,
+        region: "eu-central",
+        image_tag: "0.5.2"
+      })
+
+    {:ok, lv, html} = live(conn, ~p"/#{account.name}/settings")
+
+    assert html =~ "EU Central"
+    refute html =~ "Hetzner"
+    assert html =~ "US East"
+    assert html =~ "US West"
+    assert has_element?(lv, "button", "Deploy Kura server")
+  end
+
+  test "keeps an active Kura server active during an in-flight deployment", %{conn: conn, account: account} do
     FunWithFlags.enable(:kura, for_actor: account)
     stub(Kura, :latest_versions, fn 1 -> [%{version: "0.5.3", released_at: DateTime.utc_now(:second)}] end)
 
@@ -143,8 +167,8 @@ defmodule TuistWeb.AccountSettingsLiveTest do
 
     {:ok, _lv, html} = live(conn, ~p"/#{account.name}/settings")
 
-    assert html =~ "Deploying"
-    refute html =~ ">Active<"
+    assert html =~ "Active"
+    refute html =~ "Deploying"
   end
 
   test "deploys a Kura server from account settings", %{conn: conn, account: account} do

--- a/server/test/tuist_web/live/ops_account_kura_deployment_live_test.exs
+++ b/server/test/tuist_web/live/ops_account_kura_deployment_live_test.exs
@@ -33,7 +33,8 @@ defmodule TuistWeb.OpsAccountKuraDeploymentLiveTest do
     {:ok, _lv, html} = live(conn, ~p"/ops/accounts/#{user.account.id}/kura/deployments/#{deployment.id}")
 
     assert html =~ "Kura deployment"
-    assert html =~ "kura@0.5.2"
+    assert html =~ "0.5.2"
+    refute html =~ "kura@0.5.2"
     assert html =~ "Grafana"
     assert html =~ "tuist.grafana.net/explore"
   end

--- a/server/test/tuist_web/live/ops_account_kura_deployment_live_test.exs
+++ b/server/test/tuist_web/live/ops_account_kura_deployment_live_test.exs
@@ -33,7 +33,7 @@ defmodule TuistWeb.OpsAccountKuraDeploymentLiveTest do
     {:ok, _lv, html} = live(conn, ~p"/ops/accounts/#{user.account.id}/kura/deployments/#{deployment.id}")
 
     assert html =~ "Kura deployment"
-    assert html =~ "0.5.2"
+    assert html =~ "kura@0.5.2"
     assert html =~ "Grafana"
     assert html =~ "tuist.grafana.net/explore"
   end

--- a/server/test/tuist_web/live/ops_account_live_test.exs
+++ b/server/test/tuist_web/live/ops_account_live_test.exs
@@ -42,7 +42,8 @@ defmodule TuistWeb.OpsAccountLiveTest do
 
     {:ok, _lv, html} = live(conn, ~p"/ops/accounts/#{user.account.id}")
 
-    assert html =~ "kura@0.5.2"
+    assert html =~ "0.5.2"
+    refute html =~ "kura@0.5.2"
     assert html =~ ~p"/ops/accounts/#{user.account.id}/kura/deployments/#{deployment.id}"
   end
 

--- a/server/test/tuist_web/live/ops_account_live_test.exs
+++ b/server/test/tuist_web/live/ops_account_live_test.exs
@@ -42,7 +42,7 @@ defmodule TuistWeb.OpsAccountLiveTest do
 
     {:ok, _lv, html} = live(conn, ~p"/ops/accounts/#{user.account.id}")
 
-    assert html =~ "0.5.2"
+    assert html =~ "kura@0.5.2"
     assert html =~ ~p"/ops/accounts/#{user.account.id}/kura/deployments/#{deployment.id}"
   end
 


### PR DESCRIPTION
## Summary

- Allow accounts to add additional Kura regions and keep region labels/provider details out of customer-facing rows.
- Use the latest `kura@...` GitHub release as the displayed version while rolling out the matching Docker tag internally.
- Cache GitHub release page responses so App and Kura release lookups share paginated API data within the release TTL.
- Gate Kura endpoint activation on DNS plus HTTPS `/up` readiness so TLS/DNS propagation does not expose unusable endpoints to the CLI.
- Keep active servers marked `Active` during background rollouts and update the Kura Grafana dashboard to query Kura node metrics instead of legacy cache endpoints.

## Root Cause

The account settings UI was mixing server lifecycle state with deployment state, so active servers with in-flight deployments appeared as `Deploying`. Endpoint activation only waited for DNS, which meant an endpoint could be mirrored into `account_cache_endpoints` before HTTPS/TLS was actually usable.

## Validation

- `mix test test/tuist/github/releases_test.exs`
- `mix test test/tuist/kura_test.exs test/tuist/kura/reconciler_test.exs test/tuist_web/live/account_settings_live_test.exs`
- `mix test test/tuist/kura/regions_test.exs test/tuist_web/live/ops_account_live_test.exs test/tuist_web/live/ops_account_kura_deployment_live_test.exs`
- `git diff --check`
- `jq empty infra/grafana-dashboards/tuist-kura.json`
