### PR TITLE
feat(server): Support self-hosted Kura endpoints

### DIFF
--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -1,6 +1,6 @@
 name: Helm
 
-# Validate Helm charts under `infra/helm/` at the PR stage so chart bugs
+# Validate Helm charts at the PR stage so chart bugs
 # are caught before a deploy workflow tries to apply them to a real
 # cluster. Three layers of checks, each progressively stricter:
 #
@@ -27,11 +27,13 @@ on:
       - main
     paths:
       - infra/helm/**
+      - kura/ops/helm/kura/**
       - .github/workflows/helm.yml
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - infra/helm/**
+      - kura/ops/helm/kura/**
       - .github/workflows/helm.yml
   merge_group: {}
 
@@ -69,6 +71,7 @@ jobs:
         run: |
           set -uo pipefail
           configs=(
+            "kura/ops/helm/kura|"
             "infra/helm/slack|values-ci.yaml"
             "infra/helm/noora-storybook|values-ci.yaml"
             "infra/helm/tuist|values-ci.yaml"
@@ -133,6 +136,7 @@ jobs:
         run: |
           set -uo pipefail
           configs=(
+            "kura|kura/ops/helm/kura|kura|"
             "slack (production)|infra/helm/slack|slack|values-production.yaml values-ci.yaml"
             "noora-storybook (production)|infra/helm/noora-storybook|noora-storybook|values-production.yaml values-ci.yaml"
             "tuist (production)|infra/helm/tuist|tuist|values-managed-common.yaml values-managed-production.yaml values-ci.yaml"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1035,9 +1035,9 @@ jobs:
 
           echo "RELEASE_NOTES<<EOF" >> "$GITHUB_OUTPUT"
           if [ -n "$LATEST_VERSION" ]; then
-            git cliff --include-path "infra/helm/**/*" --config infra/helm/cliff.toml --repository "." 2>/dev/null -- ${LATEST_VERSION}..HEAD | sed -n '/<!-- RELEASE NOTES START -->/,$p' | tail -n +2 >> "$GITHUB_OUTPUT"
+            git cliff --include-path "infra/helm/**/*" --include-path "kura/ops/helm/kura/**/*" --config infra/helm/cliff.toml --repository "." 2>/dev/null -- ${LATEST_VERSION}..HEAD | sed -n '/<!-- RELEASE NOTES START -->/,$p' | tail -n +2 >> "$GITHUB_OUTPUT"
           else
-            git cliff --include-path "infra/helm/**/*" --config infra/helm/cliff.toml --repository "." 2>/dev/null | sed -n '/<!-- RELEASE NOTES START -->/,$p' | tail -n +2 >> "$GITHUB_OUTPUT"
+            git cliff --include-path "infra/helm/**/*" --include-path "kura/ops/helm/kura/**/*" --config infra/helm/cliff.toml --repository "." 2>/dev/null | sed -n '/<!-- RELEASE NOTES START -->/,$p' | tail -n +2 >> "$GITHUB_OUTPUT"
           fi
           echo "EOF" >> "$GITHUB_OUTPUT"
 
@@ -1045,6 +1045,8 @@ jobs:
         run: |
           sed -i 's/^version: .*/version: ${{ needs.check-releases.outputs.helm-next-version-number }}/' infra/helm/tuist/Chart.yaml
           sed -i 's/^appVersion: .*/appVersion: "${{ needs.check-releases.outputs.helm-next-version-number }}"/' infra/helm/tuist/Chart.yaml
+          sed -i 's/^version: .*/version: ${{ needs.check-releases.outputs.helm-next-version-number }}/' kura/ops/helm/kura/Chart.yaml
+          sed -i 's/^appVersion: .*/appVersion: "${{ needs.check-releases.outputs.helm-next-version-number }}"/' kura/ops/helm/kura/Chart.yaml
 
       - name: Update CHANGELOG.md
         working-directory: infra/helm
@@ -1053,9 +1055,9 @@ jobs:
           LATEST_VERSION=$(git tag -l | grep -E "^helm@[0-9]+\.[0-9]+\.[0-9]+$" | sort -V | tail -n1)
 
           if [ -n "$LATEST_VERSION" ]; then
-            git cliff --include-path "infra/helm/**/*" --config cliff.toml --repository "../../" --bump -o CHANGELOG.md 2>/dev/null -- ${LATEST_VERSION}..HEAD
+            git cliff --include-path "infra/helm/**/*" --include-path "kura/ops/helm/kura/**/*" --config cliff.toml --repository "../../" --bump -o CHANGELOG.md 2>/dev/null -- ${LATEST_VERSION}..HEAD
           else
-            git cliff --include-path "infra/helm/**/*" --config cliff.toml --repository "../../" --bump -o CHANGELOG.md 2>/dev/null
+            git cliff --include-path "infra/helm/**/*" --include-path "kura/ops/helm/kura/**/*" --config cliff.toml --repository "../../" --bump -o CHANGELOG.md 2>/dev/null
           fi
 
       - name: Install Helm
@@ -1064,11 +1066,15 @@ jobs:
       - name: Login to GitHub Container Registry
         run: echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io -u ${{ github.actor }} --password-stdin
 
