### PR TITLE
feat(infra): add CAPI cluster autoscaler

### DIFF
--- a/.github/workflows/mgmt-cluster-apply.yml
+++ b/.github/workflows/mgmt-cluster-apply.yml
@@ -39,6 +39,7 @@ on:
     branches: [main]
     paths:
       - 'infra/k8s/clusters/**'
+      - 'infra/k8s/mgmt/cluster-autoscaler.yaml'
       - 'infra/k8s/mgmt/etcd-snapshot.yaml'
       - 'infra/k8s/mgmt/tailscale.yaml'
       - 'infra/k8s/mgmt/hetzner-robot-controller.yaml'
@@ -110,6 +111,9 @@ jobs:
           echo "::group::hetzner-robot-controller.yaml diff"
           kubectl diff -f infra/k8s/mgmt/hetzner-robot-controller.yaml || true
           echo "::endgroup::"
+          echo "::group::cluster-autoscaler.yaml diff"
+          kubectl diff -f infra/k8s/mgmt/cluster-autoscaler.yaml || true
+          echo "::endgroup::"
       - name: Apply ClusterClass first (Cluster CRs reference it)
         run: |
           kubectl apply -f infra/k8s/clusters/clusterclass-tuist.yaml
@@ -160,5 +164,6 @@ jobs:
         # CRs. Independent of the CAPI manifests above.
         run: |
           kubectl apply -f infra/k8s/mgmt/hetzner-robot-controller.yaml
+          kubectl apply -f infra/k8s/mgmt/cluster-autoscaler.yaml
           kubectl apply -f infra/k8s/mgmt/etcd-snapshot.yaml
           kubectl apply -f infra/k8s/mgmt/tailscale.yaml

--- a/infra/AGENTS.md
+++ b/infra/AGENTS.md
@@ -31,7 +31,7 @@ Cluster API CRs and cluster-scoped manifests for the self-hosted CAPI + caph sta
 - `clusters/cluster-{staging,canary,production,preview}.yaml` — per-env Cluster CRs in topology mode.
 - `clusters/cluster-production-us-{east,west}.yaml` — production Kura regional workload clusters mapped to Hetzner `ash` / `hil`.
 - `clusters/README.md` — ClusterClass authoring + caph-upstream porting notes.
-- `mgmt/etcd-snapshot.yaml`, `mgmt/tailscale.yaml` — mgmt-cluster workloads (hourly etcd snapshot to Tigris, tailnet-only operator access).
+- `mgmt/cluster-autoscaler.yaml`, `mgmt/etcd-snapshot.yaml`, `mgmt/tailscale.yaml` — mgmt-cluster workloads (Cluster API node autoscaling for managed Kura/app clusters, hourly etcd snapshot to Tigris, tailnet-only operator access).
 - `mgmt/bootstrap/` — Helm values for the per-workload bootstrap (Cilium, HCCM, hcloud-csi, ESO `ClusterSecretStore`).
 - `mgmt/ci-service-account.yaml` — SA + RBAC for the GitHub Actions deployer (applied per workload).
 - `mgmt/preview-mgmt-rbac.yaml` — narrow SA + Role on the mgmt cluster used by the preview-deploy / preview-sweep workflows to scale the preview MachineDeployment.

--- a/infra/k8s/clusters/cluster-production-us-east.yaml
+++ b/infra/k8s/clusters/cluster-production-us-east.yaml
@@ -40,6 +40,7 @@ spec:
           failureDomain: ash
           metadata:
             labels:
+              autoscaling.tuist.dev/group: kura
               node.cluster.x-k8s.io/pool: kura
             annotations:
               cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size: "3"

--- a/infra/k8s/clusters/cluster-production-us-west.yaml
+++ b/infra/k8s/clusters/cluster-production-us-west.yaml
@@ -40,6 +40,7 @@ spec:
           failureDomain: hil
           metadata:
             labels:
+              autoscaling.tuist.dev/group: kura
               node.cluster.x-k8s.io/pool: kura
             annotations:
               cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size: "3"

