### PR TITLE
fix(kura, infra): restore logs and geography on the Tuist Kura dashboard

### DIFF
--- a/infra/grafana-dashboards/tuist-kura.json
+++ b/infra/grafana-dashboards/tuist-kura.json
@@ -107,7 +107,7 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "up{cluster=\"kura-tuist\", instance=~\"${instance:regex}\"}",
+            "expr": "up{cluster=~\"${cluster:regex}\", instance=~\"${instance:regex}\"}",
             "instant": true,
             "legendFormat": "{{instance}}",
             "range": false,
@@ -170,7 +170,7 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "sum(rate(kura_http_requests_total_total{cluster=\"kura-tuist\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"}[$__rate_interval]))",
+            "expr": "sum(rate(kura_http_requests_total_total{cluster=~\"${cluster:regex}\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"}[$__rate_interval]))",
             "instant": true,
             "legendFormat": "req/s",
             "range": false,
@@ -236,7 +236,7 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "sum(rate(kura_http_requests_total_total{cluster=\"kura-tuist\", instance=~\"${instance:regex}\", region=~\"${region:regex}\", status=~\"5..\"}[$__rate_interval]))",
+            "expr": "sum(rate(kura_http_requests_total_total{cluster=~\"${cluster:regex}\", instance=~\"${instance:regex}\", region=~\"${region:regex}\", status=~\"5..\"}[$__rate_interval]))",
             "instant": true,
             "legendFormat": "errors/s",
             "range": false,
@@ -302,7 +302,7 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "histogram_quantile(0.95, sum by (le) (rate(kura_http_request_duration_seconds_bucket{cluster=\"kura-tuist\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"}[$__rate_interval])))",
+            "expr": "histogram_quantile(0.95, sum by (le) (rate(kura_http_request_duration_seconds_bucket{cluster=~\"${cluster:regex}\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"}[$__rate_interval])))",
             "instant": true,
             "legendFormat": "p95",
             "range": false,
@@ -399,7 +399,7 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "sum by (instance) (rate(kura_http_requests_total_total{cluster=\"kura-tuist\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"}[$__rate_interval]))",
+            "expr": "sum by (instance) (rate(kura_http_requests_total_total{cluster=~\"${cluster:regex}\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"}[$__rate_interval]))",
             "legendFormat": "{{instance}}",
             "refId": "A"
           }
@@ -465,7 +465,7 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "topk(10, sum by (route) (rate(kura_http_requests_total_total{cluster=\"kura-tuist\", instance=~\"${instance:regex}\", region=~\"${region:regex}\", route=~\"${route:regex}\"}[$__rate_interval])))",
+            "expr": "topk(10, sum by (route) (rate(kura_http_requests_total_total{cluster=~\"${cluster:regex}\", instance=~\"${instance:regex}\", region=~\"${region:regex}\", route=~\"${route:regex}\"}[$__rate_interval])))",
             "legendFormat": "{{route}}",
             "refId": "A"
           }
@@ -531,7 +531,7 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "sum by (status) (rate(kura_http_requests_total_total{cluster=\"kura-tuist\", instance=~\"${instance:regex}\", region=~\"${region:regex}\", status=~\"${status:regex}\"}[$__rate_interval]))",
+            "expr": "sum by (status) (rate(kura_http_requests_total_total{cluster=~\"${cluster:regex}\", instance=~\"${instance:regex}\", region=~\"${region:regex}\", status=~\"${status:regex}\"}[$__rate_interval]))",
             "legendFormat": "{{status}}",
             "refId": "A"
           }
@@ -597,21 +597,21 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "histogram_quantile(0.50, sum by (le) (rate(kura_http_request_duration_seconds_bucket{cluster=\"kura-tuist\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"}[$__rate_interval])))",
+            "expr": "histogram_quantile(0.50, sum by (le) (rate(kura_http_request_duration_seconds_bucket{cluster=~\"${cluster:regex}\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"}[$__rate_interval])))",
             "legendFormat": "p50",
             "refId": "A"
           },
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "histogram_quantile(0.95, sum by (le) (rate(kura_http_request_duration_seconds_bucket{cluster=\"kura-tuist\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"}[$__rate_interval])))",
+            "expr": "histogram_quantile(0.95, sum by (le) (rate(kura_http_request_duration_seconds_bucket{cluster=~\"${cluster:regex}\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"}[$__rate_interval])))",
             "legendFormat": "p95",
             "refId": "B"
           },
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "histogram_quantile(0.99, sum by (le) (rate(kura_http_request_duration_seconds_bucket{cluster=\"kura-tuist\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"}[$__rate_interval])))",
+            "expr": "histogram_quantile(0.99, sum by (le) (rate(kura_http_request_duration_seconds_bucket{cluster=~\"${cluster:regex}\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"}[$__rate_interval])))",
             "legendFormat": "p99",
             "refId": "C"
           }
