### PR TITLE
Harden Kura regional rollout bootstrap

### DIFF
--- a/infra/grafana-dashboards/tuist-kura.json
+++ b/infra/grafana-dashboards/tuist-kura.json
@@ -107,7 +107,7 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "up{cluster=~\"${cluster:regex}\", instance=~\"${instance:regex}\"}",
+            "expr": "up{cluster=~\"$cluster\", instance=~\"$instance\"}",
             "instant": true,
             "legendFormat": "{{instance}}",
             "range": false,
@@ -170,7 +170,7 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "sum(rate(kura_http_requests_total_total{cluster=~\"${cluster:regex}\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"}[$__rate_interval]))",
+            "expr": "sum(rate(kura_http_requests_total_total{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\"}[$__rate_interval]))",
             "instant": true,
             "legendFormat": "req/s",
             "range": false,
@@ -236,7 +236,7 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "sum(rate(kura_http_requests_total_total{cluster=~\"${cluster:regex}\", instance=~\"${instance:regex}\", region=~\"${region:regex}\", status=~\"5..\"}[$__rate_interval]))",
+            "expr": "sum(rate(kura_http_requests_total_total{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\", status=~\"5..\"}[$__rate_interval]))",
             "instant": true,
             "legendFormat": "errors/s",
             "range": false,
@@ -302,7 +302,7 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "histogram_quantile(0.95, sum by (le) (rate(kura_http_request_duration_seconds_bucket{cluster=~\"${cluster:regex}\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"}[$__rate_interval])))",
+            "expr": "histogram_quantile(0.95, sum by (le) (rate(kura_http_request_duration_seconds_bucket{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\"}[$__rate_interval])))",
             "instant": true,
             "legendFormat": "p95",
             "range": false,
@@ -399,7 +399,7 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "sum by (instance) (rate(kura_http_requests_total_total{cluster=~\"${cluster:regex}\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"}[$__rate_interval]))",
+            "expr": "sum by (instance) (rate(kura_http_requests_total_total{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\"}[$__rate_interval]))",
             "legendFormat": "{{instance}}",
             "refId": "A"
           }
@@ -465,7 +465,7 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "topk(10, sum by (route) (rate(kura_http_requests_total_total{cluster=~\"${cluster:regex}\", instance=~\"${instance:regex}\", region=~\"${region:regex}\", route=~\"${route:regex}\"}[$__rate_interval])))",
+            "expr": "topk(10, sum by (route) (rate(kura_http_requests_total_total{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\", route=~\"$route\"}[$__rate_interval])))",
             "legendFormat": "{{route}}",
             "refId": "A"
           }
@@ -531,7 +531,7 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "sum by (status) (rate(kura_http_requests_total_total{cluster=~\"${cluster:regex}\", instance=~\"${instance:regex}\", region=~\"${region:regex}\", status=~\"${status:regex}\"}[$__rate_interval]))",
+            "expr": "sum by (status) (rate(kura_http_requests_total_total{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\", status=~\"$status\"}[$__rate_interval]))",
             "legendFormat": "{{status}}",
             "refId": "A"
           }
@@ -597,21 +597,21 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "histogram_quantile(0.50, sum by (le) (rate(kura_http_request_duration_seconds_bucket{cluster=~\"${cluster:regex}\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"}[$__rate_interval])))",
+            "expr": "histogram_quantile(0.50, sum by (le) (rate(kura_http_request_duration_seconds_bucket{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\"}[$__rate_interval])))",
             "legendFormat": "p50",
             "refId": "A"
           },
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "histogram_quantile(0.95, sum by (le) (rate(kura_http_request_duration_seconds_bucket{cluster=~\"${cluster:regex}\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"}[$__rate_interval])))",
+            "expr": "histogram_quantile(0.95, sum by (le) (rate(kura_http_request_duration_seconds_bucket{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\"}[$__rate_interval])))",
             "legendFormat": "p95",
             "refId": "B"
           },
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "histogram_quantile(0.99, sum by (le) (rate(kura_http_request_duration_seconds_bucket{cluster=~\"${cluster:regex}\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"}[$__rate_interval])))",
+            "expr": "histogram_quantile(0.99, sum by (le) (rate(kura_http_request_duration_seconds_bucket{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\"}[$__rate_interval])))",
             "legendFormat": "p99",
             "refId": "C"
           }
