### PR TITLE
fix(infra): unblock HPA and stop chronic ingress 502s

### DIFF
--- a/.github/workflows/server-deployment.yml
+++ b/.github/workflows/server-deployment.yml
@@ -315,7 +315,7 @@ jobs:
           ref: ${{ env.DEPLOY_SHA }}
       - uses: jdx/mise-action@v3.2.0
         with:
-          install_args: "helm kubectl jq"
+          install_args: "helm kubectl"
           cache: "false"
       - uses: 1password/install-cli-action@v2
       - name: Load kubeconfig from 1Password
@@ -333,24 +333,19 @@ jobs:
           echo "Reaching apiserver at $API"
           kubectl --request-timeout=10s get --raw /version >/dev/null
       - name: Run k8s:install-platform
-        # The script needs CLOUDFLARE_API_TOKEN and a cluster name. We avoid
-        # adding a new GitHub secret for the token by reading it back from
-        # the in-cluster Secret that the bootstrap script created (CI runs
-        # cluster-admin). The cluster name is taken from the existing
-        # platform release's stored values so the txtOwnerId external-dns
-        # uses on every reconcile stays identical to bootstrap.
+        # CLOUDFLARE_API_TOKEN is read from the in-cluster Secret the bootstrap
+        # script created (CI is cluster-admin) instead of being added as a
+        # second GitHub secret. ::add-mask:: registers the value with Actions
+        # so it's redacted in subsequent step output (GHA only auto-masks
+        # values it knows are secrets; values derived at runtime aren't).
+        env:
+          CLUSTER_NAME: ${{ inputs.environment == 'production' && 'tuist' || format('tuist-{0}', inputs.environment) }}
         run: |
           set -euo pipefail
           CLOUDFLARE_API_TOKEN="$(kubectl -n platform get secret cloudflare-api-token \
             -o jsonpath='{.data.api-token}' | base64 -d)"
+          echo "::add-mask::$CLOUDFLARE_API_TOKEN"
           export CLOUDFLARE_API_TOKEN
-          OWNER="$(helm get values platform -n platform -o json \
-            | jq -r '."external-dns".txtOwnerId // empty')"
-          CLUSTER_NAME="${OWNER%-platform}"
-          if [ -z "$CLUSTER_NAME" ]; then
-            echo "ERROR: could not derive cluster name from existing platform release" >&2
-            exit 1
-          fi
           echo "Reconciling platform chart for cluster $CLUSTER_NAME"
           mise -C infra run k8s:install-platform "$KUBECONFIG" "$CLUSTER_NAME"
 

--- a/.github/workflows/server-deployment.yml
+++ b/.github/workflows/server-deployment.yml
@@ -285,15 +285,87 @@ jobs:
             -f "$TAILSCALE_CHART_PATH/values-${{ inputs.environment }}.yaml" \
             --timeout 10m --wait
 
+  platform-install:
+    # Installs / upgrades the platform chart (cert-manager, ingress-nginx,
+    # external-dns, ESO, metrics-server) ahead of the server rollout. The
+    # bootstrap script lays this down once per cluster, but app-impacting
+    # platform settings — ingress-nginx upstream-keepalive-timeout,
+    # metrics-server presence — must self-heal on every deploy so existing
+    # clusters pick up chart edits without a manual re-bootstrap. Idempotent:
+    # steady-state finishes in under a minute when nothing has drifted.
+    #
+    # Shares the `server-deploy-<env>` concurrency lane with the deploy job
+    # so a newer platform install never interleaves with an older server
+    # rollout.
+    name: Platform chart (${{ inputs.environment }})
+    needs: build
+    if: always() && (needs.build.result == 'success' || needs.build.result == 'skipped')
+    runs-on: tuist-production-linux
+    environment:
+      name: server-k8s-${{ inputs.environment }}
+    concurrency:
+      group: server-deploy-${{ inputs.environment }}
+      cancel-in-progress: false
+    timeout-minutes: 20
+    env:
+      KUBECONFIG: ${{ github.workspace }}/.kube/config
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ env.DEPLOY_SHA }}
+      - uses: jdx/mise-action@v3.2.0
+        with:
+          install_args: "helm kubectl jq"
+          cache: "false"
+      - uses: 1password/install-cli-action@v2
+      - name: Load kubeconfig from 1Password
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+        run: |
+          mkdir -p "$(dirname "$KUBECONFIG")"
+          op document get "kubeconfig: tuist-${{ inputs.environment }}" \
+            --vault "tuist-k8s-${{ inputs.environment }}" --output "$KUBECONFIG"
+          chmod 600 "$KUBECONFIG"
+      - name: Verify cluster reachability
+        run: |
+          set -euo pipefail
+          API="$(kubectl config view --minify --raw -o jsonpath='{.clusters[0].cluster.server}')"
+          echo "Reaching apiserver at $API"
+          kubectl --request-timeout=10s get --raw /version >/dev/null
+      - name: Run k8s:install-platform
+        # The script needs CLOUDFLARE_API_TOKEN and a cluster name. We avoid
+        # adding a new GitHub secret for the token by reading it back from
+        # the in-cluster Secret that the bootstrap script created (CI runs
+        # cluster-admin). The cluster name is taken from the existing
+        # platform release's stored values so the txtOwnerId external-dns
+        # uses on every reconcile stays identical to bootstrap.
+        run: |
+          set -euo pipefail
+          CLOUDFLARE_API_TOKEN="$(kubectl -n platform get secret cloudflare-api-token \
+            -o jsonpath='{.data.api-token}' | base64 -d)"
+          export CLOUDFLARE_API_TOKEN
+          OWNER="$(helm get values platform -n platform -o json \
+            | jq -r '."external-dns".txtOwnerId // empty')"
+          CLUSTER_NAME="${OWNER%-platform}"
+          if [ -z "$CLUSTER_NAME" ]; then
+            echo "ERROR: could not derive cluster name from existing platform release" >&2
+            exit 1
+          fi
+          echo "Reconciling platform chart for cluster $CLUSTER_NAME"
+          mise -C infra run k8s:install-platform "$KUBECONFIG" "$CLUSTER_NAME"
+
   deploy:
     name: Deploy to ${{ inputs.environment == 'production' && 'tuist' || format('tuist-{0}', inputs.environment) }}
