### PR TITLE
fix(kura): repair public load balancer exposure

### DIFF
--- a/.github/workflows/kura-controller-image.yml
+++ b/.github/workflows/kura-controller-image.yml
@@ -21,6 +21,23 @@ env:
   IMAGE_NAME: tuist/kura-controller
 
 jobs:
+  format:
+    runs-on: namespace-profile-default
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: infra/kura-controller/go.mod
+          cache-dependency-path: infra/kura-controller/go.sum
+      - name: Check formatting
+        working-directory: infra/kura-controller
+        run: |
+          files="$(gofmt -l .)"
+          if [ -n "$files" ]; then
+            echo "$files"
+            exit 1
+          fi
+
   test:
     runs-on: namespace-profile-default
     steps:
@@ -37,7 +54,9 @@ jobs:
         run: go vet ./...
 
   build:
-    needs: test
+    needs:
+      - format
+      - test
     if: github.event_name != 'pull_request'
     runs-on: namespace-profile-default
     steps:

--- a/infra/helm/platform/values.yaml
+++ b/infra/helm/platform/values.yaml
@@ -63,6 +63,9 @@ external-dns:
   sources:
     - service
     - ingress
+  # Must be unique per workload cluster because several managed clusters
+  # write records under tuist.dev. The bootstrap task overrides this with
+  # "<cluster-name>-platform".
   txtOwnerId: tuist-platform
   # Limit which records external-dns will touch; be explicit for prod safety.
   domainFilters:

--- a/infra/kura-controller/controllers/kurainstance_controller.go
+++ b/infra/kura-controller/controllers/kurainstance_controller.go
@@ -29,11 +29,11 @@ import (
 const (
 	KuraInstanceFinalizer = "kurainstances.kura.tuist.dev/finalizer"
 
-	httpPort          int32 = 4000
-	httpsPort         int32 = 443
-	httpsTargetPort   int32 = 4443
-	grpcPort          int32 = 50051
-	peerPort          int32 = 7443
+	httpPort        int32 = 4000
+	httpsPort       int32 = 443
+	httpsTargetPort int32 = 4443
+	grpcPort        int32 = 50051
+	peerPort        int32 = 7443
 
 	// drainCompletionTimeoutMs and preStopDelaySeconds together set how
 	// long a Kura pod is given to bleed connections off before SIGTERM.
@@ -476,15 +476,15 @@ func podTemplate(instance *kurav1alpha1.KuraInstance) corev1.PodTemplateSpec {
 				Name:            "kura",
 				Image:           instance.Spec.Image,
 				ImagePullPolicy: corev1.PullIfNotPresent,
-				Ports: containerPorts(instance),
-				Env:            append(baseEnv(instance), instance.Spec.ExtraEnv...),
-				EnvFrom:        sharedSecretsEnvFrom(),
-				Resources:      defaultResources(),
-				VolumeMounts:   volumeMounts(instance),
-				Lifecycle:      preStopLifecycle(),
-				ReadinessProbe: httpProbe("/ready", 5, 10),
-				LivenessProbe:  httpProbe("/up", 20, 20),
-				StartupProbe:   httpProbe("/up", 0, 10),
+				Ports:           containerPorts(instance),
+				Env:             append(baseEnv(instance), instance.Spec.ExtraEnv...),
+				EnvFrom:         sharedSecretsEnvFrom(),
+				Resources:       defaultResources(),
+				VolumeMounts:    volumeMounts(instance),
+				Lifecycle:       preStopLifecycle(),
+				ReadinessProbe:  httpProbe("/ready", 5, 10),
+				LivenessProbe:   httpProbe("/up", 20, 20),
+				StartupProbe:    httpProbe("/up", 0, 10),
 			}},
 			Volumes: volumes(instance),
 		},
