### PR TITLE
ci(runner-image): drop on.push trigger, keep workflow_dispatch only

### DIFF
--- a/.github/workflows/runner-image.yml
+++ b/.github/workflows/runner-image.yml
@@ -1,25 +1,26 @@
 name: Runner Image
 
-# Builds the Tart VM image hosted on the customer-runner Mac mini
-# fleet. Pushes to ghcr.io/tuist/tuist-runner:<git-sha>.
+# On-demand build of the Tart VM image hosted on the customer-runner
+# Mac mini fleet. Invoke via `gh workflow run runner-image.yml --ref
+# <branch>` when probing image contents or smoke-testing a Packer
+# change before merging.
+#
+# The push-on-main flow lives in release.yml's release-runner-image
+# job — that's the path that produces digest-pinned tags and rewrites
+# the runnersFleet.runnerImage value in the chart. This workflow's
+# `:<git-sha>` tag is dispatch-only and not consumed by the chart.
 #
 # Runs on the same self-hosted bare-metal Mac mini as the
 # xcresult-processor image — Tart needs a live GUI session for
 # Virtualization.framework, so this can't run on hosted runners.
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - infra/runner-image/**
-      - .github/workflows/runner-image.yml
   workflow_dispatch:
     inputs:
       base_image:
         description: "Base Tart image"
         required: false
-        default: "ghcr.io/cirruslabs/macos-tahoe-xcode:26.4"
+        default: "ghcr.io/cirruslabs/macos-tahoe-xcode:26.4.1"
       runner_version:
         description: "GitHub Actions runner version"
         required: false


### PR DESCRIPTION
> Every main merge touching `infra/runner-image/**` was running the Packer build twice on the same bare-metal Mac mini — once here, once inside `release.yml`'s `release-runner-image` job — competing for the only image-builder slot and stretching wall-clock through the cancel-in-progress thrash we've been hitting on the runner-image release loop.

## Why

Looked at what consumes this workflow's output and what the `workflow_dispatch` path actually gets used for:

- **Nothing in the repo references `tuist-runner:<git-sha>`** outside the workflow itself. The chart pins `runnersFleet.runnerImage` to `@sha256:…`, and that digest is produced exclusively by `release.yml`'s `release-runner-image` job (which also pushes the semver tag + `:latest` and rewrites the helm pin).
- **Staging's lingering `:08e66c9b` short-tag pin** is a one-off legacy reference; the release flow's `Bump runner image digest pin in chart values` step normalizes it back to a digest on the next runner-image release. So even that doesn't actually consume this workflow's output.
- **`workflow_dispatch` invocation history**: one invocation in months (today's Xcode-path probe). The other entries in `gh run list --workflow=runner-image.yml` are all `push` runs — the duplication this PR removes.

So the workflow is doing nothing useful on push, but the `workflow_dispatch` capability is a real (if rarely-used) escape hatch for probing image contents or smoke-testing a Packer change against a branch before merging — which is what we used it for today to discover that Cirrus' `:26.4.1` image ships Xcode at `/Applications/Xcode_26.4.app` rather than the expected `Xcode_26.4.1.app`.

## What changes

- Remove the `on.push` block entirely.
- Keep `workflow_dispatch` (with its `base_image` / `runner_version` inputs) so the smoke-test path stays available.
- Update the header comment to explain the new shape (dispatch-only, with a pointer at `release.yml`'s `release-runner-image` as the actual production path).
- Bump the dispatch-input default for `base_image` from `:26.4` to `:26.4.1` to match the Packer template's current default.

## How to test locally

- [ ] After merge, push a `fix(runner-image): …` commit to a branch and merge to main: only one Packer build should fire on the bare-metal Mac mini (the `Release runner image` job inside `release.yml`'s push-on-main run). The standalone "Runner Image" workflow should not fire.
- [ ] `gh workflow run runner-image.yml --ref some-branch` should still queue and run the standalone build (smoke-test path preserved).