### PR TITLE
fix(kura): recover managed cache usage

### DIFF
--- a/kura/ops/helm/kura/hooks/tuist.lua
+++ b/kura/ops/helm/kura/hooks/tuist.lua
@@ -44,6 +44,14 @@ local function bearer_token(headers)
   return string.gsub(authorization, "^Bearer%s+", "")
 end
 
+local function env_value(key)
+  if type(kura.env) ~= "function" then
+    return nil
+  end
+
+  return kura.env(key)
+end
+
 local function normalized_handles(handles)
   local normalized = {}
 
@@ -282,15 +290,15 @@ local function grant_allows(grants, scope, action, identifier)
 end
 
 local function introspection_client_configured()
-  local client_id = kura.env("KURA_CONTROL_PLANE_CLIENT_ID") or kura.env("KURA_EXTENSION_TUIST_INTROSPECT_CLIENT_ID")
-  local client_secret = kura.env("KURA_CONTROL_PLANE_CLIENT_SECRET") or kura.env("KURA_EXTENSION_TUIST_INTROSPECT_CLIENT_SECRET")
+  local client_id = env_value("KURA_CONTROL_PLANE_CLIENT_ID") or env_value("KURA_EXTENSION_TUIST_INTROSPECT_CLIENT_ID")
+  local client_secret = env_value("KURA_CONTROL_PLANE_CLIENT_SECRET") or env_value("KURA_EXTENSION_TUIST_INTROSPECT_CLIENT_SECRET")
 
   return client_id ~= nil and client_id ~= "" and client_secret ~= nil and client_secret ~= ""
 end
 
 local function authenticate_via_introspection_endpoint(token)
-  local client_id = kura.env("KURA_CONTROL_PLANE_CLIENT_ID") or kura.env("KURA_EXTENSION_TUIST_INTROSPECT_CLIENT_ID")
-  local client_secret = kura.env("KURA_CONTROL_PLANE_CLIENT_SECRET") or kura.env("KURA_EXTENSION_TUIST_INTROSPECT_CLIENT_SECRET")
+  local client_id = env_value("KURA_CONTROL_PLANE_CLIENT_ID") or env_value("KURA_EXTENSION_TUIST_INTROSPECT_CLIENT_ID")
+  local client_secret = env_value("KURA_CONTROL_PLANE_CLIENT_SECRET") or env_value("KURA_EXTENSION_TUIST_INTROSPECT_CLIENT_SECRET")
   local response = kura.http_json("tuist", {
     method = "POST",
     path = "/oauth2/introspect",

--- a/server/assets/app/css/components/empty_card_section.css
+++ b/server/assets/app/css/components/empty_card_section.css
@@ -10,10 +10,15 @@
     }
 
     & > [data-part="image"] {
-      height: 122px;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      height: 150px;
 
       & > img {
         border-radius: 10px;
+        max-width: 100%;
+        max-height: 100%;
         html[data-theme="light"] &[data-theme="dark"] {
           display: none;
         }

--- a/server/test/tuist/kura/reconciler_test.exs
+++ b/server/test/tuist/kura/reconciler_test.exs
@@ -56,6 +56,22 @@ defmodule Tuist.Kura.ReconcilerTest do
              Repo.get!(Server, server.id)
   end
 
+  test "marks a pending deployment running before succeeding when the requested image is already observed" do
+    {_account, server, deployment} = create_server()
+
+    expect(Provisioner, :current_image_tag, fn %Server{id: id} ->
+      assert id == server.id
+      {:ok, deployment.image_tag}
+    end)
+
+    assert :ok = Reconciler.reconcile()
+
+    assert %Deployment{status: :succeeded, error_message: nil} = Repo.get!(Deployment, deployment.id)
+
+    assert %Server{status: :active, current_image_tag: "0.5.2", url: "http://localhost:4100"} =
+             Repo.get!(Server, server.id)
+  end
+
   test "keeps a deployment running until the public HTTPS endpoint is ready" do
     {account, server, deployment} = create_server()
     {:ok, deployment} = Kura.mark_running(deployment)


### PR DESCRIPTION
Related to Sentry issue 124145394

This PR keeps the parts that are still relevant after rebasing on current `origin/main`.

- Adds regression coverage for the already-merged Kura reconciler behavior that moves observed pending deployments through `:running` before `:succeeded`.
- Makes the Tuist Kura hook tolerate runtimes that do not expose `kura.env`, falling back to the legacy cache access path instead of crashing authentication.
- Gives empty card illustrations a fixed flex slot so the Usage empty-state image cannot overlap its title.

The original reconciler implementation change is no longer included because `origin/main` already contains the equivalent fix.

### How to test locally

- `git diff --check origin/main...HEAD`
- `mise exec -- prettier -c assets/app/css/components/empty_card_section.css` from `server/`
- Not rerun: full `mise run --no-deps format --check` and focused Mix tests are currently blocked locally by unrelated dependency resolver drift around `thousand_island`; the original PR run had Server Test and Kura checks passing, and the failing Server Format log pointed specifically to `assets/app/css/components/empty_card_section.css`.
- Live verification from the incident: patched the US West KuraInstance, recycled the three pods, and verified `https://tuist-us-west-1.kura.tuist.dev/up` returns `200`.
