### PR TITLE
feat(infra): add AWS Marketplace deploy scaffold

### DIFF
--- a/.github/workflows/aws-marketplace.yml
+++ b/.github/workflows/aws-marketplace.yml
@@ -1,0 +1,120 @@
+name: AWS Marketplace
+
+# Validates the AWS Marketplace deployment packaging without requiring a live
+# buyer account. The CloudFormation template uses AWSQS public extensions for
+# Kubernetes resources, so cfn-lint runs with the extension-type rule ignored
+# unless those extensions are activated in the CI region.
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - infra/aws-marketplace/**
+      - infra/helm/tuist/**
+      - .github/workflows/aws-marketplace.yml
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - infra/aws-marketplace/**
+      - infra/helm/tuist/**
+      - .github/workflows/aws-marketplace.yml
+  workflow_dispatch: {}
+  merge_group: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: aws-marketplace-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+env:
+  MISE_VERSION: "2026.4.18"
+  MISE_GITHUB_TOKEN: ${{ github.token }}
+  HELM_VERSION: "4.1.4"
+  KUBECONFORM_VERSION: "0.7.0"
+  AWS_REGION: us-east-1
+  MARKETPLACE_TEMPLATE: infra/aws-marketplace/cloudformation/tuist-existing-eks.yaml
+  MARKETPLACE_VALUES: infra/aws-marketplace/helm/values-existing-eks.yaml
+
+jobs:
+  offline:
+    name: Offline Validation
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: jdx/mise-action@v4.0.1
+        with:
+          version: ${{ env.MISE_VERSION }}
+          install: "false"
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - name: Install tools
+        run: |
+          set -euo pipefail
+          mise use -g "helm@${HELM_VERSION}" "yq@4.52.5"
+          python3 -m pip install --user "cfn-lint>=1,<2"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+      - name: Install kubeconform
+        run: |
+          set -euo pipefail
+          archive="kubeconform-linux-amd64.tar.gz"
+          curl -fsSL \
+            "https://github.com/yannh/kubeconform/releases/download/v${KUBECONFORM_VERSION}/${archive}" \
+            -o "$archive"
+          mkdir -p "$HOME/.local/bin"
+          tar -xzf "$archive" kubeconform
+          install -m 0755 kubeconform "$HOME/.local/bin/kubeconform"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+      - name: Parse CloudFormation template
+        run: yq '.' "$MARKETPLACE_TEMPLATE" >/dev/null
+      - name: cfn-lint
+        run: |
+          cfn-lint \
+            --non-zero-exit-code error \
+            --ignore-checks E3006 W1011 \
+            --regions "$AWS_REGION" \
+            --template "$MARKETPLACE_TEMPLATE"
+      - name: Helm lint
+        run: helm lint infra/helm/tuist -f "$MARKETPLACE_VALUES"
+      - name: Helm template
+        run: |
+          helm template tuist infra/helm/tuist \
+            -f "$MARKETPLACE_VALUES" \
+            > rendered.yaml
+          echo "Rendered $(wc -l <rendered.yaml) lines of manifests."
+      - name: kubeconform
+        run: |
+          kubeconform \
+            -strict \
+            -ignore-missing-schemas \
+            -summary \
+            -schema-location default \
+            -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json' \
+            rendered.yaml
+
+  aws-validate-template:
+    name: AWS Validate Template
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: offline
+    if: >-
+      (github.event.pull_request.draft == false || github.event_name != 'pull_request') &&
+      vars.AWS_MARKETPLACE_VALIDATE_ROLE_ARN != ''
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_MARKETPLACE_VALIDATE_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+      - name: Validate CloudFormation template
+        run: |
+          aws cloudformation validate-template \
+            --template-body "file://${MARKETPLACE_TEMPLATE}"

--- a/infra/AGENTS.md
+++ b/infra/AGENTS.md
@@ -46,6 +46,9 @@ Geo-routes cache registry requests to the nearest healthy cache origin based on 
 ### `cnpg/` — CloudNativePG bootstrap SQL + Supabase→CNPG migration runbook
 SQL files for per-table GRANTs that don't fit CNPG's `managed.roles[]` declarative surface (`tuist_processor` writes on Oban tables; `tuist_ops_ro` extras on top of `pg_read_all_data`). Also holds the end-to-end migration runbook for moving each managed env's Postgres from Supabase to the in-cluster CNPG cluster via logical replication. The actual `Cluster` / `ScheduledBackup` / ESO Secret manifests are rendered by the main Helm chart whenever `postgresql.cnpg.enabled` is true (provisioning + soak) or `postgresql.mode == "cnpg"` (cutover); this directory holds only the operator-run SQL + procedural docs that can't fit in the chart.
 
+### `aws-marketplace/` — AWS Marketplace one-click deployment assets
+AWS-specific packaging for buyer-owned Tuist deployments. Starts with an existing-EKS CloudFormation path that provisions AWS dependencies and installs the Tuist Helm chart, then grows toward Marketplace Quick Launch. Keep AWS Marketplace review constraints, CloudFormation templates, and AWS-specific values here rather than baking provider assumptions into `helm/tuist/`.
+
 ### `vm-image-builder.md` — bare-metal builder fleet operator runbook
 End-to-end runbook for the bare-metal Mac mini fleet that bakes our Tart VM images (runner-image, xcresult-processor-image). Cluster-managed via the same CAPI provider that runs the other macOS fleets; hosts are regular Nodes with tart-kubelet idle plus a GitHub Actions self-hosted runner installed on top via the `ScalewayAppleSiliconMachineSpec.GHActionsRunner` sub-spec. Scale by editing `buildersFleet.replicas` or `kubectl scale machinedeployment`.
 

--- a/infra/aws-marketplace/AGENTS.md
+++ b/infra/aws-marketplace/AGENTS.md
@@ -1,0 +1,20 @@
+# AWS Marketplace
+
+This node covers AWS Marketplace packaging for buyer-owned Tuist deployments.
+
+## Scope
+- CloudFormation templates that support Marketplace-style one-click deployment
+- AWS-specific Helm values overlays for EKS installs
+- Marketplace readiness notes for images, IAM, networking, and buyer instructions
+
+## Conventions
+- Keep the main `infra/helm/tuist` chart provider-agnostic. Put AWS defaults and Marketplace review constraints here.
+- Prefer AWS-managed infrastructure for first-click buyer deployments: RDS for Postgres, S3 for object storage, and EKS for Kubernetes workloads.
+- Use workload identity for AWS access. Do not introduce long-lived AWS access keys in templates or values.
+- Treat Marketplace submission constraints as product constraints: document them next to the template that must satisfy them.
+- Validate CloudFormation templates with YAML parsing first, then `aws cloudformation validate-template` when AWS credentials are available.
+
+## Related Context
+- Parent infra context: `infra/AGENTS.md`
+- Tuist Helm chart: `infra/helm/tuist/AGENTS.md`
+- Server self-hosting docs: `server/priv/docs/en/guides/server/self-host/control-plane.md`

--- a/infra/aws-marketplace/README.md
+++ b/infra/aws-marketplace/README.md
@@ -9,7 +9,7 @@ The first deployable milestone is an **existing EKS** Marketplace-style stack:
 1. The buyer selects an existing EKS cluster.
 2. CloudFormation creates AWS dependencies:
    - RDS Postgres for Tuist relational data.
-   - S3 buckets for Tuist artifacts, cache artifacts, Xcode cache artifacts, and registry artifacts.
+   - S3 buckets for Tuist artifacts and registry artifacts.
    - An IAM role for the Tuist server ServiceAccount to access those buckets through IRSA.
 3. CloudFormation installs the Tuist Helm chart into the cluster through the `AWSQS::Kubernetes::Helm` public extension.
 
@@ -30,6 +30,8 @@ The first template assumes the buyer already has:
 - The EKS worker node security group ID, so the template can allow Postgres traffic from the cluster.
 - A public Tuist URL. The current template exposes the server through a `LoadBalancer` Service; DNS/TLS automation is deferred to the full Quick Launch milestone.
 - A valid Tuist Enterprise self-hosting license key.
+
+The deprecated cache service is explicitly disabled in the Marketplace overlay. Kura cache nodes should be modeled separately from this legacy cache service path.
 
 ## Marketplace readiness gaps
 

--- a/infra/aws-marketplace/README.md
+++ b/infra/aws-marketplace/README.md
@@ -1,0 +1,72 @@
+# AWS Marketplace one-click deployment
+
+This directory contains the AWS-specific packaging path for buyer-owned Tuist deployments. It intentionally sits outside `infra/helm/tuist` so the main chart stays provider-agnostic.
+
+## Product shape
+
+The first deployable milestone is an **existing EKS** Marketplace-style stack:
+
+1. The buyer selects an existing EKS cluster.
+2. CloudFormation creates AWS dependencies:
+   - RDS Postgres for Tuist relational data.
+   - S3 buckets for Tuist artifacts, cache artifacts, Xcode cache artifacts, and registry artifacts.
+   - An IAM role for the Tuist server ServiceAccount to access those buckets through IRSA.
+3. CloudFormation installs the Tuist Helm chart into the cluster through the `AWSQS::Kubernetes::Helm` public extension.
+
+This is not the final Marketplace Quick Launch experience yet. It is the smallest end-to-end path that exercises the AWS procurement/deployment shape without also provisioning the EKS cluster.
+
+## Files
+
+- `cloudformation/tuist-existing-eks.yaml` - CloudFormation entrypoint for an existing EKS cluster.
+- `helm/values-existing-eks.yaml` - Helm values overlay that mirrors the same deployment shape for local chart rendering.
+
+## Existing-EKS prerequisites
+
+The first template assumes the buyer already has:
+
+- An EKS cluster with Linux worker nodes and a default `ReadWriteOnce` storage class for embedded ClickHouse.
+- The `AWSQS::Kubernetes::Helm` and `AWSQS::Kubernetes::Resource` public CloudFormation extensions activated in the target account and Region.
+- An EKS IAM OIDC provider configured for IRSA.
+- The EKS worker node security group ID, so the template can allow Postgres traffic from the cluster.
+- A public Tuist URL. The current template exposes the server through a `LoadBalancer` Service; DNS/TLS automation is deferred to the full Quick Launch milestone.
+- A valid Tuist Enterprise self-hosting license key.
+
+## Marketplace readiness gaps
+
+Before submitting this as a public AWS Marketplace container product:
+
+- Mirror every required image into AWS Marketplace-managed ECR repositories, including supporting images such as ClickHouse.
+- Replace the public GHCR chart source with the Marketplace-managed Helm artifact.
+- Verify whether the Marketplace review path supports the `AWSQS::Kubernetes::Helm` extension directly, or whether AWS requires a different Quick Launch wrapper.
+- Add the full empty-account Quick Launch template that provisions VPC, EKS, node groups, ingress, and DNS.
+- Decide whether the first public listing is BYOL or uses AWS Marketplace container billing/licensing.
+- Produce the required architecture diagram and buyer usage instructions.
+
+## Validation
+
+CI validates this directory through `.github/workflows/aws-marketplace.yml` when Marketplace assets or the Tuist Helm chart change.
+
+The required offline job checks:
+
+- CloudFormation YAML parsing with `yq`.
+- CloudFormation linting with `cfn-lint`.
+- Helm linting with `values-existing-eks.yaml`.
+- Helm rendering plus Kubernetes schema validation with `kubeconform`.
+
+The workflow also has an optional AWS validation job. It runs `aws cloudformation validate-template` only when the repository variable `AWS_MARKETPLACE_VALIDATE_ROLE_ARN` is set to an IAM role that GitHub Actions can assume through OIDC.
+
+Render the current Helm overlay from the repository root:
+
+```bash
+helm template tuist infra/helm/tuist \
+  -f infra/aws-marketplace/helm/values-existing-eks.yaml
+```
+
+When AWS credentials are available, validate the CloudFormation template:
+
+```bash
+aws cloudformation validate-template \
+  --template-body file://infra/aws-marketplace/cloudformation/tuist-existing-eks.yaml
+```
+
+The CloudFormation stack depends on the `AWSQS::Kubernetes::Helm` and `AWSQS::Kubernetes::Resource` public extensions being activated in the buyer account and Region.

--- a/infra/aws-marketplace/cloudformation/tuist-existing-eks.yaml
+++ b/infra/aws-marketplace/cloudformation/tuist-existing-eks.yaml
@@ -1,0 +1,497 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >
+  Deploy Tuist into an existing Amazon EKS cluster with AWS-managed Postgres and
+  S3 dependencies. This is the first AWS Marketplace one-click deployment
+  milestone, before the full empty-account Quick Launch template.
+
+Metadata:
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+      - Label:
+          default: EKS target
+        Parameters:
+          - EKSClusterName
+          - KubernetesNamespace
+          - HelmReleaseName
+          - NodeSecurityGroupId
+          - OIDCProviderArn
+          - OIDCIssuerHostPath
+      - Label:
+          default: Tuist configuration
+        Parameters:
+          - TuistAppUrl
+          - TuistLicenseKey
+          - TuistChartRepository
+          - TuistChartName
+          - TuistChartVersion
+      - Label:
+          default: Database
+        Parameters:
+          - VpcId
+          - PrivateSubnet1Id
+          - PrivateSubnet2Id
+          - DatabaseName
+          - DatabaseUsername
+          - DatabasePassword
+          - DatabaseInstanceClass
+          - DatabaseAllocatedStorage
+          - DatabaseMultiAZ
+    ParameterLabels:
+      EKSClusterName:
+        default: EKS cluster name
+      KubernetesNamespace:
+        default: Kubernetes namespace
+      HelmReleaseName:
+        default: Helm release name
+      NodeSecurityGroupId:
+        default: EKS node security group
+      OIDCProviderArn:
+        default: EKS OIDC provider ARN
+      OIDCIssuerHostPath:
+        default: EKS OIDC issuer host path
+      TuistAppUrl:
+        default: Public Tuist URL
+      TuistLicenseKey:
+        default: Tuist license key
+      TuistChartRepository:
+        default: Helm chart repository
+      TuistChartName:
+        default: Helm chart name
+      TuistChartVersion:
+        default: Helm chart version
+      VpcId:
+        default: VPC
+      PrivateSubnet1Id:
+        default: Private subnet 1
+      PrivateSubnet2Id:
+        default: Private subnet 2
+      DatabaseName:
+        default: Database name
+      DatabaseUsername:
+        default: Database username
+      DatabasePassword:
+        default: Database password
+      DatabaseInstanceClass:
+        default: Database instance class
+      DatabaseAllocatedStorage:
+        default: Database storage
+      DatabaseMultiAZ:
+        default: Multi-AZ database
+
+Parameters:
+  EKSClusterName:
+    Type: String
+    Description: Existing EKS cluster where Tuist will be installed.
+
+  KubernetesNamespace:
+    Type: String
+    Default: tuist
+    AllowedPattern: "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+    Description: Kubernetes namespace for the Tuist Helm release.
+
+  HelmReleaseName:
+    Type: String
+    Default: tuist
+    AllowedPattern: "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+    Description: Helm release name.
+
+  NodeSecurityGroupId:
+    Type: AWS::EC2::SecurityGroup::Id
+    Description: Security group used by EKS worker nodes. RDS allows Postgres traffic from this group.
+
+  OIDCProviderArn:
+    Type: String
+    Description: IAM OIDC provider ARN for the target EKS cluster, used for IRSA.
+
+  OIDCIssuerHostPath:
+    Type: String
+    Description: >
+      OIDC issuer host and path without https://, for example
+      oidc.eks.us-east-1.amazonaws.com/id/0123456789ABCDEF.
+
+  TuistAppUrl:
+    Type: String
+    Default: https://tuist.example.com
+    Description: Public URL that users and the Tuist CLI use to reach this deployment.
+
+  TuistLicenseKey:
+    Type: String
+    NoEcho: true
+    AllowedPattern: "^[A-Za-z0-9_.:-]{1,2048}$"
+    Description: Tuist Enterprise self-hosting license key.
+
+  TuistChartRepository:
+    Type: String
+    Default: oci://ghcr.io/tuist/charts
+    Description: >
+      Helm chart repository. Marketplace submission should replace this with
+      the AWS Marketplace-managed chart location.
+
+  TuistChartName:
+    Type: String
+    Default: tuist
+    Description: Helm chart name.
+
+  TuistChartVersion:
+    Type: String
+    Default: 0.2.0
+    Description: Tuist Helm chart version to install.
+
+  VpcId:
+    Type: AWS::EC2::VPC::Id
+    Description: VPC that contains the EKS worker nodes and private database subnets.
+
+  PrivateSubnet1Id:
+    Type: AWS::EC2::Subnet::Id
+    Description: First private subnet for the RDS subnet group.
+
+  PrivateSubnet2Id:
+    Type: AWS::EC2::Subnet::Id
+    Description: Second private subnet for the RDS subnet group.
+
+  DatabaseName:
+    Type: String
+    Default: tuist
+    AllowedPattern: "^[A-Za-z][A-Za-z0-9_]{0,62}$"
+    Description: Initial Postgres database name.
+
+  DatabaseUsername:
+    Type: String
+    Default: tuist
+    AllowedPattern: "^[A-Za-z][A-Za-z0-9_]{0,62}$"
+    Description: Postgres owner username.
+
+  DatabasePassword:
+    Type: String
+    NoEcho: true
+    MinLength: 16
+    MaxLength: 64
+    AllowedPattern: "^[A-Za-z0-9]{16,64}$"
+    Description: Postgres owner password. Use only letters and numbers because the chart composes this into DATABASE_URL.
+
+  DatabaseInstanceClass:
+    Type: String
+    Default: db.t4g.medium
+    Description: RDS instance class for Postgres.
+
+  DatabaseAllocatedStorage:
+    Type: Number
+    Default: 100
+    MinValue: 20
+    Description: Allocated RDS storage in GiB.
+
+  DatabaseMultiAZ:
+    Type: String
+    Default: "false"
+    AllowedValues:
+      - "true"
+      - "false"
+    Description: Whether to provision RDS as Multi-AZ.
+
+Conditions:
+  UseMultiAZDatabase: !Equals [!Ref DatabaseMultiAZ, "true"]
+
+Resources:
+  ArtifactBucket:
+    Type: AWS::S3::Bucket
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    Properties:
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
+
+  CacheBucket:
+    Type: AWS::S3::Bucket
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    Properties:
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
+
+  XcodeCacheBucket:
+    Type: AWS::S3::Bucket
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    Properties:
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
+
+  RegistryBucket:
+    Type: AWS::S3::Bucket
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    Properties:
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
+
+  DatabaseSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Allow Tuist EKS nodes to reach Tuist Postgres.
+      VpcId: !Ref VpcId
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: 5432
+          ToPort: 5432
+          SourceSecurityGroupId: !Ref NodeSecurityGroupId
+
+  DatabaseSubnetGroup:
+    Type: AWS::RDS::DBSubnetGroup
+    Properties:
+      DBSubnetGroupDescription: Private subnets for Tuist Postgres.
+      SubnetIds:
+        - !Ref PrivateSubnet1Id
+        - !Ref PrivateSubnet2Id
+
+  TuistDatabase:
+    Type: AWS::RDS::DBInstance
+    DeletionPolicy: Snapshot
+    UpdateReplacePolicy: Snapshot
+    Properties:
+      AllocatedStorage: !Ref DatabaseAllocatedStorage
+      AutoMinorVersionUpgrade: true
+      BackupRetentionPeriod: 7
+      DBInstanceClass: !Ref DatabaseInstanceClass
+      DBName: !Ref DatabaseName
+      DBSubnetGroupName: !Ref DatabaseSubnetGroup
+      Engine: postgres
+      MasterUsername: !Ref DatabaseUsername
+      MasterUserPassword: !Ref DatabasePassword
+      MultiAZ: !If [UseMultiAZDatabase, true, false]
+      PubliclyAccessible: false
+      StorageEncrypted: true
+      VPCSecurityGroups:
+        - !GetAtt DatabaseSecurityGroup.GroupId
+
+  TuistServerS3Role:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Fn::Sub:
+          - |
+            {
+              "Version": "2012-10-17",
+              "Statement": [
+                {
+                  "Effect": "Allow",
+                  "Principal": {
+                    "Federated": "${ProviderArn}"
+                  },
+                  "Action": "sts:AssumeRoleWithWebIdentity",
+                  "Condition": {
+                    "StringEquals": {
+                      "${IssuerHostPath}:aud": "sts.amazonaws.com",
+                      "${IssuerHostPath}:sub": "system:serviceaccount:${Namespace}:tuist-server"
+                    }
+                  }
+                }
+              ]
+            }
+          - ProviderArn: !Ref OIDCProviderArn
+            IssuerHostPath: !Ref OIDCIssuerHostPath
+            Namespace: !Ref KubernetesNamespace
+      Policies:
+        - PolicyName: tuist-s3-access
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - s3:DeleteObject
+                  - s3:GetObject
+                  - s3:PutObject
+                Resource:
+                  - !Sub "${ArtifactBucket.Arn}/*"
+                  - !Sub "${CacheBucket.Arn}/*"
+                  - !Sub "${XcodeCacheBucket.Arn}/*"
+                  - !Sub "${RegistryBucket.Arn}/*"
+              - Effect: Allow
+                Action:
+                  - s3:ListBucket
+                Resource:
+                  - !GetAtt ArtifactBucket.Arn
+                  - !GetAtt CacheBucket.Arn
+                  - !GetAtt XcodeCacheBucket.Arn
+                  - !GetAtt RegistryBucket.Arn
+
+  TuistNamespace:
+    Type: AWSQS::Kubernetes::Resource
+    Properties:
+      ClusterName: !Ref EKSClusterName
+      Namespace: default
+      Manifest: !Sub |
+        apiVersion: v1
+        kind: Namespace
+        metadata:
+          name: ${KubernetesNamespace}
+
+  TuistHelmRelease:
+    Type: AWSQS::Kubernetes::Helm
+    DependsOn:
+      - TuistNamespace
+    Properties:
+      ClusterID: !Ref EKSClusterName
+      Name: !Ref HelmReleaseName
+      Namespace: !Ref KubernetesNamespace
+      Repository: !Ref TuistChartRepository
+      Chart: !Ref TuistChartName
+      Version: !Ref TuistChartVersion
+      TimeOut: 20
+      ValueYaml:
+        Fn::Sub:
+          - |
+            global:
+              commonLabels:
+                tuist.dev/distribution: aws-marketplace
+
+            server:
+              replicaCount: 1
+              appUrl: "${TuistAppUrl}"
+              hosted: false
+              skipEmailConfirmation: true
+              database:
+                ssl: true
+              service:
+                type: LoadBalancer
+                port: 80
+                targetPort: 8080
+              s3:
+                region: "${AWS::Region}"
+                bucketName: "${ArtifactBucketName}"
+                virtualHost: false
+                bucketAsHost: false
+              serviceAccount:
+                create: true
+                name: tuist-server
+                annotations:
+                  eks.amazonaws.com/role-arn: "${TuistServerS3RoleArn}"
+              extraEnv:
+                - name: TUIST_S3_AUTHENTICATION_METHOD
+                  value: aws_web_identity_token_from_env_vars
+              license:
+                key: "${TuistLicenseKey}"
+
+            cache:
+              enabled: false
+              s3:
+                region: "${AWS::Region}"
+                bucket: "${CacheBucketName}"
+                xcodeCacheBucket: "${XcodeCacheBucketName}"
+                registryBucket: "${RegistryBucketName}"
+
+            processor:
+              enabled: false
+
+            xcresultProcessor:
+              enabled: false
+
+            runnersFleet:
+              enabled: false
+
+            runnersFleetLinux:
+              enabled: false
+
+            kuraController:
+              enabled: false
+
+            capi:
+              enabled: false
+
+            postgresql:
+              mode: external
+              external:
+                host: "${DatabaseHost}"
+                port: ${DatabasePort}
+                database: "${DatabaseName}"
+                username: "${DatabaseUsername}"
+                password: "${DatabasePassword}"
+
+            clickhouse:
+              mode: embedded
+              embedded:
+                persistence:
+                  size: 100Gi
+
+            objectStorage:
+              mode: external
+              external:
+                endpoint: "https://s3.${AWS::Region}.${AWS::URLSuffix}"
+                accessKey: ""
+                secretKey: ""
+                region: "${AWS::Region}"
+                buckets:
+                  default: "${ArtifactBucketName}"
+                  cache: "${CacheBucketName}"
+                  xcodeCache: "${XcodeCacheBucketName}"
+                  registry: "${RegistryBucketName}"
+
+            observability:
+              enabled: false
+          - TuistServerS3RoleArn: !GetAtt TuistServerS3Role.Arn
+            DatabaseHost: !GetAtt TuistDatabase.Endpoint.Address
+            DatabasePort: !GetAtt TuistDatabase.Endpoint.Port
+            ArtifactBucketName: !Ref ArtifactBucket
+            CacheBucketName: !Ref CacheBucket
+            XcodeCacheBucketName: !Ref XcodeCacheBucket
+            RegistryBucketName: !Ref RegistryBucket
+
+Outputs:
+  Namespace:
+    Description: Kubernetes namespace where Tuist was installed.
+    Value: !Ref KubernetesNamespace
+
+  HelmRelease:
+    Description: Tuist Helm release name.
+    Value: !Ref HelmReleaseName
+
+  DatabaseEndpoint:
+    Description: RDS Postgres endpoint.
+    Value: !GetAtt TuistDatabase.Endpoint.Address
+
+  ArtifactBucketName:
+    Description: S3 bucket used for Tuist artifacts.
+    Value: !Ref ArtifactBucket
+
+  CacheBucketName:
+    Description: S3 bucket reserved for cache artifacts.
+    Value: !Ref CacheBucket
+
+  XcodeCacheBucketName:
+    Description: S3 bucket reserved for Xcode cache artifacts.
+    Value: !Ref XcodeCacheBucket
+
+  RegistryBucketName:
+    Description: S3 bucket reserved for registry artifacts.
+    Value: !Ref RegistryBucket
+
+  TuistServerS3RoleArn:
+    Description: IAM role annotated on the Tuist server ServiceAccount.
+    Value: !GetAtt TuistServerS3Role.Arn

--- a/infra/aws-marketplace/cloudformation/tuist-existing-eks.yaml
+++ b/infra/aws-marketplace/cloudformation/tuist-existing-eks.yaml
@@ -207,36 +207,6 @@ Resources:
         IgnorePublicAcls: true
         RestrictPublicBuckets: true
 
-  CacheBucket:
-    Type: AWS::S3::Bucket
-    DeletionPolicy: Retain
-    UpdateReplacePolicy: Retain
-    Properties:
-      BucketEncryption:
-        ServerSideEncryptionConfiguration:
-          - ServerSideEncryptionByDefault:
-              SSEAlgorithm: AES256
-      PublicAccessBlockConfiguration:
-        BlockPublicAcls: true
-        BlockPublicPolicy: true
-        IgnorePublicAcls: true
-        RestrictPublicBuckets: true
-
-  XcodeCacheBucket:
-    Type: AWS::S3::Bucket
-    DeletionPolicy: Retain
-    UpdateReplacePolicy: Retain
-    Properties:
-      BucketEncryption:
-        ServerSideEncryptionConfiguration:
-          - ServerSideEncryptionByDefault:
-              SSEAlgorithm: AES256
-      PublicAccessBlockConfiguration:
-        BlockPublicAcls: true
-        BlockPublicPolicy: true
-        IgnorePublicAcls: true
-        RestrictPublicBuckets: true
-
   RegistryBucket:
     Type: AWS::S3::Bucket
     DeletionPolicy: Retain
@@ -330,16 +300,12 @@ Resources:
                   - s3:PutObject
                 Resource:
                   - !Sub "${ArtifactBucket.Arn}/*"
-                  - !Sub "${CacheBucket.Arn}/*"
-                  - !Sub "${XcodeCacheBucket.Arn}/*"
                   - !Sub "${RegistryBucket.Arn}/*"
               - Effect: Allow
                 Action:
                   - s3:ListBucket
                 Resource:
                   - !GetAtt ArtifactBucket.Arn
-                  - !GetAtt CacheBucket.Arn
-                  - !GetAtt XcodeCacheBucket.Arn
                   - !GetAtt RegistryBucket.Arn
 
   TuistNamespace:
@@ -401,11 +367,6 @@ Resources:
 
             cache:
               enabled: false
-              s3:
-                region: "${AWS::Region}"
-                bucket: "${CacheBucketName}"
-                xcodeCacheBucket: "${XcodeCacheBucketName}"
-                registryBucket: "${RegistryBucketName}"
 
             processor:
               enabled: false
@@ -449,8 +410,8 @@ Resources:
                 region: "${AWS::Region}"
                 buckets:
                   default: "${ArtifactBucketName}"
-                  cache: "${CacheBucketName}"
-                  xcodeCache: "${XcodeCacheBucketName}"
+                  cache: "${ArtifactBucketName}"
+                  xcodeCache: "${ArtifactBucketName}"
                   registry: "${RegistryBucketName}"
 
             observability:
@@ -459,8 +420,6 @@ Resources:
             DatabaseHost: !GetAtt TuistDatabase.Endpoint.Address
             DatabasePort: !GetAtt TuistDatabase.Endpoint.Port
             ArtifactBucketName: !Ref ArtifactBucket
-            CacheBucketName: !Ref CacheBucket
-            XcodeCacheBucketName: !Ref XcodeCacheBucket
             RegistryBucketName: !Ref RegistryBucket
 
 Outputs:
@@ -479,14 +438,6 @@ Outputs:
   ArtifactBucketName:
     Description: S3 bucket used for Tuist artifacts.
     Value: !Ref ArtifactBucket
-
-  CacheBucketName:
-    Description: S3 bucket reserved for cache artifacts.
-    Value: !Ref CacheBucket
-
-  XcodeCacheBucketName:
-    Description: S3 bucket reserved for Xcode cache artifacts.
-    Value: !Ref XcodeCacheBucket
 
   RegistryBucketName:
     Description: S3 bucket reserved for registry artifacts.

--- a/infra/aws-marketplace/helm/values-existing-eks.yaml
+++ b/infra/aws-marketplace/helm/values-existing-eks.yaml
@@ -31,11 +31,6 @@ server:
 
 cache:
   enabled: false
-  s3:
-    region: us-east-1
-    bucket: tuist-cache-example
-    xcodeCacheBucket: tuist-xcode-cache-example
-    registryBucket: tuist-registry-example
 
 processor:
   enabled: false
@@ -79,8 +74,8 @@ objectStorage:
     region: us-east-1
     buckets:
       default: tuist-artifacts-example
-      cache: tuist-cache-example
-      xcodeCache: tuist-xcode-cache-example
+      cache: tuist-artifacts-example
+      xcodeCache: tuist-artifacts-example
       registry: tuist-registry-example
 
 observability:

--- a/infra/aws-marketplace/helm/values-existing-eks.yaml
+++ b/infra/aws-marketplace/helm/values-existing-eks.yaml
@@ -1,0 +1,87 @@
+global:
+  commonLabels:
+    tuist.dev/distribution: aws-marketplace
+
+server:
+  replicaCount: 1
+  appUrl: https://tuist.example.com
+  hosted: false
+  skipEmailConfirmation: true
+  database:
+    ssl: true
+  service:
+    type: LoadBalancer
+    port: 80
+    targetPort: 8080
+  s3:
+    region: us-east-1
+    bucketName: tuist-artifacts-example
+    virtualHost: false
+    bucketAsHost: false
+  serviceAccount:
+    create: true
+    name: tuist-server
+    annotations:
+      eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/tuist-server-s3
+  extraEnv:
+    - name: TUIST_S3_AUTHENTICATION_METHOD
+      value: aws_web_identity_token_from_env_vars
+  license:
+    key: REPLACE_WITH_TUIST_LICENSE
+
+cache:
+  enabled: false
+  s3:
+    region: us-east-1
+    bucket: tuist-cache-example
+    xcodeCacheBucket: tuist-xcode-cache-example
+    registryBucket: tuist-registry-example
+
+processor:
+  enabled: false
+
+xcresultProcessor:
+  enabled: false
+
+runnersFleet:
+  enabled: false
+
+runnersFleetLinux:
+  enabled: false
+
+kuraController:
+  enabled: false
+
+capi:
+  enabled: false
+
+postgresql:
+  mode: external
+  external:
+    host: tuist-postgres.example.com
+    port: 5432
+    database: tuist
+    username: tuist
+    password: REPLACE_WITH_DATABASE_PASSWORD
+
+clickhouse:
+  mode: embedded
+  embedded:
+    persistence:
+      size: 100Gi
+
+objectStorage:
+  mode: external
+  external:
+    endpoint: https://s3.us-east-1.amazonaws.com
+    accessKey: ""
+    secretKey: ""
+    region: us-east-1
+    buckets:
+      default: tuist-artifacts-example
+      cache: tuist-cache-example
+      xcodeCache: tuist-xcode-cache-example
+      registry: tuist-registry-example
+
+observability:
+  enabled: false

--- a/infra/helm/tuist/templates/app-secrets.yaml
+++ b/infra/helm/tuist/templates/app-secrets.yaml
@@ -22,8 +22,10 @@ metadata:
 type: Opaque
 stringData:
   server-secret-key-base: {{ .Values.server.secretKeyBase | default (get $existingData "server-secret-key-base" | default "" | b64dec) | default (randAlphaNum 64) | quote }}
+  {{- if .Values.cache.enabled }}
   cache-secret-key-base: {{ .Values.cache.secretKeyBase | default (get $existingData "cache-secret-key-base" | default "" | b64dec) | default (randAlphaNum 64) | quote }}
   cache-guardian-secret-key: {{ .Values.cache.guardianSecretKey | default (get $existingData "cache-guardian-secret-key" | default "" | b64dec) | default (randAlphaNum 64) | quote }}
+  {{- end }}
   postgres-password: {{ ternary .Values.postgresql.embedded.password .Values.postgresql.external.password (eq .Values.postgresql.mode "embedded") | quote }}
   object-storage-access-key: {{ include "tuist.objectStorageAccessKey" . | quote }}
   object-storage-secret-key: {{ include "tuist.objectStorageSecretKey" . | quote }}

--- a/infra/helm/tuist/templates/server-deployment.yaml
+++ b/infra/helm/tuist/templates/server-deployment.yaml
@@ -243,11 +243,11 @@ spec:
             {{- if .Values.cache.enabled }}
             - name: TUIST_CACHE_ENDPOINTS
               value: {{ .Values.server.cacheEndpointUrl | default (printf "http://%s:%v" (include "tuist.componentName" (dict "root" . "component" "cache")) .Values.cache.service.port) | quote }}
-            {{- end }}
             - name: TUIST_CACHE_S3_BUCKET_NAME
               value: {{ .Values.cache.s3.bucket | quote }}
             - name: TUIST_CACHE_XCODE_S3_BUCKET_NAME
               value: {{ .Values.cache.s3.xcodeCacheBucket | quote }}
+            {{- end }}
             {{- with .Values.server.kuraEndpointUrls }}
             - name: TUIST_KURA_ENDPOINTS
               value: {{ join "," . | quote }}


### PR DESCRIPTION
Resolves N/A

Adds the first AWS Marketplace one-click deployment milestone for buyer-owned Tuist installs. The new `infra/aws-marketplace` directory contains an existing-EKS CloudFormation template that provisions RDS Postgres, S3 buckets for Tuist artifacts and registry artifacts, IRSA, a Kubernetes namespace, and a Tuist Helm install, plus an AWS-specific Helm values overlay.

Documents the Marketplace packaging boundary, existing-EKS prerequisites, remaining readiness gaps before public submission, and the CI validation contract. The new AWS Marketplace workflow validates the CloudFormation template and Helm overlay offline, with an optional AWS `validate-template` job gated by `AWS_MARKETPLACE_VALIDATE_ROLE_ARN`.

The deprecated cache service is explicitly disabled in the Marketplace overlay. Its cache/Xcode cache buckets, IAM grants, outputs, and server env wiring are not part of the Marketplace graph; Kura cache nodes should be modeled separately from this legacy cache-service path.

### How to test locally

- `yq '.' .github/workflows/aws-marketplace.yml >/dev/null && yq '.' infra/aws-marketplace/cloudformation/tuist-existing-eks.yaml >/dev/null`
- `$HOME/Library/Python/3.9/bin/cfn-lint --non-zero-exit-code error --ignore-checks E3006 W1011 --regions us-east-1 --template infra/aws-marketplace/cloudformation/tuist-existing-eks.yaml`
- `helm lint infra/helm/tuist -f infra/aws-marketplace/helm/values-existing-eks.yaml`
- `helm lint infra/helm/tuist -f infra/helm/tuist/values-ci.yaml && helm template tuist infra/helm/tuist -f infra/helm/tuist/values-ci.yaml >/tmp/tuist-ci-rendered.yaml`
- `helm template tuist infra/helm/tuist -f infra/aws-marketplace/helm/values-existing-eks.yaml >/tmp/tuist-aws-marketplace-rendered.yaml && /tmp/kubeconform -strict -ignore-missing-schemas -summary -schema-location default -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json' /tmp/tuist-aws-marketplace-rendered.yaml`
- Attempted `AWS_REGION=us-east-1 aws cloudformation validate-template --template-body file://infra/aws-marketplace/cloudformation/tuist-existing-eks.yaml`, but local AWS credentials are not configured.
