### PR TITLE
feat(kura): prioritize public cache traffic over sync

### DIFF
--- a/kura/AGENTS.md
+++ b/kura/AGENTS.md
@@ -10,6 +10,7 @@ This node covers the `kura/` workspace, a Rust service for low-latency cache mes
 - Runtime configuration and limits: `src/config.rs`, `src/constants.rs`
 - Observability and analytics: `src/metrics.rs`, `src/telemetry.rs`, `src/analytics.rs`
 - Peer TLS support: `src/peer_tls.rs`
+- Peer sync bandwidth shaping: `src/bandwidth.rs`
 - Operational assets: `docker-compose.yml`, `ops/`, `test/e2e/`, `spec/e2e/`
   - See `ops/AGENTS.md` for Helm, rollout helpers, and observability config boundaries
 - License and contribution terms: `LICENSE.md`, `CLA.md`, `cla/`

--- a/kura/Cargo.toml
+++ b/kura/Cargo.toml
@@ -40,6 +40,7 @@ tokio = { version = "1.48.0", features = ["fs", "macros", "rt-multi-thread", "si
 tokio-stream = { version = "0.1.17", features = ["net"] }
 tokio-util = { version = "0.7.17", features = ["io"] }
 tonic = { version = "0.14.2", features = ["tls-ring"] }
+tower = { version = "0.5.2", features = ["util"] }
 tracing = "0.1.41"
 tracing-opentelemetry = "0.32.1"
 tracing-subscriber = { version = "0.3.20", features = ["env-filter", "fmt", "json"] }
@@ -51,4 +52,3 @@ tikv-jemallocator = "0.6.0"
 [dev-dependencies]
 rcgen = "0.14.5"
 tempfile = "3.23.0"
-tower = { version = "0.5.2", features = ["util"] }

--- a/kura/README.md
+++ b/kura/README.md
@@ -229,6 +229,7 @@ When `Optional` is `Yes`, the `Default` column shows what Kura uses today. `auto
 | `KURA_METADATA_STORE_WRITE_BUFFER_BYTES` | Size of each metadata write buffer before flush. | Yes | auto |
 | `KURA_METADATA_STORE_MAX_WRITE_BUFFERS` | Maximum number of metadata write buffers kept in memory. | Yes | auto |
 | `KURA_OUTBOX_MAX_DEPTH` | Maximum number of replication outbox messages allowed before public writes return 503 with Retry-After. | Yes | `100000` |
+| `KURA_REPLICATION_BANDWIDTH_LIMIT_BYTES_PER_SECOND` | Aggregate per-node byte-per-second ceiling for peer artifact body transfers. Kura dynamically divides this ceiling by `public_inflight + 1`, so sync traffic backs off while public HTTP or gRPC cache work is active; `0` disables throttling. | Yes | `0` |
 | `KURA_CONTROL_PLANE_URL` | Base URL for the control plane Kura reports usage to. When set with the client credentials below, Kura pushes usage rollups to `/_internal/kura/usage`. | Yes | disabled |
 | `KURA_CONTROL_PLANE_CLIENT_ID` | OAuth client id used for Kura control-plane calls. | Yes | disabled |
 | `KURA_CONTROL_PLANE_CLIENT_SECRET` | OAuth client secret used for Kura control-plane calls. | Yes | disabled |
@@ -247,7 +248,7 @@ When `Optional` is `Yes`, the `Default` column shows what Kura uses today. `auto
 
 Kura also enforces a few hard-coded budgets that are not configurable:
 
-- Replication ingest bodies on `/_internal/replicate/artifact` are capped at four times `MAX_SEGMENT_BYTES` (2 GiB) so a misbehaving peer cannot fill the data PVC. Bootstrap-from-peer fetches enforce the same ceiling for segment-backed artifacts and a 4 MiB ceiling for inline artifacts; bootstrap manifest and tombstone pages are capped at 32 MiB each.
+- Replication ingest bodies on `/_internal/replicate/artifact` are capped at four times `MAX_SEGMENT_BYTES` (2 GiB) so a misbehaving peer cannot fill the data PVC. Bootstrap-from-peer fetches enforce the same ceiling for segment-backed artifacts and a 4 MiB ceiling for inline artifacts; bootstrap manifest and tombstone pages are capped at 32 MiB each. When `KURA_REPLICATION_BANDWIDTH_LIMIT_BYTES_PER_SECOND` is positive, Kura also applies a shared per-node bandwidth ceiling to peer artifact body traffic. The effective rate shrinks as public HTTP and gRPC requests are in flight, so background sync yields network capacity to public cache reads.
 - Public writes are rejected with `503 Service Unavailable` and a short `Retry-After` header when memory pressure reaches `Critical`, when the outbox is at `KURA_OUTBOX_MAX_DEPTH`, when the FD pool is exhausted, or when the data PVC has insufficient free space for a new segment.
 - RocksDB column families are configured with explicit level-0 slowdown/stop triggers and pending compaction limits so backlog turns into write-side backpressure instead of unbounded write-buffer growth.
 - Inline keyvalue payloads are buffered in memory before being written. Total RAM committed to inline payloads is bounded by `KURA_FILE_DESCRIPTOR_POOL_SIZE * KURA_MAX_KEYVALUE_BYTES`; both knobs are tuned together when sizing per-pod memory.
@@ -269,7 +270,7 @@ Auto-derived defaults currently follow these rules:
 - `KURA_METADATA_STORE_WRITE_BUFFER_POOL_BYTES` follows the same `memory_limit_bytes / 32` rule as the metadata-store read cache.
 - `KURA_METADATA_STORE_WRITE_BUFFER_BYTES` is `KURA_METADATA_STORE_WRITE_BUFFER_POOL_BYTES / 4`, rounded down to MiB boundaries and clamped to `[4 MiB, 32 MiB]`.
 - `KURA_METADATA_STORE_MAX_WRITE_BUFFERS` is `KURA_METADATA_STORE_WRITE_BUFFER_POOL_BYTES / KURA_METADATA_STORE_WRITE_BUFFER_BYTES`, clamped to `[2, 8]`.
-- `KURA_MAX_KEYVALUE_BYTES` defaults to `1048576`, `KURA_FILE_DESCRIPTOR_ACQUIRE_TIMEOUT_MS` defaults to `5000`, and `KURA_DRAIN_COMPLETION_TIMEOUT_MS` defaults to `240000`.
+- `KURA_MAX_KEYVALUE_BYTES` defaults to `1048576`, `KURA_FILE_DESCRIPTOR_ACQUIRE_TIMEOUT_MS` defaults to `5000`, `KURA_DRAIN_COMPLETION_TIMEOUT_MS` defaults to `240000`, and `KURA_REPLICATION_BANDWIDTH_LIMIT_BYTES_PER_SECOND` defaults to `0` (disabled).
 
 A minimal direct-binary deployment still looks like:
 

--- a/kura/README.md
+++ b/kura/README.md
@@ -229,7 +229,8 @@ When `Optional` is `Yes`, the `Default` column shows what Kura uses today. `auto
 | `KURA_METADATA_STORE_WRITE_BUFFER_BYTES` | Size of each metadata write buffer before flush. | Yes | auto |
 | `KURA_METADATA_STORE_MAX_WRITE_BUFFERS` | Maximum number of metadata write buffers kept in memory. | Yes | auto |
 | `KURA_OUTBOX_MAX_DEPTH` | Maximum number of replication outbox messages allowed before public writes return 503 with Retry-After. | Yes | `100000` |
-| `KURA_REPLICATION_BANDWIDTH_LIMIT_BYTES_PER_SECOND` | Aggregate per-node byte-per-second ceiling for peer artifact body transfers. Kura dynamically divides this ceiling by `public_inflight + 1`, so sync traffic backs off while public HTTP or gRPC cache work is active; `0` disables throttling. | Yes | `0` |
+| `KURA_REPLICATION_BANDWIDTH_LIMIT_BYTES_PER_SECOND` | Aggregate per-node byte-per-second ceiling for peer artifact body transfers. Kura dynamically divides this ceiling by the larger of `public_inflight + 1` and recent public request latency pressure, so sync traffic backs off while public HTTP or gRPC cache work is active or slow; `0` disables throttling. | Yes | `0` |
+| `KURA_REPLICATION_PUBLIC_LATENCY_TARGET_MS` | Public HTTP/gRPC request latency target used to adapt peer artifact body bandwidth. If recent public latency exceeds the target, sync traffic backs off proportionally; `0` disables latency-based pressure. | Yes | `100` |
 | `KURA_CONTROL_PLANE_URL` | Base URL for the control plane Kura reports usage to. When set with the client credentials below, Kura pushes usage rollups to `/_internal/kura/usage`. | Yes | disabled |
 | `KURA_CONTROL_PLANE_CLIENT_ID` | OAuth client id used for Kura control-plane calls. | Yes | disabled |
 | `KURA_CONTROL_PLANE_CLIENT_SECRET` | OAuth client secret used for Kura control-plane calls. | Yes | disabled |
@@ -248,7 +249,7 @@ When `Optional` is `Yes`, the `Default` column shows what Kura uses today. `auto
 
 Kura also enforces a few hard-coded budgets that are not configurable:
 
-- Replication ingest bodies on `/_internal/replicate/artifact` are capped at four times `MAX_SEGMENT_BYTES` (2 GiB) so a misbehaving peer cannot fill the data PVC. Bootstrap-from-peer fetches enforce the same ceiling for segment-backed artifacts and a 4 MiB ceiling for inline artifacts; bootstrap manifest and tombstone pages are capped at 32 MiB each. When `KURA_REPLICATION_BANDWIDTH_LIMIT_BYTES_PER_SECOND` is positive, Kura also applies a shared per-node bandwidth ceiling to peer artifact body traffic. The effective rate shrinks as public HTTP and gRPC requests are in flight, so background sync yields network capacity to public cache reads.
+- Replication ingest bodies on `/_internal/replicate/artifact` are capped at four times `MAX_SEGMENT_BYTES` (2 GiB) so a misbehaving peer cannot fill the data PVC. Bootstrap-from-peer fetches enforce the same ceiling for segment-backed artifacts and a 4 MiB ceiling for inline artifacts; bootstrap manifest and tombstone pages are capped at 32 MiB each. When `KURA_REPLICATION_BANDWIDTH_LIMIT_BYTES_PER_SECOND` is positive, Kura also applies a shared per-node bandwidth ceiling to peer artifact body traffic. The effective rate shrinks as public HTTP and gRPC requests are in flight or recent public latency rises above `KURA_REPLICATION_PUBLIC_LATENCY_TARGET_MS`, so background sync yields network capacity to public cache reads.
 - Public writes are rejected with `503 Service Unavailable` and a short `Retry-After` header when memory pressure reaches `Critical`, when the outbox is at `KURA_OUTBOX_MAX_DEPTH`, when the FD pool is exhausted, or when the data PVC has insufficient free space for a new segment.
 - RocksDB column families are configured with explicit level-0 slowdown/stop triggers and pending compaction limits so backlog turns into write-side backpressure instead of unbounded write-buffer growth.
 - Inline keyvalue payloads are buffered in memory before being written. Total RAM committed to inline payloads is bounded by `KURA_FILE_DESCRIPTOR_POOL_SIZE * KURA_MAX_KEYVALUE_BYTES`; both knobs are tuned together when sizing per-pod memory.
@@ -270,7 +271,7 @@ Auto-derived defaults currently follow these rules:
 - `KURA_METADATA_STORE_WRITE_BUFFER_POOL_BYTES` follows the same `memory_limit_bytes / 32` rule as the metadata-store read cache.
 - `KURA_METADATA_STORE_WRITE_BUFFER_BYTES` is `KURA_METADATA_STORE_WRITE_BUFFER_POOL_BYTES / 4`, rounded down to MiB boundaries and clamped to `[4 MiB, 32 MiB]`.
 - `KURA_METADATA_STORE_MAX_WRITE_BUFFERS` is `KURA_METADATA_STORE_WRITE_BUFFER_POOL_BYTES / KURA_METADATA_STORE_WRITE_BUFFER_BYTES`, clamped to `[2, 8]`.
-- `KURA_MAX_KEYVALUE_BYTES` defaults to `1048576`, `KURA_FILE_DESCRIPTOR_ACQUIRE_TIMEOUT_MS` defaults to `5000`, `KURA_DRAIN_COMPLETION_TIMEOUT_MS` defaults to `240000`, and `KURA_REPLICATION_BANDWIDTH_LIMIT_BYTES_PER_SECOND` defaults to `0` (disabled).
+- `KURA_MAX_KEYVALUE_BYTES` defaults to `1048576`, `KURA_FILE_DESCRIPTOR_ACQUIRE_TIMEOUT_MS` defaults to `5000`, `KURA_DRAIN_COMPLETION_TIMEOUT_MS` defaults to `240000`, `KURA_REPLICATION_BANDWIDTH_LIMIT_BYTES_PER_SECOND` defaults to `0` (disabled), and `KURA_REPLICATION_PUBLIC_LATENCY_TARGET_MS` defaults to `100`.
 
 A minimal direct-binary deployment still looks like:
 

--- a/kura/docs/architecture.md
+++ b/kura/docs/architecture.md
@@ -93,7 +93,7 @@ Replication is **leaderless and eventually consistent**:
 - Every node is a writer for its own clients.
 - A successful local write enqueues an `OutboxMessage` in RocksDB inside the same atomic batch as the metadata commit.
 - A background **outbox worker** drains the queue and PUTs each message to the corresponding peer over the internal plane. On success, the message is deleted; on failure it stays queued and the worker retries.
-- Large peer artifact body transfers can be application-throttled with `KURA_REPLICATION_BANDWIDTH_LIMIT_BYTES_PER_SECOND`. The limiter is shared per node across live replication uploads, replication ingests, and bootstrap artifact fetches/responses. The configured value is a ceiling; the effective sync rate is divided by `public_inflight + 1`, where public inflight includes non-probe public HTTP requests plus gRPC cache RPCs. Internal replication and probe requests do not count as public load. This lets sync work use its full budget while the node is quiet and back off automatically when public cache traffic is active.
+- Large peer artifact body transfers can be application-throttled with `KURA_REPLICATION_BANDWIDTH_LIMIT_BYTES_PER_SECOND`. The limiter is shared per node across live replication uploads, replication ingests, and bootstrap artifact fetches/responses. The configured value is a ceiling; the effective sync rate is divided by the larger of `public_inflight + 1` and the recent public request latency EWMA over `KURA_REPLICATION_PUBLIC_LATENCY_TARGET_MS`. Public inflight includes non-probe public HTTP requests plus gRPC cache RPCs. Internal replication and probe requests do not count as public load. This lets sync work use its full budget while the node is quiet and back off automatically when public cache traffic is active or slow.
 - Conflicts are resolved by `version_ms` (last-writer-wins per key); stale applies are rejected with `ArtifactApplyOutcome::IgnoredStale`.
 
 Newly joined nodes catch up by **bootstrapping from a peer**: paginated manifest and tombstone fetches followed by lazy artifact body fetches. Bootstrap re-uses the same apply paths as live replication, so the same conflict rules apply.
@@ -186,7 +186,7 @@ All configuration is environment-driven (`src/config.rs`). The full table lives 
 - Required identity and addressing: `KURA_TENANT_ID`, `KURA_REGION`, `KURA_NODE_URL`, `KURA_PORT`, `KURA_GRPC_PORT`, `KURA_INTERNAL_PORT`, `KURA_DATA_DIR`, `KURA_TMP_DIR`.
 - Peer plane: `KURA_PEERS`, `KURA_DISCOVERY_DNS_NAME`, optional `KURA_INTERNAL_TLS_*` for peer mTLS.
 - Resource budgets: file-descriptor pool, memory soft/hard limits, manifest cache, RocksDB write buffer pool, all with `auto` defaults derived from the host.
-- Peer sync bandwidth: `KURA_REPLICATION_BANDWIDTH_LIMIT_BYTES_PER_SECOND` sets the aggregate peer artifact body traffic ceiling per node when set above `0`; Kura adapts the effective rate downward under public HTTP or gRPC load.
+- Peer sync bandwidth: `KURA_REPLICATION_BANDWIDTH_LIMIT_BYTES_PER_SECOND` sets the aggregate peer artifact body traffic ceiling per node when set above `0`; Kura adapts the effective rate downward under public HTTP or gRPC load, and `KURA_REPLICATION_PUBLIC_LATENCY_TARGET_MS` controls the latency target for additional backoff.
 - Drain timing: `KURA_DRAIN_COMPLETION_TIMEOUT_MS`.
 
 When budget vars are unset Kura inspects `RLIMIT_NOFILE`, the cgroup memory limit, and detected CPU count to pick safe defaults.

--- a/kura/docs/architecture.md
+++ b/kura/docs/architecture.md
@@ -93,6 +93,7 @@ Replication is **leaderless and eventually consistent**:
 - Every node is a writer for its own clients.
 - A successful local write enqueues an `OutboxMessage` in RocksDB inside the same atomic batch as the metadata commit.
 - A background **outbox worker** drains the queue and PUTs each message to the corresponding peer over the internal plane. On success, the message is deleted; on failure it stays queued and the worker retries.
+- Large peer artifact body transfers can be application-throttled with `KURA_REPLICATION_BANDWIDTH_LIMIT_BYTES_PER_SECOND`. The limiter is shared per node across live replication uploads, replication ingests, and bootstrap artifact fetches/responses. The configured value is a ceiling; the effective sync rate is divided by `public_inflight + 1`, where public inflight includes non-probe public HTTP requests plus gRPC cache RPCs. Internal replication and probe requests do not count as public load. This lets sync work use its full budget while the node is quiet and back off automatically when public cache traffic is active.
 - Conflicts are resolved by `version_ms` (last-writer-wins per key); stale applies are rejected with `ArtifactApplyOutcome::IgnoredStale`.
 
 Newly joined nodes catch up by **bootstrapping from a peer**: paginated manifest and tombstone fetches followed by lazy artifact body fetches. Bootstrap re-uses the same apply paths as live replication, so the same conflict rules apply.
@@ -185,6 +186,7 @@ All configuration is environment-driven (`src/config.rs`). The full table lives 
 - Required identity and addressing: `KURA_TENANT_ID`, `KURA_REGION`, `KURA_NODE_URL`, `KURA_PORT`, `KURA_GRPC_PORT`, `KURA_INTERNAL_PORT`, `KURA_DATA_DIR`, `KURA_TMP_DIR`.
 - Peer plane: `KURA_PEERS`, `KURA_DISCOVERY_DNS_NAME`, optional `KURA_INTERNAL_TLS_*` for peer mTLS.
 - Resource budgets: file-descriptor pool, memory soft/hard limits, manifest cache, RocksDB write buffer pool, all with `auto` defaults derived from the host.
+- Peer sync bandwidth: `KURA_REPLICATION_BANDWIDTH_LIMIT_BYTES_PER_SECOND` sets the aggregate peer artifact body traffic ceiling per node when set above `0`; Kura adapts the effective rate downward under public HTTP or gRPC load.
 - Drain timing: `KURA_DRAIN_COMPLETION_TIMEOUT_MS`.
 
 When budget vars are unset Kura inspects `RLIMIT_NOFILE`, the cgroup memory limit, and detected CPU count to pick safe defaults.

--- a/kura/ops/helm/kura/templates/statefulset.yaml
+++ b/kura/ops/helm/kura/templates/statefulset.yaml
@@ -114,6 +114,8 @@ spec:
               value: {{ printf "%d" (int .Values.config.metadataStore.maxBackgroundJobs) | quote }}
             - name: KURA_REPLICATION_BANDWIDTH_LIMIT_BYTES_PER_SECOND
               value: {{ printf "%d" (int64 .Values.config.replication.bandwidthLimitBytesPerSecond) | quote }}
+            - name: KURA_REPLICATION_PUBLIC_LATENCY_TARGET_MS
+              value: {{ printf "%d" (int64 .Values.config.replication.publicLatencyTargetMs) | quote }}
             {{- if .Values.config.telemetry.otlpTracesEndpoint }}
             - name: KURA_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
               value: {{ .Values.config.telemetry.otlpTracesEndpoint | quote }}

--- a/kura/ops/helm/kura/templates/statefulset.yaml
+++ b/kura/ops/helm/kura/templates/statefulset.yaml
@@ -112,6 +112,8 @@ spec:
               value: {{ printf "%d" (int .Values.config.metadataStore.maxOpenFiles) | quote }}
             - name: KURA_METADATA_STORE_MAX_BACKGROUND_JOBS
               value: {{ printf "%d" (int .Values.config.metadataStore.maxBackgroundJobs) | quote }}
+            - name: KURA_REPLICATION_BANDWIDTH_LIMIT_BYTES_PER_SECOND
+              value: {{ printf "%d" (int64 .Values.config.replication.bandwidthLimitBytesPerSecond) | quote }}
             {{- if .Values.config.telemetry.otlpTracesEndpoint }}
             - name: KURA_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
               value: {{ .Values.config.telemetry.otlpTracesEndpoint | quote }}

--- a/kura/ops/helm/kura/values.yaml
+++ b/kura/ops/helm/kura/values.yaml
@@ -121,6 +121,11 @@ config:
   metadataStore:
     maxOpenFiles: 1024
     maxBackgroundJobs: 4
+  replication:
+    # 0 disables application-level peer artifact body throttling.
+    # Positive values are adaptive ceilings: Kura divides the configured
+    # bytes/second by public_inflight + 1.
+    bandwidthLimitBytesPerSecond: 0
   telemetry:
     otlpTracesEndpoint: http://otel-collector:4318/v1/traces
     deploymentEnvironment: production

--- a/kura/ops/helm/kura/values.yaml
+++ b/kura/ops/helm/kura/values.yaml
@@ -123,9 +123,12 @@ config:
     maxBackgroundJobs: 4
   replication:
     # 0 disables application-level peer artifact body throttling.
-    # Positive values are adaptive ceilings: Kura divides the configured
-    # bytes/second by public_inflight + 1.
+    # Positive values are adaptive ceilings: Kura lowers the effective sync
+    # rate under public inflight load or elevated public request latency.
     bandwidthLimitBytesPerSecond: 0
+    # Public request latency target used to further back off peer sync traffic.
+    # Set to 0 to disable latency-based pressure.
+    publicLatencyTargetMs: 100
   telemetry:
     otlpTracesEndpoint: http://otel-collector:4318/v1/traces
     deploymentEnvironment: production

--- a/kura/src/app.rs
+++ b/kura/src/app.rs
@@ -16,6 +16,7 @@ use tracing::{Instrument, info, warn};
 
 use crate::{
     analytics::Analytics,
+    bandwidth::BandwidthLimiter,
     config::Config,
     extension::ExtensionEngine,
     geoip::GeoIp,
@@ -116,6 +117,12 @@ async fn run_with_config(
     );
     let store = Store::open(&config, io.clone(), memory.clone())?;
     let client = build_peer_client(&config).await?;
+    let runtime = RuntimeState::new();
+    let replication_bandwidth_limiter = BandwidthLimiter::new(
+        config.replication_bandwidth_limit_bytes_per_second,
+        runtime.clone(),
+    )
+    .map(Arc::new);
     let notify = Notify::new();
 
     let bootstrap_semaphore = Arc::new(Semaphore::new(config.bootstrap_max_concurrent_peers));
@@ -126,12 +133,13 @@ async fn run_with_config(
         io,
         memory,
         metrics,
-        runtime: RuntimeState::new(),
+        runtime,
         extension,
         analytics,
         usage,
         geoip,
         client,
+        replication_bandwidth_limiter,
         notify,
         readiness: tokio::sync::Mutex::new(ReadinessState::new(Instant::now())),
         bootstrap_semaphore,
@@ -810,7 +818,9 @@ mod tests {
     #[tokio::test]
     async fn wait_for_inflight_drain_returns_when_requests_finish() {
         let context = test_context(|_| {}).await;
-        let guard = context.state.start_http_request();
+        let guard = context
+            .state
+            .start_http_request(crate::runtime::HttpTrafficClass::Public);
         let waiter = tokio::spawn(wait_for_inflight_drain(
             context.state.clone(),
             ShutdownBudget::new(Duration::from_millis(250)),

--- a/kura/src/app.rs
+++ b/kura/src/app.rs
@@ -120,6 +120,7 @@ async fn run_with_config(
     let runtime = RuntimeState::new();
     let replication_bandwidth_limiter = BandwidthLimiter::new(
         config.replication_bandwidth_limit_bytes_per_second,
+        config.replication_public_latency_target_ms,
         runtime.clone(),
     )
     .map(Arc::new);

--- a/kura/src/bandwidth.rs
+++ b/kura/src/bandwidth.rs
@@ -1,0 +1,99 @@
+use std::{sync::Arc, time::Duration};
+
+use tokio::{
+    sync::Mutex,
+    time::{Instant, sleep},
+};
+
+use crate::runtime::RuntimeState;
+
+pub struct BandwidthLimiter {
+    bytes_per_second: u64,
+    runtime: Arc<RuntimeState>,
+    next_available: Mutex<Instant>,
+}
+
+impl BandwidthLimiter {
+    pub fn new(bytes_per_second: u64, runtime: Arc<RuntimeState>) -> Option<Self> {
+        if bytes_per_second == 0 {
+            return None;
+        }
+
+        Some(Self {
+            bytes_per_second,
+            runtime,
+            next_available: Mutex::new(Instant::now()),
+        })
+    }
+
+    pub async fn acquire(&self, bytes: usize) {
+        if bytes == 0 {
+            return;
+        }
+
+        let bytes_per_second =
+            effective_bytes_per_second(self.bytes_per_second, self.runtime.public_inflight());
+        let wait = {
+            let mut next_available = self.next_available.lock().await;
+            let now = Instant::now();
+            let start = (*next_available).max(now);
+            *next_available = start + duration_for_bytes(bytes, bytes_per_second);
+            start.saturating_duration_since(now)
+        };
+
+        if !wait.is_zero() {
+            sleep(wait).await;
+        }
+    }
+
+    pub fn effective_bytes_per_second(&self) -> u64 {
+        effective_bytes_per_second(self.bytes_per_second, self.runtime.public_inflight())
+    }
+}
+
+pub fn effective_bytes_per_second(configured_bytes_per_second: u64, public_inflight: usize) -> u64 {
+    if configured_bytes_per_second == 0 {
+        return 0;
+    }
+
+    configured_bytes_per_second
+        .checked_div((public_inflight as u64).saturating_add(1))
+        .unwrap_or(1)
+        .max(1)
+}
+
+fn duration_for_bytes(bytes: usize, bytes_per_second: u64) -> Duration {
+    let nanos = (bytes as u128)
+        .saturating_mul(1_000_000_000)
+        .div_ceil(bytes_per_second as u128)
+        .min(u64::MAX as u128);
+    Duration::from_nanos(nanos as u64)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn disabled_when_limit_is_zero() {
+        assert!(BandwidthLimiter::new(0, RuntimeState::new()).is_none());
+    }
+
+    #[test]
+    fn duration_rounds_up_to_avoid_zero_cost_bytes() {
+        assert_eq!(
+            duration_for_bytes(1, 10_000_000_000),
+            Duration::from_nanos(1)
+        );
+        assert_eq!(duration_for_bytes(2_000, 1_000), Duration::from_secs(2));
+    }
+
+    #[test]
+    fn effective_rate_shrinks_as_public_inflight_grows() {
+        assert_eq!(effective_bytes_per_second(10_000, 0), 10_000);
+        assert_eq!(effective_bytes_per_second(10_000, 1), 5_000);
+        assert_eq!(effective_bytes_per_second(10_000, 4), 2_000);
+        assert_eq!(effective_bytes_per_second(1, 10), 1);
+        assert_eq!(effective_bytes_per_second(0, 10), 0);
+    }
+}

--- a/kura/src/bandwidth.rs
+++ b/kura/src/bandwidth.rs
@@ -9,18 +9,24 @@ use crate::runtime::RuntimeState;
 
 pub struct BandwidthLimiter {
     bytes_per_second: u64,
+    public_latency_target_ms: u64,
     runtime: Arc<RuntimeState>,
     next_available: Mutex<Instant>,
 }
 
 impl BandwidthLimiter {
-    pub fn new(bytes_per_second: u64, runtime: Arc<RuntimeState>) -> Option<Self> {
+    pub fn new(
+        bytes_per_second: u64,
+        public_latency_target_ms: u64,
+        runtime: Arc<RuntimeState>,
+    ) -> Option<Self> {
         if bytes_per_second == 0 {
             return None;
         }
 
         Some(Self {
             bytes_per_second,
+            public_latency_target_ms,
             runtime,
             next_available: Mutex::new(Instant::now()),
         })
@@ -31,8 +37,12 @@ impl BandwidthLimiter {
             return;
         }
 
-        let bytes_per_second =
-            effective_bytes_per_second(self.bytes_per_second, self.runtime.public_inflight());
+        let bytes_per_second = effective_bytes_per_second(
+            self.bytes_per_second,
+            self.runtime.public_inflight(),
+            self.runtime
+                .public_latency_pressure_divisor(self.public_latency_target_ms),
+        );
         let wait = {
             let mut next_available = self.next_available.lock().await;
             let now = Instant::now();
@@ -47,17 +57,29 @@ impl BandwidthLimiter {
     }
 
     pub fn effective_bytes_per_second(&self) -> u64 {
-        effective_bytes_per_second(self.bytes_per_second, self.runtime.public_inflight())
+        effective_bytes_per_second(
+            self.bytes_per_second,
+            self.runtime.public_inflight(),
+            self.runtime
+                .public_latency_pressure_divisor(self.public_latency_target_ms),
+        )
     }
 }
 
-pub fn effective_bytes_per_second(configured_bytes_per_second: u64, public_inflight: usize) -> u64 {
+pub fn effective_bytes_per_second(
+    configured_bytes_per_second: u64,
+    public_inflight: usize,
+    latency_pressure_divisor: usize,
+) -> u64 {
     if configured_bytes_per_second == 0 {
         return 0;
     }
 
+    let divisor = (public_inflight as u64)
+        .saturating_add(1)
+        .max(latency_pressure_divisor.max(1) as u64);
     configured_bytes_per_second
-        .checked_div((public_inflight as u64).saturating_add(1))
+        .checked_div(divisor)
         .unwrap_or(1)
         .max(1)
 }
@@ -76,7 +98,7 @@ mod tests {
 
     #[test]
     fn disabled_when_limit_is_zero() {
-        assert!(BandwidthLimiter::new(0, RuntimeState::new()).is_none());
+        assert!(BandwidthLimiter::new(0, 100, RuntimeState::new()).is_none());
     }
 
     #[test]
@@ -90,10 +112,16 @@ mod tests {
 
     #[test]
     fn effective_rate_shrinks_as_public_inflight_grows() {
-        assert_eq!(effective_bytes_per_second(10_000, 0), 10_000);
-        assert_eq!(effective_bytes_per_second(10_000, 1), 5_000);
-        assert_eq!(effective_bytes_per_second(10_000, 4), 2_000);
-        assert_eq!(effective_bytes_per_second(1, 10), 1);
-        assert_eq!(effective_bytes_per_second(0, 10), 0);
+        assert_eq!(effective_bytes_per_second(10_000, 0, 1), 10_000);
+        assert_eq!(effective_bytes_per_second(10_000, 1, 1), 5_000);
+        assert_eq!(effective_bytes_per_second(10_000, 4, 1), 2_000);
+        assert_eq!(effective_bytes_per_second(1, 10, 1), 1);
+        assert_eq!(effective_bytes_per_second(0, 10, 1), 0);
+    }
+
+    #[test]
+    fn effective_rate_uses_larger_latency_pressure_divisor() {
+        assert_eq!(effective_bytes_per_second(10_000, 0, 4), 2_500);
+        assert_eq!(effective_bytes_per_second(10_000, 4, 2), 2_000);
     }
 }

--- a/kura/src/config.rs
+++ b/kura/src/config.rs
@@ -70,6 +70,7 @@ const KURA_USAGE_OUTBOX_MAX_DEPTH: &str = "KURA_USAGE_OUTBOX_MAX_DEPTH";
 const KURA_OUTBOX_MAX_DEPTH: &str = "KURA_OUTBOX_MAX_DEPTH";
 const KURA_REPLICATION_BANDWIDTH_LIMIT_BYTES_PER_SECOND: &str =
     "KURA_REPLICATION_BANDWIDTH_LIMIT_BYTES_PER_SECOND";
+const KURA_REPLICATION_PUBLIC_LATENCY_TARGET_MS: &str = "KURA_REPLICATION_PUBLIC_LATENCY_TARGET_MS";
 const KURA_MULTIPART_UPLOAD_TTL_MS: &str = "KURA_MULTIPART_UPLOAD_TTL_MS";
 const KURA_MULTIPART_JANITOR_INTERVAL_MS: &str = "KURA_MULTIPART_JANITOR_INTERVAL_MS";
 const KURA_BOOTSTRAP_TIMEOUT_MS: &str = "KURA_BOOTSTRAP_TIMEOUT_MS";
@@ -88,6 +89,7 @@ const DEFAULT_FILE_DESCRIPTOR_ACQUIRE_TIMEOUT_MS: u64 = 5_000;
 const DEFAULT_DRAIN_COMPLETION_TIMEOUT_MS: u64 = 240_000;
 const DEFAULT_MAX_KEYVALUE_BYTES: usize = 1024 * 1024;
 const DEFAULT_REPLICATION_BANDWIDTH_LIMIT_BYTES_PER_SECOND: u64 = 0;
+const DEFAULT_REPLICATION_PUBLIC_LATENCY_TARGET_MS: u64 = 100;
 const FALLBACK_HOST_FD_LIMIT: usize = 4096;
 const FALLBACK_HOST_MEMORY_LIMIT_BYTES: u64 = 1024 * BYTES_PER_MIB;
 const FALLBACK_HOST_CPU_COUNT: usize = 4;
@@ -124,6 +126,7 @@ pub struct Config {
     pub rocksdb_max_write_buffer_number: i32,
     pub outbox_max_depth: usize,
     pub replication_bandwidth_limit_bytes_per_second: u64,
+    pub replication_public_latency_target_ms: u64,
     pub multipart_upload_ttl_ms: u64,
     pub multipart_janitor_interval_ms: u64,
     pub bootstrap_timeout_ms: u64,
@@ -699,6 +702,17 @@ impl Config {
             },
         )
         .unwrap_or(DEFAULT_REPLICATION_BANDWIDTH_LIMIT_BYTES_PER_SECOND);
+        let replication_public_latency_target_ms = optional_parsed_value(
+            &mut lookup,
+            KURA_REPLICATION_PUBLIC_LATENCY_TARGET_MS,
+            &mut invalid,
+            |value| {
+                value.parse::<u64>().map_err(|_| {
+                    format!("{KURA_REPLICATION_PUBLIC_LATENCY_TARGET_MS} must be a valid u64")
+                })
+            },
+        )
+        .unwrap_or(DEFAULT_REPLICATION_PUBLIC_LATENCY_TARGET_MS);
         let multipart_upload_ttl_ms = optional_parsed_value(
             &mut lookup,
             KURA_MULTIPART_UPLOAD_TTL_MS,
@@ -1162,6 +1176,7 @@ impl Config {
             rocksdb_max_write_buffer_number,
             outbox_max_depth,
             replication_bandwidth_limit_bytes_per_second,
+            replication_public_latency_target_ms,
             multipart_upload_ttl_ms,
             multipart_janitor_interval_ms,
             bootstrap_timeout_ms,
@@ -1426,6 +1441,7 @@ mod tests {
         );
         assert_eq!(config.rocksdb_max_write_buffer_number, 4);
         assert_eq!(config.replication_bandwidth_limit_bytes_per_second, 0);
+        assert_eq!(config.replication_public_latency_target_ms, 100);
         assert_eq!(config.sentry_dsn, None);
     }
 
@@ -1457,6 +1473,7 @@ mod tests {
                 KURA_REPLICATION_BANDWIDTH_LIMIT_BYTES_PER_SECOND,
                 "10485760",
             ),
+            (KURA_REPLICATION_PUBLIC_LATENCY_TARGET_MS, "75"),
             (
                 KURA_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT,
                 "https://otel.example.com/v1/traces",
@@ -1502,6 +1519,7 @@ mod tests {
             config.replication_bandwidth_limit_bytes_per_second,
             10_485_760
         );
+        assert_eq!(config.replication_public_latency_target_ms, 75);
         assert_eq!(config.analytics, None);
         assert_eq!(
             config.otlp_traces_endpoint.as_deref(),
@@ -1592,6 +1610,7 @@ mod tests {
             (KURA_METADATA_STORE_WRITE_BUFFER_BYTES, "invalid"),
             (KURA_METADATA_STORE_MAX_WRITE_BUFFERS, "invalid"),
             (KURA_REPLICATION_BANDWIDTH_LIMIT_BYTES_PER_SECOND, "invalid"),
+            (KURA_REPLICATION_PUBLIC_LATENCY_TARGET_MS, "invalid"),
             (
                 KURA_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT,
                 "https://otel.example.com/v1/traces",
@@ -1619,6 +1638,7 @@ mod tests {
         assert!(error.contains(KURA_METADATA_STORE_WRITE_BUFFER_BYTES));
         assert!(error.contains(KURA_METADATA_STORE_MAX_WRITE_BUFFERS));
         assert!(error.contains(KURA_REPLICATION_BANDWIDTH_LIMIT_BYTES_PER_SECOND));
+        assert!(error.contains(KURA_REPLICATION_PUBLIC_LATENCY_TARGET_MS));
     }
 
     #[test]

--- a/kura/src/config.rs
+++ b/kura/src/config.rs
@@ -68,6 +68,8 @@ const KURA_USAGE_BATCH_SIZE: &str = "KURA_USAGE_BATCH_SIZE";
 const KURA_USAGE_MAX_BUCKETS: &str = "KURA_USAGE_MAX_BUCKETS";
 const KURA_USAGE_OUTBOX_MAX_DEPTH: &str = "KURA_USAGE_OUTBOX_MAX_DEPTH";
 const KURA_OUTBOX_MAX_DEPTH: &str = "KURA_OUTBOX_MAX_DEPTH";
+const KURA_REPLICATION_BANDWIDTH_LIMIT_BYTES_PER_SECOND: &str =
+    "KURA_REPLICATION_BANDWIDTH_LIMIT_BYTES_PER_SECOND";
 const KURA_MULTIPART_UPLOAD_TTL_MS: &str = "KURA_MULTIPART_UPLOAD_TTL_MS";
 const KURA_MULTIPART_JANITOR_INTERVAL_MS: &str = "KURA_MULTIPART_JANITOR_INTERVAL_MS";
 const KURA_BOOTSTRAP_TIMEOUT_MS: &str = "KURA_BOOTSTRAP_TIMEOUT_MS";
@@ -85,6 +87,7 @@ const BYTES_PER_MIB: u64 = 1024 * 1024;
 const DEFAULT_FILE_DESCRIPTOR_ACQUIRE_TIMEOUT_MS: u64 = 5_000;
 const DEFAULT_DRAIN_COMPLETION_TIMEOUT_MS: u64 = 240_000;
 const DEFAULT_MAX_KEYVALUE_BYTES: usize = 1024 * 1024;
+const DEFAULT_REPLICATION_BANDWIDTH_LIMIT_BYTES_PER_SECOND: u64 = 0;
 const FALLBACK_HOST_FD_LIMIT: usize = 4096;
 const FALLBACK_HOST_MEMORY_LIMIT_BYTES: u64 = 1024 * BYTES_PER_MIB;
 const FALLBACK_HOST_CPU_COUNT: usize = 4;
@@ -120,6 +123,7 @@ pub struct Config {
     pub rocksdb_write_buffer_size_bytes: usize,
     pub rocksdb_max_write_buffer_number: i32,
     pub outbox_max_depth: usize,
+    pub replication_bandwidth_limit_bytes_per_second: u64,
     pub multipart_upload_ttl_ms: u64,
     pub multipart_janitor_interval_ms: u64,
     pub bootstrap_timeout_ms: u64,
@@ -682,6 +686,19 @@ impl Config {
         if outbox_max_depth == 0 {
             invalid.push(format!("{KURA_OUTBOX_MAX_DEPTH} must be greater than 0"));
         }
+        let replication_bandwidth_limit_bytes_per_second = optional_parsed_value(
+            &mut lookup,
+            KURA_REPLICATION_BANDWIDTH_LIMIT_BYTES_PER_SECOND,
+            &mut invalid,
+            |value| {
+                value.parse::<u64>().map_err(|_| {
+                    format!(
+                        "{KURA_REPLICATION_BANDWIDTH_LIMIT_BYTES_PER_SECOND} must be a valid u64"
+                    )
+                })
+            },
+        )
+        .unwrap_or(DEFAULT_REPLICATION_BANDWIDTH_LIMIT_BYTES_PER_SECOND);
         let multipart_upload_ttl_ms = optional_parsed_value(
             &mut lookup,
             KURA_MULTIPART_UPLOAD_TTL_MS,
@@ -1144,6 +1161,7 @@ impl Config {
             rocksdb_write_buffer_size_bytes,
             rocksdb_max_write_buffer_number,
             outbox_max_depth,
+            replication_bandwidth_limit_bytes_per_second,
             multipart_upload_ttl_ms,
             multipart_janitor_interval_ms,
             bootstrap_timeout_ms,
@@ -1407,6 +1425,7 @@ mod tests {
             (8 * BYTES_PER_MIB) as usize
         );
         assert_eq!(config.rocksdb_max_write_buffer_number, 4);
+        assert_eq!(config.replication_bandwidth_limit_bytes_per_second, 0);
         assert_eq!(config.sentry_dsn, None);
     }
 
@@ -1434,6 +1453,10 @@ mod tests {
             (KURA_MAX_KEYVALUE_BYTES, "1048576"),
             (KURA_METADATA_STORE_MAX_OPEN_FILES, "1024"),
             (KURA_METADATA_STORE_MAX_BACKGROUND_JOBS, "4"),
+            (
+                KURA_REPLICATION_BANDWIDTH_LIMIT_BYTES_PER_SECOND,
+                "10485760",
+            ),
             (
                 KURA_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT,
                 "https://otel.example.com/v1/traces",
@@ -1475,6 +1498,10 @@ mod tests {
         assert_eq!(config.rocksdb_write_buffer_manager_bytes, 32 * 1024 * 1024);
         assert_eq!(config.rocksdb_write_buffer_size_bytes, 8 * 1024 * 1024);
         assert_eq!(config.rocksdb_max_write_buffer_number, 4);
+        assert_eq!(
+            config.replication_bandwidth_limit_bytes_per_second,
+            10_485_760
+        );
         assert_eq!(config.analytics, None);
         assert_eq!(
             config.otlp_traces_endpoint.as_deref(),
@@ -1564,6 +1591,7 @@ mod tests {
             (KURA_METADATA_STORE_WRITE_BUFFER_POOL_BYTES, "invalid"),
             (KURA_METADATA_STORE_WRITE_BUFFER_BYTES, "invalid"),
             (KURA_METADATA_STORE_MAX_WRITE_BUFFERS, "invalid"),
+            (KURA_REPLICATION_BANDWIDTH_LIMIT_BYTES_PER_SECOND, "invalid"),
             (
                 KURA_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT,
                 "https://otel.example.com/v1/traces",
@@ -1590,6 +1618,7 @@ mod tests {
         assert!(error.contains(KURA_METADATA_STORE_WRITE_BUFFER_POOL_BYTES));
         assert!(error.contains(KURA_METADATA_STORE_WRITE_BUFFER_BYTES));
         assert!(error.contains(KURA_METADATA_STORE_MAX_WRITE_BUFFERS));
+        assert!(error.contains(KURA_REPLICATION_BANDWIDTH_LIMIT_BYTES_PER_SECOND));
     }
 
     #[test]

--- a/kura/src/http.rs
+++ b/kura/src/http.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::{BTreeMap, HashMap},
     net::IpAddr,
+    sync::Arc,
 };
 
 use axum::{
@@ -13,13 +14,14 @@ use axum::{
     routing::{delete, get, head, post, put},
 };
 use bytes::Bytes;
-use futures_util::stream;
+use futures_util::{StreamExt, stream};
 use serde::Deserialize;
 use tokio_util::io::ReaderStream;
 use tracing::{Instrument, field};
 
 use crate::{
     artifact::{manifest::ArtifactManifest, producer::ArtifactProducer},
+    bandwidth::BandwidthLimiter,
     constants::{
         MAX_GRADLE_BYTES, MAX_MODULE_PART_BYTES, MAX_MODULE_TOTAL_BYTES,
         MAX_REPLICATION_BODY_BYTES, MAX_XCODE_BYTES,
@@ -29,6 +31,7 @@ use crate::{
     memory::MemoryPressure,
     multipart::error::MultipartError,
     replication::replication_targets,
+    runtime::HttpTrafficClass,
     state::SharedState,
     store::is_disk_full_error,
     telemetry::{attach_parent_context, record_trace_context},
@@ -477,9 +480,14 @@ async fn track_http_metrics(
     req: Request,
     next: Next,
 ) -> Response {
-    let _request_guard = state.start_http_request();
     let start = std::time::Instant::now();
     let route = request_route(&req);
+    let traffic_class = if is_public_load_route(&route) {
+        HttpTrafficClass::Public
+    } else {
+        HttpTrafficClass::Background
+    };
+    let _request_guard = state.start_http_request(traffic_class);
     let method = req.method().to_string();
     let uri_path = req.uri().path().to_owned();
     let client_location = state
@@ -527,6 +535,10 @@ async fn track_http_metrics(
         .record_http(route, response.status(), client_country, start.elapsed());
 
     response
+}
+
+fn is_public_load_route(route: &str) -> bool {
+    !is_probe_route(route) && !route.starts_with("/_internal/") && route != UNMATCHED_ROUTE
 }
 
 fn client_ip_from_headers(headers: &axum::http::HeaderMap) -> Option<IpAddr> {
@@ -1509,6 +1521,7 @@ async fn upload_module_part(
         &state.config.tmp_dir.join("parts"),
         MAX_MODULE_PART_BYTES,
         &state.io,
+        None,
     )
     .await
     {
@@ -1701,7 +1714,15 @@ async fn internal_bootstrap_artifact(
         .fetch_artifact_by_id_for_serving(&artifact_id)
         .await
     {
-        Ok(Some(manifest)) => serve_file(&state, StatusCode::OK, &manifest).await,
+        Ok(Some(manifest)) => {
+            serve_file_reader(
+                &state,
+                StatusCode::OK,
+                &manifest,
+                state.replication_bandwidth_limiter.clone(),
+            )
+            .await
+        }
         Ok(None) => StatusCode::NOT_FOUND.into_response(),
         Err(error) => error_response(
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -1801,6 +1822,7 @@ async fn internal_replicate_artifact(
         &state.config.tmp_dir.join("uploads"),
         MAX_REPLICATION_BODY_BYTES,
         &state.io,
+        state.replication_bandwidth_limiter.clone(),
     )
     .await
     {
@@ -1971,6 +1993,7 @@ async fn put_blob_artifact(
         &state.config.tmp_dir.join("uploads"),
         spec.max_bytes,
         &state.io,
+        None,
     )
     .await
     {
@@ -2122,14 +2145,14 @@ async fn serve_file(
             apply_artifact_response_headers(&mut response, manifest);
             response
         }
-        Ok(None) => serve_file_reader(state, status, manifest).await,
+        Ok(None) => serve_file_reader(state, status, manifest, None).await,
         Err(error) => {
             tracing::warn!(
                 artifact_id = %manifest.artifact_id,
                 %error,
                 "mmap artifact serving failed; falling back to streaming reader"
             );
-            serve_file_reader(state, status, manifest).await
+            serve_file_reader(state, status, manifest, None).await
         }
     }
 }
@@ -2138,10 +2161,12 @@ async fn serve_file_reader(
     state: &SharedState,
     status: StatusCode,
     manifest: &ArtifactManifest,
+    bandwidth_limiter: Option<Arc<BandwidthLimiter>>,
 ) -> Response {
     match state.store.open_artifact_reader(manifest).await {
         Ok(reader) => {
             let stream = ReaderStream::with_capacity(reader, RESPONSE_STREAM_CHUNK_BYTES);
+            let stream = throttle_body_stream(stream, bandwidth_limiter);
             let mut response = Response::new(Body::from_stream(stream));
             *response.status_mut() = status;
             apply_artifact_response_headers(&mut response, manifest);
@@ -2152,6 +2177,24 @@ async fn serve_file_reader(
             format!("Artifact bytes are missing from local storage: {error}"),
         ),
     }
+}
+
+fn throttle_body_stream<S, E>(
+    stream: S,
+    bandwidth_limiter: Option<Arc<BandwidthLimiter>>,
+) -> impl futures_util::Stream<Item = Result<Bytes, E>>
+where
+    S: futures_util::Stream<Item = Result<Bytes, E>>,
+{
+    stream.then(move |item| {
+        let bandwidth_limiter = bandwidth_limiter.clone();
+        async move {
+            if let (Some(limiter), Ok(chunk)) = (bandwidth_limiter.as_ref(), item.as_ref()) {
+                limiter.acquire(chunk.len()).await;
+            }
+            item
+        }
+    })
 }
 
 fn bytes_chunks(bytes: Bytes) -> impl futures_util::Stream<Item = Result<Bytes, std::io::Error>> {
@@ -2363,6 +2406,16 @@ mod tests {
             UNMATCHED_ROUTE
         );
         assert_eq!(route_template_for_path("/.docker/.env"), UNMATCHED_ROUTE);
+    }
+
+    #[test]
+    fn public_load_routes_exclude_probes_internal_and_unmatched_routes() {
+        assert!(is_public_load_route(ROUTE_API_CACHE_CAS));
+        assert!(is_public_load_route(ROUTE_API_CACHE_MODULE));
+        assert!(!is_public_load_route(ROUTE_UP));
+        assert!(!is_public_load_route(ROUTE_METRICS));
+        assert!(!is_public_load_route(ROUTE_INTERNAL_REPLICATE_ARTIFACT));
+        assert!(!is_public_load_route(UNMATCHED_ROUTE));
     }
 
     #[tokio::test]

--- a/kura/src/lib.rs
+++ b/kura/src/lib.rs
@@ -1,6 +1,7 @@
 mod analytics;
 mod app;
 mod artifact;
+mod bandwidth;
 mod config;
 mod constants;
 mod extension;

--- a/kura/src/metrics.rs
+++ b/kura/src/metrics.rs
@@ -44,6 +44,8 @@ pub struct Metrics {
     replication_requests: Family<ReplicationLabels, Counter>,
     replication_request_duration: Family<ReplicationRouteLabels, Histogram>,
     replication_apply_results: Family<ReplicationApplyLabels, Counter>,
+    replication_bandwidth_configured_limit_bytes_per_second: Gauge,
+    replication_bandwidth_effective_limit_bytes_per_second: Gauge,
     multipart_parts: Family<MultipartLabels, Counter>,
     node_info: Family<NodeInfoLabels, Gauge>,
     node_geo: Family<NodeGeoLabels, Gauge>,
@@ -56,6 +58,7 @@ pub struct Metrics {
     file_descriptor_waiting: Gauge,
     file_descriptor_capacity: Gauge,
     http_inflight_requests: Gauge,
+    public_http_inflight_requests: Gauge,
     grpc_inflight_requests: Gauge,
     segment_handles_cached: Gauge,
     segment_handle_cache_capacity: Gauge,
@@ -152,6 +155,8 @@ impl Metrics {
                 Histogram::new(exponential_buckets(0.001, 2.0, 16))
             });
         let replication_apply_results = Family::<ReplicationApplyLabels, Counter>::default();
+        let replication_bandwidth_configured_limit_bytes_per_second = Gauge::default();
+        let replication_bandwidth_effective_limit_bytes_per_second = Gauge::default();
         let multipart_parts = Family::<MultipartLabels, Counter>::default();
         let node_info = Family::<NodeInfoLabels, Gauge>::default();
         let node_geo = Family::<NodeGeoLabels, Gauge>::default();
@@ -170,6 +175,7 @@ impl Metrics {
         let file_descriptor_waiting = Gauge::default();
         let file_descriptor_capacity = Gauge::default();
         let http_inflight_requests = Gauge::default();
+        let public_http_inflight_requests = Gauge::default();
         let grpc_inflight_requests = Gauge::default();
         let segment_handles_cached = Gauge::default();
         let segment_handle_cache_capacity = Gauge::default();
@@ -323,6 +329,16 @@ impl Metrics {
             replication_apply_results.clone(),
         );
         registry.register(
+            "kura_replication_bandwidth_configured_limit_bytes_per_second",
+            "Configured aggregate byte-per-second ceiling for peer artifact body transfers where 0 disables throttling",
+            replication_bandwidth_configured_limit_bytes_per_second.clone(),
+        );
+        registry.register(
+            "kura_replication_bandwidth_effective_limit_bytes_per_second",
+            "Current aggregate byte-per-second limit for peer artifact body transfers after public-load adaptation",
+            replication_bandwidth_effective_limit_bytes_per_second.clone(),
+        );
+        registry.register(
             "kura_multipart_parts_total",
             "Multipart part uploads by result",
             multipart_parts.clone(),
@@ -381,6 +397,11 @@ impl Metrics {
             "kura_http_inflight_requests",
             "HTTP requests currently in flight across public and internal listeners",
             http_inflight_requests.clone(),
+        );
+        registry.register(
+            "kura_public_http_inflight_requests",
+            "Public non-probe HTTP requests currently in flight",
+            public_http_inflight_requests.clone(),
         );
         registry.register(
             "kura_grpc_inflight_requests",
@@ -688,6 +709,8 @@ impl Metrics {
             replication_requests,
             replication_request_duration,
             replication_apply_results,
+            replication_bandwidth_configured_limit_bytes_per_second,
+            replication_bandwidth_effective_limit_bytes_per_second,
             multipart_parts,
             node_info,
             node_geo,
@@ -700,6 +723,7 @@ impl Metrics {
             file_descriptor_waiting,
             file_descriptor_capacity,
             http_inflight_requests,
+            public_http_inflight_requests,
             grpc_inflight_requests,
             segment_handles_cached,
             segment_handle_cache_capacity,
@@ -916,6 +940,17 @@ impl Metrics {
             .inc();
     }
 
+    pub fn update_replication_bandwidth_limits(
+        &self,
+        configured_bytes_per_second: u64,
+        effective_bytes_per_second: u64,
+    ) {
+        self.replication_bandwidth_configured_limit_bytes_per_second
+            .set(configured_bytes_per_second as i64);
+        self.replication_bandwidth_effective_limit_bytes_per_second
+            .set(effective_bytes_per_second as i64);
+    }
+
     pub fn record_multipart_part(&self, result: &str) {
         self.multipart_parts
             .get_or_create(&MultipartLabels {
@@ -976,6 +1011,10 @@ impl Metrics {
 
     pub fn update_http_inflight(&self, count: usize) {
         self.http_inflight_requests.set(count as i64);
+    }
+
+    pub fn update_public_http_inflight(&self, count: usize) {
+        self.public_http_inflight_requests.set(count as i64);
     }
 
     pub fn update_grpc_inflight(&self, count: usize) {
@@ -1573,11 +1612,13 @@ mod tests {
         );
         metrics.record_replication_apply("replication", "artifact", "applied");
         metrics.record_replication_apply("bootstrap", "namespace_delete", "ignored_older");
+        metrics.update_replication_bandwidth_limits(10_485_760, 5_242_880);
         metrics.record_multipart_part("ok");
         metrics.record_file_descriptor_wait("ok", Duration::from_millis(1));
         metrics.record_file_operation("open_read", "ok", Duration::from_millis(2), 42);
         metrics.update_file_descriptor_pool(64, 3, 61, 1);
         metrics.update_http_inflight(2);
+        metrics.update_public_http_inflight(1);
         metrics.update_grpc_inflight(1);
         metrics.update_segment_handles_cached(2);
         metrics.update_segment_handle_cache_capacity(8);
@@ -1665,6 +1706,7 @@ mod tests {
         assert!(rendered.contains("kura_file_operations_total"));
         assert!(rendered.contains("kura_file_descriptor_in_use"));
         assert!(rendered.contains("kura_http_inflight_requests"));
+        assert!(rendered.contains("kura_public_http_inflight_requests"));
         assert!(rendered.contains("kura_grpc_inflight_requests"));
         assert!(rendered.contains("kura_segment_handles_cached"));
         assert!(rendered.contains("kura_segment_handle_cache_capacity"));
@@ -1687,6 +1729,8 @@ mod tests {
         assert!(rendered.contains("kura_bootstrap_runs_total"));
         assert!(rendered.contains("kura_bootstrap_duration_seconds"));
         assert!(rendered.contains("kura_bootstrap_applied_items_total"));
+        assert!(rendered.contains("kura_replication_bandwidth_configured_limit_bytes_per_second"));
+        assert!(rendered.contains("kura_replication_bandwidth_effective_limit_bytes_per_second"));
         assert!(rendered.contains("kura_analytics_events_total"));
         assert!(rendered.contains("kura_analytics_batches_total"));
         assert!(rendered.contains("kura_analytics_batch_duration_seconds"));

--- a/kura/src/metrics.rs
+++ b/kura/src/metrics.rs
@@ -46,6 +46,7 @@ pub struct Metrics {
     replication_apply_results: Family<ReplicationApplyLabels, Counter>,
     replication_bandwidth_configured_limit_bytes_per_second: Gauge,
     replication_bandwidth_effective_limit_bytes_per_second: Gauge,
+    replication_bandwidth_public_latency_target_ms: Gauge,
     multipart_parts: Family<MultipartLabels, Counter>,
     node_info: Family<NodeInfoLabels, Gauge>,
     node_geo: Family<NodeGeoLabels, Gauge>,
@@ -59,6 +60,7 @@ pub struct Metrics {
     file_descriptor_capacity: Gauge,
     http_inflight_requests: Gauge,
     public_http_inflight_requests: Gauge,
+    public_request_latency_ewma_ms: Gauge,
     grpc_inflight_requests: Gauge,
     segment_handles_cached: Gauge,
     segment_handle_cache_capacity: Gauge,
@@ -157,6 +159,7 @@ impl Metrics {
         let replication_apply_results = Family::<ReplicationApplyLabels, Counter>::default();
         let replication_bandwidth_configured_limit_bytes_per_second = Gauge::default();
         let replication_bandwidth_effective_limit_bytes_per_second = Gauge::default();
+        let replication_bandwidth_public_latency_target_ms = Gauge::default();
         let multipart_parts = Family::<MultipartLabels, Counter>::default();
         let node_info = Family::<NodeInfoLabels, Gauge>::default();
         let node_geo = Family::<NodeGeoLabels, Gauge>::default();
@@ -176,6 +179,7 @@ impl Metrics {
         let file_descriptor_capacity = Gauge::default();
         let http_inflight_requests = Gauge::default();
         let public_http_inflight_requests = Gauge::default();
+        let public_request_latency_ewma_ms = Gauge::default();
         let grpc_inflight_requests = Gauge::default();
         let segment_handles_cached = Gauge::default();
         let segment_handle_cache_capacity = Gauge::default();
@@ -339,6 +343,11 @@ impl Metrics {
             replication_bandwidth_effective_limit_bytes_per_second.clone(),
         );
         registry.register(
+            "kura_replication_bandwidth_public_latency_target_ms",
+            "Public request latency target in milliseconds used to adapt peer artifact body bandwidth",
+            replication_bandwidth_public_latency_target_ms.clone(),
+        );
+        registry.register(
             "kura_multipart_parts_total",
             "Multipart part uploads by result",
             multipart_parts.clone(),
@@ -402,6 +411,11 @@ impl Metrics {
             "kura_public_http_inflight_requests",
             "Public non-probe HTTP requests currently in flight",
             public_http_inflight_requests.clone(),
+        );
+        registry.register(
+            "kura_public_request_latency_ewma_ms",
+            "EWMA of completed public HTTP and gRPC request latency in milliseconds used by peer sync bandwidth adaptation",
+            public_request_latency_ewma_ms.clone(),
         );
         registry.register(
             "kura_grpc_inflight_requests",
@@ -711,6 +725,7 @@ impl Metrics {
             replication_apply_results,
             replication_bandwidth_configured_limit_bytes_per_second,
             replication_bandwidth_effective_limit_bytes_per_second,
+            replication_bandwidth_public_latency_target_ms,
             multipart_parts,
             node_info,
             node_geo,
@@ -724,6 +739,7 @@ impl Metrics {
             file_descriptor_capacity,
             http_inflight_requests,
             public_http_inflight_requests,
+            public_request_latency_ewma_ms,
             grpc_inflight_requests,
             segment_handles_cached,
             segment_handle_cache_capacity,
@@ -944,11 +960,14 @@ impl Metrics {
         &self,
         configured_bytes_per_second: u64,
         effective_bytes_per_second: u64,
+        public_latency_target_ms: u64,
     ) {
         self.replication_bandwidth_configured_limit_bytes_per_second
             .set(configured_bytes_per_second as i64);
         self.replication_bandwidth_effective_limit_bytes_per_second
             .set(effective_bytes_per_second as i64);
+        self.replication_bandwidth_public_latency_target_ms
+            .set(public_latency_target_ms as i64);
     }
 
     pub fn record_multipart_part(&self, result: &str) {
@@ -1015,6 +1034,11 @@ impl Metrics {
 
     pub fn update_public_http_inflight(&self, count: usize) {
         self.public_http_inflight_requests.set(count as i64);
+    }
+
+    pub fn update_public_request_latency_ewma(&self, duration: Duration) {
+        self.public_request_latency_ewma_ms
+            .set(duration.as_millis().min(i64::MAX as u128) as i64);
     }
 
     pub fn update_grpc_inflight(&self, count: usize) {
@@ -1612,13 +1636,14 @@ mod tests {
         );
         metrics.record_replication_apply("replication", "artifact", "applied");
         metrics.record_replication_apply("bootstrap", "namespace_delete", "ignored_older");
-        metrics.update_replication_bandwidth_limits(10_485_760, 5_242_880);
+        metrics.update_replication_bandwidth_limits(10_485_760, 5_242_880, 100);
         metrics.record_multipart_part("ok");
         metrics.record_file_descriptor_wait("ok", Duration::from_millis(1));
         metrics.record_file_operation("open_read", "ok", Duration::from_millis(2), 42);
         metrics.update_file_descriptor_pool(64, 3, 61, 1);
         metrics.update_http_inflight(2);
         metrics.update_public_http_inflight(1);
+        metrics.update_public_request_latency_ewma(Duration::from_millis(42));
         metrics.update_grpc_inflight(1);
         metrics.update_segment_handles_cached(2);
         metrics.update_segment_handle_cache_capacity(8);
@@ -1731,6 +1756,8 @@ mod tests {
         assert!(rendered.contains("kura_bootstrap_applied_items_total"));
         assert!(rendered.contains("kura_replication_bandwidth_configured_limit_bytes_per_second"));
         assert!(rendered.contains("kura_replication_bandwidth_effective_limit_bytes_per_second"));
+        assert!(rendered.contains("kura_replication_bandwidth_public_latency_target_ms"));
+        assert!(rendered.contains("kura_public_request_latency_ewma_ms"));
         assert!(rendered.contains("kura_analytics_events_total"));
         assert!(rendered.contains("kura_analytics_batches_total"));
         assert!(rendered.contains("kura_analytics_batch_duration_seconds"));

--- a/kura/src/reapi/mod.rs
+++ b/kura/src/reapi/mod.rs
@@ -1,4 +1,11 @@
-use std::{collections::BTreeMap, future::Future, pin::Pin, time::Duration};
+use std::{
+    collections::BTreeMap,
+    error::Error,
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+    time::Duration,
+};
 
 use bazel_remote_apis::{
     build::bazel::{
@@ -20,7 +27,9 @@ use bazel_remote_apis::{
         rpc::Status as RpcStatus,
     },
 };
-use futures_util::StreamExt;
+use bytes::Bytes;
+use futures_util::{StreamExt, future::BoxFuture};
+use http_body_util::{BodyExt, combinators::UnsyncBoxBody};
 use prost::Message;
 use sha2::{Digest as _, Sha256};
 use tokio::net::TcpListener;
@@ -28,8 +37,11 @@ use tokio_stream::wrappers::TcpListenerStream;
 use tokio_util::io::ReaderStream;
 use tonic::{
     Request, Response, Status,
+    body::Body as TonicBody,
+    codegen::{Body as HttpBody, Service, http},
     transport::{Identity, Server, ServerTlsConfig},
 };
+use tower::Layer;
 
 use crate::{
     artifact::{manifest::ArtifactManifest, producer::ArtifactProducer},
@@ -44,6 +56,8 @@ use crate::{
 const DEFAULT_INSTANCE_NAME: &str = "default";
 const REAPI_READ_STREAM_CHUNK_BYTES: usize = 256 * 1024;
 const REAPI_MATERIALIZATION_REJECTED_ACTION: &str = "reapi_materialization_rejected";
+type BoxError = Box<dyn Error + Send + Sync + 'static>;
+type GrpcAccountingBody = UnsyncBoxBody<Bytes, BoxError>;
 
 #[derive(Clone)]
 pub struct ReapiService {
@@ -65,7 +79,9 @@ where
     F: Future<Output = ()> + Send + 'static,
 {
     let tls = state.config.grpc_tls.clone();
-    let service = ReapiService { state };
+    let service = ReapiService {
+        state: state.clone(),
+    };
     let capabilities = CapabilitiesServer::new(service.clone()).max_decoding_message_size(64 << 20);
     let action_cache = ActionCacheServer::new(service.clone()).max_decoding_message_size(64 << 20);
     let cas =
@@ -74,7 +90,8 @@ where
 
     let mut builder = Server::builder()
         .max_connection_age(Duration::from_secs(300))
-        .max_connection_age_grace(Duration::from_secs(300));
+        .max_connection_age_grace(Duration::from_secs(300))
+        .layer(GrpcRequestAccountingLayer { state });
     if let Some(tls) = tls {
         builder = builder
             .tls_config(load_grpc_tls_config(&tls).await?)
@@ -89,6 +106,61 @@ where
         .serve_with_incoming_shutdown(TcpListenerStream::new(listener), shutdown)
         .await
         .map_err(|error| format!("gRPC server error: {error}"))
+}
+
+#[derive(Clone)]
+struct GrpcRequestAccountingLayer {
+    state: SharedState,
+}
+
+impl<S> Layer<S> for GrpcRequestAccountingLayer {
+    type Service = GrpcRequestAccountingService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        GrpcRequestAccountingService {
+            inner,
+            state: self.state.clone(),
+        }
+    }
+}
+
+#[derive(Clone)]
+struct GrpcRequestAccountingService<S> {
+    inner: S,
+    state: SharedState,
+}
+
+impl<S, ResBody> Service<http::Request<TonicBody>> for GrpcRequestAccountingService<S>
+where
+    S: Service<http::Request<TonicBody>, Response = http::Response<ResBody>> + Send + 'static,
+    S::Future: Send + 'static,
+    S::Error: Send + 'static,
+    ResBody: HttpBody<Data = Bytes> + Send + 'static,
+    ResBody::Error: Into<BoxError> + 'static,
+{
+    type Response = http::Response<GrpcAccountingBody>;
+    type Error = S::Error;
+    type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, request: http::Request<TonicBody>) -> Self::Future {
+        let guard = self.state.start_grpc_request();
+        let future = self.inner.call(request);
+        Box::pin(async move {
+            let response = future.await?;
+            Ok(response.map(|body| {
+                body.map_frame(move |frame| {
+                    let _guard = &guard;
+                    frame
+                })
+                .map_err(|error| -> BoxError { error.into() })
+                .boxed_unsync()
+            }))
+        })
+    }
 }
 
 async fn load_grpc_tls_config(tls: &GrpcTlsConfig) -> Result<ServerTlsConfig, String> {
@@ -166,7 +238,6 @@ impl Capabilities for ReapiService {
         &self,
         request: Request<reapi::GetCapabilitiesRequest>,
     ) -> Result<Response<reapi::ServerCapabilities>, Status> {
-        let _request_guard = self.state.start_grpc_request();
         let extension = GrpcExtensionSpec {
             route: "reapi.capabilities.get",
             operation: "capabilities.read",
@@ -220,7 +291,6 @@ impl ActionCache for ReapiService {
         &self,
         request: Request<reapi::GetActionResultRequest>,
     ) -> Result<Response<reapi::ActionResult>, Status> {
-        let _request_guard = self.state.start_grpc_request();
         require_sha256(request.get_ref().digest_function)?;
         let namespace_id = namespace_from_instance(&request.get_ref().instance_name);
         let digest = request
@@ -312,7 +382,6 @@ impl ActionCache for ReapiService {
         &self,
         request: Request<reapi::UpdateActionResultRequest>,
     ) -> Result<Response<reapi::ActionResult>, Status> {
-        let _request_guard = self.state.start_grpc_request();
         require_sha256(request.get_ref().digest_function)?;
         let namespace_id = namespace_from_instance(&request.get_ref().instance_name);
         let digest = request
@@ -370,7 +439,6 @@ impl ContentAddressableStorage for ReapiService {
         &self,
         request: Request<reapi::FindMissingBlobsRequest>,
     ) -> Result<Response<reapi::FindMissingBlobsResponse>, Status> {
-        let _request_guard = self.state.start_grpc_request();
         require_sha256(request.get_ref().digest_function)?;
         let namespace_id = namespace_from_instance(&request.get_ref().instance_name);
         let extension = GrpcExtensionSpec {
@@ -410,7 +478,6 @@ impl ContentAddressableStorage for ReapiService {
         &self,
         request: Request<reapi::BatchUpdateBlobsRequest>,
     ) -> Result<Response<reapi::BatchUpdateBlobsResponse>, Status> {
-        let _request_guard = self.state.start_grpc_request();
         require_sha256(request.get_ref().digest_function)?;
         let namespace_id = namespace_from_instance(&request.get_ref().instance_name);
         let extension = GrpcExtensionSpec {
@@ -464,7 +531,6 @@ impl ContentAddressableStorage for ReapiService {
         &self,
         request: Request<reapi::BatchReadBlobsRequest>,
     ) -> Result<Response<reapi::BatchReadBlobsResponse>, Status> {
-        let _request_guard = self.state.start_grpc_request();
         require_sha256(request.get_ref().digest_function)?;
         let namespace_id = namespace_from_instance(&request.get_ref().instance_name);
         let extension = GrpcExtensionSpec {
@@ -547,7 +613,6 @@ impl ByteStream for ReapiService {
         &self,
         request: Request<bytestream::ReadRequest>,
     ) -> Result<Response<Self::ReadStream>, Status> {
-        let request_guard = self.state.start_grpc_request();
         let resource = parse_read_resource_name(&request.get_ref().resource_name)?;
         let extension = GrpcExtensionSpec {
             route: "reapi.bytestream.read",
@@ -618,7 +683,6 @@ impl ByteStream for ReapiService {
             .record_artifact_read(ArtifactProducer::Reapi, "ok", bytes_to_read);
         let stream =
             ReaderStream::with_capacity(reader, REAPI_READ_STREAM_CHUNK_BYTES).map(move |result| {
-                let _keep_guard_alive = &request_guard;
                 match result {
                     Ok(bytes) => Ok(bytestream::ReadResponse {
                         data: bytes.to_vec(),
@@ -639,7 +703,6 @@ impl ByteStream for ReapiService {
         &self,
         request: Request<tonic::Streaming<bytestream::WriteRequest>>,
     ) -> Result<Response<bytestream::WriteResponse>, Status> {
-        let _request_guard = self.state.start_grpc_request();
         let extension = GrpcExtensionSpec {
             route: "reapi.bytestream.write",
             operation: "artifact.write",
@@ -778,7 +841,6 @@ impl ByteStream for ReapiService {
         &self,
         request: Request<bytestream::QueryWriteStatusRequest>,
     ) -> Result<Response<bytestream::QueryWriteStatusResponse>, Status> {
-        let _request_guard = self.state.start_grpc_request();
         let resource = parse_write_resource_name(&request.get_ref().resource_name)?;
         let extension = GrpcExtensionSpec {
             route: "reapi.bytestream.query_write_status",
@@ -1164,13 +1226,39 @@ fn parse_blob_resource_name(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::time::Duration;
+    use std::{convert::Infallible, time::Duration};
 
     use crate::{
         artifact::producer::ArtifactProducer,
         failpoints::{FailpointAction, FailpointName},
         test_support::test_context,
     };
+
+    #[tokio::test]
+    async fn grpc_request_accounting_layer_keeps_guard_until_response_body_drops() {
+        let context = test_context(|_| {}).await;
+        let layer = GrpcRequestAccountingLayer {
+            state: context.state.clone(),
+        };
+        let mut service = layer.layer(tower::service_fn(
+            |_request: http::Request<TonicBody>| async {
+                Ok::<_, Infallible>(http::Response::new(TonicBody::empty()))
+            },
+        ));
+
+        let response = service
+            .call(http::Request::new(TonicBody::empty()))
+            .await
+            .expect("accounting layer should pass through service response");
+
+        assert_eq!(context.state.runtime.grpc_inflight(), 1);
+        assert_eq!(context.state.runtime.public_inflight(), 1);
+
+        drop(response);
+
+        assert_eq!(context.state.runtime.grpc_inflight(), 0);
+        assert_eq!(context.state.runtime.public_inflight(), 0);
+    }
 
     #[test]
     fn parses_read_resource_names_with_and_without_instance_names() {

--- a/kura/src/replication/mod.rs
+++ b/kura/src/replication/mod.rs
@@ -414,6 +414,9 @@ async fn stream_response_to_temp(
                 "bootstrap artifact response exceeded limit of {MAX_REPLICATION_BODY_BYTES} bytes"
             ));
         }
+        if let Some(limiter) = state.replication_bandwidth_limiter.as_ref() {
+            limiter.acquire(chunk.len()).await;
+        }
         destination
             .write_all(&chunk)
             .await
@@ -633,7 +636,18 @@ async fn replicate_message(state: &SharedState, message: &OutboxMessage) -> Resu
                 url_encode(content_type),
                 version_ms,
             );
-            let body = reqwest::Body::wrap_stream(ReaderStream::new(file));
+            let bandwidth_limiter = state.replication_bandwidth_limiter.clone();
+            let body_stream = ReaderStream::new(file).then(move |item| {
+                let bandwidth_limiter = bandwidth_limiter.clone();
+                async move {
+                    if let (Some(limiter), Ok(chunk)) = (bandwidth_limiter.as_ref(), item.as_ref())
+                    {
+                        limiter.acquire(chunk.len()).await;
+                    }
+                    item
+                }
+            });
+            let body = reqwest::Body::wrap_stream(body_stream);
             let request_span = tracing::info_span!(
                 "replication.request",
                 otel.name = "PUT /_internal/replicate/artifact",

--- a/kura/src/runtime.rs
+++ b/kura/src/runtime.rs
@@ -4,8 +4,9 @@ use std::{
     path::Path,
     sync::{
         Arc,
-        atomic::{AtomicBool, AtomicUsize, Ordering},
+        atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering},
     },
+    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
 
 #[cfg(test)]
@@ -16,6 +17,9 @@ use tokio::sync::{Notify, futures::Notified};
 use crate::metrics::Metrics;
 
 const DATA_DIR_LOCK_FILE: &str = ".kura.writer.lock";
+const PUBLIC_REQUEST_LATENCY_EWMA_DENOMINATOR: u64 = 8;
+const PUBLIC_REQUEST_LATENCY_STALE_MS: u64 = 30_000;
+const MAX_PUBLIC_LATENCY_PRESSURE_DIVISOR: usize = 64;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum TrafficState {
@@ -49,6 +53,8 @@ pub struct RuntimeState {
     http_inflight: AtomicUsize,
     public_http_inflight: AtomicUsize,
     grpc_inflight: AtomicUsize,
+    public_request_latency_ewma_micros: AtomicU64,
+    public_request_latency_sampled_at_ms: AtomicU64,
     outbox_depth: AtomicUsize,
     inflight_changed: Notify,
 }
@@ -62,6 +68,8 @@ impl RuntimeState {
             http_inflight: AtomicUsize::new(0),
             public_http_inflight: AtomicUsize::new(0),
             grpc_inflight: AtomicUsize::new(0),
+            public_request_latency_ewma_micros: AtomicU64::new(0),
+            public_request_latency_sampled_at_ms: AtomicU64::new(0),
             outbox_depth: AtomicUsize::new(0),
             inflight_changed: Notify::new(),
         })
@@ -125,6 +133,44 @@ impl RuntimeState {
         self.public_http_inflight() + self.grpc_inflight()
     }
 
+    #[cfg(test)]
+    pub fn public_request_latency_ewma(&self) -> Option<Duration> {
+        let micros = self
+            .public_request_latency_ewma_micros
+            .load(Ordering::SeqCst);
+        if micros == 0 {
+            None
+        } else {
+            Some(Duration::from_micros(micros))
+        }
+    }
+
+    pub fn public_latency_pressure_divisor(&self, target_ms: u64) -> usize {
+        if target_ms == 0 {
+            return 1;
+        }
+
+        let ewma_micros = self
+            .public_request_latency_ewma_micros
+            .load(Ordering::SeqCst);
+        if ewma_micros == 0 {
+            return 1;
+        }
+
+        let sampled_at_ms = self
+            .public_request_latency_sampled_at_ms
+            .load(Ordering::SeqCst);
+        if sampled_at_ms == 0
+            || now_ms().saturating_sub(sampled_at_ms) > PUBLIC_REQUEST_LATENCY_STALE_MS
+        {
+            return 1;
+        }
+
+        let target_micros = target_ms.saturating_mul(1_000).max(1);
+        let divisor = ewma_micros.div_ceil(target_micros).max(1) as usize;
+        divisor.min(MAX_PUBLIC_LATENCY_PRESSURE_DIVISOR)
+    }
+
     pub fn total_inflight(&self) -> usize {
         self.http_inflight() + self.grpc_inflight()
     }
@@ -160,6 +206,39 @@ impl RuntimeState {
         self.inflight_changed.notify_waiters();
         InflightGuard::new(self.clone(), metrics.clone(), InflightKind::Grpc)
     }
+
+    fn record_public_request_latency(&self, metrics: &Metrics, duration: Duration) {
+        let sample_micros = duration.as_micros().min(u64::MAX as u128) as u64;
+        if sample_micros == 0 {
+            return;
+        }
+
+        let mut current = self
+            .public_request_latency_ewma_micros
+            .load(Ordering::SeqCst);
+        loop {
+            let next = if current == 0 {
+                sample_micros
+            } else {
+                ((current * (PUBLIC_REQUEST_LATENCY_EWMA_DENOMINATOR - 1)) + sample_micros)
+                    / PUBLIC_REQUEST_LATENCY_EWMA_DENOMINATOR
+            };
+            match self.public_request_latency_ewma_micros.compare_exchange(
+                current,
+                next,
+                Ordering::SeqCst,
+                Ordering::SeqCst,
+            ) {
+                Ok(_) => {
+                    self.public_request_latency_sampled_at_ms
+                        .store(now_ms(), Ordering::SeqCst);
+                    metrics.update_public_request_latency_ewma(Duration::from_micros(next));
+                    break;
+                }
+                Err(actual) => current = actual,
+            }
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -184,6 +263,7 @@ pub struct InflightGuard {
     runtime: Arc<RuntimeState>,
     metrics: Metrics,
     kind: InflightKind,
+    started_at: Instant,
     active: bool,
 }
 
@@ -193,6 +273,7 @@ impl InflightGuard {
             runtime,
             metrics,
             kind,
+            started_at: Instant::now(),
             active: true,
         }
     }
@@ -204,6 +285,10 @@ impl Drop for InflightGuard {
             return;
         }
         self.active = false;
+        let public_load = matches!(
+            self.kind,
+            InflightKind::Http { public_load: true } | InflightKind::Grpc
+        );
         match self.kind {
             InflightKind::Http { public_load } => {
                 let previous = self.runtime.http_inflight.fetch_sub(1, Ordering::SeqCst);
@@ -224,8 +309,19 @@ impl Drop for InflightGuard {
                     .update_grpc_inflight(previous.saturating_sub(1));
             }
         }
+        if public_load {
+            self.runtime
+                .record_public_request_latency(&self.metrics, self.started_at.elapsed());
+        }
         self.runtime.inflight_changed.notify_waiters();
     }
+}
+
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_else(|_| Duration::from_secs(0))
+        .as_millis() as u64
 }
 
 pub struct DataDirLock {
@@ -359,5 +455,22 @@ mod tests {
         drop(background);
         assert_eq!(runtime.http_inflight(), 0);
         assert_eq!(runtime.public_http_inflight(), 0);
+    }
+
+    #[test]
+    fn public_latency_pressure_divisor_tracks_recent_request_latency() {
+        let runtime = RuntimeState::new();
+        let metrics = Metrics::new("region".into(), "tenant".into());
+
+        assert_eq!(runtime.public_latency_pressure_divisor(100), 1);
+
+        runtime.record_public_request_latency(&metrics, Duration::from_millis(250));
+
+        assert_eq!(
+            runtime.public_request_latency_ewma(),
+            Some(Duration::from_millis(250))
+        );
+        assert_eq!(runtime.public_latency_pressure_divisor(100), 3);
+        assert_eq!(runtime.public_latency_pressure_divisor(0), 1);
     }
 }

--- a/kura/src/runtime.rs
+++ b/kura/src/runtime.rs
@@ -47,6 +47,7 @@ pub struct RuntimeState {
     serving: AtomicBool,
     writer_lock_owned: AtomicBool,
     http_inflight: AtomicUsize,
+    public_http_inflight: AtomicUsize,
     grpc_inflight: AtomicUsize,
     outbox_depth: AtomicUsize,
     inflight_changed: Notify,
@@ -59,6 +60,7 @@ impl RuntimeState {
             serving: AtomicBool::new(false),
             writer_lock_owned: AtomicBool::new(true),
             http_inflight: AtomicUsize::new(0),
+            public_http_inflight: AtomicUsize::new(0),
             grpc_inflight: AtomicUsize::new(0),
             outbox_depth: AtomicUsize::new(0),
             inflight_changed: Notify::new(),
@@ -111,8 +113,16 @@ impl RuntimeState {
         self.http_inflight.load(Ordering::SeqCst)
     }
 
+    pub fn public_http_inflight(&self) -> usize {
+        self.public_http_inflight.load(Ordering::SeqCst)
+    }
+
     pub fn grpc_inflight(&self) -> usize {
         self.grpc_inflight.load(Ordering::SeqCst)
+    }
+
+    pub fn public_inflight(&self) -> usize {
+        self.public_http_inflight() + self.grpc_inflight()
     }
 
     pub fn total_inflight(&self) -> usize {
@@ -123,11 +133,25 @@ impl RuntimeState {
         self.inflight_changed.notified()
     }
 
-    pub fn start_http_request(self: &Arc<Self>, metrics: &Metrics) -> InflightGuard {
+    pub fn start_http_request(
+        self: &Arc<Self>,
+        metrics: &Metrics,
+        traffic_class: HttpTrafficClass,
+    ) -> InflightGuard {
         let count = self.http_inflight.fetch_add(1, Ordering::SeqCst) + 1;
         metrics.update_http_inflight(count);
+        if traffic_class.contributes_to_public_load() {
+            let count = self.public_http_inflight.fetch_add(1, Ordering::SeqCst) + 1;
+            metrics.update_public_http_inflight(count);
+        }
         self.inflight_changed.notify_waiters();
-        InflightGuard::new(self.clone(), metrics.clone(), InflightKind::Http)
+        InflightGuard::new(
+            self.clone(),
+            metrics.clone(),
+            InflightKind::Http {
+                public_load: traffic_class.contributes_to_public_load(),
+            },
+        )
     }
 
     pub fn start_grpc_request(self: &Arc<Self>, metrics: &Metrics) -> InflightGuard {
@@ -138,9 +162,21 @@ impl RuntimeState {
     }
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum HttpTrafficClass {
+    Public,
+    Background,
+}
+
+impl HttpTrafficClass {
+    fn contributes_to_public_load(self) -> bool {
+        matches!(self, Self::Public)
+    }
+}
+
 #[derive(Clone, Copy)]
 enum InflightKind {
-    Http,
+    Http { public_load: bool },
     Grpc,
 }
 
@@ -169,10 +205,18 @@ impl Drop for InflightGuard {
         }
         self.active = false;
         match self.kind {
-            InflightKind::Http => {
+            InflightKind::Http { public_load } => {
                 let previous = self.runtime.http_inflight.fetch_sub(1, Ordering::SeqCst);
                 self.metrics
                     .update_http_inflight(previous.saturating_sub(1));
+                if public_load {
+                    let previous = self
+                        .runtime
+                        .public_http_inflight
+                        .fetch_sub(1, Ordering::SeqCst);
+                    self.metrics
+                        .update_public_http_inflight(previous.saturating_sub(1));
+                }
             }
             InflightKind::Grpc => {
                 let previous = self.runtime.grpc_inflight.fetch_sub(1, Ordering::SeqCst);
@@ -284,7 +328,7 @@ mod tests {
     async fn inflight_change_notification_resolves_on_request_completion() {
         let runtime = RuntimeState::new();
         let metrics = Metrics::new("region".into(), "tenant".into());
-        let guard = runtime.start_http_request(&metrics);
+        let guard = runtime.start_http_request(&metrics, HttpTrafficClass::Public);
 
         let notified = runtime.inflight_changed();
         drop(guard);
@@ -292,5 +336,28 @@ mod tests {
         timeout(Duration::from_secs(1), notified)
             .await
             .expect("request completion should wake inflight waiters");
+    }
+
+    #[test]
+    fn public_http_inflight_excludes_background_http_requests() {
+        let runtime = RuntimeState::new();
+        let metrics = Metrics::new("region".into(), "tenant".into());
+
+        let background = runtime.start_http_request(&metrics, HttpTrafficClass::Background);
+        assert_eq!(runtime.http_inflight(), 1);
+        assert_eq!(runtime.public_http_inflight(), 0);
+
+        let public = runtime.start_http_request(&metrics, HttpTrafficClass::Public);
+        assert_eq!(runtime.http_inflight(), 2);
+        assert_eq!(runtime.public_http_inflight(), 1);
+        assert_eq!(runtime.public_inflight(), 1);
+
+        drop(public);
+        assert_eq!(runtime.http_inflight(), 1);
+        assert_eq!(runtime.public_http_inflight(), 0);
+
+        drop(background);
+        assert_eq!(runtime.http_inflight(), 0);
+        assert_eq!(runtime.public_http_inflight(), 0);
     }
 }

--- a/kura/src/state.rs
+++ b/kura/src/state.rs
@@ -11,13 +11,14 @@ use tokio::{
 
 use crate::{
     analytics::Analytics,
+    bandwidth::BandwidthLimiter,
     config::Config,
     extension::SharedExtension,
     geoip::GeoIp,
     io::IoController,
     memory::MemoryController,
     metrics::Metrics,
-    runtime::{DataDirLock, InflightGuard, RuntimeState, TrafficState},
+    runtime::{DataDirLock, HttpTrafficClass, InflightGuard, RuntimeState, TrafficState},
     store::Store,
     usage::Usage,
 };
@@ -37,6 +38,7 @@ pub struct AppState {
     pub usage: Option<Usage>,
     pub geoip: Option<GeoIp>,
     pub client: Client,
+    pub replication_bandwidth_limiter: Option<Arc<BandwidthLimiter>>,
     pub notify: Notify,
     pub readiness: Mutex<ReadinessState>,
     pub bootstrap_semaphore: Arc<Semaphore>,
@@ -227,8 +229,9 @@ impl ReadinessState {
 }
 
 impl AppState {
-    pub fn start_http_request(&self) -> InflightGuard {
-        self.runtime.start_http_request(&self.metrics)
+    pub fn start_http_request(&self, traffic_class: HttpTrafficClass) -> InflightGuard {
+        self.runtime
+            .start_http_request(&self.metrics, traffic_class)
     }
 
     pub fn start_grpc_request(&self) -> InflightGuard {
@@ -439,6 +442,12 @@ impl AppState {
             report.known_peers.len(),
             report.bootstrapped_peers.len(),
             report.bootstrap_inflight_peers.len(),
+        );
+        self.metrics.update_replication_bandwidth_limits(
+            self.config.replication_bandwidth_limit_bytes_per_second,
+            self.replication_bandwidth_limiter
+                .as_ref()
+                .map_or(0, |limiter| limiter.effective_bytes_per_second()),
         );
     }
 }

--- a/kura/src/state.rs
+++ b/kura/src/state.rs
@@ -448,6 +448,7 @@ impl AppState {
             self.replication_bandwidth_limiter
                 .as_ref()
                 .map_or(0, |limiter| limiter.effective_bytes_per_second()),
+            self.config.replication_public_latency_target_ms,
         );
     }
 }

--- a/kura/src/store.rs
+++ b/kura/src/store.rs
@@ -2712,6 +2712,7 @@ mod tests {
             rocksdb_write_buffer_size_bytes: 8 * 1024 * 1024,
             rocksdb_max_write_buffer_number: 4,
             outbox_max_depth: 100_000,
+            replication_bandwidth_limit_bytes_per_second: 0,
             multipart_upload_ttl_ms: 24 * 60 * 60 * 1000,
             multipart_janitor_interval_ms: 10 * 60 * 1000,
             bootstrap_timeout_ms: 30 * 60 * 1000,

--- a/kura/src/store.rs
+++ b/kura/src/store.rs
@@ -2713,6 +2713,7 @@ mod tests {
             rocksdb_max_write_buffer_number: 4,
             outbox_max_depth: 100_000,
             replication_bandwidth_limit_bytes_per_second: 0,
+            replication_public_latency_target_ms: 100,
             multipart_upload_ttl_ms: 24 * 60 * 60 * 1000,
             multipart_janitor_interval_ms: 10 * 60 * 1000,
             bootstrap_timeout_ms: 30 * 60 * 1000,

--- a/kura/src/test_support.rs
+++ b/kura/src/test_support.rs
@@ -9,6 +9,7 @@ use tokio::time::Instant;
 
 use crate::{
     analytics::Analytics,
+    bandwidth::BandwidthLimiter,
     config::Config,
     extension::SharedExtension,
     io::IoController,
@@ -70,6 +71,7 @@ where
         rocksdb_write_buffer_size_bytes: 8 * 1024 * 1024,
         rocksdb_max_write_buffer_number: 4,
         outbox_max_depth: 100_000,
+        replication_bandwidth_limit_bytes_per_second: 0,
         multipart_upload_ttl_ms: 24 * 60 * 60 * 1000,
         multipart_janitor_interval_ms: 10 * 60 * 1000,
         bootstrap_timeout_ms: 30 * 60 * 1000,
@@ -116,6 +118,12 @@ where
         .timeout(Duration::from_secs(5))
         .build()
         .expect("failed to build test client");
+    let runtime = RuntimeState::new();
+    let replication_bandwidth_limiter = BandwidthLimiter::new(
+        config.replication_bandwidth_limit_bytes_per_second,
+        runtime.clone(),
+    )
+    .map(Arc::new);
     let bootstrap_semaphore = Arc::new(Semaphore::new(config.bootstrap_max_concurrent_peers));
     let state = Arc::new(AppState {
         config,
@@ -124,12 +132,13 @@ where
         io,
         memory,
         metrics,
-        runtime: RuntimeState::new(),
+        runtime,
         extension,
         analytics,
         usage,
         geoip: None,
         client,
+        replication_bandwidth_limiter,
         notify: Notify::new(),
         readiness: tokio::sync::Mutex::new(ReadinessState::new(Instant::now())),
         bootstrap_semaphore,

--- a/kura/src/test_support.rs
+++ b/kura/src/test_support.rs
@@ -72,6 +72,7 @@ where
         rocksdb_max_write_buffer_number: 4,
         outbox_max_depth: 100_000,
         replication_bandwidth_limit_bytes_per_second: 0,
+        replication_public_latency_target_ms: 100,
         multipart_upload_ttl_ms: 24 * 60 * 60 * 1000,
         multipart_janitor_interval_ms: 10 * 60 * 1000,
         bootstrap_timeout_ms: 30 * 60 * 1000,
@@ -121,6 +122,7 @@ where
     let runtime = RuntimeState::new();
     let replication_bandwidth_limiter = BandwidthLimiter::new(
         config.replication_bandwidth_limit_bytes_per_second,
+        config.replication_public_latency_target_ms,
         runtime.clone(),
     )
     .map(Arc::new);

--- a/kura/src/utils.rs
+++ b/kura/src/utils.rs
@@ -1,5 +1,6 @@
 use std::{
     path::{Path, PathBuf},
+    sync::Arc,
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
@@ -9,7 +10,7 @@ use sha2::{Digest, Sha256};
 use tokio::io::AsyncWriteExt;
 use uuid::Uuid;
 
-use crate::{artifact::producer::ArtifactProducer, io::IoController};
+use crate::{artifact::producer::ArtifactProducer, bandwidth::BandwidthLimiter, io::IoController};
 
 #[derive(Debug)]
 pub struct TempBodyFile {
@@ -28,6 +29,7 @@ pub async fn read_request_to_temp(
     directory: &Path,
     max_bytes: u64,
     io: &IoController,
+    bandwidth_limiter: Option<Arc<BandwidthLimiter>>,
 ) -> Result<TempBodyFile, BodyReadError> {
     let temp_path = temp_file_path(directory, "upload");
     if let Some(parent) = temp_path.parent() {
@@ -57,6 +59,9 @@ pub async fn read_request_to_temp(
             drop(file);
             io.remove_file_if_exists(&temp_path).await;
             return Err(BodyReadError::TooLarge);
+        }
+        if let Some(limiter) = bandwidth_limiter.as_ref() {
+            limiter.acquire(chunk.len()).await;
         }
 
         if let Err(error) = file.write_all(&chunk).await {
@@ -273,7 +278,7 @@ mod tests {
             .body(Body::from("hello"))
             .expect("failed to build request");
 
-        let temp = read_request_to_temp(request, directory.path(), 10, &io)
+        let temp = read_request_to_temp(request, directory.path(), 10, &io, None)
             .await
             .expect("failed to read request to temp");
 
@@ -298,7 +303,7 @@ mod tests {
             .body(Body::from("hello"))
             .expect("failed to build request");
 
-        let error = read_request_to_temp(request, directory.path(), 4, &io)
+        let error = read_request_to_temp(request, directory.path(), 4, &io, None)
             .await
             .expect_err("expected body reader to reject oversized request");
 


### PR DESCRIPTION
Resolves no linked issue.

Adds adaptive Kura peer artifact bandwidth shaping so background replication does not consume the same network budget as public cache traffic.

- Introduces `KURA_REPLICATION_BANDWIDTH_LIMIT_BYTES_PER_SECOND` as an opt-in per-node ceiling for peer artifact body transfers.
- Applies the limiter to live replication uploads, replication ingests, and bootstrap artifact body transfers while leaving public cache reads unconstrained.
- Makes the limiter dynamic by dividing the configured ceiling by the larger of `public_inflight + 1` and recent public request latency pressure, using `KURA_REPLICATION_PUBLIC_LATENCY_TARGET_MS` as the target.
- Centralizes gRPC request accounting in a tonic server layer so every routed gRPC call contributes to public load for its full response-body lifetime, including streaming responses.
- Exposes public-load, configured/effective bandwidth, latency target, and public latency EWMA metrics, with Helm and documentation wiring.

### How to test locally

- `mise exec -- cargo test --lib`
- `mise exec -- cargo clippy --all-targets -- -D warnings`
- `helm template kura kura/ops/helm/kura`
