### PR TITLE
fix(infra): disable tart-kubelet orphan-VM GC on builder nodes

### DIFF
--- a/infra/macos-host-bootstrap/bootstrap.go
+++ b/infra/macos-host-bootstrap/bootstrap.go
@@ -177,11 +177,13 @@ type Config struct {
 	// vm-image-builder fleet; pure Node hosts leave this nil.
 	//
 	// The runner agent runs as a LaunchAgent under cfg.SSHUser and
-	// picks up image-bake workflow jobs from GitHub. It coexists
-	// peacefully with tart-kubelet on the same host because no Pods
-	// are ever scheduled to builder Nodes (the per-fleet
-	// `tuist.dev/fleet` NodeLabel scopes Pod selection away from
-	// the builder fleet name).
+	// picks up image-bake workflow jobs from GitHub. No Pods are ever
+	// scheduled to builder Nodes (the per-fleet `tuist.dev/fleet`
+	// NodeLabel scopes Pod selection away from the builder fleet
+	// name). That same property means tart-kubelet's orphan-VM GC
+	// would treat the host-baked build VM as collectable and reap it
+	// mid-`tart push`, so renderLaunchdPlist passes `--disable-vm-gc`
+	// when this is set.
 	//
 	// The reconciler is responsible for resolving the registration
 	// token from a Secret before populating
@@ -539,6 +541,17 @@ func renderLaunchdPlist(cfg Config) string {
 	if cfg.ProviderID != "" {
 		providerIDArg = fmt.Sprintf("\n    <string>--provider-id=%s</string>", cfg.ProviderID)
 	}
+	// Builder-fleet hosts (GHActionsRunner set) never have Pods
+	// scheduled but bake images with a host-level Packer/`tart`
+	// process. tart-kubelet's orphan-VM GC treats every local VM not
+	// backed by a Pod as collectable, so it would reap the in-flight
+	// build VM mid-`tart push` (the push then fails at the NVRAM layer
+	// with `nvram.bin doesn't exist`). Disable the GC there; the
+	// image-bake workflow reclaims its own Tart disk.
+	disableVMGCArg := ""
+	if cfg.GHActionsRunner != nil {
+		disableVMGCArg = "\n    <string>--disable-vm-gc</string>"
+	}
 	// Run tart-kubelet as the SSH user (m1). Apple's
 	// Virtualization.framework requires the calling process to be the
 	// same user that holds the live GUI console session — Tart's
@@ -561,7 +574,7 @@ func renderLaunchdPlist(cfg Config) string {
     <string>--kubeconfig=/etc/tart-kubelet/kubeconfig</string>
     <string>--host-cpu=%[2]d</string>
     <string>--host-memory-mb=%[3]d</string>
-    <string>--max-pods=%[4]d</string>%[6]s%[7]s%[8]s
+    <string>--max-pods=%[4]d</string>%[6]s%[7]s%[8]s%[9]s
   </array>
   <key>RunAtLoad</key><true/>
   <key>KeepAlive</key><true/>
@@ -575,7 +588,7 @@ func renderLaunchdPlist(cfg Config) string {
   </dict>
 </dict>
 </plist>
-`, cfg.NodeName, cpu, mem, maxPods, user, nodeLabelsArg, nodeIPSourceArg, providerIDArg)
+`, cfg.NodeName, cpu, mem, maxPods, user, nodeLabelsArg, nodeIPSourceArg, providerIDArg, disableVMGCArg)
 }
 
 func shellQuote(s string) string {

--- a/infra/macos-host-bootstrap/bootstrap_test.go
+++ b/infra/macos-host-bootstrap/bootstrap_test.go
@@ -71,6 +71,24 @@ func TestRenderLaunchdPlist_RendersMultipleLabelsSorted(t *testing.T) {
 	}
 }
 
+func TestRenderLaunchdPlist_OmitsDisableVMGCForPureNode(t *testing.T) {
+	out := renderLaunchdPlist(Config{NodeName: "n1", SSHUser: "m1"})
+	if strings.Contains(out, "--disable-vm-gc") {
+		t.Fatalf("expected --disable-vm-gc to be absent on a pure Node (no GHActionsRunner)\n%s", out)
+	}
+}
+
+func TestRenderLaunchdPlist_RendersDisableVMGCForBuilder(t *testing.T) {
+	out := renderLaunchdPlist(Config{
+		NodeName:        "n1",
+		SSHUser:         "m1",
+		GHActionsRunner: &GHActionsRunnerConfig{},
+	})
+	if !strings.Contains(out, "<string>--disable-vm-gc</string>") {
+		t.Fatalf("expected --disable-vm-gc in plist for a builder host\n%s", out)
+	}
+}
+
 // HostKeyState is the SSH-side TOFU primitive. The first observation
 // of a host key on a fresh state is captured; later observations
 // against a state seeded with KnownHostFingerprint must match.

--- a/infra/tart-kubelet/cmd/tart-kubelet/main.go
+++ b/infra/tart-kubelet/cmd/tart-kubelet/main.go
@@ -65,6 +65,7 @@ func main() {
 		metricsAddr        string
 		probeAddr          string
 		tartBinary         string
+		disableVMGC        bool
 	)
 	flag.StringVar(&nodeName, "node-name", envOr("TART_KUBELET_NODE_NAME", ""), "Node name to register as. Defaults to os.Hostname() when empty.")
 	flag.StringVar(&providerID, "provider-id", envOr("TART_KUBELET_PROVIDER_ID", ""),
@@ -101,6 +102,13 @@ func main() {
 			"the endpoint on the WAN.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "Liveness/readiness probe endpoint.")
 	flag.StringVar(&tartBinary, "tart-binary", "/usr/local/bin/tart", "Path to the local tart CLI.")
+	flag.BoolVar(&disableVMGC, "disable-vm-gc", false,
+		"Disable the periodic orphan-VM garbage collector. The GC deletes every local "+
+			"Tart VM not backed by a Pod scheduled to this Node. On builder-fleet Nodes — "+
+			"which never have Pods scheduled but bake images with a host-level Packer/`tart` "+
+			"process — every local VM looks orphaned, so the GC reaps the in-flight build VM "+
+			"mid-`tart push` (it fails at the NVRAM layer with `nvram.bin doesn't exist`). Set "+
+			"this on builder Nodes; the image-bake workflow reclaims its own Tart disk.")
 
 	// `--kubeconfig` is registered automatically by controller-runtime's
 	// init() (sigs.k8s.io/controller-runtime/pkg/client/config). Defining
@@ -207,16 +215,28 @@ func main() {
 
 	store := podagent.NewStore()
 
-	gcCollector := &podagent.Collector{
-		K8s:      mgr.GetAPIReader(),
-		Tart:     tartClient,
-		NodeName: nodeName,
-		Interval: 5 * time.Minute,
-		Store:    store,
-	}
-	if err := mgr.Add(gcCollector); err != nil {
-		setupLog.Error(err, "add gc collector")
-		os.Exit(1)
+	// The orphan-VM GC reaps any local Tart VM not backed by a Pod on
+	// this Node. Builder-fleet Nodes never run Pods (they bake images
+	// with a host-level Packer/`tart` process), so every local VM —
+	// including the in-flight build VM — looks orphaned to the GC; it
+	// would `tart delete` the bundle mid-`tart push`, failing the push
+	// at the NVRAM layer. `--disable-vm-gc` leaves the collector off on
+	// those Nodes; the image-bake workflow reclaims its own disk.
+	var gcCollector *podagent.Collector
+	if disableVMGC {
+		setupLog.Info("orphan-VM garbage collector disabled (--disable-vm-gc); this Node manages its own Tart disk")
+	} else {
+		gcCollector = &podagent.Collector{
+			K8s:      mgr.GetAPIReader(),
+			Tart:     tartClient,
+			NodeName: nodeName,
+			Interval: 5 * time.Minute,
+			Store:    store,
+		}
+		if err := mgr.Add(gcCollector); err != nil {
+			setupLog.Error(err, "add gc collector")
+			os.Exit(1)
+		}
 	}
 
 	// Hydrate the Pod ↔ VM map from on-host state before reconciles

--- a/infra/vm-image-builder.md
+++ b/infra/vm-image-builder.md
@@ -324,8 +324,18 @@ workflows can't run as Pods on that model because they'd need to
 spawn nested macOS guests (Packer → Tart → macOS), which Apple
 Silicon Virtualization.framework refuses. So the builder runs as a
 host-level LaunchAgent that invokes Tart directly, sitting beside
-tart-kubelet on the same host without conflict because no Pods are
-ever scheduled there.
+tart-kubelet on the same host.
+
+The one place this isn't conflict-free: tart-kubelet's orphan-VM
+GC (`internal/podagent/garbage.go`) deletes every local Tart VM
+not backed by a Pod scheduled to the Node. Because no Pods ever
+land on a builder, the host-baked build VM looks orphaned and the
+GC would `tart delete` it mid-`tart push` — the push then fails at
+the NVRAM layer with `The file "nvram.bin" doesn't exist`. The
+bootstrap therefore starts tart-kubelet with `--disable-vm-gc` on
+builder Nodes (`renderLaunchdPlist` keys this off `GHActionsRunner`
+being set); the image-bake workflow's own "Reclaim Tart disk" step
+handles disk reclamation there instead.
 
 The bootstrap helpers in
 [`infra/macos-host-bootstrap/`](macos-host-bootstrap/) are shared


### PR DESCRIPTION
## What changed

Adds a `--disable-vm-gc` flag to `tart-kubelet` that turns off the periodic orphan-VM garbage collector, and wires it on automatically for builder-fleet Nodes via `macos-host-bootstrap`. Pure Nodes are unaffected.

- `infra/tart-kubelet/cmd/tart-kubelet/main.go` — new `--disable-vm-gc` flag (default `false`). When set, the `podagent.Collector` is never constructed or added to the manager, and the reconciler gets a nil `GC` (its existing `if r.GC != nil` guard then skips the reactive no-space path too).
- `infra/macos-host-bootstrap/bootstrap.go` — `renderLaunchdPlist` emits `--disable-vm-gc` when `cfg.GHActionsRunner != nil` (builder hosts), mirroring the conditional rendering of `--node-labels`/`--provider-id`. The CAPI provider already sets `GHActionsRunner` only for builder machines, so no provider change is needed.
- `infra/vm-image-builder.md` — corrects the "sits beside tart-kubelet without conflict" claim this bug disproved.
- Tests: two new `renderLaunchdPlist` cases (flag present for builders, absent for pure Nodes).

## Why

Release image bakes were failing at `tart push` with `The file "nvram.bin" doesn't exist`, independently on each builder host (both `release-runner-image` and `release-xcresult-processor-image` in the same release run, on two separate runners). Example: https://github.com/tuist/tuist/actions/runs/26895463934/job/79335847508

### Root cause

Builder Mac minis are full Kubernetes Nodes running `tart-kubelet`. Its periodic orphan-VM GC (`internal/podagent/garbage.go`, 5-minute interval) deletes every `local` Tart VM not backed by a Pod scheduled to that Node. Builder Nodes **never** have Pods scheduled — they bake images with a host-level Packer/`tart` process — so the freshly-built VM (`tuist-runner` / `tuist-xcresult-processor`) is always classified as an orphan and `tart delete`d.

`tart push` uploads config → disk → NVRAM. The disk stage takes ~5+ minutes, which meets/exceeds the GC interval, so a GC pass lands mid-push and unlinks the VM bundle. The already-open `disk.img` survives on its file descriptor (so the disk upload completes), but `nvram.bin` is opened only *after* the disk finishes — by then the bundle is gone, hence the failure at the NVRAM layer.

This explains why both bakes failed identically on different hosts, why it is effectively deterministic for any push longer than the GC interval, and why earlier image releases succeeded (they ran on the old hand-bootstrapped builder hosts that did not run tart-kubelet).

### Why this approach

The GC exists to reclaim disk from terminated pod-VMs and stale OCI cache. Neither exists on a builder (no Pods are scheduled), so the GC has nothing legitimate to collect there — it is pure downside. Builders already reclaim their own disk via the image-bake workflow's "Reclaim Tart disk" step. Disabling the GC on builder Nodes is therefore the most surgical fix and matches the documented "kubelet stays idle on builders" intent. A name-based ownership guard in the GC was considered as durable hardening but is out of scope here.

## Rollout note

`tart-kubelet` and `macos-host-bootstrap` are baked into the `capi-provider-scaleway-applesilicon` operator image. This fix takes effect on live builders only after the operator image is rebuilt and the builder hosts are re-bootstrapped/rolled so their launchd plist is re-rendered with `--disable-vm-gc`. Until then, re-running the failed release jobs will fail again; the manual stop-gap is to stop `dev.tuist.tart-kubelet` on each builder for the duration of a dispatched bake.

## How to test locally

- `cd infra/tart-kubelet && go build ./... && go vet ./... && go test ./...`
- `cd infra/macos-host-bootstrap && go build ./... && go vet ./... && go test ./...`

The new `renderLaunchdPlist` tests assert `--disable-vm-gc` is present when `GHActionsRunner` is set and absent otherwise.