### PR TITLE
ci(cli): dedupe 1Password reads in CLI bundle script

### DIFF
--- a/mise/tasks/cli/bundle.sh
+++ b/mise/tasks/cli/bundle.sh
@@ -19,6 +19,7 @@ TMP_DIR=/private$(mktemp -d)
 trap "rm -rf $TMP_DIR" EXIT # Ensures it gets deleted
 TUIST_DIR=$MISE_PROJECT_ROOT
 APPLE_ID=$(op read "op://tuist/App Specific Password/username")
+APPLE_PASSWORD=$(op read "op://tuist/App Specific Password/password")
 TEAM_ID='U6LC622NKF'
 ASC_PROVIDER=PedroPieraBuendia211042238 # Obtained with xcrun altool -list-providers
 CERTIFICATE_NAME="Developer ID Application: Tuist GmbH (U6LC622NKF)"
@@ -108,7 +109,7 @@ echo "$(format_section "Bundling")"
     RAW_JSON=$(xcrun notarytool submit "notarization-bundle.zip" \
         --apple-id "$APPLE_ID" \
         --team-id "$TEAM_ID" \
-        --password "$(op read "op://tuist/App Specific Password/password")" \
+        --password "$APPLE_PASSWORD" \
         --output-format json)
     echo "$RAW_JSON"
     SUBMISSION_ID=$(echo "$RAW_JSON" | jq -r '.id')
@@ -118,7 +119,7 @@ echo "$(format_section "Bundling")"
         STATUS=$(xcrun notarytool info "$SUBMISSION_ID" \
             --apple-id "$APPLE_ID" \
             --team-id "$TEAM_ID" \
-            --password "$(op read "op://tuist/App Specific Password/password")" \
+            --password "$APPLE_PASSWORD" \
             --output-format json | jq -r '.status')
 
         case $STATUS in
@@ -135,7 +136,7 @@ echo "$(format_section "Bundling")"
                 xcrun notarytool log "$SUBMISSION_ID" \
                     --apple-id "$APPLE_ID" \
                     --team-id "$TEAM_ID" \
-                    --password "$(op read "op://tuist/App Specific Password/password")"
+                    --password "$APPLE_PASSWORD"
                 exit 1
                 ;;
             *)


### PR DESCRIPTION
### What changed

`mise/tasks/cli/bundle.sh` reads `op://tuist/App Specific Password/password` three times during notarization (submit, status-poll loop, and the failure-log path). Read it once at the top of the script alongside the username read that's already there, and reuse via `\$APPLE_PASSWORD` in the three `xcrun notarytool` invocations.

```diff
 APPLE_ID=\$(op read \"op://tuist/App Specific Password/username\")
+APPLE_PASSWORD=\$(op read \"op://tuist/App Specific Password/password\")
```

### Why

While investigating a 1Password 429 in https://github.com/tuist/tuist/actions/runs/26218938026/job/77149976416, I noticed the script makes three identical Service Account requests for the same secret per CLI release. Reading once is strictly better, no downside.

### Scope, honestly

This is a **small efficiency cleanup**, not a fix for the 429. The failure in the linked run hit on the very first \`op read\` (the username read at line 21), which this change does not touch. The deduped triple-read is later in notarization, which that job never reached.

The 429 itself is being addressed separately by raising the Service Account rate limit with 1Password support.

### Risk

None meaningful. The plaintext was already passed via \`--password \"...\"\` on the three notarytool commands, so argv exposure (visible to \`ps\` for the lifetime of each command) is unchanged. The variable is not exported, so subshells don't inherit it.

### How to test locally

Not reproducible locally without prod notarization secrets — the change is a refactor of how the same value flows through three commands. Validation will come from the next release run.