### PR TITLE
fix(runner-image): symlink Xcode_26.4.1.app at the real Xcode_26.4.app bundle

### DIFF
--- a/infra/runner-image/runner.pkr.hcl
+++ b/infra/runner-image/runner.pkr.hcl
@@ -117,18 +117,36 @@ build {
     ]
   }
 
-  # Cirrus' macos-tahoe-xcode:26.4.1 image ships Xcode at
-  # /Applications/Xcode_26.4.1.app. GitHub's actions/runner-images
-  # exposes each Xcode under BOTH the full and major-minor path
-  # (see images/macos/macos-26-arm64-Readme.md#xcode) so customer
-  # workflows that pin `.xcode-version=26.4` work the same as ones
-  # pinning `.xcode-version=26.4.1`. Mirror that convention here so
-  # repos don't have to switch their `.xcode-version` file each
-  # time the patch component rolls.
+  # GitHub's actions/runner-images exposes each Xcode under BOTH
+  # the full and the major-minor path (see images/macos/macos-26-
+  # arm64-Readme.md#xcode) so customer workflows that pin
+  # `.xcode-version=26.4` work the same as ones pinning
+  # `.xcode-version=26.4.1`. Mirror that here so repos don't have
+  # to switch their `.xcode-version` file each time the patch
+  # component rolls.
+  #
+  # We don't hardcode the on-disk path because Cirrus' xcode
+  # provisioner installs at `Xcode_${version}.app` where ${version}
+  # is whatever they configured at image-build time — and that
+  # doesn't always match the OCI tag (the :26.4.1 image observed
+  # in production didn't carry a literal `/Applications/Xcode_26.4.1.app`).
+  # Discover the real Xcode app at build time and symlink both
+  # versioned names at it. `xcode-select -p` is the authoritative
+  # source: it returns `<APP>/Contents/Developer`, which we walk
+  # back to the bundle root.
   provisioner "shell" {
     inline = [
-      "echo 'admin' | sudo -S ln -sfn /Applications/Xcode_26.4.1.app /Applications/Xcode_26.4.app",
-      "test -d /Applications/Xcode_26.4.app && test -d /Applications/Xcode_26.4.1.app"
+      "set -euo pipefail",
+      "developer=$(xcode-select -p)",
+      "real_xcode=$(cd \"$developer/../..\" && pwd -P)",
+      "echo \"Discovered Xcode bundle at $real_xcode\"",
+      "for alias in /Applications/Xcode_26.4.1.app /Applications/Xcode_26.4.app; do",
+      "  if [ \"$alias\" = \"$real_xcode\" ]; then continue; fi",
+      "  echo 'admin' | sudo -S ln -sfn \"$real_xcode\" \"$alias\"",
+      "done",
+      "test -d /Applications/Xcode_26.4.app",
+      "test -d /Applications/Xcode_26.4.1.app",
+      "ls -ld /Applications/Xcode_26.4*.app"
     ]
   }
 

