### PR TITLE
ci(infra): raise deploy job ceiling above helm's timeout so it can't SIGKILL helm

### DIFF
--- a/.github/workflows/server-deployment.yml
+++ b/.github/workflows/server-deployment.yml
@@ -600,12 +600,15 @@ jobs:
             --set kuraController.image.tag="$IMAGE_TAG" \
             --set kuraRuntime.image.tag="$KURA_RUNTIME_IMAGE_TAG" \
             --atomic --timeout 60m --wait
-      - name: Diagnostics on failure
-        # `--atomic` rolls back the release on timeout, so `helm history` and
-        # most cluster state reflect the rolled-back revision rather than the
-        # failure. Migration-job pods linger long enough for logs to be useful;
-        # everything else is best-effort.
-        if: failure()
+      - name: Diagnostics on failure or cancellation
+        # Runs on cancellation as well as failure. Cancelling a deploy while
+        # `helm upgrade --wait` is still converging is the common interruption
+        # (someone kills a deploy that looks stuck), and that is exactly when
+        # we most need to capture which workload never went Ready, which a
+        # cancel would otherwise discard. On a clean `--atomic` timeout the
+        # release is already rolled back, so `helm history` reflects that;
+        # everything here is best-effort.
+        if: ${{ failure() || cancelled() }}
         run: |
           set +e
           echo "::group::helm history"
@@ -693,3 +696,39 @@ jobs:
           kubectl -n "$NAMESPACE" rollout status deploy/tuist-tuist-server --timeout=10m
           kubectl -n "$NAMESPACE" run smoke-$RANDOM --rm -i --restart=Never --image=curlimages/curl \
             --command -- curl -fsS "http://tuist-tuist-server/ready"
+      - name: Recover release if the deploy was interrupted
+        # A cancelled deploy SIGKILLs `helm upgrade --atomic` mid-flight, so it
+        # neither finishes nor completes its own rollback and the release is
+        # left in pending-upgrade. That wedges the next deploy until its
+        # start-of-run recovery rolls it back, and leaves the cluster sitting
+        # in a half-applied upgrade in the meantime. Roll back to the last
+        # deployed revision here so an interrupted deploy self-heals. No-op on
+        # a clean `--atomic` timeout, where the status is already deployed.
+        # Best-effort: if the cancellation grace window cuts this short, the
+        # next deploy's "Recover interrupted Helm release" step still covers it.
+        if: ${{ failure() || cancelled() }}
+        run: |
+          set +e
+          status="$(
+            helm status "$HELM_RELEASE_NAME" -n "$NAMESPACE" 2>/dev/null |
+              awk '/^STATUS:/ { print $2 }'
+          )"
+          case "$status" in
+            pending-install|pending-upgrade|pending-rollback)
+              echo "Release $HELM_RELEASE_NAME is $status after interruption; rolling back to the last deployed revision."
+              deployed_revision="$(
+                helm history "$HELM_RELEASE_NAME" -n "$NAMESPACE" --max 20 |
+                  awk '$0 ~ /[[:space:]]deployed[[:space:]]/ { revision = $1 } END { print revision }'
+              )"
+              if [ -n "$deployed_revision" ]; then
+                helm rollback "$HELM_RELEASE_NAME" "$deployed_revision" \
+                  --namespace "$NAMESPACE" --timeout 3m
+                helm status "$HELM_RELEASE_NAME" -n "$NAMESPACE" | awk '/^STATUS:/ { print }'
+              else
+                echo "No deployed revision found; leaving recovery to the next deploy."
+              fi
+              ;;
+            *)
+              echo "Release $HELM_RELEASE_NAME status is ${status:-unknown}; no recovery needed."
+              ;;
+          esac

--- a/.github/workflows/server-deployment.yml
+++ b/.github/workflows/server-deployment.yml
@@ -392,13 +392,15 @@ jobs:
     concurrency:
       group: server-deploy-${{ inputs.environment }}-deploy
       cancel-in-progress: false
