### PR TITLE
fix(infra): skip ingress-nginx on Kura regional clusters

### DIFF
--- a/.github/workflows/server-deployment.yml
+++ b/.github/workflows/server-deployment.yml
@@ -462,10 +462,11 @@ jobs:
             echo "Deploying Kura controller to $region at $api"
             KUBECONFIG="$kubeconfig" kubectl --request-timeout=10s get --raw /version >/dev/null
 
-            # Bring the cluster's platform layer (cert-manager + the
-            # letsencrypt ClusterIssuer, ingress-nginx, external-dns,
-            # ESO) to chart HEAD before installing the kura-controller,
-            # whose StatefulSet reconcile depends on cert-manager.io/v1
+            # Bring the cluster's shared platform layer (cert-manager +
+            # the letsencrypt ClusterIssuer, external-dns, ESO, and
+            # ingress-nginx only where it is actually needed) to chart
+            # HEAD before installing the kura-controller, whose
+            # StatefulSet reconcile depends on cert-manager.io/v1
             # Certificate. Idempotent: a no-op on clusters already at
             # head, a self-heal on half-bootstrapped ones. The mise -C
             # is required because k8s:* tasks live in infra/mise.toml

--- a/infra/AGENTS.md
+++ b/infra/AGENTS.md
@@ -17,7 +17,7 @@ Wraps the upstream `grafana/k8s-monitoring` chart and adds the 1Password-via-ESO
 README: [`helm/k8s-monitoring/README.md`](helm/k8s-monitoring/README.md).
 
 ### `helm/platform/` — platform bootstrap chart
-cert-manager + ingress-nginx + external-dns + ESO controllers, installed once per workload cluster. Provider-specific LB annotations live in per-provider overlays (e.g., `values-hetzner.yaml`).
+cert-manager + external-dns + ESO controllers, installed once per workload cluster. ingress-nginx is enabled only on app-serving clusters; Kura regional clusters use direct `LoadBalancer` Services instead. Provider-specific LB annotations live in per-provider overlays (e.g., `values-hetzner.yaml`).
 
 ### `k8s/` — CAPI cluster manifests
 Cluster API CRs and cluster-scoped manifests for the self-hosted CAPI + caph stack we operate on Hetzner:

--- a/infra/helm/platform/values-kura-region.yaml
+++ b/infra/helm/platform/values-kura-region.yaml
@@ -1,0 +1,5 @@
+# Kura regional clusters do not serve traffic through ingress-nginx.
+# Each KuraInstance gets its own LoadBalancer Service and external-dns
+# hostname directly from the Kura controller.
+ingress-nginx:
+  enabled: false

--- a/infra/helm/platform/values.yaml
+++ b/infra/helm/platform/values.yaml
@@ -36,13 +36,6 @@ ingress-nginx:
   enabled: true
   controller:
     replicaCount: 2
-    # Regional Kura clusters can temporarily be single-node control-plane-only
-    # clusters during bootstrap or recovery. Allow the controller and its
-    # admission hook Jobs to land there so platform upgrades do not deadlock.
-    tolerations:
-      - key: node-role.kubernetes.io/control-plane
-        operator: Exists
-        effect: NoSchedule
     publishService:
       enabled: true
     service:
@@ -61,12 +54,6 @@ ingress-nginx:
       use-forwarded-headers: "true"
       use-proxy-protocol: "true"
       compute-full-forwarded-for: "true"
-    admissionWebhooks:
-      patch:
-        tolerations:
-          - key: node-role.kubernetes.io/control-plane
-            operator: Exists
-            effect: NoSchedule
     metrics:
       enabled: true
 

--- a/infra/helm/platform/values.yaml
+++ b/infra/helm/platform/values.yaml
@@ -36,6 +36,13 @@ ingress-nginx:
   enabled: true
   controller:
     replicaCount: 2
+    # Regional Kura clusters can temporarily be single-node control-plane-only
+    # clusters during bootstrap or recovery. Allow the controller and its
+    # admission hook Jobs to land there so platform upgrades do not deadlock.
+    tolerations:
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+        effect: NoSchedule
     publishService:
       enabled: true
     service:
@@ -54,6 +61,12 @@ ingress-nginx:
       use-forwarded-headers: "true"
       use-proxy-protocol: "true"
       compute-full-forwarded-for: "true"
+    admissionWebhooks:
+      patch:
+        tolerations:
+          - key: node-role.kubernetes.io/control-plane
+            operator: Exists
+            effect: NoSchedule
     metrics:
       enabled: true
 