@@ -690,7 +690,7 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "sum by (result) (rate(kura_artifact_reads_total_total{cluster=~\"${cluster:regex}\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"}[$__rate_interval]))",
+            "expr": "sum by (result) (rate(kura_artifact_reads_total_total{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\"}[$__rate_interval]))",
             "legendFormat": "{{result}}",
             "refId": "A"
           }
@@ -756,7 +756,7 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "sum by (result) (rate(kura_artifact_writes_total_total{cluster=~\"${cluster:regex}\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"}[$__rate_interval])) or on() label_replace(vector(0), \"result\", \"no_writes\", \"__name__\", \".*\")",
+            "expr": "sum by (result) (rate(kura_artifact_writes_total_total{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\"}[$__rate_interval])) or on() label_replace(vector(0), \"result\", \"no_writes\", \"__name__\", \".*\")",
             "legendFormat": "{{result}}",
             "refId": "A"
           }
@@ -822,7 +822,7 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "sum by (producer) (rate(kura_artifact_reads_total_total{cluster=~\"${cluster:regex}\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"}[$__rate_interval]))",
+            "expr": "sum by (producer) (rate(kura_artifact_reads_total_total{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\"}[$__rate_interval]))",
             "legendFormat": "{{producer}}",
             "refId": "A"
           }
@@ -888,7 +888,7 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "sum by (producer) (rate(kura_artifact_writes_total_total{cluster=~\"${cluster:regex}\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"}[$__rate_interval])) or on() label_replace(vector(0), \"producer\", \"no_writes\", \"__name__\", \".*\")",
+            "expr": "sum by (producer) (rate(kura_artifact_writes_total_total{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\"}[$__rate_interval])) or on() label_replace(vector(0), \"producer\", \"no_writes\", \"__name__\", \".*\")",
             "legendFormat": "{{producer}}",
             "refId": "A"
           }
@@ -967,7 +967,7 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "sum by (outcome, instance) (rate(kura_replication_apply_results_total_total{cluster=~\"${cluster:regex}\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"}[$__rate_interval]))",
+            "expr": "sum by (outcome, instance) (rate(kura_replication_apply_results_total_total{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\"}[$__rate_interval]))",
             "legendFormat": "{{instance}} {{outcome}}",
             "refId": "A"
           }
@@ -1033,21 +1033,21 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "histogram_quantile(0.50, sum by (le) (rate(kura_replication_request_duration_seconds_bucket{cluster=~\"${cluster:regex}\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"}[$__rate_interval]))) or on() vector(0)",
+            "expr": "histogram_quantile(0.50, sum by (le) (rate(kura_replication_request_duration_seconds_bucket{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\"}[$__rate_interval]))) or on() vector(0)",
             "legendFormat": "p50",
             "refId": "A"
           },
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "histogram_quantile(0.95, sum by (le) (rate(kura_replication_request_duration_seconds_bucket{cluster=~\"${cluster:regex}\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"}[$__rate_interval]))) or on() vector(0)",
+            "expr": "histogram_quantile(0.95, sum by (le) (rate(kura_replication_request_duration_seconds_bucket{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\"}[$__rate_interval]))) or on() vector(0)",
             "legendFormat": "p95",
             "refId": "B"
           },
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "histogram_quantile(0.99, sum by (le) (rate(kura_replication_request_duration_seconds_bucket{cluster=~\"${cluster:regex}\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"}[$__rate_interval]))) or on() vector(0)",
+            "expr": "histogram_quantile(0.99, sum by (le) (rate(kura_replication_request_duration_seconds_bucket{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\"}[$__rate_interval]))) or on() vector(0)",
             "legendFormat": "p99",
             "refId": "C"
           }
@@ -1113,7 +1113,7 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "sum by (instance, route, status) (rate(kura_http_requests_total_total{cluster=~\"${cluster:regex}\", instance=~\"${instance:regex}\", region=~\"${region:regex}\", route=~\"/_internal/.*\"}[$__rate_interval]))",
+            "expr": "sum by (instance, route, status) (rate(kura_http_requests_total_total{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\", route=~\"/_internal/.*\"}[$__rate_interval]))",
             "legendFormat": "{{instance}} {{route}} {{status}}",
             "refId": "A"
           }
