### PR TITLE
fix(server): keep Kura cache grants compact

### DIFF
--- a/server/lib/tuist/authentication.ex
+++ b/server/lib/tuist/authentication.ex
@@ -118,9 +118,8 @@ defmodule Tuist.Authentication do
   def encode_and_sign(resource, claims \\ %{}, opts \\ []) do
     claims =
       claims
-      |> Map.put("projects", Cache.accessible_project_handles(resource, recent: 5))
-      |> Map.put("accounts", Cache.accessible_account_handles(resource))
-      |> Map.put("cache_grants", Cache.cache_grants(resource, recent: 5))
+      |> Map.delete("accounts")
+      |> Map.merge(Cache.embedded_cache_claims(resource, recent: 5))
 
     Tuist.Guardian.encode_and_sign(resource, claims, opts)
   end

--- a/server/lib/tuist/cache.ex
+++ b/server/lib/tuist/cache.ex
@@ -37,6 +37,22 @@ defmodule Tuist.Cache do
     }
   end
 
+  def embedded_cache_claims(resource, opts \\ [])
+
+  def embedded_cache_claims(%User{} = user, opts), do: project_only_embedded_cache_claims(user, opts)
+
+  def embedded_cache_claims(%AuthenticatedAccount{issued_by: %User{}} = subject, opts) do
+    project_only_embedded_cache_claims(subject, opts)
+  end
+
+  def embedded_cache_claims(resource, opts) do
+    %{
+      "accounts" => accessible_account_handles(resource),
+      "projects" => accessible_project_handles(resource, opts),
+      "cache_grants" => cache_grants(resource, opts)
+    }
+  end
+
   def accessible_account_handles(%User{} = user) do
     user
     |> accessible_accounts()
@@ -126,6 +142,19 @@ defmodule Tuist.Cache do
       |> Enum.map(& &1.account)
 
     Enum.reject([personal_account | organization_accounts], &is_nil/1)
+  end
+
+  defp project_only_embedded_cache_claims(resource, opts) do
+    %{
+      "projects" => accessible_project_handles(resource, opts),
+      "cache_grants" => %{
+        "account" => %{"read" => [], "write" => []},
+        "project" => %{
+          "read" => project_cache_handles(resource, :read, opts),
+          "write" => project_cache_handles(resource, :write, opts)
+        }
+      }
+    }
   end
 
   defp account_cache_handles(%User{} = user, _action), do: accessible_account_handles(user)

--- a/server/lib/tuist/oauth/token_generator.ex
+++ b/server/lib/tuist/oauth/token_generator.ex
@@ -47,11 +47,7 @@ defmodule Tuist.OAuth.TokenGenerator do
         issued_by: user
       }
 
