### PR TITLE
fix(infra): remediate failed Kura machine provisioning

### DIFF
--- a/.github/workflows/mgmt-cluster-apply.yml
+++ b/.github/workflows/mgmt-cluster-apply.yml
@@ -62,9 +62,9 @@ jobs:
     runs-on: tuist-linux
     environment:
       name: mgmt-cluster-apply
-    # The apply path normally finishes in under 2 min; 5 min
-    # leaves slack for slow `kubectl diff` against large CRDs.
-    timeout-minutes: 5
+    # `kubectl diff` can be slow against the Cluster API CRDs when many
+    # Machines are changing, so leave enough room for the visibility step.
+    timeout-minutes: 15
     env:
       KUBECONFIG: ${{ github.workspace }}/.kube/config
     steps:

--- a/infra/k8s/clusters/README.md
+++ b/infra/k8s/clusters/README.md
@@ -35,7 +35,7 @@ clusters/
 | `tuist-staging` | 3× cpx22 | md-0: 2× cpx31 |
 | `tuist-canary` | 3× cpx22 | md-0: 2× cpx32; kura: 3× ccx13 (`pool=kura`) |
 | `tuist` (production) | 3× cpx22 | md-0: 2× ccx23 (`pool=general`); md-processor: 2× cpx62 (`pool=processor`, autoscaled 2→6); kura: 3× ccx13 (`pool=kura`, autoscaled 3→12) |
-| `tuist-kura-us-east` (production Kura `us-east-1`) | 3× ccx13 in `ash` | kura: 3× ccx13 (`pool=kura`, autoscaled 3→12) |
+| `tuist-kura-us-east` (production Kura `us-east-1`) | 3× ccx13 in `ash` | kura: 3× ccx13 (`pool=kura`, autoscaled 3→32) |
 | `tuist-kura-us-west` (production Kura `us-west-1`) | 3× ccx13 in `hil` | kura: 3× ccx13 (`pool=kura`, autoscaled 3→12) |
 | `tuist-preview` | 1× cpx22 | md-0: 1× cpx42 |
 

--- a/infra/k8s/clusters/cluster-canary.yaml
+++ b/infra/k8s/clusters/cluster-canary.yaml
@@ -52,6 +52,19 @@ spec:
           name: kura
           replicas: 3
           failureDomain: fsn1
+          healthCheck:
+            checks:
+              nodeStartupTimeoutSeconds: 600
+              unhealthyNodeConditions:
+                - type: Ready
+                  status: Unknown
+                  timeoutSeconds: 300
+                - type: Ready
+                  status: "False"
+                  timeoutSeconds: 300
+            remediation:
+              triggerIf:
+                unhealthyLessThanOrEqualTo: 100%
           metadata:
             labels:
               node.cluster.x-k8s.io/pool: kura

--- a/infra/k8s/clusters/cluster-production-us-east.yaml
+++ b/infra/k8s/clusters/cluster-production-us-east.yaml
@@ -38,12 +38,25 @@ spec:
         - class: hcloud-worker
           name: kura
           failureDomain: ash
+          healthCheck:
+            checks:
+              nodeStartupTimeoutSeconds: 600
+              unhealthyNodeConditions:
+                - type: Ready
+                  status: Unknown
+                  timeoutSeconds: 300
+                - type: Ready
+                  status: "False"
+                  timeoutSeconds: 300
+            remediation:
+              triggerIf:
+                unhealthyLessThanOrEqualTo: 100%
           metadata:
             labels:
               autoscaling.tuist.dev/group: kura
               node.cluster.x-k8s.io/pool: kura
             annotations:
               cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size: "3"
-              cluster.x-k8s.io/cluster-api-autoscaler-node-group-max-size: "12"
+              cluster.x-k8s.io/cluster-api-autoscaler-node-group-max-size: "32"
               cluster.x-k8s.io/cluster-autoscaler-node-group-min-size: "3"
-              cluster.x-k8s.io/cluster-autoscaler-node-group-max-size: "12"
+              cluster.x-k8s.io/cluster-autoscaler-node-group-max-size: "32"

--- a/infra/k8s/clusters/cluster-production-us-west.yaml
+++ b/infra/k8s/clusters/cluster-production-us-west.yaml
@@ -38,6 +38,19 @@ spec:
         - class: hcloud-worker
           name: kura
           failureDomain: hil
