### PR TITLE
fix: reject invalid Kura deployment endpoints

### DIFF
--- a/infra/helm/tuist/values-managed-canary.yaml
+++ b/infra/helm/tuist/values-managed-canary.yaml
@@ -9,6 +9,9 @@
 #     -f infra/helm/tuist/values-managed-canary.yaml \
 #     --set server.image.tag=$GIT_SHA
 
+kuraGlobalEndpointsEnabled: false
+kuraGlobalEndpointsRequired: false
+
 server:
   replicaCount: 1
 
@@ -63,6 +66,12 @@ server:
       value: "15"
     - name: TUIST_OTEL_EXPORTER_OTLP_ENDPOINT
       value: http://k8s-monitoring-alloy-receiver.observability.svc.cluster.local:4317
+
+kuraController:
+  cloudflareLoadBalancing:
+    # Cloudflare Load Balancing is disabled for Kura. The server should use
+    # regional Kura endpoints and fail closed if no valid endpoint is resolved.
+    enabled: false
 
 objectStorage:
   external:

--- a/infra/helm/tuist/values-managed-staging.yaml
+++ b/infra/helm/tuist/values-managed-staging.yaml
@@ -8,6 +8,9 @@
 #     -f infra/helm/tuist/values-managed-staging.yaml \
 #     --set server.image.tag=$GIT_SHA
 
+kuraGlobalEndpointsEnabled: false
+kuraGlobalEndpointsRequired: false
+
 server:
   replicaCount: 1
 
@@ -82,6 +85,12 @@ server:
       requests:
         cpu: "100m"
         memory: "200Mi"
+
+kuraController:
+  cloudflareLoadBalancing:
+    # Cloudflare Load Balancing is disabled for Kura. The server should use
+    # regional Kura endpoints and fail closed if no valid endpoint is resolved.
+    enabled: false
 
 objectStorage:
   external:

--- a/server/lib/tuist_web/controllers/api/cache_controller.ex
+++ b/server/lib/tuist_web/controllers/api/cache_controller.ex
@@ -76,7 +76,7 @@ defmodule TuistWeb.API.CacheController do
       |> Accounts.get_cache_endpoints_for_handle(technology)
       |> Enum.reject(&is_nil/1)
 
-    if technology == :kura and Enum.any?(endpoints, &(String.trim(&1) == "")) do
+    if technology == :kura and Enum.any?(endpoints, &invalid_kura_endpoint_url?/1) do
       conn
       |> put_status(:service_unavailable)
       |> json(%{message: "Kura cache endpoint is unavailable."})
@@ -84,6 +84,14 @@ defmodule TuistWeb.API.CacheController do
       json(conn, %{endpoints: endpoints})
     end
   end
+
+  defp invalid_kura_endpoint_url?(endpoint) when is_binary(endpoint) do
+    uri = URI.parse(String.trim(endpoint))
+
+    uri.scheme not in ["http", "https"] or is_nil(uri.host) or uri.host == ""
+  end
+
+  defp invalid_kura_endpoint_url?(_endpoint), do: true
 
   operation(:access,
     summary: "Get first-class cache access scopes.",

--- a/server/test/tuist_web/controllers/api/cache_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/cache_controller_test.exs
@@ -269,6 +269,25 @@ defmodule TuistWeb.API.CacheControllerTest do
       # Then
       assert json_response(conn, 503) == %{"message" => "Kura cache endpoint is unavailable."}
     end
+
+    test "returns service unavailable when Kura resolves to an endpoint without a host", %{conn: conn} do
+      # Given
+      user = AccountsFixtures.user_fixture()
+      account = Accounts.get_account_from_user(user)
+
+      stub(Tuist.Environment, :kura_endpoints, fn -> ["https://"] end)
+
+      conn =
+        conn
+        |> Authentication.put_current_user(user)
+        |> Headers.put_client_feature_flags(["kura"])
+
+      # When
+      conn = get(conn, ~p"/api/cache/endpoints?account_handle=#{account.name}")
+
+      # Then
+      assert json_response(conn, 503) == %{"message" => "Kura cache endpoint is unavailable."}
+    end
   end
 
   describe "GET /api/cache/access" do


### PR DESCRIPTION
Resolves <https://github.com/tuist/tuist/actions/runs/26633002329>

The production deployment from #10990 stopped at the canary acceptance gate with `NSURLErrorBadURL (-1000)`. The canary app was still able to hand the CLI an invalid Kura cache endpoint, so production was skipped before rollout.

This tightens the server-side guard from only rejecting an empty string to rejecting any Kura endpoint that is not an HTTP or HTTPS URL with a host. That covers the observed invalid `https://` style endpoint as well as a blank endpoint, and returns `503` instead of a clean `200` response that the CLI later turns into a bad artifact URL.

It also disables Kura global endpoint reconciliation and required global endpoint readiness explicitly in staging and canary, matching production and the regional Kura chart. That keeps the pre-prod gates from trying to use the Cloudflare global endpoint path while Cloudflare Load Balancing is disabled.

### How to test locally

- `mix test test/tuist_web/controllers/api/cache_controller_test.exs`
- `helm template tuist infra/helm/tuist -f infra/helm/tuist/values-managed-common.yaml -f infra/helm/tuist/values-managed-canary.yaml --set server.image.tag=test --set kuraController.image.tag=test --set clickhouse.external.url=http://clickhouse.example.com | rg -n "cloudflare-api-token|CLOUDFLARE_API_TOKEN|cloudflare-zone|reconcile-global-endpoints|require-global-endpoints"`
- `helm template tuist infra/helm/tuist -f infra/helm/tuist/values-managed-common.yaml -f infra/helm/tuist/values-managed-staging.yaml --set server.image.tag=test --set kuraController.image.tag=test --set clickhouse.external.url=http://clickhouse.example.com | rg -n "cloudflare-api-token|CLOUDFLARE_API_TOKEN|cloudflare-zone|reconcile-global-endpoints|require-global-endpoints"`
- `helm template tuist infra/helm/tuist -f infra/helm/tuist/values-managed-common.yaml -f infra/helm/tuist/values-managed-production.yaml --set server.image.tag=test --set kuraController.image.tag=test --set clickhouse.external.url=http://clickhouse.example.com | rg -n "cloudflare-api-token|CLOUDFLARE_API_TOKEN|cloudflare-zone|reconcile-global-endpoints|require-global-endpoints"`
- `helm template tuist infra/helm/tuist -f infra/helm/tuist/values-managed-kura-region.yaml --set kuraController.image.tag=test | rg -n "cloudflare-api-token|CLOUDFLARE_API_TOKEN|cloudflare-zone|reconcile-global-endpoints|require-global-endpoints"`
- `git diff --check`
