### PR TITLE
fix(runner-image): trigger release pipeline now that 403 is fixed

### DIFF
--- a/infra/runner-image/launchd.plist
+++ b/infra/runner-image/launchd.plist
@@ -55,6 +55,11 @@
           environment — there's no separation gain from dropping
           privileges, and the inject-env.sh + dispatch-poll.sh
           chain assumes root for /etc writes. Bypass the check.
+
+          The HOME entry below sets the matching home directory for
+          that root user; both keys exist because macOS LaunchDaemons
+          start with a near-empty environment — see the HOME comment
+          for the full failure mode.
         -->
         <key>RUNNER_ALLOW_RUNASROOT</key>
         <string>1</string>


### PR DESCRIPTION
> Tiny `fix(runner-image)`-scoped commit to retrigger the release pipeline, now that #10801 has resolved the GHCR 403 that blocked the previous attempt.

## Why

Recap of the three-PR chain:

1. **#10797** added `HOME=/var/root` to the runner LaunchDaemon. Merged with `fix(infra):` scope — the runner-image cliff config didn't match, so the release pipeline computed no version bump and the new image never built.
2. **#10800** republished the HOME fix under `fix(runner-image):` scope. The release pipeline correctly fired this time, but the `Release runner image` job failed at the Cirrus base-image pull with a GHCR 403 — same root cause #10796 had just diagnosed for the xcresult-processor build (Tart reads `$HOME/.docker/config.json` directly and the bare-metal runner's Docker credential helper hands it a wrong-scope `ghcr.io` token).
3. **#10801** ported #10796's credential-isolation recipe to the runner-image build paths (`runner-image.yml` standalone + `Release runner image` job in `release.yml`). Scoped `ci(runner-image)` so it doesn't trigger a version bump on its own — that's intentional, it's CI plumbing.

This PR is what actually publishes the HOME fix. The commit body of #10801 is `ci(...)` so cliff skipped it for version-bump purposes; we need a `fix(runner-image):` commit on main to compute a bump and run the release-runner-image job.

## What changed

One small comment edit in [`infra/runner-image/launchd.plist`](infra/runner-image/launchd.plist): the `RUNNER_ALLOW_RUNASROOT` block now points readers at the `HOME` entry right below it, so the env shape reads as one decision (LaunchDaemon env is near-empty; we set the two keys that have to exist for the runner to spawn customer step shells correctly) instead of two unrelated bypasses. Real doc improvement, doesn't touch behavior.

## How to test locally

- [ ] `git cliff --include-path "infra/runner-image/**/*" --config infra/runner-image/cliff.toml --bumped-version -- runner-image@0.1.0..HEAD` should print `runner-image@0.1.1`.
- [ ] On merge, `release.yml` should:
  1. Report `runner-image-should-release=true`.
  2. Build the image cleanly through the credential-isolation dance from #10801 (no 403 on the Cirrus pull, no helper credentials overriding the push token).
  3. Push `ghcr.io/tuist/tuist-runner:0.1.1` + `:latest` and resolve the digest.
  4. Rewrite `runnersFleet.runnerImage` in `infra/helm/tuist/values-managed-{staging,canary,production}.yaml` to the new `@sha256:...`.
- [ ] Auto-bump PR merges, server deploy picks up the new image digest, the next CLI lint job on PR #10793 passes its `Initialize TuistCacheEE submodule` step (HOME is set in the daemon → propagates to step shells).