### PR TITLE
fix(kura): improve Grafana observability

### DIFF
--- a/.github/workflows/secret-scanning.yml
+++ b/.github/workflows/secret-scanning.yml
@@ -30,7 +30,7 @@ jobs:
         uses: trufflesecurity/trufflehog@v3.92.4
         continue-on-error: true
         with:
-          version: v3.92.4
+          version: 3.92.4
           extra_args: --results=verified --json
       - name: Comment on PR
         if: steps.trufflehog.outcome == 'failure' && github.event_name == 'pull_request'

--- a/infra/grafana-dashboards/tuist-kura.json
+++ b/infra/grafana-dashboards/tuist-kura.json
@@ -690,7 +690,7 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "sum by (result) (rate(kura_artifact_reads_total_total{instance=~\"${instance:regex}\", region=~\"${region:regex}\"}[$__rate_interval]))",
+            "expr": "sum by (result) (rate(kura_artifact_reads_total_total{cluster=\"kura-tuist\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"}[$__rate_interval]))",
             "legendFormat": "{{result}}",
             "refId": "A"
           }
@@ -756,7 +756,7 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "sum by (result) (rate(kura_artifact_writes_total_total{instance=~\"${instance:regex}\", region=~\"${region:regex}\"}[$__rate_interval]))",
+            "expr": "sum by (result) (rate(kura_artifact_writes_total_total{cluster=\"kura-tuist\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"}[$__rate_interval])) or on() label_replace(vector(0), \"result\", \"no_writes\", \"__name__\", \".*\")",
             "legendFormat": "{{result}}",
             "refId": "A"
           }
@@ -822,7 +822,7 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "sum by (producer) (rate(kura_artifact_reads_total_total{instance=~\"${instance:regex}\", region=~\"${region:regex}\"}[$__rate_interval]))",
+            "expr": "sum by (producer) (rate(kura_artifact_reads_total_total{cluster=\"kura-tuist\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"}[$__rate_interval]))",
             "legendFormat": "{{producer}}",
             "refId": "A"
           }
@@ -888,7 +888,7 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "sum by (producer) (rate(kura_artifact_writes_total_total{instance=~\"${instance:regex}\", region=~\"${region:regex}\"}[$__rate_interval]))",
+            "expr": "sum by (producer) (rate(kura_artifact_writes_total_total{cluster=\"kura-tuist\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"}[$__rate_interval])) or on() label_replace(vector(0), \"producer\", \"no_writes\", \"__name__\", \".*\")",
             "legendFormat": "{{producer}}",
             "refId": "A"
           }
@@ -911,7 +911,7 @@
       },
       {
         "datasource": "$datasource",
-        "description": "Replication operations per second grouped by outcome and instance.",
+        "description": "Receiver and bootstrap apply operations per second grouped by outcome and instance.",
         "fieldConfig": {
           "defaults": {
             "color": {
@@ -967,17 +967,17 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "sum by (outcome, instance) (rate(kura_replication_apply_results_total_total{instance=~\"${instance:regex}\", region=~\"${region:regex}\"}[$__rate_interval]))",
+            "expr": "sum by (outcome, instance) (rate(kura_replication_apply_results_total_total{cluster=\"kura-tuist\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"}[$__rate_interval]))",
             "legendFormat": "{{instance}} {{outcome}}",
             "refId": "A"
           }
         ],
-        "title": "Replication Operations by Outcome",
+        "title": "Replication Applies by Outcome",
         "type": "timeseries"
       },
       {
         "datasource": "$datasource",
-        "description": "Replication round-trip latency percentiles.",
+        "description": "Outbound outbox replication request round-trip latency percentiles.",
         "fieldConfig": {
           "defaults": {
             "color": {
@@ -1033,26 +1033,26 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "histogram_quantile(0.50, sum by (le) (rate(kura_replication_request_duration_seconds_bucket{instance=~\"${instance:regex}\", region=~\"${region:regex}\"}[$__rate_interval])))",
+            "expr": "histogram_quantile(0.50, sum by (le) (rate(kura_replication_request_duration_seconds_bucket{cluster=\"kura-tuist\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"}[$__rate_interval]))) or on() vector(0)",
             "legendFormat": "p50",
             "refId": "A"
           },
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "histogram_quantile(0.95, sum by (le) (rate(kura_replication_request_duration_seconds_bucket{instance=~\"${instance:regex}\", region=~\"${region:regex}\"}[$__rate_interval])))",
+            "expr": "histogram_quantile(0.95, sum by (le) (rate(kura_replication_request_duration_seconds_bucket{cluster=\"kura-tuist\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"}[$__rate_interval]))) or on() vector(0)",
             "legendFormat": "p95",
             "refId": "B"
           },
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "histogram_quantile(0.99, sum by (le) (rate(kura_replication_request_duration_seconds_bucket{instance=~\"${instance:regex}\", region=~\"${region:regex}\"}[$__rate_interval])))",
+            "expr": "histogram_quantile(0.99, sum by (le) (rate(kura_replication_request_duration_seconds_bucket{cluster=\"kura-tuist\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"}[$__rate_interval]))) or on() vector(0)",
             "legendFormat": "p99",
             "refId": "C"
           }
         ],
