### PR TITLE
fix(kura): derive FD pool from process capacity

### DIFF
--- a/kura/ops/helm/kura/templates/statefulset.yaml
+++ b/kura/ops/helm/kura/templates/statefulset.yaml
@@ -92,14 +92,18 @@ spec:
             - name: KURA_INTERNAL_TLS_KEY_PATH
               value: {{ printf "/etc/kura/peer-tls/%s" .Values.peerTls.keyFileName | quote }}
             {{- end }}
+            {{- with .Values.config.fileDescriptors.poolSize }}
             - name: KURA_FILE_DESCRIPTOR_POOL_SIZE
-              value: {{ printf "%d" (int .Values.config.fileDescriptors.poolSize) | quote }}
+              value: {{ printf "%d" (int .) | quote }}
+            {{- end }}
             - name: KURA_FILE_DESCRIPTOR_ACQUIRE_TIMEOUT_MS
               value: {{ printf "%d" (int64 .Values.config.fileDescriptors.acquireTimeoutMs) | quote }}
             - name: KURA_DRAIN_COMPLETION_TIMEOUT_MS
               value: {{ printf "%d" (int64 .Values.config.shutdown.drainCompletionTimeoutMs) | quote }}
+            {{- with .Values.config.fileDescriptors.segmentHandleCacheSize }}
             - name: KURA_SEGMENT_HANDLE_CACHE_SIZE
-              value: {{ printf "%d" (int .Values.config.fileDescriptors.segmentHandleCacheSize) | quote }}
+              value: {{ printf "%d" (int .) | quote }}
+            {{- end }}
             - name: KURA_ACCELERATED_FILE_SERVING_ENABLED
               value: {{ ternary "true" "false" .Values.config.acceleratedFileServing.enabled | quote }}
             - name: KURA_ACCELERATED_FILE_SERVING_MODE

--- a/kura/ops/helm/kura/values.yaml
+++ b/kura/ops/helm/kura/values.yaml
@@ -108,9 +108,12 @@ config:
   tenantId: default
   region: fr-par
   fileDescriptors:
-    poolSize: 128
+    # Leave unset to derive from the process RLIMIT_NOFILE after Kura raises
+    # the soft limit to the hard limit at startup.
+    poolSize: null
     acquireTimeoutMs: 5000
-    segmentHandleCacheSize: 32
+    # Leave unset to derive from the effective file descriptor pool size.
+    segmentHandleCacheSize: null
   acceleratedFileServing:
     enabled: true
     mode: splice

