### PR TITLE
fix(server): route project-only test case run listings through a slim MV

### DIFF
--- a/server/lib/tuist/tests.ex
+++ b/server/lib/tuist/tests.ex
@@ -44,6 +44,7 @@ defmodule Tuist.Tests do
   alias Tuist.Tests.TestCaseRunArgument
   alias Tuist.Tests.TestCaseRunAttachment
   alias Tuist.Tests.TestCaseRunByCommit
+  alias Tuist.Tests.TestCaseRunByProject
   alias Tuist.Tests.TestCaseRunByShardId
   alias Tuist.Tests.TestCaseRunByTestRun
   alias Tuist.Tests.TestCaseRunDashboardCount
@@ -1042,6 +1043,12 @@ defmodule Tuist.Tests do
       {:test_run_id, _test_run_id} ->
         list_test_case_runs_via_test_run_mv(attrs, preloads)
 
+      {:test_case_id, _test_case_id} ->
+        list_test_case_runs_from(from(tcr in TestCaseRun), attrs, preloads)
+
+      {:project_id, _project_id} ->
+        list_test_case_runs_via_project_mv(attrs, preloads)
+
       nil ->
         list_test_case_runs_from(from(tcr in TestCaseRun), attrs, preloads)
     end
@@ -1084,6 +1091,27 @@ defmodule Tuist.Tests do
 
     {slim_results, meta} =
       Tuist.ClickHouseFlop.validate_and_run!(base_query, attrs, for: TestCaseRunByShardId)
+
+    ids = Enum.map(slim_results, & &1.id)
+
+    full_results = fetch_full_test_case_runs(slim_results)
+
+    ordered_by_id = Map.new(full_results, &{&1.id, &1})
+    ordered = ids |> Enum.map(&Map.get(ordered_by_id, &1)) |> Enum.reject(&is_nil/1)
+
+    results =
+      ordered
+      |> ClickHouseRepo.preload(preloads)
+      |> Repo.preload(:ran_by_account)
+
+    {results, meta}
+  end
+
+  defp list_test_case_runs_via_project_mv(attrs, preloads) do
+    base_query = from(mv in TestCaseRunByProject, hints: ["FINAL"])
+
+    {slim_results, meta} =
+      Tuist.ClickHouseFlop.validate_and_run!(base_query, attrs, for: TestCaseRunByProject)
 
     ids = Enum.map(slim_results, & &1.id)
 
@@ -1145,25 +1173,38 @@ defmodule Tuist.Tests do
     end)
   end
 
+  # Filter precedence for routing: a narrower scope wins so we use the
+  # most-selective MV available. `test_case_id` keeps the main table because
+  # its primary key `(project_id, test_case_id, ran_at, id)` already serves
+  # those queries cheaply. `project_id` falls through to the project MV when
+  # no narrower scope is present — without it, the listing query scans every
+  # row for the project.
   defp extract_mv_scope_filter(%{filters: filters}) when is_list(filters) do
-    Enum.find_value(filters, fn
-      %{field: :test_run_id, op: :==, value: value} -> {:test_run_id, value}
-      %{field: :shard_id, op: :==, value: value} -> {:shard_id, value}
-      _ -> nil
-    end)
+    filters
+    |> Enum.map(&filter_scope/1)
+    |> pick_mv_scope()
   end
 
   defp extract_mv_scope_filter(%Flop{} = flop) do
     flop.filters
     |> List.wrap()
-    |> Enum.find_value(fn
-      %Flop.Filter{field: :test_run_id, op: :==, value: value} -> {:test_run_id, value}
-      %Flop.Filter{field: :shard_id, op: :==, value: value} -> {:shard_id, value}
-      _ -> nil
-    end)
+    |> Enum.map(&filter_scope/1)
+    |> pick_mv_scope()
   end
 
   defp extract_mv_scope_filter(_), do: nil
