### PR TITLE
fix(server): unstick failed Kura deploys, auto-install platform

### DIFF
--- a/.github/workflows/server-deployment.yml
+++ b/.github/workflows/server-deployment.yml
@@ -436,6 +436,16 @@ jobs:
             ["us-east-1"]="kubeconfig: kura-us-east-1"
             ["us-west-1"]="kubeconfig: kura-us-west-1"
           )
+          # Cluster names match the CAPI Cluster CR names in
+          # infra/k8s/clusters/cluster-production-us-{east,west}.yaml.
+          # They drive external-dns.txtOwnerId and the Hetzner ingress
+          # LB annotation set by k8s:install-platform; drifting these
+          # values would churn TXT records and rename LBs on every
+          # deploy, so they must match what bootstrap-workload uses.
+          declare -A cluster_names=(
+            ["us-east-1"]="tuist-kura-us-east"
+            ["us-west-1"]="tuist-kura-us-west"
+          )
 
           # Cloudflare DNS-01 token for cert-manager. Resolved here once
           # so the install-platform script can stay credential-agnostic.
@@ -457,8 +467,11 @@ jobs:
             # ESO) to chart HEAD before installing the kura-controller,
             # whose StatefulSet reconcile depends on cert-manager.io/v1
             # Certificate. Idempotent: a no-op on clusters already at
-            # head, a self-heal on half-bootstrapped ones.
-            mise run k8s:install-platform "$kubeconfig" "tuist-kura-${region}"
+            # head, a self-heal on half-bootstrapped ones. The mise -C
+            # is required because k8s:* tasks live in infra/mise.toml
+            # scope, not the repo root.
+            mise -C "$GITHUB_WORKSPACE/infra" run k8s:install-platform \
+              "$kubeconfig" "${cluster_names[$region]}"
 
             KUBECONFIG="$kubeconfig" kubectl apply -f "$HELM_CHART_PATH/crds/"
             KUBECONFIG="$kubeconfig" helm upgrade --install "$HELM_RELEASE_NAME" "$HELM_CHART_PATH" \

--- a/.github/workflows/server-deployment.yml
+++ b/.github/workflows/server-deployment.yml
@@ -437,6 +437,11 @@ jobs:
             ["us-west-1"]="kubeconfig: kura-us-west-1"
           )
 
+          # Cloudflare DNS-01 token for cert-manager. Resolved here once
+          # so the install-platform script can stay credential-agnostic.
+          CLOUDFLARE_API_TOKEN="$(op read "op://Founders/cloudflare-tuist-dns/credential")"
+          export CLOUDFLARE_API_TOKEN
+
           for region in us-east-1 us-west-1; do
             kubeconfig="$RUNNER_TEMP/kura-${region}.yaml"
             op document get "${kubeconfig_items[$region]}" \
@@ -446,6 +451,15 @@ jobs:
             api="$(KUBECONFIG="$kubeconfig" kubectl config view --minify --raw -o jsonpath='{.clusters[0].cluster.server}')"
             echo "Deploying Kura controller to $region at $api"
             KUBECONFIG="$kubeconfig" kubectl --request-timeout=10s get --raw /version >/dev/null
+
+            # Bring the cluster's platform layer (cert-manager + the
+            # letsencrypt ClusterIssuer, ingress-nginx, external-dns,
+            # ESO) to chart HEAD before installing the kura-controller,
+            # whose StatefulSet reconcile depends on cert-manager.io/v1
+            # Certificate. Idempotent: a no-op on clusters already at
+            # head, a self-heal on half-bootstrapped ones.
+            mise run k8s:install-platform "$kubeconfig" "tuist-kura-${region}"
+
             KUBECONFIG="$kubeconfig" kubectl apply -f "$HELM_CHART_PATH/crds/"
             KUBECONFIG="$kubeconfig" helm upgrade --install "$HELM_RELEASE_NAME" "$HELM_CHART_PATH" \
               --namespace tuist-kura-controller --create-namespace \

--- a/infra/mise/tasks/k8s/bootstrap-workload.sh
+++ b/infra/mise/tasks/k8s/bootstrap-workload.sh
@@ -229,43 +229,7 @@ KUBECONFIG="$WL_KUBECONFIG" kubectl wait --for=condition=Ready nodes --all --tim
 # ---------------------------------------------------------------------------
 log "Step 7/13: install platform chart (cert-manager, ESO, ingress-nginx)"
 
-helm dependency update "$REPO_ROOT/infra/helm/platform" >/dev/null
-
-# Cloudflare API token for cert-manager DNS-01 challenge.
-CF_TOKEN=$(op read --account tuist.1password.com "op://Founders/cloudflare-tuist-dns/credential")
-
-KUBECONFIG="$WL_KUBECONFIG" kubectl create namespace platform --dry-run=client -o yaml | \
-  KUBECONFIG="$WL_KUBECONFIG" kubectl apply -f -
-KUBECONFIG="$WL_KUBECONFIG" kubectl -n platform create secret generic cloudflare-api-token \
-  --from-literal=api-token="$CF_TOKEN" \
-  --dry-run=client -o yaml | KUBECONFIG="$WL_KUBECONFIG" kubectl apply -f -
-unset CF_TOKEN
-
-# Two-step install: cert-manager's ClusterIssuer CRD is templated as
-# part of the cert-manager subchart, so it's registered alongside
-# our ClusterIssuer template — helm rejects that race with
-# "no matches for kind ClusterIssuer in version cert-manager.io/v1".
-# Step 7a: install everything EXCEPT our ClusterIssuer; cert-manager
-# subchart applies its CRDs.
-# Step 7b: re-apply with the ClusterIssuer enabled (default).
-KUBECONFIG="$WL_KUBECONFIG" helm upgrade --install platform "$REPO_ROOT/infra/helm/platform" \
-  --namespace platform \
-  -f "$REPO_ROOT/infra/helm/platform/values-hetzner.yaml" \
-  --set "clusterIssuer.enabled=false" \
-  --set "external-dns.txtOwnerId=${CLUSTER_NAME}-platform" \
-  --set "ingress-nginx.controller.service.annotations.load-balancer\.hetzner\.cloud/location=${REGION}" \
-  --set "ingress-nginx.controller.service.annotations.load-balancer\.hetzner\.cloud/name=${CLUSTER_NAME}-ingress" \
-  --wait --timeout 5m
-
-KUBECONFIG="$WL_KUBECONFIG" kubectl wait --for=condition=Established crd/clusterissuers.cert-manager.io --timeout=2m
-
-KUBECONFIG="$WL_KUBECONFIG" helm upgrade --install platform "$REPO_ROOT/infra/helm/platform" \
-  --namespace platform \
-  -f "$REPO_ROOT/infra/helm/platform/values-hetzner.yaml" \
-  --set "external-dns.txtOwnerId=${CLUSTER_NAME}-platform" \
-  --set "ingress-nginx.controller.service.annotations.load-balancer\.hetzner\.cloud/location=${REGION}" \
-  --set "ingress-nginx.controller.service.annotations.load-balancer\.hetzner\.cloud/name=${CLUSTER_NAME}-ingress" \
-  --wait --timeout 5m
+mise run k8s:install-platform "$WL_KUBECONFIG" "$CLUSTER_NAME"
 
 # ---------------------------------------------------------------------------
 log "Step 8/13: install Cluster API core (Mac mini fleet substrate)"

