### PR TITLE
chore(ci): register macos-xcode-image workflow on main as a stub

### DIFF
--- a/.github/workflows/macos-xcode-image.yml
+++ b/.github/workflows/macos-xcode-image.yml
@@ -1,0 +1,45 @@
+name: macOS + Xcode Image
+
+# Registration stub. The real implementation of this workflow
+# lives on the development branch shipping the macos-xcode-image
+# work (PR #10834) and a few iterations beyond. GitHub Actions
+# requires a workflow to exist on the default branch before
+# `workflow_dispatch --ref <branch>` can target it; the actual
+# execution body comes from whichever ref is dispatched, so this
+# file's job content is only what runs when someone dispatches
+# the stub against `main` directly.
+#
+# Once #10834 merges, the no-op `stub` job below is overwritten
+# by the real Packer build that lays Xcode onto
+# `macos-tahoe-base`. Until then, dispatching against `main`
+# fails fast with a pointer to the implementing branch — better
+# than silently succeeding with nothing done.
+
+on:
+  workflow_dispatch:
+    inputs:
+      # Inputs match the real workflow's schema so dispatches
+      # against the development branch can pass them through
+      # `gh workflow run --ref <branch>` without surprises.
+      xcode_version:
+        description: "Xcode version to install (e.g. 26.4.1, 26.5)."
+        required: true
+      base_image:
+        description: "Base Tart image to layer Xcode onto"
+        required: false
+        default: "ghcr.io/cirruslabs/macos-tahoe-base:latest"
+
+jobs:
+  stub:
+    runs-on: ubuntu-latest
+    steps:
+      - name: This is the registration stub, not the real workflow
+        run: |
+          {
+            echo "::error::macos-xcode-image's stub on main was dispatched directly."
+            echo "::error::The real implementation lives on the development branch."
+            echo "::error::Dispatch with --ref <branch>:"
+            echo "::error::  gh workflow run macos-xcode-image.yml --ref <branch> -f xcode_version=${{ inputs.xcode_version }}"
+            echo "::error::See https://github.com/tuist/tuist/pull/10834 for context."
+          } >&2
+          exit 1


### PR DESCRIPTION
> Lands the registration stub for the `macos-xcode-image` workflow so `gh workflow run macos-xcode-image.yml --ref <branch>` works against #10834's branch. The full implementation (Packer template, mise tasks, `oras` + `xcodes` pins in `mise.toml`, AGENTS.md) stays on #10834 for proper review.

## Why a stub?

GitHub Actions only lets you dispatch a `workflow_dispatch` against a workflow that exists on the default branch — even when you pass `--ref <other-branch>`. The branch's version of the workflow is what *runs*, but main is the registration surface. So the smallest unit that unblocks `gh workflow run --ref claude/dreamy-banach-49bf79 -f xcode_version=26.5` is a single workflow YAML on main with the right name and inputs schema.

## Behaviour

- **Dispatched with `--ref <implementing-branch>`** (the intended path): GitHub uses the workflow YAML from that branch, runs the real Packer build against the bare-metal builder Mac mini, pushes `ghcr.io/tuist/macos-tahoe-xcode:<xcode-version-dashes>` to GHCR.
- **Dispatched against `main` directly** (the unintended path): the stub job runs, fails fast with an `::error::` pointing at #10834. Better than silently succeeding with nothing built.

Inputs (`xcode_version`, `base_image`) mirror #10834's schema so passthrough dispatches don't hit "unknown input" validation.

## Test plan

- `actionlint` clean (only the pre-existing self-hosted-label warnings on the other workflows in this repo).
- Post-merge: `gh workflow run macos-xcode-image.yml --ref claude/dreamy-banach-49bf79 -f xcode_version=26.5` → workflow runs against #10834's branch → `ghcr.io/tuist/macos-tahoe-xcode:26-5` lands in GHCR.

## What's *not* in this PR

Stays on #10834:
- `infra/macos-xcode-image/macos-xcode.pkr.hcl` (the actual Packer template)
- `infra/macos-xcode-image/AGENTS.md`
- `mise/tasks/xcode-mirror/upload.sh`
- `mise.toml` additions (`oras`, `xcodes`)
- Layer 2 simplifications for `runner-image` / `xcresult-processor-image`
- Per-image `XCODE_VERSION` pin files
- All chart wiring

Once #10834 merges, the stub job here gets overwritten by the real Packer build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)