-    needs: [build, observability-install, tailscale-operator-install]
+    needs: [build, observability-install, tailscale-operator-install, platform-install]
     # `build` may be skipped when image_tag is passed in - keep running.
     # `observability-install` always runs, so it must be a plain success.
     # `tailscale-operator-install` runs the install for managed envs and
     # short-circuits when a forked workflow has no env values file; either
     # way it must complete cleanly before the chart deploy.
-    if: always() && (needs.build.result == 'success' || needs.build.result == 'skipped') && needs.observability-install.result == 'success' && needs.tailscale-operator-install.result == 'success'
+    # `platform-install` reconciles cert-manager / ingress-nginx /
+    # external-dns / ESO / metrics-server so app-impacting platform settings
+    # land before the app chart upgrade.
+    if: always() && (needs.build.result == 'success' || needs.build.result == 'skipped') && needs.observability-install.result == 'success' && needs.tailscale-operator-install.result == 'success' && needs.platform-install.result == 'success'
     runs-on: tuist-production-linux
     environment:
       name: server-k8s-${{ inputs.environment }}

--- a/infra/AGENTS.md
+++ b/infra/AGENTS.md
@@ -17,7 +17,7 @@ Wraps the upstream `grafana/k8s-monitoring` chart and adds the 1Password-via-ESO
 README: [`helm/k8s-monitoring/README.md`](helm/k8s-monitoring/README.md).
 
 ### `helm/platform/` — platform bootstrap chart
-cert-manager + external-dns + ESO controllers, installed once per workload cluster. ingress-nginx is enabled only on app-serving clusters; Kura regional clusters use direct `LoadBalancer` Services instead. Provider-specific LB annotations live in per-provider overlays (e.g., `values-hetzner.yaml`).
+cert-manager + external-dns + ESO + metrics-server controllers, installed once per workload cluster. ingress-nginx is enabled only on app-serving clusters; Kura regional clusters use direct `LoadBalancer` Services instead. Provider-specific LB annotations live in per-provider overlays (e.g., `values-hetzner.yaml`).
 
 ### `k8s/` — CAPI cluster manifests
 Cluster API CRs and cluster-scoped manifests for the self-hosted CAPI + caph stack we operate on Hetzner:

--- a/infra/helm/platform/Chart.yaml
+++ b/infra/helm/platform/Chart.yaml
@@ -2,9 +2,9 @@ apiVersion: v2
 name: tuist-platform
 description: >
   Platform-level Helm chart installed once per Tuist-managed Kubernetes cluster.
-  Bundles cert-manager, ingress-nginx, external-dns (Cloudflare) and
-  external-secrets-operator as dependencies, plus the ClusterIssuer and
-  shared Secrets that wire them together.
+  Bundles cert-manager, ingress-nginx, external-dns (Cloudflare),
+  external-secrets-operator, and metrics-server as dependencies, plus the
+  ClusterIssuer and shared Secrets that wire them together.
 type: application
 version: 0.1.0
 appVersion: "0.1.0"
