### PR TITLE
Fix Kura tenant filtering and route metrics in Grafana

### DIFF
--- a/infra/grafana-dashboards/tuist-kura.json
+++ b/infra/grafana-dashboards/tuist-kura.json
@@ -107,7 +107,7 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "up{cluster=~\"$cluster\", instance=~\"$instance\"}",
+            "expr": "up{cluster=~\"$cluster\", instance=~\"$instance\"} and on (cluster, instance) max by (cluster, instance) (kura_node_info{cluster=~\"$cluster\", tenant_id=~\"$tenant\", instance=~\"$instance\", region=~\"$region\"})",
             "instant": true,
             "legendFormat": "{{instance}}",
             "range": false,
@@ -170,7 +170,7 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "sum(rate(kura_http_requests_total_total{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\"}[$__rate_interval]))",
+            "expr": "sum((rate(kura_http_requests_total_total{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\", route!~\"/_internal/.*|/up|/ready|/status/rollout|/metrics|/_unmatched\"}[$__rate_interval])) and on (cluster, instance) max by (cluster, instance) (kura_node_info{cluster=~\"$cluster\", tenant_id=~\"$tenant\", instance=~\"$instance\", region=~\"$region\"}))",
             "instant": true,
             "legendFormat": "req/s",
             "range": false,
@@ -236,7 +236,7 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "sum(rate(kura_http_requests_total_total{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\", status=~\"5..\"}[$__rate_interval]))",
+            "expr": "sum((rate(kura_http_requests_total_total{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\", route!~\"/_internal/.*|/up|/ready|/status/rollout|/metrics|/_unmatched\", status=~\"5..\"}[$__rate_interval])) and on (cluster, instance) max by (cluster, instance) (kura_node_info{cluster=~\"$cluster\", tenant_id=~\"$tenant\", instance=~\"$instance\", region=~\"$region\"}))",
             "instant": true,
             "legendFormat": "errors/s",
             "range": false,
@@ -302,7 +302,7 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "histogram_quantile(0.95, sum by (le) (rate(kura_http_request_duration_seconds_bucket{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\"}[$__rate_interval])))",
+            "expr": "histogram_quantile(0.95, sum by (le) ((rate(kura_http_request_duration_seconds_bucket{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\", route!~\"/_internal/.*|/up|/ready|/status/rollout|/metrics|/_unmatched\"}[$__rate_interval])) and on (cluster, instance) max by (cluster, instance) (kura_node_info{cluster=~\"$cluster\", tenant_id=~\"$tenant\", instance=~\"$instance\", region=~\"$region\"})))",
             "instant": true,
             "legendFormat": "p95",
             "range": false,
@@ -399,7 +399,7 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "sum by (instance) (rate(kura_http_requests_total_total{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\"}[$__rate_interval]))",
+            "expr": "sum by (instance) ((rate(kura_http_requests_total_total{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\", route!~\"/_internal/.*|/up|/ready|/status/rollout|/metrics|/_unmatched\"}[$__rate_interval])) and on (cluster, instance) max by (cluster, instance) (kura_node_info{cluster=~\"$cluster\", tenant_id=~\"$tenant\", instance=~\"$instance\", region=~\"$region\"}))",
             "legendFormat": "{{instance}}",
             "refId": "A"
           }
@@ -465,7 +465,7 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "topk(10, sum by (route) (rate(kura_http_requests_total_total{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\", route=~\"$route\"}[$__rate_interval])))",
+            "expr": "topk(10, sum by (route) ((rate(kura_http_requests_total_total{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\", route!~\"/_internal/.*|/up|/ready|/status/rollout|/metrics|/_unmatched\", route=~\"$route\"}[$__rate_interval])) and on (cluster, instance) max by (cluster, instance) (kura_node_info{cluster=~\"$cluster\", tenant_id=~\"$tenant\", instance=~\"$instance\", region=~\"$region\"})))",
             "legendFormat": "{{route}}",
             "refId": "A"
           }
@@ -531,7 +531,7 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "sum by (status) (rate(kura_http_requests_total_total{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\", status=~\"$status\"}[$__rate_interval]))",
+            "expr": "sum by (status) ((rate(kura_http_requests_total_total{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\", route!~\"/_internal/.*|/up|/ready|/status/rollout|/metrics|/_unmatched\", status=~\"$status\"}[$__rate_interval])) and on (cluster, instance) max by (cluster, instance) (kura_node_info{cluster=~\"$cluster\", tenant_id=~\"$tenant\", instance=~\"$instance\", region=~\"$region\"}))",
             "legendFormat": "{{status}}",
             "refId": "A"
           }
@@ -597,21 +597,21 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "histogram_quantile(0.50, sum by (le) (rate(kura_http_request_duration_seconds_bucket{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\"}[$__rate_interval])))",
+            "expr": "histogram_quantile(0.50, sum by (le) ((rate(kura_http_request_duration_seconds_bucket{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\", route!~\"/_internal/.*|/up|/ready|/status/rollout|/metrics|/_unmatched\"}[$__rate_interval])) and on (cluster, instance) max by (cluster, instance) (kura_node_info{cluster=~\"$cluster\", tenant_id=~\"$tenant\", instance=~\"$instance\", region=~\"$region\"})))",
             "legendFormat": "p50",
             "refId": "A"
           },
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "histogram_quantile(0.95, sum by (le) (rate(kura_http_request_duration_seconds_bucket{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\"}[$__rate_interval])))",
+            "expr": "histogram_quantile(0.95, sum by (le) ((rate(kura_http_request_duration_seconds_bucket{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\", route!~\"/_internal/.*|/up|/ready|/status/rollout|/metrics|/_unmatched\"}[$__rate_interval])) and on (cluster, instance) max by (cluster, instance) (kura_node_info{cluster=~\"$cluster\", tenant_id=~\"$tenant\", instance=~\"$instance\", region=~\"$region\"})))",
             "legendFormat": "p95",
             "refId": "B"
           },
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "histogram_quantile(0.99, sum by (le) (rate(kura_http_request_duration_seconds_bucket{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\"}[$__rate_interval])))",
+            "expr": "histogram_quantile(0.99, sum by (le) ((rate(kura_http_request_duration_seconds_bucket{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\", route!~\"/_internal/.*|/up|/ready|/status/rollout|/metrics|/_unmatched\"}[$__rate_interval])) and on (cluster, instance) max by (cluster, instance) (kura_node_info{cluster=~\"$cluster\", tenant_id=~\"$tenant\", instance=~\"$instance\", region=~\"$region\"})))",
             "legendFormat": "p99",
             "refId": "C"
           }
