### PR TITLE
fix(server): isolate Tart GHCR credentials for xcresult image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2212,6 +2212,10 @@ jobs:
         run: echo "${{ secrets.GITHUB_TOKEN }}" | tart login ghcr.io --username tuist-bot --password-stdin
 
       - name: Push image to GHCR
+        env:
+          TART_REGISTRY_HOSTNAME: ghcr.io
+          TART_REGISTRY_USERNAME: tuist-bot
+          TART_REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           VERSION="${{ needs.check-releases.outputs.xcresult-processor-image-next-version-number }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2184,7 +2184,7 @@ jobs:
       - name: Build image
         working-directory: infra/xcresult-processor-image
         run: |
-          env -u GITHUB_TOKEN packer build \
+          env -u GITHUB_TOKEN -u MISE_GITHUB_TOKEN packer build \
             -var "output_image=tuist-xcresult-processor" \
             -var "release_tarball=/tmp/release.tar.gz" \
             xcresult-processor.pkr.hcl

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2184,6 +2184,25 @@ jobs:
       - name: Build image
         working-directory: infra/xcresult-processor-image
         run: |
+          set -euo pipefail
+          docker_config="$HOME/.docker/config.json"
+          docker_config_backup=""
+          restore_docker_config() {
+            if [ -n "$docker_config_backup" ] && [ -f "$docker_config_backup" ]; then
+              mkdir -p "$HOME/.docker"
+              mv "$docker_config_backup" "$docker_config"
+            fi
+          }
+          trap restore_docker_config EXIT
+
+          # Tart hardcodes ~/.docker/config.json when looking up Docker
+          # credential helpers. Move it aside so the public Cirrus image is
+          # pulled anonymously instead of through stale ghcr.io credentials.
+          if [ -f "$docker_config" ]; then
+            docker_config_backup="$(mktemp "${RUNNER_TEMP:-/tmp}/docker-config.XXXXXX")"
+            mv "$docker_config" "$docker_config_backup"
+          fi
+
           env -u GITHUB_TOKEN -u MISE_GITHUB_TOKEN packer build \
             -var "output_image=tuist-xcresult-processor" \
             -var "release_tarball=/tmp/release.tar.gz" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2147,14 +2147,21 @@ jobs:
         run: packer init xcresult-processor.pkr.hcl
 
       # Keep the Cirrus base-image pull anonymous. Tart also consults
-      # Docker credential helpers, so clear both stores before Packer
-      # clones ghcr.io/cirruslabs/*.
+      # Docker credential helpers, and this runner can have the macOS
+      # helper installed without the Docker CLI. Clear both stores
+      # before Packer clones ghcr.io/cirruslabs/*.
       - name: Drop cached ghcr.io credentials
         run: |
           tart logout ghcr.io || true
           if command -v docker >/dev/null 2>&1; then
             docker logout ghcr.io || true
           fi
+          for helper in docker-credential-osxkeychain docker-credential-desktop; do
+            if command -v "$helper" >/dev/null 2>&1; then
+              printf 'ghcr.io' | "$helper" erase || true
+              printf 'https://ghcr.io' | "$helper" erase || true
+            fi
+          done
 
       - name: Reclaim Tart disk
         run: |
@@ -2170,7 +2177,7 @@ jobs:
       - name: Build image
         working-directory: infra/xcresult-processor-image
         run: |
-          packer build \
+          env -u GITHUB_TOKEN packer build \
             -var "output_image=tuist-xcresult-processor" \
             -var "release_tarball=/tmp/release.tar.gz" \
             xcresult-processor.pkr.hcl

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2142,9 +2142,16 @@ jobs:
           tar -czf /tmp/release.tar.gz -C "${{ steps.release.outputs.dir }}" .
           ls -lh /tmp/release.tar.gz
 
+      - name: Update Tart
+        run: |
+          set -euo pipefail
+          brew update
+          brew upgrade cirruslabs/cli/tart || brew install cirruslabs/cli/tart
+          tart --version
+
       - name: Initialize Packer
         working-directory: infra/xcresult-processor-image
-        run: packer init xcresult-processor.pkr.hcl
+        run: packer init -upgrade xcresult-processor.pkr.hcl
 
       # Keep the Cirrus base-image pull anonymous. Tart also consults
       # Docker credential helpers, and this runner can have the macOS

--- a/.github/workflows/xcresult-processor-image.yml
+++ b/.github/workflows/xcresult-processor-image.yml
@@ -145,6 +145,25 @@ jobs:
       - name: Build image
         working-directory: infra/xcresult-processor-image
         run: |
