### PR TITLE
test(server): run isolated test modules async to speed up the suite

### DIFF
--- a/.github/workflows/gradle-cache-acceptance.yml
+++ b/.github/workflows/gradle-cache-acceptance.yml
@@ -37,8 +37,7 @@ jobs:
     name: Gradle Cache Acceptance
     runs-on: tuist-linux
     timeout-minutes: 30
-    # TEMP: draft-only while iterating on test perf; revert before ready.
-    if: github.event.pull_request.draft == true
+    if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     services:
       postgres:
         image: postgres:16

--- a/.github/workflows/gradle-cache-acceptance.yml
+++ b/.github/workflows/gradle-cache-acceptance.yml
@@ -35,7 +35,9 @@ env:
 jobs:
   gradle_cache_acceptance:
     name: Gradle Cache Acceptance
-    runs-on: tuist-linux
+    # TEMP: trying the 4 vCPU shape to see if it speeds up compile + e2e.
+    # Decide before ready.
+    runs-on: tuist-linux-large
     timeout-minutes: 30
     # TEMP: draft-only while iterating on test perf; revert before ready.
     if: github.event.pull_request.draft == true

--- a/.github/workflows/gradle-cache-acceptance.yml
+++ b/.github/workflows/gradle-cache-acceptance.yml
@@ -35,9 +35,7 @@ env:
 jobs:
   gradle_cache_acceptance:
     name: Gradle Cache Acceptance
-    # TEMP: trying the 4 vCPU shape to see if it speeds up compile + e2e.
-    # Decide before ready.
-    runs-on: tuist-linux-large
+    runs-on: tuist-linux
     timeout-minutes: 30
     # TEMP: draft-only while iterating on test perf; revert before ready.
     if: github.event.pull_request.draft == true

--- a/.github/workflows/gradle-cache-acceptance.yml
+++ b/.github/workflows/gradle-cache-acceptance.yml
@@ -117,7 +117,11 @@ jobs:
         run: |
           # Single mix do so compile + all ecto tasks + seeds share one BEAM
           # (and peak memory only once) before we ever start the web server.
-          MIX_ENV=dev mix do \
+          # +S 1 caps the parallel compiler exactly like Start main server
+          # below: on a cold _build cache this does a full compile, and at 4
+          # workers the in-flight module copies OOM the runner from inside the
+          # guest ("lost communication").
+          ELIXIR_ERL_OPTIONS="+S 1" MIX_ENV=dev mix do \
             compile, \
             ecto.create, \
             run priv/repo/timezone.exs, \

--- a/.github/workflows/gradle-cache-acceptance.yml
+++ b/.github/workflows/gradle-cache-acceptance.yml
@@ -37,7 +37,8 @@ jobs:
     name: Gradle Cache Acceptance
     runs-on: tuist-linux
     timeout-minutes: 30
-    if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
+    # TEMP: draft-only while iterating on test perf; revert before ready.
+    if: github.event.pull_request.draft == true
     services:
       postgres:
         image: postgres:16

--- a/.github/workflows/gradle-cache-acceptance.yml
+++ b/.github/workflows/gradle-cache-acceptance.yml
@@ -35,7 +35,11 @@ env:
 jobs:
   gradle_cache_acceptance:
     name: Gradle Cache Acceptance
-    runs-on: tuist-linux
+    # Bigger shape: the e2e compiles and boots the full server + ClickHouse,
+    # which peaks over the 2 vCPU / 8 GB default microVM and OOM-kills the
+    # runner from inside the guest ("lost communication"). The 4 vCPU / 16 GB
+    # shape restores the headroom from before the default downsize (#11052).
+    runs-on: tuist-linux-large
     timeout-minutes: 30
     if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     services:

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -161,8 +161,7 @@ jobs:
     name: Test
     runs-on: tuist-linux
     timeout-minutes: 30
-    # TEMP: draft-only while iterating on test perf; revert before ready.
-    if: github.event.pull_request.draft == true
+    if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     services:
       postgres:
         image: postgres:16
@@ -196,8 +195,6 @@ jobs:
     name: Credo
     runs-on: tuist-linux
     timeout-minutes: 15
-    # TEMP: skip while iterating on test perf; revert before ready.
-    if: github.event.pull_request.draft == false
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-server-mix
@@ -301,8 +298,7 @@ jobs:
     # the dind sidecar) OOMs the 2 vCPU / 8 GB default microVM.
     runs-on: tuist-linux-large
     timeout-minutes: 30
-    # TEMP: draft-only while iterating on test perf; revert before ready.
-    if: github.event.pull_request.draft == true
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -159,7 +159,11 @@ jobs:
           echo "✅ All dashboard translation templates present"
   test:
     name: Test
-    runs-on: tuist-linux
+    # Bigger shape: the test compile + ClickHouse + Postgres peak over the
+    # 2 vCPU / 8 GB default microVM, OOM-killing the runner from inside the
+    # guest ("lost communication"). The 4 vCPU / 16 GB shape restores the
+    # headroom this job had before the default was downsized (#11052).
+    runs-on: tuist-linux-large
     timeout-minutes: 30
     if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     services:
@@ -372,7 +376,10 @@ jobs:
   #         fi
   seed:
     name: Seed
-    runs-on: tuist-linux
+    # Bigger shape: database setup (migrations + seeds) is too slow on the
+    # 2 vCPU default and overruns the 15m timeout under fleet load. The
+    # 4 vCPU / 16 GB shape restores the headroom from before #11052.
+    runs-on: tuist-linux-large
     timeout-minutes: 15
     if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     services:

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -159,7 +159,9 @@ jobs:
           echo "✅ All dashboard translation templates present"
   test:
     name: Test
-    runs-on: tuist-linux
+    # TEMP: trying the 4 vCPU shape to see how much the async conversions
+    # parallelize beyond the 2 vCPU default. Decide before ready.
+    runs-on: tuist-linux-large
     timeout-minutes: 30
     # TEMP: draft-only while iterating on test perf; revert before ready.
     if: github.event.pull_request.draft == true

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -318,8 +318,6 @@ jobs:
           push: false
           load: true
           tags: tuist/tuist
-          cache-from: type=gha,scope=server-image
-          cache-to: type=gha,mode=max,scope=server-image
           build-args: |
             TUIST_HOSTED=0
             TUIST_VERSION=1.24.11.11

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -161,7 +161,8 @@ jobs:
     name: Test
     runs-on: tuist-linux
     timeout-minutes: 30
-    if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
+    # TEMP: draft-only while iterating on test perf; revert before ready.
+    if: github.event.pull_request.draft == true
     services:
       postgres:
         image: postgres:16
@@ -195,6 +196,8 @@ jobs:
     name: Credo
     runs-on: tuist-linux
     timeout-minutes: 15
+    # TEMP: skip while iterating on test perf; revert before ready.
+    if: github.event.pull_request.draft == false
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-server-mix
@@ -298,7 +301,8 @@ jobs:
     # the dind sidecar) OOMs the 2 vCPU / 8 GB default microVM.
     runs-on: tuist-linux-large
     timeout-minutes: 30
-    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    # TEMP: draft-only while iterating on test perf; revert before ready.
+    if: github.event.pull_request.draft == true
     steps:
       - uses: actions/checkout@v4
         with:
@@ -314,6 +318,8 @@ jobs:
           push: false
           load: true
           tags: tuist/tuist
+          cache-from: type=gha,scope=server-image
+          cache-to: type=gha,mode=max,scope=server-image
           build-args: |
             TUIST_HOSTED=0
             TUIST_VERSION=1.24.11.11

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -159,9 +159,7 @@ jobs:
           echo "✅ All dashboard translation templates present"
   test:
     name: Test
-    # TEMP: trying the 4 vCPU shape to see how much the async conversions
-    # parallelize beyond the 2 vCPU default. Decide before ready.
-    runs-on: tuist-linux-large
+    runs-on: tuist-linux
     timeout-minutes: 30
     # TEMP: draft-only while iterating on test perf; revert before ready.
     if: github.event.pull_request.draft == true

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -76,6 +76,14 @@ ENV TUIST_HOSTED=$TUIST_HOSTED
 # during the first resolver fetch. No measurable effect on fast networks.
 ENV HEX_HTTP_TIMEOUT=120
 
+# Cap the BEAM at 2 schedulers for every compile in this stage and the two
+# that branch from it. og-images and builder compile concurrently, so the
+# default (4 schedulers each on the 4-core runner) oversubscribes to 8
+# threads holding ~8 in-flight module copies, which OOM-kills the 16 GB
+# runner mid-build ("lost communication"). 2 each = 4 total still saturates
+# the cores, without the memory spike.
+ENV ELIXIR_ERL_OPTIONS="+S 2"
+
 COPY server/mix.exs server/mix.lock ./
 RUN mkdir config
 

--- a/server/priv/gettext/dashboard.pot
+++ b/server/priv/gettext/dashboard.pot
@@ -58,7 +58,7 @@ msgstr ""
 msgid "Bad request"
 msgstr ""
 
-#: lib/tuist_web/components/app_layout_components.ex:430
+#: lib/tuist_web/components/app_layout_components.ex:437
 #, elixir-autogen, elixir-format
 msgid "Billing"
 msgstr ""
@@ -93,8 +93,8 @@ msgstr ""
 msgid "Cache Runs"
 msgstr ""
 
-#: lib/tuist_web/live/layout_live.ex:96
-#: lib/tuist_web/live/layout_live.ex:176
+#: lib/tuist_web/live/layout_live.ex:106
+#: lib/tuist_web/live/layout_live.ex:191
 #, elixir-autogen, elixir-format
 msgid "Create organization"
 msgstr ""
@@ -104,7 +104,7 @@ msgstr ""
 msgid "Download macOS app"
 msgstr ""
 
-#: lib/tuist_web/components/app_layout_components.ex:531
+#: lib/tuist_web/components/app_layout_components.ex:538
 #, elixir-autogen, elixir-format
 msgid "Emails"
 msgstr ""
@@ -116,12 +116,12 @@ msgstr ""
 msgid "Error"
 msgstr ""
 
-#: lib/tuist_web/components/app_layout_components.ex:546
+#: lib/tuist_web/components/app_layout_components.ex:553
 #, elixir-autogen, elixir-format
 msgid "Errors"
 msgstr ""
 
-#: lib/tuist_web/components/app_layout_components.ex:524
+#: lib/tuist_web/components/app_layout_components.ex:531
 #, elixir-autogen, elixir-format
 msgid "Flags"
 msgstr ""
@@ -137,13 +137,13 @@ msgstr ""
 msgid "Go to dashboard"
 msgstr ""
 
-#: lib/tuist_web/components/app_layout_components.ex:554
+#: lib/tuist_web/components/app_layout_components.ex:561
 #: lib/tuist_web/live/ops_account_kura_deployment_live.html.heex:52
 #, elixir-autogen, elixir-format
 msgid "Grafana"
 msgstr ""
 
-#: lib/tuist_web/components/app_layout_components.ex:470
+#: lib/tuist_web/components/app_layout_components.ex:477
 #, elixir-autogen, elixir-format
 msgid "Integrations"
 msgstr ""
@@ -159,8 +159,8 @@ msgstr ""
 msgid "Invalid installation request. Please try again."
 msgstr ""
 
-#: lib/tuist_web/components/app_layout_components.ex:408
-#: lib/tuist_web/components/app_layout_components.ex:518
+#: lib/tuist_web/components/app_layout_components.ex:409
+#: lib/tuist_web/components/app_layout_components.ex:525
 #, elixir-autogen, elixir-format
 msgid "Jobs"
 msgstr ""
@@ -170,7 +170,7 @@ msgstr ""
 msgid "Learn more"
 msgstr ""
 
-#: lib/tuist_web/components/app_layout_components.ex:512
+#: lib/tuist_web/components/app_layout_components.ex:519
 #, elixir-autogen, elixir-format
 msgid "LiveDashboard"
 msgstr ""
