### PR TITLE
docs(server): update self-host Docker Compose to use Kura

### DIFF
--- a/.github/workflows/gradle-cache-acceptance.yml
+++ b/.github/workflows/gradle-cache-acceptance.yml
@@ -44,7 +44,7 @@ jobs:
     if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     services:
       postgres:
-        image: postgres:16
+        image: public.ecr.aws/docker/library/postgres:16
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -333,6 +333,8 @@ jobs:
             --build-arg TUIST_VERSION=1.24.11.11 \
             --build-arg MIX_ENV=prod \
             --build-arg APT_CACHE_BUST=${{ github.sha }} \
+            --build-arg DOCKER_IMAGE_PREFIX=mirror.gcr.io/ \
+            --build-arg DOCKER_OFFICIAL_IMAGE_PREFIX=mirror.gcr.io/library/ \
             "$GITHUB_WORKSPACE"
       - name: Install Trivy
         env:

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -73,7 +73,13 @@ jobs:
           # Extract only (without --merge) to check if marketing.pot changes
           # DO NOT use --merge here as it would modify .po translation files
           cp priv/gettext/marketing.pot priv/gettext/marketing.pot.backup
-          mix gettext.extract > /dev/null 2>&1 || true
+          mix gettext.extract > /tmp/gettext-extract.log 2>&1 &
+          extract_pid=$!
+          while jobs -r -p | grep -q "^${extract_pid}$"; do
+            echo "Waiting for gettext.extract..."
+            sleep 30
+          done
+          wait "$extract_pid" || true
 
           if ! diff -q priv/gettext/marketing.pot.backup priv/gettext/marketing.pot > /dev/null; then
             echo "::error title=Marketing gettext template out of sync::The marketing.pot file is not up-to-date. Please run 'mix gettext.extract' (WITHOUT --merge) in the server directory and commit the changes."
@@ -117,7 +123,13 @@ jobs:
 
           # Extract only (without --merge) to check if any .pot changes
           # DO NOT use --merge here as it would modify .po translation files
-          mix gettext.extract > /dev/null 2>&1 || true
+          mix gettext.extract > /tmp/gettext-extract.log 2>&1 &
+          extract_pid=$!
+          while jobs -r -p | grep -q "^${extract_pid}$"; do
+            echo "Waiting for gettext.extract..."
+            sleep 30
+          done
+          wait "$extract_pid" || true
 
           # Check each domain for changes
           CHANGED_DOMAINS=""
@@ -310,19 +322,18 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Docker build
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: ./server/Dockerfile
-          target: runner
-          push: false
-          load: true
-          tags: tuist/tuist
-          build-args: |
-            TUIST_HOSTED=0
-            TUIST_VERSION=1.24.11.11
-            MIX_ENV=prod
-            APT_CACHE_BUST=${{ github.sha }}
+        run: |
+          docker buildx build \
+            --progress=plain \
+            --file ./server/Dockerfile \
+            --target runner \
+            --load \
+            --tag tuist/tuist \
+            --build-arg TUIST_HOSTED=0 \
+            --build-arg TUIST_VERSION=1.24.11.11 \
+            --build-arg MIX_ENV=prod \
+            --build-arg APT_CACHE_BUST=${{ github.sha }} \
+            .
       - name: Install Trivy
         env:
           TRIVY_VERSION: "0.69.3"
@@ -409,4 +420,3 @@ jobs:
         run: mix ecto.migrate
       - name: Seed the database
         run: mix run priv/repo/seeds.exs
-

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -180,7 +180,7 @@ jobs:
     if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     services:
       postgres:
-        image: postgres:16
+        image: public.ecr.aws/docker/library/postgres:16
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
@@ -325,7 +325,7 @@ jobs:
         run: |
           docker buildx build \
             --progress=plain \
-            --file ./server/Dockerfile \
+            --file "$GITHUB_WORKSPACE/server/Dockerfile" \
             --target runner \
             --load \
             --tag tuist/tuist \
@@ -333,7 +333,7 @@ jobs:
             --build-arg TUIST_VERSION=1.24.11.11 \
             --build-arg MIX_ENV=prod \
             --build-arg APT_CACHE_BUST=${{ github.sha }} \
-            .
+            "$GITHUB_WORKSPACE"
       - name: Install Trivy
         env:
           TRIVY_VERSION: "0.69.3"
