### PR TITLE
Fix Kura rollout and deployment runner safety

### DIFF
--- a/.github/workflows/mgmt-cluster-apply.yml
+++ b/.github/workflows/mgmt-cluster-apply.yml
@@ -78,31 +78,8 @@ jobs:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
         run: |
           mkdir -p "$(dirname "$KUBECONFIG")"
-          tmp="${KUBECONFIG}.tmp"
-          attempts=6
-          delay=5
-          rm -f "$tmp"
-
-          for attempt in $(seq 1 "$attempts"); do
-            if op document get "kubeconfig: tuist-mgmt" --vault tuist-k8s-mgmt --output "$tmp"; then
-              mv "$tmp" "$KUBECONFIG"
-              chmod 600 "$KUBECONFIG"
-              exit 0
-            fi
-
-            rm -f "$tmp"
-            if [ "$attempt" -eq "$attempts" ]; then
-              echo "Failed to fetch mgmt kubeconfig from 1Password after $attempts attempts."
-              exit 1
-            fi
-
-            echo "1Password document fetch failed on attempt $attempt/$attempts; retrying in ${delay}s..."
-            sleep "$delay"
-            delay=$((delay * 2))
-            if [ "$delay" -gt 60 ]; then
-              delay=60
-            fi
-          done
+          op document get "kubeconfig: tuist-mgmt" --vault tuist-k8s-mgmt --output "$KUBECONFIG"
+          chmod 600 "$KUBECONFIG"
       - name: Diff (visibility into what's about to change)
         # `kubectl diff` exits non-zero when there's a diff, which is
         # the expected case here, so don't fail the step on that.

--- a/.github/workflows/mgmt-cluster-apply.yml
+++ b/.github/workflows/mgmt-cluster-apply.yml
@@ -78,8 +78,31 @@ jobs:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
         run: |
           mkdir -p "$(dirname "$KUBECONFIG")"
-          op document get "kubeconfig: tuist-mgmt" --vault tuist-k8s-mgmt --output "$KUBECONFIG"
-          chmod 600 "$KUBECONFIG"
+          tmp="${KUBECONFIG}.tmp"
+          attempts=6
+          delay=5
+          rm -f "$tmp"
+
+          for attempt in $(seq 1 "$attempts"); do
+            if op document get "kubeconfig: tuist-mgmt" --vault tuist-k8s-mgmt --output "$tmp"; then
+              mv "$tmp" "$KUBECONFIG"
+              chmod 600 "$KUBECONFIG"
+              exit 0
+            fi
+
+            rm -f "$tmp"
+            if [ "$attempt" -eq "$attempts" ]; then
+              echo "Failed to fetch mgmt kubeconfig from 1Password after $attempts attempts."
+              exit 1
+            fi
+
+            echo "1Password document fetch failed on attempt $attempt/$attempts; retrying in ${delay}s..."
+            sleep "$delay"
+            delay=$((delay * 2))
+            if [ "$delay" -gt 60 ]; then
+              delay=60
+            fi
+          done
       - name: Diff (visibility into what's about to change)
         # `kubectl diff` exits non-zero when there's a diff, which is
         # the expected case here, so don't fail the step on that.

--- a/.github/workflows/server-deployment.yml
+++ b/.github/workflows/server-deployment.yml
@@ -168,10 +168,7 @@ jobs:
     needs: build
     # `build` is skipped when image_tag is supplied - keep running.
     if: always() && (needs.build.result == 'success' || needs.build.result == 'skipped')
-    # This job mutates cluster control-plane charts. Keep it off
-    # `tuist-production-linux`, which is itself managed by the Tuist
-    # Helm release and can be deleted by rollbacks/upgrades.
-    runs-on: namespace-profile-default-with-volume
+    runs-on: tuist-production-linux
     environment:
       name: server-k8s-${{ inputs.environment }}
     concurrency:
@@ -237,10 +234,7 @@ jobs:
     name: Tailscale operator chart (${{ inputs.environment }})
     needs: build
     if: always() && (needs.build.result == 'success' || needs.build.result == 'skipped')
-    # This job mutates cluster control-plane charts. Keep it off
-    # `tuist-production-linux`, which is itself managed by the Tuist
-    # Helm release and can be deleted by rollbacks/upgrades.
-    runs-on: namespace-profile-default-with-volume
+    runs-on: tuist-production-linux
     environment:
       name: server-k8s-${{ inputs.environment }}
     concurrency:
@@ -317,10 +311,7 @@ jobs:
     name: Platform chart (${{ inputs.environment }})
     needs: build
     if: always() && (needs.build.result == 'success' || needs.build.result == 'skipped')
-    # This job mutates cluster control-plane charts. Keep it off
-    # `tuist-production-linux`, which is itself managed by the Tuist
-    # Helm release and can be deleted by rollbacks/upgrades.
-    runs-on: namespace-profile-default-with-volume
+    runs-on: tuist-production-linux
     environment:
       name: server-k8s-${{ inputs.environment }}
     concurrency:
@@ -387,7 +378,7 @@ jobs:
     if: always() && (needs.build.result == 'success' || needs.build.result == 'skipped') && needs.observability-install.result == 'success' && needs.tailscale-operator-install.result == 'success' && needs.platform-install.result == 'success'
     # This job deploys the Tuist Helm release, including the RunnerPool
     # backing `tuist-production-linux`. Running it on that same mutable
-    # pool lets a rollback kill the job's own runner.
+    # pool can make rollback kill or wait on the job's own runner.
     runs-on: namespace-profile-default-with-volume
     environment:
       name: server-k8s-${{ inputs.environment }}

--- a/.github/workflows/server-deployment.yml
+++ b/.github/workflows/server-deployment.yml
@@ -168,7 +168,10 @@ jobs:
     needs: build
     # `build` is skipped when image_tag is supplied - keep running.
     if: always() && (needs.build.result == 'success' || needs.build.result == 'skipped')
-    runs-on: tuist-production-linux
+    # This job mutates cluster control-plane charts. Keep it off
+    # `tuist-production-linux`, which is itself managed by the Tuist
+    # Helm release and can be deleted by rollbacks/upgrades.
+    runs-on: namespace-profile-default-with-volume
     environment:
       name: server-k8s-${{ inputs.environment }}
     concurrency:
@@ -234,7 +237,10 @@ jobs:
     name: Tailscale operator chart (${{ inputs.environment }})
     needs: build
     if: always() && (needs.build.result == 'success' || needs.build.result == 'skipped')
-    runs-on: tuist-production-linux
+    # This job mutates cluster control-plane charts. Keep it off
+    # `tuist-production-linux`, which is itself managed by the Tuist
+    # Helm release and can be deleted by rollbacks/upgrades.
+    runs-on: namespace-profile-default-with-volume
     environment:
       name: server-k8s-${{ inputs.environment }}
     concurrency:
@@ -311,7 +317,10 @@ jobs:
     name: Platform chart (${{ inputs.environment }})
     needs: build
     if: always() && (needs.build.result == 'success' || needs.build.result == 'skipped')
-    runs-on: tuist-production-linux
+    # This job mutates cluster control-plane charts. Keep it off
+    # `tuist-production-linux`, which is itself managed by the Tuist
+    # Helm release and can be deleted by rollbacks/upgrades.
+    runs-on: namespace-profile-default-with-volume
     environment:
       name: server-k8s-${{ inputs.environment }}
     concurrency:
@@ -376,7 +385,10 @@ jobs:
     # platform settings (including CNPG CRDs the Tuist chart consumes for
     # the in-cluster Postgres rollout) land before the app chart upgrade.
     if: always() && (needs.build.result == 'success' || needs.build.result == 'skipped') && needs.observability-install.result == 'success' && needs.tailscale-operator-install.result == 'success' && needs.platform-install.result == 'success'
-    runs-on: tuist-production-linux
+    # This job deploys the Tuist Helm release, including the RunnerPool
+    # backing `tuist-production-linux`. Running it on that same mutable
+    # pool lets a rollback kill the job's own runner.
+    runs-on: namespace-profile-default-with-volume
     environment:
       name: server-k8s-${{ inputs.environment }}
       url: https://${{ inputs.environment == 'production' && 'tuist.dev' || format('{0}.tuist.dev', inputs.environment) }}

--- a/infra/grafana-dashboards/tuist-kura.json
+++ b/infra/grafana-dashboards/tuist-kura.json
@@ -302,7 +302,7 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "histogram_quantile(0.95, sum by (le) ((rate(kura_http_request_duration_seconds_bucket{cluster=~\"$cluster\", instance=~\"$instance\"}[$__rate_interval])) and on (cluster, instance) max by (cluster, instance) (kura_node_info{cluster=~\"$cluster\", tenant_id=~\"$tenant\", instance=~\"$instance\", region=~\"$region\"})))",
+            "expr": "histogram_quantile(0.95, sum by (le) ((rate(kura_http_request_duration_seconds_bucket{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\"}[$__rate_interval])) and on (cluster, instance) max by (cluster, instance) (kura_node_info{cluster=~\"$cluster\", tenant_id=~\"$tenant\", instance=~\"$instance\", region=~\"$region\"})))",
             "instant": true,
             "legendFormat": "p95",
             "range": false,
@@ -597,21 +597,21 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "histogram_quantile(0.50, sum by (le) ((rate(kura_http_request_duration_seconds_bucket{cluster=~\"$cluster\", instance=~\"$instance\"}[$__rate_interval])) and on (cluster, instance) max by (cluster, instance) (kura_node_info{cluster=~\"$cluster\", tenant_id=~\"$tenant\", instance=~\"$instance\", region=~\"$region\"})))",
+            "expr": "histogram_quantile(0.50, sum by (le) ((rate(kura_http_request_duration_seconds_bucket{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\"}[$__rate_interval])) and on (cluster, instance) max by (cluster, instance) (kura_node_info{cluster=~\"$cluster\", tenant_id=~\"$tenant\", instance=~\"$instance\", region=~\"$region\"})))",
             "legendFormat": "p50",
             "refId": "A"
           },
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "histogram_quantile(0.95, sum by (le) ((rate(kura_http_request_duration_seconds_bucket{cluster=~\"$cluster\", instance=~\"$instance\"}[$__rate_interval])) and on (cluster, instance) max by (cluster, instance) (kura_node_info{cluster=~\"$cluster\", tenant_id=~\"$tenant\", instance=~\"$instance\", region=~\"$region\"})))",
+            "expr": "histogram_quantile(0.95, sum by (le) ((rate(kura_http_request_duration_seconds_bucket{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\"}[$__rate_interval])) and on (cluster, instance) max by (cluster, instance) (kura_node_info{cluster=~\"$cluster\", tenant_id=~\"$tenant\", instance=~\"$instance\", region=~\"$region\"})))",
             "legendFormat": "p95",
             "refId": "B"
           },
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "histogram_quantile(0.99, sum by (le) ((rate(kura_http_request_duration_seconds_bucket{cluster=~\"$cluster\", instance=~\"$instance\"}[$__rate_interval])) and on (cluster, instance) max by (cluster, instance) (kura_node_info{cluster=~\"$cluster\", tenant_id=~\"$tenant\", instance=~\"$instance\", region=~\"$region\"})))",
+            "expr": "histogram_quantile(0.99, sum by (le) ((rate(kura_http_request_duration_seconds_bucket{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\"}[$__rate_interval])) and on (cluster, instance) max by (cluster, instance) (kura_node_info{cluster=~\"$cluster\", tenant_id=~\"$tenant\", instance=~\"$instance\", region=~\"$region\"})))",
             "legendFormat": "p99",
             "refId": "C"
           }
