### PR TITLE
ci(infra): run server deploy jobs on external runners to break the deploy deadlock

### DIFF
--- a/.github/workflows/server-deployment.yml
+++ b/.github/workflows/server-deployment.yml
@@ -174,7 +174,7 @@ jobs:
     needs: build
     # `build` is skipped when image_tag is supplied - keep running.
     if: always() && (needs.build.result == 'success' || needs.build.result == 'skipped')
-    runs-on: tuist-production-linux
+    runs-on: namespace-profile-default
     environment:
       name: server-k8s-${{ inputs.environment }}
     concurrency:
@@ -240,7 +240,7 @@ jobs:
     name: Tailscale operator chart (${{ inputs.environment }})
     needs: build
     if: always() && (needs.build.result == 'success' || needs.build.result == 'skipped')
-    runs-on: tuist-production-linux
+    runs-on: namespace-profile-default
     environment:
       name: server-k8s-${{ inputs.environment }}
     concurrency:
@@ -317,7 +317,7 @@ jobs:
     name: Platform chart (${{ inputs.environment }})
     needs: build
     if: always() && (needs.build.result == 'success' || needs.build.result == 'skipped')
-    runs-on: tuist-production-linux
+    runs-on: namespace-profile-default
     environment:
       name: server-k8s-${{ inputs.environment }}
     concurrency:
@@ -382,7 +382,7 @@ jobs:
     # platform settings (including CNPG CRDs the Tuist chart consumes for
     # the in-cluster Postgres rollout) land before the app chart upgrade.
     if: always() && (needs.build.result == 'success' || needs.build.result == 'skipped') && needs.observability-install.result == 'success' && needs.tailscale-operator-install.result == 'success' && needs.platform-install.result == 'success'
-    runs-on: tuist-production-linux
+    runs-on: namespace-profile-default
     environment:
       name: server-k8s-${{ inputs.environment }}
       url: https://${{ inputs.environment == 'production' && 'tuist.dev' || format('{0}.tuist.dev', inputs.environment) }}


### PR DESCRIPTION
## Why (the deadlock)

Production deploys are wedged, and the fix for the underlying bug is stuck behind the bug.

No production deploy has completed since #11038 merged at 16:45:
- #11038's own production deploy — failed
- the `runners-controller@0.6.1` release deploy — failed
- manual `workflow_dispatch` retries — failed

All with the same `the self-hosted runner lost communication with the server`. So the cluster is still running the **old coupled NetworkPolicy** and the **old controller**: the decoupled-egress policy ships in #11038's chart and the drain logic ships in controller 0.6.1, but neither can land because the deploy that would apply them gets its runner killed first. The "Recover interrupted Helm release" step's `helm rollback` also reverts any partially-applied policy back to the pre-fix revision.

### Refined root cause

The runner dies at varying **early** steps (Recover, Clean up stale migration Jobs) — *before* `helm upgrade` ever runs. So the trigger is not the deploy's own server rollout (my earlier framing). It's **background production server-pod churn** (HPA, traffic-driven restarts) regenerating every runner Pod's egress under the still-live coupled NetworkPolicy (the dispatch rule's `podSelector: component=server` peer set changes whenever server pods change). A 10-minute on-fleet deploy reliably overlaps one of those churns; staging's idle server doesn't churn, which is why staging deploys on the same runner survive. The consistent ~10m1s job duration is GitHub's lost-communication detection window, not when the runner actually died.

## What

Move `deploy`, `observability-install`, `tailscale-operator-install`, and `platform-install` from `tuist-production-linux` back to `namespace-profile-default`. `build` already runs on a Namespace runner and is untouched.

An external runner lives outside the cluster it mutates, so it can't be killed by that NetworkPolicy regen. One external deploy completes the full chart (decoupled policy) + controller 0.6.1; after that, on-fleet runners are protected by the very fix this unblocks.

This is the known-good pre-#10886 configuration — these four jobs ran on `namespace-profile-default` before that PR migrated them to the in-house fleet.

## After this lands

1. Merge → the production cascade runs on external runners and completes, applying #11038's policy + controller 0.6.1.
2. Confirm on-fleet runners survive a server rollout (the in-cluster check from #11038: `kubectl -n tuist rollout restart deploy/tuist-tuist-server` while a Linux job runs).
3. Follow-up PR to move these jobs back to `tuist-production-linux` — or keep them external on the bootstrap-recovery argument (don't make the tool that recovers the fleet depend on the fleet being healthy).

## Validation

Minimal diff: four `runs-on` lines, no logic change. The target runner profile is already in use elsewhere in the repo.
