### PR TITLE
feat(infra): mirror runner Docker Hub pulls through mirror.gcr.io

### DIFF
--- a/.github/workflows/runners-controller-image.yml
+++ b/.github/workflows/runners-controller-image.yml
@@ -68,14 +68,6 @@ jobs:
   build:
     needs: test
     if: github.event_name != 'pull_request'
-    # TEMPORARY: GitHub-hosted while we bootstrap the Docker Hub
-    # registry-mirror fix. This build pulls golang:alpine + buildkit
-    # from Docker Hub through the dind dockerd, which on tuist-linux
-    # has no mirror yet and trips the per-IP rate limit — the very
-    # bug this image's change fixes. ubuntu-latest pulls via GitHub's
-    # rotating IP pool instead of the fleet's shared egress IP.
-    # Revert to `tuist-linux` once the mirrored controller is rolled
-    # out fleet-wide.
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/runners-controller-image.yml
+++ b/.github/workflows/runners-controller-image.yml
@@ -68,7 +68,15 @@ jobs:
   build:
     needs: test
     if: github.event_name != 'pull_request'
-    runs-on: tuist-linux
+    # TEMPORARY: GitHub-hosted while we bootstrap the Docker Hub
+    # registry-mirror fix. This build pulls golang:alpine + buildkit
+    # from Docker Hub through the dind dockerd, which on tuist-linux
+    # has no mirror yet and trips the per-IP rate limit — the very
+    # bug this image's change fixes. ubuntu-latest pulls via GitHub's
+    # rotating IP pool instead of the fleet's shared egress IP.
+    # Revert to `tuist-linux` once the mirrored controller is rolled
+    # out fleet-wide.
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: docker/setup-qemu-action@v3

--- a/.github/workflows/server-deployment.yml
+++ b/.github/workflows/server-deployment.yml
@@ -118,7 +118,15 @@ jobs:
     # the dind sidecar) OOMs the 2 vCPU / 8 GB default microVM, killing the
     # runner mid-build ("lost communication"). Mirrors server.yml's
     # docker_build job.
-    runs-on: tuist-linux-large
+    # TEMPORARY: on ubuntu-latest (4 vCPU / 16 GB — same memory as
+    # tuist-linux-large) while we bootstrap the Docker Hub registry-mirror
+    # fix. The tuist-linux fleet shares one egress IP, so this build's
+    # `FROM` pulls trip the unauthenticated rate limit (toomanyrequests).
+    # ubuntu-latest pulls via GitHub's rotating IP pool. Revert to
+    # `tuist-linux-large` once the mirrored controller is rolled out
+    # fleet-wide. Watch root-disk headroom — the heavy multi-stage image
+    # can crowd ubuntu-latest's ~14 GB free `/`.
+    runs-on: ubuntu-latest
     # 60m absorbs a fully cold build (no buildcache hits).
     timeout-minutes: 60
     outputs:

--- a/.github/workflows/server-deployment.yml
+++ b/.github/workflows/server-deployment.yml
@@ -118,14 +118,6 @@ jobs:
     # the dind sidecar) OOMs the 2 vCPU / 8 GB default microVM, killing the
     # runner mid-build ("lost communication"). Mirrors server.yml's
     # docker_build job.
-    # TEMPORARY: on ubuntu-latest (4 vCPU / 16 GB — same memory as
-    # tuist-linux-large) while we bootstrap the Docker Hub registry-mirror
-    # fix. The tuist-linux fleet shares one egress IP, so this build's
-    # `FROM` pulls trip the unauthenticated rate limit (toomanyrequests).
-    # ubuntu-latest pulls via GitHub's rotating IP pool. Revert to
-    # `tuist-linux-large` once the mirrored controller is rolled out
-    # fleet-wide. Watch root-disk headroom — the heavy multi-stage image
-    # can crowd ubuntu-latest's ~14 GB free `/`.
     runs-on: ubuntu-latest
     # 60m absorbs a fully cold build (no buildcache hits).
     timeout-minutes: 60

--- a/.github/workflows/server-production-deployment.yml
+++ b/.github/workflows/server-production-deployment.yml
@@ -84,7 +84,15 @@ jobs:
     # the dind sidecar) OOMs the 2 vCPU / 8 GB default microVM, killing the
     # runner mid-build ("lost communication"). Mirrors server.yml's
     # docker_build job.
-    runs-on: tuist-linux-large
+    # TEMPORARY: on ubuntu-latest (4 vCPU / 16 GB — same memory as
+    # tuist-linux-large) while we bootstrap the Docker Hub registry-mirror
+    # fix. The tuist-linux fleet shares one egress IP, so this build's
+    # `FROM` pulls trip the unauthenticated rate limit (toomanyrequests).
+    # ubuntu-latest pulls via GitHub's rotating IP pool. Revert to
+    # `tuist-linux-large` once the mirrored controller is rolled out
+    # fleet-wide. Watch root-disk headroom — the heavy multi-stage image
+    # can crowd ubuntu-latest's ~14 GB free `/`.
+    runs-on: ubuntu-latest
     timeout-minutes: 40
     outputs:
       image_tag: ${{ steps.tag.outputs.image_tag }}