--- a/infra/k8s/clusters/cluster-production.yaml
+++ b/infra/k8s/clusters/cluster-production.yaml
@@ -97,6 +97,7 @@ spec:
           failureDomain: fsn1
           metadata:
             labels:
+              autoscaling.tuist.dev/group: kura
               node.cluster.x-k8s.io/pool: kura
             annotations:
               cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size: "3"

--- a/infra/k8s/mgmt/cluster-autoscaler.yaml
+++ b/infra/k8s/mgmt/cluster-autoscaler.yaml
@@ -1,0 +1,232 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cluster-autoscaler
+  namespace: org-tuist
+  labels:
+    app.kubernetes.io/name: cluster-autoscaler
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cluster-autoscaler-management
+  namespace: org-tuist
+  labels:
+    app.kubernetes.io/name: cluster-autoscaler
+rules:
+  - apiGroups:
+      - cluster.x-k8s.io
+    resources:
+      - clusters
+      - machinedeployments
+      - machinedeployments/scale
+      - machines
+      - machinesets
+      - machinepools
+    verbs:
+      - get
+      - list
+      - update
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cluster-autoscaler-management
+  namespace: org-tuist
+  labels:
+    app.kubernetes.io/name: cluster-autoscaler
+subjects:
+  - kind: ServiceAccount
+    name: cluster-autoscaler
+    namespace: org-tuist
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cluster-autoscaler-management
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cluster-autoscaler-tuist
+  namespace: org-tuist
+  labels:
+    app.kubernetes.io/name: cluster-autoscaler
+    app.kubernetes.io/instance: tuist
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: cluster-autoscaler
+      app.kubernetes.io/instance: tuist
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: cluster-autoscaler
+        app.kubernetes.io/instance: tuist
+    spec:
+      serviceAccountName: cluster-autoscaler
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: cluster-autoscaler
+          image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.34.0
+          imagePullPolicy: IfNotPresent
+          command:
+            - /cluster-autoscaler
+          args:
+            - --cloud-provider=clusterapi
+            - --clusterapi-cloud-config-authoritative
+            - --kubeconfig=/etc/cluster-autoscaler/workload/value
+            - --node-group-auto-discovery=clusterapi:namespace=org-tuist,clusterName=tuist,autoscaling.tuist.dev/group=kura
+            - --scale-down-unneeded-time=10m
+            - --scale-down-delay-after-add=10m
+            - --max-node-provision-time=15m
+            - --v=4
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              memory: 512Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 65532
+          volumeMounts:
+            - name: workload-kubeconfig
+              mountPath: /etc/cluster-autoscaler/workload
+              readOnly: true
+      volumes:
+        - name: workload-kubeconfig
+          secret:
+            secretName: tuist-kubeconfig
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cluster-autoscaler-tuist-kura-us-east
+  namespace: org-tuist
+  labels:
+    app.kubernetes.io/name: cluster-autoscaler
+    app.kubernetes.io/instance: tuist-kura-us-east
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: cluster-autoscaler
+      app.kubernetes.io/instance: tuist-kura-us-east
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: cluster-autoscaler
+        app.kubernetes.io/instance: tuist-kura-us-east
+    spec:
+      serviceAccountName: cluster-autoscaler
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: cluster-autoscaler
+          image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.34.0
+          imagePullPolicy: IfNotPresent
+          command:
+            - /cluster-autoscaler
+          args:
+            - --cloud-provider=clusterapi
+            - --clusterapi-cloud-config-authoritative
+            - --kubeconfig=/etc/cluster-autoscaler/workload/value
+            - --node-group-auto-discovery=clusterapi:namespace=org-tuist,clusterName=tuist-kura-us-east,autoscaling.tuist.dev/group=kura
+            - --scale-down-unneeded-time=10m
+            - --scale-down-delay-after-add=10m
+            - --max-node-provision-time=15m
+            - --v=4
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              memory: 512Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 65532
+          volumeMounts:
+            - name: workload-kubeconfig
+              mountPath: /etc/cluster-autoscaler/workload
+              readOnly: true
+      volumes:
+        - name: workload-kubeconfig
+          secret:
+            secretName: tuist-kura-us-east-kubeconfig
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cluster-autoscaler-tuist-kura-us-west
+  namespace: org-tuist
+  labels:
+    app.kubernetes.io/name: cluster-autoscaler
+    app.kubernetes.io/instance: tuist-kura-us-west
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: cluster-autoscaler
+      app.kubernetes.io/instance: tuist-kura-us-west
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: cluster-autoscaler
+        app.kubernetes.io/instance: tuist-kura-us-west
+    spec:
+      serviceAccountName: cluster-autoscaler
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: cluster-autoscaler
+          image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.34.0
+          imagePullPolicy: IfNotPresent
+          command:
+            - /cluster-autoscaler
+          args:
+            - --cloud-provider=clusterapi
+            - --clusterapi-cloud-config-authoritative
+            - --kubeconfig=/etc/cluster-autoscaler/workload/value
+            - --node-group-auto-discovery=clusterapi:namespace=org-tuist,clusterName=tuist-kura-us-west,autoscaling.tuist.dev/group=kura
+            - --scale-down-unneeded-time=10m
+            - --scale-down-delay-after-add=10m
+            - --max-node-provision-time=15m
+            - --v=4
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              memory: 512Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 65532
+          volumeMounts:
+            - name: workload-kubeconfig
+              mountPath: /etc/cluster-autoscaler/workload
+              readOnly: true
+      volumes:
+        - name: workload-kubeconfig
+          secret:
+            secretName: tuist-kura-us-west-kubeconfig


