### PR TITLE
fix(infra): stream bootstrap binaries instead of copying them per roll

### DIFF
--- a/infra/helm/tuist/templates/capi-scaleway-applesilicon.yaml
+++ b/infra/helm/tuist/templates/capi-scaleway-applesilicon.yaml
@@ -295,6 +295,15 @@ spec:
             - --tailscale-egress-magicdns-suffix={{ required "macosFleet.tailscaleEgress.magicDNSSuffix is required when tailscaleEgress.enabled" .Values.macosFleet.tailscaleEgress.magicDNSSuffix }}
             {{- end }}
           env:
+            # Soft heap cap so Go's GC reclaims before the cgroup hard
+            # limit OOM-kills the manager. The process keeps the macOS
+            # bootstrap binaries (tart-kubelet, tart, tailscale,
+            # node_exporter — ~100Mi total) resident and reconciles the
+            # whole fleet in a cold-start burst, so the live heap sits
+            # close enough to the limit that default GOGC pacing can
+            # overshoot. Kept below the memory limit below.
+            - name: GOMEMLIMIT
+              value: "900MiB"
             # Scaleway credentials. ESO syncs them from 1Password into
             # this Secret automatically (see
             # capi-scaleway-applesilicon-external-secrets.yaml). For
@@ -332,8 +341,8 @@ spec:
           resources:
             requests:
               cpu: "100m"
-              memory: "128Mi"
+              memory: "256Mi"
             limits:
               cpu: "500m"
-              memory: "512Mi"
+              memory: "1Gi"
 {{- end }}

--- a/infra/helm/tuist/templates/capi-scaleway-applesilicon.yaml
+++ b/infra/helm/tuist/templates/capi-scaleway-applesilicon.yaml
@@ -295,15 +295,6 @@ spec:
             - --tailscale-egress-magicdns-suffix={{ required "macosFleet.tailscaleEgress.magicDNSSuffix is required when tailscaleEgress.enabled" .Values.macosFleet.tailscaleEgress.magicDNSSuffix }}
             {{- end }}
           env:
-            # Soft heap cap so Go's GC reclaims before the cgroup hard
-            # limit OOM-kills the manager. The process keeps the macOS
-            # bootstrap binaries (tart-kubelet, tart, tailscale,
-            # node_exporter — ~100Mi total) resident and reconciles the
-            # whole fleet in a cold-start burst, so the live heap sits
-            # close enough to the limit that default GOGC pacing can
-            # overshoot. Kept below the memory limit below.
-            - name: GOMEMLIMIT
-              value: "900MiB"
             # Scaleway credentials. ESO syncs them from 1Password into
             # this Secret automatically (see
             # capi-scaleway-applesilicon-external-secrets.yaml). For
@@ -341,8 +332,8 @@ spec:
           resources:
             requests:
               cpu: "100m"
-              memory: "256Mi"
+              memory: "128Mi"
             limits:
               cpu: "500m"
-              memory: "1Gi"
+              memory: "512Mi"
 {{- end }}

--- a/infra/macos-host-bootstrap/actions_runner.go
+++ b/infra/macos-host-bootstrap/actions_runner.go
@@ -3,6 +3,7 @@ package bootstrap
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"golang.org/x/crypto/ssh"
 )
@@ -284,7 +285,7 @@ sudo launchctl kickstart -k "gui/$RUNNER_UID/$RUNNER_LABEL"
 		shellQuote(cfg.GHRunnerLabels),
 		shellQuote(runnerName),
 	)
-	return RunCommandWithStdin(ctx, client, script, cfg.GHRunnerRegistrationToken)
+	return RunCommandWithStdin(ctx, client, script, strings.NewReader(cfg.GHRunnerRegistrationToken))
 }
 
 // runActionsRunnerInstall is the public entrypoint Run() calls when

--- a/infra/macos-host-bootstrap/bootstrap.go
+++ b/infra/macos-host-bootstrap/bootstrap.go
@@ -44,6 +44,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"io"
 	"net"
 	"sort"
 	"strings"