--- a/.github/workflows/server-production-deployment.yml
+++ b/.github/workflows/server-production-deployment.yml
@@ -84,14 +84,6 @@ jobs:
     # the dind sidecar) OOMs the 2 vCPU / 8 GB default microVM, killing the
     # runner mid-build ("lost communication"). Mirrors server.yml's
     # docker_build job.
-    # TEMPORARY: on ubuntu-latest (4 vCPU / 16 GB — same memory as
-    # tuist-linux-large) while we bootstrap the Docker Hub registry-mirror
-    # fix. The tuist-linux fleet shares one egress IP, so this build's
-    # `FROM` pulls trip the unauthenticated rate limit (toomanyrequests).
-    # ubuntu-latest pulls via GitHub's rotating IP pool. Revert to
-    # `tuist-linux-large` once the mirrored controller is rolled out
-    # fleet-wide. Watch root-disk headroom — the heavy multi-stage image
-    # can crowd ubuntu-latest's ~14 GB free `/`.
     runs-on: ubuntu-latest
     timeout-minutes: 40
     outputs:

--- a/infra/runners-controller/AGENTS.md
+++ b/infra/runners-controller/AGENTS.md
@@ -322,6 +322,17 @@ Shape:
   starts dockerd to cover dockerd's own fd budget. Kata's
   microVM kernel defaults nofile=1024; without both, a docker
   build that walks a non-trivial `node_modules` tree EMFILEs.
+- `--registry-mirror=https://mirror.gcr.io` passed to dockerd so
+  Docker Hub pulls route through Google's public pull-through
+  cache. Every microVM on a bare-metal host NATs through that
+  host's single egress IP, so the whole host shares one Docker
+  Hub per-IP pull budget (100/6h anon) and CI jobs trip
+  `toomanyrequests`. GCR absorbs cache misses on its own backend,
+  so the runner's IP never hits Hub for `docker.io` images;
+  dockerd only contacts Hub directly if the mirror is unreachable.
+  Mirror semantics only cover `docker.io`; gcr.io/ghcr.io/quay.io
+  pulls are unaffected. Stopgap ahead of a self-hosted
+  pull-through cache backed by our own object storage.
 
 ### Why loop-mount? (the virtio-fs / overlay2 gotcha)
 