@@ -180,7 +180,7 @@ msgstr ""
 msgid "Log out"
 msgstr ""
 
-#: lib/tuist_web/components/app_layout_components.ex:416
+#: lib/tuist_web/components/app_layout_components.ex:423
 #, elixir-autogen, elixir-format
 msgid "Members"
 msgstr ""
@@ -266,7 +266,7 @@ msgstr ""
 msgid "Profiles"
 msgstr ""
 
-#: lib/tuist_web/components/app_layout_components.ex:382
+#: lib/tuist_web/components/app_layout_components.ex:383
 #, elixir-autogen, elixir-format
 msgid "Projects"
 msgstr ""
@@ -276,7 +276,7 @@ msgstr ""
 msgid "Server error"
 msgstr ""
 
-#: lib/tuist_web/components/app_layout_components.ex:444
+#: lib/tuist_web/components/app_layout_components.ex:451
 #, elixir-autogen, elixir-format
 msgid "Settings"
 msgstr ""
@@ -301,7 +301,7 @@ msgstr ""
 msgid "Sorry, you made too many requests. Please try again later."
 msgstr ""
 
-#: lib/tuist_web/components/app_layout_components.ex:538
+#: lib/tuist_web/components/app_layout_components.ex:545
 #, elixir-autogen, elixir-format
 msgid "Storage"
 msgstr ""
@@ -334,7 +334,7 @@ msgstr ""
 msgid "The account %{account_handle} was not found."
 msgstr ""
 
-#: lib/tuist_web/live/layout_live.ex:153
+#: lib/tuist_web/live/layout_live.ex:168
 #, elixir-autogen, elixir-format
 msgid "The account you are looking for doesn't exist or has been moved."
 msgstr ""
@@ -367,17 +367,12 @@ msgstr ""
 msgid "The project full handle %{project_slug} is invalid. It should follow the convention 'account_handle/project_handle'."
 msgstr ""
 
-#: lib/tuist_web/live/layout_live.ex:61
-#, elixir-autogen, elixir-format
-msgid "The project you are looking for doesn't exist or has been moved."
-msgstr ""
-
 #: lib/tuist_web/plugs/loader_plug.ex:95
 #, elixir-autogen, elixir-format
 msgid "The run with ID %{run_id} was not found."
 msgstr ""
 
-#: lib/tuist_web/live/layout_live.ex:260
+#: lib/tuist_web/live/layout_live.ex:270
 #, elixir-autogen, elixir-format
 msgid "The run you are looking for doesn't exist or has been moved."
 msgstr ""
@@ -392,8 +387,8 @@ msgstr ""
 msgid "Too many requests."
 msgstr ""
 
-#: lib/tuist_web/components/app_layout_components.ex:579
-#: lib/tuist_web/components/app_layout_components.ex:616
+#: lib/tuist_web/components/app_layout_components.ex:586
+#: lib/tuist_web/components/app_layout_components.ex:623
 #, elixir-autogen, elixir-format
 msgid "Tuist Icon"
 msgstr ""
@@ -501,12 +496,12 @@ msgstr ""
 msgid "Gradle Cache"
 msgstr ""
 
-#: lib/tuist_web/live/layout_live.ex:119
+#: lib/tuist_web/live/layout_live.ex:129
 #, elixir-autogen, elixir-format
 msgid "Create project"
 msgstr ""
 
-#: lib/tuist_web/components/app_layout_components.ex:493
+#: lib/tuist_web/components/app_layout_components.ex:500
 #: lib/tuist_web/live/ops_cache_live.html.heex:3
 #, elixir-autogen, elixir-format
 msgid "Cache"
@@ -639,7 +634,7 @@ msgstr ""
 msgid "Dashboard"
 msgstr ""
 
-#: lib/tuist_web/components/app_layout_components.ex:500
+#: lib/tuist_web/components/app_layout_components.ex:507
 #: lib/tuist_web/live/ops_accounts_live.ex:18
 #: lib/tuist_web/live/ops_accounts_live.html.heex:3
 #: lib/tuist_web/live/ops_accounts_live.html.heex:5
@@ -647,7 +642,7 @@ msgstr ""
 msgid "Accounts"
 msgstr ""
 
-#: lib/tuist_web/components/app_layout_components.ex:479
+#: lib/tuist_web/components/app_layout_components.ex:486
 #, elixir-autogen, elixir-format
 msgid "Authentication"
 msgstr ""
@@ -1339,27 +1334,27 @@ msgstr ""
 msgid "Tuist could not resolve %{url}. Double-check the GitHub Enterprise Server URL is correct and publicly resolvable."
 msgstr ""
 
-#: lib/tuist_web/components/app_layout_components.ex:464
+#: lib/tuist_web/components/app_layout_components.ex:471
 #, elixir-autogen, elixir-format
 msgid "General"
 msgstr ""
 
-#: lib/tuist_web/components/app_layout_components.ex:393
+#: lib/tuist_web/components/app_layout_components.ex:394
 #, elixir-autogen, elixir-format
 msgid "Runners"
 msgstr ""
 
-#: lib/tuist_web/components/app_layout_components.ex:423
+#: lib/tuist_web/components/app_layout_components.ex:430
 #, elixir-autogen, elixir-format
 msgid "Webhooks"
 msgstr ""
 
-#: lib/tuist_web/components/app_layout_components.ex:402
+#: lib/tuist_web/components/app_layout_components.ex:403
 #, elixir-autogen, elixir-format
 msgid "Workflows"
 msgstr ""
 
-#: lib/tuist_web/live/ops_database_live.html.heex:476
+#: lib/tuist_web/live/ops_database_live.html.heex:485
 #, elixir-autogen, elixir-format
 msgid "%{n} row(s) · %{duration}%{trunc}"
 msgstr ""
@@ -1427,27 +1422,27 @@ msgstr ""
 msgid "Connections"
 msgstr ""
 
-#: lib/tuist_web/live/ops_database_live.html.heex:459
+#: lib/tuist_web/live/ops_database_live.html.heex:468
 #, elixir-autogen, elixir-format
 msgid "Copy as CSV"
 msgstr ""
 
-#: lib/tuist_web/live/ops_database_live.html.heex:451
+#: lib/tuist_web/live/ops_database_live.html.heex:460
 #, elixir-autogen, elixir-format
 msgid "Copy as JSON"
 msgstr ""
 
-#: lib/tuist_web/live/ops_database_live.html.heex:443
+#: lib/tuist_web/live/ops_database_live.html.heex:452
 #, elixir-autogen, elixir-format
 msgid "Copy as Markdown"
 msgstr ""
 
-#: lib/tuist_web/live/ops_database_live.ex:203
+#: lib/tuist_web/live/ops_database_live.ex:202
 #, elixir-autogen, elixir-format
 msgid "Could not read the cluster's Backup resources from the Kubernetes API — check the server ServiceAccount's RBAC on postgresql.cnpg.io."
 msgstr ""
 
-#: lib/tuist_web/components/app_layout_components.ex:506
+#: lib/tuist_web/components/app_layout_components.ex:513
 #: lib/tuist_web/live/ops_database_live.html.heex:3
 #: lib/tuist_web/live/ops_database_live.html.heex:58
 #, elixir-autogen, elixir-format
@@ -1464,7 +1459,7 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: lib/tuist_web/live/ops_database_live.html.heex:467
+#: lib/tuist_web/live/ops_database_live.html.heex:476
 #, elixir-autogen, elixir-format
 msgid "Download CSV"
 msgstr ""
@@ -1479,7 +1474,7 @@ msgstr ""
 msgid "Duration"
 msgstr ""
 
-#: lib/tuist_web/live/ops_database_live.html.heex:509
+#: lib/tuist_web/live/ops_database_live.html.heex:518
 #, elixir-autogen, elixir-format
 msgid "Empty result"
 msgstr ""
@@ -1489,7 +1484,7 @@ msgstr ""
 msgid "Every index has been used at least once."
 msgstr ""
 
-#: lib/tuist_web/live/ops_database_live.html.heex:439
+#: lib/tuist_web/live/ops_database_live.html.heex:448
 #, elixir-autogen, elixir-format
 msgid "Export"
 msgstr ""
@@ -1565,7 +1560,7 @@ msgstr ""
 msgid "Mode"
 msgstr ""
 
-#: lib/tuist_web/live/ops_database_live.ex:196
+#: lib/tuist_web/live/ops_database_live.ex:195
 #, elixir-autogen, elixir-format
 msgid "No CNPG cluster wired to this server (dev, or Postgres still on the external provider). Base backups appear once the server runs against the in-cluster cluster."
 msgstr ""
@@ -1620,7 +1615,7 @@ msgstr ""
 msgid "No unused indexes"
 msgstr ""
 
-#: lib/tuist_web/live/ops_database_live.ex:178
+#: lib/tuist_web/live/ops_database_live.ex:177
 #, elixir-autogen, elixir-format
 msgid "Not configured"
 msgstr ""
@@ -1783,7 +1778,7 @@ msgstr ""
 msgid "Tables"
 msgstr ""
 
-#: lib/tuist_web/live/ops_database_live.ex:208
+#: lib/tuist_web/live/ops_database_live.ex:207
 #, elixir-autogen, elixir-format
 msgid "The cluster has not produced any base backups yet."
 msgstr ""
@@ -1793,7 +1788,7 @@ msgstr ""
 msgid "The database is empty."
 msgstr ""
 
-#: lib/tuist_web/live/ops_database_live.html.heex:510
+#: lib/tuist_web/live/ops_database_live.html.heex:519
 #, elixir-autogen, elixir-format
 msgid "The query returned no rows."
 msgstr ""
@@ -1828,7 +1823,7 @@ msgstr ""
 msgid "Write lag (bytes)"
 msgstr ""
 
-#: lib/tuist_web/components/app_layout_components.ex:437
+#: lib/tuist_web/components/app_layout_components.ex:444
 #, elixir-autogen, elixir-format
 msgid "Usage"
 msgstr ""

--- a/server/priv/gettext/dashboard_account.pot
+++ b/server/priv/gettext/dashboard_account.pot
@@ -72,13 +72,13 @@ msgstr ""
 msgid "All members"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:779
+#: lib/tuist_web/live/account_settings_live.ex:770
 #, elixir-autogen, elixir-format
 msgid "All regions"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.html.heex:118
-#: lib/tuist_web/live/account_settings_live.html.heex:275
+#: lib/tuist_web/live/account_settings_live.html.heex:117
+#: lib/tuist_web/live/account_settings_live.html.heex:273
 #, elixir-autogen, elixir-format
 msgid "Are you sure you want to delete this?"
 msgstr ""
@@ -99,13 +99,13 @@ msgstr ""
 msgid "Billing email"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:518
-#: lib/tuist_web/live/account_settings_live.ex:851
-#: lib/tuist_web/live/account_settings_live.ex:938
-#: lib/tuist_web/live/account_settings_live.html.heex:82
-#: lib/tuist_web/live/account_settings_live.html.heex:156
-#: lib/tuist_web/live/account_settings_live.html.heex:239
-#: lib/tuist_web/live/account_settings_live.html.heex:311
+#: lib/tuist_web/live/account_settings_live.ex:515
+#: lib/tuist_web/live/account_settings_live.ex:842
+#: lib/tuist_web/live/account_settings_live.ex:929
+#: lib/tuist_web/live/account_settings_live.html.heex:81
+#: lib/tuist_web/live/account_settings_live.html.heex:155
+#: lib/tuist_web/live/account_settings_live.html.heex:237
+#: lib/tuist_web/live/account_settings_live.html.heex:309
 #: lib/tuist_web/live/authentication_settings_live.html.heex:518
 #: lib/tuist_web/live/create_organization_live.ex:83
 #: lib/tuist_web/live/members_live.ex:156
