### PR TITLE
fix(infra): report container readiness for tart-kubelet VM pods

### DIFF
--- a/infra/tart-kubelet/internal/podagent/reconciler.go
+++ b/infra/tart-kubelet/internal/podagent/reconciler.go
@@ -583,12 +583,45 @@ func (r *Reconciler) podStatus(ctx context.Context, pod *corev1.Pod) (*corev1.Po
 		status.Conditions = []corev1.PodCondition{
 			{Type: corev1.PodReady, Status: corev1.ConditionTrue},
 		}
+		// tart-kubelet runs the Pod as a single VM with no per-container
+		// CRI, so the API server receives no containerStatuses on its own
+		// and `kubectl get pods` reads 0/N READY for a healthy VM. Mirror
+		// the Ready condition above into synthesized statuses so the READY
+		// column reflects the running workload.
+		status.ContainerStatuses = runningContainerStatuses(pod, entry.VMName, entry.StartTS)
 	} else {
 		// VM process is alive but IP isn't yet available — the
 		// guest is still booting. Pending is the right read.
 		status.Phase = corev1.PodPending
 	}
 	return status, nil
+}
+
+// runningContainerStatuses synthesizes the per-container statuses for a
+// Pod whose Tart VM is up and serving. tart-kubelet has no per-container
+// runtime to source them from, so without this a healthy VM reports 0/N
+// READY in `kubectl get pods` even though its Pod Ready condition is
+// true. The statuses mirror that condition: VM running with an IP means
+// the workload is serving, so each container reads Ready + Running. Pod
+// ↔ VM is 1:1 (multi-container Pods are rejected at admission), so this
+// is effectively a single status.
+func runningContainerStatuses(pod *corev1.Pod, vmName string, startedAt metav1.Time) []corev1.ContainerStatus {
+	started := true
+	statuses := make([]corev1.ContainerStatus, 0, len(pod.Spec.Containers))
+	for _, c := range pod.Spec.Containers {
+		statuses = append(statuses, corev1.ContainerStatus{
+			Name:         c.Name,
+			Image:        c.Image,
+			ContainerID:  "tart://" + vmName,
+			Ready:        true,
+			Started:      &started,
+			RestartCount: 0,
+			State: corev1.ContainerState{
+				Running: &corev1.ContainerStateRunning{StartedAt: startedAt},
+			},
+		})
+	}
+	return statuses
 }
 
 func (r *Reconciler) publishStatus(ctx context.Context, pod *corev1.Pod, status *corev1.PodStatus) error {

--- a/infra/tart-kubelet/internal/podagent/reconciler_test.go
+++ b/infra/tart-kubelet/internal/podagent/reconciler_test.go
@@ -101,6 +101,46 @@ func TestReconcileTerminalPodWithDeletionTimestampRemovesFinalizer(t *testing.T)
 	assertPodDeleted(t, ctx, kubeClient, types.NamespacedName{Namespace: "tuist-runners", Name: "runner-stuck-terminating"})
 }
 
+// TestRunningContainerStatusesReportsReady guards the kubectl READY
+// column for VM-backed Pods. tart-kubelet has no per-container CRI, so
+// it must synthesize containerStatuses; without ready=true a healthy
+// VM reads 0/N READY and is easily misread as an outage. The statuses
+// mirror the Pod Ready condition the reconciler sets when the VM is up.
+func TestRunningContainerStatusesReportsReady(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "tuist", Name: "xcresult-processor-abc"},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "xcresult-processor", Image: "ghcr.io/tuist/tuist:sha-x"}},
+		},
+	}
+	startedAt := metav1.Now()
+
+	statuses := runningContainerStatuses(pod, "vm-abc", startedAt)
+
+	if len(statuses) != 1 {
+		t.Fatalf("expected 1 container status (Pod ↔ VM is 1:1), got %d", len(statuses))
+	}
+	cs := statuses[0]
+	if !cs.Ready {
+		t.Fatalf("expected Ready=true so kubectl shows N/N for a running VM")
+	}
+	if cs.Started == nil || !*cs.Started {
+		t.Fatalf("expected Started=true, got %v", cs.Started)
+	}
+	if cs.State.Running == nil {
+		t.Fatalf("expected Running state, got %+v", cs.State)
+	}
+	if !cs.State.Running.StartedAt.Equal(&startedAt) {
+		t.Fatalf("expected StartedAt to mirror the VM start time")
+	}
+	if cs.Name != "xcresult-processor" || cs.Image != "ghcr.io/tuist/tuist:sha-x" {
+		t.Fatalf("expected name/image mirrored from the spec, got %q/%q", cs.Name, cs.Image)
+	}
+	if cs.ContainerID != "tart://vm-abc" {
+		t.Fatalf("expected ContainerID to carry the VM name, got %q", cs.ContainerID)
+	}
+}
+
 func newPodTestClient(t *testing.T, objects ...runtime.Object) client.Client {
 	t.Helper()
 	scheme := runtime.NewScheme()


### PR DESCRIPTION
## What

When a Tart VM is up with an IP, tart-kubelet now synthesizes a `containerStatus` per spec container (`Ready: true`, `Running`, name/image from the spec, `ContainerID: tart://<vm>`), mirroring the Pod `Ready` condition it already sets. Implemented as a small pure helper in [reconciler.go](infra/tart-kubelet/internal/podagent/reconciler.go)'s `podStatus`, unit-tested directly.

## Why

tart-kubelet runs each Pod as a single Tart VM with no per-container CRI, so it never reports any `containerStatuses` to the API server. It *does* set the Pod `Ready` condition — which is what Deployments and `helm --wait` use for availability — but `kubectl get pods` counts ready *containers*, and with none reported, every healthy VM-backed Pod shows `0/N READY` permanently.

That's not just cosmetic in practice: the `READY` column is the first thing an operator reads, and a working xcresult-processor sitting at `0/1` for hours read as an outage during a real incident. The investigation chased a phantom DB problem and nearly scaled the Deployment to zero before confirming (via the Oban queue) that the processor was fine all along — the column was lying. This makes the column tell the truth for the whole macOS fleet (xcresult-processor **and** customer runner Pods).

## Scope / safety

- Only the **running** branch (VM up + IP) is touched. Booting (`Pending`) and exited (`Succeeded`) Pods keep reporting no ready containers, which is accurate.
- **No behavior change to availability**: Deployments/`helm --wait` already used the `Ready` *condition*, which is unchanged. This only populates the per-container view `kubectl`/tooling read.
- **No billing impact**: the runners-controller's pod-lifecycle billing reads `state.terminated.finishedAt`; the running branch sets `state.Running` only, and the Succeeded branch is untouched, so the existing fallback is preserved.
- Pod ↔ VM is 1:1 (multi-container Pods are rejected at admission), so this is effectively a single status, but the helper iterates the spec to stay correct if that ever changes.

## Validation

`go build ./...`, `go vet`, `gofmt`, and `go test ./internal/podagent/...` all pass. New test `TestRunningContainerStatusesReportsReady` asserts `Ready`/`Started`/`Running` + name/image/ContainerID mirroring the spec and VM.

Opening as a draft for review.
