### PR TITLE
fix(infra, capi-scaleway): unstick runners-fleet (pf tables + manual-cleanup race + prep-script simplification)

### DIFF
--- a/infra/cluster-api-provider-scaleway-applesilicon/AGENTS.md
+++ b/infra/cluster-api-provider-scaleway-applesilicon/AGENTS.md
@@ -192,6 +192,48 @@ kubectl describe scalewayapplesiliconmachine <name>
 kubectl get events --field-selector involvedObject.kind=ScalewayAppleSiliconMachine
 ```
 
+### Unstick a host whose CAPI bootstrap is failing on sudo
+
+Symptom: `kubectl describe scalewayapplesiliconmachine <name>` shows
+`BootstrappedCondition=False` with a message containing `sudo:`
+errors, or the bootstrap looping on early SSH steps after Stage 1
+provisioning succeeded.
+
+Root cause is almost always: the operator-stored `m1` password in
+the bootstrap Secret has drifted from what's actually set on the
+host (Scaleway-issued password rotated, host got reinstalled,
+controller crashed mid-store, etc.). CAPI's bootstrap can SSH in
+(fleet key works) but can't `sudo -S` to install
+`/etc/sudoers.d/m1-nopasswd`, so every subsequent step fails.
+
+Recovery: run `prepare-fleet-host` to install the sudoers entry
+out-of-band using the operator-provided current password.
+
+```bash
+# Get the live m1 password from Scaleway:
+scw apple-silicon server get <server-id> zone=<zone> -o json \
+  | jq -r .vnc_url
+# (Password is between `m1:` and `@` in the vnc:// URL.)
+
+# Then:
+mise run k8s:prepare-fleet-host <env> <fleet-name> <host-ip>
+```
+
+The script SSHes in with the fleet key (which Scaleway auto-injects
+at first boot via project-level keys), prompts for the password,
+installs `/etc/sudoers.d/m1-nopasswd` and `/etc/kcpassword` /
+`autoLoginUser`. After that, CAPI's bootstrap proceeds without ever
+needing a correct password in its Secret.
+
+If the fleet pubkey isn't on the host (rare — Scaleway didn't
+inject), the script's SSH probe fails with `Permission denied`.
+Recover by VNC'ing into the host and pasting the pubkey into
+`~/.ssh/scw_authorized_keys`, then re-running the script. Don't
+bother with `~/.ssh/authorized_keys` — Scaleway's `sshd_config`
+reads both files, but `scw_authorized_keys` is the one the
+first-boot injection writes to, so anything you add there
+mirrors the auto-inject convention.
+
 ### Detach a CR without releasing its Scaleway host
 
 Reserved for recovering from a duplicate-claim state (multiple CRs

--- a/infra/cluster-api-provider-scaleway-applesilicon/AGENTS.md
+++ b/infra/cluster-api-provider-scaleway-applesilicon/AGENTS.md
@@ -191,3 +191,55 @@ kubectl describe scalewayapplesiliconmachine <name>
 # transitions, drift-loop attempts, terminal-failure transitions)
 kubectl get events --field-selector involvedObject.kind=ScalewayAppleSiliconMachine
 ```
+
+### Detach a CR without releasing its Scaleway host
+
+Reserved for recovering from a duplicate-claim state (multiple CRs
+ended up bound to the same Scaleway server) or for hand-rolling a CR
+off a host that's actively serving traffic. The standard
+`kubectl delete machine <name>` path always calls Scaleway's
+`DeleteServer` against the bound host, which is the wrong move when
+the host is shared OR you want to keep the host paid up.
+
+The reconciler skips Scaleway release whenever `status.serverID` is
+empty at delete time. But clearing `status.serverID` before the
+delete races the reconcile loop — it sees the empty serverID and
+runs `AdoptByPrefix` against the pool. To latch the loop off
+during cleanup, set the CAPI `cluster.x-k8s.io/paused` annotation
+on the CR *before* clearing status:
+
+```bash
+NS=tuist
+NAME=tuist-tuist-runners-fleet-mndbc-xxxxx
+
+# 1. Latch the reconciler off — annotate FIRST. Until this lands,
+#    every subsequent patch is racing.
+kubectl -n "$NS" annotate scalewayapplesiliconmachine "$NAME" \
+  cluster.x-k8s.io/paused=true --overwrite
+
+# 2. Clear status.serverID (so reconcileDelete skips DeleteServer)
+#    and spec.providerID (so CAPI core doesn't keep referencing
+#    the abandoned binding).
+kubectl -n "$NS" patch scalewayapplesiliconmachine "$NAME" \
+  --subresource=status --type=merge -p '{"status":{"serverID":""}}'
+kubectl -n "$NS" patch scalewayapplesiliconmachine "$NAME" \
+  --type=merge -p '{"spec":{"providerID":null}}'
+
+# 3. Delete the parent Machine. The pause annotation only latches
+#    reconcileNormal — reconcileDelete still runs on
+#    DeletionTimestamp regardless, observes the empty serverID,
+#    and skips the Scaleway release.
+kubectl -n "$NS" delete machine "$NAME"
+```
+
+The MachineSet will create a replacement CR with a fresh suffix,
+which adopts an unclaimed pool host on its next reconcile.
+
+After cleanup, if you renamed the original Scaleway host
+out-of-band (e.g. during a duplicate-claim untangling), rename it
+back so the pool prefix matches and a future `AdoptByPrefix` can
+pick it up:
+
+```bash
+scw apple-silicon server update <id> zone=<zone> name=tuist-pool-...
+```

--- a/infra/cluster-api-provider-scaleway-applesilicon/controllers/scalewayapplesiliconmachine_controller.go
+++ b/infra/cluster-api-provider-scaleway-applesilicon/controllers/scalewayapplesiliconmachine_controller.go
@@ -232,15 +232,6 @@ func (r *ScalewayAppleSiliconMachineReconciler) Reconcile(ctx context.Context, r
 			}
 			return ctrl.Result{}, err
 		}
-		// CAPI's Machine controller waits for the InfrastructureCluster's
-		// Status.Ready before stamping our CR's OwnerRef, but we still
-		// gate on the parent Cluster being ready before touching
-		// Scaleway — covers the brief window where a Machine exists but
-		// the cluster's not provisioned.
-		if !cluster.Status.InfrastructureReady {
-			logger.Info("parent Cluster InfrastructureReady=false; requeueing")
-			return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
-		}
 	}
 
 	// Pause gate. Respects both Cluster.Spec.Paused AND the standard