@@ -127,7 +127,7 @@ msgstr ""
 msgid "Change your subscription to fit your needs."
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:763
+#: lib/tuist_web/live/account_settings_live.ex:754
 #, elixir-autogen, elixir-format
 msgid "Choose where your artifacts, like module cache binaries, are stored for legal compliance."
 msgstr ""
@@ -215,17 +215,17 @@ msgstr ""
 msgid "Decline"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:912
-#: lib/tuist_web/live/account_settings_live.ex:946
-#: lib/tuist_web/live/account_settings_live.ex:958
-#: lib/tuist_web/live/account_settings_live.html.heex:164
-#: lib/tuist_web/live/account_settings_live.html.heex:319
+#: lib/tuist_web/live/account_settings_live.ex:903
+#: lib/tuist_web/live/account_settings_live.ex:937
+#: lib/tuist_web/live/account_settings_live.ex:949
+#: lib/tuist_web/live/account_settings_live.html.heex:163
+#: lib/tuist_web/live/account_settings_live.html.heex:317
 #, elixir-autogen, elixir-format
 msgid "Delete"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.html.heex:260
-#: lib/tuist_web/live/account_settings_live.html.heex:281
+#: lib/tuist_web/live/account_settings_live.html.heex:258
+#: lib/tuist_web/live/account_settings_live.html.heex:279
 #, elixir-autogen, elixir-format
 msgid "Delete account"
 msgstr ""
@@ -300,18 +300,18 @@ msgstr ""
 msgid "The client secret from your OAuth2 application."
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.html.heex:103
-#: lib/tuist_web/live/account_settings_live.html.heex:124
+#: lib/tuist_web/live/account_settings_live.html.heex:102
+#: lib/tuist_web/live/account_settings_live.html.heex:123
 #, elixir-autogen, elixir-format
 msgid "Delete organization"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.html.heex:137
+#: lib/tuist_web/live/account_settings_live.html.heex:136
 #, elixir-autogen, elixir-format
 msgid "Deleting the organization will delete all of its projects"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.html.heex:293
+#: lib/tuist_web/live/account_settings_live.html.heex:291
 #, elixir-autogen, elixir-format
 msgid "Deleting your account will also delete all the projects that belong to it"
 msgstr ""
@@ -342,12 +342,12 @@ msgstr ""
 msgid "Email address"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.html.heex:144
+#: lib/tuist_web/live/account_settings_live.html.heex:143
 #, elixir-autogen, elixir-format
 msgid "Enter this organization's name to confirm"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.html.heex:300
+#: lib/tuist_web/live/account_settings_live.html.heex:298
 #, elixir-autogen, elixir-format
 msgid "Enter your username to confirm"
 msgstr ""
@@ -359,7 +359,7 @@ msgstr ""
 msgid "Enterprise"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:780
+#: lib/tuist_web/live/account_settings_live.ex:771
 #, elixir-autogen, elixir-format
 msgid "Europe"
 msgstr ""
@@ -541,8 +541,8 @@ msgstr ""
 msgid "Open source"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.html.heex:73
-#: lib/tuist_web/live/account_settings_live.html.heex:147
+#: lib/tuist_web/live/account_settings_live.html.heex:72
+#: lib/tuist_web/live/account_settings_live.html.heex:146
 #, elixir-autogen, elixir-format
 msgid "Organization name"
 msgstr ""
@@ -574,10 +574,10 @@ msgstr ""
 msgid "Payments for your subscription are made using the default card."
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:659
-#: lib/tuist_web/live/account_settings_live.ex:663
-#: lib/tuist_web/live/account_settings_live.ex:671
-#: lib/tuist_web/live/account_settings_live.ex:674
+#: lib/tuist_web/live/account_settings_live.ex:651
+#: lib/tuist_web/live/account_settings_live.ex:654
+#: lib/tuist_web/live/account_settings_live.ex:662
+#: lib/tuist_web/live/account_settings_live.ex:665
 #: lib/tuist_web/live/members_live.ex:278
 #, elixir-autogen, elixir-format
 msgid "Pending"
@@ -615,10 +615,10 @@ msgstr ""
 msgid "Pro"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:473
-#: lib/tuist_web/live/account_settings_live.ex:486
-#: lib/tuist_web/live/account_settings_live.ex:558
-#: lib/tuist_web/live/account_settings_live.ex:776
+#: lib/tuist_web/live/account_settings_live.ex:470
+#: lib/tuist_web/live/account_settings_live.ex:483
+#: lib/tuist_web/live/account_settings_live.ex:555
+#: lib/tuist_web/live/account_settings_live.ex:767
 #, elixir-autogen, elixir-format
 msgid "Region"
 msgstr ""
@@ -644,30 +644,30 @@ msgstr ""
 msgid "Remove member"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.html.heex:90
-#: lib/tuist_web/live/account_settings_live.html.heex:247
+#: lib/tuist_web/live/account_settings_live.html.heex:89
+#: lib/tuist_web/live/account_settings_live.html.heex:245
 #, elixir-autogen, elixir-format
 msgid "Rename"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.html.heex:32
-#: lib/tuist_web/live/account_settings_live.html.heex:56
+#: lib/tuist_web/live/account_settings_live.html.heex:31
+#: lib/tuist_web/live/account_settings_live.html.heex:55
 #, elixir-autogen, elixir-format
 msgid "Rename organization"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.html.heex:50
+#: lib/tuist_web/live/account_settings_live.html.heex:49
 #, elixir-autogen, elixir-format
 msgid "Rename your organization?"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.html.heex:68
-#: lib/tuist_web/live/account_settings_live.html.heex:226
+#: lib/tuist_web/live/account_settings_live.html.heex:67
+#: lib/tuist_web/live/account_settings_live.html.heex:224
 #, elixir-autogen, elixir-format
 msgid "Renaming can have unexpected consequences"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.html.heex:35
+#: lib/tuist_web/live/account_settings_live.html.heex:34
 #, elixir-autogen, elixir-format
 msgid "Renaming your organization can have unintended side effects."
 msgstr ""
@@ -703,7 +703,7 @@ msgstr ""
 msgid "Search members..."
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:771
+#: lib/tuist_web/live/account_settings_live.ex:762
 #, elixir-autogen, elixir-format
 msgid "Select region"
 msgstr ""
@@ -736,7 +736,7 @@ msgstr ""
 msgid "Standard support: Via Slack and email"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:561
+#: lib/tuist_web/live/account_settings_live.ex:558
 #: lib/tuist_web/live/members_live.ex:276
 #: lib/tuist_web/live/webhook_event_live.html.heex:28
 #: lib/tuist_web/live/webhook_live.ex:265
@@ -745,7 +745,7 @@ msgstr ""
 msgid "Status"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:760
+#: lib/tuist_web/live/account_settings_live.ex:751
 #, elixir-autogen, elixir-format
 msgid "Storage region"
 msgstr ""
@@ -760,8 +760,8 @@ msgstr ""
 msgid "Tailored agreements to meet your specific needs"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.html.heex:106
-#: lib/tuist_web/live/account_settings_live.html.heex:263
+#: lib/tuist_web/live/account_settings_live.html.heex:105
+#: lib/tuist_web/live/account_settings_live.html.heex:261
 #, elixir-autogen, elixir-format
 msgid "This action cannot be undone."
 msgstr ""
@@ -789,7 +789,7 @@ msgstr ""
 msgid "Tuist Logo"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:781
+#: lib/tuist_web/live/account_settings_live.ex:772
 #, elixir-autogen, elixir-format
 msgid "United States"
 msgstr ""
@@ -814,18 +814,18 @@ msgstr ""
 msgid "Update payment method"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.html.heex:191
-#: lib/tuist_web/live/account_settings_live.html.heex:215
+#: lib/tuist_web/live/account_settings_live.html.heex:189
+#: lib/tuist_web/live/account_settings_live.html.heex:213
 #, elixir-autogen, elixir-format
 msgid "Update username"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.html.heex:209
+#: lib/tuist_web/live/account_settings_live.html.heex:207
 #, elixir-autogen, elixir-format
 msgid "Update your username?"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.html.heex:194
+#: lib/tuist_web/live/account_settings_live.html.heex:192
 #, elixir-autogen, elixir-format
 msgid "Updating your username can have unintended consequences."
 msgstr ""
@@ -892,8 +892,8 @@ msgstr ""
 msgid "User"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.html.heex:231
-#: lib/tuist_web/live/account_settings_live.html.heex:303
+#: lib/tuist_web/live/account_settings_live.html.heex:229
+#: lib/tuist_web/live/account_settings_live.html.heex:301
 #, elixir-autogen, elixir-format
 msgid "Username"
 msgstr ""
@@ -979,61 +979,61 @@ msgstr ""
 msgid "xxxx xxxx xxxx %{card_number}"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:859
+#: lib/tuist_web/live/account_settings_live.ex:850
 #, elixir-autogen, elixir-format
 msgid "Add"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:821
+#: lib/tuist_web/live/account_settings_live.ex:812
 #, elixir-autogen, elixir-format
 msgid "Add cache endpoint"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:828
+#: lib/tuist_web/live/account_settings_live.ex:819
 #: lib/tuist_web/live/webhooks_live.html.heex:35
 #, elixir-autogen, elixir-format
 msgid "Add endpoint"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:841
+#: lib/tuist_web/live/account_settings_live.ex:832
 #: lib/tuist_web/live/webhook_endpoint_form.ex:75
 #: lib/tuist_web/live/webhook_live.html.heex:71
 #, elixir-autogen, elixir-format
 msgid "Endpoint URL"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:898
+#: lib/tuist_web/live/account_settings_live.ex:889
 #: lib/tuist_web/live/webhooks_live.html.heex:137
 #, elixir-autogen, elixir-format
 msgid "URL"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:905
+#: lib/tuist_web/live/account_settings_live.ex:896
 #, elixir-autogen, elixir-format
 msgid "Delete last cache endpoint?"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:925
+#: lib/tuist_web/live/account_settings_live.ex:916
 #, elixir-autogen, elixir-format
 msgid "Removing the last custom cache endpoint will switch your organization back to Tuist-hosted caching. This affects all builds across your organization."
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:803
+#: lib/tuist_web/live/account_settings_live.ex:794
 #, elixir-autogen, elixir-format
 msgid "Cache endpoints"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:807
+#: lib/tuist_web/live/account_settings_live.ex:798
 #, elixir-autogen, elixir-format
 msgid "Configure custom cache endpoints for self-hosted cache setups. When enabled, Tuist will read from and write to these endpoints instead of the default Tuist-hosted cache."
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:875
+#: lib/tuist_web/live/account_settings_live.ex:866
 #, elixir-autogen, elixir-format
 msgid "Custom cache endpoints are disabled. Tuist will use the default Tuist-hosted cache."
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:887
+#: lib/tuist_web/live/account_settings_live.ex:878
 #, elixir-autogen, elixir-format
 msgid "No custom cache endpoints configured. Tuist will use the default Tuist-hosted cache until endpoints are added."
 msgstr ""
@@ -1177,23 +1177,23 @@ msgstr ""
 msgid "What's the name of your company or team? You can change this later in the settings"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:715
+#: lib/tuist_web/live/account_settings_live.ex:706
 #, elixir-autogen, elixir-format
 msgid "Browser default"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:725
+#: lib/tuist_web/live/account_settings_live.ex:716
 #, elixir-autogen, elixir-format
 msgid "Choose your preferred dashboard language."
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:722
+#: lib/tuist_web/live/account_settings_live.ex:713
 #, elixir-autogen, elixir-format
 msgid "Dashboard language"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:730
-#: lib/tuist_web/live/account_settings_live.ex:735
+#: lib/tuist_web/live/account_settings_live.ex:721
+#: lib/tuist_web/live/account_settings_live.ex:726
 #, elixir-autogen, elixir-format
 msgid "Language"
 msgstr ""