--- a/infra/k8s/onboarding.md
+++ b/infra/k8s/onboarding.md
@@ -59,7 +59,7 @@ kubectl -n org-tuist get cluster <name> -w
 
 ## 4. Bootstrap the workload cluster
 
-Run the `k8s:bootstrap-workload` task. It is idempotent and handles every step the workload cluster needs before CI deploys can target it (Cilium, HCCM, hcloud-csi, the `hetzner` Secret on the workload, the platform chart, ESO + the per-env `onepassword` ClusterSecretStore, the monitoring chart, the app namespace + the Cloudflare origin TLS Secret, and a final ingress smoke test):
+Run the `k8s:bootstrap-workload` task. It is idempotent and handles every step the workload cluster needs before CI deploys can target it. App-serving clusters get the full path (Cilium, HCCM, hcloud-csi, the `hetzner` Secret on the workload, the platform chart, ESO + the per-env `onepassword` ClusterSecretStore, the monitoring chart, the app namespace + the Cloudflare origin TLS Secret, and a final ingress smoke test). Production Kura regional clusters install only the shared platform pieces they need, then upload the workload kubeconfig:
 
 ```bash
 mise run k8s:bootstrap-workload <cluster_name> <env> [kubeconfig_item]

--- a/infra/mise/tasks/k8s/bootstrap-workload.sh
+++ b/infra/mise/tasks/k8s/bootstrap-workload.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-#MISE description="Bootstrap a freshly-provisioned workload cluster end-to-end (CNI, CCM, CSI, platform, monitoring, app). Idempotent."
+#MISE description="Bootstrap a freshly-provisioned workload cluster end-to-end (CNI, CCM, CSI, platform, monitoring, and app bits when needed). Idempotent."
 #USAGE arg "<cluster_name>" help="Cluster name (e.g. tuist-staging-2, tuist-canary, tuist, tuist-preview)"
 #USAGE arg "<env>" help="Helm values overlay (staging | canary | production | preview)"
 #USAGE arg "[kubeconfig_item]" help="Optional 1Password document title for the workload kubeconfig"
@@ -18,15 +18,17 @@
 #      enables LoadBalancer Services).
 #   5. Install hcloud-csi-driver (for parity; no PVCs use it today).
 #   6. Wait for nodes to go Ready (CNI- and CCM-dependent).
-#   7. Install the platform chart (cert-manager, ESO, ingress-nginx,
-#      external-dns).
+#   7. Install the platform chart (cert-manager, ESO, external-dns,
+#      and ingress-nginx only for app-serving clusters).
 #   8. Install Cluster API core for the Mac mini fleet substrate.
 #   9. Create the `onepassword` namespace + service-account-token
 #      Secret + ClusterSecretStore so ESO can pull from 1Password.
 #  10. Install the monitoring chart (Grafana Cloud agent).
-#  11. Pre-create the app namespace.
-#  12. Install the Cloudflare origin cert TLS Secret.
-#  13. Smoke ingress + upload workload kubeconfig to 1Password.
+#  11. App-serving clusters: pre-create the app namespace.
+#  12. App-serving clusters: install the Cloudflare origin cert TLS Secret.
+#  13. App-serving clusters: smoke ingress. Kura regional clusters
+#      instead verify the shared platform bits, then upload the workload
+#      kubeconfig to 1Password.
 #
 # Idempotent: re-running is safe; helm upgrades in-place, kubectl
 # create | apply uses --dry-run + apply.
@@ -49,6 +51,11 @@ REPO_ROOT="$(git rev-parse --show-toplevel)"
 BOOTSTRAP_DIR="$REPO_ROOT/infra/k8s/mgmt/bootstrap"
 MGMT_KUBECONFIG="${MGMT_KUBECONFIG:-$HOME/.kube/tuist-mgmt.yaml}"
 WL_KUBECONFIG="$HOME/.kube/${CLUSTER_NAME}.yaml"
+IS_KURA_REGIONAL_CLUSTER=false
+
+if [[ "$CLUSTER_NAME" == tuist-kura-* ]]; then
+  IS_KURA_REGIONAL_CLUSTER=true
+fi
 
 case "$ENV" in
   staging|canary|production|preview) ;;
@@ -67,6 +74,20 @@ esac
 
 log() { printf '\n\033[1;34m==> %s\033[0m\n' "$*"; }
 err() { printf '\n\033[1;31mERROR: %s\033[0m\n' "$*" >&2; }
+
+upload_workload_kubeconfig() {
+  local kubeconfig_vault="tuist-k8s-${ENV}"
+
+  if op item get "$KUBECONFIG_ITEM" --account tuist.1password.com --vault "$kubeconfig_vault" >/dev/null 2>&1; then
+    echo "Existing 1P item found; replacing the document"
+    existing_id=$(op item get "$KUBECONFIG_ITEM" --account tuist.1password.com --vault "$kubeconfig_vault" --format json | jq -r '.id')
+    op item delete "$existing_id" --account tuist.1password.com --vault "$kubeconfig_vault" --archive
+  fi
+
+  op document create "$WL_KUBECONFIG" \
+    --title "$KUBECONFIG_ITEM" \
+    --account tuist.1password.com --vault "$kubeconfig_vault"
+}
 
 # ---------------------------------------------------------------------------
 log "Step 1/13: extract workload kubeconfig + API endpoint from mgmt"
@@ -334,6 +355,36 @@ KUBECONFIG="$WL_KUBECONFIG" helm upgrade --install k8s-monitoring "$REPO_ROOT/in
   -f "$REPO_ROOT/infra/helm/k8s-monitoring/values-${ENV}.yaml" \
   --wait --timeout 5m || echo "WARN: monitoring chart didn't go Ready in 5min; continuing (not blocking the cluster)"
 
+if [ "$IS_KURA_REGIONAL_CLUSTER" = true ]; then
+  # ---------------------------------------------------------------------------
+  log "Step 11/11: verify Kura regional platform + upload workload kubeconfig to 1Password"
+
+  KUBECONFIG="$WL_KUBECONFIG" kubectl wait \
+    --for=condition=Ready clusterissuer/letsencrypt-cloudflare --timeout=2m
+  KUBECONFIG="$WL_KUBECONFIG" kubectl -n platform wait \
+    --for=condition=Available deploy -l app.kubernetes.io/name=external-dns --timeout=2m
+
+  upload_workload_kubeconfig
+
+  echo
+
+  cat <<DONE
+
+================================================================
+Bootstrap of $CLUSTER_NAME complete.
+
+  Workload kubeconfig: $WL_KUBECONFIG
+
+Kura regional clusters do not get an app ingress or Cloudflare origin
+certificate. Their per-account LoadBalancer Services carry
+external-dns annotations and publish hosts like
+{account}-{cluster_id}.kura.tuist.dev after the controller deploys.
+================================================================
+DONE
+
+  exit 0
+fi
+
 # ---------------------------------------------------------------------------
 log "Step 11/13: pre-create the app namespace (CI deploys the app itself)"
 
@@ -441,24 +492,15 @@ echo "ingress LB responded HTTP $SMOKE_HTTP. Routing is healthy."
 
 # Stash the freshly-minted workload kubeconfig in the per-env vault
 # so CI (server-deployment.yml) can read it via the per-env
-# OP_SERVICE_ACCOUNT_TOKEN. Idempotent: if the item exists, replace
-# the file contents; if not, create. Only runs after the smoke above
-# passes, so a stale kubeconfig never overwrites a working one when
-# bootstrap is invoked against a half-built cluster.
+# OP_SERVICE_ACCOUNT_TOKEN. Only runs after the smoke above passes, so
+# a stale kubeconfig never overwrites a working one when bootstrap is
+# invoked against a half-built cluster.
 # By default, app cluster document names follow env, not cluster_name,
 # so the deploy workflow can look up `kubeconfig: tuist-${env}`
 # uniformly across all environments. Regional Kura production clusters
 # pass an explicit title such as `kubeconfig: kura-us-east-1`, matching
 # the product cluster_id consumed by TUIST_KURA_KUBECONFIG_*.
-KUBECONFIG_VAULT="tuist-k8s-${ENV}"
-if op item get "$KUBECONFIG_ITEM" --account tuist.1password.com --vault "$KUBECONFIG_VAULT" >/dev/null 2>&1; then
-  echo "Existing 1P item found; replacing the document"
-  EXISTING_ID=$(op item get "$KUBECONFIG_ITEM" --account tuist.1password.com --vault "$KUBECONFIG_VAULT" --format json | jq -r '.id')
-  op item delete "$EXISTING_ID" --account tuist.1password.com --vault "$KUBECONFIG_VAULT" --archive
-fi
-op document create "$WL_KUBECONFIG" \
-  --title "$KUBECONFIG_ITEM" \
-  --account tuist.1password.com --vault "$KUBECONFIG_VAULT"
+upload_workload_kubeconfig
 
 echo
 

--- a/infra/mise/tasks/k8s/bootstrap-workload.sh
+++ b/infra/mise/tasks/k8s/bootstrap-workload.sh
@@ -79,6 +79,7 @@ upload_workload_kubeconfig() {
   local kubeconfig_vault="tuist-k8s-${ENV}"
 
   if op item get "$KUBECONFIG_ITEM" --account tuist.1password.com --vault "$kubeconfig_vault" >/dev/null 2>&1; then
+    local existing_id
     echo "Existing 1P item found; replacing the document"
     existing_id=$(op item get "$KUBECONFIG_ITEM" --account tuist.1password.com --vault "$kubeconfig_vault" --format json | jq -r '.id')
     op item delete "$existing_id" --account tuist.1password.com --vault "$kubeconfig_vault" --archive
@@ -248,7 +249,7 @@ fi
 KUBECONFIG="$WL_KUBECONFIG" kubectl wait --for=condition=Ready nodes --all --timeout=5m
 
 # ---------------------------------------------------------------------------
-log "Step 7/13: install platform chart (cert-manager, ESO, ingress-nginx)"
+log "Step 7/13: install shared platform chart"
 
 # `mise -C "$REPO_ROOT/infra"` so the nested task resolves regardless
 # of where the caller ran bootstrap-workload from; k8s:* tasks live in

--- a/infra/mise/tasks/k8s/install-platform.sh
+++ b/infra/mise/tasks/k8s/install-platform.sh
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
-#MISE description="Install or upgrade the Tuist platform chart (cert-manager, ESO, ingress-nginx, external-dns) on a workload cluster. Idempotent — safe to run on every deploy."
+#MISE description="Install or upgrade the Tuist platform chart (cert-manager, ESO, external-dns, and optionally ingress-nginx) on a workload cluster. Idempotent — safe to run on every deploy."
 #USAGE arg "<kubeconfig>" help="Path to the workload cluster kubeconfig"
-#USAGE arg "<cluster_name>" help="Cluster name, used for the ingress LoadBalancer Hetzner name and the external-dns owner ID (e.g. tuist-kura-us-east)"
+#USAGE arg "<cluster_name>" help="Cluster name, used for the external-dns owner ID and, for app clusters, the ingress LoadBalancer name"
 
 # Brings a workload cluster to the desired state of the platform chart
-# at HEAD: cert-manager + ClusterIssuer, ingress-nginx, external-dns,
-# external-secrets. Designed to run from CI on every deploy so a
+# at HEAD: cert-manager + ClusterIssuer + external-dns +
+# external-secrets, plus ingress-nginx on app-serving clusters.
+# Designed to run from CI on every deploy so a
 # half-bootstrapped cluster self-heals instead of silently breaking
 # downstream installs that depend on cert-manager.io/v1 Certificate.
 #
@@ -19,6 +20,11 @@ WL_KUBECONFIG="$1"
 CLUSTER_NAME="$2"
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 CHART_PATH="$REPO_ROOT/infra/helm/platform"
+IS_KURA_REGIONAL_CLUSTER=false
+
+if [[ "$CLUSTER_NAME" == tuist-kura-* ]]; then
+  IS_KURA_REGIONAL_CLUSTER=true
+fi
 
 log() { printf '\n\033[1;34m==> %s\033[0m\n' "$*"; }
 
@@ -55,15 +61,24 @@ unset CLOUDFLARE_API_TOKEN
 
 HELM_SET_ARGS=(
   --set "external-dns.txtOwnerId=${CLUSTER_NAME}-platform"
-  --set "ingress-nginx.controller.service.annotations.load-balancer\.hetzner\.cloud/location=${REGION}"
-  --set "ingress-nginx.controller.service.annotations.load-balancer\.hetzner\.cloud/name=${CLUSTER_NAME}-ingress"
 )
+HELM_VALUES_ARGS=(-f "$CHART_PATH/values-hetzner.yaml")
 
-# Sized for a cold cluster: ingress-nginx ships a pre-install admission
-# Job whose image pull + cert generation, combined with the Hetzner LB
-# provision for the controller Service, can take several minutes. 15m
-# absorbs that with headroom; steady-state runs finish in under a
-# minute and exit as soon as helm finds nothing to roll out.
+if [ "$IS_KURA_REGIONAL_CLUSTER" = true ]; then
+  log "Regional Kura cluster detected; skipping ingress-nginx install"
+  HELM_VALUES_ARGS+=(-f "$CHART_PATH/values-kura-region.yaml")
+else
+  HELM_SET_ARGS+=(
+    --set "ingress-nginx.controller.service.annotations.load-balancer\.hetzner\.cloud/location=${REGION}"
+    --set "ingress-nginx.controller.service.annotations.load-balancer\.hetzner\.cloud/name=${CLUSTER_NAME}-ingress"
+  )
+fi
+
+# Sized for a cold cluster: cert-manager CRDs, webhooks, and, on app
+# clusters, ingress-nginx admission hooks and LB provision can take
+# several minutes. 15m absorbs that with headroom; steady-state runs
+# finish in under a minute and exit as soon as helm finds nothing to
+# roll out.
 HELM_TIMEOUT="15m"
 
 # Helm installs chart CRDs only on `install`, not on `upgrade`. Some
@@ -104,7 +119,8 @@ KUBECONFIG="$WL_KUBECONFIG" kubectl -n platform delete job \
   --ignore-not-found --cascade=foreground --timeout=2m || true
 
 HELM_EXTRA_ARGS=()
-if KUBECONFIG="$WL_KUBECONFIG" helm status platform --namespace platform >/dev/null 2>&1 &&
+if [ "$IS_KURA_REGIONAL_CLUSTER" = false ] &&
+  KUBECONFIG="$WL_KUBECONFIG" helm status platform --namespace platform >/dev/null 2>&1 &&
   KUBECONFIG="$WL_KUBECONFIG" kubectl -n platform get secret platform-ingress-nginx-admission >/dev/null 2>&1; then
   HELM_EXTRA_ARGS+=(--no-hooks)
 fi
@@ -158,7 +174,7 @@ trap dump_diagnostics EXIT
 
 KUBECONFIG="$WL_KUBECONFIG" helm upgrade --install platform "$CHART_PATH" \
   --namespace platform \
-  -f "$CHART_PATH/values-hetzner.yaml" \
+  "${HELM_VALUES_ARGS[@]}" \
   "${HELM_SET_ARGS[@]}" \
   "${HELM_EXTRA_ARGS[@]}" \
   --wait --timeout "$HELM_TIMEOUT"


### PR DESCRIPTION
## Summary

- stop installing ingress-nginx on Kura regional clusters
- add a regional platform overlay for Kura clusters and teach `k8s:install-platform` to apply it automatically
- make `k8s:bootstrap-workload` skip app-ingress and origin-cert steps for Kura regional clusters and validate the shared platform bits instead
- update the production deploy comment and onboarding docs to reflect the regional-cluster topology

## Root cause

Kura regional clusters do not serve traffic through ingress-nginx. Each `KuraInstance` publishes direct per-account `LoadBalancer` Services with `external-dns` hostnames and cert-manager certificates. The generic platform install path was still deploying ingress-nginx there, and on a control-plane-only regional cluster the ingress admission hook job could not schedule. That deadlocked platform upgrades and kept Kura endpoints stuck in `Deploying`.

> [!NOTE]
> `EU Central` looked healthy because it does not use the same cluster path as `US East` and `US West`. `eu-central` runs in the main production cluster (`tuist`), while `us-east` and `us-west` run in separate regional clusters (`tuist-kura-us-east`, `tuist-kura-us-west`). The settings UI also keeps an already-serving region as `Active` during later in-flight deployments, so one healthy region does not imply the regional Kura path is healthy everywhere.

## Impact

- preserves the direct Kura data path instead of making an unused ingress controller schedulable on control-plane nodes
- removes an unnecessary dependency from regional Kura clusters
- keeps app-serving clusters on the existing platform path with ingress-nginx enabled

## Validation

- `bash -n infra/mise/tasks/k8s/install-platform.sh`
- `bash -n infra/mise/tasks/k8s/bootstrap-workload.sh`
- `helm lint infra/helm/platform`
- `helm template platform infra/helm/platform -f infra/helm/platform/values-hetzner.yaml`
- `helm template platform infra/helm/platform -f infra/helm/platform/values-hetzner.yaml -f infra/helm/platform/values-kura-region.yaml` (verifies ingress-nginx resources are omitted)
