### PR TITLE
ci(release): stop Release runs from cancelling each other and add manual dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -13,7 +14,7 @@ permissions:
 
 concurrency:
   group: release-workflow-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 env:
   MISE_VERSION: "2026.4.18"


### PR DESCRIPTION
## Problem

`release.yml` uses:

\`\`\`yaml
concurrency:
  group: release-workflow-${{ github.ref }}
  cancel-in-progress: true
\`\`\`

`github.ref` is `refs/heads/main` for every push to main, so all Release runs share one concurrency group. With `cancel-in-progress: true`, each new merge to main cancels the still-running Release run. The workflow needs ~15-20 min to reach its publish jobs, but main is merged to far more frequently, so it never gets there.

Result: of the last ~20 Release runs, ~18 cancelled, 0 succeeded. Releases stopped going out entirely (`cache@0.32.5`, `server@1.197.x` stuck even though the code is already deployed via the path-filtered deploy workflows).

## Change

- `cancel-in-progress: false` so Release runs queue serially instead of killing each other, matching the deploy workflows which already use `cancel-in-progress: false`. Each run checks out its own SHA and the `check-releases` gate makes no-op runs cheap, so serial queuing is correct.
- Add `workflow_dispatch` so a release can be triggered manually if the pipeline needs a nudge.

Once this merges, the triggered Release run will queue (not be cancelled) and publish the current backlog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)