### PR TITLE
fix(server): collapse webhook empty-state subtitle to fix mix format

### DIFF
--- a/server/lib/tuist_web/live/webhooks_live.html.heex
+++ b/server/lib/tuist_web/live/webhooks_live.html.heex
@@ -206,9 +206,7 @@
       <:empty_state>
         <.table_empty_state
           title={dgettext("dashboard_account", "No webhook endpoints yet")}
-          subtitle={
-            dgettext("dashboard_account", "Add one to start receiving events.")
-          }
+          subtitle={dgettext("dashboard_account", "Add one to start receiving events.")}
         />
       </:empty_state>
     </.table>


### PR DESCRIPTION
## Summary
- Format check on main is failing because `subtitle={dgettext(...)}` in the webhooks empty-state was wrapped across three lines after #10846 trimmed the string. `mix format` prefers the single-line form.
- Failing run: https://github.com/tuist/tuist/actions/runs/26043992028/job/76563065418

## Test plan
- [x] `mix format --check-formatted server/lib/tuist_web/live/webhooks_live.html.heex` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)