### PR TITLE
fix(server): aggregate Kura usage by region

### DIFF
--- a/.github/actions/setup-server-mix/action.yml
+++ b/.github/actions/setup-server-mix/action.yml
@@ -20,6 +20,10 @@ inputs:
     description: Restore-keys prefix for deps + _build cache fallback
     required: false
     default: mix-
+  restore-mix-cache:
+    description: Restore the cached server deps + _build state before fetching dependencies
+    required: false
+    default: "true"
   mix-os-deps-compile-partition-count:
     description: Lower Mix dependency compilation parallelism for CI runners with tighter memory limits.
     required: false
@@ -43,6 +47,7 @@ runs:
         working_directory: server
         github_token: ${{ inputs.github-token || env.MISE_GITHUB_TOKEN }}
     - name: Restore Mix Cache
+      if: ${{ inputs['restore-mix-cache'] == 'true' }}
       uses: actions/cache@v4
       with:
         path: |

--- a/.github/workflows/gradle-cache-acceptance.yml
+++ b/.github/workflows/gradle-cache-acceptance.yml
@@ -159,14 +159,21 @@ jobs:
       - name: Start cache server
         working-directory: cache
         run: |
-          MIX_ENV=dev mix phx.server &
+          nohup bash -c 'ELIXIR_ERL_OPTIONS="+S 1" MIX_ENV=dev mix phx.server' >/tmp/cache-server.log 2>&1 &
+          disown
           cache_port="${TUIST_CACHE_PORT:-8087}"
-          for i in {1..30}; do
+          for i in {1..180}; do
             if nc -z localhost "$cache_port" 2>/dev/null; then
-              echo "Cache server is ready"
+              echo "Cache server is listening on :${cache_port} after ${i} attempts"
               break
             fi
-            echo "Waiting for cache server... ($i/30)"
+            if [ "$i" = "180" ]; then
+              echo "Cache server never came up on :${cache_port}" >&2
+              echo "--- cache-server.log tail ---" >&2
+              tail -50 /tmp/cache-server.log >&2
+              exit 1
+            fi
+            echo "Waiting for cache server... ($i/180)"
             sleep 2
           done
       - name: Run Gradle cache acceptance test

--- a/.github/workflows/gradle-cache-acceptance.yml
+++ b/.github/workflows/gradle-cache-acceptance.yml
@@ -85,30 +85,12 @@ jobs:
           distribution: temurin
           java-version: '21'
       - uses: android-actions/setup-android@v3
-      - name: Restore server deps
-        uses: actions/cache@v4
-        with:
-          path: |
-            server/deps
-            server/_build
-          key: mix-${{ hashFiles('server/mix.lock') }}
-          restore-keys: |
-            mix-
       - name: Install server deps
         working-directory: server
         run: mix deps.get
       - name: Start ClickHouse
         working-directory: server
         run: mise run --no-deps clickhouse:start
-      - name: Restore cache deps
-        uses: actions/cache@v4
-        with:
-          path: |
-            cache/deps
-            cache/_build
-          key: cache-mix-${{ hashFiles('cache/mix.lock') }}
-          restore-keys: |
-            cache-mix-
       - name: Install cache deps
         working-directory: cache
         run: mix deps.get

--- a/.github/workflows/gradle-cache-acceptance.yml
+++ b/.github/workflows/gradle-cache-acceptance.yml
@@ -121,13 +121,30 @@ jobs:
           # below: on a cold _build cache this does a full compile, and at 4
           # workers the in-flight module copies OOM the runner from inside the
           # guest ("lost communication").
+          log_file=/tmp/setup-main-server.log
           ELIXIR_ERL_OPTIONS="+S 1" MIX_ENV=dev mix do \
             compile, \
             ecto.create, \
             run priv/repo/timezone.exs, \
             ecto.load, \
             ecto.migrate, \
