### PR TITLE
feat(server): instrument runners dispatch path and extend Grafana dashboard

### DIFF
--- a/infra/grafana-dashboards/runners.json
+++ b/infra/grafana-dashboards/runners.json
@@ -41,7 +41,7 @@
         {
           "current": { "selected": false, "text": "All", "value": "$__all" },
           "datasource": "$datasource",
-          "definition": "label_values(tuist_runners_accounts_enabled, job)",
+          "definition": "label_values(tuist_runners_pool_replicas_desired, job)",
           "hide": 0,
           "includeAll": true,
           "label": "Server job",
@@ -50,7 +50,7 @@
           "options": [],
           "query": {
             "qryType": 1,
-            "query": "label_values(tuist_runners_accounts_enabled, job)",
+            "query": "label_values(tuist_runners_pool_replicas_desired, job)",
             "refId": "PrometheusVariableQueryEditor-VariableQuery"
           },
           "refresh": 1,
@@ -266,43 +266,6 @@
       },
       {
         "datasource": "$datasource",
-        "description": "Accounts with `runner_max_concurrent > 0` — the tenant base actively eligible to receive dispatched work. Flat day-over-day is healthy; a sudden drop probably means a billing-side flag flipped a cohort to 0.",
-        "fieldConfig": {
-          "defaults": {
-            "color": { "mode": "thresholds" },
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                { "color": "blue", "value": null }
-              ]
-            },
-            "unit": "short"
-          }
-        },
-        "gridPos": { "h": 4, "w": 4, "x": 16, "y": 1 },
-        "id": 114,
-        "options": {
-          "colorMode": "background",
-          "graphMode": "none",
-          "justifyMode": "center",
-          "orientation": "horizontal",
-          "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
-          "textMode": "auto"
-        },
-        "targets": [
-          {
-            "datasource": "$datasource",
-            "editorMode": "code",
-            "expr": "max(tuist_runners_accounts_enabled{job=~\"$server_job\"})",
-            "instant": true,
-            "refId": "A"
-          }
-        ],
-        "title": "Accounts enabled",
-        "type": "stat"
-      },
-      {
-        "datasource": "$datasource",
         "description": "Mac minis where tart-kubelet's controller-runtime metrics endpoint is reachable. Bound to the tailnet IP when --node-ip-source=tailscale, scraped through the Tailscale operator's egress ProxyGroup. A drop here is a routing failure (ProxyGroup pod down, ACL drift, missing egress Service) before it's a host failure; the node_exporter scrape on :9100 is the second sanity check.",
         "fieldConfig": {
           "defaults": {
@@ -319,7 +282,7 @@
             "unit": "none"
           }
         },
-        "gridPos": { "h": 4, "w": 4, "x": 20, "y": 1 },
+        "gridPos": { "h": 4, "w": 4, "x": 16, "y": 1 },
         "id": 1,
         "options": {
           "colorMode": "background",

--- a/infra/grafana-dashboards/runners.json
+++ b/infra/grafana-dashboards/runners.json
@@ -71,7 +71,7 @@
           "options": [],
           "query": {
             "qryType": 1,
-            "query": "label_values(tuist_runners_pool_replicas_desired, pool)",
+            "query": "label_values(tuist_runners_pool_replicas_desired, fleet)",
             "refId": "PrometheusVariableQueryEditor-VariableQuery"
           },
           "refresh": 1,

--- a/infra/grafana-dashboards/runners.json
+++ b/infra/grafana-dashboards/runners.json
@@ -10,7 +10,7 @@
   "spec": {
     "title": "Tuist Runners",
     "uid": "tuist-runners",
-    "description": "VM boot duration for the customer-runner Mac mini fleet, emitted by tart-kubelet on each Mac mini and scraped over the tailnet.",
+    "description": "Health of the Tuist-managed GitHub Actions runner fleet. Combines server-side dispatch + lifecycle telemetry (PromEx) with host-side VM boot telemetry scraped from each Mac mini's tart-kubelet over the tailnet.",
     "schemaVersion": 39,
     "refresh": "30s",
     "tags": ["tuist", "runners", "macos"],
@@ -39,16 +39,54 @@
           "type": "datasource"
         },
         {
-          "current": {
-            "selected": false,
-            "text": "All",
-            "value": "$__all"
+          "current": { "selected": false, "text": "All", "value": "$__all" },
+          "datasource": "$datasource",
+          "definition": "label_values(tuist_runners_accounts_enabled, job)",
+          "hide": 0,
+          "includeAll": true,
+          "label": "Server job",
+          "multi": true,
+          "name": "server_job",
+          "options": [],
+          "query": {
+            "qryType": 1,
+            "query": "label_values(tuist_runners_accounts_enabled, job)",
+            "refId": "PrometheusVariableQueryEditor-VariableQuery"
           },
+          "refresh": 1,
+          "regex": "",
+          "skipUrlSync": false,
+          "sort": 1,
+          "type": "query"
+        },
+        {
+          "current": { "selected": false, "text": "All", "value": "$__all" },
+          "datasource": "$datasource",
+          "definition": "label_values(tuist_runners_pool_replicas_desired, fleet)",
+          "hide": 0,
+          "includeAll": true,
+          "label": "Fleet",
+          "multi": true,
+          "name": "fleet",
+          "options": [],
+          "query": {
+            "qryType": 1,
+            "query": "label_values(tuist_runners_pool_replicas_desired, pool)",
+            "refId": "PrometheusVariableQueryEditor-VariableQuery"
+          },
+          "refresh": 1,
+          "regex": "",
+          "skipUrlSync": false,
+          "sort": 1,
+          "type": "query"
+        },
+        {
+          "current": { "selected": false, "text": "All", "value": "$__all" },
           "datasource": "$datasource",
           "definition": "label_values(tart_kubelet_vm_boot_duration_seconds_count, pool)",
           "hide": 0,
           "includeAll": true,
-          "label": "Pool",
+          "label": "Mac mini pool",
           "multi": true,
           "name": "pool",
           "options": [],
@@ -76,6 +114,195 @@
       },
       {
         "datasource": "$datasource",
+        "description": "Workflow jobs currently queued waiting for a runner. Polled from ClickHouse `runner_jobs` (status='queued') every 30s. A sustained non-zero queue with idle Pods suggests dispatch is failing; a sustained non-zero queue with no idle Pods means we're at capacity.",
+        "fieldConfig": {
+          "defaults": {
+            "color": { "mode": "thresholds" },
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                { "color": "green", "value": null },
+                { "color": "yellow", "value": 5 },
+                { "color": "red", "value": 25 }
+              ]
+            },
+            "unit": "short"
+          }
+        },
+        "gridPos": { "h": 4, "w": 4, "x": 0, "y": 1 },
+        "id": 110,
+        "options": {
+          "colorMode": "background",
+          "graphMode": "area",
+          "justifyMode": "center",
+          "orientation": "horizontal",
+          "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+          "textMode": "auto"
+        },
+        "targets": [
+          {
+            "datasource": "$datasource",
+            "editorMode": "code",
+            "expr": "sum(tuist_runners_queue_length{job=~\"$server_job\"})",
+            "instant": true,
+            "refId": "A"
+          }
+        ],
+        "title": "Queued jobs",
+        "type": "stat"
+      },
+      {
+        "datasource": "$datasource",
+        "description": "PG `runner_claims` rows in `lifecycle_state='claimed'` — work the server has handed to a Pod but for which JIT mint hasn't yet completed. Steady-state near zero; a climbing value points to the JIT-mint path stalling and `StaleClaimsWorker` not yet sweeping.",
+        "fieldConfig": {
+          "defaults": {
+            "color": { "mode": "thresholds" },
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                { "color": "green", "value": null },
+                { "color": "yellow", "value": 3 },
+                { "color": "red", "value": 10 }
+              ]
+            },
+            "unit": "short"
+          }
+        },
+        "gridPos": { "h": 4, "w": 4, "x": 4, "y": 1 },
+        "id": 111,
+        "options": {
+          "colorMode": "background",
+          "graphMode": "area",
+          "justifyMode": "center",
+          "orientation": "horizontal",
+          "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+          "textMode": "auto"
+        },
+        "targets": [
+          {
+            "datasource": "$datasource",
+            "editorMode": "code",
+            "expr": "sum(tuist_runners_claims_count{job=~\"$server_job\", lifecycle_state=\"claimed\"})",
+            "instant": true,
+            "refId": "A"
+          }
+        ],
+        "title": "Pre-mint (claimed)",
+        "type": "stat"
+      },
+      {
+        "datasource": "$datasource",
+        "description": "Active customer builds on the fleet — PG claims in `lifecycle_state='running'`. Real cap occupancy; compare against the per-account `runner_max_concurrent` to spot account-level contention.",
+        "fieldConfig": {
+          "defaults": {
+            "color": { "mode": "thresholds" },
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                { "color": "blue", "value": null }
+              ]
+            },
+            "unit": "short"
+          }
+        },
+        "gridPos": { "h": 4, "w": 4, "x": 8, "y": 1 },
+        "id": 112,
+        "options": {
+          "colorMode": "background",
+          "graphMode": "area",
+          "justifyMode": "center",
+          "orientation": "horizontal",
+          "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+          "textMode": "auto"
+        },
+        "targets": [
+          {
+            "datasource": "$datasource",
+            "editorMode": "code",
+            "expr": "sum(tuist_runners_claims_count{job=~\"$server_job\", lifecycle_state=\"running\"})",
+            "instant": true,
+            "refId": "A"
+          }
+        ],
+        "title": "Running builds",
+        "type": "stat"
+      },
+      {
+        "datasource": "$datasource",
+        "description": "Sum of `spec.replicas` across every RunnerPool — the warm-pool capacity the controller is asked to maintain. Compare with the `observed` ribbon below to see when the controller is mid-rollout or short on Mac mini capacity.",
+        "fieldConfig": {
+          "defaults": {
+            "color": { "mode": "thresholds" },
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                { "color": "blue", "value": null }
+              ]
+            },
+            "unit": "short"
+          }
+        },
+        "gridPos": { "h": 4, "w": 4, "x": 12, "y": 1 },
+        "id": 113,
+        "options": {
+          "colorMode": "background",
+          "graphMode": "none",
+          "justifyMode": "center",
+          "orientation": "horizontal",
+          "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+          "textMode": "auto"
+        },
+        "targets": [
+          {
+            "datasource": "$datasource",
+            "editorMode": "code",
+            "expr": "sum(tuist_runners_pool_replicas_desired{job=~\"$server_job\"})",
+            "instant": true,
+            "refId": "A"
+          }
+        ],
+        "title": "Desired runners",
+        "type": "stat"
+      },
+      {
+        "datasource": "$datasource",
+        "description": "Accounts with `runner_max_concurrent > 0` — the tenant base actively eligible to receive dispatched work. Flat day-over-day is healthy; a sudden drop probably means a billing-side flag flipped a cohort to 0.",
+        "fieldConfig": {
+          "defaults": {
+            "color": { "mode": "thresholds" },
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                { "color": "blue", "value": null }
+              ]
+            },
+            "unit": "short"
+          }
+        },
+        "gridPos": { "h": 4, "w": 4, "x": 16, "y": 1 },
+        "id": 114,
+        "options": {
+          "colorMode": "background",
+          "graphMode": "none",
+          "justifyMode": "center",
+          "orientation": "horizontal",
+          "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+          "textMode": "auto"
+        },
+        "targets": [
+          {
+            "datasource": "$datasource",
+            "editorMode": "code",
+            "expr": "max(tuist_runners_accounts_enabled{job=~\"$server_job\"})",
+            "instant": true,
+            "refId": "A"
+          }
+        ],
+        "title": "Accounts enabled",
+        "type": "stat"
+      },
+      {
+        "datasource": "$datasource",
         "description": "Mac minis where tart-kubelet's controller-runtime metrics endpoint is reachable. Bound to the tailnet IP when --node-ip-source=tailscale, scraped through the Tailscale operator's egress ProxyGroup. A drop here is a routing failure (ProxyGroup pod down, ACL drift, missing egress Service) before it's a host failure; the node_exporter scrape on :9100 is the second sanity check.",
         "fieldConfig": {
           "defaults": {
@@ -92,18 +319,14 @@
             "unit": "none"
           }
         },
-        "gridPos": { "h": 4, "w": 6, "x": 0, "y": 1 },
+        "gridPos": { "h": 4, "w": 4, "x": 20, "y": 1 },
         "id": 1,
         "options": {
           "colorMode": "background",
           "graphMode": "none",
           "justifyMode": "center",
           "orientation": "horizontal",
-          "reduceOptions": {
-            "calcs": ["lastNotNull"],
-            "fields": "",
-            "values": false
-          },
+          "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
           "textMode": "auto"
         },
         "pluginVersion": "11.0.0",
@@ -123,6 +346,750 @@
         "collapsed": false,
         "gridPos": { "h": 1, "w": 24, "x": 0, "y": 5 },
         "id": 200,
+        "panels": [],
+        "title": "Throughput",
+        "type": "row"
+      },
+      {
+        "datasource": "$datasource",
+        "description": "Workflow jobs entering the queue per second, by fleet. Source: `workflow_job.queued` webhook. The first signal that customer traffic exists. A drop while builds are still running indicates webhook delivery problems or a Tuist GitHub App outage.",
+        "fieldConfig": {
+          "defaults": {
+            "color": { "mode": "palette-classic" },
+            "custom": {
+              "drawStyle": "line",
+              "fillOpacity": 10,
+              "lineInterpolation": "linear",
+              "lineWidth": 2,
+              "pointSize": 5,
+              "showPoints": "never",
+              "spanNulls": false,
+              "stacking": { "group": "A", "mode": "none" }
+            },
+            "unit": "ops"
+          }
+        },
+        "gridPos": { "h": 8, "w": 12, "x": 0, "y": 6 },
+        "id": 210,
+        "options": {
+          "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "right" },
+          "tooltip": { "mode": "multi", "sort": "desc" }
+        },
+        "targets": [
+          {
+            "datasource": "$datasource",
+            "editorMode": "code",
+            "expr": "sum by (fleet) (rate(tuist_runners_job_enqueued_count{job=~\"$server_job\", fleet=~\"$fleet\"}[5m]))",
+            "legendFormat": "{{fleet}}",
+            "refId": "A"
+          }
+        ],
+        "title": "Jobs enqueued / sec by fleet",
+        "type": "timeseries"
+      },
+      {
+        "datasource": "$datasource",
+        "description": "Workflow job completions per second, grouped by GitHub conclusion. A `success`-dominated stack is healthy; a `failure` floor that creeps above the historical baseline points to flaky tests in customer pipelines OR a runner-image regression — diff against recent `runner-image` workflow runs to disambiguate.",
+        "fieldConfig": {
+          "defaults": {
+            "color": { "mode": "palette-classic" },
+            "custom": {
+              "drawStyle": "line",
+              "fillOpacity": 30,
+              "lineInterpolation": "linear",
+              "lineWidth": 2,
+              "pointSize": 5,
+              "showPoints": "never",
+              "spanNulls": false,
+              "stacking": { "group": "A", "mode": "normal" }
+            },
+            "unit": "ops"
+          },
+          "overrides": [
+            { "matcher": { "id": "byName", "options": "success" }, "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "green" } }] },
+            { "matcher": { "id": "byName", "options": "failure" }, "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "red" } }] },
+            { "matcher": { "id": "byName", "options": "cancelled" }, "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "orange" } }] }
+          ]
+        },
+        "gridPos": { "h": 8, "w": 12, "x": 12, "y": 6 },
+        "id": 211,
+        "options": {
+          "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "right" },
+          "tooltip": { "mode": "multi", "sort": "desc" }
+        },
+        "targets": [
+          {
+            "datasource": "$datasource",
+            "editorMode": "code",
+            "expr": "sum by (conclusion) (rate(tuist_runners_job_completed_count{job=~\"$server_job\", fleet=~\"$fleet\"}[5m]))",
+            "legendFormat": "{{conclusion}}",
+            "refId": "A"
+          }
+        ],
+        "title": "Jobs completed / sec by conclusion",
+        "type": "timeseries"
+      },
+      {
+        "datasource": "$datasource",
+        "description": "Jobs reaching `claimed` (off the queue) and `running` (after JIT mint) per second. The `claimed`→`running` gap is the JIT-mint window; a widening gap means the GitHub API path or K8s pod-patch path is slow.",
+        "fieldConfig": {
+          "defaults": {
+            "color": { "mode": "palette-classic" },
+            "custom": {
+              "drawStyle": "line",
+              "fillOpacity": 10,
+              "lineInterpolation": "linear",
+              "lineWidth": 2,
+              "pointSize": 5,
+              "showPoints": "never",
+              "spanNulls": false,
+              "stacking": { "group": "A", "mode": "none" }
+            },
+            "unit": "ops"
+          }
+        },
+        "gridPos": { "h": 8, "w": 12, "x": 0, "y": 14 },
+        "id": 212,
+        "options": {
+          "legend": { "calcs": ["mean"], "displayMode": "table", "placement": "right" },
+          "tooltip": { "mode": "multi", "sort": "desc" }
+        },
+        "targets": [
+          {
+            "datasource": "$datasource",
+            "editorMode": "code",
+            "expr": "sum(rate(tuist_runners_job_claim_count{job=~\"$server_job\", fleet=~\"$fleet\", outcome=\"ok\"}[5m]))",
+            "legendFormat": "claimed",
+            "refId": "A"
+          },
+          {
+            "datasource": "$datasource",
+            "editorMode": "code",
+            "expr": "sum(rate(tuist_runners_job_running_count{job=~\"$server_job\", fleet=~\"$fleet\"}[5m]))",
+            "legendFormat": "running",
+            "refId": "B"
+          }
+        ],
+        "title": "Claim and run rate",
+        "type": "timeseries"
+      },
+      {
+        "datasource": "$datasource",
+        "description": "GitHub `workflow_job` webhooks received, bucketed by action and outcome. `queued/queued` and `completed/completed` should track each other steady-state; `*/ignored` rows are workflows whose `runs-on` didn't match a Tuist pool (perfectly normal in mixed-runner orgs).",
+        "fieldConfig": {
+          "defaults": {
+            "color": { "mode": "palette-classic" },
+            "custom": {
+              "drawStyle": "line",
+              "fillOpacity": 10,
+              "lineInterpolation": "linear",
+              "lineWidth": 2,
+              "pointSize": 5,
+              "showPoints": "never",
+              "spanNulls": false,
+              "stacking": { "group": "A", "mode": "none" }
+            },
+            "unit": "ops"
+          }
+        },
+        "gridPos": { "h": 8, "w": 12, "x": 12, "y": 14 },
+        "id": 213,
+        "options": {
+          "legend": { "calcs": ["mean"], "displayMode": "table", "placement": "right" },
+          "tooltip": { "mode": "multi", "sort": "desc" }
+        },
+        "targets": [
+          {
+            "datasource": "$datasource",
+            "editorMode": "code",
+            "expr": "sum by (action, outcome) (rate(tuist_runners_webhook_count{job=~\"$server_job\"}[5m]))",
+            "legendFormat": "{{action}} / {{outcome}}",
+            "refId": "A"
+          }
+        ],
+        "title": "Webhook deliveries by action and outcome",
+        "type": "timeseries"
+      },
+      {
+        "collapsed": false,
+        "gridPos": { "h": 1, "w": 24, "x": 0, "y": 22 },
+        "id": 300,
+        "panels": [],
+        "title": "Latency",
+        "type": "row"
+      },
+      {
+        "datasource": "$datasource",
+        "description": "Time a workflow job sits queued before a polling Pod claims it. p50 ~= idle pool latency (sub-second); p95 / p99 climb when the pool is at capacity and queue depth grows. Combine with the queue-length stat on the overview row to disambiguate between \"no idle Pods\" and \"dispatch is stuck\".",
+        "fieldConfig": {
+          "defaults": {
+            "color": { "mode": "palette-classic" },
+            "custom": {
+              "drawStyle": "line",
+              "fillOpacity": 10,
+              "lineInterpolation": "linear",
+              "lineWidth": 2,
+              "pointSize": 5,
+              "showPoints": "never",
+              "spanNulls": false,
+              "stacking": { "group": "A", "mode": "none" }
+            },
+            "unit": "ms"
+          }
+        },
+        "gridPos": { "h": 8, "w": 12, "x": 0, "y": 23 },
+        "id": 310,
+        "options": {
+          "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "right" },
+          "tooltip": { "mode": "multi", "sort": "desc" }
+        },
+        "targets": [
+          {
+            "datasource": "$datasource",
+            "editorMode": "code",
+            "expr": "histogram_quantile(0.50, sum by (le) (rate(tuist_runners_job_queue_time_milliseconds_bucket{job=~\"$server_job\", fleet=~\"$fleet\"}[5m])))",
+            "legendFormat": "p50",
+            "refId": "A"
+          },
+          {
+            "datasource": "$datasource",
+            "editorMode": "code",
+            "expr": "histogram_quantile(0.95, sum by (le) (rate(tuist_runners_job_queue_time_milliseconds_bucket{job=~\"$server_job\", fleet=~\"$fleet\"}[5m])))",
+            "legendFormat": "p95",
+            "refId": "B"
+          },
+          {
+            "datasource": "$datasource",
+            "editorMode": "code",
+            "expr": "histogram_quantile(0.99, sum by (le) (rate(tuist_runners_job_queue_time_milliseconds_bucket{job=~\"$server_job\", fleet=~\"$fleet\"}[5m])))",
+            "legendFormat": "p99",
+            "refId": "C"
+          }
+        ],
+        "title": "Queue time (enqueue → claim)",
+        "type": "timeseries"
+      },
+      {
+        "datasource": "$datasource",
+        "description": "Time from claim to the running transition — covers JIT mint (GitHub API) and the Pod label patch. Independent of queue depth. A widening p95 here is almost always a GitHub API regression (rate limiting, latency on the JIT endpoint) since the local steps are sub-millisecond.",
+        "fieldConfig": {
+          "defaults": {
+            "color": { "mode": "palette-classic" },
+            "custom": {
+              "drawStyle": "line",
+              "fillOpacity": 10,
+              "lineInterpolation": "linear",
+              "lineWidth": 2,
+              "pointSize": 5,
+              "showPoints": "never",
+              "spanNulls": false,
+              "stacking": { "group": "A", "mode": "none" }
+            },
+            "unit": "ms"
+          }
+        },
+        "gridPos": { "h": 8, "w": 12, "x": 12, "y": 23 },
+        "id": 311,
+        "options": {
+          "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "right" },
+          "tooltip": { "mode": "multi", "sort": "desc" }
+        },
+        "targets": [
+          {
+            "datasource": "$datasource",
+            "editorMode": "code",
+            "expr": "histogram_quantile(0.50, sum by (le) (rate(tuist_runners_job_queue_to_running_time_milliseconds_bucket{job=~\"$server_job\", fleet=~\"$fleet\"}[5m]))) - histogram_quantile(0.50, sum by (le) (rate(tuist_runners_job_queue_time_milliseconds_bucket{job=~\"$server_job\", fleet=~\"$fleet\"}[5m])))",
+            "legendFormat": "p50 (claim→running, approx)",
+            "refId": "A"
+          },
+          {
+            "datasource": "$datasource",
+            "editorMode": "code",
+            "expr": "histogram_quantile(0.50, sum by (le) (rate(tuist_runners_job_queue_to_running_time_milliseconds_bucket{job=~\"$server_job\", fleet=~\"$fleet\"}[5m])))",
+            "legendFormat": "p50 (total enqueue→running)",
+            "refId": "B"
+          },
+          {
+            "datasource": "$datasource",
+            "editorMode": "code",
+            "expr": "histogram_quantile(0.95, sum by (le) (rate(tuist_runners_job_queue_to_running_time_milliseconds_bucket{job=~\"$server_job\", fleet=~\"$fleet\"}[5m])))",
+            "legendFormat": "p95 (total enqueue→running)",
+            "refId": "C"
+          }
+        ],
+        "title": "Enqueue → running (JIT-mint included)",
+        "type": "timeseries"
+      },
+      {
+        "datasource": "$datasource",
+        "description": "Wall-clock execution time on the runner — `started_at` to `completed_at`. This is the customer build duration, not Tuist infra. Useful as a baseline against the host-side `tart_kubelet_vm_boot_duration_seconds` to see what fraction of total time is infra overhead vs build work.",
+        "fieldConfig": {
+          "defaults": {
+            "color": { "mode": "palette-classic" },
+            "custom": {
+              "drawStyle": "line",
+              "fillOpacity": 10,
+              "lineInterpolation": "linear",
+              "lineWidth": 2,
+              "pointSize": 5,
+              "showPoints": "never",
+              "spanNulls": false,
+              "stacking": { "group": "A", "mode": "none" }
+            },
+            "unit": "ms"
+          }
+        },
+        "gridPos": { "h": 8, "w": 12, "x": 0, "y": 31 },
+        "id": 312,
+        "options": {
+          "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "right" },
+          "tooltip": { "mode": "multi", "sort": "desc" }
+        },
+        "targets": [
+          {
+            "datasource": "$datasource",
+            "editorMode": "code",
+            "expr": "histogram_quantile(0.50, sum by (le) (rate(tuist_runners_job_run_time_milliseconds_bucket{job=~\"$server_job\", fleet=~\"$fleet\"}[10m])))",
+            "legendFormat": "p50",
+            "refId": "A"
+          },
+          {
+            "datasource": "$datasource",
+            "editorMode": "code",
+            "expr": "histogram_quantile(0.95, sum by (le) (rate(tuist_runners_job_run_time_milliseconds_bucket{job=~\"$server_job\", fleet=~\"$fleet\"}[10m])))",
+            "legendFormat": "p95",
+            "refId": "B"
+          },
+          {
+            "datasource": "$datasource",
+            "editorMode": "code",
+            "expr": "histogram_quantile(0.99, sum by (le) (rate(tuist_runners_job_run_time_milliseconds_bucket{job=~\"$server_job\", fleet=~\"$fleet\"}[10m])))",
+            "legendFormat": "p99",
+            "refId": "C"
+          }
+        ],
+        "title": "Run time (running → completed)",
+        "type": "timeseries"
+      },
+      {
+        "datasource": "$datasource",
+        "description": "End-to-end time from `workflow_job.queued` webhook arrival to `workflow_job.completed` — the customer-visible \"how long until my build is done?\" number. Splits into queue + JIT-mint + run; the latency panels above isolate each component.",
+        "fieldConfig": {
+          "defaults": {
+            "color": { "mode": "palette-classic" },
+            "custom": {
+              "drawStyle": "line",
+              "fillOpacity": 10,
+              "lineInterpolation": "linear",
+              "lineWidth": 2,
+              "pointSize": 5,
+              "showPoints": "never",
+              "spanNulls": false,
+              "stacking": { "group": "A", "mode": "none" }
+            },
+            "unit": "ms"
+          }
+        },
+        "gridPos": { "h": 8, "w": 12, "x": 12, "y": 31 },
+        "id": 313,
+        "options": {
+          "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "right" },
+          "tooltip": { "mode": "multi", "sort": "desc" }
+        },
+        "targets": [
+          {
+            "datasource": "$datasource",
+            "editorMode": "code",
+            "expr": "histogram_quantile(0.50, sum by (le) (rate(tuist_runners_job_total_time_milliseconds_bucket{job=~\"$server_job\", fleet=~\"$fleet\"}[10m])))",
+            "legendFormat": "p50",
+            "refId": "A"
+          },
+          {
+            "datasource": "$datasource",
+            "editorMode": "code",
+            "expr": "histogram_quantile(0.95, sum by (le) (rate(tuist_runners_job_total_time_milliseconds_bucket{job=~\"$server_job\", fleet=~\"$fleet\"}[10m])))",
+            "legendFormat": "p95",
+            "refId": "B"
+          },
+          {
+            "datasource": "$datasource",
+            "editorMode": "code",
+            "expr": "histogram_quantile(0.99, sum by (le) (rate(tuist_runners_job_total_time_milliseconds_bucket{job=~\"$server_job\", fleet=~\"$fleet\"}[10m])))",
+            "legendFormat": "p99",
+            "refId": "C"
+          }
+        ],
+        "title": "Total time (enqueue → completed)",
+        "type": "timeseries"
+      },
+      {
+        "datasource": "$datasource",
+        "description": "Distribution of queue wait times as a heatmap. Surfaces multi-modal patterns the quantile lines hide — e.g. a fast-dispatch population at <100ms overlapping a saturated-pool population sitting at >30s.",
+        "fieldConfig": {
+          "defaults": {
+            "custom": {
+              "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+              "scaleDistribution": { "type": "linear" }
+            }
+          }
+        },
+        "gridPos": { "h": 8, "w": 24, "x": 0, "y": 39 },
+        "id": 314,
+        "options": {
+          "calculate": false,
+          "cellGap": 1,
+          "color": {
+            "exponent": 0.5,
+            "fill": "dark-orange",
+            "mode": "scheme",
+            "reverse": false,
+            "scale": "exponential",
+            "scheme": "Blues",
+            "steps": 64
+          },
+          "exemplars": { "color": "rgba(255,0,255,0.7)" },
+          "filterValues": { "le": 1e-9 },
+          "legend": { "show": true },
+          "rowsFrame": { "layout": "auto" },
+          "tooltip": { "show": true, "yHistogram": false },
+          "yAxis": { "axisPlacement": "left", "reverse": false, "unit": "ms" }
+        },
+        "targets": [
+          {
+            "datasource": "$datasource",
+            "editorMode": "code",
+            "expr": "sum by (le) (rate(tuist_runners_job_queue_time_milliseconds_bucket{job=~\"$server_job\", fleet=~\"$fleet\"}[5m]))",
+            "format": "heatmap",
+            "legendFormat": "{{le}}",
+            "refId": "A"
+          }
+        ],
+        "title": "Queue time distribution (heatmap)",
+        "type": "heatmap"
+      },
+      {
+        "collapsed": false,
+        "gridPos": { "h": 1, "w": 24, "x": 0, "y": 47 },
+        "id": 400,
+        "panels": [],
+        "title": "Capacity",
+        "type": "row"
+      },
+      {
+        "datasource": "$datasource",
+        "description": "Per-pool desired (spec.replicas) vs observed (status.observedReplicas) ribbon. The two should track each other. A persistent gap means the runners-controller can't bring Pods up — usually because the Mac mini fleet is full, the dispatch label collides, or the image pull is failing on every host.",
+        "fieldConfig": {
+          "defaults": {
+            "color": { "mode": "palette-classic" },
+            "custom": {
+              "drawStyle": "line",
+              "fillOpacity": 10,
+              "lineInterpolation": "stepAfter",
+              "lineWidth": 2,
+              "pointSize": 5,
+              "showPoints": "never",
+              "spanNulls": false,
+              "stacking": { "group": "A", "mode": "none" }
+            },
+            "unit": "short"
+          }
+        },
+        "gridPos": { "h": 8, "w": 16, "x": 0, "y": 48 },
+        "id": 410,
+        "options": {
+          "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "right" },
+          "tooltip": { "mode": "multi", "sort": "desc" }
+        },
+        "targets": [
+          {
+            "datasource": "$datasource",
+            "editorMode": "code",
+            "expr": "max by (fleet) (tuist_runners_pool_replicas_desired{job=~\"$server_job\", fleet=~\"$fleet\"})",
+            "legendFormat": "{{fleet}} desired",
+            "refId": "A"
+          },
+          {
+            "datasource": "$datasource",
+            "editorMode": "code",
+            "expr": "max by (fleet) (tuist_runners_pool_replicas_observed{job=~\"$server_job\", fleet=~\"$fleet\"})",
+            "legendFormat": "{{fleet}} observed",
+            "refId": "B"
+          }
+        ],
+        "title": "RunnerPool replicas (desired vs observed)",
+        "type": "timeseries"
+      },
+      {
+        "datasource": "$datasource",
+        "description": "Pool utilisation — `running` claims as a fraction of `observed` pool capacity. 100% = every warm Pod is on a build; sustained 100% with non-zero queue is the right signal to scale the pool up. Per pool.",
+        "fieldConfig": {
+          "defaults": {
+            "color": { "mode": "thresholds" },
+            "custom": {
+              "drawStyle": "line",
+              "fillOpacity": 20,
+              "lineInterpolation": "linear",
+              "lineWidth": 2,
+              "pointSize": 5,
+              "showPoints": "never",
+              "spanNulls": false
+            },
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                { "color": "green", "value": null },
+                { "color": "yellow", "value": 0.75 },
+                { "color": "red", "value": 0.95 }
+              ]
+            },
+            "unit": "percentunit",
+            "min": 0,
+            "max": 1
+          }
+        },
+        "gridPos": { "h": 8, "w": 8, "x": 16, "y": 48 },
+        "id": 411,
+        "options": {
+          "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom" },
+          "tooltip": { "mode": "multi", "sort": "desc" }
+        },
+        "targets": [
+          {
+            "datasource": "$datasource",
+            "editorMode": "code",
+            "expr": "sum by (fleet) (tuist_runners_claims_count{job=~\"$server_job\", fleet=~\"$fleet\", lifecycle_state=\"running\"}) / clamp_min(max by (fleet) (tuist_runners_pool_replicas_observed{job=~\"$server_job\", fleet=~\"$fleet\"}), 1)",
+            "legendFormat": "{{fleet}}",
+            "refId": "A"
+          }
+        ],
+        "title": "Pool utilisation (running / observed)",
+        "type": "timeseries"
+      },
+      {
+        "datasource": "$datasource",
+        "description": "Queue length per fleet over time, polled every 30s from ClickHouse. Sawtooth pattern is healthy (work arrives in bursts, drains as Pods claim). A flat-line at non-zero means dispatch is stuck — cross-reference the Capacity panel and the Dispatch endpoint panels below.",
+        "fieldConfig": {
+          "defaults": {
+            "color": { "mode": "palette-classic" },
+            "custom": {
+              "drawStyle": "line",
+              "fillOpacity": 30,
+              "lineInterpolation": "linear",
+              "lineWidth": 2,
+              "pointSize": 5,
+              "showPoints": "never",
+              "spanNulls": false,
+              "stacking": { "group": "A", "mode": "normal" }
+            },
+            "unit": "short"
+          }
+        },
+        "gridPos": { "h": 8, "w": 12, "x": 0, "y": 56 },
+        "id": 412,
+        "options": {
+          "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "right" },
+          "tooltip": { "mode": "multi", "sort": "desc" }
+        },
+        "targets": [
+          {
+            "datasource": "$datasource",
+            "editorMode": "code",
+            "expr": "sum by (fleet) (tuist_runners_queue_length{job=~\"$server_job\", fleet=~\"$fleet\"})",
+            "legendFormat": "{{fleet}}",
+            "refId": "A"
+          }
+        ],
+        "title": "Queue length by fleet",
+        "type": "timeseries"
+      },
+      {
+        "datasource": "$datasource",
+        "description": "Inflight PG claims split by lifecycle state per fleet. `claimed` is pre-mint (sub-second steady state); `running` is the customer-build window (potentially hours). A growing `claimed` baseline points to JIT mint failures piling up before the stale-claims worker sweeps them.",
+        "fieldConfig": {
+          "defaults": {
+            "color": { "mode": "palette-classic" },
+            "custom": {
+              "drawStyle": "line",
+              "fillOpacity": 30,
+              "lineInterpolation": "linear",
+              "lineWidth": 2,
+              "pointSize": 5,
+              "showPoints": "never",
+              "spanNulls": false,
+              "stacking": { "group": "A", "mode": "normal" }
+            },
+            "unit": "short"
+          }
+        },
+        "gridPos": { "h": 8, "w": 12, "x": 12, "y": 56 },
+        "id": 413,
+        "options": {
+          "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "right" },
+          "tooltip": { "mode": "multi", "sort": "desc" }
+        },
+        "targets": [
+          {
+            "datasource": "$datasource",
+            "editorMode": "code",
+            "expr": "sum by (fleet, lifecycle_state) (tuist_runners_claims_count{job=~\"$server_job\", fleet=~\"$fleet\"})",
+            "legendFormat": "{{fleet}} / {{lifecycle_state}}",
+            "refId": "A"
+          }
+        ],
+        "title": "Inflight claims by fleet + state",
+        "type": "timeseries"
+      },
+      {
+        "collapsed": false,
+        "gridPos": { "h": 1, "w": 24, "x": 0, "y": 64 },
+        "id": 500,
+        "panels": [],
+        "title": "Dispatch endpoint",
+        "type": "row"
+      },
+      {
+        "datasource": "$datasource",
+        "description": "Polling Pod dispatch requests per second, by outcome. `served` = JIT delivered; `no_work_yet` = queue empty or all candidate accounts at cap (normal idle); `drain` = stale image (HTTP 410, expected during rollouts); anything else is a fault.",
+        "fieldConfig": {
+          "defaults": {
+            "color": { "mode": "palette-classic" },
+            "custom": {
+              "drawStyle": "line",
+              "fillOpacity": 10,
+              "lineInterpolation": "linear",
+              "lineWidth": 2,
+              "pointSize": 5,
+              "showPoints": "never",
+              "spanNulls": false,
+              "stacking": { "group": "A", "mode": "none" }
+            },
+            "unit": "ops"
+          },
+          "overrides": [
+            { "matcher": { "id": "byName", "options": "served" }, "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "green" } }] },
+            { "matcher": { "id": "byName", "options": "no_work_yet" }, "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "blue" } }] },
+            { "matcher": { "id": "byName", "options": "drain" }, "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "orange" } }] },
+            { "matcher": { "id": "byName", "options": "github_mint_failed" }, "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "red" } }] }
+          ]
+        },
+        "gridPos": { "h": 8, "w": 16, "x": 0, "y": 65 },
+        "id": 510,
+        "options": {
+          "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "right" },
+          "tooltip": { "mode": "multi", "sort": "desc" }
+        },
+        "targets": [
+          {
+            "datasource": "$datasource",
+            "editorMode": "code",
+            "expr": "sum by (outcome) (rate(tuist_runners_dispatch_request_count{job=~\"$server_job\"}[5m]))",
+            "legendFormat": "{{outcome}}",
+            "refId": "A"
+          }
+        ],
+        "title": "Dispatch requests / sec by outcome",
+        "type": "timeseries"
+      },
+      {
+        "datasource": "$datasource",
+        "description": "Latency of the `/api/internal/runners/dispatch` endpoint. p50 is dominated by the PG cap check + ClickHouse `pick_queued`. p95 spikes correlate with K8s apiserver latency (the TokenReview + Pod GET round-trips) or contention on the per-account advisory lock.",
+        "fieldConfig": {
+          "defaults": {
+            "color": { "mode": "palette-classic" },
+            "custom": {
+              "drawStyle": "line",
+              "fillOpacity": 10,
+              "lineInterpolation": "linear",
+              "lineWidth": 2,
+              "pointSize": 5,
+              "showPoints": "never",
+              "spanNulls": false,
+              "stacking": { "group": "A", "mode": "none" }
+            },
+            "unit": "ms"
+          }
+        },
+        "gridPos": { "h": 8, "w": 8, "x": 16, "y": 65 },
+        "id": 511,
+        "options": {
+          "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom" },
+          "tooltip": { "mode": "multi", "sort": "desc" }
+        },
+        "targets": [
+          {
+            "datasource": "$datasource",
+            "editorMode": "code",
+            "expr": "histogram_quantile(0.50, sum by (le) (rate(tuist_runners_dispatch_request_duration_milliseconds_bucket{job=~\"$server_job\"}[5m])))",
+            "legendFormat": "p50",
+            "refId": "A"
+          },
+          {
+            "datasource": "$datasource",
+            "editorMode": "code",
+            "expr": "histogram_quantile(0.95, sum by (le) (rate(tuist_runners_dispatch_request_duration_milliseconds_bucket{job=~\"$server_job\"}[5m])))",
+            "legendFormat": "p95",
+            "refId": "B"
+          },
+          {
+            "datasource": "$datasource",
+            "editorMode": "code",
+            "expr": "histogram_quantile(0.99, sum by (le) (rate(tuist_runners_dispatch_request_duration_milliseconds_bucket{job=~\"$server_job\"}[5m])))",
+            "legendFormat": "p99",
+            "refId": "C"
+          }
+        ],
+        "title": "Dispatch endpoint latency",
+        "type": "timeseries"
+      },
+      {
+        "collapsed": false,
+        "gridPos": { "h": 1, "w": 24, "x": 0, "y": 73 },
+        "id": 600,
+        "panels": [],
+        "title": "Recovery",
+        "type": "row"
+      },
+      {
+        "datasource": "$datasource",
+        "description": "Recovery-worker output by kind. `stale_claim` = `StaleClaimsWorker` swept a PG claim that never advanced past `claimed` in 5 minutes (a JIT-mint crash). `orphan_requeued` = `OrphanedRunnersWorker` found a row in `running` whose GitHub-side runner never registered. `orphan_completed` = a missed `workflow_job.completed` webhook, recovered by polling GH. Any non-zero baseline is worth investigating but a one-shot spike during a rollout is expected.",
+        "fieldConfig": {
+          "defaults": {
+            "color": { "mode": "palette-classic" },
+            "custom": {
+              "drawStyle": "line",
+              "fillOpacity": 20,
+              "lineInterpolation": "linear",
+              "lineWidth": 2,
+              "pointSize": 5,
+              "showPoints": "always",
+              "spanNulls": false,
+              "stacking": { "group": "A", "mode": "none" }
+            },
+            "unit": "ops"
+          }
+        },
+        "gridPos": { "h": 8, "w": 24, "x": 0, "y": 74 },
+        "id": 610,
+        "options": {
+          "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "right" },
+          "tooltip": { "mode": "multi", "sort": "desc" }
+        },
+        "targets": [
+          {
+            "datasource": "$datasource",
+            "editorMode": "code",
+            "expr": "sum by (kind) (rate(tuist_runners_recovery_count{job=~\"$server_job\"}[15m]))",
+            "legendFormat": "{{kind}}",
+            "refId": "A"
+          }
+        ],
+        "title": "Recovery rate by kind",
+        "type": "timeseries"
+      },
+      {
+        "collapsed": false,
+        "gridPos": { "h": 1, "w": 24, "x": 0, "y": 82 },
+        "id": 700,
         "panels": [],
         "title": "VM boot time",
         "type": "row"
@@ -155,7 +1122,7 @@
             "unit": "s"
           }
         },
-        "gridPos": { "h": 10, "w": 16, "x": 0, "y": 6 },
+        "gridPos": { "h": 10, "w": 16, "x": 0, "y": 83 },
         "id": 2,
         "options": {
           "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "right" },
@@ -215,7 +1182,7 @@
             "unit": "ops"
           }
         },
-        "gridPos": { "h": 10, "w": 8, "x": 16, "y": 6 },
+        "gridPos": { "h": 10, "w": 8, "x": 16, "y": 83 },
         "id": 3,
         "options": {
           "legend": { "calcs": ["mean"], "displayMode": "table", "placement": "bottom" },
@@ -244,7 +1211,7 @@
             }
           }
         },
