### PR TITLE
ci(infra): collapse the three pre-deploy chart installs into one job

### DIFF
--- a/.github/workflows/server-deployment.yml
+++ b/.github/workflows/server-deployment.yml
@@ -143,18 +143,31 @@ jobs:
           push: true
           tags: |
             ${{ env.REGISTRY }}/${{ env.KURA_CONTROLLER_IMAGE_NAME }}:${{ steps.tag.outputs.image_tag }}
-  observability-install:
-    # Installs / upgrades the grafana/k8s-monitoring wrapper chart ahead of
-    # the server rollout so the Alloy OTLP receiver is ready before the
-    # server starts pushing spans to it. Idempotent: on every run it's a
-    # no-op if Chart.lock + values haven't changed.
+  chart-installs:
+    # Installs / upgrades the supporting charts that must be in place
+    # before the server rollout, in order:
+    #   1. observability (grafana/k8s-monitoring) — the Alloy OTLP
+    #      receiver must be ready before the server pushes spans to it.
+    #   2. tailscale-operator — the Connector subnet router announcing
+    #      the macOS fleet's CGNAT range must be Ready before the CAPI
+    #      provider bootstraps Mac minis. Skipped when a forked workflow
+    #      ships no values-<env>.yaml.
+    #   3. platform (cert-manager, ingress-nginx, external-dns, ESO,
+    #      metrics-server) — app-impacting platform settings must
+    #      self-heal so existing clusters pick up chart edits without a
+    #      manual re-bootstrap.
+    # All idempotent — no-ops when Chart.lock + values haven't drifted.
     #
-    # Per-chart concurrency lane: serializes this install against its
-    # own past runs without making sibling install jobs in the same
-    # run cancel each other. A single shared lane caps the GitHub
-    # queue at running + 1 waiting and drops the rest, which used to
-    # leave only one of the three install jobs running per deploy.
-    name: Observability chart (${{ inputs.environment }})
+    # One job, not three, so the 1Password kubeconfig is fetched once
+    # instead of three times at the same instant: three simultaneous
+    # `op document get` calls were tripping the 1Password rate limit at
+    # deploy start. The deploy job below still fetches its own copy —
+    # it's a separate runner and a kubeconfig is secret-bearing, so it
+    # can't be shared across jobs without persisting it insecurely.
+    #
+    # Single concurrency lane serializes this phase against its own past
+    # runs without colliding with the deploy lane.
+    name: Pre-deploy charts (${{ inputs.environment }})
     needs: build
     # `build` is skipped when image_tag is supplied - keep running.
     if: always() && (needs.build.result == 'success' || needs.build.result == 'skipped')
@@ -162,11 +175,14 @@ jobs:
     environment:
       name: server-k8s-${{ inputs.environment }}
     concurrency:
-      group: server-deploy-${{ inputs.environment }}-observability
+      group: server-deploy-${{ inputs.environment }}-chart-installs
       cancel-in-progress: false
-    timeout-minutes: 15
+    timeout-minutes: 40
     env:
       KUBECONFIG: ${{ github.workspace }}/.kube/config
+      TAILSCALE_CHART_PATH: infra/helm/tailscale-operator
+      TAILSCALE_RELEASE_NAME: tailscale-operator
+      TAILSCALE_NAMESPACE: tailscale-operator
     steps:
       - uses: actions/checkout@v4
         with:
@@ -195,7 +211,7 @@ jobs:
           API="$(kubectl config view --minify --raw -o jsonpath='{.clusters[0].cluster.server}')"
           echo "Reaching apiserver at $API"
           kubectl --request-timeout=10s get --raw /version >/dev/null
-      - name: helm dependency update
+      - name: helm dependency update (k8s-monitoring)
         run: helm dependency update "$OBSERVABILITY_CHART_PATH"
       - name: helm upgrade --install k8s-monitoring
         run: |
@@ -203,45 +219,14 @@ jobs:
             --namespace "$OBSERVABILITY_NAMESPACE" --create-namespace \
             -f "$OBSERVABILITY_CHART_PATH/values-${{ inputs.environment }}.yaml" \
             --timeout 10m --wait
