### PR TITLE
fix(server): handle GitHub log redirects manually

### DIFF
--- a/server/lib/tuist/runners/workers/fetch_logs_worker.ex
+++ b/server/lib/tuist/runners/workers/fetch_logs_worker.ex
@@ -59,6 +59,7 @@ defmodule Tuist.Runners.Workers.FetchLogsWorker do
   # amortising the per-INSERT overhead across enough rows to keep
   # the worker CPU-bound rather than network-bound.
   @batch_lines 1_000
+  @max_log_redirects 5
 
   @impl Oban.Worker
   def perform(%Oban.Job{
@@ -100,18 +101,20 @@ defmodule Tuist.Runners.Workers.FetchLogsWorker do
 
   defp stream_log(api_url, repository, workflow_job_id, account_id, token) do
     url = "#{api_url}/repos/#{repository}/actions/jobs/#{workflow_job_id}/logs"
+    stream_log_url(url, github_log_headers(token), workflow_job_id, account_id, 0)
+  end
+
+  defp stream_log_url(url, headers, workflow_job_id, account_id, redirect_count) do
     initial = new_stream_state(workflow_job_id, account_id)
 
     req_opts =
       [
         url: url,
-        headers: [
-          {"Authorization", "Bearer #{token}"},
-          {"Accept", "application/vnd.github+json"},
-          {"X-GitHub-Api-Version", "2022-11-28"}
-        ],
-        # Follow the 302 to the actual log payload (S3/Azure).
-        redirect: true,
+        headers: headers,
+        # Streaming responses and Req's redirect step don't compose here:
+        # GitHub first returns a 302 to a signed archive URL, then the
+        # archive body streams from that URL.
+        redirect: false,
         # Logs come back as plain text, not JSON.
         decode_body: false,
         into: fn {:data, chunk}, {req, resp} ->
@@ -138,11 +141,43 @@ defmodule Tuist.Runners.Workers.FetchLogsWorker do
       {:ok, %{status: 404}} ->
         {:error, :log_not_ready_yet}
 
+      {:ok, %{status: status} = resp} when status in [301, 302, 303, 307, 308] ->
+        follow_log_redirect(url, resp, workflow_job_id, account_id, redirect_count)
+
       {:ok, %{status: status, body: body}} ->
         {:error, {:unexpected_status, status, body}}
 
       {:error, reason} ->
         {:error, reason}
+    end
+  end
+
+  defp github_log_headers(token) do
+    [
+      {"Authorization", "Bearer #{token}"},
+      {"Accept", "application/vnd.github+json"},
+      {"X-GitHub-Api-Version", "2022-11-28"}
+    ]
+  end
+
+  defp follow_log_redirect(_url, _resp, _workflow_job_id, _account_id, redirect_count)
+       when redirect_count >= @max_log_redirects do
+    {:error, :too_many_log_redirects}
+  end
+
+  defp follow_log_redirect(url, resp, workflow_job_id, account_id, redirect_count) do
+    case Req.Response.get_header(resp, "location") do
+      [location | _] ->
+        redirected_url =
+          url
+          |> URI.parse()
+          |> URI.merge(URI.parse(location))
+          |> URI.to_string()
+
+        stream_log_url(redirected_url, [], workflow_job_id, account_id, redirect_count + 1)
+
+      [] ->
+        {:error, {:unexpected_status, resp.status, resp.body}}
     end
   end
 

--- a/server/test/tuist/runners/workers/fetch_logs_worker_test.exs
+++ b/server/test/tuist/runners/workers/fetch_logs_worker_test.exs
@@ -105,6 +105,49 @@ defmodule Tuist.Runners.Workers.FetchLogsWorkerTest do
       )
     end
 
+    test "follows GitHub's log archive redirect manually without forwarding the installation token" do
+      account = account_fixture()
+      enqueue(account, 9_910_005)
+      stub_gh_installation_token()
+
+      body = "2026-06-02T15:31:03.111111Z downloaded from signed URL\n"
+      signed_url = "https://objects.githubusercontent.com/github-production-repository-file-5/logs.txt"
+
+      expect(Req, :get, 2, fn opts ->
+        case Keyword.fetch!(opts, :url) do
+          "https://api.github.com/repos/tuist/tuist/actions/jobs/9910005/logs" ->
+            assert opts[:redirect] == false
+            assert {"Authorization", "Bearer ghs_test_token"} in opts[:headers]
+
+            {:ok,
+             %Req.Response{
+               status: 302,
+               headers: %{"location" => [signed_url]},
+               body: "",
+               private: %{}
+             }}
+
+          ^signed_url ->
+            assert opts[:redirect] == false
+            refute Enum.any?(opts[:headers], fn {name, _value} -> String.downcase(name) == "authorization" end)
+
+            resp = %Req.Response{status: 200, private: %{}}
+            {:cont, {_req, resp}} = opts[:into].({:data, body}, {opts, resp})
+            {:ok, resp}
+        end
+      end)
+
+      assert :ok = FetchLogsWorker.perform(%Oban.Job{args: args(9_910_005, account.id)})
+
+      [line] = JobLogs.list_for_job(9_910_005)
+      assert line.message == "downloaded from signed URL"
+
+      assert_enqueued(
+        worker: ArchiveLogsWorker,
+        args: %{workflow_job_id: 9_910_005, account_id: account.id}
+      )
+    end
+
     test "returns the error so Oban retries when GitHub hasn't published the log yet (404)" do
       account = account_fixture()
       enqueue(account, 9_910_002)


### PR DESCRIPTION
## What changed

- Disabled automatic redirects for the GitHub Actions job log streaming request.
- Added manual redirect handling for GitHub's log archive `Location` response.
- Kept GitHub installation headers only on the GitHub API request and intentionally dropped them when following the signed archive URL.
- Added a regression test covering the 302 archive redirect and token handling.

## Why

Sentry reported `TUIST-N3`, where `FetchLogsWorker` crashed while fetching job logs after GitHub returned a 302 from the Actions logs endpoint. The worker was streaming the response through Req's `:into` callback while also asking Req to auto-follow redirects.

## Root cause

Req's automatic redirect handling does not compose safely with this streaming response shape. The first response from GitHub is a redirect to a signed archive URL, and the streaming callback path can leave Req handling a tuple-shaped response instead of the map shape expected by the redirect step.

## Impact

Completed runner jobs whose logs are served through GitHub's redirect path can now be ingested instead of failing the Oban job with the Sentry crash. The signed archive request also avoids forwarding the GitHub installation token outside GitHub's API host.

## Validation

- `mix test test/tuist/runners/workers/fetch_logs_worker_test.exs:108`
- `mix test test/tuist/runners/workers/fetch_logs_worker_test.exs`
- `mix format lib/tuist/runners/workers/fetch_logs_worker.ex test/tuist/runners/workers/fetch_logs_worker_test.exs`
- `git diff --check`
