### PR TITLE
ci(kura): harden runtime image release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -705,7 +705,7 @@ jobs:
     # TODO: migrate to tuist-production-linux once the runner image ships
     # a docker daemon — buildx requires a working docker engine.
     runs-on: namespace-profile-default-with-volume
-    timeout-minutes: 45
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v4
 
@@ -735,6 +735,8 @@ jobs:
           file: ./kura/Dockerfile
           push: true
           platforms: linux/amd64,linux/arm64
+          cache-from: type=gha,scope=kura-runtime
+          cache-to: type=gha,mode=max,scope=kura-runtime
           tags: |
             ghcr.io/tuist/kura:${{ needs.check-releases.outputs.kura-next-version-number }}
             ghcr.io/tuist/kura:latest
@@ -1957,7 +1959,11 @@ jobs:
           path: cache
 
       - name: Download Kura release metadata
-        if: needs.check-releases.outputs.kura-should-release == 'true' && needs.release-kura-prepare.result == 'success'
+        if: |
+          needs.check-releases.outputs.kura-should-release == 'true' &&
+          needs.release-kura-prepare.result == 'success' &&
+          needs.release-kura-binaries.result == 'success' &&
+          needs.release-kura-docker.result == 'success'
         uses: actions/download-artifact@v4
         with:
           name: kura-release-metadata
@@ -2397,7 +2403,7 @@ jobs:
             FILES_ADDED=true
           fi
 
-          if [ "${{ needs.check-releases.outputs.kura-should-release }}" == "true" ] && [ "${{ needs.release-kura-prepare.result }}" == "success" ]; then
+          if [ "${{ needs.check-releases.outputs.kura-should-release }}" == "true" ] && [ "${{ needs.release-kura-prepare.result }}" == "success" ] && [ "${{ needs.release-kura-binaries.result }}" == "success" ] && [ "${{ needs.release-kura-docker.result }}" == "success" ]; then
             git add kura/CHANGELOG.md kura/Cargo.toml kura/Cargo.lock
             FILES_ADDED=true
           fi
@@ -2500,7 +2506,7 @@ jobs:
               if [ "${{ needs.check-releases.outputs.cache-should-release }}" == "true" ] && [ "${{ needs.release-cache.result }}" == "success" ]; then
                 COMMIT_MSG="$COMMIT_MSG Tuist Cache ${{ needs.check-releases.outputs.cache-next-version }}"
               fi
-              if [ "${{ needs.check-releases.outputs.kura-should-release }}" == "true" ] && [ "${{ needs.release-kura-prepare.result }}" == "success" ]; then
+              if [ "${{ needs.check-releases.outputs.kura-should-release }}" == "true" ] && [ "${{ needs.release-kura-prepare.result }}" == "success" ] && [ "${{ needs.release-kura-binaries.result }}" == "success" ] && [ "${{ needs.release-kura-docker.result }}" == "success" ]; then
                 COMMIT_MSG="$COMMIT_MSG Kura ${{ needs.check-releases.outputs.kura-next-version }}"
               fi
               if [ "${{ needs.check-releases.outputs.gradle-should-release }}" == "true" ] && [ "${{ needs.release-gradle.result }}" == "success" ]; then

--- a/kura/Dockerfile
+++ b/kura/Dockerfile
@@ -1,4 +1,8 @@
+# syntax=docker/dockerfile:1.7
+
 FROM rust:1.94.1-bookworm AS build
+
+ARG TARGETARCH
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
@@ -10,10 +14,25 @@ RUN apt-get update && \
 
 WORKDIR /app
 
+ENV CARGO_INCREMENTAL=0
+
 COPY Cargo.toml Cargo.lock ./
+
+RUN --mount=type=cache,id=kura-cargo-registry,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,id=kura-cargo-git,target=/usr/local/cargo/git,sharing=locked \
+    mkdir -p src && \
+    printf 'fn main() {}\n' > src/main.rs && \
+    touch src/lib.rs && \
+    cargo fetch --locked && \
+    rm -rf src
+
 COPY src src
 
-RUN cargo build --release --locked
+RUN --mount=type=cache,id=kura-target-${TARGETARCH},target=/app/target,sharing=locked \
+    --mount=type=cache,id=kura-cargo-registry,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,id=kura-cargo-git,target=/usr/local/cargo/git,sharing=locked \
+    cargo build --release --locked && \
+    cp /app/target/release/kura /usr/local/bin/kura
 
 FROM debian:bookworm-slim AS geoip
 
@@ -55,7 +74,7 @@ ENV RUST_LOG=info
 
 WORKDIR /app
 
-COPY --from=build /app/target/release/kura /usr/local/bin/kura
+COPY --from=build /usr/local/bin/kura /usr/local/bin/kura
 COPY --from=geoip /opt/geoip/dbip-city-lite.mmdb /opt/geoip/dbip-city-lite.mmdb
 
 EXPOSE 4000


### PR DESCRIPTION
Resolves: N/A

This hardens the Kura runtime image release path so release metadata no longer gets committed before the deployable runtime image exists.

The Kura Docker release job now has a 90-minute timeout and uses GitHub Actions Docker layer caching. The Kura Dockerfile also enables BuildKit cache mounts for Cargo registry, git, and target directories, which should prevent every release image from cold-building the full Rust dependency graph.

The release workflow now only downloads, commits, and mentions Kura release metadata when the metadata preparation, all Kura binaries, and the Kura Docker image build have succeeded. The tag and GitHub release were already gated this way; this aligns the commit path with the actual published release state.

### How to test locally

- `git diff --check`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/release.yml'); puts 'release.yml parsed'"`
- `docker buildx build --progress=plain -t tuist/kura:local --load ./kura`
