### PR TITLE
feat(infra): enable PSI + add CPU-busy% for Linux runner vitals

### DIFF
--- a/infra/linux-runner-image/AGENTS.md
+++ b/infra/linux-runner-image/AGENTS.md
@@ -32,11 +32,16 @@ macOS image). Same single-shot lifecycle, much simpler substrate.
   dispatch-poll rollout-bridge path does too), so it samples for the
   job's lifetime and its last line lands in the Pod logs -> Loki even
   after the microVM is reaped. Tag `RUNNER_VITALS`; fields cover
-  cgroup memory (current/peak/max, `oom_kill`), CPU/mem/io PSI avg10,
-  loadavg, and a best-effort `/dev/kmsg` OOM watcher. The forensic
-  trail for a runner that dies mid-job (guest OOM vs CPU/memory
-  starvation), which is otherwise invisible from outside the guest.
-  Interval via `TUIST_RUNNER_VITALS_INTERVAL` (default 3s).
+  guest-wide memory (`/proc/meminfo`), cgroup memory
+  (current/peak/max, `oom_kill`), guest CPU-busy% (`/proc/stat`
+  deltas), loadavg, and a best-effort `/dev/kmsg` OOM watcher. PSI
+  (`/proc/pressure/*`) avg10 fields are appended only when the guest
+  exposes them — the runners-controller sets `psi=1` on the kata
+  guest cmdline via a pod annotation, since the kata kernel boots
+  with PSI off. The forensic trail for a runner that dies mid-job
+  (guest OOM vs CPU/memory starvation), which is otherwise invisible
+  from outside the guest. Interval via
+  `TUIST_RUNNER_VITALS_INTERVAL` (default 3s).
 - `docker-ce-cli`, `docker-buildx-plugin`, `docker-compose-plugin`
   from the official Docker apt repo — client side only. The
   daemon runs in the `dind` native sidecar (`docker:dind`)

--- a/infra/linux-runner-image/vitals.sh
+++ b/infra/linux-runner-image/vitals.sh
@@ -57,6 +57,11 @@ psi() {
   awk -v c="$2" '$1==c{for(i=2;i<=NF;i++){split($i,a,"=");if(a[1]=="avg10")print a[2]}}' "$1" 2>/dev/null || true
 }
 
+# Total and idle jiffies from /proc/stat's aggregate cpu line. Diffed
+# between samples to derive guest-wide CPU-busy%, the CPU-starvation
+# signal that works even when the guest kernel doesn't expose PSI.
+cpu_times() { awk '/^cpu /{t=0; for(i=2;i<=NF;i++) t+=$i; print t, $5+$6; exit}' /proc/stat 2>/dev/null; }
+
 # Best-effort guest-kernel OOM watcher. Reading /dev/kmsg needs an
 # unrestricted guest (kernel.dmesg_restrict=0) or capability; when it
 # is readable, an OOM kill shows up here verbatim, which is the
@@ -74,21 +79,37 @@ if [ -r /dev/kmsg ]; then
   ) &
 fi
 
+# CPU baseline so the first sample has a prior to diff against.
+cur="$(cpu_times)"
+prev_total="${cur%% *}"
+prev_idle="${cur##* }"
+
 while :; do