@@ -690,7 +690,7 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "sum by (result) (rate(kura_artifact_reads_total_total{cluster=\"kura-tuist\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"}[$__rate_interval]))",
+            "expr": "sum by (result) (rate(kura_artifact_reads_total_total{cluster=~\"${cluster:regex}\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"}[$__rate_interval]))",
             "legendFormat": "{{result}}",
             "refId": "A"
           }
@@ -756,7 +756,7 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "sum by (result) (rate(kura_artifact_writes_total_total{cluster=\"kura-tuist\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"}[$__rate_interval])) or on() label_replace(vector(0), \"result\", \"no_writes\", \"__name__\", \".*\")",
+            "expr": "sum by (result) (rate(kura_artifact_writes_total_total{cluster=~\"${cluster:regex}\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"}[$__rate_interval])) or on() label_replace(vector(0), \"result\", \"no_writes\", \"__name__\", \".*\")",
             "legendFormat": "{{result}}",
             "refId": "A"
           }
@@ -822,7 +822,7 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "sum by (producer) (rate(kura_artifact_reads_total_total{cluster=\"kura-tuist\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"}[$__rate_interval]))",
+            "expr": "sum by (producer) (rate(kura_artifact_reads_total_total{cluster=~\"${cluster:regex}\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"}[$__rate_interval]))",
             "legendFormat": "{{producer}}",
             "refId": "A"
           }
@@ -888,7 +888,7 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "sum by (producer) (rate(kura_artifact_writes_total_total{cluster=\"kura-tuist\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"}[$__rate_interval])) or on() label_replace(vector(0), \"producer\", \"no_writes\", \"__name__\", \".*\")",
+            "expr": "sum by (producer) (rate(kura_artifact_writes_total_total{cluster=~\"${cluster:regex}\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"}[$__rate_interval])) or on() label_replace(vector(0), \"producer\", \"no_writes\", \"__name__\", \".*\")",
             "legendFormat": "{{producer}}",
             "refId": "A"
           }
@@ -967,7 +967,7 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "sum by (outcome, instance) (rate(kura_replication_apply_results_total_total{cluster=\"kura-tuist\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"}[$__rate_interval]))",
+            "expr": "sum by (outcome, instance) (rate(kura_replication_apply_results_total_total{cluster=~\"${cluster:regex}\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"}[$__rate_interval]))",
             "legendFormat": "{{instance}} {{outcome}}",
             "refId": "A"
           }
@@ -1033,21 +1033,21 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "histogram_quantile(0.50, sum by (le) (rate(kura_replication_request_duration_seconds_bucket{cluster=\"kura-tuist\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"}[$__rate_interval]))) or on() vector(0)",
+            "expr": "histogram_quantile(0.50, sum by (le) (rate(kura_replication_request_duration_seconds_bucket{cluster=~\"${cluster:regex}\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"}[$__rate_interval]))) or on() vector(0)",
             "legendFormat": "p50",
             "refId": "A"
           },
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "histogram_quantile(0.95, sum by (le) (rate(kura_replication_request_duration_seconds_bucket{cluster=\"kura-tuist\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"}[$__rate_interval]))) or on() vector(0)",
+            "expr": "histogram_quantile(0.95, sum by (le) (rate(kura_replication_request_duration_seconds_bucket{cluster=~\"${cluster:regex}\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"}[$__rate_interval]))) or on() vector(0)",
             "legendFormat": "p95",
             "refId": "B"
           },
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "histogram_quantile(0.99, sum by (le) (rate(kura_replication_request_duration_seconds_bucket{cluster=\"kura-tuist\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"}[$__rate_interval]))) or on() vector(0)",
+            "expr": "histogram_quantile(0.99, sum by (le) (rate(kura_replication_request_duration_seconds_bucket{cluster=~\"${cluster:regex}\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"}[$__rate_interval]))) or on() vector(0)",
             "legendFormat": "p99",
             "refId": "C"
           }
