### PR TITLE
fix(kura): improve extension routing and observability

### DIFF
--- a/infra/helm/tuist/templates/server-deployment.yaml
+++ b/infra/helm/tuist/templates/server-deployment.yaml
@@ -256,6 +256,8 @@ spec:
             - name: TUIST_KURA_RUNTIME_IMAGE_TAG
               value: {{ .Values.kuraRuntime.image.tag | quote }}
             {{- end }}
+            - name: TUIST_KURA_TUIST_BASE_URL
+              value: {{ printf "http://%s.%s.svc.cluster.local:%v" (include "tuist.componentName" (dict "root" . "component" "server")) .Release.Namespace (.Values.server.service.port | default 80) | quote }}
             {{- $redisUrl := include "tuist.redisUrl" . }}
             {{- if and .Values.redis.enabled $redisUrl }}
             - name: TUIST_REDIS_URL

--- a/kura/src/extension/mod.rs
+++ b/kura/src/extension/mod.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::{BTreeMap, HashMap},
+    error::Error as _,
     path::PathBuf,
     sync::Arc,
     time::{Duration, Instant},
@@ -18,7 +19,7 @@ use mlua::{Function, Lua, LuaSerdeExt, SerializeOptions, Table};
 const SERIALIZE_NONE_AS_NIL: SerializeOptions = SerializeOptions::new()
     .serialize_none_to_null(false)
     .serialize_unit_to_null(false);
-use reqwest::{Client, Method};
+use reqwest::{Client, Method, RequestBuilder};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use sha2::{Digest as _, Sha256};
@@ -224,7 +225,7 @@ struct SignInstruction {
     payload: String,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 struct HttpJsonRequest {
     #[serde(default = "default_http_method")]
     method: String,
@@ -267,7 +268,7 @@ impl ExtensionEngine {
                 )
             })?;
         let script_hash = fingerprint(&script);
