### PR TITLE
fix(infra): repair runner-fleet bootstrap regressions

### DIFF
--- a/infra/cluster-api-provider-scaleway-applesilicon/controllers/scalewayapplesiliconmachine_controller.go
+++ b/infra/cluster-api-provider-scaleway-applesilicon/controllers/scalewayapplesiliconmachine_controller.go
@@ -293,20 +293,32 @@ func (r *ScalewayAppleSiliconMachineReconciler) reconcileNormal(
 	// Secret and proceed with bootstrap. Only surface
 	// MissingSudoPassword when even the refresh comes back empty (the
 	// host genuinely has no recoverable credentials).
-	if bootstrapCreds.SudoPassword == "" {
-		if machine.Status.ServerID != "" {
-			srv, refreshErr := r.ScalewayClient.GetServer(ctx, machine.Status.ServerID, machine.Spec.Zone)
-			if refreshErr == nil && srv != nil && srv.SudoPassword != "" {
-				if writeErr := r.CredentialsManager.SetMachineCredentials(ctx, machine.Name, srv.SudoPassword, srv.SSHUsername); writeErr != nil {
-					logger.Error(writeErr, "refresh bootstrap secret from Scaleway")
-					return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
-				}
-				r.Recorder.Eventf(machine, corev1.EventTypeNormal, "CredentialsReclaimed",
-					"Recovered sudo password for %s from Scaleway vnc_url; bootstrap will resume",
-					machine.Name)
-				bootstrapCreds.SudoPassword = srv.SudoPassword
-				bootstrapCreds.SSHUsername = srv.SSHUsername
+	if bootstrapCreds.SudoPassword == "" && machine.Status.ServerID != "" {
+		srv, refreshErr := r.ScalewayClient.GetServer(ctx, machine.Status.ServerID, machine.Spec.Zone)
+		switch {
+		case refreshErr != nil:
+			// Transient Scaleway error (network blip, 5xx, throttle).
+			// Don't bury it as `MissingSudoPassword` with a 5-minute
+			// backoff — that condition is reserved for a definitive
+			// "Scaleway says there's no password". Surface a
+			// retryable condition and requeue soon so the refresh
+			// gets another chance on the next reconcile tick.
+			conditions.MarkFalse(machine, BootstrappedCondition, "CredentialsRefreshFailed",
+				clusterv1.ConditionSeverityWarning, "%v", refreshErr)
+			r.Recorder.Eventf(machine, corev1.EventTypeWarning, "CredentialsRefreshFailed",
+				"Scaleway GetServer for %s failed while trying to recover sudo password: %v",
+				machine.Name, refreshErr)
+			return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
+		case srv != nil && srv.SudoPassword != "":
+			if writeErr := r.CredentialsManager.SetMachineCredentials(ctx, machine.Name, srv.SudoPassword, srv.SSHUsername); writeErr != nil {
+				logger.Error(writeErr, "refresh bootstrap secret from Scaleway")
+				return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 			}
+			r.Recorder.Eventf(machine, corev1.EventTypeNormal, "CredentialsReclaimed",
+				"Recovered sudo password for %s from Scaleway vnc_url; bootstrap will resume",
+				machine.Name)
+			bootstrapCreds.SudoPassword = srv.SudoPassword
+			bootstrapCreds.SSHUsername = srv.SSHUsername
 		}
 	}
 	if bootstrapCreds.SudoPassword == "" {

--- a/infra/cluster-api-provider-scaleway-applesilicon/controllers/scalewayapplesiliconmachine_controller.go
+++ b/infra/cluster-api-provider-scaleway-applesilicon/controllers/scalewayapplesiliconmachine_controller.go
@@ -275,6 +275,27 @@ func (r *ScalewayAppleSiliconMachineReconciler) reconcileNormal(
 		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 	}
 
+	// Refuse to bootstrap with an empty sudo password. The bootstrap
+	// path stages `/etc/kcpassword` from `UserPassword`; an empty
+	// value XORs to just the cipher key padding, loginwindow rejects
+	// the auto-login, and Aqua never comes up — `tart run` then fails
+	// on every Pod with a 30s SIGHUP timeout for the lifetime of the
+	// host. Fail loudly here so the Machine stays in a visible state
+	// the operator can drain rather than joining the cluster as a
+	// permanently-broken Node. Stage 1's vnc_url fallback in
+	// `scalewayServerToServer` is what's expected to fill this in
+	// for adopted hosts; if it still came through empty, something
+	// upstream is wrong and a silent re-bootstrap won't fix it.
+	if bootstrapCreds.SudoPassword == "" {
+		conditions.MarkFalse(machine, BootstrappedCondition, "MissingSudoPassword",
+			clusterv1.ConditionSeverityError,
+			"bootstrap secret has no sudo password; refusing to bootstrap a host without auto-login credentials")
+		r.Recorder.Eventf(machine, corev1.EventTypeWarning, "MissingSudoPassword",
+			"Bootstrap secret for %s has no sudo password — verify Scaleway returned credentials at provisioning time (CreateServer response or vnc_url for adopted hosts)",
+			machine.Name)
+		return ctrl.Result{RequeueAfter: 5 * time.Minute}, nil
+	}
+
 	// Detect Node drift: bootstrap previously succeeded
 	// (BootstrappedCondition=True) but the Node tart-kubelet
 	// registered no longer exists in the cluster. Causes seen in

--- a/infra/cluster-api-provider-scaleway-applesilicon/controllers/scalewayapplesiliconmachine_controller.go
+++ b/infra/cluster-api-provider-scaleway-applesilicon/controllers/scalewayapplesiliconmachine_controller.go
@@ -280,18 +280,41 @@ func (r *ScalewayAppleSiliconMachineReconciler) reconcileNormal(
 	// value XORs to just the cipher key padding, loginwindow rejects
 	// the auto-login, and Aqua never comes up — `tart run` then fails
 	// on every Pod with a 30s SIGHUP timeout for the lifetime of the
-	// host. Fail loudly here so the Machine stays in a visible state
-	// the operator can drain rather than joining the cluster as a
-	// permanently-broken Node. Stage 1's vnc_url fallback in
-	// `scalewayServerToServer` is what's expected to fill this in
-	// for adopted hosts; if it still came through empty, something
-	// upstream is wrong and a silent re-bootstrap won't fix it.
+	// host.
+	//
+	// Before refusing, attempt to reclaim the password from Scaleway.
+	// Machines that hit the pre-fix failure mode still have
+	// Status.ServerID set and a bootstrap Secret with an empty
+	// sudo-password, so this reconcile pass would skip Stage 1 (which
+	// is where the vnc_url fallback runs) and loop on
+	// MissingSudoPassword forever. A fresh GetServer goes through
+	// scalewayServerToServer, which now reads the password out of
+	// vnc_url; if that produces a non-empty value, persist it to the
+	// Secret and proceed with bootstrap. Only surface
+	// MissingSudoPassword when even the refresh comes back empty (the
+	// host genuinely has no recoverable credentials).
+	if bootstrapCreds.SudoPassword == "" {
+		if machine.Status.ServerID != "" {
+			srv, refreshErr := r.ScalewayClient.GetServer(ctx, machine.Status.ServerID, machine.Spec.Zone)
+			if refreshErr == nil && srv != nil && srv.SudoPassword != "" {
+				if writeErr := r.CredentialsManager.SetMachineCredentials(ctx, machine.Name, srv.SudoPassword, srv.SSHUsername); writeErr != nil {
+					logger.Error(writeErr, "refresh bootstrap secret from Scaleway")
+					return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
+				}
+				r.Recorder.Eventf(machine, corev1.EventTypeNormal, "CredentialsReclaimed",
+					"Recovered sudo password for %s from Scaleway vnc_url; bootstrap will resume",
+					machine.Name)
+				bootstrapCreds.SudoPassword = srv.SudoPassword
+				bootstrapCreds.SSHUsername = srv.SSHUsername
+			}
+		}
+	}
 	if bootstrapCreds.SudoPassword == "" {
 		conditions.MarkFalse(machine, BootstrappedCondition, "MissingSudoPassword",
 			clusterv1.ConditionSeverityError,
-			"bootstrap secret has no sudo password; refusing to bootstrap a host without auto-login credentials")
+			"bootstrap secret has no sudo password and Scaleway did not surface one; refusing to bootstrap a host without auto-login credentials")
 		r.Recorder.Eventf(machine, corev1.EventTypeWarning, "MissingSudoPassword",
-			"Bootstrap secret for %s has no sudo password — verify Scaleway returned credentials at provisioning time (CreateServer response or vnc_url for adopted hosts)",
+			"Bootstrap secret for %s has no sudo password and the Scaleway refresh did not recover one — verify credentials at the source",
 			machine.Name)
 		return ctrl.Result{RequeueAfter: 5 * time.Minute}, nil
 	}

--- a/infra/cluster-api-provider-scaleway-applesilicon/go.mod
+++ b/infra/cluster-api-provider-scaleway-applesilicon/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/google/gnostic-models v0.6.8 // indirect
 	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
-	github.com/google/uuid v1.6.0 // indirect
+	github.com/google/uuid v1.6.0
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect

--- a/infra/cluster-api-provider-scaleway-applesilicon/internal/scaleway/client.go
+++ b/infra/cluster-api-provider-scaleway-applesilicon/internal/scaleway/client.go
@@ -14,6 +14,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 
 	"github.com/google/uuid"
 	applesilicon "github.com/scaleway/scaleway-sdk-go/api/applesilicon/v1alpha1"
@@ -50,6 +51,19 @@ type AppleSiliconAPI interface {
 type Client struct {
 	API AppleSiliconAPI
 	IAM *iam.API
+
+	// adoptMu serializes AdoptByPrefix across all goroutines in this
+	// process. Scaleway's UpdateServer is not conditional — two
+	// concurrent rename calls against the same server both succeed,
+	// last-write-wins — so per-call optimistic read-after-write
+	// verification can't establish a "we own this server" invariant.
+	// The controller is single-replica via leader election, so a
+	// process-local mutex is sufficient: only the leader runs, and
+	// the leader doesn't race itself once adoptions are serialized.
+	// Adoption is rare (one acquisition per Machine bring-up) and
+	// short (a few API calls); serializing it has no meaningful
+	// throughput cost.
+	adoptMu sync.Mutex
 }
 
 // NewClient initializes a Scaleway client from the standard environment
@@ -248,27 +262,29 @@ var ErrNoAvailableHost = errors.New("no available Apple Silicon host in pool")
 // and makes the host findable on future reconciles via the existing
 // name-based idempotency path (`findServerByName`).
 //
-// Concurrent reconciles racing the same pool host are resolved via
-// a two-phase claim:
+// Concurrent claims are resolved by a process-local mutex
+// (`adoptMu`). Scaleway's UpdateServer is not conditional — two
+// renames to different target names against the same server both
+// succeed, last-write-wins — so optimistic read-after-write
+// verification alone can't prevent two reconciles from walking
+// away with the same ServerID. The controller is single-replica
+// via leader election, so serializing adoption inside the leader
+// is sufficient; only one goroutine at a time enters this function.
 //
-//  1. Pick a candidate. UpdateServer renames it to a per-reconcile
-//     marker `tuist-claim-pending-<uuid>`. Each reconcile generates
-//     its own uuid, so two reconciles racing the same host write
-//     two distinct names — one of the two writes lands last.
-//  2. GetServer the candidate immediately. If `Name` still matches
-//     OUR marker, no one else's rename has landed after ours and we
-//     have the only outstanding claim. Promote with a second
-//     UpdateServer to `claimName`. If `Name` reflects somebody
-//     else's marker (or any unexpected value), the race is lost —
-//     skip the candidate and let the loop pick another.
+// Within that serialized section, a two-phase rename also runs as
+// defense-in-depth against external mutation (operator-driven
+// rename via the Scaleway console mid-adoption, or a future
+// multi-replica deployment that loses leader election between
+// reconciles):
 //
-// Why two phases instead of renaming straight to `claimName`: every
-// concurrent UpdateServer with a *different* target name succeeds
-// against Scaleway (no name-conflict response on differing targets),
-// so a single-step rename allows two Machines to both walk away with
-// the same ServerID, which is what we hit on the May 14 production
-// roll (multiple ScalewayAppleSiliconMachine CRs sharing one
-// ProviderID).
+//  1. Pick a candidate. UpdateServer renames it to a per-call
+//     marker `tuist-claim-pending-<uuid>`. GetServer the candidate
+//     and confirm the marker survived.
+//  2. UpdateServer to the final `claimName`.
+//
+// If between phase 1 and phase 2 some external actor renames the
+// server, the verify GET reveals the foreign name and the
+// candidate is skipped.
 //
 // Recovery from a crash between phases: if the controller exits
 // after phase 1, the server is stuck at `tuist-claim-pending-<uuid>`
@@ -283,6 +299,9 @@ func (c *Client) AdoptByPrefix(ctx context.Context, claimName, zone, serverType,
 	if poolPrefix == "" {
 		return nil, fmt.Errorf("poolPrefix is required for adoption")
 	}
+
+	c.adoptMu.Lock()
+	defer c.adoptMu.Unlock()
 
 	// Idempotent rediscovery: if a previous reconcile completed phase 2
 	// for this Machine but its `status.serverID` patch was lost (process
@@ -354,38 +373,51 @@ func (c *Client) AdoptByPrefix(ctx context.Context, claimName, zone, serverType,
 //
 // Returns:
 //
-//   - (*Server, nil)   — we won the race and promoted to claimName.
-//   - (nil, nil)       — lost the race; caller should try another
-//     candidate. Phase 1 either failed transiently or our pending
-//     marker was overwritten before phase 2.
-//   - (nil, error)     — phase 2 promotion failed after phase 1
-//     succeeded, which leaves the server in pendingName. The caller
-//     should requeue; on the next reconcile this server is matched
-//     as a claim-pending orphan and re-adopted.
+//   - (*Server, nil)   — we won and promoted to claimName.
+//   - (nil, nil)       — race lost or candidate vanished (404).
+//     Caller should try another candidate. Triggered by a server
+//     that disappears (deleted by an operator mid-scan) or whose
+//     pending marker is overwritten between phase 1 and verify.
+//   - (nil, error)     — Scaleway returned a non-404 error on
+//     phase 1 / verify, or phase 2 promotion failed. The caller
+//     should surface it as a real provisioning failure rather
+//     than rolling on to "no available capacity" — a 403, 500, or
+//     validation error means something operational is wrong and
+//     pre-ordering more hosts won't help.
 func (c *Client) tryTwoPhaseClaim(ctx context.Context, serverID, zone, pendingName, claimName string) (*Server, error) {
-	// Phase 1: stake the candidate with our per-reconcile marker.
+	// Phase 1: stake the candidate with our per-call marker.
 	if _, err := c.API.UpdateServer(&applesilicon.UpdateServerRequest{
 		ServerID: serverID,
 		Zone:     scw.Zone(zone),
 		Name:     &pendingName,
 	}, scw.WithContext(ctx)); err != nil {
-		// Treat a 404 as race-lost (someone else claimed and then we
-		// raced a delete; rare but recoverable). All other errors
-		// abort the candidate — the caller's outer loop will move on.
-		return nil, nil
+		// 404 means the candidate was deleted out from under us
+		// between the list and our UpdateServer call (concurrent
+		// operator action). That's recoverable — try the next
+		// candidate. Every other Scaleway error (auth, validation,
+		// outage) is operational and must surface, otherwise the
+		// outer loop quietly downgrades it to ErrNoAvailableHost
+		// and tells operators to pre-order capacity they already have.
+		if IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("phase 1 rename of server %s to pending marker: %w", serverID, err)
 	}
 
-	// Verify the marker survived. A concurrent reconcile that also
-	// wrote a pending name for this serverID after ours would show
-	// its own marker here; if so we lost the race.
+	// Verify the marker survived. With adoptMu held we won't race
+	// ourselves, but an external rename (operator console, future
+	// multi-replica deployment that lost leader election) can still
+	// overwrite the marker — bail in that case rather than promote a
+	// name we may not actually hold.
 	verified, err := c.API.GetServer(&applesilicon.GetServerRequest{
 		ServerID: serverID,
 		Zone:     scw.Zone(zone),
 	}, scw.WithContext(ctx))
 	if err != nil {
-		// Can't confirm we own the marker — safest is to skip rather
-		// than promote a name we may not actually hold.
-		return nil, nil
+		if IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("phase 1 verify of server %s: %w", serverID, err)
 	}
 	if verified.Name != pendingName {
 		return nil, nil

--- a/infra/cluster-api-provider-scaleway-applesilicon/internal/scaleway/client.go
+++ b/infra/cluster-api-provider-scaleway-applesilicon/internal/scaleway/client.go
@@ -12,12 +12,22 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 
+	"github.com/google/uuid"
 	applesilicon "github.com/scaleway/scaleway-sdk-go/api/applesilicon/v1alpha1"
 	iam "github.com/scaleway/scaleway-sdk-go/api/iam/v1alpha1"
 	"github.com/scaleway/scaleway-sdk-go/scw"
 )
+
+// claimPendingPrefix marks a server that's mid-adoption — it has been
+// renamed out of the operator's pool prefix but not yet to the final
+// per-Machine `claimName`. Used by AdoptByPrefix's two-phase claim to
+// detect race losers (their pending name has been overwritten by
+// someone else's) and to let subsequent reconciles re-adopt orphans
+// from a controller crash between the two phases.
+const claimPendingPrefix = "tuist-claim-pending-"
 
 // Client talks to Scaleway's Apple Silicon + IAM APIs. Construct with
 // NewClient; in tests, the API fields can be replaced with fakes.
@@ -217,26 +227,38 @@ var ErrNoAvailableHost = errors.New("no available Apple Silicon host in pool")
 // AdoptByPrefix claims a pre-ordered server in `zone` whose
 // Scaleway-side name starts with `poolPrefix`, matches
 // (`serverType`, `osName`), and is `Delivered=true` +
-// `Status=ready`. It renames the chosen server to `claimName` via
-// UpdateServer; that rename IS the claim — it both removes the
-// pool prefix (so the host no longer appears available) and
-// makes the host findable on future reconciles via the existing
+// `Status=ready`. The rename to `claimName` IS the claim — it both
+// removes the pool prefix (so the host no longer appears available)
+// and makes the host findable on future reconciles via the existing
 // name-based idempotency path (`findServerByName`).
 //
-// The "claim by rename" model relies on the operator's naming
-// convention as the single source of truth for "available":
+// Concurrent reconciles racing the same pool host are resolved via
+// a two-phase claim:
 //
-//   * Operator pre-orders a Mac mini in the Scaleway console and
-//     names it `<poolPrefix>-<anything>` (e.g. the chart default
-//     `tuist-pool-001`, `tuist-pool-fr-par-1-a`, etc.).
-//   * Controller picks the first one whose `(type, os, status)`
-//     match this Machine and renames it. Two concurrent
-//     reconciles racing for the same host both call UpdateServer
-//     with the same `claimName`; Scaleway returns a name
-//     conflict on the losing call, which we surface and let the
-//     parent reconcile retry — the renamed host is no longer in
-//     the pool prefix on the next ListServers, so the retry
-//     picks a different one (or hits ErrNoAvailableHost).
+//  1. Pick a candidate. UpdateServer renames it to a per-reconcile
+//     marker `tuist-claim-pending-<uuid>`. Each reconcile generates
+//     its own uuid, so two reconciles racing the same host write
+//     two distinct names — one of the two writes lands last.
+//  2. GetServer the candidate immediately. If `Name` still matches
+//     OUR marker, no one else's rename has landed after ours and we
+//     have the only outstanding claim. Promote with a second
+//     UpdateServer to `claimName`. If `Name` reflects somebody
+//     else's marker (or any unexpected value), the race is lost —
+//     skip the candidate and let the loop pick another.
+//
+// Why two phases instead of renaming straight to `claimName`: every
+// concurrent UpdateServer with a *different* target name succeeds
+// against Scaleway (no name-conflict response on differing targets),
+// so a single-step rename allows two Machines to both walk away with
+// the same ServerID, which is what we hit on the May 14 production
+// roll (multiple ScalewayAppleSiliconMachine CRs sharing one
+// ProviderID).
+//
+// Recovery from a crash between phases: if the controller exits
+// after phase 1, the server is stuck at `tuist-claim-pending-<uuid>`
+// outside any pool prefix. Subsequent scans treat any name carrying
+// `claimPendingPrefix` as eligible — same two-phase dance applies,
+// so the next reconcile re-adopts the orphan cleanly.
 //
 // Why a rename and not a Scaleway tag? The Apple Silicon API
 // doesn't expose tags. Naming is the only mutable, queryable
@@ -246,18 +268,18 @@ func (c *Client) AdoptByPrefix(ctx context.Context, claimName, zone, serverType,
 		return nil, fmt.Errorf("poolPrefix is required for adoption")
 	}
 
-	// Idempotent rediscovery: if a previous reconcile renamed a
-	// pool host to `claimName` but its `status.serverID` patch was
-	// lost (process crash, conflicted optimistic write), the host
-	// no longer carries `poolPrefix` and the scan below would
-	// return ErrNoAvailableHost — leaving the renamed server
-	// orphaned outside the pool. Check by name first so the next
-	// reconcile picks the already-claimed host back up.
+	// Idempotent rediscovery: if a previous reconcile completed phase 2
+	// for this Machine but its `status.serverID` patch was lost (process
+	// crash, conflicted optimistic write), the host already has the
+	// final claimName. Check by name first so the next reconcile picks
+	// the already-claimed host back up without burning a second host.
 	if existing, err := c.findServerByName(ctx, claimName, zone); err != nil {
 		return nil, fmt.Errorf("lookup existing claim %q: %w", claimName, err)
 	} else if existing != nil {
 		return scalewayServerToServer(existing), nil
 	}
+
+	pendingName := claimPendingPrefix + uuid.NewString()
 
 	page := int32(1)
 	pageSize := uint32(100)
@@ -272,7 +294,14 @@ func (c *Client) AdoptByPrefix(ctx context.Context, claimName, zone, serverType,
 		}
 
 		for _, s := range resp.Servers {
-			if !strings.HasPrefix(s.Name, poolPrefix) {
+			// Eligible candidates: untouched pool hosts AND
+			// claim-pending orphans from a prior crashed reconcile.
+			// Orphans are safe to re-adopt because the two-phase dance
+			// below guarantees only one reconcile can promote the
+			// pending name.
+			eligible := strings.HasPrefix(s.Name, poolPrefix) ||
+				strings.HasPrefix(s.Name, claimPendingPrefix)
+			if !eligible {
 				continue
 			}
 			if !s.Delivered || s.Status != applesilicon.ServerStatusReady {
@@ -285,15 +314,16 @@ func (c *Client) AdoptByPrefix(ctx context.Context, claimName, zone, serverType,
 				continue
 			}
 
-			renamed, err := c.API.UpdateServer(&applesilicon.UpdateServerRequest{
-				ServerID: s.ID,
-				Zone:     scw.Zone(zone),
-				Name:     &claimName,
-			}, scw.WithContext(ctx))
+			claimed, err := c.tryTwoPhaseClaim(ctx, s.ID, zone, pendingName, claimName)
 			if err != nil {
-				return nil, fmt.Errorf("claim server %s via rename: %w", s.ID, err)
+				return nil, err
 			}
-			return scalewayServerToServer(renamed), nil
+			if claimed == nil {
+				// Lost the phase-1 race; another reconcile got there
+				// after us. Try the next candidate.
+				continue
+			}
+			return claimed, nil
 		}
 
 		if len(resp.Servers) < int(pageSize) {
@@ -301,6 +331,61 @@ func (c *Client) AdoptByPrefix(ctx context.Context, claimName, zone, serverType,
 		}
 		page++
 	}
+}
+
+// tryTwoPhaseClaim attempts to claim `serverID` via the two-phase
+// rename described in AdoptByPrefix.
+//
+// Returns:
+//
+//   - (*Server, nil)   — we won the race and promoted to claimName.
+//   - (nil, nil)       — lost the race; caller should try another
+//     candidate. Phase 1 either failed transiently or our pending
+//     marker was overwritten before phase 2.
+//   - (nil, error)     — phase 2 promotion failed after phase 1
+//     succeeded, which leaves the server in pendingName. The caller
+//     should requeue; on the next reconcile this server is matched
+//     as a claim-pending orphan and re-adopted.
+func (c *Client) tryTwoPhaseClaim(ctx context.Context, serverID, zone, pendingName, claimName string) (*Server, error) {
+	// Phase 1: stake the candidate with our per-reconcile marker.
+	if _, err := c.API.UpdateServer(&applesilicon.UpdateServerRequest{
+		ServerID: serverID,
+		Zone:     scw.Zone(zone),
+		Name:     &pendingName,
+	}, scw.WithContext(ctx)); err != nil {
+		// Treat a 404 as race-lost (someone else claimed and then we
+		// raced a delete; rare but recoverable). All other errors
+		// abort the candidate — the caller's outer loop will move on.
+		return nil, nil
+	}
+
+	// Verify the marker survived. A concurrent reconcile that also
+	// wrote a pending name for this serverID after ours would show
+	// its own marker here; if so we lost the race.
+	verified, err := c.API.GetServer(&applesilicon.GetServerRequest{
+		ServerID: serverID,
+		Zone:     scw.Zone(zone),
+	}, scw.WithContext(ctx))
+	if err != nil {
+		// Can't confirm we own the marker — safest is to skip rather
+		// than promote a name we may not actually hold.
+		return nil, nil
+	}
+	if verified.Name != pendingName {
+		return nil, nil
+	}
+
+	// Phase 2: promote pending marker to the final claimName.
+	promoted, err := c.API.UpdateServer(&applesilicon.UpdateServerRequest{
+		ServerID: serverID,
+		Zone:     scw.Zone(zone),
+		Name:     &claimName,
+	}, scw.WithContext(ctx))
+	if err != nil {
+		return nil, fmt.Errorf("promote claim from %q to %q on server %s: %w",
+			pendingName, claimName, serverID, err)
+	}
+	return scalewayServerToServer(promoted), nil
 }
 
 // GetServer fetches the current state of an existing server.
@@ -409,5 +494,44 @@ func scalewayServerToServer(s *applesilicon.Server) *Server {
 	if s.IP != nil {
 		out.IP = s.IP.String()
 	}
+	// Scaleway only populates `sudo_password` on the CreateServer
+	// response — once that one-time window closes, every subsequent
+	// GET/list returns an empty `sudo_password`. Hosts adopted from
+	// the pre-ordered pool never go through CreateServer, so without
+	// this fallback the controller stages an empty password into the
+	// bootstrap Secret and `enableAutoLogin` either silently skips
+	// (writing nothing) or writes a kcpassword whose plaintext is
+	// just the cipher key padding — either way Aqua never comes up
+	// and `tart run` fails forever.
+	//
+	// The `vnc_url` field embeds the same OS-default credentials as
+	// `vnc://<ssh_username>:<password>@<ip>:<port>`. It's surfaced on
+	// every GET, including for adopted servers, and verified out-of-
+	// band to authenticate the m1 macOS user. Pull the password from
+	// there when `sudo_password` is empty.
+	if out.SudoPassword == "" {
+		out.SudoPassword = passwordFromVncURL(s.VncURL)
+	}
 	return out
+}
+
+// passwordFromVncURL extracts the password embedded in a Scaleway
+// Apple Silicon `vnc_url` of the form
+// `vnc://<user>:<password>@<host>:<port>`. Returns "" if the URL is
+// empty, malformed, or doesn't carry user-info. Special characters in
+// the password are percent-decoded by `url.Parse` so callers receive
+// the raw plaintext.
+func passwordFromVncURL(raw string) string {
+	if raw == "" {
+		return ""
+	}
+	u, err := url.Parse(raw)
+	if err != nil || u.User == nil {
+		return ""
+	}
+	pwd, ok := u.User.Password()
+	if !ok {
+		return ""
+	}
+	return pwd
 }

--- a/infra/cluster-api-provider-scaleway-applesilicon/internal/scaleway/client.go
+++ b/infra/cluster-api-provider-scaleway-applesilicon/internal/scaleway/client.go
@@ -29,10 +29,26 @@ import (
 // from a controller crash between the two phases.
 const claimPendingPrefix = "tuist-claim-pending-"
 
+// AppleSiliconAPI is the slice of the Scaleway SDK's
+// `applesilicon.API` surface the CAPI provider touches. Declared as
+// an interface so tests can drop in a fake without needing the real
+// SDK + HTTP client. The concrete `*applesilicon.API` satisfies it
+// via Go's structural typing — no adapter required.
+type AppleSiliconAPI interface {
+	CreateServer(req *applesilicon.CreateServerRequest, opts ...scw.RequestOption) (*applesilicon.Server, error)
+	GetServer(req *applesilicon.GetServerRequest, opts ...scw.RequestOption) (*applesilicon.Server, error)
+	ListServers(req *applesilicon.ListServersRequest, opts ...scw.RequestOption) (*applesilicon.ListServersResponse, error)
+	UpdateServer(req *applesilicon.UpdateServerRequest, opts ...scw.RequestOption) (*applesilicon.Server, error)
+	DeleteServer(req *applesilicon.DeleteServerRequest, opts ...scw.RequestOption) error
+	WaitForServer(req *applesilicon.WaitForServerRequest, opts ...scw.RequestOption) (*applesilicon.Server, error)
+	ListOS(req *applesilicon.ListOSRequest, opts ...scw.RequestOption) (*applesilicon.ListOSResponse, error)
+}
+
 // Client talks to Scaleway's Apple Silicon + IAM APIs. Construct with
-// NewClient; in tests, the API fields can be replaced with fakes.
+// NewClient; in tests, the API fields can be replaced with fakes
+// (see AppleSiliconAPI).
 type Client struct {
-	API *applesilicon.API
+	API AppleSiliconAPI
 	IAM *iam.API
 }
 

--- a/infra/cluster-api-provider-scaleway-applesilicon/internal/scaleway/client_test.go
+++ b/infra/cluster-api-provider-scaleway-applesilicon/internal/scaleway/client_test.go
@@ -1,9 +1,13 @@
 package scaleway
 
 import (
+	"context"
+	"errors"
+	"strings"
 	"testing"
 
 	applesilicon "github.com/scaleway/scaleway-sdk-go/api/applesilicon/v1alpha1"
+	"github.com/scaleway/scaleway-sdk-go/scw"
 )
 
 func TestPasswordFromVncURL(t *testing.T) {
@@ -99,5 +103,337 @@ func TestScalewayServerToServer_LeavesPasswordEmptyWhenBothSourcesEmpty(t *testi
 	out := scalewayServerToServer(in)
 	if out.SudoPassword != "" {
 		t.Fatalf("expected empty SudoPassword when both sources are empty, got %q", out.SudoPassword)
+	}
+}
+
+// --- two-phase adoption tests ---------------------------------------------
+//
+// The two-phase claim in AdoptByPrefix is what keeps two concurrent
+// reconciles from both walking away with the same ServerID. Test it
+// against a fake Scaleway API that models the rename-store semantics
+// the production code relies on. The fake is intentionally minimal:
+// just enough surface to drive the candidate scan + the rename
+// sequence, plus a hook to inject a concurrent rename between phase
+// 1's UpdateServer and phase 1's verify GET.
+
+// fakeAppleSiliconAPI is a small in-memory simulator. Servers are
+// pointers — UpdateServer mutates them in place so subsequent GETs
+// reflect the rename, matching Scaleway's own read-after-write
+// semantics. Only the methods AdoptByPrefix touches are implemented;
+// the rest return a sentinel error so test failures are obvious if
+// a test triggers an unexpected call path.
+type fakeAppleSiliconAPI struct {
+	servers []*applesilicon.Server
+
+	// beforeGet fires immediately before each GetServer responds.
+	// Tests use it to mutate server state (typically: a second
+	// rename) to simulate a concurrent reconcile having raced us
+	// between phase 1's UpdateServer and phase 1's verify GET.
+	beforeGet func(serverID string)
+
+	// updateErrors maps `<update-call-index> -> error`. The first
+	// UpdateServer call is index 1. Lets a test force a phase-2
+	// failure without affecting phase 1.
+	updateErrors map[int]error
+	updateCalls  int
+}
+
+func (f *fakeAppleSiliconAPI) ListServers(req *applesilicon.ListServersRequest, _ ...scw.RequestOption) (*applesilicon.ListServersResponse, error) {
+	// Return everything in one page. AdoptByPrefix paginates by
+	// `len(resp.Servers) < pageSize` to stop, so a single full slice
+	// causes the loop to exit after one pass.
+	return &applesilicon.ListServersResponse{
+		Servers:    f.servers,
+		TotalCount: uint32(len(f.servers)),
+	}, nil
+}
+
+func (f *fakeAppleSiliconAPI) GetServer(req *applesilicon.GetServerRequest, _ ...scw.RequestOption) (*applesilicon.Server, error) {
+	if f.beforeGet != nil {
+		f.beforeGet(req.ServerID)
+	}
+	for _, s := range f.servers {
+		if s.ID == req.ServerID {
+			return s, nil
+		}
+	}
+	return nil, errors.New("not found")
+}
+
+func (f *fakeAppleSiliconAPI) UpdateServer(req *applesilicon.UpdateServerRequest, _ ...scw.RequestOption) (*applesilicon.Server, error) {
+	f.updateCalls++
+	if err, ok := f.updateErrors[f.updateCalls]; ok {
+		return nil, err
+	}
+	for _, s := range f.servers {
+		if s.ID == req.ServerID {
+			if req.Name != nil {
+				s.Name = *req.Name
+			}
+			return s, nil
+		}
+	}
+	return nil, errors.New("not found")
+}
+
+func (f *fakeAppleSiliconAPI) CreateServer(*applesilicon.CreateServerRequest, ...scw.RequestOption) (*applesilicon.Server, error) {
+	return nil, errors.New("CreateServer not implemented in fake")
+}
+
+func (f *fakeAppleSiliconAPI) DeleteServer(*applesilicon.DeleteServerRequest, ...scw.RequestOption) error {
+	return errors.New("DeleteServer not implemented in fake")
+}
+
+func (f *fakeAppleSiliconAPI) WaitForServer(*applesilicon.WaitForServerRequest, ...scw.RequestOption) (*applesilicon.Server, error) {
+	return nil, errors.New("WaitForServer not implemented in fake")
+}
+
+func (f *fakeAppleSiliconAPI) ListOS(*applesilicon.ListOSRequest, ...scw.RequestOption) (*applesilicon.ListOSResponse, error) {
+	return nil, errors.New("ListOS not implemented in fake")
+}
+
+// readyServer builds a server in the state AdoptByPrefix is willing
+// to consider — Delivered + Ready, plus the type/os filters the
+// callers pass.
+func readyServer(id, name string) *applesilicon.Server {
+	return &applesilicon.Server{
+		ID:        id,
+		Name:      name,
+		Status:    applesilicon.ServerStatusReady,
+		Delivered: true,
+		Type:      "M2-L",
+		Os:        &applesilicon.OS{Name: "macos-tahoe-26.0"},
+	}
+}
+
+func newTestClient(api *fakeAppleSiliconAPI) *Client {
+	return &Client{API: api}
+}
+
+func TestAdoptByPrefix_HappyPath(t *testing.T) {
+	api := &fakeAppleSiliconAPI{
+		servers: []*applesilicon.Server{
+			readyServer("srv-1", "tuist-pool-001"),
+		},
+	}
+	c := newTestClient(api)
+
+	srv, err := c.AdoptByPrefix(context.Background(),
+		"tuist-tuist-runners-fleet-abc", "fr-par-1", "M2-L", "macos-tahoe-26.0", "tuist-pool-")
+	if err != nil {
+		t.Fatalf("AdoptByPrefix returned error: %v", err)
+	}
+	if srv == nil || srv.ID != "srv-1" {
+		t.Fatalf("expected srv-1 returned, got %+v", srv)
+	}
+	if got := api.servers[0].Name; got != "tuist-tuist-runners-fleet-abc" {
+		t.Fatalf("expected server renamed to final claimName, got %q", got)
+	}
+	// Phase 1 UpdateServer + Phase 2 UpdateServer = 2 total.
+	if api.updateCalls != 2 {
+		t.Fatalf("expected 2 UpdateServer calls (phase 1 + phase 2), got %d", api.updateCalls)
+	}
+}
+
+func TestAdoptByPrefix_IdempotentRediscovery(t *testing.T) {
+	// Server already carries the final claimName from a prior
+	// reconcile whose status patch was lost. Adoption must return it
+	// immediately without going through the two-phase dance again
+	// (which would rename to a fresh pending marker and burn API
+	// calls on an already-claimed host).
+	api := &fakeAppleSiliconAPI{
+		servers: []*applesilicon.Server{
+			readyServer("srv-1", "tuist-tuist-runners-fleet-abc"),
+		},
+	}
+	c := newTestClient(api)
+
+	srv, err := c.AdoptByPrefix(context.Background(),
+		"tuist-tuist-runners-fleet-abc", "fr-par-1", "M2-L", "macos-tahoe-26.0", "tuist-pool-")
+	if err != nil {
+		t.Fatalf("expected idempotent rediscovery, got error: %v", err)
+	}
+	if srv.ID != "srv-1" {
+		t.Fatalf("expected srv-1, got %+v", srv)
+	}
+	if api.updateCalls != 0 {
+		t.Fatalf("expected zero UpdateServer calls on rediscovery, got %d", api.updateCalls)
+	}
+}
+
+func TestAdoptByPrefix_RaceLost_SkipsCandidate(t *testing.T) {
+	// Two pool hosts. A concurrent reconcile overwrites our phase-1
+	// pending marker on srv-1 between our UpdateServer and our GET.
+	// AdoptByPrefix should detect the race (verify.Name != ours) and
+	// move on to srv-2, where there's no contention.
+	api := &fakeAppleSiliconAPI{
+		servers: []*applesilicon.Server{
+			readyServer("srv-1", "tuist-pool-001"),
+			readyServer("srv-2", "tuist-pool-002"),
+		},
+	}
+	// Only mutate the FIRST GetServer (the verify on srv-1).
+	var getCalls int
+	api.beforeGet = func(id string) {
+		getCalls++
+		if getCalls == 1 && id == "srv-1" {
+			// Simulate a concurrent reconcile that claimed srv-1
+			// after our phase 1 UpdateServer landed — they overwrote
+			// our pending marker with their own.
+			api.servers[0].Name = claimPendingPrefix + "competitor"
+		}
+	}
+	c := newTestClient(api)
+
+	srv, err := c.AdoptByPrefix(context.Background(),
+		"tuist-tuist-runners-fleet-mine", "fr-par-1", "M2-L", "macos-tahoe-26.0", "tuist-pool-")
+	if err != nil {
+		t.Fatalf("AdoptByPrefix returned error: %v", err)
+	}
+	if srv.ID != "srv-2" {
+		t.Fatalf("expected adoption to skip srv-1 and pick srv-2, got %q", srv.ID)
+	}
+	// srv-1's name is whatever the competitor wrote; we must not have
+	// promoted it to our claimName.
+	if api.servers[0].Name == "tuist-tuist-runners-fleet-mine" {
+		t.Fatalf("phase 2 must not promote srv-1 when phase 1 verify failed")
+	}
+	if api.servers[1].Name != "tuist-tuist-runners-fleet-mine" {
+		t.Fatalf("expected srv-2 to be renamed to our claimName, got %q", api.servers[1].Name)
+	}
+}
+
+func TestAdoptByPrefix_OrphanReAdopted(t *testing.T) {
+	// A previous reconcile crashed between phase 1 and phase 2 —
+	// srv-1 sits outside any pool prefix, named only by a stale
+	// claim-pending marker. The next reconcile must treat that marker
+	// as an eligible candidate and re-adopt cleanly.
+	api := &fakeAppleSiliconAPI{
+		servers: []*applesilicon.Server{
+			readyServer("srv-1", claimPendingPrefix+"crashed-uuid"),
+		},
+	}
+	c := newTestClient(api)
+
+	srv, err := c.AdoptByPrefix(context.Background(),
+		"tuist-tuist-runners-fleet-recovered", "fr-par-1", "M2-L", "macos-tahoe-26.0", "tuist-pool-")
+	if err != nil {
+		t.Fatalf("orphan re-adoption returned error: %v", err)
+	}
+	if srv.ID != "srv-1" {
+		t.Fatalf("expected srv-1 re-adopted, got %+v", srv)
+	}
+	if api.servers[0].Name != "tuist-tuist-runners-fleet-recovered" {
+		t.Fatalf("expected orphan renamed to our claimName, got %q", api.servers[0].Name)
+	}
+}
+
+func TestAdoptByPrefix_NoEligibleHosts(t *testing.T) {
+	cases := []struct {
+		name string
+		srv  *applesilicon.Server
+	}{
+		{
+			name: "wrong prefix",
+			srv: &applesilicon.Server{
+				ID: "srv-1", Name: "unrelated-host",
+				Status: applesilicon.ServerStatusReady, Delivered: true,
+				Type: "M2-L", Os: &applesilicon.OS{Name: "macos-tahoe-26.0"},
+			},
+		},
+		{
+			name: "not delivered",
+			srv: &applesilicon.Server{
+				ID: "srv-1", Name: "tuist-pool-001",
+				Status: applesilicon.ServerStatusReady, Delivered: false,
+				Type: "M2-L", Os: &applesilicon.OS{Name: "macos-tahoe-26.0"},
+			},
+		},
+		{
+			name: "not ready",
+			srv: &applesilicon.Server{
+				ID: "srv-1", Name: "tuist-pool-001",
+				Status: applesilicon.ServerStatusStarting, Delivered: true,
+				Type: "M2-L", Os: &applesilicon.OS{Name: "macos-tahoe-26.0"},
+			},
+		},
+		{
+			name: "wrong type",
+			srv: &applesilicon.Server{
+				ID: "srv-1", Name: "tuist-pool-001",
+				Status: applesilicon.ServerStatusReady, Delivered: true,
+				Type: "M1-M", Os: &applesilicon.OS{Name: "macos-tahoe-26.0"},
+			},
+		},
+		{
+			name: "wrong os",
+			srv: &applesilicon.Server{
+				ID: "srv-1", Name: "tuist-pool-001",
+				Status: applesilicon.ServerStatusReady, Delivered: true,
+				Type: "M2-L", Os: &applesilicon.OS{Name: "macos-sonoma-14"},
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			api := &fakeAppleSiliconAPI{servers: []*applesilicon.Server{tc.srv}}
+			c := newTestClient(api)
+			_, err := c.AdoptByPrefix(context.Background(),
+				"tuist-tuist-runners-fleet-x", "fr-par-1", "M2-L", "macos-tahoe-26.0", "tuist-pool-")
+			if !errors.Is(err, ErrNoAvailableHost) {
+				t.Fatalf("expected ErrNoAvailableHost, got %v", err)
+			}
+			if api.updateCalls != 0 {
+				t.Fatalf("expected no UpdateServer calls on ineligible candidate, got %d", api.updateCalls)
+			}
+		})
+	}
+}
+
+func TestAdoptByPrefix_Phase2FailureSurfacesError(t *testing.T) {
+	// Phase 1 succeeds (the candidate is renamed to our pending
+	// marker), then phase 2 fails. The function must propagate the
+	// error so the caller requeues; the server is left in the
+	// claim-pending state so the next reconcile re-adopts it via the
+	// orphan path covered above.
+	api := &fakeAppleSiliconAPI{
+		servers: []*applesilicon.Server{
+			readyServer("srv-1", "tuist-pool-001"),
+		},
+		updateErrors: map[int]error{
+			// 1 = phase-1 UpdateServer (succeeds)
+			// 2 = phase-2 UpdateServer (fail this one)
+			2: errors.New("scaleway transient error"),
+		},
+	}
+	c := newTestClient(api)
+
+	_, err := c.AdoptByPrefix(context.Background(),
+		"tuist-tuist-runners-fleet-x", "fr-par-1", "M2-L", "macos-tahoe-26.0", "tuist-pool-")
+	if err == nil {
+		t.Fatalf("expected phase-2 error to be surfaced, got nil")
+	}
+	if !strings.Contains(err.Error(), "promote claim") {
+		t.Fatalf("expected error to mention claim promotion, got %v", err)
+	}
+	// Server should be stuck at the pending marker, NOT at the final
+	// claimName. The next reconcile will see it as an orphan and
+	// re-adopt.
+	if !strings.HasPrefix(api.servers[0].Name, claimPendingPrefix) {
+		t.Fatalf("expected server to be left in claim-pending state after phase-2 failure, got name=%q",
+			api.servers[0].Name)
+	}
+}
+
+func TestAdoptByPrefix_RequiresPoolPrefix(t *testing.T) {
+	api := &fakeAppleSiliconAPI{}
+	c := newTestClient(api)
+	_, err := c.AdoptByPrefix(context.Background(),
+		"tuist-tuist-runners-fleet-x", "fr-par-1", "M2-L", "macos-tahoe-26.0", "")
+	if err == nil {
+		t.Fatalf("expected error when poolPrefix is empty")
+	}
+	if !strings.Contains(err.Error(), "poolPrefix") {
+		t.Fatalf("expected error to mention poolPrefix, got %v", err)
 	}
 }

--- a/infra/cluster-api-provider-scaleway-applesilicon/internal/scaleway/client_test.go
+++ b/infra/cluster-api-provider-scaleway-applesilicon/internal/scaleway/client_test.go
@@ -1,0 +1,103 @@
+package scaleway
+
+import (
+	"testing"
+
+	applesilicon "github.com/scaleway/scaleway-sdk-go/api/applesilicon/v1alpha1"
+)
+
+func TestPasswordFromVncURL(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{
+			name: "empty input returns empty",
+			raw:  "",
+			want: "",
+		},
+		{
+			name: "well-formed vnc URL with alphanumeric password",
+			raw:  "vnc://m1:69ovyKUj4nLD@62.210.194.41:59010",
+			want: "69ovyKUj4nLD",
+		},
+		{
+			name: "password with percent-encoded special characters is decoded",
+			raw:  "vnc://m1:p%40ss%3Aword@host:1234",
+			want: "p@ss:word",
+		},
+		{
+			name: "no userinfo returns empty",
+			raw:  "vnc://host:1234",
+			want: "",
+		},
+		{
+			name: "user only, no password returns empty",
+			raw:  "vnc://m1@host:1234",
+			want: "",
+		},
+		{
+			name: "malformed URL returns empty",
+			raw:  "not a url",
+			want: "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := passwordFromVncURL(tc.raw)
+			if got != tc.want {
+				t.Fatalf("passwordFromVncURL(%q) = %q, want %q", tc.raw, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestScalewayServerToServer_FallsBackToVncURLWhenSudoPasswordEmpty(t *testing.T) {
+	// Adopted servers come back from list/GET with an empty
+	// SudoPassword; the controller needs a real password to stage
+	// kcpassword. The vnc_url embeds the same OS-default credentials
+	// and is the only surface that survives past CreateServer.
+	in := &applesilicon.Server{
+		ID:           "server-id",
+		Status:       applesilicon.ServerStatusReady,
+		SudoPassword: "",
+		SSHUsername:  "m1",
+		VncURL:       "vnc://m1:secretpwd@host:59010",
+	}
+	out := scalewayServerToServer(in)
+	if out.SudoPassword != "secretpwd" {
+		t.Fatalf("expected password to fall back to vnc_url value 'secretpwd', got %q", out.SudoPassword)
+	}
+}
+
+func TestScalewayServerToServer_PrefersAPISudoPasswordWhenSet(t *testing.T) {
+	// CreateServer responses populate SudoPassword directly. The vnc
+	// fallback must not override that — if the API gave us a value,
+	// it's the authoritative one.
+	in := &applesilicon.Server{
+		ID:           "server-id",
+		Status:       applesilicon.ServerStatusReady,
+		SudoPassword: "fromCreate",
+		SSHUsername:  "m1",
+		VncURL:       "vnc://m1:fromVNC@host:59010",
+	}
+	out := scalewayServerToServer(in)
+	if out.SudoPassword != "fromCreate" {
+		t.Fatalf("expected primary SudoPassword to win, got %q", out.SudoPassword)
+	}
+}
+
+func TestScalewayServerToServer_LeavesPasswordEmptyWhenBothSourcesEmpty(t *testing.T) {
+	in := &applesilicon.Server{
+		ID:           "server-id",
+		Status:       applesilicon.ServerStatusReady,
+		SudoPassword: "",
+		SSHUsername:  "m1",
+		VncURL:       "",
+	}
+	out := scalewayServerToServer(in)
+	if out.SudoPassword != "" {
+		t.Fatalf("expected empty SudoPassword when both sources are empty, got %q", out.SudoPassword)
+	}
+}

--- a/infra/cluster-api-provider-scaleway-applesilicon/internal/scaleway/client_test.go
+++ b/infra/cluster-api-provider-scaleway-applesilicon/internal/scaleway/client_test.go
@@ -131,11 +131,17 @@ type fakeAppleSiliconAPI struct {
 	// between phase 1's UpdateServer and phase 1's verify GET.
 	beforeGet func(serverID string)
 
-	// updateErrors maps `<update-call-index> -> error`. The first
-	// UpdateServer call is index 1. Lets a test force a phase-2
-	// failure without affecting phase 1.
+	// updateErrors / getErrors map `<call-index> -> error`. Call
+	// indices are 1-based per method (the first UpdateServer call is
+	// 1, regardless of how many GetServer calls precede it). Lets a
+	// test force a specific phase or step to fail — including with a
+	// scw.ResourceNotFoundError, to exercise the IsNotFound branch
+	// where the caller treats the candidate as race-lost rather than
+	// propagating the error.
 	updateErrors map[int]error
 	updateCalls  int
+	getErrors    map[int]error
+	getCalls     int
 }
 
 func (f *fakeAppleSiliconAPI) ListServers(req *applesilicon.ListServersRequest, _ ...scw.RequestOption) (*applesilicon.ListServersResponse, error) {
@@ -149,6 +155,10 @@ func (f *fakeAppleSiliconAPI) ListServers(req *applesilicon.ListServersRequest, 
 }
 
 func (f *fakeAppleSiliconAPI) GetServer(req *applesilicon.GetServerRequest, _ ...scw.RequestOption) (*applesilicon.Server, error) {
+	f.getCalls++
+	if err, ok := f.getErrors[f.getCalls]; ok {
+		return nil, err
+	}
 	if f.beforeGet != nil {
 		f.beforeGet(req.ServerID)
 	}
@@ -435,5 +445,114 @@ func TestAdoptByPrefix_RequiresPoolPrefix(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "poolPrefix") {
 		t.Fatalf("expected error to mention poolPrefix, got %v", err)
+	}
+}
+
+func TestAdoptByPrefix_Phase1Update404SkipsCandidate(t *testing.T) {
+	// A 404 on phase 1 UpdateServer means the candidate was deleted
+	// out from under us between list and UpdateServer (concurrent
+	// operator action). The function should treat that as a per-
+	// candidate race-lost and let the outer loop move on to the
+	// next eligible host, NOT propagate as a real error.
+	api := &fakeAppleSiliconAPI{
+		servers: []*applesilicon.Server{
+			readyServer("srv-1", "tuist-pool-001"),
+			readyServer("srv-2", "tuist-pool-002"),
+		},
+		// First UpdateServer call (phase 1 against srv-1) returns
+		// the Scaleway-typed NotFound error; the remaining calls
+		// (phase 1 + phase 2 against srv-2) succeed.
+		updateErrors: map[int]error{
+			1: &scw.ResourceNotFoundError{Resource: "server", ResourceID: "srv-1"},
+		},
+	}
+	c := newTestClient(api)
+
+	srv, err := c.AdoptByPrefix(context.Background(),
+		"tuist-tuist-runners-fleet-x", "fr-par-1", "M2-L", "macos-tahoe-26.0", "tuist-pool-")
+	if err != nil {
+		t.Fatalf("phase 1 404 should be race-lost, not error; got %v", err)
+	}
+	if srv.ID != "srv-2" {
+		t.Fatalf("expected fallthrough to srv-2, got %q", srv.ID)
+	}
+}
+
+func TestAdoptByPrefix_Phase1UpdateNon404SurfacesError(t *testing.T) {
+	// Any non-NotFound Scaleway error (403 auth, 5xx outage,
+	// validation error) is operational and must propagate as a real
+	// failure. The pre-fix behavior swallowed every UpdateServer
+	// error as "race lost" and let the outer loop downgrade it to
+	// ErrNoAvailableHost — telling operators to pre-order capacity
+	// they already have.
+	api := &fakeAppleSiliconAPI{
+		servers: []*applesilicon.Server{
+			readyServer("srv-1", "tuist-pool-001"),
+		},
+		updateErrors: map[int]error{
+			1: errors.New("scaleway: 403 forbidden"),
+		},
+	}
+	c := newTestClient(api)
+
+	_, err := c.AdoptByPrefix(context.Background(),
+		"tuist-tuist-runners-fleet-x", "fr-par-1", "M2-L", "macos-tahoe-26.0", "tuist-pool-")
+	if err == nil {
+		t.Fatalf("expected non-404 phase 1 error to be surfaced")
+	}
+	if errors.Is(err, ErrNoAvailableHost) {
+		t.Fatalf("non-404 phase 1 error must not be downgraded to ErrNoAvailableHost, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "phase 1 rename") {
+		t.Fatalf("expected error to identify phase 1 rename, got %v", err)
+	}
+}
+
+func TestAdoptByPrefix_Phase1Verify404SkipsCandidate(t *testing.T) {
+	// 404 on the verify GET (server deleted between phase 1 and
+	// verify) is recoverable per-candidate, same handling as a phase
+	// 1 update 404.
+	api := &fakeAppleSiliconAPI{
+		servers: []*applesilicon.Server{
+			readyServer("srv-1", "tuist-pool-001"),
+			readyServer("srv-2", "tuist-pool-002"),
+		},
+		getErrors: map[int]error{
+			1: &scw.ResourceNotFoundError{Resource: "server", ResourceID: "srv-1"},
+		},
+	}
+	c := newTestClient(api)
+
+	srv, err := c.AdoptByPrefix(context.Background(),
+		"tuist-tuist-runners-fleet-x", "fr-par-1", "M2-L", "macos-tahoe-26.0", "tuist-pool-")
+	if err != nil {
+		t.Fatalf("verify 404 should be race-lost, not error; got %v", err)
+	}
+	if srv.ID != "srv-2" {
+		t.Fatalf("expected fallthrough to srv-2, got %q", srv.ID)
+	}
+}
+
+func TestAdoptByPrefix_Phase1VerifyNon404SurfacesError(t *testing.T) {
+	api := &fakeAppleSiliconAPI{
+		servers: []*applesilicon.Server{
+			readyServer("srv-1", "tuist-pool-001"),
+		},
+		getErrors: map[int]error{
+			1: errors.New("scaleway: 502 bad gateway"),
+		},
+	}
+	c := newTestClient(api)
+
+	_, err := c.AdoptByPrefix(context.Background(),
+		"tuist-tuist-runners-fleet-x", "fr-par-1", "M2-L", "macos-tahoe-26.0", "tuist-pool-")
+	if err == nil {
+		t.Fatalf("expected non-404 verify error to be surfaced")
+	}
+	if errors.Is(err, ErrNoAvailableHost) {
+		t.Fatalf("non-404 verify error must not be downgraded to ErrNoAvailableHost, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "phase 1 verify") {
+		t.Fatalf("expected error to identify phase 1 verify, got %v", err)
 	}
 }

--- a/infra/macos-host-bootstrap/bootstrap.go
+++ b/infra/macos-host-bootstrap/bootstrap.go
@@ -734,6 +734,16 @@ load anchor "tuist.runners" from "/etc/pf.anchors/tuist.runners"
 PFCONFENTRY
 fi
 
+# Flush any state already loaded under our anchor before validating.
+# The 'persist' tables defined in the anchor file (vm_sources,
+# blocked_dst) survive across 'pfctl -f' invocations once loaded;
+# without flushing, a re-run on an already-bootstrapped host fails
+# the validation step below with 'cannot define table vm_sources:
+# Resource busy'. Flushing only our own anchor leaves the system's
+# main ruleset untouched. Tolerate failure here — on a first-run
+# host the anchor doesn't exist yet, and pfctl returns non-zero.
+sudo pfctl -a tuist.runners -F all 2>/dev/null || true
+
 # Validate the ruleset before activating. -nf parses without
 # loading; if this fails we want a clear bootstrap error rather
 # than a half-loaded filter.


### PR DESCRIPTION
> Three independent regressions in the CAPI Scaleway provider and macOS host bootstrap kept the canary/production runner fleet from coming up healthy. Fix them together because they were all introduced in the same window and they all live on the bootstrap path.

## Symptoms

When validating the runner fleet roll on PR #10793, every Pod on every Mac mini in production was stuck in `TartCreateFailed` with:

```
tart run: ensure gui session: Aqua session for uid 501 did not come up within 30s after SIGHUP loginwindow
```

…even after a manual reboot of the host. CAPI also reported 9 Machine CRs in the runner MachineDeployment but only 5 unique Scaleway servers backed them; the remaining 4 were duplicates and the operator-pre-ordered `tuist-pool-*` hosts sat unclaimed. The controller was looping on bootstrap retries (192 attempts in 4h55m on a single Machine).

Root-causing surfaced three independent bugs.

## Bug 1 — Empty kcpassword on adopted hosts

**Root cause.** Scaleway's Apple Silicon API only populates the `sudo_password` field on the **CreateServer** response. Every subsequent GET/list returns it empty. Hosts adopted from the pool prefix never go through CreateServer, so [`scalewayServerToServer`](infra/cluster-api-provider-scaleway-applesilicon/internal/scaleway/client.go) staged an empty password into the bootstrap Secret. Downstream, [`enableAutoLogin`](infra/macos-host-bootstrap/bootstrap.go) either silently skipped (post-#10653) or wrote a kcpassword whose plaintext was just the 11-byte cipher key padding (older controller image). Either way `loginwindow` rejected the auto-login, Aqua never came up on boot, and `tart run` failed forever.

**Fix.** Scaleway's `vnc_url` field embeds the same OS-default credentials as `vnc://<ssh_username>:<password>@<host>:<port>` and IS surfaced on every GET. `passwordFromVncURL` parses the password out of that URL (handling percent-encoded special characters), and `scalewayServerToServer` uses it as a fallback when `SudoPassword` is empty. Verified out-of-band that the VNC password authenticates the m1 macOS user.

Defense-in-depth: the controller refuses to bootstrap a Machine whose bootstrap Secret has no sudo password. Machines that already hit the failure mode have `Status.ServerID` set and an existing bootstrap Secret with an empty sudo-password, so this reconcile pass would skip Stage 1 (where the vnc_url fallback runs) and loop on `MissingSudoPassword` forever. Before refusing, the controller now tries a fresh `ScalewayClient.GetServer`; if it returns a non-empty `SudoPassword` (from the vnc_url fallback), the Secret is updated in place and bootstrap resumes. `MissingSudoPassword` is surfaced only when even the refresh comes back empty.

## Bug 2 — Non-idempotent pf install

**Root cause.** [`installVMEgressFirewall`](infra/macos-host-bootstrap/bootstrap.go) validates `/etc/pf.conf` with `pfctl -nf` before loading. The anchor defines two `persist` tables (`vm_sources`, `blocked_dst`); once loaded they survive subsequent `pfctl -f` invocations. A re-run on an already-bootstrapped host fails the validate step with `cannot define table vm_sources: Resource busy`, the whole bootstrap step errors, and the controller retries forever.

**Fix.** Flush the anchor's state before validating:

```bash
sudo pfctl -a tuist.runners -F all 2>/dev/null || true
```

Scoped to the named anchor so the system's main ruleset stays untouched. First-run hosts (where the anchor doesn't exist yet) tolerate the non-zero exit via `|| true`.

## Bug 3 — Duplicate adoption of the same pool host

**Root cause.** [`AdoptByPrefix`](infra/cluster-api-provider-scaleway-applesilicon/internal/scaleway/client.go) assumed that when two reconciles race the same pool host, Scaleway would return a name conflict on the losing UpdateServer call. **It does not** — every UpdateServer with a *different* target name succeeds. Both reconciles walked away with the same ServerID. Production state: 3 Machine CRs pointing at one Scaleway server, plus 2 unclaimed pool hosts left over because the duplicates were burning the controller's reconciliation budget.

**Fix — serialize adoption with a process-local mutex.**

Scaleway's `UpdateServer` is unconditional (no CAS / etag), so optimistic read-after-write verification alone can't establish "we own this server" — two interleaved phase-1+verify rounds can each observe their own pending marker and both proceed to phase 2, leaving both callers with the same ServerID. The controller is single-replica via leader election, so a `sync.Mutex` on `Client` keyed at `AdoptByPrefix` entry is sufficient: only the leader runs, and the leader doesn't race itself once adoption is serialized.

A two-phase rename runs *inside* the mutex as defense-in-depth against external mutation (operator console rename mid-adoption, or a future multi-replica deployment that loses leader election between reconciles):

1. **Phase 1.** Rename the candidate `tuist-pool-001` → `tuist-claim-pending-<uuid>`. GetServer the candidate; verify `Name` reflects OUR marker.
2. **Phase 2.** Rename the marker to the final `claimName`.

A crash between phases leaves the host outside any pool prefix as a `tuist-claim-pending-*` orphan. The adoption scan matches that prefix too, so the next reconcile re-adopts it through the same two-phase dance.

### Scaleway error handling

The previous code swallowed every `UpdateServer` / `GetServer` failure in phase 1 / verify as "race lost." That meant a 403 (auth), 5xx (outage), or validation error across all candidates was silently downgraded to `ErrNoAvailableHost` and the operator was told to pre-order capacity they already had. Now only `scw.ResourceNotFoundError` is treated as race-lost; everything else surfaces as `ScalewayAdoptFailed`.

## Tests

A small `AppleSiliconAPI` interface in `internal/scaleway/client.go` is the seam between `Client` and the SDK's concrete `*applesilicon.API`. Production code is unaffected — the SDK type satisfies the interface via Go's structural typing. Tests drive an in-memory fake that simulates Scaleway's rename-store semantics, with hooks for injecting concurrent renames and forcing per-call errors on `UpdateServer` / `GetServer`.

Coverage in `internal/scaleway/client_test.go`:

- `passwordFromVncURL` — empty input, alphanumeric password, percent-encoded special chars, no userinfo, user-only, malformed URL.
- `scalewayServerToServer` — VNC fallback when `SudoPassword` is empty, primary `SudoPassword` wins when both sources are set, both-empty stays empty.
- `AdoptByPrefix`:
  - Happy path (single pool host, both phases run, server renamed to claimName).
  - Idempotent rediscovery (host already named claimName from a prior reconcile; zero UpdateServer calls).
  - Race-lost via external rename overwriting the pending marker between phase 1 and verify; AdoptByPrefix skips the candidate and picks another.
  - Orphan re-adoption (stale `tuist-claim-pending-*` host from a crashed reconcile is treated as eligible and re-adopted via the same two-phase path).
  - Eligibility filters (wrong prefix / not delivered / not ready / wrong type / wrong OS → ErrNoAvailableHost, zero UpdateServer calls).
  - Phase 1 UpdateServer **404** (server deleted under us) — skips candidate, falls through to next.
  - Phase 1 UpdateServer **non-404** (auth / outage / validation) — surfaces as a real error, NOT ErrNoAvailableHost.
  - Phase 1 verify GetServer **404** — skips candidate.
  - Phase 1 verify GetServer **non-404** — surfaces as a real error.
  - Phase-2 promotion failure (error surfaced, server left in claim-pending state so the next reconcile re-adopts it).
  - Empty `poolPrefix` rejected.

## How to test locally

This is the kind of change that's most meaningfully validated against the real Scaleway API + a real Mac mini. Test plan:

- [ ] `go build ./...` and `go test ./...` clean in both `infra/cluster-api-provider-scaleway-applesilicon` and `infra/macos-host-bootstrap`.
- [ ] On merge, the controller image rebuilds. On the next reconcile pass against the production cluster:
  - The 4 existing duplicate Machine CRs (`mndbc-m7r47`, `mndbc-xs6fx`, `mndbc-bzd26`, `mndbc-ffjpx`) need to be deleted by hand so CAPI re-creates Machines that actually adopt the pre-ordered `tuist-pool-005` and `tuist-pool-007` hosts via the two-phase path.
  - Newly-bootstrapped hosts should reach `Ready` with kcpassword=22 bytes (vs the broken 11 bytes on the current 4 hosts) and `stat -f "%Su" /dev/console` returning `m1`.
  - Existing Machines whose Secret holds an empty sudo-password should refresh on the next reconcile (a `CredentialsReclaimed` event will be emitted) and proceed to bootstrap rather than stalling on `MissingSudoPassword`.
- [ ] The pf install becomes idempotent on a re-bootstrap; can be verified by deleting + recreating a Machine and watching the controller's retry log.

## Follow-ups (out of scope here; tracked for separate PRs)

- **Operator runbook for cleaning up the existing duplicate Machine CRs** on the production cluster, plus the manual kcpassword fix that's already been applied to the 4 stuck hosts (sblfl, m789d, hz6vv, k6kwt) via SSH out-of-band. Captured in the runner-feature project notes.
- **Runner image \$HOME parity** is tracked in #10797 (independent fix).