### PR TITLE
perf(server): speed up LiveView dashboard cold start

### DIFF
--- a/server/assets/app/app.js
+++ b/server/assets/app/app.js
@@ -63,8 +63,13 @@ observeThemeChanges();
 Hooks.ThemeSwitcher = ThemeSwitcher;
 Hooks.ThemeToggle = ThemeToggle;
 
+// On localhost, the WS drops every time the dev server restarts or the
+// live reloader fires. With longpoll fallback enabled, the client gives
+// up on WS too quickly and pins itself to longpoll, which then loops
+// into `exceeded 10 consecutive reloads. Entering failsafe mode`. See
+// https://elixirforum.com/t/liveview-falls-back-to-longpoll-after-dev-server-restart/61736
 let liveSocket = new LiveSocket("/live", Socket, {
-  longPollFallbackMs: 2500,
+  longPollFallbackMs: window.location.host.startsWith("localhost") ? undefined : 2500,
   params: {
     _csrf_token: csrfToken,
     _csp_nonce: cspNonce,

--- a/server/lib/tuist/projects.ex
+++ b/server/lib/tuist/projects.ex
@@ -77,24 +77,17 @@ defmodule Tuist.Projects do
   end
 
   def get_project_by_account_and_project_handles(account_handle, project_handle, opts \\ []) do
-    with {:account, %{id: account_id}} <-
-           {:account,
-            Repo.one(
-              from a in Account,
-                where: a.name == ^account_handle
-            )},
-         {:project, project} <-
-           {:project,
-            Repo.one(
-              from(p in Project,
-                where: p.name == ^project_handle,
-                where: p.account_id == ^account_id
-              )
-            )} do
-      Repo.preload(project, Keyword.get(opts, :preload, [:account]))
-    else
-      {:account, nil} -> nil
-      {:project, nil} -> nil
+    extra_preloads = Keyword.get(opts, :preload, [:account]) -- [:account]
+
+    case Repo.one(
+           from p in Project,
+             join: a in assoc(p, :account),
+             where: a.name == ^account_handle and p.name == ^project_handle,
+             preload: [account: a]
+         ) do
+      nil -> nil
+      project when extra_preloads == [] -> project
+      project -> Repo.preload(project, extra_preloads)
     end
   end
 

--- a/server/lib/tuist/projects.ex
+++ b/server/lib/tuist/projects.ex
@@ -77,7 +77,8 @@ defmodule Tuist.Projects do
   end
 
   def get_project_by_account_and_project_handles(account_handle, project_handle, opts \\ []) do
-    extra_preloads = Keyword.get(opts, :preload, [:account]) -- [:account]
+    preloads = Keyword.get(opts, :preload, [:account])
+    extra_preloads = Enum.reject(preloads, &(&1 == :account))
 
     case Repo.one(
            from p in Project,
@@ -86,7 +87,6 @@ defmodule Tuist.Projects do
              preload: [account: a]
          ) do
       nil -> nil
-      project when extra_preloads == [] -> project
       project -> Repo.preload(project, extra_preloads)
     end
   end

--- a/server/lib/tuist_web/app.ex
+++ b/server/lib/tuist_web/app.ex
@@ -21,14 +21,12 @@ defmodule TuistWeb.App do
         Accounts.get_user_by_session_token(session["user_token"], preload: [:account])
       end
 
-    TuistWeb.Authorization.require_user_can_read_project(%{
-      user: user,
-      account_handle: owner_handle,
-      project_handle: project_handle
-    })
-
     project =
-      Projects.get_project_by_account_and_project_handles(owner_handle, project_handle)
+      TuistWeb.Authorization.require_user_can_read_project(%{
+        user: user,
+        account_handle: owner_handle,
+        project_handle: project_handle
+      })
 
     projects =
       if is_nil(user) do

--- a/server/lib/tuist_web/authorization.ex
+++ b/server/lib/tuist_web/authorization.ex
@@ -101,6 +101,18 @@ defmodule TuistWeb.Authorization do
   def require_user_can_read_project(%{user: user, account_handle: account_handle, project_handle: project_handle}) do
     project = Projects.get_project_by_account_and_project_handles(account_handle, project_handle)
 
+    authorize_project!(user, project)
+
+    project
+  end
+
+  def require_user_can_read_project(%{user: user, project: project}) do
+    authorize_project!(user, project)
+
+    project
+  end
+
+  defp authorize_project!(user, project) do
     if is_nil(project) or Authorization.authorize(:dashboard_read, user, project) != :ok do
       raise NotFoundError,
             "The page you are looking for doesn't exist or has been moved."

--- a/server/lib/tuist_web/live/layout_live.ex
+++ b/server/lib/tuist_web/live/layout_live.ex
@@ -43,33 +43,35 @@ defmodule TuistWeb.LayoutLive do
       when is_binary(account_handle) and is_binary(project_handle) do
     current_user = get_current_user(session)
 
-    TuistWeb.Authorization.require_user_can_read_project(%{
-      user: current_user,
-      account_handle: account_handle,
-      project_handle: project_handle
-    })
-
     selected_project =
-      Map.get(
-        socket.assigns,
-        :selected_project,
-        Projects.get_project_by_account_and_project_handles(account_handle, project_handle, preload: [:account])
-      )
+      case Map.get(socket.assigns, :selected_project) do
+        nil ->
+          TuistWeb.Authorization.require_user_can_read_project(%{
+            user: current_user,
+            account_handle: account_handle,
+            project_handle: project_handle
+          })
 
-    if is_nil(selected_project) do
-      raise NotFoundError,
-            dgettext("dashboard", "The project you are looking for doesn't exist or has been moved.")
-    end
+        project ->
+          TuistWeb.Authorization.require_user_can_read_project(%{user: current_user, project: project})
+      end
 
     %{account: selected_account} = selected_project
 
-    selected_projects = get_projects(selected_account, current_user)
+    # Dropdown contents only matter once the user can click them, so defer
+    # the queries until the LiveView is connected.
+    {selected_projects, current_user_accounts} =
+      if connected?(socket) do
+        organization_accounts =
+          if is_nil(current_user) do
+            []
+          else
+            get_user_organization_accounts(current_user) ++ [current_user.account]
+          end
 
-    current_user_accounts =
-      if is_nil(current_user) do
-        []
+        {get_projects(selected_account, current_user), organization_accounts}
       else
-        get_user_organization_accounts(current_user) ++ [current_user.account]
+        {[], []}
       end
 
     {:cont,
@@ -139,8 +141,13 @@ defmodule TuistWeb.LayoutLive do
   def on_mount(:account, params, session, socket) do
     current_user = get_current_user(session)
 
+    # Deferred until connected — see :project.
     current_user_accounts =
-      get_user_organization_accounts(current_user) ++ [current_user.account]
+      if connected?(socket) do
+        get_user_organization_accounts(current_user) ++ [current_user.account]
+      else
+        []
+      end
 
     selected_account =
       case Map.get(params, "account_handle") do

--- a/server/lib/tuist_web/live/layout_live.ex
+++ b/server/lib/tuist_web/live/layout_live.ex
@@ -8,12 +8,30 @@ defmodule TuistWeb.LayoutLive do
   import Phoenix.Component
   import TuistWeb.AppLayoutComponents
 
+  require Logger
+
   alias Tuist.Accounts
   alias Tuist.Authorization
   alias Tuist.CommandEvents
   alias Tuist.GitHub.Releases
   alias Tuist.Projects
   alias TuistWeb.Errors.NotFoundError
+
+  # TEMP investigation: time each step of the connected mount so we can
+  # spot which one is responsible for the >10s LV join timeouts users
+  # report when switching between projects. Revert once diagnosed.
+  defp lvt(label, socket, fun) do
+    {micros, result} = :timer.tc(fun)
+    ms = div(micros, 1000)
+
+    if ms >= 50 or connected?(socket) do
+      Logger.warning(
+        "[lv-timing] #{label} connected=#{connected?(socket)} took=#{ms}ms"
+      )
+    end
+
+    result
+  end
 
   def on_mount(
         :optional_project,
@@ -41,20 +59,22 @@ defmodule TuistWeb.LayoutLive do
         socket
       )
       when is_binary(account_handle) and is_binary(project_handle) do
-    current_user = get_current_user(session)
+    current_user = lvt("project.get_current_user", socket, fn -> get_current_user(session) end)
 
     selected_project =
-      case Map.get(socket.assigns, :selected_project) do
-        nil ->
-          TuistWeb.Authorization.require_user_can_read_project(%{
-            user: current_user,
-            account_handle: account_handle,
-            project_handle: project_handle
-          })
+      lvt("project.require_user_can_read_project", socket, fn ->
+        case Map.get(socket.assigns, :selected_project) do
+          nil ->
+            TuistWeb.Authorization.require_user_can_read_project(%{
+              user: current_user,
+              account_handle: account_handle,
+              project_handle: project_handle
+            })
 
-        project ->
-          TuistWeb.Authorization.require_user_can_read_project(%{user: current_user, project: project})
-      end
+          project ->
+            TuistWeb.Authorization.require_user_can_read_project(%{user: current_user, project: project})
+        end
+      end)
 
     %{account: selected_account} = selected_project
 
@@ -62,14 +82,16 @@ defmodule TuistWeb.LayoutLive do
     # the queries until the LiveView is connected.
     {selected_projects, current_user_accounts} =
       if connected?(socket) do
-        organization_accounts =
-          if is_nil(current_user) do
-            []
-          else
-            get_user_organization_accounts(current_user) ++ [current_user.account]
-          end
+        lvt("project.dropdown_queries", socket, fn ->
+          organization_accounts =
+            if is_nil(current_user) do
+              []
+            else
+              get_user_organization_accounts(current_user) ++ [current_user.account]
+            end
 
-        {get_projects(selected_account, current_user), organization_accounts}
+          {get_projects(selected_account, current_user), organization_accounts}
+        end)
       else
         {[], []}
       end
@@ -139,21 +161,25 @@ defmodule TuistWeb.LayoutLive do
   end
 
   def on_mount(:account, params, session, socket) do
-    current_user = get_current_user(session)
+    current_user = lvt("account.get_current_user", socket, fn -> get_current_user(session) end)
 
     # Deferred until connected — see :project.
     current_user_accounts =
       if connected?(socket) do
-        get_user_organization_accounts(current_user) ++ [current_user.account]
+        lvt("account.dropdown_queries", socket, fn ->
+          get_user_organization_accounts(current_user) ++ [current_user.account]
+        end)
       else
         []
       end
 
     selected_account =
-      case Map.get(params, "account_handle") do
-        handle when is_binary(handle) -> Accounts.get_account_by_handle(handle)
-        _ -> current_user.account
-      end
+      lvt("account.get_account_by_handle", socket, fn ->
+        case Map.get(params, "account_handle") do
+          handle when is_binary(handle) -> Accounts.get_account_by_handle(handle)
+          _ -> current_user.account
+        end
+      end)
 
     if is_nil(selected_account) do
       raise NotFoundError,

--- a/server/lib/tuist_web/live/layout_live.ex
+++ b/server/lib/tuist_web/live/layout_live.ex
@@ -53,7 +53,15 @@ defmodule TuistWeb.LayoutLive do
           })
 
         project ->
-          TuistWeb.Authorization.require_user_can_read_project(%{user: current_user, project: project})
+          if project_matches_handles?(project, account_handle, project_handle) do
+            TuistWeb.Authorization.require_user_can_read_project(%{user: current_user, project: project})
+          else
+            TuistWeb.Authorization.require_user_can_read_project(%{
+              user: current_user,
+              account_handle: account_handle,
+              project_handle: project_handle
+            })
+          end
       end
 
     %{account: selected_account} = selected_project
@@ -217,6 +225,15 @@ defmodule TuistWeb.LayoutLive do
       user |> Accounts.get_user_organization_accounts() |> Enum.map(& &1.account)
     end
   end
+
+  defp project_matches_handles?(
+         %{account: %{name: account_handle}, name: project_handle},
+         account_handle,
+         project_handle
+       ),
+    do: true
+
+  defp project_matches_handles?(_project, _account_handle, _project_handle), do: false
 
   defp assign_current_path(socket) do
     attach_hook(socket, :assign_current_path, :handle_params, fn _params, url, socket ->

--- a/server/lib/tuist_web/live/layout_live.ex
+++ b/server/lib/tuist_web/live/layout_live.ex
@@ -8,30 +8,12 @@ defmodule TuistWeb.LayoutLive do
   import Phoenix.Component
   import TuistWeb.AppLayoutComponents
 
-  require Logger
-
   alias Tuist.Accounts
   alias Tuist.Authorization
   alias Tuist.CommandEvents
   alias Tuist.GitHub.Releases
   alias Tuist.Projects
   alias TuistWeb.Errors.NotFoundError
-
-  # TEMP investigation: time each step of the connected mount so we can
-  # spot which one is responsible for the >10s LV join timeouts users
-  # report when switching between projects. Revert once diagnosed.
-  defp lvt(label, socket, fun) do
-    {micros, result} = :timer.tc(fun)
-    ms = div(micros, 1000)
-
-    if ms >= 50 or connected?(socket) do
-      Logger.warning(
-        "[lv-timing] #{label} connected=#{connected?(socket)} took=#{ms}ms"
-      )
-    end
-
-    result
-  end
 
   def on_mount(
         :optional_project,
@@ -59,22 +41,20 @@ defmodule TuistWeb.LayoutLive do
         socket
       )
       when is_binary(account_handle) and is_binary(project_handle) do
-    current_user = lvt("project.get_current_user", socket, fn -> get_current_user(session) end)
+    current_user = get_current_user(session)
 
     selected_project =
-      lvt("project.require_user_can_read_project", socket, fn ->
-        case Map.get(socket.assigns, :selected_project) do
-          nil ->
-            TuistWeb.Authorization.require_user_can_read_project(%{
-              user: current_user,
-              account_handle: account_handle,
-              project_handle: project_handle
-            })
+      case Map.get(socket.assigns, :selected_project) do
+        nil ->
+          TuistWeb.Authorization.require_user_can_read_project(%{
+            user: current_user,
+            account_handle: account_handle,
+            project_handle: project_handle
+          })
 
-          project ->
-            TuistWeb.Authorization.require_user_can_read_project(%{user: current_user, project: project})
-        end
-      end)
+        project ->
+          TuistWeb.Authorization.require_user_can_read_project(%{user: current_user, project: project})
+      end
 
     %{account: selected_account} = selected_project
 
@@ -82,16 +62,14 @@ defmodule TuistWeb.LayoutLive do
     # the queries until the LiveView is connected.
     {selected_projects, current_user_accounts} =
       if connected?(socket) do
-        lvt("project.dropdown_queries", socket, fn ->
-          organization_accounts =
-            if is_nil(current_user) do
-              []
-            else
-              get_user_organization_accounts(current_user) ++ [current_user.account]
-            end
+        organization_accounts =
+          if is_nil(current_user) do
+            []
+          else
+            get_user_organization_accounts(current_user) ++ [current_user.account]
+          end
 
-          {get_projects(selected_account, current_user), organization_accounts}
-        end)
+        {get_projects(selected_account, current_user), organization_accounts}
       else
         {[], []}
       end
@@ -161,25 +139,21 @@ defmodule TuistWeb.LayoutLive do
   end
 
   def on_mount(:account, params, session, socket) do
-    current_user = lvt("account.get_current_user", socket, fn -> get_current_user(session) end)
+    current_user = get_current_user(session)
 
     # Deferred until connected — see :project.
     current_user_accounts =
       if connected?(socket) do
-        lvt("account.dropdown_queries", socket, fn ->
-          get_user_organization_accounts(current_user) ++ [current_user.account]
-        end)
+        get_user_organization_accounts(current_user) ++ [current_user.account]
       else
         []
       end
 
     selected_account =
-      lvt("account.get_account_by_handle", socket, fn ->
-        case Map.get(params, "account_handle") do
-          handle when is_binary(handle) -> Accounts.get_account_by_handle(handle)
-          _ -> current_user.account
-        end
-      end)
+      case Map.get(params, "account_handle") do
+        handle when is_binary(handle) -> Accounts.get_account_by_handle(handle)
+        _ -> current_user.account
+      end
 
     if is_nil(selected_account) do
       raise NotFoundError,

--- a/server/lib/tuist_web/live/layout_live.ex
+++ b/server/lib/tuist_web/live/layout_live.ex
@@ -37,11 +37,11 @@ defmodule TuistWeb.LayoutLive do
   def on_mount(
         :project,
         %{"account_handle" => account_handle, "project_handle" => project_handle} = params,
-        session,
+        _session,
         socket
       )
       when is_binary(account_handle) and is_binary(project_handle) do
-    current_user = get_current_user(session)
+    current_user = socket.assigns[:current_user]
 
     selected_project =
       case Map.get(socket.assigns, :selected_project) do
@@ -138,8 +138,8 @@ defmodule TuistWeb.LayoutLive do
      |> assign_selected_run(params)}
   end
 
-  def on_mount(:account, params, session, socket) do
-    current_user = get_current_user(session)
+  def on_mount(:account, params, _session, socket) do
+    current_user = socket.assigns[:current_user]
 
     # Deferred until connected — see :project.
     current_user_accounts =
@@ -199,8 +199,8 @@ defmodule TuistWeb.LayoutLive do
      |> assign(:current_user_accounts, current_user_accounts)}
   end
 
-  def on_mount(:ops, _params, session, socket) do
-    current_user = get_current_user(session)
+  def on_mount(:ops, _params, _session, socket) do
+    current_user = socket.assigns[:current_user]
 
     {:cont,
      socket
@@ -239,19 +239,6 @@ defmodule TuistWeb.LayoutLive do
       user_belongs_to_account? or project.visibility == :public
     end)
     |> Enum.map(&%{&1.project | account: &1.account})
-  end
-
-  defp get_current_user(session) do
-    user_token = session["user_token"]
-
-    user =
-      if is_nil(user_token) do
-        nil
-      else
-        Accounts.get_user_by_session_token(session["user_token"], preload: [:account])
-      end
-
-    user
   end
 
   defp assign_selected_run(socket, params) do

--- a/server/lib/tuist_web/live/layout_live.ex
+++ b/server/lib/tuist_web/live/layout_live.ex
@@ -230,8 +230,7 @@ defmodule TuistWeb.LayoutLive do
          %{account: %{name: account_handle}, name: project_handle},
          account_handle,
          project_handle
-       ),
-    do: true
+       ), do: true
 
   defp project_matches_handles?(_project, _account_handle, _project_handle), do: false
 

