### PR TITLE
feat(infra): scale production bare-metal pool to 2 hosts

### DIFF
--- a/infra/k8s/clusters/cluster-production.yaml
+++ b/infra/k8s/clusters/cluster-production.yaml
@@ -116,6 +116,12 @@ spec:
         # bump `replicas:` here to grow capacity.
         - class: bare-metal-worker
           name: runners-linux
+          # Two pre-ordered AX162-R hosts (`tuist-bm-production-1` and
+          # `tuist-bm-production-2`) in FSN1. Each box hosts ~64 Kata-
+          # QEMU runner slots at the chart's 1 vCPU / 4 GB slot size;
+          # two boxes give ~128 runner slots + one host of HA headroom.
+          # Bump in lockstep with new Robot orders.
+          replicas: 2
           failureDomain: fsn1
           metadata:
             labels:


### PR DESCRIPTION
## Summary
- Sets \`replicas: 2\` on the production cluster's \`bare-metal-worker\` MachineDeployment so caph claims both pre-ordered AX162-R boxes.

## Context
Production has two boxes in Robot:

| Server | Name | Status |
|---|---|---|
| #3000872 | \`tuist-bm-production-1\` | Already claimed by production's MD (HBMM \`m8tb2-8mrp2\`), caph mid-installimage |
| #3001108 | \`tuist-bm-production-2\` | HBM exists with \`cluster=production\`, unclaimed — MD is at \`replicas: 1\` |

This bump makes the MD ask caph for the second host, which then walks its HBMM template's hostSelector (\`cluster=production\` after the patch in #10794) and matches \`bm-3001108\`.

## Capacity math
Per the chart comment on \`values-managed-production.yaml\`'s \`runnersFleetLinux\`: AX162-R at 1 vCPU / 4 GB slot sizing fits ~64 runner slots per host (\`96 threads / 1.5x headroom = 64\` and \`256 GB / 4 GB = 64\` — both ceilings land on the same number, by design). Two hosts → ~128 slots + one host of HA headroom if either box goes down.

## Test plan
- [ ] CI passes (only \`infra/k8s/clusters/**\` touched → \`mgmt-cluster-apply\` is the relevant workflow).
- [ ] On merge, \`mgmt-cluster-apply\` runs; the topology controller bumps the production bare-metal MD's \`replicas\` to 2; CAPI creates a second HBMM from the patched template.
- [ ] Verify: \`KUBECONFIG=~/.kube/tuist-mgmt.yaml kubectl get hbm -n org-tuist bm-3001108 -o jsonpath='{.spec.consumerRef.name}'\` returns a \`tuist-runners-linux-*\` HBMM name (production), not empty.
- [ ] Watch \`bm-3001108\` walk \`preparing → registering → image-installing → ensure-provisioned → provisioned → kubeadm-joined\` (~10-15 min on AX162-R).
- [ ] Confirm second Node joins the production workload cluster, labeled \`node.cluster.x-k8s.io/pool=runners-linux\`, tainted \`tuist.dev/runner-tier=bare-metal:NoSchedule\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)