### PR TITLE
fix(cli): Implicit imports with SPM binary deps

### DIFF
--- a/cli/Sources/TuistInspectCommand/Services/GraphImportsLinter.swift
+++ b/cli/Sources/TuistInspectCommand/Services/GraphImportsLinter.swift
@@ -60,18 +60,19 @@
             var observedTargetImports: [Target: Set<String>] = [:]
 
             let allTargetNames = Set(allTargets.map(\.target.productName))
+            let allModuleNames = allTargetNames.union(precompiledModuleNames(graphTraverser: graphTraverser))
 
             for target in allInternalTargets {
                 let reachableModules = reachableModules(
                     for: target,
                     graphTraverser: graphTraverser,
-                    allTargetNames: allTargetNames
+                    allModuleNames: allModuleNames
                 )
                 let sourceDependencies = Set(
                     try await targetScanner.imports(for: target.target, reachableModules: reachableModules)
                 )
 
-                let explicitTargetDependencies = explicitTargetDependencies(
+                let explicitDependencyModules = explicitDependencyModules(
                     graphTraverser: graphTraverser,
                     target: target,
                     includeExternalDependencies: inspectType == .implicit,
@@ -81,10 +82,10 @@
 
                 let observedImports = switch inspectType {
                 case .redundant:
-                    explicitTargetDependencies.subtracting(sourceDependencies)
+                    explicitDependencyModules.subtracting(sourceDependencies)
                 case .implicit:
-                    sourceDependencies.subtracting(explicitTargetDependencies)
-                        .intersection(allTargetNames)
+                    sourceDependencies.subtracting(explicitDependencyModules)
+                        .intersection(allModuleNames)
                 }
                 if !observedImports.isEmpty {
                     observedTargetImports[target.target] = observedImports
@@ -93,7 +94,7 @@
             return observedTargetImports
         }
 
-        private func explicitTargetDependencies(
+        private func explicitDependencyModules(
             graphTraverser: GraphTraverser,
             target: GraphTarget,
             includeExternalDependencies: Bool,
@@ -157,18 +158,34 @@
                 }
                 .map { dependency in
                     if case .external = dependency.graphTarget.project.type {
-                        let targets = [dependency.graphTarget] + graphTraverser.allTargetDependencies(
-                            path: dependency.graphTarget.project.path,
-                            name: dependency.graphTarget.target.name
+                        let graphDependency = GraphDependency.target(
+                            name: dependency.graphTarget.target.name,
+                            path: dependency.graphTarget.project.path
                         )
-                        return Set(targets)
+                        return Set([dependency.graphTarget.target.productName])
+                            .union(
+                                transitiveDependencies(
+                                    from: graphDependency,
+                                    graphTraverser: graphTraverser
+                                )
+                                .flatMap { moduleNames(for: $0, graphTraverser: graphTraverser) }
+                            )
                     } else {
-                        return Set(arrayLiteral: dependency.graphTarget)
+                        return Set(arrayLiteral: dependency.graphTarget.target.productName)
                     }
                 }
                 .flatMap { $0 }
-                .map(\.target.productName)
-            return Set(explicitTargetDependencies)
+            var explicitDependencyModules = Set(explicitTargetDependencies)
+
+            if includeExternalDependencies {
+                let graphDependency = GraphDependency.target(name: target.target.name, path: target.project.path)
+                let directPrecompiledDependencyModules = graphTraverser.dependencies[graphDependency, default: []]
+                    .filter { !$0.isTarget }
+                    .flatMap { moduleNames(for: $0, graphTraverser: graphTraverser) }
+                explicitDependencyModules.formUnion(directPrecompiledDependencyModules)
+            }
+
+            return explicitDependencyModules
         }
 
         /// Modules reachable from the target's transitive declared-dependency closure.
@@ -177,13 +194,60 @@
         private func reachableModules(
             for target: GraphTarget,
             graphTraverser: GraphTraverser,
-            allTargetNames: Set<String>
+            allModuleNames: Set<String>
         ) -> Set<String> {
-            let transitive = graphTraverser.allTargetDependencies(
-                path: target.path,
-                name: target.target.name
+            let graphDependency = GraphDependency.target(name: target.target.name, path: target.path)
+            return Set(
+                transitiveDependencies(from: graphDependency, graphTraverser: graphTraverser)
+                    .flatMap { moduleNames(for: $0, graphTraverser: graphTraverser) }
             )
-            return Set(transitive.map(\.target.productName)).intersection(allTargetNames)
+            .intersection(allModuleNames)
+        }
+
+        private func precompiledModuleNames(graphTraverser: GraphTraverser) -> Set<String> {
+            var dependencies = Set(graphTraverser.dependencies.keys)
+            graphTraverser.dependencies.values.forEach { dependencies.formUnion($0) }
+            return Set(
+                dependencies
+                    .filter { !$0.isTarget }
+                    .flatMap { moduleNames(for: $0, graphTraverser: graphTraverser) }
+            )
+        }
+
+        private func transitiveDependencies(
+            from root: GraphDependency,
+            graphTraverser: GraphTraverser
+        ) -> Set<GraphDependency> {
+            var visited: Set<GraphDependency> = []
+            var stack = Array(graphTraverser.dependencies[root, default: []])
+
+            while let dependency = stack.popLast() {
+                guard visited.insert(dependency).inserted else { continue }
+                stack.append(contentsOf: graphTraverser.dependencies[dependency, default: []])
+            }
+
+            return visited
+        }
+
+        private func moduleNames(
+            for dependency: GraphDependency,
+            graphTraverser: GraphTraverser
+        ) -> Set<String> {
+            switch dependency {
+            case let .target(name, path, _):
+                guard let target = graphTraverser.target(path: path, name: name) else { return [] }
+                return [target.target.productName]
+            case let .xcframework(xcframework):
+                return Set(xcframework.infoPlist.libraries.map(\.binaryName))
+            case let .framework(path, _, _, _, _, _, _):
+                return [path.basenameWithoutExt]
+            case let .foreignBuildOutput(output):
+                return [output.name]
+            case let .packageProduct(_, product, _):
+                return [product]
+            case .bundle, .library, .macro, .sdk:
+                return []
+            }
         }
     }
 #endif

--- a/cli/Tests/TuistKitTests/Services/Inspect/InspectDependenciesCommandServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/Inspect/InspectDependenciesCommandServiceTests.swift
@@ -33,6 +33,18 @@ struct InspectDependenciesCommandServiceTests {
         )
     }
 
+    private func xcframeworkDependency(moduleName: String) throws -> GraphDependency {
+        .testXCFramework(
+            path: try AbsolutePath(validating: "/dependencies/\(moduleName).xcframework"),
+            infoPlist: .test(libraries: [
+                .test(
+                    path: try RelativePath(validating: "ios-arm64/\(moduleName).framework"),
+                    architectures: [.arm64]
+                ),
+            ])
+        )
+    }
+
     // MARK: - Both Checks Tests
 
     @Test
@@ -287,6 +299,83 @@ struct InspectDependenciesCommandServiceTests {
         ) {
             try await subject.run(path: path.pathString, inspectionTypes: [.implicit])
         }
+    }
+
+    @Test
+    func runImplicitOnlyWhenXCFrameworkFromSPMPackageIsImplicitlyImported() async throws {
+        // Given
+        let config = Tuist.test()
+
+        let path = try AbsolutePath(validating: "/project")
+        let app = Target.test(name: "App", product: .app)
+        let project = Project.test(path: path, targets: [app])
+
+        let packageTarget = Target.test(name: "PackageTarget", product: .staticFramework)
+        let packageTargetPath = try AbsolutePath(validating: "/spm/Package")
+        let packageProject = Project.test(path: packageTargetPath, targets: [packageTarget], type: .external(hash: "hash"))
+        let binaryDependency = try xcframeworkDependency(moduleName: "BinaryKit")
+
+        let graph = Graph.test(
+            path: path,
+            projects: [
+                path: project,
+                packageTargetPath: packageProject,
+            ],
+            dependencies: [
+                .target(name: "PackageTarget", path: packageTargetPath): [
+                    binaryDependency,
+                ],
+            ]
+        )
+
+        given(configLoader).loadConfig(path: .value(path)).willReturn(config)
+        given(generatorFactory).defaultGenerator(config: .value(config), includedTargets: .any).willReturn(generator)
+        given(generator).load(path: .value(path), options: .any).willReturn(graph)
+        given(targetScanner).imports(for: .value(app), reachableModules: .any).willReturn(Set(["BinaryKit"]))
+
+        // When / Then
+        await #expect(
+            throws: InspectImportsServiceError.issuesFound(implicit: [.init(
+                target: "App",
+                dependencies: ["BinaryKit"]
+            )])
+        ) {
+            try await subject.run(path: path.pathString, inspectionTypes: [.implicit])
+        }
+    }
+
+    @Test
+    func runImplicitOnlyTreatsDirectXCFrameworkDependencyAsExplicitAndReachable() async throws {
+        // Given
+        let config = Tuist.test()
+
+        let path = try AbsolutePath(validating: "/project")
+        let app = Target.test(name: "App", product: .app)
+        let project = Project.test(path: path, targets: [app])
+        let binaryDependency = try xcframeworkDependency(moduleName: "BinaryKit")
+
+        let graph = Graph.test(
+            path: path,
+            projects: [path: project],
+            dependencies: [
+                .target(name: "App", path: path): [
+                    binaryDependency,
+                ],
+            ]
+        )
+
+        given(configLoader).loadConfig(path: .value(path)).willReturn(config)
+        given(generatorFactory).defaultGenerator(config: .value(config), includedTargets: .any).willReturn(generator)
+        given(generator).load(path: .value(path), options: .any).willReturn(graph)
+        given(targetScanner).imports(for: .value(app), reachableModules: .any).willReturn(Set(["BinaryKit"]))
+
+        // When
+        try await subject.run(path: path.pathString, inspectionTypes: [.implicit])
+
+        // Then
+        verify(targetScanner)
+            .imports(for: .value(app), reachableModules: .value(["BinaryKit"]))
+            .called(1)
     }
 
     @Test


### PR DESCRIPTION
## What changed

- Updated `tuist inspect dependencies` so implicit dependency detection includes importable modules exposed by precompiled graph dependencies, especially SPM binary targets backed by `.xcframework` artifacts.
- Added regression tests for:
  - reporting an implicit import of an XCFramework module from an SPM-style external package graph
  - treating a directly declared XCFramework dependency as explicit and reachable for `canImport`

## Why

`tuist inspect dependencies --only implicit` only compared source imports against target product names. SwiftPM binary targets backed by XCFrameworks are represented as precompiled graph dependencies, not `Target` nodes, so their module names were absent from the known module set. As a result, imports from those binaries could be missed.

## Solution

The inspect linter now derives module names from non-target graph dependencies, including XCFramework `Info.plist` library binary names, and uses that module set for both implicit dependency detection and `canImport` reachability.

## Impact

Projects using Swift Package dependencies with XCFramework binary targets now get accurate implicit dependency reports when source imports those binary modules without declaring the required dependency path.