@@ -1192,21 +1192,21 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "kura_rocksdb_block_cache_usage_bytes{cluster=~\"${cluster:regex}\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"}",
+            "expr": "kura_rocksdb_block_cache_usage_bytes{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\"}",
             "legendFormat": "{{instance}} usage",
             "refId": "A"
           },
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "kura_rocksdb_block_cache_pinned_usage_bytes{cluster=~\"${cluster:regex}\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"}",
+            "expr": "kura_rocksdb_block_cache_pinned_usage_bytes{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\"}",
             "legendFormat": "{{instance}} pinned",
             "refId": "B"
           },
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "kura_rocksdb_block_cache_capacity_bytes{cluster=~\"${cluster:regex}\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"}",
+            "expr": "kura_rocksdb_block_cache_capacity_bytes{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\"}",
             "legendFormat": "{{instance}} capacity",
             "refId": "C"
           }
@@ -1272,14 +1272,14 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "kura_rocksdb_write_buffer_usage_bytes{cluster=~\"${cluster:regex}\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"}",
+            "expr": "kura_rocksdb_write_buffer_usage_bytes{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\"}",
             "legendFormat": "{{instance}} usage",
             "refId": "A"
           },
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "kura_rocksdb_write_buffer_capacity_bytes{cluster=~\"${cluster:regex}\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"}",
+            "expr": "kura_rocksdb_write_buffer_capacity_bytes{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\"}",
             "legendFormat": "{{instance}} capacity",
             "refId": "B"
           }
@@ -1338,7 +1338,7 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "kura_rocksdb_block_cache_usage_bytes{cluster=~\"${cluster:regex}\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"} / kura_rocksdb_block_cache_capacity_bytes{cluster=~\"${cluster:regex}\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"}",
+            "expr": "kura_rocksdb_block_cache_usage_bytes{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\"} / kura_rocksdb_block_cache_capacity_bytes{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\"}",
             "instant": true,
             "legendFormat": "{{instance}}",
             "range": false,
@@ -1399,7 +1399,7 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "kura_rocksdb_write_buffer_usage_bytes{cluster=~\"${cluster:regex}\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"} / kura_rocksdb_write_buffer_capacity_bytes{cluster=~\"${cluster:regex}\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"}",
+            "expr": "kura_rocksdb_write_buffer_usage_bytes{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\"} / kura_rocksdb_write_buffer_capacity_bytes{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\"}",
             "instant": true,
             "legendFormat": "{{instance}}",
             "range": false,
@@ -1480,7 +1480,7 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "1 - avg by (instance) (rate(node_cpu_seconds_total{mode=\"idle\"}[$__rate_interval]) and on (instance) max by (instance) (kura_node_info{cluster=~\"${cluster:regex}\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"}))",
+            "expr": "1 - avg by (instance) (rate(node_cpu_seconds_total{mode=\"idle\"}[$__rate_interval]) and on (instance) max by (instance) (kura_node_info{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\"}))",
             "legendFormat": "{{instance}}",
             "refId": "A"
           }
@@ -1546,7 +1546,7 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "1 - ((node_memory_MemAvailable_bytes and on (instance) max by (instance) (kura_node_info{cluster=~\"${cluster:regex}\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"})) / (node_memory_MemTotal_bytes and on (instance) max by (instance) (kura_node_info{cluster=~\"${cluster:regex}\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"})))",
+            "expr": "1 - ((node_memory_MemAvailable_bytes and on (instance) max by (instance) (kura_node_info{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\"})) / (node_memory_MemTotal_bytes and on (instance) max by (instance) (kura_node_info{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\"})))",
             "legendFormat": "{{instance}}",
             "refId": "A"
           }
@@ -1620,7 +1620,7 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "1 - ((node_filesystem_avail_bytes{mountpoint=\"/\", fstype!~\"tmpfs|overlay\"} and on (instance) max by (instance) (kura_node_info{cluster=~\"${cluster:regex}\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"})) / (node_filesystem_size_bytes{mountpoint=\"/\", fstype!~\"tmpfs|overlay\"} and on (instance) max by (instance) (kura_node_info{cluster=~\"${cluster:regex}\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"})))",
+            "expr": "1 - ((node_filesystem_avail_bytes{mountpoint=\"/\", fstype!~\"tmpfs|overlay\"} and on (instance) max by (instance) (kura_node_info{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\"})) / (node_filesystem_size_bytes{mountpoint=\"/\", fstype!~\"tmpfs|overlay\"} and on (instance) max by (instance) (kura_node_info{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\"})))",
             "legendFormat": "{{instance}}",
             "refId": "A"
           }
