### PR TITLE
fix(server): send large test case lookups as multipart

### DIFF
--- a/server/lib/tuist/tests.ex
+++ b/server/lib/tuist/tests.ex
@@ -784,16 +784,9 @@ defmodule Tuist.Tests do
     |> Enum.uniq()
   end
 
-  # Batch size for `id IN (...)` lookups. Each UUID is ~38 bytes encoded in the
-  # SQL body, so 5_000 IDs is ~190 KB, well below ClickHouse's default
-  # `max_query_size` of 256 KB even with surrounding query text. Larger batches
-  # would risk a `TOO_LARGE_QUERY` rejection on big test reports.
-  #
-  # This lookup intentionally uses a raw multipart query instead of the Ecto
-  # `Repo.all` path. The ClickHouse client backing Ecto sends bound params as
-  # HTTP URL params, which turns a large `id IN ^ids` list into a request-line
-  # blow-up and can trigger 431 "Request Header Fields Too Large" on self-hosted
-  # stacks even though the SQL itself is within ClickHouse limits.
+  # Batch size for multipart `id IN ^ids` lookups. The generated SQL still
+  # contains one placeholder per test case ID, so we keep the batches small
+  # enough to stay below ClickHouse query/form limits on large reports.
   @existing_test_cases_batch_size 5_000
 
   defp get_existing_test_cases(_project_id, []), do: %{}
@@ -813,71 +806,24 @@ defmodule Tuist.Tests do
   end
 
   defp fetch_existing_test_cases_chunk(project_id, ids_chunk) do
-    %{rows: rows} =
-      ClickHouseRepo.query!(
-        """
-        SELECT
-          id,
-          recent_durations,
-          is_flaky,
-          state,
-          last_ran_at_ci,
-          last_ran_at_local,
-          inserted_at
-        FROM test_cases
-        WHERE project_id = {project_id:Int64}
-          AND id IN (#{inline_uuid_list(ids_chunk)})
-        """,
-        %{project_id: project_id},
-        multipart: true
-      )
-
-    Enum.map(rows, &decode_existing_test_case_row/1)
+    project_id
+    |> existing_test_cases_chunk_query(ids_chunk)
+    |> ClickHouseRepo.all(multipart: true)
   end
 
-  defp inline_uuid_list(ids_chunk) do
-    Enum.map_join(ids_chunk, ",", fn id ->
-      "'#{Ecto.UUID.cast!(id)}'::UUID"
-    end)
-  end
-
-  defp decode_existing_test_case_row([
-         id,
-         recent_durations,
-         is_flaky,
-         state,
-         last_ran_at_ci,
-         last_ran_at_local,
-         inserted_at
-       ]) do
-    %{
-      id: decode_clickhouse_uuid(id),
-      recent_durations: recent_durations || [],
-      is_flaky: decode_clickhouse_boolean(is_flaky),
-      state: state,
-      last_ran_at_ci: decode_clickhouse_datetime(last_ran_at_ci),
-      last_ran_at_local: decode_clickhouse_datetime(last_ran_at_local),
-      inserted_at: decode_clickhouse_datetime(inserted_at)
-    }
-  end
-
-  defp decode_clickhouse_uuid(uuid) when is_binary(uuid) and byte_size(uuid) == 16, do: Ecto.UUID.load!(uuid)
-  defp decode_clickhouse_uuid(uuid), do: uuid
-
-  defp decode_clickhouse_boolean(value) when value in [true, false], do: value
-  defp decode_clickhouse_boolean(1), do: true
-  defp decode_clickhouse_boolean(0), do: false
-  defp decode_clickhouse_boolean(value), do: value
-
-  defp decode_clickhouse_datetime(nil), do: nil
-  defp decode_clickhouse_datetime(%NaiveDateTime{} = value), do: value
-  defp decode_clickhouse_datetime(%DateTime{} = value), do: DateTime.to_naive(value)
-
-  defp decode_clickhouse_datetime(value) when is_binary(value) do
-    case NaiveDateTime.from_iso8601(value) do
-      {:ok, datetime} -> datetime
-      {:error, _} -> value
-    end
+  defp existing_test_cases_chunk_query(project_id, ids_chunk) do
+    from(tc in TestCase,
+      where: tc.project_id == ^project_id and tc.id in ^ids_chunk,
+      select: %{
+        id: tc.id,
+        recent_durations: tc.recent_durations,
+        is_flaky: tc.is_flaky,
+        state: tc.state,
+        last_ran_at_ci: tc.last_ran_at_ci,
+        last_ran_at_local: tc.last_ran_at_local,
+        inserted_at: tc.inserted_at
+      }
+    )
   end
 
   defp merge_latest_test_case(row, acc) do