@@ -690,7 +690,7 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "sum by (result) (rate(kura_artifact_reads_total_total{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\"}[$__rate_interval]))",
+            "expr": "sum by (result) ((rate(kura_artifact_reads_total_total{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\"}[$__rate_interval])) and on (cluster, instance) max by (cluster, instance) (kura_node_info{cluster=~\"$cluster\", tenant_id=~\"$tenant\", instance=~\"$instance\", region=~\"$region\"}))",
             "legendFormat": "{{result}}",
             "refId": "A"
           }
@@ -756,7 +756,7 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "sum by (result) (rate(kura_artifact_writes_total_total{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\"}[$__rate_interval])) or on() label_replace(vector(0), \"result\", \"no_writes\", \"__name__\", \".*\")",
+            "expr": "sum by (result) ((rate(kura_artifact_writes_total_total{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\"}[$__rate_interval])) and on (cluster, instance) max by (cluster, instance) (kura_node_info{cluster=~\"$cluster\", tenant_id=~\"$tenant\", instance=~\"$instance\", region=~\"$region\"})) or on() label_replace(vector(0), \"result\", \"no_writes\", \"__name__\", \".*\")",
             "legendFormat": "{{result}}",
             "refId": "A"
           }
@@ -822,7 +822,7 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "sum by (producer) (rate(kura_artifact_reads_total_total{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\"}[$__rate_interval]))",
+            "expr": "sum by (producer) ((rate(kura_artifact_reads_total_total{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\"}[$__rate_interval])) and on (cluster, instance) max by (cluster, instance) (kura_node_info{cluster=~\"$cluster\", tenant_id=~\"$tenant\", instance=~\"$instance\", region=~\"$region\"}))",
             "legendFormat": "{{producer}}",
             "refId": "A"
           }
@@ -888,7 +888,7 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "sum by (producer) (rate(kura_artifact_writes_total_total{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\"}[$__rate_interval])) or on() label_replace(vector(0), \"producer\", \"no_writes\", \"__name__\", \".*\")",
+            "expr": "sum by (producer) ((rate(kura_artifact_writes_total_total{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\"}[$__rate_interval])) and on (cluster, instance) max by (cluster, instance) (kura_node_info{cluster=~\"$cluster\", tenant_id=~\"$tenant\", instance=~\"$instance\", region=~\"$region\"})) or on() label_replace(vector(0), \"producer\", \"no_writes\", \"__name__\", \".*\")",
             "legendFormat": "{{producer}}",
             "refId": "A"
           }
@@ -967,7 +967,7 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "sum by (outcome, instance) (rate(kura_replication_apply_results_total_total{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\"}[$__rate_interval]))",
+            "expr": "sum by (outcome, instance) ((rate(kura_replication_apply_results_total_total{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\"}[$__rate_interval])) and on (cluster, instance) max by (cluster, instance) (kura_node_info{cluster=~\"$cluster\", tenant_id=~\"$tenant\", instance=~\"$instance\", region=~\"$region\"}))",
             "legendFormat": "{{instance}} {{outcome}}",
             "refId": "A"
           }
@@ -1033,21 +1033,21 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "histogram_quantile(0.50, sum by (le) (rate(kura_replication_request_duration_seconds_bucket{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\"}[$__rate_interval]))) or on() vector(0)",
+            "expr": "histogram_quantile(0.50, sum by (le) ((rate(kura_replication_request_duration_seconds_bucket{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\"}[$__rate_interval])) and on (cluster, instance) max by (cluster, instance) (kura_node_info{cluster=~\"$cluster\", tenant_id=~\"$tenant\", instance=~\"$instance\", region=~\"$region\"}))) or on() vector(0)",
             "legendFormat": "p50",
             "refId": "A"
           },
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "histogram_quantile(0.95, sum by (le) (rate(kura_replication_request_duration_seconds_bucket{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\"}[$__rate_interval]))) or on() vector(0)",
+            "expr": "histogram_quantile(0.95, sum by (le) ((rate(kura_replication_request_duration_seconds_bucket{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\"}[$__rate_interval])) and on (cluster, instance) max by (cluster, instance) (kura_node_info{cluster=~\"$cluster\", tenant_id=~\"$tenant\", instance=~\"$instance\", region=~\"$region\"}))) or on() vector(0)",
             "legendFormat": "p95",
             "refId": "B"
           },
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "histogram_quantile(0.99, sum by (le) (rate(kura_replication_request_duration_seconds_bucket{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\"}[$__rate_interval]))) or on() vector(0)",
+            "expr": "histogram_quantile(0.99, sum by (le) ((rate(kura_replication_request_duration_seconds_bucket{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\"}[$__rate_interval])) and on (cluster, instance) max by (cluster, instance) (kura_node_info{cluster=~\"$cluster\", tenant_id=~\"$tenant\", instance=~\"$instance\", region=~\"$region\"}))) or on() vector(0)",
             "legendFormat": "p99",
             "refId": "C"
           }
@@ -1113,7 +1113,7 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "sum by (instance, route, status) (rate(kura_http_requests_total_total{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\", route=~\"/_internal/.*\"}[$__rate_interval]))",
+            "expr": "sum by (instance, route, status) ((rate(kura_http_requests_total_total{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\", route=~\"/_internal/.*\"}[$__rate_interval])) and on (cluster, instance) max by (cluster, instance) (kura_node_info{cluster=~\"$cluster\", tenant_id=~\"$tenant\", instance=~\"$instance\", region=~\"$region\"}))",
             "legendFormat": "{{instance}} {{route}} {{status}}",
             "refId": "A"
           }
