### PR TITLE
feat(linux-runner-image): emit resource vitals so mid-job runner deaths are diagnosable

### DIFF
--- a/.github/workflows/linux-runner-image.yml
+++ b/.github/workflows/linux-runner-image.yml
@@ -53,6 +53,7 @@ jobs:
         run: |
           bash -n infra/linux-runner-image/dispatch-poll.sh
           bash -n infra/linux-runner-image/run-job.sh
+          bash -n infra/linux-runner-image/vitals.sh
 
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3

--- a/infra/helm/k8s-monitoring/values.yaml
+++ b/infra/helm/k8s-monitoring/values.yaml
@@ -364,6 +364,19 @@ k8s-monitoring:
     # logs from disk (matches the podLogsViaLoki feature).
     alloy-logs:
       presets: [filesystem-log-reader]
+      # Tolerate the bare-metal runner taint so the log DaemonSet also
+      # lands on the runner-tier nodes and tails the Linux runner Pods.
+      # Without this, runner Pod logs (including RUNNER_VITALS) never
+      # reach Loki: those nodes repel everything but runner Pods, so the
+      # default-toleration DaemonSet skips them. Tolerations live under
+      # `controller` (the Alloy CR's controller spec); a top-level
+      # `tolerations` here renders to spec.tolerations and is ignored.
+      controller:
+        tolerations:
+          - key: tuist.dev/runner-tier
+            operator: Equal
+            value: bare-metal
+            effect: NoSchedule
     # Kubernetes Events must come from exactly one replica — otherwise
     # every pod watches the event stream and emits duplicate log lines.
     alloy-singleton:

--- a/infra/linux-runner-image/AGENTS.md
+++ b/infra/linux-runner-image/AGENTS.md
@@ -27,6 +27,16 @@ macOS image). Same single-shot lifecycle, much simpler substrate.
   (`TUIST_RUNNER_JIT_PATH`) and `exec`s
   `./run.sh --jitconfig <jit> --disableupdate`, or exits 0 if no
   JIT was staged (410 drain / poller abort). Holds no SA token.
+- `/usr/local/bin/vitals.sh` — periodic resource-vitals emitter.
+  `run-job.sh` backgrounds it just before exec'ing the runner (the
+  dispatch-poll rollout-bridge path does too), so it samples for the
+  job's lifetime and its last line lands in the Pod logs -> Loki even
+  after the microVM is reaped. Tag `RUNNER_VITALS`; fields cover
+  cgroup memory (current/peak/max, `oom_kill`), CPU/mem/io PSI avg10,
+  loadavg, and a best-effort `/dev/kmsg` OOM watcher. The forensic
+  trail for a runner that dies mid-job (guest OOM vs CPU/memory
+  starvation), which is otherwise invisible from outside the guest.
+  Interval via `TUIST_RUNNER_VITALS_INTERVAL` (default 3s).
 - `docker-ce-cli`, `docker-buildx-plugin`, `docker-compose-plugin`
   from the official Docker apt repo — client side only. The
   daemon runs in the `dind` native sidecar (`docker:dind`)

--- a/infra/linux-runner-image/Dockerfile
+++ b/infra/linux-runner-image/Dockerfile
@@ -199,7 +199,8 @@ USER root
 # infra/runners-controller/AGENTS.md for the split-credential shape.
 COPY dispatch-poll.sh /usr/local/bin/dispatch-poll.sh
 COPY run-job.sh /usr/local/bin/run-job.sh
-RUN chmod +x /usr/local/bin/dispatch-poll.sh /usr/local/bin/run-job.sh
+COPY vitals.sh /usr/local/bin/vitals.sh
+RUN chmod +x /usr/local/bin/dispatch-poll.sh /usr/local/bin/run-job.sh /usr/local/bin/vitals.sh
 
 USER runner
 

--- a/infra/linux-runner-image/dispatch-poll.sh
+++ b/infra/linux-runner-image/dispatch-poll.sh
@@ -123,6 +123,13 @@ while true; do
         exit 0
       fi
       echo "$(date -u +%FT%TZ) dispatch-poll: dispatched, starting runner"
+      # Forensic vitals (rollout-bridge single-container mode only; the
+      # split Pod shape runs vitals from run-job.sh). Backgrounded so it
+      # survives the exec and its last sample before a mid-job death
+      # lands in the Pod logs. Guarded so a missing script never blocks.
+      if [ -x /usr/local/bin/vitals.sh ]; then
+        /usr/local/bin/vitals.sh &
+      fi
       # `--jitconfig` makes the runner ephemeral (one job + exit).
       # `--disableupdate` pins to whatever runner version is baked
       # into the image; Renovate bumps RUNNER_VERSION in the

