### PR TITLE
feat(infra): wire CAPI core's workload connection for the Mac-mini fleets

### DIFF
--- a/infra/cluster-api-provider-scaleway-applesilicon/controllers/scalewayapplesiliconmachine_controller.go
+++ b/infra/cluster-api-provider-scaleway-applesilicon/controllers/scalewayapplesiliconmachine_controller.go
@@ -498,6 +498,7 @@ func (r *ScalewayAppleSiliconMachineReconciler) reconcileNormal(
 			UserPassword:         bootstrapCreds.SudoPassword,
 			SSHPrivateKey:        sshKey,
 			NodeName:             machine.Name,
+			ProviderID:           providerIDOf(machine),
 			Kubeconfig:           kubeconfigYAML,
 			TartKubeletBinary:    r.TartKubeletBinary,
 			TartTarball:          r.TartTarball,
@@ -596,6 +597,7 @@ func (r *ScalewayAppleSiliconMachineReconciler) reconcileNormal(
 			SSHUser:           bootstrapCreds.SSHUsername,
 			SSHPrivateKey:     sshKey,
 			NodeName:          machine.Name,
+			ProviderID:        providerIDOf(machine),
 			Kubeconfig:        kubeconfigYAML,
 			TartKubeletBinary: r.TartKubeletBinary,
 			TailscaleBinaries: r.TailscaleBinaries,
@@ -967,6 +969,17 @@ func machineIP(m *infrav1.ScalewayAppleSiliconMachine) string {
 		}
 	}
 	return ""
+}
+
+// providerIDOf returns the machine's providerID
+// (scw-applesilicon://<zone>/<id>), set once the server is ordered or
+// adopted. Empty until then — bootstrap renders no --provider-id flag
+// and a later reconcile re-renders the plist once it's known.
+func providerIDOf(m *infrav1.ScalewayAppleSiliconMachine) string {
+	if m.Spec.ProviderID == nil {
+		return ""
+	}
+	return *m.Spec.ProviderID
 }
 
 // hostCPUFor / hostMemoryMBFor select the per-Machine capacity

--- a/infra/helm/tuist/templates/capi-remote-kubeconfig-external-secret.yaml
+++ b/infra/helm/tuist/templates/capi-remote-kubeconfig-external-secret.yaml
@@ -1,0 +1,52 @@
+{{- if and .Values.capi.enabled (or .Values.macosFleet.enabled .Values.runnersFleet.enabled) .Values.capi.remoteKubeconfig.externalSecrets.enabled }}
+{{- $clusterName := include "tuist.componentName" (dict "root" . "component" "capi") }}
+{{- /*
+Syncs the CAPI workload kubeconfig from 1Password into
+<cluster>-kubeconfig — the Secret CAPI core's cluster cache reads to
+connect to the (local) cluster. Without it CAPI falls back to the stub
+controlPlaneEndpoint in capi-cluster.yaml (127.0.0.1) and can never bind
+Machines to Nodes, so every fleet MachineDeployment stays perpetually
+unavailable and the server `helm --wait` times out on it.
+
+pre-upgrade hook so the Secret materialises before the Cluster +
+MachineDeployments in the main release are evaluated by `helm --wait`.
+deletionPolicy Retain so the synced kubeconfig survives an --atomic
+rollback — a failed deploy won't disconnect CAPI and re-wedge the fleets.
+
+One-time per cluster: store the kubeconfig (server = in-cluster API,
+cluster CA, the capi-remote SA token from capi-remote-rbac.yaml) in the
+1Password item referenced below. See infra/k8s/onboarding.md.
+*/ -}}
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ $clusterName }}-kubeconfig
+  labels:
+    {{- include "tuist.labels" . | nindent 4 }}
+    app.kubernetes.io/component: capi-remote
+    cluster.x-k8s.io/cluster-name: {{ $clusterName }}
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-10"
+    helm.sh/hook-delete-policy: before-hook-creation
+spec:
+  refreshInterval: {{ .Values.capi.remoteKubeconfig.externalSecrets.refreshInterval | default "1h" }}
+  secretStoreRef:
+    name: {{ .Values.capi.remoteKubeconfig.externalSecrets.storeRef.name | default "onepassword" }}
+    kind: {{ .Values.capi.remoteKubeconfig.externalSecrets.storeRef.kind | default "ClusterSecretStore" }}
+  target:
+    name: {{ $clusterName }}-kubeconfig
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    template:
+      engineVersion: v2
+      metadata:
+        labels:
+          cluster.x-k8s.io/cluster-name: {{ $clusterName }}
+      data:
+        value: "{{ `{{ .value }}` }}"
+  data:
+    - secretKey: value
+      remoteRef:
+        key: "{{ .Values.capi.remoteKubeconfig.externalSecrets.item | default "capi-workload-kubeconfig" }}/{{ .Values.capi.remoteKubeconfig.externalSecrets.field | default "kubeconfig" }}"
+{{- end }}

--- a/infra/helm/tuist/templates/capi-remote-kubeconfig-external-secret.yaml
+++ b/infra/helm/tuist/templates/capi-remote-kubeconfig-external-secret.yaml
@@ -10,8 +10,13 @@ unavailable and the server `helm --wait` times out on it.
 
 pre-upgrade hook so the Secret materialises before the Cluster +
 MachineDeployments in the main release are evaluated by `helm --wait`.
-deletionPolicy Retain so the synced kubeconfig survives an --atomic
-rollback — a failed deploy won't disconnect CAPI and re-wedge the fleets.
+creationPolicy Orphan (not Owner) so ESO does not owner-reference the
+Secret to this ExternalSecret: the hook's before-hook-creation policy
+deletes the prior ExternalSecret on every upgrade, and an Owner-created
+Secret would be garbage-collected with it, disconnecting CAPI mid-deploy.
+Orphan + deletionPolicy Retain keep the synced kubeconfig in place across
+hook churn and an --atomic rollback, so a failed deploy won't re-wedge the
+fleets.
 
 One-time per cluster: store the kubeconfig (server = in-cluster API,
 cluster CA, the capi-remote SA token from capi-remote-rbac.yaml) in the
@@ -36,7 +41,7 @@ spec:
     kind: {{ .Values.capi.remoteKubeconfig.externalSecrets.storeRef.kind | default "ClusterSecretStore" }}
   target:
     name: {{ $clusterName }}-kubeconfig
