### PR TITLE
ci(kura): flip the compile gate to Bazel (container: debian)

### DIFF
--- a/.github/workflows/kura.yml
+++ b/.github/workflows/kura.yml
@@ -56,25 +56,88 @@ jobs:
   compile:
     name: Compile
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
+    # The compile gate is a Bazel build that dogfoods Kura as the remote cache. Kura runs as
+    # a normal `docker run` container (bazel/ci-kura-cache.sh) so it can be GRACEFULLY stopped
+    # (SIGTERM -> RocksDB flush) as the last step before its data dir is snapshotted by
+    # actions/cache — the restore/save split persists the action cache across runs. Bazel runs
+    # inside the dev image (bazel/linux-dev.Dockerfile, built in-step) because the cross-GCC
+    # toolchain is non-hermetic and must match the bookworm runtime; the build command is
+    # inlined (no wrapper script). Builds BOTH Linux arches with warnings-as-errors (the old
+    # `cargo check` only checked x86_64). `//:all` is the crate's lib+bin+test targets; it
+    # excludes the OCI image, which builds under a different (transition) cache keyspace.
+    # See kura/docs/bazel-migration-plan.md (Phase 3.6).
     steps:
       - uses: actions/checkout@v4
 
-      - uses: jdx/mise-action@v4.0.1
+      # The action cache lives in Kura; persist Kura's data dir. Restore/save split so a red
+      # run still warms the next, and so the save happens AFTER Kura is gracefully stopped.
+      - name: Restore Kura cache (data dir)
+        id: kura-cache
+        uses: actions/cache/restore@v4
         with:
-          version: ${{ env.MISE_VERSION }}
-          install_args: --force rust
-          working_directory: kura
+          path: ${{ runner.temp }}/kura-data
+          key: kura-compile-data-${{ hashFiles('kura/MODULE.bazel.lock', 'kura/Cargo.Bazel.lock') }}
+          restore-keys: |
+            kura-compile-data-
 
-      - uses: Swatinem/rust-cache@v2
+      # Bazel's repository cache (downloaded crate sources) is not served by Kura's REAPI.
+      - name: Cache Bazel repository downloads
+        uses: actions/cache@v4
         with:
-          shared-key: kura-rust-${{ runner.os }}
-          workspaces: |
-            kura -> target
+          path: ${{ runner.temp }}/bazel-repo
+          key: bazel-repo-compile-${{ hashFiles('kura/MODULE.bazel.lock', 'kura/Cargo.Bazel.lock') }}
+          restore-keys: |
+            bazel-repo-compile-
 
-      - name: Compile without warnings
-        run: env -u RUSTUP_TOOLCHAIN RUSTFLAGS="-D warnings" cargo check --locked --all-targets
+      - name: Build the Bazel dev image (Debian Bookworm + cross GCC)
+        run: docker build -f kura/bazel/linux-dev.Dockerfile -t kura-bazel-dev kura
+
+      - name: Start Kura as the Bazel remote cache
+        working-directory: kura
+        env:
+          KURA_CI_DATA_DIR: ${{ runner.temp }}/kura-data
+        run: bash bazel/ci-kura-cache.sh start
+
+      - name: Compile (Bazel, both Linux arches, warnings-as-errors)
+        run: |
+          docker run --rm \
+            --network kura-bazel-ci-net \
+            -v "$GITHUB_WORKSPACE/kura:/workspace/kura" \
+            -v "${{ runner.temp }}/bazel-repo:/bazelrepo" \
+            kura-bazel-dev \
+            bash -c '
+              mkdir -p /bazelrepo
+              {
+                echo "common --repository_cache=/bazelrepo"
+                echo "common --http_timeout_scaling=8"
+                echo "common --remote_cache=grpc://kura-bazel-ci-cache:50051"
+                echo "common --remote_instance_name=kura-bazel-ci"
+                echo "common --remote_upload_local_results=true"
+                echo "common --remote_download_outputs=minimal"
+              } > /root/.bazelrc
+              ec=0
+              for platform in //bazel/platforms:linux_x86_64 //bazel/platforms:linux_arm64; do
+                bazel build //:all -c opt --platforms="$platform" \
+                  --@rules_rust//rust/settings:extra_rustc_flags=-Dwarnings || ec=$?
+              done
+              chmod -R a+rX /bazelrepo 2>/dev/null || true
+              exit $ec'
+
+      - name: Stop Kura and surface cache errors
+        if: always()
+        working-directory: kura
+        env:
+          KURA_CI_DATA_DIR: ${{ runner.temp }}/kura-data
+        run: bash bazel/ci-kura-cache.sh stop
+
+      - name: Save Kura cache (data dir)
+        if: always() && steps.kura-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ runner.temp }}/kura-data
+          key: kura-compile-data-${{ hashFiles('kura/MODULE.bazel.lock', 'kura/Cargo.Bazel.lock') }}
 
   clippy:
     name: Clippy


