### PR TITLE
fix(infra): pin runners-controller to 0.11.0 to deploy the runner _diag env var

### DIFF
--- a/infra/helm/tuist/values-managed-common.yaml
+++ b/infra/helm/tuist/values-managed-common.yaml
@@ -254,7 +254,7 @@ runnersController:
     repository: ghcr.io/tuist/tuist-runners-controller
     # SHA-tagged build from the runners-controller-image.yml
     # workflow.
-    tag: "0.10.0"
+    tag: "0.11.0"
 
 # Everything below = external. The managed deployment never runs embedded
 # Postgres / ClickHouse / object storage / observability stacks.


### PR DESCRIPTION
## What

Bump the `runnersController.image.tag` pin in `values-managed-common.yaml` from `0.10.0` to `0.11.0`.

## Why

#11114 added `ACTIONS_RUNNER_PRINT_LOG_TO_STDOUT=1` to the runner container (so the actions/runner `_diag` log streams to Loki and survives the reaped Pod). The controller image carrying that change was **built and published** — `ghcr.io/tuist/tuist-runners-controller:0.11.0` exists in ghcr (pushed at 13:41Z by the Release run's `Release runners-controller` job, and it includes #11114). But the **pin is still `0.10.0`**, so the cluster keeps deploying the old controller and new runner pods don't get the env var.

Root cause: the Release run that would create the `runners-controller@0.11.0` tag *and* run the single-writer pin-bump step on `values-managed-common.yaml` was **cancelled before that final step** (superseded by later pushes to `main`). So the image got published but the pin bump and tag never landed. (Release reliability is being addressed separately.)

## Why `0.11.0` specifically

`0.11.0` is exactly the value the release single-writer would have written (`sed ... tag: "0.11.0"`), and the image is confirmed present in ghcr and built from a commit that includes #11114. So when release reliability is fixed and a release does complete, re-pinning to `0.11.0` (or a higher version that still contains #11114) is a no-op / forward-compatible — no churn from this stopgap.

## Impact

The server-deployment cascade redeploys the controller at `0.11.0`. The controller stamps `ACTIONS_RUNNER_PRINT_LOG_TO_STDOUT=1` onto **newly-created** runner pods (warm pods keep the old env until they recycle), so runner `_diag` starts reaching Loki. Paired with the node-logs shipping from #11114, the next mid-job runner death becomes self-diagnosing from both the runner and host sides.

## Validation

Confirmed `ghcr.io/tuist/tuist-runners-controller:0.11.0` exists in the registry; confirmed `runners-controller-deployment.yaml` renders the image as `{{ .repository }}:{{ .tag }}`, so this pin directly controls the deployed image. One-line values change, no template logic touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)