### PR TITLE
fix(infra): discover bare-metal envs from CAPI Cluster CRs

### DIFF
--- a/infra/hetzner-robot-controller/AGENTS.md
+++ b/infra/hetzner-robot-controller/AGENTS.md
@@ -148,17 +148,26 @@ get hetznerbaremetalhost` shows them in numerical order.
 ## Per-cluster partitioning
 
 The Robot account is shared across `staging`, `canary`, `production`,
-and any future CAPI clusters. `--clusters=staging,canary,production`
-turns on cluster gating: a Robot server is included in inventory only
-if its name parses to one of those values via either of:
+and any future CAPI clusters. The controller discovers which envs
+exist by listing CAPI `Cluster` CRs in `org-tuist` and reading each
+one's `spec.topology.variables[name=bareMetalCluster].value` — that
+value is the env's short label (`staging`, `canary`, `production`).
 
-- `tuist-bm-<cluster>-…` — operator's name in the Robot panel.
-- `tuist-<cluster>-…` — caph rewrites the name to the
-  `HetznerBareMetalMachine` name during provisioning; that's
-  `<clusterName>-<deploymentName>-…` per CAPI templating.
+A Robot server is included in inventory only if its name parses to
+one of those envs via either of:
 
-The matched cluster gets stamped on the HBM as `tuist.dev/cluster`,
-and each env's `HetznerBareMetalMachineTemplate.spec.template.spec.hostSelector`
+- `tuist-bm-<envLabel>-…` — operator's name in the Robot panel.
+- `bm-<clusterCRName>-…` — caph rewrites the Robot server name to
+  `bm-<HBMM-name>` during provisioning; HBMMs are CAPI-templated as
+  `<clusterCRName>-<deploymentName>-…`. Note `clusterCRName` is the
+  Cluster CR's `metadata.name` — which doesn't always follow the
+  `tuist-<env>` convention (production's CR is just `tuist`).
+
+Longest-prefix wins so a short Cluster name like `tuist` (production)
+can't accidentally swallow `tuist-staging`-prefixed servers.
+
+The matched env gets stamped on the HBM as `tuist.dev/cluster`, and
+each env's `HetznerBareMetalMachineTemplate.spec.template.spec.hostSelector`
 filters on it:
 
 ```yaml
