### PR TITLE
fix(infra): switch xcresult-processor to Recreate on single-host envs

### DIFF
--- a/infra/helm/tuist/values-managed-canary.yaml
+++ b/infra/helm/tuist/values-managed-canary.yaml
@@ -106,6 +106,16 @@ xcresultProcessor:
   # Mac mini and replicaCount=2 the second pod has nowhere to land
   # without violating Apple's 2-VM SLA cap that Tart enforces.
   replicaCount: 1
+  # Single-host fleet override. The chart default
+  # RollingUpdate(maxSurge=0, maxUnavailable=1) still lets the
+  # Deployment controller create the new Pod in Pending before the
+  # old Pod releases hostPort 9091, generating a FailedScheduling
+  # warning every rollout. Recreate waits for full termination first
+  # so no Pending pod is created against an occupied port. Same
+  # effective downtime - Tart VM cold-boot dominates either way.
+  strategy:
+    type: Recreate
+    rollingUpdate: null
   extraEnv:
     - name: TUIST_DEPLOY_ENV
       value: can

--- a/infra/helm/tuist/values-managed-staging.yaml
+++ b/infra/helm/tuist/values-managed-staging.yaml
@@ -131,16 +131,21 @@ processor:
       memory: "1536Mi"
 
 xcresultProcessor:
-  # Single replica in staging. Inherits the chart default rolling
-  # strategy (maxSurge=1, maxUnavailable=0) so helm upgrade --wait
-  # actually blocks on the new Tart-VM Pod becoming Ready before
-  # marking the rollout done — without this, replicas=1 +
-  # maxUnavailable=1 lets a Deployment look "Available" with zero
-  # actually-running Pods, and a stuck rollout slips past --atomic.
-  # Surge-during-roll fits within tart-kubelet's max-pods=3
-  # (chart default): csi-daemonset(1) + old(1) + new(1) = 3.
+  # Single replica in staging, matching macosFleet.replicas=1.
   enabled: true
   replicaCount: 1
+  # Single-host fleet override. The chart default
+  # RollingUpdate(maxSurge=0, maxUnavailable=1) still lets the
+  # Deployment controller create the new Pod in Pending before the
+  # old Pod releases hostPort 9091, generating a FailedScheduling
+  # warning every rollout. Recreate waits for full termination first
+  # so no Pending pod is created against an occupied port, and
+  # `helm upgrade --wait` blocks until the new Pod is actually Ready
+  # before declaring the rollout done. Same effective downtime -
+  # Tart VM cold-boot dominates either way.
+  strategy:
+    type: Recreate
+    rollingUpdate: null
   extraEnv:
     - name: TUIST_DEPLOY_ENV
       value: stag


### PR DESCRIPTION
## Summary

On canary and staging the xcresult-processor Deployment generates a `FailedScheduling … didn't have free ports for the requested pod ports` warning on every rollout. The chart default `RollingUpdate(maxSurge=0, maxUnavailable=1)` from [values.yaml:436-450](infra/helm/tuist/values.yaml) is the right choice for production (two Mac minis, replicaCount=2, topology spread = one Pod per host) but on single-host envs the Deployment controller still creates the new Pod in `Pending` before the old Pod releases `hostPort: 9091`, generating the warning. The Pod schedules normally once the old one terminates, so functionally fine, but the warning lands in dashboards on every deploy.

This switches canary + staging to `strategy.type: Recreate`, which waits for the old Pod to fully terminate before creating the new one. Same effective downtime either way (Tart VM cold-boot dominates).

## What changed

- [infra/helm/tuist/values-managed-canary.yaml](infra/helm/tuist/values-managed-canary.yaml): add `strategy: {type: Recreate, rollingUpdate: null}` override under `xcresultProcessor`.
- [infra/helm/tuist/values-managed-staging.yaml](infra/helm/tuist/values-managed-staging.yaml): same override, plus drop a stale comment that claimed staging inherits `RollingUpdate(maxSurge=1, maxUnavailable=0)` — the chart default is the opposite (`maxSurge=0, maxUnavailable=1`). The stale comment's stated concern (`helm upgrade --wait` slipping past a Pod that never becomes Ready) is naturally addressed by `Recreate`, which has no surge or unavailability tolerance and so cannot mark the rollout done until the new Pod is `Ready`.
- Production unchanged.

## Validation

Rendered the chart locally with `helm template` against each env. Output:

| Env        | `spec.strategy`                                                  |
| ---------- | ---------------------------------------------------------------- |
| canary     | `type: Recreate` (no `rollingUpdate`)                            |
| staging    | `type: Recreate` (no `rollingUpdate`)                            |
| production | `type: RollingUpdate` + `rollingUpdate: {maxSurge: 0, maxUnavailable: 1}` |

The `rollingUpdate: null` override correctly removes the chart-default `rollingUpdate` block from the merged values (helm 3+ treats null as deletion) so k8s doesn't reject the manifest for declaring `rollingUpdate` fields under `type: Recreate`.

## Test plan

- [ ] Canary deploy after merge: no `FailedScheduling … didn't have free ports` event on the xcresult-processor Pod.
- [ ] Staging deploy: same.
- [ ] Production deploy still emits the rolling replace one Pod at a time (PDB-respecting).