### PR TITLE
fix(cli): upload skipped selective test runs

### DIFF
--- a/cli/Sources/TuistKit/Services/TestService.swift
+++ b/cli/Sources/TuistKit/Services/TestService.swift
@@ -429,7 +429,12 @@ public struct TestService { // swiftlint:disable:this type_body_length
                         testPlanConfiguration: testPlanConfiguration,
                         action: action
                     )
-                    try await outputEmptyShardMatrixIfNeeded(isSharding: isSharding, action: action)
+                    try await finishEarlyWithNoTests(
+                        isSharding: isSharding,
+                        action: action,
+                        schemeName: scheme.name,
+                        config: config
+                    )
                     return
                 } else {
                     throw TestServiceError.schemeNotFound(
@@ -458,14 +463,24 @@ public struct TestService { // swiftlint:disable:this type_body_length
                     level: .info,
                     "The scheme \(schemeName)'s test action has no tests to run, finishing early."
                 )
-                try await outputEmptyShardMatrixIfNeeded(isSharding: isSharding, action: action)
+                try await finishEarlyWithNoTests(
+                    isSharding: isSharding,
+                    action: action,
+                    schemeName: scheme.name,
+                    config: config
+                )
                 return
             case (_?, _, true), (_?, _, nil):
                 Logger.current.log(
                     level: .info,
                     "The scheme \(schemeName)'s test action has no test plans to run, finishing early."
                 )
-                try await outputEmptyShardMatrixIfNeeded(isSharding: isSharding, action: action)
+                try await finishEarlyWithNoTests(
+                    isSharding: isSharding,
+                    action: action,
+                    schemeName: testPlanConfiguration?.testPlan ?? scheme.name,
+                    config: config
+                )
                 return
             default:
                 break
@@ -491,16 +506,12 @@ public struct TestService { // swiftlint:disable:this type_body_length
             requestedTestTargets: testTargets,
             passthroughXcodeBuildArguments: passthroughXcodeBuildArguments
         ) {
-            if action == .build {
-                try await outputEmptyShardMatrixIfNeeded(isSharding: isSharding, action: action)
-            } else {
-                let timer = clock.startTimer()
-                try await uploadSkippedTestSummary(
-                    schemeName: schemes.first?.name,
-                    config: config,
-                    timer: timer
-                )
-            }
+            try await finishEarlyWithNoTests(
+                isSharding: isSharding,
+                action: action,
+                schemeName: schemes.first?.name,
+                config: config
+            )
             return
         }
 
@@ -1282,6 +1293,24 @@ public struct TestService { // swiftlint:disable:this type_body_length
         }
     }
 
+    private func finishEarlyWithNoTests(
+        isSharding: Bool,
+        action: XcodeBuildTestAction,
+        schemeName: String?,
+        config: Tuist
+    ) async throws {
+        if action == .build {
+            try await outputEmptyShardMatrixIfNeeded(isSharding: isSharding, action: action)
+        } else {
+            let timer = clock.startTimer()
+            try await uploadSkippedTestSummary(
+                schemeName: schemeName,
+                config: config,
+                timer: timer
+            )
+        }
+    }
+
     private func shouldRunTest(
         for schemes: [Scheme],
         testPlanConfiguration: TestPlanConfiguration?,
@@ -1811,7 +1840,7 @@ public struct TestService { // swiftlint:disable:this type_body_length
 
         let testSummary = TestSummary(
             testPlanName: schemeName,
-            status: .passed,
+            status: .skipped,
             duration: durationInMs,
             testModules: []
         )

--- a/cli/Tests/TuistKitTests/Services/TestServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/TestServiceTests.swift
@@ -1086,6 +1086,104 @@ final class TestServiceTests: TuistUnitTestCase {
         }
     }
 
+    func test_uploads_skipped_test_run_when_scheme_is_in_initial_graph_only() async throws {
+        try await withMockedDependencies {
+            // Given
+            givenGenerator()
+            var environment = MapperEnvironment()
+            environment.initialGraph = .test(
+                projects: [
+                    try temporaryPath(): .test(schemes: [.test(name: "ProjectSchemeOne")]),
+                ]
+            )
+            given(configLoader)
+                .loadConfig(path: .any)
+                .willReturn(.test(project: .testGeneratedProject(), fullHandle: "tuist/tuist"))
+            given(generator)
+                .generateWithGraph(path: .any, options: .any)
+                .willProduce { path, _ in
+                    (
+                        path,
+                        .test(),
+                        environment
+                    )
+                }
+            given(createTestService)
+                .createTest(
+                    fullHandle: .any,
+                    serverURL: .any,
+                    id: .any,
+                    testSummary: .any,
+                    buildRunId: .any,
+                    gitBranch: .any,
+                    gitCommitSHA: .any,
+                    gitRef: .any,
+                    gitRemoteURLOrigin: .any,
+                    isCI: .any,
+                    modelIdentifier: .any,
+                    macOSVersion: .any,
+                    xcodeVersion: .any,
+                    ciRunId: .any,
+                    ciProjectHandle: .any,
+                    ciHost: .any,
+                    ciProvider: .any,
+                    shardPlanId: .any,
+                    shardIndex: .any
+                )
+                .willReturn(
+                    Components.Schemas.RunsTest(
+                        duration: 0,
+                        id: "skipped-test-run-id",
+                        project_id: 0,
+                        test_case_runs: [],
+                        _type: .test,
+                        url: ""
+                    )
+                )
+            given(xcodebuildController)
+                .version()
+                .willReturn(Version(16, 0, 0))
+
+            // When
+            try await testRun(
+                schemeName: "ProjectSchemeOne",
+                path: try temporaryPath()
+            )
+
+            // Then
+            XCTAssertEmpty(testedSchemes)
+            verify(createTestService)
+                .createTest(
+                    fullHandle: .value("tuist/tuist"),
+                    serverURL: .value(URL(string: "https://tuist.dev")!),
+                    id: .value(nil),
+                    testSummary: .matching { summary in
+                        summary.testPlanName == "ProjectSchemeOne"
+                            && summary.status == .skipped
+                            && summary.testModules.isEmpty
+                    },
+                    buildRunId: .value(nil),
+                    gitBranch: .any,
+                    gitCommitSHA: .any,
+                    gitRef: .any,
+                    gitRemoteURLOrigin: .any,
+                    isCI: .value(false),
+                    modelIdentifier: .any,
+                    macOSVersion: .any,
+                    xcodeVersion: .any,
+                    ciRunId: .any,
+                    ciProjectHandle: .any,
+                    ciHost: .any,
+                    ciProvider: .any,
+                    shardPlanId: .value(nil),
+                    shardIndex: .value(nil)
+                )
+                .called(1)
+            let testRunId = await runMetadataStorage.testRunId
+            XCTAssertEqual(testRunId, "skipped-test-run-id")
+        }
+    }
+
     func test_skips_running_tests_when_all_tests_are_cached() async throws {
         try await withMockedDependencies {
             // Given


### PR DESCRIPTION
## Summary
- create skipped test runs when selective testing exits before xcodebuild because no tests remain
- share one early-exit path for non-build no-test cases while keeping shard build empty-matrix behavior
- mark synthetic no-test summaries as skipped so they appear correctly in Test Runs

## Testing
- `git diff --check -- cli/Sources/TuistKit/Services/TestService.swift cli/Tests/TuistKitTests/Services/TestServiceTests.swift`
- `xcrun swiftc -parse cli/Tests/TuistKitTests/Services/TestServiceTests.swift`
- `swift test --replace-scm-with-registry --filter TestServiceTests/test_uploads_skipped_test_run_when_scheme_is_in_initial_graph_only` (builds, but SwiftPM reports `No matching test cases were run` because `TuistKitTests` is Xcode-workspace-only)