### PR TITLE
fix(infra): stop server deploys from killing in-flight runner jobs

### DIFF
--- a/infra/helm/tuist/templates/runners-namespace.yaml
+++ b/infra/helm/tuist/templates/runners-namespace.yaml
@@ -153,42 +153,43 @@ roleRef:
 {{- end }}
 {{- if .Values.runnersFleet.networkPolicy.enabled }}
 ---
-# Pod-network policy for the runner Pod shell. Selects every Pod
-# in tuist-runners (the runners-controller stamps
-# `tuist.dev/runner=true` on every Pod it creates).
+# Base runner Pod-network policy. Selects every Pod in
+# tuist-runners (the runners-controller stamps `tuist.dev/runner=true`
+# on every Pod it creates) and holds the rules whose peer set is
+# CONSTANT across deploys: ingress default-deny, DNS, and public
+# internet egress.
 #
 # Scope (what this gates):
-#   * The Pod's own network namespace: the tart-cri-hosted process
-#     that owns the VM, the dispatch-poll curl, projected-SA-token
-#     requests to apiserver, etc.
-#   * Ingress: default-deny. The polling model doesn't need any
-#     inbound connection to the Pod.
-#   * Egress: HTTPS / HTTP to the public internet, with
-#     `exceptCIDRs` carving out cluster-internal ranges (Pod
-#     CIDR, Service CIDR, Node CIDR). Closes the lateral-pivot
-#     path from the Pod into ClickHouse / Postgres / the
-#     server's admin endpoints.
+#   * The Pod's own network namespace: the dispatch-poll curl,
+#     projected-SA-token requests to apiserver, and, for Linux kata
+#     Pods, the GitHub Actions runner's own egress (those Pods live
+#     in the CNI network namespace, so this policy is their real
+#     egress gate).
+#   * Ingress: default-deny. The polling model needs no inbound
+#     connection to the Pod.
+#   * Egress: DNS + HTTPS/HTTP to the public internet, with
+#     `exceptCIDRs` carving out cluster-internal ranges (Pod CIDR,
+#     Service CIDR, Node CIDR). Closes the lateral-pivot path from
+#     the Pod into ClickHouse / Postgres / the server's admin
+#     endpoints.
 #
-# **What this DOES NOT gate**: the Tart VM's own network traffic.
-# Tart VMs do not live in the Pod network namespace — vmnet /
-# bridged networking on the macOS host puts the VM's interface
-# alongside the host's, NAT'd by Tart, and CNI-based NetworkPolicy
-# does not see that traffic. The "Customer CI workflow reaches
-# api.github.com / GHCR / npm / Homebrew" egress happens from
-# inside the VM and is unaffected by these rules.
+# macOS Tart VMs: their own traffic is NOT gated here. Tart VMs do
+# not live in the Pod network namespace (vmnet / bridged networking
+# on the macOS host puts the VM's interface alongside the host's,
+# NAT'd by Tart), so CNI NetworkPolicy never sees it. The customer
+# CI workflow's reach to api.github.com / GHCR / npm / Homebrew
+# happens from inside the VM and is gated separately by the pfctl
+# ruleset that `macos-host-bootstrap`'s `installVMEgressFirewall`
+# step installs (drops vmnet 192.168.64.0/22 to 10.0.0.0/8,
+# 172.16.0.0/12, 169.254.0.0/16 incl. metadata 169.254.169.254; a
+# launchd daemon re-arms it at boot). An L7 domain-allowlist proxy
+# is on the v2 hardening list; until then VM egress is RFC1918-
+# blocked but otherwise open.
 #
-# That gap is intentional for v1 — customer CI workflows
-# legitimately reach a long tail of third-party hosts, so any
-# closed allowlist would break real workloads. The real VM
-# egress gate lives on the Mac mini itself as a pfctl ruleset
-# installed by `macos-host-bootstrap`'s
-# `installVMEgressFirewall` step: it drops VM-source packets
-# (vmnet 192.168.64.0/22) destined for 10.0.0.0/8, 172.16.0.0/12,
-# and 169.254.0.0/16 (incl. cloud metadata 169.254.169.254). A
-# launchd daemon re-arms the ruleset at every host boot so the
-# filter survives reboots. An L7 domain-allowlist proxy is on
-# the v2 hardening list; until then VM egress is RFC1918-blocked
-# but otherwise unconstrained on the public internet.
+# The dispatch egress (reaching the in-cluster server) is split into
+# `runners-dispatch-egress` below precisely so a server rollout
+# cannot perturb the egress program of a Pod that is mid-job. See
+# that policy for the full rationale.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -217,11 +218,15 @@ spec:
           port: 53
         - protocol: TCP
           port: 53
