### PR TITLE
fix(infra): bump runner image to dispatch-built /Users/runner-fix image

### DIFF
--- a/infra/helm/tuist/values-managed-canary.yaml
+++ b/infra/helm/tuist/values-managed-canary.yaml
@@ -137,7 +137,7 @@ runnersFleet:
   pools:
     - name: default
       replicas: 1
-      runnerImage: "ghcr.io/tuist/tuist-runner@sha256:13f45853f4153f6717dff0aad23e7c896e46bc48cc41df4be314605adeadb5ff"
+      runnerImage: "ghcr.io/tuist/tuist-runner@sha256:d4824d8b6a8c7b6d1c2e87dda7f4c4b751ef87f03f87a9c409cfa15756fb198c"
       dispatchLabel: "tuist-canary-macos"
 
 # In-cluster Valkey backs the auth rate limiter (Hammer.Redis). The

--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -232,7 +232,7 @@ runnersFleet:
   pools:
     - name: default
       replicas: 9
-      runnerImage: "ghcr.io/tuist/tuist-runner@sha256:13f45853f4153f6717dff0aad23e7c896e46bc48cc41df4be314605adeadb5ff"
+      runnerImage: "ghcr.io/tuist/tuist-runner@sha256:d4824d8b6a8c7b6d1c2e87dda7f4c4b751ef87f03f87a9c409cfa15756fb198c"
       dispatchLabel: "tuist-macos"
 
 # In-cluster Valkey backs the auth rate limiter (Hammer.Redis). The

--- a/infra/helm/tuist/values-managed-staging.yaml
+++ b/infra/helm/tuist/values-managed-staging.yaml
@@ -235,7 +235,7 @@ runnersFleet:
       # pool only produces unschedulable Pods that drag readiness
       # gates without adding capacity.
       replicas: 1
-      runnerImage: "ghcr.io/tuist/tuist-runner@sha256:13f45853f4153f6717dff0aad23e7c896e46bc48cc41df4be314605adeadb5ff"
+      runnerImage: "ghcr.io/tuist/tuist-runner@sha256:d4824d8b6a8c7b6d1c2e87dda7f4c4b751ef87f03f87a9c409cfa15756fb198c"
       dispatchLabel: "tuist-staging-macos"
       pod:
         # Pod request = host capacity. kube-scheduler bin-packs one


### PR DESCRIPTION
[#10833](https://github.com/tuist/tuist/pull/10833)'s release.yml run failed at a transient \`Timeout waiting for SSH\` step in the Packer build (the dispatch-built variant of the same commit on the same host succeeded, so it's flake), and every subsequent release.yml run has been cancelled by rapid PR merges. So the bot \`[Release] Runner Image\` PR for 0.1.6 never landed. Chart is still pinned to \`runner-image@0.1.5\` = pre-#10833, and every macOS job that needs to mkdir under \`/Users/runner\` at runtime (\`mise\`, \`defaults write\` to \`~/Library/Preferences\`, etc.) keeps hitting EACCES.

## Fix

The dispatch-only [\`runner-image.yml\` run 25999064986](https://github.com/tuist/tuist/actions/runs/25999064986) ran cleanly against #10833's branch yesterday and pushed:

\`\`\`
ghcr.io/tuist/tuist-runner:077082af = sha256:d4824d8b6a8c7b6d1c2e87dda7f4c4b751ef87f03f87a9c409cfa15756fb198c
\`\`\`

Same commit content, same Packer template, same Cirrus base — byte-identical to what \`runner-image@0.1.6\` would have been, just without the versioned tag the auto-release flow produces. Pin all three managed-env values files to that digest so deploys can proceed without waiting on the release pipeline to re-cooperate.

When the auto-release flow recovers (or we re-trigger it manually), the next bot release PR will overwrite this pin with the versioned \`runner-image@0.1.6\` carrying the same content. No content drift, just a temporary tag swap.

## How to test

- [ ] Server deploy on merge succeeds.
- [ ] Warm Pods recycle to the new digest (runners-controller's staggered drain handles the rollout).
- [ ] Reruns of the failing Lint / Unit Tests / Build / Test / Device Build / Build Acceptance Tests jobs on [PR #10793](https://github.com/tuist/tuist/pull/10793) go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)