### PR TITLE
fix(server): send Content-Length on GHES manifest exchange

### DIFF
--- a/server/config/config.exs
+++ b/server/config/config.exs
@@ -154,7 +154,11 @@ config :logger, :console,
     :ours,
     :winner,
     :observed_status,
-    :ch_error
+    :ch_error,
+    :stage,
+    :client_url,
+    :status,
+    :body
   ]
 
 config :mime, :types, %{

--- a/server/lib/tuist_web/controllers/github_app_manifest_controller.ex
+++ b/server/lib/tuist_web/controllers/github_app_manifest_controller.ex
@@ -75,7 +75,7 @@ defmodule TuistWeb.GitHubAppManifestController do
     with {:ok, %{account_id: account_id, client_url: client_url}} <- VCS.verify_github_state_token(state_token),
          :ok <- ensure_entitled(account_id),
          {:ok, account} <- Accounts.get_account_by_id(account_id),
-         {:ok, app} <- exchange_manifest_code(client_url, code),
+         {:ok, app} <- exchange_manifest_code(account_id, client_url, code),
          {:ok, installation} <- upsert_installation(account, client_url, app) do
       install_state = VCS.generate_github_state_token(account.id, client_url)
       install_url = "#{client_url}/apps/#{installation.app_slug}/installations/new?state=#{install_state}"
@@ -101,13 +101,8 @@ defmodule TuistWeb.GitHubAppManifestController do
                 "GitHub Enterprise Server is only available on the Enterprise plan."
               )
 
-      {:error, reason} when is_binary(reason) ->
-        Logger.error("GitHub App manifest exchange failed: #{reason}")
-        raise BadRequestError, dgettext("dashboard", "Could not complete the GitHub App registration.")
-
-      {:error, reason} ->
-        Logger.error("GitHub App manifest exchange failed: #{inspect(reason)}")
-        raise BadRequestError, dgettext("dashboard", "Could not complete the GitHub App registration.")
+      {:error, {:exchange_failed, ctx}} ->
+        handle_exchange_failure(ctx)
     end
   end
 