-    # This job ceiling MUST stay above helm's `--timeout` plus its
-    # `--atomic` rollback, or GitHub SIGKILLs helm mid-wait and the
-    # release is left wedged in pending-upgrade. helm waits up to 25m
-    # and its rollback up to ~10m; with ~5m setup, 50m leaves helm room
-    # to reach its own timeout (clean rollback + diagnostics) before
-    # this ceiling fires.
-    timeout-minutes: 50
+    # This ceiling MUST stay above the helm step's own timeout (70m =
+    # helm `--timeout 60m` + ~10m `--atomic` rollback) plus the ~5-10m
+    # of setup before it. Otherwise GitHub SIGKILLs helm mid-`--wait`,
+    # before its rollback can run, and the release is left wedged in
+    # pending-upgrade (the bug that drove the long pending-upgrade ->
+    # rollback churn: the ceiling had drifted to 50m, under helm's 60m,
+    # when helm was bumped from 30m). 80m keeps helm < step < job so a
+    # stuck deploy fails via helm's own clean path, not this ceiling.
+    timeout-minutes: 80
     env:
       KUBECONFIG: ${{ github.workspace }}/.kube/config
       NAMESPACE: ${{ inputs.environment == 'production' && 'tuist' || format('tuist-{0}', inputs.environment) }}
@@ -563,17 +565,18 @@ jobs:
         # in-cluster ExternalSecret. Passing secrets through --set would
         # leak them into `helm get manifest`.
         #
-        # helm `--timeout 25m` is deliberately well under this job's 50m
-        # `timeout-minutes` ceiling. On a stuck rollout helm reaches its
-        # own timeout first and runs the `--atomic` rollback, which
-        # restores a clean deployed release and lets the failure-path
-        # diagnostics below run. If the job ceiling fired first it would
-        # SIGKILL helm mid-wait, before the rollback, leaving the release
-        # wedged in pending-upgrade (the failure mode that produced the
-        # long pending-upgrade/rollback churn). Steady-state deploys
-        # finish in 5-15m, so 25m is ample headroom; the 40m step timeout
-        # covers helm's 25m wait plus its rollback.
-        timeout-minutes: 40
+        # `--timeout 60m` is generous on purpose: a complex migration
+        # (the pre-upgrade hook runs inside this budget) plus the
+        # `--wait` rollout can genuinely take a while, and undershooting
+        # would kill a legitimately-slow deploy mid-migration. The 70m
+        # step timeout is helm's 60m plus a ~10m cushion for the
+        # in-process `--atomic` rollback. The job's `timeout-minutes`
+        # ceiling sits above this (helm < step < job): that ordering is
+        # what makes a stuck deploy hit helm's own timeout first (clean
+        # rollback + failure diagnostics) instead of the job ceiling
+        # SIGKILLing helm mid-wait and wedging the release in
+        # pending-upgrade.
+        timeout-minutes: 70
         run: |
           # Stream cluster state every 30s while helm waits. helm
           # --atomic --wait produces no stdout during the wait, so
@@ -599,7 +602,7 @@ jobs:
             --set server.image.tag="$IMAGE_TAG" \
             --set kuraController.image.tag="$IMAGE_TAG" \
             --set kuraRuntime.image.tag="$KURA_RUNTIME_IMAGE_TAG" \
-            --atomic --timeout 25m --wait
+            --atomic --timeout 60m --wait
       - name: Diagnostics on failure
         # `--atomic` rolls back the release on timeout, so `helm history` and
         # most cluster state reflect the rolled-back revision rather than the

--- a/.github/workflows/server-deployment.yml
+++ b/.github/workflows/server-deployment.yml
@@ -392,9 +392,12 @@ jobs:
     concurrency:
       group: server-deploy-${{ inputs.environment }}-deploy
       cancel-in-progress: false
