### PR TITLE
feat(capi-scaleway): pool-release semantics + fix the broken billing-floor fallback

### DIFF
--- a/.github/workflows/server-deployment.yml
+++ b/.github/workflows/server-deployment.yml
@@ -541,33 +541,24 @@ jobs:
         #
         # --wait=hookOnly (helm 4 default) waits only for chart hooks —
         # the pre-upgrade migration Job — not for every resource the
-        # chart renders. The chart owns three CAPI MachineDeployments
-        # (macos / runners / builders fleets) whose readiness lives
-        # behind a slow async CAPI reconciliation loop driven by an
-        # out-of-cluster Scaleway control plane: Scaleway DeleteServer
-        # is gated by a multi-week billing-floor that the controller
-        # can't shortcut, and CreateServer on a fresh host runs 50+
-        # min. The chart's `OnDelete` rollout strategy was picked for
-        # exactly this reason (manual machine churn by the operator,
-        # not auto-rolling on every chart change), and the assumption
-        # is that the operator times Machine churn against the billing
-        # floor. Gating the server rollout on that loop means any
-        # CAPI hiccup — billing-floor on a Machine that's mid-roll,
-        # network blip to the Scaleway API, stuck adoption — cascades
-        # into a multi-hour deploy hang while the server change itself
-        # has nothing to do with the fleets.
+        # chart renders. The chart owns resources whose readiness sits
+        # behind slow async reconciliation loops outside this deploy's
+        # critical path (e.g. infrastructure CRs that reconcile
+        # against external control planes); gating the server rollout
+        # on them turns any out-of-band reconciliation hiccup into a
+        # multi-hour deploy hang on a change that has nothing to do
+        # with those resources. Readiness for everything we actually
+        # ship in a code deploy (server, processors, controllers) is
+        # verified by the `kubectl rollout status` loop below.
         #
-        # Readiness for everything we ship in a code deploy (server,
-        # processors, controllers) is verified by the `kubectl rollout
-        # status` loop below. On any helm failure or rollout failure
-        # we roll back to the revision that was `deployed` *before*
-        # this upgrade started (captured up front; awk-ing
-        # `helm history` after the fact would pick the just-completed
-        # bad revision since helm marks it `deployed` once manifests
-        # apply, before the rollout-status loop runs). That's the
-        # safety net the legacy `--atomic` flag used to provide,
-        # restricted to the resources whose readiness actually gates
-        # "deploy good."
+        # On any helm failure or rollout failure we roll back to the
+        # revision that was `deployed` *before* this upgrade started
+        # (captured up front; awk-ing `helm history` after the fact
+        # would pick the just-completed bad revision since helm marks
+        # it `deployed` once manifests apply, before the rollout-
+        # status loop runs). That's the safety net the legacy
+        # `--atomic` flag used to provide, restricted to the resources
+        # whose readiness actually gates "deploy good."
         timeout-minutes: 25
         run: |
           # Stream cluster state every 30s while helm and the rollout

--- a/.github/workflows/server-deployment.yml
+++ b/.github/workflows/server-deployment.yml
@@ -542,20 +542,32 @@ jobs:
         # --wait=hookOnly (helm 4 default) waits only for chart hooks —
         # the pre-upgrade migration Job — not for every resource the
         # chart renders. The chart owns three CAPI MachineDeployments
-        # (macos / runners / builders fleets) whose readiness depends
-        # on out-of-band Scaleway Mac mini provisioning (50+ min cold
-        # order, operator-driven host pool refill, no SLA). Gating the
-        # server rollout on them turns a routine deploy into a multi-
-        # hour hang the moment the pre-ordered `tuist-pool-` pool runs
-        # dry. CAPI controllers reconcile the fleets asynchronously;
-        # their state is independent of the server's readiness.
+        # (macos / runners / builders fleets) whose readiness lives
+        # behind a slow async CAPI reconciliation loop driven by an
+        # out-of-cluster Scaleway control plane: Scaleway DeleteServer
+        # is gated by a multi-week billing-floor that the controller
+        # can't shortcut, and CreateServer on a fresh host runs 50+
+        # min. The chart's `OnDelete` rollout strategy was picked for
+        # exactly this reason (manual machine churn by the operator,
+        # not auto-rolling on every chart change), and the assumption
+        # is that the operator times Machine churn against the billing
+        # floor. Gating the server rollout on that loop means any
+        # CAPI hiccup — billing-floor on a Machine that's mid-roll,
+        # network blip to the Scaleway API, stuck adoption — cascades
+        # into a multi-hour deploy hang while the server change itself
+        # has nothing to do with the fleets.
         #
         # Readiness for everything we ship in a code deploy (server,
         # processors, controllers) is verified by the `kubectl rollout
-        # status` loop below, with a manual helm rollback to the last
-        # deployed revision when any of them fails — that's the safety
-        # net the legacy `--atomic` flag used to provide, restricted to
-        # the resources whose readiness actually gates "deploy good."
+        # status` loop below. On any helm failure or rollout failure
+        # we roll back to the revision that was `deployed` *before*
+        # this upgrade started (captured up front; awk-ing
+        # `helm history` after the fact would pick the just-completed
+        # bad revision since helm marks it `deployed` once manifests
+        # apply, before the rollout-status loop runs). That's the
+        # safety net the legacy `--atomic` flag used to provide,
+        # restricted to the resources whose readiness actually gates
+        # "deploy good."
         timeout-minutes: 25
         run: |
           # Stream cluster state every 30s while helm and the rollout
@@ -576,18 +588,27 @@ jobs:
 
           set -uo pipefail
 
+          # Capture the revision that is `deployed` *right now*, before
+          # this upgrade runs. That's our rollback target: once helm
+          # upgrade succeeds, the new revision is also marked `deployed`
+          # and a post-hoc awk over `helm history` can no longer
+          # distinguish "the old good one" from "the one whose pods are
+          # crashing." First-install case (no history) returns empty;
+          # rollback_release degrades gracefully and exits 1 below.
+          pre_upgrade_revision="$(
+            helm history "$HELM_RELEASE_NAME" -n "$NAMESPACE" --max 20 2>/dev/null |
+              awk '$0 ~ /[[:space:]]deployed[[:space:]]/ { rev = $1 } END { print rev }' ||
+              true
+          )"
+          echo "Pre-upgrade deployed revision: ${pre_upgrade_revision:-<none, first install>}"
+
           rollback_release() {
-            local prev_revision
-            prev_revision="$(
-              helm history "$HELM_RELEASE_NAME" -n "$NAMESPACE" --max 20 |
-                awk '$0 ~ /[[:space:]]deployed[[:space:]]/ { rev = $1 } END { print rev }'
-            )"
-            if [ -z "$prev_revision" ]; then
-              echo "No prior deployed revision; leaving release as-is for the next run's recovery step."
+            if [ -z "$pre_upgrade_revision" ]; then
+              echo "No prior deployed revision to roll back to; leaving release as-is for the next run's recovery step."
               return
             fi
-            echo "Rolling back $HELM_RELEASE_NAME to revision $prev_revision."
-            helm rollback "$HELM_RELEASE_NAME" "$prev_revision" \
+            echo "Rolling back $HELM_RELEASE_NAME to revision $pre_upgrade_revision."
+            helm rollback "$HELM_RELEASE_NAME" "$pre_upgrade_revision" \
               -n "$NAMESPACE" --timeout 10m --cleanup-on-fail || true
           }
 

--- a/.github/workflows/server-deployment.yml
+++ b/.github/workflows/server-deployment.yml
@@ -370,11 +370,10 @@ jobs:
     concurrency:
       group: server-deploy-${{ inputs.environment }}
       cancel-in-progress: false
-    # helm-upgrade waits up to 10m for hooks plus ~10m of explicit
-    # rollout-status checks, with setup/teardown adding ~5m. 30m
+    # helm-upgrade waits up to 30m and setup/teardown adds ~5m. 50m
     # leaves a healthy buffer around that stack and keeps a
     # SIGTERM-stuck helm from holding the slot indefinitely.
-    timeout-minutes: 30
+    timeout-minutes: 50
     env:
       KUBECONFIG: ${{ github.workspace }}/.kube/config
       NAMESPACE: ${{ inputs.environment == 'production' && 'tuist' || format('tuist-{0}', inputs.environment) }}
@@ -461,13 +460,13 @@ jobs:
               fi
 
               # This is a metadata recovery path, not the real health gate.
-              # An interrupted rollback can leave the latest Helm revision
-              # in pending-rollback even when the last deployed revision
-              # is the only viable base for the next deploy. Waiting here
-              # replays the old manifest's readiness problems and can
+              # An interrupted atomic rollback can leave the latest Helm
+              # revision in pending-rollback even when the last deployed
+              # revision is the only viable base for the next deploy. Waiting
+              # here replays the old manifest's readiness problems and can
               # strand this recovery step before the current chart gets a
-              # chance to fix them. The following helm upgrade owns the
-              # full rollout with richer diagnostics.
+              # chance to fix them. The following helm upgrade owns the full
+              # --wait/--atomic rollout with richer diagnostics.
               helm rollback "$HELM_RELEASE_NAME" "$deployed_revision" \
                 --namespace "$NAMESPACE" --timeout 5m
 
@@ -539,31 +538,25 @@ jobs:
         # in-cluster ExternalSecret. Passing secrets through --set would
         # leak them into `helm get manifest`.
         #