@@ -1033,21 +1033,21 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "histogram_quantile(0.50, sum by (le) ((rate(kura_replication_request_duration_seconds_bucket{cluster=~\"$cluster\", instance=~\"$instance\"}[$__rate_interval])) and on (cluster, instance) max by (cluster, instance) (kura_node_info{cluster=~\"$cluster\", tenant_id=~\"$tenant\", instance=~\"$instance\", region=~\"$region\"}))) or on() vector(0)",
+            "expr": "histogram_quantile(0.50, sum by (le) ((rate(kura_replication_request_duration_seconds_bucket{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\"}[$__rate_interval])) and on (cluster, instance) max by (cluster, instance) (kura_node_info{cluster=~\"$cluster\", tenant_id=~\"$tenant\", instance=~\"$instance\", region=~\"$region\"}))) or on() vector(0)",
             "legendFormat": "p50",
             "refId": "A"
           },
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "histogram_quantile(0.95, sum by (le) ((rate(kura_replication_request_duration_seconds_bucket{cluster=~\"$cluster\", instance=~\"$instance\"}[$__rate_interval])) and on (cluster, instance) max by (cluster, instance) (kura_node_info{cluster=~\"$cluster\", tenant_id=~\"$tenant\", instance=~\"$instance\", region=~\"$region\"}))) or on() vector(0)",
+            "expr": "histogram_quantile(0.95, sum by (le) ((rate(kura_replication_request_duration_seconds_bucket{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\"}[$__rate_interval])) and on (cluster, instance) max by (cluster, instance) (kura_node_info{cluster=~\"$cluster\", tenant_id=~\"$tenant\", instance=~\"$instance\", region=~\"$region\"}))) or on() vector(0)",
             "legendFormat": "p95",
             "refId": "B"
           },
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "histogram_quantile(0.99, sum by (le) ((rate(kura_replication_request_duration_seconds_bucket{cluster=~\"$cluster\", instance=~\"$instance\"}[$__rate_interval])) and on (cluster, instance) max by (cluster, instance) (kura_node_info{cluster=~\"$cluster\", tenant_id=~\"$tenant\", instance=~\"$instance\", region=~\"$region\"}))) or on() vector(0)",
+            "expr": "histogram_quantile(0.99, sum by (le) ((rate(kura_replication_request_duration_seconds_bucket{cluster=~\"$cluster\", instance=~\"$instance\", region=~\"$region\"}[$__rate_interval])) and on (cluster, instance) max by (cluster, instance) (kura_node_info{cluster=~\"$cluster\", tenant_id=~\"$tenant\", instance=~\"$instance\", region=~\"$region\"}))) or on() vector(0)",
             "legendFormat": "p99",
             "refId": "C"
           }