-    # Public internet egress for HTTP(S) — required for the GH
-    # Actions runner binary to reach api.github.com, the actions
-    # cache, and the customer's package registries during builds.
-    # An L7 allowlist proxy (deferred to v2 hardening) tightens
-    # this; for v1 we accept "all of HTTPS".
+    # Public internet egress for HTTP(S): the GH Actions runner
+    # reaches api.github.com, the actions cache, and the customer's
+    # package registries through here. This rule has no churning
+    # peer (a pure ipBlock) and lives in this all-runners policy
+    # whose selected-Pod set is constant across deploys, so a
+    # server rollout never forces Cilium to regenerate the egress
+    # datapath of a mid-job Pod and drop its connection to GitHub.
+    # An L7 allowlist proxy (deferred to v2 hardening) tightens the
+    # `0.0.0.0/0` later.
     - to:
         - ipBlock:
             cidr: 0.0.0.0/0
@@ -236,14 +241,57 @@ spec:
           port: 443
         - protocol: TCP
           port: 80
-    # In-cluster Tuist server. Linux runner Pods (CNI-attached)
-    # call the dispatch endpoint via the in-cluster Service URL
-    # because Hetzner Cloud LBs don't hairpin — they can't reach
-    # the public ingress IP from inside the cluster. macOS Tart
-    # VMs use the public path (vmnet bypasses CNI), so this rule
-    # is essentially "Linux runners only," scoped to the server's
-    # Pod label so it doesn't widen access to ClickHouse / Postgres
-    # / Kura on the cluster network.
+---
+# Dispatch-egress policy: lets a runner Pod reach the in-cluster
+# Tuist server's dispatch endpoint. Split out from the base policy
+# and scoped to IDLE Pods only (those without a
+# `tuist.dev/runner-pool-owner` label).
+#
+# Why split, and why idle-only:
+#   The server Deployment rolls on every deploy (its image tag is
+#   `sha-<commit>`, set on every `helm upgrade`), so a
+#   `podSelector: component=server` rule resolves to a peer set
+#   whose identities change on every deploy. If a Pod that is
+#   mid-job were selected by that rule, Cilium would regenerate the
+#   Pod's egress datapath when the server rolled, dropping the
+#   in-flight runner's long-lived connection to GitHub. GitHub
+#   reports that as "runner lost communication" and fails the job.
+#   Linux kata Pods route GitHub egress through CNI (macOS Tart VMs
+#   do not), so they are the ones exposed.
+#
+#   A claimed Pod carries `tuist.dev/runner-pool-owner=<account>`,
+#   stamped by the server at JIT-mint time, before the Pod execs the
+#   runner and connects to GitHub. Excluding owned Pods here means a
+#   mid-job Pod is selected only by the constant base policy above,
+#   so a server rollout cannot perturb its egress. Idle Pods (still
+#   polling, no owner label) keep dispatch egress; the occasional
+#   regeneration is harmless to them (they just retry the poll).
+#
+#   Tightening side-effect: a running customer job can no longer
+#   reach the internal dispatch API at all, which is the correct
+#   posture.
+#
+# Linux runners only in practice: Hetzner Cloud LBs don't hairpin,
+# so CNI Pods hit the in-cluster Service URL, while macOS uses the
+# public path (vmnet bypasses CNI). Scoped to the server's Pod
+# label so it doesn't widen access to ClickHouse / Postgres / Kura.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "tuist.componentName" (dict "root" . "component" "runners-dispatch-egress") }}
+  namespace: {{ $namespace | quote }}
+  labels:
+    {{- include "tuist.labels" . | nindent 4 }}
+    app.kubernetes.io/component: runners
+spec:
+  podSelector:
+    matchLabels:
+      tuist.dev/runner: "true"
+    matchExpressions:
+      - key: tuist.dev/runner-pool-owner
+        operator: DoesNotExist
+  policyTypes: [Egress]
+  egress:
     - to:
         - namespaceSelector:
             matchLabels:

