### PR TITLE
fix(ci): use TruffleHog image tag without prefix

### DIFF
--- a/.github/workflows/secret-scanning.yml
+++ b/.github/workflows/secret-scanning.yml
@@ -30,7 +30,7 @@ jobs:
         uses: trufflesecurity/trufflehog@v3.92.4
         continue-on-error: true
         with:
-          version: v3.92.4
+          version: 3.92.4
           extra_args: --results=verified --json
       - name: Comment on PR
         if: steps.trufflehog.outcome == 'failure' && github.event_name == 'pull_request'


### PR DESCRIPTION
## What

Updates the TruffleHog secret scanning workflow to pass `version: 3.92.4` instead of `version: v3.92.4`.

## Why

The TruffleHog GitHub Action passes the `version` input directly to `ghcr.io/trufflesecurity/trufflehog:${VERSION}`. The GitHub Action tag uses the `v` prefix, but the GHCR image tag does not. As a result, `v3.92.4` resolves to a missing image manifest while `3.92.4` resolves correctly.

## Validation

- Checked that `ghcr.io/trufflesecurity/trufflehog:3.92.4` returns `HTTP/2 200` from the registry manifest endpoint.