--- a/kura/src/app.rs
+++ b/kura/src/app.rs
@@ -62,6 +62,8 @@ impl ShutdownBudget {
 }
 
 pub async fn run() -> Result<(), String> {
+    let nofile_raise_error = raise_nofile_soft_to_hard().err();
+
     let config = Config::from_env().map_err(|error| format!("invalid configuration: {error}"))?;
     let geoip = GeoIp::open();
     let node_location = resolve_node_location(
@@ -72,6 +74,9 @@ pub async fn run() -> Result<(), String> {
     )
     .await;
     let telemetry = init_tracing(&config, &node_location);
+    if let Some(error) = nofile_raise_error {
+        warn!("failed to raise RLIMIT_NOFILE soft limit: {error}");
+    }
     let log_context = log_context_span(&config, &node_location);
     let result = run_with_config(config, geoip, node_location)
         .instrument(log_context)
@@ -86,10 +91,6 @@ async fn run_with_config(
     geoip: Option<GeoIp>,
     node_location: crate::node_location::NodeLocation,
 ) -> Result<(), String> {
-    if let Err(error) = raise_nofile_soft_to_hard() {
-        tracing::warn!("failed to raise RLIMIT_NOFILE soft limit: {error}");
-    }
-
     config
         .ensure_directories()
         .await

--- a/kura/src/config.rs
+++ b/kura/src/config.rs
@@ -270,8 +270,8 @@ impl DerivedRuntimeDefaults {
             .file_descriptor_limit
             .saturating_sub(reserved_fds.max(64))
             .max(256);
-        let file_descriptor_pool_size = clamp_usize(usable_fds / 8, 64, 256);
-        let segment_handle_cache_size = clamp_usize(file_descriptor_pool_size / 4, 16, 64)
+        let file_descriptor_pool_size = clamp_usize(usable_fds / 2, 128, 4096);
+        let segment_handle_cache_size = clamp_usize(file_descriptor_pool_size / 8, 16, 256)
             .min(file_descriptor_pool_size.saturating_sub(1).max(1));
         let metadata_store_max_open_files =
             clamp_usize(usable_fds / 2, 128, 1024).min(i32::MAX as usize) as i32;
@@ -1507,10 +1507,10 @@ mod tests {
             config.peers,
             vec!["http://kura.example.com:7443".to_owned()]
         );
-        assert_eq!(config.file_descriptor_pool_size, 256);
+        assert_eq!(config.file_descriptor_pool_size, 1792);
         assert_eq!(config.file_descriptor_acquire_timeout_ms, 5_000);
         assert_eq!(config.drain_completion_timeout_ms, 240_000);
-        assert_eq!(config.segment_handle_cache_size, 64);
+        assert_eq!(config.segment_handle_cache_size, 224);
         assert_eq!(config.memory_soft_limit_bytes, 716 * BYTES_PER_MIB);
         assert_eq!(config.memory_hard_limit_bytes, 870 * BYTES_PER_MIB);
         assert_eq!(
@@ -1548,6 +1548,19 @@ mod tests {
             }
         );
         assert_eq!(config.sentry_dsn, None);
+    }
+
+    #[test]
+    fn derived_file_descriptor_defaults_scale_with_high_process_limits() {
+        let defaults = DerivedRuntimeDefaults::from_host_resources(HostResources {
+            file_descriptor_limit: 16_384,
+            memory_limit_bytes: 1024 * 1024 * 1024,
+            cpu_count: 6,
+        });
+
+        assert_eq!(defaults.file_descriptor_pool_size, 4096);
+        assert_eq!(defaults.segment_handle_cache_size, 256);
+        assert_eq!(defaults.file_descriptor_acquire_timeout_ms, 5_000);
     }
 
     #[test]

--- a/kura/src/reapi/mod.rs
+++ b/kura/src/reapi/mod.rs
@@ -48,6 +48,7 @@ use crate::{
     config::GrpcTlsConfig,
     constants::MAX_MODULE_TOTAL_BYTES,
     extension::{AccessDecision, ExtensionContext, Principal},
+    io::is_fd_pool_exhausted_error,
     replication::replication_targets,
     state::SharedState,
     utils::{action_cache_key, blob_key, temp_file_path},
@@ -835,7 +836,15 @@ impl ByteStream for ReapiService {
                 &targets,
             )
             .await
-            .map_err(|error| Status::internal(format!("failed to persist CAS blob: {error}")))?;
+            .map_err(|error| {
+                if is_fd_pool_exhausted_error(&error) {
+                    Status::resource_exhausted(format!(
+                        "file descriptor pool exhausted while persisting CAS blob: {error}"
+                    ))
+                } else {
+                    Status::internal(format!("failed to persist CAS blob: {error}"))
+                }
+            })?;
         self.state.notify.notify_one();
         self.state
             .metrics


### PR DESCRIPTION
Resolves <https://github.com/tuist/tuist/issues/11132>

This adjusts Kura's file descriptor admission control for bursty REAPI ByteStream uploads:

- Raise the soft `RLIMIT_NOFILE` before loading config so dynamic defaults are derived from the real process capacity.
- Derive the internal FD pool and segment handle cache from the detected limit while keeping bounded headroom and the existing 5s acquire timeout.
- Stop pinning Helm's default FD pool and segment cache values so production deployments use dynamic sizing unless explicitly overridden.
- Return `RESOURCE_EXHAUSTED` for REAPI ByteStream writes when the FD pool is exhausted, instead of surfacing it as an internal CAS persistence failure.

### How to test locally

- `mise exec -- cargo fmt`
- `git diff --check`
- `mise exec -- cargo test config::tests --lib`
- `mise exec -- cargo test reapi::tests::bytestream_writes_persist_completely_under_concurrency --lib`
- `helm template kura ./kura/ops/helm/kura`
- `helm template kura ./kura/ops/helm/kura --set config.fileDescriptors.poolSize=2048 --set config.fileDescriptors.segmentHandleCacheSize=128`