@@ -343,7 +344,7 @@ sudo mkdir -p /etc/tart-kubelet
 sudo tee /etc/tart-kubelet/kubeconfig >/dev/null
 sudo chmod 0600 /etc/tart-kubelet/kubeconfig
 `
-	return RunCommandWithStdin(ctx, client, script, kubeconfig)
+	return RunCommandWithStdin(ctx, client, script, strings.NewReader(kubeconfig))
 }
 
 // installTartKubelet uploads the operator-baked tart-kubelet binary
@@ -373,7 +374,7 @@ sudo chmod 0755 /usr/local/bin/tart-kubelet
 # stale cache so the rolled binary actually runs.
 sudo codesign --force --sign - /usr/local/bin/tart-kubelet
 `
-	return RunCommandWithStdin(ctx, client, script, string(binary))
+	return RunCommandWithStdin(ctx, client, script, bytes.NewReader(binary))
 }
 
 // loadTartKubeletLaunchd writes /Library/LaunchDaemons/dev.tuist.tart-kubelet.plist
@@ -466,7 +467,7 @@ settled && exit 0
 echo "tart-kubelet did not reach a running state after launchd reload" >&2
 exit 1
 `, shellQuote(cfg.SSHUser))
-	return RunCommandWithStdin(ctx, client, script, plist)
+	return RunCommandWithStdin(ctx, client, script, strings.NewReader(plist))
 }
 
 func renderLaunchdPlist(cfg Config) string {
@@ -898,7 +899,7 @@ EOF
 sudo chmod 0755 /usr/local/bin/tart
 /usr/local/bin/tart --version
 `
-	return RunCommandWithStdin(ctx, client, script, string(tarball))
+	return RunCommandWithStdin(ctx, client, script, bytes.NewReader(tarball))
 }
 
 // installVMEgressFirewall configures pfctl rules that drop egress
@@ -1093,7 +1094,7 @@ func installTailscale(ctx context.Context, client *ssh.Client, cfg Config) error
 sudo mkdir -p /etc/tuist
 sudo tee /etc/tuist/tailscale-auth-key >/dev/null
 sudo chmod 0600 /etc/tuist/tailscale-auth-key`
-	if err := RunCommandWithStdin(ctx, client, keyScript, cfg.TailscaleAuthKey); err != nil {
+	if err := RunCommandWithStdin(ctx, client, keyScript, strings.NewReader(cfg.TailscaleAuthKey)); err != nil {
 		return fmt.Errorf("stage tailscale auth key: %w", err)
 	}
 
@@ -1248,7 +1249,7 @@ echo "tailscale up returned but no tailnet IPv4 within 30s; current status:" >&2
 sudo /usr/local/bin/tailscale status >&2 || true
 exit 1
 `, hostnameArg, tagsArg)
-	return RunCommandWithStdin(ctx, client, script, string(cfg.TailscaleBinaries))
+	return RunCommandWithStdin(ctx, client, script, bytes.NewReader(cfg.TailscaleBinaries))
 }
 
 // installNodeExporter drops the cross-compiled darwin/arm64 binary,
