### PR TITLE
fix(server): expose Kura controls to ops

### DIFF
--- a/.blick/skills/tuist-elixir-review/SKILL.md
+++ b/.blick/skills/tuist-elixir-review/SKILL.md
@@ -334,6 +334,12 @@ controllers, templates, page CSS, settings pages, integration flows,
 alerts, reports, previews, build/test/cache/bundle analytics, or public
 API behavior that customers can observe.
 
+Do not treat a dashboard/UI change as announceable only because it lives
+in user-facing code. If the diff gates the behavior behind an
+account/org feature flag, ops/admin-only access, or an explicit internal
+rollout path, it is not ready for the product changelog unless the PR
+also makes that behavior broadly available to customers.
+
 When suggesting a fix, ask for a short marketing changelog entry with
 frontmatter like `title`, `category: "Product"`, and `pull_request`.
 Mention an accompanying image under
@@ -350,6 +356,9 @@ description or internal release notes instead.
 - Refactors, performance work, infrastructure, ops/admin-only paths,
   internal jobs, telemetry-only changes, tests, fixtures, or schema-only
   plumbing whose effect is not directly visible to customers.
+- Features gated behind account/org feature flags that are being used
+  for internal rollout or controlled access, unless the PR also makes
+  the feature generally available to customers.
 - Documentation-only or marketing-only PRs.
 - CLI/app/cache/kura/noora-only changes. This rule is for
   user-facing server/dashboard features.

--- a/.blick/skills/tuist-elixir-review/SKILL.md
+++ b/.blick/skills/tuist-elixir-review/SKILL.md
@@ -324,6 +324,10 @@ authors.
 - A PR that adds or materially changes a user-facing server/dashboard
   feature without also adding or updating a
   `server/priv/marketing/changelog/*.md` entry.
+- A PR that adds or updates a `server/priv/marketing/changelog/*.md`
+  entry for a feature that is ops-only, admin-only, feature-flagged only
+  for internal rollout, infrastructure-only, or otherwise not meant to
+  be announced to customers yet.
 
 User-facing signals include changed dashboard routes, LiveViews,
 controllers, templates, page CSS, settings pages, integration flows,
@@ -335,6 +339,10 @@ frontmatter like `title`, `category: "Product"`, and `pull_request`.
 Mention an accompanying image under
 `server/priv/static/marketing/images/changelog/` only when the feature
 has a visual dashboard/UI state worth showing.
+
+When flagging an inappropriate changelog entry, suggest removing the
+entry and, if the work still needs coordination, tracking it in the PR
+description or internal release notes instead.
 
 ### Do not flag
 

--- a/server/lib/tuist/authorization.ex
+++ b/server/lib/tuist/authorization.ex
@@ -160,8 +160,8 @@ defmodule Tuist.Authorization do
       desc("Allows the admin of an account to update its settings.")
       allow([:authenticated_as_user, user_role: :admin])
 
-      desc("Allows users with ops access to update any account's settings.")
-      allow([:authenticated_as_user, :ops_access])
+      desc("Allows users with ops write access to update any account's settings.")
+      allow([:authenticated_as_user, :ops_write_access])
     end
 
     action :delete do

--- a/server/lib/tuist/authorization.ex
+++ b/server/lib/tuist/authorization.ex
@@ -159,6 +159,9 @@ defmodule Tuist.Authorization do
     action :update do
       desc("Allows the admin of an account to update its settings.")
       allow([:authenticated_as_user, user_role: :admin])
+
+      desc("Allows users with ops access to update any account's settings.")
+      allow([:authenticated_as_user, :ops_access])
     end
 
     action :delete do

--- a/server/lib/tuist/authorization/checks.ex
+++ b/server/lib/tuist/authorization/checks.ex
@@ -206,6 +206,10 @@ defmodule Tuist.Authorization.Checks do
     false
   end
 
+  def ops_write_access(subject, object) do
+    ops_access(subject, object)
+  end
+
   def project_command_event_access(%User{} = user, %{project: %Project{} = project}) do
     user_role(user, project, :user)
   end

--- a/server/lib/tuist_web/live/account_settings_live.ex
+++ b/server/lib/tuist_web/live/account_settings_live.ex
@@ -10,7 +10,6 @@ defmodule TuistWeb.AccountSettingsLive do
   alias Tuist.Accounts.Account
   alias Tuist.Accounts.AccountCacheEndpoint
   alias Tuist.Authorization
-  alias Tuist.Environment
   alias Tuist.Kura
   alias Tuist.Kura.Regions
   alias Tuist.Kura.Server
@@ -30,7 +29,7 @@ defmodule TuistWeb.AccountSettingsLive do
     add_cache_endpoint_form = to_form(AccountCacheEndpoint.create_changeset(%{}))
     cache_endpoints = Accounts.list_account_cache_endpoints(selected_account)
     custom_cache_endpoints_available = Accounts.custom_cache_endpoints_available?(selected_account)