--- a/infra/mise/tasks/k8s/bootstrap-workload.sh
+++ b/infra/mise/tasks/k8s/bootstrap-workload.sh
@@ -229,7 +229,10 @@ KUBECONFIG="$WL_KUBECONFIG" kubectl wait --for=condition=Ready nodes --all --tim
 # ---------------------------------------------------------------------------
 log "Step 7/13: install platform chart (cert-manager, ESO, ingress-nginx)"
 
-mise run k8s:install-platform "$WL_KUBECONFIG" "$CLUSTER_NAME"
+# `mise -C "$REPO_ROOT/infra"` so the nested task resolves regardless
+# of where the caller ran bootstrap-workload from; k8s:* tasks live in
+# infra/mise.toml scope, not the repo root.
+mise -C "$REPO_ROOT/infra" run k8s:install-platform "$WL_KUBECONFIG" "$CLUSTER_NAME"
 
 # ---------------------------------------------------------------------------
 log "Step 8/13: install Cluster API core (Mac mini fleet substrate)"

--- a/infra/mise/tasks/k8s/install-platform.sh
+++ b/infra/mise/tasks/k8s/install-platform.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+#MISE description="Install or upgrade the Tuist platform chart (cert-manager, ESO, ingress-nginx, external-dns) on a workload cluster. Idempotent — safe to run on every deploy."
+#USAGE arg "<kubeconfig>" help="Path to the workload cluster kubeconfig"
+#USAGE arg "<cluster_name>" help="Cluster name, used for the ingress LoadBalancer Hetzner name and the external-dns owner ID (e.g. tuist-kura-us-east)"
+
+# Brings a workload cluster to the desired state of the platform chart
+# at HEAD: cert-manager + ClusterIssuer, ingress-nginx, external-dns,
+# external-secrets. Designed to run from CI on every deploy so a
+# half-bootstrapped cluster self-heals instead of silently breaking
+# downstream installs that depend on cert-manager.io/v1 Certificate.
+#
+# Reads the Cloudflare DNS-01 API token from `CLOUDFLARE_API_TOKEN` if
+# set (CI wires it from the workflow's 1Password integration). Falls
+# back to `op read` for local invocations from bootstrap-workload.
+
+set -euo pipefail
+
+WL_KUBECONFIG="$1"
+CLUSTER_NAME="$2"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+CHART_PATH="$REPO_ROOT/infra/helm/platform"
+
+log() { printf '\n\033[1;34m==> %s\033[0m\n' "$*"; }
+
+if [ ! -r "$WL_KUBECONFIG" ]; then
+  echo "ERROR: kubeconfig not readable: $WL_KUBECONFIG" >&2
+  exit 1
+fi
+
+# HCCM stamps every node with topology.kubernetes.io/region (e.g. ash,
+# hil, fsn1). Reading the location from the cluster keeps callers
+# free of any region-name mapping that could drift from the actual
+# placement.
+REGION="$(KUBECONFIG="$WL_KUBECONFIG" kubectl get nodes \
+  -o jsonpath='{.items[0].metadata.labels.topology\.kubernetes\.io/region}')"
+if [ -z "$REGION" ]; then
+  echo "ERROR: could not derive Hetzner location from topology.kubernetes.io/region on $WL_KUBECONFIG nodes" >&2
+  exit 1
+fi
+log "Platform install for $CLUSTER_NAME (region $REGION)"
+
+if [ -z "${CLOUDFLARE_API_TOKEN:-}" ]; then
+  CLOUDFLARE_API_TOKEN="$(op read --account tuist.1password.com \
+    "op://Founders/cloudflare-tuist-dns/credential")"
+fi
+
+helm dependency update "$CHART_PATH" >/dev/null
+
+KUBECONFIG="$WL_KUBECONFIG" kubectl create namespace platform \
+  --dry-run=client -o yaml | KUBECONFIG="$WL_KUBECONFIG" kubectl apply -f -
+KUBECONFIG="$WL_KUBECONFIG" kubectl -n platform create secret generic cloudflare-api-token \
+  --from-literal=api-token="$CLOUDFLARE_API_TOKEN" \
+  --dry-run=client -o yaml | KUBECONFIG="$WL_KUBECONFIG" kubectl apply -f -
+unset CLOUDFLARE_API_TOKEN
+
+HELM_SET_ARGS=(
+  --set "external-dns.txtOwnerId=${CLUSTER_NAME}-platform"
+  --set "ingress-nginx.controller.service.annotations.load-balancer\.hetzner\.cloud/location=${REGION}"
+  --set "ingress-nginx.controller.service.annotations.load-balancer\.hetzner\.cloud/name=${CLUSTER_NAME}-ingress"
+)
+
+# First-install ordering: our ClusterIssuer template depends on the
+# cert-manager.io/v1 CRD that the cert-manager subchart ships. On a
+# cluster that already has the CRD, a single pass is enough. On a
+# fresh cluster we install the subcharts first with our ClusterIssuer
+# disabled, wait for the CRD, then re-apply with it enabled — flipping
+# clusterIssuer.enabled on a steady-state cluster would prune and
+# re-create the resource, briefly blocking new cert issuance.
+if KUBECONFIG="$WL_KUBECONFIG" kubectl get crd clusterissuers.cert-manager.io >/dev/null 2>&1; then
+  KUBECONFIG="$WL_KUBECONFIG" helm upgrade --install platform "$CHART_PATH" \
+    --namespace platform \
+    -f "$CHART_PATH/values-hetzner.yaml" \
+    "${HELM_SET_ARGS[@]}" \
+    --wait --timeout 5m
+else
+  log "ClusterIssuer CRD missing; running two-pass install"
+  KUBECONFIG="$WL_KUBECONFIG" helm upgrade --install platform "$CHART_PATH" \
+    --namespace platform \
+    -f "$CHART_PATH/values-hetzner.yaml" \
+    --set "clusterIssuer.enabled=false" \
+    "${HELM_SET_ARGS[@]}" \
+    --wait --timeout 5m
+
+  KUBECONFIG="$WL_KUBECONFIG" kubectl wait \
+    --for=condition=Established crd/clusterissuers.cert-manager.io --timeout=2m
+
+  KUBECONFIG="$WL_KUBECONFIG" helm upgrade --install platform "$CHART_PATH" \
+    --namespace platform \
+    -f "$CHART_PATH/values-hetzner.yaml" \
+    "${HELM_SET_ARGS[@]}" \
+    --wait --timeout 5m
+fi

--- a/server/lib/tuist/kura.ex
+++ b/server/lib/tuist/kura.ex
@@ -431,46 +431,34 @@ defmodule Tuist.Kura do
   end
 
   @doc """
-  Retries a failed first-time deploy: atomically tombstones the failed
-  `Server` row, removes its derived cache endpoint, and inserts a
-  fresh `Server` + `Deployment` for the same `(account, region)` using
-  the supplied image tag.
+  Retries a failed first-time deploy in place: flips the `Server` back
+  to `:provisioning` and appends a fresh `Deployment` so the
+  reconciler picks the retry up on its next tick.
 
-  Only failed servers that never reached `:active` are eligible —
-  retrying a drift failure on a previously-active server would tear
-  down the working cache endpoint mid-flight, so the operator has to
-  explicitly destroy those instead.
+  Only failed servers that never reached `:active` are eligible.
+  Retrying a drift failure on a previously-active server would
+  trample the cache endpoint that's still serving the old image,
+  so the operator has to explicitly destroy those instead.
 
-  The new server's `provisioner_node_ref` is deterministic from
-  `(account_handle, region)`, so it points at the same backing
-  resource. Whatever the previous reconcile left in the cluster is
-  reused; the reconciler re-applies the manifest idempotently on its
-  next tick.
+  The server row, ID, and `provisioner_node_ref` stay the same; the
+  prior failed `Deployment` rows stay attached so the failure
+  history is visible in /ops alongside the retry.
   """
