### PR TITLE
fix(server): handle GitHub rate-limit responses when fetching CLI releases

### DIFF
--- a/server/lib/tuist/github/releases.ex
+++ b/server/lib/tuist/github/releases.ex
@@ -79,7 +79,8 @@ defmodule Tuist.GitHub.Releases do
       {:ok, %Req.Response{status: 200, body: releases}} ->
         releases
 
-      {:ok, %Req.Response{status: status}} when status in 500..599 ->
+      {:ok, %Req.Response{status: status}} ->
+        Logger.error("Failed to fetch GitHub releases, status: #{status}")
         []
 
       {:error, _reason} ->

--- a/server/test/tuist/github/releases_test.exs
+++ b/server/test/tuist/github/releases_test.exs
@@ -157,6 +157,29 @@ defmodule Tuist.GitHub.ReleasesTest do
     assert release == nil
   end
 
+  test "returns nil when GitHub rate-limits the request with a 403" do
+    # Given
+    releases_url = Releases.releases_url()
+
+    stub(
+      Req,
+      :get,
+      fn ^releases_url, _opts ->
+        {:ok,
+         %Req.Response{
+           status: 403,
+           body: %{"message" => "API rate limit exceeded"}
+         }}
+      end
+    )
+
+    # When
+    release = Releases.get_latest_cli_release()
+
+    # Then
+    assert release == nil
+  end
+
   describe "get_latest_app_release/0" do
     test "returns latest release if the response is successful" do
       # Given


### PR DESCRIPTION
## What changed

`Tuist.GitHub.Releases.req_releases/0` now handles any non-200 response from the GitHub releases API. The previous code only matched `200`, `500..599`, and `{:error, _}`, so a `403` (rate limit) response fell through with no matching `case` clause. The narrow `status in 500..599` clause is replaced with a catch-all that logs the status and returns `[]`.

## Why

Sentry issue TUIST-KR (`Protocol.UndefinedError: protocol Enumerable not implemented for Tuple`) was escalating in production.

Root cause: when GitHub rate-limited the server (`403 "API rate limit exceeded"`), `req_releases/0` had no matching `case` clause for `{:ok, %Req.Response{status: 403}}`, raising a `CaseClauseError`. That error was raised *inside* the Cachex transaction wrapping the fetch in `KeyValueStore.get_or_update/3`; Cachex caught it and turned it into an `{:error, "no case clause matching..."}` tuple. That tuple got cached and returned to `get_latest_cli_release/1`, where `Enum.find/3` then crashed because a tuple is not `Enumerable`.

The trigger was the GitHub token's hourly core quota (`x-ratelimit-limit: 5000`) being exhausted in prod. The `get_latest_app_release/0` path already had a catch-all clause, so only the CLI-release path was affected.

## Why this solution

Returning `[]` on any failed fetch matches the existing intent (the `500..599` and `{:error, _}` clauses already returned `[]`) and keeps the contract that `get_latest_cli_release/1` always feeds a list into `Enum.find/3`. A catch-all is more robust than enumerating every individual status GitHub might return (403, 429, 401, etc.).

## Developer impact

When GitHub is unreachable or rate-limiting, the layout's "latest CLI release" banner degrades gracefully (shows nothing) instead of crashing the LiveView async assign.

## How to test locally

Run the module's tests:

```
cd server && mix test test/tuist/github/releases_test.exs
```

The suite includes a new test that stubs a `403` rate-limit response and asserts `get_latest_cli_release/0` returns `nil`. Before the fix it raised `CaseClauseError`; after the fix all 13 tests pass.

Fixes TUIST-KR

🤖 Generated with [Claude Code](https://claude.com/claude-code)