### PR TITLE
fix(server): use request origin for MCP OAuth metadata

### DIFF
--- a/server/lib/tuist_web/controllers/well_known_controller.ex
+++ b/server/lib/tuist_web/controllers/well_known_controller.ex
@@ -93,7 +93,7 @@ defmodule TuistWeb.WellKnownController do
   Returns OAuth Authorization Server metadata.
   """
   def oauth_authorization_server(conn, _params) do
-    issuer = Environment.app_url()
+    issuer = RequestOrigin.from_conn(conn)
 
     configuration = %{
       issuer: issuer,

--- a/server/test/tuist_web/controllers/well_known_controller_test.exs
+++ b/server/test/tuist_web/controllers/well_known_controller_test.exs
@@ -186,17 +186,31 @@ defmodule TuistWeb.WellKnownControllerTest do
 
   describe "GET /.well-known/oauth-authorization-server" do
     test "returns OAuth authorization server metadata", %{conn: conn} do
-      stub(Environment, :app_url, fn -> "https://test.tuist.dev" end)
-
       conn = get(conn, "/.well-known/oauth-authorization-server")
 
       response = json_response(conn, 200)
 
-      assert response["issuer"] == "https://test.tuist.dev"
-      assert response["authorization_endpoint"] == "https://test.tuist.dev/oauth2/authorize"
-      assert response["token_endpoint"] == "https://test.tuist.dev/oauth2/token"
-      assert response["registration_endpoint"] == "https://test.tuist.dev/oauth2/register"
+      assert response["issuer"] == "http://www.example.com"
+      assert response["authorization_endpoint"] == "http://www.example.com/oauth2/authorize"
+      assert response["token_endpoint"] == "http://www.example.com/oauth2/token"
+      assert response["registration_endpoint"] == "http://www.example.com/oauth2/register"
       assert response["scopes_supported"] == ["mcp"]
+    end
+
+    test "uses forwarded request origin for OAuth authorization server metadata", %{conn: conn} do
+      conn =
+        conn
+        |> put_req_header("x-forwarded-proto", "https")
+        |> put_req_header("x-forwarded-host", "self-hosted.example.com")
+        |> put_req_header("x-forwarded-port", "443")
+        |> get("/.well-known/oauth-authorization-server")
+
+      response = json_response(conn, 200)
+
+      assert response["issuer"] == "https://self-hosted.example.com"
+      assert response["authorization_endpoint"] == "https://self-hosted.example.com/oauth2/authorize"
+      assert response["token_endpoint"] == "https://self-hosted.example.com/oauth2/token"
+      assert response["registration_endpoint"] == "https://self-hosted.example.com/oauth2/register"
     end
   end
 


### PR DESCRIPTION
## Summary
- Use the incoming request origin for OAuth authorization server metadata instead of the globally configured application URL.
- Keep `/.well-known/oauth-authorization-server` consistent with `/.well-known/oauth-protected-resource`, which already derives metadata from the request origin.
- Add coverage for reverse-proxy forwarded headers using generic example-domain data.

## Problem
Self-hosted Tuist instances can sit behind a reverse proxy and be reached through a different public host than the default Tuist-hosted domain. MCP clients discover OAuth metadata from `/.well-known/oauth-authorization-server`; when that metadata is built from the configured app URL instead of the request origin, clients can be sent to the wrong issuer and authorization endpoints.

## Solution
`WellKnownController.oauth_authorization_server/2` now uses `RequestOrigin.from_conn(conn)`. That helper respects `x-forwarded-proto`, `x-forwarded-host`, and `x-forwarded-port`, so the issuer, authorization endpoint, token endpoint, and registration endpoint match the origin used by the MCP client.

## Behavior
For a request forwarded as `https://self-hosted.example.com`, the OAuth authorization server metadata now returns:

- `issuer`: `https://self-hosted.example.com`
- `authorization_endpoint`: `https://self-hosted.example.com/oauth2/authorize`
- `token_endpoint`: `https://self-hosted.example.com/oauth2/token`
- `registration_endpoint`: `https://self-hosted.example.com/oauth2/register`

## Testing
- `mix test test/tuist_web/controllers/well_known_controller_test.exs`