### PR TITLE
fix(cache): preserve prerelease dots in registry versions

### DIFF
--- a/cache/lib/cache/registry/key_normalizer.ex
+++ b/cache/lib/cache/registry/key_normalizer.ex
@@ -8,7 +8,7 @@ defmodule Cache.Registry.KeyNormalizer do
   """
 
   @source_tag_regex ~r/^v?\d+\.\d+(\.\d+)?(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$/
-  @storage_version_regex ~r/^\d+\.\d+(\.\d+)?(-[0-9A-Za-z-]+(\+[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$/
+  @storage_version_regex ~r/^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*))*))?(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$/
 
   @doc """
   Normalizes a scope by downcasing it.
@@ -57,8 +57,7 @@ defmodule Cache.Registry.KeyNormalizer do
 
   - Strips leading "v" prefix
   - Adds trailing zeros for incomplete versions (1 -> 1.0.0, 1.2 -> 1.2.0)
-  - Converts pre-release dot separator to plus (1.0.0-alpha.1 -> 1.0.0-alpha+1)
-  - Versions with multiple hyphens are passed through with only trailing zeros added
+  - Preserves pre-release and build metadata identifiers
 
   ## Examples
 
@@ -72,10 +71,10 @@ defmodule Cache.Registry.KeyNormalizer do
       "1.2.0"
 
       iex> Cache.Registry.KeyNormalizer.normalize_version("1.0.0-alpha.1")
-      "1.0.0-alpha+1"
+      "1.0.0-alpha.1"
 
       iex> Cache.Registry.KeyNormalizer.normalize_version("v2.0.0-beta.2")
-      "2.0.0-beta+2"
+      "2.0.0-beta.2"
 
       iex> Cache.Registry.KeyNormalizer.normalize_version("0.20.0-prerelease-5")
       "0.20.0-prerelease-5"
@@ -83,15 +82,8 @@ defmodule Cache.Registry.KeyNormalizer do
   def normalize_version(version) when is_binary(version) do
     version = String.trim_leading(version, "v")
 