--- a/server/lib/tuist/tests.ex
+++ b/server/lib/tuist/tests.ex
@@ -785,9 +785,15 @@ defmodule Tuist.Tests do
   end
 
   # Batch size for `id IN (...)` lookups. Each UUID is ~38 bytes encoded in the
-  # SQL, so 5_000 IDs is ~190 KB, well below ClickHouse's default
+  # SQL body, so 5_000 IDs is ~190 KB, well below ClickHouse's default
   # `max_query_size` of 256 KB even with surrounding query text. Larger batches
   # would risk a `TOO_LARGE_QUERY` rejection on big test reports.
+  #
+  # This lookup intentionally uses a raw multipart query instead of the Ecto
+  # `Repo.all` path. The ClickHouse client backing Ecto sends bound params as
+  # HTTP URL params, which turns a large `id IN ^ids` list into a request-line
+  # blow-up and can trigger 431 "Request Header Fields Too Large" on self-hosted
+  # stacks even though the SQL itself is within ClickHouse limits.
   @existing_test_cases_batch_size 5_000
 
   defp get_existing_test_cases(_project_id, []), do: %{}
@@ -801,26 +807,77 @@ defmodule Tuist.Tests do
     |> Enum.chunk_every(@existing_test_cases_batch_size)
     |> Enum.reduce(%{}, fn ids_chunk, acc ->
       project_id
-      |> existing_test_cases_chunk_query(ids_chunk)
-      |> ClickHouseRepo.all()
+      |> fetch_existing_test_cases_chunk(ids_chunk)
       |> Enum.reduce(acc, &merge_latest_test_case/2)
     end)
   end
 
-  defp existing_test_cases_chunk_query(project_id, ids_chunk) do
-    from(test_case in TestCase,
-      where: test_case.project_id == ^project_id,
-      where: test_case.id in ^ids_chunk,
-      select: %{
-        id: test_case.id,
-        recent_durations: test_case.recent_durations,
-        is_flaky: test_case.is_flaky,
-        state: test_case.state,
-        last_ran_at_ci: test_case.last_ran_at_ci,
-        last_ran_at_local: test_case.last_ran_at_local,
-        inserted_at: test_case.inserted_at
-      }
-    )
+  defp fetch_existing_test_cases_chunk(project_id, ids_chunk) do
+    %{rows: rows} =
+      ClickHouseRepo.query!(
+        """
+        SELECT
+          id,
+          recent_durations,
+          is_flaky,
+          state,
+          last_ran_at_ci,
+          last_ran_at_local,
+          inserted_at
+        FROM test_cases
+        WHERE project_id = {project_id:Int64}
+          AND id IN (#{inline_uuid_list(ids_chunk)})
+        """,
+        %{project_id: project_id},
+        multipart: true
+      )
+
+    Enum.map(rows, &decode_existing_test_case_row/1)
+  end
+
+  defp inline_uuid_list(ids_chunk) do
+    Enum.map_join(ids_chunk, ",", fn id ->
+      "'#{Ecto.UUID.cast!(id)}'::UUID"
+    end)
+  end
+
+  defp decode_existing_test_case_row([
+         id,
+         recent_durations,
+         is_flaky,
+         state,
+         last_ran_at_ci,
+         last_ran_at_local,
+         inserted_at
+       ]) do
+    %{
+      id: decode_clickhouse_uuid(id),
+      recent_durations: recent_durations || [],
+      is_flaky: decode_clickhouse_boolean(is_flaky),
+      state: state,
+      last_ran_at_ci: decode_clickhouse_datetime(last_ran_at_ci),
+      last_ran_at_local: decode_clickhouse_datetime(last_ran_at_local),
+      inserted_at: decode_clickhouse_datetime(inserted_at)
+    }
+  end
+
+  defp decode_clickhouse_uuid(uuid) when is_binary(uuid) and byte_size(uuid) == 16, do: Ecto.UUID.load!(uuid)
+  defp decode_clickhouse_uuid(uuid), do: uuid
+
+  defp decode_clickhouse_boolean(value) when value in [true, false], do: value
+  defp decode_clickhouse_boolean(1), do: true
+  defp decode_clickhouse_boolean(0), do: false
+  defp decode_clickhouse_boolean(value), do: value
+
+  defp decode_clickhouse_datetime(nil), do: nil
+  defp decode_clickhouse_datetime(%NaiveDateTime{} = value), do: value
+  defp decode_clickhouse_datetime(%DateTime{} = value), do: DateTime.to_naive(value)
+
+  defp decode_clickhouse_datetime(value) when is_binary(value) do
+    case NaiveDateTime.from_iso8601(value) do
+      {:ok, datetime} -> datetime
+      {:error, _} -> value
+    end
   end
 
   defp merge_latest_test_case(row, acc) do

