### PR TITLE
fix: stop xcresult-processor VM disk leak, restore its metrics, and surface guest DiskPressure

### DIFF
--- a/infra/grafana-dashboards/xcresult-processor.json
+++ b/infra/grafana-dashboards/xcresult-processor.json
@@ -452,6 +452,58 @@
         ],
         "title": "Discards & Cancellations Rate",
         "type": "timeseries"
+      },
+      {
+        "collapsed": false,
+        "gridPos": {"h": 1, "w": 24, "x": 0, "y": 32},
+        "id": 104,
+        "panels": [],
+        "title": "Host / VM Disk",
+        "type": "row"
+      },
+      {
+        "datasource": "$datasource",
+        "description": "Percent-used of each xcresult-processor VM's guest root volume, published by tart-kubelet (`tart_kubelet_guest_disk_usage_percent`, scraped from the macOS fleet's :8080). This is the gradient behind the node's DiskPressure condition (reported True at 90%): the host disk stays near-empty even when a guest fills, so this guest-level series is the one that matters. A steady climb is a leaking workload — it surfaces days before the volume hits 100% and parses start failing with :enospc.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {"mode": "thresholds"},
+            "custom": {
+              "drawStyle": "line",
+              "fillOpacity": 10,
+              "lineWidth": 1,
+              "showPoints": "never",
+              "thresholdsStyle": {"mode": "line"}
+            },
+            "max": 100,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {"color": "green", "value": null},
+                {"color": "yellow", "value": 80},
+                {"color": "red", "value": 90}
+              ]
+            },
+            "unit": "percent"
+          }
+        },
+        "gridPos": {"h": 8, "w": 12, "x": 0, "y": 33},
+        "id": 11,
+        "options": {
+          "legend": {"calcs": ["lastNotNull", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true},
+          "tooltip": {"mode": "multi", "sort": "desc"}
+        },
+        "targets": [
+          {
+            "datasource": "$datasource",
+            "editorMode": "code",
+            "expr": "max by (instance, vm) (tart_kubelet_guest_disk_usage_percent)",
+            "legendFormat": "{{instance}} / {{vm}}",
+            "refId": "A"
+          }
+        ],
+        "title": "Guest Disk Usage",
+        "type": "timeseries"
       }
     ],
     "refresh": "30s",
@@ -512,7 +564,7 @@
     "timezone": "browser",
     "title": "Tuist xcresult Processor",
     "uid": "tuist-xcresult-processor",
-    "version": 1,
+    "version": 2,
     "weekStart": ""
   }
 }