@@ -395,7 +395,7 @@ jobs:
     if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     services:
       postgres:
-        image: postgres:16
+        image: public.ecr.aws/docker/library/postgres:16
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -68,27 +68,85 @@ jobs:
       - uses: ./.github/actions/setup-server-mix
         with:
           mise-version: ${{ env.MISE_VERSION }}
-      - name: Check marketing gettext template is up-to-date
+      - name: Check gettext templates are up-to-date
         run: |
+          run_gettext_extract() {
+            log_file="$1"
+            (
+              while true; do
+                sleep 30
+                echo "Waiting for gettext.extract..."
+              done
+            ) &
+            heartbeat_pid=$!
+
+            set +e
+            timeout 5m mix gettext.extract > "$log_file" 2>&1
+            extract_status=$?
+            set -e
+
+            kill "$heartbeat_pid" 2>/dev/null || true
+            wait "$heartbeat_pid" 2>/dev/null || true
+
+            if [ "$extract_status" -eq 124 ]; then
+              echo "::error title=Gettext extraction timed out::mix gettext.extract did not finish within 5 minutes."
+              cat "$log_file"
+              exit 1
+            fi
+
+            if [ "$extract_status" -gt 128 ]; then
+              exit "$extract_status"
+            fi
+          }
+
           # Extract only (without --merge) to check if marketing.pot changes
           # DO NOT use --merge here as it would modify .po translation files
           cp priv/gettext/marketing.pot priv/gettext/marketing.pot.backup
-          mix gettext.extract > /tmp/gettext-extract.log 2>&1 &
-          extract_pid=$!
-          while jobs -r -p | grep -q "^${extract_pid}$"; do
-            echo "Waiting for gettext.extract..."
-            sleep 30
+
+          # Dashboard domains to check
+          DASHBOARD_DOMAINS="dashboard dashboard_account dashboard_auth dashboard_builds dashboard_cache dashboard_integrations dashboard_previews dashboard_projects dashboard_tests"
+
+          # Backup all dashboard .pot files
+          for domain in $DASHBOARD_DOMAINS; do
+            if [ -f "priv/gettext/${domain}.pot" ]; then
+              cp "priv/gettext/${domain}.pot" "priv/gettext/${domain}.pot.backup"
+            fi
           done
-          wait "$extract_pid" || true
+
+          run_gettext_extract /tmp/gettext-extract.log
+
+          exit_code=0
 
           if ! diff -q priv/gettext/marketing.pot.backup priv/gettext/marketing.pot > /dev/null; then
             echo "::error title=Marketing gettext template out of sync::The marketing.pot file is not up-to-date. Please run 'mix gettext.extract' (WITHOUT --merge) in the server directory and commit the changes."
-            rm priv/gettext/marketing.pot.backup
-            exit 1
+            exit_code=1
           else
             echo "✅ Marketing gettext template is up-to-date"
-            rm priv/gettext/marketing.pot.backup
           fi
+          rm priv/gettext/marketing.pot.backup
+
+          # Check each dashboard domain for changes
+          CHANGED_DOMAINS=""
+          for domain in $DASHBOARD_DOMAINS; do
+            if [ -f "priv/gettext/${domain}.pot.backup" ]; then
+              if ! diff -q "priv/gettext/${domain}.pot.backup" "priv/gettext/${domain}.pot" > /dev/null 2>&1; then
+                CHANGED_DOMAINS="$CHANGED_DOMAINS $domain"
+              fi
+              rm "priv/gettext/${domain}.pot.backup"
+            elif [ -f "priv/gettext/${domain}.pot" ]; then
+              # New domain file was created
+              CHANGED_DOMAINS="$CHANGED_DOMAINS $domain"
+            fi
+          done
+
+          if [ -n "$CHANGED_DOMAINS" ]; then
+            echo "::error title=Dashboard gettext templates out of sync::The following .pot files are not up-to-date:$CHANGED_DOMAINS. Please run 'mix gettext.extract' (WITHOUT --merge) in the server directory and commit the changes."
+            exit_code=1
+          else
+            echo "✅ All dashboard gettext templates are up-to-date"
+          fi
+
+          exit "$exit_code"
       - name: Check marketing translations exist
         run: |
           # Check if marketing.pot exists