-        "gridPos": { "h": 10, "w": 24, "x": 0, "y": 16 },
+        "gridPos": { "h": 10, "w": 24, "x": 0, "y": 93 },
         "id": 4,
         "options": {
           "calculate": false,

--- a/infra/grafana-dashboards/runners.json
+++ b/infra/grafana-dashboards/runners.json
@@ -561,26 +561,26 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "histogram_quantile(0.50, sum by (le) (rate(tuist_runners_job_queue_to_running_time_milliseconds_bucket{job=~\"$server_job\", fleet=~\"$fleet\"}[5m]))) - histogram_quantile(0.50, sum by (le) (rate(tuist_runners_job_queue_time_milliseconds_bucket{job=~\"$server_job\", fleet=~\"$fleet\"}[5m])))",
-            "legendFormat": "p50 (claim→running, approx)",
+            "expr": "histogram_quantile(0.50, sum by (le) (rate(tuist_runners_job_claim_to_running_time_milliseconds_bucket{job=~\"$server_job\", fleet=~\"$fleet\"}[5m])))",
+            "legendFormat": "p50",
             "refId": "A"
           },
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "histogram_quantile(0.50, sum by (le) (rate(tuist_runners_job_queue_to_running_time_milliseconds_bucket{job=~\"$server_job\", fleet=~\"$fleet\"}[5m])))",
-            "legendFormat": "p50 (total enqueue→running)",
+            "expr": "histogram_quantile(0.95, sum by (le) (rate(tuist_runners_job_claim_to_running_time_milliseconds_bucket{job=~\"$server_job\", fleet=~\"$fleet\"}[5m])))",
+            "legendFormat": "p95",
             "refId": "B"
           },
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "histogram_quantile(0.95, sum by (le) (rate(tuist_runners_job_queue_to_running_time_milliseconds_bucket{job=~\"$server_job\", fleet=~\"$fleet\"}[5m])))",
-            "legendFormat": "p95 (total enqueue→running)",
+            "expr": "histogram_quantile(0.99, sum by (le) (rate(tuist_runners_job_claim_to_running_time_milliseconds_bucket{job=~\"$server_job\", fleet=~\"$fleet\"}[5m])))",
+            "legendFormat": "p99",
             "refId": "C"
           }
         ],
