### PR TITLE
fix(ci): pin TruffleHog scanner image

### DIFF
--- a/.github/workflows/secret-scanning.yml
+++ b/.github/workflows/secret-scanning.yml
@@ -30,6 +30,7 @@ jobs:
         uses: trufflesecurity/trufflehog@v3.92.4
         continue-on-error: true
         with:
+          version: v3.92.4
           extra_args: --results=verified --json
       - name: Comment on PR
         if: steps.trufflehog.outcome == 'failure' && github.event_name == 'pull_request'
@@ -75,5 +76,5 @@ jobs:
       - name: Fail if secrets detected
         if: steps.trufflehog.outcome == 'failure'
         run: |
-          echo "::error::TruffleHog detected verified secrets in the codebase"
+          echo "::error::TruffleHog failed. Check the scan logs to distinguish verified secrets from scanner infrastructure errors."
           exit 1


### PR DESCRIPTION
## Summary

Pins the TruffleHog scanner image version used by the secret scanning workflow and updates the terminal failure message so scanner infrastructure failures are not reported as verified secrets.

## Root cause

The workflow pinned the GitHub Action to `trufflesecurity/trufflehog@v3.92.4`, but the action defaulted its Docker image input to `latest`. The failing run timed out while pulling `ghcr.io/trufflesecurity/trufflehog:latest`, then the follow-up step reported that as a verified secret detection.

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/secret-scanning.yml"); puts "YAML ok"'`\n