### PR TITLE
fix(capi-scaleway, server): unstick orphaned running workflow_jobs end-to-end

### DIFF
--- a/infra/cluster-api-provider-scaleway-applesilicon/cliff.toml
+++ b/infra/cluster-api-provider-scaleway-applesilicon/cliff.toml
@@ -62,19 +62,24 @@ split_commits = false
 commit_preprocessors = [
     { pattern = '\((\w+\s)?#([0-9]+)\)', replace = "" },
 ]
-# Match commits scoped to capi-scaleway. The component spans three Go
-# modules (the operator itself, macos-host-bootstrap, tart-kubelet) but
-# they ship together in one operator image, so a single scope is enough.
+# Type-only parsers, path filtering via `--include-path` in
+# release.yml. Any conventional-commit touching the component path
+# triggers a bump regardless of the commit's scope tag — a
+# `fix(infra):` PR that changes bootstrap.go still releases the
+# operator image. Mirrors the runners-controller / runner-image /
+# xcresult-processor-image cliffs (#10824). The component spans
+# three Go modules (the operator itself, macos-host-bootstrap,
+# tart-kubelet); release.yml's `--include-path` covers all three.
 commit_parsers = [
-    { message = "^feat\\([^)]*\\bcapi-scaleway\\b[^)]*\\)", group = "<!-- 0 -->⛰️  Features" },
-    { message = "^fix\\([^)]*\\bcapi-scaleway\\b[^)]*\\)", group = "<!-- 1 -->🐛 Bug Fixes" },
-    { message = "^docs?\\([^)]*\\bcapi-scaleway\\b[^)]*\\)", group = "<!-- 3 -->📚 Documentation" },
-    { message = "^perf\\([^)]*\\bcapi-scaleway\\b[^)]*\\)", group = "<!-- 4 -->⚡ Performance" },
-    { message = "^refactor\\([^)]*\\bcapi-scaleway\\b[^)]*\\)", group = "<!-- 2 -->🚜 Refactor" },
-    { message = "^style\\([^)]*\\bcapi-scaleway\\b[^)]*\\)", group = "<!-- 5 -->🎨 Styling" },
-    { message = "^test\\([^)]*\\bcapi-scaleway\\b[^)]*\\)", group = "<!-- 6 -->🧪 Testing" },
-    { message = "^chore\\([^)]*\\bcapi-scaleway\\b[^)]*\\)", skip = true },
-    { message = "^ci\\([^)]*\\bcapi-scaleway\\b[^)]*\\)", skip = true },
+    { message = "^feat(\\([^)]*\\))?", group = "<!-- 0 -->⛰️  Features" },
+    { message = "^fix(\\([^)]*\\))?", group = "<!-- 1 -->🐛 Bug Fixes" },
+    { message = "^docs?(\\([^)]*\\))?", group = "<!-- 3 -->📚 Documentation" },
+    { message = "^perf(\\([^)]*\\))?", group = "<!-- 4 -->⚡ Performance" },
+    { message = "^refactor(\\([^)]*\\))?", group = "<!-- 2 -->🚜 Refactor" },
+    { message = "^style(\\([^)]*\\))?", group = "<!-- 5 -->🎨 Styling" },
+    { message = "^test(\\([^)]*\\))?", group = "<!-- 6 -->🧪 Testing" },
+    { message = "^chore(\\([^)]*\\))?", skip = true },
+    { message = "^ci(\\([^)]*\\))?", skip = true },
     { message = "^[a-z]+\\([^)]+\\)", skip = true },
 ]
 protect_breaking_commits = false

--- a/server/lib/tuist/github/client.ex
+++ b/server/lib/tuist/github/client.ex
@@ -388,6 +388,49 @@ defmodule Tuist.GitHub.Client do
     end
   end
 
