### PR TITLE
fix(server): drop :finch from SSRF-pinned Req calls

### DIFF
--- a/server/lib/tuist/github/app.ex
+++ b/server/lib/tuist/github/app.ex
@@ -142,8 +142,7 @@ defmodule Tuist.GitHub.App do
       req_opts =
         [
           url: pinned_url,
-          headers: headers,
-          finch: Tuist.Finch
+          headers: headers
         ] ++ ssrf_opts ++ Retry.retry_options()
 
       case Req.post(req_opts) do
@@ -165,7 +164,11 @@ defmodule Tuist.GitHub.App do
 
   # Skip SSRF pinning for the canonical github.com REST host; pin every
   # GHES instance, since their hostnames are user-controlled.
-  defp pin_for_request(url, "https://api.github.com"), do: {:ok, url, []}
+  #
+  # github.com uses the shared `Tuist.Finch` pool. GHES uses Req's default
+  # pool because the per-host `:connect_options` (SNI / cert hostname) are
+  # mutually exclusive with a user-supplied `:finch` pool.
+  defp pin_for_request(url, "https://api.github.com"), do: {:ok, url, [finch: Tuist.Finch]}
 
   defp pin_for_request(url, _api_url) do
     case SSRFGuard.pin(url) do

--- a/server/lib/tuist/github/client.ex
+++ b/server/lib/tuist/github/client.ex
@@ -35,8 +35,7 @@ defmodule Tuist.GitHub.Client do
       req_opts =
         [
           url: request_url,
-          headers: default_headers(token),
-          finch: Tuist.Finch
+          headers: default_headers(token)
         ] ++ ssrf_opts ++ Retry.retry_options()
 
       case Req.get(req_opts) do
@@ -222,7 +221,6 @@ defmodule Tuist.GitHub.Client do
           {"Accept", "application/vnd.github.v3+json"},
           {"Authorization", "token #{token}"}
         ])
-        |> Keyword.put(:finch, Tuist.Finch)
         |> Keyword.merge(ssrf_opts)
         |> Keyword.merge(Retry.retry_options())
         |> Keyword.delete(:installation)
@@ -374,8 +372,7 @@ defmodule Tuist.GitHub.Client do
         [
           url: request_url,
           json: body,
-          headers: default_headers(token),
-          finch: Tuist.Finch
+          headers: default_headers(token)
         ] ++ ssrf_opts ++ Retry.retry_options()
 
       case Req.post(req_opts) do
@@ -396,7 +393,11 @@ defmodule Tuist.GitHub.Client do
 
   # Pin GHES URLs to a public IP to defend against DNS rebinding /
   # SSRF; github.com is treated as a known public host and skips the pin.
-  defp pin_ghes_url(url, "https://api.github.com"), do: {:ok, url, []}
+  #
+  # github.com uses the shared `Tuist.Finch` pool. GHES uses Req's default
+  # pool because the per-host `:connect_options` (SNI / cert hostname) are
+  # mutually exclusive with a user-supplied `:finch` pool.
+  defp pin_ghes_url(url, "https://api.github.com"), do: {:ok, url, [finch: Tuist.Finch]}
 
   defp pin_ghes_url(url, _api_url) do
     case SSRFGuard.pin(url) do

--- a/server/lib/tuist_web/controllers/github_app_manifest_controller.ex
+++ b/server/lib/tuist_web/controllers/github_app_manifest_controller.ex
@@ -256,6 +256,12 @@ defmodule TuistWeb.GitHubAppManifestController do
     # `body: ""` forces a `Content-Length: 0` header. GitHub Enterprise
     # Server rejects this POST with HTTP 411 otherwise; github.com's API
     # tolerates the missing header.
+    #
+    # No `finch:` here: Req refuses `:finch` alongside `:connect_options`
+    # because a user-supplied Finch pool's connect options are frozen at
+    # boot and can't be overridden per-request. The SSRF-pinned call needs
+    # per-request TLS settings (SNI / cert hostname) for the customer's
+    # GHES host, so Req's default pool is the only option.
     case Req.post(
            url: pinned_url,
            body: "",
@@ -265,7 +271,6 @@ defmodule TuistWeb.GitHubAppManifestController do
              {"User-Agent", "Tuist"},
              {"X-GitHub-Api-Version", "2022-11-28"}
            ],
-           finch: Tuist.Finch,
            connect_options: SSRFGuard.connect_options(hostname)
          ) do
       {:ok, %Req.Response{status: status, body: %{"id" => _} = body}} when status in 200..299 ->

--- a/server/test/tuist_web/controllers/github_app_manifest_controller_test.exs
+++ b/server/test/tuist_web/controllers/github_app_manifest_controller_test.exs
@@ -118,7 +118,13 @@ defmodule TuistWeb.GitHubAppManifestControllerTest do
         # emits the header when an explicit body is passed, so guard the
         # call shape here.
         assert Keyword.fetch!(opts, :body) == ""
-        assert Keyword.fetch!(opts, :finch) == Tuist.Finch
+
+        # Req refuses `:finch` alongside `:connect_options` because the
+        # named pool's connect options are frozen at boot. The manifest
+        # exchange must carry per-GHES TLS settings via `:connect_options`,
+        # so it has to use Req's default pool.
+        refute Keyword.has_key?(opts, :finch)
+        assert Keyword.fetch!(opts, :connect_options) == [hostname: "github.example.com"]
 
         assert Keyword.fetch!(opts, :headers) == [
                  {"Accept", "application/vnd.github+json"},


### PR DESCRIPTION
## Summary

- The GHES manifest exchange has been crashing in production with `ArgumentError: cannot set both :finch and :connect_options` ([Sentry TUIST-FH](https://tuist.sentry.io/issues/TUIST-FH)). Req refuses that combination at request time because a user-supplied Finch pool's connect options are frozen at boot and can't be overridden per-request.
- The same latent crash exists on every other GHES-pinned path in `Tuist.GitHub.App` and `Tuist.GitHub.Client` — every GHES installation-token refresh, every GHES API call, and the GHES JIT-config call would have hit it the moment they tried.
- Moves `finch: Tuist.Finch` into the github.com branch of each pin function so the two return tuples are mutually exclusive at the source. The github.com path keeps using the shared pool; the GHES path uses Req's default pool because per-host `:connect_options` (SNI / cert hostname) can only flow through it.
- The manifest controller test was asserting the exact shape that crashes in production because `Req.post` was fully mocked and never executed Req's option validator. Flipped to `refute :finch` + assert `:connect_options` so the contract is documented in the test.

## Test plan

- [x] `mix test test/tuist_web/controllers/github_app_manifest_controller_test.exs` (15/15)
- [x] `mix test test/tuist/github/app_test.exs test/tuist/github/client_test.exs` (30/30)
- [x] `mix credo` clean on changed files
- [ ] Manual GHES manifest exchange against Bumble's instance once deployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)