+
+  defp filter_scope(%{field: :test_run_id, op: :==, value: value}), do: {:test_run_id, value}
+  defp filter_scope(%{field: :shard_id, op: :==, value: value}), do: {:shard_id, value}
+  defp filter_scope(%{field: :test_case_id, op: :==, value: value}), do: {:test_case_id, value}
+  defp filter_scope(%{field: :project_id, op: :==, value: value}), do: {:project_id, value}
+  defp filter_scope(_), do: nil
+
+  defp pick_mv_scope(scopes) do
+    Enum.find_value([:test_run_id, :shard_id, :test_case_id, :project_id], fn key ->
+      Enum.find(scopes, &match?({^key, _}, &1))
+    end)
+  end
 
   @doc """
   Gets a test case run by its UUID.

--- a/server/lib/tuist/tests/test_case_run_by_project.ex
+++ b/server/lib/tuist/tests/test_case_run_by_project.ex
@@ -1,0 +1,50 @@
+defmodule Tuist.Tests.TestCaseRunByProject do
+  @moduledoc """
+  Slim read-only schema backed by the `test_case_runs_by_project` materialized
+  view. Ordered by `(project_id, ran_at, id)`, making queries that filter by
+  `project_id` and sort by `ran_at` efficient without scanning the whole
+  project on the main table.
+
+  Used by `Tuist.Tests.list_test_case_runs/2` for the project-only filter
+  path: filter + sort + paginate run on the MV, then the page-sized set of
+  IDs is fetched from the main `test_case_runs` table.
+  """
+  use Ecto.Schema
+
+  @derive {
+    Flop.Schema,
+    filterable: [
+      :project_id,
+      :test_case_id,
+      :name,
+      :status,
+      :is_flaky,
+      :is_new,
+      :is_ci,
+      :is_quarantined,
+      :duration,
+      :account_id,
+      :scheme,
+      :git_branch
+    ],
+    sortable: [:inserted_at, :duration, :name, :ran_at]
+  }
+
+  @primary_key {:id, Ecto.UUID, autogenerate: false}
+  schema "test_case_runs_by_project" do
+    field :project_id, Ch, type: "Int64"
+    field :ran_at, Ch, type: "DateTime64(6)"
+    field :inserted_at, Ch, type: "DateTime64(6)"
+    field :name, Ch, type: "String"
+    field :status, Ch, type: "Enum8('success' = 0, 'failure' = 1, 'skipped' = 2)"
+    field :is_flaky, :boolean, default: false
+    field :is_new, :boolean, default: false
+    field :is_ci, :boolean, default: false
+    field :is_quarantined, :boolean, default: false
+    field :duration, Ch, type: "Int32"
+    field :test_case_id, Ch, type: "Nullable(UUID)"
+    field :account_id, Ch, type: "Nullable(Int64)"
+    field :scheme, Ch, type: "String"
+    field :git_branch, Ch, type: "String"
+  end
+end

--- a/server/priv/ingest_repo/migrations/20260526111417_create_test_case_runs_by_project_mv.exs
+++ b/server/priv/ingest_repo/migrations/20260526111417_create_test_case_runs_by_project_mv.exs
@@ -1,0 +1,116 @@
+defmodule Tuist.IngestRepo.Migrations.CreateTestCaseRunsByProjectMv do
+  @moduledoc """
+  Slim materialized view ordered by `(project_id, ran_at, id)` to support
+  efficient listing of test case runs scoped to a project, sorted by `ran_at`.
+
+  The main `test_case_runs` table's primary key is
+  `(project_id, test_case_id, ran_at, id)`. Queries that filter by
+  `project_id` alone and sort by `ran_at DESC` cannot stream rows in `ran_at`
+  order — `ran_at` is only sorted within each `test_case_id`. ClickHouse
+  therefore reads every row for the project before applying the LIMIT.
+  On busy projects this scans 100M+ rows and times out at 15s.
+
+  Projections on the parent table cannot be used to fix this:
+  `test_case_runs` is a ReplacingMergeTree and ClickHouse projections do not
+  work with it (issue #46968), which is why the historical
+  `proj_test_case_runs_by_project_ran_at` was dropped in
+  `20260319120000_reorder_test_case_runs.exs`.
+
+  Uses the explicit TO-table pattern with `ReplacingMergeTree(inserted_at)` so
+  re-inserts in `test_case_runs` (e.g. flaky-flag updates) deduplicate here
+  too. Query reads use the `FINAL` hint to collapse pending duplicates,
+  matching `test_case_runs_by_test_run`.
+
+  Full rows are fetched from the main table for the page-sized result set,
+  mirroring the pattern used by `test_case_runs_by_test_run` and
+  `test_case_runs_by_shard_id`.
+  """
+  use Ecto.Migration
+  alias Tuist.IngestRepo
+  require Logger
+
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  @columns ~w(id project_id ran_at inserted_at name status is_flaky is_new is_ci is_quarantined duration test_case_id account_id scheme git_branch)
+
+  def up do
+    IngestRepo.query!("""
+    CREATE TABLE IF NOT EXISTS test_case_runs_by_project (
+      id UUID,
+      project_id Int64,
+      ran_at DateTime64(6),
+      inserted_at DateTime64(6),
+      name String,
+      status Enum8('success' = 0, 'failure' = 1, 'skipped' = 2),
+      is_flaky Bool DEFAULT false,
+      is_new Bool DEFAULT false,
+      is_ci Bool DEFAULT false,
+      is_quarantined Bool DEFAULT false,
+      duration Int32,
+      test_case_id Nullable(UUID),
+      account_id Nullable(Int64),
+      scheme String DEFAULT '',
+      git_branch String DEFAULT ''
+    ) ENGINE = ReplacingMergeTree(inserted_at)
+    ORDER BY (project_id, ran_at, id)
+    """)
+
+    backfill_by_partition()
+
+    IngestRepo.query!("""
+    CREATE MATERIALIZED VIEW IF NOT EXISTS test_case_runs_by_project_mv
+    TO test_case_runs_by_project
+    AS SELECT #{Enum.join(@columns, ", ")}
+    FROM test_case_runs
+    """)
+  end
+
+  def down do
+    IngestRepo.query!("DROP VIEW IF EXISTS test_case_runs_by_project_mv")
+    IngestRepo.query!("DROP TABLE IF EXISTS test_case_runs_by_project")
+  end
+
+  defp backfill_by_partition do
+    {:ok, %{rows: partitions}} =
+      IngestRepo.query(
+        """
+        SELECT DISTINCT partition
+        FROM system.parts
+        WHERE database = currentDatabase() AND table = {table:String} AND active
+        ORDER BY partition
+        """,
+        %{table: "test_case_runs"}
+      )
+
+    for [partition] <- partitions do
+      Logger.info("Backfilling partition #{partition} into test_case_runs_by_project")
+
+      retry_on_shutting_down(fn ->
+        IngestRepo.query!(
+          """
+          INSERT INTO test_case_runs_by_project (#{Enum.join(@columns, ", ")})
+          SELECT #{Enum.join(@columns, ", ")}
+          FROM test_case_runs FINAL
+          WHERE toYYYYMM(inserted_at) = {partition:UInt32}
+          """,
+          %{partition: String.to_integer(partition)},
+          timeout: 1_200_000
+        )
+      end)
+    end
+  end
+
+  defp retry_on_shutting_down(fun, attempts \\ 5) do
+    fun.()
+  rescue
+    e in Ch.Error ->
+      if attempts > 1 and String.contains?(to_string(e.message), "TABLE_IS_READ_ONLY") do
+        Logger.warning("Table is shutting down, retrying in 5s (#{attempts - 1} attempts left)")
+        Process.sleep(:timer.seconds(5))
+        retry_on_shutting_down(fun, attempts - 1)
+      else
+        reraise e, __STACKTRACE__
+      end
+  end
+end

--- a/server/test/tuist/tests_test.exs
+++ b/server/test/tuist/tests_test.exs
@@ -752,6 +752,70 @@ defmodule Tuist.TestsTest do
       assert test_cases == []
       assert meta.total_count == 0
     end
+
+    test "lists test case runs scoped to a project across multiple test runs" do
+      # Given
+      project = ProjectsFixtures.project_fixture()
+
+      {:ok, _first_test} =
+        RunsFixtures.test_fixture(
+          project_id: project.id,
+          test_modules: [
+            %{
+              name: "ModuleA",
+              status: "success",
+              duration: 1000,
+              test_cases: [
+                %{name: "testAlpha", status: "success", duration: 100},
+                %{name: "testBeta", status: "failure", duration: 200}
+              ]
+            }
+          ]
+        )
+
+      {:ok, _second_test} =
+        RunsFixtures.test_fixture(
+          project_id: project.id,
+          test_modules: [
+            %{
+              name: "ModuleB",
+              status: "success",
+              duration: 500,
+              test_cases: [
+                %{name: "testGamma", status: "success", duration: 50}
+              ]
+            }
+          ]
+        )
+
+      # Different project — must not show up.
+      {:ok, _other_project_test} =
+        RunsFixtures.test_fixture(
+          test_modules: [
+            %{
+              name: "ModuleC",
+              status: "success",
+              duration: 100,
+              test_cases: [
+                %{name: "testDelta", status: "success", duration: 25}
+              ]
+            }
+          ]
+        )
+
+      # When
+      {runs, meta} =
+        Tests.list_test_case_runs(%{
+          filters: [%{field: :project_id, op: :==, value: project.id}],
+          order_by: [:ran_at],
+          order_directions: [:desc]
+        })
+
+      # Then
+      assert meta.total_count == 3
+      names = runs |> Enum.map(& &1.name) |> Enum.sort()
+      assert names == ["testAlpha", "testBeta", "testGamma"]
+    end
   end
 
   describe "get_test_run_failures_count/1" do


### PR DESCRIPTION
### Summary

The API endpoint `GET /projects/:account/:project/test_case_runs` filters only by `project_id` when neither `test_run_id` nor `test_case_id` is provided. With the main `test_case_runs` `ORDER BY (project_id, test_case_id, ran_at, id)`, that query has to scan every row for the project before `ORDER BY ran_at DESC LIMIT N` can resolve, because `ran_at` is only sorted within each `test_case_id`. On a busy project this is ~110M rows and times out at 15s. The historical `proj_test_case_runs_by_project_ran_at` projection was dropped when the parent table moved to `ReplacingMergeTree` (projections + RMT don't coexist).

### Fix

Add a slim materialized view `test_case_runs_by_project` ordered by `(project_id, ran_at, id)` (`ReplacingMergeTree(inserted_at)`), and route project-only listings through it, mirroring the established `test_case_runs_by_test_run` / `test_case_runs_by_shard_id` pattern: slim MV serves filter+sort+paginate, then we look up the page rows in the main table by `id`.

Filter precedence in `Tuist.Tests.list_test_case_runs/2`:

1. `test_run_id` -> `TestCaseRunByTestRun` MV
2. `shard_id` -> `TestCaseRunByShardId` MV
3. `test_case_id` -> main table (PK `(project_id, test_case_id, ran_at, id)` already covers it cheaply)
4. `project_id` -> new `TestCaseRunByProject` MV

### Why this approach

Considered alternatives:

- **Re-add the projection on the main table.** Not possible: `test_case_runs` is `ReplacingMergeTree`, which doesn't support projections.
- **Reorder the main table.** Would invalidate every existing access pattern and require a full backfill.
- **Add a skip index.** Doesn't help when the filter is the entire project and the bottleneck is the sort, not the scan.

A slim MV matches the pattern already used for `test_run_id` and `shard_id` scopes and keeps the main table untouched.

### Impact

- API list endpoint and any LiveView / MCP tool path that lists test case runs scoped to a project (no test_run_id / test_case_id) goes from a 110M-row scan to an ordered slim-MV read of page size.
- New ingest path writes to one additional MV; throughput impact is the same as the existing per-test-run and per-shard MVs.
- No schema change to the main `test_case_runs` table.

### How to test locally

1. Apply migrations: `cd server && mise exec -- mix ecto.migrate`.
2. Run the targeted test:
   ```
   cd server && mise exec -- mix test test/tuist/tests_test.exs --only describe:\"list_test_case_runs/1\"
   ```
3. Broader sanity:
   ```
   mise exec -- mix test test/tuist/tests_test.exs test/tuist_web/controllers/api/test_case_runs_controller_test.exs test/tuist_web/live/test_case_live_test.exs test/tuist_web/live/test_run_live_test.exs test/tuist/mcp/components/tools/test_tools_test.exs
   ```

### Validation done

- `list_test_case_runs/1` describe block: 4/4 green (new test covers project-scoped listing across multiple test runs, isolated from other projects).
- Full affected file set: 266/266 green across `tests_test.exs`, `test_case_runs_controller_test.exs`, `test_case_live_test.exs`, `test_run_live_test.exs`, `test_tools_test.exs`.
- `mix format` and `mix credo` clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)