### PR TITLE
fix(cache): support private CAs for cache-to-server auth

### DIFF
--- a/cache/README.md
+++ b/cache/README.md
@@ -36,6 +36,7 @@ This service provides:
    - `PUBLIC_HOST` - Hostname for the service (release entrypoint sets `$(cat /etc/host_hostname).tuist.dev`)
    - `PORT` - Port to run on (default: 4000)
    - `SERVER_URL` - URL of the main Tuist server for authentication
+   - `SERVER_CA_CERT_PEM` - Optional PEM-encoded CA certificate for verifying HTTPS connections to `SERVER_URL` (also accepted as `TUIST_SERVER_CA_CERT_PEM`)
    - `STORAGE_DIR` - Directory for artifact storage (default: `/storage`)
    - `DISK_HIGH_WATERMARK_PERCENT` - Optional high watermark (%) that triggers disk eviction (default: `75`)
    - `DISK_TARGET_PERCENT` - Optional target usage (%) the eviction job aims for after cleanup (default: `60`)

--- a/cache/config/runtime.exs
+++ b/cache/config/runtime.exs
@@ -145,6 +145,7 @@ if config_env() == :prod do
 
   config :cache,
     server_url: System.get_env("SERVER_URL") || "https://tuist.dev",
+    server_ca_cert_pem: System.get_env("SERVER_CA_CERT_PEM") || System.get_env("TUIST_SERVER_CA_CERT_PEM"),
     storage_dir: System.get_env("STORAGE_DIR") || raise("environment variable STORAGE_DIR is missing"),
     disk_usage_high_watermark_percent: Cache.Config.float_env("DISK_HIGH_WATERMARK_PERCENT", 75.0),
     disk_usage_target_percent: Cache.Config.float_env("DISK_TARGET_PERCENT", 60.0),

--- a/cache/docker-compose.yml
+++ b/cache/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       PHX_SERVER: "true"
       SECRET_KEY_BASE: ${SECRET_KEY_BASE}
       SERVER_URL: ${SERVER_URL}
+      SERVER_CA_CERT_PEM: ${SERVER_CA_CERT_PEM}
       STORAGE_DIR: /storage
       PHX_SOCKET_PATH: /run/cache/cache.sock
       PHX_SOCKET_LINK: /run/cache/current.sock

--- a/cache/lib/cache/config.ex
+++ b/cache/lib/cache/config.ex
@@ -136,6 +136,13 @@ defmodule Cache.Config do
     end
   end
 
+  def server_ca_cert_pem(value \\ Application.get_env(:cache, :server_ca_cert_pem)) do
+    case value do
+      pem when is_binary(pem) and pem != "" -> pem
+      _ -> nil
+    end
+  end
+
   def s3_virtual_host do
     !!Application.get_env(:ex_aws, :s3)[:virtual_host]
   end

--- a/cache/lib/cache/finch/pools.ex
+++ b/cache/lib/cache/finch/pools.ex
@@ -11,10 +11,10 @@ defmodule Cache.Finch.Pools do
         conn_opts: [
           log: true,
           protocols: [:http2, :http1],
-          transport_opts: [
-            cacertfile: CAStore.file_path(),
-            verify: :verify_peer
-          ]
+          transport_opts:
+            [
+              verify: :verify_peer
+            ] ++ TuistCommon.FinchPools.ca_cert_opts(Cache.Config.server_ca_cert_pem())
         ],
         size: 32,
         count: 8,

--- a/cache/test/cache/config_test.exs
+++ b/cache/test/cache/config_test.exs
@@ -19,4 +19,15 @@ defmodule Cache.ConfigTest do
       assert Cache.Config.s3_ca_cert_pem(ca_cert_pem: "") == nil
     end
   end
+
+  describe "server_ca_cert_pem/1" do
+    test "returns the configured PEM bundle" do
+      assert Cache.Config.server_ca_cert_pem("pem-content") == "pem-content"
+    end
+
+    test "returns nil when unset or blank" do
+      assert Cache.Config.server_ca_cert_pem(nil) == nil
+      assert Cache.Config.server_ca_cert_pem("") == nil
+    end
+  end
 end

--- a/cache/test/cache/finch/pools_test.exs
+++ b/cache/test/cache/finch/pools_test.exs
@@ -10,6 +10,7 @@ defmodule Cache.Finch.PoolsTest do
     setup do
       stub(Cache.Config, :cache_bucket, fn -> "cache-bucket" end)
       stub(Cache.Config, :server_url, fn -> "https://tuist.dev" end)
+      stub(Cache.Config, :server_ca_cert_pem, fn -> nil end)
       stub(Cache.Config, :s3_ca_cert_pem, fn -> nil end)
       stub(Cache.Config, :s3_virtual_host, fn -> false end)
 
