### PR TITLE
ci(release): disable SLSA verification to skip GitHub API calls

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,7 @@ env:
   MISE_GITHUB_TOKEN: ${{ secrets.TUIST_RELEASE_GITHUB_TOKEN || github.token }}
   TUIST_ENABLE_CACHING: "true"
   MISE_GITHUB_ATTESTATIONS: 0
+  MISE_LOCKED: 1
 
 jobs:
   check-releases:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,8 @@ env:
   MISE_GITHUB_TOKEN: ${{ secrets.TUIST_RELEASE_GITHUB_TOKEN || github.token }}
   TUIST_ENABLE_CACHING: "true"
   MISE_GITHUB_ATTESTATIONS: 0
-  MISE_LOCKED: 1
+  MISE_GITHUB_SLSA: false
+  MISE_AQUA_SLSA: false
 
 jobs:
   check-releases:


### PR DESCRIPTION
### What

In `.github/workflows/release.yml`, replace `MISE_LOCKED=1` with `MISE_GITHUB_SLSA=false` and `MISE_AQUA_SLSA=false` so every release job skips mise's SLSA provenance verification step.

### Why

The last release run failed in `check-releases` because `mise install` hit the unauthenticated GitHub rate limit. The 403s landed on requests like `GET https://api.github.com/repos/endevco/aube/releases/tags/v1.6.2`, blocking installs for `aube`, `blick`, and `caddy` and stopping the entire pipeline.

The existing `MISE_GITHUB_ATTESTATIONS=0` was insufficient — that setting only covers GitHub Artifact Attestations. The actual offending step is a separate code path, mise's SLSA provenance verification (visible in verbose logs as `verify SLSA provenance`), which is controlled by `MISE_GITHUB_SLSA` for github-backend tools and `MISE_AQUA_SLSA` for aqua-backend tools. Both default to `true` and trigger an API call per tool, per install.

Integrity isn't lost: `mise.lock` already pins checksums for every platform entry, so mise still verifies the download against the locked hash. SLSA provenance is an additional supply-chain guarantee we're trading away on this CI path in exchange for a release pipeline that doesn't depend on GitHub's anonymous rate limit.

### Why not `MISE_LOCKED=1`

The first commit on this branch tried `MISE_LOCKED=1`, which forces mise to install strictly from lockfile URLs. Verified locally that this errors out on `core:erlang`:

```
mise ERROR Failed to install core:erlang@28.4.3: No lockfile URL found for erlang@28.4.3 on platform macos-arm64 (--locked mode)
```

`core:erlang` builds from source via kerl and has no precompiled URL to pin; `mise lock erlang` reports success but writes no platform entries. `MISE_LOCKED=1` is therefore incompatible with this project's tool set.

### Local verification

Reproduced the CI failure path and confirmed the fix with the github-backed `blick` tool, which is in `mise.lock`:

- **Without** `MISE_GITHUB_SLSA=false`, `mise install github:tuist/blick@0.8.0` runs `verify SLSA provenance` and hits `GET https://api.github.com/repos/tuist/blick/releases/tags/v0.8.0` — the exact request that 403'd in CI.
- **With** `MISE_GITHUB_SLSA=false`, the same install makes zero `api.github.com` calls and verifies against the lockfile checksum only.

### How to test

CI-only change. Confirm on the next `main` push that the `check-releases` job no longer logs `GitHub rate limit exceeded` / 403s from `api.github.com` during `mise install`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)