### PR TITLE
fix(server): disconnect active sessions after password reset

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,18 @@ Examples:
 - `feat(skills): add new migration skill`
 - `docs(handbook): update project setup guide`
 
+When creating pull requests, write descriptions that preserve the reasoning from the implementation work, not just the surface diff.
+
+Pull request descriptions should cover:
+- What changed
+- Why it changed
+- The root cause when the change is a fix
+- Why the chosen solution was selected over the obvious alternatives when that context matters
+- User or developer impact
+- The concrete validation that was run
+
+Avoid minimal PR descriptions that only restate the code diff. The goal is that a reviewer can understand the problem, the reasoning, and the validation without reopening the full agent session.
+
 # Tuist CLI (Swift)
 
 ## Code style

--- a/server/lib/tuist/accounts.ex
+++ b/server/lib/tuist/accounts.ex
@@ -1501,7 +1501,7 @@ defmodule Tuist.Accounts do
   ## Examples
 
       iex> reset_user_password(user, %{password: "new long password", password_confirmation: "new long password"})
-      {:ok, %User{}}
+      {:ok, %{user: %User{}, revoked_session_live_socket_ids: []}}
 
       iex> reset_user_password(user, %{password: "valid", password_confirmation: "not the same"})
       {:error, %Ecto.Changeset{}}
@@ -1509,12 +1509,20 @@ defmodule Tuist.Accounts do
   """
   def reset_user_password(user, attrs) do
     Multi.new()
+    |> Multi.all(:session_tokens, UserToken.by_user_and_contexts_query(user, ["session"]))
     |> Multi.update(:user, User.password_changeset(user, attrs))
     |> Multi.delete_all(:tokens, UserToken.by_user_and_contexts_query(user, :all))
     |> Repo.transaction()
     |> case do
-      {:ok, %{user: user}} -> {:ok, user}
-      {:error, :user, changeset, _} -> {:error, changeset}
+      {:ok, %{user: user, session_tokens: session_tokens}} ->
+        {:ok,
+         %{
+           user: user,
+           revoked_session_live_socket_ids: Enum.map(session_tokens, &UserToken.live_socket_id/1)
+         }}
+
+      {:error, :user, changeset, _} ->
+        {:error, changeset}
     end
   end
 

--- a/server/lib/tuist/accounts/user_token.ex
+++ b/server/lib/tuist/accounts/user_token.ex
@@ -52,6 +52,14 @@ defmodule Tuist.Accounts.UserToken do
     {token, %UserToken{token: token, context: "session", user_id: user.id}}
   end
 
+  def live_socket_id(%UserToken{context: "session", token: token}) do
+    live_socket_id(token)
+  end
+
+  def live_socket_id(token) when is_binary(token) do
+    "users_sessions:#{Base.url_encode64(token)}"
+  end
+
   @doc """
   Checks if the token is valid and returns its underlying lookup query.
 

--- a/server/lib/tuist_web/live/user_reset_password_live.ex
+++ b/server/lib/tuist_web/live/user_reset_password_live.ex
@@ -6,6 +6,7 @@ defmodule TuistWeb.UserResetPasswordLive do
   import TuistWeb.AppAuthComponents
 
   alias Tuist.Accounts