@@ -1113,7 +1113,7 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "sum by (instance, route, status) (rate(kura_http_requests_total_total{cluster=\"kura-tuist\", instance=~\"${instance:regex}\", region=~\"${region:regex}\", route=~\"/_internal/.*\"}[$__rate_interval]))",
+            "expr": "sum by (instance, route, status) (rate(kura_http_requests_total_total{cluster=~\"${cluster:regex}\", instance=~\"${instance:regex}\", region=~\"${region:regex}\", route=~\"/_internal/.*\"}[$__rate_interval]))",
             "legendFormat": "{{instance}} {{route}} {{status}}",
             "refId": "A"
           }
@@ -1192,21 +1192,21 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "kura_rocksdb_block_cache_usage_bytes{cluster=\"kura-tuist\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"}",
+            "expr": "kura_rocksdb_block_cache_usage_bytes{cluster=~\"${cluster:regex}\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"}",
             "legendFormat": "{{instance}} usage",
             "refId": "A"
           },
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "kura_rocksdb_block_cache_pinned_usage_bytes{cluster=\"kura-tuist\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"}",
+            "expr": "kura_rocksdb_block_cache_pinned_usage_bytes{cluster=~\"${cluster:regex}\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"}",
             "legendFormat": "{{instance}} pinned",
             "refId": "B"
           },
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "kura_rocksdb_block_cache_capacity_bytes{cluster=\"kura-tuist\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"}",
+            "expr": "kura_rocksdb_block_cache_capacity_bytes{cluster=~\"${cluster:regex}\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"}",
             "legendFormat": "{{instance}} capacity",
             "refId": "C"
           }
@@ -1272,14 +1272,14 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "kura_rocksdb_write_buffer_usage_bytes{cluster=\"kura-tuist\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"}",
+            "expr": "kura_rocksdb_write_buffer_usage_bytes{cluster=~\"${cluster:regex}\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"}",
             "legendFormat": "{{instance}} usage",
             "refId": "A"
           },
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "kura_rocksdb_write_buffer_capacity_bytes{cluster=\"kura-tuist\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"}",
+            "expr": "kura_rocksdb_write_buffer_capacity_bytes{cluster=~\"${cluster:regex}\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"}",
             "legendFormat": "{{instance}} capacity",
             "refId": "B"
           }
@@ -1338,7 +1338,7 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "kura_rocksdb_block_cache_usage_bytes{cluster=\"kura-tuist\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"} / kura_rocksdb_block_cache_capacity_bytes{cluster=\"kura-tuist\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"}",
+            "expr": "kura_rocksdb_block_cache_usage_bytes{cluster=~\"${cluster:regex}\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"} / kura_rocksdb_block_cache_capacity_bytes{cluster=~\"${cluster:regex}\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"}",
             "instant": true,
             "legendFormat": "{{instance}}",
             "range": false,
@@ -1399,7 +1399,7 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "kura_rocksdb_write_buffer_usage_bytes{cluster=\"kura-tuist\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"} / kura_rocksdb_write_buffer_capacity_bytes{cluster=\"kura-tuist\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"}",
+            "expr": "kura_rocksdb_write_buffer_usage_bytes{cluster=~\"${cluster:regex}\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"} / kura_rocksdb_write_buffer_capacity_bytes{cluster=~\"${cluster:regex}\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"}",
             "instant": true,
             "legendFormat": "{{instance}}",
             "range": false,
@@ -1480,7 +1480,7 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "1 - avg by (instance) (rate(node_cpu_seconds_total{mode=\"idle\"}[$__rate_interval]) and on (instance) max by (instance) (kura_node_info{cluster=\"kura-tuist\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"}))",
+            "expr": "1 - avg by (instance) (rate(node_cpu_seconds_total{mode=\"idle\"}[$__rate_interval]) and on (instance) max by (instance) (kura_node_info{cluster=~\"${cluster:regex}\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"}))",
             "legendFormat": "{{instance}}",
             "refId": "A"
           }
@@ -1546,7 +1546,7 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "1 - ((node_memory_MemAvailable_bytes and on (instance) max by (instance) (kura_node_info{cluster=\"kura-tuist\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"})) / (node_memory_MemTotal_bytes and on (instance) max by (instance) (kura_node_info{cluster=\"kura-tuist\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"})))",
+            "expr": "1 - ((node_memory_MemAvailable_bytes and on (instance) max by (instance) (kura_node_info{cluster=~\"${cluster:regex}\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"})) / (node_memory_MemTotal_bytes and on (instance) max by (instance) (kura_node_info{cluster=~\"${cluster:regex}\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"})))",
             "legendFormat": "{{instance}}",
             "refId": "A"
           }
