### PR TITLE
fix(server): add id tiebreaker to test case runs pagination

### DIFF
--- a/server/lib/tuist/tests/test_case_run.ex
+++ b/server/lib/tuist/tests/test_case_run.ex
@@ -28,7 +28,7 @@ defmodule Tuist.Tests.TestCaseRun do
       :shard_id,
       :shard_index
     ],
-    sortable: [:inserted_at, :duration, :name, :ran_at]
+    sortable: [:inserted_at, :duration, :name, :ran_at, :id]
   }
 
   @primary_key {:id, Ecto.UUID, autogenerate: false}

--- a/server/lib/tuist/tests/test_case_run_by_project.ex
+++ b/server/lib/tuist/tests/test_case_run_by_project.ex
@@ -27,7 +27,7 @@ defmodule Tuist.Tests.TestCaseRunByProject do
       :scheme,
       :git_branch
     ],
-    sortable: [:inserted_at, :duration, :name, :ran_at]
+    sortable: [:inserted_at, :duration, :name, :ran_at, :id]
   }
 
   @primary_key {:id, Ecto.UUID, autogenerate: false}

--- a/server/lib/tuist/tests/test_case_run_by_test_run.ex
+++ b/server/lib/tuist/tests/test_case_run_by_test_run.ex
@@ -14,7 +14,7 @@ defmodule Tuist.Tests.TestCaseRunByTestRun do
   @derive {
     Flop.Schema,
     filterable: [:test_run_id, :name, :status, :is_flaky, :is_new, :duration, :project_id, :test_case_id],
-    sortable: [:inserted_at, :duration, :name, :ran_at]
+    sortable: [:inserted_at, :duration, :name, :ran_at, :id]
   }
 
   @primary_key {:id, Ecto.UUID, autogenerate: false}

--- a/server/lib/tuist_web/controllers/api/test_case_runs_controller.ex
+++ b/server/lib/tuist_web/controllers/api/test_case_runs_controller.ex
@@ -471,8 +471,8 @@ defmodule TuistWeb.API.TestCaseRunsController do
   defp render_test_case_runs(conn, filters, page, page_size) do
     options = %{
       filters: filters,
-      order_by: [:ran_at],
-      order_directions: [:desc],
+      order_by: [:ran_at, :id],
+      order_directions: [:desc, :asc],
       page: page,
       page_size: page_size
     }


### PR DESCRIPTION
## What

Add `:id` as a secondary sort key to the test case runs list endpoint pagination.

## Why

The endpoint orders by `ran_at` only. When multiple rows share the same `ran_at` timestamp (common in parallel test runs), ClickHouse reshuffles their relative order between page fetches. This causes:

- Duplicate rows appearing on adjacent pages
- Rows that never appear on any page (skipped during the reshuffle)

In practice, a test run with 5681 test cases only returns ~4254 unique rows through pagination, with ~1427 rows lost. This means downstream consumers (like our CI test reporting) miss quarantined test failures that should be filtered from results.

## How

Add `:id` to `order_by` and `:asc` to `order_directions` in `render_test_case_runs`, matching the pattern already used in `apply_quarantined_order` which has a comment explaining the exact same issue (lines 2396-2399 of `tests.ex`).

Also added `:id` to the `sortable` list in `TestCaseRunByTestRun` and `TestCaseRunByProject` schemas so Flop accepts it.