### PR TITLE
feat(server): support dedicated ops host

### DIFF
--- a/infra/helm/tuist/templates/server-deployment.yaml
+++ b/infra/helm/tuist/templates/server-deployment.yaml
@@ -93,6 +93,14 @@ spec:
             {{- end }}
             - name: TUIST_APP_URL
               value: {{ .Values.server.appUrl | quote }}
+            {{- with .Values.server.ops.url }}
+            - name: TUIST_OPS_URL
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.server.ops.hosts }}
+            - name: TUIST_OPS_HOSTS
+              value: {{ join "," . | quote }}
+            {{- end }}
             - name: TUIST_LOG_LEVEL
               value: {{ .Values.server.logLevel | quote }}
             - name: TUIST_HOSTED

--- a/infra/helm/tuist/templates/server-migration-job.yaml
+++ b/infra/helm/tuist/templates/server-migration-job.yaml
@@ -87,6 +87,14 @@ spec:
             {{- end }}
             - name: TUIST_APP_URL
               value: {{ .Values.server.appUrl | quote }}
+            {{- with .Values.server.ops.url }}
+            - name: TUIST_OPS_URL
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.server.ops.hosts }}
+            - name: TUIST_OPS_HOSTS
+              value: {{ join "," . | quote }}
+            {{- end }}
             - name: TUIST_HOSTED
               value: {{ .Values.server.hosted | ternary "1" "0" | quote }}
             - name: TUIST_SELF_HOSTING_DEVELOPMENT_MODE

--- a/infra/helm/tuist/templates/server-ops-ingress.yaml
+++ b/infra/helm/tuist/templates/server-ops-ingress.yaml
@@ -1,0 +1,37 @@
+{{- if and .Values.server.enabled .Values.server.ops.ingress.enabled }}
+{{- $svcName := include "tuist.componentName" (dict "root" . "component" "server") }}
+{{- $svcPort := .Values.server.service.port }}
+{{- $host := required "server.ops.ingress.host is required when server.ops.ingress.enabled=true" .Values.server.ops.ingress.host }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "tuist.componentName" (dict "root" . "component" "server") }}-ops
+  labels:
+    {{- include "tuist.labels" . | nindent 4 }}
+    app.kubernetes.io/component: server
+  {{- with .Values.server.ops.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.server.ops.ingress.className }}
+  ingressClassName: {{ . | quote }}
+  {{- end }}
+  tls:
+    - hosts:
+        - {{ $host | quote }}
+      {{- with .Values.server.ops.ingress.tlsSecretName }}
+      secretName: {{ . | quote }}
+      {{- end }}
+  rules:
+    - host: {{ $host | quote }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ $svcName }}
+                port:
+                  number: {{ $svcPort }}
+{{- end }}

--- a/infra/helm/tuist/values.yaml
+++ b/infra/helm/tuist/values.yaml
@@ -74,6 +74,24 @@ server:
   # each one in values.yaml.
   extraEnvFrom: []
   appUrl: http://tuist.local
+  ops:
+    # Optional absolute URL for the human ops surface. When set, the app
+    # renders ops links against this URL and only serves /ops on the hosts
+    # configured below (or the host parsed from this URL).
+    url: ""
+    # Optional comma-equivalent allowlist for Host headers that may serve
+    # /ops. Leave empty to derive the single host from ops.url. Self-hosted
+    # installs with no ops.url keep the historical same-host /ops behavior.
+    hosts: []
+    # Optional dedicated ingress for the ops host. Use an internal-only
+    # ingress class such as tailscale; a public nginx ingress would make the
+    # host reachable from the internet.
+    ingress:
+      enabled: false
+      className: ""
+      host: ""
+      tlsSecretName: ""
+      annotations: {}
   logLevel: info
   hosted: false
   skipEmailConfirmation: true

--- a/server/lib/tuist/environment.ex
+++ b/server/lib/tuist/environment.ex
@@ -891,8 +891,10 @@ defmodule Tuist.Environment do
   end
 
   def ops_url(opts \\ [], secrets \\ secrets()) do
