### PR TITLE
fix(cli): stop deleting the framework search path response file during generation

### DIFF
--- a/cli/Sources/TuistGenerator/Mappers/DeleteDerivedDirectoryProjectMapper.swift
+++ b/cli/Sources/TuistGenerator/Mappers/DeleteDerivedDirectoryProjectMapper.swift
@@ -31,7 +31,13 @@ public struct DeleteDerivedDirectoryProjectMapper: ProjectMapping {
 
         let contents = try await fileSystem.glob(directory: derivedDirectoryPath, include: ["*"]).collect()
         var sideEffects: [SideEffectDescriptor] = []
-        for item in contents where item.extension != "modulemap" {
+        // FrameworkSearchPaths holds the .resp files written by LinkGenerator as project side
+        // effects, which run before these cleanup side effects. Deleting the directory here would
+        // wipe the just-written response files (leaving the build referencing a missing @file),
+        // so it is preserved; LinkGenerator overwrites its contents on every generation.
+        for item in contents
+            where item.extension != "modulemap" && item.basename != Constants.DerivedDirectory.frameworkSearchPaths
+        {
             if try await fileSystem.exists(item, isDirectory: true) {
                 sideEffects.append(.directory(DirectoryDescriptor(path: item, state: .absent)))
             } else {

--- a/cli/Tests/TuistGeneratorTests/ProjectMappers/DeleteDerivedDirectoryProjectMapperTests.swift
+++ b/cli/Tests/TuistGeneratorTests/ProjectMappers/DeleteDerivedDirectoryProjectMapperTests.swift
@@ -37,4 +37,26 @@ public final class DeleteDerivedDirectoryProjectMapperTests: TuistUnitTestCase {
             .directory(.init(path: derivedDirectory.appending(component: "InfoPlists"), state: .absent)),
         ])
     }
+
+    func test_map_preserves_frameworkSearchPaths_directory() async throws {
+        // Given
+        let projectPath = try temporaryPath()
+        let derivedDirectory = projectPath.appending(component: Constants.DerivedDirectory.name)
+        let project = Project.test(path: projectPath)
+        try await fileSystem.makeDirectory(at: derivedDirectory)
+        try await fileSystem.makeDirectory(at: derivedDirectory.appending(component: "InfoPlists"))
+        try await fileSystem.makeDirectory(
+            at: derivedDirectory.appending(component: Constants.DerivedDirectory.frameworkSearchPaths)
+        )
+
+        // When
+        let (_, sideEffects) = try await subject.map(project: project)
+
+        // Then
+        // FrameworkSearchPaths holds .resp files written by LinkGenerator before this cleanup runs,
+        // so it must be preserved while other derived subdirectories are still deleted.
+        XCTAssertEqual(sideEffects, [
+            .directory(.init(path: derivedDirectory.appending(component: "InfoPlists"), state: .absent)),
+        ])
+    }
 }


### PR DESCRIPTION
## What changed

`DeleteDerivedDirectoryProjectMapper` now preserves the `Derived/FrameworkSearchPaths` directory (where `LinkGenerator` writes `<Target>.resp` files), the same way it already preserves module maps. One line in the cleanup filter, plus a regression test.

## Why

This is the root cause behind the recurring `<Target>.resp` "missing file" build failures on the framework-search-path consolidation (#10228), of which the Xcode 26 Swift errors were only the first-observed symptom.

`DeleteDerivedDirectoryProjectMapper` exists to clear stale generated content: when a project's `Derived/` already exists, it emits side effects to delete every subdirectory (`InfoPlists`, `ModuleMaps`, `Sources`, `FrameworkSearchPaths`, …) so regeneration starts clean.

The framework-search-path response files are written by `LinkGenerator` as **project** side effects, executed in `XcodeProjWriter.write` — an *earlier* phase than the mapper cleanup side effects (`Generator.generateWithGraph` runs `writer.write` before `sideEffectDescriptorExecutor.execute(mapperSideEffects)`). So the sequence on a regeneration over a pre-existing `Derived/` is:

1. write `Derived/FrameworkSearchPaths/<Target>.resp` (project side effect)
2. delete `Derived/FrameworkSearchPaths` (mapper cleanup side effect) ← wipes step 1

The build then references a response file that no longer exists:

```
error: no such file or directory: '@.../Derived/FrameworkSearchPaths/<Target>.resp'
```

Under Xcode 26 the Swift compiler surfaced earlier variants of the same missing-file problem first — `Unexpected input file: <srcroot>/@<srcroot>/.../<Target>.resp` (integrated SwiftDriver resolving the unexpanded `@file` token as a working-directory-relative input) and, before that, `unable to handle compilation, expected exactly one compiler job` (`-Xcc @file` reaching the ClangImporter). With the Swift compiler no longer routed through the response file, the failure simply moved to the next consumer (clang compiling the `_vers.c` versioning stub, then the linker).

### Why other Derived/ content was unaffected

Everything else under `Derived/` (InfoPlists, module maps, resources, generated sources) is written by **mappers**, whose create side effects land in the *same* batch as the cleanup deletes — delete-then-recreate leaves them intact. The `.resp` is the only `Derived/` artifact written in the earlier project-side-effect phase, so it is the only one the cleanup can delete without a following recreate. Module maps were already explicitly preserved in this mapper; the `FrameworkSearchPaths` directory is now preserved for the same reason.

### Why this only reproduces sometimes

The cleanup only emits delete side effects when `Derived/` already exists at the start of generation. A fresh checkout (no `Derived/`) never triggers it, so the `.resp` survives; a repeated/incremental generation over an existing `Derived/` (typical on CI that retains a working copy or regenerates in place) triggers it and deletes the `.resp`. That intermittence is why this took several iterations to localize.

## Validation

- Reproduced deterministically against a project with 22 precompiled framework dependencies (crosses the consolidation threshold): `tuist generate` once writes `Derived/FrameworkSearchPaths/App.resp`; a second `tuist generate` over the now-existing `Derived/` **deleted** it (and `ModuleMaps/` survived) — matching the reported failure exactly.
- With this fix, the `.resp` survives the 2nd and 3rd consecutive `tuist generate`, while the rest of the `Derived/` cleanup still happens.
- Added `DeleteDerivedDirectoryProjectMapperTests.test_map_preserves_frameworkSearchPaths_directory`; the suite compiles and the existing deletion test still asserts other subdirectories are removed. (Test execution was validated via the build/codegen path; the assertion change is mechanical.)
- Lint clean.

## Impact

Restores buildability for projects that regenerate over an existing `Derived/` and cross the framework-search-path consolidation threshold (commonly large graphs with many precompiled/binary dependencies on CI). Complements the earlier change that stopped routing the Swift compiler through the response file; together they make the consolidated framework search paths robust under Xcode 26.