### PR TITLE
fix(cli): HAR recording shutdown crash

### DIFF
--- a/Tuist/ProjectDescriptionHelpers/Module.swift
+++ b/Tuist/ProjectDescriptionHelpers/Module.swift
@@ -1630,6 +1630,8 @@ public enum Module: String, CaseIterable {
                     .target(name: Module.testing.targetName),
                     .external(name: "FileSystem"),
                     .external(name: "FileSystemTesting"),
+                    .external(name: "HTTPTypes"),
+                    .external(name: "OpenAPIRuntime"),
                 ]
             case .tuistFixtureGenerator:
                 [

--- a/cli/Sources/TuistHAR/HARRecorder.swift
+++ b/cli/Sources/TuistHAR/HARRecorder.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Path
+import Synchronization
 import TuistConstants
 import TuistLogging
 
@@ -22,27 +23,20 @@ public actor HARRecorder { // swiftlint:disable:this type_body_length
         "x-amz-credential",
     ]
 
-    private final class State: @unchecked Sendable {
-        private let lock = NSLock()
-        private var finished = false
+    private nonisolated let finishedState = Mutex(false)
 
-        var isFinished: Bool {
-            lock.lock()
-            defer { lock.unlock() }
-            return finished
-        }
+    private nonisolated var isFinished: Bool {
+        finishedState.withLock { $0 }
+    }
 
-        func markFinished() -> Bool {
-            lock.lock()
-            defer { lock.unlock() }
-
-            guard !finished else { return false }
-            finished = true
+    private nonisolated func markFinished() -> Bool {
+        finishedState.withLock { isFinished in
+            guard !isFinished else { return false }
+            isFinished = true
             return true
         }
     }
 
-    private nonisolated let state = State()
     private var log: HAR.Log
     private let filePath: AbsolutePath?
 
@@ -79,10 +73,14 @@ public actor HARRecorder { // swiftlint:disable:this type_body_length
         current?.recordDetached(action)
     }
 
+    public static func finishCurrent() async {
+        await current?.finish()
+    }
+
     public nonisolated func recordDetached(_ action: @escaping @Sendable (HARRecorder) async -> Void) {
-        guard !state.isFinished else { return }
+        guard !isFinished else { return }
         Task.detached(priority: .background) {
-            guard !self.state.isFinished else { return }
+            guard !self.isFinished else { return }
             await action(self)
         }
     }
@@ -90,13 +88,13 @@ public actor HARRecorder { // swiftlint:disable:this type_body_length
     /// Records a new entry to the HAR log.
     /// - Parameter entry: The entry to record.
     public func record(_ entry: HAR.Entry) {
-        guard !state.isFinished else { return }
+        guard !isFinished else { return }
         log.entries.append(entry)
     }
 
     /// Stops accepting new HAR entries and persists the entries recorded so far.
     public nonisolated func finish() async {
-        guard state.markFinished() else { return }
+        guard markFinished() else { return }
         await persist()
     }
 
@@ -118,7 +116,7 @@ public actor HARRecorder { // swiftlint:disable:this type_body_length
         responseHeadersSize: Int? = nil,
         requestBodySize: Int? = nil
     ) {
-        guard !state.isFinished else { return }
+        guard !isFinished else { return }
         let entry = buildEntry(
             url: url,
             method: method,
@@ -187,7 +185,7 @@ public actor HARRecorder { // swiftlint:disable:this type_body_length
         requestHeadersSize: Int? = nil,
         requestBodySize: Int? = nil
     ) {
-        guard !state.isFinished else { return }
+        guard !isFinished else { return }
         let entry = buildErrorEntry(
             url: url,
             method: method,

--- a/cli/Sources/TuistHAR/HARRecorder.swift
+++ b/cli/Sources/TuistHAR/HARRecorder.swift
@@ -22,9 +22,29 @@ public actor HARRecorder { // swiftlint:disable:this type_body_length
         "x-amz-credential",
     ]
 
+    private final class State: @unchecked Sendable {
+        private let lock = NSLock()
+        private var finished = false
+
+        var isFinished: Bool {
+            lock.lock()
+            defer { lock.unlock() }
+            return finished
+        }
+
+        func markFinished() -> Bool {
+            lock.lock()
+            defer { lock.unlock() }
+
+            guard !finished else { return false }
+            finished = true
+            return true
+        }
+    }
+
+    private nonisolated let state = State()
     private var log: HAR.Log
     private let filePath: AbsolutePath?
-    private var isFinished = false
 
     /// Creates a new HAR recorder.
     /// - Parameters:
@@ -60,7 +80,9 @@ public actor HARRecorder { // swiftlint:disable:this type_body_length
     }
 
     public nonisolated func recordDetached(_ action: @escaping @Sendable (HARRecorder) async -> Void) {
+        guard !state.isFinished else { return }
         Task.detached(priority: .background) {
+            guard !self.state.isFinished else { return }
             await action(self)
         }
     }
@@ -68,15 +90,14 @@ public actor HARRecorder { // swiftlint:disable:this type_body_length
     /// Records a new entry to the HAR log.
     /// - Parameter entry: The entry to record.
     public func record(_ entry: HAR.Entry) {
-        guard !isFinished else { return }
+        guard !state.isFinished else { return }
         log.entries.append(entry)
     }
 
     /// Stops accepting new HAR entries and persists the entries recorded so far.
-    public func finish() {
-        guard !isFinished else { return }
-        isFinished = true
-        persist()
+    public nonisolated func finish() async {
+        guard state.markFinished() else { return }
+        await persist()
     }
 
     /// Records an HTTP request and response.
@@ -97,7 +118,7 @@ public actor HARRecorder { // swiftlint:disable:this type_body_length
         responseHeadersSize: Int? = nil,
         requestBodySize: Int? = nil
     ) {
-        guard !isFinished else { return }
+        guard !state.isFinished else { return }
         let entry = buildEntry(
             url: url,
             method: method,
@@ -166,7 +187,7 @@ public actor HARRecorder { // swiftlint:disable:this type_body_length
         requestHeadersSize: Int? = nil,
         requestBodySize: Int? = nil
     ) {
-        guard !isFinished else { return }
+        guard !state.isFinished else { return }
         let entry = buildErrorEntry(
             url: url,
             method: method,

--- a/cli/Sources/TuistHAR/HARRecorder.swift
+++ b/cli/Sources/TuistHAR/HARRecorder.swift
@@ -42,15 +42,39 @@ public actor HARRecorder { // swiftlint:disable:this type_body_length
         )
     }
 
+    public static func withCurrent<T>(_ recorder: HARRecorder?, _ action: () async throws -> T) async throws -> T {
+        try await $current.withValue(recorder) {
+            do {
+                let result = try await action()
+                await recorder?.finish()
+                return result
+            } catch {
+                await recorder?.finish()
+                throw error
+            }
+        }
+    }
+
+    public static func recordDetached(_ action: @escaping @Sendable (HARRecorder) async -> Void) {
+        current?.recordDetached(action)
+    }
+
+    public nonisolated func recordDetached(_ action: @escaping @Sendable (HARRecorder) async -> Void) {
+        Task.detached(priority: .background) {
+            await action(self)
+        }
+    }
+
     /// Records a new entry to the HAR log.
     /// - Parameter entry: The entry to record.
-    public func record(_ entry: HAR.Entry) async {
+    public func record(_ entry: HAR.Entry) {
         guard !isFinished else { return }
         log.entries.append(entry)
     }
 
     /// Stops accepting new HAR entries and persists the entries recorded so far.
-    public func finish() async {
+    public func finish() {
+        guard !isFinished else { return }
         isFinished = true
         persist()
     }
@@ -72,7 +96,7 @@ public actor HARRecorder { // swiftlint:disable:this type_body_length
         requestHeadersSize: Int? = nil,
         responseHeadersSize: Int? = nil,
         requestBodySize: Int? = nil
-    ) async {
+    ) {
         guard !isFinished else { return }
         let entry = buildEntry(
             url: url,
@@ -91,7 +115,7 @@ public actor HARRecorder { // swiftlint:disable:this type_body_length
             responseHeadersSize: responseHeadersSize,
             requestBodySize: requestBodySize
         )
-        await record(entry)
+        record(entry)
     }
 
     /// Records an HTTP request and response from URLRequest/HTTPURLResponse.
@@ -107,9 +131,9 @@ public actor HARRecorder { // swiftlint:disable:this type_body_length
         requestHeadersSize: Int? = nil,
         responseHeadersSize: Int? = nil,
         requestBodySize: Int? = nil
-    ) async {
+    ) {
         guard let url = request.url else { return }
-        await recordRequest(
+        recordRequest(
             url: url,
             method: request.httpMethod ?? "GET",
             requestHeaders: Self.headers(from: request),
@@ -141,7 +165,7 @@ public actor HARRecorder { // swiftlint:disable:this type_body_length
         httpVersion: String? = nil,
         requestHeadersSize: Int? = nil,
         requestBodySize: Int? = nil
-    ) async {
+    ) {
         guard !isFinished else { return }
         let entry = buildErrorEntry(
             url: url,
@@ -156,7 +180,7 @@ public actor HARRecorder { // swiftlint:disable:this type_body_length
             requestHeadersSize: requestHeadersSize,
             requestBodySize: requestBodySize
         )
-        await record(entry)
+        record(entry)
     }
 
     /// Records a failed HTTP request from URLRequest.
@@ -170,9 +194,9 @@ public actor HARRecorder { // swiftlint:disable:this type_body_length
         httpVersion: String? = nil,
         requestHeadersSize: Int? = nil,
         requestBodySize: Int? = nil
-    ) async {
+    ) {
         guard let url = request.url else { return }
-        await recordError(
+        recordError(
             url: url,
             method: request.httpMethod ?? "GET",
             requestHeaders: Self.headers(from: request),

--- a/cli/Sources/TuistHAR/HARRecorder.swift
+++ b/cli/Sources/TuistHAR/HARRecorder.swift
@@ -24,6 +24,7 @@ public actor HARRecorder { // swiftlint:disable:this type_body_length
 
     private var log: HAR.Log
     private let filePath: AbsolutePath?
+    private var isFinished = false
 
     /// Creates a new HAR recorder.
     /// - Parameters:
@@ -44,8 +45,14 @@ public actor HARRecorder { // swiftlint:disable:this type_body_length
     /// Records a new entry to the HAR log.
     /// - Parameter entry: The entry to record.
     public func record(_ entry: HAR.Entry) async {
+        guard !isFinished else { return }
         log.entries.append(entry)
-        await persist()
+    }
+
+    /// Stops accepting new HAR entries and persists the entries recorded so far.
+    public func finish() async {
+        isFinished = true
+        persist()
     }
 
     /// Records an HTTP request and response.
@@ -66,6 +73,7 @@ public actor HARRecorder { // swiftlint:disable:this type_body_length
         responseHeadersSize: Int? = nil,
         requestBodySize: Int? = nil
     ) async {
+        guard !isFinished else { return }
         let entry = buildEntry(
             url: url,
             method: method,
@@ -134,6 +142,7 @@ public actor HARRecorder { // swiftlint:disable:this type_body_length
         requestHeadersSize: Int? = nil,
         requestBodySize: Int? = nil
     ) async {
+        guard !isFinished else { return }
         let entry = buildErrorEntry(
             url: url,
             method: method,
@@ -201,8 +210,8 @@ public actor HARRecorder { // swiftlint:disable:this type_body_length
     }
 
     /// Persists the current HAR log to disk if a file path was provided.
-    private func persist() async {
-        guard let filePath else { return }
+    private func persist() {
+        guard let filePath, !log.entries.isEmpty else { return }
         do {
             let data = try HAR.encode(log)
             try data.write(to: URL(fileURLWithPath: filePath.pathString), options: .atomic)

--- a/cli/Sources/TuistHAR/HARRecordingMiddleware.swift
+++ b/cli/Sources/TuistHAR/HARRecordingMiddleware.swift
@@ -32,7 +32,7 @@ public struct HARRecordingMiddleware: ClientMiddleware {
                 contentType: responseContentType
             )
 
-            Task.detached(priority: .background) {
+            recorder.recordDetached { recorder in
                 let fullURL = Self.buildURL(baseURL: baseURL, path: request.path)
                 let harMetadata = await Self.retrieveHARMetadata(for: fullURL)
 
@@ -56,7 +56,7 @@ public struct HARRecordingMiddleware: ClientMiddleware {
 
             return (response, responseBodyForNext)
         } catch {
-            Task.detached(priority: .background) {
+            recorder.recordDetached { recorder in
                 let fullURL = Self.buildURL(baseURL: baseURL, path: request.path)
                 let harMetadata = await Self.retrieveHARMetadata(for: fullURL)
 

--- a/cli/Sources/TuistHAR/HARRecordingMiddleware.swift
+++ b/cli/Sources/TuistHAR/HARRecordingMiddleware.swift
@@ -32,47 +32,43 @@ public struct HARRecordingMiddleware: ClientMiddleware {
                 contentType: responseContentType
             )
 
-            Task.detached(priority: .background) {
-                let fullURL = Self.buildURL(baseURL: baseURL, path: request.path)
-                let harMetadata = await Self.retrieveHARMetadata(for: fullURL)
+            let fullURL = Self.buildURL(baseURL: baseURL, path: request.path)
+            let harMetadata = await Self.retrieveHARMetadata(for: fullURL)
 
-                await recorder.recordRequest(
-                    url: fullURL,
-                    method: request.method.rawValue,
-                    requestHeaders: request.headerFields.map { HAR.Header(name: $0.name.rawName, value: $0.value) },
-                    requestBody: requestBodyData,
-                    responseStatusCode: response.status.code,
-                    responseStatusText: response.status.reasonPhrase ?? "",
-                    responseHeaders: response.headerFields.map { HAR.Header(name: $0.name.rawName, value: $0.value) },
-                    responseBody: responseBodyData,
-                    startTime: harMetadata.startTime,
-                    endTime: harMetadata.endTime,
-                    timings: harMetadata.timings,
-                    httpVersion: harMetadata.httpVersion,
-                    requestHeadersSize: harMetadata.requestHeadersSize,
-                    responseHeadersSize: harMetadata.responseHeadersSize
-                )
-            }
+            await recorder.recordRequest(
+                url: fullURL,
+                method: request.method.rawValue,
+                requestHeaders: request.headerFields.map { HAR.Header(name: $0.name.rawName, value: $0.value) },
+                requestBody: requestBodyData,
+                responseStatusCode: response.status.code,
+                responseStatusText: response.status.reasonPhrase ?? "",
+                responseHeaders: response.headerFields.map { HAR.Header(name: $0.name.rawName, value: $0.value) },
+                responseBody: responseBodyData,
+                startTime: harMetadata.startTime,
+                endTime: harMetadata.endTime,
+                timings: harMetadata.timings,
+                httpVersion: harMetadata.httpVersion,
+                requestHeadersSize: harMetadata.requestHeadersSize,
+                responseHeadersSize: harMetadata.responseHeadersSize
+            )
 
             return (response, responseBodyForNext)
         } catch {
-            Task.detached(priority: .background) {
-                let fullURL = Self.buildURL(baseURL: baseURL, path: request.path)
-                let harMetadata = await Self.retrieveHARMetadata(for: fullURL)
+            let fullURL = Self.buildURL(baseURL: baseURL, path: request.path)
+            let harMetadata = await Self.retrieveHARMetadata(for: fullURL)
 
-                await recorder.recordError(
-                    url: fullURL,
-                    method: request.method.rawValue,
-                    requestHeaders: request.headerFields.map { HAR.Header(name: $0.name.rawName, value: $0.value) },
-                    requestBody: requestBodyData,
-                    error: error,
-                    startTime: harMetadata.startTime,
-                    endTime: harMetadata.endTime,
-                    timings: harMetadata.timings,
-                    httpVersion: harMetadata.httpVersion,
-                    requestHeadersSize: harMetadata.requestHeadersSize
-                )
-            }
+            await recorder.recordError(
+                url: fullURL,
+                method: request.method.rawValue,
+                requestHeaders: request.headerFields.map { HAR.Header(name: $0.name.rawName, value: $0.value) },
+                requestBody: requestBodyData,
+                error: error,
+                startTime: harMetadata.startTime,
+                endTime: harMetadata.endTime,
+                timings: harMetadata.timings,
+                httpVersion: harMetadata.httpVersion,
+                requestHeadersSize: harMetadata.requestHeadersSize
+            )
 
             throw error
         }

--- a/cli/Sources/TuistHAR/HARRecordingMiddleware.swift
+++ b/cli/Sources/TuistHAR/HARRecordingMiddleware.swift
@@ -32,43 +32,47 @@ public struct HARRecordingMiddleware: ClientMiddleware {
                 contentType: responseContentType
             )
 
-            let fullURL = Self.buildURL(baseURL: baseURL, path: request.path)
-            let harMetadata = await Self.retrieveHARMetadata(for: fullURL)
+            Task.detached(priority: .background) {
+                let fullURL = Self.buildURL(baseURL: baseURL, path: request.path)
+                let harMetadata = await Self.retrieveHARMetadata(for: fullURL)
 
-            await recorder.recordRequest(
-                url: fullURL,
-                method: request.method.rawValue,
-                requestHeaders: request.headerFields.map { HAR.Header(name: $0.name.rawName, value: $0.value) },
-                requestBody: requestBodyData,
-                responseStatusCode: response.status.code,
-                responseStatusText: response.status.reasonPhrase ?? "",
-                responseHeaders: response.headerFields.map { HAR.Header(name: $0.name.rawName, value: $0.value) },
-                responseBody: responseBodyData,
-                startTime: harMetadata.startTime,
-                endTime: harMetadata.endTime,
-                timings: harMetadata.timings,
-                httpVersion: harMetadata.httpVersion,
-                requestHeadersSize: harMetadata.requestHeadersSize,
-                responseHeadersSize: harMetadata.responseHeadersSize
-            )
+                await recorder.recordRequest(
+                    url: fullURL,
+                    method: request.method.rawValue,
+                    requestHeaders: request.headerFields.map { HAR.Header(name: $0.name.rawName, value: $0.value) },
+                    requestBody: requestBodyData,
+                    responseStatusCode: response.status.code,
+                    responseStatusText: response.status.reasonPhrase ?? "",
+                    responseHeaders: response.headerFields.map { HAR.Header(name: $0.name.rawName, value: $0.value) },
+                    responseBody: responseBodyData,
+                    startTime: harMetadata.startTime,
+                    endTime: harMetadata.endTime,
+                    timings: harMetadata.timings,
+                    httpVersion: harMetadata.httpVersion,
+                    requestHeadersSize: harMetadata.requestHeadersSize,
+                    responseHeadersSize: harMetadata.responseHeadersSize
+                )
+            }
 
             return (response, responseBodyForNext)
         } catch {
-            let fullURL = Self.buildURL(baseURL: baseURL, path: request.path)
-            let harMetadata = await Self.retrieveHARMetadata(for: fullURL)
+            Task.detached(priority: .background) {
+                let fullURL = Self.buildURL(baseURL: baseURL, path: request.path)
+                let harMetadata = await Self.retrieveHARMetadata(for: fullURL)
 
-            await recorder.recordError(
-                url: fullURL,
-                method: request.method.rawValue,
-                requestHeaders: request.headerFields.map { HAR.Header(name: $0.name.rawName, value: $0.value) },
-                requestBody: requestBodyData,
-                error: error,
-                startTime: harMetadata.startTime,
-                endTime: harMetadata.endTime,
-                timings: harMetadata.timings,
-                httpVersion: harMetadata.httpVersion,
-                requestHeadersSize: harMetadata.requestHeadersSize
-            )
+                await recorder.recordError(
+                    url: fullURL,
+                    method: request.method.rawValue,
+                    requestHeaders: request.headerFields.map { HAR.Header(name: $0.name.rawName, value: $0.value) },
+                    requestBody: requestBodyData,
+                    error: error,
+                    startTime: harMetadata.startTime,
+                    endTime: harMetadata.endTime,
+                    timings: harMetadata.timings,
+                    httpVersion: harMetadata.httpVersion,
+                    requestHeadersSize: harMetadata.requestHeadersSize
+                )
+            }
 
             throw error
         }

--- a/cli/Sources/TuistHTTP/FileClient.swift
+++ b/cli/Sources/TuistHTTP/FileClient.swift
@@ -80,10 +80,18 @@ import Path
                 let (localUrl, response) = try await session.download(for: request)
                 guard let httpResponse = response as? HTTPURLResponse else {
                     let error = FileClientError.invalidResponse(request, nil)
-                    await Self.recordDownloadError(request: request, error: error)
+                    if let recorder = HARRecorder.current {
+                        Task.detached(priority: .background) {
+                            await Self.recordDownloadError(request: request, error: error, recorder: recorder)
+                        }
+                    }
                     throw error
                 }
-                await Self.recordDownload(request: request, response: httpResponse)
+                if let recorder = HARRecorder.current {
+                    Task.detached(priority: .background) {
+                        await Self.recordDownload(request: request, response: httpResponse, recorder: recorder)
+                    }
+                }
                 if successStatusCodeRange.contains(httpResponse.statusCode) {
                     return try AbsolutePath(validating: localUrl.path)
                 } else {
@@ -92,7 +100,11 @@ import Path
             } catch let error as FileClientError {
                 throw error
             } catch {
-                await Self.recordDownloadError(request: request, error: error)
+                if let recorder = HARRecorder.current {
+                    Task.detached(priority: .background) {
+                        await Self.recordDownloadError(request: request, error: error, recorder: recorder)
+                    }
+                }
                 throw FileClientError.urlSessionError(request, error, nil)
             }
         }
@@ -109,10 +121,28 @@ import Path
                 let (_, response) = try await session.data(for: request)
                 guard let httpResponse = response as? HTTPURLResponse else {
                     let error = FileClientError.invalidResponse(request, file)
-                    await Self.recordUploadError(request: request, error: error, requestBodySize: Int(fileSize))
+                    if let recorder = HARRecorder.current {
+                        Task.detached(priority: .background) {
+                            await Self.recordUploadError(
+                                request: request,
+                                error: error,
+                                requestBodySize: Int(fileSize),
+                                recorder: recorder
+                            )
+                        }
+                    }
                     throw error
                 }
-                await Self.recordUpload(request: request, response: httpResponse, requestBodySize: Int(fileSize))
+                if let recorder = HARRecorder.current {
+                    Task.detached(priority: .background) {
+                        await Self.recordUpload(
+                            request: request,
+                            response: httpResponse,
+                            requestBodySize: Int(fileSize),
+                            recorder: recorder
+                        )
+                    }
+                }
                 if successStatusCodeRange.contains(httpResponse.statusCode) {
                     return true
                 } else {
@@ -121,7 +151,16 @@ import Path
             } catch let error as FileClientError {
                 throw error
             } catch {
-                await Self.recordUploadError(request: request, error: error, requestBodySize: Int(fileSize))
+                if let recorder = HARRecorder.current {
+                    Task.detached(priority: .background) {
+                        await Self.recordUploadError(
+                            request: request,
+                            error: error,
+                            requestBodySize: Int(fileSize),
+                            recorder: recorder
+                        )
+                    }
+                }
                 throw FileClientError.urlSessionError(request, error, file)
             }
         }
@@ -144,8 +183,8 @@ import Path
 
         // MARK: - HAR Recording
 
-        private static func recordDownload(request: URLRequest, response: HTTPURLResponse) async {
-            guard let recorder = HARRecorder.current, let url = request.url else { return }
+        private static func recordDownload(request: URLRequest, response: HTTPURLResponse, recorder: HARRecorder) async {
+            guard let url = request.url else { return }
             let metadata = await retrieveHARMetadata(for: url)
             await recorder.recordRequest(
                 request: request,
@@ -161,8 +200,8 @@ import Path
             )
         }
 
-        private static func recordDownloadError(request: URLRequest, error: Error) async {
-            guard let recorder = HARRecorder.current, let url = request.url else { return }
+        private static func recordDownloadError(request: URLRequest, error: Error, recorder: HARRecorder) async {
+            guard let url = request.url else { return }
             let metadata = await retrieveHARMetadata(for: url)
             await recorder.recordError(
                 request: request,
@@ -176,8 +215,13 @@ import Path
             )
         }
 
-        private static func recordUpload(request: URLRequest, response: HTTPURLResponse, requestBodySize: Int) async {
-            guard let recorder = HARRecorder.current, let url = request.url else { return }
+        private static func recordUpload(
+            request: URLRequest,
+            response: HTTPURLResponse,
+            requestBodySize: Int,
+            recorder: HARRecorder
+        ) async {
+            guard let url = request.url else { return }
             let metadata = await retrieveHARMetadata(for: url)
             await recorder.recordRequest(
                 request: request,
@@ -194,8 +238,13 @@ import Path
             )
         }
 
-        private static func recordUploadError(request: URLRequest, error: Error, requestBodySize: Int) async {
-            guard let recorder = HARRecorder.current, let url = request.url else { return }
+        private static func recordUploadError(
+            request: URLRequest,
+            error: Error,
+            requestBodySize: Int,
+            recorder: HARRecorder
+        ) async {
+            guard let url = request.url else { return }
             let metadata = await retrieveHARMetadata(for: url)
             await recorder.recordError(
                 request: request,

--- a/cli/Sources/TuistHTTP/FileClient.swift
+++ b/cli/Sources/TuistHTTP/FileClient.swift
@@ -80,17 +80,13 @@ import Path
                 let (localUrl, response) = try await session.download(for: request)
                 guard let httpResponse = response as? HTTPURLResponse else {
                     let error = FileClientError.invalidResponse(request, nil)
-                    if let recorder = HARRecorder.current {
-                        Task.detached(priority: .background) {
-                            await Self.recordDownloadError(request: request, error: error, recorder: recorder)
-                        }
+                    HARRecorder.recordDetached { recorder in
+                        await Self.recordDownloadError(request: request, error: error, recorder: recorder)
                     }
                     throw error
                 }
-                if let recorder = HARRecorder.current {
-                    Task.detached(priority: .background) {
-                        await Self.recordDownload(request: request, response: httpResponse, recorder: recorder)
-                    }
+                HARRecorder.recordDetached { recorder in
+                    await Self.recordDownload(request: request, response: httpResponse, recorder: recorder)
                 }
                 if successStatusCodeRange.contains(httpResponse.statusCode) {
                     return try AbsolutePath(validating: localUrl.path)
@@ -100,10 +96,8 @@ import Path
             } catch let error as FileClientError {
                 throw error
             } catch {
-                if let recorder = HARRecorder.current {
-                    Task.detached(priority: .background) {
-                        await Self.recordDownloadError(request: request, error: error, recorder: recorder)
-                    }
+                HARRecorder.recordDetached { recorder in
+                    await Self.recordDownloadError(request: request, error: error, recorder: recorder)
                 }
                 throw FileClientError.urlSessionError(request, error, nil)
             }
@@ -121,27 +115,23 @@ import Path
                 let (_, response) = try await session.data(for: request)
                 guard let httpResponse = response as? HTTPURLResponse else {
                     let error = FileClientError.invalidResponse(request, file)
-                    if let recorder = HARRecorder.current {
-                        Task.detached(priority: .background) {
-                            await Self.recordUploadError(
-                                request: request,
-                                error: error,
-                                requestBodySize: Int(fileSize),
-                                recorder: recorder
-                            )
-                        }
-                    }
-                    throw error
-                }
-                if let recorder = HARRecorder.current {
-                    Task.detached(priority: .background) {
-                        await Self.recordUpload(
+                    HARRecorder.recordDetached { recorder in
+                        await Self.recordUploadError(
                             request: request,
-                            response: httpResponse,
+                            error: error,
                             requestBodySize: Int(fileSize),
                             recorder: recorder
                         )
                     }
+                    throw error
+                }
+                HARRecorder.recordDetached { recorder in
+                    await Self.recordUpload(
+                        request: request,
+                        response: httpResponse,
+                        requestBodySize: Int(fileSize),
+                        recorder: recorder
+                    )
                 }
                 if successStatusCodeRange.contains(httpResponse.statusCode) {
                     return true
@@ -151,15 +141,13 @@ import Path
             } catch let error as FileClientError {
                 throw error
             } catch {
-                if let recorder = HARRecorder.current {
-                    Task.detached(priority: .background) {
-                        await Self.recordUploadError(
-                            request: request,
-                            error: error,
-                            requestBodySize: Int(fileSize),
-                            recorder: recorder
-                        )
-                    }
+                HARRecorder.recordDetached { recorder in
+                    await Self.recordUploadError(
+                        request: request,
+                        error: error,
+                        requestBodySize: Int(fileSize),
+                        recorder: recorder
+                    )
                 }
                 throw FileClientError.urlSessionError(request, error, file)
             }

--- a/cli/Sources/TuistHTTP/FileClient.swift
+++ b/cli/Sources/TuistHTTP/FileClient.swift
@@ -79,25 +79,21 @@ import Path
             do {
                 let (localUrl, response) = try await session.download(for: request)
                 guard let httpResponse = response as? HTTPURLResponse else {
-                    throw FileClientError.invalidResponse(request, nil)
+                    let error = FileClientError.invalidResponse(request, nil)
+                    await Self.recordDownloadError(request: request, error: error)
+                    throw error
                 }
-                Task.detached(priority: .background) {
-                    await Self.recordDownload(request: request, response: httpResponse)
-                }
+                await Self.recordDownload(request: request, response: httpResponse)
                 if successStatusCodeRange.contains(httpResponse.statusCode) {
                     return try AbsolutePath(validating: localUrl.path)
                 } else {
                     throw FileClientError.invalidResponse(request, nil)
                 }
+            } catch let error as FileClientError {
+                throw error
             } catch {
-                Task.detached(priority: .background) {
-                    await Self.recordDownloadError(request: request, error: error)
-                }
-                if error is FileClientError {
-                    throw error
-                } else {
-                    throw FileClientError.urlSessionError(request, error, nil)
-                }
+                await Self.recordDownloadError(request: request, error: error)
+                throw FileClientError.urlSessionError(request, error, nil)
             }
         }
 
@@ -112,25 +108,21 @@ import Path
             do {
                 let (_, response) = try await session.data(for: request)
                 guard let httpResponse = response as? HTTPURLResponse else {
-                    throw FileClientError.invalidResponse(request, file)
+                    let error = FileClientError.invalidResponse(request, file)
+                    await Self.recordUploadError(request: request, error: error, requestBodySize: Int(fileSize))
+                    throw error
                 }
-                Task.detached(priority: .background) {
-                    await Self.recordUpload(request: request, response: httpResponse, requestBodySize: Int(fileSize))
-                }
+                await Self.recordUpload(request: request, response: httpResponse, requestBodySize: Int(fileSize))
                 if successStatusCodeRange.contains(httpResponse.statusCode) {
                     return true
                 } else {
                     throw FileClientError.serverSideError(request, httpResponse, file)
                 }
+            } catch let error as FileClientError {
+                throw error
             } catch {
-                Task.detached(priority: .background) {
-                    await Self.recordUploadError(request: request, error: error, requestBodySize: Int(fileSize))
-                }
-                if error is FileClientError {
-                    throw error
-                } else {
-                    throw FileClientError.urlSessionError(request, error, file)
-                }
+                await Self.recordUploadError(request: request, error: error, requestBodySize: Int(fileSize))
+                throw FileClientError.urlSessionError(request, error, file)
             }
         }
 

--- a/cli/Sources/TuistKit/Utils/Dependencies.swift
+++ b/cli/Sources/TuistKit/Utils/Dependencies.swift
@@ -45,10 +45,17 @@ public func initDependencies(_ action: (SessionPaths) async throws -> Void) asyn
                 try await Noora.$current.withValue(initNoora()) {
                     try await Logger.$current.withValue(logger) {
                         try await HARRecorder.$current.withValue(harRecorder) {
-                            try await ServerCredentialsStore.$current.withValue(ServerCredentialsStore(backend: .fileSystem)) {
-                                try await CachedValueStore.$current.withValue(CachedValueStore(backend: .fileSystem)) {
-                                    try await action(sessionPaths)
-                                }
+                            do {
+                                try await ServerCredentialsStore.$current
+                                    .withValue(ServerCredentialsStore(backend: .fileSystem)) {
+                                        try await CachedValueStore.$current.withValue(CachedValueStore(backend: .fileSystem)) {
+                                            try await action(sessionPaths)
+                                        }
+                                    }
+                                await harRecorder.finish()
+                            } catch {
+                                await harRecorder.finish()
+                                throw error
                             }
                         }
                     }

--- a/cli/Sources/TuistKit/Utils/Dependencies.swift
+++ b/cli/Sources/TuistKit/Utils/Dependencies.swift
@@ -44,19 +44,13 @@ public func initDependencies(_ action: (SessionPaths) async throws -> Void) asyn
             try await ServerAuthenticationConfig.$current.withValue(ServerAuthenticationConfig(backgroundRefresh: true)) {
                 try await Noora.$current.withValue(initNoora()) {
                     try await Logger.$current.withValue(logger) {
-                        try await HARRecorder.$current.withValue(harRecorder) {
-                            do {
-                                try await ServerCredentialsStore.$current
-                                    .withValue(ServerCredentialsStore(backend: .fileSystem)) {
-                                        try await CachedValueStore.$current.withValue(CachedValueStore(backend: .fileSystem)) {
-                                            try await action(sessionPaths)
-                                        }
+                        try await HARRecorder.withCurrent(harRecorder) {
+                            try await ServerCredentialsStore.$current
+                                .withValue(ServerCredentialsStore(backend: .fileSystem)) {
+                                    try await CachedValueStore.$current.withValue(CachedValueStore(backend: .fileSystem)) {
+                                        try await action(sessionPaths)
                                     }
-                                await harRecorder.finish()
-                            } catch {
-                                await harRecorder.finish()
-                                throw error
-                            }
+                                }
                         }
                     }
                 }

--- a/cli/Sources/tuist/TuistCommand.swift
+++ b/cli/Sources/tuist/TuistCommand.swift
@@ -375,7 +375,13 @@ public struct TuistCommand: AsyncParsableCommand {
             let harRecorder: HARRecorder? =
                 shouldRecordHAR ? HARRecorder(filePath: networkFilePath) : nil
             try await HARRecorder.$current.withValue(harRecorder) {
-                try await action()
+                do {
+                    try await action()
+                    await harRecorder?.finish()
+                } catch {
+                    await harRecorder?.finish()
+                    throw error
+                }
             }
         }
     #endif

--- a/cli/Sources/tuist/TuistCommand.swift
+++ b/cli/Sources/tuist/TuistCommand.swift
@@ -372,16 +372,15 @@ public struct TuistCommand: AsyncParsableCommand {
             shouldRecordHAR: Bool,
             _ action: () async throws -> Void
         ) async throws {
+            if shouldRecordHAR, HARRecorder.current != nil {
+                try await action()
+                return
+            }
+
             let harRecorder: HARRecorder? =
                 shouldRecordHAR ? HARRecorder(filePath: networkFilePath) : nil
-            try await HARRecorder.$current.withValue(harRecorder) {
-                do {
-                    try await action()
-                    await harRecorder?.finish()
-                } catch {
-                    await harRecorder?.finish()
-                    throw error
-                }
+            try await HARRecorder.withCurrent(harRecorder) {
+                try await action()
             }
         }
     #endif

--- a/cli/Sources/tuist/TuistCommand.swift
+++ b/cli/Sources/tuist/TuistCommand.swift
@@ -232,8 +232,8 @@ public struct TuistCommand: AsyncParsableCommand {
                 }
             } catch {
                 try await withLoggerForNoora(logFilePath: logFilePath) {
-                    Noora.$current.withValue(initNoora()) {
-                        onError(
+                    await Noora.$current.withValue(initNoora()) {
+                        await onError(
                             parsingError ?? error, isParsingError: parsingError != nil, logFilePath: logFilePath
                         )
                     }
@@ -257,13 +257,13 @@ public struct TuistCommand: AsyncParsableCommand {
                         )
                     }
                 } catch {
-                    onError(error, isParsingError: false, logFilePath: logFilePath)
+                    await onError(error, isParsingError: false, logFilePath: logFilePath)
                 }
             }
         #endif
     }
 
-    private static func onError(_ error: Error, isParsingError: Bool, logFilePath: AbsolutePath) {
+    private static func onError(_ error: Error, isParsingError: Bool, logFilePath: AbsolutePath) async {
         var errorAlertMessage: TerminalText?
         var errorAlertNextSteps: [TerminalText] = [
             "If the error is actionable, address it",
@@ -273,6 +273,7 @@ public struct TuistCommand: AsyncParsableCommand {
         let exitCode = exitCode(for: error).rawValue
 
         if error.localizedDescription.contains("ArgumentParser") {
+            await finishHARRecordingBeforeExit()
             exit(withError: error)
         }
 
@@ -303,6 +304,7 @@ public struct TuistCommand: AsyncParsableCommand {
         }
 
         if !errorHandled, isParsingError, self.exitCode(for: error).rawValue == 0 {
+            await finishHARRecordingBeforeExit()
             exit(withError: error)
         } else if !errorHandled, let localizedError = error as? LocalizedError {
             errorAlertMessage =
@@ -317,7 +319,14 @@ public struct TuistCommand: AsyncParsableCommand {
             errorAlertMessage: errorAlertMessage,
             errorAlertNextSteps: errorAlertNextSteps
         )
+        await finishHARRecordingBeforeExit()
         _exit(exitCode)
+    }
+
+    private static func finishHARRecordingBeforeExit() async {
+        #if os(macOS)
+            await HARRecorder.finishCurrent()
+        #endif
     }
 
     private static func outputCompletion(

--- a/cli/Tests/TuistHARTests/HARRecorderTests.swift
+++ b/cli/Tests/TuistHARTests/HARRecorderTests.swift
@@ -173,7 +173,7 @@ struct HARRecorderTests {
     }
 
     @Test(.inTemporaryDirectory)
-    func record_persistsToFile() async throws {
+    func finish_persistsToFile() async throws {
         let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
         let harFilePath = temporaryDirectory.appending(component: "network.har")
 
@@ -183,6 +183,7 @@ struct HARRecorderTests {
 
         // When
         await recorder.record(entry)
+        await recorder.finish()
 
         // Then
         let fileSystem = FileSystem()
@@ -191,6 +192,20 @@ struct HARRecorderTests {
         let data = try Data(contentsOf: URL(fileURLWithPath: harFilePath.pathString))
         let log = try HAR.decode(from: data)
         #expect(log.entries.count == 1)
+    }
+
+    @Test
+    func finish_ignoresEntriesRecordedAfterFinishing() async {
+        // Given
+        let recorder = HARRecorder(filePath: nil)
+
+        // When
+        await recorder.finish()
+        await recorder.record(makeTestEntry())
+
+        // Then
+        let entries = await recorder.getEntries()
+        #expect(entries.isEmpty)
     }
 
     @Test

--- a/cli/Tests/TuistHARTests/HARRecorderTests.swift
+++ b/cli/Tests/TuistHARTests/HARRecorderTests.swift
@@ -209,6 +209,49 @@ struct HARRecorderTests {
     }
 
     @Test
+    func record_handlesConcurrentEntries() async {
+        // Given
+        let recorder = HARRecorder(filePath: nil)
+        let entryCount = 500
+
+        // When
+        await withTaskGroup(of: Void.self) { group in
+            for index in 0 ..< entryCount {
+                group.addTask {
+                    await recorder.record(Self.makeConcurrentEntry(index: index))
+                }
+            }
+        }
+
+        // Then
+        let entries = await recorder.getEntries()
+        #expect(entries.count == entryCount)
+    }
+
+    @Test
+    func finish_ignoresDetachedEntriesThatResumeAfterFinishing() async throws {
+        // Given
+        let recorder = HARRecorder(filePath: nil)
+        let gate = Gate()
+
+        // When
+        for index in 0 ..< 100 {
+            recorder.recordDetached { recorder in
+                await gate.wait()
+                await recorder.record(Self.makeConcurrentEntry(index: index))
+            }
+        }
+        await recorder.finish()
+        await gate.open()
+
+        try await Task.sleep(nanoseconds: 10_000_000)
+
+        // Then
+        let entries = await recorder.getEntries()
+        #expect(entries.isEmpty)
+    }
+
+    @Test
     func record_withoutFilePath_doesNotPersist() async throws {
         // Given
         let recorder = HARRecorder(filePath: nil)
@@ -242,6 +285,51 @@ struct HARRecorderTests {
         #expect(filtered[2].value == "[REDACTED]")
         #expect(filtered[3].value == "*/*")
         #expect(filtered[4].value == "[REDACTED]")
+    }
+
+    private actor Gate {
+        private var isOpen = false
+        private var continuations: [CheckedContinuation<Void, Never>] = []
+
+        func wait() async {
+            if isOpen { return }
+
+            await withCheckedContinuation { continuation in
+                continuations.append(continuation)
+            }
+        }
+
+        func open() {
+            isOpen = true
+            let continuations = continuations
+            self.continuations.removeAll()
+            continuations.forEach { $0.resume() }
+        }
+    }
+
+    private static func makeConcurrentEntry(index: Int) -> HAR.Entry {
+        HAR.Entry(
+            startedDateTime: Date(),
+            time: 100,
+            request: HAR.Request(
+                method: "GET",
+                url: "https://api.example.com/test/\(index)"
+            ),
+            response: HAR.Response(
+                status: 200,
+                statusText: "OK",
+                content: HAR.Content(
+                    size: 10,
+                    mimeType: "application/json",
+                    text: "{}"
+                )
+            ),
+            timings: HAR.Timings(
+                send: 0,
+                wait: 100,
+                receive: 0
+            )
+        )
     }
 
     private func makeTestEntry() -> HAR.Entry {

--- a/cli/Tests/TuistHARTests/HARRecorderTests.swift
+++ b/cli/Tests/TuistHARTests/HARRecorderTests.swift
@@ -194,6 +194,26 @@ struct HARRecorderTests {
         #expect(log.entries.count == 1)
     }
 
+    @Test(.inTemporaryDirectory)
+    func finishCurrent_persistsActiveRecorderBeforeTaskLocalScopeExits() async throws {
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let harFilePath = temporaryDirectory.appending(component: "network.har")
+
+        let recorder = HARRecorder(filePath: harFilePath)
+
+        try await HARRecorder.withCurrent(recorder) {
+            await recorder.record(makeTestEntry())
+            await HARRecorder.finishCurrent()
+
+            let fileSystem = FileSystem()
+            #expect(try await fileSystem.exists(harFilePath))
+
+            let data = try Data(contentsOf: URL(fileURLWithPath: harFilePath.pathString))
+            let log = try HAR.decode(from: data)
+            #expect(log.entries.count == 1)
+        }
+    }
+
     @Test
     func finish_ignoresEntriesRecordedAfterFinishing() async {
         // Given

--- a/cli/Tests/TuistHARTests/HARRecordingMiddlewareTests.swift
+++ b/cli/Tests/TuistHARTests/HARRecordingMiddlewareTests.swift
@@ -10,7 +10,7 @@ import Testing
 
 struct HARRecordingMiddlewareTests {
     @Test(.inTemporaryDirectory)
-    func intercept_recordsResponseBeforeReturning() async throws {
+    func intercept_recordsResponseInDetachedTask() async throws {
         let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
         let harFilePath = temporaryDirectory.appending(component: "network.har")
         let recorder = HARRecorder(filePath: harFilePath)
@@ -36,11 +36,13 @@ struct HARRecordingMiddlewareTests {
             let bodyData = try await Data(collecting: body, upTo: responseBody.count)
             #expect(bodyData == responseBody)
 
-            let entries = await recorder.getEntries()
+            let entries = try await waitForEntries(recorder, count: 1)
             #expect(entries.count == 1)
             #expect(entries[0].request.method == "POST")
             #expect(entries[0].request.url == "https://api.example.com/v1/projects?filter=owned")
             #expect(entries[0].response.status == 201)
+
+            await recorder.finish()
         }
 
         let data = try Data(contentsOf: URL(fileURLWithPath: harFilePath.pathString))
@@ -69,10 +71,21 @@ struct HARRecordingMiddlewareTests {
             }
         }
 
-        let entries = await recorder.getEntries()
+        let entries = try await waitForEntries(recorder, count: 1)
         #expect(entries.count == 1)
         #expect(entries[0].request.method == "GET")
         #expect(entries[0].request.url == "https://api.example.com/v1/projects")
         #expect(entries[0].response.status == 0)
+    }
+
+    private func waitForEntries(_ recorder: HARRecorder, count: Int) async throws -> [HAR.Entry] {
+        for _ in 0 ..< 100 {
+            let entries = await recorder.getEntries()
+            if entries.count >= count {
+                return entries
+            }
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+        return await recorder.getEntries()
     }
 }

--- a/cli/Tests/TuistHARTests/HARRecordingMiddlewareTests.swift
+++ b/cli/Tests/TuistHARTests/HARRecordingMiddlewareTests.swift
@@ -1,0 +1,78 @@
+import FileSystem
+import FileSystemTesting
+import Foundation
+import HTTPTypes
+import OpenAPIRuntime
+import Path
+import Testing
+
+@testable import TuistHAR
+
+struct HARRecordingMiddlewareTests {
+    @Test(.inTemporaryDirectory)
+    func intercept_recordsResponseBeforeReturning() async throws {
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let harFilePath = temporaryDirectory.appending(component: "network.har")
+        let recorder = HARRecorder(filePath: harFilePath)
+        let subject = HARRecordingMiddleware()
+        var request = HTTPRequest(method: .post, scheme: nil, authority: nil, path: "/v1/projects?filter=owned")
+        request.headerFields[.contentType] = "application/json"
+        let responseBody = Data(#"{"ok":true}"#.utf8)
+
+        try await HARRecorder.$current.withValue(recorder) {
+            let (response, bodyForNext) = try await subject.intercept(
+                request,
+                body: HTTPBody(Data(#"{"name":"tuist"}"#.utf8)),
+                baseURL: URL(string: "https://api.example.com")!,
+                operationID: "createProject"
+            ) { _, _, _ in
+                var response = HTTPResponse(status: 201)
+                response.headerFields[.contentType] = "application/json"
+                return (response, HTTPBody(responseBody))
+            }
+
+            #expect(response.status.code == 201)
+            let body = try #require(bodyForNext)
+            let bodyData = try await Data(collecting: body, upTo: responseBody.count)
+            #expect(bodyData == responseBody)
+
+            let entries = await recorder.getEntries()
+            #expect(entries.count == 1)
+            #expect(entries[0].request.method == "POST")
+            #expect(entries[0].request.url == "https://api.example.com/v1/projects?filter=owned")
+            #expect(entries[0].response.status == 201)
+        }
+
+        let data = try Data(contentsOf: URL(fileURLWithPath: harFilePath.pathString))
+        let log = try HAR.decode(from: data)
+        #expect(log.entries.count == 1)
+    }
+
+    @Test
+    func intercept_recordsErrorBeforeThrowing() async throws {
+        struct TestError: Error {}
+
+        let recorder = HARRecorder(filePath: nil)
+        let subject = HARRecordingMiddleware()
+        let request = HTTPRequest(method: .get, scheme: nil, authority: nil, path: "/v1/projects")
+
+        await #expect(throws: TestError.self) {
+            try await HARRecorder.$current.withValue(recorder) {
+                try await subject.intercept(
+                    request,
+                    body: nil,
+                    baseURL: URL(string: "https://api.example.com")!,
+                    operationID: "listProjects"
+                ) { _, _, _ in
+                    throw TestError()
+                }
+            }
+        }
+
+        let entries = await recorder.getEntries()
+        #expect(entries.count == 1)
+        #expect(entries[0].request.method == "GET")
+        #expect(entries[0].request.url == "https://api.example.com/v1/projects")
+        #expect(entries[0].response.status == 0)
+    }
+}


### PR DESCRIPTION
Resolves N/A

This fixes a crash pattern reported from `.ips` files where the CLI could continue HAR JSON encoding and persistence on detached background tasks while command execution was already completing.

The crash happened because HAR recording was detached and every entry persisted by JSON-encoding and writing `network.har` from the background task. On the affected GitLab runner, command completion could race those detached tasks, leaving `HARRecorder.persist()` active while `swift_errorInMain` was unwinding. This can look customer-specific because it depends on runner timing, macOS scheduling, network activity, and HAR being enabled, so most runs either finish the detached work earlier or exit before the race becomes visible.

The change keeps recording detached so the middleware does not block on HAR work. `HARRecorder` now owns both detached scheduling and scoped finishing: detached work appends entries to the recorder actor, and the active recorder is finished once at the session boundary to persist entries recorded so far. The recorder closes through a lock-protected state before awaiting actor isolation, so a high-concurrency burst cannot keep shutdown stuck behind a large queue of pending HAR messages. Commands that disable HAR recording temporarily shadow the task-local recorder with `nil`; commands that keep HAR enabled reuse the existing session recorder instead of creating a nested writer. Any detached recording that arrives after `finish()` is ignored, which can lose a late HAR entry but prevents JSON encoding and file writes from continuing during shutdown. File upload and download recording now use the same detached recorder API instead of depending on task-local state inside detached tasks.

### How to test locally

- `mise run cli:lint --fix`
- `tuist generate tuist TuistHAR TuistHARTests ProjectDescription --no-open`
- `xcodebuild test -workspace Tuist.xcworkspace -scheme Tuist-Workspace -only-testing TuistHARTests/HARRecordingMiddlewareTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" COMPILATION_CACHE_ENABLE_CACHING=NO`
- `xcodebuild test -workspace Tuist.xcworkspace -scheme Tuist-Workspace -only-testing TuistHARTests/HARRecorderTests -only-testing TuistHARTests/HARRecordingMiddlewareTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" COMPILATION_CACHE_ENABLE_CACHING=NO`
