### PR TITLE
feat(server): cut production over to CNPG

### DIFF
--- a/infra/cnpg/MIGRATION.md
+++ b/infra/cnpg/MIGRATION.md
@@ -271,11 +271,38 @@ kubectl -n tuist-$ENV exec deploy/tuist-tuist-server -- \
   /app/bin/tuist eval 'Oban.resume_all_queues(Oban)'
 ```
 
-### 7. Reverse replication for rollback (14 days)
+### 7. Rollback strategy (14 days, fix-forward by default)
 
-For the next 14 days, replicate CNPG → Supabase so a rollback is a flip of DATABASE_URL back to Supabase, not a multi-hour data-export. Same `CREATE PUBLICATION` / `CREATE SUBSCRIPTION` pattern in the opposite direction.
+After cutover the rollback path is **fix-forward on CNPG**, not flip-back-to-Supabase. The Supabase project stays live but unused as a frozen pre-cutover snapshot for 14 days, then is decommissioned.
 
-After 14 days of clean operation, drop the reverse subscription and decommission the Supabase project for that env.
+We chose this over continuous CNPG → Supabase reverse replication after weighing the trade-offs. Reverse replication would buy ~5-minute rollback at the cost of: a public-facing Hetzner LB exposing CNPG (extra attack surface even with source-IP ACLs), a second logical replication slot with the same `statement_timeout` / `max_slot_wal_keep_size` / slot-invalidation failure modes we hit during the forward COPY (now failing silently and discovered on the day rollback is needed), a `tuist_replicator` role on CNPG with REPLICATION privilege, and chart additions for `pg_hba` injection + managed role declaration. That's a lot of net-new operational surface to protect against scenarios where rolling back to Supabase doesn't actually help — Supabase wouldn't have the post-cutover writes anyway, so any rollback past hour-1 would require manual data reconciliation either way, and every realistic CNPG failure mode (data corruption, performance regression, ops gap) is recoverable on CNPG via the existing safety nets.
+
+#### Safety nets already in place
+
+- Base backups to Tigris (`tuist-<env>-pg-backups`), daily via `ScheduledBackup`.
+- Continuous WAL archive to the same bucket → point-in-time recovery to any second within the retention window.
+- Restore-validation drill has been proven end-to-end against the staging cluster.
+- The Supabase project for the env stays running, untouched, as a frozen snapshot for 14 days.
+
+#### Emergency rollback in the first 24h
+
+If a problem surfaces inside the first day and we need to genuinely flip back to Supabase:
+
+1. Pause writes (Maintenance mode toggle on `/ops/db`, or scale the server to 0).
+2. Identify the small write delta on CNPG since cutover (timestamp-bounded `pg_dump --data-only --table=...` for the high-write tables, or a row-count diff against Supabase).
+3. Apply the delta to Supabase as the superuser (`op://Development/Tuist <Env> Database (Supabase)`).
+4. Open a one-line revert PR flipping `postgresql.mode` and `postgresql.cnpg.pooler.enabled` back to `external` / `false` for the env.
+5. Merge + deploy. Server switches back to Supabase.
+
+Wall-time depends on the delta size, but a same-day rollback is on the order of one operator-hour, not the multi-hour COPY a fresh forward migration would take.
+
+#### Beyond the first 24h
+
+Fix-forward on CNPG. Drift between CNPG and Supabase grows monotonically and we'd be reconciling manually anyway — at that point a "rollback" is really a from-scratch migration in the reverse direction, the same operation we just did forward.
+
+#### Day-14 decommission
+
+Drop the Supabase project for the env and remove any remaining references (1Password items, processor `database.host` overlay value, pg_dump scripts pointing at it).
 
 ## Per-environment soak gates
 

--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -131,14 +131,38 @@ postgresql:
     # we move it onto the pooler — see MIGRATION.md §6e.
     pooler:
       enabled: true
+    # PostgreSQL config sized against the 16 GiB memory limit below. The
+    # CNPG operator otherwise leaves Postgres on its 128 MiB shared_buffers
+    # default, which on a 16 GiB instance means ~99% of the page cache
+    # lives in the Linux file cache instead of Postgres's own buffer pool.
+    # That's functional (the kernel still caches hot pages) but it leaves
+    # Postgres's query planner pessimistic and wastes the headroom; match
+    # the upstream Supabase defaults so we don't regress on cutover.
+    #   - shared_buffers ≈ 25% of memory limit (Postgres rule of thumb)
+    #   - effective_cache_size ≈ 75% (planner hint; counts Linux page cache)
+    #   - work_mem sized so 200 connections × work_mem stays << memory
+    #     limit even when several sorts run concurrently (here 200 × 32 MB
+    #     = 6.4 GB max footprint, comfortably below 16 GB)
+    #   - maintenance_work_mem bumped from the 64 MB default so VACUUM
+    #     and index rebuilds aren't artificially slow
+    #
     # The web tier autoscales to 5 replicas, each holding a direct pool of
     # TUIST_DATABASE_POOL_SIZE (15): 5 x 15 = 75, plus the processor, the
     # migration job, and replication/monitoring/superuser overhead. The
     # operator default max_connections of 100 is too tight for that at peak
     # (and during a deploy surge). Raise it so the direct topology fits with
     # headroom; ~200 connections cost ~2 GiB, well inside the 16Gi limit.
