### PR TITLE
fix(server): unify Cloudflare token for Kura regional deploys

### DIFF
--- a/infra/helm/tuist/templates/kura-controller-external-secrets.yaml
+++ b/infra/helm/tuist/templates/kura-controller-external-secrets.yaml
@@ -23,5 +23,5 @@ spec:
   data:
     - secretKey: api_token
       remoteRef:
-        key: "{{ .Values.kuraController.cloudflareLoadBalancing.apiTokenSecret.item | default "KURA_CLOUDFLARE_API_TOKEN" }}/{{ .Values.kuraController.cloudflareLoadBalancing.apiTokenSecret.field | default "credential" }}"
+        key: "{{ .Values.kuraController.cloudflareLoadBalancing.apiTokenSecret.item | default "cloudflare-tuist-dns" }}/{{ .Values.kuraController.cloudflareLoadBalancing.apiTokenSecret.field | default "credential" }}"
 {{- end }}

--- a/infra/helm/tuist/values-managed-kura-region.yaml
+++ b/infra/helm/tuist/values-managed-kura-region.yaml
@@ -30,7 +30,7 @@ kuraController:
     zoneName: tuist.dev
     apiTokenSecret:
       managed: true
-      item: KURA_CLOUDFLARE_API_TOKEN
+      item: cloudflare-tuist-dns
   sharedSecrets:
     # In managed regions, kura-shared-secrets is populated by CI from
     # the same secret store as the Tuist server release.

--- a/infra/helm/tuist/values.yaml
+++ b/infra/helm/tuist/values.yaml
@@ -46,7 +46,7 @@ kuraController:
       storeRef:
         kind: ClusterSecretStore
         name: onepassword
-      item: KURA_CLOUDFLARE_API_TOKEN
+      item: cloudflare-tuist-dns
       field: credential
   sharedSecrets:
     # Renders the kura-shared-secrets Kubernetes Secret in the

--- a/infra/k8s/onboarding.md
+++ b/infra/k8s/onboarding.md
@@ -13,8 +13,8 @@ This doc is the runbook for onboarding **a new workload cluster** end-to-end. Th
 - Tailscale on the `tuist.dev` tailnet, with `talosctl` reachable on the mgmt VM at `100.92.208.109:50000` (see [`mgmt/tailscale.yaml`](mgmt/tailscale.yaml) for tailnet onboarding).
 - Mgmt cluster kubeconfig in 1Password as `kubeconfig: tuist-mgmt` in the `tuist-k8s-mgmt` vault.
 - Hetzner Cloud project `tuist-workloads` (separate from `tuist-mgmt`) with API access. Token in 1Password as `tuist-workloads`.
-- A Cloudflare account with an API token scoped to `Zone.DNS:Edit` on `tuist.dev` (1Password: `cloudflare-tuist-dns`).
-- Production Kura regional deploys additionally need a `KURA_CLOUDFLARE_API_TOKEN` item in the `tuist-k8s-production` vault. The token must be able to manage Cloudflare Load Balancers and read `tuist.dev` zone metadata; the Kura controller chart syncs it through ESO into the `kura` namespace.
+- A Cloudflare account with an API token stored as `cloudflare-tuist-dns`. Local bootstrap reads it from the `Founders` vault; production Kura regional deploys also need the same item in `tuist-k8s-production` so CI and the Kura controller can read it.
+- The `cloudflare-tuist-dns` token must be able to edit DNS for `tuist.dev`, read `tuist.dev` zone metadata, manage zone Load Balancers, and manage account-level Load Balancing pools/monitors.
 - Per-env 1Password vault (`tuist-k8s-staging` / `tuist-k8s-canary` / `tuist-k8s-production` / `tuist-k8s-preview`) holding the runtime secrets (`MASTER_KEY`, `TUIST_LICENSE_KEY` for preview, Grafana Cloud tokens) and a Service Account token scoped to the vault.
 - CLI tools installed via mise:
   ```bash

--- a/infra/mise/tasks/k8s/deploy-kura-regionals.sh
+++ b/infra/mise/tasks/k8s/deploy-kura-regionals.sh
@@ -18,6 +18,11 @@ KUBECONFIG_DIR="${RUNNER_TEMP:-${TMPDIR:-/tmp}}/kura-kubeconfigs"
 mkdir -p "$KUBECONFIG_DIR"
 trap 'rm -rf "$KUBECONFIG_DIR"' EXIT
 
+if [ -z "${CLOUDFLARE_API_TOKEN:-}" ]; then
+  CLOUDFLARE_API_TOKEN="$(op read "op://tuist-k8s-production/cloudflare-tuist-dns/credential")"
+fi
+export CLOUDFLARE_API_TOKEN
+
 deploy_region() {
   local region="$1"
   local cluster_name="$2"


### PR DESCRIPTION
Resolves <https://github.com/tuist/tuist/actions/runs/26106376830>

This restores the Kura regional deploy's Cloudflare token wiring and standardizes the CI and controller paths on the same `cloudflare-tuist-dns` item in `tuist-k8s-production`.

- point the Kura controller ExternalSecret defaults and regional overlay at `cloudflare-tuist-dns`
- export `CLOUDFLARE_API_TOKEN` from `op://tuist-k8s-production/cloudflare-tuist-dns/credential` before `k8s:install-platform`
- document the shared production-vault item and the Cloudflare permissions it needs

### How to test locally

- `bash -n infra/mise/tasks/k8s/deploy-kura-regionals.sh`
- `helm template tuist infra/helm/tuist -f infra/helm/tuist/values-managed-kura-region.yaml --set kuraController.image.tag=test | rg -n "cloudflare-tuist-dns|cloudflare-api-token|cloudflare-zone-name|ExternalSecret"`
