### PR TITLE
feat(server): make the GitHub webhook hot path leave Postgres alone

### DIFF
--- a/server/lib/tuist/key_value_store.ex
+++ b/server/lib/tuist/key_value_store.ex
@@ -167,6 +167,31 @@ defmodule Tuist.KeyValueStore do
     end
   end
 
+  @doc ~S"""
+  Removes a value from the cache. Idempotent — deleting a missing
+  key is a no-op.
+
+  ## Opts
+
+  - `:cache`: The cache to use. Defaults to `:tuist`.
+  """
+  def delete(cache_key, opts \\ []) do
+    if use_redis?(opts) do
+      try do
+        Redix.command(Environment.redis_conn_name(), ["DEL", cache_key(cache_key)])
+      rescue
+        _error in Redix.ConnectionError ->
+          delete_from_cachex(cache_key, opts)
+      end
+    else
+      delete_from_cachex(cache_key, opts)
+    end
+  end
+
+  defp delete_from_cachex(cache_key, opts) do
+    Cachex.del(cachex_cache(opts), cache_key(cache_key))
+  end
+
   defp put_in_redis(cache_key, value, opts) do
     cache_key = cache_key(cache_key)
     cache_ttl = Keyword.get(opts, :ttl, to_timeout(minute: 1))

--- a/server/lib/tuist/key_value_store.ex
+++ b/server/lib/tuist/key_value_store.ex
@@ -167,31 +167,6 @@ defmodule Tuist.KeyValueStore do
     end
   end
 
-  @doc ~S"""
-  Removes a value from the cache. Idempotent — deleting a missing
-  key is a no-op.
-
-  ## Opts
-
-  - `:cache`: The cache to use. Defaults to `:tuist`.
-  """
-  def delete(cache_key, opts \\ []) do
-    if use_redis?(opts) do
-      try do
-        Redix.command(Environment.redis_conn_name(), ["DEL", cache_key(cache_key)])
-      rescue
-        _error in Redix.ConnectionError ->
-          delete_from_cachex(cache_key, opts)
-      end
-    else
-      delete_from_cachex(cache_key, opts)
-    end
-  end
-
-  defp delete_from_cachex(cache_key, opts) do
-    Cachex.del(cachex_cache(opts), cache_key(cache_key))
-  end
-
   defp put_in_redis(cache_key, value, opts) do
     cache_key = cache_key(cache_key)
     cache_ttl = Keyword.get(opts, :ttl, to_timeout(minute: 1))

--- a/server/lib/tuist/vcs.ex
+++ b/server/lib/tuist/vcs.ex
@@ -34,12 +34,11 @@ defmodule Tuist.VCS do
   # Per-webhook lookup cache: every inbound GitHub webhook calls
   # `list_github_app_installations_for_webhook/2` once before HMAC
   # verification, so memoising the result keeps that PG read off the
-  # request path under burst load. The TTL is short enough that an
-  # in-flight rotation of `webhook_secret` heals within a minute, and
-  # mutating callers (`update_github_app_installation` /
-  # `replace_github_app_installation` / `create_github_app_installation`
-  # / `delete_github_app_installation`) evict explicitly so the cache
-  # never carries a deleted or rewritten row past the next mutation.
+  # request path under burst load. The TTL is short enough that any
+  # install / uninstall / re-register flow heals within a minute,
+  # and the only field a stale entry could mis-serve (`webhook_secret`)
+  # is rotated through `replace_github_app_installation/2` whose flow
+  # already spans longer than the TTL.
   @webhook_installations_cache_ttl_ms 60_000
 
   @doc """
@@ -1305,11 +1304,10 @@ defmodule Tuist.VCS do
   this path before HMAC verification, and the underlying table only
   changes on App install / update / uninstall (rare relative to
   webhook traffic), so memoising the lookup removes one Postgres
-  round-trip per webhook on the hot path. Mutating functions
-  (`update_github_app_installation`, `replace_github_app_installation`,
-  `create_github_app_installation`, `delete_github_app_installation`)
-  call `invalidate_webhook_installation_cache/1` so the cache never
-  outlives the row it points at by more than the TTL window.
+  round-trip per webhook on the hot path. The TTL is the sole
+  invalidation mechanism: mutations don't bust the cache because
+  the only field a stale entry could mis-serve (`webhook_secret`)
+  rotates through a flow that takes longer than the TTL anyway.
   """
   def list_github_app_installations_for_webhook(installation_id, app_id) do
     installation_id = maybe_to_string(installation_id)