-        # --wait=hookOnly (helm 4 default) waits only for chart hooks —
-        # the pre-upgrade migration Job — not for every resource the
-        # chart renders. The chart owns resources whose readiness sits
-        # behind slow async reconciliation loops outside this deploy's
-        # critical path (e.g. infrastructure CRs that reconcile
-        # against external control planes); gating the server rollout
-        # on them turns any out-of-band reconciliation hiccup into a
-        # multi-hour deploy hang on a change that has nothing to do
-        # with those resources. Readiness for everything we actually
-        # ship in a code deploy (server, processors, controllers) is
-        # verified by the `kubectl rollout status` loop below.
+        # helm --timeout 30m is sized for the adoption path: Mac minis
+        # are pre-ordered by the operator under the `tuist-pool-` prefix
+        # and the CAPI controller claims them on demand. Adoption is
+        # cheap (rename + tart-kubelet bootstrap + Tart VM cold-boot)
+        # vs Scaleway CreateServer (~50 min). Steady-state deploys
+        # finish in 5-15 min once the Mac mini is already in the cluster.
+        # If we ever flip back to auto-order in an env, bump this back
+        # to ~90m to absorb a fresh Scaleway provisioning.
         #
-        # On any helm failure or rollout failure we roll back to the
-        # revision that was `deployed` *before* this upgrade started
-        # (captured up front; awk-ing `helm history` after the fact
-        # would pick the just-completed bad revision since helm marks
-        # it `deployed` once manifests apply, before the rollout-
-        # status loop runs). That's the safety net the legacy
-        # `--atomic` flag used to provide, restricted to the resources
-        # whose readiness actually gates "deploy good."
-        timeout-minutes: 25
+        # 35 min = helm's `--timeout 30m` plus a 5-min cushion for the
+        # in-process `--atomic` rollback. A workflow-side timeout under
+        # 35 min risks killing helm after it has moved the release into
+        # pending-rollback, leaving the cluster wedged for the next run.
+        timeout-minutes: 35
         run: |
-          # Stream cluster state every 30s while helm and the rollout
-          # checks run. Otherwise the action log shows nothing for up to
-          # --timeout. The watcher dies via trap when the step exits.
+          # Stream cluster state every 30s while helm waits. helm
+          # --atomic --wait produces no stdout during the wait, so
+          # without this the action log shows nothing for up to 90 min.
+          # The watcher dies via trap when helm exits (either way).
           (
             while true; do
               sleep 30
@@ -577,84 +570,19 @@ jobs:
           watcher_pid=$!
           trap 'kill "$watcher_pid" 2>/dev/null || true; wait "$watcher_pid" 2>/dev/null || true' EXIT
 
-          set -uo pipefail
-
-          # Capture the revision that is `deployed` *right now*, before
-          # this upgrade runs. That's our rollback target: once helm
-          # upgrade succeeds, the new revision is also marked `deployed`
-          # and a post-hoc awk over `helm history` can no longer
-          # distinguish "the old good one" from "the one whose pods are
-          # crashing." First-install case (no history) returns empty;
-          # rollback_release degrades gracefully and exits 1 below.
-          pre_upgrade_revision="$(
-            helm history "$HELM_RELEASE_NAME" -n "$NAMESPACE" --max 20 2>/dev/null |
-              awk '$0 ~ /[[:space:]]deployed[[:space:]]/ { rev = $1 } END { print rev }' ||
-              true
-          )"
-          echo "Pre-upgrade deployed revision: ${pre_upgrade_revision:-<none, first install>}"
-
-          rollback_release() {
-            if [ -z "$pre_upgrade_revision" ]; then
-              echo "No prior deployed revision to roll back to; leaving release as-is for the next run's recovery step."
-              return
-            fi
-            echo "Rolling back $HELM_RELEASE_NAME to revision $pre_upgrade_revision."
-            helm rollback "$HELM_RELEASE_NAME" "$pre_upgrade_revision" \
-              -n "$NAMESPACE" --timeout 10m --cleanup-on-fail || true
-          }
-
-          if ! helm upgrade --install "$HELM_RELEASE_NAME" "$HELM_CHART_PATH" \
-              --namespace "$NAMESPACE" --create-namespace \
-              -f "$HELM_CHART_PATH/values-managed-common.yaml" \
-              -f "$HELM_CHART_PATH/values-managed-${{ inputs.environment }}.yaml" \
-              --set server.image.tag="$IMAGE_TAG" \
-              --set kuraController.image.tag="$IMAGE_TAG" \
-              --set kuraRuntime.image.tag="$KURA_RUNTIME_IMAGE_TAG" \
-              --timeout 10m --wait=hookOnly --cleanup-on-fail; then
-            echo "::error::helm upgrade failed."
-            rollback_release
-            exit 1
-          fi
-
-          # Verify the chart-managed Deployments became healthy. The
-          # label selector picks up every Deployment owned by this
-          # release regardless of component; new Deployments added to
-          # the chart get gated automatically. CAPI MachineDeployments
-          # aren't Deployments and are skipped here on purpose.
-          mapfile -t deployments < <(
-            kubectl -n "$NAMESPACE" get deploy \
-              -l "app.kubernetes.io/instance=$HELM_RELEASE_NAME" \
-              -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' |
-              sort
-          )
-          if [ "${#deployments[@]}" -eq 0 ]; then
-            echo "::error::No Deployments found for release $HELM_RELEASE_NAME in $NAMESPACE."
-            rollback_release
-            exit 1
-          fi
-
-          failed_deploy=""
-          for d in "${deployments[@]}"; do
-            echo "::group::rollout status $d"
-            if ! kubectl -n "$NAMESPACE" rollout status deploy/"$d" --timeout=10m; then
-              failed_deploy="$d"
-              echo "::endgroup::"
-              break
-            fi
-            echo "::endgroup::"
-          done
-
-          if [ -n "$failed_deploy" ]; then
-            echo "::error::Deployment $failed_deploy did not become healthy."
-            rollback_release
-            exit 1
-          fi
+          helm upgrade --install "$HELM_RELEASE_NAME" "$HELM_CHART_PATH" \
+            --namespace "$NAMESPACE" --create-namespace \
+            -f "$HELM_CHART_PATH/values-managed-common.yaml" \
+            -f "$HELM_CHART_PATH/values-managed-${{ inputs.environment }}.yaml" \
+            --set server.image.tag="$IMAGE_TAG" \
+            --set kuraController.image.tag="$IMAGE_TAG" \
+            --set kuraRuntime.image.tag="$KURA_RUNTIME_IMAGE_TAG" \
+            --atomic --timeout 30m --wait
       - name: Diagnostics on failure
-        # The previous step rolls back the release before exiting, so
-        # `helm history` and most cluster state reflect the rolled-back
-        # revision rather than the failure. Migration-job pods linger
-        # long enough for logs to be useful; everything else is best-
-        # effort.
+        # `--atomic` rolls back the release on timeout, so `helm history` and
+        # most cluster state reflect the rolled-back revision rather than the
+        # failure. Migration-job pods linger long enough for logs to be useful;
+        # everything else is best-effort.
         if: failure()
         run: |
           set +e

--- a/.github/workflows/server-deployment.yml
+++ b/.github/workflows/server-deployment.yml
@@ -370,10 +370,11 @@ jobs:
     concurrency:
       group: server-deploy-${{ inputs.environment }}
       cancel-in-progress: false
-    # helm-upgrade waits up to 30m and setup/teardown adds ~5m. 50m
+    # helm-upgrade waits up to 10m for hooks plus ~10m of explicit
+    # rollout-status checks, with setup/teardown adding ~5m. 30m
     # leaves a healthy buffer around that stack and keeps a
     # SIGTERM-stuck helm from holding the slot indefinitely.
-    timeout-minutes: 50
+    timeout-minutes: 30
     env:
       KUBECONFIG: ${{ github.workspace }}/.kube/config
       NAMESPACE: ${{ inputs.environment == 'production' && 'tuist' || format('tuist-{0}', inputs.environment) }}
@@ -460,13 +461,13 @@ jobs:
               fi
 
               # This is a metadata recovery path, not the real health gate.
-              # An interrupted atomic rollback can leave the latest Helm
-              # revision in pending-rollback even when the last deployed
-              # revision is the only viable base for the next deploy. Waiting
-              # here replays the old manifest's readiness problems and can
+              # An interrupted rollback can leave the latest Helm revision
+              # in pending-rollback even when the last deployed revision
+              # is the only viable base for the next deploy. Waiting here
+              # replays the old manifest's readiness problems and can
               # strand this recovery step before the current chart gets a
-              # chance to fix them. The following helm upgrade owns the full
-              # --wait/--atomic rollout with richer diagnostics.
+              # chance to fix them. The following helm upgrade owns the
+              # full rollout with richer diagnostics.
               helm rollback "$HELM_RELEASE_NAME" "$deployed_revision" \
                 --namespace "$NAMESPACE" --timeout 5m
 
@@ -538,25 +539,28 @@ jobs:
         # in-cluster ExternalSecret. Passing secrets through --set would
         # leak them into `helm get manifest`.
         #
-        # helm --timeout 30m is sized for the adoption path: Mac minis
-        # are pre-ordered by the operator under the `tuist-pool-` prefix
-        # and the CAPI controller claims them on demand. Adoption is
-        # cheap (rename + tart-kubelet bootstrap + Tart VM cold-boot)
-        # vs Scaleway CreateServer (~50 min). Steady-state deploys
-        # finish in 5-15 min once the Mac mini is already in the cluster.
-        # If we ever flip back to auto-order in an env, bump this back
-        # to ~90m to absorb a fresh Scaleway provisioning.
+        # --wait=hookOnly (helm 4 default) waits only for chart hooks —
+        # the pre-upgrade migration Job — not for every resource the
+        # chart renders. The chart owns three CAPI MachineDeployments
+        # (macos / runners / builders fleets) whose readiness depends
+        # on out-of-band Scaleway Mac mini provisioning (50+ min cold
+        # order, operator-driven host pool refill, no SLA). Gating the
+        # server rollout on them turns a routine deploy into a multi-
+        # hour hang the moment the pre-ordered `tuist-pool-` pool runs
+        # dry. CAPI controllers reconcile the fleets asynchronously;
+        # their state is independent of the server's readiness.
         #