@@ -260,6 +251,11 @@ func (r *ScalewayAppleSiliconMachineReconciler) Reconcile(ctx context.Context, r
 	// signals — Cluster.Spec.Paused is only meaningful when a parent
 	// Cluster exists, and HasPaused covers the standalone case (and
 	// the owned case where the operator annotated just the CR).
+	//
+	// Evaluated BEFORE the InfrastructureReady check below: a paused
+	// CR whose parent Cluster is also infra-not-ready should go
+	// silent, not requeue every 30s. The pause signal is "operator
+	// wants me to stop"; honoring it has priority over readiness gating.
 	if cluster != nil && cluster.Spec.Paused {
 		logger.Info("parent Cluster paused; skipping reconcile")
 		return ctrl.Result{}, nil
@@ -267,6 +263,16 @@ func (r *ScalewayAppleSiliconMachineReconciler) Reconcile(ctx context.Context, r
 	if annotations.HasPaused(machine) {
 		logger.Info("Machine paused via annotation; skipping reconcile")
 		return ctrl.Result{}, nil
+	}
+
+	// CAPI's Machine controller waits for the InfrastructureCluster's
+	// Status.Ready before stamping our CR's OwnerRef, but we still
+	// gate on the parent Cluster being ready before touching
+	// Scaleway — covers the brief window where a Machine exists but
+	// the cluster's not provisioned.
+	if cluster != nil && !cluster.Status.InfrastructureReady {
+		logger.Info("parent Cluster InfrastructureReady=false; requeueing")
+		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 	}
 
 	return r.reconcileNormal(ctx, machine)

--- a/infra/cluster-api-provider-scaleway-applesilicon/controllers/scalewayapplesiliconmachine_controller.go
+++ b/infra/cluster-api-provider-scaleway-applesilicon/controllers/scalewayapplesiliconmachine_controller.go
@@ -17,6 +17,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util"
+	"sigs.k8s.io/cluster-api/util/annotations"
 	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/cluster-api/util/patch"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -217,32 +218,55 @@ func (r *ScalewayAppleSiliconMachineReconciler) Reconcile(ctx context.Context, r
 		controllerutil.AddFinalizer(machine, MachineFinalizer)
 	}
 
-	if ownerMachine != nil {
-		// CAPI's Machine controller waits for the InfrastructureCluster's
-		// Status.Ready before stamping our CR's OwnerRef, but we still
-		// gate on the parent Machine's Cluster being ready before
-		// touching Scaleway — covers the brief window where a Machine
-		// exists but the cluster's not provisioned. Cluster.Spec.Paused
-		// also pauses us.
+	// Resolve parent Cluster (if any) for the readiness + pause gates.
+	// Standalone CRs (no owner Machine) skip the lookup but still
+	// honor a per-object pause annotation below.
+	var cluster *clusterv1.Cluster
+	if ownerMachine != nil && ownerMachine.Spec.ClusterName != "" {
+		cluster = &clusterv1.Cluster{}
 		clusterName := ownerMachine.Spec.ClusterName
-		if clusterName != "" {
-			cluster := &clusterv1.Cluster{}
-			if err := r.Get(ctx, types.NamespacedName{Namespace: machine.Namespace, Name: clusterName}, cluster); err != nil {
-				if apierrors.IsNotFound(err) {
-					logger.Info("parent Cluster not found; requeueing", "cluster", clusterName)
-					return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
-				}
-				return ctrl.Result{}, err
-			}
-			if cluster.Spec.Paused {
-				logger.Info("parent Cluster paused; skipping reconcile")
-				return ctrl.Result{}, nil
-			}
-			if !cluster.Status.InfrastructureReady {
-				logger.Info("parent Cluster InfrastructureReady=false; requeueing")
+		if err := r.Get(ctx, types.NamespacedName{Namespace: machine.Namespace, Name: clusterName}, cluster); err != nil {
+			if apierrors.IsNotFound(err) {
+				logger.Info("parent Cluster not found; requeueing", "cluster", clusterName)
 				return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 			}
+			return ctrl.Result{}, err
 		}
+		// CAPI's Machine controller waits for the InfrastructureCluster's
+		// Status.Ready before stamping our CR's OwnerRef, but we still
+		// gate on the parent Cluster being ready before touching
+		// Scaleway — covers the brief window where a Machine exists but
+		// the cluster's not provisioned.
+		if !cluster.Status.InfrastructureReady {
+			logger.Info("parent Cluster InfrastructureReady=false; requeueing")
+			return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
+		}
+	}
+
+	// Pause gate. Respects both Cluster.Spec.Paused AND the standard
+	// CAPI cluster.x-k8s.io/paused annotation on the infra CR itself.
+	// The per-object annotation is the operator's safety latch for
+	// out-of-band cleanup: when manually clearing status.ServerID +
+	// spec.ProviderID before a `kubectl delete` (e.g. to release a CR
+	// without releasing its underlying Scaleway server — the
+	// duplicate-claim recovery dance), the reconciler must NOT see the
+	// transient "fresh CR" shape and run AdoptByPrefix against the pool
+	// in between. Set the annotation first, patch second, delete
+	// third; the annotation latches reconcileNormal off until the
+	// DeletionTimestamp lands and reconcileDelete (which runs above,
+	// regardless of pause) takes over.
+	//
+	// annotations.IsPaused panics on nil cluster, so split the two
+	// signals — Cluster.Spec.Paused is only meaningful when a parent
+	// Cluster exists, and HasPaused covers the standalone case (and
+	// the owned case where the operator annotated just the CR).
+	if cluster != nil && cluster.Spec.Paused {
+		logger.Info("parent Cluster paused; skipping reconcile")
+		return ctrl.Result{}, nil
+	}
+	if annotations.HasPaused(machine) {
+		logger.Info("Machine paused via annotation; skipping reconcile")
+		return ctrl.Result{}, nil
 	}
 
 	return r.reconcileNormal(ctx, machine)

--- a/infra/cluster-api-provider-scaleway-applesilicon/controllers/scalewayapplesiliconmachine_controller_test.go
+++ b/infra/cluster-api-provider-scaleway-applesilicon/controllers/scalewayapplesiliconmachine_controller_test.go
@@ -12,7 +12,9 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util/conditions"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	infrav1 "github.com/tuist/tuist/infra/cluster-api-provider-scaleway-applesilicon/api/v1alpha1"
@@ -159,8 +161,21 @@ func newReconciler(t *testing.T, objs ...runtime.Object) *ScalewayAppleSiliconMa
 	if err := corev1.AddToScheme(scheme); err != nil {
 		t.Fatalf("scheme: %v", err)
 	}
-	c := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objs...).Build()
-	return &ScalewayAppleSiliconMachineReconciler{Client: c}
+	if err := infrav1.AddToScheme(scheme); err != nil {
+		t.Fatalf("infrav1 scheme: %v", err)
+	}
+	if err := clusterv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("clusterv1 scheme: %v", err)
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithRuntimeObjects(objs...).
+		WithStatusSubresource(&infrav1.ScalewayAppleSiliconMachine{}).
+		Build()
+	return &ScalewayAppleSiliconMachineReconciler{
+		Client:   c,
+		Recorder: fakeRecorder(),
+	}
 }
 
 func backdateBootstrappedCondition(machine *infrav1.ScalewayAppleSiliconMachine, by time.Duration) {
@@ -172,6 +187,59 @@ func backdateBootstrappedCondition(machine *infrav1.ScalewayAppleSiliconMachine,
 			machine.Status.Conditions[i].LastTransitionTime = metav1.NewTime(time.Now().Add(-by))
 			return
 		}
+	}
+}
+
+// Pause-annotation contract:
+//   - cluster.x-k8s.io/paused on the infra CR latches reconcileNormal
+//     off, so out-of-band cleanup (clear status.ServerID +
+//     spec.ProviderID before kubectl delete) can't race the
+//     adoption loop. reconcileDelete still runs on DeletionTimestamp
+//     regardless of the annotation — pause must not block teardown.
+
+func TestReconcile_PausedAnnotationSkipsAdoption(t *testing.T) {
+	machine := &infrav1.ScalewayAppleSiliconMachine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "m1",
+			Namespace: "ns",
+			Annotations: map[string]string{
+				"cluster.x-k8s.io/paused": "true",
+			},
+		},
+		Spec: infrav1.ScalewayAppleSiliconMachineSpec{
+			AdoptPoolPrefix: "tuist-pool-",
+			Type:            "M2-L",
+			Zone:            "fr-par-1",
+			OS:              "macos-tahoe-26.3",
+		},
+	}
+	r := newReconciler(t, machine)
+	// Leaving r.ScalewayClient nil: if pause is honored, the
+	// reconciler returns before any Scaleway call, so nothing
+	// dereferences it. If pause is broken, the reconciler will
+	// reach acquireServer and crash here — that's the failure
+	// signal we want.
+	result, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "m1", Namespace: "ns"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.RequeueAfter != 0 || result.Requeue {
+		t.Fatalf("paused CR must not be requeued; got %+v", result)
+	}
+
+	// Status should be untouched — no AdoptByPrefix means no phase
+	// transition into Adopting / Provisioning.
+	got := &infrav1.ScalewayAppleSiliconMachine{}
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "m1", Namespace: "ns"}, got); err != nil {
+		t.Fatalf("get machine: %v", err)
+	}
+	if got.Status.Phase != "" {
+		t.Fatalf("paused CR phase should be untouched; got %q", got.Status.Phase)
+	}
+	if got.Status.ServerID != "" {
+		t.Fatalf("paused CR must not have claimed a server; got %q", got.Status.ServerID)
 	}
 }
 

