### PR TITLE
fix(server): derive module name for UI test bundles in xcresult parser

### DIFF
--- a/server/native/xcresult_nif/Package.swift
+++ b/server/native/xcresult_nif/Package.swift
@@ -43,7 +43,10 @@ let package = Package(
         ),
         .testTarget(
             name: "XCResultParserTests",
-            dependencies: ["XCResultParser"],
+            dependencies: [
+                "XCResultParser",
+                .product(name: "Command", package: "tuist.Command"),
+            ],
             resources: [.copy("../Fixtures")]
         ),
     ]

--- a/server/native/xcresult_nif/Sources/XCResultParser/XCResultParser.swift
+++ b/server/native/xcresult_nif/Sources/XCResultParser/XCResultParser.swift
@@ -129,7 +129,7 @@ public struct XCResultParser: Sendable {
         module: String?,
         into results: inout [TestResultStatuses.TestCaseStatus]
     ) {
-        let currentModule = node.nodeType == "Unit test bundle" ? node.name : module
+        let currentModule = (node.nodeType == "Unit test bundle" || node.nodeType == "UI test bundle") ? node.name : module
 
         if node.nodeType == "Test Case", let name = node.name {
             results.append(
@@ -245,7 +245,7 @@ public struct XCResultParser: Sendable {
         rootDirectory: AbsolutePath?,
         actionLogFailures: [String: [TestFailure]]
     ) {
-        let currentModule = node.nodeType == "Unit test bundle" ? node.name : module
+        let currentModule = (node.nodeType == "Unit test bundle" || node.nodeType == "UI test bundle") ? node.name : module
 
         captureSuiteDuration(from: node, into: &suiteDurations)
 

--- a/server/native/xcresult_nif/Tests/XCResultParserTests/XCResultParserTests.swift
+++ b/server/native/xcresult_nif/Tests/XCResultParserTests/XCResultParserTests.swift
@@ -1,8 +1,34 @@
+import Command
 import FileSystem
 import Foundation
 import Path
 import Testing
 @testable import XCResultParser
+
+/// Stands in for `xcresulttool`. `loadTestOutput` shells out with a redirect to
+/// a temp file and reads it back, so the stub writes the canned test-results
+/// JSON to that redirect target — the real decoding and node classification then
+/// run unchanged through the public parsing API.
+private struct XCResultToolStub: CommandRunning {
+    let testResultsJSON: String
+
+    func run(
+        arguments: [String],
+        environment _: [String: String],
+        workingDirectory _: AbsolutePath?
+    ) -> AsyncThrowingStream<CommandEvent, any Error> {
+        let command = arguments.last ?? ""
+        return AsyncThrowingStream { continuation in
+            if let redirect = command.range(of: "> '") {
+                let tail = command[redirect.upperBound...]
+                if let close = tail.firstIndex(of: "'") {
+                    try? testResultsJSON.write(toFile: String(tail[..<close]), atomically: true, encoding: .utf8)
+                }
+            }
+            continuation.finish()
+        }
+    }
+}
 
 struct XCResultParserTests {
     let fileSystem = FileSystem()
@@ -52,6 +78,71 @@ struct XCResultParserTests {
             // attachments dir so its wholesale cleanup reclaims them.
             #expect(try await fileSystem.exists(attachmentsDirectory.appending(component: "xcresult-attachments")))
         }
+    }
+
+    @Test
+    func parseTestStatuses_derivesModuleNameForUITestBundlesNotJustUnitTestBundles() async throws {
+        // xcresulttool reports unit test bundles as "Unit test bundle" and UI
+        // test bundles as "UI test bundle". When the module isn't derived, the
+        // server stores it as "Unknown", which breaks quarantine `-skip-testing`
+        // matching so the test keeps running. Both bundle kinds must resolve to
+        // their bundle name.
+        let json = """
+        {
+          "testNodes": [
+            {
+              "nodeType": "Test Plan",
+              "name": "DepopTests",
+              "children": [
+                {
+                  "nodeType": "Unit test bundle",
+                  "name": "DepopUnitTests",
+                  "children": [
+                    {
+                      "nodeType": "Test Suite",
+                      "name": "ProductDetailsTests",
+                      "children": [
+                        {
+                          "nodeType": "Test Case",
+                          "name": "testUnitExample()",
+                          "nodeIdentifier": "ProductDetailsTests/testUnitExample()",
+                          "result": "Passed"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "nodeType": "UI test bundle",
+                  "name": "DepopUITests",
+                  "children": [
+                    {
+                      "nodeType": "Test Suite",
+                      "name": "BuyerMakeOfferFlowFunctionalTests",
+                      "children": [
+                        {
+                          "nodeType": "Test Case",
+                          "name": "testMakeOfferOnProductWithoutSize()",
+                          "nodeIdentifier": "BuyerMakeOfferFlowFunctionalTests/testMakeOfferOnProductWithoutSize()",
+                          "result": "Passed"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+        """
+        let parser = XCResultParser(commandRunner: XCResultToolStub(testResultsJSON: json))
+
+        let statuses = try await parser.parseTestStatuses(path: try AbsolutePath(validating: "/tmp/depop.xcresult"))
+
+        let uiTest = try #require(statuses.testCases.first { $0.name == "testMakeOfferOnProductWithoutSize()" })
+        #expect(uiTest.module == "DepopUITests")
+        let unitTest = try #require(statuses.testCases.first { $0.name == "testUnitExample()" })
+        #expect(unitTest.module == "DepopUnitTests")
     }
 
     @Test

--- a/server/native/xcresult_nif/Tests/XCResultParserTests/XCResultParserTests.swift
+++ b/server/native/xcresult_nif/Tests/XCResultParserTests/XCResultParserTests.swift
@@ -92,20 +92,20 @@ struct XCResultParserTests {
           "testNodes": [
             {
               "nodeType": "Test Plan",
-              "name": "DepopTests",
+              "name": "AppTests",
               "children": [
                 {
                   "nodeType": "Unit test bundle",
-                  "name": "DepopUnitTests",
+                  "name": "AppUnitTests",
                   "children": [
                     {
                       "nodeType": "Test Suite",
-                      "name": "ProductDetailsTests",
+                      "name": "CalculatorTests",
                       "children": [
                         {
                           "nodeType": "Test Case",
                           "name": "testUnitExample()",
-                          "nodeIdentifier": "ProductDetailsTests/testUnitExample()",
+                          "nodeIdentifier": "CalculatorTests/testUnitExample()",
                           "result": "Passed"
                         }
                       ]
@@ -114,16 +114,16 @@ struct XCResultParserTests {
                 },
                 {
                   "nodeType": "UI test bundle",
-                  "name": "DepopUITests",
+                  "name": "AppUITests",
                   "children": [
                     {
                       "nodeType": "Test Suite",
-                      "name": "BuyerMakeOfferFlowFunctionalTests",
+                      "name": "OnboardingFlowTests",
                       "children": [
                         {
                           "nodeType": "Test Case",
-                          "name": "testMakeOfferOnProductWithoutSize()",
-                          "nodeIdentifier": "BuyerMakeOfferFlowFunctionalTests/testMakeOfferOnProductWithoutSize()",
+                          "name": "testUIExample()",
+                          "nodeIdentifier": "OnboardingFlowTests/testUIExample()",
                           "result": "Passed"
                         }
                       ]
@@ -137,12 +137,12 @@ struct XCResultParserTests {
         """
         let parser = XCResultParser(commandRunner: XCResultToolStub(testResultsJSON: json))
 
-        let statuses = try await parser.parseTestStatuses(path: try AbsolutePath(validating: "/tmp/depop.xcresult"))
+        let statuses = try await parser.parseTestStatuses(path: try AbsolutePath(validating: "/tmp/app.xcresult"))
 
-        let uiTest = try #require(statuses.testCases.first { $0.name == "testMakeOfferOnProductWithoutSize()" })
-        #expect(uiTest.module == "DepopUITests")
+        let uiTest = try #require(statuses.testCases.first { $0.name == "testUIExample()" })
+        #expect(uiTest.module == "AppUITests")
         let unitTest = try #require(statuses.testCases.first { $0.name == "testUnitExample()" })
-        #expect(unitTest.module == "DepopUnitTests")
+        #expect(unitTest.module == "AppUnitTests")
     }
 
     @Test


### PR DESCRIPTION
### What changed

The xcresult parser now derives a test case's module name from `"UI test bundle"` nodes in addition to `"Unit test bundle"` nodes, at both node-classification sites in `XCResultParser`.

### Why

`xcrun xcresulttool get test-results tests` reports unit test bundles with `nodeType: "Unit test bundle"` and UI test bundles with `nodeType: "UI test bundle"`. The parser only matched the former, so every UI test case was parsed with a `nil` module and grouped under the `"Unknown"` fallback, which is what gets stored as `module_name`.

### Root cause and impact

Quarantine skipping breaks when the stored module is wrong:

- Test case identity is the deterministic UUID of `(project_id, name, module_name, suite_name)`.
- The CLI builds xcodebuild `-skip-testing` arguments from the stored module name.
- With `module_name = "Unknown"`, the CLI emits `-skip-testing Unknown/Suite/method`. xcodebuild silently ignores skip identifiers whose target does not exist, so the quarantined UI test keeps running and failing in CI.

Unit tests were unaffected because their module name was parsed correctly. This matched a report of quarantined (skipped) UI tests still running and failing in CI, where the affected tests showed `Module: Unknown`.

### Why this fix

The fix is at the single source of the wrong data, the node-type classification, rather than papering over `"Unknown"` downstream in the CLI or server matcher. Correcting the parsed module fixes both the broken `-skip-testing` matching and the `Module: Unknown` display.

### Caveats for rollout

- Not retroactive. Existing UI test cases already stored under `"Unknown"` keep that identity. Once the corrected module name is parsed they reappear as new test cases, so they must be re-quarantined.
- This NIF is baked into the xcresult-processor Tart VM image, so the fix takes effect only after that image is rebuilt and rolled, not on a normal server deploy.

### Validation

Developed TDD-style:

1. Added a test that drives canned `xcresulttool` JSON (one unit test bundle and one UI test bundle) through the public `parseTestStatuses(path:)` API via an injected `CommandRunning` stub that mimics the tool's file-redirect. It failed first with the UI test's module resolving to `nil`, while the unit test assertion already passed.
2. Applied the fix. The test passes.
3. Full `XCResultParser` suite green (8/8), no regressions.

The test exercises the real public API with dependency injection, so no `private` visibility was widened.

### How to test locally

```sh
cd server/native/xcresult_nif
swift test --replace-scm-with-registry --filter parseTestStatuses_derivesModuleNameForUITestBundlesNotJustUnitTestBundles
```

Revert either classification site in `Sources/XCResultParser/XCResultParser.swift` to the `"Unit test bundle"`-only check to see the test fail.
