### PR TITLE
fix(server): expand production CNPG storage to 250 GiB

### DIFF
--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -116,7 +116,13 @@ postgresql:
   cnpg:
     instances: 3
     storage:
-      size: "100Gi"
+      # Sized for the Supabase → CNPG initial COPY: per-table sync workers
+      # each pin WAL until their COPY commits, so peak disk during the
+      # one-time migration is data + indexes + accumulated WAL — for
+      # cache_events (6 secondary indexes, 6-10× WAL amplification per
+      # insert) that runs ~5× the source data size. Steady-state usage
+      # after the COPY commits and slots release is ~30-40 GiB.
+      size: "250Gi"
     # Requests sized to fit three instances under hard pod anti-affinity
     # alongside the rest of the pool tenants; limits left generous so
     # Postgres runtime peaks aren't capped by the scheduling budget.


### PR DESCRIPTION
## Why

The Supabase → CNPG initial COPY on production filled the 100 GiB PVCs and CrashLoopBackoff'd the primary. The cluster is currently in `Not enough disk space` phase.

```
/var/lib/postgresql/data/pgdata: 95 GiB used / 98 GiB available
├── databases:    11 GiB
└── pg_wal:       84 GiB   ← table-sync workers pinning WAL during COPY
```

The 100 GiB sizing was made against Supabase's reported total (21.7 GiB) without accounting for the per-table-sync-worker WAL retention pattern. `cache_events` carries 5 secondary indexes (4.2 GiB of index data); each replicated row writes 6 WAL records, so during the cache_events COPY transaction (which holds its replication slot open until commit) WAL accumulates at ~6x the replicated-data rate. Once `cache_events` finishes and the slot releases, the WAL drains in minutes back to the ~30-40 GiB steady state.

## What

Raise `postgresql.cnpg.storage.size` from `100Gi` to `250Gi` in `values-managed-production.yaml`.

```diff
   cnpg:
     instances: 3
     storage:
+      # Sized for the Supabase → CNPG initial COPY: per-table sync workers
+      # each pin WAL until their COPY commits, so peak disk during the
+      # one-time migration is data + indexes + accumulated WAL — for
+      # cache_events (6 secondary indexes, 6-10× WAL amplification per
+      # insert) that runs ~5× the source data size. Steady-state usage
+      # after the COPY commits and slots release is ~30-40 GiB.
-      size: "100Gi"
+      size: "250Gi"
```

## Cost

| | total across 3 PVCs | monthly |
|---|---|---|
| Today (100 GiB × 3) | 300 GiB | €13.20 |
| After (250 GiB × 3) | 750 GiB | €33.00 |
| Delta | +450 GiB | **+€19.80/month** |

Well within the 40 TiB Hetzner quota. Single-volume max is 10 TiB so we're three orders of magnitude under the per-volume cap.

## Online expansion mechanics

Hetzner CSI has `allowVolumeExpansion: true`. CNPG's controller watches the Cluster spec for `storage.size` changes and patches the PVCs in place. The Hetzner CSI driver picks up the PVC resize and grows the underlying volume online — no detach, no pod restart. The kernel sees the larger block device, `resize2fs` runs, and Postgres keeps going (or, in our current case, the crashloop pod's next restart finds the disk space it needs to come up).

## Recovery sequence after merge

1. `gh workflow run server-deployment.yml -f environment=production`
2. CNPG patches the 3 PVCs to 250 GiB; CSI expands online (~30s per volume)
3. Primary boots successfully, syncs sync replicas, resumes the COPY where it left off
4. Once `cache_events` + `cache_action_items` finish (~2 more hours at current rate), all 49 tables hit `srsubstate='r'`, sync-worker slots release, WAL drains back to steady state

## Test plan

- [x] `helm template` renders `storage.size: "250Gi"` in `templates/postgresql-cnpg.yaml`
- [ ] After deploy: `kubectl get pvc -n tuist -l cnpg.io/cluster=tuist-tuist-pg` shows 250Gi on all three
- [ ] After deploy: `kubectl get cluster.postgresql.cnpg.io tuist-tuist-pg -n tuist` reports `healthy` and `3/3 ready`
- [ ] After deploy: subscription resumes, `srsubstate='r'` reaches 49/49