### PR TITLE
chore(kura): stabilize Kura E2E replication check and image reuse

### DIFF
--- a/.github/workflows/kura.yml
+++ b/.github/workflows/kura.yml
@@ -148,10 +148,37 @@ jobs:
       - name: Audit dependencies
         run: env -u RUSTUP_TOOLCHAIN cargo audit
 
+  e2e-images:
+    name: E2E Images
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
+    env:
+      COMPOSE_PROJECT_NAME: kura
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Show Docker tooling
+        run: docker compose version
+
+      - name: Prebuild Docker images
+        run: docker compose build
+
+      - name: Archive Docker images
+        run: docker save kura-kura-us kura-kura-eu kura-kura-ap | zstd -T0 -o kura-e2e-images.tar.zst
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: kura-e2e-images
+          path: kura/kura-e2e-images.tar.zst
+          if-no-files-found: error
+          retention-days: 1
+
   e2e:
     name: E2E (${{ matrix.shard_name }})
     runs-on: ubuntu-latest
     timeout-minutes: 90
+    needs: e2e-images
     if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     strategy:
       fail-fast: false
@@ -165,6 +192,8 @@ jobs:
             specs: "spec/e2e/discovery_spec.sh spec/e2e/faults_spec.sh spec/e2e/handoff_spec.sh"
           - shard_name: extension-mtls
             specs: "spec/e2e/extension_spec.sh spec/e2e/mtls_spec.sh"
+    env:
+      KURA_E2E_SKIP_BUILD: "1"
     steps:
       - uses: actions/checkout@v4
 
@@ -177,8 +206,21 @@ jobs:
       - name: Show Docker tooling
         run: docker compose version
 
-      - name: Prebuild Docker images
-        run: docker compose build
+      - uses: actions/download-artifact@v4
+        with:
+          name: kura-e2e-images
+          path: kura/prebuilt-images
+
+      - name: Load prebuilt Docker images
+        run: zstd -dc prebuilt-images/kura-e2e-images.tar.zst | docker load
+
+      - name: Retag prebuilt Docker images for every suite project
+        run: |
+          for project in kura-e2e kura-clients kura-discovery kura-faults kura-handoff kura-extension kura-mtls kura-rollout; do
+            for service in kura-us kura-eu kura-ap; do
+              docker tag "kura-${service}" "${project}-${service}"
+            done
+          done
 
       - name: Run end-to-end suite
         run: shellspec ${{ matrix.specs }}

--- a/kura/spec/e2e/clients_spec.sh
+++ b/kura/spec/e2e/clients_spec.sh
@@ -19,7 +19,7 @@ Describe 'actively supported protocol interoperability'
     setup_suite_tmpdir
 
     dc down -v --remove-orphans >/dev/null 2>&1 || true
-    dc up --build -d kura-us kura-eu kura-ap >/dev/null 2>&1
+    compose_up kura-us kura-eu kura-ap || return 1
 
     wait_for_http "${KURA_US_URL}/up"
     wait_for_http "${KURA_EU_URL}/up"

--- a/kura/spec/e2e/cluster_spec.sh
+++ b/kura/spec/e2e/cluster_spec.sh
@@ -23,7 +23,7 @@ Describe 'core cluster behaviour'
     setup_suite_tmpdir
 
     dc down -v --remove-orphans >/dev/null 2>&1 || true
-    dc up --build -d >/dev/null 2>&1
+    compose_up || return 1
 
     wait_for_http "${KURA_US_URL}/up"
     wait_for_http "${KURA_EU_URL}/up"
@@ -121,8 +121,10 @@ Describe 'core cluster behaviour'
       -d '{"parts":[1,2]}')"
     The variable complete_status should eq 204
 
-    head_status="$(status_only -I \
-      "${KURA_EU_URL}/api/cache/module/module-1?tenant_id=acme&namespace_id=ios&hash=hash-1&name=Module.framework&cache_category=builds")"
+    capture_into head_status \
+      wait_for_head_status \
+      "${KURA_EU_URL}/api/cache/module/module-1?tenant_id=acme&namespace_id=ios&hash=hash-1&name=Module.framework&cache_category=builds" \
+      204 || return 1
     The variable head_status should eq 204
 
     capture_into module_body \

