### PR TITLE
fix(cli): avoid collecting large verbose HTTP bodies

### DIFF
--- a/cli/Sources/TuistHTTP/VerboseLoggingMiddleware.swift
+++ b/cli/Sources/TuistHTTP/VerboseLoggingMiddleware.swift
@@ -7,6 +7,7 @@ import TuistLogging
 /// A middleware that outputs in debug mode the request and responses sent and received from the server
 public struct VerboseLoggingMiddleware: ClientMiddleware {
     private let serviceName: String
+    private let maxBodyBytesToLog: Int64
 
     private static let sensitiveHeaders: Set<String> = [
         "authorization",
@@ -21,8 +22,9 @@ public struct VerboseLoggingMiddleware: ClientMiddleware {
         "x-amz-credential",
     ]
 
-    public init(serviceName: String = "Tuist") {
+    public init(serviceName: String = "Tuist", maxBodyBytesToLog: Int64 = 64 * 1024) {
         self.serviceName = serviceName
+        self.maxBodyBytesToLog = maxBodyBytesToLog
     }
 
     public func intercept(
@@ -97,6 +99,9 @@ public struct VerboseLoggingMiddleware: ClientMiddleware {
         case .none: return (.none, body)
         case .unknown: return (.unknownLength, body)
         case let .known(length):
+            guard length <= maxBodyBytesToLog else {
+                return (.tooManyBytesToLog(length), body)
+            }
             let bodyData = try await Data(collecting: body!, upTo: Int(length))
             return (.complete(bodyData), HTTPBody(bodyData))
         }

--- a/cli/Tests/TuistHTTPTests/VerboseLoggingMiddlewareTests.swift
+++ b/cli/Tests/TuistHTTPTests/VerboseLoggingMiddlewareTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import HTTPTypes
+import OpenAPIRuntime
 import Testing
 
 @testable import TuistHTTP
@@ -98,4 +99,59 @@ struct VerboseLoggingMiddlewareTests {
 
         #expect(gotResponse.status == response.status)
     }
+
+    @Test func process_logs_complete_body_when_within_size_limit() async throws {
+        let subject = VerboseLoggingMiddleware(maxBodyBytesToLog: 5)
+        let body = HTTPBody(Data("hello".utf8))
+
+        let result = try await subject.process(body)
+
+        #expect(result.bodyToLog == .complete(Data("hello".utf8)))
+        let bodyForNext = try #require(result.bodyForNext)
+        let dataForNext = try await Data(collecting: bodyForNext, upTo: 5)
+        #expect(dataForNext == Data("hello".utf8))
+    }
+
+    @Test func process_does_not_collect_body_when_it_exceeds_size_limit() async throws {
+        let subject = VerboseLoggingMiddleware(maxBodyBytesToLog: 4)
+        let body = HTTPBody(Data("hello".utf8))
+
+        let result = try await subject.process(body)
+
+        #expect(result.bodyToLog == .tooManyBytesToLog(5))
+        let bodyForNext = try #require(result.bodyForNext)
+        #expect(bodyForNext == body)
+        let dataForNext = try await Data(collecting: bodyForNext, upTo: 5)
+        #expect(dataForNext == Data("hello".utf8))
+    }
+
+    @Test func process_does_not_iterate_body_when_it_exceeds_size_limit() async throws {
+        let subject = VerboseLoggingMiddleware(maxBodyBytesToLog: 4)
+        let body = HTTPBody(
+            FailingOnIterationBodySequence(),
+            length: .known(5),
+            iterationBehavior: .single
+        )
+
+        let result = try await subject.process(body)
+
+        #expect(result.bodyToLog == .tooManyBytesToLog(5))
+        #expect(result.bodyForNext == body)
+    }
 }
+
+private struct FailingOnIterationBodySequence: AsyncSequence, Sendable {
+    typealias Element = HTTPBody.ByteChunk
+
+    func makeAsyncIterator() -> Iterator {
+        Iterator()
+    }
+
+    struct Iterator: AsyncIteratorProtocol {
+        mutating func next() async throws -> HTTPBody.ByteChunk? {
+            throw BodyWasIteratedError()
+        }
+    }
+}
+
+private struct BodyWasIteratedError: Error {}


### PR DESCRIPTION
## Summary
- Limit verbose HTTP body logging to 64 KB and pass through larger bodies without collecting them.
- Preserve small-body logging behavior.
- Add regression coverage that fails if the middleware iterates an oversized body.

## Investigation
The attached CI logs show Tuist 4.194.0 fetching remote cache binaries with high concurrency and verbose logs enabled. The verbose HTTP middleware collected known-length response bodies for logging, including large binary cache artifacts, which matches the observed crash pattern.

## TDD Evidence
Focused red check, with the guard temporarily removed:

```text
Caught error: BodyWasIteratedError()
```

Green check after restoring the fix:

```sh
swift test --replace-scm-with-registry --filter VerboseLoggingMiddlewareTests
```

Result: 10 tests passed.