@@ -1397,56 +1397,56 @@ msgstr ""
 msgid "Revoke token"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:689
+#: lib/tuist_web/live/account_settings_live.ex:680
 #, elixir-autogen, elixir-format
 msgid "Active"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:536
-#: lib/tuist_web/live/account_settings_live.ex:542
-#: lib/tuist_web/live/account_settings_live.ex:604
+#: lib/tuist_web/live/account_settings_live.ex:533
+#: lib/tuist_web/live/account_settings_live.ex:539
+#: lib/tuist_web/live/account_settings_live.ex:601
 #, elixir-autogen, elixir-format
 msgid "Deploy"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:450
-#: lib/tuist_web/live/account_settings_live.ex:457
+#: lib/tuist_web/live/account_settings_live.ex:447
+#: lib/tuist_web/live/account_settings_live.ex:454
 #, elixir-autogen, elixir-format
 msgid "Deploy Kura server"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:441
+#: lib/tuist_web/live/account_settings_live.ex:438
 #, elixir-autogen, elixir-format
 msgid "Deploy regional Kura cache servers for this account. Each region can have at most one server."
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:678
-#: lib/tuist_web/live/account_settings_live.ex:688
+#: lib/tuist_web/live/account_settings_live.ex:669
+#: lib/tuist_web/live/account_settings_live.ex:679
 #, elixir-autogen, elixir-format
 msgid "Deploying"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:387
+#: lib/tuist_web/live/account_settings_live.ex:385
 #, elixir-autogen, elixir-format
 msgid "Deploying Kura in %{region}..."
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:588
+#: lib/tuist_web/live/account_settings_live.ex:585
 #, elixir-autogen, elixir-format
 msgid "Destroy"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:594
+#: lib/tuist_web/live/account_settings_live.ex:591
 #, elixir-autogen, elixir-format
 msgid "Destroy the Kura server in %{region}? This removes the account's Kura cache endpoint for that region."
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:692
+#: lib/tuist_web/live/account_settings_live.ex:683
 #, elixir-autogen, elixir-format
 msgid "Destroyed"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:691
+#: lib/tuist_web/live/account_settings_live.ex:682
 #, elixir-autogen, elixir-format
 msgid "Destroying"
 msgstr ""
@@ -1456,12 +1456,12 @@ msgstr ""
 msgid "Destroying Kura server..."
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:568
+#: lib/tuist_web/live/account_settings_live.ex:565
 #, elixir-autogen, elixir-format
 msgid "Domain"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:690
+#: lib/tuist_web/live/account_settings_live.ex:681
 #: lib/tuist_web/live/webhook_live.ex:233
 #: lib/tuist_web/live/webhook_live.ex:270
 #: lib/tuist_web/live/webhook_live.html.heex:143
@@ -1470,13 +1470,13 @@ msgstr ""
 msgid "Failed"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:397
-#: lib/tuist_web/live/account_settings_live.ex:406
+#: lib/tuist_web/live/account_settings_live.ex:395
+#: lib/tuist_web/live/account_settings_live.ex:404
 #, elixir-autogen, elixir-format
 msgid "Failed to deploy Kura: %{reason}"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:438
+#: lib/tuist_web/live/account_settings_live.ex:435
 #, elixir-autogen, elixir-format
 msgid "Kura cache servers"
 msgstr ""
@@ -1486,23 +1486,23 @@ msgstr ""
 msgid "Kura server not found."
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:505
+#: lib/tuist_web/live/account_settings_live.ex:502
 #, elixir-autogen, elixir-format
 msgid "New servers start on Kura"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:571
+#: lib/tuist_web/live/account_settings_live.ex:568
 #, elixir-autogen, elixir-format
 msgid "Version"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:507
+#: lib/tuist_web/live/account_settings_live.ex:504
 #, elixir-autogen, elixir-format
 msgid "(current deploy)."
 msgstr ""
 
 #: lib/tuist_web/live/account_settings_live.ex:251
-#: lib/tuist_web/live/account_settings_live.ex:500
+#: lib/tuist_web/live/account_settings_live.ex:497
 #, elixir-autogen, elixir-format
 msgid "No Kura runtime image is configured right now. Try again after the next server deploy."
 msgstr ""
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Select a Kura region before deploying."
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:648
+#: lib/tuist_web/live/account_settings_live.ex:645
 #, elixir-autogen, elixir-format
 msgid "Not deployed"
 msgstr ""
@@ -1820,7 +1820,7 @@ msgstr ""
 msgid "Copy payload"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:578
+#: lib/tuist_web/live/account_settings_live.ex:575
 #, elixir-autogen, elixir-format
 msgid "Retry"
 msgstr ""

--- a/server/priv/gettext/dashboard_previews.pot
+++ b/server/priv/gettext/dashboard_previews.pot
@@ -11,7 +11,7 @@
 msgid ""
 msgstr ""
 
-#: lib/tuist_web/live/preview_live.html.heex:67
+#: lib/tuist_web/live/preview_live.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "%{app_name} icon"
 msgstr ""
@@ -21,7 +21,7 @@ msgstr ""
 msgid "%{display_name} · Tuist"
 msgstr ""
 
-#: lib/tuist_web/live/preview_live.html.heex:152
+#: lib/tuist_web/live/preview_live.html.heex:153
 #: lib/tuist_web/live/previews_live.ex:174
 #: lib/tuist_web/live/previews_live.html.heex:84
 #, elixir-autogen, elixir-format
@@ -33,28 +33,28 @@ msgstr ""
 msgid "Built at"
 msgstr ""
 
-#: lib/tuist_web/live/preview_live.html.heex:133
+#: lib/tuist_web/live/preview_live.html.heex:134
 #, elixir-autogen, elixir-format
 msgid "Bundle identifier"
 msgstr ""
 
-#: lib/tuist_web/live/preview_live.html.heex:159
+#: lib/tuist_web/live/preview_live.html.heex:160
 #: lib/tuist_web/live/previews_live.html.heex:87
 #, elixir-autogen, elixir-format
 msgid "Commit SHA"
 msgstr ""
 
-#: lib/tuist_web/live/preview_live.html.heex:123
+#: lib/tuist_web/live/preview_live.html.heex:124
 #, elixir-autogen, elixir-format
 msgid "Created by"
 msgstr ""
 
-#: lib/tuist_web/live/preview_live.html.heex:41
+#: lib/tuist_web/live/preview_live.html.heex:42
 #, elixir-autogen, elixir-format
 msgid "Delete preview"
 msgstr ""
 
-#: lib/tuist_web/live/preview_live.html.heex:109
+#: lib/tuist_web/live/preview_live.html.heex:110
 #, elixir-autogen, elixir-format
 msgid "Details"
 msgstr ""
@@ -64,13 +64,13 @@ msgstr ""
 msgid "Don't have the Tuist app installed?"
 msgstr ""
 
-#: lib/tuist_web/live/preview_live.html.heex:23
-#: lib/tuist_web/live/preview_live.html.heex:87
+#: lib/tuist_web/live/preview_live.html.heex:24
+#: lib/tuist_web/live/preview_live.html.heex:88
 #, elixir-autogen, elixir-format
 msgid "Download"
 msgstr ""
 
-#: lib/tuist_web/live/preview_live.html.heex:179
+#: lib/tuist_web/live/preview_live.html.heex:180
 #, elixir-autogen, elixir-format
 msgid "Install App"
 msgstr ""
@@ -85,13 +85,13 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lib/tuist_web/live/preview_live.html.heex:155
+#: lib/tuist_web/live/preview_live.html.heex:156
 #: lib/tuist_web/live/previews_live.ex:182
 #, elixir-autogen, elixir-format
 msgid "None"
 msgstr ""
 
-#: lib/tuist_web/live/preview_live.html.heex:276
+#: lib/tuist_web/live/preview_live.html.heex:277
 #, elixir-autogen, elixir-format
 msgid "Or run using CLI"
 msgstr ""
@@ -101,7 +101,7 @@ msgstr ""
 msgid "Platforms"
 msgstr ""
 
-#: lib/tuist_web/live/preview_live.html.heex:29
+#: lib/tuist_web/live/preview_live.html.heex:30
 #: lib/tuist_web/live/previews_live.ex:25
 #: lib/tuist_web/live/previews_live.html.heex:19
 #: lib/tuist_web/live/previews_live.html.heex:33
@@ -109,13 +109,13 @@ msgstr ""
 msgid "Previews"
 msgstr ""
 
-#: lib/tuist_web/live/preview_live.html.heex:203
-#: lib/tuist_web/live/preview_live.html.heex:249
+#: lib/tuist_web/live/preview_live.html.heex:204
+#: lib/tuist_web/live/preview_live.html.heex:250
 #, elixir-autogen, elixir-format
 msgid "QR code"
 msgstr ""
 
-#: lib/tuist_web/live/preview_live.html.heex:141
+#: lib/tuist_web/live/preview_live.html.heex:142
 #, elixir-autogen, elixir-format
 msgid "Ran at"
 msgstr ""
@@ -125,7 +125,7 @@ msgstr ""
 msgid "Ran by"
 msgstr ""
 
-#: lib/tuist_web/live/preview_live.html.heex:98
+#: lib/tuist_web/live/preview_live.html.heex:99
 #, elixir-autogen, elixir-format
 msgid "Run"
 msgstr ""
@@ -135,13 +135,13 @@ msgstr ""
 msgid "Run the following command to share app preview."
 msgstr ""
 
-#: lib/tuist_web/live/preview_live.html.heex:190
-#: lib/tuist_web/live/preview_live.html.heex:236
+#: lib/tuist_web/live/preview_live.html.heex:191
+#: lib/tuist_web/live/preview_live.html.heex:237
 #, elixir-autogen, elixir-format
 msgid "Scan QR code"
 msgstr ""
 
-#: lib/tuist_web/live/preview_live.html.heex:239
+#: lib/tuist_web/live/preview_live.html.heex:240
 #, elixir-autogen, elixir-format
 msgid "Scan this QR code on your iOS device to install this version of the app"
 msgstr ""
@@ -151,17 +151,17 @@ msgstr ""
 msgid "Share app previews in one click"
 msgstr ""
 
-#: lib/tuist_web/live/preview_live.html.heex:115
+#: lib/tuist_web/live/preview_live.html.heex:116
 #, elixir-autogen, elixir-format
 msgid "Supported platforms"
 msgstr ""
 
-#: lib/tuist_web/live/preview_live.html.heex:269
+#: lib/tuist_web/live/preview_live.html.heex:270
 #, elixir-autogen, elixir-format
 msgid "This preview is only supported on simulators and can't be installed on a physical device"
 msgstr ""
 
-#: lib/tuist_web/live/preview_live.html.heex:263
+#: lib/tuist_web/live/preview_live.html.heex:264
 #, elixir-autogen, elixir-format
 msgid "This preview isn't available for device installation"
 msgstr ""
@@ -171,7 +171,7 @@ msgstr ""
 msgid "To run the preview directly from the browser, download and install the Tuist macOS app"
 msgstr ""
 
-#: lib/tuist_web/live/preview_live.html.heex:81
+#: lib/tuist_web/live/preview_live.html.heex:82
 #, elixir-autogen, elixir-format
 msgid "V %{version}"
 msgstr ""
@@ -186,29 +186,29 @@ msgstr ""
 msgid "Search..."
 msgstr ""
 
-#: lib/tuist_web/live/preview_live.html.heex:167
+#: lib/tuist_web/live/preview_live.html.heex:168
 #: lib/tuist_web/live/previews_live.ex:166
 #: lib/tuist_web/live/previews_live.html.heex:81
 #, elixir-autogen, elixir-format
 msgid "Track"
 msgstr ""
 
-#: lib/tuist_web/live/preview_live.html.heex:131
+#: lib/tuist_web/live/preview_live.html.heex:132
 #, elixir-autogen, elixir-format
 msgid "Package name"
 msgstr ""
 
