### PR TITLE
fix(infra): trust nested infra mise config in Kura regional deploy

### DIFF
--- a/.github/workflows/server-kura-regional-deployment.yml
+++ b/.github/workflows/server-kura-regional-deployment.yml
@@ -69,4 +69,10 @@ jobs:
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
         run: |
+          # k8s:deploy-kura-regionals is a file task under
+          # infra/mise/tasks, discovered only when infra/mise.toml is
+          # loaded. mise-action trusts the repo-root config but not the
+          # nested infra one, so without this the task resolves against
+          # the root config and mise exits with "no task found".
+          mise trust "$GITHUB_WORKSPACE/infra/mise.toml"
           mise -C "$GITHUB_WORKSPACE/infra" run k8s:deploy-kura-regionals "$IMAGE_TAG"


### PR DESCRIPTION
> Describe here the purpose of your PR.

The **Server Kura Regional Deployment** workflow is failing on `main` (e.g. [run 26047265787](https://github.com/tuist/tuist/actions/runs/26047265787/job/76574620434)) at the *Deploy Kura regional controllers* step:

```
mise ERROR no task k8s:deploy-kura-regionals found
```

`k8s:deploy-kura-regionals` is a file task under `infra/mise/tasks/k8s/`, discovered by mise only when `infra/mise.toml` is loaded. `jdx/mise-action` trusts the repo-root `mise.toml` but not the nested `infra/mise.toml`. So when the step runs `mise -C "$GITHUB_WORKSPACE/infra" run k8s:deploy-kura-regionals`, mise skips the untrusted nested config, resolves the task name against the root config instead, and exits 1 listing the root tasks (which is exactly what the failing job shows).

This trusts `infra/mise.toml` in the step before invoking the task. It is the same mechanism the workflow added in #10845 needs but never set up.

Reproduced and verified locally:

- `mise trust --untrust infra/mise.toml` then `mise -C infra tasks ls` -> `k8s:deploy-kura-regionals` not found (reproduces the CI failure exactly).
- `mise trust infra/mise.toml` (the line this PR adds) then the same lookup -> task found again.

Scope: infra CI only. Separate from the Kura state-healing work in #10851.

### How to test locally

```sh
WS="$(git rev-parse --show-toplevel)"
mise trust --untrust "$WS/infra/mise.toml"
mise -C "$WS/infra" tasks ls | grep k8s:deploy-kura-regionals   # not found
mise trust "$WS/infra/mise.toml"
mise -C "$WS/infra" tasks ls | grep k8s:deploy-kura-regionals   # found
```