+          set -euo pipefail
+          docker_config="$HOME/.docker/config.json"
+          docker_config_backup=""
+          restore_docker_config() {
+            if [ -n "$docker_config_backup" ] && [ -f "$docker_config_backup" ]; then
+              mkdir -p "$HOME/.docker"
+              mv "$docker_config_backup" "$docker_config"
+            fi
+          }
+          trap restore_docker_config EXIT
+
+          # Tart hardcodes ~/.docker/config.json when looking up Docker
+          # credential helpers. Move it aside so the public Cirrus image is
+          # pulled anonymously instead of through stale ghcr.io credentials.
+          if [ -f "$docker_config" ]; then
+            docker_config_backup="$(mktemp "${RUNNER_TEMP:-/tmp}/docker-config.XXXXXX")"
+            mv "$docker_config" "$docker_config_backup"
+          fi
+
           env -u GITHUB_TOKEN -u MISE_GITHUB_TOKEN packer build \
             -var "base_image=${{ inputs.base_image || 'ghcr.io/cirruslabs/macos-tahoe-xcode:26.4' }}" \
             -var "output_image=tuist-xcresult-processor" \

--- a/.github/workflows/xcresult-processor-image.yml
+++ b/.github/workflows/xcresult-processor-image.yml
@@ -104,14 +104,21 @@ jobs:
       # The bare-metal runner has tuist-bot ghcr.io creds cached from
       # earlier image-push jobs. Those creds don't authorize pulls
       # from ghcr.io/cirruslabs/*, so Tart's token-fetch returns 403.
-      # Tart also consults Docker credential helpers, so clear both
-      # stores before the public anonymous pull.
+      # Tart also consults Docker credential helpers, and this runner
+      # can have the macOS helper installed without the Docker CLI.
+      # Clear both stores before the public anonymous pull.
       - name: Drop cached ghcr.io credentials
         run: |
           tart logout ghcr.io || true
           if command -v docker >/dev/null 2>&1; then
             docker logout ghcr.io || true
           fi
+          for helper in docker-credential-osxkeychain docker-credential-desktop; do
+            if command -v "$helper" >/dev/null 2>&1; then
+              printf 'ghcr.io' | "$helper" erase || true
+              printf 'https://ghcr.io' | "$helper" erase || true
+            fi
+          done
 
       # Reclaim disk before the Cirrus pull. macos-tahoe-xcode:26.4 is
       # ~70GB on disk; the bare-metal Mac mini accumulates older Tart
@@ -131,7 +138,7 @@ jobs:
       - name: Build image
         working-directory: infra/xcresult-processor-image
         run: |
-          packer build \
+          env -u GITHUB_TOKEN packer build \
             -var "base_image=${{ inputs.base_image || 'ghcr.io/cirruslabs/macos-tahoe-xcode:26.4' }}" \
             -var "output_image=tuist-xcresult-processor" \
             -var "release_tarball=/tmp/release.tar.gz" \

--- a/.github/workflows/xcresult-processor-image.yml
+++ b/.github/workflows/xcresult-processor-image.yml
@@ -174,6 +174,10 @@ jobs:
         run: echo "${{ secrets.GITHUB_TOKEN }}" | tart login ghcr.io --username tuist-bot --password-stdin
 
       - name: Push image to GHCR
+        env:
+          TART_REGISTRY_HOSTNAME: ghcr.io
+          TART_REGISTRY_USERNAME: tuist-bot
+          TART_REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # SHA-tagged builds for ad-hoc deploys; semver tags + `:latest`
           # are owned by release.yml's release-xcresult-processor job.

--- a/.github/workflows/xcresult-processor-image.yml
+++ b/.github/workflows/xcresult-processor-image.yml
@@ -145,7 +145,7 @@ jobs:
       - name: Build image
         working-directory: infra/xcresult-processor-image
         run: |
-          env -u GITHUB_TOKEN packer build \
+          env -u GITHUB_TOKEN -u MISE_GITHUB_TOKEN packer build \
             -var "base_image=${{ inputs.base_image || 'ghcr.io/cirruslabs/macos-tahoe-xcode:26.4' }}" \
             -var "output_image=tuist-xcresult-processor" \
             -var "release_tarball=/tmp/release.tar.gz" \

--- a/.github/workflows/xcresult-processor-image.yml
+++ b/.github/workflows/xcresult-processor-image.yml
@@ -96,10 +96,17 @@ jobs:
           tar -czf /tmp/release.tar.gz -C "${{ steps.release.outputs.dir }}" .
           ls -lh /tmp/release.tar.gz
 
+      - name: Update Tart
+        run: |
+          set -euo pipefail
+          brew update
+          brew upgrade cirruslabs/cli/tart || brew install cirruslabs/cli/tart
+          tart --version
+
       # 2. Bake the tarball into a Tart image.
       - name: Initialize Packer
         working-directory: infra/xcresult-processor-image