-        # 35 min = helm's `--timeout 30m` plus a 5-min cushion for the
-        # in-process `--atomic` rollback. A workflow-side timeout under
-        # 35 min risks killing helm after it has moved the release into
-        # pending-rollback, leaving the cluster wedged for the next run.
-        timeout-minutes: 35
+        # Readiness for everything we ship in a code deploy (server,
+        # processors, controllers) is verified by the `kubectl rollout
+        # status` loop below, with a manual helm rollback to the last
+        # deployed revision when any of them fails — that's the safety
+        # net the legacy `--atomic` flag used to provide, restricted to
+        # the resources whose readiness actually gates "deploy good."
+        timeout-minutes: 25
         run: |
-          # Stream cluster state every 30s while helm waits. helm
-          # --atomic --wait produces no stdout during the wait, so
-          # without this the action log shows nothing for up to 90 min.
-          # The watcher dies via trap when helm exits (either way).
+          # Stream cluster state every 30s while helm and the rollout
+          # checks run. Otherwise the action log shows nothing for up to
+          # --timeout. The watcher dies via trap when the step exits.
           (
             while true; do
               sleep 30
@@ -570,19 +574,75 @@ jobs:
           watcher_pid=$!
           trap 'kill "$watcher_pid" 2>/dev/null || true; wait "$watcher_pid" 2>/dev/null || true' EXIT
 
-          helm upgrade --install "$HELM_RELEASE_NAME" "$HELM_CHART_PATH" \
-            --namespace "$NAMESPACE" --create-namespace \
-            -f "$HELM_CHART_PATH/values-managed-common.yaml" \
-            -f "$HELM_CHART_PATH/values-managed-${{ inputs.environment }}.yaml" \
-            --set server.image.tag="$IMAGE_TAG" \
-            --set kuraController.image.tag="$IMAGE_TAG" \
-            --set kuraRuntime.image.tag="$KURA_RUNTIME_IMAGE_TAG" \
-            --atomic --timeout 30m --wait
+          set -uo pipefail
+
+          rollback_release() {
+            local prev_revision
+            prev_revision="$(
+              helm history "$HELM_RELEASE_NAME" -n "$NAMESPACE" --max 20 |
+                awk '$0 ~ /[[:space:]]deployed[[:space:]]/ { rev = $1 } END { print rev }'
+            )"
+            if [ -z "$prev_revision" ]; then
+              echo "No prior deployed revision; leaving release as-is for the next run's recovery step."
+              return
+            fi
+            echo "Rolling back $HELM_RELEASE_NAME to revision $prev_revision."
+            helm rollback "$HELM_RELEASE_NAME" "$prev_revision" \
+              -n "$NAMESPACE" --timeout 10m --cleanup-on-fail || true
+          }
+
+          if ! helm upgrade --install "$HELM_RELEASE_NAME" "$HELM_CHART_PATH" \
+              --namespace "$NAMESPACE" --create-namespace \
+              -f "$HELM_CHART_PATH/values-managed-common.yaml" \
+              -f "$HELM_CHART_PATH/values-managed-${{ inputs.environment }}.yaml" \
+              --set server.image.tag="$IMAGE_TAG" \
+              --set kuraController.image.tag="$IMAGE_TAG" \
+              --set kuraRuntime.image.tag="$KURA_RUNTIME_IMAGE_TAG" \
+              --timeout 10m --wait=hookOnly --cleanup-on-fail; then
+            echo "::error::helm upgrade failed."
+            rollback_release
+            exit 1
+          fi
+
+          # Verify the chart-managed Deployments became healthy. The
+          # label selector picks up every Deployment owned by this
+          # release regardless of component; new Deployments added to
+          # the chart get gated automatically. CAPI MachineDeployments
+          # aren't Deployments and are skipped here on purpose.
+          mapfile -t deployments < <(
+            kubectl -n "$NAMESPACE" get deploy \
+              -l "app.kubernetes.io/instance=$HELM_RELEASE_NAME" \
+              -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' |
+              sort
+          )
+          if [ "${#deployments[@]}" -eq 0 ]; then
+            echo "::error::No Deployments found for release $HELM_RELEASE_NAME in $NAMESPACE."
+            rollback_release
+            exit 1
+          fi
+
+          failed_deploy=""
+          for d in "${deployments[@]}"; do
+            echo "::group::rollout status $d"
+            if ! kubectl -n "$NAMESPACE" rollout status deploy/"$d" --timeout=10m; then
+              failed_deploy="$d"
+              echo "::endgroup::"
+              break
+            fi
+            echo "::endgroup::"
+          done
+
+          if [ -n "$failed_deploy" ]; then
+            echo "::error::Deployment $failed_deploy did not become healthy."
+            rollback_release
+            exit 1
+          fi
       - name: Diagnostics on failure
-        # `--atomic` rolls back the release on timeout, so `helm history` and
-        # most cluster state reflect the rolled-back revision rather than the
-        # failure. Migration-job pods linger long enough for logs to be useful;
-        # everything else is best-effort.
+        # The previous step rolls back the release before exiting, so
+        # `helm history` and most cluster state reflect the rolled-back
+        # revision rather than the failure. Migration-job pods linger
+        # long enough for logs to be useful; everything else is best-
+        # effort.
         if: failure()
         run: |
           set +e

--- a/infra/cluster-api-provider-scaleway-applesilicon/AGENTS.md
+++ b/infra/cluster-api-provider-scaleway-applesilicon/AGENTS.md
@@ -173,16 +173,40 @@ them Ready.
 ```bash
 kubectl scale machinedeployment <fleet-name> --replicas=1
 ```
-CAPI core picks the most-recently-created Machines for deletion;
-operator releases them via Scaleway's API (the 24h Apple licensing
-floor still applies — Scaleway keeps charging until the boundary).
+CAPI core picks the most-recently-created Machines for deletion. For
+pool-adopted Machines (the default — `Spec.AdoptPoolPrefix` set), the
+controller does NOT call `Scaleway DeleteServer`. Instead it renames
+the host back into the pool namespace (`<poolPrefix><uuid>`) and
+triggers a Scaleway OS reinstall; the host stays alive, returns to
+factory-default state, and becomes eligible for the next adoption
+once Scaleway flips it back to `Delivered + Ready`. The 24h Apple
+licensing floor stays in operator-owned territory — you keep paying
+for capacity you already pre-ordered until you decide to release it
+via the Scaleway console.
 
 ### Replace a wedged host
 ```bash
 kubectl delete machine <machine-name>
 ```
 The MachineSet immediately creates a replacement; the old Mac mini
