### PR TITLE
fix(infra): four forward-only bootstrap fixes from the runners-fleet incident

### DIFF
--- a/infra/macos-host-bootstrap/bootstrap.go
+++ b/infra/macos-host-bootstrap/bootstrap.go
@@ -618,28 +618,64 @@ func enableAutoLogin(ctx context.Context, client *ssh.Client, user, password str
 	// which means tart-kubelet's `tart run` fails on every pod even
 	// after Tart and the kubelet are correctly installed.
 	//
-	// Killing loginwindow with SIGHUP forces it to respawn, and the
-	// respawned process — unlike the boot-time process — does honor
-	// the auto-login preference, brings up the Aqua session, and the
-	// bridge100 vmnet interface starts working. Idempotent: if the
-	// Aqua session already exists, the kick still works (loginwindow
-	// re-establishes it cleanly) and we accept that small cost over
-	// branching on session state.
+	// `launchctl kickstart -k system/com.apple.loginwindow` is the
+	// modern way to do this and handles both cases uniformly:
+	//   * loginwindow IS running: SIGTERM the existing instance and
+	//     respawn it.
+	//   * loginwindow is NOT running: just spawn it.
+	// `killall -HUP loginwindow` (the previous approach) exits 1 with
+	// "No matching processes were found" when loginwindow is missing,
+	// which is the state we land in if the host had loginwindow exit
+	// via SIGHUP earlier (launchd's policy is to not auto-respawn
+	// after SIGHUP for a console-bound daemon). kickstart talks to
+	// launchd's service registry directly so the missing-process case
+	// is a clean start, not an error.
 	script := fmt.Sprintf(`set -euo pipefail
 echo '%[2]s' | base64 -d | sudo tee /etc/kcpassword > /dev/null
 sudo chmod 600 /etc/kcpassword
 sudo defaults write /Library/Preferences/com.apple.loginwindow autoLoginUser '%[1]s'
-sudo killall -HUP loginwindow 2>/dev/null || true
+sudo launchctl kickstart -k system/com.apple.loginwindow 2>/dev/null || true
 # Wait for the Aqua session to come up. loginwindow respawn typically
-# takes <2s; 30s is generous. If it still doesn't appear we let
-# bootstrap continue — Stage 2 of reconcileNormal will retry on the
-# next reconcile if VZ subsequently rejects the VM start.
+# takes <2s; 30s is generous. If it still doesn't appear we still
+# proceed to the kcpassword verification below before failing — the
+# Aqua check is best-effort because launchctl's session inspection
+# semantics vary between macOS releases.
+session_up=0
 for i in $(seq 1 30); do
   if sudo launchctl print "gui/$(id -u '%[1]s')" 2>/dev/null | grep -q 'session = Aqua'; then
-    exit 0
+    session_up=1
+    break
   fi
   sleep 1
 done
+
+# Verify /etc/kcpassword wasn't replaced by macOS Tahoe's "<sealed>"
+# marker. When the password we wrote doesn't actually match the
+# user's, loginwindow rejects the auto-login attempt and overwrites
+# /etc/kcpassword with the XOR-encoded literal string "<sealed>"
+# (8 bytes + 3 NUL padding = 11 bytes total). Bootstrap silently
+# completes but every subsequent reboot fails to bring up an Aqua
+# session — Tart can't start guests, all runner pods hit
+# TartCreateFailed indefinitely.
+#
+# Read kcpassword as root and XOR-decode it; the first 8 bytes are
+# the signal. Python exit 1 here propagates via 'set -e' and fails
+# the bootstrap loudly, so the operator fixes the bootstrap-Secret-
+# vs-host password drift before the host ships.
+sudo /usr/bin/python3 - <<'CHECK'
+import sys
+key = bytes([0x7d, 0x89, 0x52, 0x23, 0xd2, 0xbc, 0xdd, 0xea, 0xa3, 0xb9, 0x1f])
+with open('/etc/kcpassword', 'rb') as f:
+    enc = f.read()
+dec = bytes(b ^ key[i %% len(key)] for i, b in enumerate(enc))
+if dec.startswith(b'<sealed>'):
+    sys.stderr.write("kcpassword replaced by macOS with <sealed> marker — bootstrap-stored password does not match m1's actual password on this host\n")
+    sys.exit(1)
+CHECK
+
+if [ "$session_up" = "0" ]; then
+  echo "WARN: Aqua session for %[1]s did not appear after loginwindow kick; bootstrap continues — VM-start preflight will retry"
+fi
 `, user, encoded)
 	return runCommand(ctx, client, script)
 }