-    # helm-upgrade waits up to 30m and setup/teardown adds ~5m. 50m
-    # leaves a healthy buffer around that stack and keeps a
-    # SIGTERM-stuck helm from holding the slot indefinitely.
+    # This job ceiling MUST stay above helm's `--timeout` plus its
+    # `--atomic` rollback, or GitHub SIGKILLs helm mid-wait and the
+    # release is left wedged in pending-upgrade. helm waits up to 25m
+    # and its rollback up to ~10m; with ~5m setup, 50m leaves helm room
+    # to reach its own timeout (clean rollback + diagnostics) before
+    # this ceiling fires.
     timeout-minutes: 50
     env:
       KUBECONFIG: ${{ github.workspace }}/.kube/config
@@ -560,20 +563,17 @@ jobs:
         # in-cluster ExternalSecret. Passing secrets through --set would
         # leak them into `helm get manifest`.
         #
-        # helm --timeout 60m is sized for the adoption path: Mac minis
-        # are pre-ordered by the operator under the `tuist-pool-` prefix
-        # and the CAPI controller claims them on demand. Adoption is
-        # cheap (rename + tart-kubelet bootstrap + Tart VM cold-boot)
-        # vs Scaleway CreateServer (~50 min). Steady-state deploys
-        # finish in 5-15 min once the Mac mini is already in the cluster.
-        # If we ever flip back to auto-order in an env, bump this back
-        # to ~90m to absorb a fresh Scaleway provisioning.
-        #
-        # 70 min = helm's `--timeout 60m` plus a 10-min cushion for the
-        # in-process `--atomic` rollback. A workflow-side timeout under
-        # 70 min risks killing helm after it has moved the release into
-        # pending-rollback, leaving the cluster wedged for the next run.
-        timeout-minutes: 70
+        # helm `--timeout 25m` is deliberately well under this job's 50m
+        # `timeout-minutes` ceiling. On a stuck rollout helm reaches its
+        # own timeout first and runs the `--atomic` rollback, which
+        # restores a clean deployed release and lets the failure-path
+        # diagnostics below run. If the job ceiling fired first it would
+        # SIGKILL helm mid-wait, before the rollback, leaving the release
+        # wedged in pending-upgrade (the failure mode that produced the
+        # long pending-upgrade/rollback churn). Steady-state deploys
+        # finish in 5-15m, so 25m is ample headroom; the 40m step timeout
+        # covers helm's 25m wait plus its rollback.
+        timeout-minutes: 40
         run: |
           # Stream cluster state every 30s while helm waits. helm
           # --atomic --wait produces no stdout during the wait, so
@@ -599,16 +599,13 @@ jobs:
             --set server.image.tag="$IMAGE_TAG" \
             --set kuraController.image.tag="$IMAGE_TAG" \
             --set kuraRuntime.image.tag="$KURA_RUNTIME_IMAGE_TAG" \
-            --atomic --timeout 60m --wait
-      - name: Diagnostics on failure or cancellation
-        # Runs on cancellation as well as failure. Cancelling a deploy while
-        # `helm upgrade --wait` is still converging is the common interruption
-        # (someone kills a deploy that looks stuck), and that is exactly when
-        # we most need to capture which workload never went Ready, which a
-        # cancel would otherwise discard. On a clean `--atomic` timeout the
-        # release is already rolled back, so `helm history` reflects that;
-        # everything here is best-effort.
-        if: ${{ failure() || cancelled() }}
+            --atomic --timeout 25m --wait
+      - name: Diagnostics on failure
+        # `--atomic` rolls back the release on timeout, so `helm history` and
+        # most cluster state reflect the rolled-back revision rather than the
+        # failure. Migration-job pods linger long enough for logs to be useful;
+        # everything else is best-effort.
+        if: failure()
         run: |
           set +e
           echo "::group::helm history"
@@ -696,39 +693,3 @@ jobs:
           kubectl -n "$NAMESPACE" rollout status deploy/tuist-tuist-server --timeout=10m
           kubectl -n "$NAMESPACE" run smoke-$RANDOM --rm -i --restart=Never --image=curlimages/curl \
             --command -- curl -fsS "http://tuist-tuist-server/ready"