--- a/server/test/tuist/tests_test.exs
+++ b/server/test/tuist/tests_test.exs
@@ -1190,7 +1190,7 @@ defmodule Tuist.TestsTest do
         assert Keyword.get(opts, :multipart) == true
         {sql, params} = Ecto.Adapters.ClickHouse.to_sql(:all, query)
 
-        assert sql =~ "FROM test_cases"
+        assert sql =~ ~s[FROM "test_cases"]
         assert sql =~ ~s["project_id"]
         assert sql =~ ~s["id"]
         assert project.id in params

--- a/server/test/tuist/tests_test.exs
+++ b/server/test/tuist/tests_test.exs
@@ -1174,10 +1174,7 @@ defmodule Tuist.TestsTest do
 
     test "uses multipart ClickHouse lookups for large test case batches" do
       # Given
-      project =
-        ProjectsFixtures.project_fixture()
-        |> Ecto.Changeset.change(default_branch: nil)
-        |> Tuist.Repo.update!()
+      project = ProjectsFixtures.project_fixture()
 
       test_cases =
         for index <- 1..5_001 do
@@ -1189,14 +1186,17 @@ defmodule Tuist.TestsTest do
           }
         end
 
-      expect(ClickHouseRepo, :query!, 2, fn sql, %{project_id: project_id}, opts ->
-        assert project_id == project.id
+      expect(ClickHouseRepo, :all, 2, fn query, opts ->
         assert Keyword.get(opts, :multipart) == true
+        {sql, params} = Ecto.Adapters.ClickHouse.to_sql(:all, query)
+
         assert sql =~ "FROM test_cases"
-        assert sql =~ "project_id = {project_id:Int64}"
-        assert sql =~ "AND id IN ("
-        assert sql =~ "::UUID"
-        %{rows: []}
+        assert sql =~ ~s["project_id"]
+        assert sql =~ ~s["id"]
+        assert project.id in params
+        assert length(params) > 1
+
+        []
       end)
 
       test_attrs = %{

--- a/server/test/tuist/tests_test.exs
+++ b/server/test/tuist/tests_test.exs
@@ -1172,6 +1172,56 @@ defmodule Tuist.TestsTest do
       assert test.is_ci == true
     end
 
+    test "uses multipart ClickHouse lookups for large test case batches" do
+      # Given
+      project =
+        ProjectsFixtures.project_fixture()
+        |> Ecto.Changeset.change(default_branch: nil)
+        |> Tuist.Repo.update!()
+
+      test_cases =
+        for index <- 1..5_001 do
+          %{
+            name: "test_#{index}",
+            status: "success",
+            duration: 10,
+            test_suite_name: "Suite"
+          }
+        end
+
+      expect(ClickHouseRepo, :query!, 2, fn sql, %{project_id: project_id}, opts ->
+        assert project_id == project.id
+        assert Keyword.get(opts, :multipart) == true
+        assert sql =~ "FROM test_cases"
+        assert sql =~ "project_id = {project_id:Int64}"
+        assert sql =~ "AND id IN ("
+        assert sql =~ "::UUID"
+        %{rows: []}
+      end)
+
+      test_attrs = %{
+        id: UUIDv7.generate(),
+        project_id: project.id,
+        account_id: project.account_id,
+        duration: 1500,
+        status: "success",
+        ran_at: NaiveDateTime.utc_now(),
+        is_ci: false,
+        test_modules: [
+          %{
+            name: "Module",
+            status: "success",
+            duration: 1500,
+            test_suites: [%{name: "Suite", status: "success", duration: 1500}],
+            test_cases: test_cases
+          }
+        ]
+      }
+
+      # When/Then
+      assert {:ok, _test} = Tests.create_test(test_attrs)
+    end
+
     test "persists run_destinations as separate rows linked to the test run" do
       # Given
       project = ProjectsFixtures.project_fixture()


### PR DESCRIPTION
## Summary
- Fix the self-hosted test ingestion path where large existing-test-case lookups can exceed request header limits.
- Keep the lookup on Ecto primitives and pass `multipart: true` to `ClickHouseRepo.all/2`, so `ecto_ch` keeps handling UUID, boolean, datetime, and array decoding.
- Add a regression test that builds a 5,001-test-case payload and asserts the lookup uses multipart transport for both chunks.

## Testing
- `mix format lib/tuist/tests.ex test/tuist/tests_test.exs`
- `MIX_ENV=test mix compile`
- `mix test test/tuist/tests_test.exs:1175` (blocked during test DB setup: `20240415140351_create_users_auth_tables.exs` tries to create `users_tokens` before a `users` table exists, raising `ERROR 42P01 (undefined_table) relation "users" does not exist`)
