### PR TITLE
fix(cli): preserve module names for xcframework wrappers

### DIFF
--- a/cli/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
+++ b/cli/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
@@ -440,7 +440,7 @@ public struct PackageInfoMapper: PackageInfoMapping {
             .joined(separator: ".")
     }
 
-    private static func effectiveModuleName(
+    private static func effectiveProductName(
         targetName: String,
         products: Set<PackageInfo.Product>,
         packageTargets: [PackageInfo.Target]
@@ -459,9 +459,38 @@ public struct PackageInfoMapper: PackageInfoMapping {
         if targetName == productName {
             // Wrapper target already shares its name with the product (e.g. Singular 12.10.1's `Singular` target
             // wrapping `SingularBinary` at `Singular.xcframework`). Suffix the product name so Xcode doesn't emit
-            // the same `.framework` from both the wrapper target and `ProcessXCFramework`. Users importing the
-            // product name still resolve to the xcframework's module.
+            // the same `.framework` from both the wrapper target and `ProcessXCFramework`.
             return wrapsProductFramework ? "\(targetName)Wrapper" : targetName
+        }
+
+        // Target name differs from the product. SwiftPM hoists the product name onto single-target wrappers whose
+        // name has the product as a prefix (e.g. `FirebaseCrashlyticsTarget` becomes `FirebaseCrashlytics`). Skip
+        // the hoist when the rename would collide with a sibling target or the framework a wrapped binary already
+        // emits.
+        guard targetName.hasPrefix(productName) else { return targetName }
+        return wrapsProductFramework ? targetName : productName
+    }
+
+    private static func effectiveModuleName(
+        targetName: String,
+        products: Set<PackageInfo.Product>,
+        packageTargets: [PackageInfo.Target]
+    ) -> String {
+        guard products.count == 1,
+              let singleProduct = products.first,
+              singleProduct.targets.count == 1,
+              singleProduct.targets.first == targetName
+        else { return targetName }
+
+        let productName = singleProduct.name
+        let wrapsProductFramework = wrapsProductNamedFramework(
+            targetName: targetName, productName: productName, packageTargets: packageTargets
+        )
+
+        if targetName == productName {
+            // Keep the original import name even when the built artifact has to be suffixed to avoid colliding with
+            // the wrapped xcframework emitted by ProcessXCFramework.
+            return targetName
         }
 
         // Target name differs from the product. SwiftPM hoists the product name onto single-target wrappers whose
@@ -613,7 +642,7 @@ public struct PackageInfoMapper: PackageInfoMapping {
 
             moduleMap = ModuleMap.custom(moduleMapPath, umbrellaHeaderPath: nil)
         case .regular, .test:
-            let effectiveName = PackageInfoMapper.effectiveModuleName(
+            let moduleName = PackageInfoMapper.effectiveModuleName(
                 targetName: target.name, products: products, packageTargets: packageInfo.targets
             )
             let swiftPackageManagerScratchDirectory: AbsolutePath? = if packageType.isRemoteExternal {
@@ -623,7 +652,7 @@ public struct PackageInfoMapper: PackageInfoMapping {
             }
             moduleMap = try await moduleMapGenerator.generate(
                 packageDirectory: path,
-                moduleName: effectiveName,
+                moduleName: moduleName,
                 publicHeadersPath: target.publicHeadersPath(packageFolder: path),
                 swiftPackageManagerScratchDirectory: swiftPackageManagerScratchDirectory
             )
@@ -759,16 +788,23 @@ public struct PackageInfoMapper: PackageInfoMapping {
 
         let targetName = packageModuleAliases[packageInfo.name]?[target.name] ?? target.name
         let sanitizedTargetName = PackageInfoMapper.sanitize(targetName: targetName)
-        let effectiveName = PackageInfoMapper.effectiveModuleName(
+        let effectiveModuleName = PackageInfoMapper.effectiveModuleName(
             targetName: target.name, products: products, packageTargets: packageInfo.targets
         )
-        let aliasedEffectiveName = packageModuleAliases[packageInfo.name]?[effectiveName] ?? effectiveName
-        let productName = PackageInfoMapper.sanitize(targetName: aliasedEffectiveName)
+        let aliasedEffectiveModuleName = packageModuleAliases[packageInfo.name]?[effectiveModuleName] ?? effectiveModuleName
+        let moduleName = PackageInfoMapper.sanitize(targetName: aliasedEffectiveModuleName)
+            .replacingOccurrences(of: "-", with: "_")
+        let effectiveProductName = PackageInfoMapper.effectiveProductName(
+            targetName: target.name, products: products, packageTargets: packageInfo.targets
+        )
+        let aliasedEffectiveProductName = packageModuleAliases[packageInfo.name]?[effectiveProductName] ?? effectiveProductName
+        let productName = PackageInfoMapper.sanitize(targetName: aliasedEffectiveProductName)
             .replacingOccurrences(of: "-", with: "_")
 
         let settings = try await Settings.from(
             target: target,
             productName: productName,
+            moduleName: moduleName,
             packageFolder: packageFolder,
             settings: target.settings,
             moduleMap: moduleMap,
@@ -1314,6 +1350,7 @@ extension ProjectDescription.Settings {
     fileprivate static func from(
         target: PackageInfo.Target,
         productName: String,
+        moduleName: String,
         packageFolder: AbsolutePath,
         settings: [PackageInfo.Target.TargetBuildSettingDescription.Setting],
         moduleMap: ModuleMap?,
@@ -1383,6 +1420,10 @@ extension ProjectDescription.Settings {
         let resolvedSettings = try mapper.mapSettings()
         settingsDictionary.merge(resolvedSettings) { $1 }
 
+        if moduleName != productName {
+            settingsDictionary["PRODUCT_MODULE_NAME"] = .string(moduleName)
+        }
+
         if forceEnabledTestingSearchPath.contains(target.name) {
             if settingsDictionary["ENABLE_TESTING_SEARCH_PATHS"] == nil {
                 settingsDictionary["ENABLE_TESTING_SEARCH_PATHS"] = "YES"
@@ -1399,10 +1440,10 @@ extension ProjectDescription.Settings {
                 settingsDictionary["DEFINES_MODULE"] = "NO"
                 switch settingsDictionary["OTHER_CFLAGS"] ?? .array(["$(inherited)"]) {
                 case let .array(values):
-                    settingsDictionary["OTHER_CFLAGS"] = .array(values + ["-fmodule-name=\(productName)"])
+                    settingsDictionary["OTHER_CFLAGS"] = .array(values + ["-fmodule-name=\(moduleName)"])
                 case let .string(value):
                     settingsDictionary["OTHER_CFLAGS"] = .array(
-                        value.split(separator: " ").map(String.init) + ["-fmodule-name=\(productName)"]
+                        value.split(separator: " ").map(String.init) + ["-fmodule-name=\(moduleName)"]
                     )
                 }
             case .none:

--- a/cli/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
+++ b/cli/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
@@ -6915,6 +6915,11 @@ struct PackageInfoMapperTests {
                             "Singular",
                             basePath: basePath,
                             customProductName: "SingularWrapper",
+                            dependencies: [.xcframework(path: .path(
+                                basePath
+                                    .appending(try RelativePath(validating: "Singular.xcframework"))
+                                    .pathString
+                            ))],
                             customSettings: [
                                 "HEADER_SEARCH_PATHS": ["$(inherited)", "$(SRCROOT)/Sources/Singular/include"],
                                 "DEFINES_MODULE": "NO",

--- a/cli/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
+++ b/cli/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
@@ -6863,6 +6863,72 @@ struct PackageInfoMapperTests {
 
         let mappedTarget = try #require(project?.targets.first(where: { $0.name == "Singular" }))
         #expect(mappedTarget.productName == "SingularWrapper")
+        #expect(mappedTarget.settings?.base["PRODUCT_MODULE_NAME"] == .string("Singular"))
+    }
+
+    @Test(
+        .inTemporaryDirectory, .withMockedSwiftVersionProvider
+    ) func map_whenWrapperTargetSharesProductNameWithBinaryXcframework_keepsOriginalModuleNameInModuleMap() async throws {
+        let basePath = try #require(FileSystem.temporaryTestDirectory)
+        let headersPath = basePath.appending(try RelativePath(validating: "Package/Sources/Singular/include"))
+        let headerPath = headersPath.appending(component: "Singular.h")
+
+        try await fileSystem.makeDirectory(at: headersPath)
+        try await fileSystem.writeText("", at: headerPath)
+
+        let project = try await subject.map(
+            package: "Package",
+            basePath: basePath,
+            packageInfos: [
+                "Package": .test(
+                    name: "Singular",
+                    products: [
+                        .init(name: "Singular", type: .library(.automatic), targets: ["Singular"]),
+                    ],
+                    targets: [
+                        .test(
+                            name: "Singular",
+                            dependencies: [
+                                .target(name: "SingularBinary", condition: nil),
+                            ]
+                        ),
+                        .test(
+                            name: "SingularBinary",
+                            type: .binary,
+                            path: "Singular.xcframework"
+                        ),
+                    ],
+                    platforms: [.ios],
+                    cLanguageStandard: nil,
+                    cxxLanguageStandard: nil,
+                    swiftLanguageVersions: nil
+                ),
+            ]
+        )
+
+        #expect(
+            project ==
+                .testWithDefaultConfigs(
+                    name: "Singular",
+                    targets: [
+                        .test(
+                            "Singular",
+                            basePath: basePath,
+                            customProductName: "SingularWrapper",
+                            customSettings: [
+                                "HEADER_SEARCH_PATHS": ["$(inherited)", "$(SRCROOT)/Sources/Singular/include"],
+                                "DEFINES_MODULE": "NO",
+                                "OTHER_CFLAGS": .array(["$(inherited)", "-fmodule-name=Singular"]),
+                                "OTHER_SWIFT_FLAGS": [
+                                    "$(inherited)",
+                                ],
+                                "PRODUCT_MODULE_NAME": "Singular",
+                            ],
+                            moduleMap: "$(SRCROOT)/Derived/Singular.modulemap"
+                        ),
+                    ]
+                )
+        )
     }
 
     @Test(


### PR DESCRIPTION
## Summary
- Fix the SwiftPM wrapper regression where same-name source wrappers around `.xcframework` binaries inherited the suffixed artifact name as their module name after the wrapper collision handling added in `4.181.1`.
- Split wrapper artifact naming from module naming so Tuist can still emit `...Wrapper` products to avoid `ProcessXCFramework` collisions while preserving the original import/module name via `PRODUCT_MODULE_NAME` and module-map flags.
- Add regression coverage for same-name wrapper targets, including the header and module-map path that local packages use.

## Testing
- `xcodebuild test -workspace Tuist.xcworkspace -scheme TuistUnitTests -destination 'platform=macOS' -only-testing:TuistLoaderTests/PackageInfoMapperTests/map_whenWrapperTargetSharesProductNameWithBinaryXcframework_suffixesProductName -only-testing:TuistLoaderTests/PackageInfoMapperTests/map_whenWrapperTargetSharesProductNameWithBinaryXcframework_keepsOriginalModuleNameInModuleMap CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY='' COMPILATION_CACHE_ENABLE_CACHING=NO`