-  printf '%s RUNNER_VITALS vm.mem.total.kb=%s vm.mem.avail.kb=%s mem.current=%s mem.peak=%s mem.max=%s mem.swap=%s oom=%s oom_kill=%s cpu.psi.some.avg10=%s mem.psi.some.avg10=%s mem.psi.full.avg10=%s io.psi.some.avg10=%s load=%s\n' \
-    "$(date -u +%FT%TZ)" \
-    "$(meminfo MemTotal)" \
-    "$(meminfo MemAvailable)" \
-    "$(field "$cg/memory.current")" \
-    "$(field "$cg/memory.peak")" \
-    "$(field "$cg/memory.max")" \
-    "$(field "$cg/memory.swap.current")" \
-    "$(events oom)" \
-    "$(events oom_kill)" \
-    "$(psi /proc/pressure/cpu some)" \
-    "$(psi /proc/pressure/memory some)" \
-    "$(psi /proc/pressure/memory full)" \
-    "$(psi /proc/pressure/io some)" \
-    "$(cut -d' ' -f1-3 /proc/loadavg 2>/dev/null | tr ' ' ',')"
-  sleep "$interval"
+  # Guest-wide CPU-busy% over the interval (all vCPUs), from /proc/stat
+  # deltas. Reliable CPU-starvation signal independent of PSI.
+  cur="$(cpu_times)"
+  cur_total="${cur%% *}"
+  cur_idle="${cur##* }"
+  cpu_busy=""
+  if [ -n "${cur_total}" ] && [ -n "${prev_total}" ] && [ "${cur_total}" -gt "${prev_total}" ] 2>/dev/null; then
+    cpu_busy="$(awk -v t="$((cur_total - prev_total))" -v i="$((cur_idle - prev_idle))" 'BEGIN{printf "%d", (t>0)?(1-i/t)*100:0}')"
+  fi
+  prev_total="${cur_total}"
+  prev_idle="${cur_idle}"
+
+  line="$(date -u +%FT%TZ) RUNNER_VITALS"
+  line="${line} vm.mem.total.kb=$(meminfo MemTotal) vm.mem.avail.kb=$(meminfo MemAvailable)"
+  line="${line} mem.current=$(field "$cg/memory.current") mem.peak=$(field "$cg/memory.peak") mem.max=$(field "$cg/memory.max") mem.swap=$(field "$cg/memory.swap.current")"
+  line="${line} oom=$(events oom) oom_kill=$(events oom_kill)"
+  [ -n "${cpu_busy}" ] && line="${line} cpu.busy.pct=${cpu_busy}"
+  # PSI fields only when the guest kernel exposes them (psi=1 on the
+  # kata cmdline). Omitted otherwise so we don't log empty noise.
+  v="$(psi /proc/pressure/cpu some)" && [ -n "${v}" ] && line="${line} cpu.psi.some.avg10=${v}"
+  v="$(psi /proc/pressure/memory some)" && [ -n "${v}" ] && line="${line} mem.psi.some.avg10=${v}"
+  v="$(psi /proc/pressure/memory full)" && [ -n "${v}" ] && line="${line} mem.psi.full.avg10=${v}"
+  v="$(psi /proc/pressure/io some)" && [ -n "${v}" ] && line="${line} io.psi.some.avg10=${v}"
+  line="${line} load=$(cut -d' ' -f1-3 /proc/loadavg 2>/dev/null | tr ' ' ',')"
+
+  printf '%s\n' "${line}"
+  sleep "${interval}"
 done

