### PR TITLE
chore(kura): repair e2e shellspec suite and add test runner tasks

### DIFF
--- a/kura/docker-compose.yml
+++ b/kura/docker-compose.yml
@@ -1,5 +1,6 @@
 services:
   kura-us:
+    image: ${KURA_IMAGE:-}
     build:
       context: .
       dockerfile: Dockerfile
@@ -49,6 +50,7 @@ services:
           - kura-ring.kura.internal
 
   kura-eu:
+    image: ${KURA_IMAGE:-}
     build:
       context: .
       dockerfile: Dockerfile
@@ -83,6 +85,7 @@ services:
           - kura-ring.kura.internal
 
   kura-ap:
+    image: ${KURA_IMAGE:-}
     build:
       context: .
       dockerfile: Dockerfile

--- a/kura/mise.toml
+++ b/kura/mise.toml
@@ -11,4 +11,4 @@ run = "ulimit -n 65536 && cargo test"
 
 [tasks.test-e2e]
 description = "Run the end-to-end shellspec suite against the Dockerized service"
-run = ["docker compose up --build -d", "shellspec"]
+run = "shellspec"

--- a/kura/mise.toml
+++ b/kura/mise.toml
@@ -4,3 +4,11 @@ shellspec = "0.28.1"
 bazel = "9.1.0"
 "aqua:facebook/buck2" = "2026-04-15"
 node = "25.9.0"
+
+[tasks.test-unit]
+description = "Run the Rust unit tests with a raised file-descriptor limit (RocksDB-backed tests open many fds in parallel)"
+run = "ulimit -n 65536 && cargo test"
+
+[tasks.test-e2e]
+description = "Run the end-to-end shellspec suite against the Dockerized service"
+run = ["docker compose up --build -d", "shellspec"]

--- a/kura/mise.toml
+++ b/kura/mise.toml
@@ -4,11 +4,3 @@ shellspec = "0.28.1"
 bazel = "9.1.0"
 "aqua:facebook/buck2" = "2026-04-15"
 node = "25.9.0"
-
-[tasks.test-unit]
-description = "Run the Rust unit tests with a raised file-descriptor limit (RocksDB-backed tests open many fds in parallel)"
-run = "ulimit -n 65536 && cargo test"
-
-[tasks.test-e2e]
-description = "Run the end-to-end shellspec suite against the Dockerized service"
-run = "shellspec"

--- a/kura/mise/tasks/test-e2e.sh
+++ b/kura/mise/tasks/test-e2e.sh
@@ -1,5 +1,14 @@
 #!/usr/bin/env bash
-#MISE description="Run the end-to-end shellspec suite against the Dockerized service"
+#MISE description="Run the end-to-end shellspec suite against the Dockerized service (pass shellspec args through, e.g. mise run test-e2e -- -j 8)"
 set -euo pipefail
 
-shellspec
+# Build the kura image once and share it across every suite. The compose services
+# declare `image: ${KURA_IMAGE:-}` (empty by default, so local `docker compose up`
+# keeps its per-project image naming), so exporting a fixed KURA_IMAGE makes every
+# suite -- regardless of its COMPOSE_PROJECT_NAME -- resolve to this one prebuilt
+# image. No per-project rebuilds, which is what would otherwise serialize parallel
+# `-j` workers. The suites then run with KURA_E2E_SKIP_BUILD=1 and reuse it.
+export KURA_IMAGE=kura:e2e
+docker compose build
+
+KURA_E2E_SKIP_BUILD=1 shellspec "$@"

--- a/kura/mise/tasks/test-e2e.sh
+++ b/kura/mise/tasks/test-e2e.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+#MISE description="Run the end-to-end shellspec suite against the Dockerized service"
+set -euo pipefail
+
+shellspec

--- a/kura/mise/tasks/test-unit.sh
+++ b/kura/mise/tasks/test-unit.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+#MISE description="Run the Rust unit tests with a raised file-descriptor limit (RocksDB-backed tests open many fds in parallel)"
+set -euo pipefail
+
+ulimit -n 65536
+cargo test

