### PR TITLE
fix(infra): disable Kura Cloudflare load balancing

### DIFF
--- a/infra/helm/tuist/values-managed-kura-region.yaml
+++ b/infra/helm/tuist/values-managed-kura-region.yaml
@@ -8,10 +8,10 @@ global:
     tuist.dev/service: kura
     tuist.dev/stack: managed
 
-# Regional Kura clusters still expose their per-region public and gRPC
-# endpoints through Hetzner LoadBalancer Services. This only disables
-# the Cloudflare-fronted global endpoint layer until the Cloudflare
-# pool quota is raised.
+# Regional Kura clusters expose their per-region public and gRPC
+# endpoints through Hetzner LoadBalancer Services. Keep Cloudflare load
+# balancing disabled until the pool quota is raised and the global
+# endpoint design is revisited.
 kuraGlobalEndpointsEnabled: false
 kuraGlobalEndpointsRequired: false
 
@@ -35,10 +35,7 @@ kuraController:
   telemetry:
     otlpTracesEndpoint: http://k8s-monitoring-alloy-receiver.observability.svc.cluster.local:4318/v1/traces
   cloudflareLoadBalancing:
-    # Keep Cloudflare credentials wired so destroy flows can still clean
-    # up any previously provisioned global endpoints after reconciliation
-    # is re-enabled.
-    enabled: true
+    enabled: false
     zoneName: tuist.dev
     apiTokenSecret:
       managed: true

--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -6,10 +6,10 @@
 #     -f infra/helm/tuist/values-managed-production.yaml \
 #     --set server.image.tag=$GIT_SHA
 
-# The production workload cluster still serves per-region Kura HTTPS and
-# gRPC traffic directly via Hetzner LoadBalancer Services. Disable the
-# Cloudflare-fronted global endpoint layer here too until the Cloudflare
-# pool quota is raised.
+# The production workload cluster serves Kura HTTPS and gRPC traffic
+# directly via Hetzner LoadBalancer Services. Keep Cloudflare load
+# balancing disabled until the pool quota is raised and the global
+# endpoint design is revisited.
 kuraGlobalEndpointsEnabled: false
 kuraGlobalEndpointsRequired: false
 
@@ -108,10 +108,7 @@ server:
 
 kuraController:
   cloudflareLoadBalancing:
-    # Keep Cloudflare credentials wired so destroy flows can still clean
-    # up any previously provisioned global endpoints after reconciliation
-    # is re-enabled.
-    enabled: true
+    enabled: false
     zoneName: tuist.dev
     apiTokenSecret:
       managed: true

--- a/infra/kura-controller/controllers/cloudflare.go
+++ b/infra/kura-controller/controllers/cloudflare.go
@@ -91,6 +91,39 @@ type cloudflareError struct {
 	Message string `json:"message"`
 }
 