-
-  tailscale-operator-install:
-    # Installs / upgrades the tailscale-operator wrapper chart ahead of
-    # the server rollout so the Connector subnet router that announces
-    # the macOS fleet's CGNAT range is Ready before the CAPI provider
-    # starts bootstrapping Mac minis. Idempotent: a no-op if Chart.lock
-    # + values haven't changed.
-    #
-    # All three Tuist-managed envs (staging, canary, production) ship
-    # their own values-<env>.yaml under infra/helm/tailscale-operator/,
-    # so this skip path is reachable only when the workflow is forked
-    # by a self-hoster who hasn't authored one. Keeps the workflow
-    # usable downstream without a hard dependency on Tailscale; the
-    # main server deploy continues either way.
-    #
-    # Per-chart concurrency lane: same reasoning as
-    # observability-install. Serializes this install against its own
-    # past runs without sharing a slot with the sibling install jobs.
-    name: Tailscale operator chart (${{ inputs.environment }})
-    needs: build
-    if: always() && (needs.build.result == 'success' || needs.build.result == 'skipped')
-    runs-on: tuist-production-linux
-    environment:
-      name: server-k8s-${{ inputs.environment }}
-    concurrency:
-      group: server-deploy-${{ inputs.environment }}-tailscale
-      cancel-in-progress: false
-    timeout-minutes: 15
-    env:
-      KUBECONFIG: ${{ github.workspace }}/.kube/config
-      TAILSCALE_CHART_PATH: infra/helm/tailscale-operator
-      TAILSCALE_RELEASE_NAME: tailscale-operator
-      TAILSCALE_NAMESPACE: tailscale-operator
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ env.DEPLOY_SHA }}
-      - id: check-values
-        name: Check for env values file
+      # --- tailscale-operator chart ---
+      # All three Tuist-managed envs (staging, canary, production) ship
+      # their own values-<env>.yaml under infra/helm/tailscale-operator/,
+      # so the skip path is reachable only when the workflow is forked by
+      # a self-hoster who hasn't authored one. Keeps the workflow usable
+      # downstream without a hard dependency on Tailscale.
+      - id: check-tailscale-values
+        name: Check for Tailscale env values file
         run: |
           set -euo pipefail
           VALUES="$TAILSCALE_CHART_PATH/values-${{ inputs.environment }}.yaml"
@@ -252,87 +237,17 @@ jobs:
             echo "exists=false" >> "$GITHUB_OUTPUT"
             echo "$VALUES not present; skipping tailscale-operator install for this env."
           fi
-      - if: steps.check-values.outputs.exists == 'true'
-        uses: jdx/mise-action@v3.2.0
-        with:
-          install_args: "helm kubectl"
-          cache: "false"
-      - if: steps.check-values.outputs.exists == 'true'
-        uses: 1password/install-cli-action@v2
-      - if: steps.check-values.outputs.exists == 'true'
-        name: Load kubeconfig from 1Password
-        env:
-          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-        run: |
-          mkdir -p "$(dirname "$KUBECONFIG")"
-          op document get "kubeconfig: tuist-${{ inputs.environment }}" \
-            --vault "tuist-k8s-${{ inputs.environment }}" --output "$KUBECONFIG"
-          chmod 600 "$KUBECONFIG"
-      - if: steps.check-values.outputs.exists == 'true'
-        name: Verify cluster reachability
-        run: |
-          set -euo pipefail
-          API="$(kubectl config view --minify --raw -o jsonpath='{.clusters[0].cluster.server}')"
-          echo "Reaching apiserver at $API"
-          kubectl --request-timeout=10s get --raw /version >/dev/null
-      - if: steps.check-values.outputs.exists == 'true'
-        name: helm dependency update
+      - if: steps.check-tailscale-values.outputs.exists == 'true'
+        name: helm dependency update (tailscale-operator)
         run: helm dependency update "$TAILSCALE_CHART_PATH"
-      - if: steps.check-values.outputs.exists == 'true'
+      - if: steps.check-tailscale-values.outputs.exists == 'true'
         name: helm upgrade --install tailscale-operator
         run: |
           helm upgrade --install "$TAILSCALE_RELEASE_NAME" "$TAILSCALE_CHART_PATH" \
             --namespace "$TAILSCALE_NAMESPACE" --create-namespace \
             -f "$TAILSCALE_CHART_PATH/values-${{ inputs.environment }}.yaml" \
             --timeout 10m --wait