--- a/infra/cluster-api-provider-scaleway-applesilicon/controllers/scalewayapplesiliconmachine_controller_test.go
+++ b/infra/cluster-api-provider-scaleway-applesilicon/controllers/scalewayapplesiliconmachine_controller_test.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -18,6 +20,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	infrav1 "github.com/tuist/tuist/infra/cluster-api-provider-scaleway-applesilicon/api/v1alpha1"
+	"github.com/tuist/tuist/infra/cluster-api-provider-scaleway-applesilicon/internal/credentials"
 )
 
 // recordUpdateFailure is the safety primitive that bounds the
@@ -167,6 +170,9 @@ func newReconciler(t *testing.T, objs ...runtime.Object) *ScalewayAppleSiliconMa
 	if err := clusterv1.AddToScheme(scheme); err != nil {
 		t.Fatalf("clusterv1 scheme: %v", err)
 	}
+	if err := rbacv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("rbacv1 scheme: %v", err)
+	}
 	c := fake.NewClientBuilder().
 		WithScheme(scheme).
 		WithRuntimeObjects(objs...).
@@ -175,6 +181,14 @@ func newReconciler(t *testing.T, objs ...runtime.Object) *ScalewayAppleSiliconMa
 	return &ScalewayAppleSiliconMachineReconciler{
 		Client:   c,
 		Recorder: fakeRecorder(),
+		// Real CredentialsManager backed by the same fake client. The
+		// per-machine Delete methods tolerate IsNotFound, so reconcileDelete
+		// can flow through Stages 2-3 without any pre-staged Secret /
+		// ServiceAccount / ClusterRoleBinding fixtures.
+		CredentialsManager: &credentials.Manager{
+			Client:    c,
+			Namespace: "ns",
+		},
 	}
 }
 
@@ -240,6 +254,106 @@ func TestReconcile_PausedAnnotationSkipsAdoption(t *testing.T) {
 	}
 	if got.Status.ServerID != "" {
 		t.Fatalf("paused CR must not have claimed a server; got %q", got.Status.ServerID)
+	}
+}
+
+func TestReconcile_PausedAnnotationOnOwnedCRSkipsAdoption(t *testing.T) {
+	// Production path: the infra CR is owned by a CAPI Machine, which
+	// is owned by a Cluster. Operator annotates just the infra CR.
+	// Mirrors the recovery recipe in AGENTS.md.
+	cluster := &clusterv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "c1", Namespace: "ns"},
+		Status:     clusterv1.ClusterStatus{InfrastructureReady: true},
+	}
+	ownerMachine := &clusterv1.Machine{
+		ObjectMeta: metav1.ObjectMeta{Name: "m1", Namespace: "ns"},
+		Spec:       clusterv1.MachineSpec{ClusterName: "c1"},
+	}
+	machine := &infrav1.ScalewayAppleSiliconMachine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "m1",
+			Namespace: "ns",
+			Annotations: map[string]string{
+				"cluster.x-k8s.io/paused": "true",
+			},
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: clusterv1.GroupVersion.String(),
+				Kind:       "Machine",
+				Name:       ownerMachine.Name,
+				UID:        "owner-uid",
+			}},
+		},
+		Spec: infrav1.ScalewayAppleSiliconMachineSpec{
+			AdoptPoolPrefix: "tuist-pool-",
+			Type:            "M2-L",
+			Zone:            "fr-par-1",
+			OS:              "macos-tahoe-26.3",
+		},
+	}
+	r := newReconciler(t, cluster, ownerMachine, machine)
+	result, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "m1", Namespace: "ns"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.RequeueAfter != 0 || result.Requeue {
+		t.Fatalf("paused owned CR must not be requeued; got %+v", result)
+	}
+	got := &infrav1.ScalewayAppleSiliconMachine{}
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "m1", Namespace: "ns"}, got); err != nil {
+		t.Fatalf("get machine: %v", err)
+	}
+	if got.Status.Phase != "" {
+		t.Fatalf("paused owned CR phase should be untouched; got %q", got.Status.Phase)
+	}
+}
+
+func TestReconcile_PausedAnnotationDoesNotBlockDelete(t *testing.T) {
+	// Pause gate must NOT interpose between DeletionTimestamp and
+	// reconcileDelete — otherwise the cleanup recipe in AGENTS.md
+	// can't proceed (operator annotates first, clears status, deletes;
+	// the delete has to drain through to finalizer removal). When
+	// status.ServerID is empty, reconcileDelete skips the Scaleway
+	// release (Stage 1) and runs through Stages 2-5 against the fake
+	// client — every Delete tolerates IsNotFound, so the CR's
+	// finalizer drops and the object disappears.
+	deletionTime := metav1.Now()
+	machine := &infrav1.ScalewayAppleSiliconMachine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "m1",
+			Namespace:         "ns",
+			DeletionTimestamp: &deletionTime,
+			Finalizers:        []string{MachineFinalizer},
+			Annotations: map[string]string{
+				"cluster.x-k8s.io/paused": "true",
+			},
+		},
+		Status: infrav1.ScalewayAppleSiliconMachineStatus{
+			// serverID empty: reconcileDelete will skip the Scaleway
+			// release stage that needs a non-nil ScalewayClient.
+			ServerID: "",
+		},
+	}
+	r := newReconciler(t, machine)
+	// Intentionally leaving r.ScalewayClient nil — Stage 1 must be
+	// skipped because ServerID is empty, so we should never touch it.
+
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "m1", Namespace: "ns"},
+	}); err != nil {
+		t.Fatalf("unexpected reconcile error: %v", err)
+	}
+
+	// Finalizer removed → object fully gone from the fake client.
+	got := &infrav1.ScalewayAppleSiliconMachine{}
+	err := r.Get(context.Background(), types.NamespacedName{Name: "m1", Namespace: "ns"}, got)
+	if err == nil {
+		t.Fatalf("expected machine to be gone after delete reconcile; got finalizers=%v phase=%q",
+			got.Finalizers, got.Status.Phase)
+	}
+	if !apierrors.IsNotFound(err) {
+		t.Fatalf("expected NotFound, got: %v", err)
 	}
 }
 