@@ -52,6 +53,22 @@ defmodule Cache.Finch.PoolsTest do
 
       assert Keyword.get(server_pool, :protocols) == [:http2, :http1]
       assert Keyword.get(server_pool[:conn_opts], :protocols) == [:http2, :http1]
+    end
+
+    test "uses the configured CA bundle for server TLS" do
+      pem = File.read!(CAStore.file_path())
+
+      stub(Cache.Config, :server_ca_cert_pem, fn -> pem end)
+
+      config = Pools.config()
+      server_pool = Map.get(config, "https://tuist.dev")
+      transport_opts = Keyword.fetch!(server_pool[:conn_opts], :transport_opts)
+
+      refute Keyword.has_key?(transport_opts, :cacertfile)
+
+      cacerts = Keyword.fetch!(transport_opts, :cacerts)
+      assert is_list(cacerts) and cacerts != []
+      assert Enum.all?(cacerts, &is_binary/1)
     end
 
     test "defaults S3 protocols to [:http2, :http1] when not configured" do

--- a/server/priv/docs/en/guides/cache/self-host.md
+++ b/server/priv/docs/en/guides/cache/self-host.md
@@ -58,6 +58,9 @@ PUBLIC_HOST=cache.example.com
 # - Hosted: https://tuist.dev
 # - Self-hosted: https://your-tuist-server.example.com
 SERVER_URL=https://tuist.dev
+# Optional: PEM-encoded CA certificate for internal or self-signed Tuist server endpoints.
+# Also accepted as TUIST_SERVER_CA_CERT_PEM.
+# SERVER_CA_CERT_PEM=-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----
 
 # S3 Storage configuration
 S3_BUCKET=your-cache-bucket
@@ -94,6 +97,7 @@ KEY_VALUE_DATABASE_PATH=/data/key_value.sqlite
 | `SECRET_KEY_BASE` | Yes | | Secret key used to sign and encrypt data (minimum 64 characters). |
 | `PUBLIC_HOST` | Yes | | Public hostname or IP address of your cache service. Used to generate absolute URLs. |
 | `SERVER_URL` | No | `https://tuist.dev` | URL of your Tuist server for authentication. |
+| `SERVER_CA_CERT_PEM` | No | System CA bundle | PEM-encoded CA certificate for verifying HTTPS connections to `SERVER_URL`. Useful for internal Certificate Authorities or self-signed Tuist server endpoints. Also accepted as `TUIST_SERVER_CA_CERT_PEM`. |
 | `STORAGE_DIR` | Yes | | Directory where CAS artifacts are stored on disk. The provided Docker Compose setup uses `/storage`. |
 | `KEY_VALUE_DATABASE_PATH` | No | `/data/key_value.sqlite` | Path to the dedicated SQLite database used by the key-value store. |
 | `POOL_SIZE` | No | `2` | Connection pool size for the primary metadata SQLite database. |

--- a/tuist_common/lib/tuist_common/finch_pools.ex
+++ b/tuist_common/lib/tuist_common/finch_pools.ex
@@ -76,9 +76,16 @@ defmodule TuistCommon.FinchPools do
     end
   end
 
-  defp ca_cert_opts(nil), do: [cacertfile: CAStore.file_path()]
+  @doc """
+  Returns TLS CA verification options for Finch/Mint transport options.
 
-  defp ca_cert_opts(pem_content) do
+  When `pem_content` is nil, the bundled CAStore bundle is used. When a PEM
+  bundle is supplied, it is decoded into DER certificates so callers can trust
+  private or internal CAs that are not in CAStore.
+  """
+  def ca_cert_opts(nil), do: [cacertfile: CAStore.file_path()]
+
+  def ca_cert_opts(pem_content) do
     der_certs =
       pem_content
       |> normalize_pem_content()


### PR DESCRIPTION
Resolves N/A

> Cache auth requests to `SERVER_URL` were always pinned to `CAStore.file_path()`, so self-hosted deployments that terminate TLS with a private or internal CA could not verify `/api/projects` and failed authorization even when the server endpoint itself was configured correctly.
>
> This adds a dedicated `SERVER_CA_CERT_PEM` override, wires the cache service's server Finch pool through the shared CA helper already used for S3, and documents the new self-hosted configuration path. The helper stays responsible for translating PEM bundles into Mint transport options, which keeps the trust override logic in one place instead of duplicating certificate handling in the cache app.
>
> The change also adds tests for the new config accessor and for the server Finch pool trust options so we cover the regression directly.

### How to test locally

- `cd cache && mix test test/cache/config_test.exs test/cache/finch/pools_test.exs`
- `cd tuist_common && mix test test/tuist_common/finch_pools_test.exs`