-        "title": "Replication Latency p50 / p95 / p99",
+        "title": "Outbound Replication Latency p50 / p95 / p99",
         "type": "timeseries"
       },
       {
@@ -1782,7 +1782,7 @@
       },
       {
         "datasource": "$traces_datasource",
-        "description": "Kura traces from mesh nodes. Filter by service name, duration, or status in Explore for deeper inspection.",
+        "description": "Recent Kura cache endpoint traces from mesh nodes. Internal health checks and scrape traffic are intentionally excluded.",
         "fieldConfig": {
           "defaults": {
             "custom": {
@@ -1809,14 +1809,14 @@
         "targets": [
           {
             "datasource": "$traces_datasource",
-            "limit": 20,
-            "query": "{ resource.service.namespace = \"kura\" }",
+            "limit": 50,
+            "query": "{ resource.service.namespace = \"kura\" && span.http.route =~ \"/api/cache.*|/api/metro/cache.*|/v1/cache.*\" } with (most_recent=true)",
             "queryType": "traceql",
             "refId": "A",
             "tableType": "traces"
           }
         ],
-        "title": "Kura Traces",
+        "title": "Cache Endpoint Traces",
         "type": "table"
       },
       {
@@ -1834,7 +1834,7 @@
       },
       {
         "datasource": "$logs_datasource",
-        "description": "Live log stream from selected Kura nodes.",
+        "description": "Structured Kura runtime logs from selected Kura containers.",
         "fieldConfig": {
           "defaults": {},
           "overrides": []
@@ -1861,7 +1861,7 @@
         "targets": [
           {
             "datasource": "$logs_datasource",
-            "expr": "{cluster=\"kura-tuist\", instance=~\"${instance:regex}\"}",
+            "expr": "{cluster=\"kura-tuist\", container=\"kura\", instance=~\"${instance:regex}\"} | json",
             "refId": "A"
           }
         ],

--- a/kura/Cargo.lock
+++ b/kura/Cargo.lock
@@ -3395,6 +3395,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3404,12 +3414,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex-automata",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/kura/Cargo.toml
+++ b/kura/Cargo.toml
@@ -37,7 +37,7 @@ tokio-util = { version = "0.7.17", features = ["io"] }
 tonic = { version = "0.14.2", features = ["tls-ring"] }
 tracing = "0.1.41"
 tracing-opentelemetry = "0.32.1"
-tracing-subscriber = { version = "0.3.20", features = ["env-filter", "fmt"] }
+tracing-subscriber = { version = "0.3.20", features = ["env-filter", "fmt", "json"] }
 uuid = { version = "1.18.1", features = ["serde", "v7"] }
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]

--- a/kura/ops/grafana/dashboards/kura-cluster.json
+++ b/kura/ops/grafana/dashboards/kura-cluster.json
@@ -376,8 +376,8 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "sum by (region, kind, result) (rate(kura_artifact_write_bytes_total[5m]))",
-          "legendFormat": "{{region}} {{kind}} {{result}}",
+          "expr": "sum by (region, producer, result) (rate(kura_artifact_write_bytes_total[5m]))",
+          "legendFormat": "{{region}} {{producer}} {{result}}",
           "refId": "A"
         }
       ],
@@ -414,8 +414,8 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "sum by (region, kind, result) (rate(kura_artifact_read_bytes_total[5m]))",
-          "legendFormat": "{{region}} {{kind}} {{result}}",
+          "expr": "sum by (region, producer, result) (rate(kura_artifact_read_bytes_total[5m]))",
+          "legendFormat": "{{region}} {{producer}} {{result}}",
           "refId": "A"
         }
       ],
@@ -819,8 +819,8 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "sum by (region, kind, result) (rate(kura_segment_refreshes_total[5m]))",
-          "legendFormat": "{{region}} {{kind}} {{result}}",
+          "expr": "sum by (region, producer, result) (rate(kura_segment_refreshes_total[5m]))",
+          "legendFormat": "{{region}} {{producer}} {{result}}",
           "refId": "A"
         }
       ],
@@ -859,8 +859,8 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "sum by (region, kind, generation) (kura_segment_generation_count)",
-          "legendFormat": "{{region}} {{kind}} {{generation}}",
+          "expr": "sum by (region, generation) (kura_segment_generation_count)",
+          "legendFormat": "{{region}} {{generation}}",
           "refId": "A"
         }
       ],
