### PR TITLE
feat(infra): NodeProviderIDFillReconciler — patch bare-metal Node providerID

### DIFF
--- a/infra/hetzner-robot-controller/AGENTS.md
+++ b/infra/hetzner-robot-controller/AGENTS.md
@@ -57,10 +57,22 @@ Robot webservice (https://robot.hetzner.com/api)
 │   │    and rootDeviceHints is empty:    │   │
 │   │    patch rootDeviceHints.raid.wwn   │   │
 │   └─────────────────────────────────────┘   │
+│   ┌─────────────────────────────────────┐   │
+│   │ NodeProviderIDFillReconciler        │   │
+│   │  - watches HetznerBareMetalHost     │   │
+│   │  - filters managed-by label         │   │
+│   │  - when state=provisioned + a       │   │
+│   │    consumerRef HBMM exists:         │   │
+│   │    look up workload kubeconfig,     │   │
+│   │    patch Node.spec.providerID to    │   │
+│   │    hcloud://bm-<server-number>      │   │
+│   └─────────────────────────────────────┘   │
 └────────────────────┬─────────────────────────┘
-                     │ creates / patches
+                     │ creates / patches CRs (mgmt)
+                     │ patches Nodes (workload)
                      ▼
        HetznerBareMetalHost CRs (caph claims these)
+       + workload-cluster Nodes (providerID set)
 ```
 
 ## Module layout
@@ -78,7 +90,9 @@ infra/hetzner-robot-controller/
 │   ├── hostdiscovery.go      # InventorySyncer Runnable
 │   ├── hostdiscovery_test.go
 │   ├── wwnfill.go            # WWNFillReconciler
-│   └── wwnfill_test.go
+│   ├── wwnfill_test.go
+│   ├── nodeproviderfill.go   # NodeProviderIDFillReconciler
+│   └── nodeproviderfill_test.go
 ├── internal/robot/
 │   └── client.go             # hrobot-go SDK wrapper + FakeClient
 └── config/rbac/role.yaml     # ClusterRole the chart binds

--- a/infra/hetzner-robot-controller/cmd/manager/main.go
+++ b/infra/hetzner-robot-controller/cmd/manager/main.go
@@ -140,6 +140,14 @@ func main() {
 		os.Exit(1)
 	}
 
+	if err := (&controllers.NodeProviderIDFillReconciler{
+		Client: mgr.GetClient(),
+		Scheme: mgr.GetScheme(),
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "setup NodeProviderIDFillReconciler")
+		os.Exit(1)
+	}
+
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
 		setupLog.Error(err, "set up health check")
 		os.Exit(1)

--- a/infra/hetzner-robot-controller/controllers/nodeproviderfill.go
+++ b/infra/hetzner-robot-controller/controllers/nodeproviderfill.go
@@ -1,0 +1,246 @@
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+// hetznerBareMetalMachineGVK is the caph HBMM resource. We read
+// it (not own it) to look up the cluster a host is bound to.
+var hetznerBareMetalMachineGVK = schema.GroupVersionKind{
+	Group:   "infrastructure.cluster.x-k8s.io",
+	Version: "v1beta1",
+	Kind:    "HetznerBareMetalMachine",
+}
+
+// NodeProviderIDFillReconciler patches `Node.spec.providerID` on
+// workload-cluster Nodes whose backing `HetznerBareMetalMachine`
+// has a providerID set.
+//
+// Why this exists: our `bare-metal.yaml` `joinConfiguration`
+// intentionally does NOT pass `--cloud-provider=external` because
+// there's no CCM that knows about Hetzner Robot bare-metal hosts —
+// setting the flag would add `node.cloudprovider.kubernetes.io/uninitialized:NoSchedule`,
+// which nothing would ever remove, blocking every Pod. The
+// downside is that the kubelet never sets `Node.spec.providerID`
+// itself, and CAPI's `noderef` controller can't match Machine to
+// Node by providerID — so `Machine.Status.NodeRef.Name` stays
+// empty forever and caph hot-loops at `actionProvisioned` with
+// `machine.Status.NodeRef.Name is empty`.
+//
+// caph's HetznerBareMetalMachineReconciler is supposed to patch
+// the Node's providerID itself but only does so when
+// `--cloud-provider=external` is set (per its source). With that
+// flag removed, nothing patches the Node, the deadlock persists.
+//
+// This reconciler closes the gap: once an HBM is `provisioned`
+// and has a `consumerRef`, we look up the HBMM (to find the
+// cluster name), load the workload kubeconfig from
+// `org-tuist/<cluster>-kubeconfig`, find the Node, and patch
+// `spec.providerID = hcloud://bm-<server-number>` if empty. CAPI
+// then matches Node→Machine, sets `NodeRef`, drops the
+// `node.cluster.x-k8s.io/uninitialized` taint, and caph stops
+// looping.
+//
+// Naming: caph rewrites the Robot panel name (and OS hostname)
+// to `bm-<HBMM-name>` during provisioning, and kubeadm-join
+// registers the Node with the OS hostname — so the Node name in
+// the workload cluster is `bm-` + HBMM name. We try that first
+// and fall back to the bare HBMM name in case the prefix
+// convention changes.
+type NodeProviderIDFillReconciler struct {
+	client.Client
+	Scheme *runtime.Scheme
+
+	// workloadClientFor builds a Kubernetes clientset against a
+	// workload cluster from a kubeconfig stored in a mgmt-cluster
+	// Secret. Pluggable so tests can stub it.
+	workloadClientFor func(kubeconfig []byte) (kubernetes.Interface, error)
+}
+
+// retryAfterNodeNotReady is how long we wait before re-checking
+// when the HBM is `provisioned` but its Node hasn't joined the
+// workload cluster yet (kubeadm-join still mid-flight, or kubelet
+// hasn't registered).
+const retryAfterNodeNotReady = 20 * time.Second
+
+func (r *NodeProviderIDFillReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx).WithValues("host", req.NamespacedName)
+
+	hbm := &unstructured.Unstructured{}
+	hbm.SetGroupVersionKind(hetznerBareMetalHostGVK)
+	if err := r.Get(ctx, req.NamespacedName, hbm); err != nil {
+		if apierrors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, fmt.Errorf("get host: %w", err)
+	}
+
+	// Only act on CRs we own (same posture as WWNFillReconciler).
+	if hbm.GetLabels()[ManagedByLabel] != ManagedByValue {
+		return ctrl.Result{}, nil
+	}
+
+	// Skip until caph reaches `provisioned`. Earlier states either
+	// haven't installimaged the host yet (no Node exists), or
+	// they're mid-flight and the Node, if it exists, isn't joined
+	// yet. The HBM transitions to `provisioned` only after kubeadm
+	// reports success — by that point the workload Node has
+	// already registered.
+	state, _, _ := unstructured.NestedString(hbm.Object, "spec", "status", "provisioningState")
+	if state != "provisioned" {
+		return ctrl.Result{}, nil
+	}
+
+	// `consumerRef` is set by caph when an HBMM claims this HBM.
+	// Without it we can't know which cluster the Node lives in.
+	consumerName, _, _ := unstructured.NestedString(hbm.Object, "spec", "consumerRef", "name")
+	if consumerName == "" {
+		return ctrl.Result{}, nil
+	}
+
+	// Server number comes from the label the InventorySyncer
+	// stamps at create time. This is the integer Robot ID; caph
+	// composes the providerID as `hcloud://bm-<n>` for bare-metal
+	// hosts, distinct from `hcloud://<n>` for hcloud VMs.
+	serverNumber := hbm.GetLabels()[ServerNumberLabel]
+	if serverNumber == "" {
+		logger.Info("host missing server-number label; cannot derive providerID", "name", req.Name)
+		return ctrl.Result{}, nil
+	}
+	wantProviderID := fmt.Sprintf("hcloud://bm-%s", serverNumber)
+
+	// HBMM holds `cluster.x-k8s.io/cluster-name` — that's how we
+	// know which workload cluster's API server to talk to.
+	hbmm := &unstructured.Unstructured{}
+	hbmm.SetGroupVersionKind(hetznerBareMetalMachineGVK)
+	if err := r.Get(ctx, types.NamespacedName{Namespace: hbm.GetNamespace(), Name: consumerName}, hbmm); err != nil {
+		if apierrors.IsNotFound(err) {
+			// HBMM disappeared between us reading the HBM and now.
+			// Caph will clear consumerRef next reconcile; just retry.
+			return ctrl.Result{RequeueAfter: retryAfterNodeNotReady}, nil
+		}
+		return ctrl.Result{}, fmt.Errorf("get HBMM: %w", err)
+	}
+	clusterName := hbmm.GetLabels()["cluster.x-k8s.io/cluster-name"]
+	if clusterName == "" {
+		logger.Info("HBMM missing cluster-name label; cannot find workload kubeconfig", "hbmm", consumerName)
+		return ctrl.Result{}, nil
+	}
+
+	// CAPI convention: workload kubeconfig lives in
+	// `<cluster-name>-kubeconfig` Secret, key `value`, in the
+	// same namespace as the Cluster CR.
+	secret := &corev1.Secret{}
+	if err := r.Get(ctx, types.NamespacedName{Namespace: hbm.GetNamespace(), Name: clusterName + "-kubeconfig"}, secret); err != nil {
+		if apierrors.IsNotFound(err) {
+			// Cluster control plane may still be coming up. Retry.
+			return ctrl.Result{RequeueAfter: retryAfterNodeNotReady}, nil
+		}
+		return ctrl.Result{}, fmt.Errorf("get workload kubeconfig secret: %w", err)
+	}
+	kubeconfigBytes := secret.Data["value"]
+	if len(kubeconfigBytes) == 0 {
+		logger.Info("workload kubeconfig secret has empty `value` key", "secret", clusterName+"-kubeconfig")
+		return ctrl.Result{RequeueAfter: retryAfterNodeNotReady}, nil
+	}
+
+	cs, err := r.buildWorkloadClient(kubeconfigBytes)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("build workload client: %w", err)
+	}
+
+	// Node name = `bm-<HBMM-name>` per caph's rename convention.
+	// Fall back to the bare HBMM name in case a future caph
+	// release stops adding the prefix.
+	candidates := []string{"bm-" + consumerName, consumerName}
+	var node *corev1.Node
+	for _, name := range candidates {
+		n, err := cs.CoreV1().Nodes().Get(ctx, name, metav1.GetOptions{})
+		if err == nil {
+			node = n
+			break
+		}
+		if !apierrors.IsNotFound(err) {
+			return ctrl.Result{}, fmt.Errorf("get workload Node %s: %w", name, err)
+		}
+	}
+	if node == nil {
+		// kubelet hasn't registered yet — common for the ~30s
+		// between caph marking `provisioned` and the Node
+		// actually being visible.
+		logger.V(1).Info("workload Node not found yet; will retry", "cluster", clusterName, "candidates", candidates)
+		return ctrl.Result{RequeueAfter: retryAfterNodeNotReady}, nil
+	}
+
+	// Idempotent: if providerID is already set, we're done. We
+	// only patch the empty case — never overwrite an existing
+	// value, even if it doesn't match what we'd derive.
+	if node.Spec.ProviderID != "" {
+		return ctrl.Result{}, nil
+	}
+
+	patch := []byte(fmt.Sprintf(`{"spec":{"providerID":%q}}`, wantProviderID))
+	if _, err := cs.CoreV1().Nodes().Patch(ctx, node.Name, types.MergePatchType, patch, metav1.PatchOptions{}); err != nil {
+		return ctrl.Result{}, fmt.Errorf("patch Node providerID: %w", err)
+	}
+	logger.Info("patched Node providerID",
+		"cluster", clusterName, "node", node.Name, "providerID", wantProviderID)
+	return ctrl.Result{}, nil
+}
+
+func (r *NodeProviderIDFillReconciler) buildWorkloadClient(kubeconfig []byte) (kubernetes.Interface, error) {
+	if r.workloadClientFor != nil {
+		return r.workloadClientFor(kubeconfig)
+	}
+	return defaultWorkloadClient(kubeconfig)
+}
+
+func defaultWorkloadClient(kubeconfig []byte) (kubernetes.Interface, error) {
+	cfg, err := clientcmd.NewClientConfigFromBytes(kubeconfig)
+	if err != nil {
+		return nil, fmt.Errorf("parse kubeconfig: %w", err)
+	}
+	rc, err := cfg.ClientConfig()
+	if err != nil {
+		return nil, fmt.Errorf("rest config from kubeconfig: %w", err)
+	}
+	return kubernetes.NewForConfig(rc)
+}
+
+// Compile-time assertion this signature matches rest.Config consumers.
+var _ = (*rest.Config)(nil)
+
+// SetupWithManager wires the reconciler. Predicate-filtered to
+// our own CRs so we don't get woken for hand-authored hosts (the
+// `managed-by` label scopes "what's mine").
+func (r *NodeProviderIDFillReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(hetznerBareMetalHostGVK)
+
+	managedByFilter := predicate.NewPredicateFuncs(func(o client.Object) bool {
+		return o.GetLabels()[ManagedByLabel] == ManagedByValue
+	})
+
+	return ctrl.NewControllerManagedBy(mgr).
+		Named("nodeproviderfill").
+		For(obj, builder.WithPredicates(managedByFilter)).
+		Complete(r)
+}