-#: lib/tuist_web/live/preview_live.html.heex:193
+#: lib/tuist_web/live/preview_live.html.heex:194
 #, elixir-autogen, elixir-format
 msgid "Scan this QR code on your Android device to download and install this version of the app"
 msgstr ""
 
-#: lib/tuist_web/live/preview_live.html.heex:221
+#: lib/tuist_web/live/preview_live.html.heex:222
 #, elixir-autogen, elixir-format
 msgid "The APK for this preview is no longer available"
 msgstr ""
 
-#: lib/tuist_web/live/preview_live.html.heex:215
+#: lib/tuist_web/live/preview_live.html.heex:216
 #, elixir-autogen, elixir-format
 msgid "This preview isn't available for download"
 msgstr ""

--- a/server/priv/gettext/dashboard_runners.pot
+++ b/server/priv/gettext/dashboard_runners.pot
@@ -51,7 +51,7 @@ msgstr ""
 msgid "Avg. workflow duration"
 msgstr ""
 
-#: lib/tuist/runners/analytics.ex:938
+#: lib/tuist/runners/analytics.ex:946
 #: lib/tuist_web/live/runner_job_live.html.heex:112
 #: lib/tuist_web/live/runner_jobs_live.ex:507
 #: lib/tuist_web/live/runner_jobs_live.html.heex:616
@@ -64,15 +64,15 @@ msgid "Branch"
 msgstr ""
 
 #: lib/tuist_web/live/runner_jobs_live.html.heex:89
-#: lib/tuist_web/live/runner_profiles_live.html.heex:134
-#: lib/tuist_web/live/runner_profiles_live.html.heex:264
+#: lib/tuist_web/live/runner_profiles_live.html.heex:135
+#: lib/tuist_web/live/runner_profiles_live.html.heex:266
 #: lib/tuist_web/live/runner_workflows_live.html.heex:89
 #: lib/tuist_web/live/runners_live.html.heex:89
 #, elixir-autogen, elixir-format
 msgid "Cancel"
 msgstr ""
 
-#: lib/tuist/runners/analytics.ex:909
+#: lib/tuist/runners/analytics.ex:910
 #: lib/tuist_web/live/runner_job_live.ex:87
 #: lib/tuist_web/live/runner_jobs_live.ex:498
 #: lib/tuist_web/live/runner_jobs_live.ex:523
@@ -119,7 +119,7 @@ msgstr ""
 msgid "Custom"
 msgstr ""
 
-#: lib/tuist/runners/analytics.ex:941
+#: lib/tuist/runners/analytics.ex:949
 #: lib/tuist_web/live/runner_jobs_live.ex:584
 #: lib/tuist_web/live/runner_jobs_live.html.heex:551
 #: lib/tuist_web/live/runner_jobs_live.html.heex:639
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Failed jobs"
 msgstr ""
 
-#: lib/tuist/runners/analytics.ex:908
+#: lib/tuist/runners/analytics.ex:909
 #: lib/tuist_web/live/runner_jobs_live.ex:497
 #: lib/tuist_web/live/runner_jobs_live.ex:522
 #: lib/tuist_web/live/runner_workflow_live.ex:177
@@ -164,7 +164,7 @@ msgstr ""
 msgid "Filter"
 msgstr ""
 
-#: lib/tuist/runners/analytics.ex:936
+#: lib/tuist/runners/analytics.ex:944
 #: lib/tuist_web/live/runner_jobs_live.ex:582
 #: lib/tuist_web/live/runner_jobs_live.html.heex:535
 #: lib/tuist_web/live/runner_jobs_live.html.heex:578
@@ -295,7 +295,7 @@ msgstr ""
 msgid "Recent jobs"
 msgstr ""
 
-#: lib/tuist/runners/analytics.ex:937
+#: lib/tuist/runners/analytics.ex:945
 #: lib/tuist_web/live/runner_job_live.html.heex:128
 #: lib/tuist_web/live/runner_jobs_live.html.heex:597
 #: lib/tuist_web/live/runner_workflows_live.html.heex:365
@@ -321,7 +321,7 @@ msgstr ""
 msgid "Running"
 msgstr ""
 
-#: lib/tuist/runners/analytics.ex:910
+#: lib/tuist/runners/analytics.ex:911
 #: lib/tuist_web/live/runner_job_live.ex:90
 #: lib/tuist_web/live/runner_jobs_live.ex:499
 #: lib/tuist_web/live/runner_jobs_live.ex:524
@@ -333,7 +333,7 @@ msgstr ""
 msgid "Skipped"
 msgstr ""
 
-#: lib/tuist/runners/analytics.ex:939
+#: lib/tuist/runners/analytics.ex:947
 #: lib/tuist_web/live/runner_job_live.html.heex:59
 #: lib/tuist_web/live/runner_jobs_live.ex:489
 #: lib/tuist_web/live/runner_jobs_live.html.heex:364
@@ -347,7 +347,7 @@ msgstr ""
 msgid "Status"
 msgstr ""
 
-#: lib/tuist/runners/analytics.ex:907
+#: lib/tuist/runners/analytics.ex:908
 #: lib/tuist_web/live/runner_jobs_live.ex:496
 #: lib/tuist_web/live/runner_jobs_live.ex:521
 #: lib/tuist_web/live/runner_workflow_live.ex:176
@@ -379,7 +379,7 @@ msgstr ""
 
 #: lib/tuist_web/live/runner_job_live.ex:21
 #: lib/tuist_web/live/runner_jobs_live.ex:32
-#: lib/tuist_web/live/runner_profiles_live.ex:21
+#: lib/tuist_web/live/runner_profiles_live.ex:27
 #: lib/tuist_web/live/runner_workflow_live.ex:30
 #: lib/tuist_web/live/runner_workflows_live.ex:25
 #: lib/tuist_web/live/runners_live.ex:27
@@ -406,10 +406,10 @@ msgstr ""
 msgid "Total wall-clock time from the first job start to the last job completion in a workflow run."
 msgstr ""
 
-#: lib/tuist/runners/analytics.ex:905
 #: lib/tuist/runners/analytics.ex:906
-#: lib/tuist/runners/analytics.ex:945
-#: lib/tuist/runners/analytics.ex:946
+#: lib/tuist/runners/analytics.ex:907
+#: lib/tuist/runners/analytics.ex:953
+#: lib/tuist/runners/analytics.ex:954
 #: lib/tuist_web/live/runner_job_live.ex:100
 #: lib/tuist_web/live/runner_job_live.ex:106
 #: lib/tuist_web/live/runner_job_live.ex:110
@@ -442,7 +442,7 @@ msgstr ""
 msgid "View more"
 msgstr ""
 
-#: lib/tuist/runners/analytics.ex:935
+#: lib/tuist/runners/analytics.ex:943
 #: lib/tuist_web/live/runner_jobs_live.ex:474
 #: lib/tuist_web/live/runner_jobs_live.ex:583
 #: lib/tuist_web/live/runner_jobs_live.html.heex:543
@@ -702,12 +702,12 @@ msgstr ""
 msgid "All job runs"
 msgstr ""
 
-#: lib/tuist/runners/analytics.ex:920
+#: lib/tuist/runners/analytics.ex:926
 #: lib/tuist_web/live/runner_job_live.ex:105
 #: lib/tuist_web/live/runner_jobs_live.ex:579
 #: lib/tuist_web/live/runner_jobs_live.ex:623
-#: lib/tuist_web/live/runner_profiles_live.ex:268
-#: lib/tuist_web/live/runner_profiles_live.ex:282
+#: lib/tuist_web/live/runner_profiles_live.ex:280
+#: lib/tuist_web/live/runner_profiles_live.ex:294
 #: lib/tuist_web/live/runner_workflows_live.ex:241
 #: lib/tuist_web/live/runners_live.ex:287
 #, elixir-autogen, elixir-format
@@ -728,7 +728,7 @@ msgstr ""
 msgid "Platform:"
 msgstr ""
 
-#: lib/tuist/runners/analytics.ex:919
+#: lib/tuist/runners/analytics.ex:923
 #: lib/tuist_web/live/runner_job_live.ex:104
 #: lib/tuist_web/live/runner_jobs_live.ex:578
 #: lib/tuist_web/live/runner_jobs_live.ex:622
@@ -744,19 +744,19 @@ msgstr ""
 msgid "The 10,000 entry limit has been reached, data is only included up to %{date}. Try narrowing the date range, repository, or platform."
 msgstr ""
 
-#: lib/tuist/runners/analytics.ex:921
-#: lib/tuist/runners/analytics.ex:925
+#: lib/tuist/runners/analytics.ex:929
+#: lib/tuist/runners/analytics.ex:933
 #, elixir-autogen, elixir-format
 msgid "Other"
 msgstr ""
 
-#: lib/tuist/runners/analytics.ex:940
+#: lib/tuist/runners/analytics.ex:948
 #: lib/tuist_web/live/runner_job_live.html.heex:103
 #: lib/tuist_web/live/runner_jobs_live.html.heex:365
 #: lib/tuist_web/live/runner_jobs_live.html.heex:416
 #: lib/tuist_web/live/runner_jobs_live.html.heex:630
-#: lib/tuist_web/live/runner_profiles_live.html.heex:75
-#: lib/tuist_web/live/runner_profiles_live.html.heex:162
+#: lib/tuist_web/live/runner_profiles_live.html.heex:76
+#: lib/tuist_web/live/runner_profiles_live.html.heex:163
 #, elixir-autogen, elixir-format
 msgid "Platform"
 msgstr ""
@@ -812,114 +812,114 @@ msgstr ""
 msgid "Search by job name..."
 msgstr ""
 
-#: lib/tuist_web/live/runner_profiles_live.html.heex:143
+#: lib/tuist_web/live/runner_profiles_live.html.heex:144
 #, elixir-autogen, elixir-format
 msgid "Create profile"
 msgstr ""
 
-#: lib/tuist_web/live/runner_profiles_live.html.heex:201
+#: lib/tuist_web/live/runner_profiles_live.html.heex:203
 #, elixir-autogen, elixir-format
 msgid "Delete"
 msgstr ""
 
-#: lib/tuist_web/live/runner_profiles_live.html.heex:189
+#: lib/tuist_web/live/runner_profiles_live.html.heex:190
 #, elixir-autogen, elixir-format
 msgid "Edit"
 msgstr ""
 
-#: lib/tuist_web/live/runner_profiles_live.html.heex:159
+#: lib/tuist_web/live/runner_profiles_live.html.heex:160
 #, elixir-autogen, elixir-format
 msgid "Label"
 msgstr ""
 
-#: lib/tuist_web/live/runner_profiles_live.html.heex:51
+#: lib/tuist_web/live/runner_profiles_live.html.heex:52
 #, elixir-autogen, elixir-format
 msgid "Name"
 msgstr ""
 
-#: lib/tuist_web/live/runner_profiles_live.html.heex:20
-#: lib/tuist_web/live/runner_profiles_live.html.heex:29
+#: lib/tuist_web/live/runner_profiles_live.html.heex:21
+#: lib/tuist_web/live/runner_profiles_live.html.heex:30
 #, elixir-autogen, elixir-format
 msgid "New profile"
 msgstr ""
 
-#: lib/tuist_web/live/runner_profiles_live.html.heex:215
+#: lib/tuist_web/live/runner_profiles_live.html.heex:217
 #, elixir-autogen, elixir-format
 msgid "No profiles yet"
 msgstr ""
 
-#: lib/tuist_web/live/runner_profiles_live.ex:198
+#: lib/tuist_web/live/runner_profiles_live.ex:209
 #, elixir-autogen, elixir-format
 msgid "Profile %{name} created."
 msgstr ""
 
