### PR TITLE
fix(infra): disable prod Kura global endpoint reconciliation

### DIFF
--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -6,6 +6,11 @@
 #     -f infra/helm/tuist/values-managed-production.yaml \
 #     --set server.image.tag=$GIT_SHA
 
+# The production workload cluster still serves per-region Kura HTTPS and
+# gRPC traffic directly via Hetzner LoadBalancer Services. Disable the
+# Cloudflare-fronted global endpoint layer here too until the Cloudflare
+# pool quota is raised.
+kuraGlobalEndpointsEnabled: false
 kuraGlobalEndpointsRequired: false
 
 server:
@@ -99,6 +104,9 @@ server:
 
 kuraController:
   cloudflareLoadBalancing:
+    # Keep Cloudflare credentials wired so destroy flows can still clean
+    # up any previously provisioned global endpoints after reconciliation
+    # is re-enabled.
     enabled: true
     zoneName: tuist.dev
     apiTokenSecret:


### PR DESCRIPTION
## What changed

This disables Kura global endpoint reconciliation in the main production overlay by setting `kuraGlobalEndpointsEnabled: false` in `infra/helm/tuist/values-managed-production.yaml`.

The production overlay already had `kuraGlobalEndpointsRequired: false`, which only relaxed readiness. It still let the production-cluster Kura controller reconcile the Cloudflare global endpoint layer for `eu-central`.

## Why it changed

Affected Kura instances are currently healthy at the regional workload level, but the production-cluster controller is repeatedly failing Cloudflare pool creation before it can write `KuraInstance.status`.

That keeps the CRD status blank, which means the server never observes `observedImage` / `publicURL` and the account settings UI stays stuck in `Deploying` / `Pending` even though the regional endpoint is already serving.

We already disabled global endpoint reconciliation for the dedicated regional Kura clusters. This extends the same stopgap to the main production cluster until the Cloudflare pool quota is raised.

## Root cause

The recent regional fix only changed `values-managed-kura-region.yaml`. The main production overlay still left Cloudflare global endpoint reconciliation enabled for the controller that owns `eu-central`, so quota failures in Cloudflare were still aborting reconciliation there.

## Impact

- The production-cluster Kura controller will stop trying to reconcile the Cloudflare global endpoint layer.
- Regional Hetzner-backed Kura endpoints continue to serve traffic.
- Once the production server rollout that carries the relaxed readiness flag is live, account settings can converge on the regional endpoint instead of waiting on Cloudflare.

## Validation

- Rendered the production chart locally with:

  ```bash
  helm template tuist infra/helm/tuist \
    -f infra/helm/tuist/values-managed-common.yaml \
    -f infra/helm/tuist/values-managed-production.yaml \
    --set kuraController.image.tag=test-sha \
    --set server.image.tag=test-sha \
    --set runnersController.image.tag=test-sha \
    --set cache.image.tag=test-sha \
    --set xcresultProcessor.image.tag=test-sha
  ```

- Verified the rendered controller args include:
  - `--reconcile-global-endpoints=false`
  - `--require-global-endpoints=false`
