### PR TITLE
chore(cli): bump Command to 0.14.9

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -608,7 +608,7 @@
       "kind" : "registry",
       "location" : "",
       "state" : {
-        "version" : "0.14.8"
+        "version" : "0.14.9"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -1744,7 +1744,7 @@ let package = Package(
         .package(id: "tuist.Path", .upToNextMajor(from: "0.3.8")),
         .package(id: "p-x9.MachOKit", .upToNextMajor(from: "0.46.1")),
         .package(id: "tuist.FileSystem", .upToNextMajor(from: "0.17.3")),
-        .package(id: "tuist.Command", .upToNextMajor(from: "0.14.9")),
+        .package(id: "tuist.Command", .upToNextMajor(from: "0.14.8")),
         .package(id: "apple.swift-crypto", from: "3.0.0"),
         .package(id: "crspybits.swift-log-file", .upToNextMajor(from: "0.1.0")),
         .package(id: "tuist.Noora", from: "0.55.0"),

--- a/Package.swift
+++ b/Package.swift
@@ -1744,7 +1744,7 @@ let package = Package(
         .package(id: "tuist.Path", .upToNextMajor(from: "0.3.8")),
         .package(id: "p-x9.MachOKit", .upToNextMajor(from: "0.46.1")),
         .package(id: "tuist.FileSystem", .upToNextMajor(from: "0.17.3")),
-        .package(id: "tuist.Command", .upToNextMajor(from: "0.14.8")),
+        .package(id: "tuist.Command", .upToNextMajor(from: "0.14.9")),
         .package(id: "apple.swift-crypto", from: "3.0.0"),
         .package(id: "crspybits.swift-log-file", .upToNextMajor(from: "0.1.0")),
         .package(id: "tuist.Noora", from: "0.55.0"),


### PR DESCRIPTION
## What changed

Updates the resolved `Command` pin from 0.14.8 to **0.14.9** in `Package.resolved`, pulling in tuist/Command#275. The manifest range (`upToNextMajor(from: "0.14.8")`) already permits 0.14.9, so no `Package.swift` change is needed — this is the pin-only update `swift package update tuist.command` produces.

## Why

`tuist graph` on very large projects (the AWS SDK for iOS — thousands of SwiftPM targets) aborts on CI with:

```
✖ Error
  Error Domain=NSPOSIXErrorDomain Code=9 "Bad file descriptor"
```

Graph generation fans out many concurrent subprocesses (manifest + Swift Package Manager evaluation), each holding pipe file descriptors. Since `Command` 0.14.4 made the subprocess wait async (fixing thread starvation), launches are no longer implicitly bounded by the cooperative thread pool — so on CI's low default soft `RLIMIT_NOFILE` (256 on macOS) the concurrent pipes exhaust the descriptor table and `Process.run()` fails with EBADF.

## The fix

Command 0.14.9 (#275) bounds concurrent subprocess launches with an `AsyncResourceLimiter` sized from the current soft fd limit, so the descriptor table can't be exhausted regardless of how many commands are fanned out. It suspends waiters rather than blocking threads, so it doesn't reintroduce the thread starvation. The fix is **internal to Command** — no Tuist code changes, only the dependency version.

Pairs with #11036 (raise the open-file limit at startup): the limiter is the correctness guarantee, the raise gives it more headroom.

## Validation

`swift package resolve --replace-scm-with-registry` succeeds with the pin at 0.14.9 (no manifest change, so no full re-resolve / no `originHash` drift). Fix-level validation (limiter + red/green concurrency-bound test) lives in tuist/Command#275.
