### PR TITLE
fix(cli): keep tuist dump stdout machine-readable

### DIFF
--- a/cli/Sources/TuistKit/Utils/Dependencies.swift
+++ b/cli/Sources/TuistKit/Utils/Dependencies.swift
@@ -128,7 +128,9 @@ private func initSession() async throws -> (Logger, SessionPaths) {
 }
 
 func initNoora(jsonThroughNoora: Bool = false) -> Noora {
-    if CommandLine.arguments.contains("--json") || CommandLine.arguments.contains("--quiet") {
+    if MachineReadableOutput.isEnabled(arguments: Environment.current.arguments)
+        || CommandLine.arguments.contains("--quiet")
+    {
         Noora(
             standardPipelines: jsonThroughNoora ? StandardPipelines() : StandardPipelines(
                 output: IgnoreOutputPipeline()

--- a/cli/Sources/TuistKit/Utils/Dependencies.swift
+++ b/cli/Sources/TuistKit/Utils/Dependencies.swift
@@ -128,7 +128,9 @@ private func initSession() async throws -> (Logger, SessionPaths) {
 }
 
 func initNoora(jsonThroughNoora: Bool = false) -> Noora {
-    if MachineReadableOutput.shouldSuppressNooraOutput(arguments: Environment.current.arguments) {
+    if MachineReadableOutput.isEnabled(arguments: Environment.current.arguments)
+        || MachineReadableOutput.isQuiet(arguments: Environment.current.arguments)
+    {
         Noora(
             standardPipelines: jsonThroughNoora ? StandardPipelines() : StandardPipelines(
                 output: IgnoreOutputPipeline()

--- a/cli/Sources/TuistKit/Utils/Dependencies.swift
+++ b/cli/Sources/TuistKit/Utils/Dependencies.swift
@@ -128,9 +128,7 @@ private func initSession() async throws -> (Logger, SessionPaths) {
 }
 
 func initNoora(jsonThroughNoora: Bool = false) -> Noora {
-    if MachineReadableOutput.isEnabled(arguments: Environment.current.arguments)
-        || CommandLine.arguments.contains("--quiet")
-    {
+    if MachineReadableOutput.shouldSuppressNooraOutput(arguments: Environment.current.arguments) {
         Noora(
             standardPipelines: jsonThroughNoora ? StandardPipelines() : StandardPipelines(
                 output: IgnoreOutputPipeline()

--- a/cli/Sources/TuistKit/Utils/SessionController.swift
+++ b/cli/Sources/TuistKit/Utils/SessionController.swift
@@ -25,15 +25,8 @@ public struct SessionController {
         stateDirectory: AbsolutePath
     ) async throws -> (@Sendable (String) -> any LogHandler, SessionPaths) {
         let sessionPaths = try await createSessionDirectory(stateDirectory: stateDirectory)
-
-        let machineReadableCommands = [DumpCommand.self]
-        // swiftformat:disable all
-        let isCommandMachineReadable =
-            CommandLine.arguments.count > 1
-            && machineReadableCommands.map { $0._commandName }.contains(CommandLine.arguments[1])
-        // swiftformat:enable all
         let loggingConfig =
-            if isCommandMachineReadable || CommandLine.arguments.contains("--json") {
+            if MachineReadableOutput.isEnabled(arguments: CommandLine.arguments) {
                 LoggingConfig(
                     loggerType: .json,
                     verbose: Environment.current.isVerbose

--- a/cli/Sources/TuistSupport/Utils/MachineReadableOutput.swift
+++ b/cli/Sources/TuistSupport/Utils/MachineReadableOutput.swift
@@ -23,4 +23,8 @@ public enum MachineReadableOutput {
 
         return machineReadableCommands.contains(command)
     }
+
+    public static func shouldSuppressNooraOutput(arguments: [String]) -> Bool {
+        isEnabled(arguments: arguments) || arguments.contains("--quiet")
+    }
 }

--- a/cli/Sources/TuistSupport/Utils/MachineReadableOutput.swift
+++ b/cli/Sources/TuistSupport/Utils/MachineReadableOutput.swift
@@ -24,7 +24,7 @@ public enum MachineReadableOutput {
         return machineReadableCommands.contains(command)
     }
 
-    public static func shouldSuppressNooraOutput(arguments: [String]) -> Bool {
-        isEnabled(arguments: arguments) || arguments.contains("--quiet")
+    public static func isQuiet(arguments: [String]) -> Bool {
+        arguments.contains("--quiet")
     }
 }

--- a/cli/Sources/TuistSupport/Utils/MachineReadableOutput.swift
+++ b/cli/Sources/TuistSupport/Utils/MachineReadableOutput.swift
@@ -1,0 +1,26 @@
+public enum MachineReadableOutput {
+    private static let machineReadableCommands: Set<String> = [
+        "dump",
+    ]
+
+    private static let ignoredGlobalFlags: Set<String> = [
+        "--quiet",
+        "--verbose",
+    ]
+
+    public static func isEnabled(arguments: [String]) -> Bool {
+        if arguments.contains("--json") {
+            return true
+        }
+
+        let commandArguments = arguments
+            .dropFirst()
+            .filter { !ignoredGlobalFlags.contains($0) }
+
+        guard let command = commandArguments.first else {
+            return false
+        }
+
+        return machineReadableCommands.contains(command)
+    }
+}

--- a/cli/Sources/tuist/Dependencies.swift
+++ b/cli/Sources/tuist/Dependencies.swift
@@ -6,12 +6,12 @@ import TuistEnvironment
 import TuistLogging
 import TuistNooraExtension
 import TuistServer
+import TuistSupport
 
 #if os(macOS)
     import TuistExtension
     import TuistKit
     import TuistLoader
-    import TuistSupport
 
     #if canImport(TuistCacheEE)
         import TuistCacheEE

--- a/cli/Sources/tuist/Dependencies.swift
+++ b/cli/Sources/tuist/Dependencies.swift
@@ -52,9 +52,7 @@ struct IgnoreOutputPipeline: StandardPipelining {
 }
 
 func initNoora(jsonThroughNoora: Bool = false) -> Noora {
-    if MachineReadableOutput.isEnabled(arguments: Environment.current.arguments)
-        || CommandLine.arguments.contains("--quiet")
-    {
+    if MachineReadableOutput.shouldSuppressNooraOutput(arguments: Environment.current.arguments) {
         Noora(
             standardPipelines: jsonThroughNoora ? StandardPipelines() : StandardPipelines(
                 output: IgnoreOutputPipeline()

--- a/cli/Sources/tuist/Dependencies.swift
+++ b/cli/Sources/tuist/Dependencies.swift
@@ -52,7 +52,9 @@ struct IgnoreOutputPipeline: StandardPipelining {
 }
 
 func initNoora(jsonThroughNoora: Bool = false) -> Noora {
-    if CommandLine.arguments.contains("--json") || CommandLine.arguments.contains("--quiet") {
+    if MachineReadableOutput.isEnabled(arguments: Environment.current.arguments)
+        || CommandLine.arguments.contains("--quiet")
+    {
         Noora(
             standardPipelines: jsonThroughNoora ? StandardPipelines() : StandardPipelines(
                 output: IgnoreOutputPipeline()

--- a/cli/Sources/tuist/Dependencies.swift
+++ b/cli/Sources/tuist/Dependencies.swift
@@ -52,7 +52,9 @@ struct IgnoreOutputPipeline: StandardPipelining {
 }
 
 func initNoora(jsonThroughNoora: Bool = false) -> Noora {
-    if MachineReadableOutput.shouldSuppressNooraOutput(arguments: Environment.current.arguments) {
+    if MachineReadableOutput.isEnabled(arguments: Environment.current.arguments)
+        || MachineReadableOutput.isQuiet(arguments: Environment.current.arguments)
+    {
         Noora(
             standardPipelines: jsonThroughNoora ? StandardPipelines() : StandardPipelines(
                 output: IgnoreOutputPipeline()

--- a/cli/Sources/tuist/TuistCommand.swift
+++ b/cli/Sources/tuist/TuistCommand.swift
@@ -220,12 +220,14 @@ public struct TuistCommand: AsyncParsableCommand {
 
             do {
                 try await executeCommand()
-                try await withLoggerForNoora(logFilePath: logFilePath) {
-                    Noora.$current.withValue(initNoora()) {
-                        outputCompletion(
-                            logFilePath: logFilePath,
-                            shouldOutputLogFilePath: logFilePathDisplayStrategy == .always
-                        )
+                if !MachineReadableOutput.isEnabled(arguments: Environment.current.arguments) {
+                    try await withLoggerForNoora(logFilePath: logFilePath) {
+                        Noora.$current.withValue(initNoora()) {
+                            outputCompletion(
+                                logFilePath: logFilePath,
+                                shouldOutputLogFilePath: logFilePathDisplayStrategy == .always
+                            )
+                        }
                     }
                 }
             } catch {

--- a/cli/Sources/tuist/TuistCommand.swift
+++ b/cli/Sources/tuist/TuistCommand.swift
@@ -21,6 +21,7 @@ import TuistProjectCommand
 import TuistRegistryCommand
 import TuistRunCommand
 import TuistShareCommand
+import TuistSupport
 import TuistTestCommand
 import TuistVersionCommand
 
@@ -31,7 +32,6 @@ import TuistVersionCommand
     import TuistKit
     import TuistLoader
     import TuistServer
-    import TuistSupport
 #endif
 
 public struct TuistCommand: AsyncParsableCommand {

--- a/cli/Tests/TuistSupportTests/Utils/MachineReadableOutputTests.swift
+++ b/cli/Tests/TuistSupportTests/Utils/MachineReadableOutputTests.swift
@@ -26,21 +26,27 @@ struct MachineReadableOutputTests {
         #expect(MachineReadableOutput.isEnabled(arguments: arguments) == false)
     }
 
-    @Test func shouldSuppressNooraOutput_whenQuietFlagIsPresent() {
+    @Test func isQuiet_whenQuietFlagIsPresent() {
         let arguments = ["tuist", "--quiet", "generate"]
 
-        #expect(MachineReadableOutput.shouldSuppressNooraOutput(arguments: arguments))
+        #expect(MachineReadableOutput.isQuiet(arguments: arguments))
     }
 
-    @Test func shouldSuppressNooraOutput_whenMachineReadableOutputIsEnabled() {
-        let arguments = ["tuist", "dump"]
-
-        #expect(MachineReadableOutput.shouldSuppressNooraOutput(arguments: arguments))
-    }
-
-    @Test func shouldNotSuppressNooraOutput_forHumanReadableCommands() {
+    @Test func isQuiet_whenQuietFlagIsNotPresent() {
         let arguments = ["tuist", "generate"]
 
-        #expect(MachineReadableOutput.shouldSuppressNooraOutput(arguments: arguments) == false)
+        #expect(MachineReadableOutput.isQuiet(arguments: arguments) == false)
+    }
+
+    @Test func isEnabled_whenQuietFlagIsPresentForHumanReadableCommand() {
+        let arguments = ["tuist", "--quiet", "generate"]
+
+        #expect(MachineReadableOutput.isEnabled(arguments: arguments) == false)
+    }
+
+    @Test func isEnabled_whenQuietFlagIsPresentForMachineReadableCommand() {
+        let arguments = ["tuist", "--quiet", "dump"]
+
+        #expect(MachineReadableOutput.isEnabled(arguments: arguments))
     }
 }

--- a/cli/Tests/TuistSupportTests/Utils/MachineReadableOutputTests.swift
+++ b/cli/Tests/TuistSupportTests/Utils/MachineReadableOutputTests.swift
@@ -1,0 +1,28 @@
+import Testing
+@testable import TuistSupport
+
+struct MachineReadableOutputTests {
+    @Test func isEnabled_whenJSONFlagIsPresent() {
+        let arguments = ["tuist", "--json", "generate"]
+
+        #expect(MachineReadableOutput.isEnabled(arguments: arguments))
+    }
+
+    @Test func isEnabled_whenDumpCommandIsExecuted() {
+        let arguments = ["tuist", "dump"]
+
+        #expect(MachineReadableOutput.isEnabled(arguments: arguments))
+    }
+
+    @Test func isEnabled_whenDumpCommandFollowsGlobalFlags() {
+        let arguments = ["tuist", "--verbose", "dump"]
+
+        #expect(MachineReadableOutput.isEnabled(arguments: arguments))
+    }
+
+    @Test func isDisabled_forHumanReadableCommands() {
+        let arguments = ["tuist", "generate"]
+
+        #expect(MachineReadableOutput.isEnabled(arguments: arguments) == false)
+    }
+}

--- a/cli/Tests/TuistSupportTests/Utils/MachineReadableOutputTests.swift
+++ b/cli/Tests/TuistSupportTests/Utils/MachineReadableOutputTests.swift
@@ -25,4 +25,22 @@ struct MachineReadableOutputTests {
 
         #expect(MachineReadableOutput.isEnabled(arguments: arguments) == false)
     }
+
+    @Test func shouldSuppressNooraOutput_whenQuietFlagIsPresent() {
+        let arguments = ["tuist", "--quiet", "generate"]
+
+        #expect(MachineReadableOutput.shouldSuppressNooraOutput(arguments: arguments))
+    }
+
+    @Test func shouldSuppressNooraOutput_whenMachineReadableOutputIsEnabled() {
+        let arguments = ["tuist", "dump"]
+
+        #expect(MachineReadableOutput.shouldSuppressNooraOutput(arguments: arguments))
+    }
+
+    @Test func shouldNotSuppressNooraOutput_forHumanReadableCommands() {
+        let arguments = ["tuist", "generate"]
+
+        #expect(MachineReadableOutput.shouldSuppressNooraOutput(arguments: arguments) == false)
+    }
 }


### PR DESCRIPTION
Resolves n/a

> Keep `tuist dump` machine-readable when the CLI collects warnings such as expiring server licence notices. This centralizes machine-readable command detection so JSON logging, Noora suppression, and completion output all agree on when stdout must stay JSON-only, and adds focused tests for the detection path.

### How to test locally

```bash
mise run install
tuist generate tuist ProjectDescription TuistKitTests TuistSupportTests --no-open
xcodebuild test -workspace Tuist.xcworkspace -scheme Tuist-Workspace -only-testing TuistSupportTests/MachineReadableOutputTests -only-testing TuistKitTests/SessionControllerTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""
```
