### PR TITLE
fix(infra): bump hetzner-robot-controller image to post-cluster-gate build

### DIFF
--- a/infra/k8s/mgmt/hetzner-robot-controller.yaml
+++ b/infra/k8s/mgmt/hetzner-robot-controller.yaml
@@ -115,7 +115,7 @@ spec:
           # for the first time, the bump-chart-image-pins step
           # rewrites this line to a semver tag (`0.1.0`, `0.2.0`,
           # …) and from there it's owned by the release pipeline.
-          image: ghcr.io/tuist/tuist-hetzner-robot-controller:sha-5fdd66ccc037
+          image: ghcr.io/tuist/tuist-hetzner-robot-controller:sha-59deca403dc9
           imagePullPolicy: IfNotPresent
           args:
             - --leader-elect=true


### PR DESCRIPTION
## Summary
- Bumps the `hetzner-robot-controller` image pin from `sha-5fdd66ccc037` → `sha-59deca403dc9` so the binary matches the manifest's new `--clusters` flag.

## Why
PR #10794 added the `--clusters=staging,canary,production` arg to the controller's binary AND to the deployment manifest in the same change, but the image SHA pin in `infra/k8s/mgmt/hetzner-robot-controller.yaml` still pointed at a build from before the flag landed.

On merge, `mgmt-cluster-apply` applied the new manifest, kubelet rolled the deployment, but the new pod crash-looped:

\`\`\`
flag provided but not defined: -clusters
Usage of /usr/local/bin/manager:
  -health-probe-bind-address string ...
  -host-namespace string ...
  (... no -clusters flag in the list ...)
\`\`\`

Two old replicas without `--clusters` keep serving (no per-env gate), and a canary box that was ordered in the meantime got mis-claimed by staging.

`sha-59deca403dc9` is the build from the merge commit itself (`59deca403d`), produced by the `hetzner-robot-controller-image` workflow at 08:47 UTC after the merge at 08:43 UTC. That binary has the flag.

## Test plan
- [ ] CI passes (image-build workflow on this branch shouldn't re-build the controller image since this PR only touches the manifest).
- [ ] On merge, `mgmt-cluster-apply` rolls the deployment; the new pod (image `sha-59deca403dc9`) starts cleanly, old replicas terminate.
- [ ] Verify with `kubectl -n org-tuist logs deployment/hetzner-robot-controller --tail=20` — should show \"starting manager\" + \"clusters\" + \"staging,canary,production\" in the structured log, no flag error.
- [ ] Verify HBM labels stamp + back-fill: `kubectl -n org-tuist get hbm -o custom-columns=NAME:.metadata.name,SERVER_NAME:.metadata.labels.robot\.hetzner\.com/server-name,CLUSTER:.metadata.labels.tuist\.dev/cluster,CONSUMER:.spec.consumerRef.name` — every HBM should have a non-empty CLUSTER value matching its server-name prefix.
- [ ] Release staging's stale claim on the canary HBM (`kubectl -n org-tuist delete hbm bm-2987569`); confirm controller recreates it stamped `tuist.dev/cluster=canary` and canary's HBMM (patched selector) picks it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)