### PR TITLE
fix(server): move shared_preload_libraries out of CNPG parameters map

### DIFF
--- a/infra/helm/tuist/templates/postgresql-cnpg.yaml
+++ b/infra/helm/tuist/templates/postgresql-cnpg.yaml
@@ -52,8 +52,18 @@ spec:
   #
   # `parameters` sets server-level Postgres settings (notably
   # max_connections, which must clear the aggregate connection budget).
-  {{- if or .Values.postgresql.cnpg.parameters (gt (int .Values.postgresql.cnpg.instances) 1) }}
+  # `sharedPreloadLibraries` is a separate list on the CR rather than
+  # a parameter map entry because CNPG's admission webhook treats
+  # `shared_preload_libraries` as a fixed parameter (the operator
+  # manages its own required entries) and rejects it under `parameters`.
+  {{- if or .Values.postgresql.cnpg.parameters .Values.postgresql.cnpg.sharedPreloadLibraries (gt (int .Values.postgresql.cnpg.instances) 1) }}
   postgresql:
+    {{- with .Values.postgresql.cnpg.sharedPreloadLibraries }}
+    shared_preload_libraries:
+      {{- range . }}
+      - {{ . | quote }}
+      {{- end }}
+    {{- end }}
     {{- with .Values.postgresql.cnpg.parameters }}
     parameters:
       {{- range $key, $value := . }}

--- a/infra/helm/tuist/values-managed-canary.yaml
+++ b/infra/helm/tuist/values-managed-canary.yaml
@@ -114,6 +114,19 @@ postgresql:
   mode: cnpg
   cnpg:
     instances: 2
+    # PostgreSQL config sized against the 8 GiB memory limit below. CNPG
+    # otherwise leaves Postgres on its 128 MiB shared_buffers default;
+    # mirror the production tuning shape so canary catches any regression
+    # before it reaches prod.
+    parameters:
+      shared_buffers: "2GB"
+      effective_cache_size: "6GB"
+      work_mem: "32MB"
+      maintenance_work_mem: "512MB"
+    # See values.yaml for why this is a list at the CR level instead of
+    # an entry under `parameters`.
+    sharedPreloadLibraries:
+      - pg_stat_statements
     # Route the processor through the transaction-mode PgBouncer pooler so
     # this soak env matches production's post-CNPG-cutover topology
     # (processor pooled, web tier direct on -rw). CNPG's built-in

--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -162,7 +162,12 @@ postgresql:
       effective_cache_size: "12GB"
       work_mem: "32MB"
       maintenance_work_mem: "512MB"
-      shared_preload_libraries: "pg_stat_statements"
+    # `shared_preload_libraries` is a fixed parameter managed by the CNPG
+    # operator and rejected by the admission webhook if listed under
+    # `parameters` above — extra libs go in this list instead and the
+    # chart renders them to `spec.postgresql.shared_preload_libraries`.
+    sharedPreloadLibraries:
+      - pg_stat_statements
     storage:
       # Sized for the Supabase → CNPG initial COPY: per-table sync workers
       # each pin WAL until their COPY commits, so peak disk during the

--- a/infra/helm/tuist/values-managed-staging.yaml
+++ b/infra/helm/tuist/values-managed-staging.yaml
@@ -119,6 +119,19 @@ postgresql:
   mode: cnpg
   cnpg:
     instances: 2
+    # PostgreSQL config sized against the 4 GiB memory limit below. CNPG
+    # otherwise leaves Postgres on its 128 MiB shared_buffers default;
+    # mirror the production tuning shape so canary catches any regression
+    # before it reaches prod.
+    parameters:
+      shared_buffers: "1GB"
+      effective_cache_size: "3GB"
+      work_mem: "16MB"
+      maintenance_work_mem: "256MB"
+    # See values.yaml for why this is a list at the CR level instead of
+    # an entry under `parameters`.
+    sharedPreloadLibraries:
+      - pg_stat_statements
     # Route the processor through the transaction-mode PgBouncer pooler so
     # this soak env matches production's post-CNPG-cutover topology
     # (processor pooled, web tier direct on -rw). CNPG's built-in