--- a/infra/runners-controller/internal/podtemplate/podtemplate.go
+++ b/infra/runners-controller/internal/podtemplate/podtemplate.go
@@ -255,6 +255,16 @@ func Build(pool *tuistv1.RunnerPool, podName, saName, dispatchURL, dispatchInter
 				// --group pins the docker.sock GID so the runner
 				// user (member of `docker` group, GID 123) can
 				// reach it.
+				// --registry-mirror routes Docker Hub pulls through
+				// Google's public pull-through cache. Every microVM
+				// on a bare-metal host NATs through that host's single
+				// egress IP, so the whole host shares one Docker Hub
+				// per-IP pull budget (100/6h anon) and CI jobs trip
+				// "toomanyrequests". GCR absorbs cache misses on its
+				// own backend, so the runner's IP never hits Hub for
+				// docker.io images; dockerd only contacts Hub directly
+				// if the mirror itself is unreachable. Mirror semantics
+				// cover docker.io only (gcr/ghcr/quay are untouched).
 				Command: []string{"sh", "-c"},
 				Args: []string{
 					"set -e && " +
@@ -266,6 +276,7 @@ func Build(pool *tuistv1.RunnerPool, podName, saName, dispatchURL, dispatchInter
 						"mkdir -p /var/lib/docker && " +
 						"mount -o loop /mnt/dind-disk/disk.img /var/lib/docker && " +
 						"exec dockerd --host=unix:///var/run/docker.sock --group=123 " +
+						"--registry-mirror=https://mirror.gcr.io " +
 						"--default-ulimit nofile=1048576:1048576",
 				},
 				SecurityContext: &corev1.SecurityContext{

--- a/infra/runners-controller/internal/podtemplate/podtemplate_test.go
+++ b/infra/runners-controller/internal/podtemplate/podtemplate_test.go
@@ -1,6 +1,7 @@
 package podtemplate
 
 import (
+	"strings"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -239,6 +240,18 @@ func TestBuild_LinuxPodGetsDindSidecar(t *testing.T) {
 				t.Errorf("dind-storage EmptyDir.Medium = %q, want \"\" (node disk)", v.EmptyDir.Medium)
 			}
 		}
+	}
+}
+
+func TestBuild_LinuxDindUsesRegistryMirror(t *testing.T) {
+	// dockerd must launch with a Docker Hub pull-through mirror.
+	// Every microVM on a bare-metal host shares that host's egress
+	// IP, so the fleet shares one Docker Hub per-IP pull budget;
+	// the mirror keeps CI jobs off "toomanyrequests".
+	pod := build(t, basePool("linux"))
+	dind := pod.Spec.InitContainers[0]
+	if len(dind.Args) == 0 || !strings.Contains(dind.Args[0], "--registry-mirror=https://mirror.gcr.io") {
+		t.Errorf("dind args missing --registry-mirror=https://mirror.gcr.io; got %v", dind.Args)
 	}
 }
 


### PR DESCRIPTION
## What changed

Two things, in two commits:

1. **The fix** (`feat(infra)`): the Linux runner `dind` sidecar's `dockerd` now launches with `--registry-mirror=https://mirror.gcr.io`, so Docker Hub (`docker.io`) image pulls route through Google's public pull-through cache instead of hitting Docker Hub directly.
2. **Bootstrap unblocks** (`ci(infra)`, temporary): the `runners-controller` image build and the server + Kura controller image builds (production cascade + standalone staging deploy) move to `ubuntu-latest`.

## Why

We recently enabled Docker support in the Tuist runners. Linux runner Pods run a privileged `docker:dind` sidecar, and every microVM on a bare-metal host NATs through that host's **single egress IP**. Docker Hub rate-limits by IP (100 pulls / 6h unauthenticated), so the whole host shares one budget and CI jobs started failing with `toomanyrequests`:

```
buildx failed with: toomanyrequests: You have reached your unauthenticated pull rate limit.
```

The sidecar's `dockerd` had no registry mirror and no authentication, so every `docker pull` / `FROM` went straight to `registry-1.docker.io` from the shared IP.

### Root cause of the fix's chosen shape

`mirror.gcr.io` is the lowest-effort durable mitigation that needs no infrastructure and no secret: it's a transparent Docker Hub pull-through cache. GCR absorbs cache misses on its own backend, so the runner's IP never contacts Docker Hub for `docker.io` images; `dockerd` only falls back to Hub directly if the mirror itself is unreachable (fail-safe). It's hardcoded rather than a Helm knob because there's no per-environment branch point today and a new controller *flag* would risk the `flag.Parse` -> `os.Exit(2)` CrashLoop skew; the flag here goes to `dockerd` inside the `docker:28-dind` sidecar, which supports it, so there's no skew.

### Why the temporary `ubuntu-latest` moves

Chicken-and-egg: the fix only takes effect once a **new** controller image is built and the chart redeploys, but those builds run on the rate-limited `tuist-linux` fleet and pull base images from Docker Hub through the same un-mirrored `dind`, so they fail with the very error the change fixes. The production deploy's `Build server image` job already hit this. `ubuntu-latest` pulls via GitHub's rotating IP pool instead of the fleet's shared egress IP. It's 4 vCPU / 16 GB (same memory as `tuist-linux-large`), so the Elixir release compile won't OOM.

## Rollout

1. Merge -> controller image builds on `ubuntu-latest`, lands in ghcr.
2. Deploy (production cascade): `Build server image` now runs on `ubuntu-latest`, helm rolls the mirrored controller.
3. Verify on a **fresh** runner pod: `docker info` in the dind sidecar lists `mirror.gcr.io` under Registry Mirrors and a `docker pull` succeeds. (Existing pods are unaffected; the mirror only applies to newly created pods.)
4. **Revert** the three `runs-on` changes back to `tuist-linux` / `tuist-linux-large` once the mirror is fleet-wide. Each carries a `TEMPORARY:` comment: `git grep -n "TEMPORARY: " .github/workflows`.

## Scope / follow-ups (not in this PR)

- The mirror covers the **dind dockerd** layer (the job's own pulls) only. The host **containerd** pull of `docker:28-dind` and the runner image from Docker Hub is a separate dependency on the same shared IP, bounded by per-node image caching. A host-level containerd registry mirror closes it.
- Durable fix is a **self-hosted pull-through cache** backed by our own object storage, removing the dependency on the Google-operated, unauthenticated `mirror.gcr.io`.
- Watch `ubuntu-latest` root-disk headroom (~14 GB free) for the heavy server image build; if it `ENOSPC`s, add a disk-reclaim step or switch that one job to a buildkit-level mirror.

## Validation

- `go build ./...` and `go test ./internal/podtemplate/` pass (new `TestBuild_LinuxDindUsesRegistryMirror` asserts the flag is wired into the sidecar).
- Both deploy workflow YAMLs and the controller-image workflow YAML parse.