@@ -1192,21 +1192,21 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "kura_rocksdb_block_cache_usage_bytes{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\"}",
+            "expr": "kura_rocksdb_block_cache_usage_bytes{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\"} and on (cluster, instance) max by (cluster, instance) (kura_node_info{cluster=~\"$cluster\", tenant_id=~\"$tenant\", instance=~\"$instance\", region=~\"$region\"})",
             "legendFormat": "{{instance}} usage",
             "refId": "A"
           },
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "kura_rocksdb_block_cache_pinned_usage_bytes{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\"}",
+            "expr": "kura_rocksdb_block_cache_pinned_usage_bytes{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\"} and on (cluster, instance) max by (cluster, instance) (kura_node_info{cluster=~\"$cluster\", tenant_id=~\"$tenant\", instance=~\"$instance\", region=~\"$region\"})",
             "legendFormat": "{{instance}} pinned",
             "refId": "B"
           },
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "kura_rocksdb_block_cache_capacity_bytes{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\"}",
+            "expr": "kura_rocksdb_block_cache_capacity_bytes{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\"} and on (cluster, instance) max by (cluster, instance) (kura_node_info{cluster=~\"$cluster\", tenant_id=~\"$tenant\", instance=~\"$instance\", region=~\"$region\"})",
             "legendFormat": "{{instance}} capacity",
             "refId": "C"
           }
@@ -1272,14 +1272,14 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "kura_rocksdb_write_buffer_usage_bytes{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\"}",
+            "expr": "kura_rocksdb_write_buffer_usage_bytes{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\"} and on (cluster, instance) max by (cluster, instance) (kura_node_info{cluster=~\"$cluster\", tenant_id=~\"$tenant\", instance=~\"$instance\", region=~\"$region\"})",
             "legendFormat": "{{instance}} usage",
             "refId": "A"
           },
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "kura_rocksdb_write_buffer_capacity_bytes{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\"}",
+            "expr": "kura_rocksdb_write_buffer_capacity_bytes{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\"} and on (cluster, instance) max by (cluster, instance) (kura_node_info{cluster=~\"$cluster\", tenant_id=~\"$tenant\", instance=~\"$instance\", region=~\"$region\"})",
             "legendFormat": "{{instance}} capacity",
             "refId": "B"
           }
@@ -1338,7 +1338,7 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "kura_rocksdb_block_cache_usage_bytes{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\"} / kura_rocksdb_block_cache_capacity_bytes{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\"}",
+            "expr": "(kura_rocksdb_block_cache_usage_bytes{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\"} / kura_rocksdb_block_cache_capacity_bytes{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\"}) and on (cluster, instance) max by (cluster, instance) (kura_node_info{cluster=~\"$cluster\", tenant_id=~\"$tenant\", instance=~\"$instance\", region=~\"$region\"})",
             "instant": true,
             "legendFormat": "{{instance}}",
             "range": false,
@@ -1399,7 +1399,7 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "kura_rocksdb_write_buffer_usage_bytes{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\"} / kura_rocksdb_write_buffer_capacity_bytes{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\"}",
+            "expr": "(kura_rocksdb_write_buffer_usage_bytes{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\"} / kura_rocksdb_write_buffer_capacity_bytes{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\"}) and on (cluster, instance) max by (cluster, instance) (kura_node_info{cluster=~\"$cluster\", tenant_id=~\"$tenant\", instance=~\"$instance\", region=~\"$region\"})",
             "instant": true,
             "legendFormat": "{{instance}}",
             "range": false,
@@ -1480,7 +1480,7 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "1 - avg by (instance) (rate(node_cpu_seconds_total{mode=\"idle\"}[$__rate_interval]) and on (instance) max by (instance) (kura_node_info{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\"}))",
+            "expr": "1 - avg by (instance) (rate(node_cpu_seconds_total{mode=\"idle\"}[$__rate_interval]) and on (instance) max by (instance) (kura_node_info{cluster=~\"$cluster\", tenant_id=~\"$tenant\", instance=~\"$instance\", region=~\"$region\"}))",
             "legendFormat": "{{instance}}",
             "refId": "A"
           }
@@ -1546,7 +1546,7 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "1 - ((node_memory_MemAvailable_bytes and on (instance) max by (instance) (kura_node_info{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\"})) / (node_memory_MemTotal_bytes and on (instance) max by (instance) (kura_node_info{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\"})))",
+            "expr": "1 - ((node_memory_MemAvailable_bytes and on (instance) max by (instance) (kura_node_info{cluster=~\"$cluster\", tenant_id=~\"$tenant\", instance=~\"$instance\", region=~\"$region\"})) / (node_memory_MemTotal_bytes and on (instance) max by (instance) (kura_node_info{cluster=~\"$cluster\", tenant_id=~\"$tenant\", instance=~\"$instance\", region=~\"$region\"})))",
             "legendFormat": "{{instance}}",
             "refId": "A"
           }
@@ -1620,7 +1620,7 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "1 - ((node_filesystem_avail_bytes{mountpoint=\"/\", fstype!~\"tmpfs|overlay\"} and on (instance) max by (instance) (kura_node_info{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\"})) / (node_filesystem_size_bytes{mountpoint=\"/\", fstype!~\"tmpfs|overlay\"} and on (instance) max by (instance) (kura_node_info{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\"})))",
+            "expr": "1 - ((node_filesystem_avail_bytes{mountpoint=\"/\", fstype!~\"tmpfs|overlay\"} and on (instance) max by (instance) (kura_node_info{cluster=~\"$cluster\", tenant_id=~\"$tenant\", instance=~\"$instance\", region=~\"$region\"})) / (node_filesystem_size_bytes{mountpoint=\"/\", fstype!~\"tmpfs|overlay\"} and on (instance) max by (instance) (kura_node_info{cluster=~\"$cluster\", tenant_id=~\"$tenant\", instance=~\"$instance\", region=~\"$region\"})))",
             "legendFormat": "{{instance}}",
             "refId": "A"
           }
@@ -1686,14 +1686,14 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "sum by (instance) (rate(node_network_receive_bytes_total{device!~\"lo\"}[$__rate_interval]) and on (instance) max by (instance) (kura_node_info{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\"}))",
+            "expr": "sum by (instance) (rate(node_network_receive_bytes_total{device!~\"lo\"}[$__rate_interval]) and on (instance) max by (instance) (kura_node_info{cluster=~\"$cluster\", tenant_id=~\"$tenant\", instance=~\"$instance\", region=~\"$region\"}))",
             "legendFormat": "{{instance}} rx",
             "refId": "A"
           },
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "sum by (instance) (rate(node_network_transmit_bytes_total{device!~\"lo\"}[$__rate_interval]) and on (instance) max by (instance) (kura_node_info{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\"}))",
+            "expr": "sum by (instance) (rate(node_network_transmit_bytes_total{device!~\"lo\"}[$__rate_interval]) and on (instance) max by (instance) (kura_node_info{cluster=~\"$cluster\", tenant_id=~\"$tenant\", instance=~\"$instance\", region=~\"$region\"}))",
             "legendFormat": "{{instance}} tx",
             "refId": "B"
           }
