### PR TITLE
fix(infra): shrink production CNPG resource requests so 3rd instance schedules

### DIFF
--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -117,10 +117,18 @@ postgresql:
     instances: 3
     storage:
       size: "100Gi"
+    # Requests sized to fit three instances across the available worker
+    # nodes (md-0 general pool + md-processor). With 2000m/8Gi requests
+    # only two CNPG pods could land — the third was permanently Pending,
+    # which made `helm --wait --atomic` time out and roll the whole
+    # release back on every deploy. 1500m/6Gi gives the same headroom
+    # for steady-state Postgres without exceeding the per-node budget
+    # the other workloads (server, processor, redis, system DaemonSets)
+    # leave free. Limits stay at 4000m/16Gi so peaks aren't constrained.
     resources:
       requests:
-        cpu: "2000m"
-        memory: "8Gi"
+        cpu: "1500m"
+        memory: "6Gi"
       limits:
         cpu: "4000m"
         memory: "16Gi"

--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -117,14 +117,9 @@ postgresql:
     instances: 3
     storage:
       size: "100Gi"
-    # Requests sized to fit three instances across the available worker
-    # nodes (md-0 general pool + md-processor). With 2000m/8Gi requests
-    # only two CNPG pods could land — the third was permanently Pending,
-    # which made `helm --wait --atomic` time out and roll the whole
-    # release back on every deploy. 1500m/6Gi gives the same headroom
-    # for steady-state Postgres without exceeding the per-node budget
-    # the other workloads (server, processor, redis, system DaemonSets)
-    # leave free. Limits stay at 4000m/16Gi so peaks aren't constrained.
+    # Requests sized to fit three instances under hard pod anti-affinity
+    # alongside the rest of the pool tenants; limits left generous so
+    # Postgres runtime peaks aren't capped by the scheduling budget.
     resources:
       requests:
         cpu: "1500m"


### PR DESCRIPTION
## Why

Production deploys are stuck in a doom loop. Every `Server Deployment` invocation against production:

1. Hits an existing `pending-upgrade` helm release (from the previous failed attempt).
2. The `Recover interrupted Helm release` step does a `helm rollback` to escape the stuck state — which **deletes the CNPG `Cluster` CR + PVCs** because the rollback target predates the cluster.
3. Then `helm upgrade --install --wait --timeout 10m` re-applies the manifest. The cluster recreates, `pg-1`/`pg-2` come up on processor-pool nodes, but **`pg-3` can never schedule**.
4. helm `--wait` expires exactly 10 minutes later, `--atomic` rolls everything back, the cluster + PVCs are destroyed again.
5. Loop repeats. Production has been oscillating between "cluster exists, 2/3 healthy" and "cluster torn down" all morning.

The smoking gun on `pg-3`:

```
FailedScheduling  pod/tuist-tuist-pg-3-join-...
  0/22 nodes are available:
    1 didn't match pod anti-affinity rules
    15 had untolerated taints
    4 Insufficient memory
    5 Insufficient cpu
```

With the production CNPG pod requesting `cpu: 2000m` and `memory: 8Gi`, and hard pod anti-affinity (`topologyKey: kubernetes.io/hostname, podAntiAffinityType: required`) forcing each instance onto a different node, only 2 of the available general/processor-pool workers can fit a CNPG pod alongside the existing server / processor / redis / DaemonSet workloads. There's no third schedulable host.

## What changed

`values-managed-production.yaml`, CNPG resource requests only:

| | Before | After |
|---|---|---|
| `requests.cpu` | 2000m | **1500m** |
| `requests.memory` | 8Gi | **6Gi** |
| `limits.cpu` | 4000m | 4000m (unchanged) |
| `limits.memory` | 16Gi | 16Gi (unchanged) |

Postgres steady-state working set on a ~22 GiB DB sits well under 6 GiB, so the smaller request still covers actual usage with headroom; the higher limits stay so runtime peaks aren't constrained.

## Expected effect on the next production deploy

1. helm upgrade applies the new requests.
2. CNPG operator rolling-restarts the existing pods with the new requests (mutable field).
3. `pg-3` finds a node that now has 6Gi free instead of needing 8Gi → schedules.
4. Cluster reaches 3/3 healthy.
5. `helm --wait` succeeds → no rollback → no cluster destruction.

If the cluster is currently torn down (last seen: rev 146 is "Rollback to 144", no Cluster CR), the next deploy with this change will recreate it fresh at the right shape from the start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)