### PR TITLE
fix(infra): detect bare-metal NIC name dynamically in postInstallScript

### DIFF
--- a/infra/k8s/clusters/bare-metal.yaml
+++ b/infra/k8s/clusters/bare-metal.yaml
@@ -166,11 +166,25 @@ spec:
           # box ends up unreachable post-install. Augment with a
           # higher-priority netplan drop-in (netplan merges in
           # alphabetical order, 99 wins).
-          cat > /etc/netplan/99-tuist-disable-dhcp6.yaml <<'NETPLAN'
+          #
+          # Detect the primary interface name from Hetzner's
+          # installimage-written `01-netcfg.yaml` rather than
+          # hardcoding it. AX42-U boxes use `enp3s0`, AX162-R
+          # (EPYC 9454P) uses a different name — hardcoding broke
+          # provisioning on production. The awk picks the first
+          # `ethernets:` child, which is the single Hetzner-
+          # configured uplink across every AX-class box we use.
+          PRIMARY_NIC=$(awk '/^[[:space:]]+ethernets:[[:space:]]*$/{flag=1; next} flag && /^[[:space:]]+[a-z0-9]+:[[:space:]]*$/{gsub(":","",$1); print $1; exit}' /etc/netplan/01-netcfg.yaml)
+          if [ -z "$PRIMARY_NIC" ]; then
+            echo "FATAL: could not detect primary NIC from /etc/netplan/01-netcfg.yaml" >&2
+            cat /etc/netplan/01-netcfg.yaml >&2
+            exit 1
+          fi
+          cat > /etc/netplan/99-tuist-disable-dhcp6.yaml <<NETPLAN
           network:
             version: 2
             ethernets:
-              enp3s0:
+              $PRIMARY_NIC:
                 dhcp6: false
                 accept-ra: false
           NETPLAN


### PR DESCRIPTION
## Summary
- Replaces the hardcoded \`enp3s0\` interface name in \`bare-metal.yaml\`'s netplan \`99-tuist-disable-dhcp6.yaml\` drop-in with an awk parse of Hetzner's installimage-written \`01-netcfg.yaml\`.

## What broke
Both production AX162-Rs (\`tuist-bm-production-1\` / \`-2\`, ordered today) completed installimage successfully but came up unreachable after caph's post-install reboot. SSH timed out on port 22 for both.

Root cause: AX42-U (staging) has its uplink at \`enp3s0\`. AX162-R (EPYC 9454P) uses a different name due to a different PCI topology. Our \`99-tuist-disable-dhcp6.yaml\` drop-in hardcoded \`enp3s0\`, so on AX162-R it targeted a non-existent interface. Result:

- The real NIC retained kernel-default DHCPv6.
- networkd in Ubuntu 24.04 tries DHCPv6 implicitly when the interface has an IPv6 address (as Hetzner's \`01-netcfg.yaml\` configures it to).
- DHCPv6 client fails (Hetzner's network has no DHCPv6 server). networkd marks the interface Failed.
- Static IPv4 from \`01-netcfg.yaml\` never binds.
- Box is off the network. caph reports \`ssh timeout error - server has not restarted yet\`.

## The fix
Parse the installimage-generated \`/etc/netplan/01-netcfg.yaml\` to extract the actual NIC name, then write the disable-DHCPv6 drop-in against that name. Awk picks the first key under \`ethernets:\` — Hetzner only configures one uplink per AX-class box, so first-match is unambiguous.

Smoke-tested the awk on the live AX42-U (\`bm-tuist-staging-runners-linux-v5bcr-gwn8x-7mhgg\`):

\`\`\`
$ awk '/^[[:space:]]+ethernets:[[:space:]]*$/{flag=1; next} flag && /^[[:space:]]+[a-z0-9]+:[[:space:]]*$/{gsub(":","",$1); print $1; exit}' /etc/netplan/01-netcfg.yaml
enp3s0
\`\`\`

Returns the right name on AX42-U today (matches the hardcode), and will return whatever the AX162-R kernel names its uplink once a fresh installimage runs there.

Also adds a fail-fast guard: if the awk yields nothing, the script exits with the file dumped to stderr so caph surfaces the failure mode in events.

## Post-merge action
The two stuck AX162-Rs need a fresh installimage cycle to pick up the new script:

\`\`\`bash
export KUBECONFIG=~/.kube/tuist-mgmt.yaml
for hbm in bm-3000872 bm-3001108; do
  # Delete the chain (Machine + HBMM + HBM). MD recreates from the
  # current template, hetzner-robot-controller re-creates the HBM,
  # caph runs the full rescue+installimage cycle with the fixed script.
  MACHINE=$(kubectl get hetznerbaremetalhost -n org-tuist $hbm -o jsonpath='{.spec.consumerRef.name}')
  kubectl delete machine -n org-tuist $MACHINE --wait=false
  kubectl delete hetznerbaremetalmachine -n org-tuist $MACHINE --wait=false
  kubectl delete hetznerbaremetalhost -n org-tuist $hbm --wait=false
done
\`\`\`

10-15 min later both boxes should walk through provisioning cleanly and join the production workload cluster.

## Test plan
- [ ] CI green.
- [ ] After merge, the apply step in \`mgmt-cluster-apply\` updates the bare-metal substrate. CAPI clones the new template; staging keeps using its existing snapshot (no churn there).
- [ ] Delete production's HBM chain (commands above) to trigger fresh installimage.
- [ ] Verify the new boxes come up reachable + caph completes \`provisioned\` + the new \`NodeProviderIDFiller\` patches their providerIDs automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)