### PR TITLE
feat(runner-image, server): align self-hosted runner paths with GitHub-hosted

### DIFF
--- a/infra/runner-image/AGENTS.md
+++ b/infra/runner-image/AGENTS.md
@@ -7,31 +7,45 @@ runner.
 
 ## What's in the image
 
-- `/opt/actions-runner/` — GitHub Actions runner binary (no
-  registration; we register at runtime via JIT config minted by
-  `Tuist.Runners.Reconciler` / `Tuist.Runners.Dispatch`).
-- `/opt/tuist/inject-env.sh` — reads tart-kubelet's env mount
-  (`/Volumes/My Shared Files/env/tuist.env`) into `/etc/tuist.env`.
+The runtime user is `runner` with home `/Users/runner`, matching
+GitHub-hosted macOS runner images. On-disk artifacts that bake
+absolute paths (SwiftPM `.build/checkouts/`, Xcode DerivedData,
+`actions/cache` payloads) are interchangeable between hosted and
+self-hosted runs without per-environment cache keys.
+
+The Cirrus base image's pre-existing `admin` user is kept around
+as the Packer SSH provisioning identity but is not used at
+runtime — no service, sudo entry, or auto-login targets it.
+
+- `/Users/runner/actions-runner/` — GitHub Actions runner binary
+  (no registration; we register at runtime via JIT config minted
+  by `Tuist.Runners.Reconciler` / `Tuist.Runners.Dispatch`).
+- `/Users/runner/work/<owner>/<repo>` — workspace path the JIT
+  config sets via `work_folder: "/Users/runner/work"`; matches
+  GitHub-hosted's `GITHUB_WORKSPACE`.
+- `/opt/tuist/inject-env.sh` — root-owned helper; reads
+  tart-kubelet's env mount (`/Volumes/My Shared Files/env/tuist.env`)
+  into `/etc/tuist.env`.
 - `/opt/tuist/dispatch-poll.sh` — polls
   `TUIST_RUNNER_DISPATCH_URL?pod_uid=…&token=…`. While 204 it
-  sleeps; on 200 it runs `./run.sh --jitconfig $JIT`. Captures the
-  rc and `sudo shutdown -h now`s the VM via an `EXIT` trap so
+  sleeps; on 200 it runs `./run.sh --jitconfig $JIT`. Captures
+  the rc and `sudo shutdown -h now`s the VM via an `EXIT` trap so
   `tart run` returns and tart-kubelet flips the Pod to
   Succeeded — the watcher's GC + warm-pool refill are gated on
   that transition.
-- `/Users/admin/Library/LaunchAgents/dev.tuist.runner.plist` —
+- `/Users/runner/Library/LaunchAgents/dev.tuist.runner.plist` —
   the LaunchAgent that auto-runs `inject-env.sh` then
-  `dispatch-poll.sh` once admin's user session starts at boot.
+  `dispatch-poll.sh` once runner's user session starts at boot.
   Wraps the entrypoint in `zsh -lc` so `~/.zprofile` is sourced
   (Homebrew shellenv, rbenv init, LANG=en_US.UTF-8, PATH
   additions for the cirruslabs base's pre-installed tools), so
   step shells see the same environment an interactive SSH
   session on the same VM would.
-- `/etc/kcpassword` + `autoLoginUser=admin` — macOS auto-login
+- `/etc/kcpassword` + `autoLoginUser=runner` — macOS auto-login
   config so the desktop session exists at boot and loginwindow
   loads the LaunchAgent. Without this the VM boots to a login
   screen and the agent never starts.
-- `/etc/sudoers.d/admin-nopasswd` — passwordless sudo for the
+- `/etc/sudoers.d/runner-nopasswd` — passwordless sudo for the
   agent's privileged ops (installing /etc/tuist.env, halting the
   VM at job exit). Single-tenant ephemeral VM — the entire OS is
   the customer's job environment.