@@ -1620,7 +1620,7 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "1 - ((node_filesystem_avail_bytes{mountpoint=\"/\", fstype!~\"tmpfs|overlay\"} and on (instance) max by (instance) (kura_node_info{cluster=\"kura-tuist\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"})) / (node_filesystem_size_bytes{mountpoint=\"/\", fstype!~\"tmpfs|overlay\"} and on (instance) max by (instance) (kura_node_info{cluster=\"kura-tuist\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"})))",
+            "expr": "1 - ((node_filesystem_avail_bytes{mountpoint=\"/\", fstype!~\"tmpfs|overlay\"} and on (instance) max by (instance) (kura_node_info{cluster=~\"${cluster:regex}\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"})) / (node_filesystem_size_bytes{mountpoint=\"/\", fstype!~\"tmpfs|overlay\"} and on (instance) max by (instance) (kura_node_info{cluster=~\"${cluster:regex}\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"})))",
             "legendFormat": "{{instance}}",
             "refId": "A"
           }
@@ -1686,14 +1686,14 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "sum by (instance) (rate(node_network_receive_bytes_total{device!~\"lo\"}[$__rate_interval]) and on (instance) max by (instance) (kura_node_info{cluster=\"kura-tuist\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"}))",
+            "expr": "sum by (instance) (rate(node_network_receive_bytes_total{device!~\"lo\"}[$__rate_interval]) and on (instance) max by (instance) (kura_node_info{cluster=~\"${cluster:regex}\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"}))",
             "legendFormat": "{{instance}} rx",
             "refId": "A"
           },
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "sum by (instance) (rate(node_network_transmit_bytes_total{device!~\"lo\"}[$__rate_interval]) and on (instance) max by (instance) (kura_node_info{cluster=\"kura-tuist\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"}))",
+            "expr": "sum by (instance) (rate(node_network_transmit_bytes_total{device!~\"lo\"}[$__rate_interval]) and on (instance) max by (instance) (kura_node_info{cluster=~\"${cluster:regex}\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"}))",
             "legendFormat": "{{instance}} tx",
             "refId": "B"
           }
@@ -1759,7 +1759,7 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "node_filefd_allocated and on (instance) max by (instance) (kura_node_info{cluster=\"kura-tuist\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"})",
+            "expr": "node_filefd_allocated and on (instance) max by (instance) (kura_node_info{cluster=~\"${cluster:regex}\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"})",
             "legendFormat": "{{instance}}",
             "refId": "A"
           }
@@ -2116,7 +2116,7 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "sum by (region, country, subdivision, lookup) (label_replace(kura_node_geo_info{cluster=\"kura-tuist\", tenant_id=~\"${tenant:regex}\", instance=~\"${instance:regex}\", region=~\"${region:regex}\", country=\"US\", subdivision=~\"US-.*\"}, \"lookup\", \"$1\", \"subdivision\", \"US-(.*)\"))",
+            "expr": "sum by (region, country, subdivision, lookup) (label_replace(kura_node_geo_info{cluster=~\"${cluster:regex}\", tenant_id=~\"${tenant:regex}\", instance=~\"${instance:regex}\", region=~\"${region:regex}\", country=\"US\", subdivision=~\"US-.*\"}, \"lookup\", \"$1\", \"subdivision\", \"US-(.*)\"))",
             "format": "table",
             "instant": true,
             "range": false,
@@ -2125,7 +2125,7 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "sum by (region, country, subdivision, lookup) (label_replace(kura_node_geo_info{cluster=\"kura-tuist\", tenant_id=~\"${tenant:regex}\", instance=~\"${instance:regex}\", region=~\"${region:regex}\", country!=\"unknown\", country!=\"US\"}, \"lookup\", \"$1\", \"country\", \"(.*)\"))",
+            "expr": "sum by (region, country, subdivision, lookup) (label_replace(kura_node_geo_info{cluster=~\"${cluster:regex}\", tenant_id=~\"${tenant:regex}\", instance=~\"${instance:regex}\", region=~\"${region:regex}\", country!=\"unknown\", country!=\"US\"}, \"lookup\", \"$1\", \"country\", \"(.*)\"))",
             "format": "table",
             "instant": true,
             "range": false,
