### PR TITLE
fix(cli): generate foreign build aggregates as scripts

### DIFF
--- a/cli/Sources/TuistGenerator/Generator/ConfigGenerator.swift
+++ b/cli/Sources/TuistGenerator/Generator/ConfigGenerator.swift
@@ -169,6 +169,18 @@ struct ConfigGenerator: ConfigGenerating {
         configurationList: XCConfigurationList,
         sourceRootPath: AbsolutePath
     ) async throws {
+        if target.isAggregate {
+            try generateAggregateTargetSettingsFor(
+                target: target,
+                buildConfiguration: buildConfiguration,
+                configuration: configuration,
+                fileElements: fileElements,
+                pbxproj: pbxproj,
+                configurationList: configurationList
+            )
+            return
+        }
+
         let settingsHelper = SettingsHelper()
 
         var settings: SettingsDictionary = try await defaultSettingsProvider.targetSettings(
@@ -201,6 +213,38 @@ struct ConfigGenerator: ConfigGenerating {
                 ),
                 inherit: true
             )
+
+        let variantBuildConfiguration = XCBuildConfiguration(
+            name: buildConfiguration.xcodeValue,
+            baseConfiguration: nil,
+            buildSettings: [:]
+        )
+        if let variantConfig = configuration, let xcconfig = variantConfig.xcconfig {
+            let fileReference = fileElements.file(path: xcconfig)
+            variantBuildConfiguration.baseConfiguration = fileReference
+        }
+
+        variantBuildConfiguration.buildSettings = settings.toBuildSettings()
+        pbxproj.add(object: variantBuildConfiguration)
+        configurationList.buildConfigurations.append(variantBuildConfiguration)
+    }
+
+    private func generateAggregateTargetSettingsFor(
+        target: Target,
+        buildConfiguration: BuildConfiguration,
+        configuration: Configuration?,
+        fileElements: ProjectFileElements,
+        pbxproj: PBXProj,
+        configurationList: XCConfigurationList
+    ) throws {
+        let settingsHelper = SettingsHelper()
+        var settings: SettingsDictionary = [:]
+        settingsHelper.extend(buildSettings: &settings, with: target.settings?.base ?? [:])
+        if buildConfiguration.variant == .debug {
+            settingsHelper.extend(buildSettings: &settings, with: target.settings?.baseDebug ?? [:])
+        }
+        settingsHelper.extend(buildSettings: &settings, with: configuration?.settings ?? [:])
+        settings["VERSIONING_SYSTEM"] = ""
 
         let variantBuildConfiguration = XCBuildConfiguration(
             name: buildConfiguration.xcodeValue,

--- a/cli/Sources/TuistGenerator/Generator/TargetGenerator.swift
+++ b/cli/Sources/TuistGenerator/Generator/TargetGenerator.swift
@@ -122,6 +122,18 @@ struct TargetGenerator: TargetGenerating {
             sourceRootPath: project.sourceRootPath
         )
 
+        if target.isAggregate {
+            Logger.current.debug("TargetGenerator: Generating post-scripts for aggregate target \(target.name)")
+            try await buildPhaseGenerator.generateScripts(
+                target.scripts.postScripts,
+                pbxTarget: pbxTarget,
+                pbxproj: pbxproj,
+                sourceRootPath: project.sourceRootPath
+            )
+            Logger.current.debug("TargetGenerator: Finished generation for aggregate target \(target.name)")
+            return (pbxTarget, [])
+        }
+
         // Build phases
         Logger.current.debug("TargetGenerator: Generating build phases for \(target.name)")
         try await buildPhaseGenerator.generateBuildPhases(

--- a/cli/Tests/TuistGeneratorTests/Generator/ConfigGeneratorTests.swift
+++ b/cli/Tests/TuistGeneratorTests/Generator/ConfigGeneratorTests.swift
@@ -101,6 +101,67 @@ struct ConfigGeneratorTests {
         assert(config: customReleaseConfig, contains: releaseSettings)
     }
 
+    @Test(.withMockedXcodeController, .inTemporaryDirectory)
+    func generateTargetConfig_whenAggregateTarget_clearsVersioningSystem() async throws {
+        // Given
+        let dir = try #require(FileSystem.temporaryTestDirectory)
+        let target = Target.test(
+            name: "SharedKMP",
+            settings: nil,
+            foreignBuild: ForeignBuild(
+                script: "gradle build",
+                inputs: [],
+                output: .xcframework(
+                    path: dir.appending(component: "SharedKMP.xcframework"),
+                    linking: .dynamic
+                )
+            )
+        )
+        let aggregateTarget = PBXAggregateTarget(
+            name: "SharedKMP",
+            buildConfigurationList: nil,
+            buildPhases: [],
+            buildRules: [],
+            dependencies: [],
+            productName: nil
+        )
+        pbxproj.add(object: aggregateTarget)
+        let projectSettings = Settings.test(
+            configurations: [
+                .debug: Configuration(settings: ["VERSIONING_SYSTEM": "apple-generic"]),
+                .release: Configuration(settings: ["VERSIONING_SYSTEM": "apple-generic"]),
+            ]
+        )
+        let project = Project.test(
+            path: dir,
+            sourceRootPath: dir,
+            xcodeProjPath: dir.appending(component: "Project.xcodeproj"),
+            settings: projectSettings,
+            targets: [target]
+        )
+        let graph = Graph.test(path: project.path)
+        let graphTraverser = GraphTraverser(graph: graph)
+
+        // When
+        try await subject.generateTargetConfig(
+            target,
+            project: project,
+            pbxTarget: aggregateTarget,
+            pbxproj: pbxproj,
+            projectSettings: project.settings,
+            fileElements: .init(),
+            graphTraverser: graphTraverser,
+            sourceRootPath: dir
+        )
+
+        // Then
+        let debugConfig = aggregateTarget.buildConfigurationList?.configuration(name: "Debug")
+        #expect(debugConfig?.buildSettings["VERSIONING_SYSTEM"]?.stringValue == "")
+        #expect(debugConfig?.buildSettings["PRODUCT_NAME"] == nil)
+        #expect(debugConfig?.buildSettings["PRODUCT_BUNDLE_IDENTIFIER"] == nil)
+        #expect(debugConfig?.buildSettings["SDKROOT"] == nil)
+    }
+
     @Test(
         .withMockedXcodeController,
         .inTemporaryDirectory

--- a/cli/Tests/TuistGeneratorTests/Generator/TargetGeneratorTests.swift
+++ b/cli/Tests/TuistGeneratorTests/Generator/TargetGeneratorTests.swift
@@ -418,6 +418,70 @@ struct TargetGeneratorTests {
         #expect(postBuildPhase?.shellScript == "\"$SRCROOT\"/script.sh arg")
     }
 
+    @Test func generateTarget_whenAggregateTarget_generatesOnlyScriptPhases() async throws {
+        // Given
+        let outputPath = path.appending(component: "SharedKMP.xcframework")
+        let target = Target.test(
+            name: "SharedKMP",
+            product: .framework,
+            sources: [],
+            resources: .init([]),
+            scripts: [
+                TargetScript(
+                    name: "Foreign Build: SharedKMP",
+                    order: .pre,
+                    script: .embedded("gradle build")
+                ),
+                TargetScript(
+                    name: "post",
+                    order: .post,
+                    script: .embedded("echo post")
+                ),
+            ],
+            foreignBuild: ForeignBuild(
+                script: "gradle build",
+                inputs: [],
+                output: .xcframework(path: outputPath, linking: .dynamic)
+            )
+        )
+        let project = Project.test(
+            path: path,
+            sourceRootPath: path,
+            xcodeProjPath: path.appending(component: "Project.xcodeproj"),
+            targets: [target]
+        )
+        let graph = Graph.test(path: project.path, projects: [project.path: project])
+        let graphTraverser = GraphTraverser(graph: graph)
+        let groups = ProjectGroups.generate(
+            project: project,
+            pbxproj: pbxproj
+        )
+        try fileElements.generateProjectFiles(
+            project: project,
+            graphTraverser: graphTraverser,
+            groups: groups,
+            pbxproj: pbxproj
+        )
+
+        // When
+        let (pbxTarget, _) = try await subject.generateTarget(
+            target: target,
+            project: project,
+            pbxproj: pbxproj,
+            pbxProject: pbxProject,
+            projectSettings: project.settings,
+            fileElements: fileElements,
+            path: path,
+            graphTraverser: graphTraverser
+        )
+
+        // Then
+        #expect(pbxTarget is PBXAggregateTarget)
+        #expect(pbxTarget.buildPhases.count == 2)
+        #expect(pbxTarget.buildPhases.compactMap { $0 as? PBXShellScriptBuildPhase }.count == 2)
+        #expect(pbxTarget.buildPhases.map { $0.name() } == ["Foreign Build: SharedKMP", "post"])
+    }
+
     // MARK: - Helpers
 
     private func createNativeTarget(for target: Target) -> PBXNativeTarget {


### PR DESCRIPTION
Resolves N/A

Fixes foreign build aggregate targets leaking native-target generation behavior when a project sets `VERSIONING_SYSTEM=apple-generic`.

- Generate aggregate target configs from explicit aggregate settings only and clear `VERSIONING_SYSTEM` so project-level versioning does not make Xcode treat the aggregate as a versioned product.
- Stop generating native sources, resources, linking, embed, and build-rule phases for aggregate foreign build targets while preserving pre and post scripts.
- Add focused generator coverage for the versioning override and script-only phase generation.

### How to test locally

- `tuist generate TuistGeneratorTests tuist ProjectDescription --no-open`
- `xcodebuild test -workspace Tuist.xcworkspace -scheme TuistUnitTests -only-testing TuistGeneratorTests/ConfigGeneratorTests/generateTargetConfig_whenAggregateTarget_clearsVersioningSystem -only-testing TuistGeneratorTests/TargetGeneratorTests/generateTarget_whenAggregateTarget_generatesOnlyScriptPhases CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""`
- `xcodebuild build -workspace Tuist.xcworkspace -scheme tuist CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""`
- Regenerated the provided foreign-build sample with the local `tuist` binary and reran the failing Xcode build. The duplicate-output error is gone and the build advances to the sample Gradle wrapper checksum failure.
- `git diff --check`
