### PR TITLE
fix(infra): bump hetzner-robot-controller image to post-cluster-discovery build

### DIFF
--- a/infra/k8s/mgmt/hetzner-robot-controller.yaml
+++ b/infra/k8s/mgmt/hetzner-robot-controller.yaml
@@ -135,7 +135,7 @@ spec:
           # for the first time, the bump-chart-image-pins step
           # rewrites this line to a semver tag (`0.1.0`, `0.2.0`,
           # …) and from there it's owned by the release pipeline.
-          image: ghcr.io/tuist/tuist-hetzner-robot-controller:sha-9f91ba2bd8f8
+          image: ghcr.io/tuist/tuist-hetzner-robot-controller:sha-c837ff316f9f
           imagePullPolicy: IfNotPresent
           args:
             - --leader-elect=true


### PR DESCRIPTION
## Summary
Bumps the controller image pin to \`sha-c837ff316f9f\` so the running binary matches the manifest after #10888 (Cluster-CR-based env discovery).

Same image-out-of-sync pattern as #10880 / #10884.

## Test plan
- [ ] On merge, \`mgmt-cluster-apply\` rolls the deployment. Confirm the new pod starts with image \`sha-c837ff316f9f\` and the startup log no longer mentions \`clusters\` (the flag is gone now): \`KUBECONFIG=~/.kube/tuist-mgmt.yaml kubectl logs -n org-tuist deployment/hetzner-robot-controller --tail=5\` should show \`"starting manager","namespace":"org-tuist","prefix":"tuist-","interval":60\` — no clusters key.
- [ ] Verify env discovery is working: after a sync cycle (≤60s), the controller's logs should show the same back-fill / create patterns as before, but driven by Cluster-CR discovery rather than the static flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)