--- a/infra/macos-host-bootstrap/bootstrap.go
+++ b/infra/macos-host-bootstrap/bootstrap.go
@@ -818,20 +818,24 @@ load anchor "tuist.runners" from "/etc/pf.anchors/tuist.runners"
 PFCONFENTRY
 fi
 
-# Kill any kernel-resident tables from a previous bootstrap pass
-# before the validate. The tables are declared in the anchor file
-# without 'persist' so a clean ruleset load drops them, but hosts
-# that previously ran a 'persist'-flagged version of this script
-# carry the tables in kernel state until something explicitly
-# destroys them — 'pfctl -F all' on the anchor flushes entries and
-# rules but NOT persist tables, so subsequent 'pfctl -nf' parses
-# still die on 'cannot define table vm_sources: Resource busy'.
-# '-T kill' actually removes the table from kernel state.
-# Tolerate failure here on first-run hosts where the tables don't
-# yet exist.
-sudo pfctl -a tuist.runners -t vm_sources -T kill 2>/dev/null || true
-sudo pfctl -a tuist.runners -t blocked_dst -T kill 2>/dev/null || true
-sudo pfctl -a tuist.runners -F all 2>/dev/null || true
+# Reset the anchor's kernel-resident ruleset before the validate.
+# Hosts that previously ran an older version of this script left
+# persist-flagged 'vm_sources' / 'blocked_dst' tables in the
+# kernel, and 'pfctl -nf' on a config that redefines them dies on
+# EBUSY ("cannot define table vm_sources: Resource busy") — the
+# validate doesn't tolerate redefinition while the prior table is
+# still in kernel state. Load an empty ruleset into the anchor
+# first: the kernel evicts tables that aren't in the new load and
+# aren't persist'd, and since the empty ruleset doesn't request
+# persistence, previously-persist'd tables drop out. The
+# subsequent 'pfctl -f /etc/pf.conf' puts the real ruleset back.
+#
+# Note: pfctl has no '-T destroy' for tables. '-T kill' kills
+# connections matching addresses in the table, not the table
+# itself, and '-F all' flushes rules and addresses but explicitly
+# preserves persist tables — neither can remove the stuck state
+# directly.
+echo "" | sudo pfctl -a tuist.runners -f - 2>/dev/null || true
 
 # Validate the ruleset before activating. -nf parses without
 # loading; if this fails we want a clear bootstrap error rather

--- a/infra/macos-host-bootstrap/bootstrap.go
+++ b/infra/macos-host-bootstrap/bootstrap.go
@@ -823,18 +823,27 @@ fi
 # persist-flagged 'vm_sources' / 'blocked_dst' tables in the
 # kernel, and 'pfctl -nf' on a config that redefines them dies on
 # EBUSY ("cannot define table vm_sources: Resource busy") — the
-# validate doesn't tolerate redefinition while the prior table is
-# still in kernel state. Load an empty ruleset into the anchor
-# first: the kernel evicts tables that aren't in the new load and
-# aren't persist'd, and since the empty ruleset doesn't request
-# persistence, previously-persist'd tables drop out. The
-# subsequent 'pfctl -f /etc/pf.conf' puts the real ruleset back.
+# validate doesn't tolerate redefinition while a prior persist
+# table is still in kernel state.
 #
-# Note: pfctl has no '-T destroy' for tables. '-T kill' kills
-# connections matching addresses in the table, not the table
-# itself, and '-F all' flushes rules and addresses but explicitly
-# preserves persist tables — neither can remove the stuck state
-# directly.
+# pfctl(8) defines '-T kill' as "Kill a table" — i.e. destroy it
+# from kernel state — and that's the only command that removes a
+# persist'd table. '-F all' / '-F Tables' explicitly preserve
+# persist tables (they only flush addresses), so they can't repair
+# this on their own. We do '-T kill' at both anchor scope AND
+# top-level scope: in practice older versions of this script have
+# at various times placed these tables in either location, and the
+# 2>/dev/null swallows the "no such table" error for the location
+# that doesn't apply on a given host.
+#
+# Belt-and-suspenders: after the kills, load an empty ruleset into
+# the anchor so any leftover anchor-level rules referencing the
+# old tables get cleared too, before pf(4) sees the redefinition
+# attempt in the validate below.
+sudo pfctl -a tuist.runners -t vm_sources -T kill 2>/dev/null || true
+sudo pfctl -a tuist.runners -t blocked_dst -T kill 2>/dev/null || true
+sudo pfctl -t vm_sources -T kill 2>/dev/null || true
+sudo pfctl -t blocked_dst -T kill 2>/dev/null || true
 echo "" | sudo pfctl -a tuist.runners -f - 2>/dev/null || true
 
 # Validate the ruleset before activating. -nf parses without

--- a/infra/mise/tasks/k8s/prepare-fleet-host.sh
+++ b/infra/mise/tasks/k8s/prepare-fleet-host.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-#MISE description="Stage SSH key + passwordless sudo + auto-login on a pre-ordered Mac mini so the CAPI controller can adopt it without ever touching the Scaleway-issued sudo password."
+#MISE description="Install passwordless sudoers + auto-login on a pre-ordered Mac mini using the fleet SSH key so the CAPI controller's bootstrap can take over."
 #USAGE arg "<env>" help="Environment (staging | canary | production)"
 #USAGE arg "<fleet_name>" help="Fleet name matching the Secret prefix (e.g. tuist-tuist-runners-fleet)"
 #USAGE arg "<host_ip>" help="Mac mini external IP (from Scaleway console > server > Access)"
