### PR TITLE
fix(infra): exclude bare-metal Robot nodes from hcloud-csi-node

### DIFF
--- a/infra/k8s/mgmt/bootstrap/hcloud-csi-values.yaml
+++ b/infra/k8s/mgmt/bootstrap/hcloud-csi-values.yaml
@@ -58,7 +58,18 @@ node:
   #      before binding its `:9808` healthz port, so the liveness
   #      probe gets `connection refused` and CrashLoopBackOff kicks
   #      in. Observed on `bm-tuist-staging-runners-linux-*`.
-  # Future bare-metal pools should carry the same
+  #
+  # Helm replaces (rather than merges) `node.affinity` when set, so
+  # the chart's upstream Robot exclusions (`is-root-server`,
+  # `provided-by=robot`) are re-declared here alongside our pool
+  # rule. All three live in one `matchExpressions` list so they AND
+  # together — a node schedules the pod only if it is none of:
+  # Hetzner root server, Robot-provisioned, or in `runners-linux`.
+  # Our CAPI HCCM doesn't set the `is-root-server` / `provided-by`
+  # labels today (upstream chart with no Robot creds), so the pool
+  # rule is what actually filters in this cluster; the others are
+  # forward-compat with a Syself-style HCCM or a future Robot-aware
+  # upstream. Future bare-metal pools should carry the same
   # `node.cluster.x-k8s.io/pool` label convention so this affinity
   # can be extended with another `values:` entry.
   affinity:
@@ -66,6 +77,14 @@ node:
       requiredDuringSchedulingIgnoredDuringExecution:
         nodeSelectorTerms:
           - matchExpressions:
+              - key: instance.hetzner.cloud/is-root-server
+                operator: NotIn
+                values:
+                  - "true"
+              - key: instance.hetzner.cloud/provided-by
+                operator: NotIn
+                values:
+                  - robot
               - key: node.cluster.x-k8s.io/pool
                 operator: NotIn
                 values:

--- a/infra/k8s/mgmt/bootstrap/hcloud-csi-values.yaml
+++ b/infra/k8s/mgmt/bootstrap/hcloud-csi-values.yaml
@@ -43,6 +43,33 @@ node:
   # to a CrashLoopBackOff with "context deadline exceeded" trying to
   # GET /hetzner/v1/metadata/availability-zone.
   hostNetwork: true
+  # Skip Hetzner Robot bare-metal nodes (the `runners-linux` pool in
+  # `cluster-<env>.yaml`). The chart's default tolerations are
+  # `operator: Exists`, which swallows the
+  # `tuist.dev/runner-tier=bare-metal:NoSchedule` taint and lands the
+  # pod on bare metal, where two things go wrong:
+  #   1. Hetzner Cloud Volumes can't attach to Robot servers, so the
+  #      driver has nothing to do there — it's the wrong CSI for the
+  #      hardware.
+  #   2. The driver's startup call to `api.hetzner.cloud` truncates
+  #      to the first 3 nameservers (Linux resolv.conf limit), which
+  #      on a multi-NIC bare-metal box can omit the working upstream;
+  #      kubelet logs `DNSConfigForming` and the process exits Error
+  #      before binding its `:9808` healthz port, so the liveness
+  #      probe gets `connection refused` and CrashLoopBackOff kicks
+  #      in. Observed on `bm-tuist-staging-runners-linux-*`.
+  # Future bare-metal pools should carry the same
+  # `node.cluster.x-k8s.io/pool` label convention so this affinity
+  # can be extended with another `values:` entry.
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: node.cluster.x-k8s.io/pool
+                operator: NotIn
+                values:
+                  - runners-linux
   resources:
     requests:
       cpu: 25m


### PR DESCRIPTION
> Keeps the Hetzner Cloud CSI node DaemonSet off `runners-linux` bare-metal Robot hosts, where it was CrashLoopBackOff-ing because the driver can't talk to `api.hetzner.cloud` through a multi-NIC `resolv.conf` and has nothing useful to do there anyway.

### What was happening

`hcloud-csi-node-blm5x` on `bm-tuist-staging-runners-linux-v5bcr-qww4j-h5v7z` started crash-looping with two stacked failures:

1. `DNSConfigForming` warnings (285+) — kubelet truncates the bare-metal node's resolv.conf to the first three nameservers (Linux limit), the working upstream drops off, and the driver's startup call to `api.hetzner.cloud` fails name resolution.
2. Liveness probe `:9808` `connection refused` — the process exits `Error` before binding its healthz port.

Only this one pod was affected; the four CSI node pods on Hetzner Cloud nodes (`9x4kp`, `tgfbk`, `wmshg`, `4bhbd`) are fine.

### Why exclude the DaemonSet rather than fix DNS

Hetzner Cloud Volumes can't attach to Hetzner Robot bare-metal servers at all, so `hcloud-csi-node` running there is semantically wrong regardless of the DNS misconfig. Patching `/etc/resolv.conf` on the runner node would only mask that. The chart's default `node.tolerations: [{operator: Exists}]` is what defeats the existing `tuist.dev/runner-tier=bare-metal:NoSchedule` taint; an explicit `nodeAffinity` is the canonical Hetzner mixed-cluster pattern.

### Change

`infra/k8s/mgmt/bootstrap/hcloud-csi-values.yaml` — added `node.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution` excluding nodes labeled `node.cluster.x-k8s.io/pool=runners-linux`. Future bare-metal pools (e.g. a Kura bare-metal fleet) should carry the same label convention and extend the `values:` list.

### Branch note

The `runners-linux` MachineDeployment lives on `claude/priceless-wozniak-85daf8` and isn't in `main` yet, but the values file is byte-identical on both branches, so this commit is harmless on hcloud-only clusters today and takes effect the moment the bare-metal pool lands.

### How to test locally

```bash
# 1. Validate the YAML and the rendered chart.
yq '.node.affinity' infra/k8s/mgmt/bootstrap/hcloud-csi-values.yaml
helm template hcloud-csi hcloud/hcloud-csi \
  -n kube-system -f infra/k8s/mgmt/bootstrap/hcloud-csi-values.yaml \
  | yq 'select(.kind == "DaemonSet") | .spec.template.spec.affinity'

# 2. Apply against staging.
KUBECONFIG=<workload-staging> helm upgrade hcloud-csi hcloud/hcloud-csi \
  -n kube-system -f infra/k8s/mgmt/bootstrap/hcloud-csi-values.yaml

# 3. Confirm no CSI pods land on bare-metal runner nodes.
kubectl -n kube-system get pods -l app.kubernetes.io/name=hcloud-csi -o wide
# Expected: no pods scheduled on bm-tuist-staging-runners-linux-* nodes;
# the crash-looping pod is gone.
```