### PR TITLE
ci(release): revert SLSA disable, add GITHUB_TOKEN and bump mise

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,12 +16,11 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  MISE_VERSION: "2026.4.18"
+  MISE_VERSION: "2026.5.15"
   MISE_GITHUB_TOKEN: ${{ secrets.TUIST_RELEASE_GITHUB_TOKEN || github.token }}
+  GITHUB_TOKEN: ${{ secrets.TUIST_RELEASE_GITHUB_TOKEN || github.token }}
   TUIST_ENABLE_CACHING: "true"
   MISE_GITHUB_ATTESTATIONS: 0
-  MISE_GITHUB_SLSA: false
-  MISE_AQUA_SLSA: false
 
 jobs:
   check-releases:


### PR DESCRIPTION
### What

In [.github/workflows/release.yml](.github/workflows/release.yml):

- Revert `MISE_GITHUB_SLSA: false` and `MISE_AQUA_SLSA: false` introduced by [#10960](https://github.com/tuist/tuist/pull/10960).
- Add `GITHUB_TOKEN` at the workflow `env` block alongside the existing `MISE_GITHUB_TOKEN`.
- Bump `MISE_VERSION` from `2026.4.18` to `2026.5.15`.

### Why

Disabling SLSA verification globally broke the release: mise treats a disabled verification setting combined with a lockfile entry that *already* records SLSA provenance (e.g., `sops`) as a downgrade attack and aborts the install:

```
ERROR Failed to install aqua:getsops/sops@3.9.3: Lockfile requires slsa provenance for aqua:getsops/sops@3.9.3 but the corresponding verification setting is disabled. This may indicate a downgrade attack. Enable the setting or update the lockfile.
```

So we can't simply turn SLSA off. The actual root cause of the original failure is that mise's SLSA verification calls `api.github.com/repos/<owner>/<repo>/releases/tags/<v>` once per tool that doesn't yet have a provenance entry in `mise.lock` (`blick`, `caddy`, `aube`, etc.), and the release runs on the shared `tuist-production-linux` fleet — concurrent jobs share one outbound IP and exhaust the 60/hr unauthenticated rate limit. Even though `MISE_GITHUB_TOKEN` is set, the failure log showed mise's verification path hitting the unauth limit, suggesting not every code path was reading that env var.

This change keeps SLSA verification on (so lockfile-provenance integrity holds) and reduces the chance of hitting the unauth limit:

- `GITHUB_TOKEN` at workflow level covers any mise code path that reaches for the standard env var instead of `MISE_GITHUB_TOKEN`. Per-job `env: GITHUB_TOKEN: ...` overrides for the `release-*` jobs still win, so this only fills in jobs that didn't set it (notably `check-releases`).
- `MISE_VERSION` bump pulls in fixes from the 2026.5.x line: attestation caching of `"unavailable"` markers for tools known to have none (v2026.5.6), `mise lock`-time provenance recording (v2026.5.11), and credential-handling fixes (v2026.5.7, v2026.5.9). The local install pipeline has been exercised against 2026.5.15 without regressions in this repo's tool set.

### What this does not do

- It does not pre-populate `mise.lock` with `provenance = "unavailable"` entries for `blick` / `caddy` (no published attestations). Mise's automatic recording of those markers only fires under `MISE_LOCKED=1`, which is incompatible with `core:erlang` (verified locally — erlang builds from source via kerl, has no URL to lock). The newer mise version will still need an API call per such tool on the first install, but with `GITHUB_TOKEN` authenticated, that call uses the 5000/hr per-token quota instead of the shared 60/hr IP quota.

### Local verification

- Confirmed the `Lockfile requires slsa provenance` failure mode is real: running `mise install` with `MISE_GITHUB_SLSA=false` against this repo's lockfile fails on `aqua:getsops/sops@3.9.3` with the message above.
- Confirmed `MISE_LOCKED=1` is not a viable alternative — it errors on `core:erlang` because the `core:` backend cannot supply a lockfile URL.
- Reverting to SLSA enabled + bumping mise installs the tool set cleanly under newer mise (2026.5.15) on this machine.

### How to test

Merge to `main` and observe the Release workflow's `check-releases` job:
- No `GitHub rate limit exceeded` warning followed by 403s from `api.github.com`.
- No `Lockfile requires slsa provenance` error for `sops` or other lockfile-provenance-pinned tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)