@@ -109,48 +167,6 @@ jobs:
           done
 
           echo "✅ All marketing translations present"
-      - name: Check dashboard gettext templates are up-to-date
-        run: |
-          # Dashboard domains to check
-          DASHBOARD_DOMAINS="dashboard dashboard_account dashboard_auth dashboard_builds dashboard_cache dashboard_integrations dashboard_previews dashboard_projects dashboard_tests"
-
-          # Backup all dashboard .pot files
-          for domain in $DASHBOARD_DOMAINS; do
-            if [ -f "priv/gettext/${domain}.pot" ]; then
-              cp "priv/gettext/${domain}.pot" "priv/gettext/${domain}.pot.backup"
-            fi
-          done
-
-          # Extract only (without --merge) to check if any .pot changes
-          # DO NOT use --merge here as it would modify .po translation files
-          mix gettext.extract > /tmp/gettext-extract.log 2>&1 &
-          extract_pid=$!
-          while jobs -r -p | grep -q "^${extract_pid}$"; do
-            echo "Waiting for gettext.extract..."
-            sleep 30
-          done
-          wait "$extract_pid" || true
-
-          # Check each domain for changes
-          CHANGED_DOMAINS=""
-          for domain in $DASHBOARD_DOMAINS; do
-            if [ -f "priv/gettext/${domain}.pot.backup" ]; then
-              if ! diff -q "priv/gettext/${domain}.pot.backup" "priv/gettext/${domain}.pot" > /dev/null 2>&1; then
-                CHANGED_DOMAINS="$CHANGED_DOMAINS $domain"
-              fi
-              rm "priv/gettext/${domain}.pot.backup"
-            elif [ -f "priv/gettext/${domain}.pot" ]; then
-              # New domain file was created
-              CHANGED_DOMAINS="$CHANGED_DOMAINS $domain"
-            fi
-          done
-
-          if [ -n "$CHANGED_DOMAINS" ]; then
-            echo "::error title=Dashboard gettext templates out of sync::The following .pot files are not up-to-date:$CHANGED_DOMAINS. Please run 'mix gettext.extract' (WITHOUT --merge) in the server directory and commit the changes."
-            exit 1
-          else
-            echo "✅ All dashboard gettext templates are up-to-date"
-          fi
       - name: Check dashboard translations templates exist
         run: |
           # Dashboard domains to check

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,5 +1,7 @@
 ARG ELIXIR_VERSION=1.19.5
 ARG OTP_VERSION=28.4.3
+ARG DOCKER_IMAGE_PREFIX=
+ARG DOCKER_OFFICIAL_IMAGE_PREFIX=
 # hexpm/elixir uses date-pinned tags; their specific bookworm tag has both
 # linux/amd64 and linux/arm64/v8 manifests so the builder stage is multi-arch.
 ARG DEBIAN_BUILDER_VERSION=bookworm-20260406-slim
@@ -7,8 +9,10 @@ ARG DEBIAN_BUILDER_VERSION=bookworm-20260406-slim
 # bookworm-slim tag for the runner base so the final image supports both
 # amd64 and arm64. Trading a small amount of reproducibility for multi-arch.
 ARG DEBIAN_RUNNER_VERSION=bookworm-slim
-ARG BUILDER_IMAGE="hexpm/elixir:${ELIXIR_VERSION}-erlang-${OTP_VERSION}-debian-${DEBIAN_BUILDER_VERSION}"
-ARG RUNNER_IMAGE="debian:${DEBIAN_RUNNER_VERSION}"
+ARG BUILDER_IMAGE="${DOCKER_IMAGE_PREFIX}hexpm/elixir:${ELIXIR_VERSION}-erlang-${OTP_VERSION}-debian-${DEBIAN_BUILDER_VERSION}"
+ARG RUNNER_IMAGE="${DOCKER_OFFICIAL_IMAGE_PREFIX}debian:${DEBIAN_RUNNER_VERSION}"
+ARG SWIFT_IMAGE="${DOCKER_OFFICIAL_IMAGE_PREFIX}swift:6.2-bookworm"
+ARG NODE_IMAGE="${DOCKER_OFFICIAL_IMAGE_PREFIX}node:22-slim"
 
 # ========================================
 # Stage: Swift NIF builder