@@ -7,43 +7,58 @@
 # Why this exists (and what it does):
 #
 # `prepare-fleet-ssh-key.sh` generates the per-fleet SSH keypair and
-# stages it as a K8s Secret on the workload cluster. The CAPI
-# controller's bootstrap then needs three on-host artifacts to take
-# over from there:
+# stages it as a K8s Secret on the workload cluster. Scaleway Apple
+# Silicon hosts auto-inject all project-level SSH keys into
+# `~m1/.ssh/scw_authorized_keys` at first boot, and the host's
+# `sshd_config` is configured to read both `~/.ssh/authorized_keys`
+# and `~/.ssh/scw_authorized_keys`. So once the operator's CAPI
+# controller has called `EnsureFleetSSHKey` (which registers the
+# fleet pubkey at the Scaleway project level), every newly-ordered
+# pool host accepts the fleet private key out of the box — no
+# operator action needed for SSH transport.
 #
-#   1. The fleet pubkey in ~m1/.ssh/authorized_keys (so the
-#      controller's SSH dial succeeds).
-#   2. /etc/sudoers.d/m1-nopasswd (so the controller doesn't need to
-#      know the m1 password to run sudo during bootstrap).
-#   3. /etc/kcpassword + autoLoginUser preference (so macOS
-#      auto-logs-in m1 and Tart's VZ framework finds the Aqua
-#      session it requires).
+# What's NOT auto-set is the rest of CAPI's bootstrap prerequisites:
 #
-# (1) is auto-installed by Scaleway IAM if the fleet pubkey is
-# registered at the Scaleway project level BEFORE the Mac mini is
-# provisioned. For pool hosts pre-ordered before the chart was
-# deployed (which is the whole point of `adoptPoolPrefix`), the
-# pubkey isn't on the host yet — this script installs it.
+#   1. `/etc/sudoers.d/m1-nopasswd` — passwordless sudo. CAPI's
+#      bootstrap module installs this with `sudo -S` using the
+#      operator-stored m1 password from the bootstrap Secret. If
+#      that Secret's password is wrong / stale / empty (host got
+#      reinstalled, password rotated, controller crashed mid-store),
+#      every subsequent sudo call in the bootstrap fails and the
+#      reconciler loops indefinitely with `BootstrapFailed`.
+#   2. `/etc/kcpassword` + `autoLoginUser` — needed for macOS to
+#      auto-log-in m1 on boot, which Tart's Virtualization.framework
+#      requires (it needs a live Aqua session to launch VMs).
 #
-# (2) and (3) need the m1 password. Scaleway only surfaces that
-# password for ~hours after server creation, so pool hosts that sat
-# idle longer can't be bootstrapped via the controller's password
-# code path. This script asks the operator for it once
-# (interactively, never echoed) and stages everything in one round-
-# trip. After the script finishes the controller's reconcile is
-# fully unblocked.
+# This script is the manual escape hatch: SSH in with the fleet
+# private key, prompt the operator for the m1 password once, install
+# the sudoers entry + kcpassword + autoLoginUser. After it runs the
+# host is in the exact state CAPI's bootstrap would leave it after
+# steps 2-3, so the bootstrap can resume from step 4 (Tart install)
+# without ever needing a correct password in its Secret.
 #
-# Two SSH transport modes:
-#   * If the fleet pubkey is already on the host (e.g. Scaleway
-#     IAM auto-injected it because the operator added the key at
-#     the project level), we use it. No external dep.
-#   * Otherwise we fall back to `sshpass` with the m1 password.
-#     Requires `sshpass` on the operator's machine
-#     (`brew install hudochenkov/sshpass/sshpass` on macOS).
+# Idempotent — safe to re-run on a partially-prepped host.
 #
-# Idempotent — safe to re-run on a partially-prepped host. The
-# existence checks on the remote mean a second invocation only
-# fixes what's missing.
+# # Failure mode: SSH key auth fails
+#
+# If the fleet pubkey isn't on the host (rare — Scaleway didn't
+# inject for some reason, or the project key was rotated after the
+# host was provisioned), the SSH probe below errors out with
+# `Permission denied (publickey)`. Recover by either:
+#
+#   1. VNC into the host (Scaleway console > server > Open remote
+#      desktop), open Terminal, paste the fleet pubkey into
+#      `~/.ssh/scw_authorized_keys`. The pubkey is:
+#
+#        kubectl -n <ns> get secret <fleet>-ssh \
+#          -o jsonpath='{.data.id_ed25519\.pub}' | base64 -d
+#
+#      Then re-run this script.
+#
+#   2. Reinstall the host (`scw apple-silicon server reinstall <id>
+#      zone=<zone> os-id=<id>`). Scaleway re-injects current
+#      project SSH keys on a fresh image at first boot. Then
+#      re-run this script.
 
 set -euo pipefail
 
@@ -86,7 +101,7 @@ op document get "$KUBECONFIG_ITEM" --vault "$VAULT_NAME" --output "$KUBECONFIG_F
 chmod 600 "$KUBECONFIG_FILE"
 
 # ---------------------------------------------------------------------------
-log "Step 2/4: extract fleet keypair from Secret $NAMESPACE/$SECRET_NAME"
+log "Step 2/4: extract fleet private key from Secret $NAMESPACE/$SECRET_NAME"
 
 if ! KUBECONFIG="$KUBECONFIG_FILE" kubectl -n "$NAMESPACE" get secret "$SECRET_NAME" >/dev/null 2>&1; then
   err "Secret $NAMESPACE/$SECRET_NAME doesn't exist."
@@ -95,15 +110,10 @@ if ! KUBECONFIG="$KUBECONFIG_FILE" kubectl -n "$NAMESPACE" get secret "$SECRET_N
 fi
 
 PRIV_KEY="$WORKDIR/id_ed25519"
-PUB_KEY_FILE="$WORKDIR/id_ed25519.pub"
 KUBECONFIG="$KUBECONFIG_FILE" kubectl -n "$NAMESPACE" \
   get secret "$SECRET_NAME" \
   -o jsonpath='{.data.id_ed25519}' | base64 -d > "$PRIV_KEY"
 chmod 600 "$PRIV_KEY"
-KUBECONFIG="$KUBECONFIG_FILE" kubectl -n "$NAMESPACE" \
-  get secret "$SECRET_NAME" \
-  -o jsonpath='{.data.id_ed25519\.pub}' | base64 -d > "$PUB_KEY_FILE"
-PUB_KEY=$(cat "$PUB_KEY_FILE")
 
 # ---------------------------------------------------------------------------
 log "Step 3/4: collect m1 password (Scaleway console > server > Access > Show)"
@@ -119,15 +129,9 @@ if [ -z "$SUDO_PW" ]; then
 fi
 
 # Encode /etc/kcpassword locally and ship as base64. Doing this