--- a/infra/runners-controller/AGENTS.md
+++ b/infra/runners-controller/AGENTS.md
@@ -10,7 +10,12 @@ independent workqueues:
 - **`RunnerPoolReconciler`** — converges Pods + SAs to match
   `spec.replicas`. Idle Pods (those without the
   `tuist.dev/runner-pool-owner` label) are the only ones eligible for
-  scale-down deletion; runners mid-job are never killed.
+  scale-down deletion; runners mid-job are never killed. It also owns
+  a `tuist.dev/runner-pool-drain` finalizer: deleting or renaming a
+  RunnerPool (e.g. a helm pool-topology change) would otherwise let
+  GC cascade-delete the owned Pods — busy ones included — so the
+  finalizer holds the CR Terminating, reaps only idle Pods, and waits
+  for mid-job Pods to finish their single-shot job before releasing.
 
 - **`AutoscalerReconciler`** — on a 5-second cadence, calls the
   server's `/api/internal/runners/desired_replicas` endpoint and

--- a/infra/runners-controller/controllers/autoscaler_controller.go
+++ b/infra/runners-controller/controllers/autoscaler_controller.go
@@ -92,6 +92,13 @@ func (r *AutoscalerReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return ctrl.Result{}, err
 	}
 
+	if !pool.DeletionTimestamp.IsZero() {
+		// Pool is being drained by the RunnerPoolReconciler's
+		// finalizer. Don't patch replicas on a Terminating CR, and
+		// don't requeue — the drain owns its lifecycle from here.
+		return ctrl.Result{}, nil
+	}
+
 	if pool.Spec.Autoscaling == nil || !pool.Spec.Autoscaling.Enabled {
 		// Pool opted out (or never opted in) — don't requeue.
 		// A future patch that flips `enabled` true will trigger

--- a/infra/runners-controller/controllers/runnerpool_controller.go
+++ b/infra/runners-controller/controllers/runnerpool_controller.go
@@ -24,6 +24,13 @@ import (
 	"github.com/tuist/tuist/infra/runners-controller/internal/podtemplate"
 )
 
+// runnerPoolFinalizer gates RunnerPool deletion on a graceful drain
+// of in-flight runners. Without it, deleting (or renaming, via a
+// helm pool-topology change) a RunnerPool would let Kubernetes GC
+// cascade-delete the owned Pods, killing runners mid-job. See
+// reconcileDelete.
+const runnerPoolFinalizer = "tuist.dev/runner-pool-drain"
+
 // RunnerPoolReconciler maintains a fleet of runner Pods + per-Pod
 // ServiceAccounts. Pods are owned directly by the RunnerPool (no
 // RunnerAssignment intermediate). When a Pod hits a terminal
@@ -68,6 +75,23 @@ func (r *RunnerPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 			return ctrl.Result{}, nil
 		}
 		return ctrl.Result{}, err
+	}
+
+	// Graceful drain on delete/rename. A helm upgrade that drops or
+	// renames a RunnerPool deletes the CR; because Pods carry an owner
+	// reference to it, Kubernetes GC would cascade-delete them, busy
+	// or not. The finalizer holds the CR in etcd (GC leaves owned Pods
+	// alone while the owner still exists) until reconcileDelete has
+	// drained the pool: idle Pods deleted now, mid-job Pods left to
+	// finish their single-shot job. Only then is the finalizer
+	// dropped, letting the CR and any remaining terminal Pods/SAs GC.
+	if !pool.DeletionTimestamp.IsZero() {
+		return r.reconcileDelete(ctx, pool)
+	}
+	if controllerutil.AddFinalizer(pool, runnerPoolFinalizer) {
+		if err := r.Update(ctx, pool); err != nil {
+			return ctrl.Result{}, fmt.Errorf("add drain finalizer: %w", err)
+		}
 	}
 
 	// Track image rolls. The server-side drain endpoint reads