@@ -73,7 +87,7 @@ hosted runners.
 2. `Tuist.Runners.Reconciler` creates a Pod with this image as
    `spec.containers[0].image`; tart-kubelet on the target Mac
    mini calls `tart pull`/`tart clone`/`tart run`.
-3. The VM boots, auto-login brings up admin's desktop session,
+3. The VM boots, auto-login brings up runner's desktop session,
    loginwindow loads the LaunchAgent, and the agent's entrypoint
    runs `inject-env.sh` then `dispatch-poll.sh`. The dispatch
    script exchanges the projected SA token for a JIT config (200

--- a/infra/runner-image/dispatch-poll.sh
+++ b/infra/runner-image/dispatch-poll.sh
@@ -100,7 +100,7 @@ while true; do
         continue
       fi
       echo "$(date -u +%FT%TZ) dispatch-poll: dispatched, starting runner"
-      cd /opt/actions-runner
+      cd /Users/runner/actions-runner
       # `--jitconfig` implies ephemeral: the runner accepts one job
       # and exits. `--disableupdate` pins the runner to whatever
       # version is baked into the image; we bump that via Renovate

--- a/infra/runner-image/launchd.plist
+++ b/infra/runner-image/launchd.plist
@@ -9,10 +9,11 @@
        for a JIT config and execs ./run.sh on first 200.
 
   This is a LaunchAgent loaded from
-  /Users/admin/Library/LaunchAgents/. The Packer build configures
-  admin auto-login + passwordless sudo, so the VM boots into a
-  real desktop session for admin, loginwindow loads this agent,
-  and the agent process inherits the user session.
+  /Users/runner/Library/LaunchAgents/. The Packer build configures
+  runner auto-login + passwordless sudo, so the VM boots into a
+  real desktop session for the `runner` user (matching GitHub-
+  hosted's runtime account), loginwindow loads this agent, and
+  the agent process inherits the user session.
 
   Why an agent and not a daemon: LaunchDaemons start with a
   near-empty environment (no HOME, no PATH past launchd's
@@ -46,13 +47,13 @@
           inject-env.sh runs under sudo. tart-kubelet stages the
           shared env directory at /Volumes/My Shared Files/env/ as
           0700 root, with tuist.env / sa_token inside at 0600 root.
-          The agent runs as admin, so without elevation admin can't
-          even stat the directory: inject-env.sh's `[ ! -f ENV_SRC ]`
-          test returns true, the script exits 0 ("no env source"),
-          and dispatch-poll.sh boots with an empty /etc/tuist.env
-          (no TUIST_RUNNER_DISPATCH_URL, no SA token). Elevate only
-          the injector; dispatch-poll runs as admin so the GitHub
-          runner stays non-root.
+          The agent runs as the `runner` user, so without elevation
+          runner can't even stat the directory: inject-env.sh's
+          `[ ! -f ENV_SRC ]` test returns true, the script exits 0
+          ("no env source"), and dispatch-poll.sh boots with an
+          empty /etc/tuist.env (no TUIST_RUNNER_DISPATCH_URL, no
+          SA token). Elevate only the injector; dispatch-poll runs
+          as runner so the GitHub runner stays non-root.
         -->
         <string>sudo /opt/tuist/inject-env.sh &amp;&amp; source /etc/tuist.env &amp;&amp; exec /opt/tuist/dispatch-poll.sh</string>
     </array>
@@ -64,7 +65,7 @@
     <false/>
 
     <key>WorkingDirectory</key>
-    <string>/opt/actions-runner</string>
+    <string>/Users/runner/actions-runner</string>
 
     <key>StandardOutPath</key>
     <string>/var/log/tuist-runner/stdout.log</string>

--- a/infra/runner-image/runner.pkr.hcl
+++ b/infra/runner-image/runner.pkr.hcl
@@ -22,23 +22,37 @@ packer {
 #  4. Once the server returns 200 with `encoded_jit_config`, the
 #     script writes the JIT to a temp file and execs
 #     `./run.sh --jitconfig $JIT` against the GitHub Actions
-#     runner under /opt/actions-runner.
+#     runner under /Users/runner/actions-runner.
 #  5. The runner accepts a single queued job (JIT config implies
 #     ephemeral=true), runs the workflow, and exits.
 #  6. tart-kubelet observes the VM stop, transitions the Pod to
 #     Completed, and the next reconcile tick creates a fresh Pod.
 #
-# Image layout:
-#   /opt/actions-runner/        <- GitHub Actions runner binary
-#   /opt/tuist/dispatch-poll.sh <- the dispatch poll loop
-#   /opt/tuist/inject-env.sh    <- reads kubelet env mount → /etc/tuist.env
-#   /Library/LaunchDaemons/dev.tuist.runner.plist
+# Image layout (mirrors GitHub-hosted macOS paths so on-disk
+# artifacts that bake absolute paths — SwiftPM `.build/checkouts/`,
+# Xcode DerivedData, `actions/cache` payloads — work interchangeably
+# between hosted and self-hosted runs without per-environment cache
+# keys):
+#   /Users/runner/                              <- runtime user
+#   /Users/runner/actions-runner/               <- GitHub Actions runner binary
+#   /Users/runner/work/<owner>/<repo>           <- workspace, set via JIT work_folder
+#   /Users/runner/Library/LaunchAgents/         <- dev.tuist.runner.plist
+#   /opt/tuist/dispatch-poll.sh                 <- the dispatch poll loop (root-owned)
+#   /opt/tuist/inject-env.sh                    <- reads kubelet env mount → /etc/tuist.env
+#
+# The Cirrus base image ships with an `admin` user; we keep admin
+# around as Packer's SSH provisioning identity but create a
+# dedicated `runner` user as the runtime account, mirroring
+# `/Users/runner` on GitHub-hosted images. Auto-login + LaunchAgent
+# target runner, not admin.
 #
 # Note that the runner is registered with GitHub at *job* time,
 # not image-build time — the image carries the runner binary but
 # no credentials. The JIT config delivered via dispatch is the
 # only piece that authenticates this VM as a runner for any
-# specific repo.
+# specific repo. The matching `Tuist.Runners.mint_jit` call passes
+# `work_folder: "/Users/runner/work"` so the agent's workspace
+# lands at the same absolute path GitHub-hosted runners use.
 
 variable "base_image" {
   type        = string
@@ -110,10 +124,18 @@ source "tart-cli" "runner" {
 build {
   sources = ["source.tart-cli.runner"]
 
+  # Create the `runner` user (Cirrus base image ships with `admin`
+  # only). `-admin` adds the user to the admin GROUP, which is
+  # what `/etc/sudoers.d/%admin` and `inject-env.sh`'s `root:admin`
+  # file ownership reference. Password "runner" is encoded into
+  # /etc/kcpassword below so the auto-login flow can unlock the
+  # account at boot.
   provisioner "shell" {
     inline = [
-      "echo 'admin' | sudo -S mkdir -p /opt/actions-runner /opt/tuist /etc/tuist",
-      "echo 'admin' | sudo -S chown admin:staff /opt/actions-runner /opt/tuist"
+      "set -euo pipefail",
+      "echo 'admin' | sudo -S sysadminctl -addUser runner -fullName 'GitHub Actions Runner' -password runner -admin",
+      "echo 'admin' | sudo -S mkdir -p /opt/tuist /etc/tuist",
+      "echo 'admin' | sudo -S chown root:wheel /opt/tuist"
     ]
   }
 
@@ -139,13 +161,21 @@ build {
     ]
   }
 
+  # Install the Actions runner agent under runner's home so the
+  # binary, its `_diag` logs, and any side data it writes land
+  # under `/Users/runner/...` — matching GitHub-hosted's layout
+  # (their agent installs at `/Users/runner/runners/<version>/`).
+  # `--work` for the workspace is set at JIT-generation time
+  # (`work_folder: "/Users/runner/work"`), so the actual checkout
+  # ends up at the GH-parity path regardless of the agent's home.
   provisioner "shell" {
     inline = [
       "set -euo pipefail",
-      "cd /opt/actions-runner",
-      "curl -sSL -o actions-runner.tar.gz https://github.com/actions/runner/releases/download/v${var.runner_version}/actions-runner-osx-arm64-${var.runner_version}.tar.gz",
-      "tar xzf actions-runner.tar.gz",
-      "rm actions-runner.tar.gz",
+      "sudo -u runner mkdir -p /Users/runner/actions-runner /Users/runner/work",
+      "cd /Users/runner/actions-runner",
+      "sudo -u runner curl -sSL -o actions-runner.tar.gz https://github.com/actions/runner/releases/download/v${var.runner_version}/actions-runner-osx-arm64-${var.runner_version}.tar.gz",
+      "sudo -u runner tar xzf actions-runner.tar.gz",
+      "sudo -u runner rm actions-runner.tar.gz",
       # Sanity check: configure script exists. We don't run
       # ./config.sh — JIT config is provided at runtime.
       "test -x ./run.sh"
@@ -170,37 +200,38 @@ build {
     ]
   }
 
-  # Passwordless sudo for admin. The runner agent runs as admin in
-  # a real user session (LaunchAgent + auto-login), not as root, so
-  # the few privileged operations the agent needs — installing
-  # /etc/tuist.env from the kubelet env mount, halting the VM at
-  # job exit — go through sudo. Passwordless because the VM is
-  # ephemeral and single-tenant; the entire OS is the customer's
-  # job environment.
+  # Passwordless sudo for runner. The agent runs as the `runner`
+  # user in a real desktop session (LaunchAgent + auto-login),
+  # not as root, so the few privileged operations the agent needs
+  # — installing /etc/tuist.env from the kubelet env mount,
+  # halting the VM at job exit — go through sudo. Passwordless
+  # because the VM is ephemeral and single-tenant; the entire OS
+  # is the customer's job environment.
   provisioner "shell" {
     inline = [
       "set -euo pipefail",
-      "echo 'admin ALL=(ALL) NOPASSWD: ALL' > /tmp/admin-nopasswd",
-      "echo 'admin' | sudo -S install -m 0440 -o root -g wheel /tmp/admin-nopasswd /etc/sudoers.d/admin-nopasswd",
-      "rm -f /tmp/admin-nopasswd",
-      "sudo -n true"
+      "echo 'admin' | sudo -S sh -c 'echo \"runner ALL=(ALL) NOPASSWD: ALL\" > /etc/sudoers.d/runner-nopasswd'",
+      "echo 'admin' | sudo -S chmod 0440 /etc/sudoers.d/runner-nopasswd",
+      "echo 'admin' | sudo -S chown root:wheel /etc/sudoers.d/runner-nopasswd",
+      "sudo -u runner sudo -n true"
     ]
   }
 
-  # Auto-login as admin so a desktop session exists at boot and
-  # loginwindow loads /Users/admin/Library/LaunchAgents agents.
+  # Auto-login as runner so a desktop session exists at boot and
+  # loginwindow loads /Users/runner/Library/LaunchAgents agents.
   # macOS implements auto-login via /etc/kcpassword (XOR-encoded
   # password using Apple's well-known key) + the autoLoginUser
-  # preference. The encoded payload for password "admin":
-  # bytes 0x1c, 0xed, 0x3f, 0x4a, 0xbc, 0xbc, 0xdd, 0xea, 0xa3,
-  # 0xb9, 0x1f (admin XOR key, padded to one key-length block).
+  # preference. The encoded payload for password "runner" is the
+  # 6 password bytes followed by 6 zero-pad bytes, each XOR'd
+  # against the 12-byte Apple key — total 12 bytes (one full
+  # key-length block).
   provisioner "shell" {
     inline = [
       "set -euo pipefail",
-      "printf '\\x1c\\xed\\x3f\\x4a\\xbc\\xbc\\xdd\\xea\\xa3\\xb9\\x1f' > /tmp/kcpassword",
+      "printf '\\x0f\\xfc\\x3c\\x4d\\xb7\\xce\\xdd\\xea\\xa3\\xb9\\x1f\\xb5' > /tmp/kcpassword",
       "sudo install -m 0600 -o root -g wheel /tmp/kcpassword /etc/kcpassword",
       "rm -f /tmp/kcpassword",
-      "sudo defaults write /Library/Preferences/com.apple.loginwindow autoLoginUser admin"
+      "sudo defaults write /Library/Preferences/com.apple.loginwindow autoLoginUser runner"
     ]
   }
 
@@ -209,18 +240,18 @@ build {
     destination = "/tmp/dev.tuist.runner.plist"
   }
 
-  # Install as a LaunchAgent under admin's home so it loads inside
-  # admin's user session (auto-login above guarantees the session
-  # exists at boot). User-owned (admin:staff, 0644) per Apple's
-  # LaunchAgent ownership rules.
+  # Install as a LaunchAgent under runner's home so it loads
+  # inside runner's user session (auto-login above guarantees the
+  # session exists at boot). User-owned (runner:staff, 0644) per
+  # Apple's LaunchAgent ownership rules.
   provisioner "shell" {
     inline = [
       "set -euo pipefail",
-      "sudo -u admin mkdir -p /Users/admin/Library/LaunchAgents",
-      "sudo install -m 0644 -o admin -g staff /tmp/dev.tuist.runner.plist /Users/admin/Library/LaunchAgents/dev.tuist.runner.plist",
+      "sudo -u runner mkdir -p /Users/runner/Library/LaunchAgents",
+      "sudo install -m 0644 -o runner -g staff /tmp/dev.tuist.runner.plist /Users/runner/Library/LaunchAgents/dev.tuist.runner.plist",
       "rm -f /tmp/dev.tuist.runner.plist",
       "sudo mkdir -p /var/log/tuist-runner",
-      "sudo chown admin:staff /var/log/tuist-runner"
+      "sudo chown runner:staff /var/log/tuist-runner"
     ]
   }
 
@@ -236,7 +267,7 @@ build {
   provisioner "shell" {
     inline = [
       "set -euo pipefail",
-      "sudo -u admin /bin/zsh -lc 'for tool in brew mise tuist gh git-lfs jq yq swiftlint swiftformat xcbeautify fastlane pod carthage; do command -v \"$tool\" >/dev/null 2>&1 || { echo \"sanity check: $tool not reachable in admin login shell — base image regression\" >&2; exit 1; }; done'"
+      "sudo -u runner /bin/zsh -lc 'for tool in brew mise tuist gh git-lfs jq yq swiftlint swiftformat xcbeautify fastlane pod carthage; do command -v \"$tool\" >/dev/null 2>&1 || { echo \"sanity check: $tool not reachable in runner login shell — base image regression\" >&2; exit 1; }; done'"
     ]
   }
 }

--- a/server/lib/tuist/runners.ex
+++ b/server/lib/tuist/runners.ex
@@ -318,7 +318,14 @@ defmodule Tuist.Runners do
          {:ok, %{encoded_jit_config: jit, runner_name: runner_name}} <-
            GitHubClient.generate_jit_config(installation, account.name, %{
              name: runner_name,
-             labels: ["self-hosted", "macOS", "ARM64", dispatch_label]
+             labels: ["self-hosted", "macOS", "ARM64", dispatch_label],
+             # Match GitHub-hosted's workspace path so on-disk
+             # artifacts that bake absolute paths (SwiftPM
+             # `.build/checkouts/`, DerivedData, `actions/cache`
+             # payloads) work interchangeably between hosted and
+             # self-hosted runs. The runner image creates a `runner`
+             # user with home `/Users/runner` to match.
+             work_folder: "/Users/runner/work"
            }) do
       {:ok, jit, runner_name}
     else


### PR DESCRIPTION
## Why

The Cirrus base image's \`admin\` user (home \`/Users/admin\`, agent under \`/opt/actions-runner\`) was a self-hosted-only convention that diverged from GitHub-hosted's \`/Users/runner/work/<owner>/<repo>\` workspace path. Anything on disk that bakes absolute paths becomes incompatible between \`macos-26\` and \`tuist-macos\` runs:

- SwiftPM \`.build/checkouts/...\` (each cached \`Package.swift\` is referenced by absolute path)
- Xcode DerivedData (project paths)
- \`actions/cache\` payloads

The symptom on [#10793](https://github.com/tuist/tuist/pull/10793) was:

\`\`\`
✖ Error 
  Package.swift not found at path /Users/runner/work/tuist/tuist/server/native/xcactivitylog_nif
\`\`\`

A GitHub-hosted run had written that cache; the self-hosted Pod restored it against \`/opt/actions-runner/_work/...\` and Tuist's graph load died on the missing absolute path. The cache-key salt in #10793 segregates self-hosted from hosted caches, but doesn't eliminate the underlying friction — any third-party tool that hardcodes \`/Users/runner\` (some Actions do) still surprises customers, and hosted/self-hosted caches can never share artifacts.

## What

Make the self-hosted runner image structurally indistinguishable from GitHub-hosted for path purposes:

- **User**: create \`runner\` (home \`/Users/runner\`) via \`sysadminctl -addUser ... -admin\` in the Packer template. The base image's pre-existing \`admin\` user stays around as Packer's SSH provisioning identity but no runtime service references it.
- **Agent**: install at \`/Users/runner/actions-runner/\` (was \`/opt/actions-runner/\`).
- **Workspace**: \`Tuist.Runners.mint_jit\` now passes \`work_folder: "/Users/runner/work"\` in the JIT config, so each workflow_job checkout lands at \`/Users/runner/work/<owner>/<repo>\` — matching GitHub-hosted's \`GITHUB_WORKSPACE\`.
- **LaunchAgent**: moves to \`/Users/runner/Library/LaunchAgents/dev.tuist.runner.plist\`. WorkingDirectory updated, comments updated.
- **Auto-login**: \`/etc/kcpassword\` re-encoded for password \`runner\` (12-byte XOR'd payload against Apple's well-known key). \`autoLoginUser\` preference set to \`runner\`.
- **Passwordless sudo**: \`/etc/sudoers.d/runner-nopasswd\`.
- **dispatch-poll.sh**: \`cd /Users/runner/actions-runner\` before \`./run.sh\`.

## Result

After this PR + a runner-image release + the resulting chart bump:

- Self-hosted Pods check out customer code at \`/Users/runner/work/<owner>/<repo>\` — the same path GitHub-hosted runners use.
- \`actions/cache\` keyed on \`runner.os\` can be shared across hosted and self-hosted (the [#10793](https://github.com/tuist/tuist/pull/10793) \`runner.environment\` salt becomes unnecessary; can be reverted in a follow-up).
- Third-party Actions that assume \`/Users/runner\` paths just work.

## How to test

- [ ] \`mix test test/tuist/runners_test.exs\` clean.
- [ ] Next runner-image release builds + pushes a new digest; chart pin rolls.
- [ ] Following server deploy recycles warm Pods to the new image.
- [ ] On \`tuist-macos\`, \`cli-lint\` checkout lands at \`/Users/runner/work/tuist/tuist\` — verifiable via the SwiftLint output's absolute paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)