### PR TITLE
refactor(capi-scaleway): drop auto-order + terminate paths, pool only

### DIFF
--- a/infra/cluster-api-provider-scaleway-applesilicon/AGENTS.md
+++ b/infra/cluster-api-provider-scaleway-applesilicon/AGENTS.md
@@ -28,7 +28,7 @@ API group: `infrastructure.cluster.x-k8s.io/v1alpha1`. Short names:
  │ capi-scaleway-applesilicon manager           │
  │   ├── ScalewayAppleSiliconMachineReconciler  │
  │   │   ├── 1. Stage: Adopting                 │
- │   │   │      scaleway.AdoptByPrefix(...)     │
+ │   │   │      scaleway.AdoptFromPool(...)     │
  │   │   │      → ProviderID, IP, sudo password │
  │   │   ├── 2. Stage: Bootstrapping            │
  │   │   │      bootstrap.Run(SSH, Tart, kubelet,│
@@ -260,7 +260,7 @@ current state intact.
 The reconciler skips Scaleway release whenever `status.serverID` is
 empty at delete time. But clearing `status.serverID` before the
 delete races the reconcile loop — it sees the empty serverID and
-runs `AdoptByPrefix` against the pool. To latch the loop off
+runs `AdoptFromPool` against the pool. To latch the loop off
 during cleanup, set the CAPI `cluster.x-k8s.io/paused` annotation
 on the CR *before* clearing status:
 
@@ -293,7 +293,7 @@ which adopts an unclaimed pool host on its next reconcile.
 
 After cleanup, if you renamed the original Scaleway host
 out-of-band (e.g. during a duplicate-claim untangling), rename it
-back so the pool prefix matches and a future `AdoptByPrefix` can
+back so the pool prefix matches and a future `AdoptFromPool` can
 pick it up:
 
 ```bash

--- a/infra/cluster-api-provider-scaleway-applesilicon/AGENTS.md
+++ b/infra/cluster-api-provider-scaleway-applesilicon/AGENTS.md
@@ -27,8 +27,8 @@ API group: `infrastructure.cluster.x-k8s.io/v1alpha1`. Short names:
  ┌──────────────────────────────────────────────┐
  │ capi-scaleway-applesilicon manager           │
  │   ├── ScalewayAppleSiliconMachineReconciler  │
- │   │   ├── 1. Stage: Provisioning             │
- │   │   │      scaleway.CreateServer(...)      │
+ │   │   ├── 1. Stage: Adopting                 │
+ │   │   │      scaleway.AdoptByPrefix(...)     │
  │   │   │      → ProviderID, IP, sudo password │
  │   │   ├── 2. Stage: Bootstrapping            │
  │   │   │      bootstrap.Run(SSH, Tart, kubelet,│
@@ -173,16 +173,14 @@ them Ready.
 ```bash
 kubectl scale machinedeployment <fleet-name> --replicas=1
 ```
-CAPI core picks the most-recently-created Machines for deletion. For
-pool-adopted Machines (the default — `Spec.AdoptPoolPrefix` set), the
-controller does NOT call `Scaleway DeleteServer`. Instead it renames
-the host back into the pool namespace (`<poolPrefix><uuid>`) and
-triggers a Scaleway OS reinstall; the host stays alive, returns to
-factory-default state, and becomes eligible for the next adoption
-once Scaleway flips it back to `Delivered + Ready`. The 24h Apple
-licensing floor stays in operator-owned territory — you keep paying
-for capacity you already pre-ordered until you decide to release it
-via the Scaleway console.
+CAPI core picks the most-recently-created Machines for deletion. The
+controller renames the host back into the pool namespace
+(`<poolPrefix><uuid>`) and triggers a Scaleway OS reinstall; the
+host stays alive, returns to factory-default state, and becomes
+eligible for the next adoption once Scaleway flips it back to
+`Delivered + Ready`. The 24h Apple licensing floor stays in
+operator-owned territory — you keep paying for capacity you already
+pre-ordered until you decide to release it via the Scaleway console.
 
 ### Replace a wedged host
 ```bash
@@ -195,18 +193,9 @@ next adoption. The replacement Machine will adopt either this host
 Scaleway returns to `Ready` first.
 
 If the host is genuinely broken (kernel panic loop, hardware fault,
-retired SKU) and must not be re-adopted, force the legacy physical-
-terminate path before deleting:
-
-```bash
-kubectl -n "$NS" annotate scalewayapplesiliconmachine <name> \
-  tuist.dev/release-policy=terminate --overwrite
-kubectl -n "$NS" delete machine <machine-name>
-```
-
-The annotation switches `reconcileDelete` from `ReleaseToPool` to
-`DeleteServer`. The schedule-deletion fallback handles the 24h
-billing floor; Scaleway stops billing at floor expiry.
+retired SKU) and must not be re-adopted, release it via the
+Scaleway console before deleting the Machine — the controller has
+no physical-terminate path.
 
 ### Investigate a failure
 ```bash
@@ -264,8 +253,9 @@ Reserved for recovering from a duplicate-claim state (multiple CRs
 ended up bound to the same Scaleway server) or for hand-rolling a CR
 off a host that's actively serving traffic. The standard
 `kubectl delete machine <name>` path always calls Scaleway's
-`DeleteServer` against the bound host, which is the wrong move when
-the host is shared OR you want to keep the host paid up.
+`ReleaseToPool` against the bound host (rename + reinstall), which
+is the wrong move when the host is shared OR you want to keep its
+current state intact.
 
 The reconciler skips Scaleway release whenever `status.serverID` is
 empty at delete time. But clearing `status.serverID` before the
@@ -283,7 +273,7 @@ NAME=tuist-tuist-runners-fleet-mndbc-xxxxx
 kubectl -n "$NS" annotate scalewayapplesiliconmachine "$NAME" \
   cluster.x-k8s.io/paused=true --overwrite
 
-# 2. Clear status.serverID (so reconcileDelete skips DeleteServer)
+# 2. Clear status.serverID (so reconcileDelete skips ReleaseToPool)
 #    and spec.providerID (so CAPI core doesn't keep referencing
 #    the abandoned binding).
 kubectl -n "$NS" patch scalewayapplesiliconmachine "$NAME" \

--- a/infra/cluster-api-provider-scaleway-applesilicon/api/v1alpha1/scalewayapplesiliconmachine_types.go
+++ b/infra/cluster-api-provider-scaleway-applesilicon/api/v1alpha1/scalewayapplesiliconmachine_types.go
@@ -107,6 +107,7 @@ type ScalewayAppleSiliconMachineSpec struct {
 	// scan once Scaleway flips it back to `Delivered + Ready`.
 	// Physical destruction is operator-owned via the Scaleway
 	// console so the 24h billing floor doesn't leak into deploy flows.
+	// +kubebuilder:validation:MinLength=1
 	AdoptPoolPrefix string `json:"adoptPoolPrefix"`
 }
 

--- a/infra/cluster-api-provider-scaleway-applesilicon/api/v1alpha1/scalewayapplesiliconmachine_types.go
+++ b/infra/cluster-api-provider-scaleway-applesilicon/api/v1alpha1/scalewayapplesiliconmachine_types.go
@@ -103,7 +103,7 @@ type ScalewayAppleSiliconMachineSpec struct {
 	// the host back into the pool namespace (with a fresh UUID
 	// suffix) and triggers a Scaleway OS reinstall, then drops the
 	// k8s-side state. The host stays alive, is reset to factory-
-	// default state, and becomes eligible for the next AdoptByPrefix
+	// default state, and becomes eligible for the next AdoptFromPool
 	// scan once Scaleway flips it back to `Delivered + Ready`.
 	// Physical destruction is operator-owned via the Scaleway
 	// console so the 24h billing floor doesn't leak into deploy flows.

--- a/infra/cluster-api-provider-scaleway-applesilicon/api/v1alpha1/scalewayapplesiliconmachine_types.go
+++ b/infra/cluster-api-provider-scaleway-applesilicon/api/v1alpha1/scalewayapplesiliconmachine_types.go
@@ -76,13 +76,12 @@ type ScalewayAppleSiliconMachineSpec struct {
 	// +optional
 	HostMemoryMB int `json:"hostMemoryMB,omitempty"`
 
-	// AdoptPoolPrefix switches the controller from `Scaleway CreateServer`
-	// (auto-order) to "claim a pre-ordered host whose Scaleway-side
-	// name starts with this prefix." Recommended for the customer-
-	// runner fleet because Scaleway Mac mini inventory is frequently
-	// out of stock and Apple's 24h licensing floor makes speculative
-	// auto-ordering expensive — pre-ordering days in advance and
-	// letting the controller adopt is the operationally sane path.
+	// AdoptPoolPrefix is the Scaleway-side name prefix the controller
+	// scans when claiming a Mac mini for this Machine. Required:
+	// the controller has no auto-order path. Operators pre-order
+	// capacity in the Scaleway console because Mac mini inventory is
+	// frequently out of stock and Apple's 24h licensing floor makes
+	// speculative ordering expensive.
 	//
 	// Operator workflow:
 	//
@@ -98,27 +97,17 @@ type ScalewayAppleSiliconMachineSpec struct {
 	//      reconcile won't double-claim.
 	//
 	// When no compatible pre-ordered host is available, reconcile
-	// requeues with a `NoAvailableHost` event. No auto-order
-	// fallback — the operator pre-orders, the controller adopts.
+	// requeues with a `NoAvailableHost` event.
 	//
-	// Delete semantics also change in pool mode: when the Machine is
-	// deleted, the controller renames the host back into the pool
-	// namespace (with a fresh UUID suffix) and triggers a Scaleway
-	// OS reinstall, then drops the k8s-side state. The host stays
-	// alive, is reset to factory-default state, and becomes eligible
-	// for the next AdoptByPrefix scan once Scaleway flips it back to
-	// `Delivered + Ready`. Physical destruction is left to the
-	// operator — they pre-order capacity, they decide when to release
-	// it, and the 24h billing floor stays in operator-owned territory
-	// instead of leaking into deploy flows. Force the legacy
-	// physical-terminate path on individual broken hosts via the
-	// `tuist.dev/release-policy: terminate` annotation on the Machine.
-	//
-	// Empty (default) preserves the legacy auto-order behavior, and
-	// delete falls back to `Scaleway DeleteServer` regardless of the
-	// release-policy annotation (there's no pool to return to).
-	// +optional
-	AdoptPoolPrefix string `json:"adoptPoolPrefix,omitempty"`
+	// Delete semantics: on Machine deletion the controller renames
+	// the host back into the pool namespace (with a fresh UUID
+	// suffix) and triggers a Scaleway OS reinstall, then drops the
+	// k8s-side state. The host stays alive, is reset to factory-
+	// default state, and becomes eligible for the next AdoptByPrefix
+	// scan once Scaleway flips it back to `Delivered + Ready`.
+	// Physical destruction is operator-owned via the Scaleway
+	// console so the 24h billing floor doesn't leak into deploy flows.
+	AdoptPoolPrefix string `json:"adoptPoolPrefix"`
 }
 
 // GHActionsRunnerConfig tells the reconciler what GitHub Actions

--- a/infra/cluster-api-provider-scaleway-applesilicon/cmd/manager/main.go
+++ b/infra/cluster-api-provider-scaleway-applesilicon/cmd/manager/main.go
@@ -156,7 +156,7 @@ func main() {
 		"How many ScalewayAppleSiliconMachine reconciles run in parallel. The "+
 			"default of 1 (controller-runtime's default) serializes the whole "+
 			"fleet behind one worker — first-time bring-up of N Mac minis takes "+
-			"N × bootstrap time because each CreateServer + SSH bootstrap "+
+			"N × bootstrap time because each AdoptByPrefix + SSH bootstrap "+
 			"blocks the worker for ~50 min. Bumping this lets distinct machines "+
 			"provision in parallel; reconciles for the same machine remain "+
 			"serialized by controller-runtime's per-key locking. 4 covers the "+

--- a/infra/cluster-api-provider-scaleway-applesilicon/cmd/manager/main.go
+++ b/infra/cluster-api-provider-scaleway-applesilicon/cmd/manager/main.go
@@ -156,7 +156,7 @@ func main() {
 		"How many ScalewayAppleSiliconMachine reconciles run in parallel. The "+
 			"default of 1 (controller-runtime's default) serializes the whole "+
 			"fleet behind one worker — first-time bring-up of N Mac minis takes "+
-			"N × bootstrap time because each AdoptByPrefix + SSH bootstrap "+
+			"N × bootstrap time because each AdoptFromPool + SSH bootstrap "+
 			"blocks the worker for ~50 min. Bumping this lets distinct machines "+
 			"provision in parallel; reconciles for the same machine remain "+
 			"serialized by controller-runtime's per-key locking. 4 covers the "+

--- a/infra/cluster-api-provider-scaleway-applesilicon/controllers/scalewayapplesiliconmachine_controller.go
+++ b/infra/cluster-api-provider-scaleway-applesilicon/controllers/scalewayapplesiliconmachine_controller.go
@@ -45,21 +45,6 @@ const (
 	// Conditions surfaced on the CR for operator visibility.
 	ProvisionedCondition  clusterv1.ConditionType = "Provisioned"
 	BootstrappedCondition clusterv1.ConditionType = "Bootstrapped"
-
-	// ReleasePolicyAnnotation controls what happens to the underlying
-	// Scaleway server when its ScalewayAppleSiliconMachine is deleted.
-	// Default for pool-adopted Machines (Spec.AdoptPoolPrefix set) is
-	// "pool": rename the server back into the pool namespace and
-	// trigger a Scaleway OS reinstall, so the next AdoptByPrefix sees
-	// factory-default state. Operator can set this to "terminate" on
-	// individual Machines to force the legacy DeleteServer path —
-	// useful for broken hosts that must not be re-adopted (kernel
-	// panic loop, hardware fault, retired SKU). Auto-order Machines
-	// (no AdoptPoolPrefix) always use the terminate path regardless,
-	// because there's no pool to return to.
-	ReleasePolicyAnnotation = "tuist.dev/release-policy"
-	ReleasePolicyPool       = "pool"
-	ReleasePolicyTerminate  = "terminate"
 )
 
 // ScalewayAppleSiliconMachineReconciler reconciles ScalewayAppleSiliconMachine objects.
@@ -143,7 +128,7 @@ type ScalewayAppleSiliconMachineReconciler struct {
 	// MaxConcurrentReconciles is how many machines this controller
 	// reconciles in parallel. controller-runtime's default of 1
 	// serializes first-time fleet bring-up: each Mac mini's
-	// CreateServer + SSH bootstrap blocks the worker for ~50 min, so
+	// AdoptByPrefix + SSH bootstrap blocks the worker for ~50 min, so
 	// N machines take N × that wall-clock. Reconciles for the same
 	// machine are still serialized by controller-runtime's per-key
 	// locking — bumping this only parallelizes across distinct CRs.
@@ -200,8 +185,8 @@ type ScalewayAppleSiliconMachineReconciler struct {
 // variable that Go has already evaluated for the return — the defer
 // would silently swallow the patch failure and the function would
 // report success, leaving Status.ServerID unpersisted after a
-// successful CreateServer and letting the next reconcile order a
-// second Mac mini.
+// successful AdoptByPrefix and letting the next reconcile claim a
+// second Mac mini from the pool.
 func (r *ScalewayAppleSiliconMachineReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, err error) {
 	logger := log.FromContext(ctx).WithValues("machine", req.NamespacedName)
 	logger.Info("reconcile entry")
@@ -315,11 +300,12 @@ func (r *ScalewayAppleSiliconMachineReconciler) reconcileNormal(
 	logger := log.FromContext(ctx)
 
 	// Stage 0: ensure the per-fleet SSH key is registered with Scaleway
-	// BEFORE we order the Mac mini. Scaleway only injects project SSH
-	// keys at first-boot — keys registered after CreateServer are not
-	// auto-installed on the host, leaving us locked out of SSH and
-	// unable to bootstrap kubelet. Doing this first means the Mac mini
-	// comes up with our pubkey already in ~/.ssh/authorized_keys.
+	// BEFORE we adopt the Mac mini. Scaleway only injects project SSH
+	// keys at the host's first-boot — keys registered after the order
+	// are not auto-installed, leaving us locked out of SSH and unable
+	// to bootstrap kubelet. Doing this first means a freshly pre-
+	// ordered Mac mini comes up with our pubkey already in
+	// ~/.ssh/authorized_keys, ready for adoption.
 	fleet := machine.Spec.FleetName
 	if fleet == "" {
 		fleet = machine.Namespace + "-" + machine.Name
@@ -374,7 +360,7 @@ func (r *ScalewayAppleSiliconMachineReconciler) reconcileNormal(
 	}
 	if bootstrapCreds == nil {
 		// Stage 1 didn't write the Secret yet (fresh CR mid-reconcile,
-		// or operator pod that crashed between CreateServer + Secret
+		// or operator pod that crashed between AdoptByPrefix + Secret
 		// write). Requeue.
 		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 	}
@@ -691,40 +677,22 @@ func (r *ScalewayAppleSiliconMachineReconciler) reconcileDelete(
 	logger := log.FromContext(ctx)
 	machine.Status.Phase = "Deleting"
 
-	// Stage 1: release the Scaleway server. Skip if already released
-	// (mid-cleanup retry). For pool-adopted Machines this is a soft
-	// release back into the pool — rename + reinstall — so the host
-	// stays alive for the next adopt. Auto-order Machines and any
-	// Machine annotated `tuist.dev/release-policy: terminate` go
-	// through the legacy DeleteServer path; see ReleasePolicyAnnotation
-	// for the contract.
+	// Stage 1: release the Scaleway server back into the pool —
+	// rename + reinstall — so the host stays alive for the next
+	// adopt. Skip if already released (mid-cleanup retry).
 	if machine.Status.ServerID != "" {
-		if shouldReleaseToPool(machine) {
-			r.Recorder.Eventf(machine, corev1.EventTypeNormal, "Releasing",
-				"Returning Scaleway server %s to pool %q (with reinstall)",
-				machine.Status.ServerID, machine.Spec.AdoptPoolPrefix)
-			if err := r.ScalewayClient.ReleaseToPool(ctx, machine.Status.ServerID, machine.Spec.Zone, machine.Spec.AdoptPoolPrefix); err != nil {
-				logger.Error(err, "Scaleway release-to-pool failed; will retry")
-				r.Recorder.Eventf(machine, corev1.EventTypeWarning, "ReleaseFailed",
-					"Scaleway ReleaseToPool: %v (will retry)", err)
-				return ctrl.Result{RequeueAfter: 60 * time.Second}, nil
-			}
-			machine.Status.ServerID = ""
-			r.Recorder.Eventf(machine, corev1.EventTypeNormal, "Released",
-				"Scaleway server returned to pool; reinstall triggered")
-		} else {
-			r.Recorder.Eventf(machine, corev1.EventTypeNormal, "Deleting",
-				"Releasing Scaleway server %s", machine.Status.ServerID)
-			if err := r.ScalewayClient.DeleteServer(ctx, machine.Status.ServerID, machine.Spec.Zone); err != nil {
-				logger.Error(err, "Scaleway delete failed; will retry")
-				r.Recorder.Eventf(machine, corev1.EventTypeWarning, "DeleteFailed",
-					"Scaleway DeleteServer: %v (will retry)", err)
-				return ctrl.Result{RequeueAfter: 60 * time.Second}, nil
-			}
-			machine.Status.ServerID = ""
-			r.Recorder.Eventf(machine, corev1.EventTypeNormal, "Deleted",
-				"Scaleway server released")
+		r.Recorder.Eventf(machine, corev1.EventTypeNormal, "Releasing",
+			"Returning Scaleway server %s to pool %q (with reinstall)",
+			machine.Status.ServerID, machine.Spec.AdoptPoolPrefix)
+		if err := r.ScalewayClient.ReleaseToPool(ctx, machine.Status.ServerID, machine.Spec.Zone, machine.Spec.AdoptPoolPrefix); err != nil {
+			logger.Error(err, "Scaleway release-to-pool failed; will retry")
+			r.Recorder.Eventf(machine, corev1.EventTypeWarning, "ReleaseFailed",
+				"Scaleway ReleaseToPool: %v (will retry)", err)
+			return ctrl.Result{RequeueAfter: 60 * time.Second}, nil
 		}
+		machine.Status.ServerID = ""
+		r.Recorder.Eventf(machine, corev1.EventTypeNormal, "Released",
+			"Scaleway server returned to pool; reinstall triggered")
 	}
 
 	// Stage 2: drop the per-machine kubelet identity. The token is
@@ -889,71 +857,58 @@ func recordUpdateFailure(machine *infrav1.ScalewayAppleSiliconMachine, err error
 		machine.Status.TartKubeletUpdateAttempts, maxAttempts, err)
 }
 
-// acquireServer either claims a pre-ordered host from the pool
-// (when `Spec.AdoptPoolPrefix` is set) or orders a new one. The
-// adoption path returns (nil, requeue, nil) on
-// `ErrNoAvailableHost` — that's a transient "wait for operator
-// pre-order" state, not a failure; surfaces a `NoAvailableHost`
-// event so the operator sees the queue. On any other error the
-// caller requeues and the condition message carries the detail.
+// acquireServer claims a pre-ordered host from the pool. Returns
+// (nil, requeue, nil) on `ErrNoAvailableHost` — that's a transient
+// "wait for operator pre-order" state, not a failure; surfaces a
+// `NoAvailableHost` event so the operator sees the queue. On any
+// other error the caller requeues and the condition message carries
+// the detail.
 func (r *ScalewayAppleSiliconMachineReconciler) acquireServer(
 	ctx context.Context,
 	machine *infrav1.ScalewayAppleSiliconMachine,
 ) (*scaleway.Server, time.Duration, error) {
-	if machine.Spec.AdoptPoolPrefix != "" {
-		machine.Status.Phase = "Adopting"
-		r.Recorder.Eventf(machine, corev1.EventTypeNormal, "Adopting",
-			"Searching pool %q for an unclaimed %s Mac mini in zone %s",
-			machine.Spec.AdoptPoolPrefix, machine.Spec.Type, machine.Spec.Zone)
-		srv, err := r.ScalewayClient.AdoptByPrefix(
-			ctx,
-			machine.Name,
-			machine.Spec.Zone,
-			machine.Spec.Type,
-			machine.Spec.OS,
-			machine.Spec.AdoptPoolPrefix,
-		)
-		if errors.Is(err, scaleway.ErrNoAvailableHost) {
-			conditions.MarkFalse(machine, ProvisionedCondition, "NoAvailableHost",
-				clusterv1.ConditionSeverityWarning,
-				"no server with prefix %q matching %s/%s/%s in zone %s; pre-order more capacity",
-				machine.Spec.AdoptPoolPrefix, machine.Spec.Type, machine.Spec.OS,
-				"ready", machine.Spec.Zone)
-			r.Recorder.Eventf(machine, corev1.EventTypeWarning, "NoAvailableHost",
-				"No pre-ordered Mac mini matching pool=%q type=%s os=%s zone=%s; waiting for operator to pre-order more capacity",
-				machine.Spec.AdoptPoolPrefix, machine.Spec.Type, machine.Spec.OS, machine.Spec.Zone)
-			return nil, 60 * time.Second, nil
-		}
-		if err != nil {
-			conditions.MarkFalse(machine, ProvisionedCondition, "ScalewayAdoptFailed",
-				clusterv1.ConditionSeverityError, "%v", err)
-			r.Recorder.Eventf(machine, corev1.EventTypeWarning, "ProvisioningFailed",
-				"Scaleway AdoptByPrefix: %v", err)
-			return nil, 30 * time.Second, err
-		}
-		r.Recorder.Eventf(machine, corev1.EventTypeNormal, "Adopted",
-			"Claimed Mac mini %s from pool %q (renamed to %s)",
-			srv.ID, machine.Spec.AdoptPoolPrefix, machine.Name)
-		return srv, 0, nil
+	if machine.Spec.AdoptPoolPrefix == "" {
+		conditions.MarkFalse(machine, ProvisionedCondition, "MissingAdoptPoolPrefix",
+			clusterv1.ConditionSeverityError,
+			"Spec.AdoptPoolPrefix is required; auto-order via CreateServer is no longer supported")
+		r.Recorder.Eventf(machine, corev1.EventTypeWarning, "MissingAdoptPoolPrefix",
+			"Spec.AdoptPoolPrefix is required; pre-order capacity and set the prefix on the MachineTemplate")
+		return nil, 5 * time.Minute, nil
 	}
 
-	machine.Status.Phase = "Provisioning"
-	r.Recorder.Eventf(machine, corev1.EventTypeNormal, "Provisioning",
-		"Ordering %s Mac mini in zone %s", machine.Spec.Type, machine.Spec.Zone)
-	srv, err := r.ScalewayClient.CreateServer(
+	machine.Status.Phase = "Adopting"
+	r.Recorder.Eventf(machine, corev1.EventTypeNormal, "Adopting",
+		"Searching pool %q for an unclaimed %s Mac mini in zone %s",
+		machine.Spec.AdoptPoolPrefix, machine.Spec.Type, machine.Spec.Zone)
+	srv, err := r.ScalewayClient.AdoptByPrefix(
 		ctx,
 		machine.Name,
 		machine.Spec.Zone,
 		machine.Spec.Type,
 		machine.Spec.OS,
+		machine.Spec.AdoptPoolPrefix,
 	)
+	if errors.Is(err, scaleway.ErrNoAvailableHost) {
+		conditions.MarkFalse(machine, ProvisionedCondition, "NoAvailableHost",
+			clusterv1.ConditionSeverityWarning,
+			"no server with prefix %q matching %s/%s/%s in zone %s; pre-order more capacity",
+			machine.Spec.AdoptPoolPrefix, machine.Spec.Type, machine.Spec.OS,
+			"ready", machine.Spec.Zone)
+		r.Recorder.Eventf(machine, corev1.EventTypeWarning, "NoAvailableHost",
+			"No pre-ordered Mac mini matching pool=%q type=%s os=%s zone=%s; waiting for operator to pre-order more capacity",
+			machine.Spec.AdoptPoolPrefix, machine.Spec.Type, machine.Spec.OS, machine.Spec.Zone)
+		return nil, 60 * time.Second, nil
+	}
 	if err != nil {
-		conditions.MarkFalse(machine, ProvisionedCondition, "ScalewayCreateFailed",
+		conditions.MarkFalse(machine, ProvisionedCondition, "ScalewayAdoptFailed",
 			clusterv1.ConditionSeverityError, "%v", err)
 		r.Recorder.Eventf(machine, corev1.EventTypeWarning, "ProvisioningFailed",
-			"Scaleway CreateServer: %v", err)
-		return nil, 60 * time.Second, err
+			"Scaleway AdoptByPrefix: %v", err)
+		return nil, 30 * time.Second, err
 	}
+	r.Recorder.Eventf(machine, corev1.EventTypeNormal, "Adopted",
+		"Claimed Mac mini %s from pool %q (renamed to %s)",
+		srv.ID, machine.Spec.AdoptPoolPrefix, machine.Name)
 	return srv, 0, nil
 }
 
@@ -1053,30 +1008,6 @@ func (r *ScalewayAppleSiliconMachineReconciler) SetupWithManager(mgr ctrl.Manage
 			handler.EnqueueRequestsFromMapFunc(scalewayMachineForCAPIMachine),
 		).
 		Complete(r)
-}
-
-// shouldReleaseToPool decides whether reconcileDelete should hand the
-// underlying Scaleway server back to the adopt pool (with reinstall)
-// or fall through to the legacy physical-terminate path.
-//
-//   - No AdoptPoolPrefix → auto-order Machine, no pool to return to;
-//     must terminate.
-//   - `tuist.dev/release-policy: terminate` annotation → operator
-//     opt-out, e.g. a broken host that shouldn't be re-adopted.
-//   - Default → pool.
-//
-// Empty / unknown annotation values are treated as the default. The
-// operator opt-in is intentionally minimal-surface so the common case
-// (Mac mini in good health, fleet scaling down or rolling) doesn't
-// need any per-Machine annotation gymnastics.
-func shouldReleaseToPool(machine *infrav1.ScalewayAppleSiliconMachine) bool {
-	if machine.Spec.AdoptPoolPrefix == "" {
-		return false
-	}
-	if machine.Annotations[ReleasePolicyAnnotation] == ReleasePolicyTerminate {
-		return false
-	}
-	return true
 }
 
 // scalewayMachineForCAPIMachine maps a CAPI Machine event to a

--- a/infra/cluster-api-provider-scaleway-applesilicon/controllers/scalewayapplesiliconmachine_controller.go
+++ b/infra/cluster-api-provider-scaleway-applesilicon/controllers/scalewayapplesiliconmachine_controller.go
@@ -867,15 +867,6 @@ func (r *ScalewayAppleSiliconMachineReconciler) acquireServer(
 	ctx context.Context,
 	machine *infrav1.ScalewayAppleSiliconMachine,
 ) (*scaleway.Server, time.Duration, error) {
-	if machine.Spec.AdoptPoolPrefix == "" {
-		conditions.MarkFalse(machine, ProvisionedCondition, "MissingAdoptPoolPrefix",
-			clusterv1.ConditionSeverityError,
-			"Spec.AdoptPoolPrefix is required; auto-order via CreateServer is no longer supported")
-		r.Recorder.Eventf(machine, corev1.EventTypeWarning, "MissingAdoptPoolPrefix",
-			"Spec.AdoptPoolPrefix is required; pre-order capacity and set the prefix on the MachineTemplate")
-		return nil, 5 * time.Minute, nil
-	}
-
 	machine.Status.Phase = "Adopting"
 	r.Recorder.Eventf(machine, corev1.EventTypeNormal, "Adopting",
 		"Searching pool %q for an unclaimed %s Mac mini in zone %s",

--- a/infra/cluster-api-provider-scaleway-applesilicon/controllers/scalewayapplesiliconmachine_controller.go
+++ b/infra/cluster-api-provider-scaleway-applesilicon/controllers/scalewayapplesiliconmachine_controller.go
@@ -680,19 +680,40 @@ func (r *ScalewayAppleSiliconMachineReconciler) reconcileDelete(
 	// Stage 1: release the Scaleway server back into the pool —
 	// rename + reinstall — so the host stays alive for the next
 	// adopt. Skip if already released (mid-cleanup retry).
+	//
+	// Legacy CRs predating the required-AdoptPoolPrefix contract may
+	// still exist with the field unset (the older chart only
+	// rendered `adoptPoolPrefix` when the value was non-empty, so
+	// fleets that didn't set it produced bare CRs). For those we
+	// can't ReleaseToPool — the client rejects an empty prefix as a
+	// guard against orphaning hosts outside the pool namespace — so
+	// skip the Scaleway release stage entirely, leave the host
+	// running, and let the operator clean it up via the Scaleway
+	// console. Without this fallthrough, deleting a legacy CR would
+	// loop forever on a precondition error and block fleet teardown.
 	if machine.Status.ServerID != "" {
-		r.Recorder.Eventf(machine, corev1.EventTypeNormal, "Releasing",
-			"Returning Scaleway server %s to pool %q (with reinstall)",
-			machine.Status.ServerID, machine.Spec.AdoptPoolPrefix)
-		if err := r.ScalewayClient.ReleaseToPool(ctx, machine.Status.ServerID, machine.Spec.Zone, machine.Spec.AdoptPoolPrefix); err != nil {
-			logger.Error(err, "Scaleway release-to-pool failed; will retry")
-			r.Recorder.Eventf(machine, corev1.EventTypeWarning, "ReleaseFailed",
-				"Scaleway ReleaseToPool: %v (will retry)", err)
-			return ctrl.Result{RequeueAfter: 60 * time.Second}, nil
+		switch {
+		case machine.Spec.AdoptPoolPrefix == "":
+			r.Recorder.Eventf(machine, corev1.EventTypeWarning, "ReleaseSkipped",
+				"Spec.AdoptPoolPrefix is empty (legacy CR); skipping Scaleway release of %s — clean up the host via the Scaleway console if needed",
+				machine.Status.ServerID)
+			logger.Info("legacy CR without AdoptPoolPrefix; skipping Scaleway release",
+				"serverID", machine.Status.ServerID)
+			machine.Status.ServerID = ""
+		default:
+			r.Recorder.Eventf(machine, corev1.EventTypeNormal, "Releasing",
+				"Returning Scaleway server %s to pool %q (with reinstall)",
+				machine.Status.ServerID, machine.Spec.AdoptPoolPrefix)
+			if err := r.ScalewayClient.ReleaseToPool(ctx, machine.Status.ServerID, machine.Spec.Zone, machine.Spec.AdoptPoolPrefix); err != nil {
+				logger.Error(err, "Scaleway release-to-pool failed; will retry")
+				r.Recorder.Eventf(machine, corev1.EventTypeWarning, "ReleaseFailed",
+					"Scaleway ReleaseToPool: %v (will retry)", err)
+				return ctrl.Result{RequeueAfter: 60 * time.Second}, nil
+			}
+			machine.Status.ServerID = ""
+			r.Recorder.Eventf(machine, corev1.EventTypeNormal, "Released",
+				"Scaleway server returned to pool; reinstall triggered")
 		}
-		machine.Status.ServerID = ""
-		r.Recorder.Eventf(machine, corev1.EventTypeNormal, "Released",
-			"Scaleway server returned to pool; reinstall triggered")
 	}
 
 	// Stage 2: drop the per-machine kubelet identity. The token is

--- a/infra/cluster-api-provider-scaleway-applesilicon/controllers/scalewayapplesiliconmachine_controller.go
+++ b/infra/cluster-api-provider-scaleway-applesilicon/controllers/scalewayapplesiliconmachine_controller.go
@@ -128,7 +128,7 @@ type ScalewayAppleSiliconMachineReconciler struct {
 	// MaxConcurrentReconciles is how many machines this controller
 	// reconciles in parallel. controller-runtime's default of 1
 	// serializes first-time fleet bring-up: each Mac mini's
-	// AdoptByPrefix + SSH bootstrap blocks the worker for ~50 min, so
+	// AdoptFromPool + SSH bootstrap blocks the worker for ~50 min, so
 	// N machines take N × that wall-clock. Reconciles for the same
 	// machine are still serialized by controller-runtime's per-key
 	// locking — bumping this only parallelizes across distinct CRs.
@@ -185,7 +185,7 @@ type ScalewayAppleSiliconMachineReconciler struct {
 // variable that Go has already evaluated for the return — the defer
 // would silently swallow the patch failure and the function would
 // report success, leaving Status.ServerID unpersisted after a
-// successful AdoptByPrefix and letting the next reconcile claim a
+// successful AdoptFromPool and letting the next reconcile claim a
 // second Mac mini from the pool.
 func (r *ScalewayAppleSiliconMachineReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, err error) {
 	logger := log.FromContext(ctx).WithValues("machine", req.NamespacedName)
@@ -256,7 +256,7 @@ func (r *ScalewayAppleSiliconMachineReconciler) Reconcile(ctx context.Context, r
 	// spec.ProviderID before a `kubectl delete` (e.g. to release a CR
 	// without releasing its underlying Scaleway server — the
 	// duplicate-claim recovery dance), the reconciler must NOT see the
-	// transient "fresh CR" shape and run AdoptByPrefix against the pool
+	// transient "fresh CR" shape and run AdoptFromPool against the pool
 	// in between. Set the annotation first, patch second, delete
 	// third; the annotation latches reconcileNormal off until the
 	// DeletionTimestamp lands and reconcileDelete (which runs above,
@@ -360,7 +360,7 @@ func (r *ScalewayAppleSiliconMachineReconciler) reconcileNormal(
 	}
 	if bootstrapCreds == nil {
 		// Stage 1 didn't write the Secret yet (fresh CR mid-reconcile,
-		// or operator pod that crashed between AdoptByPrefix + Secret
+		// or operator pod that crashed between AdoptFromPool + Secret
 		// write). Requeue.
 		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 	}
@@ -880,7 +880,7 @@ func (r *ScalewayAppleSiliconMachineReconciler) acquireServer(
 	r.Recorder.Eventf(machine, corev1.EventTypeNormal, "Adopting",
 		"Searching pool %q for an unclaimed %s Mac mini in zone %s",
 		machine.Spec.AdoptPoolPrefix, machine.Spec.Type, machine.Spec.Zone)
-	srv, err := r.ScalewayClient.AdoptByPrefix(
+	srv, err := r.ScalewayClient.AdoptFromPool(
 		ctx,
 		machine.Name,
 		machine.Spec.Zone,
@@ -903,7 +903,7 @@ func (r *ScalewayAppleSiliconMachineReconciler) acquireServer(
 		conditions.MarkFalse(machine, ProvisionedCondition, "ScalewayAdoptFailed",
 			clusterv1.ConditionSeverityError, "%v", err)
 		r.Recorder.Eventf(machine, corev1.EventTypeWarning, "ProvisioningFailed",
-			"Scaleway AdoptByPrefix: %v", err)
+			"Scaleway AdoptFromPool: %v", err)
 		return nil, 30 * time.Second, err
 	}
 	r.Recorder.Eventf(machine, corev1.EventTypeNormal, "Adopted",

--- a/infra/cluster-api-provider-scaleway-applesilicon/controllers/scalewayapplesiliconmachine_controller_test.go
+++ b/infra/cluster-api-provider-scaleway-applesilicon/controllers/scalewayapplesiliconmachine_controller_test.go
@@ -246,7 +246,7 @@ func TestReconcile_PausedAnnotationSkipsAdoption(t *testing.T) {
 		t.Fatalf("paused CR must not be requeued; got %+v", result)
 	}
 
-	// Status should be untouched — no AdoptByPrefix means no phase
+	// Status should be untouched — no AdoptFromPool means no phase
 	// transition into Adopting / Provisioning.
 	got := &infrav1.ScalewayAppleSiliconMachine{}
 	if err := r.Get(context.Background(), types.NamespacedName{Name: "m1", Namespace: "ns"}, got); err != nil {

--- a/infra/cluster-api-provider-scaleway-applesilicon/controllers/scalewayapplesiliconmachine_controller_test.go
+++ b/infra/cluster-api-provider-scaleway-applesilicon/controllers/scalewayapplesiliconmachine_controller_test.go
@@ -483,88 +483,23 @@ func TestReconcileTailscaleEgressService_IdempotentAndPreservesOperatorRewrite(t
 	}
 }
 
-// --- release policy --------------------------------------------------------
+// --- reconcileDelete -------------------------------------------------------
 //
-// shouldReleaseToPool decides whether reconcileDelete returns the
-// Scaleway server to the adopt pool (rename + reinstall) or
-// physically terminates it. The contract:
-//
-//   - Pool-adopted Machine, no annotation → pool (default).
-//   - Pool-adopted Machine, `release-policy: terminate` → terminate
-//     (operator opt-out for broken hosts that shouldn't re-adopt).
-//   - Auto-order Machine (no AdoptPoolPrefix) → always terminate;
-//     there's no pool to return to and the annotation is ignored.
-//   - Unknown / empty annotation value → default (pool when
-//     AdoptPoolPrefix set, terminate otherwise).
-
-func TestShouldReleaseToPool_PoolAdoptedDefault(t *testing.T) {
-	m := &infrav1.ScalewayAppleSiliconMachine{
-		Spec: infrav1.ScalewayAppleSiliconMachineSpec{AdoptPoolPrefix: "tuist-pool-"},
-	}
-	if !shouldReleaseToPool(m) {
-		t.Fatal("pool-adopted Machine with no annotation should default to pool release")
-	}
-}
-
-func TestShouldReleaseToPool_PoolAdoptedTerminateOptOut(t *testing.T) {
-	m := &infrav1.ScalewayAppleSiliconMachine{
-		ObjectMeta: metav1.ObjectMeta{
-			Annotations: map[string]string{ReleasePolicyAnnotation: ReleasePolicyTerminate},
-		},
-		Spec: infrav1.ScalewayAppleSiliconMachineSpec{AdoptPoolPrefix: "tuist-pool-"},
-	}
-	if shouldReleaseToPool(m) {
-		t.Fatal("terminate annotation should force the physical-delete path")
-	}
-}
-
-func TestShouldReleaseToPool_AutoOrderAlwaysTerminate(t *testing.T) {
-	// AdoptPoolPrefix empty: there's nowhere to return the host to,
-	// so even an explicit `release-policy: pool` annotation falls
-	// back to terminate.
-	m := &infrav1.ScalewayAppleSiliconMachine{
-		ObjectMeta: metav1.ObjectMeta{
-			Annotations: map[string]string{ReleasePolicyAnnotation: ReleasePolicyPool},
-		},
-		Spec: infrav1.ScalewayAppleSiliconMachineSpec{AdoptPoolPrefix: ""},
-	}
-	if shouldReleaseToPool(m) {
-		t.Fatal("auto-order Machine has no pool; must always terminate regardless of annotation")
-	}
-}
-
-func TestShouldReleaseToPool_UnknownAnnotationFallsThroughToDefault(t *testing.T) {
-	m := &infrav1.ScalewayAppleSiliconMachine{
-		ObjectMeta: metav1.ObjectMeta{
-			Annotations: map[string]string{ReleasePolicyAnnotation: "garbage"},
-		},
-		Spec: infrav1.ScalewayAppleSiliconMachineSpec{AdoptPoolPrefix: "tuist-pool-"},
-	}
-	if !shouldReleaseToPool(m) {
-		t.Fatal("unknown annotation value should not flip the default; pool-adopted defaults to pool")
-	}
-}
-
-// --- reconcileDelete branching -------------------------------------------
-//
-// End-to-end check that reconcileDelete actually calls
-// ScalewayClient.ReleaseToPool for pool-adopted Machines and
-// ScalewayClient.DeleteServer for the terminate-annotated case. Uses
-// a real *scaleway.Client backed by a minimal in-memory API so the
-// recorded side-effects (rename + reinstall vs delete) are visible.
+// End-to-end check that reconcileDelete always returns the Scaleway
+// server to the pool via ReleaseToPool. Uses a real *scaleway.Client
+// backed by a minimal in-memory API so the recorded side-effects
+// (rename + reinstall) are visible.
 
 // scalewayAPIStub is a tiny implementation of
 // scaleway.AppleSiliconAPI sufficient for the deletion path. Every
 // method we don't care about returns an error so an unexpected call
 // is loud in test output rather than silently doing nothing.
 type scalewayAPIStub struct {
-	servers         []*applesilicon.Server
-	updateCalls     int
-	updatedNames    []string
-	deletedIDs      []string
-	reinstalledIDs  []string
-	reinstallErrors map[int]error
-	reinstallCalls  int
+	servers        []*applesilicon.Server
+	updateCalls    int
+	updatedNames   []string
+	reinstalledIDs []string
+	reinstallCalls int
 }
 
 func (f *scalewayAPIStub) ListServers(*applesilicon.ListServersRequest, ...scw.RequestOption) (*applesilicon.ListServersResponse, error) {
@@ -594,20 +529,8 @@ func (f *scalewayAPIStub) UpdateServer(req *applesilicon.UpdateServerRequest, _ 
 	return nil, errors.New("not found")
 }
 
-func (f *scalewayAPIStub) CreateServer(*applesilicon.CreateServerRequest, ...scw.RequestOption) (*applesilicon.Server, error) {
-	return nil, errors.New("CreateServer not implemented in stub")
-}
-
-func (f *scalewayAPIStub) DeleteServer(req *applesilicon.DeleteServerRequest, _ ...scw.RequestOption) error {
-	f.deletedIDs = append(f.deletedIDs, req.ServerID)
-	return nil
-}
-
 func (f *scalewayAPIStub) ReinstallServer(req *applesilicon.ReinstallServerRequest, _ ...scw.RequestOption) (*applesilicon.Server, error) {
 	f.reinstallCalls++
-	if err, ok := f.reinstallErrors[f.reinstallCalls]; ok {
-		return nil, err
-	}
 	for _, s := range f.servers {
 		if s.ID == req.ServerID {
 			f.reinstalledIDs = append(f.reinstalledIDs, s.ID)
@@ -617,15 +540,7 @@ func (f *scalewayAPIStub) ReinstallServer(req *applesilicon.ReinstallServerReque
 	return nil, errors.New("not found")
 }
 
-func (f *scalewayAPIStub) WaitForServer(*applesilicon.WaitForServerRequest, ...scw.RequestOption) (*applesilicon.Server, error) {
-	return nil, errors.New("WaitForServer not implemented in stub")
-}
-
-func (f *scalewayAPIStub) ListOS(*applesilicon.ListOSRequest, ...scw.RequestOption) (*applesilicon.ListOSResponse, error) {
-	return nil, errors.New("ListOS not implemented in stub")
-}
-
-func TestReconcileDelete_PoolAdoptedReleasesToPool(t *testing.T) {
+func TestReconcileDelete_ReleasesToPool(t *testing.T) {
 	api := &scalewayAPIStub{
 		servers: []*applesilicon.Server{{ID: "srv-1", Name: "tuist-tuist-macos-fleet-0"}},
 	}
@@ -648,9 +563,6 @@ func TestReconcileDelete_PoolAdoptedReleasesToPool(t *testing.T) {
 		t.Fatalf("reconcileDelete: %v", err)
 	}
 
-	if len(api.deletedIDs) != 0 {
-		t.Fatalf("pool-adopted delete must NOT call DeleteServer; got deletes for %v", api.deletedIDs)
-	}
 	if got := api.reinstalledIDs; len(got) != 1 || got[0] != "srv-1" {
 		t.Fatalf("expected ReinstallServer call for srv-1, got %v", got)
 	}
@@ -659,72 +571,6 @@ func TestReconcileDelete_PoolAdoptedReleasesToPool(t *testing.T) {
 	}
 	if machine.Status.ServerID != "" {
 		t.Fatalf("Status.ServerID should be cleared after release, got %q", machine.Status.ServerID)
-	}
-}
-
-func TestReconcileDelete_TerminateAnnotationFallsBackToDeleteServer(t *testing.T) {
-	api := &scalewayAPIStub{
-		servers: []*applesilicon.Server{{ID: "srv-2", Name: "tuist-tuist-macos-fleet-1"}},
-	}
-	machine := &infrav1.ScalewayAppleSiliconMachine{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        "macos-fleet-1",
-			Namespace:   "ns",
-			Finalizers:  []string{MachineFinalizer},
-			Annotations: map[string]string{ReleasePolicyAnnotation: ReleasePolicyTerminate},
-		},
-		Spec: infrav1.ScalewayAppleSiliconMachineSpec{
-			AdoptPoolPrefix: "tuist-pool-",
-			Zone:            "fr-par-1",
-		},
-		Status: infrav1.ScalewayAppleSiliconMachineStatus{ServerID: "srv-2"},
-	}
-	r := newReconciler(t)
-	r.ScalewayClient = &scaleway.Client{API: api}
-
-	if _, err := r.reconcileDelete(context.Background(), machine); err != nil {
-		t.Fatalf("reconcileDelete: %v", err)
-	}
-
-	if got := api.deletedIDs; len(got) != 1 || got[0] != "srv-2" {
-		t.Fatalf("expected DeleteServer call for srv-2, got %v", got)
-	}
-	if len(api.reinstalledIDs) != 0 {
-		t.Fatalf("terminate path must NOT reinstall; got reinstalls for %v", api.reinstalledIDs)
-	}
-	if len(api.updatedNames) != 0 {
-		t.Fatalf("terminate path must NOT rename; got renames %v", api.updatedNames)
-	}
-}
-
-func TestReconcileDelete_AutoOrderUsesDeleteServer(t *testing.T) {
-	api := &scalewayAPIStub{
-		servers: []*applesilicon.Server{{ID: "srv-3", Name: "tuist-tuist-macos-fleet-2"}},
-	}
-	machine := &infrav1.ScalewayAppleSiliconMachine{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:       "macos-fleet-2",
-			Namespace:  "ns",
-			Finalizers: []string{MachineFinalizer},
-		},
-		Spec: infrav1.ScalewayAppleSiliconMachineSpec{
-			// AdoptPoolPrefix empty → auto-order, no pool to return to.
-			Zone: "fr-par-1",
-		},
-		Status: infrav1.ScalewayAppleSiliconMachineStatus{ServerID: "srv-3"},
-	}
-	r := newReconciler(t)
-	r.ScalewayClient = &scaleway.Client{API: api}
-
-	if _, err := r.reconcileDelete(context.Background(), machine); err != nil {
-		t.Fatalf("reconcileDelete: %v", err)
-	}
-
-	if got := api.deletedIDs; len(got) != 1 || got[0] != "srv-3" {
-		t.Fatalf("auto-order Machine should DeleteServer, got %v", got)
-	}
-	if len(api.reinstalledIDs) != 0 {
-		t.Fatalf("auto-order Machine must NOT reinstall; got %v", api.reinstalledIDs)
 	}
 }
 

--- a/infra/cluster-api-provider-scaleway-applesilicon/controllers/scalewayapplesiliconmachine_controller_test.go
+++ b/infra/cluster-api-provider-scaleway-applesilicon/controllers/scalewayapplesiliconmachine_controller_test.go
@@ -574,6 +574,51 @@ func TestReconcileDelete_ReleasesToPool(t *testing.T) {
 	}
 }
 
+// TestReconcileDelete_LegacyCRWithoutPrefixSkipsRelease covers the
+// compatibility path for CRs created under the older chart that only
+// rendered `adoptPoolPrefix` when the value was non-empty. Those
+// objects can't safely ReleaseToPool (the client refuses an empty
+// prefix to avoid orphaning hosts outside the pool namespace), so
+// the controller skips Stage 1 and proceeds to the rest of the
+// teardown. Without this fallthrough, deleting a legacy CR would
+// loop forever and block fleet shrinkage.
+func TestReconcileDelete_LegacyCRWithoutPrefixSkipsRelease(t *testing.T) {
+	api := &scalewayAPIStub{
+		servers: []*applesilicon.Server{{ID: "srv-legacy", Name: "tuist-tuist-macos-fleet-legacy"}},
+	}
+	machine := &infrav1.ScalewayAppleSiliconMachine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "macos-fleet-legacy",
+			Namespace:  "ns",
+			Finalizers: []string{MachineFinalizer},
+		},
+		Spec: infrav1.ScalewayAppleSiliconMachineSpec{
+			// Empty AdoptPoolPrefix — predates the required-prefix contract.
+			Zone: "fr-par-1",
+		},
+		Status: infrav1.ScalewayAppleSiliconMachineStatus{ServerID: "srv-legacy"},
+	}
+	r := newReconciler(t)
+	r.ScalewayClient = &scaleway.Client{API: api}
+
+	result, err := r.reconcileDelete(context.Background(), machine)
+	if err != nil {
+		t.Fatalf("reconcileDelete: %v", err)
+	}
+	if result.RequeueAfter != 0 || result.Requeue {
+		t.Fatalf("legacy CR delete must not requeue; got %+v", result)
+	}
+	if len(api.reinstalledIDs) != 0 {
+		t.Fatalf("legacy CR must NOT trigger Scaleway release; got reinstalls for %v", api.reinstalledIDs)
+	}
+	if len(api.updatedNames) != 0 {
+		t.Fatalf("legacy CR must NOT rename the server; got %v", api.updatedNames)
+	}
+	if machine.Status.ServerID != "" {
+		t.Fatalf("Status.ServerID should be cleared even when release is skipped, got %q", machine.Status.ServerID)
+	}
+}
+
 func startsWith(s, prefix string) bool {
 	return len(s) >= len(prefix) && s[:len(prefix)] == prefix
 }

--- a/infra/cluster-api-provider-scaleway-applesilicon/internal/credentials/machine.go
+++ b/infra/cluster-api-provider-scaleway-applesilicon/internal/credentials/machine.go
@@ -54,7 +54,7 @@ type MachineBootstrap struct {
 }
 
 // GetMachineBootstrap reads the Secret. Returns (nil, nil) if it doesn't
-// exist yet — the Stage 1 reconcile call writes it after CreateServer.
+// exist yet — the Stage 1 reconcile call writes it after AdoptByPrefix.
 func (m *Manager) GetMachineBootstrap(ctx context.Context, machineName string) (*MachineBootstrap, error) {
 	secret := &corev1.Secret{}
 	err := m.Client.Get(ctx, types.NamespacedName{Namespace: m.Namespace, Name: machineName + machineBootstrapSecretSuffix}, secret)

--- a/infra/cluster-api-provider-scaleway-applesilicon/internal/credentials/machine.go
+++ b/infra/cluster-api-provider-scaleway-applesilicon/internal/credentials/machine.go
@@ -54,7 +54,7 @@ type MachineBootstrap struct {
 }
 
 // GetMachineBootstrap reads the Secret. Returns (nil, nil) if it doesn't
-// exist yet — the Stage 1 reconcile call writes it after AdoptByPrefix.
+// exist yet — the Stage 1 reconcile call writes it after AdoptFromPool.
 func (m *Manager) GetMachineBootstrap(ctx context.Context, machineName string) (*MachineBootstrap, error) {
 	secret := &corev1.Secret{}
 	err := m.Client.Get(ctx, types.NamespacedName{Namespace: m.Namespace, Name: machineName + machineBootstrapSecretSuffix}, secret)

--- a/infra/cluster-api-provider-scaleway-applesilicon/internal/scaleway/client.go
+++ b/infra/cluster-api-provider-scaleway-applesilicon/internal/scaleway/client.go
@@ -36,14 +36,10 @@ const claimPendingPrefix = "tuist-claim-pending-"
 // SDK + HTTP client. The concrete `*applesilicon.API` satisfies it
 // via Go's structural typing — no adapter required.
 type AppleSiliconAPI interface {
-	CreateServer(req *applesilicon.CreateServerRequest, opts ...scw.RequestOption) (*applesilicon.Server, error)
 	GetServer(req *applesilicon.GetServerRequest, opts ...scw.RequestOption) (*applesilicon.Server, error)
 	ListServers(req *applesilicon.ListServersRequest, opts ...scw.RequestOption) (*applesilicon.ListServersResponse, error)
 	UpdateServer(req *applesilicon.UpdateServerRequest, opts ...scw.RequestOption) (*applesilicon.Server, error)
-	DeleteServer(req *applesilicon.DeleteServerRequest, opts ...scw.RequestOption) error
 	ReinstallServer(req *applesilicon.ReinstallServerRequest, opts ...scw.RequestOption) (*applesilicon.Server, error)
-	WaitForServer(req *applesilicon.WaitForServerRequest, opts ...scw.RequestOption) (*applesilicon.Server, error)
-	ListOS(req *applesilicon.ListOSRequest, opts ...scw.RequestOption) (*applesilicon.ListOSResponse, error)
 }
 
 // Client talks to Scaleway's Apple Silicon + IAM APIs. Construct with
@@ -187,62 +183,6 @@ type Server struct {
 	Status       string
 	SudoPassword string
 	SSHUsername  string
-}
-
-// CreateServer orders a new Mac mini in `zone`. Blocks until Scaleway
-// reports the server in a state past `starting`. The returned struct
-// includes the one-time OS-default sudo password the controller stashes
-// for break-glass SSH access; it isn't persisted in Scaleway after the
-// initial provisioning window.
-//
-// Idempotent on `name`: if a server with the given name already exists
-// in the project we adopt it instead of creating a duplicate. This
-// matters because CreateServer + WaitForServer can take 3-5min total,
-// long enough for the parent reconcile context to time out and trigger
-// a retry that would otherwise re-call CreateServer (and burn another
-// 24h of Apple licensing on a server we won't end up using).
-func (c *Client) CreateServer(ctx context.Context, name, zone, serverType, osName string) (*Server, error) {
-	if existing, err := c.findServerByName(ctx, name, zone); err != nil {
-		return nil, fmt.Errorf("lookup existing server: %w", err)
-	} else if existing != nil {
-		// Adopt the in-flight server. WaitForServer is idempotent — it
-		// just polls until state==ready, fine to call on a server that
-		// already finished provisioning.
-		final, err := c.API.WaitForServer(&applesilicon.WaitForServerRequest{
-			ServerID: existing.ID,
-			Zone:     scw.Zone(zone),
-		}, scw.WithContext(ctx))
-		if err != nil {
-			return nil, fmt.Errorf("wait for existing server: %w", err)
-		}
-		return scalewayServerToServer(final), nil
-	}
-
-	osID, err := c.resolveOSID(ctx, zone, osName)
-	if err != nil {
-		return nil, err
-	}
-
-	created, err := c.API.CreateServer(&applesilicon.CreateServerRequest{
-		Zone: scw.Zone(zone),
-		Name: name,
-		Type: serverType,
-		OsID: &osID,
-	}, scw.WithContext(ctx))
-	if err != nil {
-		return nil, fmt.Errorf("create server: %w", err)
-	}
-
-	// Wait for the server to be ready (Scaleway calls this `ready`).
-	final, err := c.API.WaitForServer(&applesilicon.WaitForServerRequest{
-		ServerID: created.ID,
-		Zone:     scw.Zone(zone),
-	}, scw.WithContext(ctx))
-	if err != nil {
-		return nil, fmt.Errorf("wait for server: %w", err)
-	}
-
-	return scalewayServerToServer(final), nil
 }
 
 // findServerByName returns the first server in the zone whose name
@@ -477,56 +417,15 @@ func (c *Client) GetServer(ctx context.Context, id, zone string) (*Server, error
 	return scalewayServerToServer(srv), nil
 }
 
-// DeleteServer terminates a Mac mini. Apple's licensing enforces a
-// 24h floor — DeleteServer fails with HTTP 412 inside that window.
-// When that happens we fall back to UpdateServer with
-// `schedule_deletion=true`, which queues the delete for the floor
-// expiry. Scaleway keeps billing through the floor either way.
-//
-// 404 from Scaleway means the server is already gone (manual delete,
-// scheduled-deletion already executed, or a previous reconcile that
-// completed but crashed before the patch landed). Treated as success
-// so the finalizer comes off and the CR can be GC'd; without this the
-// reconcile loops forever and the Mac mini billing keeps running on
-// any sibling server we haven't pruned.
-func (c *Client) DeleteServer(ctx context.Context, id, zone string) error {
-	err := c.API.DeleteServer(&applesilicon.DeleteServerRequest{
-		ServerID: id,
-		Zone:     scw.Zone(zone),
-	}, scw.WithContext(ctx))
-	if err == nil {
-		return nil
-	}
-	if IsNotFound(err) {
-		return nil
-	}
-	if !isPreconditionFailed(err) {
-		return err
-	}
-	scheduled := true
-	_, updateErr := c.API.UpdateServer(&applesilicon.UpdateServerRequest{
-		ServerID:         id,
-		Zone:             scw.Zone(zone),
-		ScheduleDeletion: &scheduled,
-	}, scw.WithContext(ctx))
-	if updateErr != nil {
-		if IsNotFound(updateErr) {
-			return nil
-		}
-		return fmt.Errorf("schedule deletion (after immediate delete failed with %v): %w", err, updateErr)
-	}
-	return nil
-}
-
-// ReleaseToPool returns a Mac mini to the adopt pool instead of
-// physically terminating it. Operator-driven physical destruction
-// is intentionally separated from cluster-driven Machine churn: the
-// 24h Apple-licensing floor makes destroy-and-recreate wildly
-// expensive (you pay for the floor regardless of whether the host is
-// in your cluster), and the operator already owns host capacity
-// planning via the pre-order workflow. So "Machine deleted" should
-// mean "host returned to the pool, freshly reinstalled, ready for
-// the next adopt" — not "Scaleway DeleteServer fires."
+// ReleaseToPool returns a Mac mini to the adopt pool. Operator-
+// driven physical destruction is intentionally separated from
+// cluster-driven Machine churn: the 24h Apple-licensing floor makes
+// destroy-and-recreate wildly expensive (you pay for the floor
+// regardless of whether the host is in your cluster), and the
+// operator already owns host capacity planning via the pre-order
+// workflow. So "Machine deleted" means "host returned to the pool,
+// freshly reinstalled, ready for the next adopt." Operators
+// retiring a broken host do so out-of-band via the Scaleway console.
 //
 // Two-step:
 //
@@ -554,10 +453,6 @@ func (c *Client) DeleteServer(ctx context.Context, id, zone string) error {
 // TransientStateError if the server is already mid-reinstall from a
 // previous attempt; we swallow it as success. 404 on either step
 // means the operator deleted the host out-of-band; also success.
-//
-// Callers that want the legacy physical-terminate semantics — for
-// broken hosts that must not be re-adopted — should call
-// DeleteServer directly and skip this entry point.
 func (c *Client) ReleaseToPool(ctx context.Context, id, zone, poolPrefix string) error {
 	if poolPrefix == "" {
 		return fmt.Errorf("ReleaseToPool: poolPrefix is required")
@@ -598,37 +493,12 @@ func (c *Client) ReleaseToPool(ctx context.Context, id, zone, poolPrefix string)
 // isTransientState detects scaleway-sdk-go's typed
 // `*scw.TransientStateError`, which the SDK returns when a request
 // can't proceed because the resource is in a transitional phase
-// (`reinstalling`, `deleting`, …). Same shape consideration as
-// isPreconditionFailed: this is parsed into its own concrete type
-// inside hasResponseError, so checking *ResponseError alone misses
-// it.
+// (`reinstalling`, `deleting`, …). The SDK parses this into its own
+// concrete type inside hasResponseError, so checking *ResponseError
+// alone misses it.
 func isTransientState(err error) bool {
 	var transientErr *scw.TransientStateError
 	return errors.As(err, &transientErr)
-}
-
-// isPreconditionFailed detects Scaleway's HTTP 412 — typically the
-// 24h Apple-licensing floor on DeleteServer.
-//
-// The SDK parses standard error types into their own concrete types
-// (PreconditionFailedError, ResourceNotFoundError, …) inside
-// hasResponseError before they reach us; the generic ResponseError is
-// only returned for unparsed responses (non-JSON body, unknown error
-// type). Match both so DeleteServer's schedule-deletion fallback
-// actually fires — otherwise the controller loops DeleteServer every
-// 60 s for the multi-week Apple billing floor while the
-// MachineDeployment sits at 0 available, wedging every helm upgrade
-// that gates on it.
-func isPreconditionFailed(err error) bool {
-	var preconditionErr *scw.PreconditionFailedError
-	if errors.As(err, &preconditionErr) {
-		return true
-	}
-	var scwErr *scw.ResponseError
-	if errors.As(err, &scwErr) {
-		return scwErr.StatusCode == http.StatusPreconditionFailed
-	}
-	return false
 }
 
 // IsNotFound returns true for Scaleway's 404 responses. Exposed so the
@@ -649,21 +519,6 @@ func IsNotFound(err error) bool {
 	return false
 }
 
-func (c *Client) resolveOSID(ctx context.Context, zone, name string) (string, error) {
-	resp, err := c.API.ListOS(&applesilicon.ListOSRequest{
-		Zone: scw.Zone(zone),
-	}, scw.WithContext(ctx))
-	if err != nil {
-		return "", fmt.Errorf("list OS: %w", err)
-	}
-	for _, os := range resp.Os {
-		if os.Name == name {
-			return os.ID, nil
-		}
-	}
-	return "", fmt.Errorf("OS %q not found in zone %s", name, zone)
-}
-
 func scalewayServerToServer(s *applesilicon.Server) *Server {
 	out := &Server{
 		ID:           s.ID,
@@ -674,21 +529,19 @@ func scalewayServerToServer(s *applesilicon.Server) *Server {
 	if s.IP != nil {
 		out.IP = s.IP.String()
 	}
-	// Scaleway only populates `sudo_password` on the CreateServer
-	// response — once that one-time window closes, every subsequent
-	// GET/list returns an empty `sudo_password`. Hosts adopted from
-	// the pre-ordered pool never go through CreateServer, so without
-	// this fallback the controller stages an empty password into the
-	// bootstrap Secret and `enableAutoLogin` either silently skips
-	// (writing nothing) or writes a kcpassword whose plaintext is
-	// just the cipher key padding — either way Aqua never comes up
-	// and `tart run` fails forever.
+	// Scaleway never surfaces `sudo_password` on GET/list responses
+	// for pool-adopted hosts (the field is only populated on the
+	// one-time CreateServer response, and the pool workflow never
+	// hits that path). Without a fallback the controller stages an
+	// empty password into the bootstrap Secret and `enableAutoLogin`
+	// either silently skips (writing nothing) or writes a kcpassword
+	// whose plaintext is just the cipher key padding — either way
+	// Aqua never comes up and `tart run` fails forever.
 	//
 	// The `vnc_url` field embeds the same OS-default credentials as
 	// `vnc://<ssh_username>:<password>@<ip>:<port>`. It's surfaced on