@@ -1883,7 +1883,7 @@
       },
       {
         "datasource": "$datasource",
-        "description": "Request origins for the selected tenant over the selected time range, alongside the tenant's serving regions.",
+        "description": "Serving-node geography and request-origin geography for the selected tenant and range. Blue markers are deployed Kura nodes; orange markers are client request origins.",
         "fieldConfig": {
           "defaults": {
             "color": {
@@ -1986,7 +1986,7 @@
                 "lookup": "lookup",
                 "mode": "lookup"
               },
-              "name": "US regions",
+              "name": "Serving nodes (US)",
               "tooltip": true,
               "type": "markers"
             },
@@ -2041,7 +2041,7 @@
                 "lookup": "lookup",
                 "mode": "lookup"
               },
-              "name": "Global regions",
+              "name": "Serving nodes (global)",
               "tooltip": true,
               "type": "markers"
             },
@@ -2074,8 +2074,9 @@
                     "vertical": "center"
                   },
                   "text": {
+                    "field": "lookup",
                     "fixed": "",
-                    "mode": "fixed"
+                    "mode": "field"
                   },
                   "textConfig": {
                     "fontSize": 11,
@@ -2095,7 +2096,7 @@
                 "lookup": "lookup",
                 "mode": "lookup"
               },
-              "name": "Request origins",
+              "name": "Request origins (country)",
               "tooltip": true,
               "type": "markers"
             }
