### PR TITLE
fix(linux-runner-image): install openssh-client for ssh-agent

### DIFF
--- a/infra/linux-runner-image/Dockerfile
+++ b/infra/linux-runner-image/Dockerfile
@@ -47,7 +47,9 @@ ENV DEBIAN_FRONTEND=noninteractive \
 #     when actions/setup-{node,python,ruby,...} compiles them
 #   - archive: zip + bzip2 + p7zip-full (unzip + xz-utils already
 #     covered above)
-#   - VCS extras: git-lfs (assumed present by many CI workflows)
+#   - VCS extras: git-lfs (assumed present by many CI workflows),
+#     openssh-client for ssh-agent / scp / git-over-ssh (required by
+#     webfactory/ssh-agent and any workflow step that talks SSH)
 #   - DB clients: client-only — services land in containers in
 #     workflows that need them
 #   - common CLI utilities: ripgrep, fd-find, tree, less, vim,
@@ -105,6 +107,7 @@ RUN apt-get update \
         p7zip-full \
         file \
         git-lfs \
+        openssh-client \
         postgresql-client \
         mariadb-client \
         redis-tools \


### PR DESCRIPTION
### What changed

Added `openssh-client` to the apt-get install layer in `infra/linux-runner-image/Dockerfile`, slotted next to `git-lfs` under the existing "VCS extras" category.

### Why

Any workflow using `webfactory/ssh-agent` (or otherwise relying on `ssh-agent`, `ssh-add`, `scp`, or git-over-ssh) on the self-hosted Linux runner pool was failing at the SSH-setup step with:

```
The 'ssh-agent' executable could not be found.
##[error]spawnSync ssh-agent ENOENT
```

The Dockerfile was installing a fairly broad tooling layer but `openssh-client` was never on the list. GitHub's hosted Ubuntu runner image ships it by default; this mirrors that posture so workflows portable from `ubuntu-latest` keep working on our pool.

### Root cause

`openssh-client` (which provides `ssh-agent`) was simply absent from the package list. Confirmed via a failing job on `tuist-tuist-runner-pool-linux-ubuntu-22-04-runner-…` — `ssh-agent` was not on `PATH` and not installed anywhere on the image.

### Impact

- Workflows using `webfactory/ssh-agent` on the Linux runner pool will succeed once the rebuilt image is digest-pinned into the managed-env values files (per `infra/linux-runner-image/AGENTS.md`).
- No behavior change for workflows that didn't touch SSH.
- Marginal image-size increase (`openssh-client` is ~1 MB).

### How to test locally

```bash
cd infra/linux-runner-image
docker build --pull -t tuist-linux-runner:ssh-test .
docker run --rm tuist-linux-runner:ssh-test ssh-agent -h
```

The last command should print ssh-agent usage (instead of "executable not found").