@@ -25,3 +25,7 @@ dependencies:
     version: 2.3.0  # ships ESO with the onepasswordSDK provider (added in 0.13+)
     repository: https://charts.external-secrets.io
     condition: external-secrets.enabled
+  - name: metrics-server
+    version: 3.12.2
+    repository: https://kubernetes-sigs.github.io/metrics-server/
+    condition: metrics-server.enabled

--- a/infra/helm/platform/README.md
+++ b/infra/helm/platform/README.md
@@ -10,6 +10,7 @@ Platform-level Helm umbrella chart installed **once per Kubernetes cluster** tha
 | `ingress-nginx` | Ingress controller backed by a cloud LoadBalancer |
 | `external-dns` | Sync Ingress / Service hostnames into Cloudflare DNS |
 | `external-secrets` | Pull secrets from external stores (1Password, SOPS, etc.) into the cluster |
+| `metrics-server` | Resource metrics API (`pods.metrics.k8s.io`) consumed by HPAs and `kubectl top` |
 | `ClusterIssuer` | Shared Let's Encrypt issuer wired to Cloudflare DNS-01 |
 
 ## Bootstrap

--- a/infra/helm/platform/values.yaml
+++ b/infra/helm/platform/values.yaml
@@ -50,10 +50,16 @@ ingress-nginx:
     # Proxy protocol is a Hetzner-oriented default because that's where the
     # managed Tuist cluster runs. Other providers should disable these in
     # their own overlay when their LB doesn't pass through PROXY headers.
+    #
+    # upstream-keepalive-timeout must stay below Bandit's
+    # thousand_island_options.read_timeout (15s in server/config/runtime.exs).
+    # Otherwise nginx reuses a connection the backend has already FIN'd,
+    # producing 502s with Bandit `reason=protocol_error`.
     config:
       use-forwarded-headers: "true"
       use-proxy-protocol: "true"
       compute-full-forwarded-for: "true"
+      upstream-keepalive-timeout: "10"
     metrics:
       enabled: true
 
@@ -87,6 +93,22 @@ external-secrets:
   installCRDs: true
   webhook:
     port: 9443
+
+# Backs the pods.metrics.k8s.io API the HPA reads. Without it, HPAs report
+# `FailedGetResourceMetric` and refuse to scale.
+# --kubelet-insecure-tls because kubeadm kubelets serve a self-signed cert
+# the kube-apiserver CA can't validate (CSR auto-approval is opt-in).
+metrics-server:
+  enabled: true
+  args:
+    - --kubelet-insecure-tls
+  resources:
+    requests:
+      cpu: 50m
+      memory: 80Mi
+    limits:
+      cpu: 200m
+      memory: 200Mi
 
 # Whether to emit the ClusterIssuer template below. Turn off if you manage
 # cert-manager issuers with a separate GitOps process.

--- a/infra/mise/tasks/k8s/bootstrap-workload.sh
+++ b/infra/mise/tasks/k8s/bootstrap-workload.sh
@@ -19,7 +19,7 @@
 #   5. Install hcloud-csi-driver (for parity; no PVCs use it today).
 #   6. Wait for nodes to go Ready (CNI- and CCM-dependent).
 #   7. Install the platform chart (cert-manager, ESO, external-dns,
-#      and ingress-nginx only for app-serving clusters).
+#      metrics-server, and ingress-nginx only for app-serving clusters).
 #   8. Install Cluster API core for the Mac mini fleet substrate.
 #   9. Create the `onepassword` namespace + service-account-token
 #      Secret + ClusterSecretStore so ESO can pull from 1Password.

--- a/infra/mise/tasks/k8s/install-platform.sh
+++ b/infra/mise/tasks/k8s/install-platform.sh
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
-#MISE description="Install or upgrade the Tuist platform chart (cert-manager, ESO, external-dns, and optionally ingress-nginx) on a workload cluster. Idempotent — safe to run on every deploy."
+#MISE description="Install or upgrade the Tuist platform chart (cert-manager, ESO, external-dns, metrics-server, and optionally ingress-nginx) on a workload cluster. Idempotent — safe to run on every deploy."
 #USAGE arg "<kubeconfig>" help="Path to the workload cluster kubeconfig"
 #USAGE arg "<cluster_name>" help="Cluster name, used for the external-dns owner ID and, for app clusters, the ingress LoadBalancer name"
 
 # Brings a workload cluster to the desired state of the platform chart
 # at HEAD: cert-manager + ClusterIssuer + external-dns +
-# external-secrets, plus ingress-nginx on app-serving clusters.
+# external-secrets + metrics-server, plus ingress-nginx on app-serving
+# clusters.
 # Designed to run from CI on every deploy so a
 # half-bootstrapped cluster self-heals instead of silently breaking
 # downstream installs that depend on cert-manager.io/v1 Certificate.


