### PR TITLE
fix(search): restore translation guide search sync

### DIFF
--- a/search/bin/scrape
+++ b/search/bin/scrape
@@ -8,6 +8,8 @@ set -euo pipefail
 SERVER_HOST="91.99.179.13"
 SSH_USER="${SEARCH_SSH_USER:-root}"
 CONTAINER=$(ssh ${SSH_USER}@${SERVER_HOST} "docker ps --filter label=service=tuist-search --filter label=role=web --format '{{.Names}}' | head -1")
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SEARCH_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
 CONFIGS=("docsearch.json" "docsearch-forum.json")
 
@@ -17,9 +19,10 @@ fi
 
 for config_name in "${CONFIGS[@]}"; do
   echo "==> Scraping with ${config_name}..."
+  scp "${SEARCH_ROOT}/config/${config_name}" ${SSH_USER}@${SERVER_HOST}:/opt/docsearch/${config_name} >/dev/null
   ssh ${SSH_USER}@${SERVER_HOST} \
     "TYPESENSE_API_KEY=\$(cat /opt/docsearch/.api_key) && \
-     CONFIG=\$(docker exec ${CONTAINER} cat /opt/docsearch/${config_name}) && \
+     CONFIG=\$(cat /opt/docsearch/${config_name}) && \
      docker run --rm --network kamal --dns 8.8.8.8 \
       -e TYPESENSE_API_KEY=\"\$TYPESENSE_API_KEY\" \
       -e TYPESENSE_HOST=${CONTAINER} \

--- a/search/bin/scrape-cron
+++ b/search/bin/scrape-cron
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Installs a systemd timer (daily at 04:00 UTC) on the remote server that
-# runs all indexers via docker exec on the TypeSense container:
-# DocSearch scrapers (docs + forum), DocC API indexer, and GitHub issues/PRs.
+# runs the DocSearch scrapers (docs + forum), DocC API indexer, and GitHub
+# issues/PR indexer against the live TypeSense container.
 set -euo pipefail
 
 TYPESENSE_API_KEY=$(op read "op://cache/TYPESENSE_API_KEY/password")
