### PR TITLE
fix(server): move Kura Cloudflare wiring into the controller chart

### DIFF
--- a/.github/workflows/server-kura-regional-deployment.yml
+++ b/.github/workflows/server-kura-regional-deployment.yml
@@ -68,6 +68,7 @@ jobs:
       - name: Deploy Kura regional controllers
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          KURA_CLOUDFLARE_API_TOKEN: ${{ secrets.KURA_CLOUDFLARE_API_TOKEN }}
         run: |
           # k8s:deploy-kura-regionals is a file task under
           # infra/mise/tasks, discovered only when infra/mise.toml is

--- a/.github/workflows/server-kura-regional-deployment.yml
+++ b/.github/workflows/server-kura-regional-deployment.yml
@@ -68,7 +68,6 @@ jobs:
       - name: Deploy Kura regional controllers
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-          KURA_CLOUDFLARE_API_TOKEN: ${{ secrets.KURA_CLOUDFLARE_API_TOKEN }}
         run: |
           # k8s:deploy-kura-regionals is a file task under
           # infra/mise/tasks, discovered only when infra/mise.toml is

--- a/infra/helm/tuist/templates/kura-controller-external-secrets.yaml
+++ b/infra/helm/tuist/templates/kura-controller-external-secrets.yaml
@@ -1,0 +1,27 @@
+{{- if and .Values.kuraController.enabled .Values.kuraController.cloudflareLoadBalancing.enabled .Values.kuraController.cloudflareLoadBalancing.apiTokenSecret.managed }}
+{{- $namespace := .Values.kuraController.namespace }}
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ .Values.kuraController.cloudflareLoadBalancing.apiTokenSecret.name }}
+  namespace: {{ $namespace }}
+  labels:
+    {{- include "tuist.labels" . | nindent 4 }}
+    app.kubernetes.io/component: kura-controller
+spec:
+  refreshInterval: {{ .Values.kuraController.cloudflareLoadBalancing.apiTokenSecret.refreshInterval | default "1h" }}
+  secretStoreRef:
+    name: {{ .Values.kuraController.cloudflareLoadBalancing.apiTokenSecret.storeRef.name | default "onepassword" }}
+    kind: {{ .Values.kuraController.cloudflareLoadBalancing.apiTokenSecret.storeRef.kind | default "ClusterSecretStore" }}
+  target:
+    name: {{ .Values.kuraController.cloudflareLoadBalancing.apiTokenSecret.name }}
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        {{ .Values.kuraController.cloudflareLoadBalancing.apiTokenSecret.key }}: "{{ `{{ .api_token | trim }}` }}"
+  data:
+    - secretKey: api_token
+      remoteRef:
+        key: "{{ .Values.kuraController.cloudflareLoadBalancing.apiTokenSecret.item | default "KURA_CLOUDFLARE_API_TOKEN" }}/{{ .Values.kuraController.cloudflareLoadBalancing.apiTokenSecret.field | default "credential" }}"
+{{- end }}

--- a/infra/helm/tuist/templates/kura-controller.yaml
+++ b/infra/helm/tuist/templates/kura-controller.yaml
@@ -158,8 +158,15 @@ spec:
             - --grpc-cluster-issuer={{ $tlsClusterIssuer }}
             {{- end }}
             {{- if .Values.kuraController.cloudflareLoadBalancing.enabled }}
+            {{- if .Values.kuraController.cloudflareLoadBalancing.zoneName }}
+            - --cloudflare-zone-name={{ .Values.kuraController.cloudflareLoadBalancing.zoneName }}
+            {{- end }}
+            {{- if .Values.kuraController.cloudflareLoadBalancing.accountID }}
             - --cloudflare-account-id={{ .Values.kuraController.cloudflareLoadBalancing.accountID }}
+            {{- end }}
+            {{- if .Values.kuraController.cloudflareLoadBalancing.zoneID }}
             - --cloudflare-zone-id={{ .Values.kuraController.cloudflareLoadBalancing.zoneID }}
+            {{- end }}
             - --cloudflare-api-token=$(CLOUDFLARE_API_TOKEN)
             {{- end }}
           ports:

--- a/infra/helm/tuist/values-managed-kura-region.yaml
+++ b/infra/helm/tuist/values-managed-kura-region.yaml
@@ -25,6 +25,12 @@ kuraController:
   # cluster (cert-manager + the issuer are bootstrapped via the
   # mgmt-cluster pipeline).
   tlsClusterIssuer: "letsencrypt-cloudflare"
+  cloudflareLoadBalancing:
+    enabled: true
+    zoneName: tuist.dev
+    apiTokenSecret:
+      managed: true
+      item: KURA_CLOUDFLARE_API_TOKEN
   sharedSecrets:
     # In managed regions, kura-shared-secrets is populated by CI from
     # the same secret store as the Tuist server release.

--- a/infra/helm/tuist/values.yaml
+++ b/infra/helm/tuist/values.yaml
@@ -35,11 +35,19 @@ kuraController:
   # Kura hostnames to healthy regional origins without proxying traffic.
   cloudflareLoadBalancing:
     enabled: false
+    zoneName: ""
     accountID: ""
     zoneID: ""
     apiTokenSecret:
       name: cloudflare-api-token
       key: api-token
+      managed: false
+      refreshInterval: "1h"
+      storeRef:
+        kind: ClusterSecretStore
+        name: onepassword
+      item: KURA_CLOUDFLARE_API_TOKEN
+      field: credential
   sharedSecrets:
     # Renders the kura-shared-secrets Kubernetes Secret in the
     # controller namespace. Set to false if the Secret is managed

--- a/infra/k8s/onboarding.md
+++ b/infra/k8s/onboarding.md
@@ -14,6 +14,7 @@ This doc is the runbook for onboarding **a new workload cluster** end-to-end. Th
 - Mgmt cluster kubeconfig in 1Password as `kubeconfig: tuist-mgmt` in the `tuist-k8s-mgmt` vault.
 - Hetzner Cloud project `tuist-workloads` (separate from `tuist-mgmt`) with API access. Token in 1Password as `tuist-workloads`.
 - A Cloudflare account with an API token scoped to `Zone.DNS:Edit` on `tuist.dev` (1Password: `cloudflare-tuist-dns`).
+- Production Kura regional deploys additionally need a Cloudflare token that can manage Load Balancers and read `tuist.dev` zone metadata. Wire it into the `server-k8s-production` GitHub environment as `KURA_CLOUDFLARE_API_TOKEN`.
 - Per-env 1Password vault (`tuist-k8s-staging` / `tuist-k8s-canary` / `tuist-k8s-production` / `tuist-k8s-preview`) holding the runtime secrets (`MASTER_KEY`, `TUIST_LICENSE_KEY` for preview, Grafana Cloud tokens) and a Service Account token scoped to the vault.
 - CLI tools installed via mise:
   ```bash

--- a/infra/k8s/onboarding.md
+++ b/infra/k8s/onboarding.md
@@ -14,7 +14,7 @@ This doc is the runbook for onboarding **a new workload cluster** end-to-end. Th
 - Mgmt cluster kubeconfig in 1Password as `kubeconfig: tuist-mgmt` in the `tuist-k8s-mgmt` vault.
 - Hetzner Cloud project `tuist-workloads` (separate from `tuist-mgmt`) with API access. Token in 1Password as `tuist-workloads`.
 - A Cloudflare account with an API token scoped to `Zone.DNS:Edit` on `tuist.dev` (1Password: `cloudflare-tuist-dns`).
-- Production Kura regional deploys additionally need a Cloudflare token that can manage Load Balancers and read `tuist.dev` zone metadata. Wire it into the `server-k8s-production` GitHub environment as `KURA_CLOUDFLARE_API_TOKEN`.
+- Production Kura regional deploys additionally need a `KURA_CLOUDFLARE_API_TOKEN` item in the `tuist-k8s-production` vault. The token must be able to manage Cloudflare Load Balancers and read `tuist.dev` zone metadata; the Kura controller chart syncs it through ESO into the `kura` namespace.
 - Per-env 1Password vault (`tuist-k8s-staging` / `tuist-k8s-canary` / `tuist-k8s-production` / `tuist-k8s-preview`) holding the runtime secrets (`MASTER_KEY`, `TUIST_LICENSE_KEY` for preview, Grafana Cloud tokens) and a Service Account token scoped to the vault.
 - CLI tools installed via mise:
   ```bash