-    path = opts |> Keyword.get(:path, "/ops") |> String.trim_trailing("/")
-    base_url = get([:ops, :url], secrets) || app_base_url(secrets)
+    configured_ops_url = non_empty_value(get([:ops, :url], secrets))
+    default_path = if is_nil(configured_ops_url), do: "/ops", else: "/"
+    path = opts |> Keyword.get(:path, default_path) |> String.trim_trailing("/")
+    base_url = configured_ops_url || app_base_url(secrets)
 
     URI.to_string(%{URI.parse(base_url) | path: path})
   end
@@ -928,6 +930,12 @@ defmodule Tuist.Environment do
       get([:app, :url], secrets) || "http://localhost:8080"
     end
   end
+
+  defp non_empty_value(value) when is_binary(value) do
+    if value == "", do: nil, else: value
+  end
+
+  defp non_empty_value(value), do: value
 
   defp get_route_info(path) do
     case Phoenix.Router.route_info(TuistWeb.Router, "GET", path, "") do

--- a/server/lib/tuist/environment.ex
+++ b/server/lib/tuist/environment.ex
@@ -890,6 +890,37 @@ defmodule Tuist.Environment do
     end
   end
 
+  def ops_url(opts \\ [], secrets \\ secrets()) do
+    path = opts |> Keyword.get(:path, "/ops") |> String.trim_trailing("/")
+    base_url = get([:ops, :url], secrets) || app_base_url(secrets)
+
+    URI.to_string(%{URI.parse(base_url) | path: path})
+  end
+
+  def ops_hosts(secrets \\ secrets()) do
+    case get([:ops, :hosts], secrets) do
+      hosts when is_binary(hosts) ->
+        hosts
+        |> String.split(",")
+        |> Enum.map(&String.trim/1)
+        |> Enum.reject(&(&1 == ""))
+        |> Enum.map(&String.downcase/1)
+
+      _ ->
+        case get([:ops, :url], secrets) do
+          url when is_binary(url) and url != "" ->
+            url
+            |> URI.parse()
+            |> Map.get(:host)
+            |> List.wrap()
+            |> Enum.map(&String.downcase/1)
+
+          _ ->
+            []
+        end
+    end
+  end
+
   defp app_base_url(secrets) do
     if dev?() do
       System.get_env("TUIST_SERVER_URL") || get([:app, :url], secrets) || "http://localhost:8080"

--- a/server/lib/tuist_web/components/account_dropdown.ex
+++ b/server/lib/tuist_web/components/account_dropdown.ex
@@ -77,7 +77,7 @@ defmodule TuistWeb.AccountDropdown do
               </.button>
               <.button
                 :if={Authorization.authorize(:ops_read, @current_user) == :ok}
-                navigate={~p"/ops"}
+                href={Tuist.Environment.ops_url(path: ~p"/ops")}
                 label={dgettext("dashboard", "Operations")}
                 variant="secondary"
               >

--- a/server/lib/tuist_web/components/account_dropdown.ex
+++ b/server/lib/tuist_web/components/account_dropdown.ex
@@ -77,7 +77,7 @@ defmodule TuistWeb.AccountDropdown do
               </.button>
               <.button
                 :if={Authorization.authorize(:ops_read, @current_user) == :ok}
-                href={Tuist.Environment.ops_url(path: ~p"/ops")}
+                href={Tuist.Environment.ops_url()}
                 label={dgettext("dashboard", "Operations")}
                 variant="secondary"
               >

--- a/server/lib/tuist_web/endpoint.ex
+++ b/server/lib/tuist_web/endpoint.ex
@@ -108,5 +108,6 @@ defmodule TuistWeb.Endpoint do
   plug Plug.MethodOverride
   plug Plug.Head
   plug Plug.Session, @session_options
+  plug TuistWeb.Plugs.OpsRootRedirectPlug
   plug TuistWeb.Router
 end

