### PR TITLE
fix(server): align regional Kura TLS issuer with eu-central

### DIFF
--- a/infra/helm/tuist/values-managed-kura-region.yaml
+++ b/infra/helm/tuist/values-managed-kura-region.yaml
@@ -24,7 +24,7 @@ kuraController:
   # with Let's Encrypt certificates. Must already exist on the regional
   # cluster (cert-manager + the issuer are bootstrapped via the
   # mgmt-cluster pipeline).
-  tlsClusterIssuer: "letsencrypt-prod"
+  tlsClusterIssuer: "letsencrypt-cloudflare"
   sharedSecrets:
     # In managed regions, kura-shared-secrets is populated by CI from
     # the same secret store as the Tuist server release.


### PR DESCRIPTION
## Summary
- switch the regional Kura controller overlay from `letsencrypt-prod` to `letsencrypt-cloudflare`
- align the us-east and us-west regional Kura clusters with the issuer used by the platform bootstrap and the managed common chart values
- unblock regional Kura TLS certificate issuance in clusters where the controller was requesting a ClusterIssuer that does not exist

## Testing
- `rg -n 'letsencrypt-prod|letsencrypt-cloudflare' infra/helm/tuist infra/helm/platform`
- `helm template tuist infra/helm/tuist -f infra/helm/tuist/values.yaml -f infra/helm/tuist/values-managed-kura-region.yaml --set kuraController.image.tag=test | rg --context 2 'grpc-cluster-issuer|letsencrypt-cloudflare'`
