### PR TITLE
fix(cli): synthesize Bundle.module for static frameworks with .metal in buildable folders

### DIFF
--- a/cli/Sources/TuistGenerator/Mappers/BuildableFolderResourcePartitioner.swift
+++ b/cli/Sources/TuistGenerator/Mappers/BuildableFolderResourcePartitioner.swift
@@ -147,24 +147,31 @@ extension BuildableFolder {
 // MARK: - Per-file routing rules
 
 /// Where a single file inside a buildable folder should end up when the target needs a companion
-/// resource bundle. Centralising the per-extension rules here avoids the predicate-chain pattern
-/// the partitioner used to spell across half a dozen properties.
-private enum FilePartitionRouting {
-    /// Source-like file that lives on the original target only (Swift, Obj-C, headers, …).
+/// resource bundle. The mental model mirrors SwiftPM's: source files compile on the original
+/// target, resource files (including a handful of extensions that look "source-like" but route
+/// through xcbuild's resource pipeline) compile on the bundle, and `.xcstrings` straddles both.
+///
+/// See `TargetSourcesBuilder` (where SwiftPM declares `xcbuildFileTypes`) and
+/// `PackagePIFProjectBuilder.processResources` (where those extensions are emitted to the
+/// resource bundle target):
+/// - https://github.com/swiftlang/swift-package-manager/blob/main/Sources/PackageLoading/TargetSourcesBuilder.swift#L811-L865
+/// - https://github.com/swiftlang/swift-package-manager/blob/main/Sources/SwiftBuildSupport/PackagePIFProjectBuilder.swift#L274-L362
+fileprivate enum FilePartitionRouting {
+    /// File that compiles on the original target only — Swift, Obj-C, C, headers, …
     case originalTargetOnly
-    /// File that must appear on both the original target's Resources phase (so Xcode runs
-    /// extraction / stale-string detection where the source references live) and the bundle's
-    /// Resources phase (so `Bundle.module` can resolve at runtime). Today: `.xcstrings`.
+    /// File that must appear on *both* targets — the original so Xcode runs extraction /
+    /// symbol generation with the Swift code, the bundle so `Bundle.module` can resolve the
+    /// compiled artifact at runtime. Today: `.xcstrings`.
     case sharedBetweenTargets
-    /// Everything else — pure resources, plus source-like extensions that Xcode compiles into a
-    /// resource (today: `.metal` → `default.metallib`).
+    /// File whose compiled output Xcode packages into the bundle — pure resources plus the
+    /// SwiftPM-style "source-y resources" (`.metal` → `default.metallib`).
     case bundleTargetOnly
 
     init(extension fileExtension: String?) {
-        let ext = fileExtension ?? ""
-        if Self.sharedExtensions.contains(ext) {
+        let ext = (fileExtension ?? "").lowercased()
+        if Self.sharedWithOriginalTarget.contains(ext) {
             self = .sharedBetweenTargets
-        } else if Self.bundleProducingSourceExtensions.contains(ext) {
+        } else if Self.routedToBundle.contains(ext) {
             self = .bundleTargetOnly
         } else if AbsolutePath.isSourceLikeExtension(ext) {
             self = .originalTargetOnly
@@ -173,18 +180,30 @@ private enum FilePartitionRouting {
         }
     }
 
-    /// Files that must live in *both* targets so Xcode can extract symbols on one side and
-    /// compile resources on the other.
-    private static let sharedExtensions: Set<String> = ["xcstrings"]
+    /// `.xcstrings` belongs on both targets. `PACKAGE_RESOURCE_BUNDLE_NAME` (set on the main
+    /// target) makes swift-build skip the duplicate compile, so Xcode runs extraction on the
+    /// main target while only the bundle actually compiles the catalog.
+    /// https://github.com/swiftlang/swift-build/blob/main/Sources/SWBApplePlatform/XCStringsCompiler.swift
+    private static let sharedWithOriginalTarget: Set<String> = ["xcstrings"]
 
-    /// Source extensions whose output Xcode treats as a resource (compiled into a file the
-    /// companion bundle must contain).
-    private static let bundleProducingSourceExtensions: Set<String> = ["metal"]
+    /// Extensions SwiftPM declares as `xcbuildFileTypes` (resources processed by xcbuild) that
+    /// also happen to be in Tuist's `validSourceExtensions`. Routing them to the bundle matches
+    /// SwiftPM's PIF builder, which adds these as source files of the resource bundle target so
+    /// the compiled output (e.g. `default.metallib`) lands inside `Bundle.module`.
+    static let routedToBundle: Set<String> = ["metal"]
 }
 
 // MARK: - Path predicates
 
 extension AbsolutePath {
+    /// True for file extensions that SwiftPM routes through the resource bundle even though
+    /// Tuist's domain model classifies them as sources (`.metal` today). Used both by the
+    /// resource mapper's early-return guard and by the per-file routing in the partitioner.
+    var routesThroughResourceBundle: Bool {
+        guard let `extension` else { return false }
+        return FilePartitionRouting.routedToBundle.contains(`extension`.lowercased())
+    }
+
     fileprivate static func isSourceLikeExtension(_ fileExtension: String) -> Bool {
         let valid = Target.validSourceExtensions
             + Target.validSourceCompatibleFolderExtensions

--- a/cli/Sources/TuistGenerator/Mappers/BuildableFolderResourcePartitioner.swift
+++ b/cli/Sources/TuistGenerator/Mappers/BuildableFolderResourcePartitioner.swift
@@ -109,7 +109,7 @@ extension BuildableFolder {
         var shared: [BuildableFolderFile] = []
         var bundleOnly: [BuildableFolderFile] = []
         for file in resolvedFiles {
-            switch FilePartitionRouting(extension: file.path.extension) {
+            switch FilePartitionRouting(file.path) {
             case .originalTargetOnly:
                 originalOnly.append(file)
             case .sharedBetweenTargets:
@@ -146,80 +146,67 @@ extension BuildableFolder {
 
 // MARK: - Per-file routing rules
 
-/// Where a single file inside a buildable folder should end up when the target needs a companion
-/// resource bundle. The mental model mirrors SwiftPM's: source files compile on the original
-/// target, resource files (including a handful of extensions that look "source-like" but route
-/// through xcbuild's resource pipeline) compile on the bundle, and `.xcstrings` straddles both.
+/// Where a single file inside a buildable folder ends up when the target needs a companion
+/// resource bundle. Mirrors SwiftPM's classification (see references below): most files are
+/// either pure sources or pure resources; `.xcstrings` is the only extension Tuist routes to
+/// *both* targets today (it stays on the main target's Resources phase for stale-string
+/// detection and lives in the bundle's Resources phase for runtime resolution).
 ///
-/// See `TargetSourcesBuilder` (where SwiftPM declares `xcbuildFileTypes`) and
-/// `PackagePIFProjectBuilder.processResources` (where those extensions are emitted to the
-/// resource bundle target):
+/// SwiftPM additionally adds `.xcassets`, `.xcdatamodeld`, `.xcdatamodel`, `.mlmodel` and
+/// `.mlpackage` to *both* targets so the main target can run typed-symbol / codegen tasks. For
+/// `target.resources` Tuist matches that shape for `.xcassets` (via a separate code path in
+/// `synthesizeCompanionBundle`) and `.xcdatamodeld` (via `target.coreDataModels`). The same
+/// "shared with main target" treatment for buildable folders is a known gap; see #TODO.
+///
+/// References:
 /// - https://github.com/swiftlang/swift-package-manager/blob/main/Sources/PackageLoading/TargetSourcesBuilder.swift#L811-L865
 /// - https://github.com/swiftlang/swift-package-manager/blob/main/Sources/SwiftBuildSupport/PackagePIFProjectBuilder.swift#L274-L362
 fileprivate enum FilePartitionRouting {
     /// File that compiles on the original target only — Swift, Obj-C, C, headers, …
     case originalTargetOnly
-    /// File that must appear on *both* targets — the original so Xcode runs extraction /
-    /// symbol generation with the Swift code, the bundle so `Bundle.module` can resolve the
-    /// compiled artifact at runtime. Today: `.xcstrings`.
+    /// File that must appear on *both* targets. Today: `.xcstrings` (main target's Resources
+    /// for stale-string detection, bundle's Resources for runtime resolution).
     case sharedBetweenTargets
     /// File whose compiled output Xcode packages into the bundle — pure resources plus the
-    /// SwiftPM-style "source-y resources" (`.metal` → `default.metallib`).
+    /// SwiftPM-style "source-y resources" via `AbsolutePath.routesThroughResourceBundle`.
     case bundleTargetOnly
 
-    init(extension fileExtension: String?) {
-        let ext = (fileExtension ?? "").lowercased()
-        if Self.sharedWithOriginalTarget.contains(ext) {
+    init(_ path: AbsolutePath) {
+        if path.extension?.lowercased() == "xcstrings" {
             self = .sharedBetweenTargets
-        } else if Self.routedToBundle.contains(ext) {
+        } else if path.routesThroughResourceBundle {
             self = .bundleTargetOnly
-        } else if AbsolutePath.isSourceLikeExtension(ext) {
+        } else if path.isSourceLike {
             self = .originalTargetOnly
         } else {
             self = .bundleTargetOnly
         }
     }
-
-    /// `.xcstrings` belongs on both targets. `PACKAGE_RESOURCE_BUNDLE_NAME` (set on the main
-    /// target) makes swift-build skip the duplicate compile, so Xcode runs extraction on the
-    /// main target while only the bundle actually compiles the catalog.
-    /// https://github.com/swiftlang/swift-build/blob/main/Sources/SWBApplePlatform/XCStringsCompiler.swift
-    private static let sharedWithOriginalTarget: Set<String> = ["xcstrings"]
-
-    /// Extensions SwiftPM declares as `xcbuildFileTypes` (resources processed by xcbuild) that
-    /// also happen to be in Tuist's `validSourceExtensions`. Routing them to the bundle matches
-    /// SwiftPM's PIF builder, which adds these as source files of the resource bundle target so
-    /// the compiled output (e.g. `default.metallib`) lands inside `Bundle.module`.
-    static let routedToBundle: Set<String> = ["metal"]
 }
 
 // MARK: - Path predicates
 
 extension AbsolutePath {
-    /// True for file extensions that SwiftPM routes through the resource bundle even though
-    /// Tuist's domain model classifies them as sources (`.metal` today). Used both by the
-    /// resource mapper's early-return guard and by the per-file routing in the partitioner.
+    /// True for extensions Tuist's domain model treats as sources (`Target.validSourceExtensions`)
+    /// but SwiftPM treats as resources (`xcbuildFileTypes`). They must ride on the resource
+    /// bundle target so Xcode compiles them in the bundle's context — today only `.metal`,
+    /// whose `default.metallib` output has to live next to `Bundle.module`.
     var routesThroughResourceBundle: Bool {
-        guard let `extension` else { return false }
-        return FilePartitionRouting.routedToBundle.contains(`extension`.lowercased())
-    }
-
-    fileprivate static func isSourceLikeExtension(_ fileExtension: String) -> Bool {
-        let valid = Target.validSourceExtensions
-            + Target.validSourceCompatibleFolderExtensions
-            + Target.validHeaderExtensions
-        return valid.contains { $0.caseInsensitiveCompare(fileExtension) == .orderedSame }
+        `extension`?.lowercased() == "metal"
     }
 
     fileprivate var isSourceLike: Bool {
-        guard let `extension` else { return false }
-        return AbsolutePath.isSourceLikeExtension(`extension`)
+        guard let ext = `extension` else { return false }
+        let valid = Target.validSourceExtensions
+            + Target.validSourceCompatibleFolderExtensions
+            + Target.validHeaderExtensions
+        return valid.contains { $0.caseInsensitiveCompare(ext) == .orderedSame }
     }
 
     fileprivate var isResourceLike: Bool {
-        guard let `extension` else { return false }
+        guard let ext = `extension` else { return false }
         let valid = Target.validResourceExtensions + Target.validResourceCompatibleFolderExtensions
-        return valid.contains { $0.caseInsensitiveCompare(`extension`) == .orderedSame }
+        return valid.contains { $0.caseInsensitiveCompare(ext) == .orderedSame }
     }
 }
 

--- a/cli/Sources/TuistGenerator/Mappers/BuildableFolderResourcePartitioner.swift
+++ b/cli/Sources/TuistGenerator/Mappers/BuildableFolderResourcePartitioner.swift
@@ -161,7 +161,7 @@ extension BuildableFolder {
 /// References:
 /// - https://github.com/swiftlang/swift-package-manager/blob/main/Sources/PackageLoading/TargetSourcesBuilder.swift#L811-L865
 /// - https://github.com/swiftlang/swift-package-manager/blob/main/Sources/SwiftBuildSupport/PackagePIFProjectBuilder.swift#L274-L362
-fileprivate enum FilePartitionRouting {
+private enum FilePartitionRouting {
     /// File that compiles on the original target only — Swift, Obj-C, C, headers, …
     case originalTargetOnly
     /// File that must appear on *both* targets. Today: `.xcstrings` (main target's Resources

--- a/cli/Sources/TuistGenerator/Mappers/BuildableFolderResourcePartitioner.swift
+++ b/cli/Sources/TuistGenerator/Mappers/BuildableFolderResourcePartitioner.swift
@@ -1,0 +1,221 @@
+import Path
+import XcodeGraph
+
+/// Result of splitting a target's buildable folders between the main target and the companion
+/// resource bundle generated for static frameworks / targets that cannot host their own resources.
+///
+/// Xcode treats a buildable folder as a single synchronized group. To attach the same folder to
+/// both targets, we duplicate the folder reference and add complementary exclusion rules to each
+/// copy: the main-target copy excludes the resource files, and the bundle-target copy excludes
+/// the source files.
+struct BuildableFolderResourcePartition {
+    /// Folders (or per-folder views) that stay on the original target.
+    var originalTargetFolders: [BuildableFolder] = []
+
+    /// Folders (or per-folder views) that move to the companion resource bundle.
+    var bundleTargetFolders: [BuildableFolder] = []
+
+    /// Files that should also appear on the original target's Resources phase, outside the
+    /// synchronized group. Used for `.xcstrings` so Xcode runs localization extraction in the
+    /// target where the Swift sources live.
+    var originalTargetExplicitResources: [ResourceFileElement] = []
+}
+
+struct BuildableFolderResourcePartitioner {
+    func partition(_ folders: [BuildableFolder]) -> BuildableFolderResourcePartition {
+        folders.reduce(into: BuildableFolderResourcePartition()) { result, folder in
+            switch folder.partitioned() {
+            case .none:
+                result.originalTargetFolders.append(folder)
+            case let .some(partition):
+                if let original = partition.originalTargetFolder {
+                    result.originalTargetFolders.append(original)
+                }
+                if let bundle = partition.bundleTargetFolder {
+                    result.bundleTargetFolders.append(bundle)
+                }
+                result.originalTargetExplicitResources.append(contentsOf: partition.originalTargetExplicitResources)
+            }
+        }
+    }
+}
+
+// MARK: - Single-folder partition
+
+private struct SingleFolderPartition {
+    let originalTargetFolder: BuildableFolder?
+    let bundleTargetFolder: BuildableFolder?
+    let originalTargetExplicitResources: [ResourceFileElement]
+}
+
+extension BuildableFolder {
+    fileprivate func partitioned() -> SingleFolderPartition? {
+        if let folderLevel = folderLevelPartition() {
+            return folderLevel
+        }
+
+        let split = splitFilesByRouting()
+        let bundleEntries = split.bundleOnly + split.shared
+        let explicitResources = split.shared.map { ResourceFileElement.file(path: $0.path) }
+
+        if bundleEntries.isEmpty {
+            return ambivalentFolderPartition()
+        }
+
+        if split.originalOnly.isEmpty {
+            return SingleFolderPartition(
+                originalTargetFolder: nil,
+                bundleTargetFolder: self,
+                originalTargetExplicitResources: explicitResources
+            )
+        }
+
+        return duplicateWithExclusions(
+            originalEntries: split.originalOnly,
+            bundleEntries: bundleEntries,
+            originalTargetExplicitResources: explicitResources
+        )
+    }
+
+    /// When the folder name itself signals a pure-resource folder (e.g. `Foo.xcassets`), route
+    /// the whole folder to the bundle without inspecting its contents.
+    private func folderLevelPartition() -> SingleFolderPartition? {
+        guard path.isResourceLike, !path.isSourceLike, resolvedFiles.isEmpty else { return nil }
+        return SingleFolderPartition(
+            originalTargetFolder: nil,
+            bundleTargetFolder: self,
+            originalTargetExplicitResources: []
+        )
+    }
+
+    /// When the folder contains no bundle-bound files, keep it on the original target. The
+    /// duplicate-on-original branch only fires for folder names that look both source-like and
+    /// resource-like (rare), where we still want to materialise the folder explicitly.
+    private func ambivalentFolderPartition() -> SingleFolderPartition? {
+        guard path.isResourceLike, path.isSourceLike else { return nil }
+        return SingleFolderPartition(
+            originalTargetFolder: self,
+            bundleTargetFolder: nil,
+            originalTargetExplicitResources: []
+        )
+    }
+
+    private func splitFilesByRouting() -> (
+        originalOnly: [BuildableFolderFile],
+        shared: [BuildableFolderFile],
+        bundleOnly: [BuildableFolderFile]
+    ) {
+        var originalOnly: [BuildableFolderFile] = []
+        var shared: [BuildableFolderFile] = []
+        var bundleOnly: [BuildableFolderFile] = []
+        for file in resolvedFiles {
+            switch FilePartitionRouting(extension: file.path.extension) {
+            case .originalTargetOnly:
+                originalOnly.append(file)
+            case .sharedBetweenTargets:
+                shared.append(file)
+            case .bundleTargetOnly:
+                bundleOnly.append(file)
+            }
+        }
+        return (originalOnly, shared, bundleOnly)
+    }
+
+    private func duplicateWithExclusions(
+        originalEntries: [BuildableFolderFile],
+        bundleEntries: [BuildableFolderFile],
+        originalTargetExplicitResources: [ResourceFileElement]
+    ) -> SingleFolderPartition {
+        let original = BuildableFolder(
+            path: path,
+            exceptions: exceptions.addingExcluded(paths: bundleEntries.map(\.path)),
+            resolvedFiles: originalEntries
+        )
+        let bundle = BuildableFolder(
+            path: path,
+            exceptions: exceptions.addingExcluded(paths: originalEntries.map(\.path)),
+            resolvedFiles: bundleEntries
+        )
+        return SingleFolderPartition(
+            originalTargetFolder: original,
+            bundleTargetFolder: bundle,
+            originalTargetExplicitResources: originalTargetExplicitResources
+        )
+    }
+}
+
+// MARK: - Per-file routing rules
+
+/// Where a single file inside a buildable folder should end up when the target needs a companion
+/// resource bundle. Centralising the per-extension rules here avoids the predicate-chain pattern
+/// the partitioner used to spell across half a dozen properties.
+private enum FilePartitionRouting {
+    /// Source-like file that lives on the original target only (Swift, Obj-C, headers, …).
+    case originalTargetOnly
+    /// File that must appear on both the original target's Resources phase (so Xcode runs
+    /// extraction / stale-string detection where the source references live) and the bundle's
+    /// Resources phase (so `Bundle.module` can resolve at runtime). Today: `.xcstrings`.
+    case sharedBetweenTargets
+    /// Everything else — pure resources, plus source-like extensions that Xcode compiles into a
+    /// resource (today: `.metal` → `default.metallib`).
+    case bundleTargetOnly
+
+    init(extension fileExtension: String?) {
+        let ext = fileExtension ?? ""
+        if Self.sharedExtensions.contains(ext) {
+            self = .sharedBetweenTargets
+        } else if Self.bundleProducingSourceExtensions.contains(ext) {
+            self = .bundleTargetOnly
+        } else if AbsolutePath.isSourceLikeExtension(ext) {
+            self = .originalTargetOnly
+        } else {
+            self = .bundleTargetOnly
+        }
+    }
+
+    /// Files that must live in *both* targets so Xcode can extract symbols on one side and
+    /// compile resources on the other.
+    private static let sharedExtensions: Set<String> = ["xcstrings"]
+
+    /// Source extensions whose output Xcode treats as a resource (compiled into a file the
+    /// companion bundle must contain).
+    private static let bundleProducingSourceExtensions: Set<String> = ["metal"]
+}
+
+// MARK: - Path predicates
+
+extension AbsolutePath {
+    fileprivate static func isSourceLikeExtension(_ fileExtension: String) -> Bool {
+        let valid = Target.validSourceExtensions
+            + Target.validSourceCompatibleFolderExtensions
+            + Target.validHeaderExtensions
+        return valid.contains { $0.caseInsensitiveCompare(fileExtension) == .orderedSame }
+    }
+
+    fileprivate var isSourceLike: Bool {
+        guard let `extension` else { return false }
+        return AbsolutePath.isSourceLikeExtension(`extension`)
+    }
+
+    fileprivate var isResourceLike: Bool {
+        guard let `extension` else { return false }
+        let valid = Target.validResourceExtensions + Target.validResourceCompatibleFolderExtensions
+        return valid.contains { $0.caseInsensitiveCompare(`extension`) == .orderedSame }
+    }
+}
+
+extension BuildableFolderExceptions {
+    fileprivate func addingExcluded(paths: [AbsolutePath]) -> BuildableFolderExceptions {
+        guard !paths.isEmpty else { return self }
+        var updated = exceptions
+        updated.append(
+            BuildableFolderException(
+                excluded: paths,
+                compilerFlags: [:],
+                publicHeaders: [],
+                privateHeaders: []
+            )
+        )
+        return BuildableFolderExceptions(exceptions: updated)
+    }
+}

--- a/cli/Sources/TuistGenerator/Mappers/BundleAccessorTemplate.swift
+++ b/cli/Sources/TuistGenerator/Mappers/BundleAccessorTemplate.swift
@@ -1,0 +1,252 @@
+import Foundation
+import Path
+import TuistConstants
+import XcodeGraph
+
+/// A file Tuist writes into a target's Derived directory to expose `Bundle.module` (and the
+/// SwiftPM-compatible C entry point) to the target's own sources.
+struct SynthesizedBundleAccessorFile {
+    let path: AbsolutePath
+    let contents: Data?
+}
+
+/// Renders the Swift / Objective-C accessor files Tuist injects so that user code can reach the
+/// companion resource bundle via `Bundle.module` — mirroring the shape SwiftPM produces.
+enum BundleAccessorTemplate {
+    static func swiftAccessor(
+        target: Target,
+        bundleName: String,
+        project: Project
+    ) -> SynthesizedBundleAccessorFile {
+        let filename = "TuistBundle+\(target.name.toValidSwiftIdentifier()).swift"
+        let path = project.derivedDirectoryPath(for: target)
+            .appending(components: Constants.DerivedDirectory.sources, filename)
+        let contents = swiftAccessorContents(target: target, bundleName: bundleName, project: project)
+        return SynthesizedBundleAccessorFile(path: path, contents: contents.data(using: .utf8))
+    }
+
+    static func objcAccessorHeader(target: Target, project: Project) -> SynthesizedBundleAccessorFile {
+        let path = objcAccessorPath(target: target, project: project, fileExtension: "h")
+        return SynthesizedBundleAccessorFile(
+            path: path,
+            contents: objcHeaderContents(targetName: target.name).data(using: .utf8)
+        )
+    }
+
+    static func objcAccessorImplementation(
+        target: Target,
+        bundleName: String,
+        project: Project
+    ) -> SynthesizedBundleAccessorFile {
+        let path = objcAccessorPath(target: target, project: project, fileExtension: "m")
+        return SynthesizedBundleAccessorFile(
+            path: path,
+            contents: objcImplementationContents(targetName: target.name, bundleName: bundleName).data(using: .utf8)
+        )
+    }
+
+    // MARK: - Rendering
+
+    static func swiftAccessorContents(target: Target, bundleName: String, project: Project) -> String {
+        let bundleAccessor = if target.supportsResources, target.product != .staticFramework {
+            frameworkBundleAccessor(for: target)
+        } else {
+            spmBundleAccessor(for: target, bundleName: bundleName)
+        }
+
+        let (imports, publicBundleAccessor) = swiftAccessorPreamble(target: target, project: project)
+
+        return """
+        // periphery:ignore:all
+        // swiftlint:disable:this file_name
+        // swiftlint:disable all
+        // swift-format-ignore-file
+        // swiftformat:disable all
+        \(imports)
+        \(bundleAccessor)
+        \(publicBundleAccessor)
+        // swiftformat:enable all
+        // swiftlint:enable all
+        """
+    }
+
+    static func objcHeaderContents(targetName: String) -> String {
+        let identifier = targetName.toValidSwiftIdentifier()
+        return """
+        #import <Foundation/Foundation.h>
+
+        #if __cplusplus
+        extern "C" {
+        #endif
+
+        NSBundle* \(identifier)_SWIFTPM_MODULE_BUNDLE(void) NS_SWIFT_NONISOLATED;
+
+        #define SWIFTPM_MODULE_BUNDLE \(identifier)_SWIFTPM_MODULE_BUNDLE()
+
+        #if __cplusplus
+        }
+        #endif
+        """
+    }
+
+    static func objcImplementationContents(targetName: String, bundleName: String) -> String {
+        let identifier = targetName.toValidSwiftIdentifier()
+        return """
+        #import <Foundation/Foundation.h>
+        #import "TuistBundle+\(targetName).h"
+
+        @interface \(identifier)BundleFinder : NSObject
+        @end
+
+        @implementation \(identifier)BundleFinder
+        @end
+
+        NSBundle* \(identifier)_SWIFTPM_MODULE_BUNDLE(void) {
+            NSString *bundleName = @"\(bundleName)";
+
+            NSURL *bundleURL = [[NSBundle bundleForClass:\(identifier)BundleFinder.self] resourceURL];
+            NSMutableArray *candidates = [NSMutableArray arrayWithObjects:
+                                          [[NSBundle mainBundle] resourceURL],
+                                          bundleURL,
+                                          [[NSBundle mainBundle] bundleURL],
+                                          nil];
+
+            NSString* override = [[[NSProcessInfo processInfo] environment] objectForKey:@"PACKAGE_RESOURCE_BUNDLE_PATH"];
+            if (override) {
+                [candidates addObject:override];
+
+                NSString *subpaths = [[NSFileManager defaultManager] contentsOfDirectoryAtPath:override error:nil];
+                if (subpaths) {
+                    for (NSString *subpath in subpaths) {
+                        if ([subpath hasSuffix:@".framework"]) {
+                            [candidates addObject:[NSURL fileURLWithPath:[NSString stringWithFormat:@"%@/%@", override, subpath]]];
+                        }
+                    }
+                }
+            }
+
+            #if __has_include(<XCTest/XCTest.h>)
+            [candidates addObject:[bundleURL URLByAppendingPathComponent:@".."]];
+            #endif
+
+            for (NSURL *candidate in candidates) {
+                NSURL *bundlePath = [candidate URLByAppendingPathComponent:[NSString stringWithFormat:@"%@%@", bundleName, @".bundle"]];
+                NSBundle *bundle = [NSBundle bundleWithURL:bundlePath];
+
+                if (bundle) {
+                    return bundle;
+                }
+            }
+
+            [NSException raise:@"BundleNotFound" format:nil];
+        }
+        """
+    }
+
+    // MARK: - Helpers
+
+    private static func objcAccessorPath(target: Target, project: Project, fileExtension: String) -> AbsolutePath {
+        let filename = "TuistBundle+\(target.name.uppercasingFirst).\(fileExtension)"
+        return project.derivedDirectoryPath(for: target)
+            .appending(components: Constants.DerivedDirectory.sources, filename)
+    }
+
+    private static func swiftAccessorPreamble(
+        target: Target,
+        project: Project
+    ) -> (imports: String, publicBundleAccessor: String) {
+        switch project.type {
+        case .external,
+             .local where target.sourcesContainsPublicResourceClassName:
+            return ("import Foundation", "")
+        case .local:
+            let imports = """
+            #if hasFeature(InternalImportsByDefault)
+            public import Foundation
+            #else
+            import Foundation
+            #endif
+            """
+            return (imports, publicBundleAccessor(for: target))
+        }
+    }
+
+    private static func publicBundleAccessor(for target: Target) -> String {
+        """
+        // MARK: - Objective-C Bundle Accessor
+        @objc
+        public final class \(target.productName.toValidSwiftIdentifier())Resources: NSObject {
+        @objc public nonisolated class var bundle: Bundle {
+            return .module
+        }
+        }
+        """
+    }
+
+    private static func spmBundleAccessor(for target: Target, bundleName: String) -> String {
+        """
+        // MARK: - Swift Bundle Accessor - for SPM
+        private class BundleFinder {}
+        extension Foundation.Bundle {
+        /// Since \(target.name) is a \(target.product), the bundle containing the resources is copied into the final product.
+            nonisolated static let module: Bundle = {
+                let bundleName = "\(bundleName)"
+                let bundleFinderResourceURL = Bundle(for: BundleFinder.self).resourceURL
+                var candidates = [
+                    Bundle.main.resourceURL,
+                    bundleFinderResourceURL,
+                    Bundle.main.bundleURL,
+                ]
+                // This is a fix to make Previews work with bundled resources.
+                // Logic here is taken from SPM's generated `resource_bundle_accessors.swift` file,
+                // which is located under the derived data directory after building the project.
+                if let override = ProcessInfo.processInfo.environment["PACKAGE_RESOURCE_BUNDLE_PATH"] {
+                    candidates.append(URL(fileURLWithPath: override))
+                    // Deleting derived data and not rebuilding the frameworks containing resources may result in a state
+                    // where the bundles are only available in the framework's directory that is actively being previewed.
+                    // Since we don't know which framework this is, we also need to look in all the framework subpaths.
+                    if let subpaths = try? Foundation.FileManager.default.contentsOfDirectory(atPath: override) {
+                        for subpath in subpaths {
+                            if subpath.hasSuffix(".framework") {
+                                candidates.append(URL(fileURLWithPath: override + "/" + subpath))
+                            }
+                        }
+                    }
+                }
+
+                // This is a fix to make unit tests work with bundled resources.
+                // Making this change allows unit tests to search one directory up for a bundle.
+                // More context can be found in this PR: https://github.com/tuist/tuist/pull/6895
+                #if canImport(XCTest)
+                candidates.append(bundleFinderResourceURL?.appendingPathComponent(".."))
+                #endif
+
+                for candidate in candidates {
+                    let bundlePath = candidate?.appendingPathComponent(bundleName + ".bundle")
+                    if let bundle = bundlePath.flatMap(Bundle.init(url:)) {
+                        return bundle
+                    }
+                }
+                fatalError("unable to find bundle named \(bundleName)")
+            }()
+        }
+        """
+    }
+
+    private static func frameworkBundleAccessor(for target: Target) -> String {
+        """
+        // MARK: - Swift Bundle Accessor for Frameworks
+        private class BundleFinder {}
+        extension Foundation.Bundle {
+        /// Since \(target.name) is a \(target.product), the bundle for classes within this module can be used directly.
+            nonisolated static let module = Bundle(for: BundleFinder.self)
+        }
+        """
+    }
+}
+
+extension Target {
+    fileprivate var sourcesContainsPublicResourceClassName: Bool {
+        sources.contains(where: { $0.path.basename == "\(name)Resources.swift" })
+    }
+}

--- a/cli/Sources/TuistGenerator/Mappers/BundleAccessorTemplate.swift
+++ b/cli/Sources/TuistGenerator/Mappers/BundleAccessorTemplate.swift
@@ -1,19 +1,34 @@
 import Foundation
+import Mockable
 import Path
 import TuistConstants
 import XcodeGraph
 
 /// A file Tuist writes into a target's Derived directory to expose `Bundle.module` (and the
 /// SwiftPM-compatible C entry point) to the target's own sources.
-struct SynthesizedBundleAccessorFile {
-    let path: AbsolutePath
-    let contents: Data?
+public struct SynthesizedBundleAccessorFile {
+    public let path: AbsolutePath
+    public let contents: Data?
+
+    public init(path: AbsolutePath, contents: Data?) {
+        self.path = path
+        self.contents = contents
+    }
 }
 
 /// Renders the Swift / Objective-C accessor files Tuist injects so that user code can reach the
 /// companion resource bundle via `Bundle.module` — mirroring the shape SwiftPM produces.
-enum BundleAccessorTemplate {
-    static func swiftAccessor(
+@Mockable
+public protocol BundleAccessorTemplating {
+    func swiftAccessor(target: Target, bundleName: String, project: Project) -> SynthesizedBundleAccessorFile
+    func objcAccessorHeader(target: Target, project: Project) -> SynthesizedBundleAccessorFile
+    func objcAccessorImplementation(target: Target, bundleName: String, project: Project) -> SynthesizedBundleAccessorFile
+}
+
+public struct BundleAccessorTemplate: BundleAccessorTemplating {
+    public init() {}
+
+    public func swiftAccessor(
         target: Target,
         bundleName: String,
         project: Project
@@ -21,27 +36,27 @@ enum BundleAccessorTemplate {
         let filename = "TuistBundle+\(target.name.toValidSwiftIdentifier()).swift"
         let path = project.derivedDirectoryPath(for: target)
             .appending(components: Constants.DerivedDirectory.sources, filename)
-        let contents = swiftAccessorContents(target: target, bundleName: bundleName, project: project)
+        let contents = Self.swiftAccessorContents(target: target, bundleName: bundleName, project: project)
         return SynthesizedBundleAccessorFile(path: path, contents: contents.data(using: .utf8))
     }
 
-    static func objcAccessorHeader(target: Target, project: Project) -> SynthesizedBundleAccessorFile {
-        let path = objcAccessorPath(target: target, project: project, fileExtension: "h")
+    public func objcAccessorHeader(target: Target, project: Project) -> SynthesizedBundleAccessorFile {
+        let path = Self.objcAccessorPath(target: target, project: project, fileExtension: "h")
         return SynthesizedBundleAccessorFile(
             path: path,
-            contents: objcHeaderContents(targetName: target.name).data(using: .utf8)
+            contents: Self.objcHeaderContents(targetName: target.name).data(using: .utf8)
         )
     }
 
-    static func objcAccessorImplementation(
+    public func objcAccessorImplementation(
         target: Target,
         bundleName: String,
         project: Project
     ) -> SynthesizedBundleAccessorFile {
-        let path = objcAccessorPath(target: target, project: project, fileExtension: "m")
+        let path = Self.objcAccessorPath(target: target, project: project, fileExtension: "m")
         return SynthesizedBundleAccessorFile(
             path: path,
-            contents: objcImplementationContents(targetName: target.name, bundleName: bundleName).data(using: .utf8)
+            contents: Self.objcImplementationContents(targetName: target.name, bundleName: bundleName).data(using: .utf8)
         )
     }
 

--- a/cli/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
+++ b/cli/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
@@ -63,7 +63,7 @@ public struct ResourcesProjectMapper: ProjectMapping {
         var sideEffects: [SideEffectDescriptor] = []
 
         if targetNeedsCompanionBundle(target) {
-            let companion = synthesizeCompanionBundle(for: target, project: project, bundleName: bundleName)
+            let companion = synthesizeCompanionBundle(for: target, bundleName: bundleName)
             modifiedTarget = companion.modifiedTarget
             additionalTargets.append(companion.bundleTarget)
         }
@@ -99,7 +99,7 @@ public struct ResourcesProjectMapper: ProjectMapping {
         // `.metal` files are declared by users as sources, but SwiftPM treats them as resources
         // (xcbuildFileTypes) and Xcode compiles them into `default.metallib` — which has to ship
         // inside the resource bundle for `Bundle.module` to resolve it at runtime.
-        if target.sources.contains(where: { $0.path.routesThroughResourceBundle }) { return true }
+        if target.sources.contains(where: \.path.routesThroughResourceBundle) { return true }
         if try await buildableFolderChecker.containsResources(target.buildableFolders) { return true }
         if buildableFoldersContainBundleResources(target: target, project: project) { return true }
         return false
@@ -151,7 +151,6 @@ public struct ResourcesProjectMapper: ProjectMapping {
 
     private func synthesizeCompanionBundle(
         for target: Target,
-        project: Project,
         bundleName: String
     ) -> CompanionBundleResult {
         let partition = partitioner.partition(target.buildableFolders)

--- a/cli/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
+++ b/cli/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
@@ -90,10 +90,12 @@ public struct ResourcesProjectMapper: ProjectMapping {
     private func targetNeedsBundleSynthesis(_ target: Target, project: Project) async throws -> Bool {
         if !target.resources.resources.isEmpty { return true }
         if !target.coreDataModels.isEmpty { return true }
-        if target.sources.contains(where: { $0.path.extension == "metal" }) { return true }
+        // `.metal` files are declared by users as sources, but SwiftPM treats them as resources
+        // (xcbuildFileTypes) and Xcode compiles them into `default.metallib` — which has to ship
+        // inside the resource bundle for `Bundle.module` to resolve it at runtime.
+        if target.sources.contains(where: { $0.path.routesThroughResourceBundle }) { return true }
         if try await buildableFolderChecker.containsResources(target.buildableFolders) { return true }
-        if buildableFoldersContainSynthesizedFiles(target: target, project: project) { return true }
-        if buildableFoldersContainMetalFiles(target.buildableFolders) { return true }
+        if buildableFoldersContainBundleResources(target: target, project: project) { return true }
         return false
     }
 
@@ -120,19 +122,17 @@ public struct ResourcesProjectMapper: ProjectMapping {
         return containsObjc && hasBundleResources && needsBundle
     }
 
-    private func buildableFoldersContainSynthesizedFiles(target: Target, project: Project) -> Bool {
-        let extensions = Set(project.resourceSynthesizers.flatMap(\.extensions))
+    /// Files inside buildable folders that should trip bundle synthesis but aren't caught by
+    /// `BuildableFolderChecker.containsResources` (which treats anything in `validSourceExtensions`
+    /// as a source): files declared as resource synthesizers, and source-like extensions that
+    /// SwiftPM routes through the resource bundle (today: `.metal`).
+    private func buildableFoldersContainBundleResources(target: Target, project: Project) -> Bool {
+        let synthesizerExtensions = Set(project.resourceSynthesizers.flatMap(\.extensions))
         return target.buildableFolders.contains(where: { folder in
-            folder.resolvedFiles.contains(where: { extensions.contains($0.path.extension ?? "") })
-        })
-    }
-
-    /// Xcode compiles `.metal` sources into a `default.metallib` resource. For static frameworks
-    /// and other targets that can't host their own resources, the metallib must live in the
-    /// companion bundle so `Bundle.module.makeDefaultLibrary(...)` can find it.
-    private func buildableFoldersContainMetalFiles(_ folders: [BuildableFolder]) -> Bool {
-        folders.contains(where: { folder in
-            folder.resolvedFiles.contains(where: { $0.path.extension == "metal" })
+            folder.resolvedFiles.contains(where: { file in
+                file.path.routesThroughResourceBundle
+                    || synthesizerExtensions.contains(file.path.extension ?? "")
+            })
         })
     }
 
@@ -158,9 +158,10 @@ public struct ResourcesProjectMapper: ProjectMapping {
 
         var modifiedTarget = target
 
-        // Source files: keep everything except `.metal` (which Xcode compiles into a resource
-        // that must live in the companion bundle alongside the buildable-folder partition).
-        modifiedTarget.sources = target.sources.filter { $0.path.extension != "metal" }
+        // Drop source-listed files that SwiftPM routes through the resource bundle (today:
+        // `.metal`). The bundle target's `sources` parameter, set in `makeBundleTarget`, picks
+        // them up so Xcode compiles them inside the bundle.
+        modifiedTarget.sources = target.sources.filter { !$0.path.routesThroughResourceBundle }
 
         // Asset catalogs (.xcassets) sit on the main target's Sources phase so Xcode generates
         // typed asset symbols, and on the companion bundle's Resources phase so the catalog is
@@ -239,7 +240,7 @@ public struct ResourcesProjectMapper: ProjectMapping {
                 ],
                 configurations: [:]
             ),
-            sources: target.sources.filter { $0.path.extension == "metal" },
+            sources: target.sources.filter(\.path.routesThroughResourceBundle),
             resources: target.resources,
             copyFiles: target.copyFiles,
             coreDataModels: target.coreDataModels,

--- a/cli/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
+++ b/cli/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
@@ -18,11 +18,17 @@ import XcodeGraph
 public struct ResourcesProjectMapper: ProjectMapping {
     private let contentHasher: ContentHashing
     private let buildableFolderChecker: BuildableFolderChecking
+    private let bundleAccessorTemplate: BundleAccessorTemplating
     private let partitioner = BuildableFolderResourcePartitioner()
 
-    public init(contentHasher: ContentHashing, buildableFolderChecker: BuildableFolderChecking = BuildableFolderChecker()) {
+    public init(
+        contentHasher: ContentHashing,
+        buildableFolderChecker: BuildableFolderChecking = BuildableFolderChecker(),
+        bundleAccessorTemplate: BundleAccessorTemplating = BundleAccessorTemplate()
+    ) {
         self.contentHasher = contentHasher
         self.buildableFolderChecker = buildableFolderChecker
+        self.bundleAccessorTemplate = bundleAccessorTemplate
     }
 
     public func map(project: Project) async throws -> (Project, [SideEffectDescriptor]) {
@@ -259,7 +265,7 @@ public struct ResourcesProjectMapper: ProjectMapping {
         project: Project,
         bundleName: String
     ) throws {
-        let file = BundleAccessorTemplate.swiftAccessor(target: target, bundleName: bundleName, project: project)
+        let file = bundleAccessorTemplate.swiftAccessor(target: target, bundleName: bundleName, project: project)
         let hash = try file.contents.map(contentHasher.hash)
         modifiedTarget.sources.append(SourceFile(path: file.path, contentHash: hash))
         sideEffects.append(.file(.init(path: file.path, contents: file.contents, state: .present)))
@@ -272,8 +278,8 @@ public struct ResourcesProjectMapper: ProjectMapping {
         project: Project,
         bundleName: String
     ) throws {
-        let header = BundleAccessorTemplate.objcAccessorHeader(target: target, project: project)
-        let implementation = BundleAccessorTemplate.objcAccessorImplementation(
+        let header = bundleAccessorTemplate.objcAccessorHeader(target: target, project: project)
+        let implementation = bundleAccessorTemplate.objcAccessorImplementation(
             target: target,
             bundleName: bundleName,
             project: project

--- a/cli/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
+++ b/cli/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
@@ -42,7 +42,8 @@ public struct ResourcesProjectMapper: ProjectMapping { // swiftlint:disable:this
         if target.resources.resources.isEmpty, target.coreDataModels.isEmpty,
            !target.sources.contains(where: { $0.path.extension == "metal" }),
            !(try await buildableFolderChecker.containsResources(target.buildableFolders)),
-           !containsSynthesizedFilesInBuildableFolders(target: target, project: project)
+           !containsSynthesizedFilesInBuildableFolders(target: target, project: project),
+           !containsMetalFilesInBuildableFolders(target.buildableFolders)
         { return (
             [target],
             []
@@ -204,6 +205,15 @@ public struct ResourcesProjectMapper: ProjectMapping { // swiftlint:disable:this
         let extensions = Set(project.resourceSynthesizers.flatMap(\.extensions))
         return target.buildableFolders.contains(where: { folder in
             folder.resolvedFiles.contains(where: { extensions.contains($0.path.extension ?? "") })
+        })
+    }
+
+    // Xcode compiles `.metal` sources into a `default.metallib` resource. For static frameworks and
+    // other targets that can't host their own resources, the metallib must live in the companion
+    // bundle so that `Bundle.module` can load it via `makeDefaultLibrary(bundle:)`.
+    private func containsMetalFilesInBuildableFolders(_ folders: [BuildableFolder]) -> Bool {
+        folders.contains(where: { folder in
+            folder.resolvedFiles.contains(where: { $0.path.extension == "metal" })
         })
     }
 
@@ -633,11 +643,20 @@ extension AbsolutePath {
     }
 
     fileprivate var shouldStayOnlyOnOriginalTargetWhenSplittingResources: Bool {
-        isSourceLike && !shouldBeSharedAcrossTargetsWhenSplittingResources
+        isSourceLike
+            && !shouldBeSharedAcrossTargetsWhenSplittingResources
+            && !shouldBeMovedToBundleWhenSplittingResources
     }
 
     fileprivate var shouldBeSharedAcrossTargetsWhenSplittingResources: Bool {
         matchesExtension(in: ["xcstrings"])
+    }
+
+    // `.metal` is a source extension, but for targets that need a companion resource bundle
+    // (e.g. static frameworks), the compiled `default.metallib` must live in that bundle so
+    // `Bundle.module` can resolve it. Treat it as resource-only when partitioning.
+    fileprivate var shouldBeMovedToBundleWhenSplittingResources: Bool {
+        matchesExtension(in: ["metal"])
     }
 }
 

--- a/cli/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
+++ b/cli/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
@@ -1,15 +1,24 @@
 import Foundation
 import Path
-import TuistConstants
 import TuistCore
 import TuistLogging
 import TuistSupport
 import XcodeGraph
 
-/// A project mapper that adds support for defining resources in targets that don't support it
-public struct ResourcesProjectMapper: ProjectMapping { // swiftlint:disable:this type_body_length
+/// Generates the plumbing that lets targets without a runtime bundle reach their resources via
+/// `Bundle.module` — mirroring SwiftPM's shape.
+///
+/// For each target the mapper, when needed:
+///   1. Splits the target's buildable folders and resources between the target itself and a
+///      synthesised companion `.bundle` target (for static frameworks and other targets that
+///      cannot host their own resources).
+///   2. Writes a `TuistBundle+<Target>.swift` accessor into the target's Derived directory so
+///      that user code can call `Bundle.module`.
+///   3. For external Obj-C targets, also emits SwiftPM-shaped C bridging files.
+public struct ResourcesProjectMapper: ProjectMapping {
     private let contentHasher: ContentHashing
     private let buildableFolderChecker: BuildableFolderChecking
+    private let partitioner = BuildableFolderResourcePartitioner()
 
     public init(contentHasher: ContentHashing, buildableFolderChecker: BuildableFolderChecking = BuildableFolderChecker()) {
         self.contentHasher = contentHasher
@@ -37,663 +46,249 @@ public struct ResourcesProjectMapper: ProjectMapping { // swiftlint:disable:this
         return (project, sideEffects)
     }
 
-    // swiftlint:disable:next function_body_length
     public func mapTarget(_ target: Target, project: Project) async throws -> ([Target], [SideEffectDescriptor]) {
-        if target.resources.resources.isEmpty, target.coreDataModels.isEmpty,
-           !target.sources.contains(where: { $0.path.extension == "metal" }),
-           !(try await buildableFolderChecker.containsResources(target.buildableFolders)),
-           !containsSynthesizedFilesInBuildableFolders(target: target, project: project),
-           !containsMetalFilesInBuildableFolders(target.buildableFolders)
-        { return (
-            [target],
-            []
-        ) }
+        guard try await targetNeedsBundleSynthesis(target, project: project) else {
+            return ([target], [])
+        }
 
+        let bundleName = "\(project.name)_\(target.name.sanitizedModuleName)"
+        var modifiedTarget = target
         var additionalTargets: [Target] = []
         var sideEffects: [SideEffectDescriptor] = []
 
-        let sanitizedTargetName = target.name.sanitizedModuleName
-        let bundleName = "\(project.name)_\(sanitizedTargetName)"
-        var modifiedTarget = target
-
-        if !target.supportsResources || target.product == .staticFramework {
-            let (
-                resourceBuildableFolders,
-                remainingBuildableFolders,
-                originalTargetExplicitResources
-            ) = partitionBuildableFoldersForResources(
-                target.buildableFolders
-            )
-            var synthesizedMetadata = target.metadata
-            synthesizedMetadata.tags.insert("tuist:synthesized")
-            let resourcesTarget = Target(
-                name: bundleName,
-                destinations: target.destinations,
-                product: .bundle,
-                productName: bundleName,
-                bundleId: "\(target.bundleId).generated.resources",
-                deploymentTargets: target.deploymentTargets,
-                infoPlist: .extendingDefault(with: [:]),
-                settings: Settings(
-                    base: [
-                        "CODE_SIGNING_ALLOWED": "NO",
-                        "SKIP_INSTALL": "YES",
-                        "GENERATE_MASTER_OBJECT_FILE": "NO",
-                        "VERSIONING_SYSTEM": "",
-                        // https://github.com/swiftlang/swift-package-manager/blob/main/Sources/XCBuildSupport/PIFBuilder.swift#L925
-                        // https://github.com/swiftlang/swift-package-manager/blob/main/Sources/SwiftBuildSupport/PackagePIFProjectBuilder.swift#L225
-                        "PACKAGE_RESOURCE_TARGET_KIND": "resource",
-                    ],
-                    configurations: [:]
-                ),
-                sources: target.sources.filter { $0.path.extension == "metal" },
-                resources: target.resources,
-                copyFiles: target.copyFiles,
-                coreDataModels: target.coreDataModels,
-                filesGroup: target.filesGroup,
-                metadata: synthesizedMetadata,
-                buildableFolders: resourceBuildableFolders
-            )
-            modifiedTarget.sources = target.sources.filter { $0.path.extension != "metal" }
-            // Asset catalogs are added to the main target's Sources build phase so Xcode
-            // generates typed asset symbols. This mirrors SwiftPM's PIF builder:
-            //   - https://github.com/swiftlang/swift-package-manager/blob/main/Sources/XCBuildSupport/PIFBuilder.swift#L944-L952
-            //   - https://github.com/swiftlang/swift-package-manager/blob/main/Sources/SwiftBuildSupport/PackagePIFProjectBuilder.swift#L347-L353
-            // They are also compiled into the companion resource bundle via its Resources phase.
-            let assetCatalogExtensions: Set<String> = ["xcassets"]
-            for resource in target.resources.resources {
-                if let ext = resource.path.extension, assetCatalogExtensions.contains(ext) {
-                    modifiedTarget.sources.append(SourceFile(path: resource.path))
-                }
-            }
-            // String catalogs (.xcstrings) stay on the main target's Resources phase so Xcode
-            // runs localization extraction and stale-string detection in the same target where
-            // the Swift sources live. They are also kept on the companion bundle's Resources
-            // phase so the catalog is compiled to .strings for Bundle.module lookups at runtime.
-            // PACKAGE_RESOURCE_BUNDLE_NAME (set on the main target below) makes swift-build's
-            // XCStringsCompiler.shouldCompileCatalog skip catalog compilation here, so the
-            // catalog is only compiled once, inside the companion bundle.
-            // See: https://github.com/swiftlang/swift-build/blob/main/Sources/SWBApplePlatform/XCStringsCompiler.swift
-            // The buildable-folders path arrives at the same shape via the partition logic,
-            // which routes shared entries (xcstrings) into originalTargetExplicitResources.
-            var explicitResources = originalTargetExplicitResources
-            explicitResources.append(
-                contentsOf: target.resources.resources.filter { $0.path.extension == "xcstrings" }
-            )
-            modifiedTarget.resources.resources = explicitResources
-            modifiedTarget.copyFiles = []
-            modifiedTarget.buildableFolders = remainingBuildableFolders
-            modifiedTarget.dependencies.append(.target(
-                name: bundleName,
-                status: .required,
-                condition: .when(target.dependencyPlatformFilters)
-            ))
-            // PACKAGE_RESOURCE_BUNDLE_NAME tells Xcode that a companion bundle target owns the
-            // compiled asset catalogs, which suppresses LinkAssetCatalog on this target while
-            // preserving GenerateAssetSymbols for typed resource accessors. Without this,
-            // xcodebuild archive fails for static targets because LinkAssetCatalog references
-            // an UninstalledProducts path that doesn't exist during archiving.
-            //
-            // PACKAGE_RESOURCE_TARGET_KIND = "regular" tells Xcode this is a normal compilation
-            // target (not a resource bundle) so string extraction runs here where the Swift
-            // source references live. This mirrors SwiftPM's PIF builder:
-            //   - https://github.com/swiftlang/swift-package-manager/blob/main/Sources/XCBuildSupport/PIFBuilder.swift#L642
-            //   - https://github.com/swiftlang/swift-package-manager/blob/main/Sources/SwiftBuildSupport/PackagePIFProjectBuilder%2BModules.swift#L524
-            var base = modifiedTarget.settings?.base ?? SettingsDictionary()
-            base["PACKAGE_RESOURCE_BUNDLE_NAME"] = .string(bundleName)
-            base["PACKAGE_RESOURCE_TARGET_KIND"] = .string("regular")
-            modifiedTarget.settings = modifiedTarget.settings?.with(base: base)
-                ?? Settings(base: base, configurations: [:])
-            additionalTargets.append(resourcesTarget)
+        if targetNeedsCompanionBundle(target) {
+            let companion = synthesizeCompanionBundle(for: target, project: project, bundleName: bundleName)
+            modifiedTarget = companion.modifiedTarget
+            additionalTargets.append(companion.bundleTarget)
         }
 
-        let containSourcesInBuildableFolders = try await buildableFolderChecker.containsSources(target.buildableFolders)
-        if target.sources.containsSwiftFiles || containSourcesInBuildableFolders {
-            let (filePath, data) = synthesizedSwiftFile(bundleName: bundleName, target: target, project: project)
-
-            let hash = try data.map(contentHasher.hash)
-            let sourceFile = SourceFile(path: filePath, contentHash: hash)
-            let sideEffect = SideEffectDescriptor.file(.init(path: filePath, contents: data, state: .present))
-            modifiedTarget.sources.append(sourceFile)
-            sideEffects.append(sideEffect)
-        }
-
-        if case .external = project.type,
-           target.sources.containsObjcFiles,
-           target.resources.containsBundleAccessedResources,
-           !target.supportsResources || target.product == .staticFramework
-        {
-            let (headerFilePath, headerData) = synthesizedObjcHeaderFile(bundleName: bundleName, target: target, project: project)
-
-            let headerHash = try headerData.map(contentHasher.hash)
-            let headerFile = SourceFile(path: headerFilePath, contentHash: headerHash)
-            let headerSideEffect = SideEffectDescriptor.file(.init(path: headerFilePath, contents: headerData, state: .present))
-
-            let gccPrefixHeader = "$(SRCROOT)/\(headerFile.path.relative(to: project.path).pathString)"
-            var settings = modifiedTarget.settings?.base ?? SettingsDictionary()
-            settings["GCC_PREFIX_HEADER"] = .string(gccPrefixHeader)
-            modifiedTarget.settings = modifiedTarget.settings?.with(base: settings)
-
-            sideEffects.append(headerSideEffect)
-
-            let (resourceAccessorPath, resourceAccessorData) = synthesizedObjcImplementationFile(
-                bundleName: bundleName,
+        if try await targetNeedsSwiftAccessor(target) {
+            try appendSwiftBundleAccessor(
+                to: &modifiedTarget,
+                sideEffects: &sideEffects,
                 target: target,
-                project: project
+                project: project,
+                bundleName: bundleName
             )
-            modifiedTarget.sources.append(
-                SourceFile(
-                    path: resourceAccessorPath,
-                    contentHash: try resourceAccessorData.map(contentHasher.hash)
-                )
-            )
-            sideEffects.append(
-                SideEffectDescriptor.file(
-                    FileDescriptor(
-                        path: resourceAccessorPath,
-                        contents: resourceAccessorData,
-                        state: .present
-                    )
-                )
+        }
+
+        if targetNeedsObjcAccessor(target, project: project) {
+            try appendObjcBundleAccessor(
+                to: &modifiedTarget,
+                sideEffects: &sideEffects,
+                target: target,
+                project: project,
+                bundleName: bundleName
             )
         }
 
         return ([modifiedTarget] + additionalTargets, sideEffects)
     }
 
-    private func containsSynthesizedFilesInBuildableFolders(target: Target, project: Project) -> Bool {
+    // MARK: - Should we map this target?
+
+    private func targetNeedsBundleSynthesis(_ target: Target, project: Project) async throws -> Bool {
+        if !target.resources.resources.isEmpty { return true }
+        if !target.coreDataModels.isEmpty { return true }
+        if target.sources.contains(where: { $0.path.extension == "metal" }) { return true }
+        if try await buildableFolderChecker.containsResources(target.buildableFolders) { return true }
+        if buildableFoldersContainSynthesizedFiles(target: target, project: project) { return true }
+        if buildableFoldersContainMetalFiles(target.buildableFolders) { return true }
+        return false
+    }
+
+    private func targetNeedsCompanionBundle(_ target: Target) -> Bool {
+        !target.supportsResources || target.product == .staticFramework
+    }
+
+    private func targetNeedsSwiftAccessor(_ target: Target) async throws -> Bool {
+        let containsSwift = target.sources.contains(where: { $0.path.extension == "swift" })
+        let containsSourcesInBuildableFolders = try await buildableFolderChecker
+            .containsSources(target.buildableFolders)
+        return containsSwift || containsSourcesInBuildableFolders
+    }
+
+    private func targetNeedsObjcAccessor(_ target: Target, project: Project) -> Bool {
+        guard case .external = project.type else { return false }
+        let containsObjc = target.sources.contains {
+            $0.path.extension == "m" || $0.path.extension == "mm"
+        }
+        let hasBundleResources = !target.resources.resources
+            .filter { $0.path.extension != "xcprivacy" }
+            .isEmpty
+        let needsBundle = !target.supportsResources || target.product == .staticFramework
+        return containsObjc && hasBundleResources && needsBundle
+    }
+
+    private func buildableFoldersContainSynthesizedFiles(target: Target, project: Project) -> Bool {
         let extensions = Set(project.resourceSynthesizers.flatMap(\.extensions))
         return target.buildableFolders.contains(where: { folder in
             folder.resolvedFiles.contains(where: { extensions.contains($0.path.extension ?? "") })
         })
     }
 
-    // Xcode compiles `.metal` sources into a `default.metallib` resource. For static frameworks and
-    // other targets that can't host their own resources, the metallib must live in the companion
-    // bundle so that `Bundle.module` can load it via `makeDefaultLibrary(bundle:)`.
-    private func containsMetalFilesInBuildableFolders(_ folders: [BuildableFolder]) -> Bool {
+    /// Xcode compiles `.metal` sources into a `default.metallib` resource. For static frameworks
+    /// and other targets that can't host their own resources, the metallib must live in the
+    /// companion bundle so `Bundle.module.makeDefaultLibrary(...)` can find it.
+    private func buildableFoldersContainMetalFiles(_ folders: [BuildableFolder]) -> Bool {
         folders.contains(where: { folder in
             folder.resolvedFiles.contains(where: { $0.path.extension == "metal" })
         })
     }
 
-    private func synthesizedSwiftFile(bundleName: String, target: Target, project: Project) -> (AbsolutePath, Data?) {
-        let filePath = project.derivedDirectoryPath(for: target)
-            .appending(component: Constants.DerivedDirectory.sources)
-            .appending(component: "TuistBundle+\(target.name.toValidSwiftIdentifier()).swift")
+    // MARK: - Companion bundle target
 
-        let content: String = ResourcesProjectMapper.fileContent(
-            targetName: target.name,
-            bundleName: bundleName,
-            target: target,
-            in: project
-        )
-        return (filePath, content.data(using: .utf8))
+    private struct CompanionBundleResult {
+        let modifiedTarget: Target
+        let bundleTarget: Target
     }
 
-    private func synthesizedObjcHeaderFile(bundleName _: String, target: Target, project: Project) -> (AbsolutePath, Data?) {
-        let filePath = synthesizedFilePath(target: target, project: project, fileExtension: "h")
-
-        let content: String = ResourcesProjectMapper.objcHeaderFileContent(targetName: target.name)
-        return (filePath, content.data(using: .utf8))
-    }
-
-    private func synthesizedObjcImplementationFile(
-        bundleName: String,
-        target: Target,
-        project: Project
-    ) -> (AbsolutePath, Data?) {
-        let filePath = synthesizedFilePath(target: target, project: project, fileExtension: "m")
-
-        let content: String = ResourcesProjectMapper.objcImplementationFileContent(
-            targetName: target.name,
-            bundleName: bundleName
-        )
-        return (filePath, content.data(using: .utf8))
-    }
-
-    private func synthesizedFilePath(target: Target, project: Project, fileExtension: String) -> AbsolutePath {
-        let filename = "TuistBundle+\(target.name.uppercasingFirst).\(fileExtension)"
-        return project.derivedDirectoryPath(for: target).appending(components: Constants.DerivedDirectory.sources, filename)
-    }
-
-    /// Splits the incoming buildable folders into:
-    ///  - folders that should stay on the original target (source-only, or mixed folders after excluding bundle-owned files)
-    ///  - folders that should move to the generated bundle (pure resources, or the resource portion of mixed folders)
-    ///  - explicit resource files that should be added to the original target outside the synchronized group
-    /// Mixed folders are duplicated with exclusion rules so the static target keeps sources in the synchronized group, while the
-    /// bundle owns the resource view and the original target can still explicitly reference files like `.xcstrings`.
-    private func partitionBuildableFoldersForResources(
-        _ folders: [BuildableFolder]
-    ) -> (
-        resourceFolders: [BuildableFolder],
-        remainingFolders: [BuildableFolder],
-        originalTargetExplicitResources: [ResourceFileElement]
-    ) {
-        folders.reduce(
-            into: (
-                resourceFolders: [BuildableFolder](),
-                remainingFolders: [BuildableFolder](),
-                originalTargetExplicitResources: [ResourceFileElement]()
-            )
-        ) { result, folder in
-            guard let partition = folder.partitionedForResources() else {
-                result.remainingFolders.append(folder)
-                return
-            }
-
-            if let originalTargetFolder = partition.originalTargetFolder {
-                result.remainingFolders.append(originalTargetFolder)
-            }
-
-            if let resourcesFolder = partition.resourcesFolder {
-                result.resourceFolders.append(resourcesFolder)
-            }
-
-            result.originalTargetExplicitResources.append(contentsOf: partition.originalTargetExplicitResources)
-        }
-    }
-
-    // swiftlint:disable:next function_body_length
-    static func fileContent(targetName _: String, bundleName: String, target: Target, in project: Project) -> String {
-        let bundleAccessor = if target.supportsResources, target.product != .staticFramework {
-            swiftFrameworkBundleAccessorString(for: target)
-        } else {
-            swiftSPMBundleAccessorString(for: target, and: bundleName)
-        }
-
-        let (imports, publicBundleAccessor): (String, String) = switch project.type {
-        case .external,
-             .local where target.sourcesContainsPublicResourceClassName:
-            (
-                """
-                import Foundation
-                """,
-                ""
-            )
-        case .local:
-            (
-                """
-                #if hasFeature(InternalImportsByDefault)
-                public import Foundation
-                #else
-                import Foundation
-                #endif
-                """,
-                publicBundleAccessorString(for: target)
-            )
-        }
-
-        return """
-        // periphery:ignore:all
-        // swiftlint:disable:this file_name
-        // swiftlint:disable all
-        // swift-format-ignore-file
-        // swiftformat:disable all
-        \(imports)
-        \(bundleAccessor)
-        \(publicBundleAccessor)
-        // swiftformat:enable all
-        // swiftlint:enable all
-        """
-    }
-
-    static func objcHeaderFileContent(
-        targetName: String
-    ) -> String {
-        let identifier = targetName.toValidSwiftIdentifier()
-        return """
-        #import <Foundation/Foundation.h>
-
-        #if __cplusplus
-        extern "C" {
-        #endif
-
-        NSBundle* \(identifier)_SWIFTPM_MODULE_BUNDLE(void) NS_SWIFT_NONISOLATED;
-
-        #define SWIFTPM_MODULE_BUNDLE \(identifier)_SWIFTPM_MODULE_BUNDLE()
-
-        #if __cplusplus
-        }
-        #endif
-        """
-    }
-
-    static func objcImplementationFileContent(
-        targetName: String,
+    private func synthesizeCompanionBundle(
+        for target: Target,
+        project: Project,
         bundleName: String
-    ) -> String {
-        let identifier = targetName.toValidSwiftIdentifier()
-        return """
-        #import <Foundation/Foundation.h>
-        #import "TuistBundle+\(targetName).h"
+    ) -> CompanionBundleResult {
+        let partition = partitioner.partition(target.buildableFolders)
 
-        @interface \(identifier)BundleFinder : NSObject
-        @end
+        let bundleTarget = makeBundleTarget(
+            for: target,
+            bundleName: bundleName,
+            buildableFolders: partition.bundleTargetFolders
+        )
 
-        @implementation \(identifier)BundleFinder
-        @end
+        var modifiedTarget = target
 
-        NSBundle* \(identifier)_SWIFTPM_MODULE_BUNDLE(void) {
-            NSString *bundleName = @"\(bundleName)";
+        // Source files: keep everything except `.metal` (which Xcode compiles into a resource
+        // that must live in the companion bundle alongside the buildable-folder partition).
+        modifiedTarget.sources = target.sources.filter { $0.path.extension != "metal" }
 
-            NSURL *bundleURL = [[NSBundle bundleForClass:\(identifier)BundleFinder.self] resourceURL];
-            NSMutableArray *candidates = [NSMutableArray arrayWithObjects:
-                                          [[NSBundle mainBundle] resourceURL],
-                                          bundleURL,
-                                          [[NSBundle mainBundle] bundleURL],
-                                          nil];
-
-            NSString* override = [[[NSProcessInfo processInfo] environment] objectForKey:@"PACKAGE_RESOURCE_BUNDLE_PATH"];
-            if (override) {
-                [candidates addObject:override];
-
-                NSString *subpaths = [[NSFileManager defaultManager] contentsOfDirectoryAtPath:override error:nil];
-                if (subpaths) {
-                    for (NSString *subpath in subpaths) {
-                        if ([subpath hasSuffix:@".framework"]) {
-                            [candidates addObject:[NSURL fileURLWithPath:[NSString stringWithFormat:@"%@/%@", override, subpath]]];
-                        }
-                    }
-                }
-            }
-
-            #if __has_include(<XCTest/XCTest.h>)
-            [candidates addObject:[bundleURL URLByAppendingPathComponent:@".."]];
-            #endif
-
-            for (NSURL *candidate in candidates) {
-                NSURL *bundlePath = [candidate URLByAppendingPathComponent:[NSString stringWithFormat:@"%@%@", bundleName, @".bundle"]];
-                NSBundle *bundle = [NSBundle bundleWithURL:bundlePath];
-
-                if (bundle) {
-                    return bundle;
-                }
-            }
-
-            [NSException raise:@"BundleNotFound" format:nil];
+        // Asset catalogs (.xcassets) sit on the main target's Sources phase so Xcode generates
+        // typed asset symbols, and on the companion bundle's Resources phase so the catalog is
+        // actually compiled. Mirrors SwiftPM's PIF builder:
+        //   - https://github.com/swiftlang/swift-package-manager/blob/main/Sources/XCBuildSupport/PIFBuilder.swift#L944-L952
+        //   - https://github.com/swiftlang/swift-package-manager/blob/main/Sources/SwiftBuildSupport/PackagePIFProjectBuilder.swift#L347-L353
+        for resource in target.resources.resources where resource.path.extension == "xcassets" {
+            modifiedTarget.sources.append(SourceFile(path: resource.path))
         }
-        """
+
+        // String catalogs (.xcstrings) stay on the main target's Resources phase so Xcode runs
+        // localization extraction and stale-string detection in the same target where the Swift
+        // sources live. They are also kept on the companion bundle's Resources phase so the
+        // catalog is compiled to .strings for `Bundle.module` lookups at runtime.
+        // `PACKAGE_RESOURCE_BUNDLE_NAME` (set on the main target below) makes swift-build's
+        // `XCStringsCompiler.shouldCompileCatalog` skip catalog compilation here, so the catalog
+        // is only compiled once, inside the companion bundle.
+        //   - https://github.com/swiftlang/swift-build/blob/main/Sources/SWBApplePlatform/XCStringsCompiler.swift
+        var explicitResources = partition.originalTargetExplicitResources
+        explicitResources.append(
+            contentsOf: target.resources.resources.filter { $0.path.extension == "xcstrings" }
+        )
+        modifiedTarget.resources.resources = explicitResources
+        modifiedTarget.copyFiles = []
+        modifiedTarget.buildableFolders = partition.originalTargetFolders
+        modifiedTarget.dependencies.append(.target(
+            name: bundleName,
+            status: .required,
+            condition: .when(target.dependencyPlatformFilters)
+        ))
+
+        // `PACKAGE_RESOURCE_BUNDLE_NAME` tells Xcode that a companion bundle target owns the
+        // compiled asset catalogs, which suppresses `LinkAssetCatalog` on this target while
+        // preserving `GenerateAssetSymbols` for typed resource accessors. Without this,
+        // `xcodebuild archive` fails for static targets because `LinkAssetCatalog` references an
+        // `UninstalledProducts` path that doesn't exist during archiving.
+        //
+        // `PACKAGE_RESOURCE_TARGET_KIND = "regular"` tells Xcode this is a normal compilation
+        // target (not a resource bundle) so string extraction runs here where the Swift source
+        // references live. Mirrors SwiftPM's PIF builder:
+        //   - https://github.com/swiftlang/swift-package-manager/blob/main/Sources/XCBuildSupport/PIFBuilder.swift#L642
+        //   - https://github.com/swiftlang/swift-package-manager/blob/main/Sources/SwiftBuildSupport/PackagePIFProjectBuilder%2BModules.swift#L524
+        var base = modifiedTarget.settings?.base ?? SettingsDictionary()
+        base["PACKAGE_RESOURCE_BUNDLE_NAME"] = .string(bundleName)
+        base["PACKAGE_RESOURCE_TARGET_KIND"] = .string("regular")
+        modifiedTarget.settings = modifiedTarget.settings?.with(base: base)
+            ?? Settings(base: base, configurations: [:])
+
+        return CompanionBundleResult(modifiedTarget: modifiedTarget, bundleTarget: bundleTarget)
     }
 
-    private static func publicBundleAccessorString(for target: Target) -> String {
-        """
-        // MARK: - Objective-C Bundle Accessor
-        @objc
-        public final class \(target.productName.toValidSwiftIdentifier())Resources: NSObject {
-        @objc public nonisolated class var bundle: Bundle {
-            return .module
-        }
-        }
-        """
-    }
-
-    private static func swiftSPMBundleAccessorString(for target: Target, and bundleName: String) -> String {
-        """
-        // MARK: - Swift Bundle Accessor - for SPM
-        private class BundleFinder {}
-        extension Foundation.Bundle {
-        /// Since \(target.name) is a \(
-            target
-                .product
-        ), the bundle containing the resources is copied into the final product.
-            nonisolated static let module: Bundle = {
-                let bundleName = "\(bundleName)"
-                let bundleFinderResourceURL = Bundle(for: BundleFinder.self).resourceURL
-                var candidates = [
-                    Bundle.main.resourceURL,
-                    bundleFinderResourceURL,
-                    Bundle.main.bundleURL,
-                ]
-                // This is a fix to make Previews work with bundled resources.
-                // Logic here is taken from SPM's generated `resource_bundle_accessors.swift` file,
-                // which is located under the derived data directory after building the project.
-                if let override = ProcessInfo.processInfo.environment["PACKAGE_RESOURCE_BUNDLE_PATH"] {
-                    candidates.append(URL(fileURLWithPath: override))
-                    // Deleting derived data and not rebuilding the frameworks containing resources may result in a state
-                    // where the bundles are only available in the framework's directory that is actively being previewed.
-                    // Since we don't know which framework this is, we also need to look in all the framework subpaths.
-                    if let subpaths = try? Foundation.FileManager.default.contentsOfDirectory(atPath: override) {
-                        for subpath in subpaths {
-                            if subpath.hasSuffix(".framework") {
-                                candidates.append(URL(fileURLWithPath: override + "/" + subpath))
-                            }
-                        }
-                    }
-                }
-
-                // This is a fix to make unit tests work with bundled resources.
-                // Making this change allows unit tests to search one directory up for a bundle.
-                // More context can be found in this PR: https://github.com/tuist/tuist/pull/6895
-                #if canImport(XCTest)
-                candidates.append(bundleFinderResourceURL?.appendingPathComponent(".."))
-                #endif
-
-                for candidate in candidates {
-                    let bundlePath = candidate?.appendingPathComponent(bundleName + ".bundle")
-                    if let bundle = bundlePath.flatMap(Bundle.init(url:)) {
-                        return bundle
-                    }
-                }
-                fatalError("unable to find bundle named \(bundleName)")
-            }()
-        }
-        """
-    }
-
-    private static func swiftFrameworkBundleAccessorString(for target: Target) -> String {
-        """
-        // MARK: - Swift Bundle Accessor for Frameworks
-        private class BundleFinder {}
-        extension Foundation.Bundle {
-        /// Since \(target.name) is a \(
-            target
-                .product
-        ), the bundle for classes within this module can be used directly.
-            nonisolated static let module = Bundle(for: BundleFinder.self)
-        }
-        """
-    }
-}
-
-/// Represents the result of splitting a buildable folder into source and resource subsets.
-private struct BuildableFolderPartition {
-    /// The view of the folder that should stay on the original target.
-    let originalTargetFolder: BuildableFolder?
-
-    /// The view of the folder that should move to the generated bundle target (resources only).
-    let resourcesFolder: BuildableFolder?
-
-    /// Files that should be added explicitly to the original target outside the synchronized group.
-    let originalTargetExplicitResources: [ResourceFileElement]
-}
-
-extension BuildableFolder {
-    /// Produces copies of the buildable folder suitable for source-only and resource-only targets.
-    /// - Returns: `nil` when the folder should stay untouched on the original target, otherwise a partition describing the two
-    /// views.
-    fileprivate func partitionedForResources() -> BuildableFolderPartition? {
-        if let directAssignment = folderOnlyPartition() {
-            return directAssignment
-        }
-
-        let (originalOnlyEntries, sharedEntries, resourceOnlyEntries) = splitFilesByKind()
-        let originalTargetEntries = originalOnlyEntries
-        let resourceEntries = resourceOnlyEntries + sharedEntries
-        let originalTargetExplicitResources = sharedEntries.map { ResourceFileElement.file(path: $0.path) }
-
-        if resourceEntries.isEmpty {
-            return handleOriginalTargetOnlyFolder()
-        }
-
-        if originalTargetEntries.isEmpty {
-            return BuildableFolderPartition(
-                originalTargetFolder: nil,
-                resourcesFolder: self,
-                originalTargetExplicitResources: originalTargetExplicitResources
-            )
-        }
-
-        return duplicateFolderWithExclusions(
-            originalOnlyEntries: originalOnlyEntries,
-            sharedEntries: sharedEntries,
-            resourceOnlyEntries: resourceOnlyEntries,
-            originalTargetEntries: originalTargetEntries,
-            resourceEntries: resourceEntries,
-            originalTargetExplicitResources: originalTargetExplicitResources
+    private func makeBundleTarget(
+        for target: Target,
+        bundleName: String,
+        buildableFolders: [BuildableFolder]
+    ) -> Target {
+        var synthesizedMetadata = target.metadata
+        synthesizedMetadata.tags.insert("tuist:synthesized")
+        return Target(
+            name: bundleName,
+            destinations: target.destinations,
+            product: .bundle,
+            productName: bundleName,
+            bundleId: "\(target.bundleId).generated.resources",
+            deploymentTargets: target.deploymentTargets,
+            infoPlist: .extendingDefault(with: [:]),
+            settings: Settings(
+                base: [
+                    "CODE_SIGNING_ALLOWED": "NO",
+                    "SKIP_INSTALL": "YES",
+                    "GENERATE_MASTER_OBJECT_FILE": "NO",
+                    "VERSIONING_SYSTEM": "",
+                    // https://github.com/swiftlang/swift-package-manager/blob/main/Sources/XCBuildSupport/PIFBuilder.swift#L925
+                    // https://github.com/swiftlang/swift-package-manager/blob/main/Sources/SwiftBuildSupport/PackagePIFProjectBuilder.swift#L225
+                    "PACKAGE_RESOURCE_TARGET_KIND": "resource",
+                ],
+                configurations: [:]
+            ),
+            sources: target.sources.filter { $0.path.extension == "metal" },
+            resources: target.resources,
+            copyFiles: target.copyFiles,
+            coreDataModels: target.coreDataModels,
+            filesGroup: target.filesGroup,
+            metadata: synthesizedMetadata,
+            buildableFolders: buildableFolders
         )
     }
 
-    /// Handles cases where the folder path itself reveals a pure resource folder.
-    private func folderOnlyPartition() -> BuildableFolderPartition? {
-        // Xcode treats buildable folders as a single synchronized group. To attach the same folder to
-        // multiple targets we duplicate the reference and add complementary exclusion rules to each copy.
-        if path.isResourceLike, !path.isSourceLike, resolvedFiles.isEmpty {
-            return BuildableFolderPartition(
-                originalTargetFolder: nil,
-                resourcesFolder: self,
-                originalTargetExplicitResources: []
-            )
-        }
-        return nil
+    // MARK: - Synthesised accessor files
+
+    private func appendSwiftBundleAccessor(
+        to modifiedTarget: inout Target,
+        sideEffects: inout [SideEffectDescriptor],
+        target: Target,
+        project: Project,
+        bundleName: String
+    ) throws {
+        let file = BundleAccessorTemplate.swiftAccessor(target: target, bundleName: bundleName, project: project)
+        let hash = try file.contents.map(contentHasher.hash)
+        modifiedTarget.sources.append(SourceFile(path: file.path, contentHash: hash))
+        sideEffects.append(.file(.init(path: file.path, contents: file.contents, state: .present)))
     }
 
-    /// Splits the folder contents into files that belong only on the original target, files that should stay in the bundle but
-    /// also be promoted as explicit resources on the original target, and files that belong only in the bundle.
-    private func splitFilesByKind() -> (
-        originalOnlyEntries: [BuildableFolderFile],
-        sharedEntries: [BuildableFolderFile],
-        resourceOnlyEntries: [BuildableFolderFile]
-    ) {
-        let originalOnlyEntries = resolvedFiles.filter(\.path.shouldStayOnlyOnOriginalTargetWhenSplittingResources)
-        let sharedEntries = resolvedFiles.filter(\.path.shouldBeSharedAcrossTargetsWhenSplittingResources)
-        let resourceOnlyEntries = resolvedFiles.filter {
-            !$0.path.shouldStayOnlyOnOriginalTargetWhenSplittingResources
-                && !$0.path.shouldBeSharedAcrossTargetsWhenSplittingResources
-        }
-        return (originalOnlyEntries, sharedEntries, resourceOnlyEntries)
-    }
-
-    /// Retains the folder on the original target when no bundle-only resources were found, duplicating it only when both
-    /// original-target and bundle heuristics match at the folder level.
-    private func handleOriginalTargetOnlyFolder() -> BuildableFolderPartition? {
-        if path.isResourceLike, path.isSourceLike {
-            return BuildableFolderPartition(
-                originalTargetFolder: BuildableFolder(
-                    path: path,
-                    exceptions: exceptions,
-                    resolvedFiles: resolvedFiles
-                ),
-                resourcesFolder: nil,
-                originalTargetExplicitResources: []
-            )
-        }
-        return nil
-    }
-
-    /// Duplicates the folder reference and adds complementary exclusions to the source and resource views.
-    private func duplicateFolderWithExclusions(
-        originalOnlyEntries: [BuildableFolderFile],
-        sharedEntries: [BuildableFolderFile],
-        resourceOnlyEntries: [BuildableFolderFile],
-        originalTargetEntries: [BuildableFolderFile],
-        resourceEntries: [BuildableFolderFile],
-        originalTargetExplicitResources: [ResourceFileElement]
-    ) -> BuildableFolderPartition {
-        let sourceExcludedPaths = (resourceOnlyEntries + sharedEntries).map(\.path)
-        let resourceExcludedPaths = originalOnlyEntries.map(\.path)
-
-        let originalTargetFolder = BuildableFolder(
-            path: path,
-            exceptions: exceptions.addingExcluded(paths: sourceExcludedPaths),
-            resolvedFiles: originalTargetEntries
+    private func appendObjcBundleAccessor(
+        to modifiedTarget: inout Target,
+        sideEffects: inout [SideEffectDescriptor],
+        target: Target,
+        project: Project,
+        bundleName: String
+    ) throws {
+        let header = BundleAccessorTemplate.objcAccessorHeader(target: target, project: project)
+        let implementation = BundleAccessorTemplate.objcAccessorImplementation(
+            target: target,
+            bundleName: bundleName,
+            project: project
         )
 
-        let resourcesFolder = BuildableFolder(
-            path: path,
-            exceptions: exceptions.addingExcluded(paths: resourceExcludedPaths),
-            resolvedFiles: resourceEntries
-        )
+        // Point the target's prefix header at the synthesised .h so every Obj-C file picks up
+        // `SWIFTPM_MODULE_BUNDLE` without an explicit `#import`.
+        let prefixHeaderPath = "$(SRCROOT)/\(header.path.relative(to: project.path).pathString)"
+        var settings = modifiedTarget.settings?.base ?? SettingsDictionary()
+        settings["GCC_PREFIX_HEADER"] = .string(prefixHeaderPath)
+        modifiedTarget.settings = modifiedTarget.settings?.with(base: settings)
 
-        return BuildableFolderPartition(
-            originalTargetFolder: originalTargetFolder,
-            resourcesFolder: resourcesFolder,
-            originalTargetExplicitResources: originalTargetExplicitResources
-        )
-    }
-}
+        let implementationHash = try implementation.contents.map(contentHasher.hash)
+        modifiedTarget.sources.append(SourceFile(path: implementation.path, contentHash: implementationHash))
 
-extension AbsolutePath {
-    private func matchesExtension(in allowedExtensions: [String]) -> Bool {
-        guard let `extension` else { return false }
-        return allowedExtensions.contains { $0.caseInsensitiveCompare(`extension`) == .orderedSame }
-    }
-
-    fileprivate var isSourceLike: Bool {
-        let validExtensions = Target.validSourceExtensions
-            + Target.validSourceCompatibleFolderExtensions
-            + Target.validHeaderExtensions
-        return matchesExtension(in: validExtensions)
-    }
-
-    fileprivate var isResourceLike: Bool {
-        let validExtensions = Target.validResourceExtensions
-            + Target.validResourceCompatibleFolderExtensions
-        return matchesExtension(in: validExtensions)
-    }
-
-    fileprivate var shouldStayOnlyOnOriginalTargetWhenSplittingResources: Bool {
-        isSourceLike
-            && !shouldBeSharedAcrossTargetsWhenSplittingResources
-            && !shouldBeMovedToBundleWhenSplittingResources
-    }
-
-    fileprivate var shouldBeSharedAcrossTargetsWhenSplittingResources: Bool {
-        matchesExtension(in: ["xcstrings"])
-    }
-
-    // `.metal` is a source extension, but for targets that need a companion resource bundle
-    // (e.g. static frameworks), the compiled `default.metallib` must live in that bundle so
-    // `Bundle.module` can resolve it. Treat it as resource-only when partitioning.
-    fileprivate var shouldBeMovedToBundleWhenSplittingResources: Bool {
-        matchesExtension(in: ["metal"])
-    }
-}
-
-extension BuildableFolderExceptions {
-    fileprivate func addingExcluded(paths: [AbsolutePath]) -> BuildableFolderExceptions {
-        guard !paths.isEmpty else { return self }
-        var updated = exceptions
-        updated.append(
-            BuildableFolderException(
-                excluded: paths,
-                compilerFlags: [:],
-                publicHeaders: [],
-                privateHeaders: []
-            )
-        )
-        return BuildableFolderExceptions(exceptions: updated)
-    }
-}
-
-extension [SourceFile] {
-    fileprivate var containsObjcFiles: Bool {
-        contains(where: { $0.path.extension == "m" || $0.path.extension == "mm" })
-    }
-
-    fileprivate var containsSwiftFiles: Bool {
-        contains(where: { $0.path.extension == "swift" })
-    }
-}
-
-extension ResourceFileElements {
-    fileprivate var containsBundleAccessedResources: Bool {
-        !resources.filter { $0.path.extension != "xcprivacy" }.isEmpty
-    }
-}
-
-extension Target {
-    fileprivate var sourcesContainsPublicResourceClassName: Bool {
-        sources.contains(where: { $0.path.basename == "\(name)Resources.swift" })
+        sideEffects.append(.file(.init(path: header.path, contents: header.contents, state: .present)))
+        sideEffects.append(.file(.init(path: implementation.path, contents: implementation.contents, state: .present)))
     }
 }

--- a/cli/Tests/TuistGeneratorTests/ProjectMappers/ResourcesProjectMapperTests.swift
+++ b/cli/Tests/TuistGeneratorTests/ProjectMappers/ResourcesProjectMapperTests.swift
@@ -329,6 +329,88 @@ struct ResourcesProjectMapperTests {
     }
 
     @Test
+    func mapWhenStaticFrameworkBuildableFolderContainsMetalAndSwift() async throws {
+        // Given
+        let folderPath = try AbsolutePath(validating: "/Sources/Foo")
+        let metalPath = try AbsolutePath(validating: "/Sources/Foo/Shader.metal")
+        let swiftPath = try AbsolutePath(validating: "/Sources/Foo/Foo.swift")
+        let buildableFolder = BuildableFolder(
+            path: folderPath,
+            exceptions: BuildableFolderExceptions(exceptions: []),
+            resolvedFiles: [
+                BuildableFolderFile(path: metalPath, compilerFlags: nil),
+                BuildableFolderFile(path: swiftPath, compilerFlags: nil),
+            ]
+        )
+
+        let target = Target.test(
+            product: .staticFramework,
+            sources: [],
+            resources: ResourceFileElements([]),
+            buildableFolders: [buildableFolder]
+        )
+        let project = Project.test(targets: [target])
+        // Mirrors the production checker, which excludes source extensions (including `.metal`).
+        given(buildableFolderChecker).containsResources(.value([buildableFolder])).willReturn(false)
+        given(buildableFolderChecker).containsSources(.value([buildableFolder])).willReturn(true)
+
+        // When
+        let (gotProject, gotSideEffects) = try await subject.map(project: project)
+
+        // Then: a companion bundle target is synthesized so `Bundle.module` exists and Xcode can
+        // place the compiled `default.metallib` somewhere that `makeDefaultLibrary(bundle:)` can find.
+        #expect(gotProject.targets.count == 2)
+
+        let gotTarget = try #require(gotProject.targets.values.sorted().last)
+        #expect(gotTarget.name == target.name)
+        #expect(gotTarget.product == .staticFramework)
+        let expectedSwiftFolder = BuildableFolder(
+            path: folderPath,
+            exceptions: BuildableFolderExceptions(
+                exceptions: [
+                    BuildableFolderException(
+                        excluded: [metalPath],
+                        compilerFlags: [:],
+                        publicHeaders: [],
+                        privateHeaders: []
+                    ),
+                ]
+            ),
+            resolvedFiles: [
+                BuildableFolderFile(path: swiftPath, compilerFlags: nil),
+            ]
+        )
+        #expect(gotTarget.buildableFolders == [expectedSwiftFolder])
+        #expect(gotTarget.dependencies.contains(TargetDependency.target(
+            name: "\(project.name)_\(target.name)",
+            condition: .when([.ios])
+        )))
+
+        let resourcesTarget = try #require(gotProject.targets.values.sorted().first)
+        #expect(resourcesTarget.product == .bundle)
+        let expectedMetalFolder = BuildableFolder(
+            path: folderPath,
+            exceptions: BuildableFolderExceptions(
+                exceptions: [
+                    BuildableFolderException(
+                        excluded: [swiftPath],
+                        compilerFlags: [:],
+                        publicHeaders: [],
+                        privateHeaders: []
+                    ),
+                ]
+            ),
+            resolvedFiles: [
+                BuildableFolderFile(path: metalPath, compilerFlags: nil),
+            ]
+        )
+        #expect(resourcesTarget.buildableFolders == [expectedMetalFolder])
+
+        // The TuistBundle+ swift accessor is generated so user code can call `Bundle.module`.
+        #expect(gotSideEffects.count == 1)
+    }
+
+    @Test
     func mapWhenBuildableFolderContainsSourcesAndResources() async throws {
         // Given
         let sharedFolderPath = try AbsolutePath(validating: "/shared")

--- a/cli/Tests/TuistGeneratorTests/ProjectMappers/ResourcesProjectMapperTests.swift
+++ b/cli/Tests/TuistGeneratorTests/ProjectMappers/ResourcesProjectMapperTests.swift
@@ -51,8 +51,8 @@ struct ResourcesProjectMapperTests {
             .appending(component: Constants.DerivedDirectory.name)
             .appending(component: Constants.DerivedDirectory.sources)
             .appending(component: "TuistBundle+\(target.name).swift")
-        let expectedContents = ResourcesProjectMapper
-            .fileContent(targetName: target.name, bundleName: "\(project.name)_\(target.name)", target: target, in: project)
+        let expectedContents = BundleAccessorTemplate
+            .swiftAccessorContents(target: target, bundleName: "\(project.name)_\(target.name)", project: project)
         #expect(file.path == expectedPath)
         #expect(file.contents == expectedContents.data(using: .utf8))
 
@@ -228,8 +228,8 @@ struct ResourcesProjectMapperTests {
             .appending(component: Constants.DerivedDirectory.name)
             .appending(component: Constants.DerivedDirectory.sources)
             .appending(component: "TuistBundle+\(target.name).swift")
-        let expectedContents = ResourcesProjectMapper
-            .fileContent(targetName: target.name, bundleName: "\(project.name)_\(target.name)", target: target, in: project)
+        let expectedContents = BundleAccessorTemplate
+            .swiftAccessorContents(target: target, bundleName: "\(project.name)_\(target.name)", project: project)
         #expect(file.path == expectedPath)
         #expect(file.contents == expectedContents.data(using: .utf8))
 
@@ -301,8 +301,8 @@ struct ResourcesProjectMapperTests {
             .appending(component: Constants.DerivedDirectory.name)
             .appending(component: Constants.DerivedDirectory.sources)
             .appending(component: "TuistBundle+\(target.name).swift")
-        let expectedContents = ResourcesProjectMapper
-            .fileContent(targetName: target.name, bundleName: "\(project.name)_\(target.name)", target: target, in: project)
+        let expectedContents = BundleAccessorTemplate
+            .swiftAccessorContents(target: target, bundleName: "\(project.name)_\(target.name)", project: project)
         #expect(file.path == expectedPath)
         #expect(file.contents == expectedContents.data(using: .utf8))
 
@@ -756,8 +756,8 @@ struct ResourcesProjectMapperTests {
             .appending(component: Constants.DerivedDirectory.name)
             .appending(component: Constants.DerivedDirectory.sources)
             .appending(component: "TuistBundle+\(target.name).swift")
-        let expectedContents = ResourcesProjectMapper
-            .fileContent(targetName: target.name, bundleName: "\(project.name)_\(target.name)", target: target, in: project)
+        let expectedContents = BundleAccessorTemplate
+            .swiftAccessorContents(target: target, bundleName: "\(project.name)_\(target.name)", project: project)
         #expect(file.path == expectedPath)
         #expect(file.contents == expectedContents.data(using: .utf8))
 
@@ -809,8 +809,8 @@ struct ResourcesProjectMapperTests {
             .appending(component: Constants.DerivedDirectory.name)
             .appending(component: Constants.DerivedDirectory.sources)
             .appending(component: "TuistBundle+\(target.name).swift")
-        let expectedContents = ResourcesProjectMapper
-            .fileContent(targetName: target.name, bundleName: irrelevantBundleName, target: target, in: project)
+        let expectedContents = BundleAccessorTemplate
+            .swiftAccessorContents(target: target, bundleName: irrelevantBundleName, project: project)
         #expect(file.path == expectedPath)
         #expect(file.contents == expectedContents.data(using: .utf8))
 
@@ -852,8 +852,8 @@ struct ResourcesProjectMapperTests {
             .appending(component: Constants.DerivedDirectory.name)
             .appending(component: Constants.DerivedDirectory.sources)
             .appending(component: "TuistBundle+\(target.name).swift")
-        let expectedContents = ResourcesProjectMapper
-            .fileContent(targetName: target.name, bundleName: irrelevantBundleName, target: target, in: project)
+        let expectedContents = BundleAccessorTemplate
+            .swiftAccessorContents(target: target, bundleName: irrelevantBundleName, project: project)
         #expect(file.path == expectedPath)
         #expect(file.contents == expectedContents.data(using: .utf8))
 
@@ -892,8 +892,8 @@ struct ResourcesProjectMapperTests {
             .appending(component: Constants.DerivedDirectory.name)
             .appending(component: Constants.DerivedDirectory.sources)
             .appending(component: "TuistBundle+\(target.name).swift")
-        let expectedContents = ResourcesProjectMapper
-            .fileContent(targetName: target.name, bundleName: irrelevantBundleName, target: target, in: project)
+        let expectedContents = BundleAccessorTemplate
+            .swiftAccessorContents(target: target, bundleName: irrelevantBundleName, project: project)
         #expect(file.path == expectedPath)
         #expect(file.contents == expectedContents.data(using: .utf8))
 
@@ -974,8 +974,8 @@ struct ResourcesProjectMapperTests {
             .appending(component: Constants.DerivedDirectory.name)
             .appending(component: Constants.DerivedDirectory.sources)
             .appending(component: "TuistBundle+\(target.name.camelized.uppercasingFirst).swift")
-        let expectedContents = ResourcesProjectMapper
-            .fileContent(targetName: target.name, bundleName: "\(project.name)_test_tuist", target: target, in: project)
+        let expectedContents = BundleAccessorTemplate
+            .swiftAccessorContents(target: target, bundleName: "\(project.name)_test_tuist", project: project)
         #expect(file.path == expectedPath)
         #expect(file.contents == expectedContents.data(using: .utf8))
     }
@@ -1248,7 +1248,7 @@ struct ResourcesProjectMapperTests {
         let targetName = "YoutubePlayer-in-WKWebView"
 
         // When
-        let got = ResourcesProjectMapper.objcImplementationFileContent(
+        let got = BundleAccessorTemplate.objcImplementationContents(
             targetName: targetName,
             bundleName: "MyProject_YoutubePlayer-in-WKWebView"
         )
@@ -1266,7 +1266,7 @@ struct ResourcesProjectMapperTests {
         let targetName = "YoutubePlayer-in-WKWebView"
 
         // When
-        let got = ResourcesProjectMapper.objcHeaderFileContent(targetName: targetName)
+        let got = BundleAccessorTemplate.objcHeaderContents(targetName: targetName)
 
         // Then
         #expect(got.contains("YoutubePlayerInWKWebView_SWIFTPM_MODULE_BUNDLE"))
@@ -1292,13 +1292,11 @@ struct ResourcesProjectMapperTests {
             .appending(component: Constants.DerivedDirectory.name)
             .appending(component: Constants.DerivedDirectory.sources)
             .appending(component: "TuistBundle+\(target.name.camelized.uppercasingFirst).swift")
-        let expectedContents = ResourcesProjectMapper
-            .fileContent(
-                targetName: target.name,
-                bundleName: bundleName,
-                target: target,
-                in: project
-            )
+        let expectedContents = BundleAccessorTemplate.swiftAccessorContents(
+            target: target,
+            bundleName: bundleName,
+            project: project
+        )
         #expect(file.path == expectedPath)
         #expect(file.contents == expectedContents.data(using: .utf8))
         if let additionalFileExpectations {
@@ -1334,14 +1332,14 @@ struct ResourcesProjectMapperTests {
             generatedFiles == [
                 FileDescriptor(
                     path: expectedBasePath.appending(component: "TuistBundle+\(target.name).h"),
-                    contents: ResourcesProjectMapper
-                        .objcHeaderFileContent(targetName: target.name)
+                    contents: BundleAccessorTemplate
+                        .objcHeaderContents(targetName: target.name)
                         .data(using: .utf8)
                 ),
                 FileDescriptor(
                     path: expectedBasePath.appending(component: "TuistBundle+\(target.name).m"),
-                    contents: ResourcesProjectMapper
-                        .objcImplementationFileContent(
+                    contents: BundleAccessorTemplate
+                        .objcImplementationContents(
                             targetName: target.name,
                             bundleName: "\(project.name)_\(target.name)"
                         )


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/10745

A static framework whose `buildableFolders` contained only Swift and `.metal` files was being skipped by `ResourcesProjectMapper`: no companion `.bundle` target was synthesized and no `TuistBundle+<Target>.swift` accessor was generated, so user code calling `Bundle.module` (e.g. `device.makeDefaultLibrary(bundle: .module)`) failed to compile with `'module' is inaccessible due to 'internal' protection level`.

The mapper already triggers bundle synthesis when a target has `.metal` files in `target.sources`, since Xcode compiles them into a `default.metallib` resource. The same trigger now fires when the `.metal` file lives inside a buildable folder. When the partition logic splits a buildable folder between the original target and the companion bundle, `.metal` is now routed to the bundle side (matching how SPM's PIF builder hosts `default.metallib` in the resource bundle).

### How to test locally

1. Download the project from [TuistBuildableFolderMetalRepro.zip](https://github.com/user-attachments/files/27640713/TuistBuildableFolderMetalRepro.zip).
2. Generate it with the patched CLI: `tuist generate Foo --no-open`.
3. Confirm `Derived/Sources/TuistBundle+Foo.swift` is generated and that the project contains a `Repro_Foo` bundle target.
4. Build the `Foo` scheme (requires the Metal toolchain) and verify `Foo.swift` compiles.

Automated coverage: `mapWhenStaticFrameworkBuildableFolderContainsMetalAndSwift` in `ResourcesProjectMapperTests`.