@@ -1324,24 +1325,29 @@ sudo chmod 0644 /Library/LaunchDaemons/dev.tuist.node-exporter.plist
 sudo launchctl bootout system /Library/LaunchDaemons/dev.tuist.node-exporter.plist 2>/dev/null || true
 sudo launchctl bootstrap system /Library/LaunchDaemons/dev.tuist.node-exporter.plist
 `
-	return RunCommandWithStdin(ctx, client, script, string(cfg.NodeExporterBinary))
+	return RunCommandWithStdin(ctx, client, script, bytes.NewReader(cfg.NodeExporterBinary))
 }
 
 // === SSH helpers ===========================================================
 
 func RunCommand(ctx context.Context, client *ssh.Client, cmd string) error {
-	return RunCommandWithStdin(ctx, client, cmd, "")
+	return RunCommandWithStdin(ctx, client, cmd, nil)
 }
 
-func RunCommandWithStdin(ctx context.Context, client *ssh.Client, cmd, stdin string) error {
+// stdin is an io.Reader rather than a string so callers streaming the
+// multi-MB bootstrap binaries can pass bytes.NewReader over the
+// operator's resident slice — no per-call copy. The reader is read
+// once and never mutated, so concurrent reconciles can share the same
+// backing slice safely.
+func RunCommandWithStdin(ctx context.Context, client *ssh.Client, cmd string, stdin io.Reader) error {
 	session, err := client.NewSession()
 	if err != nil {
 		return err
 	}
 	defer session.Close()
 
-	if stdin != "" {
-		session.Stdin = strings.NewReader(stdin)
+	if stdin != nil {
+		session.Stdin = stdin
 	}
 
 	var stderr bytes.Buffer


### PR DESCRIPTION
## What changed

`RunCommandWithStdin` in `infra/macos-host-bootstrap` now takes an `io.Reader` instead of a `string`. The four bootstrap binaries (tart-kubelet, tart, tailscale, node_exporter) are streamed to the host with `bytes.NewReader` over the operator's already-resident slice instead of `string(binary)`, which copied the whole binary on every call. String payloads (kubeconfig, launchd plist, auth keys, runner token) pass `strings.NewReader`.

No resource-limit change — the limit is left at the original `512Mi`.

## Why

The `capi-scaleway-applesilicon` manager was OOMKilling in production (`Exit Code: 137`), both replicas ping-ponging the leader lease and firing a `Pod CrashLoop / Frequent Restarts` alert. This removes the actual cause rather than giving it more headroom.

## Root cause

It's an OOM, not an application error — logs show a clean startup with no panic; the process is killed mid-reconcile.

The manager reads the four macOS bootstrap artifacts into memory once at startup and holds them resident for the process lifetime (~96MB total: tart-kubelet 47MB + tart 22MB + tailscale 14MB + node_exporter 13MB). That part is deliberate. The problem was the transfer path: each host install called `RunCommandWithStdin(..., string(binary))`, and the `[]byte` → `string` conversion **allocates a fresh copy of the whole binary on every call**.

When the embedded tart-kubelet SHA changes — which is exactly what the `capi-scaleway@0.7.2` deploy did, since #11044 shipped a new tart-kubelet binary — every `ScalewayAppleSiliconMachine` shows binary drift and re-rolls at once. With `--machine-max-concurrent-reconciles=4`, that's up to four concurrent 47MB copies on top of the ~96MB resident set, and default GOGC pacing lets the heap overshoot before a collection runs:

```
~96MB resident
+ 4 × 47MB transient string copies (concurrent drift rolls)  ≈ 188MB
+ GC headroom (GOGC=100 → heap grows ~2× live before collecting)
= peak past 512Mi during a fleet-wide roll
```

Already-`Ready` machines skip the full bootstrap, so this isn't generic reconcile pressure — it's specifically the binary-SHA drift roll fanning across the fleet, which recurs every time the embedded tart-kubelet changes.

## Why this solution over raising the limit

The earlier revision of this PR bumped the limit to `1Gi` + added `GOMEMLIMIT`. That treats the symptom. The transient copies are pure waste: `bytes.NewReader` streams straight from the resident slice with zero extra allocation, so the burst disappears entirely. `bytes.Reader` only reads and never mutates the backing array, so the concurrent rolls share the one resident slice safely. With the copies gone, the working set during a fleet-wide roll stays near the ~96MB baseline — comfortably inside the original `512Mi`, no headroom bump needed.

## Impact

No customer-facing outage during the incident — the Mac mini nodes kept running (independent kubelets, all `Ready`). But the fleet control plane was degraded: machine provisioning/recovery, fleet-spread auto-roll, and node-readiness reconciliation flapped. This fix lands in the manager image, so it takes effect once a new `capi-scaleway` release is built and deployed (not on a plain Helm value roll).

## Validation

- `go build` / `go vet` / `go test` pass for `macos-host-bootstrap`.
- The `cluster-api-provider-scaleway-applesilicon` consumer still builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)