### PR TITLE
feat(server, cache): credo — flag directives inside ExUnit block macros

### DIFF
--- a/cache/.credo.exs
+++ b/cache/.credo.exs
@@ -22,7 +22,7 @@ alias Credo.Checks.TimestampsType
           {Credo.Check.Refactor.Nesting, [max_nesting: 3]},
           {TimestampsType, files: %{included: ["lib/"]}, allowed_type: :utc_datetime},
           {DisallowSpec, []},
-          {DisallowDirectivesInFunction, files: %{included: ["lib/"]}},
+          {DisallowDirectivesInFunction, files: %{included: ["lib/", "test/"]}},
           {DisallowJason, []},
           {Credo.Checks.UnusedReturnValue,
            [

--- a/cache/test/cache/registry/lock_test.exs
+++ b/cache/test/cache/registry/lock_test.exs
@@ -2,6 +2,8 @@ defmodule Cache.Registry.LockTest do
   use ExUnit.Case, async: true
   use Mimic
 
+  import ExUnit.CaptureLog
+
   alias Cache.Registry.Lock
 
   setup :set_mimic_from_context
@@ -107,8 +109,6 @@ defmodule Cache.Registry.LockTest do
     end
 
     test "returns ok even if delete fails" do
-      import ExUnit.CaptureLog
-
       expect(ExAws, :request, fn %{http_method: :delete} ->
         {:error, {:http_error, 500, ""}}
       end)

--- a/cache/test/cache/sqlite_buffer_test.exs
+++ b/cache/test/cache/sqlite_buffer_test.exs
@@ -194,8 +194,6 @@ defmodule Cache.SQLiteBufferTest do
   end
 
   test "flush inserts and deletes s3 transfers with de-duplication" do
-    import Ecto.Query
-
     key = "account/project/xcode/ab/cd/key"
 
     :ok = S3TransfersBuffer.enqueue(:upload, "account", "project", :xcode_cache, key)
@@ -306,8 +304,6 @@ defmodule Cache.SQLiteBufferTest do
   end
 
   test "writes during flush are not lost" do
-    import Ecto.Query
-
     base_key = "keyvalue:during_flush:account:project"
 
     for i <- 1..50 do

--- a/processor/.credo.exs
+++ b/processor/.credo.exs
@@ -19,7 +19,7 @@ alias Credo.Checks.DisallowSpec
         extra: [
           {Credo.Check.Refactor.Nesting, [max_nesting: 3]},
           {DisallowSpec, []},
-          {DisallowDirectivesInFunction, files: %{included: ["lib/"]}},
+          {DisallowDirectivesInFunction, files: %{included: ["lib/", "test/"]}},
           {DisallowJason, []},
           {DisallowGlobalStateMutation, files: %{included: ["test/"]}}
         ],

--- a/server/.credo.exs
+++ b/server/.credo.exs
@@ -25,7 +25,7 @@ alias Credo.Checks.TimestampsType
           {TimestampsType, files: %{included: ["priv/repo/migrations/"]}, allowed_type: :timestamptz},
           {TimestampsType, files: %{included: ["lib/"]}, allowed_type: :utc_datetime},
           {DisallowSpec, []},
-          {DisallowDirectivesInFunction, files: %{included: ["lib/"]}},
+          {DisallowDirectivesInFunction, files: %{included: ["lib/", "test/"]}},
           {DisallowJason, []},
           {ExcellentMigrations.CredoCheck.MigrationsSafety, []},
           {Credo.Checks.UnusedReturnValue, files: %{excluded: ["priv/repo/migrations/"]}},

--- a/server/test/support/tuist_test_support/fixtures/projects_fixtures.ex
+++ b/server/test/support/tuist_test_support/fixtures/projects_fixtures.ex
@@ -1,6 +1,8 @@
 defmodule TuistTestSupport.Fixtures.ProjectsFixtures do
   @moduledoc false
 
+  import Ecto.Query
+
   alias Tuist.Projects
   alias Tuist.Repo
   alias Tuist.VCS
@@ -48,8 +50,6 @@ defmodule TuistTestSupport.Fixtures.ProjectsFixtures do
     # Pass `with_default_alert: true` to opt in when you need the realistic
     # shape.
     if !Keyword.get(opts, :with_default_alert, false) do
-      import Ecto.Query
-
       Repo.delete_all(
         from a in Tuist.Automations.Alerts.Alert,
           where: a.project_id == ^project.id

--- a/server/test/tuist/tests_test.exs
+++ b/server/test/tuist/tests_test.exs
@@ -2,6 +2,8 @@ defmodule Tuist.TestsTest do
   use TuistTestSupport.Cases.DataCase
   use Mimic
 
+  import Ecto.Query
+
   alias Tuist.Automations
   alias Tuist.Automations.ActionExecutor
   alias Tuist.ClickHouseRepo
@@ -2110,8 +2112,6 @@ defmodule Tuist.TestsTest do
     end
 
     test "shard run is created for each shard" do
-      import Ecto.Query
-
       project = ProjectsFixtures.project_fixture()
       account = AccountsFixtures.user_fixture(preload: [:account]).account
       plan = ShardsFixtures.shard_plan_fixture(project_id: project.id, shard_count: 2)

--- a/server/test/tuist_web/live/test_run_live_test.exs
+++ b/server/test/tuist_web/live/test_run_live_test.exs
@@ -10,6 +10,7 @@ defmodule TuistWeb.TestRunLiveTest do
   alias Tuist.Shards.Analytics, as: ShardsAnalytics
   alias Tuist.Storage
   alias TuistTestSupport.Fixtures.AccountsFixtures
+  alias TuistTestSupport.Fixtures.CommandEventsFixtures
   alias TuistTestSupport.Fixtures.RunsFixtures
   alias TuistTestSupport.Fixtures.ShardsFixtures
 
@@ -101,7 +102,6 @@ defmodule TuistWeb.TestRunLiveTest do
     organization: organization,
     project: project
   } do
-    alias TuistTestSupport.Fixtures.CommandEventsFixtures
     # Given
     {:ok, test_run} =
       RunsFixtures.test_fixture(project_id: project.id)

--- a/tuist_common/credo/checks/disallow_directives_in_function.ex
+++ b/tuist_common/credo/checks/disallow_directives_in_function.ex
@@ -1,20 +1,24 @@
 defmodule Credo.Checks.DisallowDirectivesInFunction do
   @moduledoc """
-  Ensure that `import`, `alias`, and `require` statements are not placed inside function bodies.
+  Ensure that `import`, `alias`, and `require` statements are not placed inside
+  function bodies or ExUnit block macros (`describe`, `test`, `setup`, `setup_all`).
 
-  These directives should be declared at the module level, not inside `def` or `defp` blocks.
+  These directives should be declared at the module level, not inside `def`, `defp`,
+  or test-block bodies.
   """
 
   use Credo.Check,
     category: :warning,
     explanations: [
       check: """
-      `import`, `alias`, and `require` statements should be at the module level, not inside
-      function bodies. Move them to the top of the module alongside other directives.
+      `import`, `alias`, and `require` statements should be at the module level, not
+      inside function bodies or ExUnit block macros (`describe`, `test`, `setup`,
+      `setup_all`). Move them to the top of the module alongside other directives.
       """
     ]
 
   @directives [:import, :alias, :require]
+  @exunit_blocks [:describe, :test, :setup, :setup_all]
 
   def run(source_file, params \\ []) do
     issue_meta = IssueMeta.for(source_file, params)
@@ -44,7 +48,22 @@ defmodule Credo.Checks.DisallowDirectivesInFunction do
     {nil, issues ++ collect_directives(body)}
   end
 
+  defp do_traverse({op, _meta, args} = ast, issues)
+       when op in @exunit_blocks and is_list(args) do
+    case extract_do_block(args) do
+      nil -> {ast, issues}
+      body -> {nil, issues ++ collect_directives(body)}
+    end
+  end
+
   defp do_traverse(ast, issues), do: {ast, issues}
+
+  defp extract_do_block(args) do
+    case List.last(args) do
+      kw when is_list(kw) -> Keyword.get(kw, :do)
+      _ -> nil
+    end
+  end
 
   defp collect_directives(ast) do
     {_ast, directives} =
@@ -66,7 +85,8 @@ defmodule Credo.Checks.DisallowDirectivesInFunction do
   defp issue_for({directive, meta}, issue_meta) do
     format_issue(
       issue_meta,
-      message: "Move `#{directive}` to the module level instead of inside a function body.",
+      message:
+        "Move `#{directive}` to the module level instead of inside a function or block body.",
       line_no: meta[:line],
       column: meta[:column]
     )


### PR DESCRIPTION
### Summary

Originally raised in https://github.com/tuist/tuist/pull/10878#discussion_r3273526712 — an `alias` inside a `describe` body slipped through review. We had `Credo.Checks.DisallowDirectivesInFunction` that catches `import`/`alias`/`require` inside `def`/`defp`, but it only ran on `lib/` and only matched function definitions, so it never looked at ExUnit block macros.

### What changed

- **Check (`tuist_common/credo/checks/disallow_directives_in_function.ex`)** — added a traversal clause for `describe`, `test`, `setup`, `setup_all`. When one is encountered the `do:` body is run through the same `collect_directives/1` walk as `def`/`defp` bodies, and the existing `quote` skip still applies. Updated the moduledoc, explanation, and issue message to read "function or block body".
- **Configs** — `server/.credo.exs`, `cache/.credo.exs`, and `processor/.credo.exs` now apply this check to `test/` as well as `lib/`.
- **Sweep** — fixed the six pre-existing violations the broadened check surfaced:
  - `server/test/support/tuist_test_support/fixtures/projects_fixtures.ex` — `import Ecto.Query` lifted from `project_fixture/1` to the module
  - `server/test/tuist/tests_test.exs` — `import Ecto.Query` lifted from a `test` to the module
  - `server/test/tuist_web/live/test_run_live_test.exs` — `alias TuistTestSupport.Fixtures.CommandEventsFixtures` lifted from a `test` to the module
  - `cache/test/cache/registry/lock_test.exs` — `import ExUnit.CaptureLog` lifted from a `test` to the module
  - `cache/test/cache/sqlite_buffer_test.exs` — two redundant `import Ecto.Query` inside `test` blocks removed (already imported at module level)

### How to test locally

- `cd server && mix credo --strict` — passes, no `DisallowDirectivesInFunction` violations.
- `cd cache && mix credo --strict` — passes.
- Synthetic verification: dropped a one-off `_sample_check_test.exs` with `alias` inside `describe`/`setup`/`test` and confirmed the check reports all three sites.
- Re-ran the touched tests:
  - `cd cache && mix test test/cache/registry/lock_test.exs test/cache/sqlite_buffer_test.exs` — 27/27 pass
  - `cd server && mix test test/tuist/tests_test.exs:2110 test/tuist_web/live/test_run_live_test.exs` — 16/16 pass
- `mix format --check-formatted` is clean on every touched file.