### PR TITLE
feat(infra): bump production runner fleet to 9 hosts

### DIFF
--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -208,7 +208,7 @@ macosFleet:
   controlPlane:
     host: api.tuist.dev
 
-# Customer-runner Mac mini fleet. Sized to 5 hosts = 5 concurrent
+# Customer-runner Mac mini fleet. Sized to 9 hosts = 9 concurrent
 # customer runs. Apple's SLA permits up to two VMs per host; v1
 # runs one VM per host to keep capacity reasoning simple. Bump
 # this once the operational story for two-per-host is in place.
@@ -216,7 +216,7 @@ macosFleet:
 # releases can safely bump all enabled managed environments.
 runnersFleet:
   enabled: true
-  hostCount: 5
+  hostCount: 9
   # Pre-ordered pool. Operator orders M2-L hosts in the Scaleway
   # console with names starting with `tuist-pool-` ahead of
   # bringing this block live (Mac mini lead times can stretch
@@ -231,7 +231,7 @@ runnersFleet:
       - "192.168.0.0/16"
   pools:
     - name: default
-      replicas: 5
+      replicas: 9
       runnerImage: "ghcr.io/tuist/tuist-runner@sha256:666cf1180bab17d5b6f5cb800a6b21ecb5b078183a532bcc7a1c040711a295df"
       dispatchLabel: "tuist-macos"
 


### PR DESCRIPTION
## Summary
- Bumps the managed production runner fleet from 5 to 9 Mac mini hosts (four extra machines) to add concurrent customer-run capacity headroom.
- Updates `hostCount`, `pools[0].replicas`, and the sizing comment in `infra/helm/tuist/values-managed-production.yaml` accordingly.

## Test plan
- [ ] CI passes on the helm chart
- [ ] Verify four additional `tuist-pool-` Mac minis are pre-ordered in Scaleway before this rolls out
- [ ] After deploy, confirm the new hosts are adopted by the CAPI controller and registered as online runners