-            run priv/repo/seeds.exs
+            run priv/repo/seeds.exs > "$log_file" 2>&1 &
+          setup_pid=$!
+          while kill -0 "$setup_pid" 2>/dev/null; do
+            echo "Waiting for main server setup..."
+            sleep 30
+          done &
+          heartbeat_pid=$!
+          status=0
+          wait "$setup_pid" || status=$?
+          kill "$heartbeat_pid" 2>/dev/null || true
+          wait "$heartbeat_pid" 2>/dev/null || true
+          if [ "$status" -ne 0 ]; then
+            echo "--- setup-main-server.log tail ---" >&2
+            tail -100 "$log_file" >&2
+            exit "$status"
+          fi
+          echo "Main server setup completed"
       - name: Start main server
         working-directory: server
         run: |

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -243,10 +243,15 @@ jobs:
     if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     steps:
       - uses: actions/checkout@v4
-      - uses: ./.github/actions/setup-server-mix
+      - uses: jdx/mise-action@v4.0.1
         with:
-          mise-version: ${{ env.MISE_VERSION }}
-          mise-install-args: erlang elixir node aube npm:prettier
+          version: ${{ env.MISE_VERSION }}
+          install_args: erlang elixir node aube npm:prettier
+          cache: "true"
+          working_directory: server
+          github_token: ${{ env.MISE_GITHUB_TOKEN }}
+      - name: Install mix dependencies
+        run: mix deps.get
       - name: Install aube dependencies
         run: aube install
       - name: Check format

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -247,13 +247,6 @@ jobs:
         with:
           mise-version: ${{ env.MISE_VERSION }}
           mise-install-args: erlang elixir node aube npm:prettier
-      - name: Restore Aube Cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.local/share/aube
-            ~/.cache/aube
-          key: aube-server-${{ hashFiles('server/pnpm-lock.yaml') }}
       - name: Install aube dependencies
         run: aube install
       - name: Check format

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -246,7 +246,7 @@ jobs:
       - uses: jdx/mise-action@v4.0.1
         with:
           version: ${{ env.MISE_VERSION }}
-          install_args: erlang elixir node aube npm:prettier
+          install_args: erlang elixir node aube
           cache: "true"
           working_directory: server
           github_token: ${{ env.MISE_GITHUB_TOKEN }}
@@ -255,7 +255,10 @@ jobs:
       - name: Install aube dependencies
         run: aube install
       - name: Check format
-        run: mise run --no-deps format --check
+        run: |
+          mix format --check-formatted
+          aube exec prettier -c priv/static/app
+          aube exec prettier -c assets
   esbuild:
     name: esbuild
     runs-on: tuist-linux

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -215,6 +215,7 @@ jobs:
           mise-install-args: erlang elixir github:ClickHouse/ClickHouse
           mix-cache-key: mix-test-v2
           mix-cache-restore-key: mix-test-v2-
+          restore-mix-cache: "false"
       - name: Compile
         run: mix compile --warnings-as-errors
       - name: Start ClickHouse
@@ -448,6 +449,7 @@ jobs:
         with:
           mise-version: ${{ env.MISE_VERSION }}
           mise-install-args: erlang elixir github:ClickHouse/ClickHouse
+          restore-mix-cache: "false"
       - name: Start ClickHouse
         run: mise run --no-deps clickhouse:start
       - name: Setup database

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -339,6 +339,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
       - name: Docker build
         run: |
+          log_file=/tmp/server-docker-build.log
           docker buildx build \
             --progress=plain \
             --file "$GITHUB_WORKSPACE/server/Dockerfile" \
@@ -351,7 +352,23 @@ jobs:
             --build-arg APT_CACHE_BUST=${{ github.sha }} \
             --build-arg DOCKER_IMAGE_PREFIX=mirror.gcr.io/ \
             --build-arg DOCKER_OFFICIAL_IMAGE_PREFIX=mirror.gcr.io/library/ \