-        "title": "Enqueue → running (JIT-mint included)",
+        "title": "Claim → running (JIT mint)",
         "type": "timeseries"
       },
       {

--- a/server/lib/tuist.ex
+++ b/server/lib/tuist.ex
@@ -178,6 +178,8 @@ defmodule Tuist do
       Runners.Claim,
       Runners.Jobs,
       Runners.Job,
+      Runners.PromExPlugin,
+      Runners.Telemetry,
       Kubernetes.Client
     ]
 end

--- a/server/lib/tuist/prom_ex.ex
+++ b/server/lib/tuist/prom_ex.ex
@@ -74,6 +74,7 @@ defmodule Tuist.PromEx do
         Tuist.KeyValueStore.PromExPlugin,
         Tuist.Authentication.PromExPlugin,
         Tuist.HTTP.PromExPlugin,
+        Tuist.Runners.PromExPlugin,
         TuistCommon.HTTP.TransportPromExPlugin
       ]
 

--- a/server/lib/tuist/runners.ex
+++ b/server/lib/tuist/runners.ex
@@ -101,12 +101,10 @@ defmodule Tuist.Runners do
       the check runs only on idle polls (before claim attempt).
   """
   def dispatch_for_sa(namespace, sa_name) when is_binary(namespace) and is_binary(sa_name) do
-    start_time = System.monotonic_time()
-
-    result = do_dispatch_for_sa(namespace, sa_name)
-    duration_ms = System.convert_time_unit(System.monotonic_time() - start_time, :native, :millisecond)
-    emit_dispatch_telemetry(result, duration_ms)
-    result
+    :telemetry.span(Telemetry.event_name_dispatch_request(), %{}, fn ->
+      result = do_dispatch_for_sa(namespace, sa_name)
+      {result, %{outcome: dispatch_outcome(result)}}
+    end)
   end
 
   defp do_dispatch_for_sa(namespace, sa_name) do
@@ -159,14 +157,6 @@ defmodule Tuist.Runners do
           {:error, :no_work_yet}
       end
     end
-  end
-
-  defp emit_dispatch_telemetry(result, duration_ms) do
-    :telemetry.execute(
-      Telemetry.event_name_dispatch_request(),
-      %{count: 1, duration_ms: duration_ms},
-      %{outcome: dispatch_outcome(result)}
-    )
   end
 
   defp dispatch_outcome({:ok, _}), do: "served"

--- a/server/lib/tuist/runners.ex
+++ b/server/lib/tuist/runners.ex
@@ -56,6 +56,7 @@ defmodule Tuist.Runners do
   alias Tuist.Runners.Claims
   alias Tuist.Runners.Dispatch
   alias Tuist.Runners.Jobs
+  alias Tuist.Runners.Telemetry
   alias Tuist.VCS
 
   require Logger
@@ -100,6 +101,15 @@ defmodule Tuist.Runners do
       the check runs only on idle polls (before claim attempt).
   """
   def dispatch_for_sa(namespace, sa_name) when is_binary(namespace) and is_binary(sa_name) do