@@ -540,25 +540,21 @@ func defaultResources() corev1.ResourceRequirements {
 // publicServiceAnnotations returns the Hetzner Cloud LoadBalancer
 // annotations for the public Service. The LB runs in tcp-passthrough
 // mode and TLS is terminated inside the Kura pod from a cert-manager-
-// issued Secret. Health checks talk plain HTTP to the pod's HTTP port
-// because cluster DNS for kura.tuist.dev sits on Cloudflare and the
-// previous Hetzner-managed-certificate flow could not validate against
-// a zone Hetzner does not own.
+// issued Secret. Health checks use TCP against the Service NodePort
+// because Hetzner targets nodes, not pods; HTTP health checks would
+// speak cleartext to the TLS passthrough port.
 func publicServiceAnnotations(instance *kurav1alpha1.KuraInstance) map[string]string {
 	if instance.Spec.PublicHost == "" {
 		return nil
 	}
 
 	return map[string]string{
-		"external-dns.alpha.kubernetes.io/hostname":          instance.Spec.PublicHost,
-		"load-balancer.hetzner.cloud/name":                   instance.Name,
-		"load-balancer.hetzner.cloud/protocol":               "tcp",
-		"load-balancer.hetzner.cloud/algorithm-type":         "least_connections",
-		"load-balancer.hetzner.cloud/node-selector":          "node.cluster.x-k8s.io/pool=kura",
-		"load-balancer.hetzner.cloud/health-check-protocol":  "http",
-		"load-balancer.hetzner.cloud/health-check-port":      strconv.Itoa(int(httpPort)),
-		"load-balancer.hetzner.cloud/health-check-http-path": "/ready",
-		"load-balancer.hetzner.cloud/http-status-codes":      "200",
+		"external-dns.alpha.kubernetes.io/hostname":         instance.Spec.PublicHost,
+		"load-balancer.hetzner.cloud/name":                  instance.Name,
+		"load-balancer.hetzner.cloud/protocol":              "tcp",
+		"load-balancer.hetzner.cloud/algorithm-type":        "least_connections",
+		"load-balancer.hetzner.cloud/node-selector":         "node.cluster.x-k8s.io/pool=kura",
+		"load-balancer.hetzner.cloud/health-check-protocol": "tcp",
 	}
 }
 
@@ -568,15 +564,12 @@ func grpcServiceAnnotations(instance *kurav1alpha1.KuraInstance) map[string]stri
 	}
 
 	return map[string]string{
-		"external-dns.alpha.kubernetes.io/hostname":            instance.Spec.GRPCPublicHost,
-		"load-balancer.hetzner.cloud/name":                     grpcServiceName(instance),
-		"load-balancer.hetzner.cloud/protocol":                 "tcp",
-		"load-balancer.hetzner.cloud/algorithm-type":           "least_connections",
-		"load-balancer.hetzner.cloud/node-selector":            "node.cluster.x-k8s.io/pool=kura",
-		"load-balancer.hetzner.cloud/health-check-protocol":    "http",
-		"load-balancer.hetzner.cloud/health-check-port":        strconv.Itoa(int(httpPort)),
-		"load-balancer.hetzner.cloud/health-check-http-path":   "/ready",
-		"load-balancer.hetzner.cloud/http-status-codes":        "200",
+		"external-dns.alpha.kubernetes.io/hostname":         instance.Spec.GRPCPublicHost,
+		"load-balancer.hetzner.cloud/name":                  grpcServiceName(instance),
+		"load-balancer.hetzner.cloud/protocol":              "tcp",
+		"load-balancer.hetzner.cloud/algorithm-type":        "least_connections",
+		"load-balancer.hetzner.cloud/node-selector":         "node.cluster.x-k8s.io/pool=kura",
+		"load-balancer.hetzner.cloud/health-check-protocol": "tcp",
 	}
 }
 
