### PR TITLE
ci(infra): build the cache image on tuist-linux-large to stop runner OOM

### DIFF
--- a/.github/workflows/cache-deploy.yml
+++ b/.github/workflows/cache-deploy.yml
@@ -27,7 +27,8 @@ env:
 
 jobs:
   deploy-canary:
-    runs-on: tuist-linux
+    # kamal deploy builds the Elixir release image locally; the 2/8 default shape OOMs.
+    runs-on: tuist-linux-large
     timeout-minutes: 30
     environment: cache-canary
     steps:
@@ -48,7 +49,8 @@ jobs:
         run: |
           mise run deploy canary
   deploy-production:
-    runs-on: tuist-linux
+    # kamal deploy builds the Elixir release image locally; the 2/8 default shape OOMs.
+    runs-on: tuist-linux-large
     timeout-minutes: 30
     needs: deploy-canary
     if: ${{ needs.deploy-canary.result == 'success' }}

--- a/.github/workflows/cache-staging-deploy.yml
+++ b/.github/workflows/cache-staging-deploy.yml
@@ -20,7 +20,8 @@ env:
 
 jobs:
   deploy:
-    runs-on: tuist-linux
+    # kamal deploy builds the Elixir release image locally; the 2/8 default shape OOMs.
+    runs-on: tuist-linux-large
     timeout-minutes: 30
     environment: cache-staging
     steps:


### PR DESCRIPTION
## What changed

Pin the cache deploy jobs that build the Docker image locally to `tuist-linux-large`:

- `cache-deploy.yml` — `deploy-canary` and `deploy-production`
- `cache-staging-deploy.yml` — `deploy`

`cache.yml` CI jobs stay on `tuist-linux` (see validation below).

## Why

Cache Deploy has failed on **every run since [#11057](https://github.com/tuist/tuist/pull/11057)** with:

> The self-hosted runner lost communication with the server.

That annotation is the generic GitHub symptom for *anything* that kills the runner agent — here it's an out-of-memory kill, not a network problem.

## Root cause

[#11057](https://github.com/tuist/tuist/pull/11057) ("consolidate movable CI jobs onto the in-house tuist-linux fleet") moved the cache deploy jobs from `namespace-profile-default` to `runs-on: tuist-linux` — the in-house default profile that [#11052](https://github.com/tuist/tuist/pull/11052) had just sized to **2 vCPU / 8 GB**.

`mise run deploy <env>` runs `kamal deploy`, and the Kamal builder in `cache/config/deploy.yml` has **no `remote:` directive**, so the Elixir/Phoenix cache release image is compiled **locally on the runner**. That compile peaks above 8 GB, the kernel OOM-kills the runner agent mid-build, and GitHub reports the lost-communication error. The dying step ("Deploy with Kamal") produced essentially no log output before the agent was killed — consistent with an abrupt OOM rather than a clean failure.

#11052 had even added a `# kamal deploy builds the image locally` comment as a warning; #11057 dropped it while flipping the label.

## Why `tuist-linux-large` (and not just keep everything on `tuist-linux`)

The differentiator is build memory footprint, not the runner fleet itself:

- The server deploys and image builds that compile Elixir releases already run on `tuist-linux-large` for exactly this reason.
- A cross-check confirms the fleet is healthy: the `kura-controller-image` (a lightweight Go binary) builds fine on `tuist-linux`. Only the heavy Elixir release compile blows the 8 GB ceiling.

## Validation

- Failure timeline: green on the run immediately before #11057; #11057's own push (run 26895464566) was the first failure; every Cache Deploy since (incl. run 26952134701) failed with the same annotation.
- Confirmed `cache.yml` CI does **not** need the larger shape: the most recent push run after #11057 passed all jobs on `tuist-linux`, including the heaviest one, `Compile (prod)` (`MIX_ENV=prod mix compile`, ~658s). Those jobs are left on `tuist-linux`.
- The two `cache.yml` runs from today that looked red were `queued`, not failed.

## Impact

Restores cache canary + production deploys (production was never even reaching its job, since it is gated on canary succeeding) and the staging deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)