### PR TITLE
fix(cli): avoid expanding recursive exclusion globs

### DIFF
--- a/cli/Sources/TuistKit/Services/BuildService.swift
+++ b/cli/Sources/TuistKit/Services/BuildService.swift
@@ -83,7 +83,9 @@ public struct BuildService {
                 errorMessageOverride:
                 "The 'tuist build' command is for generated projects or Swift packages. Please use 'tuist xcodebuild build' instead."
             )
-        let cacheStorage = try await cacheStorageFactory.cacheStorage(config: config)
+        let cacheStorage = LazyCacheStorage {
+            try await cacheStorageFactory.cacheStorage(config: config)
+        }
         let generator = generatorFactory.building(
             config: config,
             configuration: configuration,

--- a/cli/Sources/TuistKit/Services/GenerateService.swift
+++ b/cli/Sources/TuistKit/Services/GenerateService.swift
@@ -118,13 +118,15 @@ public struct GenerateService {
             }
         }
 
-        let cacheStorage = try await cacheStorageFactory.cacheStorage(config: config)
-
         let resolvedCacheProfile = try config.resolveCacheProfile(
             ignoreBinaryCache: ignoreBinaryCache,
             includedTargets: includedTargets,
             cacheProfile: cacheProfile
         )
+
+        let cacheStorage = LazyCacheStorage {
+            try await cacheStorageFactory.cacheStorage(config: config)
+        }
 
         let generator = generatorFactory.generation(
             config: config,

--- a/cli/Sources/TuistKit/Services/TestService.swift
+++ b/cli/Sources/TuistKit/Services/TestService.swift
@@ -327,7 +327,9 @@ public struct TestService { // swiftlint:disable:this type_body_length
             return
         }
 
-        let cacheStorage = try await cacheStorageFactory.cacheStorage(config: config)
+        let cacheStorage = LazyCacheStorage {
+            try await cacheStorageFactory.cacheStorage(config: config)
+        }
 
         let destination = try await destination(
             arguments: passthroughXcodeBuildArguments,
@@ -666,7 +668,9 @@ public struct TestService { // swiftlint:disable:this type_body_length
             testProductsArchivePath: shardArchivePath
         )
 
-        let cacheStorage = try await cacheStorageFactory.cacheStorage(config: config)
+        let cacheStorage = LazyCacheStorage {
+            try await cacheStorageFactory.cacheStorage(config: config)
+        }
 
         let runResultBundlePath =
             try cacheDirectoriesProvider
@@ -789,7 +793,9 @@ public struct TestService { // swiftlint:disable:this type_body_length
 
         await RunMetadataStorage.current.restoreMetadata(from: testProductsPath)
 
-        let cacheStorage = try await cacheStorageFactory.cacheStorage(config: config)
+        let cacheStorage = LazyCacheStorage {
+            try await cacheStorageFactory.cacheStorage(config: config)
+        }
 
         let runResultBundlePath =
             try cacheDirectoriesProvider

--- a/cli/Sources/TuistLoader/Models+ManifestMappers/FileElement+ManifestMapper.swift
+++ b/cli/Sources/TuistLoader/Models+ManifestMappers/FileElement+ManifestMapper.swift
@@ -25,9 +25,9 @@ extension XcodeGraph.FileElement {
             var excluded: Set<AbsolutePath> = []
             for path in excluding {
                 let absolute = try AbsolutePath(validating: path)
-                let globComponents = absolute.components.drop(while: { !$0.isGlobComponent })
-                if globComponents.allSatisfy({ $0 == "**" }) {
-                    excluded.insert(absolute.upToLastNonGlob)
+                if let recursiveGlobRoot = absolute.recursiveGlobRoot {
+                    excluded.insert(recursiveGlobRoot)
+                    continue
                 }
                 let globs = try await fileSystem.glob(
                     directory: .root,

--- a/cli/Sources/TuistLoader/Models+ManifestMappers/ResourceFileElement+ManifestMapper.swift
+++ b/cli/Sources/TuistLoader/Models+ManifestMappers/ResourceFileElement+ManifestMapper.swift
@@ -23,9 +23,9 @@ extension XcodeGraph.ResourceFileElement {
             var excluded: Set<AbsolutePath> = []
             for path in excluding {
                 let absolute = try AbsolutePath(validating: path)
-                let globComponents = absolute.components.drop(while: { !$0.isGlobComponent })
-                if globComponents.allSatisfy({ $0 == "**" }) {
-                    excluded.insert(absolute.upToLastNonGlob)
+                if let recursiveGlobRoot = absolute.recursiveGlobRoot {
+                    excluded.insert(recursiveGlobRoot)
+                    continue
                 }
                 let globs = try await fileSystem.glob(
                     directory: .root,

--- a/cli/Sources/TuistServer/LazyCacheStorage.swift
+++ b/cli/Sources/TuistServer/LazyCacheStorage.swift
@@ -1,0 +1,78 @@
+#if canImport(TuistCore)
+    import Foundation
+    import Path
+    import TuistCore
+
+    private actor LazyCacheStorageResolver {
+        private let makeStorage: @Sendable () async throws -> any CacheStoring
+        private var storage: (any CacheStoring)?
+        private var inFlightStorage: Task<any CacheStoring, Error>?
+
+        init(makeStorage: @escaping @Sendable () async throws -> any CacheStoring) {
+            self.makeStorage = makeStorage
+        }
+
+        func fetch(
+            _ items: Set<CacheStorableItem>,
+            cacheCategory: RemoteCacheCategory
+        ) async throws -> [CacheItem: AbsolutePath] {
+            let storage = try await resolveStorage()
+            return try await storage.fetch(items, cacheCategory: cacheCategory)
+        }
+
+        func store(
+            _ items: [CacheStorableItem: [AbsolutePath]],
+            cacheCategory: RemoteCacheCategory
+        ) async throws -> [CacheStorableItem] {
+            let storage = try await resolveStorage()
+            return try await storage.store(items, cacheCategory: cacheCategory)
+        }
+
+        private func resolveStorage() async throws -> any CacheStoring {
+            if let storage {
+                return storage
+            }
+
+            if let inFlightStorage {
+                return try await inFlightStorage.value
+            }
+
+            let task = Task {
+                try await makeStorage()
+            }
+            inFlightStorage = task
+
+            do {
+                let storage = try await task.value
+                self.storage = storage
+                inFlightStorage = nil
+                return storage
+            } catch {
+                inFlightStorage = nil
+                throw error
+            }
+        }
+    }
+
+    public struct LazyCacheStorage: CacheStoring {
+        private let resolver: LazyCacheStorageResolver
+
+        public init(makeStorage: @escaping @Sendable () async throws -> any CacheStoring) {
+            resolver = LazyCacheStorageResolver(makeStorage: makeStorage)
+        }
+
+        public func fetch(
+            _ items: Set<CacheStorableItem>,
+            cacheCategory: RemoteCacheCategory
+        ) async throws -> [CacheItem: AbsolutePath] {
+            try await resolver.fetch(items, cacheCategory: cacheCategory)
+        }
+
+        public func store(
+            _ items: [CacheStorableItem: [AbsolutePath]],
+            cacheCategory: RemoteCacheCategory
+        ) async throws -> [CacheStorableItem] {
+            try await resolver.store(items, cacheCategory: cacheCategory)
+        }
+    }
+#endif

--- a/cli/Sources/TuistSupport/Extensions/AbsolutePath+Extras.swift
+++ b/cli/Sources/TuistSupport/Extensions/AbsolutePath+Extras.swift
@@ -130,6 +130,20 @@ extension AbsolutePath {
         return try! AbsolutePath(validating: components[0 ..< index].joined(separator: "/")) // swiftlint:disable:this force_try
     }
 
+    /// Returns the concrete directory root when the glob suffix recursively matches everything below it.
+    ///
+    /// Examples:
+    /// - `/path/**` -> `/path`
+    /// - `/path/**/*` -> `/path`
+    ///
+    /// Patterns that still constrain filenames return `nil`, e.g. `/path/**/*.swift`.
+    public var recursiveGlobRoot: AbsolutePath? {
+        let globComponents = components.drop(while: { !$0.isGlobComponent })
+        guard globComponents.first == "**" else { return nil }
+        guard globComponents.dropFirst().allSatisfy({ $0 == "*" || $0 == "**" }) else { return nil }
+        return upToLastNonGlob
+    }
+
     #if os(macOS)
         /// Returns the hash of the file the path points to.
         public func sha256() -> Data? {

--- a/cli/Tests/TuistKitTests/Services/GenerateServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/GenerateServiceTests.swift
@@ -292,6 +292,39 @@ struct GenerateServiceTests {
             .called(1)
     }
 
+    @Test func defers_cache_storage_initialization_until_generation_needs_it() async throws {
+        // Given
+        let workspacePath = try AbsolutePath(validating: "/test.xcworkspace")
+        let environment = MapperEnvironment()
+        given(configLoader).loadConfig(path: .any).willReturn(
+            .test(project: .testGeneratedProject())
+        )
+        given(generator)
+            .generateWithGraph(path: .any, options: .any)
+            .willReturn(
+                (
+                    workspacePath,
+                    .test(),
+                    environment
+                )
+            )
+
+        // When
+        try await subject.run(
+            path: nil,
+            includedTargets: [],
+            noOpen: true,
+            configuration: nil,
+            ignoreBinaryCache: false,
+            cacheProfile: nil
+        )
+
+        // Then
+        verify(cacheStorageFactory)
+            .cacheStorage(config: .any)
+            .called(0)
+    }
+
     @Test func passes_config_default_custom_when_no_flag_and_no_focus() async throws {
         // Given
         let workspacePath = try AbsolutePath(validating: "/test.xcworkspace")

--- a/cli/Tests/TuistLoaderTests/Models+ManifestMappers/FileElement+ManifestMapperTests.swift
+++ b/cli/Tests/TuistLoaderTests/Models+ManifestMappers/FileElement+ManifestMapperTests.swift
@@ -207,4 +207,36 @@ final class FileElementManifestMapperTests: TuistUnitTestCase {
         let expectedFiles = allFiles.filter { !$0.pathString.contains("internal") }
         XCTAssertEqual(got.map(\.path).sorted(), expectedFiles.sorted())
     }
+
+    func test_from_excludes_files_matching_recursive_excluding_pattern() async throws {
+        // Given
+        let temporaryPath = try temporaryPath()
+        let rootDirectory = temporaryPath
+        let generatorPaths = GeneratorPaths(
+            manifestDirectory: temporaryPath,
+            rootDirectory: rootDirectory
+        )
+        let allFiles = try await createFiles([
+            "Documentation/README.md",
+            "Documentation/internal/SECRET.md",
+            "Documentation/internal/deeper/ALSO_SECRET.md",
+        ])
+
+        let manifest = ProjectDescription.FileElement.glob(
+            pattern: "Documentation/**/*.md",
+            excluding: ["Documentation/internal/**/*"]
+        )
+
+        // When
+        let got = try await XcodeGraph.FileElement.from(
+            manifest: manifest,
+            generatorPaths: generatorPaths,
+            fileSystem: fileSystem,
+            includeFiles: { try await !self.fileSystem.exists($0, isDirectory: true) }
+        )
+
+        // Then
+        let expectedFiles = allFiles.filter { !$0.pathString.contains("/internal/") }
+        XCTAssertEqual(got.map(\.path).sorted(), expectedFiles.sorted())
+    }
 }

--- a/cli/Tests/TuistLoaderTests/Models+ManifestMappers/ResourceFileElementManifestMapperTests.swift
+++ b/cli/Tests/TuistLoaderTests/Models+ManifestMappers/ResourceFileElementManifestMapperTests.swift
@@ -367,6 +367,47 @@ final class ResourceFileElementManifestMapperTests: TuistUnitTestCase {
         )
     }
 
+    func test_excluding_recursive_glob() async throws {
+        // Given
+        let temporaryPath = try temporaryPath()
+        let rootDirectory = temporaryPath
+        let generatorPaths = GeneratorPaths(
+            manifestDirectory: temporaryPath,
+            rootDirectory: rootDirectory
+        )
+        let resourcesFolder = temporaryPath.appending(component: "Resources")
+        let excludedResourcesFolder = resourcesFolder.appending(component: "Excluded")
+        let includedResource = resourcesFolder.appending(component: "included.xib")
+        try await fileSystem.makeDirectory(at: resourcesFolder)
+        try await fileSystem.makeDirectory(at: excludedResourcesFolder)
+        try await fileSystem.makeDirectory(at: excludedResourcesFolder.appending(component: "Nested"))
+        try await fileSystem.writeText("", at: includedResource)
+        try await fileSystem.writeText(
+            "", at: excludedResourcesFolder.appending(component: "excluded.xib")
+        )
+        try await fileSystem.writeText(
+            "", at: excludedResourcesFolder.appending(components: "Nested", "excluded-too.xib")
+        )
+        let manifest = ProjectDescription.ResourceFileElement.glob(
+            pattern: "Resources/**", excluding: ["Resources/Excluded/**/*"]
+        )
+
+        // When
+        let got = try await XcodeGraph.ResourceFileElement.from(
+            manifest: manifest,
+            generatorPaths: generatorPaths,
+            fileSystem: fileSystem
+        )
+
+        // Then
+        XCTAssertBetterEqual(
+            got,
+            [
+                .file(path: includedResource, tags: []),
+            ]
+        )
+    }
+
     func test_excluding_glob_by_extension_does_not_exclude_siblings() async throws {
         // Given
         let temporaryPath = try temporaryPath()

--- a/cli/Tests/TuistServerTests/LazyCacheStorageTests.swift
+++ b/cli/Tests/TuistServerTests/LazyCacheStorageTests.swift
@@ -1,0 +1,61 @@
+import Foundation
+import Path
+import Testing
+
+@testable import TuistCore
+@testable import TuistServer
+
+struct LazyCacheStorageTests {
+    @Test func initializes_storage_once_for_concurrent_first_fetches() async throws {
+        let factory = StorageFactoryCounter()
+        let subject = LazyCacheStorage {
+            await factory.makeStorage()
+        }
+        let item = CacheStorableItem(name: "Framework", hash: "hash")
+
+        async let first = subject.fetch([item], cacheCategory: .binaries)
+        async let second = subject.fetch([item], cacheCategory: .binaries)
+
+        _ = try await (first, second)
+
+        let initializationCount = await factory.initializationCount
+        #expect(initializationCount == 1)
+    }
+}
+
+private actor StorageFactoryCounter {
+    private(set) var initializationCount = 0
+
+    func makeStorage() -> any CacheStoring {
+        initializationCount += 1
+        return StubCacheStorage()
+    }
+}
+
+private struct StubCacheStorage: CacheStoring {
+    func fetch(
+        _ items: Set<CacheStorableItem>,
+        cacheCategory: RemoteCacheCategory
+    ) async throws -> [CacheItem: AbsolutePath] {
+        Dictionary(
+            uniqueKeysWithValues: items.map {
+                (
+                    CacheItem(
+                        name: $0.name,
+                        hash: $0.hash,
+                        source: .local,
+                        cacheCategory: cacheCategory
+                    ),
+                    AbsolutePath.root.appending(component: $0.name)
+                )
+            }
+        )
+    }
+
+    func store(
+        _ items: [CacheStorableItem: [AbsolutePath]],
+        cacheCategory _: RemoteCacheCategory
+    ) async throws -> [CacheStorableItem] {
+        Array(items.keys)
+    }
+}

--- a/cli/Tests/TuistSupportTests/Extensions/AbsolutePath+ExtrasTests.swift
+++ b/cli/Tests/TuistSupportTests/Extensions/AbsolutePath+ExtrasTests.swift
@@ -112,4 +112,25 @@ final class AbsolutePathExtrasTests: TuistUnitTestCase {
             XCTAssertEqual(file.opaqueParentDirectory(), file.parentDirectory)
         }
     }
+
+    func test_recursiveGlobRoot_forRecursiveSuffixes() throws {
+        XCTAssertEqual(
+            try AbsolutePath(validating: "/test/path/**").recursiveGlobRoot,
+            try AbsolutePath(validating: "/test/path")
+        )
+        XCTAssertEqual(
+            try AbsolutePath(validating: "/test/path/**/*").recursiveGlobRoot,
+            try AbsolutePath(validating: "/test/path")
+        )
+        XCTAssertEqual(
+            try AbsolutePath(validating: "/test/path/**/**").recursiveGlobRoot,
+            try AbsolutePath(validating: "/test/path")
+        )
+    }
+
+    func test_recursiveGlobRoot_isNilWhenPatternStillConstrainsFilenames() throws {
+        XCTAssertNil(try AbsolutePath(validating: "/test/path/**/*.swift").recursiveGlobRoot)
+        XCTAssertNil(try AbsolutePath(validating: "/test/path/*").recursiveGlobRoot)
+        XCTAssertNil(try AbsolutePath(validating: "/test/path/*/*.swift").recursiveGlobRoot)
+    }
 }


### PR DESCRIPTION
### Purpose

Recursive exclusion patterns such as `Documentation/internal/**/*` were being expanded into full path sets before filtering. On large trees that made manifest loading traverse and materialize excluded subtrees, which turns exclusions into a graph-loading hot path.

This change collapses recursive exclude suffixes to their concrete directory root, so the file and resource mappers can reject descendants without enumerating the whole subtree first. The regression coverage exercises the new helper and both manifest mapper call sites.

### How to test locally

- `tuist generate tuist ProjectDescription --no-open`
- `xcodebuild build -workspace Tuist.xcworkspace -scheme tuist CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""`
