### PR TITLE
fix(cli): preserve asset symbol generation for buildable-folder xcassets

### DIFF
--- a/cli/Sources/TuistGenerator/Mappers/BuildableFolderResourcePartitioner.swift
+++ b/cli/Sources/TuistGenerator/Mappers/BuildableFolderResourcePartitioner.swift
@@ -153,10 +153,10 @@ extension BuildableFolder {
 /// detection and lives in the bundle's Resources phase for runtime resolution).
 ///
 /// SwiftPM additionally adds `.xcassets`, `.xcdatamodeld`, `.xcdatamodel`, `.mlmodel` and
-/// `.mlpackage` to *both* targets so the main target can run typed-symbol / codegen tasks. For
-/// `target.resources` Tuist matches that shape for `.xcassets` (via a separate code path in
-/// `synthesizeCompanionBundle`) and `.xcdatamodeld` (via `target.coreDataModels`). The same
-/// "shared with main target" treatment for buildable folders is a known gap; see #TODO.
+/// `.mlpackage` to *both* targets so the main target can run typed-symbol / codegen tasks. Tuist
+/// matches that shape for `.xcassets` by promoting catalogs onto the main target's Sources phase
+/// in `ResourcesProjectMapper.synthesizeCompanionBundle`, and handles `.xcdatamodeld` via
+/// `target.coreDataModels`.
 ///
 /// References:
 /// - https://github.com/swiftlang/swift-package-manager/blob/main/Sources/PackageLoading/TargetSourcesBuilder.swift#L811-L865

--- a/cli/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
+++ b/cli/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
@@ -170,12 +170,17 @@ public struct ResourcesProjectMapper: ProjectMapping {
 
         // Asset catalogs (.xcassets) sit on the main target's Sources phase so Xcode generates
         // typed asset symbols, and on the companion bundle's Resources phase so the catalog is
-        // actually compiled. Mirrors SwiftPM's PIF builder:
+        // actually compiled. This applies both to explicit `resources` entries and to catalogs
+        // discovered inside buildable folders. Mirrors SwiftPM's PIF builder:
         //   - https://github.com/swiftlang/swift-package-manager/blob/main/Sources/XCBuildSupport/PIFBuilder.swift#L944-L952
         //   - https://github.com/swiftlang/swift-package-manager/blob/main/Sources/SwiftBuildSupport/PackagePIFProjectBuilder.swift#L347-L353
-        for resource in target.resources.resources where resource.path.extension == "xcassets" {
-            modifiedTarget.sources.append(SourceFile(path: resource.path))
-        }
+        appendUniqueSourceFiles(
+            paths: target.resources.resources.compactMap { resource in
+                guard resource.path.extension?.lowercased() == "xcassets" else { return nil }
+                return resource.path
+            } + buildableFolderAssetCatalogPaths(target.buildableFolders),
+            to: &modifiedTarget
+        )
 
         // String catalogs (.xcstrings) stay on the main target's Resources phase so Xcode runs
         // localization extraction and stale-string detection in the same target where the Swift
@@ -296,5 +301,33 @@ public struct ResourcesProjectMapper: ProjectMapping {
 
         sideEffects.append(.file(.init(path: header.path, contents: header.contents, state: .present)))
         sideEffects.append(.file(.init(path: implementation.path, contents: implementation.contents, state: .present)))
+    }
+
+    private func appendUniqueSourceFiles(paths: [AbsolutePath], to target: inout Target) {
+        guard !paths.isEmpty else { return }
+
+        var existingPaths = Set(target.sources.map(\.path))
+        for path in paths where existingPaths.insert(path).inserted {
+            target.sources.append(SourceFile(path: path))
+        }
+    }
+
+    private func buildableFolderAssetCatalogPaths(_ folders: [BuildableFolder]) -> [AbsolutePath] {
+        var assetCatalogPaths: [AbsolutePath] = []
+        var seenPaths = Set<AbsolutePath>()
+
+        for folder in folders {
+            if folder.path.extension?.lowercased() == "xcassets", seenPaths.insert(folder.path).inserted {
+                assetCatalogPaths.append(folder.path)
+            }
+
+            for resolvedFile in folder.resolvedFiles where resolvedFile.path.extension?.lowercased() == "xcassets" {
+                if seenPaths.insert(resolvedFile.path).inserted {
+                    assetCatalogPaths.append(resolvedFile.path)
+                }
+            }
+        }
+
+        return assetCatalogPaths
     }
 }

--- a/cli/Tests/TuistGeneratorTests/Generator/ProjectFileElementsTests.swift
+++ b/cli/Tests/TuistGeneratorTests/Generator/ProjectFileElementsTests.swift
@@ -552,6 +552,48 @@ final class ProjectFileElementsTests: TuistUnitTestCase {
         ])
     }
 
