### PR TITLE
ci(runner-image): isolate Tart GHCR credentials

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2261,15 +2261,35 @@ jobs:
             git cliff "${INCLUDE_PATHS[@]}" --config cliff.toml --repository "../../" --bump -o CHANGELOG.md 2>/dev/null
           fi
 
+      - name: Update Tart
+        run: |
+          set -euo pipefail
+          brew update
+          brew upgrade cirruslabs/cli/tart || brew install cirruslabs/cli/tart
+          tart --version
+
       - name: Initialize Packer
         working-directory: infra/runner-image
-        run: packer init runner.pkr.hcl
+        run: packer init -upgrade runner.pkr.hcl
 
       - name: Drop cached ghcr.io credentials
         # Same anonymous-pull dance as xcresult-processor-image: the
         # bare-metal runner has tuist-bot creds cached for ghcr.io
-        # which don't authorize ghcr.io/cirruslabs/* pulls.
-        run: tart logout ghcr.io || true
+        # which don't authorize ghcr.io/cirruslabs/* pulls. Tart also
+        # consults Docker credential helpers, and this runner can have
+        # the macOS helper installed without the Docker CLI — clear
+        # both stores before Packer clones ghcr.io/cirruslabs/*.
+        run: |
+          tart logout ghcr.io || true
+          if command -v docker >/dev/null 2>&1; then
+            docker logout ghcr.io || true
+          fi
+          for helper in docker-credential-osxkeychain docker-credential-desktop; do
+            if command -v "$helper" >/dev/null 2>&1; then
+              printf 'ghcr.io' | "$helper" erase || true
+              printf 'https://ghcr.io' | "$helper" erase || true
+            fi
+          done
 
       - name: Reclaim Tart disk
         run: |
@@ -2285,7 +2305,26 @@ jobs:
       - name: Build image
         working-directory: infra/runner-image
         run: |
-          packer build \
+          set -euo pipefail
+          docker_config="$HOME/.docker/config.json"
+          docker_config_backup=""
+          restore_docker_config() {
+            if [ -n "$docker_config_backup" ] && [ -f "$docker_config_backup" ]; then
+              mkdir -p "$HOME/.docker"
+              mv "$docker_config_backup" "$docker_config"
+            fi
+          }
+          trap restore_docker_config EXIT
+
+          # Tart hardcodes ~/.docker/config.json when looking up Docker
+          # credential helpers. Move it aside so the public Cirrus image is
+          # pulled anonymously instead of through stale ghcr.io credentials.
+          if [ -f "$docker_config" ]; then
+            docker_config_backup="$(mktemp "${RUNNER_TEMP:-/tmp}/docker-config.XXXXXX")"
+            mv "$docker_config" "$docker_config_backup"
+          fi
+
+          env -u GITHUB_TOKEN -u MISE_GITHUB_TOKEN packer build \
             -var "output_image=tuist-runner" \
             runner.pkr.hcl
 
@@ -2300,6 +2339,10 @@ jobs:
 
       - name: Push image to GHCR + resolve digest
         id: push
+        env:
+          TART_REGISTRY_HOSTNAME: ghcr.io
+          TART_REGISTRY_USERNAME: tuist-bot
+          TART_REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           VERSION="${{ needs.check-releases.outputs.runner-image-next-version-number }}"

--- a/.github/workflows/runner-image.yml
+++ b/.github/workflows/runner-image.yml
@@ -42,15 +42,35 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Update Tart
+        run: |
+          set -euo pipefail
+          brew update
+          brew upgrade cirruslabs/cli/tart || brew install cirruslabs/cli/tart
+          tart --version
+
       - name: Initialize Packer
         working-directory: infra/runner-image
-        run: packer init runner.pkr.hcl
+        run: packer init -upgrade runner.pkr.hcl
 
       # Same anonymous-pull dance as xcresult-processor-image.yml:
       # the bare-metal runner has tuist-bot creds cached for ghcr.io
-      # which don't authorize ghcr.io/cirruslabs/* pulls.
+      # which don't authorize ghcr.io/cirruslabs/* pulls. Tart also
+      # consults Docker credential helpers, and this runner can have
+      # the macOS helper installed without the Docker CLI — clear
+      # both stores before Packer clones ghcr.io/cirruslabs/*.
       - name: Drop cached ghcr.io credentials
-        run: tart logout ghcr.io || true
+        run: |
+          tart logout ghcr.io || true
+          if command -v docker >/dev/null 2>&1; then
+            docker logout ghcr.io || true
+          fi
+          for helper in docker-credential-osxkeychain docker-credential-desktop; do
+            if command -v "$helper" >/dev/null 2>&1; then
+              printf 'ghcr.io' | "$helper" erase || true
+              printf 'https://ghcr.io' | "$helper" erase || true
+            fi
+          done
 
       - name: Reclaim Tart disk
         run: |
@@ -66,7 +86,26 @@ jobs:
       - name: Build image
         working-directory: infra/runner-image
         run: |
