### PR TITLE
fix(runner-image): wipe Cirrus's placeholder /Users/runner before addUser

### DIFF
--- a/infra/runner-image/runner.pkr.hcl
+++ b/infra/runner-image/runner.pkr.hcl
@@ -126,14 +126,17 @@ build {
 
   # Create the `runner` user. The Cirrus base image ships with
   # `admin` as its working user but pre-stages `/Users/runner` as a
-  # placeholder (sysadminctl logs `Directory at path:/Users/runner
-  # already exists; Assigning UID: 502 GID: 20`). Whatever the base
-  # left there carries ACLs / flags / SIP attributes that survive
-  # `chown -R` — empirically a follow-up `sudo -u runner mkdir
-  # /Users/runner/work` still hits `Permission denied`. Every later
-  # write under `/Users/runner` is therefore done as root and then
-  # chown'd to runner per-subdirectory, sidestepping whatever
-  # protects the placeholder home itself.
+  # placeholder carrying ACLs / flags that survive `chown -R`. If
+  # we leave it in place, `sysadminctl -addUser runner` logs
+  # `Directory at path:/Users/runner already exists` and skips home
+  # creation, so the new user never owns its own home and runtime
+  # mkdirs like `~/.local/share/mise` blow up with EACCES the first
+  # time any step tries to create a top-level subdir we didn't
+  # pre-chown.
+  #
+  # Wipe the placeholder before sysadminctl so it creates a fresh
+  # home from scratch with the correct POSIX ownership and the
+  # default macOS-user ACLs — no Cirrus residue to fight.
   #
   # `-admin` adds the user to the admin GROUP, which is what
   # `/etc/sudoers.d/%admin` and `inject-env.sh`'s `root:admin`
@@ -143,6 +146,7 @@ build {
   provisioner "shell" {
     inline = [
       "set -euo pipefail",
+      "echo 'admin' | sudo -S rm -rf /Users/runner",
       "echo 'admin' | sudo -S sysadminctl -addUser runner -fullName 'GitHub Actions Runner' -password runner -admin",
       "echo 'admin' | sudo -S mkdir -p /opt/tuist /etc/tuist",
       "echo 'admin' | sudo -S chown root:wheel /opt/tuist"


### PR DESCRIPTION
Unit Tests on [PR #10793](https://github.com/tuist/tuist/pull/10793) failed with:

\`\`\`
EACCES: permission denied, mkdir '/Users/runner/.local/share/mise'
\`\`\`

Same root cause that nagged the Packer build: the Cirrus base ships \`/Users/runner\` as a placeholder owned by \`admin\`, sysadminctl sees the dir already exists and skips home creation, so the new \`runner\` user never actually owns its home. [#10832](https://github.com/tuist/tuist/pull/10832) papered over the known build-time directories (\`actions-runner/\`, \`work/\`, \`Library/\`) by root-creating + chowning, but anything else the runtime tries to put under \`/Users/runner\` — \`.local\`, \`.cache\`, \`.tuist\`, etc. — falls into the same trap.

## Fix

Wipe \`/Users/runner\` before \`sysadminctl -addUser runner\`. With no pre-existing placeholder, sysadminctl creates a fresh home from scratch with correct POSIX ownership and the default macOS user ACLs. The pre-create + chown stanzas later in the Packer template remain (idempotent), but they're now belt-and-suspenders rather than a workaround — every \`/Users/runner/<anything>\` mkdir at runtime succeeds without us having to enumerate it ahead of time.

## How to test

- [ ] `gh workflow run runner-image.yml --ref claude/runner-image-fresh-home` produces a green Packer build.
- [ ] After deploy, `jdx/mise-action` runs cleanly on a real workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)