### PR TITLE
fix(noora): declare storybook TLS certificate explicitly

### DIFF
--- a/infra/helm/noora-storybook/README.md
+++ b/infra/helm/noora-storybook/README.md
@@ -40,5 +40,6 @@ helm upgrade --install noora-storybook infra/helm/noora-storybook \
   --set image.tag=<sha-tag>
 ```
 
-`external-dns` reconciles the Ingress hostname into Cloudflare and `cert-manager`
-issues the TLS certificate through the cluster's `letsencrypt-cloudflare` issuer.
+`external-dns` reconciles the Ingress hostname into Cloudflare and the chart creates
+an explicit `cert-manager.io/v1` `Certificate` for the `storybook.noora.tuist.dev`
+secret through the cluster's `letsencrypt-cloudflare` issuer.

--- a/infra/helm/noora-storybook/templates/certificate.yaml
+++ b/infra/helm/noora-storybook/templates/certificate.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.certificate.enabled }}
+{{- $host := required "ingress.host is required when certificate.enabled is true" .Values.ingress.host -}}
+{{- $secretName := required "ingress.tlsSecretName is required when certificate.enabled is true" .Values.ingress.tlsSecretName -}}
+{{- $issuerName := required "certificate.issuerRef.name is required when certificate.enabled is true" .Values.certificate.issuerRef.name -}}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "noora-storybook.fullname" . }}-tls
+  labels:
+    {{- include "noora-storybook.labels" . | nindent 4 }}
+    app.kubernetes.io/component: storybook
+spec:
+  secretName: {{ $secretName | quote }}
+  dnsNames:
+    - {{ $host | quote }}
+  issuerRef:
+    group: {{ .Values.certificate.issuerRef.group | quote }}
+    kind: {{ .Values.certificate.issuerRef.kind | quote }}
+    name: {{ $issuerName | quote }}
+{{- end }}

--- a/infra/helm/noora-storybook/values-production.yaml
+++ b/infra/helm/noora-storybook/values-production.yaml
@@ -8,8 +8,11 @@ ingress:
   className: nginx
   host: storybook.noora.tuist.dev
   tlsSecretName: noora-storybook-tls
-  annotations:
-    cert-manager.io/cluster-issuer: letsencrypt-cloudflare
+
+certificate:
+  enabled: true
+  issuerRef:
+    name: letsencrypt-cloudflare
 
 networkPolicy:
   enabled: true

--- a/infra/helm/noora-storybook/values.yaml
+++ b/infra/helm/noora-storybook/values.yaml
@@ -40,6 +40,13 @@ ingress:
   tlsSecretName: ""
   annotations: {}
 
+certificate:
+  enabled: false
+  issuerRef:
+    group: cert-manager.io
+    kind: ClusterIssuer
+    name: ""
+
 resources: {}
 podSecurityContext:
   seccompProfile:


### PR DESCRIPTION
Resolves N/A

> Describe here the purpose of your PR.

The Noora Storybook ingress for `storybook.noora.tuist.dev` is currently serving the nginx fallback certificate because the chart only relied on the ingress-shim annotation path to create `noora-storybook-tls`. This change makes certificate provisioning explicit in the chart so the TLS secret is declared and reconciled as part of the release instead of depending on ingress annotation side effects.

- add an explicit `cert-manager.io/v1` `Certificate` for the Storybook hostname and TLS secret
- move issuer configuration into chart values and enable it in production
- remove the ingress annotation that implicitly requested the certificate
- document the certificate ownership model in the chart README

### How to test locally

- `helm lint infra/helm/noora-storybook -f infra/helm/noora-storybook/values-ci.yaml`
- `helm template noora-storybook infra/helm/noora-storybook -f infra/helm/noora-storybook/values-production.yaml -f infra/helm/noora-storybook/values-ci.yaml`