-        let runtime = LuaRuntime::load(&script, &config).await?;
+        let runtime = LuaRuntime::load(&script, &config, metrics.clone()).await?;
 
         Ok(Self {
             config,
@@ -639,9 +640,13 @@ fn evict_expired_authorize(cache: &mut HashMap<String, CachedAuthorizeResult>) {
 }
 
 impl LuaRuntime {
-    async fn load(script: &str, config: &ExtensionConfig) -> Result<Self, String> {
+    async fn load(
+        script: &str,
+        config: &ExtensionConfig,
+        metrics: Metrics,
+    ) -> Result<Self, String> {
         let lua = Lua::new();
-        install_host_api(&lua, config).await?;
+        install_host_api(&lua, config, metrics).await?;
         lua.load(script)
             .set_name("kura-extension")
             .exec_async()
@@ -667,7 +672,11 @@ fn has_hook(globals: &Table, name: &str) -> bool {
     )
 }
 
-async fn install_host_api(lua: &Lua, config: &ExtensionConfig) -> Result<(), String> {
+async fn install_host_api(
+    lua: &Lua,
+    config: &ExtensionConfig,
+    metrics: Metrics,
+) -> Result<(), String> {
     let kura = lua
         .create_table()
         .map_err(|error| format!("failed to create extension API table: {error}"))?;
@@ -695,10 +704,11 @@ async fn install_host_api(lua: &Lua, config: &ExtensionConfig) -> Result<(), Str
     let http_json = lua
         .create_async_function(move |lua, (id, request): (String, mlua::Value)| {
             let http_clients = http_clients.clone();
+            let metrics = metrics.clone();
             async move {
                 let request: HttpJsonRequest =
                     lua.from_value(request).map_err(mlua::Error::external)?;
-                let response = execute_http_json(&http_clients, &id, request)
+                let response = execute_http_json(&http_clients, &metrics, &id, request)
                     .await
                     .map_err(mlua::Error::external)?;
                 lua.to_value(&response)
@@ -774,6 +784,7 @@ fn verify_jwt(
 
 async fn execute_http_json(
     http_clients: &HashMap<String, ExtensionHttpClient>,
+    metrics: &Metrics,
     client_id: &str,
     request: HttpJsonRequest,
 ) -> Result<HttpJsonResponse, String> {
@@ -793,18 +804,48 @@ async fn execute_http_json(
         url.push_str(&request.path);
     }
 
-    let mut builder = client.client.request(method, &url).query(&request.query);
-    for (name, value) in request.headers {
-        builder = builder.header(name, value);
-    }
-    if let Some(body) = request.body {
-        builder = builder.json(&body);
-    }
-
-    let response = builder
-        .send()
-        .await
-        .map_err(|error| format!("HTTP client '{client_id}' request failed: {error}"))?;
+    let route = extension_http_route_label(&request.path);
+    let normalized_client_id = normalize_id(client_id);
+    let mut attempt = 0;
+    let response = loop {
+        attempt += 1;
+        let start = Instant::now();
+        let result = build_http_json_request(client, method.clone(), &url, &request)
+            .send()
+            .await;
+        match result {
+            Ok(response) => {
+                metrics.record_extension_http_client(
+                    &normalized_client_id,
+                    route,
+                    "ok",
+                    status_class(response.status().as_u16()),
+                    "none",
+                    start.elapsed(),
+                );
+                break response;
+            }
+            Err(error) => {
+                let error_kind = classify_reqwest_error(&error);
+                metrics.record_extension_http_client(
+                    &normalized_client_id,
+                    route,
+                    "error",
+                    "none",
+                    error_kind,
+                    start.elapsed(),
+                );
+                if attempt < 2 && retryable_reqwest_error(error_kind) {
+                    tokio::time::sleep(Duration::from_millis(100)).await;
+                    continue;
+                }
+                return Err(format!(
+                    "HTTP client '{client_id}' request failed after {attempt} attempt(s): {}",
+                    format_reqwest_error(&error)
+                ));
+            }
+        }
+    };
     let status = response.status();
     let headers = response
         .headers()
@@ -826,6 +867,109 @@ async fn execute_http_json(
         headers,
         body,
     })
+}
+
+fn build_http_json_request(
+    client: &ExtensionHttpClient,
+    method: Method,
+    url: &str,
+    request: &HttpJsonRequest,
+) -> RequestBuilder {
+    let mut builder = client.client.request(method, url).query(&request.query);
+    for (name, value) in &request.headers {
+        builder = builder.header(name, value);
+    }
+    if let Some(body) = &request.body {
+        builder = builder.json(body);
+    }
+    builder
+}
+
+fn extension_http_route_label(path: &str) -> &'static str {
+    match path {
+        "/oauth2/introspect" => "oauth2_introspect",
+        "/api/cache/access" => "api_cache_access",
+        _ => "other",
+    }
+}
+
+fn status_class(status: u16) -> &'static str {
+    match status {
+        100..=199 => "1xx",
+        200..=299 => "2xx",
+        300..=399 => "3xx",
+        400..=499 => "4xx",
+        500..=599 => "5xx",
+        _ => "other",
+    }
+}
+
+fn classify_reqwest_error(error: &reqwest::Error) -> &'static str {
+    let chain = error_chain_string(error);
+    if error.is_timeout() {
+        "timeout"
+    } else if chain.contains("dns") {
+        "dns"
+    } else if chain.contains("tls") || chain.contains("certificate") {
+        "tls"
+    } else if chain.contains("connection closed")
+        || chain.contains("closed for writing")
+        || chain.contains("server closed")
+    {
+        "closed"
+    } else if error.is_connect() {
+        "connect"
+    } else if error.is_request() {
+        "request"
+    } else if error.is_body() {
+        "body"
+    } else if error.is_decode() {
+        "decode"
+    } else {
+        "unknown"
+    }
+}
+
+fn retryable_reqwest_error(error_kind: &str) -> bool {
+    matches!(
+        error_kind,
+        "timeout" | "dns" | "tls" | "closed" | "connect" | "request" | "unknown"
+    )
+}
+
+fn format_reqwest_error(error: &reqwest::Error) -> String {
+    let mut message = format!(
+        "{error}; kind={}; is_timeout={}; is_connect={}; is_request={}; is_body={}; is_decode={}; status={}",
+        classify_reqwest_error(error),
+        error.is_timeout(),
+        error.is_connect(),
+        error.is_request(),
+        error.is_body(),
+        error.is_decode(),
+        error
+            .status()
+            .map(|status| status.as_u16().to_string())
+            .unwrap_or_else(|| "none".to_owned())
+    );
+
+    let mut source = error.source();
+    while let Some(current) = source {
+        message.push_str("; caused_by=");
+        message.push_str(&current.to_string());
+        source = current.source();
+    }
+    message
+}
+
+fn error_chain_string(error: &reqwest::Error) -> String {
+    let mut chain = error.to_string().to_lowercase();
+    let mut source = error.source();
+    while let Some(current) = source {
+        chain.push_str("; ");
+        chain.push_str(&current.to_string().to_lowercase());
+        source = current.source();
+    }
+    chain
 }
 
 impl ExtensionConfig {
@@ -1503,7 +1647,16 @@ end
         }
 
         async fn engine_pointing_at(base_url: &str, introspection_client: bool) -> SharedExtension {
+            engine_pointing_at_with_timeout(base_url, introspection_client, "4000").await
+        }
+
+        async fn engine_pointing_at_with_timeout(
+            base_url: &str,
+            introspection_client: bool,
+            request_timeout_ms: &str,
+        ) -> SharedExtension {
             let url = base_url.to_owned();
+            let request_timeout_ms = request_timeout_ms.to_owned();
             test_engine(&script(), move |_| unsafe {
                 std::env::set_var("KURA_EXTENSION_HTTP_CLIENT_TUIST_BASE_URL", &url);
                 std::env::set_var("KURA_EXTENSION_HOOK_TIMEOUT_MS", "5000");
@@ -1515,7 +1668,7 @@ end
                 std::env::set_var("KURA_EXTENSION_JWT_VERIFIER_TUIST_ISSUER", "tuist");
                 std::env::set_var(
                     "KURA_EXTENSION_HTTP_CLIENT_TUIST_REQUEST_TIMEOUT_MS",
-                    "4000",
+                    &request_timeout_ms,
                 );
 
                 if introspection_client {
@@ -1844,6 +1997,44 @@ end
             let decision = engine.evaluate_access(&context).await;
             assert!(matches!(decision, AccessDecision::Allow(Some(_))));
             assert_eq!(*calls.lock().unwrap(), 1);
+        }
+
+        #[tokio::test]
+        async fn retries_introspection_transport_failures_once() {
+            let calls = Arc::new(Mutex::new(0usize));
+            let calls_for_handler = calls.clone();
+            let base = spawn_tuist_auth_mock(
+                move |_headers, _payload| {
+                    let mut calls = calls_for_handler.lock().unwrap();
+                    *calls += 1;
+                    if *calls == 1 {
+                        std::thread::sleep(Duration::from_millis(50));
+                    }
+                    (
+                        StatusCode::OK,
+                        introspection_payload(cache_grants_payload(
+                            &[],
+                            &[],
+                            &["acme/ios"],
+                            &["acme/ios"],
+                        )),
+                    )
+                },
+                |_| (StatusCode::OK, cache_access_payload(&[], &[])),
+            )
+            .await;
+            let engine = engine_pointing_at_with_timeout(&base, true, "10").await;
+
+            let mut context = ctx();
+            context.tenant_id = Some("acme".into());
+            context.namespace_id = Some("ios".into());
+            context
+                .headers
+                .insert("authorization".into(), "Bearer opaque-token".into());
+
+            let decision = engine.evaluate_access(&context).await;
+            assert!(matches!(decision, AccessDecision::Allow(Some(_))));
+            assert_eq!(*calls.lock().unwrap(), 2);
         }
 
         #[tokio::test]

--- a/kura/src/metrics.rs
+++ b/kura/src/metrics.rs
@@ -90,6 +90,8 @@ pub struct Metrics {
     extension_hooks: Family<ExtensionHookLabels, Counter>,
     extension_hook_duration: Family<ExtensionHookRouteLabels, Histogram>,
     extension_cache: Family<ExtensionCacheLabels, Counter>,
+    extension_http_client_requests: Family<ExtensionHttpClientLabels, Counter>,
+    extension_http_client_duration: Family<ExtensionHttpClientRouteLabels, Histogram>,
     process_resident_memory_bytes: Gauge,
     process_virtual_memory_bytes: Gauge,
     rocksdb_block_cache_usage_bytes: Gauge,
@@ -210,6 +212,12 @@ impl Metrics {
                 Histogram::new(exponential_buckets(0.0005, 2.0, 16))
             });
         let extension_cache = Family::<ExtensionCacheLabels, Counter>::default();
+        let extension_http_client_requests =
+            Family::<ExtensionHttpClientLabels, Counter>::default();
+        let extension_http_client_duration =
+            Family::<ExtensionHttpClientRouteLabels, Histogram>::new_with_constructor(|| {
+                Histogram::new(exponential_buckets(0.001, 2.0, 16))
+            });
         let process_resident_memory_bytes = Gauge::default();
         let process_virtual_memory_bytes = Gauge::default();
         let rocksdb_block_cache_usage_bytes = Gauge::default();
@@ -545,6 +553,16 @@ impl Metrics {
             extension_cache.clone(),
         );
         registry.register(
+            "kura_extension_http_client_requests_total",
+            "Extension HTTP client requests by client, route, result, status class, and error kind",
+            extension_http_client_requests.clone(),
+        );
+        registry.register(
+            "kura_extension_http_client_request_duration_seconds",
+            "Extension HTTP client request latency by client and route",
+            extension_http_client_duration.clone(),
+        );
+        registry.register(
             "kura_process_resident_memory_bytes",
             "Process resident memory size in bytes",
             process_resident_memory_bytes.clone(),
@@ -716,6 +734,8 @@ impl Metrics {
             extension_hooks,
             extension_hook_duration,
             extension_cache,
+            extension_http_client_requests,
+            extension_http_client_duration,
             process_resident_memory_bytes,
             process_virtual_memory_bytes,
             rocksdb_block_cache_usage_bytes,
@@ -1172,6 +1192,32 @@ impl Metrics {
             .inc();
     }
 
+    pub fn record_extension_http_client(
+        &self,
+        client: &str,
+        route: &str,
+        result: &str,
+        status_class: &str,
+        error_kind: &str,
+        duration: Duration,
+    ) {
+        self.extension_http_client_requests
+            .get_or_create(&ExtensionHttpClientLabels {
+                client: client.to_owned(),
+                route: route.to_owned(),
+                result: result.to_owned(),
+                status_class: status_class.to_owned(),
+                error_kind: error_kind.to_owned(),
+            })
+            .inc();
+        self.extension_http_client_duration
+            .get_or_create(&ExtensionHttpClientRouteLabels {
+                client: client.to_owned(),
+                route: route.to_owned(),
+            })
+            .observe(duration.as_secs_f64());
+    }
+
     pub fn update_process_memory(&self, resident_bytes: u64, virtual_bytes: u64) {
         self.process_resident_memory_bytes
             .set(resident_bytes as i64);
@@ -1421,6 +1467,21 @@ struct ExtensionHookRouteLabels {
 struct ExtensionCacheLabels {
     cache: String,
     result: String,
+}
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
+struct ExtensionHttpClientLabels {
+    client: String,
+    route: String,
+    result: String,
+    status_class: String,
+    error_kind: String,
+}
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
+struct ExtensionHttpClientRouteLabels {
+    client: String,
+    route: String,
 }
 
 #[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]

--- a/server/lib/tuist/environment.ex
+++ b/server/lib/tuist/environment.ex
@@ -181,6 +181,10 @@ defmodule Tuist.Environment do
     System.get_env("TUIST_KURA_RUNTIME_IMAGE_TAG") || get([:kura, :runtime_image_tag], secrets)
   end
 
+  def kura_tuist_base_url do
+    System.get_env("TUIST_KURA_TUIST_BASE_URL")
+  end
+
   def prometheus_enabled? do
     prometheus_enabled = System.get_env("TUIST_PROMETHEUS_ENABLED")
 
@@ -216,7 +220,8 @@ defmodule Tuist.Environment do
   def agent_auth_default_trusted_providers, do: @agent_auth_default_trusted_providers
 
   def agent_auth_trusted_providers(secrets \\ secrets()) do
-    case System.get_env("TUIST_AGENT_AUTH_TRUSTED_PROVIDERS_JSON") || get([:agent_auth, :trusted_providers], secrets) do
+    case System.get_env("TUIST_AGENT_AUTH_TRUSTED_PROVIDERS_JSON") ||
+           get([:agent_auth, :trusted_providers], secrets) do
       providers when is_list(providers) ->
         providers
 
@@ -1031,9 +1036,14 @@ defmodule Tuist.Environment do
       kura_control_plane_client_secret(secrets) != nil
   end
 
-  def kura_introspection_client_id(secrets \\ secrets()), do: kura_control_plane_client_id(secrets)
-  def kura_introspection_client_secret(secrets \\ secrets()), do: kura_control_plane_client_secret(secrets)
-  def kura_introspection_configured?(secrets \\ secrets()), do: kura_control_plane_configured?(secrets)
+  def kura_introspection_client_id(secrets \\ secrets()),
+    do: kura_control_plane_client_id(secrets)
+
+  def kura_introspection_client_secret(secrets \\ secrets()),
+    do: kura_control_plane_client_secret(secrets)
+
+  def kura_introspection_configured?(secrets \\ secrets()),
+    do: kura_control_plane_configured?(secrets)
 
   @doc """
   Returns the Namespace SSH private key used to establish secure SSH connections between the server and the Namespace runner.
@@ -1135,7 +1145,9 @@ defmodule Tuist.Environment do
   end
 
   def typesense_search_api_key do
-    get([:typesense, :search_api_key], secrets(), default_value: "RgIpKytJBtSQf9CoYKxIfVxh8ma5kzs6")
+    get([:typesense, :search_api_key], secrets(),
+      default_value: "RgIpKytJBtSQf9CoYKxIfVxh8ma5kzs6"
+    )
   end
 
   def get(keys, secrets \\ secrets(), opts \\ []) do

--- a/server/lib/tuist/environment.ex
+++ b/server/lib/tuist/environment.ex
@@ -1036,14 +1036,11 @@ defmodule Tuist.Environment do
       kura_control_plane_client_secret(secrets) != nil
   end
 
-  def kura_introspection_client_id(secrets \\ secrets()),
-    do: kura_control_plane_client_id(secrets)
+  def kura_introspection_client_id(secrets \\ secrets()), do: kura_control_plane_client_id(secrets)
 
-  def kura_introspection_client_secret(secrets \\ secrets()),
-    do: kura_control_plane_client_secret(secrets)
+  def kura_introspection_client_secret(secrets \\ secrets()), do: kura_control_plane_client_secret(secrets)
 
-  def kura_introspection_configured?(secrets \\ secrets()),
-    do: kura_control_plane_configured?(secrets)
+  def kura_introspection_configured?(secrets \\ secrets()), do: kura_control_plane_configured?(secrets)
 
   @doc """
   Returns the Namespace SSH private key used to establish secure SSH connections between the server and the Namespace runner.
@@ -1145,9 +1142,7 @@ defmodule Tuist.Environment do
   end
 
   def typesense_search_api_key do
-    get([:typesense, :search_api_key], secrets(),
-      default_value: "RgIpKytJBtSQf9CoYKxIfVxh8ma5kzs6"
-    )
+    get([:typesense, :search_api_key], secrets(), default_value: "RgIpKytJBtSQf9CoYKxIfVxh8ma5kzs6")
   end
 
   def get(keys, secrets \\ secrets(), opts \\ []) do

--- a/server/lib/tuist/kura/provisioner/kubernetes_controller.ex
+++ b/server/lib/tuist/kura/provisioner/kubernetes_controller.ex
@@ -22,7 +22,12 @@ defmodule Tuist.Kura.Provisioner.KubernetesController do
   @impl true
   def rollout(
         name,
-        %{image_tag: image_tag, account: account, server: %Server{} = server, region: %Regions{} = region} = inputs
+        %{
+          image_tag: image_tag,
+          account: account,
+          server: %Server{} = server,
+          region: %Regions{} = region
+        } = inputs
       ) do
     with {:ok, hook_script} <- hook_script(inputs) do
       manifest = manifest(name, image_tag, account, region, server, hook_script)
@@ -147,13 +152,17 @@ defmodule Tuist.Kura.Provisioner.KubernetesController do
     }
   end
 
-  defp public_host(handle, %Regions{provisioner_config: %{public_host_template: template} = config}) do
+  defp public_host(handle, %Regions{
+         provisioner_config: %{public_host_template: template} = config
+       }) do
     interpolate_host(template, dns_handle(handle), config)
   end
 
   defp public_host(_handle, _region), do: nil
 
-  defp grpc_public_host(handle, %Regions{provisioner_config: %{grpc_public_host_template: template} = config}) do
+  defp grpc_public_host(handle, %Regions{
+         provisioner_config: %{grpc_public_host_template: template} = config
+       }) do
     interpolate_host(template, dns_handle(handle), config)
   end
 
@@ -208,15 +217,22 @@ defmodule Tuist.Kura.Provisioner.KubernetesController do
     |> URI.to_string()
   end
 
+  defp tuist_base_url(%Regions{provisioner_config: %{tuist_base_url: url}})
+       when is_binary(url) and url != "",
+       do: url
+
   defp tuist_base_url(_), do: Tuist.Environment.app_url()
 
-  defp rewrite_loopback(%URI{host: host} = uri, replacement) when host in ["localhost", "127.0.0.1", "0.0.0.0"] do
+  defp rewrite_loopback(%URI{host: host} = uri, replacement)
+       when host in ["localhost", "127.0.0.1", "0.0.0.0"] do
     %{uri | host: replacement}
   end
 
   defp rewrite_loopback(uri, _), do: uri
 
-  defp storage_class(%Regions{provisioner_config: %{storage_class: storage_class}}), do: storage_class
+  defp storage_class(%Regions{provisioner_config: %{storage_class: storage_class}}),
+    do: storage_class
+
   defp storage_class(_), do: nil
 
   defp storage_size(%Regions{provisioner_config: %{storage_size: storage_size}}), do: storage_size
@@ -225,7 +241,9 @@ defmodule Tuist.Kura.Provisioner.KubernetesController do
   defp replicas(%Regions{provisioner_config: %{replicas: replicas}}), do: replicas
   defp replicas(_), do: nil
 
-  defp node_selector(%Regions{provisioner_config: %{node_selector: node_selector}}), do: node_selector
+  defp node_selector(%Regions{provisioner_config: %{node_selector: node_selector}}),
+    do: node_selector
+
   defp node_selector(_), do: nil
 
   defp interpolate_host(template, handle, %{cluster_id: cluster_id}) do

--- a/server/lib/tuist/kura/provisioner/kubernetes_controller.ex
+++ b/server/lib/tuist/kura/provisioner/kubernetes_controller.ex
@@ -22,12 +22,7 @@ defmodule Tuist.Kura.Provisioner.KubernetesController do
   @impl true
   def rollout(
         name,
-        %{
-          image_tag: image_tag,
-          account: account,
-          server: %Server{} = server,
-          region: %Regions{} = region
-        } = inputs
+        %{image_tag: image_tag, account: account, server: %Server{} = server, region: %Regions{} = region} = inputs
       ) do
     with {:ok, hook_script} <- hook_script(inputs) do
       manifest = manifest(name, image_tag, account, region, server, hook_script)
@@ -152,17 +147,13 @@ defmodule Tuist.Kura.Provisioner.KubernetesController do
     }
   end
 
-  defp public_host(handle, %Regions{
-         provisioner_config: %{public_host_template: template} = config
-       }) do
+  defp public_host(handle, %Regions{provisioner_config: %{public_host_template: template} = config}) do
     interpolate_host(template, dns_handle(handle), config)
   end
 
   defp public_host(_handle, _region), do: nil
 
-  defp grpc_public_host(handle, %Regions{
-         provisioner_config: %{grpc_public_host_template: template} = config
-       }) do
+  defp grpc_public_host(handle, %Regions{provisioner_config: %{grpc_public_host_template: template} = config}) do
     interpolate_host(template, dns_handle(handle), config)
   end
 
@@ -217,21 +208,17 @@ defmodule Tuist.Kura.Provisioner.KubernetesController do
     |> URI.to_string()
   end
 
-  defp tuist_base_url(%Regions{provisioner_config: %{tuist_base_url: url}})
-       when is_binary(url) and url != "",
-       do: url
+  defp tuist_base_url(%Regions{provisioner_config: %{tuist_base_url: url}}) when is_binary(url) and url != "", do: url
 
   defp tuist_base_url(_), do: Tuist.Environment.app_url()
 
-  defp rewrite_loopback(%URI{host: host} = uri, replacement)
-       when host in ["localhost", "127.0.0.1", "0.0.0.0"] do
+  defp rewrite_loopback(%URI{host: host} = uri, replacement) when host in ["localhost", "127.0.0.1", "0.0.0.0"] do
     %{uri | host: replacement}
   end
 
   defp rewrite_loopback(uri, _), do: uri
 
-  defp storage_class(%Regions{provisioner_config: %{storage_class: storage_class}}),
-    do: storage_class
+  defp storage_class(%Regions{provisioner_config: %{storage_class: storage_class}}), do: storage_class
 
   defp storage_class(_), do: nil
 
@@ -241,8 +228,7 @@ defmodule Tuist.Kura.Provisioner.KubernetesController do
   defp replicas(%Regions{provisioner_config: %{replicas: replicas}}), do: replicas
   defp replicas(_), do: nil
 
-  defp node_selector(%Regions{provisioner_config: %{node_selector: node_selector}}),
-    do: node_selector
+  defp node_selector(%Regions{provisioner_config: %{node_selector: node_selector}}), do: node_selector
 
   defp node_selector(_), do: nil
 

--- a/server/lib/tuist/kura/regions.ex
+++ b/server/lib/tuist/kura/regions.ex
@@ -119,7 +119,8 @@ defmodule Tuist.Kura.Regions do
         hetzner_location: "fsn1",
         public_host_template: "{account_handle}-{cluster_id}.kura.tuist.dev",
         grpc_public_host_template: "grpc.{account_handle}-{cluster_id}.kura.tuist.dev",
-        storage_class: "hcloud-volumes"
+        storage_class: "hcloud-volumes",
+        tuist_base_url: Tuist.Environment.kura_tuist_base_url()
       }
     }
   end

--- a/server/test/tuist/kura/provisioner/kubernetes_controller_test.exs
+++ b/server/test/tuist/kura/provisioner/kubernetes_controller_test.exs
@@ -88,6 +88,57 @@ defmodule Tuist.Kura.Provisioner.KubernetesControllerTest do
       assert spec["grpcPublicHost"] == "grpc.bumble-eu-central-1.kura.tuist.dev"
     end
 
+    test "uses the region-configured Tuist server URL for managed eu-central Kura instances" do
+      stub(Tuist.Environment, :app_url, fn -> "https://tuist.dev" end)
+
+      stub(Tuist.Environment, :kura_control_plane_client_id, fn ->
+        "00000000-0000-0000-0000-000000000001"
+      end)
+
+      manifest =
+        KubernetesController.manifest(
+          "kura-tuist-eu-central-1",
+          "0.5.2",
+          %{name: "tuist"},
+          eu_region(%{
+            tuist_base_url: "http://tuist-tuist-server.tuist-canary.svc.cluster.local:80"
+          }),
+          %Server{},
+          "return true"
+        )
+
+      env = Map.new(manifest["spec"]["extraEnv"], &{&1["name"], &1["value"]})
+
+      assert env["KURA_CONTROL_PLANE_URL"] ==
+               "http://tuist-tuist-server.tuist-canary.svc.cluster.local:80"
+
+      assert env["KURA_EXTENSION_HTTP_CLIENT_TUIST_BASE_URL"] ==
+               "http://tuist-tuist-server.tuist-canary.svc.cluster.local:80"
+    end
+
+    test "falls back to the app URL when the region has no configured Tuist server URL" do
+      stub(Tuist.Environment, :app_url, fn -> "https://tuist.dev" end)
+
+      stub(Tuist.Environment, :kura_control_plane_client_id, fn ->
+        "00000000-0000-0000-0000-000000000001"
+      end)
+
+      manifest =
+        KubernetesController.manifest(
+          "kura-tuist-eu-central-1",
+          "0.5.2",
+          %{name: "tuist"},
+          eu_region(),
+          %Server{},
+          "return true"
+        )
+
+      env = Map.new(manifest["spec"]["extraEnv"], &{&1["name"], &1["value"]})
+
+      assert env["KURA_CONTROL_PLANE_URL"] == "https://tuist.dev"
+      assert env["KURA_EXTENSION_HTTP_CLIENT_TUIST_BASE_URL"] == "https://tuist.dev"
+    end
+
     test "renders local controller overrides for kind testing" do
       stub(Tuist.Environment, :app_url, fn -> "http://localhost:8080" end)
 
@@ -115,7 +166,10 @@ defmodule Tuist.Kura.Provisioner.KubernetesControllerTest do
 
       env = Map.new(spec["extraEnv"], &{&1["name"], &1["value"]})
       assert env["KURA_CONTROL_PLANE_URL"] == "http://host.docker.internal:8080"
-      assert env["KURA_EXTENSION_HTTP_CLIENT_TUIST_BASE_URL"] == "http://host.docker.internal:8080"
+
+      assert env["KURA_EXTENSION_HTTP_CLIENT_TUIST_BASE_URL"] ==
+               "http://host.docker.internal:8080"
+
       assert env["KURA_CONTROL_PLANE_CLIENT_ID"] == "00000000-0000-0000-0000-000000000001"
 
       assert env["KURA_EXTENSION_TUIST_INTROSPECT_CLIENT_ID"] ==
@@ -171,7 +225,9 @@ defmodule Tuist.Kura.Provisioner.KubernetesControllerTest do
 
   describe "destroy/2" do
     test "deletes the KuraInstance and treats already-missing resources as gone" do
-      expect(Client, :delete_kura_instance, fn "kura", "kura-tuist-eu-central-1" -> {:error, :not_found} end)
+      expect(Client, :delete_kura_instance, fn "kura", "kura-tuist-eu-central-1" ->
+        {:error, :not_found}
+      end)
 
       assert :ok = KubernetesController.destroy("kura-tuist-eu-central-1", eu_region())
     end
@@ -214,7 +270,10 @@ defmodule Tuist.Kura.Provisioner.KubernetesControllerTest do
       end)
 
       assert {:ok, "sha-abcdef123456"} =
-               KubernetesController.current_image_tag("kura-tuist-local-controller", local_controller_region())
+               KubernetesController.current_image_tag(
+                 "kura-tuist-local-controller",
+                 local_controller_region()
+               )
     end
   end
 
@@ -224,7 +283,8 @@ defmodule Tuist.Kura.Provisioner.KubernetesControllerTest do
     end
 
     test "extracts the tag from an image reference that uses a registry port" do
-      assert KubernetesController.image_tag_from_image("localhost:5001/tuist/kura:0.5.2") == "0.5.2"
+      assert KubernetesController.image_tag_from_image("localhost:5001/tuist/kura:0.5.2") ==
+               "0.5.2"
     end
 
     test "returns nil when the image reference has no tag" do
@@ -233,7 +293,9 @@ defmodule Tuist.Kura.Provisioner.KubernetesControllerTest do
     end
 
     test "extracts the tag from a reference that also has a digest" do
-      assert KubernetesController.image_tag_from_image("ghcr.io/tuist/kura:sha-abcdef123456@sha256:abc123") ==
+      assert KubernetesController.image_tag_from_image(
+               "ghcr.io/tuist/kura:sha-abcdef123456@sha256:abc123"
+             ) ==
                "sha-abcdef123456"
     end
   end
@@ -244,15 +306,17 @@ defmodule Tuist.Kura.Provisioner.KubernetesControllerTest do
     end
   end
 
-  defp eu_region do
+  defp eu_region(extra_config \\ %{}) do
     %Regions{
       id: "eu-central",
-      provisioner_config: %{
-        cluster_id: "eu-central-1",
-        public_host_template: "{account_handle}-{cluster_id}.kura.tuist.dev",
-        grpc_public_host_template: "grpc.{account_handle}-{cluster_id}.kura.tuist.dev",
-        storage_class: "hcloud-volumes"
-      }
+      provisioner_config:
+        %{
+          cluster_id: "eu-central-1",
+          public_host_template: "{account_handle}-{cluster_id}.kura.tuist.dev",
+          grpc_public_host_template: "grpc.{account_handle}-{cluster_id}.kura.tuist.dev",
+          storage_class: "hcloud-volumes"
+        }
+        |> Map.merge(extra_config)
     }
   end
 

--- a/server/test/tuist/kura/provisioner/kubernetes_controller_test.exs
+++ b/server/test/tuist/kura/provisioner/kubernetes_controller_test.exs
@@ -293,9 +293,7 @@ defmodule Tuist.Kura.Provisioner.KubernetesControllerTest do
     end
 
     test "extracts the tag from a reference that also has a digest" do
-      assert KubernetesController.image_tag_from_image(
-               "ghcr.io/tuist/kura:sha-abcdef123456@sha256:abc123"
-             ) ==
+      assert KubernetesController.image_tag_from_image("ghcr.io/tuist/kura:sha-abcdef123456@sha256:abc123") ==
                "sha-abcdef123456"
     end
   end
@@ -310,13 +308,15 @@ defmodule Tuist.Kura.Provisioner.KubernetesControllerTest do
     %Regions{
       id: "eu-central",
       provisioner_config:
-        %{
-          cluster_id: "eu-central-1",
-          public_host_template: "{account_handle}-{cluster_id}.kura.tuist.dev",
-          grpc_public_host_template: "grpc.{account_handle}-{cluster_id}.kura.tuist.dev",
-          storage_class: "hcloud-volumes"
-        }
-        |> Map.merge(extra_config)
+        Map.merge(
+          %{
+            cluster_id: "eu-central-1",
+            public_host_template: "{account_handle}-{cluster_id}.kura.tuist.dev",
+            grpc_public_host_template: "grpc.{account_handle}-{cluster_id}.kura.tuist.dev",
+            storage_class: "hcloud-volumes"
+          },
+          extra_config
+        )
     }
   end
 

--- a/server/test/tuist/kura/regions_test.exs
+++ b/server/test/tuist/kura/regions_test.exs
@@ -17,20 +17,34 @@ defmodule Tuist.Kura.RegionsTest do
       assert "eu-central" in ids
 
       for id <- ["us-east", "us-west", "eu-central"] do
-        assert %Regions{provisioner: KubernetesController, provisioner_config: config} = Regions.get(id)
+        assert %Regions{provisioner: KubernetesController, provisioner_config: config} =
+                 Regions.get(id)
+
         refute Regions.get(id).display_name =~ "Hetzner"
         assert config.cluster_id == "#{id}-1"
         assert config.hetzner_location == hetzner_locations[id]
         assert config.storage_class == "hcloud-volumes"
       end
 
-      assert Regions.get("us-east").provisioner_config.kubernetes_client == [mode: :kubeconfig, cluster_id: "us-east-1"]
-      assert Regions.get("us-west").provisioner_config.kubernetes_client == [mode: :kubeconfig, cluster_id: "us-west-1"]
+      assert Regions.get("us-east").provisioner_config.kubernetes_client == [
+               mode: :kubeconfig,
+               cluster_id: "us-east-1"
+             ]
+
+      assert Regions.get("us-west").provisioner_config.kubernetes_client == [
+               mode: :kubeconfig,
+               cluster_id: "us-west-1"
+             ]
+
       refute Map.has_key?(Regions.get("eu-central").provisioner_config, :kubernetes_client)
     end
 
     test "exposes a local controller-backed region for kind smoke tests" do
-      assert %Regions{id: "local-controller", provisioner: KubernetesController, provisioner_config: config} =
+      assert %Regions{
+               id: "local-controller",
+               provisioner: KubernetesController,
+               provisioner_config: config
+             } =
                Enum.find(Regions.all(), &(&1.id == "local-controller"))
 
       assert config.cluster_id == "local-controller"
@@ -40,6 +54,15 @@ defmodule Tuist.Kura.RegionsTest do
       assert config.replicas == 1
       assert config.storage_size == "10Gi"
       assert config.node_selector == %{"kubernetes.io/os" => "linux"}
+    end
+
+    test "reads the managed-region Tuist base URL from the environment adapter" do
+      stub(Tuist.Environment, :kura_tuist_base_url, fn ->
+        "http://tuist-tuist-server.tuist-canary.svc.cluster.local:80"
+      end)
+
+      assert Regions.get("eu-central").provisioner_config.tuist_base_url ==
+               "http://tuist-tuist-server.tuist-canary.svc.cluster.local:80"
     end
   end
 
@@ -59,7 +82,10 @@ defmodule Tuist.Kura.RegionsTest do
     test "returns every configured managed region outside test and development" do
       stub(Tuist.Environment, :dev?, fn -> false end)
       stub(Tuist.Environment, :test?, fn -> false end)
-      stub(Tuist.Environment, :kura_available_region_ids, fn -> ["eu-central", "us-east", "us-west"] end)
+
+      stub(Tuist.Environment, :kura_available_region_ids, fn ->
+        ["eu-central", "us-east", "us-west"]
+      end)
 
       assert Enum.map(Regions.available(), & &1.id) == ["us-east", "us-west", "eu-central"]
     end
@@ -136,7 +162,9 @@ defmodule Tuist.Kura.RegionsTest do
       stub(Tuist.Environment, :dev_instance_suffix, fn -> 42 end)
       controller_region = Regions.get("local-controller")
 
-      assert controller_region.provisioner_config.kubernetes_client[:context] == "kind-kura-dev-42"
+      assert controller_region.provisioner_config.kubernetes_client[:context] ==
+               "kind-kura-dev-42"
+
       assert controller_region.provisioner_config.public_url == "http://localhost:4142"
     end
 


### PR DESCRIPTION
Resolves N/A

This PR improves Kura extension reliability and observability when managed eu-central instances call back to the Tuist server.

- Injects `TUIST_KURA_TUIST_BASE_URL` from the Helm release context so managed eu-central Kura instances use the in-cluster Tuist service URL for production, canary, and staging instead of the public application URL.
- Reads that URL through the region provisioner config, keeping the Kubernetes controller generic and avoiding hardcoded environment-to-namespace branching.
- Adds bounded-cardinality metrics for extension HTTP client calls, including normalized client, route, result, status class, and error kind labels.
- Retries transient extension HTTP transport failures once and includes richer reqwest error classification in hook failures.

### How to test locally

- `mise exec -- cargo fmt --check`
- `mise exec -- cargo test retries_introspection_transport_failures_once -- --nocapture`
- `mise exec -- cargo test authorizes_from_local_jwt_cache_grants_without_introspection -- --nocapture`
- `mise exec -- cargo test falls_back_to_introspection_when_jwt_cache_grants_do_not_cover_requested_project -- --nocapture`
- `mise exec -- cargo test metrics -- --nocapture`
- `mise exec -- cargo clippy --all-targets -- -D warnings`
- `mix format server/lib/tuist/environment.ex server/lib/tuist/kura/regions.ex server/lib/tuist/kura/provisioner/kubernetes_controller.ex server/test/tuist/kura/regions_test.exs server/test/tuist/kura/provisioner/kubernetes_controller_test.exs`
- `helm template tuist infra/helm/tuist -n tuist-canary -f infra/helm/tuist/values-managed-common.yaml -f infra/helm/tuist/values-managed-canary.yaml --set kuraController.image.tag=test --set kuraRuntime.image.tag=test | rg -n -C 1 "TUIST_KURA_TUIST_BASE_URL|tuist-tuist-server.tuist-canary.svc.cluster.local"`
- `helm template tuist infra/helm/tuist -n tuist -f infra/helm/tuist/values-managed-common.yaml -f infra/helm/tuist/values-managed-production.yaml --set kuraController.image.tag=test --set kuraRuntime.image.tag=test | rg -n -C 1 "TUIST_KURA_TUIST_BASE_URL|tuist-tuist-server.tuist.svc.cluster.local"`
- Not completed: `mix test test/tuist/kura/provisioner/kubernetes_controller_test.exs test/tuist/kura/regions_test.exs` because this worktree is missing server dependencies and Mix reports running `mix deps.get` is required.
