### PR TITLE
fix(noora): pin aube version in storybook Dockerfile

### DIFF
--- a/noora/storybook/Dockerfile
+++ b/noora/storybook/Dockerfile
@@ -20,7 +20,7 @@ ARG RUNNER_IMAGE="debian:${DEBIAN_VERSION}"
 
 FROM node:24-slim AS npm-deps
 ENV CI=1
-RUN npm install -g --ignore-scripts=false @endevco/aube
+RUN npm install -g --ignore-scripts=false @endevco/aube@1.6.2
 
 COPY package.json aube-lock.yaml /app/noora/
 COPY js/ /app/noora/js/


### PR DESCRIPTION
The Dockerfile installed @endevco/aube without a version pin, so each CI run picked up whatever was latest on npm. Recent aube releases (1.10+) execute esbuild's bin shim through Node, which fails with "SyntaxError: Invalid or unexpected token" because esbuild's postinstall replaces the shim with the platform-native binary.

Pin to 1.6.2 to match the version pinned in mise.lock for local dev.
