### PR TITLE
fix(cli): update SwifterPM to 0.7.1

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "1f3e5ee5b66fb28f9141e6501cf9ca1adeea56fc91c10f14aa4ebec232838c9e",
+  "originHash" : "8d5d9c04eaae33643ec455b899e85a539fe7d9acda97c6a261b39abac12d9f0e",
   "pins" : [
     {
       "identity" : "1024jp.gzipswift",
@@ -519,8 +519,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tuist/swifterpm",
       "state" : {
-        "revision" : "c58fe5f6f44ccc888f3c60acfc140c3010dd4438",
-        "version" : "0.7.0"
+        "revision" : "97693fc545e5f75cf3cae8aef7a9210e303b01c7",
+        "version" : "0.7.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -1779,7 +1779,7 @@ let package = Package(
         .package(id: "swiftlang.swift-docc-plugin", from: "1.4.6"),
         .package(name: "XCResultNIF", path: "server/native/xcresult_nif"),
         .package(id: "stephencelis.SQLite_swift", from: "0.16.0"),
-        .package(url: "https://github.com/tuist/swifterpm", exact: "0.7.0"),
+        .package(url: "https://github.com/tuist/swifterpm", exact: "0.7.1"),
     ],
     targets: targets,
     swiftLanguageModes: [.v5]


### PR DESCRIPTION
Resolves <https://github.com/tuist/tuist/pull/11099>

Updates SwifterPM from `0.7.0` to `0.7.1` so the CLI release can pick up the musl Linux build fix from <https://github.com/tuist/swifterpm/pull/17>.

The previous Tuist CLI release path failed while compiling SwifterPM for the static Linux SDK because SwifterPM imported `Glibc` for all Linux targets. SwifterPM `0.7.1` switches to `canImport(Glibc)` / `canImport(Musl)`, which keeps glibc Linux builds working and supports the musl target used by Tuist's static Linux release build.

### How to test locally

- `swift package resolve --replace-scm-with-registry`
- `xcodebuild test -workspace Tuist.xcworkspace -scheme Tuist-Workspace -only-testing TuistSupportTests/SwiftPackageManagerControllerTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""`
- `xcodebuild build -workspace Tuist.xcworkspace -scheme Tuist-Workspace CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""`
