### PR TITLE
fix(infra): bump pinned Kura runtime

### DIFF
--- a/infra/helm/tuist/values-managed-common.yaml
+++ b/infra/helm/tuist/values-managed-common.yaml
@@ -263,7 +263,7 @@ runnersController:
 kuraRuntime:
   image:
     repository: ghcr.io/tuist/kura
-    tag: "0.7.1"
+    tag: "0.7.3"
 
 # Everything below = external. The managed deployment never runs embedded
 # Postgres / ClickHouse / object storage / observability stacks.


### PR DESCRIPTION
## What changed

Bumps the pinned managed Kura runtime image from `0.7.1` to `0.7.3` in `values-managed-common.yaml`.

## Why

The backward-compatibility acceptance gate is failing because the oldest supported CLI (`4.150.0`) is routed to the regional Kura module cache and receives `401 {"message":"Invalid or expired token"}` from the Kura runtime. The chart currently pins the managed Kura runtime to `0.7.1`, even though `kura@0.7.3` is the latest release.

`#11137` made the Kura runtime pin explicit and intended release automation to bump it on every `kura@` release, but the `kura@0.7.3` release commit only updated `kura/CHANGELOG.md`, `kura/Cargo.toml`, and `kura/Cargo.lock`. This left deploys using the stale runtime pin.

## Impact

The next managed server deploy will reconcile account Kura meshes against `ghcr.io/tuist/kura:0.7.3`, which should unblock the oldest-supported-CLI module-cache acceptance path.

## Validation

- Confirmed `kura@0.7.3` is the latest Kura release with `gh release list --repo tuist/tuist --limit 5`.
- Parsed `infra/helm/tuist/values-managed-common.yaml` with Ruby's YAML parser.
