### PR TITLE
fix(server): look up existing test cases with a single array param

### DIFF
--- a/server/lib/tuist/tests.ex
+++ b/server/lib/tuist/tests.ex
@@ -785,10 +785,18 @@ defmodule Tuist.Tests do
     |> Enum.uniq()
   end
 
-  # Batch size for multipart `id IN ^ids` lookups. The generated SQL still
-  # contains one placeholder per test case ID, so we keep the batches small
-  # enough to stay below ClickHouse query/form limits on large reports.
-  @existing_test_cases_batch_size 5_000
+  # Batch size for the `id IN {ids:Array(UUID)}` lookup. The IDs travel as a
+  # single ClickHouse array parameter sent over multipart, so the request always
+  # carries one form field for the IDs regardless of batch size. We still chunk
+  # to keep that parameter's encoded value below ClickHouse's per-field value
+  # length limit on large reports.
+  @existing_test_cases_batch_size 2_000
+
+  @existing_test_cases_chunk_sql """
+  SELECT id, recent_durations, is_flaky, state, last_ran_at_ci, last_ran_at_local, inserted_at
+  FROM test_cases
+  WHERE project_id = {project_id:Int64} AND id IN ({ids:Array(UUID)})
+  """
 
   defp get_existing_test_cases(_project_id, []), do: %{}
 
@@ -806,25 +814,40 @@ defmodule Tuist.Tests do
     end)
   end
 
+  # Sent as a raw multipart query with a single `{ids:Array(UUID)}` parameter
+  # rather than an Ecto `id in ^ids` clause: the latter binds one parameter per
+  # ID, and in multipart mode each parameter becomes its own form field, which
+  # overflows ClickHouse's form-field limit on large reports.
   defp fetch_existing_test_cases_chunk(project_id, ids_chunk) do
-    project_id
-    |> existing_test_cases_chunk_query(ids_chunk)
-    |> ClickHouseRepo.all(multipart: true)
-  end
+    {:ok, %{rows: rows}} =
+      ClickHouseRepo.query(
+        @existing_test_cases_chunk_sql,
+        %{"project_id" => project_id, "ids" => ids_chunk},
+        multipart: true
+      )
 
-  defp existing_test_cases_chunk_query(project_id, ids_chunk) do
-    from(tc in TestCase,
-      where: tc.project_id == ^project_id and tc.id in ^ids_chunk,
-      select: %{
-        id: tc.id,
-        recent_durations: tc.recent_durations,
-        is_flaky: tc.is_flaky,
-        state: tc.state,
-        last_ran_at_ci: tc.last_ran_at_ci,
-        last_ran_at_local: tc.last_ran_at_local,
-        inserted_at: tc.inserted_at
+    Enum.map(rows, fn [
+                        id,
+                        recent_durations,
+                        is_flaky,
+                        state,
+                        last_ran_at_ci,
+                        last_ran_at_local,
+                        inserted_at
+                      ] ->
+      # A raw query decodes the UUID column to its 16-byte binary form, so load
+      # it back into the canonical string that `generate_test_case_id/4` emits;
+      # callers key off this value.
+      %{
+        id: Ecto.UUID.load!(id),
+        recent_durations: recent_durations,
+        is_flaky: is_flaky,
+        state: state,
+        last_ran_at_ci: last_ran_at_ci,
+        last_ran_at_local: last_ran_at_local,
+        inserted_at: inserted_at
       }
-    )
+    end)
   end
 
   defp merge_latest_test_case(row, acc) do

--- a/server/lib/tuist/tests.ex
+++ b/server/lib/tuist/tests.ex
@@ -785,18 +785,12 @@ defmodule Tuist.Tests do
     |> Enum.uniq()
   end
 
-  # Batch size for the `id IN {ids:Array(UUID)}` lookup. The IDs travel as a
-  # single ClickHouse array parameter sent over multipart, so the request always
-  # carries one form field for the IDs regardless of batch size. We still chunk
-  # to keep that parameter's encoded value below ClickHouse's per-field value
-  # length limit on large reports.
+  # Batch size for the existing-test-case lookup. The IDs travel as a single
+  # ClickHouse array parameter (see existing_test_cases_chunk_query/2), so the
+  # multipart request always carries one form field for them regardless of batch
+  # size. We still chunk to keep that parameter's encoded value below
+  # ClickHouse's per-field value-length limit on large reports.
   @existing_test_cases_batch_size 2_000
-
-  @existing_test_cases_chunk_sql """
-  SELECT id, recent_durations, is_flaky, state, last_ran_at_ci, last_ran_at_local, inserted_at
-  FROM test_cases
-  WHERE project_id = {project_id:Int64} AND id IN ({ids:Array(UUID)})
-  """
 
   defp get_existing_test_cases(_project_id, []), do: %{}
 
@@ -814,40 +808,31 @@ defmodule Tuist.Tests do
     end)
   end
 