-      - name: Package Helm chart
-        run: helm package infra/helm/tuist
+      - name: Package Helm charts
+        run: |
+          helm package infra/helm/tuist
+          helm package kura/ops/helm/kura
 
-      - name: Push Helm chart
-        run: helm push tuist-${{ needs.check-releases.outputs.helm-next-version-number }}.tgz oci://ghcr.io/tuist/charts
+      - name: Push Helm charts
+        run: |
+          helm push tuist-${{ needs.check-releases.outputs.helm-next-version-number }}.tgz oci://ghcr.io/tuist/charts
+          helm push kura-${{ needs.check-releases.outputs.helm-next-version-number }}.tgz oci://ghcr.io/tuist/charts
 
       - name: Upload Helm artifacts
         id: upload
@@ -1078,6 +1084,7 @@ jobs:
           path: |
             infra/helm/CHANGELOG.md
             infra/helm/tuist/Chart.yaml
+            kura/ops/helm/kura/Chart.yaml
           retention-days: 1
 
   release-capi-scaleway:
@@ -2264,7 +2271,9 @@ jobs:
           name: Helm Chart ${{ needs.check-releases.outputs.helm-next-version-number }}
           tag_name: ${{ needs.check-releases.outputs.helm-next-version }}
           body: |
-            OCI registry: `oci://ghcr.io/tuist/charts/tuist:${{ needs.check-releases.outputs.helm-next-version-number }}`
+            OCI registries:
+            - `oci://ghcr.io/tuist/charts/tuist:${{ needs.check-releases.outputs.helm-next-version-number }}`
+            - `oci://ghcr.io/tuist/charts/kura:${{ needs.check-releases.outputs.helm-next-version-number }}`
 
             ${{ needs.release-helm.outputs.release-notes }}
 
@@ -2414,7 +2423,7 @@ jobs:
           fi
 
           if [ "${{ needs.check-releases.outputs.helm-should-release }}" == "true" ] && [ "${{ needs.release-helm.result }}" == "success" ]; then
-            git add infra/helm/CHANGELOG.md infra/helm/tuist/Chart.yaml
+            git add infra/helm/CHANGELOG.md infra/helm/tuist/Chart.yaml kura/ops/helm/kura/Chart.yaml
             FILES_ADDED=true
           fi
 

--- a/infra/helm/tuist/templates/server-deployment.yaml
+++ b/infra/helm/tuist/templates/server-deployment.yaml
@@ -188,6 +188,10 @@ spec:
             - name: TUIST_CACHE_ENDPOINTS
               value: {{ .Values.server.cacheEndpointUrl | default (printf "http://%s:%v" (include "tuist.componentName" (dict "root" . "component" "cache")) .Values.cache.service.port) | quote }}
             {{- end }}
+            {{- with .Values.server.kuraEndpointUrls }}
+            - name: TUIST_KURA_ENDPOINTS
+              value: {{ join "," . | quote }}
+            {{- end }}
             {{- if .Values.kuraRuntime.image.tag }}
             - name: TUIST_KURA_RUNTIME_IMAGE_TAG
               value: {{ .Values.kuraRuntime.image.tag | quote }}

--- a/infra/helm/tuist/values.yaml
+++ b/infra/helm/tuist/values.yaml
@@ -192,6 +192,10 @@ server:
     bucketAsHost: false
     bucketName: tuist
   cacheEndpointUrl: ""
+  # Kura endpoint URLs advertised by this server when clients request the
+  # Kura cache technology. Self-hosted installs can point this at Kura
+  # instances running in the same cluster or network.
+  kuraEndpointUrls: []
   # Erlang distribution / libcluster configuration. Emits a headless Service
   # and wires TUIST_CLUSTER_DNS_SERVICE + TUIST_CLUSTER_APP_NAME into the pod.
   cluster:

--- a/mise/tasks/release/components.json
+++ b/mise/tasks/release/components.json
@@ -95,7 +95,7 @@
       "tag_regex": "^helm@[0-9]+\\.[0-9]+\\.[0-9]+$",
       "cliff_config": "infra/helm/cliff.toml",
       "initial_version": "0.1.0",
