### PR TITLE
feat(infra): switch runner image to LaunchAgent + autologin

### DIFF
--- a/infra/runner-image/AGENTS.md
+++ b/infra/runner-image/AGENTS.md
@@ -15,12 +15,26 @@ runner.
 - `/opt/tuist/dispatch-poll.sh` — polls
   `TUIST_RUNNER_DISPATCH_URL?pod_uid=…&token=…`. While 204 it
   sleeps; on 200 it runs `./run.sh --jitconfig $JIT`. Captures the
-  rc and `shutdown -h now`s the VM via an `EXIT` trap so
+  rc and `sudo shutdown -h now`s the VM via an `EXIT` trap so
   `tart run` returns and tart-kubelet flips the Pod to
   Succeeded — the watcher's GC + warm-pool refill are gated on
   that transition.
-- `/Library/LaunchDaemons/dev.tuist.runner.plist` — auto-runs
-  `inject-env.sh` then `dispatch-poll.sh` on first boot.
+- `/Users/admin/Library/LaunchAgents/dev.tuist.runner.plist` —
+  the LaunchAgent that auto-runs `inject-env.sh` then
+  `dispatch-poll.sh` once admin's user session starts at boot.
+  Wraps the entrypoint in `zsh -lc` so `~/.zprofile` is sourced
+  (Homebrew shellenv, rbenv init, LANG=en_US.UTF-8, PATH
+  additions for the cirruslabs base's pre-installed tools), so
+  step shells see the same environment an interactive SSH
+  session on the same VM would.
+- `/etc/kcpassword` + `autoLoginUser=admin` — macOS auto-login
+  config so the desktop session exists at boot and loginwindow
+  loads the LaunchAgent. Without this the VM boots to a login
+  screen and the agent never starts.
+- `/etc/sudoers.d/admin-nopasswd` — passwordless sudo for the
+  agent's privileged ops (installing /etc/tuist.env, halting the
+  VM at job exit). Single-tenant ephemeral VM — the entire OS is
+  the customer's job environment.
 
 ## Build
 
@@ -59,14 +73,16 @@ hosted runners.
 2. `Tuist.Runners.Reconciler` creates a Pod with this image as
    `spec.containers[0].image`; tart-kubelet on the target Mac
    mini calls `tart pull`/`tart clone`/`tart run`.
-3. The launchd plist runs on first boot inside the VM. The
-   dispatch-poll script exchanges the projected SA token for a
-   JIT config (200 with the JIT when a queue row is claimed, 204
-   while idle), runs the GitHub Actions runner single-shot,
-   traps the exit, halts the VM. tart-kubelet sees `tart run`
-   exit, the Pod goes Succeeded, the RunnerPoolReconciler reaps
-   the Pod + sibling SA and boots a replacement to keep the
-   pool at `spec.replicas`.
+3. The VM boots, auto-login brings up admin's desktop session,
+   loginwindow loads the LaunchAgent, and the agent's entrypoint
+   runs `inject-env.sh` then `dispatch-poll.sh`. The dispatch
+   script exchanges the projected SA token for a JIT config (200
+   with the JIT when a queue row is claimed, 204 while idle),
+   runs the GitHub Actions runner single-shot, traps the exit,
+   halts the VM. tart-kubelet sees `tart run` exit, the Pod goes
+   Succeeded, the RunnerPoolReconciler reaps the Pod + sibling
+   SA and boots a replacement to keep the pool at
+   `spec.replicas`.
 
 For the customer-facing dispatch label and capacity model see
 `server/lib/tuist/runners.ex` and `infra/helm/tuist/values.yaml`

--- a/infra/runner-image/dispatch-poll.sh
+++ b/infra/runner-image/dispatch-poll.sh
@@ -34,7 +34,7 @@ exec >>"${LOG}" 2>&1
 # refilling. The trap fires once on EXIT so the happy path
 # (clean ./run.sh exit) and every error path halt the VM the
 # same way.
