### PR TITLE
fix(server): gate Kura reconcile task on prod-like envs only

### DIFF
--- a/server/lib/tuist/application.ex
+++ b/server/lib/tuist/application.ex
@@ -401,10 +401,12 @@ defmodule Tuist.Application do
   end
 
   # Reconciles Kura deployments stranded in `:running` after a crash or
-  # rolling deploy. Web mode only; processor mode doesn't run Kura
-  # rollout jobs and so never produces orphans.
+  # rolling deploy. Mirrors the gate on the `Tuist.Kura.Reconciler` cron
+  # in `Tuist.Oban.RuntimeConfig.crontab/3`: web mode, prod-like env,
+  # Tuist-hosted. Anywhere else (dev, test, self-hosted, non-web pods)
+  # Kura is not provisioned and the reconciler has nothing to do.
   defp kura_children do
-    if Environment.web?() and not Environment.test?() do
+    if Environment.web?() and Environment.env() in [:prod, :stag, :can] and Environment.tuist_hosted?() do
       [
         Supervisor.child_spec(
           {Task, &Kura.reconcile_orphaned_deployments/0},


### PR DESCRIPTION
## Summary

- Align the boot-time `Kura.Reconciler` task in `Tuist.Application.kura_children/0` with the cron gate in `Tuist.Oban.RuntimeConfig.crontab/3`: require `web?` + prod-like env + `tuist_hosted?`. The task only does useful work in those environments anyway (Kura isn't provisioned in dev / test / self-hosted).
- Fixes the `Gradle Cache Acceptance` workflow's `Setup main server` step on `main`, where the prior gate (`web? and not test?`) let the task fire in `MIX_ENV=dev` before migrations had run.

## Why this broke

The workflow runs:

```bash
MIX_ENV=dev mix do compile, ecto.create, run priv/repo/timezone.exs, \
  ecto.load, ecto.migrate, run priv/repo/seeds.exs
```

The first `mix run priv/repo/timezone.exs` boots Tuist's supervision tree before `ecto.load`/`ecto.migrate`. With the previous gate, `kura_children/0` started a `Task` that ran `Kura.reconcile_orphaned_deployments/0` → `Tuist.Kura.Reconciler.reconcile/0` → `Repo.all/1` on `kura_servers`. The table didn't exist yet:

```
** (Postgrex.Error) ERROR 42P01 (undefined_table) relation "kura_servers" does not exist
```

Regression-introducing commit: `515159ab05` (`fix(kura): repair public load balancer exposure`), which appears to have made the pre-existing race reliable.

## Test plan

- [x] `cd server && MIX_ENV=dev mix do compile, ecto.drop, ecto.create, run priv/repo/timezone.exs, ecto.load, ecto.migrate, run priv/repo/seeds.exs` — completes without the `kura_servers` error.
- [x] `cd server && mix test test/tuist/oban/runtime_config_test.exs` — 6 tests, 0 failures. The cron-gate test still asserts `Kura.Reconciler` only appears on `:web` + prod-like env + `tuist_hosted?`, which now matches the boot-time gate.