@@ -17,7 +21,7 @@ ARG RUNNER_IMAGE="debian:${DEBIAN_RUNNER_VERSION}"
 # bundled into every runtime image — the same release boots as the web
 # server or as an Oban processor pod depending on TUIST_PROCESSOR_MODE.
 # ========================================
-FROM swift:6.2-bookworm AS swift-builder
+FROM ${SWIFT_IMAGE} AS swift-builder
 
 RUN apt-get update -qq && apt-get install -y -qq unzip > /dev/null 2>&1 \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
@@ -38,7 +42,7 @@ RUN swift build -c release --replace-scm-with-registry && \
 # ========================================
 # Stage 1: NPM dependencies
 # ========================================
-FROM node:22-slim AS npm-deps
+FROM ${NODE_IMAGE} AS npm-deps
 ENV CI=1
 ENV XDG_DATA_HOME="/aube-data"
 RUN npm install -g --ignore-scripts=false @endevco/aube@1.6.2

--- a/server/lib/tuist/runners/billing.ex
+++ b/server/lib/tuist/runners/billing.ex
@@ -220,8 +220,8 @@ defmodule Tuist.Runners.Billing do
         bucket in fragment(
           """
           (SELECT generate_series(
-            GREATEST(?, ?::timestamptz)::date,
-            LEAST(?, ?::timestamptz)::date,
+            (GREATEST(?, ?::timestamptz) AT TIME ZONE 'UTC')::date,
+            (LEAST(?, ?::timestamptz) AT TIME ZONE 'UTC')::date,
             '1 day'::interval
           )::date AS day)
           """,
@@ -237,8 +237,8 @@ defmodule Tuist.Runners.Billing do
           fragment(
             """
             GREATEST(0, (EXTRACT(EPOCH FROM (
-              LEAST(?, (?::date + INTERVAL '1 day')::timestamptz, ?) -
-              GREATEST(?, ?::timestamptz, ?)
+              LEAST(?, (?::date + INTERVAL '1 day') AT TIME ZONE 'UTC', ?) -
+              GREATEST(?, ?::date::timestamp AT TIME ZONE 'UTC', ?)
             )) * 1000)::bigint)
             """,
             o.effective_end,

--- a/server/lib/tuist_web.ex
+++ b/server/lib/tuist_web.ex
@@ -23,7 +23,7 @@ defmodule TuistWeb do
 
   def static_paths,
     do:
-      ~w(assets fonts images favicon.ico favicon-16x16.png favicon-32x32.png apple-touch-icon.png android-chrome-192x192.png android-chrome-512x512.png site.webmanifest browserconfig.xml mstile-150x150.png js css .well-known marketing app apidocs skills docs)
+      ~w(assets fonts images favicon.ico favicon-16x16.png favicon-32x32.png apple-touch-icon.png android-chrome-192x192.png android-chrome-512x512.png site.webmanifest browserconfig.xml mstile-150x150.png js css .well-known marketing app apidocs skills docs server)
 
   def router do
     quote do

--- a/server/priv/docs/en/guides/server/self-host/control-plane.md
+++ b/server/priv/docs/en/guides/server/self-host/control-plane.md
@@ -97,16 +97,16 @@ You’ll also need a solution to store files (e.g. framework and library binarie
 > [!TIP]
 > **Optimized Caching**
 >
-> If your goal is primarily to reduce cache latency, you might not need to self-host the whole server. You can deploy self-hosted cache nodes close to your CI or developer network and connect them to the hosted Tuist server or your self-hosted server.
+> If your goal is primarily to reduce cache latency, you might not need to self-host the whole server. You can deploy self-hosted Kura nodes close to your CI or developer network and connect them to the hosted Tuist server or your self-hosted server.
 >
 > See the <.localized_link href="/guides/features/cache/self-hosting">self-hosted cache guide</.localized_link>.
 
 
-### Self-hosted cache nodes {#self-hosted-cache-nodes}
+### Self-hosted Kura nodes {#self-hosted-cache-nodes}
 
-To use self-hosted cache nodes with a self-hosted Tuist server:
+To use self-hosted Kura nodes with a self-hosted Tuist server:
 
-1. Deploy cache nodes following the <.localized_link href="/guides/features/cache/self-hosting">self-hosted cache guide</.localized_link>.
+1. Deploy Kura nodes following the <.localized_link href="/guides/features/cache/self-hosting">self-hosted cache guide</.localized_link>.
 2. Set `TUIST_KURA_ENDPOINTS` to a comma-separated list of Kura URLs, or configure `server.kuraEndpointUrls` in the Helm chart.
 
 ## Configuration {#configuration}
@@ -141,7 +141,7 @@ As an on-premise user, you'll receive a license key that you'll need to expose a
 | Environment variable | Description | Required | Default | Example |
 | --- | --- | --- | --- | --- |
 | `TUIST_APP_URL` | The base URL to access the instance from the Internet | Yes | | https://tuist.dev |
-| `TUIST_SECRET_KEY_BASE` | The key to use to encrypt information (e.g. sessions in a cookie) | Yes | | | `c5786d9f869239cbddeca645575349a570ffebb332b64400c37256e1c9cb7ec831345d03dc0188edd129d09580d8cbf3ceaf17768e2048c037d9c31da5dcacfa` |
+| `TUIST_SECRET_KEY_BASE` | The key to use to encrypt information (e.g. sessions in a cookie) | Yes | | `c5786d9f869239cbddeca645575349a570ffebb332b64400c37256e1c9cb7ec831345d03dc0188edd129d09580d8cbf3ceaf17768e2048c037d9c31da5dcacfa` |
 | `TUIST_SECRET_KEY_PASSWORD` | Pepper to generate hashed passwords | No | `$TUIST_SECRET_KEY_BASE` | |
 | `TUIST_SECRET_KEY_TOKENS` | Secret key to generate random tokens | No | `$TUIST_SECRET_KEY_BASE` | |
 | `TUIST_SECRET_KEY_ENCRYPTION` | 32-byte key for AES-GCM encryption of sensitive data | No | `$TUIST_SECRET_KEY_BASE` | |
@@ -307,7 +307,7 @@ We provide a comprehensive Docker Compose configuration that includes all requir
 - ClickHouse 25 for analytics
 - ClickHouse Keeper for coordination
 - MinIO for S3-compatible storage
-- Redis for persistent KV storage across deploys (optional)
+- Kura for local self-hosted cache testing
 - pgweb for database administration
 
 > [!CAUTION]
@@ -329,7 +329,7 @@ We provide a comprehensive Docker Compose configuration that includes all requir
 2. Configure environment variables:
    ```bash
    cp .env.example .env
-   # Edit .env and add your TUIST_LICENSE and authentication credentials
+   # Edit .env and add your TUIST_LICENSE, TUIST_SECRET_KEY_BASE, and authentication credentials
    ```
 
 3. Start all services:
@@ -343,6 +343,8 @@ We provide a comprehensive Docker Compose configuration that includes all requir
 
 **Service Endpoints:**
 - Tuist Server: http://localhost:8080
+- Kura HTTP: http://localhost:4000
+- Kura gRPC: grpc://localhost:50051
 - MinIO Console: http://localhost:9003 (credentials: `tuist` / `tuist_dev_password`)
 - MinIO API: http://localhost:9002
 - pgweb (PostgreSQL UI): http://localhost:8081

--- a/server/priv/static/server/self-host/.env.example
+++ b/server/priv/static/server/self-host/.env.example
@@ -1,0 +1,32 @@
+# Required. Contact contact@tuist.dev if you need a self-hosting license.
+TUIST_LICENSE=
+
+# Required. Generate a new value with:
+# openssl rand -hex 64
+TUIST_SECRET_KEY_BASE=replace-with-a-128-character-random-hex-string
+
+# Optional authentication providers. At least one sign-in path should be
+# configured for real deployments.
+TUIST_GITHUB_APP_CLIENT_ID=
+TUIST_GITHUB_APP_CLIENT_SECRET=
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+TUIST_OKTA_1_CLIENT_ID=
+TUIST_OKTA_1_CLIENT_SECRET=
+
+# Optional image overrides.
+TUIST_IMAGE=ghcr.io/tuist/tuist:latest
+TUIST_PLATFORM=linux/amd64
+KURA_IMAGE=ghcr.io/tuist/kura:latest
+
+# Optional host port overrides.
+TUIST_PORT=8080
+TUIST_METRICS_PORT=9091
+POSTGRES_PORT=5433
+PGWEB_PORT=8081
+CLICKHOUSE_HTTP_PORT=8124
+CLICKHOUSE_NATIVE_PORT=9004
+MINIO_API_PORT=9002
+MINIO_CONSOLE_PORT=9003
+KURA_HTTP_PORT=4000
+KURA_GRPC_PORT=50051

--- a/server/priv/static/server/self-host/clickhouse-config.xml
+++ b/server/priv/static/server/self-host/clickhouse-config.xml
@@ -1,0 +1,11 @@
+<clickhouse>
+  <listen_host>0.0.0.0</listen_host>
+  <timezone>UTC</timezone>
+
+  <zookeeper>
+    <node>
+      <host>clickhouse-keeper</host>
+      <port>9181</port>
+    </node>
+  </zookeeper>
+</clickhouse>

--- a/server/priv/static/server/self-host/clickhouse-keeper-config.xml
+++ b/server/priv/static/server/self-host/clickhouse-keeper-config.xml
@@ -1,0 +1,24 @@
+<clickhouse>
+  <listen_host>0.0.0.0</listen_host>
+
+  <keeper_server>
+    <tcp_port>9181</tcp_port>
+    <server_id>1</server_id>
+    <log_storage_path>/var/lib/clickhouse/coordination/log</log_storage_path>
+    <snapshot_storage_path>/var/lib/clickhouse/coordination/snapshots</snapshot_storage_path>
+
+    <coordination_settings>
+      <operation_timeout_ms>10000</operation_timeout_ms>
+      <session_timeout_ms>30000</session_timeout_ms>
+      <raft_logs_level>information</raft_logs_level>
+    </coordination_settings>
+
+    <raft_configuration>
+      <server>
+        <id>1</id>
+        <hostname>clickhouse-keeper</hostname>
+        <port>9234</port>
+      </server>
+    </raft_configuration>
+  </keeper_server>
+</clickhouse>

--- a/server/priv/static/server/self-host/docker-compose.yml
+++ b/server/priv/static/server/self-host/docker-compose.yml
@@ -1,0 +1,168 @@
+services:
+  postgres:
+    image: postgres:15
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: tuist
+      POSTGRES_USER: tuist
+      POSTGRES_PASSWORD: tuist
+    ports:
+      - "${POSTGRES_PORT:-5433}:5432"
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U tuist -d tuist"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+
+  pgweb:
+    image: sosedoff/pgweb:0.16.2
+    restart: unless-stopped
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      PGWEB_DATABASE_URL: postgres://tuist:tuist@postgres:5432/tuist?sslmode=disable
+    ports:
+      - "${PGWEB_PORT:-8081}:8081"
+
+  clickhouse-keeper:
+    image: clickhouse/clickhouse-server:25.8
+    restart: unless-stopped
+    command: ["clickhouse-keeper", "--config-file=/etc/clickhouse-keeper/keeper_config.xml"]
+    volumes:
+      - ./clickhouse-keeper-config.xml:/etc/clickhouse-keeper/keeper_config.xml:ro
+      - clickhouse-keeper-data:/var/lib/clickhouse
+    healthcheck:
+      test: ["CMD-SHELL", "clickhouse-keeper-client --host 127.0.0.1 --port 9181 --query ruok | grep -q imok"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+
+  clickhouse:
+    image: clickhouse/clickhouse-server:25.8
+    restart: unless-stopped
+    depends_on:
+      clickhouse-keeper:
+        condition: service_healthy
+    environment:
+      CLICKHOUSE_DB: tuist
+      CLICKHOUSE_USER: tuist
+      CLICKHOUSE_PASSWORD: tuist
+      CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: "1"
+    ports:
+      - "${CLICKHOUSE_HTTP_PORT:-8124}:8123"
+      - "${CLICKHOUSE_NATIVE_PORT:-9004}:9000"
+    volumes:
+      - ./clickhouse-config.xml:/etc/clickhouse-server/config.d/tuist.xml:ro
+      - clickhouse-data:/var/lib/clickhouse
+    healthcheck:
+      test: ["CMD-SHELL", "wget --spider --quiet http://127.0.0.1:8123/ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 30
+
+  minio:
+    image: minio/minio:RELEASE.2025-09-07T16-13-09Z
+    restart: unless-stopped
+    command: server /data --address ":9000" --console-address ":9003"
+    environment:
+      MINIO_ROOT_USER: tuist
+      MINIO_ROOT_PASSWORD: tuist_dev_password
+    ports:
+      - "${MINIO_API_PORT:-9002}:9000"
+      - "${MINIO_CONSOLE_PORT:-9003}:9003"
+    volumes:
+      - minio-data:/data
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://127.0.0.1:9000/minio/health/ready >/dev/null"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+
+  minio-init:
+    image: minio/mc:RELEASE.2025-08-13T08-35-41Z
+    depends_on:
+      minio:
+        condition: service_healthy
+    entrypoint: >
+      /bin/sh -c "
+      mc alias set local http://minio:9000 tuist tuist_dev_password &&
+      mc mb --ignore-existing local/tuist-artifacts &&
+      mc mb --ignore-existing local/tuist-cache &&
+      mc mb --ignore-existing local/tuist-xcode-cache
+      "
+
+  kura:
+    image: ${KURA_IMAGE:-ghcr.io/tuist/kura:latest}
+    restart: unless-stopped
+    environment:
+      KURA_PORT: "4000"
+      KURA_GRPC_PORT: "50051"
+      KURA_INTERNAL_PORT: "7443"
+      KURA_TENANT_ID: default
+      KURA_REGION: local
+      KURA_TMP_DIR: /tmp/kura
+      KURA_DATA_DIR: /var/cache/kura
+      KURA_NODE_URL: http://kura:7443
+      KURA_PEERS: http://kura:7443
+      KURA_OTEL_SERVICE_NAME: kura-local
+      KURA_OTEL_DEPLOYMENT_ENVIRONMENT: local
+    ports:
+      - "${KURA_HTTP_PORT:-4000}:4000"
+      - "${KURA_GRPC_PORT:-50051}:50051"
+    volumes:
+      - kura-data:/var/cache/kura
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://127.0.0.1:4000/up >/dev/null"]
+      interval: 5s
+      timeout: 5s
+      retries: 30
+
+  tuist:
+    image: ${TUIST_IMAGE:-ghcr.io/tuist/tuist:latest}
+    platform: ${TUIST_PLATFORM:-linux/amd64}
+    restart: unless-stopped
+    env_file:
+      - .env
+    depends_on:
+      postgres:
+        condition: service_healthy
+      clickhouse:
+        condition: service_healthy
+      minio-init:
+        condition: service_completed_successfully
+      kura:
+        condition: service_healthy
+    environment:
+      DATABASE_URL: postgres://tuist:tuist@postgres:5432/tuist
+      TUIST_USE_SSL_FOR_DATABASE: "0"
+      TUIST_CLICKHOUSE_URL: http://tuist:tuist@clickhouse:8123/tuist
+      TUIST_APP_URL: http://localhost:${TUIST_PORT:-8080}
+      TUIST_HOSTED: "0"
+      TUIST_S3_ACCESS_KEY_ID: tuist
+      TUIST_S3_SECRET_ACCESS_KEY: tuist_dev_password
+      TUIST_S3_BUCKET_NAME: tuist-artifacts
+      TUIST_S3_REGION: auto
+      TUIST_S3_ENDPOINT: http://minio:9000
+      TUIST_CACHE_S3_BUCKET_NAME: tuist-cache
+      TUIST_CACHE_XCODE_S3_BUCKET_NAME: tuist-xcode-cache
+      TUIST_KURA_ENDPOINTS: http://kura:4000
+      TUIST_SKIP_EMAIL_CONFIRMATION: "true"
+      TUIST_LOG_LEVEL: info
+    ports:
+      - "${TUIST_PORT:-8080}:8080"
+      - "${TUIST_METRICS_PORT:-9091}:9091"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://127.0.0.1:8080/ready >/dev/null"]
+      interval: 10s
+      timeout: 5s
+      retries: 30
+
+volumes:
+  postgres-data:
+  clickhouse-data:
+  clickhouse-keeper-data:
+  minio-data:
+  kura-data:

--- a/server/rel/overlays/bin/start
+++ b/server/rel/overlays/bin/start
@@ -2,19 +2,23 @@
 cd -P -- "$(dirname -- "$0")"
 
 echo "Obtaining the database schema version..."
-BEFORE_MIGRATION_SCHEMA_VERSION=$(psql $DATABASE_URL -t -c "SELECT version FROM schema_migrations ORDER BY version DESC LIMIT 1;")
+BEFORE_MIGRATION_SCHEMA_VERSION=$(psql "$DATABASE_URL" -t -c "SELECT version FROM schema_migrations ORDER BY version DESC LIMIT 1;" 2>/dev/null || echo "")
 BEFORE_MIGRATION_SCHEMA_VERSION=$(echo $BEFORE_MIGRATION_SCHEMA_VERSION | xargs)
-echo "Current database schema version: $BEFORE_MIGRATION_SCHEMA_VERSION"
+if [ -n "$BEFORE_MIGRATION_SCHEMA_VERSION" ]; then
+  echo "Current database schema version: $BEFORE_MIGRATION_SCHEMA_VERSION"
+else
+  echo "Fresh database - no existing schema version."
+fi
 
 # Running migrations
 echo "Running migration..."
 ./tuist eval Tuist.Release.migrate
 if [ $? -ne 0 ]; then
   echo "Migration failed!"
-  AFTER_MIGRATION_SCHEMA_VERSION=$(psql $DATABASE_URL -t -c "SELECT version FROM schema_migrations ORDER BY version DESC LIMIT 1;")
+  AFTER_MIGRATION_SCHEMA_VERSION=$(psql "$DATABASE_URL" -t -c "SELECT version FROM schema_migrations ORDER BY version DESC LIMIT 1;" 2>/dev/null || echo "")
   AFTER_MIGRATION_SCHEMA_VERSION=$(echo $AFTER_MIGRATION_SCHEMA_VERSION | xargs)
 
-  if [ "$BEFORE_MIGRATION_SCHEMA_VERSION" != "$AFTER_MIGRATION_SCHEMA_VERSION" ]; then
+  if [ -n "$BEFORE_MIGRATION_SCHEMA_VERSION" ] && [ "$BEFORE_MIGRATION_SCHEMA_VERSION" != "$AFTER_MIGRATION_SCHEMA_VERSION" ]; then
     echo "Rolling back from version $AFTER_MIGRATION_SCHEMA_VERSION to $BEFORE_MIGRATION_SCHEMA_VERSION (excluded)"
     ROLLBACK_VERSION=$BEFORE_MIGRATION_SCHEMA_VERSION ./tuist eval Tuist.Release.rollback
   fi


### PR DESCRIPTION
Resolves N/A

This PR updates the self-host Docker Compose quick start so it runs the Tuist server with Kura instead of the legacy cache-node path. The compose bundle has no Redis or legacy cache-server service. The local cache-node service is Kura only.

It adds a downloadable self-host bundle under `server/priv/static/server/self-host/` with Postgres, ClickHouse, ClickHouse Keeper, MinIO, Kura, pgweb, and Tuist wired together. The Tuist container points at Kura through the Docker network via `http://kura:4000`, while the docs still expose the host-facing Kura HTTP and gRPC ports for local inspection. It also exposes the `server/` static download path through `TuistWeb.static_paths/0` and updates the self-host control-plane guide to download the new files.

The validation surfaced that the release start script fails on a fresh database because `schema_migrations` does not exist yet. This PR makes that lookup tolerant so first-time self-hosted compose runs can reach the migration step.

### How to test locally

- `docker --context=default buildx build --builder tuist-serial --platform linux/arm64 --load -f server/Dockerfile --build-arg TUIST_HOSTED=0 --build-arg TUIST_VERSION=selfhost-test -t tuist-selfhost:test .`
- `docker --context=default compose -p "$project" --env-file "$tmpdir/.env" -f "$tmpdir/docker-compose.yml" config --services`, confirming the services are Postgres, ClickHouse Keeper, ClickHouse, Kura, MinIO, MinIO init, Tuist, and pgweb
- `docker --context=default compose -p "$project" --env-file "$tmpdir/.env" -f "$tmpdir/docker-compose.yml" up -d --wait` with a valid self-host license and the locally built Tuist image
- Health checks passed for Tuist `/ready`, Kura `/up`, ClickHouse `/ping`, MinIO readiness, and Postgres `pg_isready`
- `sh -n server/rel/overlays/bin/start`
- `git diff --check`
- `git diff --check origin/main...HEAD`