-trap '_rc=$?; echo "$(date -u +%FT%TZ) dispatch-poll: exiting (rc=${_rc}); halting VM"; /sbin/shutdown -h now || true; exit "${_rc}"' EXIT
+trap '_rc=$?; echo "$(date -u +%FT%TZ) dispatch-poll: exiting (rc=${_rc}); halting VM"; sudo /sbin/shutdown -h now || true; exit "${_rc}"' EXIT
 
 if [ ! -f /etc/tuist.env ]; then
   echo "$(date -u +%FT%TZ) dispatch-poll: /etc/tuist.env missing; aborting"

--- a/infra/runner-image/launchd.plist
+++ b/infra/runner-image/launchd.plist
@@ -8,15 +8,30 @@
     3. Execs /opt/tuist/dispatch-poll.sh — polls the Tuist server
        for a JIT config and execs ./run.sh on first 200.
 
-  KeepAlive=false: the runner image is single-shot. After the GH
-  Actions job finishes, dispatch-poll.sh halts the VM so `tart
-  run` returns and tart-kubelet transitions the Pod to Succeeded;
-  the watcher then reconciles a fresh warm Pod into its place.
-  Restarting the wrapper would just re-poll for a JIT config
-  that's already been claimed.
+  This is a LaunchAgent loaded from
+  /Users/admin/Library/LaunchAgents/. The Packer build configures
+  admin auto-login + passwordless sudo, so the VM boots into a
+  real desktop session for admin, loginwindow loads this agent,
+  and the agent process inherits the user session.
 
