### PR TITLE
ci(infra): release runners-controller image on ubuntu-latest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1132,7 +1132,7 @@ jobs:
     name: Release runners-controller
     needs: check-releases
     if: needs.check-releases.outputs.runners-controller-should-release == 'true'
-    runs-on: tuist-linux
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What changed

Move the `release-runners-controller` job in `release.yml` from `tuist-linux` to `ubuntu-latest`.

## Why

Follow-up to [#11096](https://github.com/tuist/tuist/pull/11096), which added a Docker Hub pull-through mirror (`--registry-mirror=https://mirror.gcr.io`) to the runner `dind` sidecar. That fix is now on `main`, but it does **not** reach runner pods until a new `runners-controller` version is released: the chart pins `runnersController.image.tag` in `values-managed-common.yaml` (currently `0.7.0`, cut *before* the mirror merged), and only `release-runners-controller` bumps it (building the mirrored image and committing the pin bump).

The problem: `release-runners-controller` runs on `tuist-linux` and does a `docker/build-push` of the controller Dockerfile, whose `FROM golang:alpine` plus the buildkit image are pulled from Docker Hub through the same un-mirrored `dind`. So the release that is supposed to *ship* the mirror trips the very rate limit it fixes:

```
toomanyrequests: You have reached your unauthenticated pull rate limit.
```

This is the last link in the bootstrap chicken-and-egg. #11096 already moved the controller-image, server, and Kura builds to `ubuntu-latest`; this was the one Docker-building job on the mirror's critical path that was missed.

`ubuntu-latest` pulls via GitHub's rotating IP pool rather than the fleet's single shared egress IP. The controller build is a CGO-free Go cross-compile into a distroless image (no QEMU emulation), so it's cheap on a hosted runner.

## Rollout impact

Once merged, the next `runners-controller` release (triggered by #11096's `feat(infra)` commit, which touches `infra/runners-controller/**`) can build the mirrored image and bump the pin. The deploy from that bump commit is what activates the mirror on freshly-created runner pods.

## Scope / not included

The sibling release jobs build on `tuist-linux` too and share the same Docker Hub exposure until the mirror is fleet-wide, but they're off the mirror's critical path and left as-is for now:

- `release-server` (`tuist-linux-large`)
- `release-kura-docker`, `release-cache`, `release-capi-scaleway`, `release-hetzner-robot-controller`, `release-linux-runner-image` (`tuist-linux`)

## Revert

Temporary. Revert to `tuist-linux` once the mirrored controller is rolled out fleet-wide.

## Validation

`release.yml` parses (YAML lint). Change is a single `runs-on` line scoped to the `release-runners-controller` job; the adjacent `release-hetzner-robot-controller` job is unchanged.