+    start_time = System.monotonic_time()
+
+    result = do_dispatch_for_sa(namespace, sa_name)
+    duration_ms = System.convert_time_unit(System.monotonic_time() - start_time, :native, :millisecond)
+    emit_dispatch_telemetry(result, duration_ms)
+    result
+  end
+
+  defp do_dispatch_for_sa(namespace, sa_name) do
     with {:ok, sa} <- K8sClient.get_service_account(namespace, sa_name),
          {:ok, fleet_name} <- pool_label(sa),
          :ok <- check_not_stale(namespace, sa_name, fleet_name) do
@@ -150,6 +160,18 @@ defmodule Tuist.Runners do
       end
     end
   end
+
+  defp emit_dispatch_telemetry(result, duration_ms) do
+    :telemetry.execute(
+      Telemetry.event_name_dispatch_request(),
+      %{count: 1, duration_ms: duration_ms},
+      %{outcome: dispatch_outcome(result)}
+    )
+  end
+
+  defp dispatch_outcome({:ok, _}), do: "served"
+  defp dispatch_outcome({:error, reason}) when is_atom(reason), do: Atom.to_string(reason)
+  defp dispatch_outcome(_), do: "unknown"
 
   defp serve_claim(namespace, sa_name, fleet_name, candidate, claim) do
     case Accounts.get_account_by_id(candidate.account_id) do

--- a/server/lib/tuist/runners/dispatch.ex
+++ b/server/lib/tuist/runners/dispatch.ex
@@ -37,6 +37,7 @@ defmodule Tuist.Runners.Dispatch do
   alias Tuist.Kubernetes.Client
   alias Tuist.Runners.Claims
   alias Tuist.Runners.Jobs
+  alias Tuist.Runners.Telemetry
 
   require Logger
 
@@ -44,14 +45,31 @@ defmodule Tuist.Runners.Dispatch do
   Handle a `workflow_job` webhook payload. Branches on `action`.
   """
   def handle_webhook(%{"action" => "queued"} = payload, installation_id) when is_integer(installation_id) do
-    handle_queued(payload)
+    result = handle_queued(payload)
+    emit_webhook_telemetry("queued", result)
+    result
   end
 
   def handle_webhook(%{"action" => "completed"} = payload, installation_id) when is_integer(installation_id) do
-    handle_completed(payload)
+    result = handle_completed(payload)
+    emit_webhook_telemetry("completed", result)
+    result
   end
 
   def handle_webhook(_payload, _installation_id), do: :ignored
+
+  defp emit_webhook_telemetry(action, result) do
+    :telemetry.execute(
+      Telemetry.event_name_webhook(),
+      %{count: 1},
+      %{action: action, outcome: webhook_outcome(result)}
+    )
+  end
+
+  defp webhook_outcome({:ok, kind}), do: Atom.to_string(kind)
+  defp webhook_outcome(:ignored), do: "ignored"
+  defp webhook_outcome({:error, reason}) when is_atom(reason), do: Atom.to_string(reason)
+  defp webhook_outcome(_), do: "unknown"
 
   defp handle_queued(payload) do
     job = Map.get(payload, "workflow_job", %{})

--- a/server/lib/tuist/runners/jobs.ex
+++ b/server/lib/tuist/runners/jobs.ex
@@ -182,7 +182,11 @@ defmodule Tuist.Runners.Jobs do
 
         :telemetry.execute(
           Telemetry.event_name_job_running(),
-          %{count: 1, queue_to_running_ms: duration_ms(job.enqueued_at, now)},
+          %{
+            count: 1,
+            queue_to_running_ms: duration_ms(job.enqueued_at, now),
+            claim_to_running_ms: duration_ms(job.claimed_at, now)
+          },
           %{fleet: job.fleet_name || ""}
         )
 

--- a/server/lib/tuist/runners/jobs.ex
+++ b/server/lib/tuist/runners/jobs.ex
@@ -46,8 +46,15 @@ defmodule Tuist.Runners.Jobs do
   alias Tuist.ClickHouseRepo
   alias Tuist.IngestRepo
   alias Tuist.Runners.Job
+  alias Tuist.Runners.Telemetry
 
   require Logger
+
+  # Pre-1970 sentinel used for "not yet set" timestamp slots. Any
+  # timestamp at or below this epoch is treated as missing when
+  # computing telemetry durations so a delivery-race `completed`
+  # (no `started_at`) doesn't emit a multi-decade run_time spike.
+  @epoch ~U[1970-01-01 00:00:00.000000Z]
 
   @doc """
   Idempotent enqueue. Inserts a `status='queued'` row for the
@@ -66,6 +73,13 @@ defmodule Tuist.Runners.Jobs do
       |> Map.put(:updated_at, now)
 
     insert_row!(row)
+
+    :telemetry.execute(
+      Telemetry.event_name_job_enqueued(),
+      %{count: 1},
+      %{fleet: Map.get(row, :fleet_name, "")}
+    )
+
     :ok
   end
 
@@ -128,6 +142,13 @@ defmodule Tuist.Runners.Jobs do
     row = Map.merge(candidate, %{status: "claimed", claimed_at: claimed_at, pod_name: pod_name, updated_at: now})
 
     insert_row!(row)
+
+    :telemetry.execute(
+      Telemetry.event_name_job_claim(),
+      %{count: 1, queue_time_ms: duration_ms(candidate[:enqueued_at], claimed_at)},
+      %{fleet: Map.get(candidate, :fleet_name, ""), outcome: "ok"}
+    )
+
     :ok
   end
 
@@ -158,6 +179,13 @@ defmodule Tuist.Runners.Jobs do
           })
 
         insert_row!(row)
+
+        :telemetry.execute(
+          Telemetry.event_name_job_running(),
+          %{count: 1, queue_to_running_ms: duration_ms(job.enqueued_at, now)},
+          %{fleet: job.fleet_name || ""}
+        )
+
         :ok
     end
   end
@@ -186,6 +214,13 @@ defmodule Tuist.Runners.Jobs do
           })
 
         insert_row!(row)
+
+        :telemetry.execute(
+          Telemetry.event_name_job_requeued(),
+          %{count: 1},
+          %{fleet: job.fleet_name || ""}
+        )
+
         :ok
     end
   end
@@ -219,6 +254,20 @@ defmodule Tuist.Runners.Jobs do
           })
 
         insert_row!(row)
+
+        :telemetry.execute(
+          Telemetry.event_name_job_completed(),
+          %{
+            count: 1,
+            run_time_ms: duration_ms(job.started_at, now),
+            queue_time_ms: duration_ms(job.enqueued_at, job.claimed_at),
+            total_time_ms: duration_ms(job.enqueued_at, now)
+          },
+          %{
+            fleet: job.fleet_name || "",
+            conclusion: normalise_conclusion(conclusion)
+          }
+        )
 
         {:ok,
          Map.merge(job, %{
@@ -297,5 +346,25 @@ defmodule Tuist.Runners.Jobs do
     |> Map.delete(:__meta__)
   end
 
-  defp epoch, do: ~U[1970-01-01 00:00:00.000000Z]
+  defp epoch, do: @epoch
+
+  # Returns `nil` when either bound is missing/epoch so the
+  # histogram bucketer drops the sample instead of recording a
+  # garbage duration.
+  defp duration_ms(%DateTime{} = from, %DateTime{} = to) do
+    if DateTime.after?(from, @epoch) and DateTime.after?(to, from) do
+      DateTime.diff(to, from, :millisecond)
+    end
+  end
+
+  defp duration_ms(_, _), do: nil
+
+  # Normalise GH conclusion strings into the bounded tag set the
+  # dashboard groups by. `nil` and `""` collapse to `"unknown"`
+  # so the conclusion-by-rate panel doesn't grow a phantom empty
+  # series for in-flight rows that crash through the orphan
+  # recovery path.
+  defp normalise_conclusion(c) when c in [nil, ""], do: "unknown"
+  defp normalise_conclusion(c) when is_binary(c), do: c
+  defp normalise_conclusion(_), do: "unknown"
 end

--- a/server/lib/tuist/runners/prom_ex_plugin.ex
+++ b/server/lib/tuist/runners/prom_ex_plugin.ex
@@ -53,6 +53,14 @@ defmodule Tuist.Runners.PromExPlugin do
   # series until process restart.
   @lifecycle_states ~w(claimed running)
 
+  # Process-dict key for the set of RunnerPool fleet names emitted
+  # on the previous `execute_pool_replicas_telemetry_event/0` tick.
+  # Lets the poll emit an explicit `0` for a fleet that was visible
+  # in the cluster on the prior tick but isn't now — without this,
+  # `last_value` keeps the last `desired`/`observed` sample forever
+  # after a RunnerPool is deleted.
+  @pool_replicas_seen_key :tuist_runners_pool_replicas_seen_fleets
+
   # Buckets cover the realistic wall-clock range for each duration.
   # `queue_time` and `queue_to_running` are sub-minute on the happy
   # path; `run_time` / `total_time` span seconds to the GH-side
@@ -111,6 +119,15 @@ defmodule Tuist.Runners.PromExPlugin do
             event_name: Telemetry.event_name_job_running(),
             measurement: :queue_to_running_ms,
             description: "Time between webhook enqueue and the running transition (queue + claim + mint).",
+            reporter_options: [buckets: @short_duration_buckets],
+            tags: [:fleet],
+            unit: :millisecond
+          ),
+          distribution(
+            @metric_prefix ++ [:job, :claim_to_running, :time, :milliseconds],
+            event_name: Telemetry.event_name_job_running(),
+            measurement: :claim_to_running_ms,
+            description: "Time between claim and the running transition — JIT mint plus pod label patch.",
             reporter_options: [buckets: @short_duration_buckets],
             tags: [:fleet],
             unit: :millisecond
@@ -236,14 +253,14 @@ defmodule Tuist.Runners.PromExPlugin do
             event_name: Telemetry.event_name_pool_replicas(),
             description: "Desired RunnerPool replicas (spec.replicas).",
             measurement: :desired,
-            tags: [:fleet, :dispatch_label]
+            tags: [:fleet]
           ),
           last_value(
             @metric_prefix ++ [:pool, :replicas, :observed],
             event_name: Telemetry.event_name_pool_replicas(),
             description: "Observed RunnerPool replicas (status.observedReplicas).",
             measurement: :observed,
-            tags: [:fleet, :dispatch_label]
+            tags: [:fleet]
           )
         ]
       )
