### PR TITLE
fix(infra): handle unlabeled nodes in platform install

### DIFF
--- a/infra/mise/tasks/k8s/install-platform.sh
+++ b/infra/mise/tasks/k8s/install-platform.sh
@@ -34,17 +34,34 @@ if [ ! -r "$WL_KUBECONFIG" ]; then
   exit 1
 fi
 
-# HCCM stamps every node with topology.kubernetes.io/region (e.g. ash,
-# hil, fsn1). Reading the location from the cluster keeps callers
-# free of any region-name mapping that could drift from the actual
-# placement.
-REGION="$(KUBECONFIG="$WL_KUBECONFIG" kubectl get nodes \
-  -o jsonpath='{.items[0].metadata.labels.topology\.kubernetes\.io/region}')"
-if [ -z "$REGION" ]; then
-  echo "ERROR: could not derive Hetzner location from topology.kubernetes.io/region on $WL_KUBECONFIG nodes" >&2
+derive_region_from_nodes() {
+  KUBECONFIG="$WL_KUBECONFIG" kubectl get nodes \
+    -o jsonpath='{range .items[*]}{.metadata.labels.topology\.kubernetes\.io/region}{"\n"}{end}' |
+    awk 'NF { print; exit }'
+}
+
+derive_region_from_ingress_service() {
+  KUBECONFIG="$WL_KUBECONFIG" kubectl -n platform get service platform-ingress-nginx-controller \
+    -o jsonpath='{.metadata.annotations.load-balancer\.hetzner\.cloud/location}' 2>/dev/null || true
+}
+
+# HCCM stamps hcloud-backed nodes with topology.kubernetes.io/region
+# (e.g. ash, hil, fsn1). Mixed clusters can also carry bare-metal
+# runner nodes that do not have that label, so scan all nodes instead
+# of assuming `.items[0]` is an hcloud VM.
+REGION="$(derive_region_from_nodes)"
+if [ -z "$REGION" ] && [ "$IS_KURA_REGIONAL_CLUSTER" = false ]; then
+  REGION="$(derive_region_from_ingress_service)"
+fi
+if [ -z "$REGION" ] && [ "$IS_KURA_REGIONAL_CLUSTER" = false ]; then
+  echo "ERROR: could not derive Hetzner location from topology.kubernetes.io/region on any node or from the existing ingress Service annotation on $WL_KUBECONFIG" >&2
   exit 1
 fi
-log "Platform install for $CLUSTER_NAME (region $REGION)"
+if [ -n "$REGION" ]; then
+  log "Platform install for $CLUSTER_NAME (region $REGION)"
+else
+  log "Platform install for $CLUSTER_NAME"
+fi
 
 if [ -z "${CLOUDFLARE_API_TOKEN:-}" ]; then
   CLOUDFLARE_API_TOKEN="$(op read --account tuist.1password.com \


### PR DESCRIPTION
Resolves the canary platform chart failure in <https://github.com/tuist/tuist/actions/runs/26236998813/job/77219464610>

> The platform installer assumed the first node returned by `kubectl get nodes` would always carry `topology.kubernetes.io/region`. That stopped being safe once canary started returning mixed pools that include bare-metal runner nodes without that label. This change scans all nodes for the first non-empty region label instead of indexing `.items[0]`, and for app clusters it falls back to the existing ingress Service's `load-balancer.hetzner.cloud/location` annotation before failing. That keeps the location source cluster-derived, avoids reintroducing a hardcoded region mapping, and preserves the current Kura regional behavior where ingress is skipped entirely.

### How to test locally

- `bash -n infra/mise/tasks/k8s/install-platform.sh`
