### PR TITLE
ci(infra): skip canary on hotfix production deploys (hotfix)

### DIFF
--- a/.github/workflows/server-production-deployment.yml
+++ b/.github/workflows/server-production-deployment.yml
@@ -123,13 +123,17 @@ jobs:
           tags: |
             ${{ env.REGISTRY }}/${{ env.KURA_CONTROLLER_IMAGE_NAME }}:${{ steps.tag.outputs.image_tag }}
   # --------------------------------------------------------------------------
-  # Canary leg - deploys the pre-built image. Runs for every push (hotfix
-  # or not) and for manual dispatch. On hotfix pushes it still runs as a
-  # safety net; the hotfix fast-path below deploys production in parallel
-  # without waiting for tests.
+  # Canary leg - deploys the pre-built image. Runs on standard pushes and
+  # manual dispatch. Skipped on hotfix pushes: the whole point of the
+  # hotfix fast-path is to ship straight to production without waiting on
+  # the canary cascade, and running canary in parallel just doubles the
+  # rollout surface (and noise) for a push that explicitly opted out.
   # --------------------------------------------------------------------------
   canary:
     needs: build
+    if: >-
+      (github.event_name == 'push' && !contains(github.event.head_commit.message, '(hotfix)')) ||
+      github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/server-deployment.yml
     with:
       environment: canary
@@ -195,7 +199,8 @@ jobs:
   # Hotfix fast-path: push-to-main with "(hotfix)" in the commit subject
   # ships production without waiting for canary + acceptance tests. Kept
   # independent of the cascade so a flaky acceptance test can't block an
-  # urgent fix. Canary still runs above as a safety net.
+  # urgent fix; canary is skipped above on hotfix pushes so the fast-path
+  # is the only deploy in flight.
   # --------------------------------------------------------------------------
   production-hotfix:
     needs: build


### PR DESCRIPTION
## Why

Hotfix pushes (commit subject contains \`(hotfix)\`) intentionally bypass the canary cascade and ship straight to production via \`production-hotfix\`. The \`canary\` job had no \`if:\` gate, so it ran in parallel on every hotfix push under \"safety net\" framing — see [run 26747929047](https://github.com/tuist/tuist/actions/runs/26747929047), where the canary leg of an explicit hotfix push deploys to canary alongside the prod hotfix.

That defeats the point of the fast-path: a hotfix push that opted out of the cascade still triggers a canary rollout, doubling the surface, the helm churn, and the Slack noise.

## What

Gate the \`canary\` job behind the same condition as the standard \`production\` job — standard push **or** \`workflow_dispatch\`. On hotfix pushes:

- \`canary\` → skipped
- \`acceptance-tests\` (\`needs: canary\`) → skipped automatically (default \`if: success()\`)
- \`production\` → already skipped by its own condition
- \`production-hotfix\` → runs

On standard pushes and manual dispatch, behavior is unchanged: \`build → canary → acceptance-tests → production\`.

## Test plan

- [ ] Next hotfix push: confirm only \`build\` + \`production-hotfix\` run (no \`canary\` / \`acceptance-tests\` / \`production\`).
- [ ] Next standard push: confirm the full cascade still runs.
- [ ] \`workflow_dispatch\`: confirm the full cascade still runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)