### PR TITLE
ci: stabilize Gradle cache acceptance ports

### DIFF
--- a/.github/workflows/gradle-cache-acceptance.yml
+++ b/.github/workflows/gradle-cache-acceptance.yml
@@ -63,6 +63,7 @@ jobs:
       TUIST_SECRET_KEY_TOKENS: ci-test-secret-key-tokens
       TUIST_SECRET_KEY_ENCRYPTION: ci-test-encryption-key-32-bytes!
       TUIST_CACHE_API_KEY: 7a3de63bb6136d94539e9976b1c54bfd553467c2c4775f84b7b2baf27f8b38c6
+      TUIST_DEV_INSTANCE: 1
     steps:
       - uses: actions/checkout@v4
       - uses: jdx/mise-action@v4.0.1


### PR DESCRIPTION
Resolves <https://github.com/tuist/tuist/actions/runs/26523368584/job/78120318631>

The Gradle Cache Acceptance workflow was failing before the acceptance test ran because the mise dev-instance suffix can derive `TUIST_SERVER_PORT=9005`. That collides with ClickHouse's fixed PostgreSQL compatibility port, so the setup step starts the Phoenix endpoint and exits with `:eaddrinuse`.

This pins `TUIST_DEV_INSTANCE` to `1` for the workflow, keeping the mise-derived main and cache server ports stable and away from ClickHouse's auxiliary ports.

### How to test locally

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/gradle-cache-acceptance.yml"); puts "yaml ok"'`