--- a/infra/linux-runner-image/run-job.sh
+++ b/infra/linux-runner-image/run-job.sh
@@ -37,4 +37,12 @@ if [ -z "${jit}" ]; then
   exit 1
 fi
 echo "$(date -u +%FT%TZ) run-job: JIT staged, starting runner"
+# Forensic vitals for this job's lifetime. Backgrounded so it
+# survives the `exec` below and keeps sampling until the container
+# (and microVM) dies; its last line before a mid-job death lands in
+# the Pod logs, the only trail left once the VM is reaped. Guarded so
+# a missing script (older image) never blocks the runner.
+if [ -x /usr/local/bin/vitals.sh ]; then
+  /usr/local/bin/vitals.sh &
+fi
 exec ./run.sh --jitconfig "${jit}" --disableupdate

--- a/infra/linux-runner-image/vitals.sh
+++ b/infra/linux-runner-image/vitals.sh
@@ -16,17 +16,35 @@
 #   - CPU/mem starvation  -> cpu.psi / mem.psi avg10 climb, mem.current
 #                            approaching mem.max
 #
+# Scope note: the cgroup mem.* / oom_kill fields are THIS (runner)
+# container only. The heavy build steps often run in the dind sidecar,
+# so vm.mem.* (guest-wide /proc/meminfo), the PSI fields, and the
+# /dev/kmsg OOM watcher are what catch a Docker/buildkit OOM or
+# starvation living in the sidecar / pod / VM boundary.
+#
 # Dependency-free and best-effort: unreadable files (PSI disabled in
 # the guest kernel, cgroup v1, restricted /dev/kmsg) degrade to empty
 # fields, never an error, so this can never block or fail the runner.
 # It only runs while a job executes, so idle warm Pods stay quiet.
 set -u
 
+# Clamp the interval to a positive integer. A 0, empty, or non-numeric
+# value would spin the loop and flood the logs, the opposite of
+# fail-open telemetry.
 interval="${TUIST_RUNNER_VITALS_INTERVAL:-3}"
+if ! [ "${interval}" -ge 1 ] 2>/dev/null; then
+  interval=3
+fi
 cg="/sys/fs/cgroup"
 
 # Read a single cgroup/proc value, stripped of its trailing newline.
 field() { [ -r "$1" ] && tr -d '\n' <"$1" 2>/dev/null || true; }
