### PR TITLE
ci(infra): extend platform install timeout

### DIFF
--- a/.github/workflows/server-deployment.yml
+++ b/.github/workflows/server-deployment.yml
@@ -307,7 +307,7 @@ jobs:
     concurrency:
       group: server-deploy-${{ inputs.environment }}-platform
       cancel-in-progress: false
-    timeout-minutes: 20
+    timeout-minutes: 30
     env:
       KUBECONFIG: ${{ github.workspace }}/.kube/config
     steps:


### PR DESCRIPTION
Resolves N/A

This extends the `platform-install` job timeout in the reusable server deployment workflow from 20 minutes to 30 minutes.

The production deployment for `4f4c89b439d778f78a3c4273a853cdd09a742fe2` was cancelled before the canary app deployment started. The canary platform chart job spent the full 20 minute job budget inside `actions/checkout`, specifically while fetching the pinned commit, and GitHub cancelled the job at the timeout boundary. The logs do not show slower Helm/platform reconciliation because the job never reached those steps.

This gives that pre-deploy platform leg more headroom so a transient checkout or runner/network stall does not consume the entire job budget before the actual platform reconciliation can run.

### How to test locally

- `git diff --check`
