### PR TITLE
fix(server): exclude processing test runs from Recent Test Runs

### DIFF
--- a/server/lib/tuist_web/live/tests_live.ex
+++ b/server/lib/tuist_web/live/tests_live.ex
@@ -291,6 +291,9 @@ defmodule TuistWeb.TestsLive do
     filters =
       [
         %{field: :project_id, op: :==, value: project.id},
+        %{field: :status, op: :!=, value: "in_progress"},
+        %{field: :status, op: :!=, value: "processing"},
+        %{field: :status, op: :!=, value: "failed_processing"},
         %{field: :ran_at, op: :>=, value: start_datetime},
         %{field: :ran_at, op: :<=, value: end_datetime}
       ]


### PR DESCRIPTION
### Summary

The "Recent Test Runs" card on the project Tests page was including test runs in non-terminal states (`in_progress`, `processing`, `failed_processing`). These rows showed up with no status badge and `0ms` duration, like the "Unknown" row at the top of the list.

This change filters those statuses out of the query, mirroring the pattern already used in `xcode_overview_live.ex`. The chart, pass/fail legend counts, and the recent runs table now only reflect completed runs.

### How to test locally

1. Start the server (`mise run dev`).
2. Navigate to a project's Tests dashboard for an account with in-flight or processing-status test runs.
3. Confirm the Recent Test Runs card shows only `success`, `failure`, or `skipped` runs — no rows with missing schemes/statuses or `0ms` durations.