### PR TITLE
feat(infra): log terminal runner exit code/reason for lost-communication post-mortems

### DIFF
--- a/infra/runners-controller/AGENTS.md
+++ b/infra/runners-controller/AGENTS.md
@@ -16,6 +16,11 @@ independent workqueues:
   GC cascade-delete the owned Pods — busy ones included — so the
   finalizer holds the CR Terminating, reaps only idle Pods, and waits
   for mid-job Pods to finish their single-shot job before releasing.
+  When it reaps a terminal Pod it logs the `runner` container's
+  `exitCode`/`reason` first — the durable, image-independent post-mortem
+  fingerprint for a runner that "lost communication" (0 = clean,
+  137+OOMKilled = host OOM, 137+Error = guest OOM / in-VM kill, signal
+  15 = SIGTERM, other = crash), captured before the Pod is gone.
 
 - **`AutoscalerReconciler`** — on a 5-second cadence, calls the
   server's `/api/internal/runners/desired_replicas` endpoint and

--- a/infra/runners-controller/controllers/runnerpool_controller.go
+++ b/infra/runners-controller/controllers/runnerpool_controller.go
@@ -181,6 +181,27 @@ func (r *RunnerPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 			// stopped Pods + orphaned SAs, and the projected-token
 			// cache in tart-kubelet keeps re-validating SAs whose
 			// Pods are already gone.
+			//
+			// Log the runner container's exit code + reason first: it is
+			// the durable, image-independent fingerprint of HOW the job
+			// ended, captured before the Pod is reaped. A runner that
+			// "lost communication with the server" can then be classified
+			// from the controller logs (which land in Loki) instead of
+			// from the reaped Pod (long gone) or the runner image's vitals
+			// (absent on older images): 0 = clean exit (the runner
+			// finished; a lost-comms here is the GitHub completion
+			// handshake, not a death), 137 + reason=OOMKilled = host
+			// cgroup OOM, 137 + reason=Error = guest-internal OOM or in-VM
+			// kill, signal 15 = SIGTERM/deletion, other = crash.
+			if t := runnerTerminated(p); t != nil {
+				logger.Info("runner pod terminated",
+					"pod", p.Name,
+					"phase", string(p.Status.Phase),
+					"exitCode", t.ExitCode,
+					"signal", t.Signal,
+					"reason", t.Reason,
+				)
+			}
 			if err := r.reapRunner(ctx, p); err != nil {
 				logger.Error(err, "reap terminal runner; will retry", "pod", p.Name)
 				return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
@@ -426,6 +447,25 @@ func pollerTerminated(pod *corev1.Pod) bool {
 		}
 	}
 	return false
+}
+
+// runnerTerminated returns the terminated state of the `runner`
+// container, or nil if the container is absent or has no recorded
+// termination. Prefers the current terminated state; falls back to the
+// last termination. The exitCode + reason are the post-mortem
+// fingerprint logged on reap (see the terminal branch in Reconcile).
+func runnerTerminated(pod *corev1.Pod) *corev1.ContainerStateTerminated {
+	for i := range pod.Status.ContainerStatuses {
+		cs := &pod.Status.ContainerStatuses[i]
+		if cs.Name != "runner" {
+			continue
+		}
+		if cs.State.Terminated != nil {
+			return cs.State.Terminated
+		}
+		return cs.LastTerminationState.Terminated
+	}
+	return nil
 }
 
 // isStaleImage returns true when the Pod's runner container image

--- a/infra/runners-controller/controllers/runnerpool_controller_test.go
+++ b/infra/runners-controller/controllers/runnerpool_controller_test.go
@@ -134,6 +134,54 @@ func TestIsIdle(t *testing.T) {
 	}
 }
 