@@ -1356,24 +1354,6 @@ defmodule Tuist.VCS do
   """
   def cache_name, do: :tuist
 
-  # Evicts the three cache entries that could materialise the given
-  # row through `list_github_app_installations_for_webhook/2`'s
-  # `installation_id` OR `app_id` matcher: a lookup keyed by just
-  # the installation, just the App, or both. Called by every
-  # mutation on `GitHubAppInstallation` so the cache can't hand
-  # back a row that was deleted or whose `webhook_secret` rotated.
-  defp invalidate_webhook_installation_cache(%GitHubAppInstallation{installation_id: installation_id, app_id: app_id}) do
-    installation_id = maybe_to_string(installation_id)
-    app_id = maybe_to_string(app_id)
-
-    for {iid, aid} <- [{installation_id, app_id}, {installation_id, nil}, {nil, app_id}],
-        not (iid == nil and aid == nil) do
-      KeyValueStore.delete(webhook_installations_cache_key(iid, aid), cache: cache_name())
-    end
-
-    :ok
-  end
-
   # Cachex's key serialiser (`Tuist.KeyValueStore.cache_key/1`) joins
   # list elements with `-`, so the key needs to be a flat list of
   # `to_string/1`-friendly terms. The two `_` slots reserve dedicated
@@ -1387,21 +1367,9 @@ defmodule Tuist.VCS do
   Updates a GitHub app installation.
   """
   def update_github_app_installation(%GitHubAppInstallation{} = github_app_installation, attrs) do
-    result =
-      github_app_installation
-      |> GitHubAppInstallation.update_changeset(attrs)
-      |> Repo.update()
-
-    case result do
-      {:ok, updated} ->
-        invalidate_webhook_installation_cache(github_app_installation)
-        invalidate_webhook_installation_cache(updated)
-
-      _ ->
-        :ok
-    end
-
-    result
+    github_app_installation
+    |> GitHubAppInstallation.update_changeset(attrs)
+    |> Repo.update()
   end
 
   @doc """
@@ -1412,38 +1380,18 @@ defmodule Tuist.VCS do
   def replace_github_app_installation(%GitHubAppInstallation{} = github_app_installation, attrs) do
     # The new row supersedes the old one; clear the prior installation_id
     # since the customer has not yet installed the freshly registered App.
-    result =
-      github_app_installation
-      |> GitHubAppInstallation.changeset(Map.merge(%{installation_id: nil, html_url: nil}, attrs))
-      |> Repo.update()
-
-    case result do
-      {:ok, updated} ->
-        invalidate_webhook_installation_cache(github_app_installation)
-        invalidate_webhook_installation_cache(updated)
-
-      _ ->
-        :ok
-    end
-
-    result
+    github_app_installation
+    |> GitHubAppInstallation.changeset(Map.merge(%{installation_id: nil, html_url: nil}, attrs))
+    |> Repo.update()
   end
 
   @doc """
   Creates a new GitHub app installation.
   """
   def create_github_app_installation(attrs) do
-    result =
-      %GitHubAppInstallation{}
-      |> GitHubAppInstallation.changeset(attrs)
-      |> Repo.insert()
-
-    case result do
-      {:ok, inserted} -> invalidate_webhook_installation_cache(inserted)
-      _ -> :ok
-    end
-
-    result
+    %GitHubAppInstallation{}
+    |> GitHubAppInstallation.changeset(attrs)
+    |> Repo.insert()
   end
 
   @doc """
@@ -1508,14 +1456,7 @@ defmodule Tuist.VCS do
   Deletes a GitHub app installation.
   """
   def delete_github_app_installation(%GitHubAppInstallation{} = github_app_installation) do
-    result = Repo.delete(github_app_installation, stale_error_field: :id)
-
-    case result do
-      {:ok, _deleted} -> invalidate_webhook_installation_cache(github_app_installation)
-      _ -> :ok
-    end
-
-    result
+    Repo.delete(github_app_installation, stale_error_field: :id)
   end
 
   @doc """

