### PR TITLE
fix(server): gate Guardian.DB.Sweeper on web mode

### DIFF
--- a/server/lib/tuist/application.ex
+++ b/server/lib/tuist/application.ex
@@ -4,6 +4,7 @@ defmodule Tuist.Application do
   use Application
   use Boundary, top_level?: true, deps: [Tuist, TuistWeb]
 
+  alias Tuist.Application.RuntimeChildren
   alias Tuist.Builds.Build
   alias Tuist.Builds.BuildFile
   alias Tuist.Builds.BuildIssue
@@ -312,7 +313,7 @@ defmodule Tuist.Application do
         {TuistWeb.RateLimit.InMemory, [clean_period: to_timeout(hour: 1)]},
         {Tuist.API.Pipeline, []},
         TuistWeb.Telemetry
-      ] ++ guardian_db_sweeper_children() ++ dev_content_children() ++ [TuistWeb.Endpoint]
+      ] ++ RuntimeChildren.guardian_db_sweeper(Environment.mode()) ++ dev_content_children() ++ [TuistWeb.Endpoint]
 
     children
     |> Kernel.++(
@@ -394,18 +395,6 @@ defmodule Tuist.Application do
           id: Tuist.Marketing.ContentFileWatcher
         )
       ]
-    else
-      []
-    end
-  end
-
-  # Guardian refresh tokens are only issued and verified by the Phoenix
-  # endpoint, and the `:processor` / `:xcresult_processor` pods connect
-  # with a DB role that lacks privileges on `guardian_tokens`. Running
-  # the sweeper there fails every interval with `permission denied`.
-  defp guardian_db_sweeper_children do
-    if Environment.web?() do
-      [{Guardian.DB.Sweeper, [interval: 60 * 60 * 1000]}]
     else
       []
     end

--- a/server/lib/tuist/application.ex
+++ b/server/lib/tuist/application.ex
@@ -311,9 +311,8 @@ defmodule Tuist.Application do
         {Phoenix.PubSub, name: Tuist.PubSub},
         {TuistWeb.RateLimit.InMemory, [clean_period: to_timeout(hour: 1)]},
         {Tuist.API.Pipeline, []},
-        {Guardian.DB.Sweeper, [interval: 60 * 60 * 1000]},
         TuistWeb.Telemetry
-      ] ++ dev_content_children() ++ [TuistWeb.Endpoint]
+      ] ++ guardian_db_sweeper_children() ++ dev_content_children() ++ [TuistWeb.Endpoint]
 
     children
     |> Kernel.++(
@@ -395,6 +394,18 @@ defmodule Tuist.Application do
           id: Tuist.Marketing.ContentFileWatcher
         )
       ]
+    else
+      []
+    end
+  end
+
+  # Guardian refresh tokens are only issued and verified by the Phoenix
+  # endpoint, and the `:processor` / `:xcresult_processor` pods connect
+  # with a DB role that lacks privileges on `guardian_tokens`. Running
+  # the sweeper there fails every interval with `permission denied`.
+  defp guardian_db_sweeper_children do
+    if Environment.web?() do
+      [{Guardian.DB.Sweeper, [interval: 60 * 60 * 1000]}]
     else
       []
     end

--- a/server/lib/tuist/application/runtime_children.ex
+++ b/server/lib/tuist/application/runtime_children.ex
@@ -1,0 +1,26 @@
+defmodule Tuist.Application.RuntimeChildren do
+  @moduledoc """
+  Pure functions deriving supervision-tree children from pod role.
+
+  Lifted out of `Tuist.Application` so they can be unit-tested against
+  every value of `Tuist.Environment.modes/0`. Mirrors the rationale in
+  `Tuist.Oban.RuntimeConfig`: keep mode-specific gates expressed as
+  allowlists (`mode == :web`) rather than denylists of known non-web
+  modes, so a future role (`:scheduler`, `:ingest`, ...) is excluded by
+  default and has to opt in.
+  """
+
+  @sweeper_interval_ms 60 * 60 * 1000
+
+  @doc """
+  Child spec list for `Guardian.DB.Sweeper`, gated on pod mode.
+
+  Returns the sweeper for `:web`; empty for every other mode. Refresh
+  tokens are only issued and verified by the Phoenix endpoint, and
+  non-web pods connect with a DB role that lacks privileges on
+  `guardian_tokens` — running the sweeper there fails every interval
+  with `permission denied`.
+  """
+  def guardian_db_sweeper(:web), do: [{Guardian.DB.Sweeper, [interval: @sweeper_interval_ms]}]
+  def guardian_db_sweeper(_), do: []
+end

--- a/server/test/tuist/application/runtime_children_test.exs
+++ b/server/test/tuist/application/runtime_children_test.exs
@@ -1,0 +1,23 @@
+defmodule Tuist.Application.RuntimeChildrenTest do
+  use ExUnit.Case, async: true
+
+  alias Tuist.Application.RuntimeChildren
+  alias Tuist.Environment
+
+  describe "guardian_db_sweeper/1" do
+    test ":web starts the sweeper" do
+      assert [{Guardian.DB.Sweeper, opts}] = RuntimeChildren.guardian_db_sweeper(:web)
+      assert Keyword.fetch!(opts, :interval) > 0
+    end
+
+    test "every non-web mode returns no children" do
+      for mode <- Environment.modes(), mode != :web do
+        assert RuntimeChildren.guardian_db_sweeper(mode) == [],
+               "expected no Guardian.DB.Sweeper child for #{inspect(mode)} — " <>
+                 "non-web pods connect with a DB role that lacks privileges on " <>
+                 "`guardian_tokens` and the sweeper would fail every interval " <>
+                 "with `permission denied`"
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes [TUIST-3Q](https://tuist.sentry.io/issues/TUIST-3Q) — `Postgrex.Error: ERROR 42501 (insufficient_privilege) permission denied for table guardian_tokens` (1770 occurrences, regressed).

### What changed

`Guardian.DB.Sweeper` is now only started on `:web` pods, via a new pure module `Tuist.Application.RuntimeChildren` that returns the child spec list for a given pod mode.

Structure follows [#10679](https://github.com/tuist/tuist/pull/10679)'s `Tuist.Oban.RuntimeConfig`: the gate is an **allowlist** keyed on `:web` (not a denylist of known non-web modes), and the logic lives in a pure module so a unit test can iterate `Tuist.Environment.modes/0` and assert every non-web mode returns `[]`. A future role like `:scheduler` or `:ingest` is excluded by default and has to opt in.

### Why

The sweeper was previously started in every pod regardless of `TUIST_MODE`. The `:processor` and `:xcresult_processor` pods connect with a DB role that has no privileges on `guardian_tokens`, so the hourly sweep raised `permission denied` on every tick from each non-web pod.

Refresh tokens are issued and verified exclusively by the Phoenix endpoint, which the processor pods don't run, so gating the sweeper on web mode aligns its lifecycle with the only pod that owns the table.

### How to test locally

- `mix test test/tuist/application/runtime_children_test.exs` — 2 tests, all modes covered.
- Manual: start with `TUIST_MODE=processor mix phx.server` and confirm `Guardian.DB.Sweeper` is absent from the supervision tree (`Supervisor.which_children(Tuist.Supervisor)`). With `TUIST_MODE` unset (web mode), it should still appear.