--- a/kura/spec/e2e/clients_spec.sh
+++ b/kura/spec/e2e/clients_spec.sh
@@ -4,22 +4,22 @@ Describe 'actively supported protocol interoperability'
   Include spec/e2e/support.sh
 
   setup_suite() {
-    export COMPOSE_PROJECT_NAME="kura-clients"
-    export KURA_US_PORT=4401
-    export KURA_EU_PORT=4402
-    export KURA_AP_PORT=4403
-    export KURA_US_GRPC_PORT=5501
-    export KURA_EU_GRPC_PORT=5502
-    export KURA_AP_GRPC_PORT=5503
-    export KURA_US_URL="http://localhost:${KURA_US_PORT}"
-    export KURA_EU_URL="http://localhost:${KURA_EU_PORT}"
-    export KURA_AP_URL="http://localhost:${KURA_AP_PORT}"
-
     COMPOSE_FILES=(-f "${PROJECT_ROOT}/docker-compose.yml")
     setup_suite_tmpdir
 
+    suite_env COMPOSE_PROJECT_NAME kura-clients
+    ephemeral_ports KURA_US_PORT KURA_EU_PORT KURA_AP_PORT \
+      KURA_US_GRPC_PORT KURA_EU_GRPC_PORT KURA_AP_GRPC_PORT
+
     dc down -v --remove-orphans >/dev/null 2>&1 || true
     compose_up kura-us kura-eu kura-ap || return 1
+
+    resolve_http_node KURA_US kura-us
+    resolve_http_node KURA_EU kura-eu
+    resolve_http_node KURA_AP kura-ap
+    KURA_US_GRPC_PORT="$(resolve_host_port kura-us 50051)"
+    KURA_EU_GRPC_PORT="$(resolve_host_port kura-eu 50051)"
+    KURA_AP_GRPC_PORT="$(resolve_host_port kura-ap 50051)"
 
     wait_for_http "${KURA_US_URL}/up"
     wait_for_http "${KURA_EU_URL}/up"

--- a/kura/spec/e2e/cluster_spec.sh
+++ b/kura/spec/e2e/cluster_spec.sh
@@ -3,27 +3,27 @@
 Describe 'core cluster behaviour'
   Include spec/e2e/support.sh
 
-  setup_suite() {
-    export COMPOSE_PROJECT_NAME="kura-e2e"
-    export KURA_US_PORT=4201
-    export KURA_EU_PORT=4202
-    export KURA_AP_PORT=4203
-    export GRAFANA_PORT=3300
-    export PROMETHEUS_PORT=9190
-    export LOKI_PORT=3201
-    export TEMPO_PORT=3301
-    export OTLP_PORT=4418
-    export KURA_US_URL="http://localhost:${KURA_US_PORT}"
-    export KURA_EU_URL="http://localhost:${KURA_EU_PORT}"
-    export KURA_AP_URL="http://localhost:${KURA_AP_PORT}"
-    export GRAFANA_URL="http://localhost:${GRAFANA_PORT}"
-    export PROMETHEUS_URL="http://localhost:${PROMETHEUS_PORT}"
+  resolve_endpoints() {
+    resolve_http_node KURA_US kura-us
+    resolve_http_node KURA_EU kura-eu
+    resolve_http_node KURA_AP kura-ap
+    resolve_http_node GRAFANA grafana 3000
+    resolve_http_node PROMETHEUS prometheus 9090
+  }
 
+  setup_suite() {
     COMPOSE_FILES=(-f "${PROJECT_ROOT}/docker-compose.yml")
     setup_suite_tmpdir
 
+    suite_env COMPOSE_PROJECT_NAME kura-e2e
+    ephemeral_ports KURA_US_PORT KURA_EU_PORT KURA_AP_PORT \
+      KURA_US_GRPC_PORT KURA_EU_GRPC_PORT KURA_AP_GRPC_PORT \
+      GRAFANA_PORT PROMETHEUS_PORT LOKI_PORT TEMPO_PORT OTLP_PORT
+
     dc down -v --remove-orphans >/dev/null 2>&1 || true
     compose_up || return 1
+
+    resolve_endpoints
 
     wait_for_http "${KURA_US_URL}/up"
     wait_for_http "${KURA_EU_URL}/up"
@@ -40,6 +40,7 @@ Describe 'core cluster behaviour'
   }
 
   BeforeAll 'setup_suite'
+  Before 'resolve_endpoints'
   AfterAll 'teardown_suite'
 
   It 'syncs keyvalue entries across regions'
@@ -71,6 +72,7 @@ Describe 'core cluster behaviour'
     The variable body should eq 'xcode-binary'
 
     dc restart kura-eu >/dev/null 2>&1 || return 1
+    resolve_http_node KURA_EU kura-eu
     wait_for_http "${KURA_EU_URL}/up" || return 1
     capture_into eu_up wait_for_contains "${KURA_EU_URL}/up" '"ring_members":3' || return 1
     The variable eu_up should include '"ring_members":3'

--- a/kura/spec/e2e/discovery_spec.sh
+++ b/kura/spec/e2e/discovery_spec.sh
@@ -4,23 +4,20 @@ Describe 'DNS discovery and bootstrap'
   Include spec/e2e/support.sh
 
   setup_suite() {
-    export COMPOSE_PROJECT_NAME="kura-discovery"
-    export KURA_US_PORT=4401
-    export KURA_US_2_PORT=4402
-    export TEMPO_PORT=3303
-    export OTLP_PORT=4420
-    export KURA_US_URL="http://localhost:${KURA_US_PORT}"
-    export KURA_US_2_URL="http://localhost:${KURA_US_2_PORT}"
-
     COMPOSE_FILES=(
       -f "${PROJECT_ROOT}/docker-compose.yml"
       -f "${PROJECT_ROOT}/test/e2e/docker-compose.discovery.yml"
     )
     setup_suite_tmpdir
 
+    suite_env COMPOSE_PROJECT_NAME kura-discovery
+    ephemeral_ports KURA_US_PORT KURA_US_2_PORT KURA_US_GRPC_PORT KURA_US_2_GRPC_PORT TEMPO_PORT OTLP_PORT
+
     dc down -v --remove-orphans >/dev/null 2>&1 || true
     dc build kura-us kura-us-2 >/dev/null 2>&1
     dc up -d kura-us >/dev/null 2>&1
+
+    resolve_http_node KURA_US kura-us
 
     wait_for_http "${KURA_US_URL}/up"
     capture_into us_up wait_for_contains "${KURA_US_URL}/up" '"ring_members":1' || return 1
@@ -48,6 +45,7 @@ Describe 'DNS discovery and bootstrap'
     The variable artifact_status should eq 204
 
     dc up -d kura-us-2 >/dev/null 2>&1 || return 1
+    resolve_http_node KURA_US_2 kura-us-2
 
     wait_for_http "${KURA_US_2_URL}/up" || return 1
     capture_into us_ring wait_for_contains "${KURA_US_URL}/up" '"ring_members":2' || return 1

--- a/kura/spec/e2e/extension_spec.sh
+++ b/kura/spec/e2e/extension_spec.sh
@@ -4,22 +4,22 @@ Describe 'extension hooks'
   Include spec/e2e/support.sh
 
   setup_suite() {
-    export COMPOSE_PROJECT_NAME="kura-extension"
-    export KURA_US_PORT=4501
-    export KURA_EU_PORT=4502
-    export KURA_AP_PORT=4503
-    export KURA_US_URL="http://localhost:${KURA_US_PORT}"
-    export KURA_EU_URL="http://localhost:${KURA_EU_PORT}"
-    export KURA_AP_URL="http://localhost:${KURA_AP_PORT}"
-
     COMPOSE_FILES=(
       -f "${PROJECT_ROOT}/docker-compose.yml"
       -f "${PROJECT_ROOT}/test/e2e/docker-compose.extension.yml"
     )
     setup_suite_tmpdir
 
+    suite_env COMPOSE_PROJECT_NAME kura-extension
+    ephemeral_ports KURA_US_PORT KURA_EU_PORT KURA_AP_PORT \
+      KURA_US_GRPC_PORT KURA_EU_GRPC_PORT KURA_AP_GRPC_PORT
+
     dc down -v --remove-orphans >/dev/null 2>&1 || true
     compose_up kura-us kura-eu kura-ap || return 1
+
+    resolve_http_node KURA_US kura-us
+    resolve_http_node KURA_EU kura-eu
+    resolve_http_node KURA_AP kura-ap
 
     wait_for_http "${KURA_US_URL}/up"
     wait_for_http "${KURA_EU_URL}/up"

--- a/kura/spec/e2e/faults_spec.sh
+++ b/kura/spec/e2e/faults_spec.sh
@@ -4,19 +4,14 @@ Describe 'eventual-consistency fault recovery'
   Include spec/e2e/support.sh
 
   setup_suite() {
-    export COMPOSE_PROJECT_NAME="kura-faults"
-    export KURA_US_PORT=4501
-    export KURA_US_2_PORT=4502
-    export TEMPO_PORT=3305
-    export OTLP_PORT=4422
-    export KURA_US_URL="http://localhost:${KURA_US_PORT}"
-    export KURA_US_2_URL="http://localhost:${KURA_US_2_PORT}"
-
     COMPOSE_FILES=(
       -f "${PROJECT_ROOT}/docker-compose.yml"
       -f "${PROJECT_ROOT}/test/e2e/docker-compose.discovery.yml"
     )
     setup_suite_tmpdir
+
+    suite_env COMPOSE_PROJECT_NAME kura-faults
+    ephemeral_ports KURA_US_PORT KURA_US_2_PORT KURA_US_GRPC_PORT KURA_US_2_GRPC_PORT TEMPO_PORT OTLP_PORT
 
     dc down -v --remove-orphans >/dev/null 2>&1 || true
     dc build kura-us kura-us-2 >/dev/null 2>&1
@@ -25,6 +20,7 @@ Describe 'eventual-consistency fault recovery'
   reset_cluster() {
     dc down -v --remove-orphans >/dev/null 2>&1 || true
     dc up -d kura-us >/dev/null 2>&1
+    resolve_http_node KURA_US kura-us
     wait_for_http "${KURA_US_URL}/up"
     capture_into us_up wait_for_contains "${KURA_US_URL}/up" '"ring_members":1' || return 1
     [[ "${us_up}" == *'"ring_members":1'* ]]
@@ -56,6 +52,7 @@ Describe 'eventual-consistency fault recovery'
     The variable delete_status should eq 204
 
     dc up -d kura-us-2 >/dev/null 2>&1 || return 1
+    resolve_http_node KURA_US_2 kura-us-2
     wait_for_http "${KURA_US_2_URL}/up" || return 1
     capture_into us_ring wait_for_contains "${KURA_US_URL}/up" '"ring_members":2' || return 1
     capture_into us2_ring wait_for_contains "${KURA_US_2_URL}/up" '"ring_members":2' || return 1
@@ -73,6 +70,7 @@ Describe 'eventual-consistency fault recovery'
 
   It 'converges after a node rejoins and queued retries race with bootstrap'
     dc up -d kura-us-2 >/dev/null 2>&1 || return 1
+    resolve_http_node KURA_US_2 kura-us-2
     wait_for_http "${KURA_US_2_URL}/up" || return 1
     capture_into us_ring wait_for_contains "${KURA_US_URL}/up" '"ring_members":2' || return 1
     capture_into us2_ring wait_for_contains "${KURA_US_2_URL}/up" '"ring_members":2' || return 1
@@ -94,6 +92,7 @@ Describe 'eventual-consistency fault recovery'
     The variable artifact_status should eq 204
 
     dc up -d kura-us-2 >/dev/null 2>&1 || return 1
+    resolve_http_node KURA_US_2 kura-us-2
     wait_for_http "${KURA_US_2_URL}/up" || return 1
     capture_into us_ring_after wait_for_contains "${KURA_US_URL}/up" '"ring_members":2' || return 1
     capture_into us2_ring_after wait_for_contains "${KURA_US_2_URL}/up" '"ring_members":2' || return 1

--- a/kura/spec/e2e/handoff_spec.sh
+++ b/kura/spec/e2e/handoff_spec.sh
@@ -4,22 +4,19 @@ Describe 'singleton handoff to joined nodes'
   Include spec/e2e/support.sh
 
   setup_suite() {
-    export COMPOSE_PROJECT_NAME="kura-handoff"
-    export KURA_US_PORT=4301
-    export KURA_EU_PORT=4302
-    export KURA_AP_PORT=4303
-    export TEMPO_PORT=3302
-    export OTLP_PORT=4419
-    export KURA_US_URL="http://localhost:${KURA_US_PORT}"
-    export KURA_EU_URL="http://localhost:${KURA_EU_PORT}"
-    export KURA_AP_URL="http://localhost:${KURA_AP_PORT}"
-
     COMPOSE_FILES=(-f "${PROJECT_ROOT}/docker-compose.yml")
     setup_suite_tmpdir
+
+    suite_env COMPOSE_PROJECT_NAME kura-handoff
+    ephemeral_ports KURA_US_PORT KURA_EU_PORT KURA_AP_PORT \
+      KURA_US_GRPC_PORT KURA_EU_GRPC_PORT KURA_AP_GRPC_PORT \
+      TEMPO_PORT OTLP_PORT
 
     dc down -v --remove-orphans >/dev/null 2>&1 || true
     dc build kura-us kura-eu kura-ap >/dev/null 2>&1
     dc up -d kura-us >/dev/null 2>&1
+
+    resolve_http_node KURA_US kura-us
 
     wait_for_http "${KURA_US_URL}/up"
     capture_into us_up wait_for_contains "${KURA_US_URL}/up" '"ring_members":1' || return 1
@@ -47,6 +44,8 @@ Describe 'singleton handoff to joined nodes'
     The variable singleton_body should include '"from-singleton"'
 
     dc up -d kura-eu kura-ap >/dev/null 2>&1 || return 1
+    resolve_http_node KURA_EU kura-eu
+    resolve_http_node KURA_AP kura-ap
 
     wait_for_http "${KURA_EU_URL}/up" || return 1
     wait_for_http "${KURA_AP_URL}/up" || return 1

--- a/kura/spec/e2e/memory_pressure_spec.sh
+++ b/kura/spec/e2e/memory_pressure_spec.sh
@@ -41,6 +41,7 @@ Describe 'memory pressure resilience'
   }
 
   teardown_suite() {
+    compose_teardown
     unset COMPOSE_PROJECT_NAME
     unset KURA_US_PORT KURA_EU_PORT KURA_AP_PORT
     unset KURA_US_URL KURA_EU_URL KURA_AP_URL
@@ -50,7 +51,6 @@ Describe 'memory pressure resilience'
     unset KURA_E2E_METADATA_STORE_READ_CACHE_BYTES
     unset KURA_E2E_METADATA_STORE_WRITE_BUFFER_POOL_BYTES
     unset KURA_E2E_METADATA_STORE_WRITE_BUFFER_BYTES
-    compose_teardown
   }
 
   BeforeAll 'setup_suite'

--- a/kura/spec/e2e/memory_pressure_spec.sh
+++ b/kura/spec/e2e/memory_pressure_spec.sh
@@ -4,30 +4,30 @@ Describe 'memory pressure resilience'
   Include spec/e2e/support.sh
 
   setup_suite() {
-    export COMPOSE_PROJECT_NAME="kura-memory-pressure"
-    export KURA_US_PORT=4701
-    export KURA_EU_PORT=4702
-    export KURA_AP_PORT=4703
-    export KURA_US_URL="http://localhost:${KURA_US_PORT}"
-    export KURA_EU_URL="http://localhost:${KURA_EU_PORT}"
-    export KURA_AP_URL="http://localhost:${KURA_AP_PORT}"
-    export KURA_E2E_DOCKER_MEMORY_LIMIT=512m
-    export KURA_E2E_MEMORY_SOFT_LIMIT_BYTES=$((256 * 1024 * 1024))
-    export KURA_E2E_MEMORY_HARD_LIMIT_BYTES=$((320 * 1024 * 1024))
-    export KURA_E2E_MANIFEST_CACHE_MAX_BYTES=$((16 * 1024 * 1024))
-    export KURA_E2E_SEGMENT_HANDLE_CACHE_SIZE=8
-    export KURA_E2E_METADATA_STORE_READ_CACHE_BYTES=$((16 * 1024 * 1024))
-    export KURA_E2E_METADATA_STORE_WRITE_BUFFER_POOL_BYTES=$((16 * 1024 * 1024))
-    export KURA_E2E_METADATA_STORE_WRITE_BUFFER_BYTES=$((8 * 1024 * 1024))
-
     COMPOSE_FILES=(
       -f "${PROJECT_ROOT}/docker-compose.yml"
       -f "${PROJECT_ROOT}/spec/e2e/docker-compose.memory-pressure.yml"
     )
     setup_suite_tmpdir
 
+    suite_env COMPOSE_PROJECT_NAME kura-memory-pressure
+    ephemeral_ports KURA_US_PORT KURA_EU_PORT KURA_AP_PORT \
+      KURA_US_GRPC_PORT KURA_EU_GRPC_PORT KURA_AP_GRPC_PORT
+    suite_env KURA_E2E_DOCKER_MEMORY_LIMIT 512m
+    suite_env KURA_E2E_MEMORY_SOFT_LIMIT_BYTES $((256 * 1024 * 1024))
+    suite_env KURA_E2E_MEMORY_HARD_LIMIT_BYTES $((320 * 1024 * 1024))
+    suite_env KURA_E2E_MANIFEST_CACHE_MAX_BYTES $((16 * 1024 * 1024))
+    suite_env KURA_E2E_SEGMENT_HANDLE_CACHE_SIZE 8
+    suite_env KURA_E2E_METADATA_STORE_READ_CACHE_BYTES $((16 * 1024 * 1024))
+    suite_env KURA_E2E_METADATA_STORE_WRITE_BUFFER_POOL_BYTES $((16 * 1024 * 1024))
+    suite_env KURA_E2E_METADATA_STORE_WRITE_BUFFER_BYTES $((8 * 1024 * 1024))
+
     dc down -v --remove-orphans >/dev/null 2>&1 || true
     compose_up kura-us kura-eu kura-ap || return 1
+
+    resolve_http_node KURA_US kura-us
+    resolve_http_node KURA_EU kura-eu
+    resolve_http_node KURA_AP kura-ap
 
     wait_for_http "${KURA_US_URL}/up"
     wait_for_http "${KURA_EU_URL}/up"
@@ -42,15 +42,6 @@ Describe 'memory pressure resilience'
 
   teardown_suite() {
     compose_teardown
-    unset COMPOSE_PROJECT_NAME
-    unset KURA_US_PORT KURA_EU_PORT KURA_AP_PORT
-    unset KURA_US_URL KURA_EU_URL KURA_AP_URL
-    unset KURA_E2E_DOCKER_MEMORY_LIMIT
-    unset KURA_E2E_MEMORY_SOFT_LIMIT_BYTES KURA_E2E_MEMORY_HARD_LIMIT_BYTES
-    unset KURA_E2E_MANIFEST_CACHE_MAX_BYTES KURA_E2E_SEGMENT_HANDLE_CACHE_SIZE
-    unset KURA_E2E_METADATA_STORE_READ_CACHE_BYTES
-    unset KURA_E2E_METADATA_STORE_WRITE_BUFFER_POOL_BYTES
-    unset KURA_E2E_METADATA_STORE_WRITE_BUFFER_BYTES
   }
 
   BeforeAll 'setup_suite'

--- a/kura/spec/e2e/mtls_spec.sh
+++ b/kura/spec/e2e/mtls_spec.sh
@@ -4,29 +4,25 @@ Describe 'peer mTLS'
   Include spec/e2e/support.sh
 
   setup_suite() {
-    export COMPOSE_PROJECT_NAME="kura-mtls"
-    export KURA_US_PORT=4501
-    export KURA_EU_PORT=4502
-    export KURA_AP_PORT=4503
-    export GRAFANA_PORT=3400
-    export PROMETHEUS_PORT=9290
-    export LOKI_PORT=3210
-    export TEMPO_PORT=3310
-    export OTLP_PORT=4425
-    export KURA_US_URL="http://localhost:${KURA_US_PORT}"
-    export KURA_EU_URL="http://localhost:${KURA_EU_PORT}"
-    export KURA_AP_URL="http://localhost:${KURA_AP_PORT}"
-
     COMPOSE_FILES=(
       -f "${PROJECT_ROOT}/docker-compose.yml"
       -f "${PROJECT_ROOT}/test/e2e/docker-compose.mtls.yml"
     )
     setup_suite_tmpdir
-    export KURA_MTLS_CERT_DIR="${SUITE_TMP_DIR}/mtls"
+
+    suite_env COMPOSE_PROJECT_NAME kura-mtls
+    ephemeral_ports KURA_US_PORT KURA_EU_PORT KURA_AP_PORT \
+      KURA_US_GRPC_PORT KURA_EU_GRPC_PORT KURA_AP_GRPC_PORT \
+      GRAFANA_PORT PROMETHEUS_PORT LOKI_PORT TEMPO_PORT OTLP_PORT
+    suite_env KURA_MTLS_CERT_DIR "${SUITE_TMP_DIR}/mtls"
     generate_peer_tls_material
 
     dc down -v --remove-orphans >/dev/null 2>&1 || true
     compose_up || return 1
+
+    resolve_http_node KURA_US kura-us
+    resolve_http_node KURA_EU kura-eu
+    resolve_http_node KURA_AP kura-ap
 
     wait_for_http "${KURA_US_URL}/up"
     wait_for_http "${KURA_EU_URL}/up"

--- a/kura/spec/e2e/rollout_spec.sh
+++ b/kura/spec/e2e/rollout_spec.sh
@@ -4,17 +4,14 @@ Describe 'warm rollout lifecycle'
   Include spec/e2e/support.sh
 
   setup_suite() {
-    export COMPOSE_PROJECT_NAME="kura-rollout"
-    export KURA_US_PORT=4601
-    export TEMPO_PORT=3315
-    export OTLP_PORT=4430
-    export KURA_US_URL="http://localhost:${KURA_US_PORT}"
-
     COMPOSE_FILES=(
       -f "${PROJECT_ROOT}/docker-compose.yml"
       -f "${PROJECT_ROOT}/test/e2e/docker-compose.discovery.yml"
     )
     setup_suite_tmpdir
+
+    suite_env COMPOSE_PROJECT_NAME kura-rollout
+    ephemeral_ports KURA_US_PORT KURA_US_GRPC_PORT TEMPO_PORT OTLP_PORT
 
     dc down -v --remove-orphans >/dev/null 2>&1 || true
     dc build kura-us >/dev/null 2>&1
@@ -23,6 +20,7 @@ Describe 'warm rollout lifecycle'
   reset_cluster() {
     dc down -v --remove-orphans >/dev/null 2>&1 || true
     dc up -d kura-us >/dev/null 2>&1
+    resolve_http_node KURA_US kura-us
     wait_for_http "${KURA_US_URL}/up" || return 1
     wait_for_http "${KURA_US_URL}/ready" || return 1
     capture_into ready_body wait_for_contains "${KURA_US_URL}/ready" '"state":"serving"' || return 1
@@ -69,6 +67,7 @@ Describe 'warm rollout lifecycle'
     dc stop kura-us >/dev/null 2>&1 || return 1
     dc rm -f kura-us >/dev/null 2>&1 || return 1
     dc up -d kura-us >/dev/null 2>&1 || return 1
+    resolve_http_node KURA_US kura-us
 
     wait_for_http "${KURA_US_URL}/up" || return 1
     wait_for_http "${KURA_US_URL}/ready" || return 1

--- a/kura/spec/e2e/support.sh
+++ b/kura/spec/e2e/support.sh
@@ -2,8 +2,13 @@
 
 PROJECT_ROOT="${KURA_PROJECT_ROOT:?missing KURA_PROJECT_ROOT}"
 
+# Detach stdin (`docker compose exec` attaches the caller's stdin by default, unlike
+# raw `docker exec`). Under shellspec the inherited stdin is wired into the
+# executor->reporter pipeline, so an attached `compose exec` corrupts the descriptor
+# the reporter reads from and crashes it ([reporter: 1]) even when examples pass.
+# No `dc` subcommand we use reads stdin, so redirecting from /dev/null is safe.
 dc() {
-  docker compose "${COMPOSE_FILES[@]}" "$@"
+  docker compose "${COMPOSE_FILES[@]}" "$@" </dev/null
 }
 
 dc_container_id() {

--- a/kura/spec/e2e/support.sh
+++ b/kura/spec/e2e/support.sh
@@ -7,8 +7,13 @@ PROJECT_ROOT="${KURA_PROJECT_ROOT:?missing KURA_PROJECT_ROOT}"
 # executor->reporter pipeline, so an attached `compose exec` corrupts the descriptor
 # the reporter reads from and crashes it ([reporter: 1]) even when examples pass.
 # No `dc` subcommand we use reads stdin, so redirecting from /dev/null is safe.
+#
+# `--env-file` supplies compose interpolation values and COMPOSE_PROJECT_NAME from a
+# per-suite file (populated via `suite_env`) instead of exported variables, so each
+# suite stays scoped and never leaks settings into the shell process that shellspec
+# shares across spec files.
 dc() {
-  docker compose "${COMPOSE_FILES[@]}" "$@" </dev/null
+  docker compose --env-file "${COMPOSE_ENV_FILE}" "${COMPOSE_FILES[@]}" "$@" </dev/null
 }
 
 dc_container_id() {
@@ -25,6 +30,48 @@ compose_up() {
 
 setup_suite_tmpdir() {
   SUITE_TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/kura-e2e.XXXXXX")"
+  COMPOSE_ENV_FILE="${SUITE_TMP_DIR}/compose.env"
+  : >"${COMPOSE_ENV_FILE}"
+}
+
+# Set NAME=VALUE as a non-exported shell variable for in-shell use and record it in
+# the per-suite env file that `dc` feeds to `docker compose --env-file`. This replaces
+# the previous `export`/`unset` pattern: values reach both docker compose and the spec
+# body without leaking into the process environment shellspec shares across spec files,
+# so suites no longer have to unset state to avoid bleeding into one another.
+suite_env() {
+  printf -v "$1" '%s' "$2"
+  printf '%s=%s\n' "$1" "$2" >>"${COMPOSE_ENV_FILE}"
+}
+
+# Request ephemeral host ports for the given compose variables by recording each as 0
+# in the suite env file. docker compose then publishes those container ports on a free
+# host port chosen by the kernel, so parallel suites (`shellspec -j N`) can never clash
+# on `port is already allocated`. Read the actual ports back after startup with
+# resolve_http_node / resolve_host_port.
+ephemeral_ports() {
+  local name
+  for name in "$@"; do
+    suite_env "$name" 0
+  done
+}
+
+# Print the host port docker compose published for SERVICE's CONTAINER_PORT.
+# `docker compose port` prints e.g. "0.0.0.0:49153"; emit just the port number.
+resolve_host_port() {
+  dc port "$1" "$2" | head -n1 | sed 's/.*://'
+}
+
+# Resolve SERVICE's published HTTP port (CONTAINER_PORT, default 4000) into the shell
+# vars <PREFIX>_PORT and <PREFIX>_URL, e.g. `resolve_http_node KURA_US kura-us` sets
+# KURA_US_PORT and KURA_US_URL=http://localhost:<port>. Call it after every `dc up`,
+# `dc restart`, or `dc stop`+`dc up` of the service: an ephemeral host port is
+# re-allocated on each container start (recreate AND plain restart change it).
+resolve_http_node() {
+  local prefix="$1" service="$2" container_port="${3:-4000}" port
+  port="$(resolve_host_port "$service" "$container_port")"
+  printf -v "${prefix}_PORT" '%s' "$port"
+  printf -v "${prefix}_URL" 'http://localhost:%s' "$port"
 }
 
 compose_teardown() {

--- a/kura/spec/e2e/tenant_scope_spec.sh
+++ b/kura/spec/e2e/tenant_scope_spec.sh
@@ -4,19 +4,19 @@ Describe 'tenant-scoped HTTP cache interoperability'
   Include spec/e2e/support.sh
 
   setup_suite() {
-    export COMPOSE_PROJECT_NAME="kura-tenant-scope"
-    export KURA_US_PORT=4601
-    export KURA_EU_PORT=4602
-    export KURA_AP_PORT=4603
-    export KURA_US_URL="http://localhost:${KURA_US_PORT}"
-    export KURA_EU_URL="http://localhost:${KURA_EU_PORT}"
-    export KURA_AP_URL="http://localhost:${KURA_AP_PORT}"
-
     COMPOSE_FILES=(-f "${PROJECT_ROOT}/docker-compose.yml")
     setup_suite_tmpdir
 
+    suite_env COMPOSE_PROJECT_NAME kura-tenant-scope
+    ephemeral_ports KURA_US_PORT KURA_EU_PORT KURA_AP_PORT \
+      KURA_US_GRPC_PORT KURA_EU_GRPC_PORT KURA_AP_GRPC_PORT
+
     dc down -v --remove-orphans >/dev/null 2>&1 || true
     compose_up kura-us kura-eu kura-ap || return 1
+
+    resolve_http_node KURA_US kura-us
+    resolve_http_node KURA_EU kura-eu
+    resolve_http_node KURA_AP kura-ap
 
     wait_for_http "${KURA_US_URL}/up"
     wait_for_http "${KURA_EU_URL}/up"

--- a/kura/test/e2e/docker-compose.discovery.yml
+++ b/kura/test/e2e/docker-compose.discovery.yml
@@ -10,6 +10,7 @@ services:
           - kura-ring.kura.internal
 
   kura-us-2:
+    image: ${KURA_IMAGE:-}
     build:
       context: .
       dockerfile: Dockerfile


### PR DESCRIPTION
## What changed

Repairs the Kura `shellspec` e2e suite (which **hung indefinitely** and reported failures even though every spec passed in isolation), and then hardens the harness so the suites are isolated and can run in parallel. Concretely:

- **Suite repair** — fix a container/port leak in `memory_pressure` teardown and a reporter crash caused by `docker compose exec` stealing stdin.
- **Test runner tasks** — add `test-unit` / `test-e2e` as file-based `mise` tasks.
- **Per-suite env scoping** (review feedback) — replace `export`/`unset` with a per-suite `--env-file`.
- **Parallelizable suite** — publish every container on an ephemeral host port (no manual port bookkeeping) and make `test-e2e` build once then fan out with `-j`.

## Suite repair

Running each spec individually passed, so the failures were *interactions* that only surfaced in the full run (shellspec runs files alphabetically). There were **two independent root causes**, both in the test harness:

**1. Container/port leak from `memory_pressure` teardown.**
`teardown_suite` unset `COMPOSE_PROJECT_NAME` and the compose-file interpolation vars *before* calling `compose_teardown`, so `docker compose down` targeted the wrong project (the directory-default `kura`) and left its 3 containers running. Those containers held the **default gRPC host ports 5101–5103** — this spec didn't override them, and most specs shared those defaults. Every spec that ran afterward then broke:
- **mtls** and **tenant_scope** → `setup_suite` failed fast on `Bind for 0.0.0.0:5101 failed: port is already allocated`
- **rollout** → spun in 180s `wait_for_http` retry loops (per example, twice), which is what presented as the suite "never ending"

Fix: reorder `teardown_suite` so `compose_teardown` runs *before* the env is torn down, letting the `down` target the correct, still-named project. (The env scoping below later removes the unsets entirely.)

**2. shellspec reporter crash from `docker compose exec`.**
Even after fixing #1, the suite ran green but aborted with `[reporter: 1]` → fatal exit 1. `docker compose exec` attaches the caller's **stdin** by default (unlike raw `docker exec`, which needs `-i`). Under shellspec, that inherited stdin is wired into the executor→reporter pipeline, so an attached `exec` corrupts the descriptor the reporter reads from and crashes it — even when the example passes. Triggered by rollout's three `dc exec` calls.

Fix: detach stdin (`</dev/null`) in the central `dc()` wrapper rather than per call site, since the behavior is intrinsic to `docker compose exec` regardless of where it's called. Verified no `dc` subcommand in the suite reads stdin, so it's safe.

## Test runner tasks

`test-unit` and `test-e2e` are defined as scripts under `kura/mise/tasks/` (the repo-wide convention used by `cache/`, `slack/`, `handbook/`, and the root `mise/tasks/`) rather than inline `[tasks.*]` in `mise.toml`.

- `test-unit` — runs `cargo test` with a raised file-descriptor limit; the RocksDB-backed unit tests open many fds in parallel and hit `EMFILE` under the default macOS `ulimit -n` of 256.
- `test-e2e` — builds the image once, then runs the shellspec suite (see parallelization below).

## Per-suite env scoping (review feedback)

Each spec used to `export` its compose configuration (project name, ports, resource limits) into the shell, and the `memory_pressure` spec had to `unset` it all again in teardown. Because shellspec runs every spec file in **one shared shell process**, that exported state leaked across specs — which is also what made the original teardown bug so destructive.

Now `dc()` passes `docker compose --env-file <per-suite file>`, and a new `suite_env NAME VALUE` helper sets a **non-exported** shell variable (for in-shell use such as building URLs) while recording `NAME=VALUE` in that per-suite file (created under the suite's temp dir). Values reach docker compose and the spec body without ever entering the process environment, so nothing leaks between spec files and the `export`/`unset` pattern is gone.

`local` isn't an option here: shellspec invokes `setup_suite`, each example, and `teardown_suite` as separate shell calls, so the values must persist beyond a single function scope — but they must not become process-wide `export`s. The `--env-file` indirection is what satisfies both.

## Parallelizable suite

shellspec parallelizes across spec **files** (`shellspec -j N`; within a file, examples stay serial). Concurrent suites would otherwise clash on published host ports — the base compose publishes a gRPC host port per node defaulting to `5101-5103` that most specs never overrode, plus several overlapping HTTP ports.

Rather than hand-assign a disjoint port range per spec (which has to stay unique as specs are added and can still collide with unrelated processes on the host), each spec **requests ephemeral host ports**: it records the relevant compose port variables as `0` (`ephemeral_ports`), so docker compose publishes them on a free host port chosen by the kernel, and reads the actual ports back after startup (`resolve_http_node` / `resolve_host_port`). The kernel guarantees uniqueness, so parallel suites can never clash. The compose files are **untouched**, so local `docker compose up` keeps its stable default ports; only the e2e env files set `0`.

An ephemeral host port is re-allocated on **every container start** — recreate, restart, and stop+start all change it — so specs re-resolve after each such operation. `cluster`, whose stateful examples share one stack and restart a node mid-run, re-resolves before every example via a `Before` hook, because shellspec isolates per-example variable state in subshells (a value re-resolved inside one example would not survive to the next).

The other thing that would serialize workers is each suite building its own image — compose names a built image `<project>-<service>`, and every suite uses a distinct `COMPOSE_PROJECT_NAME`. So the kura services declare `image: ${KURA_IMAGE:-}` (empty by default, so local `docker compose up` keeps its per-project naming), and the `test-e2e` task exports a fixed `KURA_IMAGE` and builds it once; every suite then resolves to that single prebuilt image and reuses it under `KURA_E2E_SKIP_BUILD=1`, with no per-project rebuilds. The task forwards arguments rather than hardcoding a job count:

```bash
mise run test-e2e            # serial
mise run test-e2e -- -j 8    # parallel
```

## Validation

- Full `shellspec` run **green serially (18 examples, 0 failures)** and under **`shellspec -j 4` (18/18, ~3.5x faster: 266s → 75s, single shared image, no per-project rebuilds, 0 leftover containers)**.
- Original suite repair confirmed with **0 leftover containers**; each previously-failing spec (mtls, rollout, tenant_scope) also passing in a clean environment.
- `suite_env` + `dc --env-file` verified end-to-end, including a check that a non-exported value from one suite does **not** leak into another suite's `docker compose`.
- Ephemeral allocation + `docker compose port` resolution verified against a live container; `bash -n` clean on all specs and tasks; `mise` argument forwarding confirmed (`-- -j 8` → `shellspec -j 8`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