--- a/kura/spec/e2e/extension_spec.sh
+++ b/kura/spec/e2e/extension_spec.sh
@@ -19,7 +19,7 @@ Describe 'extension hooks'
     setup_suite_tmpdir
 
     dc down -v --remove-orphans >/dev/null 2>&1 || true
-    dc up --build -d kura-us kura-eu kura-ap >/dev/null 2>&1
+    compose_up kura-us kura-eu kura-ap || return 1
 
     wait_for_http "${KURA_US_URL}/up"
     wait_for_http "${KURA_EU_URL}/up"

--- a/kura/spec/e2e/mtls_spec.sh
+++ b/kura/spec/e2e/mtls_spec.sh
@@ -26,7 +26,7 @@ Describe 'peer mTLS'
     generate_peer_tls_material
 
     dc down -v --remove-orphans >/dev/null 2>&1 || true
-    dc up --build -d >/dev/null 2>&1
+    compose_up || return 1
 
     wait_for_http "${KURA_US_URL}/up"
     wait_for_http "${KURA_EU_URL}/up"

--- a/kura/spec/e2e/support.sh
+++ b/kura/spec/e2e/support.sh
@@ -10,6 +10,14 @@ dc_container_id() {
   dc ps -q "$1"
 }
 
+compose_up() {
+  if [ "${KURA_E2E_SKIP_BUILD:-0}" = "1" ]; then
+    dc up -d "$@" >/dev/null 2>&1
+  else
+    dc up --build -d "$@" >/dev/null 2>&1
+  fi
+}
+
 setup_suite_tmpdir() {
   SUITE_TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/kura-e2e.XXXXXX")"
 }
@@ -71,6 +79,26 @@ wait_for_status() {
   done
 
   printf 'Timed out waiting for %s to return %s (last status %s)\n' "$url" "$expected_status" "${actual_status:-unknown}" >&2
+  return 1
+}
+
+wait_for_head_status() {
+  local url="$1"
+  local expected_status="$2"
+  local attempts="${3:-45}"
+  local sleep_seconds="${4:-2}"
+  local actual_status
+
+  for _ in $(seq 1 "$attempts"); do
+    actual_status="$(status_only -I "$url" 2>/dev/null || true)"
+    if [ "$actual_status" = "$expected_status" ]; then
+      printf '%s' "$actual_status"
+      return 0
+    fi
+    sleep "$sleep_seconds"
+  done
+
+  printf 'Timed out waiting for HEAD %s to return %s (last status %s)\n' "$url" "$expected_status" "${actual_status:-unknown}" >&2
   return 1
 }
 


### PR DESCRIPTION
## Summary

- poll the multipart module visibility check with a real HEAD request instead of asserting immediate cross-node visibility
- add a shellspec helper that can skip compose rebuilds when prebuilt images are already present
- prebuild the Kura Docker images once in GitHub Actions, upload them as an artifact, then load and retag them in each E2E shard job

## Why

The failing Kura run was caused by the cluster shellspec assuming module replication was synchronous. `complete` only persists locally and enqueues replication, so an immediate HEAD on another node can legitimately return 404 for a short window.

The workflow was also rebuilding the same Docker images in every E2E shard, which was wasting roughly 10 to 11 minutes per shard.

## Impact

- reduces flakiness in the multipart replication example
- keeps the existing E2E shard names for branch protection compatibility
- moves the expensive Docker build to a single shared job

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/kura.yml"); puts "yaml ok"'`
- `docker compose build`
- `env MISE_TRUSTED_CONFIG_PATHS=/Users/pepicrft/.superconductor/worktrees/tuist/sc-cooled-josephson-f475 mise exec -- shellspec spec/e2e/cluster_spec.sh spec/e2e/clients_spec.sh` with `KURA_E2E_SKIP_BUILD=1` and pre-tagged images