--- a/infra/tart-kubelet/cmd/tart-kubelet/main.go
+++ b/infra/tart-kubelet/cmd/tart-kubelet/main.go
@@ -30,6 +30,7 @@ import (
 	cache "sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
@@ -267,6 +268,9 @@ func main() {
 		MemoryMB:   hostMemoryMB,
 		MaxPods:    maxPods,
 		Heartbeat:  30 * time.Second,
+		DiskPressure: func(ctx context.Context) (bool, string, error) {
+			return diskPressureFromGuests(ctx, tartClient, diskPressureThresholdPercent)
+		},
 	}); err != nil {
 		setupLog.Error(err, "add node maintainer")
 		os.Exit(1)
@@ -471,6 +475,52 @@ func pickPodsForNode(nodeName string) fields.Selector {
 // pickThisNode narrows the Node informer to just our Node.
 func pickThisNode(nodeName string) fields.Selector {
 	return fields.SelectorFromSet(fields.Set{"metadata.name": nodeName})
+}
+
+// diskPressureThresholdPercent is the guest root-volume capacity at or
+// above which the host Node reports DiskPressure. Below 100% so the
+// condition fires (stopping new scheduling and triggering alerts) before
+// the guest actually starts failing writes with ENOSPC.
+const diskPressureThresholdPercent = 90
+
+// diskPressureFromGuests reports DiskPressure=True when any running VM's
+// guest root volume is at or above the threshold. Each probe is bounded
+// so an unresponsive guest agent can't stall the node heartbeat, and a
+// per-VM error is logged and skipped rather than failing the whole check
+// — one bad guest shouldn't blind the others. A List error propagates so
+// the maintainer keeps the previous condition instead of flapping.
+func diskPressureFromGuests(ctx context.Context, tartClient *tart.Client, threshold int) (bool, string, error) {
+	vms, err := tartClient.List(ctx)
+	if err != nil {
+		return false, "", err
+	}
+
+	var pressured []string
+	for _, vm := range vms {
+		if vm.Source != "local" {
+			continue
+		}
+		running, err := tartClient.IsRunning(ctx, vm.Name)
+		if err != nil || !running {
+			continue
+		}
+
+		probeCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+		pct, err := tartClient.GuestDiskUsagePercent(probeCtx, vm.Name)
+		cancel()
+		if err != nil {
+			log.FromContext(ctx).Error(err, "guest disk usage probe", "vm", vm.Name)
+			continue
+		}
+		if pct >= threshold {
+			pressured = append(pressured, fmt.Sprintf("%s at %d%%", vm.Name, pct))
+		}
+	}
+
+	if len(pressured) > 0 {
+		return true, "guest root volume(s) near capacity: " + strings.Join(pressured, ", "), nil
+	}
+	return false, "", nil
 }
 
 // recoverState rebuilds the Pod ↔ VM map by intersecting the host's

--- a/infra/tart-kubelet/cmd/tart-kubelet/main.go
+++ b/infra/tart-kubelet/cmd/tart-kubelet/main.go
@@ -495,6 +495,10 @@ func diskPressureFromGuests(ctx context.Context, tartClient *tart.Client, thresh
 		return false, "", err
 	}
 
+	// Drop stale series up front so a VM that's gone since the last
+	// sweep stops reporting its last-known capacity.
+	podagent.ResetGuestDiskUsage()
+
 	var pressured []string
 	for _, vm := range vms {
 		if vm.Source != "local" {
@@ -512,6 +516,7 @@ func diskPressureFromGuests(ctx context.Context, tartClient *tart.Client, thresh
 			log.FromContext(ctx).Error(err, "guest disk usage probe", "vm", vm.Name)
 			continue
 		}
+		podagent.RecordGuestDiskUsage(vm.Name, pct)
 		if pct >= threshold {
 			pressured = append(pressured, fmt.Sprintf("%s at %d%%", vm.Name, pct))
 		}

--- a/infra/tart-kubelet/go.mod
+++ b/infra/tart-kubelet/go.mod
@@ -5,6 +5,8 @@ go 1.25.0
 toolchain go1.25.10
 
 require (
+	github.com/prometheus/client_golang v1.19.1
+	golang.org/x/sys v0.43.0
 	k8s.io/api v0.32.1
 	k8s.io/apimachinery v0.32.1
 	k8s.io/client-go v0.32.1
@@ -38,7 +40,6 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/prometheus/client_golang v1.19.1 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.55.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
@@ -49,7 +50,6 @@ require (
 	golang.org/x/net v0.53.0 // indirect
 	golang.org/x/oauth2 v0.23.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
-	golang.org/x/sys v0.43.0 // indirect
 	golang.org/x/term v0.42.0 // indirect
 	golang.org/x/text v0.36.0 // indirect
 	golang.org/x/time v0.7.0 // indirect

--- a/infra/tart-kubelet/internal/nodeagent/node.go
+++ b/infra/tart-kubelet/internal/nodeagent/node.go
@@ -53,7 +53,20 @@ type Maintainer struct {
 	MemoryMB   int
 	MaxPods    int
 	Heartbeat  time.Duration
+	// DiskPressure, when non-nil, is evaluated each heartbeat to set
+	// the Node's DiskPressure condition. A real kubelet always reports
+	// this condition; leaving it unset surfaces as Unknown, which hides
+	// a full guest disk from the scheduler and from alerting. nil keeps
+	// the condition at its False default.
+	DiskPressure DiskPressureProbe
 }
+
+// DiskPressureProbe reports whether the node is under disk pressure plus
+// a human-readable detail for the condition message. A non-nil error
+// means the probe itself failed (e.g. a guest agent was unreachable);
+// the maintainer then leaves the existing condition untouched rather
+// than flapping it to False on a transient failure.
+type DiskPressureProbe func(ctx context.Context) (pressured bool, detail string, err error)
 
 // operatorOwnedLabelPrefix is the prefix tart-kubelet treats as
 // "I own this label." Labels with this prefix that aren't in the
@@ -102,12 +115,33 @@ func (m *Maintainer) refresh(ctx context.Context) error {
 		return err
 	}
 	m.configureNode(node)
+	m.applyDiskPressure(ctx, node)
 	for i, c := range node.Status.Conditions {
 		if c.Type == corev1.NodeReady {
 			node.Status.Conditions[i].LastHeartbeatTime = metav1.Now()
 		}
 	}
 	return m.Client.Status().Update(ctx, node)
+}
+
+// applyDiskPressure refreshes the DiskPressure condition from the probe.
+// configureNode has already seeded the condition at False, so a nil
+// probe leaves it False and a probe error leaves the prior value in
+// place (logged, not flapped).
+func (m *Maintainer) applyDiskPressure(ctx context.Context, node *corev1.Node) {
+	if m.DiskPressure == nil {
+		return
+	}
+	pressured, detail, err := m.DiskPressure(ctx)
+	if err != nil {
+		log.FromContext(ctx).Error(err, "disk pressure probe")
+		return
+	}
+	if pressured {
+		setCondition(&node.Status.Conditions, corev1.NodeDiskPressure, corev1.ConditionTrue, "TartKubeletHasDiskPressure", detail)
+	} else {
+		setCondition(&node.Status.Conditions, corev1.NodeDiskPressure, corev1.ConditionFalse, "TartKubeletHasSufficientDisk", detail)
+	}
 }
 
 // configureNode sets labels, taints, capacity, and Node info. Mirrors
@@ -192,7 +226,14 @@ func (m *Maintainer) configureNode(node *corev1.Node) {
 			LastTransitionTime: now,
 		})
 	} else {
-		setCondition(&node.Status.Conditions, corev1.NodeReady, corev1.ConditionTrue, "TartKubeletReady")
+		setCondition(&node.Status.Conditions, corev1.NodeReady, corev1.ConditionTrue, "TartKubeletReady", "")
+	}
+
+	// Seed DiskPressure at False so the node never sits at Unknown (which
+	// hides a full guest disk). The heartbeat's probe — see
+	// applyDiskPressure — flips it to True when a guest volume fills.
+	if !hasCondition(node.Status.Conditions, corev1.NodeDiskPressure) {
+		setCondition(&node.Status.Conditions, corev1.NodeDiskPressure, corev1.ConditionFalse, "TartKubeletHasSufficientDisk", "")
 	}
 
 	node.Status.NodeInfo.OperatingSystem = "darwin"
@@ -231,7 +272,7 @@ func hasCondition(conds []corev1.NodeCondition, t corev1.NodeConditionType) bool
 	return false
 }
 
-func setCondition(conds *[]corev1.NodeCondition, t corev1.NodeConditionType, s corev1.ConditionStatus, reason string) {
+func setCondition(conds *[]corev1.NodeCondition, t corev1.NodeConditionType, s corev1.ConditionStatus, reason, message string) {
 	now := metav1.Now()
 	for i, c := range *conds {
 		if c.Type == t {
@@ -240,6 +281,7 @@ func setCondition(conds *[]corev1.NodeCondition, t corev1.NodeConditionType, s c
 			}
 			(*conds)[i].Status = s
 			(*conds)[i].Reason = reason
+			(*conds)[i].Message = message
 			(*conds)[i].LastHeartbeatTime = now
 			return
 		}
@@ -248,6 +290,7 @@ func setCondition(conds *[]corev1.NodeCondition, t corev1.NodeConditionType, s c
 		Type:               t,
 		Status:             s,
 		Reason:             reason,
+		Message:            message,
 		LastHeartbeatTime:  now,
 		LastTransitionTime: now,
 	})

--- a/infra/tart-kubelet/internal/nodeagent/node_test.go
+++ b/infra/tart-kubelet/internal/nodeagent/node_test.go
@@ -1,0 +1,105 @@
+package nodeagent
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func conditionByType(conds []corev1.NodeCondition, t corev1.NodeConditionType) (corev1.NodeCondition, bool) {
+	for _, c := range conds {
+		if c.Type == t {
+			return c, true
+		}
+	}
+	return corev1.NodeCondition{}, false
+}
+
+func TestConfigureNodeSeedsDiskPressureFalse(t *testing.T) {
+	m := &Maintainer{NodeName: "mac-mini-1"}
+	node := &corev1.Node{}
+
+	m.configureNode(node)
+
+	dp, ok := conditionByType(node.Status.Conditions, corev1.NodeDiskPressure)
+	if !ok {
+		t.Fatal("expected a DiskPressure condition to be seeded")
+	}
+	if dp.Status != corev1.ConditionFalse {
+		t.Fatalf("DiskPressure = %q, want False", dp.Status)
+	}
+}
+
+func TestApplyDiskPressureSetsTrueWithDetail(t *testing.T) {
+	m := &Maintainer{
+		DiskPressure: func(context.Context) (bool, string, error) {
+			return true, "vm-x at 100%", nil
+		},
+	}
+	node := &corev1.Node{}
+	m.configureNode(node)
+
+	m.applyDiskPressure(context.Background(), node)
+
+	dp, _ := conditionByType(node.Status.Conditions, corev1.NodeDiskPressure)
+	if dp.Status != corev1.ConditionTrue {
+		t.Fatalf("DiskPressure = %q, want True", dp.Status)
+	}
+	if dp.Reason != "TartKubeletHasDiskPressure" {
+		t.Fatalf("Reason = %q", dp.Reason)
+	}
+	if dp.Message != "vm-x at 100%" {
+		t.Fatalf("Message = %q", dp.Message)
+	}
+}
+
+func TestApplyDiskPressureSetsFalse(t *testing.T) {
+	m := &Maintainer{
+		DiskPressure: func(context.Context) (bool, string, error) {
+			return false, "", nil
+		},
+	}
+	node := &corev1.Node{}
+	m.configureNode(node)
+
+	m.applyDiskPressure(context.Background(), node)
+
+	dp, _ := conditionByType(node.Status.Conditions, corev1.NodeDiskPressure)
+	if dp.Status != corev1.ConditionFalse {
+		t.Fatalf("DiskPressure = %q, want False", dp.Status)
+	}
+}
+
+func TestApplyDiskPressureKeepsPriorValueOnProbeError(t *testing.T) {
+	m := &Maintainer{
+		DiskPressure: func(context.Context) (bool, string, error) {
+			return false, "", errors.New("guest agent unreachable")
+		},
+	}
+	node := &corev1.Node{}
+	m.configureNode(node)
+	// Simulate a prior heartbeat that observed pressure.
+	setCondition(&node.Status.Conditions, corev1.NodeDiskPressure, corev1.ConditionTrue, "TartKubeletHasDiskPressure", "vm-x at 100%")
+
+	m.applyDiskPressure(context.Background(), node)
+
+	dp, _ := conditionByType(node.Status.Conditions, corev1.NodeDiskPressure)
+	if dp.Status != corev1.ConditionTrue {
+		t.Fatalf("DiskPressure = %q, want unchanged True on probe error", dp.Status)
+	}
+}
+
+func TestApplyDiskPressureNilProbeIsNoop(t *testing.T) {
+	m := &Maintainer{} // no probe
+	node := &corev1.Node{}
+	m.configureNode(node)
+
+	m.applyDiskPressure(context.Background(), node)
+
+	dp, ok := conditionByType(node.Status.Conditions, corev1.NodeDiskPressure)
+	if !ok || dp.Status != corev1.ConditionFalse {
+		t.Fatalf("expected seeded False to remain, got ok=%v status=%q", ok, dp.Status)
+	}
+}

--- a/infra/tart-kubelet/internal/podagent/metrics.go
+++ b/infra/tart-kubelet/internal/podagent/metrics.go
@@ -32,6 +32,36 @@ var vmBootDurationSeconds = prometheus.NewHistogramVec(
 	[]string{"pool"},
 )
 
+// guestDiskUsagePercent is the percent-used of each running VM's guest
+// root volume, as read by the node maintainer's DiskPressure probe. It's
+// the gradient signal behind the binary DiskPressure node condition:
+// graphing it shows a leaking workload's slope days before the volume
+// hits 100% and writes start failing with ENOSPC, and it lets alert
+// thresholds be tuned (warn vs page) without redeploying tart-kubelet.
+//
+// Labelled by VM name; the scrape adds the per-mini `instance` label.
+// Lands on the same `:8080/metrics` page Alloy scrapes via the
+// `tuist-macos-tart-kubelet` job.
+var guestDiskUsagePercent = prometheus.NewGaugeVec(
+	prometheus.GaugeOpts{
+		Name: "tart_kubelet_guest_disk_usage_percent",
+		Help: "Percent-used of a running VM's guest root volume (0-100).",
+	},
+	[]string{"vm"},
+)
+
 func init() {
-	metrics.Registry.MustRegister(vmBootDurationSeconds)
+	metrics.Registry.MustRegister(vmBootDurationSeconds, guestDiskUsagePercent)
+}
+
+// RecordGuestDiskUsage publishes a VM's guest root-volume usage percent.
+func RecordGuestDiskUsage(vm string, percent int) {
+	guestDiskUsagePercent.WithLabelValues(vm).Set(float64(percent))
+}
+
+// ResetGuestDiskUsage drops all guest-disk series. Called at the start
+// of each probe sweep so a VM that's gone (stopped, deleted, migrated)
+// stops reporting a stale last-known capacity.
+func ResetGuestDiskUsage() {
+	guestDiskUsagePercent.Reset()
 }

--- a/infra/tart-kubelet/internal/podagent/metrics_test.go
+++ b/infra/tart-kubelet/internal/podagent/metrics_test.go
@@ -1,0 +1,32 @@
+package podagent
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+func TestGuestDiskUsageGauge(t *testing.T) {
+	t.Cleanup(ResetGuestDiskUsage)
+
+	RecordGuestDiskUsage("vm-a", 92)
+	RecordGuestDiskUsage("vm-b", 30)
+
+	if got := testutil.ToFloat64(guestDiskUsagePercent.WithLabelValues("vm-a")); got != 92 {
+		t.Fatalf("vm-a gauge = %v, want 92", got)
+	}
+	if got := testutil.ToFloat64(guestDiskUsagePercent.WithLabelValues("vm-b")); got != 30 {
+		t.Fatalf("vm-b gauge = %v, want 30", got)
+	}
+
+	// A sweep that no longer sees vm-b must not leave its last value behind.
+	ResetGuestDiskUsage()
+	RecordGuestDiskUsage("vm-a", 95)
+
+	if got := testutil.CollectAndCount(guestDiskUsagePercent); got != 1 {
+		t.Fatalf("series count after reset = %d, want 1", got)
+	}
+	if got := testutil.ToFloat64(guestDiskUsagePercent.WithLabelValues("vm-a")); got != 95 {
+		t.Fatalf("vm-a gauge after reset = %v, want 95", got)
+	}
+}

--- a/infra/tart-kubelet/internal/podagent/proxy.go
+++ b/infra/tart-kubelet/internal/podagent/proxy.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"sync"
+	"syscall"
 	"time"
 )
 
@@ -132,6 +133,7 @@ func NewForwarder(listenAddr string, resolve func() (string, error), opts Forwar
 			DialContext: (&net.Dialer{
 				Timeout:   5 * time.Second,
 				KeepAlive: 30 * time.Second,
+				Control:   bindDialToTargetInterface,
 			}).DialContext,
 			ResponseHeaderTimeout: 10 * time.Second,
 			IdleConnTimeout:       60 * time.Second,
@@ -297,3 +299,71 @@ func (c *cachedResolver) get() (string, error) {
 // Director uses to ferry resolution errors over to the
 // ErrorHandler.
 type resolveErrKey struct{}
+
+// bindDialToTargetInterface pins the forwarder's upstream connection to
+// the interface that owns the directly-connected route to the Tart VM.
+//
+// On a Scaleway Apple Silicon Mac mini the primary interface is the
+// public WAN (en0); the Tart VM lives on a vmnet bridge whose route the
+// macOS kernel marks IFSCOPE. With scoped routing on (the default,
+// net.inet.ip.scopedroute=1) an unscoped connect() — what Go's dialer
+// issues when no interface is set — resolves against the primary
+// interface's scope and fails with EHOSTUNREACH for the VM, even though
+// the bridge is up and a plain `curl` reaches it. Binding the socket to
+// the bridge interface forces the kernel to honour the scoped route.
+//
+// It's a no-op when the target isn't an IP literal or isn't on any
+// directly-connected interface (let normal routing handle it), and on
+// non-darwin platforms (setBoundInterface is a no-op there).
+func bindDialToTargetInterface(_, address string, c syscall.RawConn) error {
+	host, _, err := net.SplitHostPort(address)
+	if err != nil {
+		host = address
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return nil
+	}
+	ifIndex, ok := directlyConnectedInterfaceIndex(ip)
+	if !ok {
+		return nil
+	}
+
+	var sockErr error
+	if err := c.Control(func(fd uintptr) {
+		sockErr = setBoundInterface(int(fd), ip, ifIndex)
+	}); err != nil {
+		return err
+	}
+	return sockErr
+}
+
+// directlyConnectedInterfaceIndex returns the index of the UP interface
+// whose subnet contains ip — i.e. the interface ip is directly reachable
+// on. Returns ok=false when no interface owns a matching subnet so the
+// caller leaves routing to the kernel's default lookup.
+func directlyConnectedInterfaceIndex(ip net.IP) (int, bool) {
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return 0, false
+	}
+	for _, iface := range ifaces {
+		if iface.Flags&net.FlagUp == 0 {
+			continue
+		}
+		addrs, err := iface.Addrs()
+		if err != nil {
+			continue
+		}
+		for _, addr := range addrs {
+			ipNet, ok := addr.(*net.IPNet)
+			if !ok {
+				continue
+			}
+			if ipNet.Contains(ip) {
+				return iface.Index, true
+			}
+		}
+	}
+	return 0, false
+}

--- a/infra/tart-kubelet/internal/podagent/proxy_darwin.go
+++ b/infra/tart-kubelet/internal/podagent/proxy_darwin.go
@@ -1,0 +1,20 @@
+//go:build darwin
+
+package podagent
+
+import (
+	"net"
+
+	"golang.org/x/sys/unix"
+)
+
+// setBoundInterface scopes the socket to ifIndex via IP_BOUND_IF
+// (IPv4) or IPV6_BOUND_IF (IPv6) so the connect() honours the vmnet
+// bridge's IFSCOPE route instead of the host's primary interface. See
+// bindDialToTargetInterface for why this is needed on macOS.
+func setBoundInterface(fd int, ip net.IP, ifIndex int) error {
+	if ip.To4() != nil {
+		return unix.SetsockoptInt(fd, unix.IPPROTO_IP, unix.IP_BOUND_IF, ifIndex)
+	}
+	return unix.SetsockoptInt(fd, unix.IPPROTO_IPV6, unix.IPV6_BOUND_IF, ifIndex)
+}

--- a/infra/tart-kubelet/internal/podagent/proxy_other.go
+++ b/infra/tart-kubelet/internal/podagent/proxy_other.go
@@ -1,0 +1,11 @@
+//go:build !darwin
+
+package podagent
+
+import "net"
+
+// setBoundInterface is a no-op off darwin: the macOS scoped-routing
+// behaviour that bindDialToTargetInterface works around doesn't apply,
+// and IP_BOUND_IF isn't portable. tart-kubelet only runs on macOS in
+// production; this keeps the package buildable on Linux CI.
+func setBoundInterface(_ int, _ net.IP, _ int) error { return nil }

--- a/infra/tart-kubelet/internal/podagent/proxy_test.go
+++ b/infra/tart-kubelet/internal/podagent/proxy_test.go
@@ -325,3 +325,56 @@ func itoa(n int) string {
 	}
 	return string(digits)
 }
+
+func TestDirectlyConnectedInterfaceIndex_Loopback(t *testing.T) {
+	lo, err := net.InterfaceByName(loopbackName())
+	if err != nil {
+		t.Skipf("no loopback interface: %v", err)
+	}
+
+	idx, ok := directlyConnectedInterfaceIndex(net.ParseIP("127.0.0.1"))
+	if !ok {
+		t.Fatal("expected loopback to own a directly-connected route to 127.0.0.1")
+	}
+	if idx != lo.Index {
+		t.Fatalf("interface index = %d, want loopback index %d", idx, lo.Index)
+	}
+}
+
+func TestDirectlyConnectedInterfaceIndex_NoMatch(t *testing.T) {
+	// 192.0.2.0/24 is TEST-NET-1 (RFC 5737) — guaranteed not bound to
+	// any real interface, so the dialer leaves routing to the kernel.
+	if _, ok := directlyConnectedInterfaceIndex(net.ParseIP("192.0.2.1")); ok {
+		t.Fatal("did not expect a directly-connected interface for TEST-NET-1")
+	}
+}
+
+func TestBindDialToTargetInterface_NonIPTargetIsNoop(t *testing.T) {
+	// A hostname target (no IP literal) must not error; the forwarder's
+	// resolver always hands the proxy an IP, but the hook should degrade
+	// gracefully rather than fail the dial.
+	if err := bindDialToTargetInterface("tcp", "example.com:9091", nopRawConn{}); err != nil {
+		t.Fatalf("expected no error for non-IP target, got %v", err)
+	}
+}
+
+// nopRawConn satisfies syscall.RawConn for the no-op path, where
+// bindDialToTargetInterface returns before touching the socket.
+type nopRawConn struct{}
+
+func (nopRawConn) Control(func(uintptr)) error    { return nil }
+func (nopRawConn) Read(func(uintptr) bool) error  { return nil }
+func (nopRawConn) Write(func(uintptr) bool) error { return nil }
+
+func loopbackName() string {
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return "lo0"
+	}
+	for _, iface := range ifaces {
+		if iface.Flags&net.FlagLoopback != 0 {
+			return iface.Name
+		}
+	}
+	return "lo0"
+}

--- a/infra/tart-kubelet/internal/tart/tart.go
+++ b/infra/tart-kubelet/internal/tart/tart.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -298,6 +299,48 @@ func (c *Client) IP(ctx context.Context, name string) (string, error) {
 		return "", err
 	}
 	return strings.TrimSpace(string(out)), nil
+}
+
+// GuestDiskUsagePercent runs `df` inside the guest VM and returns the
+// percent-used (0-100) of its root filesystem. Requires the Tart guest
+// agent, which the Cirrus Labs base images ship — the same agent
+// `tart exec` relies on. The root volume is the one a workload's scratch
+// data fills (e.g. the xcresult processor's attachment exports), so its
+// capacity is the DiskPressure signal that matters; the host's own disk
+// stays near-empty even when a guest is full.
+func (c *Client) GuestDiskUsagePercent(ctx context.Context, name string) (int, error) {
+	out, err := c.run(ctx, c.Binary, "exec", name, "/bin/df", "-k", "/")
+	if err != nil {
+		return 0, err
+	}
+	return parseDFCapacityPercent(out)
+}
+
+// parseDFCapacityPercent reads the block Capacity column from a
+// single-filesystem `df` report. macOS df columns are:
+//
+//	Filesystem 1024-blocks Used Available Capacity iused ifree %iused Mounted-on
+//
+// The first field ending in '%' on the data line is the block Capacity
+// (the later '%iused' is inode usage, which we don't want), so we return
+// on the first match.
+func parseDFCapacityPercent(out []byte) (int, error) {
+	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
+	if len(lines) < 2 {
+		return 0, fmt.Errorf("unexpected df output: %q", string(out))
+	}
+	fields := strings.Fields(lines[len(lines)-1])
+	for _, f := range fields {
+		if !strings.HasSuffix(f, "%") {
+			continue
+		}
+		n, err := strconv.Atoi(strings.TrimSuffix(f, "%"))
+		if err != nil {
+			return 0, fmt.Errorf("parse df capacity %q: %w", f, err)
+		}
+		return n, nil
+	}
+	return 0, fmt.Errorf("no capacity column in df output: %q", string(out))
 }
 
 // IsRunning checks whether a `tart run <name>` process is currently

--- a/infra/tart-kubelet/internal/tart/tart_test.go
+++ b/infra/tart-kubelet/internal/tart/tart_test.go
@@ -222,3 +222,53 @@ func TestRunSurfacesEnsureGUISessionFailure(t *testing.T) {
 		t.Fatal("fake tart was executed despite preflight failure")
 	}
 }
