### PR TITLE
ci(server): build the server image on tuist-linux-large to stop runner OOM

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -236,7 +236,11 @@ jobs:
     name: Build + push
     needs: resolve
     if: needs.resolve.outputs.action == 'deploy'
-    runs-on: tuist-linux
+    # Bigger shape: the server image build (Elixir release compile inside
+    # the dind sidecar) OOMs the 2 vCPU / 8 GB default microVM, killing the
+    # runner mid-build ("lost communication"). Mirrors server.yml's
+    # docker_build job.
+    runs-on: tuist-linux-large
     timeout-minutes: 40
     outputs:
       image_tag: ${{ steps.tag.outputs.image_tag }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -408,7 +408,11 @@ jobs:
     name: Release Server
     needs: check-releases
     if: needs.check-releases.outputs.server-should-release == 'true'
-    runs-on: tuist-linux
+    # Bigger shape: the server image build (Elixir release compile inside
+    # the dind sidecar) OOMs the 2 vCPU / 8 GB default microVM, killing the
+    # runner mid-build ("lost communication"). Mirrors server.yml's
+    # docker_build job.
+    runs-on: tuist-linux-large
     timeout-minutes: 30
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/server-deployment.yml
+++ b/.github/workflows/server-deployment.yml
@@ -114,7 +114,11 @@ jobs:
   build:
     name: Build + push
     if: inputs.image_tag == ''
-    runs-on: tuist-linux
+    # Bigger shape: the server image build (Elixir release compile inside
+    # the dind sidecar) OOMs the 2 vCPU / 8 GB default microVM, killing the
+    # runner mid-build ("lost communication"). Mirrors server.yml's
+    # docker_build job.
+    runs-on: tuist-linux-large
     # 60m absorbs a fully cold build (no buildcache hits).
     timeout-minutes: 60
     outputs:

--- a/.github/workflows/server-production-deployment.yml
+++ b/.github/workflows/server-production-deployment.yml
@@ -80,7 +80,11 @@ jobs:
   # --------------------------------------------------------------------------
   build:
     name: Build server image
-    runs-on: tuist-linux
+    # Bigger shape: the server image build (Elixir release compile inside
+    # the dind sidecar) OOMs the 2 vCPU / 8 GB default microVM, killing the
+    # runner mid-build ("lost communication"). Mirrors server.yml's
+    # docker_build job.
+    runs-on: tuist-linux-large
     timeout-minutes: 40
     outputs:
       image_tag: ${{ steps.tag.outputs.image_tag }}


### PR DESCRIPTION
## What changed

Moved every CI job that builds the server image (`server/Dockerfile`, target `runner`) from the default `tuist-linux` shape to `tuist-linux-large`:

- `server-deployment.yml` — `Build + push` (the job that failed the prod deploy)
- `server-production-deployment.yml` — `Build server image` (push-to-main cascade)
- `preview-deploy.yml` — PR preview `Build + push`
- `release.yml` — `Release Server`

## Why

The production [Server Deployment run](https://github.com/tuist/tuist/actions/runs/26937628167/job/79471067270) failed in the **Build + push** job with GitHub's `The self-hosted runner lost communication with the server` annotation.

### Root cause

This annotation is misleading. It is **not** the documented deploy self-eviction incident (helm mutating the cluster its own runner lives in). The job log cuts off mid-Docker-build, right after `docker/login` succeeds — the runner was **OOM-killed**. The server image build runs the Elixir release compile inside the dind sidecar, which exhausts the default 2 vCPU / 8 GB `tuist-linux` microVM.

[#11071](https://github.com/tuist/tuist/pull/11071) already diagnosed this exact failure for `server.yml`'s `docker_build` job and fixed it by moving to `tuist-linux-large`. That fix was never applied to the deploy / preview / release workflows, which build the identical image and were still on `tuist-linux`.

### Why this solution

`tuist-linux-large` is a confirmed, routable shape — the main-push `Docker build` job ran successfully on it (16m27s) in [run 26940953311](https://github.com/tuist/tuist/actions/runs/26940953311). The fix mirrors the established #11071 pattern rather than inventing a new mechanism.

The fix is extended to the preview and release builds (not just the failing prod-deploy build) because they share the identical OOM root cause and would fail the same way on the next PR preview / server release. Fixing them together avoids whack-a-mole.

Build jobs run no helm, so moving them to a larger shape carries no self-eviction risk — the bigger box is purely for the compile's memory footprint.

## Impact

- Production / single-env server deploys, push-to-main cascade, PR previews, and server releases can all get past the image build.
- The downstream deploy legs (helm install/upgrade) are a separate, previously-documented concern and are unchanged here; they never ran in the failing run since they are `needs: build`.

## Validation

- Confirmed `tuist-linux-large` routes and successfully builds the server image (the `server.yml` `docker_build` job, 16m27s on the latest main push).
- Confirmed all five `server/Dockerfile` builds in `.github/workflows/` now resolve to a `tuist-linux-large` job (the four here + `server.yml` from #11071).
- All four edited workflow files parse as valid YAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)