-    case String.split(version, "-") do
-      [base, prerelease] ->
-        prerelease_with_plus = String.replace(prerelease, ".", "+")
-        base = add_trailing_semantic_version_zeros(base)
-        "#{base}-#{prerelease_with_plus}"
-
-      _ ->
-        add_trailing_semantic_version_zeros(version)
-    end
+    {core, suffix} = split_version_suffix(version)
+    add_trailing_semantic_version_zeros(core) <> suffix
   end
 
   @doc """
@@ -128,6 +120,13 @@ defmodule Cache.Registry.KeyNormalizer do
     case Integer.parse(component) do
       {int, ""} -> Integer.to_string(int)
       _ -> component
+    end
+  end
+
+  defp split_version_suffix(version) do
+    case Regex.run(~r/^([^-+]+)(.*)$/, version, capture: :all_but_first) do
+      [core, suffix] -> {core, suffix}
+      _ -> {version, ""}
     end
   end
 

--- a/cache/test/cache/registry/disk_test.exs
+++ b/cache/test/cache/registry/disk_test.exs
@@ -38,7 +38,7 @@ defmodule Cache.Registry.DiskTest do
 
     test "handles pre-release version" do
       key = RegistryDisk.key("apple", "parser", "1.0.0-alpha.1", "source_archive.zip")
-      assert key == "registry/swift/apple/parser/1.0.0-alpha+1/source_archive.zip"
+      assert key == "registry/swift/apple/parser/1.0.0-alpha.1/source_archive.zip"
     end
   end
 

--- a/cache/test/cache/registry/key_normalizer_test.exs
+++ b/cache/test/cache/registry/key_normalizer_test.exs
@@ -43,12 +43,12 @@ defmodule Cache.Registry.KeyNormalizerTest do
       assert KeyNormalizer.normalize_version("v1.2") == "1.2.0"
     end
 
-    test "converts pre-release dot to plus" do
-      assert KeyNormalizer.normalize_version("1.0.0-alpha.1") == "1.0.0-alpha+1"
+    test "preserves pre-release dot identifiers" do
+      assert KeyNormalizer.normalize_version("1.0.0-alpha.1") == "1.0.0-alpha.1"
     end
 
     test "handles pre-release with v prefix" do
-      assert KeyNormalizer.normalize_version("v2.0.0-beta.2") == "2.0.0-beta+2"
+      assert KeyNormalizer.normalize_version("v2.0.0-beta.2") == "2.0.0-beta.2"
     end
 
     test "handles pre-release without dot" do
@@ -56,11 +56,16 @@ defmodule Cache.Registry.KeyNormalizerTest do
     end
 
     test "handles incomplete version with pre-release" do
-      assert KeyNormalizer.normalize_version("1-alpha.1") == "1.0.0-alpha+1"
+      assert KeyNormalizer.normalize_version("1-alpha.1") == "1.0.0-alpha.1"
     end
 
     test "handles multiple dots in pre-release" do
-      assert KeyNormalizer.normalize_version("1.0.0-alpha.1.2") == "1.0.0-alpha+1+2"
+      assert KeyNormalizer.normalize_version("1.0.0-alpha.1.2") == "1.0.0-alpha.1.2"
+    end
+
+    test "preserves build metadata" do
+      assert KeyNormalizer.normalize_version("1.2+build.5") == "1.2.0+build.5"
+      assert KeyNormalizer.normalize_version("1.0.0-alpha.1+build.5") == "1.0.0-alpha.1+build.5"
     end
 
     test "strips leading zeros from version components" do
@@ -115,12 +120,13 @@ defmodule Cache.Registry.KeyNormalizerTest do
     test "accepts normalized storage version formats" do
       assert KeyNormalizer.valid_storage_version?("1.2.3")
       assert KeyNormalizer.valid_storage_version?("1.2.0")
-      assert KeyNormalizer.valid_storage_version?("1.0.0-alpha+1+2")
+      assert KeyNormalizer.valid_storage_version?("1.0.0-alpha.1.2")
+      assert KeyNormalizer.valid_storage_version?("1.0.0-alpha.1+build.5")
     end
 
     test "rejects invalid storage version formats" do
       refute KeyNormalizer.valid_storage_version?("v1.2.3")
-      refute KeyNormalizer.valid_storage_version?("1.0.0-alpha.1.2")
+      refute KeyNormalizer.valid_storage_version?("1.0.0-alpha+1+2")
       refute KeyNormalizer.valid_storage_version?("0.0.24b")
     end
   end
@@ -167,7 +173,7 @@ defmodule Cache.Registry.KeyNormalizerTest do
           path: "source_archive.zip"
         )
 
-      assert result == "registry/swift/apple/swift-syntax/1.0.0-alpha+1/source_archive.zip"
+      assert result == "registry/swift/apple/swift-syntax/1.0.0-alpha.1/source_archive.zip"
     end
 
     test "constructs key without version" do

--- a/cache/test/cache_web/controllers/registry_controller_test.exs
+++ b/cache/test/cache_web/controllers/registry_controller_test.exs
@@ -452,7 +452,7 @@ defmodule CacheWeb.RegistryControllerTest do
         "scope" => scope,
         "name" => name,
         "releases" => %{
-          "1.2.3-alpha+1+2" => %{"checksum" => "abc123"}
+          "1.2.3-alpha.1.2" => %{"checksum" => "abc123"}
         }
       }
 
@@ -466,7 +466,7 @@ defmodule CacheWeb.RegistryControllerTest do
       assert conn.status == 200
 
       response = json_response(conn, :ok)
-      assert response["version"] == "1.2.3-alpha+1+2"
+      assert response["version"] == "1.2.3-alpha.1.2"
     end
 
     test "returns 404 when version not found", %{conn: conn} do


### PR DESCRIPTION
Resolves no tracked issue.

Fixes Swift package registry version normalization so prerelease identifiers keep their SemVer dot separators instead of being rewritten as build metadata separators. The previous behavior turned versions like `1.0.0-beta.5` into `1.0.0-beta+5`, which made registry metadata disagree with package manifests that depend on exact prerelease versions.

This updates the cache registry normalizer to only normalize the core numeric version components while preserving prerelease and build metadata suffixes. It also tightens storage-version validation around SemVer-compatible prerelease/build forms and updates registry controller and disk tests to cover the corrected storage keys and response versions.

### How to test locally

```sh
cd cache
mix test test/cache/registry/key_normalizer_test.exs test/cache/registry/disk_test.exs test/cache_web/controllers/registry_controller_test.exs
```
