### PR TITLE
fix(infra): adopt production macOS fleet from warm pool

### DIFF
--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -189,6 +189,9 @@ xcresultProcessor:
 # xcresult capacity offline.
 macosFleet:
   replicas: 2
+  # Claim pre-ordered Mac minis during the CAPI MachineDeployment
+  # cutover instead of auto-ordering fresh production hosts.
+  adoptPoolPrefix: "tuist-pool-"
   machine:
     # Production tracks the chart default — M2-L on Scaleway:
     # M2 Pro 10-core / 16 GB. Explicit here so the matching


### PR DESCRIPTION
## Summary
- set production macosFleet.adoptPoolPrefix to tuist-pool- so the CAPI MachineDeployment claims preordered hosts
- keep the active production xcresult fleet aligned with staging's adoption path

## Verification
- helm template tuist infra/helm/tuist --namespace tuist -f infra/helm/tuist/values-managed-common.yaml -f infra/helm/tuist/values-managed-production.yaml --set server.image.tag=sha-test --set kuraController.image.tag=sha-test --set kuraRuntime.image.tag=0.4.0 --show-only templates/macos-fleet.yaml
- helm lint infra/helm/tuist -f infra/helm/tuist/values-managed-common.yaml -f infra/helm/tuist/values-managed-production.yaml --set server.image.tag=sha-test --set kuraController.image.tag=sha-test --set kuraRuntime.image.tag=0.4.0

Context: https://github.com/tuist/tuist/actions/runs/25803826670/job/75823966361