@@ -1686,14 +1686,14 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "sum by (instance) (rate(node_network_receive_bytes_total{device!~\"lo\"}[$__rate_interval]) and on (instance) max by (instance) (kura_node_info{cluster=~\"${cluster:regex}\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"}))",
+            "expr": "sum by (instance) (rate(node_network_receive_bytes_total{device!~\"lo\"}[$__rate_interval]) and on (instance) max by (instance) (kura_node_info{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\"}))",
             "legendFormat": "{{instance}} rx",
             "refId": "A"
           },
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "sum by (instance) (rate(node_network_transmit_bytes_total{device!~\"lo\"}[$__rate_interval]) and on (instance) max by (instance) (kura_node_info{cluster=~\"${cluster:regex}\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"}))",
+            "expr": "sum by (instance) (rate(node_network_transmit_bytes_total{device!~\"lo\"}[$__rate_interval]) and on (instance) max by (instance) (kura_node_info{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\"}))",
             "legendFormat": "{{instance}} tx",
             "refId": "B"
           }
@@ -1759,7 +1759,7 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "node_filefd_allocated and on (instance) max by (instance) (kura_node_info{cluster=~\"${cluster:regex}\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"})",
+            "expr": "node_filefd_allocated and on (instance) max by (instance) (kura_node_info{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\"})",
             "legendFormat": "{{instance}}",
             "refId": "A"
           }
@@ -1861,7 +1861,7 @@
         "targets": [
           {
             "datasource": "$logs_datasource",
-            "expr": "{cluster=~\"${cluster:regex}\", namespace=\"kura\", container=\"kura\", pod=~\"${pod:regex}\"} | json",
+            "expr": "{cluster=~\"$cluster\", namespace=\"kura\", container=\"kura\", pod=~\"$pod\"} | json",
             "refId": "A"
           }
         ],
@@ -2116,7 +2116,7 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "sum by (region, country, subdivision, lookup) (label_replace(kura_node_geo_info{cluster=~\"${cluster:regex}\", tenant_id=~\"${tenant:regex}\", instance=~\"${instance:regex}\", region=~\"${region:regex}\", country=\"US\", subdivision=~\"US-.*\"}, \"lookup\", \"$1\", \"subdivision\", \"US-(.*)\"))",
+            "expr": "sum by (region, country, subdivision, lookup) (label_replace(kura_node_geo_info{cluster=~\"$cluster\", tenant_id=~\"$tenant\", instance=~\"$instance\", region=~\"$region\", country=\"US\", subdivision=~\"US-.*\"}, \"lookup\", \"$1\", \"subdivision\", \"US-(.*)\"))",
             "format": "table",
             "instant": true,
             "range": false,
@@ -2125,7 +2125,7 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "sum by (region, country, subdivision, lookup) (label_replace(kura_node_geo_info{cluster=~\"${cluster:regex}\", tenant_id=~\"${tenant:regex}\", instance=~\"${instance:regex}\", region=~\"${region:regex}\", country!=\"unknown\", country!=\"US\"}, \"lookup\", \"$1\", \"country\", \"(.*)\"))",
+            "expr": "sum by (region, country, subdivision, lookup) (label_replace(kura_node_geo_info{cluster=~\"$cluster\", tenant_id=~\"$tenant\", instance=~\"$instance\", region=~\"$region\", country!=\"unknown\", country!=\"US\"}, \"lookup\", \"$1\", \"country\", \"(.*)\"))",
             "format": "table",
             "instant": true,
             "range": false,
@@ -2134,7 +2134,7 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "label_replace(sum by (client_country) (increase(kura_http_requests_total_total{cluster=~\"${cluster:regex}\", instance=~\"${instance:regex}\", region=~\"${region:regex}\", client_country!=\"unknown\"}[$__range])), \"lookup\", \"$1\", \"client_country\", \"(.*)\")",
+            "expr": "label_replace(sum by (client_country) (increase(kura_http_requests_total_total{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\", client_country!=\"unknown\"}[$__range])), \"lookup\", \"$1\", \"client_country\", \"(.*)\")",
             "format": "table",
             "instant": true,
             "range": false,
@@ -2229,14 +2229,14 @@
             "value": "$__all"
           },
           "datasource": "$datasource",