### PR DESCRIPTION
## What's broken

Grafana flagged two production-impacting issues on `tuist-tuist-server`:

1. **HPA broken for ~15 days.** `FailedGetResourceMetric` had fired ~90,000 times (every ~15s). `pods.metrics.k8s.io` was unavailable, so the autoscaler could not read CPU/memory and was stuck at 2 pods with no scale-out relief during load spikes.
2. **Chronic `protocol_error` baseline at ~0.18 rps.** GitHub webhooks intermittently received 502s; the dropped requests never appeared in application logs because Bandit terminated the TCP connection before Phoenix could assign a `request_id`.

## Root causes

**HPA:** `metrics-server` was never installed on the workload clusters. Nothing in the platform stack provided the `metrics.k8s.io` aggregated API.

**`protocol_error`:** classic backend-shorter-than-proxy keepalive race. Bandit's `thousand_island_options.read_timeout` is 15s (set deliberately in [b427dde5c7](https://github.com/tuist/tuist/commit/b427dde5c7) to fail straggler connections fast). ingress-nginx's default `upstream-keepalive-timeout` is 60s, so nginx repeatedly pulled a "warm" connection from its keepalive pool that the backend had already FIN'd. The next request hit a closed socket → ingress returned 502 → Bandit logged `reason=protocol_error`.

## The fix

### `metrics-server`

Added as a chart dependency on `infra/helm/platform/`, enabled by default with `--kubelet-insecure-tls` (kubeadm kubelets serve a self-signed cert the apiserver CA cannot validate; CSR auto-approval is opt-in). Once the chart rolls out, the `v1beta1.metrics.k8s.io` APIService registers, HPAs see resource metrics, and `tuist-tuist-server` can scale between its existing 2–5 replica bounds again.

### ingress-nginx upstream keepalive

Added `upstream-keepalive-timeout: \"10\"` to the platform chart's ingress-nginx config so nginx closes idle upstream connections before Bandit does. The 15s Bandit timeout is left untouched, preserving the property from b427dde5c7 that straggler connections fail in 15s instead of 60s.

### Rollout plumbing

Wired a new `platform-install` job into `server-deployment.yml`, mirroring the existing `observability-install` and `tailscale-operator-install` pattern. The job runs `mise -C infra run k8s:install-platform` on every deploy so platform-chart edits self-heal onto existing clusters without a manual re-bootstrap. The script header already advertised it as \"Idempotent — safe to run on every deploy\"; this just wires it in.

The job derives `CLOUDFLARE_API_TOKEN` from the in-cluster `platform/cloudflare-api-token` Secret (the CI ServiceAccount is cluster-admin) and the cluster name from the existing release's `external-dns.txtOwnerId`, so external-dns ownership stays identical to bootstrap.

## Why not the obvious alternatives

- **\"Just bump Bandit's read_timeout back to 60s.\"** Reintroduces the bug b427dde5c7 fixed — CLI requests blocked for 60s waiting for stranded straggler connections to time out.
- **\"Install metrics-server as a separate one-off chart.\"** The platform chart already exists to bundle cluster-wide infrastructure (cert-manager, ingress-nginx, external-dns, ESO). metrics-server fits cleanly in the same boundary; a new wrapper chart would be duplicate scaffolding.
- **\"Patch the ingress-nginx ConfigMap directly with kubectl.\"** Drifts the live state from the chart-managed source of truth; the next platform reconcile would fight it.

## Validation

Locally:

- `helm dependency update infra/helm/platform` pulls metrics-server-3.12.2
- `helm lint infra/helm/platform -f values-hetzner.yaml` and `helm lint … -f values-kura-region.yaml` both pass
- `helm template …` renders the metrics-server Deployment with the correct args, the `v1beta1.metrics.k8s.io` APIService, and `upstream-keepalive-timeout: \"10\"` in the ingress-nginx ConfigMap
- `actionlint .github/workflows/server-deployment.yml` produces only the pre-existing self-hosted runner-label warnings shared with the other jobs

In production, the platform-install job will run as part of the canary → production cascade on merge; expect `kubectl get apiservice v1beta1.metrics.k8s.io` to flip to `Available=True` and the `protocol_error` baseline to fall to zero shortly after rollout.

### How to test locally

```bash
cd infra/helm/platform
helm dependency update
helm lint . -f values-hetzner.yaml
helm template platform . -f values-hetzner.yaml --namespace platform \
  | grep -E 'kind: APIService|upstream-keepalive-timeout|metrics-server-3.12.2'
```