-	// every GET, including for adopted servers, and verified out-of-
-	// band to authenticate the m1 macOS user. Pull the password from
-	// there when `sudo_password` is empty.
+	// every GET and verified out-of-band to authenticate the m1
+	// macOS user; pull the password from there.
 	if out.SudoPassword == "" {
 		out.SudoPassword = passwordFromVncURL(s.VncURL)
 	}

--- a/infra/cluster-api-provider-scaleway-applesilicon/internal/scaleway/client.go
+++ b/infra/cluster-api-provider-scaleway-applesilicon/internal/scaleway/client.go
@@ -24,7 +24,7 @@ import (
 
 // claimPendingPrefix marks a server that's mid-adoption — it has been
 // renamed out of the operator's pool prefix but not yet to the final
-// per-Machine `claimName`. Used by AdoptByPrefix's two-phase claim to
+// per-Machine `claimName`. Used by AdoptFromPool's two-phase claim to
 // detect race losers (their pending name has been overwritten by
 // someone else's) and to let subsequent reconciles re-adopt orphans
 // from a controller crash between the two phases.
@@ -59,7 +59,7 @@ type Client struct {
 	// org-wide list and Scaleway returns "insufficient permissions".
 	DefaultProjectID string
 
-	// adoptMu serializes AdoptByPrefix across all goroutines in this
+	// adoptMu serializes AdoptFromPool across all goroutines in this
 	// process. Scaleway's UpdateServer is not conditional — two
 	// concurrent rename calls against the same server both succeed,
 	// last-write-wins — so per-call optimistic read-after-write
@@ -214,7 +214,7 @@ func (c *Client) findServerByName(ctx context.Context, name, zone string) (*appl
 	}
 }
 
-// ErrNoAvailableHost is returned by AdoptByPrefix when no
+// ErrNoAvailableHost is returned by AdoptFromPool when no
 // pre-ordered server in the project carries the configured pool
 // prefix AND matches the requested spec (`type`/`os`/`zone`).
 // Scaleway Mac mini lead times rule out auto-ordering on the hot
@@ -223,7 +223,7 @@ func (c *Client) findServerByName(ctx context.Context, name, zone string) (*appl
 // more capacity.
 var ErrNoAvailableHost = errors.New("no available Apple Silicon host in pool")
 
-// AdoptByPrefix claims a pre-ordered server in `zone` whose
+// AdoptFromPool claims a pre-ordered server in `zone` whose
 // Scaleway-side name starts with `poolPrefix`, matches
 // (`serverType`, `osName`), and is `Delivered=true` +
 // `Status=ready`. The rename to `claimName` IS the claim — it both
@@ -264,7 +264,7 @@ var ErrNoAvailableHost = errors.New("no available Apple Silicon host in pool")
 // Why a rename and not a Scaleway tag? The Apple Silicon API
 // doesn't expose tags. Naming is the only mutable, queryable
 // signal we have.
-func (c *Client) AdoptByPrefix(ctx context.Context, claimName, zone, serverType, osName, poolPrefix string) (*Server, error) {
+func (c *Client) AdoptFromPool(ctx context.Context, claimName, zone, serverType, osName, poolPrefix string) (*Server, error) {
 	if poolPrefix == "" {
 		return nil, fmt.Errorf("poolPrefix is required for adoption")
 	}
@@ -338,7 +338,7 @@ func (c *Client) AdoptByPrefix(ctx context.Context, claimName, zone, serverType,
 }
 
 // tryTwoPhaseClaim attempts to claim `serverID` via the two-phase
-// rename described in AdoptByPrefix.
+// rename described in AdoptFromPool.
 //
 // Returns:
 //
@@ -433,15 +433,15 @@ func (c *Client) GetServer(ctx context.Context, id, zone string) (*Server, error
 //     UpdateServer. The new name is `poolPrefix + uuid` — a fresh
 //     UUID so we don't collide with any other pool host that's been
 //     parked at the same name earlier in the host's lifetime, and
-//     because AdoptByPrefix scans on the prefix (the exact suffix
+//     because AdoptFromPool scans on the prefix (the exact suffix
 //     doesn't matter). Once renamed, the host is invisible to
 //     `findServerByName(claimName)` lookups (the per-Machine name
-//     is gone) and visible to future `AdoptByPrefix` scans.
+//     is gone) and visible to future `AdoptFromPool` scans.
 //
 //  2. Trigger ReinstallServer, which wipes the disk and reimages
 //     with the server type's default OS. Async on Scaleway's side
 //     (~5-15 min on M2-L); we fire-and-forget because
-//     AdoptByPrefix already filters on `Delivered + Status == Ready`
+//     AdoptFromPool already filters on `Delivered + Status == Ready`
 //     and the host transitions through `reinstalling → ready` on
 //     its own. Means: next adopt sees factory-default state — no
 //     stale tart-kubelet config, no leftover Tailscale auth, no

--- a/infra/cluster-api-provider-scaleway-applesilicon/internal/scaleway/client_test.go
+++ b/infra/cluster-api-provider-scaleway-applesilicon/internal/scaleway/client_test.go
@@ -61,7 +61,7 @@ func TestScalewayServerToServer_FallsBackToVncURLWhenSudoPasswordEmpty(t *testin
 	// Adopted servers come back from list/GET with an empty
 	// SudoPassword; the controller needs a real password to stage
 	// kcpassword. The vnc_url embeds the same OS-default credentials
-	// and is the only surface that survives past CreateServer.
+	// and is the surface AdoptByPrefix reads them from.
 	in := &applesilicon.Server{
 		ID:           "server-id",
 		Status:       applesilicon.ServerStatusReady,
@@ -76,18 +76,17 @@ func TestScalewayServerToServer_FallsBackToVncURLWhenSudoPasswordEmpty(t *testin
 }
 
 func TestScalewayServerToServer_PrefersAPISudoPasswordWhenSet(t *testing.T) {
-	// CreateServer responses populate SudoPassword directly. The vnc
-	// fallback must not override that — if the API gave us a value,
-	// it's the authoritative one.
+	// If Scaleway surfaces a non-empty SudoPassword on the response,
+	// it's authoritative and the vnc fallback must not override it.
 	in := &applesilicon.Server{
 		ID:           "server-id",
 		Status:       applesilicon.ServerStatusReady,
-		SudoPassword: "fromCreate",
+		SudoPassword: "fromAPI",
 		SSHUsername:  "m1",
 		VncURL:       "vnc://m1:fromVNC@host:59010",
 	}
 	out := scalewayServerToServer(in)
-	if out.SudoPassword != "fromCreate" {
+	if out.SudoPassword != "fromAPI" {
 		t.Fatalf("expected primary SudoPassword to win, got %q", out.SudoPassword)
 	}
 }
@@ -143,18 +142,6 @@ type fakeAppleSiliconAPI struct {
 	getErrors    map[int]error
 	getCalls     int
 
-	// deleteErrors maps `<call-index> -> error` for DeleteServer; an
-	// absent / nil entry returns success (Scaleway accepts the
-	// immediate delete). Lets the precondition-fallback tests force
-	// the typed scw.PreconditionFailedError that the SDK returns for
-	// a server still inside its 24h Apple-licensing floor, then
-	// observe the schedule-deletion UpdateServer call that should
-	// follow.
-	deleteErrors map[int]error
-	deleteCalls  int
-	deletedIDs   []string
-	scheduledIDs []string
-
 	// reinstallErrors maps `<call-index> -> error` for ReinstallServer;
 	// an absent / nil entry returns success and appends to
 	// reinstalledIDs. ReleaseToPool tests use this to force the
@@ -202,26 +189,10 @@ func (f *fakeAppleSiliconAPI) UpdateServer(req *applesilicon.UpdateServerRequest
 			if req.Name != nil {
 				s.Name = *req.Name
 			}
-			if req.ScheduleDeletion != nil && *req.ScheduleDeletion {
-				f.scheduledIDs = append(f.scheduledIDs, s.ID)
-			}
 			return s, nil
 		}
 	}
 	return nil, errors.New("not found")
-}
-
-func (f *fakeAppleSiliconAPI) CreateServer(*applesilicon.CreateServerRequest, ...scw.RequestOption) (*applesilicon.Server, error) {
-	return nil, errors.New("CreateServer not implemented in fake")
-}
-
-func (f *fakeAppleSiliconAPI) DeleteServer(req *applesilicon.DeleteServerRequest, _ ...scw.RequestOption) error {
-	f.deleteCalls++
-	if err, ok := f.deleteErrors[f.deleteCalls]; ok {
-		return err
-	}
-	f.deletedIDs = append(f.deletedIDs, req.ServerID)
-	return nil
 }
 
 func (f *fakeAppleSiliconAPI) ReinstallServer(req *applesilicon.ReinstallServerRequest, _ ...scw.RequestOption) (*applesilicon.Server, error) {
@@ -237,14 +208,6 @@ func (f *fakeAppleSiliconAPI) ReinstallServer(req *applesilicon.ReinstallServerR
 		}
 	}
 	return nil, errors.New("not found")
-}
-
-func (f *fakeAppleSiliconAPI) WaitForServer(*applesilicon.WaitForServerRequest, ...scw.RequestOption) (*applesilicon.Server, error) {
-	return nil, errors.New("WaitForServer not implemented in fake")
-}
-
-func (f *fakeAppleSiliconAPI) ListOS(*applesilicon.ListOSRequest, ...scw.RequestOption) (*applesilicon.ListOSResponse, error) {
-	return nil, errors.New("ListOS not implemented in fake")
 }
 
 // readyServer builds a server in the state AdoptByPrefix is willing
@@ -602,106 +565,6 @@ func TestAdoptByPrefix_Phase1VerifyNon404SurfacesError(t *testing.T) {
 	}
 }
 
-// --- DeleteServer fallback for the 24h billing floor ----------------------
-//
-// The SDK parses standard error types into their own concrete types
-// inside hasResponseError — a 412 with `"type": "precondition_failed"`
-// comes back as *scw.PreconditionFailedError, not as the generic
-// *scw.ResponseError. An earlier version of isPreconditionFailed only
-// checked the generic shape and so missed every real 412 the SDK
-// returned, leaving DeleteServer to loop on the Apple 24h floor while
-// the MachineDeployment sat at 0 available and gated every helm
-// upgrade behind it. These tests pin the wiring so the schedule-
-// deletion fallback actually fires.
-
-func TestDeleteServer_PreconditionFailedTriggersScheduleDeletion(t *testing.T) {
-	api := &fakeAppleSiliconAPI{
-		servers: []*applesilicon.Server{
-			readyServer("srv-1", "tuist-tuist-macos-fleet-0"),
-		},
-		deleteErrors: map[int]error{
-			1: &scw.PreconditionFailedError{Precondition: "unknown_precondition", HelpMessage: "this server cannot be deleted before 2026-06-12 07:06:59"},
-		},
-	}
-	c := newTestClient(api)
-
-	if err := c.DeleteServer(context.Background(), "srv-1", "fr-par-1"); err != nil {
-		t.Fatalf("DeleteServer: expected nil after schedule-deletion fallback, got %v", err)
-	}
-	if got := api.scheduledIDs; len(got) != 1 || got[0] != "srv-1" {
-		t.Fatalf("expected schedule-deletion UpdateServer call for srv-1, got %v", got)
-	}
-}
-
-func TestDeleteServer_ResponseError412AlsoTriggersScheduleDeletion(t *testing.T) {
-	// Unparsed 412 responses (non-JSON body or unknown error type) come
-	// back as the generic *scw.ResponseError. The wiring should still
-	// catch this path so the fallback isn't tied to one error shape.
-	api := &fakeAppleSiliconAPI{
-		servers: []*applesilicon.Server{
-			readyServer("srv-2", "tuist-tuist-macos-fleet-1"),
-		},
-		deleteErrors: map[int]error{
-			1: &scw.ResponseError{StatusCode: 412, Status: "412 Precondition Failed"},
-		},
-	}
-	c := newTestClient(api)
-
-	if err := c.DeleteServer(context.Background(), "srv-2", "fr-par-1"); err != nil {
-		t.Fatalf("DeleteServer: expected nil after schedule-deletion fallback, got %v", err)
-	}
-	if got := api.scheduledIDs; len(got) != 1 || got[0] != "srv-2" {
-		t.Fatalf("expected schedule-deletion UpdateServer call for srv-2, got %v", got)
-	}
-}
-
-func TestDeleteServer_PreconditionFallbackPropagatesNon404UpdateError(t *testing.T) {
-	api := &fakeAppleSiliconAPI{
-		servers: []*applesilicon.Server{
-			readyServer("srv-3", "tuist-tuist-macos-fleet-2"),
-		},
-		deleteErrors: map[int]error{
-			1: &scw.PreconditionFailedError{Precondition: "unknown_precondition"},
-		},
-		updateErrors: map[int]error{
-			1: errors.New("scaleway: 502 bad gateway"),
-		},
-	}
-	c := newTestClient(api)
-
-	err := c.DeleteServer(context.Background(), "srv-3", "fr-par-1")
-	if err == nil {
-		t.Fatalf("expected schedule-deletion failure to be surfaced")
-	}
-	if !strings.Contains(err.Error(), "schedule deletion") {
-		t.Fatalf("expected error to identify the schedule-deletion fallback, got %v", err)
-	}
-}
-
-func TestDeleteServer_PreconditionFallbackTreats404AsAlreadyGone(t *testing.T) {
-	// Race window: a previous reconcile already scheduled the
-	// deletion, the billing floor expired between reconciles, and
-	// Scaleway has since removed the server. The fallback's
-	// UpdateServer comes back 404 — that's a clean "already gone"
-	// and should not propagate as a reconcile failure.
-	api := &fakeAppleSiliconAPI{
-		servers: []*applesilicon.Server{
-			readyServer("srv-4", "tuist-tuist-macos-fleet-3"),
-		},
-		deleteErrors: map[int]error{
-			1: &scw.PreconditionFailedError{Precondition: "unknown_precondition"},
-		},
-		updateErrors: map[int]error{
-			1: &scw.ResourceNotFoundError{Resource: "server", ResourceID: "srv-4"},
-		},
-	}
-	c := newTestClient(api)
-
-	if err := c.DeleteServer(context.Background(), "srv-4", "fr-par-1"); err != nil {
-		t.Fatalf("DeleteServer: expected nil when schedule-deletion sees 404, got %v", err)
-	}
-}
-
 // --- ReleaseToPool ---------------------------------------------------------
 //
 // ReleaseToPool is the cluster-driven exit for a Mac mini: rename
@@ -735,8 +598,7 @@ func TestReleaseToPool_RejectsEmptyPoolPrefix(t *testing.T) {
 	// An empty poolPrefix would rename the server to a bare UUID
 	// outside the pool namespace, where AdoptByPrefix would never
 	// find it again — effectively orphaning the host. Refuse loudly
-	// so the caller fixes the call site (auto-order mode should call
-	// DeleteServer directly, not ReleaseToPool with "").
+	// so callers fix their call site.
 	api := &fakeAppleSiliconAPI{
 		servers: []*applesilicon.Server{readyServer("srv-1", "tuist-tuist-macos-fleet-0")},
 	}

--- a/infra/cluster-api-provider-scaleway-applesilicon/internal/scaleway/client_test.go
+++ b/infra/cluster-api-provider-scaleway-applesilicon/internal/scaleway/client_test.go
@@ -61,7 +61,7 @@ func TestScalewayServerToServer_FallsBackToVncURLWhenSudoPasswordEmpty(t *testin
 	// Adopted servers come back from list/GET with an empty
 	// SudoPassword; the controller needs a real password to stage
 	// kcpassword. The vnc_url embeds the same OS-default credentials
-	// and is the surface AdoptByPrefix reads them from.
+	// and is the surface AdoptFromPool reads them from.
 	in := &applesilicon.Server{
 		ID:           "server-id",
 		Status:       applesilicon.ServerStatusReady,
@@ -107,7 +107,7 @@ func TestScalewayServerToServer_LeavesPasswordEmptyWhenBothSourcesEmpty(t *testi
 
 // --- two-phase adoption tests ---------------------------------------------
 //
-// The two-phase claim in AdoptByPrefix is what keeps two concurrent
+// The two-phase claim in AdoptFromPool is what keeps two concurrent
 // reconciles from both walking away with the same ServerID. Test it
 // against a fake Scaleway API that models the rename-store semantics
 // the production code relies on. The fake is intentionally minimal:
@@ -118,7 +118,7 @@ func TestScalewayServerToServer_LeavesPasswordEmptyWhenBothSourcesEmpty(t *testi
 // fakeAppleSiliconAPI is a small in-memory simulator. Servers are
 // pointers — UpdateServer mutates them in place so subsequent GETs
 // reflect the rename, matching Scaleway's own read-after-write
-// semantics. Only the methods AdoptByPrefix touches are implemented;
+// semantics. Only the methods AdoptFromPool touches are implemented;
 // the rest return a sentinel error so test failures are obvious if
 // a test triggers an unexpected call path.
 type fakeAppleSiliconAPI struct {
@@ -154,7 +154,7 @@ type fakeAppleSiliconAPI struct {
 }
 
 func (f *fakeAppleSiliconAPI) ListServers(req *applesilicon.ListServersRequest, _ ...scw.RequestOption) (*applesilicon.ListServersResponse, error) {
-	// Return everything in one page. AdoptByPrefix paginates by
+	// Return everything in one page. AdoptFromPool paginates by
 	// `len(resp.Servers) < pageSize` to stop, so a single full slice
 	// causes the loop to exit after one pass.
 	return &applesilicon.ListServersResponse{
@@ -210,7 +210,7 @@ func (f *fakeAppleSiliconAPI) ReinstallServer(req *applesilicon.ReinstallServerR
 	return nil, errors.New("not found")
 }
 
-// readyServer builds a server in the state AdoptByPrefix is willing
+// readyServer builds a server in the state AdoptFromPool is willing
 // to consider — Delivered + Ready, plus the type/os filters the
 // callers pass.
 func readyServer(id, name string) *applesilicon.Server {
@@ -228,7 +228,7 @@ func newTestClient(api *fakeAppleSiliconAPI) *Client {
 	return &Client{API: api}
 }
 
-func TestAdoptByPrefix_HappyPath(t *testing.T) {
+func TestAdoptFromPool_HappyPath(t *testing.T) {
 	api := &fakeAppleSiliconAPI{
 		servers: []*applesilicon.Server{
 			readyServer("srv-1", "tuist-pool-001"),
@@ -236,10 +236,10 @@ func TestAdoptByPrefix_HappyPath(t *testing.T) {
 	}
 	c := newTestClient(api)
 
-	srv, err := c.AdoptByPrefix(context.Background(),
+	srv, err := c.AdoptFromPool(context.Background(),
 		"tuist-tuist-runners-fleet-abc", "fr-par-1", "M2-L", "macos-tahoe-26.0", "tuist-pool-")
 	if err != nil {
-		t.Fatalf("AdoptByPrefix returned error: %v", err)
+		t.Fatalf("AdoptFromPool returned error: %v", err)
 	}
 	if srv == nil || srv.ID != "srv-1" {
 		t.Fatalf("expected srv-1 returned, got %+v", srv)
@@ -253,7 +253,7 @@ func TestAdoptByPrefix_HappyPath(t *testing.T) {
 	}
 }
 
-func TestAdoptByPrefix_IdempotentRediscovery(t *testing.T) {
+func TestAdoptFromPool_IdempotentRediscovery(t *testing.T) {
 	// Server already carries the final claimName from a prior
 	// reconcile whose status patch was lost. Adoption must return it
 	// immediately without going through the two-phase dance again
@@ -266,7 +266,7 @@ func TestAdoptByPrefix_IdempotentRediscovery(t *testing.T) {
 	}
 	c := newTestClient(api)
 
-	srv, err := c.AdoptByPrefix(context.Background(),
+	srv, err := c.AdoptFromPool(context.Background(),
 		"tuist-tuist-runners-fleet-abc", "fr-par-1", "M2-L", "macos-tahoe-26.0", "tuist-pool-")
 	if err != nil {
 		t.Fatalf("expected idempotent rediscovery, got error: %v", err)
@@ -279,10 +279,10 @@ func TestAdoptByPrefix_IdempotentRediscovery(t *testing.T) {
 	}
 }
 
-func TestAdoptByPrefix_RaceLost_SkipsCandidate(t *testing.T) {
+func TestAdoptFromPool_RaceLost_SkipsCandidate(t *testing.T) {
 	// Two pool hosts. A concurrent reconcile overwrites our phase-1
 	// pending marker on srv-1 between our UpdateServer and our GET.
-	// AdoptByPrefix should detect the race (verify.Name != ours) and
+	// AdoptFromPool should detect the race (verify.Name != ours) and
 	// move on to srv-2, where there's no contention.
 	api := &fakeAppleSiliconAPI{
 		servers: []*applesilicon.Server{
@@ -303,10 +303,10 @@ func TestAdoptByPrefix_RaceLost_SkipsCandidate(t *testing.T) {
 	}
 	c := newTestClient(api)
 
-	srv, err := c.AdoptByPrefix(context.Background(),
+	srv, err := c.AdoptFromPool(context.Background(),
 		"tuist-tuist-runners-fleet-mine", "fr-par-1", "M2-L", "macos-tahoe-26.0", "tuist-pool-")
 	if err != nil {
-		t.Fatalf("AdoptByPrefix returned error: %v", err)
+		t.Fatalf("AdoptFromPool returned error: %v", err)
 	}
 	if srv.ID != "srv-2" {
 		t.Fatalf("expected adoption to skip srv-1 and pick srv-2, got %q", srv.ID)
@@ -321,7 +321,7 @@ func TestAdoptByPrefix_RaceLost_SkipsCandidate(t *testing.T) {
 	}
 }
 
-func TestAdoptByPrefix_OrphanReAdopted(t *testing.T) {
+func TestAdoptFromPool_OrphanReAdopted(t *testing.T) {
 	// A previous reconcile crashed between phase 1 and phase 2 —
 	// srv-1 sits outside any pool prefix, named only by a stale
 	// claim-pending marker. The next reconcile must treat that marker
@@ -333,7 +333,7 @@ func TestAdoptByPrefix_OrphanReAdopted(t *testing.T) {
 	}
 	c := newTestClient(api)
 
-	srv, err := c.AdoptByPrefix(context.Background(),
+	srv, err := c.AdoptFromPool(context.Background(),
 		"tuist-tuist-runners-fleet-recovered", "fr-par-1", "M2-L", "macos-tahoe-26.0", "tuist-pool-")
 	if err != nil {
 		t.Fatalf("orphan re-adoption returned error: %v", err)
@@ -346,7 +346,7 @@ func TestAdoptByPrefix_OrphanReAdopted(t *testing.T) {
 	}
 }
 
-func TestAdoptByPrefix_NoEligibleHosts(t *testing.T) {
+func TestAdoptFromPool_NoEligibleHosts(t *testing.T) {
 	cases := []struct {
 		name string
 		srv  *applesilicon.Server
@@ -396,7 +396,7 @@ func TestAdoptByPrefix_NoEligibleHosts(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			api := &fakeAppleSiliconAPI{servers: []*applesilicon.Server{tc.srv}}
 			c := newTestClient(api)
-			_, err := c.AdoptByPrefix(context.Background(),
+			_, err := c.AdoptFromPool(context.Background(),
 				"tuist-tuist-runners-fleet-x", "fr-par-1", "M2-L", "macos-tahoe-26.0", "tuist-pool-")
 			if !errors.Is(err, ErrNoAvailableHost) {
 				t.Fatalf("expected ErrNoAvailableHost, got %v", err)
@@ -408,7 +408,7 @@ func TestAdoptByPrefix_NoEligibleHosts(t *testing.T) {
 	}
 }
 
-func TestAdoptByPrefix_Phase2FailureSurfacesError(t *testing.T) {
+func TestAdoptFromPool_Phase2FailureSurfacesError(t *testing.T) {
 	// Phase 1 succeeds (the candidate is renamed to our pending
 	// marker), then phase 2 fails. The function must propagate the
 	// error so the caller requeues; the server is left in the
@@ -426,7 +426,7 @@ func TestAdoptByPrefix_Phase2FailureSurfacesError(t *testing.T) {
 	}
 	c := newTestClient(api)
 
-	_, err := c.AdoptByPrefix(context.Background(),
+	_, err := c.AdoptFromPool(context.Background(),
 		"tuist-tuist-runners-fleet-x", "fr-par-1", "M2-L", "macos-tahoe-26.0", "tuist-pool-")
 	if err == nil {
 		t.Fatalf("expected phase-2 error to be surfaced, got nil")
@@ -443,10 +443,10 @@ func TestAdoptByPrefix_Phase2FailureSurfacesError(t *testing.T) {
 	}
 }
 
-func TestAdoptByPrefix_RequiresPoolPrefix(t *testing.T) {
+func TestAdoptFromPool_RequiresPoolPrefix(t *testing.T) {
 	api := &fakeAppleSiliconAPI{}
 	c := newTestClient(api)
-	_, err := c.AdoptByPrefix(context.Background(),
+	_, err := c.AdoptFromPool(context.Background(),
 		"tuist-tuist-runners-fleet-x", "fr-par-1", "M2-L", "macos-tahoe-26.0", "")
 	if err == nil {
 		t.Fatalf("expected error when poolPrefix is empty")
@@ -456,7 +456,7 @@ func TestAdoptByPrefix_RequiresPoolPrefix(t *testing.T) {
 	}
 }
 
-func TestAdoptByPrefix_Phase1Update404SkipsCandidate(t *testing.T) {
+func TestAdoptFromPool_Phase1Update404SkipsCandidate(t *testing.T) {
 	// A 404 on phase 1 UpdateServer means the candidate was deleted
 	// out from under us between list and UpdateServer (concurrent
 	// operator action). The function should treat that as a per-
@@ -476,7 +476,7 @@ func TestAdoptByPrefix_Phase1Update404SkipsCandidate(t *testing.T) {
 	}
 	c := newTestClient(api)
 
-	srv, err := c.AdoptByPrefix(context.Background(),
+	srv, err := c.AdoptFromPool(context.Background(),
 		"tuist-tuist-runners-fleet-x", "fr-par-1", "M2-L", "macos-tahoe-26.0", "tuist-pool-")
 	if err != nil {
 		t.Fatalf("phase 1 404 should be race-lost, not error; got %v", err)
@@ -486,7 +486,7 @@ func TestAdoptByPrefix_Phase1Update404SkipsCandidate(t *testing.T) {
 	}
 }
 
-func TestAdoptByPrefix_Phase1UpdateNon404SurfacesError(t *testing.T) {
+func TestAdoptFromPool_Phase1UpdateNon404SurfacesError(t *testing.T) {
 	// Any non-NotFound Scaleway error (403 auth, 5xx outage,
 	// validation error) is operational and must propagate as a real
 	// failure. The pre-fix behavior swallowed every UpdateServer
@@ -503,7 +503,7 @@ func TestAdoptByPrefix_Phase1UpdateNon404SurfacesError(t *testing.T) {
 	}
 	c := newTestClient(api)
 
-	_, err := c.AdoptByPrefix(context.Background(),
+	_, err := c.AdoptFromPool(context.Background(),
 		"tuist-tuist-runners-fleet-x", "fr-par-1", "M2-L", "macos-tahoe-26.0", "tuist-pool-")
 	if err == nil {
 		t.Fatalf("expected non-404 phase 1 error to be surfaced")
@@ -516,7 +516,7 @@ func TestAdoptByPrefix_Phase1UpdateNon404SurfacesError(t *testing.T) {
 	}
 }
 
-func TestAdoptByPrefix_Phase1Verify404SkipsCandidate(t *testing.T) {
+func TestAdoptFromPool_Phase1Verify404SkipsCandidate(t *testing.T) {
 	// 404 on the verify GET (server deleted between phase 1 and
 	// verify) is recoverable per-candidate, same handling as a phase
 	// 1 update 404.
@@ -531,7 +531,7 @@ func TestAdoptByPrefix_Phase1Verify404SkipsCandidate(t *testing.T) {
 	}
 	c := newTestClient(api)
 
-	srv, err := c.AdoptByPrefix(context.Background(),
+	srv, err := c.AdoptFromPool(context.Background(),
 		"tuist-tuist-runners-fleet-x", "fr-par-1", "M2-L", "macos-tahoe-26.0", "tuist-pool-")
 	if err != nil {
 		t.Fatalf("verify 404 should be race-lost, not error; got %v", err)
@@ -541,7 +541,7 @@ func TestAdoptByPrefix_Phase1Verify404SkipsCandidate(t *testing.T) {
 	}
 }
 
-func TestAdoptByPrefix_Phase1VerifyNon404SurfacesError(t *testing.T) {
+func TestAdoptFromPool_Phase1VerifyNon404SurfacesError(t *testing.T) {
 	api := &fakeAppleSiliconAPI{
 		servers: []*applesilicon.Server{
 			readyServer("srv-1", "tuist-pool-001"),
@@ -552,7 +552,7 @@ func TestAdoptByPrefix_Phase1VerifyNon404SurfacesError(t *testing.T) {
 	}
 	c := newTestClient(api)
 
-	_, err := c.AdoptByPrefix(context.Background(),
+	_, err := c.AdoptFromPool(context.Background(),
 		"tuist-tuist-runners-fleet-x", "fr-par-1", "M2-L", "macos-tahoe-26.0", "tuist-pool-")
 	if err == nil {
 		t.Fatalf("expected non-404 verify error to be surfaced")
@@ -596,7 +596,7 @@ func TestReleaseToPool_HappyPathRenamesAndReinstalls(t *testing.T) {
 
 func TestReleaseToPool_RejectsEmptyPoolPrefix(t *testing.T) {
 	// An empty poolPrefix would rename the server to a bare UUID
-	// outside the pool namespace, where AdoptByPrefix would never
+	// outside the pool namespace, where AdoptFromPool would never
 	// find it again — effectively orphaning the host. Refuse loudly
 	// so callers fix their call site.
 	api := &fakeAppleSiliconAPI{

--- a/infra/helm/tuist/crds/infrastructure.cluster.x-k8s.io_scalewayapplesiliconmachines.yaml
+++ b/infra/helm/tuist/crds/infrastructure.cluster.x-k8s.io_scalewayapplesiliconmachines.yaml
@@ -82,6 +82,7 @@ spec:
 
                     When no compatible pre-ordered host is available, reconcile
                     requeues with a `NoAvailableHost` event.
+                  minLength: 1
                   type: string
                 fleetName:
                   description: |-

--- a/infra/helm/tuist/crds/infrastructure.cluster.x-k8s.io_scalewayapplesiliconmachines.yaml
+++ b/infra/helm/tuist/crds/infrastructure.cluster.x-k8s.io_scalewayapplesiliconmachines.yaml
@@ -60,13 +60,12 @@ spec:
               properties:
                 adoptPoolPrefix:
                   description: |-
-                    AdoptPoolPrefix switches the controller from `Scaleway CreateServer`
-                    (auto-order) to "claim a pre-ordered host whose Scaleway-side
-                    name starts with this prefix." Recommended for the customer-
-                    runner fleet because Scaleway Mac mini inventory is frequently
+                    AdoptPoolPrefix is the Scaleway-side name prefix the controller
+                    scans when claiming a Mac mini for this Machine. Required: the
+                    controller has no auto-order path. Operators pre-order capacity
+                    in the Scaleway console because Mac mini inventory is frequently
                     out of stock and Apple's 24h licensing floor makes speculative
-                    auto-ordering expensive — pre-ordering days in advance and
-                    letting the controller adopt is the operationally sane path.
+                    ordering expensive.
 
                     Operator workflow:
 
@@ -82,10 +81,7 @@ spec:
                          reconcile won't double-claim.
 
                     When no compatible pre-ordered host is available, reconcile
-                    requeues with a `NoAvailableHost` event. No auto-order
-                    fallback — the operator pre-orders, the controller adopts.
-
-                    Empty (default) preserves the legacy auto-order behavior.
+                    requeues with a `NoAvailableHost` event.
                   type: string
                 fleetName:
                   description: |-
@@ -203,6 +199,8 @@ spec:
                   default: fr-par-1
                   description: Zone is the Scaleway zone (fr-par-1, fr-par-3, etc.).
                   type: string
+              required:
+                - adoptPoolPrefix
               type: object
             status:
               description: ScalewayAppleSiliconMachineStatus is the observed state of the Machine.

--- a/infra/helm/tuist/crds/infrastructure.cluster.x-k8s.io_scalewayapplesiliconmachinetemplates.yaml
+++ b/infra/helm/tuist/crds/infrastructure.cluster.x-k8s.io_scalewayapplesiliconmachinetemplates.yaml
@@ -60,13 +60,12 @@ spec:
                       properties:
                         adoptPoolPrefix:
                           description: |-
-                            AdoptPoolPrefix switches the controller from `Scaleway CreateServer`
-                            (auto-order) to "claim a pre-ordered host whose Scaleway-side
-                            name starts with this prefix." Recommended for the customer-
-                            runner fleet because Scaleway Mac mini inventory is frequently
+                            AdoptPoolPrefix is the Scaleway-side name prefix the controller
+                            scans when claiming a Mac mini for this Machine. Required: the
+                            controller has no auto-order path. Operators pre-order capacity
+                            in the Scaleway console because Mac mini inventory is frequently
                             out of stock and Apple's 24h licensing floor makes speculative
-                            auto-ordering expensive — pre-ordering days in advance and
-                            letting the controller adopt is the operationally sane path.
+                            ordering expensive.
 
                             Operator workflow:
 
@@ -82,10 +81,7 @@ spec:
                                  reconcile won't double-claim.
 
                             When no compatible pre-ordered host is available, reconcile
-                            requeues with a `NoAvailableHost` event. No auto-order
-                            fallback — the operator pre-orders, the controller adopts.
-
-                            Empty (default) preserves the legacy auto-order behavior.
+                            requeues with a `NoAvailableHost` event.
                           type: string
                         fleetName:
                           description: |-
@@ -203,6 +199,8 @@ spec:
                           default: fr-par-1
                           description: Zone is the Scaleway zone (fr-par-1, fr-par-3, etc.).
                           type: string
+                      required:
+                        - adoptPoolPrefix
                       type: object
                   required:
                     - spec

--- a/infra/helm/tuist/crds/infrastructure.cluster.x-k8s.io_scalewayapplesiliconmachinetemplates.yaml
+++ b/infra/helm/tuist/crds/infrastructure.cluster.x-k8s.io_scalewayapplesiliconmachinetemplates.yaml
@@ -82,6 +82,7 @@ spec:
 
                             When no compatible pre-ordered host is available, reconcile
                             requeues with a `NoAvailableHost` event.
+                          minLength: 1
                           type: string
                         fleetName:
                           description: |-

--- a/infra/helm/tuist/templates/builders-fleet.yaml
+++ b/infra/helm/tuist/templates/builders-fleet.yaml
@@ -57,9 +57,9 @@ spec:
       {{- with .Values.buildersFleet.machine.hostMemoryMB }}
       hostMemoryMB: {{ . }}
       {{- end }}
-      {{- with .Values.buildersFleet.adoptPoolPrefix }}
-      adoptPoolPrefix: {{ . | quote }}
-      {{- end }}
+      # Required. Adopts from the same pre-ordered pool as the
+      # other fleets.
+      adoptPoolPrefix: {{ required "buildersFleet.adoptPoolPrefix is required" .Values.buildersFleet.adoptPoolPrefix | quote }}
       ghActionsRunner:
         ghOrg: {{ .Values.buildersFleet.ghOrg | default "tuist" | quote }}
         ghRunnerLabels: {{ .Values.buildersFleet.ghRunnerLabels | default "self-hosted,macos,bare-metal,vm-image-builder" | quote }}

--- a/infra/helm/tuist/templates/macos-fleet.yaml
+++ b/infra/helm/tuist/templates/macos-fleet.yaml
@@ -43,14 +43,11 @@ spec:
       {{- with .Values.macosFleet.machine.hostMemoryMB }}
       hostMemoryMB: {{ . }}
       {{- end }}
-      {{- with .Values.macosFleet.adoptPoolPrefix }}
-      # Adoption mode: skip Scaleway CreateServer and claim a
-      # pre-ordered host whose name starts with this prefix.
-      # Shared with runnersFleet by default — operator pre-orders
-      # one Mac mini pool, both fleets draw from it as
-      # MachineDeployments scale.
-      adoptPoolPrefix: {{ . | quote }}
-      {{- end }}
+      # Required. The controller claims a pre-ordered host whose
+      # Scaleway-side name starts with this prefix. Shared with
+      # runnersFleet by default — operator pre-orders one Mac mini
+      # pool, both fleets draw from it as MachineDeployments scale.
+      adoptPoolPrefix: {{ required "macosFleet.adoptPoolPrefix is required" .Values.macosFleet.adoptPoolPrefix | quote }}
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment

--- a/infra/helm/tuist/templates/runners-fleet.yaml
+++ b/infra/helm/tuist/templates/runners-fleet.yaml
@@ -35,13 +35,10 @@ spec:
       {{- with .Values.runnersFleet.machine.hostMemoryMB }}
       hostMemoryMB: {{ . }}
       {{- end }}
-      {{- with .Values.runnersFleet.adoptPoolPrefix }}
-      # Adoption mode: skip Scaleway CreateServer and claim a
-      # pre-ordered host whose name starts with this prefix.
-      # Operator pre-orders Mac minis in the Scaleway console with
-      # this prefix; the controller renames them on adoption.
-      adoptPoolPrefix: {{ . | quote }}
-      {{- end }}
+      # Required. Operator pre-orders Mac minis in the Scaleway
+      # console with this prefix; the controller renames them on
+      # adoption.
+      adoptPoolPrefix: {{ required "runnersFleet.adoptPoolPrefix is required" .Values.runnersFleet.adoptPoolPrefix | quote }}
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment

--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -204,8 +204,9 @@ macosFleet:
   tailscale:
     enabled: true
     tags: ["tag:tuist-macmini-production"]
-  # Claim pre-ordered Mac minis during the CAPI MachineDeployment
-  # cutover instead of auto-ordering fresh production hosts.
+  # Claim pre-ordered Mac minis from the shared `tuist-pool-`
+  # pool. The CAPI controller has no auto-order path; operators
+  # pre-order capacity in the Scaleway console.
   adoptPoolPrefix: "tuist-pool-"
   machine:
     # Production tracks the chart default — M2-L on Scaleway:

--- a/infra/helm/tuist/values.yaml
+++ b/infra/helm/tuist/values.yaml
@@ -488,15 +488,13 @@ macosFleet:
   name: ""             # default: <release>-macos-fleet
   replicas: 1
   kubeletVersion: 1.32.1
-  # See `runnersFleet.adoptPoolPrefix` for the full operator
-  # workflow + adoption semantics. Empty (default) preserves
-  # auto-order behavior; set per-env to a Scaleway-name prefix to
-  # claim from a pre-ordered pool. Sharing the same prefix with
-  # `runnersFleet.adoptPoolPrefix` lets one pool of pre-ordered
+  # Required. See `runnersFleet.adoptPoolPrefix` for the full
+  # operator workflow + adoption semantics. Sharing the same prefix
+  # with `runnersFleet.adoptPoolPrefix` lets one pool of pre-ordered
   # Mac minis serve both fleets — the controller claims the first
   # match per Machine, so whichever MachineDeployment scales first
   # gets the next host.
-  adoptPoolPrefix: ""
+  adoptPoolPrefix: "tuist-pool-"
   controlPlane:
     host: ""           # API server endpoint Mac minis dial when joining
     port: 6443
@@ -693,18 +691,16 @@ runnersFleet:
   # `helm.sh/resource-policy: keep` so an uninstall doesn't yank in-
   # flight Pods. Per-namespace RBAC + NetworkPolicy live alongside.
   namespace: tuist-runners
-  # Number of Mac mini hosts the CAPI MachineDeployment provisions
-  # (orders, or adopts when `adoptPoolPrefix` is set — see below).
-  # Sum of `pools[*].replicas` must fit within `hostCount` (one
-  # VM per host today).
+  # Number of Mac mini hosts the CAPI MachineDeployment adopts
+  # from the pool. Sum of `pools[*].replicas` must fit within
+  # `hostCount` (one VM per host today).
   hostCount: 0
-  # When set, the CAPI controller skips Scaleway CreateServer and
-  # instead claims a pre-ordered Mac mini whose Scaleway-side name
-  # starts with this prefix. Recommended for the customer-runner
-  # fleet: Scaleway Mac mini stock is unreliable and Apple's 24h
-  # licensing floor makes speculative auto-ordering expensive — the
-  # operationally sane path is to pre-order Mac minis days in
-  # advance and let the controller adopt them on demand.
+  # Required. The controller claims a pre-ordered Mac mini whose
+  # Scaleway-side name starts with this prefix; there is no
+  # auto-order path. Scaleway Mac mini stock is unreliable and
+  # Apple's 24h licensing floor makes speculative auto-ordering
+  # expensive, so capacity planning is operator-owned via the
+  # Scaleway console.
   #
   # Operator workflow:
   #
@@ -719,22 +715,15 @@ runnersFleet:
   #      bootstraps tart-kubelet on it.
   #
   # When no compatible pre-ordered host is available, the CR stays
-  # in `Provisioning` phase with a `NoAvailableHost` event so the
+  # in `Adopting` phase with a `NoAvailableHost` event so the
   # operator sees the queue and knows to pre-order more capacity.
-  # No auto-order fallback.
-  #
-  # Empty string preserves the auto-order behavior. We default to
-  # empty (i.e. auto-order) so a greenfield bring-up can land a
-  # cluster without pre-staging hardware; production envs override
-  # this in their `values-managed-<env>.yaml`.
-  adoptPoolPrefix: ""
+  adoptPoolPrefix: "tuist-pool-"
   machine:
     # Match the existing macosFleet shape — same M2-L baseline.
     # Override per-env when product demands a beefier SKU (M4-M for
-    # memory-heavy iOS apps, etc.). When `adoptPoolPrefix` is set,
-    # the operator pre-orders Mac minis matching these `type` /
-    # `zone` / `os` values; the controller's adoption query filters
-    # on the same three.
+    # memory-heavy iOS apps, etc.). The operator pre-orders Mac
+    # minis matching these `type` / `zone` / `os` values; the
+    # controller's adoption query filters on the same three.
     type: M2-L
     zone: fr-par-1
     os: macos-tahoe-26.3
@@ -872,11 +861,10 @@ buildersFleet:
   # `kubectl scale machinedeployment <name> --replicas=N` after
   # install if you'd rather drive scaling out-of-band.
   replicas: 0
-  # Adopt from the same `tuist-pool-` pre-ordered pool the other
-  # two fleets use. See `runnersFleet.adoptPoolPrefix` for the
-  # full operator workflow. Empty preserves auto-order; production
-  # envs set this in their `values-managed-<env>.yaml`.
-  adoptPoolPrefix: ""
+  # Required. Adopts from the same `tuist-pool-` pre-ordered pool
+  # the other two fleets use. See `runnersFleet.adoptPoolPrefix`
+  # for the full operator workflow.
+  adoptPoolPrefix: "tuist-pool-"
   # GitHub Actions runner agent configuration. The agent registers
   # with GitHub at host bootstrap time and picks up jobs from then
   # on; ghOrg + ghRunnerLabels must match the workflow `runs-on:`


### PR DESCRIPTION
### Purpose

Every managed environment already runs the CAPI Scaleway provider with `Spec.AdoptPoolPrefix` set, and the operator-owned pre-order workflow is the only sane path on Scaleway Apple Silicon (24h Apple licensing floor, flaky inventory). The companion `tuist.dev/release-policy: terminate` opt-out that #10922 added was extra surface nobody used, plus a `shouldReleaseToPool` decision that had to be re-derived on every delete. Collapse it to the pool path.

### What changed

- **`acquireServer`** always calls `AdoptByPrefix`. An empty `Spec.AdoptPoolPrefix` now surfaces a `MissingAdoptPoolPrefix` condition + event instead of silently falling through to `CreateServer`.
- **`reconcileDelete`** always calls `ReleaseToPool`. The `ReleasePolicyAnnotation` / `ReleasePolicyPool` / `ReleasePolicyTerminate` constants and the `shouldReleaseToPool` helper are gone. Operators retiring a broken host do so via the Scaleway console.
- **`scaleway.Client`** drops `CreateServer`, `DeleteServer`, `resolveOSID`, and `isPreconditionFailed`. The `AppleSiliconAPI` interface loses the four SDK methods nothing calls anymore (`CreateServer`, `DeleteServer`, `WaitForServer`, `ListOS`).
- **`Spec.AdoptPoolPrefix`** is now required: no `omitempty` on the type, `required: [adoptPoolPrefix]` in both CRDs, and chart templates emit the field unconditionally guarded by a `required` helper. Chart defaults flip to `"tuist-pool-"` so a greenfield install matches the managed envs.
- **Docs**: AGENTS.md, CRDs, `values.yaml`, `values-managed-production.yaml`, and the controller's surrounding prose stop referencing the removed paths. The detach-without-release runbook now points at `ReleaseToPool` rather than `DeleteServer`.
- **Tests**: removed the `TestShouldReleaseToPool_*`, `TestReconcileDelete_TerminateAnnotationFallsBackToDeleteServer`, `TestReconcileDelete_AutoOrderUsesDeleteServer`, and the four `TestDeleteServer_*` cases. The remaining delete-path test is `TestReconcileDelete_ReleasesToPool`.

### How to test locally

From the provider module:

\`\`\`bash
cd infra/cluster-api-provider-scaleway-applesilicon
go build ./...
go vet ./...
go test ./...
\`\`\`

Render the chart against each managed env to confirm the new \`adoptPoolPrefix\` field is emitted everywhere:

\`\`\`bash
helm template tuist infra/helm/tuist -f infra/helm/tuist/values-managed-canary.yaml | grep adoptPoolPrefix
helm template tuist infra/helm/tuist -f infra/helm/tuist/values-managed-staging.yaml | grep adoptPoolPrefix
helm template tuist infra/helm/tuist -f infra/helm/tuist/values-managed-production.yaml | grep adoptPoolPrefix
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)