@@ -604,15 +597,24 @@ func (r *KuraInstanceReconciler) reconcileNetworkPolicy(ctx context.Context, ins
 				},
 			},
 			{
-				// LoadBalancer / Hetzner LB health probes and the
-				// Tuist server's pod-list calls. Limit to in-cluster
-				// peers without further restriction; the JWT layer in
-				// the runtime is the auth boundary.
+				// Tuist server pod-list calls and internal health
+				// checks. Limit plain HTTP and plaintext gRPC to
+				// in-cluster peers; the JWT layer in the runtime is
+				// the auth boundary.
 				From: []networkingv1.NetworkPolicyPeer{
 					{NamespaceSelector: &metav1.LabelSelector{}},
 				},
 				Ports: []networkingv1.NetworkPolicyPort{
 					{Port: ptr(intstr.FromString("http")), Protocol: ptr(corev1.ProtocolTCP)},
+					{Port: ptr(intstr.FromString("grpc")), Protocol: ptr(corev1.ProtocolTCP)},
+				},
+			},
+			{
+				// Public LoadBalancer traffic. With externalTrafficPolicy=Local
+				// the original client/LB source IP is preserved, so these ports
+				// need an explicit all-sources rule.
+				Ports: []networkingv1.NetworkPolicyPort{
+					{Port: ptr(intstr.FromString("https")), Protocol: ptr(corev1.ProtocolTCP)},
 					{Port: ptr(intstr.FromString("grpc")), Protocol: ptr(corev1.ProtocolTCP)},
 				},
 			},