-is released back to Scaleway after the operator's delete reconcile.
+is renamed back into the pool, reinstalled, and re-eligible for the
+next adoption. The replacement Machine will adopt either this host
+(post-reinstall) or any other available pool host, whichever
+Scaleway returns to `Ready` first.
+
+If the host is genuinely broken (kernel panic loop, hardware fault,
+retired SKU) and must not be re-adopted, force the legacy physical-
+terminate path before deleting:
+
+```bash
+kubectl -n "$NS" annotate scalewayapplesiliconmachine <name> \
+  tuist.dev/release-policy=terminate --overwrite
+kubectl -n "$NS" delete machine <machine-name>
+```
+
+The annotation switches `reconcileDelete` from `ReleaseToPool` to
+`DeleteServer`. The schedule-deletion fallback handles the 24h
+billing floor; Scaleway stops billing at floor expiry.
 
 ### Investigate a failure
 ```bash

--- a/infra/cluster-api-provider-scaleway-applesilicon/api/v1alpha1/scalewayapplesiliconmachine_types.go
+++ b/infra/cluster-api-provider-scaleway-applesilicon/api/v1alpha1/scalewayapplesiliconmachine_types.go
@@ -101,7 +101,22 @@ type ScalewayAppleSiliconMachineSpec struct {
 	// requeues with a `NoAvailableHost` event. No auto-order
 	// fallback — the operator pre-orders, the controller adopts.
 	//
-	// Empty (default) preserves the legacy auto-order behavior.
+	// Delete semantics also change in pool mode: when the Machine is
+	// deleted, the controller renames the host back into the pool
+	// namespace (with a fresh UUID suffix) and triggers a Scaleway
+	// OS reinstall, then drops the k8s-side state. The host stays
+	// alive, is reset to factory-default state, and becomes eligible
+	// for the next AdoptByPrefix scan once Scaleway flips it back to
+	// `Delivered + Ready`. Physical destruction is left to the
+	// operator — they pre-order capacity, they decide when to release
+	// it, and the 24h billing floor stays in operator-owned territory
+	// instead of leaking into deploy flows. Force the legacy
+	// physical-terminate path on individual broken hosts via the
+	// `tuist.dev/release-policy: terminate` annotation on the Machine.
+	//
+	// Empty (default) preserves the legacy auto-order behavior, and
+	// delete falls back to `Scaleway DeleteServer` regardless of the
+	// release-policy annotation (there's no pool to return to).
 	// +optional
 	AdoptPoolPrefix string `json:"adoptPoolPrefix,omitempty"`
 }

--- a/infra/cluster-api-provider-scaleway-applesilicon/controllers/scalewayapplesiliconmachine_controller.go
+++ b/infra/cluster-api-provider-scaleway-applesilicon/controllers/scalewayapplesiliconmachine_controller.go
@@ -45,6 +45,21 @@ const (
 	// Conditions surfaced on the CR for operator visibility.
 	ProvisionedCondition  clusterv1.ConditionType = "Provisioned"
 	BootstrappedCondition clusterv1.ConditionType = "Bootstrapped"
+
+	// ReleasePolicyAnnotation controls what happens to the underlying
+	// Scaleway server when its ScalewayAppleSiliconMachine is deleted.
+	// Default for pool-adopted Machines (Spec.AdoptPoolPrefix set) is
+	// "pool": rename the server back into the pool namespace and
+	// trigger a Scaleway OS reinstall, so the next AdoptByPrefix sees
+	// factory-default state. Operator can set this to "terminate" on
+	// individual Machines to force the legacy DeleteServer path —
+	// useful for broken hosts that must not be re-adopted (kernel
+	// panic loop, hardware fault, retired SKU). Auto-order Machines
+	// (no AdoptPoolPrefix) always use the terminate path regardless,
+	// because there's no pool to return to.
+	ReleasePolicyAnnotation = "tuist.dev/release-policy"
+	ReleasePolicyPool       = "pool"
+	ReleasePolicyTerminate  = "terminate"
 )
 
 // ScalewayAppleSiliconMachineReconciler reconciles ScalewayAppleSiliconMachine objects.
@@ -677,19 +692,39 @@ func (r *ScalewayAppleSiliconMachineReconciler) reconcileDelete(
 	machine.Status.Phase = "Deleting"
 
 	// Stage 1: release the Scaleway server. Skip if already released
-	// (mid-cleanup retry).
+	// (mid-cleanup retry). For pool-adopted Machines this is a soft
+	// release back into the pool — rename + reinstall — so the host
+	// stays alive for the next adopt. Auto-order Machines and any
+	// Machine annotated `tuist.dev/release-policy: terminate` go
+	// through the legacy DeleteServer path; see ReleasePolicyAnnotation
+	// for the contract.
 	if machine.Status.ServerID != "" {
-		r.Recorder.Eventf(machine, corev1.EventTypeNormal, "Deleting",
-			"Releasing Scaleway server %s", machine.Status.ServerID)
-		if err := r.ScalewayClient.DeleteServer(ctx, machine.Status.ServerID, machine.Spec.Zone); err != nil {
-			logger.Error(err, "Scaleway delete failed; will retry")
-			r.Recorder.Eventf(machine, corev1.EventTypeWarning, "DeleteFailed",
-				"Scaleway DeleteServer: %v (will retry)", err)
-			return ctrl.Result{RequeueAfter: 60 * time.Second}, nil
+		if shouldReleaseToPool(machine) {
+			r.Recorder.Eventf(machine, corev1.EventTypeNormal, "Releasing",
+				"Returning Scaleway server %s to pool %q (with reinstall)",
+				machine.Status.ServerID, machine.Spec.AdoptPoolPrefix)
+			if err := r.ScalewayClient.ReleaseToPool(ctx, machine.Status.ServerID, machine.Spec.Zone, machine.Spec.AdoptPoolPrefix); err != nil {
+				logger.Error(err, "Scaleway release-to-pool failed; will retry")
+				r.Recorder.Eventf(machine, corev1.EventTypeWarning, "ReleaseFailed",
+					"Scaleway ReleaseToPool: %v (will retry)", err)
+				return ctrl.Result{RequeueAfter: 60 * time.Second}, nil
+			}
+			machine.Status.ServerID = ""
+			r.Recorder.Eventf(machine, corev1.EventTypeNormal, "Released",
+				"Scaleway server returned to pool; reinstall triggered")
+		} else {
+			r.Recorder.Eventf(machine, corev1.EventTypeNormal, "Deleting",
+				"Releasing Scaleway server %s", machine.Status.ServerID)
+			if err := r.ScalewayClient.DeleteServer(ctx, machine.Status.ServerID, machine.Spec.Zone); err != nil {
+				logger.Error(err, "Scaleway delete failed; will retry")
+				r.Recorder.Eventf(machine, corev1.EventTypeWarning, "DeleteFailed",
+					"Scaleway DeleteServer: %v (will retry)", err)
+				return ctrl.Result{RequeueAfter: 60 * time.Second}, nil
+			}
+			machine.Status.ServerID = ""
+			r.Recorder.Eventf(machine, corev1.EventTypeNormal, "Deleted",
+				"Scaleway server released")
 		}
-		machine.Status.ServerID = ""
-		r.Recorder.Eventf(machine, corev1.EventTypeNormal, "Deleted",
-			"Scaleway server released")
 	}
 
 	// Stage 2: drop the per-machine kubelet identity. The token is
@@ -1018,6 +1053,30 @@ func (r *ScalewayAppleSiliconMachineReconciler) SetupWithManager(mgr ctrl.Manage
 			handler.EnqueueRequestsFromMapFunc(scalewayMachineForCAPIMachine),
 		).
 		Complete(r)
+}
+
+// shouldReleaseToPool decides whether reconcileDelete should hand the
+// underlying Scaleway server back to the adopt pool (with reinstall)
+// or fall through to the legacy physical-terminate path.
+//
+//   - No AdoptPoolPrefix → auto-order Machine, no pool to return to;
+//     must terminate.
+//   - `tuist.dev/release-policy: terminate` annotation → operator
+//     opt-out, e.g. a broken host that shouldn't be re-adopted.
+//   - Default → pool.
+//
+// Empty / unknown annotation values are treated as the default. The
+// operator opt-in is intentionally minimal-surface so the common case
+// (Mac mini in good health, fleet scaling down or rolling) doesn't
+// need any per-Machine annotation gymnastics.
+func shouldReleaseToPool(machine *infrav1.ScalewayAppleSiliconMachine) bool {
+	if machine.Spec.AdoptPoolPrefix == "" {
+		return false
+	}
+	if machine.Annotations[ReleasePolicyAnnotation] == ReleasePolicyTerminate {
+		return false
+	}
+	return true
 }
 
 // scalewayMachineForCAPIMachine maps a CAPI Machine event to a

--- a/infra/cluster-api-provider-scaleway-applesilicon/controllers/scalewayapplesiliconmachine_controller_test.go
+++ b/infra/cluster-api-provider-scaleway-applesilicon/controllers/scalewayapplesiliconmachine_controller_test.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	applesilicon "github.com/scaleway/scaleway-sdk-go/api/applesilicon/v1alpha1"
+	"github.com/scaleway/scaleway-sdk-go/scw"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -21,6 +23,7 @@ import (
 
 	infrav1 "github.com/tuist/tuist/infra/cluster-api-provider-scaleway-applesilicon/api/v1alpha1"
 	"github.com/tuist/tuist/infra/cluster-api-provider-scaleway-applesilicon/internal/credentials"
+	"github.com/tuist/tuist/infra/cluster-api-provider-scaleway-applesilicon/internal/scaleway"
 )
 
 // recordUpdateFailure is the safety primitive that bounds the
@@ -478,4 +481,253 @@ func TestReconcileTailscaleEgressService_IdempotentAndPreservesOperatorRewrite(t
 		t.Errorf("re-reconcile clobbered operator's externalName rewrite (now %q)",
 			got.Spec.ExternalName)
 	}
+}
+
+// --- release policy --------------------------------------------------------
+//
+// shouldReleaseToPool decides whether reconcileDelete returns the
+// Scaleway server to the adopt pool (rename + reinstall) or
+// physically terminates it. The contract:
+//
+//   - Pool-adopted Machine, no annotation → pool (default).
+//   - Pool-adopted Machine, `release-policy: terminate` → terminate
+//     (operator opt-out for broken hosts that shouldn't re-adopt).
+//   - Auto-order Machine (no AdoptPoolPrefix) → always terminate;
+//     there's no pool to return to and the annotation is ignored.
+//   - Unknown / empty annotation value → default (pool when
+//     AdoptPoolPrefix set, terminate otherwise).
+
+func TestShouldReleaseToPool_PoolAdoptedDefault(t *testing.T) {
+	m := &infrav1.ScalewayAppleSiliconMachine{
+		Spec: infrav1.ScalewayAppleSiliconMachineSpec{AdoptPoolPrefix: "tuist-pool-"},
+	}
+	if !shouldReleaseToPool(m) {
+		t.Fatal("pool-adopted Machine with no annotation should default to pool release")
+	}
+}
+
+func TestShouldReleaseToPool_PoolAdoptedTerminateOptOut(t *testing.T) {
+	m := &infrav1.ScalewayAppleSiliconMachine{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{ReleasePolicyAnnotation: ReleasePolicyTerminate},
+		},
+		Spec: infrav1.ScalewayAppleSiliconMachineSpec{AdoptPoolPrefix: "tuist-pool-"},
+	}
+	if shouldReleaseToPool(m) {
+		t.Fatal("terminate annotation should force the physical-delete path")
+	}
+}
+
+func TestShouldReleaseToPool_AutoOrderAlwaysTerminate(t *testing.T) {
+	// AdoptPoolPrefix empty: there's nowhere to return the host to,
+	// so even an explicit `release-policy: pool` annotation falls
+	// back to terminate.
+	m := &infrav1.ScalewayAppleSiliconMachine{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{ReleasePolicyAnnotation: ReleasePolicyPool},
+		},
+		Spec: infrav1.ScalewayAppleSiliconMachineSpec{AdoptPoolPrefix: ""},
+	}
+	if shouldReleaseToPool(m) {
+		t.Fatal("auto-order Machine has no pool; must always terminate regardless of annotation")
+	}
+}
+
+func TestShouldReleaseToPool_UnknownAnnotationFallsThroughToDefault(t *testing.T) {
+	m := &infrav1.ScalewayAppleSiliconMachine{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{ReleasePolicyAnnotation: "garbage"},
+		},
+		Spec: infrav1.ScalewayAppleSiliconMachineSpec{AdoptPoolPrefix: "tuist-pool-"},
+	}
+	if !shouldReleaseToPool(m) {
+		t.Fatal("unknown annotation value should not flip the default; pool-adopted defaults to pool")
+	}
+}
+
+// --- reconcileDelete branching -------------------------------------------
+//
+// End-to-end check that reconcileDelete actually calls
+// ScalewayClient.ReleaseToPool for pool-adopted Machines and
+// ScalewayClient.DeleteServer for the terminate-annotated case. Uses
+// a real *scaleway.Client backed by a minimal in-memory API so the
+// recorded side-effects (rename + reinstall vs delete) are visible.
+
+// scalewayAPIStub is a tiny implementation of
+// scaleway.AppleSiliconAPI sufficient for the deletion path. Every
+// method we don't care about returns an error so an unexpected call
+// is loud in test output rather than silently doing nothing.
+type scalewayAPIStub struct {
+	servers         []*applesilicon.Server
+	updateCalls     int
+	updatedNames    []string
+	deletedIDs      []string
+	reinstalledIDs  []string
+	reinstallErrors map[int]error
+	reinstallCalls  int
+}
+
+func (f *scalewayAPIStub) ListServers(*applesilicon.ListServersRequest, ...scw.RequestOption) (*applesilicon.ListServersResponse, error) {
+	return nil, errors.New("ListServers not implemented in stub")
+}
+
+func (f *scalewayAPIStub) GetServer(req *applesilicon.GetServerRequest, _ ...scw.RequestOption) (*applesilicon.Server, error) {
+	for _, s := range f.servers {
+		if s.ID == req.ServerID {
+			return s, nil
+		}
+	}
+	return nil, errors.New("not found")
+}
+
+func (f *scalewayAPIStub) UpdateServer(req *applesilicon.UpdateServerRequest, _ ...scw.RequestOption) (*applesilicon.Server, error) {
+	f.updateCalls++
+	for _, s := range f.servers {
+		if s.ID == req.ServerID {
+			if req.Name != nil {
+				s.Name = *req.Name
+				f.updatedNames = append(f.updatedNames, *req.Name)
+			}
+			return s, nil
+		}
+	}
+	return nil, errors.New("not found")
+}
+
+func (f *scalewayAPIStub) CreateServer(*applesilicon.CreateServerRequest, ...scw.RequestOption) (*applesilicon.Server, error) {
+	return nil, errors.New("CreateServer not implemented in stub")
+}
+
+func (f *scalewayAPIStub) DeleteServer(req *applesilicon.DeleteServerRequest, _ ...scw.RequestOption) error {
+	f.deletedIDs = append(f.deletedIDs, req.ServerID)
+	return nil
+}
+
+func (f *scalewayAPIStub) ReinstallServer(req *applesilicon.ReinstallServerRequest, _ ...scw.RequestOption) (*applesilicon.Server, error) {
+	f.reinstallCalls++
+	if err, ok := f.reinstallErrors[f.reinstallCalls]; ok {
+		return nil, err
+	}
+	for _, s := range f.servers {
+		if s.ID == req.ServerID {
+			f.reinstalledIDs = append(f.reinstalledIDs, s.ID)
+			return s, nil
+		}
+	}
+	return nil, errors.New("not found")
+}
+
+func (f *scalewayAPIStub) WaitForServer(*applesilicon.WaitForServerRequest, ...scw.RequestOption) (*applesilicon.Server, error) {
+	return nil, errors.New("WaitForServer not implemented in stub")
+}
+
+func (f *scalewayAPIStub) ListOS(*applesilicon.ListOSRequest, ...scw.RequestOption) (*applesilicon.ListOSResponse, error) {
+	return nil, errors.New("ListOS not implemented in stub")
+}
+
+func TestReconcileDelete_PoolAdoptedReleasesToPool(t *testing.T) {
+	api := &scalewayAPIStub{
+		servers: []*applesilicon.Server{{ID: "srv-1", Name: "tuist-tuist-macos-fleet-0"}},
+	}
+	machine := &infrav1.ScalewayAppleSiliconMachine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "macos-fleet-0",
+			Namespace:  "ns",
+			Finalizers: []string{MachineFinalizer},
+		},
+		Spec: infrav1.ScalewayAppleSiliconMachineSpec{
+			AdoptPoolPrefix: "tuist-pool-",
+			Zone:            "fr-par-1",
+		},
+		Status: infrav1.ScalewayAppleSiliconMachineStatus{ServerID: "srv-1"},
+	}
+	r := newReconciler(t)
+	r.ScalewayClient = &scaleway.Client{API: api}
+
+	if _, err := r.reconcileDelete(context.Background(), machine); err != nil {
+		t.Fatalf("reconcileDelete: %v", err)
+	}
+
+	if len(api.deletedIDs) != 0 {
+		t.Fatalf("pool-adopted delete must NOT call DeleteServer; got deletes for %v", api.deletedIDs)
+	}
+	if got := api.reinstalledIDs; len(got) != 1 || got[0] != "srv-1" {
+		t.Fatalf("expected ReinstallServer call for srv-1, got %v", got)
+	}
+	if got := api.updatedNames; len(got) != 1 || !startsWith(got[0], "tuist-pool-") {
+		t.Fatalf("expected rename into the pool namespace, got %v", got)
+	}
+	if machine.Status.ServerID != "" {
+		t.Fatalf("Status.ServerID should be cleared after release, got %q", machine.Status.ServerID)
+	}
+}
+
+func TestReconcileDelete_TerminateAnnotationFallsBackToDeleteServer(t *testing.T) {
+	api := &scalewayAPIStub{
+		servers: []*applesilicon.Server{{ID: "srv-2", Name: "tuist-tuist-macos-fleet-1"}},
+	}
+	machine := &infrav1.ScalewayAppleSiliconMachine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "macos-fleet-1",
+			Namespace:   "ns",
+			Finalizers:  []string{MachineFinalizer},
+			Annotations: map[string]string{ReleasePolicyAnnotation: ReleasePolicyTerminate},
+		},
+		Spec: infrav1.ScalewayAppleSiliconMachineSpec{
+			AdoptPoolPrefix: "tuist-pool-",
+			Zone:            "fr-par-1",
+		},
+		Status: infrav1.ScalewayAppleSiliconMachineStatus{ServerID: "srv-2"},
+	}
+	r := newReconciler(t)
+	r.ScalewayClient = &scaleway.Client{API: api}
+
+	if _, err := r.reconcileDelete(context.Background(), machine); err != nil {
+		t.Fatalf("reconcileDelete: %v", err)
+	}
+
+	if got := api.deletedIDs; len(got) != 1 || got[0] != "srv-2" {
+		t.Fatalf("expected DeleteServer call for srv-2, got %v", got)
+	}
+	if len(api.reinstalledIDs) != 0 {
+		t.Fatalf("terminate path must NOT reinstall; got reinstalls for %v", api.reinstalledIDs)
+	}
+	if len(api.updatedNames) != 0 {
+		t.Fatalf("terminate path must NOT rename; got renames %v", api.updatedNames)
+	}
+}
+
+func TestReconcileDelete_AutoOrderUsesDeleteServer(t *testing.T) {
+	api := &scalewayAPIStub{
+		servers: []*applesilicon.Server{{ID: "srv-3", Name: "tuist-tuist-macos-fleet-2"}},
+	}
+	machine := &infrav1.ScalewayAppleSiliconMachine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "macos-fleet-2",
+			Namespace:  "ns",
+			Finalizers: []string{MachineFinalizer},
+		},
+		Spec: infrav1.ScalewayAppleSiliconMachineSpec{
+			// AdoptPoolPrefix empty → auto-order, no pool to return to.
+			Zone: "fr-par-1",
+		},
+		Status: infrav1.ScalewayAppleSiliconMachineStatus{ServerID: "srv-3"},
+	}
+	r := newReconciler(t)
+	r.ScalewayClient = &scaleway.Client{API: api}
+
+	if _, err := r.reconcileDelete(context.Background(), machine); err != nil {
+		t.Fatalf("reconcileDelete: %v", err)
+	}
+
+	if got := api.deletedIDs; len(got) != 1 || got[0] != "srv-3" {
+		t.Fatalf("auto-order Machine should DeleteServer, got %v", got)
+	}
+	if len(api.reinstalledIDs) != 0 {
+		t.Fatalf("auto-order Machine must NOT reinstall; got %v", api.reinstalledIDs)
+	}
+}
+
+func startsWith(s, prefix string) bool {
+	return len(s) >= len(prefix) && s[:len(prefix)] == prefix
 }

--- a/infra/cluster-api-provider-scaleway-applesilicon/internal/scaleway/client.go
+++ b/infra/cluster-api-provider-scaleway-applesilicon/internal/scaleway/client.go
@@ -519,7 +519,21 @@ func (c *Client) DeleteServer(ctx context.Context, id, zone string) error {
 
 // isPreconditionFailed detects Scaleway's HTTP 412 — typically the
 // 24h Apple-licensing floor on DeleteServer.
+//
+// The SDK parses standard error types into their own concrete types
+// (PreconditionFailedError, ResourceNotFoundError, …) inside
+// hasResponseError before they reach us; the generic ResponseError is
+// only returned for unparsed responses (non-JSON body, unknown error
+// type). Match both so DeleteServer's schedule-deletion fallback
+// actually fires — otherwise the controller loops DeleteServer every
+// 60 s for the multi-week Apple billing floor while the
+// MachineDeployment sits at 0 available, wedging every helm upgrade
+// that gates on it.
 func isPreconditionFailed(err error) bool {
+	var preconditionErr *scw.PreconditionFailedError
+	if errors.As(err, &preconditionErr) {
+		return true
+	}
 	var scwErr *scw.ResponseError
 	if errors.As(err, &scwErr) {
 		return scwErr.StatusCode == http.StatusPreconditionFailed

--- a/infra/cluster-api-provider-scaleway-applesilicon/internal/scaleway/client.go
+++ b/infra/cluster-api-provider-scaleway-applesilicon/internal/scaleway/client.go
@@ -41,6 +41,7 @@ type AppleSiliconAPI interface {
 	ListServers(req *applesilicon.ListServersRequest, opts ...scw.RequestOption) (*applesilicon.ListServersResponse, error)
 	UpdateServer(req *applesilicon.UpdateServerRequest, opts ...scw.RequestOption) (*applesilicon.Server, error)
 	DeleteServer(req *applesilicon.DeleteServerRequest, opts ...scw.RequestOption) error
+	ReinstallServer(req *applesilicon.ReinstallServerRequest, opts ...scw.RequestOption) (*applesilicon.Server, error)
 	WaitForServer(req *applesilicon.WaitForServerRequest, opts ...scw.RequestOption) (*applesilicon.Server, error)
 	ListOS(req *applesilicon.ListOSRequest, opts ...scw.RequestOption) (*applesilicon.ListOSResponse, error)
 }
@@ -515,6 +516,95 @@ func (c *Client) DeleteServer(ctx context.Context, id, zone string) error {
 		return fmt.Errorf("schedule deletion (after immediate delete failed with %v): %w", err, updateErr)
 	}
 	return nil
+}
+
+// ReleaseToPool returns a Mac mini to the adopt pool instead of
+// physically terminating it. Operator-driven physical destruction
+// is intentionally separated from cluster-driven Machine churn: the
+// 24h Apple-licensing floor makes destroy-and-recreate wildly
+// expensive (you pay for the floor regardless of whether the host is
+// in your cluster), and the operator already owns host capacity
+// planning via the pre-order workflow. So "Machine deleted" should
+// mean "host returned to the pool, freshly reinstalled, ready for
+// the next adopt" — not "Scaleway DeleteServer fires."
+//
+// Two-step:
+//
+//  1. Rename the server back into the pool namespace via
+//     UpdateServer. The new name is `poolPrefix + uuid` — a fresh
+//     UUID so we don't collide with any other pool host that's been
+//     parked at the same name earlier in the host's lifetime, and
+//     because AdoptByPrefix scans on the prefix (the exact suffix
+//     doesn't matter). Once renamed, the host is invisible to
+//     `findServerByName(claimName)` lookups (the per-Machine name
+//     is gone) and visible to future `AdoptByPrefix` scans.
+//
+//  2. Trigger ReinstallServer, which wipes the disk and reimages
+//     with the server type's default OS. Async on Scaleway's side
+//     (~5-15 min on M2-L); we fire-and-forget because
+//     AdoptByPrefix already filters on `Delivered + Status == Ready`
+//     and the host transitions through `reinstalling → ready` on
+//     its own. Means: next adopt sees factory-default state — no
+//     stale tart-kubelet config, no leftover Tailscale auth, no
+//     cached secrets — so bootstrap doesn't need to be re-entrant.
+//
+// Idempotency: callers retry on error. Step 1 is safe to repeat —
+// renaming to a different UUID just lands the host at a different
+// pool name, both eligible for adoption. Step 2 returns a
+// TransientStateError if the server is already mid-reinstall from a
+// previous attempt; we swallow it as success. 404 on either step
+// means the operator deleted the host out-of-band; also success.
+//
+// Callers that want the legacy physical-terminate semantics — for
+// broken hosts that must not be re-adopted — should call
+// DeleteServer directly and skip this entry point.
+func (c *Client) ReleaseToPool(ctx context.Context, id, zone, poolPrefix string) error {
+	if poolPrefix == "" {
+		return fmt.Errorf("ReleaseToPool: poolPrefix is required")
+	}
+
+	newName := poolPrefix + uuid.NewString()
+	if _, err := c.API.UpdateServer(&applesilicon.UpdateServerRequest{
+		ServerID: id,
+		Zone:     scw.Zone(zone),
+		Name:     &newName,
+	}, scw.WithContext(ctx)); err != nil {
+		if IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("rename server %s into pool: %w", id, err)
+	}
+
+	if _, err := c.API.ReinstallServer(&applesilicon.ReinstallServerRequest{
+		ServerID: id,
+		Zone:     scw.Zone(zone),
+	}, scw.WithContext(ctx)); err != nil {
+		if IsNotFound(err) {
+			return nil
+		}
+		if isTransientState(err) {
+			// Server is already in `reinstalling` (or some other
+			// transient phase) from a prior reconcile attempt or an
+			// out-of-band operator action. Either way the reinstall is
+			// in flight and we don't need to kick off another one.
+			return nil
+		}
+		return fmt.Errorf("reinstall server %s: %w", id, err)
+	}
+
+	return nil
+}
+
+// isTransientState detects scaleway-sdk-go's typed
+// `*scw.TransientStateError`, which the SDK returns when a request
+// can't proceed because the resource is in a transitional phase
+// (`reinstalling`, `deleting`, …). Same shape consideration as
+// isPreconditionFailed: this is parsed into its own concrete type
+// inside hasResponseError, so checking *ResponseError alone misses
+// it.
+func isTransientState(err error) bool {
+	var transientErr *scw.TransientStateError
+	return errors.As(err, &transientErr)
 }
 
 // isPreconditionFailed detects Scaleway's HTTP 412 — typically the

--- a/infra/cluster-api-provider-scaleway-applesilicon/internal/scaleway/client_test.go
+++ b/infra/cluster-api-provider-scaleway-applesilicon/internal/scaleway/client_test.go
@@ -154,6 +154,16 @@ type fakeAppleSiliconAPI struct {
 	deleteCalls   int
 	deletedIDs    []string
 	scheduledIDs  []string
+
+	// reinstallErrors maps `<call-index> -> error` for ReinstallServer;
+	// an absent / nil entry returns success and appends to
+	// reinstalledIDs. ReleaseToPool tests use this to force the
+	// crash-recovery shape where a previous reinstall is still in
+	// flight (TransientStateError) and confirm the second attempt
+	// degrades gracefully.
+	reinstallErrors map[int]error
+	reinstallCalls  int
+	reinstalledIDs  []string
 }
 
 func (f *fakeAppleSiliconAPI) ListServers(req *applesilicon.ListServersRequest, _ ...scw.RequestOption) (*applesilicon.ListServersResponse, error) {
@@ -212,6 +222,21 @@ func (f *fakeAppleSiliconAPI) DeleteServer(req *applesilicon.DeleteServerRequest
 	}
 	f.deletedIDs = append(f.deletedIDs, req.ServerID)
 	return nil
+}
+
+func (f *fakeAppleSiliconAPI) ReinstallServer(req *applesilicon.ReinstallServerRequest, _ ...scw.RequestOption) (*applesilicon.Server, error) {
+	f.reinstallCalls++
+	if err, ok := f.reinstallErrors[f.reinstallCalls]; ok {
+		return nil, err
+	}
+	for _, s := range f.servers {
+		if s.ID == req.ServerID {
+			f.reinstalledIDs = append(f.reinstalledIDs, s.ID)
+			s.Status = applesilicon.ServerStatusReinstalling
+			return s, nil
+		}
+	}
+	return nil, errors.New("not found")
 }
 
 func (f *fakeAppleSiliconAPI) WaitForServer(*applesilicon.WaitForServerRequest, ...scw.RequestOption) (*applesilicon.Server, error) {
@@ -674,5 +699,128 @@ func TestDeleteServer_PreconditionFallbackTreats404AsAlreadyGone(t *testing.T) {
 
 	if err := c.DeleteServer(context.Background(), "srv-4", "fr-par-1"); err != nil {
 		t.Fatalf("DeleteServer: expected nil when schedule-deletion sees 404, got %v", err)
+	}
+}
+
+// --- ReleaseToPool ---------------------------------------------------------
+//
+// ReleaseToPool is the cluster-driven exit for a Mac mini: rename
+// back into the pool namespace and trigger an OS reinstall, leaving
+// physical destruction as an out-of-band operator action. These
+// tests pin the rename target shape, the reinstall side-effect, the
+// crash-recovery shape (TransientStateError from a second reinstall
+// while the first is still in flight), and the 404-as-success paths
+// that let an operator-deleted host clean up its Machine cleanly.
+
+func TestReleaseToPool_HappyPathRenamesAndReinstalls(t *testing.T) {
+	api := &fakeAppleSiliconAPI{
+		servers: []*applesilicon.Server{
+			readyServer("srv-1", "tuist-tuist-macos-fleet-0"),
+		},
+	}
+	c := newTestClient(api)
+
+	if err := c.ReleaseToPool(context.Background(), "srv-1", "fr-par-1", "tuist-pool-"); err != nil {
+		t.Fatalf("ReleaseToPool: %v", err)
+	}
+	if got := api.servers[0].Name; !strings.HasPrefix(got, "tuist-pool-") {
+		t.Fatalf("server should be renamed back into the pool namespace, got %q", got)
+	}
+	if got := api.reinstalledIDs; len(got) != 1 || got[0] != "srv-1" {
+		t.Fatalf("expected ReinstallServer call for srv-1, got %v", got)
+	}
+}
+
+func TestReleaseToPool_RejectsEmptyPoolPrefix(t *testing.T) {
+	// An empty poolPrefix would rename the server to a bare UUID
+	// outside the pool namespace, where AdoptByPrefix would never
+	// find it again — effectively orphaning the host. Refuse loudly
+	// so the caller fixes the call site (auto-order mode should call
+	// DeleteServer directly, not ReleaseToPool with "").
+	api := &fakeAppleSiliconAPI{
+		servers: []*applesilicon.Server{readyServer("srv-1", "tuist-tuist-macos-fleet-0")},
+	}
+	c := newTestClient(api)
+
+	if err := c.ReleaseToPool(context.Background(), "srv-1", "fr-par-1", ""); err == nil {
+		t.Fatal("expected ReleaseToPool to refuse empty poolPrefix")
+	}
+	if api.updateCalls != 0 || api.reinstallCalls != 0 {
+		t.Fatalf("no Scaleway calls should fire when validation rejects the input; updates=%d reinstalls=%d",
+			api.updateCalls, api.reinstallCalls)
+	}
+}
+
+func TestReleaseToPool_SwallowsTransientStateOnReinstall(t *testing.T) {
+	// Crash-recovery: a prior reconcile already triggered a reinstall;
+	// the controller restarted, sees ServerID still set, and retries.
+	// Rename succeeds (different UUID — pool happy with either name),
+	// reinstall fails with TransientStateError because the server is
+	// still `reinstalling`. Treat as success so the Machine finalizes
+	// and the host eventually becomes ready under its pool name.
+	api := &fakeAppleSiliconAPI{
+		servers: []*applesilicon.Server{readyServer("srv-1", "tuist-tuist-macos-fleet-0")},
+		reinstallErrors: map[int]error{
+			1: &scw.TransientStateError{Resource: "server", ResourceID: "srv-1", CurrentState: "reinstalling"},
+		},
+	}
+	c := newTestClient(api)
+
+	if err := c.ReleaseToPool(context.Background(), "srv-1", "fr-par-1", "tuist-pool-"); err != nil {
+		t.Fatalf("ReleaseToPool: expected nil on TransientStateError, got %v", err)
+	}
+}
+
+func TestReleaseToPool_TreatsRename404AsAlreadyGone(t *testing.T) {
+	// Operator force-deleted the host out-of-band between reconciles.
+	// The rename comes back 404; nothing left to release, so return
+	// success and let the controller finalize the Machine cleanly.
+	api := &fakeAppleSiliconAPI{
+		servers: []*applesilicon.Server{readyServer("srv-2", "tuist-tuist-macos-fleet-1")},
+		updateErrors: map[int]error{
+			1: &scw.ResourceNotFoundError{Resource: "server", ResourceID: "srv-2"},
+		},
+	}
+	c := newTestClient(api)
+
+	if err := c.ReleaseToPool(context.Background(), "srv-2", "fr-par-1", "tuist-pool-"); err != nil {
+		t.Fatalf("ReleaseToPool: expected nil when rename sees 404, got %v", err)
+	}
+	if api.reinstallCalls != 0 {
+		t.Fatalf("rename 404 means host is gone; reinstall must be skipped, got %d calls", api.reinstallCalls)
+	}
+}
+
+func TestReleaseToPool_TreatsReinstall404AsAlreadyGone(t *testing.T) {
+	// Race: rename lands, then operator deletes the host before
+	// reinstall fires. Reinstall 404 is also "already gone".
+	api := &fakeAppleSiliconAPI{
+		servers: []*applesilicon.Server{readyServer("srv-3", "tuist-tuist-macos-fleet-2")},
+		reinstallErrors: map[int]error{
+			1: &scw.ResourceNotFoundError{Resource: "server", ResourceID: "srv-3"},
+		},
+	}
+	c := newTestClient(api)
+
+	if err := c.ReleaseToPool(context.Background(), "srv-3", "fr-par-1", "tuist-pool-"); err != nil {
+		t.Fatalf("ReleaseToPool: expected nil when reinstall sees 404, got %v", err)
+	}
+}
+
+func TestReleaseToPool_PropagatesNonRecoverableReinstallError(t *testing.T) {
+	api := &fakeAppleSiliconAPI{
+		servers: []*applesilicon.Server{readyServer("srv-4", "tuist-tuist-macos-fleet-3")},
+		reinstallErrors: map[int]error{
+			1: errors.New("scaleway: 502 bad gateway"),
+		},
+	}
+	c := newTestClient(api)
+
+	err := c.ReleaseToPool(context.Background(), "srv-4", "fr-par-1", "tuist-pool-")
+	if err == nil {
+		t.Fatal("expected non-recoverable reinstall error to surface")
+	}
+	if !strings.Contains(err.Error(), "reinstall server") {
+		t.Fatalf("expected error to identify reinstall step, got %v", err)
 	}
 }

--- a/infra/cluster-api-provider-scaleway-applesilicon/internal/scaleway/client_test.go
+++ b/infra/cluster-api-provider-scaleway-applesilicon/internal/scaleway/client_test.go
@@ -142,6 +142,18 @@ type fakeAppleSiliconAPI struct {
 	updateCalls  int
 	getErrors    map[int]error
 	getCalls     int
+
+	// deleteErrors maps `<call-index> -> error` for DeleteServer; an
+	// absent / nil entry returns success (Scaleway accepts the
+	// immediate delete). Lets the precondition-fallback tests force
+	// the typed scw.PreconditionFailedError that the SDK returns for
+	// a server still inside its 24h Apple-licensing floor, then
+	// observe the schedule-deletion UpdateServer call that should
+	// follow.
+	deleteErrors  map[int]error
+	deleteCalls   int
+	deletedIDs    []string
+	scheduledIDs  []string
 }
 
 func (f *fakeAppleSiliconAPI) ListServers(req *applesilicon.ListServersRequest, _ ...scw.RequestOption) (*applesilicon.ListServersResponse, error) {
@@ -180,6 +192,9 @@ func (f *fakeAppleSiliconAPI) UpdateServer(req *applesilicon.UpdateServerRequest
 			if req.Name != nil {
 				s.Name = *req.Name
 			}
+			if req.ScheduleDeletion != nil && *req.ScheduleDeletion {
+				f.scheduledIDs = append(f.scheduledIDs, s.ID)
+			}
 			return s, nil
 		}
 	}
@@ -190,8 +205,13 @@ func (f *fakeAppleSiliconAPI) CreateServer(*applesilicon.CreateServerRequest, ..
 	return nil, errors.New("CreateServer not implemented in fake")
 }
 
-func (f *fakeAppleSiliconAPI) DeleteServer(*applesilicon.DeleteServerRequest, ...scw.RequestOption) error {
-	return errors.New("DeleteServer not implemented in fake")
+func (f *fakeAppleSiliconAPI) DeleteServer(req *applesilicon.DeleteServerRequest, _ ...scw.RequestOption) error {
+	f.deleteCalls++
+	if err, ok := f.deleteErrors[f.deleteCalls]; ok {
+		return err
+	}
+	f.deletedIDs = append(f.deletedIDs, req.ServerID)
+	return nil
 }
 
 func (f *fakeAppleSiliconAPI) WaitForServer(*applesilicon.WaitForServerRequest, ...scw.RequestOption) (*applesilicon.Server, error) {
@@ -554,5 +574,105 @@ func TestAdoptByPrefix_Phase1VerifyNon404SurfacesError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "phase 1 verify") {
 		t.Fatalf("expected error to identify phase 1 verify, got %v", err)
+	}
+}
+
+// --- DeleteServer fallback for the 24h billing floor ----------------------
+//
+// The SDK parses standard error types into their own concrete types
+// inside hasResponseError — a 412 with `"type": "precondition_failed"`
+// comes back as *scw.PreconditionFailedError, not as the generic
+// *scw.ResponseError. An earlier version of isPreconditionFailed only
+// checked the generic shape and so missed every real 412 the SDK
+// returned, leaving DeleteServer to loop on the Apple 24h floor while
+// the MachineDeployment sat at 0 available and gated every helm
+// upgrade behind it. These tests pin the wiring so the schedule-
+// deletion fallback actually fires.
+
+func TestDeleteServer_PreconditionFailedTriggersScheduleDeletion(t *testing.T) {
+	api := &fakeAppleSiliconAPI{
+		servers: []*applesilicon.Server{
+			readyServer("srv-1", "tuist-tuist-macos-fleet-0"),
+		},
+		deleteErrors: map[int]error{
+			1: &scw.PreconditionFailedError{Precondition: "unknown_precondition", HelpMessage: "this server cannot be deleted before 2026-06-12 07:06:59"},
+		},
+	}
+	c := newTestClient(api)
+
+	if err := c.DeleteServer(context.Background(), "srv-1", "fr-par-1"); err != nil {
+		t.Fatalf("DeleteServer: expected nil after schedule-deletion fallback, got %v", err)
+	}
+	if got := api.scheduledIDs; len(got) != 1 || got[0] != "srv-1" {
+		t.Fatalf("expected schedule-deletion UpdateServer call for srv-1, got %v", got)
+	}
+}
+
+func TestDeleteServer_ResponseError412AlsoTriggersScheduleDeletion(t *testing.T) {
+	// Unparsed 412 responses (non-JSON body or unknown error type) come
+	// back as the generic *scw.ResponseError. The wiring should still
+	// catch this path so the fallback isn't tied to one error shape.
+	api := &fakeAppleSiliconAPI{
+		servers: []*applesilicon.Server{
+			readyServer("srv-2", "tuist-tuist-macos-fleet-1"),
+		},
+		deleteErrors: map[int]error{
+			1: &scw.ResponseError{StatusCode: 412, Status: "412 Precondition Failed"},
+		},
+	}
+	c := newTestClient(api)
+
+	if err := c.DeleteServer(context.Background(), "srv-2", "fr-par-1"); err != nil {
+		t.Fatalf("DeleteServer: expected nil after schedule-deletion fallback, got %v", err)
+	}
+	if got := api.scheduledIDs; len(got) != 1 || got[0] != "srv-2" {
+		t.Fatalf("expected schedule-deletion UpdateServer call for srv-2, got %v", got)
+	}
+}
+
+func TestDeleteServer_PreconditionFallbackPropagatesNon404UpdateError(t *testing.T) {
+	api := &fakeAppleSiliconAPI{
+		servers: []*applesilicon.Server{
+			readyServer("srv-3", "tuist-tuist-macos-fleet-2"),
+		},
+		deleteErrors: map[int]error{
+			1: &scw.PreconditionFailedError{Precondition: "unknown_precondition"},
+		},
+		updateErrors: map[int]error{
+			1: errors.New("scaleway: 502 bad gateway"),
+		},
+	}
+	c := newTestClient(api)
+
+	err := c.DeleteServer(context.Background(), "srv-3", "fr-par-1")
+	if err == nil {
+		t.Fatalf("expected schedule-deletion failure to be surfaced")
+	}
+	if !strings.Contains(err.Error(), "schedule deletion") {
+		t.Fatalf("expected error to identify the schedule-deletion fallback, got %v", err)
+	}
+}
+
+func TestDeleteServer_PreconditionFallbackTreats404AsAlreadyGone(t *testing.T) {
+	// Race window: a previous reconcile already scheduled the
+	// deletion, the billing floor expired between reconciles, and
+	// Scaleway has since removed the server. The fallback's
+	// UpdateServer comes back 404 — that's a clean "already gone"
+	// and should not propagate as a reconcile failure.
+	api := &fakeAppleSiliconAPI{
+		servers: []*applesilicon.Server{
+			readyServer("srv-4", "tuist-tuist-macos-fleet-3"),
+		},
+		deleteErrors: map[int]error{
+			1: &scw.PreconditionFailedError{Precondition: "unknown_precondition"},
+		},
+		updateErrors: map[int]error{
+			1: &scw.ResourceNotFoundError{Resource: "server", ResourceID: "srv-4"},
+		},
+	}
+	c := newTestClient(api)
+
+	if err := c.DeleteServer(context.Background(), "srv-4", "fr-par-1"); err != nil {
+		t.Fatalf("DeleteServer: expected nil when schedule-deletion sees 404, got %v", err)
 	}
 }

--- a/infra/cluster-api-provider-scaleway-applesilicon/internal/scaleway/client_test.go
+++ b/infra/cluster-api-provider-scaleway-applesilicon/internal/scaleway/client_test.go
@@ -150,10 +150,10 @@ type fakeAppleSiliconAPI struct {
 	// a server still inside its 24h Apple-licensing floor, then
 	// observe the schedule-deletion UpdateServer call that should
 	// follow.
-	deleteErrors  map[int]error
-	deleteCalls   int
-	deletedIDs    []string
-	scheduledIDs  []string
+	deleteErrors map[int]error
+	deleteCalls  int
+	deletedIDs   []string
+	scheduledIDs []string
 
 	// reinstallErrors maps `<call-index> -> error` for ReinstallServer;
 	// an absent / nil entry returns success and appends to


### PR DESCRIPTION
## What was broken

[Run 26219893038](https://github.com/tuist/tuist/actions/runs/26219893038/job/77155360804) timed out after 35 minutes with all three CAPI `MachineDeployment`s stuck at 0/1 available replicas. The cluster events show why:

```
scalewayapplesiliconmachine/tuist-tuist-macos-fleet-0
  Scaleway DeleteServer: scaleway-sdk-go: precondition failed:
  unknown precondition, this server cannot be deleted before 2026-06-12 07:06:59 (will retry)