-    creationPolicy: Owner
+    creationPolicy: Orphan
     deletionPolicy: Retain
     template:
       engineVersion: v2

--- a/infra/helm/tuist/templates/capi-remote-rbac.yaml
+++ b/infra/helm/tuist/templates/capi-remote-rbac.yaml
@@ -1,0 +1,72 @@
+{{- if and .Values.capi.enabled (or .Values.macosFleet.enabled .Values.runnersFleet.enabled) }}
+{{- $name := include "tuist.componentName" (dict "root" . "component" "capi-remote") }}
+{{- /*
+Identity CAPI core's cluster cache uses to reach this cluster.
+
+The in-cluster CAPI manages the Mac-mini fleet as Machines in the same
+cluster it runs in, so the <cluster>-kubeconfig Secret it connects with
+must point at the local API server with permission to watch Nodes (to
+set Machine.status.nodeRef by matching Node.spec.providerID) and to
+drain + delete a Node when its Machine is removed.
+
+This SA + scoped ClusterRole is that identity. The kubeconfig itself
+(server + CA + this SA's token) lives in 1Password and is synced by ESO
+into <cluster>-kubeconfig — see capi-remote-kubeconfig-external-secret.yaml.
+The token Secret below is a long-lived (non-expiring) SA token so the
+stored kubeconfig stays valid without rotation churn.
+*/ -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "tuist.labels" . | nindent 4 }}
+    app.kubernetes.io/component: capi-remote
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "tuist.labels" . | nindent 4 }}
+    app.kubernetes.io/component: capi-remote
+rules:
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch", "patch", "delete"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["pods/eviction"]
+    verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "tuist.labels" . | nindent 4 }}
+    app.kubernetes.io/component: capi-remote
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ $name }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ $name }}
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $name }}-token
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "tuist.labels" . | nindent 4 }}
+    app.kubernetes.io/component: capi-remote
+  annotations:
+    kubernetes.io/service-account.name: {{ $name }}
+type: kubernetes.io/service-account-token
+{{- end }}

--- a/infra/helm/tuist/templates/capi-remote-rbac.yaml
+++ b/infra/helm/tuist/templates/capi-remote-rbac.yaml
@@ -41,6 +41,12 @@ rules:
   - apiGroups: [""]
     resources: ["pods/eviction"]
     verbs: ["create"]
