### PR TITLE
fix(server): restore cache response signatures

### DIFF
--- a/server/lib/tuist_web/controllers/api/cache_controller.ex
+++ b/server/lib/tuist_web/controllers/api/cache_controller.ex
@@ -35,6 +35,8 @@ defmodule TuistWeb.API.CacheController do
 
   plug TuistWeb.API.Authorization.BillingPlug when action not in [:access, :endpoints]
 
+  plug :sign
+
   tags(["Cache"])
 
   operation(:endpoints,
@@ -737,6 +739,18 @@ defmodule TuistWeb.API.CacheController do
       "#{String.downcase(project_slug)}/#{hash}/#{name}"
     else
       "#{String.downcase(project_slug)}/#{cache_category}/#{hash}/#{name}"
+    end
+  end
+
+  defp sign(%{query_params: %{"hash" => hash}} = conn, _opts), do: sign_conn(conn, hash)
+  defp sign(%{path_params: %{"hash" => hash}} = conn, _opts), do: sign_conn(conn, hash)
+  defp sign(conn, _opts), do: conn
+
+  defp sign_conn(conn, hash) do
+    if Tuist.Environment.test?() or Tuist.Environment.dev?() do
+      put_resp_header(conn, "x-tuist-signature", "tuist")
+    else
+      put_resp_header(conn, "x-tuist-signature", Tuist.License.sign(hash))
     end
   end
 end

--- a/server/test/tuist_web/controllers/api/cache_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/cache_controller_test.exs
@@ -381,6 +381,9 @@ defmodule TuistWeb.API.CacheControllerTest do
       object_key = "#{project_slug}/#{cache_category}/#{hash}/#{name}"
       date = ~N[2024-04-30 10:20:30Z]
 
+      stub(Tuist.Environment, :test?, fn -> false end)
+      stub(Tuist.Environment, :dev?, fn -> false end)
+      stub(Tuist.License, :sign, fn ^hash -> "signature" end)
       stub(NaiveDateTime, :utc_now, fn :second -> date end)
 
       expect(Storage, :generate_download_url, fn ^object_key, _, _ ->
@@ -402,6 +405,7 @@ defmodule TuistWeb.API.CacheControllerTest do
 
       # Then
       response = json_response(conn, 200)
+      assert Plug.Conn.get_resp_header(conn, "x-tuist-signature") == ["signature"]
       assert response["status"] == "success"
       response_data = response["data"]
       assert response_data["url"] == download_url
@@ -498,6 +502,10 @@ defmodule TuistWeb.API.CacheControllerTest do
       {:ok, account} = Accounts.get_account_by_id(project.account_id)
       hash = "hash"
 
+      stub(Tuist.Environment, :test?, fn -> false end)
+      stub(Tuist.Environment, :dev?, fn -> false end)
+      stub(Tuist.License, :sign, fn ^hash -> "signature" end)
+
       CacheActionItems.create_cache_action_item(%{
         hash: hash,
         project: project
@@ -513,6 +521,8 @@ defmodule TuistWeb.API.CacheControllerTest do
 
       # Then
       response = json_response(conn, :ok)
+
+      assert Plug.Conn.get_resp_header(conn, "x-tuist-signature") == ["signature"]
 
       assert response == %{
                "hash" => "hash"


### PR DESCRIPTION
## Summary

- Restore `x-tuist-signature` on central Tuist cache responses when the request carries a cache hash.
- Add controller coverage for signed cache download and cache action item responses.

## Why

Zillow reported cache downloads failing with `Invalid or missing signature from cache server`. CLI 4.193.4 still verifies cache responses with `SignatureVerifierMiddleware`, but PR #10899 removed response signing from the central cache controller. Unsigned responses are rejected by those clients even when the cache artifact itself is valid.

## Root Cause

The central Tuist cache API stopped emitting `x-tuist-signature` for hash-addressed cache responses while signed-response clients were still in use.

## Validation

- `mix test test/tuist_web/controllers/api/cache_controller_test.exs`
- `git diff --check HEAD~1`