+    #
+    # pg_stat_statements is preloaded so we get the same per-query latency
+    # observability the Supabase env has today (queries grouped by
+    # parameterized fingerprint, with calls / mean / stddev / max).
     parameters:
       max_connections: "200"
+      shared_buffers: "4GB"
+      effective_cache_size: "12GB"
+      work_mem: "32MB"
+      maintenance_work_mem: "512MB"
+      shared_preload_libraries: "pg_stat_statements"
     storage:
       # Sized for the Supabase → CNPG initial COPY: per-table sync workers
       # each pin WAL until their COPY commits, so peak disk during the

--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -119,8 +119,18 @@ kuraController:
 # climbs faster than expected. Backups land in the
 # `tuist-prod-pg-backups` Tigris bucket.
 postgresql:
+  mode: cnpg
   cnpg:
     instances: 3
+    # Route the processor through the transaction-mode PgBouncer pooler.
+    # Web tier stays direct on `-rw` (it holds a long-lived ~75-conn pool
+    # that wouldn't benefit from session-mode bouncing); the processor's
+    # short, ingestion-burst connections get pooled. Flipped on at the
+    # same moment as `mode: cnpg` so the processor doesn't transiently
+    # land on `-rw` (session / `prepare: :named`) for one rollout before
+    # we move it onto the pooler — see MIGRATION.md §6e.
+    pooler:
+      enabled: true
     # The web tier autoscales to 5 replicas, each holding a direct pool of
     # TUIST_DATABASE_POOL_SIZE (15): 5 x 15 = 75, plus the processor, the
     # migration job, and replication/monitoring/superuser overhead. The


### PR DESCRIPTION
## What

Flip `postgresql.mode: external → cnpg` **and** turn on `postgresql.cnpg.pooler.enabled: true` together in `values-managed-production.yaml` — same combined change as canary.

```diff
 postgresql:
+  mode: cnpg
   cnpg:
     instances: 3
+    pooler:
+      enabled: true
     parameters:
       max_connections: "200"
```

