### PR TITLE
fix(server): analyze every shard of a sharded test run

### DIFF
--- a/server/lib/tuist/shards/analytics.ex
+++ b/server/lib/tuist/shards/analytics.ex
@@ -477,14 +477,21 @@ defmodule Tuist.Shards.Analytics do
   defp get_clickhouse_date_format(_), do: "%Y-%m-%d"
 
   def shard_metrics(test_run_id) when is_binary(test_run_id) do
+    # The shard_runs table is a MergeTree, so each shard can carry multiple
+    # rows: the controller inserts one upfront with duration=0 when the
+    # CLI uploads with status=processing, and the xcresult worker inserts
+    # another with the parsed duration afterwards. Collapse them per
+    # shard_index, picking the row with the largest inserted_at so the
+    # dashboard shows the latest data.
     ClickHouseRepo.all(
       from(sr in ShardRun,
         where: sr.test_run_id == ^test_run_id,
+        group_by: sr.shard_index,
         select: %{
           shard_index: sr.shard_index,
-          actual_duration_ms: sr.duration,
-          status: sr.status,
-          ran_at: sr.ran_at
+          actual_duration_ms: fragment("argMax(?, ?)", sr.duration, sr.inserted_at),
+          status: fragment("argMax(?, ?)", sr.status, sr.inserted_at),
+          ran_at: fragment("argMax(?, ?)", sr.ran_at, sr.inserted_at)
         }
       )
     )

--- a/server/lib/tuist/tests.ex
+++ b/server/lib/tuist/tests.ex
@@ -500,7 +500,15 @@ defmodule Tuist.Tests do
               create_test_modules(existing_test, test_modules, shard_index, shard_plan)
             end
 
-          reported_count = count_reported_shards(existing_test.id) + 1
+          # Each shard can have multiple ShardRun rows (the controller
+          # inserts one with status=processing when the CLI is still
+          # uploading, the worker inserts another after parsing). Count
+          # distinct shard indexes that have already produced a non-
+          # processing row, and only count the current shard if its own
+          # status is non-processing too.
+          reported_count =
+            count_completed_shards(existing_test.id, shard_index) +
+              if shard_status == "processing", do: 0, else: 1
 
           merged_status =
             if reported_count >= expected_shard_count do
@@ -593,11 +601,16 @@ defmodule Tuist.Tests do
   defp blank?(""), do: true
   defp blank?(_), do: false
 
-  defp count_reported_shards(test_run_id) do
+  defp count_completed_shards(test_run_id, current_shard_index) do
+    # A shard counts as completed once any ShardRun row for it carries a
+    # non-processing status. The current shard is excluded because the
+    # caller decides whether to add it based on the incoming attrs.
     ClickHouseRepo.one(
       from(sr in ShardRun,
         where: sr.test_run_id == ^test_run_id,
-        select: count()
+        where: sr.status != "processing",
+        where: sr.shard_index != ^(current_shard_index || -1),
+        select: fragment("uniqExact(?)", sr.shard_index)
       )
     ) || 0
   end

--- a/server/lib/tuist/tests.ex
+++ b/server/lib/tuist/tests.ex
@@ -511,7 +511,11 @@ defmodule Tuist.Tests do
 
           merged_duration = max(existing_test.duration, shard_duration)
 
-          updated_test = %{existing_test | status: merged_status, duration: merged_duration}
+          updated_test =
+            existing_test
+            |> Map.put(:status, merged_status)
+            |> Map.put(:duration, merged_duration)
+            |> merge_shard_metadata(attrs)
 
           update_attrs =
             updated_test
@@ -550,6 +554,44 @@ defmodule Tuist.Tests do
       {:ok, test}
     end
   end