-  RunAsUser is implicit (root via LaunchDaemon) — the runner
-  binary handles its own user dropping if needed.
+  Why an agent and not a daemon: LaunchDaemons start with a
+  near-empty environment (no HOME, no PATH past launchd's
+  defaults, locale = C) and the Actions runner forwards its env
+  to every step shell. Customer workflows that read $HOME or
+  invoke a Homebrew-installed tool break before the first step
+  runs. Wrapping the entrypoint in `/bin/zsh -lc` here makes it
+  a login shell, which sources the cirruslabs base's ~/.zprofile
+  (Homebrew shellenv, rbenv init, LANG=en_US.UTF-8, PATH
+  additions for Android SDK + Flutter + openjdk + Node). Step
+  shells inherit the same environment an interactive SSH session
+  on the same VM would see. Supersedes the per-var workarounds
+  layered on top of the prior LaunchDaemon (#10797, #10800).
+
+  KeepAlive=false: the runner image is single-shot. After the
+  GitHub Actions job finishes, dispatch-poll.sh halts the VM so
+  `tart run` returns and tart-kubelet transitions the Pod to
+  Succeeded. Restarting would just re-poll for a JIT config
+  that's already been claimed.
 -->
 <plist version="1.0">
 <dict>
@@ -25,8 +40,8 @@
 
     <key>ProgramArguments</key>
     <array>
-        <string>/bin/bash</string>
-        <string>-c</string>
+        <string>/bin/zsh</string>
+        <string>-lc</string>
         <string>/opt/tuist/inject-env.sh &amp;&amp; source /etc/tuist.env &amp;&amp; exec /opt/tuist/dispatch-poll.sh</string>
     </array>
 
@@ -44,47 +59,6 @@
 
     <key>StandardErrorPath</key>
     <string>/var/log/tuist-runner/stderr.log</string>
-
-    <key>EnvironmentVariables</key>
-    <dict>
-        <!--
-          The GitHub Actions runner aborts on startup when uid=0
-          unless RUNNER_ALLOW_RUNASROOT is set, on the assumption
-          that runner-as-root is a security mistake. Inside our
-          ephemeral Tart VM the entire OS is the customer's job
-          environment — there's no separation gain from dropping
-          privileges, and the inject-env.sh + dispatch-poll.sh
-          chain assumes root for /etc writes. Bypass the check.
-
-          The HOME entry below sets the matching home directory for
-          that root user; both keys exist because macOS LaunchDaemons
-          start with a near-empty environment — see the HOME comment
-          for the full failure mode.
-        -->
-        <key>RUNNER_ALLOW_RUNASROOT</key>
-        <string>1</string>
-
-        <!--
-          LaunchDaemons start with a minimal environment — no HOME,
-          no PATH beyond the daemon defaults. The Actions runner
-          forwards its own env to every step shell, so an unset
-          HOME here propagates into customer workflows where any
-          tool that reads `$HOME/.gitconfig` (git, mise, gh) errors
-          out with `fatal: $HOME not set` before doing anything.
-          `/var/root` is the canonical home for uid 0 on macOS;
-          set it so step shells inherit a working HOME that matches
-          the user the runner is actually running as.
-
-          actions/checkout briefly sets a temporary HOME during its
-          own git invocations and restores the prior value on exit,
-          so the symptom only shows up on the *next* step after
-          checkout (the first step that reads `$HOME/.gitconfig`
-          with no actions/checkout-managed override in scope). See
-          #10797 for the first observation in production.
-        -->
-        <key>HOME</key>
-        <string>/var/root</string>
-    </dict>
 
     <key>ProcessType</key>
     <string>Interactive</string>

--- a/infra/runner-image/launchd.plist
+++ b/infra/runner-image/launchd.plist
@@ -42,7 +42,19 @@
     <array>
         <string>/bin/zsh</string>
         <string>-lc</string>
-        <string>/opt/tuist/inject-env.sh &amp;&amp; source /etc/tuist.env &amp;&amp; exec /opt/tuist/dispatch-poll.sh</string>
+        <!--
+          inject-env.sh runs under sudo. tart-kubelet stages the
+          shared env directory at /Volumes/My Shared Files/env/ as
+          0700 root, with tuist.env / sa_token inside at 0600 root.
+          The agent runs as admin, so without elevation admin can't
+          even stat the directory: inject-env.sh's `[ ! -f ENV_SRC ]`
+          test returns true, the script exits 0 ("no env source"),
+          and dispatch-poll.sh boots with an empty /etc/tuist.env
+          (no TUIST_RUNNER_DISPATCH_URL, no SA token). Elevate only
+          the injector; dispatch-poll runs as admin so the GitHub
+          runner stays non-root.
+        -->
+        <string>sudo /opt/tuist/inject-env.sh &amp;&amp; source /etc/tuist.env &amp;&amp; exec /opt/tuist/dispatch-poll.sh</string>
     </array>
 
     <key>RunAtLoad</key>

--- a/infra/runner-image/runner.pkr.hcl
+++ b/infra/runner-image/runner.pkr.hcl
@@ -163,18 +163,73 @@ build {
     ]
   }
 
+  # Passwordless sudo for admin. The runner agent runs as admin in
+  # a real user session (LaunchAgent + auto-login), not as root, so
+  # the few privileged operations the agent needs — installing
+  # /etc/tuist.env from the kubelet env mount, halting the VM at
+  # job exit — go through sudo. Passwordless because the VM is
+  # ephemeral and single-tenant; the entire OS is the customer's
+  # job environment.
+  provisioner "shell" {
+    inline = [
+      "set -euo pipefail",
+      "echo 'admin ALL=(ALL) NOPASSWD: ALL' > /tmp/admin-nopasswd",
+      "echo 'admin' | sudo -S install -m 0440 -o root -g wheel /tmp/admin-nopasswd /etc/sudoers.d/admin-nopasswd",
+      "rm -f /tmp/admin-nopasswd",
+      "sudo -n true"
+    ]
+  }
+
+  # Auto-login as admin so a desktop session exists at boot and
+  # loginwindow loads /Users/admin/Library/LaunchAgents agents.
+  # macOS implements auto-login via /etc/kcpassword (XOR-encoded
+  # password using Apple's well-known key) + the autoLoginUser
+  # preference. The encoded payload for password "admin":
+  # bytes 0x1c, 0xed, 0x3f, 0x4a, 0xbc, 0xbc, 0xdd, 0xea, 0xa3,
+  # 0xb9, 0x1f (admin XOR key, padded to one key-length block).
+  provisioner "shell" {
+    inline = [
+      "set -euo pipefail",
+      "printf '\\x1c\\xed\\x3f\\x4a\\xbc\\xbc\\xdd\\xea\\xa3\\xb9\\x1f' > /tmp/kcpassword",
+      "sudo install -m 0600 -o root -g wheel /tmp/kcpassword /etc/kcpassword",
+      "rm -f /tmp/kcpassword",
+      "sudo defaults write /Library/Preferences/com.apple.loginwindow autoLoginUser admin"
+    ]
+  }
+
   provisioner "file" {
     source      = "${path.root}/launchd.plist"
     destination = "/tmp/dev.tuist.runner.plist"
   }
 