@@ -209,6 +233,64 @@ func (r *RunnerPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	// missed events. Pod-event-driven reconcile via Owns() is the
 	// primary trigger; this is the catch-all.
 	return ctrl.Result{RequeueAfter: 60 * time.Second}, nil
+}
+
+// reconcileDelete drains a RunnerPool that's being deleted before
+// releasing the finalizer. Idle Pods are reaped immediately; Pods
+// running a job (carrying the `tuist.dev/runner-pool-owner` label)
+// are left to finish their single-shot lifecycle. The CR stays
+// Terminating until no live Pod remains, so GC never cascade-deletes
+// a mid-job runner. Terminal Pods and the per-Pod SAs are collected
+// by GC alongside the CR once the finalizer clears.
+func (r *RunnerPoolReconciler) reconcileDelete(ctx context.Context, pool *tuistv1.RunnerPool) (ctrl.Result, error) {
+	logger := log.FromContext(ctx).WithValues("pool", client.ObjectKeyFromObject(pool))
+
+	if !controllerutil.ContainsFinalizer(pool, runnerPoolFinalizer) {
+		// Already drained, or never managed by us — let GC proceed.
+		return ctrl.Result{}, nil
+	}
+
+	pods := &corev1.PodList{}
+	if err := r.List(ctx, pods,
+		client.InNamespace(pool.Namespace),
+		client.MatchingLabels{"tuist.dev/runner-pool": pool.Name},
+	); err != nil {
+		return ctrl.Result{}, fmt.Errorf("list pods: %w", err)
+	}
+
+	running := 0
+	drainedIdle := 0
+	for i := range pods.Items {
+		p := &pods.Items[i]
+		switch {
+		case !isAlive(p):
+			// Terminal or already deleting — GC takes it with the CR.
+		case isIdle(p):
+			if err := r.reapRunner(ctx, p); err != nil {
+				logger.Error(err, "drain idle pod; will retry", "pod", p.Name)
+				return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
+			}
+			drainedIdle++
+		default:
+			running++
+		}
+	}
+
+	if running > 0 {
+		// Mid-job runners still finishing. Hold the finalizer and
+		// re-check; single-shot Pods turn over to terminal on exit.
+		// Bounded in practice by the GitHub Actions job timeout.
+		logger.Info("draining pool; waiting on in-flight runners",
+			"running", running, "drainedIdle", drainedIdle)
+		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
+	}
+
+	controllerutil.RemoveFinalizer(pool, runnerPoolFinalizer)
+	if err := r.Update(ctx, pool); err != nil {
+		return ctrl.Result{}, fmt.Errorf("remove drain finalizer: %w", err)
+	}
+	logger.Info("pool drained; finalizer released", "drainedIdle", drainedIdle)
+	return ctrl.Result{}, nil
 }
 
 // createRunner provisions one Pod + per-Pod ServiceAccount pair,

--- a/infra/runners-controller/controllers/runnerpool_controller_test.go
+++ b/infra/runners-controller/controllers/runnerpool_controller_test.go
@@ -6,11 +6,13 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	tuistv1 "github.com/tuist/tuist/infra/runners-controller/api/v1alpha1"
 )
