### PR TITLE
fix(server): rebackfill window_type on stale automation_alerts rows

### DIFF
--- a/server/priv/repo/migrations/20260514120000_rebackfill_window_type_on_automation_alerts.exs
+++ b/server/priv/repo/migrations/20260514120000_rebackfill_window_type_on_automation_alerts.exs
@@ -1,0 +1,47 @@
+defmodule Tuist.Repo.Migrations.RebackfillWindowTypeOnAutomationAlerts do
+  use Ecto.Migration
+
+  @moduledoc """
+  Re-runs the `window_type` backfill from `20260508120000` to catch rows
+  that slipped past the original pass. Production observed a flakiness
+  alert whose `trigger_config` and `recovery_config` still lacked
+  `window_type`, crashing `AlertEvaluationWorker.establish_baseline/2`
+  on every cadence. The statements are idempotent, so re-running is safe
+  for already-backfilled rows.
+  """
+
+  def up do
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    execute("""
+    UPDATE automation_alerts
+    SET trigger_config = trigger_config || jsonb_build_object('window_type', 'last_days')
+    WHERE NOT (trigger_config ? 'window_type')
+    """)
+
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    execute("""
+    UPDATE automation_alerts
+    SET recovery_config =
+      (recovery_config - 'days_without_trigger')
+      || jsonb_build_object(
+        'window',
+        (recovery_config->>'days_without_trigger') || 'd'
+      )
+    WHERE recovery_enabled = true
+      AND NOT (recovery_config ? 'window')
+      AND recovery_config ? 'days_without_trigger'
+    """)
+
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    execute("""
+    UPDATE automation_alerts
+    SET recovery_config = recovery_config || jsonb_build_object('window_type', 'last_days')
+    WHERE recovery_enabled = true
+      AND NOT (recovery_config ? 'window_type')
+    """)
+  end
+
+  def down do
+    :ok
+  end
+end


### PR DESCRIPTION
Resolves the `MatchError` crash in `Tuist.Automations.Workers.AlertEvaluationWorker.establish_baseline/2` reported in [Sentry TUIST-FE](https://tuist.sentry.io/issues/TUIST-FE) (164 occurrences in prod over a few hours, looping every 5 min via Oban retries).

### Root cause

At least one production row in `automation_alerts` still has `trigger_config` and `recovery_config` without `window_type`. The original backfill at `20260508120000` should have normalised every row, but it missed this one. Any update through `Alert.changeset/2` (UI toggle, API edit, the worker's baseline stamp) re-validates the whole row and fails with:

```
recovery_config: {"window_type must be one of: last_days, rolling", []},
trigger_config:  {"window_type must be one of: last_days, rolling", []}
```

### Fix

Re-run the same idempotent backfill so any rows that slipped past the first pass get the same `window_type: "last_days"` default. Safe to re-run for rows that already have `window_type`; the `WHERE NOT (... ? 'window_type')` clauses make every statement a no-op against already-backfilled rows.

### How to test locally

```
cd server
mix test test/tuist/automations/workers/alert_evaluation_worker_test.exs
```

The test suite runs all pending migrations during setup, so the new migration is exercised. The worker tests continue to pass.