-  # Sent as a raw multipart query with a single `{ids:Array(UUID)}` parameter
-  # rather than an Ecto `id in ^ids` clause: the latter binds one parameter per
-  # ID, and in multipart mode each parameter becomes its own form field, which
-  # overflows ClickHouse's form-field limit on large reports.
   defp fetch_existing_test_cases_chunk(project_id, ids_chunk) do
-    {:ok, %{rows: rows}} =
-      ClickHouseRepo.query(
-        @existing_test_cases_chunk_sql,
-        %{"project_id" => project_id, "ids" => ids_chunk},
-        multipart: true
-      )
+    project_id
+    |> existing_test_cases_chunk_query(ids_chunk)
+    |> ClickHouseRepo.all(multipart: true)
+  end
 
-    Enum.map(rows, fn [
-                        id,
-                        recent_durations,
-                        is_flaky,
-                        state,
-                        last_ran_at_ci,
-                        last_ran_at_local,
-                        inserted_at
-                      ] ->
-      # A raw query decodes the UUID column to its 16-byte binary form, so load
-      # it back into the canonical string that `generate_test_case_id/4` emits;
-      # callers key off this value.
-      %{
-        id: Ecto.UUID.load!(id),
-        recent_durations: recent_durations,
-        is_flaky: is_flaky,
-        state: state,
-        last_ran_at_ci: last_ran_at_ci,
-        last_ran_at_local: last_ran_at_local,
-        inserted_at: inserted_at
+  # Binds the IDs as a single `Array(UUID)` parameter via a fragment instead of
+  # `tc.id in ^ids_chunk`. `in` expands to one bound parameter per ID, and in
+  # multipart mode each parameter becomes its own form field, which overflows
+  # ClickHouse's form-field limit on large reports.
+  defp existing_test_cases_chunk_query(project_id, ids_chunk) do
+    from(tc in TestCase,
+      where:
+        tc.project_id == ^project_id and
+          fragment("? IN (?)", tc.id, type(^ids_chunk, {:array, Ecto.UUID})),
+      select: %{
+        id: tc.id,
+        recent_durations: tc.recent_durations,
+        is_flaky: tc.is_flaky,
+        state: tc.state,
+        last_ran_at_ci: tc.last_ran_at_ci,
+        last_ran_at_local: tc.last_ran_at_local,
+        inserted_at: tc.inserted_at
       }
-    end)
+    )
   end
 
   defp merge_latest_test_case(row, acc) do

--- a/server/test/tuist/tests_test.exs
+++ b/server/test/tuist/tests_test.exs
@@ -1264,54 +1264,36 @@ defmodule Tuist.TestsTest do
       assert test.is_ci == true
     end
 
-    test "looks up existing test cases with a bounded multipart form-field count for large batches" do
+    test "looks up existing test cases by binding the IDs as a single array parameter" do
       # Given
       project = ProjectsFixtures.project_fixture()
 
       test_cases =
-        for index <- 1..5_001 do
-          %{
-            name: "test_#{index}",
-            status: "success",
-            duration: 10,
-            test_suite_name: "Suite"
-          }
+        for index <- 1..3 do
+          %{name: "test_#{index}", status: "success", duration: 10, test_suite_name: "Suite"}
         end
 
       parent = self()
 
-      # Capture the lookup at the repo boundary to assert the shape of the query
-      # we build. `multipart: true` is passed only by the existing-test-case
-      # lookup, so it precisely targets that call; the end-to-end test below
-      # covers that the query actually runs and decodes against real ClickHouse.
-      # We can't observe this through real-ClickHouse behaviour: a regression to
-      # one parameter per ID is only rejected by ClickHouse's form-field limit,
-      # which the local instance does not enforce.
+      # Only the existing-test-case lookup passes `multipart: true`, so capturing
+      # it at the repo boundary targets that query precisely.
       stub(ClickHouseRepo, :all, fn query, opts ->
         if Keyword.get(opts, :multipart), do: send(parent, {:lookup, query})
         []
       end)
 
       # When
-      assert {:ok, _test} = Tests.create_test(large_test_report(project, test_cases))
+      assert {:ok, _test} = Tests.create_test(test_report(project, test_cases))
 
-      # Then
-      lookups = drain_lookups([])
-      assert lookups != []
-
-      for query <- lookups do
-        {sql, params} = Ecto.Adapters.ClickHouse.to_sql(:all, query)
-        assert sql =~ "Array(UUID)"
-
-        # The whole batch travels as one array parameter (alongside project_id),
-        # so ClickHouse only ever parses a constant set of multipart form fields
-        # no matter how many test cases the report has. An `id in ^ids` clause
-        # binds one parameter per ID, which emits one form field per ID and
-        # overflows ClickHouse's form-field limit on large reports
-        # (`HTML Form Exception: Too many form fields`).
-        assert length(params) == 2
-        assert multipart_form_field_count(sql, params) == 3
-      end
+      # Then: the IDs are bound as one Array(UUID) parameter (alongside
+      # project_id), so the parameter count stays constant. An `id in ^ids`
+      # clause binds one parameter per ID, and in multipart mode each parameter
+      # becomes its own form field, overflowing ClickHouse's form-field limit on
+      # large reports (`HTML Form Exception: Too many form fields`).
+      assert_received {:lookup, query}
+      {sql, params} = Ecto.Adapters.ClickHouse.to_sql(:all, query)
+      assert sql =~ "Array(UUID)"
+      assert length(params) == 2
     end
 
     test "ingests a large test report end to end without exceeding ClickHouse multipart limits" do
@@ -1320,19 +1302,14 @@ defmodule Tuist.TestsTest do
 
       test_cases =
         for index <- 1..5_001 do
-          %{
-            name: "test_#{index}",
-            status: "success",
-            duration: 10,
-            test_suite_name: "Suite"
-          }
+          %{name: "test_#{index}", status: "success", duration: 10, test_suite_name: "Suite"}
         end
 
       # When/Then: the existing-test-case lookup runs against the real
       # ClickHouse here (not a mock), so this fails if the IDs are sent in a way
       # that trips either the form-field count or the per-field value-length
       # limit (e.g. batching too aggressively).
-      assert {:ok, _test} = Tests.create_test(large_test_report(project, test_cases))
+      assert {:ok, _test} = Tests.create_test(test_report(project, test_cases))
     end
 
     test "persists run_destinations as separate rows linked to the test run" do
@@ -8799,7 +8776,7 @@ defmodule Tuist.TestsTest do
     end
   end
 
-  defp large_test_report(project, test_cases) do
+  defp test_report(project, test_cases) do
     %{
       id: UUIDv7.generate(),
       project_id: project.id,
@@ -8818,25 +8795,5 @@ defmodule Tuist.TestsTest do
         }
       ]
     }