@@ -2141,7 +2142,7 @@
             "refId": "C"
           }
         ],
-        "title": "Tenant Geography",
+        "title": "Geography: serving nodes vs request origins",
         "type": "geomap"
       }
     ],

--- a/infra/helm/tuist/values-managed-canary.yaml
+++ b/infra/helm/tuist/values-managed-canary.yaml
@@ -14,6 +14,10 @@ server:
 
   appUrl: https://canary.tuist.dev
 
+  externalSecrets:
+    kuraIntrospection:
+      item: kura-introspection-oauth-client
+
   autoscaling:
     enabled: false
 
@@ -65,6 +69,12 @@ server:
       value: http://k8s-monitoring-alloy-receiver.observability.svc.cluster.local:4317
     - name: TUIST_KURA_AVAILABLE_REGIONS
       value: eu-central
+
+kuraController:
+  sharedSecrets:
+    externalSecret:
+      enabled: true
+      item: kura-introspection-oauth-client
 
 objectStorage:
   external:

--- a/infra/runners-controller/AGENTS.md
+++ b/infra/runners-controller/AGENTS.md
@@ -11,6 +11,9 @@ independent workqueues:
   `spec.replicas`. Idle Pods (those without the
   `tuist.dev/runner-pool-owner` label) are the only ones eligible for
   scale-down deletion; runners mid-job are never killed.
