### PR TITLE
fix(cli): deduplicate conditioned xcframework search paths

### DIFF
--- a/cli/Sources/TuistKit/Mappers/Graph/StaticXCFrameworkModuleMapGraphMapper.swift
+++ b/cli/Sources/TuistKit/Mappers/Graph/StaticXCFrameworkModuleMapGraphMapper.swift
@@ -288,49 +288,53 @@ extension SettingsDictionary {
         }
     }
 
-    /// There are scenarios when the combined settings introduce duplicates for these setting keys.
-    /// We don't know how to reproduce – either in a reproducible sample or via unit tests.
-    /// This is also why the `removeOtherSwiftFlagsDuplicates` is `internal` instead of `fileprivate`, so we can at least test the
+    /// Combining target settings can introduce duplicates when a graph reaches the same dependency through multiple paths.
+    /// This is also why the `removeOtherSwiftFlagsDuplicates` is `internal` instead of `fileprivate`, so we can test the
     /// method itself in isolation.
     fileprivate func removeDuplicates() -> SettingsDictionary {
         removeDuplicates(for: "FRAMEWORK_SEARCH_PATHS")
             .removeDuplicates(for: "HEADER_SEARCH_PATHS")
             .removeDuplicates(for: "OTHER_C_FLAGS")
+            .removeDuplicates(forConditionedKey: "FRAMEWORK_SEARCH_PATHS")
+            .removeDuplicates(forConditionedKey: "HEADER_SEARCH_PATHS")
+            .removeDuplicates(forConditionedKey: "OTHER_C_FLAGS")
             .removeOtherSwiftFlagsDuplicates()
     }
 
     func removeOtherSwiftFlagsDuplicates() -> SettingsDictionary {
-        let key = "OTHER_SWIFT_FLAGS"
         var settings = self
-        guard let value = settings[key] else { return settings }
-        switch value {
-        case let .string(value):
-            settings[key] = .string(value)
-        case let .array(value):
-            var seen = Set<String>()
-            let value = value.enumerated().filter {
-                if $0.element.isFlagWithArgument {
-                    if value.endIndex > $0.offset + 1 {
-                        return !seen.contains($0.element + value[$0.offset + 1])
-                    } else {
-                        return true
-                    }
-                } else {
-                    if $0.offset == 0 {
-                        return seen.insert($0.element).inserted
-                    } else {
-                        let previousElement = value[$0.offset - 1]
-                        if previousElement.isFlagWithArgument {
-                            return seen.insert(previousElement + $0.element).inserted
+        let keys = settings.keys.filter { $0 == "OTHER_SWIFT_FLAGS" || $0.hasPrefix("OTHER_SWIFT_FLAGS[") }
+        for key in keys {
+            guard let value = settings[key] else { continue }
+            switch value {
+            case let .string(value):
+                settings[key] = .string(value)
+            case let .array(value):
+                var seen = Set<String>()
+                let value = value.enumerated().filter {
+                    if $0.element.isFlagWithArgument {
+                        if value.endIndex > $0.offset + 1 {
+                            return !seen.contains($0.element + value[$0.offset + 1])
                         } else {
+                            return true
+                        }
+                    } else {
+                        if $0.offset == 0 {
                             return seen.insert($0.element).inserted
+                        } else {
+                            let previousElement = value[$0.offset - 1]
+                            if previousElement.isFlagWithArgument {
+                                return seen.insert(previousElement + $0.element).inserted
+                            } else {
+                                return seen.insert($0.element).inserted
+                            }
                         }
                     }
                 }
+                settings[key] = .array(
+                    value.map(\.element)
+                )
             }
-            settings[key] = .array(
-                value.map(\.element)
-            )
         }
         return settings
     }
@@ -347,6 +351,28 @@ extension SettingsDictionary {
             )
         }
         return settings
+    }
+
+    fileprivate func removeDuplicates(forConditionedKey key: String) -> SettingsDictionary {
+        var settings = self
+        let conditionedKeys = settings.keys.filter { $0.hasPrefix("\(key)[") }
+        for conditionedKey in conditionedKeys {
+            guard let value = settings[conditionedKey] else { continue }
+            switch value {
+            case let .string(value):
+                settings[conditionedKey] = .string(value)
+            case let .array(value):
+                settings[conditionedKey] = .array(value.uniquedPreservingOrder())
+            }
+        }
+        return settings
+    }
+}
+
+extension [String] {
+    fileprivate func uniquedPreservingOrder() -> [String] {
+        var seen = Set<String>()
+        return filter { seen.insert($0).inserted }
     }
 }
 

--- a/cli/Tests/TuistKitTests/Mappers/Graph/StaticXCFrameworkModuleMapGraphMapperTests.swift
+++ b/cli/Tests/TuistKitTests/Mappers/Graph/StaticXCFrameworkModuleMapGraphMapperTests.swift
@@ -379,6 +379,122 @@ final class StaticXCFrameworkModuleMapGraphMapperTests: TuistUnitTestCase {
         XCTAssertEmpty(gotSideEffects)
     }
 
+    func test_map_when_static_swift_xcframework_is_reached_through_multiple_paths_deduplicates_search_paths(
+    ) async throws {
+        // Given
+        let projectPath = try temporaryPath()
+            .appending(component: "Project")
+        given(manifestFilesLocator)
+            .locatePackageManifest(at: .any)
+            .willReturn(
+                projectPath.appending(components: Constants.tuistDirectoryName, Constants.SwiftPackageManager.packageSwiftName)
+            )
+
+        let dynamicXCFrameworkPath = projectPath
+            .parentDirectory
+            .appending(component: "DynamicFramework.xcframework")
+        let staticSwiftXCFrameworkPath = projectPath
+            .parentDirectory
+            .appending(component: "StaticSwift.xcframework")
+        let dynamicXCFramework: GraphDependency = .testXCFramework(
+            path: dynamicXCFrameworkPath,
+            linking: .dynamic
+        )
+        let staticSwiftXCFramework: GraphDependency = .testXCFramework(
+            path: staticSwiftXCFrameworkPath,
+            infoPlist: .test(
+                libraries: [
+                    .test(
+                        identifier: "ios-arm64",
+                        path: try RelativePath(validating: "StaticSwift.framework/StaticSwift")
+                    ),
+                ]
+            ),
+            linking: .static,
+            swiftModules: [
+                staticSwiftXCFrameworkPath.appending(
+                    components: "ios-arm64",
+                    "StaticSwift.framework",
+                    "Modules",
+                    "StaticSwift.swiftmodule"
+                ),
+            ]
+        )
+
+        let graph: Graph = .test(
+            name: "App",
+            path: projectPath,
+            projects: [
+                projectPath: .test(
+                    path: projectPath,
+                    targets: [
+                        .test(
+                            name: "App"
+                        ),
+                        .test(
+                            name: "Feature"
+                        ),
+                        .test(
+                            name: "Leaf"
+                        ),
+                    ]
+                ),
+            ],
+            dependencies: [
+                .target(name: "App", path: projectPath): [
+                    .target(name: "Feature", path: projectPath),
+                    .target(name: "Leaf", path: projectPath),
+                ],
+                .target(name: "Feature", path: projectPath): [
+                    .target(name: "Leaf", path: projectPath),
+                ],
+                .target(name: "Leaf", path: projectPath): [
+                    dynamicXCFramework,
+                ],
+                dynamicXCFramework: [
+                    staticSwiftXCFramework,
+                ],
+            ]
+        )
+
+        let expectedSettings: SettingsDictionary = [
+            "FRAMEWORK_SEARCH_PATHS[sdk=iphoneos*]": [
+                "$(inherited)",
+                "\"$(SRCROOT)/../StaticSwift.xcframework/ios-arm64\"",
+            ],
+        ]
+        var expectedGraph = graph
+        expectedGraph.projects = [
+            projectPath: .test(
+                path: projectPath,
+                targets: [
+                    .test(
+                        name: "App",
+                        settings: .test(base: expectedSettings)
+                    ),
+                    .test(
+                        name: "Feature",
+                        settings: .test(base: expectedSettings)
+                    ),
+                    .test(
+                        name: "Leaf",
+                        settings: .test(base: expectedSettings)
+                    ),
+                ]
+            ),
+        ]
+
+        // When
+        let (gotGraph, gotSideEffects, _) = try await subject.map(graph: graph, environment: MapperEnvironment())
+
+        // Then
+        XCTAssertBetterEqual(
+            expectedGraph,
+            gotGraph
+        )
+        XCTAssertEmpty(gotSideEffects)
+    }
+
     func test_map_when_static_xcframework_without_umbrella_header_linked_via_dynamic_xcframework() async throws {
         // Given
         let projectPath = try temporaryPath()
@@ -1525,6 +1641,39 @@ final class StaticXCFrameworkModuleMapGraphMapperTests: TuistUnitTestCase {
                         "-enable-upcoming-feature", "NonfrozenEnumExhaustivity",
                         "-enable-experimental-feature", "StrictConcurrency",
                         "-enable-experimental-feature", "TypedThrows",
+                    ]
+                ),
+            ]
+        )
+    }
+
+    func test_removeOtherSwiftDuplicates_when_conditioned_key() {
+        // Given
+        let settings: SettingsDictionary = [
+            "OTHER_SWIFT_FLAGS[sdk=iphoneos*]": .array(
+                [
+                    "-Xcc", "value-one",
+                    "-Xcc", "value-one",
+                    "-enable-upcoming-feature", "DeprecateApplicationMain",
+                    "-enable-upcoming-feature", "DeprecateApplicationMain",
+                    "value-two",
+                    "value-two",
+                ]
+            ),
+        ]
+
+        // When
+        let got = settings.removeOtherSwiftFlagsDuplicates()
+
+        // Then
+        XCTAssertEqual(
+            got,
+            [
+                "OTHER_SWIFT_FLAGS[sdk=iphoneos*]": .array(
+                    [
+                        "-Xcc", "value-one",
+                        "-enable-upcoming-feature", "DeprecateApplicationMain",
+                        "value-two",
                     ]
                 ),
             ]


### PR DESCRIPTION
## Summary

- Deduplicate SDK-conditioned search path settings when static XCFramework settings are combined through multiple dependency paths.
- Apply `OTHER_SWIFT_FLAGS` duplicate removal to SDK-conditioned variants too.
- Add a regression test for a diamond-shaped graph that reaches the same static Swift XCFramework behind a dynamic XCFramework through multiple paths.

## Investigation

The customer confirmed `4.192.3` works and `4.192.4` crashes, which points to #10704. That change started routing static Swift XCFrameworks behind dynamic XCFrameworks through SDK-conditioned `FRAMEWORK_SEARCH_PATHS[...]`. The existing duplicate cleanup only handled unconditioned keys, so large graphs could repeatedly accumulate the same conditioned settings while propagating through multiple paths.

## E2E / TDD testing

- E2E regression window: the customer reproduced the crash on `4.192.4` and confirmed the same workflow succeeds on `4.192.3`, which isolates the regression to the release that introduced #10704.
- TDD red step: restored the old mapper behavior locally while keeping the new regression test, then confirmed the test fails with duplicated `FRAMEWORK_SEARCH_PATHS[sdk=iphoneos*]` entries.
- TDD green step: restored this fix and confirmed the same regression test passes.
- `xcodebuild build-for-testing -quiet -workspace Tuist.xcworkspace -scheme Tuist-Workspace -destination platform=macOS,arch=arm64 -only-testing:TuistKitTests/StaticXCFrameworkModuleMapGraphMapperTests/test_map_when_static_swift_xcframework_is_reached_through_multiple_paths_deduplicates_search_paths CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" COMPILATION_CACHE_ENABLE_CACHING=NO`
- Direct XCTest run: `StaticXCFrameworkModuleMapGraphMapperTests`, 16 tests, 0 failures.

Note: normal `xcodebuild test`/`xcsiftbuild test` began hitting an `IDEPseudoTerminalDomain` launcher error in this local Codex environment, so I used `build-for-testing` plus direct `xctest` for the final red/green signal.