@@ -233,29 +228,130 @@ defmodule TuistWeb.GitHubAppManifestController do
     """
   end
 
-  defp exchange_manifest_code(client_url, code) do
+  defp exchange_manifest_code(account_id, client_url, code) do
     api_url = VCS.api_url(:github, client_url)
     url = "#{api_url}/app-manifests/#{code}/conversions"
+    base_ctx = %{account_id: account_id, client_url: client_url}
 
-    with {:ok, pinned_url, hostname} <- SSRFGuard.pin(url) do
-      case Req.post(
-             url: pinned_url,
-             headers: [
-               {"Accept", "application/vnd.github+json"},
-               {"X-GitHub-Api-Version", "2022-11-28"}
-             ],
-             connect_options: SSRFGuard.connect_options(hostname)
-           ) do
-        {:ok, %Req.Response{status: status, body: %{"id" => _} = body}} when status in 200..299 ->
-          {:ok, body}
+    case SSRFGuard.pin(url) do
+      {:ok, pinned_url, hostname} ->
+        post_manifest_exchange(base_ctx, pinned_url, hostname)
 
-        {:ok, %Req.Response{status: status, body: body}} ->
-          {:error, "Manifest conversion failed (HTTP #{status}): #{redact_secrets(body)}"}
-
-        {:error, reason} ->
-          {:error, "Manifest conversion request failed: #{inspect(reason)}"}
-      end
+      {:error, reason} ->
+        {:error, {:exchange_failed, Map.merge(base_ctx, %{stage: :ssrf, reason: reason})}}
     end
+  end
+
+  defp post_manifest_exchange(base_ctx, pinned_url, hostname) do
+    # `body: ""` forces a `Content-Length: 0` header. GitHub Enterprise
+    # Server rejects this POST with HTTP 411 otherwise; github.com's API
+    # tolerates the missing header.
+    case Req.post(
+           url: pinned_url,
+           body: "",
+           headers: [
+             {"Accept", "application/vnd.github+json"},
+             {"X-GitHub-Api-Version", "2022-11-28"}
+           ],
+           connect_options: SSRFGuard.connect_options(hostname)
+         ) do
+      {:ok, %Req.Response{status: status, body: %{"id" => _} = body}} when status in 200..299 ->
+        {:ok, body}
+
+      {:ok, %Req.Response{status: status, body: body}} ->
+        {:error, {:exchange_failed, Map.merge(base_ctx, %{stage: :http, status: status, body: redact_secrets(body)})}}
+
+      {:error, reason} ->
+        {:error, {:exchange_failed, Map.merge(base_ctx, %{stage: :transport, reason: inspect(reason)})}}
+    end
+  end
+
+  defp handle_exchange_failure(%{stage: :ssrf, client_url: client_url, account_id: account_id, reason: reason}) do
+    Logger.error("GitHub App manifest exchange blocked by SSRF guard",
+      stage: :ssrf,
+      client_url: client_url,
+      account_id: account_id,
+      reason: inspect(reason)
+    )
+
+    message =
+      case reason do
+        :private_ip_resolved ->
+          dgettext(
+            "dashboard",
+            "%{url} resolves to a non-public IP address, so Tuist Cloud refuses to connect to it. Self-host Tuist inside your network to integrate with an internal GitHub Enterprise Server.",
+            url: client_url
+          )
+
+        :dns_failure ->
+          dgettext(
+            "dashboard",
+            "Tuist could not resolve %{url}. Double-check the GitHub Enterprise Server URL is correct and publicly resolvable.",
+            url: client_url
+          )
+
+        _ ->
+          dgettext("dashboard", "Could not complete the GitHub App registration.")
+      end
+
+    raise BadRequestError, message
+  end
+
+  defp handle_exchange_failure(%{stage: :transport, client_url: client_url, account_id: account_id, reason: reason}) do
+    Logger.error("GitHub App manifest exchange request failed",
+      stage: :transport,
+      client_url: client_url,
+      account_id: account_id,
+      reason: reason
+    )
+
+    raise BadRequestError,
+          dgettext(
+            "dashboard",
+            "Tuist could not reach %{url}. Confirm the instance is reachable from the public internet, or self-host Tuist if it's internal-only.",
+            url: client_url
+          )
+  end
+
+  defp handle_exchange_failure(%{
+         stage: :http,
+         client_url: client_url,
+         account_id: account_id,
+         status: status,
+         body: body
+       }) do
+    Logger.error("GitHub App manifest exchange returned non-success",
+      stage: :http,
+      client_url: client_url,
+      account_id: account_id,
+      status: status,
+      body: body
+    )
+
+    message =
+      case status do
+        404 ->
+          dgettext(
+            "dashboard",
+            "GitHub Enterprise Server returned 404 when converting the manifest. The temporary registration code may have expired (it's valid for one hour) — start the flow again from the integrations page."
+          )
+
+        s when s in [410, 422] ->
+          dgettext(
+            "dashboard",
+            "GitHub Enterprise Server rejected the manifest with HTTP %{status}. The registration code is no longer usable — start the flow again from the integrations page.",
+            status: s
+          )
+
+        s ->
+          dgettext(
+            "dashboard",
+            "GitHub Enterprise Server returned HTTP %{status} when converting the manifest. Check the server logs for the request body and retry.",
+            status: s
+          )
+      end
+
+    raise BadRequestError, message
   end
 
   defp upsert_installation(account, client_url, app) do

--- a/server/lib/tuist_web/controllers/github_app_manifest_controller.ex
+++ b/server/lib/tuist_web/controllers/github_app_manifest_controller.ex
@@ -279,7 +279,7 @@ defmodule TuistWeb.GitHubAppManifestController do
         :private_ip_resolved ->
           dgettext(
             "dashboard",
-            "%{url} resolves to a non-public IP address, so Tuist Cloud refuses to connect to it. Self-host Tuist inside your network to integrate with an internal GitHub Enterprise Server.",
+            "%{url} resolves to a non-public IP address, so Tuist refuses to connect to it. Self-host Tuist inside your network to integrate with an internal GitHub Enterprise Server.",
             url: client_url
           )
 

--- a/server/lib/tuist_web/controllers/github_app_manifest_controller.ex
+++ b/server/lib/tuist_web/controllers/github_app_manifest_controller.ex
@@ -279,7 +279,7 @@ defmodule TuistWeb.GitHubAppManifestController do
         :private_ip_resolved ->
           dgettext(
             "dashboard",
-            "%{url} resolves to a non-public IP address, so Tuist refuses to connect to it. Self-host Tuist inside your network to integrate with an internal GitHub Enterprise Server.",
+            "%{url} resolves to a non-public IP address, so Tuist refuses to connect to it. Either expose the GitHub Enterprise Server API on a public address (allowlisting Tuist's egress IPs is enough), or self-host Tuist inside your network.",
             url: client_url
           )
 

--- a/server/priv/gettext/dashboard.pot
+++ b/server/priv/gettext/dashboard.pot
@@ -1282,7 +1282,7 @@ msgstr ""
 
 #: lib/tuist_web/controllers/github_app_manifest_controller.ex:276
 #, elixir-autogen, elixir-format
-msgid "%{url} resolves to a non-public IP address, so Tuist Cloud refuses to connect to it. Self-host Tuist inside your network to integrate with an internal GitHub Enterprise Server."
+msgid "%{url} resolves to a non-public IP address, so Tuist refuses to connect to it. Self-host Tuist inside your network to integrate with an internal GitHub Enterprise Server."
 msgstr ""
 
 #: lib/tuist_web/controllers/github_app_manifest_controller.ex:336

--- a/server/priv/gettext/dashboard.pot
+++ b/server/priv/gettext/dashboard.pot
@@ -110,7 +110,7 @@ msgid "Emails"
 msgstr ""
 
 #: lib/tuist_web/controllers/error_html.ex:133
-#: lib/tuist_web/live/ops_account_kura_deployment_live.html.heex:40
+#: lib/tuist_web/live/ops_account_kura_deployment_live.html.heex:42
 #, elixir-autogen, elixir-format
 msgid "Error"
 msgstr ""
@@ -137,7 +137,7 @@ msgid "Go to dashboard"
 msgstr ""
 
 #: lib/tuist_web/components/app_layout_components.ex:428
-#: lib/tuist_web/live/ops_account_kura_deployment_live.html.heex:50
+#: lib/tuist_web/live/ops_account_kura_deployment_live.html.heex:52
 #, elixir-autogen, elixir-format
 msgid "Grafana"
 msgstr ""
@@ -664,12 +664,12 @@ msgstr ""
 msgid "Active"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:150
+#: lib/tuist_web/live/ops_account_live.html.heex:152
 #, elixir-autogen, elixir-format
 msgid "Address line 1"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:158
+#: lib/tuist_web/live/ops_account_live.html.heex:160
 #, elixir-autogen, elixir-format
 msgid "Address line 2 (optional)"
 msgstr ""
@@ -699,13 +699,13 @@ msgstr ""
 msgid "Belgium"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:196
+#: lib/tuist_web/live/ops_account_live.html.heex:198
 #, elixir-autogen, elixir-format
 msgid "Billing cadence"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:59
-#: lib/tuist_web/live/ops_account_live.html.heex:142
+#: lib/tuist_web/live/ops_account_live.html.heex:61
+#: lib/tuist_web/live/ops_account_live.html.heex:144
 #: lib/tuist_web/live/ops_accounts_live.html.heex:30
 #, elixir-autogen, elixir-format
 msgid "Billing email"
@@ -726,12 +726,12 @@ msgstr ""
 msgid "Canada"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:213
+#: lib/tuist_web/live/ops_account_live.html.heex:215
 #, elixir-autogen, elixir-format
 msgid "Cancel"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:92
+#: lib/tuist_web/live/ops_account_live.html.heex:94
 #, elixir-autogen, elixir-format
 msgid "Cancel %{account}'s subscription at the end of the current billing period? Access is kept until then."
 msgstr ""
@@ -741,7 +741,7 @@ msgstr ""
 msgid "Cancel failed: %{reason}"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:89
+#: lib/tuist_web/live/ops_account_live.html.heex:91
 #, elixir-autogen, elixir-format
 msgid "Cancel plan"
 msgstr ""
@@ -762,7 +762,7 @@ msgstr ""
 msgid "China"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:164
+#: lib/tuist_web/live/ops_account_live.html.heex:166
 #, elixir-autogen, elixir-format
 msgid "City"
 msgstr ""
@@ -772,12 +772,12 @@ msgstr ""
 msgid "Colombia"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:184
+#: lib/tuist_web/live/ops_account_live.html.heex:186
 #, elixir-autogen, elixir-format
 msgid "Country"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:112
+#: lib/tuist_web/live/ops_account_live.html.heex:114
 #, elixir-autogen, elixir-format
 msgid "Creates a Stripe customer (if missing), sets the billing address, and starts an invoice-billed Enterprise subscription. The customer receives an invoice by email; no card is collected here."
 msgstr ""
@@ -832,7 +832,7 @@ msgstr ""
 msgid "Failed"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_kura_deployment_live.html.heex:31
+#: lib/tuist_web/live/ops_account_kura_deployment_live.html.heex:33
 #, elixir-autogen, elixir-format
 msgid "Finished"
 msgstr ""
@@ -912,7 +912,7 @@ msgstr ""
 msgid "Kura deployment"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:28
+#: lib/tuist_web/live/ops_account_live.html.heex:30
 #, elixir-autogen, elixir-format
 msgid "Latest deployment"
 msgstr ""
@@ -942,7 +942,7 @@ msgstr ""
 msgid "Malta"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:72
+#: lib/tuist_web/live/ops_account_live.html.heex:74
 #, elixir-autogen, elixir-format
 msgid "Manage on Stripe"
 msgstr ""
@@ -952,8 +952,8 @@ msgstr ""
 msgid "Mexico"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:199
-#: lib/tuist_web/live/ops_account_live.html.heex:203
+#: lib/tuist_web/live/ops_account_live.html.heex:201
+#: lib/tuist_web/live/ops_account_live.html.heex:205
 #, elixir-autogen, elixir-format
 msgid "Monthly"
 msgstr ""
@@ -963,7 +963,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:134
+#: lib/tuist_web/live/ops_account_live.html.heex:136
 #, elixir-autogen, elixir-format
 msgid "Name on invoice"
 msgstr ""
@@ -995,9 +995,9 @@ msgstr ""
 
 #: lib/tuist_web/live/ops_account_kura_deployment_live.ex:85
 #: lib/tuist_web/live/ops_account_live.html.heex:23
-#: lib/tuist_web/live/ops_account_live.html.heex:26
-#: lib/tuist_web/live/ops_account_live.html.heex:31
-#: lib/tuist_web/live/ops_account_live.html.heex:60
+#: lib/tuist_web/live/ops_account_live.html.heex:27
+#: lib/tuist_web/live/ops_account_live.html.heex:33
+#: lib/tuist_web/live/ops_account_live.html.heex:62
 #: lib/tuist_web/live/ops_accounts_live.html.heex:31
 #, elixir-autogen, elixir-format
 msgid "None"
@@ -1008,7 +1008,7 @@ msgstr ""
 msgid "Norway"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:63
+#: lib/tuist_web/live/ops_account_live.html.heex:65
 #: lib/tuist_web/live/ops_accounts_live.html.heex:48
 #, elixir-autogen, elixir-format
 msgid "Not created"
@@ -1034,13 +1034,13 @@ msgstr ""
 msgid "Philippines"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:45
+#: lib/tuist_web/live/ops_account_live.html.heex:47
 #: lib/tuist_web/live/ops_accounts_live.html.heex:33
 #, elixir-autogen, elixir-format
 msgid "Plan"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:42
+#: lib/tuist_web/live/ops_account_live.html.heex:44
 #, elixir-autogen, elixir-format
 msgid "Plan & billing"
 msgstr ""
@@ -1055,7 +1055,7 @@ msgstr ""
 msgid "Portugal"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:178
+#: lib/tuist_web/live/ops_account_live.html.heex:180
 #, elixir-autogen, elixir-format
 msgid "Postal code"
 msgstr ""
@@ -1085,7 +1085,7 @@ msgstr ""
 msgid "Search by name"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:187
+#: lib/tuist_web/live/ops_account_live.html.heex:189
 #, elixir-autogen, elixir-format
 msgid "Select a country"
 msgstr ""
@@ -1120,26 +1120,26 @@ msgstr ""
 msgid "Spain"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_kura_deployment_live.html.heex:27
+#: lib/tuist_web/live/ops_account_kura_deployment_live.html.heex:29
 #, elixir-autogen, elixir-format
 msgid "Started"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:172
+#: lib/tuist_web/live/ops_account_live.html.heex:174
 #, elixir-autogen, elixir-format
 msgid "State / region (optional)"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_kura_deployment_live.html.heex:11
-#: lib/tuist_web/live/ops_account_kura_deployment_live.html.heex:16
+#: lib/tuist_web/live/ops_account_kura_deployment_live.html.heex:13
+#: lib/tuist_web/live/ops_account_kura_deployment_live.html.heex:18
 #: lib/tuist_web/live/ops_account_live.html.heex:15
-#: lib/tuist_web/live/ops_account_live.html.heex:52
+#: lib/tuist_web/live/ops_account_live.html.heex:54
 #: lib/tuist_web/live/ops_accounts_live.html.heex:40
 #, elixir-autogen, elixir-format
 msgid "Status"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:62
+#: lib/tuist_web/live/ops_account_live.html.heex:64
 #: lib/tuist_web/live/ops_accounts_live.html.heex:47
 #, elixir-autogen, elixir-format
 msgid "Stripe customer"
@@ -1210,13 +1210,13 @@ msgstr ""
 msgid "United States"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:107
+#: lib/tuist_web/live/ops_account_live.html.heex:109
 #, elixir-autogen, elixir-format
 msgid "Upgrade %{account} to Enterprise"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:80
-#: lib/tuist_web/live/ops_account_live.html.heex:221
+#: lib/tuist_web/live/ops_account_live.html.heex:82
+#: lib/tuist_web/live/ops_account_live.html.heex:223
 #, elixir-autogen, elixir-format
 msgid "Upgrade to Enterprise"
 msgstr ""
@@ -1236,13 +1236,12 @@ msgstr ""
 msgid "Vietnam"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:204
+#: lib/tuist_web/live/ops_account_live.html.heex:206
 #, elixir-autogen, elixir-format
 msgid "Yearly"
 msgstr ""
 
-#: lib/tuist_web/controllers/github_app_manifest_controller.ex:106
-#: lib/tuist_web/controllers/github_app_manifest_controller.ex:110
+#: lib/tuist_web/controllers/github_app_manifest_controller.ex:290
 #, elixir-autogen, elixir-format
 msgid "Could not complete the GitHub App registration."
 msgstr ""
@@ -1253,15 +1252,15 @@ msgid "GitHub Enterprise Server installations must go through the App registrati
 msgstr ""
 
 #: lib/tuist_web/controllers/github_app_manifest_controller.ex:99
-#: lib/tuist_web/controllers/github_app_manifest_controller.ex:125
+#: lib/tuist_web/controllers/github_app_manifest_controller.ex:120
 #, elixir-autogen, elixir-format
 msgid "GitHub Enterprise Server is only available on the Enterprise plan."
 msgstr ""
 
 #: lib/tuist_web/controllers/github_app_manifest_controller.ex:66
 #: lib/tuist_web/controllers/github_app_manifest_controller.ex:85
-#: lib/tuist_web/controllers/github_app_manifest_controller.ex:115
-#: lib/tuist_web/controllers/github_app_manifest_controller.ex:131
+#: lib/tuist_web/controllers/github_app_manifest_controller.ex:110
+#: lib/tuist_web/controllers/github_app_manifest_controller.ex:126
 #, elixir-autogen, elixir-format
 msgid "Invalid manifest registration request."
 msgstr ""
@@ -1279,4 +1278,34 @@ msgstr ""
 #: lib/tuist_web/controllers/github_app_manifest_controller.ex:92
 #, elixir-autogen, elixir-format
 msgid "This account already has a GitHub app installation. Uninstall it before registering a new one."
+msgstr ""
+
+#: lib/tuist_web/controllers/github_app_manifest_controller.ex:276
+#, elixir-autogen, elixir-format
+msgid "%{url} resolves to a non-public IP address, so Tuist Cloud refuses to connect to it. Self-host Tuist inside your network to integrate with an internal GitHub Enterprise Server."
+msgstr ""
+
+#: lib/tuist_web/controllers/github_app_manifest_controller.ex:336
+#, elixir-autogen, elixir-format
+msgid "GitHub Enterprise Server rejected the manifest with HTTP %{status}. The registration code is no longer usable — start the flow again from the integrations page."
+msgstr ""
+
+#: lib/tuist_web/controllers/github_app_manifest_controller.ex:330
+#, elixir-autogen, elixir-format
+msgid "GitHub Enterprise Server returned 404 when converting the manifest. The temporary registration code may have expired (it's valid for one hour) — start the flow again from the integrations page."
+msgstr ""
+
+#: lib/tuist_web/controllers/github_app_manifest_controller.ex:343
+#, elixir-autogen, elixir-format
+msgid "GitHub Enterprise Server returned HTTP %{status} when converting the manifest. Check the server logs for the request body and retry."
+msgstr ""
+
+#: lib/tuist_web/controllers/github_app_manifest_controller.ex:305
+#, elixir-autogen, elixir-format
+msgid "Tuist could not reach %{url}. Confirm the instance is reachable from the public internet, or self-host Tuist if it's internal-only."
+msgstr ""
+
+#: lib/tuist_web/controllers/github_app_manifest_controller.ex:283
+#, elixir-autogen, elixir-format
+msgid "Tuist could not resolve %{url}. Double-check the GitHub Enterprise Server URL is correct and publicly resolvable."
 msgstr ""

--- a/server/priv/gettext/dashboard.pot
+++ b/server/priv/gettext/dashboard.pot
@@ -1282,7 +1282,7 @@ msgstr ""
 
 #: lib/tuist_web/controllers/github_app_manifest_controller.ex:276
 #, elixir-autogen, elixir-format
-msgid "%{url} resolves to a non-public IP address, so Tuist refuses to connect to it. Self-host Tuist inside your network to integrate with an internal GitHub Enterprise Server."
+msgid "%{url} resolves to a non-public IP address, so Tuist refuses to connect to it. Either expose the GitHub Enterprise Server API on a public address (allowlisting Tuist's egress IPs is enough), or self-host Tuist inside your network."
 msgstr ""
 
 #: lib/tuist_web/controllers/github_app_manifest_controller.ex:336

--- a/server/test/tuist_web/controllers/github_app_manifest_controller_test.exs
+++ b/server/test/tuist_web/controllers/github_app_manifest_controller_test.exs
@@ -100,7 +100,13 @@ defmodule TuistWeb.GitHubAppManifestControllerTest do
 
       stub(SSRFGuard, :connect_options, fn "github.example.com" -> [hostname: "github.example.com"] end)
 
-      stub(Req, :post, fn _opts -> {:ok, %Req.Response{status: 201, body: app_payload}} end)
+      stub(Req, :post, fn opts ->
+        # GHES rejects POSTs without Content-Length with HTTP 411. Req only
+        # emits the header when an explicit body is passed, so guard the
+        # call shape here.
+        assert Keyword.fetch!(opts, :body) == ""
+        {:ok, %Req.Response{status: 201, body: app_payload}}
+      end)
 
       conn =
         get(conn, ~p"/integrations/github/manifest/callback", %{
@@ -124,6 +130,70 @@ defmodule TuistWeb.GitHubAppManifestControllerTest do
     test "rejects an invalid state token", %{conn: conn} do
       assert_raise BadRequestError, fn ->
         get(conn, ~p"/integrations/github/manifest/callback", %{"code" => "x", "state" => "garbage"})
+      end
+    end
+
+    test "surfaces a private-IP SSRF block as a self-host hint", %{conn: conn} do
+      account = AccountsFixtures.user_fixture(preload: [:account]).account
+      ghes_url = "https://github.internal.example.com"
+      state_token = VCS.generate_github_state_token(account.id, ghes_url)
+
+      stub(SSRFGuard, :pin, fn _url -> {:error, :private_ip_resolved} end)
+
+      assert_raise BadRequestError, ~r/non-public IP address.*Self-host Tuist/s, fn ->
+        get(conn, ~p"/integrations/github/manifest/callback", %{
+          "code" => "tmpcode",
+          "state" => state_token
+        })
+      end
+    end
+
+    test "surfaces a DNS failure with the offending URL", %{conn: conn} do
+      account = AccountsFixtures.user_fixture(preload: [:account]).account
+      ghes_url = "https://github.does-not-exist.example.com"
+      state_token = VCS.generate_github_state_token(account.id, ghes_url)
+
+      stub(SSRFGuard, :pin, fn _url -> {:error, :dns_failure} end)
+
+      assert_raise BadRequestError, ~r/could not resolve #{Regex.escape(ghes_url)}/, fn ->
+        get(conn, ~p"/integrations/github/manifest/callback", %{
+          "code" => "tmpcode",
+          "state" => state_token
+        })
+      end
+    end
+
+    test "surfaces a transport failure as an unreachable-instance hint", %{conn: conn} do
+      account = AccountsFixtures.user_fixture(preload: [:account]).account
+      ghes_url = "https://github.example.com"
+      state_token = VCS.generate_github_state_token(account.id, ghes_url)
+
+      stub(SSRFGuard, :pin, fn _url -> {:ok, "https://198.51.100.10/path", "github.example.com"} end)
+      stub(SSRFGuard, :connect_options, fn _ -> [] end)
+      stub(Req, :post, fn _opts -> {:error, %Mint.TransportError{reason: :econnrefused}} end)
+
+      assert_raise BadRequestError, ~r/could not reach #{Regex.escape(ghes_url)}/, fn ->
+        get(conn, ~p"/integrations/github/manifest/callback", %{
+          "code" => "tmpcode",
+          "state" => state_token
+        })
+      end
+    end
+
+    test "surfaces an HTTP 404 as a likely-expired-code hint", %{conn: conn} do
+      account = AccountsFixtures.user_fixture(preload: [:account]).account
+      ghes_url = "https://github.example.com"
+      state_token = VCS.generate_github_state_token(account.id, ghes_url)
+
+      stub(SSRFGuard, :pin, fn _url -> {:ok, "https://198.51.100.10/path", "github.example.com"} end)
+      stub(SSRFGuard, :connect_options, fn _ -> [] end)
+      stub(Req, :post, fn _opts -> {:ok, %Req.Response{status: 404, body: %{"message" => "Not Found"}}} end)
+
+      assert_raise BadRequestError, ~r/returned 404.*valid for one hour/s, fn ->
+        get(conn, ~p"/integrations/github/manifest/callback", %{
+          "code" => "tmpcode",
+          "state" => state_token
+        })
       end
     end
 

--- a/server/test/tuist_web/controllers/github_app_manifest_controller_test.exs
+++ b/server/test/tuist_web/controllers/github_app_manifest_controller_test.exs
@@ -140,7 +140,7 @@ defmodule TuistWeb.GitHubAppManifestControllerTest do
 
       stub(SSRFGuard, :pin, fn _url -> {:error, :private_ip_resolved} end)
 
-      assert_raise BadRequestError, ~r/non-public IP address.*Self-host Tuist/s, fn ->
+      assert_raise BadRequestError, ~r/non-public IP address.*self-host Tuist/si, fn ->
         get(conn, ~p"/integrations/github/manifest/callback", %{
           "code" => "tmpcode",
           "state" => state_token


### PR DESCRIPTION
### Summary

The GitHub App manifest registration flow for self-hosted GitHub Enterprise Server was failing with a generic 400 "Could not complete the GitHub App registration." page after the customer successfully created the app on their GHES instance.

Root cause: `Req.post(url: ..., headers: ...)` with no `body` field results in a request without a `Content-Length` header. GHES enforces RFC 7230 strictly and rejects such POSTs with HTTP 411 Length Required; github.com's API tolerates the missing header. Fix is `body: ""` to force `Content-Length: 0`.

While here, the catch-all error branch in the callback was collapsing every distinct failure mode (SSRF block, transport error, non-2xx response, malformed body) into the same generic message. That made the original 411 invisible from the user's side and required a Grafana sweep to surface. The callback now:

- Returns a tagged error tuple per failure stage (`:ssrf | :transport | :http`).
- Emits structured `Logger.error` metadata (`stage`, `client_url`, `account_id`, plus `reason`/`status`/`body`) so future surprises are filterable in Grafana.
- Renders a stage-appropriate user-facing message — e.g. private-IP block → "Self-host Tuist inside your network"; DNS failure → "Tuist could not resolve <url>"; HTTP 404 → "registration code may have expired".

Logger metadata allowlist in `config/config.exs` extended with `:stage`, `:client_url`, `:status`, `:body`.

### How to test locally

1. `mix test test/tuist_web/controllers/github_app_manifest_controller_test.exs` — 14 tests, including a regression assertion that `Req.post` is called with `body: ""`, plus dedicated tests for SSRF / DNS / transport / HTTP 404 paths.
2. Manual smoke check (any self-hosted GHES instance): hit `/integrations/github/manifest/start?state=<token>`, complete the manifest creation on GHES, confirm you're redirected to the install page rather than the 400 page. If you don't have a GHES instance handy, the new tests pin the call shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)