### PR TITLE
chore(cli): bump Command to 0.14.8

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "6509c5128720e5500134753128a176cdd86aad821edf5a7082044e263f85cac0",
+  "originHash" : "e1aa130707485ee4ef299ccc5cdba5c2eaa633efbeb8778be57b51cb457c2b1a",
   "pins" : [
     {
       "identity" : "1024jp.gzipswift",
@@ -94,7 +94,7 @@
       "kind" : "registry",
       "location" : "",
       "state" : {
-        "version" : "1.12.0"
+        "version" : "1.13.1"
       }
     },
     {
@@ -591,7 +591,7 @@
       "kind" : "registry",
       "location" : "",
       "state" : {
-        "version" : "0.14.5"
+        "version" : "0.14.8"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -1739,7 +1739,7 @@ let package = Package(
         .package(id: "tuist.Path", .upToNextMajor(from: "0.3.8")),
         .package(id: "p-x9.MachOKit", .upToNextMajor(from: "0.46.1")),
         .package(id: "tuist.FileSystem", .upToNextMajor(from: "0.17.3")),
-        .package(id: "tuist.Command", .upToNextMajor(from: "0.14.5")),
+        .package(id: "tuist.Command", .upToNextMajor(from: "0.14.8")),
         .package(id: "apple.swift-crypto", from: "3.0.0"),
         .package(id: "crspybits.swift-log-file", .upToNextMajor(from: "0.1.0")),
         .package(id: "tuist.Noora", from: "0.55.0"),


### PR DESCRIPTION
## What changed

Bumps the `Command` dependency from 0.14.5 to **0.14.8**, pulling in tuist/Command#272. Command 0.14.8 raises its `swift-log` floor to 1.13.1, hence the accompanying `Package.resolved` change.

## Why

`tuist graph` (and other commands) crash/abort on CI when the process working directory can't be resolved by `getcwd`:

```
Couldn't resolve the current working directory: FileManager returned an empty path (getcwd likely failed).
```

or, for bare-name executables:

```
*** -[NSConcreteTask setCurrentDirectoryURL:]: non-file URL argument
Command.CommandRunner.lookupExecutable(firstArgument:)
```

A consumer's version bisection isolated the regression to **tuist 4.192.1**, which bumped `Command` 0.14.1 → 0.14.4. Command 0.14.4 (#249) replaced the blocking `waitUntilExit()` with an async continuation to avoid thread starvation; that unserialized subprocess launches, and under the new concurrency Foundation's per-launch working-directory handling on macOS races so `getcwd` transiently returns an empty string — even though the working directory is valid. `CommandRunner` assumed `getcwd` always succeeds and fed the empty result straight into `Process`, producing the throw/crash.

tuist/Command#272 fixes this by not requiring `getcwd` to succeed: it inherits the process working directory when `getcwd` is empty, and drops the `getcwd` read in the executable lookup (which resolves via `PATH`). This bump brings that fix into Tuist.

## Validation

- `swift package resolve --replace-scm-with-registry` and `swift build --product tuist` succeed with 0.14.8.
- Fix-level validation lives in tuist/Command#272 (deterministic repro of the `NSTask` crash before/after, plus an e2e through the Tuist binary on `examples/xcode/generated_app_with_alamofire`).