--- a/infra/kura-controller/cmd/manager/main.go
+++ b/infra/kura-controller/cmd/manager/main.go
@@ -33,6 +33,7 @@ func main() {
 	var enableLeaderElection bool
 	var watchNamespace string
 	var grpcClusterIssuer string
+	var cloudflareZoneName string
 	var cloudflareAccountID string
 	var cloudflareZoneID string
 	var cloudflareAPIToken string
@@ -42,6 +43,7 @@ func main() {
 	flag.BoolVar(&enableLeaderElection, "leader-elect", true, "Single-leader election")
 	flag.StringVar(&watchNamespace, "watch-namespace", "", "Namespace to watch for KuraInstance resources")
 	flag.StringVar(&grpcClusterIssuer, "grpc-cluster-issuer", "", "cert-manager ClusterIssuer to use for gRPC TLS certificates (leaves gRPC plaintext when empty)")
+	flag.StringVar(&cloudflareZoneName, "cloudflare-zone-name", "", "Cloudflare zone name for Kura global DNS steering")
 	flag.StringVar(&cloudflareAccountID, "cloudflare-account-id", "", "Cloudflare account ID for Kura global DNS steering")
 	flag.StringVar(&cloudflareZoneID, "cloudflare-zone-id", "", "Cloudflare zone ID for Kura global DNS steering")
 	flag.StringVar(&cloudflareAPIToken, "cloudflare-api-token", "", "Cloudflare API token for Kura global DNS steering")
@@ -76,6 +78,7 @@ func main() {
 		Scheme:            mgr.GetScheme(),
 		GRPCClusterIssuer: grpcClusterIssuer,
 		CloudflareLoadBalancing: controllers.CloudflareLoadBalancingConfig{
+			ZoneName:  cloudflareZoneName,
 			AccountID: cloudflareAccountID,
 			ZoneID:    cloudflareZoneID,
 			APIToken:  cloudflareAPIToken,

--- a/infra/kura-controller/controllers/cloudflare.go
+++ b/infra/kura-controller/controllers/cloudflare.go
@@ -17,17 +17,19 @@ import (
 const cloudflareAPIBaseURL = "https://api.cloudflare.com/client/v4"
 
 type CloudflareLoadBalancingConfig struct {
+	ZoneName  string
 	AccountID string
 	ZoneID    string
 	APIToken  string
 }
 
 func (c CloudflareLoadBalancingConfig) Enabled() bool {
-	return c.AccountID != "" && c.ZoneID != "" && c.APIToken != ""
+	return c.APIToken != "" && (c.ZoneName != "" || (c.AccountID != "" && c.ZoneID != ""))
 }
 
 type cloudflareClient struct {
 	baseURL    string
+	zoneName   string
 	accountID  string
 	zoneID     string
 	apiToken   string
@@ -87,9 +89,18 @@ type cloudflareError struct {
 	Message string `json:"message"`
 }
 
+type cloudflareZone struct {
+	ID      string `json:"id"`
+	Name    string `json:"name"`
+	Account struct {
+		ID string `json:"id"`
+	} `json:"account"`
+}
+
 func newCloudflareClient(config CloudflareLoadBalancingConfig) *cloudflareClient {
 	return &cloudflareClient{
 		baseURL:   cloudflareAPIBaseURL,
+		zoneName:  config.ZoneName,
 		accountID: config.AccountID,
 		zoneID:    config.ZoneID,
 		apiToken:  config.APIToken,
@@ -100,6 +111,10 @@ func newCloudflareClient(config CloudflareLoadBalancingConfig) *cloudflareClient
 }
 
 func (c *cloudflareClient) reconcileKuraLoadBalancers(ctx context.Context, instance *kurav1alpha1.KuraInstance) error {
+	if err := c.ensureZoneResolved(ctx); err != nil {
+		return err
+	}
+
 	if instance.Spec.GlobalPublicHost != "" && instance.Spec.PublicHost != "" {
 		if err := c.reconcileKuraLoadBalancer(ctx, instance, instance.Spec.GlobalPublicHost, instance.Spec.PublicHost, "https"); err != nil {
 			return err
@@ -114,6 +129,10 @@ func (c *cloudflareClient) reconcileKuraLoadBalancers(ctx context.Context, insta
 }
 
 func (c *cloudflareClient) deleteKuraLoadBalancers(ctx context.Context, instance *kurav1alpha1.KuraInstance) error {
+	if err := c.ensureZoneResolved(ctx); err != nil {
+		return err
+	}
+
 	if instance.Spec.GlobalPublicHost != "" {
 		if err := c.removeKuraPool(ctx, instance, instance.Spec.GlobalPublicHost, "https"); err != nil {
 			return err
@@ -124,6 +143,30 @@ func (c *cloudflareClient) deleteKuraLoadBalancers(ctx context.Context, instance
 			return err
 		}
 	}
+	return nil
+}
+
+func (c *cloudflareClient) ensureZoneResolved(ctx context.Context) error {
+	if c.accountID != "" && c.zoneID != "" {
+		return nil
+	}
+	if c.zoneName == "" {
+		return fmt.Errorf("cloudflare zone metadata is incomplete")
+	}
+
+	zone, err := c.zoneByName(ctx, c.zoneName)
+	if err != nil {
+		return err
+	}
+	if zone == nil {
+		return fmt.Errorf("cloudflare zone %q not found", c.zoneName)
+	}
+	if zone.ID == "" || zone.Account.ID == "" {
+		return fmt.Errorf("cloudflare zone %q returned incomplete metadata", c.zoneName)
+	}
+
+	c.zoneID = zone.ID
+	c.accountID = zone.Account.ID
 	return nil
 }
 
@@ -325,6 +368,25 @@ func (c *cloudflareClient) loadBalancerByName(ctx context.Context, name string) 
 	return nil, nil
 }
 
+func (c *cloudflareClient) zoneByName(ctx context.Context, name string) (*cloudflareZone, error) {
+	zones, err := c.listZonesByName(ctx, name)
+	if err != nil {
+		return nil, err
+	}
+	for _, zone := range zones {
+		if zone.Name == name {
+			return &zone, nil
+		}
+	}
+	return nil, nil
+}
+
+func (c *cloudflareClient) listZonesByName(ctx context.Context, name string) ([]cloudflareZone, error) {
+	var response cloudflareListResponse[cloudflareZone]
+	err := c.do(ctx, http.MethodGet, fmt.Sprintf("/zones?name=%s", name), nil, &response)
+	return response.Result, err
+}
+
 func (c *cloudflareClient) listPools(ctx context.Context) ([]cloudflarePool, error) {
 	var response cloudflareListResponse[cloudflarePool]
 	err := c.do(ctx, http.MethodGet, fmt.Sprintf("/accounts/%s/load_balancers/pools?per_page=1000", c.accountID), nil, &response)
@@ -411,6 +473,10 @@ func (c *cloudflareClient) do(ctx context.Context, method, path string, body any
 func cloudflareResponseError(response any) error {
 	switch value := response.(type) {
 	case *cloudflareListResponse[cloudflarePool]:
+		if !value.Success {
+			return fmt.Errorf("cloudflare API error: %v", value.Errors)
+		}
+	case *cloudflareListResponse[cloudflareZone]:
 		if !value.Success {
 			return fmt.Errorf("cloudflare API error: %v", value.Errors)
 		}

--- a/infra/kura-controller/controllers/cloudflare_test.go
+++ b/infra/kura-controller/controllers/cloudflare_test.go
@@ -1,6 +1,11 @@
 package controllers
 
-import "testing"
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
 
 func TestDesiredCloudflareLoadBalancerUsesDNSOnlyProximitySteering(t *testing.T) {
 	loadBalancer := desiredCloudflareLoadBalancer("tuist.kura.tuist.dev", "https", []string{"pool-eu", "pool-us"})
@@ -22,5 +27,48 @@ func TestDesiredCloudflareLoadBalancerUsesDNSOnlyProximitySteering(t *testing.T)
 	}
 	if len(loadBalancer.DefaultPools) != 2 || loadBalancer.DefaultPools[0] != "pool-eu" || loadBalancer.DefaultPools[1] != "pool-us" {
 		t.Fatalf("expected default pools to be preserved, got %v", loadBalancer.DefaultPools)
+	}
+}
+
+func TestCloudflareLoadBalancingEnabledWithZoneName(t *testing.T) {
+	config := CloudflareLoadBalancingConfig{
+		ZoneName: "tuist.dev",
+		APIToken: "token",
+	}
+
+	if !config.Enabled() {
+		t.Fatal("expected Cloudflare load balancing to be enabled with zone name plus API token")
+	}
+}
+
+func TestCloudflareClientResolvesZoneMetadataFromZoneName(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/zones" || r.URL.Query().Get("name") != "tuist.dev" {
+			t.Fatalf("unexpected request path: %s?%s", r.URL.Path, r.URL.RawQuery)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer token" {
+			t.Fatalf("expected bearer token auth header, got %q", got)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"success":true,"result":[{"id":"zone-123","name":"tuist.dev","account":{"id":"account-456"}}],"errors":[]}`))
+	}))
+	defer server.Close()
+
+	client := newCloudflareClient(CloudflareLoadBalancingConfig{
+		ZoneName: "tuist.dev",
+		APIToken: "token",
+	})
+	client.baseURL = server.URL
+	client.httpClient = server.Client()
+
+	if err := client.ensureZoneResolved(context.Background()); err != nil {
+		t.Fatalf("expected zone resolution to succeed, got %v", err)
+	}
+	if client.zoneID != "zone-123" {
+		t.Fatalf("expected resolved zone ID, got %q", client.zoneID)
+	}
+	if client.accountID != "account-456" {
+		t.Fatalf("expected resolved account ID, got %q", client.accountID)
 	}
 }

--- a/infra/mise/tasks/k8s/deploy-kura-regionals.sh
+++ b/infra/mise/tasks/k8s/deploy-kura-regionals.sh
@@ -14,14 +14,52 @@ REPO_ROOT="$(git rev-parse --show-toplevel)"
 HELM_CHART_PATH="$REPO_ROOT/infra/helm/tuist"
 HELM_RELEASE_NAME="tuist"
 KUBECONFIG_DIR="${RUNNER_TEMP:-${TMPDIR:-/tmp}}/kura-kubeconfigs"
+CLOUDFLARE_ZONE_NAME="${CLOUDFLARE_ZONE_NAME:-tuist.dev}"
 
 mkdir -p "$KUBECONFIG_DIR"
 trap 'rm -rf "$KUBECONFIG_DIR"' EXIT
 
-if [ -z "${CLOUDFLARE_API_TOKEN:-}" ]; then
+# Prefer a dedicated Kura/Cloudflare Load Balancing token when one is
+# provided. The platform token is often limited to DNS-01 / external-dns
+# scopes and cannot manage Cloudflare Load Balancers.
+if [ -n "${KURA_CLOUDFLARE_API_TOKEN:-}" ]; then
+  CLOUDFLARE_API_TOKEN="$KURA_CLOUDFLARE_API_TOKEN"
+elif [ -z "${CLOUDFLARE_API_TOKEN:-}" ]; then
   CLOUDFLARE_API_TOKEN="$(op read "op://tuist-k8s-production/cloudflare-tuist-dns/credential")"
 fi
 export CLOUDFLARE_API_TOKEN
+
+if [ -z "${CLOUDFLARE_ZONE_ID:-}" ] || [ -z "${CLOUDFLARE_ACCOUNT_ID:-}" ]; then
+  ZONE_RESPONSE="$(
+    curl --fail --silent --show-error \
+      --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+      --header "Content-Type: application/json" \
+      "https://api.cloudflare.com/client/v4/zones?name=${CLOUDFLARE_ZONE_NAME}"
+  )"
+
+  if ! jq -e '.success == true and (.result | length) == 1' >/dev/null <<<"$ZONE_RESPONSE"; then
+    echo "ERROR: could not resolve Cloudflare zone details for ${CLOUDFLARE_ZONE_NAME}" >&2
+    jq -r '.errors // []' <<<"$ZONE_RESPONSE" >&2 || true
+    exit 1
+  fi
+
+  export CLOUDFLARE_ZONE_ID="${CLOUDFLARE_ZONE_ID:-$(jq -r '.result[0].id' <<<"$ZONE_RESPONSE")}"
+  export CLOUDFLARE_ACCOUNT_ID="${CLOUDFLARE_ACCOUNT_ID:-$(jq -r '.result[0].account.id' <<<"$ZONE_RESPONSE")}"
+fi
+
+LB_RESPONSE="$(
+  curl --fail --silent --show-error \
+    --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+    --header "Content-Type: application/json" \
+    "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/load_balancers/pools?per_page=1"
+)"
+
+if ! jq -e '.success == true' >/dev/null <<<"$LB_RESPONSE"; then
+  echo "ERROR: Cloudflare token cannot access Load Balancing APIs for account ${CLOUDFLARE_ACCOUNT_ID}." >&2
+  echo "Set KURA_CLOUDFLARE_API_TOKEN to a token with Load Balancer permissions, or update the fallback token." >&2
+  jq -r '.errors // []' <<<"$LB_RESPONSE" >&2 || true
+  exit 1
+fi
 
 deploy_region() {
   local region="$1"
@@ -44,11 +82,20 @@ deploy_region() {
   mise -C "$REPO_ROOT/infra" run k8s:install-platform \
     "$kubeconfig" "$cluster_name"
 
+  KUBECONFIG="$kubeconfig" kubectl create namespace kura \
+    --dry-run=client -o yaml | KUBECONFIG="$kubeconfig" kubectl apply -f -
+  KUBECONFIG="$kubeconfig" kubectl -n kura create secret generic cloudflare-api-token \
+    --from-literal=api-token="$CLOUDFLARE_API_TOKEN" \
+    --dry-run=client -o yaml | KUBECONFIG="$kubeconfig" kubectl apply -f -
+
   KUBECONFIG="$kubeconfig" kubectl apply -f "$HELM_CHART_PATH/crds/"
   KUBECONFIG="$kubeconfig" helm upgrade --install "$HELM_RELEASE_NAME" "$HELM_CHART_PATH" \
     --namespace tuist-kura-controller --create-namespace \
     -f "$HELM_CHART_PATH/values-managed-kura-region.yaml" \
     --set kuraController.image.tag="$IMAGE_TAG" \
+    --set kuraController.cloudflareLoadBalancing.enabled=true \
+    --set kuraController.cloudflareLoadBalancing.accountID="$CLOUDFLARE_ACCOUNT_ID" \
+    --set kuraController.cloudflareLoadBalancing.zoneID="$CLOUDFLARE_ZONE_ID" \
     --atomic --timeout 10m --wait
 }
 

--- a/infra/mise/tasks/k8s/deploy-kura-regionals.sh
+++ b/infra/mise/tasks/k8s/deploy-kura-regionals.sh
@@ -14,52 +14,9 @@ REPO_ROOT="$(git rev-parse --show-toplevel)"
 HELM_CHART_PATH="$REPO_ROOT/infra/helm/tuist"
 HELM_RELEASE_NAME="tuist"
 KUBECONFIG_DIR="${RUNNER_TEMP:-${TMPDIR:-/tmp}}/kura-kubeconfigs"
-CLOUDFLARE_ZONE_NAME="${CLOUDFLARE_ZONE_NAME:-tuist.dev}"
 
 mkdir -p "$KUBECONFIG_DIR"
 trap 'rm -rf "$KUBECONFIG_DIR"' EXIT
-
-# Prefer a dedicated Kura/Cloudflare Load Balancing token when one is
-# provided. The platform token is often limited to DNS-01 / external-dns
-# scopes and cannot manage Cloudflare Load Balancers.
-if [ -n "${KURA_CLOUDFLARE_API_TOKEN:-}" ]; then
-  CLOUDFLARE_API_TOKEN="$KURA_CLOUDFLARE_API_TOKEN"
-elif [ -z "${CLOUDFLARE_API_TOKEN:-}" ]; then
-  CLOUDFLARE_API_TOKEN="$(op read "op://tuist-k8s-production/cloudflare-tuist-dns/credential")"
-fi
-export CLOUDFLARE_API_TOKEN
-
-if [ -z "${CLOUDFLARE_ZONE_ID:-}" ] || [ -z "${CLOUDFLARE_ACCOUNT_ID:-}" ]; then
-  ZONE_RESPONSE="$(
-    curl --fail --silent --show-error \
-      --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
-      --header "Content-Type: application/json" \
-      "https://api.cloudflare.com/client/v4/zones?name=${CLOUDFLARE_ZONE_NAME}"
-  )"
-
-  if ! jq -e '.success == true and (.result | length) == 1' >/dev/null <<<"$ZONE_RESPONSE"; then
-    echo "ERROR: could not resolve Cloudflare zone details for ${CLOUDFLARE_ZONE_NAME}" >&2
-    jq -r '.errors // []' <<<"$ZONE_RESPONSE" >&2 || true
-    exit 1
-  fi
-
-  export CLOUDFLARE_ZONE_ID="${CLOUDFLARE_ZONE_ID:-$(jq -r '.result[0].id' <<<"$ZONE_RESPONSE")}"
-  export CLOUDFLARE_ACCOUNT_ID="${CLOUDFLARE_ACCOUNT_ID:-$(jq -r '.result[0].account.id' <<<"$ZONE_RESPONSE")}"
-fi
-
-LB_RESPONSE="$(
-  curl --fail --silent --show-error \
-    --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
-    --header "Content-Type: application/json" \
-    "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/load_balancers/pools?per_page=1"
-)"
-
-if ! jq -e '.success == true' >/dev/null <<<"$LB_RESPONSE"; then
-  echo "ERROR: Cloudflare token cannot access Load Balancing APIs for account ${CLOUDFLARE_ACCOUNT_ID}." >&2
-  echo "Set KURA_CLOUDFLARE_API_TOKEN to a token with Load Balancer permissions, or update the fallback token." >&2
-  jq -r '.errors // []' <<<"$LB_RESPONSE" >&2 || true
-  exit 1
-fi
 
 deploy_region() {
   local region="$1"
@@ -82,20 +39,11 @@ deploy_region() {
   mise -C "$REPO_ROOT/infra" run k8s:install-platform \
     "$kubeconfig" "$cluster_name"
 
-  KUBECONFIG="$kubeconfig" kubectl create namespace kura \
-    --dry-run=client -o yaml | KUBECONFIG="$kubeconfig" kubectl apply -f -
-  KUBECONFIG="$kubeconfig" kubectl -n kura create secret generic cloudflare-api-token \
-    --from-literal=api-token="$CLOUDFLARE_API_TOKEN" \
-    --dry-run=client -o yaml | KUBECONFIG="$kubeconfig" kubectl apply -f -
-
   KUBECONFIG="$kubeconfig" kubectl apply -f "$HELM_CHART_PATH/crds/"
   KUBECONFIG="$kubeconfig" helm upgrade --install "$HELM_RELEASE_NAME" "$HELM_CHART_PATH" \
     --namespace tuist-kura-controller --create-namespace \
     -f "$HELM_CHART_PATH/values-managed-kura-region.yaml" \
     --set kuraController.image.tag="$IMAGE_TAG" \
-    --set kuraController.cloudflareLoadBalancing.enabled=true \
-    --set kuraController.cloudflareLoadBalancing.accountID="$CLOUDFLARE_ACCOUNT_ID" \
-    --set kuraController.cloudflareLoadBalancing.zoneID="$CLOUDFLARE_ZONE_ID" \
     --atomic --timeout 10m --wait
 }
 


### PR DESCRIPTION
## Summary
- move Kura regional Cloudflare load-balancing configuration into the controller/chart path instead of resolving and wiring it in `deploy-kura-regionals.sh`
- add controller support for `--cloudflare-zone-name` and resolve the Cloudflare zone/account metadata from the API at runtime when explicit IDs are not configured
- sync the controller's `KURA_CLOUDFLARE_API_TOKEN` into the `kura` namespace with an `ExternalSecret`, and enable that managed path in the regional Kura values overlay
- document the new `KURA_CLOUDFLARE_API_TOKEN` vault item requirement for production Kura regional deploys

## Testing
- `bash -n infra/mise/tasks/k8s/deploy-kura-regionals.sh`
- `helm template tuist infra/helm/tuist -f infra/helm/tuist/values-managed-kura-region.yaml --set kuraController.image.tag=test | rg -n 'cloudflare-zone-name|ExternalSecret|cloudflare-api-token|KURA_CLOUDFLARE_API_TOKEN'`
- `mise x go@1.25.0 -- go test ./...`
