### PR TITLE
feat(server): cut staging + canary over to CNPG

### DIFF
--- a/infra/helm/tuist/values-managed-canary.yaml
+++ b/infra/helm/tuist/values-managed-canary.yaml
@@ -84,6 +84,7 @@ objectStorage:
 # footprint climbs. Backups land in the `tuist-can-pg-backups` Tigris
 # bucket.
 postgresql:
+  mode: cnpg
   cnpg:
     instances: 2
     storage:

--- a/infra/helm/tuist/values-managed-staging.yaml
+++ b/infra/helm/tuist/values-managed-staging.yaml
@@ -106,6 +106,13 @@ objectStorage:
 # the migration-job ends up Pending. The 4Gi limit stays so runtime
 # memory isn't constrained.
 postgresql:
+  # Cutover to the in-cluster CNPG cluster. The chart's server-deployment,
+  # processor-external-secrets, and server-migration-job templates resolve
+  # DATABASE_URL from the CNPG `<cluster>-app` Secret instead of the
+  # Supabase pooler. Initial COPY from Supabase finished at 0 lag; the
+  # subscription is dropped at cutover so the now-active CNPG isn't
+  # rewinding Supabase replays into itself.
+  mode: cnpg
   cnpg:
     instances: 2
     storage:

--- a/infra/helm/tuist/values-managed-staging.yaml
+++ b/infra/helm/tuist/values-managed-staging.yaml
@@ -106,12 +106,6 @@ objectStorage:
 # the migration-job ends up Pending. The 4Gi limit stays so runtime
 # memory isn't constrained.
 postgresql:
-  # Cutover to the in-cluster CNPG cluster. The chart's server-deployment,
-  # processor-external-secrets, and server-migration-job templates resolve
-  # DATABASE_URL from the CNPG `<cluster>-app` Secret instead of the
-  # Supabase pooler. Initial COPY from Supabase finished at 0 lag; the
-  # subscription is dropped at cutover so the now-active CNPG isn't
-  # rewinding Supabase replays into itself.
   mode: cnpg
   cnpg:
     instances: 2


### PR DESCRIPTION
## What

Flip `postgresql.mode` from the inherited `external` (Supabase pooler) to `cnpg` in both `values-managed-staging.yaml` and `values-managed-canary.yaml`.

```diff
 postgresql:
+  mode: cnpg
   cnpg: { ... }
```

After deploy, server / processor / migration-job pods in each env resolve `DATABASE_URL` from the in-cluster `tuist-tuist-pg-app` Secret and the `<cluster>-rw` Service instead of the Supabase host.

Production is **not** included; it'll land in a separate PR after its CNPG soak.

## State at the time of cutover

### staging
| | |
|---|---|
| Cluster | healthy, 2/2 |
| Subscription `tuist_replication` | 50/50 `srsubstate='r'`, apply lag 0 |
| Per-table grants on `tuist_app` | applied |
| Seed-conflict rows | cleared |

