### PR TITLE
fix(cache): honor custom S3 CA bundles for virtual-hosted endpoints

### DIFF
--- a/cache/lib/cache/finch/pools.ex
+++ b/cache/lib/cache/finch/pools.ex
@@ -40,7 +40,9 @@ defmodule Cache.Finch.Pools do
             ca_cert_pem: Cache.Config.s3_ca_cert_pem()
           )
 
-        Map.put(pools, s3_url, s3_pool_opts)
+        s3_url
+        |> s3_endpoints()
+        |> Enum.reduce(pools, fn endpoint, acc -> Map.put(acc, endpoint, s3_pool_opts) end)
 
       :error ->
         pools
@@ -51,5 +53,30 @@ defmodule Cache.Finch.Pools do
     config()
     |> Map.keys()
     |> Enum.reject(&(&1 == :default))
+  end
+
+  defp s3_endpoints(s3_url) do
+    Enum.uniq([s3_url | virtual_host_s3_endpoints(s3_url)])
+  end
+
+  defp virtual_host_s3_endpoints(s3_url) do
+    if Cache.Config.s3_virtual_host() do
+      [
+        Cache.Config.cache_bucket(),
+        Cache.Config.xcode_cache_bucket() || Cache.Config.cache_bucket(),
+        Cache.Config.registry_bucket()
+      ]
+      |> Enum.filter(&is_binary/1)
+      |> Enum.map(&bucket_endpoint(s3_url, &1))
+    else
+      []
+    end
+  end
+
+  defp bucket_endpoint(s3_url, bucket) do
+    s3_url
+    |> URI.parse()
+    |> Map.update!(:host, fn host -> "#{bucket}.#{host}" end)
+    |> URI.to_string()
   end
 end

--- a/cache/test/cache/finch/pools_test.exs
+++ b/cache/test/cache/finch/pools_test.exs
@@ -8,12 +8,17 @@ defmodule Cache.Finch.PoolsTest do
 
   describe "config/0 S3 pool protocols" do
     setup do
+      stub(Cache.Config, :cache_bucket, fn -> "cache-bucket" end)
       stub(Cache.Config, :server_url, fn -> "https://tuist.dev" end)
       stub(Cache.Config, :s3_ca_cert_pem, fn -> nil end)
+      stub(Cache.Config, :s3_virtual_host, fn -> false end)
 
       stub(Cache.Config, :s3_config, fn ->
         {:ok, [scheme: "https://", host: "s3.example.com", region: "us-east-1"]}
       end)
+
+      stub(Cache.Config, :xcode_cache_bucket, fn -> nil end)
+      stub(Cache.Config, :registry_bucket, fn -> nil end)
 
       :ok
     end
@@ -70,6 +75,19 @@ defmodule Cache.Finch.PoolsTest do
       cacerts = Keyword.fetch!(transport_opts, :cacerts)
       assert is_list(cacerts) and cacerts != []
       assert Enum.all?(cacerts, &is_binary/1)
+    end
+
+    test "registers virtual-hosted bucket pools when enabled" do
+      stub(Cache.Config, :s3_virtual_host, fn -> true end)
+      stub(Cache.Config, :xcode_cache_bucket, fn -> "xcode-bucket" end)
+      stub(Cache.Config, :registry_bucket, fn -> "registry-bucket" end)
+
+      config = Pools.config()
+
+      assert Map.has_key?(config, "https://s3.example.com")
+      assert Map.has_key?(config, "https://cache-bucket.s3.example.com")
+      assert Map.has_key?(config, "https://xcode-bucket.s3.example.com")
+      assert Map.has_key?(config, "https://registry-bucket.s3.example.com")
     end
   end
 end

--- a/tuist_common/lib/tuist_common/finch_pools.ex
+++ b/tuist_common/lib/tuist_common/finch_pools.ex
@@ -81,9 +81,16 @@ defmodule TuistCommon.FinchPools do
   defp ca_cert_opts(pem_content) do
     der_certs =
       pem_content
+      |> normalize_pem_content()
       |> :public_key.pem_decode()
       |> Enum.map(fn {_, der, _} -> der end)
 
     [cacerts: der_certs]
+  end
+
+  defp normalize_pem_content(pem_content) do
+    pem_content
+    |> String.replace("\r\n", "\n")
+    |> String.replace("\\n", "\n")
   end
 end

--- a/tuist_common/test/tuist_common/finch_pools_test.exs
+++ b/tuist_common/test/tuist_common/finch_pools_test.exs
@@ -57,6 +57,22 @@ defmodule TuistCommon.FinchPoolsTest do
       assert Enum.all?(cacerts, &is_binary/1)
     end
 
+    test "accepts PEM bundles with escaped newlines" do
+      pem =
+        CAStore.file_path()
+        |> File.read!()
+        |> String.replace("\n", "\\n")
+
+      {_endpoint, opts} =
+        FinchPools.s3_pool(endpoint: "https://s3.example.com", ca_cert_pem: pem)
+
+      transport_opts = opts |> Keyword.fetch!(:conn_opts) |> Keyword.fetch!(:transport_opts)
+      cacerts = Keyword.fetch!(transport_opts, :cacerts)
+
+      assert is_list(cacerts) and cacerts != []
+      assert Enum.all?(cacerts, &is_binary/1)
+    end
+
     test "raises when endpoint is missing" do
       assert_raise KeyError, fn -> FinchPools.s3_pool([]) end
     end


### PR DESCRIPTION
## Summary
- Register Finch pools for virtual-hosted S3 bucket origins so cache requests still use the configured custom CA bundle when `S3_VIRTUAL_HOST` is enabled.
- Normalize CRLF and escaped newline PEM content before decoding custom S3 CA bundles, which keeps container-injected certificate secrets usable.
- Add focused regression coverage for virtual-hosted bucket pools and escaped-newline PEM bundles.

## Testing
- `mix test test/tuist_common/finch_pools_test.exs`
- `mix test test/cache/finch/pools_test.exs`