@@ -2134,7 +2134,7 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "label_replace(sum by (client_country) (increase(kura_http_requests_total_total{cluster=\"kura-tuist\", instance=~\"${instance:regex}\", region=~\"${region:regex}\", client_country!=\"unknown\"}[$__range])), \"lookup\", \"$1\", \"client_country\", \"(.*)\")",
+            "expr": "label_replace(sum by (client_country) (increase(kura_http_requests_total_total{cluster=~\"${cluster:regex}\", instance=~\"${instance:regex}\", region=~\"${region:regex}\", client_country!=\"unknown\"}[$__range])), \"lookup\", \"$1\", \"client_country\", \"(.*)\")",
             "format": "table",
             "instant": true,
             "range": false,
@@ -2206,14 +2206,37 @@
             "value": "$__all"
           },
           "datasource": "$datasource",
-          "definition": "label_values(kura_node_info{cluster=\"kura-tuist\"}, tenant_id)",
+          "definition": "label_values(kura_node_info, cluster)",
+          "hide": 0,
+          "includeAll": true,
+          "label": "Cluster",
+          "multi": true,
+          "name": "cluster",
+          "query": {
+            "query": "label_values(kura_node_info, cluster)",
+            "refId": "PrometheusVariableQueryEditor-VariableQuery"
+          },
+          "refresh": 1,
+          "regex": "",
+          "sort": 1,
+          "type": "query"
+        },
+        {
+          "allValue": ".*",
+          "current": {
+            "selected": true,
+            "text": "All",
+            "value": "$__all"
+          },
+          "datasource": "$datasource",
+          "definition": "label_values(kura_node_info{cluster=~\"${cluster:regex}\"}, tenant_id)",
           "hide": 0,
           "includeAll": true,
           "label": "Tenant",
           "multi": true,
           "name": "tenant",
           "query": {
-            "query": "label_values(kura_node_info{cluster=\"kura-tuist\"}, tenant_id)",
+            "query": "label_values(kura_node_info{cluster=~\"${cluster:regex}\"}, tenant_id)",
             "refId": "PrometheusVariableQueryEditor-VariableQuery"
           },
           "refresh": 1,
@@ -2229,14 +2252,14 @@
             "value": "$__all"
           },
           "datasource": "$datasource",
-          "definition": "label_values(kura_node_info{cluster=\"kura-tuist\", tenant_id=~\"${tenant:regex}\"}, instance)",
+          "definition": "label_values(kura_node_info{cluster=~\"${cluster:regex}\", tenant_id=~\"${tenant:regex}\"}, instance)",
           "hide": 0,
           "includeAll": true,
           "label": "Instance",
           "multi": true,
           "name": "instance",
           "query": {
-            "query": "label_values(kura_node_info{cluster=\"kura-tuist\", tenant_id=~\"${tenant:regex}\"}, instance)",
+            "query": "label_values(kura_node_info{cluster=~\"${cluster:regex}\", tenant_id=~\"${tenant:regex}\"}, instance)",
             "refId": "PrometheusVariableQueryEditor-VariableQuery"
           },
           "refresh": 1,
@@ -2252,14 +2275,14 @@
             "value": "$__all"
           },
           "datasource": "$datasource",
-          "definition": "label_values(kura_node_info{cluster=\"kura-tuist\", tenant_id=~\"${tenant:regex}\"}, region)",
+          "definition": "label_values(kura_node_info{cluster=~\"${cluster:regex}\", tenant_id=~\"${tenant:regex}\"}, region)",
           "hide": 0,
           "includeAll": true,
           "label": "Region",
           "multi": true,
           "name": "region",
           "query": {
-            "query": "label_values(kura_node_info{cluster=\"kura-tuist\", tenant_id=~\"${tenant:regex}\"}, region)",
+            "query": "label_values(kura_node_info{cluster=~\"${cluster:regex}\", tenant_id=~\"${tenant:regex}\"}, region)",
             "refId": "PrometheusVariableQueryEditor-VariableQuery"
           },
           "refresh": 1,
@@ -2275,14 +2298,14 @@
             "value": "$__all"
           },
           "datasource": "$datasource",
-          "definition": "label_values(kura_http_requests_total_total{cluster=\"kura-tuist\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"}, route)",
+          "definition": "label_values(kura_http_requests_total_total{cluster=~\"${cluster:regex}\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"}, route)",
           "hide": 0,
           "includeAll": true,
           "label": "Route",
           "multi": true,
           "name": "route",
           "query": {
-            "query": "label_values(kura_http_requests_total_total{cluster=\"kura-tuist\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"}, route)",
+            "query": "label_values(kura_http_requests_total_total{cluster=~\"${cluster:regex}\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"}, route)",
             "refId": "PrometheusVariableQueryEditor-VariableQuery"
           },
           "refresh": 1,