-
-  platform-install:
-    # Installs / upgrades the platform chart (cert-manager, ingress-nginx,
-    # external-dns, ESO, metrics-server) ahead of the server rollout. The
-    # bootstrap script lays this down once per cluster, but app-impacting
-    # platform settings — ingress-nginx upstream-keepalive-timeout,
-    # metrics-server presence — must self-heal on every deploy so existing
-    # clusters pick up chart edits without a manual re-bootstrap. Idempotent:
-    # steady-state finishes in under a minute when nothing has drifted.
-    #
-    # Per-chart concurrency lane: same reasoning as
-    # observability-install. Serializes this install against its own
-    # past runs without sharing a slot with the sibling install jobs.
-    name: Platform chart (${{ inputs.environment }})
-    needs: build
-    if: always() && (needs.build.result == 'success' || needs.build.result == 'skipped')
-    runs-on: tuist-production-linux
-    environment:
-      name: server-k8s-${{ inputs.environment }}
-    concurrency:
-      group: server-deploy-${{ inputs.environment }}-platform
-      cancel-in-progress: false
-    timeout-minutes: 20
-    env:
-      KUBECONFIG: ${{ github.workspace }}/.kube/config
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ env.DEPLOY_SHA }}
-      - uses: jdx/mise-action@v3.2.0
-        with:
-          install_args: "helm kubectl"
-          cache: "false"
-      - uses: 1password/install-cli-action@v2
-      - name: Load kubeconfig from 1Password
-        env:
-          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-        run: |
-          mkdir -p "$(dirname "$KUBECONFIG")"
-          op document get "kubeconfig: tuist-${{ inputs.environment }}" \
-            --vault "tuist-k8s-${{ inputs.environment }}" --output "$KUBECONFIG"
-          chmod 600 "$KUBECONFIG"
-      - name: Verify cluster reachability
-        run: |
-          set -euo pipefail
-          API="$(kubectl config view --minify --raw -o jsonpath='{.clusters[0].cluster.server}')"
-          echo "Reaching apiserver at $API"
-          kubectl --request-timeout=10s get --raw /version >/dev/null
+      # --- platform chart ---
       - name: Run k8s:install-platform
         # CLOUDFLARE_API_TOKEN is read from the in-cluster Secret the bootstrap
         # script created (CI is cluster-admin) instead of being added as a
@@ -352,16 +267,13 @@ jobs:
 
   deploy:
     name: Deploy to ${{ inputs.environment == 'production' && 'tuist' || format('tuist-{0}', inputs.environment) }}
-    needs: [build, observability-install, tailscale-operator-install, platform-install]
+    needs: [build, chart-installs]
     # `build` may be skipped when image_tag is passed in - keep running.
-    # `observability-install` always runs, so it must be a plain success.
-    # `tailscale-operator-install` runs the install for managed envs and
-    # short-circuits when a forked workflow has no env values file; either
-    # way it must complete cleanly before the chart deploy.
-    # `platform-install` reconciles cert-manager / ingress-nginx /
-    # external-dns / ESO / metrics-server so app-impacting platform settings
-    # land before the app chart upgrade.
-    if: always() && (needs.build.result == 'success' || needs.build.result == 'skipped') && needs.observability-install.result == 'success' && needs.tailscale-operator-install.result == 'success' && needs.platform-install.result == 'success'
+    # `chart-installs` lands observability + tailscale-operator +
+    # platform (cert-manager / ingress-nginx / external-dns / ESO /
+    # metrics-server) before the app chart upgrade, so it must complete
+    # cleanly first.
+    if: always() && (needs.build.result == 'success' || needs.build.result == 'skipped') && needs.chart-installs.result == 'success'
     runs-on: tuist-production-linux
     environment:
       name: server-k8s-${{ inputs.environment }}

--- a/infra/helm/k8s-monitoring/README.md
+++ b/infra/helm/k8s-monitoring/README.md
@@ -16,7 +16,7 @@ With these in place the Grafana Cloud **Observability → Kubernetes** app popul
 
 ## Install
 
-Installed automatically by the `observability-install` job in [`.github/workflows/server-deployment.yml`](../../../.github/workflows/server-deployment.yml) for the main managed clusters, and by [`infra/mise/tasks/k8s/deploy-kura-regionals.sh`](../../mise/tasks/k8s/deploy-kura-regionals.sh) for the regional Kura clusters. Both paths are idempotent, so the chart tracks whatever's committed on `main`.
+Installed automatically by the `chart-installs` job in [`.github/workflows/server-deployment.yml`](../../../.github/workflows/server-deployment.yml) for the main managed clusters, and by [`infra/mise/tasks/k8s/deploy-kura-regionals.sh`](../../mise/tasks/k8s/deploy-kura-regionals.sh) for the regional Kura clusters. Both paths are idempotent, so the chart tracks whatever's committed on `main`.
 
 Manual install (only needed when bootstrapping a fresh cluster ahead of the first CI deploy, or iterating locally):
 

--- a/infra/k8s/onboarding.md
+++ b/infra/k8s/onboarding.md
@@ -145,7 +145,7 @@ gh workflow run server-deployment.yml -f environment=<env>
 
 ## 7. Observability
 