+func TestRunnerTerminated(t *testing.T) {
+	withRunner := func(state corev1.ContainerState) *corev1.Pod {
+		p := newRunnerPod("p", "img", corev1.PodFailed, "p")
+		p.Status.ContainerStatuses = []corev1.ContainerStatus{
+			{Name: "dind", State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{ExitCode: 0}}},
+			{Name: "runner", State: state},
+		}
+		return p
+	}
+
+	t.Run("guest-OOM fingerprint (137/Error) is captured", func(t *testing.T) {
+		got := runnerTerminated(withRunner(corev1.ContainerState{
+			Terminated: &corev1.ContainerStateTerminated{ExitCode: 137, Signal: 9, Reason: "Error"},
+		}))
+		if got == nil || got.ExitCode != 137 || got.Reason != "Error" {
+			t.Fatalf("runnerTerminated = %+v, want exitCode=137 reason=Error", got)
+		}
+	})
+
+	t.Run("falls back to LastTerminationState", func(t *testing.T) {
+		p := newRunnerPod("p", "img", corev1.PodRunning, "p")
+		p.Status.ContainerStatuses = []corev1.ContainerStatus{
+			{Name: "runner", LastTerminationState: corev1.ContainerState{
+				Terminated: &corev1.ContainerStateTerminated{ExitCode: 1},
+			}},
+		}
+		if got := runnerTerminated(p); got == nil || got.ExitCode != 1 {
+			t.Fatalf("runnerTerminated = %+v, want exitCode=1 from LastTerminationState", got)
+		}
+	})
+
+	t.Run("no runner container returns nil", func(t *testing.T) {
+		p := newRunnerPod("p", "img", corev1.PodRunning, "p")
+		p.Status.ContainerStatuses = []corev1.ContainerStatus{
+			{Name: "dind", State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}},
+		}
+		if got := runnerTerminated(p); got != nil {
+			t.Fatalf("runnerTerminated = %+v, want nil", got)
+		}
+	})
+
+	t.Run("running runner returns nil", func(t *testing.T) {
+		if got := runnerTerminated(withRunner(corev1.ContainerState{Running: &corev1.ContainerStateRunning{}})); got != nil {
+			t.Fatalf("runnerTerminated = %+v, want nil", got)
+		}
+	})
+}
+
 // TestReconcile_DeletesStalePendingPodAndCreatesReplacement is the
 // behaviour that fixes the operator-side dance we hit while rolling
 // out runner-image bumps: when the chart rewrites the digest pin,


### PR DESCRIPTION
## What

When the `RunnerPoolReconciler` reaps a terminal (Succeeded/Failed) runner Pod, it now logs the `runner` container's `exitCode` + `signal` + `reason` first, before deleting the Pod.

## Why

We've chased "self-hosted runner lost communication with the server" deaths through three different hypotheses (guest OOM, network, controller recycling) and hard evidence refuted each. The recurring problem was always the same: the one datum that classifies the death — **how the runner process actually ended** — was never captured. The Pod is reaped within seconds (so `kubectl logs` is gone), and older runner images don't carry the in-VM vitals probe.

The runner container's terminated state is exactly that datum, and the controller already holds the terminal Pod in the reconcile that reaps it. Logging it there is durable (controller logs ship to Loki) and image-independent (works for any Pod, including ones predating the vitals probe — which is precisely the case that left a recent investigation with no data).

## The fingerprint

| `exitCode` | `reason` | Cause |
|---|---|---|
| `0` | Completed | Clean exit — a lost-comms here is the GitHub completion handshake failing, not a death |
| `137` | OOMKilled | Host cgroup OOM (VM hit its memory limit) |
| `137` | Error | Guest-internal OOM or in-VM SIGKILL (host cgroup fine) |
| signal `15` | — | SIGTERM = pod deletion / drain |
| other | Error | Crash (segfault/abort) |

Debugging flow: lost-comms job → `runner_name` (= pod name) → grep controller logs in Loki for `runner pod terminated pod=… exitCode=… reason=…` → classify → cross-reference vitals only if it's a `137`-class. Turns a forensics expedition into a lookup.

## Scope and safety

- Read-only: it logs a field on a Pod the reconcile already observes. No behavior change, no new RBAC.
- Captured in the terminal-reap branch (Succeeded/Failed Pods), so it covers the normal single-shot completion path. A Pod hard-deleted out from under the controller before it's reaped won't be captured — but that absence is itself diagnostic (VM/node hard-kill vs in-guest process exit).

## Validation

`go build` / `go vet` / `go test ./controllers/...` clean. New `TestRunnerTerminated` covers the 137/Error fingerprint, `LastTerminationState` fallback, and the no-runner-container / running-runner nil cases.