### PR TITLE
fix(kura): meter public cache traffic usage

### DIFF
--- a/kura/src/http.rs
+++ b/kura/src/http.rs
@@ -224,6 +224,13 @@ impl NamespaceQuery {
             }),
         }
     }
+
+    fn usage_context(&self) -> UsageContext {
+        UsageContext {
+            tenant_id: self.tenant_id.clone(),
+            namespace_id: self.namespace_id.clone(),
+        }
+    }
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -324,7 +331,13 @@ struct ProjectAnalyticsContext<'a> {
     namespace_id: &'a str,
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone)]
+struct UsageContext {
+    tenant_id: String,
+    namespace_id: String,
+}
+
+#[derive(Clone)]
 struct BlobPutSpec<'a> {
     namespace_id: &'a str,
     key: &'a str,
@@ -333,6 +346,7 @@ struct BlobPutSpec<'a> {
     success_status: StatusCode,
     existing_status: StatusCode,
     analytics: Option<ProjectAnalyticsContext<'a>>,
+    usage: Option<UsageContext>,
 }
 
 impl PageQuery {
@@ -1047,6 +1061,7 @@ async fn get_keyvalue(
         Ok(namespace) => namespace,
         Err(message) => return error_response(StatusCode::BAD_REQUEST, message),
     };
+    let usage = namespace.usage_context();
 
     let key = action_cache_key(&cas_id);
     match state.store.fetch_inline_artifact_bytes(
@@ -1058,6 +1073,13 @@ async fn get_keyvalue(
             state
                 .metrics
                 .record_artifact_read(ArtifactProducer::Xcode, "ok", bytes.len() as u64);
+            record_usage_event(
+                &state,
+                ArtifactProducer::Xcode,
+                "download",
+                Some(&usage),
+                bytes.len() as u64,
+            );
             (
                 [(
                     axum::http::header::CONTENT_TYPE,
@@ -1086,6 +1108,11 @@ async fn get_keyvalue(
 }
 
 async fn get_nx(AxumPath(hash): AxumPath<String>, State(state): State<SharedState>) -> Response {
+    let usage = UsageContext {
+        tenant_id: state.config.tenant_id.clone(),
+        namespace_id: NX_NAMESPACE_ID.to_owned(),
+    };
+
     get_artifact(
         state,
         ArtifactProducer::Nx,
@@ -1093,6 +1120,7 @@ async fn get_nx(AxumPath(hash): AxumPath<String>, State(state): State<SharedStat
         &hash,
         None,
         None,
+        Some(usage),
     )
     .await
 }
@@ -1102,6 +1130,11 @@ async fn put_nx(
     State(state): State<SharedState>,
     request: Request,
 ) -> Response {
+    let usage = UsageContext {
+        tenant_id: state.config.tenant_id.clone(),
+        namespace_id: NX_NAMESPACE_ID.to_owned(),
+    };
+
     put_blob_artifact(
         state,
         ArtifactProducer::Nx,
@@ -1114,6 +1147,7 @@ async fn put_nx(
             success_status: StatusCode::OK,
             existing_status: StatusCode::OK,
             analytics: None,
+            usage: Some(usage),
         },
     )
     .await
@@ -1123,6 +1157,11 @@ async fn get_metro(
     AxumPath(cache_key): AxumPath<String>,
     State(state): State<SharedState>,
 ) -> Response {
+    let usage = UsageContext {
+        tenant_id: state.config.tenant_id.clone(),
+        namespace_id: METRO_NAMESPACE_ID.to_owned(),
+    };
+
     get_artifact(
         state,
         ArtifactProducer::Metro,
@@ -1130,6 +1169,7 @@ async fn get_metro(
         &cache_key,
         None,
         None,
+        Some(usage),
     )
     .await
 }
@@ -1139,6 +1179,11 @@ async fn put_metro(
     State(state): State<SharedState>,
     request: Request,
 ) -> Response {
+    let usage = UsageContext {
+        tenant_id: state.config.tenant_id.clone(),
+        namespace_id: METRO_NAMESPACE_ID.to_owned(),
+    };
+
     put_blob_artifact(
         state,
         ArtifactProducer::Metro,
@@ -1151,6 +1196,7 @@ async fn put_metro(
             success_status: StatusCode::OK,
             existing_status: StatusCode::OK,
             analytics: None,
+            usage: Some(usage),
         },
     )
     .await
@@ -1165,6 +1211,7 @@ async fn put_keyvalue(
         Ok(namespace) => namespace,
         Err(message) => return error_response(StatusCode::BAD_REQUEST, message),
     };
+    let usage = namespace.usage_context();
 
     let body = match to_bytes(request.into_body(), state.config.max_keyvalue_bytes).await {
         Ok(body) => body,
@@ -1220,6 +1267,13 @@ async fn put_keyvalue(
             state
                 .metrics
                 .record_artifact_write(ArtifactProducer::Xcode, "ok", manifest.size);
+            record_usage_event(
+                &state,
+                ArtifactProducer::Xcode,
+                "upload",
+                Some(&usage),
+                manifest.size,
+            );
             StatusCode::NO_CONTENT.into_response()
         }
         Err(error) => {
@@ -1245,6 +1299,7 @@ async fn get_xcode(
     };
 
     let analytics = namespace.project_analytics_context();
+    let usage = namespace.usage_context();
 
     get_artifact(
         state,
@@ -1253,6 +1308,7 @@ async fn get_xcode(
         &blob_key(&id),
         Some(&id),
         analytics,
+        Some(usage),
     )
     .await
 }
@@ -1269,6 +1325,7 @@ async fn put_xcode(
     };
 
     let analytics = namespace.project_analytics_context();
+    let usage = namespace.usage_context();
 
     put_blob_artifact(
         state,
@@ -1282,6 +1339,7 @@ async fn put_xcode(
             success_status: StatusCode::NO_CONTENT,
             existing_status: StatusCode::NO_CONTENT,
             analytics,
+            usage: Some(usage),
         },
     )
     .await
@@ -1298,6 +1356,7 @@ async fn get_gradle(
     };
 
     let analytics = namespace.project_analytics_context();
+    let usage = namespace.usage_context();
 
     get_artifact(
         state,
@@ -1306,6 +1365,7 @@ async fn get_gradle(
         &cache_key,
         Some(&cache_key),
         analytics,
+        Some(usage),
     )
     .await
 }
@@ -1322,6 +1382,7 @@ async fn put_gradle(
     };
 
     let analytics = namespace.project_analytics_context();
+    let usage = namespace.usage_context();
 
     put_blob_artifact(
         state,
@@ -1335,6 +1396,7 @@ async fn put_gradle(
             success_status: StatusCode::CREATED,
             existing_status: StatusCode::OK,
             analytics,
+            usage: Some(usage),
         },
     )
     .await
@@ -1375,6 +1437,7 @@ async fn get_module(
         Ok(query) => query,
         Err(message) => return error_response(StatusCode::BAD_REQUEST, message),
     };
+    let usage = query.namespace.usage_context();
 
     get_artifact(
         state,
@@ -1383,6 +1446,7 @@ async fn get_module(
         &query.artifact_key(),
         None,
         None,
+        Some(usage),
     )
     .await
 }
@@ -1505,6 +1569,15 @@ async fn complete_module_upload(
         Ok(query) => query,
         Err(message) => return error_response(StatusCode::BAD_REQUEST, message),
     };
+    let usage = state
+        .store
+        .multipart_upload(&query.upload_id)
+        .ok()
+        .flatten()
+        .map(|upload| UsageContext {
+            tenant_id: upload.tenant_id,
+            namespace_id: upload.namespace_id,
+        });
 
     let targets = replication_targets(&state).await;
     match state
@@ -1517,6 +1590,13 @@ async fn complete_module_upload(
             state
                 .metrics
                 .record_artifact_write(ArtifactProducer::Module, "ok", manifest.size);
+            record_usage_event(
+                &state,
+                ArtifactProducer::Module,
+                "upload",
+                usage.as_ref(),
+                manifest.size,
+            );
             StatusCode::NO_CONTENT.into_response()
         }
         Err(MultipartError::NotFound) => error_response(StatusCode::NOT_FOUND, "Upload not found"),
@@ -1820,6 +1900,7 @@ async fn get_artifact(
     key: &str,
     analytics_key: Option<&str>,
     analytics: Option<ProjectAnalyticsContext<'_>>,
+    usage: Option<UsageContext>,
 ) -> Response {
     match state
         .store
@@ -1832,7 +1913,7 @@ async fn get_artifact(
                 state
                     .metrics
                     .record_artifact_read(producer, "ok", manifest.size);
-                record_usage_event(&state, producer, "download", analytics, manifest.size);
+                record_usage_event(&state, producer, "download", usage.as_ref(), manifest.size);
                 record_project_scoped_cache_event(
                     &state,
                     producer,
@@ -1925,7 +2006,13 @@ async fn put_blob_artifact(
             state
                 .metrics
                 .record_artifact_write(producer, "ok", manifest.size);
-            record_usage_event(&state, producer, "upload", spec.analytics, manifest.size);
+            record_usage_event(
+                &state,
+                producer,
+                "upload",
+                spec.usage.as_ref(),
+                manifest.size,
+            );
             record_project_scoped_cache_event(
                 &state,
                 producer,
@@ -1950,10 +2037,10 @@ fn record_usage_event(
     state: &SharedState,
     producer: ArtifactProducer,
     action: &str,
-    analytics: Option<ProjectAnalyticsContext<'_>>,
+    usage_context: Option<&UsageContext>,
     size: u64,
 ) {
-    let Some(context) = analytics else {
+    let Some(context) = usage_context else {
         return;
     };
     let Some(usage) = state.usage.as_ref() else {
@@ -1963,14 +2050,17 @@ fn record_usage_event(
 
     match action {
         "download" => usage.record_public_download(
-            context.tenant_id,
-            context.namespace_id,
+            &context.tenant_id,
+            &context.namespace_id,
             artifact_kind,
             size,
         ),
-        "upload" => {
-            usage.record_public_upload(context.tenant_id, context.namespace_id, artifact_kind, size)
-        }
+        "upload" => usage.record_public_upload(
+            &context.tenant_id,
+            &context.namespace_id,
+            artifact_kind,
+            size,
+        ),
         _ => {}
     }
 }
@@ -2086,10 +2176,24 @@ mod tests {
     use super::*;
     use crate::{
         artifact::producer::ArtifactProducer,
-        config::AnalyticsConfig,
+        config::{AnalyticsConfig, UsageConfig},
         test_support::{response_text, test_context},
         utils::blob_key,
     };
+
+    fn test_usage_config() -> UsageConfig {
+        UsageConfig {
+            control_plane_url: "http://localhost:0".to_owned(),
+            client_id: "kura".to_owned(),
+            client_secret: "secret".to_owned(),
+            window_secs: 60,
+            flush_interval_ms: 1_000,
+            delivery_interval_ms: 1_000,
+            batch_size: 100,
+            max_buckets: 100,
+            outbox_max_depth: 100,
+        }
+    }
 
     #[tokio::test]
     async fn up_includes_current_node_and_known_members() {
@@ -2540,6 +2644,70 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn keyvalue_routes_emit_usage_events() {
+        let context = test_context(|config| {
+            config.usage = Some(test_usage_config());
+        })
+        .await;
+        let app = router(context.state.clone());
+
+        let put_response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri("/api/cache/keyvalue?tenant_id=acme&namespace_id=ios")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        r#"{"cas_id":"cas-1","entries":[{"value":"x"}]}"#,
+                    ))
+                    .expect("failed to build put request"),
+            )
+            .await
+            .expect("put request failed");
+        assert_eq!(put_response.status(), StatusCode::NO_CONTENT);
+
+        let get_response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/cache/keyvalue/cas-1?tenant_id=acme&namespace_id=ios")
+                    .body(Body::empty())
+                    .expect("failed to build get request"),
+            )
+            .await
+            .expect("get request failed");
+        assert_eq!(get_response.status(), StatusCode::OK);
+        let body = response_text(get_response).await;
+        assert_eq!(body, r#"{"entries":[{"value":"x"}]}"#);
+
+        let rollups = context
+            .state
+            .usage
+            .as_ref()
+            .expect("usage should be enabled")
+            .current_rollups_for_tests();
+
+        assert!(rollups.iter().any(|rollup| {
+            rollup.tenant_id == "acme"
+                && rollup.namespace_id == "ios"
+                && rollup.direction == "ingress"
+                && rollup.operation == "upload"
+                && rollup.artifact_kind == "xcode"
+                && rollup.bytes == 27
+                && rollup.request_count == 1
+        }));
+        assert!(rollups.iter().any(|rollup| {
+            rollup.tenant_id == "acme"
+                && rollup.namespace_id == "ios"
+                && rollup.direction == "egress"
+                && rollup.operation == "download"
+                && rollup.artifact_kind == "xcode"
+                && rollup.bytes == 27
+                && rollup.request_count == 1
+        }));
+    }
+
+    #[tokio::test]
     async fn account_and_project_handle_aliases_work_through_router() {
         let context = test_context(|_| {}).await;
         let app = router(context.state.clone());
@@ -2745,6 +2913,164 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn tenant_only_xcode_routes_emit_usage_events() {
+        let context = test_context(|config| {
+            config.usage = Some(test_usage_config());
+        })
+        .await;
+        let app = router(context.state.clone());
+
+        let put_response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/cache/cas/account-artifact?tenant_id=acme")
+                    .header("content-type", "application/octet-stream")
+                    .body(Body::from("account-binary"))
+                    .expect("failed to build put request"),
+            )
+            .await
+            .expect("put request failed");
+        assert_eq!(put_response.status(), StatusCode::NO_CONTENT);
+
+        let get_response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/cache/cas/account-artifact?tenant_id=acme")
+                    .body(Body::empty())
+                    .expect("failed to build get request"),
+            )
+            .await
+            .expect("get request failed");
+        assert_eq!(get_response.status(), StatusCode::OK);
+        assert_eq!(response_text(get_response).await, "account-binary");
+
+        let rollups = context
+            .state
+            .usage
+            .as_ref()
+            .expect("usage should be enabled")
+            .current_rollups_for_tests();
+
+        assert!(rollups.iter().any(|rollup| {
+            rollup.tenant_id == "acme"
+                && rollup.namespace_id.is_empty()
+                && rollup.direction == "ingress"
+                && rollup.operation == "upload"
+                && rollup.artifact_kind == "xcode"
+                && rollup.bytes == 14
+                && rollup.request_count == 1
+        }));
+        assert!(rollups.iter().any(|rollup| {
+            rollup.tenant_id == "acme"
+                && rollup.namespace_id.is_empty()
+                && rollup.direction == "egress"
+                && rollup.operation == "download"
+                && rollup.artifact_kind == "xcode"
+                && rollup.bytes == 14
+                && rollup.request_count == 1
+        }));
+    }
+
+    #[tokio::test]
+    async fn fixed_namespace_cache_routes_emit_usage_events() {
+        let context = test_context(|config| {
+            config.tenant_id = "acme".into();
+            config.usage = Some(test_usage_config());
+        })
+        .await;
+        let app = router(context.state.clone());
+
+        let nx_put = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri("/v1/cache/nx-key")
+                    .body(Body::from("nx-bytes"))
+                    .expect("failed to build nx put request"),
+            )
+            .await
+            .expect("nx put request failed");
+        assert_eq!(nx_put.status(), StatusCode::OK);
+
+        let nx_get = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/v1/cache/nx-key")
+                    .body(Body::empty())
+                    .expect("failed to build nx get request"),
+            )
+            .await
+            .expect("nx get request failed");
+        assert_eq!(nx_get.status(), StatusCode::OK);
+        assert_eq!(response_text(nx_get).await, "nx-bytes");
+
+        let metro_put = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri("/api/metro/cache/metro-key")
+                    .body(Body::from("metro-bytes"))
+                    .expect("failed to build metro put request"),
+            )
+            .await
+            .expect("metro put request failed");
+        assert_eq!(metro_put.status(), StatusCode::OK);
+
+        let metro_get = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/metro/cache/metro-key")
+                    .body(Body::empty())
+                    .expect("failed to build metro get request"),
+            )
+            .await
+            .expect("metro get request failed");
+        assert_eq!(metro_get.status(), StatusCode::OK);
+        assert_eq!(response_text(metro_get).await, "metro-bytes");
+
+        let rollups = context
+            .state
+            .usage
+            .as_ref()
+            .expect("usage should be enabled")
+            .current_rollups_for_tests();
+
+        assert!(rollups.iter().any(|rollup| {
+            rollup.tenant_id == "acme"
+                && rollup.namespace_id == "nx"
+                && rollup.direction == "ingress"
+                && rollup.artifact_kind == "nx"
+                && rollup.bytes == 8
+        }));
+        assert!(rollups.iter().any(|rollup| {
+            rollup.tenant_id == "acme"
+                && rollup.namespace_id == "nx"
+                && rollup.direction == "egress"
+                && rollup.artifact_kind == "nx"
+                && rollup.bytes == 8
+        }));
+        assert!(rollups.iter().any(|rollup| {
+            rollup.tenant_id == "acme"
+                && rollup.namespace_id == "metro"
+                && rollup.direction == "ingress"
+                && rollup.artifact_kind == "metro"
+                && rollup.bytes == 11
+        }));
+        assert!(rollups.iter().any(|rollup| {
+            rollup.tenant_id == "acme"
+                && rollup.namespace_id == "metro"
+                && rollup.direction == "egress"
+                && rollup.artifact_kind == "metro"
+                && rollup.bytes == 11
+        }));
+    }
+
+    #[tokio::test]
     async fn multipart_module_round_trip_works_through_router() {
         let context = test_context(|_| {}).await;
         let app = router(context.state.clone());
@@ -2834,6 +3160,99 @@ mod tests {
             Some("17")
         );
         assert_eq!(response_text(get).await, "part-one-part-two");
+    }
+
+    #[tokio::test]
+    async fn multipart_module_routes_emit_usage_events() {
+        let context = test_context(|config| {
+            config.usage = Some(test_usage_config());
+        })
+        .await;
+        let app = router(context.state.clone());
+
+        let start = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/cache/module/start?tenant_id=acme&namespace_id=ios&hash=hash-1&name=Module.framework&cache_category=builds")
+                    .body(Body::empty())
+                    .expect("failed to build start request"),
+            )
+            .await
+            .expect("start request failed");
+        let payload: Value = serde_json::from_str(&response_text(start).await)
+            .expect("failed to decode start payload");
+        let upload_id = payload["upload_id"]
+            .as_str()
+            .expect("upload id should be present");
+
+        let part_response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!(
+                        "/api/cache/module/part?upload_id={upload_id}&part_number=1"
+                    ))
+                    .body(Body::from("module-bytes"))
+                    .expect("failed to build part request"),
+            )
+            .await
+            .expect("part request failed");
+        assert_eq!(part_response.status(), StatusCode::NO_CONTENT);
+
+        let complete_response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/api/cache/module/complete?upload_id={upload_id}"))
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"parts":[1]}"#))
+                    .expect("failed to build complete request"),
+            )
+            .await
+            .expect("complete request failed");
+        assert_eq!(complete_response.status(), StatusCode::NO_CONTENT);
+
+        let get_response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/cache/module/module-1?tenant_id=acme&namespace_id=ios&hash=hash-1&name=Module.framework&cache_category=builds")
+                    .body(Body::empty())
+                    .expect("failed to build get request"),
+            )
+            .await
+            .expect("get request failed");
+        assert_eq!(get_response.status(), StatusCode::OK);
+        assert_eq!(response_text(get_response).await, "module-bytes");
+
+        let rollups = context
+            .state
+            .usage
+            .as_ref()
+            .expect("usage should be enabled")
+            .current_rollups_for_tests();
+
+        assert!(rollups.iter().any(|rollup| {
+            rollup.tenant_id == "acme"
+                && rollup.namespace_id == "ios"
+                && rollup.direction == "ingress"
+                && rollup.operation == "upload"
+                && rollup.artifact_kind == "module"
+                && rollup.bytes == 12
+                && rollup.request_count == 1
+        }));
+        assert!(rollups.iter().any(|rollup| {
+            rollup.tenant_id == "acme"
+                && rollup.namespace_id == "ios"
+                && rollup.direction == "egress"
+                && rollup.operation == "download"
+                && rollup.artifact_kind == "module"
+                && rollup.bytes == 12
+                && rollup.request_count == 1
+        }));
     }
 
     #[tokio::test]

--- a/kura/src/test_support.rs
+++ b/kura/src/test_support.rs
@@ -17,6 +17,7 @@ use crate::{
     runtime::{DataDirLock, RuntimeState},
     state::{AppState, ReadinessState},
     store::Store,
+    usage::Usage,
 };
 
 pub(crate) struct TestContext {
@@ -109,6 +110,8 @@ where
     let analytics =
         Analytics::from_config(config.analytics.as_ref(), &config.node_url, metrics.clone())
             .expect("failed to build test analytics");
+    let usage = Usage::from_config(config.usage.as_ref(), &config.node_url, metrics.clone())
+        .expect("failed to build test usage");
     let client = Client::builder()
         .timeout(Duration::from_secs(5))
         .build()
@@ -124,7 +127,7 @@ where
         runtime: RuntimeState::new(),
         extension,
         analytics,
-        usage: None,
+        usage,
         geoip: None,
         client,
         notify: Notify::new(),

--- a/kura/src/usage.rs
+++ b/kura/src/usage.rs
@@ -191,39 +191,43 @@ impl Usage {
         closed_keys
             .into_iter()
             .filter_map(|key| {
-                buckets.get(&key).map(|bucket| {
-                    let event_id = format!(
-                        "{}:{}:{}:{}:{}:{}:{}:{}:{}",
-                        self.inner.node_id,
-                        key.window_start_unix_seconds,
-                        key.tenant_id,
-                        key.namespace_id,
-                        key.traffic_plane,
-                        key.direction,
-                        key.operation,
-                        key.protocol,
-                        key.artifact_kind
-                    );
-                    let rollup = UsageRollup {
-                        event_id,
-                        tenant_id: key.tenant_id.clone(),
-                        namespace_id: key.namespace_id.clone(),
-                        window_start_unix_seconds: key.window_start_unix_seconds,
-                        window_seconds: self.inner.config.window_secs,
-                        node_id: self.inner.node_id.clone(),
-                        region: self.inner.region.clone(),
-                        traffic_plane: key.traffic_plane.to_owned(),
-                        direction: key.direction.to_owned(),
-                        operation: key.operation.to_owned(),
-                        protocol: key.protocol.to_owned(),
-                        artifact_kind: key.artifact_kind.to_owned(),
-                        bytes: bucket.bytes,
-                        request_count: bucket.request_count,
-                    };
-                    (key, rollup)
-                })
+                buckets
+                    .get(&key)
+                    .map(|bucket| (key.clone(), self.rollup_for_bucket(&key, bucket)))
             })
             .collect()
+    }
+
+    fn rollup_for_bucket(&self, key: &UsageBucketKey, bucket: &UsageBucket) -> UsageRollup {
+        let event_id = format!(
+            "{}:{}:{}:{}:{}:{}:{}:{}:{}",
+            self.inner.node_id,
+            key.window_start_unix_seconds,
+            key.tenant_id,
+            key.namespace_id,
+            key.traffic_plane,
+            key.direction,
+            key.operation,
+            key.protocol,
+            key.artifact_kind
+        );
+
+        UsageRollup {
+            event_id,
+            tenant_id: key.tenant_id.clone(),
+            namespace_id: key.namespace_id.clone(),
+            window_start_unix_seconds: key.window_start_unix_seconds,
+            window_seconds: self.inner.config.window_secs,
+            node_id: self.inner.node_id.clone(),
+            region: self.inner.region.clone(),
+            traffic_plane: key.traffic_plane.to_owned(),
+            direction: key.direction.to_owned(),
+            operation: key.operation.to_owned(),
+            protocol: key.protocol.to_owned(),
+            artifact_kind: key.artifact_kind.to_owned(),
+            bytes: bucket.bytes,
+            request_count: bucket.request_count,
+        }
     }
 
     fn remove_buckets(&self, keys: &[UsageBucketKey]) {
@@ -231,6 +235,16 @@ impl Usage {
         for key in keys {
             buckets.remove(key);
         }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn current_rollups_for_tests(&self) -> Vec<UsageRollup> {
+        let buckets = self.inner.buckets.lock().expect("usage buckets poisoned");
+
+        buckets
+            .iter()
+            .map(|(key, bucket)| self.rollup_for_bucket(key, bucket))
+            .collect()
     }
 }
 


### PR DESCRIPTION
Resolves N/A

This fixes Kura usage visibility by metering successful public cache transfers independently from project-scoped analytics.

Usage events now cover key-value, Xcode, Gradle, Nx, Metro, and module cache ingress and egress paths. Module multipart uploads snapshot the tenant and namespace from the multipart upload before completion removes that state, then record ingress after the artifact is persisted. Internal replication and bootstrap routes remain excluded because they are peer maintenance traffic, not customer-facing usage.

### How to test locally

- `mise exec -- cargo test http::tests`
- `mise exec -- cargo clippy --all-targets -- -D warnings`