-The [`infra/helm/k8s-monitoring/`](../helm/k8s-monitoring/) chart forwards Kubernetes telemetry to Grafana Cloud. The bootstrap task in §4 installs it; the `observability-install` job in `server-deployment.yml` keeps it in sync on every deploy. After it lights up, look for the cluster name in **Observability → Kubernetes** in Grafana Cloud. Verification steps live in [`infra/helm/k8s-monitoring/README.md`](../helm/k8s-monitoring/README.md).
+The [`infra/helm/k8s-monitoring/`](../helm/k8s-monitoring/) chart forwards Kubernetes telemetry to Grafana Cloud. The bootstrap task in §4 installs it; the `chart-installs` job in `server-deployment.yml` keeps it in sync on every deploy. After it lights up, look for the cluster name in **Observability → Kubernetes** in Grafana Cloud. Verification steps live in [`infra/helm/k8s-monitoring/README.md`](../helm/k8s-monitoring/README.md).
 
 ## 8. Preview environments (ephemeral PR / commit deploys)
 


### PR DESCRIPTION
## Summary

The `observability-install`, `tailscale-operator-install`, and `platform-install` jobs in [server-deployment.yml](.github/workflows/server-deployment.yml) each fetched the **same** kubeconfig from 1Password via `op document get "kubeconfig: tuist-<env>"`. All three ran in parallel on `needs: build`, so three identical fetches fired within the same instant at the start of every deploy — and that burst was tripping the 1Password service-account rate limit (`Too many requests`).

This collapses the three into a single sequential `chart-installs` job that fetches the kubeconfig **once** and runs each chart as its own named step. The `deploy` job keeps its own fetch.

## Why this shape

Diagnosing the rate-limit failure showed the quota counters had plenty of headroom (`op service-account ratelimit` reported tokens at ~0% and the account-wide daily pool at ~10%). So the failure wasn't quota exhaustion — it was **concurrency**: too many requests in the same instant. A kubeconfig is secret-bearing, so it can't be fetched once in a setup job and handed to separate-runner jobs without persisting it (an artifact would leak cluster credentials). The only way to cut the redundant fetch is to put the work that needs it on the **same runner** — i.e. one job.

Net effect on a single env leg: **4 simultaneous kubeconfig fetches → 2 staggered ones** (one in `chart-installs`, one later in `deploy`), with at most one `op` call in flight at any moment.

## Trade-offs

- **Charts run sequentially now, not in parallel.** They're idempotent and finish sub-minute when nothing has drifted, so the added wall-clock is small. The job `timeout-minutes` is set to 40 to cover a cold/changed rollout (each `helm --timeout` is 10m).
- This supersedes part of #10969: the three separate per-chart concurrency lanes collapse into one job, so the cancellation pathology that PR fixed can't recur here (there's only one job to schedule). The `deploy` lane is unchanged.
- Each chart is still a distinct, named step (`helm upgrade --install k8s-monitoring`, `... tailscale-operator`, `Run k8s:install-platform`), so per-chart visibility in the Actions UI is preserved.
- The tailscale skip-path for forked workflows without a `values-<env>.yaml` is preserved as a per-step `if:` gate.

Docs that named the old `observability-install` job ([infra/k8s/onboarding.md](infra/k8s/onboarding.md), [infra/helm/k8s-monitoring/README.md](infra/helm/k8s-monitoring/README.md)) are updated to `chart-installs`.

## What this does NOT fix

The other consumer of the same per-env service-account token is External Secrets Operator (continuous `onepasswordSDK` reads). This PR only addresses the CI burst. If rate-limit pressure persists, the next levers are separating CI vs ESO service accounts, lengthening ESO `refreshInterval`, or moving ESO to a 1Password Connect server.

## Validation

- `actionlint` parses the workflow with no errors on the job graph or step syntax (only pre-existing custom self-hosted-runner-label warnings).
- Job graph confirmed: `build → chart-installs → deploy`; `deploy.needs` and `deploy.if` rewired to the single job.
- `op document get` invocations on the env path reduced from 6 to 4; the 3-way simultaneous kubeconfig fetch is eliminated.

## Test plan

- [ ] Next canary deploy: `chart-installs` runs all three charts as steps, no `Too many requests` on the kubeconfig fetch.
- [ ] Confirm observability + tailscale + platform charts all reconcile (not just one, as happened under the old shared-lane cancellation).
- [ ] `deploy` still gates on `chart-installs` success.