### PR TITLE
fix(server): stop leaking component release titles into the CLI deprecation warning

### DIFF
--- a/server/lib/tuist/github/releases.ex
+++ b/server/lib/tuist/github/releases.ex
@@ -38,8 +38,13 @@ defmodule Tuist.GitHub.Releases do
           [__MODULE__, "github_releases"] |> KeyValueStore.get() |> List.wrap()
         end
 
+      # Filter on tag_name, not name: CLI tags are bare semver (e.g. "4.196.0")
+      # while component tags are scoped (e.g. "runners-controller@0.11.0"). The
+      # human-readable `name` field never contains "@" (it is a title like
+      # "Runners Controller 0.11.0"), so filtering on name lets component
+      # releases through and the latest one wins regardless of type.
       case Enum.find(releases, fn release ->
-             not String.contains?(release["name"], "@")
+             not String.contains?(release["tag_name"] || "", "@")
            end) do
         nil -> nil
         release -> map_release(release)

--- a/server/lib/tuist_web/plugs/warnings_header_plug.ex
+++ b/server/lib/tuist_web/plugs/warnings_header_plug.ex
@@ -50,9 +50,12 @@ defmodule TuistWeb.WarningsHeaderPlug do
   end
 
   defp get_latest_cli_version do
+    # Prefer the bare semver `tag_name` (e.g. "4.196.0") over `name`
+    # (e.g. "CLI 4.196.0"); the former is the version string users actually
+    # install.
     case Releases.get_latest_cli_release(update_if_needed: false) do
       nil -> nil
-      release -> release.name
+      release -> release.tag_name
     end
   end
 

--- a/server/test/tuist/github/releases_test.exs
+++ b/server/test/tuist/github/releases_test.exs
@@ -16,7 +16,8 @@ defmodule Tuist.GitHub.ReleasesTest do
 
       release = %{
         "published_at" => Timex.format!(published_at, "{ISO:Extended}"),
-        "name" => "v2.0.0",
+        "name" => "CLI 4.196.0",
+        "tag_name" => "4.196.0",
         "html_url" => "https://github.com/release",
         "assets" => []
       }
@@ -35,24 +36,24 @@ defmodule Tuist.GitHub.ReleasesTest do
       release = Releases.get_latest_cli_release()
 
       # Then
-      assert release.name == "v2.0.0"
+      assert release.tag_name == "4.196.0"
       assert release.html_url == "https://github.com/release"
     end
 
-    test "returns the latest CLI release if the latest release is an App release" do
-      # Given
+    test "skips component releases (scoped tags) and returns the CLI release" do
+      # Given: mirror the real GitHub release shape. Component releases have a
+      # human-readable `name` like "Runners Controller 0.9.0" (no "@") and a
+      # scoped `tag_name` like "runners-controller@0.9.0". CLI releases have a
+      # bare semver `tag_name` like "4.196.0". The filter must look at
+      # `tag_name`, not `name`, to skip the components.
       published_at = DateTime.utc_now()
 
-      release = %{
+      cli_release = %{
         "published_at" => Timex.format!(published_at, "{ISO:Extended}"),
-        "name" => "v2.0.0",
-        "html_url" => "https://github.com/release",
-        "assets" => [
-          %{
-            "name" => "tuist.zip",
-            "browser_download_url" => "https://github.com/tuist/tuist/releases/download/app@0.1.0/app.dmg"
-          }
-        ]
+        "name" => "CLI 4.196.0",
+        "tag_name" => "4.196.0",
+        "html_url" => "https://github.com/tuist/tuist/releases/tag/4.196.0",
+        "assets" => []
       }
 
       releases_url = Releases.releases_url()
@@ -67,11 +68,19 @@ defmodule Tuist.GitHub.ReleasesTest do
              body: [
                %{
                  "published_at" => Timex.format!(published_at, "{ISO:Extended}"),
-                 "name" => "app@2.0.0",
+                 "name" => "Runners Controller 0.11.0",
+                 "tag_name" => "runners-controller@0.11.0",
                  "html_url" => "https://github.com/release",
                  "assets" => []
                },
-               release
+               %{
+                 "published_at" => Timex.format!(published_at, "{ISO:Extended}"),
+                 "name" => "Server 1.207.0",
+                 "tag_name" => "server@1.207.0",
+                 "html_url" => "https://github.com/release",
+                 "assets" => []
+               },
+               cli_release
              ]
            }}
         end
@@ -81,8 +90,8 @@ defmodule Tuist.GitHub.ReleasesTest do
       release = Releases.get_latest_cli_release()
 
       # Then
-      assert release.name == "v2.0.0"
-      assert release.html_url == "https://github.com/release"
+      assert release.tag_name == "4.196.0"
+      assert release.name == "CLI 4.196.0"
     end
 
     test "returns cached release when update: false and cache exists" do
@@ -91,7 +100,8 @@ defmodule Tuist.GitHub.ReleasesTest do
 
       cached_release = %{
         "published_at" => Timex.format!(published_at, "{ISO:Extended}"),
-        "name" => "v3.0.0",
+        "name" => "CLI 4.196.0",
+        "tag_name" => "4.196.0",
         "html_url" => "https://github.com/cached-release",
         "assets" => []
       }
