### PR TITLE
fix(server): remove min-width:100vw causing horizontal scroll with classic scrollbars

### DIFF
--- a/server/assets/app/css/layouts.css
+++ b/server/assets/app/css/layouts.css
@@ -4,7 +4,6 @@
 .layout {
   display: flex;
   flex-direction: column;
-  min-width: 100vw;
   min-height: 100vh;
 }
 


### PR DESCRIPTION
## What changed

Removed `min-width: 100vw` from the dashboard's top-level `.layout` element in `server/assets/app/css/layouts.css`.

## Why

When opening the server dashboard in Chrome on macOS with a **regular mouse** (not a trackpad), a spurious horizontal scrollbar appeared.

### Root cause

`100vw` measures the full viewport width **including the vertical scrollbar gutter**:

- **Trackpad** → macOS uses overlay scrollbars (0px wide), so `100vw` equals the usable content area and nothing overflows.
- **Regular mouse** → macOS shows classic scrollbars (~15px wide), so the usable content area becomes `100vw − 15px`, while `.layout` was still forced to the full `100vw` — about 15px wider than the space it occupies. That overflow is the horizontal scrollbar.

`.layout` is used by every dashboard layout (`account`, `project`, `headerbar`, `ops`).

### Why remove rather than swap to `100%`

`.layout` is a block-level `<main>` rendered directly inside `<body>`, so it already fills the available width by default — and that width already excludes the scrollbar (the root `<html>` carries `scrollbar-gutter: stable`). The `min-width` floor was therefore redundant. Swapping to `100%` would also work, but the cleanest fix is to drop the unnecessary declaration entirely.

A viewport unit (`100vw`/`100dvw`/`100svw`) would **not** fix this — none of them subtract the classic scrollbar; the `d`/`s`/`l` variants only differ in how they treat mobile browser chrome.

## Impact

The dashboard no longer shows a horizontal scrollbar on macOS (or any platform with classic, space-occupying scrollbars). No visual change for trackpad/overlay-scrollbar users.

## Validation

Inspected the layout chain (`app.html.heex` → `<body>` → `<main class="layout">`) to confirm `.layout` fills `<body>`'s content width without the `min-width` floor, and that `scrollbar-gutter: stable` already reserves the gutter. The removed declaration was the only `100vw` usage in the app dashboard CSS.

### Before
<img width="1222" height="825" alt="Screenshot 2026-06-01 at 15 47 22" src="https://github.com/user-attachments/assets/f7472b54-370f-4a7f-b6e9-ccee8fa15288" />

### After
<img width="1222" height="825" alt="Screenshot 2026-06-01 at 15 47 37" src="https://github.com/user-attachments/assets/9b5e9a5a-666b-481b-851d-8086acacedf2" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)