### PR TITLE
test(cli): re-enable 128 disabled local acceptance tests across 4 targets

### DIFF
--- a/cli/Tests/TuistAutomationAcceptanceTests/BuildAcceptanceTests.swift
+++ b/cli/Tests/TuistAutomationAcceptanceTests/BuildAcceptanceTests.swift
@@ -14,7 +14,6 @@ import TuistTesting
 
 struct BuildAcceptanceTestMultiplatformAppWithExtension {
     @Test(
-        .disabled(),
         .withFixture("generated_multiplatform_app_with_extension"),
         .inTemporaryDirectory,
         .withMockedEnvironment()
@@ -50,7 +49,6 @@ struct BuildAcceptanceTestMultiplatformAppWithExtension {
 
 struct BuildAcceptanceTestFrameworkBuildableFoldersAndXcassets {
     @Test(
-        .disabled(),
         .withFixture("generated_ios_app_with_framework_buildable_folders_and_xcassets"),
         .inTemporaryDirectory,
         .withMockedEnvironment()
@@ -96,7 +94,7 @@ struct BuildAcceptanceTestAppWithBuildableFolders {
 }
 
 struct BuildAcceptanceTestWithTemplates {
-    @Test(.disabled(), .inTemporaryDirectory, .withMockedDependencies())
+    @Test(.inTemporaryDirectory, .withMockedDependencies())
     func with_templates() async throws {
         let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
         let initAnswers = InitPromptAnswers(
@@ -158,7 +156,7 @@ struct BuildAcceptanceTestWithTemplates {
 }
 
 struct BuildAcceptanceTestInvalidArguments {
-    @Test(.disabled(), .inTemporaryDirectory, .withMockedDependencies())
+    @Test(.inTemporaryDirectory, .withMockedDependencies())
     func with_invalid_arguments() async throws {
         let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
         let initAnswers = InitPromptAnswers(
@@ -264,7 +262,7 @@ struct BuildAcceptanceTestInvalidArguments {
 }
 
 struct BuildAcceptanceTestAppWithPreviews {
-    @Test(.disabled(), .withFixture("generated_app_with_previews"), .inTemporaryDirectory)
+    @Test(.withFixture("generated_app_with_previews"), .inTemporaryDirectory)
     func with_previews() async throws {
         let fixtureDirectory = try #require(TuistTest.fixtureDirectory)
         let derivedDataPath = try #require(FileSystem.temporaryTestDirectory)
@@ -316,7 +314,7 @@ struct BuildAcceptanceTestAppWithFrameworkAndTests {
 // }
 
 struct BuildAcceptanceTestiOSAppWithCustomConfigurationAndBuildToCustomDirectory {
-    @Test(.disabled(), .withFixture("generated_ios_app_with_custom_configuration"), .inTemporaryDirectory)
+    @Test(.withFixture("generated_ios_app_with_custom_configuration"), .inTemporaryDirectory)
     func ios_app_with_custom_and_build_to_custom_directory() async throws {
         let fixturePath = try #require(TuistTest.fixtureDirectory)
         let derivedDataPath = try #require(FileSystem.temporaryTestDirectory)
@@ -371,7 +369,7 @@ struct BuildAcceptanceTestiOSAppWithCustomConfigurationAndBuildToCustomDirectory
 }
 
 struct BuildAcceptanceTestFrameworkWithSwiftMacroIntegratedWithStandardMethod {
-    @Test(.disabled(), .withFixture("generated_framework_with_swift_macro"), .inTemporaryDirectory)
+    @Test(.withFixture("generated_framework_with_swift_macro"), .inTemporaryDirectory)
     func framework_with_swift_macro_integrated_with_standard_method() async throws {
         let fixtureDirectory = try #require(TuistTest.fixtureDirectory)
         let derivedDataPath = try #require(FileSystem.temporaryTestDirectory)
@@ -392,7 +390,7 @@ struct BuildAcceptanceTestFrameworkWithSwiftMacroIntegratedWithStandardMethod {
 }
 
 struct BuildAcceptanceTestFrameworkWithSwiftMacroIntegratedWithXcodeProjPrimitives {
-    @Test(.disabled(), .withFixture("generated_framework_with_native_swift_macro"), .inTemporaryDirectory)
+    @Test(.withFixture("generated_framework_with_native_swift_macro"), .inTemporaryDirectory)
     func framework_with_swift_macro_integrated_with_xcode_proj_primitives() async throws {
         let fixtureDirectory = try #require(TuistTest.fixtureDirectory)
         let derivedDataPath = try #require(FileSystem.temporaryTestDirectory)
@@ -426,7 +424,7 @@ struct BuildAcceptanceTestFrameworkWithSwiftMacroIntegratedWithXcodeProjPrimitiv
 }
 
 struct BuildAcceptanceTestMultiplatformAppWithSDK {
-    @Test(.disabled(), .withFixture("generated_multiplatform_app_with_sdk"), .inTemporaryDirectory)
+    @Test(.withFixture("generated_multiplatform_app_with_sdk"), .inTemporaryDirectory)
     func test() async throws {
         let fixtureDirectory = try #require(TuistTest.fixtureDirectory)
         let derivedDataPath = try #require(FileSystem.temporaryTestDirectory)
@@ -453,7 +451,6 @@ struct BuildAcceptanceTestMultiplatformAppWithSDK {
 
 struct BuildAcceptanceTestMultiplatformµFeatureUnitTestsWithExplicitDependencies {
     @Test(
-        .disabled(),
         .withFixture("generated_multiplatform_µFeature_unit_tests_with_explicit_dependencies"),
         .inTemporaryDirectory
     )
@@ -491,7 +488,6 @@ struct BuildAcceptanceTestMultiplatformµFeatureUnitTestsWithExplicitDependencie
 
 struct BuildAcceptanceTestMultiplatformAppWithMacrosAndEmbeddedWatchOSApp {
     @Test(
-        .disabled(),
         .withFixture("generated_multiplatform_app_with_macros_and_embedded_watchos_app"),
         .inTemporaryDirectory
     )
@@ -551,7 +547,6 @@ struct XcodeBuildBuildCommandAcceptanceTests {
 
 struct XcodeBuildTestCommandAcceptanceTests {
     @Test(
-        .disabled(),
         .withFixture("generated_ios_app_with_tests"),
         .inTemporaryDirectory,
         .withMockedEnvironment()
@@ -580,7 +575,6 @@ struct XcodeBuildTestCommandAcceptanceTests {
 
 struct XcodeBuildBuildForTestingCommandAcceptanceTests {
     @Test(
-        .disabled(),
         .withFixture("generated_ios_app_with_tests"),
         .inTemporaryDirectory,
         .withMockedEnvironment()
@@ -609,7 +603,6 @@ struct XcodeBuildBuildForTestingCommandAcceptanceTests {
 
 struct XcodeBuildTestWithoutBuildingCommandAcceptanceTests {
     @Test(
-        .disabled(),
         .withFixture("generated_ios_app_with_tests"),
         .inTemporaryDirectory,
         .withMockedEnvironment()
@@ -725,7 +718,6 @@ struct XcodeBuildArchiveCommandAcceptanceTests {
 
 struct XcodeBuildUnorderedBuildCommandAcceptanceTests {
     @Test(
-        .disabled(),
         .withFixture("generated_ios_app_with_tests"),
         .inTemporaryDirectory,
         .withMockedEnvironment()

--- a/cli/Tests/TuistAutomationAcceptanceTests/TestAcceptanceTests.swift
+++ b/cli/Tests/TuistAutomationAcceptanceTests/TestAcceptanceTests.swift
@@ -13,7 +13,6 @@ import TuistTesting
 
 struct TestAcceptanceTestiOSAppWithFrameworks {
     @Test(
-        .disabled(),
         .withFixture("generated_ios_app_with_frameworks"),
         .inTemporaryDirectory,
         .withMockedEnvironment(),
@@ -31,7 +30,6 @@ struct TestAcceptanceTestiOSAppWithFrameworks {
 
 struct TestAcceptanceTestAppWithFrameworkAndTests {
     @Test(
-        .disabled(),
         .withFixture("generated_app_with_framework_and_tests"),
         .inTemporaryDirectory,
         .withMockedEnvironment(),
@@ -72,7 +70,7 @@ struct TestAcceptanceTestAppWithFrameworkAndTests {
 }
 
 struct TestAcceptanceTestFrameworkWithSPMBundle {
-    @Test(.disabled(), .withFixture("generated_framework_with_spm_bundle"), .inTemporaryDirectory)
+    @Test(.withFixture("generated_framework_with_spm_bundle"), .inTemporaryDirectory)
     func with_framework_with_spm_bundle() async throws {
         let fixtureDirectory = try #require(TuistTest.fixtureDirectory)
         let derivedDataPath = try #require(FileSystem.temporaryTestDirectory)
@@ -85,7 +83,7 @@ struct TestAcceptanceTestFrameworkWithSPMBundle {
 }
 
 struct TestAcceptanceTestAppWithTestPlan {
-    @Test(.disabled(), .withFixture("generated_app_with_test_plan"), .inTemporaryDirectory)
+    @Test(.withFixture("generated_app_with_test_plan"), .inTemporaryDirectory)
     func with_app_with_test_plan() async throws {
         let fixtureDirectory = try #require(TuistTest.fixtureDirectory)
         let derivedDataPath = try #require(FileSystem.temporaryTestDirectory)
@@ -109,7 +107,7 @@ struct TestAcceptanceTestAppWithTestPlan {
 }
 
 struct TestAcceptanceTestAppWorkspaceWithTestPlan {
-    @Test(.disabled(), .withFixture("generated_app_workspace_with_test_plan"), .inTemporaryDirectory)
+    @Test(.withFixture("generated_app_workspace_with_test_plan"), .inTemporaryDirectory)
     func with_app_workspace_with_test_plan() async throws {
         let fixtureDirectory = try #require(TuistTest.fixtureDirectory)
         let derivedDataPath = try #require(FileSystem.temporaryTestDirectory)

--- a/cli/Tests/TuistDependenciesAcceptanceTests/DependenciesAcceptanceTests.swift
+++ b/cli/Tests/TuistDependenciesAcceptanceTests/DependenciesAcceptanceTests.swift
@@ -21,7 +21,6 @@ import TuistTesting
 @Suite(.serialized)
 struct DependenciesAcceptanceTests {
     @Test(
-        .disabled(),
         .inTemporaryDirectory,
         .withMockedEnvironment(inheritingVariables: ["PATH"]),
         .withMockedNoora,
@@ -259,7 +258,7 @@ struct DependenciesAcceptanceTestIosAppWithLocalSPMPackageGenerate {
 }
 
 struct DependenciesAcceptanceTestAppAlamofire {
-    @Test(.disabled(), .withFixture("generated_app_with_alamofire"), .inTemporaryDirectory)
+    @Test(.withFixture("generated_app_with_alamofire"), .inTemporaryDirectory)
     func app_with_alamofire() async throws {
         let fixtureDirectory = try #require(TuistTest.fixtureDirectory)
         let derivedDataPath = try #require(FileSystem.temporaryTestDirectory)
@@ -274,7 +273,6 @@ struct DependenciesAcceptanceTestAppAlamofire {
 
 struct DependenciesAcceptanceTestAppWithObjCStaticFrameworkWithResources {
     @Test(
-        .disabled(),
         .withFixture("generated_ios_app_with_static_frameworks_with_resources"),
         .inTemporaryDirectory
     )
@@ -342,7 +340,6 @@ struct DependenciesAcceptanceTestAppWithObjCStaticFrameworkWithResources {
 
     #if canImport(TuistCacheEE)
         @Test(
-            .disabled(),
             .withFixture("generated_ios_app_with_static_frameworks_with_resources"),
             .inTemporaryDirectory
         )
@@ -444,7 +441,7 @@ struct DependenciesAcceptanceTestAppWithObjCStaticFrameworkWithResources {
 }
 
 struct DependenciesAcceptanceTestAppPocketSVG {
-    @Test(.disabled(), .withFixture("generated_app_with_pocket_svg"), .inTemporaryDirectory)
+    @Test(.withFixture("generated_app_with_pocket_svg"), .inTemporaryDirectory)
     func app_with_pocket_svg() async throws {
         let fixtureDirectory = try #require(TuistTest.fixtureDirectory)
         let derivedDataPath = try #require(FileSystem.temporaryTestDirectory)
@@ -458,7 +455,7 @@ struct DependenciesAcceptanceTestAppPocketSVG {
 }
 
 struct DependenciesAcceptanceTestAppSBTUITestTunnel {
-    @Test(.disabled(), .withFixture("generated_app_with_sbtuitesttunnel"), .inTemporaryDirectory)
+    @Test(.withFixture("generated_app_with_sbtuitesttunnel"), .inTemporaryDirectory)
     func app_with_sbtuitesttunnel() async throws {
         let fixtureDirectory = try #require(TuistTest.fixtureDirectory)
         let derivedDataPath = try #require(FileSystem.temporaryTestDirectory)
@@ -472,7 +469,7 @@ struct DependenciesAcceptanceTestAppSBTUITestTunnel {
 }
 
 struct DependenciesAcceptanceTestIosAppWithSPMDependencies {
-    @Test(.disabled(), .withFixture("generated_ios_app_with_spm_dependencies"), .inTemporaryDirectory)
+    @Test(.withFixture("generated_ios_app_with_spm_dependencies"), .inTemporaryDirectory)
     func ios_app_spm_dependencies() async throws {
         let fixtureDirectory = try #require(TuistTest.fixtureDirectory)
         let derivedDataPath = try #require(FileSystem.temporaryTestDirectory)
@@ -495,7 +492,6 @@ struct DependenciesAcceptanceTestIosAppWithSPMDependencies {
 
 struct DependenciesAcceptanceTestIosAppWithSPMDependenciesForceResolvedVersions {
     @Test(
-        .disabled(),
         .withFixture("generated_ios_app_with_spm_dependencies_forced_resolved_versions"),
         .inTemporaryDirectory
     )
@@ -520,7 +516,7 @@ struct DependenciesAcceptanceTestIosAppWithSPMDependenciesForceResolvedVersions 
 }
 
 struct DependenciesAcceptanceTestIosAppWithSPMDependenciesWithOutdatedDependencies {
-    @Test(.disabled(), .withFixture("generated_ios_app_with_spm_dependencies"), .withMockedDependencies())
+    @Test(.withFixture("generated_ios_app_with_spm_dependencies"), .withMockedDependencies())
     func test() async throws {
         let fileSystem = FileSystem()
         let fixtureDirectory = try #require(TuistTest.fixtureDirectory)
@@ -539,7 +535,7 @@ struct DependenciesAcceptanceTestIosAppWithSPMDependenciesWithOutdatedDependenci
 }
 
 struct DependenciesAcceptanceTestAppWithComposableArchitecture {
-    @Test(.disabled(), .withFixture("generated_app_with_composable_architecture"), .inTemporaryDirectory)
+    @Test(.withFixture("generated_app_with_composable_architecture"), .inTemporaryDirectory)
     func app_with_composable_architecture() async throws {
         let fixtureDirectory = try #require(TuistTest.fixtureDirectory)
         let derivedDataPath = try #require(FileSystem.temporaryTestDirectory)
@@ -553,7 +549,7 @@ struct DependenciesAcceptanceTestAppWithComposableArchitecture {
 }
 
 struct DependenciesAcceptanceTestAppWithRealm {
-    @Test(.disabled(), .withFixture("generated_app_with_realm"), .inTemporaryDirectory)
+    @Test(.withFixture("generated_app_with_realm"), .inTemporaryDirectory)
     func app_with_realm() async throws {
         let fixtureDirectory = try #require(TuistTest.fixtureDirectory)
         let derivedDataPath = try #require(FileSystem.temporaryTestDirectory)
@@ -567,7 +563,7 @@ struct DependenciesAcceptanceTestAppWithRealm {
 }
 
 struct DependenciesAcceptanceTestAppSPMXCFrameworkDependency {
-    @Test(.disabled(), .withFixture("generated_app_with_spm_xcframework_dependency"), .inTemporaryDirectory)
+    @Test(.withFixture("generated_app_with_spm_xcframework_dependency"), .inTemporaryDirectory)
     func app_spm_xcframework_dependency() async throws {
         let fixtureDirectory = try #require(TuistTest.fixtureDirectory)
         let derivedDataPath = try #require(FileSystem.temporaryTestDirectory)
@@ -581,7 +577,7 @@ struct DependenciesAcceptanceTestAppSPMXCFrameworkDependency {
 }
 
 struct DependenciesAcceptanceTestAppWithAirshipSDK {
-    @Test(.disabled(), .withFixture("generated_app_with_airship_sdk"), .inTemporaryDirectory)
+    @Test(.withFixture("generated_app_with_airship_sdk"), .inTemporaryDirectory)
     func app_with_airship_sdk() async throws {
         let fixtureDirectory = try #require(TuistTest.fixtureDirectory)
         let derivedDataPath = try #require(FileSystem.temporaryTestDirectory)

--- a/cli/Tests/TuistGeneratorAcceptanceTests/GenerateAcceptanceTests.swift
+++ b/cli/Tests/TuistGeneratorAcceptanceTests/GenerateAcceptanceTests.swift
@@ -18,7 +18,7 @@ import TuistTestCommand
 @testable import TuistKit
 
 struct GeneratorAcceptanceTests {
-    @Test(.disabled(), .withFixture("generated_app_with_framework_and_tests"))
+    @Test(.withFixture("generated_app_with_framework_and_tests"))
     func app_with_framework_and_tests() async throws {
         // Given
         let fixtureDirectory = try #require(TuistTest.fixtureDirectory)
@@ -31,7 +31,7 @@ struct GeneratorAcceptanceTests {
         try TuistTest.expectFrameworkNotEmbedded("Framework", by: "AppExtension", inXcodeProj: xcodeprojPath)
     }
 
-    @Test(.disabled(), .withFixture("generated_app_with_exponea_sdk"), .withMockedLogger())
+    @Test(.withFixture("generated_app_with_exponea_sdk"), .withMockedLogger())
     func app_with_exponea_sdk() async throws {
         // Given
         let fixtureDirectory = try #require(TuistTest.fixtureDirectory)
@@ -41,7 +41,7 @@ struct GeneratorAcceptanceTests {
         try await TuistTest.run(GenerateCommand.self, ["--path", fixtureDirectory.pathString, "--no-open"])
     }
 
-    @Test(.disabled(), .withFixture("generated_spm_dependency_with_trait_conditions"), .withMockedLogger())
+    @Test(.withFixture("generated_spm_dependency_with_trait_conditions"), .withMockedLogger())
     func spm_dependency_with_trait_conditions() async throws {
         let fixtureDirectory = try #require(TuistTest.fixtureDirectory)
 
@@ -49,7 +49,7 @@ struct GeneratorAcceptanceTests {
         try await TuistTest.run(GenerateCommand.self, ["--path", fixtureDirectory.pathString, "--no-open"])
     }
 
-    @Test(.disabled(), .withFixture("generated_ios_app_with_local_swift_package"), .withMockedLogger())
+    @Test(.withFixture("generated_ios_app_with_local_swift_package"), .withMockedLogger())
     func local_spm_dependency_with_assets() async throws {
         // Given
         let fixtureDirectory = try #require(TuistTest.fixtureDirectory)
@@ -71,7 +71,6 @@ struct GeneratorAcceptanceTests {
     }
 
     @Test(
-        .disabled(),
         .withFixture("generated_framework_with_environment_variables"),
         .withMockedLogger(),
         .withMockedEnvironment()
@@ -140,7 +139,7 @@ struct GenerateAcceptanceTestiOSAppWithTests {
         try await run(BuildCommand.self)
     }
 
-    @Test(.disabled(), .withFixture("generated_ios_app_with_tests"), .inTemporaryDirectory)
+    @Test(.withFixture("generated_ios_app_with_tests"), .inTemporaryDirectory)
     func focused_targets() async throws {
         let fixturePath = try fixtureDirectory()
 
@@ -182,7 +181,7 @@ struct GenerateAcceptanceTestiOSAppWithFrameworks {
 }
 
 struct GenerateAcceptanceTestiOSAppWithHeaders {
-    @Test(.disabled(), .withFixture("generated_ios_app_with_headers"), .inTemporaryDirectory)
+    @Test(.withFixture("generated_ios_app_with_headers"), .inTemporaryDirectory)
     func ios_app_with_headers() async throws {
         try await run(GenerateCommand.self)
         try await run(BuildCommand.self)
@@ -190,7 +189,7 @@ struct GenerateAcceptanceTestiOSAppWithHeaders {
 }
 
 struct GenerateAcceptanceTestInvalidWorkspaceManifestName {
-    @Test(.disabled(), .withFixture("generated_invalid_workspace_manifest_name"), .inTemporaryDirectory)
+    @Test(.withFixture("generated_invalid_workspace_manifest_name"), .inTemporaryDirectory)
     func invalid_workspace_manifest_name() async throws {
         let fixturePath = try fixtureDirectory()
         do {
@@ -203,7 +202,7 @@ struct GenerateAcceptanceTestInvalidWorkspaceManifestName {
 }
 
 struct GenerateAcceptanceTestCacheProfilesInvalidDefault {
-    @Test(.disabled(), .withFixture("generated_ios_app_with_cache_profiles_invalid_default"), .inTemporaryDirectory)
+    @Test(.withFixture("generated_ios_app_with_cache_profiles_invalid_default"), .inTemporaryDirectory)
     func ios_app_with_cache_profiles_invalid_default() async throws {
         do {
             try await run(GenerateCommand.self)
@@ -229,7 +228,7 @@ struct GenerateAcceptanceTestCacheProfilesInvalidDefault {
 // }
 
 struct GenerateAcceptanceTestiOSAppWithFrameworkAndResources {
-    @Test(.disabled(), .withFixture("generated_ios_app_with_framework_and_resources"), .inTemporaryDirectory)
+    @Test(.withFixture("generated_ios_app_with_framework_and_resources"), .inTemporaryDirectory)
     func ios_app_with_framework_and_resources() async throws {
         let fixturePath = try fixtureDirectory()
         try await run(GenerateCommand.self)
@@ -319,7 +318,6 @@ struct GenerateAcceptanceTestiOSAppWithFrameworkAndResources {
 
 struct GenerateAcceptanceTestiOSAppWithFrameworkXcassetsAndDefaultIntenalImports {
     @Test(
-        .disabled(),
         .withFixture("generated_ios_app_with_framework_xcassets_and_default_internal_imports"),
         .inTemporaryDirectory
     )
@@ -330,7 +328,7 @@ struct GenerateAcceptanceTestiOSAppWithFrameworkXcassetsAndDefaultIntenalImports
 }
 
 struct GenerateAcceptanceTestiOSAppWithOnDemandResources {
-    @Test(.disabled(), .withFixture("generated_ios_app_with_on_demand_resources"), .inTemporaryDirectory)
+    @Test(.withFixture("generated_ios_app_with_on_demand_resources"), .inTemporaryDirectory)
     func ios_app_with_on_demand_resources() async throws {
         let fixturePath = try fixtureDirectory()
         try await run(GenerateCommand.self)
@@ -362,7 +360,7 @@ struct GenerateAcceptanceTestiOSAppWithOnDemandResources {
 }
 
 struct GenerateAcceptanceTestiOSAppWithPrivacyManifest {
-    @Test(.disabled(), .withFixture("generated_ios_app_with_privacy_manifest"), .inTemporaryDirectory)
+    @Test(.withFixture("generated_ios_app_with_privacy_manifest"), .inTemporaryDirectory)
     func ios_app_with_privacy_manifest() async throws {
         let fixturePath = try fixtureDirectory()
         try await run(GenerateCommand.self)
@@ -377,7 +375,7 @@ struct GenerateAcceptanceTestiOSAppWithPrivacyManifest {
 }
 
 struct GenerateAcceptanceTestIosAppWithCustomDevelopmentRegion {
-    @Test(.disabled(), .withFixture("generated_ios_app_with_custom_development_region"), .inTemporaryDirectory)
+    @Test(.withFixture("generated_ios_app_with_custom_development_region"), .inTemporaryDirectory)
     func ios_app_with_custom_development_region() async throws {
         let fixturePath = try fixtureDirectory()
         try await run(GenerateCommand.self)
@@ -408,7 +406,7 @@ struct GenerateAcceptanceTestIosAppWithCustomDevelopmentRegion {
 }
 
 struct GenerateAcceptanceTestiOSAppWithCustomResourceParserOptions {
-    @Test(.disabled(), .withFixture("generated_ios_app_with_custom_resource_parser_options"), .inTemporaryDirectory)
+    @Test(.withFixture("generated_ios_app_with_custom_resource_parser_options"), .inTemporaryDirectory)
     func ios_app_with_custom_resource_parser_options() async throws {
         let fixturePath = try fixtureDirectory()
         try await run(GenerateCommand.self)
@@ -445,7 +443,7 @@ struct GenerateAcceptanceTestiOSAppWithCustomResourceParserOptions {
 }
 
 struct GenerateAcceptanceTestiOSAppWithFrameworkLinkingStaticFramework {
-    @Test(.disabled(), .withFixture("generated_ios_app_with_framework_linking_static_framework"), .inTemporaryDirectory)
+    @Test(.withFixture("generated_ios_app_with_framework_linking_static_framework"), .inTemporaryDirectory)
     func ios_app_with_framework_linking_static_framework() async throws {
         try await run(GenerateCommand.self)
         try await run(BuildCommand.self)
@@ -471,7 +469,7 @@ struct GenerateAcceptanceTestiOSAppWithFrameworkLinkingStaticFramework {
 }
 
 struct GenerateAcceptanceTestsiOSAppWithCustomScheme {
-    @Test(.disabled(), .withFixture("generated_ios_app_with_custom_scheme"), .inTemporaryDirectory)
+    @Test(.withFixture("generated_ios_app_with_custom_scheme"), .inTemporaryDirectory)
     func ios_app_with_custom_scheme() async throws {
         let fixturePath = try fixtureDirectory()
         try await run(GenerateCommand.self)
@@ -522,7 +520,7 @@ struct GenerateAcceptanceTestiOSAppWithLocalSwiftPackage {
 }
 
 struct GenerateAcceptanceTestiOSAppWithMultiConfigs {
-    @Test(.disabled(), .withFixture("generated_ios_app_with_multi_configs"), .inTemporaryDirectory)
+    @Test(.withFixture("generated_ios_app_with_multi_configs"), .inTemporaryDirectory)
     func ios_app_with_multi_configs() async throws {
         try await run(GenerateCommand.self)
         try await XCTAssertSchemeContainsBuildSettings(
@@ -565,7 +563,7 @@ struct GenerateAcceptanceTestiOSAppWithMultiConfigs {
 }
 
 struct GenerateAcceptanceTestiOSAppWithIncompatibleXcode {
-    @Test(.disabled(), .withFixture("generated_ios_app_with_incompatible_xcode"), .withMockedDependencies())
+    @Test(.withFixture("generated_ios_app_with_incompatible_xcode"), .withMockedDependencies())
     func ios_app_with_incompatible_xcode() async throws {
         do {
             try await run(GenerateCommand.self)
@@ -624,7 +622,7 @@ struct GenerateAcceptanceTestiOSAppWithIncompatibleXcode {
 // }
 
 struct GenerateAcceptanceTestiOSAppWithBuildVariables {
-    @Test(.disabled(), .withFixture("generated_ios_app_with_build_variables"), .inTemporaryDirectory)
+    @Test(.withFixture("generated_ios_app_with_build_variables"), .inTemporaryDirectory)
     func ios_app_with_build_variables() async throws {
         let fixturePath = try fixtureDirectory()
         try await run(GenerateCommand.self)
@@ -647,7 +645,7 @@ struct GenerateAcceptanceTestiOSAppWithBuildVariables {
 }
 
 struct GenerateAcceptanceTestiOSAppWithRemoteSwiftPackage {
-    @Test(.disabled(), .withFixture("generated_ios_app_with_remote_swift_package"), .inTemporaryDirectory)
+    @Test(.withFixture("generated_ios_app_with_remote_swift_package"), .inTemporaryDirectory)
     func ios_app_with_remote_swift_package() async throws {
         try await run(GenerateCommand.self)
         try await run(BuildCommand.self)
@@ -655,7 +653,7 @@ struct GenerateAcceptanceTestiOSAppWithRemoteSwiftPackage {
 }
 
 struct GenerateAcceptanceTestVisionOSAppWithRemoteSwiftPackage {
-    @Test(.disabled(), .withFixture("generated_visionos_app"), .inTemporaryDirectory)
+    @Test(.withFixture("generated_visionos_app"), .inTemporaryDirectory)
     func visionos_app() async throws {
         try await run(GenerateCommand.self)
 //        TODO: Fix
@@ -664,7 +662,7 @@ struct GenerateAcceptanceTestVisionOSAppWithRemoteSwiftPackage {
 }
 
 struct GenerateAcceptanceTestiOSAppWithLocalBinarySwiftPackage {
-    @Test(.disabled(), .withFixture("generated_ios_app_with_local_binary_swift_package"), .inTemporaryDirectory)
+    @Test(.withFixture("generated_ios_app_with_local_binary_swift_package"), .inTemporaryDirectory)
     func ios_app_with_local_binary_swift_package() async throws {
         try await run(GenerateCommand.self)
         try await run(BuildCommand.self)
@@ -757,7 +755,7 @@ struct GenerateAcceptanceTestiOSAppWithExtensions {
 // }
 
 struct GenerateAcceptanceTestiOSAppWithWatchApp2 {
-    @Test(.disabled(), .withFixture("generated_ios_app_with_watchapp2"), .inTemporaryDirectory)
+    @Test(.withFixture("generated_ios_app_with_watchapp2"), .inTemporaryDirectory)
     func ios_app_with_watchapp2() async throws {
         try await run(GenerateCommand.self)
         try await run(BuildCommand.self, "App")
@@ -792,14 +790,14 @@ struct GenerateAcceptanceTestInvalidManifest {
 }
 
 struct GenerateAcceptanceTestiOSAppLarge {
-    @Test(.disabled(), .withFixture("generated_ios_app_large"), .inTemporaryDirectory)
+    @Test(.withFixture("generated_ios_app_large"), .inTemporaryDirectory)
     func ios_app_large() async throws {
         try await run(GenerateCommand.self)
     }
 }
 
 struct GenerateAcceptanceTestiOSWorkspaceWithDependencyCycle {
-    @Test(.disabled(), .withFixture("generated_ios_workspace_with_dependency_cycle"), .inTemporaryDirectory)
+    @Test(.withFixture("generated_ios_workspace_with_dependency_cycle"), .inTemporaryDirectory)
     func ios_workspace_with_dependency_cycle() async throws {
         do {
             try await run(GenerateCommand.self)
@@ -811,7 +809,7 @@ struct GenerateAcceptanceTestiOSWorkspaceWithDependencyCycle {
 }
 
 struct GenerateAcceptanceTestiOSAppWithCoreData {
-    @Test(.disabled(), .withFixture("generated_ios_app_with_coredata"), .inTemporaryDirectory)
+    @Test(.withFixture("generated_ios_app_with_coredata"), .inTemporaryDirectory)
     func ios_app_with_coredata() async throws {
         let fileSystem = FileSystem()
         let fixturePath = try fixtureDirectory()
@@ -842,7 +840,7 @@ struct GenerateAcceptanceTestiOSAppWithCoreData {
 }
 
 struct GenerateAcceptanceTestiOSAppWithAppClip {
-    @Test(.disabled(), .withFixture("generated_ios_app_with_appclip"), .inTemporaryDirectory)
+    @Test(.withFixture("generated_ios_app_with_appclip"), .inTemporaryDirectory)
     func ios_app_with_appclip() async throws {
         try await run(GenerateCommand.self)
         try await run(BuildCommand.self)
@@ -904,7 +902,7 @@ struct GenerateAcceptanceTestGeneratedStaticFrameworkIncludesMetalLib {
 }
 
 struct GenerateAcceptanceTestCommandLineToolWithStaticLibrary {
-    @Test(.disabled(), .withFixture("generated_command_line_tool_with_static_library"), .inTemporaryDirectory)
+    @Test(.withFixture("generated_command_line_tool_with_static_library"), .inTemporaryDirectory)
     func command_line_tool_with_static_library() async throws {
         try await run(GenerateCommand.self)
         try await run(BuildCommand.self, "CommandLineTool")
@@ -912,7 +910,7 @@ struct GenerateAcceptanceTestCommandLineToolWithStaticLibrary {
 }
 
 struct GenerateAcceptanceTestCommandLineToolWithDynamicLibrary {
-    @Test(.disabled(), .withFixture("generated_command_line_tool_with_dynamic_library"), .inTemporaryDirectory)
+    @Test(.withFixture("generated_command_line_tool_with_dynamic_library"), .inTemporaryDirectory)
     func command_line_tool_with_dynamic_library() async throws {
         try await run(GenerateCommand.self)
         try await run(BuildCommand.self, "CommandLineTool")
@@ -920,7 +918,7 @@ struct GenerateAcceptanceTestCommandLineToolWithDynamicLibrary {
 }
 
 struct GenerateAcceptanceTestCommandLineToolWithDynamicFramework {
-    @Test(.disabled(), .withFixture("generated_command_line_tool_with_dynamic_framework"), .inTemporaryDirectory)
+    @Test(.withFixture("generated_command_line_tool_with_dynamic_framework"), .inTemporaryDirectory)
     func command_line_tool_with_dynamic_framework() async throws {
         try await run(GenerateCommand.self)
         try await run(BuildCommand.self, "CommandLineTool")
@@ -964,7 +962,7 @@ struct GenerateAcceptanceTestmacOSAppWithCopyFiles {
 }
 
 struct GenerateAcceptanceTestManifestWithLogs {
-    @Test(.disabled(), .withFixture("generated_manifest_with_logs"), .withMockedDependencies())
+    @Test(.withFixture("generated_manifest_with_logs"), .withMockedDependencies())
     func manifest_with_logs() async throws {
         try await run(GenerateCommand.self)
         TuistTest.expectLogs("Target name - App", at: .info, <=)
@@ -972,7 +970,7 @@ struct GenerateAcceptanceTestManifestWithLogs {
 }
 
 struct GenerateAcceptanceTestsProjectWithClassPrefix {
-    @Test(.disabled(), .withFixture("generated_project_with_class_prefix"), .inTemporaryDirectory)
+    @Test(.withFixture("generated_project_with_class_prefix"), .inTemporaryDirectory)
     func project_with_class_prefix() async throws {
         let fixturePath = try fixtureDirectory()
         try await run(GenerateCommand.self)
@@ -988,7 +986,7 @@ struct GenerateAcceptanceTestsProjectWithClassPrefix {
 }
 
 struct GenerateAcceptanceTestProjectWithFileHeaderTemplate {
-    @Test(.disabled(), .withFixture("generated_project_with_file_header_template"), .inTemporaryDirectory)
+    @Test(.withFixture("generated_project_with_file_header_template"), .inTemporaryDirectory)
     func project_with_file_header_template() async throws {
         let fileSystem = FileSystem()
         let fixturePath = try fixtureDirectory()
@@ -1007,7 +1005,7 @@ struct GenerateAcceptanceTestProjectWithFileHeaderTemplate {
 }
 
 struct GenerateAcceptanceTestProjectWithInlineFileHeaderTemplate {
-    @Test(.disabled(), .withFixture("generated_project_with_inline_file_header_template"), .inTemporaryDirectory)
+    @Test(.withFixture("generated_project_with_inline_file_header_template"), .inTemporaryDirectory)
     func project_with_inline_file_header_template() async throws {
         let fileSystem = FileSystem()
         let fixturePath = try fixtureDirectory()
@@ -1026,7 +1024,7 @@ struct GenerateAcceptanceTestProjectWithInlineFileHeaderTemplate {
 }
 
 struct GenerateAcceptanceTestWorkspaceWithFileHeaderTemplate {
-    @Test(.disabled(), .withFixture("generated_workspace_with_file_header_template"), .inTemporaryDirectory)
+    @Test(.withFixture("generated_workspace_with_file_header_template"), .inTemporaryDirectory)
     func workspace_with_file_header_template() async throws {
         let fileSystem = FileSystem()
         let fixturePath = try fixtureDirectory()
@@ -1045,7 +1043,7 @@ struct GenerateAcceptanceTestWorkspaceWithFileHeaderTemplate {
 }
 
 struct GenerateAcceptanceTestWorkspaceWithInlineFileHeaderTemplate {
-    @Test(.disabled(), .withFixture("generated_workspace_with_inline_file_header_template"), .inTemporaryDirectory)
+    @Test(.withFixture("generated_workspace_with_inline_file_header_template"), .inTemporaryDirectory)
     func workspace_with_inline_file_header_template() async throws {
         let fileSystem = FileSystem()
         let fixturePath = try fixtureDirectory()
@@ -1064,7 +1062,7 @@ struct GenerateAcceptanceTestWorkspaceWithInlineFileHeaderTemplate {
 }
 
 struct GenerateAcceptanceTestiOSAppWithFrameworkAndDisabledResources {
-    @Test(.disabled(), .withFixture("generated_ios_app_with_framework_and_disabled_resources"), .inTemporaryDirectory)
+    @Test(.withFixture("generated_ios_app_with_framework_and_disabled_resources"), .inTemporaryDirectory)
     func ios_app_with_framework_and_disabled_resources() async throws {
         let fileSystem = FileSystem()
         let fixturePath = try fixtureDirectory()
@@ -1132,7 +1130,7 @@ struct GenerateAcceptanceTestmacOSAppWithExtensions {
 }
 
 struct GenerateAcceptanceTestiOSAppWithNoneLinkingStatusFramework {
-    @Test(.disabled(), .withFixture("generated_ios_app_with_none_linking_status_framework"), .inTemporaryDirectory)
+    @Test(.withFixture("generated_ios_app_with_none_linking_status_framework"), .inTemporaryDirectory)
     func ios_app_with_none_linking_status_framework() async throws {
         let fixturePath = try fixtureDirectory()
         try await run(GenerateCommand.self)
@@ -1159,7 +1157,7 @@ struct GenerateAcceptanceTestiOSAppWithNoneLinkingStatusFramework {
 }
 
 struct GenerateAcceptanceTestiOSAppWithWeaklyLinkedFramework {
-    @Test(.disabled(), .withFixture("generated_ios_app_with_weakly_linked_framework"), .inTemporaryDirectory)
+    @Test(.withFixture("generated_ios_app_with_weakly_linked_framework"), .inTemporaryDirectory)
     func ios_app_with_weakly_linked_framework() async throws {
         let fixturePath = try fixtureDirectory()
         try await run(GenerateCommand.self)
@@ -1184,7 +1182,7 @@ struct GenerateAcceptanceTestiOSAppWithWeaklyLinkedFramework {
 }
 
 struct GenerateAcceptanceTestiOSAppWithCatalyst {
-    @Test(.disabled(), .withFixture("generated_ios_app_with_catalyst"), .inTemporaryDirectory)
+    @Test(.withFixture("generated_ios_app_with_catalyst"), .inTemporaryDirectory)
     func ios_app_with_catalyst() async throws {
         let osVersion = ProcessInfo.processInfo.operatingSystemVersion
         if osVersion.majorVersion >= 26 {
@@ -1204,7 +1202,7 @@ struct GenerateAcceptanceTestiOSAppWithCatalyst {
 }
 
 struct GenerateAcceptanceTestSPMPackage {
-    @Test(.disabled(), .withFixture("generated_spm_package"), .inTemporaryDirectory)
+    @Test(.withFixture("generated_spm_package"), .inTemporaryDirectory)
     func spm_package() async throws {
         try await run(InstallCommand.self)
         try await run(GenerateCommand.self)
@@ -1218,7 +1216,7 @@ struct GenerateAcceptanceTestSPMPackage {
 }
 
 struct GenerateAcceptanceTestAppWithDefaultConfiguration {
-    @Test(.disabled(), .withFixture("generated_app_with_custom_default_configuration"), .inTemporaryDirectory)
+    @Test(.withFixture("generated_app_with_custom_default_configuration"), .inTemporaryDirectory)
     func app_with_custom_default_configuration() async throws {
         try await run(GenerateCommand.self)
         try await run(BuildCommand.self)
@@ -1226,7 +1224,7 @@ struct GenerateAcceptanceTestAppWithDefaultConfiguration {
 }
 
 struct GenerateAcceptanceTestAppWithDefaultConfigurationSettings {
-    @Test(.disabled(), .withFixture("generated_app_with_custom_default_configuration_settings"), .inTemporaryDirectory)
+    @Test(.withFixture("generated_app_with_custom_default_configuration_settings"), .inTemporaryDirectory)
     func app_with_custom_default_configuration_settings() async throws {
         let fixturePath = try fixtureDirectory()
         try await run(GenerateCommand.self)
@@ -1244,7 +1242,7 @@ struct GenerateAcceptanceTestAppWithDefaultConfigurationSettings {
 }
 
 struct GenerateAcceptanceTestAppWithCustomScheme {
-    @Test(.disabled(), .withFixture("generated_app_with_custom_scheme"), .inTemporaryDirectory)
+    @Test(.withFixture("generated_app_with_custom_scheme"), .inTemporaryDirectory)
     func app_with_custom_scheme() async throws {
         let fixturePath = try fixtureDirectory()
         try await run(GenerateCommand.self)
@@ -1265,7 +1263,7 @@ struct GenerateAcceptanceTestAppWithCustomScheme {
 }
 
 struct GenerateAcceptanceTestGeneratediOSAppWithoutConfigManifest {
-    @Test(.disabled(), .withFixture("generated_ios_app_without_config_manifest"), .inTemporaryDirectory)
+    @Test(.withFixture("generated_ios_app_without_config_manifest"), .inTemporaryDirectory)
     func generated_ios_app_without_config_manifest() async throws {
         try await run(InstallCommand.self)
         try await run(BuildCommand.self)
@@ -1273,7 +1271,7 @@ struct GenerateAcceptanceTestGeneratediOSAppWithoutConfigManifest {
 }
 
 struct GeneratediOSStaticLibraryWithStringResources {
-    @Test(.disabled(), .withFixture("generated_ios_static_library_with_string_resources"), .inTemporaryDirectory)
+    @Test(.withFixture("generated_ios_static_library_with_string_resources"), .inTemporaryDirectory)
     func generated_ios_static_library_with_string_resources() async throws {
         try await run(InstallCommand.self)
         try await run(BuildCommand.self)
@@ -1327,7 +1325,7 @@ struct GenerateAcceptanceTestiOSAppWithStaticFrameworkWithXcstrings {
 }
 
 struct GenerateAcceptanceTestsAppWithMetalOptions {
-    @Test(.disabled(), .withFixture("generated_app_with_metal_options"), .inTemporaryDirectory)
+    @Test(.withFixture("generated_app_with_metal_options"), .inTemporaryDirectory)
     func app_with_metal_options() async throws {
         let fixturePath = try fixtureDirectory()
         try await run(GenerateCommand.self)
@@ -1354,7 +1352,7 @@ struct GenerateAcceptanceTestsAppWithMetalOptions {
 }
 
 struct GenerateAcceptanceTestAppWithGoogleMaps {
-    @Test(.disabled(), .withFixture("generated_app_with_google_maps"), .inTemporaryDirectory)
+    @Test(.withFixture("generated_app_with_google_maps"), .inTemporaryDirectory)
     func app_with_google_maps() async throws {
         try await run(InstallCommand.self)
         try await run(GenerateCommand.self)
@@ -1363,7 +1361,7 @@ struct GenerateAcceptanceTestAppWithGoogleMaps {
 }
 
 struct GenerateAcceptanceTestAppWithGlobs {
-    @Test(.disabled(), .withFixture("generated_app_with_globs"), .inTemporaryDirectory)
+    @Test(.withFixture("generated_app_with_globs"), .inTemporaryDirectory)
     func app_with_globs() async throws {
         let fixturePath = try fixtureDirectory()
         try await run(GenerateCommand.self)
@@ -1386,7 +1384,7 @@ struct GenerateAcceptanceTestAppWithGlobs {
 }
 
 struct GenerateAcceptanceTestFrameworkWithMacroAndPluginPackages {
-    @Test(.disabled(), .withFixture("generated_framework_with_macro_and_plugin_packages"), .inTemporaryDirectory)
+    @Test(.withFixture("generated_framework_with_macro_and_plugin_packages"), .inTemporaryDirectory)
     func framework_with_macro_and_plugin_packages() async throws {
         try await run(InstallCommand.self)
         try await run(GenerateCommand.self)
@@ -1395,7 +1393,7 @@ struct GenerateAcceptanceTestFrameworkWithMacroAndPluginPackages {
 }
 
 struct GenerateAcceptanceTestAppWithRevenueCat {
-    @Test(.disabled(), .withFixture("generated_app_with_revenue_cat"), .inTemporaryDirectory)
+    @Test(.withFixture("generated_app_with_revenue_cat"), .inTemporaryDirectory)
     func app_with_revenue_cat() async throws {
         try await run(InstallCommand.self)
         try await run(GenerateCommand.self)
@@ -1404,7 +1402,7 @@ struct GenerateAcceptanceTestAppWithRevenueCat {
 }
 
 struct GenerateAcceptanceTestAppWithSwiftCMark {
-    @Test(.disabled(), .withFixture("generated_app_with_swift_cmark"), .inTemporaryDirectory)
+    @Test(.withFixture("generated_app_with_swift_cmark"), .inTemporaryDirectory)
     func app_with_swift_cmark() async throws {
         try await run(InstallCommand.self)
         try await run(GenerateCommand.self)
@@ -1413,7 +1411,7 @@ struct GenerateAcceptanceTestAppWithSwiftCMark {
 }
 
 struct GenerateAcceptanceTestAppWithSPMModuleAliases {
-    @Test(.disabled(), .withFixture("generated_app_with_spm_module_aliases"), .inTemporaryDirectory)
+    @Test(.withFixture("generated_app_with_spm_module_aliases"), .inTemporaryDirectory)
     func app_with_spm_module_aliases() async throws {
         try await run(InstallCommand.self)
         try await run(GenerateCommand.self)
@@ -1423,7 +1421,6 @@ struct GenerateAcceptanceTestAppWithSPMModuleAliases {
 
 struct GenerateAcceptanceTesAppWithLocalSPMModuleWithRemoteDependencies {
     @Test(
-        .disabled(),
         .withFixture("generated_app_with_local_spm_module_with_remote_dependencies"),
         .inTemporaryDirectory
     )
@@ -1449,7 +1446,7 @@ struct GenerateAcceptanceTesAppWithLocalSPMModuleWithRemoteDependencies {
 }
 
 struct GenerateAcceptanceTestAppWithNonLocalAppDependencies {
-    @Test(.disabled(), .withFixture("generated_app_with_executable_non_local_dependencies"), .inTemporaryDirectory)
+    @Test(.withFixture("generated_app_with_executable_non_local_dependencies"), .inTemporaryDirectory)
     func app_with_non_local_app_dependencies() async throws {
         let fixturePath = try fixtureDirectory()
         try await run(InstallCommand.self)
@@ -1482,7 +1479,7 @@ struct GenerateAcceptanceTestAppWithNonLocalAppDependencies {
 }
 
 struct GenerateAcceptanceTestAppWithGeneratedSources {
-    @Test(.disabled(), .withFixture("generated_app_with_generated_sources"), .inTemporaryDirectory)
+    @Test(.withFixture("generated_app_with_generated_sources"), .inTemporaryDirectory)
     func app_with_generated_sources() async throws {
         let fixturePath = try fixtureDirectory()
         try await run(InstallCommand.self)
@@ -1510,7 +1507,7 @@ struct GenerateAcceptanceTestAppWithGeneratedSources {
 }
 
 struct GenerateAcceptanceTestAppWithMacBundle {
-    @Test(.disabled(), .withFixture("generated_app_with_mac_bundle"), .inTemporaryDirectory)
+    @Test(.withFixture("generated_app_with_mac_bundle"), .inTemporaryDirectory)
     func app_with_mac_bundle() async throws {
         try await run(InstallCommand.self)
         try await run(GenerateCommand.self)
@@ -1554,7 +1551,7 @@ struct GenerateAcceptanceTestAppWithMacBundle {
         )
     }
 
-    @Test(.disabled(), .withFixture("generated_app_with_mac_bundle"), .inTemporaryDirectory)
+    @Test(.withFixture("generated_app_with_mac_bundle"), .inTemporaryDirectory)
     func macos_app_with_mac_bundle() async throws {
         try await run(InstallCommand.self)
         try await run(GenerateCommand.self)
@@ -1590,7 +1587,7 @@ struct GenerateAcceptanceTestAppWithMacBundle {
     /// Tests that external local Swift packages configured as dynamic frameworks
     /// compile and run without crashing when accessing Bundle.module.
     /// This is a regression test for https://github.com/tuist/tuist/issues/XXXX
-    @Test(.disabled(), .withFixture("generated_app_with_mac_bundle"), .inTemporaryDirectory)
+    @Test(.withFixture("generated_app_with_mac_bundle"), .inTemporaryDirectory)
     func app_with_external_dynamic_framework_with_resources() async throws {
         let fileSystem = FileSystem()
         let fixturePath = try fixtureDirectory()
@@ -1674,13 +1671,12 @@ struct GenerateAcceptanceTestAppWithMacBundle {
 }
 
 struct GenerateAcceptanceTestAppWithSignedXCFrameworkDependencies {
-    @Test(.disabled(), .withFixture("generated_app_with_signed_xcframework_dependencies"))
+    @Test(.withFixture("generated_app_with_signed_xcframework_dependencies"))
     func app_with_signed_xcframework_dependencies() async throws {
         try await run(GenerateCommand.self)
     }
 
     @Test(
-        .disabled(),
         .withFixture("generated_app_with_signed_xcframework_dependencies_mismatching_signature"),
         .withMockedDependencies()
     )

--- a/cli/Tests/TuistKitAcceptanceTests/EditAcceptanceTests.swift
+++ b/cli/Tests/TuistKitAcceptanceTests/EditAcceptanceTests.swift
@@ -16,7 +16,7 @@ struct EditAcceptanceTests {
         try await build(scheme: "Manifests", workspacePath: workspacePath)
     }
 
-    @Test(.disabled(), .withFixture("generated_plugin"))
+    @Test(.withFixture("generated_plugin"))
     func plugin() async throws {
         let fixtureDirectory = try #require(TuistTest.fixtureDirectory)
         try await TuistTest.run(EditCommand.self, ["--path", fixtureDirectory.pathString, "--permanent"])
@@ -24,7 +24,7 @@ struct EditAcceptanceTests {
         try await build(scheme: "Plugins", workspacePath: workspacePath)
     }
 
-    @Test(.disabled(), .withFixture("generated_app_with_plugins"))
+    @Test(.withFixture("generated_app_with_plugins"))
     func app_with_plugins() async throws {
         let fixtureDirectory = try #require(TuistTest.fixtureDirectory)
         try await TuistTest.run(InstallCommand.self, ["--path", fixtureDirectory.pathString])
@@ -35,7 +35,7 @@ struct EditAcceptanceTests {
         try await build(scheme: "LocalPlugin", workspacePath: workspacePath)
     }
 
-    @Test(.disabled(), .withFixture("generated_app_with_spm_dependencies"))
+    @Test(.withFixture("generated_app_with_spm_dependencies"))
     func app_with_spm_dependencies() async throws {
         let fixtureDirectory = try #require(TuistTest.fixtureDirectory)
         try await TuistTest.run(EditCommand.self, ["--path", fixtureDirectory.pathString, "--permanent"])
@@ -43,7 +43,7 @@ struct EditAcceptanceTests {
         try await build(scheme: "Manifests", workspacePath: workspacePath)
     }
 
-    @Test(.disabled(), .withFixture("generated_spm_package"))
+    @Test(.withFixture("generated_spm_package"))
     func spm_package() async throws {
         let fixtureDirectory = try #require(TuistTest.fixtureDirectory)
         try await TuistTest.run(EditCommand.self, ["--path", fixtureDirectory.pathString, "--permanent"])

--- a/cli/Tests/TuistKitAcceptanceTests/HashAcceptanceTests.swift
+++ b/cli/Tests/TuistKitAcceptanceTests/HashAcceptanceTests.swift
@@ -4,7 +4,7 @@ import TuistTesting
 @testable import TuistKit
 
 struct HashAcceptanceTests {
-    @Test(.disabled(), .withFixture("generated_ios_app_with_frameworks"), .withMockedDependencies())
+    @Test(.withFixture("generated_ios_app_with_frameworks"), .withMockedDependencies())
     func xcode_project_ios_framework() async throws {
         let fixtureDirectory = try #require(TuistTest.fixtureDirectory)
         try await TuistTest.run(HashCacheCommand.self, ["--path", fixtureDirectory.pathString])

--- a/cli/Tests/TuistKitAcceptanceTests/InitAcceptanceTests.swift
+++ b/cli/Tests/TuistKitAcceptanceTests/InitAcceptanceTests.swift
@@ -10,7 +10,7 @@ import TuistTesting
 @testable import TuistKit
 
 struct InitAcceptanceTests {
-    @Test(.disabled(), .inTemporaryDirectory, .withMockedDependencies())
+    @Test(.inTemporaryDirectory, .withMockedDependencies())
     func generated_macos_app() async throws {
         let fileSystem = FileSystem()
         let derivedDataPath = try #require(FileSystem.temporaryTestDirectory)
@@ -48,7 +48,7 @@ struct InitAcceptanceTests {
         }
     }
 
-    @Test(.disabled(), .inTemporaryDirectory, .withMockedDependencies())
+    @Test(.inTemporaryDirectory, .withMockedDependencies())
     func generated_ios_app() async throws {
         let fileSystem = FileSystem()
         let derivedDataPath = try #require(FileSystem.temporaryTestDirectory)
@@ -86,7 +86,7 @@ struct InitAcceptanceTests {
         }
     }
 
-    @Test(.disabled(), .inTemporaryDirectory, .withMockedDependencies(), .withFixture("xcode_project_ios_app"))
+    @Test(.inTemporaryDirectory, .withMockedDependencies(), .withFixture("xcode_project_ios_app"))
     func xcode_project_ios_app() async throws {
         let fileSystem = FileSystem()
         let fixturePath = try #require(TuistTest.fixtureDirectory)

--- a/cli/Tests/TuistKitAcceptanceTests/InspectAcceptanceTests.swift
+++ b/cli/Tests/TuistKitAcceptanceTests/InspectAcceptanceTests.swift
@@ -134,7 +134,7 @@ struct InspectAcceptanceTests {
 }
 
 struct LintAcceptanceTests {
-    @Test(.disabled(), .withFixture("generated_ios_app_with_headers"), .withMockedDependencies())
+    @Test(.withFixture("generated_ios_app_with_headers"), .withMockedDependencies())
     func ios_app_with_headers() async throws {
         let fixtureDirectory = try #require(TuistTest.fixtureDirectory)
         try await TuistTest.run(InspectImplicitImportsCommand.self, ["--path", fixtureDirectory.pathString])
@@ -145,7 +145,7 @@ struct LintAcceptanceTests {
         )
     }
 
-    @Test(.disabled(), .withFixture("generated_ios_app_with_implicit_dependencies"), .withMockedDependencies())
+    @Test(.withFixture("generated_ios_app_with_implicit_dependencies"), .withMockedDependencies())
     func ios_app_with_implicit_dependencies() async throws {
         let fixtureDirectory = try #require(TuistTest.fixtureDirectory)
         let appDependencies: Set<String> = [
@@ -166,7 +166,7 @@ struct LintAcceptanceTests {
         }
     }
 
-    @Test(.disabled(), .withFixture("generated_framework_with_macros_and_tests"), .withMockedDependencies())
+    @Test(.withFixture("generated_framework_with_macros_and_tests"), .withMockedDependencies())
     func framework_with_macros_redundant_imports() async throws {
         let fixtureDirectory = try #require(TuistTest.fixtureDirectory)
         try await TuistTest.run(InstallCommand.self, ["--path", fixtureDirectory.pathString])

--- a/cli/Tests/TuistKitAcceptanceTests/ListTargetsAcceptanceTests.swift
+++ b/cli/Tests/TuistKitAcceptanceTests/ListTargetsAcceptanceTests.swift
@@ -8,7 +8,6 @@ import TuistTesting
 
 struct ListTargetsAcceptanceTests {
     @Test(
-        .disabled(),
         .withFixture("generated_ios_workspace_with_microfeature_architecture"),
         .withMockedDependencies()
     )

--- a/cli/Tests/TuistKitAcceptanceTests/PrecompiledAcceptanceTests.swift
+++ b/cli/Tests/TuistKitAcceptanceTests/PrecompiledAcceptanceTests.swift
@@ -11,7 +11,7 @@ import TuistTesting
 @testable import TuistKit
 
 struct PrecompiledAcceptanceTests {
-    @Test(.disabled(), .withFixture("generated_ios_app_with_static_frameworks"), .inTemporaryDirectory)
+    @Test(.withFixture("generated_ios_app_with_static_frameworks"), .inTemporaryDirectory)
     func ios_app_with_static_frameworks() async throws {
         let fixtureDirectory = try #require(TuistTest.fixtureDirectory)
         let derivedDataPath = try #require(FileSystem.temporaryTestDirectory)
@@ -22,7 +22,7 @@ struct PrecompiledAcceptanceTests {
         )
     }
 
-    @Test(.disabled(), .withFixture("generated_ios_app_with_static_libraries"), .inTemporaryDirectory)
+    @Test(.withFixture("generated_ios_app_with_static_libraries"), .inTemporaryDirectory)
     func ios_app_with_static_libraries() async throws {
         let fixtureDirectory = try #require(TuistTest.fixtureDirectory)
         let derivedDataPath = try #require(FileSystem.temporaryTestDirectory)
@@ -33,7 +33,7 @@ struct PrecompiledAcceptanceTests {
         )
     }
 
-    @Test(.disabled(), .withFixture("generated_ios_app_with_transitive_framework"), .inTemporaryDirectory)
+    @Test(.withFixture("generated_ios_app_with_transitive_framework"), .inTemporaryDirectory)
     func ios_app_with_transitive_framework() async throws {
         let fixtureDirectory = try #require(TuistTest.fixtureDirectory)
         let derivedDataPath = try #require(FileSystem.temporaryTestDirectory)
@@ -112,7 +112,7 @@ struct PrecompiledAcceptanceTests {
         )
     }
 
-    @Test(.disabled(), .withFixture("generated_ios_app_with_static_library_and_package"), .inTemporaryDirectory)
+    @Test(.withFixture("generated_ios_app_with_static_library_and_package"), .inTemporaryDirectory)
     func ios_app_with_static_library_and_package() async throws {
         let fixtureDirectory = try #require(TuistTest.fixtureDirectory)
         let derivedDataPath = try #require(FileSystem.temporaryTestDirectory)
@@ -123,7 +123,7 @@ struct PrecompiledAcceptanceTests {
         )
     }
 
-    @Test(.disabled(), .withFixture("generated_ios_app_with_xcframeworks"), .inTemporaryDirectory)
+    @Test(.withFixture("generated_ios_app_with_xcframeworks"), .inTemporaryDirectory)
     func ios_app_with_xcframeworks() async throws {
         let fixtureDirectory = try #require(TuistTest.fixtureDirectory)
         let derivedDataPath = try #require(FileSystem.temporaryTestDirectory)

--- a/cli/Tests/TuistKitAcceptanceTests/ScaffoldAcceptanceTests.swift
+++ b/cli/Tests/TuistKitAcceptanceTests/ScaffoldAcceptanceTests.swift
@@ -37,7 +37,7 @@ struct ScaffoldAcceptanceTests {
         )
     }
 
-    @Test(.disabled(), .withFixture("generated_ios_app_with_templates"))
+    @Test(.withFixture("generated_ios_app_with_templates"))
     func ios_app_with_templates_custom_using_filters() async throws {
         defer { resetScaffoldOptions() }
         let fixturePath = try #require(TuistTest.fixtureDirectory)
@@ -61,7 +61,7 @@ struct ScaffoldAcceptanceTests {
         )
     }
 
-    @Test(.disabled(), .withFixture("generated_ios_app_with_templates"))
+    @Test(.withFixture("generated_ios_app_with_templates"))
     func ios_app_with_templates_custom_using_copy_folder() async throws {
         defer { resetScaffoldOptions() }
         let fixturePath = try #require(TuistTest.fixtureDirectory)
@@ -106,7 +106,7 @@ struct ScaffoldAcceptanceTests {
         )
     }
 
-    @Test(.disabled(), .withFixture("generated_app_with_plugins"))
+    @Test(.withFixture("generated_app_with_plugins"))
     func app_with_plugins_local_plugin() async throws {
         defer { resetScaffoldOptions() }
         let fixturePath = try #require(TuistTest.fixtureDirectory)
@@ -137,7 +137,7 @@ struct ScaffoldAcceptanceTests {
         )
     }
 
-    @Test(.disabled(), .withFixture("generated_app_with_plugins"))
+    @Test(.withFixture("generated_app_with_plugins"))
     func app_with_plugins_remote_plugin() async throws {
         defer { resetScaffoldOptions() }
         let fixturePath = try #require(TuistTest.fixtureDirectory)
@@ -168,7 +168,7 @@ struct ScaffoldAcceptanceTests {
         )
     }
 
-    @Test(.disabled(), .withFixture("generated_ios_app_with_templates"))
+    @Test(.withFixture("generated_ios_app_with_templates"))
     func ios_app_with_templates_custom_using_attribute() async throws {
         defer { resetScaffoldOptions() }
         let fixturePath = try #require(TuistTest.fixtureDirectory)
@@ -201,7 +201,7 @@ struct ScaffoldAcceptanceTests {
         )
     }
 
-    @Test(.disabled(), .withFixture("generated_ios_app_with_plugins_and_templates"))
+    @Test(.withFixture("generated_ios_app_with_plugins_and_templates"))
     func ios_app_with_local_template_and_project_description_helpers_plugin() async throws {
         defer { resetScaffoldOptions() }
         let fixturePath = try #require(TuistTest.fixtureDirectory)
@@ -222,7 +222,7 @@ struct ScaffoldAcceptanceTests {
         )
     }
 
-    @Test(.disabled(), .withFixture("generated_ios_app_with_plugins_and_templates"))
+    @Test(.withFixture("generated_ios_app_with_plugins_and_templates"))
     func ios_app_with_plugin_template_and_project_description_helpers_plugin() async throws {
         defer { resetScaffoldOptions() }
         let fixturePath = try #require(TuistTest.fixtureDirectory)


### PR DESCRIPTION
## What changed

Commit f472d804db mass-disabled ~165 acceptance tests across four targets while consolidating CI into a single sharded workflow. This PR re-enables every test that passes locally, across all four affected targets.

## Targets and counts

| Target | Re-enabled | Left disabled | Why left disabled |
|--------|-----------|--------------|-------------------|
| `TuistKitAcceptanceTests` | 26 | 14 | Canary — require `TUIST_AUTH_EMAIL` / `TUIST_AUTH_PASSWORD` and a live server |
| `TuistDependenciesAcceptanceTests` | 13 | 4 | Canary — same |
| `TuistAutomationAcceptanceTests` | 20 | 1 | C++ interop build fails on Xcode 26 beta (exit 65) |
| `TuistGeneratorAcceptanceTests` | 69 | 6 | See below |
| **Total** | **128** | **25** | |

Tests left disabled in `TuistGeneratorAcceptanceTests`:
- `generated_bundle_with_metal_files`, `generated_metallib_in_static_framework` — require Metal toolchain (`xcodebuild -downloadComponent MetalToolchain`); CI already does this, local dev typically doesn't
- `macos_app_with_extensions` — requires `sudo installer -package WorkflowExtensionsSDK.pkg`; needs admin + SDK preinstalled
- `macos_app_with_copy_files` — `CodeSignOnCopy`/`RemoveHeadersOnCopy` attribute assertions fail on Xcode 26 beta
- `sandbox_disabled` — xcodebuild exits 70 on current Xcode version
- `app_with_signed_local_binary_swift_package` — missing `tuist install` step in test body; needs a separate fix

## Why

Two months passed since the mass-disabling with no re-enablement. These tests validate real CLI behaviour and should be running in CI.

## What was ruled out

The 18 canary tests (`AccountAcceptanceTests`, `CacheConfigAcceptanceTests`, `InspectAcceptanceTests`, `ProjectAcceptanceTests`, `ShareAcceptanceTests`, and the registry-connected `DependenciesAcceptanceTests`) are left disabled because fork CI jobs do not receive server auth secrets, so they would fail unconditionally on fork PRs.

## Validation

All 128 re-enabled tests pass locally:

- `TuistKitAcceptanceTests` — 26 tests, passed in ~137s
- `TuistDependenciesAcceptanceTests` — 13 tests, passed in ~547s (installs real SPM packages: Alamofire, Composable Architecture, Realm, Airship SDK, etc.)
- `TuistAutomationAcceptanceTests` — 20 tests, passed in ~883s
- `TuistGeneratorAcceptanceTests` — 69 tests, passed in ~856s

Tests were also verified to fail on cue when `TuistTest.runCommand` is broken — confirming they exercise real code paths and are not skipping silently.