--- a/server/lib/tuist_web/plugs/ops_host_plug.ex
+++ b/server/lib/tuist_web/plugs/ops_host_plug.ex
@@ -1,0 +1,20 @@
+defmodule TuistWeb.Plugs.OpsHostPlug do
+  @moduledoc """
+  Restricts ops routes to the configured ops host when one is set.
+  """
+
+  alias Tuist.Environment
+  alias TuistWeb.Errors.NotFoundError
+
+  def init(opts), do: opts
+
+  def call(conn, _opts) do
+    ops_hosts = Environment.ops_hosts()
+
+    if ops_hosts == [] or String.downcase(conn.host) in ops_hosts do
+      conn
+    else
+      raise NotFoundError, "The page you are looking for doesn't exist or has been moved."
+    end
+  end
+end

--- a/server/lib/tuist_web/plugs/ops_host_plug.ex
+++ b/server/lib/tuist_web/plugs/ops_host_plug.ex
@@ -1,6 +1,6 @@
 defmodule TuistWeb.Plugs.OpsHostPlug do
   @moduledoc """
-  Restricts ops routes to the configured ops host when one is set.
+  Restricts ops routes to the configured ops host.
   """
 
   alias Tuist.Environment
@@ -11,10 +11,15 @@ defmodule TuistWeb.Plugs.OpsHostPlug do
   def call(conn, _opts) do
     ops_hosts = Environment.ops_hosts()
 
-    if ops_hosts == [] or String.downcase(conn.host) in ops_hosts do
-      conn
-    else
-      raise NotFoundError, "The page you are looking for doesn't exist or has been moved."
+    cond do
+      String.downcase(conn.host) in ops_hosts ->
+        conn
+
+      ops_hosts == [] and not Environment.tuist_hosted?() ->
+        conn
+
+      true ->
+        raise NotFoundError, "The page you are looking for doesn't exist or has been moved."
     end
   end
 end

--- a/server/lib/tuist_web/plugs/ops_root_redirect_plug.ex
+++ b/server/lib/tuist_web/plugs/ops_root_redirect_plug.ex
@@ -1,0 +1,28 @@
+defmodule TuistWeb.Plugs.OpsRootRedirectPlug do
+  @moduledoc """
+  Redirects the configured ops host root to the ops surface.
+  """
+
+  import Phoenix.Controller
+  import Plug.Conn
+
+  alias Tuist.Environment
+
+  def init(opts), do: opts
+
+  def call(%{host: host, request_path: "/"} = conn, _opts) do
+    if String.downcase(host) in Environment.ops_hosts() do
+      conn
+      |> put_status(:found)
+      |> redirect(to: redirect_path(conn))
+      |> halt()
+    else
+      conn
+    end
+  end
+
+  def call(conn, _opts), do: conn
+
+  defp redirect_path(%{query_string: ""}), do: "/ops"
+  defp redirect_path(%{query_string: query_string}), do: "/ops?#{query_string}"
+end

--- a/server/lib/tuist_web/router.ex
+++ b/server/lib/tuist_web/router.ex
@@ -721,6 +721,7 @@ defmodule TuistWeb.Router do
 
   # Ops Routes
   pipeline :ops do
+    plug TuistWeb.Plugs.OpsHostPlug
     plug TuistWeb.Authorization, [:current_user, :read, :ops]
     plug :assign_current_path
     plug :skip_csrf_for_fun_with_flags_assets

--- a/server/test/tuist/environment_test.exs
+++ b/server/test/tuist/environment_test.exs
@@ -219,4 +219,52 @@ defmodule Tuist.EnvironmentTest do
       end
     end
   end