+type cloudflareRequestError struct {
+	Method     string
+	Path       string
+	StatusCode int
+	Body       string
+	Errors     []cloudflareError
+}
+
+func (e cloudflareRequestError) Error() string {
+	if len(e.Errors) > 0 {
+		return fmt.Sprintf("cloudflare %s %s failed with status %d: %v", e.Method, e.Path, e.StatusCode, e.Errors)
+	}
+	return fmt.Sprintf("cloudflare %s %s failed with status %d: %s", e.Method, e.Path, e.StatusCode, e.Body)
+}
+
+func (e cloudflareRequestError) OriginLimitExceeded() bool {
+	if e.StatusCode != http.StatusBadRequest {
+		return false
+	}
+
+	body := strings.ToLower(e.Body)
+	if strings.Contains(body, "origin") && strings.Contains(body, "limit") {
+		return true
+	}
+	for _, err := range e.Errors {
+		message := strings.ToLower(err.Message)
+		if strings.Contains(message, "origin") && strings.Contains(message, "limit") {
+			return true
+		}
+	}
+	return false
+}
+
 type cloudflareZone struct {
 	ID      string `json:"id"`
 	Name    string `json:"name"`
@@ -461,7 +494,13 @@ func (c *cloudflareClient) do(ctx context.Context, method, path string, body any
 		return err
 	}
 	if httpResponse.StatusCode < 200 || httpResponse.StatusCode >= 300 {
-		return fmt.Errorf("cloudflare %s %s failed with status %d: %s", method, path, httpResponse.StatusCode, string(responseBody))
+		return cloudflareRequestError{
+			Method:     method,
+			Path:       path,
+			StatusCode: httpResponse.StatusCode,
+			Body:       string(responseBody),
+			Errors:     cloudflareErrors(responseBody),
+		}
 	}
 	if response == nil || len(responseBody) == 0 {
 		return nil
@@ -470,6 +509,16 @@ func (c *cloudflareClient) do(ctx context.Context, method, path string, body any
 		return err
 	}
 	return cloudflareResponseError(response)
+}
+
+func cloudflareErrors(body []byte) []cloudflareError {
+	var response struct {
+		Errors []cloudflareError `json:"errors"`
+	}
+	if err := json.Unmarshal(body, &response); err != nil {
+		return nil
+	}
+	return response.Errors
 }
 
 func cloudflareResponseError(response any) error {

--- a/infra/kura-controller/controllers/cloudflare_test.go
+++ b/infra/kura-controller/controllers/cloudflare_test.go
@@ -73,6 +73,35 @@ func TestCloudflareClientResolvesZoneMetadataFromZoneName(t *testing.T) {
 	}
 }
 
+func TestCloudflareClientClassifiesOriginLimitErrors(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/accounts/account-123/load_balancers/pools" {
+			t.Fatalf("unexpected request path: %s", r.URL.Path)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"success":false,"errors":[{"code":1000,"message":"origin limit exceeded for pool"}]}`))
+	}))
+	defer server.Close()
+
+	client := newCloudflareClient(CloudflareLoadBalancingConfig{
+		AccountID: "account-123",
+		ZoneID:    "zone-123",
+		APIToken:  "token",
+	})
+	client.baseURL = server.URL
+	client.httpClient = server.Client()
+
+	_, err := client.createPool(context.Background(), cloudflarePool{Name: "pool"})
+	if err == nil {
+		t.Fatal("expected Cloudflare request to fail")
+	}
+	if !cloudflareOriginLimitExceeded(err) {
+		t.Fatalf("expected origin limit error classification, got %v", err)
+	}
+}
+
 func TestJoinStatusMessage(t *testing.T) {
 	got := joinStatusMessage("3/3 replicas ready", "global endpoint reconciliation degraded: quota exceeded")
 

--- a/infra/kura-controller/controllers/kurainstance_controller.go
+++ b/infra/kura-controller/controllers/kurainstance_controller.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -168,11 +169,15 @@ func (r *KuraInstanceReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	globalStatusWarnings := []string{}
 	if r.CloudflareLoadBalancing.Enabled() && r.CloudflareLoadBalancing.ReconcileGlobalEndpoints {
 		if err := newCloudflareClient(r.CloudflareLoadBalancing).reconcileKuraLoadBalancers(ctx, instance); err != nil {
-			if r.CloudflareLoadBalancing.RequireGlobalEndpoints {
+			if cloudflareOriginLimitExceeded(err) {
+				logger.Error(err, "global endpoint reconciliation hit the Cloudflare origin limit; continuing with workload status update")
+				globalStatusWarnings = append(globalStatusWarnings, fmt.Sprintf("global endpoint reconciliation degraded: %v", err))
+			} else if r.CloudflareLoadBalancing.RequireGlobalEndpoints {
 				return ctrl.Result{}, err
+			} else {
+				logger.Error(err, "global endpoint reconciliation degraded; continuing with workload status update")
+				globalStatusWarnings = append(globalStatusWarnings, fmt.Sprintf("global endpoint reconciliation degraded: %v", err))
 			}
-			logger.Error(err, "global endpoint reconciliation degraded; continuing with workload status update")
-			globalStatusWarnings = append(globalStatusWarnings, fmt.Sprintf("global endpoint reconciliation degraded: %v", err))
 		} else {
 			statusGlobalPublicURL = globalPublicURL(instance)
 			statusGlobalGRPCPublicURL = globalGRPCPublicURL(instance)
@@ -213,6 +218,11 @@ func joinStatusMessage(primary string, extras ...string) string {
 		}
 	}
 	return strings.Join(parts, "; ")
+}
+
+func cloudflareOriginLimitExceeded(err error) bool {
+	var requestError cloudflareRequestError
+	return errors.As(err, &requestError) && requestError.OriginLimitExceeded()
 }
 
 func (r *KuraInstanceReconciler) reconcileConfigMap(ctx context.Context, instance *kurav1alpha1.KuraInstance) error {

--- a/server/lib/tuist_web/controllers/api/cache_controller.ex
+++ b/server/lib/tuist_web/controllers/api/cache_controller.ex
@@ -69,10 +69,20 @@ defmodule TuistWeb.API.CacheController do
   )
 
   def endpoints(conn, params) do
-    endpoints =
-      Accounts.get_cache_endpoints_for_handle(params[:account_handle], technology(conn))
+    technology = technology(conn)
 
-    json(conn, %{endpoints: endpoints})
+    endpoints =
+      params[:account_handle]
+      |> Accounts.get_cache_endpoints_for_handle(technology)
+      |> Enum.reject(&is_nil/1)
+
+    if technology == :kura and Enum.any?(endpoints, &(String.trim(&1) == "")) do
+      conn
+      |> put_status(:service_unavailable)
+      |> json(%{message: "Kura cache endpoint is unavailable."})
+    else
+      json(conn, %{endpoints: endpoints})
+    end
   end
 
   operation(:access,

--- a/server/test/tuist_web/controllers/api/cache_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/cache_controller_test.exs
@@ -250,6 +250,25 @@ defmodule TuistWeb.API.CacheControllerTest do
       response = json_response(conn, 200)
       assert response["endpoints"] == []
     end
+
+    test "returns service unavailable when Kura resolves to an empty endpoint", %{conn: conn} do
+      # Given
+      user = AccountsFixtures.user_fixture()
+      account = Accounts.get_account_from_user(user)
+
+      stub(Tuist.Environment, :kura_endpoints, fn -> [""] end)
+
+      conn =
+        conn
+        |> Authentication.put_current_user(user)
+        |> Headers.put_client_feature_flags(["kura"])
+
+      # When
+      conn = get(conn, ~p"/api/cache/endpoints?account_handle=#{account.name}")
+
+      # Then
+      assert json_response(conn, 503) == %{"message" => "Kura cache endpoint is unavailable."}
+    end
   end
 
   describe "GET /api/cache/access" do


### PR DESCRIPTION
Resolves <https://github.com/tuist/tuist/actions/runs/26625595391/job/78466263474>

Fixes the Kura cache endpoint failure mode where Cloudflare load-balancer origin quota exhaustion could leave the server returning an empty cache endpoint in a successful API response.

- Disable Kura Cloudflare load balancing entirely in the managed production and regional Kura Helm overlays so the controller is no longer wired with Cloudflare LB credentials or flags.
- Return `503` from the cache endpoints API when Kura endpoint resolution yields an empty endpoint instead of handing clients an invalid URL.
- Preserve structured Cloudflare API errors in the Kura controller and classify 400 origin-limit responses explicitly.
- Treat Cloudflare origin-limit failures as degraded global endpoint reconciliation so workload status can still converge without the controller entering the hard-error retry path if Cloudflare LB is re-enabled later.

### How to test locally

- `mise exec go -- go test ./...` from `infra/kura-controller`
- `mix test test/tuist_web/controllers/api/cache_controller_test.exs` from `server`
- `helm template tuist infra/helm/tuist -f infra/helm/tuist/values-managed-common.yaml -f infra/helm/tuist/values-managed-production.yaml --set server.image.tag=test --set kuraController.image.tag=test --set clickhouse.external.url=http://clickhouse.example.com | rg -n "cloudflare-api-token|CLOUDFLARE_API_TOKEN|cloudflare-zone|cloudflare-api-token|reconcile-global-endpoints|require-global-endpoints"`
- `helm template tuist infra/helm/tuist -f infra/helm/tuist/values-managed-kura-region.yaml --set kuraController.image.tag=test | rg -n "cloudflare-api-token|CLOUDFLARE_API_TOKEN|cloudflare-zone|cloudflare-api-token|reconcile-global-endpoints|require-global-endpoints"`
- `git diff --check`
