### PR TITLE
fix(slack): make notifier secrets optional

### DIFF
--- a/infra/helm/slack/README.md
+++ b/infra/helm/slack/README.md
@@ -42,6 +42,10 @@ The production overlay expects one 1Password item named
 - `turnstile-secret-key`
 - `mailgun-api-key`
 - `slack-invite-url`
+
+These fields are optional. When omitted, the app still boots and simply
+disables the internal Slack notification hook:
+
 - `slack-bot-token`
 - `slack-channel-id`
 

--- a/infra/helm/slack/templates/externalsecret.yaml
+++ b/infra/helm/slack/templates/externalsecret.yaml
@@ -24,8 +24,8 @@ spec:
         TURNSTILE_SECRET_KEY: "{{ `{{ .TURNSTILE_SECRET_KEY | trim }}` }}"
         MAILGUN_API_KEY: "{{ `{{ .MAILGUN_API_KEY | trim }}` }}"
         SLACK_INVITE_URL: "{{ `{{ .SLACK_INVITE_URL | trim }}` }}"
-        SLACK_BOT_TOKEN: "{{ `{{ .SLACK_BOT_TOKEN | trim }}` }}"
-        SLACK_CHANNEL_ID: "{{ `{{ .SLACK_CHANNEL_ID | trim }}` }}"
+        SLACK_BOT_TOKEN: '{{ `{{ index . "slack-bot-token" | default "" | trim }}` }}'
+        SLACK_CHANNEL_ID: '{{ `{{ index . "slack-channel-id" | default "" | trim }}` }}'
   data:
     - secretKey: ADMIN_USERNAME
       remoteRef:
@@ -45,10 +45,7 @@ spec:
     - secretKey: SLACK_INVITE_URL
       remoteRef:
         key: {{ printf "%s/%s" .Values.runtimeSecrets.externalSecret.item .Values.runtimeSecrets.externalSecret.fields.slackInviteUrl | quote }}
-    - secretKey: SLACK_BOT_TOKEN
-      remoteRef:
-        key: {{ printf "%s/%s" .Values.runtimeSecrets.externalSecret.item .Values.runtimeSecrets.externalSecret.fields.slackBotToken | quote }}
-    - secretKey: SLACK_CHANNEL_ID
-      remoteRef:
-        key: {{ printf "%s/%s" .Values.runtimeSecrets.externalSecret.item .Values.runtimeSecrets.externalSecret.fields.slackChannelId | quote }}
+  dataFrom:
+    - extract:
+        key: {{ .Values.runtimeSecrets.externalSecret.item | quote }}
 {{- end }}

--- a/infra/helm/slack/templates/runtime-secret.yaml
+++ b/infra/helm/slack/templates/runtime-secret.yaml
@@ -14,6 +14,6 @@ stringData:
   TURNSTILE_SECRET_KEY: {{ required "runtimeSecrets.inline.turnstileSecretKey is required when runtimeSecrets.externalSecret.enabled is false" .Values.runtimeSecrets.inline.turnstileSecretKey | quote }}
   MAILGUN_API_KEY: {{ required "runtimeSecrets.inline.mailgunApiKey is required when runtimeSecrets.externalSecret.enabled is false" .Values.runtimeSecrets.inline.mailgunApiKey | quote }}
   SLACK_INVITE_URL: {{ required "runtimeSecrets.inline.slackInviteUrl is required when runtimeSecrets.externalSecret.enabled is false" .Values.runtimeSecrets.inline.slackInviteUrl | quote }}
-  SLACK_BOT_TOKEN: {{ required "runtimeSecrets.inline.slackBotToken is required when runtimeSecrets.externalSecret.enabled is false" .Values.runtimeSecrets.inline.slackBotToken | quote }}
-  SLACK_CHANNEL_ID: {{ required "runtimeSecrets.inline.slackChannelId is required when runtimeSecrets.externalSecret.enabled is false" .Values.runtimeSecrets.inline.slackChannelId | quote }}
+  SLACK_BOT_TOKEN: {{ .Values.runtimeSecrets.inline.slackBotToken | default "" | quote }}
+  SLACK_CHANNEL_ID: {{ .Values.runtimeSecrets.inline.slackChannelId | default "" | quote }}
 {{- end }}

