### PR TITLE
fix(server): fall back from empty Kura endpoints

### DIFF
--- a/.github/workflows/server-production-deployment.yml
+++ b/.github/workflows/server-production-deployment.yml
@@ -171,15 +171,7 @@ jobs:
       - name: Test
         env:
           TUIST_EE: 1
-        # Temporary: mise.toml's [env] sets TUIST_FEATURE_FLAG_KURA=1 globally,
-        # which makes the CLI route the cache through Kura. Canary's global Kura
-        # endpoints are intentionally unprovisioned, so the cache resolves to an
-        # empty URL and the suite fails with "bad URL". Drop the flag for this
-        # step (env-level, so it covers the EE canary harness too) until we run
-        # acceptance against Kura properly.
-        run: |
-          unset TUIST_FEATURE_FLAG_KURA
-          tuist test TuistCacheEEAcceptanceTests --no-selective-testing -- -retry-tests-on-failure -test-iterations 2
+        run: tuist test TuistCacheEEAcceptanceTests --no-selective-testing -- -retry-tests-on-failure -test-iterations 2
 
   # --------------------------------------------------------------------------
   # Production leg - standard path: canary ready + tests green. Promotes

--- a/cli/Sources/TuistAcceptanceTesting/TuistAcceptanceTestFixtureTestingTrait.swift
+++ b/cli/Sources/TuistAcceptanceTesting/TuistAcceptanceTestFixtureTestingTrait.swift
@@ -16,9 +16,11 @@ import TuistTesting
 
 public struct TuistAcceptanceTestFixtureTestingTrait: TestTrait, SuiteTrait, TestScoping {
     let fixtureDirectory: AbsolutePath
+    let accountHandle: String?
 
-    init(fixture: String, fixturesDirectory: AbsolutePath = Fixtures.directory) {
+    init(fixture: String, fixturesDirectory: AbsolutePath = Fixtures.directory, accountHandle: String? = nil) {
         fixtureDirectory = fixturesDirectory.appending(component: fixture)
+        self.accountHandle = accountHandle
     }
 
     public func provideScope(
@@ -27,9 +29,10 @@ public struct TuistAcceptanceTestFixtureTestingTrait: TestTrait, SuiteTrait, Tes
         performing function: @Sendable () async throws -> Void
     ) async throws {
         let fileSystem = FileSystem()
-        let organizationHandle = String(UUID().uuidString.prefix(12).lowercased())
+        let fixtureAccountHandle = accountHandle ?? String(UUID().uuidString.prefix(12).lowercased())
         let projectHandle = String(UUID().uuidString.prefix(12).lowercased())
-        let fullHandle = "\(organizationHandle)/\(projectHandle)"
+        let fullHandle = "\(fixtureAccountHandle)/\(projectHandle)"
+        let createsOrganization = accountHandle == nil
         let email = try #require(ProcessInfo.processInfo.environment[EnvKey.authEmail.rawValue])
         let password = try #require(ProcessInfo.processInfo.environment[EnvKey.authPassword.rawValue])
 
@@ -47,7 +50,7 @@ public struct TuistAcceptanceTestFixtureTestingTrait: TestTrait, SuiteTrait, Tes
                     )
                     try await fileSystem.copy(fixtureDirectory, to: fixtureTemporaryDirectory)
                     try await TuistTest.$fixtureDirectory.withValue(fixtureTemporaryDirectory) {
-                        try await TuistTest.$fixtureAccountHandle.withValue(organizationHandle) {
+                        try await TuistTest.$fixtureAccountHandle.withValue(fixtureAccountHandle) {
                             try await TuistTest.$fixtureFullHandle.withValue(fullHandle) {
                                 let serverURL = Environment.current.variables["TUIST_URL"] ?? "https://canary.tuist.dev"
 
@@ -75,10 +78,12 @@ public struct TuistAcceptanceTestFixtureTestingTrait: TestTrait, SuiteTrait, Tes
                                         serverURL,
                                     ]
                                 )
-                                try await TuistTest.run(
-                                    OrganizationCreateCommand.self,
-                                    [organizationHandle, "--path", fixtureTemporaryDirectory.pathString]
-                                )
+                                if createsOrganization {
+                                    try await TuistTest.run(
+                                        OrganizationCreateCommand.self,
+                                        [fixtureAccountHandle, "--path", fixtureTemporaryDirectory.pathString]
+                                    )
+                                }
                                 try await TuistTest.run(
                                     ProjectCreateCommand.self,
                                     [fullHandle, "--path", fixtureTemporaryDirectory.pathString, "--build-system", "xcode"]
@@ -90,10 +95,12 @@ public struct TuistAcceptanceTestFixtureTestingTrait: TestTrait, SuiteTrait, Tes
                                         ProjectDeleteCommand.self,
                                         [fullHandle, "--path", fixtureTemporaryDirectory.pathString]
                                     )
-                                    try await TuistTest.run(
-                                        OrganizationDeleteCommand.self,
-                                        [organizationHandle, "--path", fixtureTemporaryDirectory.pathString]
-                                    )
+                                    if createsOrganization {
+                                        try await TuistTest.run(
+                                            OrganizationDeleteCommand.self,
+                                            [fixtureAccountHandle, "--path", fixtureTemporaryDirectory.pathString]
+                                        )
+                                    }
                                     try await TuistTest.run(
                                         LogoutCommand.self
                                     )
@@ -117,8 +124,9 @@ public struct TuistAcceptanceTestFixtureTestingTrait: TestTrait, SuiteTrait, Tes
 extension Trait where Self == TuistAcceptanceTestFixtureTestingTrait {
     public static func withFixtureConnectedToCanary(
         _ fixture: String,
-        fixturesDirectory: AbsolutePath = Fixtures.directory
+        fixturesDirectory: AbsolutePath = Fixtures.directory,
+        accountHandle: String? = nil
     ) -> Self {
-        return Self(fixture: fixture, fixturesDirectory: fixturesDirectory)
+        return Self(fixture: fixture, fixturesDirectory: fixturesDirectory, accountHandle: accountHandle)
     }
 }

--- a/cli/Tests/TuistCacheEEAcceptanceTests/TuistCacheEECanaryAcceptanceTests.swift
+++ b/cli/Tests/TuistCacheEEAcceptanceTests/TuistCacheEECanaryAcceptanceTests.swift
@@ -28,7 +28,7 @@ struct TuistCacheEECanaryAcceptanceTests {
         .withMockedEnvironment(inheritingVariables: ["PATH"]),
         .withMockedNoora,
         .withMockedLogger(forwardLogs: true),
-        .withFixtureConnectedToCanary("generated_project_with_caching_enabled")
+        .withFixtureConnectedToCanary("generated_project_with_caching_enabled", accountHandle: "tuist")
     ) func generated_project_with_caching_enabled() async throws {
         let fixtureDirectory = try #require(TuistTest.fixtureDirectory)
         let xcodeprojPath = fixtureDirectory.appending(component: "App.xcodeproj")
@@ -103,7 +103,7 @@ struct TuistCacheEECanaryAcceptanceTests {
         .withMockedEnvironment(inheritingVariables: ["PATH"]),
         .withMockedNoora,
         .withMockedLogger(forwardLogs: true),
-        .withFixtureConnectedToCanary("generated_multiplatform_app")
+        .withFixtureConnectedToCanary("generated_multiplatform_app", accountHandle: "tuist")
     ) func multiplatform_app_module_cache() async throws {
         let fixtureDirectory = try #require(TuistTest.fixtureDirectory)
         let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
@@ -146,7 +146,7 @@ struct TuistCacheEECanaryAcceptanceTests {
         .withMockedEnvironment(inheritingVariables: ["PATH"]),
         .withMockedNoora,
         .withMockedLogger(forwardLogs: true),
-        .withFixtureConnectedToCanary("generated_multiplatform_app")
+        .withFixtureConnectedToCanary("generated_multiplatform_app", accountHandle: "tuist")
     ) func multiplatform_app_selective_testing() async throws {
         let fixtureDirectory = try #require(TuistTest.fixtureDirectory)
         let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)

--- a/infra/k8s/clusters/README.md
+++ b/infra/k8s/clusters/README.md
@@ -33,7 +33,7 @@ clusters/
 | Cluster | CP | Workers |
 |---|---|---|
 | `tuist-staging` | 3× cpx22 | md-0: 2× cpx31 |
-| `tuist-canary` | 3× cpx22 | md-0: 2× cpx31 |
+| `tuist-canary` | 3× cpx22 | md-0: 2× cpx32; kura: 3× ccx13 (`pool=kura`) |
 | `tuist` (production) | 3× cpx22 | md-0: 2× ccx23 (`pool=general`); md-processor: 2× cpx62 (`pool=processor`, autoscaled 2→6); kura: 3× ccx13 (`pool=kura`, autoscaled 3→12) |
 | `tuist-kura-us-east` (production Kura `us-east-1`) | 3× ccx13 in `ash` | kura: 3× ccx13 (`pool=kura`, autoscaled 3→12) |
 | `tuist-kura-us-west` (production Kura `us-west-1`) | 3× ccx13 in `hil` | kura: 3× ccx13 (`pool=kura`, autoscaled 3→12) |

--- a/infra/k8s/clusters/cluster-canary.yaml
+++ b/infra/k8s/clusters/cluster-canary.yaml
@@ -1,5 +1,6 @@
 # Canary workload Cluster, topology mode against tuist-hcloud.
-# Mirrors staging shape.
+# Mirrors staging shape, plus a small Kura pool so the canary-only
+# managed Kura region exposed in account settings can actually schedule.
 apiVersion: cluster.x-k8s.io/v1beta2
 kind: Cluster
 metadata:
@@ -44,6 +45,20 @@ spec:
           name: md-0
           replicas: 2
           failureDomain: fsn1
+        # Dedicated Kura pool. Kura StatefulSets default to this node
+        # selector and use hard hostname spread, so keep three workers
+        # for the default three replicas.
+        - class: hcloud-worker
+          name: kura
+          replicas: 3
+          failureDomain: fsn1
+          metadata:
+            labels:
+              node.cluster.x-k8s.io/pool: kura
+          variables:
+            overrides:
+              - name: hcloudWorkerMachineType
+                value: ccx13
         # Linux runner pool on Hetzner Robot bare metal. The
         # `hetzner-robot-controller` reflects `tuist-bm-canary-*`
         # Robot servers into HBM CRs stamped

--- a/server/lib/tuist/accounts.ex
+++ b/server/lib/tuist/accounts.ex
@@ -1933,7 +1933,8 @@ defmodule Tuist.Accounts do
   - The account has `custom_cache_endpoints_enabled` set to `true`
   - The account has at least one custom cache endpoint configured
 
-  For Kura, account-specific endpoints are returned only when they have been configured.
+  For Kura, configured Kura endpoints are returned when available. When none are configured or usable,
+  the default cache endpoints are returned so clients can fall back to Tuist-hosted cache nodes.
   """
   def get_cache_endpoints_for_handle(account_handle, technology \\ :default)
 
@@ -1952,22 +1953,24 @@ defmodule Tuist.Accounts do
   end
 
   def get_cache_endpoints_for_handle(account_handle, :kura) when is_binary(account_handle) do
-    case Environment.kura_endpoints() do
-      endpoints when is_list(endpoints) ->
-        endpoints
+    account_handle
+    |> kura_endpoint_urls()
+    |> case do
+      [] ->
+        get_cache_endpoints_for_handle(account_handle, :default)
 
-      nil ->
-        case get_account_by_handle(account_handle) do
-          %Account{} = account -> kura_cache_endpoint_urls(account)
-          _ -> []
-        end
+      endpoints ->
+        endpoints
     end
   end
 
   def get_cache_endpoints_for_handle(_, :default), do: CacheEndpoints.active_endpoint_urls()
 
   def get_cache_endpoints_for_handle(_, :kura) do
-    Environment.kura_endpoints() || []
+    case configured_kura_endpoint_urls() do
+      [] -> CacheEndpoints.active_endpoint_urls()
+      endpoints -> endpoints
+    end
   end
 
   defp custom_cache_endpoints(%Account{custom_cache_endpoints_enabled: true} = account) do
@@ -1983,6 +1986,29 @@ defmodule Tuist.Accounts do
   defp kura_cache_endpoints(%Account{} = account), do: list_account_cache_endpoints(account, :kura)
 
   defp kura_cache_endpoints(_), do: []
+
+  defp kura_endpoint_urls(account_handle) do
+    case configured_kura_endpoint_urls() do
+      [] ->
+        case get_account_by_handle(account_handle) do
+          %Account{} = account -> kura_cache_endpoint_urls(account)
+          _ -> []
+        end
+
+      endpoints ->
+        endpoints
+    end
+  end
+
+  defp configured_kura_endpoint_urls do
+    Environment.kura_endpoints()
+    |> case do
+      endpoints when is_list(endpoints) -> endpoints
+      _ -> []
+    end
+    |> Enum.map(&String.trim/1)
+    |> Enum.reject(&(&1 == ""))
+  end
 
   defp kura_cache_endpoint_urls(%Account{} = account) do
     endpoints = kura_cache_endpoints(account)

--- a/server/package.json
+++ b/server/package.json
@@ -13,7 +13,7 @@
       "vue-demi"
     ],
     "overrides": {
-      "axios": "1.15.2",
+      "axios": "1.16.0",
       "mdast-util-to-hast": "13.2.1",
       "ajv": "8.18.0",
       "dompurify": "3.4.0",

--- a/server/pnpm-lock.yaml
+++ b/server/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 overrides:
   ajv: 8.18.0
-  axios: 1.15.2
+  axios: 1.16.0
   defu: 6.1.5
   dompurify: 3.4.0
   fast-uri: 3.1.2
@@ -21,7 +21,7 @@ time:
   '@protobufjs/codegen@2.0.5': 2026-04-27T20:30:11.789Z
   '@protobufjs/inquire@1.1.1': 2026-04-27T20:32:10.012Z
   '@protobufjs/utf8@1.1.1': 2026-04-27T20:31:28.490Z
-  axios@1.15.2: 2026-04-21T17:53:03.731Z
+  axios@1.16.0: 2026-05-02T15:04:00.274Z
   fast-uri@3.1.2: 2026-05-05T08:31:31.849Z
   protobufjs@7.5.8: 2026-05-12T09:40:11.300Z
 
@@ -519,7 +519,7 @@ packages:
     resolution: {integrity: sha512-SDobKBbPIOe0cVL7QxMzGkuUGHvWTdihi9zOrrWaWUgFKe15cwEcwfWmgrcNzjT6kHnNmWuTajPHoIzUjYNYYQ==}
     peerDependencies:
       async-validator: ^4
-      axios: 1.15.0
+      axios: 1.16.0
       change-case: ^5
       drauu: ^0.4
       focus-trap: ^7
@@ -603,8 +603,8 @@ packages:
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
-  axios@1.15.2:
-    resolution: {integrity: sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==}
+  axios@1.16.0:
+    resolution: {integrity: sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==}
 
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
@@ -1906,7 +1906,7 @@ snapshots:
       '@scalar/workspace-store': 0.44.0
       '@types/har-format': 1.2.16
       '@vueuse/core': 13.9.0(vue@3.5.30(typescript@5.9.3))
-      '@vueuse/integrations': 13.9.0(axios@1.15.2)(focus-trap@7.8.0)(fuse.js@7.1.0)(vue@3.5.30(typescript@5.9.3))
+      '@vueuse/integrations': 13.9.0(axios@1.16.0)(focus-trap@7.8.0)(fuse.js@7.1.0)(vue@3.5.30(typescript@5.9.3))
       focus-trap: 7.8.0
       fuse.js: 7.1.0
       js-base64: 3.7.8
@@ -2317,13 +2317,13 @@ snapshots:
       '@vueuse/shared': 13.9.0(vue@3.5.30(typescript@5.9.3))
       vue: 3.5.30(typescript@5.9.3)
 
-  '@vueuse/integrations@13.9.0(axios@1.15.2)(focus-trap@7.8.0)(fuse.js@7.1.0)(vue@3.5.30(typescript@5.9.3))':
+  '@vueuse/integrations@13.9.0(axios@1.16.0)(focus-trap@7.8.0)(fuse.js@7.1.0)(vue@3.5.30(typescript@5.9.3))':
     dependencies:
       '@vueuse/core': 13.9.0(vue@3.5.30(typescript@5.9.3))
       '@vueuse/shared': 13.9.0(vue@3.5.30(typescript@5.9.3))
       vue: 3.5.30(typescript@5.9.3)
     optionalDependencies:
-      axios: 1.15.2
+      axios: 1.16.0
       focus-trap: 7.8.0
       fuse.js: 7.1.0
 
@@ -2371,7 +2371,7 @@ snapshots:
 
   asynckit@0.4.0: {}
 
-  axios@1.15.2:
+  axios@1.16.0:
     dependencies:
       follow-redirects: 1.16.0(debug@4.4.1)
       form-data: 4.0.5
@@ -3383,7 +3383,7 @@ snapshots:
   typesense@3.0.5(@babel/runtime@7.29.2):
     dependencies:
       '@babel/runtime': 7.29.2
-      axios: 1.15.2
+      axios: 1.16.0
       loglevel: 1.9.2
       tslib: 2.8.1
     transitivePeerDependencies:

--- a/server/test/tuist/accounts_test.exs
+++ b/server/test/tuist/accounts_test.exs
@@ -4223,9 +4223,11 @@ defmodule Tuist.AccountsTest do
       assert endpoints == ["https://#{account.name}.kura.tuist.dev"]
     end
 
-    test "returns no Kura endpoints when account has none configured" do
+    test "returns default endpoints when account has no Kura endpoints configured" do
       # Given
+      default_endpoints = ["https://default.tuist.dev"]
       stub(Environment, :kura_endpoints, fn -> nil end)
+      stub(Environment, :cache_endpoints, fn -> default_endpoints end)
       user = AccountsFixtures.user_fixture()
       account = Accounts.get_account_from_user(user)
 
@@ -4233,15 +4235,17 @@ defmodule Tuist.AccountsTest do
       endpoints = Accounts.get_cache_endpoints_for_handle(account.name, :kura)
 
       # Then
-      assert endpoints == []
+      assert endpoints == default_endpoints
     end
 
-    test "does not return a stale global Kura endpoint without regional endpoints" do
+    test "returns default endpoints instead of a stale global Kura endpoint without regional endpoints" do
       # Given
+      default_endpoints = ["https://default.tuist.dev"]
       stub(Environment, :tuist_hosted?, fn -> true end)
       stub(Environment, :dev?, fn -> false end)
       stub(Environment, :test?, fn -> false end)
       stub(Environment, :kura_endpoints, fn -> nil end)
+      stub(Environment, :cache_endpoints, fn -> default_endpoints end)
       user = AccountsFixtures.user_fixture()
       account = Accounts.get_account_from_user(user)
 
@@ -4255,7 +4259,7 @@ defmodule Tuist.AccountsTest do
       endpoints = Accounts.get_cache_endpoints_for_handle(account.name, :kura)
 
       # Then
-      assert endpoints == []
+      assert endpoints == default_endpoints
     end
   end
 

--- a/server/test/tuist_web/controllers/api/cache_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/cache_controller_test.exs
@@ -231,12 +231,19 @@ defmodule TuistWeb.API.CacheControllerTest do
                Enum.sort(["https://kura-cache-1.example.com", "https://kura-cache-2.example.com"])
     end
 
-    test "returns empty list when Kura is requested without account-specific endpoints", %{
+    test "returns default endpoints when Kura is requested without account-specific endpoints", %{
       conn: conn
     } do
       # Given
       user = AccountsFixtures.user_fixture()
       account = Accounts.get_account_from_user(user)
+
+      default_endpoints = [
+        "https://cache-eu-central-test.tuist.dev",
+        "https://cache-us-east-test.tuist.dev"
+      ]
+
+      stub(Tuist.Environment, :cache_endpoints, fn -> default_endpoints end)
 
       conn =
         conn
@@ -248,15 +255,21 @@ defmodule TuistWeb.API.CacheControllerTest do
 
       # Then
       response = json_response(conn, 200)
-      assert response["endpoints"] == []
+      assert response["endpoints"] == default_endpoints
     end
 
-    test "returns service unavailable when Kura resolves to an empty endpoint", %{conn: conn} do
+    test "returns default endpoints when Kura resolves to an empty endpoint", %{conn: conn} do
       # Given
       user = AccountsFixtures.user_fixture()
       account = Accounts.get_account_from_user(user)
 
+      default_endpoints = [
+        "https://cache-eu-central-test.tuist.dev",
+        "https://cache-us-east-test.tuist.dev"
+      ]
+
       stub(Tuist.Environment, :kura_endpoints, fn -> [""] end)
+      stub(Tuist.Environment, :cache_endpoints, fn -> default_endpoints end)
 
       conn =
         conn
@@ -267,7 +280,34 @@ defmodule TuistWeb.API.CacheControllerTest do
       conn = get(conn, ~p"/api/cache/endpoints?account_handle=#{account.name}")
 
       # Then
-      assert json_response(conn, 503) == %{"message" => "Kura cache endpoint is unavailable."}
+      response = json_response(conn, 200)
+      assert response["endpoints"] == default_endpoints
+    end
+
+    test "returns default endpoints when configured Kura endpoints are empty", %{conn: conn} do
+      # Given
+      user = AccountsFixtures.user_fixture()
+      account = Accounts.get_account_from_user(user)
+
+      default_endpoints = [
+        "https://cache-eu-central-test.tuist.dev",
+        "https://cache-us-east-test.tuist.dev"
+      ]
+
+      stub(Tuist.Environment, :kura_endpoints, fn -> [] end)
+      stub(Tuist.Environment, :cache_endpoints, fn -> default_endpoints end)
+
+      conn =
+        conn
+        |> Authentication.put_current_user(user)
+        |> Headers.put_client_feature_flags(["kura"])
+
+      # When
+      conn = get(conn, ~p"/api/cache/endpoints?account_handle=#{account.name}")
+
+      # Then
+      response = json_response(conn, 200)
+      assert response["endpoints"] == default_endpoints
     end
   end
 


### PR DESCRIPTION
## What changed

- Canary Kura acceptance tests now reuse the existing `tuist` account and create random projects under it, instead of creating random temporary organizations.
- The production deployment workflow no longer strips `TUIST_FEATURE_FLAG_KURA` from the acceptance test step, so the canary leg exercises Kura again.
- Server Kura endpoint resolution now falls back to the existing cache endpoints when the account-scoped Kura endpoint list is empty or the configured global Kura endpoint list only contains blanks.
- Canary cluster config now declares a `kura` worker pool labeled with `node.cluster.x-k8s.io/pool=kura`, matching the scheduler selector used by Kura pods.

## Why

Kura servers are scoped to an account. In canary, the Kura servers are bound to `tuist`, but the acceptance tests were creating temporary organizations. With `TUIST_FEATURE_FLAG_KURA=1`, those temporary accounts requested Kura endpoints and got no usable endpoint back, which led the CLI into a bad cache URL path.

There was also an infrastructure issue in canary: the Kura StatefulSet pods were pending because they select `node.cluster.x-k8s.io/pool=kura`, but the cluster had no nodes with that pool label.

## Impact

The acceptance tests create isolated random projects while using the account that owns the canary Kura nodes. When Kura is unavailable or has no endpoints, clients still receive the normal cache endpoints instead of an empty list.

## Validation

- `swiftformat cli/Sources/TuistAcceptanceTesting/TuistAcceptanceTestFixtureTestingTrait.swift cli/Tests/TuistCacheEEAcceptanceTests/TuistCacheEECanaryAcceptanceTests.swift`
- `tuist install`
- `mise run cli:ee`
- `TUIST_EE=1 tuist generate TuistAcceptanceTesting TuistCacheEEAcceptanceTests --no-open`
- `xcodebuild build -workspace Tuist.xcworkspace -scheme TuistCacheEEAcceptanceTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""`
- `mix format --check-formatted lib/tuist/accounts.ex test/tuist_web/controllers/api/cache_controller_test.exs`
- `MIX_ENV=test mix ecto.reset`
- `mix test test/tuist_web/controllers/api/cache_controller_test.exs`
- `git diff --check origin/main...HEAD`
- Canary diagnosis with `kubectl`: `kura-tuist-eu-central-1-0` was pending because no node matched `node.cluster.x-k8s.io/pool=kura`.
