### PR TITLE
fix(infra): shrink CNPG cluster PVC sizes to match real data footprint

### DIFF
--- a/infra/helm/tuist/values-managed-canary.yaml
+++ b/infra/helm/tuist/values-managed-canary.yaml
@@ -72,16 +72,18 @@ objectStorage:
       default: tuist-can-storage
 
 # CloudNativePG cluster — canary shape. 3 instances (primary + 2 sync
-# replicas), 30Gi per instance. The live Supabase canary DB sits at
-# ~2 GiB, so 30Gi is ~15× of actual; the Hetzner CSI storage class has
-# `allowVolumeExpansion: true`, so we grow these in place if the
-# footprint ever climbs. Backups land in the `tuist-can-pg-backups`
-# Tigris bucket.
+# replicas), 10Gi per instance. Each instance is a streaming replica
+# holding the whole DB, so the size is per-replica capacity, not a
+# pool to split across them. The live Supabase canary sits at ~2 GiB
+# on an 8 GB provisioned disk, so 10Gi tracks that with a little
+# headroom; the Hetzner CSI storage class has
+# `allowVolumeExpansion: true` for in-place growth if it ever climbs.
+# Backups land in the `tuist-can-pg-backups` Tigris bucket.
 postgresql:
   cnpg:
     instances: 3
     storage:
-      size: "30Gi"
+      size: "10Gi"
     resources:
       requests:
         cpu: "1000m"

--- a/infra/helm/tuist/values-managed-canary.yaml
+++ b/infra/helm/tuist/values-managed-canary.yaml
@@ -72,13 +72,16 @@ objectStorage:
       default: tuist-can-storage
 
 # CloudNativePG cluster — canary shape. 3 instances (primary + 2 sync
-# replicas), 250Gi storage. Backups land in the `tuist-can-pg-backups`
+# replicas), 30Gi per instance. The live Supabase canary DB sits at
+# ~2 GiB, so 30Gi is ~15× of actual; the Hetzner CSI storage class has
+# `allowVolumeExpansion: true`, so we grow these in place if the
+# footprint ever climbs. Backups land in the `tuist-can-pg-backups`
 # Tigris bucket.
 postgresql:
   cnpg:
     instances: 3
     storage:
-      size: "250Gi"
+      size: "30Gi"
     resources:
       requests:
         cpu: "1000m"

--- a/infra/helm/tuist/values-managed-canary.yaml
+++ b/infra/helm/tuist/values-managed-canary.yaml
@@ -74,11 +74,9 @@ objectStorage:
 # CloudNativePG cluster — canary shape. 3 instances (primary + 2 sync
 # replicas), 10Gi per instance. Each instance is a streaming replica
 # holding the whole DB, so the size is per-replica capacity, not a
-# pool to split across them. The live Supabase canary sits at ~2 GiB
-# on an 8 GB provisioned disk, so 10Gi tracks that with a little
-# headroom; the Hetzner CSI storage class has
-# `allowVolumeExpansion: true` for in-place growth if it ever climbs.
-# Backups land in the `tuist-can-pg-backups` Tigris bucket.
+# pool to split across them. The Hetzner CSI storage class has
+# `allowVolumeExpansion: true` for in-place growth if the footprint
+# climbs. Backups land in the `tuist-can-pg-backups` Tigris bucket.
 postgresql:
   cnpg:
     instances: 3

--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -121,11 +121,9 @@ kuraController:
 # CloudNativePG cluster — production shape. 3 instances (primary + 2
 # sync replicas), 100Gi per instance. Each instance is a streaming
 # replica holding the whole DB, so the size is per-replica capacity,
-# not a pool to split across them. The live Supabase production sits
-# at ~22 GiB (cache_events + oban_jobs dominate), so 100Gi tracks that
-# with ~5× headroom for steady growth; the Hetzner CSI storage class
-# has `allowVolumeExpansion: true`, so we grow in place if the
-# footprint climbs faster than that. Backups land in the
+# not a pool to split across them. The Hetzner CSI storage class has
+# `allowVolumeExpansion: true`, so we grow in place if the footprint
+# climbs faster than expected. Backups land in the
 # `tuist-prod-pg-backups` Tigris bucket.
 postgresql:
   cnpg:

--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -119,11 +119,13 @@ kuraController:
       item: kura-introspection-oauth-client
 
 # CloudNativePG cluster — production shape. 3 instances (primary + 2
