### PR TITLE
fix(infra): run vm-image-builder fleet in production only

### DIFF
--- a/infra/helm/tuist/values-managed-canary.yaml
+++ b/infra/helm/tuist/values-managed-canary.yaml
@@ -176,19 +176,18 @@ runnersFleet:
       runnerImage: "ghcr.io/tuist/tuist-runner@sha256:d4824d8b6a8c7b6d1c2e87dda7f4c4b751ef87f03f87a9c409cfa15756fb198c"
       dispatchLabel: "tuist-canary-macos"
 
-# Bare-metal vm-image-builder fleet — bakes the Tart VM images
-# the macosFleet and runnersFleet hosts run. Sized at 1 in canary
-# to mirror staging; canary is a pre-prod gate, not a capacity
-# tier. Shares the `tuist-pool-` host pool with the other two
-# fleets, so adding this fleet costs one more pre-ordered host on
-# top of macosFleet (1) + runnersFleet (1) = 3 hosts of pool
-# demand in canary.
+# Bare-metal vm-image-builder fleet. Disabled in canary: the baked
+# Tart images are global GHCR artifacts, so only the production fleet
+# bakes them. A builder here registers the shared `vm-image-builder`
+# org runner label (the fleets advertise identical labels to the same
+# org, with no per-env scoping), so it would pick up production release
+# jobs, exactly the cross-env bleed we want to avoid.
 buildersFleet:
-  enabled: true
-  replicas: 1
+  enabled: false
+  replicas: 0
   adoptPoolPrefix: "tuist-pool-"
   externalSecrets:
-    enabled: true
+    enabled: false
 
 # Kata Containers + QEMU runtime for the Linux runner microVM pool.
 kataContainers:

--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -279,24 +279,26 @@ runnersFleet:
       dispatchLabel: "tuist-macos"
 
 # Bare-metal vm-image-builder fleet — bakes the Tart VM images the
-# macosFleet and runnersFleet hosts run. Sized at 1 to start so the
-# cluster-managed builder lands alongside the existing hand-
-# bootstrapped `vm-image-builder-01` host (which carries the same
-# `vm-image-builder` runner label, so GitHub's scheduler routes
-# between them). Retire `-01` per the "Migrating from hand-
-# bootstrapped hosts" section of vm-image-builder.md once the
-# cluster-managed builder is comfortably taking jobs; scale up
-# `replicas` here to whatever capacity ends up needed.
+# macosFleet and runnersFleet hosts run. Production is the only env
+# that runs a builder (staging/canary disable theirs to avoid the
+# shared `vm-image-builder` org label routing release jobs cross-env).
+# Sized at 2 so the release's two parallel image bakes (runner image +
+# xcresult processor image) run concurrently instead of serializing on
+# one host. Each builder needs the one-time Local Network access grant
+# (see vm-image-builder.md) before it can reach its Tart guests over
+# SSH. Retire the hand-bootstrapped `vm-image-builder-01` host per the
+# "Migrating from hand-bootstrapped hosts" section of
+# vm-image-builder.md once these cluster-managed builders are
+# comfortably taking jobs.
 #
 # Shares the `tuist-pool-` host pool with macosFleet (2) and
-# runnersFleet (9), so this fleet adds 1 to the pool-demand
+# runnersFleet (9), so this fleet adds 2 to the pool-demand
 # total. The operator's pre-order job for production already
-# tracks the macos + runners side; bump it by 1 ahead of the
-# first `helm upgrade` that flips this fleet's pool-claim path
-# on.
+# tracks the macos + runners side; bump it by 2 ahead of the
+# `helm upgrade` that applies this replica count.
 buildersFleet:
   enabled: true
-  replicas: 1
+  replicas: 2
   adoptPoolPrefix: "tuist-pool-"
   externalSecrets:
     enabled: true

--- a/infra/helm/tuist/values-managed-staging.yaml
+++ b/infra/helm/tuist/values-managed-staging.yaml
@@ -286,22 +286,18 @@ runnersFleet:
         cpuMilli: 8000
         memoryMB: 14336
 
