### PR TITLE
fix(runner-image): publish #10807's LaunchAgent rebuild through release pipeline

### DIFF
--- a/infra/runner-image/dispatch-poll.sh
+++ b/infra/runner-image/dispatch-poll.sh
@@ -13,7 +13,9 @@
 #   POST <url> with header `Authorization: Bearer <sa_token>`
 #     200 with body { encoded_jit_config: "...", pool: "...", owner: "..." }
 #       -> exec ./run.sh --jitconfig <jit> --disableupdate
+#     204  -> no work yet, keep polling
 #     401  -> auth failed, abort (the SA was likely GCed already)
+#     403  -> server-side authz refused the SA, abort
 #     5xx  -> transient; sleep + retry
 #
 # Once the runner exits, the EXIT trap halts the VM. tart-kubelet


### PR DESCRIPTION
> #10807 merged with `feat(infra)` scope, so the runner-image cliff config didn't match and `release-runner-image` was skipped — same scope mismatch trap as #10797 → #10800. The new LaunchAgent runner image content is on main but hasn't been built or pinned in the chart. Trigger the release path now with a properly-scoped commit.

## Why

The release pipeline's `runner-image-should-release` step uses [`infra/runner-image/cliff.toml`](infra/runner-image/cliff.toml), whose `commit_parsers` only match commits **scoped to `runner-image`**:

```toml
{ message = "^feat\\([^)]*\\brunner-image\\b[^)]*\\)", group = "..." },
...
{ message = "^[a-z]+\\([^)]+\\)", skip = true },
```

#10807's merge commit is `feat(infra): switch runner image to LaunchAgent + autologin (#10807)`. The scope is `infra`, the catch-all skips it, git-cliff computes no bump, and the release-runner-image job in release.yml run 25921905146 was marked `skipped`. Production is still pulling the previous digest (`@sha256:0c8f84b31bba…`), which is the LaunchDaemon-as-root model — so the `Setup Tuist` step that's currently failing on PR #10793 with `Bootstrap failed: 125: Domain does not support specified action` will keep failing until the LaunchAgent image is actually published.

## What changed

A genuine doc improvement in [`infra/runner-image/dispatch-poll.sh`](infra/runner-image/dispatch-poll.sh): the top-of-file `Server contract` comment listed `200`, `401`, and `5xx` but didn't mention `204` or `403`, which the case statement handles identically to their cousins. Spelling them out keeps the reader from having to scan the case block to see the full response shape.

The commit is small on purpose — same shape as #10800 was for #10797. The work that actually matters happened in #10807; this PR's job is to pass the cliff filter so the release pipeline acts on it.

## How to test locally

- [ ] `git cliff --include-path "infra/runner-image/**/*" --config infra/runner-image/cliff.toml --bumped-version -- runner-image@0.1.2..HEAD` should print `runner-image@0.1.3` (or whatever git-cliff picks).
- [ ] On merge, `release.yml`'s `Release runner image` should run cleanly through the credential-isolation + Packer build path we just got working (#10801, #10814). New digest gets pinned across the three managed-env values files.
- [ ] After the auto-bump PR lands and a server deploy rolls, recycle stale Pending Pods (manually, until #10817 lands) and retrigger the lint job on PR #10793. The `Setup Tuist` step should now succeed because the LaunchAgent runs in a real `gui/501` session that `launchctl bootstrap gui/501` can target.