### PR TITLE
ci(infra): enable the dockerd sidecar on canary and production Linux runners

### DIFF
--- a/infra/helm/tuist/values-managed-canary.yaml
+++ b/infra/helm/tuist/values-managed-canary.yaml
@@ -202,6 +202,10 @@ buildersFleet:
 kataContainers:
   enabled: true
 
+runnersController:
+  features:
+    dindImage: true
+
 # Linux runner fleet on a single bare-metal AX42-U host (FSN1).
 # Canary mirrors staging's substrate exactly so the deploy pipeline
 # catches regressions on a production-shape cluster before they hit

--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -301,6 +301,10 @@ buildersFleet:
 kataContainers:
   enabled: true
 
+runnersController:
+  features:
+    dindImage: true
+
 # Linux runner fleet on Hetzner Robot AX162-R hosts (FSN1).
 #
 # Each AX162-R (48c/96t EPYC Genoa, 256 GB ECC, 2x1.92 TB NVMe DC


### PR DESCRIPTION
## What changed

Flips `runnersController.features.dindImage: true` on the canary and production managed overlays (`values-managed-canary.yaml`, `values-managed-production.yaml`). That makes the runners-controller pass `--dind-image=docker:28-dind@...` on those envs, so it attaches the privileged `docker:dind` native sidecar to every Linux runner Pod and Docker workloads work on the `tuist-linux` / `tuist-canary-linux` labels.

## Why

The Linux runner image already ships the Docker CLI + buildx + compose plugins, but `dockerd` itself does not run in that image. It runs in a `docker:dind` native sidecar that the runners-controller staples onto each Linux runner Pod, and only when the controller is started with `--dind-image`. That flag is gated per environment by `runnersController.features.dindImage` (default `false`) and the controller hard-requires `runtimeClass: kata-qemu` before it will build a Linux+dind Pod.

Staging has carried the gate since the docker-in-runner change. Canary and production left it off, so the Linux labels resolved to kata-qemu microVMs with **no daemon**, and the Docker-requiring CI jobs (image builds, service containers, `docker compose`, kamal) could not run there. They stayed parked on Namespace / GitHub-hosted runners.

## Why this is safe

The feature gate exists because controller binaries older than the docker-in-runner change reject the `--dind-image` flag (`flag.Parse` exits 2). That is not a risk here:

- `values-managed-common.yaml` pins **every** managed env to `tuist-runners-controller:0.6.1`.
- Staging already runs that exact `0.6.1` binary **with** `--dind-image` successfully.
- Canary and production already set `kataContainers.enabled: true` and `shapeRuntimeClass: kata-qemu`, so the controller's kata-qemu precondition is met.

So the only missing piece is the gate, and flipping it cannot crash the controller.

The sidecar runs `privileged: true`, but each runner Pod is a kata-qemu microVM with its own kernel, so the privileged surface is bounded by the microVM and never reaches the bare-metal host. This is the same posture staging already runs.

## Rollout

A push to `main` cascades the deploy canary -> acceptance -> production, so canary picks up the sidecar first and the acceptance gate validates it before production cuts over. No routing or capacity change: the same warm floor the default shape already carries now also runs a dockerd sidecar per Pod.

## User / developer impact

Once deployed, Docker jobs can run on the in-house `tuist-linux` fleet. The actual job migration (25 parked jobs across 16 workflows) lands as a **follow-up PR** that must merge only after this is deployed to production, otherwise those jobs would hit a daemon-less microVM and fail.

## Validation

- `helm template` with `values-managed-common.yaml` + each env overlay now renders `--dind-image=docker:28-dind@sha256:2a23...` in the runners-controller `args` for both production and canary (absent before this change, since the gate defaulted to `false`).
- Both edited values files parse as valid YAML.
- No capacity, shape, or routing changes; this is purely the per-env sidecar gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)