### PR TITLE
fix(runner-image): publish HOME fix through release pipeline

### DIFF
--- a/.github/workflows/runner-image.yml
+++ b/.github/workflows/runner-image.yml
@@ -33,10 +33,6 @@ permissions:
   contents: read
   packages: write
 
-permissions:
-  contents: read
-  packages: write
-
 jobs:
   build:
     runs-on: [self-hosted, macos, bare-metal, vm-image-builder]

--- a/infra/runner-image/launchd.plist
+++ b/infra/runner-image/launchd.plist
@@ -69,6 +69,13 @@
           `/var/root` is the canonical home for uid 0 on macOS;
           set it so step shells inherit a working HOME that matches
           the user the runner is actually running as.
+
+          actions/checkout briefly sets a temporary HOME during its
+          own git invocations and restores the prior value on exit,
+          so the symptom only shows up on the *next* step after
+          checkout (the first step that reads `$HOME/.gitconfig`
+          with no actions/checkout-managed override in scope). See
+          #10797 for the first observation in production.
         -->
         <key>HOME</key>
         <string>/var/root</string>


### PR DESCRIPTION
> Re-publish the HOME fix from #10797 under the scope the release pipeline actually looks at, and clean up the duplicate `permissions:` block in the standalone runner-image workflow that's been failing on every push since #10653.

## Why this is needed

#10797 merged with the commit `fix(infra): set HOME on the runner image LaunchDaemon (#10797)`. The release pipeline's [runner-image release flow](https://github.com/tuist/tuist/blob/main/.github/workflows/release.yml) uses [`infra/runner-image/cliff.toml`](infra/runner-image/cliff.toml) to decide whether to bump the image version, and the cliff config only matches commits scoped to `runner-image`:

```toml
{ message = "^fix\\([^)]*\\brunner-image\\b[^)]*\\)", group = "..." },
...
{ message = "^[a-z]+\\([^)]+\\)", skip = true },   # catch-all that skips everything else
```

The `infra` scope didn't match, so the catch-all skipped the commit. git-cliff computed `Next runner-image version: runner-image@0.1.0` (same as `Latest`), `runner-image-should-release` resolved to `false`, and the `Release runner image` job was skipped — meaning the new image with the HOME fix never got built or pinned in the helm values. Production runner Pods are still pulling `@sha256:666cf1180b…`, and customer workflows still fail at the first post-checkout step with `fatal: $HOME not set`.

Republishing under the right scope re-triggers the release pipeline. The `launchd.plist` change itself is a comment elaboration — adds an actions/checkout note that explains why the symptom only shows up *after* the checkout step, so a future reader matches symptom to cause without re-tracing it.

## The bonus workflow fix (separate commit)

While diagnosing this I noticed that the standalone [`.github/workflows/runner-image.yml`](.github/workflows/runner-image.yml) also fired on the #10797 merge and failed at YAML parse time. It has a **duplicate `permissions:` block** (introduced by #10653 stacking a second one on the existing one — nothing touched `infra/runner-image/**` between #10653 and #10797 to surface it before now). GitHub Actions rejects workflows with duplicate top-level keys, so every push to that workflow's paths has been failing.

This workflow is **independent** of the release path — the actual image-build flow lives inline in `release.yml`'s `release-runner-image` job — so the failed run wasn't what blocked the rollout. But the standalone workflow still serves the `workflow_dispatch` + push-trigger case (one-off rebuilds without a version bump), so worth fixing.

Scoped `ci(runner-image)` so the cliff config skips it for changelog/bump purposes — the comment-only fix in the preceding commit is the one that carries the version-bump signal.

## How to test locally

- [ ] `git cliff --include-path "infra/runner-image/**/*" --config infra/runner-image/cliff.toml --bumped-version -- runner-image@0.1.0..HEAD` should print `runner-image@0.1.1` (or whatever git-cliff picks based on the commit type).
- [ ] On merge, `release.yml` should report `runner-image-should-release=true` and the `Release runner image` job should build, push, and rewrite the digest pin in `infra/helm/tuist/values-managed-{staging,canary,production}.yaml`.
- [ ] After the auto-bump PR lands and a server deploy, retrigger the lint job on PR #10793 — the `Initialize TuistCacheEE submodule` step should now pass.
- [ ] The standalone `runner-image.yml` should load cleanly: visit it on GitHub or run `gh workflow view runner-image.yml --repo tuist/tuist` and confirm no "workflow file issue" banner.