### PR TITLE
fix(server): use a version below the floor in the lower-than-floor deprecation test

### DIFF
--- a/server/test/tuist_web/plugs/warnings_header_plug_test.exs
+++ b/server/test/tuist_web/plugs/warnings_header_plug_test.exs
@@ -91,7 +91,7 @@ defmodule TuistWeb.WarningsHeaderPlugTest do
       conn =
         :get
         |> conn("/")
-        |> Plug.Conn.put_req_header(Headers.cli_version_header(), "4.154.0")
+        |> Plug.Conn.put_req_header(Headers.cli_version_header(), "4.149.0")
 
       # When
       got = WarningsHeaderPlug.call(conn, %{})
@@ -102,7 +102,7 @@ defmodule TuistWeb.WarningsHeaderPlugTest do
       warning = got |> Plug.Conn.get_resp_header("x-tuist-cloud-warnings") |> List.first()
 
       assert JSON.decode!(Base.decode64!(warning)) == [
-               "Your Tuist version 4.154.0 is deprecated. Please upgrade to version 4.160.0 for server-side features to continue working."
+               "Your Tuist version 4.149.0 is deprecated. Please upgrade to version 4.160.0 for server-side features to continue working."
              ]
     end
 


### PR DESCRIPTION
## What changed

The \"deprecation warning if the version is lower than 4.150.0\" test in `warnings_header_plug_test.exs` now stubs the request header with **4.149.0** (and asserts on the matching message), instead of `4.154.0`.

## Why

[#11120](https://github.com/tuist/tuist/pull/11120) lowered the minimum supported CLI version from 4.155.0 to 4.150.0 and renamed this test, but didn't update its body: the request still claimed CLI version 4.154.0. Under the new floor, 4.154.0 is *above* 4.150.0 and therefore not deprecated, so no warning header is emitted, but the assertion expected the deprecation message. The test became internally inconsistent and the Test job has been failing on `main` since the merge ([example run](https://github.com/tuist/tuist/actions/runs/27024771123)). Using 4.149.0 actually exercises the lower-than-floor path the test is supposed to cover.

## Validation

`mix format` not needed (no Elixir source files outside the test changed). Syntax of the edited file is valid. Once merged, the Test job on `main` should go green again.

## Notes (not in this PR)

While looking at this, I noticed the live deprecation warning text is corrupted in customer reports — *\"Please upgrade to version **Runners Controller 0.9.0**\"* instead of the latest CLI release. That's a separate bug: `Tuist.GitHub.Releases.get_latest_cli_release/1` is returning a component tag (e.g. `runners-controller@0.11.0`) rather than filtering to CLI releases. Worth tracking separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)