### PR TITLE
refactor(capi-scaleway): release on path, not commit scope

### DIFF
--- a/infra/cluster-api-provider-scaleway-applesilicon/cliff.toml
+++ b/infra/cluster-api-provider-scaleway-applesilicon/cliff.toml
@@ -62,19 +62,24 @@ split_commits = false
 commit_preprocessors = [
     { pattern = '\((\w+\s)?#([0-9]+)\)', replace = "" },
 ]
-# Match commits scoped to capi-scaleway. The component spans three Go
-# modules (the operator itself, macos-host-bootstrap, tart-kubelet) but
-# they ship together in one operator image, so a single scope is enough.
+# Type-only parsers, path filtering via `--include-path` in
+# release.yml. Any conventional-commit touching the component path
+# triggers a bump regardless of the commit's scope tag — a
+# `fix(infra):` PR that changes bootstrap.go still releases the
+# operator image. Mirrors the runners-controller / runner-image /
+# xcresult-processor-image cliffs (#10824). The component spans
+# three Go modules (the operator itself, macos-host-bootstrap,
+# tart-kubelet); release.yml's `--include-path` covers all three.
 commit_parsers = [
-    { message = "^feat\\([^)]*\\bcapi-scaleway\\b[^)]*\\)", group = "<!-- 0 -->⛰️  Features" },
-    { message = "^fix\\([^)]*\\bcapi-scaleway\\b[^)]*\\)", group = "<!-- 1 -->🐛 Bug Fixes" },
-    { message = "^docs?\\([^)]*\\bcapi-scaleway\\b[^)]*\\)", group = "<!-- 3 -->📚 Documentation" },
-    { message = "^perf\\([^)]*\\bcapi-scaleway\\b[^)]*\\)", group = "<!-- 4 -->⚡ Performance" },
-    { message = "^refactor\\([^)]*\\bcapi-scaleway\\b[^)]*\\)", group = "<!-- 2 -->🚜 Refactor" },
-    { message = "^style\\([^)]*\\bcapi-scaleway\\b[^)]*\\)", group = "<!-- 5 -->🎨 Styling" },
-    { message = "^test\\([^)]*\\bcapi-scaleway\\b[^)]*\\)", group = "<!-- 6 -->🧪 Testing" },
-    { message = "^chore\\([^)]*\\bcapi-scaleway\\b[^)]*\\)", skip = true },
-    { message = "^ci\\([^)]*\\bcapi-scaleway\\b[^)]*\\)", skip = true },
+    { message = "^feat(\\([^)]*\\))?", group = "<!-- 0 -->⛰️  Features" },
+    { message = "^fix(\\([^)]*\\))?", group = "<!-- 1 -->🐛 Bug Fixes" },
+    { message = "^docs?(\\([^)]*\\))?", group = "<!-- 3 -->📚 Documentation" },
+    { message = "^perf(\\([^)]*\\))?", group = "<!-- 4 -->⚡ Performance" },
+    { message = "^refactor(\\([^)]*\\))?", group = "<!-- 2 -->🚜 Refactor" },
+    { message = "^style(\\([^)]*\\))?", group = "<!-- 5 -->🎨 Styling" },
+    { message = "^test(\\([^)]*\\))?", group = "<!-- 6 -->🧪 Testing" },
+    { message = "^chore(\\([^)]*\\))?", skip = true },
+    { message = "^ci(\\([^)]*\\))?", skip = true },
     { message = "^[a-z]+\\([^)]+\\)", skip = true },
 ]
 protect_breaking_commits = false


### PR DESCRIPTION
## Summary

- Switch the capi-scaleway `cliff.toml` from scope-filtered parsers (`^fix\(capi-scaleway\)`) to type-only parsers; path filtering is delegated to `release.yml`'s existing `--include-path`. Any conventional-commit touching the operator image's source paths now triggers a release, regardless of the commit's scope tag. Mirrors #10824.
- This commit itself uses scope `refactor(capi-scaleway):` and touches an include-path, so the next `release.yml` run cuts a new operator image that bakes in the unreleased adoption-path fixes and the `bootstrap.go` pf flush.

## Why this matters now

Production has been pinned to operator image `af8204b1` (2026-05-12) for five days. Two independent bugs are stuck behind that pin:

1. **Duplicate-ServerID across MachineDeployment burst.** Pre-fix `AdoptByPrefix` has no `adoptMu` and no two-phase claim. With `MaxConcurrentReconciles: 4`, concurrent reconciles race `ListServers` + `UpdateServer` and converge on the same pool host. Cluster state today: 9 `ScalewayAppleSiliconMachine` CRs claim only 5 distinct Scaleway servers (3+3+1+1+1). The bogus 4 will not heal on their own under the new controller — their `Status.ServerID` is already populated, so the `acquireServer` guard short-circuits.
2. **pf table-busy bootstrap loop.** `installVMEgressFirewall` re-defined `persist` tables that survived across `pfctl -f`, failing with `Resource busy` on every retry. Two hosts have been looping 2,300+ times since 2026-05-14. `bootstrap.go` already has the `pfctl -a tuist.runners -F all` flush — it's just stuck behind the same release pin.

## Post-merge operator playbook

1. Watch `release.yml` cut a new `capi-scaleway@*` tag and auto-bump `tag:` in `values-managed-common.yaml`.
2. After the new operator image is live in production, delete the four duplicate Machines so the MachineSet recreates them under the new controller's idempotent adoption path:
   ```
   kubectl -n tuist delete machine \
     tuist-tuist-runners-fleet-mndbc-m7r47 \
     tuist-tuist-runners-fleet-mndbc-xs6fx \
     tuist-tuist-runners-fleet-mndbc-ffjpx \
     tuist-tuist-runners-fleet-mndbc-bzd26
   ```
3. The MachineSet will create four fresh Machines. Three claim the unallocated `tuist-pool-08`, `tuist-pool-09`, `tuist-pool-005` hosts via the new two-phase claim. The fourth requeues with `NoAvailableHost` until another pool host is pre-ordered.
4. The two hosts that were looping on `Resource busy` (`c0b4b946`, `9cceb4b7`) will reconcile and progress past the pf step on the next bootstrap attempt under the new image.

## Test plan

- [ ] Confirm `release.yml` triggers on merge and produces a new `capi-scaleway@*` tag + image push.
- [ ] Confirm `values-managed-common.yaml` `tag:` is auto-bumped in the same release commit.
- [ ] After deploy, run the four `kubectl delete machine` calls above and watch the new Machines reach `Provisioned` against the unclaimed `tuist-pool-*` hosts.
- [ ] Confirm the two previously stuck bootstraps complete past the pf step (no more `Resource busy`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)