+  RunnerPool deletion follows the same rule: the finalizer deletes
+  idle/terminal Pods and waits for claimed Pods to finish before letting
+  Kubernetes garbage-collect the pool-owned resources.
 
 - **`AutoscalerReconciler`** — on a 5-second cadence, calls the
   server's `/api/internal/runners/desired_replicas` endpoint and

--- a/infra/runners-controller/controllers/runnerpool_controller.go
+++ b/infra/runners-controller/controllers/runnerpool_controller.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -23,6 +24,8 @@ import (
 	tuistv1 "github.com/tuist/tuist/infra/runners-controller/api/v1alpha1"
 	"github.com/tuist/tuist/infra/runners-controller/internal/podtemplate"
 )
+
+const runnerPoolFinalizer = "tuist.dev/runner-pool-protection"
 
 // RunnerPoolReconciler maintains a fleet of runner Pods + per-Pod
 // ServiceAccounts. Pods are owned directly by the RunnerPool (no
@@ -62,6 +65,17 @@ func (r *RunnerPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 			return ctrl.Result{}, nil
 		}
 		return ctrl.Result{}, err
+	}
+
+	if !pool.DeletionTimestamp.IsZero() {
+		return r.reconcileDelete(ctx, pool, logger)
+	}
+
+	if !controllerutil.ContainsFinalizer(pool, runnerPoolFinalizer) {
+		controllerutil.AddFinalizer(pool, runnerPoolFinalizer)
+		if err := r.Update(ctx, pool); err != nil {
+			return ctrl.Result{}, fmt.Errorf("add finalizer: %w", err)
+		}
 	}
 
 	// Track image rolls. The server-side drain endpoint reads
@@ -203,6 +217,45 @@ func (r *RunnerPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	// missed events. Pod-event-driven reconcile via Owns() is the
 	// primary trigger; this is the catch-all.
 	return ctrl.Result{RequeueAfter: 60 * time.Second}, nil
+}
+
+func (r *RunnerPoolReconciler) reconcileDelete(ctx context.Context, pool *tuistv1.RunnerPool, logger logr.Logger) (ctrl.Result, error) {
+	if !controllerutil.ContainsFinalizer(pool, runnerPoolFinalizer) {
+		return ctrl.Result{}, nil
+	}
+
+	pods := &corev1.PodList{}
+	if err := r.List(ctx, pods,
+		client.InNamespace(pool.Namespace),
+		client.MatchingLabels{"tuist.dev/runner-pool": pool.Name},
+	); err != nil {
+		return ctrl.Result{}, fmt.Errorf("list pods during delete: %w", err)
+	}
+
+	active := 0
+	for i := range pods.Items {
+		p := &pods.Items[i]
+		if isAlive(p) && !isIdle(p) {
+			active++
+			continue
+		}
+
+		if err := r.reapRunner(ctx, p); err != nil {
+			logger.Error(err, "delete runner during pool deletion; will retry", "pod", p.Name)
+			return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
+		}
+	}
+
+	if active > 0 {
+		logger.Info("waiting for active runners before deleting pool", "active", active)
+		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
+	}
+
+	controllerutil.RemoveFinalizer(pool, runnerPoolFinalizer)
+	if err := r.Update(ctx, pool); err != nil {
+		return ctrl.Result{}, fmt.Errorf("remove finalizer: %w", err)
+	}
+	return ctrl.Result{}, nil
 }
 
 // createRunner provisions one Pod + per-Pod ServiceAccount pair,