-#: lib/tuist_web/live/runner_profiles_live.ex:161
+#: lib/tuist_web/live/runner_profiles_live.ex:163
 #, elixir-autogen, elixir-format
 msgid "Profile %{name} deleted."
 msgstr ""
 
-#: lib/tuist_web/live/runner_profiles_live.ex:201
+#: lib/tuist_web/live/runner_profiles_live.ex:212
 #, elixir-autogen, elixir-format
 msgid "Profile %{name} updated."
 msgstr ""
 
-#: lib/tuist_web/live/runner_profiles_live.ex:188
+#: lib/tuist_web/live/runner_profiles_live.ex:199
 #, elixir-autogen, elixir-format
 msgid "Profile limit reached (%{max})."
 msgstr ""
 
-#: lib/tuist_web/live/runner_profiles_live.ex:28
+#: lib/tuist_web/live/runner_profiles_live.ex:34
 #: lib/tuist_web/live/runner_profiles_live.html.heex:4
 #, elixir-autogen, elixir-format
 msgid "Profiles"
 msgstr ""
 
-#: lib/tuist_web/live/runner_profiles_live.html.heex:172
+#: lib/tuist_web/live/runner_profiles_live.html.heex:173
 #, elixir-autogen, elixir-format
 msgid "RAM"
 msgstr ""
 
-#: lib/tuist_web/live/runner_profiles_live.html.heex:93
+#: lib/tuist_web/live/runner_profiles_live.html.heex:94
 #, elixir-autogen, elixir-format
 msgid "Resources"
 msgstr ""
 
-#: lib/tuist_web/live/runner_profiles_live.html.heex:144
+#: lib/tuist_web/live/runner_profiles_live.html.heex:145
 #, elixir-autogen, elixir-format
 msgid "Save changes"
 msgstr ""
 
-#: lib/tuist_web/live/runner_profiles_live.html.heex:169
+#: lib/tuist_web/live/runner_profiles_live.html.heex:170
 #, elixir-autogen, elixir-format
 msgid "vCPU"
 msgstr ""
 
-#: lib/tuist_web/live/runner_profiles_live.html.heex:217
+#: lib/tuist_web/live/runner_profiles_live.html.heex:219
 #, elixir-autogen, elixir-format
 msgid "Create one to let your workflows reference Tuist runners by name."
 msgstr ""
 
-#: lib/tuist_web/live/runner_profiles_live.html.heex:21
+#: lib/tuist_web/live/runner_profiles_live.html.heex:22
 #, elixir-autogen, elixir-format
 msgid "Edit profile"
 msgstr ""
 
-#: lib/tuist_web/live/runner_profiles_live.html.heex:119
+#: lib/tuist_web/live/runner_profiles_live.html.heex:120
 #, elixir-autogen, elixir-format
 msgid "No resource catalog is configured yet. Contact support."
 msgstr ""
 
-#: lib/tuist_web/live/runner_profiles_live.html.heex:100
+#: lib/tuist_web/live/runner_profiles_live.html.heex:101
 #, elixir-autogen, elixir-format
 msgid "Select resources"
 msgstr ""
 
-#: lib/tuist_web/live/runner_profiles_live.html.heex:175
+#: lib/tuist_web/live/runner_profiles_live.html.heex:176
 #, elixir-autogen, elixir-format
 msgid "Last used"
 msgstr ""
 
-#: lib/tuist_web/live/runner_profiles_live.ex:260
+#: lib/tuist_web/live/runner_profiles_live.ex:272
 #, elixir-autogen, elixir-format
 msgid "Never"
 msgstr ""
@@ -929,38 +929,38 @@ msgstr ""
 msgid "Named bundles of vCPU and RAM. Reference them from your workflows as runs-on: %{prefix}<name>."
 msgstr ""
 
-#: lib/tuist_web/live/runner_profiles_live.html.heex:59
+#: lib/tuist_web/live/runner_profiles_live.html.heex:60
 #, elixir-autogen, elixir-format
 msgid "e.g. \"default\", \"large\", \"ci\""
 msgstr ""
 
-#: lib/tuist_web/live/runner_profiles_live.html.heex:67
+#: lib/tuist_web/live/runner_profiles_live.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "Becomes part of your runs-on label, so it can't be renamed later."
 msgstr ""
 
-#: lib/tuist_web/live/runner_profiles_live.ex:291
+#: lib/tuist_web/live/runner_profiles_live.ex:303
 #, elixir-autogen, elixir-format
 msgid "Select platform"
 msgstr ""
 
-#: lib/tuist_web/live/runner_profiles_live.ex:153
-#, elixir-autogen, elixir-format
-msgid "You can't delete your only profile."
-msgstr ""
-
-#: lib/tuist_web/live/runner_profiles_live.html.heex:231
-#: lib/tuist_web/live/runner_profiles_live.html.heex:271
+#: lib/tuist_web/live/runner_profiles_live.html.heex:233
+#: lib/tuist_web/live/runner_profiles_live.html.heex:273
 #, elixir-autogen, elixir-format
 msgid "Delete profile"
 msgstr ""
 
-#: lib/tuist_web/live/runner_profiles_live.html.heex:252
+#: lib/tuist_web/live/runner_profiles_live.html.heex:254
 #, elixir-autogen, elixir-format
 msgid "Delete profile %{name}? This can't be undone."
 msgstr ""
 
-#: lib/tuist_web/live/runner_profiles_live.html.heex:244
+#: lib/tuist_web/live/runner_profiles_live.html.heex:246
 #, elixir-autogen, elixir-format
 msgid "Workflows using runs-on: %{label} will fail to dispatch until they're updated."
+msgstr ""
+
+#: lib/tuist_web/live/runner_profiles_live.ex:170
+#, elixir-autogen, elixir-format
+msgid "This profile is a default and can't be deleted."
 msgstr ""

--- a/server/priv/gettext/dashboard_usage.pot
+++ b/server/priv/gettext/dashboard_usage.pot
@@ -52,7 +52,7 @@ msgstr ""
 msgid "Last 7 days"
 msgstr ""
 
-#: lib/tuist_web/live/usage_live.html.heex:229
+#: lib/tuist_web/live/usage_live.html.heex:223
 #, elixir-autogen, elixir-format
 msgid "Node"
 msgstr ""
@@ -62,13 +62,13 @@ msgstr ""
 msgid "Project:"
 msgstr ""
 
-#: lib/tuist_web/live/usage_live.html.heex:232
+#: lib/tuist_web/live/usage_live.html.heex:226
 #, elixir-autogen, elixir-format
 msgid "Region"
 msgstr ""
 
-#: lib/tuist_web/live/usage_live.html.heex:149
-#: lib/tuist_web/live/usage_live.html.heex:241
+#: lib/tuist_web/live/usage_live.html.heex:145
+#: lib/tuist_web/live/usage_live.html.heex:235
 #, elixir-autogen, elixir-format
 msgid "Requests"
 msgstr ""
@@ -83,7 +83,7 @@ msgstr ""
 msgid "The page you are looking for doesn't exist or has been moved."
 msgstr ""
 
-#: lib/tuist_web/live/usage_live.html.heex:205
+#: lib/tuist_web/live/usage_live.html.heex:199
 #, elixir-autogen, elixir-format
 msgid "Traffic by node"
 msgstr ""
@@ -95,13 +95,13 @@ msgid "Usage"
 msgstr ""
 
 #: lib/tuist_web/live/usage_live.html.heex:105
-#: lib/tuist_web/live/usage_live.html.heex:235
+#: lib/tuist_web/live/usage_live.html.heex:229
 #, elixir-autogen, elixir-format
 msgid "Egress"
 msgstr ""
 
-#: lib/tuist_web/live/usage_live.html.heex:127
-#: lib/tuist_web/live/usage_live.html.heex:238
+#: lib/tuist_web/live/usage_live.html.heex:125
+#: lib/tuist_web/live/usage_live.html.heex:232
 #, elixir-autogen, elixir-format
 msgid "Ingress"
 msgstr ""
@@ -112,7 +112,7 @@ msgstr ""
 msgid "Unknown"
 msgstr ""
 
-#: lib/tuist_web/live/usage_live.html.heex:130
+#: lib/tuist_web/live/usage_live.html.heex:128
 #, elixir-autogen, elixir-format
 msgid "Bytes received by the cache from clients (cache uploads) in the selected window."
 msgstr ""
@@ -127,12 +127,12 @@ msgstr ""
 msgid "Cache traffic"
 msgstr ""
 
-#: lib/tuist_web/live/usage_live.ex:252
+#: lib/tuist_web/live/usage_live.ex:244
 #, elixir-autogen, elixir-format
 msgid "No cache traffic in this window yet"
 msgstr ""
 
-#: lib/tuist_web/live/usage_live.html.heex:152
+#: lib/tuist_web/live/usage_live.html.heex:148
 #, elixir-autogen, elixir-format
 msgid "Number of cache requests served in the selected window."
 msgstr ""

--- a/server/test/tuist/accounts/account_test.exs
+++ b/server/test/tuist/accounts/account_test.exs
@@ -1,5 +1,5 @@
 defmodule Tuist.AccountTest do
-  use TuistTestSupport.Cases.DataCase
+  use TuistTestSupport.Cases.DataCase, async: true
   use Mimic
 
   alias Tuist.Accounts.Account

--- a/server/test/tuist/accounts/account_token_project_test.exs
+++ b/server/test/tuist/accounts/account_token_project_test.exs
@@ -1,5 +1,5 @@
 defmodule Tuist.Accounts.AccountTokenProjectTest do
-  use TuistTestSupport.Cases.DataCase
+  use TuistTestSupport.Cases.DataCase, async: true
 
   alias Tuist.Accounts.AccountTokenProject
   alias TuistTestSupport.Fixtures.AccountsFixtures

--- a/server/test/tuist/accounts/account_token_test.exs
+++ b/server/test/tuist/accounts/account_token_test.exs
@@ -1,5 +1,5 @@
 defmodule Tuist.Accounts.AccountTokenTest do
-  use TuistTestSupport.Cases.DataCase
+  use TuistTestSupport.Cases.DataCase, async: true
 
   alias Tuist.Accounts.AccountToken
   alias TuistTestSupport.Fixtures.AccountsFixtures

--- a/server/test/tuist/accounts/invitation_test.exs
+++ b/server/test/tuist/accounts/invitation_test.exs
@@ -1,5 +1,5 @@
 defmodule Tuist.InvitationTest do
-  use TuistTestSupport.Cases.DataCase
+  use TuistTestSupport.Cases.DataCase, async: true
   use Mimic
 
   alias Tuist.Accounts.Invitation

--- a/server/test/tuist/accounts/organization_test.exs
+++ b/server/test/tuist/accounts/organization_test.exs
@@ -1,5 +1,5 @@
 defmodule Tuist.OrganizationTest do
-  use TuistTestSupport.Cases.DataCase
+  use TuistTestSupport.Cases.DataCase, async: true
   use Mimic
 
   alias Tuist.Accounts.Organization

--- a/server/test/tuist/accounts/subscription_test.exs
+++ b/server/test/tuist/accounts/subscription_test.exs
@@ -1,5 +1,5 @@
 defmodule Tuist.SubscriptionTest do
-  use TuistTestSupport.Cases.DataCase
+  use TuistTestSupport.Cases.DataCase, async: true
 
   alias Tuist.Accounts
   alias Tuist.Billing.Subscription

--- a/server/test/tuist/accounts/user_test.exs
+++ b/server/test/tuist/accounts/user_test.exs
@@ -1,5 +1,5 @@
 defmodule Tuist.Accounts.UserTest do
-  use TuistTestSupport.Cases.DataCase
+  use TuistTestSupport.Cases.DataCase, async: true
 
   alias Tuist.Accounts.User
   alias TuistTestSupport.Fixtures.AccountsFixtures

