### PR TITLE
fix(infra): match CNPG instances to general-worker pool size per env

### DIFF
--- a/infra/helm/tuist/values-managed-canary.yaml
+++ b/infra/helm/tuist/values-managed-canary.yaml
@@ -71,15 +71,21 @@ objectStorage:
     buckets:
       default: tuist-can-storage
 
-# CloudNativePG cluster — canary shape. 3 instances (primary + 2 sync
-# replicas), 10Gi per instance. Each instance is a streaming replica
-# holding the whole DB, so the size is per-replica capacity, not a
-# pool to split across them. The Hetzner CSI storage class has
-# `allowVolumeExpansion: true` for in-place growth if the footprint
-# climbs. Backups land in the `tuist-can-pg-backups` Tigris bucket.
+# CloudNativePG cluster — canary shape. 2 instances (primary + 1 sync
+# replica), 10Gi per instance. Matches the cluster's general-purpose
+# hcloud-worker pool (md-0, replicas: 2) — hard pod anti-affinity
+# requires one CNPG instance per host, so a 3-instance cluster would
+# leave the third pod permanently Pending until md-0 was scaled up.
+# Canary is a soak environment, not an HA-shape one; production keeps
+# the 3-instance design on its 3-worker pool. Each instance is a
+# streaming replica holding the whole DB, so the size is per-replica
+# capacity, not a pool to split across them. The Hetzner CSI storage
+# class has `allowVolumeExpansion: true` for in-place growth if the
+# footprint climbs. Backups land in the `tuist-can-pg-backups` Tigris
+# bucket.
 postgresql:
   cnpg:
-    instances: 3
+    instances: 2
     storage:
       size: "10Gi"
     resources:

--- a/infra/k8s/clusters/cluster-production.yaml
+++ b/infra/k8s/clusters/cluster-production.yaml
@@ -48,10 +48,15 @@ spec:
         value: production
     workers:
       machineDeployments:
-        # General-purpose pool: Phoenix server, redis, system DaemonSets.
+        # General-purpose pool: Phoenix server, redis, system DaemonSets,
+        # plus the 3-instance CloudNativePG cluster — its hard pod
+        # anti-affinity (`topologyKey: kubernetes.io/hostname,
+        # podAntiAffinityType: required`) needs one CNPG instance per
+        # host, so the pool size has to match the configured instance
+        # count to avoid leaving a CNPG pod permanently Pending.
         - class: hcloud-worker
           name: md-0
-          replicas: 2
+          replicas: 3
           failureDomain: fsn1
           metadata:
             labels:


### PR DESCRIPTION
## Why

Follow-up to #11020 (right-sizing) and #10942 (introducing CNPG): the canary deploy of the cascade is currently stuck on a third CNPG pod that can never schedule.

The merged CNPG config has `instances: 3` on both canary and production, but the general-purpose hcloud-worker pool (`md-0`) is sized at `replicas: 2` on both. With hard pod anti-affinity (`topologyKey: kubernetes.io/hostname`, `podAntiAffinityType: required`) the third CNPG pod has nowhere to land — the other 5 nodes in the cluster are tainted (control plane, CAPI controllers, Kura pool, mac mini), so the deploy hangs forever:

```
FailedScheduling  pod/tuist-tuist-pg-3-join-…
  0/7 nodes are available:
    2 Insufficient memory
    5 node(s) had untolerated taint(s)
```

## What changed

Reconcile the design intent vs the actual pool per env:

- **Canary**: drop CNPG to `instances: 2` (matches its 2-worker pool). Canary is a soak environment, not an HA-shape one; two instances are the same shape as staging and let the deploy unblock without scaling infra.
- **Production**: keep `instances: 3` and bump `cluster-production.yaml` `md-0` to `replicas: 3` so production actually has three distinct hosts for the synchronous `ANY 1` quorum to land on. Preserves the original HA design.

| Env | CNPG instances | md-0 replicas | Notes |
|---|---|---|---|
| staging | 2 | 2 | Unchanged |
| canary | **2** (was 3) | 2 | Matches md-0; same shape as staging |
| production | 3 | **3** (was 2) | Preserves HA; one extra cpx32 node (~€14/mo) |

## Validation

\`\`\`bash
for env in staging canary production; do
  helm template tuist infra/helm/tuist --namespace tuist-\$env \\
    -f infra/helm/tuist/values-managed-common.yaml \\
    -f infra/helm/tuist/values-managed-\$env.yaml \\
    --set server.image.tag=test --set kuraController.image.tag=test \\
    --set macosFleet.image.tag=test --set runnersController.image.tag=test \\
    --set xcresultProcessor.image.tag=test >/dev/null && echo "\$env OK"
done
\`\`\`

Renders cleanly with `instances: 2` on staging+canary and `instances: 3` on production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)