### PR TITLE
fix(server): support org-owned GHES app manifests

### DIFF
--- a/.blick/skills/tuist-elixir-review/SKILL.md
+++ b/.blick/skills/tuist-elixir-review/SKILL.md
@@ -340,6 +340,13 @@ account/org feature flag, ops/admin-only access, or an explicit internal
 rollout path, it is not ready for the product changelog unless the PR
 also makes that behavior broadly available to customers.
 
+Do not request a product changelog for fix PRs. This includes fixes that
+add or adjust dashboard fields, copy, validation, or settings controls
+when those UI changes are part of making an already-announced or already
+shipped flow work correctly. Only ask for a changelog when the PR's
+primary purpose is to launch a new customer-facing capability, not when
+the PR is repairing or completing a broken flow.
+
 When suggesting a fix, ask for a short marketing changelog entry with
 frontmatter like `title`, `category: "Product"`, and `pull_request`.
 Mention an accompanying image under
@@ -353,6 +360,8 @@ description or internal release notes instead.
 ### Do not flag
 
 - Bug fixes with no new or materially changed user-facing behavior.
+- Fix PRs, even when the fix includes small user-facing UI changes needed
+  to make an already-shipped flow work correctly.
 - Refactors, performance work, infrastructure, ops/admin-only paths,
   internal jobs, telemetry-only changes, tests, fixtures, or schema-only
   plumbing whose effect is not directly visible to customers.

--- a/server/assets/app/css/pages/integrations.css
+++ b/server/assets/app/css/pages/integrations.css
@@ -56,6 +56,12 @@
             white-space: nowrap;
           }
         }