+  @doc """
+  GETs a single `workflow_job` and returns the GitHub-side status
+  (`"queued"` / `"in_progress"` / `"completed"`). Used by
+  `OrphanedRunnersWorker` to detect rows we transitioned to
+  `running` locally but whose JIT was never consumed by an
+  actually-registered runner on the GH side — the GitHub view of
+  the job is the only authoritative signal for "did the Pod
+  successfully come up".
+
+  `repository_full_handle` is the standard `<owner>/<repo>` form
+  GitHub uses everywhere.
+
+  See: https://docs.github.com/en/rest/actions/workflow-jobs#get-a-job-for-a-workflow-run
+  """
+  def get_workflow_job(installation, repository_full_handle, workflow_job_id)
+      when is_binary(repository_full_handle) and is_integer(workflow_job_id) do
+    api_url = installation_api_url(installation)
+    url = "#{api_url}/repos/#{repository_full_handle}/actions/jobs/#{workflow_job_id}"
+
+    with {:ok, %{token: token}} <- App.get_installation_token(installation, api_url: api_url),
+         {:ok, request_url, ssrf_opts} <- pin_ghes_url(url, api_url) do
+      req_opts =
+        [
+          url: request_url,
+          headers: default_headers(token)
+        ] ++ ssrf_opts ++ Retry.retry_options()
+
+      case Req.get(req_opts) do
+        {:ok, %{status: 200, body: %{"status" => status} = job}} when is_binary(status) ->
+          {:ok, %{status: status, conclusion: Map.get(job, "conclusion"), runner_name: Map.get(job, "runner_name")}}
+
+        {:ok, %{status: 404}} ->
+          {:error, :not_found}
+
+        {:ok, %{status: status, body: body}} ->
+          {:error, {:http, status, body}}
+
+        {:error, reason} ->
+          {:error, {:transport, reason}}
+      end
+    end
+  end
+
   defp installation_api_url(%{client_url: client_url}), do: VCS.api_url(:github, client_url)
   defp installation_api_url(_), do: VCS.api_url(:github, nil)
 

--- a/server/lib/tuist/oban/runtime_config.ex
+++ b/server/lib/tuist/oban/runtime_config.ex
@@ -26,7 +26,8 @@ defmodule Tuist.Oban.RuntimeConfig do
     {"@daily", Tuist.Accounts.Workers.UpdateAllAccountsUsageWorker},
     {"@daily", Tuist.Billing.Workers.SyncStripeMetersWorker},
     {"* * * * *", Tuist.Kura.Reconciler},
-    {"* * * * *", Tuist.Runners.Workers.StaleClaimsWorker}
+    {"* * * * *", Tuist.Runners.Workers.StaleClaimsWorker},
+    {"* * * * *", Tuist.Runners.Workers.OrphanedRunnersWorker}
   ]
 
   @prod_like_envs [:prod, :stag, :can]

--- a/server/lib/tuist/runners/jobs.ex
+++ b/server/lib/tuist/runners/jobs.ex
@@ -244,6 +244,34 @@ defmodule Tuist.Runners.Jobs do
     |> Map.new()
   end
 
+  @doc """
+  Lists `runner_jobs` rows in `status = 'running'` whose
+  `started_at` is older than `threshold` — candidates for the
+  "Pod minted a JIT but the GitHub runner never registered"
+  recovery path. `OrphanedRunnersWorker` cross-checks each
+  candidate against GitHub's view of the workflow_job; if GH
+  still reports `queued`, the runner never came up and we
+  release + re-queue.
+
+  Returns a list of maps carrying everything the worker needs
+  (`repo` for the GH API call, `claimed_at` for the PG release
+  handle), so the worker doesn't need a second round trip.
+  """
+  def list_orphaned_running(%DateTime{} = threshold) do
+    Job
+    |> from(hints: ["FINAL"])
+    |> where([j], j.status == "running" and j.started_at < ^threshold)
+    |> select([j], %{
+      workflow_job_id: j.workflow_job_id,
+      account_id: j.account_id,
+      repo: j.repo,
+      claimed_at: j.claimed_at,
+      started_at: j.started_at,
+      pod_name: j.pod_name
+    })
+    |> ClickHouseRepo.all()
+  end
+
   # ----- internal -----
 
   # Fetch the merged current state of a workflow_job. The RMT

--- a/server/lib/tuist/runners/workers/orphaned_runners_worker.ex
+++ b/server/lib/tuist/runners/workers/orphaned_runners_worker.ex
@@ -137,10 +137,25 @@ defmodule Tuist.Runners.Workers.OrphanedRunnersWorker do
          pod_name: pod_name
        }) do
     with {:ok, account} <- Accounts.get_account_by_id(account_id),
-         {:ok, installation} <- VCS.get_github_app_installation_for_account(account.id),
-         {:ok, %{status: gh_status}} <-
-           GitHubClient.get_workflow_job(installation, repo, workflow_job_id) do
-      handle_gh_status(gh_status, workflow_job_id, claimed_at, pod_name, account)
+         {:ok, installation} <- VCS.get_github_app_installation_for_account(account.id) do
+      case GitHubClient.get_workflow_job(installation, repo, workflow_job_id) do
+        {:ok, %{status: gh_status, conclusion: conclusion}} ->
+          handle_gh_status(gh_status, conclusion, workflow_job_id, claimed_at, pod_name, account)
+
+        {:error, :not_found} ->
+          # GH pruned the workflow_job (90-day retention by default).
+          # The job can't be live; treat as completed so the PG cap
+          # slot doesn't leak forever.
+          handle_gh_status("completed", "", workflow_job_id, claimed_at, pod_name, account)
+
+        {:error, reason} ->
+          Logger.warning("runners: orphan worker GH lookup failed; will retry next tick",
+            workflow_job_id: workflow_job_id,
+            reason: inspect(reason)
+          )
+
+          false
+      end
     else
       {:error, :not_found} ->
         # Account row gone (rare). Leave the orphan; cap accounting
