### PR TITLE
fix(server): guard marketing blog iframe template resolution

### DIFF
--- a/server/lib/tuist_web/marketing/controllers/marketing_blog_iframe_controller.ex
+++ b/server/lib/tuist_web/marketing/controllers/marketing_blog_iframe_controller.ex
@@ -10,29 +10,43 @@ defmodule TuistWeb.Marketing.MarketingBlogIframeController do
   def show(conn, params) do
     case Map.get(params, "id") do
       nil ->
-        # No id parameter - return empty page
-        conn
-        |> put_resp_content_type("text/html")
-        |> send_resp(200, "")
+        empty_page(conn, 200)
 
       id ->
-        # Build template name from route params so the locale prefix in the
-        # request path doesn't leak into the template lookup.
-        # e.g., year=2025, month=11, day=6, slug=zero-to-many, id=lone_wolf
-        # becomes :blog_2025_11_6_zero_to_many_lone_wolf
-        template =
-          "blog_#{params["year"]}_#{params["month"]}_#{params["day"]}_#{params["slug"]}_#{id}"
-          |> String.replace("-", "_")
-          |> String.to_atom()
+        case iframe_template(params, id) do
+          {:ok, template} ->
+            conn
+            |> put_resp_content_type("text/html")
+            |> put_layout(false)
+            |> put_view(MarketingHTML)
+            |> assign(:plain_disabled?, true)
+            |> assign(:analytics_disabled?, true)
+            |> render(template)
 
-        # Render the template directly without LiveView
-        conn
-        |> put_resp_content_type("text/html")
-        |> put_layout(false)
-        |> put_view(MarketingHTML)
-        |> assign(:plain_disabled?, true)
-        |> assign(:analytics_disabled?, true)
-        |> render(template)
+          :error ->
+            empty_page(conn, 404)
+        end
     end
+  end
+
+  defp iframe_template(params, id) do
+    template_name =
+      String.replace("blog_#{params["year"]}_#{params["month"]}_#{params["day"]}_#{params["slug"]}_#{id}", "-", "_")
+
+    :functions
+    |> MarketingHTML.__info__()
+    |> Enum.find_value(:error, fn
+      {name, 1} ->
+        if Atom.to_string(name) == template_name, do: {:ok, name}
+
+      _ ->
+        nil
+    end)
+  end
+
+  defp empty_page(conn, status) do
+    conn
+    |> put_resp_content_type("text/html")
+    |> send_resp(status, "")
   end
 end

--- a/server/test/tuist_web/controllers/marketing_blog_iframe_controller_test.exs
+++ b/server/test/tuist_web/controllers/marketing_blog_iframe_controller_test.exs
@@ -29,5 +29,26 @@ defmodule TuistWeb.Marketing.MarketingBlogIframeControllerTest do
       assert response(conn, 200) =~ "viz-container"
       assert get_resp_header(conn, "content-type") == ["text/html; charset=utf-8"]
     end
+
+    test "returns 404 when the requested visualization does not exist", %{conn: conn} do
+      # When
+      conn = get(conn, "/blog/2025/11/17/smart-before-fast/iframe.html?id=does_not_exist")
+
+      # Then
+      assert response(conn, 404) == ""
+      assert get_resp_header(conn, "content-type") == ["text/html; charset=utf-8"]
+    end
+
+    test "returns 404 for malformed visualization ids", %{conn: conn} do
+      # When
+      conn =
+        get(conn, "/blog/2025/11/17/smart-before-fast/iframe.html", %{
+          "id" => "5712' ORDER BY 1#"
+        })
+
+      # Then
+      assert response(conn, 404) == ""
+      assert get_resp_header(conn, "content-type") == ["text/html; charset=utf-8"]
+    end
   end
 end


### PR DESCRIPTION
[Fixes](https://tuist.sentry.io/issues/101629638/?project=4510777094373456&referrer=metric-issue-contributing-issues-issue-stream)

## Summary
- Stop turning the marketing blog iframe `id` query parameter into a fresh atom during template lookup.
- Resolve iframe templates only from compiled `MarketingHTML` functions so localized routes still work, but unknown or malformed ids now return a blank `404` instead of raising.
- Add controller regressions for an unknown visualization id and the malformed `5712' ORDER BY 1#` id that showed up in Sentry.

## Testing
- `MIX_ENV=test mix test test/tuist_web/controllers/marketing_blog_iframe_controller_test.exs`
