### PR TITLE
chore(cli): bump tuist.Command to 0.14.5

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -591,7 +591,7 @@
       "kind" : "registry",
       "location" : "",
       "state" : {
-        "version" : "0.14.4"
+        "version" : "0.14.5"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -1739,7 +1739,7 @@ let package = Package(
         .package(id: "tuist.Path", .upToNextMajor(from: "0.3.8")),
         .package(id: "p-x9.MachOKit", .upToNextMajor(from: "0.46.1")),
         .package(id: "tuist.FileSystem", .upToNextMajor(from: "0.17.3")),
-        .package(id: "tuist.Command", .upToNextMajor(from: "0.14.4")),
+        .package(id: "tuist.Command", .upToNextMajor(from: "0.14.5")),
         .package(id: "apple.swift-crypto", from: "3.0.0"),
         .package(id: "crspybits.swift-log-file", .upToNextMajor(from: "0.1.0")),
         .package(id: "tuist.Noora", from: "0.55.0"),


### PR DESCRIPTION
## Summary

Bumps `tuist.Command` from `0.14.4` to `0.14.5` to pick up [tuist/Command#262](https://github.com/tuist/Command/pull/262), which replaces a `try!` trap in `CommandRunner.run` with proper error propagation through the `AsyncThrowingStream` continuation.

### Why

When `FileManager.default.currentDirectoryPath` returns an empty string (Foundation's signal that the underlying `getcwd` failed), the old code trapped via `try! AbsolutePath(validating: "")`, surfacing as `Trace/BPT trap: 5` with no usable stack — the trap aborts the process before any Swift error unwinds.

After this bump, the same condition surfaces as a regular Swift error at the awaiting call site. That makes the next reproducer of the recently-reported `tuist generate` crash diagnosable instead of opaque.

This pairs with [#10891](https://github.com/tuist/tuist/pull/10891), which removes the implicit `currentDirectoryPath` dependency at the highest-volume SPM callers as a defensive measure. The two changes are independently useful — this one is the diagnostic safety net; the other reduces the surface area where the failure can fire.

## Test plan

- [ ] CI green