+  # CAPI core's cluster cache health-probes the connection with `GET /`
+  # (clustercache/cluster_accessor_client.go) before it will use the
+  # cluster. Without this the probe 403s and CAPI reports the cluster as
+  # "not reachable", so Machines never bind to Nodes.
+  - nonResourceURLs: ["/"]
+    verbs: ["get"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/infra/helm/tuist/values-managed-common.yaml
+++ b/infra/helm/tuist/values-managed-common.yaml
@@ -212,6 +212,17 @@ xcresultProcessor:
     # xcresult-processor-image.yml workflow pushed.
     tag: "0.9.1"
 
+capi:
+  # Managed clusters store the CAPI workload kubeconfig in their
+  # per-env 1Password vault, so ESO can sync it into the
+  # <release>-capi-kubeconfig Secret that CAPI core's cluster cache
+  # reads. Without it CAPI can't bind fleet Machines to Nodes and the
+  # server deploy's `helm --wait` times out on the fleet
+  # MachineDeployments.
+  remoteKubeconfig:
+    externalSecrets:
+      enabled: true
+
 # Mac mini fleet provisioned declaratively via the Cluster API
 # Scaleway-Apple-Silicon provider. Scaling is `kubectl scale
 # machinedeployment <name> --replicas=N`. Per-env overlay sets the

--- a/infra/helm/tuist/values.yaml
+++ b/infra/helm/tuist/values.yaml
@@ -502,6 +502,25 @@ xcresultProcessor:
 # alongside `macosFleet.enabled`.
 capi:
   enabled: true
+  # Workload kubeconfig CAPI core's cluster cache uses to reach this
+  # cluster and bind Mac-mini Machines to Nodes. Synced from 1Password
+  # by ESO into <release>-capi-kubeconfig (the Secret CAPI looks up).
+  # Off by default — self-hosters without the 1Password item leave it
+  # off; the in-cluster CAPI then can't bind Machines, but the fleet
+  # still works at the Kubernetes level (tart-kubelet registers the
+  # nodes directly). Managed envs enable it.
+  remoteKubeconfig:
+    externalSecrets:
+      enabled: false
+      refreshInterval: "1h"
+      # 1Password item holding the assembled kubeconfig (server =
+      # in-cluster API, cluster CA, the capi-remote SA token). Populated
+      # once per cluster — see infra/k8s/onboarding.md.
+      item: "capi-workload-kubeconfig"
+      field: "kubeconfig"
+      storeRef:
+        name: onepassword
+        kind: ClusterSecretStore
 
 # Scaling: `kubectl scale machinedeployment <name> --replicas=N`.
 macosFleet:

--- a/infra/k8s/onboarding.md
+++ b/infra/k8s/onboarding.md
@@ -120,6 +120,43 @@ shred -u /tmp/ci-kubeconfig.yaml
 # changes automatically.
 ```
 
+## 5b. CAPI workload kubeconfig (Mac-mini fleets only)
+
+Skip this for clusters without a Mac-mini fleet (`macosFleet.enabled: false` and `runnersFleet.enabled: false`).
+
+The chart runs an in-cluster CAPI that manages the Mac minis as `Machine`/`MachineDeployment` objects in this same cluster. CAPI core's cluster cache reaches the cluster through a `<release>-capi-kubeconfig` Secret; the chart's [`capi-cluster.yaml`](../helm/tuist/templates/capi-cluster.yaml) sets a stub `controlPlaneEndpoint` (`127.0.0.1`), so that Secret has to be supplied. Without it CAPI can't bind Machines to Nodes, every fleet `MachineDeployment` stays unavailable, and the server deploy's `helm --wait` times out on them.
+
+The chart creates the identity (`capi-remote` SA + scoped `ClusterRole` + non-expiring token Secret) and an `ExternalSecret` that syncs the kubeconfig from 1Password (`capi.remoteKubeconfig.externalSecrets`, on for managed envs). You populate the 1Password item once — assemble a kubeconfig pointing at the in-cluster API with the `capi-remote` SA token:
+
+```bash
+export KUBECONFIG=~/.kube/<cluster_name>.yaml
+NS=tuist-<env>   # production uses tuist
+TOKEN=$(kubectl -n "$NS" get secret tuist-tuist-capi-remote-token -o jsonpath='{.data.token}' | base64 -d)
+CA=$(kubectl -n "$NS" get secret tuist-tuist-capi-remote-token -o jsonpath='{.data.ca\.crt}')   # already base64
+cat > /tmp/capi-workload-kubeconfig.yaml <<EOF
+apiVersion: v1
+kind: Config
+clusters:
+- name: tuist-tuist-capi
+  cluster: { server: https://kubernetes.default.svc:443, certificate-authority-data: $CA }
+contexts:
+- name: tuist-tuist-capi
+  context: { cluster: tuist-tuist-capi, user: tuist-tuist-capi }
+current-context: tuist-tuist-capi
+users:
+- name: tuist-tuist-capi
+  user: { token: $TOKEN }
+EOF
+op document create /tmp/capi-workload-kubeconfig.yaml \
+  --title capi-workload-kubeconfig --vault tuist-k8s-<env>   # or store the contents in the `kubeconfig` field of that item
+shred -u /tmp/capi-workload-kubeconfig.yaml
+```
+
+ESO then materializes `<release>-capi-kubeconfig` and CAPI binds the fleet. The `capi-remote-token` Secret is non-expiring, so this is a one-time step per cluster.
+
+> **Node `providerID`:** CAPI binds a Node to its Machine by matching `Node.spec.providerID` to `Machine.spec.providerID` (`scw-applesilicon://<zone>/<id>`). tart-kubelet does not yet set this, so a freshly-bootstrapped fleet node needs a one-time patch until that ships:
+> `kubectl patch node <node> --type merge -p '{"spec":{"providerID":"<machine providerID>"}}'`
+
 ## 6. First deploy
 
 ### Manual smoke test

--- a/infra/k8s/onboarding.md
+++ b/infra/k8s/onboarding.md
@@ -126,30 +126,19 @@ Skip this for clusters without a Mac-mini fleet (`macosFleet.enabled: false` and
 
 The chart runs an in-cluster CAPI that manages the Mac minis as `Machine`/`MachineDeployment` objects in this same cluster. CAPI core's cluster cache reaches the cluster through a `<release>-capi-kubeconfig` Secret; the chart's [`capi-cluster.yaml`](../helm/tuist/templates/capi-cluster.yaml) sets a stub `controlPlaneEndpoint` (`127.0.0.1`), so that Secret has to be supplied. Without it CAPI can't bind Machines to Nodes, every fleet `MachineDeployment` stays unavailable, and the server deploy's `helm --wait` times out on them.
 
-The chart creates the identity (`capi-remote` SA + scoped `ClusterRole` + non-expiring token Secret) and an `ExternalSecret` that syncs the kubeconfig from 1Password (`capi.remoteKubeconfig.externalSecrets`, on for managed envs). You populate the 1Password item once — assemble a kubeconfig pointing at the in-cluster API with the `capi-remote` SA token:
+The chart creates the identity (`capi-remote` SA + scoped `ClusterRole` + non-expiring token Secret) and an `ExternalSecret` that syncs the kubeconfig from 1Password (`capi.remoteKubeconfig.externalSecrets`, on for managed envs). You populate the 1Password item once.
+
+The kubeconfig's `server` **must be the in-cluster API endpoint** (the kubernetes Service ClusterIP). CAPI core's cluster cache ([`controllers/clustercache`](https://github.com/kubernetes-sigs/cluster-api/blob/v1.10.4/controllers/clustercache/cluster_accessor_client.go)) builds its REST config from this Secret and runs an initial reachability probe with the Secret's `server` *before* it overrides `Host`/`CAData` with the controller's own in-cluster config. So the `server` has to be reachable + TLS-valid from inside the cluster — the external control-plane LB IP is unroutable from a Pod (instant "no route"), and `kubernetes.default.svc` risks a cert-SAN mismatch. The ClusterIP is exactly what the controller's own client uses, so the probe is guaranteed to pass.
 
 ```bash
 export KUBECONFIG=~/.kube/<cluster_name>.yaml
 NS=tuist-<env>   # production uses tuist
+APISERVER="https://$(kubectl -n default get svc kubernetes -o jsonpath='{.spec.clusterIP}'):443"
 TOKEN=$(kubectl -n "$NS" get secret tuist-tuist-capi-remote-token -o jsonpath='{.data.token}' | base64 -d)
 CA=$(kubectl -n "$NS" get secret tuist-tuist-capi-remote-token -o jsonpath='{.data.ca\.crt}')   # already base64
-cat > /tmp/capi-workload-kubeconfig.yaml <<EOF
-apiVersion: v1
-kind: Config
-clusters:
-- name: tuist-tuist-capi
-  cluster: { server: https://kubernetes.default.svc:443, certificate-authority-data: $CA }
-contexts:
-- name: tuist-tuist-capi
-  context: { cluster: tuist-tuist-capi, user: tuist-tuist-capi }
-current-context: tuist-tuist-capi
-users:
-- name: tuist-tuist-capi
-  user: { token: $TOKEN }
-EOF
-op document create /tmp/capi-workload-kubeconfig.yaml \
-  --title capi-workload-kubeconfig --vault tuist-k8s-<env>   # or store the contents in the `kubeconfig` field of that item
-shred -u /tmp/capi-workload-kubeconfig.yaml
+KCFG=$(printf 'apiVersion: v1\nkind: Config\nclusters:\n- name: tuist-tuist-capi\n  cluster: { server: %s, certificate-authority-data: %s }\ncontexts:\n- name: tuist-tuist-capi\n  context: { cluster: tuist-tuist-capi, user: tuist-tuist-capi }\ncurrent-context: tuist-tuist-capi\nusers:\n- name: tuist-tuist-capi\n  user: { token: %s }\n' "$APISERVER" "$CA" "$TOKEN")
+op item create --vault tuist-k8s-<env> --category "Secure Note" --title capi-workload-kubeconfig "kubeconfig[password]=$KCFG"
+unset TOKEN KCFG
 ```
 
 ESO then materializes `<release>-capi-kubeconfig` and CAPI binds the fleet. The `capi-remote-token` Secret is non-expiring, so this is a one-time step per cluster.

--- a/infra/macos-host-bootstrap/bootstrap.go
+++ b/infra/macos-host-bootstrap/bootstrap.go
@@ -365,14 +365,38 @@ sudo chmod 0755 /usr/local/bin/tart-kubelet
 // with this host's flags substituted in, fixes ownership on the
 // kubelet's writable paths so the SSH user owns them (the launchd job
 // runs as that user — see the comment in renderLaunchdPlist), then
-// `launchctl bootstrap`s it. Idempotent across reruns.
+// reloads the launchd job and verifies it actually came up. Idempotent
+// across reruns.
+//
+// The reload is the fragile part on a headless Mac, and getting it
+// wrong is what strands a fleet Node NotReady:
+//
+//   - Re-registration churn: every `bootout`+`bootstrap` re-registers
+//     the plist with macOS Background Task Management. BTM caps "legacy
+//     daemon" notifications and, once exceeded, stops honouring the
+//     job's KeepAlive automatic respawn — so a later clean exit never
+//     restarts and the Node goes NotReady. We avoid this by only
+//     rewriting + bootout/bootstrapping when the plist content actually
+//     changed; a binary-only roll (the common drift case) leaves the
+//     launchd args identical, so we restart in place with `kickstart -k`
+//     instead, which re-execs the new binary without touching BTM.
+//
+//   - Silent reload failure: `bootout` immediately followed by
+//     `bootstrap` can race (or be BTM-throttled) and leave the job
+//     booted-out, which KeepAlive cannot recover. The old code returned
+//     success regardless, so the reconciler recorded the SHA roll as
+//     done and never retried, leaving the Node NotReady indefinitely.
+//     We now poll for a live PID, force a `kickstart` if it didn't come
+//     up, and exit non-zero if it still won't run — so the caller keeps
+//     the drift set and retries instead of recording a roll that never
+//     took.
 func loadTartKubeletLaunchd(ctx context.Context, client *ssh.Client, cfg Config) error {
 	plist := renderLaunchdPlist(cfg)
 	script := fmt.Sprintf(`set -euo pipefail
 PLIST=/Library/LaunchDaemons/dev.tuist.tart-kubelet.plist
-sudo tee "$PLIST" >/dev/null
-sudo chown root:wheel "$PLIST"
-sudo chmod 0644 "$PLIST"
+NEW="$(mktemp)"
+trap 'rm -f "$NEW"' EXIT
+cat >"$NEW"
 # Apple's Virtualization.framework requires the calling process to be
 # owned by the user with the live GUI console session — see
 # renderLaunchdPlist's UserName field. Hand kubelet-writable paths to
@@ -382,10 +406,27 @@ sudo touch /var/log/tart-kubelet.log
 sudo chown -R %[1]s:staff /var/log/tart-vms /var/lib/tart-userdata /var/log/tart-kubelet.log
 sudo chown %[1]s:staff /etc/tart-kubelet/kubeconfig
 sudo chmod 0600 /etc/tart-kubelet/kubeconfig
-# launchctl bootstrap is the modern API; bootout first to make this
-# idempotent across reruns with new args.
-sudo launchctl bootout system "$PLIST" 2>/dev/null || true
-sudo launchctl bootstrap system "$PLIST"
+
+running() { sudo launchctl print system/dev.tuist.tart-kubelet 2>/dev/null | grep -qE '^[[:space:]]*pid = [0-9]+'; }
+
+# Restart in place when the plist is unchanged (avoids BTM churn);
+# otherwise rewrite it and bootout+bootstrap to pick up the new args.
+if cmp -s "$NEW" "$PLIST" && running; then
+  sudo launchctl kickstart -k system/dev.tuist.tart-kubelet 2>/dev/null || true
+else
+  sudo cp "$NEW" "$PLIST"
+  sudo chown root:wheel "$PLIST"
+  sudo chmod 0644 "$PLIST"
+  sudo launchctl bootout system "$PLIST" 2>/dev/null || true
+  sudo launchctl bootstrap system "$PLIST" 2>/dev/null || true
+fi
+
+# Verify the agent reached a running state; force a kickstart if not.
+for _ in $(seq 1 20); do running && exit 0; sleep 1; done
+sudo launchctl kickstart -k system/dev.tuist.tart-kubelet 2>/dev/null || true
+for _ in $(seq 1 20); do running && exit 0; sleep 1; done
+echo "tart-kubelet did not reach a running state after launchd reload" >&2
+exit 1
 `, shellQuote(cfg.SSHUser))
 	return RunCommandWithStdin(ctx, client, script, plist)
 }

--- a/infra/macos-host-bootstrap/bootstrap.go
+++ b/infra/macos-host-bootstrap/bootstrap.go
@@ -71,6 +71,13 @@ type Config struct {
 	// nodes` reflects the inventory.
 	NodeName string
 
+	// ProviderID is the CAPI machine ID (scw-applesilicon://<zone>/<id>)
+	// rendered into tart-kubelet's --provider-id flag so it sets
+	// Node.spec.providerID — the field CAPI core matches to bind the
+	// Machine to its Node. Empty omits the flag (Node left unbound until
+	// patched by hand).
+	ProviderID string
+
 	// Kubeconfig is the YAML kubeconfig the controller built for this
 	// host (contains a long-lived ServiceAccount token + the API
 	// server's external URL + CA bundle). Dropped at
@@ -501,6 +508,15 @@ func renderLaunchdPlist(cfg Config) string {
 	if len(cfg.TailscaleBinaries) > 0 && cfg.TailscaleAuthKey != "" {
 		nodeIPSourceArg = "\n    <string>--node-ip-source=tailscale</string>"
 	}
+	// providerID binds the Node to its CAPI Machine. Rendered as a flag so
+	// freshly-provisioned and re-rolled nodes self-bind without a manual
+	// `kubectl patch node ... providerID`. Empty (e.g. before the server
+	// is ordered) omits it; tart-kubelet then leaves spec.providerID unset
+	// and a later reconcile re-renders the plist once it's known.
+	providerIDArg := ""
+	if cfg.ProviderID != "" {
+		providerIDArg = fmt.Sprintf("\n    <string>--provider-id=%s</string>", cfg.ProviderID)
+	}
 	// Run tart-kubelet as the SSH user (m1). Apple's
 	// Virtualization.framework requires the calling process to be the
 	// same user that holds the live GUI console session — Tart's
@@ -523,7 +539,7 @@ func renderLaunchdPlist(cfg Config) string {
     <string>--kubeconfig=/etc/tart-kubelet/kubeconfig</string>
     <string>--host-cpu=%[2]d</string>
     <string>--host-memory-mb=%[3]d</string>
-    <string>--max-pods=%[4]d</string>%[6]s%[7]s
+    <string>--max-pods=%[4]d</string>%[6]s%[7]s%[8]s
   </array>
   <key>RunAtLoad</key><true/>
   <key>KeepAlive</key><true/>
@@ -537,7 +553,7 @@ func renderLaunchdPlist(cfg Config) string {
   </dict>
 </dict>
 </plist>
-`, cfg.NodeName, cpu, mem, maxPods, user, nodeLabelsArg, nodeIPSourceArg)
+`, cfg.NodeName, cpu, mem, maxPods, user, nodeLabelsArg, nodeIPSourceArg, providerIDArg)
 }
 
 func shellQuote(s string) string {

--- a/infra/macos-host-bootstrap/bootstrap.go
+++ b/infra/macos-host-bootstrap/bootstrap.go
@@ -407,11 +407,18 @@ sudo chown -R %[1]s:staff /var/log/tart-vms /var/lib/tart-userdata /var/log/tart
 sudo chown %[1]s:staff /etc/tart-kubelet/kubeconfig
 sudo chmod 0600 /etc/tart-kubelet/kubeconfig
 
-running() { sudo launchctl print system/dev.tuist.tart-kubelet 2>/dev/null | grep -qE '^[[:space:]]*pid = [0-9]+'; }
+# pid prints the launchd-tracked PID (empty when not running). restarted
+# is true only once a NEW pid appears (different from the pre-reload one):
+# a no-op kickstart that leaves the old process running must not be
+# mistaken for a successful roll into the freshly-uploaded binary.
+pid() { sudo launchctl print system/dev.tuist.tart-kubelet 2>/dev/null | awk '/^[[:space:]]*pid = [0-9]+/{print $3; exit}' || true; }
+OLD="$(pid)"
+restarted() { p="$(pid)"; [ -n "$p" ] && [ "$p" != "$OLD" ]; }
 
-# Restart in place when the plist is unchanged (avoids BTM churn);
-# otherwise rewrite it and bootout+bootstrap to pick up the new args.
-if cmp -s "$NEW" "$PLIST" && running; then
+# Restart in place when the plist is unchanged and a process is running
+# (avoids BTM re-registration churn); otherwise rewrite it and
+# bootout+bootstrap to pick up the new args / start it fresh.
+if cmp -s "$NEW" "$PLIST" && [ -n "$OLD" ]; then
   sudo launchctl kickstart -k system/dev.tuist.tart-kubelet 2>/dev/null || true
 else
   sudo cp "$NEW" "$PLIST"
@@ -421,10 +428,13 @@ else
   sudo launchctl bootstrap system "$PLIST" 2>/dev/null || true
 fi
 
-# Verify the agent reached a running state; force a kickstart if not.
-for _ in $(seq 1 20); do running && exit 0; sleep 1; done
+# Require a fresh process (new PID) — not merely "something is alive" —
+# then force a kickstart and re-check if the reload didn't restart it.
+# Exit non-zero if it never restarts so the reconciler keeps the drift
+# set and retries instead of recording a roll that never took.
+for _ in $(seq 1 20); do restarted && exit 0; sleep 1; done
 sudo launchctl kickstart -k system/dev.tuist.tart-kubelet 2>/dev/null || true
-for _ in $(seq 1 20); do running && exit 0; sleep 1; done
+for _ in $(seq 1 20); do restarted && exit 0; sleep 1; done
 echo "tart-kubelet did not reach a running state after launchd reload" >&2
 exit 1
 `, shellQuote(cfg.SSHUser))

--- a/infra/macos-host-bootstrap/bootstrap.go
+++ b/infra/macos-host-bootstrap/bootstrap.go
@@ -364,6 +364,14 @@ func installTartKubelet(ctx context.Context, client *ssh.Client, binary []byte) 
 sudo mkdir -p /usr/local/bin
 sudo tee /usr/local/bin/tart-kubelet >/dev/null
 sudo chmod 0755 /usr/local/bin/tart-kubelet
+# Re-sign in place. The binary already carries a valid Go linker ad-hoc
+# signature, but overwriting /usr/local/bin/tart-kubelet at the same inode
+# leaves macOS's AMFI validating the new pages against the previous
+# binary's cached cdhash — a mismatch the kernel kills as
+# OS_REASON_CODESIGNING on the next launch, stranding the Node NotReady.
+# A forced ad-hoc re-sign refreshes the signature and invalidates that
+# stale cache so the rolled binary actually runs.
+sudo codesign --force --sign - /usr/local/bin/tart-kubelet
 `
 	return RunCommandWithStdin(ctx, client, script, string(binary))
 }
@@ -414,13 +422,26 @@ sudo chown -R %[1]s:staff /var/log/tart-vms /var/lib/tart-userdata /var/log/tart
 sudo chown %[1]s:staff /etc/tart-kubelet/kubeconfig
 sudo chmod 0600 /etc/tart-kubelet/kubeconfig
 
-# pid prints the launchd-tracked PID (empty when not running). restarted
-# is true only once a NEW pid appears (different from the pre-reload one):
-# a no-op kickstart that leaves the old process running must not be
-# mistaken for a successful roll into the freshly-uploaded binary.
+# pid prints the launchd-tracked PID (empty when not running). settled
+# waits for a NEW pid (different from the pre-reload one) and confirms it
+# is still the same a few seconds later. That rules out two false
+# positives: a no-op kickstart that leaves the old process running, and a
+# crash-looping launch (e.g. an OS_REASON_CODESIGNING kill) that briefly
+# shows a transient pid on each respawn — neither must be mistaken for a
+# successful roll into the freshly-uploaded binary.
 pid() { sudo launchctl print system/dev.tuist.tart-kubelet 2>/dev/null | awk '/^[[:space:]]*pid = [0-9]+/{print $3; exit}' || true; }
 OLD="$(pid)"
-restarted() { p="$(pid)"; [ -n "$p" ] && [ "$p" != "$OLD" ]; }
+settled() {
+  for _ in $(seq 1 20); do
+    p="$(pid)"
+    if [ -n "$p" ] && [ "$p" != "$OLD" ]; then
+      sleep 5
+      [ "$(pid)" = "$p" ] && return 0 || return 1
+    fi
+    sleep 1
+  done
+  return 1
+}
 
 # Restart in place when the plist is unchanged and a process is running
 # (avoids BTM re-registration churn); otherwise rewrite it and
@@ -435,13 +456,13 @@ else
   sudo launchctl bootstrap system "$PLIST" 2>/dev/null || true
 fi
 
-# Require a fresh process (new PID) — not merely "something is alive" —
-# then force a kickstart and re-check if the reload didn't restart it.
-# Exit non-zero if it never restarts so the reconciler keeps the drift
-# set and retries instead of recording a roll that never took.
-for _ in $(seq 1 20); do restarted && exit 0; sleep 1; done
+# Require a fresh, stable process — then force a kickstart and re-check if
+# the reload didn't restart it. Exit non-zero if it never settles so the
+# reconciler keeps the drift set and retries instead of recording a roll
+# that never took.
+settled && exit 0
 sudo launchctl kickstart -k system/dev.tuist.tart-kubelet 2>/dev/null || true
-for _ in $(seq 1 20); do restarted && exit 0; sleep 1; done
+settled && exit 0
 echo "tart-kubelet did not reach a running state after launchd reload" >&2
 exit 1
 `, shellQuote(cfg.SSHUser))

--- a/infra/macos-host-bootstrap/bootstrap_test.go
+++ b/infra/macos-host-bootstrap/bootstrap_test.go
@@ -25,6 +25,24 @@ func TestRenderLaunchdPlist_OmitsNodeLabelsWhenEmpty(t *testing.T) {
 	}
 }
 
+func TestRenderLaunchdPlist_OmitsProviderIDWhenEmpty(t *testing.T) {
+	out := renderLaunchdPlist(Config{NodeName: "n1", SSHUser: "m1"})
+	if strings.Contains(out, "--provider-id") {
+		t.Fatalf("expected --provider-id to be absent when ProviderID is empty\n%s", out)
+	}
+}
+
+func TestRenderLaunchdPlist_RendersProviderID(t *testing.T) {
+	out := renderLaunchdPlist(Config{
+		NodeName:   "n1",
+		SSHUser:    "m1",
+		ProviderID: "scw-applesilicon://fr-par-1/abc-123",
+	})
+	if !strings.Contains(out, "<string>--provider-id=scw-applesilicon://fr-par-1/abc-123</string>") {
+		t.Fatalf("expected --provider-id flag in plist\n%s", out)
+	}
+}
+
 func TestRenderLaunchdPlist_RendersFleetLabel(t *testing.T) {
 	out := renderLaunchdPlist(Config{
 		NodeName:   "n1",

--- a/infra/tart-kubelet/cmd/tart-kubelet/main.go
+++ b/infra/tart-kubelet/cmd/tart-kubelet/main.go
@@ -54,6 +54,7 @@ func init() {
 func main() {
 	var (
 		nodeName           string
+		providerID         string
 		nodeIP             string
 		nodeIPSource       string
 		scrapeAllowedCIDRs cidrList
@@ -66,6 +67,8 @@ func main() {
 		tartBinary         string
 	)
 	flag.StringVar(&nodeName, "node-name", envOr("TART_KUBELET_NODE_NAME", ""), "Node name to register as. Defaults to os.Hostname() when empty.")
+	flag.StringVar(&providerID, "provider-id", envOr("TART_KUBELET_PROVIDER_ID", ""),
+		"Cloud providerID (e.g. scw-applesilicon://<zone>/<id>) to set on Node.spec.providerID. CAPI matches this against Machine.spec.providerID to bind the Machine to this Node; empty leaves it unset.")
 	flag.StringVar(&nodeIP, "node-ip", envOr("TART_KUBELET_NODE_IP", ""),
 		"Routable IP of this Mac mini. Pods that opt into Prometheus scraping advertise it as their PodIP and run a host-side forwarder on the host port. Defaults to the first non-loopback IPv4 address on a UP interface.")
 	flag.StringVar(&nodeIPSource, "node-ip-source", envOr("TART_KUBELET_NODE_IP_SOURCE", "auto"),
@@ -262,6 +265,7 @@ func main() {
 	if err := mgr.Add(&nodeagent.Maintainer{
 		Client:     mgr.GetClient(),
 		NodeName:   nodeName,
+		ProviderID: providerID,
 		NodeIP:     nodeIP,
 		NodeLabels: nodeLabels,
 		CPU:        hostCPU,

--- a/infra/tart-kubelet/internal/nodeagent/node.go
+++ b/infra/tart-kubelet/internal/nodeagent/node.go
@@ -28,6 +28,12 @@ import (
 type Maintainer struct {
 	Client   client.Client
 	NodeName string
+	// ProviderID is the cloud machine ID (scw-applesilicon://<zone>/<id>)
+	// the CAPI provider passes at bootstrap. CAPI core binds a Machine to
+	// its Node by matching Node.spec.providerID == Machine.spec.providerID;
+	// without it the fleet MachineDeployment never reports available.
+	// Empty leaves spec.providerID untouched.
+	ProviderID string
 	// NodeIP is the address advertised as the Node's InternalIP so
 	// in-cluster scrapers (alloy-metrics) targeting the Node role
 	// (host-level node_exporter at :9100, or any future host-bound
@@ -99,13 +105,26 @@ func (m *Maintainer) ensureNode(ctx context.Context) error {
 	err := m.Client.Get(ctx, types.NamespacedName{Name: m.NodeName}, node)
 	if apierrors.IsNotFound(err) {
 		node.Name = m.NodeName
+		if m.ProviderID != "" {
+			node.Spec.ProviderID = m.ProviderID
+		}
 		m.configureNode(node)
 		return m.Client.Create(ctx, node)
 	}
 	if err != nil {
 		return err
 	}
-	// Node already exists (kubelet restart): just refresh status.
+	// Node already exists (kubelet restart). spec.providerID is immutable
+	// once set, so only fill it when empty — this binds nodes that
+	// registered before tart-kubelet learned to set it. refresh() below
+	// writes only the status subresource, so the spec patch has to happen
+	// here.
+	if m.ProviderID != "" && node.Spec.ProviderID == "" {
+		node.Spec.ProviderID = m.ProviderID
+		if err := m.Client.Update(ctx, node); err != nil {
+			return err
+		}
+	}
 	return m.refresh(ctx)
 }
 

--- a/infra/tart-kubelet/internal/nodeagent/node_test.go
+++ b/infra/tart-kubelet/internal/nodeagent/node_test.go
@@ -4,9 +4,72 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
+
+func newNodeFakeClient(objs ...client.Object) client.Client {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	return fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&corev1.Node{}).
+		WithObjects(objs...).
+		Build()
+}
+
+func nodeProviderID(t *testing.T, c client.Client, name string) string {
+	t.Helper()
+	node := &corev1.Node{}
+	if err := c.Get(context.Background(), types.NamespacedName{Name: name}, node); err != nil {
+		t.Fatalf("get node: %v", err)
+	}
+	return node.Spec.ProviderID
+}
+
+func TestEnsureNodeSetsProviderIDOnCreate(t *testing.T) {
+	c := newNodeFakeClient()
+	m := &Maintainer{Client: c, NodeName: "mac-1", ProviderID: "scw-applesilicon://fr-par-1/abc", Heartbeat: time.Second}
+	if err := m.ensureNode(context.Background()); err != nil {
+		t.Fatalf("ensureNode: %v", err)
+	}
+	if got := nodeProviderID(t, c, "mac-1"); got != "scw-applesilicon://fr-par-1/abc" {
+		t.Fatalf("providerID = %q, want it set on create", got)
+	}
+}
+
+func TestEnsureNodePatchesEmptyProviderID(t *testing.T) {
+	existing := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "mac-1"}}
+	c := newNodeFakeClient(existing)
+	m := &Maintainer{Client: c, NodeName: "mac-1", ProviderID: "scw-applesilicon://fr-par-1/abc", Heartbeat: time.Second}
+	if err := m.ensureNode(context.Background()); err != nil {
+		t.Fatalf("ensureNode: %v", err)
+	}
+	if got := nodeProviderID(t, c, "mac-1"); got != "scw-applesilicon://fr-par-1/abc" {
+		t.Fatalf("providerID = %q, want it patched onto a node registered without one", got)
+	}
+}
+
+func TestEnsureNodeDoesNotOverwriteExistingProviderID(t *testing.T) {
+	existing := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "mac-1"},
+		Spec:       corev1.NodeSpec{ProviderID: "scw-applesilicon://fr-par-1/original"},
+	}
+	c := newNodeFakeClient(existing)
+	m := &Maintainer{Client: c, NodeName: "mac-1", ProviderID: "scw-applesilicon://fr-par-1/different", Heartbeat: time.Second}
+	if err := m.ensureNode(context.Background()); err != nil {
+		t.Fatalf("ensureNode: %v", err)
+	}
+	if got := nodeProviderID(t, c, "mac-1"); got != "scw-applesilicon://fr-par-1/original" {
+		t.Fatalf("providerID = %q, want the original left untouched (immutable)", got)
+	}
+}
 
 func conditionByType(conds []corev1.NodeCondition, t corev1.NodeConditionType) (corev1.NodeCondition, bool) {
 	for _, c := range conds {


### PR DESCRIPTION
## What changed

The in-cluster CAPI that manages the Mac-mini fleets (`macos` / `runners` / `builders`) as `Machine`/`MachineDeployment` objects had several gaps that made every server deploy time out and roll back. This PR closes them.

### 1. CAPI workload connection (the wire-up)

**Why a self-managed CAPI needs a kubeconfig to its own cluster.** The Mac minis are real Nodes of *this* app cluster (the #10499 design — so macOS work like xcresult-processor and runners schedules as ordinary `Deployment`s alongside everything else, rather than through a central fleet manager that would be a SPOF), and the CAPI that manages them runs *inside* this same cluster. That placement is deliberate, not incidental: the provider mints each mini's join-credentials — API URL, CA, a `bootstrap.kubernetes.io/token` — from its **own in-cluster ServiceAccount context**, so a mini joins the cluster the provider runs in with no stored, cross-cluster credentials (see the provider's `AGENTS.md`: "No 1Password entry, no manual rotation"). Running it from the Hetzner management cluster instead would either land the minis in *mgmt* (wrong cluster) or require injecting the app cluster's API/CA and creating bootstrap tokens cross-cluster — exactly the plumbing this design avoids. The mgmt cluster is scoped to caph provisioning the Hetzner *clusters themselves*, not to bolting node pools onto already-running ones.

The residual cost of self-managing is that **CAPI core's generic cluster-cache still insists on connecting via a `<cluster>-kubeconfig` Secret — even when "the workload cluster" is itself.** That Secret was missing, so CAPI fell back to the stub `controlPlaneEndpoint` (`127.0.0.1`) in `capi-cluster.yaml` and could never reach the cluster to watch Nodes / set `Machine.status.nodeRef`. This PR supplies it — the one part of the design that needs a stored credential (the bootstrap path above deliberately needs none):

- **`capi-remote` SA + scoped `ClusterRole`** (`nodes` get/list/watch/patch/delete; `pods` get/list; `pods/eviction` create for drain; **`nonResourceURLs: ["/"]` get** for CAPI's cluster-cache health probe) + a non-expiring SA-token Secret — `capi-remote-rbac.yaml`.
- An **`ExternalSecret`** syncing the kubeconfig from 1Password into `<release>-capi-kubeconfig` — `capi-remote-kubeconfig-external-secret.yaml`. It's a `pre-upgrade` hook (lands before `helm --wait` evaluates the fleet MDs) with **`creationPolicy: Orphan`**: the hook's `before-hook-creation` policy deletes the prior ExternalSecret on every upgrade, and an Owner-created Secret would be garbage-collected with it (its ownerReference points at the ExternalSecret), disconnecting CAPI mid-deploy. Orphan keeps the Secret unowned; together with `deletionPolicy: Retain` the synced kubeconfig survives hook churn and an `--atomic` rollback.
- Enabled for managed envs in `values-managed-common.yaml`; **off by default** so self-hosters without the 1P item are unaffected.

### 2. tart-kubelet reload robustness

The CAPI provider's drift-loop reload ran `bootout`+`bootstrap` unconditionally and returned success on shell exit. On a headless Mac that pair races and re-registers the plist with Background Task Management, whose "legacy daemon" notification cap then stops honouring KeepAlive's automatic respawn — so a clean exit never restarts and the Node goes NotReady. Because the reconciler recorded the SHA roll as done regardless, it never retried and the Node stayed stranded (observed flapping canary's builders/runners fleets and blocking the deploy's `helm --wait`).

`loadTartKubeletLaunchd` now:
- Restarts in place with `kickstart -k` when the rendered plist is byte-identical to what's installed (the common binary-only roll) — no BTM re-registration churn; only rewrites + bootstraps on an actual arg change.
- Requires the new PID to be **stable** (same pid a few seconds later), not merely to appear, with a kickstart fallback, and exits non-zero otherwise so the reconciler keeps the drift set and retries instead of recording a roll that never took. (A no-op kickstart leaves the old process; a code-signing crash-loop briefly shows a transient pid on each respawn — the stability check rejects both.)

And `installTartKubelet` now **`codesign --force --sign -`s the binary right after upload**. Overwriting `/usr/local/bin/tart-kubelet` in place (same inode) leaves macOS's AMFI validating the new pages against the previous binary's cached cdhash, so the kernel kills the new process with `OS_REASON_CODESIGNING` and the Node goes NotReady — even though the Go linker ad-hoc signature is valid. A forced re-sign refreshes the signature and invalidates the stale cache so the rolled binary runs. (Surfaced by the canary providerID smoke-test, which codesigning-killed 2 of 3 minis on the roll.)

### 3. Node `providerID` — CAPI Node↔Machine binding

CAPI core binds a `Machine` to its `Node` by matching `Node.spec.providerID == Machine.spec.providerID`. tart-kubelet never set `Node.spec.providerID`, so every fleet node had to be patched by hand (`kubectl patch node … providerID`) before its MachineDeployment would report available — and any re-created/re-rolled node silently broke binding again. Threaded end to end:
- The provider already computes `scw-applesilicon://<zone>/<id>` and stores it on `Machine.spec.providerID`; it's now passed into `bootstrap.Config.ProviderID` for both first bootstrap (`Run`) and the drift roll (`UpdateTartKubelet`).
- `renderLaunchdPlist` emits a `--provider-id=<id>` flag when set.
- tart-kubelet's `nodeagent` sets `Node.spec.providerID` at registration and, for nodes that registered before this change, patches it when empty (`spec.providerID` is immutable once set, so it's never overwritten; the status-only heartbeat path can't write spec, so the patch happens in `ensureNode`).

This removes the manual-patch step from onboarding, and existing empty-providerID nodes (e.g. production's 11) get patched on the deploy's kubelet re-roll — so the cascade binds the fleet without a manual N-node patch.

## Why (root cause of the canary deploy failures)

Every fleet `MachineDeployment` was stuck `0 available` because CAPI couldn't bind Machines to Nodes (no workload connection, and no Node `providerID` to match), so `helm --atomic --wait` timed out at the 30m mark and rolled back — reverting good workloads (e.g. `runners-controller` `0.4.0 → 0.3.0`). CAPI fleet management was only added to the chart ~3 weeks ago (#10499, #10653) and the kubeconfig + providerID wiring was never completed. The reload fragility then turned each provider-image change into a fleet-wide flap that re-failed deploys.

We chose to *complete* the CAPI wiring (rather than de-gate `helm --wait` from the fleets) so MD "available" status becomes a real fleet-health signal the deploy can legitimately gate on.

## Validation

- **Full green gated canary deploy from this branch**: run `26589479994` → `helm` rev 185 `deployed` ("Upgrade complete"); all three fleet MDs `READY 1 / UNAVAILABLE 0 / Running`; server / processor / xcresult-processor ready. The provider image reverting to the chart-pinned tag caused no drift roll (its baked kubelet SHA matches what the minis run), so the fleet stayed stable through the deploy.
- **providerID + codesign validated by an out-of-band provider roll on canary**: rolling a provider image built from this branch re-rolled all three minis to the new kubelet, the `--provider-id=scw-applesilicon://…` flag rendered and was honored, and every node's providerID stayed unchanged (no-overwrite). The roll initially codesigning-killed 2 of 3 minis — which surfaced the `installTartKubelet` re-sign fix; a forced re-roll through the fixed path recovered all three (including a stranded macos-fleet, with no manual SSH), `fail=none`, providerIDs intact, all MDs `READY 1`.
- The reload fix validated live on the canary runners-fleet mini: the unchanged-plist path takes `kickstart -k`, restarts the daemon, and the stable-PID check correctly distinguishes a real restart from a no-op.
- `go build` / `go vet` / `go test` pass across `tart-kubelet`, `macos-host-bootstrap`, and `cluster-api-provider-scaleway-applesilicon`. New unit tests cover the `--provider-id` plist rendering and the `ensureNode` set-on-create / patch-empty / never-overwrite behavior.
- `helm template` renders the RBAC resources + the ExternalSecret (creationPolicy Orphan, deletionPolicy Retain, pre-upgrade hook) correctly and is gated off by default.

## One-time per cluster (not automatable — needs a runtime token)

The kubeconfig embeds the `capi-remote` SA token, which Helm can't template, so it's stored in 1Password like `MASTER_KEY` and friends. Steps are in `onboarding.md` §5b. Populated for staging / canary / production.

## Follow-ups (separate)

- **`--atomic` rollback trap.** Rolling back to a pre-`adoptPoolPrefix` revision is rejected by CRD validation, so a *failed* deploy can wedge the release in `pending-rollback`. Tracked separately (drop `--atomic`, or prune the pre-`adoptPoolPrefix` revisions).
- **Deletion-time mini leak.** Machine deletion can strand the Scaleway mini (server left running while the k8s object hangs on its finalizer). The fix is to return minis to the `tuist-pool-` pool on deletion rather than orphaning them. (Production's stranded macos mini was returned to the pool by hand this session; staging's stranded runners mini and an unnamed orphan are still pending.)

## Test plan

- [x] Populate `capi-workload-kubeconfig` in the canary 1P vault (per onboarding §5b).
- [x] Deploy to canary; CAPI binds the fleet Machines (`Running` with `nodeRef`) and the MachineDeployments go available; `helm --wait` passes (rev 185 deployed).
- [x] Populate the 1P item for staging + production.
- [ ] Build a provider image from this branch and roll it on canary; confirm fleet nodes get `spec.providerID` set automatically and an already-patched node is left unchanged.
- [ ] Confirm `helm --wait` passes on production and the cascade completes green (the kubelet re-roll patches production's 11 empty-providerID nodes).
