### PR TITLE
docs: clarify preview kubeconfig rotation

### DIFF
--- a/infra/k8s/mgmt/ci-service-account.yaml
+++ b/infra/k8s/mgmt/ci-service-account.yaml
@@ -13,8 +13,8 @@
 # chart itself grants in steady state.
 #
 # Applied per-environment by substituting __NAMESPACE__ with the target
-# namespace (tuist-staging / tuist-canary / tuist) and piping into kubectl.
-# Example for staging:
+# namespace (tuist-staging / tuist-canary / tuist; preview uses
+# preview-system) and piping into kubectl. Example for staging:
 #
 #   sed 's/__NAMESPACE__/tuist-staging/g' infra/k8s/mgmt/ci-service-account.yaml \
 #     | kubectl --kubeconfig ~/.kube/tuist-staging.yaml apply -f -

--- a/infra/k8s/onboarding.md
+++ b/infra/k8s/onboarding.md
@@ -77,7 +77,7 @@ Skip this section for production Kura regional clusters. The production server d
 
 ```bash
 WL_KUBECONFIG=~/.kube/<cluster_name>.yaml
-APP_NS=tuist-<env>   # production uses tuist (no suffix)
+APP_NS=tuist-<env>   # production uses tuist (no suffix); preview uses preview-system
 
 sed "s/__NAMESPACE__/${APP_NS}/g" infra/k8s/mgmt/ci-service-account.yaml \
   | KUBECONFIG="$WL_KUBECONFIG" kubectl apply -f -
@@ -111,6 +111,12 @@ KUBECONFIG=/tmp/ci-kubeconfig.yaml kubectl -n "$APP_NS" get pods   # sanity-chec
 base64 < /tmp/ci-kubeconfig.yaml | gh secret set KUBECONFIG \
   --env server-k8s-<env> --repo tuist/tuist
 shred -u /tmp/ci-kubeconfig.yaml
+
+# If the workload cluster's control-plane endpoint changes later (for
+# example after a load-balancer recreation), re-run the minting flow
+# above and refresh the GitHub Environment secret. The kubeconfig
+# embeds `clusters[].cluster.server`, so it does not follow endpoint
+# changes automatically.
 ```
 
 ## 6. First deploy


### PR DESCRIPTION
Resolves n/a

> Clarify the preview-cluster kubeconfig setup in the infra runbook. This documents that the preview deployer lives in `preview-system` and that the `server-k8s-preview` GitHub environment secret must be re-minted if the workload cluster control-plane endpoint changes.

### How to test locally

- `clusterctl get kubeconfig tuist-preview -n org-tuist --kubeconfig ~/.kube/tuist-mgmt.yaml > /tmp/tuist-preview.yaml`
- `KUBECONFIG=/tmp/tuist-preview.yaml kubectl get --raw /version`
- `KUBECONFIG=/tmp/tuist-preview.yaml kubectl get namespaces`
- `gh workflow run preview-sweep.yml --repo tuist/tuist`
- `gh run watch 26030834658 --repo tuist/tuist --exit-status`