@@ -377,29 +394,50 @@ defmodule Tuist.Runners.PromExPlugin do
   def execute_pool_replicas_telemetry_event do
     case K8sClient.list_runner_pools(Environment.runners_namespace()) do
       {:ok, items} ->
-        Enum.each(items, &emit_pool_replicas/1)
+        current = pool_replicas_from_items(items)
+        current_fleets = current |> Map.keys() |> MapSet.new()
+        previous_fleets = Process.get(@pool_replicas_seen_key, MapSet.new())
+
+        Enum.each(current, fn {fleet, {desired, observed}} ->
+          :telemetry.execute(
+            Telemetry.event_name_pool_replicas(),
+            %{desired: desired, observed: observed},
+            %{fleet: fleet}
+          )
+        end)
+
+        previous_fleets
+        |> MapSet.difference(current_fleets)
+        |> Enum.each(fn fleet ->
+          :telemetry.execute(
+            Telemetry.event_name_pool_replicas(),
+            %{desired: 0, observed: 0},
+            %{fleet: fleet}
+          )
+        end)
+
+        Process.put(@pool_replicas_seen_key, current_fleets)
+        :ok
 
       _ ->
         :ok
     end
   end
 
-  defp emit_pool_replicas(%{"metadata" => %{"name" => name}} = pool) do
-    spec = Map.get(pool, "spec", %{})
-    status = Map.get(pool, "status", %{})
+  defp pool_replicas_from_items(items) do
+    items
+    |> Enum.flat_map(fn pool ->
+      case pool_name(pool) do
+        nil ->
+          []
 
-    :telemetry.execute(
-      Telemetry.event_name_pool_replicas(),
-      %{
-        desired: Map.get(spec, "replicas", 0),
-        observed: Map.get(status, "observedReplicas", 0)
-      },
-      %{
-        fleet: name,
-        dispatch_label: Map.get(spec, "dispatchLabel", "")
-      }
-    )
+        name ->
+          spec = Map.get(pool, "spec", %{})
+          status = Map.get(pool, "status", %{})
+
+          [{name, {Map.get(spec, "replicas", 0), Map.get(status, "observedReplicas", 0)}}]
+      end
+    end)
+    |> Map.new()
   end
-
-  defp emit_pool_replicas(_), do: :ok
 end

--- a/server/lib/tuist/runners/prom_ex_plugin.ex
+++ b/server/lib/tuist/runners/prom_ex_plugin.ex
@@ -33,7 +33,7 @@ defmodule Tuist.Runners.PromExPlugin do
 
   use PromEx.Plugin
 
-  import Ecto.Query, only: [from: 2]
+  import Ecto.Query, only: [from: 2, subquery: 1]
 
   alias Tuist.ClickHouseRepo
   alias Tuist.Environment
@@ -267,16 +267,40 @@ defmodule Tuist.Runners.PromExPlugin do
     end
   end
 
+  # Avoid `FINAL` — at scale it forces ClickHouse to merge across
+  # every part of `runner_jobs` on every 30s poll. Instead, collapse
+  # per workflow_job via `argMax(updated_at)` in a subquery, then
+  # filter the *current* state to `queued` and group by fleet.
+  #
+  # The `enqueued_at >= cutoff` prunes partitions (the table is
+  # `PARTITION BY toYYYYMM(enqueued_at)` and every state-transition
+  # INSERT carries the original `enqueued_at` forward, so all rows
+  # for a workflow_job live in the same partition). Seven days is
+  # well past any realistic queue lifetime — GitHub's own queue
+  # timeout is ~24h — so any row still queued beyond the cutoff is
+  # a system-wide outage where a slightly low gauge is the least
+  # of our problems.
+  @queue_lookback_days 7
+
   defp fetch_queue_counts do
-    query =
+    cutoff = DateTime.add(DateTime.utc_now(), -@queue_lookback_days, :day)
+
+    latest =
       from(j in Job,
-        hints: ["FINAL"],
-        where: j.status == "queued",
-        group_by: j.fleet_name,
-        select: {j.fleet_name, count(j.workflow_job_id)}
+        where: j.enqueued_at >= ^cutoff,
+        group_by: j.workflow_job_id,
+        select: %{
+          workflow_job_id: j.workflow_job_id,
+          fleet_name: fragment("argMax(?, ?)", j.fleet_name, j.updated_at),
+          status: fragment("argMax(?, ?)", j.status, j.updated_at)
+        }
       )
 
-    query
+    from(s in subquery(latest),
+      where: s.status == "queued",
+      group_by: s.fleet_name,
+      select: {s.fleet_name, count(s.workflow_job_id)}
+    )
     |> ClickHouseRepo.all()
     |> Map.new(fn {fleet, count} -> {fleet || "", count} end)
   end

--- a/server/lib/tuist/runners/prom_ex_plugin.ex
+++ b/server/lib/tuist/runners/prom_ex_plugin.ex
@@ -1,0 +1,381 @@
+defmodule Tuist.Runners.PromExPlugin do
+  @moduledoc """
+  PromEx plugin for the customer-runner dispatch path.
+
+  Two metric families:
+
+    * **Event metrics.** Counters + duration histograms attached to
+      the `:tuist, :runners, ...` events emitted by `Tuist.Runners`,
+      `Tuist.Runners.Jobs`, `Tuist.Runners.Dispatch`, and the
+      recovery workers. Counters cover throughput (`enqueued`,
+      `claim`, `running`, `completed`); histograms cover wall-clock
+      durations (`queue_time_ms` at claim, `queue_to_running_ms` at
+      mint, `run_time_ms` / `total_time_ms` at completion). The
+      dispatch endpoint emits its own latency histogram tagged by
+      outcome so a saturating poll loop is visible separately from
+      a slow CH/PG.
+
+    * **Polling metrics.** Three poll loops at a coarse 30s cadence
+      query authoritative state and emit gauges: queue length per
+      fleet from CH, inflight claim counts per fleet / lifecycle
+      state from PG, RunnerPool desired-vs-observed replica counts
+      from the K8s apiserver. Polled gauges are deliberately
+      separate from the event counters — `runner_pool_replicas` is
+      a level (current capacity), not a flux (boot/teardown rate
+      already covered by tart-kubelet's boot duration histogram).
+
+  Cardinality budget: `fleet` is bounded by the number of
+  RunnerPool CRs (currently 1 — `default`). Per-account fan-out is
+  *not* tagged on event metrics; account-level views are exposed
+  as polled aggregates only.
+  """
+
+  use PromEx.Plugin
+
+  import Ecto.Query, only: [from: 2]
+
+  alias Tuist.Accounts.Account
+  alias Tuist.ClickHouseRepo
+  alias Tuist.Environment
+  alias Tuist.Kubernetes.Client, as: K8sClient
+  alias Tuist.Repo
+  alias Tuist.Runners.Claim
+  alias Tuist.Runners.Job
+  alias Tuist.Runners.Telemetry
+  alias TuistCommon.Repo.PoolMetrics
+
+  require Logger
+
+  @metric_prefix [:tuist, :runners]
+
+  # Buckets cover the realistic wall-clock range for each duration.
+  # `queue_time` and `queue_to_running` are sub-minute on the happy
+  # path; `run_time` / `total_time` span seconds to the GH-side
+  # 6-hour ceiling, so the upper bucket sits at 6 * 3600 * 1000 ms.
+  @short_duration_buckets [50, 100, 250, 500, 1_000, 2_500, 5_000, 10_000, 30_000, 60_000, 300_000]
+  @long_duration_buckets [
+    1_000,
+    5_000,
+    30_000,
+    60_000,
+    300_000,
+    900_000,
+    1_800_000,
+    3_600_000,
+    7_200_000,
+    14_400_000,
+    21_600_000
+  ]
+  @dispatch_duration_buckets [10, 50, 100, 250, 500, 1_000, 2_500, 5_000, 10_000]
+
+  @impl true
+  def event_metrics(_opts) do
+    [
+      Event.build(
+        :tuist_runners_lifecycle_event_metrics,
+        [
+          counter(
+            @metric_prefix ++ [:job, :enqueued, :count],
+            event_name: Telemetry.event_name_job_enqueued(),
+            description: "Workflow jobs enqueued for a Tuist-managed runner fleet.",
+            tags: [:fleet]
+          ),
+          counter(
+            @metric_prefix ++ [:job, :claim, :count],
+            event_name: Telemetry.event_name_job_claim(),
+            description: "Workflow jobs claimed off the queue by a polling runner Pod.",
+            tags: [:fleet, :outcome]
+          ),
+          distribution(
+            @metric_prefix ++ [:job, :queue, :time, :milliseconds],
+            event_name: Telemetry.event_name_job_claim(),
+            measurement: :queue_time_ms,
+            description: "Time between webhook enqueue and the first successful claim.",
+            reporter_options: [buckets: @short_duration_buckets],
+            tags: [:fleet],
+            unit: :millisecond
+          ),
+          counter(
+            @metric_prefix ++ [:job, :running, :count],
+            event_name: Telemetry.event_name_job_running(),
+            description: "Workflow jobs that reached the running state after a successful JIT mint.",
+            tags: [:fleet]
+          ),
+          distribution(
+            @metric_prefix ++ [:job, :queue_to_running, :time, :milliseconds],
+            event_name: Telemetry.event_name_job_running(),
+            measurement: :queue_to_running_ms,
+            description: "Time between webhook enqueue and the running transition (queue + claim + mint).",
+            reporter_options: [buckets: @short_duration_buckets],
+            tags: [:fleet],
+            unit: :millisecond
+          ),
+          counter(
+            @metric_prefix ++ [:job, :completed, :count],
+            event_name: Telemetry.event_name_job_completed(),
+            description: "Workflow jobs that reached a terminal GitHub conclusion.",
+            tags: [:fleet, :conclusion]
+          ),
+          distribution(
+            @metric_prefix ++ [:job, :run, :time, :milliseconds],
+            event_name: Telemetry.event_name_job_completed(),
+            measurement: :run_time_ms,
+            description: "Time between running and completed — the actual execution window on the runner.",
+            reporter_options: [buckets: @long_duration_buckets],
+            tags: [:fleet],
+            unit: :millisecond
+          ),
+          distribution(
+            @metric_prefix ++ [:job, :total, :time, :milliseconds],
+            event_name: Telemetry.event_name_job_completed(),
+            measurement: :total_time_ms,
+            description: "End-to-end time from webhook enqueue to completion.",
+            reporter_options: [buckets: @long_duration_buckets],
+            tags: [:fleet],
+            unit: :millisecond
+          ),
+          counter(
+            @metric_prefix ++ [:job, :requeued, :count],
+            event_name: Telemetry.event_name_job_requeued(),
+            description: "Workflow jobs returned to the queued state via release or recovery.",
+            tags: [:fleet]
+          )
+        ]
+      ),
+      Event.build(
+        :tuist_runners_dispatch_event_metrics,
+        [
+          counter(
+            @metric_prefix ++ [:dispatch, :request, :count],
+            event_name: Telemetry.event_name_dispatch_request(),
+            description: "Polling Pod dispatch requests bucketed by outcome.",
+            tags: [:outcome]
+          ),
+          distribution(
+            @metric_prefix ++ [:dispatch, :request, :duration, :milliseconds],
+            event_name: Telemetry.event_name_dispatch_request(),
+            measurement: :duration_ms,
+            description: "Wall-clock time the dispatch endpoint spent serving a polling Pod.",
+            reporter_options: [buckets: @dispatch_duration_buckets],
+            tags: [:outcome],
+            unit: :millisecond
+          )
+        ]
+      ),
+      Event.build(
+        :tuist_runners_webhook_event_metrics,
+        [
+          counter(
+            @metric_prefix ++ [:webhook, :count],
+            event_name: Telemetry.event_name_webhook(),
+            description: "GitHub workflow_job webhook deliveries bucketed by action and outcome.",
+            tags: [:action, :outcome]
+          )
+        ]
+      ),
+      Event.build(
+        :tuist_runners_recovery_event_metrics,
+        [
+          counter(
+            @metric_prefix ++ [:recovery, :count],
+            event_name: Telemetry.event_name_recovery(),
+            measurement: :count,
+            description: "Stale or orphaned rows recovered by the recovery workers, by kind.",
+            tags: [:kind]
+          )
+        ]
+      )
+    ]
+  end
+
+  @impl true
+  def polling_metrics(opts) do
+    poll_rate = Keyword.get(opts, :poll_rate, to_timeout(second: 30))
+
+    [
+      Polling.build(
+        :tuist_runners_queue_length_metrics,
+        poll_rate,
+        {__MODULE__, :execute_queue_length_telemetry_event, []},
+        [
+          last_value(
+            @metric_prefix ++ [:queue, :length],
+            event_name: Telemetry.event_name_queue_length(),
+            description: "Queued workflow jobs per fleet (ClickHouse runner_jobs).",
+            measurement: :count,
+            tags: [:fleet]
+          )
+        ]
+      ),
+      Polling.build(
+        :tuist_runners_claims_metrics,
+        poll_rate,
+        {__MODULE__, :execute_claims_telemetry_event, []},
+        [
+          last_value(
+            @metric_prefix ++ [:claims, :count],
+            event_name: Telemetry.event_name_claims_count(),
+            description: "Active PG claims per fleet and lifecycle state (claimed or running).",
+            measurement: :count,
+            tags: [:fleet, :lifecycle_state]
+          )
+        ]
+      ),
+      Polling.build(
+        :tuist_runners_pool_replicas_metrics,
+        poll_rate,
+        {__MODULE__, :execute_pool_replicas_telemetry_event, []},
+        [
+          last_value(
+            @metric_prefix ++ [:pool, :replicas, :desired],
+            event_name: Telemetry.event_name_pool_replicas(),
+            description: "Desired RunnerPool replicas (spec.replicas).",
+            measurement: :desired,
+            tags: [:fleet, :dispatch_label]
+          ),
+          last_value(
+            @metric_prefix ++ [:pool, :replicas, :observed],
+            event_name: Telemetry.event_name_pool_replicas(),
+            description: "Observed RunnerPool replicas (status.observedReplicas).",
+            measurement: :observed,
+            tags: [:fleet, :dispatch_label]
+          )
+        ]
+      ),
+      Polling.build(
+        :tuist_runners_accounts_enabled_metrics,
+        poll_rate,
+        {__MODULE__, :execute_accounts_enabled_telemetry_event, []},
+        [
+          last_value(
+            @metric_prefix ++ [:accounts, :enabled],
+            event_name: Telemetry.event_name_accounts_enabled(),
+            description: "Accounts with runner_max_concurrent > 0.",
+            measurement: :count
+          )
+        ]
+      )
+    ]
+  end
+
+  @doc false
+  def execute_queue_length_telemetry_event do
+    if PoolMetrics.running?(ClickHouseRepo) do
+      query =
+        from(j in Job,
+          hints: ["FINAL"],
+          where: j.status == "queued",
+          group_by: j.fleet_name,
+          select: {j.fleet_name, count(j.workflow_job_id)}
+        )
+
+      try_result =
+        try do
+          ClickHouseRepo.all(query)
+        rescue
+          e ->
+            Logger.debug("runners: queue_length poll failed", reason: Exception.message(e))
+            []
+        end
+
+      Enum.each(try_result, fn {fleet, count} ->
+        :telemetry.execute(
+          Telemetry.event_name_queue_length(),
+          %{count: count},
+          %{fleet: fleet || ""}
+        )
+      end)
+    end
+  end
+
+  @doc false
+  def execute_claims_telemetry_event do
+    if PoolMetrics.running?(Repo) do
+      query =
+        from(c in Claim,
+          group_by: [c.fleet_name, c.lifecycle_state],
+          select: {c.fleet_name, c.lifecycle_state, count(c.workflow_job_id)}
+        )
+
+      try_result =
+        try do
+          Repo.all(query)
+        rescue
+          e ->
+            Logger.debug("runners: claims poll failed", reason: Exception.message(e))
+            []
+        end
+
+      Enum.each(try_result, fn {fleet, state, count} ->
+        :telemetry.execute(
+          Telemetry.event_name_claims_count(),
+          %{count: count},
+          %{fleet: fleet || "", lifecycle_state: state || ""}
+        )
+      end)
+    end
+  end
+
+  @doc false
+  def execute_pool_replicas_telemetry_event do
+    case safe_list_runner_pools() do
+      {:ok, items} ->
+        Enum.each(items, &emit_pool_replicas/1)
+
+      _ ->
+        :ok
+    end
+  end
+
+  @doc false
+  def execute_accounts_enabled_telemetry_event do
+    if PoolMetrics.running?(Repo) do
+      count =
+        try do
+          Repo.one(
+            from(a in Account,
+              where: not is_nil(a.runner_max_concurrent) and a.runner_max_concurrent > 0,
+              select: count(a.id)
+            )
+          ) || 0
+        rescue
+          e ->
+            Logger.debug("runners: accounts_enabled poll failed", reason: Exception.message(e))
+            0
+        end
+
+      :telemetry.execute(
+        Telemetry.event_name_accounts_enabled(),
+        %{count: count},
+        %{}
+      )
+    end
+  end
+
+  defp safe_list_runner_pools do
+    K8sClient.list_runner_pools(Environment.runners_namespace())
+  rescue
+    e ->
+      Logger.debug("runners: pool replicas poll failed", reason: Exception.message(e))
+      :error
+  end
+
+  defp emit_pool_replicas(%{"metadata" => %{"name" => name}} = pool) do
+    spec = Map.get(pool, "spec", %{})
+    status = Map.get(pool, "status", %{})
+
+    :telemetry.execute(
+      Telemetry.event_name_pool_replicas(),
+      %{
+        desired: Map.get(spec, "replicas", 0),
+        observed: Map.get(status, "observedReplicas", 0)
+      },
+      %{
+        fleet: name,
+        dispatch_label: Map.get(spec, "dispatchLabel", "")
+      }
+    )
+  end
+
+  defp emit_pool_replicas(_), do: :ok
+end

