### PR TITLE
Move self-hosted cache guide under Cache docs

### DIFF
--- a/server/lib/tuist/docs/redirects.ex
+++ b/server/lib/tuist/docs/redirects.ex
@@ -124,6 +124,7 @@ defmodule Tuist.Docs.Redirects do
     {:exact, "/guides/features/mcp", "/guides/features/agentic-coding/mcp"},
     {:exact, "/guides/features/agentic-building/mcp", "/guides/features/agentic-coding/mcp"},
     {:exact, "/guides/server/self-host/install", "/guides/server/self-host/control-plane"},
+    {:exact, "/guides/server/self-host/kura", "/guides/features/cache/self-hosting"},
     {:exact, "/guides/environments/continuous-integration", "/guides/integrations/continuous-integration"},
     {:exact, "/guides/environments/automate/continuous-integration", "/guides/integrations/continuous-integration"},
     {:prefix, "/guides/automate/", "/guides/environments/"},

--- a/server/lib/tuist/docs_sidebar.ex
+++ b/server/lib/tuist/docs_sidebar.ex
@@ -379,7 +379,7 @@ defmodule Tuist.Docs.Sidebar do
             label: "Self-hosting",
             items: [
               %Item{label: "Control plane", slug: "/en/guides/server/self-host/control-plane"},
-              %Item{label: "Kura", slug: "/en/guides/server/self-host/kura"},
+              %Item{label: "Cache", slug: "/en/guides/features/cache/self-hosting"},
               %Item{label: "Telemetry", slug: "/en/guides/server/self-host/telemetry"}
             ]
           }

--- a/server/priv/docs/en/guides/features/cache.md
+++ b/server/priv/docs/en/guides/features/cache.md
@@ -9,7 +9,7 @@
 
 Build artifacts are not shared across environments, forcing you to rebuild the same code over and over. Tuist's caching feature shares artifacts remotely so your team and CI get faster builds without rebuilding what has already been built.
 
-Pick the caching solution that matches your build system:
+Learn the cache workflow that matches your project or deployment model:
 
 <HomeCards>
     <HomeCard
@@ -30,4 +30,10 @@ Pick the caching solution that matches your build system:
         details="Share Gradle build cache artifacts remotely. Includes build insights for performance visibility."
         linkText="Set up Gradle cache"
         link="/guides/features/cache/gradle-cache"/>
+    <HomeCard
+        icon="<img src='/images/logo.webp' alt='Tuist' width='32' height='32' />"
+        title="Self-hosting"
+        details="Run cache nodes close to CI, offices, or regional compute and connect them to hosted or self-hosted Tuist."
+        linkText="Deploy self-hosted cache"
+        link="/guides/features/cache/self-hosting"/>
 </HomeCards>

--- a/server/priv/docs/en/guides/features/cache/self-hosting.md
+++ b/server/priv/docs/en/guides/features/cache/self-hosting.md
@@ -1,22 +1,23 @@
 ---
 {
-  "title": "Kura",
-  "titleTemplate": ":title | Self-hosting | Server | Guides | Tuist",
-  "description": "Deploy Kura and connect it to a self-hosted Tuist server."
+  "title": "Self-hosted cache",
+  "titleTemplate": ":title | Cache | Guides | Tuist",
+  "description": "Deploy self-hosted cache nodes and connect them to Tuist."
 }
 ---
 
-# Kura {#kura}
+# Self-hosted cache {#self-hosted-cache}
 
-Kura is Tuist's decentralized cache mesh for build artifacts and cache metadata. It lets you place cache nodes close to the machines that produce and consume build outputs, whether those machines run in CI, developer offices, remote workstations, or regional compute clusters.
+Self-hosted cache nodes let you keep build artifacts and cache metadata close to the machines that produce and consume build outputs. Use them when cache latency matters across CI, developer offices, remote workstations, or regional compute clusters, while keeping endpoint discovery centralized through Tuist.
 
-The goal is low-latency caching everywhere, not only in the one environment where a central cache happens to be nearby. Each Kura node serves reads and writes from local disk, while the mesh replicates artifacts and metadata between peers so other locations can benefit from the same cache over time.
+The goal is low-latency caching everywhere, not only in the one environment where a central cache happens to be nearby. Each cache node serves reads and writes from local disk, while the mesh replicates artifacts and metadata between peers so other locations can benefit from the same cache over time.
 
-## How Kura fits with Tuist {#how-kura-fits-with-tuist}
+> [!NOTE]
+> Tuist's self-hosted cache nodes are powered by [Kura](https://github.com/tuist/tuist/tree/main/kura), Tuist's decentralized cache mesh. Kura is the data plane for cache nodes: it serves cache reads and writes, stores local state on disk, and replicates artifacts and metadata to peer nodes.
 
