### PR TITLE
fix(server): avoid Kura readiness probe Req option conflict

### DIFF
--- a/server/lib/tuist/kura.ex
+++ b/server/lib/tuist/kura.ex
@@ -335,9 +335,9 @@ defmodule Tuist.Kura do
       |> URI.to_string()
 
     case Req.get(url,
-           finch: Tuist.Finch,
            receive_timeout: @public_endpoint_timeout,
-           connect_options: [timeout: @public_endpoint_timeout]
+           connect_options: [timeout: @public_endpoint_timeout],
+           retry: false
          ) do
       {:ok, %Req.Response{status: status}} when status in 200..299 ->
         :ok

--- a/server/test/tuist/kura/reconciler_test.exs
+++ b/server/test/tuist/kura/reconciler_test.exs
@@ -72,9 +72,10 @@ defmodule Tuist.Kura.ReconcilerTest do
     end)
 
     expect(Req, :get, fn "https://localhost:4100/up", opts ->
-      assert opts[:finch] == Tuist.Finch
+      refute Keyword.has_key?(opts, :finch)
       assert opts[:receive_timeout] == 5_000
       assert opts[:connect_options] == [timeout: 5_000]
+      assert opts[:retry] == false
       {:error, %Mint.TransportError{reason: {:tls_alert, ~c"unknown ca"}}}
     end)
 

--- a/server/test/tuist/kura_test.exs
+++ b/server/test/tuist/kura_test.exs
@@ -336,9 +336,10 @@ defmodule Tuist.KuraTest do
       end)
 
       expect(Req, :get, fn "https://localhost:4100/up", opts ->
-        assert opts[:finch] == Tuist.Finch
+        refute Keyword.has_key?(opts, :finch)
         assert opts[:receive_timeout] == 5_000
         assert opts[:connect_options] == [timeout: 5_000]
+        assert opts[:retry] == false
         {:error, %Mint.TransportError{reason: {:tls_alert, ~c"unknown ca"}}}
       end)
 
@@ -347,6 +348,29 @@ defmodule Tuist.KuraTest do
 
       assert %Server{status: :provisioning, current_image_tag: nil, url: nil} = Repo.get!(Server, server.id)
       assert Accounts.list_account_cache_endpoints(account, :kura) == []
+    end
+
+    test "returns endpoint not ready instead of raising when the HTTPS readiness probe cannot connect" do
+      user = AccountsFixtures.user_fixture()
+      account = Accounts.get_account_from_user(user)
+
+      {:ok, server} =
+        Kura.create_server(%{
+          account_id: account.id,
+          region: "local-controller",
+          image_tag: "0.5.2"
+        })
+
+      expect(Provisioner, :public_url, fn account_arg, %Server{id: id} ->
+        assert account_arg.id == account.id
+        assert id == server.id
+        "https://localhost:65534"
+      end)
+
+      assert {:error, {:public_endpoint_not_ready, "localhost", reason}} =
+               Kura.activate_server(server, "0.5.2")
+
+      refute match?(%ArgumentError{}, reason)
     end
 
     test "reactivates a failed server when its cache endpoint already exists" do


### PR DESCRIPTION
## Summary

This fixes Sentry issue `TUIST-FB`, where Kura deployment reconciliation could crash while activating a server after the controller had already observed the requested image tag.

During activation, `Tuist.Kura.activate_server/2` verifies that the public HTTPS endpoint is reachable by probing `/up`. That probe passed both `finch: Tuist.Finch` and `connect_options: [timeout: ...]` to Req. In Req 0.5, custom connection options require Req to manage a dedicated Finch pool for those options, so passing an explicit `:finch` at the same time raises:

```text
ArgumentError: cannot set both :finch and :connect_options
```

Because the exception happened inside `Tuist.Kura.Reconciler.activate_and_mark_succeeded/2`, the deployment tick crashed instead of returning `{:public_endpoint_not_ready, host, reason}` and letting the next reconciler tick retry normally.

## Changes

- Remove the explicit `finch: Tuist.Finch` option from the Kura public HTTPS readiness probe.
- Keep the explicit connect and receive timeouts so readiness checks stay bounded.
- Set `retry: false` on the probe. Req retries transient GET failures by default, but Kura already retries readiness through the reconciler loop, so this avoids delaying each tick by an extra retry backoff.
- Update the existing mocked readiness-probe tests to assert the Req-compatible option set.
- Add a regression test that leaves `Req.get/2` real and points the HTTPS probe at an unused local port, proving activation returns `:public_endpoint_not_ready` instead of raising the production `ArgumentError`.

## Behavior After This PR

If DNS has propagated but the public HTTPS endpoint is not reachable yet, Kura activation now returns the existing readiness error tuple. The reconciler keeps the deployment running and retries on the next tick, which is the intended behavior for external-dns, TLS, or load balancer propagation delays.

Non-HTTPS URLs still skip the HTTPS `/up` check as before.

Fixes TUIST-FB

## Testing

```bash
MIX_ENV=test MISE_STATE_DIR=/private/tmp/mise-state MISE_TRUSTED_CONFIG_PATHS=/Users/marekfort/.codex/worktrees/509e/tuist/mise.toml:/Users/marekfort/.codex/worktrees/509e/tuist/server/mise.toml mix test test/tuist/kura_test.exs test/tuist/kura/reconciler_test.exs
```

Result: `34 tests, 0 failures`

```bash
git diff --check
```

Result: passed