--- a/server/lib/tuist/runners/prom_ex_plugin.ex
+++ b/server/lib/tuist/runners/prom_ex_plugin.ex
@@ -48,6 +48,13 @@ defmodule Tuist.Runners.PromExPlugin do
 
   @metric_prefix [:tuist, :runners]
 
+  # The bounded universe of lifecycle states a `runner_claims` row
+  # can carry. The poll iterates this list so a fleet whose final
+  # `claimed` row was just released drains the gauge to zero on the
+  # next tick instead of `last_value` keeping a phantom non-zero
+  # series until process restart.
+  @lifecycle_states ~w(claimed running)
+
   # Buckets cover the realistic wall-clock range for each duration.
   # `queue_time` and `queue_to_running` are sub-minute on the happy
   # path; `run_time` / `total_time` span seconds to the GH-side
@@ -261,60 +268,109 @@ defmodule Tuist.Runners.PromExPlugin do
   @doc false
   def execute_queue_length_telemetry_event do
     if PoolMetrics.running?(ClickHouseRepo) do
-      query =
-        from(j in Job,
-          hints: ["FINAL"],
-          where: j.status == "queued",
-          group_by: j.fleet_name,
-          select: {j.fleet_name, count(j.workflow_job_id)}
-        )
+      counts = fetch_queue_counts()
 
-      try_result =
-        try do
-          ClickHouseRepo.all(query)
-        rescue
-          e ->
-            Logger.debug("runners: queue_length poll failed", reason: Exception.message(e))
-            []
-        end
-
-      Enum.each(try_result, fn {fleet, count} ->
+      counts
+      |> universe_fleets()
+      |> Enum.each(fn fleet ->
         :telemetry.execute(
           Telemetry.event_name_queue_length(),
-          %{count: count},
-          %{fleet: fleet || ""}
+          %{count: Map.get(counts, fleet, 0)},
+          %{fleet: fleet}
         )
       end)
     end
+  end
+
+  defp fetch_queue_counts do
+    query =
+      from(j in Job,
+        hints: ["FINAL"],
+        where: j.status == "queued",
+        group_by: j.fleet_name,
+        select: {j.fleet_name, count(j.workflow_job_id)}
+      )
+
+    query
+    |> ClickHouseRepo.all()
+    |> Map.new(fn {fleet, count} -> {fleet || "", count} end)
+  rescue
+    e ->
+      Logger.debug("runners: queue_length poll failed", reason: Exception.message(e))
+      %{}
   end
 
   @doc false
   def execute_claims_telemetry_event do
     if PoolMetrics.running?(Repo) do
-      query =
-        from(c in Claim,
-          group_by: [c.fleet_name, c.lifecycle_state],
-          select: {c.fleet_name, c.lifecycle_state, count(c.workflow_job_id)}
-        )
+      counts = fetch_claim_counts()
+      observed_fleets = counts |> Map.keys() |> Enum.map(&elem(&1, 0))
 
-      try_result =
-        try do
-          Repo.all(query)
-        rescue
-          e ->
-            Logger.debug("runners: claims poll failed", reason: Exception.message(e))
-            []
-        end
-
-      Enum.each(try_result, fn {fleet, state, count} ->
-        :telemetry.execute(
-          Telemetry.event_name_claims_count(),
-          %{count: count},
-          %{fleet: fleet || "", lifecycle_state: state || ""}
-        )
+      observed_fleets
+      |> universe_fleets()
+      |> Enum.each(fn fleet ->
+        Enum.each(@lifecycle_states, fn state ->
+          :telemetry.execute(
+            Telemetry.event_name_claims_count(),
+            %{count: Map.get(counts, {fleet, state}, 0)},
+            %{fleet: fleet, lifecycle_state: state}
+          )
+        end)
       end)
     end
   end
+
+  defp fetch_claim_counts do
+    query =
+      from(c in Claim,
+        group_by: [c.fleet_name, c.lifecycle_state],
+        select: {c.fleet_name, c.lifecycle_state, count(c.workflow_job_id)}
+      )
+
+    query
+    |> Repo.all()
+    |> Map.new(fn {fleet, state, count} -> {{fleet || "", state || ""}, count} end)
+  rescue
+    e ->
+      Logger.debug("runners: claims poll failed", reason: Exception.message(e))
+      %{}
+  end
+
+  # Union of (RunnerPool CRs currently in the cluster) and any
+  # fleets observed in the source-of-truth query. The cluster set
+  # ensures we emit a `0` for a fleet that just drained — otherwise
+  # `last_value` would keep the previous non-zero sample
+  # indefinitely. The observed set covers the edge case where a
+  # RunnerPool was deleted with leftover queued / claimed rows; we
+  # still surface those until the rows are cleared.
+  defp universe_fleets(observed) when is_list(observed) or is_map(observed) do
+    cluster_fleets = active_fleets()
+    observed_set = observed |> ensure_list() |> MapSet.new()
+
+    cluster_fleets
+    |> MapSet.union(observed_set)
+    |> MapSet.delete(nil)
+    |> MapSet.to_list()
+  end
+
+  defp ensure_list(map) when is_map(map), do: Map.keys(map)
+  defp ensure_list(list) when is_list(list), do: list
+
+  defp active_fleets do
+    case safe_list_runner_pools() do
+      {:ok, items} ->
+        items
+        |> Enum.map(&pool_name/1)
+        |> Enum.reject(&is_nil/1)
+        |> MapSet.new()
+
+      _ ->
+        MapSet.new()
+    end
+  end
+
+  defp pool_name(%{"metadata" => %{"name" => name}}) when is_binary(name) and name != "", do: name
+  defp pool_name(_), do: nil
 
   @doc false
   def execute_pool_replicas_telemetry_event do

--- a/server/lib/tuist/runners/prom_ex_plugin.ex
+++ b/server/lib/tuist/runners/prom_ex_plugin.ex
@@ -17,12 +17,13 @@ defmodule Tuist.Runners.PromExPlugin do
 
     * **Polling metrics.** Three poll loops at a coarse 30s cadence
       query authoritative state and emit gauges: queue length per
-      fleet from CH, inflight claim counts per fleet / lifecycle
-      state from PG, RunnerPool desired-vs-observed replica counts
-      from the K8s apiserver. Polled gauges are deliberately
-      separate from the event counters — `runner_pool_replicas` is
-      a level (current capacity), not a flux (boot/teardown rate
-      already covered by tart-kubelet's boot duration histogram).
+      fleet from ClickHouse, inflight claim counts per fleet /
+      lifecycle state from Postgres, RunnerPool desired-vs-observed
+      replica counts from the K8s apiserver. Polled gauges are
+      deliberately separate from the event counters —
+      `runner_pool_replicas` is a level (current capacity), not a
+      flux (boot/teardown rate already covered by tart-kubelet's
+      boot duration histogram).
 
   Cardinality budget: `fleet` is bounded by the number of
   RunnerPool CRs (currently 1 — `default`). Per-account fan-out is
@@ -34,7 +35,6 @@ defmodule Tuist.Runners.PromExPlugin do
 
   import Ecto.Query, only: [from: 2]
 
-  alias Tuist.Accounts.Account
   alias Tuist.ClickHouseRepo
   alias Tuist.Environment
   alias Tuist.Kubernetes.Client, as: K8sClient
@@ -246,19 +246,6 @@ defmodule Tuist.Runners.PromExPlugin do
             tags: [:fleet, :dispatch_label]
           )
         ]
-      ),
-      Polling.build(
-        :tuist_runners_accounts_enabled_metrics,
-        poll_rate,
-        {__MODULE__, :execute_accounts_enabled_telemetry_event, []},
-        [
-          last_value(
-            @metric_prefix ++ [:accounts, :enabled],
-            event_name: Telemetry.event_name_accounts_enabled(),
-            description: "Accounts with runner_max_concurrent > 0.",
-            measurement: :count
-          )
-        ]
       )
     ]
   end
@@ -370,25 +357,6 @@ defmodule Tuist.Runners.PromExPlugin do
 
       _ ->
         :ok
-    end
-  end
-
-  @doc false
-  def execute_accounts_enabled_telemetry_event do
-    if PoolMetrics.running?(Repo) do
-      count =
-        Repo.one(
-          from(a in Account,
-            where: not is_nil(a.runner_max_concurrent) and a.runner_max_concurrent > 0,
-            select: count(a.id)
-          )
-        ) || 0
-
-      :telemetry.execute(
-        Telemetry.event_name_accounts_enabled(),
-        %{count: count},
-        %{}
-      )
     end
   end
 

