### PR TITLE
fix(cli): preserve active session logs during cleanup

### DIFF
--- a/cli/Sources/TuistKit/Utils/SessionController.swift
+++ b/cli/Sources/TuistKit/Utils/SessionController.swift
@@ -5,6 +5,12 @@ import TuistEnvironment
 import TuistLogging
 import TuistSupport
 
+#if canImport(Glibc)
+    import Glibc
+#elseif canImport(Darwin)
+    import Darwin
+#endif
+
 /// Manages CLI session directories containing logs and network recordings.
 ///
 /// Session directories are stored at `$XDG_STATE_HOME/tuist/sessions/<UUID>/`
@@ -12,6 +18,10 @@ import TuistSupport
 /// - `logs.txt`: The text log file for the session
 /// - `network.har`: HTTP Archive file containing all network requests/responses
 public struct SessionController {
+    static let defaultMaxSessions = 50
+    static let maxSessionsEnvironmentVariable = "TUIST_SESSION_MAX_SESSIONS"
+    static let processIdentifierFileName = "process.pid"
+
     private let fileSystem: FileSystem
 
     public init(fileSystem: FileSystem = FileSystem()) {
@@ -44,8 +54,9 @@ public struct SessionController {
 
     /// Schedules best-effort cleanup of old session directories.
     public func scheduleMaintenance(stateDirectory: AbsolutePath) {
+        let maxSessions = Self.maxSessions(environment: Environment.current)
         Task.detached(priority: .background) { [fileSystem] in
-            try? await Self.clean(fileSystem: fileSystem, stateDirectory: stateDirectory)
+            try? await Self.clean(fileSystem: fileSystem, stateDirectory: stateDirectory, maxSessions: maxSessions)
         }
     }
 
@@ -68,6 +79,10 @@ public struct SessionController {
         let logFilePath = sessionDirectory.appending(component: "logs.txt")
         let networkFilePath = sessionDirectory.appending(component: "network.har")
 
+        try await fileSystem.writeText(
+            "\(ProcessInfo.processInfo.processIdentifier)",
+            at: sessionDirectory.appending(component: Self.processIdentifierFileName)
+        )
         try await fileSystem.touch(logFilePath)
 
         return SessionPaths(
@@ -87,34 +102,74 @@ public struct SessionController {
         fileSystem: FileSystem,
         stateDirectory: AbsolutePath,
         maxAge: TimeInterval = 5 * 24 * 60 * 60,
-        maxSessions: Int = 50
+        maxSessions: Int = Self.defaultMaxSessions
     ) async throws {
         let sessionsDirectory = stateDirectory.appending(component: "sessions")
         guard try await fileSystem.exists(sessionsDirectory) else { return }
 
         let cutoffDate = Date().addingTimeInterval(-maxAge)
 
-        var sessionsWithDates: [(path: AbsolutePath, creationDate: Date)] = []
+        var inactiveSessionsWithDates: [(path: AbsolutePath, creationDate: Date)] = []
 
         for sessionPath in try await fileSystem.glob(directory: sessionsDirectory, include: ["*"]).collect() {
-            guard let creationDate = try FileManager.default.attributesOfItem(
-                atPath: sessionPath.pathString
-            )[.creationDate] as? Date else { continue }
+            guard let creationDate = creationDate(for: sessionPath) else { continue }
 
-            if creationDate < cutoffDate {
-                try await fileSystem.remove(sessionPath)
+            if await isSessionActive(sessionPath, fileSystem: fileSystem) {
+                continue
+            } else if creationDate < cutoffDate {
+                try? await fileSystem.remove(sessionPath)
             } else {
-                sessionsWithDates.append((path: sessionPath, creationDate: creationDate))
+                inactiveSessionsWithDates.append((path: sessionPath, creationDate: creationDate))
             }
         }
 
-        if sessionsWithDates.count > maxSessions {
-            sessionsWithDates.sort { $0.creationDate > $1.creationDate }
-            let sessionsToRemove = sessionsWithDates.dropFirst(maxSessions)
+        if inactiveSessionsWithDates.count > maxSessions {
+            inactiveSessionsWithDates.sort { $0.creationDate > $1.creationDate }
+            let sessionsToRemove = inactiveSessionsWithDates.dropFirst(maxSessions)
             for session in sessionsToRemove {
-                try await fileSystem.remove(session.path)
+                try? await fileSystem.remove(session.path)
             }
         }
+    }
+
+    private static func creationDate(for sessionPath: AbsolutePath) -> Date? {
+        let attributes = try? FileManager.default.attributesOfItem(atPath: sessionPath.pathString)
+        return attributes?[.creationDate] as? Date
+    }
+
+    static func maxSessions(environment: Environmenting) -> Int {
+        guard let value = environment.variables[maxSessionsEnvironmentVariable],
+              let maxSessions = Int(value),
+              maxSessions > 0
+        else {
+            return defaultMaxSessions
+        }
+
+        return maxSessions
+    }
+
+    private static func isSessionActive(_ sessionPath: AbsolutePath, fileSystem: FileSystem) async -> Bool {
+        let processIdentifierPath = sessionPath.appending(component: processIdentifierFileName)
+        guard let processIdentifierString = try? await fileSystem.readTextFile(at: processIdentifierPath)
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+            let processIdentifier = Int32(processIdentifierString)
+        else {
+            return false
+        }
+
+        return isProcessRunning(processIdentifier)
+    }
+
+    private static func isProcessRunning(_ processIdentifier: Int32) -> Bool {
+        #if canImport(Glibc) || canImport(Darwin)
+            if kill(processIdentifier, 0) == 0 {
+                return true
+            }
+
+            return errno == EPERM
+        #else
+            return false
+        #endif
     }
 }
 

--- a/cli/Tests/TuistKitTests/Utils/SessionControllerTests.swift
+++ b/cli/Tests/TuistKitTests/Utils/SessionControllerTests.swift
@@ -3,6 +3,8 @@ import FileSystemTesting
 import Foundation
 import Path
 import Testing
+import TuistEnvironment
+import TuistEnvironmentTesting
 @testable import TuistKit
 
 struct SessionControllerTests {
@@ -19,6 +21,11 @@ struct SessionControllerTests {
         // Then
         #expect(try await fileSystem.exists(sessionPaths.sessionDirectory))
         #expect(try await fileSystem.exists(sessionPaths.logFilePath))
+        #expect(
+            try await fileSystem.exists(
+                sessionPaths.sessionDirectory.appending(component: SessionController.processIdentifierFileName)
+            )
+        )
         #expect(sessionPaths.logFilePath.pathString.hasSuffix("logs.txt"))
         #expect(sessionPaths.networkFilePath.pathString.hasSuffix("network.har"))
     }
@@ -77,5 +84,73 @@ struct SessionControllerTests {
         // Then: Only 50 sessions should remain
         let sessions = try await fileSystem.glob(directory: sessionsDirectory, include: ["*"]).collect()
         #expect(sessions.count == 50)
+    }
+
+    @Test(.inTemporaryDirectory)
+    func clean_doesNotRemoveActiveSessionsWhenLimitingMaxSessions() async throws {
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+
+        let sessionsDirectory = temporaryDirectory.appending(component: "sessions")
+        try await fileSystem.makeDirectory(at: sessionsDirectory)
+
+        let activeSessionDirectory = sessionsDirectory.appending(component: UUID().uuidString)
+
+        for i in 0 ..< 55 {
+            let sessionDirectory = i == 54 ? activeSessionDirectory : sessionsDirectory.appending(component: UUID().uuidString)
+            try await fileSystem.makeDirectory(at: sessionDirectory)
+            try await fileSystem.touch(sessionDirectory.appending(component: "logs.txt"))
+
+            let date = Calendar.current.date(byAdding: .hour, value: -i, to: Date())!
+            try FileManager.default.setAttributes(
+                [FileAttributeKey.creationDate: date],
+                ofItemAtPath: sessionDirectory.pathString
+            )
+        }
+
+        try await fileSystem.writeText(
+            "\(ProcessInfo.processInfo.processIdentifier)",
+            at: activeSessionDirectory.appending(component: SessionController.processIdentifierFileName)
+        )
+
+        try await SessionController.clean(fileSystem: fileSystem, stateDirectory: temporaryDirectory)
+
+        let sessions = try await fileSystem.glob(directory: sessionsDirectory, include: ["*"]).collect()
+        #expect(try await fileSystem.exists(activeSessionDirectory))
+        #expect(sessions.count == 51)
+    }
+
+    @Test(.inTemporaryDirectory)
+    func clean_ignoresSessionsWithUnreadableAttributes() async throws {
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+
+        let sessionsDirectory = temporaryDirectory.appending(component: "sessions")
+        try await fileSystem.makeDirectory(at: sessionsDirectory)
+
+        let staleSessionPath = sessionsDirectory.appending(component: UUID().uuidString)
+        try FileManager.default.createSymbolicLink(
+            atPath: staleSessionPath.pathString,
+            withDestinationPath: temporaryDirectory.appending(component: "missing").pathString
+        )
+
+        try await SessionController.clean(fileSystem: fileSystem, stateDirectory: temporaryDirectory)
+    }
+
+    @Test(.withMockedEnvironment())
+    func maxSessions_usesEnvironmentOverride() async throws {
+        let environment = try #require(Environment.mocked)
+        environment.variables[SessionController.maxSessionsEnvironmentVariable] = "75"
+
+        #expect(SessionController.maxSessions(environment: Environment.current) == 75)
+    }
+
+    @Test(.withMockedEnvironment())
+    func maxSessions_ignoresInvalidEnvironmentOverride() async throws {
+        let environment = try #require(Environment.mocked)
+
+        for value in ["", "0", "-1", "abc"] {
+            environment.variables[SessionController.maxSessionsEnvironmentVariable] = value
+
+            #expect(SessionController.maxSessions(environment: Environment.current) == SessionController.defaultMaxSessions)
+        }
     }
 }

--- a/server/priv/docs/en/cli/debugging.md
+++ b/server/priv/docs/en/cli/debugging.md
@@ -37,7 +37,7 @@ The HAR file records all HTTP requests and responses made during the session, wh
 
 By default, the CLI outputs the session path when the execution exits unexpectedly. If it doesn't, you can find the session data in the path mentioned above (i.e., the most recent session directory).
 
-Session directories older than 5 days are automatically cleaned up.
+Session directories older than 5 days are automatically cleaned up. Tuist also keeps at most 50 inactive session directories by default, while preserving sessions owned by currently running Tuist processes. In CI environments that run many Tuist commands with the same state directory, you can raise the inactive-session cap with `TUIST_SESSION_MAX_SESSIONS`, for example `TUIST_SESSION_MAX_SESSIONS=200`. Invalid values, zero, and negative values are ignored and Tuist falls back to the default of 50.
 
 ### Continuous integration {#diagnose-issues-using-logs-ci}
 

--- a/server/priv/docs/en/cli/directories.md
+++ b/server/priv/docs/en/cli/directories.md
@@ -73,7 +73,7 @@ tuist cache
 **Default:** `~/.local/state/tuist`
 
 **Used for:**
-- **Logs**: Log files (`logs/{uuid}.log`)
+- **Sessions**: Session logs and network recordings (`sessions/{uuid}/`)
 - **Locks**: Authentication lock files (`{handle}.sock`)
 
 **Example:**


### PR DESCRIPTION
Resolves no tracked issue.

Prevents session maintenance from deleting a session directory while the owning CLI process is still running. Each session now writes its owner process identifier to `process.pid`, and cleanup skips sessions whose owner process is alive before applying age and max-session pruning.

This can happen when multiple `tuist` invocations share the same `$XDG_STATE_HOME/tuist/sessions` directory, which is common in CI jobs that run several Tuist commands in the same workspace or user account. Each invocation schedules detached session cleanup after setup. Before this change, cleanup treated every session as removable based only on creation date and the global session limit. A long-running command could be one of the oldest sessions while newer commands were created, so another process could remove that active session directory. When the long-running command later tried to finish rendering Noora output through its `logs.txt`, the file path was gone and the thrown file error escaped through `swift_errorInMain`.

The analytics upload path was checked because the crash happens after run metadata is printed. `AnalyticsArtifactUploadService` zips a copied staging directory and does not remove the live session directory, so the root issue is session cleanup not knowing which sessions are still active. Keeping the logger strict is intentional here: if session setup fails for another reason, that error should still be visible instead of being hidden behind a fallback.

Cleanup itself remains best-effort. If a session disappears while maintenance is scanning, if its attributes cannot be read, or if a removal loses a filesystem race, cleanup skips that entry instead of letting the maintenance task fail.

The inactive-session retention cap remains 50 by default and can be raised with `TUIST_SESSION_MAX_SESSIONS`. Invalid values, zero, and negative values fall back to the default. The CLI debugging and directories docs now describe the session directory layout and the environment override.

### How to test locally

- `mise run cli:lint --fix`
- `tuist generate tuist TuistKit TuistKitTests --no-open`
- `xcodebuild test -workspace Tuist.xcworkspace -scheme Tuist-Workspace -only-testing TuistKitTests/SessionControllerTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""`
- `xcodebuild build -workspace Tuist.xcworkspace -scheme tuist CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""`
- `git diff --check`
