### PR TITLE
fix(infra): expose Kura control plane env to server

### DIFF
--- a/infra/helm/tuist/templates/_helpers.tpl
+++ b/infra/helm/tuist/templates/_helpers.tpl
@@ -322,6 +322,16 @@ server.externalSecrets.kuraIntrospection.item is set.
 {{- define "tuist.kuraIntrospectionEnv" -}}
 {{- $esoSecret := include "tuist.componentName" (dict "root" . "component" "server-external-secrets") -}}
 {{- if ne (.Values.server.externalSecrets.kuraIntrospection.item | default "") "" }}
+- name: KURA_CONTROL_PLANE_CLIENT_ID
+  valueFrom:
+    secretKeyRef:
+      name: {{ $esoSecret | quote }}
+      key: KURA_CONTROL_PLANE_CLIENT_ID
+- name: KURA_CONTROL_PLANE_CLIENT_SECRET
+  valueFrom:
+    secretKeyRef:
+      name: {{ $esoSecret | quote }}
+      key: KURA_CONTROL_PLANE_CLIENT_SECRET
 - name: TUIST_KURA_INTROSPECTION_CLIENT_ID
   valueFrom:
     secretKeyRef:


### PR DESCRIPTION
## Summary
- Mount the current `KURA_CONTROL_PLANE_CLIENT_ID` and `KURA_CONTROL_PLANE_CLIENT_SECRET` env vars into the Tuist server when Kura introspection ExternalSecrets are enabled.
- Keep the legacy `TUIST_KURA_INTROSPECTION_*` env vars mounted from the same synced secret for compatibility.
- Fix the remaining canary Kura reconciler path so it reads the UUID client id from the environment instead of falling back to the stale encrypted canary secret.

## Testing
- `helm template tuist infra/helm/tuist -n tuist-canary -f infra/helm/tuist/values-managed-common.yaml -f infra/helm/tuist/values-managed-canary.yaml --set server.image.tag=test --set kuraController.image.tag=test | rg -n "KURA_CONTROL_PLANE_CLIENT_ID|KURA_CONTROL_PLANE_CLIENT_SECRET|TUIST_KURA_INTROSPECTION_CLIENT_ID|TUIST_KURA_INTROSPECTION_CLIENT_SECRET" -C 2`
- Monitored deployment run `26886189657`; acceptance tests still failed because the live server pod had `TUIST_KURA_INTROSPECTION_CLIENT_ID=0907daa5-350f-4cac-bb69-587126ce8e88` but empty `KURA_CONTROL_PLANE_CLIENT_ID`, leaving the KuraInstance on the old prefixed client id.