+
+# Guest-wide memory (kB) from /proc/meminfo. Unlike the cgroup memory.*
+# fields, which are scoped to this container, /proc/meminfo covers the
+# whole microVM, so it reflects the dind sidecar's dockerd/buildkit
+# usage too.
+meminfo() { awk -v k="$1" '$1==k":"{print $2}' /proc/meminfo 2>/dev/null || true; }
 
 # Pull a named counter out of cgroup v2 memory.events (e.g. oom_kill).
 events() {
@@ -57,8 +75,10 @@ if [ -r /dev/kmsg ]; then
 fi
 
 while :; do
-  printf '%s RUNNER_VITALS mem.current=%s mem.peak=%s mem.max=%s mem.swap=%s oom=%s oom_kill=%s cpu.psi.some.avg10=%s mem.psi.some.avg10=%s mem.psi.full.avg10=%s io.psi.some.avg10=%s load=%s\n' \
+  printf '%s RUNNER_VITALS vm.mem.total.kb=%s vm.mem.avail.kb=%s mem.current=%s mem.peak=%s mem.max=%s mem.swap=%s oom=%s oom_kill=%s cpu.psi.some.avg10=%s mem.psi.some.avg10=%s mem.psi.full.avg10=%s io.psi.some.avg10=%s load=%s\n' \
     "$(date -u +%FT%TZ)" \
+    "$(meminfo MemTotal)" \
+    "$(meminfo MemAvailable)" \
     "$(field "$cg/memory.current")" \
     "$(field "$cg/memory.peak")" \
     "$(field "$cg/memory.max")" \

--- a/infra/linux-runner-image/vitals.sh
+++ b/infra/linux-runner-image/vitals.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Periodic resource-vitals emitter for the Linux runner.
+#
+# A runner that dies mid-job ("self-hosted runner lost communication
+# with the server") leaves nothing behind: the kata microVM is torn
+# down and reaped, and every external vantage point (k8s events, node
+# metrics, GitHub) is blind to what happened *inside* the guest. This
+# script closes that gap. dispatch-poll.sh launches it in the
+# background right before exec'ing the runner, so it samples for the
+# job's lifetime and its last line before a death lands in the Pod's
+# stdout -> Pod logs -> Loki, surviving the VM.
+#
+# Each line is tagged RUNNER_VITALS so it filters cleanly in Loki.
+# It distinguishes the two leading death modes:
+#   - guest OOM           -> oom_kill increments / kmsg.oom line
+#   - CPU/mem starvation  -> cpu.psi / mem.psi avg10 climb, mem.current
+#                            approaching mem.max
+#
+# Dependency-free and best-effort: unreadable files (PSI disabled in
+# the guest kernel, cgroup v1, restricted /dev/kmsg) degrade to empty
+# fields, never an error, so this can never block or fail the runner.
+# It only runs while a job executes, so idle warm Pods stay quiet.
+set -u
+
+interval="${TUIST_RUNNER_VITALS_INTERVAL:-3}"
+cg="/sys/fs/cgroup"
+
+# Read a single cgroup/proc value, stripped of its trailing newline.
+field() { [ -r "$1" ] && tr -d '\n' <"$1" 2>/dev/null || true; }
+
+# Pull a named counter out of cgroup v2 memory.events (e.g. oom_kill).
+events() {
+  [ -r "$cg/memory.events" ] && awk -v k="$1" '$1==k{print $2}' "$cg/memory.events" 2>/dev/null || true
+}
+
+# avg10 of a PSI class (some|full) from a /proc/pressure/* file.
+psi() {
+  [ -r "$1" ] || return 0
+  awk -v c="$2" '$1==c{for(i=2;i<=NF;i++){split($i,a,"=");if(a[1]=="avg10")print a[2]}}' "$1" 2>/dev/null || true
+}
+
+# Best-effort guest-kernel OOM watcher. Reading /dev/kmsg needs an
+# unrestricted guest (kernel.dmesg_restrict=0) or capability; when it
+# is readable, an OOM kill shows up here verbatim, which is the
+# ground-truth signal. When it is not, the cgroup oom_kill counter
+# below is the privilege-free fallback.
+if [ -r /dev/kmsg ]; then
+  (
+    while IFS= read -r line; do
+      case "$line" in
+        *"oom-kill:"* | *"Out of memory:"* | *"Killed process"*)
+          printf '%s RUNNER_VITALS kmsg.oom %s\n' "$(date -u +%FT%TZ)" "${line#*;}"
+          ;;
+      esac
+    done <"/dev/kmsg"
+  ) &
+fi
+
+while :; do
+  printf '%s RUNNER_VITALS mem.current=%s mem.peak=%s mem.max=%s mem.swap=%s oom=%s oom_kill=%s cpu.psi.some.avg10=%s mem.psi.some.avg10=%s mem.psi.full.avg10=%s io.psi.some.avg10=%s load=%s\n' \
+    "$(date -u +%FT%TZ)" \
+    "$(field "$cg/memory.current")" \
+    "$(field "$cg/memory.peak")" \
+    "$(field "$cg/memory.max")" \
+    "$(field "$cg/memory.swap.current")" \
+    "$(events oom)" \
+    "$(events oom_kill)" \
+    "$(psi /proc/pressure/cpu some)" \
+    "$(psi /proc/pressure/memory some)" \
+    "$(psi /proc/pressure/memory full)" \
+    "$(psi /proc/pressure/io some)" \
+    "$(cut -d' ' -f1-3 /proc/loadavg 2>/dev/null | tr ' ' ',')"
+  sleep "$interval"
+done


### PR DESCRIPTION
## What this does

Makes a Linux runner that dies mid-job ("self-hosted runner lost communication with the server") **diagnosable**, end to end: a resource-vitals probe in the runner image, plus the log-collection change that actually gets its output to Grafana.

## Why

When a Linux runner dies mid-job, there is currently no trail. The kata microVM is single-shot and reaped on exit, and every external vantage point is clean by construction: no `OOMKilled` (a guest-internal OOM never trips the host cgroup), no node `SystemOOM`, no eviction, no controller reap, and no GitHub incident. The failure happens inside the guest VM, which has zero telemetry. Observed across many deaths: they consistently land on the job's heaviest step (docker build, dependency install, cache restore, `tuist cache`), never on light steps, which points at the workload starving or OOM-ing the runner agent inside its VM until its heartbeat to GitHub dies. This PR makes that provable instead of inferred.

