### PR TITLE
fix(server): add stable egress for customer allowlists

### DIFF
--- a/infra/helm/platform/README.md
+++ b/infra/helm/platform/README.md
@@ -12,6 +12,7 @@ Platform-level Helm umbrella chart installed **once per Kubernetes cluster** tha
 | `external-secrets` | Pull secrets from external stores (1Password, SOPS, etc.) into the cluster |
 | `metrics-server` | Resource metrics API (`pods.metrics.k8s.io`) consumed by HPAs and `kubectl top` |
 | `ClusterIssuer` | Shared Let's Encrypt issuer wired to Cloudflare DNS-01 |
+| `CiliumEgressGatewayPolicy` | Optional stable outbound source IP for hosted Tuist server traffic |
 
 ## Bootstrap
 
@@ -37,6 +38,10 @@ Other clouds can plug in by adding a `values-<provider>.yaml` overlay that
 sets the provider-specific LoadBalancer annotations + any LB-specific
 ingress-nginx config.
 
+`k8s:install-platform` also loads `values-<cluster-name>.yaml` when present.
+Use that cluster overlay for static environment configuration such as stable
+egress IPs.
+
 ## Local validation
 
 ```bash
@@ -44,6 +49,54 @@ helm dependency update infra/helm/platform
 helm template platform infra/helm/platform | kubectl apply --dry-run=client -f -
 helm lint infra/helm/platform
 ```
+
+## Stable Server Egress
+
+Server pods use a Cilium egress gateway so customer-facing outbound traffic
+leaves from a stable environment-specific address. These addresses are Hetzner
+Floating IPs in the `tuist-workloads` project.
+
+| Cluster | Namespace | Egress IP | HCloud resource | Host configurer | Status |
+|---|---|---|---|---|---|
+| `tuist-staging` | `tuist-staging` | `78.47.186.71` | Floating IP `tuist-staging-server-egress` | Enabled | Active and verified |
+| `tuist-canary` | `tuist-canary` | `78.47.174.50` | Floating IP `tuist-canary-server-egress` | Enabled | Active and verified |
+| `tuist` | `tuist` | `116.202.0.10` | Floating IP `tuist-production-server-egress` | Enabled | Active and verified |
+
+When enabled, a `values-<cluster-name>.yaml` overlay renders:
+
+- `CiliumEgressGatewayPolicy/tuist-server-stable-egress`, which selects server
+  pods in the configured namespace and SNATs public-internet traffic to the
+  configured egress IP.
+- `DaemonSet/kube-system/tuist-server-stable-egress-host-configurer`, which
+  runs only on the node labelled `tuist.dev/stable-egress-gateway=server` and
+  keeps the Floating IP plus source route present on that node's `eth0`.
+
+If the gateway node is replaced or you need to fail over manually:
+
+```bash
+export KUBECONFIG=~/.kube/tuist-production.yaml
+export FLOATING_IP_NAME=tuist-production-server-egress
+export EGRESS_IP=116.202.0.10
+export OLD_NODE=<old-gateway-node>
+export NEW_NODE=<new-general-pool-node>
+
+# Move the cloud route in Hetzner first. Use the tuist-workloads hcloud token.
+hcloud floating-ip assign "$FLOATING_IP_NAME" "$NEW_NODE"
+
+kubectl label node "$OLD_NODE" tuist.dev/stable-egress-gateway- --overwrite
+kubectl label node "$NEW_NODE" tuist.dev/stable-egress-gateway=server --overwrite
+
+# Force Cilium to re-select the gateway after the label move.
+kubectl annotate ciliumegressgatewaypolicy tuist-server-stable-egress \
+  "tuist.dev/reapplied-at=$(date -u +%s)" --overwrite
+
+# Verify from any server pod.
+kubectl -n tuist exec deploy/tuist-tuist-server -- curl -fsS https://api.ipify.org
+```
+
+The verification command should print the environment's configured egress IP.
+Existing outbound connections may reset when the gateway node changes; new
+connections should use the new gateway once the policy is re-applied.
 
 ## Notes
 