--- a/infra/runners-controller/controllers/runnerpool_controller_test.go
+++ b/infra/runners-controller/controllers/runnerpool_controller_test.go
@@ -6,11 +6,13 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	tuistv1 "github.com/tuist/tuist/infra/runners-controller/api/v1alpha1"
 )
@@ -235,6 +237,131 @@ func TestReconcile_NoDeletionWhenImageMatches(t *testing.T) {
 	}
 	if len(pods.Items) != 1 || pods.Items[0].Name != "p-runner-current" {
 		t.Fatalf("expected current-image pod to survive reconcile untouched, got %v", podNames(pods.Items))
+	}
+}
+
+func TestReconcile_AddsFinalizer(t *testing.T) {
+	scheme := mustScheme(t)
+	pool := newPool("p", "ghcr.io/tuist/tuist-runner@sha256:current", 1)
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(pool).
+		WithStatusSubresource(&tuistv1.RunnerPool{}).
+		Build()
+
+	r := &RunnerPoolReconciler{Client: c, Scheme: scheme, DispatchURL: "http://dispatch"}
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: nn(pool.Namespace, pool.Name),
+	}); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	updated := &tuistv1.RunnerPool{}
+	if err := c.Get(context.Background(), nn(pool.Namespace, pool.Name), updated); err != nil {
+		t.Fatalf("get pool: %v", err)
+	}
+	if !controllerutil.ContainsFinalizer(updated, runnerPoolFinalizer) {
+		t.Fatalf("expected finalizer %q to be present, got %v", runnerPoolFinalizer, updated.Finalizers)
+	}
+
+	pods := &corev1.PodList{}
+	if err := c.List(context.Background(), pods); err != nil {
+		t.Fatalf("list pods: %v", err)
+	}
+	if len(pods.Items) != 1 {
+		t.Fatalf("expected first reconcile to continue managing runners, got pods %v", podNames(pods.Items))
+	}
+}
+
+func TestReconcile_DeleteWaitsForActiveRunnerAndReapsIdleRunners(t *testing.T) {
+	scheme := mustScheme(t)
+	deletion := metav1.Now()
+	pool := newPool("p", "ghcr.io/tuist/tuist-runner@sha256:current", 0)
+	pool.Finalizers = []string{runnerPoolFinalizer}
+	pool.DeletionTimestamp = &deletion
+
+	activePod := newRunnerPod("p-runner-active", pool.Spec.Image, corev1.PodRunning, "p")
+	activePod.Labels["tuist.dev/runner-pool-owner"] = "tuist"
+	idlePod := newRunnerPod("p-runner-idle", pool.Spec.Image, corev1.PodRunning, "p")
+	terminalPod := newRunnerPod("p-runner-terminal", pool.Spec.Image, corev1.PodSucceeded, "p")
+	activeSA := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: activePod.Name, Namespace: "tuist-runners"}}
+	idleSA := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: idlePod.Name, Namespace: "tuist-runners"}}
+	terminalSA := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: terminalPod.Name, Namespace: "tuist-runners"}}
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(pool, activePod, idlePod, terminalPod, activeSA, idleSA, terminalSA).
+		WithStatusSubresource(&tuistv1.RunnerPool{}).
+		Build()
+
+	r := &RunnerPoolReconciler{Client: c, Scheme: scheme, DispatchURL: "http://dispatch"}
+	result, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: nn(pool.Namespace, pool.Name),
+	})
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if result.RequeueAfter == 0 {
+		t.Fatalf("expected requeue while active runner remains")
+	}
+
+	updated := &tuistv1.RunnerPool{}
+	if err := c.Get(context.Background(), nn(pool.Namespace, pool.Name), updated); err != nil {
+		t.Fatalf("get pool: %v", err)
+	}
+	if !controllerutil.ContainsFinalizer(updated, runnerPoolFinalizer) {
+		t.Fatalf("expected finalizer to remain while active runner exists")
+	}
+
+	for _, name := range []string{idlePod.Name, terminalPod.Name} {
+		pod := &corev1.Pod{}
+		if err := c.Get(context.Background(), nn("tuist-runners", name), pod); !apierrors.IsNotFound(err) {
+			t.Fatalf("expected pod %s to be deleted, got err %v", name, err)
+		}
+		sa := &corev1.ServiceAccount{}
+		if err := c.Get(context.Background(), nn("tuist-runners", name), sa); !apierrors.IsNotFound(err) {
+			t.Fatalf("expected service account %s to be deleted, got err %v", name, err)
+		}
+	}
+
+	pod := &corev1.Pod{}
+	if err := c.Get(context.Background(), nn("tuist-runners", activePod.Name), pod); err != nil {
+		t.Fatalf("expected active pod to remain: %v", err)
+	}
+	sa := &corev1.ServiceAccount{}
+	if err := c.Get(context.Background(), nn("tuist-runners", activeSA.Name), sa); err != nil {
+		t.Fatalf("expected active service account to remain: %v", err)
+	}
+}
+
+func TestReconcile_DeleteRemovesFinalizerWhenNoActiveRunnersRemain(t *testing.T) {
+	scheme := mustScheme(t)
+	deletion := metav1.Now()
+	pool := newPool("p", "ghcr.io/tuist/tuist-runner@sha256:current", 0)
+	pool.Finalizers = []string{runnerPoolFinalizer}
+	pool.DeletionTimestamp = &deletion
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(pool).
+		WithStatusSubresource(&tuistv1.RunnerPool{}).
+		Build()
+
+	r := &RunnerPoolReconciler{Client: c, Scheme: scheme, DispatchURL: "http://dispatch"}
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: nn(pool.Namespace, pool.Name),
+	}); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	updated := &tuistv1.RunnerPool{}
+	err := c.Get(context.Background(), nn(pool.Namespace, pool.Name), updated)
+	if err == nil && controllerutil.ContainsFinalizer(updated, runnerPoolFinalizer) {
+		t.Fatalf("expected finalizer to be removed, got %v", updated.Finalizers)
+	}
+	if err != nil && !apierrors.IsNotFound(err) {
+		t.Fatalf("get pool: %v", err)
 	}
 }
 


