### PR TITLE
fix(cli): raise the open-file limit at startup

### DIFF
--- a/cli/Sources/tuist/Dependencies.swift
+++ b/cli/Sources/tuist/Dependencies.swift
@@ -35,11 +35,11 @@ private enum DependenciesError: LocalizedError {
     }
 }
 
-// Raise the soft open-file limit toward the hard limit. Generating the graph for large
-// projects launches many concurrent subprocesses (manifest and Swift Package Manager
-// evaluation), and CI machines often ship a low default soft limit (256 on macOS) that the
-// process can exhaust, surfacing as "Bad file descriptor" errors. Best-effort: failures are
-// ignored, leaving the inherited limit untouched.
+/// Raises the soft open-file limit toward the hard limit. Generating the graph for large
+/// projects launches many concurrent subprocesses (manifest and Swift Package Manager
+/// evaluation), and CI machines often ship a low default soft limit (256 on macOS) that the
+/// process can exhaust, surfacing as "Bad file descriptor" errors. Best-effort: failures are
+/// ignored, leaving the inherited limit untouched.
 private func raiseOpenFileLimit() {
     var limit = rlimit()
     guard getrlimit(RLIMIT_NOFILE, &limit) == 0 else { return }

--- a/cli/Sources/tuist/Dependencies.swift
+++ b/cli/Sources/tuist/Dependencies.swift
@@ -8,6 +8,12 @@ import TuistNooraExtension
 import TuistServer
 import TuistSupport
 
+#if canImport(Darwin)
+    import Darwin
+#elseif canImport(Glibc)
+    import Glibc
+#endif
+
 #if os(macOS)
     import TuistExtension
     import TuistKit
@@ -29,7 +35,25 @@ private enum DependenciesError: LocalizedError {
     }
 }
 
+// Raise the soft open-file limit toward the hard limit. Generating the graph for large
+// projects launches many concurrent subprocesses (manifest and Swift Package Manager
+// evaluation), and CI machines often ship a low default soft limit (256 on macOS) that the
+// process can exhaust, surfacing as "Bad file descriptor" errors. Best-effort: failures are
+// ignored, leaving the inherited limit untouched.
+private func raiseOpenFileLimit() {
+    var limit = rlimit()
+    guard getrlimit(RLIMIT_NOFILE, &limit) == 0 else { return }
+    // Cap at 10240 (macOS's typical per-process maximum) so an unlimited hard limit
+    // doesn't make `setrlimit` reject the request; that's ~2,500 concurrent subprocesses.
+    let target = min(limit.rlim_max, rlim_t(10240))
+    guard limit.rlim_cur < target else { return }
+    limit.rlim_cur = target
+    _ = setrlimit(RLIMIT_NOFILE, &limit)
+}
+
 private func initEnv() throws {
+    raiseOpenFileLimit()
+
     if CommandLine.arguments.contains("--quiet"), CommandLine.arguments.contains("--verbose") {
         throw DependenciesError.exclusiveOptionError("quiet", "verbose")
     }


### PR DESCRIPTION
## What changed

Raise the soft open-file limit (`RLIMIT_NOFILE`) toward the hard limit at CLI startup (`initEnv` in `cli/Sources/tuist/Dependencies.swift`), capped at 10240. Best-effort and a no-op when the limit is already high.

## Why

After upgrading to 4.195.13 (which fixed the earlier `getcwd` crash), a user running `tuist graph -f legacyJSON --no-open` on a very large project (the AWS SDK for iOS — thousands of SwiftPM targets) on CircleCI hit:

```
✖ Error
  Error Domain=NSPOSIXErrorDomain Code=9 "Bad file descriptor"
```

The log shows the failure during the `swift package` step (after acquiring the SwiftPM lock), once a large number of manifest/SPM subprocesses had run.

## Root cause

Graph generation for a project this size launches many concurrent subprocesses. CI machines commonly ship a low default soft open-file limit (256 on macOS), and the concurrent subprocesses — each holding pipe file descriptors — exhaust it. Foundation's `Process.run()` then fails with `NSPOSIXErrorDomain Code=9 "Bad file descriptor"`.

This became reachable after `Command` 0.14.4 (Tuist 4.192.1) replaced the blocking `waitUntilExit()` with an async continuation. The blocking wait used to keep pooled threads busy, which implicitly bounded launch concurrency (and therefore fd usage); the async wait removes that bound, so on a 256-fd limit the launches now run concurrently enough to run the process out of descriptors.

## Why this fix

Raising the soft limit to the hard limit is the standard remedy for subprocess-heavy CLIs and is the smallest, lowest-risk change — it's process-wide, so it covers every subprocess path (manifest eval, SPM, git, …) without reworking the concurrency model. The cap of 10240 (macOS's typical `kern.maxfilesperproc`) avoids `setrlimit` rejecting an unlimited hard limit, and still allows ~2,500 concurrent subprocesses — far beyond what any real graph needs.

## Validation

Reproduced and verified with a standalone harness depending on the `Command` package:

- Under a forced 256-fd limit, 60+ concurrent subprocess launches per round throw the exact error:
  ```
  getdtablesize=256
  run error [NSPOSIXErrorDomain 9]: Bad file descriptor
  ```
- Modeling the fix (low soft limit, then raise the soft limit to the hard limit) makes the identical load complete with zero errors:
  ```
  before raise: getdtablesize=256
  raise rc=0, after raise: getdtablesize=10240
  DONE ebadf_errors=0
  ```

The `setrlimit`/`getrlimit` usage compiles and runs standalone on macOS.