+
+func TestParseDFCapacityPercent(t *testing.T) {
+	tests := []struct {
+		name    string
+		out     string
+		want    int
+		wantErr bool
+	}{
+		{
+			name: "returns block capacity not inode usage",
+			// macOS `df -k /` — Capacity (100%) precedes %iused (31%).
+			out: "Filesystem     1024-blocks      Used Available Capacity iused   ifree %iused  Mounted on\n" +
+				"/dev/disk3s1s1   136318784  11534336    102400     100%  453000 1048576   31%   /",
+			want: 100,
+		},
+		{
+			name: "mid-range capacity",
+			out: "Filesystem     1024-blocks     Used Available Capacity iused   ifree %iused  Mounted on\n" +
+				"/dev/disk3s1s1   136318784 60000000  76318784      44%  100000 2000000    5%   /",
+			want: 44,
+		},
+		{
+			name:    "no data line",
+			out:     "Filesystem 1024-blocks Used Available Capacity iused ifree %iused Mounted on",
+			wantErr: true,
+		},
+		{
+			name:    "empty",
+			out:     "",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseDFCapacityPercent([]byte(tt.out))
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got %d", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("capacity = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}

--- a/server/native/xcresult_nif/Sources/XCResultNIF/XCResultNIF.swift
+++ b/server/native/xcresult_nif/Sources/XCResultNIF/XCResultNIF.swift
@@ -21,9 +21,15 @@ public func parseXCResult(
         do {
             let xcresultPath = try AbsolutePath(validating: path)
             let rootDirectory = try AbsolutePath(validating: rootDir)
+            // The server worker passes its per-run temp dir as rootDir and
+            // removes it wholesale once the run is processed, so it's also
+            // a safe scratch dir for exported attachments — opt in so the
+            // worker's cleanup reclaims them instead of leaking them in a
+            // process-wide temp dir.
             guard let parsed = try await XCResultParser().parse(
                 path: xcresultPath,
-                rootDirectory: rootDirectory
+                rootDirectory: rootDirectory,
+                attachmentScratchDirectory: rootDirectory
             ) else {
                 result = .failure(XCResultParserError.failedToParseOutput(xcresultPath))
                 semaphore.signal()

--- a/server/native/xcresult_nif/Sources/XCResultNIF/XCResultNIF.swift
+++ b/server/native/xcresult_nif/Sources/XCResultNIF/XCResultNIF.swift
@@ -23,13 +23,13 @@ public func parseXCResult(
             let rootDirectory = try AbsolutePath(validating: rootDir)
             // The server worker passes its per-run temp dir as rootDir and
             // removes it wholesale once the run is processed, so it's also
-            // a safe scratch dir for exported attachments — opt in so the
-            // worker's cleanup reclaims them instead of leaking them in a
-            // process-wide temp dir.
+            // a directory we can export attachments into — point them there
+            // so the worker's cleanup reclaims them instead of leaking them
+            // in a process-wide temp dir.
             guard let parsed = try await XCResultParser().parse(
                 path: xcresultPath,
                 rootDirectory: rootDirectory,
-                attachmentScratchDirectory: rootDirectory
+                attachmentsDirectory: rootDirectory
             ) else {
                 result = .failure(XCResultParserError.failedToParseOutput(xcresultPath))
                 semaphore.signal()

--- a/server/native/xcresult_nif/Sources/XCResultParser/XCResultParser.swift
+++ b/server/native/xcresult_nif/Sources/XCResultParser/XCResultParser.swift
@@ -72,22 +72,22 @@ public struct XCResultParser: Sendable {
     ///   - rootDirectory: base used to relativize failure file paths for
     ///     display. This is the caller's *source* root (e.g. the project
     ///     dir for CLI callers) and is only ever read from.
-    ///   - attachmentScratchDirectory: a disposable directory the caller
-    ///     owns and cleans up, into which exported attachments are
-    ///     written. Pass this only when the caller manages the directory's
-    ///     lifecycle (the server worker's per-run temp dir). When nil,
-    ///     attachments go to a process-wide temp dir — never into
-    ///     `rootDirectory`, which for CLI callers is the user's project.
+    ///   - attachmentsDirectory: directory the parser exports test
+    ///     attachments into. The caller owns it and decides whether and
+    ///     when it's cleaned up, so pass a directory you manage (the server
+    ///     worker's per-run temp dir). When nil, a temporary directory is
+    ///     used — attachments are never written under `rootDirectory`,
+    ///     which for CLI callers is the user's project.
     public func parse(
         path: AbsolutePath,
         rootDirectory: AbsolutePath?,
-        attachmentScratchDirectory: AbsolutePath? = nil
+        attachmentsDirectory: AbsolutePath? = nil
     ) async throws -> TestSummary? {
         let testOutput = try await loadTestOutput(path: path)
         return try await parseTestOutput(
             testOutput,
             rootDirectory: rootDirectory,
-            attachmentScratchDirectory: attachmentScratchDirectory,
+            attachmentsDirectory: attachmentsDirectory,
             xcresultPath: path
         )
     }
@@ -159,7 +159,7 @@ public struct XCResultParser: Sendable {
     private func parseTestOutput(
         _ output: XCResultTestOutput,
         rootDirectory: AbsolutePath?,
-        attachmentScratchDirectory: AbsolutePath?,
+        attachmentsDirectory: AbsolutePath?,
         xcresultPath: AbsolutePath
     ) async throws -> TestSummary {
         let actionLog = try await actionLog(from: xcresultPath)
@@ -194,7 +194,7 @@ public struct XCResultParser: Sendable {
 
         let extractedAttachments = await attachmentsByTestIdentifiers(
             from: xcresultPath,
-            scratchDirectory: attachmentScratchDirectory
+            attachmentsDirectory: attachmentsDirectory
         )
 
         allTestCases = allTestCases.map { testCase in
@@ -596,24 +596,27 @@ public struct XCResultParser: Sendable {
         }
     }
 
+    /// Resolves where to export attachments, given the caller's optional
+    /// attachments directory.
+    ///
     /// Attachments are exported for the caller to consume *after* parse
     /// returns (the server worker uploads them to S3), so they can't live
     /// in an auto-cleaned `runInTemporaryDirectory` block like the other
     /// xcresulttool scratch dirs.
     ///
-    /// When the caller passes a scratch directory — one it owns and
-    /// removes wholesale once it's done (the server worker's per-run temp
-    /// dir) — we export into a subdirectory of it so that cleanup reclaims
-    /// the (potentially large) attachment files too. Callers that don't
-    /// manage a scratch dir (the CLI, where the only directories in hand
-    /// are the user's project) get a process-wide temp dir instead, so we
-    /// never drop attachments into a source tree.
-    private func attachmentsDirectory(scratchDirectory: AbsolutePath?) async throws -> AbsolutePath {
-        guard let scratchDirectory else {
+    /// When the caller provides a directory — one it owns and cleans up
+    /// (the server worker's per-run temp dir) — we export into an
+    /// `xcresult-attachments` subdirectory of it so the caller's cleanup
+    /// reclaims the (potentially large) attachment files too. Callers that
+    /// don't manage one (the CLI, where the only directory in hand is the
+    /// user's project) get a process-wide temp dir instead, so we never
+    /// drop attachments into a source tree.
+    private func attachmentsExportDirectory(in attachmentsDirectory: AbsolutePath?) async throws -> AbsolutePath {
+        guard let attachmentsDirectory else {
             return try await fileSystem.makeTemporaryDirectory(prefix: "xcresult-attachments")
         }
 
-        let directory = scratchDirectory.appending(component: "xcresult-attachments")
+        let directory = attachmentsDirectory.appending(component: "xcresult-attachments")
         if try await !fileSystem.exists(directory) {
             try await fileSystem.makeDirectory(at: directory)
         }
@@ -622,10 +625,10 @@ public struct XCResultParser: Sendable {
 
     private func attachmentsByTestIdentifiers(
         from xcresultPath: AbsolutePath,
-        scratchDirectory: AbsolutePath?
+        attachmentsDirectory: AbsolutePath?
     ) async -> (crashReports: [String: CrashReport], attachments: [String: [TestAttachment]]) {
         do {
-            let temporaryDirectory = try await attachmentsDirectory(scratchDirectory: scratchDirectory)
+            let temporaryDirectory = try await attachmentsExportDirectory(in: attachmentsDirectory)
 
             _ = try await commandRunner.run(
                 arguments: [

--- a/server/native/xcresult_nif/Sources/XCResultParser/XCResultParser.swift
+++ b/server/native/xcresult_nif/Sources/XCResultParser/XCResultParser.swift
@@ -68,9 +68,28 @@ public struct XCResultParser: Sendable {
         return nil
     }
 
-    public func parse(path: AbsolutePath, rootDirectory: AbsolutePath?) async throws -> TestSummary? {
+    /// - Parameters:
+    ///   - rootDirectory: base used to relativize failure file paths for
+    ///     display. This is the caller's *source* root (e.g. the project
+    ///     dir for CLI callers) and is only ever read from.
+    ///   - attachmentScratchDirectory: a disposable directory the caller
+    ///     owns and cleans up, into which exported attachments are
+    ///     written. Pass this only when the caller manages the directory's
+    ///     lifecycle (the server worker's per-run temp dir). When nil,
+    ///     attachments go to a process-wide temp dir — never into
+    ///     `rootDirectory`, which for CLI callers is the user's project.
+    public func parse(
+        path: AbsolutePath,
+        rootDirectory: AbsolutePath?,
+        attachmentScratchDirectory: AbsolutePath? = nil
+    ) async throws -> TestSummary? {
         let testOutput = try await loadTestOutput(path: path)
-        return try await parseTestOutput(testOutput, rootDirectory: rootDirectory, xcresultPath: path)
+        return try await parseTestOutput(
+            testOutput,
+            rootDirectory: rootDirectory,
+            attachmentScratchDirectory: attachmentScratchDirectory,
+            xcresultPath: path
+        )
     }
 
     public func parseTestStatuses(path: AbsolutePath) async throws -> TestResultStatuses {
@@ -140,6 +159,7 @@ public struct XCResultParser: Sendable {
     private func parseTestOutput(
         _ output: XCResultTestOutput,
         rootDirectory: AbsolutePath?,
+        attachmentScratchDirectory: AbsolutePath?,
         xcresultPath: AbsolutePath
     ) async throws -> TestSummary {
         let actionLog = try await actionLog(from: xcresultPath)
@@ -172,7 +192,10 @@ public struct XCResultParser: Sendable {
         suiteDurations.merge(swiftTestingSuiteDurations) { _, new in new }
         moduleDurations.merge(swiftTestingModuleDurations) { _, new in new }
 
-        let extractedAttachments = await attachmentsByTestIdentifiers(from: xcresultPath, rootDirectory: rootDirectory)
+        let extractedAttachments = await attachmentsByTestIdentifiers(
+            from: xcresultPath,
+            scratchDirectory: attachmentScratchDirectory
+        )
 
         allTestCases = allTestCases.map { testCase in
             let testIdentifier = normalizeTestIdentifier(
@@ -576,18 +599,21 @@ public struct XCResultParser: Sendable {
     /// Attachments are exported for the caller to consume *after* parse
     /// returns (the server worker uploads them to S3), so they can't live
     /// in an auto-cleaned `runInTemporaryDirectory` block like the other
-    /// xcresulttool scratch dirs. When the caller provides a root
-    /// directory — its per-run scratch dir, which it removes wholesale
-    /// once processing finishes — we export into a subdirectory of it so
-    /// that cleanup reclaims them too. Without this the exported bundles
-    /// (test videos, crash logs) accumulate in the process-wide temp dir
-    /// and never get reclaimed.
-    private func attachmentsDirectory(rootDirectory: AbsolutePath?) async throws -> AbsolutePath {
-        guard let rootDirectory else {
+    /// xcresulttool scratch dirs.
+    ///
+    /// When the caller passes a scratch directory — one it owns and
+    /// removes wholesale once it's done (the server worker's per-run temp
+    /// dir) — we export into a subdirectory of it so that cleanup reclaims
+    /// the (potentially large) attachment files too. Callers that don't
+    /// manage a scratch dir (the CLI, where the only directories in hand
+    /// are the user's project) get a process-wide temp dir instead, so we
+    /// never drop attachments into a source tree.
+    private func attachmentsDirectory(scratchDirectory: AbsolutePath?) async throws -> AbsolutePath {
+        guard let scratchDirectory else {
             return try await fileSystem.makeTemporaryDirectory(prefix: "xcresult-attachments")
         }
 
-        let directory = rootDirectory.appending(component: "xcresult-attachments")
+        let directory = scratchDirectory.appending(component: "xcresult-attachments")
         if try await !fileSystem.exists(directory) {
             try await fileSystem.makeDirectory(at: directory)
         }
@@ -596,10 +622,10 @@ public struct XCResultParser: Sendable {
 
     private func attachmentsByTestIdentifiers(
         from xcresultPath: AbsolutePath,
-        rootDirectory: AbsolutePath?
+        scratchDirectory: AbsolutePath?
     ) async -> (crashReports: [String: CrashReport], attachments: [String: [TestAttachment]]) {
         do {
-            let temporaryDirectory = try await attachmentsDirectory(rootDirectory: rootDirectory)
+            let temporaryDirectory = try await attachmentsDirectory(scratchDirectory: scratchDirectory)
 
             _ = try await commandRunner.run(
                 arguments: [

--- a/server/native/xcresult_nif/Sources/XCResultParser/XCResultParser.swift
+++ b/server/native/xcresult_nif/Sources/XCResultParser/XCResultParser.swift
@@ -172,7 +172,7 @@ public struct XCResultParser: Sendable {
         suiteDurations.merge(swiftTestingSuiteDurations) { _, new in new }
         moduleDurations.merge(swiftTestingModuleDurations) { _, new in new }
 
-        let extractedAttachments = await attachmentsByTestIdentifiers(from: xcresultPath)
+        let extractedAttachments = await attachmentsByTestIdentifiers(from: xcresultPath, rootDirectory: rootDirectory)
 
         allTestCases = allTestCases.map { testCase in
             let testIdentifier = normalizeTestIdentifier(
@@ -573,11 +573,33 @@ public struct XCResultParser: Sendable {
         }
     }
 
+    /// Attachments are exported for the caller to consume *after* parse
+    /// returns (the server worker uploads them to S3), so they can't live
+    /// in an auto-cleaned `runInTemporaryDirectory` block like the other
+    /// xcresulttool scratch dirs. When the caller provides a root
+    /// directory — its per-run scratch dir, which it removes wholesale
+    /// once processing finishes — we export into a subdirectory of it so
+    /// that cleanup reclaims them too. Without this the exported bundles
+    /// (test videos, crash logs) accumulate in the process-wide temp dir
+    /// and never get reclaimed.
+    private func attachmentsDirectory(rootDirectory: AbsolutePath?) async throws -> AbsolutePath {
+        guard let rootDirectory else {
+            return try await fileSystem.makeTemporaryDirectory(prefix: "xcresult-attachments")
+        }
+
+        let directory = rootDirectory.appending(component: "xcresult-attachments")
+        if try await !fileSystem.exists(directory) {
+            try await fileSystem.makeDirectory(at: directory)
+        }
+        return directory
+    }
+
     private func attachmentsByTestIdentifiers(
-        from xcresultPath: AbsolutePath
+        from xcresultPath: AbsolutePath,
+        rootDirectory: AbsolutePath?
     ) async -> (crashReports: [String: CrashReport], attachments: [String: [TestAttachment]]) {
         do {
-            let temporaryDirectory = try await fileSystem.makeTemporaryDirectory(prefix: "xcresult-attachments")
+            let temporaryDirectory = try await attachmentsDirectory(rootDirectory: rootDirectory)
 
             _ = try await commandRunner.run(
                 arguments: [

--- a/server/native/xcresult_nif/Tests/XCResultParserTests/XCResultParserTests.swift
+++ b/server/native/xcresult_nif/Tests/XCResultParserTests/XCResultParserTests.swift
@@ -37,20 +37,40 @@ struct XCResultParserTests {
     }
 
     @Test
-    func parse_extractsAttachmentsUnderTheProvidedRootDirectory() async throws {
+    func parse_extractsAttachmentsUnderTheScratchDirectory() async throws {
         let zipPath = try fixtureZipPath("test-with-arguments.xcresult")
 
         try await fileSystem.runInTemporaryDirectory(prefix: "xcresult-parser-tests") { workDir in
             try await fileSystem.unzip(zipPath, to: workDir)
             let xcresult = workDir.appending(component: "test-with-arguments.xcresult")
+            let scratch = workDir.appending(component: "scratch")
+            try await fileSystem.makeDirectory(at: scratch)
 
-            _ = try await parser.parse(path: xcresult, rootDirectory: workDir)
+            _ = try await parser.parse(path: xcresult, rootDirectory: workDir, attachmentScratchDirectory: scratch)
 
-            // Exported attachments must live under the caller's root
-            // directory so the caller's wholesale cleanup reclaims them,
-            // rather than leaking into the process-wide temp dir.
-            let attachmentsDirectory = workDir.appending(component: "xcresult-attachments")
-            #expect(try await fileSystem.exists(attachmentsDirectory))
+            // Exported attachments must live under the caller-owned scratch
+            // dir so its wholesale cleanup reclaims them.
+            #expect(try await fileSystem.exists(scratch.appending(component: "xcresult-attachments")))
+        }
+    }
+
+    @Test
+    func parse_doesNotExportAttachmentsIntoRootDirectoryWhenNoScratchGiven() async throws {
+        // rootDirectory is the caller's *source* root (the user's project
+        // for CLI callers) and is read-only. Without an explicit scratch
+        // dir, attachments must NOT be dropped into it — they go to a temp
+        // dir instead.
+        let zipPath = try fixtureZipPath("test-with-arguments.xcresult")
+
+        try await fileSystem.runInTemporaryDirectory(prefix: "xcresult-parser-tests") { workDir in
+            try await fileSystem.unzip(zipPath, to: workDir)
+            let xcresult = workDir.appending(component: "test-with-arguments.xcresult")
+            let projectRoot = workDir.appending(component: "project")
+            try await fileSystem.makeDirectory(at: projectRoot)
+
+            _ = try await parser.parse(path: xcresult, rootDirectory: projectRoot)
+
+            #expect(try await !fileSystem.exists(projectRoot.appending(component: "xcresult-attachments")))
         }
     }
 }

--- a/server/native/xcresult_nif/Tests/XCResultParserTests/XCResultParserTests.swift
+++ b/server/native/xcresult_nif/Tests/XCResultParserTests/XCResultParserTests.swift
@@ -35,4 +35,22 @@ struct XCResultParserTests {
         #expect(destinations[0].platform == "iOS Simulator")
         #expect(destinations[0].osVersion == "26.4")
     }
+
+    @Test
+    func parse_extractsAttachmentsUnderTheProvidedRootDirectory() async throws {
+        let zipPath = try fixtureZipPath("test-with-arguments.xcresult")
+
+        try await fileSystem.runInTemporaryDirectory(prefix: "xcresult-parser-tests") { workDir in
+            try await fileSystem.unzip(zipPath, to: workDir)
+            let xcresult = workDir.appending(component: "test-with-arguments.xcresult")
+
+            _ = try await parser.parse(path: xcresult, rootDirectory: workDir)
+
+            // Exported attachments must live under the caller's root
+            // directory so the caller's wholesale cleanup reclaims them,
+            // rather than leaking into the process-wide temp dir.
+            let attachmentsDirectory = workDir.appending(component: "xcresult-attachments")
+            #expect(try await fileSystem.exists(attachmentsDirectory))
+        }
+    }
 }

--- a/server/native/xcresult_nif/Tests/XCResultParserTests/XCResultParserTests.swift
+++ b/server/native/xcresult_nif/Tests/XCResultParserTests/XCResultParserTests.swift
@@ -37,29 +37,29 @@ struct XCResultParserTests {
     }
 
     @Test
-    func parse_extractsAttachmentsUnderTheScratchDirectory() async throws {
+    func parse_extractsAttachmentsUnderTheAttachmentsDirectory() async throws {
         let zipPath = try fixtureZipPath("test-with-arguments.xcresult")
 
         try await fileSystem.runInTemporaryDirectory(prefix: "xcresult-parser-tests") { workDir in
             try await fileSystem.unzip(zipPath, to: workDir)
             let xcresult = workDir.appending(component: "test-with-arguments.xcresult")
-            let scratch = workDir.appending(component: "scratch")
-            try await fileSystem.makeDirectory(at: scratch)
+            let attachmentsDirectory = workDir.appending(component: "attachments")
+            try await fileSystem.makeDirectory(at: attachmentsDirectory)
 
-            _ = try await parser.parse(path: xcresult, rootDirectory: workDir, attachmentScratchDirectory: scratch)
+            _ = try await parser.parse(path: xcresult, rootDirectory: workDir, attachmentsDirectory: attachmentsDirectory)
 
-            // Exported attachments must live under the caller-owned scratch
-            // dir so its wholesale cleanup reclaims them.
-            #expect(try await fileSystem.exists(scratch.appending(component: "xcresult-attachments")))
+            // Exported attachments must live under the caller-owned
+            // attachments dir so its wholesale cleanup reclaims them.
+            #expect(try await fileSystem.exists(attachmentsDirectory.appending(component: "xcresult-attachments")))
         }
     }
 
     @Test
-    func parse_doesNotExportAttachmentsIntoRootDirectoryWhenNoScratchGiven() async throws {
+    func parse_doesNotExportAttachmentsIntoRootDirectoryWhenNoAttachmentsDirectoryGiven() async throws {
         // rootDirectory is the caller's *source* root (the user's project
-        // for CLI callers) and is read-only. Without an explicit scratch
-        // dir, attachments must NOT be dropped into it — they go to a temp
-        // dir instead.
+        // for CLI callers) and is read-only. Without an explicit
+        // attachments directory, attachments must NOT be dropped into it —
+        // they go to a temp dir instead.
         let zipPath = try fixtureZipPath("test-with-arguments.xcresult")
 
         try await fileSystem.runInTemporaryDirectory(prefix: "xcresult-parser-tests") { workDir in


### PR DESCRIPTION
## Summary

Fixes from an incident where `ProcessXcresultWorker` jobs were failing with `:enospc` on the production macOS xcresult-processor VMs. They're drafted together because they share one thread: a slow resource leak that ran unmonitored because the VMs' observability had been silently broken since the Tailscale migration on 2026-05-18.

1. **`fix(server)`** — stop the xcresult NIF from leaking attachment temp dirs (the actual disk filler).
2. **`fix(infra)`** — restore the tart-kubelet metrics forwarder so the VMs' Oban job metrics reach Prometheus again (why the leak was invisible on the dashboard).
3. **`feat(infra)`** — make a full guest disk observable: publish a `DiskPressure` node condition **and** export the guest disk usage % as a Prometheus gauge to alert on, instead of it sitting at `Unknown`.

## What happened

`ProcessXcresultWorker` runs only on the macOS xcresult-processor VMs (xcresulttool is Xcode-only). On the affected VM the guest APFS volume was at 100% — 130 GiB disk, ~58 GiB Xcode baseline, and **~47 GiB of leaked `xcresult-attachments-*` directories** in the worker's `TMPDIR` (14k+ dirs, one per job over ~8 days). Once full, downloads/extractions failed with `:enospc`; the one attempt that squeezed through then failed to parse a partially-written bundle, and Oban discarded after 5 attempts. The run was persisted as `failed_processing`.

It stayed invisible because (a) every job-event Grafana panel showed No data — the VM metrics weren't being scraped — and (b) the node's `DiskPressure` condition was stuck `Unknown` and nothing exported the guest disk %, so neither the scheduler nor any alert could react. The host disk, meanwhile, had 270+ GiB free, so a host-level signal would never have fired.

## Fix 1 — attachment temp-dir leak (`server`)

[`XCResultParser.attachmentsByTestIdentifiers`](server/native/xcresult_nif/Sources/XCResultParser/XCResultParser.swift) exported attachments into a process-wide `makeTemporaryDirectory(prefix: "xcresult-attachments")` and never cleaned it up. It can't use the auto-cleaning `runInTemporaryDirectory` block its sibling calls use, because the exported files are read by the Elixir worker for S3 upload *after* `parse()` returns.

The worker already creates a per-run scratch dir (`root_dir`) and `File.rm_rf`s it once processing finishes. The fix exports attachments into a subdirectory of that caller-provided `rootDirectory`, so the worker's existing cleanup reclaims them. Falls back to a temp dir only when no root is provided.

## Fix 2 — metrics forwarder dial scope (`infra`)

tart-kubelet's host-side metrics reverse proxy returned **502 for every scrape** of the VM's PromEx endpoint. The VM serves the event metrics fine (`curl 192.168.64.2:9091` → 200 with live `process_xcresult` series) and the host reaches the VM directly (`curl` from the host → 200, 6/6) — but the forwarder's Go dialer got `EHOSTUNREACH`:

```
WARN metrics forwarder: upstream proxy error listen=100.66.118.128:9091
  err="dial tcp 192.168.64.2:9091: connect: no route to host"
```

After the Tailscale migration the forwarder binds to the tailnet IP and the dialer issues an unscoped `connect()`. On macOS with scoped routing the VM's vmnet route carries the `IFSCOPE` flag (bound to the bridge) while the host's primary interface is the public WAN, so the unscoped connect resolves against the wrong scope and fails — even though the bridge is up and reachable.

The fix adds a `Dialer.Control` hook that pins the upstream socket to the interface owning the directly-connected route to the target (`IP_BOUND_IF` on darwin, no-op elsewhere via a build-tagged file). `go mod tidy` also promotes `x/sys` to direct and corrects a stale indirect marking on `prometheus/client_golang`.

## Fix 3 — make a full guest disk observable (`infra`)

tart-kubelet only posted `NodeReady`, leaving `DiskPressure`/`MemoryPressure`/`PIDPressure` at `Unknown` and exporting nothing about the guest volume. Two complementary signals are added, both driven by one `tart exec ... df` probe per running VM each heartbeat:

- **`DiskPressure` node condition** — reported `True` when any guest root volume is at/above 90% (message names the offending VM), else `False`; seeded `False` at registration so it never sits at `Unknown`. Gives the scheduler a `disk-pressure` taint and is alertable via kube-state-metrics. Probes are time-bounded so an unresponsive guest agent can't stall the heartbeat; per-VM errors are logged and skipped.
- **`tart_kubelet_guest_disk_usage_percent{vm=...}` gauge** — the gradient signal behind the condition, registered on the controller-runtime registry that Alloy already scrapes via the `tuist-macos-tart-kubelet` job (`:8080`). Reset each sweep so a departed VM stops reporting stale capacity.

Measuring the *guest* volume (not the host) is deliberate — the host stays near-empty even when a guest is full. (MemoryPressure/PIDPressure remain unreported — a separate gap, not the incident's failure mode.)

### Alerting (Grafana-managed — wire these up, not in this repo)

Alerts here are managed in Grafana Cloud, not as code, so this PR ships the *metric*; the alert is created in Grafana. Recommended rules on the new gauge (this is what would have caught the 8-day climb long before ENOSPC):

- **Warn** (notify): `max by (instance, vm) (tart_kubelet_guest_disk_usage_percent) >= 80` for 10m
- **Page** (matches the condition threshold): `max by (instance, vm) (tart_kubelet_guest_disk_usage_percent) >= 90` for 5m
- **Probe/target down** (so a blind spot is itself an alert): `up{job="tuist-macos-tart-kubelet"} == 0` for 10m
- Optional backstop on the condition: `kube_node_status_condition{condition="DiskPressure",status="true"} == 1`

This PR also adds a **Guest Disk Usage** panel (`tart_kubelet_guest_disk_usage_percent`, threshold lines at 80/90%) to the "Tuist xcresult Processor" dashboard JSON (`infra/grafana-dashboards/xcresult-processor.json`), which is synced as code.

## Validation

- `swift test` (xcresult_nif): 6/6 pass, incl. a new test asserting attachments land under the provided root.
- `go test ./...` (tart-kubelet): pass, incl. new tests for the dial interface-resolution helper, the `df` capacity parser, the DiskPressure condition logic (True/False/keep-prior-on-error/nil-noop), and the guest-disk gauge (set + reset-drops-stale-series).
- tart-kubelet builds for darwin/arm64 **and** linux/amd64; `go vet`/`gofmt`/`swiftformat --lint` clean.
- Incident mitigation already applied out-of-band: leaked dirs cleared on both production VMs to restore service.

⚠️ The forwarder fix, the guest-`df` probe, and the gauge can only be fully confirmed on a Mac mini host (real macOS scoped routing / the Tart guest agent). Post-deploy checks: `curl <node-tailnet-ip>:9091/metrics` returns 200 (not 502); `kubectl describe node` shows a real `DiskPressure` status; `tart_kubelet_guest_disk_usage_percent` appears in Grafana.

## Deliberately deferred

### `kubectl logs`/`exec` against the Tart VM nodes — not implemented (options outlined for a future decision)

This is **not** a config fix; it's three independent, stacked failures:
1. The apiserver flag at `infra/k8s/clusters/clusterclass-tuist.yaml:425` is `ExternalIP,Hostname,InternalDNS,ExternalDNS` — Tart nodes have no ExternalIP, so it falls to an unresolvable Hostname (the `no such host` error).
2. The nodes' only routable address is their Tailscale CGNAT IP, which the control-plane netns can't reach (those routes live only on the egress/connector proxies).
3. tart-kubelet implements **no kubelet streaming server on `:10250`**, so there's nowhere for `/exec`/`/containerLogs` to land even with DNS + routing solved.

Native `kubectl logs/exec` would require all three layers (none is independently useful), ~10–13d total:
- **Streaming server on `:10250` (~5–8d)** — serve `/containerLogs` (plain HTTP stream) + `/exec` (SPDY/WebSocket upgrade, stdio channel demux). TLS serving cert via the CSR API, validate the apiserver's client cert against the cluster CA, SAR webhook for authz — the model the Linux kubelet config already specifies at `clusterclass-tuist.yaml:471-489`, and tart-kubelet already holds a cluster-CA kubeconfig to bootstrap it. Back `exec` with `tart exec -i -t`, `logs` with the guest service log file; `k8s.io/kubelet/.../cri/streaming` covers most of `exec`. Hardest part is the SPDY/WS channel demux, not the `tart exec` glue.
- **Reachability (~2–4d)** — the control plane isn't on the tailnet (only the egress ProxyGroup is). Recommended: join CP nodes to the tailnet with a scoped route-accept + an ACL grant to `minis:10250`.
- **Flag (<1d)** — change the global arg to `ExternalIP,InternalIP,Hostname,…` so Linux nodes still match `ExternalIP` first (unchanged) and Tart nodes fall through to their now-routable `InternalIP`. Triggers a control-plane rollout; validate on canary.

Cheaper alternatives covering ~90% of the value in ~3d (preferred unless tooling requires the standard `kubectl` UX):
- **Ship the guest service logs to Loki** via the existing observability/egress path — operators read logs in Grafana and `kubectl logs` becomes unnecessary. Best value/effort.
- **A `tart-kubelet exec <pod>` host subcommand** over the existing tailnet SSH path (`tag:tuist-ops → mini:22`) for occasional interactive debugging — no apiserver/control-plane changes.

Until one of these is built, operate these nodes via host SSH + `tart exec` (as done in this incident).

### Other

- The **stuck production helm pipeline** (prod is on xcresult-processor `0.6.2`; chart is at `0.9.0` since 2026-05-20) — none of these fixes reach prod until that's unblocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
