### PR TITLE
fix(cli): bind shard reference across split build/test jobs

### DIFF
--- a/cli/Sources/TuistCI/CIController.swift
+++ b/cli/Sources/TuistCI/CIController.swift
@@ -53,9 +53,13 @@ public struct CIController: CIControlling {
             } else {
                 nil
             }
+            // CIRCLE_WORKFLOW_ID is stable across jobs in a workflow (e.g. a `build-for-testing`
+            // job and downstream `test-without-building` shard jobs), so it lets the derived
+            // shard reference bind across them. Fall back to CIRCLE_BUILD_NUM for environments
+            // where workflows aren't in use.
             return CIInfo(
                 provider: .circleci,
-                runId: env["CIRCLE_BUILD_NUM"],
+                runId: env["CIRCLE_WORKFLOW_ID"] ?? env["CIRCLE_BUILD_NUM"],
                 projectHandle: projectHandle
             )
         }

--- a/cli/Sources/TuistCI/CIController.swift
+++ b/cli/Sources/TuistCI/CIController.swift
@@ -53,14 +53,15 @@ public struct CIController: CIControlling {
             } else {
                 nil
             }
-            // CIRCLE_WORKFLOW_ID is stable across jobs in a workflow (e.g. a `build-for-testing`
-            // job and downstream `test-without-building` shard jobs), so it lets the derived
-            // shard reference bind across them. Fall back to CIRCLE_BUILD_NUM for environments
-            // where workflows aren't in use.
+            // CIRCLE_BUILD_NUM is the per-job number used to build dashboard URLs.
+            // CIRCLE_WORKFLOW_ID is stable across all jobs in a workflow, so we surface it as
+            // `pipelineId` and prefer it for shard reference derivation: a `build-for-testing`
+            // job and its downstream `test-without-building` shard jobs share the workflow id.
             return CIInfo(
                 provider: .circleci,
-                runId: env["CIRCLE_WORKFLOW_ID"] ?? env["CIRCLE_BUILD_NUM"],
-                projectHandle: projectHandle
+                runId: env["CIRCLE_BUILD_NUM"],
+                projectHandle: projectHandle,
+                pipelineId: env["CIRCLE_WORKFLOW_ID"]
             )
         }
 