+          healthCheck:
+            checks:
+              nodeStartupTimeoutSeconds: 600
+              unhealthyNodeConditions:
+                - type: Ready
+                  status: Unknown
+                  timeoutSeconds: 300
+                - type: Ready
+                  status: "False"
+                  timeoutSeconds: 300
+            remediation:
+              triggerIf:
+                unhealthyLessThanOrEqualTo: 100%
           metadata:
             labels:
               autoscaling.tuist.dev/group: kura

--- a/infra/k8s/clusters/cluster-production.yaml
+++ b/infra/k8s/clusters/cluster-production.yaml
@@ -95,6 +95,19 @@ spec:
         - class: hcloud-worker
           name: kura
           failureDomain: fsn1
+          healthCheck:
+            checks:
+              nodeStartupTimeoutSeconds: 600
+              unhealthyNodeConditions:
+                - type: Ready
+                  status: Unknown
+                  timeoutSeconds: 300
+                - type: Ready
+                  status: "False"
+                  timeoutSeconds: 300
+            remediation:
+              triggerIf:
+                unhealthyLessThanOrEqualTo: 100%
           metadata:
             labels:
               autoscaling.tuist.dev/group: kura

--- a/infra/k8s/mgmt/cluster-autoscaler.yaml
+++ b/infra/k8s/mgmt/cluster-autoscaler.yaml
@@ -18,15 +18,24 @@ rules:
       - cluster.x-k8s.io
     resources:
       - clusters
+      - machines
       - machinedeployments
       - machinedeployments/scale
-      - machines
       - machinesets
       - machinepools
     verbs:
       - get
       - list
+      - patch
       - update
+      - watch
+  - apiGroups:
+      - infrastructure.cluster.x-k8s.io
+    resources:
+      - hcloudmachinetemplates
+    verbs:
+      - get
+      - list
       - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
## What changed

- Keeps the missing `patch` verb on the management-cluster Cluster Autoscaler Role for `machinedeployments/scale`.
- Adds the missing read permission for Hetzner `HCloudMachineTemplate` resources that the Cluster API autoscaler watches.
- Raises the US-east Kura autoscaler max from 12 to 32 workers so the enterprise rollout can continue scheduling the remaining Kura replicas.
- Adds explicit Kura MachineDeployment healthCheck overrides that allow MachineHealthCheck remediation up to 100% unhealthy for Kura pools.
- Extends the mgmt apply workflow timeout from 5 to 15 minutes because `kubectl diff` timed out while many CAPI Machines were changing.

## Why

The Kura autoscaler can request more nodes, but Hetzner Ashburn capacity failures can leave new Machines stuck with `ServerCreateFailedIrrecoverableError`. Cluster API already has the right remediation primitive for this: MachineHealthCheck marks not-started Machines unhealthy and lets the MachineSet replace them.

The existing `hcloud-worker` class limits remediation to `unhealthyInRange: [0-2]`, which is sensible for small general worker pools but blocks elastic Kura scale-up waves. In the US-east rollout, the Kura pool had many provider-capacity failures at once, so CAPI refused remediation with `TooManyUnhealthy`.

This PR keeps the generic class conservative and overrides remediation only at Kura MachineDeployment topology sites. That avoids custom retry jobs and keeps replacement behavior inside CAPI.

## Impact

Kura pools can keep replacing not-started Machines during large autoscaled rollout waves, while general and processor hcloud worker pools keep their existing conservative remediation behavior.

The US-east Kura pool can now grow up to 32 workers. Europe and US-west keep their existing max size.

## Validation

- `kubectl --kubeconfig=$HOME/.kube/tuist-mgmt.yaml apply --dry-run=server -f infra/k8s/clusters/cluster-production.yaml -f infra/k8s/clusters/cluster-production-us-east.yaml -f infra/k8s/clusters/cluster-production-us-west.yaml -f infra/k8s/clusters/cluster-canary.yaml -f infra/k8s/mgmt/cluster-autoscaler.yaml`
- Live US-east autoscaler picked up max 32 and scaled the Kura MachineDeployment from 12 to 28 desired replicas
- `git diff --check`