### PR TITLE
fix(cli): infer DerivedData location for inspect build and tests

### DIFF
--- a/cli/Sources/TuistEnvironment/DerivedDataLocation.swift
+++ b/cli/Sources/TuistEnvironment/DerivedDataLocation.swift
@@ -20,18 +20,19 @@ public enum DerivedDataLocation: Equatable, Sendable {
     /// `<workspaceName>` without a hash, since the directory lives next to the workspace.
     case relativeToWorkspace(RelativePath)
 
-    /// Classifies the raw value of `IDECustomDerivedDataLocation` (or `IDEDerivedDataPathOverride`)
-    /// into a location, mirroring how Xcode interprets the preference string.
-    public static func classify(rawLocation: String?) -> DerivedDataLocation {
-        guard let rawLocation, !rawLocation.isEmpty else {
-            return .default
+    /// Builds a location from the raw value of `IDECustomDerivedDataLocation` (or
+    /// `IDEDerivedDataPathOverride`), mirroring how Xcode interprets the preference string:
+    /// an empty value means the default, an absolute path a custom location, and a relative
+    /// path a location resolved against the workspace directory.
+    public init(_ location: String) {
+        if location.isEmpty {
+            self = .default
+        } else if let absolute = try? AbsolutePath(validating: location) {
+            self = .custom(absolute)
+        } else if let relative = try? RelativePath(validating: location) {
+            self = .relativeToWorkspace(relative)
+        } else {
+            self = .default
         }
-        if let absolute = try? AbsolutePath(validating: rawLocation) {
-            return .custom(absolute)
-        }
-        if let relative = try? RelativePath(validating: rawLocation) {
-            return .relativeToWorkspace(relative)
-        }
-        return .default
     }
 }

--- a/cli/Sources/TuistEnvironment/DerivedDataLocation.swift
+++ b/cli/Sources/TuistEnvironment/DerivedDataLocation.swift
@@ -1,0 +1,37 @@
+import Path
+
+/// Describes how Xcode is configured to resolve the DerivedData location, mirroring the
+/// `IDECustomDerivedDataLocation` preference in Xcode > Settings > Locations > Derived Data.
+///
+/// Xcode does not store a separate enum for the Default / Relative / Custom choice. It infers
+/// the mode entirely from the shape of the `IDECustomDerivedDataLocation` string: a missing
+/// value means the shared default, an absolute path means a custom location, and a relative
+/// path is resolved against the workspace directory.
+public enum DerivedDataLocation: Equatable, Sendable {
+    /// Xcode's shared default location (`~/Library/Developer/Xcode/DerivedData`).
+    /// Per-project folders are named `<name>-<hash>`.
+    case `default`
+
+    /// An absolute custom location. Per-project folders are named `<name>-<hash>`, using the
+    /// same hashing as the default location, so a shared directory can host several projects.
+    case custom(AbsolutePath)
+
+    /// A location relative to the workspace directory. Per-project folders are named
+    /// `<workspaceName>` without a hash, since the directory lives next to the workspace.
+    case relativeToWorkspace(RelativePath)
+
+    /// Classifies the raw value of `IDECustomDerivedDataLocation` (or `IDEDerivedDataPathOverride`)
+    /// into a location, mirroring how Xcode interprets the preference string.
+    public static func classify(rawLocation: String?) -> DerivedDataLocation {
+        guard let rawLocation, !rawLocation.isEmpty else {
+            return .default
+        }
+        if let absolute = try? AbsolutePath(validating: rawLocation) {
+            return .custom(absolute)
+        }
+        if let relative = try? RelativePath(validating: rawLocation) {
+            return .relativeToWorkspace(relative)
+        }
+        return .default
+    }
+}

--- a/cli/Sources/TuistEnvironment/Environment.swift
+++ b/cli/Sources/TuistEnvironment/Environment.swift
@@ -88,8 +88,12 @@ public protocol Environmenting: Sendable {
     /// Returns the current architecture of the machine
     func architecture() async throws -> MacArchitecture
 
-    /// Returns the derived data directory
+    /// Returns Xcode's shared default derived data directory (`~/Library/Developer/Xcode/DerivedData`).
     func derivedDataDirectory() async throws -> AbsolutePath
+
+    /// Returns how Xcode is configured to resolve the DerivedData location, inferred from the
+    /// `IDECustomDerivedDataLocation` preference.
+    func derivedDataLocation() async throws -> DerivedDataLocation
 }
 
 private let truthyValues = ["1", "true", "TRUE", "yes", "YES"]
@@ -413,45 +417,35 @@ public struct Environment: Environmenting {
         }
 
         public func derivedDataDirectory() async throws -> AbsolutePath {
+            homeDirectory.appending(try RelativePath(validating: "Library/Developer/Xcode/DerivedData/"))
+        }
+
+        public func derivedDataLocation() async throws -> DerivedDataLocation {
+            let rawLocation = readXcodeDefault("IDEDerivedDataPathOverride")
+                ?? readXcodeDefault("IDECustomDerivedDataLocation")
+            return DerivedDataLocation.classify(rawLocation: rawLocation)
+        }
+
+        private func readXcodeDefault(_ key: String) -> String? {
             let process = Process()
             process.executableURL = URL(fileURLWithPath: "/usr/bin/defaults")
-            process.arguments = ["read", "com.apple.dt.Xcode", "IDEDerivedDataPathOverride"]
+            process.arguments = ["read", "com.apple.dt.Xcode", key]
             let pipe = Pipe()
             process.standardOutput = pipe
             process.standardError = Pipe()
             do {
                 try process.run()
                 process.waitUntilExit()
-                if process.terminationStatus == 0 {
-                    let data = pipe.fileHandleForReading.readDataToEndOfFile()
-                    if let output = String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines),
-                       !output.isEmpty
-                    {
-                        return try AbsolutePath(validating: output)
-                    }
-                }
-            } catch {}
-
-            let customProcess = Process()
-            customProcess.executableURL = URL(fileURLWithPath: "/usr/bin/defaults")
-            customProcess.arguments = ["read", "com.apple.dt.Xcode", "IDECustomDerivedDataLocation"]
-            let customPipe = Pipe()
-            customProcess.standardOutput = customPipe
-            customProcess.standardError = Pipe()
-            do {
-                try customProcess.run()
-                customProcess.waitUntilExit()
-                if customProcess.terminationStatus == 0 {
-                    let data = customPipe.fileHandleForReading.readDataToEndOfFile()
-                    if let output = String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines),
-                       !output.isEmpty
-                    {
-                        return try AbsolutePath(validating: output)
-                    }
-                }
-            } catch {}
-
-            return homeDirectory.appending(try RelativePath(validating: "Library/Developer/Xcode/DerivedData/"))
+                guard process.terminationStatus == 0 else { return nil }
+                let data = pipe.fileHandleForReading.readDataToEndOfFile()
+                guard let output = String(data: data, encoding: .utf8)?
+                    .trimmingCharacters(in: .whitespacesAndNewlines),
+                    !output.isEmpty
+                else { return nil }
+                return output
+            } catch {
+                return nil
+            }
         }
 
     #elseif os(Linux)