@@ -104,7 +114,7 @@ defmodule Tuist.GitHub.ReleasesTest do
       release = Releases.get_latest_cli_release(update_if_needed: false)
 
       # Then
-      assert release.name == "v3.0.0"
+      assert release.tag_name == "4.196.0"
       assert release.html_url == "https://github.com/cached-release"
     end
 

--- a/server/test/tuist_web/plugs/warnings_header_plug_test.exs
+++ b/server/test/tuist_web/plugs/warnings_header_plug_test.exs
@@ -43,7 +43,7 @@ defmodule TuistWeb.WarningsHeaderPlugTest do
 
     test "it doesn't return the warnings if the version is lower than 4.11.0" do
       # Given
-      Mimic.stub(Releases, :get_latest_cli_release, fn _opts -> %{name: "4.160.0"} end)
+      Mimic.stub(Releases, :get_latest_cli_release, fn _opts -> %{name: "CLI 4.160.0", tag_name: "4.160.0"} end)
 
       conn =
         :get
@@ -62,7 +62,7 @@ defmodule TuistWeb.WarningsHeaderPlugTest do
 
     test "it returns the warnings if the version is higher or equal than 4.11.0" do
       # Given
-      Mimic.stub(Releases, :get_latest_cli_release, fn _opts -> %{name: "4.160.0"} end)
+      Mimic.stub(Releases, :get_latest_cli_release, fn _opts -> %{name: "CLI 4.160.0", tag_name: "4.160.0"} end)
 
       conn =
         :get
@@ -86,7 +86,7 @@ defmodule TuistWeb.WarningsHeaderPlugTest do
 
     test "it returns a deprecation warning if the version is lower than 4.150.0" do
       # Given
-      Mimic.stub(Releases, :get_latest_cli_release, fn _opts -> %{name: "4.160.0"} end)
+      Mimic.stub(Releases, :get_latest_cli_release, fn _opts -> %{name: "CLI 4.160.0", tag_name: "4.160.0"} end)
 
       conn =
         :get
@@ -108,7 +108,7 @@ defmodule TuistWeb.WarningsHeaderPlugTest do
 
     test "it doesn't return a deprecation warning if the version is higher or equal than 4.150.0" do
       # Given
-      Mimic.stub(Releases, :get_latest_cli_release, fn _opts -> %{name: "4.160.0"} end)
+      Mimic.stub(Releases, :get_latest_cli_release, fn _opts -> %{name: "CLI 4.160.0", tag_name: "4.160.0"} end)
 
       conn =
         :get


### PR DESCRIPTION
## What changed

The deprecation warning emitted by `TuistWeb.WarningsHeaderPlug` to old CLI clients was producing a wrong, customer-confusing message — e.g. *"Please upgrade to version **Runners Controller 0.9.0** for server-side features to continue working."* This PR fixes the two bugs combining to produce that.

### Bug 1 — filter looks at the wrong field

`Tuist.GitHub.Releases.get_latest_cli_release/1` filtered on the GitHub release `name` field:

```elixir
Enum.find(releases, fn release -> not String.contains?(release["name"], "@") end)
```

But on real GitHub releases for this repo:

| Release | `name` | `tag_name` |
|---|---|---|
| CLI | `"CLI 4.196.0"` | `"4.196.0"` |
| Server | `"Server 1.207.0"` | `"server@1.207.0"` |
| Runners Controller | `"Runners Controller 0.11.0"` | `"runners-controller@0.11.0"` |

The human-readable `name` never contains `"@"`, so the filter was a no-op and the *latest* release won regardless of type. Whenever a component release shipped after the most recent CLI release, the plug picked it up.

**Fix:** filter on `tag_name`, where the scoped format `<component>@<version>` actually distinguishes components from CLI releases.

### Bug 2 — message interpolates the wrong field

The plug built the user-facing message from `release.name`:

```
"... Please upgrade to version #{release.name} ..."
```

Even with the filter fixed, that yields *"Please upgrade to version CLI 4.196.0"*, which reads awkwardly ("version CLI version 4.196.0"). **Fix:** interpolate `release.tag_name` (`"4.196.0"`) — the bare semver users actually install.

## Tests

- Updated existing `releases_test.exs` fixtures to include `tag_name` and realistic `name` values, so they exercise the new filter.
- Rewrote the *"returns the latest CLI release if the latest release is an App release"* case as **"skips component releases (scoped tags) and returns the CLI release"**, modelled directly on the real GitHub release shape (humanized `name`, scoped `tag_name`). Component releases now use `name: "Runners Controller 0.11.0"` / `tag_name: "runners-controller@0.11.0"` — i.e. the exact regression case from the customer report.
- Updated the plug-test stubs to return both `:name` and `:tag_name`. The existing assertion on the deprecation message format (`"... Please upgrade to version 4.160.0 ..."`) now doubles as a regression test: a future revert to `release.name` would produce `"... version CLI 4.160.0 ..."` and fail.

## Scope

This is scoped to the warning-text bug. The unrelated `4.154.0` issue in the lower-than-floor deprecation test is fixed separately in [#11121](https://github.com/tuist/tuist/pull/11121); the two PRs touch non-overlapping lines and merge cleanly in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)