### PR TITLE
fix(infra): kill persist pf tables before reload so retries succeed

### DIFF
--- a/infra/macos-host-bootstrap/bootstrap.go
+++ b/infra/macos-host-bootstrap/bootstrap.go
@@ -708,8 +708,8 @@ sudo tee /etc/pf.anchors/tuist.runners >/dev/null <<'PFCONF'
 # IMPORTANT: rules are evaluated last-match-wins; the explicit
 # block lines run AFTER the default pass via the 'quick' keyword.
 
-table <vm_sources> persist { 192.168.64.0/22 }
-table <blocked_dst> persist { 10.0.0.0/8, 172.16.0.0/12, 169.254.0.0/16 }
+table <vm_sources> { 192.168.64.0/22 }
+table <blocked_dst> { 10.0.0.0/8, 172.16.0.0/12, 169.254.0.0/16 }
 
 # Drop VM→private destinations at the host edge.
 block drop out quick from <vm_sources> to <blocked_dst>
@@ -734,14 +734,19 @@ load anchor "tuist.runners" from "/etc/pf.anchors/tuist.runners"
 PFCONFENTRY
 fi
 
-# Flush any state already loaded under our anchor before validating.
-# The 'persist' tables defined in the anchor file (vm_sources,
-# blocked_dst) survive across 'pfctl -f' invocations once loaded;
-# without flushing, a re-run on an already-bootstrapped host fails
-# the validation step below with 'cannot define table vm_sources:
-# Resource busy'. Flushing only our own anchor leaves the system's
-# main ruleset untouched. Tolerate failure here — on a first-run
-# host the anchor doesn't exist yet, and pfctl returns non-zero.
+# Kill any kernel-resident tables from a previous bootstrap pass
+# before the validate. The tables are declared in the anchor file
+# without 'persist' so a clean ruleset load drops them, but hosts
+# that previously ran a 'persist'-flagged version of this script
+# carry the tables in kernel state until something explicitly
+# destroys them — 'pfctl -F all' on the anchor flushes entries and
+# rules but NOT persist tables, so subsequent `pfctl -nf` parses
+# still die on 'cannot define table vm_sources: Resource busy'.
+# `-T kill` actually removes the table from kernel state.
+# Tolerate failure here on first-run hosts where the tables don't
+# yet exist.
+sudo pfctl -a tuist.runners -t vm_sources -T kill 2>/dev/null || true
+sudo pfctl -a tuist.runners -t blocked_dst -T kill 2>/dev/null || true
 sudo pfctl -a tuist.runners -F all 2>/dev/null || true
 
 # Validate the ruleset before activating. -nf parses without

--- a/infra/macos-host-bootstrap/bootstrap.go
+++ b/infra/macos-host-bootstrap/bootstrap.go
@@ -740,9 +740,9 @@ fi
 # that previously ran a 'persist'-flagged version of this script
 # carry the tables in kernel state until something explicitly
 # destroys them — 'pfctl -F all' on the anchor flushes entries and
-# rules but NOT persist tables, so subsequent `pfctl -nf` parses
+# rules but NOT persist tables, so subsequent 'pfctl -nf' parses
 # still die on 'cannot define table vm_sources: Resource busy'.
-# `-T kill` actually removes the table from kernel state.
+# '-T kill' actually removes the table from kernel state.
 # Tolerate failure here on first-run hosts where the tables don't
 # yet exist.
 sudo pfctl -a tuist.runners -t vm_sources -T kill 2>/dev/null || true


### PR DESCRIPTION
Direct visibility from prod's kubectl:

\`\`\`
$ kubectl get scalewayapplesiliconmachine -A | grep mndbc
…hz6vv   true     Ready
…m789d   true     Ready
…m7r47   true     Ready
…sblfl   true     Ready
…xs6fx   true     Ready
…bzd26   <none>   Bootstrapping
…ffjpx   <none>   Bootstrapping
…hfqmh   <none>   Bootstrapping
…k6kwt   <none>   Bootstrapping
\`\`\`

Five hosts recovered after the capi-scaleway image with the pf-flush fix deployed, but four (bzd26, ffjpx, hfqmh, k6kwt) are still stuck — effective warm capacity is **5/9**, which is why concurrency on PR #10793 keeps capping out and jobs queue.

Reading bzd26's machine status:

\`\`\`
reason: BootstrapFailed
message: |
  pfctl: /etc/pf.anchors/tuist.runners:11: cannot define table vm_sources: Resource busy
  pfctl: /etc/pf.anchors/tuist.runners:12: cannot define table blocked_dst: Resource busy
  pfctl: Syntax error in config file: pf rules not loaded
\`\`\`

## Root cause

The flush we added in #10798 IS running on these hosts, but it can't actually destroy the tables. \`pfctl -F all\` on an anchor flushes its rules and table *entries*, but leaves \`persist\`-flagged tables alive in kernel state. The anchor file declares both tables \`persist\` (so they survive runtime entry adds), so the next \`pfctl -nf\` validation tries to redeclare a name the kernel already owns → \`Resource busy\`.

## Fix

1. **Drop \`persist\` from the table declarations.** The contents are static (192.168.64.0/22 sources, RFC1918+link-local destinations) — we never \`pfctl -T add\` at runtime, so there's no reason to keep tables alive across rule flushes. Without \`persist\`, every reload cleanly recreates them.

2. **Add \`pfctl -t <name> -T kill\` for both tables before the flush.** Handles existing hosts that have the persist-flagged versions baked into kernel state from a previous bootstrap pass. \`-T kill\` actually destroys the table; \`-F all\` doesn't.

After this lands and the operator image rebuilds, the four stuck hosts should clear their bootstrap loop on the next reconcile tick, restoring the full 9-replica warm pool.

## How to test

- [ ] Operator image rebuild + deploy via the next release.yml run.
- [ ] \`kubectl get scalewayapplesiliconmachine -A | grep Bootstrapping\` returns no rows after one reconcile cycle.
- [ ] Effective warm capacity = 9; CI on macOS jobs stops queueing behind 5-Pod cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)