--- a/server/test/tuist/accounts/workers/update_all_accounts_usage_worker_test.exs
+++ b/server/test/tuist/accounts/workers/update_all_accounts_usage_worker_test.exs
@@ -1,5 +1,5 @@
 defmodule Tuist.Accounts.Workers.UpdateAllAccountsUsageWorkerTest do
-  use TuistTestSupport.Cases.DataCase
+  use TuistTestSupport.Cases.DataCase, async: true
   use Mimic
 
   alias Tuist.Accounts.Workers.UpdateAllAccountsUsageWorker

--- a/server/test/tuist/authentication_test.exs
+++ b/server/test/tuist/authentication_test.exs
@@ -1,5 +1,5 @@
 defmodule Tuist.AuthenticationTest do
-  use TuistTestSupport.Cases.DataCase
+  use TuistTestSupport.Cases.DataCase, async: true
   use Mimic
 
   alias Tuist.Accounts

--- a/server/test/tuist/authorization_test.exs
+++ b/server/test/tuist/authorization_test.exs
@@ -1,5 +1,5 @@
 defmodule Tuist.AuthorizationTest do
-  use TuistTestSupport.Cases.DataCase
+  use TuistTestSupport.Cases.DataCase, async: true
   use Mimic
 
   alias Tuist.Accounts

--- a/server/test/tuist/billing/token_usage_test.exs
+++ b/server/test/tuist/billing/token_usage_test.exs
@@ -1,5 +1,5 @@
 defmodule Tuist.Billing.TokenUsageTest do
-  use TuistTestSupport.Cases.DataCase
+  use TuistTestSupport.Cases.DataCase, async: true
 
   import TuistTestSupport.Fixtures.AccountsFixtures
 

--- a/server/test/tuist/billing_test.exs
+++ b/server/test/tuist/billing_test.exs
@@ -1,5 +1,5 @@
 defmodule Tuist.BillingTest do
-  use TuistTestSupport.Cases.DataCase
+  use TuistTestSupport.Cases.DataCase, async: true
   use Mimic
 
   alias Tuist.Accounts

--- a/server/test/tuist/builds_test.exs
+++ b/server/test/tuist/builds_test.exs
@@ -1,5 +1,5 @@
 defmodule Tuist.BuildsTest do
-  use TuistTestSupport.Cases.DataCase
+  use TuistTestSupport.Cases.DataCase, async: true
   use Mimic
 
   alias Tuist.Builds

--- a/server/test/tuist/cache_action_items/cache_action_item_test.exs
+++ b/server/test/tuist/cache_action_items/cache_action_item_test.exs
@@ -1,5 +1,5 @@
 defmodule Tuist.CacheActionItems.CacheActionItemTest do
-  use TuistTestSupport.Cases.DataCase
+  use TuistTestSupport.Cases.DataCase, async: true
 
   alias Tuist.CacheActionItems.CacheActionItem
   alias TuistTestSupport.Fixtures.ProjectsFixtures

--- a/server/test/tuist/cache_test.exs
+++ b/server/test/tuist/cache_test.exs
@@ -1,5 +1,5 @@
 defmodule Tuist.CacheTest do
-  use TuistTestSupport.Cases.DataCase
+  use TuistTestSupport.Cases.DataCase, async: true
   use Mimic
 
   alias Tuist.Cache

--- a/server/test/tuist/command_events/cache_event_test.exs
+++ b/server/test/tuist/command_events/cache_event_test.exs
@@ -1,5 +1,5 @@
 defmodule Tuist.CacheEventTest do
-  use TuistTestSupport.Cases.DataCase
+  use TuistTestSupport.Cases.DataCase, async: true
   use Mimic
 
   alias Tuist.CommandEvents.CacheEvent

--- a/server/test/tuist/command_events/event_test.exs
+++ b/server/test/tuist/command_events/event_test.exs
@@ -1,5 +1,5 @@
 defmodule Tuist.CommandEvents.EventTest do
-  use TuistTestSupport.Cases.DataCase
+  use TuistTestSupport.Cases.DataCase, async: true
 
   alias Tuist.CommandEvents.Event
 

--- a/server/test/tuist/guardian_test.exs
+++ b/server/test/tuist/guardian_test.exs
@@ -1,5 +1,5 @@
 defmodule Tuist.GuardianTest do
-  use TuistTestSupport.Cases.DataCase
+  use TuistTestSupport.Cases.DataCase, async: true
   use Mimic
 
   alias Tuist.Accounts.Account

--- a/server/test/tuist/oauth/clients_test.exs
+++ b/server/test/tuist/oauth/clients_test.exs
@@ -1,5 +1,5 @@
 defmodule Tuist.OAuth.ClientsTest do
-  use TuistTestSupport.Cases.DataCase
+  use TuistTestSupport.Cases.DataCase, async: true
   use Mimic
 
   alias Boruta.Oauth.Client

--- a/server/test/tuist/oauth/token_generator_test.exs
+++ b/server/test/tuist/oauth/token_generator_test.exs
@@ -1,5 +1,5 @@
 defmodule Tuist.OAuth.TokenGeneratorTest do
-  use TuistTestSupport.Cases.DataCase
+  use TuistTestSupport.Cases.DataCase, async: true
   use Mimic
 
   alias Boruta.Ecto.Token

--- a/server/test/tuist/previews/app_build_test.exs
+++ b/server/test/tuist/previews/app_build_test.exs
@@ -1,5 +1,5 @@
 defmodule Tuist.AppBuilds.AppBuildTest do
-  use TuistTestSupport.Cases.DataCase
+  use TuistTestSupport.Cases.DataCase, async: true
 
   alias Tuist.AppBuilds.AppBuild
 

--- a/server/test/tuist/previews/preview_test.exs
+++ b/server/test/tuist/previews/preview_test.exs
@@ -1,6 +1,6 @@
 defmodule Tuist.AppBuilds.PreviewTest do
   @moduledoc false
-  use TuistTestSupport.Cases.DataCase
+  use TuistTestSupport.Cases.DataCase, async: true
 
   alias Tuist.AppBuilds.Preview
 

--- a/server/test/tuist/projects/project_test.exs
+++ b/server/test/tuist/projects/project_test.exs
@@ -1,5 +1,5 @@
 defmodule Tuist.ProjectTest do
-  use TuistTestSupport.Cases.DataCase
+  use TuistTestSupport.Cases.DataCase, async: true
 
   alias Tuist.Projects.Project
   alias TuistTestSupport.Fixtures.AccountsFixtures

--- a/server/test/tuist/projects/project_token_test.exs
+++ b/server/test/tuist/projects/project_token_test.exs
@@ -1,5 +1,5 @@
 defmodule Tuist.Projects.ProjectTokenTest do
-  use TuistTestSupport.Cases.DataCase
+  use TuistTestSupport.Cases.DataCase, async: true
 
   alias Tuist.Projects.ProjectToken
   alias TuistTestSupport.Fixtures.ProjectsFixtures

--- a/server/test/tuist/projects/vcs_connection_test.exs
+++ b/server/test/tuist/projects/vcs_connection_test.exs
@@ -1,5 +1,5 @@
 defmodule Tuist.Projects.VCSConnectionTest do
-  use TuistTestSupport.Cases.DataCase
+  use TuistTestSupport.Cases.DataCase, async: true
 
   alias Tuist.Projects.VCSConnection
   alias TuistTestSupport.Fixtures.AccountsFixtures

--- a/server/test/tuist/projects/workers/clean_project_worker_test.exs
+++ b/server/test/tuist/projects/workers/clean_project_worker_test.exs
@@ -1,5 +1,5 @@
 defmodule Tuist.Projects.Workers.CleanProjectWorkerTest do
-  use TuistTestSupport.Cases.DataCase
+  use TuistTestSupport.Cases.DataCase, async: true
   use Mimic
 
   alias Tuist.CacheActionItems

--- a/server/test/tuist/runners/analytics_test.exs
+++ b/server/test/tuist/runners/analytics_test.exs
@@ -1,5 +1,5 @@
 defmodule Tuist.Runners.AnalyticsTest do
-  use TuistTestSupport.Cases.DataCase
+  use TuistTestSupport.Cases.DataCase, async: true
 
   import TuistTestSupport.Fixtures.AccountsFixtures
 

--- a/server/test/tuist/runners/billing_test.exs
+++ b/server/test/tuist/runners/billing_test.exs
@@ -1,5 +1,5 @@
 defmodule Tuist.Runners.BillingTest do
-  use TuistTestSupport.Cases.DataCase
+  use TuistTestSupport.Cases.DataCase, async: true
 
   import TuistTestSupport.Fixtures.AccountsFixtures
 

--- a/server/test/tuist/runners/jobs_test.exs
+++ b/server/test/tuist/runners/jobs_test.exs
@@ -1,5 +1,5 @@
 defmodule Tuist.Runners.JobsTest do
-  use TuistTestSupport.Cases.DataCase
+  use TuistTestSupport.Cases.DataCase, async: true
 
   import Ecto.Query
   import TuistTestSupport.Fixtures.AccountsFixtures

--- a/server/test/tuist/runners/runner_sessions_test.exs
+++ b/server/test/tuist/runners/runner_sessions_test.exs
@@ -1,5 +1,5 @@
 defmodule Tuist.Runners.RunnerSessionsTest do
-  use TuistTestSupport.Cases.DataCase
+  use TuistTestSupport.Cases.DataCase, async: true
 
   import TuistTestSupport.Fixtures.AccountsFixtures
 

--- a/server/test/tuist/shards_test.exs
+++ b/server/test/tuist/shards_test.exs
@@ -1,5 +1,5 @@
 defmodule Tuist.ShardsTest do
-  use TuistTestSupport.Cases.DataCase
+  use TuistTestSupport.Cases.DataCase, async: true
   use Mimic
 
   alias Tuist.Shards

--- a/server/test/tuist/slack/reports_test.exs
+++ b/server/test/tuist/slack/reports_test.exs
@@ -1,5 +1,5 @@
 defmodule Tuist.Slack.ReportsTest do
-  use TuistTestSupport.Cases.DataCase
+  use TuistTestSupport.Cases.DataCase, async: true
   use Mimic
 
   alias Tuist.Cache.Analytics

--- a/server/test/tuist/slack_test.exs
+++ b/server/test/tuist/slack_test.exs
@@ -1,5 +1,5 @@
 defmodule Tuist.SlackTest do
-  use TuistTestSupport.Cases.DataCase
+  use TuistTestSupport.Cases.DataCase, async: true
   use Mimic
 
   alias Tuist.Environment

--- a/server/test/tuist/storage/artifact_retention_cursor_test.exs
+++ b/server/test/tuist/storage/artifact_retention_cursor_test.exs
@@ -1,5 +1,5 @@
 defmodule Tuist.Storage.ArtifactRetentionCursorTest do
-  use TuistTestSupport.Cases.DataCase
+  use TuistTestSupport.Cases.DataCase, async: true
 
   alias Tuist.Repo
   alias Tuist.Storage.ArtifactRetentionCursor

--- a/server/test/tuist/telemetry/sanitizer_test.exs
+++ b/server/test/tuist/telemetry/sanitizer_test.exs
@@ -1,5 +1,5 @@
 defmodule Tuist.Telemetry.SanitizerTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
 
   alias Tuist.Telemetry.Sanitizer
 

--- a/server/test/tuist/tests_test.exs
+++ b/server/test/tuist/tests_test.exs
@@ -1,5 +1,5 @@
 defmodule Tuist.TestsTest do
-  use TuistTestSupport.Cases.DataCase
+  use TuistTestSupport.Cases.DataCase, async: true
   use Mimic
 
   import Ecto.Query

--- a/server/test/tuist/url_test.exs
+++ b/server/test/tuist/url_test.exs
@@ -1,5 +1,5 @@
 defmodule Tuist.URLTest do
-  use TuistTestSupport.Cases.DataCase
+  use TuistTestSupport.Cases.DataCase, async: true
   use Mimic
 
   alias Tuist.URL

