### PR TITLE
fix(server): tune CI mix dependency compile parallelism

### DIFF
--- a/.github/actions/setup-server-mix/action.yml
+++ b/.github/actions/setup-server-mix/action.yml
@@ -23,7 +23,7 @@ inputs:
   mix-os-deps-compile-partition-count:
     description: Lower Mix dependency compilation parallelism for CI runners with tighter memory limits.
     required: false
-    default: "1"
+    default: "3"
   github-token:
     description: GitHub token used by mise to fetch tools (avoids rate limits)
     required: false

--- a/.github/actions/setup-server-mix/action.yml
+++ b/.github/actions/setup-server-mix/action.yml
@@ -20,6 +20,10 @@ inputs:
     description: Restore-keys prefix for deps + _build cache fallback
     required: false
     default: mix-
+  mix-os-deps-compile-partition-count:
+    description: Lower Mix dependency compilation parallelism for CI runners with tighter memory limits.
+    required: false
+    default: "1"
   github-token:
     description: GitHub token used by mise to fetch tools (avoids rate limits)
     required: false
@@ -28,6 +32,9 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Tune Mix dependency compilation parallelism
+      shell: bash
+      run: echo "MIX_OS_DEPS_COMPILE_PARTITION_COUNT=${{ inputs.mix-os-deps-compile-partition-count }}" >> "$GITHUB_ENV"
     - uses: jdx/mise-action@v4.0.1
       with:
         version: ${{ inputs.mise-version }}


### PR DESCRIPTION
Resolves the repeated Server workflow failures caused by `mix deps.partition` crashing on lower-memory Linux runners.

This PR updates the shared `setup-server-mix` composite action to export `MIX_OS_DEPS_COMPILE_PARTITION_COUNT=3` before server jobs run `mix`.

The failing Server workflow jobs were not isolated to one target. `Credo`, `Format`, `esbuild`, and `Security` all failed during dependency compilation with the same `mix deps.partition` crash while running with `MIX_OS_DEPS_COMPILE_PARTITION_COUNT: 4`. After lowering the memory assigned to individual Linux VMs to allow higher concurrency, that default became too aggressive for these jobs.

I kept the fix scoped to CI by applying it in the shared GitHub Action instead of lowering the default in `mise.toml`, which would also slow down local developer workflows. Using `3` preserves some parallelism instead of forcing dependency compilation to run fully serially.

### How to test locally

- `ruby -e 'require "yaml"; YAML.load_file(".github/actions/setup-server-mix/action.yml"); puts "YAML OK"'`
- `gh run view 26217004468 --job 77141920173 --log | tail -n 120`
- `gh run view 26217004468 --job 77141920132 --log | tail -n 80`
- `gh run view 26217004468 --job 77141920125 --log | tail -n 120`
- `gh run view 26217004468 --job 77141920124 --log | tail -n 80`
- Push the branch or re-run the Server workflow and confirm the affected jobs report `MIX_OS_DEPS_COMPILE_PARTITION_COUNT: 3` and proceed past dependency compilation.
