### PR TITLE
fix(server): stop OrphanedStampedPodsWorker from killing live runner pods

### DIFF
--- a/server/lib/tuist/runners/runner_sessions.ex
+++ b/server/lib/tuist/runners/runner_sessions.ex
@@ -180,4 +180,28 @@ defmodule Tuist.Runners.RunnerSessions do
   defp earlier(%DateTime{} = a, %DateTime{} = b) do
     if DateTime.before?(a, b), do: a, else: b
   end
+
+  @doc """
+  Returns the set of `pod_name`s that currently hold an *open*
+  billing session (`is_nil(ended_at)`).
+
+  Used by `OrphanedStampedPodsWorker` as a shape-independent proof
+  that dispatch fully committed for a Pod: `open/1` is only called
+  inside `Tuist.Runners.serve_claim/5`'s success branch, after every
+  step that could trigger `release_safely/3`. So a Pod with an open
+  session can never be the wedge that worker exists to clean up —
+  it received its JIT and is (or just was) running a customer job.
+
+  Closes happen via `close_by_pod_name/2` from the runners-controller
+  reporting pod-stop, so a closed session means the Pod actually
+  stopped — at which point reaping it is harmless.
+  """
+  def live_pod_names do
+    RunnerSession
+    |> where([s], is_nil(s.ended_at))
+    |> select([s], s.pod_name)
+    |> distinct(true)
+    |> Repo.all()
+    |> MapSet.new()
+  end
 end

--- a/server/lib/tuist/runners/workers/orphaned_stamped_pods_worker.ex
+++ b/server/lib/tuist/runners/workers/orphaned_stamped_pods_worker.ex
@@ -73,31 +73,44 @@ defmodule Tuist.Runners.Workers.OrphanedStampedPodsWorker do
   customer Pod — observable from GitHub's side as a runner that
   "lost communication with the server."
 
-  The Kubernetes Pod's `runner` container state is the ground truth
-  for "did this Pod actually start executing a job" — but only in
-  the **Linux split-container shape**. There the `runner` container
-  is gated behind the `poller` init container, so it reaches
-  `started=true` only once the poller successfully claimed *and*
-  staged a JIT — exactly the transition that means "JIT was
-  delivered, the runner is or was executing a customer job." We
-  refuse to reap any Linux Pod whose `runner` container has reached
-  `started=true` or `terminated`, even when the claim is missing.
-  The wedge signature this worker was built for (poller poll-loops
-  forever without ever receiving a JIT) still trips the reap
-  because the `runner` container never leaves `waiting`.
+  Two independent signals shield Pods that are actually executing,
+  layered for shape coverage:
 