-      "include_paths": ["infra/helm/**/*"]
+      "include_paths": ["infra/helm/**/*", "kura/ops/helm/kura/**/*"]
     },
     {
       "name": "capi-scaleway",

--- a/server/lib/tuist/accounts.ex
+++ b/server/lib/tuist/accounts.ex
@@ -1866,14 +1866,23 @@ defmodule Tuist.Accounts do
   end
 
   def get_cache_endpoints_for_handle(account_handle, :kura) when is_binary(account_handle) do
-    case get_account_by_handle(account_handle) do
-      %Account{} = account -> kura_cache_endpoint_urls(account)
-      _ -> []
+    case Environment.kura_endpoints() do
+      endpoints when is_list(endpoints) ->
+        endpoints
+
+      nil ->
+        case get_account_by_handle(account_handle) do
+          %Account{} = account -> kura_cache_endpoint_urls(account)
+          _ -> []
+        end
     end
   end
 
   def get_cache_endpoints_for_handle(_, :default), do: CacheEndpoints.active_endpoint_urls()
-  def get_cache_endpoints_for_handle(_, :kura), do: []
+
+  def get_cache_endpoints_for_handle(_, :kura) do
+    Environment.kura_endpoints() || []
+  end
 
   defp custom_cache_endpoints(%Account{custom_cache_endpoints_enabled: true} = account) do
     if custom_cache_endpoints_available?(account) do

--- a/server/lib/tuist/docs/redirects.ex
+++ b/server/lib/tuist/docs/redirects.ex
@@ -39,10 +39,10 @@ defmodule Tuist.Docs.Redirects do
     {:exact, "/tutorials/tuist/install", "/tutorials/xcode/create-a-generated-project"},
     {:exact, "/tutorials/tuist/create-project", "/tutorials/xcode/create-a-generated-project"},
     {:exact, "/tutorials/tuist/external-dependencies", "/tutorials/xcode/create-a-generated-project"},
-    {:exact, "/tutorials/tuist-cloud-tutorials", "/guides/server/self-host/install"},
-    {:exact, "/tutorials/tuist/enterprise-infrastructure-requirements", "/guides/server/self-host/install"},
-    {:exact, "/tutorials/tuist/enterprise-environment", "/guides/server/self-host/install"},
-    {:exact, "/tutorials/tuist/enterprise-deployment", "/guides/server/self-host/install"},
+    {:exact, "/tutorials/tuist-cloud-tutorials", "/guides/server/self-host/control-plane"},
+    {:exact, "/tutorials/tuist/enterprise-infrastructure-requirements", "/guides/server/self-host/control-plane"},
+    {:exact, "/tutorials/tuist/enterprise-environment", "/guides/server/self-host/control-plane"},
+    {:exact, "/tutorials/tuist/enterprise-deployment", "/guides/server/self-host/control-plane"},
 
     # Legacy guide structure
     {:exact, "/contributors/get-started", "/contributors/code"},
@@ -84,7 +84,7 @@ defmodule Tuist.Docs.Redirects do
     {:exact, "/cloud/binary-caching", "/guides/features/cache"},
     {:exact, "/cloud/selective-testing", "/guides/features/selective-testing"},
     {:exact, "/cloud/hashing", "/guides/features/projects/hashing"},
-    {:exact, "/cloud/on-premise", "/guides/server/self-host/install"},
+    {:exact, "/cloud/on-premise", "/guides/server/self-host/control-plane"},
     {:exact, "/cloud/on-premise/metrics", "/guides/server/self-host/telemetry"},
 
     # Examples and project description references
@@ -103,7 +103,7 @@ defmodule Tuist.Docs.Redirects do
 
     # VitePress docs reorganizations
     {:exact, "/guides/develop/workflows", "/guides/integrations/continuous-integration"},
-    {:exact, "/guides/dashboard/on-premise/install", "/guides/server/self-host/install"},
+    {:exact, "/guides/dashboard/on-premise/install", "/guides/server/self-host/control-plane"},
     {:exact, "/guides/dashboard/on-premise/metrics", "/guides/server/self-host/telemetry"},
     {:exact, "/guides/start/new-project", "/guides/features/projects/adoption/new-project"},
     {:exact, "/guides/start/swift-package", "/guides/features/projects/adoption/swift-package"},
@@ -123,6 +123,7 @@ defmodule Tuist.Docs.Redirects do
     {:exact, "/guides/develop/selective-testing/xcodebuild", "/guides/features/selective-testing"},
     {:exact, "/guides/features/mcp", "/guides/features/agentic-coding/mcp"},
     {:exact, "/guides/features/agentic-building/mcp", "/guides/features/agentic-coding/mcp"},
+    {:exact, "/guides/server/self-host/install", "/guides/server/self-host/control-plane"},
     {:exact, "/guides/environments/continuous-integration", "/guides/integrations/continuous-integration"},
     {:exact, "/guides/environments/automate/continuous-integration", "/guides/integrations/continuous-integration"},
     {:prefix, "/guides/automate/", "/guides/environments/"},
@@ -130,9 +131,9 @@ defmodule Tuist.Docs.Redirects do
     {:exact, "/server/introduction/accounts-and-projects", "/guides/server/accounts-and-projects"},
     {:exact, "/server/introduction/authentication", "/guides/server/authentication"},
     {:exact, "/server/introduction/integrations", "/guides/integrations/gitforge/github"},
-    {:exact, "/server/on-premise/install", "/guides/server/self-host/install"},
+    {:exact, "/server/on-premise/install", "/guides/server/self-host/control-plane"},
     {:exact, "/server/on-premise/metrics", "/guides/server/self-host/telemetry"},
-    {:exact, "/guides/server/install", "/guides/server/self-host/install"},
+    {:exact, "/guides/server/install", "/guides/server/self-host/control-plane"},
     {:exact, "/guides/server/metrics", "/guides/server/self-host/telemetry"},
     {:exact, "/server", "/guides/server/accounts-and-projects"},
     {:exact, "/guides/quick-start/install-tuist", "/guides/install-tuist"},

--- a/server/lib/tuist/docs_sidebar.ex
+++ b/server/lib/tuist/docs_sidebar.ex
@@ -378,9 +378,8 @@ defmodule Tuist.Docs.Sidebar do
           %Item{
             label: "Self-hosting",
             items: [
-              %Item{label: "Installation", slug: "/en/guides/server/self-host/install"},
-              %Item{label: "Cache nodes", slug: "/en/guides/cache/self-host"},
-              %Item{label: "Cache architecture", slug: "/en/guides/cache/architecture"},
+              %Item{label: "Control plane", slug: "/en/guides/server/self-host/control-plane"},
+              %Item{label: "Kura", slug: "/en/guides/server/self-host/kura"},
               %Item{label: "Telemetry", slug: "/en/guides/server/self-host/telemetry"}
             ]
           }

--- a/server/lib/tuist/environment.ex
+++ b/server/lib/tuist/environment.ex
@@ -228,7 +228,17 @@ defmodule Tuist.Environment do
   def cache_endpoints(secrets \\ secrets()) do
     case get([:cache, :endpoints], secrets) do
       endpoints when is_binary(endpoints) ->
-        endpoints |> String.split(",") |> Enum.map(&String.trim/1)
+        split_endpoints(endpoints)
+
+      _ ->
+        nil
+    end
+  end
+
+  def kura_endpoints(secrets \\ secrets()) do
+    case get([:kura, :endpoints], secrets) do
+      endpoints when is_binary(endpoints) ->
+        split_endpoints(endpoints)
 
       _ ->
         nil
@@ -1073,6 +1083,13 @@ defmodule Tuist.Environment do
 
   defp falsey?(value) when is_binary(value) do
     String.downcase(value) in ["0", "false", "no", "off"]
+  end
+
+  defp split_endpoints(endpoints) do
+    endpoints
+    |> String.split(",")
+    |> Enum.map(&String.trim/1)
+    |> Enum.reject(&(&1 == ""))
   end
 
   def secrets do

--- a/server/priv/docs/en/guides/cache/self-host.md
+++ b/server/priv/docs/en/guides/cache/self-host.md
@@ -13,7 +13,7 @@ The Tuist cache service can be self-hosted to provide a private binary cache for
 > [!NOTE]
 > Self-hosting cache nodes requires an **Enterprise plan**.
 >
-> You can connect self-hosted cache nodes to either the hosted Tuist server (`https://tuist.dev`) or a self-hosted Tuist server. Self-hosting the Tuist server itself requires a separate server license. See the <.localized_link href="/guides/server/self-host/install">server self-hosting guide</.localized_link>.
+> You can connect self-hosted cache nodes to either the hosted Tuist server (`https://tuist.dev`) or a self-hosted Tuist server. Self-hosting the Tuist server itself requires a separate server license. See the <.localized_link href="/guides/server/self-host/control-plane">server self-hosting guide</.localized_link>.
 
 
 ## Prerequisites {#prerequisites}

--- a/server/priv/docs/en/guides/server/self-host/control-plane.md
+++ b/server/priv/docs/en/guides/server/self-host/control-plane.md
@@ -1,11 +1,11 @@
 ---
 {
-  "title": "Installation",
+  "title": "Control plane",
   "titleTemplate": ":title | Self-hosting | Server | Guides | Tuist",
-  "description": "Learn how to install Tuist on your infrastructure."
+  "description": "Learn how to deploy the Tuist control plane on your infrastructure."
 }
 ---
-# Self-host installation {#self-host-installation}
+# Control plane {#control-plane}
 
 We offer a self-hosted version of the Tuist server for organizations that require more control over their infrastructure. This version allows you to host Tuist on your own infrastructure, ensuring that your data remains secure and private.
 
@@ -14,6 +14,12 @@ We offer a self-hosted version of the Tuist server for organizations that requir
 >
 > Self-hosting Tuist requires a legally valid paid license. The on-premise version of Tuist is available only for organizations on the Enterprise plan. If you are interested in this version, please reach out to [contact@tuist.dev](mailto:contact@tuist.dev).
 
+> [!WARNING]
+> **Legacy cache service**
+>
+> The old self-hosted cache-node technology is deprecated for new installations. Use <.localized_link href="/guides/server/self-host/kura">Kura</.localized_link> for self-hosted cache infrastructure.
+>
+> Existing deployments can still reference the legacy source documentation in GitHub's markdown viewer: [cache nodes](https://github.com/tuist/tuist/blob/main/server/priv/docs/en/guides/cache/self-host.md) and [cache architecture](https://github.com/tuist/tuist/blob/main/server/priv/docs/en/guides/cache/architecture.md).
 
 ## Release cadence {#release-cadence}
 
@@ -91,17 +97,17 @@ You’ll also need a solution to store files (e.g. framework and library binarie
 > [!TIP]
 > **Optimized Caching**
 >
-> If your goal is primarily to bring your own bucket for storing binaries and reduce cache latency, you might not need to self-host the whole server. You can self-host cache nodes and connect them to the hosted Tuist server or your self-hosted server.
+> If your goal is primarily to reduce cache latency, you might not need to self-host the whole server. You can deploy Kura close to your CI or developer network and connect it to the hosted Tuist server or your self-hosted server.
 >
-> See the <.localized_link href="/guides/cache/self-host">cache self-hosting guide</.localized_link>.
+> See the <.localized_link href="/guides/server/self-host/kura">Kura self-hosting guide</.localized_link>.
 
 
-### Self-hosted cache nodes {#self-hosted-cache-nodes}
+### Kura cache nodes {#kura-cache-nodes}
 
-To use self-hosted cache nodes with a self-hosted Tuist server:
+To use Kura with a self-hosted Tuist server:
 
-1. Deploy your cache nodes following the <.localized_link href="/guides/cache/self-host">cache self-hosting guide</.localized_link>.
-2. Set `TUIST_CACHE_ENDPOINTS` to a comma-separated list of cache node URLs (for example, `https://cache-1.example.com,https://cache-2.example.com`).
+1. Deploy Kura following the <.localized_link href="/guides/server/self-host/kura">Kura self-hosting guide</.localized_link>.
+2. Set `TUIST_KURA_ENDPOINTS` to a comma-separated list of Kura URLs, or configure `server.kuraEndpointUrls` in the Helm chart.
 
 ## Configuration {#configuration}
 

--- a/server/priv/docs/en/guides/server/self-host/kura.md
+++ b/server/priv/docs/en/guides/server/self-host/kura.md
@@ -1,0 +1,133 @@
+---
+{
+  "title": "Kura",
+  "titleTemplate": ":title | Self-hosting | Server | Guides | Tuist",
+  "description": "Deploy Kura and connect it to a self-hosted Tuist server."
+}
+---
+
+# Kura {#kura}
+
+Kura is Tuist's decentralized cache mesh for build artifacts and cache metadata. It lets you place cache nodes close to the machines that produce and consume build outputs, whether those machines run in CI, developer offices, remote workstations, or regional compute clusters.
+
+The goal is low-latency caching everywhere, not only in the one environment where a central cache happens to be nearby. Each Kura node serves reads and writes from local disk, while the mesh replicates artifacts and metadata between peers so other locations can benefit from the same cache over time.
+
+## How Kura fits with Tuist {#how-kura-fits-with-tuist}
+
+The Tuist server tells clients which Kura endpoints to use. This keeps endpoint discovery centralized while allowing the cache itself to stay decentralized and close to the compute that needs it.
+
+Kura is the data plane. It serves cache reads and writes, stores local state on disk, and replicates artifacts and metadata to peer nodes.
+
+## Deploy on Kubernetes {#deploy-on-kubernetes}
+
+Kura is distributed as a Helm chart through GitHub Container Registry. It deploys Kura as a `StatefulSet` with persistent volumes, a headless service for peer discovery, and a regular service for HTTP and gRPC traffic.
+
+```bash
+helm upgrade --install kura oci://ghcr.io/tuist/charts/kura \
+  --namespace kura \
+  --create-namespace \
+  --version <version> \
+  --set image.tag=<tag> \
+  --set config.region=local
+```
+
+For a self-hosted Tuist server running in the same cluster, expose the Kura service through the Tuist chart:
+
+```yaml
+server:
+  kuraEndpointUrls:
+    - http://kura.kura.svc.cluster.local:4000
+```
+
+This renders `TUIST_KURA_ENDPOINTS` in the server pod. When clients request the Kura cache technology, the server returns those endpoints.
+
+> [!IMPORTANT]
+> Every Kura node must own its own `KURA_DATA_DIR`. Kura takes an application-level writer lock on the data directory and expects exactly one process to own it. In Kubernetes, use one persistent volume per pod. Outside Kubernetes, do not point multiple processes at the same mounted directory.
+
+## Deploy without Kubernetes {#deploy-without-kubernetes}
+
+Kura can also run as a regular container on VMs or bare-metal hosts. In this mode, you are responsible for process supervision, persistent storage, routing, and peer discovery.
+
+At minimum, each node needs a persistent data directory, a temporary directory, a public HTTP port, an internal peer URL, and either a static peer list or a discovery mechanism:
+
+```bash
+docker run -d --name kura \
+  -p 4000:4000 \
+  -p 50051:50051 \
+  -p 7443:7443 \
+  -v /var/lib/kura:/var/cache/kura \
+  -e KURA_PORT=4000 \
+  -e KURA_GRPC_PORT=50051 \
+  -e KURA_INTERNAL_PORT=7443 \
+  -e KURA_TENANT_ID=default \
+  -e KURA_REGION=local \
+  -e KURA_TMP_DIR=/tmp/kura \
+  -e KURA_DATA_DIR=/var/cache/kura \
+  -e KURA_NODE_URL=http://kura-1.internal:7443 \
+  -e KURA_PEERS=http://kura-1.internal:7443,http://kura-2.internal:7443 \
+  ghcr.io/tuist/kura:<tag>
+```
+
+Then configure the Tuist server with the URLs that clients can reach:
+
+```bash
+TUIST_KURA_ENDPOINTS=https://kura-1.example.com,https://kura-2.example.com
+```
+
+## Configuration {#configuration}
+
+The Helm chart renders the common runtime settings from `values.yaml`. If you run Kura without Kubernetes, set the same variables directly on the process. Variables that the chart does not map directly can be injected through `extraEnv` or `extraEnvFrom`.
+
+| Environment variable | Description | Required | Default | Helm value |
+| --- | --- | --- | --- | --- |
+| `KURA_PORT` | Public HTTP port for cache traffic and health endpoints. | Yes | No default | `service.httpPort` |
+| `KURA_GRPC_PORT` | gRPC port for Bazel and Buck2 REAPI traffic. | Yes | No default | `service.grpcPort` |
+| `KURA_INTERNAL_PORT` | Internal HTTP or mTLS port used by Kura peers. | Yes | No default | `peerTls.internalPort` |
+| `KURA_TENANT_ID` | Default tenant identifier for the node. | Yes | No default | `config.tenantId` |
+| `KURA_REGION` | Region label used in metrics and replication state. | Yes | No default | `config.region` |
+| `KURA_TMP_DIR` | Temporary directory for staged request bodies and multipart assembly. | Yes | No default | Fixed to `/tmp/kura` |
+| `KURA_DATA_DIR` | Persistent directory for metadata state and segment files. | Yes | No default | Fixed to `/var/cache/kura` |
+| `KURA_NODE_URL` | Canonical internal URL other peers use to reach this node. | Yes | No default | Derived from the pod DNS name and `peerTls.internalPort` |
+| `KURA_PEERS` | Seed peer list used before discovery converges. | No | `KURA_NODE_URL` | Derived from the StatefulSet replicas |
+| `KURA_DISCOVERY_DNS_NAME` | DNS name used for automatic peer discovery. | No | Disabled | Enabled by `config.discovery.enabled` |
+| `KURA_INTERNAL_TLS_CA_CERT_PATH` | CA certificate used to verify peer mTLS. | No | Disabled | `peerTls.enabled` and `peerTls.caCertFileName` |
+| `KURA_INTERNAL_TLS_CERT_PATH` | Certificate used by the internal peer mTLS listener. | No | Disabled | `peerTls.enabled` and `peerTls.certFileName` |
+| `KURA_INTERNAL_TLS_KEY_PATH` | Private key used by the internal peer mTLS listener. | No | Disabled | `peerTls.enabled` and `peerTls.keyFileName` |
+| `KURA_GRPC_TLS_CERT_PATH` | Certificate used to terminate TLS on the public gRPC listener. | No | Disabled | `extraEnv` |
+| `KURA_GRPC_TLS_KEY_PATH` | Private key paired with `KURA_GRPC_TLS_CERT_PATH`. | No | Disabled | `extraEnv` |
+| `KURA_FILE_DESCRIPTOR_POOL_SIZE` | File-descriptor budget for request and background I/O. | No | Auto-derived | `config.fileDescriptors.poolSize` |
+| `KURA_FILE_DESCRIPTOR_ACQUIRE_TIMEOUT_MS` | How long a request waits before FD backpressure fails the checkout. | No | `5000` | `config.fileDescriptors.acquireTimeoutMs` |
+| `KURA_SEGMENT_HANDLE_CACHE_SIZE` | Maximum number of pinned segment read handles. | No | Auto-derived | `config.fileDescriptors.segmentHandleCacheSize` |
+| `KURA_DRAIN_COMPLETION_TIMEOUT_MS` | Grace window for in-flight HTTP and gRPC work during shutdown. | No | `240000` | `config.shutdown.drainCompletionTimeoutMs` |
+| `KURA_MEMORY_SOFT_LIMIT_BYTES` | Soft memory watermark where Kura starts reducing optional memory use. | No | Auto-derived | `config.memory.softLimitBytes` |
+| `KURA_MEMORY_HARD_LIMIT_BYTES` | Hard memory watermark where Kura pauses replication and trims hot caches. | No | Auto-derived | `config.memory.hardLimitBytes` |
+| `KURA_MANIFEST_CACHE_MAX_BYTES` | Maximum size of the in-memory manifest cache. | No | Auto-derived | `config.memory.manifestCacheMaxBytes` |
+| `KURA_MAX_KEYVALUE_BYTES` | Maximum per-request keyvalue payload size. | No | `1048576` | `config.memory.maxKeyvalueBytes` |
+| `KURA_METADATA_STORE_MAX_OPEN_FILES` | File descriptor budget reserved for the metadata store. | No | Auto-derived | `config.metadataStore.maxOpenFiles` |
+| `KURA_METADATA_STORE_MAX_BACKGROUND_JOBS` | Background flush and compaction concurrency for the metadata store. | No | Auto-derived | `config.metadataStore.maxBackgroundJobs` |
+| `KURA_METADATA_STORE_READ_CACHE_BYTES` | Capacity of the metadata-store read cache. | No | Auto-derived | `extraEnv` |
+| `KURA_METADATA_STORE_WRITE_BUFFER_POOL_BYTES` | Total memory budget reserved for metadata write buffering. | No | Auto-derived | `extraEnv` |
+| `KURA_METADATA_STORE_WRITE_BUFFER_BYTES` | Size of each metadata write buffer before flush. | No | Auto-derived | `extraEnv` |
+| `KURA_METADATA_STORE_MAX_WRITE_BUFFERS` | Maximum number of metadata write buffers kept in memory. | No | Auto-derived | `extraEnv` |
+| `KURA_OUTBOX_MAX_DEPTH` | Maximum replication outbox depth before public writes return backpressure. | No | `100000` | `extraEnv` |
+| `KURA_MULTIPART_UPLOAD_TTL_MS` | How long an in-progress multipart upload may sit before expiring. | No | `86400000` | `extraEnv` |
+| `KURA_MULTIPART_JANITOR_INTERVAL_MS` | How often Kura scans for stale multipart uploads. | No | `600000` | `extraEnv` |
+| `KURA_BOOTSTRAP_TIMEOUT_MS` | Maximum time a single bootstrap-from-peer task may run. | No | `1800000` | `extraEnv` |
+| `KURA_BOOTSTRAP_MAX_CONCURRENT_PEERS` | Maximum concurrent bootstrap-from-peer tasks. | No | `8` | `extraEnv` |
+| `KURA_TOKIO_WORKER_THREADS` | Number of Tokio worker threads. | No | Auto-derived | `extraEnv` |
+| `KURA_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` | OTLP traces endpoint. Leave empty to disable tracing. | No | Disabled | `config.telemetry.otlpTracesEndpoint` |
+| `KURA_OTEL_SERVICE_NAME` | OpenTelemetry service name. | Yes | No default | Pod name in Helm |
+| `KURA_OTEL_DEPLOYMENT_ENVIRONMENT` | OpenTelemetry deployment environment. | Yes | No default | `config.telemetry.deploymentEnvironment` |
+| `KURA_SENTRY_DSN` | Sentry DSN for panic and error reporting. | No | Disabled | `extraEnv` or `extraEnvFrom` |
+| `KURA_GEOIP_REFRESH_INTERVAL_SECS` | Interval for refreshing the vendored GeoIP database. Set `0` to disable refreshes. | No | `86400` | `config.geoip.refreshIntervalSecs` |
+| `KURA_EXTENSION_ENABLED` | Enables Lua extension hooks. | No | Disabled | `extension.enabled` |
+| `KURA_EXTENSION_SCRIPT_PATH` | Path to the Lua extension script. | Required when extensions are enabled | No default | Derived from `extension.mountDir` and `extension.scriptFileName` |
+| `KURA_EXTENSION_HOOK_TIMEOUT_MS` | Timeout for each extension hook invocation. | No | `25` | `extraEnv` |
+| `KURA_EXTENSION_AUTH_CACHE_ALLOW_TTL_SECONDS` | TTL for positive extension authentication and authorization cache entries. | No | `600` | `extraEnv` |
+| `KURA_EXTENSION_AUTH_CACHE_DENY_TTL_SECONDS` | TTL for negative extension authentication and authorization cache entries. | No | `3` | `extraEnv` |
+| `KURA_EXTENSION_FAIL_CLOSED_AUTHENTICATE` | Whether authentication hook errors reject the request. | No | `true` | `extraEnv` |
+| `KURA_EXTENSION_FAIL_CLOSED_AUTHORIZE` | Whether authorization hook errors reject the request. | No | `true` | `extraEnv` |
+| `KURA_EXTENSION_FAIL_OPEN_RESPONSE_HEADERS` | Whether response-header hook errors are ignored. | No | `true` | `extraEnv` |
+| `KURA_EXTENSION_CACHE_MAX_ENTRIES` | Maximum entries kept in each extension cache. | No | `100000` | `extraEnv` |
+
+If you enable internal peer mTLS, set `KURA_INTERNAL_TLS_CA_CERT_PATH`, `KURA_INTERNAL_TLS_CERT_PATH`, and `KURA_INTERNAL_TLS_KEY_PATH` together. `KURA_NODE_URL` and every value in `KURA_PEERS` must then use `https://` with the internal peer port.

--- a/server/priv/docs/strings/en.json
+++ b/server/priv/docs/strings/en.json
@@ -474,8 +474,11 @@
             "self-hosting": {
               "text": "Self-hosting",
               "items": {
-                "installation": {
-                  "text": "Installation"
+                "control-plane": {
+                  "text": "Control plane"
+                },
+                "kura": {
+                  "text": "Kura"
                 },
                 "telemetry": {
                   "text": "Telemetry"

--- a/server/test/tuist/accounts_test.exs
+++ b/server/test/tuist/accounts_test.exs
@@ -4102,6 +4102,7 @@ defmodule Tuist.AccountsTest do
     test "returns Kura endpoints when account has them configured" do
       # Given
       stub(Environment, :tuist_hosted?, fn -> true end)
+      stub(Environment, :kura_endpoints, fn -> nil end)
       user = AccountsFixtures.user_fixture()
       account = Accounts.get_account_from_user(user)
 
@@ -4125,11 +4126,48 @@ defmodule Tuist.AccountsTest do
                Enum.sort(["https://kura-cache-1.example.com", "https://kura-cache-2.example.com"])
     end
 
+    test "returns environment Kura endpoints over account-specific endpoints" do
+      # Given
+      environment_endpoints = [
+        "https://kura-cluster-1.example.com",
+        "https://kura-cluster-2.example.com"
+      ]
+
+      stub(Environment, :kura_endpoints, fn -> environment_endpoints end)
+      user = AccountsFixtures.user_fixture()
+      account = Accounts.get_account_from_user(user)
+
+      {:ok, _} =
+        Accounts.create_account_cache_endpoint(account, %{
+          url: "https://kura-cache-1.example.com",
+          technology: :kura
+        })
+
+      # When
+      endpoints = Accounts.get_cache_endpoints_for_handle(account.name, :kura)
+
+      # Then
+      assert endpoints == environment_endpoints
+    end
+
+    test "returns environment Kura endpoints when the account handle is missing" do
+      # Given
+      environment_endpoints = ["https://kura-cluster.example.com"]
+      stub(Environment, :kura_endpoints, fn -> environment_endpoints end)
+
+      # When
+      endpoints = Accounts.get_cache_endpoints_for_handle(nil, :kura)
+
+      # Then
+      assert endpoints == environment_endpoints
+    end
+
     test "returns regional Kura endpoints until the global endpoint has been reconciled" do
       # Given
       stub(Environment, :tuist_hosted?, fn -> true end)
       stub(Environment, :dev?, fn -> false end)
       stub(Environment, :test?, fn -> false end)
+      stub(Environment, :kura_endpoints, fn -> nil end)
       user = AccountsFixtures.user_fixture()
       account = Accounts.get_account_from_user(user)
 
@@ -4158,6 +4196,7 @@ defmodule Tuist.AccountsTest do
       stub(Environment, :tuist_hosted?, fn -> true end)
       stub(Environment, :dev?, fn -> false end)
       stub(Environment, :test?, fn -> false end)
+      stub(Environment, :kura_endpoints, fn -> nil end)
       user = AccountsFixtures.user_fixture()
       account = Accounts.get_account_from_user(user)
 
@@ -4182,6 +4221,7 @@ defmodule Tuist.AccountsTest do
 
     test "returns no Kura endpoints when account has none configured" do
       # Given
+      stub(Environment, :kura_endpoints, fn -> nil end)
       user = AccountsFixtures.user_fixture()
       account = Accounts.get_account_from_user(user)
 
@@ -4197,6 +4237,7 @@ defmodule Tuist.AccountsTest do
       stub(Environment, :tuist_hosted?, fn -> true end)
       stub(Environment, :dev?, fn -> false end)
       stub(Environment, :test?, fn -> false end)
+      stub(Environment, :kura_endpoints, fn -> nil end)
       user = AccountsFixtures.user_fixture()
       account = Accounts.get_account_from_user(user)
 

--- a/server/test/tuist/docs/redirects_test.exs
+++ b/server/test/tuist/docs/redirects_test.exs
@@ -24,6 +24,11 @@ defmodule Tuist.Docs.RedirectsTest do
                {:ok, "/en/docs/guides/integrations/authentication/sso"}
     end
 
+    test "redirects the old self-host installation route to control plane" do
+      assert Redirects.resolve("/en/docs/guides/server/self-host/install") ==
+               {:ok, "/en/docs/guides/server/self-host/control-plane"}
+    end
+
     test "redirects the old translation guide slug to languages" do
       assert Redirects.resolve("/en/docs/contributors/translate") ==
                {:ok, "/en/docs/contributors/languages"}

--- a/server/test/tuist/environment_test.exs
+++ b/server/test/tuist/environment_test.exs
@@ -219,4 +219,23 @@ defmodule Tuist.EnvironmentTest do
       end
     end
   end
+
+  describe "kura_endpoints/1" do
+    test "returns trimmed Kura endpoints from secrets" do
+      secrets = %{
+        "kura" => %{
+          "endpoints" => " https://kura-1.example.com,https://kura-2.example.com , "
+        }
+      }
+
+      assert Environment.kura_endpoints(secrets) == [
+               "https://kura-1.example.com",
+               "https://kura-2.example.com"
+             ]
+    end
+
+    test "returns nil when Kura endpoints are not configured" do
+      assert Environment.kura_endpoints(%{}) == nil
+    end
+  end
 end


### PR DESCRIPTION
Resolves N/A

Adds self-hosted Kura endpoint support for on-premise Tuist deployments. The server can now read Kura endpoints from runtime configuration, the Tuist Helm chart can render those endpoints into the server pod, and the Kura Helm chart is included in Helm validation and release publishing.

The self-hosting docs now split the old installation page into a Control plane page, remove the legacy cache-node pages from the sidebar, point existing cache-node users to the deprecated source docs, and add a Kura page that explains why Kura is decentralized, how to deploy it with or without Kubernetes, and which runtime variables operators can configure.

### How to test locally

- `git diff --check origin/main...HEAD`
- `helm lint kura/ops/helm/kura`
- `helm template kura kura/ops/helm/kura > /tmp/kura-rendered.yaml && wc -l /tmp/kura-rendered.yaml`
- `helm package kura/ops/helm/kura --destination /tmp`
- `helm lint infra/helm/tuist --set 'server.kuraEndpointUrls[0]=http://kura:4000'`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); YAML.load_file(".github/workflows/helm.yml"); puts "ok"'`
- `mix test test/tuist/environment_test.exs test/tuist/accounts_test.exs test/tuist/docs/redirects_test.exs` (fails during test database setup with `Postgrex.Error` because relation `users` does not exist)
