### PR TITLE
perf(server): cut FINAL scans on ClickHouse test_case_runs and test_runs

### DIFF
--- a/server/lib/tuist/tests.ex
+++ b/server/lib/tuist/tests.ex
@@ -1108,16 +1108,21 @@ defmodule Tuist.Tests do
     test_case_ids = slim_results |> Enum.map(& &1.test_case_id) |> Enum.uniq()
     {min_ran_at, max_ran_at} = ran_at_bounds(slim_results)
 
-    ClickHouseRepo.all(
-      from(tcr in TestCaseRun,
-        hints: ["FINAL"],
-        where: tcr.project_id in ^project_ids,
-        where: tcr.test_case_id in ^test_case_ids,
-        where: tcr.ran_at >= ^min_ran_at,
-        where: tcr.ran_at <= ^max_ran_at,
-        where: tcr.id in ^ids
-      )
+    # `test_case_runs` is ReplacingMergeTree; re-inserts (e.g. flaky flag
+    # updates) leave multiple versions per id until background merges
+    # collapse them. Dedupe in Elixir by `desc: inserted_at` rather than
+    # paying FINAL's full-part scan and in-memory merge for the page-sized
+    # set of ids that the slim MV already narrowed us to.
+    from(tcr in TestCaseRun,
+      where: tcr.project_id in ^project_ids,
+      where: tcr.test_case_id in ^test_case_ids,
+      where: tcr.ran_at >= ^min_ran_at,
+      where: tcr.ran_at <= ^max_ran_at,
+      where: tcr.id in ^ids,
+      order_by: [desc: tcr.inserted_at]
     )
+    |> ClickHouseRepo.all()
+    |> Enum.uniq_by(& &1.id)
   end
 
   defp ran_at_bounds([first | rest]) do
@@ -2890,14 +2895,35 @@ defmodule Tuist.Tests do
     six_hours_ago = NaiveDateTime.add(NaiveDateTime.utc_now(), -6, :hour)
     now = NaiveDateTime.utc_now()
 
-    stale_runs =
+    # `test_runs` is ReplacingMergeTree, and FINAL re-expands granule
+    # selection across parts so duplicates can be merged. That defeats the
+    # `idx_status` skip index, which is the only thing that makes finding
+    # `in_progress` rows cheap. Find candidate ids without FINAL (the skip
+    # index then prunes granules), then re-resolve their latest version via
+    # the `proj_by_id` projection — FINAL over a small id set stays cheap.
+    candidate_ids =
       ClickHouseRepo.all(
         from(t in Test,
-          hints: ["FINAL"],
           where: t.status == "in_progress",
-          where: t.inserted_at < ^six_hours_ago
+          where: t.inserted_at < ^six_hours_ago,
+          select: t.id,
+          distinct: true
         )
       )
+
+    stale_runs =
+      if candidate_ids == [] do
+        []
+      else
+        ClickHouseRepo.all(
+          from(t in Test,
+            hints: ["FINAL"],
+            where: t.id in ^candidate_ids,
+            where: t.status == "in_progress",
+            where: t.inserted_at < ^six_hours_ago
+          )
+        )
+      end
 
     updated_runs =
       Enum.map(stale_runs, fn run ->

--- a/server/lib/tuist/tests/analytics.ex
+++ b/server/lib/tuist/tests/analytics.ex
@@ -795,14 +795,18 @@ defmodule Tuist.Tests.Analytics do
   def test_runs_metrics(project_id, test_runs) when is_list(test_runs) do
     test_run_ids = Enum.map(test_runs, & &1.id)
 
+    # The `test_case_runs_by_test_run` MV is ordered by
+    # `(test_run_id, ran_at, id)`, giving an O(log N) seek per test_run_id.
+    # It is ReplacingMergeTree, so re-inserts can duplicate rows per id;
+    # `count(DISTINCT id)` gets the right count without paying for FINAL.
     test_case_counts =
       ClickHouseRepo.all(
-        from(t in TestCaseRun,
+        from(t in TestCaseRunByTestRun,
           where: t.project_id == ^project_id and t.test_run_id in ^test_run_ids,
           group_by: t.test_run_id,
           select: %{
             test_run_id: t.test_run_id,
-            total_count: count(t.id)
+            total_count: fragment("count(DISTINCT ?)", t.id)
           }
         )
       )


### PR DESCRIPTION
## Summary

Three call sites that account for the bulk of CPU and I/O on production ClickHouse were rewritten to avoid full-part FINAL scans. Each query plan was validated against the local ClickHouse via `EXPLAIN indexes = 1`.

### `fetch_full_test_case_runs/1` (server/lib/tuist/tests.ex)
Drops `FINAL` on `test_case_runs`. Re-inserted rows (flaky flag updates) preserve the `(project_id, test_case_id, ran_at, id)` ORDER BY tuple, so `ORDER BY inserted_at DESC` + `Enum.uniq_by(& &1.id)` returns the same logical row without the per-key in-memory merge across all matching parts. The slim MV already narrows the result to a page-sized set of ids, keeping the Elixir dedup small. Mirrors the pattern already used in `mark_test_case_runs_as_flaky`.

### `expire_stale_in_progress_test_runs/0` (server/lib/tuist/tests.ex)
`test_runs` was converted to `ReplacingMergeTree` by migration `20260114100000`, so FINAL is not a no-op. But the local EXPLAIN shows FINAL triggers `PrimaryKeyExpand` from 1/15 granules back to 15/15, defeating the `idx_status` set(3) skip index. Split into:
1. Candidate-id scan without FINAL — `idx_status` prunes to a single granule.
2. FINAL resolve step over the small id set — uses the `proj_by_id` projection ordered by `id`, and re-checks `status = 'in_progress'` and `inserted_at < cutoff` after the merge so runs that have already completed are filtered out.

### `test_runs_metrics/2` (server/lib/tuist/tests/analytics.ex)
Switched the count from `test_case_runs` (ORDER BY `(project_id, test_case_id, ran_at, id)` — `test_run_id` is only a bloom_filter) to the `test_case_runs_by_test_run` MV (ORDER BY `(test_run_id, ran_at, id)`). EXPLAIN confirms a PrimaryKey binary search on `test_run_id` (1/1 granule) versus the previous 24-part scan. `count(DISTINCT id)` handles the MV's `ReplacingMergeTree` duplicates without paying for FINAL.

## Local EXPLAIN deltas

| Pattern | Before | After |
|---|---|---|
| `expire_stale_in_progress_test_runs` candidate scan | 15/15 granules (PrimaryKeyExpand after FINAL) | 1/15 granules (idx_status) |
| `expire_stale_in_progress_test_runs` resolve step | n/a | FINAL constrained to candidate ids via proj_by_id |
| `test_runs_metrics` | 3/24 parts via project_id PK + bloom_filter | 1/1 granule via test_run_id PK |

`groupArrayLastMerge` (the flakiness monitor) is intentionally untouched — it is being investigated separately.

### How to test locally

1. `mise run clickhouse:start`
2. `mix test test/tuist/tests_test.exs:8533 test/tuist/tests/analytics_test.exs:206 test/tuist/tests_test.exs:660 test/tuist/tests_test.exs:873` — all 11 targeted tests pass.
3. Optionally re-run the EXPLAIN snippets above against your local `tuist_development` database to confirm the index-selection deltas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)