-  end
-
-  defp drain_lookups(acc) do
-    receive do
-      {:lookup, query} -> drain_lookups([query | acc])
-    after
-      0 -> Enum.reverse(acc)
-    end
-  end
-
-  defp multipart_form_field_count(sql, params) do
-    {_params, _headers, body} =
-      sql
-      |> Ch.Query.build(multipart: true)
-      |> DBConnection.Query.encode(params, [])
-
-    body
-    |> IO.iodata_to_binary()
-    |> then(&Regex.scan(~r/content-disposition: form-data; name=/, &1))
-    |> length()
   end
 end

--- a/server/test/tuist/tests_test.exs
+++ b/server/test/tuist/tests_test.exs
@@ -1280,25 +1280,27 @@ defmodule Tuist.TestsTest do
 
       parent = self()
 
+      # Capture the lookup at the repo boundary to assert the shape of the query
+      # we build. `multipart: true` is passed only by the existing-test-case
+      # lookup, so it precisely targets that call; the end-to-end test below
+      # covers that the query actually runs and decodes against real ClickHouse.
+      # We can't observe this through real-ClickHouse behaviour: a regression to
+      # one parameter per ID is only rejected by ClickHouse's form-field limit,
+      # which the local instance does not enforce.
       stub(ClickHouseRepo, :all, fn query, opts ->
-        send(parent, {:ch_all, query, opts})
+        if Keyword.get(opts, :multipart), do: send(parent, {:lookup, query})
         []
       end)
 
       # When
       assert {:ok, _test} = Tests.create_test(large_test_report(project, test_cases))
 
