### PR TITLE
[codex] fix(infra): stop Kura global endpoint reconciliation in regionals

### DIFF
--- a/infra/helm/tuist/templates/kura-controller.yaml
+++ b/infra/helm/tuist/templates/kura-controller.yaml
@@ -172,6 +172,7 @@ spec:
             {{- end }}
             - --cloudflare-api-token=$(CLOUDFLARE_API_TOKEN)
             {{- end }}
+            - --reconcile-global-endpoints={{ ternary "true" "false" .Values.kuraGlobalEndpointsEnabled }}
             - --require-global-endpoints={{ ternary "true" "false" .Values.kuraGlobalEndpointsRequired }}
           ports:
             - name: metrics

--- a/infra/helm/tuist/values-managed-kura-region.yaml
+++ b/infra/helm/tuist/values-managed-kura-region.yaml
@@ -8,6 +8,13 @@ global:
     tuist.dev/service: kura
     tuist.dev/stack: managed
 
+# Regional Kura clusters still expose their per-region public and gRPC
+# endpoints through Hetzner LoadBalancer Services. This only disables
+# the Cloudflare-fronted global endpoint layer until the Cloudflare
+# pool quota is raised.
+kuraGlobalEndpointsEnabled: false
+kuraGlobalEndpointsRequired: false
+
 kuraController:
   enabled: true
   namespace: kura
@@ -28,6 +35,9 @@ kuraController:
   telemetry:
     otlpTracesEndpoint: http://k8s-monitoring-alloy-receiver.observability.svc.cluster.local:4318/v1/traces
   cloudflareLoadBalancing:
+    # Keep Cloudflare credentials wired so destroy flows can still clean
+    # up any previously provisioned global endpoints after reconciliation
+    # is re-enabled.
     enabled: true
     zoneName: tuist.dev
     apiTokenSecret:

--- a/infra/helm/tuist/values.yaml
+++ b/infra/helm/tuist/values.yaml
@@ -8,10 +8,16 @@ global:
   nodeSelector: {}
   tolerations: []
 
+# When false, the regional Kura controller stops reconciling the
+# Cloudflare-fronted global endpoint layer for Kura instances. Regional
+# HTTPS and gRPC traffic still uses the per-region Hetzner
+# LoadBalancer Services managed by the controller.
+kuraGlobalEndpointsEnabled: true
+
 # When false, the server and Kura controller keep reconciling workload
 # readiness even if the Cloudflare-fronted global Kura endpoints are not
-# available yet. The global endpoint wiring remains configured; only the
-# readiness gate is relaxed.
+# available yet. This only relaxes readiness; it does not disable the
+# global endpoint wiring by itself.
 kuraGlobalEndpointsRequired: true
 
 kuraController:

--- a/infra/kura-controller/cmd/manager/main.go
+++ b/infra/kura-controller/cmd/manager/main.go
@@ -38,6 +38,7 @@ func main() {
 	var cloudflareAccountID string
 	var cloudflareZoneID string
 	var cloudflareAPIToken string
+	var reconcileGlobalEndpoints bool
 	var requireGlobalEndpoints bool
 
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "Prometheus metrics endpoint")
@@ -50,6 +51,7 @@ func main() {
 	flag.StringVar(&cloudflareAccountID, "cloudflare-account-id", "", "Cloudflare account ID for Kura global DNS steering")
 	flag.StringVar(&cloudflareZoneID, "cloudflare-zone-id", "", "Cloudflare zone ID for Kura global DNS steering")
 	flag.StringVar(&cloudflareAPIToken, "cloudflare-api-token", "", "Cloudflare API token for Kura global DNS steering")
+	flag.BoolVar(&reconcileGlobalEndpoints, "reconcile-global-endpoints", true, "Reconcile Cloudflare global endpoints for Kura instances")
 	flag.BoolVar(&requireGlobalEndpoints, "require-global-endpoints", true, "Require global Cloudflare endpoints to reconcile before marking a Kura instance ready")
 
 	opts := zap.Options{Development: false}
@@ -83,11 +85,12 @@ func main() {
 		GRPCClusterIssuer:  grpcClusterIssuer,
 		OTLPTracesEndpoint: otlpTracesEndpoint,
 		CloudflareLoadBalancing: controllers.CloudflareLoadBalancingConfig{
-			ZoneName:               cloudflareZoneName,
-			AccountID:              cloudflareAccountID,
-			ZoneID:                 cloudflareZoneID,
-			APIToken:               cloudflareAPIToken,
-			RequireGlobalEndpoints: requireGlobalEndpoints,
+			ZoneName:                 cloudflareZoneName,
+			AccountID:                cloudflareAccountID,
+			ZoneID:                   cloudflareZoneID,
+			APIToken:                 cloudflareAPIToken,
+			ReconcileGlobalEndpoints: reconcileGlobalEndpoints,
+			RequireGlobalEndpoints:   requireGlobalEndpoints,
 		},
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "setup KuraInstanceReconciler")

--- a/infra/kura-controller/controllers/cloudflare.go
+++ b/infra/kura-controller/controllers/cloudflare.go
@@ -17,11 +17,12 @@ import (
 const cloudflareAPIBaseURL = "https://api.cloudflare.com/client/v4"
 
 type CloudflareLoadBalancingConfig struct {
-	ZoneName               string
-	AccountID              string
-	ZoneID                 string
-	APIToken               string
-	RequireGlobalEndpoints bool
+	ZoneName                 string
+	AccountID                string
+	ZoneID                   string
+	APIToken                 string
+	ReconcileGlobalEndpoints bool
+	RequireGlobalEndpoints   bool
 }
 
 func (c CloudflareLoadBalancingConfig) Enabled() bool {

--- a/infra/kura-controller/controllers/kurainstance_controller.go
+++ b/infra/kura-controller/controllers/kurainstance_controller.go
@@ -166,7 +166,7 @@ func (r *KuraInstanceReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	statusGlobalPublicURL := ""
 	statusGlobalGRPCPublicURL := ""
 	globalStatusWarnings := []string{}
-	if r.CloudflareLoadBalancing.Enabled() {
+	if r.CloudflareLoadBalancing.Enabled() && r.CloudflareLoadBalancing.ReconcileGlobalEndpoints {
 		if err := newCloudflareClient(r.CloudflareLoadBalancing).reconcileKuraLoadBalancers(ctx, instance); err != nil {
 			if r.CloudflareLoadBalancing.RequireGlobalEndpoints {
 				return ctrl.Result{}, err


### PR DESCRIPTION
## What changed

This stops Kura regional controllers from reconciling Cloudflare global endpoints while keeping the existing Hetzner regional load balancer path intact.

The chart now exposes a dedicated `kuraGlobalEndpointsEnabled` flag, the controller accepts a matching `--reconcile-global-endpoints` argument, and the regional overlay disables both global endpoint reconciliation and the readiness requirement on global endpoints.

## Why this changed

Regional Kura deployments were getting stuck in `Deploying` because the controller still tried to reconcile Cloudflare global endpoints and treated failures there as blocking. We are currently hitting the Cloudflare pool origin quota, so new regional tenants can stay healthy at the pod level but never publish a ready status.

The obvious alternative was turning off Cloudflare load balancing entirely in the regional overlay, but that would also disable cleanup for tenants that already have global endpoints provisioned. The dedicated reconciliation flag is narrower: it stops creating or updating global endpoints in regionals while preserving destroy-path cleanup.

## Impact

Once this rolls out to the regional clusters, Kura tenants in those regions can become ready without being blocked by Cloudflare global endpoint reconciliation. Regional public and gRPC traffic still use the existing Hetzner load balancers.

## Root cause

The controller previously had only one Cloudflare switch. If Cloudflare load balancing was enabled at all, reconciliation always attempted to create or update global endpoints. In the current quota-constrained state, those calls fail and prevent status from progressing.

## Validation

- Rendered the regional Helm chart and confirmed the controller receives `--reconcile-global-endpoints=false` and `--require-global-endpoints=false`
- Confirmed the rendered manifest still wires the Cloudflare secret so cleanup remains available
- Ran `go test ./...` in `infra/kura-controller` with Go 1.25 in Docker
