### PR TITLE
fix(cli): pass precompiled framework search paths to Swift inline, not via @resp

### DIFF
--- a/cli/Sources/TuistGenerator/Generator/LinkGenerator.swift
+++ b/cli/Sources/TuistGenerator/Generator/LinkGenerator.swift
@@ -377,14 +377,18 @@ struct LinkGenerator: LinkGenerating { // swiftlint:disable:this type_body_lengt
             pbxTarget: pbxTarget
         )
 
-        // OTHER_SWIFT_FLAGS: add @response_file (no -Xcc) so swift-driver expands it
-        // into native -F flags. Passing -Xcc @file instead forwards the token verbatim
-        // to Swift's ClangImporter, whose createInvocation does not expand @file under
-        // Xcode 26 and treats it as a second Objective-C input, producing two -cc1 jobs
-        // and the "expected exactly one compiler job" error.
+        // OTHER_SWIFT_FLAGS: pass the precompiled framework search paths inline as native
+        // -F flags rather than through the response file. Unlike C/ObjC compilation, Swift
+        // does not hit ARG_MAX here, so it never needed the @file indirection, and routing
+        // it through @file is actively broken under Xcode 26: `-Xcc @file` makes the
+        // ClangImporter treat the response file as a second input ("expected exactly one
+        // compiler job"), while a bare `@file` is left unexpanded by Xcode's integrated
+        // SwiftDriver and resolved as a literal input ("Unexpected input file") whenever the
+        // .resp is absent at build time. Inline -F sidesteps both and needs no side-effect file.
+        let swiftFrameworkSearchPathFlags = precompiledXcodeValues.flatMap { ["-F", $0] }
         try setup(
             setting: "OTHER_SWIFT_FLAGS",
-            values: [responseFileRef],
+            values: swiftFrameworkSearchPathFlags,
             pbxTarget: pbxTarget
         )
 