@@ -805,18 +841,20 @@ block drop out quick from <vm_sources> to <blocked_dst>
 block drop out quick from <vm_sources> to 169.254.169.254
 PFCONF
 
-# Splice the anchor into /etc/pf.conf if it isn't already there.
-# /etc/pf.conf is editable per-host (vs. /System/Library which is
-# SIP-protected); macOS's default pf.conf carries a marker line
-# we anchor our insert against.
-if ! sudo grep -q "anchor \"tuist.runners\"" /etc/pf.conf; then
-  sudo tee -a /etc/pf.conf >/dev/null <<'PFCONFENTRY'
-
+# Manage the anchor block in /etc/pf.conf via begin/end markers.
+# Strip-and-append between markers is idempotent and convergent:
+# any number of pre-existing marker-delimited blocks (duplicates
+# from a stuttering reconcile, partial writes from a prior crashed
+# run) get removed before the canonical block is written.
+sudo sed -i.bak '/^# BEGIN tuist.runners$/,/^# END tuist.runners$/d' /etc/pf.conf
+sudo rm -f /etc/pf.conf.bak
+sudo tee -a /etc/pf.conf >/dev/null <<'PFCONFENTRY'
+# BEGIN tuist.runners
 # Tuist runner VM egress filter — see /etc/pf.anchors/tuist.runners
 anchor "tuist.runners"
 load anchor "tuist.runners" from "/etc/pf.anchors/tuist.runners"
+# END tuist.runners
 PFCONFENTRY
-fi
 
 # Reset the anchor's kernel-resident ruleset before the validate.
 # Hosts that previously ran an older version of this script left

--- a/infra/mise/tasks/k8s/prepare-fleet-host.sh
+++ b/infra/mise/tasks/k8s/prepare-fleet-host.sh
@@ -271,10 +271,18 @@ fi
 #    preference. Re-applied every run because there's no cheap
 #    idempotency check we trust on the encoded contents, and sudo
 #    is now passwordless so the writes are free.
+#
+#    `launchctl kickstart -k system/com.apple.loginwindow` handles
+#    both "loginwindow is running, respawn it" and "loginwindow is
+#    gone, just start it" uniformly. `killall -HUP loginwindow`
+#    exits 1 with "No matching processes were found" in the latter
+#    case, which happens when an earlier reconcile attempt SIGHUP'd
+#    loginwindow and launchd's no-respawn-after-SIGHUP policy left
+#    it dead.
 printf '%s' "$KCPW_B64" | base64 -d | sudo tee /etc/kcpassword > /dev/null
 sudo chmod 600 /etc/kcpassword
 sudo defaults write /Library/Preferences/com.apple.loginwindow autoLoginUser 'm1'
-sudo killall -HUP loginwindow 2>/dev/null || true
+sudo launchctl kickstart -k system/com.apple.loginwindow 2>/dev/null || true
 printf '  ✓ kcpassword + autoLoginUser: configured\n'
 
 printf '\n  ✓ host prepped — reboot in the Scaleway console for auto-login to take effect\n'

--- a/infra/tart-kubelet/internal/podagent/reconciler.go
+++ b/infra/tart-kubelet/internal/podagent/reconciler.go
@@ -130,23 +130,25 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{}, err
 	}
 
