### PR TITLE
feat(infra): enable managed runner fleets

### DIFF
--- a/infra/helm/tuist/values-managed-canary.yaml
+++ b/infra/helm/tuist/values-managed-canary.yaml
@@ -119,10 +119,10 @@ macosFleet:
     host: api-canary.tuist.dev
 
 # Customer-runner Mac mini fleet — sibling of macosFleet.
-# Canary runs the same concurrency tier as staging (1 host) so
-# we can de-risk the production roll on canary first.
+# Canary keeps one warm runner so the production rollout can be
+# validated on the same substrate first.
 runnersFleet:
-  enabled: false
+  enabled: true
   hostCount: 1
   # Pre-ordered pool. Operator pre-orders Mac minis named with the
   # `tuist-pool-` prefix; the CAPI controller adopts them on demand.
@@ -136,8 +136,8 @@ runnersFleet:
       - "192.168.0.0/16"
   pools:
     - name: default
-      replicas: 2
-      runnerImage: ""
+      replicas: 1
+      runnerImage: "ghcr.io/tuist/tuist-runner@sha256:666cf1180bab17d5b6f5cb800a6b21ecb5b078183a532bcc7a1c040711a295df"
       dispatchLabel: "tuist-canary-macos"
 
 # In-cluster Valkey backs the auth rate limiter (Hammer.Redis). The

--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -212,11 +212,10 @@ macosFleet:
 # customer runs. Apple's SLA permits up to two VMs per host; v1
 # runs one VM per host to keep capacity reasoning simple. Bump
 # this once the operational story for two-per-host is in place.
-# Production gates on staging + canary proving the substrate and
-# the dispatch flow first; this block is inert until
-# `runnersFleet.pools[].runnerImage` is pinned to a built image SHA.
+# Runner images are digest-pinned so subsequent runner-image
+# releases can safely bump all enabled managed environments.
 runnersFleet:
-  enabled: false
+  enabled: true
   hostCount: 5
   # Pre-ordered pool. Operator orders M2-L hosts in the Scaleway
   # console with names starting with `tuist-pool-` ahead of
@@ -233,7 +232,7 @@ runnersFleet:
   pools:
     - name: default
       replicas: 5
-      runnerImage: ""
+      runnerImage: "ghcr.io/tuist/tuist-runner@sha256:666cf1180bab17d5b6f5cb800a6b21ecb5b078183a532bcc7a1c040711a295df"
       dispatchLabel: "tuist-macos"
 
 # In-cluster Valkey backs the auth rate limiter (Hammer.Redis). The


### PR DESCRIPTION
## Summary
- Enable the managed runners fleet for canary and production.
- Pin both environments to the current immutable tuist-runner image digest.
- Keep canary at one runner on one host, and production at five runners on five hosts.

## Verification
- helm lint infra/helm/tuist -f infra/helm/tuist/values-managed-common.yaml -f infra/helm/tuist/values-managed-canary.yaml --set server.image.tag=sha-test --set kuraController.image.tag=sha-test --set kuraRuntime.image.tag=0.4.0
- helm lint infra/helm/tuist -f infra/helm/tuist/values-managed-common.yaml -f infra/helm/tuist/values-managed-production.yaml --set server.image.tag=sha-test --set kuraController.image.tag=sha-test --set kuraRuntime.image.tag=0.4.0
- helm template tuist infra/helm/tuist --namespace tuist -f infra/helm/tuist/values-managed-common.yaml -f infra/helm/tuist/values-managed-canary.yaml --set server.image.tag=sha-test --set kuraController.image.tag=sha-test --set kuraRuntime.image.tag=0.4.0
- helm template tuist infra/helm/tuist --namespace tuist -f infra/helm/tuist/values-managed-common.yaml -f infra/helm/tuist/values-managed-production.yaml --set server.image.tag=sha-test --set kuraController.image.tag=sha-test --set kuraRuntime.image.tag=0.4.0