### PR TITLE
fix(cli): pass explicit workingDirectory to swift package commands

### DIFF
--- a/cli/Sources/TuistGenerator/Utils/SwiftPackageManagerInteractor.swift
+++ b/cli/Sources/TuistGenerator/Utils/SwiftPackageManagerInteractor.swift
@@ -85,7 +85,11 @@ public struct SwiftPackageManagerInteractor: SwiftPackageManagerInteracting {
 
         arguments.append(contentsOf: ["-workspace", workspacePath.pathString, "-list"])
 
-        for try await event in commandRunner.run(arguments: arguments, environment: Environment.current.variables) {
+        for try await event in commandRunner.run(
+            arguments: arguments,
+            environment: Environment.current.variables,
+            workingDirectory: path
+        ) {
             switch event {
             case let .standardOutput(bytes):
                 let output = String(decoding: bytes, as: Unicode.UTF8.self)

--- a/cli/Sources/TuistLoader/Loaders/PackageInfoLoader.swift
+++ b/cli/Sources/TuistLoader/Loaders/PackageInfoLoader.swift
@@ -32,16 +32,16 @@ public struct PackageInfoLoader: PackageInfoLoading {
         let command = buildSwiftPackageCommand(packagePath: path, extraArguments: ["resolve"])
 
         printOutput ?
-            try await commandRunner.runAndPrint(arguments: command) :
-            try await commandRunner.runAndWait(arguments: command)
+            try await commandRunner.runAndPrint(arguments: command, workingDirectory: path) :
+            try await commandRunner.runAndWait(arguments: command, workingDirectory: path)
     }
 
     public func update(at path: AbsolutePath, printOutput: Bool) async throws {
         let command = buildSwiftPackageCommand(packagePath: path, extraArguments: ["update"])
 
         printOutput ?
-            try await commandRunner.runAndPrint(arguments: command) :
-            try await commandRunner.runAndWait(arguments: command)
+            try await commandRunner.runAndPrint(arguments: command, workingDirectory: path) :
+            try await commandRunner.runAndWait(arguments: command, workingDirectory: path)
     }
 
     public func setToolsVersion(at path: AbsolutePath, to version: TSCUtility.Version) async throws {
@@ -49,7 +49,7 @@ public struct PackageInfoLoader: PackageInfoLoading {
 
         let command = buildSwiftPackageCommand(packagePath: path, extraArguments: extraArguments)
 
-        try await commandRunner.runAndWait(arguments: command)
+        try await commandRunner.runAndWait(arguments: command, workingDirectory: path)
     }
 
     public func getToolsVersion(at path: AbsolutePath) async throws -> TSCUtility.Version {
@@ -57,7 +57,8 @@ public struct PackageInfoLoader: PackageInfoLoading {
 
         let command = buildSwiftPackageCommand(packagePath: path, extraArguments: extraArguments)
 
-        let rawVersion = try await commandRunner.capture(arguments: command).trimmingCharacters(in: .whitespacesAndNewlines)
+        let rawVersion = try await commandRunner.capture(arguments: command, workingDirectory: path)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
         return try Version(versionString: rawVersion)
     }
 
@@ -68,7 +69,7 @@ public struct PackageInfoLoader: PackageInfoLoading {
         }
         let command = buildSwiftPackageCommand(packagePath: path, extraArguments: extraArguments)
 
-        let json = try await commandRunner.capture(arguments: command)
+        let json = try await commandRunner.capture(arguments: command, workingDirectory: path)
 
         let data = Data(json.utf8)
         let decoder = JSONDecoder()
@@ -98,24 +99,29 @@ public struct PackageInfoLoader: PackageInfoLoading {
             arguments:
             buildCommand + [
                 arm64Target,
-            ]
+            ],
+            workingDirectory: packagePath
         )
         try await commandRunner.runAndWait(
             arguments:
             buildCommand + [
                 x64Target,
-            ]
+            ],
+            workingDirectory: packagePath
         )
 
         if try await !fileSystem.exists(outputPath) {
             try await fileSystem.makeDirectory(at: outputPath)
         }
 
-        try await commandRunner.runAndWait(arguments: [
-            "lipo", "-create", "-output", outputPath.appending(component: product).pathString,
-            buildPath.appending(components: arm64Target, "release", product).pathString,
-            buildPath.appending(components: x64Target, "release", product).pathString,
-        ])
+        try await commandRunner.runAndWait(
+            arguments: [
+                "lipo", "-create", "-output", outputPath.appending(component: product).pathString,
+                buildPath.appending(components: arm64Target, "release", product).pathString,
+                buildPath.appending(components: x64Target, "release", product).pathString,
+            ],
+            workingDirectory: packagePath
+        )
     }
 
     // MARK: - Helpers

--- a/cli/Sources/XcodeGraph/Sources/XcodeGraphMapper/Utilities/PackageInfoLoader.swift
+++ b/cli/Sources/XcodeGraph/Sources/XcodeGraphMapper/Utilities/PackageInfoLoader.swift
@@ -27,7 +27,8 @@ struct PackageInfoLoader: PackageInfoLoading {
                 "--package-path",
                 path.pathString,
                 "dump-package",
-            ]
+            ],
+            workingDirectory: path
         )
         .concatenatedString()
 


### PR DESCRIPTION
## Summary

Several `CommandRunner.run` call sites in the SwiftPM-driven graph-load path relied on the default `workingDirectory` resolution, which reads `FileManager.default.currentDirectoryPath`. When `getcwd` fails inside the running process (cwd deleted, unsearchable, transient state under heavy concurrent `Process` setup), Foundation returns an empty string and the underlying `AbsolutePath` validation traps via `try!` in `tuist/Command` — surfacing as a `Trace/BPT trap: 5` with no stack in user reports.

These callers fire concurrently per Swift package (hundreds of `Task.detached` in large workspaces), which maximizes exposure to the failure mode. Pass the package or workspace directory as `workingDirectory` explicitly. The commands already take `--package-path` / `-workspace` arguments, so this does not change executed behavior — it only removes the implicit dependency on `currentDirectoryPath`.

Touched call sites:
- `cli/Sources/XcodeGraph/Sources/XcodeGraphMapper/Utilities/PackageInfoLoader.swift` — `swift package dump-package`, fires concurrently per SPM dep during XcodeGraph mapping
- `cli/Sources/TuistLoader/Loaders/PackageInfoLoader.swift` — `swift package` invocations for resolve/update/tools-version/dump-package, plus the `swift build` + `lipo` chain in `buildFatReleaseBinary`
- `cli/Sources/TuistGenerator/Utils/SwiftPackageManagerInteractor.swift` — `xcodebuild -resolvePackageDependencies`

## Scope: defensive, not causal

This is a defensive fix. It does not identify or fix the underlying reason `currentDirectoryPath` returns empty. Read on for the reasoning.

A reporter hit the trap during `tuist generate` with `Trace/BPT trap: 5` and three identical `Command/CommandRunner.swift:155: 'try!' expression unexpectedly raised an error: invalid absolute path ''` lines. Notable observations:

- Idle `getcwd` and `FileManager.default.currentDirectoryPath` returned the correct path. The empty string only appeared transiently inside the running Tuist process.
- `TUIST_CONFIG_TOKEN= tuist generate` succeeded in ~22s. With the token set, it crashed.
- Running `tuist auth login` also made the crash stop reproducing.

Project tokens skip the auth-refresh codepath entirely (`tokenStatus` returns `.valid(.project)` immediately, no refresh). So the auth-refresh code itself is not the trigger. What auth state controls is whether downstream binary-cache substitution runs. With a valid token, the cache layer spawns its own concurrent `Process` work on top of the already-concurrent SPM `Task.detached` storm. Without a token, that work short-circuits and the extra concurrency disappears.

The evidence points to a race or transient state under heavy concurrent `Process` setup that makes `getcwd` (and therefore Foundation's `currentDirectoryPath`) return empty briefly. The crash surfaces at whichever `CommandRunner.run` call happens to be running at that moment — which, given call volume, is overwhelmingly the SPM callers patched here.

After this PR, those callers no longer touch `currentDirectoryPath`, so the visible crash for that user's reproducer should disappear. But the underlying race condition is unchanged, and any other `CommandRunner.run` caller without an explicit `workingDirectory` could still trigger the same trap under similar conditions.

Companion change: [tuist/Command#262](https://github.com/tuist/Command/pull/262) replaces the `try!` with proper error propagation. With both PRs landed, the next reproducer surfaces a regular Swift error pointing at the actual call site, which is what is needed to find the real root cause.

## Test plan

- [x] `swift build --replace-scm-with-registry --target TuistLoader` succeeds
- [x] `swift build --replace-scm-with-registry --target TuistGenerator` succeeds
- [x] `swift build --replace-scm-with-registry --target XcodeGraphMapper` succeeds
- [ ] Existing unit tests still pass on CI (`MockCommandRunner` matches on argument strings only, which are unchanged)