### PR TITLE
fix(cli): hash the resolved embedded product closure into the cache content hash

### DIFF
--- a/cli/Sources/TuistCore/Cache/TargetContentHashSubhashes.swift
+++ b/cli/Sources/TuistCore/Cache/TargetContentHashSubhashes.swift
@@ -36,6 +36,10 @@ public struct TargetContentHashSubhashes: Codable, Hashable, Sendable {
     public let additionalStrings: [String]
     /// Hash for external project targets (e.g., Swift packages).
     public let external: String?
+    /// Hash of the resolved set of products embedded into the target (resource bundles and embedded
+    /// frameworks). This is an emergent property of the dependency closure that isn't captured by the
+    /// per-dependency content hashes, so it's tracked separately.
+    public let embeddedProductReferences: String?
 
     public init(
         sources: String? = nil,
@@ -53,7 +57,8 @@ public struct TargetContentHashSubhashes: Codable, Hashable, Sendable {
         targetSettings: String? = nil,
         buildableFolders: String? = nil,
         additionalStrings: [String] = [],
-        external: String? = nil
+        external: String? = nil,
+        embeddedProductReferences: String? = nil
     ) {
         self.sources = sources
         self.resources = resources
@@ -71,6 +76,7 @@ public struct TargetContentHashSubhashes: Codable, Hashable, Sendable {
         self.buildableFolders = buildableFolders
         self.additionalStrings = additionalStrings
         self.external = external
+        self.embeddedProductReferences = embeddedProductReferences
     }
 
     #if DEBUG
@@ -90,7 +96,8 @@ public struct TargetContentHashSubhashes: Codable, Hashable, Sendable {
             targetSettings: String? = nil,
             buildableFolders: String? = nil,
             additionalStrings: [String] = [],
-            external: String? = nil
+            external: String? = nil,
+            embeddedProductReferences: String? = nil
         ) -> TargetContentHashSubhashes {
             TargetContentHashSubhashes(
                 sources: sources,
@@ -108,7 +115,8 @@ public struct TargetContentHashSubhashes: Codable, Hashable, Sendable {
                 targetSettings: targetSettings,
                 buildableFolders: buildableFolders,
                 additionalStrings: additionalStrings,
-                external: external
+                external: external,
+                embeddedProductReferences: embeddedProductReferences
             )
         }
     #endif

--- a/cli/Sources/TuistHasher/GraphContentHasher.swift
+++ b/cli/Sources/TuistHasher/GraphContentHasher.swift
@@ -106,6 +106,11 @@ public struct GraphContentHasher: GraphContentHashing {
             let directDepKeys = graphTraverser
                 .directTargetDependencies(path: target.path, name: target.target.name)
                 .map { GraphHashedTarget(projectPath: $0.graphTarget.path, targetName: $0.graphTarget.target.name) }
+            let embeddedProductReferences = graphTraverser
+                .resourceBundleDependencies(path: target.path, name: target.target.name)
+                .union(graphTraverser.embeddableFrameworks(path: target.path, name: target.target.name))
+                .map(\.hashIdentifier)
+                .sorted()
             let task = Task { () async throws -> TargetContentHash in
                 for depKey in directDepKeys {
                     if let depTask = tasks.value[depKey] {
@@ -117,6 +122,7 @@ public struct GraphContentHasher: GraphContentHashing {
                     hashedTargets: hashedTargets.value,
                     hashedPaths: hashedPaths.value,
                     destination: destination,
+                    embeddedProductReferences: embeddedProductReferences,
                     additionalStrings: additionalStrings
                 )
                 hashedPaths.mutate { $0.merge(hash.hashedPaths, uniquingKeysWith: { _, new in new }) }

--- a/cli/Sources/TuistHasher/GraphDependencyReference+HashIdentifier.swift
+++ b/cli/Sources/TuistHasher/GraphDependencyReference+HashIdentifier.swift
@@ -1,0 +1,34 @@
+import Path
+import TuistCore
+import XcodeGraph
+
+extension GraphDependencyReference {
+    /// A deterministic, machine-independent identifier for the reference, used to fold a target's
+    /// embedded product closure (resource bundles, embedded frameworks) into its content hash.
+    ///
+    /// It intentionally derives from product/bundle identity rather than absolute paths, so the hash
+    /// stays stable across machines and checkout locations while still changing when the set of
+    /// embedded products changes.
+    var hashIdentifier: String {
+        switch self {
+        case let .macro(path):
+            return "macro:\(path.basename)"
+        case let .foreignBuildOutput(path, linking, _):
+            return "foreignBuildOutput:\(path.basename):\(linking)"
+        case let .xcframework(path, _, _, _, _):
+            return "xcframework:\(path.basename)"
+        case let .library(path, linking, _, product, _):
+            return "library:\(path.basename):\(product.rawValue):\(linking)"
+        case let .framework(path, _, _, _, linking, _, product, _, _):
+            return "framework:\(path.basename):\(product.rawValue):\(linking)"
+        case let .bundle(path, _):
+            return "bundle:\(path.basename)"
+        case let .product(target, productName, _, _):
+            return "product:\(target):\(productName)"
+        case let .sdk(path, _, source, _):
+            return "sdk:\(path.basename):\(source)"
+        case let .packageProduct(product, _):
+            return "packageProduct:\(product)"
+        }
+    }
+}

--- a/cli/Sources/TuistHasher/TargetContentHasher.swift
+++ b/cli/Sources/TuistHasher/TargetContentHasher.swift
@@ -13,6 +13,7 @@ public protocol TargetContentHashing {
         hashedTargets: [GraphHashedTarget: String],
         hashedPaths: [AbsolutePath: String],
         destination: SimulatorDeviceAndRuntime?,
+        embeddedProductReferences: [String],
         additionalStrings: [String]
     ) async throws -> TargetContentHash
 }
@@ -122,8 +123,12 @@ public struct TargetContentHasher: TargetContentHashing {
         hashedTargets: [GraphHashedTarget: String],
         hashedPaths: [AbsolutePath: String],
         destination: SimulatorDeviceAndRuntime?,
+        embeddedProductReferences: [String] = [],
         additionalStrings: [String] = []
     ) async throws -> TargetContentHash {
+        let embeddedProductReferencesHash: String? = embeddedProductReferences.isEmpty
+            ? nil
+            : try contentHasher.hash(embeddedProductReferences.sorted())
         let projectHash: String? =
             switch graphTarget.project.type {
             case let .external(hash: hash): hash
@@ -156,6 +161,7 @@ public struct TargetContentHasher: TargetContentHashing {
                     projectSettingsHash,
                     settingsHash,
                     dependenciesHash.hash,
+                    embeddedProductReferencesHash,
                 ].compactMap { $0 } + destinations + additionalStrings
             )
 
@@ -168,6 +174,7 @@ public struct TargetContentHasher: TargetContentHashing {
                 projectSettings: \(projectSettingsHash)
                 targetSettings: \(settingsHash ?? "nil")
                 dependencies: \(dependenciesHash.hash)
+                embeddedProductReferences: \(embeddedProductReferencesHash ?? "nil")
                 destinations: \(destinations.joined(separator: ", "))
                 additionalStrings: \(additionalStrings.joined(separator: ", "))
             """)
@@ -177,7 +184,8 @@ public struct TargetContentHasher: TargetContentHashing {
                 projectSettings: projectSettingsHash,
                 targetSettings: settingsHash,
                 additionalStrings: additionalStrings,
-                external: projectHash
+                external: projectHash,
+                embeddedProductReferences: embeddedProductReferencesHash
             )
 
             return TargetContentHash(
@@ -325,6 +333,10 @@ public struct TargetContentHasher: TargetContentHashing {
             stringsToHash.append(foreignBuildHash)
         }
 
+        if let embeddedProductReferencesHash {
+            stringsToHash.append(embeddedProductReferencesHash)
+        }
+
         let hash = try contentHasher.hash(stringsToHash)
 
         Logger.current.debug("""
@@ -351,6 +363,7 @@ public struct TargetContentHasher: TargetContentHashing {
             deploymentTarget: \(deploymentTargetHash)
             infoPlist: \(infoPlistHash ?? "nil")
             entitlements: \(entitlementsHash ?? "nil")
+            embeddedProductReferences: \(embeddedProductReferencesHash ?? "nil")
         """)
 
         let subhashes = TargetContentHashSubhashes(
@@ -368,7 +381,8 @@ public struct TargetContentHasher: TargetContentHashing {
             projectSettings: projectSettingsHash,
             targetSettings: settingsHash,
             buildableFolders: buildableFoldersHash,
-            additionalStrings: additionalStrings
+            additionalStrings: additionalStrings,
+            embeddedProductReferences: embeddedProductReferencesHash
         )
 
         return TargetContentHash(

--- a/cli/Tests/TuistHasherTests/GraphContentHasherTests.swift
+++ b/cli/Tests/TuistHasherTests/GraphContentHasherTests.swift
@@ -109,4 +109,69 @@ struct GraphContentHasherTests {
         // Then
         #expect(hashedTargets == expectedCachableTargets)
     }
+
+    @Test
+    func contentHashes_passes_the_embedded_resource_bundle_closure_to_the_target_hasher() async throws {
+        // Given
+        let path: AbsolutePath = "/project"
+        let bundleTarget: Target = .test(
+            name: "Bundle",
+            product: .bundle,
+            infoPlist: nil,
+            entitlements: nil
+        )
+        let frameworkTarget: Target = .test(
+            name: "Framework",
+            product: .framework,
+            infoPlist: nil,
+            entitlements: nil
+        )
+        let project: Project = .test(
+            path: path,
+            targets: [frameworkTarget, bundleTarget]
+        )
+        let graph = Graph.test(
+            path: path,
+            projects: [path: project],
+            dependencies: [
+                .target(name: "Framework", path: path): Set([.target(name: "Bundle", path: path)]),
+            ]
+        )
+
+        let targetContentHasher = MockTargetContentHashing()
+        given(targetContentHasher)
+            .contentHash(
+                for: .any,
+                hashedTargets: .any,
+                hashedPaths: .any,
+                destination: .any,
+                embeddedProductReferences: .any,
+                additionalStrings: .any
+            )
+            .willReturn(TargetContentHash.test())
+        let subject = GraphContentHasher(
+            contentHasher: ContentHasher(),
+            targetContentHasher: targetContentHasher
+        )
+
+        // When
+        _ = try await subject.contentHashes(
+            for: graph,
+            include: { _ in true },
+            destination: nil,
+            additionalStrings: []
+        )
+
+        // Then
+        verify(targetContentHasher)
+            .contentHash(
+                for: .matching { $0.target.name == "Framework" },
+                hashedTargets: .any,
+                hashedPaths: .any,
+                destination: .any,
+                embeddedProductReferences: .value(["product:Bundle:Bundle.bundle"]),
+                additionalStrings: .any
+            )
+            .called(1)
+    }
 }

--- a/cli/Tests/TuistHasherTests/GraphDependencyReferenceHashIdentifierTests.swift
+++ b/cli/Tests/TuistHasherTests/GraphDependencyReferenceHashIdentifierTests.swift
@@ -1,0 +1,29 @@
+import Path
+import Testing
+import TuistCore
+import XcodeGraph
+
+@testable import TuistHasher
+
+struct GraphDependencyReferenceHashIdentifierTests {
+    @Test func product_reference_identifier_uses_target_and_product_name() {
+        // Given
+        let reference = GraphDependencyReference.product(
+            target: "Resources",
+            productName: "Resources.bundle"
+        )
+
+        // Then
+        #expect(reference.hashIdentifier == "product:Resources:Resources.bundle")
+    }
+
+    @Test func bundle_reference_identifier_is_independent_of_the_absolute_path() throws {
+        // Given
+        let a = GraphDependencyReference.bundle(path: try AbsolutePath(validating: "/checkout-a/Foo.bundle"))
+        let b = GraphDependencyReference.bundle(path: try AbsolutePath(validating: "/another/machine/Foo.bundle"))
+
+        // Then
+        #expect(a.hashIdentifier == "bundle:Foo.bundle")
+        #expect(a.hashIdentifier == b.hashIdentifier)
+    }
+}

--- a/cli/Tests/TuistHasherTests/TargetContentHasherTests.swift
+++ b/cli/Tests/TuistHasherTests/TargetContentHasherTests.swift
@@ -326,6 +326,82 @@ struct TargetContentHasherTests {
         #expect(gotWithDSStore.subhashes == gotWithoutDSStore.subhashes)
     }
 
+    @Test func hash_changes_when_embedded_product_references_differ() async throws {
+        // Given
+        let target = GraphTarget.test(project: .test())
+
+        // When
+        let withoutEmbedded = try await subject.contentHash(
+            for: target,
+            hashedTargets: [:],
+            hashedPaths: [:],
+            destination: nil,
+            embeddedProductReferences: []
+        )
+        let withEmbedded = try await subject.contentHash(
+            for: target,
+            hashedTargets: [:],
+            hashedPaths: [:],
+            destination: nil,
+            embeddedProductReferences: ["product:Resources:Resources.bundle"]
+        )
+
+        // Then
+        #expect(withoutEmbedded.hash != withEmbedded.hash)
+        #expect(withoutEmbedded.subhashes.embeddedProductReferences == nil)
+        #expect(withEmbedded.subhashes.embeddedProductReferences != nil)
+    }
+
+    @Test func hash_is_stable_regardless_of_embedded_product_references_order() async throws {
+        // Given
+        let target = GraphTarget.test(project: .test())
+
+        // When
+        let ordered = try await subject.contentHash(
+            for: target,
+            hashedTargets: [:],
+            hashedPaths: [:],
+            destination: nil,
+            embeddedProductReferences: ["product:A:A.bundle", "product:B:B.bundle"]
+        )
+        let reordered = try await subject.contentHash(
+            for: target,
+            hashedTargets: [:],
+            hashedPaths: [:],
+            destination: nil,
+            embeddedProductReferences: ["product:B:B.bundle", "product:A:A.bundle"]
+        )
+
+        // Then
+        #expect(ordered.hash == reordered.hash)
+    }
+
+    @Test func hash_for_external_target_changes_when_embedded_product_references_differ() async throws {
+        // Given
+        let target = GraphTarget.test(project: .test(type: .external(hash: "hash")))
+
+        // When
+        let withoutEmbedded = try await subject.contentHash(
+            for: target,
+            hashedTargets: [:],
+            hashedPaths: [:],
+            destination: nil,
+            embeddedProductReferences: []
+        )
+        let withEmbedded = try await subject.contentHash(
+            for: target,
+            hashedTargets: [:],
+            hashedPaths: [:],
+            destination: nil,
+            embeddedProductReferences: ["product:Resources:Resources.bundle"]
+        )
+
+        // Then
+        #expect(withoutEmbedded.hash != withEmbedded.hash)
+        #expect(withoutEmbedded.subhashes.embeddedProductReferences == nil)
+        #expect(withEmbedded.subhashes.embeddedProductReferences != nil)
+    }
+
     @Test func hash_with_destination() async throws {
         // Given
         let target = GraphTarget.test(


### PR DESCRIPTION
## Summary

A target's binary cache hash does not currently account for the set of products that get embedded into it (resource bundles and embedded frameworks). That set is an emergent property of the dependency closure, computed at generation time by `GraphTraverser.resourceBundleDependencies` / `embeddableFrameworks`, and it is not derivable from the per-dependency content hashes.

As a result, two builds whose embedding differs can share the same cache key while producing materially different XCFrameworks. This was observed in the wild as two cached artifacts under the same hash where one embedded SPM resource `.bundle`s directly inside the framework and the other did not (the artifacts also linked a different set of frameworks).

This PR folds a deterministic, machine-independent identifier for the resolved embedded-product closure into `TargetContentHasher`, so a change in what a target embeds always changes that target's cache key.

## Root cause

The content hash is computed over the graph before the generation mappers run. It includes each dependency's content hash (which already propagates product types, sources, settings, etc.), but it does not include the *result* of the embedding algorithm, i.e. which resource bundles and frameworks the target will actually copy in.

That result is a function of the whole dependency closure and of the generator's own embedding logic. So:

- A configuration change (e.g. flipping an SPM product between static and dynamic) is already captured, because it changes a dependency's `product.rawValue` and propagates.
- A generator-behavior change on an otherwise-identical graph (e.g. the static-framework resource embedding revert tracked by `CacheVersion`) is not captured by the dependency hashes, because no input changes, only the interpretation does. `CacheVersion` is the only existing guard for this, and it is a manual, global, all-or-nothing bump.

Hashing the resolved closure converts the embedding algorithm's output into a hashed input, giving automatic and targeted invalidation: only targets whose embedded set actually changes are invalidated.

## What changed

- New `GraphDependencyReference.hashIdentifier` (in `TuistHasher`): a deterministic identifier per reference derived from product/bundle identity rather than absolute paths, so the hash is stable across machines and checkout locations while still changing when the embedded set changes. For frameworks/libraries it retains `product` + `linking` since that encodes the static/dynamic distinction.
- `GraphContentHasher` computes `resourceBundleDependencies ∪ embeddableFrameworks` for each target via the traverser, maps to `hashIdentifier`, sorts, and passes the list to the target hasher.
- `TargetContentHasher` folds the list into both the local and external hash branches, the debug log, and a new `TargetContentHashSubhashes.embeddedProductReferences` subhash. It is sorted for order-independence and omitted entirely when empty, so unrelated target hashes are unchanged.

## Why this approach over the alternatives

- Just bumping `CacheVersion` would invalidate the affected artifacts once, but leaves the gap in place and the bug recurs the next time a generator behavior changes without a bump. It also nukes the entire global cache rather than just the affected targets.
- Hashing the closure narrows the reliance on `CacheVersion` for this class of change. `CacheVersion` remains the backstop for generator changes that alter output without changing this closure (signing, copy mechanics, other mappers).

## Validation

- `swift build --target TuistHasher` compiles cleanly.
- `TuistHasherTests` runs green (24 tests, 5 suites), including new tests written test-first:
  - hash changes when `embeddedProductReferences` differ, for both local and external target branches
  - hash is stable regardless of ordering
  - `GraphContentHasher` passes the resolved bundle closure (`product:Bundle:Bundle.bundle`) to the target hasher for a framework that embeds a bundle
  - `hashIdentifier` is correct for `.product` and path-independent for `.bundle`
- Existing `TargetContentHasher` exact-hash assertions still pass, confirming empty closures leave hashes unchanged.

## Note for operators

This adds an input to the content hash, so it invalidates cached artifacts once on rollout (expected and desirable, since it evicts any artifacts that collided under the old key). No `CacheVersion` bump is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)