### PR TITLE
feat(infra): set Node.spec.providerID from tart-kubelet so CAPI binds fleet nodes

### DIFF
--- a/infra/cluster-api-provider-scaleway-applesilicon/controllers/scalewayapplesiliconmachine_controller.go
+++ b/infra/cluster-api-provider-scaleway-applesilicon/controllers/scalewayapplesiliconmachine_controller.go
@@ -498,6 +498,7 @@ func (r *ScalewayAppleSiliconMachineReconciler) reconcileNormal(
 			UserPassword:         bootstrapCreds.SudoPassword,
 			SSHPrivateKey:        sshKey,
 			NodeName:             machine.Name,
+			ProviderID:           providerIDOf(machine),
 			Kubeconfig:           kubeconfigYAML,
 			TartKubeletBinary:    r.TartKubeletBinary,
 			TartTarball:          r.TartTarball,
@@ -596,6 +597,7 @@ func (r *ScalewayAppleSiliconMachineReconciler) reconcileNormal(
 			SSHUser:           bootstrapCreds.SSHUsername,
 			SSHPrivateKey:     sshKey,
 			NodeName:          machine.Name,
+			ProviderID:        providerIDOf(machine),
 			Kubeconfig:        kubeconfigYAML,
 			TartKubeletBinary: r.TartKubeletBinary,
 			TailscaleBinaries: r.TailscaleBinaries,
@@ -967,6 +969,17 @@ func machineIP(m *infrav1.ScalewayAppleSiliconMachine) string {
 		}
 	}
 	return ""
+}
+
+// providerIDOf returns the machine's providerID
+// (scw-applesilicon://<zone>/<id>), set once the server is ordered or
+// adopted. Empty until then — bootstrap renders no --provider-id flag
+// and a later reconcile re-renders the plist once it's known.
+func providerIDOf(m *infrav1.ScalewayAppleSiliconMachine) string {
+	if m.Spec.ProviderID == nil {
+		return ""
+	}
+	return *m.Spec.ProviderID
 }
 
 // hostCPUFor / hostMemoryMBFor select the per-Machine capacity

