### PR TITLE
fix(cli): always expose -Swift.h for Swift-only SPM frameworks (#11007)

### DIFF
--- a/cli/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
+++ b/cli/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
@@ -650,12 +650,19 @@ public struct PackageInfoMapper: PackageInfoMapping {
             } else {
                 nil
             }
+            // The headerless modulemap (issue #10967) hides the generated `-Swift.h`, so restrict it to Swift-only
+            // framework targets that don't expose `@objc` declarations to Objective-C consumers (issue #11007).
+            let generateModuleMapForSwiftOnlyTargets = if product == .framework {
+                try await !targetExposesObjCInterface(at: targetPath)
+            } else {
+                false
+            }
             moduleMap = try await moduleMapGenerator.generate(
                 packageDirectory: path,
                 moduleName: moduleName,
                 publicHeadersPath: target.publicHeadersPath(packageFolder: path),
                 swiftPackageManagerScratchDirectory: swiftPackageManagerScratchDirectory,
-                generateModuleMapForSwiftOnlyTargets: product == .framework
+                generateModuleMapForSwiftOnlyTargets: generateModuleMapForSwiftOnlyTargets
             )
         default:
             moduleMap = nil
@@ -961,6 +968,22 @@ public struct PackageInfoMapper: PackageInfoMapping {
                 return []
             }
         }
+    }
+}
+
+extension PackageInfoMapper {
+    /// Whether any of the target's Swift sources expose `@objc` declarations, which Objective-C consumers reach through
+    /// the generated `-Swift.h`.
+    private func targetExposesObjCInterface(at targetPath: AbsolutePath) async throws -> Bool {
+        guard try await fileSystem.exists(targetPath) else { return false }
+        let swiftFiles = try await fileSystem.glob(directory: targetPath, include: ["**/*.swift", "*.swift"]).collect()
+        for swiftFile in swiftFiles {
+            guard let contents = try? await fileSystem.readTextFile(at: swiftFile) else { continue }
+            if contents.contains("@objc") {
+                return true
+            }
+        }
+        return false
     }
 }
 

--- a/cli/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
+++ b/cli/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
@@ -650,19 +650,11 @@ public struct PackageInfoMapper: PackageInfoMapping {
             } else {
                 nil
             }
-            // The headerless modulemap (issue #10967) hides the generated `-Swift.h`, so restrict it to Swift-only
-            // framework targets that don't expose `@objc` declarations to Objective-C consumers (issue #11007).
-            let generateModuleMapForSwiftOnlyTargets = if product == .framework {
-                try await !targetExposesObjCInterface(at: targetPath)
-            } else {
-                false
-            }
             moduleMap = try await moduleMapGenerator.generate(
                 packageDirectory: path,
                 moduleName: moduleName,
                 publicHeadersPath: target.publicHeadersPath(packageFolder: path),
-                swiftPackageManagerScratchDirectory: swiftPackageManagerScratchDirectory,
-                generateModuleMapForSwiftOnlyTargets: generateModuleMapForSwiftOnlyTargets
+                swiftPackageManagerScratchDirectory: swiftPackageManagerScratchDirectory
             )
         default:
             moduleMap = nil
@@ -968,29 +960,6 @@ public struct PackageInfoMapper: PackageInfoMapping {
                 return []
             }
         }
-    }
-}
-
-extension PackageInfoMapper {
-    /// Whether any of the target's Swift sources expose declarations to Objective-C through the generated `-Swift.h`.
-    /// Pure-Swift targets with no Objective-C interop keep the headerless modulemap (issue #10967); targets that expose
-    /// `@objc` declarations or subclass an Objective-C type need Xcode's synthesized modulemap so consumers see
-    /// `-Swift.h` (issue #11007). A false positive only reverts a target to the synthesized modulemap, so the detection
-    /// errs towards reporting interop.
-    private func targetExposesObjCInterface(at targetPath: AbsolutePath) async throws -> Bool {
-        guard try await fileSystem.exists(targetPath) else { return false }
-        let swiftFiles = try await fileSystem.glob(directory: targetPath, include: ["**/*.swift", "*.swift"]).collect()
-        let interopAttributes = ["@objc", "@IBOutlet", "@IBAction", "@IBInspectable", "@NSManaged", "@GKInspectable"]
-        for swiftFile in swiftFiles {
-            guard let contents = try? await fileSystem.readTextFile(at: swiftFile) else { continue }
-            if interopAttributes.contains(where: contents.contains) {
-                return true
-            }
-            if contents.range(of: #":\s*NSObject\b"#, options: .regularExpression) != nil {
-                return true
-            }
-        }
-        return false
     }
 }
 