@@ -471,6 +465,10 @@ public struct Environment: Environmenting {
         public func derivedDataDirectory() async throws -> AbsolutePath {
             homeDirectory.appending(try RelativePath(validating: "Library/Developer/Xcode/DerivedData/"))
         }
+
+        public func derivedDataLocation() async throws -> DerivedDataLocation {
+            .default
+        }
     #else
         public func architecture() async throws -> MacArchitecture {
             .arm64
@@ -478,6 +476,10 @@ public struct Environment: Environmenting {
 
         public func derivedDataDirectory() async throws -> AbsolutePath {
             homeDirectory.appending(try RelativePath(validating: "Library/Developer/Xcode/DerivedData/"))
+        }
+
+        public func derivedDataLocation() async throws -> DerivedDataLocation {
+            .default
         }
     #endif
 }

--- a/cli/Sources/TuistEnvironment/Environment.swift
+++ b/cli/Sources/TuistEnvironment/Environment.swift
@@ -423,7 +423,7 @@ public struct Environment: Environmenting {
         public func derivedDataLocation() async throws -> DerivedDataLocation {
             let rawLocation = readXcodeDefault("IDEDerivedDataPathOverride")
                 ?? readXcodeDefault("IDECustomDerivedDataLocation")
-            return DerivedDataLocation.classify(rawLocation: rawLocation)
+            return rawLocation.map(DerivedDataLocation.init) ?? .default
         }
 
         private func readXcodeDefault(_ key: String) -> String? {

--- a/cli/Sources/TuistEnvironmentTesting/MockEnvironment.swift
+++ b/cli/Sources/TuistEnvironmentTesting/MockEnvironment.swift
@@ -49,6 +49,11 @@ public final class MockEnvironment: Environmenting, @unchecked Sendable {
         baseDirectory.appending(component: "DerivedData")
     }
 
+    public var derivedDataLocationStub: DerivedDataLocation?
+    public func derivedDataLocation() async throws -> DerivedDataLocation {
+        derivedDataLocationStub ?? .default
+    }
+
     public var stubbedArchitecture: MacArchitecture = .arm64
     public func architecture() async throws -> MacArchitecture {
         stubbedArchitecture

--- a/cli/Sources/TuistXcodeBuildProducts/DerivedDataLocator.swift
+++ b/cli/Sources/TuistXcodeBuildProducts/DerivedDataLocator.swift
@@ -17,22 +17,42 @@ public struct DerivedDataLocator: DerivedDataLocating {
     public func locate(
         for projectPath: AbsolutePath
     ) async throws -> AbsolutePath {
-        let defaultDerivedDataDirectory = try await Environment.current.derivedDataDirectory()
+        let root: AbsolutePath
+        let usesHash: Bool
+        switch try await Environment.current.derivedDataLocation() {
+        case .default:
+            root = try await Environment.current.derivedDataDirectory()
+            usesHash = true
+        case let .custom(path):
+            root = path
+            usesHash = true
+        case let .relativeToWorkspace(relativePath):
+            root = projectPath.parentDirectory.appending(relativePath)
+            usesHash = false
+        }
+
+        // When `inspect` runs as an Xcode build/test post-action, these variables point directly
+        // at the build's derived data and take precedence over the location inferred from Xcode's
+        // preferences.
         if let derivedDataDir = Environment.current.variables["DERIVED_DATA_DIR"] {
             let path = try AbsolutePath(validating: derivedDataDir)
-            if path != defaultDerivedDataDirectory {
+            if path != root {
                 return path
             }
         }
         if let buildDir = Environment.current.variables["BUILD_DIR"],
-           let root = Self.derivedDataRoot(from: buildDir),
-           root != defaultDerivedDataDirectory
+           let buildRoot = Self.derivedDataRoot(from: buildDir),
+           buildRoot != root
         {
-            return root
+            return buildRoot
         }
-        let hash = try XcodeProjectPathHasher.hashString(for: projectPath.pathString)
-        return defaultDerivedDataDirectory
-            .appending(component: "\(projectPath.basenameWithoutExt)-\(hash)")
+
+        if usesHash {
+            let hash = try XcodeProjectPathHasher.hashString(for: projectPath.pathString)
+            return root.appending(component: "\(projectPath.basenameWithoutExt)-\(hash)")
+        } else {
+            return root.appending(component: projectPath.basenameWithoutExt)
+        }
     }
 
     /// Extracts the derived data root from `BUILD_DIR`.

--- a/cli/Tests/TuistXcodeBuildProductsTests/Utils/DerivedDataLocationTests.swift
+++ b/cli/Tests/TuistXcodeBuildProductsTests/Utils/DerivedDataLocationTests.swift
@@ -3,22 +3,18 @@ import Testing
 import TuistEnvironment
 
 struct DerivedDataLocationTests {
-    @Test func classify_returns_default_when_value_is_missing() {
-        #expect(DerivedDataLocation.classify(rawLocation: nil) == .default)
+    @Test func init_returns_default_for_an_empty_value() {
+        #expect(DerivedDataLocation("") == .default)
     }
 
-    @Test func classify_returns_default_when_value_is_empty() {
-        #expect(DerivedDataLocation.classify(rawLocation: "") == .default)
-    }
-
-    @Test func classify_returns_custom_for_an_absolute_path() throws {
-        let result = DerivedDataLocation.classify(rawLocation: "/Users/me/DerivedData")
+    @Test func init_returns_custom_for_an_absolute_path() throws {
+        let result = DerivedDataLocation("/Users/me/DerivedData")
 
         #expect(result == .custom(try AbsolutePath(validating: "/Users/me/DerivedData")))
     }
 
-    @Test func classify_returns_relative_for_a_relative_path() throws {
-        let result = DerivedDataLocation.classify(rawLocation: ".derived-data")
+    @Test func init_returns_relative_for_a_relative_path() throws {
+        let result = DerivedDataLocation(".derived-data")
 
         #expect(result == .relativeToWorkspace(try RelativePath(validating: ".derived-data")))
     }

--- a/cli/Tests/TuistXcodeBuildProductsTests/Utils/DerivedDataLocationTests.swift
+++ b/cli/Tests/TuistXcodeBuildProductsTests/Utils/DerivedDataLocationTests.swift
@@ -1,0 +1,25 @@
+import Path
+import Testing
+import TuistEnvironment
+
+struct DerivedDataLocationTests {
+    @Test func classify_returns_default_when_value_is_missing() {
+        #expect(DerivedDataLocation.classify(rawLocation: nil) == .default)
+    }
+
+    @Test func classify_returns_default_when_value_is_empty() {
+        #expect(DerivedDataLocation.classify(rawLocation: "") == .default)
+    }
+
+    @Test func classify_returns_custom_for_an_absolute_path() throws {
+        let result = DerivedDataLocation.classify(rawLocation: "/Users/me/DerivedData")
+
+        #expect(result == .custom(try AbsolutePath(validating: "/Users/me/DerivedData")))
+    }
+
+    @Test func classify_returns_relative_for_a_relative_path() throws {
+        let result = DerivedDataLocation.classify(rawLocation: ".derived-data")
+
+        #expect(result == .relativeToWorkspace(try RelativePath(validating: ".derived-data")))
+    }
+}

--- a/cli/Tests/TuistXcodeBuildProductsTests/Utils/DerivedDataLocatorTests.swift
+++ b/cli/Tests/TuistXcodeBuildProductsTests/Utils/DerivedDataLocatorTests.swift
@@ -87,4 +87,47 @@ struct DerivedDataLocatorTests {
         #expect(result.parentDirectory == defaultDerivedDataDirectory)
         #expect(result.basename.hasPrefix("App-"))
     }
+
+    @Test(.inTemporaryDirectory, .withMockedEnvironment())
+    func locate_uses_workspace_name_without_hash_for_relative_location() async throws {
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let projectPath = temporaryDirectory.appending(component: "Capivara.xcworkspace")
+
+        let mockedEnvironment = try #require(Environment.mocked)
+        mockedEnvironment.derivedDataLocationStub = try .relativeToWorkspace(RelativePath(validating: ".derived-data"))
+
+        let result = try await subject.locate(for: projectPath)
+
+        #expect(result == temporaryDirectory.appending(components: ".derived-data", "Capivara"))
+    }
+
+    @Test(.inTemporaryDirectory, .withMockedEnvironment())
+    func locate_uses_hash_based_path_for_custom_absolute_location() async throws {
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let projectPath = temporaryDirectory.appending(component: "Capivara.xcworkspace")
+        let customDerivedDataDirectory = temporaryDirectory.appending(component: "CustomDerivedData")
+
+        let mockedEnvironment = try #require(Environment.mocked)
+        mockedEnvironment.derivedDataLocationStub = .custom(customDerivedDataDirectory)
+
+        let result = try await subject.locate(for: projectPath)
+
+        #expect(result.parentDirectory == customDerivedDataDirectory)
+        #expect(result.basename.hasPrefix("Capivara-"))
+    }
+
+    @Test(.inTemporaryDirectory, .withMockedEnvironment())
+    func locate_prefers_DERIVED_DATA_DIR_over_relative_location() async throws {
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let projectPath = temporaryDirectory.appending(component: "Capivara.xcworkspace")
+
+        let mockedEnvironment = try #require(Environment.mocked)
+        mockedEnvironment.derivedDataLocationStub = try .relativeToWorkspace(RelativePath(validating: ".derived-data"))
+        let buildDerivedDataPath = temporaryDirectory.appending(component: "build-derived-data")
+        mockedEnvironment.variables["DERIVED_DATA_DIR"] = buildDerivedDataPath.pathString
+
+        let result = try await subject.locate(for: projectPath)
+
+        #expect(result == buildDerivedDataPath)
+    }
 }


### PR DESCRIPTION
## What

When no `--derived-data-path` is passed, `tuist inspect build` and `tuist inspect tests` now infer the DerivedData location the same way Xcode does, instead of always appending `<name>-<hash>` to the default directory.

## Why

The inference only handled Xcode's default DerivedData location. A custom `IDECustomDerivedDataLocation` (Xcode > Settings > Locations > Derived Data) was not supported:

- A **relative** location (e.g. `.derived-data`) couldn't be validated as an absolute path, so it fell back to `~/Library/Developer/Xcode/DerivedData` and the `Logs` directory was never found.
- A **relative** location uses a different per-project folder than the default: just `<workspaceName>` with **no** hash (the folder sits next to the workspace).

Xcode infers the mode from the shape of the string, with no companion key. The supported rule is now:

| `IDECustomDerivedDataLocation` | Root | Per-project folder |
|---|---|---|
| missing (Default) | `~/Library/Developer/Xcode/DerivedData` | `<name>-<hash>` |
| absolute (Custom) | the value | `<name>-<hash>` |
| relative (Relative) | `<workspace dir>/<value>` | `<workspaceName>` (no hash) |

## How

- New `DerivedDataLocation` enum in `TuistEnvironment` with a pure `classify(rawLocation:)`.
- New `Environment.derivedDataLocation()` seam (reads `IDEDerivedDataPathOverride` / `IDECustomDerivedDataLocation`); `derivedDataDirectory()` now returns only the global default.
- `DerivedDataLocator.locate` resolves root + whether to hash from the mode, keeping `DERIVED_DATA_DIR` / `BUILD_DIR` precedence (set by Xcode during post-actions).

Both `inspect build` and `inspect tests` benefit, since both go through `DerivedDataLocator.locate`.

## Validation

`xcodebuild test ... -only-testing TuistXcodeBuildProductsTests` passes, including new tests for the pure classifier and for the relative/custom/precedence cases. (The one unrelated failure in that target is a pre-existing locale-dependent `AppBundleLoaderTests` assertion comparing a Foundation error string in English.)