--- a/server/test/tuist/xcode_test.exs
+++ b/server/test/tuist/xcode_test.exs
@@ -1,5 +1,5 @@
 defmodule Tuist.XcodeTest do
-  use TuistTestSupport.Cases.DataCase
+  use TuistTestSupport.Cases.DataCase, async: true
 
   import Ecto.Query
 

--- a/server/test/tuist_web/controllers/billing_controller_test.exs
+++ b/server/test/tuist_web/controllers/billing_controller_test.exs
@@ -1,5 +1,5 @@
 defmodule TuistWeb.BillingControllerTest do
-  use TuistTestSupport.Cases.ConnCase
+  use TuistTestSupport.Cases.ConnCase, async: true
   use Mimic
 
   alias Tuist.Accounts

--- a/server/test/tuist_web/controllers/ops_controller_test.exs
+++ b/server/test/tuist_web/controllers/ops_controller_test.exs
@@ -1,5 +1,5 @@
 defmodule TuistWeb.OpsControllerTest do
-  use TuistTestSupport.Cases.ConnCase
+  use TuistTestSupport.Cases.ConnCase, async: true
   use Mimic
 
   alias Tuist.Environment

--- a/server/test/tuist_web/controllers/webhooks/billing_controller_test.exs
+++ b/server/test/tuist_web/controllers/webhooks/billing_controller_test.exs
@@ -1,5 +1,5 @@
 defmodule TuistWeb.Webhooks.BillingControllerTest do
-  use TuistTestSupport.Cases.DataCase
+  use TuistTestSupport.Cases.DataCase, async: true
 
   alias Tuist.Accounts
   alias TuistTestSupport.Fixtures.AccountsFixtures

--- a/server/test/tuist_web/live/choose_username_live_test.exs
+++ b/server/test/tuist_web/live/choose_username_live_test.exs
@@ -1,6 +1,6 @@
 defmodule TuistWeb.ChooseUsernameLiveTest do
-  use TuistTestSupport.Cases.ConnCase
-  use TuistTestSupport.Cases.LiveCase
+  use TuistTestSupport.Cases.ConnCase, async: true
+  use TuistTestSupport.Cases.LiveCase, async: true
   use Mimic
 
   import Phoenix.LiveViewTest

--- a/server/test/tuist_web/live/create_organization_live_test.exs
+++ b/server/test/tuist_web/live/create_organization_live_test.exs
@@ -1,6 +1,6 @@
 defmodule TuistWeb.CreateOrganizationLiveTest do
-  use TuistTestSupport.Cases.ConnCase
-  use TuistTestSupport.Cases.LiveCase
+  use TuistTestSupport.Cases.ConnCase, async: true
+  use TuistTestSupport.Cases.LiveCase, async: true
   use Mimic
 
   import Phoenix.LiveViewTest

--- a/server/test/tuist_web/live/docs_live_test.exs
+++ b/server/test/tuist_web/live/docs_live_test.exs
@@ -1,6 +1,6 @@
 defmodule TuistWeb.DocsLiveTest do
-  use TuistTestSupport.Cases.ConnCase
-  use TuistTestSupport.Cases.LiveCase
+  use TuistTestSupport.Cases.ConnCase, async: true
+  use TuistTestSupport.Cases.LiveCase, async: true
   use Mimic
 
   import Phoenix.LiveViewTest

--- a/server/test/tuist_web/live/marketing_blog_post_live_test.exs
+++ b/server/test/tuist_web/live/marketing_blog_post_live_test.exs
@@ -1,6 +1,6 @@
 defmodule TuistWeb.Marketing.MarketingBlogPostLiveTest do
-  use TuistTestSupport.Cases.ConnCase
-  use TuistTestSupport.Cases.LiveCase
+  use TuistTestSupport.Cases.ConnCase, async: true
+  use TuistTestSupport.Cases.LiveCase, async: true
 
   import Phoenix.LiveViewTest
 

--- a/server/test/tuist_web/live/marketing_customers_live_test.exs
+++ b/server/test/tuist_web/live/marketing_customers_live_test.exs
@@ -1,6 +1,6 @@
 defmodule TuistWeb.Marketing.MarketingCustomersLiveTest do
-  use TuistTestSupport.Cases.ConnCase
-  use TuistTestSupport.Cases.LiveCase
+  use TuistTestSupport.Cases.ConnCase, async: true
+  use TuistTestSupport.Cases.LiveCase, async: true
 
   import Phoenix.LiveViewTest
 

--- a/server/test/tuist_web/live/user_confirmation_live_test.exs
+++ b/server/test/tuist_web/live/user_confirmation_live_test.exs
@@ -1,6 +1,6 @@
 defmodule TuistWeb.UserConfirmationLiveTest do
-  use TuistTestSupport.Cases.ConnCase
-  use TuistTestSupport.Cases.LiveCase
+  use TuistTestSupport.Cases.ConnCase, async: true
+  use TuistTestSupport.Cases.LiveCase, async: true
   use Mimic
 
   import Phoenix.LiveViewTest

--- a/server/test/tuist_web/live/user_forgot_password_live_test.exs
+++ b/server/test/tuist_web/live/user_forgot_password_live_test.exs
@@ -1,6 +1,6 @@
 defmodule TuistWeb.UserForgotPasswordLiveTest do
-  use TuistTestSupport.Cases.ConnCase
-  use TuistTestSupport.Cases.LiveCase
+  use TuistTestSupport.Cases.ConnCase, async: true
+  use TuistTestSupport.Cases.LiveCase, async: true
   use Mimic
 
   import Ecto.Query

--- a/server/test/tuist_web/live/user_login_live_test.exs
+++ b/server/test/tuist_web/live/user_login_live_test.exs
@@ -1,6 +1,6 @@
 defmodule TuistWeb.UserLoginLiveTest do
-  use TuistTestSupport.Cases.ConnCase
-  use TuistTestSupport.Cases.LiveCase
+  use TuistTestSupport.Cases.ConnCase, async: true
+  use TuistTestSupport.Cases.LiveCase, async: true
   use Mimic
 
   import Phoenix.LiveViewTest

--- a/server/test/tuist_web/live/user_registration_live_test.exs
+++ b/server/test/tuist_web/live/user_registration_live_test.exs
@@ -1,6 +1,6 @@
 defmodule TuistWeb.UserRegistrationLiveTest do
-  use TuistTestSupport.Cases.ConnCase
-  use TuistTestSupport.Cases.LiveCase
+  use TuistTestSupport.Cases.ConnCase, async: true
+  use TuistTestSupport.Cases.LiveCase, async: true
   use Mimic
 
   import Phoenix.LiveViewTest

--- a/server/test/tuist_web/live/user_reset_password_live_test.exs
+++ b/server/test/tuist_web/live/user_reset_password_live_test.exs
@@ -1,6 +1,6 @@
 defmodule TuistWeb.UserResetPasswordLiveTest do
-  use TuistTestSupport.Cases.ConnCase
-  use TuistTestSupport.Cases.LiveCase
+  use TuistTestSupport.Cases.ConnCase, async: true
+  use TuistTestSupport.Cases.LiveCase, async: true
   use Mimic
 
   import Phoenix.LiveViewTest

--- a/server/test/tuist_web/plugs/api/transfrom_query_array_params_plug_test.exs
+++ b/server/test/tuist_web/plugs/api/transfrom_query_array_params_plug_test.exs
@@ -1,5 +1,5 @@
 defmodule TuistWeb.API.TransformQueryArrayParamsPlugTest do
-  use TuistTestSupport.Cases.ConnCase
+  use TuistTestSupport.Cases.ConnCase, async: true
 
   alias TuistWeb.Plugs.API.TransformQueryArrayParamsPlug
 

--- a/server/test/tuist_web/plugs/on_premise_plug_test.exs
+++ b/server/test/tuist_web/plugs/on_premise_plug_test.exs
@@ -1,5 +1,5 @@
 defmodule TuistWeb.OnPremisePlugTest do
-  use TuistTestSupport.Cases.ConnCase
+  use TuistTestSupport.Cases.ConnCase, async: true
   use Mimic
 
   alias TuistTestSupport.Fixtures.AccountsFixtures

--- a/server/test/tuist_web/unit/oauth/controllers/authorize_controller_test.exs
+++ b/server/test/tuist_web/unit/oauth/controllers/authorize_controller_test.exs
@@ -1,5 +1,5 @@
 defmodule TuistWeb.Controllers.Oauth.AuthorizeControllerTest do
-  use TuistTestSupport.Cases.DataCase
+  use TuistTestSupport.Cases.DataCase, async: true
   use Mimic
 
   import ExUnit.CaptureLog


### PR DESCRIPTION
## What

Converts 54 server test modules from the default synchronous mode to `async: true` (39 `DataCase`, 14 `ConnCase`, 10 `LiveCase`, 1 `ExUnit.Case`). These are the modules that were synchronous only by omission: no global Mimic mode, no environment mutation, no explicit `async: false`. The modules that opt out with an explicit `async: false` are left untouched, since they do so for a reason.

## Why

The server `Test` job is one of the slowest CI jobs. ExUnit runs `async: true` modules concurrently up to the scheduler count, while default-sync modules run serially. A large share of the suite was serial purely because the flag was never set, so the runner left cores idle.

ClickHouse-backed cases can run async now thanks to the `ecto_ch` transaction-sandbox work (the sandbox isolates both Postgres and ClickHouse per test), so the conversions are safe across both databases.

## Impact

The conversions expose real parallelism. On an 11-core dev machine the full suite drops from about 359s to about 130s (roughly 2.7x), because the previously-serial modules now run concurrently across all cores.

On the CI runner the gain is smaller: the `Run tests` step goes from 379s to 322s (about 15%) on the 2 vCPU default. The gap between the local 2.7x and the CI 15% is the interesting part. After the conversions the suite is CPU-bound rather than concurrency-bound: the parallelism is there, but the constrained runner does not have the cores to exploit it. The `tuist-linux-large` experiment confirms this from the other side, doubling to 4 vCPU adds only about 13% (322s to 276s), sublinear scaling that shows each test is itself CPU-heavy, so cores saturate quickly.

## Possible follow-up

Now that the suite is CPU-bound, the next lever is per-test CPU cost rather than concurrency. It is worth investigating why individual tests are CPU-heavy (candidates: bcrypt/crypto work, in-test compilation, heavy fixtures). Lowering that cost would let the constrained CI runner extract more of the parallelism this PR exposes.

## Alternatives considered and rejected

Both were tried under a draft-only CI harness and reverted, so they leave no trace in the final diff:

1. **Docker build gha layer cache.** `cache-to: type=gha,mode=max` re-exports the multi-GB Swift-toolchain and Elixir-release layers every run. The app `mix release` layers change every commit, so they never cache-hit yet always re-export, adding about 15 min and pushing the build from its ~16 min baseline past the 30 min timeout (killed mid `writing layer`). There is no knob that caches only the stable deps stages while skipping the churning app layers, so caching is net-negative for this image.

2. **Bigger runner shape (`tuist-linux-large`, 4 vCPU) for `Test` and `Gradle Cache Acceptance`.** Doubling the cores bought only about 13% on each (Test 322s to 276s, Gradle 1110s to 973s). That weak scaling shows neither job is CPU-bound at four cores in a way that justifies the spend: Test is dominated by serial setup/DB/compile, and Gradle's e2e is network/IO-bound on server boot and cache round-trips. Not worth 2x the runner resources, so both stay on the 2 vCPU default.

## Validation

Full server suite run locally against Postgres and ClickHouse (0 failures), and the `Test` job validated twice on the real CI shape (322s and 276s runs, 0 failures, no flakes). `tests_live_test` is deliberately kept synchronous because its `render_async` assertion uses the 100ms default and is timing-sensitive under increased parallel load.
