### PR TITLE
refactor(runners-controller, runner-image): release on path, not commit scope

### DIFF
--- a/infra/runner-image/cliff.toml
+++ b/infra/runner-image/cliff.toml
@@ -62,21 +62,25 @@ split_commits = false
 commit_preprocessors = [
     { pattern = '\((\w+\s)?#([0-9]+)\)', replace = "" },
 ]
-# Match commits scoped to runner-image. Component covers the Tart
-# VM image hosting the customer-facing GitHub Actions runners
-# (Packer template, dispatch-poll script, launchd plist, env
-# injector). Distinct from xcresult-processor-image, which bakes
-# in the server release.
+# Type-only parsers, path filtering via `--include-path
+# "infra/runner-image/**/*"` in release.yml. Any conventional-commit
+# touching the runner-image path triggers a bump regardless of the
+# commit's scope tag — a `feat(infra):` PR that changes the Packer
+# template or dispatch-poll script still releases the image.
+# Component covers the Tart VM image hosting the customer-facing
+# GitHub Actions runners (Packer template, dispatch-poll script,
+# launchd plist, env injector). Distinct from xcresult-processor-
+# image, which bakes in the server release.
 commit_parsers = [
-    { message = "^feat\\([^)]*\\brunner-image\\b[^)]*\\)", group = "<!-- 0 -->⛰️  Features" },
-    { message = "^fix\\([^)]*\\brunner-image\\b[^)]*\\)", group = "<!-- 1 -->🐛 Bug Fixes" },
-    { message = "^docs?\\([^)]*\\brunner-image\\b[^)]*\\)", group = "<!-- 3 -->📚 Documentation" },
-    { message = "^perf\\([^)]*\\brunner-image\\b[^)]*\\)", group = "<!-- 4 -->⚡ Performance" },
-    { message = "^refactor\\([^)]*\\brunner-image\\b[^)]*\\)", group = "<!-- 2 -->🚜 Refactor" },
-    { message = "^style\\([^)]*\\brunner-image\\b[^)]*\\)", group = "<!-- 5 -->🎨 Styling" },
-    { message = "^test\\([^)]*\\brunner-image\\b[^)]*\\)", group = "<!-- 6 -->🧪 Testing" },
-    { message = "^chore\\([^)]*\\brunner-image\\b[^)]*\\)", skip = true },
-    { message = "^ci\\([^)]*\\brunner-image\\b[^)]*\\)", skip = true },
+    { message = "^feat(\\([^)]*\\))?", group = "<!-- 0 -->⛰️  Features" },
+    { message = "^fix(\\([^)]*\\))?", group = "<!-- 1 -->🐛 Bug Fixes" },
+    { message = "^docs?(\\([^)]*\\))?", group = "<!-- 3 -->📚 Documentation" },
+    { message = "^perf(\\([^)]*\\))?", group = "<!-- 4 -->⚡ Performance" },
+    { message = "^refactor(\\([^)]*\\))?", group = "<!-- 2 -->🚜 Refactor" },
+    { message = "^style(\\([^)]*\\))?", group = "<!-- 5 -->🎨 Styling" },
+    { message = "^test(\\([^)]*\\))?", group = "<!-- 6 -->🧪 Testing" },
+    { message = "^chore(\\([^)]*\\))?", skip = true },
+    { message = "^ci(\\([^)]*\\))?", skip = true },
     { message = "^[a-z]+\\([^)]+\\)", skip = true },
 ]
 protect_breaking_commits = false

--- a/infra/runners-controller/cliff.toml
+++ b/infra/runners-controller/cliff.toml
@@ -62,20 +62,22 @@ split_commits = false
 commit_preprocessors = [
     { pattern = '\((\w+\s)?#([0-9]+)\)', replace = "" },
 ]
