### PR TITLE
fix(infra): wire canary Kura introspection secrets

### DIFF
--- a/infra/helm/tuist/values-managed-canary.yaml
+++ b/infra/helm/tuist/values-managed-canary.yaml
@@ -14,6 +14,10 @@ server:
 
   appUrl: https://canary.tuist.dev
 
+  externalSecrets:
+    kuraIntrospection:
+      item: kura-introspection-oauth-client
+
   autoscaling:
     enabled: false
 
@@ -70,6 +74,12 @@ objectStorage:
   external:
     buckets:
       default: tuist-can-storage
+
+kuraController:
+  sharedSecrets:
+    externalSecret:
+      enabled: true
+      item: kura-introspection-oauth-client
 
 # CloudNativePG cluster — canary shape. 2 instances (primary + 1 sync
 # replica), 10Gi per instance. Matches the cluster's general-purpose


### PR DESCRIPTION
## Summary
- Sync the canary Kura introspection OAuth client from the `kura-introspection-oauth-client` 1Password item into the Tuist server ExternalSecret.
- Enable the canary Kura controller shared-secret ExternalSecret so Kura runtime pods receive the matching introspection client secret.
- Align canary with the production Kura auth wiring so module cache requests can authenticate against `https://canary.tuist.dev`.

## Testing
- `helm template tuist infra/helm/tuist -n tuist-canary -f infra/helm/tuist/values-managed-common.yaml -f infra/helm/tuist/values-managed-canary.yaml --set server.image.tag=test --set kuraController.image.tag=test | rg -n "kura-introspection-oauth-client|TUIST_KURA_INTROSPECTION_CLIENT_ID|KURA_CONTROL_PLANE_CLIENT_ID|name: kura-shared-secrets|kind: ExternalSecret|name: tuist-tuist-server-external-secrets" -C 3`
- Updated the canary 1Password item `kura-introspection-oauth-client` so the client id fields use the UUID-only value expected by the OAuth introspection endpoint.