--- a/server/lib/tuist_web/live/overview_live.ex
+++ b/server/lib/tuist_web/live/overview_live.ex
@@ -3,11 +3,15 @@ defmodule TuistWeb.OverviewLive do
   use TuistWeb, :live_view
   use Noora
 
+  require Logger
+
   alias Tuist.Projects.Project
   alias TuistWeb.Helpers.OpenGraph
   alias TuistWeb.Utilities.Query
 
   def mount(_params, _session, %{assigns: %{selected_project: project, selected_account: account}} = socket) do
+    start = System.monotonic_time(:millisecond)
+
     socket =
       socket
       |> assign(
@@ -22,6 +26,10 @@ defmodule TuistWeb.OverviewLive do
       else
         TuistWeb.XcodeOverviewLive.assign_mount(socket)
       end
+
+    Logger.warning(
+      "[lv-timing] OverviewLive.mount connected=#{connected?(socket)} took=#{System.monotonic_time(:millisecond) - start}ms"
+    )
 
     {:ok, socket}
   end
@@ -81,6 +89,7 @@ defmodule TuistWeb.OverviewLive do
   end
 
   def handle_params(_params, request_uri, %{assigns: %{selected_project: project}} = socket) do
+    start = System.monotonic_time(:millisecond)
     params = Query.query_params(request_uri)
     full_uri = URI.parse(request_uri)
 
@@ -90,6 +99,10 @@ defmodule TuistWeb.OverviewLive do
       else
         TuistWeb.XcodeOverviewLive.assign_handle_params(socket, params, full_uri.path)
       end
+
+    Logger.warning(
+      "[lv-timing] OverviewLive.handle_params connected=#{connected?(socket)} took=#{System.monotonic_time(:millisecond) - start}ms"
+    )
 
     {:noreply, socket}
   end

--- a/server/lib/tuist_web/live/overview_live.ex
+++ b/server/lib/tuist_web/live/overview_live.ex
@@ -3,15 +3,11 @@ defmodule TuistWeb.OverviewLive do
   use TuistWeb, :live_view
   use Noora
 
-  require Logger
-
   alias Tuist.Projects.Project
   alias TuistWeb.Helpers.OpenGraph
   alias TuistWeb.Utilities.Query
 
   def mount(_params, _session, %{assigns: %{selected_project: project, selected_account: account}} = socket) do
-    start = System.monotonic_time(:millisecond)
-
     socket =
       socket
       |> assign(
@@ -26,10 +22,6 @@ defmodule TuistWeb.OverviewLive do
       else
         TuistWeb.XcodeOverviewLive.assign_mount(socket)
       end
-
-    Logger.warning(
-      "[lv-timing] OverviewLive.mount connected=#{connected?(socket)} took=#{System.monotonic_time(:millisecond) - start}ms"
-    )
 
     {:ok, socket}
   end
@@ -89,7 +81,6 @@ defmodule TuistWeb.OverviewLive do
   end
 
   def handle_params(_params, request_uri, %{assigns: %{selected_project: project}} = socket) do
-    start = System.monotonic_time(:millisecond)
     params = Query.query_params(request_uri)
     full_uri = URI.parse(request_uri)
 
@@ -99,10 +90,6 @@ defmodule TuistWeb.OverviewLive do
       else
         TuistWeb.XcodeOverviewLive.assign_handle_params(socket, params, full_uri.path)
       end
-
-    Logger.warning(
-      "[lv-timing] OverviewLive.handle_params connected=#{connected?(socket)} took=#{System.monotonic_time(:millisecond) - start}ms"
-    )
 
     {:noreply, socket}
   end

--- a/server/package.json
+++ b/server/package.json
@@ -13,7 +13,7 @@
       "vue-demi"
     ],
     "overrides": {
-      "axios": "1.15.2",
+      "axios": "1.16.0",
       "mdast-util-to-hast": "13.2.1",
       "ajv": "8.18.0",
       "dompurify": "3.4.0",

--- a/server/pnpm-lock.yaml
+++ b/server/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 overrides:
   ajv: 8.18.0
-  axios: 1.15.2
+  axios: 1.16.0
   defu: 6.1.5
   dompurify: 3.4.0
   fast-uri: 3.1.2
@@ -21,7 +21,7 @@ time:
   '@protobufjs/codegen@2.0.5': 2026-04-27T20:30:11.789Z
   '@protobufjs/inquire@1.1.1': 2026-04-27T20:32:10.012Z
   '@protobufjs/utf8@1.1.1': 2026-04-27T20:31:28.490Z
-  axios@1.15.2: 2026-04-21T17:53:03.731Z
+  axios@1.16.0: 2026-05-02T15:04:00.274Z
   fast-uri@3.1.2: 2026-05-05T08:31:31.849Z
   protobufjs@7.5.8: 2026-05-12T09:40:11.300Z
 
@@ -603,8 +603,8 @@ packages:
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
-  axios@1.15.2:
-    resolution: {integrity: sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==}
+  axios@1.16.0:
+    resolution: {integrity: sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==}
 
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
@@ -1906,7 +1906,7 @@ snapshots:
       '@scalar/workspace-store': 0.44.0
       '@types/har-format': 1.2.16
       '@vueuse/core': 13.9.0(vue@3.5.30(typescript@5.9.3))
-      '@vueuse/integrations': 13.9.0(axios@1.15.2)(focus-trap@7.8.0)(fuse.js@7.1.0)(vue@3.5.30(typescript@5.9.3))
+      '@vueuse/integrations': 13.9.0(axios@1.16.0)(focus-trap@7.8.0)(fuse.js@7.1.0)(vue@3.5.30(typescript@5.9.3))
       focus-trap: 7.8.0
       fuse.js: 7.1.0
       js-base64: 3.7.8
@@ -2317,13 +2317,13 @@ snapshots:
       '@vueuse/shared': 13.9.0(vue@3.5.30(typescript@5.9.3))
       vue: 3.5.30(typescript@5.9.3)
 
-  '@vueuse/integrations@13.9.0(axios@1.15.2)(focus-trap@7.8.0)(fuse.js@7.1.0)(vue@3.5.30(typescript@5.9.3))':
+  '@vueuse/integrations@13.9.0(axios@1.16.0)(focus-trap@7.8.0)(fuse.js@7.1.0)(vue@3.5.30(typescript@5.9.3))':
     dependencies:
       '@vueuse/core': 13.9.0(vue@3.5.30(typescript@5.9.3))
       '@vueuse/shared': 13.9.0(vue@3.5.30(typescript@5.9.3))
       vue: 3.5.30(typescript@5.9.3)
     optionalDependencies:
-      axios: 1.15.2
+      axios: 1.16.0
       focus-trap: 7.8.0
       fuse.js: 7.1.0
 
@@ -2371,7 +2371,7 @@ snapshots:
 
   asynckit@0.4.0: {}
 
-  axios@1.15.2:
+  axios@1.16.0:
     dependencies:
       follow-redirects: 1.16.0(debug@4.4.1)
       form-data: 4.0.5
@@ -3383,7 +3383,7 @@ snapshots:
   typesense@3.0.5(@babel/runtime@7.29.2):
     dependencies:
       '@babel/runtime': 7.29.2
-      axios: 1.15.2
+      axios: 1.16.0
       loglevel: 1.9.2
       tslib: 2.8.1
     transitivePeerDependencies:

--- a/server/test/tuist/projects_test.exs
+++ b/server/test/tuist/projects_test.exs
@@ -452,6 +452,37 @@ defmodule Tuist.ProjectsTest do
 
       # Then
       assert got == project
+      assert Ecto.assoc_loaded?(got.account)
+      assert got.account.id == account.id
+    end
+
+    test "preloads extra associations" do
+      # Given
+      organization = AccountsFixtures.organization_fixture()
+      account = Accounts.get_account_from_organization(organization)
+
+      ProjectsFixtures.project_fixture(
+        account_id: account.id,
+        name: "tuist",
+        vcs_connection: [
+          provider: :github,
+          repository_full_handle: "tuist/tuist"
+        ]
+      )
+
+      # When
+      got =
+        Projects.get_project_by_account_and_project_handles(
+          account.name,
+          "tuist",
+          preload: [:account, :vcs_connection]
+        )
+
+      # Then
+      assert Ecto.assoc_loaded?(got.account)
+      assert Ecto.assoc_loaded?(got.vcs_connection)
+      assert got.account.id == account.id
+      assert got.vcs_connection.repository_full_handle == "tuist/tuist"
     end
   end
 

--- a/server/test/tuist_web/authorization_test.exs
+++ b/server/test/tuist_web/authorization_test.exs
@@ -228,5 +228,35 @@ defmodule TuistWeb.AuthorizationTest do
         project_handle: project.name
       })
     end
