### PR TITLE
fix(cli): Fix Swift-only package framework modulemaps

### DIFF
--- a/cli/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
+++ b/cli/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
@@ -654,7 +654,8 @@ public struct PackageInfoMapper: PackageInfoMapping {
                 packageDirectory: path,
                 moduleName: moduleName,
                 publicHeadersPath: target.publicHeadersPath(packageFolder: path),
-                swiftPackageManagerScratchDirectory: swiftPackageManagerScratchDirectory
+                swiftPackageManagerScratchDirectory: swiftPackageManagerScratchDirectory,
+                generateModuleMapForSwiftOnlyTargets: product == .framework
             )
         default:
             moduleMap = nil
@@ -1339,7 +1340,7 @@ extension ProjectDescription.Headers {
                     ]
                 )
             )
-        case .none, .header, .custom:
+        case .none, .swiftOnly, .header, .custom:
             return nil
         }
     }
@@ -1365,7 +1366,13 @@ extension ProjectDescription.Settings {
 
         var dependencyHeaderSearchPaths: [String] = []
         if let moduleMap {
-            if moduleMap != .none, target.type != .system {
+            let needsHeaderSearchPath = switch moduleMap {
+            case .directory, .header, .custom:
+                true
+            case .none, .swiftOnly:
+                false
+            }
+            if needsHeaderSearchPath, target.type != .system {
                 let publicHeadersPath = try await target.publicHeadersPath(packageFolder: packageFolder)
                 let publicHeadersRelativePath = publicHeadersPath.relative(to: packageFolder)
                 dependencyHeaderSearchPaths.append("$(SRCROOT)/\(publicHeadersRelativePath.pathString)")
@@ -1436,7 +1443,7 @@ extension ProjectDescription.Settings {
 
         if let moduleMap {
             switch moduleMap {
-            case .directory, .header, .custom:
+            case .directory, .header, .custom, .swiftOnly:
                 settingsDictionary["DEFINES_MODULE"] = "NO"
                 switch settingsDictionary["OTHER_CFLAGS"] ?? .array(["$(inherited)"]) {
                 case let .array(values):

--- a/cli/Sources/TuistLoader/SwiftPackageManager/SwiftPackageManagerModuleMapGenerator.swift
+++ b/cli/Sources/TuistLoader/SwiftPackageManager/SwiftPackageManagerModuleMapGenerator.swift
@@ -8,6 +8,8 @@ import TuistSupport
 public enum ModuleMap: Equatable {
     /// No headers and hence no modulemap file
     case none
+    /// A Swift-only framework target with no Clang headers.
+    case swiftOnly(moduleMapPath: AbsolutePath)
     /// Custom modulemap file provided in SPM package
     case custom(AbsolutePath, umbrellaHeaderPath: AbsolutePath?)
     /// Umbrella header provided in SPM package
@@ -18,6 +20,8 @@ public enum ModuleMap: Equatable {
     var moduleMapPath: AbsolutePath? {
         switch self {
         case let .custom(path, umbrellaHeaderPath: _):
+            return path
+        case let .swiftOnly(moduleMapPath: path):
             return path
         case let .header(_, moduleMapPath: path):
             return path
@@ -42,7 +46,8 @@ public protocol SwiftPackageManagerModuleMapGenerating {
         packageDirectory: AbsolutePath,
         moduleName: String,
         publicHeadersPath: AbsolutePath,
-        swiftPackageManagerScratchDirectory: AbsolutePath?
+        swiftPackageManagerScratchDirectory: AbsolutePath?,
+        generateModuleMapForSwiftOnlyTargets: Bool
     ) async throws -> ModuleMap
 }
 
@@ -63,7 +68,8 @@ public struct SwiftPackageManagerModuleMapGenerator: SwiftPackageManagerModuleMa
         packageDirectory: AbsolutePath,
         moduleName: String,
         publicHeadersPath: AbsolutePath,
-        swiftPackageManagerScratchDirectory: AbsolutePath? = nil
+        swiftPackageManagerScratchDirectory: AbsolutePath? = nil,
+        generateModuleMapForSwiftOnlyTargets: Bool = false
     ) async throws -> ModuleMap {
         let sanitizedModuleName = moduleName.sanitizedModuleName
         let umbrellaHeaderPath = publicHeadersPath.appending(component: sanitizedModuleName + ".h")
@@ -132,6 +138,14 @@ public struct SwiftPackageManagerModuleMapGenerator: SwiftPackageManagerModuleMa
             return .custom(customModuleMapPath, umbrellaHeaderPath: nil)
         } else if try await fileSystem.exists(publicHeadersPath) {
             if try await fileSystem.glob(directory: publicHeadersPath, include: ["**/*.h", "*.h"]).collect().isEmpty {
+                if generateModuleMapForSwiftOnlyTargets {
+                    try await writeIfDifferent(
+                        moduleMapContent: swiftOnlyModuleMap(sanitizedModuleName: sanitizedModuleName),
+                        to: generatedModuleMapPath,
+                        atomically: true
+                    )
+                    return .swiftOnly(moduleMapPath: generatedModuleMapPath)
+                }
                 return .none
             }
             // Consider the public headers folder as umbrella directory
@@ -146,6 +160,14 @@ public struct SwiftPackageManagerModuleMapGenerator: SwiftPackageManagerModuleMa
 
             return .directory(moduleMapPath: generatedModuleMapPath, umbrellaDirectory: publicHeadersPath)
         } else {
+            if generateModuleMapForSwiftOnlyTargets {
+                try await writeIfDifferent(
+                    moduleMapContent: swiftOnlyModuleMap(sanitizedModuleName: sanitizedModuleName),
+                    to: generatedModuleMapPath,
+                    atomically: true
+                )
+                return .swiftOnly(moduleMapPath: generatedModuleMapPath)
+            }
             return .none
         }
     }
@@ -191,6 +213,14 @@ public struct SwiftPackageManagerModuleMapGenerator: SwiftPackageManagerModuleMa
 
           export *
           module * { export * }
+        }
+        """
+    }
+
+    private func swiftOnlyModuleMap(sanitizedModuleName: String) -> String {
+        """
+        framework module \(sanitizedModuleName) {
+          export *
         }
         """
     }

--- a/cli/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
+++ b/cli/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
@@ -4557,7 +4557,19 @@ struct PackageInfoMapperTests {
                 .testWithDefaultConfigs(
                     name: "Package",
                     targets: [
-                        .test("RxSwift", basePath: basePath, product: .framework),
+                        .test(
+                            "RxSwift",
+                            basePath: basePath,
+                            product: .framework,
+                            customSettings: [
+                                "DEFINES_MODULE": "NO",
+                                "OTHER_CFLAGS": .array(["$(inherited)", "-fmodule-name=RxSwift"]),
+                                "OTHER_SWIFT_FLAGS": [
+                                    "$(inherited)",
+                                ],
+                            ],
+                            moduleMap: "$(SRCROOT)/Derived/RxSwift.modulemap"
+                        ),
                     ] + testTargets.map {
                         var customSettings: ProjectDescription.SettingsDictionary
                         var customProductName: String?

--- a/cli/Tests/TuistLoaderTests/SwiftPackageManager/SwiftPackageManagerModuleMapGeneratorTests.swift
+++ b/cli/Tests/TuistLoaderTests/SwiftPackageManager/SwiftPackageManagerModuleMapGeneratorTests.swift
@@ -49,6 +49,13 @@ final class SwiftPackageManagerModuleMapGeneratorTests: TuistUnitTestCase {
         try await test_generate(for: .none)
     }
 
+    func test_generate_when_no_headersAndSwiftOnlyModuleMapRequested() async throws {
+        try await test_generate(
+            for: .swiftOnly(moduleMapPath: packageDirectory.appending(components: "Derived", "Module.modulemap")),
+            generateModuleMapForSwiftOnlyTargets: true
+        )
+    }
+
     func test_generate_when_custom_module_map() async throws {
         try await test_generate(for: .custom(publicHeadersPath.appending(component: "module.modulemap"), umbrellaHeaderPath: nil))
     }
@@ -234,13 +241,18 @@ final class SwiftPackageManagerModuleMapGeneratorTests: TuistUnitTestCase {
         )
     }
 
-    private func test_generate(for moduleMap: ModuleMap) async throws {
+    private func test_generate(
+        for moduleMap: ModuleMap,
+        generateModuleMapForSwiftOnlyTargets: Bool = false
+    ) async throws {
         var writeCount = 0
 
         try await fileSystem.makeDirectory(at: publicHeadersPath)
         try await fileSystem.makeDirectory(at: packageDirectory.appending(component: "Derived"))
         switch moduleMap {
         case .none:
+            break
+        case .swiftOnly:
             break
         case let .custom(moduleMapPath, umbrellaHeaderPath: umbrellaHeaderPath):
             try await fileSystem.touch(moduleMapPath)
@@ -269,7 +281,8 @@ final class SwiftPackageManagerModuleMapGeneratorTests: TuistUnitTestCase {
         let got = try await subject.generate(
             packageDirectory: packageDirectory,
             moduleName: "Module",
-            publicHeadersPath: publicHeadersPath
+            publicHeadersPath: publicHeadersPath,
+            generateModuleMapForSwiftOnlyTargets: generateModuleMapForSwiftOnlyTargets
         )
 
         let moduleMapPath = packageDirectory.appending(components: "Derived", "Module.modulemap")
@@ -286,14 +299,15 @@ final class SwiftPackageManagerModuleMapGeneratorTests: TuistUnitTestCase {
         _ = try await subject.generate(
             packageDirectory: packageDirectory,
             moduleName: "Module",
-            publicHeadersPath: publicHeadersPath
+            publicHeadersPath: publicHeadersPath,
+            generateModuleMapForSwiftOnlyTargets: generateModuleMapForSwiftOnlyTargets
         )
 
         XCTAssertEqual(got, moduleMap)
         switch moduleMap {
         case .none, .custom:
             XCTAssertEqual(writeCount, 0)
-        case .directory, .header:
+        case .directory, .header, .swiftOnly:
             XCTAssertEqual(writeCount, 1)
         }
     }
@@ -303,6 +317,12 @@ final class SwiftPackageManagerModuleMapGeneratorTests: TuistUnitTestCase {
         switch moduleMap {
         case .none, .custom:
             return nil
+        case .swiftOnly:
+            expectedContent = """
+            framework module Module {
+              export *
+            }
+            """
         case let .header(umbrellaHeaderPath, moduleMapPath: _):
             if umbrellaHeaderPath.parentDirectory.basename == "Module" {
                 expectedContent = """


### PR DESCRIPTION
Addresses <https://github.com/tuist/tuist/issues/10967>

This fixes the modulemap failure hit by `tuist cache` for pure-Swift SwiftPM products promoted to frameworks.

The root cause was that Swift-only package framework targets had no Tuist-provided modulemap, so Xcode synthesized one that referenced `<Module>-Swift.h`. Under Xcode 26 explicit module scanning, that synthesized modulemap could be scanned before Swift emitted the compatibility header.

This change:
- Generates a minimal modulemap for Swift-only SwiftPM framework products and disables Xcode's synthesized modulemap for those targets.
- Avoids adding header search paths for Swift-only modulemaps.
- Leaves simulator architecture settings unchanged. Architecture filtering is intentionally not propagated through the generated project or cache consumption path because that can make supported architectures inconsistent across the graph.

### How to test locally

- `git diff --check`
- `TUIST_EE=1 xcodebuild test -workspace Tuist.xcworkspace -scheme TuistUnitTests -only-testing TuistLoaderTests/SwiftPackageManagerModuleMapGeneratorTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""`
- `TUIST_EE=1 xcodebuild test -workspace Tuist.xcworkspace -scheme TuistUnitTests -only-testing TuistLoaderTests/PackageInfoMapperTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""`