-The Tuist server tells clients which Kura endpoints to use. This keeps endpoint discovery centralized while allowing the cache itself to stay decentralized and close to the compute that needs it.
+## How self-hosted cache fits with Tuist {#how-self-hosted-cache-fits-with-tuist}
 
-Kura is the data plane. It serves cache reads and writes, stores local state on disk, and replicates artifacts and metadata to peer nodes.
+The Tuist server tells clients which cache endpoints to use. This keeps endpoint discovery centralized while allowing the cache itself to stay decentralized and close to the compute that needs it.
 
 ## Deploy on Kubernetes {#deploy-on-kubernetes}
 

--- a/server/priv/docs/en/guides/server/self-host/control-plane.md
+++ b/server/priv/docs/en/guides/server/self-host/control-plane.md
@@ -17,7 +17,7 @@ We offer a self-hosted version of the Tuist server for organizations that requir
 > [!WARNING]
 > **Legacy cache service**
 >
-> The old self-hosted cache-node technology is deprecated for new installations. Use <.localized_link href="/guides/server/self-host/kura">Kura</.localized_link> for self-hosted cache infrastructure.
+> The old self-hosted cache-node technology is deprecated for new installations. Use the <.localized_link href="/guides/features/cache/self-hosting">self-hosted cache guide</.localized_link> for current self-hosted cache infrastructure.
 >
 > Existing deployments can still reference the legacy source documentation in GitHub's markdown viewer: [cache nodes](https://github.com/tuist/tuist/blob/main/server/priv/docs/en/guides/cache/self-host.md) and [cache architecture](https://github.com/tuist/tuist/blob/main/server/priv/docs/en/guides/cache/architecture.md).
 
@@ -97,16 +97,16 @@ You’ll also need a solution to store files (e.g. framework and library binarie
 > [!TIP]
 > **Optimized Caching**
 >
-> If your goal is primarily to reduce cache latency, you might not need to self-host the whole server. You can deploy Kura close to your CI or developer network and connect it to the hosted Tuist server or your self-hosted server.
+> If your goal is primarily to reduce cache latency, you might not need to self-host the whole server. You can deploy self-hosted cache nodes close to your CI or developer network and connect them to the hosted Tuist server or your self-hosted server.
 >
-> See the <.localized_link href="/guides/server/self-host/kura">Kura self-hosting guide</.localized_link>.
+> See the <.localized_link href="/guides/features/cache/self-hosting">self-hosted cache guide</.localized_link>.
 
 
-### Kura cache nodes {#kura-cache-nodes}
+### Self-hosted cache nodes {#self-hosted-cache-nodes}
 
-To use Kura with a self-hosted Tuist server:
+To use self-hosted cache nodes with a self-hosted Tuist server:
 
-1. Deploy Kura following the <.localized_link href="/guides/server/self-host/kura">Kura self-hosting guide</.localized_link>.
+1. Deploy cache nodes following the <.localized_link href="/guides/features/cache/self-hosting">self-hosted cache guide</.localized_link>.
 2. Set `TUIST_KURA_ENDPOINTS` to a comma-separated list of Kura URLs, or configure `server.kuraEndpointUrls` in the Helm chart.
 
 ## Configuration {#configuration}

--- a/server/test/tuist/docs/redirects_test.exs
+++ b/server/test/tuist/docs/redirects_test.exs
@@ -29,6 +29,11 @@ defmodule Tuist.Docs.RedirectsTest do
                {:ok, "/en/docs/guides/server/self-host/control-plane"}
     end
 
+    test "redirects the old Kura self-hosting route to cache self-hosting" do
+      assert Redirects.resolve("/en/docs/guides/server/self-host/kura") ==
+               {:ok, "/en/docs/guides/features/cache/self-hosting"}
+    end
+
     test "redirects the old translation guide slug to languages" do
       assert Redirects.resolve("/en/docs/contributors/translate") ==
                {:ok, "/en/docs/contributors/languages"}


### PR DESCRIPTION
Resolves N/A

Moves the Kura self-hosting guide out of the Server self-hosting section and into the Cache feature docs as "Self-hosted cache".

This keeps the cache documentation centered on cache concepts first, while explaining that self-hosted cache nodes are powered by Kura and linking to the Kura source in the repository. The old `/guides/server/self-host/kura` route now redirects to the new Cache page, and both the Cache and Server self-hosting sidebars surface the new page.

### How to test locally

- `mix format lib/tuist/docs/redirects.ex lib/tuist/docs_sidebar.ex test/tuist/docs/redirects_test.exs`
- `mix run --no-start -e '...'` to assert the Kura redirect and sidebar entries
- `git diff --check`
- `mix test --no-start test/tuist/docs/redirects_test.exs test/tuist/docs_sidebar_test.exs` could not complete locally because the test database schema is missing the `users` table before the tests run.
