### PR TITLE
fix(server): show runner job platforms

### DIFF
--- a/server/lib/tuist_web/live/runner_job_live.ex
+++ b/server/lib/tuist_web/live/runner_job_live.ex
@@ -5,6 +5,7 @@ defmodule TuistWeb.RunnerJobLive do
 
   alias Tuist.Authorization
   alias Tuist.FeatureFlags
+  alias Tuist.Runners.Catalog
   alias Tuist.Runners.JobLogs
   alias Tuist.Runners.Jobs
   alias Tuist.Runners.JobSteps
@@ -142,9 +143,14 @@ defmodule TuistWeb.RunnerJobLive do
 
   def platform_label(fleet_name) when is_binary(fleet_name) do
     cond do
-      String.starts_with?(fleet_name, "macos-") -> dgettext("dashboard_runners", "macOS")
-      String.starts_with?(fleet_name, "linux-") -> dgettext("dashboard_runners", "Linux")
-      true -> dgettext("dashboard_runners", "Unknown")
+      String.starts_with?(fleet_name, Catalog.fleet_name_prefixes(:macos)) ->
+        dgettext("dashboard_runners", "macOS")
+
+      String.starts_with?(fleet_name, Catalog.fleet_name_prefixes(:linux)) ->
+        dgettext("dashboard_runners", "Linux")
+
+      true ->
+        dgettext("dashboard_runners", "Unknown")
     end
   end
 
@@ -158,9 +164,14 @@ defmodule TuistWeb.RunnerJobLive do
   """
   def platform_badge_color(fleet_name) when is_binary(fleet_name) do
     cond do
-      String.starts_with?(fleet_name, "macos-") -> "information"
-      String.starts_with?(fleet_name, "linux-") -> "attention"
-      true -> "neutral"
+      String.starts_with?(fleet_name, Catalog.fleet_name_prefixes(:macos)) ->
+        "information"
+
+      String.starts_with?(fleet_name, Catalog.fleet_name_prefixes(:linux)) ->
+        "attention"
+
+      true ->
+        "neutral"
     end
   end
 

--- a/server/lib/tuist_web/live/runner_jobs_live.ex
+++ b/server/lib/tuist_web/live/runner_jobs_live.ex
@@ -17,6 +17,7 @@ defmodule TuistWeb.RunnerJobsLive do
   alias Tuist.FeatureFlags
   alias Tuist.Runners.Analytics
   alias Tuist.Runners.Billing
+  alias Tuist.Runners.Catalog
   alias Tuist.Runners.Jobs
   alias Tuist.Utilities.DateFormatter
   alias TuistWeb.Helpers.DatePicker
@@ -614,14 +615,19 @@ defmodule TuistWeb.RunnerJobsLive do
 
   @doc """
   Resolves the localized platform label for a job's `fleet_name` so
-  the Platform column can replace the raw `macos-large-arm64`-style
-  fleet identifier with "macOS" / "Linux".
+  the Platform column can replace the raw fleet identifier with
+  "macOS" / "Linux".
   """
   def platform_label_from_fleet(fleet_name) when is_binary(fleet_name) do
     cond do
-      String.starts_with?(fleet_name, "macos-") -> dgettext("dashboard_runners", "macOS")
-      String.starts_with?(fleet_name, "linux-") -> dgettext("dashboard_runners", "Linux")
-      true -> dgettext("dashboard_runners", "Unknown")
+      String.starts_with?(fleet_name, Catalog.fleet_name_prefixes(:macos)) ->
+        dgettext("dashboard_runners", "macOS")
+
+      String.starts_with?(fleet_name, Catalog.fleet_name_prefixes(:linux)) ->
+        dgettext("dashboard_runners", "Linux")
+
+      true ->
+        dgettext("dashboard_runners", "Unknown")
     end
   end
 
@@ -635,9 +641,14 @@ defmodule TuistWeb.RunnerJobsLive do
   """
   def platform_badge_color(fleet_name) when is_binary(fleet_name) do
     cond do
-      String.starts_with?(fleet_name, "macos-") -> "information"
-      String.starts_with?(fleet_name, "linux-") -> "attention"
-      true -> "neutral"
+      String.starts_with?(fleet_name, Catalog.fleet_name_prefixes(:macos)) ->
+        "information"
+
+      String.starts_with?(fleet_name, Catalog.fleet_name_prefixes(:linux)) ->
+        "attention"
+
+      true ->
+        "neutral"
     end
   end
 

