### PR TITLE
ci(cli): move Release CLI job to GitHub-hosted macos-26 runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -893,7 +893,7 @@ jobs:
     name: Release CLI
     needs: check-releases
     if: needs.check-releases.outputs.cli-should-release == 'true'
-    runs-on: tuist-macos
+    runs-on: macos-26
     timeout-minutes: 50
     permissions:
       contents: write


### PR DESCRIPTION
## Summary

- The `tuist-macos` Tart image does not yet have Xcode 26.0 installed, so the `Release CLI` job fails at `xcode-select -switch /Applications/Xcode_$(cat .xcode-version-releases).app` (`.xcode-version-releases` pins to `26.0`).
- Temporarily run that job on a GitHub-hosted `macos-26` runner to unblock CLI releases until a Tart image with Xcode 26.0 is published.
- `release-cli` is the only release job that consumes `.xcode-version-releases`; `release-app` and `release-ios` use `.xcode-version` (`26.4.1`), which is already in the image.

Reference: failing job https://github.com/tuist/tuist/actions/runs/26098624202/job/76746529449

## Test plan

- [ ] Trigger the release workflow on `main` and confirm `Release CLI` runs to completion on `macos-26`.
- [ ] Once a Tart image with Xcode 26.0 ships, revert this runner change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)