### PR TITLE
fix(infra): handle <sealed> sudo password + add tiered BootstrapFailed recovery

### DIFF
--- a/infra/cluster-api-provider-scaleway-applesilicon/api/v1alpha1/scalewayapplesiliconmachine_types.go
+++ b/infra/cluster-api-provider-scaleway-applesilicon/api/v1alpha1/scalewayapplesiliconmachine_types.go
@@ -217,6 +217,27 @@ type ScalewayAppleSiliconMachineStatus struct {
 	// every 60s indefinitely with no terminal-failure signal.
 	// +optional
 	TartKubeletUpdateAttempts int32 `json:"tartKubeletUpdateAttempts,omitempty"`
+
+	// BootstrapAttempts counts consecutive bootstrap (Stage 2)
+	// failures on the currently-adopted host. Reset to zero on a
+	// successful bootstrap or whenever the underlying ServerID
+	// changes (mini swapped out). Drives the tiered recovery
+	// escalation in the BootstrapFailed path: at the reboot threshold
+	// the controller asks Scaleway to reboot the host to clear
+	// volatile state (PAM lockouts, sshd throttling, half-open
+	// connections); at the release threshold it returns the host to
+	// the adopt pool so the next reconcile claims a different mini.
+	// +optional
+	BootstrapAttempts int32 `json:"bootstrapAttempts,omitempty"`
+
+	// BootstrapRebootIssued records that a recovery reboot has
+	// already been triggered for the current host. Prevents
+	// re-rebooting the same host on every retry after the threshold
+	// crossing. Cleared when the underlying ServerID changes (mini
+	// swapped out, e.g., via release-to-pool) or on successful
+	// bootstrap.
+	// +optional
+	BootstrapRebootIssued bool `json:"bootstrapRebootIssued,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/infra/cluster-api-provider-scaleway-applesilicon/cmd/manager/main.go
+++ b/infra/cluster-api-provider-scaleway-applesilicon/cmd/manager/main.go
@@ -77,6 +77,8 @@ func main() {
 		tartKubeletHostMemory        int
 		tartKubeletMaxPods           int
 		tartKubeletMaxUpdateAttempts int
+		bootstrapRebootAfter         int
+		bootstrapMaxAttempts         int
 
 		machineMaxConcurrentReconciles int
 
@@ -152,6 +154,14 @@ func main() {
 	flag.IntVar(&tartKubeletMaxUpdateAttempts, "tartkubelet-max-update-attempts", 5,
 		"Drift-loop retries before transitioning the CR to a terminal Failed state. "+
 			"Set to 0 to disable the cap (not recommended for production).")
+	flag.IntVar(&bootstrapRebootAfter, "bootstrap-reboot-after", 3,
+		"Consecutive BootstrapFailed count at which the controller asks Scaleway to "+
+			"reboot the host once to clear volatile state (PAM lockouts, sshd throttling). "+
+			"Fires once per host. Set to 0 to disable the reboot step.")
+	flag.IntVar(&bootstrapMaxAttempts, "bootstrap-max-attempts", 8,
+		"Consecutive BootstrapFailed count at which the controller returns the host to "+
+			"the adopt pool (triggering ReinstallServer) and claims a different mini on the "+
+			"next reconcile. Set to 0 to disable pool release (host is retried forever).")
 	flag.IntVar(&machineMaxConcurrentReconciles, "machine-max-concurrent-reconciles", 4,
 		"How many ScalewayAppleSiliconMachine reconciles run in parallel. The "+
 			"default of 1 (controller-runtime's default) serializes the whole "+
@@ -353,6 +363,8 @@ func main() {
 		TartKubeletHostMemoryMB:      tartKubeletHostMemory,
 		TartKubeletMaxPods:           tartKubeletMaxPods,
 		TartKubeletMaxUpdateAttempts: int32(tartKubeletMaxUpdateAttempts),
+		BootstrapRebootAfter:         int32(bootstrapRebootAfter),
+		BootstrapMaxAttempts:         int32(bootstrapMaxAttempts),
 		MaxConcurrentReconciles:      machineMaxConcurrentReconciles,
 		EgressNamespace:              egressNamespace,
 		EgressProxyGroup:             egressProxyGroup,

--- a/infra/cluster-api-provider-scaleway-applesilicon/controllers/scalewayapplesiliconmachine_controller.go
+++ b/infra/cluster-api-provider-scaleway-applesilicon/controllers/scalewayapplesiliconmachine_controller.go
@@ -561,7 +561,7 @@ func (r *ScalewayAppleSiliconMachineReconciler) reconcileNormal(
 			}
 		}
 		if err != nil {
-			return handleBootstrapFailure(ctx, machine, err, r.ScalewayClient, r.Recorder, logger, r.BootstrapRebootAfter, r.BootstrapMaxAttempts), nil
+			return handleBootstrapFailure(ctx, machine, err, r.ScalewayClient, r.CredentialsManager, r.Recorder, logger, r.BootstrapRebootAfter, r.BootstrapMaxAttempts), nil
 		}
 
 		conditions.MarkTrue(machine, BootstrappedCondition)
@@ -927,6 +927,16 @@ type bootstrapRecoveryClient interface {
 	ReleaseToPool(ctx context.Context, id, zone, poolPrefix string) error
 }
 
+// bootstrapSecretCleaner wipes the per-machine bootstrap Secret that
+// holds the previous host's sudo password, SSH username, and TOFU
+// host fingerprint. The production *credentials.Manager satisfies it
+// via DeleteMachineBootstrap. Separating this from the Scaleway
+// surface keeps both interfaces narrow and lets tests stub the
+// concerns independently.
+type bootstrapSecretCleaner interface {
+	DeleteMachineBootstrap(ctx context.Context, machineName string) error
+}
+
 // handleBootstrapFailure records the bootstrap error on the machine
 // and runs tiered host recovery. Returns the ctrl.Result the caller
 // should propagate.
@@ -936,14 +946,30 @@ type bootstrapRecoveryClient interface {
 // production are host-volatile (PAM account lockouts from sudo
 // retries, sshd connection throttling, half-open SSH sessions) and
 // resolve after a clean boot. Gated on Status.BootstrapRebootIssued so
-// a long retry tail doesn't re-reboot the same host.
+// a long retry tail doesn't re-reboot the same host. If RebootServer
+// returns an error the flag stays false and the next reconcile retries
+// the reboot (the condition is `>=` rather than `==`).
 //
 // Tier 2: at `maxAttempts` consecutive failures, return the host to
 // the adopt pool. ReleaseToPool renames + triggers ReinstallServer
 // (full disk wipe + factory image), so the next reconcile claims a
 // different mini via AdoptFromPool. Status.ServerID is cleared so the
 // adoption stage re-runs; counter + reboot flag reset because they
-// describe the now-discarded host.
+// describe the now-discarded host. The per-machine bootstrap Secret is
+// deleted so the next adopt rebuilds it from scratch — without that
+// step the previous host's TOFU fingerprint would survive and
+// SSH-verify against the replacement host's key, locking us into a
+// fingerprint-mismatch bootstrap failure on the new mini.
+// Outwardly-visible state tied to the discarded host (Status.Ready,
+// Status.Phase, Spec.ProviderID, Status.Addresses, ProvisionedCondition)
+// is reset to its pre-adoption shape so CAPI and operators don't
+// momentarily see a stale "Ready" Machine pointing at a server we no
+// longer control.
+//
+// Order matters: at the maxAttempts threshold the release branch must
+// win even if the reboot was never attempted (e.g., rebootAfter > 0
+// but RebootServer kept failing). The switch is evaluated top-down so
+// release is listed first.
 //
 // Either tier failing to call out to Scaleway (transient API error,
 // 5xx) is non-fatal — the machine stays in the BootstrapFailed
@@ -954,6 +980,7 @@ func handleBootstrapFailure(
 	machine *infrav1.ScalewayAppleSiliconMachine,
 	err error,
 	client bootstrapRecoveryClient,
+	secrets bootstrapSecretCleaner,
 	recorder record.EventRecorder,
 	logger logr.Logger,
 	rebootAfter int32,
@@ -969,7 +996,47 @@ func handleBootstrapFailure(
 
 	hostAdoptable := machine.Status.ServerID != "" && machine.Spec.AdoptPoolPrefix != ""
 	switch {
-	case rebootAfter > 0 && attempts == rebootAfter && !machine.Status.BootstrapRebootIssued && machine.Status.ServerID != "":
+	case maxAttempts > 0 && attempts >= maxAttempts && hostAdoptable:
+		if releaseErr := client.ReleaseToPool(ctx, machine.Status.ServerID, machine.Spec.Zone, machine.Spec.AdoptPoolPrefix); releaseErr != nil {
+			logger.Error(releaseErr, "release-to-pool after bootstrap exhaustion failed; will retry")
+			recorder.Eventf(machine, corev1.EventTypeWarning, "ReleaseFailed",
+				"Scaleway ReleaseToPool after %d bootstrap failures: %v (will retry)",
+				attempts, releaseErr)
+			return ctrl.Result{RequeueAfter: 60 * time.Second}
+		}
+		releasedID := machine.Status.ServerID
+		// Wipe the per-machine bootstrap Secret. The host fingerprint
+		// stored there is TOFU-pinned to the released mini's SSH key
+		// and would silently reject the replacement host's key on
+		// next bootstrap; nothing else in the Secret (sudo password,
+		// SSH username) survives meaningfully across hosts either.
+		if cleanErr := secrets.DeleteMachineBootstrap(ctx, machine.Name); cleanErr != nil {
+			// Non-fatal: surface the error and continue. The next
+			// adopt will overwrite the credentials, and the
+			// fingerprint guard tolerates an empty pin (TOFU
+			// captures fresh on first SSH). Failing the release here
+			// would leave the host already returned to Scaleway with
+			// no way to roll back.
+			logger.Error(cleanErr, "delete per-machine bootstrap Secret on release; next adopt will recreate it")
+			recorder.Eventf(machine, corev1.EventTypeWarning, "BootstrapSecretDeleteFailed",
+				"delete per-machine bootstrap Secret after release: %v (next adopt will overwrite)",
+				cleanErr)
+		}
+		recorder.Eventf(machine, corev1.EventTypeNormal, "BootstrapExhausted",
+			"Released Scaleway server %s after %d bootstrap failures; will claim a fresh host from the pool",
+			releasedID, attempts)
+		machine.Status.ServerID = ""
+		machine.Status.BootstrapAttempts = 0
+		machine.Status.BootstrapRebootIssued = false
+		machine.Status.Ready = false
+		machine.Status.Addresses = nil
+		machine.Status.Phase = "Pending"
+		machine.Spec.ProviderID = nil
+		conditions.MarkFalse(machine, ProvisionedCondition, "HostReleased",
+			clusterv1.ConditionSeverityWarning,
+			"released Scaleway server %s after %d bootstrap failures; awaiting fresh adopt",
+			releasedID, attempts)
+	case rebootAfter > 0 && attempts >= rebootAfter && !machine.Status.BootstrapRebootIssued && machine.Status.ServerID != "":
 		if rebootErr := client.RebootServer(ctx, machine.Status.ServerID, machine.Spec.Zone); rebootErr != nil {
 			logger.Error(rebootErr, "reboot for bootstrap recovery failed; will retry on next attempt")
 			recorder.Eventf(machine, corev1.EventTypeWarning, "RebootForRecoveryFailed",
@@ -981,20 +1048,6 @@ func handleBootstrapFailure(
 				"Rebooting %s after %d bootstrap failures to clear volatile host state",
 				machine.Status.ServerID, attempts)
 		}
-	case maxAttempts > 0 && attempts >= maxAttempts && hostAdoptable:
-		if releaseErr := client.ReleaseToPool(ctx, machine.Status.ServerID, machine.Spec.Zone, machine.Spec.AdoptPoolPrefix); releaseErr != nil {
-			logger.Error(releaseErr, "release-to-pool after bootstrap exhaustion failed; will retry")
-			recorder.Eventf(machine, corev1.EventTypeWarning, "ReleaseFailed",
-				"Scaleway ReleaseToPool after %d bootstrap failures: %v (will retry)",
-				attempts, releaseErr)
-			return ctrl.Result{RequeueAfter: 60 * time.Second}
-		}
-		recorder.Eventf(machine, corev1.EventTypeNormal, "BootstrapExhausted",
-			"Released Scaleway server %s after %d bootstrap failures; will claim a fresh host from the pool",
-			machine.Status.ServerID, attempts)
-		machine.Status.ServerID = ""
-		machine.Status.BootstrapAttempts = 0
-		machine.Status.BootstrapRebootIssued = false
 	}
 
 	return ctrl.Result{RequeueAfter: 60 * time.Second}

--- a/infra/cluster-api-provider-scaleway-applesilicon/controllers/scalewayapplesiliconmachine_controller.go
+++ b/infra/cluster-api-provider-scaleway-applesilicon/controllers/scalewayapplesiliconmachine_controller.go
@@ -125,6 +125,24 @@ type ScalewayAppleSiliconMachineReconciler struct {
 	// the manager binary; chart can override per env if needed.
 	TartKubeletMaxUpdateAttempts int32
 
+	// BootstrapRebootAfter is the consecutive-failure count at which
+	// the BootstrapFailed path asks Scaleway to reboot the host. The
+	// reboot clears volatile state (PAM lockouts, sshd throttling)
+	// without paying for a disk reinstall, and is a no-op when the
+	// host wasn't the problem. Fires once per host (gated on
+	// Status.BootstrapRebootIssued). Default 3.
+	BootstrapRebootAfter int32
+
+	// BootstrapMaxAttempts is the consecutive-failure count at which
+	// the controller gives up on the current host and returns it to
+	// the adopt pool — Scaleway's ReinstallServer then wipes the disk
+	// and the next reconcile claims a different mini. Without this
+	// cap, a mini stuck in an unrecoverable state (stale
+	// authorized_keys from a previous tenant, wedged sshd, OS
+	// corruption) gets retried indefinitely against the same broken
+	// host. Default 8.
+	BootstrapMaxAttempts int32
+
 	// MaxConcurrentReconciles is how many machines this controller
 	// reconciles in parallel. controller-runtime's default of 1
 	// serializes first-time fleet bring-up: each Mac mini's
@@ -330,6 +348,14 @@ func (r *ScalewayAppleSiliconMachineReconciler) reconcileNormal(
 		}
 
 		machine.Status.ServerID = srv.ID
+		// New host adopted — the failure-tracking state from a
+		// previously-discarded host doesn't apply. (The
+		// BootstrapFailed path that called ReleaseToPool already
+		// resets these, but cover the case where ServerID flipped
+		// without going through that path — e.g., legacy CR or
+		// manual operator intervention.)
+		machine.Status.BootstrapAttempts = 0
+		machine.Status.BootstrapRebootIssued = false
 		machine.Status.Addresses = []clusterv1.MachineAddress{{
 			Type:    clusterv1.MachineExternalIP,
 			Address: srv.IP,
@@ -383,6 +409,17 @@ func (r *ScalewayAppleSiliconMachineReconciler) reconcileNormal(
 	// Secret and proceed with bootstrap. Only surface
 	// MissingSudoPassword when even the refresh comes back empty (the
 	// host genuinely has no recoverable credentials).
+	//
+	// The same recovery applies when the Secret holds Scaleway's
+	// `<sealed>` placeholder — surfaced verbatim when macOS Tahoe
+	// seals the OS-level auto-login credential. The marker isn't a
+	// usable password (sudo rejects it as "Sorry, try again") but is
+	// non-empty so the bare `== ""` check would treat it as valid
+	// and skip the recovery path. Drop it the same way an empty
+	// value gets dropped.
+	if bootstrapCreds.SudoPassword == scaleway.SealedSecretMarker {
+		bootstrapCreds.SudoPassword = ""
+	}
 	if bootstrapCreds.SudoPassword == "" && machine.Status.ServerID != "" {
 		srv, refreshErr := r.ScalewayClient.GetServer(ctx, machine.Status.ServerID, machine.Spec.Zone)
 		switch {
@@ -524,14 +561,15 @@ func (r *ScalewayAppleSiliconMachineReconciler) reconcileNormal(
 			}
 		}
 		if err != nil {
-			conditions.MarkFalse(machine, BootstrappedCondition, "BootstrapFailed",
-				clusterv1.ConditionSeverityWarning, "%v", err)
-			r.Recorder.Eventf(machine, corev1.EventTypeWarning, "BootstrapFailed",
-				"%v (will retry)", err)
-			return ctrl.Result{RequeueAfter: 60 * time.Second}, nil
+			return handleBootstrapFailure(ctx, machine, err, r.ScalewayClient, r.Recorder, logger, r.BootstrapRebootAfter, r.BootstrapMaxAttempts), nil
 		}
 
 		conditions.MarkTrue(machine, BootstrappedCondition)
+		// Reset failure-tracking state — a long retry chain that
+		// finally succeeded is, from the cluster's perspective, the
+		// same shape as a first-try success.
+		machine.Status.BootstrapAttempts = 0
+		machine.Status.BootstrapRebootIssued = false
 		r.Recorder.Eventf(machine, corev1.EventTypeNormal, "Bootstrapped",
 			"Mac mini joined cluster as Node %s", machine.Name)
 		logger.Info("bootstrap complete", "host", ip)
@@ -878,6 +916,88 @@ func recordUpdateFailure(machine *infrav1.ScalewayAppleSiliconMachine, err error
 	recorder.Eventf(machine, corev1.EventTypeWarning, "AgentRollFailed",
 		"tart-kubelet update attempt %d/%d: %v",
 		machine.Status.TartKubeletUpdateAttempts, maxAttempts, err)
+}
+
+// bootstrapRecoveryClient is the narrow Scaleway surface
+// handleBootstrapFailure needs. Tests can satisfy it with a tiny
+// in-memory stub; the production *scaleway.Client satisfies it
+// natively.
+type bootstrapRecoveryClient interface {
+	RebootServer(ctx context.Context, id, zone string) error
+	ReleaseToPool(ctx context.Context, id, zone, poolPrefix string) error
+}
+
+// handleBootstrapFailure records the bootstrap error on the machine
+// and runs tiered host recovery. Returns the ctrl.Result the caller
+// should propagate.
+//
+// Tier 1: at `rebootAfter` consecutive failures, ask Scaleway to
+// reboot the host once. Most BootstrapFailed errors observed in
+// production are host-volatile (PAM account lockouts from sudo
+// retries, sshd connection throttling, half-open SSH sessions) and
+// resolve after a clean boot. Gated on Status.BootstrapRebootIssued so
+// a long retry tail doesn't re-reboot the same host.
+//
+// Tier 2: at `maxAttempts` consecutive failures, return the host to
+// the adopt pool. ReleaseToPool renames + triggers ReinstallServer
+// (full disk wipe + factory image), so the next reconcile claims a
+// different mini via AdoptFromPool. Status.ServerID is cleared so the
+// adoption stage re-runs; counter + reboot flag reset because they
+// describe the now-discarded host.
+//
+// Either tier failing to call out to Scaleway (transient API error,
+// 5xx) is non-fatal — the machine stays in the BootstrapFailed
+// condition and the next reconcile retries the same tier on the next
+// attempt count.
+func handleBootstrapFailure(
+	ctx context.Context,
+	machine *infrav1.ScalewayAppleSiliconMachine,
+	err error,
+	client bootstrapRecoveryClient,
+	recorder record.EventRecorder,
+	logger logr.Logger,
+	rebootAfter int32,
+	maxAttempts int32,
+) ctrl.Result {
+	machine.Status.BootstrapAttempts++
+	attempts := machine.Status.BootstrapAttempts
+
+	conditions.MarkFalse(machine, BootstrappedCondition, "BootstrapFailed",
+		clusterv1.ConditionSeverityWarning, "%v", err)
+	recorder.Eventf(machine, corev1.EventTypeWarning, "BootstrapFailed",
+		"%v (attempt %d, will retry)", err, attempts)
+
+	hostAdoptable := machine.Status.ServerID != "" && machine.Spec.AdoptPoolPrefix != ""
+	switch {
+	case rebootAfter > 0 && attempts == rebootAfter && !machine.Status.BootstrapRebootIssued && machine.Status.ServerID != "":
+		if rebootErr := client.RebootServer(ctx, machine.Status.ServerID, machine.Spec.Zone); rebootErr != nil {
+			logger.Error(rebootErr, "reboot for bootstrap recovery failed; will retry on next attempt")
+			recorder.Eventf(machine, corev1.EventTypeWarning, "RebootForRecoveryFailed",
+				"Scaleway RebootServer for %s after %d bootstrap failures: %v (will retry)",
+				machine.Status.ServerID, attempts, rebootErr)
+		} else {
+			machine.Status.BootstrapRebootIssued = true
+			recorder.Eventf(machine, corev1.EventTypeNormal, "RebootingForRecovery",
+				"Rebooting %s after %d bootstrap failures to clear volatile host state",
+				machine.Status.ServerID, attempts)
+		}
+	case maxAttempts > 0 && attempts >= maxAttempts && hostAdoptable:
+		if releaseErr := client.ReleaseToPool(ctx, machine.Status.ServerID, machine.Spec.Zone, machine.Spec.AdoptPoolPrefix); releaseErr != nil {
+			logger.Error(releaseErr, "release-to-pool after bootstrap exhaustion failed; will retry")
+			recorder.Eventf(machine, corev1.EventTypeWarning, "ReleaseFailed",
+				"Scaleway ReleaseToPool after %d bootstrap failures: %v (will retry)",
+				attempts, releaseErr)
+			return ctrl.Result{RequeueAfter: 60 * time.Second}
+		}
+		recorder.Eventf(machine, corev1.EventTypeNormal, "BootstrapExhausted",
+			"Released Scaleway server %s after %d bootstrap failures; will claim a fresh host from the pool",
+			machine.Status.ServerID, attempts)
+		machine.Status.ServerID = ""
+		machine.Status.BootstrapAttempts = 0
+		machine.Status.BootstrapRebootIssued = false
+	}
+
+	return ctrl.Result{RequeueAfter: 60 * time.Second}
 }
 
 // acquireServer claims a pre-ordered host from the pool. Returns

--- a/infra/cluster-api-provider-scaleway-applesilicon/controllers/scalewayapplesiliconmachine_controller_test.go
+++ b/infra/cluster-api-provider-scaleway-applesilicon/controllers/scalewayapplesiliconmachine_controller_test.go
@@ -691,6 +691,22 @@ func (s *recoveryStub) ReleaseToPool(_ context.Context, id, zone, poolPrefix str
 	return nil
 }
 
+// secretCleanerStub records the per-machine bootstrap Secret deletes
+// the recovery helper issues on release. An optional error injection
+// covers the non-fatal degraded path.
+type secretCleanerStub struct {
+	deletedMachines []string
+	deleteErr       error
+}
+
+func (s *secretCleanerStub) DeleteMachineBootstrap(_ context.Context, machineName string) error {
+	s.deletedMachines = append(s.deletedMachines, machineName)
+	if s.deleteErr != nil {
+		return s.deleteErr
+	}
+	return nil
+}
+
 func newBootstrapFailureMachine(serverID, poolPrefix string) *infrav1.ScalewayAppleSiliconMachine {
 	return &infrav1.ScalewayAppleSiliconMachine{
 		ObjectMeta: metav1.ObjectMeta{Name: "machine-x", Namespace: "ns"},
@@ -705,7 +721,7 @@ func newBootstrapFailureMachine(serverID, poolPrefix string) *infrav1.ScalewayAp
 func TestHandleBootstrapFailure_IncrementsAttempts(t *testing.T) {
 	machine := newBootstrapFailureMachine("srv-1", "tuist-pool-")
 	stub := &recoveryStub{}
-	res := handleBootstrapFailure(context.Background(), machine, errors.New("ssh wedged"), stub, fakeRecorder(), logr.Discard(), 3, 8)
+	res := handleBootstrapFailure(context.Background(), machine, errors.New("ssh wedged"), stub, &secretCleanerStub{}, fakeRecorder(), logr.Discard(), 3, 8)
 
 	if machine.Status.BootstrapAttempts != 1 {
 		t.Fatalf("expected attempts=1, got %d", machine.Status.BootstrapAttempts)
@@ -730,7 +746,7 @@ func TestHandleBootstrapFailure_RebootsAtThresholdOnce(t *testing.T) {
 	machine.Status.BootstrapAttempts = 2 // next call lands at 3
 	stub := &recoveryStub{}
 
-	res := handleBootstrapFailure(context.Background(), machine, errors.New("sudo locked"), stub, fakeRecorder(), logr.Discard(), 3, 8)
+	res := handleBootstrapFailure(context.Background(), machine, errors.New("sudo locked"), stub, &secretCleanerStub{}, fakeRecorder(), logr.Discard(), 3, 8)
 	if res.RequeueAfter != 60*time.Second {
 		t.Fatalf("expected 60s requeue, got %v", res.RequeueAfter)
 	}
@@ -746,7 +762,7 @@ func TestHandleBootstrapFailure_RebootsAtThresholdOnce(t *testing.T) {
 
 	// Drive attempts past the threshold without crossing maxAttempts.
 	// The reboot must not fire again because BootstrapRebootIssued is set.
-	res = handleBootstrapFailure(context.Background(), machine, errors.New("still wedged"), stub, fakeRecorder(), logr.Discard(), 3, 8)
+	res = handleBootstrapFailure(context.Background(), machine, errors.New("still wedged"), stub, &secretCleanerStub{}, fakeRecorder(), logr.Discard(), 3, 8)
 	if len(stub.rebootCalls) != 1 {
 		t.Fatalf("reboot must be one-shot per host; got %d calls", len(stub.rebootCalls))
 	}
@@ -759,12 +775,35 @@ func TestHandleBootstrapFailure_RebootsAtThresholdOnce(t *testing.T) {
 }
 
 func TestHandleBootstrapFailure_ReleasesToPoolAtMax(t *testing.T) {
+	// Full release-path contract: Scaleway ReleaseToPool is called
+	// once, the per-machine bootstrap Secret is deleted (so the
+	// previous host's TOFU fingerprint can't poison the next
+	// adopt), counters reset, and outwardly-visible state tied to
+	// the discarded host (Status.Ready, Status.Phase,
+	// Spec.ProviderID, Status.Addresses, ProvisionedCondition)
+	// reverts to its pre-adoption shape.
 	machine := newBootstrapFailureMachine("srv-1", "tuist-pool-")
 	machine.Status.BootstrapAttempts = 7        // next call lands at 8 = maxAttempts
 	machine.Status.BootstrapRebootIssued = true // assume reboot already tried earlier
-	stub := &recoveryStub{}
+	// Pre-populate the outwardly-visible state from the prior
+	// successful provisioning to assert the release path rolls them
+	// back. (Status.Ready can be True on a previously-bootstrapped
+	// Machine that started failing again — Node drift, host
+	// regression — and would otherwise lie to CAPI / operators
+	// during the recovery window.)
+	machine.Status.Ready = true
+	machine.Status.Phase = "Ready"
+	providerID := "scw-applesilicon://fr-par-1/srv-1"
+	machine.Spec.ProviderID = &providerID
+	machine.Status.Addresses = []clusterv1.MachineAddress{{
+		Type:    clusterv1.MachineExternalIP,
+		Address: "62.210.0.1",
+	}}
+	conditions.MarkTrue(machine, ProvisionedCondition)
 
-	handleBootstrapFailure(context.Background(), machine, errors.New("unrecoverable"), stub, fakeRecorder(), logr.Discard(), 3, 8)
+	stub := &recoveryStub{}
+	secrets := &secretCleanerStub{}
+	handleBootstrapFailure(context.Background(), machine, errors.New("unrecoverable"), stub, secrets, fakeRecorder(), logr.Discard(), 3, 8)
 
 	if len(stub.releaseCalls) != 1 {
 		t.Fatalf("expected one release call at max attempts, got %d", len(stub.releaseCalls))
@@ -772,12 +811,85 @@ func TestHandleBootstrapFailure_ReleasesToPoolAtMax(t *testing.T) {
 	if stub.releaseCalls[0] != (recoveryReleaseCall{id: "srv-1", zone: "fr-par-1", poolPrefix: "tuist-pool-"}) {
 		t.Fatalf("unexpected release call shape: %+v", stub.releaseCalls[0])
 	}
+	if got := secrets.deletedMachines; len(got) != 1 || got[0] != "machine-x" {
+		t.Fatalf("expected per-machine bootstrap Secret to be deleted on release; got %v", got)
+	}
 	if machine.Status.ServerID != "" {
 		t.Fatalf("Status.ServerID must clear after release; got %q", machine.Status.ServerID)
 	}
 	if machine.Status.BootstrapAttempts != 0 || machine.Status.BootstrapRebootIssued {
 		t.Fatalf("counters/flags must reset after release; got attempts=%d issued=%v",
 			machine.Status.BootstrapAttempts, machine.Status.BootstrapRebootIssued)
+	}
+	if machine.Status.Ready {
+		t.Fatal("Status.Ready must flip false on release — the discarded host is no longer attached")
+	}
+	if machine.Status.Phase != "Pending" {
+		t.Fatalf("Status.Phase must revert to Pending on release, got %q", machine.Status.Phase)
+	}
+	if machine.Spec.ProviderID != nil {
+		t.Fatalf("Spec.ProviderID must clear on release, got %q", *machine.Spec.ProviderID)
+	}
+	if len(machine.Status.Addresses) != 0 {
+		t.Fatalf("Status.Addresses must clear on release, got %+v", machine.Status.Addresses)
+	}
+	if !conditions.IsFalse(machine, ProvisionedCondition) {
+		t.Fatal("ProvisionedCondition must flip False on release; the host is gone")
+	}
+}
+
+func TestHandleBootstrapFailure_RebootRetriesAfterAPIError(t *testing.T) {
+	// Regression: an earlier draft used `attempts == rebootAfter`,
+	// which meant a failed RebootServer at attempt 3 with the
+	// one-shot guard staying false was never retried on attempt 4+
+	// (the equality stopped matching). Use `>=` so the next reconcile
+	// retries the cheap recovery before escalating to release.
+	machine := newBootstrapFailureMachine("srv-1", "tuist-pool-")
+	machine.Status.BootstrapAttempts = 2 // next call lands at 3
+	stub := &recoveryStub{rebootErr: errors.New("scaleway 503")}
+
+	handleBootstrapFailure(context.Background(), machine, errors.New("ssh wedged"), stub, &secretCleanerStub{}, fakeRecorder(), logr.Discard(), 3, 8)
+	if len(stub.rebootCalls) != 1 {
+		t.Fatalf("expected one reboot attempt on attempt 3, got %d", len(stub.rebootCalls))
+	}
+	if machine.Status.BootstrapRebootIssued {
+		t.Fatal("BootstrapRebootIssued must stay false on RebootServer error so the next reconcile retries")
+	}
+
+	// Clear the injected error and drive a second failure (attempt 4).
+	// The reboot tier should fire again — that's the whole point of
+	// not consuming the one-shot flag on the prior error.
+	stub.rebootErr = nil
+	handleBootstrapFailure(context.Background(), machine, errors.New("ssh wedged again"), stub, &secretCleanerStub{}, fakeRecorder(), logr.Discard(), 3, 8)
+	if len(stub.rebootCalls) != 2 {
+		t.Fatalf("expected retry-after-error to fire a second reboot at attempt 4, got %d total calls", len(stub.rebootCalls))
+	}
+	if !machine.Status.BootstrapRebootIssued {
+		t.Fatal("BootstrapRebootIssued must flip true after the successful retry")
+	}
+	if machine.Status.BootstrapAttempts != 4 {
+		t.Fatalf("expected attempts=4 after second call, got %d", machine.Status.BootstrapAttempts)
+	}
+}
+
+func TestHandleBootstrapFailure_ReleaseSwallowsSecretDeleteError(t *testing.T) {
+	// The Secret-delete step is "best effort": the host has already
+	// been returned to Scaleway by the time we get here, so failing
+	// the release on a Secret-API blip would leave us with no way
+	// to roll back. The error is recorded as an event and we
+	// continue with the state reset.
+	machine := newBootstrapFailureMachine("srv-1", "tuist-pool-")
+	machine.Status.BootstrapAttempts = 7
+	stub := &recoveryStub{}
+	secrets := &secretCleanerStub{deleteErr: errors.New("api server unreachable")}
+
+	handleBootstrapFailure(context.Background(), machine, errors.New("unrecoverable"), stub, secrets, fakeRecorder(), logr.Discard(), 3, 8)
+
+	if len(stub.releaseCalls) != 1 {
+		t.Fatalf("Scaleway release must still happen even when Secret delete errors; got %d release calls", len(stub.releaseCalls))
+	}
+	if machine.Status.ServerID != "" {
+		t.Fatalf("Secret-delete failure must not block the state reset; ServerID still %q", machine.Status.ServerID)
 	}
 }
 
@@ -791,7 +903,7 @@ func TestHandleBootstrapFailure_ReleaseAPIErrorKeepsState(t *testing.T) {
 	machine.Status.BootstrapAttempts = 7
 	stub := &recoveryStub{releaseErr: errors.New("scaleway 503")}
 
-	handleBootstrapFailure(context.Background(), machine, errors.New("unrecoverable"), stub, fakeRecorder(), logr.Discard(), 3, 8)
+	handleBootstrapFailure(context.Background(), machine, errors.New("unrecoverable"), stub, &secretCleanerStub{}, fakeRecorder(), logr.Discard(), 3, 8)
 
 	if machine.Status.ServerID != "srv-1" {
 		t.Fatalf("ServerID must persist when release fails; got %q", machine.Status.ServerID)
@@ -810,7 +922,7 @@ func TestHandleBootstrapFailure_RebootAPIErrorDoesNotConsumeOneShot(t *testing.T
 	machine.Status.BootstrapAttempts = 2
 	stub := &recoveryStub{rebootErr: errors.New("scaleway 503")}
 
-	handleBootstrapFailure(context.Background(), machine, errors.New("ssh wedged"), stub, fakeRecorder(), logr.Discard(), 3, 8)
+	handleBootstrapFailure(context.Background(), machine, errors.New("ssh wedged"), stub, &secretCleanerStub{}, fakeRecorder(), logr.Discard(), 3, 8)
 
 	if len(stub.rebootCalls) != 1 {
 		t.Fatalf("expected one reboot attempt despite error, got %d", len(stub.rebootCalls))
@@ -831,7 +943,7 @@ func TestHandleBootstrapFailure_LegacyCRWithoutPoolPrefixNeverReleases(t *testin
 	machine.Status.BootstrapAttempts = 7
 
 	stub := &recoveryStub{}
-	handleBootstrapFailure(context.Background(), machine, errors.New("unrecoverable"), stub, fakeRecorder(), logr.Discard(), 3, 8)
+	handleBootstrapFailure(context.Background(), machine, errors.New("unrecoverable"), stub, &secretCleanerStub{}, fakeRecorder(), logr.Discard(), 3, 8)
 
 	if len(stub.releaseCalls) != 0 {
 		t.Fatalf("legacy CR (no pool prefix) must not trigger release; got %+v", stub.releaseCalls)
@@ -849,7 +961,7 @@ func TestHandleBootstrapFailure_DisabledThresholdsSkipBothTiers(t *testing.T) {
 	machine.Status.BootstrapAttempts = 100
 	stub := &recoveryStub{}
 
-	handleBootstrapFailure(context.Background(), machine, errors.New("boom"), stub, fakeRecorder(), logr.Discard(), 0, 0)
+	handleBootstrapFailure(context.Background(), machine, errors.New("boom"), stub, &secretCleanerStub{}, fakeRecorder(), logr.Discard(), 0, 0)
 
 	if len(stub.rebootCalls) != 0 || len(stub.releaseCalls) != 0 {
 		t.Fatalf("zero thresholds must skip both tiers; got reboots=%+v releases=%+v",

--- a/infra/cluster-api-provider-scaleway-applesilicon/controllers/scalewayapplesiliconmachine_controller_test.go
+++ b/infra/cluster-api-provider-scaleway-applesilicon/controllers/scalewayapplesiliconmachine_controller_test.go
@@ -500,6 +500,9 @@ type scalewayAPIStub struct {
 	updatedNames   []string
 	reinstalledIDs []string
 	reinstallCalls int
+	rebootedIDs    []string
+	rebootCalls    int
+	rebootError    error
 }
 
 func (f *scalewayAPIStub) ListServers(*applesilicon.ListServersRequest, ...scw.RequestOption) (*applesilicon.ListServersResponse, error) {
@@ -534,6 +537,20 @@ func (f *scalewayAPIStub) ReinstallServer(req *applesilicon.ReinstallServerReque
 	for _, s := range f.servers {
 		if s.ID == req.ServerID {
 			f.reinstalledIDs = append(f.reinstalledIDs, s.ID)
+			return s, nil
+		}
+	}
+	return nil, errors.New("not found")
+}
+
+func (f *scalewayAPIStub) RebootServer(req *applesilicon.RebootServerRequest, _ ...scw.RequestOption) (*applesilicon.Server, error) {
+	f.rebootCalls++
+	if f.rebootError != nil {
+		return nil, f.rebootError
+	}
+	for _, s := range f.servers {
+		if s.ID == req.ServerID {
+			f.rebootedIDs = append(f.rebootedIDs, s.ID)
 			return s, nil
 		}
 	}
@@ -621,4 +638,221 @@ func TestReconcileDelete_LegacyCRWithoutPrefixSkipsRelease(t *testing.T) {
 
 func startsWith(s, prefix string) bool {
 	return len(s) >= len(prefix) && s[:len(prefix)] == prefix
+}
+
+// --- handleBootstrapFailure ------------------------------------------------
+//
+// Tiered host recovery contract:
+//   - Every call increments BootstrapAttempts and flips the
+//     Bootstrapped condition to False with reason BootstrapFailed.
+//   - At rebootAfter the controller asks Scaleway to reboot once
+//     (gated on BootstrapRebootIssued).
+//   - At maxAttempts the controller releases the host to the pool;
+//     the counter + reboot flag reset because they describe the
+//     now-discarded host.
+//   - Scaleway API errors at either tier are non-fatal — the
+//     machine stays in the failed state and the next call retries.
+
+// recoveryStub is the smallest in-memory bootstrapRecoveryClient
+// sufficient to drive the controller helper. It records every call so
+// tests can assert on the exact API surface the recovery code
+// triggered, and lets each method's first call inject an error.
+type recoveryStub struct {
+	rebootCalls   []recoveryCall
+	rebootErr     error
+	releaseCalls  []recoveryReleaseCall
+	releaseErr    error
+}
+
+type recoveryCall struct {
+	id   string
+	zone string
+}
+
+type recoveryReleaseCall struct {
+	id         string
+	zone       string
+	poolPrefix string
+}
+
+func (s *recoveryStub) RebootServer(_ context.Context, id, zone string) error {
+	s.rebootCalls = append(s.rebootCalls, recoveryCall{id: id, zone: zone})
+	if s.rebootErr != nil {
+		return s.rebootErr
+	}
+	return nil
+}
+
+func (s *recoveryStub) ReleaseToPool(_ context.Context, id, zone, poolPrefix string) error {
+	s.releaseCalls = append(s.releaseCalls, recoveryReleaseCall{id: id, zone: zone, poolPrefix: poolPrefix})
+	if s.releaseErr != nil {
+		return s.releaseErr
+	}
+	return nil
+}
+
+func newBootstrapFailureMachine(serverID, poolPrefix string) *infrav1.ScalewayAppleSiliconMachine {
+	return &infrav1.ScalewayAppleSiliconMachine{
+		ObjectMeta: metav1.ObjectMeta{Name: "machine-x", Namespace: "ns"},
+		Spec: infrav1.ScalewayAppleSiliconMachineSpec{
+			AdoptPoolPrefix: poolPrefix,
+			Zone:            "fr-par-1",
+		},
+		Status: infrav1.ScalewayAppleSiliconMachineStatus{ServerID: serverID},
+	}
+}
+
+func TestHandleBootstrapFailure_IncrementsAttempts(t *testing.T) {
+	machine := newBootstrapFailureMachine("srv-1", "tuist-pool-")
+	stub := &recoveryStub{}
+	res := handleBootstrapFailure(context.Background(), machine, errors.New("ssh wedged"), stub, fakeRecorder(), logr.Discard(), 3, 8)
+
+	if machine.Status.BootstrapAttempts != 1 {
+		t.Fatalf("expected attempts=1, got %d", machine.Status.BootstrapAttempts)
+	}
+	if !conditions.IsFalse(machine, BootstrappedCondition) {
+		t.Fatalf("expected Bootstrapped condition False")
+	}
+	if res.RequeueAfter != 60*time.Second {
+		t.Fatalf("expected 60s requeue, got %v", res.RequeueAfter)
+	}
+	if len(stub.rebootCalls)+len(stub.releaseCalls) != 0 {
+		t.Fatalf("first failure must not call Reboot or Release; got %+v / %+v", stub.rebootCalls, stub.releaseCalls)
+	}
+}
+
+func TestHandleBootstrapFailure_RebootsAtThresholdOnce(t *testing.T) {
+	// At rebootAfter the controller fires RebootServer once and
+	// marks the attempt. Subsequent failures (gated on the issued
+	// flag) must not re-fire the reboot — that would extend any
+	// recovery window we just opened.
+	machine := newBootstrapFailureMachine("srv-1", "tuist-pool-")
+	machine.Status.BootstrapAttempts = 2 // next call lands at 3
+	stub := &recoveryStub{}
+
+	res := handleBootstrapFailure(context.Background(), machine, errors.New("sudo locked"), stub, fakeRecorder(), logr.Discard(), 3, 8)
+	if res.RequeueAfter != 60*time.Second {
+		t.Fatalf("expected 60s requeue, got %v", res.RequeueAfter)
+	}
+	if len(stub.rebootCalls) != 1 {
+		t.Fatalf("expected one reboot at threshold, got %d", len(stub.rebootCalls))
+	}
+	if stub.rebootCalls[0] != (recoveryCall{id: "srv-1", zone: "fr-par-1"}) {
+		t.Fatalf("unexpected reboot call shape: %+v", stub.rebootCalls[0])
+	}
+	if !machine.Status.BootstrapRebootIssued {
+		t.Fatalf("Status.BootstrapRebootIssued must flip true after a successful reboot")
+	}
+
+	// Drive attempts past the threshold without crossing maxAttempts.
+	// The reboot must not fire again because BootstrapRebootIssued is set.
+	res = handleBootstrapFailure(context.Background(), machine, errors.New("still wedged"), stub, fakeRecorder(), logr.Discard(), 3, 8)
+	if len(stub.rebootCalls) != 1 {
+		t.Fatalf("reboot must be one-shot per host; got %d calls", len(stub.rebootCalls))
+	}
+	if machine.Status.BootstrapAttempts != 4 {
+		t.Fatalf("expected attempts=4 after post-reboot retry, got %d", machine.Status.BootstrapAttempts)
+	}
+	if res.RequeueAfter != 60*time.Second {
+		t.Fatalf("expected 60s requeue on post-reboot retry, got %v", res.RequeueAfter)
+	}
+}
+
+func TestHandleBootstrapFailure_ReleasesToPoolAtMax(t *testing.T) {
+	machine := newBootstrapFailureMachine("srv-1", "tuist-pool-")
+	machine.Status.BootstrapAttempts = 7 // next call lands at 8 = maxAttempts
+	machine.Status.BootstrapRebootIssued = true // assume reboot already tried earlier
+	stub := &recoveryStub{}
+
+	handleBootstrapFailure(context.Background(), machine, errors.New("unrecoverable"), stub, fakeRecorder(), logr.Discard(), 3, 8)
+
+	if len(stub.releaseCalls) != 1 {
+		t.Fatalf("expected one release call at max attempts, got %d", len(stub.releaseCalls))
+	}
+	if stub.releaseCalls[0] != (recoveryReleaseCall{id: "srv-1", zone: "fr-par-1", poolPrefix: "tuist-pool-"}) {
+		t.Fatalf("unexpected release call shape: %+v", stub.releaseCalls[0])
+	}
+	if machine.Status.ServerID != "" {
+		t.Fatalf("Status.ServerID must clear after release; got %q", machine.Status.ServerID)
+	}
+	if machine.Status.BootstrapAttempts != 0 || machine.Status.BootstrapRebootIssued {
+		t.Fatalf("counters/flags must reset after release; got attempts=%d issued=%v",
+			machine.Status.BootstrapAttempts, machine.Status.BootstrapRebootIssued)
+	}
+}
+
+func TestHandleBootstrapFailure_ReleaseAPIErrorKeepsState(t *testing.T) {
+	// Scaleway 5xx / network blip at release time: stay in the
+	// failed state so the next reconcile retries the release. We
+	// must NOT clear ServerID or the counter — that would let the
+	// adoption stage try to claim a new host while the old one is
+	// still wedged in our account.
+	machine := newBootstrapFailureMachine("srv-1", "tuist-pool-")
+	machine.Status.BootstrapAttempts = 7
+	stub := &recoveryStub{releaseErr: errors.New("scaleway 503")}
+
+	handleBootstrapFailure(context.Background(), machine, errors.New("unrecoverable"), stub, fakeRecorder(), logr.Discard(), 3, 8)
+
+	if machine.Status.ServerID != "srv-1" {
+		t.Fatalf("ServerID must persist when release fails; got %q", machine.Status.ServerID)
+	}
+	if machine.Status.BootstrapAttempts != 8 {
+		t.Fatalf("attempts must still increment when release fails; got %d", machine.Status.BootstrapAttempts)
+	}
+}
+
+func TestHandleBootstrapFailure_RebootAPIErrorDoesNotConsumeOneShot(t *testing.T) {
+	// If RebootServer returns an error, BootstrapRebootIssued must
+	// stay false — otherwise the one-shot guard would consume the
+	// reboot tier on a Scaleway 5xx without actually rebooting,
+	// and the controller would never retry the cheap recovery.
+	machine := newBootstrapFailureMachine("srv-1", "tuist-pool-")
+	machine.Status.BootstrapAttempts = 2
+	stub := &recoveryStub{rebootErr: errors.New("scaleway 503")}
+
+	handleBootstrapFailure(context.Background(), machine, errors.New("ssh wedged"), stub, fakeRecorder(), logr.Discard(), 3, 8)
+
+	if len(stub.rebootCalls) != 1 {
+		t.Fatalf("expected one reboot attempt despite error, got %d", len(stub.rebootCalls))
+	}
+	if machine.Status.BootstrapRebootIssued {
+		t.Fatalf("BootstrapRebootIssued must stay false on RebootServer error to preserve the one-shot retry")
+	}
+}
+
+func TestHandleBootstrapFailure_LegacyCRWithoutPoolPrefixNeverReleases(t *testing.T) {
+	// Legacy CRs adopted under the old (no-prefix) chart contract
+	// can't be safely returned to the pool — the client refuses an
+	// empty prefix to avoid orphaning hosts outside the pool
+	// namespace. Cap behaviour: stay in the failed state, never
+	// trigger release. (Operator can clear FailureReason + ServerID
+	// out-of-band to recover.)
+	machine := newBootstrapFailureMachine("srv-legacy", "")
+	machine.Status.BootstrapAttempts = 7
+
+	stub := &recoveryStub{}
+	handleBootstrapFailure(context.Background(), machine, errors.New("unrecoverable"), stub, fakeRecorder(), logr.Discard(), 3, 8)
+
+	if len(stub.releaseCalls) != 0 {
+		t.Fatalf("legacy CR (no pool prefix) must not trigger release; got %+v", stub.releaseCalls)
+	}
+	if machine.Status.ServerID == "" {
+		t.Fatalf("legacy CR ServerID must persist; release path was bypassed")
+	}
+}
+
+func TestHandleBootstrapFailure_DisabledThresholdsSkipBothTiers(t *testing.T) {
+	// Setting either threshold to 0 disables that tier. Pure-retry
+	// mode (both 0) is the operator escape hatch when fleet-wide
+	// disruption shouldn't be automated.
+	machine := newBootstrapFailureMachine("srv-1", "tuist-pool-")
+	machine.Status.BootstrapAttempts = 100
+	stub := &recoveryStub{}
+
+	handleBootstrapFailure(context.Background(), machine, errors.New("boom"), stub, fakeRecorder(), logr.Discard(), 0, 0)
+
+	if len(stub.rebootCalls) != 0 || len(stub.releaseCalls) != 0 {
+		t.Fatalf("zero thresholds must skip both tiers; got reboots=%+v releases=%+v",
+			stub.rebootCalls, stub.releaseCalls)
+	}
 }

--- a/infra/cluster-api-provider-scaleway-applesilicon/controllers/scalewayapplesiliconmachine_controller_test.go
+++ b/infra/cluster-api-provider-scaleway-applesilicon/controllers/scalewayapplesiliconmachine_controller_test.go
@@ -658,10 +658,10 @@ func startsWith(s, prefix string) bool {
 // tests can assert on the exact API surface the recovery code
 // triggered, and lets each method's first call inject an error.
 type recoveryStub struct {
-	rebootCalls   []recoveryCall
-	rebootErr     error
-	releaseCalls  []recoveryReleaseCall
-	releaseErr    error
+	rebootCalls  []recoveryCall
+	rebootErr    error
+	releaseCalls []recoveryReleaseCall
+	releaseErr   error
 }
 
 type recoveryCall struct {
@@ -760,7 +760,7 @@ func TestHandleBootstrapFailure_RebootsAtThresholdOnce(t *testing.T) {
 
 func TestHandleBootstrapFailure_ReleasesToPoolAtMax(t *testing.T) {
 	machine := newBootstrapFailureMachine("srv-1", "tuist-pool-")
-	machine.Status.BootstrapAttempts = 7 // next call lands at 8 = maxAttempts
+	machine.Status.BootstrapAttempts = 7        // next call lands at 8 = maxAttempts
 	machine.Status.BootstrapRebootIssued = true // assume reboot already tried earlier
 	stub := &recoveryStub{}
 

--- a/infra/cluster-api-provider-scaleway-applesilicon/internal/scaleway/client.go
+++ b/infra/cluster-api-provider-scaleway-applesilicon/internal/scaleway/client.go
@@ -40,6 +40,7 @@ type AppleSiliconAPI interface {
 	ListServers(req *applesilicon.ListServersRequest, opts ...scw.RequestOption) (*applesilicon.ListServersResponse, error)
 	UpdateServer(req *applesilicon.UpdateServerRequest, opts ...scw.RequestOption) (*applesilicon.Server, error)
 	ReinstallServer(req *applesilicon.ReinstallServerRequest, opts ...scw.RequestOption) (*applesilicon.Server, error)
+	RebootServer(req *applesilicon.RebootServerRequest, opts ...scw.RequestOption) (*applesilicon.Server, error)
 }
 
 // Client talks to Scaleway's Apple Silicon + IAM APIs. Construct with
@@ -417,6 +418,33 @@ func (c *Client) GetServer(ctx context.Context, id, zone string) (*Server, error
 	return scalewayServerToServer(srv), nil
 }
 
+// RebootServer asks Scaleway to reboot the host. Fire-and-forget on
+// the wire; the server transitions through `rebooting → ready` on its
+// own (~1-2 min). Used as a cheap volatile-state clear before
+// considering a host irrecoverable — clears in-memory PAM lockouts,
+// sshd connection throttling, and other state that survives across
+// failed SSH attempts but not across a clean boot.
+func (c *Client) RebootServer(ctx context.Context, id, zone string) error {
+	_, err := c.API.RebootServer(&applesilicon.RebootServerRequest{
+		ServerID: id,
+		Zone:     scw.Zone(zone),
+	}, scw.WithContext(ctx))
+	if err != nil {
+		if IsNotFound(err) {
+			return nil
+		}
+		// A reboot issued while the server is already mid-reboot/install
+		// is harmless from our perspective; treat the typed transient
+		// state error as success so callers aren't pushed into
+		// secondary recovery for a no-op.
+		if isTransientState(err) {
+			return nil
+		}
+		return fmt.Errorf("reboot server %s: %w", id, err)
+	}
+	return nil
+}
+
 // ReleaseToPool returns a Mac mini to the adopt pool. Operator-
 // driven physical destruction is intentionally separated from
 // cluster-driven Machine churn: the 24h Apple-licensing floor makes
@@ -519,6 +547,13 @@ func IsNotFound(err error) bool {
 	return false
 }
 
+// SealedSecretMarker is the literal placeholder macOS Tahoe writes when
+// the OS-managed auto-login credential is sealed (e.g., immediately
+// after a fresh adopt or while the server is rebooting). Scaleway
+// surfaces it verbatim through both `sudo_password` and `vnc_url` while
+// the seal is in effect — the string is not a usable password.
+const SealedSecretMarker = "<sealed>"
+
 func scalewayServerToServer(s *applesilicon.Server) *Server {
 	out := &Server{
 		ID:           s.ID,
@@ -529,21 +564,23 @@ func scalewayServerToServer(s *applesilicon.Server) *Server {
 	if s.IP != nil {
 		out.IP = s.IP.String()
 	}
-	// Scaleway never surfaces `sudo_password` on GET/list responses
-	// for pool-adopted hosts (the field is only populated on the
-	// one-time CreateServer response, and the pool workflow never
-	// hits that path). Without a fallback the controller stages an
-	// empty password into the bootstrap Secret and `enableAutoLogin`
-	// either silently skips (writing nothing) or writes a kcpassword
-	// whose plaintext is just the cipher key padding — either way
-	// Aqua never comes up and `tart run` fails forever.
-	//
-	// The `vnc_url` field embeds the same OS-default credentials as
-	// `vnc://<ssh_username>:<password>@<ip>:<port>`. It's surfaced on
-	// every GET and verified out-of-band to authenticate the m1
-	// macOS user; pull the password from there.
-	if out.SudoPassword == "" {
+	// Scaleway either populates `sudo_password` directly (one-time
+	// CreateServer response, or transient post-adopt windows) or
+	// returns the literal `<sealed>` marker while the OS-level seal is
+	// in effect. The `vnc_url` field carries the same OS-default
+	// credentials as `vnc://<ssh_username>:<password>@<ip>:<port>` and
+	// is surfaced on every GET — pull the password from there when the
+	// top-level field isn't directly usable.
+	if out.SudoPassword == "" || out.SudoPassword == SealedSecretMarker {
 		out.SudoPassword = passwordFromVncURL(s.VncURL)
+	}
+	// `vnc_url` itself can carry the sealed marker either as the whole
+	// string (URL parsing returns no userinfo → empty above) or as the
+	// embedded password component (URL parsing succeeds → marker comes
+	// through verbatim). Reject the marker so downstream code never
+	// hands `<sealed>` to sudo.
+	if out.SudoPassword == SealedSecretMarker {
+		out.SudoPassword = ""
 	}
 	return out
 }

--- a/infra/cluster-api-provider-scaleway-applesilicon/internal/scaleway/client_test.go
+++ b/infra/cluster-api-provider-scaleway-applesilicon/internal/scaleway/client_test.go
@@ -105,6 +105,97 @@ func TestScalewayServerToServer_LeavesPasswordEmptyWhenBothSourcesEmpty(t *testi
 	}
 }
 
