### PR TITLE
feat(infra): rank queued load above idle warm floors in runner fleet allocation

### DIFF
--- a/infra/helm/tuist/crds/tuist.dev_runnerpools.yaml
+++ b/infra/helm/tuist/crds/tuist.dev_runnerpools.yaml
@@ -131,10 +131,17 @@ spec:
                       default: 1
                       minimum: 0
                       description: |
-                        Lower bound for the warm pool size. The server-side
-                        rolling p95 of concurrent claims over the last hour
-                        can lift the effective floor higher; this value
-                        only floors it, never caps it.
+                        Preferred lower bound (target) for the warm pool
+                        size. The server-side rolling p95 of concurrent
+                        claims over the last hour can lift the effective
+                        target higher. Not a hard floor: in a shared Linux
+                        fleet (multiple shape pools bin-packing on one
+                        bare-metal node pool), the allocator can squeeze an
+                        idle pool's desired below this value under memory
+                        contention to admit another shape's real queued
+                        work. macOS and uncontended pools honor it as a
+                        floor; real load (claimed + queued) is always funded
+                        above it.
                     maxReplicas:
                       type: integer
                       default: 0

--- a/infra/runners-controller/AGENTS.md
+++ b/infra/runners-controller/AGENTS.md
@@ -25,23 +25,30 @@ independent workqueues:
   `RunnerPool` spec, so a tuning change is helm-only.
 
   **Fleet-capacity awareness (Linux).** Linux shape pools share one
-  bare-metal node pool, so their speculative warm headroom competes for
-  the same memory. For `os: linux` pools the reconciler runs the
-  per-pool target through `internal/scaling/allocate.go`'s
-  `AllocateFleet`, a three-tier waterfall over the pools sharing a
-  `FleetSelector`: (1) every pool's `minWarmPoolFloor`, (2) real load
-  (`claimed + queued`), then (3) the speculative p95 buffer from
-  whatever memory is left. Tiers 1+2 are always honored (excess goes
-  Pending — the "add a host" signal); tier 3 is squeezed under
-  contention, so an idle shape's warm Pods fall back toward its floor to
-  admit another shape's real queued work. Memory is the only dimension
-  (kata pins it per microVM; CPU is oversubscribed). Fleet allocatable
-  is summed from nodes labeled `node.cluster.x-k8s.io/pool=<FleetSelector>`
-  (cluster-scoped `nodes` read in the ClusterRole), scaled by
-  `MemReserveFraction` (default 0.9). Any failure gathering the fleet
-  view falls back to the per-pool target — a node-read blip must never
-  trigger a mass scale-down. macOS pools (one VM per host, no
-  bin-packing) keep the plain per-pool path.
+  bare-metal node pool, so their warm capacity competes for the same
+  memory. For `os: linux` pools the reconciler runs the per-pool target
+  through `internal/scaling/allocate.go`'s `AllocateFleet`, a three-tier
+  priority allocation over the pools sharing a `FleetSelector`:
+  (1) real load (`claimed + queued`), (2) each pool's `minWarmPoolFloor`
+  above its load, then (3) the speculative p95 buffer above that. Only
+  tier 1 (real load) is inviolable — granted in full even past capacity,
+  with the excess going Pending (the "add a host" signal). Tiers 2+3 are
+  idle warm capacity and yield under contention — headroom first, then
+  floor — to admit another shape's real queued work. So when a starved
+  shape has queued jobs that don't fit, an idle shape's warm Pods are
+  reaped (its desired drops *below* its floor) to free the memory, rather
+  than leaving the queued jobs Pending while idle Pods hold reservations.
+  The tradeoff: under sustained load on one shape, other shapes' warm
+  pools shrink toward their real load, so a returning spike pays
+  cold-start — a job queued now beats a warm Pod for a job that might
+  arrive, and the scale-down cooldown damps the reap. Memory is the only
+  dimension (kata pins it per microVM; CPU is oversubscribed). Fleet
+  allocatable is summed from nodes labeled
+  `node.cluster.x-k8s.io/pool=<FleetSelector>` (cluster-scoped `nodes`
+  read in the ClusterRole), scaled by `MemReserveFraction` (default 0.9).
+  Any failure gathering the fleet view falls back to the per-pool target
+  — a node-read blip must never trigger a mass scale-down. macOS pools
+  (one VM per host, no bin-packing) keep the plain per-pool path.
 
   Pod-level autoscaling only — bare-metal Host count is operator-
   managed via the CAPI cluster topology, since Hetzner Robot hosts

