### PR TITLE
fix(cli): map default actor isolation to MainActor

### DIFF
--- a/cli/Sources/TuistLoader/SwiftPackageManager/SettingsMapper.swift
+++ b/cli/Sources/TuistLoader/SwiftPackageManager/SettingsMapper.swift
@@ -68,12 +68,13 @@ struct SettingsMapper {
         for setting in settings {
             switch (setting.tool, setting.name) {
             case (.swift, .defaultIsolation):
-                // Map SPM defaultIsolation to SWIFT_DEFAULT_ACTOR_ISOLATION
-                // nil -> "nonisolated", MainActor.self -> "main-actor"
-                if setting.value == ["nonisolated"] || setting.value == ["nil"] {
+                switch setting.value {
+                case ["nonisolated"], ["nil"]:
                     settingsDictionary["SWIFT_DEFAULT_ACTOR_ISOLATION"] = "nonisolated"
-                } else if setting.value.contains("MainActor") || setting.value == ["main-actor"] {
-                    settingsDictionary["SWIFT_DEFAULT_ACTOR_ISOLATION"] = "main-actor"
+                case ["MainActor"], ["MainActor.self"], ["main-actor"]:
+                    settingsDictionary["SWIFT_DEFAULT_ACTOR_ISOLATION"] = "MainActor"
+                default:
+                    break
                 }
             case (_, .defaultIsolation):
                 break

--- a/cli/Tests/TuistLoaderTests/SwiftPackageManager/SettingsMapperTests.swift
+++ b/cli/Tests/TuistLoaderTests/SwiftPackageManager/SettingsMapperTests.swift
@@ -93,6 +93,25 @@ final class SettingsMapperTests: XCTestCase {
         )
     }
 
+    func test_set_SWIFT_DEFAULT_ACTOR_ISOLATION_when_main_actor() throws {
+        let settings: [PackageInfo.Target.TargetBuildSettingDescription.Setting] = [
+            .init(tool: .swift, name: .defaultIsolation, condition: nil, value: ["MainActor"]),
+        ]
+
+        let mapper = SettingsMapper(
+            headerSearchPaths: [],
+            mainRelativePath: try RelativePath(validating: "path"),
+            settings: settings
+        )
+
+        let resolvedSettings = try mapper.settingsDictionary()
+
+        XCTAssertEqual(
+            resolvedSettings["SWIFT_DEFAULT_ACTOR_ISOLATION"],
+            .string("MainActor")
+        )
+    }
+
     func test_set_HEADER_SEARCH_PATHS() throws {
         let settings: [PackageInfo.Target.TargetBuildSettingDescription.Setting] = [
             .init(tool: .c, name: .headerSearchPath, condition: nil, value: ["cPath"]),


### PR DESCRIPTION
## Summary

This fixes the SwiftPM-to-Xcode build setting mapping for package targets that use default main actor isolation. SwiftPM packages can declare `.defaultIsolation(MainActor.self)`, but Tuist was generating `SWIFT_DEFAULT_ACTOR_ISOLATION = main-actor`. Xcode expects `MainActor`, so the setting was effectively ignored for generated external package projects.

## Changes

- Map SwiftPM `defaultIsolation` values for `MainActor`, `MainActor.self`, and the previously emitted `main-actor` spelling to `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor`.
- Preserve the existing `nonisolated`/`nil` mapping to `SWIFT_DEFAULT_ACTOR_ISOLATION = nonisolated`.
- Add a focused regression test in `SettingsMapperTests` to lock the `MainActor` Xcode build setting value.

## Why

External SPM dependencies that opt into default main actor isolation rely on Xcode receiving the exact build setting value. Emitting `main-actor` means generated projects compile as though the package did not request default actor isolation, which can change Swift concurrency checking and runtime isolation assumptions.

## Testing

```sh
xcodebuild test -workspace Tuist.xcworkspace -scheme TuistUnitTests -destination platform=macOS -only-testing TuistLoaderTests/SettingsMapperTests/test_set_SWIFT_DEFAULT_ACTOR_ISOLATION_when_main_actor -derivedDataPath /private/tmp/tuist-settingsmapper-derived CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" COMPILATION_CACHE_ENABLE_CACHING=NO
```

Result: `TEST SUCCEEDED`.

## Notes

The change is intentionally scoped to the SwiftPM settings mapper and does not alter package decoding or project generation outside the emitted build setting value.