### PR TITLE
fix(cli): canonicalize xcodebuild analytics metadata

### DIFF
--- a/cli/Sources/TuistCore/Analytics/RunMetadataStorage.swift
+++ b/cli/Sources/TuistCore/Analytics/RunMetadataStorage.swift
@@ -6,6 +6,22 @@ import TuistLogging
 import TuistSupport
 import XcodeGraph
 
+public struct AnalyticsCommandMetadata: Equatable, Sendable {
+    public let name: String
+    public let subcommand: String?
+    public let commandArguments: [String]
+
+    public init(
+        name: String,
+        subcommand: String?,
+        commandArguments: [String]
+    ) {
+        self.name = name
+        self.subcommand = subcommand
+        self.commandArguments = commandArguments
+    }
+}
+
 /// Storage for run metadata, such as binary cache.
 public actor RunMetadataStorage {
     @TaskLocal public static var current: RunMetadataStorage = .init()
@@ -86,6 +102,12 @@ public actor RunMetadataStorage {
     public private(set) var cacheEndpoint: String = ""
     public func update(cacheEndpoint: String) {
         self.cacheEndpoint = cacheEndpoint
+    }
+
+    /// Canonical command metadata derived during command execution.
+    public private(set) var resolvedCommandMetadata: AnalyticsCommandMetadata?
+    public func update(resolvedCommandMetadata: AnalyticsCommandMetadata?) {
+        self.resolvedCommandMetadata = resolvedCommandMetadata
     }
 
     /// Writes a `RunMetadata` snapshot of the current storage to the `.xctestproducts`

--- a/cli/Sources/TuistKit/Commands/TrackableCommand/TrackableCommand.swift
+++ b/cli/Sources/TuistKit/Commands/TrackableCommand/TrackableCommand.swift
@@ -3,6 +3,7 @@ import FileSystem
 import Foundation
 import OpenAPIRuntime
 import Path
+import TuistAlert
 import TuistCache
 import TuistCore
 import TuistEnvironment
@@ -247,8 +248,8 @@ public class TrackableCommand {
             )
         }
 
-        Logger.current.warning(
-            "Failed to resolve canonical command metadata for analytics. Falling back to command arguments."
+        AlertController.current.warning(
+            .alert("Failed to resolve canonical command metadata for analytics. Falling back to command arguments.")
         )
         return AnalyticsCommandMetadata(
             name: fallbackName,

--- a/cli/Sources/TuistKit/Commands/TrackableCommand/TrackableCommand.swift
+++ b/cli/Sources/TuistKit/Commands/TrackableCommand/TrackableCommand.swift
@@ -144,12 +144,15 @@ public class TrackableCommand {
             let durationInSeconds = timer.stop()
             let durationInMs = Int(durationInSeconds * 1000)
             let configuration = type(of: command).configuration
-            let (name, subcommand) = extractCommandName(from: configuration)
+            let commandMetadata = await analyticsCommandMetadata(
+                from: configuration,
+                runMetadataStorage: runMetadataStorage
+            )
             let info = await TrackableCommandInfo(
                 runId: runId,
-                name: name,
-                subcommand: subcommand,
-                commandArguments: commandArguments,
+                name: commandMetadata.name,
+                subcommand: commandMetadata.subcommand,
+                commandArguments: commandMetadata.commandArguments,
                 durationInMs: durationInMs,
                 status: status,
                 graph: runMetadataStorage.graph,
@@ -215,16 +218,42 @@ public class TrackableCommand {
         }
     }
 
-    private func extractCommandName(from configuration: CommandConfiguration) -> (name: String, subcommand: String?) {
-        let name: String
-        let subcommand: String?
-        if let superCommandName = configuration._superCommandName {
-            name = superCommandName
-            subcommand = configuration.commandName!
-        } else {
-            name = configuration.commandName!
-            subcommand = nil
+    private func analyticsCommandMetadata(
+        from configuration: CommandConfiguration,
+        runMetadataStorage: RunMetadataStorage
+    ) async -> AnalyticsCommandMetadata {
+        if let resolvedCommandMetadata = await runMetadataStorage.resolvedCommandMetadata {
+            return resolvedCommandMetadata
         }
-        return (name, subcommand)
+
+        let fallbackName = commandArguments.first ?? String(describing: type(of: command))
+        let fallbackSubcommand = commandArguments.dropFirst().first.flatMap { argument in
+            argument.hasPrefix("-") ? nil : argument
+        }
+
+        if let superCommandName = configuration._superCommandName {
+            return AnalyticsCommandMetadata(
+                name: superCommandName,
+                subcommand: configuration.commandName ?? fallbackSubcommand,
+                commandArguments: commandArguments
+            )
+        }
+
+        if let commandName = configuration.commandName {
+            return AnalyticsCommandMetadata(
+                name: commandName,
+                subcommand: nil,
+                commandArguments: commandArguments
+            )
+        }
+
+        Logger.current.warning(
+            "Failed to resolve canonical command metadata for analytics. Falling back to command arguments."
+        )
+        return AnalyticsCommandMetadata(
+            name: fallbackName,
+            subcommand: fallbackSubcommand,
+            commandArguments: commandArguments
+        )
     }
 }

--- a/cli/Sources/TuistKit/Commands/XcodeBuild/XcodeBuildCommandReorderer.swift
+++ b/cli/Sources/TuistKit/Commands/XcodeBuild/XcodeBuildCommandReorderer.swift
@@ -35,6 +35,14 @@ struct XcodeBuildCommandReorderer: AsyncParsableCommand {
         let postActionArgs = actionIndex + 1 < arguments.count ? Array(arguments[(actionIndex + 1)...]) : []
 
         let reorderedArgs = [action] + preActionArgs + postActionArgs
+        let commandName = XcodeBuildCommand.configuration.commandName ?? "xcodebuild"
+        await RunMetadataStorage.current.update(
+            resolvedCommandMetadata: AnalyticsCommandMetadata(
+                name: commandName,
+                subcommand: action,
+                commandArguments: [commandName] + reorderedArgs
+            )
+        )
 
         guard reorderedArgs != arguments else {
             throw ValidationError("Unable to reorder arguments to match subcommand format.")

--- a/cli/Tests/TuistKitTests/CommandTracking/TrackableCommandTests.swift
+++ b/cli/Tests/TuistKitTests/CommandTracking/TrackableCommandTests.swift
@@ -2,6 +2,7 @@ import ArgumentParser
 import Foundation
 import Mockable
 import Path
+import TuistAlert
 import TuistCore
 import TuistGit
 import TuistLogging
@@ -259,13 +260,16 @@ final class TrackableCommandTests: TuistTestCase {
             command: UnnamedCommand(),
             commandArguments: ["mystery"]
         )
+        let alertController = AlertController()
 
         // When
-        try await subject.run(
-            fullHandle: "tuist/tuist",
-            serverURL: .test(),
-            shouldTrackAnalytics: true
-        )
+        try await AlertController.$current.withValue(alertController) {
+            try await subject.run(
+                fullHandle: "tuist/tuist",
+                serverURL: .test(),
+                shouldTrackAnalytics: true
+            )
+        }
 
         // Then
         verify(uploadAnalyticsService)
@@ -278,6 +282,11 @@ final class TrackableCommandTests: TuistTestCase {
                 sessionDirectory: .any
             )
             .called(1)
+        XCTAssertEqual(alertController.warnings().count, 1)
+        XCTAssertEqual(
+            alertController.warnings().first?.message.plain(),
+            "Failed to resolve canonical command metadata for analytics. Falling back to command arguments."
+        )
     }
 
     func test_whenCommandStoresResolvedAnalyticsMetadata_uploadsCanonicalValues() async throws {

--- a/cli/Tests/TuistKitTests/CommandTracking/TrackableCommandTests.swift
+++ b/cli/Tests/TuistKitTests/CommandTracking/TrackableCommandTests.swift
@@ -253,6 +253,62 @@ final class TrackableCommandTests: TuistTestCase {
             .called(0)
     }
 
+    func test_whenCommandConfigurationHasNoName_usesArgumentsAsFallbackName() async throws {
+        // Given
+        try makeSubject(
+            command: UnnamedCommand(),
+            commandArguments: ["mystery"]
+        )
+
+        // When
+        try await subject.run(
+            fullHandle: "tuist/tuist",
+            serverURL: .test(),
+            shouldTrackAnalytics: true
+        )
+
+        // Then
+        verify(uploadAnalyticsService)
+            .upload(
+                commandEvent: .matching { event in
+                    event.name == "mystery" && event.subcommand == nil
+                },
+                fullHandle: .any,
+                serverURL: .any,
+                sessionDirectory: .any
+            )
+            .called(1)
+    }
+
+    func test_whenCommandStoresResolvedAnalyticsMetadata_uploadsCanonicalValues() async throws {
+        // Given
+        try makeSubject(
+            command: ResolvedMetadataCommand(),
+            commandArguments: ["xcodebuild", "-workspace", "App.xcworkspace", "build"]
+        )
+
+        // When
+        try await subject.run(
+            fullHandle: "tuist/tuist",
+            serverURL: .test(),
+            shouldTrackAnalytics: true
+        )
+
+        // Then
+        verify(uploadAnalyticsService)
+            .upload(
+                commandEvent: .matching { event in
+                    event.name == "xcodebuild" &&
+                        event.subcommand == "build" &&
+                        event.commandArguments == ["xcodebuild", "build", "-workspace", "App.xcworkspace"]
+                },
+                fullHandle: .any,
+                serverURL: .any,
+                sessionDirectory: .any
+            )
+            .called(1)
+    }
+
     func test_whenOptionalAuthenticationIsEnabled_background_upload_does_not_add_a_flag() async throws {
         // Given
         try makeSubject(analyticsRequired: false)
@@ -336,5 +392,33 @@ private struct ConfigObservingCommand: TrackableParsableCommand, AsyncParsableCo
 
     func run() async throws {
         await ConfigObservingCommandState.recorder.record(ServerAuthenticationConfig.current.optionalAuthentication)
+    }
+}
+
+private struct UnnamedCommand: TrackableParsableCommand, ParsableCommand {
+    static var configuration: CommandConfiguration {
+        CommandConfiguration()
+    }
+
+    var analyticsRequired: Bool { true }
+
+    func run() throws {}
+}
+
+private struct ResolvedMetadataCommand: TrackableParsableCommand, AsyncParsableCommand {
+    static var configuration: CommandConfiguration {
+        CommandConfiguration()
+    }
+
+    var analyticsRequired: Bool { true }
+
+    func run() async throws {
+        await RunMetadataStorage.current.update(
+            resolvedCommandMetadata: AnalyticsCommandMetadata(
+                name: "xcodebuild",
+                subcommand: "build",
+                commandArguments: ["xcodebuild", "build", "-workspace", "App.xcworkspace"]
+            )
+        )
     }
 }


### PR DESCRIPTION
## Summary
- fix the `tuist xcodebuild` analytics crash when the command is parsed through the unordered `XcodeBuildCommandReorderer` path
- persist canonical analytics command metadata in `RunMetadataStorage` so post-run uploads use the resolved `xcodebuild` subcommand and reordered arguments
- keep raw fallback behavior non-fatal in `TrackableCommand` when command configuration metadata is still missing
- add regression coverage for both anonymous command fallback handling and canonical reordered metadata uploads

## Testing
- `xcodebuild test -workspace Tuist.xcworkspace -scheme Tuist-Workspace -only-testing TuistKitTests/TrackableCommandTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=''` (failed: `Tuist.xcworkspace` does not exist in this worktree)
- `tuist generate tuist TuistKit TuistKitTests ProjectDescription --no-open` (failed: external dependencies were not installed yet)
- `tuist install` (failed: registry checksum mismatch for `pointfreeco.swift-snapshot-testing`)
