### PR TITLE
chore(cli): enable Kura cache endpoints in mise

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -31,6 +31,7 @@
     # Elixir recommends half of the number of cores: https://elixir-lang.org/blog/2025/10/16/elixir-v1-19-0-released/
     MIX_OS_DEPS_COMPILE_PARTITION_COUNT=4
     TUIST_INSPECT_TEST_MODE = "remote"
+    TUIST_FEATURE_FLAG_KURA = "1"
     TUIST_HOSTED = "1"
     TUIST_S3_VIRTUAL_HOST = "1"
     TUIST_S3_BUCKET_AS_HOST = "1"


### PR DESCRIPTION
## Summary

- Set `TUIST_FEATURE_FLAG_KURA=1` in `mise.toml` so local mise sessions opt into Kura cache endpoint discovery.

## Validation

- `mise exec -- env | rg '^TUIST_FEATURE_FLAG_KURA='`\n- `mise exec -- bash -lc 'cd gradle && ./gradlew --stop && ./gradlew clean build --build-cache --info --no-daemon'`\n- `mise exec -- tuist cache warm --path examples/xcode/generated_ios_app_with_foreign_build_dependency`\n- `mise exec -- tuist generate --no-open --path examples/xcode/generated_ios_app_with_foreign_build_dependency App`\n- Explicit Kura probe: `PUT` returned `201` and `GET` returned `200` against `https://tuist-eu-central-1.kura.tuist.dev/api/cache/gradle/...` with matching payload SHA.