--- a/infra/macos-host-bootstrap/bootstrap.go
+++ b/infra/macos-host-bootstrap/bootstrap.go
@@ -71,6 +71,13 @@ type Config struct {
 	// nodes` reflects the inventory.
 	NodeName string
 
+	// ProviderID is the CAPI machine ID (scw-applesilicon://<zone>/<id>)
+	// rendered into tart-kubelet's --provider-id flag so it sets
+	// Node.spec.providerID — the field CAPI core matches to bind the
+	// Machine to its Node. Empty omits the flag (Node left unbound until
+	// patched by hand).
+	ProviderID string
+
 	// Kubeconfig is the YAML kubeconfig the controller built for this
 	// host (contains a long-lived ServiceAccount token + the API
 	// server's external URL + CA bundle). Dropped at
@@ -501,6 +508,15 @@ func renderLaunchdPlist(cfg Config) string {
 	if len(cfg.TailscaleBinaries) > 0 && cfg.TailscaleAuthKey != "" {
 		nodeIPSourceArg = "\n    <string>--node-ip-source=tailscale</string>"
 	}
+	// providerID binds the Node to its CAPI Machine. Rendered as a flag so
+	// freshly-provisioned and re-rolled nodes self-bind without a manual
+	// `kubectl patch node ... providerID`. Empty (e.g. before the server
+	// is ordered) omits it; tart-kubelet then leaves spec.providerID unset
+	// and a later reconcile re-renders the plist once it's known.
+	providerIDArg := ""
+	if cfg.ProviderID != "" {
+		providerIDArg = fmt.Sprintf("\n    <string>--provider-id=%s</string>", cfg.ProviderID)
+	}
 	// Run tart-kubelet as the SSH user (m1). Apple's
 	// Virtualization.framework requires the calling process to be the
 	// same user that holds the live GUI console session — Tart's
@@ -523,7 +539,7 @@ func renderLaunchdPlist(cfg Config) string {
     <string>--kubeconfig=/etc/tart-kubelet/kubeconfig</string>
     <string>--host-cpu=%[2]d</string>
     <string>--host-memory-mb=%[3]d</string>
-    <string>--max-pods=%[4]d</string>%[6]s%[7]s
+    <string>--max-pods=%[4]d</string>%[6]s%[7]s%[8]s
   </array>
   <key>RunAtLoad</key><true/>
   <key>KeepAlive</key><true/>
@@ -537,7 +553,7 @@ func renderLaunchdPlist(cfg Config) string {
   </dict>
 </dict>
 </plist>
-`, cfg.NodeName, cpu, mem, maxPods, user, nodeLabelsArg, nodeIPSourceArg)
+`, cfg.NodeName, cpu, mem, maxPods, user, nodeLabelsArg, nodeIPSourceArg, providerIDArg)
 }
 
 func shellQuote(s string) string {

--- a/infra/macos-host-bootstrap/bootstrap_test.go
+++ b/infra/macos-host-bootstrap/bootstrap_test.go
@@ -25,6 +25,24 @@ func TestRenderLaunchdPlist_OmitsNodeLabelsWhenEmpty(t *testing.T) {
 	}
 }
 
+func TestRenderLaunchdPlist_OmitsProviderIDWhenEmpty(t *testing.T) {
+	out := renderLaunchdPlist(Config{NodeName: "n1", SSHUser: "m1"})
+	if strings.Contains(out, "--provider-id") {
+		t.Fatalf("expected --provider-id to be absent when ProviderID is empty\n%s", out)
+	}
+}
+
+func TestRenderLaunchdPlist_RendersProviderID(t *testing.T) {
+	out := renderLaunchdPlist(Config{
+		NodeName:   "n1",
+		SSHUser:    "m1",
+		ProviderID: "scw-applesilicon://fr-par-1/abc-123",
+	})
+	if !strings.Contains(out, "<string>--provider-id=scw-applesilicon://fr-par-1/abc-123</string>") {
+		t.Fatalf("expected --provider-id flag in plist\n%s", out)
+	}
+}
+
 func TestRenderLaunchdPlist_RendersFleetLabel(t *testing.T) {
 	out := renderLaunchdPlist(Config{
 		NodeName:   "n1",

--- a/infra/tart-kubelet/cmd/tart-kubelet/main.go
+++ b/infra/tart-kubelet/cmd/tart-kubelet/main.go
@@ -54,6 +54,7 @@ func init() {
 func main() {
 	var (
 		nodeName           string
+		providerID         string
 		nodeIP             string
 		nodeIPSource       string
 		scrapeAllowedCIDRs cidrList
@@ -66,6 +67,8 @@ func main() {
 		tartBinary         string
 	)
 	flag.StringVar(&nodeName, "node-name", envOr("TART_KUBELET_NODE_NAME", ""), "Node name to register as. Defaults to os.Hostname() when empty.")
+	flag.StringVar(&providerID, "provider-id", envOr("TART_KUBELET_PROVIDER_ID", ""),
+		"Cloud providerID (e.g. scw-applesilicon://<zone>/<id>) to set on Node.spec.providerID. CAPI matches this against Machine.spec.providerID to bind the Machine to this Node; empty leaves it unset.")
 	flag.StringVar(&nodeIP, "node-ip", envOr("TART_KUBELET_NODE_IP", ""),
 		"Routable IP of this Mac mini. Pods that opt into Prometheus scraping advertise it as their PodIP and run a host-side forwarder on the host port. Defaults to the first non-loopback IPv4 address on a UP interface.")
 	flag.StringVar(&nodeIPSource, "node-ip-source", envOr("TART_KUBELET_NODE_IP_SOURCE", "auto"),
@@ -262,6 +265,7 @@ func main() {
 	if err := mgr.Add(&nodeagent.Maintainer{
 		Client:     mgr.GetClient(),
 		NodeName:   nodeName,
+		ProviderID: providerID,
 		NodeIP:     nodeIP,
 		NodeLabels: nodeLabels,
 		CPU:        hostCPU,

--- a/infra/tart-kubelet/internal/nodeagent/node.go
+++ b/infra/tart-kubelet/internal/nodeagent/node.go
@@ -28,6 +28,12 @@ import (
 type Maintainer struct {
 	Client   client.Client
 	NodeName string
+	// ProviderID is the cloud machine ID (scw-applesilicon://<zone>/<id>)
+	// the CAPI provider passes at bootstrap. CAPI core binds a Machine to
+	// its Node by matching Node.spec.providerID == Machine.spec.providerID;
+	// without it the fleet MachineDeployment never reports available.
+	// Empty leaves spec.providerID untouched.
+	ProviderID string
 	// NodeIP is the address advertised as the Node's InternalIP so
 	// in-cluster scrapers (alloy-metrics) targeting the Node role
 	// (host-level node_exporter at :9100, or any future host-bound
@@ -99,13 +105,26 @@ func (m *Maintainer) ensureNode(ctx context.Context) error {
 	err := m.Client.Get(ctx, types.NamespacedName{Name: m.NodeName}, node)
 	if apierrors.IsNotFound(err) {
 		node.Name = m.NodeName
+		if m.ProviderID != "" {
+			node.Spec.ProviderID = m.ProviderID
+		}
 		m.configureNode(node)
 		return m.Client.Create(ctx, node)
 	}
 	if err != nil {
 		return err
 	}
-	// Node already exists (kubelet restart): just refresh status.
+	// Node already exists (kubelet restart). spec.providerID is immutable
+	// once set, so only fill it when empty — this binds nodes that
+	// registered before tart-kubelet learned to set it. refresh() below
+	// writes only the status subresource, so the spec patch has to happen
+	// here.
+	if m.ProviderID != "" && node.Spec.ProviderID == "" {
+		node.Spec.ProviderID = m.ProviderID
+		if err := m.Client.Update(ctx, node); err != nil {
+			return err
+		}
+	}
 	return m.refresh(ctx)
 }
 

--- a/infra/tart-kubelet/internal/nodeagent/node_test.go
+++ b/infra/tart-kubelet/internal/nodeagent/node_test.go
@@ -4,9 +4,72 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
+
+func newNodeFakeClient(objs ...client.Object) client.Client {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	return fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&corev1.Node{}).
+		WithObjects(objs...).
+		Build()
+}
+
+func nodeProviderID(t *testing.T, c client.Client, name string) string {
+	t.Helper()
+	node := &corev1.Node{}
+	if err := c.Get(context.Background(), types.NamespacedName{Name: name}, node); err != nil {
+		t.Fatalf("get node: %v", err)
+	}
+	return node.Spec.ProviderID
+}
+
+func TestEnsureNodeSetsProviderIDOnCreate(t *testing.T) {
+	c := newNodeFakeClient()
+	m := &Maintainer{Client: c, NodeName: "mac-1", ProviderID: "scw-applesilicon://fr-par-1/abc", Heartbeat: time.Second}
+	if err := m.ensureNode(context.Background()); err != nil {
+		t.Fatalf("ensureNode: %v", err)
+	}
+	if got := nodeProviderID(t, c, "mac-1"); got != "scw-applesilicon://fr-par-1/abc" {
+		t.Fatalf("providerID = %q, want it set on create", got)
+	}
+}
+
+func TestEnsureNodePatchesEmptyProviderID(t *testing.T) {
+	existing := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "mac-1"}}
+	c := newNodeFakeClient(existing)
+	m := &Maintainer{Client: c, NodeName: "mac-1", ProviderID: "scw-applesilicon://fr-par-1/abc", Heartbeat: time.Second}
+	if err := m.ensureNode(context.Background()); err != nil {
+		t.Fatalf("ensureNode: %v", err)
+	}
+	if got := nodeProviderID(t, c, "mac-1"); got != "scw-applesilicon://fr-par-1/abc" {
+		t.Fatalf("providerID = %q, want it patched onto a node registered without one", got)
+	}
+}
+
+func TestEnsureNodeDoesNotOverwriteExistingProviderID(t *testing.T) {
+	existing := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "mac-1"},
+		Spec:       corev1.NodeSpec{ProviderID: "scw-applesilicon://fr-par-1/original"},
+	}
+	c := newNodeFakeClient(existing)
+	m := &Maintainer{Client: c, NodeName: "mac-1", ProviderID: "scw-applesilicon://fr-par-1/different", Heartbeat: time.Second}
+	if err := m.ensureNode(context.Background()); err != nil {
+		t.Fatalf("ensureNode: %v", err)
+	}
+	if got := nodeProviderID(t, c, "mac-1"); got != "scw-applesilicon://fr-par-1/original" {
+		t.Fatalf("providerID = %q, want the original left untouched (immutable)", got)
+	}
+}
 
 func conditionByType(conds []corev1.NodeCondition, t corev1.NodeConditionType) (corev1.NodeCondition, bool) {
 	for _, c := range conds {


### PR DESCRIPTION
## What changed

CAPI core binds a `Machine` to its `Node` by matching `Node.spec.providerID == Machine.spec.providerID`. tart-kubelet never set `Node.spec.providerID`, so every fleet node had to be patched by hand (`kubectl patch node … providerID`) before its `MachineDeployment` would report available — and any re-created/re-rolled node silently broke binding again. This is the follow-up flagged in #10981.

Threads the providerID end to end:

- **Provider → bootstrap.** The Scaleway provider already computes `scw-applesilicon://<zone>/<id>` and stores it on `Machine.spec.providerID` when it orders/adopts the server. Pass it into `bootstrap.Config.ProviderID` for both first bootstrap (`Run`) and the drift roll (`UpdateTartKubelet`).
- **bootstrap → plist.** `renderLaunchdPlist` emits a `--provider-id=<id>` flag when set (omitted when empty, e.g. before the server is ordered — a later reconcile re-renders the plist once it's known).
- **tart-kubelet → Node.** The `nodeagent` sets `Node.spec.providerID` at registration and, for nodes that registered *before* this change, patches it when empty. `spec.providerID` is immutable once set, so it's never overwritten; `refresh()` writes only the status subresource, so the spec write happens in `ensureNode`.

## Why separate from #10981

#10981 completes CAPI's *connection* to the cluster; this completes the *Node↔Machine match* that connection then uses. It spans 3 components (kubelet + provider + bootstrap) and changes the baked kubelet binary (so it triggers a drift roll on deploy), so it gets its own canary validation rather than bloating an already-green, ready-to-merge PR.

## Impact

- New / re-rolled fleet nodes self-bind — removes the manual `kubectl patch node … providerID` step from onboarding.
- **Existing nodes** registered without a providerID (e.g. production's 11) get it patched on the next kubelet roll, which the deploy performs anyway — so the production cascade can bind its fleet without a manual 11-node patch.

## Validation

- `go build` / `go vet` / `go test` pass across all three modules (`tart-kubelet`, `macos-host-bootstrap`, `cluster-api-provider-scaleway-applesilicon`).
- New unit tests: `renderLaunchdPlist` renders/omits `--provider-id`; `ensureNode` sets providerID on create, patches an empty one on an existing node, and never overwrites a set one.

## Test plan

- [ ] Build a provider image from this branch and roll it on canary; confirm the fleet nodes get `spec.providerID` set automatically (`kubectl get nodes -o custom-columns=NAME:.metadata.name,PID:.spec.providerID`) and CAPI still binds.
- [ ] Confirm a node that already had a hand-patched providerID is left unchanged.

> Stacked on #10981 (shares `bootstrap.go`). Retarget to `main` once #10981 merges.