### PR TITLE
fix(cli): repair process working directory at startup when getcwd fails

### DIFF
--- a/cli/Sources/TuistEnvironment/Environment.swift
+++ b/cli/Sources/TuistEnvironment/Environment.swift
@@ -232,18 +232,7 @@ public struct Environment: Environmenting {
     }
 
     public func currentWorkingDirectory() async throws -> AbsolutePath {
-        do {
-            return try await FileSystem().currentWorkingDirectory()
-        } catch {
-            // Some CI environments leave the process with a working directory that
-            // `getcwd` can no longer resolve (e.g. it was deleted and recreated by a
-            // previous step), so `FileManager` reports an empty path. Fall back to the
-            // shell-provided `PWD` when it points at a valid absolute path.
-            if let pwd = variables["PWD"], let path = try? AbsolutePath(validating: pwd) {
-                return path
-            }
-            throw error
-        }
+        return try await FileSystem().currentWorkingDirectory()
     }
 
     private func variable(_ variableName: String) -> String? {

--- a/cli/Sources/TuistLoader/Loaders/ManifestLoader.swift
+++ b/cli/Sources/TuistLoader/Loaders/ManifestLoader.swift
@@ -344,11 +344,9 @@ public class ManifestLoader: ManifestLoading {
         ) + ["--tuist-dump"]
 
         do {
-            let workingDirectory = try await Environment.current.currentWorkingDirectory()
             let string = try await commandRunner.capture(
                 arguments: arguments,
-                environment: Environment.current.manifestLoadingVariables,
-                workingDirectory: workingDirectory
+                environment: Environment.current.manifestLoadingVariables
             )
 
             guard let startTokenRange = string.range(of: ManifestLoader.startManifestToken, options: .literal),

--- a/cli/Sources/tuist/Dependencies.swift
+++ b/cli/Sources/tuist/Dependencies.swift
@@ -30,6 +30,8 @@ private enum DependenciesError: LocalizedError {
 }
 
 private func initEnv() throws {
+    repairCurrentWorkingDirectoryIfNeeded()
+
     if CommandLine.arguments.contains("--quiet"), CommandLine.arguments.contains("--verbose") {
         throw DependenciesError.exclusiveOptionError("quiet", "verbose")
     }
@@ -45,6 +47,21 @@ private func initEnv() throws {
     if CommandLine.arguments.contains("--quiet") {
         setenv(Constants.EnvironmentVariables.quiet, "true", 1)
     }
+}
+
+/// Rebinds the process to `PWD` when `getcwd` can no longer resolve the working directory.
+///
+/// On CI a previous step can delete and recreate the working directory, leaving the process
+/// with a dangling cwd. `getcwd` then returns an empty path, which crashes any subprocess
+/// launch (`NSTask` rejects an empty `currentDirectoryURL`). Re-entering `PWD` repairs the
+/// process-wide cwd so every later `getcwd` succeeds.
+private func repairCurrentWorkingDirectoryIfNeeded() {
+    guard FileManager.default.currentDirectoryPath.isEmpty else { return }
+    guard let pwd = ProcessInfo.processInfo.environment["PWD"], !pwd.isEmpty else { return }
+    var isDirectory: ObjCBool = false
+    guard FileManager.default.fileExists(atPath: pwd, isDirectory: &isDirectory), isDirectory.boolValue
+    else { return }
+    _ = FileManager.default.changeCurrentDirectoryPath(pwd)
 }
 
 struct IgnoreOutputPipeline: StandardPipelining {


### PR DESCRIPTION
## What changed

Repair the process working directory once at startup. If `getcwd` reports an empty path but `$PWD` points to an existing directory, rebind the process to it ([cli/Sources/tuist/Dependencies.swift](cli/Sources/tuist/Dependencies.swift), `initEnv`). This also removes the now-redundant `Environment` PWD fallback and the explicit manifest working directory added in #10996.

## Why

Follow-up to #10996. That PR fixed the manifest-evaluation `getcwd` failure, but a customer's CI (CircleCI macOS, `tuist graph -f legacyJSON --no-open` via fastlane) then hit a second, uncatchable crash:

```
*** Terminating app due to uncaught exception 'NSInvalidArgumentException',
reason: '*** -[NSConcreteTask setCurrentDirectoryURL:]: non-file URL argument'
...
Command.CommandRunner.lookupExecutable(firstArgument:)
Command.CommandRunner.run(arguments:environment:workingDirectory:)
tuist.initDependencies(...)
```

## Root cause

The `Command` package has **two** `getcwd` dependencies:

1. `run()` resolves `FileManager.default.currentDirectoryPath` when no `workingDirectory` is passed — fixed for manifest evaluation in #10996.
2. `lookupExecutable()` runs `/usr/bin/which <name>` to locate any **non-absolute** executable and sets that helper's `currentDirectoryURL = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)`. When `getcwd` returns `""`, that's a non-file URL and `NSTask` raises an **uncatchable** ObjC exception.

tuist invokes many subprocesses by bare name (`git`, `swift`, `xcodebuild`, `xcode-select`, `lipo`, `chmod`, `open`, …), so site 2 is hit all over the place — `git` for run metadata runs early during startup, which is where the customer crashes. Passing an explicit `workingDirectory` to a single call site can never cover this; only commands invoked with an absolute path (e.g. the manifest loader's `/usr/bin/xcrun`) avoid it.

The common denominator of every symptom is that the process working directory is unresolvable. On CI a previous step deletes and recreates the working directory, leaving the process with a dangling cwd whose inode no longer exists, so `getcwd(3)` fails and `FileManager` returns an empty path.

## Why repair at startup instead of per-call-site

Hardening individual call sites (passing `workingDirectory`, or using absolute executable paths everywhere) is whack-a-mole across dozens of invocations, and new ones would silently reintroduce the crash. Repairing the cwd once, before any command runs, makes `getcwd` reliable **process-wide** — so manifest evaluation, executable lookup, `FileSystem`, and every other consumer just work. It runs in `initEnv`, the shared entry point for both macOS and Linux, and only acts when `getcwd` is actually broken (empty) and `$PWD` resolves to a real directory; healthy runs are untouched.

This supersedes #10996's mitigations, so they're removed here: with `getcwd` repaired, the `Environment` PWD fallback is unreachable and the manifest loader no longer needs an explicit working directory. (This also addresses @pepicrft's review note on the `Environment` fallback — the logic no longer lives there.)

## Impact

`tuist graph` and all other commands stop crashing on CI when the working directory was deleted/recreated but `$PWD` is still valid. No behavior change when `getcwd` resolves normally.

## Validation

- Read `CommandRunner` (Command 0.14.5): confirmed both `getcwd` sites and that site 2 (`lookupExecutable`) is reached for any bare-name executable, producing the `NSTask` crash on empty `getcwd`.
- Confirmed the crash is on the `initDependencies` / startup path (matches the customer's stack: `git` invoked early), which the repair runs before.
- Local SwiftPM build: `Build of product 'tuist' complete!`
