### PR TITLE
fix(server): drop stale automation framing from webhook copy

### DIFF
--- a/server/lib/tuist_web/live/webhook_live.html.heex
+++ b/server/lib/tuist_web/live/webhook_live.html.heex
@@ -45,7 +45,7 @@
           data-confirm={
             dgettext(
               "dashboard_account",
-              "Delete this endpoint? Automations referencing it will stop delivering."
+              "Delete this endpoint? It will stop receiving event notifications."
             )
           }
         >

--- a/server/lib/tuist_web/live/webhook_live.html.heex
+++ b/server/lib/tuist_web/live/webhook_live.html.heex
@@ -45,7 +45,7 @@
           data-confirm={
             dgettext(
               "dashboard_account",
-              "Delete this endpoint? It will stop receiving event notifications."
+              "Delete this endpoint? It will stop receiving events."
             )
           }
         >

--- a/server/lib/tuist_web/live/webhooks_live.html.heex
+++ b/server/lib/tuist_web/live/webhooks_live.html.heex
@@ -4,7 +4,7 @@
     <span data-part="subtitle">
       {dgettext(
         "dashboard_account",
-        "Configure HTTPS endpoints that receive event notifications from projects in this account."
+        "Configure HTTPS endpoints that receive events from projects in this account."
       )}
     </span>
   </div>
@@ -192,7 +192,7 @@
                   data-confirm={
                     dgettext(
                       "dashboard_account",
-                      "Delete this endpoint? It will stop receiving event notifications."
+                      "Delete this endpoint? It will stop receiving events."
                     )
                   }
                 >
@@ -207,7 +207,7 @@
         <.table_empty_state
           title={dgettext("dashboard_account", "No webhook endpoints yet")}
           subtitle={
-            dgettext("dashboard_account", "Add one to start receiving event notifications.")
+            dgettext("dashboard_account", "Add one to start receiving events.")
           }
         />
       </:empty_state>

--- a/server/lib/tuist_web/live/webhooks_live.html.heex
+++ b/server/lib/tuist_web/live/webhooks_live.html.heex
@@ -4,7 +4,7 @@
     <span data-part="subtitle">
       {dgettext(
         "dashboard_account",
-        "Configure HTTPS endpoints where automations across projects in this account can send events."
+        "Configure HTTPS endpoints that receive event notifications from projects in this account."
       )}
     </span>
   </div>
@@ -192,7 +192,7 @@
                   data-confirm={
                     dgettext(
                       "dashboard_account",
-                      "Delete this endpoint? Automations referencing it will stop delivering."
+                      "Delete this endpoint? It will stop receiving event notifications."
                     )
                   }
                 >
@@ -207,7 +207,7 @@
         <.table_empty_state
           title={dgettext("dashboard_account", "No webhook endpoints yet")}
           subtitle={
-            dgettext("dashboard_account", "Add one to make it available to automation actions.")
+            dgettext("dashboard_account", "Add one to start receiving event notifications.")
           }
         />
       </:empty_state>

--- a/server/priv/gettext/dashboard_account.pot
+++ b/server/priv/gettext/dashboard_account.pot
@@ -1538,7 +1538,7 @@ msgstr[1] ""
 
 #: lib/tuist_web/live/webhooks_live.html.heex:292
 #, elixir-autogen, elixir-format
-msgid "Add one to start receiving event notifications."
+msgid "Add one to start receiving events."
 msgstr ""
 
 #: lib/tuist_web/live/webhook_live.html.heex:126
@@ -1560,7 +1560,7 @@ msgstr ""
 
 #: lib/tuist_web/live/webhooks_live.html.heex:5
 #, elixir-autogen, elixir-format
-msgid "Configure HTTPS endpoints that receive event notifications from projects in this account."
+msgid "Configure HTTPS endpoints that receive events from projects in this account."
 msgstr ""
 
 #: lib/tuist_web/live/webhooks_live.html.heex:52
@@ -1588,7 +1588,7 @@ msgstr ""
 #: lib/tuist_web/live/webhook_live.html.heex:46
 #: lib/tuist_web/live/webhooks_live.html.heex:275
 #, elixir-autogen, elixir-format
-msgid "Delete this endpoint? It will stop receiving event notifications."
+msgid "Delete this endpoint? It will stop receiving events."
 msgstr ""
 
 #: lib/tuist_web/live/webhook_live.ex:230

--- a/server/priv/gettext/dashboard_account.pot
+++ b/server/priv/gettext/dashboard_account.pot
@@ -1538,7 +1538,7 @@ msgstr[1] ""
 
 #: lib/tuist_web/live/webhooks_live.html.heex:292
 #, elixir-autogen, elixir-format
-msgid "Add one to make it available to automation actions."
+msgid "Add one to start receiving event notifications."
 msgstr ""
 
 #: lib/tuist_web/live/webhook_live.html.heex:126
@@ -1560,7 +1560,7 @@ msgstr ""
 
 #: lib/tuist_web/live/webhooks_live.html.heex:5
 #, elixir-autogen, elixir-format
-msgid "Configure HTTPS endpoints where automations across projects in this account can send events."
+msgid "Configure HTTPS endpoints that receive event notifications from projects in this account."
 msgstr ""
 
 #: lib/tuist_web/live/webhooks_live.html.heex:52
@@ -1588,7 +1588,7 @@ msgstr ""
 #: lib/tuist_web/live/webhook_live.html.heex:46
 #: lib/tuist_web/live/webhooks_live.html.heex:275
 #, elixir-autogen, elixir-format
-msgid "Delete this endpoint? Automations referencing it will stop delivering."
+msgid "Delete this endpoint? It will stop receiving event notifications."
 msgstr ""
 
 #: lib/tuist_web/live/webhook_live.ex:230


### PR DESCRIPTION
### Summary

The account-level webhook endpoints page still described itself as plumbing for automation actions, but webhook endpoints subscribe directly to event types now and dispatch independently of the automations feature. Three strings were stale:

- Page subtitle (`webhooks_live.html.heex`)
- Empty-state subtitle (`webhooks_live.html.heex`)
- Delete confirmation, shared between `webhooks_live.html.heex` and `webhook_live.html.heex`

Rewrote each one to describe what the endpoints actually do (receive event notifications) and synced the matching `msgid` entries in `dashboard_account.pot`. Translation `.po` files left untouched per the gettext workflow — Weblate / `tuistit` will pick up the template change.

### How to test locally

- Open the account-level Webhooks page and confirm the page subtitle reads "Configure HTTPS endpoints that receive event notifications from projects in this account."
- With no endpoints configured, the empty-state card now reads "No webhook endpoints yet" / "Add one to start receiving event notifications."
- Open the delete dropdown on any endpoint (account list view and the per-endpoint detail page) and confirm the confirm dialog reads "Delete this endpoint? It will stop receiving event notifications."