### PR TITLE
feat(infra,kura): Expose Kura gRPC ingress in Helm chart

### DIFF
--- a/kura/README.md
+++ b/kura/README.md
@@ -310,6 +310,7 @@ The repository includes a Helm chart at `ops/helm/kura` that deploys Kura as a `
 - 🧭 a headless service for stable pod DNS and peer discovery
 - 🌐 a regular service exposing both HTTP and gRPC
 - 🚪 optional ingress for the HTTP API
+- 🚪 optional ingress for the gRPC Remote Execution API
 - 🧩 optional inline extension script mounting through a `ConfigMap`
 - 🔐 optional peer mTLS for `/_internal/*` traffic via a mounted Kubernetes `Secret`
 - 🚦 `/ready` for public readiness and `/up` for liveness, with a `preStop` `SIGUSR1` drain hook that removes pods from traffic before `SIGTERM`
@@ -320,6 +321,21 @@ Lint and render the chart:
 ```bash
 helm lint ops/helm/kura
 helm template kura ops/helm/kura --namespace kura
+```
+
+Enable `grpcIngress` when the Bazel Remote Execution API should be reachable outside the cluster. It renders a separate ingress that routes to the service's `grpc` port so you can attach controller-specific gRPC annotations without changing the HTTP API ingress:
+
+```yaml
+grpcIngress:
+  enabled: true
+  className: nginx
+  annotations:
+    nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
+  hosts:
+    - host: kura-grpc.example.com
+      paths:
+        - path: /
+          pathType: Prefix
 ```
 
 Install it on a generic cluster:

--- a/kura/ops/helm/kura/Chart.yaml
+++ b/kura/ops/helm/kura/Chart.yaml
@@ -2,6 +2,5 @@ apiVersion: v2
 name: kura
 description: Kura distributed cache mesh for build artifacts and metadata
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "0.1.0"
-

--- a/kura/ops/helm/kura/templates/ingress.yaml
+++ b/kura/ops/helm/kura/templates/ingress.yaml
@@ -34,3 +34,39 @@ spec:
   {{- end }}
 {{- end }}
 
+{{- if .Values.grpcIngress.enabled }}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "kura.fullname" . }}-grpc
+  labels:
+    {{- include "kura.labels" . | nindent 4 }}
+  {{- with .Values.grpcIngress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.grpcIngress.className }}
+  ingressClassName: {{ .Values.grpcIngress.className }}
+  {{- end }}
+  rules:
+    {{- range .Values.grpcIngress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "kura.fullname" $ }}
+                port:
+                  name: grpc
+          {{- end }}
+    {{- end }}
+  {{- with .Values.grpcIngress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/kura/ops/helm/kura/values.yaml
+++ b/kura/ops/helm/kura/values.yaml
@@ -50,6 +50,17 @@ ingress:
           pathType: Prefix
   tls: []
 
+grpcIngress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    - host: kura-grpc.local
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []
+
 persistence:
   enabled: true
   # Prefer ReadWriteOncePod to enforce one Kura writer per PVC.


### PR DESCRIPTION
> Adds optional gRPC ingress support to the Kura Helm chart so REAPI clients can reach the service's gRPC port externally while HTTP ingress keeps its own controller annotations.

### How to test locally

- `helm lint ops/helm/kura`
- `helm template kura ops/helm/kura --namespace kura`
- `helm template kura ops/helm/kura --namespace kura --set grpcIngress.enabled=true --set grpcIngress.className=nginx --set 'grpcIngress.annotations.nginx\\.ingress\\.kubernetes\\.io/backend-protocol=GRPC'`