--- a/infra/hetzner-robot-controller/controllers/nodeproviderfill_test.go
+++ b/infra/hetzner-robot-controller/controllers/nodeproviderfill_test.go
@@ -1,0 +1,222 @@
+package controllers
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	apitypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// makeHostForProviderFill builds a managed HBM CR with the
+// labels + spec.status the reconciler reads (server-number
+// label, provisioningState, consumerRef).
+func makeHostForProviderFill(name, serverNumber, state, consumer string) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(hetznerBareMetalHostGVK)
+	obj.SetName(name)
+	obj.SetNamespace("org-tuist")
+	labels := map[string]string{ManagedByLabel: ManagedByValue}
+	if serverNumber != "" {
+		labels[ServerNumberLabel] = serverNumber
+	}
+	obj.SetLabels(labels)
+	if state != "" {
+		_ = unstructured.SetNestedField(obj.Object, state, "spec", "status", "provisioningState")
+	}
+	if consumer != "" {
+		_ = unstructured.SetNestedField(obj.Object, consumer, "spec", "consumerRef", "name")
+	}
+	return obj
+}
+
+// makeHBMM builds an HBMM CR with the cluster-name label the
+// reconciler reads to find the workload kubeconfig.
+func makeHBMM(name, clusterName string) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(hetznerBareMetalMachineGVK)
+	obj.SetName(name)
+	obj.SetNamespace("org-tuist")
+	obj.SetLabels(map[string]string{
+		"cluster.x-k8s.io/cluster-name": clusterName,
+	})
+	return obj
+}
+
+func makeKubeconfigSecret(clusterName string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      clusterName + "-kubeconfig",
+			Namespace: "org-tuist",
+		},
+		Data: map[string][]byte{"value": []byte("fake-kubeconfig-bytes")},
+	}
+}
+
+func runReconciler(
+	t *testing.T,
+	hbm *unstructured.Unstructured,
+	hbmm *unstructured.Unstructured,
+	secret *corev1.Secret,
+	workloadObjs ...runtime.Object,
+) (kubernetes.Interface, ctrl.Result, error) {
+	t.Helper()
+	builder := fake.NewClientBuilder().WithObjects(hbm)
+	if hbmm != nil {
+		builder = builder.WithObjects(hbmm)
+	}
+	if secret != nil {
+		builder = builder.WithObjects(secret)
+	}
+	cli := builder.Build()
+	cs := k8sfake.NewSimpleClientset(workloadObjs...)
+	r := &NodeProviderIDFillReconciler{
+		Client: cli, Scheme: cli.Scheme(),
+		workloadClientFor: func(_ []byte) (kubernetes.Interface, error) { return cs, nil },
+	}
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: apitypes.NamespacedName{Namespace: "org-tuist", Name: hbm.GetName()},
+	})
+	return cs, res, err
+}
+
+// nodeGotProviderID reads the Node back from the workload fake
+// client and returns its providerID (empty string if missing).
+func nodeGotProviderID(t *testing.T, cs kubernetes.Interface, name string) string {
+	t.Helper()
+	n, err := cs.CoreV1().Nodes().Get(context.Background(), name, metav1.GetOptions{})
+	if err != nil {
+		return ""
+	}
+	return n.Spec.ProviderID
+}
+
+func TestNodeProviderFill_PatchesEmptyProviderID(t *testing.T) {
+	hbm := makeHostForProviderFill("bm-2986829", "2986829", "provisioned", "tuist-staging-runners-linux-v5bcr-gwn8x-7mhgg")
+	hbmm := makeHBMM("tuist-staging-runners-linux-v5bcr-gwn8x-7mhgg", "tuist-staging")
+	secret := makeKubeconfigSecret("tuist-staging")
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "bm-tuist-staging-runners-linux-v5bcr-gwn8x-7mhgg"},
+		Spec:       corev1.NodeSpec{}, // empty providerID
+	}
+
+	cs, _, err := runReconciler(t, hbm, hbmm, secret, node)
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if got := nodeGotProviderID(t, cs, node.Name); got != "hcloud://bm-2986829" {
+		t.Errorf("providerID = %q, want %q", got, "hcloud://bm-2986829")
+	}
+}
+
+func TestNodeProviderFill_LeavesExistingProviderIDAlone(t *testing.T) {
+	hbm := makeHostForProviderFill("bm-1", "1", "provisioned", "tuist-staging-runners-linux-v5bcr-gwn8x-7mhgg")
+	hbmm := makeHBMM("tuist-staging-runners-linux-v5bcr-gwn8x-7mhgg", "tuist-staging")
+	secret := makeKubeconfigSecret("tuist-staging")
+	// Different (or stale) value — reconciler must NOT overwrite.
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "bm-tuist-staging-runners-linux-v5bcr-gwn8x-7mhgg"},
+		Spec:       corev1.NodeSpec{ProviderID: "hcloud://bm-9999"},
+	}
+
+	cs, _, err := runReconciler(t, hbm, hbmm, secret, node)
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if got := nodeGotProviderID(t, cs, node.Name); got != "hcloud://bm-9999" {
+		t.Errorf("providerID changed unexpectedly: got %q, want %q", got, "hcloud://bm-9999")
+	}
+}
+
+func TestNodeProviderFill_FallsBackToBareHBMMNameIfPrefixedNotFound(t *testing.T) {
+	hbm := makeHostForProviderFill("bm-1", "1", "provisioned", "consumer-x")
+	hbmm := makeHBMM("consumer-x", "tuist-canary")
+	secret := makeKubeconfigSecret("tuist-canary")
+	// Node registered WITHOUT the `bm-` prefix — e.g. a future
+	// caph release that drops the convention.
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "consumer-x"},
+	}
+
+	cs, _, err := runReconciler(t, hbm, hbmm, secret, node)
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if got := nodeGotProviderID(t, cs, node.Name); got != "hcloud://bm-1" {
+		t.Errorf("providerID = %q, want %q", got, "hcloud://bm-1")
+	}
+}
+
+func TestNodeProviderFill_RequeuesWhenNodeNotYetJoined(t *testing.T) {
+	hbm := makeHostForProviderFill("bm-1", "1", "provisioned", "consumer-x")
+	hbmm := makeHBMM("consumer-x", "tuist-canary")
+	secret := makeKubeconfigSecret("tuist-canary")
+	// No workload Nodes — kubelet hasn't registered yet.
+
+	_, res, err := runReconciler(t, hbm, hbmm, secret)
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if res.RequeueAfter == 0 {
+		t.Errorf("expected RequeueAfter > 0 when Node not joined, got %v", res.RequeueAfter)
+	}
+}
+
+func TestNodeProviderFill_SkipsUntilProvisioned(t *testing.T) {
+	// `image-installing` is mid-state — reconciler should no-op.
+	hbm := makeHostForProviderFill("bm-1", "1", "image-installing", "consumer-x")
+	hbmm := makeHBMM("consumer-x", "tuist-canary")
+	secret := makeKubeconfigSecret("tuist-canary")
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "bm-consumer-x"},
+	}
+
+	cs, _, err := runReconciler(t, hbm, hbmm, secret, node)
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if got := nodeGotProviderID(t, cs, "bm-consumer-x"); got != "" {
+		t.Errorf("reconciler patched Node before HBM reached provisioned state: providerID=%q", got)
+	}
+}
+
+func TestNodeProviderFill_SkipsWithoutConsumerRef(t *testing.T) {
+	hbm := makeHostForProviderFill("bm-1", "1", "provisioned", "")
+	// No HBMM, no Secret, no workload Node — reconciler shouldn't try.
+
+	_, _, err := runReconciler(t, hbm, nil, nil)
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+}
+
+func TestNodeProviderFill_IgnoresHandAuthoredHBMs(t *testing.T) {
+	// Same as the WWN reconciler — managed-by gate keeps us from
+	// touching CRs an operator wrote by hand.
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(hetznerBareMetalHostGVK)
+	obj.SetName("hand-authored")
+	obj.SetNamespace("org-tuist")
+	// NO managed-by label.
+	_ = unstructured.SetNestedField(obj.Object, "provisioned", "spec", "status", "provisioningState")
+	_ = unstructured.SetNestedField(obj.Object, "consumer-x", "spec", "consumerRef", "name")
+
+	hbmm := makeHBMM("consumer-x", "tuist-canary")
+	secret := makeKubeconfigSecret("tuist-canary")
+	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "bm-consumer-x"}}
+
+	cs, _, err := runReconciler(t, obj, hbmm, secret, node)
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if got := nodeGotProviderID(t, cs, "bm-consumer-x"); got != "" {
+		t.Errorf("reconciler touched a hand-authored HBM's Node: providerID=%q", got)
+	}
+}