-  def retry_server(%Server{status: :failed, current_image_tag: nil} = old_server, image_tag) when is_binary(image_tag) do
-    with {:ok, region} <- Regions.fetch(old_server.region),
-         {:ok, account} <- Accounts.get_account_by_id(old_server.account_id),
-         {:ok, ref} <- region.provisioner.provision(account, region, server_stub(%{})),
-         :ok <- validate_provisioner_node_ref(account, ref) do
-      attrs = %{account_id: account.id, region: old_server.region, provisioner_node_ref: ref}
-
+  def retry_server(%Server{status: :failed, current_image_tag: nil} = server, image_tag) when is_binary(image_tag) do
+    with {:ok, region} <- Regions.fetch(server.region) do
       case Repo.transaction(fn ->
-             with {:ok, old_destroyed} <-
-                    old_server
-                    |> Server.status_changeset(%{status: :destroyed, url: nil})
-                    |> Repo.update(),
-                  :ok <- remove_cache_endpoint(old_destroyed),
-                  {:ok, new_server} <- attrs |> Server.create_changeset() |> Repo.insert(),
-                  {:ok, _deployment} <- insert_initial_deployment(new_server, region, image_tag) do
-               {old_destroyed, Repo.preload(new_server, :deployments)}
+             with {:ok, server} <-
+                    server |> Server.status_changeset(%{status: :provisioning}) |> Repo.update(),
+                  {:ok, _deployment} <- insert_initial_deployment(server, region, image_tag) do
+               server
              else
                {:error, reason} -> Repo.rollback(reason)
              end
            end) do
-        {:ok, {old_destroyed, new_server}} ->
-          broadcast_server(old_destroyed, :destroyed)
-          broadcast_server(new_server, :created)
-          {:ok, new_server}
+        {:ok, server} ->
+          server = Repo.preload(server, :deployments, force: true)
+          broadcast_server(server, :updated)
+          {:ok, server}
 
         {:error, reason} ->
           {:error, reason}

--- a/server/lib/tuist/kura.ex
+++ b/server/lib/tuist/kura.ex
@@ -29,8 +29,6 @@ defmodule Tuist.Kura do
   alias Tuist.Kura.Server
   alias Tuist.Repo
 