--- a/infra/helm/platform/templates/cilium-egress-gateway-host-configurer.yaml
+++ b/infra/helm/platform/templates/cilium-egress-gateway-host-configurer.yaml
@@ -1,0 +1,64 @@
+{{- with .Values.ciliumEgressGateway.server }}
+{{- if and .enabled .hostConfigurator.enabled }}
+{{- $egressIP := required "ciliumEgressGateway.server.egressIP is required when ciliumEgressGateway.server.hostConfigurator.enabled=true" .egressIP }}
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ printf "%s-host-configurer" .name | quote }}
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/name: {{ printf "%s-host-configurer" .name | quote }}
+    app.kubernetes.io/component: stable-egress
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ printf "%s-host-configurer" .name | quote }}
+      app.kubernetes.io/component: stable-egress
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ printf "%s-host-configurer" .name | quote }}
+        app.kubernetes.io/component: stable-egress
+    spec:
+      hostNetwork: true
+      nodeSelector:
+        {{- toYaml .gatewayNodeSelector | nindent 8 }}
+      tolerations:
+        - operator: Exists
+      containers:
+        - name: host-configurer
+          image: {{ .hostConfigurator.image | quote }}
+          imagePullPolicy: {{ .hostConfigurator.imagePullPolicy | quote }}
+          securityContext:
+            privileged: true
+            runAsUser: 0
+          env:
+            - name: EGRESS_IP
+              value: {{ $egressIP | quote }}
+            - name: INTERFACE
+              value: {{ .hostConfigurator.interface | quote }}
+            - name: GATEWAY
+              value: {{ .hostConfigurator.gateway | quote }}
+            - name: ROUTE_TABLE
+              value: {{ .hostConfigurator.routeTable | quote }}
+            - name: RULE_PRIORITY
+              value: {{ .hostConfigurator.rulePriority | quote }}
+            - name: RECONCILE_INTERVAL_SECONDS
+              value: {{ .hostConfigurator.reconcileIntervalSeconds | quote }}
+          command:
+            - /bin/sh
+            - -ec
+            - |
+              while true; do
+                ip addr replace "${EGRESS_IP}/32" dev "${INTERFACE}"
+                ip route replace "${GATEWAY}" dev "${INTERFACE}" scope link table "${ROUTE_TABLE}"
+                ip route replace default via "${GATEWAY}" dev "${INTERFACE}" src "${EGRESS_IP}" table "${ROUTE_TABLE}"
+
+                if ! ip rule show | grep -q "from ${EGRESS_IP} lookup ${ROUTE_TABLE}"; then
+                  ip rule add from "${EGRESS_IP}/32" table "${ROUTE_TABLE}" priority "${RULE_PRIORITY}" 2>/dev/null || true
+                fi
+
+                sleep "${RECONCILE_INTERVAL_SECONDS}"
+              done
+{{- end }}
+{{- end }}

--- a/infra/helm/platform/templates/cilium-egress-gateway-policy.yaml
+++ b/infra/helm/platform/templates/cilium-egress-gateway-policy.yaml
@@ -1,0 +1,26 @@
+{{- with .Values.ciliumEgressGateway.server }}
+{{- if .enabled }}
+{{- $egressIP := required "ciliumEgressGateway.server.egressIP is required when ciliumEgressGateway.server.enabled=true" .egressIP }}
+apiVersion: cilium.io/v2
+kind: CiliumEgressGatewayPolicy
+metadata:
+  name: {{ .name | quote }}
+spec:
+  selectors:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: {{ .namespace | quote }}
+      podSelector:
+        matchLabels:
+          {{- toYaml .podSelector | nindent 10 }}
+  destinationCIDRs:
+    {{- toYaml .destinationCIDRs | nindent 4 }}
+  excludedCIDRs:
+    {{- toYaml .excludedCIDRs | nindent 4 }}
+  egressGateway:
+    nodeSelector:
+      matchLabels:
+        {{- toYaml .gatewayNodeSelector | nindent 8 }}
+    egressIP: {{ $egressIP | quote }}
+{{- end }}
+{{- end }}

