### PR TITLE
fix(infra): bump hetzner-robot-controller image to post-NodeProviderIDFiller build

### DIFF
--- a/infra/k8s/mgmt/hetzner-robot-controller.yaml
+++ b/infra/k8s/mgmt/hetzner-robot-controller.yaml
@@ -127,7 +127,7 @@ spec:
           # for the first time, the bump-chart-image-pins step
           # rewrites this line to a semver tag (`0.1.0`, `0.2.0`,
           # …) and from there it's owned by the release pipeline.
-          image: ghcr.io/tuist/tuist-hetzner-robot-controller:sha-59deca403dc9
+          image: ghcr.io/tuist/tuist-hetzner-robot-controller:sha-9f91ba2bd8f8
           imagePullPolicy: IfNotPresent
           args:
             - --leader-elect=true


### PR DESCRIPTION
## Summary
- Bumps the controller image pin from \`sha-59deca403dc9\` → \`sha-9f91ba2bd8f8\` so the running binary matches the manifest after #10883.

## Why
#10883 added \`NodeProviderIDFillReconciler\` to the Go binary AND wired it in \`cmd/manager/main.go\`. The manifest itself didn't change in that PR (only RBAC). So the image-pin still references the pre-#10883 build, and rolling the deployment now would run the OLD binary that has no NodeProviderIDFiller — the new feature would be DOA until this PR lands.

Same pattern as #10880.

## Test plan
- [ ] CI green.
- [ ] On merge, \`mgmt-cluster-apply\` rolls the deployment; new pod starts with image \`sha-9f91ba2bd8f8\`.
- [ ] Verify the new reconciler is active: \`KUBECONFIG=~/.kube/tuist-mgmt.yaml kubectl logs -n org-tuist deployment/hetzner-robot-controller | grep -i nodeprovider\` returns startup logs from \`NodeProviderIDFillReconciler\`.
- [ ] When the canary + production bare-metal Nodes finish provisioning (next ~10 min), confirm the reconciler patches their \`Node.spec.providerID\` automatically: \`KUBECONFIG=~/.kube/tuist-canary.yaml kubectl get node -l node.cluster.x-k8s.io/pool=runners-linux -o jsonpath='{range .items[*]}{.metadata.name}{": "}{.spec.providerID}{"\\n"}{end}'\` — should be non-empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)