@@ -349,6 +351,98 @@ func TestReconcile_LeavesImageRolledAtAloneWhenImageUnchanged(t *testing.T) {
 	}
 	if !updated.Status.ImageRolledAt.Equal(&priorRoll) {
 		t.Fatalf("ImageRolledAt = %v, expected unchanged %v", updated.Status.ImageRolledAt, priorRoll)
+	}
+}
+
+// TestReconcile_DrainsPoolOnDeleteWithoutKillingRunningPod is the
+// regression test for the cascade-GC kill: a helm upgrade that drops
+// or renames a RunnerPool deletes the CR, and because Pods carry an
+// owner reference to it, Kubernetes GC would otherwise cascade-delete
+// every Pod the pool owns — including runners mid-job. The drain
+// finalizer must hold the CR Terminating while a mid-job Pod is still
+// running, reap only the idle Pods, and release the CR once the last
+// in-flight runner has exited.
+func TestReconcile_DrainsPoolOnDeleteWithoutKillingRunningPod(t *testing.T) {
+	scheme := mustScheme(t)
+	image := "ghcr.io/tuist/tuist-runner@sha256:current"
+	pool := newPool("p", image, 2)
+
+	// Idle pod: warm-polling, no owner label — safe to reap on drain.
+	idle := newRunnerPod("p-runner-idle", image, corev1.PodRunning, "p")
+	idleSA := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "p-runner-idle", Namespace: "tuist-runners"}}
+	// Mid-job pod: the server stamped the owner label at claim time —
+	// must survive the drain.
+	busy := newRunnerPod("p-runner-busy", image, corev1.PodRunning, "p")
+	busy.Labels["tuist.dev/runner-pool-owner"] = "acme"
+	busySA := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "p-runner-busy", Namespace: "tuist-runners"}}
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(pool, idle, idleSA, busy, busySA).
+		WithStatusSubresource(&tuistv1.RunnerPool{}).
+		Build()
+
+	r := &RunnerPoolReconciler{Client: c, Scheme: scheme, DispatchURL: "http://dispatch"}
+	ctx := context.Background()
+
+	// First reconcile installs the drain finalizer.
+	if _, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: nn(pool.Namespace, pool.Name)}); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	got := &tuistv1.RunnerPool{}
+	if err := c.Get(ctx, nn(pool.Namespace, pool.Name), got); err != nil {
+		t.Fatalf("get pool: %v", err)
+	}
+	if !controllerutil.ContainsFinalizer(got, runnerPoolFinalizer) {
+		t.Fatalf("expected drain finalizer to be installed")
+	}
+
+	// helm-style delete: the finalizer holds the CR Terminating.
+	if err := c.Delete(ctx, got); err != nil {
+		t.Fatalf("delete pool: %v", err)
+	}
+
+	// Drain reconcile: idle pod reaped, mid-job pod survives, CR remains.
+	if _, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: nn(pool.Namespace, pool.Name)}); err != nil {
+		t.Fatalf("drain reconcile: %v", err)
+	}
+	if err := c.Get(ctx, nn("tuist-runners", "p-runner-busy"), &corev1.Pod{}); err != nil {
+		t.Fatalf("expected mid-job pod to survive drain: %v", err)
+	}
+	if err := c.Get(ctx, nn("tuist-runners", "p-runner-idle"), &corev1.Pod{}); err == nil {
+		t.Fatalf("expected idle pod to be reaped during drain")
+	}
+	if err := c.Get(ctx, nn(pool.Namespace, pool.Name), got); err != nil {
+		t.Fatalf("expected pool to remain Terminating while a runner is mid-job: %v", err)
+	}
+
+	// The job finishes: the single-shot pod exits and goes away. With
+	// no live runner left, the next reconcile finds running == 0 and
+	// releases the finalizer, so the CR (and the now-unblocked GC) can
+	// finalize.
+	busyLive := &corev1.Pod{}
+	if err := c.Get(ctx, nn("tuist-runners", "p-runner-busy"), busyLive); err != nil {
+		t.Fatalf("get busy pod: %v", err)
+	}
+	if err := c.Delete(ctx, busyLive); err != nil {
+		t.Fatalf("remove finished busy pod: %v", err)
+	}
+
+	if _, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: nn(pool.Namespace, pool.Name)}); err != nil {
+		t.Fatalf("final drain reconcile: %v", err)
+	}
+	// The controller's contract is to release the finalizer once the
+	// pool is drained; the apiserver then GCs the CR. Assert the
+	// finalizer is gone (the CR is either deleted or no longer holds
+	// it) rather than the fake client's GC behaviour.
+	drained := &tuistv1.RunnerPool{}
+	switch err := c.Get(ctx, nn(pool.Namespace, pool.Name), drained); {
+	case apierrors.IsNotFound(err):
+		// CR collected — fully drained.
+	case err != nil:
+		t.Fatalf("get pool after drain: %v", err)
+	case controllerutil.ContainsFinalizer(drained, runnerPoolFinalizer):
+		t.Fatalf("expected drain finalizer to be released after the drain completed")
 	}
 }
 


### PR DESCRIPTION
## Invariant