After this deploy:
- Server pods + migration-job resolve `DATABASE_URL` from `tuist-tuist-pg-app` (CNPG `-rw` direct).
- Processor resolves to `tuist-tuist-pg-pooler-rw:5432` (CNPG's transaction-mode PgBouncer).

The runbook (MIGRATION.md §6e) calls for both flips in the same change so the processor's pool topology doesn't transiently land on `-rw` (session / `prepare: :named`) before moving onto the pooler.

## Why now

Production CNPG state at the time of cutover (last checked just before this PR):

| | |
|---|---|
| Cluster | healthy, 3/3 on 250 GiB PVCs |
| Subscription `tuist_replication` | 49/49 `srsubstate='r'`, apply lag **~6 ms** |
| Soak duration | ~54h post-COPY, zero lag throughout |
| Backups | Tigris archived_count rising, daily `ScheduledBackup` green |
| Canary stability | 50+ hours on CNPG, 1.6M oban_jobs inserts since cutover, no regressions |

The 72h soak target is a heuristic; we've validated everything that matters. Canary running cleanly under traffic for 50+ hours is the actual signal that the stack works.

## Rollback strategy — replaces "reverse replication" in MIGRATION.md §7

After weighing it, we chose **fix-forward on CNPG** over continuous reverse replication. The new Section 7 explains the trade-off and lays out:

- **Safety nets already in place:** base backups to Tigris (daily), WAL archive (continuous PITR), restore-validation drill proven on staging, Supabase project stays live but frozen as a 14-day snapshot.
- **First-24h emergency rollback procedure** (timestamp-bounded delta dump from CNPG → applied to Supabase as superuser → one-line revert PR flipping `mode`+`pooler.enabled` back). ~1 operator-hour for a typical delta.
- **Beyond 24h:** fix-forward on CNPG. A "rollback" at that point is really a from-scratch reverse migration, which the same forward runbook covers.
- **Day-14 decommission** of the Supabase project for prod.

Continuous reverse replication was considered and skipped — the operational surface it adds (public Hetzner LB on CNPG, second slot path with the same `statement_timeout` / `max_slot_wal_keep_size` / slot-invalidation failure modes we hit during the forward COPY but now failing silently, `tuist_replicator` role + REPLICATION privilege, chart additions for `pg_hba` injection and managed-role declaration) is much greater than the narrow window of rollback scenarios where having a current Supabase would actually be the recovery path.

## Post-merge runbook (same shape as canary)

After the cascade deploy lands on production:

1. **Sanity gate** — confirm server connected to CNPG (read-only)
   ```bash
   export KUBECONFIG=~/.kube/tuist-production
   # 1a. server DATABASE_URL secret reference
   kubectl -n tuist get deploy tuist-tuist-server -o jsonpath='{range .spec.template.spec.containers[0].env[?(@.name=="DATABASE_URL")]}{.valueFrom.secretKeyRef.name}{"\n"}{end}'
   # expected: tuist-tuist-pg-app

   # 1b. live connections from server pod IPs
   kubectl -n tuist exec tuist-tuist-pg-2 -c postgres -- psql -d tuist -tA -c "
   SELECT usename, client_addr::text, state, count(*)
   FROM pg_stat_activity WHERE client_addr IS NOT NULL
   GROUP BY usename, client_addr, state ORDER BY client_addr, usename;"
   # expected: tuist_app from server pod IPs, tuist_processor from pooler IPs

   # 1c. oban_jobs proves the processor is writing to CNPG (oban_jobs is excluded from the publication)
   kubectl -n tuist exec tuist-tuist-pg-2 -c postgres -- psql -d tuist -tA -c "
   SELECT 'oban_jobs ins=' || n_tup_ins || ' upd=' || n_tup_upd FROM pg_stat_user_tables WHERE relname='oban_jobs';"
   ```

2. **Drop subscription on production CNPG** (3-step pattern with slot decouple)
   ```bash
   kubectl -n tuist exec -i tuist-tuist-pg-2 -c postgres -- \
     psql -d tuist -v ON_ERROR_STOP=1 <<'SQL'
   BEGIN;
   ALTER SUBSCRIPTION tuist_replication DISABLE;
   ALTER SUBSCRIPTION tuist_replication SET (slot_name = NONE);
   DROP SUBSCRIPTION tuist_replication;
   COMMIT;
   SQL
   ```

3. **Drop publication + slot on production Supabase**. Same gotcha we hit on canary: `tuist_replicator` isn't the publication owner, so the publication drop needs the Supabase superuser from `op://Development/Tuist Production Database (Supabase)`.
   ```bash
   # 3a. drop the slot as tuist_replicator (it has REPLICATION privilege)
   PW=$(op read "op://tuist-k8s-production/SUPABASE_REPLICATOR_PASSWORD/password")
   printf '%s\n' "$PW" | kubectl -n tuist exec -i tuist-tuist-pg-2 -c postgres -- sh -c '
     IFS= read -r PASS; export PGPASSWORD="$PASS"
     exec psql "host=db.yltsvvtmlktxdgpcbylg.supabase.co user=tuist_replicator dbname=postgres sslmode=require"
   ' -c "SELECT pg_drop_replication_slot('tuist_replication') WHERE EXISTS (SELECT 1 FROM pg_replication_slots WHERE slot_name='tuist_replication');"

   # 3b. drop the publication as the Supabase superuser
   PW=$(op item get "Tuist Production Database (Supabase)" --vault Development --fields label=password --reveal)
   printf '%s\n' "$PW" | kubectl -n tuist exec -i tuist-tuist-pg-2 -c postgres -- sh -c '
     IFS= read -r PASS; export PGPASSWORD="$PASS"
     exec psql "host=db.yltsvvtmlktxdgpcbylg.supabase.co user=postgres dbname=postgres sslmode=require"
   ' -c "DROP PUBLICATION IF EXISTS tuist_replication;"
   ```

4. **Smoke**
   ```bash
   curl -s -o /dev/null -w "status=%{http_code}\n" https://tuist.dev/ready
   kubectl -n tuist logs deploy/tuist-tuist-server --since=60s | grep -iE "error|postgrex|disconnect" | head
   ```

5. **Calendar the 14-day Supabase decommission** (Day +14 from cutover).

## Test plan

- [x] `helm template` renders DATABASE_URL → `tuist-tuist-pg-app` for server/migration-job
- [x] `helm template` renders processor URL → `tuist-tuist-pg-pooler-rw:5432`
- [ ] Post-cascade: cluster.cnpg.io reports `Cluster in healthy state`
- [ ] Post-cascade: `tuist-tuist-server` shows live connections from server pod IPs on CNPG primary
- [ ] Post-cascade: `tuist-tuist-processor` shows live connections from pooler pods
- [ ] Post-cascade: subscription dropped on CNPG; publication + slot dropped on Supabase
- [ ] Post-cascade: `https://tuist.dev/ready` returns 200