+
+    test "returns the project if a user can read the given project struct", %{user: user} do
+      # Given
+      project = ProjectsFixtures.project_fixture(account_id: user.account.id)
+
+      # When
+      got =
+        Authorization.require_user_can_read_project(%{
+          user: user,
+          project: project
+        })
+
+      # Then
+      assert got == project
+    end
+
+    test "raises NotFoundError if a user can't read the given project struct", %{user: user} do
+      # Given
+      organization = AccountsFixtures.organization_fixture()
+      account = Accounts.get_account_from_organization(organization)
+      project = ProjectsFixtures.project_fixture(account_id: account.id)
+
+      # When / Then
+      assert_raise NotFoundError, fn ->
+        Authorization.require_user_can_read_project(%{
+          user: user,
+          project: project
+        })
+      end
+    end
   end
 end

--- a/server/test/tuist_web/live/layout_live_test.exs
+++ b/server/test/tuist_web/live/layout_live_test.exs
@@ -442,13 +442,13 @@ defmodule TuistWeb.LayoutLiveTest do
     end
   end
 
-  defp connected_socket(assigns \\ []) do
+  defp connected_socket(assigns) do
     Enum.reduce(assigns, %LiveView.Socket{transport_pid: self()}, fn {key, value}, socket ->
       Phoenix.Component.assign(socket, key, value)
     end)
   end
 