### PR DESCRIPTION
## What

Replaces the Kura `compile` CI job's `cargo check --locked --all-targets` with a **Bazel build that dogfoods Kura as the remote cache**. First **Phase-3.6 cutover** step (production CI flips Cargo → Bazel). **Draft** — based on `kura-bazel-phase1` (needs the Bazel foundation on the target branch).

## Design — mirrors the validated shadow `bazel-linux` job, reusing existing files (no new scripts)

Runs on the **host runner** (not `container:` / not `services:`), so Kura's lifecycle is fully controlled:

1. `actions/cache/restore` Kura's data dir (the action cache lives *in* Kura).
2. `docker build` the dev image from `kura/bazel/linux-dev.Dockerfile`.
3. Start Kura as a **normal `docker run` container** via `bazel/ci-kura-cache.sh start`.
4. `bazel build //:all` for **both** Linux arches **inside the dev container** — command **inlined** in the step (no wrapper script).
5. **Gracefully stop Kura** (`ci-kura-cache.sh stop` → `docker stop -t 60` → RocksDB flush) — the last step *before* the snapshot.
6. `actions/cache/save` the now-flushed data dir.

The restore/save split (vs. the auto-save `actions/cache`) is what lets the save run **after** the graceful stop — so the snapshot is a clean, flushed RocksDB. A `services:`/`container:` Kura can't do this: GitHub stops service containers only in final cleanup, so the cache would snapshot a live, unflushed RocksDB and corrupt it.

## Why the dev container, not host Bazel or `container: debian`

The cc toolchain is **non-hermetic** (`compiler_files = ":empty"`, `tool_paths` → the image's gcc-12 / glibc-2.36). Running Bazel on the host (or installing the toolchain ad-hoc) would compile with the wrong gcc/glibc → binaries that don't match the `bookworm-slim` runtime, and — because the compiler isn't a declared action input — those outputs would land under the **same action keys** as the real builds → **cache poisoning**. So Bazel runs inside the bookworm dev image.

## Coverage upgrade over `cargo check`

- Builds **both** Linux arches (`x86_64` + `arm64`); the cargo gate only checked `x86_64`, so arm64 cross-compile breakage previously surfaced only at release.
- **Warnings-as-errors** via `--@rules_rust//rust/settings:extra_rustc_flags=-Dwarnings`.
- `//:all` = the crate's `kura_lib` + `kura` + `kura_lib_test` targets (compiles the lib, binary, and test code). It **excludes** the OCI image, which builds under a different (rules_oci transition) cache keyspace — see `kura/docs/bazel-migration-plan.md` → "OCI cache fragmentation".

## Caching scope

This is the **per-job snapshot** model (a dedicated `kura-compile-data-*` cache, keyed on the lockfiles). It warms **future compile runs**, not sibling jobs in the same run — cross-job warming needs a **shared persistent Kura**, which is the separate follow-up. The first run is cold; subsequent runs restore the warm Kura data dir.

## Validation

- `actionlint .github/workflows/kura.yml` → clean.
- The underlying `bazel build //:all` (both arches, `-c opt`) is already green on the shadow CI (`kura-bazel.yml` builds `//:kura` + `//:kura_lib_test`, both in `//:all`).

## Follow-ups (not in this PR)

- Shared persistent Kura (warm builds + cross-job warming).
- Flip `tests`, then `e2e`/image, then release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
