### PR TITLE
fix(linux-runner-image): release on path changes, not just commit scope

### DIFF
--- a/infra/linux-runner-image/cliff.toml
+++ b/infra/linux-runner-image/cliff.toml
@@ -62,21 +62,24 @@ split_commits = false
 commit_preprocessors = [
     { pattern = '\((\w+\s)?#([0-9]+)\)', replace = "" },
 ]
-# Match commits scoped to linux-runner-image. Covers the Linux
-# OCI image hosting customer-facing GitHub Actions runners
-# (Dockerfile + dispatch-poll script). Distinct from the
-# macOS runner-image which lives in `infra/runner-image/`.
+# Path-scoped releases: check.sh and the release-notes / CHANGELOG
+# steps pass `--include-path infra/linux-runner-image/**`, so the
+# directory is the release gate. Parsers match by type only (not by a
+# `linux-runner-image` scope), so any feat/fix touching the image —
+# whatever the commit's conventional scope — bumps it. Covers the
+# Linux OCI image hosting customer-facing GitHub Actions runners
+# (Dockerfile + dispatch-poll script); the macOS runner-image lives
+# in `infra/runner-image/` and is path-filtered out.
 commit_parsers = [
-    { message = "^feat\\([^)]*\\blinux-runner-image\\b[^)]*\\)", group = "<!-- 0 -->⛰️  Features" },
-    { message = "^fix\\([^)]*\\blinux-runner-image\\b[^)]*\\)", group = "<!-- 1 -->🐛 Bug Fixes" },
-    { message = "^docs?\\([^)]*\\blinux-runner-image\\b[^)]*\\)", group = "<!-- 3 -->📚 Documentation" },
-    { message = "^perf\\([^)]*\\blinux-runner-image\\b[^)]*\\)", group = "<!-- 4 -->⚡ Performance" },
-    { message = "^refactor\\([^)]*\\blinux-runner-image\\b[^)]*\\)", group = "<!-- 2 -->🚜 Refactor" },
-    { message = "^style\\([^)]*\\blinux-runner-image\\b[^)]*\\)", group = "<!-- 5 -->🎨 Styling" },
-    { message = "^test\\([^)]*\\blinux-runner-image\\b[^)]*\\)", group = "<!-- 6 -->🧪 Testing" },
-    { message = "^chore\\([^)]*\\blinux-runner-image\\b[^)]*\\)", skip = true },
-    { message = "^ci\\([^)]*\\blinux-runner-image\\b[^)]*\\)", skip = true },
-    { message = "^[a-z]+\\([^)]+\\)", skip = true },
+    { message = "^feat[(:!]", group = "<!-- 0 -->⛰️  Features" },
+    { message = "^fix[(:!]", group = "<!-- 1 -->🐛 Bug Fixes" },
+    { message = "^docs?[(:!]", group = "<!-- 3 -->📚 Documentation" },
+    { message = "^perf[(:!]", group = "<!-- 4 -->⚡ Performance" },
+    { message = "^refactor[(:!]", group = "<!-- 2 -->🚜 Refactor" },
+    { message = "^style[(:!]", group = "<!-- 5 -->🎨 Styling" },
+    { message = "^test[(:!]", group = "<!-- 6 -->🧪 Testing" },
+    { message = "^chore[(:!]", skip = true },
+    { message = "^ci[(:!]", skip = true },
 ]
 protect_breaking_commits = false
 filter_commits = true


### PR DESCRIPTION
## What changed

Rewrites the `infra/linux-runner-image/cliff.toml` commit parsers to match by conventional-commit **type** (`feat`/`fix`/...) instead of requiring a `linux-runner-image` **scope**. The release check already passes `--include-path infra/linux-runner-image/**` to git-cliff, so the directory becomes the actual release gate.

## Why (root cause)

`mise/tasks/release/check.sh` decides whether to release a component by running:

```
git cliff --include-path "infra/linux-runner-image/**/*" --config <cliff.toml> --bumped-version -- <last-tag>..HEAD
```

The `--include-path` correctly restricts git-cliff to commits that touched the image directory. But the cliff.toml parsers then required the commit's *conventional scope* to contain `linux-runner-image`, and skipped everything else via the `^[a-z]+\(...\)` catch-all. With `filter_commits = true`, a path-touching commit under any other scope was discarded, so it produced no version bump and no release. The `--include-path` was doing nothing; the scope was the real (and wrong) gate.

That is exactly how the runner image ended up without a Docker client:

- #10905 (`feat(infra): docker-in-runner`) added `docker-ce-cli` + buildx + compose to the Dockerfile.
- It touched `infra/linux-runner-image/Dockerfile`, so it passed `--include-path` — but its scope is `infra`, so the parser skipped it. No release.
- Production stayed pinned to `linux-runner-image@0.1.1` (cut 2026-05-27, six days before the CLI was added).
- So even after the dind sidecar was enabled (#11055), Docker workflows on `tuist-linux` fail with `Unable to locate executable file: docker` — the daemon is there, the client isn't.

## The fix

Match by type, let `--include-path` gate by path. Any `feat`/`fix`/`docs`/`perf`/`refactor`/`style`/`test` touching `infra/linux-runner-image/**` now triggers a release, whatever the commit's scope. `chore`/`ci` stay skipped. The release-notes and CHANGELOG steps already pass the same `--include-path`, so the changelog is not polluted by unrelated commits.

## Impact

On merge, the release check re-evaluates `linux-runner-image@0.1.1..HEAD`, now counts #10905's `feat`, and cuts the overdue **`linux-runner-image@0.2.0`** — built from the current Dockerfile (with the Docker CLI), on the external runner it still uses on `main`. The release pipeline pins the new digest into the managed values; the next server deploy rolls it out, and Docker finally works on the in-house fleet. This is the prerequisite that unblocks #11057.

## Validation

- `git cliff --bumped-version` with the new config returns `linux-runner-image@0.2.0` (was stuck at `0.1.1`).
- Generated release notes correctly list `docker-in-runner for Linux pools` under Features and nothing unrelated.

## Note: this pattern is systemic

The same scope-gated catch-all (`^[a-z]+\(...\)` skip) exists in **14 other** component `cliff.toml` files (`server`, `cli`, `cache`, `kura`, `runners-controller`, `app`, `noora`, `gradle`, `skills`, and the other infra images). Each has the same latent failure: a path-touching change under a mismatched scope silently skips its release. Worth a follow-up to convert them all to path-gated, but doing it in one shot risks triggering a wave of catch-up releases, so it's intentionally out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)