--- a/infra/kura-controller/controllers/kurainstance_controller_test.go
+++ b/infra/kura-controller/controllers/kurainstance_controller_test.go
@@ -79,8 +79,11 @@ func TestKuraInstanceReconcileCreatesWorkloadResources(t *testing.T) {
 	if _, ok := service.Annotations["load-balancer.hetzner.cloud/certificate-type"]; ok {
 		t.Fatal("expected managed-cert annotations to be dropped now that cert-manager issues the public cert")
 	}
-	if got := service.Annotations["load-balancer.hetzner.cloud/health-check-port"]; got != "4000" {
-		t.Fatalf("expected health check to target the plain HTTP port, got %q", got)
+	if got := service.Annotations["load-balancer.hetzner.cloud/health-check-protocol"]; got != "tcp" {
+		t.Fatalf("expected health check to use TCP against the passthrough NodePort, got %q", got)
+	}
+	if _, ok := service.Annotations["load-balancer.hetzner.cloud/health-check-port"]; ok {
+		t.Fatal("expected health check port annotation to be omitted so Hetzner probes the Service NodePort")
 	}
 
 	publicCert := &unstructured.Unstructured{}
@@ -248,6 +251,22 @@ func TestKuraInstanceReconcileCreatesWorkloadResources(t *testing.T) {
 	if got := policy.Spec.PodSelector.MatchLabels["app.kubernetes.io/instance"]; got != instance.Name {
 		t.Fatalf("expected NetworkPolicy to select this instance's pods, got %q", got)
 	}
+	if len(policy.Spec.Ingress) != 3 {
+		t.Fatalf("expected NetworkPolicy to have 3 ingress rules, got %d", len(policy.Spec.Ingress))
+	}
+	publicPorts := policy.Spec.Ingress[2].Ports
+	if len(policy.Spec.Ingress[2].From) != 0 {
+		t.Fatalf("expected public NetworkPolicy rule to allow all sources, got %v", policy.Spec.Ingress[2].From)
+	}
+	if len(publicPorts) != 2 {
+		t.Fatalf("expected public NetworkPolicy rule to expose HTTPS and gRPC, got %d ports", len(publicPorts))
+	}
+	if got := publicPorts[0].Port.StrVal; got != "https" {
+		t.Fatalf("expected public NetworkPolicy rule to expose https, got %q", got)
+	}
+	if got := publicPorts[1].Port.StrVal; got != "grpc" {
+		t.Fatalf("expected public NetworkPolicy rule to expose grpc, got %q", got)
+	}
 }
 
 func TestKuraInstanceReconcileExposesGRPCWhenHostSet(t *testing.T) {
@@ -292,6 +311,9 @@ func TestKuraInstanceReconcileExposesGRPCWhenHostSet(t *testing.T) {
 	}
 	if grpcService.Annotations["load-balancer.hetzner.cloud/protocol"] != "tcp" {
 		t.Fatalf("expected Hetzner LB tcp passthrough for gRPC, got %q", grpcService.Annotations["load-balancer.hetzner.cloud/protocol"])
+	}
+	if got := grpcService.Annotations["load-balancer.hetzner.cloud/health-check-protocol"]; got != "tcp" {
+		t.Fatalf("expected gRPC health check to use TCP against the passthrough NodePort, got %q", got)
 	}
 	if grpcService.Annotations["external-dns.alpha.kubernetes.io/hostname"] != "grpc.tuist-eu-1.kura.tuist.dev" {
 		t.Fatalf("expected gRPC external-dns hostname, got %q", grpcService.Annotations["external-dns.alpha.kubernetes.io/hostname"])

--- a/infra/mise/tasks/k8s/bootstrap-workload.sh
+++ b/infra/mise/tasks/k8s/bootstrap-workload.sh
@@ -251,6 +251,7 @@ KUBECONFIG="$WL_KUBECONFIG" helm upgrade --install platform "$REPO_ROOT/infra/he
   --namespace platform \
   -f "$REPO_ROOT/infra/helm/platform/values-hetzner.yaml" \
   --set "clusterIssuer.enabled=false" \
+  --set "external-dns.txtOwnerId=${CLUSTER_NAME}-platform" \
   --set "ingress-nginx.controller.service.annotations.load-balancer\.hetzner\.cloud/location=${REGION}" \
   --set "ingress-nginx.controller.service.annotations.load-balancer\.hetzner\.cloud/name=${CLUSTER_NAME}-ingress" \
   --wait --timeout 5m
@@ -260,6 +261,7 @@ KUBECONFIG="$WL_KUBECONFIG" kubectl wait --for=condition=Established crd/cluster
 KUBECONFIG="$WL_KUBECONFIG" helm upgrade --install platform "$REPO_ROOT/infra/helm/platform" \
   --namespace platform \
   -f "$REPO_ROOT/infra/helm/platform/values-hetzner.yaml" \
+  --set "external-dns.txtOwnerId=${CLUSTER_NAME}-platform" \
   --set "ingress-nginx.controller.service.annotations.load-balancer\.hetzner\.cloud/location=${REGION}" \
   --set "ingress-nginx.controller.service.annotations.load-balancer\.hetzner\.cloud/name=${CLUSTER_NAME}-ingress" \
   --wait --timeout 5m


### PR DESCRIPTION
## Summary

- Switch Kura Hetzner LoadBalancer health checks to TCP for the TCP passthrough HTTPS and gRPC services.
- Allow public HTTPS and gRPC traffic in the Kura NetworkPolicy while keeping plain HTTP limited to in-cluster peers.
- Make workload cluster bootstrap set a cluster-specific external-dns TXT owner id so managed clusters do not fight over records under `tuist.dev`.

## Root cause

Kura pods and cluster-internal routing were healthy, but Hetzner marked the public LoadBalancer targets unhealthy because it was probing HTTP `/ready` against the TLS passthrough NodePort. The NetworkPolicy also did not allow external-source traffic to the public TLS ports when `externalTrafficPolicy: Local` preserved the client or load balancer source IP.

## Validation

- `mise exec go@1.25.10 -- go test ./...` from `infra/kura-controller`
- Verified the live production workaround returns `HTTP 200` from `https://tuist-eu-central-1.kura.tuist.dev/up` and Hetzner marks the Kura HTTPS and gRPC targets healthy.