@@ -169,9 +178,9 @@ hostSelector:
 ```
 
 Existing CRs that pre-date the label get back-filled on the next sync
-based on `robot.hetzner.com/server-name`. Empty `--clusters` disables
-the gate entirely (legacy single-env mode) — production should always
-set the flag.
+based on `robot.hetzner.com/server-name`. If no Cluster CR sets
+`bareMetalCluster`, the gate is off and the controller falls back to
+the legacy `--name-prefix` filter (single-env mode).
 
 ## Cascade safety on deletion
 

--- a/infra/hetzner-robot-controller/cmd/manager/main.go
+++ b/infra/hetzner-robot-controller/cmd/manager/main.go
@@ -17,7 +17,6 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"strings"
 	"time"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -51,7 +50,6 @@ func main() {
 
 		hostNamespace string
 		namePrefix    string
-		clustersFlag  string
 		pollInterval  time.Duration
 
 		robotUserPath string
@@ -70,14 +68,6 @@ func main() {
 		envOrDefault("HRC_NAME_PREFIX", "tuist-bm-"),
 		"Robot servers whose name starts with this are managed by this controller. "+
 			"Servers outside the prefix are ignored on both creation and deletion.")
-	flag.StringVar(&clustersFlag, "clusters",
-		envOrDefault("HRC_CLUSTERS", ""),
-		"Comma-separated list of CAPI cluster names that share this Robot account "+
-			"(e.g. `staging,canary,production`). A Robot server is included in inventory "+
-			"only if its name matches `tuist-bm-<cluster>-...` or `tuist-<cluster>-...` "+
-			"(the caph-rewritten shape) for one of these clusters; the match is stamped "+
-			"on the HBM as `tuist.dev/cluster=<cluster>` so each env's HBMM hostSelector "+
-			"can scope itself. Empty disables cluster gating (legacy single-env mode).")
 	flag.DurationVar(&pollInterval, "poll-interval", 60*time.Second,
 		"How often to poll Robot for inventory changes. Hardware procurement is "+
 			"human-paced — short intervals just add load without speeding anything up.")
@@ -124,7 +114,6 @@ func main() {
 		Robot:        robotClient,
 		Namespace:    hostNamespace,
 		NamePrefix:   namePrefix,
-		Clusters:     parseClusters(clustersFlag),
 		PollInterval: pollInterval,
 	}
 	if err := mgr.Add(syncer); err != nil {
@@ -158,8 +147,7 @@ func main() {
 	}
 
 	setupLog.Info("starting manager",
-		"namespace", hostNamespace, "prefix", namePrefix,
-		"clusters", parseClusters(clustersFlag), "interval", pollInterval)
+		"namespace", hostNamespace, "prefix", namePrefix, "interval", pollInterval)
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
 		setupLog.Error(err, "manager exited")
 		os.Exit(1)
@@ -171,23 +159,6 @@ func envOrDefault(key, fallback string) string {
 		return v
 	}
 	return fallback
-}
-
-// parseClusters splits the comma-separated `--clusters` flag
-// into a clean slice. Empty input yields nil (legacy single-env
-// mode — no cluster gating, no label stamping).
-func parseClusters(s string) []string {
-	if s == "" {
-		return nil
-	}
-	parts := strings.Split(s, ",")
-	out := make([]string, 0, len(parts))
-	for _, p := range parts {
-		if p = strings.TrimSpace(p); p != "" {
-			out = append(out, p)
-		}
-	}
-	return out
 }
 
 // trimNewline strips a single trailing newline if present.

--- a/infra/hetzner-robot-controller/controllers/hostdiscovery.go
+++ b/infra/hetzner-robot-controller/controllers/hostdiscovery.go
@@ -99,20 +99,30 @@ type InventorySyncer struct {
 	// CR) and for deletion (we won't touch their CRs).
 	NamePrefix string
 
-	// Clusters partitions a shared Robot account across CAPI
-	// clusters. A Robot server is included in inventory only if
-	// its name matches `tuist-bm-{cluster}-...` (operator-named)
-	// or `tuist-{cluster}-...` (caph-renamed during provisioning),
-	// where `{cluster}` is one of these values. The matched value
-	// is stamped on the HBM as `tuist.dev/cluster=<cluster>` so
-	// each env's HBMM `hostSelector` can scope itself.
-	//
-	// Empty list = legacy single-env mode: no gating, no cluster
-	// label stamped. Production should always set this.
-	Clusters []string
-
 	// PollInterval between Robot list calls. Default 60s.
 	PollInterval time.Duration
+}
+
+// clusterEnv pairs the CAPI Cluster CR's `metadata.name` with the
+// short env label its `bareMetalCluster` topology variable sets.
+// Two names exist because they don't always match: production's
+// Cluster CR is just `tuist` while its env label is `production`.
+// We need both — the Cluster CR name matches caph's mid-
+// provisioning Robot rename (`bm-<clusterName>-...`), while the
+// env label matches the operator's `tuist-bm-<env>-N` convention
+// and is what gets stamped on the HBM for HBMM hostSelectors.
+type clusterEnv struct {
+	clusterName string // e.g. "tuist", "tuist-staging"
+	envLabel    string // e.g. "production", "staging"
+}
+
+// capiClusterGVK is the upstream CAPI Cluster CRD we list to
+// discover envs. Unstructured access so we don't pull in the
+// full CAPI v1beta types just to read two fields.
+var capiClusterGVK = schema.GroupVersionKind{
+	Group:   "cluster.x-k8s.io",
+	Version: "v1beta1",
+	Kind:    "Cluster",
 }
 
 // NeedLeaderElection makes the manager only run this on the
@@ -181,33 +191,49 @@ func (s *InventorySyncer) sync(ctx context.Context) error {
 		return fmt.Errorf("list robot servers: %w", err)
 	}
 
+	// Read the Cluster CRs every sync to discover which envs share
+	// the Robot account. Source of truth is each Cluster's
+	// `spec.topology.variables[name=bareMetalCluster]`. An empty
+	// list means "no bare-metal-enabled clusters in this
+	// namespace" — gate stays off and the controller falls back to
+	// pure-prefix matching (legacy single-env behaviour).
+	envs, err := s.discoverClusterEnvs(ctx)
+	if err != nil {
+		return fmt.Errorf("discover cluster envs: %w", err)
+	}
+
 	// `eligibleForCreation` — name prefix matches AND not cancelled.
 	// `liveServerNumbers` — every non-cancelled server in the account,
 	// regardless of name. Used for the deletion gate so caph's rename
 	// doesn't cause us to reap a live host.
-	// `clusterByName` — the cluster derived from the server name (if
+	// `clusterByName` — the env derived from the server name (if
 	// any). Cached here so we can stamp it on creation AND back-fill
 	// it on existing CRs without re-parsing inside two separate loops.
 	eligibleForCreation := map[string]robot.Server{} // CR name → server
-	clusterByName := map[string]string{}             // CR name → cluster (may be "")
+	clusterByName := map[string]string{}             // CR name → env (may be "")
 	liveServerNumbers := map[int]struct{}{}
 	for _, srv := range servers {
 		if srv.Cancelled {
 			continue
 		}
 		liveServerNumbers[srv.Number] = struct{}{}
-		if !strings.HasPrefix(srv.Name, s.NamePrefix) {
-			continue
-		}
-		cluster := clusterFromServerName(srv.Name, s.Clusters)
-		// Cluster gating: when `--clusters` is configured, only
-		// servers whose name parses to one of them get a CR. This
-		// is what keeps a shared Robot account from cross-claiming
-		// across envs after `NamePrefix` got widened past
-		// `tuist-bm-` to accommodate caph's mid-provisioning name
-		// rewrite (e.g. `tuist-staging-runners-linux-…`).
-		if len(s.Clusters) > 0 && cluster == "" {
-			continue
+		cluster := clusterFromServerName(srv.Name, envs)
+		// When at least one Cluster CR has `bareMetalCluster`
+		// set, the cluster-gate is the source of truth and
+		// supersedes `NamePrefix` — only servers whose name
+		// parses to one of those envs get a CR. The
+		// `NamePrefix` flag stays around as a legacy fallback
+		// for single-env clusters that haven't migrated yet
+		// (e.g. a brand-new workload cluster bootstrapping
+		// before its topology variables land).
+		if len(envs) > 0 {
+			if cluster == "" {
+				continue
+			}
+		} else {
+			if !strings.HasPrefix(srv.Name, s.NamePrefix) {
+				continue
+			}
 		}
 		name := crNameForServer(srv.Number)
 		eligibleForCreation[name] = srv
@@ -253,13 +279,13 @@ func (s *InventorySyncer) sync(ctx context.Context) error {
 	// would never gain the label and caph hostSelector wouldn't
 	// claim them after an env adopts the per-cluster gate.
 	backfilledCount := 0
-	if len(s.Clusters) > 0 {
+	if len(envs) > 0 {
 		for name, obj := range owned {
 			if obj.GetLabels()[ClusterLabel] != "" {
 				continue
 			}
 			robotName := obj.GetLabels()[ServerNameLabel]
-			cluster := clusterFromServerName(robotName, s.Clusters)
+			cluster := clusterFromServerName(robotName, envs)
 			if cluster == "" {
 				continue
 			}
@@ -321,38 +347,81 @@ func (s *InventorySyncer) sync(ctx context.Context) error {
 	return nil
 }
 
-// clusterFromServerName returns which of the configured clusters
-// a Robot server name belongs to, or "" if none match. Accepts
-// both shapes the controller sees in practice:
+// discoverClusterEnvs lists CAPI Cluster CRs in `namespace` and
+// builds the (clusterName, envLabel) mapping from each Cluster's
+// `spec.topology.variables[name=bareMetalCluster].value`.
 //
-//   - `tuist-bm-<cluster>-<n>` — the operator's name in the
-//     Robot panel.
-//   - `tuist-<cluster>-...` — caph rewrites the server name to
-//     the HetznerBareMetalMachine name during provisioning, which
-//     CAPI templates as `<clusterName>-<deploymentName>-…`. The
-//     cluster name is the first segment after `tuist-`.
+// Clusters without that variable are skipped — they don't use the
+// bare-metal worker pool, so they don't need a partition in the
+// shared Robot account. Returning an empty list is the correct
+// outcome for clusters that don't enable bare-metal at all (e.g.
+// Kura-only regional clusters).
+func (s *InventorySyncer) discoverClusterEnvs(ctx context.Context) ([]clusterEnv, error) {
+	list := &unstructured.UnstructuredList{}
+	list.SetGroupVersionKind(capiClusterGVK)
+	if err := s.Client.List(ctx, list, client.InNamespace(s.Namespace)); err != nil {
+		return nil, fmt.Errorf("list capi clusters: %w", err)
+	}
+	out := make([]clusterEnv, 0, len(list.Items))
+	for i := range list.Items {
+		cl := &list.Items[i]
+		vars, _, _ := unstructured.NestedSlice(cl.Object, "spec", "topology", "variables")
+		for _, v := range vars {
+			vm, ok := v.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			if vm["name"] != "bareMetalCluster" {
+				continue
+			}
+			env, _ := vm["value"].(string)
+			if env == "" {
+				continue
+			}
+			out = append(out, clusterEnv{clusterName: cl.GetName(), envLabel: env})
+			break
+		}
+	}
+	return out, nil
+}
+
+// clusterFromServerName returns which env a Robot server name
+// belongs to, or "" if none match. Accepts both shapes the
+// controller sees in practice:
 //
-// Cluster names are matched as literal prefixes (with a trailing
-// `-` to avoid `production` accidentally matching `prod`).
-// Longest match wins so `production-us-east` takes precedence
-// over `production`.
-func clusterFromServerName(name string, clusters []string) string {
-	// Try `tuist-bm-<cluster>-` first (operator-named original).
-	// Then `tuist-<cluster>-` (caph-renamed). Take the longest
-	// matching cluster so multi-segment names like
-	// `production-us-east` aren't shadowed by `production`.
-	best := ""
-	for _, c := range clusters {
-		if c == "" {
+//   - `tuist-bm-<env>-<n>` — the operator's name in the Robot
+//     panel. `<env>` is the short label (`staging`, `canary`,
+//     `production`).
+//   - `bm-<clusterName>-...` — caph rewrites the server name to
+//     `bm-<HBMM-name>` during provisioning; HBMMs are CAPI-
+//     templated as `<clusterName>-<deploymentName>-…`, so the
+//     prefix after the leading `bm-` is the Cluster CR name.
+//     This matters because the Cluster CR name doesn't always
+//     follow the `tuist-<env>` convention — production's Cluster
+//     CR is just `tuist`, while its env label is `production`.
+//
+// Longest prefix wins, so `tuist-staging` beats `tuist`
+// (production's short Cluster name) on a server like
+// `bm-tuist-staging-runners-linux-…`.
+func clusterFromServerName(name string, envs []clusterEnv) string {
+	bestLen := 0
+	bestEnv := ""
+	for _, e := range envs {
+		if e.envLabel == "" {
 			continue
 		}
-		for _, prefix := range []string{"tuist-bm-" + c + "-", "tuist-" + c + "-"} {
-			if strings.HasPrefix(name, prefix) && len(c) > len(best) {
-				best = c
+		candidates := []string{
+			"tuist-bm-" + e.envLabel + "-",
+			"bm-" + e.clusterName + "-",
+		}
+		for _, p := range candidates {
+			if strings.HasPrefix(name, p) && len(p) > bestLen {
+				bestLen = len(p)
+				bestEnv = e.envLabel
 			}
 		}
 	}
-	return best
+	return bestEnv
 }
 
 // serverNumberFromCR reads the Robot server number from the

--- a/infra/hetzner-robot-controller/controllers/hostdiscovery_test.go
+++ b/infra/hetzner-robot-controller/controllers/hostdiscovery_test.go
@@ -40,6 +40,23 @@ func newSyncer(t *testing.T, servers []robot.Server, existing ...*unstructured.U
 	}
 }
 
+// makeClusterCR builds a fake CAPI Cluster CR with a single
+// `bareMetalCluster` topology variable. discoverClusterEnvs reads
+// these to figure out the (clusterName, envLabel) mapping.
+func makeClusterCR(name, envLabel string) *unstructured.Unstructured {
+	cl := &unstructured.Unstructured{}
+	cl.SetGroupVersionKind(capiClusterGVK)
+	cl.SetName(name)
+	cl.SetNamespace("org-tuist")
+	_ = unstructured.SetNestedSlice(cl.Object, []interface{}{
+		map[string]interface{}{
+			"name":  "bareMetalCluster",
+			"value": envLabel,
+		},
+	}, "spec", "topology", "variables")
+	return cl
+}
+
 // makeHost builds a HetznerBareMetalHost CR with the controller's
 // managed-by label and the given server-number label, optionally
 // with a `consumerRef` to simulate caph having claimed it.
@@ -309,28 +326,37 @@ func TestSyncer_RespectsContext(t *testing.T) {
 var _ = types.NamespacedName{}
 
 func TestClusterFromServerName(t *testing.T) {
-	clusters := []string{"staging", "canary", "production", "production-us-east"}
+	// Real-world env layout including the irregular "tuist" name
+	// for production (Cluster CR named `tuist` but env label
+	// `production`). The longest-prefix rule keeps that short
+	// name from accidentally swallowing tuist-staging / tuist-canary.
+	envs := []clusterEnv{
+		{clusterName: "tuist-staging", envLabel: "staging"},
+		{clusterName: "tuist-canary", envLabel: "canary"},
+		{clusterName: "tuist", envLabel: "production"},
+	}
 	cases := []struct {
-		name     string
-		in       string
-		clusters []string
-		want     string
+		name string
+		in   string
+		envs []clusterEnv
+		want string
 	}{
-		{"operator-named staging", "tuist-bm-staging-1", clusters, "staging"},
-		{"operator-named canary", "tuist-bm-canary-3", clusters, "canary"},
-		{"caph-renamed staging", "tuist-staging-runners-linux-v5bcr-nx8h7-fgfc5", clusters, "staging"},
-		{"caph-renamed canary", "tuist-canary-runners-linux-abcde-fghij-klmno", clusters, "canary"},
-		{"multi-segment cluster wins over shorter prefix",
-			"tuist-production-us-east-runners-linux-xyz", clusters, "production-us-east"},
-		{"unknown cluster", "tuist-foo-runners-linux", clusters, ""},
-		{"non-tuist prefix", "some-other-server", clusters, ""},
-		{"empty cluster list", "tuist-bm-staging-1", nil, ""},
-		{"name happens to start with cluster but no '-' boundary",
-			"tuist-stagingoid-something", clusters, ""},
+		{"operator-named staging", "tuist-bm-staging-1", envs, "staging"},
+		{"operator-named canary", "tuist-bm-canary-3", envs, "canary"},
+		{"operator-named production", "tuist-bm-production-1", envs, "production"},
+		{"caph-renamed staging (bm- prefix)", "bm-tuist-staging-runners-linux-v5bcr-nx8h7-fgfc5", envs, "staging"},
+		{"caph-renamed canary (bm- prefix)", "bm-tuist-canary-runners-linux-abcde-fghij-klmno", envs, "canary"},
+		{"caph-renamed production (bm- prefix)", "bm-tuist-runners-linux-pvv5b-m8tb2-8mrp2", envs, "production"},
+		{"longer Cluster CR name wins over shorter prefix",
+			"bm-tuist-staging-runners-linux-xyz", envs, "staging"},
+		{"unknown env", "tuist-bm-foo-1", envs, ""},
+		{"non-tuist prefix", "some-other-server", envs, ""},
+		{"empty env list", "tuist-bm-staging-1", nil, ""},
+		{"prefix without trailing dash boundary", "tuist-stagingoid-something", envs, ""},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			got := clusterFromServerName(c.in, c.clusters)
+			got := clusterFromServerName(c.in, c.envs)
 			if got != c.want {
 				t.Errorf("clusterFromServerName(%q) = %q, want %q", c.in, got, c.want)
 			}
@@ -340,14 +366,17 @@ func TestClusterFromServerName(t *testing.T) {
 
 func TestSync_ClusterGating_SkipsUnrecognizedNames(t *testing.T) {
 	// `tuist-foo-1` matches the wide `tuist-` NamePrefix but is
-	// not in the cluster list — should be ignored entirely.
+	// not under any discovered cluster — should be ignored entirely.
+	// caph-rewritten name uses the `bm-<clusterName>-` shape.
 	syncer := newSyncer(t, []robot.Server{
 		{Number: 1, Name: "tuist-bm-staging-1"},
 		{Number: 2, Name: "tuist-foo-1"},
-		{Number: 3, Name: "tuist-canary-runners-linux-xyz"}, // caph-renamed canary
-	})
+		{Number: 3, Name: "bm-tuist-canary-runners-linux-xyz"}, // caph-renamed canary
+	},
+		makeClusterCR("tuist-staging", "staging"),
+		makeClusterCR("tuist-canary", "canary"),
+	)
 	syncer.NamePrefix = "tuist-"
-	syncer.Clusters = []string{"staging", "canary"}
 
 	if err := syncer.sync(context.Background()); err != nil {
 		t.Fatalf("sync: %v", err)
@@ -367,6 +396,37 @@ func TestSync_ClusterGating_SkipsUnrecognizedNames(t *testing.T) {
 	}
 }
 
+func TestSync_ClusterGating_HandlesIrregularProductionClusterName(t *testing.T) {
+	// Production's Cluster CR is just `tuist` (no `tuist-production`
+	// convention). caph rewrites its bare-metal Robot servers to
+	// `bm-tuist-runners-linux-...` — which the parser must
+	// correctly attribute to env=production despite the prefix
+	// also being a substring of `bm-tuist-staging-...`.
+	syncer := newSyncer(t, []robot.Server{
+		{Number: 1, Name: "tuist-bm-production-1"},                       // operator-named
+		{Number: 2, Name: "bm-tuist-runners-linux-pvv5b-m8tb2-8mrp2"},    // caph-renamed
+		{Number: 3, Name: "bm-tuist-staging-runners-linux-v5bcr-xyz"},   // unrelated staging
+	},
+		makeClusterCR("tuist", "production"),
+		makeClusterCR("tuist-staging", "staging"),
+	)
+	syncer.NamePrefix = "tuist-"
+
+	if err := syncer.sync(context.Background()); err != nil {
+		t.Fatalf("sync: %v", err)
+	}
+	hosts := listHosts(t, syncer)
+	if got := len(hosts); got != 3 {
+		t.Fatalf("hosts: got %d want 3", got)
+	}
+	want := map[string]string{"bm-1": "production", "bm-2": "production", "bm-3": "staging"}
+	for _, h := range hosts {
+		if got := h.GetLabels()[ClusterLabel]; got != want[h.GetName()] {
+			t.Errorf("%s cluster label = %q, want %q", h.GetName(), got, want[h.GetName()])
+		}
+	}
+}
+
 func TestSync_ClusterGating_BackfillsExistingHostsMissingLabel(t *testing.T) {
 	// Pre-cluster-gate HBM: has managed-by + server-name but no
 	// cluster label. The back-fill loop should add the label
@@ -377,10 +437,12 @@ func TestSync_ClusterGating_BackfillsExistingHostsMissingLabel(t *testing.T) {
 	existing.SetLabels(lbls)
 
 	syncer := newSyncer(t, []robot.Server{
-		{Number: 1, Name: "tuist-staging-runners-linux-renamed"}, // caph already renamed
-	}, existing)
+		{Number: 1, Name: "bm-tuist-staging-runners-linux-renamed"}, // caph already renamed
+	}, existing,
+		makeClusterCR("tuist-staging", "staging"),
+		makeClusterCR("tuist-canary", "canary"),
+	)
 	syncer.NamePrefix = "tuist-"
-	syncer.Clusters = []string{"staging", "canary"}
 
 	if err := syncer.sync(context.Background()); err != nil {
 		t.Fatalf("sync: %v", err)

--- a/infra/k8s/mgmt/hetzner-robot-controller.yaml
+++ b/infra/k8s/mgmt/hetzner-robot-controller.yaml
@@ -58,6 +58,14 @@ rules:
   - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["get", "list", "watch"]
+  # InventorySyncer reads CAPI Cluster CRs to discover the
+  # (clusterName, envLabel) mapping from each Cluster's
+  # `spec.topology.variables[name=bareMetalCluster]`. Source of
+  # truth for the per-env gate — replaced the static `--clusters`
+  # flag, since the controller picks up new clusters automatically.
+  - apiGroups: ["cluster.x-k8s.io"]
+    resources: ["clusters"]
+    verbs: ["get", "list", "watch"]
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
@@ -134,26 +142,17 @@ spec:
             - --metrics-bind-address=:8080
             - --health-probe-bind-address=:8081
             - --host-namespace=org-tuist
-            # Originally `tuist-bm-` to match only operator-named
-            # bare-metal servers. caph rewrites Robot server names
-            # to the HBMM name during provisioning
-            # (e.g. `tuist-staging-runners-linux-v5bcr-…-…`); the
-            # narrow prefix then refuses to re-create an HBM after
-            # a roll, blocking re-installimage cycles. Widened to
-            # `tuist-` so both original and caph-rewritten names
-            # match. Per-cluster isolation across the shared Robot
-            # account is now enforced via `--clusters` below.
+            # Legacy fallback only: matches operator-named
+            # servers like `tuist-bm-staging-1`. When at least one
+            # Cluster CR sets `spec.topology.variables[bareMetalCluster]`,
+            # the controller discovers envs from those CRs and
+            # supersedes this prefix entirely — see the
+            # InventorySyncer doc-comment in
+            # `infra/hetzner-robot-controller/controllers/hostdiscovery.go`.
+            # New bare-metal clusters get added by setting the
+            # topology variable in their `cluster-<env>.yaml`; no
+            # change is needed here.
             - --name-prefix=tuist-
-            # Cluster gate. A Robot server is included in inventory
-            # only if its name parses to one of these (matching
-            # `tuist-bm-<cluster>-…` or the caph-rewritten
-            # `tuist-<cluster>-…`); the match is stamped on the HBM
-            # as `tuist.dev/cluster=<cluster>` so each env's HBMM
-            # `hostSelector` can scope itself. Update this list when
-            # a new cluster comes online; canary / production are
-            # listed pre-emptively so the controller picks them up
-            # the moment their cluster CRs land.
-            - --clusters=staging,canary,production
             - --poll-interval=60s
             - --robot-user-path=/etc/hetzner-robot-controller/robot-user
             - --robot-pass-path=/etc/hetzner-robot-controller/robot-pass


### PR DESCRIPTION
## Summary
- Replaces the static \`--clusters=staging,canary,production\` flag on \`hetzner-robot-controller\` with discovery from CAPI Cluster CRs (\`spec.topology.variables[name=bareMetalCluster]\`). Closes the parser bug we hit today on production.

## The bug
Production's Cluster CR is just \`tuist\` (not \`tuist-production\`), but my previous parser only knew \`tuist-bm-<env>-\` and \`tuist-<env>-\` patterns where \`<env>\` was the literal short label. caph's mid-provisioning Robot rename produces names like \`bm-tuist-runners-linux-pvv5b-...\` — the parser looked for \`tuist-bm-production-...\` / \`tuist-production-...\` and missed.

Net effect: after a roll, the controller stopped recognising caph-renamed production hosts, didn't recreate their HBMs, and the operator had to manually rename them back via Robot WS every time.

## The fix
The controller now lists \`cluster.x-k8s.io/v1beta1\` Cluster CRs in \`org-tuist\` each sync tick and pairs each one with its \`spec.topology.variables[name=bareMetalCluster].value\` (already set per env: staging/canary/production). That gives a \`(clusterCRName, envLabel)\` mapping the parser uses to try both shapes:

- \`tuist-bm-<envLabel>-\` — operator-named.
- \`bm-<clusterCRName>-\` — caph-rewritten.

Longest-prefix wins so \`tuist\` (production) can't swallow \`tuist-staging-*\` names.

Single setting, two readers (\`HetznerBareMetalMachineTemplateClusterSelector\` patch + the controller) — no drift. New clusters light up automatically the moment their topology variable lands; no manifest or controller change needed.

## Behaviour preserved
- If no Cluster CR sets the variable (cold bootstrap), the controller falls back to the legacy \`--name-prefix\` filter — single-env mode keeps working.
- Existing HBMs that pre-date the cluster label still get back-filled on the next sync from their \`robot.hetzner.com/server-name\` label.

## Removed
- \`--clusters\` flag + \`HRC_CLUSTERS\` env var
- \`parseClusters\` helper + the \`Clusters []string\` field on \`InventorySyncer\`

## RBAC added
- \`cluster.x-k8s.io/clusters\` get/list/watch in the controller's ClusterRole

## Tests
- \`TestClusterFromServerName\` rewritten to the new signature with realistic env data (including \`{clusterName: "tuist", envLabel: "production"}\`); covers operator-named, caph-rewritten, longest-prefix disambiguation, and the unknown-env / boundary edge cases.
- \`TestSync_ClusterGating_*\` updated to seed fake Cluster CRs via the new \`makeClusterCR\` helper instead of setting the removed \`Clusters\` field.
- New \`TestSync_ClusterGating_HandlesIrregularProductionClusterName\` proves the irregular \`tuist\`→\`production\` mapping doesn't cross-match staging.

\`go test ./... \` passes locally.

## Sequencing after merge
Same pattern as #10880 / #10884:
1. Merge.
2. Image build produces \`sha-<merge>\`.
3. Open one-line image-pin bump PR for \`infra/k8s/mgmt/hetzner-robot-controller.yaml\`.
4. \`mgmt-cluster-apply\` rolls the controller — discovery activates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)