--- a/server/lib/tuist/vcs.ex
+++ b/server/lib/tuist/vcs.ex
@@ -1308,8 +1308,13 @@ defmodule Tuist.VCS do
   invalidation mechanism: mutations don't bust the cache because
   the only field a stale entry could mis-serve (`webhook_secret`)
   rotates through a flow that takes longer than the TTL anyway.
+
+  ## Opts
+
+  - `:cache` — Cachex instance to use. Defaults to `:tuist`; tests
+    pass a per-case Cachex so state doesn't leak across runs.
   """
-  def list_github_app_installations_for_webhook(installation_id, app_id) do
+  def list_github_app_installations_for_webhook(installation_id, app_id, opts \\ []) do
     installation_id = maybe_to_string(installation_id)
     app_id = maybe_to_string(app_id)
 
@@ -1318,7 +1323,7 @@ defmodule Tuist.VCS do
     else
       KeyValueStore.get_or_update(
         webhook_installations_cache_key(installation_id, app_id),
-        [cache: cache_name(), ttl: @webhook_installations_cache_ttl_ms],
+        [cache: Keyword.get(opts, :cache, :tuist), ttl: @webhook_installations_cache_ttl_ms],
         fn ->
           case build_webhook_lookup_query(installation_id, app_id) do
             nil -> []
@@ -1345,21 +1350,6 @@ defmodule Tuist.VCS do
     )
   end
 
-  @doc """
-  Name of the Cachex instance backing the webhook installations cache.
-  Returns the application-wide `:tuist` cache in prod; tests can
-  `stub/3` this to point at a per-test Cachex started via
-  `start_supervised!` so cache state never leaks across parallel
-  cases.
-  """
-  def cache_name, do: :tuist
-
-  # Cachex's key serialiser (`Tuist.KeyValueStore.cache_key/1`) joins
-  # list elements with `-`, so the key needs to be a flat list of
-  # `to_string/1`-friendly terms. The two `_` slots reserve dedicated
-  # positions for `installation_id` and `app_id` (empty string when
-  # absent) so a lookup keyed by just one of them can't collide with a
-  # lookup keyed by the other.
   defp webhook_installations_cache_key(installation_id, app_id),
     do: [__MODULE__, :webhook_installations, installation_id || "_", app_id || "_"]
 

--- a/server/lib/tuist/vcs.ex
+++ b/server/lib/tuist/vcs.ex
@@ -31,6 +31,17 @@ defmodule Tuist.VCS do
   @max_flaky_tests_in_comment 5
   @max_failed_tests_in_comment 5
 
+  # Per-webhook lookup cache: every inbound GitHub webhook calls
+  # `list_github_app_installations_for_webhook/2` once before HMAC
+  # verification, so memoising the result keeps that PG read off the
+  # request path under burst load. The TTL is short enough that an
+  # in-flight rotation of `webhook_secret` heals within a minute, and
+  # mutating callers (`update_github_app_installation` /
+  # `replace_github_app_installation` / `create_github_app_installation`
+  # / `delete_github_app_installation`) evict explicitly so the cache
+  # never carries a deleted or rewritten row past the next mutation.
+  @webhook_installations_cache_ttl_ms 60_000
+
   @doc """
   Constructs a CI run URL based on the CI provider and metadata.
   Returns nil if the required CI information is missing.
@@ -1288,11 +1299,35 @@ defmodule Tuist.VCS do
 
   Both filters are optional. Pass `nil` for either to skip it. With
   both `nil`, returns `[]`.
+
+  The result is cached for #{@webhook_installations_cache_ttl_ms} ms
+  keyed by `(installation_id, app_id)`. Every inbound webhook hits
+  this path before HMAC verification, and the underlying table only
+  changes on App install / update / uninstall (rare relative to
+  webhook traffic), so memoising the lookup removes one Postgres
+  round-trip per webhook on the hot path. Mutating functions
+  (`update_github_app_installation`, `replace_github_app_installation`,
+  `create_github_app_installation`, `delete_github_app_installation`)
+  call `invalidate_webhook_installation_cache/1` so the cache never
+  outlives the row it points at by more than the TTL window.
   """
   def list_github_app_installations_for_webhook(installation_id, app_id) do
-    case build_webhook_lookup_query(maybe_to_string(installation_id), maybe_to_string(app_id)) do
-      nil -> []
-      query -> Repo.all(query)
+    installation_id = maybe_to_string(installation_id)
+    app_id = maybe_to_string(app_id)
+
+    if installation_id == nil and app_id == nil do
+      []
+    else
+      KeyValueStore.get_or_update(
+        webhook_installations_cache_key(installation_id, app_id),
+        [cache: cache_name(), ttl: @webhook_installations_cache_ttl_ms],
+        fn ->
+          case build_webhook_lookup_query(installation_id, app_id) do
+            nil -> []
+            query -> Repo.all(query)
+          end
+        end
+      )
     end
   end
 
@@ -1313,12 +1348,60 @@ defmodule Tuist.VCS do
   end
 
   @doc """
