### PR TITLE
fix(cli): avoid checkout cwd for SwiftPM package dumps

### DIFF
--- a/cli/Sources/TuistLoader/Loaders/PackageInfoLoader.swift
+++ b/cli/Sources/TuistLoader/Loaders/PackageInfoLoader.swift
@@ -69,7 +69,7 @@ public struct PackageInfoLoader: PackageInfoLoading {
         }
         let command = buildSwiftPackageCommand(packagePath: path, extraArguments: extraArguments)
 
-        let json = try await commandRunner.capture(arguments: command, workingDirectory: path)
+        let json = try await commandRunner.capture(arguments: command)
 
         let data = Data(json.utf8)
         let decoder = JSONDecoder()

--- a/cli/Sources/TuistTesting/Utils/MockCommandRunner.swift
+++ b/cli/Sources/TuistTesting/Utils/MockCommandRunner.swift
@@ -12,6 +12,7 @@ public final class MockCommandRunner: CommandRunning, @unchecked Sendable {
     // swiftlint:disable:next large_tuple
     private var _captureStubs: [String: (stderror: String?, stdout: String?, exitstatus: Int?)] = [:]
     private var _calls: [String] = []
+    private var _workingDirectories: [Path.AbsolutePath?] = []
     public var whichStub: ((String) throws -> String?)?
 
     // swiftlint:disable:next large_tuple
@@ -32,6 +33,12 @@ public final class MockCommandRunner: CommandRunning, @unchecked Sendable {
         lock.lock()
         defer { lock.unlock() }
         return _calls
+    }
+
+    public var workingDirectories: [Path.AbsolutePath?] {
+        lock.lock()
+        defer { lock.unlock() }
+        return _workingDirectories
     }
 
     public init() {}
@@ -58,12 +65,13 @@ public final class MockCommandRunner: CommandRunning, @unchecked Sendable {
     public func run(
         arguments: [String],
         environment _: [String: String],
-        workingDirectory _: Path.AbsolutePath?
+        workingDirectory: Path.AbsolutePath?
     ) -> AsyncThrowingStream<CommandEvent, any Error> {
         AsyncThrowingStream { continuation in
             let command = arguments.joined(separator: " ")
             lock.lock()
             _calls.append(command)
+            _workingDirectories.append(workingDirectory)
             let stub = _captureStubs[command] ?? _defaultCaptureStubs
             lock.unlock()
 

--- a/cli/Sources/XcodeGraph/Sources/XcodeGraphMapper/Utilities/PackageInfoLoader.swift
+++ b/cli/Sources/XcodeGraph/Sources/XcodeGraphMapper/Utilities/PackageInfoLoader.swift
@@ -27,8 +27,7 @@ struct PackageInfoLoader: PackageInfoLoading {
                 "--package-path",
                 path.pathString,
                 "dump-package",
-            ],
-            workingDirectory: path
+            ]
         )
         .concatenatedString()
 

--- a/cli/Tests/TuistLoaderTests/Loaders/PackageInfoLoaderTests.swift
+++ b/cli/Tests/TuistLoaderTests/Loaders/PackageInfoLoaderTests.swift
@@ -111,4 +111,27 @@ final class PackageInfoLoaderTests: TuistUnitTestCase {
         // Then
         XCTAssertEqual(packageInfo, PackageInfo.googleAppMeasurement)
     }
+
+    func test_loadPackageInfo_doesNotOverrideWorkingDirectory() async throws {
+        // Given
+        let path = try temporaryPath()
+        mockCommandRunner.succeedCommand(
+            [
+                "swift",
+                "package",
+                "--package-path",
+                path.pathString,
+                "--disable-sandbox",
+                "dump-package",
+            ],
+            output: PackageInfo.testJSON
+        )
+
+        // When
+        _ = try await subject.loadPackageInfo(at: path, disableSandbox: true)
+
+        // Then
+        XCTAssertEqual(mockCommandRunner.workingDirectories.count, 1)
+        XCTAssertNil(mockCommandRunner.workingDirectories[0])
+    }
 }


### PR DESCRIPTION
## Summary
- Stop passing the package checkout as the working directory when loading SwiftPM package metadata with `dump-package`.
- Keep the explicit working directory behavior for SwiftPM commands that mutate or build packages.
- Add a regression test that verifies package-info loading does not override the caller working directory.

> [!NOTE]
> This is not a full revert of the previous working-directory fix. Commands such as `resolve`, `update`, `tools-version`, package builds, and `lipo` still run with the explicit package working directory. The exception is `dump-package`, which already receives an absolute `--package-path` and only reads manifest metadata, so running it from inside `Tuist/.build/checkouts/<Package>` can expose SwiftPM cwd or scratch-state issues without providing a benefit.

## Testing
- `swift build --replace-scm-with-registry`
- `mise run lint`
- Reproduced the released `4.195.7` failure shape with a cwd-sensitive `swift` shim against a CombineExt fixture.
- Verified `4.195.0` and the locally fixed binary pass under the same shim.
