### PR TITLE
feat(linux-runner-image): pre-install kubectl and helm

### DIFF
--- a/infra/linux-runner-image/Dockerfile
+++ b/infra/linux-runner-image/Dockerfile
@@ -124,6 +124,29 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
+# kubectl + helm: GitHub's Ubuntu runner image pre-installs both
+# via `install-kubernetes-tools.sh` so every k8s deploy / sweep
+# workflow in the repo assumes they're on `/usr/local/bin`.
+# Mirror that posture here. Versions are Renovate-managed; bumps
+# land as `fix(linux-runner-image): …` and route through the
+# release flow same as `RUNNER_VERSION`.
+# renovate: datasource=github-releases depName=kubernetes/kubernetes
+ARG KUBECTL_VERSION=1.36.1
+# renovate: datasource=github-releases depName=helm/helm
+ARG HELM_VERSION=4.2.0
+RUN ARCH="$(dpkg --print-architecture)" \
+    && curl -fSL "https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl" \
+         -o /usr/local/bin/kubectl \
+    && chmod 0755 /usr/local/bin/kubectl \
+    && kubectl version --client \
+    && curl -fSL "https://get.helm.sh/helm-v${HELM_VERSION}-linux-${ARCH}.tar.gz" \
+         -o /tmp/helm.tgz \
+    && tar -xzf /tmp/helm.tgz -C /tmp \
+    && mv "/tmp/linux-${ARCH}/helm" /usr/local/bin/helm \
+    && rm -rf /tmp/helm.tgz "/tmp/linux-${ARCH}" \
+    && chmod 0755 /usr/local/bin/helm \
+    && helm version --short
+
 # Non-root runner user. `actions/runner` refuses to register as
 # root unless `RUNNER_ALLOW_RUNASROOT=1` is set — explicitly opt
 # out by creating a dedicated user. The user gets passwordless

--- a/renovate.json
+++ b/renovate.json
@@ -12,10 +12,10 @@
     },
     {
       "customType": "regex",
-      "description": "GitHub Actions runner version baked into the Linux runner image. Same shape as the macOS counterpart above; bumps land as `fix(linux-runner-image): …` commits which release.yml's release-linux-runner-image flow picks up to rebuild + push + rewrite the runnersFleetLinux pin.",
+      "description": "ARG-based version pins in the Linux runner image (actions/runner, kubectl, helm). Bumps land as `fix(linux-runner-image): …` commits which release.yml's release-linux-runner-image flow picks up to rebuild + push + rewrite the runnersFleetLinux pin.",
       "fileMatch": ["^infra/linux-runner-image/Dockerfile$"],
       "matchStrings": [
-        "# renovate: datasource=(?<datasource>[a-z-]+) depName=(?<depName>[^\\s]+)\\s+ARG\\s+RUNNER_VERSION=(?<currentValue>[^\\s]+)"
+        "# renovate: datasource=(?<datasource>[a-z-]+) depName=(?<depName>[^\\s]+)\\s+ARG\\s+[A-Z_]+=(?<currentValue>[^\\s]+)"
       ],
       "extractVersionTemplate": "^v?(?<version>.+)$"
     }
@@ -31,12 +31,11 @@
       "automerge": true
     },
     {
-      "description": "actions/runner bumps for the Linux image: route through the linux-runner-image release flow.",
+      "description": "Linux-runner-image ARG bumps (actions/runner, kubectl, helm): route through the linux-runner-image release flow.",
       "matchManagers": ["custom.regex"],
       "matchFileNames": ["infra/linux-runner-image/Dockerfile"],
-      "matchPackageNames": ["actions/runner"],
+      "matchPackageNames": ["actions/runner", "kubernetes/kubernetes", "helm/helm"],
       "commitMessagePrefix": "fix(linux-runner-image):",
-      "commitMessageTopic": "GitHub Actions runner",
       "automerge": true
     }
   ]


### PR DESCRIPTION
## What

Bake `kubectl` and `helm` into the `tuist-linux-runner` OCI image at `/usr/local/bin` via two new Renovate-managed `ARG`s in [`infra/linux-runner-image/Dockerfile`](https://github.com/tuist/tuist/blob/main/infra/linux-runner-image/Dockerfile):

```dockerfile
# renovate: datasource=github-releases depName=kubernetes/kubernetes
ARG KUBECTL_VERSION=1.36.1
# renovate: datasource=github-releases depName=helm/helm
ARG HELM_VERSION=4.2.0
```

The existing custom regex manager in `renovate.json` is generalized from `RUNNER_VERSION` to any `ARG <UPPER_SNAKE>_VERSION=…` in this one file, and the matching package rule is extended to cover `kubernetes/kubernetes` + `helm/helm` (same `fix(linux-runner-image):` commit prefix + automerge as `actions/runner`).

## Why

GitHub-hosted Ubuntu runners pre-install both binaries via the upstream [`install-kubernetes-tools.sh`](https://github.com/actions/runner-images/blob/main/images/ubuntu/scripts/build/install-kubernetes-tools.sh) build script. Namespace's `namespace-profile-default` mirrors that. Our in-house `tuist-production-linux` image, introduced in [#10886](https://github.com/tuist/tuist/pull/10886), omitted both.

That parity gap was the underlying cause of the [`mgmt-cluster-apply` failure](https://github.com/tuist/tuist/actions/runs/26177538175/job/77011481843) the day after the runner migration: `mise install kubectl` (no version pin) creates an unactivated shim that shadows the system binary, but on hosted runners the system fallback at `/usr/local/bin/kubectl` was masking the bug. Drop the fallback and the shim error surfaces.

## Relationship to #10907

[#10907](https://github.com/tuist/tuist/pull/10907) fixes the mise-action invocations themselves (`install: false` + `mise use -g <tool>` so the shim has a real version source). That PR is the load-bearing fix that unblocks `mgmt-cluster-apply` right now.

This PR is the defensive complement: even with the workflow fix in place, future deploy steps written against the runner image will continue to assume kubectl + helm exist on PATH (because that's what GitHub-hosted does). Closing the parity gap means the next slim-image consumer doesn't rediscover this footgun.

Order is independent — either PR can land first.

## Validation

- [ ] `.github/workflows/linux-runner-image.yml` (PR trigger) builds the image without pushing — green = Dockerfile + curl URLs resolve.
- [ ] After merge: `release-linux-runner-image` job in `release.yml` runs on main, builds + pushes a new semver tag, and rewrites `runnersFleetLinux.pools[*].runnerImage` in managed-env values files where the pin is currently non-empty. Once the helm chart redeploys (next runners-controller reconcile), new runner Pods come up with the binaries baked in.
- [ ] Renovate next sees the two new `ARG`s and starts opening `fix(linux-runner-image): update <kubectl|helm>` PRs on upstream releases (one-time validation: confirm a PR opens within the next renovation cycle).

## Notes

- Versions chosen to match current upstream stable: kubectl `v1.36.1` (`https://dl.k8s.io/release/stable.txt`) and helm `v4.2.0` (latest GitHub release).
- `helm` is the v4 line. Our `infra/mise.toml` already pins `helm = "4.1.3"` for local development, so this is consistent.
- `dpkg --print-architecture` is used to pick the right binary URL so the same Dockerfile will work when we add `linux/arm64` to the buildx `platforms:` list (currently amd64-only per the workflow comment).