### PR TITLE
feat(server): isolate VCS comment worker on its own queue and dedupe

### DIFF
--- a/server/config/runtime.exs
+++ b/server/config/runtime.exs
@@ -434,7 +434,7 @@ otel_endpoint = Tuist.Environment.get([:otel, :exporter, :otlp, :endpoint])
 #     flags the server would race the processors on SKIP LOCKED, and
 #     on Linux the xcresult parse would crash because the macOS-only
 #     NIF isn't loaded.
-base_queues = [default: 10]
+base_queues = [default: 10, vcs_comments: 20]
 process_build_queue = {:process_build, Tuist.Environment.process_build_queue_concurrency()}
 process_xcresult_queue = {:process_xcresult, Tuist.Environment.process_xcresult_queue_concurrency()}
 

--- a/server/lib/tuist/vcs/workers/comment_worker.ex
+++ b/server/lib/tuist/vcs/workers/comment_worker.ex
@@ -5,7 +5,9 @@ defmodule Tuist.VCS.Workers.CommentWorker do
   This worker processes VCS comment generation asynchronously to improve
   API response times for the runs endpoint.
   """
-  use Oban.Worker
+  use Oban.Worker,
+    queue: :vcs_comments,
+    unique: [keys: [:project_id, :git_ref], states: [:available], period: :infinity]
 
   use Phoenix.VerifiedRoutes,
     endpoint: TuistWeb.Endpoint,

--- a/server/test/tuist/vcs/workers/comment_worker_test.exs
+++ b/server/test/tuist/vcs/workers/comment_worker_test.exs
@@ -109,7 +109,7 @@ defmodule Tuist.VCS.Workers.CommentWorkerTest do
       # Insert a competing job and set it to "executing" state
       {:ok, competing_job} =
         competing_job_args
-        |> CommentWorker.new(queue: "default")
+        |> CommentWorker.new()
         |> Tuist.Repo.insert()
 
       {:ok, competing_job} =


### PR DESCRIPTION
### Summary

The Oban dashboard was showing dozens of 16–17 minute old `Tuist.VCS.Workers.CommentWorker` jobs for the same PR piling up on the `default` queue (limit 10).

Two reasons:

1. The worker shared the `default` queue with every other default-queue job, so VCS comments were head-of-line blocked behind unrelated work.
2. The in-perform debounce in `cancel_competing_jobs/3` only cancels jobs already in the `executing` state. Duplicates that landed in `available` were never collapsed, so multi-endpoint fan-out (builds, tests, analytics, previews, bundles) for one PR stacked up.

This PR:

- Adds a dedicated `:vcs_comments` Oban queue at concurrency 20 in `base_queues`. Available to web/server pods and self-hosted installs; processor-only modes still get their narrow queue lists.
- Sets `unique: [keys: [:project_id, :git_ref], states: [:available], period: :infinity]` on `CommentWorker`. Duplicates collapse at enqueue time once the first job is `:available`, without affecting `:scheduled` jobs (those still need their post-flush delay honored) and without overlapping the existing `:executing` debounce logic.

### How to test locally

- Run the worker tests: `mix test test/tuist/vcs/workers/comment_worker_test.exs`
- Boot the server and trigger several endpoints in quick succession against the same PR (e.g. build + test + bundle uploads). In the Oban dashboard, confirm:
  - New jobs land on the `vcs_comments` queue.
  - Repeated enqueues for the same `project_id` + `git_ref` while a job is `available` do not produce additional rows.