-            "$GITHUB_WORKSPACE"
+            "$GITHUB_WORKSPACE" > "$log_file" 2>&1 &
+          build_pid=$!
+          while kill -0 "$build_pid" 2>/dev/null; do
+            echo "Waiting for Docker build..."
+            sleep 30
+          done &
+          heartbeat_pid=$!
+          status=0
+          wait "$build_pid" || status=$?
+          kill "$heartbeat_pid" 2>/dev/null || true
+          wait "$heartbeat_pid" 2>/dev/null || true
+          if [ "$status" -ne 0 ]; then
+            echo "--- server-docker-build.log tail ---" >&2
+            tail -100 "$log_file" >&2
+            exit "$status"
+          fi
+          echo "Docker build completed"
       - name: Install Trivy
         env:
           TRIVY_VERSION: "0.69.3"

--- a/server/lib/tuist/kura/usage.ex
+++ b/server/lib/tuist/kura/usage.ex
@@ -149,17 +149,16 @@ defmodule Tuist.Kura.Usage do
   end
 
   @doc """
-  Per-node traffic breakdown within `[start_dt, end_dt]`. Returns one row per
-  `(node_id, region)` with egress + ingress bytes and request totals, sorted
-  by total bytes desc.
+  Per-region traffic breakdown within `[start_dt, end_dt]`. Returns one row per
+  region with egress + ingress bytes and request totals, sorted by total bytes
+  desc.
   """