--- a/cli/Tests/TuistGeneratorTests/Generator/LinkGeneratorTests.swift
+++ b/cli/Tests/TuistGeneratorTests/Generator/LinkGeneratorTests.swift
@@ -648,13 +648,20 @@ final class LinkGeneratorTests: XCTestCase {
         let otherCFlags = config.buildSettings["OTHER_CFLAGS"]?.arrayValue ?? []
         XCTAssertTrue(otherCFlags.contains { $0.contains("@$(SRCROOT)/Derived/FrameworkSearchPaths/MyTarget.resp") })
 
-        // OTHER_SWIFT_FLAGS should reference the response file directly (no -Xcc), so
-        // swift-driver expands it into native -F flags rather than forwarding @file to
-        // the ClangImporter, which under Xcode 26 would treat it as a second compiler
-        // input ("expected exactly one compiler job").
+        // OTHER_SWIFT_FLAGS should pass the precompiled framework search paths inline as
+        // native -F flags, never through the response file. Routing them via @file is
+        // broken under Xcode 26 (the ClangImporter or the integrated SwiftDriver mishandle
+        // the token), and Swift has no ARG_MAX problem that would require it.
         let otherSwiftFlags = config.buildSettings["OTHER_SWIFT_FLAGS"]?.arrayValue ?? []
-        XCTAssertTrue(otherSwiftFlags.contains { $0.contains("@$(SRCROOT)/Derived/FrameworkSearchPaths/MyTarget.resp") })
+        XCTAssertFalse(otherSwiftFlags.contains { $0.contains(".resp") })
         XCTAssertFalse(otherSwiftFlags.contains("-Xcc"))
+        XCTAssertTrue(otherSwiftFlags.contains("-F"))
+        for i in 0 ..< 25 {
+            XCTAssertTrue(
+                otherSwiftFlags.contains("$(SRCROOT)/cache/hash\(i)"),
+                "OTHER_SWIFT_FLAGS should contain inline framework search path for hash\(i)"
+            )
+        }
 
         // OTHER_LDFLAGS should reference the response file
         let otherLDFlags = config.buildSettings["OTHER_LDFLAGS"]?.arrayValue ?? []


### PR DESCRIPTION
> Draft. Fixes the Swift-side failures of the framework-search-path response file under Xcode 26. See the "Scope and limitation" section: this is necessary but not sufficient when the `.resp` is missing at build time.

## What changed

`LinkGenerator.setupFrameworkSearchPath` no longer injects the `@<Target>.resp` reference into `OTHER_SWIFT_FLAGS`. Instead it passes the precompiled framework search paths to the Swift compiler as **inline native `-F` flags**. `OTHER_CFLAGS` (clang) and `OTHER_LDFLAGS` (ld) are unchanged — they keep the `@resp`.

## Why

The consolidation introduced in #10228 (shipped 4.195.7) writes precompiled framework search paths to `Derived/FrameworkSearchPaths/<Target>.resp` when a target has ≥20 of them, and references that file via `@file` in `OTHER_CFLAGS`, `OTHER_SWIFT_FLAGS`, and `OTHER_LDFLAGS`. Both forms we have tried for `OTHER_SWIFT_FLAGS` break under Xcode 26:

1. `-Xcc @file` (original, ≤ 4.195.12): `-Xcc` forwards the token verbatim to Swift's ClangImporter, whose `createInvocation` does not expand `@file` under Xcode 26. clang then sees the `.resp` path as a second Objective-C input, emits two `-cc1` jobs, and fails with `unable to handle compilation, expected exactly one compiler job` / `clang importer creation failed`.

2. bare `@file` (current `main`, 4.195.13, from #11023): Xcode's integrated `builtin-SwiftDriver` does not expand the token when the `.resp` is absent at build time. Because the literal argument is `@/abs/path` (starts with `@`, not `/`), the Swift input-path resolver treats it as *relative* and joins it to `-working-directory` (= `SRCROOT`), producing the doubled path `<srcroot>/@<srcroot>/Derived/FrameworkSearchPaths/<Target>.resp` and failing with `Unexpected input file`.

Per #10228's own analysis, only C/ObjC compilation hits `ARG_MAX`; "Swift compilation handles this fine (uses `.resp` response files)". So Swift never needed the `@file` indirection at all. Passing the paths as inline native `-F` flags:

- routes them through swift-driver as ordinary search-path flags (the same thing `FRAMEWORK_SEARCH_PATHS` produces below the consolidation threshold), so there is no `@file` token for either the ClangImporter or the integrated driver to mishandle, and
- does not depend on the `.resp` existing at Swift-compile time.

clang and ld both expand `@file` correctly and genuinely need it to stay under `ARG_MAX`, so they are left on the `@resp`.

## Validation (Xcode 26.4.1, integrated `builtin-SwiftDriver`)

Reproduction project: a macOS app with 22 precompiled `.framework` dependencies plus a SwiftPM external dependency (crosses the consolidation threshold and produces the same `OTHER_SWIFT_FLAGS` shape as the affected projects).

| Scenario | `main` (bare `@resp`) | This PR (inline `-F`) |
|---|---|---|
| `.resp` present | Swift OK | Swift OK, link OK |
| `.resp` absent | Swift fails: `Unexpected input file: <srcroot>/@<srcroot>/…/App.resp` | Swift **OK** (compiles via inline `-F`); link fails on the absent `OTHER_LDFLAGS @resp` |

- The generated `OTHER_SWIFT_FLAGS` now contains `-F <path>` pairs and no `@…resp` token.
- Unit test `test_setupFrameworkSearchPath_consolidatesIntoResponseFile_whenManyPrecompiledPaths` updated to assert inline `-F` (no `.resp`, no `-Xcc`) in `OTHER_SWIFT_FLAGS`; passes.
- `xcodebuild build -scheme tuist` succeeds; lint clean.

## Scope and limitation

This fixes the **Swift** side: the Xcode-26 "expected exactly one compiler job" regression, and makes the Swift compile independent of the `.resp` file.

It does **not** by itself fix builds where the `.resp` is missing at build time. In that case clang/ld still reference `@resp`, so the failure moves from the Swift compile to the link step (`clang: error: no such file or directory: '@…/<Target>.resp'`). The `.resp` lives in the gitignored `Derived/` directory; the reported failures are on CI where the project is built without `Derived/` being regenerated alongside it. Ensuring the project is generated (so `Derived/FrameworkSearchPaths/*.resp` exists) at build time is required for those setups, and a follow-up may revisit whether the hand-rolled response file is still needed on Xcode 26 at all (Xcode 26 wraps clang compiles in its own `…-common-args.resp` response files).