+
+        & > [data-part="github-enterprise-form"] {
+          display: flex;
+          flex-direction: column;
+          gap: var(--noora-spacing-5);
+        }
       }
 
       & > [data-part="actions"] {

--- a/server/lib/tuist/vcs.ex
+++ b/server/lib/tuist/vcs.ex
@@ -1412,7 +1412,8 @@ defmodule Tuist.VCS do
   Get GitHub app installation URL with encrypted state parameter for account-specific installation.
 
   Accepts an optional `:client_url` to target a self-hosted GitHub Enterprise Server instance,
-  defaulting to https://github.com.
+  defaulting to https://github.com. Accepts an optional `:github_app_owner`
+  to register the manifest-owned App under a GitHub organization.
 
   For github.com, returns the direct installation URL of the
   globally-configured Tuist App. For a GHES `client_url`, returns an
@@ -1424,7 +1425,8 @@ defmodule Tuist.VCS do
   """
   def get_github_app_installation_url(%Account{id: account_id}, opts \\ []) do
     client_url = normalize_client_url(Keyword.get(opts, :client_url))
-    state_token = generate_github_state_token(account_id, client_url)
+    github_app_owner = normalize_github_app_owner(Keyword.get(opts, :github_app_owner))
+    state_token = generate_github_state_token(account_id, client_url, github_app_owner)
 
     if client_url == default_client_url() do
       app_name = Environment.github_app_name()
@@ -1437,7 +1439,18 @@ defmodule Tuist.VCS do
   defp normalize_client_url(nil), do: default_client_url()
   defp normalize_client_url(""), do: default_client_url()
 
-  defp normalize_client_url(url) when is_binary(url), do: url |> String.trim() |> String.trim_trailing("/")
+  defp normalize_client_url(url) when is_binary(url) do
+    url |> String.trim() |> String.trim_trailing("/")
+  end
+
+  defp normalize_github_app_owner(nil), do: nil
+
+  defp normalize_github_app_owner(owner) when is_binary(owner) do
+    case String.trim(owner) do
+      "" -> nil
+      owner -> owner
+    end
+  end
 
   # GitHub State Token functions
 
@@ -1446,25 +1459,53 @@ defmodule Tuist.VCS do
   client URL. The token round-trips through GitHub's installation flow so we
   know which GitHub instance the resulting installation belongs to.
   """
-  def generate_github_state_token(account_id, client_url \\ default_client_url()) do
-    Phoenix.Token.sign(TuistWeb.Endpoint, "github_state", {account_id, normalize_client_url(client_url)})
+  def generate_github_state_token(account_id, client_url \\ default_client_url(), github_app_owner \\ nil) do
+    Phoenix.Token.sign(
+      TuistWeb.Endpoint,
+      "github_state",
+      {
+        account_id,
+        normalize_client_url(client_url),
+        normalize_github_app_owner(github_app_owner)
+      }
+    )
   end
 
   @doc """
-  Verifies the state token. Returns `{:ok, %{account_id: id, client_url: url}}`
-  on success, `{:error, reason}` otherwise. Tokens generated before client_url
-  was introduced are accepted with the default github.com URL.
+  Verifies the state token. Returns
+  `{:ok, %{account_id: id, client_url: url, github_app_owner: owner}}` on
+  success, `{:error, reason}` otherwise. Tokens generated before client_url or
+  github_app_owner were introduced are accepted with the available defaults.
   """
   def verify_github_state_token(token) do
     # 90 days
     token_max_age_seconds = 7_776_000
 
-    case Phoenix.Token.verify(TuistWeb.Endpoint, "github_state", token, max_age: token_max_age_seconds) do
+    case Phoenix.Token.verify(
+           TuistWeb.Endpoint,
+           "github_state",
+           token,
+           max_age: token_max_age_seconds
+         ) do
+      {:ok, {account_id, client_url, github_app_owner}}
+      when is_integer(account_id) and is_binary(client_url) ->
+        {:ok,
+         %{
+           account_id: account_id,
+           client_url: normalize_client_url(client_url),
+           github_app_owner: normalize_github_app_owner(github_app_owner)
+         }}
+
       {:ok, {account_id, client_url}} when is_integer(account_id) and is_binary(client_url) ->
-        {:ok, %{account_id: account_id, client_url: normalize_client_url(client_url)}}
+        {:ok,
+         %{
+           account_id: account_id,
+           client_url: normalize_client_url(client_url),
+           github_app_owner: nil
+         }}
 
       {:ok, account_id} when is_integer(account_id) ->
-        {:ok, %{account_id: account_id, client_url: default_client_url()}}
+        {:ok, %{account_id: account_id, client_url: default_client_url(), github_app_owner: nil}}
 
       {:ok, _} ->
         {:error, :invalid}

--- a/server/lib/tuist_web/controllers/github_app_manifest_controller.ex
+++ b/server/lib/tuist_web/controllers/github_app_manifest_controller.ex
@@ -46,7 +46,7 @@ defmodule TuistWeb.GitHubAppManifestController do
 
   def start(conn, %{"state" => state_token}) when is_binary(state_token) do
     case VCS.verify_github_state_token(state_token) do
-      {:ok, %{account_id: account_id, client_url: client_url}} ->
+      {:ok, %{account_id: account_id, client_url: client_url} = state} ->
         if client_url == VCS.default_client_url() do
           raise BadRequestError, dgettext("dashboard", "Manifest flow is only available for GitHub Enterprise Server.")
         end
@@ -55,7 +55,8 @@ defmodule TuistWeb.GitHubAppManifestController do
 
         manifest = manifest_payload()
         nonce = CSP.get_csp_nonce()
-        body = render_auto_submit(client_url, manifest, state_token, nonce)
+        github_app_owner = Map.get(state, :github_app_owner)
+        body = render_auto_submit(client_url, github_app_owner, manifest, state_token, nonce)
 
         conn
         |> override_csp_for_manifest_post(client_url, nonce)
@@ -174,8 +175,8 @@ defmodule TuistWeb.GitHubAppManifestController do
   #     policy already allows `'nonce'`, but we restate it scoped to
   #     this response so a future global tightening doesn't silently
   #     break the flow.
-  #   * `form-action` whitelists the customer's GHES origin (the
-  #     manifest must be POSTed to `<ghes>/settings/apps/new`); without
+  #   * `form-action` whitelists the customer's GHES origin (the manifest
+  #     must be POSTed to the GHES app registration page); without
   #     this, the browser falls back to `default-src 'self'` and blocks
   #     the cross-origin form submission.
   defp override_csp_for_manifest_post(conn, client_url, nonce) do
@@ -197,9 +198,11 @@ defmodule TuistWeb.GitHubAppManifestController do
     put_resp_header(conn, "content-security-policy", csp)
   end
 
-  defp render_auto_submit(client_url, manifest, state_token, nonce) do
+  defp render_auto_submit(client_url, github_app_owner, manifest, state_token, nonce) do
     manifest_json = Jason.encode!(manifest)
-    action = "#{client_url}/settings/apps/new?state=#{URI.encode_www_form(state_token)}"
+
+    action =
+      "#{manifest_registration_url(client_url, github_app_owner)}?state=#{URI.encode_www_form(state_token)}"
 
     redirecting_text =
       dgettext("dashboard_integrations", "Redirecting to GitHub Enterprise Server to register the Tuist app…")
@@ -228,6 +231,13 @@ defmodule TuistWeb.GitHubAppManifestController do
     """
   end
 
+  defp manifest_registration_url(client_url, nil), do: "#{client_url}/settings/apps/new"
+
+  defp manifest_registration_url(client_url, github_app_owner) when is_binary(github_app_owner) do
+    encoded_owner = URI.encode(github_app_owner, &URI.char_unreserved?/1)
+    "#{client_url}/organizations/#{encoded_owner}/settings/apps/new"
+  end
+
   defp exchange_manifest_code(account_id, client_url, code) do
     api_url = VCS.api_url(:github, client_url)
     url = "#{api_url}/app-manifests/#{code}/conversions"
@@ -251,8 +261,11 @@ defmodule TuistWeb.GitHubAppManifestController do
            body: "",
            headers: [
              {"Accept", "application/vnd.github+json"},
+             {"Content-Type", "application/json"},
+             {"User-Agent", "Tuist"},
              {"X-GitHub-Api-Version", "2022-11-28"}
            ],
+           finch: Tuist.Finch,
            connect_options: SSRFGuard.connect_options(hostname)
          ) do
       {:ok, %Req.Response{status: status, body: %{"id" => _} = body}} when status in 200..299 ->

--- a/server/lib/tuist_web/live/integrations_live.ex
+++ b/server/lib/tuist_web/live/integrations_live.ex
@@ -46,6 +46,8 @@ defmodule TuistWeb.IntegrationsLive do
       |> assign(selected_repository_full_handle: nil)
       |> assign(github_client_url: if(default_to_enterprise?, do: "", else: VCS.default_client_url()))
       |> assign(github_client_url_error: nil)
+      |> assign(github_app_owner: "")
+      |> assign(github_app_owner_error: nil)
       |> assign(show_github_enterprise_input: default_to_enterprise?)
       |> assign(github_enterprise_available?: github_enterprise_available?)
       |> assign(github_card_visible?: github_card_visible?(selected_account, github_installation))
@@ -72,13 +74,18 @@ defmodule TuistWeb.IntegrationsLive do
   end
 
   @impl true
-  def handle_event("update-github-client-url", %{"github_client_url" => raw_url}, socket) do
+  def handle_event("update-github-client-url", params, socket) do
+    raw_url = Map.get(params, "github_client_url", socket.assigns.github_client_url)
+    raw_owner = Map.get(params, "github_app_owner", socket.assigns.github_app_owner)
     {url, error} = validate_github_client_url(raw_url, socket.assigns.show_github_enterprise_input)
+    {github_app_owner, github_app_owner_error} = validate_github_app_owner(raw_owner)
 
     socket =
       socket
       |> assign(github_client_url: url)
       |> assign(github_client_url_error: error)
+      |> assign(github_app_owner: github_app_owner)
+      |> assign(github_app_owner_error: github_app_owner_error)
 
     {:noreply, socket}
   end
@@ -90,6 +97,8 @@ defmodule TuistWeb.IntegrationsLive do
       |> assign(show_github_enterprise_input: false)
       |> assign(github_client_url: VCS.default_client_url())
       |> assign(github_client_url_error: nil)
+      |> assign(github_app_owner: "")
+      |> assign(github_app_owner_error: nil)
 
     {:noreply, socket}
   end
@@ -106,6 +115,8 @@ defmodule TuistWeb.IntegrationsLive do
         # github.com App, which is exactly the wrong target.
         |> assign(github_client_url: "")
         |> assign(github_client_url_error: nil)
+        |> assign(github_app_owner: "")
+        |> assign(github_app_owner_error: nil)
 
       {:noreply, socket}
     else
@@ -228,6 +239,7 @@ defmodule TuistWeb.IntegrationsLive do
   #     state would silently target github.com from inside the GHES tab.
   defp install_button_disabled?(assigns) do
     not is_nil(assigns.github_client_url_error) or
+      not is_nil(assigns.github_app_owner_error) or
       (assigns.show_github_enterprise_input and
          (assigns.github_client_url in ["", nil] or
             assigns.github_client_url == VCS.default_client_url()))
@@ -237,23 +249,79 @@ defmodule TuistWeb.IntegrationsLive do
     trimmed = raw_url |> to_string() |> String.trim()
 
     cond do
-      trimmed == "" and enterprise_tab? ->
-        # On the Enterprise tab the URL is required and must not silently
-        # collapse to the github.com default — that would let the Install
-        # button target github.com from inside the GHES tab.
-        {"", dgettext("dashboard_integrations", "Required")}
-
       trimmed == "" ->
-        {VCS.default_client_url(), nil}
+        validate_empty_github_client_url(enterprise_tab?)
 
-      enterprise_tab? and trimmed == VCS.default_client_url() ->
+      enterprise_tab? and github_com_url?(trimmed) ->
         {trimmed, dgettext("dashboard_integrations", "Use a GitHub Enterprise Server URL")}
 
       true ->
-        case VCS.validate_client_url(trimmed) do
-          {:ok, url} -> {url, nil}
-          {:error, _} -> {trimmed, dgettext("dashboard_integrations", "Invalid URL")}
-        end
+        validate_non_empty_github_client_url(trimmed, enterprise_tab?)
+    end
+  end
+
+  defp validate_empty_github_client_url(true) do
+    # On the Enterprise tab the URL is required and must not silently
+    # collapse to the github.com default — that would let the Install
+    # button target github.com from inside the GHES tab.
+    {"", dgettext("dashboard_integrations", "Required")}
+  end
+
+  defp validate_empty_github_client_url(false) do
+    {VCS.default_client_url(), nil}
+  end
+
+  defp validate_non_empty_github_client_url(trimmed, enterprise_tab?) do
+    case VCS.validate_client_url(trimmed) do
+      {:ok, url} ->
+        validate_enterprise_github_client_url(url, enterprise_tab?)
+
+      {:error, _} ->
+        {trimmed, dgettext("dashboard_integrations", "Invalid URL")}
+    end
+  end
+
+  defp validate_enterprise_github_client_url(url, true) do
+    if github_enterprise_base_url?(url) do
+      {url, nil}
+    else
+      {url, dgettext("dashboard_integrations", "Use a GitHub Enterprise Server URL")}
+    end
+  end
+
+  defp validate_enterprise_github_client_url(url, false) do
+    {url, nil}
+  end
+
+  defp validate_github_app_owner(raw_owner) do
+    trimmed = raw_owner |> to_string() |> String.trim()
+
+    cond do
+      trimmed == "" ->
+        {"", nil}
+
+      Regex.match?(~r/^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$/, trimmed) ->
+        {trimmed, nil}
+
+      true ->
+        {trimmed, dgettext("dashboard_integrations", "Invalid organization")}
+    end
+  end
+
+  defp github_com_url?(url) do
+    case URI.parse(url) do
+      %URI{scheme: "https", host: "github.com"} -> true
+      _ -> false
+    end
+  end
+
+  defp github_enterprise_base_url?(url) do
+    case URI.parse(url) do
+      %URI{host: host, path: path, query: nil, fragment: nil} when is_binary(host) ->
+        path in [nil, "", "/"]
+
+      _ ->
+        false
     end
   end
 

--- a/server/lib/tuist_web/live/integrations_live.html.heex
+++ b/server/lib/tuist_web/live/integrations_live.html.heex
@@ -29,15 +29,29 @@
             data-selected={@show_github_enterprise_input}
           />
         </.button_group>
-        <form :if={@show_github_enterprise_input} phx-change="update-github-client-url">
+        <form
+          :if={@show_github_enterprise_input}
+          phx-change="update-github-client-url"
+          data-part="github-enterprise-form"
+        >
           <.text_input
             id="github-client-url"
             name="github_client_url"
             type="basic"
             value={@github_client_url}
             label={dgettext("dashboard_integrations", "Server URL")}
-            placeholder="https://github.example.com"
+            placeholder="https://github.company.com"
             error={@github_client_url_error}
+            phx-debounce="300"
+          />
+          <.text_input
+            id="github-app-owner"
+            name="github_app_owner"
+            type="basic"
+            value={@github_app_owner}
+            label={dgettext("dashboard", "Organization")}
+            placeholder="my-organization"
+            error={@github_app_owner_error}
             phx-debounce="300"
           />
         </form>
@@ -48,7 +62,10 @@
           label={dgettext("dashboard_integrations", "Install GitHub App")}
           variant="primary"
           href={
-            VCS.get_github_app_installation_url(@selected_account, client_url: @github_client_url)
+            VCS.get_github_app_installation_url(@selected_account,
+              client_url: @github_client_url,
+              github_app_owner: @github_app_owner
+            )
           }
           disabled={install_button_disabled?(assigns)}
         />

--- a/server/priv/gettext/dashboard_integrations.pot
+++ b/server/priv/gettext/dashboard_integrations.pot
@@ -102,6 +102,11 @@ msgstr ""
 msgid "Invalid URL"
 msgstr ""
 
+#: lib/tuist_web/live/integrations_live.ex:287
+#, elixir-autogen, elixir-format
+msgid "Invalid organization"
+msgstr ""
+
 #: lib/tuist_web/live/integrations_live.html.heex:38
 #, elixir-autogen, elixir-format
 msgid "Server URL"

--- a/server/test/tuist/vcs_test.exs
+++ b/server/test/tuist/vcs_test.exs
@@ -3272,6 +3272,22 @@ defmodule Tuist.VCSTest do
 
       assert {:ok, %{client_url: "https://github.example.com"}} = VCS.verify_github_state_token(state_token)
     end
+
+    test "carries a separate GitHub App owner in the manifest state" do
+      # Given
+      user = AccountsFixtures.user_fixture()
+      account = user.account
+      ghes_url = "https://github.example.com"
+
+      # When
+      result = VCS.get_github_app_installation_url(account, client_url: ghes_url, github_app_owner: "ios")
+
+      # Then
+      state_token = result |> String.split("state=") |> List.last() |> URI.decode_www_form()
+
+      assert {:ok, %{client_url: ^ghes_url, github_app_owner: "ios"}} =
+               VCS.verify_github_state_token(state_token)
+    end
   end
 
   describe "account deletion cascades" do
@@ -3345,6 +3361,32 @@ defmodule Tuist.VCSTest do
 
       # Then
       assert {:ok, %{account_id: ^account_id, client_url: ^ghes_url}} = result
+    end
+
+    test "round-trips a GitHub App owner for organization-owned manifest registration" do
+      # Given
+      account_id = 321
+      ghes_url = "https://github.example.com"
+      token = VCS.generate_github_state_token(account_id, ghes_url, "ios")
+
+      # When
+      result = VCS.verify_github_state_token(token)
+
+      # Then
+      assert {:ok, %{account_id: ^account_id, client_url: ^ghes_url, github_app_owner: "ios"}} = result
+    end
+
+    test "accepts tokens generated before github_app_owner was introduced" do
+      # Given
+      account_id = 321
+      ghes_url = "https://github.example.com"
+      token = Phoenix.Token.sign(TuistWeb.Endpoint, "github_state", {account_id, ghes_url})
+
+      # When
+      result = VCS.verify_github_state_token(token)
+
+      # Then
+      assert {:ok, %{account_id: ^account_id, client_url: ^ghes_url, github_app_owner: nil}} = result
     end
 
     test "returns error for invalid token format" do

--- a/server/test/tuist_web/controllers/github_app_manifest_controller_test.exs
+++ b/server/test/tuist_web/controllers/github_app_manifest_controller_test.exs
@@ -34,6 +34,19 @@ defmodule TuistWeb.GitHubAppManifestControllerTest do
       assert body =~ "document.getElementById('manifest-form').submit()"
     end
 
+    test "renders an organization-owned manifest registration form when the state carries a GitHub owner", %{conn: conn} do
+      account = AccountsFixtures.user_fixture(preload: [:account]).account
+      ghes_url = "https://github.example.com"
+      state_token = VCS.generate_github_state_token(account.id, ghes_url, "ios")
+
+      conn = get(conn, ~p"/integrations/github/manifest/start", %{"state" => state_token})
+
+      assert conn.status == 200
+      body = response(conn, 200)
+      assert body =~ "#{ghes_url}/organizations/ios/settings/apps/new"
+      refute body =~ "#{ghes_url}/ios/settings/apps/new"
+    end
+
     test "scopes the CSP so the inline submit and cross-origin form action are allowed", %{conn: conn} do
       account = AccountsFixtures.user_fixture(preload: [:account]).account
       ghes_url = "https://github.example.com"
@@ -105,6 +118,15 @@ defmodule TuistWeb.GitHubAppManifestControllerTest do
         # emits the header when an explicit body is passed, so guard the
         # call shape here.
         assert Keyword.fetch!(opts, :body) == ""
+        assert Keyword.fetch!(opts, :finch) == Tuist.Finch
+
+        assert Keyword.fetch!(opts, :headers) == [
+                 {"Accept", "application/vnd.github+json"},
+                 {"Content-Type", "application/json"},
+                 {"User-Agent", "Tuist"},
+                 {"X-GitHub-Api-Version", "2022-11-28"}
+               ]
+
         {:ok, %Req.Response{status: 201, body: app_payload}}
       end)
 

--- a/server/test/tuist_web/live/integrations_live_test.exs
+++ b/server/test/tuist_web/live/integrations_live_test.exs
@@ -87,6 +87,7 @@ defmodule TuistWeb.IntegrationsLiveTest do
 
     html = render_click(lv, "select-github-enterprise")
     assert html =~ "Server URL"
+    assert html =~ "Organization"
   end
 
   test "shows a validation error and disables the install button for malformed URLs", %{
@@ -109,6 +110,99 @@ defmodule TuistWeb.IntegrationsLiveTest do
       |> render_change()
 
     assert html =~ "Invalid URL"
+  end
+
+  test "rejects github.com URLs on the Enterprise server tab", %{
+    conn: conn,
+    organization: organization
+  } do
+    stub(VCS, :get_github_app_installation_url, fn _account, _opts ->
+      "https://github.com/apps/test-app/installations/new"
+    end)
+
+    {:ok, lv, _html} = live(conn, ~p"/#{organization.account.name}/integrations")
+
+    render_click(lv, "select-github-enterprise")
+
+    html =
+      lv
+      |> form("form[phx-change=update-github-client-url]", %{
+        "github_client_url" => "https://github.com/tuist/tuist"
+      })
+      |> render_change()
+
+    assert html =~ "Use a GitHub Enterprise Server URL"
+  end
+
+  test "rejects repository URLs in the GitHub Enterprise Server URL field", %{
+    conn: conn,
+    organization: organization
+  } do
+    stub(VCS, :get_github_app_installation_url, fn _account, _opts ->
+      "https://tuist.dev/integrations/github/manifest/start?state=test"
+    end)
+
+    {:ok, lv, _html} = live(conn, ~p"/#{organization.account.name}/integrations")
+
+    render_click(lv, "select-github-enterprise")
+
+    html =
+      lv
+      |> form("form[phx-change=update-github-client-url]", %{
+        "github_client_url" => "https://github.example.com/ios/app"
+      })
+      |> render_change()
+
+    assert html =~ "Use a GitHub Enterprise Server URL"
+  end
+
+  test "passes the optional GitHub organization to the manifest flow", %{
+    conn: conn,
+    organization: organization
+  } do
+    stub(VCS, :get_github_app_installation_url, fn _account, opts ->
+      case Keyword.get(opts, :github_app_owner) do
+        "ios" -> "https://tuist.dev/integrations/github/manifest/start?state=with-org"
+        _ -> "https://tuist.dev/integrations/github/manifest/start?state=without-org"
+      end
+    end)
+
+    {:ok, lv, _html} = live(conn, ~p"/#{organization.account.name}/integrations")
+
+    render_click(lv, "select-github-enterprise")
+
+    html =
+      lv
+      |> form("form[phx-change=update-github-client-url]", %{
+        "github_client_url" => "https://github.example.com",
+        "github_app_owner" => "ios"
+      })
+      |> render_change()
+
+    assert html =~ "state=with-org"
+  end
+
+  test "shows a validation error for malformed GitHub organization names", %{
+    conn: conn,
+    organization: organization
+  } do
+    stub(VCS, :get_github_app_installation_url, fn _account, _opts ->
+      "https://tuist.dev/integrations/github/manifest/start?state=test"
+    end)
+
+    {:ok, lv, _html} = live(conn, ~p"/#{organization.account.name}/integrations")
+
+    render_click(lv, "select-github-enterprise")
+
+    html =
+      lv
+      |> form("form[phx-change=update-github-client-url]", %{
+        "github_client_url" => "https://github.example.com",
+        "github_app_owner" => "ios/bumble"
+      })
+      |> render_change()
+
+    assert html =~ "Invalid organization"
   end
 
   test "switching back to github.com hides the input and clears the URL", %{


### PR DESCRIPTION
## Summary
- Adds a separate optional **Organization** field to the GitHub Enterprise Server integration flow.
- Keeps **Server URL** as the GHES instance base URL, for example `https://github.company.com`.
- Carries the optional organization slug through the signed GitHub state token.
- Routes manifest registration to the org-owned GitHub App path when an organization is provided:
  `/organizations/:owner/settings/apps/new`.
- Keeps the existing personal/user-owned registration path when no organization is provided:
  `/settings/apps/new`.
- Hardens the GHES manifest conversion POST with explicit GitHub API headers, `Content-Type`, `User-Agent`, and the shared `Tuist.Finch` client.

## Context
After #10790, a customer GHES manifest conversion request still reached GitHub Enterprise Server but came back with HTTP 403.

From the production logs for the failed attempt:

- Timestamp: `2026-05-15T03:28:45Z`
- Account: customer account
- `client_url`: customer GHES base URL
- Request: `GET /integrations/github/manifest/callback`
- GHES response: HTTP 403 from the manifest conversion HTTP call
- Logged GHES body: bare HTML `403 Forbidden`, with no structured GitHub JSON error
- No SSRF guard or transport-level error was logged

That weakens the original "wrong owner path is the only issue" hypothesis. The failing request reached GHES and was rejected by GHES itself during conversion, likely before the normal GitHub API layer returned a JSON error. Possible causes include GHES edge/network restrictions, a strict gateway/WAF policy, instance-level app creation restrictions, or rejection of the HTTP request shape.

This PR still fixes the product-flow gap around org ownership. The manifest start flow previously always posted to the instance-level app registration URL, which creates a user-owned GitHub App. For a company setup, the App often needs to be created under the GitHub organization instead.

GitHub's manifest flow has separate entry points for user-owned and organization-owned Apps. A base GHES URL alone is not enough to know which organization should own the App, so this PR makes that input explicit instead of asking users to paste an org/repository URL into the server URL field.

## Implementation
- `VCS.get_github_app_installation_url/2` now accepts `:github_app_owner` alongside `:client_url`.
- GitHub state tokens now include `github_app_owner`, while still accepting older tokens that only contain account ID and client URL.
- `GitHubAppManifestController.start/2` reads the owner from state and chooses the correct manifest registration URL.
- The integrations LiveView now renders:
  - **Server URL** with placeholder `https://github.company.com`
  - **Organization** with placeholder `my-organization`
- The Server URL field rejects path/repository URLs on the Enterprise tab, keeping it scoped to the GHES instance base URL.
- The Organization field validates GitHub-style organization slugs.
- Page CSS adds explicit spacing between the two fields.
- Manifest conversion now sends:
  - `Accept: application/vnd.github+json`
  - `Content-Type: application/json`
  - `User-Agent: Tuist`
  - `X-GitHub-Api-Version: 2022-11-28`
- Manifest conversion now uses `Tuist.Finch`, matching the rest of the server's explicit HTTP client setup.

## How To Try
For an organization-owned GHES app:

- Server URL: `https://github.company.com`
- Organization: `ios`

That posts the manifest to:

`https://github.company.com/organizations/ios/settings/apps/new`

Leaving Organization blank keeps the old personal/user-owned path:

`https://github.company.com/settings/apps/new`

## Tests Added
- State token round-tripping for a separate GitHub App owner.
- Backwards compatibility for older state tokens.
- Manifest start rendering for organization-owned registration URLs.
- LiveView validation for:
  - rejecting `github.com` on the Enterprise tab
  - rejecting repository/path URLs in Server URL
  - passing the optional organization into the install URL
  - rejecting malformed organization names
- Manifest conversion request shape, including body, headers, and Finch client.

## Follow-Up Logging To Check After Deploy
If the affected customer can retry after this deploy, the useful things to confirm in Grafana are:

- Whether the request still fails at `POST /api/v3/app-manifests/:code/conversions`.
- Whether the response is still a bare HTML `403 Forbidden`.
- Any GHES response headers that identify an edge, proxy, WAF, SSO, or enterprise policy rejection.
- Whether GHES server-side logs record an app-manifest conversion denial reason for that timestamp/request.

## Testing
- `git diff --check`
- `git diff --check HEAD~1..HEAD`
- Verified locally in the in-app browser at `/tuist/integrations` that the two-field UI renders with the updated placeholders and spacing.
- Not run: `mix format` / focused tests because `server/mise.toml` is untrusted in this worktree and persistent `mise trust` was blocked by the app safety policy.
