### PR TITLE
fix(cli): isolate acceptance fixtures from feature flags

### DIFF
--- a/cli/Sources/TuistAcceptanceTesting/TuistAcceptanceTestFixtureTestingTrait.swift
+++ b/cli/Sources/TuistAcceptanceTesting/TuistAcceptanceTestFixtureTestingTrait.swift
@@ -38,7 +38,9 @@ public struct TuistAcceptanceTestFixtureTestingTrait: TestTrait, SuiteTrait, Tes
 
             try await TuistEnvironmentTesting
                 .withMockedEnvironment {
-                    existingEnvVariables.forEach { Environment.mocked?.variables[$0.key] = $0.value }
+                    existingEnvVariables
+                        .filter { key, _ in !key.hasPrefix("TUIST_FEATURE_FLAG_") }
+                        .forEach { Environment.mocked?.variables[$0.key] = $0.value }
 
                     let fixtureTemporaryDirectory = temporaryDirectory.appending(
                         component: fixtureDirectory.basename


### PR DESCRIPTION
Resolves N/A

This isolates acceptance fixtures from ambient feature flag environment variables.

The canary cache acceptance tests intentionally mock their fixture environment, but the fixture trait was copying every outer environment variable back into the mocked environment. That allowed values like `TUIST_FEATURE_FLAG_KURA` from the outer `tuist test` wrapper to leak into nested fixture commands, so canary cache tests could unexpectedly request Kura endpoints even when the fixture itself did not opt into Kura.

This keeps the existing environment handoff behavior, but filters `TUIST_FEATURE_FLAG_*` at the fixture boundary. Tests that need a feature flag can still set it explicitly inside the fixture setup, while CI-level flags no longer change acceptance test behavior implicitly.

### How to test locally

- `git diff --check`