@@ -1370,7 +1339,7 @@ extension ProjectDescription.Headers {
                     ]
                 )
             )
-        case .none, .swiftOnly, .header, .custom:
+        case .none, .header, .custom:
             return nil
         }
     }
@@ -1396,13 +1365,7 @@ extension ProjectDescription.Settings {
 
         var dependencyHeaderSearchPaths: [String] = []
         if let moduleMap {
-            let needsHeaderSearchPath = switch moduleMap {
-            case .directory, .header, .custom:
-                true
-            case .none, .swiftOnly:
-                false
-            }
-            if needsHeaderSearchPath, target.type != .system {
+            if moduleMap != .none, target.type != .system {
                 let publicHeadersPath = try await target.publicHeadersPath(packageFolder: packageFolder)
                 let publicHeadersRelativePath = publicHeadersPath.relative(to: packageFolder)
                 dependencyHeaderSearchPaths.append("$(SRCROOT)/\(publicHeadersRelativePath.pathString)")
@@ -1473,7 +1436,7 @@ extension ProjectDescription.Settings {
 
         if let moduleMap {
             switch moduleMap {
-            case .directory, .header, .custom, .swiftOnly:
+            case .directory, .header, .custom:
                 settingsDictionary["DEFINES_MODULE"] = "NO"
                 switch settingsDictionary["OTHER_CFLAGS"] ?? .array(["$(inherited)"]) {
                 case let .array(values):

--- a/cli/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
+++ b/cli/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
@@ -972,14 +972,21 @@ public struct PackageInfoMapper: PackageInfoMapping {
 }
 
 extension PackageInfoMapper {
-    /// Whether any of the target's Swift sources expose `@objc` declarations, which Objective-C consumers reach through
-    /// the generated `-Swift.h`.
+    /// Whether any of the target's Swift sources expose declarations to Objective-C through the generated `-Swift.h`.
+    /// Pure-Swift targets with no Objective-C interop keep the headerless modulemap (issue #10967); targets that expose
+    /// `@objc` declarations or subclass an Objective-C type need Xcode's synthesized modulemap so consumers see
+    /// `-Swift.h` (issue #11007). A false positive only reverts a target to the synthesized modulemap, so the detection
+    /// errs towards reporting interop.
     private func targetExposesObjCInterface(at targetPath: AbsolutePath) async throws -> Bool {
         guard try await fileSystem.exists(targetPath) else { return false }
         let swiftFiles = try await fileSystem.glob(directory: targetPath, include: ["**/*.swift", "*.swift"]).collect()
+        let interopAttributes = ["@objc", "@IBOutlet", "@IBAction", "@IBInspectable", "@NSManaged", "@GKInspectable"]
         for swiftFile in swiftFiles {
             guard let contents = try? await fileSystem.readTextFile(at: swiftFile) else { continue }
-            if contents.contains("@objc") {
+            if interopAttributes.contains(where: contents.contains) {
+                return true
+            }
+            if contents.range(of: #":\s*NSObject\b"#, options: .regularExpression) != nil {
                 return true
             }
         }

--- a/cli/Sources/TuistLoader/SwiftPackageManager/SwiftPackageManagerModuleMapGenerator.swift
+++ b/cli/Sources/TuistLoader/SwiftPackageManager/SwiftPackageManagerModuleMapGenerator.swift
@@ -8,8 +8,6 @@ import TuistSupport
 public enum ModuleMap: Equatable {
     /// No headers and hence no modulemap file
     case none
-    /// A Swift-only framework target with no Clang headers.
-    case swiftOnly(moduleMapPath: AbsolutePath)
     /// Custom modulemap file provided in SPM package
     case custom(AbsolutePath, umbrellaHeaderPath: AbsolutePath?)
     /// Umbrella header provided in SPM package
@@ -20,8 +18,6 @@ public enum ModuleMap: Equatable {
     var moduleMapPath: AbsolutePath? {
         switch self {
         case let .custom(path, umbrellaHeaderPath: _):
-            return path
-        case let .swiftOnly(moduleMapPath: path):
             return path
         case let .header(_, moduleMapPath: path):
             return path
@@ -46,8 +42,7 @@ public protocol SwiftPackageManagerModuleMapGenerating {
         packageDirectory: AbsolutePath,
         moduleName: String,
         publicHeadersPath: AbsolutePath,
-        swiftPackageManagerScratchDirectory: AbsolutePath?,
-        generateModuleMapForSwiftOnlyTargets: Bool
+        swiftPackageManagerScratchDirectory: AbsolutePath?
     ) async throws -> ModuleMap
 }
 
@@ -68,8 +63,7 @@ public struct SwiftPackageManagerModuleMapGenerator: SwiftPackageManagerModuleMa
         packageDirectory: AbsolutePath,
         moduleName: String,
         publicHeadersPath: AbsolutePath,
-        swiftPackageManagerScratchDirectory: AbsolutePath? = nil,
-        generateModuleMapForSwiftOnlyTargets: Bool = false
+        swiftPackageManagerScratchDirectory: AbsolutePath? = nil
     ) async throws -> ModuleMap {
         let sanitizedModuleName = moduleName.sanitizedModuleName
         let umbrellaHeaderPath = publicHeadersPath.appending(component: sanitizedModuleName + ".h")
@@ -138,14 +132,6 @@ public struct SwiftPackageManagerModuleMapGenerator: SwiftPackageManagerModuleMa
             return .custom(customModuleMapPath, umbrellaHeaderPath: nil)
         } else if try await fileSystem.exists(publicHeadersPath) {
             if try await fileSystem.glob(directory: publicHeadersPath, include: ["**/*.h", "*.h"]).collect().isEmpty {
-                if generateModuleMapForSwiftOnlyTargets {
-                    try await writeIfDifferent(
-                        moduleMapContent: swiftOnlyModuleMap(sanitizedModuleName: sanitizedModuleName),
-                        to: generatedModuleMapPath,
-                        atomically: true
-                    )
-                    return .swiftOnly(moduleMapPath: generatedModuleMapPath)
-                }
                 return .none
             }
             // Consider the public headers folder as umbrella directory
@@ -160,14 +146,6 @@ public struct SwiftPackageManagerModuleMapGenerator: SwiftPackageManagerModuleMa
 
             return .directory(moduleMapPath: generatedModuleMapPath, umbrellaDirectory: publicHeadersPath)
         } else {
-            if generateModuleMapForSwiftOnlyTargets {
-                try await writeIfDifferent(
-                    moduleMapContent: swiftOnlyModuleMap(sanitizedModuleName: sanitizedModuleName),
-                    to: generatedModuleMapPath,
-                    atomically: true
-                )
-                return .swiftOnly(moduleMapPath: generatedModuleMapPath)
-            }
             return .none
         }
     }
@@ -213,14 +191,6 @@ public struct SwiftPackageManagerModuleMapGenerator: SwiftPackageManagerModuleMa
 
           export *
           module * { export * }
-        }
-        """
-    }
-
-    private func swiftOnlyModuleMap(sanitizedModuleName: String) -> String {
-        """
-        framework module \(sanitizedModuleName) {
-          export *
         }
         """
     }

--- a/cli/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
+++ b/cli/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
@@ -4611,7 +4611,7 @@ struct PackageInfoMapperTests {
         try await fileSystem.makeDirectory(at: objcTargetPath)
         try await fileSystem.makeDirectory(at: pureSwiftTargetPath)
         try await fileSystem.writeText(
-            "import Foundation\n@objc public class Exposed: NSObject {}\n",
+            "import Foundation\npublic class Exposed: NSObject {}\n",
             at: objcTargetPath.appending(component: "ObjCTarget.swift")
         )
         try await fileSystem.writeText(

--- a/cli/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
+++ b/cli/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
@@ -4557,19 +4557,7 @@ struct PackageInfoMapperTests {
                 .testWithDefaultConfigs(
                     name: "Package",
                     targets: [
-                        .test(
-                            "RxSwift",
-                            basePath: basePath,
-                            product: .framework,
-                            customSettings: [
-                                "DEFINES_MODULE": "NO",
-                                "OTHER_CFLAGS": .array(["$(inherited)", "-fmodule-name=RxSwift"]),
-                                "OTHER_SWIFT_FLAGS": [
-                                    "$(inherited)",
-                                ],
-                            ],
-                            moduleMap: "$(SRCROOT)/Derived/RxSwift.modulemap"
-                        ),
+                        .test("RxSwift", basePath: basePath, product: .framework),
                     ] + testTargets.map {
                         var customSettings: ProjectDescription.SettingsDictionary
                         var customProductName: String?
@@ -4599,61 +4587,6 @@ struct PackageInfoMapperTests {
                     }
                 )
         )
-    }
-
-    @Test(
-        .inTemporaryDirectory,
-        .withMockedSwiftVersionProvider
-    ) func map_whenSwiftOnlyFrameworkExposesObjCInterface_keepsXcodeSynthesizedModuleMap() async throws {
-        let basePath = try #require(FileSystem.temporaryTestDirectory)
-        let objcTargetPath = basePath.appending(try RelativePath(validating: "Package/Sources/ObjCTarget"))
-        let pureSwiftTargetPath = basePath.appending(try RelativePath(validating: "Package/Sources/PureSwiftTarget"))
-        try await fileSystem.makeDirectory(at: objcTargetPath)
-        try await fileSystem.makeDirectory(at: pureSwiftTargetPath)
-        try await fileSystem.writeText(
-            "import Foundation\npublic class Exposed: NSObject {}\n",
-            at: objcTargetPath.appending(component: "ObjCTarget.swift")
-        )
-        try await fileSystem.writeText(
-            "public struct PureSwift {}\n",
-            at: pureSwiftTargetPath.appending(component: "PureSwiftTarget.swift")
-        )
-
-        let project = try await subject.map(
-            package: "Package",
-            basePath: basePath,
-            packageInfos: [
-                "Package": .test(
-                    name: "Package",
-                    products: [
-                        .init(name: "ObjCTarget", type: .library(.automatic), targets: ["ObjCTarget"]),
-                        .init(name: "PureSwiftTarget", type: .library(.automatic), targets: ["PureSwiftTarget"]),
-                    ],
-                    targets: [
-                        .test(name: "ObjCTarget"),
-                        .test(name: "PureSwiftTarget"),
-                    ],
-                    platforms: [.ios],
-                    cLanguageStandard: nil,
-                    cxxLanguageStandard: nil,
-                    swiftLanguageVersions: nil
-                ),
-            ],
-            packageSettings: .test(
-                productTypes: ["ObjCTarget": .framework, "PureSwiftTarget": .framework],
-                baseSettings: .default
-            )
-        )
-
-        let objcTarget = try #require(project?.targets.first(where: { $0.name == "ObjCTarget" }))
-        #expect(objcTarget.product == .framework)
-        #expect(objcTarget.settings?.base["DEFINES_MODULE"] == nil)
-        #expect(objcTarget.settings?.base["MODULEMAP_FILE"] == nil)
-
-        let pureSwiftTarget = try #require(project?.targets.first(where: { $0.name == "PureSwiftTarget" }))
-        #expect(pureSwiftTarget.product == .framework)
-        #expect(pureSwiftTarget.settings?.base["DEFINES_MODULE"] == .string("NO"))
-        #expect(pureSwiftTarget.settings?.base["MODULEMAP_FILE"] != nil)
     }
 
     @Test(

--- a/cli/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
+++ b/cli/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
@@ -4604,6 +4604,61 @@ struct PackageInfoMapperTests {
     @Test(
         .inTemporaryDirectory,
         .withMockedSwiftVersionProvider
+    ) func map_whenSwiftOnlyFrameworkExposesObjCInterface_keepsXcodeSynthesizedModuleMap() async throws {
+        let basePath = try #require(FileSystem.temporaryTestDirectory)
+        let objcTargetPath = basePath.appending(try RelativePath(validating: "Package/Sources/ObjCTarget"))
+        let pureSwiftTargetPath = basePath.appending(try RelativePath(validating: "Package/Sources/PureSwiftTarget"))
+        try await fileSystem.makeDirectory(at: objcTargetPath)
+        try await fileSystem.makeDirectory(at: pureSwiftTargetPath)
+        try await fileSystem.writeText(
+            "import Foundation\n@objc public class Exposed: NSObject {}\n",
+            at: objcTargetPath.appending(component: "ObjCTarget.swift")
+        )
+        try await fileSystem.writeText(
+            "public struct PureSwift {}\n",
+            at: pureSwiftTargetPath.appending(component: "PureSwiftTarget.swift")
+        )
+
+        let project = try await subject.map(
+            package: "Package",
+            basePath: basePath,
+            packageInfos: [
+                "Package": .test(
+                    name: "Package",
+                    products: [
+                        .init(name: "ObjCTarget", type: .library(.automatic), targets: ["ObjCTarget"]),
+                        .init(name: "PureSwiftTarget", type: .library(.automatic), targets: ["PureSwiftTarget"]),
+                    ],
+                    targets: [
+                        .test(name: "ObjCTarget"),
+                        .test(name: "PureSwiftTarget"),
+                    ],
+                    platforms: [.ios],
+                    cLanguageStandard: nil,
+                    cxxLanguageStandard: nil,
+                    swiftLanguageVersions: nil
+                ),
+            ],
+            packageSettings: .test(
+                productTypes: ["ObjCTarget": .framework, "PureSwiftTarget": .framework],
+                baseSettings: .default
+            )
+        )
+
+        let objcTarget = try #require(project?.targets.first(where: { $0.name == "ObjCTarget" }))
+        #expect(objcTarget.product == .framework)
+        #expect(objcTarget.settings?.base["DEFINES_MODULE"] == nil)
+        #expect(objcTarget.settings?.base["MODULEMAP_FILE"] == nil)
+
+        let pureSwiftTarget = try #require(project?.targets.first(where: { $0.name == "PureSwiftTarget" }))
+        #expect(pureSwiftTarget.product == .framework)
+        #expect(pureSwiftTarget.settings?.base["DEFINES_MODULE"] == .string("NO"))
+        #expect(pureSwiftTarget.settings?.base["MODULEMAP_FILE"] != nil)
+    }
+
+    @Test(
+        .inTemporaryDirectory,
+        .withMockedSwiftVersionProvider
     ) func map_whenTargetDependenciesOnTargetHaveConditions() async throws {
         let basePath = try #require(FileSystem.temporaryTestDirectory)
         try await fileSystem.makeDirectory(at: basePath.appending(try RelativePath(validating: "Package/Sources/Target1")))

--- a/cli/Tests/TuistLoaderTests/SwiftPackageManager/SwiftPackageManagerModuleMapGeneratorTests.swift
+++ b/cli/Tests/TuistLoaderTests/SwiftPackageManager/SwiftPackageManagerModuleMapGeneratorTests.swift
@@ -49,13 +49,6 @@ final class SwiftPackageManagerModuleMapGeneratorTests: TuistUnitTestCase {
         try await test_generate(for: .none)
     }
 
-    func test_generate_when_no_headersAndSwiftOnlyModuleMapRequested() async throws {
-        try await test_generate(
-            for: .swiftOnly(moduleMapPath: packageDirectory.appending(components: "Derived", "Module.modulemap")),
-            generateModuleMapForSwiftOnlyTargets: true
-        )
-    }
-
     func test_generate_when_custom_module_map() async throws {
         try await test_generate(for: .custom(publicHeadersPath.appending(component: "module.modulemap"), umbrellaHeaderPath: nil))
     }
@@ -241,18 +234,13 @@ final class SwiftPackageManagerModuleMapGeneratorTests: TuistUnitTestCase {
         )
     }
 
-    private func test_generate(
-        for moduleMap: ModuleMap,
-        generateModuleMapForSwiftOnlyTargets: Bool = false
-    ) async throws {
+    private func test_generate(for moduleMap: ModuleMap) async throws {
         var writeCount = 0
 
         try await fileSystem.makeDirectory(at: publicHeadersPath)
         try await fileSystem.makeDirectory(at: packageDirectory.appending(component: "Derived"))
         switch moduleMap {
         case .none:
-            break
-        case .swiftOnly:
             break
         case let .custom(moduleMapPath, umbrellaHeaderPath: umbrellaHeaderPath):
             try await fileSystem.touch(moduleMapPath)
@@ -281,8 +269,7 @@ final class SwiftPackageManagerModuleMapGeneratorTests: TuistUnitTestCase {
         let got = try await subject.generate(
             packageDirectory: packageDirectory,
             moduleName: "Module",
-            publicHeadersPath: publicHeadersPath,
-            generateModuleMapForSwiftOnlyTargets: generateModuleMapForSwiftOnlyTargets
+            publicHeadersPath: publicHeadersPath
         )
 
         let moduleMapPath = packageDirectory.appending(components: "Derived", "Module.modulemap")
@@ -299,15 +286,14 @@ final class SwiftPackageManagerModuleMapGeneratorTests: TuistUnitTestCase {
         _ = try await subject.generate(
             packageDirectory: packageDirectory,
             moduleName: "Module",
-            publicHeadersPath: publicHeadersPath,
-            generateModuleMapForSwiftOnlyTargets: generateModuleMapForSwiftOnlyTargets
+            publicHeadersPath: publicHeadersPath
         )
 
         XCTAssertEqual(got, moduleMap)
         switch moduleMap {
         case .none, .custom:
             XCTAssertEqual(writeCount, 0)
-        case .directory, .header, .swiftOnly:
+        case .directory, .header:
             XCTAssertEqual(writeCount, 1)
         }
     }
@@ -317,12 +303,6 @@ final class SwiftPackageManagerModuleMapGeneratorTests: TuistUnitTestCase {
         switch moduleMap {
         case .none, .custom:
             return nil
-        case .swiftOnly:
-            expectedContent = """
-            framework module Module {
-              export *
-            }
-            """
         case let .header(umbrellaHeaderPath, moduleMapPath: _):
             if umbrellaHeaderPath.parentDirectory.basename == "Module" {
                 expectedContent = """


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/11007

## What

Reverts #10971 so Swift-only SwiftPM framework targets again let Xcode synthesize their modulemap, which always exposes the `-Swift.h` Objective-C compatibility header. Also drops the `@objc`/NSObject source-scan that earlier commits on this branch explored, which was the wrong approach.

## Why

#10971 made Swift-only SwiftPM framework targets emit a headerless modulemap (`framework module X { export * }` with `DEFINES_MODULE=NO`) to avoid #10967, a crash where Xcode 26 beta's explicit-modules dependency scanner read the synthesized modulemap's `X-Swift.h` reference before Swift had emitted that header.

The headerless modulemap hides the target's Swift `@objc` interface, so Objective-C `@import` can no longer see the Swift classes. Concretely, RollbarNotifier's `@import RollbarReport;` fails to compile with `unknown receiver 'RollbarCrashDiagnosticFilter'` (#11007).

## Root cause and why this approach

- A generate-time custom `MODULEMAP_FILE` cannot reference the build-generated `X-Swift.h`. The header is produced inside the built framework, and a relative `header "X-Swift.h"` only resolves from Xcode's synthesized in-framework modulemap, never from a modulemap stored at a derived path. Every custom variant tested (top-level header, separate and nested `requires objc` submodules) fails with `Header 'X-Swift.h' not found`. So restructuring the modulemap to expose the header to Objective-C while hiding it from the Swift scanner is not possible.
- The only way to expose the Swift interface to Objective-C is to let Xcode synthesize the modulemap. That is the pre-#10971 behavior and matches what SwiftPM does, which always emits the compatibility header for library targets.
- #10967 no longer reproduces on current Xcode. Building an EE `tuist` and running the real `tuist cache` against a swift-log-as-framework project on Xcode 26.4.1, the single-arch simulator `Binaries-Cache` build (the exact #10967 scenario) succeeds with always-expose. The scanner ordering bug was specific to the Xcode 26 beta.

## Validation

Real `tuist cache` on Xcode 26.4.1, simulator pass:
- swift-log framework cache build succeeds, no `Logging-Swift.h not found`.
- Rollbar cache build with `--cache-profile only-external` succeeds; `RollbarCrashCollector.m` consumes the Swift `@objc` classes through `@import RollbarReport`.

## Caveats

- The cache device pass was not re-tested locally (no iOS device SDK on the test machine; device builds are multi-arch and not the #10967 trigger). Worth confirming on CI.
- Anyone still on an Xcode 26 beta where the scanner bug lives would regress to #10967. On release Xcode (26.4.1 and later) it is a non-issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
