### PR TITLE
ci(infra): drop xcresult-processor-image on.push trigger, keep workflow_dispatch only

### DIFF
--- a/.github/workflows/xcresult-processor-image.yml
+++ b/.github/workflows/xcresult-processor-image.yml
@@ -1,7 +1,16 @@
 name: Xcresult Processor Image
 
-# Builds the Tart VM image that hosts the Tuist xcresult processor on macOS.
-# Pushes to ghcr.io/tuist/tuist-xcresult-processor:<git-sha> + :latest.
+# On-demand build of the Tart VM image that hosts the Tuist xcresult
+# processor on macOS. Invoke via `gh workflow run
+# xcresult-processor-image.yml --ref <branch>` when probing image
+# contents or smoke-testing a Packer change before merging.
+#
+# The push-on-main flow lives in release.yml's
+# release-xcresult-processor job — that's the path that produces
+# versioned tags (`:<version>` + `:latest`) and rewrites the
+# xcresultProcessor image tag in `values-managed-common.yaml`. This
+# workflow's `:<git-sha>` tag is dispatch-only and not consumed by
+# the chart.
 #
 # Two stages on the same self-hosted bare-metal Mac mini (the same
 # vm-image-builder host #10264 introduces — Tart needs a live GUI session
@@ -11,16 +20,6 @@ name: Xcresult Processor Image
 #   2. Bake the tarball into a Tart image via Packer + push to GHCR.
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - server/lib/**
-      - server/native/xcresult_nif/**
-      - server/mix.exs
-      - server/mix.lock
-      - infra/xcresult-processor-image/**
-      - .github/workflows/xcresult-processor-image.yml
   workflow_dispatch:
     inputs:
       base_image:


### PR DESCRIPTION
Same shape as #10815 (runner-image trim).

## Why

The on-push job pushes `:<git-sha>` for "ad-hoc deploys" — but nothing in the chart consumes that tag. Versioned tags + `:latest` are owned by [release.yml](.github/workflows/release.yml)'s `release-xcresult-processor` job, which also rewrites the image tag in `values-managed-common.yaml`. So every push to main touching `server/lib/**`, `server/native/xcresult_nif/**`, `server/mix.exs`, `server/mix.lock`, `infra/xcresult-processor-image/**`, or this workflow file burns the bare-metal Mac mini for ~30–60 min producing an image nothing pulls.

The path overlap with `server/lib/**` in particular means almost every server PR merge triggers this.

## What

- Drop the `on.push` block.
- Keep `workflow_dispatch` so an operator can still produce a SHA-tagged ad-hoc build when probing changes pre-merge (`gh workflow run xcresult-processor-image.yml --ref <branch>`).
- Header comment rewritten to point at the release-pipeline path that owns versioned tags + chart rewrites.

## How to test

- [ ] Confirm the next push to main touching `server/lib/**` no longer triggers this workflow.
- [ ] `gh workflow run xcresult-processor-image.yml --ref main` still works for ad-hoc dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)