**A runner mid-job survives a server deploy.** It doesn't matter whose job it is — Tuist's own deploy runner or a customer's CI — they're identical pods on the same Linux fleet. Today a production server deploy violates this, which is what makes deploys fail ("the self-hosted runner lost communication with the server") and would take customer CI jobs down with them as the fleet ramps. This PR closes the two independent ways a deploy can kill an in-flight runner.

## Vector 1 — egress NetworkPolicy coupled to the server rollout

The `tuist-runners` egress NetworkPolicy allowed the dispatch path with `podSelector: app.kubernetes.io/component=server`. The server Deployment rolls on **every** deploy (`--set server.image.tag=sha-<commit>`, even for a CSS-only change), so that rule's resolved peer set changed on every deploy, and because it lived in the same policy that selects every `tuist.dev/runner=true` pod, Cilium regenerated the egress datapath of every runner pod — including mid-job ones — dropping the runner's connection to GitHub.

Why it surfaced now and only on Linux: macOS Tart VMs route real egress outside CNI (gated by pfctl on the host), so this policy is decorative for them. Linux kata pods route GitHub egress through CNI, so it's their actual gate. The Linux fleet inherited the macOS-era policy and it only became load-bearing once that fleet went live.

**Fix:** split the policy so the rules a mid-job runner depends on never change on a deploy.
- `runners-default-deny` (all runner pods): ingress-deny + DNS + public-internet egress. Constant selected-pod set and peer set.
- `runners-dispatch-egress` (new; idle pods only, via `tuist.dev/runner-pool-owner DoesNotExist`): the churning server-dispatch rule, now only able to regenerate idle pods (harmless — they retry the poll).

A claimed pod gets the owner label before it execs the runner, so a mid-job pod is selected only by the constant base policy. Side benefit: a running customer job can no longer reach the internal dispatch API.

## Vector 2 — ownerReference GC when a pool CR is deleted/renamed

Runner pods carry an owner reference to their `RunnerPool` CR. A helm upgrade that drops or renames a pool (the shape-keyed pool migration did exactly this, and a rollback crossing that boundary would too) deletes the CR, and Kubernetes GC then cascade-deletes every pod the pool owns — busy or not. This bypasses the reconciler's busy-pod guard entirely (GC is apiserver-level) and the NetworkPolicy split, so it's a second, independent kill path.

**Fix:** a `tuist.dev/runner-pool-drain` finalizer on the RunnerPool. On deletion the reconciler holds the CR Terminating (GC leaves owned pods alone while the owner still exists), reaps only idle pods, and waits for mid-job pods to finish their single-shot lifecycle before releasing the finalizer — at which point the CR and any remaining terminal pods/SAs GC normally. The autoscaler skips Terminating pools so it doesn't fight the drain. This covers the helm (background) deletion path; a manual `kubectl delete --cascade=foreground` on a pool still bypasses the drain (documented).

## Impact

- Production (and any cluster running the Linux fleet) can deploy the server without dropping in-flight runner jobs — Tuist's deploys and customer CI alike.
- No change to idle-pod behavior or to the macOS fleet.

## Validation

- `helm template` renders cleanly (exit 0) for `values-managed-production` and `values-managed-staging`; both runner NetworkPolicies render with the expected selectors.
- `go test ./...`, `go vet ./...`, and `gofmt` all pass for the runners-controller; new test `TestReconcile_DrainsPoolOnDeleteWithoutKillingRunningPod` covers the drain (idle reaped, mid-job pod held + survives, finalizer released once the runner exits).
- Vector 1's final causal step (Cilium *regenerating* the egress program actually *dropping* the established GitHub connection) is the one piece not provable from the repo. Recommended in-cluster confirmation: start a long job on a Linux runner, run `kubectl -n tuist rollout restart deploy/tuist-tuist-server`, and confirm the runner no longer loses GitHub comms when the server pods cycle.

## Note

This makes "the deploy job runs on a runner inside the cluster it mutates" a non-issue for correctness (the deploy runner is just another protected mid-job pod). Hosting the deployer on the fleet remains a bootstrap-recovery question (don't make the tool that recovers the fleet depend on the fleet), which is an operational call tracked separately, not a correctness fix.
