### PR TITLE
fix(infra): use Tuist profile for server deploys

### DIFF
--- a/.github/workflows/server-deployment.yml
+++ b/.github/workflows/server-deployment.yml
@@ -174,7 +174,7 @@ jobs:
     needs: build
     # `build` is skipped when image_tag is supplied - keep running.
     if: always() && (needs.build.result == 'success' || needs.build.result == 'skipped')
-    runs-on: tuist-production-linux
+    runs-on: tuist-default
     environment:
       name: server-k8s-${{ inputs.environment }}
     concurrency:
@@ -240,7 +240,7 @@ jobs:
     name: Tailscale operator chart (${{ inputs.environment }})
     needs: build
     if: always() && (needs.build.result == 'success' || needs.build.result == 'skipped')
-    runs-on: tuist-production-linux
+    runs-on: tuist-default
     environment:
       name: server-k8s-${{ inputs.environment }}
     concurrency:
@@ -317,7 +317,7 @@ jobs:
     name: Platform chart (${{ inputs.environment }})
     needs: build
     if: always() && (needs.build.result == 'success' || needs.build.result == 'skipped')
-    runs-on: tuist-production-linux
+    runs-on: tuist-default
     environment:
       name: server-k8s-${{ inputs.environment }}
     concurrency:
@@ -382,7 +382,7 @@ jobs:
     # platform settings (including CNPG CRDs the Tuist chart consumes for
     # the in-cluster Postgres rollout) land before the app chart upgrade.
     if: always() && (needs.build.result == 'success' || needs.build.result == 'skipped') && needs.observability-install.result == 'success' && needs.tailscale-operator-install.result == 'success' && needs.platform-install.result == 'success'
-    runs-on: tuist-production-linux
+    runs-on: tuist-default
     environment:
       name: server-k8s-${{ inputs.environment }}
       url: https://${{ inputs.environment == 'production' && 'tuist.dev' || format('{0}.tuist.dev', inputs.environment) }}
@@ -392,10 +392,10 @@ jobs:
     concurrency:
       group: server-deploy-${{ inputs.environment }}-deploy
       cancel-in-progress: false
-    # helm-upgrade waits up to 30m and setup/teardown adds ~5m. 50m
-    # leaves a healthy buffer around that stack and keeps a
-    # SIGTERM-stuck helm from holding the slot indefinitely.
-    timeout-minutes: 50
+    # helm-upgrade can run for 70m and setup/diagnostics add ~10m. 80m
+    # keeps the job from killing helm before its own timeout/rollback path
+    # finishes, while still bounding a SIGTERM-stuck deploy.
+    timeout-minutes: 80
     env:
       KUBECONFIG: ${{ github.workspace }}/.kube/config
       NAMESPACE: ${{ inputs.environment == 'production' && 'tuist' || format('tuist-{0}', inputs.environment) }}
@@ -535,7 +535,14 @@ jobs:
             exit 0
           fi
 
-          refs="$(git ls-remote --tags --refs origin 'refs/tags/kura@*')"
+          if ! refs="$(
+            GIT_TERMINAL_PROMPT=0 timeout 30s \
+              git ls-remote --tags --refs origin 'refs/tags/kura@*'
+          )"; then
+            echo "::error::Failed to resolve the Kura runtime image tag from Git tags within 30 seconds."
+            echo "::error::Pass kura_runtime_image_tag to skip remote tag discovery when the runtime release is known."
+            exit 1
+          fi
           tag="$(
             printf '%s\n' "$refs" |
               awk -F'refs/tags/kura@' 'NF == 2 { print $2 }' |


### PR DESCRIPTION
## What changed

- Runs the server deployment jobs on the `tuist-default` Tuist runner profile instead of the legacy `tuist-production-linux` label.
- Raises the deploy job timeout from 50 minutes to 80 minutes so it no longer undercuts the Helm step, which can run for 70 minutes including rollback cushion.
- Bounds Kura runtime tag discovery with a 30 second timeout and disables interactive Git prompts.
- Emits an actionable error pointing operators to the existing `kura_runtime_image_tag` input when tag discovery fails.

## Why

`tuist-production-linux` is now a legacy alias for pre-profile workflows. The release being deployed replaces the legacy Linux RunnerPool with shape-based Runner Profiles, and the current dispatch code resolves `tuist-default` through the profile path to the default shape pool. Using the profile label makes this deployment workflow exercise the same runner API that customers use instead of relying on the legacy production alias.

The job and step timeouts had also drifted after the Helm timeout was extended on May 29. The Helm step can run for 70 minutes, but the job was still capped at 50 minutes, which can kill Helm before its own timeout or rollback path finishes and leave the release pending.

A separate production retry got stuck before Helm while resolving the Kura runtime tag from Git tags. Passing `kura_runtime_image_tag=0.6.0` skipped that lookup and let the workflow proceed to Helm, so the remote lookup also gets its own bound.

## Validation

- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/server-deployment.yml"); puts "yaml ok"'`