+  Name of the Cachex instance backing the webhook installations cache.
+  Returns the application-wide `:tuist` cache in prod; tests can
+  `stub/3` this to point at a per-test Cachex started via
+  `start_supervised!` so cache state never leaks across parallel
+  cases.
+  """
+  def cache_name, do: :tuist
+
+  # Evicts the three cache entries that could materialise the given
+  # row through `list_github_app_installations_for_webhook/2`'s
+  # `installation_id` OR `app_id` matcher: a lookup keyed by just
+  # the installation, just the App, or both. Called by every
+  # mutation on `GitHubAppInstallation` so the cache can't hand
+  # back a row that was deleted or whose `webhook_secret` rotated.
+  defp invalidate_webhook_installation_cache(%GitHubAppInstallation{installation_id: installation_id, app_id: app_id}) do
+    installation_id = maybe_to_string(installation_id)
+    app_id = maybe_to_string(app_id)
+
+    for {iid, aid} <- [{installation_id, app_id}, {installation_id, nil}, {nil, app_id}],
+        not (iid == nil and aid == nil) do
+      KeyValueStore.delete(webhook_installations_cache_key(iid, aid), cache: cache_name())
+    end
+
+    :ok
+  end
+
+  # Cachex's key serialiser (`Tuist.KeyValueStore.cache_key/1`) joins
+  # list elements with `-`, so the key needs to be a flat list of
+  # `to_string/1`-friendly terms. The two `_` slots reserve dedicated
+  # positions for `installation_id` and `app_id` (empty string when
+  # absent) so a lookup keyed by just one of them can't collide with a
+  # lookup keyed by the other.
+  defp webhook_installations_cache_key(installation_id, app_id),
+    do: [__MODULE__, :webhook_installations, installation_id || "_", app_id || "_"]
+
+  @doc """
   Updates a GitHub app installation.
   """
   def update_github_app_installation(%GitHubAppInstallation{} = github_app_installation, attrs) do
-    github_app_installation
-    |> GitHubAppInstallation.update_changeset(attrs)
-    |> Repo.update()
+    result =
+      github_app_installation
+      |> GitHubAppInstallation.update_changeset(attrs)
+      |> Repo.update()
+
+    case result do
+      {:ok, updated} ->
+        invalidate_webhook_installation_cache(github_app_installation)
+        invalidate_webhook_installation_cache(updated)
+
+      _ ->
+        :ok
+    end
+
+    result
   end
 
   @doc """
@@ -1329,18 +1412,38 @@ defmodule Tuist.VCS do
   def replace_github_app_installation(%GitHubAppInstallation{} = github_app_installation, attrs) do
     # The new row supersedes the old one; clear the prior installation_id
     # since the customer has not yet installed the freshly registered App.
-    github_app_installation
-    |> GitHubAppInstallation.changeset(Map.merge(%{installation_id: nil, html_url: nil}, attrs))
-    |> Repo.update()
+    result =
+      github_app_installation
+      |> GitHubAppInstallation.changeset(Map.merge(%{installation_id: nil, html_url: nil}, attrs))
+      |> Repo.update()
+
+    case result do
+      {:ok, updated} ->
+        invalidate_webhook_installation_cache(github_app_installation)
+        invalidate_webhook_installation_cache(updated)
+
+      _ ->
+        :ok
+    end
+
+    result
   end
 
   @doc """
   Creates a new GitHub app installation.
   """
   def create_github_app_installation(attrs) do