-    kura_enabled = kura_enabled?(selected_account)
+    kura_enabled = kura_enabled?(current_user)
     if connected?(socket) and kura_enabled, do: Kura.subscribe_to_account(selected_account.id)
 
     preferred_locale_form =
@@ -328,8 +327,8 @@ defmodule TuistWeb.AccountSettingsLive do
     |> assign(:add_kura_server_form, default_kura_server_form(available_regions))
   end
 
-  defp kura_enabled?(account) do
-    Environment.dev?() or FunWithFlags.enabled?(:kura, for: account)
+  defp kura_enabled?(current_user) do
+    Authorization.authorize(:ops_read, current_user) == :ok
   end
 
   defp available_kura_regions(regions, servers) do
@@ -536,41 +535,53 @@ defmodule TuistWeb.AccountSettingsLive do
         </.modal>
       </div>
       <div data-part="content">
-        <.table :if={Enum.any?(@kura_servers)} id="kura-servers-table" rows={@kura_servers}>
-          <:col :let={server} label={dgettext("dashboard_account", "Region")}>
-            <.text_cell label={kura_region_label(server.region)} />
+        <.table
+          :if={Enum.any?(@kura_servers) or Enum.any?(@available_kura_regions)}
+          id="kura-servers-table"
+          rows={kura_server_rows(@kura_servers, @available_kura_regions)}
+        >
+          <:col :let={row} label={dgettext("dashboard_account", "Region")}>
+            <.text_cell label={kura_region_label(kura_row_region_id(row))} />
           </:col>
-          <:col :let={server} label={dgettext("dashboard_account", "Status")}>
+          <:col :let={row} label={dgettext("dashboard_account", "Status")}>
             <.badge_cell
-              label={kura_display_status_label(server)}
-              color={kura_display_status_color(server)}
+              label={kura_row_status_label(row)}
+              color={kura_row_status_color(row)}
               style="light-fill"
             />
           </:col>
-          <:col :let={server} label={dgettext("dashboard_account", "Domain")}>
-            <.text_cell label={server.url || dgettext("dashboard_account", "Pending")} />
+          <:col :let={row} label={dgettext("dashboard_account", "Domain")}>
+            <.text_cell label={kura_row_domain_label(row)} />
           </:col>
-          <:col :let={server} label={dgettext("dashboard_account", "Version")}>
-            <.text_cell label={
-              kura_version_label(server.current_image_tag) || dgettext("dashboard_account", "Pending")
-            } />
+          <:col :let={row} label={dgettext("dashboard_account", "Version")}>
+            <.text_cell label={kura_row_version_label(row)} />
           </:col>
-          <:col :let={server} label="">
+          <:col :let={row} label="">
             <.button
-              :if={server.status not in [:destroying, :destroyed]}
+              :if={kura_row_server?(row) and row.server.status not in [:destroying, :destroyed]}
               type="button"
               label={dgettext("dashboard_account", "Destroy")}
               variant="destructive"
               size="small"
               phx-click="destroy_kura_server"
-              phx-value-id={server.id}
+              phx-value-id={row.server.id}
               data-confirm={
                 dgettext(
                   "dashboard_account",
                   "Destroy the Kura server in %{region}? This removes the account's Kura cache endpoint for that region.",
-                  region: server.region
+                  region: row.server.region
                 )
               }
+            />
+            <.button
+              :if={kura_row_available_region?(row)}
+              type="button"
+              label={dgettext("dashboard_account", "Deploy")}
+              variant="primary"
+              size="small"
+              phx-click="create_kura_server"
+              phx-value-region={row.region.id}
+              disabled={is_nil(@latest_kura_version)}
             />
           </:col>
         </.table>
