### PR TITLE
fix(cli): re-run foreign build script when inputs cannot be tracked

### DIFF
--- a/cli/Sources/ProjectDescription/Target.swift
+++ b/cli/Sources/ProjectDescription/Target.swift
@@ -124,23 +124,18 @@ public struct Target: Codable, Equatable, Sendable {
         /// - **Content hashing**: all inputs (including scripts) are used to compute a content hash for Tuist's
         ///   binary caching and selective testing, so that the foreign build step can be skipped when inputs are unchanged.
         ///
-        /// > Important: If folder/glob inputs resolve to no files at generation time, Xcode has nothing to track and
-        /// > the script will be marked as always out-of-date so it re-runs on every build. Tuist emits a warning in
-        /// > that case — double-check the configured paths.
+        /// > Important: If folder/glob inputs resolve to no files, Xcode has nothing to track for incremental
+        /// > builds, and the foreign build script is marked as always out-of-date so it re-runs on every build.
+        /// > This is fine when the underlying build system (Gradle, Cargo, CMake, …) handles its own
+        /// > incrementality; otherwise, double-check the configured paths.
         public enum Input: Codable, Hashable, Sendable {
             /// A single file whose contents affect the build output.
             case file(Path)
 
             /// A folder whose contents (recursively) affect the build output.
-            ///
-            /// The folder is expanded at generation time. If the folder doesn't exist or is empty, Tuist emits
-            /// a warning since Xcode would otherwise have no inputs to track for incremental builds.
             case folder(Path)
 
             /// A glob pattern that resolves to files whose contents affect the build output.
-            ///
-            /// The pattern is expanded at generation time. If the pattern matches no files, Tuist emits a
-            /// warning since Xcode would otherwise have no inputs to track for incremental builds.
             case glob(Path)
 
             /// A shell script whose stdout produces a cache key component (e.g. `"git rev-parse HEAD"`).

--- a/cli/Sources/ProjectDescription/Target.swift
+++ b/cli/Sources/ProjectDescription/Target.swift
@@ -123,14 +123,24 @@ public struct Target: Codable, Equatable, Sendable {
         ///   build phase so that Xcode can skip re-running the script when inputs haven't changed.
         /// - **Content hashing**: all inputs (including scripts) are used to compute a content hash for Tuist's
         ///   binary caching and selective testing, so that the foreign build step can be skipped when inputs are unchanged.
+        ///
+        /// > Important: If folder/glob inputs resolve to no files at generation time, Xcode has nothing to track and
+        /// > the script will be marked as always out-of-date so it re-runs on every build. Tuist emits a warning in
+        /// > that case — double-check the configured paths.
         public enum Input: Codable, Hashable, Sendable {
             /// A single file whose contents affect the build output.
             case file(Path)
 
             /// A folder whose contents (recursively) affect the build output.
+            ///
+            /// The folder is expanded at generation time. If the folder doesn't exist or is empty, Tuist emits
+            /// a warning since Xcode would otherwise have no inputs to track for incremental builds.
             case folder(Path)
 
             /// A glob pattern that resolves to files whose contents affect the build output.
+            ///
+            /// The pattern is expanded at generation time. If the pattern matches no files, Tuist emits a
+            /// warning since Xcode would otherwise have no inputs to track for incremental builds.
             case glob(Path)
 
             /// A shell script whose stdout produces a cache key component (e.g. `"git rev-parse HEAD"`).

--- a/cli/Sources/TuistGenerator/Mappers/ForeignBuildGraphMapper.swift
+++ b/cli/Sources/TuistGenerator/Mappers/ForeignBuildGraphMapper.swift
@@ -2,6 +2,7 @@ import FileSystem
 import Foundation
 import Path
 import TuistCore
+import TuistLogging
 import XcodeGraph
 
 /// Configures foreign build targets with script build phases and wires up linking dependencies.
@@ -34,7 +35,7 @@ public struct ForeignBuildGraphMapper: GraphMapping {
             for (targetName, target) in project.targets {
                 guard let foreignBuild = target.foreignBuild else { continue }
 
-                let inputPaths = try await inputPaths(from: foreignBuild.inputs)
+                let inputPaths = try await inputPaths(from: foreignBuild.inputs, targetName: targetName)
                 var updatedTarget = target
                 updatedTarget.scripts = [
                     TargetScript(
@@ -43,7 +44,8 @@ public struct ForeignBuildGraphMapper: GraphMapping {
                         script: .embedded(foreignBuild.script),
                         inputPaths: inputPaths,
                         outputPaths: [foreignBuild.output.path.pathString],
-                        showEnvVarsInLog: false
+                        showEnvVarsInLog: false,
+                        basedOnDependencyAnalysis: inputPaths.isEmpty ? false : nil
                     ),
                 ]
                 updatedTarget.metadata = .metadata(
@@ -78,7 +80,7 @@ public struct ForeignBuildGraphMapper: GraphMapping {
         return (graph, [], environment)
     }
 
-    private func inputPaths(from inputs: [ForeignBuild.Input]) async throws -> [String] {
+    private func inputPaths(from inputs: [ForeignBuild.Input], targetName: String) async throws -> [String] {
         var pathStrings: [String] = []
 
         for input in inputs {
@@ -92,10 +94,21 @@ public struct ForeignBuildGraphMapper: GraphMapping {
                         try await fileSystem.exists($0, isDirectory: false)
                     }
                     .map(\.pathString)
+                if filePathStrings.isEmpty {
+                    Logger.current.warning(
+                        "Foreign build folder input '\(path.pathString)' for target '\(targetName)' is empty or does not exist. Verify the path is correct, otherwise Xcode will not detect changes to files in this folder."
+                    )
+                }
                 pathStrings.append(contentsOf: filePathStrings)
             case .script:
                 break
             }
+        }
+
+        if pathStrings.isEmpty {
+            Logger.current.warning(
+                "Foreign build target '\(targetName)' has no resolvable input file paths. The foreign build script will run on every build because Xcode has nothing to track for incremental builds."
+            )
         }
 
         return pathStrings

--- a/cli/Sources/TuistGenerator/Mappers/ForeignBuildGraphMapper.swift
+++ b/cli/Sources/TuistGenerator/Mappers/ForeignBuildGraphMapper.swift
@@ -1,8 +1,8 @@
 import FileSystem
 import Foundation
 import Path
+import TuistAlert
 import TuistCore
-import TuistLogging
 import XcodeGraph
 
 /// Configures foreign build targets with script build phases and wires up linking dependencies.
@@ -95,9 +95,9 @@ public struct ForeignBuildGraphMapper: GraphMapping {
                     }
                     .map(\.pathString)
                 if filePathStrings.isEmpty {
-                    Logger.current.warning(
+                    AlertController.current.warning(.alert(
                         "Foreign build folder input '\(path.pathString)' for target '\(targetName)' is empty or does not exist. Verify the path is correct, otherwise Xcode will not detect changes to files in this folder."
-                    )
+                    ))
                 }
                 pathStrings.append(contentsOf: filePathStrings)
             case .script:
@@ -106,9 +106,9 @@ public struct ForeignBuildGraphMapper: GraphMapping {
         }
 
         if pathStrings.isEmpty {
-            Logger.current.warning(
-                "Foreign build target '\(targetName)' has no resolvable input file paths. The foreign build script will run on every build because Xcode has nothing to track for incremental builds."
-            )
+            AlertController.current.warning(.alert(
+                "Foreign build target '\(targetName)' has no resolvable input file paths, so the script will run on every build. This is fine when the underlying build system handles its own incrementality; otherwise, declare inputs so Xcode can skip the script when nothing changed."
+            ))
         }
 
         return pathStrings

--- a/cli/Sources/TuistLoader/Models+ManifestMappers/TargetDependency+ManifestMapper.swift
+++ b/cli/Sources/TuistLoader/Models+ManifestMappers/TargetDependency+ManifestMapper.swift
@@ -133,6 +133,11 @@ extension XcodeGraph.ForeignBuild.Input {
             let resolvedPath = try generatorPaths.resolve(path: path)
             let pattern = String(resolvedPath.pathString.dropFirst())
             let matchedPaths = try await fileSystem.glob(directory: AbsolutePath.root, include: [pattern]).collect().sorted()
+            if matchedPaths.isEmpty {
+                Logger.current.warning(
+                    "Foreign build glob input '\(resolvedPath.pathString)' matched no files. Verify the path is correct, otherwise Xcode will not detect changes to the matched files and the foreign build script may not re-run."
+                )
+            }
             return matchedPaths.map { .file($0) }
         case let .script(script):
             return [.script(script)]

--- a/cli/Sources/TuistLoader/Models+ManifestMappers/TargetDependency+ManifestMapper.swift
+++ b/cli/Sources/TuistLoader/Models+ManifestMappers/TargetDependency+ManifestMapper.swift
@@ -2,6 +2,7 @@ import FileSystem
 import Foundation
 import Path
 import ProjectDescription
+import TuistAlert
 import TuistCore
 import TuistLogging
 import TuistSupport
@@ -134,9 +135,9 @@ extension XcodeGraph.ForeignBuild.Input {
             let pattern = String(resolvedPath.pathString.dropFirst())
             let matchedPaths = try await fileSystem.glob(directory: AbsolutePath.root, include: [pattern]).collect().sorted()
             if matchedPaths.isEmpty {
-                Logger.current.warning(
+                AlertController.current.warning(.alert(
                     "Foreign build glob input '\(resolvedPath.pathString)' matched no files. Verify the path is correct, otherwise Xcode will not detect changes to the matched files and the foreign build script may not re-run."
-                )
+                ))
             }
             return matchedPaths.map { .file($0) }
         case let .script(script):

--- a/cli/Tests/TuistGeneratorTests/Mappers/ForeignBuildGraphMapperTests.swift
+++ b/cli/Tests/TuistGeneratorTests/Mappers/ForeignBuildGraphMapperTests.swift
@@ -46,6 +46,9 @@ struct ForeignBuildGraphMapperTests {
         #expect(mappedForeignTarget.scripts.first?.name == "Foreign Build: SharedKMP")
         #expect(mappedForeignTarget.scripts.first?.script == .embedded("gradle build"))
         #expect(mappedForeignTarget.scripts.first?.outputPaths == [outputPath.pathString])
+        // When there are no tracked inputs, the script must always run; otherwise Xcode would
+        // skip it forever once the output exists.
+        #expect(mappedForeignTarget.scripts.first?.basedOnDependencyAnalysis == false)
     }
 
     @Test
@@ -189,6 +192,41 @@ struct ForeignBuildGraphMapperTests {
             mainFile.pathString,
             gradleFile.pathString,
         ].sorted())
+        // With tracked inputs, fall back to Xcode's default dependency analysis.
+        #expect(script.basedOnDependencyAnalysis == nil)
+    }
+
+    @Test(.inTemporaryDirectory)
+    func map_marksScriptAlwaysOutOfDateWhenFolderInputIsEmpty() async throws {
+        // Given a target whose folder input matches no files on disk — without this guard,
+        // Xcode would treat the script as up-to-date forever once the output exists.
+        let fileSystem = FileSystem()
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let emptyFolder = temporaryDirectory.appending(components: "SharedKMP", "src")
+        try await fileSystem.makeDirectory(at: emptyFolder)
+
+        let outputPath = temporaryDirectory.appending(components: "build", "SharedKMP.xcframework")
+        let foreignBuildTarget = Target.test(
+            name: "SharedKMP",
+            foreignBuild: ForeignBuild(
+                script: "gradle build",
+                inputs: [.folder(emptyFolder)],
+                output: .xcframework(path: outputPath, linking: .dynamic)
+            )
+        )
+        let project = Project.test(path: temporaryDirectory, targets: [foreignBuildTarget])
+        let graph = Graph.test(path: temporaryDirectory, projects: [temporaryDirectory: project])
+
+        // When
+        let mapper = ForeignBuildGraphMapper(fileSystem: fileSystem)
+        let (mappedGraph, _, _) = try await mapper.map(graph: graph, environment: MapperEnvironment())
+
+        // Then
+        let mappedProject = try #require(mappedGraph.projects[temporaryDirectory])
+        let mappedForeignTarget = try #require(mappedProject.targets["SharedKMP"])
+        let script = try #require(mappedForeignTarget.scripts.first)
+        #expect(script.inputPaths.isEmpty)
+        #expect(script.basedOnDependencyAnalysis == false)
     }
 
     @Test


### PR DESCRIPTION
### Purpose

Reported in the Tuist Community Slack: a user wired up `foreignBuild()` for a KMP module, but editing the Kotlin sources didn't rebuild the framework — the iOS app kept linking the stale xcframework.

The root cause is a silent failure in input expansion. When a `.glob` or `.folder` input resolves to zero files at generation time (most commonly because `.relativeToRoot("../...")` aims at the wrong path), the Xcode shell script build phase is written with an empty `inputPaths`. Combined with an existing `outputPaths` xcframework, Xcode's dependency analysis decides the script is up-to-date forever — it runs once on the first build, then never again. Source changes on the non-Xcode side are dropped on the floor without any feedback.

Reproduced statically by inspecting the generated `project.pbxproj` against a fixture whose `.glob` aims at a non-existent path:

```
inputPaths = (
);
outputPaths = (
    ../../../../myAwesomeKmpProject/build/SharedKMP.xcframework,
);
```

No `alwaysOutOfDate`, no warning, no way for the user to notice.

### Fix

- Warn when a `.glob` input matches zero files (in the manifest mapper).
- Warn when a `.folder` input expands to no files (in `ForeignBuildGraphMapper`).
- When the final `inputPaths` for a foreign build script is empty, set `basedOnDependencyAnalysis = false`, which the build-phase generator translates to `alwaysOutOfDate = 1` in the pbxproj. The script will then re-run on every build instead of caching the stale output indefinitely.
- Document the failure mode on `ForeignBuild.Input` so it's discoverable from autocomplete.

When inputs do resolve correctly, behavior is unchanged: `inputPaths` is populated, `alwaysOutOfDate` is not set, and Xcode does its usual incremental analysis.

### How to test locally

1. Set up a fixture where the foreign build's `.glob` / `.folder` input resolves to no files (e.g. a wrong `..` count in `.relativeToRoot`):

```swift
.foreignBuild(
    name: "SharedKMP",
    destinations: .iOS,
    script: "...",
    inputs: [.glob(.relativeToRoot("does-not-exist/**/*.kt"))],
    output: .xcframework(path: ..., linking: .dynamic)
)
```

2. `tuist generate` — observe the warning:

```
Foreign build glob input '.../does-not-exist/**/*.kt' matched no files. ...
```

3. Inspect the generated `project.pbxproj` and confirm the script phase has `alwaysOutOfDate = 1`.

4. Build, then build again without changing anything — the script should re-run (whereas before this fix it would have been silently skipped).

5. Run `ForeignBuildGraphMapperTests` for unit coverage.