--- a/infra/helm/platform/values-tuist-canary.yaml
+++ b/infra/helm/platform/values-tuist-canary.yaml
@@ -1,0 +1,13 @@
+# Canary workload-cluster overlay. Loaded by k8s:install-platform when
+# CLUSTER_NAME=tuist-canary.
+
+# Stable outbound source IP for canary Tuist server traffic. The IP is a
+# Hetzner Floating IP assigned to the gateway node, so the host-configurer keeps
+# the /32 address and source route present on the host interface.
+ciliumEgressGateway:
+  server:
+    enabled: true
+    namespace: tuist-canary
+    egressIP: 78.47.174.50
+    hostConfigurator:
+      enabled: true

--- a/infra/helm/platform/values-tuist-staging.yaml
+++ b/infra/helm/platform/values-tuist-staging.yaml
@@ -1,0 +1,13 @@
+# Staging workload-cluster overlay. Loaded by k8s:install-platform when
+# CLUSTER_NAME=tuist-staging.
+
+# Stable outbound source IP for staging Tuist server traffic. The IP is a
+# Hetzner Floating IP assigned to the gateway node, so the host-configurer keeps
+# the /32 address and source route present on the host interface.
+ciliumEgressGateway:
+  server:
+    enabled: true
+    namespace: tuist-staging
+    egressIP: 78.47.186.71
+    hostConfigurator:
+      enabled: true

--- a/infra/helm/platform/values-tuist.yaml
+++ b/infra/helm/platform/values-tuist.yaml
@@ -1,0 +1,16 @@
+# Production workload-cluster overlay. Loaded by k8s:install-platform when
+# CLUSTER_NAME=tuist.
+
+# Stable outbound source IP for hosted Tuist server traffic that reaches
+# customer infrastructure (for example GHES instances behind IP allowlists).
+# The IP is a Hetzner Floating IP in the tuist-workloads project. The
+# host-configurer DaemonSet makes the address and source route present on the
+# currently labelled gateway node; if that node is replaced, move the Floating
+# IP and `tuist.dev/stable-egress-gateway` node label together.
+ciliumEgressGateway:
+  server:
+    enabled: true
+    namespace: tuist
+    egressIP: 116.202.0.10
+    hostConfigurator:
+      enabled: true

--- a/infra/helm/platform/values.yaml
+++ b/infra/helm/platform/values.yaml
@@ -130,6 +130,45 @@ cloudnative-pg:
   monitoring:
     podMonitorEnabled: false
 
+# Optional Cilium egress gateway policy for managed-cluster workloads that
+# need a stable outbound source IP for customer allowlists.
+#
+# This chart only renders the policy. The egress IP itself must already be
+# provisioned in the cloud provider and assigned to the selected gateway node's
+# network interface; otherwise Cilium will drop matching traffic.
+ciliumEgressGateway:
+  server:
+    enabled: false
+    name: tuist-server-stable-egress
+    namespace: tuist
+    podSelector:
+      app.kubernetes.io/component: server
+      app.kubernetes.io/instance: tuist
+      app.kubernetes.io/name: tuist
+    destinationCIDRs:
+      - 0.0.0.0/0
+    # Keep private/link-local/tailnet destinations on their normal route.
+    # Cilium already excludes in-cluster Pod/Service/Node IPs, but keeping
+    # these here makes the policy's intended public-internet boundary obvious.
+    excludedCIDRs:
+      - 10.0.0.0/8
+      - 100.64.0.0/10
+      - 169.254.0.0/16
+      - 172.16.0.0/12
+      - 192.168.0.0/16
+    gatewayNodeSelector:
+      tuist.dev/stable-egress-gateway: server
+    egressIP: ""
+    hostConfigurator:
+      enabled: false
+      image: quay.io/cilium/cilium:v1.18.7
+      imagePullPolicy: IfNotPresent
+      interface: eth0
+      gateway: 172.31.1.1
+      routeTable: "2010"
+      rulePriority: "2010"
+      reconcileIntervalSeconds: 60
+
 # Whether to emit the ClusterIssuer template below. Turn off if you manage
 # cert-manager issuers with a separate GitOps process.
 clusterIssuer:

