### PR TITLE
ci(infra): land tuist-ops-deployment workflow on main

### DIFF
--- a/.github/workflows/tuist-ops-deployment.yml
+++ b/.github/workflows/tuist-ops-deployment.yml
@@ -1,0 +1,163 @@
+name: Tuist Ops Deployment
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - tuist-ops/**
+      - infra/helm/tuist-ops/**
+      - .github/workflows/tuist-ops-deployment.yml
+  workflow_dispatch:
+    inputs:
+      commit_sha:
+        description: Commit SHA to deploy (defaults to github.sha)
+        required: false
+      image_tag:
+        description: Pre-built image tag to deploy instead of building
+        required: false
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: tuist-ops-deploy-mgmt
+  cancel-in-progress: false
+
+env:
+  MISE_VERSION: "2026.4.18"
+  MISE_GITHUB_TOKEN: ${{ secrets.TUIST_DEPLOY_GITHUB_TOKEN || github.token }}
+  REGISTRY: ghcr.io
+  IMAGE_NAME: tuist/tuist-ops
+  HELM_CHART_PATH: infra/helm/tuist-ops
+  HELM_RELEASE_NAME: tuist-ops
+  NAMESPACE: tuist-ops
+  DEPLOY_SHA: ${{ inputs.commit_sha || github.sha }}
+
+jobs:
+  build:
+    name: Build and push tuist-ops image
+    if: inputs.image_tag == ''
+    runs-on: tuist-linux
+    timeout-minutes: 30
+    outputs:
+      image_tag: ${{ steps.tag.outputs.image_tag }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ env.DEPLOY_SHA }}
+          persist-credentials: false
+      - id: tag
+        run: echo "image_tag=sha-${DEPLOY_SHA:0:12}" >> "$GITHUB_OUTPUT"
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v6
+        name: Build and push tuist-ops image
+        with:
+          context: .
+          file: tuist-ops/Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.image_tag }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+          cache-from: type=gha,scope=tuist-ops
+          cache-to: type=gha,mode=max,scope=tuist-ops
+
+  deploy:
+    name: Deploy to mgmt
+    needs: build
+    if: always() && (needs.build.result == 'success' || needs.build.result == 'skipped')
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment:
+      # Reuses the existing environment from mgmt-cluster-apply.yml
+      # — same OP_SERVICE_ACCOUNT_TOKEN scope (read on the
+      # tuist-k8s-mgmt 1P vault) and same access gates. Any approval
+      # rules attached to mgmt-cluster-apply apply here too, which
+      # is the right posture for any workflow that mutates the mgmt
+      # cluster.
+      name: mgmt-cluster-apply
+    env:
+      KUBECONFIG: ${{ github.workspace }}/.kube/config
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ env.DEPLOY_SHA }}
+          persist-credentials: false
+      - uses: jdx/mise-action@v4.0.1
+        with:
+          version: ${{ env.MISE_VERSION }}
+          install_args: "helm kubectl"
+          cache: "false"
+      - uses: 1password/install-cli-action@v2
+      - name: Load kubeconfig from 1Password
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+        run: |
+          mkdir -p "$(dirname "$KUBECONFIG")"
+          # Matches the pattern used by slack-deployment.yml + the
+          # main server deploy: a 1P-stored kubeconfig per env.
+          op document get "kubeconfig: tuist-mgmt" \
+            --vault "tuist-k8s-mgmt" --output "$KUBECONFIG"
+          chmod 600 "$KUBECONFIG"
+      - name: Verify cluster reachability
+        run: |
+          set -euo pipefail
+          API="$(kubectl config view --minify --raw -o jsonpath='{.clusters[0].cluster.server}')"
+          echo "Reaching apiserver at $API"
+          kubectl --request-timeout=10s get --raw /version >/dev/null
+      - name: Resolve image tag
+        env:
+          INPUT_IMAGE_TAG: ${{ inputs.image_tag }}
+          BUILT_IMAGE_TAG: ${{ needs.build.outputs.image_tag }}
+        run: |
+          set -euo pipefail
+          if [ -n "${INPUT_IMAGE_TAG:-}" ]; then
+            IMAGE_TAG="$INPUT_IMAGE_TAG"
+          else
+            IMAGE_TAG="$BUILT_IMAGE_TAG"
+          fi
+
+          if [ -z "$IMAGE_TAG" ]; then
+            echo "No image tag available to deploy."
+            exit 1
+          fi
+
+          echo "IMAGE_TAG=$IMAGE_TAG" >> "$GITHUB_ENV"
+          echo "Deploying image tag $IMAGE_TAG"
+      - name: helm upgrade --install
+        run: |
+          helm upgrade --install "$HELM_RELEASE_NAME" "$HELM_CHART_PATH" \
+            --namespace "$NAMESPACE" --create-namespace \
+            -f "$HELM_CHART_PATH/values-managed-mgmt.yaml" \
+            --set image.tag="$IMAGE_TAG" \
+            --atomic --timeout 10m --wait
+      - name: Diagnostics on failure
+        if: failure()
+        run: |
+          set +e
+          echo "::group::helm history"
+          helm history "$HELM_RELEASE_NAME" -n "$NAMESPACE" --max 10 || true
+          echo "::endgroup::"
+          echo "::group::helm get manifest"
+          helm get manifest "$HELM_RELEASE_NAME" -n "$NAMESPACE" 2>&1 | head -200 || true
+          echo "::endgroup::"
+          echo "::group::workload resources"
+          kubectl -n "$NAMESPACE" get deploy,svc,ingress,externalsecret,pods,cluster.postgresql.cnpg.io \
+            -l app.kubernetes.io/instance="$HELM_RELEASE_NAME" -o wide || true
+          echo "::endgroup::"
+          echo "::group::deployment"
+          kubectl -n "$NAMESPACE" describe deploy/"$HELM_RELEASE_NAME" || true
+          echo "::endgroup::"
+          echo "::group::CNPG cluster"
+          kubectl -n "$NAMESPACE" describe cluster.postgresql.cnpg.io || true
+          echo "::endgroup::"
+          echo "::group::events"
+          kubectl -n "$NAMESPACE" get events --sort-by=.lastTimestamp 2>&1 | tail -100 || true
+          echo "::endgroup::"


### PR DESCRIPTION
Companion to PR #10988. Lands the real `tuist-ops-deployment.yml` on main so the workflow_dispatch UI exposes it. The push trigger is gated on paths that don't exist on main yet (`tuist-ops/**`, `infra/helm/tuist-ops/**`), so the workflow sits dormant until #10988 merges — until then we can dispatch it manually against the #10988 branch to validate the build + deploy path.