--- a/infra/runners-controller/api/v1alpha1/runnerpool_types.go
+++ b/infra/runners-controller/api/v1alpha1/runnerpool_types.go
@@ -115,10 +115,15 @@ type RunnerPoolAutoscaling struct {
 	// +optional
 	Enabled bool `json:"enabled,omitempty"`
 
-	// MinWarmPoolFloor is the lower bound for the desired warm
-	// pool size. The server's rolling p95 of concurrent claims
-	// can lift the effective floor higher; this value only floors
-	// the floor.
+	// MinWarmPoolFloor is the preferred lower bound (target) for the
+	// desired warm pool size; the server's rolling p95 of concurrent
+	// claims can lift the effective target higher. It is a target, not
+	// a hard floor: in a shared Linux fleet (multiple shape pools
+	// bin-packing on one bare-metal node pool), the fleet allocator can
+	// squeeze an idle pool's desired below this value under memory
+	// contention to admit another shape's real queued work. macOS pools
+	// and uncontended Linux pools honor it as a floor; real load
+	// (claimed + queued) is always funded above it.
 	// +optional
 	MinWarmPoolFloor int32 `json:"minWarmPoolFloor,omitempty"`
 

--- a/infra/runners-controller/controllers/autoscaler_controller.go
+++ b/infra/runners-controller/controllers/autoscaler_controller.go
@@ -210,6 +210,14 @@ func (r *AutoscalerReconciler) desiredForPool(
 	}
 
 	fleetMem, err := r.fleetAllocatableMemory(ctx, pool.Spec.FleetSelector)
+	// fleetMem <= 0 is treated like an error on purpose. A zero sum is
+	// almost always a transient empty node-list read (informer cache
+	// blip, or no Ready nodes mid-roll), not a genuine "fleet has no
+	// memory" state. Routing it into AllocateFleet would squeeze every
+	// pool's floor to zero and reap their warm Pods fleet-wide, the exact
+	// blip-driven mass scale-down this per-pool fallback exists to
+	// prevent. AllocateFleet's own zero-capacity contract (see its unit
+	// test) is therefore never exercised from here.
 	if err != nil || fleetMem <= 0 {
 		logger.Error(err, "read fleet allocatable memory; falling back to per-pool target",
 			"fleetSelector", pool.Spec.FleetSelector)

--- a/infra/runners-controller/internal/scaling/allocate.go
+++ b/infra/runners-controller/internal/scaling/allocate.go
@@ -27,90 +27,132 @@ type PoolDemand struct {
 }
 
 // AllocateFleet distributes `fleetMemBytes` of schedulable memory
-// across pools sharing a bare-metal node pool, in three tiers:
+// across pools sharing a bare-metal node pool, in three priority tiers:
 //
-//  1. Floor — every pool's `minWarmPoolFloor` (the warm guarantee).
-//  2. Load — `claimed + queued` real work above the floor.
-//  3. Headroom — the speculative p95 warm buffer (`Target` above
-//     floor+load).
+//  1. Load — `claimed + queued`, the real work running or waiting for a
+//     Pod. Genuine demand; granted in full even when it exceeds capacity
+//     (the excess goes Pending, the operator's "add a host" signal).
+//  2. Floor — `minWarmPoolFloor` above load: the speculative warm
+//     guarantee that keeps the next spike off cold-start. Idle warm Pods.
+//  3. Headroom — the p95 warm buffer (`Target` above floor+load). Also
+//     idle, the most speculative.
 //
-// Tiers 1+2 are genuine need and are always granted in full, even when
-// their sum exceeds capacity: the excess goes Pending, which is the
-// operator's "add a host" signal. The autoscaler must not mask real
-// demand by dropping warm guarantees or starving queued work.
+// Only tier 1 is inviolable. Tiers 2 and 3 are idle warm capacity, and
+// they yield — headroom first, then floor — to admit another pool's real
+// queued work. That is the cross-pool reclaim: when a starved shape has
+// queued jobs that don't fit, an idle shape's warm Pods are reaped
+// (its desired falls below its floor) to free the memory, rather than
+// leaving the queued jobs Pending while idle Pods hold reservations.
 //
-// Tier 3 is discretionary. It's granted only from the capacity left
-// after tiers 1+2, split proportionally to each pool's requested
-// headroom when short. That squeeze is the cross-pool reclaim: an idle
-// shape's speculative warm Pods are denied before another shape's real
-// queued work, so a starved large shape can grow as idle small shapes
-// fall back toward their floor.
+// The tradeoff is deliberate: under sustained load on one shape, other
+// shapes' warm pools shrink toward their real load, so a returning spike
+// on a squeezed shape pays cold-start. A job queued now beats a warm Pod
+// for a job that might arrive. The per-pool scale-down cooldown damps the
+// reap so it doesn't thrash.
 //
-// Returns desired replicas per pool name, each in `[base_i, Target_i]`
-// where `base_i = min(max(floor_i, load_i), target_i)`. Memory is the
-// only dimension considered.
+// Each tier is granted in full when it fits; otherwise it is split
+// proportionally to requested memory and all lower tiers get nothing.
+// Result per pool is in `[load_i, Target_i]`. Memory is the only
+// dimension considered.
 func AllocateFleet(pools []PoolDemand, fleetMemBytes int64) map[string]int32 {
 	out := make(map[string]int32, len(pools))
 
-	type headroom struct {
+	type tierWant struct {
 		name string
-		want int32 // replicas of speculative buffer requested
-		mem  int64 // per-Pod memory
+		want int32
+		mem  int64
+	}
+	var loadWants, floorWants, headWants []tierWant
+
+	// Decompose each pool's Target into the three priority tiers.
+	for _, p := range pools {
+		target := p.Target
+		if target < 0 {
+			target = 0
+		}
+
+		load := p.Load
+		if load < 0 {
+			load = 0
+		}
+		if load > target {
+			load = target
+		}
+
+		// Top of the floor tier: the warm guarantee, never below load,
+		// never above target. This is what the old "base" used to grant
+		// unconditionally; it is now squeezable above `load`.
+		floorTop := p.Floor
+		if floorTop < load {
+			floorTop = load
+		}
+		if floorTop > target {
+			floorTop = target
+		}
+
+		out[p.Name] = 0
+
+		if load > 0 {
+			loadWants = append(loadWants, tierWant{p.Name, load, p.PodMemBytes})
+		}
+		if floorWant := floorTop - load; floorWant > 0 && p.PodMemBytes > 0 {
+			floorWants = append(floorWants, tierWant{p.Name, floorWant, p.PodMemBytes})
+		}
+		if headWant := target - floorTop; headWant > 0 && p.PodMemBytes > 0 {
+			headWants = append(headWants, tierWant{p.Name, headWant, p.PodMemBytes})
+		}
 	}
 
-	var headrooms []headroom
-	var headroomMemTotal int64
 	remaining := fleetMemBytes
 
-	// Tier 1+2: grant base = real need, always in full.
-	for _, p := range pools {
-		base := p.Floor
-		if p.Load > base {
-			base = p.Load
+	// grantTier grants a discretionary tier from `remaining`, returning
+	// true only when it was satisfied in full (so the caller knows
+	// whether to attempt the next-lower tier). A partially-funded tier
+	// is split proportionally to requested memory and exhausts capacity.
+	grantTier := func(wants []tierWant) bool {
+		var total int64
+		for _, w := range wants {
+			total += int64(w.want) * w.mem
 		}
-		if base > p.Target {
-			base = p.Target
+		if total == 0 {
+			return true // nothing wanted; capacity untouched
 		}
-		if base < 0 {
-			base = 0
+		if remaining >= total {
+			for _, w := range wants {
+				out[w.name] += w.want
+			}
+			remaining -= total
+			return true
 		}
-
-		out[p.Name] = base
-		remaining -= int64(base) * p.PodMemBytes
-
-		want := p.Target - base
-		if want > 0 && p.PodMemBytes > 0 {
-			headrooms = append(headrooms, headroom{name: p.Name, want: want, mem: p.PodMemBytes})
-			headroomMemTotal += int64(want) * p.PodMemBytes
+		if remaining > 0 {
+			ratio := float64(remaining) / float64(total)
+			for _, w := range wants {
+				grant := int32(float64(w.want) * ratio)
+				if grant > w.want {
+					grant = w.want
+				}
+				out[w.name] += grant
+			}
 		}
+		remaining = 0
+		return false
 	}
 
-	// No capacity left for speculative warm, or nobody wants any.
-	if remaining <= 0 || headroomMemTotal == 0 {
-		return out
+	// Tier 1: real load — always granted in full, even past capacity.
+	// Excess drives `remaining` negative; lower tiers then get nothing.
+	for _, w := range loadWants {
+		out[w.name] += w.want
+		remaining -= int64(w.want) * w.mem
+	}
+	if remaining < 0 {
+		remaining = 0
 	}
 
-	// Uncontended: everything fits, grant all headroom.
-	if remaining >= headroomMemTotal {
-		for _, h := range headrooms {
-			out[h.name] += h.want
-		}
-		return out
-	}
-
-	// Contended: split `remaining` proportionally to requested headroom
-	// memory. Each pool's memory-fair grant works out to
-	// `ratio * want` replicas, so we scale the replica ask directly —
-	// a float ratio avoids the int64 overflow that `remaining * wantMem`
-	// hits at GiB scale. Integer floor per pool; leftover from rounding
-	// stays unused (conservative — never over-commits).
-	ratio := float64(remaining) / float64(headroomMemTotal)
-	for _, h := range headrooms {
-		grant := int32(float64(h.want) * ratio)
-		if grant > h.want {
-			grant = h.want
-		}
-		out[h.name] += grant
+	// Tier 2: floor (warm guarantee), then tier 3: headroom — only if
+	// floors fit in full. Floors yield to tier-1 load above; headroom
+	// yields to floors.
+	if grantTier(floorWants) {
+		grantTier(headWants)
 	}
 
 	return out

--- a/infra/runners-controller/internal/scaling/allocate_test.go
+++ b/infra/runners-controller/internal/scaling/allocate_test.go
@@ -121,10 +121,16 @@ func TestAllocateFleet_NeverExceedsTarget(t *testing.T) {
 }
 
 func TestAllocateFleet_ZeroCapacityHonorsLoadNotFloor(t *testing.T) {
-	// No usable memory. Real load is still granted in full — it goes
-	// Pending, the operator's "add a host" signal. A speculative floor
-	// with no load behind it is NOT manufactured into Pending Pods, since
-	// idle warm capacity yields to genuine demand.
+	// Pure-function contract at fleetMem == 0: real load is still
+	// granted (it would go Pending), while a speculative floor with no
+	// load behind it is squeezed to zero rather than manufactured into
+	// Pending Pods.
+	//
+	// NOTE: the AutoscalerReconciler never calls AllocateFleet with
+	// fleetMem <= 0. It treats a zero or failed fleet-memory read as a
+	// blip and falls back to the per-pool target (floor honored), so
+	// this pins AllocateFleet's behavior for callers that pass 0, not
+	// the deployed zero-node behavior.
 	pools := []PoolDemand{
 		{Name: "load", PodMemBytes: 4 * gib, Floor: 2, Load: 3, Target: 5},
 		{Name: "floor", PodMemBytes: 4 * gib, Floor: 2, Load: 0, Target: 5},

--- a/infra/runners-controller/internal/scaling/allocate_test.go
+++ b/infra/runners-controller/internal/scaling/allocate_test.go
@@ -48,8 +48,8 @@ func TestAllocateFleet_SqueezesSpeculativeHeadroomUnderContention(t *testing.T) 
 		{Name: "busy", PodMemBytes: 8 * gib, Floor: 1, Load: 6, Target: 8},
 		{Name: "idle", PodMemBytes: 8 * gib, Floor: 1, Load: 0, Target: 5},
 	}
-	// 64 GiB usable = 8 pods. busy base = load 6 (48 GiB); idle base =
-	// floor 1 (8 GiB). 56 GiB used, 8 GiB (1 pod) left for headroom.
+	// 64 GiB usable = 8 pods. busy load 6 (48 GiB). Floors: busy 0 (load
+	// already > floor), idle 1 (8 GiB) → fit, 8 GiB left for headroom.
 	// Headroom wants: busy 2, idle 4 (6 total). 1 pod split
 	// proportionally → busy ~0, idle ~0 (rounding down). The point:
 	// idle does NOT get its speculative 5; busy's real load is intact.
@@ -63,6 +63,31 @@ func TestAllocateFleet_SqueezesSpeculativeHeadroomUnderContention(t *testing.T) 
 	}
 	if got["idle"] < 1 {
 		t.Errorf("idle = %d, want >= floor 1", got["idle"])
+	}
+}
+
+func TestAllocateFleet_SqueezesIdleFloorForAnotherPoolsQueuedLoad(t *testing.T) {
+	// The production case this re-tiering fixes: a small shape sits at a
+	// large warm floor (mostly idle Pods), while a big shape has real
+	// queued load that doesn't fit. Real load outranks the idle floor —
+	// the small shape's floor is squeezed below its configured value so
+	// the big shape's queued work schedules, instead of leaving it Pending
+	// while idle Pods hold reservations.
+	pools := []PoolDemand{
+		// small: floor 20 (all idle, no real load behind it).
+		{Name: "small", PodMemBytes: 8 * gib, Floor: 20, Load: 0, Target: 25},
+		// big: real queued load 10, no floor — pure demand.
+		{Name: "big", PodMemBytes: 16 * gib, Floor: 0, Load: 10, Target: 10},
+	}
+	// 200 GiB usable. big's load = 160 GiB granted first, leaving 40 GiB
+	// (5 pods of 8 GiB) for small's floor of 20 → squeezed to 5.
+	got := AllocateFleet(pools, 200*gib)
+
+	if got["big"] != 10 {
+		t.Errorf("big = %d, want 10 (queued load wins over idle floor)", got["big"])
+	}
+	if got["small"] != 5 {
+		t.Errorf("small = %d, want 5 (floor squeezed from 20 to fit big's load)", got["small"])
 	}
 }
 
@@ -95,15 +120,21 @@ func TestAllocateFleet_NeverExceedsTarget(t *testing.T) {
 	}
 }
 
-func TestAllocateFleet_ZeroCapacityStillHonorsBase(t *testing.T) {
-	// Degenerate: no usable memory. Base (floor/load) is still returned
-	// — the scheduler leaves it Pending, surfaced on the dashboard.
+func TestAllocateFleet_ZeroCapacityHonorsLoadNotFloor(t *testing.T) {
+	// No usable memory. Real load is still granted in full — it goes
+	// Pending, the operator's "add a host" signal. A speculative floor
+	// with no load behind it is NOT manufactured into Pending Pods, since
+	// idle warm capacity yields to genuine demand.
 	pools := []PoolDemand{
-		{Name: "a", PodMemBytes: 4 * gib, Floor: 2, Load: 0, Target: 5},
+		{Name: "load", PodMemBytes: 4 * gib, Floor: 2, Load: 3, Target: 5},
+		{Name: "floor", PodMemBytes: 4 * gib, Floor: 2, Load: 0, Target: 5},
 	}
 	got := AllocateFleet(pools, 0)
-	if got["a"] != 2 {
-		t.Errorf("a = %d, want 2 (floor honored)", got["a"])
+	if got["load"] != 3 {
+		t.Errorf("load = %d, want 3 (real load honored even at zero capacity)", got["load"])
+	}
+	if got["floor"] != 0 {
+		t.Errorf("floor = %d, want 0 (speculative floor squeezed, not left Pending)", got["floor"])
 	}
 }
 


### PR DESCRIPTION
## What changed

Re-tiers the Linux runner fleet allocator (`AllocateFleet` in `infra/runners-controller/internal/scaling/allocate.go`) so a pool's real queued load takes precedence over other pools' idle warm-pool floors when they contend for the shared bare-metal node pool's memory.

## Why

Linux runner shapes (`2vcpu-8gb`, `4vcpu-16gb`, ...) all run as kata microVMs on the same bare-metal node pool and bin-pack on memory. The allocator distributes that memory across shapes, but it treated each pool's `minWarmPoolFloor` as an inviolable tier:

```
old: (1) floor  (2) load  (3) p95 headroom    -- tiers 1+2 always granted
```

So every shape's floor was funded before any shape's real queued work. In production this produced the exact pathology the change targets: a small shape pinned at a large warm floor (mostly idle pods) held a big chunk of fleet memory, while a larger shape's real queued jobs sat `Pending` because no memory was left. Observed live: a small shape sitting at floor with ~20 idle pods (no jobs), next to a larger shape with real queued load and ~10 pods Pending. Idle warm capacity was outranking another shape's actual queued work.

## The change

```
new: (1) load  (2) floor above load  (3) p95 headroom
```

Only tier 1 (real load = `claimed + queued`) is inviolable and granted in full, even past capacity (the excess goes Pending, the operator's "add a host" signal). Floors and the p95 buffer are idle warm capacity and now yield under contention, headroom first then floor, to admit another pool's queued work. An idle shape's `desired` can drop below its configured floor; its idle pods are then reaped to free memory for the starved shape.

## Why this over the alternatives

- Raising per-shape floors / shuffling helm values is whack-a-mole across 9 shapes and does not encode the policy (demand beats speculation).
- Native k8s priority + preemption reaches the same outcome but adds sharp edges: pod priority is immutable (cannot promote idle to busy on claim) and a claim-during-preemption race. The allocator already owns cross-pool sizing, so expressing the policy there is simpler and race-free.
- The fleet allocator and its node-memory gathering already exist; this is a focused re-tiering of the pure allocation function, no new inputs, CRD, RBAC, or config knob.

## Busy-pod safety

The reaper is unaffected. `RunnerPoolReconciler` scale-down iterates only `idleAlive`, built solely from pods where `isIdle()` is true (no `tuist.dev/runner-pool-owner` label). A mid-job pod always carries that label and is never eligible for deletion, regardless of how far below floor `desired` drops. Lowering `desired` only increases the count of idle warm pods reaped; it can never reap a running job.

## Tradeoff

Under sustained load on one shape, other shapes' warm pools shrink toward their real load, so a returning spike on a squeezed shape pays cold-start instead of landing on a warm pod. This is deliberate: a job queued now beats a warm pod held for a job that might arrive. The existing per-pool scale-down cooldown damps the reap so it does not thrash.

## Validation

- `go build ./...`, `go test ./...`, `go vet ./...`, `gofmt` all clean.
- Added `TestAllocateFleet_SqueezesIdleFloorForAnotherPoolsQueuedLoad`, a regression test mirroring the production case (a 20-floor idle shape squeezed to fit a queued-load shape).
- Updated the zero-capacity test for the new semantics: real load is still honored (goes Pending, the add-a-host signal), a speculative floor with no load behind it is no longer manufactured into Pending pods.
- The existing cross-pool reclaim controller test still passes unchanged (when the idle floor fits, only headroom squeezes, same result).

## Out of scope

Draft because it is part of ongoing runner-fleet work. A separate investigation into runners dying mid-job ("self-hosted runner lost communication") is in progress; that is a VM-sizing / observability problem (guest-side resource exhaustion), orthogonal to this allocation policy.