-        run: packer init xcresult-processor.pkr.hcl
+        run: packer init -upgrade xcresult-processor.pkr.hcl
 
       # The bare-metal runner has tuist-bot ghcr.io creds cached from
       # earlier image-push jobs. Those creds don't authorize pulls


### PR DESCRIPTION
## Summary
- Keep xcresult processor image builds from inheriting stale `ghcr.io` Docker credential-helper state on the self-hosted macOS image-builder runner.
- Update Tart before Packer runs and initialize the Packer plugin with `-upgrade` so the workflow uses the current Tart CLI/plugin behavior.
- Run the Cirrus base-image clone without GitHub token environment variables and with `~/.docker/config.json` temporarily moved aside, forcing the public Cirrus GHCR image pull to be anonymous.
- Push the resulting Tuist image with explicit Tart registry environment credentials so Docker helper credentials cannot override the freshly authorized GHCR push.
- Apply the same credential handling to both the standalone `xcresult-processor-image.yml` workflow and the release workflow.

## Context
The release job was still failing after #10792 merged:

https://github.com/tuist/tuist/actions/runs/25863860435/job/76001871128

The failure happened before provisioning the VM. Packer invoked Tart, Tart tried to clone `ghcr.io/cirruslabs/macos-tahoe-xcode:26.4`, and GHCR returned `403` while Tart retrieved the bearer token.

Anonymous GHCR access to the Cirrus image works, so the failure pointed at the image-builder runner sending an unwanted `ghcr.io` credential. The first follow-up only erased known helper entries and removed `GITHUB_TOKEN` from the Packer process, but manual preflight runs proved that was not enough.

## Root Cause
Tart checks credentials in this order:

1. `TART_REGISTRY_*` environment variables
2. Docker config credentials from `$HOME/.docker/config.json`
3. Tart keychain credentials

The key detail is that Tart hardcodes `$HOME/.docker/config.json`; it does not honor `DOCKER_CONFIG`. On this persistent macOS runner, the Docker config can point Tart at helper credentials for `ghcr.io`. Those credentials are valid enough for Tart to send authenticated GHCR token requests, but not authorized for the public Cirrus package, producing the 403.

The same precedence also affected publishing: after the build restored Docker config, `tart push` saw Docker helper credentials before the fresh `tart login` keychain entry and failed with the same token 403. Supplying `TART_REGISTRY_*` on the push step makes Tart use the workflow token first.

## Changes
- Upgrade/install Tart in the image workflows before Packer runs and print `tart --version`.
- Run `packer init -upgrade` for the xcresult processor Packer template.
- Keep the existing `tart logout ghcr.io`, guarded `docker logout ghcr.io`, and direct helper erases for `docker-credential-osxkeychain` / `docker-credential-desktop`.
- Temporarily move `$HOME/.docker/config.json` out of the way only around `packer build`, restoring it with a shell trap afterwards.
- Invoke Packer as `env -u GITHUB_TOKEN -u MISE_GITHUB_TOKEN packer build ...`.
- Add `TART_REGISTRY_HOSTNAME`, `TART_REGISTRY_USERNAME`, and `TART_REGISTRY_PASSWORD` to the GHCR push steps so Tart uses explicit Actions-token credentials for publishing.

## Manual Workflow Validation
Pre-merge validation used the existing manual workflow dispatch path on this PR branch:

| Run | Result | Notes |
| --- | --- | --- |
| https://github.com/tuist/tuist/actions/runs/25866675143 | Failed | Reproduced the original GHCR 403 on the PR branch. |
| https://github.com/tuist/tuist/actions/runs/25867351451 | Failed | Tart upgraded to `2.32.1`, but the Cirrus pull still hit the same 403. |
| https://github.com/tuist/tuist/actions/runs/25868097624 | Failed | `GITHUB_TOKEN` and `MISE_GITHUB_TOKEN` were removed from Packer, but Docker config credentials still leaked in. |
| https://github.com/tuist/tuist/actions/runs/25869191997 | Partially passed | `Build image` succeeded, proving the Cirrus pull was fixed; push then failed from Docker credential precedence. |
| https://github.com/tuist/tuist/actions/runs/25870549677 | Passed | Built and pushed `ghcr.io/tuist/tuist-xcresult-processor:976569a5`. |

## Local Validation
- `git diff --check`
- `actionlint -ignore 'label ".+" is unknown' -ignore 'property "uploaded" is not defined' .github/workflows/xcresult-processor-image.yml .github/workflows/release.yml`

The `actionlint` ignores are for existing custom runner labels and existing upload-artifact output warnings in the repo.
