### PR TITLE
feat(server): Prefer ready Kura cache endpoints

### DIFF
--- a/server/lib/tuist/accounts.ex
+++ b/server/lib/tuist/accounts.ex
@@ -1937,7 +1937,12 @@ defmodule Tuist.Accounts do
   @doc """
   Returns cache endpoint URLs for the given account handle and cache technology.
 
-  For the default cache technology, custom endpoints are only returned when:
+  For the default cache technology, ready account Kura endpoints are preferred when
+  present. Kura servers mirror their public URL into `account_cache_endpoints` only
+  after the public endpoint is ready, so clients do not need a feature flag once
+  an account has an available server.
+
+  When there is no ready account Kura endpoint, custom endpoints are only returned when:
   - The account exists
   - The account is on the enterprise plan when Tuist-hosted
   - The account has `custom_cache_endpoints_enabled` set to `true`
@@ -1950,12 +1955,23 @@ defmodule Tuist.Accounts do
 
   def get_cache_endpoints_for_handle(account_handle, :default) when is_binary(account_handle) do
     if Environment.tuist_hosted?() do
-      account_handle
-      |> get_account_by_handle()
-      |> custom_cache_endpoints()
-      |> case do
-        [] -> CacheEndpoints.active_endpoint_urls()
-        endpoints -> Enum.map(endpoints, & &1.url)
+      case get_account_by_handle(account_handle) do
+        %Account{} = account ->
+          case kura_cache_endpoint_urls(account) do
+            [] ->
+              account
+              |> custom_cache_endpoints()
+              |> case do
+                [] -> CacheEndpoints.active_endpoint_urls()
+                endpoints -> Enum.map(endpoints, & &1.url)
+              end
+
+            endpoints ->
+              endpoints
+          end
+
+        _ ->
+          CacheEndpoints.active_endpoint_urls()
       end
     else
       CacheEndpoints.active_endpoint_urls()

--- a/server/test/tuist/accounts_test.exs
+++ b/server/test/tuist/accounts_test.exs
@@ -4039,6 +4039,32 @@ defmodule Tuist.AccountsTest do
       assert Enum.sort(endpoints) == Enum.sort(["https://cache1.example.com", "https://cache2.example.com"])
     end
 
+    test "returns account Kura endpoints by default when the account has ready Kura endpoints" do
+      # Given
+      stub(Environment, :tuist_hosted?, fn -> true end)
+      user = AccountsFixtures.user_fixture()
+      account = Accounts.get_account_from_user(user)
+      BillingFixtures.subscription_fixture(account_id: account.id, plan: :enterprise)
+      {:ok, account} = Accounts.update_account(account, %{custom_cache_endpoints_enabled: true})
+
+      {:ok, _} = Accounts.create_account_cache_endpoint(account, %{url: "https://custom-cache.example.com"})
+
+      {:ok, _} =
+        Accounts.create_account_cache_endpoint(account, %{
+          url: "https://kura-cache.example.com",
+          technology: :kura
+        })
+
+      default_endpoints = ["https://default.tuist.dev"]
+      stub(Environment, :cache_endpoints, fn -> default_endpoints end)
+
+      # When
+      endpoints = Accounts.get_cache_endpoints_for_handle(account.name)
+
+      # Then
+      assert endpoints == ["https://kura-cache.example.com"]
+    end
+
     test "returns default endpoints when account has no custom endpoints" do
       # Given
       stub(Environment, :tuist_hosted?, fn -> true end)

--- a/server/test/tuist_web/controllers/api/cache_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/cache_controller_test.exs
@@ -137,6 +137,37 @@ defmodule TuistWeb.API.CacheControllerTest do
                ])
     end
 
+    test "returns ready account Kura endpoints without the Kura feature flag", %{conn: conn} do
+      # Given
+      stub(Tuist.Environment, :tuist_hosted?, fn -> true end)
+      user = AccountsFixtures.user_fixture()
+      account = Accounts.get_account_from_user(user)
+      BillingFixtures.subscription_fixture(account_id: account.id, plan: :enterprise)
+      {:ok, account} = Accounts.update_account(account, %{custom_cache_endpoints_enabled: true})
+
+      {:ok, _} =
+        Accounts.create_account_cache_endpoint(account, %{
+          url: "https://custom-cache.example.com"
+        })
+
+      {:ok, _} =
+        Accounts.create_account_cache_endpoint(account, %{
+          url: "https://kura-cache.example.com",
+          technology: :kura
+        })
+
+      stub(Tuist.Environment, :cache_endpoints, fn -> ["https://default-cache.example.com"] end)
+
+      conn = Authentication.put_current_user(conn, user)
+
+      # When
+      conn = get(conn, ~p"/api/cache/endpoints?account_handle=#{account.name}")
+
+      # Then
+      response = json_response(conn, 200)
+      assert response["endpoints"] == ["https://kura-cache.example.com"]
+    end
+
     test "returns default endpoints when account_handle does not exist",
          %{conn: conn} do
       # Given


### PR DESCRIPTION
Resolves the cache endpoint selection issue where accounts with ready Kura servers still needed client opt-in.

Prefer ready account Kura cache endpoints in the default cache endpoint resolution path. The readiness signal is the existing Kura endpoint mirror in `account_cache_endpoints`, which is only populated after the Kura server endpoint is available. If an account has no ready Kura endpoint, the previous custom endpoint and default endpoint fallback behavior is preserved.

This lets Xcode cache clients move to Kura automatically once the account has a ready Kura server, instead of continuing to use the legacy cache servers until they send the `kura` feature flag.

### How to test locally

- `mix format --check-formatted lib/tuist/accounts.ex test/tuist/accounts_test.exs test/tuist_web/controllers/api/cache_controller_test.exs`
- `mix test test/tuist/accounts_test.exs:4042 test/tuist_web/controllers/api/cache_controller_test.exs:140`