-  def per_node(account_id, start_dt, end_dt, opts \\ []) when is_integer(account_id) do
+  def per_region(account_id, start_dt, end_dt, opts \\ []) when is_integer(account_id) do
     rows =
       ClickHouseRepo.all(
         from(e in subquery(deduped_event_query(account_id, start_dt, end_dt, opts)),
-          group_by: [e.node_id, e.region, e.direction],
+          group_by: [e.region, e.direction],
           select: %{
-            node_id: e.node_id,
             region: e.region,
             direction: e.direction,
             bytes: fragment("sum(?)", e.bytes),
@@ -169,8 +168,8 @@ defmodule Tuist.Kura.Usage do
       )
 
     rows
-    |> Enum.group_by(fn r -> {r.node_id, r.region} end)
-    |> Enum.map(fn {{node_id, region}, direction_rows} ->
+    |> Enum.group_by(& &1.region)
+    |> Enum.map(fn {region, direction_rows} ->
       egress =
         Enum.find(direction_rows, &(&1.direction == "egress")) || %{bytes: 0, request_count: 0}
 
@@ -178,7 +177,6 @@ defmodule Tuist.Kura.Usage do
         Enum.find(direction_rows, &(&1.direction == "ingress")) || %{bytes: 0, request_count: 0}
 
       %{
-        node_id: node_id,
         region: region,
         egress_bytes: zeroed(egress.bytes),
         ingress_bytes: zeroed(ingress.bytes),

--- a/server/lib/tuist_web/live/usage_live.ex
+++ b/server/lib/tuist_web/live/usage_live.ex
@@ -72,7 +72,7 @@ defmodule TuistWeb.UsageLive do
      |> assign(:analytics_selected_widget, selected_widget)
      |> assign(:analytics_trend_label, trend_label(preset))
      |> assign_async(
-       [:totals, :egress_series, :ingress_series, :requests_series, :per_node],
+       [:totals, :egress_series, :ingress_series, :requests_series, :per_region],
        fn ->
          {:ok,
           %{
@@ -80,7 +80,7 @@ defmodule TuistWeb.UsageLive do
             egress_series: Usage.traffic_time_series_by_region(account.id, start_dt, end_dt, egress_opts),
             ingress_series: Usage.traffic_time_series_by_region(account.id, start_dt, end_dt, ingress_opts),
             requests_series: Usage.traffic_time_series_by_region(account.id, start_dt, end_dt, requests_opts),
-            per_node: Usage.per_node(account.id, start_dt, end_dt, base_opts)
+            per_region: Usage.per_region(account.id, start_dt, end_dt, base_opts)
           }}
        end
      )}

--- a/server/lib/tuist_web/live/usage_live.html.heex
+++ b/server/lib/tuist_web/live/usage_live.html.heex
@@ -196,15 +196,15 @@
   </.card>
 
   <.card
-    title={dgettext("dashboard_usage", "Traffic by node")}
+    title={dgettext("dashboard_usage", "Traffic by region")}
     icon="server"
-    data-part="kura-traffic-by-node-card"
+    data-part="kura-traffic-by-region-card"
   >
-    <.card_section data-part="kura-traffic-by-node-card-section">
+    <.card_section data-part="kura-traffic-by-region-card-section">
       <%= cond do %>
-        <% !@per_node.ok? -> %>
+        <% !@per_region.ok? -> %>
           <.skeleton_chart />
-        <% Enum.empty?(@per_node.result) -> %>
+        <% Enum.empty?(@per_region.result) -> %>
           <.empty_card_section
             title={TuistWeb.UsageLive.empty_label()}
             get_started_href="https://tuist.dev/en/docs"
@@ -216,15 +216,12 @@
           </.empty_card_section>
         <% true -> %>
           <.table
-            id="usage-per-node-table"
-            rows={@per_node.result}
-            row_key={fn row -> "usage-node-#{row.node_id}-#{row.region}" end}
+            id="usage-per-region-table"
+            rows={@per_region.result}
+            row_key={fn row -> "usage-region-#{row.region}" end}
           >
-            <:col :let={row} label={dgettext("dashboard_usage", "Node")}>
-              <.text_cell icon="server" label={row.node_id} />
-            </:col>
             <:col :let={row} label={dgettext("dashboard_usage", "Region")}>
-              <.text_cell label={if(row.region == "", do: "–", else: row.region)} />
+              <.text_cell icon="server" label={TuistWeb.UsageLive.region_label(row.region)} />
             </:col>
             <:col :let={row} label={dgettext("dashboard_usage", "Egress")}>
               <.text_cell label={TuistWeb.UsageLive.format_bytes(row.egress_bytes)} />

--- a/server/priv/gettext/dashboard_usage.pot
+++ b/server/priv/gettext/dashboard_usage.pot
@@ -52,23 +52,18 @@ msgstr ""
 msgid "Last 7 days"
 msgstr ""
 
-#: lib/tuist_web/live/usage_live.html.heex:223
-#, elixir-autogen, elixir-format
-msgid "Node"
-msgstr ""
-
 #: lib/tuist_web/live/usage_live.html.heex:16
 #, elixir-autogen, elixir-format
 msgid "Project:"
 msgstr ""
 
-#: lib/tuist_web/live/usage_live.html.heex:226
+#: lib/tuist_web/live/usage_live.html.heex:223
 #, elixir-autogen, elixir-format
 msgid "Region"
 msgstr ""
 
 #: lib/tuist_web/live/usage_live.html.heex:145
-#: lib/tuist_web/live/usage_live.html.heex:235
+#: lib/tuist_web/live/usage_live.html.heex:232
 #, elixir-autogen, elixir-format
 msgid "Requests"
 msgstr ""
@@ -83,11 +78,6 @@ msgstr ""
 msgid "The page you are looking for doesn't exist or has been moved."
 msgstr ""
 
-#: lib/tuist_web/live/usage_live.html.heex:199
-#, elixir-autogen, elixir-format
-msgid "Traffic by node"
-msgstr ""
-
 #: lib/tuist_web/live/usage_live.ex:39
 #: lib/tuist_web/live/usage_live.html.heex:4
 #, elixir-autogen, elixir-format
@@ -95,13 +85,13 @@ msgid "Usage"
 msgstr ""
 
 #: lib/tuist_web/live/usage_live.html.heex:105
-#: lib/tuist_web/live/usage_live.html.heex:229
+#: lib/tuist_web/live/usage_live.html.heex:226
 #, elixir-autogen, elixir-format
 msgid "Egress"
 msgstr ""
 
 #: lib/tuist_web/live/usage_live.html.heex:125
-#: lib/tuist_web/live/usage_live.html.heex:232
+#: lib/tuist_web/live/usage_live.html.heex:229
 #, elixir-autogen, elixir-format
 msgid "Ingress"
 msgstr ""
@@ -165,4 +155,9 @@ msgstr ""
 #: lib/tuist_web/live/usage_live.ex:120
 #, elixir-autogen, elixir-format
 msgid "since yesterday"
+msgstr ""
+
+#: lib/tuist_web/live/usage_live.html.heex:199
+#, elixir-autogen, elixir-format
+msgid "Traffic by region"
 msgstr ""

--- a/server/test/tuist/kura/usage_test.exs
+++ b/server/test/tuist/kura/usage_test.exs
@@ -250,8 +250,8 @@ defmodule Tuist.Kura.UsageTest do
     end
   end
 
-  describe "per_node/4" do
-    test "rolls up egress + ingress bytes per (node_id, region)" do
+  describe "per_region/4" do
+    test "rolls up egress + ingress bytes per region across nodes" do
       account_id = unique_account_id()
       {start_dt, end_dt} = window_span()
 
@@ -266,7 +266,7 @@ defmodule Tuist.Kura.UsageTest do
 
       insert_event(%{
         account_id: account_id,
-        node_id: "kura-a",
+        node_id: "kura-b",
         region: "us-east-1",
         direction: "ingress",
         bytes: 200,
@@ -275,7 +275,7 @@ defmodule Tuist.Kura.UsageTest do
 
       insert_event(%{
         account_id: account_id,
-        node_id: "kura-b",
+        node_id: "kura-c",
         region: "eu-west-1",
         direction: "egress",
         bytes: 400,
@@ -283,9 +283,9 @@ defmodule Tuist.Kura.UsageTest do
       })
 
       assert [
-               %{node_id: "kura-a", region: "us-east-1", egress_bytes: 1_000, ingress_bytes: 200, request_count: 6},
-               %{node_id: "kura-b", region: "eu-west-1", egress_bytes: 400, ingress_bytes: 0, request_count: 1}
-             ] = Usage.per_node(account_id, start_dt, end_dt)
+               %{region: "us-east-1", egress_bytes: 1_000, ingress_bytes: 200, request_count: 6},
+               %{region: "eu-west-1", egress_bytes: 400, ingress_bytes: 0, request_count: 1}
+             ] = Usage.per_region(account_id, start_dt, end_dt)
     end
   end
 

--- a/server/test/tuist_web/live/usage_live_test.exs
+++ b/server/test/tuist_web/live/usage_live_test.exs
@@ -117,7 +117,7 @@ defmodule TuistWeb.UsageLiveTest do
       assert html =~ "No cache traffic in this window yet"
     end
 
-    test "renders the per-node table when events exist", %{conn: conn, account: account} do
+    test "renders the per-region table when events exist", %{conn: conn, account: account} do
       ProjectsFixtures.project_fixture(account: account, name: "ios")
 
       insert_event(%{
@@ -132,7 +132,9 @@ defmodule TuistWeb.UsageLiveTest do
 
       html = render_async(lv, @render_async_timeout)
 
-      assert html =~ "kura-test-node"
+      assert html =~ "Traffic by region"
+      assert html =~ "us-east-1"
+      refute html =~ "kura-test-node"
       # 1 MB rendered through ByteFormatter
       assert html =~ "MB"
     end


### PR DESCRIPTION
## Summary
- Aggregate Kura usage traffic by region instead of individual Kura pod/node ids.
- Update the Usage dashboard table copy, row keys, and async assign names to reflect the region-level breakdown.
- Refresh the dashboard usage gettext template and tests for region rollups.

## Current setup

<img width="2464" height="414" alt="image" src="https://github.com/user-attachments/assets/c4ff62db-8fef-4f24-854a-093def3b3afd" />


## Testing
- `mix format --check-formatted lib/tuist/kura/usage.ex lib/tuist_web/live/usage_live.ex lib/tuist_web/live/usage_live.html.heex test/tuist/kura/usage_test.exs test/tuist_web/live/usage_live_test.exs`
- `TUIST_SERVER_CLICKHOUSE_HTTP_PORT=28123 TUIST_SERVER_TEST_CLICKHOUSE_DB=tuist_test_usage_28123 mix test test/tuist/kura/usage_test.exs test/tuist_web/live/usage_live_test.exs`
- `TUIST_ENABLE_CACHING=1 TUIST_FEATURE_FLAG_KURA=1 tuist cache warm ProjectDescription`