-	// Pod already moved to a terminal phase (we marked it Succeeded
-	// after the VM exited, or someone else marked it Failed). Do
-	// nothing here: re-running createPod would clone+boot a fresh
-	// VM for a Pod the workload controller is about to garbage-
-	// collect, and the watcher needs the Pod to stay in the
-	// terminal phase long enough to observe the transition. The
-	// finalizer comes off via the DeletionTimestamp branch below
-	// when the controller eventually deletes the Pod.
-	if pod.Status.Phase == corev1.PodSucceeded || pod.Status.Phase == corev1.PodFailed {
-		return ctrl.Result{}, nil
-	}
-
 	if !pod.DeletionTimestamp.IsZero() {
 		// Pod is being deleted. Run VM teardown, then drop our
 		// finalizer and force-complete the API object deletion. Order
 		// matters: the Pod must not disappear from kubectl's view
 		// while the VM is still running on the host.
+		//
+		// This branch must run BEFORE the terminal-phase early-return
+		// below: when a Pod's VM exits cleanly we publish
+		// Phase=Succeeded, and shortly after the owning controller
+		// issues a Delete on it. Both conditions (terminal phase AND
+		// DeletionTimestamp set) hold simultaneously from that moment
+		// on. If the terminal-phase check ran first, the reconciler
+		// would short-circuit and never remove the finalizer — Pods
+		// would sit forever in `Terminating` with the finalizer
+		// holding them open and the runners-controller's reap path
+		// (which correctly skips Pods that already have a
+		// DeletionTimestamp) unable to do anything about it. We
+		// shipped exactly that bug for several days; the fix is the
+		// ordering you see here.
 		if err := r.deletePod(ctx, pod); err != nil {
 			logger.Error(err, "delete failed; will retry")
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
@@ -158,6 +160,18 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			logger.Error(err, "complete pod deletion; will retry")
 			return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 		}
+		return ctrl.Result{}, nil
+	}
+
+	// Pod already moved to a terminal phase (we marked it Succeeded
+	// after the VM exited, or someone else marked it Failed). Do
+	// nothing here: re-running createPod would clone+boot a fresh
+	// VM for a Pod the workload controller is about to garbage-
+	// collect, and the watcher needs the Pod to stay in the
+	// terminal phase long enough to observe the transition. Finalizer
+	// removal happens via the DeletionTimestamp branch above the
+	// moment the owning controller issues a Delete on the Pod.
+	if pod.Status.Phase == corev1.PodSucceeded || pod.Status.Phase == corev1.PodFailed {
 		return ctrl.Result{}, nil
 	}
 

--- a/infra/tart-kubelet/internal/podagent/reconciler_test.go
+++ b/infra/tart-kubelet/internal/podagent/reconciler_test.go
@@ -9,6 +9,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -56,6 +57,48 @@ func TestCompletePodDeletionDeletesPodWithoutFinalizer(t *testing.T) {
 	}
 
 	assertPodDeleted(t, ctx, kubeClient, types.NamespacedName{Namespace: "default", Name: "already-cleaned"})
