### PR TITLE
fix(runner-image): chown /Users/runner so the runner user owns its home

### DIFF
--- a/infra/runner-image/runner.pkr.hcl
+++ b/infra/runner-image/runner.pkr.hcl
@@ -124,8 +124,14 @@ source "tart-cli" "runner" {
 build {
   sources = ["source.tart-cli.runner"]
 
-  # Create the `runner` user (Cirrus base image ships with `admin`
-  # only). `-admin` adds the user to the admin GROUP, which is
+  # Create the `runner` user. The Cirrus base image ships with
+  # `admin` as its working user but pre-stages `/Users/runner` as a
+  # placeholder owned by admin (sysadminctl logs `Directory at
+  # path:/Users/runner already exists` and assigns the new user a
+  # fresh UID without re-owning the home). Without an explicit
+  # chown, the subsequent `sudo -u runner mkdir` calls fail with
+  # `Permission denied` because runner doesn't own its own home.
+  # The `-admin` flag adds the user to the admin GROUP, which is
   # what `/etc/sudoers.d/%admin` and `inject-env.sh`'s `root:admin`
   # file ownership reference. Password "runner" is encoded into
   # /etc/kcpassword below so the auto-login flow can unlock the
@@ -134,6 +140,7 @@ build {
     inline = [
       "set -euo pipefail",
       "echo 'admin' | sudo -S sysadminctl -addUser runner -fullName 'GitHub Actions Runner' -password runner -admin",
+      "echo 'admin' | sudo -S chown -R runner:staff /Users/runner",
       "echo 'admin' | sudo -S mkdir -p /opt/tuist /etc/tuist",
       "echo 'admin' | sudo -S chown root:wheel /opt/tuist"
     ]


### PR DESCRIPTION
[#10826](https://github.com/tuist/tuist/pull/10826)'s release-runner-image run just failed at the Packer build step:

\`\`\`
mkdir: /Users/runner/work: Permission denied
\`\`\`

Failed step: [build](https://github.com/tuist/tuist/actions/runs/25985806890/job/76383149580). The Cirrus macos-tahoe-xcode base ships with \`/Users/runner\` pre-staged as a placeholder, owned by \`admin\`. When our Packer runs \`sysadminctl -addUser runner\` it creates a new user record (UID 502) but skips home-directory creation because the path already exists:

\`\`\`
sysadminctl[607:4215] Creating user record…
sysadminctl[607:4215] Assigning UID: 502 GID: 20
sysadminctl[607:4215] Creating home directory at /Users/runner
sysadminctl[607:4215] Directory at path:/Users/runner already exists
\`\`\`

So \`runner\` (UID 502) ends up with a "home" still owned by \`admin\` (UID 501). The next provisioner — \`sudo -u runner mkdir -p /Users/runner/actions-runner /Users/runner/work\` — then fails with Permission denied.

## Fix

Recursively chown \`/Users/runner\` to \`runner:staff\` immediately after \`sysadminctl -addUser\`. Whatever the base pre-staged in that directory is owned by admin and not load-bearing at runtime; the chown puts the user in control of its own home before any provisioner writes into it.

## How to test

- [ ] Next release.yml run on main produces a fresh \`runner-image@<next>\`.
- [ ] No \`Permission denied\` on the post-addUser steps.
- [ ] Resulting Tart image boots cleanly; \`echo \$HOME\` from a runner-user shell returns \`/Users/runner\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)