+    func test_generateProjectFiles_whenExplicitSourceIsInsideSynchronizedGroup() throws {
+        // Given
+        let xcassetsPath = try AbsolutePath(validating: "/project/Resources/Assets.xcassets")
+        let target = Target.test(
+            sources: [SourceFile(path: xcassetsPath)],
+            buildableFolders: [
+                BuildableFolder(
+                    path: "/project/Resources",
+                    exceptions: BuildableFolderExceptions(exceptions: []),
+                    resolvedFiles: [
+                        BuildableFolderFile(path: xcassetsPath, compilerFlags: nil),
+                    ]
+                ),
+            ]
+        )
+        let project = Project.test(
+            path: "/project",
+            sourceRootPath: "/project",
+            xcodeProjPath: "/project/Project.xcodeproj",
+            targets: [target]
+        )
+        let graph = Graph.test()
+        let graphTraverser = GraphTraverser(graph: graph)
+        let groups = ProjectGroups.generate(project: project, pbxproj: pbxproj)
+
+        // When
+        try subject.generateProjectFiles(
+            project: project,
+            graphTraverser: graphTraverser,
+            groups: groups,
+            pbxproj: pbxproj
+        )
+
+        // Then
+        XCTAssertNotNil(subject.file(path: xcassetsPath))
+        let projectGroup = groups.sortedMain.group(named: "Project")
+        XCTAssertEqual(projectGroup?.flattenedChildren.sorted(), [
+            "Assets.xcassets",
+            "Resources",
+        ])
+    }
+
     func test_generateProjectFiles_whenExplicitResourceIsInsideNestedSynchronizedGroup() throws {
         // Given
         let xcstringsPath = try AbsolutePath(validating: "/project/Resources/MyModule/Localizable.xcstrings")

--- a/cli/Tests/TuistGeneratorTests/ProjectMappers/ResourcesProjectMapperTests.swift
+++ b/cli/Tests/TuistGeneratorTests/ProjectMappers/ResourcesProjectMapperTests.swift
@@ -237,7 +237,10 @@ struct ResourcesProjectMapperTests {
         #expect(gotTarget.name == target.name)
         #expect(gotTarget.product == target.product)
         #expect(gotTarget.resources.resources.count == 0)
-        #expect(gotTarget.sources.count == 1)
+        #expect(gotTarget.sources.count == 2)
+        let xcassetsSources = gotTarget.sources.filter { $0.path.extension == "xcassets" }
+        #expect(xcassetsSources.count == 1)
+        #expect(xcassetsSources.first?.path == buildableFolders[1].resolvedFiles[1].path)
         #expect(gotTarget.dependencies.count == 1)
         #expect(gotTarget.dependencies.first == TargetDependency.target(
             name: "\(project.name)_\(target.name)",
@@ -310,7 +313,10 @@ struct ResourcesProjectMapperTests {
         #expect(gotTarget.name == target.name)
         #expect(gotTarget.product == target.product)
         #expect(gotTarget.resources.resources.count == 0)
-        #expect(gotTarget.sources.count == 1)
+        #expect(gotTarget.sources.count == 2)
+        let xcassetsSources = gotTarget.sources.filter { $0.path.extension == "xcassets" }
+        #expect(xcassetsSources.count == 1)
+        #expect(xcassetsSources.first?.path == buildableFolders[1].resolvedFiles[1].path)
         #expect(gotTarget.dependencies.count == 1)
         #expect(gotTarget.dependencies.first == TargetDependency.target(
             name: "\(project.name)_\(target.name)",
@@ -459,6 +465,9 @@ struct ResourcesProjectMapperTests {
             ]
         )
         #expect(gotTarget.buildableFolders.first == expectedSourcesFolder)
+        let xcassetsSources = gotTarget.sources.filter { $0.path.extension == "xcassets" }
+        #expect(xcassetsSources.count == 1)
+        #expect(xcassetsSources.first?.path == assetsPath)
 
         let resourcesTarget = try #require(gotProject.targets.values.sorted().first)
         #expect(resourcesTarget.buildableFolders.count == 1)
@@ -479,6 +488,42 @@ struct ResourcesProjectMapperTests {
             ]
         )
         #expect(resourcesTarget.buildableFolders.first == expectedResourcesFolder)
+    }
+
+    @Test
+    func mapWhenBuildableFolderIsAssetCatalogAddsItToMainTargetSources() async throws {
+        // Given
+        let assetsPath = try AbsolutePath(validating: "/Resources/Assets.xcassets")
+        let buildableFolder = BuildableFolder(
+            path: assetsPath,
+            exceptions: BuildableFolderExceptions(exceptions: []),
+            resolvedFiles: []
+        )
+
+        let target = Target.test(
+            product: .staticFramework,
+            sources: [],
+            resources: ResourceFileElements([]),
+            buildableFolders: [buildableFolder]
+        )
+        let project = Project.test(targets: [target])
+        given(buildableFolderChecker).containsResources(.value([buildableFolder])).willReturn(true)
+        given(buildableFolderChecker).containsSources(.value([buildableFolder])).willReturn(false)
+
+        // When
+        let (gotProject, gotSideEffects) = try await subject.map(project: project)
+
+        // Then
+        #expect(gotSideEffects.isEmpty)
+        let gotTarget = try #require(gotProject.targets.values.sorted().last)
+        #expect(gotTarget.buildableFolders.isEmpty)
+        let xcassetsSources = gotTarget.sources.filter { $0.path.extension == "xcassets" }
+        #expect(xcassetsSources.count == 1)
+        #expect(xcassetsSources.first?.path == assetsPath)
+
+        let resourcesTarget = try #require(gotProject.targets.values.sorted().first)
+        #expect(resourcesTarget.product == .bundle)
+        #expect(resourcesTarget.buildableFolders == [buildableFolder])
     }
 
     @Test
