### PR TITLE
docs(blick): flag changeset functions without tests

### DIFF
--- a/.blick/skills/tuist-elixir-review/SKILL.md
+++ b/.blick/skills/tuist-elixir-review/SKILL.md
@@ -376,6 +376,60 @@ description or internal release notes instead.
 
 ---
 
+## 12. Changeset functions must have tests
+
+Ecto changeset functions in schema modules under `server/lib/tuist/`
+(`def changeset/N`, `def create_changeset/N`, `def update_changeset/N`,
+or any other `*_changeset/N`) encode validation and persistence
+contracts. New or materially changed changeset bodies that ship without
+tests regress silently: a deleted `validate_*`, a widened `cast` list,
+or a missing `unique_constraint` won't fail CI — the first signal is a
+production error or a malformed row.
+
+The convention in this repo is one `<schema>_test.exs` per schema module
+that asserts on `errors_on(changeset)` for invalid inputs and
+`changeset.valid?` for valid ones — see
+`server/test/tuist/projects/project_test.exs` and
+`server/test/tuist/cache_action_items/cache_action_item_test.exs` for
+canonical examples.
+
+### Flag (Severity: medium)
+
+- A new `def changeset(`, `def create_changeset(`, `def update_changeset(`,
+  or any `def *_changeset(` added in a `server/lib/tuist/**/*.ex` file
+  whose diff does **not** also add at least one test case calling that
+  function (e.g. `WebhookEndpoint.create_changeset(...)`,
+  `Project.update_changeset(...)`) in `server/test/tuist/**/*_test.exs`.
+- A materially changed changeset body — a new or modified `cast`,
+  `validate_required`, `validate_length`, `validate_format`,
+  `validate_inclusion`, `validate_change`, `unique_constraint`,
+  `foreign_key_constraint`, or `put_change` line in the diff — where
+  the change isn't exercised by a test added or modified in the same
+  diff.
+
+When flagging, name the schema module and point to a sibling
+`<schema>_test.exs` as the place to add coverage. If no such test file
+exists, request its creation alongside the changeset.
+
+### Do not flag
+
+- Trivial mechanical edits (renaming a field already covered by an
+  existing test, removing a single `cast` field, formatting-only churn,
+  reordering pipe steps inside an unchanged body).
+- Changeset functions in `server/test/support/` fixtures or
+  `server/priv/repo/seeds*.exs`.
+- Diffs that exercise the changeset indirectly through a higher-level
+  context test (e.g. `accounts_test.exs` calling
+  `Accounts.create_user/1`, which in turn invokes the changeset) — that
+  counts as coverage. Only flag when the diff has *no* test reference
+  to the schema module or its changeset functions.
+- Changeset edits that are purely a consequence of a column rename
+  already covered by a migration-level test or by an existing
+  `errors_on(changeset)` assertion that still passes against the new
+  field name.
+
+---
+
 ## Out of scope (handled elsewhere — do not flag)
 
 - Module / function naming, pipe-chain start, function ordering,
@@ -391,7 +445,7 @@ description or internal release notes instead.
 For each finding, confirm:
 
 1. The `path:line` is real and the snippet appears in the diff.
-2. The category above is one of 1–11; if it isn't, downgrade to a
+2. The category above is one of 1–12; if it isn't, downgrade to a
    question (`uncertain: ...`) rather than asserting a finding.
 3. The severity is set: **critical** (auth bypass / cross-tenant read or
    write), **high** (likely security or correctness bug), **medium**


### PR DESCRIPTION
### Summary

Adds a new rule (section 12) to the `tuist-elixir-review` Blick skill that flags new or materially changed `*_changeset/N` functions in `server/lib/tuist/**/*.ex` whose diff doesn't include matching test coverage in `server/test/tuist/**/*_test.exs`.

Motivated by review comments on [#10748](https://github.com/tuist/tuist/pull/10748) ([r3258414785](https://github.com/tuist/tuist/pull/10748#discussion_r3258414785), [r3258415347](https://github.com/tuist/tuist/pull/10748#discussion_r3258415347)) that asked for tests on `create_changeset` / `update_changeset` — exactly the kind of gap a reviewer shouldn't have to catch by hand.

### What changed

- New section 12 "Changeset functions must have tests" with explicit Flag / Do-not-flag lists.
- References the canonical patterns at [project_test.exs](server/test/tuist/projects/project_test.exs) and [cache_action_item_test.exs](server/test/tuist/cache_action_items/cache_action_item_test.exs).
- Bumps the category range in "Before submitting findings" from 1–11 to 1–12.

### Notes for reviewers

The Do-not-flag list intentionally excludes trivial mechanical edits and coverage that comes via higher-level context tests (e.g. `Accounts.create_user/1`), to keep the signal-to-noise ratio sane.

### How to test locally

This skill is loaded by Blick on PR runs; no local test step. The rule will exercise itself on the next PR that adds or modifies a changeset.