### PR TITLE
fix(server): build noora assets with aube

### DIFF
--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -249,8 +249,7 @@ jobs:
         working-directory: noora
         run: |
           aube install
-          npx esbuild js/index.js --bundle --minify --sourcemap --format=esm --outfile=./priv/static/noora.js
-          npx esbuild css/noora.css --bundle --minify --sourcemap --outfile=./priv/static/noora.css
+          aube run build
       - name: Install esbuild
         run: mix esbuild.install
       - name: Check esbuild output

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -51,8 +51,7 @@ RUN --mount=type=cache,id=aube,target=/aube-data/aube aube install --frozen-lock
 COPY noora /noora
 WORKDIR /noora
 RUN --mount=type=cache,id=aube,target=/aube-data/aube aube install
-RUN npx esbuild js/index.js --bundle --minify --sourcemap --format=esm --outfile=./priv/static/noora.js && \
-    npx esbuild css/noora.css --bundle --minify --sourcemap --outfile=./priv/static/noora.css
+RUN aube run build
 WORKDIR /app
 
 # ========================================


### PR DESCRIPTION
Summary: Use Noora's Aube build script in the production image Dockerfile and server esbuild workflow instead of direct npx esbuild calls. Verification: git diff --check passed; Docker was not available locally.