### PR TITLE
fix(infra): trigger server deployment from Kura releases

### DIFF
--- a/.github/workflows/kura-release-deployment.yml
+++ b/.github/workflows/kura-release-deployment.yml
@@ -1,0 +1,44 @@
+name: Kura Release Deployment
+
+# Kura ships as an independent runtime image. The server chart only picks
+# up a new Kura build on the next server rollout, so the `kura@...` tag is
+# the release handoff that re-runs the normal canary -> acceptance ->
+# production promotion with the published Kura image pinned explicitly.
+#
+# Trigger on the pushed release tag, not raw `kura/**` source changes, so
+# the rollout cannot outrun the image/tag publication done in release.yml.
+
+on:
+  push:
+    tags:
+      - "kura@*"
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  dispatch:
+    runs-on: tuist-production-linux
+    timeout-minutes: 10
+    steps:
+      - name: Dispatch Server Production Deployment
+        env:
+          GH_TOKEN: ${{ github.token }}
+          KURA_RUNTIME_IMAGE_TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+
+          curl -fsSL -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/workflows/server-production-deployment.yml/dispatches" \
+            -d @- <<EOF
+          {
+            "ref": "main",
+            "inputs": {
+              "commit_sha": "${GITHUB_SHA}",
+              "kura_runtime_image_tag": "${KURA_RUNTIME_IMAGE_TAG#kura@}"
+            }
+          }
+          EOF

--- a/.github/workflows/server-production-deployment.yml
+++ b/.github/workflows/server-production-deployment.yml
@@ -3,11 +3,12 @@ name: Server Production Deployment
 # Promotion cascade: build → canary → acceptance tests → production.
 #
 # Triggers:
-#   push to main     - standard promotion. Commits whose subject contains
-#                      "(hotfix)" fast-path to production without waiting
-#                      for canary + tests.
+#   push to main      - standard promotion. Commits whose subject contains
+#                       "(hotfix)" fast-path to production without waiting
+#                       for canary + tests.
 #   workflow_dispatch - run the cascade against a pinned SHA (useful to
-#                      re-promote a past commit).
+#                       re-promote a past commit or to re-roll the same
+#                       server image against a freshly released Kura tag).
 #
 # Image architecture: the Docker image is env-agnostic (built once with
 # MIX_ENV=prod) so the same `sha-<SHA>` tag is promoted from canary to
@@ -21,7 +22,9 @@ name: Server Production Deployment
 # Kura regional controller/platform rollouts are handled by
 # server-kura-regional-deployment.yml after production succeeds so
 # regional capacity incidents do not mark the main production deploy as
-# failed.
+# failed. Kura runtime rollouts are release-driven via
+# kura-release-deployment.yml after the `kura@...` tag exists, so the
+# server promotion path never races ahead of the published runtime tag.
 #
 # Slack notifications:
 #   - Any failure on main → .github/workflows/notify-failure.yml picks up
@@ -43,7 +46,6 @@ on:
       - main
     paths:
       - server/**
-      - kura/**
       - tuist_common/**
       - noora/**
       - infra/kura-controller/**
@@ -56,6 +58,9 @@ on:
     inputs:
       commit_sha:
         description: Commit SHA to deploy (defaults to the event's SHA)
+        required: false
+      kura_runtime_image_tag:
+        description: Pre-built Kura runtime image tag to deploy
         required: false
 
 permissions:
@@ -130,6 +135,7 @@ jobs:
       environment: canary
       commit_sha: ${{ inputs.commit_sha || github.sha }}
       image_tag: ${{ needs.build.outputs.image_tag }}
+      kura_runtime_image_tag: ${{ inputs.kura_runtime_image_tag }}
     secrets: inherit
 
   acceptance-tests:
@@ -182,6 +188,7 @@ jobs:
       environment: production
       commit_sha: ${{ inputs.commit_sha || github.sha }}
       image_tag: ${{ needs.build.outputs.image_tag }}
+      kura_runtime_image_tag: ${{ inputs.kura_runtime_image_tag }}
     secrets: inherit
 
   # --------------------------------------------------------------------------
@@ -198,4 +205,5 @@ jobs:
       environment: production
       commit_sha: ${{ github.sha }}
       image_tag: ${{ needs.build.outputs.image_tag }}
+      kura_runtime_image_tag: ${{ inputs.kura_runtime_image_tag }}
     secrets: inherit


### PR DESCRIPTION
## Summary
- add a `kura_runtime_image_tag` input to the server production cascade and thread it through the canary and production deploy legs
- add a tag-driven `kura-release-deployment.yml` workflow that dispatches the normal server production deployment when a `kura@*` release tag is pushed
- stop triggering server production directly from `kura/**` source pushes so the rollout cannot race ahead of Kura image and tag publication
- keep the existing regional Kura rollout path unchanged so it still runs only after a successful production deployment

## Testing
- `ruby -e 'require "psych"; Psych.load_file(".github/workflows/server-production-deployment.yml"); Psych.load_file(".github/workflows/kura-release-deployment.yml"); puts "yaml ok"'`