-      # Then: isolate the existing-test-case lookups, the only reads on the
-      # test_cases table during ingestion.
-      lookups =
-        []
-        |> drain_ch_all()
-        |> Enum.filter(fn {sql, _params, _opts} -> sql =~ ~s["test_cases"] end)
-
+      # Then
+      lookups = drain_lookups([])
       assert lookups != []
 
-      for {sql, params, opts} <- lookups do
-        assert Keyword.get(opts, :multipart) == true
+      for query <- lookups do
+        {sql, params} = Ecto.Adapters.ClickHouse.to_sql(:all, query)
         assert sql =~ "Array(UUID)"
 
         # The whole batch travels as one array parameter (alongside project_id),
@@ -8818,11 +8820,9 @@ defmodule Tuist.TestsTest do
     }
   end
 
-  defp drain_ch_all(acc) do
+  defp drain_lookups(acc) do
     receive do
-      {:ch_all, query, opts} ->
-        {sql, params} = Ecto.Adapters.ClickHouse.to_sql(:all, query)
-        drain_ch_all([{sql, params, opts} | acc])
+      {:lookup, query} -> drain_lookups([query | acc])
     after
       0 -> Enum.reverse(acc)
     end

--- a/server/test/tuist/tests_test.exs
+++ b/server/test/tuist/tests_test.exs
@@ -1264,7 +1264,7 @@ defmodule Tuist.TestsTest do
       assert test.is_ci == true
     end
 
-    test "looks up existing test cases via a single multipart array parameter for large batches" do
+    test "looks up existing test cases with a bounded multipart form-field count for large batches" do
       # Given
       project = ProjectsFixtures.project_fixture()
 
@@ -1278,42 +1278,56 @@ defmodule Tuist.TestsTest do
           }
         end
 
-      expect(ClickHouseRepo, :query, 3, fn sql, params, opts ->
-        assert Keyword.get(opts, :multipart) == true
+      parent = self()
 
-        # The IDs must be bound as a single `{ids:Array(UUID)}` parameter so the
-        # multipart request carries a constant number of form fields regardless
-        # of how many test cases the report contains.
-        assert sql =~ "test_cases"
+      stub(ClickHouseRepo, :query, fn sql, params, opts ->
+        send(parent, {:test_case_lookup, sql, params, opts})
+        {:ok, %{rows: []}}
+      end)
+
+      # When
+      assert {:ok, _test} = Tests.create_test(large_test_report(project, test_cases))
+
+      # Then
+      lookups = drain_test_case_lookups([])
+      assert lookups != []
+
+      for {sql, params, opts} <- lookups do
+        assert Keyword.get(opts, :multipart) == true
         assert sql =~ "{project_id:Int64}"
         assert sql =~ "{ids:Array(UUID)}"
         assert params["project_id"] == project.id
         assert is_list(params["ids"])
 
-        {:ok, %{rows: []}}
-      end)
+        # The whole batch travels as one `{ids:Array(UUID)}` parameter, so
+        # ClickHouse only ever parses a constant set of multipart form fields
+        # (query + project_id + ids) no matter how many test cases the report
+        # has. An `id in ^ids` clause binds one parameter per ID, which emits
+        # one form field per ID and overflows ClickHouse's form-field limit on
+        # large reports (`HTML Form Exception: Too many form fields`).
+        assert multipart_form_field_count(sql, params) == 3
+      end
+    end
 