+func TestScalewayServerToServer_FallsBackToVncURLWhenSudoPasswordIsSealed(t *testing.T) {
+	// macOS Tahoe seals the OS-managed auto-login credential after
+	// adopt; Scaleway returns the literal "<sealed>" marker on
+	// `sudo_password` but vnc_url can still carry the real value
+	// (observed empirically during a fresh adopt: top-level field
+	// sealed, vnc_url returned the plaintext password).
+	in := &applesilicon.Server{
+		ID:           "server-id",
+		Status:       applesilicon.ServerStatusReady,
+		SudoPassword: SealedSecretMarker,
+		SSHUsername:  "m1",
+		VncURL:       "vnc://m1:realpwd@host:59010",
+	}
+	out := scalewayServerToServer(in)
+	if out.SudoPassword != "realpwd" {
+		t.Fatalf("expected vnc_url password to override <sealed>, got %q", out.SudoPassword)
+	}
+}
+
+func TestScalewayServerToServer_RejectsSealedMarkerFromVncURL(t *testing.T) {
+	// When the sealed window is in effect across both surfaces (post-
+	// reboot, mid-reinstall), `vnc_url` either equals the marker
+	// outright (URL parsing returns empty) or embeds it as the
+	// password component (URL parsing surfaces it verbatim). Both
+	// must resolve to empty so the controller's MissingSudoPassword
+	// gate fires honestly rather than handing "<sealed>" to sudo.
+	cases := []struct {
+		name   string
+		vncURL string
+	}{
+		{name: "vnc_url is the marker itself", vncURL: SealedSecretMarker},
+		{name: "vnc_url embeds the marker as password", vncURL: "vnc://m1:%3Csealed%3E@host:59010"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			in := &applesilicon.Server{
+				ID:           "server-id",
+				Status:       applesilicon.ServerStatusReady,
+				SudoPassword: SealedSecretMarker,
+				SSHUsername:  "m1",
+				VncURL:       tc.vncURL,
+			}
+			out := scalewayServerToServer(in)
+			if out.SudoPassword != "" {
+				t.Fatalf("expected SudoPassword to be empty when both sources carry the sealed marker, got %q", out.SudoPassword)
+			}
+		})
+	}
+}
+
+func TestClientRebootServer_SwallowsNotFound(t *testing.T) {
+	// Deletion races: the operator just removed the host via
+	// ReleaseToPool's reinstall path, and a concurrent recovery
+	// reboot fires against the gone serverID. NotFound should be
+	// success — the host the caller wanted rebooted no longer
+	// exists for them to act on.
+	api := &fakeAppleSiliconAPI{
+		rebootErrors: map[int]error{1: &scw.ResourceNotFoundError{Resource: "server", ResourceID: "srv-gone"}},
+	}
+	c := &Client{API: api}
+	if err := c.RebootServer(context.Background(), "srv-gone", "fr-par-1"); err != nil {
+		t.Fatalf("expected NotFound to be swallowed, got %v", err)
+	}
+}
+
+func TestClientRebootServer_SwallowsTransientState(t *testing.T) {
+	// Rebooting a server that's already mid-reboot/install is a
+	// no-op from the caller's perspective; the typed transient-state
+	// error shouldn't trigger downstream recovery.
+	api := &fakeAppleSiliconAPI{
+		rebootErrors: map[int]error{1: &scw.TransientStateError{Resource: "server", ResourceID: "srv-1", CurrentState: "rebooting"}},
+	}
+	c := &Client{API: api}
+	if err := c.RebootServer(context.Background(), "srv-1", "fr-par-1"); err != nil {
+		t.Fatalf("expected transient-state error to be swallowed, got %v", err)
+	}
+}
+
+func TestClientRebootServer_HappyPathRecordsCall(t *testing.T) {
+	api := &fakeAppleSiliconAPI{
+		servers: []*applesilicon.Server{{ID: "srv-1", Status: applesilicon.ServerStatusReady}},
+	}
+	c := &Client{API: api}
+	if err := c.RebootServer(context.Background(), "srv-1", "fr-par-1"); err != nil {
+		t.Fatalf("RebootServer: %v", err)
+	}
+	if len(api.rebootedIDs) != 1 || api.rebootedIDs[0] != "srv-1" {
+		t.Fatalf("expected one reboot of srv-1, got %v", api.rebootedIDs)
+	}
+}
+
 // --- two-phase adoption tests ---------------------------------------------
 //
 // The two-phase claim in AdoptFromPool is what keeps two concurrent