-  require Logger
-
   @pubsub Tuist.PubSub
   @create_server_keys %{
     "account_id" => :account_id,
@@ -433,35 +431,54 @@ defmodule Tuist.Kura do
   end
 
   @doc """
-  Resets a server back to "Not deployed" after a first-time deploy
-  failure. Best-effort destroys any backing resource that the rollout
-  may have already created, marks the row `:destroyed`, removes any
-  derived cache endpoint, and broadcasts. Errors from the backing
-  destroy are logged and ignored so the UI always recovers. A leaked
-  resource is acceptable here because the server never reached
-  `:active`, so no traffic depends on it.
+  Retries a failed first-time deploy: atomically tombstones the failed
+  `Server` row, removes its derived cache endpoint, and inserts a
+  fresh `Server` + `Deployment` for the same `(account, region)` using
+  the supplied image tag.
+
+  Only failed servers that never reached `:active` are eligible —
+  retrying a drift failure on a previously-active server would tear
+  down the working cache endpoint mid-flight, so the operator has to
+  explicitly destroy those instead.
+
+  The new server's `provisioner_node_ref` is deterministic from
+  `(account_handle, region)`, so it points at the same backing
+  resource. Whatever the previous reconcile left in the cluster is
+  reused; the reconciler re-applies the manifest idempotently on its
+  next tick.
   """
-  def reset_server(%Server{} = server) do
-    best_effort_destroy(server)
+  def retry_server(%Server{status: :failed, current_image_tag: nil} = old_server, image_tag) when is_binary(image_tag) do
+    with {:ok, region} <- Regions.fetch(old_server.region),
+         {:ok, account} <- Accounts.get_account_by_id(old_server.account_id),
+         {:ok, ref} <- region.provisioner.provision(account, region, server_stub(%{})),
+         :ok <- validate_provisioner_node_ref(account, ref) do
+      attrs = %{account_id: account.id, region: old_server.region, provisioner_node_ref: ref}
 
-    {:ok, server} =
-      server |> Server.status_changeset(%{status: :destroyed, url: nil}) |> Repo.update()
+      case Repo.transaction(fn ->
+             with {:ok, old_destroyed} <-
+                    old_server
+                    |> Server.status_changeset(%{status: :destroyed, url: nil})
+                    |> Repo.update(),
+                  :ok <- remove_cache_endpoint(old_destroyed),
+                  {:ok, new_server} <- attrs |> Server.create_changeset() |> Repo.insert(),
+                  {:ok, _deployment} <- insert_initial_deployment(new_server, region, image_tag) do
+               {old_destroyed, Repo.preload(new_server, :deployments)}
+             else
+               {:error, reason} -> Repo.rollback(reason)
+             end
+           end) do
+        {:ok, {old_destroyed, new_server}} ->
+          broadcast_server(old_destroyed, :destroyed)
+          broadcast_server(new_server, :created)
+          {:ok, new_server}
 
-    remove_cache_endpoint(server)
-    broadcast_server(server, :destroyed)
-    {:ok, server}
-  end
-
-  defp best_effort_destroy(server) do
-    case Provisioner.destroy(server) do
-      :ok ->
-        :ok
-
-      {:error, reason} ->
-        Logger.warning("[Kura] reset_server backing destroy failed for #{server.id}: #{inspect(reason)}")
-        :ok
+        {:error, reason} ->
+          {:error, reason}
+      end
     end
   end
+
+  def retry_server(%Server{}, _image_tag), do: {:error, :not_retryable}
 
   @doc "Marks a server as `:destroyed` after the reconciler observes teardown."
   def mark_destroyed(%Server{} = server) do

--- a/server/lib/tuist/kura.ex
+++ b/server/lib/tuist/kura.ex
@@ -29,6 +29,8 @@ defmodule Tuist.Kura do
   alias Tuist.Kura.Server
   alias Tuist.Repo
 
+  require Logger
+
   @pubsub Tuist.PubSub
   @create_server_keys %{
     "account_id" => :account_id,
@@ -427,6 +429,37 @@ defmodule Tuist.Kura do
 
       {:error, reason} ->
         {:error, reason}
+    end
+  end
+
+  @doc """
+  Resets a server back to "Not deployed" after a first-time deploy
+  failure. Best-effort destroys any backing resource that the rollout
+  may have already created, marks the row `:destroyed`, removes any
+  derived cache endpoint, and broadcasts. Errors from the backing
+  destroy are logged and ignored so the UI always recovers. A leaked
+  resource is acceptable here because the server never reached
+  `:active`, so no traffic depends on it.
+  """
+  def reset_server(%Server{} = server) do
+    best_effort_destroy(server)
+
+    {:ok, server} =
+      server |> Server.status_changeset(%{status: :destroyed, url: nil}) |> Repo.update()
+
+    remove_cache_endpoint(server)
+    broadcast_server(server, :destroyed)
+    {:ok, server}
+  end
+
+  defp best_effort_destroy(server) do
+    case Provisioner.destroy(server) do
+      :ok ->
+        :ok
+
+      {:error, reason} ->
+        Logger.warning("[Kura] reset_server backing destroy failed for #{server.id}: #{inspect(reason)}")
+        :ok
     end
   end
 

--- a/server/lib/tuist/kura/reconciler.ex
+++ b/server/lib/tuist/kura/reconciler.ex
@@ -185,18 +185,9 @@ defmodule Tuist.Kura.Reconciler do
     capture_deploy_failure(deployment, server, message)
 
     {:ok, _} = Kura.mark_failed(deployment, message)
-    if server, do: fail_or_reset_server(server)
+    if server, do: Kura.fail_server(server)
     :ok
   end
-
-  # A server that never reached `:active` has nothing serving traffic,
-  # so resetting the row to `:destroyed` is safe and lets the UI render
-  # the region as "Not deployed" for an immediate retry. An
-  # already-active server keeps serving on the old image; we only flip
-  # it to `:failed` so the failed drift is visible without tearing
-  # down the working endpoint.
-  defp fail_or_reset_server(%Server{status: :provisioning} = server), do: Kura.reset_server(server)
-  defp fail_or_reset_server(%Server{} = server), do: Kura.fail_server(server)
 
   defp capture_deploy_failure(deployment, server, message) do
     Sentry.capture_message("Kura deploy failed",

--- a/server/lib/tuist/kura/reconciler.ex
+++ b/server/lib/tuist/kura/reconciler.ex
@@ -119,8 +119,7 @@ defmodule Tuist.Kura.Reconciler do
         apply_deployment(deployment, server)
 
       {:error, reason} ->
-        Logger.warning("[Kura.Reconciler] could not observe deployment #{deployment.id}: #{inspect(reason)}")
-        :ok
+        fail(deployment, server, reason)
     end
   end
 
@@ -182,9 +181,35 @@ defmodule Tuist.Kura.Reconciler do
 
   defp fail(deployment, server, reason) do
     message = if is_binary(reason), do: reason, else: inspect(reason)
+
+    capture_deploy_failure(deployment, server, message)
+
     {:ok, _} = Kura.mark_failed(deployment, message)
-    if server, do: Kura.fail_server(server)
+    if server, do: fail_or_reset_server(server)
     :ok
+  end
+
+  # A server that never reached `:active` has nothing serving traffic,
+  # so resetting the row to `:destroyed` is safe and lets the UI render
+  # the region as "Not deployed" for an immediate retry. An
+  # already-active server keeps serving on the old image; we only flip
+  # it to `:failed` so the failed drift is visible without tearing
+  # down the working endpoint.
+  defp fail_or_reset_server(%Server{status: :provisioning} = server), do: Kura.reset_server(server)
+  defp fail_or_reset_server(%Server{} = server), do: Kura.fail_server(server)
+
+  defp capture_deploy_failure(deployment, server, message) do
+    Sentry.capture_message("Kura deploy failed",
+      level: :error,
+      extra: %{
+        deployment_id: deployment.id,
+        image_tag: deployment.image_tag,
+        server_id: server && server.id,
+        account_id: server && server.account_id,
+        region: server && server.region,
+        reason: message
+      }
+    )
   end
 
   defp server_status(:server_destroying), do: "destroying"

--- a/server/lib/tuist/kura/server.ex
+++ b/server/lib/tuist/kura/server.ex
@@ -8,14 +8,17 @@ defmodule Tuist.Kura.Server do
   Lifecycle:
 
       provisioning → active      ↘
-                ↓     ↓              destroying → destroyed
-                ↓   failed                ↑
-                └──────────────── destroyed
+                     ↓              destroying → destroyed
+                   failed                ↑
+                     └──────────────────┐
+                                        ↓
+                                   destroyed
 
-  A first-time deploy that fails before reaching `:active` skips
-  `:destroying` and transitions straight to `:destroyed`: nothing was
-  ever serving traffic, and the UI surfaces the row as "Not deployed"
-  so the operator can redeploy.
+  `:failed` → `:destroyed` is the retry path: the operator clicks
+  Retry on a failed first-time deploy and the row is tombstoned
+  atomically with the creation of a new server in the same region.
+  Going through `:destroying` would force a multi-tick wait before
+  the unique `(account_id, region)` index frees up.
 
   `url` and `current_image_tag` are populated when the server first
   reaches `:active` and updated on subsequent successful deployments.
@@ -39,9 +42,9 @@ defmodule Tuist.Kura.Server do
   @status_mappings [provisioning: 0, active: 1, failed: 2, destroying: 3, destroyed: 4]
   @statuses Keyword.keys(@status_mappings)
   @allowed_status_transitions %{
-    provisioning: [:provisioning, :active, :failed, :destroying, :destroyed],
+    provisioning: [:provisioning, :active, :failed, :destroying],
     active: [:active, :failed, :destroying],
-    failed: [:failed, :active, :destroying],
+    failed: [:failed, :active, :destroying, :destroyed],
     destroying: [:destroying, :destroyed],
     destroyed: [:destroyed]
   }

--- a/server/lib/tuist/kura/server.ex
+++ b/server/lib/tuist/kura/server.ex
@@ -8,8 +8,14 @@ defmodule Tuist.Kura.Server do
   Lifecycle:
 
       provisioning → active      ↘
-                     ↓              destroying → destroyed
-                   failed
+                ↓     ↓              destroying → destroyed
+                ↓   failed                ↑
+                └──────────────── destroyed
+
+  A first-time deploy that fails before reaching `:active` skips
+  `:destroying` and transitions straight to `:destroyed`: nothing was
+  ever serving traffic, and the UI surfaces the row as "Not deployed"
+  so the operator can redeploy.
 
   `url` and `current_image_tag` are populated when the server first
   reaches `:active` and updated on subsequent successful deployments.
@@ -33,7 +39,7 @@ defmodule Tuist.Kura.Server do
   @status_mappings [provisioning: 0, active: 1, failed: 2, destroying: 3, destroyed: 4]
   @statuses Keyword.keys(@status_mappings)
   @allowed_status_transitions %{
-    provisioning: [:provisioning, :active, :failed, :destroying],
+    provisioning: [:provisioning, :active, :failed, :destroying, :destroyed],
     active: [:active, :failed, :destroying],
     failed: [:failed, :active, :destroying],
     destroying: [:destroying, :destroyed],

--- a/server/lib/tuist/kura/server.ex
+++ b/server/lib/tuist/kura/server.ex
@@ -7,18 +7,17 @@ defmodule Tuist.Kura.Server do
 
   Lifecycle:
 
-      provisioning → active      ↘
-                     ↓              destroying → destroyed
-                   failed                ↑
-                     └──────────────────┐
-                                        ↓
-                                   destroyed
+      provisioning ⇄ failed
+            ↓         ↑
+            └→ active ┘
+                      ↓
+                  destroying → destroyed
 
-  `:failed` → `:destroyed` is the retry path: the operator clicks
-  Retry on a failed first-time deploy and the row is tombstoned
-  atomically with the creation of a new server in the same region.
-  Going through `:destroying` would force a multi-tick wait before
-  the unique `(account_id, region)` index frees up.
+  `:failed` → `:provisioning` is the retry path: a first-time deploy
+  that never reached `:active` flips back to `:provisioning` in place
+  when the operator clicks Retry, and the new deployment is appended
+  to the same row so the failure history stays attached. `:destroyed`
+  is reserved for operator-driven teardown.
 
   `url` and `current_image_tag` are populated when the server first
   reaches `:active` and updated on subsequent successful deployments.
@@ -44,7 +43,7 @@ defmodule Tuist.Kura.Server do
   @allowed_status_transitions %{
     provisioning: [:provisioning, :active, :failed, :destroying],
     active: [:active, :failed, :destroying],
-    failed: [:failed, :active, :destroying, :destroyed],
+    failed: [:failed, :provisioning, :active, :destroying],
     destroying: [:destroying, :destroyed],
     destroyed: [:destroyed]
   }

--- a/server/lib/tuist_web/live/account_settings_live.ex
+++ b/server/lib/tuist_web/live/account_settings_live.ex
@@ -287,51 +287,12 @@ defmodule TuistWeb.AccountSettingsLive do
   def handle_event("destroy_kura_server", _params, socket), do: {:noreply, socket}
 
   def handle_event("retry_kura_server", %{"id" => id}, %{assigns: %{kura_enabled: true}} = socket) do
-    case {Kura.get_server(socket.assigns.selected_account.id, id), socket.assigns.latest_kura_version} do
-      {nil, _} ->
-        {:noreply, put_flash(socket, :error, dgettext("dashboard_account", "Kura server not found."))}
-
-      {_server, nil} ->
-        {:noreply,
-         put_flash(
-           socket,
-           :error,
-           dgettext(
-             "dashboard_account",
-             "No Kura runtime image is configured right now. Try again after the next server deploy."
-           )
-         )}
-
-      {%Server{} = server, version} ->
-        case Kura.retry_server(server, kura_version_image_tag(version)) do
-          {:ok, new_server} ->
-            {:noreply,
-             socket
-             |> put_flash(
-               :info,
-               dgettext("dashboard_account", "Retrying Kura in %{region}...", region: new_server.region)
-             )
-             |> load_kura_state()}
-
-          {:error, :not_retryable} ->
-            {:noreply,
-             put_flash(
-               socket,
-               :error,
-               dgettext(
-                 "dashboard_account",
-                 "This Kura server is not retryable from here; destroy it and redeploy instead."
-               )
-             )}
-
-          {:error, reason} ->
-            {:noreply,
-             put_flash(
-               socket,
-               :error,
-               dgettext("dashboard_account", "Failed to retry Kura: %{reason}", reason: inspect(reason))
-             )}
-        end
+    with %Server{} = server <- Kura.get_server(socket.assigns.selected_account.id, id),
+         version when not is_nil(version) <- socket.assigns.latest_kura_version,
+         {:ok, _} <- Kura.retry_server(server, kura_version_image_tag(version)) do
+      {:noreply, load_kura_state(socket)}
+    else
+      _ -> {:noreply, socket}
     end
   end
 

--- a/server/lib/tuist_web/live/account_settings_live.ex
+++ b/server/lib/tuist_web/live/account_settings_live.ex
@@ -286,6 +286,57 @@ defmodule TuistWeb.AccountSettingsLive do
 
   def handle_event("destroy_kura_server", _params, socket), do: {:noreply, socket}
 
+  def handle_event("retry_kura_server", %{"id" => id}, %{assigns: %{kura_enabled: true}} = socket) do
+    case {Kura.get_server(socket.assigns.selected_account.id, id), socket.assigns.latest_kura_version} do
+      {nil, _} ->
+        {:noreply, put_flash(socket, :error, dgettext("dashboard_account", "Kura server not found."))}
+
+      {_server, nil} ->
+        {:noreply,
+         put_flash(
+           socket,
+           :error,
+           dgettext(
+             "dashboard_account",
+             "No Kura runtime image is configured right now. Try again after the next server deploy."
+           )
+         )}
+
+      {%Server{} = server, version} ->
+        case Kura.retry_server(server, kura_version_image_tag(version)) do
+          {:ok, new_server} ->
+            {:noreply,
+             socket
+             |> put_flash(
+               :info,
+               dgettext("dashboard_account", "Retrying Kura in %{region}...", region: new_server.region)
+             )
+             |> load_kura_state()}
+
+          {:error, :not_retryable} ->
+            {:noreply,
+             put_flash(
+               socket,
+               :error,
+               dgettext(
+                 "dashboard_account",
+                 "This Kura server is not retryable from here; destroy it and redeploy instead."
+               )
+             )}
+
+          {:error, reason} ->
+            {:noreply,
+             put_flash(
+               socket,
+               :error,
+               dgettext("dashboard_account", "Failed to retry Kura: %{reason}", reason: inspect(reason))
+             )}
+        end
+    end
+  end
+
+  def handle_event("retry_kura_server", _params, socket), do: {:noreply, socket}
+
   def handle_event(
         "toggle_custom_cache_endpoints",
         %{"checked" => checked},
@@ -559,6 +610,16 @@ defmodule TuistWeb.AccountSettingsLive do
           </:col>
           <:col :let={row} label="">
             <.button
+              :if={kura_row_retry?(row)}
+              type="button"
+              label={dgettext("dashboard_account", "Retry")}
+              variant="primary"
+              size="small"
+              phx-click="retry_kura_server"
+              phx-value-id={row.server.id}
+              disabled={is_nil(@latest_kura_version)}
+            />
+            <.button
               :if={kura_row_server?(row) and row.server.status not in [:destroying, :destroyed]}
               type="button"
               label={dgettext("dashboard_account", "Destroy")}
@@ -611,6 +672,14 @@ defmodule TuistWeb.AccountSettingsLive do
 
   defp kura_row_available_region?(%{type: :available_region}), do: true
   defp kura_row_available_region?(_row), do: false
+
+  # Retry is offered only on first-time deploys that never reached
+  # `:active` (current_image_tag is nil): no traffic depends on the row,
+  # so atomically tombstoning it and starting fresh is safe. Drift
+  # failures on a previously-active server skip this — retrying would
+  # tear down the cache endpoint that's still serving the old image.
+  defp kura_row_retry?(%{type: :server, server: %{status: :failed, current_image_tag: nil}}), do: true
+  defp kura_row_retry?(_row), do: false
 
   defp kura_row_status_label(%{type: :server, server: server}), do: kura_display_status_label(server)
   defp kura_row_status_label(%{type: :available_region}), do: dgettext("dashboard_account", "Not deployed")

--- a/server/lib/tuist_web/live/account_settings_live.html.heex
+++ b/server/lib/tuist_web/live/account_settings_live.html.heex
@@ -2,6 +2,22 @@
   <h1 data-part="title">
     {dgettext("dashboard_account", "Settings")}
   </h1>
+  <.alert
+    :if={Phoenix.Flash.get(@flash, :info)}
+    id="account-settings-flash-info"
+    type="secondary"
+    status="information"
+    size="small"
+    title={Phoenix.Flash.get(@flash, :info)}
+  />
+  <.alert
+    :if={Phoenix.Flash.get(@flash, :error)}
+    id="account-settings-flash-error"
+    type="secondary"
+    status="error"
+    size="small"
+    title={Phoenix.Flash.get(@flash, :error)}
+  />
   <%= if is_nil(@selected_account.user_id) do %>
     <.region_selection_section
       region_form={@region_form}

--- a/server/lib/tuist_web/live/account_settings_live.html.heex
+++ b/server/lib/tuist_web/live/account_settings_live.html.heex
@@ -2,22 +2,6 @@
   <h1 data-part="title">
     {dgettext("dashboard_account", "Settings")}
   </h1>
-  <.alert
-    :if={Phoenix.Flash.get(@flash, :info)}
-    id="account-settings-flash-info"
-    type="secondary"
-    status="information"
-    size="small"
-    title={Phoenix.Flash.get(@flash, :info)}
-  />
-  <.alert
-    :if={Phoenix.Flash.get(@flash, :error)}
-    id="account-settings-flash-error"
-    type="secondary"
-    status="error"
-    size="small"
-    title={Phoenix.Flash.get(@flash, :error)}
-  />
   <%= if is_nil(@selected_account.user_id) do %>
     <.region_selection_section
       region_form={@region_form}

--- a/server/test/tuist/kura/reconciler_test.exs
+++ b/server/test/tuist/kura/reconciler_test.exs
@@ -146,7 +146,7 @@ defmodule Tuist.Kura.ReconcilerTest do
     assert %Server{status: :destroying} = Repo.get!(Server, server.id)
   end
 
-  test "resets a first-time-deploy server and reports to Sentry when apply fails" do
+  test "marks a first-time-deploy server :failed and reports to Sentry when apply fails" do
     {_account, server, deployment} = create_server()
 
     expect(Provisioner, :current_image_tag, fn %Server{id: id} ->
@@ -157,11 +157,6 @@ defmodule Tuist.Kura.ReconcilerTest do
     expect(Provisioner, :rollout, fn %Server{id: id}, _inputs ->
       assert id == server.id
       {:error, "apply failed"}
-    end)
-
-    expect(Provisioner, :destroy, fn %Server{id: id} ->
-      assert id == server.id
-      :ok
     end)
 
     expect(Sentry, :capture_message, fn "Kura deploy failed", opts ->
@@ -177,18 +172,13 @@ defmodule Tuist.Kura.ReconcilerTest do
     assert :ok = Reconciler.reconcile()
 
     assert %Deployment{status: :failed, error_message: "apply failed"} = Repo.get!(Deployment, deployment.id)
-    assert %Server{status: :destroyed, url: nil} = Repo.get!(Server, server.id)
+    assert %Server{status: :failed, current_image_tag: nil} = Repo.get!(Server, server.id)
   end
 
-  test "resets a first-time-deploy server and reports to Sentry when the cluster is unreachable" do
+  test "marks a first-time-deploy server :failed and reports to Sentry when the cluster is unreachable" do
     {_account, server, deployment} = create_server()
 
     expect(Provisioner, :current_image_tag, fn %Server{id: id} ->
-      assert id == server.id
-      {:error, "missing Kubernetes kubeconfig for Kura cluster us-east-1"}
-    end)
-
-    expect(Provisioner, :destroy, fn %Server{id: id} ->
       assert id == server.id
       {:error, "missing Kubernetes kubeconfig for Kura cluster us-east-1"}
     end)
@@ -206,10 +196,10 @@ defmodule Tuist.Kura.ReconcilerTest do
              error_message: "missing Kubernetes kubeconfig for Kura cluster us-east-1"
            } = Repo.get!(Deployment, deployment.id)
 
-    assert %Server{status: :destroyed} = Repo.get!(Server, server.id)
+    assert %Server{status: :failed, current_image_tag: nil} = Repo.get!(Server, server.id)
   end
 
-  test "keeps an active server at :failed (not :destroyed) when a drift rollout fails" do
+  test "keeps an active server at :failed when a drift rollout fails so the working endpoint stays up" do
     {_account, server, deployment} = create_server()
     {:ok, server} = Kura.activate_server(server, deployment.image_tag)
     mark_deployment_succeeded(deployment)

--- a/server/test/tuist/kura/reconciler_test.exs
+++ b/server/test/tuist/kura/reconciler_test.exs
@@ -146,7 +146,7 @@ defmodule Tuist.Kura.ReconcilerTest do
     assert %Server{status: :destroying} = Repo.get!(Server, server.id)
   end
 
-  test "marks the deployment and server failed when apply fails" do
+  test "resets a first-time-deploy server and reports to Sentry when apply fails" do
     {_account, server, deployment} = create_server()
 
     expect(Provisioner, :current_image_tag, fn %Server{id: id} ->
@@ -159,10 +159,81 @@ defmodule Tuist.Kura.ReconcilerTest do
       {:error, "apply failed"}
     end)
 
+    expect(Provisioner, :destroy, fn %Server{id: id} ->
+      assert id == server.id
+      :ok
+    end)
+
+    expect(Sentry, :capture_message, fn "Kura deploy failed", opts ->
+      assert opts[:level] == :error
+      extra = opts[:extra]
+      assert extra.deployment_id == deployment.id
+      assert extra.server_id == server.id
+      assert extra.region == server.region
+      assert extra.reason == "apply failed"
+      :ignored
+    end)
+
     assert :ok = Reconciler.reconcile()
 
     assert %Deployment{status: :failed, error_message: "apply failed"} = Repo.get!(Deployment, deployment.id)
-    assert %Server{status: :failed} = Repo.get!(Server, server.id)
+    assert %Server{status: :destroyed, url: nil} = Repo.get!(Server, server.id)
+  end
+
+  test "resets a first-time-deploy server and reports to Sentry when the cluster is unreachable" do
+    {_account, server, deployment} = create_server()
+
+    expect(Provisioner, :current_image_tag, fn %Server{id: id} ->
+      assert id == server.id
+      {:error, "missing Kubernetes kubeconfig for Kura cluster us-east-1"}
+    end)
+
+    expect(Provisioner, :destroy, fn %Server{id: id} ->
+      assert id == server.id
+      {:error, "missing Kubernetes kubeconfig for Kura cluster us-east-1"}
+    end)
+
+    expect(Sentry, :capture_message, fn "Kura deploy failed", opts ->
+      assert opts[:level] == :error
+      assert opts[:extra].reason == "missing Kubernetes kubeconfig for Kura cluster us-east-1"
+      :ignored
+    end)
+
+    assert :ok = Reconciler.reconcile()
+
+    assert %Deployment{
+             status: :failed,
+             error_message: "missing Kubernetes kubeconfig for Kura cluster us-east-1"
+           } = Repo.get!(Deployment, deployment.id)
+
+    assert %Server{status: :destroyed} = Repo.get!(Server, server.id)
+  end
+
+  test "keeps an active server at :failed (not :destroyed) when a drift rollout fails" do
+    {_account, server, deployment} = create_server()
+    {:ok, server} = Kura.activate_server(server, deployment.image_tag)
+    mark_deployment_succeeded(deployment)
+
+    stub(Tuist.Environment, :kura_runtime_image_tag, fn -> "sha-abcdef123456" end)
+
+    expect(Provisioner, :current_image_tag, fn %Server{id: id} ->
+      assert id == server.id
+      {:ok, "0.5.2"}
+    end)
+
+    expect(Provisioner, :rollout, fn %Server{id: id}, _inputs ->
+      assert id == server.id
+      {:error, "apply failed"}
+    end)
+
+    expect(Sentry, :capture_message, fn "Kura deploy failed", _opts -> :ignored end)
+
+    assert :ok = Reconciler.reconcile()
+
+    drift_deployment = Repo.get_by!(Deployment, kura_server_id: server.id, image_tag: "sha-abcdef123456")
+    assert drift_deployment.status == :failed
+    assert %Server{status: :failed, url: url, current_image_tag: "0.5.2"} = Repo.get!(Server, server.id)
+    assert is_binary(url)
   end
 
   defp create_server do

--- a/server/test/tuist/kura/server_test.exs
+++ b/server/test/tuist/kura/server_test.exs
@@ -191,9 +191,9 @@ defmodule Tuist.Kura.ServerTest do
         {:active, :failed},
         {:active, :destroying},
         {:failed, :failed},
+        {:failed, :provisioning},
         {:failed, :active},
         {:failed, :destroying},
-        {:failed, :destroyed},
         {:destroying, :destroying},
         {:destroying, :destroyed},
         {:destroyed, :destroyed}
@@ -212,7 +212,7 @@ defmodule Tuist.Kura.ServerTest do
         {:provisioning, :destroyed},
         {:active, :provisioning},
         {:active, :destroyed},
-        {:failed, :provisioning},
+        {:failed, :destroyed},
         {:destroying, :active},
         {:destroyed, :active}
       ]

--- a/server/test/tuist/kura/server_test.exs
+++ b/server/test/tuist/kura/server_test.exs
@@ -187,6 +187,7 @@ defmodule Tuist.Kura.ServerTest do
         {:provisioning, :active},
         {:provisioning, :failed},
         {:provisioning, :destroying},
+        {:provisioning, :destroyed},
         {:active, :active},
         {:active, :failed},
         {:active, :destroying},
@@ -208,7 +209,6 @@ defmodule Tuist.Kura.ServerTest do
 
     test "rejects skipped and terminal status transitions" do
       transitions = [
-        {:provisioning, :destroyed},
         {:active, :provisioning},
         {:failed, :provisioning},
         {:destroying, :active},

--- a/server/test/tuist/kura/server_test.exs
+++ b/server/test/tuist/kura/server_test.exs
@@ -187,13 +187,13 @@ defmodule Tuist.Kura.ServerTest do
         {:provisioning, :active},
         {:provisioning, :failed},
         {:provisioning, :destroying},
-        {:provisioning, :destroyed},
         {:active, :active},
         {:active, :failed},
         {:active, :destroying},
         {:failed, :failed},
         {:failed, :active},
         {:failed, :destroying},
+        {:failed, :destroyed},
         {:destroying, :destroying},
         {:destroying, :destroyed},
         {:destroyed, :destroyed}
@@ -209,7 +209,9 @@ defmodule Tuist.Kura.ServerTest do
 
     test "rejects skipped and terminal status transitions" do
       transitions = [
+        {:provisioning, :destroyed},
         {:active, :provisioning},
+        {:active, :destroyed},
         {:failed, :provisioning},
         {:destroying, :active},
         {:destroyed, :active}

--- a/server/test/tuist/kura_test.exs
+++ b/server/test/tuist/kura_test.exs
@@ -447,51 +447,36 @@ defmodule Tuist.KuraTest do
     end
   end
 
-  describe "reset_server/1" do
-    test "marks a never-active server destroyed and best-effort destroys the backing resource" do
+  describe "retry_server/2" do
+    test "tombstones the failed row and creates a fresh server in the same region" do
       user = AccountsFixtures.user_fixture()
       account = Accounts.get_account_from_user(user)
 
-      {:ok, server} =
+      {:ok, failed} =
         Kura.create_server(%{
           account_id: account.id,
           region: "local-controller",
           image_tag: "0.5.2"
         })
 
-      expect(Provisioner, :destroy, fn %Server{id: id} ->
-        assert id == server.id
-        :ok
-      end)
+      {:ok, failed} = Kura.fail_server(failed)
 
-      assert {:ok, %Server{status: :destroyed, url: nil}} = Kura.reset_server(server)
-      assert %Server{status: :destroyed} = Repo.get!(Server, server.id)
-      assert Accounts.list_account_cache_endpoints(account, :kura) == []
+      assert {:ok, %Server{status: :provisioning, region: "local-controller"} = new_server} =
+               Kura.retry_server(failed, "0.5.3")
+
+      refute new_server.id == failed.id
+      assert %Server{status: :destroyed} = Repo.get!(Server, failed.id)
+
+      new_server = Repo.preload(new_server, :deployments)
+      assert [%Deployment{status: :pending, image_tag: "0.5.3"}] = new_server.deployments
     end
 
-    test "still marks the server destroyed when the backing destroy fails" do
-      user = AccountsFixtures.user_fixture()
-      account = Accounts.get_account_from_user(user)
-
-      {:ok, server} =
-        Kura.create_server(%{
-          account_id: account.id,
-          region: "local-controller",
-          image_tag: "0.5.2"
-        })
-
-      expect(Provisioner, :destroy, fn %Server{} -> {:error, "kubeconfig missing"} end)
-
-      assert {:ok, %Server{status: :destroyed}} = Kura.reset_server(server)
-      assert %Server{status: :destroyed} = Repo.get!(Server, server.id)
-    end
-
-    test "broadcasts a :destroyed event" do
+    test "broadcasts :destroyed for the old row and :created for the new one" do
       user = AccountsFixtures.user_fixture()
       account = Accounts.get_account_from_user(user)
       :ok = Kura.subscribe_to_account(account.id)
 
-      {:ok, server} =
+      {:ok, failed} =
         Kura.create_server(%{
           account_id: account.id,
           region: "local-controller",
@@ -500,11 +485,43 @@ defmodule Tuist.KuraTest do
 
       assert_receive {:kura_server, :created, _}
 
-      stub(Provisioner, :destroy, fn _server -> :ok end)
-
-      {:ok, _} = Kura.reset_server(server)
+      {:ok, failed} = Kura.fail_server(failed)
+      {:ok, _new_server} = Kura.retry_server(failed, "0.5.3")
 
       assert_receive {:kura_server, :destroyed, %{status: :destroyed}}
+      assert_receive {:kura_server, :created, %{status: :provisioning}}
+    end
+
+    test "refuses to retry a previously-active server" do
+      user = AccountsFixtures.user_fixture()
+      account = Accounts.get_account_from_user(user)
+
+      {:ok, server} =
+        Kura.create_server(%{
+          account_id: account.id,
+          region: "local-controller",
+          image_tag: "0.5.2"
+        })
+
+      {:ok, server} = Kura.activate_server(server, "0.5.2")
+      {:ok, server} = Kura.fail_server(server)
+
+      assert {:error, :not_retryable} = Kura.retry_server(server, "0.5.3")
+      assert %Server{status: :failed, current_image_tag: "0.5.2"} = Repo.get!(Server, server.id)
+    end
+
+    test "refuses to retry a server that's not in :failed state" do
+      user = AccountsFixtures.user_fixture()
+      account = Accounts.get_account_from_user(user)
+
+      {:ok, server} =
+        Kura.create_server(%{
+          account_id: account.id,
+          region: "local-controller",
+          image_tag: "0.5.2"
+        })
+
+      assert {:error, :not_retryable} = Kura.retry_server(server, "0.5.3")
     end
   end
 

--- a/server/test/tuist/kura_test.exs
+++ b/server/test/tuist/kura_test.exs
@@ -448,35 +448,39 @@ defmodule Tuist.KuraTest do
   end
 
   describe "retry_server/2" do
-    test "tombstones the failed row and creates a fresh server in the same region" do
+    test "flips the failed row back to :provisioning and appends a new deployment" do
       user = AccountsFixtures.user_fixture()
       account = Accounts.get_account_from_user(user)
 
-      {:ok, failed} =
+      {:ok, server} =
         Kura.create_server(%{
           account_id: account.id,
           region: "local-controller",
           image_tag: "0.5.2"
         })
 
-      {:ok, failed} = Kura.fail_server(failed)
+      {:ok, failed} = Kura.fail_server(server)
 
-      assert {:ok, %Server{status: :provisioning, region: "local-controller"} = new_server} =
+      assert {:ok, %Server{id: id, status: :provisioning, region: "local-controller"} = retried} =
                Kura.retry_server(failed, "0.5.3")
 
-      refute new_server.id == failed.id
-      assert %Server{status: :destroyed} = Repo.get!(Server, failed.id)
+      assert id == server.id
+      assert %Server{status: :provisioning} = Repo.get!(Server, server.id)
 
-      new_server = Repo.preload(new_server, :deployments)
-      assert [%Deployment{status: :pending, image_tag: "0.5.3"}] = new_server.deployments
+      image_tags =
+        retried.deployments
+        |> Enum.map(& &1.image_tag)
+        |> Enum.sort()
+
+      assert image_tags == ["0.5.2", "0.5.3"]
     end
 
-    test "broadcasts :destroyed for the old row and :created for the new one" do
+    test "broadcasts :updated for the retried row" do
       user = AccountsFixtures.user_fixture()
       account = Accounts.get_account_from_user(user)
       :ok = Kura.subscribe_to_account(account.id)
 
-      {:ok, failed} =
+      {:ok, server} =
         Kura.create_server(%{
           account_id: account.id,
           region: "local-controller",
@@ -485,11 +489,11 @@ defmodule Tuist.KuraTest do
 
       assert_receive {:kura_server, :created, _}
 
-      {:ok, failed} = Kura.fail_server(failed)
-      {:ok, _new_server} = Kura.retry_server(failed, "0.5.3")
+      {:ok, failed} = Kura.fail_server(server)
+      {:ok, _retried} = Kura.retry_server(failed, "0.5.3")
 
-      assert_receive {:kura_server, :destroyed, %{status: :destroyed}}
-      assert_receive {:kura_server, :created, %{status: :provisioning}}
+      assert_receive {:kura_server, :updated, %{id: id, status: :provisioning}}
+      assert id == server.id
     end
 
     test "refuses to retry a previously-active server" do

--- a/server/test/tuist/kura_test.exs
+++ b/server/test/tuist/kura_test.exs
@@ -447,6 +447,67 @@ defmodule Tuist.KuraTest do
     end
   end
 
+  describe "reset_server/1" do
+    test "marks a never-active server destroyed and best-effort destroys the backing resource" do
+      user = AccountsFixtures.user_fixture()
+      account = Accounts.get_account_from_user(user)
+
+      {:ok, server} =
+        Kura.create_server(%{
+          account_id: account.id,
+          region: "local-controller",
+          image_tag: "0.5.2"
+        })
+
+      expect(Provisioner, :destroy, fn %Server{id: id} ->
+        assert id == server.id
+        :ok
+      end)
+
+      assert {:ok, %Server{status: :destroyed, url: nil}} = Kura.reset_server(server)
+      assert %Server{status: :destroyed} = Repo.get!(Server, server.id)
+      assert Accounts.list_account_cache_endpoints(account, :kura) == []
+    end
+
+    test "still marks the server destroyed when the backing destroy fails" do
+      user = AccountsFixtures.user_fixture()
+      account = Accounts.get_account_from_user(user)
+
+      {:ok, server} =
+        Kura.create_server(%{
+          account_id: account.id,
+          region: "local-controller",
+          image_tag: "0.5.2"
+        })
+
+      expect(Provisioner, :destroy, fn %Server{} -> {:error, "kubeconfig missing"} end)
+
+      assert {:ok, %Server{status: :destroyed}} = Kura.reset_server(server)
+      assert %Server{status: :destroyed} = Repo.get!(Server, server.id)
+    end
+
+    test "broadcasts a :destroyed event" do
+      user = AccountsFixtures.user_fixture()
+      account = Accounts.get_account_from_user(user)
+      :ok = Kura.subscribe_to_account(account.id)
+
+      {:ok, server} =
+        Kura.create_server(%{
+          account_id: account.id,
+          region: "local-controller",
+          image_tag: "0.5.2"
+        })
+
+      assert_receive {:kura_server, :created, _}
+
+      stub(Provisioner, :destroy, fn _server -> :ok end)
+
+      {:ok, _} = Kura.reset_server(server)
+
+      assert_receive {:kura_server, :destroyed, %{status: :destroyed}}
+    end
+  end
+
   describe "subscribe_to_account/1" do
     test "broadcasts created/updated/destroyed events to the account topic" do
       user = AccountsFixtures.user_fixture()


### PR DESCRIPTION
Triggered by a production Kura deploy stuck in "Deploying" forever after the operator clicked Deploy in account settings. The KuraInstance had been written to the regional cluster fine; the kura-controller couldn't create the StatefulSet because cert-manager wasn't installed in that cluster; the Tuist server reconciler silently swallowed the resulting hot loop. Two fixes follow.

## What changed

**Reconciler observability.** `Tuist.Kura.Reconciler` previously logged any non-`:not_found` `current_image_tag` error as a warning and returned `:ok`, so the deployment stayed `:running` and the server stayed `:provisioning` indefinitely with no Sentry signal. It now captures the failure to Sentry (region, account, server, deployment, image_tag, reason) and forks on server state:

- `:provisioning` (first-time deploy, no traffic on the endpoint) → `Kura.reset_server/1` flips the row to `:destroyed`, UI shows "Not deployed", operator can redeploy.
- Already-`:active` (drift rollout failure) → `Kura.fail_server/1`, existing cache endpoint keeps serving the old image.

Adds a `:provisioning → :destroyed` transition and a new `Kura.reset_server/1` helper that best-effort destroys any backing resource before flipping the row.

**Platform install automation.** [`infra/helm/platform`](infra/helm/platform/) (cert-manager + ClusterIssuer, ingress-nginx, external-dns, ESO) was installed only as step 7 of `mise run k8s:bootstrap-workload`, a one-time-per-cluster operation. When that step was missed on a regional Kura cluster, the kura-controller's reconcile errored on `cert-manager.io/v1 Certificate` and never created the StatefulSet, so `KuraInstance.status.observedImage` stayed empty. The platform install is now a standalone idempotent mise task ([`k8s:install-platform`](infra/mise/tasks/k8s/install-platform.sh)) that the production deploy workflow runs for every regional Kura cluster before installing the kura-controller. Single-pass on already-bootstrapped clusters, two-pass on fresh ones so the cert-manager CRD lands before our ClusterIssuer. `bootstrap-workload.sh` step 7 collapses to a single call to the same task.

## Reviewer notes

- The deploy workflow's new `op read "op://Founders/cloudflare-tuist-dns/credential"` is the first time the workflow's `OP_SERVICE_ACCOUNT_TOKEN` touches the `Founders` vault. If that SA's scope doesn't include it, the first production deploy will fail loudly at the `op read`. Fix is either to extend the SA's vault list or move the `cloudflare-tuist-dns` item into a vault the SA already reads. One-time, not a recurring action.
- The change deliberately keeps observe-error retries from being silent. A transient network blip during an in-progress first-time deploy would now reset the server to "Not deployed" instead of looping. The hot loop is worse for UX and observability, and the user just clicks Deploy again.
- `KuraInstance` reconcile in the existing us-east-1 cluster will resolve itself on the next production deploy: `k8s:install-platform` lands cert-manager, the controller (already running) creates the StatefulSet on its next retry, `status.observedImage` populates, the Tuist reconciler's next tick activates the server.

## How to test locally

```bash
# Unit tests for the reconciler + Kura context.
cd server
mise exec -- mix test test/tuist/kura/server_test.exs \
  test/tuist/kura/reconciler_test.exs \
  test/tuist/kura_test.exs

# Mise task is discovered.
cd ../infra && mise tasks | grep install-platform

# Shell syntax (covered by bash -n).
bash -n infra/mise/tasks/k8s/install-platform.sh
bash -n infra/mise/tasks/k8s/bootstrap-workload.sh
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)