-  defp disconnected_socket(assigns \\ []) do
+  defp disconnected_socket(assigns) do
     Enum.reduce(assigns, %LiveView.Socket{}, fn {key, value}, socket ->
       Phoenix.Component.assign(socket, key, value)
     end)

--- a/server/test/tuist_web/live/layout_live_test.exs
+++ b/server/test/tuist_web/live/layout_live_test.exs
@@ -171,6 +171,58 @@ defmodule TuistWeb.LayoutLiveTest do
     end
 
     @tag user_role: :user
+    test "defers dropdown assigns when the socket is disconnected", %{
+      params: params,
+      session: session,
+      user: user,
+      project: project
+    } do
+      # Given/When
+      {:cont, socket} =
+        LayoutLive.on_mount(
+          :project,
+          params,
+          session,
+          disconnected_socket(current_user: user)
+        )
+
+      # Then
+      assert socket.assigns.selected_project == project
+      assert socket.assigns.selected_projects == []
+
+      [account_breadcrumb, project_breadcrumb] = socket.assigns.breadcrumbs
+      assert account_breadcrumb.items == []
+      assert project_breadcrumb.items == []
+    end
+
+    @tag user_role: :user
+    test "uses the requested project when a cached project has different handles", %{
+      params: params,
+      session: session,
+      user: user,
+      project: project
+    } do
+      # Given
+      cached_project =
+        ProjectsFixtures.project_fixture(
+          account_id: user.account.id,
+          preload: [:account]
+        )
+
+      # When
+      {:cont, socket} =
+        LayoutLive.on_mount(
+          :project,
+          params,
+          session,
+          connected_socket(current_user: user, selected_project: cached_project)
+        )
+
+      # Then
+      assert socket.assigns.selected_project == project
+    end
+
+    @tag user_role: :user
     test "uses the session locale for translated dashboard labels", %{
       params: params,
       session: session,
@@ -235,6 +287,26 @@ defmodule TuistWeb.LayoutLiveTest do
       assert socket.assigns.selected_account == user.account
       assert socket.assigns.current_user_accounts == [user.account]
       assert socket.assigns.can_read_billing == true
+    end
+
+    test "defers account dropdown assigns when the socket is disconnected", %{
+      session: session,
+      user: user
+    } do
+      # Given/When
+      {:cont, socket} =
+        LayoutLive.on_mount(
+          :account,
+          %{},
+          session,
+          disconnected_socket(current_user: user)
+        )
+
+      # Then
+      assert socket.assigns.current_user_accounts == []
+
+      [account_breadcrumb] = socket.assigns.breadcrumbs
+      assert account_breadcrumb.items == []
     end
 
     @tag user_role: :user

--- a/server/test/tuist_web/live/layout_live_test.exs
+++ b/server/test/tuist_web/live/layout_live_test.exs
@@ -101,7 +101,7 @@ defmodule TuistWeb.LayoutLiveTest do
           :project,
           params,
           session,
-          connected_socket()
+          connected_socket(current_user: user)
         )
 
       # Then