-      test_attrs = %{
-        id: UUIDv7.generate(),
-        project_id: project.id,
-        account_id: project.account_id,
-        duration: 1500,
-        status: "success",
-        ran_at: NaiveDateTime.utc_now(),
-        is_ci: false,
-        test_modules: [
+    test "ingests a large test report end to end without exceeding ClickHouse multipart limits" do
+      # Given
+      project = ProjectsFixtures.project_fixture()
+
+      test_cases =
+        for index <- 1..5_001 do
           %{
-            name: "Module",
+            name: "test_#{index}",
             status: "success",
-            duration: 1500,
-            test_suites: [%{name: "Suite", status: "success", duration: 1500}],
-            test_cases: test_cases
+            duration: 10,
+            test_suite_name: "Suite"
           }
-        ]
-      }
+        end
 
-      # When/Then
-      assert {:ok, _test} = Tests.create_test(test_attrs)
+      # When/Then: the existing-test-case lookup runs against the real
+      # ClickHouse here (not a mock), so this fails if the IDs are sent in a way
+      # that trips either the form-field count or the per-field value-length
+      # limit (e.g. batching too aggressively).
+      assert {:ok, _test} = Tests.create_test(large_test_report(project, test_cases))
     end
 
     test "persists run_destinations as separate rows linked to the test run" do
@@ -8778,5 +8792,47 @@ defmodule Tuist.TestsTest do
 
       assert run.status == "success"
     end
+  end
+
+  defp large_test_report(project, test_cases) do
+    %{
+      id: UUIDv7.generate(),
+      project_id: project.id,
+      account_id: project.account_id,
+      duration: 1500,
+      status: "success",
+      ran_at: NaiveDateTime.utc_now(),
+      is_ci: false,
+      test_modules: [
+        %{
+          name: "Module",
+          status: "success",
+          duration: 1500,
+          test_suites: [%{name: "Suite", status: "success", duration: 1500}],
+          test_cases: test_cases
+        }
+      ]
+    }
+  end
+
+  defp drain_test_case_lookups(acc) do
+    receive do
+      {:test_case_lookup, sql, params, opts} ->
+        drain_test_case_lookups([{sql, params, opts} | acc])
+    after
+      0 -> Enum.reverse(acc)
+    end
+  end
+
+  defp multipart_form_field_count(sql, params) do
+    {_params, _headers, body} =
+      sql
+      |> Ch.Query.build(multipart: true)
+      |> DBConnection.Query.encode(params, [])
+
+    body
+    |> IO.iodata_to_binary()
+    |> then(&Regex.scan(~r/content-disposition: form-data; name=/, &1))
+    |> length()
   end
 end

--- a/server/test/tuist/tests_test.exs
+++ b/server/test/tuist/tests_test.exs
@@ -1280,31 +1280,34 @@ defmodule Tuist.TestsTest do
 
       parent = self()
 