--- a/infra/runners-controller/internal/podtemplate/podtemplate.go
+++ b/infra/runners-controller/internal/podtemplate/podtemplate.go
@@ -329,6 +329,15 @@ func Build(pool *tuistv1.RunnerPool, podName, saName, dispatchURL, dispatchInter
 	// problem entirely by giving dockerd a real kernel-native
 	// filesystem.
 	annotations := map[string]string{}
+	if linuxPod && pool.Spec.RuntimeClass == "kata-qemu" {
+		// Enable PSI (/proc/pressure/*) in the kata guest so the runner
+		// vitals probe can report CPU/memory pressure. The stock kata
+		// kernel ships CONFIG_PSI=y but boots with PSI disabled; `psi=1`
+		// on the guest cmdline turns it on. The annotation is honored
+		// because the containerd kata runtime whitelists
+		// `io.katacontainers.*` pod annotations.
+		annotations["io.katacontainers.config.hypervisor.kernel_params"] = "psi=1"
+	}
 
 	return &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{

--- a/infra/runners-controller/internal/podtemplate/podtemplate_test.go
+++ b/infra/runners-controller/internal/podtemplate/podtemplate_test.go
@@ -276,6 +276,26 @@ func TestBuild_MacOSPodHasNoKataXattrAnnotation(t *testing.T) {
 	}
 }
 
+func TestBuild_LinuxPodEnablesPSIViaKataAnnotation(t *testing.T) {
+	// The vitals probe reads /proc/pressure/* for CPU/memory pressure,
+	// but the kata guest kernel boots with PSI off unless psi=1 is on
+	// the cmdline. The annotation appends it (whitelisted via the
+	// containerd kata runtime's io.katacontainers.* pod_annotations).
+	pod := build(t, basePool("linux"))
+	if got := pod.Annotations["io.katacontainers.config.hypervisor.kernel_params"]; got != "psi=1" {
+		t.Errorf("kernel_params annotation = %q, want \"psi=1\"", got)
+	}
+}
+
+func TestBuild_MacOSPodHasNoKataKernelParamsAnnotation(t *testing.T) {
+	// psi=1 is a kata-guest concern; macOS pods aren't kata, so the
+	// annotation must not leak onto them.
+	pod := build(t, basePool(""))
+	if _, ok := pod.Annotations["io.katacontainers.config.hypervisor.kernel_params"]; ok {
+		t.Errorf("macOS pod should not carry kata kernel_params annotation; got %+v", pod.Annotations)
+	}
+}
+
 func TestBuild_LinuxPodWithoutDindImageSkipsSidecar(t *testing.T) {
 	// Empty dindImage (macOS-only install) must not produce a
 	// sidecar or DOCKER_HOST env even on a Linux pool.


### PR DESCRIPTION
## What and why

The first production `RUNNER_VITALS` data (from #11094, now live) revealed two gaps:

1. **Every PSI field was empty.** `/proc/pressure/*` doesn't exist in the kata guest — the kata kernel ships `CONFIG_PSI=y` but boots with PSI **disabled**. PSI was the dedicated CPU/memory-**starvation** signal (the half of "lost communication" that isn't OOM), so we were blind to it.
2. **No PSI-independent CPU signal** beyond a coarse loadavg.

## The change (two scopes)

- **`infra` (runners-controller):** set `psi=1` on the kata guest kernel cmdline for Linux kata runner Pods, via the `io.katacontainers.config.hypervisor.kernel_params` pod annotation. It's honored because the containerd kata runtime whitelists `io.katacontainers.*` annotations. macOS pods aren't kata, so they don't get it. Covered by tests (`TestBuild_LinuxPodEnablesPSIViaKataAnnotation`, `TestBuild_MacOSPodHasNoKataKernelParamsAnnotation`).
- **`linux-runner-image` (vitals.sh):**
  - **Add `cpu.busy.pct`** from `/proc/stat` deltas — a guest-wide CPU-utilization signal that works regardless of PSI, so the CPU-starvation dimension is covered even if `psi=1` doesn't take on some kernel.
  - **Omit PSI fields when `/proc/pressure` is absent**, so we never log the empty `cpu.psi.some.avg10=` noise seen in the first data.

## Why both, not just `psi=1`

I can't verify the kata kernel's `CONFIG_PSI` offline, so shipping `psi=1` alone risks a blind deploy-and-hope round-trip. The `/proc/stat` CPU% gives a reliable starvation signal independently; if `psi=1` does take, PSI's stall-time fields are a bonus on top.

## Validation

- `go build` / `go vet` / `go test ./internal/podtemplate/...` clean; new annotation tests pass.
- `bash -n` + `shellcheck -S warning` clean on `vitals.sh`; CPU% math spot-checked.

## Deploy note

Both halves apply via the production server deployment (the runners-controller image pin + the runner image pin), same path that just landed #11094. Confirm in Grafana after rollout that `cpu.busy.pct` appears and the PSI fields populate (or are cleanly absent).