+  # Install as a LaunchAgent under admin's home so it loads inside
+  # admin's user session (auto-login above guarantees the session
+  # exists at boot). User-owned (admin:staff, 0644) per Apple's
+  # LaunchAgent ownership rules.
   provisioner "shell" {
     inline = [
-      "echo 'admin' | sudo -S install -m 0644 /tmp/dev.tuist.runner.plist /Library/LaunchDaemons/dev.tuist.runner.plist",
+      "set -euo pipefail",
+      "sudo -u admin mkdir -p /Users/admin/Library/LaunchAgents",
+      "sudo install -m 0644 -o admin -g staff /tmp/dev.tuist.runner.plist /Users/admin/Library/LaunchAgents/dev.tuist.runner.plist",
       "rm -f /tmp/dev.tuist.runner.plist",
-      "echo 'admin' | sudo -S chown root:wheel /Library/LaunchDaemons/dev.tuist.runner.plist",
-      "echo 'admin' | sudo -S mkdir -p /var/log/tuist-runner",
-      "echo 'admin' | sudo -S chown admin:staff /var/log/tuist-runner"
+      "sudo mkdir -p /var/log/tuist-runner",
+      "sudo chown admin:staff /var/log/tuist-runner"
+    ]
+  }
+
+  # Sanity check: tools customers expect on a GitHub-parity macOS
+  # runner have to be reachable from the agent's runtime
+  # environment. The agent wraps its entrypoint in `zsh -lc`, so
+  # ~/.zprofile is sourced (Homebrew shellenv, rbenv init, Android
+  # SDK / Flutter / openjdk PATH). A future base-image bump that
+  # moves Homebrew's prefix or drops a formula would silently make
+  # tools unreachable from step shells; resolve each tool against
+  # the same login-shell environment so image-build CI fails
+  # loudly instead of customer workflows.
+  provisioner "shell" {
+    inline = [
+      "set -euo pipefail",
+      "sudo -u admin /bin/zsh -lc 'for tool in brew mise tuist gh git-lfs jq yq swiftlint swiftformat xcbeautify fastlane pod carthage; do command -v \"$tool\" >/dev/null 2>&1 || { echo \"sanity check: $tool not reachable in admin login shell — base image regression\" >&2; exit 1; }; done'"
     ]
   }
 }


### PR DESCRIPTION
> Replaces the LaunchDaemon-as-root model in the runner image with a LaunchAgent loaded from admin's home, plus auto-login and passwordless sudo. Fixes the daemon-env class of regressions at the root rather than papering over each missing variable.

### Symptom

#10797 set `HOME=/var/root` to unblock the first end-to-end runner job after `fatal: \$HOME not set` killed every step that touched `\$HOME/.gitconfig`. The follow-up audit against `macos-26-arm64`, Namespace, and Blacksmith showed the same root cause would surface for `LANG`/`LC_ALL`/`PATH` next:

