### PR TITLE
fix(cli): retry run metadata upload on transient errors

### DIFF
--- a/cli/Sources/TuistServer/Services/CreateCommandEventService.swift
+++ b/cli/Sources/TuistServer/Services/CreateCommandEventService.swift
@@ -30,9 +30,29 @@
     }
 
     public struct CreateCommandEventService: CreateCommandEventServicing {
-        public init() {}
+        private let retryProvider: RetryProviding
+
+        public init(
+            retryProvider: RetryProviding = RetryProvider()
+        ) {
+            self.retryProvider = retryProvider
+        }
 
         public func createCommandEvent(
+            commandEvent: CommandEvent,
+            projectId: String,
+            serverURL: URL
+        ) async throws -> ServerCommandEvent {
+            try await retryProvider.runWithRetries {
+                try await sendCreateCommandEvent(
+                    commandEvent: commandEvent,
+                    projectId: projectId,
+                    serverURL: serverURL
+                )
+            }
+        }
+
+        private func sendCreateCommandEvent(
             commandEvent: CommandEvent,
             projectId: String,
             serverURL: URL


### PR DESCRIPTION
> Describe here the purpose of your PR.

The CLI's `createCommandEvent` call (the one that logs `Uploading run metadata...` from `TrackableCommand`) is the only step in the analytics upload flow without a retry wrapper. A single transient 5xx from the server fails the CI command and surfaces as `Failed to upload run metadata: unknownError(502)`, forcing the user to re-run their CI job. Artifact uploads (`MultipartUploadArtifactService`) already wrap their work in `RetryProvider`.

This PR injects `RetryProviding` into `CreateCommandEventService` and runs the API call inside `runWithRetries`, so transient failures (502/503/504, network errors) are retried up to three times with backoff before bubbling up. Same pattern as the existing artifact-upload path.

### How to test locally

> Document how to test your changes locally

- Point the CLI at a server that returns a 502 once and then 200 (e.g. a stub or a temporarily-down endpoint). Run any tracked command and confirm `Uploading run metadata...` succeeds without surfacing `unknownError(502)`.
- Inject a mock `RetryProviding` in a unit test to assert that `createCommandEvent` calls the underlying API up to 3 times on failure.
- Sanity check: a 4xx (e.g. unauthorized) still surfaces as before — the retry will exhaust quickly given the tiny backoff and throw the same typed error.