### PR TITLE
fix(infra): anchor runner-image cliff tag_pattern so it ignores linux-runner-image tags

### DIFF
--- a/infra/linux-runner-image/cliff.toml
+++ b/infra/linux-runner-image/cliff.toml
@@ -80,7 +80,7 @@ commit_parsers = [
 ]
 protect_breaking_commits = false
 filter_commits = true
-tag_pattern = "linux-runner-image@[0-9].*"
+tag_pattern = "^linux-runner-image@[0-9].*"
 skip_tags = "beta|alpha"
 ignore_tags = "rc"
 topo_order = false

--- a/infra/runner-image/cliff.toml
+++ b/infra/runner-image/cliff.toml
@@ -85,7 +85,9 @@ commit_parsers = [
 ]
 protect_breaking_commits = false
 filter_commits = true
-tag_pattern = "runner-image@[0-9].*"
+# Anchored with `^` so it doesn't also match `linux-runner-image@`
+# tags, whose names contain `runner-image@` as a substring.
+tag_pattern = "^runner-image@[0-9].*"
 skip_tags = "beta|alpha"
 ignore_tags = "rc"
 topo_order = false


### PR DESCRIPTION
## What changed

Anchored the git-cliff `tag_pattern` in `infra/runner-image/cliff.toml` (and the symmetric `infra/linux-runner-image/cliff.toml`) with a leading `^`:

- `runner-image@[0-9].*` → `^runner-image@[0-9].*`
- `linux-runner-image@[0-9].*` → `^linux-runner-image@[0-9].*`

## Why

The `Release runner image` job failed at the `Push image to GHCR + resolve digest` step:

```
failed to parse remote name: mismatched input '@' expecting {<EOF>, '.', '-', '_', DIGIT, LETTER} (character 46)
```

`tart push` was handed `ghcr.io/tuist/tuist-runner:linux-runner-image@0.2.0` — an image ref with a stray `@`.

## Root cause

`mise/tasks/release/check.sh` derives each component's next version with `git cliff --bumped-version`, which reads the latest tag matching the config's `tag_pattern` and bumps it. The runner-image pattern `runner-image@[0-9].*` was **unanchored**, so it also matched `linux-runner-image@…` tags (their names contain `runner-image@` as a substring). cliff resolved the version against the wrong tag family and emitted `linux-runner-image@0.2.0` as the version *number*, which the workflow interpolated straight into the image tag.

Reproduced locally against the pushed tags:

```
# before
$ git cliff --config infra/runner-image/cliff.toml --bumped-version -- runner-image@0.1.5..HEAD
linux-runner-image@0.2.0

# after
runner-image@0.2.0
```

The full `release:check` output now reports `runner-image@0.2.0 (number: 0.2.0)`, so the pushed ref becomes the valid `ghcr.io/tuist/tuist-runner:0.2.0`.

## Why this fix

Anchoring with `^` is the minimal, targeted fix — it constrains the match to the component's own tag family without touching the version-bump logic. `runner-image@` ⊂ `linux-runner-image@` was the only such substring collision among all release components, so no other cliff config needed changing; the linux config is anchored too purely to keep the pair symmetric.

## Validation

- Reproduced the malformed `linux-runner-image@0.2.0` output with the old config and confirmed `runner-image@0.2.0` with the new one, against the real pushed tags.
- Ran `mise/tasks/release/check.sh runner-image linux-runner-image` end-to-end: runner-image → `0.2.0` (release? true), linux-runner-image → `0.1.1` (release? false), matching the previous run's release decisions.
- Audited every component's `tag_prefix`/`tag_pattern`; `runner-image@`/`linux-runner-image@` was the only substring collision.

The release workflow runs on push to `main` and the failed run created no `runner-image@0.2.0` tag, so merging this re-detects the pending runner-image release and retries it correctly.