### PR TITLE
feat(infra): surface Linux runner death cause from runner and host sides

### DIFF
--- a/infra/helm/k8s-monitoring/README.md
+++ b/infra/helm/k8s-monitoring/README.md
@@ -7,6 +7,7 @@ Wraps [`grafana/k8s-monitoring`](https://github.com/grafana/k8s-monitoring-helm)
 | Server app metrics | Auto-discovered via `prometheus.io/scrape=true` annotation on the server pods |
 | Application traces | OTLP gRPC :4317 for server/processor and OTLP HTTP :4318 for managed Kura → Grafana Cloud Tempo |
 | Server logs | stdout tailed from `/var/log/pods` by a per-node Alloy DaemonSet → Grafana Cloud Loki |
+| Node logs | host journald (`containerd`, `kubelet`, kernel) read from `/var/log/journal` by the same DaemonSet → Grafana Cloud Loki |
 | kube-state-metrics | Deployed + scraped (workload / pod / deployment / replica state) |
 | node-exporter | Deployed as DaemonSet (node CPU / mem / disk / net) |
 | kubelet + cAdvisor | Scraped (container resource usage) |
@@ -66,7 +67,7 @@ Server pod metrics are discovered automatically: the server Deployment carries `
 Four Alloy instances, split by role (managed by the upstream `alloy-operator`):
 
 - `alloy-metrics` — scrapes metrics (cluster / node / app) ; runs clustered so replicas hash-partition targets
-- `alloy-logs` — DaemonSet tailing pod logs from `/var/log/pods`
+- `alloy-logs` — DaemonSet tailing pod logs from `/var/log/pods`, plus host journald from `/var/log/journal` (node logs feature, scoped to `containerd` / `kubelet` / kernel)
 - `alloy-singleton` — cluster events (singleton so events aren't duplicated)
 - `alloy-receiver` — OTLP gRPC and HTTP receiver for managed workload traces
 
@@ -118,7 +119,7 @@ Server-level labels (`namespace`, `pod`, `container`, deployment/statefulset nam
 ## RBAC — what access does this chart get?
 
 - `alloy-metrics` — cluster-wide `get/list/watch` on nodes/pods/services/endpoints for target discovery, plus `/metrics/cadvisor` on kubelets.
-- `alloy-logs` — node-local hostPath to `/var/log/pods`. A compromised pod can only read logs from the single node it runs on.
+- `alloy-logs` — node-local hostPath to `/var/log/pods` (pod logs) and `/var/log/journal` (host journald: `containerd` / `kubelet` / kernel). No extra Kubernetes API access; a compromised pod can still only read logs from the single node it runs on.
 - `alloy-singleton` — cluster-wide `get/list/watch` on events.
 - `alloy-receiver` — none beyond standard pod execution.
 - `kube-state-metrics` — cluster-wide read on most core/apps/batch objects (standard for KSM).

--- a/infra/helm/k8s-monitoring/values.yaml
+++ b/infra/helm/k8s-monitoring/values.yaml
@@ -130,6 +130,27 @@ k8s-monitoring:
     enabled: true
     collector: alloy-logs
 
+  # Node journald → Loki. The in-guest runner vitals probe is blind to a
+  # host-side microVM teardown (kata-shim/qemu kill, containerd restart,
+  # kernel OOM/segfault) — those land only in the worker node's journal,
+  # which nothing shipped before this. Assigned to alloy-logs because that
+  # DaemonSet already tolerates the bare-metal runner taint (see the
+  # collector block below), so it runs on the runner nodes where the
+  # microVMs live and a runner that vanishes mid-job leaves a host trail.
+  nodeLogs:
+    enabled: true
+    collector: alloy-logs
+    journal:
+      maxAge: "4h"
+      # Container runtime + kubelet units, plus kernel messages. The keep
+      # rule matches __journal__systemd_unit, but kernel lines carry no
+      # unit, so "^$" (empty unit) is kept too — that's where the
+      # OOM/segfault/qemu-kill evidence for a microVM teardown shows up.
+      units:
+        - "^$"
+        - "containerd.service"
+        - "kubelet.service"
+
   # Picks up any Pod/Service annotated with prometheus.io/scrape=true.
   # Upstream defaults to the k8s.grafana.com/* annotation namespace; we
   # override to prometheus.io/* so the same annotations work for both
@@ -364,14 +385,19 @@ k8s-monitoring:
     # logs from disk (matches the podLogsViaLoki feature).
     alloy-logs:
       presets: [filesystem-log-reader]
-      # Tolerate the bare-metal runner taint so the log DaemonSet also
-      # lands on the runner-tier nodes and tails the Linux runner Pods.
-      # Without this, runner Pod logs (including RUNNER_VITALS) never
-      # reach Loki: those nodes repel everything but runner Pods, so the
-      # default-toleration DaemonSet skips them. Tolerations live under
-      # `controller` (the Alloy CR's controller spec); a top-level
-      # `tolerations` here renders to spec.tolerations and is ignored.
       controller:
+        # The nodeLogs feature validation requires the assigned collector
+        # to be an explicit DaemonSet (it does not infer this from the
+        # filesystem-log-reader preset), and a DaemonSet is what we want
+        # anyway: journald is per-node, so one Alloy per node.
+        type: daemonset
+        # Tolerate the bare-metal runner taint so the log DaemonSet also
+        # lands on the runner-tier nodes and tails the Linux runner Pods.
+        # Without this, runner Pod logs (including RUNNER_VITALS) never
+        # reach Loki: those nodes repel everything but runner Pods, so the
+        # default-toleration DaemonSet skips them. Tolerations live under
+        # `controller` (the Alloy CR's controller spec); a top-level
+        # `tolerations` here renders to spec.tolerations and is ignored.
         tolerations:
           - key: tuist.dev/runner-tier
             operator: Equal

--- a/infra/runners-controller/internal/podtemplate/podtemplate.go
+++ b/infra/runners-controller/internal/podtemplate/podtemplate.go
@@ -328,6 +328,15 @@ func Build(pool *tuistv1.RunnerPool, podName, saName, dispatchURL, dispatchInter
 		annotations["io.katacontainers.config.hypervisor.kernel_params"] = "psi=1"
 	}
 
+	// Mirror the actions/runner diagnostic log (_diag) to the runner
+	// container's stdout so it reaches Loki through the pod-log pipeline.
+	// The runner's ReturnCode enum only spans 0-7 and run-helper.sh folds
+	// unknown codes to exit 0, so a runner that terminates abnormally
+	// (e.g. the microVM is torn down mid-job) writes no reason to stdout —
+	// its _diag log is the only record, and it dies with the reaped Pod.
+	// Streaming _diag makes that exit reason durable.
+	runnerEnv = append(runnerEnv, corev1.EnvVar{Name: "ACTIONS_RUNNER_PRINT_LOG_TO_STDOUT", Value: "1"})
+
 	return &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        podName,

--- a/infra/runners-controller/internal/podtemplate/podtemplate_test.go
+++ b/infra/runners-controller/internal/podtemplate/podtemplate_test.go
@@ -420,6 +420,28 @@ func TestBuild_MacOSHasNoPollerOrTokenVolume(t *testing.T) {
 	}
 }
 
+func TestBuild_RunnerMirrorsDiagLogToStdout(t *testing.T) {
+	// ACTIONS_RUNNER_PRINT_LOG_TO_STDOUT=1 streams the actions/runner
+	// _diag log to the runner's stdout so an abnormal exit's reason
+	// survives in Loki after the Pod is reaped. It belongs on the runner
+	// container in every shape, since that's where the runner binary runs.
+	for _, os := range []string{"linux", ""} {
+		pod := build(t, basePool(os))
+		runner := containerByName(t, pod, "runner")
+		if got := envValue(runner.Env, "ACTIONS_RUNNER_PRINT_LOG_TO_STDOUT"); got != "1" {
+			t.Errorf("os=%q: runner ACTIONS_RUNNER_PRINT_LOG_TO_STDOUT = %q, want \"1\"; env %+v", os, got, runner.Env)
+		}
+	}
+
+	// The poller runs dispatch-poll.sh, not the runner binary, so it must
+	// not carry the flag.
+	pod := build(t, basePool("linux"))
+	poller := initContainerByName(t, pod, "poller")
+	if got := envValue(poller.Env, "ACTIONS_RUNNER_PRINT_LOG_TO_STDOUT"); got != "" {
+		t.Errorf("poller must not carry ACTIONS_RUNNER_PRINT_LOG_TO_STDOUT; got %q", got)
+	}
+}
+
 func containerByName(t *testing.T, pod *corev1.Pod, name string) corev1.Container {
 	t.Helper()
 	for _, c := range pod.Spec.Containers {


### PR DESCRIPTION
## What

Two complementary observability instruments so the next mid-job Linux runner death is self-diagnosing, instead of leaving us to infer from the outside:

1. **runners-controller** (`podtemplate.go`): set `ACTIONS_RUNNER_PRINT_LOG_TO_STDOUT=1` on the runner container. This mirrors the actions/runner `_diag` log to stdout, which the existing pod-log pipeline ships to Loki, so the runner's own account of why it exited survives the Pod being reaped.
2. **k8s-monitoring** (`values.yaml`): enable the chart's first-class `feature-node-logs` on the `alloy-logs` DaemonSet, shipping node journald (`containerd`, `kubelet`, and kernel) to Loki.

## Why

Busy Linux runners die mid-job and GitHub reports "the self-hosted runner lost communication." Forensics narrowed the termination to a clean `exitCode=9`, `reason=Error`, no signal, empty message, and crucially the **same signature across both shapes (2vcpu-8gb and 4vcpu-16gb) and across the full load spectrum** (one died idle at load 0.6, another saturated at load 7.59).

That rules out, with data, every cause we can see from inside the cluster:

- **Not memory.** Guest `oom=0`; the two bare-metal nodes sit at 24–48% memory used with `MemoryPressure=False`; zero `SystemOOM` events.
- **Not a signal kill / OOM-killer.** A `SIGKILL` surfaces as `137` (kata follows the standard `128+signo` convention), not a literal `9`.
- **Not the controller.** Reconciles show `target >= observed`; busy pods are never drained, only already-terminal pods are reaped.
- **Not the runner software.** The v2.334.0 `ReturnCode` enum spans `0–7`, and `run-helper.sh` folds any unknown code to `exit 0`, so no software path in the image can emit `9`. Our wrapper scripts only exit `0/1`.

The only consistent reading: the runner is **killed from outside the guest** (a host-side `kata-shim`/`qemu`/containerd-level microVM teardown), which is exactly the layer our in-guest `vitals.sh` probe is structurally blind to, and why the runner vanishes with no final stdout.

## How this closes the gap

- The `_diag` stream gives the **runner-side** reason (a clean exit reason vs. an abrupt mid-job cutoff itself distinguishes "agent quit" from "VM killed").
- Node journald gives the **host-side** actor. The keep filter intentionally includes `^$` (empty systemd unit) because **kernel messages carry no unit** — that's where OOM/segfault/`qemu` kill lines live, and dropping them would discard the exact evidence we need. Assigned to `alloy-logs` because that DaemonSet already tolerates the bare-metal runner taint and selects linux nodes, so it runs where the microVMs live; the existing `varlog` mount already exposes `/var/log/journal`, so no extra mount is needed.

## Validation

- `go build ./...` + `go test ./internal/podtemplate/` pass; `gofmt`/`go vet` clean. New test asserts the env var is on the runner container (both macOS and Linux) and absent on the poller.
- `helm lint` + `helm template` succeed across production/staging/canary overlays. Verified the rendered Alloy CR has the journal source (`path=/var/log/journal`, `max_age=4h`, kernel-inclusive keep regex), the `kubernetes.io/os: linux` nodeSelector, and the runner-tier toleration.

## Notes

- **Deploy-time check:** the journal source reads `/var/log/journal` (persistent journald, the k8s convention). First post-deploy verification is that `{job="integrations/kubernetes/journal"}` returns lines; if empty, the nodes are volatile and we switch the path to `/run/log/journal`.
- **Cost:** both raise Loki ingest (`_diag` is verbose; node journald on the churning runner nodes is chatty). They are diagnostic instruments: once the teardown cause is named, `ACTIONS_RUNNER_PRINT_LOG_TO_STDOUT` can return to `0` and node-logs can be tightened or disabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)