-# Bare-metal vm-image-builder fleet — bakes the Tart VM images that
-# the macosFleet and runnersFleet hosts run. Shares the
-# `tuist-pool-` host pool with the other two fleets; CAPI claims
-# the next available `tuist-pool-*` Mac mini, bootstraps it
-# identically to the other fleets (tart-kubelet + node_exporter +
-# Tailscale), and then layers on a GitHub Actions self-hosted
-# runner LaunchAgent that picks up image-bake workflow jobs from
-# the tuist org. The runner agent's registration token is minted
-# on every bootstrap by the CAPI reconciler from the
-# `BUILDERS_FLEET_GITHUB_APP` 1P item synced via ESO.
+# Bare-metal vm-image-builder fleet. Disabled in staging: the baked
+# Tart images are global GHCR artifacts, so only the production fleet
+# bakes them. A builder here registers the shared `vm-image-builder`
+# org runner label (the fleets advertise identical labels to the same
+# org, with no per-env scoping), so it would pick up production release
+# jobs, exactly the cross-env bleed we want to avoid.
 buildersFleet:
-  enabled: true
-  replicas: 1
+  enabled: false
+  replicas: 0
   adoptPoolPrefix: "tuist-pool-"
   externalSecrets:
-    enabled: true
+    enabled: false
 
 # Kata Containers + Firecracker runtime for Linux bare-metal nodes.
 # The `kataContainers` block above defaults to disabled; staging

--- a/infra/vm-image-builder.md
+++ b/infra/vm-image-builder.md
@@ -9,6 +9,26 @@ scale by editing the `buildersFleet.replicas` chart value or running
 `kubectl scale machinedeployment <release>-builders-fleet
 --replicas=N`.
 
