### PR TITLE
ci(infra): give each server-deploy job its own concurrency lane

### DIFF
--- a/.github/workflows/server-deployment.yml
+++ b/.github/workflows/server-deployment.yml
@@ -149,10 +149,11 @@ jobs:
     # server starts pushing spans to it. Idempotent: on every run it's a
     # no-op if Chart.lock + values haven't changed.
     #
-    # Shares the `server-deploy-<env>` concurrency lane with the deploy
-    # job on purpose: the server's OTLP endpoint and the chart that
-    # provides the receiver change in lockstep, so a newer chart install
-    # must never interleave with an older server rollout.
+    # Per-chart concurrency lane: serializes this install against its
+    # own past runs without making sibling install jobs in the same
+    # run cancel each other. A single shared lane caps the GitHub
+    # queue at running + 1 waiting and drops the rest, which used to
+    # leave only one of the three install jobs running per deploy.
     name: Observability chart (${{ inputs.environment }})
     needs: build
     # `build` is skipped when image_tag is supplied - keep running.
@@ -161,7 +162,7 @@ jobs:
     environment:
       name: server-k8s-${{ inputs.environment }}
     concurrency:
-      group: server-deploy-${{ inputs.environment }}
+      group: server-deploy-${{ inputs.environment }}-observability
       cancel-in-progress: false
     timeout-minutes: 15
     env:
@@ -217,9 +218,9 @@ jobs:
     # usable downstream without a hard dependency on Tailscale; the
     # main server deploy continues either way.
     #
-    # Shares the `server-deploy-<env>` concurrency lane with the deploy
-    # job, same reasoning as observability-install: the chart and the
-    # workloads it gates must never interleave with a stale rollout.
+    # Per-chart concurrency lane: same reasoning as
+    # observability-install. Serializes this install against its own
+    # past runs without sharing a slot with the sibling install jobs.
     name: Tailscale operator chart (${{ inputs.environment }})
     needs: build
     if: always() && (needs.build.result == 'success' || needs.build.result == 'skipped')
@@ -227,7 +228,7 @@ jobs:
     environment:
       name: server-k8s-${{ inputs.environment }}
     concurrency:
-      group: server-deploy-${{ inputs.environment }}
+      group: server-deploy-${{ inputs.environment }}-tailscale
       cancel-in-progress: false
     timeout-minutes: 15
     env:
@@ -294,9 +295,9 @@ jobs:
     # clusters pick up chart edits without a manual re-bootstrap. Idempotent:
     # steady-state finishes in under a minute when nothing has drifted.
     #
-    # Shares the `server-deploy-<env>` concurrency lane with the deploy job
-    # so a newer platform install never interleaves with an older server
-    # rollout.
+    # Per-chart concurrency lane: same reasoning as
+    # observability-install. Serializes this install against its own
+    # past runs without sharing a slot with the sibling install jobs.
     name: Platform chart (${{ inputs.environment }})
     needs: build
     if: always() && (needs.build.result == 'success' || needs.build.result == 'skipped')
@@ -304,7 +305,7 @@ jobs:
     environment:
       name: server-k8s-${{ inputs.environment }}
     concurrency:
-      group: server-deploy-${{ inputs.environment }}
+      group: server-deploy-${{ inputs.environment }}-platform
       cancel-in-progress: false
     timeout-minutes: 20
     env:
@@ -366,9 +367,10 @@ jobs:
       name: server-k8s-${{ inputs.environment }}
       url: https://${{ inputs.environment == 'production' && 'tuist.dev' || format('{0}.tuist.dev', inputs.environment) }}
     # Serialize deploys targeting the same environment so two concurrent
-    # runs don't race on the Helm release.
+    # runs don't race on the Helm release. Per-job lane so the sibling
+    # chart-install jobs don't compete for this slot within one run.
     concurrency:
-      group: server-deploy-${{ inputs.environment }}
+      group: server-deploy-${{ inputs.environment }}-deploy
       cancel-in-progress: false
     # helm-upgrade waits up to 30m and setup/teardown adds ~5m. 50m
     # leaves a healthy buffer around that stack and keeps a


### PR DESCRIPTION
## Summary

A single `server-deploy-<env>` concurrency group covered all four jobs in [server-deployment.yml](.github/workflows/server-deployment.yml) (`observability-install`, `tailscale-operator-install`, `platform-install`, `deploy`). GitHub's `cancel-in-progress: false` queue caps each group at one running + one waiting and cancels any extras with `Canceling since a higher priority waiting request for ... exists`. The three install jobs fan out in parallel after `build`, so two of them got cancelled at ~1s on every deploy and only the third (plus `deploy`) actually ran.

Caught while watching a stuck canary deploy. The cancellation was visible on the latest run's [Observability chart job](https://github.com/tuist/tuist/actions/runs/26523367842/job/78123284235) and on [Tailscale operator chart](https://github.com/tuist/tuist/actions/runs/26523367842/job/78123284171); only `Platform chart` survived to run.

## What changed

Per-job suffixes on the concurrency group:

| Job                            | Group                                            |
| ------------------------------ | ------------------------------------------------ |
| `observability-install`        | `server-deploy-<env>-observability`              |
| `tailscale-operator-install`   | `server-deploy-<env>-tailscale`                  |
| `platform-install`             | `server-deploy-<env>-platform`                   |
| `deploy`                       | `server-deploy-<env>-deploy`                     |

Each lane still serializes against its own past runs, so a newer chart install never races against an older instance of the same chart, and `deploy` still serializes Helm releases across runs (the load-bearing guarantee).

## Trade-off

The previous comments implied a stronger guarantee: a newer chart install must never interleave with an older `deploy`. With per-job lanes that cross-job ordering is relaxed - a newer run's chart install can run while an older run's `deploy` is still going. The previous setup didn't actually deliver that guarantee either (it just silently dropped two of the three install jobs), and the install jobs are idempotent / no-op on no drift, so the practical exposure is small.

If we ever need that stronger ordering back, the cleanest path is to chain the three install jobs sequentially via `needs:` while keeping a single shared lane - that preserves the intent without the cancellation pathology.

## Test plan

- [ ] Next canary deploy on `main` runs all four jobs without `Canceling since a higher priority waiting request` annotations.
- [ ] Two back-to-back canary deploys serialize at the `deploy` job (second run's `deploy` waits for first run's `deploy` to finish).