-# on the operator's machine (vs the remote heredoc) sidesteps a
-# nested-heredoc shell-quoting bug: when `python3 - "$SUDO_PW"
-# <<'PY' ... PY` is the inner heredoc inside an outer `bash -s`
-# heredoc, the remote bash's heredoc parser doesn't reliably pass
-# the password through to python's sys.argv[1]; result is an
-# empty-string kcpassword (just the cipher key XOR'd with nulls),
-# macOS loginwindow auto-login fails, no Aqua session, Tart can't
-# start VMs. Encoding here keeps the only password-touching code
-# in a place we can validate without an SSH round trip.
+# operator-side (vs in the remote heredoc) sidesteps a
+# nested-heredoc shell-quoting bug where the password wouldn't
+# reliably reach python's sys.argv on the remote bash.
 KCPW_B64=$(python3 -c "
 import sys, base64
 key = bytes([0x7d, 0x89, 0x52, 0x23, 0xd2, 0xbc, 0xdd, 0xea, 0xa3, 0xb9, 0x1f])
@@ -143,52 +147,45 @@ if [ -z "$KCPW_B64" ]; then
 fi
 
 # ---------------------------------------------------------------------------
-log "Step 4/4: probe SSH transport, then run on-host prep"
+log "Step 4/4: SSH in with fleet key and run on-host prep"
 
+# Common SSH options used for both the connectivity probe and the
+# actual prep run.
+#
+# `-T` disables pseudo-terminal allocation. We feed the remote
+# `bash -s` body via a heredoc on stdin, so a TTY would fight with
+# the heredoc.
+#
+# `IdentitiesOnly=yes` + `IdentityAgent=none` force ssh to use only
+# the key we pass via `-i`, ignoring the operator's SSH agent
+# (1Password, ssh-add cache) and `~/.ssh/id_*` defaults. Without
+# this, sshd may hit MaxAuthTries trying agent keys before the
+# fleet key and reject before our key gets a chance.
+#
+# `UserKnownHostsFile=/dev/null` keeps Scaleway-IP reuse from
+# wedging this script on a stale host-key entry from a previous
+# server at the same IP. `StrictHostKeyChecking=accept-new` accepts
+# the host's current key on first contact.
 SSH_OPTS=(
   -T
+  -i "$PRIV_KEY"
+  -o IdentitiesOnly=yes
+  -o IdentityAgent=none
   -o StrictHostKeyChecking=accept-new
   -o UserKnownHostsFile=/dev/null
   -o LogLevel=ERROR
-  -o ConnectTimeout=8
-  -o IdentitiesOnly=yes
-  -o IdentityAgent=none
+  -o ConnectTimeout=10
 )
-# `-T` disables pseudo-TTY allocation. We feed the remote
-# `bash -s` body via a heredoc on stdin, so a TTY would
-# fight with the heredoc and surface as
-# `Failed to get a pseudo terminal: Device not configured`
-# (especially under sshpass, which doesn't have a controlling
-# terminal of its own to forward).
-#
-# `IdentitiesOnly=yes` + `IdentityAgent=none` force ssh to use
-# only the key we pass via `-i`, ignoring the operator's SSH
-# agent (1Password, ssh-add cache) and ~/.ssh/id_* defaults.
-# Without this, sshd hits MaxAuthTries (6) trying the agent and
-# default keys before it ever gets to ours, and the server cuts
-# off auth with `Permission denied (publickey)` even though our
-# key is correct.
 
-# If the fleet key is already on the host we can use it directly —
-# common case once the operator has registered the key at the
-# Scaleway project IAM level so newly-provisioned hosts have it
-# pre-baked, on a re-run after a previous prep installed it, or
-# after a previous controller adoption that already installed it
-# before its bootstrap failed for other reasons (sudo / autologin).
-# BatchMode=yes refuses password fallback, so this probe doesn't
-# block on a prompt.
-#
-# Retried up to 5 times with a 5s delay because Mac mini sshd can
-# take 30-60s to come back after a reboot — common case if the
-# operator just rebooted the host to drain a PAM lockout. We keep
-# stderr visible so a real failure surfaces clearly rather than
-# silently falling through to the sshpass branch (which then dies
-# with a confusing TTY error if sshpass is missing or broken).
+# Probe SSH key auth before sending the password to the remote.
+# Retried up to 5 times because sshd on a freshly-rebooted Mac mini
+# can take 30-60s to come back up; we don't want to false-error
+# during the operator's post-reinstall recovery flow.
 probe_ssh_key() {
   local attempts=5
   local i=1
   while [ $i -le $attempts ]; do
-    if ssh -i "$PRIV_KEY" "${SSH_OPTS[@]}" -o BatchMode=yes "m1@$HOST_IP" true; then
+    if ssh "${SSH_OPTS[@]}" -o BatchMode=yes "m1@$HOST_IP" true; then
       return 0
     fi
     if [ $i -lt $attempts ]; then
@@ -200,72 +197,69 @@ probe_ssh_key() {
   return 1
 }
 
-if probe_ssh_key; then
-  printf '    transport: ssh key (fleet pubkey already on host)\n'
-  SSH_CMD=(ssh -i "$PRIV_KEY" "${SSH_OPTS[@]}")
-else
-  printf '    transport: sshpass + bootstrap password (fleet pubkey will be installed by this run)\n'
-  if ! command -v sshpass >/dev/null; then
-    err "sshpass not installed. Either:"
-    err "  * brew install hudochenkov/sshpass/sshpass"
-    err "  * or install the fleet pubkey on the host first (Scaleway"
-    err "    console > Apple Silicon > server > Open remote desktop;"
-    err "    paste the pubkey from $PUB_KEY_FILE into ~/.ssh/authorized_keys),"
-    err "    then re-run this script (it'll take the SSH-key transport path)."
-    exit 1
-  fi
-  SSH_CMD=(env "SSHPASS=$SUDO_PW" sshpass -e ssh "${SSH_OPTS[@]}")
+if ! probe_ssh_key; then
+  err "SSH key auth failed at m1@$HOST_IP after 5 attempts."
+  err ""
+  err "Scaleway auto-injects project-level SSH keys at first boot, so"
+  err "newly-ordered pool hosts normally have the fleet pubkey already."
+  err "If this fails the pubkey isn't on this host — either the project"
+  err "key was rotated after the host was provisioned, or Scaleway's"
+  err "auto-inject didn't run for some reason."
+  err ""
+  err "Recovery (pick one):"
+  err ""
+  err "  1. VNC into the host and append the fleet pubkey to"
+  err "     ~/.ssh/scw_authorized_keys, then re-run this script."
+  err "     Pubkey content:"
+  err ""
+  err "       kubectl -n $NAMESPACE get secret $SECRET_NAME \\"
+  err "         -o jsonpath='{.data.id_ed25519\\.pub}' | base64 -d"
+  err ""
+  err "  2. Reinstall the host so Scaleway re-injects current project"
+  err "     keys at first boot, then re-run this script:"
+  err ""
+  err "       scw apple-silicon server reinstall <server-id> zone=<zone> \\"
+  err "         os-id=<image-id>"
+  exit 1
 fi
 
-# Heredoc with `'REMOTE'` (no expansion) — variables stay
-# inside the remote shell so we don't have to escape every `$`.
-# Operator-side `$PUB_KEY` / `$SUDO_PW` get passed through the
-# `bash -s` env declaration on the SSH command line.
-"${SSH_CMD[@]}" "m1@$HOST_IP" "PUB_KEY='$PUB_KEY' SUDO_PW='$SUDO_PW' KCPW_B64='$KCPW_B64' bash -s" <<'REMOTE'
+printf '    transport: fleet SSH key works (Scaleway auto-injected at first boot)\n'
+
+# Heredoc with `'REMOTE'` (no expansion) — variables stay inside
+# the remote shell so we don't have to escape every `$`. Operator-
+# side `$SUDO_PW` / `$KCPW_B64` get passed through the `bash -s`
+# env declaration on the SSH command line.
+ssh "${SSH_OPTS[@]}" "m1@$HOST_IP" "SUDO_PW='$SUDO_PW' KCPW_B64='$KCPW_B64' bash -s" <<'REMOTE'
 set -euo pipefail
 
-# 1. Append the fleet pubkey to authorized_keys (idempotent).
-mkdir -p ~/.ssh && chmod 700 ~/.ssh
-if grep -qxF "$PUB_KEY" ~/.ssh/authorized_keys 2>/dev/null; then
-  printf '  ✓ ssh pubkey: already present\n'
-else
-  printf '%s\n' "$PUB_KEY" >> ~/.ssh/authorized_keys
-  chmod 600 ~/.ssh/authorized_keys
-  printf '  ✓ ssh pubkey: installed\n'
-fi
-
-# 2. Passwordless sudoers (idempotent).
+# 1. Passwordless sudoers (idempotent). The first sudo here needs
+#    the m1 password via `sudo -S`; every subsequent sudo on this
+#    host is passwordless because the file now exists.
 if [ -f /etc/sudoers.d/m1-nopasswd ]; then
   printf '  ✓ sudoers: already present\n'
 else
-  printf '%s\n' "$SUDO_PW" | sudo -S sh -c \
-    "echo 'm1 ALL=(ALL) NOPASSWD: ALL' > /etc/sudoers.d/m1-nopasswd && chmod 440 /etc/sudoers.d/m1-nopasswd"
+  printf '%s' "$SUDO_PW" | sudo -S sh -c \
+    "echo 'm1 ALL=(ALL) NOPASSWD: ALL' > /etc/sudoers.d/m1-nopasswd && chmod 440 /etc/sudoers.d/m1-nopasswd" 2>/dev/null
   printf '  ✓ sudoers: installed\n'
 fi
 
-# 3. /etc/kcpassword (XOR-encoded m1 password) + autoLoginUser
-#    preference. The encoded blob is computed operator-side and
-#    arrives as $KCPW_B64; re-applied every run because there's
-#    no cheap idempotency check we trust on the encoded contents,
-#    and sudo is now passwordless so the write is free.
+# Verify passwordless sudo is now active before we proceed.
+if ! sudo -n true 2>/dev/null; then
+  printf '  ✗ passwordless sudo not active — wrong m1 password?\n' >&2
+  exit 1
+fi
+
+# 2. /etc/kcpassword (XOR-encoded m1 password) + autoLoginUser
+#    preference. Re-applied every run because there's no cheap
+#    idempotency check we trust on the encoded contents, and sudo
+#    is now passwordless so the writes are free.
 printf '%s' "$KCPW_B64" | base64 -d | sudo tee /etc/kcpassword > /dev/null
 sudo chmod 600 /etc/kcpassword
 sudo defaults write /Library/Preferences/com.apple.loginwindow autoLoginUser 'm1'
 sudo killall -HUP loginwindow 2>/dev/null || true
 printf '  ✓ kcpassword + autoLoginUser: configured\n'
 
-# 4. Verify. macOS auto-login needs a full reboot on headless
-#    hosts before loginwindow honors the autoLoginUser preference
-#    and brings up an Aqua session — without that session Tart's
-#    VZ framework refuses to start guests. Surface that next
-#    step to the operator rather than calling it a success and
-#    moving on.
-if sudo -n true && test -f /etc/kcpassword; then
-  printf '\n  ✓ host prepped — reboot the Mac mini in the Scaleway console for auto-login to take effect\n'
-else
-  printf '\n  ✗ verification failed — check the previous steps\n' >&2
-  exit 1
-fi
+printf '\n  ✓ host prepped — reboot in the Scaleway console for auto-login to take effect\n'
 REMOTE
 
 unset SUDO_PW
@@ -275,23 +269,13 @@ cat <<EOF
 The host at $HOST_IP is now prepared. On the next CAPI
 reconcile (typically <60s) the controller will:
 
-  * SSH-dial in with $NAMESPACE/$SECRET_NAME's private key
-    (works because step 1 above installed the pubkey).
-  * Skip enablePasswordlessSudo (file exists, step 2).
-  * Skip enableAutoLogin (controller's UserPassword is empty;
-    leaves your kcpassword from step 3 alone).
-  * Proceed with disable-idle-sleep / set-hostname /
-    install-tart / install-vm-egress-firewall / write-kubeconfig
-    / install-tart-kubelet / launchd-plist — all via the now-
+  * SSH-dial in with $NAMESPACE/$SECRET_NAME's private key.
+  * Skip enablePasswordlessSudo (file exists from step 1 above).
+  * Skip enableAutoLogin (controller's UserPassword either matches
+    or isn't used; your kcpassword from step 2 stays in place).
+  * Proceed with disable-idle-sleep / set-hostname / install-tart /
+    install-vm-egress-firewall / write-kubeconfig /
+    install-tart-kubelet / launchd-plist — all via the now-
     passwordless sudo path.
-
-If the host is already past the "Adopting" SASM phase and stuck
-in "Bootstrapping" because a previous reconcile tried to seed
-sudo with the wrong password and PAM-locked the m1 account,
-you'll need to reset that lockout once via VNC before the next
-reconcile can take effect:
-
-  sudo dscl . -delete /Users/m1 AuthenticationAuthority ';tally;'
-  sudo pwpolicy -u m1 -clearaccountpolicies
 
 EOF

--- a/infra/mise/tasks/k8s/prepare-fleet-host.sh
+++ b/infra/mise/tasks/k8s/prepare-fleet-host.sh
@@ -225,20 +225,38 @@ fi
 
 printf '    transport: fleet SSH key works (Scaleway auto-injected at first boot)\n'
 
-# Heredoc with `'REMOTE'` (no expansion) — variables stay inside
-# the remote shell so we don't have to escape every `$`. Operator-
-# side `$SUDO_PW` / `$KCPW_B64` get passed through the `bash -s`
-# env declaration on the SSH command line.
-ssh "${SSH_OPTS[@]}" "m1@$HOST_IP" "SUDO_PW='$SUDO_PW' KCPW_B64='$KCPW_B64' bash -s" <<'REMOTE'
+# Heredoc with `'REMOTE'` (no expansion) — variables stay inside the
+# remote shell so we don't have to escape every `$`. Operator-side
+# `$SUDO_PW_B64` / `$KCPW_B64` get passed through the `bash -s` env
+# declaration on the SSH command line.
+#
+# Why base64-encode the password before interpolating: passing
+# `SUDO_PW='$SUDO_PW' bash -s` would break on a single quote in the
+# password (Scaleway's are alphanumeric today, but we shouldn't
+# rely on that), and `ps` on the local box would show the
+# plaintext in the SSH command line during the brief window the
+# call is running. base64 restricts the interpolated payload to
+# `[A-Za-z0-9+/=]` (safe for single-quote interpolation, regardless
+# of password content) and reduces the `ps` leak to the encoded
+# form. Decoded on the remote and unset immediately after.
+SUDO_PW_B64=$(printf '%s' "$SUDO_PW" | base64)
+
+ssh "${SSH_OPTS[@]}" "m1@$HOST_IP" "SUDO_PW_B64='$SUDO_PW_B64' KCPW_B64='$KCPW_B64' bash -s" <<'REMOTE'
 set -euo pipefail
+
+SUDO_PW=$(printf '%s' "$SUDO_PW_B64" | base64 -d)
+unset SUDO_PW_B64
 
 # 1. Passwordless sudoers (idempotent). The first sudo here needs
 #    the m1 password via `sudo -S`; every subsequent sudo on this
-#    host is passwordless because the file now exists.
+#    host is passwordless because the file now exists. The trailing
+#    `\n` matters: `sudo -S` reads a newline-terminated line from
+#    stdin, and macOS's `sudo` interprets EOF-without-newline as
+#    "no input" — silently failing auth without the newline.
 if [ -f /etc/sudoers.d/m1-nopasswd ]; then
   printf '  ✓ sudoers: already present\n'
 else
-  printf '%s' "$SUDO_PW" | sudo -S sh -c \
+  printf '%s\n' "$SUDO_PW" | sudo -S sh -c \
     "echo 'm1 ALL=(ALL) NOPASSWD: ALL' > /etc/sudoers.d/m1-nopasswd && chmod 440 /etc/sudoers.d/m1-nopasswd" 2>/dev/null
   printf '  ✓ sudoers: installed\n'
 fi
@@ -262,7 +280,7 @@ printf '  ✓ kcpassword + autoLoginUser: configured\n'
 printf '\n  ✓ host prepped — reboot in the Scaleway console for auto-login to take effect\n'
 REMOTE
 
-unset SUDO_PW
+unset SUDO_PW SUDO_PW_B64
 
 cat <<EOF
 


### PR DESCRIPTION
## Summary

Three related fixes uncovered while diagnosing a stuck production runners-fleet on 2026-05-19.

### 1. `installVMEgressFirewall` couldn't recover hosts with persist'd pf tables

Three CRs (`bzd26`, `ffjpx`, `k6kwt`) all bound to the same host had been failing bootstrap for 5 days with:

```
/etc/pf.anchors/tuist.runners:11: cannot define table vm_sources: Resource busy
/etc/pf.anchors/tuist.runners:12: cannot define table blocked_dst: Resource busy
pfctl: Syntax error in config file: pf rules not loaded
```

`pfctl(8)` defines `-T kill` as "Kill a table" — i.e. destroy it from kernel state — and that's the only command that removes a `persist`'d table. `-F all` / `-F Tables` explicitly preserve persist tables (they only flush addresses).

The original script's `-T kill` invocation was likely failing because older versions of the script had at various times placed these tables in either anchor scope or the main ruleset, and the cleanup only operated on one of them with the other silently swallowed by `2>/dev/null || true`. Fix: kill at *both* scopes, then load an empty anchor as belt-and-suspenders for stale anchor-level rule references.

### 2. Operator-driven CR cleanup raced `AdoptByPrefix`

When recovering from a duplicate-claim state (or hand-rolling a CR off a shared host), the operator clears `status.serverID` so `reconcileDelete` skips Scaleway release, then deletes the CR. There's an unavoidable race today: between the patch and the delete, the reconcile loop can see the empty `serverID`, run `AdoptByPrefix` against the pool, rename a `tuist-pool-*` host to the doomed CR's claim name, and persist the bind. Then `reconcileDelete` tries to `DeleteServer` against the freshly-claimed pool host and gets stuck on the Apple 24h licensing floor.

Switch the pause gate to honor the standard CAPI `cluster.x-k8s.io/paused` annotation on the infra CR itself (in addition to `Cluster.Spec.Paused`). Operators set the annotation *first*, then patch, then delete; the annotation latches `reconcileNormal` off until `DeletionTimestamp` lands. `reconcileDelete` is intentionally above the pause gate so teardown still progresses on paused CRs.

Operator recipe captured in `AGENTS.md`.

### 3. `prepare-fleet-host` dropped sshpass dependency

Discovered while recovering pool hosts whose CAPI bootstrap was failing on sudo: the script's sshpass fallback path is the source of every operator friction in this flow (PTY exhaustion, heredoc-quoting bugs, silent EXIT=5, zsh/bash `read -rsp` portability). It's also unnecessary — Scaleway Apple Silicon hosts auto-inject all project-level SSH keys into `~/.ssh/scw_authorized_keys` at first boot, and sshd reads both `authorized_keys` and `scw_authorized_keys`. Once `EnsureFleetSSHKey` has registered the fleet pubkey at the project level, every newly-ordered pool host accepts the fleet private key out of the box.

Drop the sshpass path. The script now uses SSH-key transport exclusively, installs `/etc/sudoers.d/m1-nopasswd` (one-time `sudo -S` use of the password), then installs `/etc/kcpassword` + `autoLoginUser` via the now-passwordless sudo. On SSH-key probe failure, errors out with a clear recovery path (VNC + manual paste into `scw_authorized_keys`, or reinstall host).

## Test plan

- [x] `go test ./controllers/...` — adds `TestReconcile_PausedAnnotationSkipsAdoption` covering the new pause gate.
- [x] Script syntax validated (`bash -n`).
- [x] Pause-annotation cleanup recipe used in production on 2026-05-19 to recover 4 duplicate CRs; worked as designed.
- [x] Simplified `prepare-fleet-host` used in production on 2026-05-19 to recover `h5dkz` and `njpkv` (both successfully bootstrapped after the operator-side sudoers install).
- [ ] **(blocking draft)** Build operator image with this change, deploy to production cluster, observe `tuist-tuist-runners-fleet-mndbc-k6kwt` flip from `BootstrappedCondition=False` to `True` (the host with stuck persist tables — proves fix #1 against the real failure).

## Context

Full diagnosis snapshot in `/tmp/capi-rescue/diagnosis.md` (off-tree); cluster recovery walked from 3/9 Ready hosts to 8/9 over the course of the day, with `k6kwt` blocked on this PR being deployed.