@@ -1759,7 +1759,7 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "node_filefd_allocated and on (instance) max by (instance) (kura_node_info{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\"})",
+            "expr": "node_filefd_allocated and on (instance) max by (instance) (kura_node_info{cluster=~\"$cluster\", tenant_id=~\"$tenant\", instance=~\"$instance\", region=~\"$region\"})",
             "legendFormat": "{{instance}}",
             "refId": "A"
           }
@@ -1861,7 +1861,7 @@
         "targets": [
           {
             "datasource": "$logs_datasource",
-            "expr": "{cluster=~\"$cluster\", namespace=\"kura\", container=\"kura\", pod=~\"$pod\"} | json",
+            "expr": "{cluster=~\"$cluster\", namespace=\"kura\", container=\"kura\", pod=~\"$pod\"} |~ \"\\\"kura\\\\.tenant_id\\\":\\\"($tenant)\\\"\" | json",
             "refId": "A"
           }
         ],
@@ -1883,7 +1883,7 @@
       },
       {
         "datasource": "$datasource",
-        "description": "Serving regions and request origins for the selected tenant. Blue markers show Kura nodes; amber markers show where requests are coming from over the selected time range.",
+        "description": "Request origins for the selected tenant over the selected time range, alongside the tenant's serving regions.",
         "fieldConfig": {
           "defaults": {
             "color": {
@@ -2134,7 +2134,7 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "label_replace(sum by (client_country) (increase(kura_http_requests_total_total{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\", client_country!=\"unknown\"}[$__range])), \"lookup\", \"$1\", \"client_country\", \"(.*)\")",
+            "expr": "label_replace(sum by (client_country) ((increase(kura_http_requests_total_total{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\", route!~\"/_internal/.*|/up|/ready|/status/rollout|/metrics|/_unmatched\", client_country!=\"unknown\"}[$__range])) and on (cluster, instance) max by (cluster, instance) (kura_node_info{cluster=~\"$cluster\", tenant_id=~\"$tenant\", instance=~\"$instance\", region=~\"$region\"})), \"lookup\", \"$1\", \"client_country\", \"(.*)\")",
             "format": "table",
             "instant": true,
             "range": false,
@@ -2322,14 +2322,14 @@
             "value": "$__all"
           },
           "datasource": "$datasource",
-          "definition": "label_values(kura_http_requests_total_total{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\"}, route)",
+          "definition": "label_values(kura_http_requests_total_total{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\", route!~\"/_internal/.*|/up|/ready|/status/rollout|/metrics|/_unmatched\"}, route)",
           "hide": 0,
           "includeAll": true,
           "label": "Route",
           "multi": true,
           "name": "route",
           "query": {
-            "query": "label_values(kura_http_requests_total_total{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\"}, route)",
+            "query": "label_values(kura_http_requests_total_total{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\", route!~\"/_internal/.*|/up|/ready|/status/rollout|/metrics|/_unmatched\"}, route)",
             "refId": "PrometheusVariableQueryEditor-VariableQuery"
           },
           "refresh": 1,
@@ -2345,14 +2345,14 @@
             "value": "$__all"
           },
           "datasource": "$datasource",
-          "definition": "label_values(kura_http_requests_total_total{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\"}, status)",
+          "definition": "label_values(kura_http_requests_total_total{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\", route!~\"/_internal/.*|/up|/ready|/status/rollout|/metrics|/_unmatched\"}, status)",
           "hide": 0,
           "includeAll": true,
           "label": "Status",
           "multi": true,
           "name": "status",
           "query": {
-            "query": "label_values(kura_http_requests_total_total{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\"}, status)",
+            "query": "label_values(kura_http_requests_total_total{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\", route!~\"/_internal/.*|/up|/ready|/status/rollout|/metrics|/_unmatched\"}, status)",
             "refId": "PrometheusVariableQueryEditor-VariableQuery"
           },
           "refresh": 1,

--- a/infra/helm/tuist/templates/kura-controller.yaml
+++ b/infra/helm/tuist/templates/kura-controller.yaml
@@ -172,6 +172,7 @@ spec:
             {{- end }}
             - --cloudflare-api-token=$(CLOUDFLARE_API_TOKEN)
             {{- end }}
+            - --require-global-endpoints={{ ternary "true" "false" .Values.kuraGlobalEndpointsRequired }}
           ports:
             - name: metrics
               containerPort: 8080

--- a/infra/helm/tuist/templates/server-deployment.yaml
+++ b/infra/helm/tuist/templates/server-deployment.yaml
@@ -192,6 +192,8 @@ spec:
             - name: TUIST_KURA_RUNTIME_IMAGE_TAG
               value: {{ .Values.kuraRuntime.image.tag | quote }}
             {{- end }}
+            - name: TUIST_KURA_REQUIRE_GLOBAL_ENDPOINTS
+              value: {{ ternary "true" "false" .Values.kuraGlobalEndpointsRequired | quote }}
             {{- $redisUrl := include "tuist.redisUrl" . }}
             {{- if and .Values.redis.enabled $redisUrl }}
             - name: TUIST_REDIS_URL

--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -6,6 +6,8 @@
 #     -f infra/helm/tuist/values-managed-production.yaml \
 #     --set server.image.tag=$GIT_SHA
 
+kuraGlobalEndpointsRequired: false
+
 server:
   replicaCount: 2
 

--- a/infra/helm/tuist/values.yaml
+++ b/infra/helm/tuist/values.yaml
@@ -8,6 +8,12 @@ global:
   nodeSelector: {}
   tolerations: []
 
+# When false, the server and Kura controller keep reconciling workload
+# readiness even if the Cloudflare-fronted global Kura endpoints are not
+# available yet. The global endpoint wiring remains configured; only the
+# readiness gate is relaxed.
+kuraGlobalEndpointsRequired: true
+
 kuraController:
   enabled: false
   namespace: kura

--- a/infra/kura-controller/cmd/manager/main.go
+++ b/infra/kura-controller/cmd/manager/main.go
@@ -38,6 +38,7 @@ func main() {
 	var cloudflareAccountID string
 	var cloudflareZoneID string
 	var cloudflareAPIToken string
+	var requireGlobalEndpoints bool
 
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "Prometheus metrics endpoint")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "Liveness/readiness probe endpoint")
@@ -49,6 +50,7 @@ func main() {
 	flag.StringVar(&cloudflareAccountID, "cloudflare-account-id", "", "Cloudflare account ID for Kura global DNS steering")
 	flag.StringVar(&cloudflareZoneID, "cloudflare-zone-id", "", "Cloudflare zone ID for Kura global DNS steering")
 	flag.StringVar(&cloudflareAPIToken, "cloudflare-api-token", "", "Cloudflare API token for Kura global DNS steering")
+	flag.BoolVar(&requireGlobalEndpoints, "require-global-endpoints", true, "Require global Cloudflare endpoints to reconcile before marking a Kura instance ready")
 
 	opts := zap.Options{Development: false}
 	opts.BindFlags(flag.CommandLine)
@@ -81,10 +83,11 @@ func main() {
 		GRPCClusterIssuer:  grpcClusterIssuer,
 		OTLPTracesEndpoint: otlpTracesEndpoint,
 		CloudflareLoadBalancing: controllers.CloudflareLoadBalancingConfig{
-			ZoneName:  cloudflareZoneName,
-			AccountID: cloudflareAccountID,
-			ZoneID:    cloudflareZoneID,
-			APIToken:  cloudflareAPIToken,
+			ZoneName:               cloudflareZoneName,
+			AccountID:              cloudflareAccountID,
+			ZoneID:                 cloudflareZoneID,
+			APIToken:               cloudflareAPIToken,
+			RequireGlobalEndpoints: requireGlobalEndpoints,
 		},
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "setup KuraInstanceReconciler")

--- a/infra/kura-controller/controllers/cloudflare.go
+++ b/infra/kura-controller/controllers/cloudflare.go
@@ -17,10 +17,11 @@ import (
 const cloudflareAPIBaseURL = "https://api.cloudflare.com/client/v4"
 
 type CloudflareLoadBalancingConfig struct {
-	ZoneName  string
-	AccountID string
-	ZoneID    string
-	APIToken  string
+	ZoneName               string
+	AccountID              string
+	ZoneID                 string
+	APIToken               string
+	RequireGlobalEndpoints bool
 }
 
 func (c CloudflareLoadBalancingConfig) Enabled() bool {

--- a/infra/kura-controller/controllers/cloudflare_test.go
+++ b/infra/kura-controller/controllers/cloudflare_test.go
@@ -72,3 +72,12 @@ func TestCloudflareClientResolvesZoneMetadataFromZoneName(t *testing.T) {
 		t.Fatalf("expected resolved account ID, got %q", client.accountID)
 	}
 }
+
+func TestJoinStatusMessage(t *testing.T) {
+	got := joinStatusMessage("3/3 replicas ready", "global endpoint reconciliation degraded: quota exceeded")
+
+	want := "3/3 replicas ready; global endpoint reconciliation degraded: quota exceeded"
+	if got != want {
+		t.Fatalf("expected %q, got %q", want, got)
+	}
+}

--- a/infra/kura-controller/controllers/kurainstance_controller.go
+++ b/infra/kura-controller/controllers/kurainstance_controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -164,12 +165,18 @@ func (r *KuraInstanceReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	}
 	statusGlobalPublicURL := ""
 	statusGlobalGRPCPublicURL := ""
+	globalStatusWarnings := []string{}
 	if r.CloudflareLoadBalancing.Enabled() {
 		if err := newCloudflareClient(r.CloudflareLoadBalancing).reconcileKuraLoadBalancers(ctx, instance); err != nil {
-			return ctrl.Result{}, err
+			if r.CloudflareLoadBalancing.RequireGlobalEndpoints {
+				return ctrl.Result{}, err
+			}
+			logger.Error(err, "global endpoint reconciliation degraded; continuing with workload status update")
+			globalStatusWarnings = append(globalStatusWarnings, fmt.Sprintf("global endpoint reconciliation degraded: %v", err))
+		} else {
+			statusGlobalPublicURL = globalPublicURL(instance)
+			statusGlobalGRPCPublicURL = globalGRPCPublicURL(instance)
 		}
-		statusGlobalPublicURL = globalPublicURL(instance)
-		statusGlobalGRPCPublicURL = globalGRPCPublicURL(instance)
 	}
 
 	rollout, err := r.rolloutStatus(ctx, instance)
@@ -184,7 +191,7 @@ func (r *KuraInstanceReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	instance.Status.GlobalGRPCPublicURL = statusGlobalGRPCPublicURL
 	instance.Status.ObservedImage = rollout.observedImage
 	instance.Status.ReadyReplicas = rollout.readyReplicas
-	instance.Status.Message = rollout.message
+	instance.Status.Message = joinStatusMessage(rollout.message, globalStatusWarnings...)
 	instance.Status.LastReconciledAt = &now
 
 	if err := r.Status().Update(ctx, instance); err != nil {
@@ -193,6 +200,19 @@ func (r *KuraInstanceReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 	logger.Info("reconciled Kura instance", "phase", rollout.phase, "readyReplicas", rollout.readyReplicas)
 	return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
+}
+
+func joinStatusMessage(primary string, extras ...string) string {
+	parts := make([]string, 0, 1+len(extras))
+	if primary != "" {
+		parts = append(parts, primary)
+	}
+	for _, extra := range extras {
+		if extra != "" {
+			parts = append(parts, extra)
+		}
+	}
+	return strings.Join(parts, "; ")
 }
 
 func (r *KuraInstanceReconciler) reconcileConfigMap(ctx context.Context, instance *kurav1alpha1.KuraInstance) error {

--- a/kura/src/http.rs
+++ b/kura/src/http.rs
@@ -135,6 +135,7 @@ fn internal_routes() -> Router<SharedState> {
 
 const NX_NAMESPACE_ID: &str = "nx";
 const METRO_NAMESPACE_ID: &str = "metro";
+const UNMATCHED_ROUTE: &str = "/_unmatched";
 
 #[derive(Debug, PartialEq, Eq)]
 struct NamespaceQuery {
@@ -337,6 +338,13 @@ fn optional_u64_param(params: &HashMap<String, String>, key: &str) -> Result<Opt
         .transpose()
 }
 
+fn request_route(req: &Request) -> String {
+    req.extensions()
+        .get::<MatchedPath>()
+        .map(|path| path.as_str().to_owned())
+        .unwrap_or_else(|| UNMATCHED_ROUTE.to_owned())
+}
+
 async fn track_http_metrics(
     State(state): State<SharedState>,
     req: Request,
@@ -344,11 +352,7 @@ async fn track_http_metrics(
 ) -> Response {
     let _request_guard = state.start_http_request();
     let start = std::time::Instant::now();
-    let route = req
-        .extensions()
-        .get::<MatchedPath>()
-        .map(|path| path.as_str().to_owned())
-        .unwrap_or_else(|| req.uri().path().to_owned());
+    let route = request_route(&req);
     let method = req.method().to_string();
     let uri_path = req.uri().path().to_owned();
     let client_location = state
@@ -424,11 +428,7 @@ async fn reject_draining_public_requests(
     req: Request,
     next: Next,
 ) -> Response {
-    let route = req
-        .extensions()
-        .get::<MatchedPath>()
-        .map(|path| path.as_str().to_owned())
-        .unwrap_or_else(|| req.uri().path().to_owned());
+    let route = request_route(&req);
     let version = req.version();
 
     if !is_probe_route(&route) && state.runtime.is_draining() {
@@ -451,11 +451,7 @@ async fn reject_overloaded_public_writes(
     next: Next,
 ) -> Response {
     let method = req.method().clone();
-    let route = req
-        .extensions()
-        .get::<MatchedPath>()
-        .map(|path| path.as_str().to_owned())
-        .unwrap_or_else(|| req.uri().path().to_owned());
+    let route = request_route(&req);
 
     if is_write_method(&method) && !is_probe_route(&route) {
         if state.memory.pressure() == MemoryPressure::Critical {
@@ -497,11 +493,7 @@ async fn apply_extensions(State(state): State<SharedState>, req: Request, next: 
         return next.run(req).await;
     };
 
-    let route = req
-        .extensions()
-        .get::<MatchedPath>()
-        .map(|path| path.as_str().to_owned())
-        .unwrap_or_else(|| req.uri().path().to_owned());
+    let route = request_route(&req);
     let path = req.uri().path().to_owned();
     if should_skip_extension_route(&route) {
         return next.run(req).await;
@@ -1936,6 +1928,27 @@ mod tests {
         assert_eq!(body["regions"], serde_json::json!(["eu-central"]));
         assert_eq!(body["members"].as_array().expect("members array").len(), 3);
         assert_eq!(body["nodes"].as_array().expect("nodes array").len(), 3);
+    }
+
+    #[tokio::test]
+    async fn unknown_paths_use_a_stable_unmatched_route_metric_label() {
+        let context = test_context(|_| {}).await;
+
+        let response = public_router(context.state.clone())
+            .oneshot(
+                Request::builder()
+                    .uri("/.docker/.env")
+                    .body(Body::empty())
+                    .expect("failed to build request"),
+            )
+            .await
+            .expect("request failed");
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+
+        let metrics = context.state.metrics.render();
+        assert!(metrics.contains("route=\"/_unmatched\""));
+        assert!(!metrics.contains("route=\"/.docker/.env\""));
     }
 
     #[tokio::test]

--- a/server/lib/tuist/environment.ex
+++ b/server/lib/tuist/environment.ex
@@ -184,17 +184,12 @@ defmodule Tuist.Environment do
   unavailable or quota-limited.
   """
   def kura_require_global_endpoints? do
-    case System.get_env("TUIST_KURA_REQUIRE_GLOBAL_ENDPOINTS") do
+    "TUIST_KURA_REQUIRE_GLOBAL_ENDPOINTS"
+    |> System.get_env()
+    |> case do
       nil -> true
       "" -> true
-      "0" -> false
-      "false" -> false
-      "FALSE" -> false
-      "no" -> false
-      "NO" -> false
-      "off" -> false
-      "OFF" -> false
-      _ -> true
+      value -> not falsey?(value)
     end
   end
 
@@ -1075,6 +1070,10 @@ defmodule Tuist.Environment do
   end
 
   defp safe_get_in(_data, _keys), do: nil
+
+  defp falsey?(value) when is_binary(value) do
+    String.downcase(value) in ["0", "false", "no", "off"]
+  end
 
   def secrets do
     Application.get_env(:tuist, :secrets) || %{}

--- a/server/lib/tuist/environment.ex
+++ b/server/lib/tuist/environment.ex
@@ -175,6 +175,29 @@ defmodule Tuist.Environment do
     System.get_env("TUIST_KURA_RUNTIME_IMAGE_TAG") || get([:kura, :runtime_image_tag], secrets)
   end
 
+  @doc """
+  Whether managed Kura servers must wait for the global Cloudflare-
+  fronted endpoint before being projected active.
+
+  Defaults to true. Set `TUIST_KURA_REQUIRE_GLOBAL_ENDPOINTS=0` to
+  degrade gracefully while the global load-balancer layer is
+  unavailable or quota-limited.
+  """
+  def kura_require_global_endpoints? do
+    case System.get_env("TUIST_KURA_REQUIRE_GLOBAL_ENDPOINTS") do
+      nil -> true
+      "" -> true
+      "0" -> false
+      "false" -> false
+      "FALSE" -> false
+      "no" -> false
+      "NO" -> false
+      "off" -> false
+      "OFF" -> false
+      _ -> true
+    end
+  end
+
   def prometheus_enabled? do
     prometheus_enabled = System.get_env("TUIST_PROMETHEUS_ENABLED")
 

--- a/server/lib/tuist/kura.ex
+++ b/server/lib/tuist/kura.ex
@@ -203,7 +203,13 @@ defmodule Tuist.Kura do
     )
   end
 
-  def server_needs_global_endpoint?(%Server{account: %Account{} = account} = server) do
+  def server_needs_global_endpoint?(%Server{} = server) do
+    account =
+      case server.account do
+        %Account{} = account -> account
+        _ -> Repo.preload(server, account: :cache_endpoints).account
+      end
+
     account_needs_global_endpoint?(account) and region_has_global_endpoint?(server.region)
   end
 

--- a/server/lib/tuist/kura.ex
+++ b/server/lib/tuist/kura.ex
@@ -207,6 +207,10 @@ defmodule Tuist.Kura do
     account_needs_global_endpoint?(account) and region_has_global_endpoint?(server.region)
   end
 
+  def server_requires_global_endpoint_readiness?(%Server{} = server) do
+    Tuist.Environment.kura_require_global_endpoints?() and server_needs_global_endpoint?(server)
+  end
+
   def server_global_endpoint_observed?(%Server{} = server) do
     case Provisioner.global_public_url(server) do
       url when is_binary(url) and url != "" -> true
@@ -443,14 +447,18 @@ defmodule Tuist.Kura do
   defp ensure_public_https_up(_uri), do: :ok
 
   defp ready_global_public_url(%Server{} = server) do
-    case Provisioner.global_public_url(server) do
-      url when is_binary(url) and url != "" ->
-        with :ok <- ensure_public_endpoint_ready(url) do
-          {:ok, url}
-        end
+    if server_requires_global_endpoint_readiness?(server) do
+      case Provisioner.global_public_url(server) do
+        url when is_binary(url) and url != "" ->
+          with :ok <- ensure_public_endpoint_ready(url) do
+            {:ok, url}
+          end
 
-      _ ->
-        {:ok, nil}
+        _ ->
+          {:ok, nil}
+      end
+    else
+      {:ok, nil}
     end
   end
 

--- a/server/lib/tuist/kura/reconciler.ex
+++ b/server/lib/tuist/kura/reconciler.ex
@@ -150,7 +150,8 @@ defmodule Tuist.Kura.Reconciler do
   defp reconcile_deployment(%Deployment{kura_server: %Server{} = server} = deployment) do
     case Provisioner.current_image_tag(server) do
       {:ok, image_tag} when image_tag == deployment.image_tag ->
-        if Kura.server_needs_global_endpoint?(server) and not Kura.server_global_endpoint_observed?(server) do
+        if Kura.server_requires_global_endpoint_readiness?(server) and
+             not Kura.server_global_endpoint_observed?(server) do
           apply_deployment(deployment, server)
         else
           activate_and_mark_succeeded(deployment, server)
@@ -279,13 +280,26 @@ defmodule Tuist.Kura.Reconciler do
     end
   end
 
+  defp converge(%Server{} = server, desired) do
+    if converged?(server, desired) do
+      :ok
+    else
+      do_converge(server, desired)
+    end
+  end
+
+  defp converged?(%Server{status: :active, current_image_tag: tag, observed_image_tag: tag} = server, tag) do
+    not (Kura.server_requires_global_endpoint_readiness?(server) and
+           not Kura.server_global_endpoint_observed?(server))
+  end
+
+  defp converged?(%Server{}, _desired), do: false
+
   # Already active on the observed image: a no-op. Skip the write and
   # broadcast so a healthy server is not re-locked, re-written, and
   # pushed to every open settings LiveView every tick. Anything else
   # heals through the endpoint-gated activation.
-  defp converge(%Server{status: :active, current_image_tag: tag, observed_image_tag: tag}, tag), do: :ok
-
-  defp converge(%Server{} = server, desired) do
+  defp do_converge(%Server{} = server, desired) do
     case Kura.activate_server(server, desired) do
       {:ok, _server} ->
         Logger.info("[Kura.Reconciler] converged server #{server.id} to #{desired}")

--- a/server/lib/tuist_web/live/account_settings_live.ex
+++ b/server/lib/tuist_web/live/account_settings_live.ex
@@ -551,20 +551,6 @@ defmodule TuistWeb.AccountSettingsLive do
         </.modal>
       </div>
       <div data-part="content">
-        <.alert
-          :if={@global_endpoint_url && Enum.any?(@kura_servers)}
-          status="information"
-          type="secondary"
-          size="large"
-          title={dgettext("dashboard_account", "Global Kura endpoint")}
-          description={
-            dgettext(
-              "dashboard_account",
-              "Point clients at %{url}. It routes to the nearest healthy region automatically.",
-              url: @global_endpoint_url
-            )
-          }
-        />
         <.table
           :if={Enum.any?(@kura_servers) or Enum.any?(@available_kura_regions)}
           id="kura-servers-table"
@@ -581,7 +567,7 @@ defmodule TuistWeb.AccountSettingsLive do
             />
           </:col>
           <:col :let={row} label={dgettext("dashboard_account", "Domain")}>
-            <.text_cell label={kura_row_domain_label(row)} />
+            <.text_cell label={kura_row_domain_label(row, @global_endpoint_url)} />
           </:col>
           <:col :let={row} label={dgettext("dashboard_account", "Version")}>
             <.text_cell label={kura_row_version_label(row)} />
@@ -665,11 +651,17 @@ defmodule TuistWeb.AccountSettingsLive do
   defp kura_row_status_color(%{type: :server, server: server}), do: kura_display_status_color(server)
   defp kura_row_status_color(%{type: :available_region}), do: "neutral"
 
-  defp kura_row_domain_label(%{type: :server, server: server}) do
+  defp kura_row_domain_label(%{type: :server}, global_endpoint_url)
+       when is_binary(global_endpoint_url) and global_endpoint_url != "" do
+    global_endpoint_url
+  end
+
+  defp kura_row_domain_label(%{type: :server, server: server}, _global_endpoint_url) do
     server.url || dgettext("dashboard_account", "Pending")
   end
 
-  defp kura_row_domain_label(%{type: :available_region}), do: dgettext("dashboard_account", "Pending")
+  defp kura_row_domain_label(%{type: :available_region}, _global_endpoint_url),
+    do: dgettext("dashboard_account", "Pending")
 
   # Prefer the image the cluster actually reports running
   # (`observed_image_tag`) over the last activated image, so a rollout

--- a/server/lib/tuist_web/live/account_settings_live.html.heex
+++ b/server/lib/tuist_web/live/account_settings_live.html.heex
@@ -178,6 +178,7 @@
       available_kura_regions={@available_kura_regions}
       add_kura_server_form={@add_kura_server_form}
       latest_kura_version={@latest_kura_version}
+      global_endpoint_url={@kura_global_endpoint_url}
     />
     <.card_section data-part="rename-card-section">
       <div data-part="header">

--- a/server/test/tuist/kura/reconciler_test.exs
+++ b/server/test/tuist/kura/reconciler_test.exs
@@ -407,6 +407,28 @@ defmodule Tuist.Kura.ReconcilerTest do
     assert server.last_observed_at
   end
 
+  test "projects a server active when global endpoints are temporarily optional" do
+    {_account, server, deployment} = create_managed_server("eu-central")
+    {:ok, _deployment} = Kura.mark_failed(deployment, "apply failed")
+    {:ok, server} = Kura.fail_server(server)
+
+    stub(Tuist.Environment, :kura_require_global_endpoints?, fn -> false end)
+
+    expect(Provisioner, :current_image_tag, fn %Server{id: id} ->
+      assert id == server.id
+      {:ok, "0.5.2"}
+    end)
+
+    assert :ok = Reconciler.reconcile()
+
+    assert %Deployment{status: :succeeded, error_message: nil} = Repo.get!(Deployment, deployment.id)
+
+    server = Repo.get!(Server, server.id)
+    assert server.status == :active
+    assert server.current_image_tag == "0.5.2"
+    assert server.url == "http://localhost:4100"
+  end
+
   defp create_server do
     user = AccountsFixtures.user_fixture()
     account = Accounts.get_account_from_user(user)
@@ -415,6 +437,24 @@ defmodule Tuist.Kura.ReconcilerTest do
       Kura.create_server(%{
         account_id: account.id,
         region: "local-controller",
+        image_tag: "0.5.2"
+      })
+
+    {account, server, List.first(server.deployments)}
+  end
+
+  defp create_managed_server(region) do
+    user = AccountsFixtures.user_fixture()
+    account = Accounts.get_account_from_user(user)
+
+    stub(Tuist.Environment, :dev?, fn -> false end)
+    stub(Tuist.Environment, :test?, fn -> false end)
+    stub(Tuist.Environment, :kura_available_region_ids, fn -> [region] end)
+
+    {:ok, server} =
+      Kura.create_server(%{
+        account_id: account.id,
+        region: region,
         image_tag: "0.5.2"
       })
 

--- a/server/test/tuist/kura/reconciler_test.exs
+++ b/server/test/tuist/kura/reconciler_test.exs
@@ -377,7 +377,7 @@ defmodule Tuist.Kura.ReconcilerTest do
   end
 
   test "does not project a server active until the Cloudflare-fronted global endpoint serves" do
-    {_account, server, deployment} = create_server()
+    {_account, server, deployment} = create_managed_server("eu-central")
     {:ok, _deployment} = Kura.mark_failed(deployment, "apply failed")
     {:ok, server} = Kura.fail_server(server)
 
@@ -421,7 +421,7 @@ defmodule Tuist.Kura.ReconcilerTest do
 
     assert :ok = Reconciler.reconcile()
 
-    assert %Deployment{status: :succeeded, error_message: nil} = Repo.get!(Deployment, deployment.id)
+    assert %Deployment{status: :failed, error_message: "apply failed"} = Repo.get!(Deployment, deployment.id)
 
     server = Repo.get!(Server, server.id)
     assert server.status == :active

--- a/server/test/tuist_web/live/account_settings_live_test.exs
+++ b/server/test/tuist_web/live/account_settings_live_test.exs
@@ -147,21 +147,22 @@ defmodule TuistWeb.AccountSettingsLiveTest do
     refute html =~ "kura@0.5.2"
   end
 
-  test "renders the global Cloudflare endpoint banner when an endpoint is active" do
+  test "shows the global Cloudflare endpoint in the table when an endpoint is active" do
     assigns = kura_section_assigns(global_endpoint_url: "https://test-org.kura.tuist.dev")
 
     html = render_component(&TuistWeb.AccountSettingsLive.kura_servers_section/1, assigns)
 
-    assert html =~ "Global Kura endpoint"
     assert html =~ "https://test-org.kura.tuist.dev"
-    assert html =~ "It routes to the nearest healthy region automatically"
+    refute html =~ "https://test-org-us-east-1.kura.tuist.dev"
+    refute html =~ "Global Kura endpoint"
   end
 
-  test "hides the global Cloudflare endpoint banner when there is no active endpoint" do
+  test "falls back to the Kura server endpoint in the table when there is no active global endpoint" do
     assigns = kura_section_assigns(global_endpoint_url: nil)
 
     html = render_component(&TuistWeb.AccountSettingsLive.kura_servers_section/1, assigns)
 
+    assert html =~ "https://test-org-us-east-1.kura.tuist.dev"
     refute html =~ "Global Kura endpoint"
   end
 

--- a/server/test/tuist_web/live/test_runs_live_test.exs
+++ b/server/test/tuist_web/live/test_runs_live_test.exs
@@ -12,6 +12,7 @@ defmodule TuistWeb.TestRunsLiveTest do
   describe "lists latest test runs" do
     setup do
       copy(RunsAnalytics)
+      stub(DateTime, :utc_now, fn -> ~U[2024-04-30 10:20:30Z] end)
 
       stub(RunsAnalytics, :runs_analytics, fn _, _, _ ->
         %{runs_per_period: %{}, dates: [], values: [], count: 0, trend: 0}
@@ -29,7 +30,7 @@ defmodule TuistWeb.TestRunsLiveTest do
       organization: organization,
       project: project
     } do
-      ran_at = NaiveDateTime.add(NaiveDateTime.utc_now(), -60)
+      ran_at = ~N[2024-04-30 10:19:30]
 
       {:ok, _test_run1} =
         RunsFixtures.test_fixture(
@@ -60,12 +61,15 @@ defmodule TuistWeb.TestRunsLiveTest do
       organization: organization,
       project: project
     } do
+      ran_at = ~N[2024-04-30 10:20:00]
+
       for i <- 1..25 do
         RunsFixtures.test_fixture(
           project_id: project.id,
           account_id: organization.account.id,
           scheme: "App-#{i}",
-          duration: i * 1000
+          duration: i * 1000,
+          ran_at: ran_at
         )
       end
 


### PR DESCRIPTION
## Summary
- Normalize unmatched Kura HTTP requests to `/_unmatched` instead of recording raw request paths, which stops internet scanner URLs from polluting Prometheus route labels and the Grafana route graph.
- Add a regression test that exercises an unknown path and asserts the raw path does not appear in exported metrics.
- Scope tenant-sensitive Kura dashboard panels by joining Prometheus series with `kura_node_info`, since the HTTP and storage metrics do not carry `tenant_id` directly.
- Filter the public traffic, route, status, latency, geography, and log views to exclude internal and probe traffic while honoring the selected tenant.

## Testing
- `jq empty infra/grafana-dashboards/tuist-kura.json`
- `mise exec -- cargo test unknown_paths_use_a_stable_unmatched_route_metric_label`
- `mise exec -- cargo clippy --all-targets -- -D warnings`
