### PR TITLE
ci(server): fix the heavy tuist-linux jobs (timeouts + Docker build shape)

### DIFF
--- a/.github/actions/setup-server-mix/action.yml
+++ b/.github/actions/setup-server-mix/action.yml
@@ -39,7 +39,13 @@ runs:
       with:
         version: ${{ inputs.mise-version }}
         install_args: ${{ inputs.mise-install-args }}
-        cache: "true"
+        # The server toolchain (precompiled erlang/elixir, ClickHouse)
+        # installs in ~25s, but its mise cache is 500MB+. Restoring that
+        # costs about as long as a fresh install while consuming the
+        # repo's 10GB cache budget, which evicts the deps/_build cache
+        # below — the one that turns a cold 6-minute compile into a ~30s
+        # incremental one. Skip it so the high-value cache survives.
+        cache: "false"
         working_directory: server
         github_token: ${{ inputs.github-token || env.MISE_GITHUB_TOKEN }}
     - name: Restore Mix Cache

--- a/.github/actions/setup-server-mix/action.yml
+++ b/.github/actions/setup-server-mix/action.yml
@@ -39,13 +39,7 @@ runs:
       with:
         version: ${{ inputs.mise-version }}
         install_args: ${{ inputs.mise-install-args }}
-        # The server toolchain (precompiled erlang/elixir, ClickHouse)
-        # installs in ~25s, but its mise cache is 500MB+. Restoring that
-        # costs about as long as a fresh install while consuming the
-        # repo's 10GB cache budget, which evicts the deps/_build cache
-        # below — the one that turns a cold 6-minute compile into a ~30s
-        # incremental one. Skip it so the high-value cache survives.
-        cache: "false"
+        cache: "true"
         working_directory: server
         github_token: ${{ inputs.github-token || env.MISE_GITHUB_TOKEN }}
     - name: Restore Mix Cache

--- a/.github/workflows/gradle-cache-acceptance.yml
+++ b/.github/workflows/gradle-cache-acceptance.yml
@@ -37,7 +37,8 @@ jobs:
     name: Gradle Cache Acceptance
     runs-on: tuist-linux
     timeout-minutes: 30
-    if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
+    # TEMP: draft-only while iterating on runner perf; revert before ready.
+    if: github.event.pull_request.draft == true
     services:
       postgres:
         image: postgres:16

--- a/.github/workflows/gradle-cache-acceptance.yml
+++ b/.github/workflows/gradle-cache-acceptance.yml
@@ -37,8 +37,7 @@ jobs:
     name: Gradle Cache Acceptance
     runs-on: tuist-linux
     timeout-minutes: 30
-    # TEMP: draft-only while iterating on runner perf; revert before ready.
-    if: github.event.pull_request.draft == true
+    if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     services:
       postgres:
         image: postgres:16

--- a/.github/workflows/gradle-cache-acceptance.yml
+++ b/.github/workflows/gradle-cache-acceptance.yml
@@ -36,7 +36,7 @@ jobs:
   gradle_cache_acceptance:
     name: Gradle Cache Acceptance
     runs-on: tuist-linux
-    timeout-minutes: 15
+    timeout-minutes: 30
     if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     services:
       postgres:

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -160,7 +160,7 @@ jobs:
   test:
     name: Test
     runs-on: tuist-linux
-    timeout-minutes: 15
+    timeout-minutes: 30
     if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     services:
       postgres:
@@ -295,7 +295,7 @@ jobs:
   docker_build:
     name: Docker build
     runs-on: tuist-linux
-    timeout-minutes: 15
+    timeout-minutes: 30
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -161,7 +161,8 @@ jobs:
     name: Test
     runs-on: tuist-linux
     timeout-minutes: 30
-    if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
+    # TEMP: draft-only while iterating on runner perf; revert before ready.
+    if: github.event.pull_request.draft == true
     services:
       postgres:
         image: postgres:16
@@ -195,6 +196,8 @@ jobs:
     name: Credo
     runs-on: tuist-linux
     timeout-minutes: 15