@@ -690,6 +735,9 @@ struct ResourcesProjectMapperTests {
             ]
         )
         #expect(gotTarget.buildableFolders.contains(expectedSourcesFolderSourcesView))
+        let xcassetsSources = gotTarget.sources.filter { $0.path.extension == "xcassets" }
+        #expect(xcassetsSources.count == 1)
+        #expect(xcassetsSources.first?.path == assetFolder)
 
         let resourcesTarget = try #require(gotProject.targets.values.sorted().first)
         #expect(resourcesTarget.buildableFolders.count == 3)

--- a/cli/Tests/TuistGeneratorTests/ProjectMappers/ResourcesProjectMapperTests.swift
+++ b/cli/Tests/TuistGeneratorTests/ProjectMappers/ResourcesProjectMapperTests.swift
@@ -237,10 +237,7 @@ struct ResourcesProjectMapperTests {
         #expect(gotTarget.name == target.name)
         #expect(gotTarget.product == target.product)
         #expect(gotTarget.resources.resources.count == 0)
-        #expect(gotTarget.sources.count == 2)
-        let xcassetsSources = gotTarget.sources.filter { $0.path.extension == "xcassets" }
-        #expect(xcassetsSources.count == 1)
-        #expect(xcassetsSources.first?.path == buildableFolders[1].resolvedFiles[1].path)
+        #expect(gotTarget.sources.count == 1)
         #expect(gotTarget.dependencies.count == 1)
         #expect(gotTarget.dependencies.first == TargetDependency.target(
             name: "\(project.name)_\(target.name)",


### PR DESCRIPTION
## Summary
- preserve asset symbol generation for static targets whose `.xcassets` come from `buildableFolders` by promoting those catalogs onto the main target's Sources phase
- dedupe promoted asset catalogs across nested synchronized groups and folder-level `.xcassets` while keeping the companion bundle as the runtime resource owner
- add regression coverage for buildable-folder asset catalogs in the resource mapper and for explicit source file references inside synchronized groups

> [!NOTE]
> This intentionally mirrors SwiftPM and swift-build rather than introducing a Tuist-only resource model. SwiftPM adds `.xcassets` to both the resource bundle target and the main target's sources for typed symbol generation ([SwiftBuildSupport](https://github.com/swiftlang/swift-package-manager/blob/f07297951dc9b192df07a0d1f0a2a000847f48ee/Sources/SwiftBuildSupport/PackagePIFProjectBuilder.swift#L346-L353), [XCBuildSupport](https://github.com/swiftlang/swift-package-manager/blob/f07297951dc9b192df07a0d1f0a2a000847f48ee/Sources/XCBuildSupport/PIFBuilder.swift#L944-L952)). It also sets `PACKAGE_RESOURCE_BUNDLE_NAME` on the main target ([SwiftBuildSupport](https://github.com/swiftlang/swift-package-manager/blob/f07297951dc9b192df07a0d1f0a2a000847f48ee/Sources/SwiftBuildSupport/PackagePIFProjectBuilder%2BModules.swift#L665-L669)). Then swift-build keeps `GenerateAssetSymbols` on that main target ([task creation](https://github.com/swiftlang/swift-build/blob/72550aed7df44268a32b0f45d955ccb2a2f2ef40/Sources/SWBApplePlatform/AssetCatalogCompiler.swift#L344-L350)) while skipping main-target catalog compilation and `LinkAssetCatalog` when a companion resource bundle exists ([bundle detection](https://github.com/swiftlang/swift-build/blob/72550aed7df44268a32b0f45d955ccb2a2f2ef40/Sources/SWBApplePlatform/AssetCatalogCompiler.swift#L129-L131), [link gating](https://github.com/swiftlang/swift-build/blob/72550aed7df44268a32b0f45d955ccb2a2f2ef40/Sources/SWBApplePlatform/AssetCatalogCompiler.swift#L428-L448)). The Tuist-specific part is extending that same treatment to catalogs discovered through `buildableFolders`, which SwiftPM does not model directly.

## Testing
- `tuist install`
- `tuist generate --no-open` (in `/tmp/tuist-buildable-folder-bundle-module-bug`)
- `xcodebuild -workspace BugReproApp.xcworkspace -scheme BugReproApp -destination 'generic/platform=iOS Simulator' build` (reproduced the reported `ImageResource` failure before the fix)
- `tuist install` (in this worktree)
- `tuist generate tuist TuistGenerator TuistGeneratorTests ProjectDescription --no-open` (completed with remote cache warnings)
- `xcodebuild test -workspace Tuist.xcworkspace -scheme Tuist-Workspace -only-testing TuistGeneratorTests/ResourcesProjectMapperTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY='' COMPILATION_CACHE_ENABLE_CACHING=NO` (blocked by unrelated workspace dependency issues before reaching the targeted tests)
- `xcodebuild build -project Tuist.xcodeproj -target TuistGeneratorTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY='' COMPILATION_CACHE_ENABLE_CACHING=NO` (blocked by unrelated `TuistNooraExtension` / dependency resolution failures)
