### PR TITLE
fix(server): normalize registry manifest versions

### DIFF
--- a/cache/lib/cache_web/controllers/registry_controller.ex
+++ b/cache/lib/cache_web/controllers/registry_controller.ex
@@ -399,10 +399,18 @@ defmodule CacheWeb.RegistryController do
 
   defp swift_version_candidates(swift_version) do
     Enum.uniq([
-      String.replace_trailing(swift_version, ".0.0", ""),
-      String.replace_trailing(swift_version, ".0", ""),
-      swift_version
+      swift_version,
+      strip_suffix_once(swift_version, ".0"),
+      strip_suffix_once(swift_version, ".0.0")
     ])
+  end
+
+  defp strip_suffix_once(string, suffix) do
+    if String.ends_with?(string, suffix) do
+      binary_part(string, 0, byte_size(string) - byte_size(suffix))
+    else
+      string
+    end
   end
 
   defp build_alternate_manifests_link(scope, name, version, manifests) do

--- a/cache/test/cache_web/controllers/registry_controller_test.exs
+++ b/cache/test/cache_web/controllers/registry_controller_test.exs
@@ -923,6 +923,80 @@ defmodule CacheWeb.RegistryControllerTest do
       assert link_header =~ "swift-version=5.9"
     end
 
+    test "serves two-component manifest from disk when three-component swift-version is requested", %{conn: conn} do
+      scope = "pointfreeco"
+      name = "swift-custom-dump"
+      version = "1.3.3"
+
+      stub(Registry.Disk, :exists?, fn
+        ^scope, ^name, ^version, "Package@swift-6.0.0.swift" -> false
+        ^scope, ^name, ^version, "Package@swift-6.0.swift" -> true
+        ^scope, ^name, ^version, "Package@swift-6.swift" -> false
+      end)
+
+      stub(S3, :exists?, fn _key, _opts -> false end)
+
+      expect(Registry.Disk, :local_accel_path, fn ^scope, ^name, ^version, "Package@swift-6.0.swift" ->
+        "/internal/local/registry/swift/pointfreeco/swift-custom-dump/1.3.3/Package@swift-6.0.swift"
+      end)
+
+      conn =
+        conn
+        |> registry_swift_conn()
+        |> get("/api/registry/swift/#{scope}/#{name}/#{version}/Package.swift?swift-version=6.0.0")
+
+      assert conn.status == 200
+      assert get_resp_header(conn, "content-version") == ["1"]
+
+      assert get_resp_header(conn, "x-accel-redirect") == [
+               "/internal/local/registry/swift/pointfreeco/swift-custom-dump/1.3.3/Package@swift-6.0.swift"
+             ]
+
+      assert get_resp_header(conn, "link") == []
+    end
+
+    test "serves two-component manifest from S3 when three-component swift-version is requested", %{conn: conn} do
+      scope = "pointfreeco"
+      name = "swift-custom-dump"
+      version = "1.3.3"
+
+      stub(Registry.Disk, :exists?, fn
+        ^scope, ^name, ^version, "Package@swift-6.0.0.swift" -> false
+        ^scope, ^name, ^version, "Package@swift-6.0.swift" -> false
+        ^scope, ^name, ^version, "Package@swift-6.swift" -> false
+      end)
+
+      stub(S3, :exists?, fn
+        key, _opts when is_binary(key) ->
+          String.ends_with?(key, "/Package@swift-6.0.swift")
+      end)
+
+      expect(S3Transfers, :enqueue_registry_download, fn _key -> {:ok, %{}} end)
+
+      expect(S3, :presign_download_url, fn _key, _opts ->
+        {:ok,
+         "https://s3.example.com/registry/swift/pointfreeco/swift-custom-dump/1.3.3/Package@swift-6.0.swift?signed=true"}
+      end)
+
+      expect(S3, :remote_accel_path, fn _url ->
+        "/internal/remote/https://s3.example.com/registry/swift/pointfreeco/swift-custom-dump/1.3.3/Package@swift-6.0.swift?signed=true"
+      end)
+
+      conn =
+        conn
+        |> registry_swift_conn()
+        |> get("/api/registry/swift/#{scope}/#{name}/#{version}/Package.swift?swift-version=6.0.0")
+
+      assert conn.status == 200
+      assert get_resp_header(conn, "content-version") == ["1"]
+
+      assert get_resp_header(conn, "x-accel-redirect") == [
+               "/internal/remote/https://s3.example.com/registry/swift/pointfreeco/swift-custom-dump/1.3.3/Package@swift-6.0.swift?signed=true"
+             ]
+
+      assert get_resp_header(conn, "link") == []
+    end
+
     test "redirects to default manifest when swift-version specified but not found", %{conn: conn} do
       scope = "apple"
       name = "swift-argument-parser"


### PR DESCRIPTION
## Summary

Fixes Swift registry manifest lookup when SwiftPM requests a three-component tools version such as `6.0.0` but the package publishes a two-component alternate manifest such as `Package@swift-6.0.swift`.

The previous implementation used `String.replace_trailing/3`, which trims repeated suffix matches. That made `6.0.0` collapse directly to `6`, skipping the compatible `6.0` candidate and causing the registry to fall back to a 303 redirect to the base manifest.

This PR changes the fallback candidate generation to trim one suffix at a time, so the registry checks `6.0.0`, then `6.0`, then `6`. It also adds regression coverage for both disk and S3-backed manifest serving, asserting the compatible manifest is served directly and no `Link` header is emitted on the specific manifest response.

## Validation

- `mise exec -- mix test test/cache_web/controllers/registry_controller_test.exs`
- `swift package --package-path Tuist --replace-scm-with-registry update --verbose` in `~/Downloads/TuistRegistrySample`
