### PR TITLE
ci(infra): self-diagnosing 1Password fetch with rate-limit dump

### DIFF
--- a/.github/actions/op-document-get/action.yml
+++ b/.github/actions/op-document-get/action.yml
@@ -1,0 +1,81 @@
+name: op document get (with rate-limit diagnostics)
+description: >
+  Fetch a 1Password document to a file. On failure, dump the service
+  account's rate-limit counters and the verbose `op` error, then retry
+  with exponential backoff. Assumes the 1Password CLI is already on PATH
+  (install it with 1password/install-cli-action before calling this).
+
+  The diagnostics exist because canary deploys started getting 429
+  `Too many requests` on the kubeconfig fetch while the documented
+  hourly/daily quotas showed ample headroom. With OP_SERVICE_ACCOUNT_TOKEN
+  set, `op service-account ratelimit` reports the deploy account's own
+  counters, so a 429 shows which limit fired and whether USED climbs
+  across attempts (a continuous drain) or stays flat (a short-window or
+  sign-in throttle the published counters don't surface).
+
+inputs:
+  document:
+    description: 'Document title or ID to fetch, e.g. "kubeconfig: tuist-canary".'
+    required: true
+  vault:
+    description: Vault holding the document.
+    required: true
+  output:
+    description: File path to write the document to (chmod 600 on success).
+    required: true
+  service-account-token:
+    description: OP_SERVICE_ACCOUNT_TOKEN used for the fetch and the ratelimit dump.
+    required: true
+  max-attempts:
+    description: Attempts before giving up. Backoff is 15s, doubling each retry.
+    required: false
+    default: "4"
+
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      env:
+        OP_SERVICE_ACCOUNT_TOKEN: ${{ inputs.service-account-token }}
+        OP_DOCUMENT: ${{ inputs.document }}
+        OP_VAULT: ${{ inputs.vault }}
+        OP_OUTPUT: ${{ inputs.output }}
+        MAX_ATTEMPTS: ${{ inputs.max-attempts }}
+      run: |
+        set -uo pipefail
+        mkdir -p "$(dirname "$OP_OUTPUT")"
+
+        dump_ratelimit() {
+          echo "::group::op service-account ratelimit (after attempt $1)"
+          # No name arg: with OP_SERVICE_ACCOUNT_TOKEN set, this reports
+          # the deploy account's own counters. token read/write are
+          # per-token hourly; account read_write is the org-wide daily
+          # pool. A 429 with headroom on all three points at a limit
+          # 1Password doesn't surface here (open a support ticket with
+          # this dump plus the run URL).
+          op service-account ratelimit || echo "(ratelimit query itself failed)"
+          echo "::endgroup::"
+        }
+
+        attempt=1
+        backoff=15
+        while :; do
+          if err="$(op document get "$OP_DOCUMENT" --vault "$OP_VAULT" --output "$OP_OUTPUT" 2>&1)"; then
+            chmod 600 "$OP_OUTPUT"
+            echo "Fetched '$OP_DOCUMENT' from vault '$OP_VAULT' on attempt ${attempt}/${MAX_ATTEMPTS}."
+            exit 0
+          fi
+
+          echo "::warning::op document get '$OP_DOCUMENT' failed (attempt ${attempt}/${MAX_ATTEMPTS}): ${err}"
+          dump_ratelimit "$attempt"
+
+          if [ "$attempt" -ge "$MAX_ATTEMPTS" ]; then
+            echo "::error::op document get '$OP_DOCUMENT' failed after ${MAX_ATTEMPTS} attempts. Last error: ${err}"
+            exit 1
+          fi
+
+          echo "Retrying in ${backoff}s..."
+          sleep "$backoff"
+          attempt=$((attempt + 1))
+          backoff=$((backoff * 2))
+        done

--- a/.github/workflows/server-deployment.yml
+++ b/.github/workflows/server-deployment.yml
@@ -177,13 +177,12 @@ jobs:
           cache: "false"
       - uses: 1password/install-cli-action@v2
       - name: Load kubeconfig from 1Password
-        env:
-          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-        run: |
-          mkdir -p "$(dirname "$KUBECONFIG")"
-          op document get "kubeconfig: tuist-${{ inputs.environment }}" \
-            --vault "tuist-k8s-${{ inputs.environment }}" --output "$KUBECONFIG"
-          chmod 600 "$KUBECONFIG"
+        uses: ./.github/actions/op-document-get
+        with:
+          document: "kubeconfig: tuist-${{ inputs.environment }}"
+          vault: "tuist-k8s-${{ inputs.environment }}"
+          output: ${{ env.KUBECONFIG }}
+          service-account-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
       - name: Verify cluster reachability
         # Fail fast if the 1P-stored kubeconfig points at an unreachable
         # apiserver. Without this, the next step would hang for `--timeout`
@@ -261,13 +260,12 @@ jobs:
         uses: 1password/install-cli-action@v2
       - if: steps.check-values.outputs.exists == 'true'
         name: Load kubeconfig from 1Password
-        env:
-          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-        run: |
-          mkdir -p "$(dirname "$KUBECONFIG")"
-          op document get "kubeconfig: tuist-${{ inputs.environment }}" \
-            --vault "tuist-k8s-${{ inputs.environment }}" --output "$KUBECONFIG"
-          chmod 600 "$KUBECONFIG"
+        uses: ./.github/actions/op-document-get
+        with:
+          document: "kubeconfig: tuist-${{ inputs.environment }}"
+          vault: "tuist-k8s-${{ inputs.environment }}"
+          output: ${{ env.KUBECONFIG }}
+          service-account-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
       - if: steps.check-values.outputs.exists == 'true'
         name: Verify cluster reachability
         run: |
@@ -320,13 +318,12 @@ jobs:
           cache: "false"
       - uses: 1password/install-cli-action@v2
       - name: Load kubeconfig from 1Password
-        env:
-          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-        run: |
-          mkdir -p "$(dirname "$KUBECONFIG")"
-          op document get "kubeconfig: tuist-${{ inputs.environment }}" \
-            --vault "tuist-k8s-${{ inputs.environment }}" --output "$KUBECONFIG"
-          chmod 600 "$KUBECONFIG"
+        uses: ./.github/actions/op-document-get
+        with:
+          document: "kubeconfig: tuist-${{ inputs.environment }}"
+          vault: "tuist-k8s-${{ inputs.environment }}"
+          output: ${{ env.KUBECONFIG }}
+          service-account-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
       - name: Verify cluster reachability
         run: |
           set -euo pipefail
@@ -391,13 +388,12 @@ jobs:
           cache: "false"
       - uses: 1password/install-cli-action@v2
       - name: Load kubeconfig from 1Password
-        env:
-          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-        run: |
-          mkdir -p "$(dirname "$KUBECONFIG")"
-          op document get "kubeconfig: tuist-${{ inputs.environment }}" \
-            --vault "tuist-k8s-${{ inputs.environment }}" --output "$KUBECONFIG"
-          chmod 600 "$KUBECONFIG"
+        uses: ./.github/actions/op-document-get
+        with:
+          document: "kubeconfig: tuist-${{ inputs.environment }}"
+          vault: "tuist-k8s-${{ inputs.environment }}"
+          output: ${{ env.KUBECONFIG }}
+          service-account-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
       - name: Verify cluster reachability
         # Fail fast if the 1P-stored kubeconfig points at an unreachable
         # apiserver. Without this, helm upgrade would hang for `--timeout`


### PR DESCRIPTION
## Summary

Canary deploys are failing with `Too many requests` on the kubeconfig `op document get`, but the documented 1Password quotas show ample headroom and the failure reproduces on a **single isolated call** with no concurrency. So it's not a CI burst, and the binding limit isn't one the published counters surface. We can't diagnose it further from a laptop because `op service-account ratelimit` only reports the account whose token is in the **local** shell's env, not the one wired to the `server-k8s-<env>` GitHub environment.

This adds a `op-document-get` composite action that wraps the fetch and, on failure, dumps `op service-account ratelimit` for the **real deploy account** (CI has the right token in `OP_SERVICE_ACCOUNT_TOKEN`) plus the verbose `op` error, retrying with backoff. The four kubeconfig fetch steps in [server-deployment.yml](.github/workflows/server-deployment.yml) now call it.

## Why

Three rounds of investigation narrowed this down:
1. Burst theory (3 parallel fetches) — **disproven**: a single isolated call still 429s.
2. Quota exhaustion — **disproven by the numbers**: org-wide daily pool at ~5k/50k, per-token reads 0/10k.
3. The local `ratelimit` snapshots were the **wrong account** — the command reports the locally-authenticated token, and the name argument doesn't differentiate (five different names returned byte-identical counters).

So the next step isn't more theorizing — it's capturing the real account's counters at the **moment of failure**, which only CI can do.

## What the dump tells us

On each failed attempt the action prints the `ratelimit` table. Reading the trajectory across retries:
- **USED climbs** toward a ceiling → a continuous drain (likely ESO on the same token) exhausting a documented limit.
- **USED stays flat with headroom** → a short-window or sign-in throttle 1Password doesn't expose in these counters → escalate to 1Password support with the dump + run URL.

## Design notes

- Composite action (matches the existing `.github/actions/setup-server-mix` pattern), so the four fetch sites stay DRY and it survives the job restructure proposed in #10975.
- Assumes `op` is already on PATH (every caller installs it via `1password/install-cli-action` first).
- Secret-safe: the kubeconfig is written to `--output` (never stdout); the dumped `ratelimit` output and `op` error contain no secret material.
- Retry/backoff (15s, 30s, 60s; 4 attempts) is best-effort resilience. Honest caveat: if this is the multi-minute block some 1Password users report, a few retries won't clear it — but the dump still lands as evidence.

## Scope

Only the four kubeconfig fetches are wired (the failing path). The two Kura kubeconfig fetches in the deploy job run later in the same job and haven't been the failure point; wrapping them is a trivial follow-up if needed.

## Validation

- `actionlint` parses the workflow with no new findings (only the pre-existing custom self-hosted-runner-label warnings).
- `shellcheck` clean on the action's script.
- Both YAML files parse; the action exposes `document` / `vault` / `output` / `service-account-token` / `max-attempts` inputs.

## Test plan

- [ ] Re-run a canary deploy. If it 429s, the `Load kubeconfig from 1Password` step now shows the `op service-account ratelimit` table for the deploy account on each attempt.
- [ ] Read the trajectory: climbing USED vs flat-with-headroom, and which row (`token read` / `token write` / `account read_write`) is binding.
- [ ] If flat-with-headroom, attach the dump to a 1Password support ticket.