### PR TITLE
feat(server): tune Postgres + preload pg_stat_statements on staging + canary CNPG

### DIFF
--- a/infra/helm/tuist/values-managed-canary.yaml
+++ b/infra/helm/tuist/values-managed-canary.yaml
@@ -114,6 +114,22 @@ postgresql:
   mode: cnpg
   cnpg:
     instances: 2
+    # PostgreSQL config sized against the 8 GiB memory limit below. CNPG
+    # otherwise leaves Postgres on its 128 MiB shared_buffers default,
+    # which wastes the headroom; match the production tuning shape.
+    #   - shared_buffers ≈ 25% of memory limit
+    #   - effective_cache_size ≈ 75% (planner hint; counts Linux page cache)
+    #   - work_mem 32 MB; 100 connections × 32 MB peak (~3.2 GiB) fits the
+    #     8 GiB limit comfortably
+    #   - pg_stat_statements preloaded so the same per-query telemetry
+    #     production has is available in canary too — this is where we'd
+    #     catch a regression after a chart change before it reaches prod
+    parameters:
+      shared_buffers: "2GB"
+      effective_cache_size: "6GB"
+      work_mem: "32MB"
+      maintenance_work_mem: "512MB"
+      shared_preload_libraries: "pg_stat_statements"
     # Route the processor through the transaction-mode PgBouncer pooler so
     # this soak env matches production's post-CNPG-cutover topology
     # (processor pooled, web tier direct on -rw). CNPG's built-in

--- a/infra/helm/tuist/values-managed-staging.yaml
+++ b/infra/helm/tuist/values-managed-staging.yaml
@@ -119,6 +119,21 @@ postgresql:
   mode: cnpg
   cnpg:
     instances: 2
+    # PostgreSQL config sized against the 4 GiB memory limit below. CNPG
+    # otherwise leaves Postgres on its 128 MiB shared_buffers default,
+    # which wastes the headroom; match the production tuning shape.
+    #   - shared_buffers ≈ 25% of memory limit
+    #   - effective_cache_size ≈ 75% (planner hint; counts Linux page cache)
+    #   - work_mem kept conservative at 16 MB so 100 connections × 16 MB
+    #     stays well under the 4 GiB limit when several sorts run hot
+    #   - pg_stat_statements preloaded so the same per-query telemetry
+    #     production has is available in staging too
+    parameters:
+      shared_buffers: "1GB"
+      effective_cache_size: "3GB"
+      work_mem: "16MB"
+      maintenance_work_mem: "256MB"
+      shared_preload_libraries: "pg_stat_statements"
     # Route the processor through the transaction-mode PgBouncer pooler so
     # this soak env matches production's post-CNPG-cutover topology
     # (processor pooled, web tier direct on -rw). CNPG's built-in


### PR DESCRIPTION
## What

Mirror the production CNPG parameter tuning from #11128 onto staging and canary, sized for each env's memory limit. Also preload `pg_stat_statements` so canary has the same per-query latency telemetry as production — without it, regressions in query shape (slow Oban polls, new N+1 patterns) would only surface in production after the cascade promotes them, which is the exact gap canary is supposed to close.

```diff
 postgresql:
   mode: cnpg
   cnpg:
     instances: 2
+    parameters:
+      shared_buffers: \"1GB\" | \"2GB\"      # staging | canary (25% of memory limit)
+      effective_cache_size: \"3GB\" | \"6GB\" # 75% — planner hint
+      work_mem: \"16MB\" | \"32MB\"
+      maintenance_work_mem: \"256MB\" | \"512MB\"
+      shared_preload_libraries: \"pg_stat_statements\"
```

## Sizing rationale

CNPG leaves Postgres on its 128 MiB `shared_buffers` default. Functional (Linux's page cache compensates) but it wastes the in-cluster memory headroom and leaves the planner under-informed about what fits in cache. Standard 25% / 75% rule applied per env:

| env | mem limit | shared_buffers | effective_cache_size | work_mem |
|---|---|---|---|---|
| staging | 4 GiB | 1 GiB | 3 GiB | 16 MiB |
| canary | 8 GiB | 2 GiB | 6 GiB | 32 MiB |
| prod (PR #11128) | 16 GiB | 4 GiB | 12 GiB | 32 MiB |

`work_mem` on staging is kept at 16 MiB on purpose — with `max_connections=100` the peak sort/hash footprint is 1.6 GiB, well below the 4 GiB limit. Canary's 8 GiB budget tolerates 32 MiB the same way prod's does.

## Why pg_stat_statements specifically

Two reasons:

1. **Catch regressions in canary, not production.** When a new query shape hits production (e.g., the Oban `SELECT queue, state, count(id) FROM oban_jobs GROUP BY ...` patterns we just characterized at 1.3-1.5 s mean), canary should be the place we see it first. pg_stat_statements turns canary's existing soak window into a real performance gate.
2. **Same observability surface as Supabase.** Today's Supabase production has it installed by default and `/ops/db` (Tuist's ops UI) and the LiveDashboard both surface its output. Without preloading it on CNPG envs, the ops pages would show empty data post-cutover.

The extension is preloaded via `shared_preload_libraries`, so it requires a Postgres restart. CNPG handles that as a rolling restart — replica restarts first, then a switchover so the new replica becomes primary, then the demoted-primary restarts. No data loss; brief failover window during the switchover.

## Test plan

- [x] `helm template` renders the new parameters on both envs' `templates/postgresql-cnpg.yaml`
- [ ] After staging deploy: `SHOW shared_buffers` returns `1GB`, `SHOW shared_preload_libraries` returns `pg_stat_statements`
- [ ] After canary deploy: same for `2GB` / `pg_stat_statements`
- [ ] After both deploys: `SELECT count(*) FROM pg_extension WHERE extname='pg_stat_statements'` returns 1 (CNPG manages extension creation when the lib is preloaded; if not, a one-shot `CREATE EXTENSION pg_stat_statements;` covers it)