### PR TITLE
fix(infra): set HOME on the runner image LaunchDaemon

### DIFF
--- a/infra/runner-image/launchd.plist
+++ b/infra/runner-image/launchd.plist
@@ -58,6 +58,20 @@
         -->
         <key>RUNNER_ALLOW_RUNASROOT</key>
         <string>1</string>
+
+        <!--
+          LaunchDaemons start with a minimal environment — no HOME,
+          no PATH beyond the daemon defaults. The Actions runner
+          forwards its own env to every step shell, so an unset
+          HOME here propagates into customer workflows where any
+          tool that reads `$HOME/.gitconfig` (git, mise, gh) errors
+          out with `fatal: $HOME not set` before doing anything.
+          `/var/root` is the canonical home for uid 0 on macOS;
+          set it so step shells inherit a working HOME that matches
+          the user the runner is actually running as.
+        -->
+        <key>HOME</key>
+        <string>/var/root</string>
     </dict>
 
     <key>ProcessType</key>


### PR DESCRIPTION
> Customer workflow steps on the Tuist managed runner fleet fail with `fatal: \$HOME not set` because LaunchDaemons boot without HOME and the Actions runner forwards its env to every step shell.

### Symptom

First end-to-end workflow_job dispatched to the production fleet ([PR #10793, lint job](https://github.com/tuist/tuist/actions/runs/25853096592/job/75996012263)) failed on the second step:

```
Updating TuistCacheEE submodule...
Configuring git to use GitHub token for authentication...
fatal: \$HOME not set
fatal: \$HOME not set
##[error]Process completed with exit code 128.
```

actions/checkout works around the missing HOME by setting a temporary value during its own git invocations, then restores the original. With nothing to restore to, subsequent steps that touch `\$HOME/.gitconfig` (git, mise, gh, anything tracking per-user config) error out.

### Cause

The runner's launchd.plist explicitly sets `RUNNER_ALLOW_RUNASROOT` but no other env. On macOS, LaunchDaemons start with a near-empty environment — HOME isn't inherited because there's no parent user session. The Actions runner inside the daemon spawns step shells with that env, so HOME stays unset all the way through.

### Fix

Add `HOME=/var/root` to the daemon's `EnvironmentVariables`. `/var/root` is the canonical home for uid 0 on macOS, which matches what the daemon already runs as. One-line addition next to `RUNNER_ALLOW_RUNASROOT`.

### How to test locally

This change only takes effect once a new runner image is built and the digest is pinned in helm. Test plan:

- [ ] Wait for `runner-image.yml` to rebuild `tuist-runner` from this branch.
- [ ] Bump `runnersFleet.pools[].runnerImage` in `infra/helm/tuist/values-managed-{canary,production}.yaml` to the new digest (separate PR).
- [ ] Once deployed, dispatch a workflow_job (e.g. retrigger the CLI lint job on PR #10793) and confirm the previously-failing `Initialize TuistCacheEE submodule` step now passes.
- [ ] Quick local check before image rebuild: SSH into one of the runner Mac minis, run `launchctl print system/dev.tuist.runner | grep -i home` against the booted Tart VM — should show `HOME = /var/root`.

### Follow-ups (out of scope here; tracked for separate PRs)

The HOME bug surfaced a broader audit of how the Tuist runner image compares to `macos-26` / Namespace baselines. The items below are NOT addressed in this PR — capturing them so the gap is visible and prioritised.

**Will break customer workflows if missing (parity bugs)**

- `LANG` / `LC_ALL` set to `en_US.UTF-8` — LaunchDaemons default to `C`; Ruby, Python, Node, Bundler crash on UTF-8 paths.
- Xcode first-launch + license-accepted at image-build time (`sudo xcodebuild -runFirstLaunch`, `sudo xcodebuild -license accept`) — without these the simulator catalog is empty and some `xcodebuild` invocations error.
- `PATH` includes `/opt/homebrew/bin` and `/usr/local/bin` in the daemon env — without this, `brew` and every brew-installed tool is unreachable from step shells.
- CI keychain created and unlocked on first boot (`security create-keychain`, `set-keychain-settings -lut`) — required for `codesign` and signing-related Xcode actions.
- Drop from root to a `runner` user with passwordless sudo — Homebrew refuses to install as root, CocoaPods and Bundler behave subtly differently as uid 0. Today's `RUNNER_ALLOW_RUNASROOT=1` is a workaround that papers over a real compatibility risk for customer workflows.

**Strongly expected (workflow conveniences)**

- `gh` CLI pre-installed.
- Git LFS pre-installed.
- `mise` pre-installed — avoids the 10–30s `jdx/mise-action` install per run and the GitHub release rate limit when the fleet is busy.
- Pre-warmed simulators (`xcrun simctl list` returns instantly).
- `xcbeautify` and/or `xcpretty` available — most teams pipe `xcodebuild` through one.
- `swiftlint` / `swiftformat` available — used by Tuist's own workflows and a common customer expectation.

**Polish (close the gap to `macos-26`)**

- Language toolchains: Node, Python, Ruby — or version managers; `mise` covers all of these once it's there.
- `aws-cli`, `gcloud`, `azure-cli`, `1password-cli` for the long tail of teams pushing to cloud or pulling secrets.
- `jq`, `yq` for JSON/YAML scripting in workflows.
- APFS snapshot-friendly layout + Spotlight exclusion for `_work` so `actions/cache` restore is fast and indexing doesn't tax the VM.

Reference target: [actions/runner-images](https://github.com/actions/runner-images) `images/macos/macos-15-arm64-Readme.md` (and the Tahoe one when published) is the canonical macos-26 contents list.

### Related

This is one of four regressions identified while validating the canary/production runner-fleet roll. Separate follow-up PR will cover the bootstrap-side ones (empty kcpassword on adoption, non-idempotent pf install, duplicate adoption of pool hosts).