### PR TITLE
fix(ci): harden CLI release artifact handling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,7 +92,7 @@ jobs:
     needs: check-releases
     if: needs.check-releases.outputs.cli-should-release == 'true'
     runs-on: macos-26
-    timeout-minutes: 50
+    timeout-minutes: 75
     permissions:
       contents: write
       id-token: write
@@ -1916,21 +1916,30 @@ jobs:
           name: cli-artifacts
 
       - name: Download CLI Linux x86_64 artifacts
-        if: needs.check-releases.outputs.cli-should-release == 'true' && needs.release-cli-linux.result == 'success'
+        if: |
+          needs.check-releases.outputs.cli-should-release == 'true' &&
+          needs.release-cli.result == 'success' &&
+          needs.release-cli-linux.result == 'success'
         uses: actions/download-artifact@v4
         with:
           name: cli-linux-x86_64-artifacts
           path: build-linux-x86_64
 
       - name: Download CLI Linux aarch64 artifacts
-        if: needs.check-releases.outputs.cli-should-release == 'true' && needs.release-cli-linux.result == 'success'
+        if: |
+          needs.check-releases.outputs.cli-should-release == 'true' &&
+          needs.release-cli.result == 'success' &&
+          needs.release-cli-linux.result == 'success'
         uses: actions/download-artifact@v4
         with:
           name: cli-linux-aarch64-artifacts
           path: build-linux-aarch64
 
       - name: Merge Linux artifacts into build directory
-        if: needs.check-releases.outputs.cli-should-release == 'true' && needs.release-cli-linux.result == 'success'
+        if: |
+          needs.check-releases.outputs.cli-should-release == 'true' &&
+          needs.release-cli.result == 'success' &&
+          needs.release-cli-linux.result == 'success'
         run: |
           # Append Linux checksums to main checksum files
           cat build-linux-x86_64/SHASUMS256.txt >> build/SHASUMS256.txt


### PR DESCRIPTION
## What changed

The release workflow now:

- Downloads and merges Linux CLI artifacts in `commit-and-release` only when both CLI release jobs succeeded: `release-cli` and `release-cli-linux`.
- Increases the macOS `Release CLI` timeout from 50 to 75 minutes.

The artifact guards now match the existing guards for CLI tag creation, the CLI GitHub release, Homebrew updates, and release commit changes.

## Why it changed

The failed release run had successful Linux CLI jobs, but the macOS `Release CLI` job was cancelled before it uploaded `cli-artifacts`. That job ran for essentially its full 50-minute timeout while still inside `mise run --no-deps cli:bundle`, with cleanup terminating `xcodebuild` and `SWBBuildService`.

Because `commit-and-release` runs under `always()`, it skipped the macOS artifact download but still downloaded Linux artifacts and tried to append checksums into `build/SHASUMS256.txt`. The `build` directory only comes from `cli-artifacts`, so the job failed with `No such file or directory`.

Recent successful macOS CLI release jobs were already around 39 to 46 minutes, so the 50-minute timeout had very little headroom. The 75-minute timeout gives the release path breathing room while still bounding genuinely stuck builds.

## Impact

A cancelled or failed macOS CLI release no longer causes a secondary artifact merge failure. The macOS CLI release also has enough timeout headroom for the current observed build-time range. Other successful components can still proceed through the aggregate release job, preserving the existing partial-release behavior.

## Validation

- Parsed `.github/workflows/release.yml` with Ruby YAML loading.
- Reviewed the surrounding release guards to confirm the CLI release path already requires both CLI jobs later in the workflow.

`actionlint` was not installed in the worktree, so I could not run it locally.