-      stub(ClickHouseRepo, :query, fn sql, params, opts ->
-        send(parent, {:test_case_lookup, sql, params, opts})
-        {:ok, %{rows: []}}
+      stub(ClickHouseRepo, :all, fn query, opts ->
+        send(parent, {:ch_all, query, opts})
+        []
       end)
 
       # When
       assert {:ok, _test} = Tests.create_test(large_test_report(project, test_cases))
 
-      # Then
-      lookups = drain_test_case_lookups([])
+      # Then: isolate the existing-test-case lookups, the only reads on the
+      # test_cases table during ingestion.
+      lookups =
+        []
+        |> drain_ch_all()
+        |> Enum.filter(fn {sql, _params, _opts} -> sql =~ ~s["test_cases"] end)
+
       assert lookups != []
 
       for {sql, params, opts} <- lookups do
         assert Keyword.get(opts, :multipart) == true
-        assert sql =~ "{project_id:Int64}"
-        assert sql =~ "{ids:Array(UUID)}"
-        assert params["project_id"] == project.id
-        assert is_list(params["ids"])
+        assert sql =~ "Array(UUID)"
 
-        # The whole batch travels as one `{ids:Array(UUID)}` parameter, so
-        # ClickHouse only ever parses a constant set of multipart form fields
-        # (query + project_id + ids) no matter how many test cases the report
-        # has. An `id in ^ids` clause binds one parameter per ID, which emits
-        # one form field per ID and overflows ClickHouse's form-field limit on
-        # large reports (`HTML Form Exception: Too many form fields`).
+        # The whole batch travels as one array parameter (alongside project_id),
+        # so ClickHouse only ever parses a constant set of multipart form fields
+        # no matter how many test cases the report has. An `id in ^ids` clause
+        # binds one parameter per ID, which emits one form field per ID and
+        # overflows ClickHouse's form-field limit on large reports
+        # (`HTML Form Exception: Too many form fields`).
+        assert length(params) == 2
         assert multipart_form_field_count(sql, params) == 3
       end
     end
@@ -8815,10 +8818,11 @@ defmodule Tuist.TestsTest do
     }
   end
 
-  defp drain_test_case_lookups(acc) do
+  defp drain_ch_all(acc) do
     receive do
-      {:test_case_lookup, sql, params, opts} ->
-        drain_test_case_lookups([{sql, params, opts} | acc])
+      {:ch_all, query, opts} ->
+        {sql, params} = Ecto.Adapters.ClickHouse.to_sql(:all, query)
+        drain_ch_all([{sql, params, opts} | acc])
     after
       0 -> Enum.reverse(acc)
     end

--- a/server/test/tuist/tests_test.exs
+++ b/server/test/tuist/tests_test.exs
@@ -1264,7 +1264,7 @@ defmodule Tuist.TestsTest do
       assert test.is_ci == true
     end
 
-    test "uses multipart ClickHouse lookups for large test case batches" do
+    test "looks up existing test cases via a single multipart array parameter for large batches" do
       # Given
       project = ProjectsFixtures.project_fixture()
 
@@ -1278,17 +1278,19 @@ defmodule Tuist.TestsTest do
           }
         end
 
