### PR TITLE
fix(cli): skip invalid activity logs during cache warm

### DIFF
--- a/cli/Sources/TuistXCActivityLog/XCActivityLogController.swift
+++ b/cli/Sources/TuistXCActivityLog/XCActivityLogController.swift
@@ -106,7 +106,8 @@ public struct XCActivityLogController: XCActivityLogControlling {
                     withoutBuildSpecificInformation: false
                 )
             } catch {
-                throw XCActivityLogControllerError.wrap(error, path: activityLogPath)
+                logSkippedBuildTimeExtraction(error: error, path: activityLogPath)
+                continue
             }
             let buildStep: BuildStep
             do {
@@ -117,7 +118,8 @@ public struct XCActivityLogController: XCActivityLogControlling {
                 )
                 .parse(activityLog: activityLog)
             } catch {
-                throw XCActivityLogControllerError.wrap(error, path: activityLogPath)
+                logSkippedBuildTimeExtraction(error: error, path: activityLogPath)
+                continue
             }
 
             for (targetName, targetBuildDuration) in flattenedXCLogParserBuildStep([buildStep])
@@ -134,6 +136,13 @@ public struct XCActivityLogController: XCActivityLogControlling {
         }
 
         return buildTimes
+    }
+
+    private func logSkippedBuildTimeExtraction(error: Error, path: AbsolutePath) {
+        let wrappedError = XCActivityLogControllerError.wrap(error, path: path)
+        Logger.current.warning(
+            "Skipping activity log build-time extraction: \(wrappedError.localizedDescription)"
+        )
     }
 
     private func flattenedXCLogParserBuildStep(_ buildSteps: [XCLogParser.BuildStep])

--- a/cli/Tests/TuistXCActivityLogTests/XCActivityLog/XCActivityLogControllerTests.swift
+++ b/cli/Tests/TuistXCActivityLogTests/XCActivityLog/XCActivityLogControllerTests.swift
@@ -31,6 +31,19 @@ struct XCActivityLogControllerTests {
         #expect(got == ["Framework": 4.696011543273926])
     }
 
+    @Test(.inTemporaryDirectory) func buildTimesByTarget_skipsInvalidActivityLog() async throws {
+        // Given
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let invalidActivityLog = temporaryDirectory.appending(component: "invalid.xcactivitylog")
+        try await fileSystem.writeText("not an activity log", at: invalidActivityLog)
+
+        // When
+        let got = try await subject.buildTimesByTarget(activityLogPaths: [invalidActivityLog])
+
+        // Then
+        #expect(got.isEmpty)
+    }
+
     @Test func parseCleanBuildXCActivityLog() async throws {
         // Given
         let cleanBuildXCActivityLog = try AbsolutePath(validating: #file).parentDirectory


### PR DESCRIPTION
Resolves no GitHub issue.

This fixes cache warming failures caused by invalid `.xcactivitylog` files collected during `tuist cache warm`.

The activity log parsing in this path is only used to attach build-time metadata before storing cache artifacts. If Xcode leaves behind an invalid or incomplete log, failing the whole cache warm is stricter than necessary because the artifact has already been built and can still be stored without timing metadata.

This change makes build-time extraction best-effort: invalid logs are skipped with a warning, while valid logs continue to contribute target build times.

### How to test locally

- `tuist generate TuistXCActivityLogTests --no-open`
- `xcodebuild test -workspace Tuist.xcworkspace -scheme TuistUnitTests -only-testing TuistXCActivityLogTests/XCActivityLogControllerTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""`