### PR DESCRIPTION
Resolves N/A

This PR keeps the managed Kura rollout path durable after the canary unblocking work and fixes the production deploy failure mode found while checking the clusters.

It wires the canary Kura introspection ExternalSecret configuration that production already uses, so future canary Helm deploys keep the Kura 0.6 control-plane auth environment available to Kura instances.

The Grafana Kura dashboard now scopes HTTP and replication histogram bucket queries by region before joining against `kura_node_info`, reducing the chance of Mimir chunk-limit failures on broad time ranges. The geography panel was also renamed and relabeled so serving-node geography and request-origin geography are distinguishable: blue layers are deployed Kura serving nodes, and orange markers are request-origin countries.

The server deploy job now runs on the external Namespace runner profile because it deploys the Helm release that owns `tuist-production-linux`. The failed production deploy ran on a RunnerPool that the rollback removed, so Kubernetes garbage-collected the runner pod before `helm upgrade` could run.

The deeper fix is in the runners-controller: RunnerPools now get a finalizer. When Helm deletes or rolls back a pool, the controller deletes idle/terminal runner Pods but waits for claimed Pods to finish before allowing Kubernetes to garbage-collect the pool-owned resources. That preserves existing builds; the deploy job still stays off the mutable pool so Helm cannot end up waiting on the job that is running Helm.

### How to test locally

- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/server-deployment.yml'); YAML.load_file('infra/helm/tuist/values-managed-canary.yaml'); puts 'yaml ok'"`
- `helm template tuist infra/helm/tuist -f infra/helm/tuist/values-managed-common.yaml -f infra/helm/tuist/values-managed-canary.yaml --set server.image.tag=sha-90c7054b8eb1 --set kuraController.image.tag=sha-90c7054b8eb1 --set kuraRuntime.image.tag=0.6.0 >/tmp/tuist-canary-rendered.yaml`
- `jq empty infra/grafana-dashboards/tuist-kura.json`
- `mise exec go -- go test ./...` from `infra/runners-controller`