-# sync replicas), 100Gi per instance. The live Supabase production DB
-# sits at ~22 GiB (cache_events + oban_jobs dominate), so 100Gi is
-# ~5× of actual and leaves room for steady growth; the Hetzner CSI
-# storage class has `allowVolumeExpansion: true`, so we grow these in
-# place if the footprint climbs faster than that. Backups land in the
+# sync replicas), 100Gi per instance. Each instance is a streaming
+# replica holding the whole DB, so the size is per-replica capacity,
+# not a pool to split across them. The live Supabase production sits
+# at ~22 GiB (cache_events + oban_jobs dominate), so 100Gi tracks that
+# with ~5× headroom for steady growth; the Hetzner CSI storage class
+# has `allowVolumeExpansion: true`, so we grow in place if the
+# footprint climbs faster than that. Backups land in the
 # `tuist-prod-pg-backups` Tigris bucket.
 postgresql:
   cnpg:

--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -119,13 +119,17 @@ kuraController:
       item: kura-introspection-oauth-client
 
 # CloudNativePG cluster — production shape. 3 instances (primary + 2
-# sync replicas), 250Gi storage. Backups land in the
+# sync replicas), 100Gi per instance. The live Supabase production DB
+# sits at ~22 GiB (cache_events + oban_jobs dominate), so 100Gi is
+# ~5× of actual and leaves room for steady growth; the Hetzner CSI
+# storage class has `allowVolumeExpansion: true`, so we grow these in
+# place if the footprint climbs faster than that. Backups land in the
 # `tuist-prod-pg-backups` Tigris bucket.
 postgresql:
   cnpg:
     instances: 3
     storage:
-      size: "250Gi"
+      size: "100Gi"
     resources:
       requests:
         cpu: "2000m"

--- a/infra/helm/tuist/values-managed-staging.yaml
+++ b/infra/helm/tuist/values-managed-staging.yaml
@@ -89,8 +89,12 @@ objectStorage:
       default: tuist-stag-storage
 
 # CloudNativePG cluster — staging shape. 2 instances (primary + 1 sync
-# replica), 100Gi storage. WAL archive + daily base backups land in the
-# `tuist-stag-pg-backups` Tigris bucket; barman writes a directory
+# replica), 30Gi per instance. The live Supabase staging DB is tiny
+# (similar shape to canary); 30Gi is well over actual. The existing
+# staging volumes are already 100Gi on disk — Hetzner CSI doesn't
+# shrink in place — so this value only takes effect on a future
+# re-provision of the cluster. WAL archive + daily base backups land in
+# the `tuist-stag-pg-backups` Tigris bucket; barman writes a directory
 # per cluster name under `destinationPath`.
 #
 # Memory request kept low (1Gi vs the 2Gi default in values.yaml) because
@@ -104,7 +108,7 @@ postgresql:
   cnpg:
     instances: 2
     storage:
-      size: "100Gi"
+      size: "30Gi"
     resources:
       requests:
         cpu: "500m"

--- a/infra/helm/tuist/values-managed-staging.yaml
+++ b/infra/helm/tuist/values-managed-staging.yaml
@@ -91,13 +91,12 @@ objectStorage:
 # CloudNativePG cluster — staging shape. 2 instances (primary + 1 sync
 # replica), 10Gi per instance. Each instance is a streaming replica
 # holding the whole DB, so the size is per-replica capacity, not a
-# pool to split across them; the live Supabase staging sits at <2 GiB
-# on an 8 GB provisioned disk, so 10Gi tracks that with a little
-# headroom. The existing staging volumes are already 100Gi on disk —
-# Hetzner CSI doesn't shrink in place — so this value only takes
-# effect on a future re-provision of the cluster. WAL archive + daily
-# base backups land in the `tuist-stag-pg-backups` Tigris bucket;
-# barman writes a directory per cluster name under `destinationPath`.
+# pool to split across them. The existing staging volumes are already
+# 100Gi on disk — Hetzner CSI doesn't shrink in place — so this value
+# only takes effect on a future re-provision of the cluster. WAL
+# archive + daily base backups land in the `tuist-stag-pg-backups`
+# Tigris bucket; barman writes a directory per cluster name under
+# `destinationPath`.
 #
 # Memory request kept low (1Gi vs the 2Gi default in values.yaml) because
 # the cpx22 staging workers only have ~2.5Gi allocatable each after