--- a/infra/mise/tasks/k8s/install-platform.sh
+++ b/infra/mise/tasks/k8s/install-platform.sh
@@ -81,6 +81,7 @@ HELM_SET_ARGS=(
   --set "external-dns.txtOwnerId=${CLUSTER_NAME}-platform"
 )
 HELM_VALUES_ARGS=(-f "$CHART_PATH/values-hetzner.yaml")
+CLUSTER_VALUES_FILE="$CHART_PATH/values-${CLUSTER_NAME}.yaml"
 
 if [ "$IS_KURA_REGIONAL_CLUSTER" = true ]; then
   log "Regional Kura cluster detected; skipping ingress-nginx install"
@@ -90,6 +91,11 @@ else
     --set "ingress-nginx.controller.service.annotations.load-balancer\.hetzner\.cloud/location=${REGION}"
     --set "ingress-nginx.controller.service.annotations.load-balancer\.hetzner\.cloud/name=${CLUSTER_NAME}-ingress"
   )
+fi
+
+if [ -f "$CLUSTER_VALUES_FILE" ]; then
+  log "Loading platform values overlay $(basename "$CLUSTER_VALUES_FILE")"
+  HELM_VALUES_ARGS+=(-f "$CLUSTER_VALUES_FILE")
 fi
 
 # Sized for a cold cluster: cert-manager CRDs, webhooks, and, on app

--- a/server/priv/docs/en/guides/server/network.md
+++ b/server/priv/docs/en/guides/server/network.md
@@ -2,7 +2,7 @@
 {
   "title": "Network",
   "titleTemplate": ":title | Server | Guides | Tuist",
-  "description": "Network configuration for Tuist, including outbound IP address ranges."
+  "description": "Network configuration for Tuist, including outbound IP addresses."
 }
 ---
 # Network {#network}