+
+  describe "ops_url/2" do
+    test "uses the configured ops URL with the requested path" do
+      secrets = %{
+        "ops" => %{
+          "url" => "https://ops.tuist.dev"
+        }
+      }
+
+      assert Environment.ops_url([path: "/ops/accounts"], secrets) == "https://ops.tuist.dev/ops/accounts"
+    end
+
+    test "falls back to the app URL when no ops URL is configured" do
+      secrets = %{
+        "app" => %{
+          "url" => "https://tuist.dev"
+        }
+      }
+
+      assert Environment.ops_url([path: "/ops"], secrets) == "https://tuist.dev/ops"
+    end
+  end
+
+  describe "ops_hosts/1" do
+    test "returns normalized configured ops hosts" do
+      secrets = %{
+        "ops" => %{
+          "hosts" => "ops.tuist.dev, Ops.Canary.Tuist.Dev, "
+        }
+      }
+
+      assert Environment.ops_hosts(secrets) == ["ops.tuist.dev", "ops.canary.tuist.dev"]
+    end
+
+    test "derives the host from the ops URL when explicit hosts are not configured" do
+      secrets = %{
+        "ops" => %{
+          "url" => "https://ops.tuist.dev"
+        }
+      }
+
+      assert Environment.ops_hosts(secrets) == ["ops.tuist.dev"]
+    end
+
+    test "returns an empty list when ops host restrictions are not configured" do
+      assert Environment.ops_hosts(%{}) == []
+    end
+  end
 end

--- a/server/test/tuist/environment_test.exs
+++ b/server/test/tuist/environment_test.exs
@@ -221,6 +221,16 @@ defmodule Tuist.EnvironmentTest do
   end
 
   describe "ops_url/2" do