+
+  # Carry forward metadata fields when a later shard report has them and
+  # the existing Test row left them blank. The first shard often arrives
+  # with status=processing before xcresult parsing has populated `scheme`
+  # and friends; without this merge the dashboard's title stays "Unknown"
+  # for the lifetime of the run.
+  @shard_mergeable_fields [
+    :scheme,
+    :macos_version,
+    :xcode_version,
+    :model_identifier,
+    :git_branch,
+    :git_commit_sha,
+    :git_ref,
+    :ci_run_id,
+    :ci_project_handle,
+    :ci_host,
+    :ci_provider,
+    :build_run_id,
+    :gradle_build_id
+  ]
+
+  defp merge_shard_metadata(existing_test, attrs) do
+    Enum.reduce(@shard_mergeable_fields, existing_test, fn field, acc ->
+      incoming = Map.get(attrs, field)
+      current = Map.get(acc, field)
+
+      if blank?(current) and not blank?(incoming) do
+        Map.put(acc, field, incoming)
+      else
+        acc
+      end
+    end)
+  end
+
+  defp blank?(nil), do: true
+  defp blank?(""), do: true
+  defp blank?(_), do: false
 
   defp count_reported_shards(test_run_id) do
     ClickHouseRepo.one(

--- a/server/lib/tuist/tests/workers/process_xcresult_worker.ex
+++ b/server/lib/tuist/tests/workers/process_xcresult_worker.ex
@@ -14,7 +14,10 @@ defmodule Tuist.Tests.Workers.ProcessXcresultWorker do
   Hetzner-backed k8s cluster on Scaleway Mac minis.
   """
 
-  use Oban.Worker, queue: :process_xcresult, max_attempts: 5, unique: [keys: [:test_run_id]]
+  use Oban.Worker,
+    queue: :process_xcresult,
+    max_attempts: 5,
+    unique: [keys: [:test_run_id, :shard_index]]
 
   alias Tuist.Accounts
   alias Tuist.Storage

--- a/server/lib/tuist/tests/workers/process_xcresult_worker.ex
+++ b/server/lib/tuist/tests/workers/process_xcresult_worker.ex
@@ -73,21 +73,18 @@ defmodule Tuist.Tests.Workers.ProcessXcresultWorker do
 
   defp process_xcresult(test_run_id, storage_key, account_id, args) do
     with {:ok, account} <- Accounts.get_account_by_id(account_id) do
-      # For sharded runs, multiple workers share the same merged test_run_id
-      # and can run concurrently. Suffix the temp path with the shard index
-      # (and a unique integer as a safety net) so they never clobber each
-      # other's download mid-parse.
-      shard_suffix =
+      # For sharded runs, multiple workers share the same merged
+      # test_run_id and can run concurrently. Suffix the temp path with
+      # the shard index so they never clobber each other's download
+      # mid-parse. Oban's unique constraint already keeps a given
+      # (test_run_id, shard_index) pair from running in parallel.
+      filename =
         case Map.get(args, "shard_index") do
-          nil -> "x"
-          index -> "s#{index}"
+          nil -> "xcresult_#{test_run_id}.zip"
+          index -> "xcresult_#{test_run_id}_s#{index}.zip"
         end
 
-      temp_path =
-        Path.join(
-          System.tmp_dir!(),
-          "xcresult_#{test_run_id}_#{shard_suffix}_#{:erlang.unique_integer([:positive, :monotonic])}.zip"
-        )
+      temp_path = Path.join(System.tmp_dir!(), filename)
 
       try do
         case Storage.download_to_file(storage_key, temp_path, account) do

--- a/server/lib/tuist/tests/workers/process_xcresult_worker.ex
+++ b/server/lib/tuist/tests/workers/process_xcresult_worker.ex
@@ -73,7 +73,21 @@ defmodule Tuist.Tests.Workers.ProcessXcresultWorker do
 
   defp process_xcresult(test_run_id, storage_key, account_id, args) do
     with {:ok, account} <- Accounts.get_account_by_id(account_id) do
-      temp_path = Path.join(System.tmp_dir!(), "xcresult_#{test_run_id}.zip")
+      # For sharded runs, multiple workers share the same merged test_run_id
+      # and can run concurrently. Suffix the temp path with the shard index
+      # (and a unique integer as a safety net) so they never clobber each
+      # other's download mid-parse.
+      shard_suffix =
+        case Map.get(args, "shard_index") do
+          nil -> "x"
+          index -> "s#{index}"
+        end
+
+      temp_path =
+        Path.join(
+          System.tmp_dir!(),
+          "xcresult_#{test_run_id}_#{shard_suffix}_#{:erlang.unique_integer([:positive, :monotonic])}.zip"
+        )
 
       try do
         case Storage.download_to_file(storage_key, temp_path, account) do

--- a/server/lib/tuist_web/controllers/api/tests_controller.ex
+++ b/server/lib/tuist_web/controllers/api/tests_controller.ex
@@ -529,8 +529,17 @@ defmodule TuistWeb.API.TestsController do
         }
 
         if test_run.status == "processing" do
+          # The CLI uploads each shard's xcresult to S3 keyed on the UUID
+          # it generated locally (body_params.id). For sharded runs, the
+          # server merges all shards into a single Test row, so test_run.id
+          # is the merged id — only the first shard's. Falling back to the
+          # merged id would point the worker at a missing object for every
+          # other shard, leaving their data unprocessed and the dashboard
+          # stuck at 0.
+          xcresult_id = Map.get(body_params, :id) || test_run.id
+
           storage_key =
-            "#{selected_project.account.name}/#{selected_project.name}/runs/#{test_run.id}/result_bundle.zip"
+            "#{selected_project.account.name}/#{selected_project.name}/runs/#{xcresult_id}/result_bundle.zip"
 
           %{
             test_run_id: test_run.id,

--- a/server/lib/tuist_web/controllers/api/tests_controller.ex
+++ b/server/lib/tuist_web/controllers/api/tests_controller.ex
@@ -528,7 +528,12 @@ defmodule TuistWeb.API.TestsController do
           project_id: selected_project.id
         }
 
-        if test_run.status == "processing" do
+        # Trigger off the request status, not the merged Test row's status:
+        # for sharded runs, create_or_update_sharded_test rewrites the row
+        # to "in_progress" while it waits for the other shards, so
+        # test_run.status is never "processing" even though the CLI is
+        # uploading an xcresult that still needs parsing.
+        if Map.get(body_params, :status) == "processing" do
           # The CLI uploads each shard's xcresult to S3 keyed on the UUID
           # it generated locally (body_params.id). For sharded runs, the
           # server merges all shards into a single Test row, so test_run.id

--- a/server/test/tuist/shards/analytics_test.exs
+++ b/server/test/tuist/shards/analytics_test.exs
@@ -60,6 +60,46 @@ defmodule Tuist.Shards.AnalyticsTest do
     test "returns empty list for non-existent test_run_id" do
       assert Analytics.shard_metrics(Ecto.UUID.generate()) == []
     end
+
+    test "deduplicates rows with the same shard_index, taking the latest" do
+      # ShardRun is a MergeTree, so a shard can have multiple rows:
+      # the controller inserts one upfront with duration=0 (status=processing),
+      # then the xcresult worker inserts another with the parsed duration.
+      # The dashboard should render one row per shard with the latest data.
+      project = ProjectsFixtures.project_fixture()
+      plan = ShardsFixtures.shard_plan_fixture(project_id: project.id)
+      test_run_id = Ecto.UUID.generate()
+
+      earlier = ~N[2026-05-15 10:00:00.000000]
+      later = ~N[2026-05-15 10:01:00.000000]
+
+      IngestRepo.insert_all(ShardRun, [
+        %{
+          shard_plan_id: plan.id,
+          project_id: project.id,
+          test_run_id: test_run_id,
+          shard_index: 0,
+          status: "success",
+          duration: 0,
+          ran_at: earlier,
+          inserted_at: earlier
+        },
+        %{
+          shard_plan_id: plan.id,
+          project_id: project.id,
+          test_run_id: test_run_id,
+          shard_index: 0,
+          status: "success",
+          duration: 12_345,
+          ran_at: later,
+          inserted_at: later
+        }
+      ])
+
+      assert [shard] = Analytics.shard_metrics(test_run_id)
+      assert shard.shard_index == 0
+      assert shard.actual_duration_ms == 12_345
+    end
   end
 
   describe "sharded_run_analytics/2" do

--- a/server/test/tuist/tests/workers/process_xcresult_worker_test.exs
+++ b/server/test/tuist/tests/workers/process_xcresult_worker_test.exs
@@ -530,6 +530,7 @@ defmodule Tuist.Tests.Workers.ProcessXcresultWorkerTest do
       assert :ok == ProcessXcresultWorker.perform(oban_job(args_1))
 
       keys = paths |> :ets.tab2list() |> Enum.map(&elem(&1, 0))
+
       assert Path.basename(Enum.at(keys, 0)) in [
                "xcresult_#{test_run_id}_s0.zip",
                "xcresult_#{test_run_id}_s1.zip"

--- a/server/test/tuist/tests/workers/process_xcresult_worker_test.exs
+++ b/server/test/tuist/tests/workers/process_xcresult_worker_test.exs
@@ -500,4 +500,29 @@ defmodule Tuist.Tests.Workers.ProcessXcresultWorkerTest do
       assert {:error, _} = ProcessXcresultWorker.perform(oban_job(args, 3, 3))
     end
   end
+
+  describe "uniqueness across shards" do
+    test "different shard_index values are treated as distinct jobs" do
+      test_run_id = Ecto.UUID.generate()
+
+      shard_0 =
+        ProcessXcresultWorker.new(%{
+          "test_run_id" => test_run_id,
+          "storage_key" => "runs/shard-0/result_bundle.zip",
+          "account_id" => 1,
+          "shard_index" => 0
+        })
+
+      shard_1 =
+        ProcessXcresultWorker.new(%{
+          "test_run_id" => test_run_id,
+          "storage_key" => "runs/shard-1/result_bundle.zip",
+          "account_id" => 1,
+          "shard_index" => 1
+        })
+
+      assert shard_0.changes.unique.keys == [:test_run_id, :shard_index]
+      assert shard_1.changes.unique.keys == [:test_run_id, :shard_index]
+    end
+  end
 end

--- a/server/test/tuist/tests/workers/process_xcresult_worker_test.exs
+++ b/server/test/tuist/tests/workers/process_xcresult_worker_test.exs
@@ -501,6 +501,40 @@ defmodule Tuist.Tests.Workers.ProcessXcresultWorkerTest do
     end
   end
 
+  describe "concurrent shard workers" do
+    test "writes each shard to a distinct temp path", %{account: account, project: project} do
+      # Two workers for the same merged test_run_id (one per shard) must
+      # not race on the same temp file. Otherwise a concurrent download
+      # can clobber the bundle another worker is still reading.
+      test_run_id = Ecto.UUID.generate()
+
+      stub(Tuist.Accounts, :get_account_by_id, fn _id -> {:ok, account} end)
+
+      paths = :ets.new(:paths, [:set, :public])
+
+      stub(Tuist.Storage, :download_to_file, fn _key, path, _account ->
+        :ets.insert(paths, {path, true})
+        {:ok, :done}
+      end)
+
+      stub(XCResultProcessor, :process_local, fn _path, _opts -> {:ok, parsed_data()} end)
+      stub(Tuist.Tests, :create_test, fn _attrs -> {:ok, %{id: test_run_id}} end)
+
+      args_0 =
+        job_args(test_run_id, account.id, project.id, extra: %{"shard_index" => 0})
+
+      args_1 =
+        job_args(test_run_id, account.id, project.id, extra: %{"shard_index" => 1})
+
+      assert :ok == ProcessXcresultWorker.perform(oban_job(args_0))
+      assert :ok == ProcessXcresultWorker.perform(oban_job(args_1))
+
+      keys = paths |> :ets.tab2list() |> Enum.map(&elem(&1, 0))
+      assert length(keys) == 2
+      assert length(Enum.uniq(keys)) == 2
+    end
+  end
+
   describe "uniqueness across shards" do
     test "different shard_index values are treated as distinct jobs" do
       test_run_id = Ecto.UUID.generate()

--- a/server/test/tuist/tests/workers/process_xcresult_worker_test.exs
+++ b/server/test/tuist/tests/workers/process_xcresult_worker_test.exs
@@ -530,8 +530,34 @@ defmodule Tuist.Tests.Workers.ProcessXcresultWorkerTest do
       assert :ok == ProcessXcresultWorker.perform(oban_job(args_1))
 
       keys = paths |> :ets.tab2list() |> Enum.map(&elem(&1, 0))
-      assert length(keys) == 2
+      assert Path.basename(Enum.at(keys, 0)) in [
+               "xcresult_#{test_run_id}_s0.zip",
+               "xcresult_#{test_run_id}_s1.zip"
+             ]
+
       assert length(Enum.uniq(keys)) == 2
+    end
+
+    test "keeps the original temp path for non-sharded runs", %{account: account, project: project} do
+      test_run_id = Ecto.UUID.generate()
+
+      stub(Tuist.Accounts, :get_account_by_id, fn _id -> {:ok, account} end)
+
+      parent = self()
+
+      stub(Tuist.Storage, :download_to_file, fn _key, path, _account ->
+        send(parent, {:download_path, path})
+        {:ok, :done}
+      end)
+
+      stub(XCResultProcessor, :process_local, fn _path, _opts -> {:ok, parsed_data()} end)
+      stub(Tuist.Tests, :create_test, fn _attrs -> {:ok, %{id: test_run_id}} end)
+
+      args = job_args(test_run_id, account.id, project.id)
+      assert :ok == ProcessXcresultWorker.perform(oban_job(args))
+
+      assert_received {:download_path, path}
+      assert Path.basename(path) == "xcresult_#{test_run_id}.zip"
     end
   end
 

--- a/server/test/tuist/tests_test.exs
+++ b/server/test/tuist/tests_test.exs
@@ -2251,6 +2251,94 @@ defmodule Tuist.TestsTest do
       assert updated_test.scheme == "TuistAcceptanceTests"
     end
 
+    test "stays in_progress while every shard is still processing its xcresult" do
+      # When the CLI uploads xcresults for parsing, each shard's controller
+      # call lands with status="processing" before the worker has parsed
+      # anything. The merged Test row must not flip to a final status just
+      # because the controller has heard from every shard — otherwise the
+      # dashboard reports "Passed" with zero test cases and zero duration.
+      project = ProjectsFixtures.project_fixture()
+      account = AccountsFixtures.user_fixture(preload: [:account]).account
+      plan = ShardsFixtures.shard_plan_fixture(project_id: project.id, shard_count: 2)
+
+      {:ok, _first_test} =
+        Tests.create_test(%{
+          id: UUIDv7.generate(),
+          project_id: project.id,
+          account_id: account.id,
+          duration: 0,
+          status: "processing",
+          ran_at: NaiveDateTime.utc_now(),
+          is_ci: true,
+          shard_plan_id: plan.id,
+          shard_index: 0
+        })
+
+      {:ok, second_test} =
+        Tests.create_test(%{
+          id: UUIDv7.generate(),
+          project_id: project.id,
+          account_id: account.id,
+          duration: 0,
+          status: "processing",
+          ran_at: NaiveDateTime.utc_now(),
+          is_ci: true,
+          shard_plan_id: plan.id,
+          shard_index: 1
+        })
+
+      assert second_test.status == "in_progress"
+    end
+
+    test "counts each shard once even when the controller and worker both record it" do
+      # ShardRun is a MergeTree — both the controller's status=processing
+      # upload and the worker's parsed status="success" row coexist for
+      # the same shard_index. The completion check must not treat those
+      # as two separate shards, otherwise a 2-shard plan can finalize
+      # after a single shard's full lifecycle.
+      project = ProjectsFixtures.project_fixture()
+      account = AccountsFixtures.user_fixture(preload: [:account]).account
+      plan = ShardsFixtures.shard_plan_fixture(project_id: project.id, shard_count: 2)
+
+      shard_0_id = UUIDv7.generate()
+
+      {:ok, _processing_test} =
+        Tests.create_test(%{
+          id: shard_0_id,
+          project_id: project.id,
+          account_id: account.id,
+          duration: 0,
+          status: "processing",
+          ran_at: NaiveDateTime.utc_now(),
+          is_ci: true,
+          shard_plan_id: plan.id,
+          shard_index: 0
+        })
+
+      {:ok, parsed_test} =
+        Tests.create_test(%{
+          id: shard_0_id,
+          project_id: project.id,
+          account_id: account.id,
+          duration: 1000,
+          status: "success",
+          ran_at: NaiveDateTime.utc_now(),
+          is_ci: true,
+          shard_plan_id: plan.id,
+          shard_index: 0,
+          test_modules: [
+            %{
+              name: "ModuleA",
+              status: "success",
+              duration: 1000,
+              test_cases: [%{name: "testA", status: "success", duration: 500}]
+            }
+          ]
+        })
+
+      assert parsed_test.status == "in_progress"
+    end
+
     test "fills in macos_version, xcode_version and model_identifier from later shards" do
       project = ProjectsFixtures.project_fixture()
       account = AccountsFixtures.user_fixture(preload: [:account]).account

--- a/server/test/tuist/tests_test.exs
+++ b/server/test/tuist/tests_test.exs
@@ -2173,6 +2173,123 @@ defmodule Tuist.TestsTest do
       assert is_nil(test.build_run_id)
       assert is_nil(test.gradle_build_id)
     end
+
+    test "second shard fills in scheme when first shard left it empty" do
+      project = ProjectsFixtures.project_fixture()
+      account = AccountsFixtures.user_fixture(preload: [:account]).account
+      plan = ShardsFixtures.shard_plan_fixture(project_id: project.id, shard_count: 2)
+
+      {:ok, first_test} =
+        Tests.create_test(%{
+          id: UUIDv7.generate(),
+          project_id: project.id,
+          account_id: account.id,
+          duration: 0,
+          status: "processing",
+          scheme: nil,
+          ran_at: NaiveDateTime.utc_now(),
+          is_ci: true,
+          shard_plan_id: plan.id,
+          shard_index: 0
+        })
+
+      assert first_test.scheme in [nil, ""]
+
+      {:ok, updated_test} =
+        Tests.create_test(%{
+          id: UUIDv7.generate(),
+          project_id: project.id,
+          account_id: account.id,
+          duration: 800,
+          status: "success",
+          scheme: "TuistAcceptanceTests",
+          ran_at: NaiveDateTime.utc_now(),
+          is_ci: true,
+          shard_plan_id: plan.id,
+          shard_index: 1
+        })
+
+      assert updated_test.id == first_test.id
+      assert updated_test.scheme == "TuistAcceptanceTests"
+    end
+
+    test "preserves scheme when a later shard reports without one" do
+      project = ProjectsFixtures.project_fixture()
+      account = AccountsFixtures.user_fixture(preload: [:account]).account
+      plan = ShardsFixtures.shard_plan_fixture(project_id: project.id, shard_count: 2)
+
+      {:ok, first_test} =
+        Tests.create_test(%{
+          id: UUIDv7.generate(),
+          project_id: project.id,
+          account_id: account.id,
+          duration: 500,
+          status: "success",
+          scheme: "TuistAcceptanceTests",
+          ran_at: NaiveDateTime.utc_now(),
+          is_ci: true,
+          shard_plan_id: plan.id,
+          shard_index: 0
+        })
+
+      assert first_test.scheme == "TuistAcceptanceTests"
+
+      {:ok, updated_test} =
+        Tests.create_test(%{
+          id: UUIDv7.generate(),
+          project_id: project.id,
+          account_id: account.id,
+          duration: 800,
+          status: "success",
+          scheme: nil,
+          ran_at: NaiveDateTime.utc_now(),
+          is_ci: true,
+          shard_plan_id: plan.id,
+          shard_index: 1
+        })
+
+      assert updated_test.scheme == "TuistAcceptanceTests"
+    end
+
+    test "fills in macos_version, xcode_version and model_identifier from later shards" do
+      project = ProjectsFixtures.project_fixture()
+      account = AccountsFixtures.user_fixture(preload: [:account]).account
+      plan = ShardsFixtures.shard_plan_fixture(project_id: project.id, shard_count: 2)
+
+      {:ok, _first_test} =
+        Tests.create_test(%{
+          id: UUIDv7.generate(),
+          project_id: project.id,
+          account_id: account.id,
+          duration: 0,
+          status: "processing",
+          ran_at: NaiveDateTime.utc_now(),
+          is_ci: true,
+          shard_plan_id: plan.id,
+          shard_index: 0
+        })
+
+      {:ok, updated_test} =
+        Tests.create_test(%{
+          id: UUIDv7.generate(),
+          project_id: project.id,
+          account_id: account.id,
+          duration: 800,
+          status: "success",
+          scheme: "TuistAcceptanceTests",
+          macos_version: "26.4.1",
+          xcode_version: "26.4",
+          model_identifier: "VirtualMac2,1",
+          ran_at: NaiveDateTime.utc_now(),
+          is_ci: true,
+          shard_plan_id: plan.id,
+          shard_index: 1
+        })
+
+      assert updated_test.macos_version == "26.4.1"
+      assert updated_test.xcode_version == "26.4"
+      assert updated_test.model_identifier == "VirtualMac2,1"
+    end
   end
 
   describe "upload_crash_report/1" do

--- a/server/test/tuist_web/controllers/api/tests_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/tests_controller_test.exs
@@ -5,6 +5,7 @@ defmodule TuistWeb.API.TestsControllerTest do
   alias Tuist.Tests
   alias Tuist.Tests.Analytics
   alias Tuist.Tests.Test
+  alias Tuist.Tests.Workers.ProcessXcresultWorker
   alias TuistTestSupport.Fixtures.AccountsFixtures
   alias TuistTestSupport.Fixtures.ProjectsFixtures
   alias TuistWeb.Authentication
@@ -656,7 +657,7 @@ defmodule TuistWeb.API.TestsControllerTest do
       )
 
       assert_enqueued(
-        worker: Tuist.Tests.Workers.ProcessXcresultWorker,
+        worker: ProcessXcresultWorker,
         args: %{
           "vcs_comment_params" => %{
             "git_commit_sha" => "abc123",
@@ -664,6 +665,71 @@ defmodule TuistWeb.API.TestsControllerTest do
             "git_remote_url_origin" => "https://github.com/tuist/tuist.git",
             "project_id" => project.id
           }
+        }
+      )
+    end
+
+    test "uses the request body id (not the merged run id) for storage_key on sharded runs", %{
+      conn: conn,
+      user: user,
+      project: project
+    } do
+      # The CLI uploads each shard's xcresult to S3 keyed on the UUID
+      # it generated locally; for sharded runs the merged test run id
+      # belongs to the first shard, so the worker must read from the
+      # request body's id key, not from the merged Test row's id.
+      requested_id = UUIDv7.generate()
+      existing_merged_id = UUIDv7.generate()
+      shard_plan_id = UUIDv7.generate()
+
+      stub(Tuist.Environment, :tuist_hosted?, fn -> true end)
+      stub(Tests, :get_test, fn _id, _opts -> {:error, :not_found} end)
+
+      stub(Tests, :create_test, fn attrs ->
+        # Simulate the sharded merge: the returned id is the first shard's
+        # merged Test row id, not the request body's id for this shard.
+        {:ok,
+         %Test{
+           id: existing_merged_id,
+           duration: attrs.duration,
+           project_id: project.id,
+           account_id: attrs.account_id,
+           is_ci: true,
+           scheme: nil,
+           shard_plan_id: shard_plan_id,
+           build_system: "xcode",
+           status: "processing",
+           test_case_runs: []
+         }}
+      end)
+
+      conn =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> post(
+          "/api/projects/#{user.account.name}/#{project.name}/tests",
+          %{
+            id: requested_id,
+            duration: 0,
+            is_ci: true,
+            status: "processing",
+            shard_plan_id: shard_plan_id,
+            shard_index: 1,
+            test_modules: []
+          }
+        )
+
+      assert json_response(conn, 200)
+
+      expected_key =
+        "#{user.account.name}/#{project.name}/runs/#{requested_id}/result_bundle.zip"
+
+      assert_enqueued(
+        worker: ProcessXcresultWorker,
+        args: %{
+          "test_run_id" => existing_merged_id,
+          "storage_key" => expected_key,
+          "shard_index" => 1
         }
       )
     end

--- a/server/test/tuist_web/controllers/api/tests_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/tests_controller_test.exs
@@ -686,8 +686,10 @@ defmodule TuistWeb.API.TestsControllerTest do
       stub(Tests, :get_test, fn _id, _opts -> {:error, :not_found} end)
 
       stub(Tests, :create_test, fn attrs ->
-        # Simulate the sharded merge: the returned id is the first shard's
-        # merged Test row id, not the request body's id for this shard.
+        # Simulate the real sharded merge: create_or_update_sharded_test
+        # rewrites status to "in_progress" while it waits for the other
+        # shards, even though the CLI uploaded with status="processing".
+        # The merged id is the first shard's, not this shard's body id.
         {:ok,
          %Test{
            id: existing_merged_id,
@@ -698,7 +700,7 @@ defmodule TuistWeb.API.TestsControllerTest do
            scheme: nil,
            shard_plan_id: shard_plan_id,
            build_system: "xcode",
-           status: "processing",
+           status: "in_progress",
            test_case_runs: []
          }}
       end)


### PR DESCRIPTION
### Purpose

Sharded test runs were rendering as "Unknown" with zero test cases, zero duration, and zero per-shard duration in the dashboard, even after every shard had finished. Four bugs in the shard-merge pipeline contributed:

1. **`create_or_update_sharded_test` only refreshed `status` and `duration` on the existing Test row.** The first shard usually arrives with `status=processing` (the CLI uploads its xcresult bundle separately) and empty `scheme`, `model_identifier`, `xcode_version`, etc. Every subsequent update kept that emptiness, so the dashboard title stayed "Unknown" forever.
2. **`ProcessXcresultWorker` was uniqued by `[:test_run_id]`.** Every shard's upload returns the merged Test row's id, so Oban silently dropped the second shard's worker — only one shard's xcresult was ever parsed.
3. **The worker's `storage_key` was built from the merged `test_run.id`.** Each shard uploads its xcresult to S3 under the UUID the CLI generated for that shard (`body_params.id`); for sharded runs that does not equal `test_run.id`, so the worker for every shard but the first downloaded a missing object.
4. **`shard_metrics/1` returned every row in the `shard_runs` `MergeTree`.** With the controller inserting a row upfront (`duration=0`) and the worker inserting another later, the Shards table would render duplicate rows per `shard_index`.

### What changed

- [`Tuist.Tests.create_or_update_sharded_test`](server/lib/tuist/tests.ex) — merges `scheme`, `macos_version`, `xcode_version`, `model_identifier`, git/CI fields, and `build_run_id`/`gradle_build_id` from the incoming shard `attrs` whenever the existing row has them blank.
- [`Tuist.Tests.Workers.ProcessXcresultWorker`](server/lib/tuist/tests/workers/process_xcresult_worker.ex) — `unique: [keys: [:test_run_id, :shard_index]]` so every shard's worker runs.
- [`TuistWeb.API.TestsController.create`](server/lib/tuist_web/controllers/api/tests_controller.ex) — `storage_key` uses `body_params.id` (falling back to `test_run.id` for non-sharded runs).
- [`Tuist.Shards.Analytics.shard_metrics/1`](server/lib/tuist/shards/analytics.ex) — groups by `shard_index` and `argMax`-picks the latest `duration`/`status`/`ran_at` by `inserted_at` so duplicate inserts collapse into one row per shard.

These fixes only affect future runs; runs already persisted in ClickHouse without scheme or test cases stay as-is.

### How to test locally

1. Run the new unit/integration tests:
   ```
   cd server
   mix test test/tuist/tests_test.exs test/tuist/tests/workers/process_xcresult_worker_test.exs test/tuist/shards/analytics_test.exs test/tuist_web/controllers/api/tests_controller_test.exs:671
   ```
2. End-to-end: trigger a sharded test run (e.g. `TuistAcceptanceTests` with `shard_count: 2`) and confirm the dashboard renders the scheme, totals, and per-shard durations.