-# Scoped to the runners-controller component. Both the controller's
-# own Go module and the runner-image (which carries the dispatch-poll
-# script the controller's Pods exec) bump together since a contract
-# change in one needs a matching change in the other.
+# Type-only parsers, path filtering via `--include-path
+# "infra/runners-controller/**/*"` in release.yml. Any conventional-
+# commit touching the controller path triggers a bump regardless of
+# the commit's scope tag — a `feat(infra):` PR that changes the Go
+# code still releases the controller image. Mirrors the
+# infra/xcresult-processor-image cliff.
 commit_parsers = [
-    { message = "^feat\\([^)]*\\brunners-controller\\b[^)]*\\)", group = "<!-- 0 -->⛰️  Features" },
-    { message = "^fix\\([^)]*\\brunners-controller\\b[^)]*\\)", group = "<!-- 1 -->🐛 Bug Fixes" },
-    { message = "^docs?\\([^)]*\\brunners-controller\\b[^)]*\\)", group = "<!-- 3 -->📚 Documentation" },
-    { message = "^perf\\([^)]*\\brunners-controller\\b[^)]*\\)", group = "<!-- 4 -->⚡ Performance" },
-    { message = "^refactor\\([^)]*\\brunners-controller\\b[^)]*\\)", group = "<!-- 2 -->🚜 Refactor" },
-    { message = "^style\\([^)]*\\brunners-controller\\b[^)]*\\)", group = "<!-- 5 -->🎨 Styling" },
-    { message = "^test\\([^)]*\\brunners-controller\\b[^)]*\\)", group = "<!-- 6 -->🧪 Testing" },
-    { message = "^chore\\([^)]*\\brunners-controller\\b[^)]*\\)", skip = true },
-    { message = "^ci\\([^)]*\\brunners-controller\\b[^)]*\\)", skip = true },
+    { message = "^feat(\\([^)]*\\))?", group = "<!-- 0 -->⛰️  Features" },
+    { message = "^fix(\\([^)]*\\))?", group = "<!-- 1 -->🐛 Bug Fixes" },
+    { message = "^docs?(\\([^)]*\\))?", group = "<!-- 3 -->📚 Documentation" },
+    { message = "^perf(\\([^)]*\\))?", group = "<!-- 4 -->⚡ Performance" },
+    { message = "^refactor(\\([^)]*\\))?", group = "<!-- 2 -->🚜 Refactor" },
+    { message = "^style(\\([^)]*\\))?", group = "<!-- 5 -->🎨 Styling" },
+    { message = "^test(\\([^)]*\\))?", group = "<!-- 6 -->🧪 Testing" },
+    { message = "^chore(\\([^)]*\\))?", skip = true },
+    { message = "^ci(\\([^)]*\\))?", skip = true },
     { message = "^[a-z]+\\([^)]+\\)", skip = true },
 ]
 protect_breaking_commits = false


### PR DESCRIPTION
## Why

The current scope-only `commit_parsers` in [infra/runners-controller/cliff.toml](infra/runners-controller/cliff.toml) and [infra/runner-image/cliff.toml](infra/runner-image/cliff.toml) refuse to bump unless the squashed PR title carries the literal `runners-controller` / `runner-image` scope.

[#10817](https://github.com/tuist/tuist/pull/10817) squashed as `feat(infra):`. The PR touched the controller's Go module AND the runner-image dispatch-poll script, but neither cliff recognised the scope and both component releases were skipped. After the deploy, the chart's `runnersController.image.tag` was still pinned to the pre-#10817 commit (\`sha-08e66c9bf0e2\`) and `status.imageRolledAt` was never written, defeating the staggered drain we'd just shipped.

The mismatch between "what's changed" and "what releases" is silent — it only surfaces when chart pins stay stale post-deploy.

## What

Switch both cliffs to type-only parsers. Path filtering is already provided by `--include-path "infra/runners-controller/**/*"` / `--include-path "infra/runner-image/**/*"` in [release.yml](.github/workflows/release.yml), so any conventional-commit touching the component path triggers a bump regardless of the commit's scope tag.

Mirrors the pattern [infra/xcresult-processor-image/cliff.toml](infra/xcresult-processor-image/cliff.toml) already uses.

## Side effect

This commit itself touches both component paths with a `refactor:` prefix, so the next release.yml run will release **both** controller and runner-image — picking up the controller code that landed via #10817 (ImageRolledAt recording, sibling-SA cleanup, staggered-drain reference) and producing a current chart pin.

## How to test

- [ ] Next release.yml run produces `runners-controller@<next>` AND a `runner-image@<next>` (or whatever is next in sequence — runner-image@0.1.3 is already in flight from #10818's release).
- [ ] Helm chart values bump for both `runnersController.image.tag` and `runnersFleet.runnerImage`.
- [ ] Future PRs touching `infra/runners-controller/**` or `infra/runner-image/**` without a literal scope tag still release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)