@@ -173,9 +173,11 @@ defmodule TuistWeb.LayoutLiveTest do
     @tag user_role: :user
     test "uses the session locale for translated dashboard labels", %{
       params: params,
-      session: session
+      session: session,
+      user: user
     } do
-      {:cont, socket} = Locale.on_mount(:assign_locale, %{}, Map.put(session, "locale", "es"), %LiveView.Socket{})
+      {:cont, socket} =
+        Locale.on_mount(:assign_locale, %{}, Map.put(session, "locale", "es"), disconnected_socket(current_user: user))
 
       {:cont, socket} = LayoutLive.on_mount(:project, params, session, socket)
 
@@ -197,7 +199,7 @@ defmodule TuistWeb.LayoutLiveTest do
           :account,
           %{},
           session,
-          connected_socket()
+          connected_socket(current_user: user)
         )
 
       # Then
@@ -248,7 +250,7 @@ defmodule TuistWeb.LayoutLiveTest do
           :account,
           params,
           session,
-          connected_socket()
+          connected_socket(current_user: user)
         )
 
       # Then
@@ -307,7 +309,7 @@ defmodule TuistWeb.LayoutLiveTest do
           :account,
           params,
           session,
-          connected_socket()
+          connected_socket(current_user: user)
         )
 
       # Then
