### PR TITLE
ci(infra): skip Kura in canary acceptance tests (temporary)

### DIFF
--- a/.github/workflows/server-production-deployment.yml
+++ b/.github/workflows/server-production-deployment.yml
@@ -171,7 +171,15 @@ jobs:
       - name: Test
         env:
           TUIST_EE: 1
-        run: tuist test TuistCacheEEAcceptanceTests --no-selective-testing -- -retry-tests-on-failure -test-iterations 2
+        # Temporary: mise.toml's [env] sets TUIST_FEATURE_FLAG_KURA=1 globally,
+        # which makes the CLI route the cache through Kura. Canary's global Kura
+        # endpoints are intentionally unprovisioned, so the cache resolves to an
+        # empty URL and the suite fails with "bad URL". Drop the flag for this
+        # step (env-level, so it covers the EE canary harness too) until we run
+        # acceptance against Kura properly.
+        run: |
+          unset TUIST_FEATURE_FLAG_KURA
+          tuist test TuistCacheEEAcceptanceTests --no-selective-testing -- -retry-tests-on-failure -test-iterations 2
 
   # --------------------------------------------------------------------------
   # Production leg - standard path: canary ready + tests green. Promotes


### PR DESCRIPTION
## What changed

`unset TUIST_FEATURE_FLAG_KURA` in the `acceptance-tests` → `Test` step of `server-production-deployment.yml`, right before `tuist test TuistCacheEEAcceptanceTests`.

## Why

The canary acceptance suite (`TuistCacheEECanaryAcceptanceTests`) fails on every run with:

```
Client error … underlying error: Error Domain=NSURLErrorDomain Code=-1000 "bad URL"
```

Root cause (config + feature-flag, not the cache code):
- `mise.toml`'s global `[env]` sets `TUIST_FEATURE_FLAG_KURA = "1"` (so local dev exercises Kura). `mise-action` exports it into the CI environment.
- The CLI's `ClientFeatureFlags` is **presence-based** on `TUIST_FEATURE_FLAG_*` env vars, so it reads Kura as enabled, and `CacheURLStore` (`currentCacheEndpointKeySuffix`) routes the cache through the `"kura"` endpoint path.
- Canary **requires** global Kura endpoints (`kuraGlobalEndpointsRequired` defaults `true`; canary doesn't override it like production does) but has **none provisioned** → the cache resolves to an empty endpoint → the CLI builds a request from an empty URL → `-1000 "bad URL"`.

## Why #10993 didn't already cover it

#10993 stripped `TUIST_FEATURE_FLAG_*` from the **mocked** environment in the main-repo `TuistAcceptanceTestFixtureTestingTrait`. The failing suite lives in the private `cli/TuistCacheEE` submodule and doesn't route through that trait, so the flag still reached it. This unset is at the **environment level**, before the suite runs, so it's harness-agnostic — it covers the EE canary suite the code-level strip missed.

## Scope / safety

- **Temporary**, until we decide how to run acceptance against Kura.
- Canary keeps Kura enabled — **no server or values change**. Only the acceptance CLI stops opting into Kura, so the suite exercises the direct (Tigris) cache path.
- Harmless on envs where the flag isn't set (`unset` of an absent var is a no-op).

## Test plan

- [ ] Re-run the production cascade (or the `acceptance-tests` job); confirm `TuistCacheEECanaryAcceptanceTests` passes the cache scenarios (no more `-1000 "bad URL"`).