### PR TITLE
ci: stop Release runs from cancelling each other; add manual dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -13,7 +14,7 @@ permissions:
 
 concurrency:
   group: release-workflow-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 env:
   MISE_VERSION: "2026.4.18"


### PR DESCRIPTION
## Problem

The `Release` workflow uses:

\`\`\`yaml
concurrency:
  group: release-workflow-${{ github.ref }}
  cancel-in-progress: true
\`\`\`

`github.ref` is `refs/heads/main` for every push to main, so all Release runs share one concurrency group. With `cancel-in-progress: true`, each new merge to main cancels the still-running Release run. The workflow needs ~15-20 min to reach the publish jobs, but main is merged to far more frequently, so it never gets there.

Result: of the last ~20 Release runs, **18 cancelled, 1 failed, 0 succeeded**. Releases stopped going out entirely. `cache@0.32.5` (PRs #10855, #10861) and `server@1.197.x` were stuck even though the code was already deployed via the path-filtered deploy workflows.

## Change

- `cancel-in-progress: false` so Release runs queue serially instead of killing each other. This matches the `cache-deploy` / server deploy workflows, which already use `cancel-in-progress: false`. Cancelling a release run is never desirable: each run checks out its own SHA and the `check-releases` gate makes no-op runs cheap.
- Add `workflow_dispatch` so a release can be triggered manually if the pipeline ever needs a nudge.

## Backlog

A re-run of a cancelled Release run was triggered to publish the current backlog; once this lands, future releases will no longer cancel each other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)