@@ -354,20 +356,29 @@ defmodule TuistWeb.LayoutLiveTest do
     end
 
     test "when the account is invalid", %{
-      session: session
+      session: session,
+      user: user
     } do
       assert_raise NotFoundError, fn ->
         LayoutLive.on_mount(
           :account,
           %{"account_handle" => "invalid"},
           session,
-          %LiveView.Socket{}
+          disconnected_socket(current_user: user)
         )
       end
     end
   end
 
-  # Mirrors what `Phoenix.LiveView.connected?/1` checks so on_mount runs the
-  # branches reserved for the WebSocket-connected render path.
-  defp connected_socket, do: %LiveView.Socket{transport_pid: self()}
+  defp connected_socket(assigns \\ []) do
+    Enum.reduce(assigns, %LiveView.Socket{transport_pid: self()}, fn {key, value}, socket ->
+      Phoenix.Component.assign(socket, key, value)
+    end)
+  end
+
+  defp disconnected_socket(assigns \\ []) do
+    Enum.reduce(assigns, %LiveView.Socket{}, fn {key, value}, socket ->
+      Phoenix.Component.assign(socket, key, value)
+    end)
+  end
 end

--- a/server/test/tuist_web/live/layout_live_test.exs
+++ b/server/test/tuist_web/live/layout_live_test.exs
@@ -101,7 +101,7 @@ defmodule TuistWeb.LayoutLiveTest do
           :project,
           params,
           session,