```

CAPI was mid-roll. Scaleway refused `DeleteServer` because the Mac mini was inside its multi-week Apple-licensing billing floor. With `strategy: OnDelete` CAPI can't bring up the replacement until the old Machine finalizes, the controller retried every 60s, and `helm upgrade --atomic --wait` hung against the 0/1 MachineDeployment for the full 30-min helm timeout. The pipeline wedged on a stuck fleet reconciliation that has nothing to do with the server change being shipped.

Two independent things were wrong:

1. The controller's billing-floor fallback was unreachable. `DeleteServer` already has a deliberate `UpdateServer(scheduleDeletion=true)` fallback for HTTP 412, but the predicate `isPreconditionFailed` only checked `*scw.ResponseError`, and `scaleway-sdk-go`'s `hasResponseError` returns the more specific `*scw.PreconditionFailedError` for parsed standard errors. The fallback rotted unreachable with zero test coverage.
2. The lifecycle model was wrong. Cluster-driven Machine churn (rolls, scaling, replacement) shouldn't trigger physical-host destruction — the operator already owns host pre-ordering through the `tuist-pool-` workflow, so they should own host destruction too. Coupling the two lifecycles put the 24h Apple licensing floor directly into the deploy critical path.

## Fixes

### Fix 1 — controller predicate

`isPreconditionFailed` now matches both `*scw.PreconditionFailedError` (the typed return after `hasResponseError`'s `unmarshalStandardError`) and the generic `*scw.ResponseError` with `StatusCode == 412` (the fallback for unparsed responses). The schedule-deletion fallback was always meant to be the safety net for the terminate path; this makes it reachable. New tests pin both error shapes plus the two interesting fallback edges. The first one fails verbatim against the old code with the exact error string from the failed canary run.

### Fix 2 — lifecycle model

New `ReleaseToPool(id, zone, poolPrefix)` on the Scaleway client renames a server back into `<poolPrefix><uuid>` and triggers Scaleway's `ReinstallServer` (disk wipe + reimage with the server type's default OS, ~15-20 min async on M2-L). `reconcileDelete` branches: pool-adopted Machines (the default) go through `ReleaseToPool`; auto-order Machines and any Machine annotated `tuist.dev/release-policy: terminate` keep the legacy `DeleteServer` path.

Cluster Machine churn no longer destroys physical hosts. The Mac mini stays alive, comes back to factory-default state, and is re-eligible for the next `AdoptByPrefix` once Scaleway flips it to `Delivered + Ready`. The 24h billing floor doesn't enter cluster reconciliation at all. Bootstrap doesn't need to be re-entrant across multiple adoptions because every adopt sees a freshly reinstalled host.

`ReleaseToPool` is idempotent across controller crashes: rename to a fresh UUID is safe to repeat (both pool names are valid), a second reinstall while one is in flight returns a `TransientStateError` we swallow, and 404 on either step means an operator-deleted host so we let the Machine finalizer drop cleanly. Reinstall itself is fire-and-forget — `AdoptByPrefix`'s `Delivered + Status == Ready` filter naturally excludes a host while it's `reinstalling`, so we don't hold up Machine finalization waiting for Scaleway to finish the wipe.

Operator opt-out for broken hosts that shouldn't re-adopt (kernel panic loop, hardware fault, retired SKU):

```bash
kubectl -n "$NS" annotate scalewayapplesiliconmachine <name> \
  tuist.dev/release-policy=terminate --overwrite