-      claims =
-        claims
-        |> Map.put("projects", Cache.accessible_project_handles(cache_subject, recent: 5))
-        |> Map.put("accounts", Cache.accessible_account_handles(cache_subject))
-        |> Map.put("cache_grants", Cache.cache_grants(cache_subject, recent: 5))
+      claims = Map.merge(claims, Cache.embedded_cache_claims(cache_subject, recent: 5))
 
       {:ok, jwt_token, _claims} =
         Tuist.Guardian.encode_and_sign(user.account, claims,

--- a/server/test/tuist/authentication_test.exs
+++ b/server/test/tuist/authentication_test.exs
@@ -235,14 +235,14 @@ defmodule Tuist.AuthenticationTest do
       assert is_list(claims["projects"])
       assert "#{user.account.name}/#{project1.name}" in claims["projects"]
       assert "#{user.account.name}/#{project2.name}" in claims["projects"]
-      assert claims["accounts"] == [user.account.name]
-      assert claims["cache_grants"]["account"]["read"] == [user.account.name]
-      assert claims["cache_grants"]["account"]["write"] == [user.account.name]
+      refute Map.has_key?(claims, "accounts")
+      assert claims["cache_grants"]["account"]["read"] == []
+      assert claims["cache_grants"]["account"]["write"] == []
       assert "#{user.account.name}/#{project1.name}" in claims["cache_grants"]["project"]["read"]
       assert "#{user.account.name}/#{project2.name}" in claims["cache_grants"]["project"]["write"]
     end
 
-    test "adds empty projects claim and keeps personal account access when user has no projects" do
+    test "adds empty projects claim without embedding account access when user has no projects" do
       # Given
       user = AccountsFixtures.user_fixture()
 
@@ -257,8 +257,9 @@ defmodule Tuist.AuthenticationTest do
 
       # Then
       assert claims["projects"] == []
-      assert claims["accounts"] == [user.account.name]
-      assert claims["cache_grants"]["account"]["read"] == [user.account.name]
+      refute Map.has_key?(claims, "accounts")
+      assert claims["cache_grants"]["account"]["read"] == []
+      assert claims["cache_grants"]["account"]["write"] == []
       assert claims["cache_grants"]["project"]["read"] == []
       assert claims["cache_grants"]["project"]["write"] == []
     end
@@ -282,12 +283,53 @@ defmodule Tuist.AuthenticationTest do
 
       # Then
       assert "#{organization.account.name}/#{project.name}" in claims["projects"]
-      assert Enum.sort(claims["accounts"]) == Enum.sort([user.account.name, organization.account.name])
-
-      assert Enum.sort(claims["cache_grants"]["account"]["read"]) ==
-               Enum.sort([user.account.name, organization.account.name])
+      refute Map.has_key?(claims, "accounts")
+      assert claims["cache_grants"]["account"]["read"] == []
+      assert claims["cache_grants"]["account"]["write"] == []
 
       assert "#{organization.account.name}/#{project.name}" in claims["cache_grants"]["project"]["read"]
+    end
+
+    test "keeps user token size independent from accessible account count" do
+      # Given
+      user = AccountsFixtures.user_fixture()
+
+      for _ <- 1..20 do
+        organization = AccountsFixtures.organization_fixture()
+        Accounts.add_user_to_organization(user, organization, role: :admin)
+      end
+
+      # When
+      {:ok, token, claims} =
+        Authentication.encode_and_sign(
+          user,
+          %{email: user.email},
+          token_type: :access,
+          ttl: {1, :hour}
+        )
+
+      # Then
+      refute Map.has_key?(claims, "accounts")
+      assert claims["cache_grants"]["account"]["read"] == []
+      assert claims["cache_grants"]["account"]["write"] == []
+      assert byte_size(token) < 5_000
+    end
+
+    test "drops stale account claims when signing user tokens" do
+      # Given
+      user = AccountsFixtures.user_fixture()
+
+      # When
+      {:ok, _token, claims} =
+        Authentication.encode_and_sign(
+          user,
+          %{"accounts" => ["stale-account"], email: user.email},
+          token_type: :access,
+          ttl: {1, :hour}
+        )
+
+      # Then
+      refute Map.has_key?(claims, "accounts")
     end
 
     test "does not grant account-scoped access to project-scoped subjects" do
@@ -329,7 +371,7 @@ defmodule Tuist.AuthenticationTest do
       assert claims["email"] == user.email
       assert claims["custom_claim"] == "custom_value"
       assert is_list(claims["projects"])
-      assert is_list(claims["accounts"])
+      refute Map.has_key?(claims, "accounts")
       assert is_map(claims["cache_grants"])
     end
   end

--- a/server/test/tuist/oauth/token_generator_test.exs
+++ b/server/test/tuist/oauth/token_generator_test.exs
@@ -3,6 +3,7 @@ defmodule Tuist.OAuth.TokenGeneratorTest do
   use Mimic
 
   alias Boruta.Ecto.Token
+  alias Tuist.Accounts
   alias Tuist.Accounts.AuthenticatedAccount
   alias Tuist.OAuth.Clients
   alias Tuist.OAuth.TokenGenerator
@@ -39,6 +40,48 @@ defmodule Tuist.OAuth.TokenGeneratorTest do
       assert claims["type"] == "account"
       assert claims["all_projects"] == true
       assert is_map(claims["cache_grants"])
+    end
+
+    test "does not embed account-scoped cache grants for user-issued OAuth tokens", %{
+      user: user,
+      project: project
+    } do
+      token = %Token{
+        sub: Integer.to_string(user.id),
+        client_id: "test-client-id"
+      }
+
+      jwt_token = TokenGenerator.generate(:access_token, token)
+
+      {:ok, claims} = Tuist.Guardian.decode_and_verify(jwt_token)
+      project_handle = "#{user.account.name}/#{project.name}"
+
+      refute Map.has_key?(claims, "accounts")
+      assert claims["cache_grants"]["account"]["read"] == []
+      assert claims["cache_grants"]["account"]["write"] == []
+      assert project_handle in claims["cache_grants"]["project"]["read"]
+      assert project_handle in claims["cache_grants"]["project"]["write"]
+    end
+
+    test "keeps OAuth token size independent from accessible account count", %{user: user} do
+      for _ <- 1..20 do
+        organization = AccountsFixtures.organization_fixture()
+        Accounts.add_user_to_organization(user, organization, role: :admin)
+      end
+
+      token = %Token{
+        sub: Integer.to_string(user.id),
+        client_id: "test-client-id"
+      }
+
+      jwt_token = TokenGenerator.generate(:access_token, token)
+
+      {:ok, claims} = Tuist.Guardian.decode_and_verify(jwt_token)
+
+      refute Map.has_key?(claims, "accounts")
+      assert claims["cache_grants"]["account"]["read"] == []
+      assert claims["cache_grants"]["account"]["write"] == []
+      assert byte_size(jwt_token) < 5_000
     end
 
     test "includes user_id claim", %{user: user} do


### PR DESCRIPTION
Resolves N/A

User and user-issued OAuth tokens were embedding every accessible account handle in `accounts` plus `cache_grants.account.read` and `cache_grants.account.write`. For users with thousands of organization memberships, that made JWTs hundreds of KB large, which can break client networking and header forwarding before Kura sees the request.

This keeps those tokens compact by embedding only recent project cache grants for the Kura hot path. Account-scoped grants are omitted from user-issued tokens, stale `accounts` claims are dropped during refresh, and explicit account or project token subjects keep their existing scoped claim shape.

Kura already falls back to introspection for account-scoped cache authorization and caches successful introspection responses, so account-wide Kura access stays server-verified without making every client JWT scale with membership count.

### How to test locally

- `mix deps.get`
- `mix format lib/tuist/cache.ex lib/tuist/authentication.ex lib/tuist/oauth/token_generator.ex test/tuist/authentication_test.exs test/tuist/oauth/token_generator_test.exs`
- `MIX_ENV=test mix ecto.reset`
- `mix test test/tuist/authentication_test.exs test/tuist/oauth/token_generator_test.exs`
