### PR TITLE
feat(server): add Hit filter to Selective Testing tab

### DIFF
--- a/noora/js/Chart.js
+++ b/noora/js/Chart.js
@@ -100,10 +100,11 @@ export default {
       this.colorSchemeListener,
     );
   },
-  render() {
+  render({ animate = true } = {}) {
     if (this.chart) this.chart.dispose();
 
     const option = this.option();
+    if (!animate) option.animation = false;
     const theme = getTheme(option);
 
     echarts.registerTheme("noora", theme);
@@ -147,8 +148,9 @@ export default {
     window.addEventListener("phx:resize", this.resizeListener);
   },
   updated() {
-    // Re-render fully to update theme (including tooltip formatter)
-    this.render();
+    // Re-render fully to update theme (including tooltip formatter), but skip
+    // the entry animation so LiveView patches don't visibly re-animate charts.
+    this.render({ animate: false });
   },
   destroyed() {
     this.chart.dispose();

--- a/server/assets/app/css/components/selective_testing_tab.css
+++ b/server/assets/app/css/components/selective_testing_tab.css
@@ -19,6 +19,16 @@
     gap: var(--noora-spacing-8);
     padding: var(--noora-spacing-8);
 
+    & [data-part="filters"] {
+      display: flex;
+      gap: var(--noora-spacing-6);
+    }
+
+    & [data-part="active-filters"] {
+      display: flex;
+      gap: var(--noora-spacing-4);
+    }
+
     & .noora-text-input {
       width: 330px;
     }

--- a/server/lib/tuist/xcode/xcode_target.ex
+++ b/server/lib/tuist/xcode/xcode_target.ex
@@ -7,7 +7,7 @@ defmodule Tuist.Xcode.XcodeTarget do
 
   @derive {
     Flop.Schema,
-    filterable: [:name, :binary_cache_hit],
+    filterable: [:name, :binary_cache_hit, :selective_testing_hit],
     sortable: [:name, :binary_cache_hit, :selective_testing_hit],
     default_order: %{
       order_by: [:name],

--- a/server/lib/tuist_web/components/runs/module_cache_tab.ex
+++ b/server/lib/tuist_web/components/runs/module_cache_tab.ex
@@ -361,6 +361,7 @@ defmodule TuistWeb.Runs.ModuleCacheTab do
 
   defp cache_chart_options do
     %{
+      animation: false,
       tooltip: %{
         trigger: "axis",
         axisPointer: %{

--- a/server/lib/tuist_web/components/runs/module_cache_tab.ex
+++ b/server/lib/tuist_web/components/runs/module_cache_tab.ex
@@ -361,7 +361,6 @@ defmodule TuistWeb.Runs.ModuleCacheTab do
 
   defp cache_chart_options do
     %{
-      animation: false,
       tooltip: %{
         trigger: "axis",
         axisPointer: %{

--- a/server/lib/tuist_web/components/runs/selective_testing_tab.ex
+++ b/server/lib/tuist_web/components/runs/selective_testing_tab.ex
@@ -18,6 +18,8 @@ defmodule TuistWeb.Runs.SelectiveTestingTab do
   attr :expanded_target_names, :any, required: true
   attr :uri, :any, required: true
   attr :run, :any, required: true
+  attr :available_filters, :list, required: true
+  attr :selective_testing_active_filters, :list, required: true
 
   def selective_testing_tab(assigns) do
     assigns = assign(assigns, :selective_testing_json, selective_testing_targets_json(assigns.run))
@@ -87,17 +89,31 @@ defmodule TuistWeb.Runs.SelectiveTestingTab do
           </.button>
         </:actions>
         <.card_section data-part="selective-testing-section">
-          <.form for={%{}} phx-change="search-selective-testing" phx-debounce="200">
-            <.text_input
-              type="search"
-              id="search-selective-testing"
-              name="search"
-              placeholder={dgettext("dashboard_tests", "Search...")}
-              show_suffix={false}
-              data-part="search"
-              value={@selective_testing_filter}
+          <div data-part="filters">
+            <.form for={%{}} phx-change="search-selective-testing" phx-debounce="200">
+              <.text_input
+                type="search"
+                id="search-selective-testing"
+                name="search"
+                placeholder={dgettext("dashboard_tests", "Search...")}
+                show_suffix={false}
+                data-part="search"
+                value={@selective_testing_filter}
+              />
+            </.form>
+            <.filter_dropdown
+              id="selective-testing-filter-dropdown"
+              label={dgettext("dashboard_tests", "Filter")}
+              available_filters={@available_filters}
+              active_filters={@selective_testing_active_filters}
             />
-          </.form>
+          </div>
+          <div
+            :if={Enum.any?(@selective_testing_active_filters)}
+            data-part="active-filters"
+          >
+            <.active_filter :for={filter <- @selective_testing_active_filters} filter={filter} />
+          </div>
           <.table
             id="selective-testing-table"
             rows={@selective_testing_analytics.test_modules}

--- a/server/lib/tuist_web/live/run_detail_live.ex
+++ b/server/lib/tuist_web/live/run_detail_live.ex
@@ -35,6 +35,8 @@ defmodule TuistWeb.RunDetailLive do
      |> assign(:project, project)
      |> assign(:head_title, "#{dgettext("dashboard_builds", "Run")} · #{slug} · Tuist")
      |> assign_initial_analytics_state()
+     |> assign(:binary_cache_available_filters, define_binary_cache_filters())
+     |> assign(:selective_testing_available_filters, define_selective_testing_filters())
      |> assign(:available_filters, define_binary_cache_filters())
      |> assign(:has_selective_testing_data, Xcode.has_selective_testing_data?(run))
      |> assign(:has_binary_cache_data, Xcode.has_binary_cache_data?(run))
@@ -51,10 +53,17 @@ defmodule TuistWeb.RunDetailLive do
     uri = build_uri(params)
     selected_tab = selected_tab(params)
 
+    available_filters =
+      case selected_tab do
+        "test-optimizations" -> socket.assigns.selective_testing_available_filters
+        _ -> socket.assigns.binary_cache_available_filters
+      end
+
     socket =
       socket
       |> assign(:selected_tab, selected_tab)
       |> assign(:uri, uri)
+      |> assign(:available_filters, available_filters)
       |> assign_tab_data(selected_tab, params)
 
     {:noreply, socket}
@@ -83,10 +92,12 @@ defmodule TuistWeb.RunDetailLive do
   end
 
   def handle_event("add_filter", %{"value" => filter_id}, socket) do
+    page_param = filter_page_param(filter_id)
+
     updated_params =
       filter_id
       |> Filter.Operations.add_filter_to_query(socket)
-      |> Map.put("binary-cache-page", "1")
+      |> Map.put(page_param, "1")
 
     {:noreply,
      socket
@@ -99,10 +110,12 @@ defmodule TuistWeb.RunDetailLive do
   end
 
   def handle_event("update_filter", params, socket) do
+    page_param = filter_page_param(params["payload_filter_id"])
+
     updated_query_params =
       params
       |> Filter.Operations.update_filters_in_query(socket)
-      |> Map.put("binary-cache-page", "1")
+      |> Map.put(page_param, "1")
 
     {:noreply,
      socket
@@ -163,11 +176,15 @@ defmodule TuistWeb.RunDetailLive do
     socket
     |> assign(:selective_testing_analytics, %{})
     |> assign(:selective_testing_page_count, 0)
+    |> assign(:selective_testing_active_filters, [])
     |> assign(:binary_cache_analytics, %{})
     |> assign(:binary_cache_page_count, 0)
     |> assign(:binary_cache_active_filters, [])
     |> assign(:expanded_target_names, MapSet.new())
   end
+
+  defp filter_page_param("selective_testing_hit"), do: "selective-testing-page"
+  defp filter_page_param(_), do: "binary-cache-page"
 
   defp build_uri(params) do
     URI.new!("?" <> URI.encode_query(params))
@@ -193,18 +210,23 @@ defmodule TuistWeb.RunDetailLive do
   end
 
   defp assign_selective_testing_data(socket, analytics, meta, params) do
+    filters =
+      Filter.Operations.decode_filters_from_query(params, socket.assigns.selective_testing_available_filters)
+
     socket
     |> assign(:selective_testing_analytics, analytics)
     |> assign(:selective_testing_meta, meta)
     |> assign(:selective_testing_page_count, meta.total_pages)
     |> assign(:selective_testing_filter, params["selective-testing-filter"] || "")
+    |> assign(:selective_testing_active_filters, filters)
     |> assign(:selective_testing_page, String.to_integer(params["selective-testing-page"] || "1"))
     |> assign(:selective_testing_sort_by, params["selective-testing-sort-by"] || "name")
     |> assign(:selective_testing_sort_order, params["selective-testing-sort-order"] || "asc")
   end
 
   defp assign_binary_cache_data(socket, analytics, meta, params) do
-    filters = Filter.Operations.decode_filters_from_query(params, socket.assigns.available_filters)
+    filters =
+      Filter.Operations.decode_filters_from_query(params, socket.assigns.binary_cache_available_filters)
 
     socket
     |> assign(:binary_cache_analytics, analytics)
@@ -221,6 +243,7 @@ defmodule TuistWeb.RunDetailLive do
     socket
     |> assign(:selective_testing_analytics, socket.assigns.selective_testing_analytics)
     |> assign(:selective_testing_page_count, socket.assigns.selective_testing_page_count)
+    |> assign(:selective_testing_active_filters, [])
   end
 
   defp assign_binary_cache_defaults(socket) do
@@ -231,10 +254,15 @@ defmodule TuistWeb.RunDetailLive do
   end
 
   defp assign_param_defaults(socket, params) do
-    binary_cache_filters = Filter.Operations.decode_filters_from_query(params, socket.assigns.available_filters)
+    binary_cache_filters =
+      Filter.Operations.decode_filters_from_query(params, socket.assigns.binary_cache_available_filters)
+
+    selective_testing_filters =
+      Filter.Operations.decode_filters_from_query(params, socket.assigns.selective_testing_available_filters)
 
     socket
     |> assign(:selective_testing_filter, params["selective-testing-filter"] || "")
+    |> assign(:selective_testing_active_filters, selective_testing_filters)
     |> assign(:selective_testing_page, String.to_integer(params["selective-testing-page"] || "1"))
     |> assign(:selective_testing_sort_by, params["selective-testing-sort-by"] || "name")
     |> assign(:selective_testing_sort_order, params["selective-testing-sort-order"] || "desc")
@@ -247,9 +275,13 @@ defmodule TuistWeb.RunDetailLive do
 
   defp load_selective_testing_data(run, params) do
     counts = Xcode.selective_testing_counts(run)
+    filters = Filter.Operations.decode_filters_from_query(params, define_selective_testing_filters())
+
+    text_filters = build_text_flop_filters(params["selective-testing-filter"])
+    filter_flop_filters = build_selective_testing_flop_filters(filters)
 
     flop_params = %{
-      filters: build_text_flop_filters(params["selective-testing-filter"]),
+      filters: text_filters ++ filter_flop_filters,
       page: String.to_integer(params["selective-testing-page"] || "1"),
       page_size: @table_page_size,
       order_by: [ensure_allowed_params("selective-testing-sort-by", params)],
@@ -307,6 +339,39 @@ defmodule TuistWeb.RunDetailLive do
     |> Enum.map(fn filter ->
       case filter.id do
         "binary_cache_hit" ->
+          %{filter | value: if(filter.value, do: Atom.to_string(filter.value))}
+
+        _ ->
+          filter
+      end
+    end)
+    |> Filter.Operations.convert_filters_to_flop()
+  end
+
+  defp define_selective_testing_filters do
+    [
+      %Filter.Filter{
+        id: "selective_testing_hit",
+        field: :selective_testing_hit,
+        display_name: dgettext("dashboard_builds", "Hit"),
+        type: :option,
+        options: [:local, :remote, :miss],
+        options_display_names: %{
+          remote: dgettext("dashboard_builds", "Remote"),
+          local: dgettext("dashboard_builds", "Local"),
+          miss: dgettext("dashboard_builds", "Missed")
+        },
+        operator: :==,
+        value: nil
+      }
+    ]
+  end
+
+  defp build_selective_testing_flop_filters(filters) do
+    filters
+    |> Enum.map(fn filter ->
+      case filter.id do
+        "selective_testing_hit" ->
           %{filter | value: if(filter.value, do: Atom.to_string(filter.value))}
 
         _ ->

--- a/server/lib/tuist_web/live/run_detail_live.html.heex
+++ b/server/lib/tuist_web/live/run_detail_live.html.heex
@@ -221,6 +221,8 @@
       expanded_target_names={@expanded_target_names}
       uri={@uri}
       run={@run}
+      available_filters={@selective_testing_available_filters}
+      selective_testing_active_filters={@selective_testing_active_filters}
     />
   <% end %>
   <%= if @selected_tab == "module-cache" do %>

--- a/server/lib/tuist_web/live/test_run_live.ex
+++ b/server/lib/tuist_web/live/test_run_live.ex
@@ -116,6 +116,9 @@ defmodule TuistWeb.TestRunLive do
         {"module-cache", _} ->
           {socket.assigns.binary_cache_available_filters, socket.assigns.binary_cache_active_filters}
 
+        {"test-optimizations", _} ->
+          {socket.assigns.selective_testing_available_filters, socket.assigns.selective_testing_active_filters}
+
         _ ->
           {[], []}
       end
@@ -302,6 +305,8 @@ defmodule TuistWeb.TestRunLive do
     |> assign(:binary_cache_page_count, 0)
     |> assign(:binary_cache_available_filters, define_binary_cache_filters())
     |> assign(:binary_cache_active_filters, [])
+    |> assign(:selective_testing_available_filters, define_selective_testing_filters())
+    |> assign(:selective_testing_active_filters, [])
     |> assign(:expanded_target_names, MapSet.new())
   end
 
@@ -361,20 +366,25 @@ defmodule TuistWeb.TestRunLive do
   defp reset_test_tab_page(params, socket) do
     selected_tab = socket.assigns.selected_tab
 
-    if selected_tab == "module-cache" do
-      Map.put(params, "binary-cache-page", "1")
-    else
-      test_tab = URI.decode_query(socket.assigns.uri.query)["test-tab"] || "test-cases"
+    cond do
+      selected_tab == "module-cache" ->
+        Map.put(params, "binary-cache-page", "1")
 
-      page_param =
-        case test_tab do
-          "test-cases" -> "test-cases-page"
-          "test-suites" -> "test-suites-page"
-          "test-modules" -> "test-modules-page"
-          _ -> "test-cases-page"
-        end
+      selected_tab == "test-optimizations" ->
+        Map.put(params, "selective-testing-page", "1")
 
-      Map.put(params, page_param, "1")
+      true ->
+        test_tab = URI.decode_query(socket.assigns.uri.query)["test-tab"] || "test-cases"
+
+        page_param =
+          case test_tab do
+            "test-cases" -> "test-cases-page"
+            "test-suites" -> "test-suites-page"
+            "test-modules" -> "test-modules-page"
+            _ -> "test-cases-page"
+          end
+
+        Map.put(params, page_param, "1")
     end
   end
 
@@ -452,11 +462,15 @@ defmodule TuistWeb.TestRunLive do
   end
 
   defp assign_selective_testing_data(socket, analytics, meta, params) do
+    filters =
+      Filter.Operations.decode_filters_from_query(params, socket.assigns.selective_testing_available_filters)
+
     socket
     |> assign(:selective_testing_analytics, analytics)
     |> assign(:selective_testing_meta, meta)
     |> assign(:selective_testing_page_count, meta.total_pages)
     |> assign(:selective_testing_filter, params["selective-testing-filter"] || "")
+    |> assign(:selective_testing_active_filters, filters)
     |> assign(:selective_testing_page, String.to_integer(params["selective-testing-page"] || "1"))
     |> assign(:selective_testing_sort_by, params["selective-testing-sort-by"] || "name")
     |> assign(:selective_testing_sort_order, params["selective-testing-sort-order"] || "asc")
@@ -480,6 +494,7 @@ defmodule TuistWeb.TestRunLive do
     socket
     |> assign(:selective_testing_analytics, socket.assigns.selective_testing_analytics)
     |> assign(:selective_testing_page_count, socket.assigns.selective_testing_page_count)
+    |> assign(:selective_testing_active_filters, [])
   end
 
   defp assign_binary_cache_defaults(socket) do
@@ -536,8 +551,12 @@ defmodule TuistWeb.TestRunLive do
     binary_cache_filters =
       Filter.Operations.decode_filters_from_query(params, socket.assigns.binary_cache_available_filters)
 
+    selective_testing_filters =
+      Filter.Operations.decode_filters_from_query(params, socket.assigns.selective_testing_available_filters)
+
     socket
     |> assign(:selective_testing_filter, params["selective-testing-filter"] || "")
+    |> assign(:selective_testing_active_filters, selective_testing_filters)
     |> assign(:selective_testing_page, String.to_integer(params["selective-testing-page"] || "1"))
     |> assign(:selective_testing_sort_by, params["selective-testing-sort-by"] || "name")
     |> assign(:selective_testing_sort_order, params["selective-testing-sort-order"] || "desc")
@@ -554,9 +573,13 @@ defmodule TuistWeb.TestRunLive do
 
   defp load_selective_testing_data(run, params) do
     counts = Xcode.selective_testing_counts(run)
+    filters = Filter.Operations.decode_filters_from_query(params, define_selective_testing_filters())
+
+    text_filters = build_flop_filters(params["selective-testing-filter"])
+    filter_flop_filters = build_selective_testing_flop_filters(filters)
 
     flop_params = %{
-      filters: build_flop_filters(params["selective-testing-filter"]),
+      filters: text_filters ++ filter_flop_filters,
       page: String.to_integer(params["selective-testing-page"] || "1"),
       page_size: @table_page_size,
       order_by: [ensure_allowed_params("selective-testing-sort-by", params)],
@@ -1105,6 +1128,39 @@ defmodule TuistWeb.TestRunLive do
         value: nil
       }
     ]
+  end
+
+  defp define_selective_testing_filters do
+    [
+      %Filter.Filter{
+        id: "selective_testing_hit",
+        field: :selective_testing_hit,
+        display_name: dgettext("dashboard_tests", "Hit"),
+        type: :option,
+        options: [:local, :remote, :miss],
+        options_display_names: %{
+          remote: dgettext("dashboard_tests", "Remote"),
+          local: dgettext("dashboard_tests", "Local"),
+          miss: dgettext("dashboard_tests", "Missed")
+        },
+        operator: :==,
+        value: nil
+      }
+    ]
+  end
+
+  defp build_selective_testing_flop_filters(filters) do
+    filters
+    |> Enum.map(fn filter ->
+      case filter.id do
+        "selective_testing_hit" ->
+          %{filter | value: if(filter.value, do: Atom.to_string(filter.value))}
+
+        _ ->
+          filter
+      end
+    end)
+    |> Filter.Operations.convert_filters_to_flop()
   end
 
   defp build_binary_cache_flop_filters(filters) do

--- a/server/lib/tuist_web/live/test_run_live.html.heex
+++ b/server/lib/tuist_web/live/test_run_live.html.heex
@@ -1708,6 +1708,8 @@
       expanded_target_names={@expanded_target_names}
       uri={@uri}
       run={@command_event}
+      available_filters={@selective_testing_available_filters}
+      selective_testing_active_filters={@selective_testing_active_filters}
     />
   </div>
 

--- a/server/priv/marketing/changelog/2026.05.12-selective-testing-hit-filter.md
+++ b/server/priv/marketing/changelog/2026.05.12-selective-testing-hit-filter.md
@@ -1,0 +1,7 @@
+---
+title: Filter Selective Testing by hit
+category: "Product"
+pull_request: 10747
+---
+
+The Selective Testing tab on test run and run detail pages now has a Hit filter next to the search box, matching the existing Module Cache experience. Narrow the table to Local hits, Remote hits, or Misses to quickly see which test modules actually ran and which were skipped thanks to selective testing.

--- a/server/test/tuist_web/live/run_detail_live_test.exs
+++ b/server/test/tuist_web/live/run_detail_live_test.exs
@@ -148,6 +148,76 @@ defmodule TuistWeb.RunDetailLiveTest do
       assert has_element?(lv, ".noora-button", "Download result")
     end
 
+    test "filters selective testing modules by hit", %{
+      conn: conn,
+      organization: organization,
+      project: project,
+      user: user
+    } do
+      # Given
+      test_run =
+        CommandEventsFixtures.command_event_fixture(
+          project: project,
+          name: "test",
+          command_arguments: ["test", "App"],
+          test_targets: ["AppTests", "FrameworkTests", "UtilsTests"],
+          user_id: user.id
+        )
+
+      xcode_graph = XcodeFixtures.xcode_graph_fixture(command_event_id: test_run.id)
+
+      xcode_project =
+        XcodeFixtures.xcode_project_fixture(xcode_graph_id: xcode_graph.id)
+
+      _local =
+        XcodeFixtures.xcode_target_fixture(
+          name: "AppTests",
+          xcode_project_id: xcode_project.id,
+          selective_testing_hash: "AppTests-hash",
+          selective_testing_hit: :local
+        )
+
+      _remote =
+        XcodeFixtures.xcode_target_fixture(
+          name: "FrameworkTests",
+          xcode_project_id: xcode_project.id,
+          selective_testing_hash: "FrameworkTests-hash",
+          selective_testing_hit: :remote
+        )
+
+      _miss =
+        XcodeFixtures.xcode_target_fixture(
+          name: "UtilsTests",
+          xcode_project_id: xcode_project.id,
+          selective_testing_hash: "UtilsTests-hash",
+          selective_testing_hit: :miss
+        )
+
+      # When (no filter)
+      {:ok, lv, _html} =
+        live(
+          conn,
+          ~p"/#{organization.account.name}/#{project.name}/runs/#{test_run.id}?tab=test-optimizations"
+        )
+
+      # Then all three modules are listed
+      assert has_element?(lv, "#selective-testing-table span", "AppTests")
+      assert has_element?(lv, "#selective-testing-table span", "FrameworkTests")
+      assert has_element?(lv, "#selective-testing-table span", "UtilsTests")
+
+      # When filtering by :miss
+      {:ok, lv, _html} =
+        live(
+          conn,
+          ~p"/#{organization.account.name}/#{project.name}/runs/#{test_run.id}?tab=test-optimizations&filter_selective_testing_hit_op===&filter_selective_testing_hit_val=miss"
+        )
+
+      # Then only the miss module is listed
+      refute has_element?(lv, "#selective-testing-table span", "AppTests")
+      refute has_element?(lv, "#selective-testing-table span", "FrameworkTests")
+      assert has_element?(lv, "#selective-testing-table span", "UtilsTests")
+    end
+
     test "does not show download result button when not available", %{
       conn: conn,
       organization: organization,


### PR DESCRIPTION
## Summary
- Adds a Hit filter dropdown (Local / Remote / Missed) to the Selective Testing card on test run and run detail pages, matching the Module Cache filter pattern.
- Disables the cacheable-targets summary chart animation so it no longer re-animates on every filter change.

Requested on Slack as a parity feature with the Module Cache tab.

<img width="2984" height="1640" alt="2026-05-12 16 43 24" src="https://github.com/user-attachments/assets/494b625b-0d74-447a-b37e-81b79ab1e77b" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)