### PR TITLE
fix(infra): widen platform install helm timeout for cold regional clusters

### DIFF
--- a/infra/mise/tasks/k8s/install-platform.sh
+++ b/infra/mise/tasks/k8s/install-platform.sh
@@ -59,6 +59,13 @@ HELM_SET_ARGS=(
   --set "ingress-nginx.controller.service.annotations.load-balancer\.hetzner\.cloud/name=${CLUSTER_NAME}-ingress"
 )
 
+# Sized for a cold cluster: ingress-nginx ships a pre-install admission
+# Job whose image pull + cert generation, combined with the Hetzner LB
+# provision for the controller Service, can take several minutes. 15m
+# absorbs that with headroom; steady-state runs finish in under a
+# minute and exit as soon as helm finds nothing to roll out.
+HELM_TIMEOUT="15m"
+
 # First-install ordering: our ClusterIssuer template depends on the
 # cert-manager.io/v1 CRD that the cert-manager subchart ships. On a
 # cluster that already has the CRD, a single pass is enough. On a
@@ -71,7 +78,7 @@ if KUBECONFIG="$WL_KUBECONFIG" kubectl get crd clusterissuers.cert-manager.io >/
     --namespace platform \
     -f "$CHART_PATH/values-hetzner.yaml" \
     "${HELM_SET_ARGS[@]}" \
-    --wait --timeout 5m
+    --wait --timeout "$HELM_TIMEOUT"
 else
   log "ClusterIssuer CRD missing; running two-pass install"
   KUBECONFIG="$WL_KUBECONFIG" helm upgrade --install platform "$CHART_PATH" \
@@ -79,7 +86,7 @@ else
     -f "$CHART_PATH/values-hetzner.yaml" \
     --set "clusterIssuer.enabled=false" \
     "${HELM_SET_ARGS[@]}" \
-    --wait --timeout 5m
+    --wait --timeout "$HELM_TIMEOUT"
 
   KUBECONFIG="$WL_KUBECONFIG" kubectl wait \
     --for=condition=Established crd/clusterissuers.cert-manager.io --timeout=2m
@@ -88,5 +95,5 @@ else
     --namespace platform \
     -f "$CHART_PATH/values-hetzner.yaml" \
     "${HELM_SET_ARGS[@]}" \
-    --wait --timeout 5m
+    --wait --timeout "$HELM_TIMEOUT"
 fi


### PR DESCRIPTION
## Summary
- Production deploy's *Deploy Kura regional controllers* step failed at `helm pre-install: resource Job/platform/platform-ingress-nginx-admission-create not ready. status: InProgress` ([run 25924801846](https://github.com/tuist/tuist/actions/runs/25924801846/job/76208043607)). The 5m `helm --wait` budget expired while the ingress-nginx admission Job was still running on a regional cluster.
- Bump the `k8s:install-platform` helm timeout to 15m so a cold regional cluster has room to image-pull cert-manager / ingress-nginx / external-dns / external-secrets, run the ingress-nginx admission Job, and provision the Hetzner LB for the controller Service. Steady-state runs still exit in well under a minute as soon as helm has nothing to roll out.

## Test plan
- [ ] Re-run production deploy and confirm the regional controller step completes within the new budget.