+}
+
+// Regression guard: when a Pod is BOTH in a terminal phase AND has
+// DeletionTimestamp set (the steady state once the runners-controller
+// observes a Succeeded Pod and issues a Delete on it), the
+// reconciler must run the deletion branch — drop the finalizer and
+// force-complete the API-object deletion. The previous ordering had
+// the terminal-phase early-return ahead of the DeletionTimestamp
+// check, which left every Succeeded Pod wedged in Terminating with
+// the vm-cleanup finalizer holding it open.
+func TestReconcileTerminalPodWithDeletionTimestampRemovesFinalizer(t *testing.T) {
+	ctx := context.Background()
+	deletionTime := metav1.Now()
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:         "tuist-runners",
+			Name:              "runner-stuck-terminating",
+			Finalizers:        []string{PodFinalizer},
+			DeletionTimestamp: &deletionTime,
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "runner", Image: "ghcr.io/tuist/tuist-runner:test"}},
+		},
+		Status: corev1.PodStatus{Phase: corev1.PodSucceeded},
+	}
+	kubeClient := newPodTestClient(t, pod)
+	reconciler := &Reconciler{
+		CachedClient: kubeClient,
+		// Tart and Store are unused on this path: deletePod ->
+		// deleteByKey returns nil when Store.Get yields no entry,
+		// which is the steady state for terminal Pods (the VM was
+		// already cleaned up when its `tart run` exited).
+		Store: NewStore(),
+	}
+
+	if _, err := reconciler.Reconcile(ctx, ctrl.Request{
+		NamespacedName: types.NamespacedName{Namespace: "tuist-runners", Name: "runner-stuck-terminating"},
+	}); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+
+	assertPodDeleted(t, ctx, kubeClient, types.NamespacedName{Namespace: "tuist-runners", Name: "runner-stuck-terminating"})
 }
 
 func newPodTestClient(t *testing.T, objects ...runtime.Object) client.Client {


### PR DESCRIPTION
## Summary

Four forward-only follow-ups from the runners-fleet incident in #10858. No in-code migration of legacy hosts.

### 1. `/etc/pf.conf` anchor block could end up duplicated

The prior idempotency check appended `anchor "tuist.runners"` to `/etc/pf.conf` unless a `grep` match was found. On `k6kwt` the block ended up appended *twice*; pfctl's validate then died on `cannot define table vm_sources: Resource busy` (loading the same anchor twice tries to redeclare its tables).

Fix: marker-delimited atomic block management (`# BEGIN tuist.runners` / `# END tuist.runners`). Strip-and-append is idempotent and convergent.

### 2. `/etc/kcpassword` silently replaced with `<sealed>` on password mismatch

When the password the bootstrap module XOR-encodes into `/etc/kcpassword` doesn't match `m1`'s actual password, macOS Tahoe's `loginwindow` rejects the auto-login attempt and overwrites `/etc/kcpassword` with the XOR-encoded literal string `<sealed>`. Auto-login never fires, no Aqua session, Tart's `ensure gui session` times out at 30s, every runner pod hits `TartCreateFailed` forever — silent degradation across four production hosts today.

Fix: after writing kcpassword and the SIGHUP wait, decode the file as root and fail bootstrap if the first 8 bytes are `<sealed>` (via `set -e`).

### 3. `launchctl kickstart` instead of `killall -HUP loginwindow`

On `k6kwt` today we found loginwindow in a state where it had received SIGHUP from an earlier reconcile attempt and exited; launchd's no-auto-respawn-after-SIGHUP policy for console-bound daemons left it dead. `killall -HUP loginwindow` then exits 1 with `No matching processes were found` — no process to kick. The pod-side error surfaced as `tart run: ensure gui session: kick loginwindow: exit status 1`.

Fix: `launchctl kickstart -k system/com.apple.loginwindow` talks to launchd's service registry directly and handles both "process running, respawn it" and "process gone, spawn fresh" cases uniformly. Applied to both `bootstrap.go`'s `enableAutoLogin` and `prepare-fleet-host.sh`'s kcpassword step.

### 4. tart-kubelet reconciler stuck 504 Succeeded pods in Terminating

`infra/tart-kubelet/internal/podagent/reconciler.go` had the wrong branch ordering. The terminal-phase early-return (PodSucceeded/PodFailed) sat *above* the `DeletionTimestamp` check. Once the runners-controller observed a Pod's natural turnover (VM exited → Phase=Succeeded) and issued a `Delete` on it, both conditions held simultaneously — and the reconciler short-circuited at the terminal-phase check, never reaching the deletion branch that removes the `tart-kubelet.tuist.dev/vm-cleanup` finalizer.

Result: every successfully-completed runner Pod since 2026-05-15 sat in Terminating with the finalizer holding it open. By 2026-05-19 there were **504 stuck pods** in the `tuist-runners` namespace. The runners-controller's reap path correctly skipped them (DeletionTimestamp already set) and the controller didn't know there was a problem — its log showed `reaped=0` every reconcile.

Fix: swap the order. `DeletionTimestamp` first (drop the finalizer, force-complete the API object deletion); terminal-phase early-return after. Added a regression test (`TestReconcileTerminalPodWithDeletionTimestampRemovesFinalizer`) that fails when the order is swapped back — verified by temporarily reverting the fix and confirming the test reproduces the bug.

## Cleanup of existing stuck pods

This fix prevents new pods from getting stuck. The 504 already-stuck pods need a one-shot manual cleanup (separate from this PR):

```bash
kubectl -n tuist-runners get pods --field-selector status.phase=Succeeded \
  -o json | jq -r '.items[] | select(.metadata.finalizers != null) | .metadata.name' \
  | xargs -I{} kubectl -n tuist-runners patch pod {} \
    --type=json -p='[{"op":"remove","path":"/metadata/finalizers"}]'
```

Once this PR's tart-kubelet binary ships, future pods drain through cleanly without operator action.

## Test plan

- [x] `go test ./...` passes across both `infra/macos-host-bootstrap` and `infra/tart-kubelet/internal/podagent`.
- [x] `go vet` clean. `gofmt` clean. `bash -n` clean on the script.
- [x] Regression test for fix #4 verified by temporarily reverting reconciler.go and confirming the test fails with the bug present, passes with the fix.
- [ ] **(blocking draft)** Trigger a forced re-bootstrap on a healthy production host (e.g. by `kubectl delete node`) and confirm fixes #1-#3 run without regression.
- [ ] **(blocking draft)** After deploy, confirm fix #4: a Pod that hits `Succeeded TartRunExited` reaches deletion within a reconcile cycle instead of getting stuck in Terminating with the finalizer.

## Context

See the [#10858 description](https://github.com/tuist/tuist/pull/10858) for the full incident write-up.