@@ -13,13 +13,11 @@ This page covers network-related configuration that may be needed when integrati
 
 If your infrastructure restricts inbound traffic by IP address, you may need to allowlist the IP ranges used by Tuist. This is common when Tuist needs to communicate with services behind a firewall or VPN, such as self-hosted Git providers or artifact storage, or when your GitHub organization uses [IP allow lists](https://docs.github.com/en/organizations/keeping-your-organization-secure/managing-security-settings-for-your-organization/managing-allowed-ip-addresses-for-your-organization).
 
-Tuist outbound network traffic can originate from one of the following IP address ranges:
+Tuist outbound network traffic that reaches customer infrastructure originates from the following stable IP address:
 
 | IP range | CIDR notation |
 |---|---|
-| 74.220.51.0 – 74.220.51.255 | `74.220.51.0/24` |
-| 74.220.59.0 – 74.220.59.255 | `74.220.59.0/24` |
+| 116.202.0.10 | `116.202.0.10/32` |
 
 > [!TIP]
-> Add both ranges to your allowlist to ensure uninterrupted connectivity with Tuist services.
-
+> Add this range to your allowlist to ensure uninterrupted connectivity with Tuist services.


### PR DESCRIPTION
## What changed

- Added optional platform-chart support for `CiliumEgressGatewayPolicy` so Tuist server pods SNAT public outbound traffic through a fixed environment-specific egress IP.
- Added a host-configurer DaemonSet for the selected gateway node so the Hetzner Floating IP and source route are continuously present on the node.
- Added per-cluster platform overlays loaded by `k8s:install-platform`:
  - staging: active Floating IP egress through `78.47.186.71`
  - canary: active Floating IP egress through `78.47.174.50`
  - production: active Floating IP egress through `116.202.0.10`
- Updated the platform README with the shared Floating IP failover runbook.
- Updated the public network guide to document `116.202.0.10/32` as the production outbound address customers should allowlist.

## Why

After the Kubernetes migration, Tuist server pods egressed through whichever worker node handled the traffic. Those node IPs are tied to node lifecycle and no longer matched the documented stable outbound range, which breaks customer infrastructure allowlists such as GHES instances.

The first staging/canary Floating IP reservations were bad at the provider-routing level: the gateway host emitted packets with the `91.98.*` Floating IP source address, but return traffic never arrived, and the IPs were not reachable inbound either. A fresh Floating IP assigned to the same staging node worked immediately with the same host configuration, so the fix replaces the bad reservations instead of changing the Cilium design.

## Impact

Customer-facing outbound traffic from Tuist Server now has stable source IPs:

- staging: `78.47.186.71` (`tuist-staging-server-egress`, delete-protected)
- canary: `78.47.174.50` (`tuist-canary-server-egress`, delete-protected)
- production: `116.202.0.10` (`tuist-production-server-egress`, delete-protected)

Private, link-local, and tailnet ranges are excluded from the egress gateway policy so internal traffic keeps its normal route.

If a gateway node is replaced, operators need to move the relevant HCloud Floating IP assignment and `tuist.dev/stable-egress-gateway=server` node label together; the README includes that runbook.

## Validation

- `helm lint infra/helm/platform`
- `helm template platform infra/helm/platform --show-only templates/cilium-egress-gateway-policy.yaml -f infra/helm/platform/values-hetzner.yaml -f infra/helm/platform/values-tuist-staging.yaml`
- `helm template platform infra/helm/platform --show-only templates/cilium-egress-gateway-host-configurer.yaml -f infra/helm/platform/values-hetzner.yaml -f infra/helm/platform/values-tuist-staging.yaml`
- `helm template platform infra/helm/platform --show-only templates/cilium-egress-gateway-policy.yaml -f infra/helm/platform/values-hetzner.yaml -f infra/helm/platform/values-tuist-canary.yaml`
- `helm template platform infra/helm/platform --show-only templates/cilium-egress-gateway-host-configurer.yaml -f infra/helm/platform/values-hetzner.yaml -f infra/helm/platform/values-tuist-canary.yaml`
- `helm template platform infra/helm/platform --show-only templates/cilium-egress-gateway-policy.yaml -f infra/helm/platform/values-hetzner.yaml -f infra/helm/platform/values-tuist.yaml`
- Applied the platform chart to staging and verified:
  - `CiliumEgressGatewayPolicy/tuist-server-stable-egress` targets `78.47.186.71`
  - `DaemonSet/kube-system/tuist-server-stable-egress-host-configurer` is rolled out
  - `kubectl -n tuist-staging exec deploy/tuist-tuist-server -- curl -4 https://api.ipify.org` returns `78.47.186.71`
- Applied the platform chart to canary and verified:
  - `CiliumEgressGatewayPolicy/tuist-server-stable-egress` targets `78.47.174.50`
  - `DaemonSet/kube-system/tuist-server-stable-egress-host-configurer` is rolled out
  - `kubectl -n tuist-canary exec deploy/tuist-tuist-server -- curl -4 https://api.ipify.org` returns `78.47.174.50`
- Previously applied the platform chart to production and verified representative server pods report `116.202.0.10` from `https://api.ipify.org`.
- Verified final HCloud Floating IP table:
  - `tuist-staging-server-egress`: `78.47.186.71`, assigned to `tuist-staging-md-0-jmvxt-ljwhq-4jv57`, delete-protected
  - `tuist-canary-server-egress`: `78.47.174.50`, assigned to `tuist-canary-md-0-rwjfn-kh7bn-4ft4f`, delete-protected
  - `tuist-production-server-egress`: `116.202.0.10`, assigned to `tuist-md-0-vq65h-zm8qt-rdln4`, delete-protected
- Deleted the bad old `91.98.110.60` and `91.98.105.79` Floating IP reservations after replacing them.
- Verified temporary debug pods were deleted from staging and canary.
