### PR TITLE
feat(cli): align Settings API surface, use ConfigurationName

### DIFF
--- a/cli/Sources/ProjectDescription/Settings.swift
+++ b/cli/Sources/ProjectDescription/Settings.swift
@@ -115,7 +115,7 @@ public struct Settings: Equatable, Codable, Sendable {
     public var base: SettingsDictionary
     public var configurations: [Configuration]
     public var defaultSettings: DefaultSettings
-    public var defaultConfiguration: String?
+    public var defaultConfiguration: ConfigurationName?
 
     /// Creates settings with default.configurations `Debug` and `Release`
     ///
@@ -137,7 +137,7 @@ public struct Settings: Equatable, Codable, Sendable {
         debug: SettingsDictionary = [:],
         release: SettingsDictionary = [:],
         defaultSettings: DefaultSettings = .recommended,
-        defaultConfiguration: String? = nil
+        defaultConfiguration: ConfigurationName? = nil
     ) -> Settings {
         Settings(
             base: base,
@@ -168,7 +168,7 @@ public struct Settings: Equatable, Codable, Sendable {
         base: SettingsDictionary = [:],
         configurations: [Configuration],
         defaultSettings: DefaultSettings = .recommended,
-        defaultConfiguration: String? = nil
+        defaultConfiguration: ConfigurationName? = nil
     ) -> Settings {
         Settings(
             base: base,

--- a/cli/Sources/TuistLoader/Models+ManifestMappers/Settings+ManifestMapper.swift
+++ b/cli/Sources/TuistLoader/Models+ManifestMappers/Settings+ManifestMapper.swift
@@ -22,7 +22,7 @@ extension XcodeGraph.Settings {
             base: base,
             configurations: configurations,
             defaultSettings: defaultSettings,
-            defaultConfiguration: manifest.defaultConfiguration
+            defaultConfiguration: manifest.defaultConfiguration?.rawValue
         )
     }
 }


### PR DESCRIPTION
### Summary 

This PR aligns the API surface of the `ProjectDescription.Settings` initialiser to accept `ConfigurationName` instead of `String` types. 

`ConfigurationName` is used consistently across the API surface of `ProjectDescription` but the `defaultSettings` init parameter was missing it. With this change consumers can rely on using a type safe API which does not necessarily rely on String type to the passed in the initialiser. 

No change to any other package was made and the mapping to `XcodeGraph` is then utilising the `rawValue` of the `ConfigurationName`, essentially the same as before. 

### How to test locally

Run the unit tests.

### Notes 

This should not have any breaking change impact on existing `defaultSettings` declaration since `ConfigurationName` conforms to `ExpressibleByStringLiteral`. 