@@ -157,7 +172,7 @@ defmodule Tuist.Runners.Workers.OrphanedRunnersWorker do
     end
   end
 
-  defp handle_gh_status("queued", workflow_job_id, claimed_at, pod_name, account) do
+  defp handle_gh_status("queued", _conclusion, workflow_job_id, claimed_at, pod_name, account) do
     Logger.warning("runners: orphaned running row — GH still queued, recovering",
       workflow_job_id: workflow_job_id,
       account: account.name,
@@ -172,15 +187,39 @@ defmodule Tuist.Runners.Workers.OrphanedRunnersWorker do
     end
   end
 
-  defp handle_gh_status("in_progress", _wfid, _claimed_at, _pod, _account), do: false
+  defp handle_gh_status("in_progress", _conclusion, _wfid, _claimed_at, _pod, _account), do: false
 
-  defp handle_gh_status(other, workflow_job_id, _claimed_at, _pod, _account) do
-    # `completed` / `cancelled` / etc. — terminal state on GH but
-    # not handled here. The completed-webhook path is the right
-    # place to mark these locally.
-    Logger.debug("runners: orphan worker skipping terminal GH state",
+  defp handle_gh_status("completed", conclusion, workflow_job_id, _claimed_at, pod_name, account) do
+    # GH has a terminal status but we never saw the corresponding
+    # `workflow_job.completed` webhook (or it was retry-exhausted
+    # before reaching us). Without releasing here, the PG claim
+    # stays in `lifecycle_state='running'` forever — StaleClaimsWorker
+    # excludes `running`, and this worker would see the same row
+    # every minute. The GH lookup already proves the job is not
+    # live, so free the cap slot ourselves.
+    #
+    # PG-first matches the webhook path (`Tuist.Runners.Dispatch.mark_completed`):
+    # frees the slot the instant we know, CH state is best-effort
+    # customer visibility.
+    Logger.warning("runners: orphaned running row — GH completed, freeing claim",
       workflow_job_id: workflow_job_id,
-      gh_status: other
+      account: account.name,
+      pod: pod_name,
+      conclusion: conclusion || ""
+    )
+
+    safe_complete_pg(workflow_job_id)
+    safe_complete_ch(workflow_job_id, conclusion || "")
+    true
+  end
+
+  defp handle_gh_status(other, _conclusion, workflow_job_id, _claimed_at, _pod, _account) do
+    # Unknown / future GH status. Log and skip; if it's actually
+    # terminal we'll catch it on a later tick once GitHub-side
+    # state settles or the 404 fallback above handles retention.
+    Logger.debug("runners: orphan worker skipping unrecognised GH state",
+      workflow_job_id: workflow_job_id,
+      status: other
     )
 
     false
@@ -212,5 +251,40 @@ defmodule Tuist.Runners.Workers.OrphanedRunnersWorker do
         # our re-queue won't disturb it. Treat as a no-op.
         :error
     end
+  end
+
+  # `Claims.complete/1` is idempotent and deletes the PG row
+  # regardless of the claim handle. Used here because the GH-side
+  # job is already terminal — we don't care about handle races, we
+  # just want the cap slot back.
+  defp safe_complete_pg(workflow_job_id) do
+    :ok = Claims.complete(workflow_job_id)
+  rescue
+    e ->
+      Logger.warning("runners: Claims.complete failed in orphan worker; will retry next tick",
+        workflow_job_id: workflow_job_id,
+        release_error: Exception.message(e)
+      )
+
+      :error
+  end
+
+  # CH state transition for customer visibility. `Jobs.complete`
+  # returns `{:error, :not_found}` when there's no CH row to update
+  # (already merged out, schema migration in flight) — fine, the PG
+  # claim is already freed by `safe_complete_pg/1`.
+  defp safe_complete_ch(workflow_job_id, conclusion) do
+    case Jobs.complete(workflow_job_id, conclusion) do
+      {:ok, _} -> :ok
+      {:error, :not_found} -> :ok
+    end
+  rescue
+    e ->
+      Logger.warning("runners: Jobs.complete failed in orphan worker; CH row will resolve on next webhook",
+        workflow_job_id: workflow_job_id,
+        ch_error: Exception.message(e)
+      )
+
+      :error
   end
 end

--- a/server/lib/tuist/runners/workers/orphaned_runners_worker.ex
+++ b/server/lib/tuist/runners/workers/orphaned_runners_worker.ex
@@ -1,0 +1,216 @@
+defmodule Tuist.Runners.Workers.OrphanedRunnersWorker do
+  @moduledoc """
+  Recovers `runner_jobs` rows the server transitioned to
+  `status = 'running'` but whose GitHub Actions runner never
+  actually came up.
+
+  ## What "orphaned running" means
+
+  Happy path:
+
+      Pod polls → server claims → mints JIT → returns 200 to Pod
+        → row: status='running', PG claim: lifecycle_state='running'
+      Pod execs ./run.sh --jitconfig <JIT>
+        → runner registers with GitHub, accepts the workflow_job
+        → GitHub fires workflow_job.in_progress
+      Job runs → ./run.sh exits → Pod halts → tart-kubelet flips
+        to Succeeded → reconciler reaps + boots replacement
+      GitHub fires workflow_job.completed → server marks row
+        completed, frees PG cap slot
+
+  Failure path this worker catches:
+
+      Pod polls → server claims → mints JIT → returns 200 to Pod
+        → row: status='running'
+      Pod's tart-kubelet on a degraded node never starts the
+        container; OR the runner agent crashes before registering;
+        OR network from VM to github.com is broken
+        → runner NEVER registers with GitHub
+        → no workflow_job.in_progress webhook ever arrives
+        → row stays status='running' forever; PG cap slot
+          consumed forever; workflow_job stays 'queued' on GitHub
+          forever (no runner matched it)
+        → customer eventually times out the workflow and ships
+          a bug report
+
+  `StaleClaimsWorker` doesn't catch this case: it intentionally
+  excludes `lifecycle_state='running'` rows because a real running
+  build holds the slot for as long as the build takes (potentially
+  hours), and reaping at the 5-min threshold would free the slot
+  of an actively-running runner. The signal that distinguishes
+  "real running build" from "orphaned mint" is the GitHub-side
+  status of the workflow_job — if GH still reports `queued` after
+  we've supposedly transitioned through `claimed → running`, the
+  runner never registered.
+
+  ## How it works
+
+    1. List `runner_jobs FINAL` rows in `status='running'` with
+       `started_at < now - @stale_after_seconds`.
+    2. For each, call `GET /repos/{owner}/{repo}/actions/jobs/{id}`
+       on the org's GitHub App installation.
+    3. If GH returns `status: 'queued'` → runner never came up.
+       Recover: CH `record_queued` (RMT INSERT flipping status back
+       to `queued`), then PG `Claims.release` (delete the row using
+       the original `claimed_at` as the handle).
+    4. If GH returns `status: 'in_progress'` → runner is actually
+       running; leave the row alone.
+    5. If GH returns `status: 'completed'` → GH has a terminal
+       state but we missed the webhook. Out of scope for this
+       worker; the next `workflow_job.completed` redelivery or a
+       separate reconcile path can handle it.
+    6. Any other return / API failure → log and retry next tick.
+
+  ## Recovery order matters (CH-first, same as StaleClaimsWorker)
+
+  Re-INSERT `queued` to CH BEFORE deleting the PG claim. If we
+  deleted PG first and crashed, CH would still say `running` and
+  `pick_queued` would skip the row — but no PG claim would remain
+  for the next worker run to find. The workflow_job would be
+  stranded permanently with the PG slot leak still in effect.
+
+  CH-first guarantees:
+
+    * Both succeed → row in queued pool, PG slot freed.
+    * CH ok, PG delete fails / crash → CH says queued, PG still
+      claimed. The next dispatch poll picks the row, hits a PG PK
+      conflict on `Claims.attempt`, returns `:lost_race` and bails
+      cleanly. The next worker run sees the same stale PG row and
+      retries the release.
+    * CH fails → leave PG alone; next worker tick retries the
+      whole sequence.
+
+  ## Threshold
+
+  5 min is the same threshold `StaleClaimsWorker` uses for
+  `claimed`. The happy path from mint to runner-registers-with-GH
+  is sub-30s in practice (Pod-side: receive JIT → exec run.sh →
+  agent registers → GH dispatches the workflow_job); 5 min is a
+  generous floor that won't false-positive a slow boot.
+
+  ## Cost
+
+  One GitHub API call per orphaned candidate per tick. Steady-
+  state candidates are zero (real running builds are filtered out
+  by the GH status check, but only after one call per row). With
+  5 concurrent builds and a 1-min cadence that's 5 calls/min ≈
+  300/hr per installation, well under the 5,000/hr app-token
+  limit.
+  """
+
+  use Oban.Worker, queue: :default, max_attempts: 1
+
+  alias Tuist.Accounts
+  alias Tuist.GitHub.Client, as: GitHubClient
+  alias Tuist.Runners.Claims
+  alias Tuist.Runners.Jobs
+  alias Tuist.VCS
+
+  require Logger
+
+  @stale_after_seconds 300
+
+  @impl Oban.Worker
+  def perform(_job) do
+    threshold = DateTime.add(DateTime.utc_now(), -@stale_after_seconds, :second)
+
+    rescued =
+      threshold
+      |> Jobs.list_orphaned_running()
+      |> Enum.count(&recover_one/1)
+
+    if rescued > 0 do
+      Logger.warning("runners: rescued orphaned running rows",
+        count: rescued,
+        stale_after_seconds: @stale_after_seconds
+      )
+    end
+
+    :ok
+  end
+
+  defp recover_one(%{
+         workflow_job_id: workflow_job_id,
+         account_id: account_id,
+         repo: repo,
+         claimed_at: claimed_at,
+         pod_name: pod_name
+       }) do
+    with {:ok, account} <- Accounts.get_account_by_id(account_id),
+         {:ok, installation} <- VCS.get_github_app_installation_for_account(account.id),
+         {:ok, %{status: gh_status}} <-
+           GitHubClient.get_workflow_job(installation, repo, workflow_job_id) do
+      handle_gh_status(gh_status, workflow_job_id, claimed_at, pod_name, account)
+    else
+      {:error, :not_found} ->
+        # Account row gone (rare). Leave the orphan; cap accounting
+        # is moot if the account itself is deleted.
+        false
+
+      {:error, reason} ->
+        Logger.warning("runners: orphan worker lookup failed; will retry next tick",
+          workflow_job_id: workflow_job_id,
+          reason: inspect(reason)
+        )
+
+        false
+    end
+  end
+
+  defp handle_gh_status("queued", workflow_job_id, claimed_at, pod_name, account) do
+    Logger.warning("runners: orphaned running row — GH still queued, recovering",
+      workflow_job_id: workflow_job_id,
+      account: account.name,
+      pod: pod_name
+    )
+
+    with :ok <- safe_record_queued(workflow_job_id),
+         :ok <- safe_release(workflow_job_id, claimed_at) do
+      true
+    else
+      _ -> false
+    end
+  end
+
+  defp handle_gh_status("in_progress", _wfid, _claimed_at, _pod, _account), do: false
+
+  defp handle_gh_status(other, workflow_job_id, _claimed_at, _pod, _account) do
+    # `completed` / `cancelled` / etc. — terminal state on GH but
+    # not handled here. The completed-webhook path is the right
+    # place to mark these locally.
+    Logger.debug("runners: orphan worker skipping terminal GH state",
+      workflow_job_id: workflow_job_id,
+      gh_status: other
+    )
+
+    false
+  end
+
+  # CH first — see moduledoc. Treat a CH failure as "skip, retry
+  # next tick" — the PG claim stays put so we re-see the row.
+  defp safe_record_queued(workflow_job_id) do
+    Jobs.record_queued(workflow_job_id)
+    :ok
+  rescue
+    e ->
+      Logger.warning("runners: record_queued failed in orphan worker; will retry next tick",
+        workflow_job_id: workflow_job_id,
+        ch_error: Exception.message(e)
+      )
+
+      :error
+  end
+
+  defp safe_release(workflow_job_id, %DateTime{} = handle) do
+    case Claims.release(workflow_job_id, handle) do
+      :ok ->
+        :ok
+
+      {:error, :stale_claim} ->
+        # Someone else released + re-claimed between our CH list
+        # and our PG release. The new claim has a newer claimed_at;
+        # our re-queue won't disturb it. Treat as a no-op.
+        :error
+    end
+  end
+end

--- a/server/test/tuist/runners/workers/orphaned_runners_worker_test.exs
+++ b/server/test/tuist/runners/workers/orphaned_runners_worker_test.exs
@@ -1,0 +1,138 @@
+defmodule Tuist.Runners.Workers.OrphanedRunnersWorkerTest do
+  use TuistTestSupport.Cases.DataCase, async: true
+
+  import Mimic
+
+  alias Tuist.GitHub.Client, as: GitHubClient
+  alias Tuist.Runners.Claims
+  alias Tuist.Runners.Jobs
+  alias Tuist.Runners.Workers.OrphanedRunnersWorker
+
+  setup :verify_on_exit!
+
+  defp candidate(opts) do
+    %{
+      workflow_job_id: Keyword.get(opts, :workflow_job_id, 76_348_428_905),
+      account_id: Keyword.get(opts, :account_id, 3),
+      repo: Keyword.get(opts, :repo, "tuist/tuist"),
+      claimed_at: Keyword.get(opts, :claimed_at, ~U[2026-05-16 21:14:06.616167Z]),
+      started_at: Keyword.get(opts, :started_at, ~U[2026-05-16 21:14:07.711527Z]),
+      pod_name: Keyword.get(opts, :pod_name, "pod-1")
+    }
+  end
+
+  defp account_fixture do
+    TuistTestSupport.Fixtures.AccountsFixtures.organization_fixture(name: "tuist-#{System.unique_integer([:positive])}").account
+  end
+
+  describe "perform/1" do
+    test "re-queues + releases when GitHub still reports the workflow_job as queued" do
+      # The exact case shard 0 hit on 2026-05-16: PG/CH said the
+      # workflow_job was claimed and running, but the Pod's container
+      # never started so GH never saw a registered runner. The
+      # worker re-queues + releases so another Pod can pick up.
+      account = account_fixture()
+      orphan = candidate(account_id: account.id)
+
+      expect(Jobs, :list_orphaned_running, fn _threshold -> [orphan] end)
+
+      expect(Tuist.VCS, :get_github_app_installation_for_account, fn id ->
+        assert id == account.id
+        {:ok, %{installation_id: 1, client_url: "https://github.com"}}
+      end)
+
+      expect(GitHubClient, :get_workflow_job, fn _installation, "tuist/tuist", wfid ->
+        assert wfid == orphan.workflow_job_id
+        {:ok, %{status: "queued", conclusion: nil, runner_name: nil}}
+      end)
+
+      expect(Jobs, :record_queued, fn wfid ->
+        assert wfid == orphan.workflow_job_id
+        :ok
+      end)
+
+      expect(Claims, :release, fn wfid, handle ->
+        assert wfid == orphan.workflow_job_id
+        assert handle == orphan.claimed_at
+        :ok
+      end)
+
+      assert :ok = OrphanedRunnersWorker.perform(%Oban.Job{})
+    end
+
+    test "leaves real running builds alone when GitHub reports in_progress" do
+      # The runner registered fine and is actually executing the
+      # workflow_job. Nothing to recover; reaping here would kill a
+      # live build.
+      account = account_fixture()
+      orphan = candidate(account_id: account.id)
+
+      expect(Jobs, :list_orphaned_running, fn _ -> [orphan] end)
+
+      expect(Tuist.VCS, :get_github_app_installation_for_account, fn _id ->
+        {:ok, %{installation_id: 1, client_url: "https://github.com"}}
+      end)
+
+      expect(GitHubClient, :get_workflow_job, fn _i, _r, _wfid ->
+        {:ok, %{status: "in_progress", conclusion: nil, runner_name: "runner-x"}}
+      end)
+
+      reject(&Jobs.record_queued/1)
+      reject(&Claims.release/2)
+
+      assert :ok = OrphanedRunnersWorker.perform(%Oban.Job{})
+    end
+
+    test "no-op when GitHub reports completed — webhook redelivery handles those" do
+      account = account_fixture()
+      orphan = candidate(account_id: account.id)
+
+      expect(Jobs, :list_orphaned_running, fn _ -> [orphan] end)
+
+      expect(Tuist.VCS, :get_github_app_installation_for_account, fn _id ->
+        {:ok, %{installation_id: 1, client_url: "https://github.com"}}
+      end)
+
+      expect(GitHubClient, :get_workflow_job, fn _i, _r, _wfid ->
+        {:ok, %{status: "completed", conclusion: "success", runner_name: "runner-x"}}
+      end)
+
+      reject(&Jobs.record_queued/1)
+      reject(&Claims.release/2)
+
+      assert :ok = OrphanedRunnersWorker.perform(%Oban.Job{})
+    end
+
+    test "skips on transient GitHub lookup failure" do
+      # 502 / network blip / rate limit — retry next tick rather
+      # than re-queue speculatively. We don't have proof the runner
+      # is dead without a fresh GH status.
+      account = account_fixture()
+      orphan = candidate(account_id: account.id)
+
+      expect(Jobs, :list_orphaned_running, fn _ -> [orphan] end)
+
+      expect(Tuist.VCS, :get_github_app_installation_for_account, fn _id ->
+        {:ok, %{installation_id: 1, client_url: "https://github.com"}}
+      end)
+
+      expect(GitHubClient, :get_workflow_job, fn _i, _r, _wfid ->
+        {:error, {:http, 502, "bad gateway"}}
+      end)
+
+      reject(&Jobs.record_queued/1)
+      reject(&Claims.release/2)
+
+      assert :ok = OrphanedRunnersWorker.perform(%Oban.Job{})
+    end
+
+    test "is a no-op when nothing is orphaned" do
+      expect(Jobs, :list_orphaned_running, fn _ -> [] end)
+
+      reject(&Tuist.VCS.get_github_app_installation_for_account/1)
+      reject(&GitHubClient.get_workflow_job/3)
+
+      assert :ok = OrphanedRunnersWorker.perform(%Oban.Job{})
+    end
+  end
+end

--- a/server/test/tuist/runners/workers/orphaned_runners_worker_test.exs
+++ b/server/test/tuist/runners/workers/orphaned_runners_worker_test.exs
@@ -83,7 +83,13 @@ defmodule Tuist.Runners.Workers.OrphanedRunnersWorkerTest do
       assert :ok = OrphanedRunnersWorker.perform(%Oban.Job{})
     end
 
-    test "no-op when GitHub reports completed — webhook redelivery handles those" do
+    test "frees the claim when GitHub reports completed but we missed the webhook" do
+      # Webhook delivery can be dropped (GitHub retries exhaust, our
+      # endpoint 5xx'd, etc.). Without this branch, the PG claim
+      # would stay in lifecycle_state='running' forever — the
+      # StaleClaimsWorker excludes running, and this worker would
+      # see the same row every minute. Since the GH lookup proves
+      # the job is no longer live, free the cap slot ourselves.
       account = account_fixture()
       orphan = candidate(account_id: account.id)
 
@@ -96,6 +102,48 @@ defmodule Tuist.Runners.Workers.OrphanedRunnersWorkerTest do
       expect(GitHubClient, :get_workflow_job, fn _i, _r, _wfid ->
         {:ok, %{status: "completed", conclusion: "success", runner_name: "runner-x"}}
       end)
+
+      expect(Claims, :complete, fn wfid ->
+        assert wfid == orphan.workflow_job_id
+        :ok
+      end)
+
+      expect(Jobs, :complete, fn wfid, conclusion ->
+        assert wfid == orphan.workflow_job_id
+        assert conclusion == "success"
+        {:ok, %{}}
+      end)
+
+      reject(&Jobs.record_queued/1)
+      reject(&Claims.release/2)
+
+      assert :ok = OrphanedRunnersWorker.perform(%Oban.Job{})
+    end
+
+    test "frees the claim when GitHub returns 404 (workflow_job pruned past retention)" do
+      # GitHub retains workflow_jobs for 90 days. If our PG claim
+      # outlives that window (catastrophic outage), the GET returns
+      # 404. The job cannot be live; treat as completed so we don't
+      # leak the cap slot.
+      account = account_fixture()
+      orphan = candidate(account_id: account.id)
+
+      expect(Jobs, :list_orphaned_running, fn _ -> [orphan] end)
+
+      expect(Tuist.VCS, :get_github_app_installation_for_account, fn _id ->
+        {:ok, %{installation_id: 1, client_url: "https://github.com"}}
+      end)
+
+      expect(GitHubClient, :get_workflow_job, fn _i, _r, _wfid ->
+        {:error, :not_found}
+      end)
+
+      expect(Claims, :complete, fn wfid ->
+        assert wfid == orphan.workflow_job_id
+        :ok
+      end)
+
+      expect(Jobs, :complete, fn _wfid, "" -> {:ok, %{}} end)
 
       reject(&Jobs.record_queued/1)
       reject(&Claims.release/2)


### PR DESCRIPTION
Two fixes targeting the same failure mode that left job [76348428905](https://github.com/tuist/tuist/actions/runs/25972741876/job/76348428905) stuck in GitHub's queue for 100+ minutes on 2026-05-16:

1. **Ship the existing pf-table-busy fix in macos-host-bootstrap to production** by flipping the [capi-scaleway cliff](infra/cluster-api-provider-scaleway-applesilicon/cliff.toml) to path-based filtering.
2. **Server-side recovery** for the case where the Pod claims a JIT but the runner agent never registers with GitHub.

## Background — what happened to shard 0

Investigation pinned the cause to a degraded node (\`m789d\`) in the runner fleet. The pod was scheduled and the dispatch endpoint successfully transitioned the row to \`status='running'\`, but the runner container never started: no \`Pulling\` / \`Pulled\` / \`Created\` / \`Started\` events from the kubelet, no runner registration with GitHub.

Why the node was degraded: every host in the \`mndbc\` fleet was looping on \`BootstrapFailed\` (2,300+ retries) with:

\`\`\`
/etc/pf.anchors/tuist.runners:11: cannot define table vm_sources: Resource busy
/etc/pf.anchors/tuist.runners:12: cannot define table blocked_dst: Resource busy
pfctl: Syntax error in config file: pf rules not loaded
\`\`\`

The fix for this exists in [bootstrap.go:745](infra/macos-host-bootstrap/bootstrap.go) (commit 0eabd38e6b) — \`pfctl -a tuist.runners -F all\` before reload — but the operator image in production is pinned to \`af8204b1\` (May 12), pre-fix.

## Half 1 — \`refactor(capi-scaleway)\`: trigger the operator-image release

[#10798](https://github.com/tuist/tuist/pull/10798) squashed as \`fix(infra):\`. The [capi-scaleway cliff](infra/cluster-api-provider-scaleway-applesilicon/cliff.toml) filtered on \`^fix\(capi-scaleway\)\`, didn't match, and the operator-image release-on-bump never fired.

Switch to type-only parsers — path filtering via \`--include-path "infra/cluster-api-provider-scaleway-applesilicon/**/*"\` plus \`--include-path "infra/macos-host-bootstrap/**/*"\` (both already wired up in release.yml) covers every change. Mirrors the runners-controller / runner-image / xcresult-processor cliffs from [#10824](https://github.com/tuist/tuist/pull/10824).

This commit itself touches the capi-scaleway include-path with a \`refactor:\` prefix, so the next release.yml run releases a new operator image baking in the existing pf fix — unsticking the looping nodes.

## Half 2 — \`feat(server)\`: \`OrphanedRunnersWorker\`

Even with the infra fix deployed, the architecture had a gap: there's no recovery path for "PG/CH says \`running\`, the JIT was minted, but the runner never registered with GitHub". The existing [\`StaleClaimsWorker\`](server/lib/tuist/runners/workers/stale_claims_worker.ex) only handles \`lifecycle_state='claimed'\` rows — running rows are explicitly excluded because real running builds hold the slot for hours and reaping at the 5-min threshold would kill live work.

The signal that distinguishes a real running build from an orphaned mint is the GitHub-side status of the workflow_job. If GitHub still reports the job as \`queued\` after we've transitioned through \`claimed → running\` locally, the runner never came up.

New worker:

  1. Lists \`runner_jobs FINAL\` rows in \`status='running'\` with \`started_at\` older than 5 min.
  2. For each, \`GET /repos/{owner}/{repo}/actions/jobs/{id}\` on the org's GitHub App installation.
  3. If GH returns \`queued\` → re-queue in CH (\`record_queued\`) + release the PG claim. Another Pod picks it up.
  4. If \`in_progress\` → real running build, leave alone.
  5. If \`completed\` → out of scope; webhook redelivery handles it.
  6. Transient lookup failure → log + retry next tick.

Recovery order mirrors \`StaleClaimsWorker\` (CH-first; crash between CH and PG leaves the row safely re-queueable on the next tick).

GitHub API cost: one call per orphaned candidate per minute. Steady-state candidates are zero; even at 5 concurrent real running builds that's 300 calls/hr/installation, well under the 5,000/hr app-token limit.

## Tests

\`mix test test/tuist/runners/workers/orphaned_runners_worker_test.exs\` covers:

- GH \`queued\` → re-queue + release (the shard 0 case)
- GH \`in_progress\` → no-op (real running build)
- GH \`completed\` → no-op (webhook redelivery handles)
- Transient HTTP 502 → no-op + retry next tick
- Empty candidate list → no GH calls made

5 passing, 0 failing.

## How to test

- [ ] On merge, release.yml fires \`release-capi-scaleway\` and bumps the operator-image tag in the chart.
- [ ] Next server deploy applies the new operator image; existing bootstrap loop on \`mndbc\` fleet hosts recovers within one retry cycle (pfctl -F flushes the persist tables, reload succeeds).
- [ ] \`mix test test/tuist/runners/workers/orphaned_runners_worker_test.exs\` clean.
- [ ] Once deployed: the next time the failure mode hits, the new worker should re-queue the affected workflow_job within a minute instead of stranding it for hours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)