-          "definition": "label_values(kura_node_info{cluster=~\"${cluster:regex}\"}, tenant_id)",
+          "definition": "label_values(kura_node_info{cluster=~\"$cluster\"}, tenant_id)",
           "hide": 0,
           "includeAll": true,
           "label": "Tenant",
           "multi": true,
           "name": "tenant",
           "query": {
-            "query": "label_values(kura_node_info{cluster=~\"${cluster:regex}\"}, tenant_id)",
+            "query": "label_values(kura_node_info{cluster=~\"$cluster\"}, tenant_id)",
             "refId": "PrometheusVariableQueryEditor-VariableQuery"
           },
           "refresh": 1,
@@ -2252,14 +2252,14 @@
             "value": "$__all"
           },
           "datasource": "$datasource",
-          "definition": "label_values(kura_node_info{cluster=~\"${cluster:regex}\", tenant_id=~\"${tenant:regex}\"}, instance)",
+          "definition": "label_values(kura_node_info{cluster=~\"$cluster\", tenant_id=~\"$tenant\"}, instance)",
           "hide": 0,
           "includeAll": true,
           "label": "Instance",
           "multi": true,
           "name": "instance",
           "query": {
-            "query": "label_values(kura_node_info{cluster=~\"${cluster:regex}\", tenant_id=~\"${tenant:regex}\"}, instance)",
+            "query": "label_values(kura_node_info{cluster=~\"$cluster\", tenant_id=~\"$tenant\"}, instance)",
             "refId": "PrometheusVariableQueryEditor-VariableQuery"
           },
           "refresh": 1,
@@ -2275,14 +2275,14 @@
             "value": "$__all"
           },
           "datasource": "$datasource",
-          "definition": "label_values(kura_node_info{cluster=~\"${cluster:regex}\", tenant_id=~\"${tenant:regex}\"}, region)",
+          "definition": "label_values(kura_node_info{cluster=~\"$cluster\", tenant_id=~\"$tenant\"}, region)",
           "hide": 0,
           "includeAll": true,
           "label": "Region",
           "multi": true,
           "name": "region",
           "query": {
-            "query": "label_values(kura_node_info{cluster=~\"${cluster:regex}\", tenant_id=~\"${tenant:regex}\"}, region)",
+            "query": "label_values(kura_node_info{cluster=~\"$cluster\", tenant_id=~\"$tenant\"}, region)",
             "refId": "PrometheusVariableQueryEditor-VariableQuery"
           },
           "refresh": 1,
@@ -2298,7 +2298,7 @@
             "value": "$__all"
           },
           "datasource": "$logs_datasource",
-          "definition": "label_values({cluster=~\"${cluster:regex}\", namespace=\"kura\", container=\"kura\"}, pod)",
+          "definition": "label_values({cluster=~\"$cluster\", namespace=\"kura\", container=\"kura\"}, pod)",
           "hide": 0,
           "includeAll": true,
           "label": "Pod",
@@ -2306,7 +2306,7 @@
           "name": "pod",
           "query": {
             "qryType": 1,
-            "query": "label_values({cluster=~\"${cluster:regex}\", namespace=\"kura\", container=\"kura\"}, pod)",
+            "query": "label_values({cluster=~\"$cluster\", namespace=\"kura\", container=\"kura\"}, pod)",
             "refId": "PrometheusVariableQueryEditor-VariableQuery"
           },
           "refresh": 1,
@@ -2322,14 +2322,14 @@
             "value": "$__all"
           },
           "datasource": "$datasource",
-          "definition": "label_values(kura_http_requests_total_total{cluster=~\"${cluster:regex}\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"}, route)",
+          "definition": "label_values(kura_http_requests_total_total{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\"}, route)",
           "hide": 0,
           "includeAll": true,
           "label": "Route",
           "multi": true,
           "name": "route",
           "query": {
-            "query": "label_values(kura_http_requests_total_total{cluster=~\"${cluster:regex}\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"}, route)",
+            "query": "label_values(kura_http_requests_total_total{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\"}, route)",
             "refId": "PrometheusVariableQueryEditor-VariableQuery"
           },
           "refresh": 1,
@@ -2345,14 +2345,14 @@
             "value": "$__all"
           },
           "datasource": "$datasource",