--- a/server/lib/tuist/runners/prom_ex_plugin.ex
+++ b/server/lib/tuist/runners/prom_ex_plugin.ex
@@ -152,18 +152,18 @@ defmodule Tuist.Runners.PromExPlugin do
         [
           counter(
             @metric_prefix ++ [:dispatch, :request, :count],
-            event_name: Telemetry.event_name_dispatch_request(),
+            event_name: Telemetry.event_name_dispatch_request() ++ [:stop],
             description: "Polling Pod dispatch requests bucketed by outcome.",
             tags: [:outcome]
           ),
           distribution(
             @metric_prefix ++ [:dispatch, :request, :duration, :milliseconds],
-            event_name: Telemetry.event_name_dispatch_request(),
-            measurement: :duration_ms,
+            event_name: Telemetry.event_name_dispatch_request() ++ [:stop],
+            measurement: :duration,
             description: "Wall-clock time the dispatch endpoint spent serving a polling Pod.",
             reporter_options: [buckets: @dispatch_duration_buckets],
             tags: [:outcome],
-            unit: :millisecond
+            unit: {:native, :millisecond}
           )
         ]
       ),

--- a/server/lib/tuist/runners/prom_ex_plugin.ex
+++ b/server/lib/tuist/runners/prom_ex_plugin.ex
@@ -44,8 +44,6 @@ defmodule Tuist.Runners.PromExPlugin do
   alias Tuist.Runners.Telemetry
   alias TuistCommon.Repo.PoolMetrics
 
-  require Logger
-
   @metric_prefix [:tuist, :runners]
 
   # The bounded universe of lifecycle states a `runner_claims` row
@@ -294,10 +292,6 @@ defmodule Tuist.Runners.PromExPlugin do
     query
     |> ClickHouseRepo.all()
     |> Map.new(fn {fleet, count} -> {fleet || "", count} end)
-  rescue
-    e ->
-      Logger.debug("runners: queue_length poll failed", reason: Exception.message(e))
-      %{}
   end
 
   @doc false
@@ -330,10 +324,6 @@ defmodule Tuist.Runners.PromExPlugin do
     query
     |> Repo.all()
     |> Map.new(fn {fleet, state, count} -> {{fleet || "", state || ""}, count} end)
-  rescue
-    e ->
-      Logger.debug("runners: claims poll failed", reason: Exception.message(e))
-      %{}
   end
 
   # Union of (RunnerPool CRs currently in the cluster) and any
@@ -357,7 +347,7 @@ defmodule Tuist.Runners.PromExPlugin do
   defp ensure_list(list) when is_list(list), do: list
 
   defp active_fleets do
-    case safe_list_runner_pools() do
+    case K8sClient.list_runner_pools(Environment.runners_namespace()) do
       {:ok, items} ->
         items
         |> Enum.map(&pool_name/1)
@@ -374,7 +364,7 @@ defmodule Tuist.Runners.PromExPlugin do
 
   @doc false
   def execute_pool_replicas_telemetry_event do
-    case safe_list_runner_pools() do
+    case K8sClient.list_runner_pools(Environment.runners_namespace()) do
       {:ok, items} ->
         Enum.each(items, &emit_pool_replicas/1)
 
@@ -387,18 +377,12 @@ defmodule Tuist.Runners.PromExPlugin do
   def execute_accounts_enabled_telemetry_event do
     if PoolMetrics.running?(Repo) do
       count =
-        try do
-          Repo.one(
-            from(a in Account,
-              where: not is_nil(a.runner_max_concurrent) and a.runner_max_concurrent > 0,
-              select: count(a.id)
-            )
-          ) || 0
-        rescue
-          e ->
-            Logger.debug("runners: accounts_enabled poll failed", reason: Exception.message(e))
-            0
-        end
+        Repo.one(
+          from(a in Account,
+            where: not is_nil(a.runner_max_concurrent) and a.runner_max_concurrent > 0,
+            select: count(a.id)
+          )
+        ) || 0
 
       :telemetry.execute(
         Telemetry.event_name_accounts_enabled(),
@@ -406,14 +390,6 @@ defmodule Tuist.Runners.PromExPlugin do
         %{}
       )
     end
-  end
-
-  defp safe_list_runner_pools do
-    K8sClient.list_runner_pools(Environment.runners_namespace())
-  rescue
-    e ->
-      Logger.debug("runners: pool replicas poll failed", reason: Exception.message(e))
-      :error
   end
 
   defp emit_pool_replicas(%{"metadata" => %{"name" => name}} = pool) do

--- a/server/lib/tuist/runners/telemetry.ex
+++ b/server/lib/tuist/runners/telemetry.ex
@@ -1,0 +1,31 @@
+defmodule Tuist.Runners.Telemetry do
+  @moduledoc """
+  Telemetry event names for the customer-runner dispatch path.
+
+  Events are intentionally narrow — one per state transition plus
+  the dispatch endpoint and the two recovery workers. The PromEx
+  plugin (`Tuist.Runners.PromExPlugin`) projects them into counters
+  for throughput, histograms for queue/run/total durations, and
+  bounded-cardinality outcome tags.
+
+  Cardinality discipline: `fleet` is the only high-fan-out tag we
+  emit (one bucket per RunnerPool, currently O(1)). Per-account
+  fan-out is deliberately *not* tagged on event metrics; account-
+  level utilisation is exposed as polled aggregate gauges from
+  `Tuist.Runners.PromExPlugin` instead.
+  """
+
+  def event_name_job_enqueued, do: [:tuist, :runners, :job, :enqueued]
+  def event_name_job_claim, do: [:tuist, :runners, :job, :claim]
+  def event_name_job_running, do: [:tuist, :runners, :job, :running]
+  def event_name_job_completed, do: [:tuist, :runners, :job, :completed]
+  def event_name_job_requeued, do: [:tuist, :runners, :job, :requeued]
+  def event_name_dispatch_request, do: [:tuist, :runners, :dispatch, :request]
+  def event_name_recovery, do: [:tuist, :runners, :recovery]
+  def event_name_webhook, do: [:tuist, :runners, :webhook]
+
+  def event_name_queue_length, do: [:tuist, :runners, :queue, :length]
+  def event_name_claims_count, do: [:tuist, :runners, :claims, :count]
+  def event_name_pool_replicas, do: [:tuist, :runners, :pool, :replicas]
+  def event_name_accounts_enabled, do: [:tuist, :runners, :accounts, :enabled]
+end

--- a/server/lib/tuist/runners/telemetry.ex
+++ b/server/lib/tuist/runners/telemetry.ex
@@ -27,5 +27,4 @@ defmodule Tuist.Runners.Telemetry do
   def event_name_queue_length, do: [:tuist, :runners, :queue, :length]
   def event_name_claims_count, do: [:tuist, :runners, :claims, :count]
   def event_name_pool_replicas, do: [:tuist, :runners, :pool, :replicas]
-  def event_name_accounts_enabled, do: [:tuist, :runners, :accounts, :enabled]
 end

--- a/server/lib/tuist/runners/workers/orphaned_runners_worker.ex
+++ b/server/lib/tuist/runners/workers/orphaned_runners_worker.ex
@@ -104,6 +104,7 @@ defmodule Tuist.Runners.Workers.OrphanedRunnersWorker do
   alias Tuist.GitHub.Client, as: GitHubClient
   alias Tuist.Runners.Claims
   alias Tuist.Runners.Jobs
+  alias Tuist.Runners.Telemetry
   alias Tuist.VCS
 
   require Logger
@@ -181,6 +182,12 @@ defmodule Tuist.Runners.Workers.OrphanedRunnersWorker do
 
     with :ok <- safe_record_queued(workflow_job_id),
          :ok <- safe_release(workflow_job_id, claimed_at) do
+      :telemetry.execute(
+        Telemetry.event_name_recovery(),
+        %{count: 1},
+        %{kind: "orphan_requeued"}
+      )
+
       true
     else
       _ -> false
@@ -210,6 +217,13 @@ defmodule Tuist.Runners.Workers.OrphanedRunnersWorker do
 
     safe_complete_pg(workflow_job_id)
     safe_complete_ch(workflow_job_id, conclusion || "")
+
+    :telemetry.execute(
+      Telemetry.event_name_recovery(),
+      %{count: 1},
+      %{kind: "orphan_completed"}
+    )
+
     true
   end
 

--- a/server/lib/tuist/runners/workers/stale_claims_worker.ex
+++ b/server/lib/tuist/runners/workers/stale_claims_worker.ex
@@ -47,6 +47,7 @@ defmodule Tuist.Runners.Workers.StaleClaimsWorker do
 
   alias Tuist.Runners.Claims
   alias Tuist.Runners.Jobs
+  alias Tuist.Runners.Telemetry
 
   require Logger
 
@@ -65,6 +66,12 @@ defmodule Tuist.Runners.Workers.StaleClaimsWorker do
       Logger.warning("runners: released stale claims",
         count: released,
         stale_after_seconds: @stale_after_seconds
+      )
+
+      :telemetry.execute(
+        Telemetry.event_name_recovery(),
+        %{count: released},
+        %{kind: "stale_claim"}
       )
     end
 

--- a/server/test/tuist/runners/jobs_test.exs
+++ b/server/test/tuist/runners/jobs_test.exs
@@ -4,6 +4,7 @@ defmodule Tuist.Runners.JobsTest do
   import TuistTestSupport.Fixtures.AccountsFixtures
 
   alias Tuist.Runners.Jobs
+  alias Tuist.Runners.Telemetry
 
   defp enqueue_fixture(account, workflow_job_id, opts \\ []) do
     fleet = Keyword.get(opts, :fleet, "fleet-a")
@@ -128,6 +129,36 @@ defmodule Tuist.Runners.JobsTest do
 
       counts = Jobs.status_counts(account.id)
       assert Map.get(counts, "completed", 0) == 1
+    end
+
+    test "emits :tuist, :runners, :job, :completed with timing measurements" do
+      handler_id = make_ref()
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+      test_pid = self()
+
+      :ok =
+        :telemetry.attach(
+          handler_id,
+          Telemetry.event_name_job_completed(),
+          fn _name, measurements, metadata, _ ->
+            send(test_pid, {:completed, measurements, metadata})
+          end,
+          nil
+        )
+
+      account = account_fixture()
+      :ok = enqueue_fixture(account, 7100, fleet: "fleet-telemetry")
+      {:ok, candidate} = Jobs.pick_queued("fleet-telemetry", [])
+      :ok = Jobs.record_claimed(candidate, "pod-1", DateTime.utc_now())
+      :ok = Jobs.record_running(7100, "runner-x")
+
+      assert {:ok, _} = Jobs.complete(7100, "success")
+
+      assert_receive {:completed, measurements, %{fleet: "fleet-telemetry", conclusion: "success"}}, 500
+      assert measurements.count == 1
+      assert is_integer(measurements.run_time_ms) and measurements.run_time_ms >= 0
+      assert is_integer(measurements.total_time_ms) and measurements.total_time_ms >= 0
+      assert is_integer(measurements.queue_time_ms) and measurements.queue_time_ms >= 0
     end
 
     test "returns :not_found for an unknown workflow_job_id" do

--- a/server/test/tuist/runners/prom_ex_plugin_test.exs
+++ b/server/test/tuist/runners/prom_ex_plugin_test.exs
@@ -1,5 +1,5 @@
 defmodule Tuist.Runners.PromExPluginTest do
-  use TuistTestSupport.Cases.DataCase, async: false
+  use TuistTestSupport.Cases.DataCase, async: true
 
   import Ecto.Query
   import TuistTestSupport.Fixtures.AccountsFixtures
@@ -148,14 +148,10 @@ defmodule Tuist.Runners.PromExPluginTest do
                      500
     end
 
-    test "tolerates a missing K8s client", %{handler_id: handler_id} do
-      attach_collector(handler_id, Telemetry.event_name_pool_replicas())
-
+    test "returns :ok when the K8s client is unavailable" do
       Mimic.stub(K8sClient, :list_runner_pools, fn _ns -> {:error, :not_in_cluster} end)
 
       assert :ok = PromExPlugin.execute_pool_replicas_telemetry_event()
-
-      refute_receive {:telemetry_event, [:tuist, :runners, :pool, :replicas], _, _}, 200
     end
   end
 end

--- a/server/test/tuist/runners/prom_ex_plugin_test.exs
+++ b/server/test/tuist/runners/prom_ex_plugin_test.exs
@@ -158,19 +158,4 @@ defmodule Tuist.Runners.PromExPluginTest do
       refute_receive {:telemetry_event, [:tuist, :runners, :pool, :replicas], _, _}, 200
     end
   end
-
-  describe "execute_accounts_enabled_telemetry_event/0" do
-    test "emits the count of accounts with runner_max_concurrent > 0", %{handler_id: handler_id} do
-      attach_collector(handler_id, Telemetry.event_name_accounts_enabled())
-
-      _ = enabled_account_fixture()
-      _ = enabled_account_fixture()
-      _ = account_fixture()
-
-      PromExPlugin.execute_accounts_enabled_telemetry_event()
-
-      assert_receive {:telemetry_event, [:tuist, :runners, :accounts, :enabled], %{count: count}, _}, 500
-      assert count >= 2
-    end
-  end
 end

--- a/server/test/tuist/runners/prom_ex_plugin_test.exs
+++ b/server/test/tuist/runners/prom_ex_plugin_test.exs
@@ -40,9 +40,23 @@ defmodule Tuist.Runners.PromExPluginTest do
     Repo.reload!(account)
   end
 
+  defp stub_pool_list(fleets) when is_list(fleets) do
+    items =
+      Enum.map(fleets, fn name ->
+        %{
+          "metadata" => %{"name" => name},
+          "spec" => %{"replicas" => 0, "dispatchLabel" => name},
+          "status" => %{"observedReplicas" => 0}
+        }
+      end)
+
+    Mimic.stub(K8sClient, :list_runner_pools, fn _ns -> {:ok, items} end)
+  end
+
   describe "execute_queue_length_telemetry_event/0" do
     test "emits per-fleet queue length gauges", %{handler_id: handler_id} do
       attach_collector(handler_id, Telemetry.event_name_queue_length())
+      stub_pool_list(["fleet-poll"])
 
       account = enabled_account_fixture()
 
@@ -64,11 +78,27 @@ defmodule Tuist.Runners.PromExPluginTest do
       assert_receive {:telemetry_event, [:tuist, :runners, :queue, :length], %{count: 1}, %{fleet: "fleet-poll"}},
                      500
     end