-    %GitHubAppInstallation{}
-    |> GitHubAppInstallation.changeset(attrs)
-    |> Repo.insert()
+    result =
+      %GitHubAppInstallation{}
+      |> GitHubAppInstallation.changeset(attrs)
+      |> Repo.insert()
+
+    case result do
+      {:ok, inserted} -> invalidate_webhook_installation_cache(inserted)
+      _ -> :ok
+    end
+
+    result
   end
 
   @doc """
@@ -1405,7 +1508,14 @@ defmodule Tuist.VCS do
   Deletes a GitHub app installation.
   """
   def delete_github_app_installation(%GitHubAppInstallation{} = github_app_installation) do
-    Repo.delete(github_app_installation, stale_error_field: :id)
+    result = Repo.delete(github_app_installation, stale_error_field: :id)
+
+    case result do
+      {:ok, _deleted} -> invalidate_webhook_installation_cache(github_app_installation)
+      _ -> :ok
+    end
+
+    result
   end
 
   @doc """

--- a/server/lib/tuist_web/controllers/webhooks/github_controller.ex
+++ b/server/lib/tuist_web/controllers/webhooks/github_controller.ex
@@ -226,6 +226,16 @@ defmodule TuistWeb.Webhooks.GitHubController do
   #     would have us 503-ing anyway.
   #   * Worker errors → Oban retries with backoff up to
   #     `max_attempts`. The HTTP layer is done.
+  # Actions that the dispatch pipeline persists or claims against.
+  # `Tuist.Runners.Dispatch.handle_webhook/2` only branches on these
+  # two — every other action (notably `in_progress`, ~33 % of
+  # `workflow_job` traffic) falls through to the catch-all
+  # `:ignored` branch in the worker. Short-circuiting here removes
+  # the Oban.insert (and its Postgres write) for those events,
+  # which under burst load was costing us ~one PG checkout per
+  # webhook for work the worker was going to discard anyway.
+  @dispatchable_workflow_job_actions ~w(queued completed)
+
   defp handle_workflow_job(conn, params) do
     installation_id =
       case params do
@@ -234,11 +244,17 @@ defmodule TuistWeb.Webhooks.GitHubController do
       end
 
     delivery_guid = conn |> get_req_header("x-github-delivery") |> List.first()
+    action = Map.get(params, "action")
 
-    if installation_id do
-      enqueue_dispatch(conn, params, installation_id, delivery_guid)
-    else
-      conn |> put_status(:ok) |> json(%{status: "ok"})
+    cond do
+      is_nil(installation_id) ->
+        conn |> put_status(:ok) |> json(%{status: "ok"})
+
+      action not in @dispatchable_workflow_job_actions ->
+        conn |> put_status(:ok) |> json(%{status: "ok"})
+
+      true ->
+        enqueue_dispatch(conn, params, installation_id, delivery_guid)
     end
   end
 

--- a/server/test/tuist/vcs_test.exs
+++ b/server/test/tuist/vcs_test.exs
@@ -3663,11 +3663,11 @@ defmodule Tuist.VCSTest do
     setup do
       cache = :"vcs_webhook_#{System.unique_integer([:positive])}"
       start_supervised!({Cachex, name: cache})
-      stub(VCS, :cache_name, fn -> cache end)
-      :ok
+      %{cache: cache}
     end
 
-    test "memoises the lookup so a repeated webhook does not re-query Postgres" do
+    test "memoises the lookup so a repeated webhook does not re-query Postgres",
+         %{cache: cache} do
       # Given a real row to hit on the first call.
       account = AccountsFixtures.organization_fixture().account
 
@@ -3678,19 +3678,19 @@ defmodule Tuist.VCSTest do
           app_id: "999"
         })
 
-      first = VCS.list_github_app_installations_for_webhook("111", "999")
+      first = VCS.list_github_app_installations_for_webhook("111", "999", cache: cache)
       assert [%GitHubAppInstallation{id: id}] = first
       assert id == installation.id
 
       # Repo.all/1 must not be called on the second invocation — the
-      # mimic expect fails the test if it is.
+      # mimic reject fails the test if it is.
       reject(&Tuist.Repo.all/1)
 
-      second = VCS.list_github_app_installations_for_webhook("111", "999")
+      second = VCS.list_github_app_installations_for_webhook("111", "999", cache: cache)
       assert second == first
     end
 
-    test "honours nil filters separately from supplied ones" do
+    test "honours nil filters separately from supplied ones", %{cache: cache} do
       account = AccountsFixtures.organization_fixture().account
 
       {:ok, installation} =
@@ -3703,8 +3703,8 @@ defmodule Tuist.VCSTest do
       # Lookup by installation_id alone uses a distinct cache slot
       # from the (installation_id, app_id) lookup, so they don't
       # collide in the cache key.
-      by_installation = VCS.list_github_app_installations_for_webhook("222", nil)
-      by_both = VCS.list_github_app_installations_for_webhook("222", "1000")
+      by_installation = VCS.list_github_app_installations_for_webhook("222", nil, cache: cache)
+      by_both = VCS.list_github_app_installations_for_webhook("222", "1000", cache: cache)
 
       assert [%GitHubAppInstallation{id: id1}] = by_installation
       assert [%GitHubAppInstallation{id: id2}] = by_both
@@ -3712,9 +3712,9 @@ defmodule Tuist.VCSTest do
       assert id2 == installation.id
     end
 
-    test "returns [] without touching Postgres when both filters are nil" do
+    test "returns [] without touching Postgres when both filters are nil", %{cache: cache} do
       reject(&Tuist.Repo.all/1)
-      assert VCS.list_github_app_installations_for_webhook(nil, nil) == []
+      assert VCS.list_github_app_installations_for_webhook(nil, nil, cache: cache) == []
     end
   end
 end

--- a/server/test/tuist/vcs_test.exs
+++ b/server/test/tuist/vcs_test.exs
@@ -3658,4 +3658,112 @@ defmodule Tuist.VCSTest do
       assert changeset.valid?
     end
   end
+
+  describe "list_github_app_installations_for_webhook/2 caching" do
+    setup do
+      cache = :"vcs_webhook_#{System.unique_integer([:positive])}"
+      start_supervised!({Cachex, name: cache})
+      stub(VCS, :cache_name, fn -> cache end)
+      :ok
+    end
+
+    test "memoises the lookup so a repeated webhook does not re-query Postgres" do
+      # Given a real row to hit on the first call.
+      account = AccountsFixtures.organization_fixture().account
+
+      {:ok, installation} =
+        VCS.create_github_app_installation(%{
+          account_id: account.id,
+          installation_id: "111",
+          app_id: "999"
+        })
+
+      first = VCS.list_github_app_installations_for_webhook("111", "999")
+      assert [%GitHubAppInstallation{id: id}] = first
+      assert id == installation.id
+
+      # Repo.all/1 must not be called on the second invocation — the
+      # mimic expect fails the test if it is.
+      reject(&Tuist.Repo.all/1)
+
+      second = VCS.list_github_app_installations_for_webhook("111", "999")
+      assert second == first
+    end
+
+    test "honours nil filters separately from supplied ones" do
+      account = AccountsFixtures.organization_fixture().account
+
+      {:ok, installation} =
+        VCS.create_github_app_installation(%{
+          account_id: account.id,
+          installation_id: "222",
+          app_id: "1000"
+        })
+
+      # Lookup by installation_id alone uses a distinct cache slot
+      # from the (installation_id, app_id) lookup, so they don't
+      # collide in the cache key.
+      by_installation = VCS.list_github_app_installations_for_webhook("222", nil)
+      by_both = VCS.list_github_app_installations_for_webhook("222", "1000")
+
+      assert [%GitHubAppInstallation{id: id1}] = by_installation
+      assert [%GitHubAppInstallation{id: id2}] = by_both
+      assert id1 == installation.id
+      assert id2 == installation.id
+    end
+
+    test "returns [] without touching Postgres when both filters are nil" do
+      reject(&Tuist.Repo.all/1)
+      assert VCS.list_github_app_installations_for_webhook(nil, nil) == []
+    end
+
+    test "delete_github_app_installation/1 evicts the cache" do
+      account = AccountsFixtures.organization_fixture().account
+
+      {:ok, installation} =
+        VCS.create_github_app_installation(%{
+          account_id: account.id,
+          installation_id: "333",
+          app_id: "1001"
+        })
+
+      # Warm the cache.
+      assert [%GitHubAppInstallation{}] =
+               VCS.list_github_app_installations_for_webhook("333", "1001")
+
+      # Delete the row — invalidation must drop the stale entry, so
+      # the next lookup actually goes back to Postgres and observes
+      # the deletion.
+      {:ok, _} = VCS.delete_github_app_installation(installation)
+
+      assert VCS.list_github_app_installations_for_webhook("333", "1001") == []
+    end
+
+    test "update_github_app_installation/2 evicts the cache" do
+      account = AccountsFixtures.organization_fixture().account
+
+      {:ok, installation} =
+        VCS.create_github_app_installation(%{
+          account_id: account.id,
+          installation_id: "444",
+          app_id: "1002",
+          html_url: "https://github.com/apps/old-slug"
+        })
+
+      [%GitHubAppInstallation{html_url: cached_html_url}] =
+        VCS.list_github_app_installations_for_webhook("444", "1002")
+
+      assert cached_html_url == "https://github.com/apps/old-slug"
+
+      {:ok, _} =
+        VCS.update_github_app_installation(installation, %{
+          html_url: "https://github.com/apps/new-slug"
+        })
+
+      [%GitHubAppInstallation{html_url: fresh_html_url}] =
+        VCS.list_github_app_installations_for_webhook("444", "1002")
+
+      assert fresh_html_url == "https://github.com/apps/new-slug"
+    end
+  end
 end

--- a/server/test/tuist/vcs_test.exs
+++ b/server/test/tuist/vcs_test.exs
@@ -3716,54 +3716,5 @@ defmodule Tuist.VCSTest do
       reject(&Tuist.Repo.all/1)
       assert VCS.list_github_app_installations_for_webhook(nil, nil) == []
     end
-
-    test "delete_github_app_installation/1 evicts the cache" do
-      account = AccountsFixtures.organization_fixture().account
-
-      {:ok, installation} =
-        VCS.create_github_app_installation(%{
-          account_id: account.id,
-          installation_id: "333",
-          app_id: "1001"
-        })
-
-      # Warm the cache.
-      assert [%GitHubAppInstallation{}] =
-               VCS.list_github_app_installations_for_webhook("333", "1001")
-
-      # Delete the row — invalidation must drop the stale entry, so
-      # the next lookup actually goes back to Postgres and observes
-      # the deletion.
-      {:ok, _} = VCS.delete_github_app_installation(installation)
-
-      assert VCS.list_github_app_installations_for_webhook("333", "1001") == []
-    end
-
-    test "update_github_app_installation/2 evicts the cache" do
-      account = AccountsFixtures.organization_fixture().account
-
-      {:ok, installation} =
-        VCS.create_github_app_installation(%{
-          account_id: account.id,
-          installation_id: "444",
-          app_id: "1002",
-          html_url: "https://github.com/apps/old-slug"
-        })
-
-      [%GitHubAppInstallation{html_url: cached_html_url}] =
-        VCS.list_github_app_installations_for_webhook("444", "1002")
-
-      assert cached_html_url == "https://github.com/apps/old-slug"
-
-      {:ok, _} =
-        VCS.update_github_app_installation(installation, %{
-          html_url: "https://github.com/apps/new-slug"
-        })
-
-      [%GitHubAppInstallation{html_url: fresh_html_url}] =
-        VCS.list_github_app_installations_for_webhook("444", "1002")
-
-      assert fresh_html_url == "https://github.com/apps/new-slug"
-    end
   end
 end

--- a/server/test/tuist_web/controllers/webhooks/github_controller_test.exs
+++ b/server/test/tuist_web/controllers/webhooks/github_controller_test.exs
@@ -658,5 +658,74 @@ defmodule TuistWeb.Webhooks.GitHubControllerTest do
       assert result.status == 200
       refute_enqueued(worker: DispatchWorker)
     end
+
+    test "200s without enqueueing for action=in_progress (worker would treat it as ignored)",
+         %{conn: conn} do
+      conn =
+        conn
+        |> put_req_header("x-github-event", "workflow_job")
+        |> put_req_header("x-github-delivery", "deadbeef-in-progress")
+
+      params = %{
+        "action" => "in_progress",
+        "installation" => %{"id" => System.unique_integer([:positive])},
+        "workflow_job" => %{"id" => 1, "labels" => ["tuist-macos"]},
+        "repository" => %{"full_name" => "tuist/tuist"}
+      }
+
+      result = GitHubController.handle(conn, params)
+
+      assert result.status == 200
+      refute_enqueued(worker: DispatchWorker)
+    end
+
+    test "200s without enqueueing for unknown actions", %{conn: conn} do
+      conn =
+        conn
+        |> put_req_header("x-github-event", "workflow_job")
+        |> put_req_header("x-github-delivery", "deadbeef-unknown-action")
+
+      params = %{
+        "action" => "waiting",
+        "installation" => %{"id" => System.unique_integer([:positive])},
+        "workflow_job" => %{"id" => 1, "labels" => ["tuist-macos"]},
+        "repository" => %{"full_name" => "tuist/tuist"}
+      }
+
+      result = GitHubController.handle(conn, params)
+
+      assert result.status == 200
+      refute_enqueued(worker: DispatchWorker)
+    end
+
+    test "enqueues for action=completed", %{conn: conn} do
+      installation_id = System.unique_integer([:positive])
+      delivery_guid = "deadbeef-completed"
+
+      conn =
+        conn
+        |> put_req_header("x-github-event", "workflow_job")
+        |> put_req_header("x-github-delivery", delivery_guid)
+
+      params = %{
+        "action" => "completed",
+        "installation" => %{"id" => installation_id},
+        "workflow_job" => %{"id" => 2, "labels" => ["tuist-macos"]},
+        "repository" => %{"full_name" => "tuist/tuist"}
+      }
+
+      result = GitHubController.handle(conn, params)
+
+      assert result.status == 200
+
+      assert_enqueued(
+        worker: DispatchWorker,
+        args: %{
+          "payload" => params,
+          "installation_id" => installation_id,
+          "delivery_guid" => delivery_guid
+        }
+      )
+    end
   end
 end


### PR DESCRIPTION
## Summary

Pulls two PG round-trips out of the `/webhooks/github` request handler so a burst of inbound `workflow_job` deliveries can't saturate the Ecto pool and start returning 502 to GitHub (which we observed during the [#10886](https://github.com/tuist/tuist/pull/10886) bring-up when ~30 deliveries hit at once).

Diagnosis traced the slow path to two synchronous Postgres calls every webhook makes before returning 200:

1. `VCS.list_github_app_installations_for_webhook/2` — uncached `Repo.all` for HMAC candidate-set lookup, runs before signature verification.
2. `Oban.insert/1` — even for `workflow_job.action` values the dispatch worker treats as `:ignored` (most notably `in_progress`, which is ~33 % of `workflow_job` traffic).

Both write through the same per-replica pool. With Ecto's 15 s checkout timeout, a burst that overflows the pool produces the exact 9 s upstream-timeout 502 we caught in GitHub's hookshot delivery log.

## What changed

**Controller: skip the `Oban.insert` when the action isn't dispatchable.** `Tuist.Runners.Dispatch.handle_webhook/2` only persists `queued` and `completed`; every other action falls through its catch-all `:ignored` branch. The controller now mirrors that gate and 200s without enqueueing, removing the PG write for ~33 % of inbound `workflow_job` deliveries.

**VCS: cache `list_github_app_installations_for_webhook/2`.** 60 s TTL, keyed by `(installation_id, app_id)`. Steady-state webhook traffic skips the `Repo.all/1` entirely. The TTL is the sole invalidation mechanism: the only field a stale entry could mis-serve (`webhook_secret`) only rotates through `replace_github_app_installation/2`, whose manifest-re-registration flow takes longer than 60 s anyway. The other three mutators (`create`, `update`, `delete`) can't produce a stale-cache scenario worth instrumenting:

* `update_github_app_installation/2`'s changeset whitelists only `:html_url`, `:installation_id`, `:app_slug` — none affect HMAC verification.
* `delete_github_app_installation/1` removes a row, but GitHub stops dispatching to an uninstalled App, so any in-flight webhook is signed by the still-valid (about-to-be-deleted) secret.
* `create_github_app_installation/1` has no entry to evict — the first lookup is a cold miss by definition.

## Test plan

- [x] `mix test test/tuist/vcs_test.exs test/tuist_web/controllers/webhooks/github_controller_test.exs` — 125 tests, 0 failures
- [x] New cache-behaviour tests in `vcs_test.exs` cover: cache hit on repeated query, distinct cache slots for `(iid, nil)` vs `(iid, aid)`, no-op when both filters are nil
- [x] New controller tests in `github_controller_test.exs` cover: `in_progress` → no enqueue, unknown action → no enqueue, `completed` → enqueue, plus the existing `queued` and `no installation.id` paths
- [x] `mix credo` clean on touched files
- [x] `mix format --check-formatted` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)