### PR TITLE
fix(cli): inherit canary fixture feature flags

### DIFF
--- a/cli/Sources/TuistAcceptanceTesting/TuistAcceptanceTestFixtureTestingTrait.swift
+++ b/cli/Sources/TuistAcceptanceTesting/TuistAcceptanceTestFixtureTestingTrait.swift
@@ -42,7 +42,6 @@ public struct TuistAcceptanceTestFixtureTestingTrait: TestTrait, SuiteTrait, Tes
             try await TuistEnvironmentTesting
                 .withMockedEnvironment {
                     existingEnvVariables
-                        .filter { key, _ in !key.hasPrefix("TUIST_FEATURE_FLAG_") }
                         .forEach { Environment.mocked?.variables[$0.key] = $0.value }
 
                     let fixtureTemporaryDirectory = temporaryDirectory.appending(


### PR DESCRIPTION
Resolves N/A

The cache canary workflow sets `TUIST_FEATURE_FLAG_KURA=1`, but `withFixtureConnectedToCanary` rebuilt the mocked environment and dropped every `TUIST_FEATURE_FLAG_*` variable. That made canary cache tests call `/api/cache/endpoints` without the Kura client feature flag header. The server then returned the default cache endpoint list, and managed canary has the embedded default cache disabled, so the CLI saw an empty endpoint list and threw `.noEndpointsAvailable`.

This removes that feature flag filter from the canary fixture trait. Canary fixtures now inherit the same feature flags as the environment that scheduled the test, which matches how the GitHub Actions job controls Kura opt-in.

### How to test locally

- `mise run cli:lint --fix`
- `mise run cli:ee`
- `TUIST_EE=1 tuist generate tuist TuistAcceptanceTesting TuistCacheEEAcceptanceTests ProjectDescription --no-open`
- `TUIST_EE=1 xcodebuild build-for-testing -workspace Tuist.xcworkspace -scheme TuistCacheEEAcceptanceTests -destination platform=macOS,arch=arm64 CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" COMPILATION_CACHE_ENABLE_CACHING=NO`
- Not run locally: live `TuistCacheEECanaryAcceptanceTests`, because they require canary credentials and mutate remote projects.
