### PR TITLE
fix(infra): read Cloudflare DNS token from CI-accessible vault

### DIFF
--- a/.github/workflows/server-deployment.yml
+++ b/.github/workflows/server-deployment.yml
@@ -449,9 +449,6 @@ jobs:
 
           # Cloudflare DNS-01 token for cert-manager. Resolved here once
           # so the install-platform script can stay credential-agnostic.
-          # The CI service account (OP_SERVICE_ACCOUNT_TOKEN) is scoped to
-          # per-env vaults, not Founders — mirror the same item used by
-          # operators locally into tuist-k8s-production.
           CLOUDFLARE_API_TOKEN="$(op read "op://tuist-k8s-production/cloudflare-tuist-dns/credential")"
           export CLOUDFLARE_API_TOKEN
 

--- a/.github/workflows/server-deployment.yml
+++ b/.github/workflows/server-deployment.yml
@@ -449,7 +449,10 @@ jobs:
 
           # Cloudflare DNS-01 token for cert-manager. Resolved here once
           # so the install-platform script can stay credential-agnostic.
-          CLOUDFLARE_API_TOKEN="$(op read "op://Founders/cloudflare-tuist-dns/credential")"
+          # The CI service account (OP_SERVICE_ACCOUNT_TOKEN) is scoped to
+          # per-env vaults, not Founders — mirror the same item used by
+          # operators locally into tuist-k8s-production.
+          CLOUDFLARE_API_TOKEN="$(op read "op://tuist-k8s-production/cloudflare-tuist-dns/credential")"
           export CLOUDFLARE_API_TOKEN
 
           for region in us-east-1 us-west-1; do


### PR DESCRIPTION
## Summary

- Production deploy [#25920779005](https://github.com/tuist/tuist/actions/runs/25920779005/job/76198171826) failed with `could not get item Founders/cloudflare-tuist-dns: "Founders" isn't a vault in this account`.
- The `OP_SERVICE_ACCOUNT_TOKEN` used by CI is scoped to per-env vaults (`tuist-k8s-production`, etc.), not the `Founders` vault that operators use locally.
- This step already reads the regional kubeconfig docs from `tuist-k8s-production` on the next line — point the Cloudflare token at the same vault.

**One-time setup before merging**: copy the `cloudflare-tuist-dns` item from `Founders` into the `tuist-k8s-production` 1Password vault (same `credential` field). The local fallback in [infra/mise/tasks/k8s/install-platform.sh](infra/mise/tasks/k8s/install-platform.sh) still reads from `Founders` via the operator's personal account, so local invocations keep working.

## Test plan

- [ ] Mirror the `cloudflare-tuist-dns` item into `tuist-k8s-production`
- [ ] Re-run the production deploy workflow on `main` post-merge and confirm the `Deploy Kura regional controllers` step gets past the `op read`

🤖 Generated with [Claude Code](https://claude.com/claude-code)