### PR TITLE
fix(server): runner log spacing

### DIFF
--- a/server/assets/app/app.js
+++ b/server/assets/app/app.js
@@ -40,6 +40,7 @@ import TextAttachmentContent from "./js/hooks/TextAttachmentContent.js";
 import SubmitOnCmdEnter from "./js/SubmitOnCmdEnter.js";
 import CopyToClipboard from "./js/CopyToClipboard.js";
 import DownloadAsFile from "./js/DownloadAsFile.js";
+import ScrollToTail from "./js/ScrollToTail.js";
 import { setupQueryMemory } from "./js/QueryMemory.js";
 import { getUserLocale } from "./js/UserLocale.js";
 import { getUserTimezone } from "./js/UserTimezone.js";
@@ -64,6 +65,7 @@ Hooks.TextAttachmentContent = TextAttachmentContent;
 Hooks.SubmitOnCmdEnter = SubmitOnCmdEnter;
 Hooks.CopyToClipboard = CopyToClipboard;
 Hooks.DownloadAsFile = DownloadAsFile;
+Hooks.ScrollToTail = ScrollToTail;
 
 observeThemeChanges();
 Hooks.ThemeSwitcher = ThemeSwitcher;

--- a/server/assets/app/css/pages/runner_job.css
+++ b/server/assets/app/css/pages/runner_job.css
@@ -306,7 +306,6 @@
   & [data-part="step-logs"] {
     display: flex;
     flex-direction: column;
-    gap: var(--noora-spacing-2);
     border-radius: var(--noora-radius-4);
     background: var(--noora-surface-background-secondary);
     padding: var(--noora-spacing-5) var(--noora-spacing-7);
@@ -323,7 +322,6 @@
   & [data-part="log-stream"] {
     display: flex;
     flex-direction: column;
-    gap: var(--noora-spacing-2);
   }
 
   & [data-part="load-older"] {
@@ -346,13 +344,16 @@
   & [data-part="log-line"] {
     display: flex;
     flex-direction: row;
+    align-items: flex-start;
     gap: var(--noora-spacing-5);
+    line-height: 1.45;
 
     & > [data-part="log-ln"] {
       flex-shrink: 0;
       min-width: 3ch;
       color: var(--noora-surface-label-tertiary);
       font: var(--noora-font-weight-regular) var(--noora-font-code-medium);
+      line-height: inherit;
       user-select: none;
       text-align: right;
     }
@@ -361,6 +362,7 @@
       flex-shrink: 0;
       color: var(--noora-surface-label-secondary);
       font: var(--noora-font-weight-regular) var(--noora-font-code-medium);
+      line-height: inherit;
     }
 
     & > [data-part="log-message"] {
@@ -368,6 +370,7 @@
       min-width: 0;
       color: var(--noora-surface-label-primary);
       font: var(--noora-font-weight-regular) var(--noora-font-code-medium);
+      line-height: inherit;
       white-space: pre-wrap;
       word-break: break-word;
     }
@@ -388,6 +391,7 @@
       cursor: pointer;
       color: var(--noora-surface-label-primary);
       font: var(--noora-font-weight-regular) var(--noora-font-code-medium);
+      line-height: 1.45;
       list-style: none;
 
       &::-webkit-details-marker {

--- a/server/assets/app/js/ScrollToTail.js
+++ b/server/assets/app/js/ScrollToTail.js
@@ -1,0 +1,63 @@
+const defaultBottomThreshold = 24;
+
+export default {
+  mounted() {
+    this.hasPinnedTail = false;
+    this.pinTail();
+  },
+
+  beforeUpdate() {
+    this.wasNearBottom = this.distanceFromBottom() <= this.bottomThreshold();
+    this.previousScrollHeight = this.el.scrollHeight;
+    this.previousScrollTop = this.el.scrollTop;
+    this.previousFirstItemId = this.firstItemId();
+  },
+
+  updated() {
+    window.requestAnimationFrame(() => {
+      if (!this.isEnabled()) return;
+
+      const firstItemId = this.firstItemId();
+      const prependedItems =
+        this.previousFirstItemId && firstItemId && firstItemId !== this.previousFirstItemId;
+
+      if (!this.hasPinnedTail || this.wasNearBottom) {
+        this.pinTail();
+      } else if (prependedItems) {
+        this.el.scrollTop =
+          this.previousScrollTop + (this.el.scrollHeight - this.previousScrollHeight);
+      }
+    });
+  },
+
+  pinTail() {
+    window.requestAnimationFrame(() => {
+      if (!this.isEnabled()) return;
+
+      this.el.scrollTop = this.el.scrollHeight;
+      this.hasPinnedTail = true;
+    });
+  },
+
+  distanceFromBottom() {
+    return this.el.scrollHeight - this.el.scrollTop - this.el.clientHeight;
+  },
+
+  firstItemId() {
+    const selector = this.el.dataset.scrollToTailItemSelector;
+
+    if (!selector) return null;
+
+    return this.el.querySelector(selector)?.id;
+  },
+
+  bottomThreshold() {
+    const threshold = Number.parseInt(this.el.dataset.scrollToTailBottomThreshold, 10);
+
+    return Number.isNaN(threshold) ? defaultBottomThreshold : threshold;
+  },
+
+  isEnabled() {
+    return this.el.dataset.scrollToTailActive !== "false" && this.el.offsetParent !== null;
+  },
+};

--- a/server/lib/tuist_web/live/runner_job_live.html.heex
+++ b/server/lib/tuist_web/live/runner_job_live.html.heex
@@ -290,17 +290,19 @@
             {dgettext("dashboard_runners", "No log lines match your search.")}
           </div>
           <div :for={line <- @search_results} data-part="log-line">
+            <% message_html = Tuist.Runners.LogFormatter.render_message(line.message) %>
             <span data-part="log-ts">{TuistWeb.RunnerJobLive.log_ts(line.ts)}</span>
-            <span data-part="log-message">
-              {Tuist.Runners.LogFormatter.render_message(line.message)}
-            </span>
+            <span data-part="log-message">{message_html}</span>
           </div>
         </div>
 
         <div
           :if={@has_logs}
           id="runner-log-viewport"
+          phx-hook="ScrollToTail"
           data-part="log-viewport"
+          data-scroll-to-tail-active={to_string(@selected_tab == "logs" and @search == "")}
+          data-scroll-to-tail-item-selector="[data-part='log-line']"
           hidden={@search != ""}
         >
           <button
@@ -313,10 +315,9 @@
           </button>
           <div id="runner-logs" data-part="log-stream" phx-update="stream">
             <div :for={{dom_id, line} <- @streams.log_lines} id={dom_id} data-part="log-line">
+              <% message_html = Tuist.Runners.LogFormatter.render_message(line.message) %>
               <span data-part="log-ts">{TuistWeb.RunnerJobLive.log_ts(line.ts)}</span>
-              <span data-part="log-message">
-                {Tuist.Runners.LogFormatter.render_message(line.message)}
-              </span>
+              <span data-part="log-message">{message_html}</span>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## What changed

- Tightened the runner job log layout by removing flex gaps between rendered log rows and applying explicit line-height inheritance to log cells.
- Rendered log messages inline in the HEEx template so `white-space: pre-wrap` preserves only real log whitespace, not template indentation/newlines.
- Added a LiveView hook that pins the log viewport to the newest line on initial load and preserves scroll position when older logs are prepended.

## Why

The logs tab was showing excessive vertical space between individual log lines, and the initial view could land at the top of the loaded tail with the older-logs affordance in view. That made CI logs harder to scan and did not match the expected terminal-like behavior.

## Root cause

The visible row spacing had two contributors: CSS gaps between log rows, and HEEx formatting inside the message `<span>`. Because log messages use `white-space: pre-wrap`, template newlines and indentation around the rendered message were preserved as real whitespace. The initial scroll behavior also relied on the browser's default scroll position rather than explicitly pinning the log viewport to the tail.

## Impact

Runner job logs now render as compact single-line rows, retain intentional log indentation, and open scrolled to the most recent line. Loading older logs keeps the user's current position stable instead of jumping.

## Validation

- `mix format lib/tuist_web/live/runner_job_live.html.heex`
- `git diff --check`
- `mix test test/tuist_web/live/runner_job_live_test.exs` (16 tests, 0 failures)
- Verified in the in-app browser against the local smoke log page: log rows measured at 17.4px high and the viewport settled at the bottom (`distanceFromBottom: 0`).
