### PR TITLE
feat(infra): reclaim stranded Scaleway Apple-silicon hosts back to the pool

### DIFF
--- a/infra/cluster-api-provider-scaleway-applesilicon/AGENTS.md
+++ b/infra/cluster-api-provider-scaleway-applesilicon/AGENTS.md
@@ -54,6 +54,27 @@ redoing finished ones. Failures requeue with backoff; only terminal
 errors (Scaleway 400s, validation failures) set
 `Status.FailureReason`.
 
+Two auxiliary controllers run alongside it:
+
+- **OrphanReclaimer** (`controllers/orphan_reclaimer.go`) — a
+  leader-gated periodic sweep that returns Scaleway hosts which were
+  claimed by the controller but whose CR is gone (a legacy CR that
+  skipped release, a force-delete that bypassed the finalizer, a crash
+  mid-claim) back to the adopt pool, so a strand can't silently drain
+  the pool and keep billing under Apple's 24h floor. The per-Machine
+  delete path only covers what reaches it; the sweep is the convergent
+  backstop. A host is left untouched unless it is certainly
+  ours-but-unowned — not in the pool, not mid-adoption, and named after
+  no live CR (the claim renames a pool host to its CR's name, so a live
+  CR name is the authoritative "owned" signal). Active reclaim is gated
+  on a claim-name prefix; report-only otherwise. Exports the
+  `scaleway_orphan_servers` gauge. Enabled by
+  `macosFleet.orphanReclaim.poolPrefix`, which also serves as the
+  delete path's pool-prefix fallback for legacy CRs.
+- **FleetSpreadReconciler** (`controllers/fleetspread_controller.go`) —
+  re-rolls a target Deployment when the Ready Mac mini set changes so
+  Pods spread across newly-joined hosts.
+
 ## Module layout
 
 ```
@@ -66,7 +87,9 @@ infra/cluster-api-provider-scaleway-applesilicon/
 │   └── zz_generated.deepcopy.go
 ├── controllers/
 │   ├── scalewayapplesiliconmachine_controller.go
-│   └── scalewayapplesiliconcluster_controller.go
+│   ├── scalewayapplesiliconcluster_controller.go
+│   ├── fleetspread_controller.go
+│   └── orphan_reclaimer.go
 ├── internal/
 │   ├── scaleway/   # Scaleway SDK wrapper
 │   └── bootstrap/  # SSH-driven kubelet/tart-cri install

--- a/infra/cluster-api-provider-scaleway-applesilicon/cmd/manager/main.go
+++ b/infra/cluster-api-provider-scaleway-applesilicon/cmd/manager/main.go
@@ -433,6 +433,7 @@ func main() {
 		reclaimZones := parseCommaList(orphanReclaimZonesRaw)
 		if err := mgr.Add(&controllers.OrphanReclaimer{
 			Client:          mgr.GetClient(),
+			APIReader:       mgr.GetAPIReader(),
 			Scaleway:        scwClient,
 			Interval:        orphanReclaimInterval,
 			Zones:           reclaimZones,

--- a/infra/cluster-api-provider-scaleway-applesilicon/cmd/manager/main.go
+++ b/infra/cluster-api-provider-scaleway-applesilicon/cmd/manager/main.go
@@ -88,6 +88,11 @@ func main() {
 		egressNamespace      string
 		egressProxyGroup     string
 		egressMagicDNSSuffix string
+
+		defaultAdoptPoolPrefix       string
+		orphanReclaimClaimNamePrefix string
+		orphanReclaimZonesRaw        string
+		orphanReclaimInterval        time.Duration
 	)
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "Prometheus metrics endpoint")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "Liveness/readiness probe endpoint")
@@ -212,6 +217,33 @@ func main() {
 			"tailnet-fqdn annotation is `<machine.Name>.<suffix>`. Read from "+
 			"`tailscale status --json | .MagicDNSSuffix` on any tailnet "+
 			"device. Required when --tailscale-egress-proxy-group is set.")
+
+	flag.StringVar(&defaultAdoptPoolPrefix, "default-adopt-pool-prefix",
+		envOrDefault("CAPI_DEFAULT_ADOPT_POOL_PREFIX", ""),
+		"Pool prefix the controller falls back to when a CR's adoptPoolPrefix is "+
+			"empty (legacy CRs), used both to release such CRs on delete and as the "+
+			"orphan-reclaim sweep's pool prefix. Setting it enables the orphan-reclaim "+
+			"sweep (report-only until --orphan-reclaim-claim-name-prefix is also set). "+
+			"Empty disables both — bare legacy CRs skip release and no sweep runs.")
+	flag.StringVar(&orphanReclaimClaimNamePrefix, "orphan-reclaim-claim-name-prefix",
+		envOrDefault("CAPI_ORPHAN_RECLAIM_CLAIM_NAME_PREFIX", ""),
+		"Claimed-name namespace this cluster owns within the Scaleway project (e.g. "+
+			"`tuist-tuist-`). The orphan-reclaim sweep only returns a stranded host to "+
+			"the pool when its Scaleway name carries this prefix, so a host an operator "+
+			"is mid-provisioning under a Scaleway-default name, or a host owned by "+
+			"another cluster sharing the project, is reported via the "+
+			"scaleway_orphan_servers gauge but never mutated. Empty keeps the sweep "+
+			"report-only. Must be unique to this cluster when the Scaleway project is "+
+			"shared across environments.")
+	flag.StringVar(&orphanReclaimZonesRaw, "orphan-reclaim-zones",
+		envOrDefault("CAPI_ORPHAN_RECLAIM_ZONES", "fr-par-1"),
+		"Comma-separated Scaleway zones the orphan-reclaim sweep scans every cycle, "+
+			"unioned with the distinct zones of all live CRs. The static list keeps a "+
+			"zone covered after its last CR is deleted — the case where a strand is "+
+			"most likely and least visible.")
+	flag.DurationVar(&orphanReclaimInterval, "orphan-reclaim-interval", 15*time.Minute,
+		"How often the orphan-reclaim sweep runs. The sweep is a full Scaleway "+
+			"ListServers per zone plus a CR list, so keep it coarse.")
 
 	opts := zap.Options{Development: false}
 	opts.BindFlags(flag.CommandLine)
@@ -358,7 +390,7 @@ func main() {
 		// `tag:tuist-k8s-<env>` dial access to this tag on the
 		// scrape ports; cross-env scraping is blocked once the
 		// wide-open catch-all is removed.
-		TailscaleTags:                parseTailscaleTags(tailscaleTagsRaw),
+		TailscaleTags:                parseCommaList(tailscaleTagsRaw),
 		TartKubeletHostCPU:           tartKubeletHostCPU,
 		TartKubeletHostMemoryMB:      tartKubeletHostMemory,
 		TartKubeletMaxPods:           tartKubeletMaxPods,
@@ -366,6 +398,7 @@ func main() {
 		BootstrapRebootAfter:         int32(bootstrapRebootAfter),
 		BootstrapMaxAttempts:         int32(bootstrapMaxAttempts),
 		MaxConcurrentReconciles:      machineMaxConcurrentReconciles,
+		DefaultAdoptPoolPrefix:       defaultAdoptPoolPrefix,
 		EgressNamespace:              egressNamespace,
 		EgressProxyGroup:             egressProxyGroup,
 		EgressMagicDNSSuffix:         egressMagicDNSSuffix,
@@ -393,6 +426,29 @@ func main() {
 			"deployment", fleetSpreadDeployment, "namespace", ns)
 	}
 
+	// Orphan-reclaim sweep: enabled once a pool prefix is configured
+	// (the same prefix the delete path falls back to). Report-only
+	// until a claim-name prefix is also set; see the flag help.
+	if defaultAdoptPoolPrefix != "" {
+		reclaimZones := parseCommaList(orphanReclaimZonesRaw)
+		if err := mgr.Add(&controllers.OrphanReclaimer{
+			Client:          mgr.GetClient(),
+			Scaleway:        scwClient,
+			Interval:        orphanReclaimInterval,
+			Zones:           reclaimZones,
+			PoolPrefix:      defaultAdoptPoolPrefix,
+			ClaimNamePrefix: orphanReclaimClaimNamePrefix,
+			Log:             ctrl.Log.WithName("orphan-reclaim"),
+		}); err != nil {
+			setupLog.Error(err, "setup OrphanReclaimer")
+			os.Exit(1)
+		}
+		setupLog.Info("orphan-reclaim sweep enabled",
+			"poolPrefix", defaultAdoptPoolPrefix,
+			"claimNamePrefix", orphanReclaimClaimNamePrefix,
+			"zones", reclaimZones, "interval", orphanReclaimInterval)
+	}
+
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
 		setupLog.Error(err, "set up health check")
 		os.Exit(1)
@@ -416,12 +472,10 @@ func envOrDefault(key, fallback string) string {
 	return fallback
 }
 
-// parseTailscaleTags splits a comma-separated --tailscale-tags
-// value into a slice. Empty input returns nil — the bootstrap then
-// falls back to whatever default tag the auth key carries.
-// Whitespace around each tag is trimmed; blank entries (e.g. a
-// trailing comma) are dropped.
-func parseTailscaleTags(raw string) []string {
+// parseCommaList splits a comma-separated flag value into a slice.
+// Empty input returns nil. Whitespace around each entry is trimmed;
+// blank entries (e.g. a trailing comma) are dropped.
+func parseCommaList(raw string) []string {
 	raw = strings.TrimSpace(raw)
 	if raw == "" {
 		return nil

--- a/infra/cluster-api-provider-scaleway-applesilicon/controllers/orphan_reclaimer.go
+++ b/infra/cluster-api-provider-scaleway-applesilicon/controllers/orphan_reclaimer.go
@@ -1,0 +1,200 @@
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+
+	infrav1 "github.com/tuist/tuist/infra/cluster-api-provider-scaleway-applesilicon/api/v1alpha1"
+	"github.com/tuist/tuist/infra/cluster-api-provider-scaleway-applesilicon/internal/scaleway"
+)
+
+var (
+	orphanServersGauge = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "scaleway_orphan_servers",
+		Help: "Scaleway Apple Silicon servers that carry a claimed (non-pool) name but are backed by no live ScalewayAppleSiliconMachine CR. A sustained non-zero value means hosts are leaking out of the adopt pool — billing under Apple's 24h floor while doing no work, and draining the pool that AdoptFromPool draws from.",
+	})
+	orphansReclaimedTotal = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "scaleway_orphan_servers_reclaimed_total",
+		Help: "Stranded Scaleway Apple Silicon servers returned to the adopt pool (rename + reinstall) by the orphan-reclaim sweep.",
+	})
+)
+
+func init() {
+	metrics.Registry.MustRegister(orphanServersGauge, orphansReclaimedTotal)
+}
+
+// scalewayPool is the slice of *scaleway.Client the orphan-reclaim
+// sweep needs. An interface so tests can drive the sweep without the
+// real Scaleway SDK.
+type scalewayPool interface {
+	ListServers(ctx context.Context, zone string) ([]scaleway.Server, error)
+	ReleaseToPool(ctx context.Context, id, zone, poolPrefix string) error
+}
+
+// OrphanReclaimer is a leader-gated periodic sweep that returns
+// Scaleway Apple Silicon hosts which were once claimed by this
+// controller but whose owning ScalewayAppleSiliconMachine CR is gone
+// back to the adopt pool.
+//
+// Why a sweep and not the per-Machine delete path alone: reconcileDelete
+// releases a host on normal teardown, but a host strands whenever that
+// path doesn't run to completion — a legacy CR with no AdoptPoolPrefix
+// (and no controller default) that skips release, a force-delete that
+// bypasses the finalizer, or a crash between claiming a pool host and
+// writing its CR. Stranded hosts keep billing under Apple's 24h floor
+// and silently drain the pool, which is what surfaces later as
+// AdoptFromPool returning NoAvailableHost and wedging a deploy. The
+// per-Machine path can't cover what never reaches it; a convergent
+// sweep catches every strand cause regardless of how it happened.
+//
+// Safety. A host is left untouched when it is parked in the pool,
+// mid-adoption, or named after a live CR. The claim renames a pool host
+// to its CR's name, and the CR always exists before that rename, so a
+// live CR name is the authoritative "owned" signal and there is no
+// claimed-but-CR-missing window short of an actual delete. Active
+// reclaim is gated further on ClaimNamePrefix: a host an operator is
+// mid-provisioning under a Scaleway-default name, or a host belonging to
+// another cluster that shares the Scaleway project, fails the prefix
+// check and is reported via the gauge but never mutated. With
+// ClaimNamePrefix empty the sweep is report-only.
+type OrphanReclaimer struct {
+	client.Client
+
+	Scaleway scalewayPool
+
+	// Interval between sweeps.
+	Interval time.Duration
+
+	// Zones swept every cycle, unioned with the distinct zones of all
+	// live CRs. The static list keeps a zone covered even after its
+	// last CR is deleted (the case where a strand is most likely and
+	// least visible).
+	Zones []string
+
+	// PoolPrefix marks available pool hosts (skipped) and is the
+	// rename target when a stranded host is reclaimed.
+	PoolPrefix string
+
+	// ClaimNamePrefix gates active reclaim. Only hosts whose Scaleway
+	// name starts with this prefix — this cluster's claimed-name
+	// namespace within the Scaleway project — are reclaimed. Empty
+	// makes the sweep report-only.
+	ClaimNamePrefix string
+
+	Log logr.Logger
+}
+
+// NeedLeaderElection keeps the sweep on the single elected leader; a
+// second replica must not race ReleaseToPool against the leader.
+func (r *OrphanReclaimer) NeedLeaderElection() bool { return true }
+
+// Start runs the sweep immediately and then every Interval until the
+// manager's context is cancelled. A failed cycle is logged and retried
+// next interval rather than crashing the manager.
+func (r *OrphanReclaimer) Start(ctx context.Context) error {
+	r.Log.Info("orphan-reclaim sweep starting",
+		"interval", r.Interval, "zones", r.Zones,
+		"poolPrefix", r.PoolPrefix, "mode", r.mode())
+	wait.UntilWithContext(ctx, func(ctx context.Context) {
+		if err := r.reclaimOnce(ctx); err != nil {
+			r.Log.Error(err, "orphan-reclaim sweep cycle failed; retrying next interval")
+		}
+	}, r.Interval)
+	return nil
+}
+
+func (r *OrphanReclaimer) mode() string {
+	if r.ClaimNamePrefix == "" {
+		return "report-only"
+	}
+	return "reclaim"
+}
+
+// reclaimOnce performs a single sweep: build the owned set from live
+// CRs, list Scaleway hosts per zone, and reclaim (or report) every
+// stranded host. Returns the first error encountered so Start can log
+// it; partial progress within the cycle is kept.
+func (r *OrphanReclaimer) reclaimOnce(ctx context.Context) error {
+	machines := &infrav1.ScalewayAppleSiliconMachineList{}
+	if err := r.List(ctx, machines); err != nil {
+		return fmt.Errorf("list ScalewayAppleSiliconMachines: %w", err)
+	}
+
+	ownedNames := make(map[string]struct{}, len(machines.Items))
+	ownedServerIDs := make(map[string]struct{}, len(machines.Items))
+	zoneSet := make(map[string]struct{}, len(r.Zones))
+	for _, z := range r.Zones {
+		if z != "" {
+			zoneSet[z] = struct{}{}
+		}
+	}
+	for i := range machines.Items {
+		m := &machines.Items[i]
+		ownedNames[m.Name] = struct{}{}
+		if m.Status.ServerID != "" {
+			ownedServerIDs[m.Status.ServerID] = struct{}{}
+		}
+		if m.Spec.Zone != "" {
+			zoneSet[m.Spec.Zone] = struct{}{}
+		}
+	}
+
+	var (
+		orphanCount int
+		firstErr    error
+	)
+	for zone := range zoneSet {
+		servers, err := r.Scaleway.ListServers(ctx, zone)
+		if err != nil {
+			r.Log.Error(err, "list Scaleway servers; skipping zone this cycle", "zone", zone)
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
+		for _, s := range servers {
+			if scaleway.IsPoolOrAdopting(s.Name, r.PoolPrefix) {
+				continue
+			}
+			if _, ok := ownedNames[s.Name]; ok {
+				continue
+			}
+			if _, ok := ownedServerIDs[s.ID]; ok {
+				continue
+			}
+
+			// Stranded: a claimed-style name with no owning CR.
+			orphanCount++
+
+			if r.ClaimNamePrefix == "" || !strings.HasPrefix(s.Name, r.ClaimNamePrefix) {
+				r.Log.Info("stranded Scaleway host detected (report-only)",
+					"server", s.ID, "name", s.Name, "zone", zone,
+					"claimNamePrefix", r.ClaimNamePrefix)
+				continue
+			}
+
+			r.Log.Info("reclaiming stranded Scaleway host to pool",
+				"server", s.ID, "name", s.Name, "zone", zone)
+			if err := r.Scaleway.ReleaseToPool(ctx, s.ID, zone, r.PoolPrefix); err != nil {
+				r.Log.Error(err, "reclaim stranded host failed; retrying next cycle",
+					"server", s.ID, "name", s.Name, "zone", zone)
+				if firstErr == nil {
+					firstErr = err
+				}
+				continue
+			}
+			orphansReclaimedTotal.Inc()
+		}
+	}
+
+	orphanServersGauge.Set(float64(orphanCount))
+	return firstErr
+}

--- a/infra/cluster-api-provider-scaleway-applesilicon/controllers/orphan_reclaimer.go
+++ b/infra/cluster-api-provider-scaleway-applesilicon/controllers/orphan_reclaimer.go
@@ -68,6 +68,13 @@ type scalewayPool interface {
 type OrphanReclaimer struct {
 	client.Client
 
+	// APIReader is an uncached reader used to re-check ownership in the
+	// instant before a host is reclaimed. The cached Client can lag a
+	// just-created CR, and reclaim is destructive, so the final check
+	// reads straight from the API server. Falls back to the cached
+	// Client when nil (tests).
+	APIReader client.Reader
+
 	Scaleway scalewayPool
 
 	// Interval between sweeps.
@@ -118,40 +125,23 @@ func (r *OrphanReclaimer) mode() string {
 	return "reclaim"
 }
 
-// reclaimOnce performs a single sweep: build the owned set from live
-// CRs, list Scaleway hosts per zone, and reclaim (or report) every
+// reclaimOnce performs a single sweep: snapshot the owned set from live
+// CRs, list Scaleway hosts per zone, then reclaim (or report) every
 // stranded host. Returns the first error encountered so Start can log
 // it; partial progress within the cycle is kept.
 func (r *OrphanReclaimer) reclaimOnce(ctx context.Context) error {
-	machines := &infrav1.ScalewayAppleSiliconMachineList{}
-	if err := r.List(ctx, machines); err != nil {
-		return fmt.Errorf("list ScalewayAppleSiliconMachines: %w", err)
+	owned, zones, err := r.ownedSnapshot(ctx, r.Client)
+	if err != nil {
+		return err
 	}
 
-	ownedNames := make(map[string]struct{}, len(machines.Items))
-	ownedServerIDs := make(map[string]struct{}, len(machines.Items))
-	zoneSet := make(map[string]struct{}, len(r.Zones))
-	for _, z := range r.Zones {
-		if z != "" {
-			zoneSet[z] = struct{}{}
-		}
-	}
-	for i := range machines.Items {
-		m := &machines.Items[i]
-		ownedNames[m.Name] = struct{}{}
-		if m.Status.ServerID != "" {
-			ownedServerIDs[m.Status.ServerID] = struct{}{}
-		}
-		if m.Spec.Zone != "" {
-			zoneSet[m.Spec.Zone] = struct{}{}
-		}
-	}
-
+	type strand struct{ id, name, zone string }
 	var (
+		candidates  []strand
 		orphanCount int
 		firstErr    error
 	)
-	for zone := range zoneSet {
+	for zone := range zones {
 		servers, err := r.Scaleway.ListServers(ctx, zone)
 		if err != nil {
 			r.Log.Error(err, "list Scaleway servers; skipping zone this cycle", "zone", zone)
@@ -164,10 +154,7 @@ func (r *OrphanReclaimer) reclaimOnce(ctx context.Context) error {
 			if scaleway.IsPoolOrAdopting(s.Name, r.PoolPrefix) {
 				continue
 			}
-			if _, ok := ownedNames[s.Name]; ok {
-				continue
-			}
-			if _, ok := ownedServerIDs[s.ID]; ok {
+			if owned.has(s.Name, s.ID) {
 				continue
 			}
 
@@ -180,21 +167,100 @@ func (r *OrphanReclaimer) reclaimOnce(ctx context.Context) error {
 					"claimNamePrefix", r.ClaimNamePrefix)
 				continue
 			}
-
-			r.Log.Info("reclaiming stranded Scaleway host to pool",
-				"server", s.ID, "name", s.Name, "zone", zone)
-			if err := r.Scaleway.ReleaseToPool(ctx, s.ID, zone, r.PoolPrefix); err != nil {
-				r.Log.Error(err, "reclaim stranded host failed; retrying next cycle",
-					"server", s.ID, "name", s.Name, "zone", zone)
-				if firstErr == nil {
-					firstErr = err
-				}
-				continue
-			}
-			orphansReclaimedTotal.Inc()
+			candidates = append(candidates, strand{id: s.ID, name: s.Name, zone: zone})
 		}
 	}
-
 	orphanServersGauge.Set(float64(orphanCount))
+
+	if len(candidates) == 0 {
+		return firstErr
+	}
+
+	// Re-check ownership against the live API right before mutating. The
+	// snapshot above was taken before the per-zone Scaleway scans (and
+	// off a possibly cache-lagged client); a CR created and adopted in
+	// the meantime now owns its host under the CR's name (the claim
+	// renames the pool host to it), so releasing from the stale snapshot
+	// would wipe a live, freshly-adopted host. A failed re-check aborts
+	// reclaim this cycle rather than act on stale data.
+	fresh, _, err := r.ownedSnapshot(ctx, r.reader())
+	if err != nil {
+		return fmt.Errorf("re-check ownership before reclaim: %w", err)
+	}
+	for _, c := range candidates {
+		if fresh.has(c.name, c.id) {
+			r.Log.Info("skipping reclaim; host adopted since scan",
+				"server", c.id, "name", c.name, "zone", c.zone)
+			continue
+		}
+		r.Log.Info("reclaiming stranded Scaleway host to pool",
+			"server", c.id, "name", c.name, "zone", c.zone)
+		if err := r.Scaleway.ReleaseToPool(ctx, c.id, c.zone, r.PoolPrefix); err != nil {
+			r.Log.Error(err, "reclaim stranded host failed; retrying next cycle",
+				"server", c.id, "name", c.name, "zone", c.zone)
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
+		orphansReclaimedTotal.Inc()
+	}
 	return firstErr
+}
+
+func (r *OrphanReclaimer) reader() client.Reader {
+	if r.APIReader != nil {
+		return r.APIReader
+	}
+	return r.Client
+}
+
+// ownership is the set of host names and serverIDs claimed by live CRs.
+type ownership struct {
+	names map[string]struct{}
+	ids   map[string]struct{}
+}
+
+func (o ownership) has(name, id string) bool {
+	if _, ok := o.names[name]; ok {
+		return true
+	}
+	if id != "" {
+		if _, ok := o.ids[id]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+// ownedSnapshot lists the live ScalewayAppleSiliconMachine CRs through
+// reader and returns the owned host names + serverIDs, plus the zones to
+// sweep (the configured Zones unioned with every CR's zone, so a zone
+// stays covered after its last CR is deleted).
+func (r *OrphanReclaimer) ownedSnapshot(ctx context.Context, reader client.Reader) (ownership, map[string]struct{}, error) {
+	machines := &infrav1.ScalewayAppleSiliconMachineList{}
+	if err := reader.List(ctx, machines); err != nil {
+		return ownership{}, nil, fmt.Errorf("list ScalewayAppleSiliconMachines: %w", err)
+	}
+	owned := ownership{
+		names: make(map[string]struct{}, len(machines.Items)),
+		ids:   make(map[string]struct{}, len(machines.Items)),
+	}
+	zones := make(map[string]struct{}, len(r.Zones))
+	for _, z := range r.Zones {
+		if z != "" {
+			zones[z] = struct{}{}
+		}
+	}
+	for i := range machines.Items {
+		m := &machines.Items[i]
+		owned.names[m.Name] = struct{}{}
+		if m.Status.ServerID != "" {
+			owned.ids[m.Status.ServerID] = struct{}{}
+		}
+		if m.Spec.Zone != "" {
+			zones[m.Spec.Zone] = struct{}{}
+		}
+	}
+	return owned, zones, nil
 }

--- a/infra/cluster-api-provider-scaleway-applesilicon/controllers/orphan_reclaimer_test.go
+++ b/infra/cluster-api-provider-scaleway-applesilicon/controllers/orphan_reclaimer_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	infrav1 "github.com/tuist/tuist/infra/cluster-api-provider-scaleway-applesilicon/api/v1alpha1"
@@ -42,7 +43,7 @@ func machineCR(name, zone, serverID string) *infrav1.ScalewayAppleSiliconMachine
 	}
 }
 
-func newReclaimerTest(t *testing.T, pool scalewayPool, claimPrefix string, crs ...*infrav1.ScalewayAppleSiliconMachine) *OrphanReclaimer {
+func buildCRClient(t *testing.T, crs ...*infrav1.ScalewayAppleSiliconMachine) client.Client {
 	t.Helper()
 	scheme := runtime.NewScheme()
 	if err := infrav1.AddToScheme(scheme); err != nil {
@@ -52,9 +53,13 @@ func newReclaimerTest(t *testing.T, pool scalewayPool, claimPrefix string, crs .
 	for _, c := range crs {
 		objs = append(objs, c)
 	}
-	c := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objs...).Build()
+	return fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objs...).Build()
+}
+
+func newReclaimerTest(t *testing.T, pool scalewayPool, claimPrefix string, crs ...*infrav1.ScalewayAppleSiliconMachine) *OrphanReclaimer {
+	t.Helper()
 	return &OrphanReclaimer{
-		Client:          c,
+		Client:          buildCRClient(t, crs...),
 		Scaleway:        pool,
 		Zones:           []string{"fr-par-1"},
 		PoolPrefix:      "tuist-pool-",
@@ -120,5 +125,26 @@ func TestOrphanReclaimer_ReportOnlyDoesNotMutate(t *testing.T) {
 	// the gauge reports 2 regardless of the claim-name gate.
 	if got := testutil.ToFloat64(orphanServersGauge); got != 2 {
 		t.Fatalf("expected gauge=2 stranded hosts, got %v", got)
+	}
+}
+
+// A CR created and adopted after the cycle's initial snapshot must not
+// be reclaimed. The detection snapshot (Client) predates the CR, so the
+// host is flagged, but the pre-mutation re-check reads the live API
+// (APIReader) and sees the new owner by name, so the release is skipped.
+func TestOrphanReclaimer_SkipsHostAdoptedSinceScan(t *testing.T) {
+	pool := &fakePool{byZone: map[string][]scaleway.Server{
+		"fr-par-1": {{ID: "stray-1", Name: "tuist-tuist-builders-fleet-rg4h9-c295c"}},
+	}}
+	// Detection client has no CRs, so stray-1 is flagged as a candidate.
+	r := newReclaimerTest(t, pool, "tuist-tuist-")
+	// The live re-check reader sees a CR that now owns the host by name.
+	r.APIReader = buildCRClient(t, machineCR("tuist-tuist-builders-fleet-rg4h9-c295c", "fr-par-1", ""))
+
+	if err := r.reclaimOnce(context.Background()); err != nil {
+		t.Fatalf("reclaimOnce: %v", err)
+	}
+	if len(pool.releasedIDs) != 0 {
+		t.Fatalf("must not reclaim a host adopted since the scan, got %v", pool.releasedIDs)
 	}
 }

--- a/infra/cluster-api-provider-scaleway-applesilicon/controllers/orphan_reclaimer_test.go
+++ b/infra/cluster-api-provider-scaleway-applesilicon/controllers/orphan_reclaimer_test.go
@@ -1,0 +1,124 @@
+package controllers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	infrav1 "github.com/tuist/tuist/infra/cluster-api-provider-scaleway-applesilicon/api/v1alpha1"
+	"github.com/tuist/tuist/infra/cluster-api-provider-scaleway-applesilicon/internal/scaleway"
+)
+
+// fakePool is a stand-in for *scaleway.Client driving the sweep: it
+// serves a fixed per-zone server list and records every ReleaseToPool.
+type fakePool struct {
+	byZone      map[string][]scaleway.Server
+	releasedIDs []string
+	releaseErr  map[string]error
+}
+
+func (f *fakePool) ListServers(_ context.Context, zone string) ([]scaleway.Server, error) {
+	return f.byZone[zone], nil
+}
+
+func (f *fakePool) ReleaseToPool(_ context.Context, id, _, _ string) error {
+	if err := f.releaseErr[id]; err != nil {
+		return err
+	}
+	f.releasedIDs = append(f.releasedIDs, id)
+	return nil
+}
+
+func machineCR(name, zone, serverID string) *infrav1.ScalewayAppleSiliconMachine {
+	return &infrav1.ScalewayAppleSiliconMachine{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "tuist"},
+		Spec:       infrav1.ScalewayAppleSiliconMachineSpec{Zone: zone, AdoptPoolPrefix: "tuist-pool-"},
+		Status:     infrav1.ScalewayAppleSiliconMachineStatus{ServerID: serverID},
+	}
+}
+
+func newReclaimerTest(t *testing.T, pool scalewayPool, claimPrefix string, crs ...*infrav1.ScalewayAppleSiliconMachine) *OrphanReclaimer {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := infrav1.AddToScheme(scheme); err != nil {
+		t.Fatalf("infrav1 scheme: %v", err)
+	}
+	objs := make([]runtime.Object, 0, len(crs))
+	for _, c := range crs {
+		objs = append(objs, c)
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objs...).Build()
+	return &OrphanReclaimer{
+		Client:          c,
+		Scaleway:        pool,
+		Zones:           []string{"fr-par-1"},
+		PoolPrefix:      "tuist-pool-",
+		ClaimNamePrefix: claimPrefix,
+		Log:             logr.Discard(),
+	}
+}
+
+// The sweep must reclaim exactly the host that is (a) not in the pool,
+// (b) not mid-adoption, (c) owned by no live CR, and (d) inside this
+// cluster's claim-name namespace — and nothing else. The serverID and
+// claim-name-prefix guards are the load-bearing safety checks: a
+// freshly-claimed-but-status-only host (owned by serverID) and a host
+// outside our claim namespace (operator-in-progress or another
+// cluster) must survive.
+func TestOrphanReclaimer_ReclaimsOnlyStrandedHostsInClaimNamespace(t *testing.T) {
+	pool := &fakePool{byZone: map[string][]scaleway.Server{
+		"fr-par-1": {
+			{ID: "pool-1", Name: "tuist-pool-aaaa"},                           // available in pool
+			{ID: "pend-1", Name: "tuist-claim-pending-bbbb"},                  // mid-adoption
+			{ID: "live-name", Name: "tuist-tuist-builders-fleet-rg4h9-xqzbl"}, // owned: matches a live CR name
+			{ID: "live-id", Name: "tuist-tuist-orphan-lookalike"},             // owned: matches a live CR serverID
+			{ID: "stray-1", Name: "tuist-tuist-builders-fleet-rg4h9-c295c"},   // STRANDED, in claim namespace
+			{ID: "foreign", Name: "apple-silicon-romantic-proskuriakova"},     // stranded but outside claim namespace
+		},
+	}}
+
+	r := newReclaimerTest(t, pool, "tuist-tuist-",
+		machineCR("tuist-tuist-builders-fleet-rg4h9-xqzbl", "fr-par-1", ""),
+		machineCR("a-differently-named-cr", "fr-par-1", "live-id"),
+	)
+
+	if err := r.reclaimOnce(context.Background()); err != nil {
+		t.Fatalf("reclaimOnce: %v", err)
+	}
+
+	if len(pool.releasedIDs) != 1 || pool.releasedIDs[0] != "stray-1" {
+		t.Fatalf("expected only stray-1 reclaimed, got %v", pool.releasedIDs)
+	}
+}
+
+// With no claim-name prefix the sweep is report-only: it counts every
+// stranded host on the gauge but mutates nothing.
+func TestOrphanReclaimer_ReportOnlyDoesNotMutate(t *testing.T) {
+	pool := &fakePool{byZone: map[string][]scaleway.Server{
+		"fr-par-1": {
+			{ID: "pool-1", Name: "tuist-pool-aaaa"},
+			{ID: "stray-1", Name: "tuist-tuist-builders-fleet-rg4h9-c295c"},
+			{ID: "foreign", Name: "apple-silicon-romantic-proskuriakova"},
+		},
+	}}
+
+	r := newReclaimerTest(t, pool, "")
+
+	if err := r.reclaimOnce(context.Background()); err != nil {
+		t.Fatalf("reclaimOnce: %v", err)
+	}
+
+	if len(pool.releasedIDs) != 0 {
+		t.Fatalf("report-only mode must not reclaim, got %v", pool.releasedIDs)
+	}
+	// stray-1 + foreign are both stranded (only pool-1 is excused), so
+	// the gauge reports 2 regardless of the claim-name gate.
+	if got := testutil.ToFloat64(orphanServersGauge); got != 2 {
+		t.Fatalf("expected gauge=2 stranded hosts, got %v", got)
+	}
+}

--- a/infra/cluster-api-provider-scaleway-applesilicon/controllers/scalewayapplesiliconmachine_controller.go
+++ b/infra/cluster-api-provider-scaleway-applesilicon/controllers/scalewayapplesiliconmachine_controller.go
@@ -152,6 +152,14 @@ type ScalewayAppleSiliconMachineReconciler struct {
 	// locking — bumping this only parallelizes across distinct CRs.
 	MaxConcurrentReconciles int
 
+	// DefaultAdoptPoolPrefix is the pool prefix reconcileDelete falls
+	// back to when a CR's Spec.AdoptPoolPrefix is empty. Spec now
+	// requires the field (MinLength=1), so this only covers legacy CRs
+	// created before that contract existed: without a fallback their
+	// delete skips the Scaleway release and strands the host. Empty
+	// preserves the skip behavior (no pool prefix to release into).
+	DefaultAdoptPoolPrefix string
+
 	// Tailscale egress Service materialisation. When EgressProxyGroup
 	// is non-empty, the reconciler maintains one ExternalName Service
 	// per Mac mini in EgressNamespace, annotated so the Tailscale K8s
@@ -724,27 +732,33 @@ func (r *ScalewayAppleSiliconMachineReconciler) reconcileDelete(
 	// Legacy CRs predating the required-AdoptPoolPrefix contract may
 	// still exist with the field unset (the older chart only
 	// rendered `adoptPoolPrefix` when the value was non-empty, so
-	// fleets that didn't set it produced bare CRs). For those we
-	// can't ReleaseToPool — the client rejects an empty prefix as a
-	// guard against orphaning hosts outside the pool namespace — so
-	// skip the Scaleway release stage entirely, leave the host
-	// running, and let the operator clean it up via the Scaleway
-	// console. Without this fallthrough, deleting a legacy CR would
-	// loop forever on a precondition error and block fleet teardown.
+	// fleets that didn't set it produced bare CRs). For those, fall
+	// back to the controller-level DefaultAdoptPoolPrefix so the host
+	// still returns to the pool. Only when neither the CR nor the
+	// controller default carries a prefix do we skip the Scaleway
+	// release (the client rejects an empty prefix to avoid orphaning a
+	// host outside the pool namespace), leave the host running, and
+	// let the orphan-reclaim sweep or an operator clean it up. Without
+	// this fallthrough, deleting a bare legacy CR would loop forever on
+	// a precondition error and block fleet teardown.
 	if machine.Status.ServerID != "" {
+		poolPrefix := machine.Spec.AdoptPoolPrefix
+		if poolPrefix == "" {
+			poolPrefix = r.DefaultAdoptPoolPrefix
+		}
 		switch {
-		case machine.Spec.AdoptPoolPrefix == "":
+		case poolPrefix == "":
 			r.Recorder.Eventf(machine, corev1.EventTypeWarning, "ReleaseSkipped",
-				"Spec.AdoptPoolPrefix is empty (legacy CR); skipping Scaleway release of %s — clean up the host via the Scaleway console if needed",
+				"No AdoptPoolPrefix on the CR and no controller default; skipping Scaleway release of %s — the orphan-reclaim sweep or an operator must return it to the pool",
 				machine.Status.ServerID)
-			logger.Info("legacy CR without AdoptPoolPrefix; skipping Scaleway release",
+			logger.Info("no pool prefix available; skipping Scaleway release",
 				"serverID", machine.Status.ServerID)
 			machine.Status.ServerID = ""
 		default:
 			r.Recorder.Eventf(machine, corev1.EventTypeNormal, "Releasing",
 				"Returning Scaleway server %s to pool %q (with reinstall)",
-				machine.Status.ServerID, machine.Spec.AdoptPoolPrefix)
-			if err := r.ScalewayClient.ReleaseToPool(ctx, machine.Status.ServerID, machine.Spec.Zone, machine.Spec.AdoptPoolPrefix); err != nil {
+				machine.Status.ServerID, poolPrefix)
+			if err := r.ScalewayClient.ReleaseToPool(ctx, machine.Status.ServerID, machine.Spec.Zone, poolPrefix); err != nil {
 				logger.Error(err, "Scaleway release-to-pool failed; will retry")
 				r.Recorder.Eventf(machine, corev1.EventTypeWarning, "ReleaseFailed",
 					"Scaleway ReleaseToPool: %v (will retry)", err)

--- a/infra/cluster-api-provider-scaleway-applesilicon/controllers/scalewayapplesiliconmachine_controller_test.go
+++ b/infra/cluster-api-provider-scaleway-applesilicon/controllers/scalewayapplesiliconmachine_controller_test.go
@@ -636,6 +636,45 @@ func TestReconcileDelete_LegacyCRWithoutPrefixSkipsRelease(t *testing.T) {
 	}
 }
 
+// TestReconcileDelete_LegacyCRUsesDefaultPrefix is the same legacy CR
+// (empty Spec.AdoptPoolPrefix), but with a controller-level
+// DefaultAdoptPoolPrefix configured. The release must now happen
+// against the default prefix instead of being skipped — closing the
+// strand-on-delete hole at the source for legacy CRs.
+func TestReconcileDelete_LegacyCRUsesDefaultPrefix(t *testing.T) {
+	api := &scalewayAPIStub{
+		servers: []*applesilicon.Server{{ID: "srv-legacy", Name: "tuist-tuist-macos-fleet-legacy"}},
+	}
+	machine := &infrav1.ScalewayAppleSiliconMachine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "macos-fleet-legacy",
+			Namespace:  "ns",
+			Finalizers: []string{MachineFinalizer},
+		},
+		Spec: infrav1.ScalewayAppleSiliconMachineSpec{
+			// Empty AdoptPoolPrefix — predates the required-prefix contract.
+			Zone: "fr-par-1",
+		},
+		Status: infrav1.ScalewayAppleSiliconMachineStatus{ServerID: "srv-legacy"},
+	}
+	r := newReconciler(t)
+	r.ScalewayClient = &scaleway.Client{API: api}
+	r.DefaultAdoptPoolPrefix = "tuist-pool-"
+
+	if _, err := r.reconcileDelete(context.Background(), machine); err != nil {
+		t.Fatalf("reconcileDelete: %v", err)
+	}
+	if got := api.reinstalledIDs; len(got) != 1 || got[0] != "srv-legacy" {
+		t.Fatalf("legacy CR with controller default must release to pool; got reinstalls %v", got)
+	}
+	if got := api.updatedNames; len(got) != 1 || !startsWith(got[0], "tuist-pool-") {
+		t.Fatalf("expected rename into the default pool namespace, got %v", got)
+	}
+	if machine.Status.ServerID != "" {
+		t.Fatalf("Status.ServerID should be cleared after release, got %q", machine.Status.ServerID)
+	}
+}
+
 func startsWith(s, prefix string) bool {
 	return len(s) >= len(prefix) && s[:len(prefix)] == prefix
 }

--- a/infra/cluster-api-provider-scaleway-applesilicon/internal/scaleway/client.go
+++ b/infra/cluster-api-provider-scaleway-applesilicon/internal/scaleway/client.go
@@ -179,8 +179,11 @@ func normalizePubKey(pub string) string {
 
 // Server is the subset of fields the CAPI controller cares about.
 type Server struct {
-	ID           string
-	IP           string
+	ID   string
+	Name string
+	IP   string
+	// Status is the Scaleway lifecycle phase (`ready`, `reinstalling`,
+	// `rebooting`, …) as a raw string.
 	Status       string
 	SudoPassword string
 	SSHUsername  string
@@ -213,6 +216,49 @@ func (c *Client) findServerByName(ctx context.Context, name, zone string) (*appl
 		}
 		page++
 	}
+}
+
+// ListServers returns every Apple Silicon server the configured
+// credentials can see in `zone`, reduced to the Server view. The
+// Scaleway API has no server-side name filter, so it paginates the
+// full list and the caller filters client-side — the project holds at
+// most a few dozen hosts, so a full scan is cheap. Used by the
+// orphan-reclaim sweep to diff live hosts against the CRs that own
+// them.
+func (c *Client) ListServers(ctx context.Context, zone string) ([]Server, error) {
+	var out []Server
+	page := int32(1)
+	pageSize := uint32(100)
+	for {
+		resp, err := c.API.ListServers(&applesilicon.ListServersRequest{
+			Zone:     scw.Zone(zone),
+			Page:     &page,
+			PageSize: &pageSize,
+		}, scw.WithContext(ctx))
+		if err != nil {
+			return nil, fmt.Errorf("list servers in %s: %w", zone, err)
+		}
+		for _, s := range resp.Servers {
+			out = append(out, *scalewayServerToServer(s))
+		}
+		if len(resp.Servers) < int(pageSize) {
+			return out, nil
+		}
+		page++
+	}
+}
+
+// IsPoolOrAdopting reports whether a Scaleway server name marks a host
+// that is parked in the adopt pool (carries poolPrefix) or mid-adoption
+// (carries the internal claim-pending marker). Either is
+// controller-managed and must never be treated as stranded by the
+// orphan-reclaim sweep — the claim-pending case especially, since that
+// host is in the middle of being adopted by a live reconcile.
+func IsPoolOrAdopting(name, poolPrefix string) bool {
+	if poolPrefix != "" && strings.HasPrefix(name, poolPrefix) {
+		return true
+	}
+	return strings.HasPrefix(name, claimPendingPrefix)
 }
 
 // ErrNoAvailableHost is returned by AdoptFromPool when no
@@ -557,6 +603,7 @@ const SealedSecretMarker = "<sealed>"
 func scalewayServerToServer(s *applesilicon.Server) *Server {
 	out := &Server{
 		ID:           s.ID,
+		Name:         s.Name,
 		Status:       string(s.Status),
 		SudoPassword: s.SudoPassword,
 		SSHUsername:  s.SSHUsername,

--- a/infra/cluster-api-provider-scaleway-applesilicon/internal/scaleway/client.go
+++ b/infra/cluster-api-provider-scaleway-applesilicon/internal/scaleway/client.go
@@ -60,8 +60,14 @@ type Client struct {
 	// org-wide list and Scaleway returns "insufficient permissions".
 	DefaultProjectID string
 
-	// adoptMu serializes AdoptFromPool across all goroutines in this
-	// process. Scaleway's UpdateServer is not conditional — two
+	// adoptMu serializes AdoptFromPool and ReleaseToPool against each
+	// other across all goroutines in this process. ReleaseToPool renames
+	// a host into the pool prefix and only then requests the reinstall,
+	// so between those two calls the host carries the pool prefix and is
+	// still Status==ready; without holding this lock a concurrent
+	// adoption scan could claim it in that window and then the reinstall
+	// would wipe the freshly-claimed host. Scaleway's UpdateServer is not
+	// conditional — two
 	// concurrent rename calls against the same server both succeed,
 	// last-write-wins — so per-call optimistic read-after-write
 	// verification can't establish a "we own this server" invariant.
@@ -531,6 +537,13 @@ func (c *Client) ReleaseToPool(ctx context.Context, id, zone, poolPrefix string)
 	if poolPrefix == "" {
 		return fmt.Errorf("ReleaseToPool: poolPrefix is required")
 	}
+
+	// Hold the adoption lock across the rename + reinstall request so an
+	// AdoptFromPool scan can't claim the host in the window where it
+	// already carries the pool prefix but the wipe hasn't been requested
+	// yet. See the adoptMu field comment.
+	c.adoptMu.Lock()
+	defer c.adoptMu.Unlock()
 
 	newName := poolPrefix + uuid.NewString()
 	if _, err := c.API.UpdateServer(&applesilicon.UpdateServerRequest{

--- a/infra/cluster-api-provider-scaleway-applesilicon/internal/scaleway/client_test.go
+++ b/infra/cluster-api-provider-scaleway-applesilicon/internal/scaleway/client_test.go
@@ -800,3 +800,48 @@ func TestReleaseToPool_PropagatesNonRecoverableReinstallError(t *testing.T) {
 		t.Fatalf("expected error to identify reinstall step, got %v", err)
 	}
 }
+
+func TestListServers_ReturnsIDAndName(t *testing.T) {
+	api := &fakeAppleSiliconAPI{servers: []*applesilicon.Server{
+		{ID: "a", Name: "tuist-pool-1", Status: applesilicon.ServerStatusReady},
+		{ID: "b", Name: "tuist-tuist-macos-fleet-0", Status: applesilicon.ServerStatusReady},
+	}}
+	c := newTestClient(api)
+
+	got, err := c.ListServers(context.Background(), "fr-par-1")
+	if err != nil {
+		t.Fatalf("ListServers: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 servers, got %d", len(got))
+	}
+	if got[0].ID != "a" || got[0].Name != "tuist-pool-1" {
+		t.Fatalf("unexpected first server: %+v", got[0])
+	}
+	if got[1].ID != "b" || got[1].Name != "tuist-tuist-macos-fleet-0" {
+		t.Fatalf("unexpected second server: %+v", got[1])
+	}
+}
+
+func TestIsPoolOrAdopting(t *testing.T) {
+	cases := []struct {
+		name   string
+		server string
+		prefix string
+		want   bool
+	}{
+		{"pool host", "tuist-pool-abc", "tuist-pool-", true},
+		{"claim-pending host", "tuist-claim-pending-xyz", "tuist-pool-", true},
+		{"claimed host", "tuist-tuist-macos-fleet-0", "tuist-pool-", false},
+		{"foreign default name", "apple-silicon-romantic-x", "tuist-pool-", false},
+		{"empty pool prefix still catches claim-pending", "tuist-claim-pending-1", "", true},
+		{"empty pool prefix does not blanket-match pool names", "tuist-pool-abc", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsPoolOrAdopting(tc.server, tc.prefix); got != tc.want {
+				t.Fatalf("IsPoolOrAdopting(%q, %q) = %v, want %v", tc.server, tc.prefix, got, tc.want)
+			}
+		})
+	}
+}

--- a/infra/helm/tuist/templates/capi-scaleway-applesilicon.yaml
+++ b/infra/helm/tuist/templates/capi-scaleway-applesilicon.yaml
@@ -294,19 +294,17 @@ spec:
             - --tailscale-egress-namespace={{ .Values.macosFleet.tailscaleEgress.namespace }}
             - --tailscale-egress-magicdns-suffix={{ required "macosFleet.tailscaleEgress.magicDNSSuffix is required when tailscaleEgress.enabled" .Values.macosFleet.tailscaleEgress.magicDNSSuffix }}
             {{- end }}
-            {{- with .Values.macosFleet.orphanReclaim }}
-            {{- if .poolPrefix }}
+            {{- if .Values.macosFleet.adoptPoolPrefix }}
             # Orphan-reclaim sweep + delete-path pool-prefix fallback.
-            # poolPrefix enables both the sweep and the per-Machine
-            # delete fallback (which actively prevents new strands);
-            # claimNamePrefix, when set, flips the sweep from report-only
-            # to active reclaim. See controllers/orphan_reclaimer.go.
-            - --default-adopt-pool-prefix={{ .poolPrefix }}
-            - --orphan-reclaim-zones={{ .zones | default "fr-par-1" }}
-            - --orphan-reclaim-interval={{ .interval | default "15m" }}
-            {{- with .claimNamePrefix }}
-            - --orphan-reclaim-claim-name-prefix={{ . }}
-            {{- end }}
+            # Pool prefix and swept zones are derived from the fleet
+            # config (the sweep also unions in every live CR's zone at
+            # runtime); the claimed-name prefix is the chart name. The
+            # sweep is report-only unless orphanReclaim.activeReclaim is
+            # set. See controllers/orphan_reclaimer.go.
+            - --default-adopt-pool-prefix={{ .Values.macosFleet.adoptPoolPrefix }}
+            - --orphan-reclaim-zones={{ list (.Values.macosFleet.machine.zone | default "fr-par-1") (.Values.runnersFleet.machine.zone | default "fr-par-1") (.Values.buildersFleet.machine.zone | default "fr-par-1") | uniq | join "," }}
+            {{- if .Values.macosFleet.orphanReclaim.activeReclaim }}
+            - --orphan-reclaim-claim-name-prefix={{ include "tuist.fullname" . }}-
             {{- end }}
             {{- end }}
           env:

--- a/infra/helm/tuist/templates/capi-scaleway-applesilicon.yaml
+++ b/infra/helm/tuist/templates/capi-scaleway-applesilicon.yaml
@@ -294,6 +294,21 @@ spec:
             - --tailscale-egress-namespace={{ .Values.macosFleet.tailscaleEgress.namespace }}
             - --tailscale-egress-magicdns-suffix={{ required "macosFleet.tailscaleEgress.magicDNSSuffix is required when tailscaleEgress.enabled" .Values.macosFleet.tailscaleEgress.magicDNSSuffix }}
             {{- end }}
+            {{- with .Values.macosFleet.orphanReclaim }}
+            {{- if .poolPrefix }}
+            # Orphan-reclaim sweep + delete-path pool-prefix fallback.
+            # poolPrefix enables both the sweep and the per-Machine
+            # delete fallback (which actively prevents new strands);
+            # claimNamePrefix, when set, flips the sweep from report-only
+            # to active reclaim. See controllers/orphan_reclaimer.go.
+            - --default-adopt-pool-prefix={{ .poolPrefix }}
+            - --orphan-reclaim-zones={{ .zones | default "fr-par-1" }}
+            - --orphan-reclaim-interval={{ .interval | default "15m" }}
+            {{- with .claimNamePrefix }}
+            - --orphan-reclaim-claim-name-prefix={{ . }}
+            {{- end }}
+            {{- end }}
+            {{- end }}
           env:
             # Scaleway credentials. ESO syncs them from 1Password into
             # this Secret automatically (see

--- a/infra/helm/tuist/values.yaml
+++ b/infra/helm/tuist/values.yaml
@@ -526,27 +526,21 @@ macosFleet:
   # Orphan-reclaim sweep — a leader-gated periodic sweep that returns
   # Scaleway hosts which were claimed by the controller but whose CR is
   # gone (a legacy CR that skipped release, a force-delete that bypassed
-  # the finalizer, a crash mid-claim) back to the adopt pool. `poolPrefix`
-  # also serves as the prefix the per-Machine delete path falls back to
-  # when a CR carries no adoptPoolPrefix, which actively prevents new
-  # strands. See controllers/orphan_reclaimer.go.
+  # the finalizer, a crash mid-claim) back to the adopt pool. The sweep's
+  # pool prefix and zones are derived from the fleet config
+  # (adoptPoolPrefix + each fleet's machine.zone) and the claimed-name
+  # prefix from the chart name, so the only knob here is whether the
+  # sweep may mutate. See controllers/orphan_reclaimer.go.
   orphanReclaim:
-    # Pool prefix (shared across all fleets). Setting it enables both the
-    # delete-path fallback and the sweep. Empty disables both.
-    poolPrefix: "tuist-pool-"
-    # Claimed-name namespace this cluster owns within the Scaleway
-    # project. Empty keeps the sweep report-only — it exports the
-    # scaleway_orphan_servers gauge and logs strays but never mutates a
-    # host. Set it to actively return stranded hosts to the pool. MUST be
-    # unique to this cluster when the Scaleway project is shared across
-    # environments: a non-unique prefix could reclaim another env's live
-    # host, whose CR isn't visible to this cluster's API server. Confirm
-    # per-env project isolation before enabling.
-    claimNamePrefix: ""
-    # Zones swept each cycle (comma-separated), unioned with the zones of
-    # all live CRs so a zone stays covered after its last CR is deleted.
-    zones: "fr-par-1"
-    interval: "15m"
+    # false (default): report-only. The sweep exports the
+    # scaleway_orphan_servers gauge and logs strays but never touches a
+    # host; the per-Machine delete path still falls back to the fleet
+    # pool prefix, which prevents new strands. true: the sweep also
+    # returns stranded hosts to the pool (rename + reinstall). Enable per
+    # env only after confirming this cluster has its own Scaleway project
+    # — a shared project could let the sweep reclaim another env's live
+    # host, whose CR isn't visible to this cluster's API server.
+    activeReclaim: false
 
   # tart-kubelet — kubelet-shaped agent the CAPI provider installs on
   # each Mac mini. Each Mac mini joins the cluster as a real Node and

--- a/infra/helm/tuist/values.yaml
+++ b/infra/helm/tuist/values.yaml
@@ -523,6 +523,31 @@ macosFleet:
   # split-horizon DNS, ad-hoc override).
   apiServerURL: ""
 
+  # Orphan-reclaim sweep — a leader-gated periodic sweep that returns
+  # Scaleway hosts which were claimed by the controller but whose CR is
+  # gone (a legacy CR that skipped release, a force-delete that bypassed
+  # the finalizer, a crash mid-claim) back to the adopt pool. `poolPrefix`
+  # also serves as the prefix the per-Machine delete path falls back to
+  # when a CR carries no adoptPoolPrefix, which actively prevents new
+  # strands. See controllers/orphan_reclaimer.go.
+  orphanReclaim:
+    # Pool prefix (shared across all fleets). Setting it enables both the
+    # delete-path fallback and the sweep. Empty disables both.
+    poolPrefix: "tuist-pool-"
+    # Claimed-name namespace this cluster owns within the Scaleway
+    # project. Empty keeps the sweep report-only — it exports the
+    # scaleway_orphan_servers gauge and logs strays but never mutates a
+    # host. Set it to actively return stranded hosts to the pool. MUST be
+    # unique to this cluster when the Scaleway project is shared across
+    # environments: a non-unique prefix could reclaim another env's live
+    # host, whose CR isn't visible to this cluster's API server. Confirm
+    # per-env project isolation before enabling.
+    claimNamePrefix: ""
+    # Zones swept each cycle (comma-separated), unioned with the zones of
+    # all live CRs so a zone stays covered after its last CR is deleted.
+    zones: "fr-par-1"
+    interval: "15m"
+
   # tart-kubelet — kubelet-shaped agent the CAPI provider installs on
   # each Mac mini. Each Mac mini joins the cluster as a real Node and
   # runs Pods scheduled to it as Tart VMs. The darwin/arm64 binary is


### PR DESCRIPTION
## What changed

Adds a convergent backstop and a source-level fix so Scaleway Apple-silicon Mac minis can no longer strand outside the adopt pool.

- **`OrphanReclaimer`** (`controllers/orphan_reclaimer.go`): a leader-gated periodic sweep. Each cycle it lists Scaleway hosts per zone (the zones from `--orphan-reclaim-zones` unioned with every live CR's zone), diffs them against the live `ScalewayAppleSiliconMachine` CRs, and treats a host as stranded when it is **not** in the pool, **not** mid-adoption, and matches **no** live CR by name or `status.serverID`. Stranded hosts are exported on a `scaleway_orphan_servers` gauge and, when active reclaim is enabled, returned to the pool via the existing `ReleaseToPool` (rename + reinstall). Before each release it re-checks ownership against the live API (uncached `APIReader`) so a host adopted since the scan is never reclaimed.
- **Controller-level `DefaultAdoptPoolPrefix`**: `reconcileDelete` now falls back to it when a CR's `Spec.AdoptPoolPrefix` is empty, so legacy CRs release on delete instead of skipping. This closes the leak at the source for new deletions.
- **Chart wiring** is a single `macosFleet.orphanReclaim.activeReclaim` toggle (default `false` = report-only). Everything else is derived from existing values: the pool prefix from `macosFleet.adoptPoolPrefix`, the swept zones from the fleets' `machine.zone`, and the claimed-name prefix from the chart name (`tuist-tuist-`). The binary keeps its flags as a generic provider, but the chart computes them rather than duplicating config.

## Why

The provider only releases a claimed host on the per-Machine `reconcileDelete` path. A host strands whenever that path doesn't run to completion:

1. A legacy CR with an empty `AdoptPoolPrefix` (created before the field was required) hit the documented skip branch: no release, just a `ReleaseSkipped` warning event.
2. A force-delete or owner-reference GC that bypasses the finalizer.
3. A crash between claiming a pool host and writing its CR.

A stranded host carries a CR-style Scaleway name but is owned by no CR, so nothing ever looks at it again. It keeps billing under Apple's 24h floor, and because the claim drained it from the `tuist-pool-*` pool, it silently shrinks the capacity `AdoptFromPool` draws from. That depletion is what later surfaced as `NoAvailableHost`: a builders-fleet `MachineDeployment` stuck `ScalingUp`, which a server deploy's `helm --wait` (kstatus watcher) gated on, wedging the deploy until timeout.

A confirmed instance: `tuist-tuist-builders-fleet-rg4h9-c295c` (an M2-L billing for 14 days, no CR), almost certainly leaked via the legacy-CR skip path.

## Why this design over the obvious alternatives

- **Sweep, not just fix the delete path.** Fixing `reconcileDelete` (the `DefaultAdoptPoolPrefix` change) only prevents *future* strands from the legacy-CR cause, and can't touch what already leaked or what bypasses the finalizer entirely. A convergent sweep catches every strand cause regardless of how it happened, and self-heals existing leaks. Both are included; they're complementary.
- **Name as the owned key.** The claim renames a pool host to its CR's name (`AdoptFromPool(ctx, machine.Name, ...)`), and the CR always exists before that rename. So a live CR name is an authoritative "owned" signal with no claimed-but-CR-missing window short of an actual delete. `serverID` is matched too, as a backstop.
- **Report-only by default; active reclaim gated.** Two hosts must never be reclaimed even though they look unowned: one an operator is mid-provisioning under a Scaleway-default name (e.g. `apple-silicon-romantic-*` before the rename to `tuist-pool-*`), and one owned by another cluster that shares the Scaleway project (its CR isn't visible to this cluster's API server). The claim-name prefix (`tuist-tuist-`) scopes active reclaim to this cluster's claimed namespace; with it unset the sweep only reports. Per the provider's `AGENTS.md`, each environment already runs its own Scaleway IAM application/project, so the sweep is project-scoped and the cross-env case is moot in practice, but the gate is kept as defense in depth.
- **Derive chart config, don't duplicate it.** The pool prefix, zones, and claimed-name prefix already live in the chart; the template computes the flags from them so there's a single source of truth and no drift. The only chart knob is the one thing the chart can't safely decide on its own: whether the sweep may mutate.

## Concurrency safety

- The pre-mutation re-check (uncached `APIReader`) closes a TOCTOU where a CR created and adopted after the cycle's initial snapshot could otherwise have its live host reclaimed.
- `ReleaseToPool` now holds the same `adoptMu` as `AdoptFromPool` across its rename + reinstall, so an adoption scan can't claim a host in the window where it carries the pool prefix but the reinstall hasn't been requested. (This also hardens the pre-existing delete path; the sweep just made the race more reachable.)

## User / operator impact

- Stranded hosts stop being invisible: the `scaleway_orphan_servers` gauge surfaces them, and a sustained non-zero value is the signal that the pool is leaking (worth an alert).
- With `activeReclaim` on, strays return to the pool automatically (rename + reinstall), so the pool stops silently draining, which removes one recurring trigger of wedged deploys.
- Default behavior is conservative: detection and the delete-path fallback are on; active reclaim is opted into per-env.

## Validation

- `go build ./...`, `go vet ./...`, and `go test -count=1 -race ./...` clean across the provider module.
- New tests: `OrphanReclaimer` reclaims exactly the stranded in-namespace host while leaving pool, claim-pending, CR-owned-by-name, and CR-owned-by-serverID hosts untouched; a host adopted since the scan is not reclaimed (the re-check); report-only mode mutates nothing but still counts strays on the gauge; `ListServers` and `IsPoolOrAdopting` unit tests; `reconcileDelete` releases a legacy CR via the controller default (and the existing skip-when-no-default test still passes).
- `helm template` with the production values renders `--default-adopt-pool-prefix=tuist-pool-` and `--orphan-reclaim-zones=fr-par-1` (report-only); `--set macosFleet.orphanReclaim.activeReclaim=true` adds `--orphan-reclaim-claim-name-prefix=tuist-tuist-`.

## Follow-up

- Active reclaim is report-only by default. Set `macosFleet.orphanReclaim.activeReclaim: true` per env (after confirming the env has its own Scaleway project) to enable it.
- A `scaleway_orphan_servers > 0` alert and a sustained-`NoAvailableHost` alert are the natural companions; not included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