+
+    test "drains to zero for fleets with no remaining queued rows", %{handler_id: handler_id} do
+      attach_collector(handler_id, Telemetry.event_name_queue_length())
+
+      # Fleet is declared in the cluster but has no queued rows in
+      # ClickHouse. Without the drain-to-zero path, `last_value`
+      # would keep whatever the last non-zero sample was; this
+      # asserts we emit an explicit `0` instead.
+      stub_pool_list(["fleet-empty"])
+
+      PromExPlugin.execute_queue_length_telemetry_event()
+
+      assert_receive {:telemetry_event, [:tuist, :runners, :queue, :length], %{count: 0}, %{fleet: "fleet-empty"}},
+                     500
+    end
   end
 
   describe "execute_claims_telemetry_event/0" do
     test "emits per-fleet per-lifecycle gauges", %{handler_id: handler_id} do
       attach_collector(handler_id, Telemetry.event_name_claims_count())
+      stub_pool_list(["fleet-claims"])
 
       account = enabled_account_fixture()
       {:ok, _} = Claims.attempt(123_456, account.id, "fleet-claims", "pod-x")
@@ -77,6 +107,21 @@ defmodule Tuist.Runners.PromExPluginTest do
 
       assert_receive {:telemetry_event, [:tuist, :runners, :claims, :count], %{count: 1},
                       %{fleet: "fleet-claims", lifecycle_state: "claimed"}},
+                     500
+    end
+
+    test "drains to zero for both lifecycle states when no claims remain", %{handler_id: handler_id} do
+      attach_collector(handler_id, Telemetry.event_name_claims_count())
+      stub_pool_list(["fleet-drained"])
+
+      PromExPlugin.execute_claims_telemetry_event()
+
+      assert_receive {:telemetry_event, [:tuist, :runners, :claims, :count], %{count: 0},
+                      %{fleet: "fleet-drained", lifecycle_state: "claimed"}},
+                     500
+
+      assert_receive {:telemetry_event, [:tuist, :runners, :claims, :count], %{count: 0},
+                      %{fleet: "fleet-drained", lifecycle_state: "running"}},
                      500
     end
   end

--- a/server/test/tuist/runners/prom_ex_plugin_test.exs
+++ b/server/test/tuist/runners/prom_ex_plugin_test.exs
@@ -134,8 +134,8 @@ defmodule Tuist.Runners.PromExPluginTest do
         {:ok,
          [
            %{
-             "metadata" => %{"name" => "default"},
-             "spec" => %{"replicas" => 3, "dispatchLabel" => "tuist-runner-default"},
+             "metadata" => %{"name" => "pool-emit"},
+             "spec" => %{"replicas" => 3, "dispatchLabel" => "tuist-runner-pool-emit"},
              "status" => %{"observedReplicas" => 2}
            }
          ]}
@@ -144,7 +144,40 @@ defmodule Tuist.Runners.PromExPluginTest do
       PromExPlugin.execute_pool_replicas_telemetry_event()
 
       assert_receive {:telemetry_event, [:tuist, :runners, :pool, :replicas], %{desired: 3, observed: 2},
-                      %{fleet: "default", dispatch_label: "tuist-runner-default"}},
+                      %{fleet: "pool-emit"}},
+                     500
+    end
+
+    test "drains a pool to zero on the tick after it disappears from the cluster",
+         %{handler_id: handler_id} do
+      attach_collector(handler_id, Telemetry.event_name_pool_replicas())
+
+      # Tick 1 — pool is alive.
+      Mimic.stub(K8sClient, :list_runner_pools, fn _ns ->
+        {:ok,
+         [
+           %{
+             "metadata" => %{"name" => "pool-deleting"},
+             "spec" => %{"replicas" => 5},
+             "status" => %{"observedReplicas" => 5}
+           }
+         ]}
+      end)
+
+      PromExPlugin.execute_pool_replicas_telemetry_event()
+
+      assert_receive {:telemetry_event, [:tuist, :runners, :pool, :replicas], %{desired: 5, observed: 5},
+                      %{fleet: "pool-deleting"}},
+                     500
+
+      # Tick 2 — pool has been deleted. We expect an explicit `0`
+      # so `last_value` stops reporting the stale `5`.
+      Mimic.stub(K8sClient, :list_runner_pools, fn _ns -> {:ok, []} end)
+
+      PromExPlugin.execute_pool_replicas_telemetry_event()
+
+      assert_receive {:telemetry_event, [:tuist, :runners, :pool, :replicas], %{desired: 0, observed: 0},
+                      %{fleet: "pool-deleting"}},
                      500
     end
 

--- a/server/test/tuist/runners/prom_ex_plugin_test.exs
+++ b/server/test/tuist/runners/prom_ex_plugin_test.exs
@@ -1,0 +1,131 @@
+defmodule Tuist.Runners.PromExPluginTest do
+  use TuistTestSupport.Cases.DataCase, async: false
+
+  import Ecto.Query
+  import TuistTestSupport.Fixtures.AccountsFixtures
+
+  alias Tuist.Accounts.Account
+  alias Tuist.Kubernetes.Client, as: K8sClient
+  alias Tuist.Repo
+  alias Tuist.Runners.Claims
+  alias Tuist.Runners.Jobs
+  alias Tuist.Runners.PromExPlugin
+  alias Tuist.Runners.Telemetry
+
+  setup do
+    handler_id = make_ref()
+
+    on_exit(fn -> :telemetry.detach(handler_id) end)
+
+    {:ok, handler_id: handler_id}
+  end
+
+  defp attach_collector(handler_id, event_name) do
+    test_pid = self()
+
+    :ok =
+      :telemetry.attach(
+        handler_id,
+        event_name,
+        fn name, measurements, metadata, _config ->
+          send(test_pid, {:telemetry_event, name, measurements, metadata})
+        end,
+        nil
+      )
+  end
+
+  defp enabled_account_fixture(cap \\ 10) do
+    account = account_fixture()
+    {1, _} = Repo.update_all(from(a in Account, where: a.id == ^account.id), set: [runner_max_concurrent: cap])
+    Repo.reload!(account)
+  end
+
+  describe "execute_queue_length_telemetry_event/0" do
+    test "emits per-fleet queue length gauges", %{handler_id: handler_id} do
+      attach_collector(handler_id, Telemetry.event_name_queue_length())
+
+      account = enabled_account_fixture()
+
+      :ok =
+        Jobs.enqueue(%{
+          workflow_job_id: 999_001,
+          account_id: account.id,
+          fleet_name: "fleet-poll",
+          repo: "acme/cli",
+          workflow_run_id: 9001,
+          run_attempt: 1,
+          job_name: "build",
+          head_branch: "main",
+          head_sha: "deadbeef"
+        })
+
+      PromExPlugin.execute_queue_length_telemetry_event()
+
+      assert_receive {:telemetry_event, [:tuist, :runners, :queue, :length], %{count: 1}, %{fleet: "fleet-poll"}},
+                     500
+    end
+  end
+
+  describe "execute_claims_telemetry_event/0" do
+    test "emits per-fleet per-lifecycle gauges", %{handler_id: handler_id} do
+      attach_collector(handler_id, Telemetry.event_name_claims_count())
+
+      account = enabled_account_fixture()
+      {:ok, _} = Claims.attempt(123_456, account.id, "fleet-claims", "pod-x")
+
+      PromExPlugin.execute_claims_telemetry_event()
+
+      assert_receive {:telemetry_event, [:tuist, :runners, :claims, :count], %{count: 1},
+                      %{fleet: "fleet-claims", lifecycle_state: "claimed"}},
+                     500
+    end
+  end
+
+  describe "execute_pool_replicas_telemetry_event/0" do
+    test "emits desired + observed gauges per pool", %{handler_id: handler_id} do
+      attach_collector(handler_id, Telemetry.event_name_pool_replicas())
+
+      Mimic.stub(K8sClient, :list_runner_pools, fn _ns ->
+        {:ok,
+         [
+           %{
+             "metadata" => %{"name" => "default"},
+             "spec" => %{"replicas" => 3, "dispatchLabel" => "tuist-runner-default"},
+             "status" => %{"observedReplicas" => 2}
+           }
+         ]}
+      end)
+
+      PromExPlugin.execute_pool_replicas_telemetry_event()
+
+      assert_receive {:telemetry_event, [:tuist, :runners, :pool, :replicas], %{desired: 3, observed: 2},
+                      %{fleet: "default", dispatch_label: "tuist-runner-default"}},
+                     500
+    end
+
+    test "tolerates a missing K8s client", %{handler_id: handler_id} do
+      attach_collector(handler_id, Telemetry.event_name_pool_replicas())
+
+      Mimic.stub(K8sClient, :list_runner_pools, fn _ns -> {:error, :not_in_cluster} end)
+
+      assert :ok = PromExPlugin.execute_pool_replicas_telemetry_event()
+
+      refute_receive {:telemetry_event, [:tuist, :runners, :pool, :replicas], _, _}, 200
+    end
+  end
+
+  describe "execute_accounts_enabled_telemetry_event/0" do
+    test "emits the count of accounts with runner_max_concurrent > 0", %{handler_id: handler_id} do
+      attach_collector(handler_id, Telemetry.event_name_accounts_enabled())
+
+      _ = enabled_account_fixture()
+      _ = enabled_account_fixture()
+      _ = account_fixture()
+
+      PromExPlugin.execute_accounts_enabled_telemetry_event()
+
+      assert_receive {:telemetry_event, [:tuist, :runners, :accounts, :enabled], %{count: count}, _}, 500
+      assert count >= 2
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds health telemetry for the Tuist Runners (managed GitHub Actions runners) feature and extends the existing Grafana dashboard from a VM-boot-only view into a full operational dashboard.

Builds on the dashboard scaffolding added in [#10761](https://github.com/tuist/tuist/pull/10761) — that PR shipped the tailnet-scraped `tart_kubelet_vm_boot_duration_seconds` panels (host-side); this PR adds the server-side dispatch / lifecycle signals on top of it.

## What's emitted

**Event metrics** (via `:telemetry.execute` in the runners code, projected into Prometheus by `Tuist.Runners.PromExPlugin`):

- `tuist_runners_job_enqueued_count{fleet}` — webhook → CH enqueue.
- `tuist_runners_job_claim_count{fleet, outcome}` and `tuist_runners_job_queue_time_milliseconds_bucket{fleet}` — claim and queue wait.
- `tuist_runners_job_running_count{fleet}` and `tuist_runners_job_queue_to_running_time_milliseconds_bucket{fleet}` — JIT mint transition.
- `tuist_runners_job_completed_count{fleet, conclusion}` and `tuist_runners_job_run_time_milliseconds_bucket{fleet}` / `..._total_time_milliseconds_bucket{fleet}` — terminal state with timing breakdown.
- `tuist_runners_job_requeued_count{fleet}` — release / stale recovery.
- `tuist_runners_dispatch_request_count{outcome}` and `tuist_runners_dispatch_request_duration_milliseconds_bucket{outcome}` — wraps `Tuist.Runners.dispatch_for_sa/2` to time the dispatch endpoint from the polling Pod's perspective.
- `tuist_runners_webhook_count{action, outcome}` — `workflow_job` deliveries bucketed by action and outcome (handles `ignored`, `no_account`, `runners_disabled`, etc.).
- `tuist_runners_recovery_count{kind}` — `StaleClaimsWorker` and `OrphanedRunnersWorker` output by kind (`stale_claim`, `orphan_requeued`, `orphan_completed`).

**Polled gauges** (30s cadence, each guarded against missing infra):

- `tuist_runners_queue_length{fleet}` — `runner_jobs` in `status='queued'` per fleet (CH).
- `tuist_runners_claims_count{fleet, lifecycle_state}` — active PG `runner_claims` per fleet × state.
- `tuist_runners_pool_replicas_desired{fleet, dispatch_label}` and `tuist_runners_pool_replicas_observed{...}` — RunnerPool `spec.replicas` vs `status.observedReplicas`.
- `tuist_runners_accounts_enabled` — accounts with `runner_max_concurrent > 0`.

Cardinality discipline: `fleet` is the only fan-out tag on event metrics (bounded by RunnerPool CR count, currently 1). Per-account fan-out is deliberately not tagged on event metrics; account-level views are exposed as aggregate gauges only.

## Dashboard

`infra/grafana-dashboards/runners.json` extended from 4 panels to 32, organised into 7 sections:

1. **Overview** — 5 stat tiles (queued, pre-mint, running, desired runners, accounts enabled) plus the existing Mac-minis-reporting tile.
2. **Throughput** — enqueued/sec, completed/sec by conclusion (stacked, conclusion-coloured), claim+run rate, webhook deliveries.
3. **Latency** — p50/p95/p99 timeseries for queue time, enqueue→running, run time, total time, plus a queue-time heatmap.
4. **Capacity** — RunnerPool desired vs observed replicas, pool utilisation (running / observed), queue length per fleet, inflight claims split by lifecycle state.
5. **Dispatch endpoint** — dispatch RPS by outcome (colour-coded `served` green / `no_work_yet` blue / errors red) and p50/p95/p99 latency.
6. **Recovery** — recovery rate by kind to surface JIT-mint stalls and missed-completion webhooks.
7. **VM boot time** — the three panels from #10761 preserved verbatim, gated by the existing `\$pool` variable.

A new `\$fleet` variable (RunnerPool name) drives the server-side panels; the existing `\$pool` variable (Mac mini fleet) still drives the tart-kubelet panels.

## How to test locally

- `mix test test/tuist/runners/` — 46/46 passing, including the new `Tuist.Runners.PromExPluginTest` (5 tests covering each polling function plus the K8s-unavailable path).
- `mix credo --strict` clean for the new files.
- `mix format --check-formatted` clean.
- `python3 -m json.tool infra/grafana-dashboards/runners.json` to confirm the dashboard JSON is valid.

## What this is NOT

- **Doesn't add alert rules.** Alerts are managed in the Grafana Cloud UI, not in this repo. The dashboard panels carry threshold colours where useful so an operator can eyeball saturation.
- **Doesn't tag event metrics by account.** Per-account utilisation is a separate UX surface; tagging events here would explode cardinality without serving the operational health view.
- **Doesn't change the runners data path.** Every emission is a one-line `:telemetry.execute` after the existing side-effect; the dispatch endpoint timing wraps `dispatch_for_sa/2` with `System.monotonic_time` and is a no-op on the happy path.