+  alias TuistWeb.Endpoint
 
   def render(assigns) do
     ~H"""
@@ -91,7 +92,9 @@ defmodule TuistWeb.UserResetPasswordLive do
   # leaked token giving the user access to the account.
   def handle_event("reset_password", %{"user" => user_params}, socket) do
     case Accounts.reset_user_password(socket.assigns.user, user_params) do
-      {:ok, _} ->
+      {:ok, %{revoked_session_live_socket_ids: live_socket_ids}} ->
+        Enum.each(live_socket_ids, &Endpoint.broadcast(&1, "disconnect", %{}))
+
         {:noreply,
          socket
          |> put_flash(:info, dgettext("dashboard_auth", "Password reset successfully."))

--- a/server/test/tuist/accounts_test.exs
+++ b/server/test/tuist/accounts_test.exs
@@ -2081,9 +2081,10 @@ defmodule Tuist.AccountsTest do
     end
 
     test "updates the password", %{user: user} do
-      {:ok, _} =
+      {:ok, %{user: updated_user}} =
         Accounts.reset_user_password(user, %{"password" => "new valid password"})
 
+      assert updated_user.id == user.id
       assert Accounts.get_user_by_email_and_password(user.email, "new valid password")
     end
 
@@ -2091,6 +2092,15 @@ defmodule Tuist.AccountsTest do
       _ = Accounts.generate_user_session_token(user)
       {:ok, _} = Accounts.reset_user_password(user, %{"password" => "new valid password"})
       refute Repo.get_by(UserToken, user_id: user.id)
+    end
+
+    test "returns revoked session live socket ids", %{user: user} do
+      session_token = Accounts.generate_user_session_token(user)
+
+      assert {:ok, %{revoked_session_live_socket_ids: [live_socket_id]}} =
+               Accounts.reset_user_password(user, %{"password" => "new valid password"})
+
+      assert live_socket_id == UserToken.live_socket_id(session_token)
     end
   end
 

--- a/server/test/tuist_web/live/user_reset_password_live_test.exs
+++ b/server/test/tuist_web/live/user_reset_password_live_test.exs
@@ -7,6 +7,7 @@ defmodule TuistWeb.UserResetPasswordLiveTest do
   import TuistTestSupport.Fixtures.AccountsFixtures
 
   alias Tuist.Accounts
+  alias Tuist.Accounts.UserToken
 
   setup do
     user = user_fixture()
@@ -37,5 +38,36 @@ defmodule TuistWeb.UserResetPasswordLiveTest do
                to: ~p"/users/log_in"
              }
     end
+
+    test "disconnects all active sessions after resetting the password", %{conn: conn, token: token, user: user} do
+      live_socket_ids =
+        user
+        |> active_session_tokens()
+        |> Enum.map(&UserToken.live_socket_id/1)
+
+      Enum.each(live_socket_ids, &TuistWeb.Endpoint.subscribe/1)
+
+      {:ok, lv, _html} = live(conn, ~p"/users/reset_password/#{token}")
+
+      lv
+      |> form("#reset_password_form", %{
+        "user" => %{
+          "password" => "new valid password",
+          "password_confirmation" => "new valid password"
+        }
+      })
+      |> render_submit()
+
+      Enum.each(live_socket_ids, fn live_socket_id ->
+        assert_receive %Phoenix.Socket.Broadcast{event: "disconnect", topic: ^live_socket_id}
+      end)
+    end
+  end
+
+  defp active_session_tokens(user) do
+    [
+      Accounts.generate_user_session_token(user),
+      Accounts.generate_user_session_token(user)
+    ]
   end
 end


### PR DESCRIPTION
## Summary
- fix the password reset flow so active browser sessions are disconnected immediately after a successful reset
- keep the existing token revocation behavior, and extend it with explicit LiveView socket disconnects for already-open sessions
- add regression coverage for both the revoked session topic calculation and the end-to-end disconnect behavior
- document in `AGENTS.md` that agent-authored PR descriptions should preserve problem context, reasoning, impact, and validation instead of only restating the diff

## Problem
A password reset already deleted the user's persisted session tokens, so any new HTTP request should fail authentication.

The gap was that existing LiveView sessions were not explicitly disconnected after those tokens were deleted. In practice, that meant another browser session could stay alive until it refreshed, navigated, or otherwise re-authenticated. That is the behavior the external report was pointing at.

Separately, the review feedback on this PR highlighted that our agent-authored PR descriptions tend to be too terse and lose important implementation context. I added explicit repository guidance for that in `AGENTS.md` as part of this branch.

## Solution
The fix keeps the current revocation model and makes it immediate for connected sessions:
- query the user's active `session` tokens before deleting them during `reset_user_password/2`
- derive the corresponding `live_socket_id` topics from those session tokens
- after the password reset succeeds, broadcast `disconnect` to each topic so open LiveView sessions are forced off immediately

This approach was chosen because it is small, targeted, and consistent with the existing logout behavior. It avoids changing broader authentication flows while closing the gap between token revocation and what a user sees in already-open tabs.

The `AGENTS.md` addition is intentionally narrow: it tells agents that PR descriptions should include what changed, why it changed, the root cause for fixes, why a solution was chosen, the impact, and the validation that was run.

## Testing
- `MIX_ENV=test mix ecto.reset`
- `mix test test/tuist/accounts_test.exs:2078 test/tuist_web/live/user_reset_password_live_test.exs`
