### PR TITLE
fix(cli): stop duplicating SwiftPM output during tuist install

### DIFF
--- a/cli/Sources/TuistSupport/SwiftPackageManager/SwiftPackageManagerController.swift
+++ b/cli/Sources/TuistSupport/SwiftPackageManager/SwiftPackageManagerController.swift
@@ -1,7 +1,6 @@
 import Command
 import FileSystem
 import Foundation
-import Logging
 import Mockable
 import Path
 import TSCUtility
@@ -70,7 +69,7 @@ public struct SwiftPackageManagerController: SwiftPackageManagerControlling {
     public init() {
         self.init(
             fileSystem: FileSystem(),
-            commandRunner: { CommandRunner(logger: Logger.current) }
+            commandRunner: { CommandRunner() }
         )
     }
 


### PR DESCRIPTION
## What

`tuist install` (and any other path through `SwiftPackageManagerController.resolve`/`update` with `printOutput: true`) prints every SwiftPM line twice — every `Computing version for ...`, `Fetching ...`, `Computed ... at X.Y (Zs)`, and any warnings, all duplicated end-to-end. SwiftPM funnels nearly all of its output (progress + warnings + errors) to stderr, which is the stream that hits the duplicate write path.

## Root cause

The CLI command-execution refactor in #10628 swapped `System.runAndPrint` for `CommandRunner` + a `runAndPrint` extension on `CommandRunning`. In that refactor, `SwiftPackageManagerController` became the only call site in the repo that constructs `CommandRunner` with a logger:

```swift
commandRunner: { CommandRunner(logger: Logger.current) }
```

For every stderr chunk, `CommandRunner` does two things in the same loop (Command 0.14.4, `Sources/Command/CommandRunner.swift:181-184`):

1. `continuation.yield(.standardError(bytes))` — consumed by `runAndPrint` (`CommandRunning+TuistSupport.swift:42`), which writes the bytes to `FileHandle.standardError`.
2. `logger?.error("\(output)")` — `Logger.current` resolves to `StandardLogHandler` (default `.info` threshold, so `.error` passes), which writes the same string to `FileHandle.standardError` again, colored red.

Result: every SwiftPM line shows up twice — once plain, then again in red.

## Fix

Drop the logger from this one factory. This brings `SwiftPackageManagerController` in line with the ~30 other `CommandRunner()` instantiations across the CLI, all of which already use the no-logger default. `CommandRunner` still bundles the collected stderr into the thrown `CommandError` on non-zero exit, so failure visibility is preserved.

## Reproduction

In `examples/xcode/generated_app_with_airship_sdk`:

```bash
tuist clean dependencies
tuist install 2>install.stderr.log 1>install.stdout.log
sort install.stderr.log | uniq -c | sort -rn | head
```

Pre-fix output (every line printed exactly twice):

```
21 stderr lines, 7 unique SwiftPM messages each duplicated 2x:
      2 [1/847312] Fetching ios-library
      2 Working copy of https://github.com/urbanairship/ios-library.git resolved at 18.9.2
      2 Fetching https://github.com/urbanairship/ios-library.git
      2 Fetched https://github.com/urbanairship/ios-library.git from cache (29.91s)
      2 Creating working copy for https://github.com/urbanairship/ios-library.git
      2 Computing version for https://github.com/urbanairship/ios-library.git
      2 Computed https://github.com/urbanairship/ios-library.git at 18.9.2 (30.42s)
```

Post-fix: each unique message appears with count `1` instead of `2`.

## Test plan

- [ ] `tuist install` against a project that resolves several SwiftPM dependencies — confirm each `Computing version` / `Computed` / `Fetching` / `Fetched` line and any warnings print exactly once.
- [ ] Force a SwiftPM resolve failure (e.g. a bad URL in `Package.swift`) — confirm the error still surfaces to the user.