kubectl -n "$NS" delete machine <machine-name>
```

That branch uses `DeleteServer`, which is exactly where Fix 1's schedule-deletion fallback now reliably fires.

## What I considered and pulled out

I had a Layer 3 in here that switched the deploy workflow to helm 4's `--wait=hookOnly` plus an explicit `kubectl rollout status` loop, as defense-in-depth against future async-reconciliation hiccups stalling deploys. Pulled it out — the root cause is fixed at the controller and there's no concrete second failure mode worth defending against speculatively.

While I was in there, `server-deployment.yml` already carries a fair amount of ad-hoc bash (recover-interrupted-helm, clean-stale-jobs, Kura runtime tag resolution, watcher process, manual rollback) and adding more crowds out a cleaner refactor. Worth a separate conversation: extract the deploy logic into a versioned shell script (`infra/mise/tasks/k8s/deploy-server.sh`) so it gets shellcheck, IDE highlighting, and local-run support, or rebuild the rollout around something more elaborate than bash-in-YAML (helmfile, ArgoCD/Flux, or a small Go binary). Not for this PR — flagging it as a follow-up to discuss separately.

## Test plan

- [x] `go test ./...` in the controller module passes; new tests cover both the predicate fix and the pool-release semantics + branching matrix (17 new tests total: 4 `TestDeleteServer_*`, 6 `TestReleaseToPool_*`, 4 `TestShouldReleaseToPool_*`, 3 `TestReconcileDelete_*`).
- [ ] PR merges to `main` and the next server-production-deployment workflow runs canary → acceptance tests → production end-to-end. With the controller image rolled out, cluster Machine churn renames + reinstalls hosts instead of calling DeleteServer, so MachineDeployments converge within minutes and `helm upgrade --atomic --wait` no longer hangs on the billing floor.
- [ ] Confirm a routine `kubectl delete machine` against any pool-adopted Machine renames the Scaleway server into the pool namespace and triggers a reinstall (no `DeleteServer` call).
- [ ] Confirm the stuck `tuist-tuist-macos-fleet-0` Machine in canary clears either via the schedule-deletion fallback (Fix 1) or, more likely, because the new release path renamed it back to pool and triggered a reinstall — either way the MachineDeployment converges and the operator can decide whether to physically release the underlying host via the Scaleway console at their leisure.