--- a/server/test/tuist_web/live/runner_job_live_test.exs
+++ b/server/test/tuist_web/live/runner_job_live_test.exs
@@ -5,6 +5,7 @@ defmodule TuistWeb.RunnerJobLiveTest do
 
   import Phoenix.LiveViewTest
 
+  alias Tuist.Runners.Catalog
   alias Tuist.Runners.JobLogs
   alias Tuist.Runners.Jobs
   alias Tuist.Runners.JobSteps
@@ -34,7 +35,7 @@ defmodule TuistWeb.RunnerJobLiveTest do
       Jobs.enqueue(%{
         workflow_job_id: 31_001,
         account_id: account.id,
-        fleet_name: "macos-xcode-26.4",
+        fleet_name: Catalog.pool_name(%{platform: :macos, xcode_version: "26.4"}),
         repository: "tuist/tuist",
         workflow_run_id: 310_010,
         workflow_name: "Server",
@@ -59,7 +60,7 @@ defmodule TuistWeb.RunnerJobLiveTest do
       Jobs.enqueue(%{
         workflow_job_id: 31_101,
         account_id: account.id,
-        fleet_name: "linux-amd64",
+        fleet_name: Catalog.pool_name(%{platform: :linux, vcpus: 4, memory_gb: 16}),
         repository: "tuist/cli",
         workflow_run_id: 311_010,
         workflow_name: "CLI",
@@ -69,7 +70,9 @@ defmodule TuistWeb.RunnerJobLiveTest do
         head_sha: "1234567"
       })
 
-    {:ok, candidate} = Jobs.pick_queued("linux-amd64", [])
+    {:ok, candidate} =
+      Jobs.pick_queued(Catalog.pool_name(%{platform: :linux, vcpus: 4, memory_gb: 16}), [])
+
     :ok = Jobs.record_claimed(candidate, "pod-x", DateTime.utc_now())
     :ok = Jobs.record_running(31_101, "tuist-runner-x")
     {:ok, _completed} = Jobs.complete(31_101, "success")

--- a/server/test/tuist_web/live/runner_jobs_live_test.exs
+++ b/server/test/tuist_web/live/runner_jobs_live_test.exs
@@ -5,6 +5,7 @@ defmodule TuistWeb.RunnerJobsLiveTest do
 
   import Phoenix.LiveViewTest
 
+  alias Tuist.Runners.Catalog
   alias Tuist.Runners.Jobs
   alias TuistTestSupport.Fixtures.AccountsFixtures
 
@@ -41,7 +42,7 @@ defmodule TuistWeb.RunnerJobsLiveTest do
       Jobs.enqueue(%{
         workflow_job_id: 99_001,
         account_id: account.id,
-        fleet_name: "macos-xcode-26.4",
+        fleet_name: Catalog.pool_name(%{platform: :macos, xcode_version: "26.4"}),
         repository: "tuist/tuist",
         workflow_run_id: 990_010,
         workflow_name: "Server",


### PR DESCRIPTION
## What changed

- Updated the runner job detail page to derive the Platform badge from the shared runner catalog fleet-name prefixes.
- Updated the runner jobs table to use the same catalog-aware platform detection and badge colors.
- Adjusted LiveView coverage to use production-shaped catalog pool names for macOS and Linux jobs.

## Why

Job analytics showed Platform as `Unknown` for profile-dispatched runner jobs because those jobs store fleet names such as `tuist-runner-pool-macos-26-4` / `tuist-runner-pool-linux-4vcpu-16gb`. The UI helpers only recognized legacy `macos-` and `linux-` prefixes, so valid jobs fell through to the unknown case.

## Impact

Runner job detail and list views now display `macOS` or `Linux` consistently with the existing platform filters and analytics grouping.

## Validation

- `mix format lib/tuist_web/live/runner_job_live.ex lib/tuist_web/live/runner_jobs_live.ex test/tuist_web/live/runner_job_live_test.exs test/tuist_web/live/runner_jobs_live_test.exs`
- `MIX_ENV=test mix test test/tuist_web/live/runner_job_live_test.exs test/tuist_web/live/runner_jobs_live_test.exs`