-  The macOS Pod shape is single-container: the same `runner`
-  container runs the poll loop inside the Tart VM and execs
-  `./run.sh` in place on a successful claim. `started=true` is true
-  the moment the VM boots — long before any dispatch — so it is
-  NOT a signal that a customer job began. The guard is therefore
-  scoped to Pods that carry a `poller` init container (the
-  discriminator), preserving the wedge cleanup the worker exists
-  for on macOS. A `release_safely/3`-induced silent delete on a
-  live macOS job is a known gap of this fix; closing it requires a
-  signal that distinguishes "macOS polling" from "macOS executing"
-  (e.g., a server-confirmed live `RunnerSession`), which is left
-  for a follow-up.
+  1. **Open `RunnerSession`** (shape-independent). `open/1` is
+     called on the success branch of `serve_claim/5`, AFTER every
+     step that could trigger `release_safely/3` (mint_jit,
+     `mark_running`, `record_running_safe`). An open session is
+     therefore proof that the full dispatch committed — the JIT was
+     returned to the Pod and the runner is or was running a
+     customer job. Sessions are closed only by the controller's
+     `PodLifecycleReconciler` reporting `pods/stopped` once the
+     Pod actually stops. So a live build always has an open
+     session, regardless of whether the Pod is Linux or macOS.
+
+  2. **Linux `runner` container started/terminated** (Linux only).
+     In the split-container shape the `runner` container is gated
+     behind the `poller` init container: it reaches `started=true`
+     only once the poller successfully claimed AND staged a JIT.
+     This catches the post-job cleanup window where the session
+     has been closed (controller already reported `pods/stopped`)
+     but the Pod has not yet been reaped by the Pool reconciler —
+     `state.terminated` is set, and we defer to the reconciler so
+     it can log the runner's exit code via `#11109` instead of
+     racing it with a silent reap here.
+
+     macOS Pods are single-container: the same `runner` container
+     runs the poll loop inside the Tart VM and execs `./run.sh`
+     in place on a successful claim. `started=true` is true the
+     moment the VM boots — long before any dispatch — so it is
+     NOT a signal that a customer job began. We discriminate by
+     spec (presence of a `poller` init container) and apply this
+     check only when it carries useful information.
+
+  The wedge signature this worker was built for (poller polls
+  forever without ever receiving a JIT) still trips the reap
+  because: claim absent, session absent (open was never called),
+  and in the Linux case the runner container never leaves
+  `waiting`.
 
   The check is intentionally conservative: it prefers leaking a
   Pod for one more reconcile cycle (the Pool reconciler will
@@ -110,6 +123,7 @@ defmodule Tuist.Runners.Workers.OrphanedStampedPodsWorker do
   alias Tuist.Environment
   alias Tuist.Kubernetes.Client, as: K8sClient
   alias Tuist.Runners.Claims
+  alias Tuist.Runners.RunnerSessions
   alias Tuist.Runners.Telemetry
 
   require Logger
@@ -135,7 +149,13 @@ defmodule Tuist.Runners.Workers.OrphanedStampedPodsWorker do
   end
 
   defp reap_orphans(namespace, pods) do
-    live = Claims.live_pod_names()
+    # Two independent "this Pod is in flight" signals, unioned. Claims
+    # cover the normal busy state; sessions cover the gap where the
+    # claim was released after dispatch committed but before the Pod
+    # actually stopped (the silent-delete class this worker has been
+    # observed to produce on a `Claims.release` race). Pods is read
+    # *before* both sets — same race-safety argument as `live`.
+    live = MapSet.union(Claims.live_pod_names(), RunnerSessions.live_pod_names())
     cutoff = DateTime.add(DateTime.utc_now(), -@grace_seconds, :second)
 
     reaped =

--- a/server/lib/tuist/runners/workers/orphaned_stamped_pods_worker.ex
+++ b/server/lib/tuist/runners/workers/orphaned_stamped_pods_worker.ex
@@ -73,21 +73,36 @@ defmodule Tuist.Runners.Workers.OrphanedStampedPodsWorker do
   customer Pod — observable from GitHub's side as a runner that
   "lost communication with the server."
 
-  The Kubernetes pod itself carries the ground truth for "did this
-  Pod actually start executing a job": the `runner` container's
-  status. In the Linux token-isolation shape the `runner` container
-  is gated behind the `poller` init container, so it only starts
-  once the poller successfully claimed *and* staged a JIT — exactly
-  the transition that means "JIT was delivered, the runner is or
-  was executing a customer job." We refuse to reap any Pod whose
-  `runner` container has reached `started=true` or `terminated`,
-  even when the claim is missing. The orphan signature this worker
-  was built for (poller poll-loops forever without ever receiving a
-  JIT) still trips the reap because the `runner` container never
-  leaves `waiting`. The check is intentionally conservative: it
-  prefers leaking a Pod for one more reconcile cycle (the Pool
-  reconciler will eventually reap it once the runner exits) over
-  killing a live build.
+  The Kubernetes Pod's `runner` container state is the ground truth
+  for "did this Pod actually start executing a job" — but only in
+  the **Linux split-container shape**. There the `runner` container
+  is gated behind the `poller` init container, so it reaches
+  `started=true` only once the poller successfully claimed *and*
+  staged a JIT — exactly the transition that means "JIT was
+  delivered, the runner is or was executing a customer job." We
+  refuse to reap any Linux Pod whose `runner` container has reached
+  `started=true` or `terminated`, even when the claim is missing.
+  The wedge signature this worker was built for (poller poll-loops
+  forever without ever receiving a JIT) still trips the reap
+  because the `runner` container never leaves `waiting`.
+
+  The macOS Pod shape is single-container: the same `runner`
+  container runs the poll loop inside the Tart VM and execs
+  `./run.sh` in place on a successful claim. `started=true` is true
+  the moment the VM boots — long before any dispatch — so it is
+  NOT a signal that a customer job began. The guard is therefore
+  scoped to Pods that carry a `poller` init container (the
+  discriminator), preserving the wedge cleanup the worker exists
+  for on macOS. A `release_safely/3`-induced silent delete on a
+  live macOS job is a known gap of this fix; closing it requires a
+  signal that distinguishes "macOS polling" from "macOS executing"
+  (e.g., a server-confirmed live `RunnerSession`), which is left
+  for a follow-up.
+
+  The check is intentionally conservative: it prefers leaking a
+  Pod for one more reconcile cycle (the Pool reconciler will
+  eventually reap it once the runner exits) over killing a live
+  build.
   """
 
   use Oban.Worker, queue: :default, max_attempts: 1
@@ -150,17 +165,50 @@ defmodule Tuist.Runners.Workers.OrphanedStampedPodsWorker do
     is_binary(name) and
       not MapSet.member?(live, name) and
       created_before?(pod, cutoff) and
-      not runner_started?(pod)
+      not linux_runner_executing?(pod)
   end
 
-  # True if the Pod's `runner` container has begun executing — i.e.,
-  # the poller staged a JIT and the runner container started, OR the
-  # runner has already executed and terminated. In the token-isolation
-  # shape this is unambiguous proof that a JIT was delivered and the
-  # Pod is or was running a customer job; reaping it would kill (or
-  # has just killed) a live build. See the "Live-execution guard"
-  # section of the moduledoc.
-  defp runner_started?(pod) do
+  # True if the Pod is a Linux split-container runner whose `runner`
+  # container has begun executing a job — i.e., the `poller` init
+  # container successfully staged a JIT and kubelet started the
+  # `runner` container, OR the runner has already executed and
+  # terminated.
+  #
+  # ## Why this is Linux-only
+  #
+  # The Linux Pod shape isolates dispatch from execution across two
+  # containers: a `poller` init container holds the SA token and
+  # polls for a claim; only after it stages a JIT does kubelet start
+  # the credential-free `runner` container that runs `./run.sh`. So
+  # the `runner` container reaching `started=true` is unambiguous
+  # proof that a JIT was delivered and the Pod is or was running a
+  # customer job.
+  #
+  # The macOS Pod shape is single-container: the same `runner`
+  # container runs the poll loop (`dispatch-poll.sh`) inside the
+  # Tart VM and, on a successful claim, execs `./run.sh` in place.
+  # That means `started=true` is true the moment the VM boots — long
+  # before any dispatch has happened — so it is NOT a signal that a
+  # customer job has begun. Applying the guard to macOS would turn
+  # the worker into a no-op for that shape: a stamped/no-claim macOS
+  # Pod (the exact wedge `release_safely/3` can produce) would be
+  # protected indefinitely, and the macOS poll loop's
+  # retry-on-5xx-forever behaviour would never get cleaned up.
+  #
+  # We discriminate by spec: only the Linux shape carries a `poller`
+  # init container.
+  defp linux_runner_executing?(pod) do
+    linux_split_container?(pod) and runner_container_started?(pod)
+  end
+
+  defp linux_split_container?(pod) do
+    pod
+    |> get_in(["spec", "initContainers"])
+    |> List.wrap()
+    |> Enum.any?(&(&1["name"] == "poller"))
+  end
+
+  defp runner_container_started?(pod) do
     pod
     |> get_in(["status", "containerStatuses"])
     |> List.wrap()

--- a/server/lib/tuist/runners/workers/orphaned_stamped_pods_worker.ex
+++ b/server/lib/tuist/runners/workers/orphaned_stamped_pods_worker.ex
@@ -54,6 +54,40 @@ defmodule Tuist.Runners.Workers.OrphanedStampedPodsWorker do
   exiting anyway, and the delete is idempotent). A `@grace_seconds`
   floor on Pod age is belt-and-suspenders against clock skew and
   keeps brand-new Pods out of scope.
+
+  ## Live-execution guard
+
+  The stamp-then-no-claim signature was treated as unambiguous proof
+  of a wedge above — "an owner-stamped Pod should always have a
+  matching claim." That invariant breaks if anything releases the
+  PG claim *after* dispatch already delivered the JIT to the Pod
+  and the runner started executing a job. `release_safely/3` is the
+  documented trigger: it fires from `serve_claim/5`'s `with`-else
+  on any post-stamp error (mint blip, `mark_running` PG error,
+  `record_running_safe` CH hiccup). The dispatch fails closed and
+  the JIT never reaches the Pod, so reaping is correct. But any
+  *other* path that reaches `Claims.release`/`Claims.complete`
+  while the runner is mid-job (a stale webhook, an orphan-worker
+  false positive, future code that touches the claim table) would
+  surface here as "stamped, no claim" and force-delete a live
+  customer Pod — observable from GitHub's side as a runner that
+  "lost communication with the server."
+
+  The Kubernetes pod itself carries the ground truth for "did this
+  Pod actually start executing a job": the `runner` container's
+  status. In the Linux token-isolation shape the `runner` container
+  is gated behind the `poller` init container, so it only starts
+  once the poller successfully claimed *and* staged a JIT — exactly
+  the transition that means "JIT was delivered, the runner is or
+  was executing a customer job." We refuse to reap any Pod whose
+  `runner` container has reached `started=true` or `terminated`,
+  even when the claim is missing. The orphan signature this worker
+  was built for (poller poll-loops forever without ever receiving a
+  JIT) still trips the reap because the `runner` container never
+  leaves `waiting`. The check is intentionally conservative: it
+  prefers leaking a Pod for one more reconcile cycle (the Pool
+  reconciler will eventually reap it once the runner exits) over
+  killing a live build.
   """
 
   use Oban.Worker, queue: :default, max_attempts: 1
@@ -115,7 +149,35 @@ defmodule Tuist.Runners.Workers.OrphanedStampedPodsWorker do
 
     is_binary(name) and
       not MapSet.member?(live, name) and
-      created_before?(pod, cutoff)
+      created_before?(pod, cutoff) and
+      not runner_started?(pod)
+  end
+
+  # True if the Pod's `runner` container has begun executing — i.e.,
+  # the poller staged a JIT and the runner container started, OR the
+  # runner has already executed and terminated. In the token-isolation
+  # shape this is unambiguous proof that a JIT was delivered and the
+  # Pod is or was running a customer job; reaping it would kill (or
+  # has just killed) a live build. See the "Live-execution guard"
+  # section of the moduledoc.
+  defp runner_started?(pod) do
+    pod
+    |> get_in(["status", "containerStatuses"])
+    |> List.wrap()
+    |> Enum.find(&(&1["name"] == "runner"))
+    |> case do
+      nil ->
+        false
+
+      status ->
+        # `started: true` flips on once the container is up; it can
+        # flip back to false on termination, so also accept a present
+        # `state.terminated` or `lastState.terminated` as proof the
+        # runner already executed.
+        Map.get(status, "started") == true or
+          not is_nil(get_in(status, ["state", "terminated"])) or
+          not is_nil(get_in(status, ["lastState", "terminated"]))
+    end
   end
 
   defp created_before?(pod, cutoff) do

--- a/server/test/test_helper.exs
+++ b/server/test/test_helper.exs
@@ -134,6 +134,7 @@ Mimic.copy(Tuist.Runners.Claims)
 Mimic.copy(Tuist.Runners.Dispatch)
 Mimic.copy(Tuist.Runners.Jobs)
 Mimic.copy(Tuist.Runners.JobSteps)
+Mimic.copy(Tuist.Runners.RunnerSessions)
 Mimic.copy(Tuist.Kubernetes.Client)
 Mimic.copy(Tuist.Tasks)
 

--- a/server/test/tuist/runners/runner_sessions_test.exs
+++ b/server/test/tuist/runners/runner_sessions_test.exs
@@ -82,4 +82,37 @@ defmodule Tuist.Runners.RunnerSessionsTest do
       end
     end
   end
+
+  describe "live_pod_names/0" do
+    test "returns the pod_names of sessions whose ended_at is nil" do
+      account = account_fixture()
+      session_fixture(account, pod_name: "pod-open-1", ended_at: nil)
+      session_fixture(account, pod_name: "pod-open-2", ended_at: nil)
+      session_fixture(account, pod_name: "pod-closed", ended_at: DateTime.utc_now())
+
+      names = RunnerSessions.live_pod_names()
+
+      assert MapSet.member?(names, "pod-open-1")
+      assert MapSet.member?(names, "pod-open-2")
+      refute MapSet.member?(names, "pod-closed")
+    end
+
+    test "deduplicates pod_names across multiple open sessions for the same pod" do
+      # Re-claims insert new RunnerSession rows for the same pod_name
+      # (see the module doc). The protect-set is a MapSet of names, so
+      # the duplicate must collapse cleanly.
+      account = account_fixture()
+      session_fixture(account, pod_name: "pod-reclaim", ended_at: nil)
+      session_fixture(account, pod_name: "pod-reclaim", ended_at: nil)
+
+      assert MapSet.size(RunnerSessions.live_pod_names()) == 1
+    end
+
+    test "returns an empty set when no sessions are open" do
+      account = account_fixture()
+      session_fixture(account, pod_name: "pod-already-closed", ended_at: DateTime.utc_now())
+
+      assert MapSet.equal?(RunnerSessions.live_pod_names(), MapSet.new())
+    end
+  end
 end

--- a/server/test/tuist/runners/workers/orphaned_stamped_pods_worker_test.exs
+++ b/server/test/tuist/runners/workers/orphaned_stamped_pods_worker_test.exs
@@ -13,8 +13,38 @@ defmodule Tuist.Runners.Workers.OrphanedStampedPodsWorkerTest do
   @namespace "tuist-runners"
   @owner_label "tuist.dev/runner-pool-owner"
 
-  defp pod(name, created_at) do
-    %{"metadata" => %{"name" => name, "creationTimestamp" => created_at}}
+  defp pod(name, created_at, container_statuses \\ []) do
+    %{
+      "metadata" => %{"name" => name, "creationTimestamp" => created_at},
+      "status" => %{"containerStatuses" => container_statuses}
+    }
+  end
+
+  # The wedge state this worker exists to clean up: poller poll-loops
+  # forever without claiming a JIT, so the `runner` container never
+  # starts. kubelet reports it as waiting on the init container.
+  defp runner_waiting do
+    [%{"name" => "runner", "started" => false, "state" => %{"waiting" => %{"reason" => "PodInitializing"}}}]
+  end
+
+  # A live job: poller staged the JIT, kubelet started the runner
+  # container, the `started` gate has flipped on. The Pod is mid-build
+  # and must not be force-deleted regardless of the claim state.
+  defp runner_executing do
+    [%{"name" => "runner", "started" => true, "state" => %{"running" => %{"startedAt" => "2026-06-06T21:30:08Z"}}}]
+  end
+
+  # The narrow window between the runner exiting and the reconciler
+  # reaping the Pod. `started` flips back to false on termination, so
+  # the guard reads `state.terminated` instead.
+  defp runner_terminated do
+    [
+      %{
+        "name" => "runner",
+        "started" => false,
+        "state" => %{"terminated" => %{"exitCode" => 0, "reason" => "Completed"}}
+      }
+    ]
   end
 
   # Comfortably outside the 300s grace window.
@@ -105,6 +135,92 @@ defmodule Tuist.Runners.Workers.OrphanedStampedPodsWorkerTest do
 
       reject(&Claims.live_pod_names/0)
       reject(&K8sClient.delete_runner/2)
+
+      assert :ok = OrphanedStampedPodsWorker.perform(%Oban.Job{})
+    end
+
+    test "leaves a stamped pod whose runner container is executing, even when the claim is missing" do
+      # The class of incident this guard exists for: dispatch stamped
+      # the label, the JIT was delivered to the Pod, the runner started
+      # executing a customer job — and then *something* released the
+      # PG claim (a stale webhook, a future bug, a code path that
+      # reaches Claims.release while the runner is live). Without the
+      # guard this worker would force-delete the running Pod and the
+      # job would surface on GitHub as "lost communication with the
+      # server." With the guard we trust the `started=true` signal on
+      # the runner container and skip the reap.
+      expect(K8sClient, :list_pods, fn @namespace, _selector ->
+        {:ok, [pod("runner-live-build", aged(), runner_executing())]}
+      end)
+
+      expect(Claims, :live_pod_names, fn -> MapSet.new() end)
+
+      reject(&K8sClient.delete_runner/2)
+
+      assert :ok = OrphanedStampedPodsWorker.perform(%Oban.Job{})
+    end
+
+    test "leaves a stamped pod whose runner container has already terminated" do
+      # Narrow window: the runner exited, the Pod is in cleanup, the
+      # Pool reconciler hasn't reaped it yet. `started` flips back to
+      # false on termination — the guard reads `state.terminated`
+      # instead so we don't delete the Pod twice.
+      expect(K8sClient, :list_pods, fn @namespace, _selector ->
+        {:ok, [pod("runner-finished", aged(), runner_terminated())]}
+      end)
+
+      expect(Claims, :live_pod_names, fn -> MapSet.new() end)
+
+      reject(&K8sClient.delete_runner/2)
+
+      assert :ok = OrphanedStampedPodsWorker.perform(%Oban.Job{})
+    end
+
+    test "still reaps a stamped pod whose runner container is waiting on the poller" do
+      # The original wedge signature: the poller never claimed a JIT,
+      # so the runner container stays in `waiting`. `started=false`
+      # AND no `terminated` state — guard does not apply, reap fires.
+      expect(K8sClient, :list_pods, fn @namespace, _selector ->
+        {:ok, [pod("runner-wedged", aged(), runner_waiting())]}
+      end)
+
+      expect(Claims, :live_pod_names, fn -> MapSet.new() end)
+
+      expect(K8sClient, :delete_runner, fn @namespace, "runner-wedged" -> :ok end)
+
+      assert :ok = OrphanedStampedPodsWorker.perform(%Oban.Job{})
+    end
+
+    test "reaps a stamped pod with no containerStatuses (very early lifecycle, no JIT yet)" do
+      # If the Pod has no containerStatuses at all (scheduling/pull
+      # phase before kubelet reports any container), the runner has
+      # not started; the existing 5-min grace window already shields
+      # legitimate early-lifecycle Pods, so any Pod past the grace
+      # window with no runner status is a real orphan.
+      expect(K8sClient, :list_pods, fn @namespace, _selector ->
+        {:ok, [pod("runner-prestart", aged())]}
+      end)
+
+      expect(Claims, :live_pod_names, fn -> MapSet.new() end)
+
+      expect(K8sClient, :delete_runner, fn @namespace, "runner-prestart" -> :ok end)
+
+      assert :ok = OrphanedStampedPodsWorker.perform(%Oban.Job{})
+    end
+
+    test "reaps only the wedged orphan in a mixed batch with live and finished runners" do
+      expect(K8sClient, :list_pods, fn @namespace, _selector ->
+        {:ok,
+         [
+           pod("runner-wedged", aged(), runner_waiting()),
+           pod("runner-live-build", aged(), runner_executing()),
+           pod("runner-finished", aged(), runner_terminated())
+         ]}
+      end)
+
+      expect(Claims, :live_pod_names, fn -> MapSet.new() end)
+
+      expect(K8sClient, :delete_runner, fn @namespace, "runner-wedged" -> :ok end)
 
       assert :ok = OrphanedStampedPodsWorker.perform(%Oban.Job{})
     end

--- a/server/test/tuist/runners/workers/orphaned_stamped_pods_worker_test.exs
+++ b/server/test/tuist/runners/workers/orphaned_stamped_pods_worker_test.exs
@@ -6,6 +6,7 @@ defmodule Tuist.Runners.Workers.OrphanedStampedPodsWorkerTest do
   alias Tuist.Environment
   alias Tuist.Kubernetes.Client, as: K8sClient
   alias Tuist.Runners.Claims
+  alias Tuist.Runners.RunnerSessions
   alias Tuist.Runners.Workers.OrphanedStampedPodsWorker
 
   setup :verify_on_exit!
@@ -27,7 +28,7 @@ defmodule Tuist.Runners.Workers.OrphanedStampedPodsWorkerTest do
   # macOS single-container shape: no `poller` init container. The
   # runner container is `started=true` while merely polling, so the
   # guard must NOT treat that as proof of execution on this shape.
-  defp macos_pod(name, created_at, container_statuses \\ []) do
+  defp macos_pod(name, created_at, container_statuses) do
     %{
       "metadata" => %{"name" => name, "creationTimestamp" => created_at},
       "spec" => %{"initContainers" => []},
@@ -72,6 +73,9 @@ defmodule Tuist.Runners.Workers.OrphanedStampedPodsWorkerTest do
 
   setup do
     stub(Environment, :runners_namespace, fn -> @namespace end)
+    # Default: no open sessions. Tests that exercise the session
+    # guard override this per-case.
+    stub(RunnerSessions, :live_pod_names, fn -> MapSet.new() end)
     :ok
   end
 
@@ -246,6 +250,45 @@ defmodule Tuist.Runners.Workers.OrphanedStampedPodsWorkerTest do
       expect(Claims, :live_pod_names, fn -> MapSet.new() end)
 
       expect(K8sClient, :delete_runner, fn @namespace, "runner-macos-leak" -> :ok end)
+
+      assert :ok = OrphanedStampedPodsWorker.perform(%Oban.Job{})
+    end
+
+    test "leaves a macOS stamped pod with an open session even when the claim is missing" do
+      # The macOS analogue of the Linux live-runner protection:
+      # dispatch fully committed (`RunnerSessions.open/1` only runs on
+      # the success branch of `serve_claim/5`, after every step that
+      # could fire `release_safely/3`), then *something* released the
+      # PG claim while the runner is mid-job (a stale webhook, an
+      # `OrphanedRunnersWorker` false positive). On macOS the
+      # `runner` container's `started=true` is uninformative, so the
+      # session is the only signal that says "this pod received its
+      # JIT and is running a customer job."
+      expect(K8sClient, :list_pods, fn @namespace, _selector ->
+        {:ok, [macos_pod("runner-macos-live", aged(), runner_executing())]}
+      end)
+
+      expect(Claims, :live_pod_names, fn -> MapSet.new() end)
+      expect(RunnerSessions, :live_pod_names, fn -> MapSet.new(["runner-macos-live"]) end)
+
+      reject(&K8sClient.delete_runner/2)
+
+      assert :ok = OrphanedStampedPodsWorker.perform(%Oban.Job{})
+    end
+
+    test "leaves a Linux stamped pod with an open session even when the claim and started=false (race window)" do
+      # Narrow window on Linux: dispatch committed and the session
+      # opened, but kubelet hasn't started the `runner` container
+      # yet (poller exited, runner Pending). The container-started
+      # guard would miss this, but the session guard catches it.
+      expect(K8sClient, :list_pods, fn @namespace, _selector ->
+        {:ok, [linux_pod("runner-linux-handoff", aged(), runner_waiting())]}
+      end)
+
+      expect(Claims, :live_pod_names, fn -> MapSet.new() end)
+      expect(RunnerSessions, :live_pod_names, fn -> MapSet.new(["runner-linux-handoff"]) end)
+
+      reject(&K8sClient.delete_runner/2)
 
       assert :ok = OrphanedStampedPodsWorker.perform(%Oban.Job{})
     end

--- a/server/test/tuist/runners/workers/orphaned_stamped_pods_worker_test.exs
+++ b/server/test/tuist/runners/workers/orphaned_stamped_pods_worker_test.exs
@@ -13,12 +13,31 @@ defmodule Tuist.Runners.Workers.OrphanedStampedPodsWorkerTest do
   @namespace "tuist-runners"
   @owner_label "tuist.dev/runner-pool-owner"
 
-  defp pod(name, created_at, container_statuses \\ []) do
+  # Linux split-container shape: a `poller` init container is the
+  # discriminator the worker uses to decide whether the runner-
+  # container `started=true` signal means "executing a job."
+  defp linux_pod(name, created_at, container_statuses \\ []) do
     %{
       "metadata" => %{"name" => name, "creationTimestamp" => created_at},
+      "spec" => %{"initContainers" => [%{"name" => "poller"}]},
       "status" => %{"containerStatuses" => container_statuses}
     }
   end
+
+  # macOS single-container shape: no `poller` init container. The
+  # runner container is `started=true` while merely polling, so the
+  # guard must NOT treat that as proof of execution on this shape.
+  defp macos_pod(name, created_at, container_statuses \\ []) do
+    %{
+      "metadata" => %{"name" => name, "creationTimestamp" => created_at},
+      "spec" => %{"initContainers" => []},
+      "status" => %{"containerStatuses" => container_statuses}
+    }
+  end
+
+  # Default to Linux shape in the legacy tests that don't care about
+  # the container-status guard (they predate it).
+  defp pod(name, created_at, container_statuses \\ []), do: linux_pod(name, created_at, container_statuses)
 
   # The wedge state this worker exists to clean up: poller poll-loops
   # forever without claiming a JIT, so the `runner` container never
@@ -139,7 +158,7 @@ defmodule Tuist.Runners.Workers.OrphanedStampedPodsWorkerTest do
       assert :ok = OrphanedStampedPodsWorker.perform(%Oban.Job{})
     end
 
-    test "leaves a stamped pod whose runner container is executing, even when the claim is missing" do
+    test "leaves a Linux stamped pod whose runner container is executing, even when the claim is missing" do
       # The class of incident this guard exists for: dispatch stamped
       # the label, the JIT was delivered to the Pod, the runner started
       # executing a customer job — and then *something* released the
@@ -148,9 +167,11 @@ defmodule Tuist.Runners.Workers.OrphanedStampedPodsWorkerTest do
       # guard this worker would force-delete the running Pod and the
       # job would surface on GitHub as "lost communication with the
       # server." With the guard we trust the `started=true` signal on
-      # the runner container and skip the reap.
+      # the runner container (gated by a `poller` init container, the
+      # discriminator for the Linux split-container shape) and skip
+      # the reap.
       expect(K8sClient, :list_pods, fn @namespace, _selector ->
-        {:ok, [pod("runner-live-build", aged(), runner_executing())]}
+        {:ok, [linux_pod("runner-live-build", aged(), runner_executing())]}
       end)
 
       expect(Claims, :live_pod_names, fn -> MapSet.new() end)
@@ -160,13 +181,13 @@ defmodule Tuist.Runners.Workers.OrphanedStampedPodsWorkerTest do
       assert :ok = OrphanedStampedPodsWorker.perform(%Oban.Job{})
     end
 
-    test "leaves a stamped pod whose runner container has already terminated" do
+    test "leaves a Linux stamped pod whose runner container has already terminated" do
       # Narrow window: the runner exited, the Pod is in cleanup, the
       # Pool reconciler hasn't reaped it yet. `started` flips back to
       # false on termination — the guard reads `state.terminated`
       # instead so we don't delete the Pod twice.
       expect(K8sClient, :list_pods, fn @namespace, _selector ->
-        {:ok, [pod("runner-finished", aged(), runner_terminated())]}
+        {:ok, [linux_pod("runner-finished", aged(), runner_terminated())]}
       end)
 
       expect(Claims, :live_pod_names, fn -> MapSet.new() end)
@@ -176,12 +197,12 @@ defmodule Tuist.Runners.Workers.OrphanedStampedPodsWorkerTest do
       assert :ok = OrphanedStampedPodsWorker.perform(%Oban.Job{})
     end
 
-    test "still reaps a stamped pod whose runner container is waiting on the poller" do
+    test "still reaps a Linux stamped pod whose runner container is waiting on the poller" do
       # The original wedge signature: the poller never claimed a JIT,
       # so the runner container stays in `waiting`. `started=false`
       # AND no `terminated` state — guard does not apply, reap fires.
       expect(K8sClient, :list_pods, fn @namespace, _selector ->
-        {:ok, [pod("runner-wedged", aged(), runner_waiting())]}
+        {:ok, [linux_pod("runner-wedged", aged(), runner_waiting())]}
       end)
 
       expect(Claims, :live_pod_names, fn -> MapSet.new() end)
@@ -198,7 +219,7 @@ defmodule Tuist.Runners.Workers.OrphanedStampedPodsWorkerTest do
       # legitimate early-lifecycle Pods, so any Pod past the grace
       # window with no runner status is a real orphan.
       expect(K8sClient, :list_pods, fn @namespace, _selector ->
-        {:ok, [pod("runner-prestart", aged())]}
+        {:ok, [linux_pod("runner-prestart", aged())]}
       end)
 
       expect(Claims, :live_pod_names, fn -> MapSet.new() end)
@@ -208,19 +229,59 @@ defmodule Tuist.Runners.Workers.OrphanedStampedPodsWorkerTest do
       assert :ok = OrphanedStampedPodsWorker.perform(%Oban.Job{})
     end
 
-    test "reaps only the wedged orphan in a mixed batch with live and finished runners" do
+    test "reaps a macOS stamped pod with no live claim even when its runner container is started" do
+      # macOS Pod shape is single-container: the runner container runs
+      # the poll loop inside the Tart VM and `started=true` is true
+      # the moment the VM boots — long before any dispatch. Applying
+      # the Linux `started=true` guard here would protect a wedged
+      # stamped/no-claim macOS Pod indefinitely (the macOS dispatch
+      # script retries 5xx forever, so it never exits on its own).
+      # The guard must be scoped to the Linux split-container shape;
+      # macOS Pods fall back to the historical reap-on-stamp-no-claim
+      # behaviour the worker was originally built for.
+      expect(K8sClient, :list_pods, fn @namespace, _selector ->
+        {:ok, [macos_pod("runner-macos-leak", aged(), runner_executing())]}
+      end)
+
+      expect(Claims, :live_pod_names, fn -> MapSet.new() end)
+
+      expect(K8sClient, :delete_runner, fn @namespace, "runner-macos-leak" -> :ok end)
+
+      assert :ok = OrphanedStampedPodsWorker.perform(%Oban.Job{})
+    end
+
+    test "still leaves a macOS stamped pod that holds a live claim" do
+      # The claim-based protection still applies for macOS: a busy
+      # macOS Pod with a claim row must not be reaped regardless of
+      # container-status shape.
+      expect(K8sClient, :list_pods, fn @namespace, _selector ->
+        {:ok, [macos_pod("runner-macos-busy", aged(), runner_executing())]}
+      end)
+
+      expect(Claims, :live_pod_names, fn -> MapSet.new(["runner-macos-busy"]) end)
+
+      reject(&K8sClient.delete_runner/2)
+
+      assert :ok = OrphanedStampedPodsWorker.perform(%Oban.Job{})
+    end
+
+    test "reaps wedged Linux + macOS orphans in a mixed batch while protecting the live Linux runner" do
       expect(K8sClient, :list_pods, fn @namespace, _selector ->
         {:ok,
          [
-           pod("runner-wedged", aged(), runner_waiting()),
-           pod("runner-live-build", aged(), runner_executing()),
-           pod("runner-finished", aged(), runner_terminated())
+           linux_pod("runner-wedged", aged(), runner_waiting()),
+           linux_pod("runner-live-build", aged(), runner_executing()),
+           linux_pod("runner-finished", aged(), runner_terminated()),
+           macos_pod("runner-macos-leak", aged(), runner_executing())
          ]}
       end)
 
       expect(Claims, :live_pod_names, fn -> MapSet.new() end)
 
-      expect(K8sClient, :delete_runner, fn @namespace, "runner-wedged" -> :ok end)
+      expect(K8sClient, :delete_runner, 2, fn @namespace, name ->
+        assert name in ["runner-wedged", "runner-macos-leak"]
+        :ok
+      end)
 
       assert :ok = OrphanedStampedPodsWorker.perform(%Oban.Job{})
     end


### PR DESCRIPTION
## What

Guard `OrphanedStampedPodsWorker` against force-deleting pods that are actively executing a job. Adds a `runner_started?/1` check on the Pod's `runner` container state and refuses to reap when the runner has reached `started=true` or has a `state.terminated` / `lastState.terminated`.

## Why

The worker's safety claim has been the docstring invariant *"`Claims.attempt/4` INSERTs the claim before `stamp_owner_labels/3`, so an owner-stamped Pod should always have a matching claim."* The invariant breaks whenever anything releases the PG claim *after* dispatch already delivered the JIT and the runner started executing a job. `release_safely/3` is the documented trigger (mint blip, `mark_running` PG error, `record_running_safe` CH hiccup); any future code path that touches `Claims.release`/`Claims.complete` while the runner is mid-job has the same effect. The worker's next 1-minute tick then sees stamp + no-claim + age > 5 min and force-deletes a live customer Pod. From GitHub's side the job surfaces as *"the self-hosted runner lost communication with the server."*

This was the unified mechanism behind the runner-disconnect class of incidents we've been chasing across multiple recent runs. Confirmed in production from Loki:

```
21:30:14Z  runner registers, GitHub job starts on pod ...48379681
21:31:00Z  Loki:  pod=...48379681  "runners: reaped orphaned stamped pod"
21:35:06Z  pod NotFound; GitHub still shows the job in_progress; later → "lost communication"
```

The controller had no termination record for the pod and no k8s `Killing` event was emitted — both consistent with a server-side force-delete bypassing the normal pod lifecycle, which is exactly what `K8sClient.delete_runner/2` does. There is no other code path that can delete a runner Pod silently.

## The guard

Add `runner_started?/1` and AND it into `orphaned?/3`:

```elixir
defp runner_started?(pod) do
  pod
  |> get_in([\"status\", \"containerStatuses\"])
  |> List.wrap()
  |> Enum.find(&(&1[\"name\"] == \"runner\"))
  |> case do
    nil    -> false
    status ->
      Map.get(status, \"started\") == true or
        not is_nil(get_in(status, [\"state\", \"terminated\"])) or
        not is_nil(get_in(status, [\"lastState\", \"terminated\"]))
  end
end
```

In the Linux token-isolation shape the `runner` container is gated behind the `poller` init container, so a started runner is unambiguous proof that the poller staged a JIT and the runner is or was executing a customer job. The original wedge signature this worker was built for — poller poll-loops forever without ever claiming a JIT — still trips the reap because the `runner` container never leaves `waiting`. Pods with no container statuses yet (very early lifecycle) still reap after the existing 5-min grace window.

Deliberately conservative: a transient pod-status shape we don't recognise leaves the Pod for one more reconcile cycle (the Pool reconciler reaps terminated Pods anyway) rather than risking another silent live-build delete. The class of failure this fixes is customer-visible and hard to reproduce; the worst case of the guard is a slightly delayed leak cleanup, which the Pool reconciler also handles.

## Validation

Added test coverage:
- `runner` container `state.running` + `started=true` → guard fires, no delete
- `runner` container `state.terminated` (started flips back to false on termination) → guard fires
- `runner` container `state.waiting` (the original wedge) → guard does NOT fire, reap happens
- No `containerStatuses` at all (very early lifecycle) → reap (existing grace covers brand-new pods)
- Mixed batch with all three shapes → only the wedged one is reaped

All 11 tests pass; format check clean.

## Followups

- The companion question — *which* code path actually released the PG claim ~46 s into the job — is still open. The strong candidate is `release_safely/3` from `serve_claim/5`'s `with`-else triggered by a tail-latency error after the JIT was already returned. Worth digging into separately. This PR closes the silent-delete vulnerability regardless of which trigger fires.
- macOS Tart pods don't have a separate `runner` container that's gated on a poller; the single container is `started=true` from the moment dispatch-poll begins. The guard therefore makes the worker effectively a no-op for macOS pods. That is acceptable: the wedge this worker was built for is Linux-Kata-specific (the docstring notes "on Kata each Pod reserves its full RAM 1:1"), and we have not observed an analogous wedge on macOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)