-          "definition": "label_values(kura_http_requests_total_total{cluster=~\"${cluster:regex}\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"}, status)",
+          "definition": "label_values(kura_http_requests_total_total{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\"}, status)",
           "hide": 0,
           "includeAll": true,
           "label": "Status",
           "multi": true,
           "name": "status",
           "query": {
-            "query": "label_values(kura_http_requests_total_total{cluster=~\"${cluster:regex}\", instance=~\"${instance:regex}\", region=~\"${region:regex}\"}, status)",
+            "query": "label_values(kura_http_requests_total_total{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\"}, status)",
             "refId": "PrometheusVariableQueryEditor-VariableQuery"
           },
           "refresh": 1,

--- a/infra/mise/tasks/k8s/deploy-kura-regionals.sh
+++ b/infra/mise/tasks/k8s/deploy-kura-regionals.sh
@@ -26,6 +26,32 @@ export CLOUDFLARE_API_TOKEN
 
 helm dependency update "$MONITORING_CHART_PATH" >/dev/null
 
+require_onepassword_bootstrap() {
+  local kubeconfig="$1"
+  local cluster_name="$2"
+  local kubeconfig_item="$3"
+  local missing=()
+
+  if ! KUBECONFIG="$kubeconfig" kubectl get namespace onepassword >/dev/null 2>&1; then
+    missing+=("namespace/onepassword")
+  fi
+  if ! KUBECONFIG="$kubeconfig" kubectl -n onepassword get secret onepassword-sa-token >/dev/null 2>&1; then
+    missing+=("secret/onepassword-sa-token")
+  fi
+  if ! KUBECONFIG="$kubeconfig" kubectl get clustersecretstore onepassword >/dev/null 2>&1; then
+    missing+=("clustersecretstore/onepassword")
+  fi
+
+  if [ "${#missing[@]}" -gt 0 ]; then
+    echo "ERROR: $cluster_name is missing workload bootstrap resources: ${missing[*]}" >&2
+    echo "Run: mise -C \"$REPO_ROOT/infra\" run k8s:bootstrap-workload \"$cluster_name\" production \"$kubeconfig_item\"" >&2
+    exit 1
+  fi
+
+  KUBECONFIG="$kubeconfig" kubectl wait \
+    --for=condition=Ready clustersecretstore/onepassword --timeout=2m >/dev/null
+}
+
 deploy_region() {
   local region="$1"
   local cluster_name="$2"
@@ -38,6 +64,8 @@ deploy_region() {
 
   echo "Deploying Kura controller to $region"
   KUBECONFIG="$kubeconfig" kubectl --request-timeout=10s get --raw /version >/dev/null
+
+  require_onepassword_bootstrap "$kubeconfig" "$cluster_name" "$kubeconfig_item"
 
   # Cluster names must match the CAPI Cluster CR names in
   # infra/k8s/clusters/cluster-production-us-{east,west}.yaml. They

--- a/infra/mise/tasks/k8s/deploy-kura-regionals.sh
+++ b/infra/mise/tasks/k8s/deploy-kura-regionals.sh
@@ -26,30 +26,23 @@ export CLOUDFLARE_API_TOKEN
 
 helm dependency update "$MONITORING_CHART_PATH" >/dev/null
 
-require_onepassword_bootstrap() {
+require_managed_secret_store() {
   local kubeconfig="$1"
   local cluster_name="$2"
   local kubeconfig_item="$3"
-  local missing=()
 
-  if ! KUBECONFIG="$kubeconfig" kubectl get namespace onepassword >/dev/null 2>&1; then
-    missing+=("namespace/onepassword")
-  fi
-  if ! KUBECONFIG="$kubeconfig" kubectl -n onepassword get secret onepassword-sa-token >/dev/null 2>&1; then
-    missing+=("secret/onepassword-sa-token")
-  fi
   if ! KUBECONFIG="$kubeconfig" kubectl get clustersecretstore onepassword >/dev/null 2>&1; then
-    missing+=("clustersecretstore/onepassword")
-  fi
-
-  if [ "${#missing[@]}" -gt 0 ]; then
-    echo "ERROR: $cluster_name is missing workload bootstrap resources: ${missing[*]}" >&2
+    echo "ERROR: $cluster_name is missing ClusterSecretStore/onepassword required by managed ExternalSecrets." >&2
     echo "Run: mise -C \"$REPO_ROOT/infra\" run k8s:bootstrap-workload \"$cluster_name\" production \"$kubeconfig_item\"" >&2
     exit 1
   fi
 
-  KUBECONFIG="$kubeconfig" kubectl wait \
-    --for=condition=Ready clustersecretstore/onepassword --timeout=2m >/dev/null
+  if ! KUBECONFIG="$kubeconfig" kubectl wait \
+    --for=condition=Ready clustersecretstore/onepassword --timeout=2m >/dev/null; then
+    echo "ERROR: $cluster_name ClusterSecretStore/onepassword is not Ready; managed ExternalSecrets will not reconcile." >&2
+    echo "Run: mise -C \"$REPO_ROOT/infra\" run k8s:bootstrap-workload \"$cluster_name\" production \"$kubeconfig_item\"" >&2
+    exit 1
+  fi
 }
 
 deploy_region() {
@@ -74,6 +67,11 @@ deploy_region() {
   # records and rename LBs on every deploy.
   mise -C "$REPO_ROOT/infra" run k8s:install-platform \
     "$kubeconfig" "$cluster_name"
+
+  # Monitoring and the Kura controller chart both resolve secrets through
+  # ClusterSecretStore/onepassword. Gate on that contract instead of the
+  # bootstrap implementation details behind it.
+  require_managed_secret_store "$kubeconfig" "$cluster_name" "$kubeconfig_item"
 
   echo "Deploying Grafana monitoring to $region"
   KUBECONFIG="$kubeconfig" helm upgrade --install k8s-monitoring "$MONITORING_CHART_PATH" \

--- a/infra/mise/tasks/k8s/install-platform.sh
+++ b/infra/mise/tasks/k8s/install-platform.sh
@@ -172,9 +172,20 @@ dump_diagnostics() {
 }
 trap dump_diagnostics EXIT
 
-KUBECONFIG="$WL_KUBECONFIG" helm upgrade --install platform "$CHART_PATH" \
-  --namespace platform \
-  "${HELM_VALUES_ARGS[@]}" \
-  "${HELM_SET_ARGS[@]}" \
-  "${HELM_EXTRA_ARGS[@]}" \
-  --wait --timeout "$HELM_TIMEOUT"
+HELM_CMD=(
+  helm upgrade --install platform "$CHART_PATH"
+  --namespace platform
+  "${HELM_VALUES_ARGS[@]}"
+  "${HELM_SET_ARGS[@]}"
+)
+
+if [ "${#HELM_EXTRA_ARGS[@]}" -gt 0 ]; then
+  HELM_CMD+=("${HELM_EXTRA_ARGS[@]}")
+fi
+
+HELM_CMD+=(
+  --wait
+  --timeout "$HELM_TIMEOUT"
+)
+
+KUBECONFIG="$WL_KUBECONFIG" "${HELM_CMD[@]}"


### PR DESCRIPTION
## What changed

- build the `helm upgrade` invocation in `k8s:install-platform` as a command array so regional runs do not trip `set -u` when `HELM_EXTRA_ARGS` is empty
- add a `onepassword` bootstrap preflight to `k8s:deploy-kura-regionals` that checks `namespace/onepassword`, `secret/onepassword-sa-token`, and `ClusterSecretStore/onepassword`, then waits for the store to be `Ready` before proceeding

## Why

The regional recovery exposed two rollout hardening gaps:

- the regional clusters were missing the workload-side 1Password bootstrap, so the deploy spent ten minutes timing out in `k8s-monitoring` while its `ExternalSecret` waited on a missing `ClusterSecretStore`
- the Kura regional path leaves `HELM_EXTRA_ARGS` empty in `k8s:install-platform`, which currently triggers an `unbound variable` error under `set -u`

Failing fast with an explicit bootstrap error gives the operator the right remediation immediately, and making the Helm command-array expansion resilient removes the noisy shell failure from the same deploy path.

## Impact

- regional Kura rollouts now stop immediately with an actionable bootstrap command instead of hanging in Helm
- regional platform installs no longer error when there are no extra Helm args to pass

## Validation

- `bash -n infra/mise/tasks/k8s/install-platform.sh`
- `bash -n infra/mise/tasks/k8s/deploy-kura-regionals.sh`
- `mise -C infra run k8s:deploy-kura-regionals sha-1009a2ffc194` against `tuist-kura-us-east` and `tuist-kura-us-west` after restoring the missing bootstrap resources
- `curl -I https://whatnot.kura.tuist.dev/up` -> `HTTP/2 200`