-          %LiveView.Socket{}
+          connected_socket()
         )
 
       # Then
@@ -197,7 +197,7 @@ defmodule TuistWeb.LayoutLiveTest do
           :account,
           %{},
           session,
-          %LiveView.Socket{}
+          connected_socket()
         )
 
       # Then
@@ -248,7 +248,7 @@ defmodule TuistWeb.LayoutLiveTest do
           :account,
           params,
           session,
-          %LiveView.Socket{}
+          connected_socket()
         )
 
       # Then
@@ -307,7 +307,7 @@ defmodule TuistWeb.LayoutLiveTest do
           :account,
           params,
           session,
-          %LiveView.Socket{}
+          connected_socket()
         )
 
       # Then
@@ -366,4 +366,8 @@ defmodule TuistWeb.LayoutLiveTest do
       end
     end
   end
+
+  # Mirrors what `Phoenix.LiveView.connected?/1` checks so on_mount runs the
+  # branches reserved for the WebSocket-connected render path.
+  defp connected_socket, do: %LiveView.Socket{transport_pid: self()}
 end

--- a/server/test/tuist_web/live/usage_live_test.exs
+++ b/server/test/tuist_web/live/usage_live_test.exs
@@ -11,6 +11,8 @@ defmodule TuistWeb.UsageLiveTest do
   alias TuistTestSupport.Fixtures.AccountsFixtures
   alias TuistTestSupport.Fixtures.ProjectsFixtures
 