- `LANG=en_US.UTF-8` is set by the cirruslabs base in `~/.zprofile`. LaunchDaemons don't source zprofile, so the daemon's `LANG=C` propagates to every step shell. Ruby, Python, Bundler, CocoaPods, fastlane crash on UTF-8 paths.
- `PATH` additions for Homebrew, rbenv shims, Android SDK, Flutter, openjdk all live in zprofile. The daemon's `PATH` is launchd's defaults, so `brew`/`mise`/`tuist`/`gh`/`swiftlint`/`swiftformat`/`xcbeautify`/`fastlane`/`pod`/`carthage` are unreachable from step shells even though they're installed on disk.

Layering one env var per regression onto `EnvironmentVariables` works but doesn't compose: any future tool the base adds via zprofile needs another patch.

### Cause

LaunchDaemons start outside any user session. `~/.zprofile` is sourced for zsh login shells; a daemon-spawned `bash -c` is neither zsh nor a login shell, so the base's environment never reaches the runner.

### Fix

Replace the LaunchDaemon with a LaunchAgent loaded from `/Users/admin/Library/LaunchAgents/`, configure auto-login so loginwindow brings up admin's desktop session at boot, and wrap the entrypoint in `/bin/zsh -lc` so the agent runs as a login shell. The cirruslabs base's zprofile is sourced naturally and step shells inherit Homebrew shellenv, rbenv init, `LANG=en_US.UTF-8`, and the full PATH.

Image-build changes:

- `/etc/sudoers.d/admin-nopasswd`. The agent runs as admin, not root, so the few privileged operations it needs (installing `/etc/tuist.env` from the kubelet env mount, halting the VM at job exit) go through sudo. Passwordless because the VM is ephemeral and single-tenant: the entire OS is the customer's job environment, no separation gain from withholding sudo from the user that owns the workload.
- `/etc/kcpassword` + `autoLoginUser=admin`. Auto-login is the standard mechanism for getting a desktop session on a headless boot. Encoded payload is the XOR of `admin` against Apple's well-known kcpassword key, padded to one key-length block.
- Sanity check that resolves `brew`/`mise`/`tuist`/`gh`/`git-lfs`/`jq`/`yq`/`swiftlint`/`swiftformat`/`xcbeautify`/`fastlane`/`pod`/`carthage` inside `sudo -u admin /bin/zsh -lc`. A future base-image bump that moves Homebrew's prefix or drops a formula fails image-build CI instead of customer workflows.

`dispatch-poll.sh` switches `/sbin/shutdown` to `sudo /sbin/shutdown`. `launchd.plist` drops `RUNNER_ALLOW_RUNASROOT`, `HOME`, and the `EnvironmentVariables` block entirely; `ProgramArguments` becomes `/bin/zsh -lc`.

### How to test locally

This change only takes effect once a new runner image is built and the digest is pinned in helm. Test plan:

- [ ] `packer validate infra/runner-image/runner.pkr.hcl` passes locally.
- [ ] `runner-image.yml` rebuilds `tuist-runner` from this branch.
- [ ] Bump `runnersFleet.pools[].runnerImage` in `infra/helm/tuist/values-managed-canary.yaml` to the new digest in a follow-up PR.
- [ ] Once deployed on canary, dispatch a workflow_job and confirm a step shell shows:
  - `whoami` returns `admin` (not `root`).
  - `echo \$HOME` returns `/Users/admin`.
  - `echo \$LANG` returns `en_US.UTF-8`.
  - `command -v brew mise tuist gh swiftlint swiftformat xcbeautify fastlane pod carthage` all resolve to `/opt/homebrew/...` or rbenv shims.
- [ ] `launchctl print gui/501/dev.tuist.runner` against the booted VM shows the agent loaded under uid 501's session.

### Notes

The three bootstrap-side regressions originally bundled with this branch (kcpassword on adopted hosts, pf install idempotency, duplicate pool-host adoption) were resolved by #10798 and dropped from this PR.

### Related

- #10797 — first daemon-env fix (HOME), superseded by this change.
- #10798 — bootstrap-side regression repairs.
- #10803 — Xcode 26.4.1 base bump (already on main).