-      expect(ClickHouseRepo, :all, 2, fn query, opts ->
+      expect(ClickHouseRepo, :query, 3, fn sql, params, opts ->
         assert Keyword.get(opts, :multipart) == true
-        {sql, params} = Ecto.Adapters.ClickHouse.to_sql(:all, query)
 
-        assert sql =~ ~s[FROM "test_cases"]
-        assert sql =~ ~s["project_id"]
-        assert sql =~ ~s["id"]
-        assert project.id in params
-        assert length(params) > 1
+        # The IDs must be bound as a single `{ids:Array(UUID)}` parameter so the
+        # multipart request carries a constant number of form fields regardless
+        # of how many test cases the report contains.
+        assert sql =~ "test_cases"
+        assert sql =~ "{project_id:Int64}"
+        assert sql =~ "{ids:Array(UUID)}"
+        assert params["project_id"] == project.id
+        assert is_list(params["ids"])
 
-        []
+        {:ok, %{rows: []}}
       end)
 
       test_attrs = %{


### PR DESCRIPTION
## What changed

The existing-test-case lookup in `Tuist.Tests.get_existing_test_cases/2` now binds all test-case IDs as a single `Array(UUID)` ClickHouse parameter, instead of an Ecto `id in ^ids` clause that expands to one bound parameter per ID. It stays on Ecto primitives: `fragment("? IN (?)", tc.id, type(^ids_chunk, {:array, Ecto.UUID}))`.

## Why

Large `tuist inspect test` reports (for example an 8.8 MB xcresult with thousands of test cases) failed to ingest at `POST /api/projects/:account/:project/tests` with:

```
** (Ch.Error) Poco::Exception. Code: 1000, e.code() = 0, HTML Form Exception: Too many form fields
```

This is the same root cause as the earlier `431 Request Header Fields Too Large` failure that #10955 addressed, just shifted to a different limit.

The lookup built an Ecto query with `tc.id in ^ids_chunk`, which `ecto_ch` expands into one bound parameter per ID (`id IN ({$0:UUID}, {$1:UUID}, ...)`).

- Originally those parameters rode in the request URL/headers, so a large batch blew the header size limit (`431`).
- #10955 added `multipart: true`. But in multipart mode the `Ch` driver emits one form field per parameter (`param_$0`, `param_$1`, ...). A 5,000-ID batch produces about 5,001 form fields, which exceeds ClickHouse's Poco `HTMLForm` field-count limit (`Too many form fields`).

In both cases the failure mode is the same: the parameter count scaled with the number of test cases.

## Reproduction

Both failure modes were reproduced locally, before and after the fix.

Form-field count (the reported error). Encoding the lookup the way the `Ch` driver sends it and counting the multipart form fields:

| IDs | pre-fix (`id in ^ids`) form fields | fixed (single array param) form fields |
|-----|-----|-----|
| 10 | 12 | 3 |
| 100 | 102 | 3 |
| 1000 | 1002 | 3 |
| 5000 | 5002 | 3 |

The pre-fix lookup sends one form field per ID (5002 for a 5k-case report), which overflows the server's form-field limit. The fixed lookup is constant at 3 fields regardless of report size. The field-count regression test fails on the pre-fix implementation (its SQL is `id IN ({$1:String},{$2:String},...)`) and passes on the fix.

Per-field value length (a second, related limit found while probing). Sending the IDs as one array parameter must stay under ClickHouse's per-field value-length limit. Against a real ClickHouse, a single un-chunked request crosses it between 3,000 and 3,500 UUIDs:

```
n=3000 => :ok
n=3500 => Ch.Error ... HTML Form Exception: Field value too long
```

This is why the batch size is capped (see below); at 2,000 IDs the encoded value is about 78 KB, comfortably under the limit.

## The fix and why this approach

Binding the IDs as a single array parameter makes the request carry a constant number of form fields (`query` + `project_id` + `ids`) regardless of how many test cases the report contains, so neither the header-size nor the form-field-count limit can be tripped.

`ecto_ch` renders a pinned list inside a `fragment` as one array parameter rather than expanding it, and `type(^ids_chunk, {:array, Ecto.UUID})` types it as `Array(UUID)` (the generated SQL is `id IN (CAST({$1:Array(String)} AS Array(UUID)))`). Staying on Ecto primitives keeps the schema-typed `select` map, so `ecto_ch` continues to decode UUID, array, datetime, and boolean columns; there is no raw row mapping or manual UUID conversion.

The obvious alternative, keeping the per-ID `IN ^ids` clause but shrinking the batch below the form-field limit, was rejected: it would require dozens of sequential round trips per large report and stays fragile against an exact, version-dependent limit, whereas the single-array approach is robust by construction.

Notes:
- `multipart: true` is retained so the array travels in the request body and can't blow the header limit either.
- The batch size is lowered from 5,000 to 2,000 so the single array parameter's encoded value (about 78 KB) stays well under ClickHouse's per-field value-length limit.

## Impact

Self-hosted and managed servers can ingest test results from large reports without 500s. No API or schema changes.

### How to test locally

- `cd server && mix test test/tuist/tests_test.exs` (full suite: 223 tests, 0 failures).
- Two regression tests cover the failure modes above:
  - A field-count invariant test captures the lookup's Ecto query, asserts it binds a single `Array(UUID)` parameter, and that the encoded multipart body has a constant 3 form fields. It fails on the pre-fix code.
  - An end-to-end test ingests a 5,001-case report through `create_test/1` against the real ClickHouse, guarding the value-length limit and exercising row decoding at scale.