### PR TITLE
fix(infra): surface platform install failure cause from kura workload clusters

### DIFF
--- a/.github/workflows/server-deployment.yml
+++ b/.github/workflows/server-deployment.yml
@@ -568,6 +568,32 @@ jobs:
           kubectl -n "$NAMESPACE" get externalsecret,secretstore 2>&1 || true
           kubectl -n "$NAMESPACE" describe externalsecret 2>&1 || true
           echo "::endgroup::"
+          # Kura regional clusters: the install-platform step runs against
+          # a different kubeconfig than the main deploy. Dump platform-ns
+          # state from each region whose kubeconfig was synced earlier in
+          # the job so a stuck regional install isn't a black box.
+          for region_kubeconfig in "$RUNNER_TEMP"/kura-us-east-1.yaml "$RUNNER_TEMP"/kura-us-west-1.yaml; do
+            [ -r "$region_kubeconfig" ] || continue
+            region="$(basename "$region_kubeconfig" .yaml)"
+            echo "::group::kura $region platform namespace"
+            KUBECONFIG="$region_kubeconfig" kubectl -n platform get jobs,pods -o wide 2>&1 || true
+            KUBECONFIG="$region_kubeconfig" kubectl -n platform get events \
+              --sort-by=.lastTimestamp 2>&1 | tail -50 || true
+            for job in $(KUBECONFIG="$region_kubeconfig" kubectl -n platform get jobs \
+              -l app.kubernetes.io/name=ingress-nginx -o name 2>/dev/null); do
+              echo "--- describe $job ---"
+              KUBECONFIG="$region_kubeconfig" kubectl -n platform describe "$job" 2>&1 || true
+              for pod in $(KUBECONFIG="$region_kubeconfig" kubectl -n platform get pods \
+                -l "job-name=${job##*/}" -o name 2>/dev/null); do
+                echo "--- describe $pod ---"
+                KUBECONFIG="$region_kubeconfig" kubectl -n platform describe "$pod" 2>&1 || true
+                echo "--- logs $pod ---"
+                KUBECONFIG="$region_kubeconfig" kubectl -n platform logs "$pod" \
+                  --all-containers --tail=200 2>&1 || true
+              done
+            done
+            echo "::endgroup::"
+          done
       - name: Post-deploy smoke test
         run: |
           kubectl -n "$NAMESPACE" rollout status deploy/tuist-tuist-server --timeout=10m

--- a/infra/mise/tasks/k8s/install-platform.sh
+++ b/infra/mise/tasks/k8s/install-platform.sh
@@ -109,6 +109,44 @@ if KUBECONFIG="$WL_KUBECONFIG" helm status platform --namespace platform >/dev/n
   HELM_EXTRA_ARGS+=(--no-hooks)
 fi
 
+# Dump platform-namespace state when helm exits non-zero. The caller's
+# workflow-level diagnostics step targets the main tuist cluster, so a
+# failure here would otherwise produce no actionable signal about the
+# regional workload cluster (stuck certgen hook, image pull, RBAC, …).
+dump_diagnostics() {
+  local rc=$?
+  if [ "$rc" -eq 0 ]; then
+    return 0
+  fi
+  echo "::group::platform install diagnostics ($CLUSTER_NAME)"
+  echo "--- helm history platform ---"
+  KUBECONFIG="$WL_KUBECONFIG" helm history platform -n platform --max 5 2>&1 || true
+  echo "--- jobs in platform ns ---"
+  KUBECONFIG="$WL_KUBECONFIG" kubectl -n platform get jobs -o wide 2>&1 || true
+  echo "--- pods in platform ns ---"
+  KUBECONFIG="$WL_KUBECONFIG" kubectl -n platform get pods -o wide 2>&1 || true
+  echo "--- recent events (last 50) ---"
+  KUBECONFIG="$WL_KUBECONFIG" kubectl -n platform get events \
+    --sort-by=.lastTimestamp 2>&1 | tail -50 || true
+  echo "--- ingress-nginx admission hook jobs ---"
+  for job in $(KUBECONFIG="$WL_KUBECONFIG" kubectl -n platform get jobs \
+    -l app.kubernetes.io/name=ingress-nginx -o name 2>/dev/null); do
+    echo "--- describe $job ---"
+    KUBECONFIG="$WL_KUBECONFIG" kubectl -n platform describe "$job" 2>&1 || true
+    for pod in $(KUBECONFIG="$WL_KUBECONFIG" kubectl -n platform get pods \
+      -l "job-name=${job##*/}" -o name 2>/dev/null); do
+      echo "--- describe $pod ---"
+      KUBECONFIG="$WL_KUBECONFIG" kubectl -n platform describe "$pod" 2>&1 || true
+      echo "--- logs $pod ---"
+      KUBECONFIG="$WL_KUBECONFIG" kubectl -n platform logs "$pod" \
+        --all-containers --tail=200 2>&1 || true
+    done
+  done
+  echo "::endgroup::"
+  return "$rc"
+}
+trap dump_diagnostics EXIT
+
 KUBECONFIG="$WL_KUBECONFIG" helm upgrade --install platform "$CHART_PATH" \
   --namespace platform \
   -f "$CHART_PATH/values-hetzner.yaml" \


### PR DESCRIPTION
## Summary

The production deploy [failed on 2026-05-17](https://github.com/tuist/tuist/actions/runs/25985626638/job/76383007223) because the ingress-nginx admission pre-upgrade hook job (\`platform-ingress-nginx-admission-create\`) on the \`tuist-kura-us-east\` workload cluster hung past the 15m helm timeout. The workflow's \`Diagnostics on failure\` step queried the *main* tuist kubeconfig and namespace, so it produced zero signal about the actual stuck cluster.

This change is diagnostic-only: it does not alter the deploy path. After it lands, the next failure will tell us *why* the certgen job is stuck (image pull, RBAC, scheduling, …) so we can address the root cause.

- \`install-platform.sh\` installs an EXIT trap that, on non-zero exit, dumps helm history, jobs/pods/events in the platform namespace, and per-pod describe + logs for any ingress-nginx admission hook jobs — all via the workload kubeconfig the script ran against.
- The workflow's \`Diagnostics on failure\` step now iterates the kura regional kubeconfigs written to \`RUNNER_TEMP\` and replays the same dump for each cluster whose file is present.

## Test plan

- [ ] Re-run the failed production deploy and confirm the new diagnostic block shows up under the install-platform step (success path: no extra output).
- [ ] If it fails again, confirm we now see the certgen Job/Pod state and logs for the stuck cluster.