-          packer build \
+          set -euo pipefail
+          docker_config="$HOME/.docker/config.json"
+          docker_config_backup=""
+          restore_docker_config() {
+            if [ -n "$docker_config_backup" ] && [ -f "$docker_config_backup" ]; then
+              mkdir -p "$HOME/.docker"
+              mv "$docker_config_backup" "$docker_config"
+            fi
+          }
+          trap restore_docker_config EXIT
+
+          # Tart hardcodes ~/.docker/config.json when looking up Docker
+          # credential helpers. Move it aside so the public Cirrus image is
+          # pulled anonymously instead of through stale ghcr.io credentials.
+          if [ -f "$docker_config" ]; then
+            docker_config_backup="$(mktemp "${RUNNER_TEMP:-/tmp}/docker-config.XXXXXX")"
+            mv "$docker_config" "$docker_config_backup"
+          fi
+
+          env -u GITHUB_TOKEN -u MISE_GITHUB_TOKEN packer build \
             -var "base_image=${{ inputs.base_image || 'ghcr.io/cirruslabs/macos-tahoe-xcode:26.4' }}" \
             -var "output_image=tuist-runner" \
             -var "runner_version=${{ inputs.runner_version || '2.334.0' }}" \
@@ -77,6 +116,10 @@ jobs:
 
       - name: Push image to GHCR
         id: push
+        env:
+          TART_REGISTRY_HOSTNAME: ghcr.io
+          TART_REGISTRY_USERNAME: tuist-bot
+          TART_REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           GIT_SHA="${GITHUB_SHA::8}"


### PR DESCRIPTION
> Sibling of #10796 for the runner-image build paths.

## Why

After #10800 merged, both the standalone `runner-image.yml` workflow and `release.yml`'s `Release runner image` job tried to build the runner image and hit the same GHCR 403 that #10796 just diagnosed for the xcresult-processor build:

```
==> tart-cli.runner: pulling manifest...
==> tart-cli.runner: Error: AuthFailed(why: "received unexpected HTTP status code 403 while
                   retrieving an authentication token",
                   details: "{\"errors\":[{\"code\":\"DENIED\",\"message\":\"denied\"}]}")
```

Root cause (from #10796): Tart hardcodes `$HOME/.docker/config.json` when looking up credential helpers and doesn't honor `DOCKER_CONFIG`. The persistent bare-metal image-builder Mac mini has a macOS Docker credential helper that hands Tart a `ghcr.io` token good enough to authenticate but **not** authorized for `ghcr.io/cirruslabs/*` — so the Cirrus base-image clone fails with 403 before any VM provisioning runs. `tart logout ghcr.io` alone isn't enough because Tart re-discovers the credentials through the Docker config helper chain.

#10796 fixed this for the xcresult-processor build paths but left the runner-image paths untouched, so the runner-image release still 403s.

## Fix

Port #10796's recipe to:

- `.github/workflows/runner-image.yml` (standalone, push + workflow_dispatch)
- `.github/workflows/release.yml` → `Release runner image` job

Same five steps mirrored verbatim:

1. **Update Tart** via brew before Packer runs (`brew upgrade cirruslabs/cli/tart`).
2. **`packer init -upgrade`** to pick up the current Tart Packer plugin.
3. **Beef up the credential cleanup**: also `docker logout ghcr.io` when the CLI is present, and invoke `docker-credential-osxkeychain` / `docker-credential-desktop` `erase` for `ghcr.io` and `https://ghcr.io`.
4. **Wrap `packer build` in a trap** that temporarily moves `~/.docker/config.json` aside, restoring it on exit. Invoke Packer with `env -u GITHUB_TOKEN -u MISE_GITHUB_TOKEN` so the Cirrus pull is genuinely anonymous.
5. **Push with explicit `TART_REGISTRY_*` env**: `TART_REGISTRY_HOSTNAME=ghcr.io`, `TART_REGISTRY_USERNAME=tuist-bot`, `TART_REGISTRY_PASSWORD=${{ secrets.GITHUB_TOKEN }}` — Tart's documented precedence puts env vars ahead of Docker helpers, so the push uses the workflow's token rather than whatever the helpers restore.

## How to test locally

- [ ] `actionlint .github/workflows/runner-image.yml .github/workflows/release.yml` (with the repo's usual ignores for `label "..." is unknown`).
- [ ] Once merged + a runner-image-scoped commit lands on main, `release.yml` → `Release runner image` should succeed end-to-end: build → push semver tag → resolve digest → rewrite `runnersFleet.runnerImage` pin in `infra/helm/tuist/values-managed-*.yaml`.
- [ ] After the auto-bump PR lands and a server deploy, retrigger the lint job on PR #10793 — the `Initialize TuistCacheEE submodule` step should now pass (HOME from #10797 is in the new image).
- [ ] The standalone `runner-image.yml` (workflow_dispatch path) should also build cleanly when invoked manually.

## Scope

Scoped `ci(runner-image)` so the runner-image cliff config skips it for changelog/bump purposes — this PR is just CI plumbing, not a runner-image content change.