@@ -578,6 +589,37 @@ defmodule TuistWeb.AccountSettingsLive do
     </.card_section>
     """
   end
+
+  defp kura_server_rows(servers, available_regions) do
+    Enum.map(servers, &%{type: :server, region_id: &1.region, server: &1}) ++
+      Enum.map(available_regions, &%{type: :available_region, region_id: &1.id, region: &1})
+  end
+
+  defp kura_row_region_id(row), do: row.region_id
+
+  defp kura_row_server?(%{type: :server}), do: true
+  defp kura_row_server?(_row), do: false
+
+  defp kura_row_available_region?(%{type: :available_region}), do: true
+  defp kura_row_available_region?(_row), do: false
+
+  defp kura_row_status_label(%{type: :server, server: server}), do: kura_display_status_label(server)
+  defp kura_row_status_label(%{type: :available_region}), do: dgettext("dashboard_account", "Not deployed")
+
+  defp kura_row_status_color(%{type: :server, server: server}), do: kura_display_status_color(server)
+  defp kura_row_status_color(%{type: :available_region}), do: "neutral"
+
+  defp kura_row_domain_label(%{type: :server, server: server}) do
+    server.url || dgettext("dashboard_account", "Pending")
+  end
+
+  defp kura_row_domain_label(%{type: :available_region}), do: dgettext("dashboard_account", "Pending")
+
+  defp kura_row_version_label(%{type: :server, server: server}) do
+    kura_version_label(server.current_image_tag) || dgettext("dashboard_account", "Pending")
+  end
+
+  defp kura_row_version_label(%{type: :available_region}), do: dgettext("dashboard_account", "Pending")
 
   def kura_display_status_label(server) do
     if show_deploying?(server),

--- a/server/lib/tuist_web/live/account_settings_live.ex
+++ b/server/lib/tuist_web/live/account_settings_live.ex
@@ -591,8 +591,13 @@ defmodule TuistWeb.AccountSettingsLive do
   end
 
   defp kura_server_rows(servers, available_regions) do
-    Enum.map(servers, &%{type: :server, region_id: &1.region, server: &1}) ++
-      Enum.map(available_regions, &%{type: :available_region, region_id: &1.id, region: &1})
+    Enum.map(servers, &%{id: "server-#{&1.id}", type: :server, region_id: &1.region, server: &1}) ++
+      Enum.map(available_regions, &%{
+        id: "available-region-#{&1.id}",
+        type: :available_region,
+        region_id: &1.id,
+        region: &1,
+      })
   end
 
   defp kura_row_region_id(row), do: row.region_id

--- a/server/lib/tuist_web/live/account_settings_live.ex
+++ b/server/lib/tuist_web/live/account_settings_live.ex
@@ -10,6 +10,7 @@ defmodule TuistWeb.AccountSettingsLive do
   alias Tuist.Accounts.Account
   alias Tuist.Accounts.AccountCacheEndpoint
   alias Tuist.Authorization
+  alias Tuist.Environment
   alias Tuist.Kura
   alias Tuist.Kura.Regions
   alias Tuist.Kura.Server
@@ -29,7 +30,7 @@ defmodule TuistWeb.AccountSettingsLive do
     add_cache_endpoint_form = to_form(AccountCacheEndpoint.create_changeset(%{}))
     cache_endpoints = Accounts.list_account_cache_endpoints(selected_account)
     custom_cache_endpoints_available = Accounts.custom_cache_endpoints_available?(selected_account)
-    kura_enabled = kura_enabled?(current_user)
+    kura_enabled = kura_enabled?(selected_account)
     if connected?(socket) and kura_enabled, do: Kura.subscribe_to_account(selected_account.id)
 
     preferred_locale_form =
@@ -327,8 +328,8 @@ defmodule TuistWeb.AccountSettingsLive do
     |> assign(:add_kura_server_form, default_kura_server_form(available_regions))
   end
 
-  defp kura_enabled?(current_user) do
-    Authorization.authorize(:ops_read, current_user) == :ok
+  defp kura_enabled?(account) do
+    Environment.dev?() or FunWithFlags.enabled?(:kura, for: account)
   end
 
   defp available_kura_regions(regions, servers) do
@@ -592,12 +593,15 @@ defmodule TuistWeb.AccountSettingsLive do
 
   defp kura_server_rows(servers, available_regions) do
     Enum.map(servers, &%{id: "server-#{&1.id}", type: :server, region_id: &1.region, server: &1}) ++
-      Enum.map(available_regions, &%{
-        id: "available-region-#{&1.id}",
-        type: :available_region,
-        region_id: &1.id,
-        region: &1,
-      })
+      Enum.map(
+        available_regions,
+        &%{
+          id: "available-region-#{&1.id}",
+          type: :available_region,
+          region_id: &1.id,
+          region: &1
+        }
+      )
   end
 
   defp kura_row_region_id(row), do: row.region_id

--- a/server/priv/AGENTS.md
+++ b/server/priv/AGENTS.md
@@ -5,10 +5,13 @@ This directory contains database migrations and other private assets.
 ## Responsibilities
 - PostgreSQL migrations: `server/priv/repo/migrations`
 - ClickHouse migrations: `server/priv/ingest_repo/migrations`
+- Marketing changelog entries: `server/priv/marketing/changelog`
 
 ## Guardrails
 - If you change stored customer data, update `server/data-export.md`.
 - Use `:timestamptz` for migration timestamps (per Credo rules).
+- Add marketing changelog entries only for customer-facing product changes that are ready to announce.
+- Do not add product changelog entries for ops-only, admin-only, internal rollout, infrastructure-only, or otherwise unannounced functionality.
 
 ## Related Context
 - Business logic: `server/lib/tuist/AGENTS.md`

--- a/server/priv/gettext/dashboard_account.pot
+++ b/server/priv/gettext/dashboard_account.pot
@@ -72,7 +72,7 @@ msgstr ""
 msgid "All members"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:682
+#: lib/tuist_web/live/account_settings_live.ex:728
 #, elixir-autogen, elixir-format
 msgid "All regions"
 msgstr ""
@@ -99,9 +99,9 @@ msgstr ""
 msgid "Billing email"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:500
-#: lib/tuist_web/live/account_settings_live.ex:754
-#: lib/tuist_web/live/account_settings_live.ex:841
+#: lib/tuist_web/live/account_settings_live.ex:504
+#: lib/tuist_web/live/account_settings_live.ex:800
+#: lib/tuist_web/live/account_settings_live.ex:887
 #: lib/tuist_web/live/account_settings_live.html.heex:76
 #: lib/tuist_web/live/account_settings_live.html.heex:150
 #: lib/tuist_web/live/account_settings_live.html.heex:232
@@ -124,7 +124,7 @@ msgstr ""
 msgid "Change your subscription to fit your needs."
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:666
+#: lib/tuist_web/live/account_settings_live.ex:712
 #, elixir-autogen, elixir-format
 msgid "Choose where your artifacts, like module cache binaries, are stored for legal compliance."
 msgstr ""
@@ -211,9 +211,9 @@ msgstr ""
 msgid "Decline"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:815
-#: lib/tuist_web/live/account_settings_live.ex:849
 #: lib/tuist_web/live/account_settings_live.ex:861
+#: lib/tuist_web/live/account_settings_live.ex:895
+#: lib/tuist_web/live/account_settings_live.ex:907
 #: lib/tuist_web/live/account_settings_live.html.heex:158
 #: lib/tuist_web/live/account_settings_live.html.heex:312
 #, elixir-autogen, elixir-format
@@ -355,7 +355,7 @@ msgstr ""
 msgid "Enterprise"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:683
+#: lib/tuist_web/live/account_settings_live.ex:729
 #, elixir-autogen, elixir-format
 msgid "Europe"
 msgstr ""
@@ -573,8 +573,10 @@ msgstr ""
 msgid "Payments for your subscription are made using the default card."
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:547
-#: lib/tuist_web/live/account_settings_live.ex:550
+#: lib/tuist_web/live/account_settings_live.ex:614
+#: lib/tuist_web/live/account_settings_live.ex:617
+#: lib/tuist_web/live/account_settings_live.ex:620
+#: lib/tuist_web/live/account_settings_live.ex:623
 #: lib/tuist_web/live/members_live.ex:279
 #, elixir-autogen, elixir-format
 msgid "Pending"
@@ -612,10 +614,10 @@ msgstr ""
 msgid "Pro"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:455
-#: lib/tuist_web/live/account_settings_live.ex:468
-#: lib/tuist_web/live/account_settings_live.ex:536
-#: lib/tuist_web/live/account_settings_live.ex:679
+#: lib/tuist_web/live/account_settings_live.ex:459
+#: lib/tuist_web/live/account_settings_live.ex:472
+#: lib/tuist_web/live/account_settings_live.ex:544
+#: lib/tuist_web/live/account_settings_live.ex:725
 #, elixir-autogen, elixir-format
 msgid "Region"
 msgstr ""
@@ -700,7 +702,7 @@ msgstr ""
 msgid "Search members..."
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:674
+#: lib/tuist_web/live/account_settings_live.ex:720
 #, elixir-autogen, elixir-format
 msgid "Select region"
 msgstr ""
@@ -731,13 +733,13 @@ msgstr ""
 msgid "Standard support: Via Slack and email"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:539
+#: lib/tuist_web/live/account_settings_live.ex:547
 #: lib/tuist_web/live/members_live.ex:277
 #, elixir-autogen, elixir-format
 msgid "Status"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:663
+#: lib/tuist_web/live/account_settings_live.ex:709
 #, elixir-autogen, elixir-format
 msgid "Storage region"
 msgstr ""
@@ -779,7 +781,7 @@ msgstr ""
 msgid "Tuist Logo"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:684
+#: lib/tuist_web/live/account_settings_live.ex:730
 #, elixir-autogen, elixir-format
 msgid "United States"
 msgstr ""
@@ -966,57 +968,57 @@ msgstr ""
 msgid "xxxx xxxx xxxx %{card_number}"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:762
+#: lib/tuist_web/live/account_settings_live.ex:808
 #, elixir-autogen, elixir-format
 msgid "Add"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:724
+#: lib/tuist_web/live/account_settings_live.ex:770
 #, elixir-autogen, elixir-format
 msgid "Add cache endpoint"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:731
+#: lib/tuist_web/live/account_settings_live.ex:777
 #, elixir-autogen, elixir-format
 msgid "Add endpoint"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:744
+#: lib/tuist_web/live/account_settings_live.ex:790
 #, elixir-autogen, elixir-format
 msgid "Endpoint URL"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:801
+#: lib/tuist_web/live/account_settings_live.ex:847
 #, elixir-autogen, elixir-format
 msgid "URL"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:808
+#: lib/tuist_web/live/account_settings_live.ex:854
 #, elixir-autogen, elixir-format
 msgid "Delete last cache endpoint?"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:828
+#: lib/tuist_web/live/account_settings_live.ex:874
 #, elixir-autogen, elixir-format
 msgid "Removing the last custom cache endpoint will switch your organization back to Tuist-hosted caching. This affects all builds across your organization."
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:706
+#: lib/tuist_web/live/account_settings_live.ex:752
 #, elixir-autogen, elixir-format
 msgid "Cache endpoints"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:710
+#: lib/tuist_web/live/account_settings_live.ex:756
 #, elixir-autogen, elixir-format
 msgid "Configure custom cache endpoints for self-hosted cache setups. When enabled, Tuist will read from and write to these endpoints instead of the default Tuist-hosted cache."
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:778
+#: lib/tuist_web/live/account_settings_live.ex:824
 #, elixir-autogen, elixir-format
 msgid "Custom cache endpoints are disabled. Tuist will use the default Tuist-hosted cache."
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:790
+#: lib/tuist_web/live/account_settings_live.ex:836
 #, elixir-autogen, elixir-format
 msgid "No custom cache endpoints configured. Tuist will use the default Tuist-hosted cache until endpoints are added."
 msgstr ""
@@ -1159,23 +1161,23 @@ msgstr ""
 msgid "What's the name of your company or team? You can change this later in the settings"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:618
+#: lib/tuist_web/live/account_settings_live.ex:664
 #, elixir-autogen, elixir-format
 msgid "Browser default"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:628
+#: lib/tuist_web/live/account_settings_live.ex:674
 #, elixir-autogen, elixir-format
 msgid "Choose your preferred dashboard language."
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:625
+#: lib/tuist_web/live/account_settings_live.ex:671
 #, elixir-autogen, elixir-format
 msgid "Dashboard language"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:633
-#: lib/tuist_web/live/account_settings_live.ex:638
+#: lib/tuist_web/live/account_settings_live.ex:679
+#: lib/tuist_web/live/account_settings_live.ex:684
 #, elixir-autogen, elixir-format
 msgid "Language"
 msgstr ""
@@ -1376,55 +1378,56 @@ msgstr ""
 msgid "Revoke token"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:589
+#: lib/tuist_web/live/account_settings_live.ex:638
 #, elixir-autogen, elixir-format
 msgid "Active"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:518
-#: lib/tuist_web/live/account_settings_live.ex:524
+#: lib/tuist_web/live/account_settings_live.ex:522
+#: lib/tuist_web/live/account_settings_live.ex:528
+#: lib/tuist_web/live/account_settings_live.ex:580
 #, elixir-autogen, elixir-format
 msgid "Deploy"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:432
-#: lib/tuist_web/live/account_settings_live.ex:439
+#: lib/tuist_web/live/account_settings_live.ex:436
+#: lib/tuist_web/live/account_settings_live.ex:443
 #, elixir-autogen, elixir-format
 msgid "Deploy Kura server"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:423
+#: lib/tuist_web/live/account_settings_live.ex:427
 #, elixir-autogen, elixir-format
 msgid "Deploy regional Kura cache servers for this account. Each region can have at most one server."
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:578
-#: lib/tuist_web/live/account_settings_live.ex:588
+#: lib/tuist_web/live/account_settings_live.ex:627
+#: lib/tuist_web/live/account_settings_live.ex:637
 #, elixir-autogen, elixir-format
 msgid "Deploying"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:370
+#: lib/tuist_web/live/account_settings_live.ex:374
 #, elixir-autogen, elixir-format
 msgid "Deploying Kura in %{region}..."
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:556
+#: lib/tuist_web/live/account_settings_live.ex:564
 #, elixir-autogen, elixir-format
 msgid "Destroy"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:562
+#: lib/tuist_web/live/account_settings_live.ex:570
 #, elixir-autogen, elixir-format
 msgid "Destroy the Kura server in %{region}? This removes the account's Kura cache endpoint for that region."
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:592
+#: lib/tuist_web/live/account_settings_live.ex:641
 #, elixir-autogen, elixir-format
 msgid "Destroyed"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:591
+#: lib/tuist_web/live/account_settings_live.ex:640
 #, elixir-autogen, elixir-format
 msgid "Destroying"
 msgstr ""
@@ -1434,23 +1437,23 @@ msgstr ""
 msgid "Destroying Kura server..."
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:546
+#: lib/tuist_web/live/account_settings_live.ex:554
 #, elixir-autogen, elixir-format
 msgid "Domain"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:590
+#: lib/tuist_web/live/account_settings_live.ex:639
 #, elixir-autogen, elixir-format
 msgid "Failed"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:380
-#: lib/tuist_web/live/account_settings_live.ex:389
+#: lib/tuist_web/live/account_settings_live.ex:384
+#: lib/tuist_web/live/account_settings_live.ex:393
 #, elixir-autogen, elixir-format
 msgid "Failed to deploy Kura: %{reason}"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:420
+#: lib/tuist_web/live/account_settings_live.ex:424
 #, elixir-autogen, elixir-format
 msgid "Kura cache servers"
 msgstr ""
@@ -1460,23 +1463,23 @@ msgstr ""
 msgid "Kura server not found."
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:487
+#: lib/tuist_web/live/account_settings_live.ex:491
 #, elixir-autogen, elixir-format
 msgid "New servers start on Kura"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:549
+#: lib/tuist_web/live/account_settings_live.ex:557
 #, elixir-autogen, elixir-format
 msgid "Version"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:489
+#: lib/tuist_web/live/account_settings_live.ex:493
 #, elixir-autogen, elixir-format
 msgid "(current deploy)."
 msgstr ""
 
 #: lib/tuist_web/live/account_settings_live.ex:252
-#: lib/tuist_web/live/account_settings_live.ex:482
+#: lib/tuist_web/live/account_settings_live.ex:486
 #, elixir-autogen, elixir-format
 msgid "No Kura runtime image is configured right now. Try again after the next server deploy."
 msgstr ""
@@ -1484,4 +1487,9 @@ msgstr ""
 #: lib/tuist_web/live/account_settings_live.ex:244
 #, elixir-autogen, elixir-format
 msgid "Select a Kura region before deploying."
+msgstr ""
+
+#: lib/tuist_web/live/account_settings_live.ex:608
+#, elixir-autogen, elixir-format
+msgid "Not deployed"
 msgstr ""

--- a/server/priv/marketing/changelog/2026.05.13-kura-cache-server-regions.md
+++ b/server/priv/marketing/changelog/2026.05.13-kura-cache-server-regions.md
@@ -1,7 +1,0 @@
----
-title: Manage Kura cache server regions
-category: "Product"
-pull_request: 10769
----
-
-Ops users can now manage Kura cache servers from account settings across every account. The Kura section shows deployed servers alongside regions that are not deployed yet, with a direct deploy action for each available region so expanding Kura coverage no longer requires leaving the settings page.

--- a/server/priv/marketing/changelog/2026.05.13-kura-cache-server-regions.md
+++ b/server/priv/marketing/changelog/2026.05.13-kura-cache-server-regions.md
@@ -1,0 +1,7 @@
+---
+title: Manage Kura cache server regions
+category: "Product"
+pull_request: 10769
+---
+
+Ops users can now manage Kura cache servers from account settings across every account. The Kura section shows deployed servers alongside regions that are not deployed yet, with a direct deploy action for each available region so expanding Kura coverage no longer requires leaving the settings page.

--- a/server/test/tuist/authorization/checks_test.exs
+++ b/server/test/tuist/authorization/checks_test.exs
@@ -523,4 +523,22 @@ defmodule Tuist.Authorization.ChecksTest do
       assert Checks.ops_access("string", nil) == false
     end
   end
+
+  describe "ops_write_access/2" do
+    test "returns true when user is in ops_user_handles", %{user: user} do
+      # Given
+      expect(Tuist.Environment, :ops_user_handles, fn -> [user.account.name] end)
+
+      # When/Then
+      assert Checks.ops_write_access(user, nil) == true
+    end
+
+    test "returns false when user is not in ops_user_handles", %{user: user} do
+      # Given
+      expect(Tuist.Environment, :ops_user_handles, fn -> ["other_user"] end)
+
+      # When/Then
+      assert Checks.ops_write_access(user, nil) == false
+    end
+  end
 end

--- a/server/test/tuist/authorization_test.exs
+++ b/server/test/tuist/authorization_test.exs
@@ -10,6 +10,26 @@ defmodule Tuist.AuthorizationTest do
   alias TuistTestSupport.Fixtures.CommandEventsFixtures
   alias TuistTestSupport.Fixtures.ProjectsFixtures
 
+  test "can.update.account when the subject has ops access" do
+    # Given
+    user = AccountsFixtures.user_fixture()
+    account = AccountsFixtures.organization_fixture(preload: [:account]).account
+    stub(Environment, :ops_user_handles, fn -> [user.account.name] end)
+
+    # When
+    assert Authorization.authorize(:account_update, user, account) == :ok
+  end
+
+  test "cannot.update.account when the subject is not an admin or ops user" do
+    # Given
+    user = AccountsFixtures.user_fixture()
+    account = AccountsFixtures.organization_fixture(preload: [:account]).account
+    stub(Environment, :ops_user_handles, fn -> [] end)
+
+    # When
+    assert Authorization.authorize(:account_update, user, account) == {:error, :forbidden}
+  end
+
   test "can.update.account.billing when the subject is the same account being read and it's on-premise" do
     # Given
     user = AccountsFixtures.user_fixture()

--- a/server/test/tuist_web/live/account_settings_live_test.exs
+++ b/server/test/tuist_web/live/account_settings_live_test.exs
@@ -54,6 +54,20 @@ defmodule TuistWeb.AccountSettingsLiveTest do
     end
   end
 
+  test "allows ops users to access settings for any account", %{conn: conn} do
+    organization =
+      AccountsFixtures.organization_fixture(preload: [:account])
+
+    user = AccountsFixtures.user_fixture()
+    stub(Environment, :ops_user_handles, fn -> [user.account.name] end)
+
+    conn = log_in_user(conn, user)
+
+    {:ok, _lv, html} = live(conn, ~p"/#{organization.account.name}/settings")
+
+    assert html =~ "Settings · #{organization.account.name} · Tuist"
+  end
+
   test "displays the 'Rename organization' button when the selected account is an organization",
        %{
          conn: conn,
@@ -78,14 +92,17 @@ defmodule TuistWeb.AccountSettingsLiveTest do
     assert has_element?(lv, "button", "Update username")
   end
 
-  test "does not render Kura controls without the account feature flag", %{conn: conn, account: account} do
+  test "does not render Kura controls for non-ops users", %{conn: conn, account: account} do
+    FunWithFlags.enable(:kura, for_actor: account)
+    stub(Environment, :ops_user_handles, fn -> [] end)
+
     {:ok, _lv, html} = live(conn, ~p"/#{account.name}/settings")
 
     refute html =~ "Kura cache servers"
   end
 
-  test "renders Kura controls when the account feature flag is enabled", %{conn: conn, account: account} do
-    FunWithFlags.enable(:kura, for_actor: account)
+  test "renders Kura controls for ops users", %{conn: conn, user: user, account: account} do
+    enable_ops_for(user)
     stub(Kura, :latest_versions, fn 1 -> [%{version: "0.5.2", released_at: DateTime.utc_now(:second)}] end)
 
     {:ok, lv, html} = live(conn, ~p"/#{account.name}/settings")
@@ -97,11 +114,12 @@ defmodule TuistWeb.AccountSettingsLiveTest do
     assert has_element?(lv, "button", "Deploy Kura server")
     assert html =~ "create_kura_server"
     assert html =~ ~s(phx-value-region="local-controller")
-    refute has_element?(lv, "#kura-servers-table")
+    assert has_element?(lv, "#kura-servers-table")
+    assert html =~ "Not deployed"
   end
 
-  test "shows Kura server state, domain, and version", %{conn: conn, account: account} do
-    FunWithFlags.enable(:kura, for_actor: account)
+  test "shows Kura server state, domain, and version", %{conn: conn, user: user, account: account} do
+    enable_ops_for(user)
     stub(Kura, :latest_versions, fn 1 -> [%{version: "0.5.3", released_at: DateTime.utc_now(:second)}] end)
 
     {:ok, server} =
@@ -125,8 +143,12 @@ defmodule TuistWeb.AccountSettingsLiveTest do
     refute html =~ "kura@0.5.2"
   end
 
-  test "allows adding another managed Kura region when one is already deployed", %{conn: conn, account: account} do
-    FunWithFlags.enable(:kura, for_actor: account)
+  test "allows adding another managed Kura region when one is already deployed", %{
+    conn: conn,
+    user: user,
+    account: account
+  } do
+    enable_ops_for(user)
     stub(Environment, :dev?, fn -> false end)
     stub(Environment, :test?, fn -> false end)
     stub(Environment, :kura_available_region_ids, fn -> ["eu-central", "us-east", "us-west"] end)
@@ -145,11 +167,14 @@ defmodule TuistWeb.AccountSettingsLiveTest do
     refute html =~ "Hetzner"
     assert html =~ "US East"
     assert html =~ "US West"
+    assert html =~ "Not deployed"
+    assert html =~ ~s(phx-value-region="us-east")
+    assert html =~ ~s(phx-value-region="us-west")
     assert has_element?(lv, "button", "Deploy Kura server")
   end
 
-  test "keeps an active Kura server active during an in-flight deployment", %{conn: conn, account: account} do
-    FunWithFlags.enable(:kura, for_actor: account)
+  test "keeps an active Kura server active during an in-flight deployment", %{conn: conn, user: user, account: account} do
+    enable_ops_for(user)
     stub(Kura, :latest_versions, fn 1 -> [%{version: "0.5.3", released_at: DateTime.utc_now(:second)}] end)
 
     {:ok, server} =
@@ -172,8 +197,8 @@ defmodule TuistWeb.AccountSettingsLiveTest do
     refute html =~ "Deploying"
   end
 
-  test "deploys a Kura server from account settings", %{conn: conn, account: account} do
-    FunWithFlags.enable(:kura, for_actor: account)
+  test "deploys a Kura server from account settings", %{conn: conn, user: user, account: account} do
+    enable_ops_for(user)
     stub(Kura, :latest_versions, fn 1 -> [%{version: "0.5.2", released_at: DateTime.utc_now(:second)}] end)
 
     {:ok, lv, _html} = live(conn, ~p"/#{account.name}/settings")
@@ -187,8 +212,12 @@ defmodule TuistWeb.AccountSettingsLiveTest do
     assert [%{region: "local-controller", current_image_tag: nil}] = Kura.list_servers_for_account(account.id)
   end
 
-  test "deploys the only available Kura region when the portaled form omits inputs", %{conn: conn, account: account} do
-    FunWithFlags.enable(:kura, for_actor: account)
+  test "deploys the only available Kura region when the portaled form omits inputs", %{
+    conn: conn,
+    user: user,
+    account: account
+  } do
+    enable_ops_for(user)
     stub(Kura, :latest_versions, fn 1 -> [%{version: "0.5.2", released_at: DateTime.utc_now(:second)}] end)
 
     {:ok, lv, _html} = live(conn, ~p"/#{account.name}/settings")
@@ -196,5 +225,9 @@ defmodule TuistWeb.AccountSettingsLiveTest do
     _html = render_submit(lv, "create_kura_server", %{})
 
     assert [%{region: "local-controller", current_image_tag: nil}] = Kura.list_servers_for_account(account.id)
+  end
+
+  defp enable_ops_for(user) do
+    stub(Environment, :ops_user_handles, fn -> [user.account.name] end)
   end
 end

--- a/server/test/tuist_web/live/account_settings_live_test.exs
+++ b/server/test/tuist_web/live/account_settings_live_test.exs
@@ -92,17 +92,18 @@ defmodule TuistWeb.AccountSettingsLiveTest do
     assert has_element?(lv, "button", "Update username")
   end
 
-  test "does not render Kura controls for non-ops users", %{conn: conn, account: account} do
-    FunWithFlags.enable(:kura, for_actor: account)
+  test "does not render Kura controls when the account does not have Kura enabled", %{conn: conn, account: account} do
     stub(Environment, :ops_user_handles, fn -> [] end)
+    stub(Environment, :dev?, fn -> false end)
 
     {:ok, _lv, html} = live(conn, ~p"/#{account.name}/settings")
 
     refute html =~ "Kura cache servers"
   end
 
-  test "renders Kura controls for ops users", %{conn: conn, user: user, account: account} do
-    enable_ops_for(user)
+  test "renders Kura controls for Kura-enabled accounts", %{conn: conn, account: account} do
+    FunWithFlags.enable(:kura, for_actor: account)
+    stub(Environment, :dev?, fn -> false end)
     stub(Kura, :latest_versions, fn 1 -> [%{version: "0.5.2", released_at: DateTime.utc_now(:second)}] end)
 
     {:ok, lv, html} = live(conn, ~p"/#{account.name}/settings")
@@ -120,6 +121,8 @@ defmodule TuistWeb.AccountSettingsLiveTest do
 
   test "shows Kura server state, domain, and version", %{conn: conn, user: user, account: account} do
     enable_ops_for(user)
+    FunWithFlags.enable(:kura, for_actor: account)
+    stub(Environment, :dev?, fn -> false end)
     stub(Kura, :latest_versions, fn 1 -> [%{version: "0.5.3", released_at: DateTime.utc_now(:second)}] end)
 
     {:ok, server} =
@@ -149,6 +152,7 @@ defmodule TuistWeb.AccountSettingsLiveTest do
     account: account
   } do
     enable_ops_for(user)
+    FunWithFlags.enable(:kura, for_actor: account)
     stub(Environment, :dev?, fn -> false end)
     stub(Environment, :test?, fn -> false end)
     stub(Environment, :kura_available_region_ids, fn -> ["eu-central", "us-east", "us-west"] end)
@@ -175,6 +179,8 @@ defmodule TuistWeb.AccountSettingsLiveTest do
 
   test "keeps an active Kura server active during an in-flight deployment", %{conn: conn, user: user, account: account} do
     enable_ops_for(user)
+    FunWithFlags.enable(:kura, for_actor: account)
+    stub(Environment, :dev?, fn -> false end)
     stub(Kura, :latest_versions, fn 1 -> [%{version: "0.5.3", released_at: DateTime.utc_now(:second)}] end)
 
     {:ok, server} =
@@ -199,6 +205,8 @@ defmodule TuistWeb.AccountSettingsLiveTest do
 
   test "deploys a Kura server from account settings", %{conn: conn, user: user, account: account} do
     enable_ops_for(user)
+    FunWithFlags.enable(:kura, for_actor: account)
+    stub(Environment, :dev?, fn -> false end)
     stub(Kura, :latest_versions, fn 1 -> [%{version: "0.5.2", released_at: DateTime.utc_now(:second)}] end)
 
     {:ok, lv, _html} = live(conn, ~p"/#{account.name}/settings")
@@ -218,6 +226,8 @@ defmodule TuistWeb.AccountSettingsLiveTest do
     account: account
   } do
     enable_ops_for(user)
+    FunWithFlags.enable(:kura, for_actor: account)
+    stub(Environment, :dev?, fn -> false end)
     stub(Kura, :latest_versions, fn 1 -> [%{version: "0.5.2", released_at: DateTime.utc_now(:second)}] end)
 
     {:ok, lv, _html} = live(conn, ~p"/#{account.name}/settings")


### PR DESCRIPTION
## Summary

- Allow ops users to access settings for any account.
- Gate the Kura account settings section behind ops access only.
- Show undeployed Kura regions in the servers table with per-region deploy actions.

## Context

The Kura settings page only showed deployed servers, so there was no direct way to create a server in another available region once one region already existed. The section is also intended to stay ops-only until it is exposed to regular users later.

## Testing

- `git diff --check`

Could not complete the focused LiveView tests locally because the test database setup is blocked by duplicate migration version `20260512120000`. `mix deps.get --locked` also rewrites unrelated `cowboy` and `cowlib` lock entries in this worktree, so I left `server/mix.lock` unchanged.
