### PR TITLE
fix(server): clear docker ghcr credentials for xcresult image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2146,8 +2146,15 @@ jobs:
         working-directory: infra/xcresult-processor-image
         run: packer init xcresult-processor.pkr.hcl
 
+      # Keep the Cirrus base-image pull anonymous. Tart also consults
+      # Docker credential helpers, so clear both stores before Packer
+      # clones ghcr.io/cirruslabs/*.
       - name: Drop cached ghcr.io credentials
-        run: tart logout ghcr.io || true
+        run: |
+          tart logout ghcr.io || true
+          if command -v docker >/dev/null 2>&1; then
+            docker logout ghcr.io || true
+          fi
 
       - name: Reclaim Tart disk
         run: |

--- a/.github/workflows/xcresult-processor-image.yml
+++ b/.github/workflows/xcresult-processor-image.yml
@@ -104,9 +104,14 @@ jobs:
       # The bare-metal runner has tuist-bot ghcr.io creds cached from
       # earlier image-push jobs. Those creds don't authorize pulls
       # from ghcr.io/cirruslabs/*, so Tart's token-fetch returns 403.
-      # Log out so Tart falls back to anonymous (public) for the pull.
+      # Tart also consults Docker credential helpers, so clear both
+      # stores before the public anonymous pull.
       - name: Drop cached ghcr.io credentials
-        run: tart logout ghcr.io || true
+        run: |
+          tart logout ghcr.io || true
+          if command -v docker >/dev/null 2>&1; then
+            docker logout ghcr.io || true
+          fi
 
       # Reclaim disk before the Cirrus pull. macos-tahoe-xcode:26.4 is
       # ~70GB on disk; the bare-metal Mac mini accumulates older Tart


### PR DESCRIPTION
## Summary
- Clear any cached `ghcr.io` credentials from both Tart and Docker before the xcresult processor image build pulls the public Cirrus Labs base image.
- Apply the same cleanup to both `.github/workflows/release.yml` and `.github/workflows/xcresult-processor-image.yml` so semver releases and SHA-tagged image builds behave consistently.
- Guard `docker logout` behind `command -v docker` so the cleanup remains harmless on runners where Docker is not installed.

## Problem
The xcresult processor release failed in the `Build image` step while Packer was cloning the Tart base VM:

https://github.com/tuist/tuist/actions/runs/25851179926/job/75958475691

The release build itself completed far enough to package the macOS Erlang release. The failure happened before provisioning, when Tart attempted to pull `ghcr.io/cirruslabs/macos-tahoe-xcode:26.4` and GHCR returned `403` while retrieving an authentication token.

## Root Cause
The workflow already ran `tart logout ghcr.io` before the Packer build so Tart could pull the public Cirrus image anonymously. However, Tart also supports Docker credential helpers from `~/.docker/config.json`. On the self-hosted `vm-image-builder` runner, a cached `tuist-bot` GHCR credential can still be available through Docker. That token is valid for Tuist packages but does not authorize reads from `ghcr.io/cirruslabs/*`, so Tart sends an authenticated request that GHCR rejects instead of falling back to the anonymous public pull.

## Changes
- In `release.yml`, expand the `Drop cached ghcr.io credentials` step for the xcresult processor release job to:
  - run `tart logout ghcr.io || true`
  - run `docker logout ghcr.io || true` when Docker is available
- In `xcresult-processor-image.yml`, make the same cleanup in the standalone image workflow.
- Update the surrounding comments to explain why both credential stores are cleared before the public Cirrus pull.

## Validation
- `git diff --check`
- `actionlint -ignore 'label ".+" is unknown' -ignore 'property "uploaded" is not defined' .github/workflows/xcresult-processor-image.yml .github/workflows/release.yml`

The `actionlint` ignores are for pre-existing repo-specific warnings: custom self-hosted runner labels and existing `upload-artifact` output references.

## Rollout Notes
The fix is exercised by rerunning the xcresult processor image release path on the self-hosted Mac mini. The expected behavior is that the Cirrus Labs base-image pull is anonymous, while the later Tuist image push still logs in to GHCR explicitly after the Packer build.