--- a/infra/helm/tuist/values-managed-staging.yaml
+++ b/infra/helm/tuist/values-managed-staging.yaml
@@ -89,13 +89,15 @@ objectStorage:
       default: tuist-stag-storage
 
 # CloudNativePG cluster — staging shape. 2 instances (primary + 1 sync
-# replica), 30Gi per instance. The live Supabase staging DB is tiny
-# (similar shape to canary); 30Gi is well over actual. The existing
-# staging volumes are already 100Gi on disk — Hetzner CSI doesn't
-# shrink in place — so this value only takes effect on a future
-# re-provision of the cluster. WAL archive + daily base backups land in
-# the `tuist-stag-pg-backups` Tigris bucket; barman writes a directory
-# per cluster name under `destinationPath`.
+# replica), 10Gi per instance. Each instance is a streaming replica
+# holding the whole DB, so the size is per-replica capacity, not a
+# pool to split across them; the live Supabase staging sits at <2 GiB
+# on an 8 GB provisioned disk, so 10Gi tracks that with a little
+# headroom. The existing staging volumes are already 100Gi on disk —
+# Hetzner CSI doesn't shrink in place — so this value only takes
+# effect on a future re-provision of the cluster. WAL archive + daily
+# base backups land in the `tuist-stag-pg-backups` Tigris bucket;
+# barman writes a directory per cluster name under `destinationPath`.
 #
 # Memory request kept low (1Gi vs the 2Gi default in values.yaml) because
 # the cpx22 staging workers only have ~2.5Gi allocatable each after
@@ -108,7 +110,7 @@ postgresql:
   cnpg:
     instances: 2
     storage:
-      size: "30Gi"
+      size: "10Gi"
     resources:
       requests:
         cpu: "500m"


### PR DESCRIPTION
## Why

The CNPG cluster sizing chosen in #10942 (canary/production 3×250 GiB, staging 2×100 GiB) was an over-estimate. With the Hetzner Cloud project's 10 TB volume quota already exhausted, the canary deploy of the merged PR hangs on `ProvisioningFailed: volumes size limit exceeded` and blocks the production-deployment cascade.

## How the size knob actually works

Each CNPG instance is a streaming replica that holds the **whole DB**, so `postgresql.cnpg.storage.size` is **per-replica capacity** (the DB has to fit inside each one), not a pool to split across them. The instance count multiplies only the total Hetzner consumption, not the usable space.

## Live footprints

| Env | Supabase provisioned | Space used |
|---|---|---|
| production | 202 GB | ~22 GiB (`cache_events` + `oban_jobs` dominate) |
| canary | 8 GB | <2 GiB |
| staging | 8 GB | <2 GiB |

## What changed

| Env | Before (per-replica) | After (per-replica) | Replicas | Hetzner total |
|---|---|---|---|---|
| staging | 100 GiB | **10 GiB** | 2 | 20 GiB |
| canary | 250 GiB | **10 GiB** | 3 | 30 GiB |
| production | 250 GiB | **100 GiB** | 3 | 300 GiB |
| **CNPG total demand** | ~1.7 TiB | **~350 GiB** | | |

Hetzner CSI's storage class has `allowVolumeExpansion: true`, so any of these can be grown in place later without recreating the cluster.

## Notes

- **Staging is forward-looking.** Hetzner CSI doesn't shrink PVCs in place — the existing staging volumes stay at 100 GiB until the cluster is recreated. The change keeps the source of truth honest.
- **Hetzner quota still needs a bump.** Even at the smaller sizes, the 10 TB project quota is fully consumed by existing workloads, so the ~350 GiB of new CNPG demand still doesn't fit. A separate quota-raise request to Hetzner is in flight.

## Validation

```bash
for env in staging canary production; do
  helm template tuist infra/helm/tuist \
    --namespace tuist-$env \
    -f infra/helm/tuist/values-managed-common.yaml \
    -f infra/helm/tuist/values-managed-$env.yaml \
    --set server.image.tag=test --set kuraController.image.tag=test \
    --set macosFleet.image.tag=test --set runnersController.image.tag=test \
    --set xcresultProcessor.image.tag=test >/dev/null && echo "$env OK"
done
```

Renders cleanly for all three envs with the new sizes (`storage.size: 10Gi` for staging/canary, `100Gi` for production).

🤖 Generated with [Claude Code](https://claude.com/claude-code)