**Already deployed manually** at `0c92e054` via run [#26893648160](https://github.com/tuist/tuist/actions/runs/26893648160). Cutover already finalized (post-cutover steps below all completed).

### canary
| | |
|---|---|
| Cluster | healthy, 2/2 |
| Subscription `tuist_replication` | 49/49 `srsubstate='r'`, apply lag 0 for 24h+ |
| Per-table grants on `tuist_app` | applied |
| Seed-conflict rows | cleared |
| Backups | working — archived_count=101, last archive 7 min ago |

Will cut over automatically when this PR merges into main (the production-deployment workflow's canary stage). Post-cutover steps below need to be executed manually after the cascade deploy lands.

---

# Post-cutover steps

After each environment's cutover deploy completes, run these steps in order. The list is the same shape for both envs; only host/credential/namespace placeholders differ. The staging column shows ✅ for the steps that already ran today.

| # | step | staging | canary |
|---|---|---|---|
| 1 | Sanity gate — verify server connected to CNPG (read-only) | ✅ | TODO |
| 2 | Drop subscription on CNPG (3-step DISABLE → unset slot → DROP) | ✅ | TODO |
| 3 | Drop publication + slot on Supabase (releases WAL retention) | ✅ | TODO |
| 4 | Clean Tigris backup bucket if barman is failing with ""Expected empty archive"" | ✅ | n/a (already clean) |
| 5 | Trigger fresh manual base backup so we exit at non-zero recovery coverage | ✅ | TODO (optional — daily ScheduledBackup runs at 03:00 UTC) |
| 6 | Smoke — public `/ready` returns 200, server logs free of DB errors | ✅ | TODO |

### Per-step commands (canary)

#### 1. Sanity gate (read-only, must pass before step 2)
```bash
export KUBECONFIG=~/.kube/tuist-canary

# 1a. server DATABASE_URL secret reference points at CNPG `-app` Secret
kubectl -n tuist-canary get deploy tuist-tuist-server \
  -o jsonpath='{range .spec.template.spec.containers[0].env[?(@.name==\"DATABASE_URL\")]}{.valueFrom.secretKeyRef.name}{\"\n\"}{end}'
# expected: tuist-tuist-pg-app

# 1b. live connections from server pod IP — confirms app actually connected
SERVER_IP=$(kubectl -n tuist-canary get pod -l app.kubernetes.io/component=server -o jsonpath='{.items[0].status.podIP}')
echo \"server pod IP: $SERVER_IP\"
kubectl -n tuist-canary exec tuist-tuist-pg-1 -c postgres -- psql -d tuist -tA -c \"
SELECT usename, client_addr::text, state, count(*)
FROM pg_stat_activity WHERE client_addr IS NOT NULL
GROUP BY usename, client_addr, state ORDER BY client_addr, usename;\"
# expected: tuist_app from \$SERVER_IP with N connections (matches TUIST_DATABASE_POOL_SIZE)

# 1c. oban_jobs activity proves the processor is writing to CNPG
# (oban_jobs is excluded from the publication, so any rows here are post-cutover)
kubectl -n tuist-canary exec tuist-tuist-pg-1 -c postgres -- psql -d tuist -tA -c \"
SELECT 'oban_jobs ins=' || n_tup_ins || ' upd=' || n_tup_upd
FROM pg_stat_user_tables WHERE relname='oban_jobs';\"
# expected: ins > 0 and upd > 0
```

If any of these fails, **stop and investigate before step 2** — we can keep replication running indefinitely; we cannot un-drop a subscription.

#### 2. Drop subscription on CNPG (3-step pattern with slot decouple)
The `SET (slot_name = NONE)` step decouples the CNPG-side subscription from the publisher-side slot, so `DROP SUBSCRIPTION` doesn't RPC into Supabase to drop the slot — we do that ourselves in step 3, where we control the credentials. Without this, an unreachable publisher would hang the drop.
```bash
kubectl -n tuist-canary exec -i tuist-tuist-pg-1 -c postgres -- \
  psql -d tuist -v ON_ERROR_STOP=1 <<'SQL'
BEGIN;
ALTER SUBSCRIPTION tuist_replication DISABLE;
ALTER SUBSCRIPTION tuist_replication SET (slot_name = NONE);
DROP SUBSCRIPTION tuist_replication;
COMMIT;
SELECT count(*) AS remaining_subscriptions FROM pg_subscription;
SQL
# expected: remaining_subscriptions = 0
```

#### 3. Drop publication + slot on Supabase
Canary uses the dedicated `tuist_replicator` role (not the `postgres` superuser); credentials live in 1P at `op://tuist-k8s-canary/SUPABASE_REPLICATOR_PASSWORD/password`.
```bash
PW=$(op read \"op://tuist-k8s-canary/SUPABASE_REPLICATOR_PASSWORD/password\")
PGPASS=$(mktemp); chmod 600 \"$PGPASS\"
echo \"db.thapckmapmffdgaiarvu.supabase.co:5432:postgres:tuist_replicator:$PW\" > \"$PGPASS\"
PGPASSFILE=\"$PGPASS\" psql \"host=db.thapckmapmffdgaiarvu.supabase.co user=tuist_replicator dbname=postgres sslmode=require\" \
  -v ON_ERROR_STOP=1 <<'SQL'
BEGIN;
SELECT pg_drop_replication_slot('tuist_replication')
WHERE EXISTS (SELECT 1 FROM pg_replication_slots WHERE slot_name='tuist_replication');
DROP PUBLICATION tuist_replication;
COMMIT;
SELECT 'pubs: ' || count(*) FROM pg_publication WHERE pubname='tuist_replication';
SELECT 'slots: ' || count(*) FROM pg_replication_slots WHERE slot_name='tuist_replication';
SQL
rm -f \"$PGPASS\"
# expected: 0 pubs, 0 slots
```

#### 4. Tigris bucket cleanup — *n/a for canary*
The `tuist-can-pg-backups` bucket was already cleaned of stale prior-incarnation objects when we provisioned the canary CNPG cluster. Current archive state is healthy. Skip this step.

(Reference for future re-provisioning incidents: if `pg_stat_archiver.last_failed_wal` is set and the error trace mentions ""Expected empty archive"", the bucket has stale objects from a prior cluster's `system_identifier`. Clean the prefix `tuist-tuist-pg/` and barman starts archiving on the next WAL segment.)

#### 5. Trigger a fresh base backup (optional)
The chart's `ScheduledBackup` runs daily at 03:00 UTC and will produce a fresh base backup at the next slot. If you want immediate coverage:
```bash
kubectl -n tuist-canary create -f - <<'YAML'
apiVersion: postgresql.cnpg.io/v1
kind: Backup
metadata:
  name: tuist-tuist-pg-manual-post-cutover
  namespace: tuist-canary
spec:
  cluster:
    name: tuist-tuist-pg
YAML
# Watch:
kubectl -n tuist-canary get backup tuist-tuist-pg-manual-post-cutover -o jsonpath='{.status.phase}{\"\n\"}'
```

#### 6. Smoke
```bash
curl -s -o /dev/null -w \"status=%{http_code} time=%{time_total}s\n\" https://canary.tuist.dev/ready
kubectl -n tuist-canary logs deploy/tuist-tuist-server --since=60s | grep -iE \"error|postgrex|disconnect\" | head
# expected: status=200, no error/postgrex/disconnect matches
```

---

## Production

Stays on `mode: external` in this PR. Its CNPG cluster is still recovering from a sizing incident (PVCs being expanded from 100 → 250 GiB via #11069, CAPI provider OOMing pending #11065 rollout). Cutover lands later in its own PR.

**This PR should not be merged until the production CNPG cluster is healthy** — every `push to main` triggers the canary → acceptance → production cascade, and the production stage would fail if its CNPG cluster is still in trouble (the chart deploys for prod even though values are unchanged, and `--wait` would hang on the unhealthy CNPG).

## No reverse replication

The CNPG → Supabase reverse replication step in the original runbook (""rollback safety, 14 days post-cutover"") is replaced with an on-demand re-migration procedure (same forward migration steps, publisher/subscriber swapped). Rationale: continuous reverse replication costs ~€6/mo per env + carries ongoing bidirectional-replication failure modes; instant rollback is rarely the actual need; minute-to-hour rollback via re-migration is acceptable and uses the same code paths we exercise on forward migration.

## Test plan

- [x] `helm template` renders DATABASE_URL → `tuist-tuist-pg-app` Secret for both envs
- [x] Staging cutover deployed manually, post-cutover steps 1–6 executed, smoke passes
- [ ] After merge: cascade canary deploy succeeds, post-cutover steps 1–6 executed cleanly