### PR TITLE
revert(infra): remove the dind --registry-mirror=mirror.gcr.io flag

### DIFF
--- a/infra/runners-controller/AGENTS.md
+++ b/infra/runners-controller/AGENTS.md
@@ -345,17 +345,6 @@ Shape:
   starts dockerd to cover dockerd's own fd budget. Kata's
   microVM kernel defaults nofile=1024; without both, a docker
   build that walks a non-trivial `node_modules` tree EMFILEs.
-- `--registry-mirror=https://mirror.gcr.io` passed to dockerd so
-  Docker Hub pulls route through Google's public pull-through
-  cache. Every microVM on a bare-metal host NATs through that
-  host's single egress IP, so the whole host shares one Docker
-  Hub per-IP pull budget (100/6h anon) and CI jobs trip
-  `toomanyrequests`. GCR absorbs cache misses on its own backend,
-  so the runner's IP never hits Hub for `docker.io` images;
-  dockerd only contacts Hub directly if the mirror is unreachable.
-  Mirror semantics only cover `docker.io`; gcr.io/ghcr.io/quay.io
-  pulls are unaffected. Stopgap ahead of a self-hosted
-  pull-through cache backed by our own object storage.
 
 ### Why loop-mount? (the virtio-fs / overlay2 gotcha)
 

--- a/infra/runners-controller/internal/podtemplate/podtemplate.go
+++ b/infra/runners-controller/internal/podtemplate/podtemplate.go
@@ -255,16 +255,6 @@ func Build(pool *tuistv1.RunnerPool, podName, saName, dispatchURL, dispatchInter
 				// --group pins the docker.sock GID so the runner
 				// user (member of `docker` group, GID 123) can
 				// reach it.
-				// --registry-mirror routes Docker Hub pulls through
-				// Google's public pull-through cache. Every microVM
-				// on a bare-metal host NATs through that host's single
-				// egress IP, so the whole host shares one Docker Hub
-				// per-IP pull budget (100/6h anon) and CI jobs trip
-				// "toomanyrequests". GCR absorbs cache misses on its
-				// own backend, so the runner's IP never hits Hub for
-				// docker.io images; dockerd only contacts Hub directly
-				// if the mirror itself is unreachable. Mirror semantics
-				// cover docker.io only (gcr/ghcr/quay are untouched).
 				Command: []string{"sh", "-c"},
 				Args: []string{
 					"set -e && " +
@@ -276,7 +266,6 @@ func Build(pool *tuistv1.RunnerPool, podName, saName, dispatchURL, dispatchInter
 						"mkdir -p /var/lib/docker && " +
 						"mount -o loop /mnt/dind-disk/disk.img /var/lib/docker && " +
 						"exec dockerd --host=unix:///var/run/docker.sock --group=123 " +
-						"--registry-mirror=https://mirror.gcr.io " +
 						"--default-ulimit nofile=1048576:1048576",
 				},
 				SecurityContext: &corev1.SecurityContext{

--- a/infra/runners-controller/internal/podtemplate/podtemplate_test.go
+++ b/infra/runners-controller/internal/podtemplate/podtemplate_test.go
@@ -1,7 +1,6 @@
 package podtemplate
 
 import (
-	"strings"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -240,18 +239,6 @@ func TestBuild_LinuxPodGetsDindSidecar(t *testing.T) {
 				t.Errorf("dind-storage EmptyDir.Medium = %q, want \"\" (node disk)", v.EmptyDir.Medium)
 			}
 		}
-	}
-}
-
-func TestBuild_LinuxDindUsesRegistryMirror(t *testing.T) {
-	// dockerd must launch with a Docker Hub pull-through mirror.
-	// Every microVM on a bare-metal host shares that host's egress
-	// IP, so the fleet shares one Docker Hub per-IP pull budget;
-	// the mirror keeps CI jobs off "toomanyrequests".
-	pod := build(t, basePool("linux"))
-	dind := pod.Spec.InitContainers[0]
-	if len(dind.Args) == 0 || !strings.Contains(dind.Args[0], "--registry-mirror=https://mirror.gcr.io") {
-		t.Errorf("dind args missing --registry-mirror=https://mirror.gcr.io; got %v", dind.Args)
 	}
 }
 


### PR DESCRIPTION
## What

Removes the dind `--registry-mirror=https://mirror.gcr.io` flag (and its test + AGENTS.md note) from the runners-controller — backing out the controller-code half of [#11096](https://github.com/tuist/tuist/pull/11096).

## Why this is needed now

That flag was the **only** runner pod-template change in controller `0.8.0`, and deploying `0.8.0` took CI docker **down fleet-wide**: changing the dockerd command changed the pod-template hash, churned the fleet onto new pods, and the new dind sidecars never produced `/var/run/docker.sock` (jobs fail at `Initialize containers`). Timeline was a clean break right after the `0.8.0` prod rollout.

[#11102](https://github.com/tuist/tuist/pull/11102) rolled the **deployed** controller back to `0.7.0`, but that was pin-only — **the flag stayed in `main`**. The next `runners-controller`-path change would cut a release that rebuilds the flag, and `commit-and-release` would bump the pin forward, re-breaking the fleet. This removes it at the source so the rollback actually sticks.

## Scope

Controller code only: `podtemplate.go` (the flag + comment), its test, and the AGENTS.md note. **The `ubuntu-latest` CI build moves from #11096 stay** — the Docker Hub rate limit is still real and those builds still need a non-fleet egress IP. (The auto-generated `CHANGELOG.md` entry is left untouched per repo guardrails.)

## Effect on merge

This is a `runners-controller`-path change, so merging cuts a new (mirror-free) release and `commit-and-release` bumps the pin forward off `0.7.0`. The new image's pod template matches `0.7.0`'s dockerd command (no flag), so it deploys without a problematic churn — and if production is still on `0.8.0` at that point, it replaces the broken pods with working ones.

## What replaces it

The mirror reships **properly** via the self-hosted pull-through cache ([#11106](https://github.com/tuist/tuist/pull/11106)) — wired at **both** the dockerd and containerd layers (so the `docker:28-dind` sidecar pull is covered too) and gated behind the `linux-runners-staging-smoke` test, rather than as a bare dockerd flag rolled fleet-wide.

## Validation

`gofmt` clean, `go build ./...`, `go vet`, and `go test ./internal/podtemplate/` all pass.
