### PR TITLE
fix(cli): apply test quarantine to --without-building and shard runs

### DIFF
--- a/cli/Sources/TuistKit/Services/TestService.swift
+++ b/cli/Sources/TuistKit/Services/TestService.swift
@@ -270,6 +270,12 @@ public struct TestService { // swiftlint:disable:this type_body_length
 
         let mode = mode ?? TestProcessingMode.default(for: config.url)
 
+        let (mutedQuarantinedTests, skippedQuarantinedTests) = try await fetchQuarantinedTests(
+            skipQuarantine: skipQuarantine,
+            config: config
+        )
+        let skipTestTargets = skipTestTargets + skippedQuarantinedTests
+
         if let shardIndex, action == .testWithoutBuilding {
             try await runShard(
                 shardIndex: shardIndex,
@@ -290,6 +296,7 @@ public struct TestService { // swiftlint:disable:this type_body_length
                 runId: runId,
                 shardReference: shardReference,
                 shardArchivePath: shardArchivePath,
+                quarantinedTests: mutedQuarantinedTests,
                 mode: mode
             )
             return
@@ -314,6 +321,7 @@ public struct TestService { // swiftlint:disable:this type_body_length
                 testPlanConfiguration: testPlanConfiguration,
                 passthroughXcodeBuildArguments: passthroughXcodeBuildArguments,
                 runId: runId,
+                quarantinedTests: mutedQuarantinedTests,
                 mode: mode
             )
             return
@@ -351,35 +359,6 @@ public struct TestService { // swiftlint:disable:this type_body_length
         if generateOnly {
             return
         }
-
-        let (mutedQuarantinedTests, skippedQuarantinedTests): ([TestIdentifier], [TestIdentifier])
-        if !skipQuarantine, let fullHandle = config.fullHandle {
-            let serverURL = try serverEnvironmentService.url(configServerURL: config.url)
-            async let mutedTask = testCaseListService.listTestCases(
-                fullHandle: fullHandle, serverURL: serverURL, state: .muted
-            )
-            async let skippedTask = testCaseListService.listTestCases(
-                fullHandle: fullHandle, serverURL: serverURL, state: .skipped
-            )
-            do {
-                (mutedQuarantinedTests, skippedQuarantinedTests) = try await (mutedTask, skippedTask)
-            } catch {
-                AlertController.current.warning(
-                    .alert("Failed to fetch quarantined tests: \(error.localizedDescription). Running all tests.")
-                )
-                (mutedQuarantinedTests, skippedQuarantinedTests) = ([], [])
-            }
-            let totalQuarantined = mutedQuarantinedTests.count + skippedQuarantinedTests.count
-            if totalQuarantined > 0 {
-                Logger.current.notice(
-                    "Found \(totalQuarantined) quarantined test(s): \(mutedQuarantinedTests.count) muted, \(skippedQuarantinedTests.count) skipped",
-                    metadata: .subsection
-                )
-            }
-        } else {
-            (mutedQuarantinedTests, skippedQuarantinedTests) = ([], [])
-        }
-        let skipTestTargets = skipTestTargets + skippedQuarantinedTests
 
         let graphTraverser = GraphTraverser(graph: graph)
         let version = osVersion?.version()
@@ -611,6 +590,42 @@ public struct TestService { // swiftlint:disable:this type_body_length
         }
     }
 
+    // MARK: - Quarantine
+
+    private func fetchQuarantinedTests(
+        skipQuarantine: Bool,
+        config: Tuist
+    ) async throws -> (muted: [TestIdentifier], skipped: [TestIdentifier]) {
+        guard !skipQuarantine, let fullHandle = config.fullHandle else {
+            return ([], [])
+        }
+        let serverURL = try serverEnvironmentService.url(configServerURL: config.url)
+        async let mutedTask = testCaseListService.listTestCases(
+            fullHandle: fullHandle, serverURL: serverURL, state: .muted
+        )
+        async let skippedTask = testCaseListService.listTestCases(
+            fullHandle: fullHandle, serverURL: serverURL, state: .skipped
+        )
+        let muted: [TestIdentifier]
+        let skipped: [TestIdentifier]
+        do {
+            (muted, skipped) = try await (mutedTask, skippedTask)
+        } catch {
+            AlertController.current.warning(
+                .alert("Failed to fetch quarantined tests: \(error.localizedDescription). Running all tests.")
+            )
+            return ([], [])
+        }
+        let total = muted.count + skipped.count
+        if total > 0 {
+            Logger.current.notice(
+                "Found \(total) quarantined test(s): \(muted.count) muted, \(skipped.count) skipped",
+                metadata: .subsection
+            )
+        }
+        return (muted, skipped)
+    }
+
     // MARK: - Shard Execute
 
     // swiftlint:disable:next function_body_length function_parameter_count
@@ -633,6 +648,7 @@ public struct TestService { // swiftlint:disable:this type_body_length
         runId: String,
         shardReference: String?,
         shardArchivePath: AbsolutePath?,
+        quarantinedTests: [TestIdentifier],
         mode: TestProcessingMode
     ) async throws {
         guard let fullHandle = config.fullHandle else {
@@ -702,7 +718,7 @@ public struct TestService { // swiftlint:disable:this type_body_length
         }
 
         let summary = mode == .local
-            ? await testSummary(resultBundlePath: resultBundlePath, quarantinedTests: [])
+            ? await testSummary(resultBundlePath: resultBundlePath, quarantinedTests: quarantinedTests)
             : nil
         await uploadResultBundleIfNeeded(
             testSummary: summary,
@@ -758,6 +774,7 @@ public struct TestService { // swiftlint:disable:this type_body_length
         testPlanConfiguration: TestPlanConfiguration?,
         passthroughXcodeBuildArguments: [String],
         runId: String,
+        quarantinedTests: [TestIdentifier],
         mode: TestProcessingMode
     ) async throws {
         Logger.current.notice(
@@ -838,7 +855,7 @@ public struct TestService { // swiftlint:disable:this type_body_length
         }
 
         let summary = mode == .local
-            ? await testSummary(resultBundlePath: resultBundlePath, quarantinedTests: [])
+            ? await testSummary(resultBundlePath: resultBundlePath, quarantinedTests: quarantinedTests)
             : nil
         await uploadResultBundleIfNeeded(
             testSummary: summary,

--- a/cli/Tests/TuistKitTests/Services/TestServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/TestServiceTests.swift
@@ -4819,6 +4819,172 @@ final class TestServiceTests: TuistUnitTestCase {
             .called(1)
     }
 
+    func test_run_testWithoutBuilding_appliesQuarantinedSkipTestTargets_whenRunningFromBundle() async throws {
+        // Given — a CI runner picks up an already-built .xctestproducts bundle and runs
+        // `tuist test --without-building -testProductsPath ...`. The bundle bypass path used to
+        // skip the quarantine fetch entirely, so tests marked as skipped in the dashboard kept
+        // executing on the test VM. This test pins the fix: skipped quarantined tests must reach
+        // xcodebuild as `-skip-testing` entries.
+        let path = try temporaryPath()
+        let testProductsPath = path.appending(component: "MyApp.xctestproducts")
+        try await fileSystem.makeDirectory(at: testProductsPath)
+
+        let selectiveTestingGraph = SelectiveTestingGraph(testTargetHashes: ["MyTests": "abc123"])
+        let graphPath = testProductsPath.appending(component: SelectiveTestingGraph.fileName)
+        try JSONEncoder().encode(selectiveTestingGraph).write(to: graphPath.url)
+
+        configLoader.reset()
+        given(configLoader)
+            .loadConfig(path: .any)
+            .willReturn(.test(project: .testGeneratedProject(), fullHandle: "tuist/tuist"))
+
+        let skippedIdentifier = try TestIdentifier(
+            target: "AppTests", class: "BrokenSuite", method: "testBroken()"
+        )
+        testCaseListService.reset()
+        given(testCaseListService)
+            .listTestCases(fullHandle: .any, serverURL: .any, state: .value(.muted))
+            .willReturn([])
+        given(testCaseListService)
+            .listTestCases(fullHandle: .any, serverURL: .any, state: .value(.skipped))
+            .willReturn([skippedIdentifier])
+
+        let capture = ArgumentsCapture()
+        given(xcodebuildController)
+            .run(arguments: .any)
+            .willProduce { args in
+                capture.append(args)
+            }
+
+        // When
+        try await AlertController.$current.withValue(AlertController()) {
+            try await testRun(
+                path: path,
+                action: .testWithoutBuilding,
+                passthroughXcodeBuildArguments: ["-testProductsPath", testProductsPath.pathString]
+            )
+        }
+
+        // Then — quarantine list was fetched and the skipped test landed in xcodebuild's
+        // -skip-testing flags.
+        verify(testCaseListService)
+            .listTestCases(fullHandle: .any, serverURL: .any, state: .value(.skipped))
+            .called(1)
+        let arguments = try XCTUnwrap(capture.first())
+        XCTAssertTrue(
+            arguments.containsConsecutive(["-skip-testing", skippedIdentifier.description]),
+            "Expected xcodebuild args to contain -skip-testing for the quarantined test, got: \(arguments)"
+        )
+    }
+
+    func test_run_testWithoutBuilding_skipsQuarantineFetch_whenSkipQuarantineIsTrue_fromBundle() async throws {
+        // Given — same bundle bypass setup, but the caller opted out of quarantine via
+        // --skip-quarantine. The fetch must not happen and no -skip-testing entries should be
+        // synthesized.
+        let path = try temporaryPath()
+        let testProductsPath = path.appending(component: "MyApp.xctestproducts")
+        try await fileSystem.makeDirectory(at: testProductsPath)
+
+        let selectiveTestingGraph = SelectiveTestingGraph(testTargetHashes: ["MyTests": "abc123"])
+        let graphPath = testProductsPath.appending(component: SelectiveTestingGraph.fileName)
+        try JSONEncoder().encode(selectiveTestingGraph).write(to: graphPath.url)
+
+        configLoader.reset()
+        given(configLoader)
+            .loadConfig(path: .any)
+            .willReturn(.test(project: .testGeneratedProject(), fullHandle: "tuist/tuist"))
+
+        given(xcodebuildController)
+            .run(arguments: .any)
+            .willReturn()
+
+        // When
+        try await AlertController.$current.withValue(AlertController()) {
+            try await testRun(
+                path: path,
+                action: .testWithoutBuilding,
+                passthroughXcodeBuildArguments: ["-testProductsPath", testProductsPath.pathString],
+                skipQuarantine: true
+            )
+        }
+
+        // Then
+        verify(testCaseListService)
+            .listTestCases(fullHandle: .any, serverURL: .any, state: .any)
+            .called(0)
+    }
+
+    func test_run_shard_appliesQuarantinedSkipTestTargets() async throws {
+        // Given — sharded test-without-building runs went through `runShard`, which bypassed the
+        // quarantine fetch the same way the bundle path did. This test pins that quarantined
+        // skipped tests now reach xcodebuild on shard runs too.
+        let path = try temporaryPath()
+        let extractedTestProductsPath = path.appending(component: "Extracted.xctestproducts")
+        try await fileSystem.makeDirectory(at: extractedTestProductsPath)
+
+        configLoader.reset()
+        given(configLoader)
+            .loadConfig(path: .any)
+            .willReturn(.test(project: .testGeneratedProject(), fullHandle: "tuist/tuist"))
+
+        let skippedIdentifier = try TestIdentifier(
+            target: "AppTests", class: "BrokenSuite", method: "testBroken()"
+        )
+        testCaseListService.reset()
+        given(testCaseListService)
+            .listTestCases(fullHandle: .any, serverURL: .any, state: .value(.muted))
+            .willReturn([])
+        given(testCaseListService)
+            .listTestCases(fullHandle: .any, serverURL: .any, state: .value(.skipped))
+            .willReturn([skippedIdentifier])
+
+        given(shardService)
+            .shard(
+                shardIndex: .any,
+                fullHandle: .any,
+                serverURL: .any,
+                reference: .any,
+                testProductsPath: .any,
+                testProductsArchivePath: .any
+            )
+            .willReturn(
+                Shard(
+                    reference: "ref",
+                    shardPlanId: "plan-123",
+                    testProductsPath: extractedTestProductsPath,
+                    xcTestRunPath: nil,
+                    modules: ["AppTests"],
+                    selectiveTestingGraph: nil
+                )
+            )
+
+        let capture = ArgumentsCapture()
+        given(xcodebuildController)
+            .run(arguments: .any)
+            .willProduce { args in
+                capture.append(args)
+            }
+
+        // When
+        try await AlertController.$current.withValue(AlertController()) {
+            try await testRun(
+                path: path,
+                action: .testWithoutBuilding,
+                shardIndex: 0
+            )
+        }
+
+        // Then
+        verify(testCaseListService)
+            .listTestCases(fullHandle: .any, serverURL: .any, state: .value(.skipped))
+            .called(1)
+        let arguments = try XCTUnwrap(capture.first())
+        XCTAssertTrue(
+            arguments.containsConsecutive(["-skip-testing", skippedIdentifier.description]),
+            "Expected xcodebuild args to contain -skip-testing for the quarantined test, got: \(arguments)"
+        )
+    }
+
     func test_run_testWithoutBuilding_passesShardArchivePathToShardService() async throws {
         // Given
         let path = try temporaryPath()
@@ -5197,5 +5363,32 @@ final class TestServiceTests: TuistUnitTestCase {
     func test_inferPlatformDestination_returns_nil_for_empty_schemes() {
         let graphTraverser = MockGraphTraversing()
         XCTAssertNil(subject.inferPlatformDestination(schemes: [], graphTraverser: graphTraverser))
+    }
+}
+
+private final class ArgumentsCapture: @unchecked Sendable {
+    private let lock = NSLock()
+    private var calls: [[String]] = []
+
+    func append(_ arguments: [String]) {
+        lock.lock()
+        defer { lock.unlock() }
+        calls.append(arguments)
+    }
+
+    func first() -> [String]? {
+        lock.lock()
+        defer { lock.unlock() }
+        return calls.first
+    }
+}
+
+extension [String] {
+    fileprivate func containsConsecutive(_ pair: [String]) -> Bool {
+        guard pair.count == 2 else { return false }
+        for index in indices.dropLast() where self[index] == pair[0] && self[index + 1] == pair[1] {
+            return true
+        }
+        return false
     }
 }

--- a/cli/Tests/TuistKitTests/Services/TestServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/TestServiceTests.swift
@@ -4849,12 +4849,9 @@ final class TestServiceTests: TuistUnitTestCase {
             .listTestCases(fullHandle: .any, serverURL: .any, state: .value(.skipped))
             .willReturn([skippedIdentifier])
 
-        let capture = ArgumentsCapture()
         given(xcodebuildController)
             .run(arguments: .any)
-            .willProduce { args in
-                capture.append(args)
-            }
+            .willReturn()
 
         // When
         try await AlertController.$current.withValue(AlertController()) {
@@ -4870,11 +4867,11 @@ final class TestServiceTests: TuistUnitTestCase {
         verify(testCaseListService)
             .listTestCases(fullHandle: .any, serverURL: .any, state: .value(.skipped))
             .called(1)
-        let arguments = try XCTUnwrap(capture.first())
-        XCTAssertTrue(
-            arguments.containsConsecutive(["-skip-testing", skippedIdentifier.description]),
-            "Expected xcodebuild args to contain -skip-testing for the quarantined test, got: \(arguments)"
-        )
+        verify(xcodebuildController)
+            .run(arguments: .matching { args in
+                args.containsConsecutive("-skip-testing", skippedIdentifier.description)
+            })
+            .called(1)
     }
 
     func test_run_testWithoutBuilding_skipsQuarantineFetch_whenSkipQuarantineIsTrue_fromBundle() async throws {
@@ -4958,12 +4955,9 @@ final class TestServiceTests: TuistUnitTestCase {
                 )
             )
 
-        let capture = ArgumentsCapture()
         given(xcodebuildController)
             .run(arguments: .any)
-            .willProduce { args in
-                capture.append(args)
-            }
+            .willReturn()
 
         // When
         try await AlertController.$current.withValue(AlertController()) {
@@ -4978,11 +4972,11 @@ final class TestServiceTests: TuistUnitTestCase {
         verify(testCaseListService)
             .listTestCases(fullHandle: .any, serverURL: .any, state: .value(.skipped))
             .called(1)
-        let arguments = try XCTUnwrap(capture.first())
-        XCTAssertTrue(
-            arguments.containsConsecutive(["-skip-testing", skippedIdentifier.description]),
-            "Expected xcodebuild args to contain -skip-testing for the quarantined test, got: \(arguments)"
-        )
+        verify(xcodebuildController)
+            .run(arguments: .matching { args in
+                args.containsConsecutive("-skip-testing", skippedIdentifier.description)
+            })
+            .called(1)
     }
 
     func test_run_testWithoutBuilding_passesShardArchivePathToShardService() async throws {
@@ -5366,27 +5360,9 @@ final class TestServiceTests: TuistUnitTestCase {
     }
 }
 
-private final class ArgumentsCapture: @unchecked Sendable {
-    private let lock = NSLock()
-    private var calls: [[String]] = []
-
-    func append(_ arguments: [String]) {
-        lock.lock()
-        defer { lock.unlock() }
-        calls.append(arguments)
-    }
-
-    func first() -> [String]? {
-        lock.lock()
-        defer { lock.unlock() }
-        return calls.first
-    }
-}
-
 extension [String] {
-    fileprivate func containsConsecutive(_ pair: [String]) -> Bool {
-        guard pair.count == 2 else { return false }
-        for index in indices.dropLast() where self[index] == pair[0] && self[index + 1] == pair[1] {
+    fileprivate func containsConsecutive(_ first: String, _ second: String) -> Bool {
+        for index in indices.dropLast() where self[index] == first && self[index + 1] == second {
             return true
         }
         return false


### PR DESCRIPTION
> Describe here the purpose of your PR.

Quarantined tests marked as skipped in the dashboard were still running when CI used the bundle-bypass or shard code paths.

The fetch + skip-target merge in `TestService.run` lived **after** the early-returns into `runShard` and `runTestWithoutBuildingFromBundle`. Both helpers received the original `skipTestTargets`, never queried the server, and even passed `quarantinedTests: []` into the local summary. So:

- `tuist test --without-building -testProductsPath <bundle>` (typical Bitrise build-VM → test-VM split) skipped the quarantine fetch entirely.
- `tuist test --without-building --shard-index N` did the same.
- No `Found N quarantined test(s)` log fired on either path, so the regression was silent.

This PR:

- Extracts `fetchQuarantinedTests(skipQuarantine:config:)` and calls it once near the top of `run()`.
- Merges `skipTestTargets + skippedQuarantinedTests` before branching, so every code path sends the same `-skip-testing` set to xcodebuild.
- Threads the muted list through `runShard` and `runTestWithoutBuildingFromBundle` so their uploaded summaries mark quarantined results consistently with the main path.
- Adds regression tests for both bypass paths and for `--skip-quarantine` on the bundle path.

### How to test locally

1. On a project with `fullHandle` set, mark a failing test as **skipped** in the dashboard.
2. Build with `tuist test --without-building --build-only` (or your equivalent build-VM step) and ship the `.xctestproducts` to a separate runner.
3. On the runner: `tuist test --without-building -testProductsPath <bundle> …` — the quarantined test should now be passed to xcodebuild as `-skip-testing` and not executed. The CLI logs `Found 1 quarantined test(s): 0 muted, 1 skipped`.
4. Repeat with `--shard-index N` to confirm the shard path applies it too.