@@ -2298,14 +2321,14 @@
             "value": "$__all"
           },
           "datasource": "$datasource",
-          "definition": "label_values(kura_http_requests_total_total{cluster=\"kura-tuist\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"}, status)",
+          "definition": "label_values(kura_http_requests_total_total{cluster=~\"${cluster:regex}\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"}, status)",
           "hide": 0,
           "includeAll": true,
           "label": "Status",
           "multi": true,
           "name": "status",
           "query": {
-            "query": "label_values(kura_http_requests_total_total{cluster=\"kura-tuist\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"}, status)",
+            "query": "label_values(kura_http_requests_total_total{cluster=~\"${cluster:regex}\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"}, status)",
             "refId": "PrometheusVariableQueryEditor-VariableQuery"
           },
           "refresh": 1,

--- a/kura/ops/helm/kura/values.yaml
+++ b/kura/ops/helm/kura/values.yaml
@@ -14,7 +14,17 @@ serviceAccount:
   annotations: {}
   name: ""
 
-podAnnotations: {}
+# Exposes Kura's Prometheus /metrics endpoint to annotation-based
+# scrapers. The managed clusters' k8s-monitoring release discovers
+# targets via these prometheus.io/* keys (annotationAutodiscovery), and
+# the embedded Prometheus self-hosters opt into reads the same keys.
+# port-name pins discovery to the single `http` container port (the pod
+# also declares grpc and peer) so /metrics is scraped once per pod.
+# Inert when no scraper is present.
+podAnnotations:
+  prometheus.io/scrape: "true"
+  prometheus.io/port-name: "http"
+  prometheus.io/path: "/metrics"
 podLabels: {}
 
 podSecurityContext: {}


### PR DESCRIPTION
> Kura's Grafana dashboard showed traces but "No data" for Kura Logs and Tenant Geography. Root cause was two independent breaks in the Prometheus pipeline; traces were unaffected because Kura pushes OTLP directly and the traces panel filters on `service.namespace="kura"` with no cluster filter.

This PR fixes both:

- **`fix(kura)`**: Kura pods had no `prometheus.io/*` annotations, so the managed `k8s-monitoring` annotationAutodiscovery never scraped `:4000/metrics`. `kura_node_info`, `kura_node_geo_info`, and `kura_http_requests_total` never reached Grafana Cloud, starving every Prometheus panel and template variable. Added `scrape`/`port-name`/`path` pod annotations in the base chart values (`port-name: http` pins discovery to the single http port; the pod also declares grpc and peer). Inert when no scraper is present, so self-hosters' embedded Prometheus benefits too.
- **`fix(infra)`**: The dashboard hardcoded `cluster="kura-tuist"`, a value no cluster emits (overlays use `tuist-{staging,canary,production}`), so every Prometheus query and the `tenant`/`instance`/`region`/`route`/`status` variables matched nothing, which also broke the Kura Logs panel (it joins on the `instance` variable). Added a `Cluster` template variable (`label_values(kura_node_info, cluster)`, defaults to All) and replaced all 49 hardcoded `cluster="kura-tuist"` with `cluster=~"${cluster:regex}"` across panels and variables. Traces panel left unchanged.

**Follow-up to verify after deploy:** the Kura Logs panel filters `app_kubernetes_io_instance=~"${instance:regex}"`. `${instance}` resolves from the Prometheus `instance` label on `kura_node_info`, while the Loki side label is the Helm release name. If those values don't align once metrics flow, the logs panel may need a small follow-up (align the variable or switch the Loki filter to `pod`). The two structural blockers fixed here are independent of that.

### How to test locally

- `python3 -c "import json; json.load(open('infra/grafana-dashboards/tuist-kura.json'))"` confirms the dashboard JSON is valid and no `kura-tuist` literals remain.
- `helm lint kura/ops/helm/kura -f kura/ops/helm/kura/values.yaml` passes; `helm template` renders the three `prometheus.io/*` annotations on the StatefulSet pod template.
- Full verification is post-deploy: after the Kura clusters redeploy, the Tenant Geography and Prometheus panels populate and the template variables resolve.