### PR DESCRIPTION
## What changed

Adds a management-cluster Cluster Autoscaler deployment for each supported managed Kura workload cluster:

- `tuist`, scoped to the `eu-central` Kura MachineDeployment
- `tuist-kura-us-east`
- `tuist-kura-us-west`

Each autoscaler runs in the management cluster, uses the CAPI-generated workload kubeconfig Secret for pod and node observation, and uses the in-cluster management credentials to scale annotated MachineDeployments in `org-tuist`. The autoscaler discovery selector is constrained to MachineDeployments labeled `autoscaling.tuist.dev/group=kura`, so it does not touch the production processor pool or runner capacity.

The mgmt-cluster apply workflow now diffs and applies the autoscaler manifest, and the infra map documents the new management workload.

## Why

Kura customer rollout creates tenant-specific StatefulSets. The Kura pools already advertise autoscaler bounds, but there was no Cluster Autoscaler running to act on pending pods. That left Kura rollout capacity dependent on manual `kubectl scale machinedeployment ...` operations.

This is different from the runner path: the runners-controller scales RunnerPool pod replicas from Tuist demand signals, while the underlying runner host capacity remains operator-managed. Kura needs node pool autoscaling for CAPI MachineDeployments because pending customer cache pods should be able to request more worker nodes automatically.

## Impact

Pending Kura pods in supported regions can drive their regional Kura MachineDeployment from the configured minimum to maximum. Today that means the Kura pools can scale from 3 to 12 nodes where the existing annotations allow it. Non-Kura MachineDeployments are not selected.

## Validation

- `kubectl --kubeconfig=$HOME/.kube/tuist-mgmt.yaml apply --dry-run=server -f infra/k8s/mgmt/cluster-autoscaler.yaml`
- `kubectl --kubeconfig=$HOME/.kube/tuist-mgmt.yaml apply --dry-run=server -f infra/k8s/clusters/cluster-production.yaml -f infra/k8s/clusters/cluster-production-us-east.yaml -f infra/k8s/clusters/cluster-production-us-west.yaml`
- `git diff --check`

## Notes

This PR enables the autoscaler path, but the current production rollout may still need a one-time manual scale if we want immediate capacity before the mgmt-cluster apply workflow deploys and the autoscaler reacts.