+## Which environments run a builder
+
+Production only. The baked Tart images are global GHCR artifacts, so
+a single fleet bakes them for every environment. More to the point,
+every builder registers the same `vm-image-builder` label set to the
+same `tuist` org with no per-env scoping (see the
+[`runs-on:` selector](#workflow-runs-on-selector) section), so a
+builder running in staging or canary would pick up production
+image-release jobs indiscriminately, including pushing production
+image tags from a non-prod host. Staging and canary therefore pin
+`buildersFleet.enabled: false`; only `values-managed-production.yaml`
+runs the fleet, sized at 2 so the release's two parallel bakes (runner
+image + xcresult-processor image) run concurrently instead of
+serializing on one host.
+
+The GitHub App and the setup steps below are still written per-env
+because the App is a single shared identity any env could borrow for a
+throwaway builder in a pinch. In steady state, apply the enablement
+steps to production alone.
+
 ## Architecture
 
 Builder hosts are regular Kubernetes Nodes registered by tart-kubelet,
@@ -71,11 +91,14 @@ bootstrap is what makes the grants stable across re-runs.
    - **Install App** → select tuist → install. The URL becomes
      `…/installations/<installation-id>`. Note the installation ID.
 
-2. **Stash the App credentials in 1Password**, one item per env
-   vault (`tuist-k8s-staging`, `tuist-k8s-canary`,
-   `tuist-k8s-production`). The `ClusterSecretStore "onepassword"`
-   is pre-scoped to the matching vault per env, so the same item
-   name works across envs. Each item has three fields:
+2. **Stash the App credentials in 1Password.** Production is the
+   only env that runs a builder (see
+   [Which environments run a builder](#which-environments-run-a-builder)),
+   so the item only needs to live in the `tuist-k8s-production`
+   vault. The `ClusterSecretStore "onepassword"` is pre-scoped to
+   the matching vault per env, so the same item name works in the
+   `tuist-k8s-staging` / `tuist-k8s-canary` vaults too if you ever
+   stand up a throwaway non-prod builder. Each item has three fields:
 
    ```
    BUILDERS_FLEET_GITHUB_APP
@@ -84,11 +107,11 @@ bootstrap is what makes the grants stable across re-runs.
      private-key      = <contents of the .pem file>
    ```
 
-   Same triple in all three envs — the App is one shared identity.
-   No expiry to track, no rotation on scale-up; the reconciler
-   mints a fresh ~1h runner-registration token from these on every
-   builder-host bootstrap via the GitHub App JWT → installation
-   token → registration token flow.
+   The App is one shared identity, so the same triple works in any
+   env vault that needs it. No expiry to track, no rotation on
+   scale-up; the reconciler mints a fresh ~1h runner-registration
+   token from these on every builder-host bootstrap via the GitHub
+   App JWT -> installation token -> registration token flow.
 
 3. **Pre-order Mac minis on Scaleway** with names prefixed
    `tuist-pool-`. Same pre-ordered pool the macosFleet and
@@ -98,10 +121,12 @@ bootstrap is what makes the grants stable across re-runs.
    speculative auto-ordering expensive, so the operator does this
    ahead of any scale-up.
 
-4. **Enable the fleet** in the env's values file:
+4. **Enable the fleet** in production's values file (staging and
+   canary keep `enabled: false`, per
+   [Which environments run a builder](#which-environments-run-a-builder)):
 
    ```yaml
-   # infra/helm/tuist/values-managed-<env>.yaml
+   # infra/helm/tuist/values-managed-production.yaml
    buildersFleet:
      enabled: true
      replicas: 2


### PR DESCRIPTION
## What changed

- Disable `buildersFleet` in `values-managed-staging.yaml` and `values-managed-canary.yaml` (`enabled: false`, `replicas: 0`).
- Scale `buildersFleet` in `values-managed-production.yaml` from `replicas: 1` to `replicas: 2`.
- Update the operator runbook `infra/vm-image-builder.md`: new "Which environments run a builder" section, production-scoped 1Password credential stashing (step 2), and a production-only enablement step (step 4).

## Why

The vm-image-builder fleets in staging, canary, and production all register the **same** `vm-image-builder` runner label to the **same** `tuist` GitHub org, with no per-environment scoping. GitHub's org-level self-hosted runner pool is flat and label-keyed, so it routes production image-release jobs onto whichever builder happens to be free, regardless of environment.

### Root cause of the failing release

A production image bake was scheduled onto a builder Mac mini living in the **staging** Scaleway project. That host:

1. Lacked the one-time macOS Tahoe **Local Network access** TCC grant, so Packer could not open SSH to its Tart guest and timed out (`Waiting for SSH to become available...`).
2. Should never have been baking or pushing **production** image tags at all (supply-chain concern: a non-prod host producing prod artifacts).

Because the baked Tart images are global GHCR artifacts, a single fleet serves every environment. There is no reason for staging or canary to run a builder; doing so only creates the cross-env bleed above.

## Why 2 replicas in production

The release bakes two images in parallel (runner image + xcresult-processor image). With a single builder they serialize on one host. Two replicas let both bakes run concurrently. This adds 2 to the `tuist-pool-` host-pool demand in production (alongside macosFleet=2 and runnersFleet=9); the operator's pre-order job should be bumped by 2 before the `helm upgrade` that applies this count.

## Reviewer notes / operational follow-ups

- Deploy the chart to staging + canary (to tear down their builders) and production (to scale to 2).
- Deregister any now-orphaned GitHub org runners for the disabled non-prod builders (`gh api` cleanup snippet is in the runbook's Scaling section).
- Ensure production has 2 pre-ordered `tuist-pool-*` hosts available before the scale-up.
- Grant Local Network access on both production builders (one-time per host; see runbook).
- Unrelated and still open: a production xcresult push failed with `Error: The file "nvram.bin" doesn't exist.` during `tart push` — separate from the routing/TCC issue and not addressed here.

## Validation

- `helm template` + `helm lint` against all three env value files: staging/canary render zero builders-fleet resources, production renders the fleet at `replicas: 2`. Lint clean.