## The change (three parts)

1. **`vitals.sh` probe** (`infra/linux-runner-image/`). `run-job.sh` backgrounds it just before exec'ing the runner (and the `dispatch-poll.sh` rollout-bridge path does too), so it samples for the job's lifetime and its last line before a death lands in the Pod logs. Every line is tagged `RUNNER_VITALS` and is logfmt-shaped, distinguishing the two leading death modes:
   - **Guest OOM**: `memory.events` `oom_kill` increments, and/or a `/dev/kmsg` `Out of memory: Killed process` line.
   - **CPU/memory starvation**: `/proc/pressure/{cpu,memory}` `avg10` climbs, `mem.current` approaches `mem.max`.
   - Fields: cgroup `memory.current/peak/max/swap`, `memory.events` (`oom`, `oom_kill`), guest-wide `vm.mem.total/avail` from `/proc/meminfo`, CPU/mem/io PSI `avg10`, loadavg, and a best-effort `/dev/kmsg` OOM watcher.

2. **Log collection (`infra/helm/k8s-monitoring`)**. The probe writes to stdout, but the `alloy-logs` DaemonSet that ships Pod logs to Loki did **not** tolerate the bare-metal runner taint (`tuist.dev/runner-tier=bare-metal:NoSchedule`), so it never scheduled on the runner nodes and their logs never reached Loki. Without this, the probe would be a no-op in production. Added the toleration to the `alloy-logs` collector so the DaemonSet lands on the runner nodes too.

3. **Review-feedback hardening** on the probe:
   - **dind scope**: the cgroup `mem.*`/`oom_kill` fields are scoped to the runner container, but heavy steps run in the dind sidecar. Added guest-wide `vm.mem.total/avail` (`/proc/meminfo`, the whole microVM), which together with the already-guest-wide PSI fields and the `/dev/kmsg` watcher cover a Docker/buildkit OOM or pressure living in the sidecar.
   - **interval clamp**: `TUIST_RUNNER_VITALS_INTERVAL` is clamped to a positive integer so a 0/empty/non-numeric value cannot spin the loop and flood logs.
   - **CI**: `vitals.sh` added to the `linux-runner-image` workflow's `bash -n` syntax check.

## How vitals surface

Grafana Explore, Loki datasource:
```
{namespace="tuist-runners"} |= "RUNNER_VITALS" | logfmt
```
The dead runner's pod name equals the GitHub `runner_name`, so you filter to the exact victim and read its last samples. `| logfmt` exposes `mem_current`, `oom_kill`, `cpu_psi_some_avg10`, `vm_mem_avail_kb`, etc. as numeric fields, so it can be graphed and alerted on with no metrics-pipeline change.

## Design notes

- **Fail-open**: every read in `vitals.sh` is guarded; an unreadable file (PSI disabled in the guest kernel, cgroup v1, restricted `/dev/kmsg`) degrades to an empty field, never an error. It can never block or fail the runner, and only runs while a job executes, so idle warm Pods stay quiet.
- **Toleration placement**: it sits under the collector's `controller:` block deliberately. A top-level `tolerations` on the collector renders to `spec.tolerations` on the Alloy CR, which the alloy-operator ignores; `controller.tolerations` renders to `spec.controller.tolerations`, which it applies to the DaemonSet. Verified by `helm template`.

## Scope and follow-ups

- **Linux only.** macOS Tart VMs have no log egress (their logs die with the VM, and the `alloy-logs` Linux DaemonSet cannot run on macOS nodes), so a macOS probe needs a network sink (a SA-authed `/api/internal/runners/vitals` server endpoint). Tracked separately.
- **Diagnostic, not a fix.** This deliberately changes no runner behavior; it exists so the next disconnect resolves to OOM vs starvation vs genuine external, after which the real fix (shape sizing, dind memory caps, CPU oversubscription) can be chosen with evidence.
- A Grafana panel/alert (e.g. `oom_kill > 0`, per-pool memory/PSI) is intentionally deferred until this deploys and the field shape is confirmed against real Loki data.

## Validation

- `bash -n` and `shellcheck -S warning` clean on `vitals.sh`, `run-job.sh`, `dispatch-poll.sh`; interval clamp and `/proc/meminfo` parser unit-checked.
- `helm template` confirms the toleration renders at `spec.controller.tolerations` on the `alloy-logs` Alloy CR.
- The image's own CI (`linux-runner-image.yml` on pull_request) builds the image.