-      - name: Recover release if the deploy was interrupted
-        # A cancelled deploy SIGKILLs `helm upgrade --atomic` mid-flight, so it
-        # neither finishes nor completes its own rollback and the release is
-        # left in pending-upgrade. That wedges the next deploy until its
-        # start-of-run recovery rolls it back, and leaves the cluster sitting
-        # in a half-applied upgrade in the meantime. Roll back to the last
-        # deployed revision here so an interrupted deploy self-heals. No-op on
-        # a clean `--atomic` timeout, where the status is already deployed.
-        # Best-effort: if the cancellation grace window cuts this short, the
-        # next deploy's "Recover interrupted Helm release" step still covers it.
-        if: ${{ failure() || cancelled() }}
-        run: |
-          set +e
-          status="$(
-            helm status "$HELM_RELEASE_NAME" -n "$NAMESPACE" 2>/dev/null |
-              awk '/^STATUS:/ { print $2 }'
-          )"
-          case "$status" in
-            pending-install|pending-upgrade|pending-rollback)
-              echo "Release $HELM_RELEASE_NAME is $status after interruption; rolling back to the last deployed revision."
-              deployed_revision="$(
-                helm history "$HELM_RELEASE_NAME" -n "$NAMESPACE" --max 20 |
-                  awk '$0 ~ /[[:space:]]deployed[[:space:]]/ { revision = $1 } END { print revision }'
-              )"
-              if [ -n "$deployed_revision" ]; then
-                helm rollback "$HELM_RELEASE_NAME" "$deployed_revision" \
-                  --namespace "$NAMESPACE" --timeout 3m
-                helm status "$HELM_RELEASE_NAME" -n "$NAMESPACE" | awk '/^STATUS:/ { print }'
-              else
-                echo "No deployed revision found; leaving recovery to the next deploy."
-              fi
-              ;;
-            *)
-              echo "Release $HELM_RELEASE_NAME status is ${status:-unknown}; no recovery needed."
-              ;;
-          esac


### PR DESCRIPTION
## Why

Production has been stuck in a long `pending-upgrade → Rollback` loop, and it's a **timeout misconfiguration**, not a chart bug or manual cancellation:

- deploy job: `timeout-minutes: 50`
- helm: `--atomic --timeout 60m` (step timeout 70m)

The job ceiling (50m) is **below** helm's own timeout (60m). On any slow rollout GitHub kills the job at 50m and SIGKILLs helm *before* its `--timeout` fires, so the `--atomic` rollback never runs and the release is left wedged in `pending-upgrade`. The job reports "exceeded the maximum execution time of 50m0s" / "the operation was canceled" (looks like a cancel, is the ceiling). The next deploy's recovery rolls it back, upgrades, hits 50m again → repeat. The helm step's own comment already warned a job timeout under helm's was unsafe; the ceiling drifted to 50m when helm's `--timeout` was bumped 30m → 60m and the job wasn't raised to match.

## What

**Raise the job ceiling, don't shrink helm's timeout.** A complex migration runs as helm's pre-upgrade hook *inside* the `--timeout` budget, so the 60m budget is there for a reason — undershooting it would kill a legitimately-slow migration. So:

- keep helm `--timeout 60m` and the 70m step timeout (unchanged from `main`)
- raise the job `timeout-minutes` **50 → 80**

Now `helm (60m) < step (70m) < job (80m)`: a stuck deploy reaches helm's own timeout first, runs the clean `--atomic` rollback, and fires the existing `Diagnostics on failure` step — instead of the job ceiling SIGKILLing helm and wedging the release.

**Net functional change is one line: job timeout 50m → 80m.** (The commit history on the branch shows two earlier approaches — cancellation teardown handlers, then a too-aggressive 25m helm timeout — both superseded; the final diff vs `main` is just the ceiling.)

## Note

This makes a stuck deploy fail cleanly, fast-enough, and observably, and stops the wedge. It does not by itself make a genuinely-hung rollout *succeed* — but the next stuck deploy will now produce real diagnostics (which workload wasn't Ready) instead of a wedge.

## Validation

`actionlint` clean (only pre-existing self-hosted runner-label notices). Invariant holds: helm `--timeout` (60m) + `--atomic` rollback (~10m) ≤ step (70m), and step (70m) + setup (~5-10m) < job (80m).