--- a/infra/helm/slack/values-ci.yaml
+++ b/infra/helm/slack/values-ci.yaml
@@ -13,5 +13,3 @@ runtimeSecrets:
     turnstileSecretKey: validation-turnstile-secret-key
     mailgunApiKey: validation-mailgun-api-key
     slackInviteUrl: https://slack.example.com/invite
-    slackBotToken: xoxb-validation
-    slackChannelId: C0123456789

--- a/slack/config/runtime.exs
+++ b/slack/config/runtime.exs
@@ -74,8 +74,8 @@ if config_env() == :prod do
   config :slack, :mailer_from, {mailer_from_name, mailer_from_email}
 
   config :slack, :notifier,
-    bot_token: System.get_env("SLACK_BOT_TOKEN") || raise("environment variable SLACK_BOT_TOKEN is missing"),
-    channel_id: System.get_env("SLACK_CHANNEL_ID") || raise("environment variable SLACK_CHANNEL_ID is missing"),
+    bot_token: System.get_env("SLACK_BOT_TOKEN"),
+    channel_id: System.get_env("SLACK_CHANNEL_ID"),
     admin_url: "https://#{host}/admin/invitations"
 
   config :slack,

--- a/slack/test/slack/notifier_test.exs
+++ b/slack/test/slack/notifier_test.exs
@@ -14,6 +14,9 @@ defmodule Slack.NotifierTest do
       Application.put_env(:slack, :notifier, bot_token: nil, channel_id: nil)
       refute Notifier.enabled?()
 
+      Application.put_env(:slack, :notifier, bot_token: "", channel_id: "C123")
+      refute Notifier.enabled?()
+
       Application.put_env(:slack, :notifier, bot_token: "xoxb-test", channel_id: nil)
       refute Notifier.enabled?()
     end


### PR DESCRIPTION
## Summary
- make the Slack app stop treating `SLACK_BOT_TOKEN` and `SLACK_CHANNEL_ID` as required runtime configuration
- update the Helm inline secret template so notifier values default to empty strings instead of failing chart rendering
- update the managed-cluster ExternalSecret so notifier fields are sourced from `dataFrom.extract` and can be omitted from the `SLACK_INVITATION_APP` 1Password item without breaking reconciliation
- remove notifier placeholders from `values-ci.yaml` and document that the notifier fields are optional

## Root Cause
The notifier is intentionally optional in the application logic, but the runtime config and Helm chart still modeled it as required. In the managed-cluster path that meant the 1Password item had to contain `slack-bot-token` and `slack-channel-id`, even when we did not want internal Slack notifications enabled. That made the chart contract stricter than the app itself and made secret provisioning brittle.

## Why This Approach
I kept the required invitation-flow secrets (`admin-*`, Turnstile, Mailgun, invite URL) on explicit `remoteRef` entries and only relaxed the notifier path. For the managed-cluster case, the chart now extracts the whole 1Password item once and templates the optional notifier fields to empty strings when they are absent. That avoids weakening the required runtime secrets while aligning the optional notifier behavior across inline and ExternalSecret-backed deployments.

## Impact
Slack can now deploy with the notifier disabled without having to create placeholder bot credentials in 1Password. If the notifier fields are present, the app will still use them; if they are missing, the app boots normally and simply skips internal Slack notifications.

## Testing
- `helm lint infra/helm/slack -f infra/helm/slack/values-ci.yaml`
- `helm template slack infra/helm/slack -f infra/helm/slack/values-ci.yaml`
- `helm template slack infra/helm/slack -f infra/helm/slack/values-production.yaml --set image.tag=validation`
- `mise run test` in `slack/`
- `mise run format --check` in `slack/`
- `MIX_ENV=prod mix compile --warnings-as-errors` in `slack/`
