### PR TITLE
fix(infra): expose Kura region in canary

### DIFF
--- a/infra/helm/tuist/values-managed-canary.yaml
+++ b/infra/helm/tuist/values-managed-canary.yaml
@@ -63,6 +63,8 @@ server:
       value: "15"
     - name: TUIST_OTEL_EXPORTER_OTLP_ENDPOINT
       value: http://k8s-monitoring-alloy-receiver.observability.svc.cluster.local:4317
+    - name: TUIST_KURA_AVAILABLE_REGIONS
+      value: eu-central
 
 objectStorage:
   external:


### PR DESCRIPTION
Resolves <https://github.com/tuist/tuist/actions/runs/26633002329>

> Describe here the purpose of your PR.

Canary currently shows the Kura cache servers card without any deployable regions because `TUIST_KURA_AVAILABLE_REGIONS` is not set in the canary Helm overlay. Production exposes `eu-central,us-east,us-west`, but `us-east` and `us-west` rely on external regional kubeconfigs that are only wired for production right now.

This exposes only the in-cluster `eu-central` Kura region in canary. That should make the Kura server controls visible for canary accounts without adding regional kubeconfig dependencies to the canary deployment.

### How to test locally

- `helm template tuist infra/helm/tuist -f infra/helm/tuist/values-managed-common.yaml -f infra/helm/tuist/values-managed-canary.yaml --set server.image.tag=test --set kuraController.image.tag=test --set clickhouse.external.url=http://clickhouse.example.com | rg -n "TUIST_KURA_AVAILABLE_REGIONS|TUIST_KURA_KUBECONFIG|reconcile-global-endpoints|require-global-endpoints|CLOUDFLARE_API_TOKEN|cloudflare-api-token"`
- `git diff --check`