+    # TEMP: skip while iterating on runner perf; revert before ready.
+    if: github.event.pull_request.draft == false
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-server-mix
@@ -296,7 +299,8 @@ jobs:
     name: Docker build
     runs-on: tuist-linux
     timeout-minutes: 30
-    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    # TEMP: draft-only while iterating on runner perf; revert before ready.
+    if: github.event.pull_request.draft == true
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -297,7 +297,9 @@ jobs:
         run: ./mise/tasks/security.sh
   docker_build:
     name: Docker build
-    runs-on: tuist-linux
+    # Bigger shape: the server image build (Elixir release compile inside
+    # the dind sidecar) OOMs the 2 vCPU / 8 GB default microVM.
+    runs-on: tuist-linux-large
     timeout-minutes: 30
     # TEMP: draft-only while iterating on runner perf; revert before ready.
     if: github.event.pull_request.draft == true

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -161,8 +161,7 @@ jobs:
     name: Test
     runs-on: tuist-linux
     timeout-minutes: 30
-    # TEMP: draft-only while iterating on runner perf; revert before ready.
-    if: github.event.pull_request.draft == true
+    if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     services:
       postgres:
         image: postgres:16
@@ -196,8 +195,6 @@ jobs:
     name: Credo
     runs-on: tuist-linux
     timeout-minutes: 15
-    # TEMP: skip while iterating on runner perf; revert before ready.
-    if: github.event.pull_request.draft == false
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-server-mix
@@ -301,8 +298,7 @@ jobs:
     # the dind sidecar) OOMs the 2 vCPU / 8 GB default microVM.
     runs-on: tuist-linux-large
     timeout-minutes: 30
-    # TEMP: draft-only while iterating on runner perf; revert before ready.
-    if: github.event.pull_request.draft == true
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
After #11057 moved server **Test**, server **Docker build**, and **Gradle Cache Acceptance** onto the in-house fleet, all three failed — for two distinct reasons. This fixes both.

## What changed
1. **`timeout-minutes` 15 → 30** for the three jobs.
2. **`docker_build` runs on the new `tuist-linux-large` profile (4 vCPU / 16 GB)** instead of the default `tuist-linux` (2 vCPU / 8 GB).

## Why

These were on `namespace-profile-default-with-volume` (persistent cache + larger shape). On `tuist-linux` they run on the **2 vCPU / 8 GB** default profile (since #11052) with no persistent volume, so they lean entirely on the GitHub Actions cache.

**Test + Gradle — timed out at 15 min.** Cold runs are slow on the smaller shape, and the repo's Actions cache was thrashing at its 10 GB default limit, evicting the `_build` cache that makes `mix compile` incremental — so it recompiled cold (~6 min) every run. Two things fix this:
- The **timeout bump** lets a cold run *complete* (and reach `actions/cache`'s save step, which a killed job never does).
- Raising the **repo cache size limit to 100 GB** (a repo setting, not in this PR) stops the eviction, so the `_build` cache persists. Measured: warm `Compile` dropped **369s → 159s**, db setup **162s → 13s**; the Test job settles around ~11 min, comfortably under the timeout.

**Docker build — OOM, not a timeout.** It failed with "runner lost communication" after ~18 min. The server image build compiles the Elixir release *inside* the dind sidecar (build container + dockerd + kata-VM overhead stacked together), which exceeds 8 GB and gets the microVM OOM-killed. The Test job compiles directly and fits in 8 GB; the Docker build doesn't. Moving it to `tuist-linux-large` (16 GB) clears it — verified green in ~16 min.

## Validation
- **Test ✅** (~11 min warm), **Gradle ✅**, **Docker build ✅** (on `tuist-linux-large`) — all three confirmed green on the draft.
- All edited workflows parse as valid YAML.

## Not in scope (follow-up)
The Test suite spends ~265s of its ~359s **synchronous** (`Finished in 359.3s (93.8s async, 265.5s sync)`, 4809 tests). Converting the remaining default-sync modules to `async: true` is the lever to make `mix test` itself faster — a separate effort. (ClickHouse tests are already async via the `ecto_ch` transaction fork + #10409.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)