--- a/infra/runner-image/runner.pkr.hcl
+++ b/infra/runner-image/runner.pkr.hcl
@@ -125,28 +125,18 @@ build {
   # to switch their `.xcode-version` file each time the patch
   # component rolls.
   #
-  # We don't hardcode the on-disk path because Cirrus' xcode
-  # provisioner installs at `Xcode_${version}.app` where ${version}
-  # is whatever they configured at image-build time — and that
-  # doesn't always match the OCI tag (the :26.4.1 image observed
-  # in production didn't carry a literal `/Applications/Xcode_26.4.1.app`).
-  # Discover the real Xcode app at build time and symlink both
-  # versioned names at it. `xcode-select -p` is the authoritative
-  # source: it returns `<APP>/Contents/Developer`, which we walk
-  # back to the bundle root.
+  # The Cirrus :26.4.1 image ships the real bundle at
+  # `/Applications/Xcode_26.4.app` (major-minor only, no patch);
+  # `/Applications/Xcode_26.4.1.app` doesn't exist on the base.
+  # Verified by probing the base image — see PR #10808 body for
+  # the run output. Symlink the patch-form alias at the real
+  # bundle so workflows pinning `.xcode-version=26.4.1` find Xcode.
   provisioner "shell" {
     inline = [
       "set -euo pipefail",
-      "developer=$(xcode-select -p)",
-      "real_xcode=$(cd \"$developer/../..\" && pwd -P)",
-      "echo \"Discovered Xcode bundle at $real_xcode\"",
-      "for alias in /Applications/Xcode_26.4.1.app /Applications/Xcode_26.4.app; do",
-      "  if [ \"$alias\" = \"$real_xcode\" ]; then continue; fi",
-      "  echo 'admin' | sudo -S ln -sfn \"$real_xcode\" \"$alias\"",
-      "done",
+      "echo 'admin' | sudo -S ln -sfn /Applications/Xcode_26.4.app /Applications/Xcode_26.4.1.app",
       "test -d /Applications/Xcode_26.4.app",
-      "test -d /Applications/Xcode_26.4.1.app",
-      "ls -ld /Applications/Xcode_26.4*.app"
+      "test -d /Applications/Xcode_26.4.1.app"
     ]
   }
 


### PR DESCRIPTION
> The Xcode-version symlink I added in #10803 picked the wrong target direction and the wrong on-disk path. Probe the Cirrus :26.4.1 base image, then hardcode the right symlink.

## Symptom

The standalone runner-image workflow ran on #10803's merge SHA and failed in Packer (job [76140962482](https://github.com/tuist/tuist/actions/runs/25906365458/job/76140962482)) at the symlink provisioner. `ln -sfn` succeeded (dangling symlinks are allowed); the follow-on `test -d /Applications/Xcode_26.4.1.app` failed and Packer aborted the build.

## Root cause

I assumed Cirrus' `:26.4.1` image installs Xcode at `/Applications/Xcode_26.4.1.app`. That assumption was wrong.

To find the actual layout, ran a probe build (run [25908123971](https://github.com/tuist/tuist/actions/runs/25908123971), branch `claude/probe-xcode-path`) that dumped the real paths before aborting:

```
=== /Applications top-level Xcode entries ===
drwxr-xr-x  3 root  staff    96B Mar 28 12:29 /Applications/Xcode_26.4.app

=== xcode-select -p ===
/Applications/Xcode_26.4.app/Contents/Developer

=== resolved Xcode bundle (walk Developer back two levels) ===
/Applications/Xcode_26.4.app

=== /Applications/Xcode.app, if present ===
ls: /Applications/Xcode.app: No such file or directory
```

So even though the OCI tag is `:26.4.1`, Cirrus' release pipeline ends up renaming the bundle to `Xcode_26.4.app` (major-minor, no patch). Their `xcode.pkr.hcl` does `sudo mv $APP_DIR /Applications/Xcode_\${version}.app` where `${version}` *should* be `26.4.1` per the release CI config — but the result is `Xcode_26.4.app`. Best guess: `xcodes install 26.4.1` resolves to the 26.4 download (Apple may not ship a separate 26.4.1 .xip) and the rename ends up taking the resolved path's name.

## Fix

Single hardcoded symlink in the direction the layout actually demands:

```hcl
provisioner \"shell\" {
  inline = [
    \"set -euo pipefail\",
    \"echo 'admin' | sudo -S ln -sfn /Applications/Xcode_26.4.app /Applications/Xcode_26.4.1.app\",
    \"test -d /Applications/Xcode_26.4.app\",
    \"test -d /Applications/Xcode_26.4.1.app\"
  ]
}
```

After this provisioner the layout is:

| Path | Type | Resolves to |
|---|---|---|
| `/Applications/Xcode_26.4.app` | Real bundle | (itself) |
| `/Applications/Xcode_26.4.1.app` | Symlink | `/Applications/Xcode_26.4.app` |

Customer workflows that pin either `.xcode-version=26.4` or `.xcode-version=26.4.1` now both resolve to the same real Xcode.

The two `test -d` calls at the end fail the Packer build loudly if a future Cirrus base image moves the bundle, surfacing the breakage at image-build time rather than at first customer workflow.

## Why not discover at runtime

An earlier revision of this PR did `xcode-select -p` walk-back at build time and looped over alias names. Reviewer feedback flagged that as defensive scaffolding around a question that has a deterministic answer — we should just find out where the file is and hardcode the path. The probe gave us the deterministic answer; this revision uses it.

## How to test locally

- [ ] On merge, `release.yml` → `Release runner image` should run through the credential-isolation + Packer build without the previous test-d failure.
- [ ] The auto-bump PR rewrites the digest pin in `infra/helm/tuist/values-managed-*.yaml`; after that lands and a server deploy rolls, retrigger the lint job on PR #10793 (`gh run rerun 25853096592 --failed --repo tuist/tuist`). The `Select Xcode` step should resolve `/Applications/Xcode_26.4.1.app` (via the new symlink) and succeed.