### PR TITLE
feat(noora): update content divider to match Figma

### DIFF
--- a/noora/css/line_divider.css
+++ b/noora/css/line_divider.css
@@ -1,13 +1,9 @@
 .noora-line-divider {
   --noora-content-divider-line: light-dark(
     var(--noora-neutral-light-400),
-    oklch(0% 0 0 / 80%)
+    var(--noora-neutral-dark-900)
   );
-  --noora-content-divider: 0px 1px 0px 0px
-    light-dark(
-      oklch(from var(--noora-neutral-light-500) l c h / 30%),
-      oklch(from var(--noora-neutral-dark-900) l c h / 35%)
-    );
+
   --noora-content-divider-label: light-dark(
     var(--noora-neutral-light-700),
     var(--noora-neutral-dark-500)
@@ -21,7 +17,6 @@
 
   & [data-part="line"] {
     transform: translateY(-0.5px);
-    box-shadow: var(--noora-content-divider);
     background-color: var(--noora-content-divider-line);
     width: 100%;
     height: 1px;

--- a/noora/css/table.css
+++ b/noora/css/table.css
@@ -103,10 +103,12 @@
       }
 
       & tr:not(:first-child):not([data-part="expanded-row"]) td {
-        box-shadow:
-          0 1px 0 0
-            light-dark(var(--noora-neutral-light-400), var(--noora-neutral-dark-900))
-            inset;
+        box-shadow: 0 1px 0 0
+          light-dark(
+            var(--noora-neutral-light-400),
+            var(--noora-neutral-dark-900)
+          )
+          inset;
       }
 
       & tr:not(:last-child) td {

--- a/noora/css/table.css
+++ b/noora/css/table.css
@@ -105,13 +105,7 @@
       & tr:not(:first-child):not([data-part="expanded-row"]) td {
         box-shadow:
           0 1px 0 0
-            light-dark(var(--noora-neutral-light-400), oklch(0% 0 0 / 80%))
-            inset,
-          0px 2px 0px 0px
-            light-dark(
-              oklch(from var(--noora-neutral-light-500) l c h / 30%),
-              oklch(from var(--noora-neutral-dark-900) l c h / 35%)
-            )
+            light-dark(var(--noora-neutral-light-400), var(--noora-neutral-dark-900))
             inset;
       }
 


### PR DESCRIPTION
Removes the 2px box shadow from the content divider and table cells.
