### PR TITLE
fix(infra): bump cilium-agent memory limit to fit 256GB bare-metal nodes

### DIFF
--- a/infra/k8s/mgmt/bootstrap/cilium-values.yaml
+++ b/infra/k8s/mgmt/bootstrap/cilium-values.yaml
@@ -88,10 +88,22 @@ operator:
 prometheus:
   enabled: true
 
-# Pod resources kept moderate; tune later based on Grafana dashboards.
+# Pod resources. The limit has to accommodate the BPF maps that
+# cilium-agent allocates at startup. With `bpf-map-dynamic-size-ratio`
+# at its chart default of 0.0025 and `preallocate-bpf-maps=true`, the
+# combined dynamic maps (auth/ct/neigh/nat/policy) are sized as a
+# fraction of system memory and charged to the cilium-agent cgroup.
+#
+# On a 256GB AX162-R bare-metal node that lands at ~640MB, which blows
+# past a 512Mi limit and surfaces as `bpf(BPF_MAP_CREATE) = ENOMEM`
+# (`initializing neighbors map: cannot allocate memory`), leaving the
+# `node.cilium.io/agent-not-ready:NoSchedule` taint stuck and the node
+# unusable. 2Gi gives comfortable headroom for current and future
+# hardware sizes; actual usage stays low on the smaller Hetzner Cloud
+# nodes where the ratio resolves to tens of MB.
 resources:
   requests:
     cpu: 100m
     memory: 256Mi
   limits:
-    memory: 512Mi
+    memory: 2Gi


### PR DESCRIPTION
## Summary

- The 512Mi `cilium-agent` memory limit was sized when every workload-cluster node was a Hetzner Cloud VM (≤64GB RAM). On the 256GB AX162-R bare-metal nodes that joined the production `runners-linux` pool today, Cilium's BPF maps (auto-sized at `bpf-map-dynamic-size-ratio: 0.0025` of system memory and preallocated at startup) overrun the cgroup before the agent finishes initializing, surfacing as `bpf(BPF_MAP_CREATE) = ENOMEM` / `initializing neighbors map: cannot allocate memory` and leaving the `node.cilium.io/agent-not-ready:NoSchedule` taint stuck.
- 2Gi gives comfortable headroom for current and future node sizes; actual usage stays low on the smaller Hetzner Cloud nodes where the ratio resolves to tens of MB.

The production DaemonSet was already kubectl-patched to 2Gi to unblock the 60 Pending Linux runner pods that were waiting on the taint to clear; this PR makes the fix permanent and ensures freshly bootstrapped clusters pick it up.

## Test plan

- [ ] After merge, manually `helm upgrade cilium` against staging / canary / production workload clusters (bootstrap charts don't auto-reconcile).
- [ ] Confirm `cilium-agent` pods on bare-metal nodes still Ready with `restartCount: 0` and `memory.limit: 2Gi`.
- [ ] Confirm `node.cilium.io/agent-not-ready` taint stays gone on bare-metal Nodes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)