### PR TITLE
feat(server): surface the global Kura endpoint as a clear banner

### DIFF
--- a/server/lib/tuist_web/live/account_settings_live.ex
+++ b/server/lib/tuist_web/live/account_settings_live.ex
@@ -555,11 +555,12 @@ defmodule TuistWeb.AccountSettingsLive do
           :if={@global_endpoint_url && Enum.any?(@kura_servers)}
           status="information"
           type="secondary"
-          size="small"
-          title={
+          size="large"
+          title={dgettext("dashboard_account", "Global Kura endpoint")}
+          description={
             dgettext(
               "dashboard_account",
-              "Use the global Kura endpoint %{url} to connect clients to the nearest healthy region.",
+              "Point clients at %{url}. It routes to the nearest healthy region automatically.",
               url: @global_endpoint_url
             )
           }

--- a/server/priv/gettext/dashboard_account.pot
+++ b/server/priv/gettext/dashboard_account.pot
@@ -72,13 +72,13 @@ msgstr ""
 msgid "All members"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:736
+#: lib/tuist_web/live/account_settings_live.ex:788
 #, elixir-autogen, elixir-format
 msgid "All regions"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.html.heex:112
-#: lib/tuist_web/live/account_settings_live.html.heex:268
+#: lib/tuist_web/live/account_settings_live.html.heex:113
+#: lib/tuist_web/live/account_settings_live.html.heex:269
 #, elixir-autogen, elixir-format
 msgid "Are you sure you want to delete this?"
 msgstr ""
@@ -99,20 +99,20 @@ msgstr ""
 msgid "Billing email"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:504
-#: lib/tuist_web/live/account_settings_live.ex:808
-#: lib/tuist_web/live/account_settings_live.ex:895
-#: lib/tuist_web/live/account_settings_live.html.heex:76
-#: lib/tuist_web/live/account_settings_live.html.heex:150
-#: lib/tuist_web/live/account_settings_live.html.heex:232
-#: lib/tuist_web/live/account_settings_live.html.heex:304
+#: lib/tuist_web/live/account_settings_live.ex:519
+#: lib/tuist_web/live/account_settings_live.ex:860
+#: lib/tuist_web/live/account_settings_live.ex:947
+#: lib/tuist_web/live/account_settings_live.html.heex:77
+#: lib/tuist_web/live/account_settings_live.html.heex:151
+#: lib/tuist_web/live/account_settings_live.html.heex:233
+#: lib/tuist_web/live/account_settings_live.html.heex:305
 #: lib/tuist_web/live/authentication_settings_live.html.heex:513
 #: lib/tuist_web/live/create_organization_live.ex:83
 #: lib/tuist_web/live/members_live.ex:157
 #: lib/tuist_web/live/members_live.ex:206
-#: lib/tuist_web/live/webhook_live.html.heex:117
-#: lib/tuist_web/live/webhook_live.html.heex:404
-#: lib/tuist_web/live/webhooks_live.html.heex:190
+#: lib/tuist_web/live/webhook_live.html.heex:116
+#: lib/tuist_web/live/webhook_live.html.heex:343
+#: lib/tuist_web/live/webhooks_live.html.heex:111
 #, elixir-autogen, elixir-format
 msgid "Cancel"
 msgstr ""
@@ -127,7 +127,7 @@ msgstr ""
 msgid "Change your subscription to fit your needs."
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:720
+#: lib/tuist_web/live/account_settings_live.ex:772
 #, elixir-autogen, elixir-format
 msgid "Choose where your artifacts, like module cache binaries, are stored for legal compliance."
 msgstr ""
@@ -194,7 +194,7 @@ msgstr ""
 #: lib/tuist/billing.ex:78
 #: lib/tuist_web/live/billing_live.ex:247
 #: lib/tuist_web/live/billing_live.html.heex:70
-#: lib/tuist_web/live/webhook_live.ex:251
+#: lib/tuist_web/live/webhook_live.ex:253
 #, elixir-autogen, elixir-format
 msgid "Custom"
 msgstr ""
@@ -215,17 +215,17 @@ msgstr ""
 msgid "Decline"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:869
-#: lib/tuist_web/live/account_settings_live.ex:903
-#: lib/tuist_web/live/account_settings_live.ex:915
-#: lib/tuist_web/live/account_settings_live.html.heex:158
-#: lib/tuist_web/live/account_settings_live.html.heex:312
+#: lib/tuist_web/live/account_settings_live.ex:921
+#: lib/tuist_web/live/account_settings_live.ex:955
+#: lib/tuist_web/live/account_settings_live.ex:967
+#: lib/tuist_web/live/account_settings_live.html.heex:159
+#: lib/tuist_web/live/account_settings_live.html.heex:313
 #, elixir-autogen, elixir-format
 msgid "Delete"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.html.heex:253
-#: lib/tuist_web/live/account_settings_live.html.heex:274
+#: lib/tuist_web/live/account_settings_live.html.heex:254
+#: lib/tuist_web/live/account_settings_live.html.heex:275
 #, elixir-autogen, elixir-format
 msgid "Delete account"
 msgstr ""
@@ -300,18 +300,18 @@ msgstr ""
 msgid "The client secret from your OAuth2 application."
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.html.heex:97
-#: lib/tuist_web/live/account_settings_live.html.heex:118
+#: lib/tuist_web/live/account_settings_live.html.heex:98
+#: lib/tuist_web/live/account_settings_live.html.heex:119
 #, elixir-autogen, elixir-format
 msgid "Delete organization"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.html.heex:131
+#: lib/tuist_web/live/account_settings_live.html.heex:132
 #, elixir-autogen, elixir-format
 msgid "Deleting the organization will delete all of its projects"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.html.heex:286
+#: lib/tuist_web/live/account_settings_live.html.heex:287
 #, elixir-autogen, elixir-format
 msgid "Deleting your account will also delete all the projects that belong to it"
 msgstr ""
@@ -342,12 +342,12 @@ msgstr ""
 msgid "Email address"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.html.heex:138
+#: lib/tuist_web/live/account_settings_live.html.heex:139
 #, elixir-autogen, elixir-format
 msgid "Enter this organization's name to confirm"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.html.heex:293
+#: lib/tuist_web/live/account_settings_live.html.heex:294
 #, elixir-autogen, elixir-format
 msgid "Enter your username to confirm"
 msgstr ""
@@ -359,7 +359,7 @@ msgstr ""
 msgid "Enterprise"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:737
+#: lib/tuist_web/live/account_settings_live.ex:789
 #, elixir-autogen, elixir-format
 msgid "Europe"
 msgstr ""
@@ -509,9 +509,8 @@ msgstr ""
 
 #: lib/tuist_web/live/authentication_settings_live.html.heex:533
 #: lib/tuist_web/live/create_organization_live.ex:65
-#: lib/tuist_web/live/webhook_live.html.heex:326
-#: lib/tuist_web/live/webhooks_live.html.heex:89
-#: lib/tuist_web/live/webhooks_live.html.heex:213
+#: lib/tuist_web/live/webhook_endpoint_form.ex:64
+#: lib/tuist_web/live/webhooks_live.html.heex:134
 #, elixir-autogen, elixir-format
 msgid "Name"
 msgstr ""
@@ -547,8 +546,8 @@ msgstr ""
 msgid "Open source"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.html.heex:67
-#: lib/tuist_web/live/account_settings_live.html.heex:141
+#: lib/tuist_web/live/account_settings_live.html.heex:68
+#: lib/tuist_web/live/account_settings_live.html.heex:142
 #, elixir-autogen, elixir-format
 msgid "Organization name"
 msgstr ""
@@ -580,10 +579,10 @@ msgstr ""
 msgid "Payments for your subscription are made using the default card."
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:622
-#: lib/tuist_web/live/account_settings_live.ex:625
-#: lib/tuist_web/live/account_settings_live.ex:628
-#: lib/tuist_web/live/account_settings_live.ex:631
+#: lib/tuist_web/live/account_settings_live.ex:669
+#: lib/tuist_web/live/account_settings_live.ex:672
+#: lib/tuist_web/live/account_settings_live.ex:680
+#: lib/tuist_web/live/account_settings_live.ex:683
 #: lib/tuist_web/live/members_live.ex:279
 #, elixir-autogen, elixir-format
 msgid "Pending"
@@ -621,10 +620,10 @@ msgstr ""
 msgid "Pro"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:459
-#: lib/tuist_web/live/account_settings_live.ex:472
-#: lib/tuist_web/live/account_settings_live.ex:544
-#: lib/tuist_web/live/account_settings_live.ex:733
+#: lib/tuist_web/live/account_settings_live.ex:474
+#: lib/tuist_web/live/account_settings_live.ex:487
+#: lib/tuist_web/live/account_settings_live.ex:573
+#: lib/tuist_web/live/account_settings_live.ex:785
 #, elixir-autogen, elixir-format
 msgid "Region"
 msgstr ""
@@ -650,30 +649,30 @@ msgstr ""
 msgid "Remove member"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.html.heex:84
-#: lib/tuist_web/live/account_settings_live.html.heex:240
+#: lib/tuist_web/live/account_settings_live.html.heex:85
+#: lib/tuist_web/live/account_settings_live.html.heex:241
 #, elixir-autogen, elixir-format
 msgid "Rename"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.html.heex:26
-#: lib/tuist_web/live/account_settings_live.html.heex:50
+#: lib/tuist_web/live/account_settings_live.html.heex:27
+#: lib/tuist_web/live/account_settings_live.html.heex:51
 #, elixir-autogen, elixir-format
 msgid "Rename organization"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.html.heex:44
+#: lib/tuist_web/live/account_settings_live.html.heex:45
 #, elixir-autogen, elixir-format
 msgid "Rename your organization?"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.html.heex:62
-#: lib/tuist_web/live/account_settings_live.html.heex:219
+#: lib/tuist_web/live/account_settings_live.html.heex:63
+#: lib/tuist_web/live/account_settings_live.html.heex:220
 #, elixir-autogen, elixir-format
 msgid "Renaming can have unexpected consequences"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.html.heex:29
+#: lib/tuist_web/live/account_settings_live.html.heex:30
 #, elixir-autogen, elixir-format
 msgid "Renaming your organization can have unintended side effects."
 msgstr ""
@@ -709,7 +708,7 @@ msgstr ""
 msgid "Search members..."
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:728
+#: lib/tuist_web/live/account_settings_live.ex:780
 #, elixir-autogen, elixir-format
 msgid "Select region"
 msgstr ""
@@ -740,16 +739,16 @@ msgstr ""
 msgid "Standard support: Via Slack and email"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:547
+#: lib/tuist_web/live/account_settings_live.ex:576
 #: lib/tuist_web/live/members_live.ex:277
 #: lib/tuist_web/live/webhook_event_live.html.heex:28
-#: lib/tuist_web/live/webhook_live.ex:263
-#: lib/tuist_web/live/webhook_live.html.heex:275
+#: lib/tuist_web/live/webhook_live.ex:265
+#: lib/tuist_web/live/webhook_live.html.heex:274
 #, elixir-autogen, elixir-format
 msgid "Status"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:717
+#: lib/tuist_web/live/account_settings_live.ex:769
 #, elixir-autogen, elixir-format
 msgid "Storage region"
 msgstr ""
@@ -764,8 +763,8 @@ msgstr ""
 msgid "Tailored agreements to meet your specific needs"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.html.heex:100
-#: lib/tuist_web/live/account_settings_live.html.heex:256
+#: lib/tuist_web/live/account_settings_live.html.heex:101
+#: lib/tuist_web/live/account_settings_live.html.heex:257
 #, elixir-autogen, elixir-format
 msgid "This action cannot be undone."
 msgstr ""
@@ -776,8 +775,8 @@ msgid "To start using Tuist, verify your email and you are good to go:"
 msgstr ""
 
 #: lib/tuist_web/live/billing_live.html.heex:234
-#: lib/tuist_web/live/webhook_live.html.heex:139
-#: lib/tuist_web/live/webhook_live.html.heex:207
+#: lib/tuist_web/live/webhook_live.html.heex:138
+#: lib/tuist_web/live/webhook_live.html.heex:206
 #, elixir-autogen, elixir-format
 msgid "Total"
 msgstr ""
@@ -793,7 +792,7 @@ msgstr ""
 msgid "Tuist Logo"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:738
+#: lib/tuist_web/live/account_settings_live.ex:790
 #, elixir-autogen, elixir-format
 msgid "United States"
 msgstr ""
@@ -818,18 +817,18 @@ msgstr ""
 msgid "Update payment method"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.html.heex:184
-#: lib/tuist_web/live/account_settings_live.html.heex:208
+#: lib/tuist_web/live/account_settings_live.html.heex:185
+#: lib/tuist_web/live/account_settings_live.html.heex:209
 #, elixir-autogen, elixir-format
 msgid "Update username"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.html.heex:202
+#: lib/tuist_web/live/account_settings_live.html.heex:203
 #, elixir-autogen, elixir-format
 msgid "Update your username?"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.html.heex:187
+#: lib/tuist_web/live/account_settings_live.html.heex:188
 #, elixir-autogen, elixir-format
 msgid "Updating your username can have unintended consequences."
 msgstr ""
@@ -896,8 +895,8 @@ msgstr ""
 msgid "User"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.html.heex:224
-#: lib/tuist_web/live/account_settings_live.html.heex:296
+#: lib/tuist_web/live/account_settings_live.html.heex:225
+#: lib/tuist_web/live/account_settings_live.html.heex:297
 #, elixir-autogen, elixir-format
 msgid "Username"
 msgstr ""
@@ -983,62 +982,61 @@ msgstr ""
 msgid "xxxx xxxx xxxx %{card_number}"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:816
+#: lib/tuist_web/live/account_settings_live.ex:868
 #, elixir-autogen, elixir-format
 msgid "Add"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:778
+#: lib/tuist_web/live/account_settings_live.ex:830
 #, elixir-autogen, elixir-format
 msgid "Add cache endpoint"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:785
+#: lib/tuist_web/live/account_settings_live.ex:837
 #: lib/tuist_web/live/webhooks_live.html.heex:35
 #, elixir-autogen, elixir-format
 msgid "Add endpoint"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:798
+#: lib/tuist_web/live/account_settings_live.ex:850
+#: lib/tuist_web/live/webhook_endpoint_form.ex:75
 #: lib/tuist_web/live/webhook_live.html.heex:71
-#: lib/tuist_web/live/webhook_live.html.heex:339
-#: lib/tuist_web/live/webhooks_live.html.heex:105
 #, elixir-autogen, elixir-format
 msgid "Endpoint URL"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:855
-#: lib/tuist_web/live/webhooks_live.html.heex:216
+#: lib/tuist_web/live/account_settings_live.ex:907
+#: lib/tuist_web/live/webhooks_live.html.heex:137
 #, elixir-autogen, elixir-format
 msgid "URL"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:862
+#: lib/tuist_web/live/account_settings_live.ex:914
 #, elixir-autogen, elixir-format
 msgid "Delete last cache endpoint?"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:882
+#: lib/tuist_web/live/account_settings_live.ex:934
 #, elixir-autogen, elixir-format
 msgid "Removing the last custom cache endpoint will switch your organization back to Tuist-hosted caching. This affects all builds across your organization."
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:760
+#: lib/tuist_web/live/account_settings_live.ex:812
 #, elixir-autogen, elixir-format
 msgid "Cache endpoints"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:764
+#: lib/tuist_web/live/account_settings_live.ex:816
 #, elixir-autogen, elixir-format
 msgid "Configure custom cache endpoints for self-hosted cache setups. When enabled, Tuist will read from and write to these endpoints instead of the default Tuist-hosted cache."
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:832
+#: lib/tuist_web/live/account_settings_live.ex:884
 #, elixir-autogen, elixir-format
 msgid "Custom cache endpoints are disabled. Tuist will use the default Tuist-hosted cache."
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:844
+#: lib/tuist_web/live/account_settings_live.ex:896
 #, elixir-autogen, elixir-format
 msgid "No custom cache endpoints configured. Tuist will use the default Tuist-hosted cache until endpoints are added."
 msgstr ""
@@ -1104,7 +1102,7 @@ msgid "SSO provider"
 msgstr ""
 
 #: lib/tuist_web/live/authentication_settings_live.html.heex:377
-#: lib/tuist_web/live/webhook_live.html.heex:411
+#: lib/tuist_web/live/webhook_live.html.heex:350
 #, elixir-autogen, elixir-format
 msgid "Save changes"
 msgstr ""
@@ -1182,23 +1180,23 @@ msgstr ""
 msgid "What's the name of your company or team? You can change this later in the settings"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:672
+#: lib/tuist_web/live/account_settings_live.ex:724
 #, elixir-autogen, elixir-format
 msgid "Browser default"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:682
+#: lib/tuist_web/live/account_settings_live.ex:734
 #, elixir-autogen, elixir-format
 msgid "Choose your preferred dashboard language."
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:679
+#: lib/tuist_web/live/account_settings_live.ex:731
 #, elixir-autogen, elixir-format
 msgid "Dashboard language"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:687
-#: lib/tuist_web/live/account_settings_live.ex:692
+#: lib/tuist_web/live/account_settings_live.ex:739
+#: lib/tuist_web/live/account_settings_live.ex:744
 #, elixir-autogen, elixir-format
 msgid "Language"
 msgstr ""
@@ -1245,7 +1243,7 @@ msgid "SCIM endpoint URL"
 msgstr ""
 
 #: lib/tuist_web/live/authentication_settings_live.html.heex:453
-#: lib/tuist_web/live/webhook_live.html.heex:436
+#: lib/tuist_web/live/webhook_live.html.heex:375
 #, elixir-autogen, elixir-format
 msgid "Copy it now — it will not be shown again after you close this dialog."
 msgstr ""
@@ -1256,8 +1254,7 @@ msgid "Copy token"
 msgstr ""
 
 #: lib/tuist_web/live/authentication_settings_live.html.heex:536
-#: lib/tuist_web/live/webhook_live.html.heex:87
-#: lib/tuist_web/live/webhooks_live.html.heex:237
+#: lib/tuist_web/live/webhook_live.html.heex:89
 #, elixir-autogen, elixir-format
 msgid "Created"
 msgstr ""
@@ -1268,8 +1265,8 @@ msgid "Dashboard"
 msgstr ""
 
 #: lib/tuist_web/live/authentication_settings_live.html.heex:507
-#: lib/tuist_web/live/webhook_live.html.heex:465
-#: lib/tuist_web/live/webhooks_live.html.heex:183
+#: lib/tuist_web/live/webhook_live.html.heex:404
+#: lib/tuist_web/live/webhooks_live.html.heex:104
 #, elixir-autogen, elixir-format
 msgid "Done"
 msgstr ""
@@ -1404,56 +1401,56 @@ msgstr ""
 msgid "Revoke token"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:646
+#: lib/tuist_web/live/account_settings_live.ex:698
 #, elixir-autogen, elixir-format
 msgid "Active"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:522
-#: lib/tuist_web/live/account_settings_live.ex:528
-#: lib/tuist_web/live/account_settings_live.ex:580
+#: lib/tuist_web/live/account_settings_live.ex:537
+#: lib/tuist_web/live/account_settings_live.ex:543
+#: lib/tuist_web/live/account_settings_live.ex:619
 #, elixir-autogen, elixir-format
 msgid "Deploy"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:436
-#: lib/tuist_web/live/account_settings_live.ex:443
+#: lib/tuist_web/live/account_settings_live.ex:451
+#: lib/tuist_web/live/account_settings_live.ex:458
 #, elixir-autogen, elixir-format
 msgid "Deploy Kura server"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:427
+#: lib/tuist_web/live/account_settings_live.ex:442
 #, elixir-autogen, elixir-format
 msgid "Deploy regional Kura cache servers for this account. Each region can have at most one server."
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:635
-#: lib/tuist_web/live/account_settings_live.ex:645
+#: lib/tuist_web/live/account_settings_live.ex:687
+#: lib/tuist_web/live/account_settings_live.ex:697
 #, elixir-autogen, elixir-format
 msgid "Deploying"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:374
+#: lib/tuist_web/live/account_settings_live.ex:388
 #, elixir-autogen, elixir-format
 msgid "Deploying Kura in %{region}..."
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:564
+#: lib/tuist_web/live/account_settings_live.ex:603
 #, elixir-autogen, elixir-format
 msgid "Destroy"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:570
+#: lib/tuist_web/live/account_settings_live.ex:609
 #, elixir-autogen, elixir-format
 msgid "Destroy the Kura server in %{region}? This removes the account's Kura cache endpoint for that region."
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:649
+#: lib/tuist_web/live/account_settings_live.ex:701
 #, elixir-autogen, elixir-format
 msgid "Destroyed"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:648
+#: lib/tuist_web/live/account_settings_live.ex:700
 #, elixir-autogen, elixir-format
 msgid "Destroying"
 msgstr ""
@@ -1463,27 +1460,27 @@ msgstr ""
 msgid "Destroying Kura server..."
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:554
+#: lib/tuist_web/live/account_settings_live.ex:583
 #, elixir-autogen, elixir-format
 msgid "Domain"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:647
-#: lib/tuist_web/live/webhook_live.ex:231
-#: lib/tuist_web/live/webhook_live.ex:268
-#: lib/tuist_web/live/webhook_live.html.heex:144
-#: lib/tuist_web/live/webhook_live.html.heex:217
+#: lib/tuist_web/live/account_settings_live.ex:699
+#: lib/tuist_web/live/webhook_live.ex:233
+#: lib/tuist_web/live/webhook_live.ex:270
+#: lib/tuist_web/live/webhook_live.html.heex:143
+#: lib/tuist_web/live/webhook_live.html.heex:216
 #, elixir-autogen, elixir-format
 msgid "Failed"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:384
-#: lib/tuist_web/live/account_settings_live.ex:393
+#: lib/tuist_web/live/account_settings_live.ex:398
+#: lib/tuist_web/live/account_settings_live.ex:407
 #, elixir-autogen, elixir-format
 msgid "Failed to deploy Kura: %{reason}"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:424
+#: lib/tuist_web/live/account_settings_live.ex:439
 #, elixir-autogen, elixir-format
 msgid "Kura cache servers"
 msgstr ""
@@ -1493,23 +1490,23 @@ msgstr ""
 msgid "Kura server not found."
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:491
+#: lib/tuist_web/live/account_settings_live.ex:506
 #, elixir-autogen, elixir-format
 msgid "New servers start on Kura"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:557
+#: lib/tuist_web/live/account_settings_live.ex:586
 #, elixir-autogen, elixir-format
 msgid "Version"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:493
+#: lib/tuist_web/live/account_settings_live.ex:508
 #, elixir-autogen, elixir-format
 msgid "(current deploy)."
 msgstr ""
 
 #: lib/tuist_web/live/account_settings_live.ex:252
-#: lib/tuist_web/live/account_settings_live.ex:486
+#: lib/tuist_web/live/account_settings_live.ex:501
 #, elixir-autogen, elixir-format
 msgid "No Kura runtime image is configured right now. Try again after the next server deploy."
 msgstr ""
@@ -1519,41 +1516,36 @@ msgstr ""
 msgid "Select a Kura region before deploying."
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:550
-#, elixir-autogen, elixir-format
-msgid "Use the global Kura endpoint %{url} to connect clients to the nearest healthy region."
-msgstr ""
-
-#: lib/tuist_web/live/account_settings_live.ex:632
+#: lib/tuist_web/live/account_settings_live.ex:663
 #, elixir-autogen, elixir-format
 msgid "Not deployed"
 msgstr ""
 
-#: lib/tuist_web/live/webhooks_live.html.heex:229
+#: lib/tuist_web/live/webhooks_live.html.heex:150
 #, elixir-autogen, elixir-format
 msgid "%{count} event"
 msgid_plural "%{count} events"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/tuist_web/live/webhooks_live.html.heex:292
+#: lib/tuist_web/live/webhooks_live.html.heex:209
 #, elixir-autogen, elixir-format
 msgid "Add one to start receiving events."
 msgstr ""
 
-#: lib/tuist_web/live/webhook_live.html.heex:126
+#: lib/tuist_web/live/webhook_live.html.heex:125
 #, elixir-autogen, elixir-format
 msgid "Apply"
 msgstr ""
 
-#: lib/tuist_web/live/webhook_event_live.html.heex:45
-#: lib/tuist_web/live/webhook_live.html.heex:281
+#: lib/tuist_web/live/webhook_event_live.html.heex:49
+#: lib/tuist_web/live/webhook_live.html.heex:280
 #, elixir-autogen, elixir-format
 msgid "Attempt"
 msgstr ""
 
-#: lib/tuist_web/live/webhook_event_live.html.heex:91
-#: lib/tuist_web/live/webhook_event_live.html.heex:114
+#: lib/tuist_web/live/webhook_event_live.html.heex:108
+#: lib/tuist_web/live/webhook_event_live.html.heex:144
 #, elixir-autogen, elixir-format
 msgid "Body"
 msgstr ""
@@ -1568,47 +1560,47 @@ msgstr ""
 msgid "Copy it now — it will not be shown again after you close this dialog. Use it to verify the Tuist-Signature header on incoming webhooks."
 msgstr ""
 
-#: lib/tuist_web/live/webhook_live.html.heex:452
+#: lib/tuist_web/live/webhook_live.html.heex:391
 #: lib/tuist_web/live/webhooks_live.html.heex:70
 #, elixir-autogen, elixir-format
 msgid "Copy signing secret"
 msgstr ""
 
-#: lib/tuist_web/live/webhooks_live.html.heex:197
+#: lib/tuist_web/live/webhooks_live.html.heex:118
 #, elixir-autogen, elixir-format
 msgid "Create endpoint"
 msgstr ""
 
 #: lib/tuist_web/live/webhook_live.html.heex:42
-#: lib/tuist_web/live/webhooks_live.html.heex:270
+#: lib/tuist_web/live/webhooks_live.html.heex:188
 #, elixir-autogen, elixir-format
 msgid "Delete endpoint"
 msgstr ""
 
 #: lib/tuist_web/live/webhook_live.html.heex:46
-#: lib/tuist_web/live/webhooks_live.html.heex:275
+#: lib/tuist_web/live/webhooks_live.html.heex:193
 #, elixir-autogen, elixir-format
 msgid "Delete this endpoint? It will stop receiving events."
 msgstr ""
 
-#: lib/tuist_web/live/webhook_live.ex:230
-#: lib/tuist_web/live/webhook_live.ex:267
+#: lib/tuist_web/live/webhook_live.ex:232
+#: lib/tuist_web/live/webhook_live.ex:269
 #, elixir-autogen, elixir-format
 msgid "Delivered"
 msgstr ""
 
-#: lib/tuist_web/live/webhook_event_live.html.heex:67
+#: lib/tuist_web/live/webhook_event_live.html.heex:71
 #, elixir-autogen, elixir-format
 msgid "Destination"
 msgstr ""
 
-#: lib/tuist_web/live/webhook_event_live.html.heex:49
+#: lib/tuist_web/live/webhook_event_live.html.heex:53
 #, elixir-autogen, elixir-format
 msgid "Duration"
 msgstr ""
 
 #: lib/tuist_web/live/webhook_live.html.heex:18
-#: lib/tuist_web/live/webhook_live.html.heex:304
+#: lib/tuist_web/live/webhook_live.html.heex:311
 #, elixir-autogen, elixir-format
 msgid "Edit endpoint"
 msgstr ""
@@ -1618,102 +1610,99 @@ msgstr ""
 msgid "Endpoints"
 msgstr ""
 
-#: lib/tuist_web/live/webhook_live.ex:276
-#: lib/tuist_web/live/webhook_live.html.heex:272
+#: lib/tuist_web/live/webhook_live.ex:278
+#: lib/tuist_web/live/webhook_live.html.heex:271
 #, elixir-autogen, elixir-format
 msgid "Event"
 msgstr ""
 
-#: lib/tuist_web/live/webhook_live.html.heex:269
+#: lib/tuist_web/live/webhook_live.html.heex:268
 #, elixir-autogen, elixir-format
 msgid "Event ID"
 msgstr ""
 
-#: lib/tuist_web/live/webhook_live.html.heex:103
+#: lib/tuist_web/live/webhook_live.html.heex:102
 #, elixir-autogen, elixir-format
 msgid "Event deliveries"
 msgstr ""
 
-#: lib/tuist_web/live/webhook_live.html.heex:235
+#: lib/tuist_web/live/webhook_live.html.heex:234
 #, elixir-autogen, elixir-format
 msgid "Events"
 msgstr ""
 
-#: lib/tuist_web/live/webhooks_live.html.heex:119
+#: lib/tuist_web/live/webhooks_live.html.heex:85
 #, elixir-autogen, elixir-format
 msgid "Events to listen for"
 msgstr ""
 
-#: lib/tuist_web/live/webhook_live.html.heex:252
+#: lib/tuist_web/live/webhook_live.html.heex:251
 #, elixir-autogen, elixir-format
 msgid "Filter"
 msgstr ""
 
-#: lib/tuist_web/live/webhook_live.html.heex:341
-#: lib/tuist_web/live/webhooks_live.html.heex:107
+#: lib/tuist_web/live/webhook_endpoint_form.ex:77
 #, elixir-autogen, elixir-format
 msgid "HTTPS only. Tuist will POST signed JSON envelopes here."
 msgstr ""
 
-#: lib/tuist_web/live/webhook_event_live.html.heex:82
-#: lib/tuist_web/live/webhook_event_live.html.heex:105
+#: lib/tuist_web/live/webhook_event_live.html.heex:99
+#: lib/tuist_web/live/webhook_event_live.html.heex:135
 #, elixir-autogen, elixir-format
 msgid "Headers"
 msgstr ""
 
-#: lib/tuist_web/live/webhook_live.html.heex:328
-#: lib/tuist_web/live/webhooks_live.html.heex:91
+#: lib/tuist_web/live/webhook_endpoint_form.ex:65
 #, elixir-autogen, elixir-format
 msgid "How this endpoint will be listed in the table."
 msgstr ""
 
-#: lib/tuist_web/live/webhook_live.ex:248
+#: lib/tuist_web/live/webhook_live.ex:250
 #, elixir-autogen, elixir-format
 msgid "Last 24 hours"
 msgstr ""
 
-#: lib/tuist_web/live/webhook_live.ex:250
+#: lib/tuist_web/live/webhook_live.ex:252
 #, elixir-autogen, elixir-format
 msgid "Last 30 days"
 msgstr ""
 
-#: lib/tuist_web/live/webhook_live.ex:249
+#: lib/tuist_web/live/webhook_live.ex:251
 #, elixir-autogen, elixir-format
 msgid "Last 7 days"
 msgstr ""
 
-#: lib/tuist_web/live/webhooks_live.html.heex:227
+#: lib/tuist_web/live/webhooks_live.html.heex:148
 #, elixir-autogen, elixir-format
 msgid "Listening to"
 msgstr ""
 
-#: lib/tuist_web/live/webhook_live.html.heex:289
+#: lib/tuist_web/live/webhook_live.html.heex:288
 #, elixir-autogen, elixir-format
 msgid "No deliveries yet"
 msgstr ""
 
-#: lib/tuist_web/live/webhooks_live.html.heex:290
+#: lib/tuist_web/live/webhooks_live.html.heex:208
 #, elixir-autogen, elixir-format
 msgid "No webhook endpoints yet"
 msgstr ""
 
-#: lib/tuist_web/live/webhook_live.html.heex:291
+#: lib/tuist_web/live/webhook_live.html.heex:290
 #, elixir-autogen, elixir-format
 msgid "Once a matching event fires, attempts will show up here."
 msgstr ""
 
-#: lib/tuist_web/live/webhook_live.html.heex:353
-#: lib/tuist_web/live/webhooks_live.html.heex:122
+#: lib/tuist_web/live/webhook_endpoint_form.ex:87
 #, elixir-autogen, elixir-format
 msgid "Only the selected events trigger a delivery to this endpoint."
 msgstr ""
 
-#: lib/tuist_web/live/webhook_event_live.html.heex:78
+#: lib/tuist_web/live/webhook_event_live.html.heex:82
 #, elixir-autogen, elixir-format
 msgid "Request"
 msgstr ""
 
-#: lib/tuist_web/live/webhook_event_live.html.heex:100
+#: lib/tuist_web/live/webhook_event_live.html.heex:117
 #, elixir-autogen, elixir-format
 msgid "Response"
 msgstr ""
@@ -1724,53 +1713,52 @@ msgid "Response code"
 msgstr ""
 
 #: lib/tuist_web/live/webhook_live.html.heex:29
-#: lib/tuist_web/live/webhooks_live.html.heex:256
+#: lib/tuist_web/live/webhooks_live.html.heex:174
 #, elixir-autogen, elixir-format
 msgid "Rotate secret"
 msgstr ""
 
 #: lib/tuist_web/live/webhook_live.html.heex:33
-#: lib/tuist_web/live/webhooks_live.html.heex:261
+#: lib/tuist_web/live/webhooks_live.html.heex:179
 #, elixir-autogen, elixir-format
 msgid "Rotating replaces the signing secret. Existing consumers will fail verification until updated."
 msgstr ""
 
-#: lib/tuist_web/live/webhook_live.html.heex:244
+#: lib/tuist_web/live/webhook_live.html.heex:243
 #, elixir-autogen, elixir-format
 msgid "Search by event ID..."
 msgstr ""
 
-#: lib/tuist_web/live/webhook_live.html.heex:374
-#: lib/tuist_web/live/webhooks_live.html.heex:145
+#: lib/tuist_web/live/webhook_endpoint_form.ex:108
 #, elixir-autogen, elixir-format
 msgid "Select all %{group} events"
 msgstr ""
 
-#: lib/tuist_web/live/webhook_live.html.heex:81
-#: lib/tuist_web/live/webhook_live.html.heex:350
+#: lib/tuist_web/live/webhook_live.html.heex:83
+#: lib/tuist_web/live/webhook_live.html.heex:329
 #, elixir-autogen, elixir-format
 msgid "Selected events"
 msgstr ""
 
-#: lib/tuist_web/live/webhook_live.html.heex:284
+#: lib/tuist_web/live/webhook_live.html.heex:283
 #, elixir-autogen, elixir-format
 msgid "Sent"
 msgstr ""
 
-#: lib/tuist_web/live/webhook_event_live.html.heex:61
+#: lib/tuist_web/live/webhook_event_live.html.heex:65
 #, elixir-autogen, elixir-format
 msgid "Sent at"
 msgstr ""
 
 #: lib/tuist_web/live/webhook_live.html.heex:75
-#: lib/tuist_web/live/webhook_live.html.heex:422
+#: lib/tuist_web/live/webhook_live.html.heex:361
 #: lib/tuist_web/live/webhooks_live.html.heex:49
-#: lib/tuist_web/live/webhooks_live.html.heex:219
+#: lib/tuist_web/live/webhooks_live.html.heex:140
 #, elixir-autogen, elixir-format
 msgid "Signing secret"
 msgstr ""
 
-#: lib/tuist_web/live/webhook_live.html.heex:434
+#: lib/tuist_web/live/webhook_live.html.heex:373
 #, elixir-autogen, elixir-format
 msgid "Signing secret rotated"
 msgstr ""
@@ -1781,7 +1769,7 @@ msgstr ""
 msgid "Summary"
 msgstr ""
 
-#: lib/tuist_web/live/webhook_event_live.html.heex:119
+#: lib/tuist_web/live/webhook_event_live.html.heex:149
 #, elixir-autogen, elixir-format
 msgid "The request didn't reach the destination."
 msgstr ""
@@ -1806,8 +1794,7 @@ msgstr ""
 msgid "Webhook endpoint not found."
 msgstr ""
 
-#: lib/tuist_web/live/webhook_live.html.heex:331
-#: lib/tuist_web/live/webhooks_live.html.heex:97
+#: lib/tuist_web/live/webhook_endpoint_form.ex:67
 #, elixir-autogen, elixir-format
 msgid "Webhook name"
 msgstr ""
@@ -1821,8 +1808,33 @@ msgstr ""
 msgid "Webhooks"
 msgstr ""
 
-#: lib/tuist_web/live/webhook_event_live.html.heex:39
-#: lib/tuist_web/live/webhook_event_live.html.heex:54
+#: lib/tuist_web/live/webhook_event_live.html.heex:42
+#: lib/tuist_web/live/webhook_event_live.html.heex:58
 #, elixir-autogen, elixir-format
 msgid "—"
+msgstr ""
+
+#: lib/tuist_web/live/webhook_event_live.html.heex:123
+#, elixir-autogen, elixir-format
+msgid "Copy body"
+msgstr ""
+
+#: lib/tuist_web/live/webhook_event_live.html.heex:88
+#, elixir-autogen, elixir-format
+msgid "Copy payload"
+msgstr ""
+
+#: lib/tuist_web/live/account_settings_live.ex:559
+#, elixir-autogen, elixir-format
+msgid "Global Kura endpoint"
+msgstr ""
+
+#: lib/tuist_web/live/account_settings_live.ex:593
+#, elixir-autogen, elixir-format
+msgid "Retry"
+msgstr ""
+
+#: lib/tuist_web/live/account_settings_live.ex:561
+#, elixir-autogen, elixir-format
+msgid "Point clients at %{url}. It routes to the nearest healthy region automatically."
 msgstr ""

--- a/server/test/tuist_web/live/account_settings_live_test.exs
+++ b/server/test/tuist_web/live/account_settings_live_test.exs
@@ -8,6 +8,7 @@ defmodule TuistWeb.AccountSettingsLiveTest do
   alias Tuist.Accounts
   alias Tuist.Environment
   alias Tuist.Kura
+  alias Tuist.Kura.Server
   alias TuistTestSupport.Fixtures.AccountsFixtures
 
   setup %{conn: conn} do
@@ -144,6 +145,43 @@ defmodule TuistWeb.AccountSettingsLiveTest do
     assert html =~ server.url
     assert html =~ "0.5.2"
     refute html =~ "kura@0.5.2"
+  end
+
+  test "renders the global Cloudflare endpoint banner when an endpoint is active" do
+    assigns = kura_section_assigns(global_endpoint_url: "https://test-org.kura.tuist.dev")
+
+    html = render_component(&TuistWeb.AccountSettingsLive.kura_servers_section/1, assigns)
+
+    assert html =~ "Global Kura endpoint"
+    assert html =~ "https://test-org.kura.tuist.dev"
+    assert html =~ "It routes to the nearest healthy region automatically"
+  end
+
+  test "hides the global Cloudflare endpoint banner when there is no active endpoint" do
+    assigns = kura_section_assigns(global_endpoint_url: nil)
+
+    html = render_component(&TuistWeb.AccountSettingsLive.kura_servers_section/1, assigns)
+
+    refute html =~ "Global Kura endpoint"
+  end
+
+  defp kura_section_assigns(overrides) do
+    server = %Server{
+      id: 1,
+      region: "us-east",
+      status: :active,
+      url: "https://test-org-us-east-1.kura.tuist.dev",
+      current_image_tag: "0.5.2",
+      observed_image_tag: "0.5.2"
+    }
+
+    Enum.into(overrides, %{
+      kura_servers: [server],
+      available_kura_regions: [],
+      add_kura_server_form: Phoenix.Component.to_form(%{}, as: :server),
+      latest_kura_version: nil,
+      global_endpoint_url: nil
+    })
   end
 
   test "allows adding another managed Kura region when one is already deployed", %{


### PR DESCRIPTION
> Improve how the global Kura cache endpoint is surfaced in account settings.

The account-settings "Kura cache servers" section already exposes a global endpoint that fans clients out to the nearest healthy region, but it was rendered as a cramped single-line `size="small"` alert that was easy to miss and didn't read as a distinct, actionable piece of information.

This restructures it into a titled `size="large"` alert (Noora only renders an alert `description` at `size="large"`), with:

- A clear title (**Global Kura endpoint**) and the endpoint URL.
- Customer-facing copy ("It routes to the nearest healthy region automatically.") with no infrastructure/vendor naming.

The visibility gating is unchanged: the banner still only appears once the global endpoint is active (probed healthy and mirrored into `account_cache_endpoints`). Also adds component-level tests for the banner and re-extracts the `dashboard_account` gettext template.

<img width="2303" height="481" alt="image" src="https://github.com/user-attachments/assets/611f96e7-7368-4410-bb47-c7a7b4837853" />

> [!NOTE]
> Once we make this user-facing, I'll iterate with Asmit on the design of this one.