@@ -9,24 +9,42 @@ GITHUB_TOKEN=$(op read "op://cache/SEARCH_GITHUB_TOKEN/password" 2>/dev/null || 
 
 SERVER_HOST="91.99.179.13"
 SSH_USER="${SEARCH_SSH_USER:-root}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SEARCH_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# Ensure host prerequisites and working directory.
+ssh ${SSH_USER}@${SERVER_HOST} "mkdir -p /opt/docsearch && chmod 700 /opt/docsearch"
+ssh ${SSH_USER}@${SERVER_HOST} "command -v jq >/dev/null || (apt-get update && apt-get install -y jq)"
 
 # Store secrets on server (restricted permissions)
-ssh ${SSH_USER}@${SERVER_HOST} "mkdir -p /opt/docsearch && chmod 700 /opt/docsearch"
 echo "${TYPESENSE_API_KEY}" | ssh ${SSH_USER}@${SERVER_HOST} "cat > /opt/docsearch/.api_key && chmod 600 /opt/docsearch/.api_key"
 echo "${GITHUB_TOKEN}" | ssh ${SSH_USER}@${SERVER_HOST} "cat > /opt/docsearch/.github_token && chmod 600 /opt/docsearch/.github_token"
 
-# Create runner script that docker-execs into the TypeSense container
+# Sync configs and helper scripts to the host.
+scp "${SEARCH_ROOT}/config/docsearch.json" ${SSH_USER}@${SERVER_HOST}:/opt/docsearch/docsearch.json
+scp "${SEARCH_ROOT}/config/docsearch-forum.json" ${SSH_USER}@${SERVER_HOST}:/opt/docsearch/docsearch-forum.json
+scp "${SEARCH_ROOT}/bin/index-docc" ${SSH_USER}@${SERVER_HOST}:/opt/docsearch/index-docc
+scp "${SEARCH_ROOT}/bin/index-github" ${SSH_USER}@${SERVER_HOST}:/opt/docsearch/index-github
+ssh ${SSH_USER}@${SERVER_HOST} "chmod 755 /opt/docsearch/index-docc /opt/docsearch/index-github"
+
+# Create runner script on the host.
 ssh ${SSH_USER}@${SERVER_HOST} "cat > /opt/docsearch/run.sh" << 'REMOTE_SCRIPT'
 #!/bin/bash
 set -euo pipefail
 CONTAINER=$(docker ps --filter label=service=tuist-search --filter label=role=web --format '{{.Names}}' | head -1)
+if [ -z "$CONTAINER" ]; then
+  echo "No running tuist-search container found" >&2
+  exit 1
+fi
+
 TYPESENSE_API_KEY=$(cat /opt/docsearch/.api_key)
 GITHUB_TOKEN=$(cat /opt/docsearch/.github_token 2>/dev/null || echo "")
+CONTAINER_IP=$(docker inspect "$CONTAINER" --format '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}')
 
 # DocSearch scrapers (docs, forum) — runs as a separate container since it needs network/DNS access
 for config_file in docsearch.json docsearch-forum.json; do
   echo "==> Scraping with ${config_file}..."
-  CONFIG=$(docker exec "$CONTAINER" cat /opt/docsearch/${config_file})
+  CONFIG=$(cat "/opt/docsearch/${config_file}")
   docker run --rm --network kamal --dns 8.8.8.8 \
     -e TYPESENSE_API_KEY="$TYPESENSE_API_KEY" \
     -e TYPESENSE_HOST="$CONTAINER" \
@@ -39,19 +57,17 @@ done
 
 # DocC indexer (ProjectDescription API reference)
 echo "==> Indexing DocC (ProjectDescription)..."
-docker exec \
-  -e TYPESENSE_API_KEY="$TYPESENSE_API_KEY" \
-  -e TYPESENSE_HOST="http://localhost:8108" \
-  "$CONTAINER" /opt/docsearch/index-docc
+TYPESENSE_API_KEY="$TYPESENSE_API_KEY" \
+TYPESENSE_HOST="http://${CONTAINER_IP}:8108" \
+  /opt/docsearch/index-docc
 echo "==> Done with DocC indexer"
 
 # GitHub indexer (issues and PRs)
 echo "==> Indexing GitHub issues and PRs..."
-docker exec \
-  -e TYPESENSE_API_KEY="$TYPESENSE_API_KEY" \
-  -e TYPESENSE_HOST="http://localhost:8108" \
-  -e GITHUB_TOKEN="$GITHUB_TOKEN" \
-  "$CONTAINER" /opt/docsearch/index-github
+TYPESENSE_API_KEY="$TYPESENSE_API_KEY" \
+TYPESENSE_HOST="http://${CONTAINER_IP}:8108" \
+GITHUB_TOKEN="$GITHUB_TOKEN" \
+  /opt/docsearch/index-github
 echo "==> Done with GitHub indexer"
 REMOTE_SCRIPT
 ssh ${SSH_USER}@${SERVER_HOST} "chmod 700 /opt/docsearch/run.sh"

--- a/search/config/docsearch.json
+++ b/search/config/docsearch.json
@@ -144,7 +144,8 @@
   ],
   "allowed_domains": ["tuist.dev"],
   "stop_urls": [
-    "https://tuist.dev/(?![a-z]{2}/docs).*"
+    "https://tuist.dev/(?![a-z]{2}/docs).*",
+    "https://tuist.dev/.*/docs/contributors/translate(?:/.*)?$"
   ],
   "selectors": {
     "default": {

--- a/server/lib/tuist/docs/redirects.ex
+++ b/server/lib/tuist/docs/redirects.ex
@@ -147,6 +147,7 @@ defmodule Tuist.Docs.Redirects do
     {:exact, "/guides/features/insights", "/guides/features/build-insights"},
     {:exact, "/guides/features/insights/xcode-cache", "/guides/features/build-insights/xcode"},
     {:exact, "/guides/features/insights/gradle-cache", "/guides/features/build-insights/gradle"},
+    {:exact, "/contributors/translate", "/contributors/languages"},
     {:exact, "/cli/logging", "/cli/debugging"}
   ]
 

--- a/server/lib/tuist_web/plugs/legacy_redirects_plug.ex
+++ b/server/lib/tuist_web/plugs/legacy_redirects_plug.ex
@@ -17,8 +17,7 @@ defmodule TuistWeb.Plugs.LegacyRedirectsPlug do
   @docs_locale_redirect ~r{^/docs/(?<locale>[^/]+)(?<rest>/.*)?$}
 
   @redirects %{
-    "/blog/2024/12/16/trendyol" => "/customers/trendyol",
-    "/en/contributors/translate" => "/en/contributors/languages"
+    "/blog/2024/12/16/trendyol" => "/customers/trendyol"
   }
 
   def init(opts), do: opts

--- a/server/test/tuist/docs/redirects_test.exs
+++ b/server/test/tuist/docs/redirects_test.exs
@@ -24,6 +24,11 @@ defmodule Tuist.Docs.RedirectsTest do
                {:ok, "/en/docs/guides/integrations/authentication/sso"}
     end
 
+    test "redirects the old translation guide slug to languages" do
+      assert Redirects.resolve("/en/docs/contributors/translate") ==
+               {:ok, "/en/docs/contributors/languages"}
+    end
+
     test "preserves dynamic suffixes for example redirects" do
       assert Redirects.resolve("/en/docs/guides/examples/generated-projects/app_with_airship_sdk") ==
                {:ok, "/en/docs/references/examples/generated-projects/app_with_airship_sdk"}

--- a/server/test/tuist_web/plugs/legacy_redirects_plug_test.exs
+++ b/server/test/tuist_web/plugs/legacy_redirects_plug_test.exs
@@ -64,6 +64,16 @@ defmodule TuistWeb.Plugs.LegacyRedirectsPlugTest do
       assert conn.halted
     end
 
+    test "redirects legacy translation guide paths to the languages page" do
+      conn = %{build_conn() | request_path: "/en/docs/contributors/translate"}
+
+      conn = LegacyRedirectsPlug.call(conn, [])
+
+      assert conn.status == 301
+      assert redirected_to(conn, 301) == "/en/docs/contributors/languages"
+      assert conn.halted
+    end
+
     test "normalizes legacy docs paths and resolves content redirects in one hop" do
       conn = %{build_conn() | request_path: "/docs/en/guides/develop/build/cache", query_string: "tab=setup"}
 


### PR DESCRIPTION
This fixes the stale translation guide search result by repairing both the docs redirect path and the Hetzner-hosted DocSearch refresh flow.
- move the legacy `/contributors/translate` redirect into the docs redirect layer and cover it with redirect tests
- update the DocSearch config to stop indexing the legacy translation slug
- make the scraper scripts sync configs and indexer helpers onto `/opt/docsearch` and reinstall the missing systemd timer on the search host

### How to test locally

- `bash -n search/bin/scrape search/bin/scrape-cron`
- `jq empty search/config/docsearch.json`
- `cd server && mix format --check-formatted lib/tuist/docs/redirects.ex lib/tuist_web/plugs/legacy_redirects_plug.ex test/tuist/docs/redirects_test.exs test/tuist_web/plugs/legacy_redirects_plug_test.exs`
- `cd server && mix test test/tuist/docs/redirects_test.exs test/tuist_web/plugs/legacy_redirects_plug_test.exs` (fails locally in this worktree because the test database is missing `users`)