+    test "uses the configured ops URL root by default" do
+      secrets = %{
+        "ops" => %{
+          "url" => "https://ops.tuist.dev"
+        }
+      }
+
+      assert Environment.ops_url([], secrets) == "https://ops.tuist.dev"
+    end
+
     test "uses the configured ops URL with the requested path" do
       secrets = %{
         "ops" => %{
@@ -239,6 +249,16 @@ defmodule Tuist.EnvironmentTest do
       }
 
       assert Environment.ops_url([path: "/ops"], secrets) == "https://tuist.dev/ops"
+    end
+
+    test "falls back to the app ops path by default when no ops URL is configured" do
+      secrets = %{
+        "app" => %{
+          "url" => "https://tuist.dev"
+        }
+      }
+
+      assert Environment.ops_url([], secrets) == "https://tuist.dev/ops"
     end
   end
 

--- a/server/test/tuist_web/plugs/ops_host_plug_test.exs
+++ b/server/test/tuist_web/plugs/ops_host_plug_test.exs
@@ -8,12 +8,24 @@ defmodule TuistWeb.Plugs.OpsHostPlugTest do
 
   setup :verify_on_exit!
 
-  test "allows ops routes when no ops hosts are configured", %{conn: conn} do
+  test "allows ops routes when no ops hosts are configured in self-hosted deployments", %{conn: conn} do
     stub(Environment, :ops_hosts, fn -> [] end)
+    stub(Environment, :tuist_hosted?, fn -> false end)
 
     conn = %{conn | host: "tuist.dev"}
 
     assert OpsHostPlug.call(conn, []) == conn
+  end
+
+  test "raises not found when no ops hosts are configured in Tuist-hosted deployments", %{conn: conn} do
+    stub(Environment, :ops_hosts, fn -> [] end)
+    stub(Environment, :tuist_hosted?, fn -> true end)
+
+    conn = %{conn | host: "tuist.dev"}
+
+    assert_raise NotFoundError, "The page you are looking for doesn't exist or has been moved.", fn ->
+      OpsHostPlug.call(conn, [])
+    end
   end
 
   test "allows ops routes on a configured ops host", %{conn: conn} do

--- a/server/test/tuist_web/plugs/ops_host_plug_test.exs
+++ b/server/test/tuist_web/plugs/ops_host_plug_test.exs
@@ -1,0 +1,36 @@
+defmodule TuistWeb.Plugs.OpsHostPlugTest do
+  use TuistTestSupport.Cases.ConnCase
+  use Mimic
+
+  alias Tuist.Environment
+  alias TuistWeb.Errors.NotFoundError
+  alias TuistWeb.Plugs.OpsHostPlug
+
+  setup :verify_on_exit!
+
+  test "allows ops routes when no ops hosts are configured", %{conn: conn} do
+    stub(Environment, :ops_hosts, fn -> [] end)
+
+    conn = %{conn | host: "tuist.dev"}
+
+    assert OpsHostPlug.call(conn, []) == conn
+  end
+
+  test "allows ops routes on a configured ops host", %{conn: conn} do
+    stub(Environment, :ops_hosts, fn -> ["ops.tuist.dev"] end)
+
+    conn = %{conn | host: "ops.tuist.dev"}
+
+    assert OpsHostPlug.call(conn, []) == conn
+  end
+
+  test "raises not found for non-ops hosts when ops hosts are configured", %{conn: conn} do
+    stub(Environment, :ops_hosts, fn -> ["ops.tuist.dev"] end)
+
+    conn = %{conn | host: "tuist.dev"}
+
+    assert_raise NotFoundError, "The page you are looking for doesn't exist or has been moved.", fn ->
+      OpsHostPlug.call(conn, [])
+    end
+  end
+end

--- a/server/test/tuist_web/plugs/ops_root_redirect_plug_test.exs
+++ b/server/test/tuist_web/plugs/ops_root_redirect_plug_test.exs
@@ -1,0 +1,47 @@
+defmodule TuistWeb.Plugs.OpsRootRedirectPlugTest do
+  use TuistTestSupport.Cases.ConnCase
+  use Mimic
+
+  alias Tuist.Environment
+  alias TuistWeb.Plugs.OpsRootRedirectPlug
+
+  setup :verify_on_exit!
+
+  test "redirects the configured ops host root to /ops", %{conn: conn} do
+    stub(Environment, :ops_hosts, fn -> ["ops.tuist.dev"] end)
+
+    conn = %{conn | host: "ops.tuist.dev", request_path: "/"}
+
+    conn = OpsRootRedirectPlug.call(conn, [])
+
+    assert redirected_to(conn, 302) == "/ops"
+    assert conn.halted
+  end
+
+  test "preserves query params when redirecting", %{conn: conn} do
+    stub(Environment, :ops_hosts, fn -> ["ops.tuist.dev"] end)
+
+    conn = %{conn | host: "ops.tuist.dev", request_path: "/", query_string: "foo=bar"}
+
+    conn = OpsRootRedirectPlug.call(conn, [])
+
+    assert redirected_to(conn, 302) == "/ops?foo=bar"
+    assert conn.halted
+  end
+
+  test "does not redirect non-ops hosts", %{conn: conn} do
+    stub(Environment, :ops_hosts, fn -> ["ops.tuist.dev"] end)
+
+    conn = %{conn | host: "tuist.dev", request_path: "/"}
+
+    assert OpsRootRedirectPlug.call(conn, []) == conn
+  end
+
+  test "does not redirect non-root paths", %{conn: conn} do
+    stub(Environment, :ops_hosts, fn -> ["ops.tuist.dev"] end)
+
+    conn = %{conn | host: "ops.tuist.dev", request_path: "/projects"}
+
+    assert OpsRootRedirectPlug.call(conn, []) == conn
+  end
+end


### PR DESCRIPTION
## Summary

This adds the application and Helm-chart foundation for moving the human ops surface off the public app host and onto a dedicated ops host, such as `ops.tuist.dev`, `ops.canary.tuist.dev`, or `ops.staging.tuist.dev`.

The important hosted behavior is default-deny: on Tuist-hosted deployments, `/ops` is not served unless an explicit ops host is configured and the incoming request Host matches it. Self-hosted installs keep the existing same-host behavior when they do not configure a dedicated ops host.

The intended user-facing entry point is the ops host root. With `server.ops.url=https://ops.tuist.dev`, app links point to `https://ops.tuist.dev`. Requests to that host's root redirect to the existing `/ops` route, where the existing ops authentication and authorization checks continue to apply.

## What changed

- Added `Tuist.Environment.ops_url/2` so the app can render ops links against a configured absolute ops URL.
  - When an ops URL is configured, the default URL is the host root, for example `https://ops.tuist.dev`.
  - When no ops URL is configured, it falls back to the existing app-host `/ops` URL for self-hosted compatibility.
  - Callers can still pass an explicit path when they need a specific ops route.
- Added `Tuist.Environment.ops_hosts/1` so the app can derive or read the Host allowlist for `/ops`.
- Added `TuistWeb.Plugs.OpsHostPlug` and inserted it into the `:ops` router pipeline before the existing ops authorization check.
- Added `TuistWeb.Plugs.OpsRootRedirectPlug` so the configured ops host root redirects to `/ops` before the router serves the public marketing root.
- Updated the account dropdown's `Operations` action to use the configured ops URL instead of always navigating to `/ops` on the current host.
- Added optional Helm values under `server.ops` for:
  - `url`: the canonical ops URL used by the app.
  - `hosts`: explicit Host allowlist for serving `/ops`.
  - `ingress`: an optional dedicated ops ingress with configurable class, host, TLS secret, and annotations.
- Injected `TUIST_OPS_URL` and `TUIST_OPS_HOSTS` into the server and migration job when configured.

## Behavior

For Tuist-hosted deployments:

- If no ops host is configured, `/ops` returns not found.
- If `server.ops.url` is configured, the app derives the allowed ops host from that URL. For example, `https://ops.tuist.dev` allows ops routes only when the request Host is `ops.tuist.dev`.
- With `server.ops.url=https://ops.tuist.dev`:
  - `https://tuist.dev/ops` returns not found.
  - `https://ops.tuist.dev` redirects to `/ops` on the same host.
  - `https://ops.tuist.dev/ops` serves the existing ops LiveView surface after the current ops auth/authorization checks pass.
- If `server.ops.hosts` is configured, it becomes the explicit Host allowlist.
- Requests to `/ops` on any other host raise the existing not-found error rather than exposing that the ops surface exists.

For self-hosted deployments:

- If no ops host is configured, `/ops` keeps the existing same-host behavior.
- If an ops host is configured, `/ops` is restricted to that configured host.

## Deployment notes

This does not yet turn on dedicated ops hosts for staging, canary, or production. It only adds the knobs needed to do that safely in a follow-up deployment change once we decide the exact Tailscale/custom-domain setup.

The new `server.ops.ingress` block is meant to support an internal-only ingress class, for example Tailscale. Using a public ingress class for this host would defeat the purpose, so the default remains disabled.

A sample Tailscale-style render works with:

```bash
helm template tuist infra/helm/tuist \
  --show-only templates/server-ops-ingress.yaml \
  --set server.ops.ingress.enabled=true \
  --set server.ops.ingress.className=tailscale \
  --set server.ops.ingress.host=ops-staging
```

## Follow-ups

- Configure managed staging/canary/production values once the ops hostname/Tailscale shape is finalized.
- Add the separate audit/justification flow for sensitive customer-dashboard access. This PR only separates and gates the ops surface by host; it does not add just-in-time prompts or access-reason logging yet.
- Evaluate the same pattern for Atlas in a later PR.

## Tests

- `mix format lib/tuist/environment.ex lib/tuist_web/router.ex lib/tuist_web/components/account_dropdown.ex lib/tuist_web/endpoint.ex lib/tuist_web/plugs/ops_host_plug.ex lib/tuist_web/plugs/ops_root_redirect_plug.ex test/tuist/environment_test.exs test/tuist_web/plugs/ops_host_plug_test.exs test/tuist_web/plugs/ops_root_redirect_plug_test.exs`
- `mix test test/tuist/environment_test.exs test/tuist_web/plugs/ops_host_plug_test.exs test/tuist_web/plugs/ops_root_redirect_plug_test.exs`
- `helm template tuist infra/helm/tuist -f infra/helm/tuist/values-managed-common.yaml -f infra/helm/tuist/values-managed-staging.yaml --set server.image.tag=test --set processor.image.tag=test --set kuraController.image.tag=test`
- `helm template tuist infra/helm/tuist --show-only templates/server-ops-ingress.yaml --set server.ops.ingress.enabled=true --set server.ops.ingress.className=tailscale --set server.ops.ingress.host=ops-staging`