--- a/infra/k8s/mgmt/hetzner-robot-controller.yaml
+++ b/infra/k8s/mgmt/hetzner-robot-controller.yaml
@@ -46,6 +46,18 @@ rules:
   - apiGroups: ["infrastructure.cluster.x-k8s.io"]
     resources: ["hetznerbaremetalhosts/status"]
     verbs: ["get", "list", "watch"]
+  # NodeProviderIDFillReconciler reads the HBM's consumer HBMM
+  # to find the workload cluster name, then reads that cluster's
+  # kubeconfig Secret in `org-tuist` to patch the workload Node's
+  # providerID. The Node patch itself happens against the workload
+  # API server with its own credentials (loaded from the Secret),
+  # so no Node-level RBAC is needed here.
+  - apiGroups: ["infrastructure.cluster.x-k8s.io"]
+    resources: ["hetznerbaremetalmachines"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch"]
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]


### PR DESCRIPTION
## Summary
- New reconciler in \`hetzner-robot-controller\` that patches \`Node.spec.providerID\` on workload-cluster bare-metal Nodes once their HBM reaches \`provisioned\`. Closes the gap that was hot-looping caph and blocking every bare-metal Node from becoming usable.

## Background
Observed live this afternoon during the canary/production rollout (see PR #10794 thread).

\`bare-metal.yaml\` \`joinConfiguration\` drops \`--cloud-provider=external\` deliberately — there's no CCM for Hetzner Robot bare-metal hosts, and setting the flag would add the \`node.cloudprovider.kubernetes.io/uninitialized:NoSchedule\` taint that nothing would ever remove. Side effect: the kubelet never sets \`Node.spec.providerID\` itself, and caph's HetznerBareMetalMachineReconciler skips its own providerID patch when the cloud-provider flag isn't external. So nothing patches the Node.

Consequence: CAPI's \`noderef\` controller can't match Machine→Node by providerID, \`Machine.Status.NodeRef.Name\` stays empty, and caph hot-loops at \`actionProvisioned\`:

\`\`\`
ERROR  hbm=bm-2986829  hbmm=...  machine.Status.NodeRef.Name is empty
\`\`\`

…many times per second, starving the whole reconcile queue. Other HBMs (canary, production) never get their turn, and the staging Node's \`node.cluster.x-k8s.io/uninitialized\` taint never clears, blocking every Pod that doesn't explicitly tolerate it.

## What this PR does
Adds \`NodeProviderIDFillReconciler\` next to \`WWNFillReconciler\` in the same Go package, watching the same CRD with the same predicate (\`managed-by=hetzner-robot-controller\`):

1. When an HBM is \`provisioned\` and has a \`consumerRef\`, read the HBMM to find \`cluster.x-k8s.io/cluster-name\`.
2. Read the workload kubeconfig from the CAPI-standard \`<cluster-name>-kubeconfig\` Secret in \`org-tuist\`.
3. Build a client-go \`Clientset\` against the workload API, look up the Node by name (caph renames Robot server + sets OS hostname to \`bm-<HBMM-name>\`; falls back to bare HBMM name in case a future caph release drops the prefix).
4. If \`Node.spec.providerID\` is empty, patch it to \`hcloud://bm-<server-number>\` (the format caph composes for bare-metal). Idempotent — never overwrites an existing value.

\`workloadClientFor\` is a pluggable factory for tests; production uses \`clientcmd.NewClientConfigFromBytes\` + \`kubernetes.NewForConfig\`.

## RBAC
Two read-only additions in \`hetzner-robot-controller.yaml\`:
- \`hetznerbaremetalmachines\` (get/list/watch) — for the cluster-name label
- \`secrets\` (get/list/watch) — for the workload kubeconfig

Node patches happen against the workload API with its own credentials (from the kubeconfig), so no Node-level RBAC needed on the mgmt cluster.

## Tests
7 new cases in \`nodeproviderfill_test.go\`:
- Patches empty providerID with the right value
- Leaves an existing (even mismatched) providerID alone — idempotent
- Falls back to bare HBMM name when the \`bm-\` prefix lookup misses
- Requeues when the Node hasn't joined the workload cluster yet
- Skips while HBM is still in \`image-installing\` (any pre-\`provisioned\` state)
- Skips when \`consumerRef\` isn't set
- Ignores hand-authored HBMs (no managed-by label)

\`go test ./... \` passes.

## Test plan
- [ ] CI green — image-build workflow produces \`sha-<merge-commit>\` automatically.
- [ ] After merge, bump the image SHA pin in \`infra/k8s/mgmt/hetzner-robot-controller.yaml\` (follow-up small PR, same pattern as #10880).
- [ ] On rollout, verify with: \`kubectl -n caph-system logs deploy/caph-controller-manager --since=5m | grep -c "NodeRef.Name is empty"\` — should be 0.
- [ ] When a new bare-metal Node joins, confirm it gets \`providerID\` set automatically: \`KUBECONFIG=~/.kube/tuist-<env>.yaml kubectl get node bm-<…> -o jsonpath='{.spec.providerID}'\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)