--- a/cli/Sources/TuistCI/CIInfo.swift
+++ b/cli/Sources/TuistCI/CIInfo.swift
@@ -6,27 +6,33 @@ public struct CIInfo: Equatable {
     public let attemptNumber: String?
     public let projectHandle: String?
     public let host: String?
+    /// Workflow/pipeline-scoped identifier preferred for binding a shard plan across jobs.
+    /// Set only when the provider exposes a separate cross-job identifier (e.g. CircleCI's
+    /// `CIRCLE_WORKFLOW_ID`); `runId` is used for shard binding when this is nil.
+    public let pipelineId: String?
 
     public init(
         provider: CIProvider,
         runId: String? = nil,
         attemptNumber: String? = nil,
         projectHandle: String? = nil,
-        host: String? = nil
+        host: String? = nil,
+        pipelineId: String? = nil
     ) {
         self.provider = provider
         self.runId = runId
         self.attemptNumber = attemptNumber
         self.projectHandle = projectHandle
         self.host = host
+        self.pipelineId = pipelineId
     }
 
     public var shardReference: String? {
-        guard let runId else { return nil }
+        guard let id = pipelineId ?? runId else { return nil }
         if let attemptNumber {
-            return "\(provider)-\(runId)-\(attemptNumber)"
+            return "\(provider)-\(id)-\(attemptNumber)"
         }
-        return "\(provider)-\(runId)"
+        return "\(provider)-\(id)"
     }
 
     #if DEBUG
@@ -35,14 +41,16 @@ public struct CIInfo: Equatable {
             runId: String? = "123",
             attemptNumber: String? = nil,
             projectHandle: String? = "test-project",
-            host: String? = nil
+            host: String? = nil,
+            pipelineId: String? = nil
         ) -> CIInfo {
             CIInfo(
                 provider: provider,
                 runId: runId,
                 attemptNumber: attemptNumber,
                 projectHandle: projectHandle,
-                host: host
+                host: host,
+                pipelineId: pipelineId
             )
         }
     #endif

--- a/cli/Sources/TuistKit/Commands/XcodeBuild/XcodeBuildTestCommand.swift
+++ b/cli/Sources/TuistKit/Commands/XcodeBuild/XcodeBuildTestCommand.swift
@@ -35,6 +35,13 @@ public struct XcodeBuildTestCommand: AsyncParsableCommand, TrackableParsableComm
 
     @Option(
         name: .long,
+        help: "Explicit shard reference. Derived from environment variables for supported CI providers.",
+        envKey: .testShardReference
+    )
+    var shardReference: String?
+
+    @Option(
+        name: .long,
         help: "Path to a locally managed shard archive. Tuist extracts this archive instead of downloading test products from remote storage.",
         completion: .file(),
         envKey: .testShardArchivePath
@@ -60,6 +67,7 @@ public struct XcodeBuildTestCommand: AsyncParsableCommand, TrackableParsableComm
                 passthroughXcodebuildArguments: ["test"] + passthroughXcodebuildArguments,
                 skipQuarantine: skipQuarantine,
                 shardIndex: shardIndex ?? EnvKey.testShardIndex.envValue(),
+                shardReference: shardReference,
                 shardArchivePath: shardArchivePath,
                 mode: inspectMode
             )

--- a/cli/Sources/TuistKit/Commands/XcodeBuild/XcodeBuildTestWithoutBuildingCommand.swift
+++ b/cli/Sources/TuistKit/Commands/XcodeBuild/XcodeBuildTestWithoutBuildingCommand.swift
@@ -35,6 +35,13 @@ public struct XcodeBuildTestWithoutBuildingCommand: AsyncParsableCommand, Tracka
 
     @Option(
         name: .long,
+        help: "Explicit shard reference. Derived from environment variables for supported CI providers.",
+        envKey: .testShardReference
+    )
+    var shardReference: String?
+
+    @Option(
+        name: .long,
         help: "Path to a locally managed shard archive. Tuist extracts this archive instead of downloading test products from remote storage.",
         completion: .file(),
         envKey: .testShardArchivePath
@@ -60,6 +67,7 @@ public struct XcodeBuildTestWithoutBuildingCommand: AsyncParsableCommand, Tracka
                 passthroughXcodebuildArguments: ["test-without-building"] + passthroughXcodebuildArguments,
                 skipQuarantine: skipQuarantine,
                 shardIndex: shardIndex ?? EnvKey.testShardIndex.envValue(),
+                shardReference: shardReference,
                 shardArchivePath: shardArchivePath,
                 mode: inspectMode
             )

--- a/cli/Sources/TuistKit/Services/Sharding/ShardService.swift
+++ b/cli/Sources/TuistKit/Services/Sharding/ShardService.swift
@@ -25,6 +25,7 @@ public protocol ShardServicing {
         shardIndex: Int,
         fullHandle: String,
         serverURL: URL,
+        reference: String?,
         testProductsPath: AbsolutePath?,
         testProductsArchivePath: AbsolutePath?
     ) async throws -> Shard
@@ -76,10 +77,11 @@ public struct ShardService: ShardServicing {
         shardIndex: Int,
         fullHandle: String,
         serverURL: URL,
+        reference: String? = nil,
         testProductsPath: AbsolutePath? = nil,
         testProductsArchivePath: AbsolutePath? = nil
     ) async throws -> Shard {
-        guard let reference = ciController.ciInfo()?.shardReference else {
+        guard let reference = reference ?? ciController.ciInfo()?.shardReference else {
             throw ShardServiceError.cannotDeriveReference
         }
 

--- a/cli/Sources/TuistKit/Services/TestService.swift
+++ b/cli/Sources/TuistKit/Services/TestService.swift
@@ -288,6 +288,7 @@ public struct TestService { // swiftlint:disable:this type_body_length
                 testPlanConfiguration: testPlanConfiguration,
                 passthroughXcodeBuildArguments: passthroughXcodeBuildArguments,
                 runId: runId,
+                shardReference: shardReference,
                 shardArchivePath: shardArchivePath,
                 mode: mode
             )
@@ -630,6 +631,7 @@ public struct TestService { // swiftlint:disable:this type_body_length
         testPlanConfiguration: TestPlanConfiguration?,
         passthroughXcodeBuildArguments: [String],
         runId: String,
+        shardReference: String?,
         shardArchivePath: AbsolutePath?,
         mode: TestProcessingMode
     ) async throws {
@@ -643,6 +645,7 @@ public struct TestService { // swiftlint:disable:this type_body_length
             shardIndex: shardIndex,
             fullHandle: fullHandle,
             serverURL: serverURL,
+            reference: shardReference,
             testProductsPath: localTestProductsPath,
             testProductsArchivePath: shardArchivePath
         )

--- a/cli/Sources/TuistKit/Services/XcodeBuild/XcodeBuildTestCommandService.swift
+++ b/cli/Sources/TuistKit/Services/XcodeBuild/XcodeBuildTestCommandService.swift
@@ -77,6 +77,7 @@ struct XcodeBuildTestCommandService {
         passthroughXcodebuildArguments: [String],
         skipQuarantine: Bool = false,
         shardIndex: Int? = nil,
+        shardReference: String? = nil,
         shardArchivePath: AbsolutePath? = nil,
         mode: TestProcessingMode? = nil
     ) async throws {
@@ -109,6 +110,7 @@ struct XcodeBuildTestCommandService {
                 shardIndex: shardIndex,
                 fullHandle: fullHandle,
                 serverURL: serverURL,
+                reference: shardReference,
                 testProductsPath: testProductsPath,
                 testProductsArchivePath: shardArchivePath
             )

--- a/cli/Tests/TuistCITests/CIControllerTests.swift
+++ b/cli/Tests/TuistCITests/CIControllerTests.swift
@@ -106,6 +106,30 @@ struct CIControllerTests {
             "CIRCLECI": "true",
             "CIRCLE_PROJECT_USERNAME": "owner",
             "CIRCLE_PROJECT_REPONAME": "repo",
+            "CIRCLE_WORKFLOW_ID": "workflow-abc",
+            "CIRCLE_BUILD_NUM": "42",
+        ]
+
+        // When
+        let ciInfo = subject.ciInfo()
+
+        // Then
+        #expect(ciInfo == CIInfo(
+            provider: .circleci,
+            runId: "workflow-abc",
+            projectHandle: "owner/repo",
+            host: nil
+        ))
+    }
+
+    @Test(.withMockedEnvironment())
+    func ciInfo_returns_circleci_info_falls_back_to_build_num_when_no_workflow() throws {
+        // Given
+        let environment = try #require(Environment.mocked)
+        environment.variables = [
+            "CIRCLECI": "true",
+            "CIRCLE_PROJECT_USERNAME": "owner",
+            "CIRCLE_PROJECT_REPONAME": "repo",
             "CIRCLE_BUILD_NUM": "42",
         ]
 

--- a/cli/Tests/TuistCITests/CIControllerTests.swift
+++ b/cli/Tests/TuistCITests/CIControllerTests.swift
@@ -116,14 +116,17 @@ struct CIControllerTests {
         // Then
         #expect(ciInfo == CIInfo(
             provider: .circleci,
-            runId: "workflow-abc",
+            runId: "42",
             projectHandle: "owner/repo",
-            host: nil
+            host: nil,
+            pipelineId: "workflow-abc"
         ))
+        // Shard reference prefers the workflow id so it binds across jobs in a workflow.
+        #expect(ciInfo?.shardReference == "circleci-workflow-abc")
     }
 
     @Test(.withMockedEnvironment())
-    func ciInfo_returns_circleci_info_falls_back_to_build_num_when_no_workflow() throws {
+    func ciInfo_returns_circleci_info_without_workflow_id() throws {
         // Given
         let environment = try #require(Environment.mocked)
         environment.variables = [
@@ -143,6 +146,8 @@ struct CIControllerTests {
             projectHandle: "owner/repo",
             host: nil
         ))
+        // Falls back to runId when no workflow id is present.
+        #expect(ciInfo?.shardReference == "circleci-42")
     }
 
     @Test(.withMockedEnvironment()) func ciInfo_returns_buildkite_info() throws {

--- a/cli/Tests/TuistKitTests/Services/Sharding/ShardServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/Sharding/ShardServiceTests.swift
@@ -359,6 +359,7 @@ struct ShardServiceTests {
             shardIndex: 0,
             fullHandle: "org/project",
             serverURL: URL(string: "https://tuist.dev")!,
+            reference: nil,
             testProductsPath: testProductsPath,
             testProductsArchivePath: nil
         )
@@ -377,6 +378,66 @@ struct ShardServiceTests {
         let originalPlist = try parsePlist(originalXCTestRunData)
         let originalTargets = blueprintNames(from: originalPlist)
         #expect(originalTargets == ["AppTests", "CoreTests"])
+    }
+
+    @Test(.inTemporaryDirectory, .withMockedDependencies())
+    func shard_explicitReference_isForwardedToGetShard() async throws {
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let fileSystem = FileSystem()
+
+        let testProductsPath = temporaryDirectory.appending(component: "MyApp.xctestproducts")
+        try await fileSystem.makeDirectory(at: testProductsPath)
+
+        let xctestrunPath = testProductsPath.appending(component: "MyApp.xctestrun")
+        try await fileSystem.writeAsPlist(
+            XCTestRunFixture(
+                testConfigurations: [
+                    .init(
+                        testTargets: [
+                            .init(blueprintName: "AppTests", testHostPath: "/path/to/host"),
+                        ]
+                    ),
+                ]
+            ),
+            at: xctestrunPath,
+            encoder: plistEncoder()
+        )
+
+        let ciController = MockCIControlling()
+        // Asserts that the explicit reference wins over the CI-derived one.
+        given(ciController).ciInfo().willReturn(.test(provider: .circleci, runId: "ci-derived-ref"))
+
+        let getShardService = MockGetShardServicing()
+        given(getShardService).getShard(
+            fullHandle: .any,
+            serverURL: .any,
+            reference: .value("explicit-ref"),
+            shardIndex: .any
+        ).willReturn(
+            Components.Schemas.Shard(
+                download_url: "https://example.com/unused",
+                modules: ["AppTests"],
+                shard_plan_id: "plan-123",
+                suites: .init()
+            )
+        )
+
+        let subject = ShardService(
+            getShardService: getShardService,
+            ciController: ciController,
+            fileSystem: fileSystem
+        )
+
+        let shard = try await subject.shard(
+            shardIndex: 0,
+            fullHandle: "org/project",
+            serverURL: URL(string: "https://tuist.dev")!,
+            reference: "explicit-ref",
+            testProductsPath: testProductsPath,
+            testProductsArchivePath: nil
+        )
+
+        #expect(shard.reference == "explicit-ref")
     }
 
     @Test(.inTemporaryDirectory, .withMockedDependencies())
@@ -416,6 +477,7 @@ struct ShardServiceTests {
                 shardIndex: 0,
                 fullHandle: "org/project",
                 serverURL: URL(string: "https://tuist.dev")!,
+                reference: nil,
                 testProductsPath: testProductsPath,
                 testProductsArchivePath: nil
             )
@@ -482,6 +544,7 @@ struct ShardServiceTests {
             shardIndex: 0,
             fullHandle: "org/project",
             serverURL: URL(string: "https://tuist.dev")!,
+            reference: nil,
             testProductsPath: nil,
             testProductsArchivePath: archivePath
         )

--- a/cli/Tests/TuistKitTests/Services/TestServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/TestServiceTests.swift
@@ -4835,6 +4835,7 @@ final class TestServiceTests: TuistUnitTestCase {
                 shardIndex: .any,
                 fullHandle: .any,
                 serverURL: .any,
+                reference: .any,
                 testProductsPath: .any,
                 testProductsArchivePath: .any
             )
@@ -4869,6 +4870,7 @@ final class TestServiceTests: TuistUnitTestCase {
                 shardIndex: .value(1),
                 fullHandle: .value("tuist/tuist"),
                 serverURL: .any,
+                reference: .any,
                 testProductsPath: .value(nil),
                 testProductsArchivePath: .value(shardArchivePath)
             )

--- a/cli/Tests/TuistKitTests/Services/XcodeBuildTestCommandServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/XcodeBuildTestCommandServiceTests.swift
@@ -422,6 +422,7 @@ struct XcodeBuildTestCommandServiceTests {
                 shardIndex: .any,
                 fullHandle: .any,
                 serverURL: .any,
+                reference: .any,
                 testProductsPath: .any,
                 testProductsArchivePath: .any
             )
@@ -459,6 +460,7 @@ struct XcodeBuildTestCommandServiceTests {
                 shardIndex: .value(1),
                 fullHandle: .value("tuist/tuist"),
                 serverURL: .any,
+                reference: .any,
                 testProductsPath: .value(nil),
                 testProductsArchivePath: .value(shardArchivePath)
             )


### PR DESCRIPTION
## Summary

Two related bugs surfaced together for a user running native test sharding on CircleCI with the build and test steps in separate jobs:

1. `tuist test --shard-index` (and `tuist xcodebuild test`) silently ignored `--shard-reference` / `TUIST_SHARD_REFERENCE`. The flag was wired through the build-for-testing path but the test-execution path always derived the reference from the CI environment.
2. On CircleCI the auto-derived reference came from `CIRCLE_BUILD_NUM`, which is the per-job number. With build and test in separate jobs the reference didn't match, so the shard runner couldn't bind to the plan that the build job had uploaded.

This change:

- Adds a `reference: String?` parameter to `ShardServicing.shard(...)` and threads `shardReference` through `TestService.runShard` and `XcodeBuildTestCommandService` so an explicit reference is honored end-to-end.
- Exposes `--shard-reference` / `TUIST_SHARD_REFERENCE` on `tuist xcodebuild test` for symmetry with `tuist xcodebuild build-for-testing` (the docs already documented it on both).
- Prefers `CIRCLE_WORKFLOW_ID` over `CIRCLE_BUILD_NUM` for the CircleCI `runId` so the auto-derived shard reference is stable across jobs in a workflow. Falls back to `CIRCLE_BUILD_NUM` when workflows aren't in use.

## Test plan

- [x] `TuistCITests/CIControllerTests` (existing case updated, new fallback case added)
- [x] `TuistKitTests/ShardServiceTests` (existing cases updated for new parameter, new case verifying explicit reference wins over the CI-derived one)
- [x] `TuistKitTests/XcodeBuildTestCommandServiceTests` shard path
- [x] `TuistKitTests/TestServiceTests` shard-without-building path
- [ ] Validate end-to-end on a CircleCI workflow that splits build-for-testing and test-without-building across two jobs