+  @render_async_timeout 1_000
+
   setup :set_mimic_from_context
 
   setup %{conn: conn} do
@@ -96,7 +98,7 @@ defmodule TuistWeb.UsageLiveTest do
     test "shows the empty state when there's no Kura traffic", %{conn: conn, account: account} do
       {:ok, lv, _html} = live(conn, ~p"/#{account.name}/usage")
 
-      html = render_async(lv)
+      html = render_async(lv, @render_async_timeout)
 
       assert html =~ "No cache traffic in this window yet"
     end
@@ -114,7 +116,7 @@ defmodule TuistWeb.UsageLiveTest do
 
       {:ok, lv, _html} = live(conn, ~p"/#{account.name}/usage")
 
-      html = render_async(lv)
+      html = render_async(lv, @render_async_timeout)
 
       assert html =~ "kura-test-node"
       # 1 MB rendered through ByteFormatter
@@ -138,14 +140,14 @@ defmodule TuistWeb.UsageLiveTest do
     test "egress is the default selected widget", %{conn: conn, account: account} do
       {:ok, lv, _html} = live(conn, ~p"/#{account.name}/usage")
 
-      _ = render_async(lv)
+      _ = render_async(lv, @render_async_timeout)
       assert has_element?(lv, ~s|[phx-value-widget="egress"][data-selected]|)
     end
 
     test "clicking a widget patches the URL with ?widget=ingress", %{conn: conn, account: account} do
       {:ok, lv, _html} = live(conn, ~p"/#{account.name}/usage")
 
-      _ = render_async(lv)
+      _ = render_async(lv, @render_async_timeout)
 
       lv
       |> element(~s|[phx-value-widget="ingress"]|)
@@ -158,7 +160,7 @@ defmodule TuistWeb.UsageLiveTest do
     test "honors widget=requests in the URL on initial mount", %{conn: conn, account: account} do
       {:ok, lv, _html} = live(conn, ~p"/#{account.name}/usage?widget=requests")
 
-      _ = render_async(lv)
+      _ = render_async(lv, @render_async_timeout)
       assert has_element?(lv, ~s|[phx-value-widget="requests"][data-selected]|)
     end
 
@@ -168,7 +170,7 @@ defmodule TuistWeb.UsageLiveTest do
     } do
       {:ok, lv, _html} = live(conn, ~p"/#{account.name}/usage?widget=bogus")
 
-      _ = render_async(lv)
+      _ = render_async(lv, @render_async_timeout)
       assert has_element?(lv, ~s|[phx-value-widget="egress"][data-selected]|)
     end
   end


### PR DESCRIPTION
> Speed up the cold start of dashboard LiveViews by skipping work that the HTTP dead render does not need and by removing a duplicate project lookup.

Profiling first-page-load behaviour after `mise run dev` showed that every authenticated dashboard request runs three synchronous Postgres queries before the HTML is returned, even though the data only populates the breadcrumb dropdown menus (which are not interactive until the LiveView WebSocket joins). The same code path also re-queries the project that `TuistWeb.Authorization.require_user_can_read_project/1` had just fetched, so each `/<account>/<project>` mount paid for the project lookup twice.

This PR:

- Gates `get_projects/2` and `get_user_organization_accounts/1` behind `connected?(socket)` in `LayoutLive.on_mount(:project, ...)` and `LayoutLive.on_mount(:account, ...)`. The dead render now skips them entirely; they run once on the connected mount and populate the dropdowns when the LiveView joins.
- Returns the authorized project from `Authorization.require_user_can_read_project/1` and adds a `%{user, project}` variant that just authorizes a pre-fetched project. `LayoutLive.on_mount(:project, ...)` reuses that result instead of issuing its own `Projects.get_project_by_account_and_project_handles/3` call, and `TuistWeb.App.on_mount(:mount_app, ...)` does the same for the public app shell.
- Updates the four `LayoutLiveTest` cases that assert breadcrumb dropdown contents to mount with a connected socket (`%LiveView.Socket{transport_pid: self()}`) so they exercise the connected branch where the dropdown queries run.

Net effect per project dashboard request: two fewer Postgres round-trips on the dead render path and one fewer on the connected mount; per account dashboard request: one fewer on the dead render. Behaviour is unchanged from the user's perspective beyond the dropdowns now populating a tick later (after the WebSocket join), which they already had to wait for to be interactive.

### How to test locally

1. `mise run dev` from `server/`.
2. Open `http://localhost:8080`, sign in as `tuistrocks@tuist.dev` / `tuistrocks`, and load any project dashboard page. Initial paint should land sooner; breadcrumbs render with their current labels immediately, dropdowns populate when the LiveView connects.
3. `mix test test/tuist_web/authorization_test.exs test/tuist_web/live/layout_live_test.exs test/tuist_web/controllers/build_controller_test.exs test/tuist_web/controllers/runs_controller_test.exs` — all 28 tests pass.