@@ -890,7 +890,7 @@
       },
       "targets": [
         {
-          "expr": "{service=~\"kura-us|kura-eu|kura-ap\"}",
+          "expr": "{service=~\"kura-us|kura-eu|kura-ap\"} | json",
           "queryType": "range",
           "refId": "A"
         }

--- a/kura/src/app.rs
+++ b/kura/src/app.rs
@@ -9,7 +9,7 @@ use axum_server::Handle;
 use hyper_util::rt::TokioTimer;
 use tokio::sync::{Notify, Semaphore, oneshot};
 use tokio::{task::JoinHandle, time::Instant};
-use tracing::{info, warn};
+use tracing::{Instrument, info, warn};
 
 use crate::{
     analytics::Analytics,
@@ -25,7 +25,7 @@ use crate::{
     runtime::{DataDirLock, RuntimeState},
     state::{AppState, ReadinessState},
     store::Store,
-    telemetry::init_tracing,
+    telemetry::{init_tracing, log_context_span},
 };
 
 #[derive(Clone, Copy, Debug)]
@@ -48,7 +48,14 @@ impl ShutdownBudget {
 pub async fn run() -> Result<(), String> {
     let config = Config::from_env().map_err(|error| format!("invalid configuration: {error}"))?;
     let telemetry = init_tracing(&config);
+    let log_context = log_context_span(&config);
+    let result = run_with_config(config).instrument(log_context).await;
 
+    telemetry.shutdown();
+    result
+}
+
+async fn run_with_config(config: Config) -> Result<(), String> {
     if let Err(error) = raise_nofile_soft_to_hard() {
         tracing::warn!("failed to raise RLIMIT_NOFILE soft limit: {error}");
     }
@@ -136,23 +143,26 @@ pub async fn run() -> Result<(), String> {
     let (shutdown_budget_tx, shutdown_budget_rx) = oneshot::channel::<ShutdownBudget>();
     let grpc_shutdown_rx = shutdown_rx.clone();
     let grpc_state = state.clone();
-    let grpc_handle = tokio::spawn(async move {
-        let grpc_shutdown = async move {
-            let mut shutdown_rx = grpc_shutdown_rx;
-            if shutdown_rx.borrow().is_some() {
-                return;
-            }
-            while shutdown_rx.changed().await.is_ok() {
+    let grpc_handle = tokio::spawn(
+        async move {
+            let grpc_shutdown = async move {
+                let mut shutdown_rx = grpc_shutdown_rx;
                 if shutdown_rx.borrow().is_some() {
                     return;
                 }
-            }
-        };
+                while shutdown_rx.changed().await.is_ok() {
+                    if shutdown_rx.borrow().is_some() {
+                        return;
+                    }
+                }
+            };
 
-        if let Err(error) = reapi::serve(grpc_listener, grpc_state, grpc_shutdown).await {
-            tracing::error!("gRPC server failed: {error}");
+            if let Err(error) = reapi::serve(grpc_listener, grpc_state, grpc_shutdown).await {
+                tracing::error!("gRPC server failed: {error}");
+            }
         }
-    });
+        .in_current_span(),
+    );
 
     let internal_handle = if let Some(peer_tls) = state.config.peer_tls.clone() {
         let tls_config = build_internal_rustls_config(&peer_tls).await?;
@@ -160,53 +170,65 @@ pub async fn run() -> Result<(), String> {
         let mut internal_shutdown_rx = shutdown_rx.clone();
         let handle = Handle::new();
         let shutdown_handle = handle.clone();
-        tokio::spawn(async move {
-            if let Some(budget) = *internal_shutdown_rx.borrow() {
-                shutdown_handle.graceful_shutdown(Some(budget.remaining()));
-                return;
-            }
-            while internal_shutdown_rx.changed().await.is_ok() {
+        tokio::spawn(
+            async move {
                 if let Some(budget) = *internal_shutdown_rx.borrow() {
                     shutdown_handle.graceful_shutdown(Some(budget.remaining()));
                     return;
                 }
+                while internal_shutdown_rx.changed().await.is_ok() {
+                    if let Some(budget) = *internal_shutdown_rx.borrow() {
+                        shutdown_handle.graceful_shutdown(Some(budget.remaining()));
+                        return;
+                    }
+                }
             }
-        });
-        Some(tokio::spawn(async move {
-            if let Err(error) = axum_server::bind_rustls(internal_address, tls_config)
-                .handle(handle)
-                .serve(internal_router.into_make_service())
-                .await
-            {
-                tracing::error!("internal mTLS server failed: {error}");
+            .in_current_span(),
+        );
+        Some(tokio::spawn(
+            async move {
+                if let Err(error) = axum_server::bind_rustls(internal_address, tls_config)
+                    .handle(handle)
+                    .serve(internal_router.into_make_service())
+                    .await
+                {
+                    tracing::error!("internal mTLS server failed: {error}");
+                }
             }
-        }))
+            .in_current_span(),
+        ))
     } else {
         let internal_router = http::internal_router(state.clone());
         let mut internal_shutdown_rx = shutdown_rx.clone();
         let handle = Handle::new();
         let shutdown_handle = handle.clone();
-        tokio::spawn(async move {
-            if let Some(budget) = *internal_shutdown_rx.borrow() {
-                shutdown_handle.graceful_shutdown(Some(budget.remaining()));
-                return;
-            }
-            while internal_shutdown_rx.changed().await.is_ok() {
+        tokio::spawn(
+            async move {
                 if let Some(budget) = *internal_shutdown_rx.borrow() {
                     shutdown_handle.graceful_shutdown(Some(budget.remaining()));
                     return;
                 }
+                while internal_shutdown_rx.changed().await.is_ok() {
+                    if let Some(budget) = *internal_shutdown_rx.borrow() {
+                        shutdown_handle.graceful_shutdown(Some(budget.remaining()));
+                        return;
+                    }
+                }
             }
-        });
-        Some(tokio::spawn(async move {
-            if let Err(error) = axum_server::bind(internal_address)
-                .handle(handle)
-                .serve(internal_router.into_make_service())
-                .await
-            {
-                tracing::error!("internal server failed: {error}");
+            .in_current_span(),
+        );
+        Some(tokio::spawn(
+            async move {
+                if let Err(error) = axum_server::bind(internal_address)
+                    .handle(handle)
+                    .serve(internal_router.into_make_service())
+                    .await
+                {
+                    tracing::error!("internal server failed: {error}");
+                }
             }
-        }))
+            .in_current_span(),
+        ))
     };
 
     let router = http::public_router(state.clone());
@@ -215,32 +237,38 @@ pub async fn run() -> Result<(), String> {
     let public_shutdown_handle = public_handle.clone();
     let https_shutdown_handle = https_handle.clone();
     let public_shutdown_state = state.clone();
-    tokio::spawn(async move {
-        shutdown_signal().await;
-        let budget = ShutdownBudget::new(drain_completion_timeout);
-        let _ = shutdown_budget_tx.send(budget);
-        let _ = public_shutdown_state.enter_draining();
-        public_shutdown_state.sync_runtime_metrics().await;
-        public_shutdown_handle.graceful_shutdown(Some(budget.remaining()));
-        https_shutdown_handle.graceful_shutdown(Some(budget.remaining()));
-    });
+    tokio::spawn(
+        async move {
+            shutdown_signal().await;
+            let budget = ShutdownBudget::new(drain_completion_timeout);
+            let _ = shutdown_budget_tx.send(budget);
+            let _ = public_shutdown_state.enter_draining();
+            public_shutdown_state.sync_runtime_metrics().await;
+            public_shutdown_handle.graceful_shutdown(Some(budget.remaining()));
+            https_shutdown_handle.graceful_shutdown(Some(budget.remaining()));
+        }
+        .in_current_span(),
+    );
 
     let https_handle_task = if let Some(public_tls) = state.config.public_tls.clone() {
         let tls_config = build_public_rustls_config(&public_tls).await?;
         let https_router = http::public_router(state.clone());
-        Some(tokio::spawn(async move {
-            let mut server =
-                axum_server::bind_rustls(https_address, tls_config).handle(https_handle);
-            server
-                .http_builder()
-                .http1()
-                .keep_alive(true)
-                .timer(TokioTimer::new())
-                .header_read_timeout(Some(Duration::from_secs(30)));
-            if let Err(error) = server.serve(https_router.into_make_service()).await {
-                tracing::error!("public HTTPS server failed: {error}");
+        Some(tokio::spawn(
+            async move {
+                let mut server =
+                    axum_server::bind_rustls(https_address, tls_config).handle(https_handle);
+                server
+                    .http_builder()
+                    .http1()
+                    .keep_alive(true)
+                    .timer(TokioTimer::new())
+                    .header_read_timeout(Some(Duration::from_secs(30)));
+                if let Err(error) = server.serve(https_router.into_make_service()).await {
+                    tracing::error!("public HTTPS server failed: {error}");
+                }
             }
-        }))
+            .in_current_span(),
+        ))
     } else {
         None
     };
@@ -278,8 +306,6 @@ pub async fn run() -> Result<(), String> {
         wait_for_task_shutdown(https_handle_task, "public HTTPS", shutdown_budget).await;
     }
 
-    telemetry.shutdown();
-
     Ok(())
 }
 
@@ -302,128 +328,142 @@ async fn shutdown_signal() {
 }
 
 fn spawn_snapshot_task(state: Arc<AppState>) {
-    tokio::spawn(async move {
-        loop {
-            let worker_state = state.clone();
-            match tokio::task::spawn_blocking(move || {
-                let snapshot = worker_state.store.snapshot();
-                let memory = process_memory_snapshot();
-                (snapshot, memory)
-            })
-            .await
-            {
-                Ok((Ok(snapshot), memory)) => {
-                    state
-                        .metrics
-                        .update_outbox_messages(snapshot.outbox_messages);
-                    state.runtime.update_outbox_depth(snapshot.outbox_messages);
-                    state
-                        .metrics
-                        .update_multipart_uploads(snapshot.multipart_uploads);
-                    for (generation, count) in snapshot.segment_counts {
+    tokio::spawn(
+        async move {
+            loop {
+                let worker_state = state.clone();
+                match tokio::task::spawn_blocking(move || {
+                    let snapshot = worker_state.store.snapshot();
+                    let memory = process_memory_snapshot();
+                    (snapshot, memory)
+                })
+                .await
+                {
+                    Ok((Ok(snapshot), memory)) => {
                         state
                             .metrics
-                            .update_segment_generation_count(generation, count);
-                    }
-                    state.metrics.update_rocksdb_memory(
-                        snapshot.rocksdb_block_cache_usage_bytes,
-                        snapshot.rocksdb_block_cache_pinned_usage_bytes,
-                        snapshot.rocksdb_block_cache_capacity_bytes,
-                        snapshot.rocksdb_write_buffer_usage_bytes,
-                        snapshot.rocksdb_write_buffer_capacity_bytes,
-                    );
-                    if let Some(memory) = memory {
+                            .update_outbox_messages(snapshot.outbox_messages);
+                        state.runtime.update_outbox_depth(snapshot.outbox_messages);
                         state
                             .metrics
-                            .update_process_memory(memory.resident_bytes, memory.virtual_bytes);
-                        let pressure = state.memory.observe(memory.resident_bytes);
-                        let target_bytes = state
-                            .memory
-                            .manifest_cache_target_bytes(state.config.manifest_cache_max_bytes);
-                        let evicted = state.store.trim_manifest_cache_to(target_bytes, "pressure");
-                        if evicted > 0 {
-                            state.metrics.record_memory_action("manifest_cache_trim");
+                            .update_multipart_uploads(snapshot.multipart_uploads);
+                        for (generation, count) in snapshot.segment_counts {
+                            state
+                                .metrics
+                                .update_segment_generation_count(generation, count);
                         }
-                        state
-                            .metrics
-                            .update_background_work_paused("outbox", state.memory.pause_outbox());
-                        state.metrics.update_background_work_paused(
-                            "segment_refresh",
-                            !state.memory.allow_segment_refresh(),
+                        state.metrics.update_rocksdb_memory(
+                            snapshot.rocksdb_block_cache_usage_bytes,
+                            snapshot.rocksdb_block_cache_pinned_usage_bytes,
+                            snapshot.rocksdb_block_cache_capacity_bytes,
+                            snapshot.rocksdb_write_buffer_usage_bytes,
+                            snapshot.rocksdb_write_buffer_capacity_bytes,
                         );
-                        state
-                            .metrics
-                            .update_memory_pressure_state(pressure.as_i64());
+                        if let Some(memory) = memory {
+                            state
+                                .metrics
+                                .update_process_memory(memory.resident_bytes, memory.virtual_bytes);
+                            let pressure = state.memory.observe(memory.resident_bytes);
+                            let target_bytes = state
+                                .memory
+                                .manifest_cache_target_bytes(state.config.manifest_cache_max_bytes);
+                            let evicted =
+                                state.store.trim_manifest_cache_to(target_bytes, "pressure");
+                            if evicted > 0 {
+                                state.metrics.record_memory_action("manifest_cache_trim");
+                            }
+                            state.metrics.update_background_work_paused(
+                                "outbox",
+                                state.memory.pause_outbox(),
+                            );
+                            state.metrics.update_background_work_paused(
+                                "segment_refresh",
+                                !state.memory.allow_segment_refresh(),
+                            );
+                            state
+                                .metrics
+                                .update_memory_pressure_state(pressure.as_i64());
+                        }
+                    }
+                    Ok((Err(error), _)) => {
+                        tracing::warn!("failed to collect store snapshot metrics: {error}");
+                    }
+                    Err(error) => {
+                        tracing::warn!("snapshot metrics task failed: {error}");
                     }
                 }
-                Ok((Err(error), _)) => {
-                    tracing::warn!("failed to collect store snapshot metrics: {error}");
-                }
-                Err(error) => {
-                    tracing::warn!("snapshot metrics task failed: {error}");
-                }
-            }
 
-            tokio::time::sleep(Duration::from_secs(5)).await;
+                tokio::time::sleep(Duration::from_secs(5)).await;
+            }
         }
-    });
+        .in_current_span(),
+    );
 }
 
 fn spawn_runtime_metrics_task(state: Arc<AppState>) {
-    tokio::spawn(async move {
-        loop {
-            state.sync_runtime_metrics().await;
-            tokio::time::sleep(Duration::from_secs(1)).await;
+    tokio::spawn(
+        async move {
+            loop {
+                state.sync_runtime_metrics().await;
+                tokio::time::sleep(Duration::from_secs(1)).await;
+            }
         }
-    });
+        .in_current_span(),
+    );
 }
 
 fn spawn_multipart_janitor_task(state: Arc<AppState>) {
     let interval = Duration::from_millis(state.config.multipart_janitor_interval_ms);
     let ttl_ms = state.config.multipart_upload_ttl_ms;
-    tokio::spawn(async move {
-        loop {
-            tokio::time::sleep(interval).await;
-            let now = crate::utils::now_ms();
-            let cutoff_ms = now.saturating_sub(ttl_ms);
-            let stale = match state.store.multipart_uploads_older_than(cutoff_ms) {
-                Ok(stale) => stale,
-                Err(error) => {
-                    warn!("multipart janitor scan failed: {error}");
+    tokio::spawn(
+        async move {
+            loop {
+                tokio::time::sleep(interval).await;
+                let now = crate::utils::now_ms();
+                let cutoff_ms = now.saturating_sub(ttl_ms);
+                let stale = match state.store.multipart_uploads_older_than(cutoff_ms) {
+                    Ok(stale) => stale,
+                    Err(error) => {
+                        warn!("multipart janitor scan failed: {error}");
+                        continue;
+                    }
+                };
+                if stale.is_empty() {
                     continue;
                 }
-            };
-            if stale.is_empty() {
-                continue;
-            }
-            for upload_id in &stale {
-                if let Err(error) = state.store.abort_multipart_upload(upload_id).await {
-                    warn!("multipart janitor failed to expire {upload_id}: {error}");
+                for upload_id in &stale {
+                    if let Err(error) = state.store.abort_multipart_upload(upload_id).await {
+                        warn!("multipart janitor failed to expire {upload_id}: {error}");
+                    }
                 }
+                state
+                    .metrics
+                    .record_memory_action("multipart_janitor_pruned");
+                info!(
+                    ttl_ms,
+                    expired = stale.len(),
+                    "multipart janitor pruned stale uploads"
+                );
             }
-            state
-                .metrics
-                .record_memory_action("multipart_janitor_pruned");
-            info!(
-                ttl_ms,
-                expired = stale.len(),
-                "multipart janitor pruned stale uploads"
-            );
         }
-    });
+        .in_current_span(),
+    );
 }
 
 fn spawn_tmp_dir_metrics_task(state: Arc<AppState>) {
-    tokio::spawn(async move {
-        loop {
-            tokio::time::sleep(Duration::from_secs(30)).await;
-            let tmp_dir = state.config.tmp_dir.clone();
-            let bytes = tokio::task::spawn_blocking(move || directory_size_bytes(&tmp_dir))
-                .await
-                .unwrap_or(0);
-            state.metrics.update_tmp_dir_bytes(bytes);
+    tokio::spawn(
+        async move {
+            loop {
+                tokio::time::sleep(Duration::from_secs(30)).await;
+                let tmp_dir = state.config.tmp_dir.clone();
+                let bytes = tokio::task::spawn_blocking(move || directory_size_bytes(&tmp_dir))
+                    .await
+                    .unwrap_or(0);
+                state.metrics.update_tmp_dir_bytes(bytes);
+            }
         }
-    });
+        .in_current_span(),
+    );
 }
 
 #[cfg(unix)]
@@ -490,20 +530,23 @@ fn directory_size_bytes(path: &std::path::Path) -> u64 {
 
 #[cfg(unix)]
 fn spawn_drain_signal_task(state: Arc<AppState>) {
-    tokio::spawn(async move {
-        let mut signal =
-            tokio::signal::unix::signal(tokio::signal::unix::SignalKind::user_defined1())
-                .expect("failed to install SIGUSR1 handler");
-        loop {
-            if signal.recv().await.is_none() {
-                return;
-            }
-            if state.enter_draining() {
-                state.sync_runtime_metrics().await;
-                info!("received SIGUSR1, entering draining state");
+    tokio::spawn(
+        async move {
+            let mut signal =
+                tokio::signal::unix::signal(tokio::signal::unix::SignalKind::user_defined1())
+                    .expect("failed to install SIGUSR1 handler");
+            loop {
+                if signal.recv().await.is_none() {
+                    return;
+                }
+                if state.enter_draining() {
+                    state.sync_runtime_metrics().await;
+                    info!("received SIGUSR1, entering draining state");
+                }
             }
         }
-    });
+        .in_current_span(),
+    );
 }
 
 #[cfg(not(unix))]

--- a/kura/src/http.rs
+++ b/kura/src/http.rs
@@ -26,7 +26,7 @@ use crate::{
     replication::replication_targets,
     state::SharedState,
     store::is_disk_full_error,
-    telemetry::attach_parent_context,
+    telemetry::{attach_parent_context, record_trace_context},
     utils::{BodyReadError, action_cache_key, blob_key, module_key, read_request_to_temp},
 };
 
@@ -358,8 +358,11 @@ async fn track_http_metrics(
         url.path = %uri_path,
         http.response.status_code = field::Empty,
         otel.status_code = field::Empty,
+        trace_id = field::Empty,
+        span_id = field::Empty,
     );
     attach_parent_context(&request_span, req.headers());
+    record_trace_context(&request_span);
 
     let response = next.run(req).instrument(request_span.clone()).await;
     request_span.record("http.response.status_code", response.status().as_u16());

--- a/kura/src/replication/mod.rs
+++ b/kura/src/replication/mod.rs
@@ -25,7 +25,7 @@ use crate::{
     failpoints::FailpointName,
     state::SharedState,
     store::{ArtifactApplyOutcome, ManifestPage, NamespaceTombstonePage},
-    telemetry::inject_current_trace_context,
+    telemetry::{inject_current_trace_context, record_trace_context},
     utils::{replication_target_label, temp_file_path, url_encode},
 };
 
@@ -74,26 +74,29 @@ where
     F: Fn(SharedState) -> Fut + Send + Sync + 'static,
     Fut: std::future::Future<Output = ()> + Send + 'static,
 {
-    tokio::spawn(async move {
-        loop {
-            let task_state = state.clone();
-            let handle = tokio::spawn(work(task_state));
-            match handle.await {
-                Ok(()) => return,
-                Err(error) if error.is_panic() => {
-                    state
-                        .metrics
-                        .record_memory_action(&format!("background_panic_{name}"));
-                    warn!("background task '{name}' panicked: {error:?}; respawning in 1s");
-                    sleep(Duration::from_secs(1)).await;
-                }
-                Err(error) => {
-                    warn!("background task '{name}' aborted: {error:?}");
-                    return;
+    tokio::spawn(
+        async move {
+            loop {
+                let task_state = state.clone();
+                let handle = tokio::spawn(work(task_state).in_current_span());
+                match handle.await {
+                    Ok(()) => return,
+                    Err(error) if error.is_panic() => {
+                        state
+                            .metrics
+                            .record_memory_action(&format!("background_panic_{name}"));
+                        warn!("background task '{name}' panicked: {error:?}; respawning in 1s");
+                        sleep(Duration::from_secs(1)).await;
+                    }
+                    Err(error) => {
+                        warn!("background task '{name}' aborted: {error:?}");
+                        return;
+                    }
                 }
             }
         }
-    });
+        .in_current_span(),
+    );
 }
 
 async fn membership_task_loop(state: SharedState) {
@@ -181,43 +184,47 @@ async fn maybe_spawn_bootstrap_task(state: SharedState, peer: String) {
     }
 
     let semaphore = state.bootstrap_semaphore.clone();
-    tokio::spawn(async move {
-        let _permit = match semaphore.acquire_owned().await {
-            Ok(permit) => permit,
-            Err(_) => {
-                state.note_bootstrap_failed(&peer).await;
-                return;
-            }
-        };
-        let started_at = std::time::Instant::now();
-        let timeout = Duration::from_millis(state.config.bootstrap_timeout_ms);
-        let result = match tokio::time::timeout(timeout, bootstrap_from_peer(&state, &peer)).await {
-            Ok(result) => result,
-            Err(_) => Err(format!(
-                "bootstrap timed out after {} ms",
-                state.config.bootstrap_timeout_ms
-            )),
-        };
-        match result {
-            Ok(stats) => {
-                state.note_bootstrap_succeeded(&peer).await;
-                state.metrics.record_bootstrap_run(
-                    "ok",
-                    started_at.elapsed(),
-                    stats.tombstones_applied,
-                    stats.artifacts_applied,
-                );
-                state.maybe_mark_serving().await;
-            }
-            Err(error) => {
-                warn!("bootstrap from {peer} failed: {error}");
-                state
-                    .metrics
-                    .record_bootstrap_run("error", started_at.elapsed(), 0, 0);
-                state.note_bootstrap_failed(&peer).await;
+    tokio::spawn(
+        async move {
+            let _permit = match semaphore.acquire_owned().await {
+                Ok(permit) => permit,
+                Err(_) => {
+                    state.note_bootstrap_failed(&peer).await;
+                    return;
+                }
+            };
+            let started_at = std::time::Instant::now();
+            let timeout = Duration::from_millis(state.config.bootstrap_timeout_ms);
+            let result =
+                match tokio::time::timeout(timeout, bootstrap_from_peer(&state, &peer)).await {
+                    Ok(result) => result,
+                    Err(_) => Err(format!(
+                        "bootstrap timed out after {} ms",
+                        state.config.bootstrap_timeout_ms
+                    )),
+                };
+            match result {
+                Ok(stats) => {
+                    state.note_bootstrap_succeeded(&peer).await;
+                    state.metrics.record_bootstrap_run(
+                        "ok",
+                        started_at.elapsed(),
+                        stats.tombstones_applied,
+                        stats.artifacts_applied,
+                    );
+                    state.maybe_mark_serving().await;
+                }
+                Err(error) => {
+                    warn!("bootstrap from {peer} failed: {error}");
+                    state
+                        .metrics
+                        .record_bootstrap_run("error", started_at.elapsed(), 0, 0);
+                    state.note_bootstrap_failed(&peer).await;
+                }
             }
         }
-    });
+        .in_current_span(),
+    );
 }
 
 async fn bootstrap_from_peer(state: &SharedState, peer: &str) -> Result<BootstrapStats, String> {
@@ -637,7 +644,10 @@ async fn replicate_message(state: &SharedState, message: &OutboxMessage) -> Resu
                 peer.service = %replication_target_label(&message.target),
                 http.response.status_code = field::Empty,
                 otel.status_code = field::Empty,
+                trace_id = field::Empty,
+                span_id = field::Empty,
             );
+            record_trace_context(&request_span);
             let response_span = request_span.clone();
 
             async {
@@ -688,7 +698,10 @@ async fn replicate_message(state: &SharedState, message: &OutboxMessage) -> Resu
                 peer.service = %replication_target_label(&message.target),
                 http.response.status_code = field::Empty,
                 otel.status_code = field::Empty,
+                trace_id = field::Empty,
+                span_id = field::Empty,
             );
+            record_trace_context(&request_span);
             let response_span = request_span.clone();
 
             async {

--- a/kura/src/telemetry.rs
+++ b/kura/src/telemetry.rs
@@ -4,7 +4,7 @@ use axum::http::HeaderMap;
 use opentelemetry::{
     KeyValue, global,
     propagation::{Extractor, Injector},
-    trace::TracerProvider as _,
+    trace::{TraceContextExt, TracerProvider as _},
 };
 use opentelemetry_otlp::{Protocol, WithExportConfig};
 use opentelemetry_sdk::{
@@ -13,7 +13,7 @@ use opentelemetry_sdk::{
     trace::{Sampler, SdkTracerProvider},
 };
 use sentry::{ClientInitGuard, ClientOptions};
-use tracing::{Span, warn};
+use tracing::{Span, field, warn};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
@@ -41,7 +41,12 @@ pub fn init_tracing(config: &Config) -> TelemetryGuards {
 
     let env_filter = tracing_subscriber::EnvFilter::try_from_default_env()
         .unwrap_or_else(|_| "kura=info".into());
-    let fmt_layer = tracing_subscriber::fmt::layer();
+    let fmt_layer = tracing_subscriber::fmt::layer()
+        .json()
+        .flatten_event(true)
+        .with_current_span(true)
+        .with_span_list(true)
+        .with_ansi(false);
     let sentry_guard = init_sentry(config);
 
     let tracer_result = match config.otlp_traces_endpoint.as_deref() {
@@ -72,7 +77,6 @@ pub fn init_tracing(config: &Config) -> TelemetryGuards {
             }
         }
         Err(error) => {
-            eprintln!("OTLP tracing not active: {error}");
             if sentry_guard.is_some() {
                 tracing_subscriber::registry()
                     .with(env_filter)
@@ -85,11 +89,50 @@ pub fn init_tracing(config: &Config) -> TelemetryGuards {
                     .with(fmt_layer)
                     .init();
             }
-            TelemetryGuards {
+            let guards = TelemetryGuards {
                 tracer_provider: None,
                 sentry_guard,
-            }
+            };
+            warn!(
+                error = %error,
+                service.name = %config.otel_service_name,
+                service.namespace = "kura",
+                service.version = env!("CARGO_PKG_VERSION"),
+                deployment.environment.name = %config.otel_deployment_environment,
+                kura.region = %config.region,
+                kura.tenant_id = %config.tenant_id,
+                service.instance.id = %config.node_url,
+                "OTLP tracing not active"
+            );
+            guards
         }
+    }
+}
+
+pub fn log_context_span(config: &Config) -> Span {
+    let span = tracing::info_span!(
+        "kura.runtime",
+        service.name = %config.otel_service_name,
+        service.namespace = "kura",
+        service.version = env!("CARGO_PKG_VERSION"),
+        deployment.environment.name = %config.otel_deployment_environment,
+        kura.region = %config.region,
+        kura.tenant_id = %config.tenant_id,
+        service.instance.id = %config.node_url,
+        trace_id = field::Empty,
+        span_id = field::Empty,
+    );
+    record_trace_context(&span);
+    span
+}
+
+pub fn record_trace_context(span: &Span) {
+    let context = span.context();
+    let span_ref = context.span();
+    let span_context = span_ref.span_context();
+    if span_context.is_valid() {
+        span.record("trace_id", field::display(span_context.trace_id()));
+        span.record("span_id", field::display(span_context.span_id()));
     }
 }
 


### PR DESCRIPTION
## Summary

- Tighten Kura Grafana panels to use current metric labels, explicit cluster filters, and clearer replication panel semantics.
- Filter Tempo traces to recent cache endpoint traffic instead of broad Kura probe traffic.
- Emit structured JSON logs from Kura with service context and trace/span IDs, then parse and scope the Loki panels to Kura runtime logs.

## Root Cause

Some dashboard queries were broader than the signals they were meant to show, so probe traffic and host logs dominated the panels. Kura also emitted text logs without consistent service metadata, which made Loki parsing and trace correlation weaker than expected.

## Validation

- `git diff --check`
- `jq empty infra/grafana-dashboards/tuist-kura.json kura/ops/grafana/dashboards/kura-cluster.json`
- `mise exec -- cargo test render_includes_recorded_metrics`
- `mise exec -- cargo clippy --all-targets -- -D warnings`