### PR TITLE
fix(server): handle expired SA tokens in TokenReview response

### DIFF
--- a/server/lib/tuist/kubernetes/client.ex
+++ b/server/lib/tuist/kubernetes/client.ex
@@ -116,7 +116,7 @@ defmodule Tuist.Kubernetes.Client do
   the token, `{:error, :not_service_account}` when authenticated
   but not an SA, or `{:error, _}` on transport / non-2xx errors.
   """
-  def create_token_review(token) when is_binary(token) do
+  def create_token_review(token, opts \\ []) when is_binary(token) do
     body =
       Jason.encode!(%{
         "apiVersion" => "authentication.k8s.io/v1",
@@ -128,6 +128,7 @@ defmodule Tuist.Kubernetes.Client do
       })
 
     case request(:post, "/apis/authentication.k8s.io/v1/tokenreviews",
+           opts: opts,
            body: body,
            headers: [{"content-type", "application/json"}]
          ) do
@@ -149,6 +150,12 @@ defmodule Tuist.Kubernetes.Client do
         parse_sa_principal(user)
 
       {:ok, %{"status" => %{"authenticated" => false}}} ->
+        {:error, :unauthenticated}
+
+      {:ok, %{"status" => %{"error" => _}}} ->
+        # Apiserver omits `authenticated` when validation itself
+        # fails (expired SA token, rotated signing key, malformed
+        # JWT). Fail closed: treat as unauthenticated.
         {:error, :unauthenticated}
 
       {:error, _} = err ->

--- a/server/test/tuist/kubernetes/client_test.exs
+++ b/server/test/tuist/kubernetes/client_test.exs
@@ -218,6 +218,86 @@ defmodule Tuist.Kubernetes.ClientTest do
     end
   end
 
+  describe "create_token_review/2" do
+    @tag :tmp_dir
+    test "returns the SA principal when the token is authenticated and audience-bound", %{tmp_dir: tmp_dir} do
+      opts = in_cluster_opts(tmp_dir)
+
+      expect(Req, :request, fn request_opts ->
+        assert request_opts[:method] == :post
+
+        assert request_opts[:url] ==
+                 "https://kubernetes.default.svc:443/apis/authentication.k8s.io/v1/tokenreviews"
+
+        body = JSON.decode!(request_opts[:body])
+        assert body["spec"]["audiences"] == ["tuist-runners-dispatch"]
+        assert body["spec"]["token"] == "runner-token"
+
+        {:ok,
+         %Req.Response{
+           status: 201,
+           body: %{
+             "status" => %{
+               "authenticated" => true,
+               "audiences" => ["tuist-runners-dispatch"],
+               "user" => %{
+                 "username" => "system:serviceaccount:tuist-runners:tuist-runner-pool-default-runner-abc",
+                 "uid" => "uid-1"
+               }
+             }
+           }
+         }}
+      end)
+
+      assert {:ok, %{namespace: "tuist-runners", name: "tuist-runner-pool-default-runner-abc", uid: "uid-1"}} =
+               Client.create_token_review("runner-token", opts)
+    end
+
+    @tag :tmp_dir
+    test "returns :unauthenticated when the apiserver rejects the token", %{tmp_dir: tmp_dir} do
+      opts = in_cluster_opts(tmp_dir)
+
+      expect(Req, :request, fn _opts ->
+        {:ok, %Req.Response{status: 201, body: %{"status" => %{"authenticated" => false}}}}
+      end)
+
+      assert {:error, :unauthenticated} = Client.create_token_review("runner-token", opts)
+    end
+
+    @tag :tmp_dir
+    test "returns :unauthenticated when the token validation errors out (e.g. expired SA token)", %{tmp_dir: tmp_dir} do
+      # Reproduces the apiserver response when a projected SA token
+      # outlives its TTL: `status` carries an `error` field with no
+      # `authenticated` key. tart-kubelet mints the dispatch-audience
+      # token once at VM boot and doesn't rotate; warm-pool Pods that
+      # sit idle past the TTL hit this path on their next poll.
+      opts = in_cluster_opts(tmp_dir)
+
+      expect(Req, :request, fn _opts ->
+        {:ok,
+         %Req.Response{
+           status: 201,
+           body: %{
+             "status" => %{
+               "error" => "[invalid bearer token, service account token has expired]",
+               "user" => %{}
+             }
+           }
+         }}
+      end)
+
+      assert {:error, :unauthenticated} = Client.create_token_review("expired-token", opts)
+    end
+  end
+
+  defp in_cluster_opts(tmp_dir) do
+    token_path = Path.join(tmp_dir, "token")
+    ca_path = Path.join(tmp_dir, "ca.crt")
+    File.write!(token_path, "in-cluster-token\n")
+    File.write!(ca_path, "test-ca")
+    [env: Env, token_path: token_path, ca_path: ca_path]
+  end
+
   defp kubeconfig(%{token: token}) do
     kubeconfig_user("token: #{token}")
   end


### PR DESCRIPTION
## Summary

- The Kubernetes apiserver returns `status.error` (with no `authenticated` field) on TokenReview when token validation itself fails (expired SA token, rotated signing key, malformed JWT). The `create_token_review/1` case statement didn't cover that shape, so the dispatch endpoint crashed with `CaseClauseError`, returned HTTP 500, and `dispatch-poll.sh`'s catch-all `*)` branch kept retrying instead of taking the 401-and-abort path that lets the runners-controller recycle the Pod.
- Adds a clause that maps the error response to `{:error, :unauthenticated}` so the controller returns 401 and the runner self-heals.
- Adds a regression test plus two adjacent happy/sad-path tests for `create_token_review/2`.

## Context

This surfaced in staging Sentry as 70K events from a single warm-pool Pod ([issue 119485213](https://tuist.sentry.io/issues/119485213/)). Timeline: PR #10653 introduced the warm-pool dispatch flow and rolled out to staging at `2026-05-13 13:56 UTC`. The single warm-pool Pod's tart-kubelet-minted SA token has a 1-hour TTL with no rotation, so once the Pod sat idle for an hour the next dispatch poll triggered the unhandled branch. The retry loop in `dispatch-poll.sh` then hammered the endpoint every 2s indefinitely.

## Follow-up worth considering

This patch is the minimum needed to stop the crash and let the self-heal kick in, but the underlying issue is that `tart-kubelet` mints the SA token once at VM boot and never rotates (see `infra/tart-kubelet/internal/satoken/satoken.go:54`). The design assumption — "the dispatch poll runs once, minutes after boot at most" — doesn't hold for warm-pool Pods. Worth a follow-up to either rotate the token at ~80% of TTL in tart-kubelet (the runner script already re-reads `/etc/tuist-sa-token` per iteration so no script changes needed), or to bound warm-pool dwell time below the TTL.

## Test plan

- [x] `mix test test/tuist/kubernetes/client_test.exs` — 8 tests, 0 failures (5 pre-existing + 3 new for `create_token_review/2`).
- [ ] After staging rollout, confirm in Sentry that `CaseClauseError` events stop and the warm-pool Pod recycles cleanly (Pod transitions to Succeeded, runners-controller spins up a new one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)