### PR TITLE
fix(cli): finish test command early when every test target is filtered out

### DIFF
--- a/cli/Sources/TuistKit/Services/TestService.swift
+++ b/cli/Sources/TuistKit/Services/TestService.swift
@@ -1574,7 +1574,7 @@ public struct TestService { // swiftlint:disable:this type_body_length
         else {
             if action == .build {
                 Logger.current.notice(
-                    "The scheme \(scheme.name) has no test targets left to build after filtering, skipping."
+                    "The scheme \(scheme.name) has no testable targets to build, skipping."
                 )
                 return
             }

--- a/cli/Sources/TuistKit/Services/TestService.swift
+++ b/cli/Sources/TuistKit/Services/TestService.swift
@@ -469,6 +469,7 @@ public struct TestService { // swiftlint:disable:this type_body_length
             graph: graph,
             action: action,
             requestedTestTargets: testTargets,
+            skipTestTargets: skipTestTargets,
             passthroughXcodeBuildArguments: passthroughXcodeBuildArguments
         ) {
             if action == .build {
@@ -1315,6 +1316,7 @@ public struct TestService { // swiftlint:disable:this type_body_length
         graph: Graph,
         action: XcodeBuildTestAction,
         requestedTestTargets: [TestIdentifier] = [],
+        skipTestTargets: [TestIdentifier] = [],
         passthroughXcodeBuildArguments: [String] = []
     ) -> Bool {
         let testActionTargets = testActionTargets(
@@ -1373,7 +1375,25 @@ public struct TestService { // swiftlint:disable:this type_body_length
             return false
         }
 
-        let testedTargetNames = targetsAfterPassthroughSkip.map(\.name).sorted()
+        let skippedTargetNames = Set(
+            skipTestTargets
+                .filter { $0.class == nil && $0.method == nil }
+                .map(\.target)
+        )
+        let buildableTargets = targetsAfterPassthroughSkip.filter { target in
+            if requestedTargetNames.isEmpty {
+                return !skippedTargetNames.contains(target.name)
+            } else {
+                return requestedTargetNames.contains(target.name)
+            }
+        }
+
+        if buildableTargets.isEmpty {
+            Logger.current.notice("There are no test targets to run, finishing early")
+            return false
+        }
+
+        let testedTargetNames = buildableTargets.map(\.name).sorted()
         if !testedTargetNames.isEmpty {
             Logger.current
                 .notice(

--- a/cli/Sources/TuistKit/Services/TestService.swift
+++ b/cli/Sources/TuistKit/Services/TestService.swift
@@ -469,7 +469,6 @@ public struct TestService { // swiftlint:disable:this type_body_length
             graph: graph,
             action: action,
             requestedTestTargets: testTargets,
-            skipTestTargets: skipTestTargets,
             passthroughXcodeBuildArguments: passthroughXcodeBuildArguments
         ) {
             if action == .build {
@@ -1316,7 +1315,6 @@ public struct TestService { // swiftlint:disable:this type_body_length
         graph: Graph,
         action: XcodeBuildTestAction,
         requestedTestTargets: [TestIdentifier] = [],
-        skipTestTargets: [TestIdentifier] = [],
         passthroughXcodeBuildArguments: [String] = []
     ) -> Bool {
         let testActionTargets = testActionTargets(
@@ -1375,25 +1373,7 @@ public struct TestService { // swiftlint:disable:this type_body_length
             return false
         }
 
-        let skippedTargetNames = Set(
-            skipTestTargets
-                .filter { $0.class == nil && $0.method == nil }
-                .map(\.target)
-        )
-        let buildableTargets = targetsAfterPassthroughSkip.filter { target in
-            if requestedTargetNames.isEmpty {
-                return !skippedTargetNames.contains(target.name)
-            } else {
-                return requestedTargetNames.contains(target.name)
-            }
-        }
-
-        if buildableTargets.isEmpty {
-            Logger.current.notice("There are no test targets to run, finishing early")
-            return false
-        }
-
-        let testedTargetNames = buildableTargets.map(\.name).sorted()
+        let testedTargetNames = targetsAfterPassthroughSkip.map(\.name).sorted()
         if !testedTargetNames.isEmpty {
             Logger.current
                 .notice(
@@ -1592,6 +1572,12 @@ public struct TestService { // swiftlint:disable:this type_body_length
             action: action
         )
         else {
+            if action == .build {
+                Logger.current.notice(
+                    "The scheme \(scheme.name) has no test targets left to build after filtering, skipping."
+                )
+                return
+            }
             throw TestServiceError.schemeWithoutTestableTargets(
                 scheme: scheme.name, testPlan: testPlanConfiguration?.testPlan
             )

--- a/cli/Tests/TuistKitTests/Services/TestServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/TestServiceTests.swift
@@ -1354,7 +1354,7 @@ final class TestServiceTests: TuistUnitTestCase {
             )
 
             XCTAssertEmpty(testedSchemes)
-            XCTAssertStandardOutput(pattern: "has no test targets left to build after filtering, skipping")
+            XCTAssertStandardOutput(pattern: "has no testable targets to build, skipping")
         }
     }
 

--- a/cli/Tests/TuistKitTests/Services/TestServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/TestServiceTests.swift
@@ -1286,6 +1286,70 @@ final class TestServiceTests: TuistUnitTestCase {
         }
     }
 
+    func test_finishes_early_when_every_test_target_is_filtered_out() async throws {
+        try await withMockedDependencies {
+            // Given
+            givenGenerator()
+            given(configLoader)
+                .loadConfig(path: .any)
+                .willReturn(.default)
+
+            let projectPath = try temporaryPath().appending(component: "Project")
+            let scheme = Scheme.test(
+                name: "AllTests",
+                testAction: .test(
+                    targets: [
+                        .test(target: TargetReference(projectPath: projectPath, name: "TargetA")),
+                    ]
+                )
+            )
+            given(buildGraphInspector)
+                .workspaceSchemes(graphTraverser: .any)
+                .willReturn([scheme])
+            // The scheme still references a test target, but every testable is excluded (e.g. by
+            // selective testing or --skip-test-targets), so there is nothing buildable left.
+            given(buildGraphInspector)
+                .testableTarget(
+                    scheme: .any,
+                    testPlan: .any,
+                    testTargets: .any,
+                    skipTestTargets: .any,
+                    graphTraverser: .any,
+                    action: .any
+                )
+                .willReturn(nil)
+
+            given(generator)
+                .generateWithGraph(path: .any, options: .any)
+                .willProduce { path, _ in
+                    (
+                        path,
+                        .test(
+                            projects: [
+                                projectPath: .test(
+                                    path: projectPath,
+                                    targets: [.test(name: "TargetA")],
+                                    schemes: [scheme]
+                                ),
+                            ]
+                        ),
+                        MapperEnvironment()
+                    )
+                }
+
+            // When
+            try await testRun(
+                path: try temporaryPath(),
+                action: .build,
+                skipTestTargets: [try TestIdentifier(string: "TargetA")]
+            )
+
+            // Then
+            XCTAssertEmpty(testedSchemes)
+            XCTAssertStandardOutput(pattern: "There are no test targets to run, finishing early")
+        }
+    }
+
     func test_run_tests_when_part_is_cached() async throws {
         try await withMockedDependencies {
             // Given

--- a/cli/Tests/TuistKitTests/Services/TestServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/TestServiceTests.swift
@@ -1286,7 +1286,7 @@ final class TestServiceTests: TuistUnitTestCase {
         }
     }
 
-    func test_finishes_early_when_every_test_target_is_filtered_out() async throws {
+    func test_skips_scheme_without_buildable_targets_for_build_action() async throws {
         try await withMockedDependencies {
             // Given
             givenGenerator()
@@ -1303,6 +1303,15 @@ final class TestServiceTests: TuistUnitTestCase {
                     ]
                 )
             )
+            // Reset so testableTarget resolves to nil; setUp registers a default non-nil stub that
+            // would otherwise be matched first.
+            buildGraphInspector.reset()
+            given(buildGraphInspector)
+                .testableSchemes(graphTraverser: .any)
+                .willReturn([])
+            given(buildGraphInspector)
+                .buildArguments(project: .any, target: .any, configuration: .any, skipSigning: .any)
+                .willReturn([])
             given(buildGraphInspector)
                 .workspaceSchemes(graphTraverser: .any)
                 .willReturn([scheme])
@@ -1337,16 +1346,15 @@ final class TestServiceTests: TuistUnitTestCase {
                     )
                 }
 
-            // When
+            // When / Then: finishes successfully without throwing schemeWithoutTestableTargets
             try await testRun(
                 path: try temporaryPath(),
                 action: .build,
                 skipTestTargets: [try TestIdentifier(string: "TargetA")]
             )
 
-            // Then
             XCTAssertEmpty(testedSchemes)
-            XCTAssertStandardOutput(pattern: "There are no test targets to run, finishing early")
+            XCTAssertStandardOutput(pattern: "has no test targets left to build after filtering, skipping")
         }
     }
 


### PR DESCRIPTION
## What changed

When `tuist test` builds an app for selective tests (the sharding `.build` flow) and a scheme resolved down to **zero buildable test targets**, the CLI failed with:

> The scheme AllTests cannot be built because it contains no buildable targets.

Now, when `testableTarget` returns nil for the `.build` action — i.e. every testable target was excluded by selective testing cache hits or `--skip-test-targets` — the scheme is skipped (logged and bypassed) instead of throwing `schemeWithoutTestableTargets`. The command finishes successfully.

## Why

A run that selective testing resolves to "no test targets to build" is a success, not a failure. On a PR where all touched test targets are cache hits, the user expects the command to finish cleanly rather than error out.

## Root cause

`testScheme` unconditionally threw `schemeWithoutTestableTargets` when `buildGraphInspector.testableTarget(...)` returned nil. That nil is the legitimate outcome when target-level exclusions (`testTargets` / `skipTestTargets`) empty the scheme. For the `.build` action the right behavior is to skip that scheme and move on.

## Why this approach over the alternative

The first iteration tried to detect the empty case earlier, inside `shouldRunTest`, by re-deriving the buildable target set from `requestedTestTargets` / `skipTestTargets` and matching against graph target names. That matching does not hold in the normal test flow, so `shouldRunTest` finished early for schemes that genuinely had targets to run, breaking ~13 existing `TestServiceTests` (caught by CI). Handling the empty case at its source — the single throw site — is both smaller and correct, and leaves the normal flow untouched.

## Validation

- Added `test_skips_scheme_without_buildable_targets_for_build_action`: with `testableTarget` resolving to nil under the `.build` action, the run completes without throwing and builds nothing. Verified red→green against the fix.
- Full `TuistKitTests/TestServiceTests` suite passes (81 tests, 0 failures), confirming the earlier regression is gone.

### How to test locally

1. Generate and build: `tuist generate tuist TuistKit ProjectDescription TuistKitTests --no-open`
2. Run the suite:
   `xcodebuild test -workspace Tuist.xcworkspace -scheme Tuist-Workspace -only-testing TuistKitTests/TestServiceTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""`