### PR TITLE
fix(runner-image): bump Xcode to 26.4.1 + symlink Xcode_26.4.app

### DIFF
--- a/infra/runner-image/runner.pkr.hcl
+++ b/infra/runner-image/runner.pkr.hcl
@@ -43,7 +43,7 @@ packer {
 variable "base_image" {
   type        = string
   description = "Base Tart image. Cirrus Labs ships macOS images with Xcode preinstalled, which is what most iOS/macOS workflows expect."
-  default     = "ghcr.io/cirruslabs/macos-tahoe-xcode:26.4"
+  default     = "ghcr.io/cirruslabs/macos-tahoe-xcode:26.4.1"
 }
 
 variable "output_image" {
@@ -114,6 +114,21 @@ build {
     inline = [
       "echo 'admin' | sudo -S mkdir -p /opt/actions-runner /opt/tuist /etc/tuist",
       "echo 'admin' | sudo -S chown admin:staff /opt/actions-runner /opt/tuist"
+    ]
+  }
+
+  # Cirrus' macos-tahoe-xcode:26.4.1 image ships Xcode at
+  # /Applications/Xcode_26.4.1.app. GitHub's actions/runner-images
+  # exposes each Xcode under BOTH the full and major-minor path
+  # (see images/macos/macos-26-arm64-Readme.md#xcode) so customer
+  # workflows that pin `.xcode-version=26.4` work the same as ones
+  # pinning `.xcode-version=26.4.1`. Mirror that convention here so
+  # repos don't have to switch their `.xcode-version` file each
+  # time the patch component rolls.
+  provisioner "shell" {
+    inline = [
+      "echo 'admin' | sudo -S ln -sfn /Applications/Xcode_26.4.1.app /Applications/Xcode_26.4.app",
+      "test -d /Applications/Xcode_26.4.app && test -d /Applications/Xcode_26.4.1.app"
     ]
   }
 


### PR DESCRIPTION
> The repo pins `.xcode-version=26.4.1` but the runner image was built from `:26.4`. Customer workflows that drive `xcode-select` from `.xcode-version` fail at the `Select Xcode` step because `/Applications/Xcode_26.4.1.app` doesn't exist on the VM.

## Symptom

First end-to-end Lint job on the runner fleet (after the HOME fix in #10797 + the credential-isolation fix in #10801 finally let the build through) made it past every previous failure point and stopped at:

```
xcode-select: error: invalid developer directory '/Applications/Xcode_26.4.1.app'
##[error]Process completed with exit code 1.
```

The workflow at [`cli.yml:82-83`](.github/workflows/cli.yml:82) is:

```yaml
- name: Select Xcode
  run: sudo xcode-select -switch /Applications/Xcode_$(cat .xcode-version).app
```

`.xcode-version` is `26.4.1`; the runner image's base was `ghcr.io/cirruslabs/macos-tahoe-xcode:26.4`, which ships Xcode 26.4 (no patch). Mismatch.

## Fix

Two changes in [`runner.pkr.hcl`](infra/runner-image/runner.pkr.hcl):

1. **Bump `base_image` default to `:26.4.1`**. Cirrus publishes both `:26.4` and `:26.4.1` (confirmed via `gh api orgs/cirruslabs/packages/container/macos-tahoe-xcode/versions`), and the 26.4.1 image ships Xcode at `/Applications/Xcode_26.4.1.app`.

2. **Add `/Applications/Xcode_26.4.app` → `/Applications/Xcode_26.4.1.app` symlink** in a Packer provisioner. GitHub's [`actions/runner-images`](https://github.com/actions/runner-images/blob/main/images/macos/macos-26-arm64-Readme.md#xcode) exposes each Xcode under both the full and major-minor path so customer workflows pinning `.xcode-version=26.4` work the same as ones pinning `.xcode-version=26.4.1`. Mirroring that convention means repos don't have to bump their `.xcode-version` file in lockstep with every patch-level Xcode roll.

The provisioner also `test -d`s both paths after the symlink so a future base-image rename catches at build time rather than at first customer workflow.

## How to test locally

This change only takes effect once a new runner image is built and the digest is pinned in helm. Test plan:

- [ ] On merge, `release.yml` → `Release runner image` rebuilds + pushes a new digest. The auto-bump PR rewrites `runnersFleet.runnerImage` in the three managed-env values files.
- [ ] Once the auto-bump PR merges and a server deploy rolls, retrigger the lint job on PR #10793 (`gh run rerun 25853096592 --failed --repo tuist/tuist`). The `Select Xcode` step should now succeed.
- [ ] After this, customer workflows that pin either `.xcode-version=26.4` or `.xcode-version=26.4.1` should both work — the symlink covers both shapes.