@@ -151,6 +242,14 @@ type fakeAppleSiliconAPI struct {
 	reinstallErrors map[int]error
 	reinstallCalls  int
 	reinstalledIDs  []string
+
+	// rebootErrors / rebootedIDs mirror the reinstall shape for
+	// RebootServer. Tests exercising the BootstrapFailed reboot tier
+	// assert on rebootedIDs and use rebootErrors to force NotFound /
+	// TransientState shapes.
+	rebootErrors map[int]error
+	rebootCalls  int
+	rebootedIDs  []string
 }
 
 func (f *fakeAppleSiliconAPI) ListServers(req *applesilicon.ListServersRequest, _ ...scw.RequestOption) (*applesilicon.ListServersResponse, error) {
@@ -204,6 +303,21 @@ func (f *fakeAppleSiliconAPI) ReinstallServer(req *applesilicon.ReinstallServerR
 		if s.ID == req.ServerID {
 			f.reinstalledIDs = append(f.reinstalledIDs, s.ID)
 			s.Status = applesilicon.ServerStatusReinstalling
+			return s, nil
+		}
+	}
+	return nil, errors.New("not found")
+}
+
+func (f *fakeAppleSiliconAPI) RebootServer(req *applesilicon.RebootServerRequest, _ ...scw.RequestOption) (*applesilicon.Server, error) {
+	f.rebootCalls++
+	if err, ok := f.rebootErrors[f.rebootCalls]; ok {
+		return nil, err
+	}
+	for _, s := range f.servers {
+		if s.ID == req.ServerID {
+			f.rebootedIDs = append(f.rebootedIDs, s.ID)
+			s.Status = applesilicon.ServerStatusRebooting
 			return s, nil
 		}
 	}

--- a/infra/helm/tuist/crds/infrastructure.cluster.x-k8s.io_scalewayapplesiliconmachines.yaml
+++ b/infra/helm/tuist/crds/infrastructure.cluster.x-k8s.io_scalewayapplesiliconmachines.yaml
@@ -206,6 +206,28 @@ spec:
             status:
               description: ScalewayAppleSiliconMachineStatus is the observed state of the Machine.
               properties:
+                bootstrapAttempts:
+                  description: |-
+                    BootstrapAttempts counts consecutive bootstrap (Stage 2)
+                    failures on the currently-adopted host. Reset to zero on a
+                    successful bootstrap or whenever the underlying ServerID
+                    changes (mini swapped out). Drives the tiered recovery
+                    escalation in the BootstrapFailed path: at the reboot threshold
+                    the controller asks Scaleway to reboot the host to clear
+                    volatile state (PAM lockouts, sshd throttling, half-open
+                    connections); at the release threshold it returns the host to
+                    the adopt pool so the next reconcile claims a different mini.
+                  format: int32
+                  type: integer
+                bootstrapRebootIssued:
+                  description: |-
+                    BootstrapRebootIssued records that a recovery reboot has
+                    already been triggered for the current host. Prevents
+                    re-rebooting the same host on every retry after the threshold
+                    crossing. Cleared when the underlying ServerID changes (mini
+                    swapped out, e.g., via release-to-pool) or on successful
+                    bootstrap.
+                  type: boolean
                 addresses:
                   description: |-
                     Addresses surfaces the IP and the Scaleway-assigned hostname so


### PR DESCRIPTION
Two related provider-robustness fixes surfaced by a production fleet bring-up incident this week (see [follow-up #5 in the original incident PR](https://github.com/tuist/tuist/pull/10981)).

## (1) `<sealed>` sudo password handling

The Scaleway Apple Silicon API can return the literal placeholder `<sealed>` in both `sudo_password` and `vnc_url` while macOS Tahoe's OS-level seal of the auto-login credential is in effect — observed on a fresh adopt and during reboot windows. The codebase already has a fallback that re-fetches the password from `vnc_url` when the top-level field is empty, but the check was a bare `== \"\"` that accepted `<sealed>` as a non-empty (and therefore \"valid\") password.

Bootstrap then handed `<sealed>` to sudo verbatim, sudo rejected it as `Sorry, try again`, and after a handful of retries `pam_opendirectory` locked the m1 account — blocking the host until a manual reboot.

Treat the marker as missing in both surfaces:
- `scalewayServerToServer` falls through to `vnc_url` when the top-level field is `<sealed>` (with `<sealed>` from `vnc_url`'s embedded password component also rejected).
- The controller's recovery gate also treats `<sealed>` in the staged Secret as missing, so a Secret persisted from a pre-fix reconcile self-heals on the next loop.

## (2) Tiered host recovery on persistent BootstrapFailed

On `bootstrap.Run` error the reconciler previously only requeued after 60s, which meant a host stuck in an unrecoverable state (stale `authorized_keys` from a previous tenant, OS corruption, wedged sshd) got SSH-hammered indefinitely against the same broken server. New tiered recovery via `handleBootstrapFailure`:

- **Tier 1 (`--bootstrap-reboot-after`, default 3)** — the controller asks Scaleway to reboot the host once. Clears volatile state (PAM lockouts, sshd connection throttling, half-open sessions) without paying for the 5-15 min disk reinstall. Gated on `Status.BootstrapRebootIssued` so the reboot fires once per host even across a long retry tail.

- **Tier 2 (`--bootstrap-max-attempts`, default 8)** — the controller returns the host to the adopt pool via `ReleaseToPool`. Scaleway's `ReinstallServer` then wipes the disk and the next reconcile claims a different mini via `AdoptFromPool`. ServerID + counters reset because they describe the now-discarded host.

Each tier degrades gracefully on Scaleway API errors:
- The `RebootServer` 5xx path does **not** consume the one-shot flag, so the next reconcile retries the cheap recovery rather than skipping straight to the expensive reinstall.
- A release-tier API error keeps `Status.ServerID` populated so we never start adopting a new host while the old one is still wedged in our account.

Both thresholds can be set to 0 to disable the corresponding tier (operator escape hatch for fleet-wide disruption).

## What this PR doesn't change

- `ReleaseToPool` already calls `ReinstallServer` (full disk wipe + factory image) — clean-slate guarantee for the next pool consumer is unchanged.
- Tier 1's reboot is purely a recovery escalation, **not** a step in the normal release path. Releasing a working mini at MachineDeployment scale-down still goes straight to the reinstall flow.

I considered making Tier 1's reboot fire on *every* release-to-pool (as a fast clean-state hop before the slow reinstall), but kept it scoped to the recovery path because the reinstall already disk-wipes — a pre-release reboot would just add ~2 min latency to every scale-down without changing what arrives in the pool.

Happy to revisit if you'd rather see the reboot tier integrated into the release path or removed entirely (Tier 2 alone covers the original incident).

## Test plan

- [x] `go build ./...` clean in the provider module
- [x] `go vet ./...` clean
- [x] `go test ./...` — all pre-existing tests still pass
- [x] New unit tests:
  - `TestScalewayServerToServer_FallsBackToVncURLWhenSudoPasswordIsSealed`
  - `TestScalewayServerToServer_RejectsSealedMarkerFromVncURL` (both \"vnc_url is the marker\" and \"vnc_url embeds the marker as password\" cases)
  - `TestClientRebootServer_{SwallowsNotFound,SwallowsTransientState,HappyPathRecordsCall}`
  - `TestHandleBootstrapFailure_IncrementsAttempts`
  - `TestHandleBootstrapFailure_RebootsAtThresholdOnce` (one-shot guard)
  - `TestHandleBootstrapFailure_ReleasesToPoolAtMax`
  - `TestHandleBootstrapFailure_ReleaseAPIErrorKeepsState`
  - `TestHandleBootstrapFailure_RebootAPIErrorDoesNotConsumeOneShot`
  - `TestHandleBootstrapFailure_LegacyCRWithoutPoolPrefixNeverReleases`
  - `TestHandleBootstrapFailure_DisabledThresholdsSkipBothTiers`

CRD update applied to `infra/helm/tuist/crds/infrastructure.cluster.x-k8s.io_scalewayapplesiliconmachines.yaml` so the new status fields land in the chart at deploy time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)