--- a/infra/helm/tuist/values.yaml
+++ b/infra/helm/tuist/values.yaml
@@ -1274,6 +1274,13 @@ postgresql:
     # silently hit the ceiling. See infra/cnpg/MIGRATION.md for the budget.
     parameters:
       max_connections: "100"
+    # Extra Postgres libraries to preload via shared_preload_libraries.
+    # Kept separate from `parameters` because CNPG's admission webhook
+    # rejects shared_preload_libraries set there — it's a fixed
+    # parameter the operator manages internally. The chart renders this
+    # list to `spec.postgresql.shared_preload_libraries` on the Cluster
+    # CR, the supported path.
+    sharedPreloadLibraries: []
     # PgBouncer connection pooler (CNPG Pooler CR). Disabled by default.
     # Transaction-mode pooler for the PROCESSOR only, matching its Supabase
     # Supavisor :6543 path (prepare: :unnamed). The web tier is intentionally


### PR DESCRIPTION
## What broke

Production cutover run [#27072881658](https://github.com/tuist/tuist/actions/runs/27072881658) failed on `helm upgrade --install` with:

```
cannot patch \"tuist-tuist-pg\" with kind Cluster: admission webhook
\"vcluster.cnpg.io\" denied the request: Cluster.cluster.cnpg.io
\"tuist-tuist-pg\" is invalid:
  spec.postgresql.parameters.shared_preload_libraries:
    Invalid value: \"pg_stat_statements\": Can't set fixed configuration parameter
```

CNPG treats `shared_preload_libraries` as a fixed parameter (the operator manages its own required preloaded entries) and rejects it under `spec.postgresql.parameters`. The supported location is `spec.postgresql.shared_preload_libraries`, rendered as a list.

PR #11128 put `shared_preload_libraries: \"pg_stat_statements\"` under `parameters`; the webhook caught it and helm's `--atomic` rolled back cleanly. Production stayed on Supabase throughout, CNPG cluster and subscription unaffected.

## What this PR does

1. **Chart template** — `infra/helm/tuist/templates/postgresql-cnpg.yaml` adds a `spec.postgresql.shared_preload_libraries` block fed from a new values key `postgresql.cnpg.sharedPreloadLibraries` (list).
2. **Chart values default** — `infra/helm/tuist/values.yaml` declares `sharedPreloadLibraries: []` with a comment explaining the location requirement.
3. **Production overlay** — moves `pg_stat_statements` out of the `parameters` map and into the new list. Other tuning (`shared_buffers`, `effective_cache_size`, etc.) stays where it is.
4. **Canary + staging overlays** — adds the same parameter tuning + `pg_stat_statements` preload that PR #11130 was meant to land, but with the correct CR location. **PR #11130 should be closed after this merges.**

## Render check

```
production:
  postgresql:
    shared_preload_libraries:
      - \"pg_stat_statements\"
    parameters:
      max_connections: \"200\"
      shared_buffers: \"4GB\"
      effective_cache_size: \"12GB\"
      work_mem: \"32MB\"
      maintenance_work_mem: \"512MB\"

canary:
  postgresql:
    shared_preload_libraries: [\"pg_stat_statements\"]
    parameters:
      shared_buffers: \"2GB\"   effective_cache_size: \"6GB\"
      work_mem: \"32MB\"      maintenance_work_mem: \"512MB\"
      max_connections: \"100\"

staging:
  postgresql:
    shared_preload_libraries: [\"pg_stat_statements\"]
    parameters:
      shared_buffers: \"1GB\"   effective_cache_size: \"3GB\"
      work_mem: \"16MB\"      maintenance_work_mem: \"256MB\"
      max_connections: \"100\"
```

## Retry the production cutover

After this merges, re-trigger the cutover deploy with:

```bash
gh workflow run server-deployment.yml --ref main -f environment=production
```

Same cutover behavior as PR #11128 originally intended — the only difference is CNPG accepts the patch now. The runbook in MIGRATION.md §6e and §7 from #11128 is unchanged.

## Test plan

- [x] `helm template` renders all 3 env overlays with `shared_preload_libraries` at `spec.postgresql.shared_preload_libraries: [\"pg_stat_statements\"]`
- [ ] After staging deploy: `SHOW shared_preload_libraries;` includes `pg_stat_statements`
- [ ] After canary deploy: same
- [ ] After production cutover: same + cutover lands cleanly without rollback