### PR TITLE
ci(kura): build the OCI image with Bazel and run e2e against it

### DIFF
--- a/.github/workflows/kura.yml
+++ b/.github/workflows/kura.yml
@@ -281,21 +281,84 @@ jobs:
   e2e-images:
     name: E2E Images
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 90
     if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
-    env:
-      COMPOSE_PROJECT_NAME: kura
+    # Builds the runtime OCI image with rules_oci (//bazel/oci) — the multi-arch index plus
+    # a docker-loadable tarball for the runner's native arch — with no Docker daemon, Buildx,
+    # or QEMU, replacing the `docker compose build` of the bookworm Dockerfile. Dogfoods Kura
+    # as the Bazel remote cache, same as compile/tests. The OCI build compiles the binary
+    # under a rules_oci platform transition (ST-<hash> config), a DIFFERENT action keyspace
+    # than the compile/tests jobs' --platforms flag config, so this job keeps its OWN Kura
+    # cache namespace (kura-oci-data-) — seeding from compile's cache gives 0 hits. The native
+    # tarball is uploaded for the e2e shards to load and run against (KURA_IMAGE + skip-build),
+    # so every shard runs the real bookworm runtime (tini/curl/certs). Still no oci_push — the
+    # release image flip is a later stage.
     steps:
       - uses: actions/checkout@v4
 
-      - name: Show Docker tooling
-        run: docker compose version
+      - name: Restore Kura cache (data dir)
+        id: kura-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ runner.temp }}/kura-data
+          key: kura-oci-data-${{ hashFiles('kura/MODULE.bazel.lock', 'kura/Cargo.Bazel.lock', 'kura/bazel/oci/bookworm_apt.lock.json') }}
+          restore-keys: |
+            kura-oci-data-
 
-      - name: Prebuild Docker images
-        run: docker compose build
+      - name: Cache Bazel repository downloads
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.temp }}/bazel-repo
+          key: bazel-repo-oci-${{ hashFiles('kura/MODULE.bazel.lock', 'kura/Cargo.Bazel.lock', 'kura/bazel/oci/bookworm_apt.lock.json') }}
+          restore-keys: |
+            bazel-repo-oci-
 
-      - name: Archive Docker images
-        run: docker save kura-kura-us kura-kura-eu kura-kura-ap | zstd -T0 -o kura-e2e-images.tar.zst
+      - name: Build the Bazel dev image (Debian Bookworm + cross GCC)
+        run: docker build -f bazel/linux-dev.Dockerfile -t kura-bazel-dev .
+
+      - name: Start Kura as the Bazel remote cache
+        working-directory: kura
+        env:
+          KURA_CI_DATA_DIR: ${{ runner.temp }}/kura-data
+        run: bash bazel/ci-kura-cache.sh start
+
+      - name: Build the OCI image (multi-arch index + native tarball)
+        run: |
+          docker run --rm \
+            --network kura-bazel-ci-net \
+            -v "$GITHUB_WORKSPACE/kura:/workspace/kura" \
+            -v "${{ runner.temp }}/bazel-repo:/bazelrepo" \
+            kura-bazel-dev \
+            bash -c '
+              mkdir -p /bazelrepo
+              {
+                echo "common --repository_cache=/bazelrepo"
+                echo "common --http_timeout_scaling=8"
+                echo "common --remote_cache=grpc://kura-bazel-ci-cache:50051"
+                echo "common --remote_instance_name=kura-bazel-ci"
+                echo "common --remote_upload_local_results=true"
+                echo "common --remote_download_outputs=all"
+              } > /root/.bazelrc
+              bash bazel/ci-oci.sh; ec=$?
+              chmod -R a+rX /bazelrepo 2>/dev/null || true
+              exit $ec'
+
+      - name: Stop Kura and surface cache errors
+        if: always()
+        working-directory: kura
+        env:
+          KURA_CI_DATA_DIR: ${{ runner.temp }}/kura-data
+        run: bash bazel/ci-kura-cache.sh stop
+
+      - name: Save Kura cache (data dir)
+        if: always() && steps.kura-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ runner.temp }}/kura-data
+          key: kura-oci-data-${{ hashFiles('kura/MODULE.bazel.lock', 'kura/Cargo.Bazel.lock', 'kura/bazel/oci/bookworm_apt.lock.json') }}
+
+      - name: Compress the image tarball
+        run: zstd -T0 -o kura-e2e-images.tar.zst bazel-dist/kura-oci.tar
 
       - uses: actions/upload-artifact@v4
         with:
@@ -322,8 +385,14 @@ jobs:
             specs: "spec/e2e/discovery_spec.sh spec/e2e/faults_spec.sh spec/e2e/handoff_spec.sh"
           - shard_name: extension-mtls
             specs: "spec/e2e/extension_spec.sh spec/e2e/mtls_spec.sh"
+    # Runs against the Bazel OCI image built by e2e-images. KURA_IMAGE points every compose
+    # service (base + overlay files) at the single loaded image and KURA_E2E_SKIP_BUILD stops
+    # compose from rebuilding the Dockerfile — so the per-suite retag dance the Dockerfile
+    # path needed is gone. The mise install keeps rust/bazel/buck2: clients_spec drives Bazel
+    # and Buck2 as REAPI clients against the cluster.
     env:
       KURA_E2E_SKIP_BUILD: "1"
+      KURA_IMAGE: kura-bazel:oci
     steps:
       - uses: actions/checkout@v4
 
@@ -341,16 +410,8 @@ jobs:
           name: kura-e2e-images
           path: kura/prebuilt-images
 
-      - name: Load prebuilt Docker images
+      - name: Load the Bazel OCI image
         run: zstd -dc prebuilt-images/kura-e2e-images.tar.zst | docker load
-
-      - name: Retag prebuilt Docker images for every suite project
-        run: |
-          for project in kura-e2e kura-clients kura-discovery kura-faults kura-handoff kura-extension kura-mtls kura-rollout; do
-            for service in kura-us kura-eu kura-ap; do
-              docker tag "kura-${service}" "${project}-${service}"
-            done
-          done
 
       - name: Run end-to-end suite
         run: shellspec ${{ matrix.specs }}

--- a/kura/MODULE.bazel
+++ b/kura/MODULE.bazel
@@ -1,9 +1,10 @@
 """Kura — distributed cache mesh (Rust).
 
-Bazel foundation: workspace skeleton, Rust + cross C/C++ toolchains, and the
-third-party crate graph — enough to build //:all (lib + binary + tests). The
-runtime OCI image (rules_oci/rules_pkg/rules_distroless + the geoip/apt layers)
-is added in a later change; it is intentionally not part of this foundation.
+Bazel build: workspace skeleton, Rust + cross C/C++ toolchains, the third-party
+crate graph (//:all — lib + binary + tests), and the runtime OCI image
+(rules_oci/rules_pkg/rules_distroless + the bookworm apt and geoip layers, see
+//bazel/oci). No Docker daemon / Buildx / QEMU — a multi-arch image builds from a
+single host via the cross toolchains.
 """
 
 module(
@@ -14,6 +15,13 @@ module(
 bazel_dep(name = "rules_rust", version = "0.70.0")
 bazel_dep(name = "rules_cc", version = "0.2.17")
 bazel_dep(name = "platforms", version = "1.0.0")
+
+# Phase 3: build the runtime OCI image with rules_oci (no Docker daemon / Buildx / QEMU).
+# rules_pkg's pkg_tar packages the kura binary into an image layer; rules_distroless
+# resolves the extra Debian runtime packages (tini/curl/...) hermetically as a layer.
+bazel_dep(name = "rules_oci", version = "2.3.0")
+bazel_dep(name = "rules_pkg", version = "1.2.0")
+bazel_dep(name = "rules_distroless", version = "0.8.0")
 
 # Pin the Rust toolchain to match rust-toolchain.toml / mise.toml (1.94.1, edition 2024).
 # extra_target_triples enables cross-compilation between the two Linux arches.
@@ -81,3 +89,63 @@ crate.from_cargo(
     manifests = ["//:Cargo.toml"],
 )
 use_repo(crate, "crates")
+
+# Runtime base image: the same debian:bookworm-slim the production Dockerfile uses, pinned
+# by index digest and fetched for both arches so a multi-arch index builds from one host.
+# arm64 is published as the v8 variant (must be spelled out or the manifest match fails);
+# the @debian_bookworm_slim alias still selects it for our variant-less
+# //bazel/platforms:linux_arm64 (it keys on cpu:arm64).
+oci = use_extension("@rules_oci//oci:extensions.bzl", "oci")
+oci.pull(
+    name = "debian_bookworm_slim",
+    digest = "sha256:0104b334637a5f19aa9c983a91b54c89887c0984081f2068983107a6f6c21eeb",
+    image = "docker.io/library/debian",
+    platforms = [
+        "linux/amd64",
+        "linux/arm64/v8",
+    ],
+)
+use_repo(oci, "debian_bookworm_slim", "debian_bookworm_slim_linux_amd64", "debian_bookworm_slim_linux_arm64_v8")
+
+# Extra runtime packages layered on bookworm-slim to match the production Dockerfile
+# (tini init, curl for healthchecks, libstdc++6 for the C++ deps, ca-certificates),
+# resolved hermetically by rules_distroless and added as an image layer. The lockfile
+# pins each .deb by sha256. Regenerate it after editing the manifest:
+#   bazel run @bookworm_apt//:lock
+#
+# mergedusr = True is REQUIRED here. The bookworm-slim base is merged-/usr: it ships
+# /lib and /lib64 as symlinks to /usr/lib and /usr/lib64. By default rules_distroless
+# flattens the .debs with real /lib and /lib64 directories, which collide with the
+# base's symlinks. overlay2 (the GitHub runner's storage driver) resolves that
+# symlink-vs-directory collision by routing the layer's /lib/* through the base
+# symlink, which drops /lib/x86_64-linux-gnu/ld-linux-x86-64.so.2 — leaving the ELF
+# interpreter symlink dangling, so every binary fails `exec ...: no such file or
+# directory` natively. (Docker Desktop's driver merges it differently, which is why
+# it only reproduced on the native amd64 runner.) mergedusr keeps the layer's paths
+# under /usr with matching symlinks, so it composes cleanly with the base.
+apt = use_extension("@rules_distroless//apt:extensions.bzl", "apt")
+apt.install(
+    name = "bookworm_apt",
+    lock = "//bazel/oci:bookworm_apt.lock.json",
+    manifest = "//bazel/oci:bookworm_apt.yaml",
+    mergedusr = True,
+)
+use_repo(apt, "bookworm_apt")
+
+# GeoIP seed database — DB-IP IP-to-City Lite (https://db-ip.com), CC BY 4.0. The
+# production Dockerfile downloads the time-dependent monthly dump (dbip-city-lite-YYYY-MM);
+# here it is a reproducible, digest-pinned http_file decompressed into an image layer by
+# //bazel/oci (placed at /opt/geoip/dbip-city-lite.mmdb, the path GeoIp::open reads).
+# This is only the startup seed: Kura's background refresher
+# (KURA_GEOIP_REFRESH_INTERVAL_SECS, daily by default) keeps the running database current,
+# and GeoIp::open degrades gracefully when the file is absent. DB-IP keeps only recent
+# months online, so bump the URL + sha256 periodically (re-pin: curl the new dump and
+# `sha256sum`).
+http_file = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
+
+http_file(
+    name = "dbip_city_lite",
+    downloaded_file_path = "dbip-city-lite.mmdb.gz",
+    sha256 = "6785ef1db6cb0d0979bcf437a06bea8f1a4729e050845e530604bdac58781ccb",
+    urls = ["https://download.db-ip.com/free/dbip-city-lite-2026-06.mmdb.gz"],
+)

--- a/kura/MODULE.bazel.lock
+++ b/kura/MODULE.bazel.lock
@@ -21,6 +21,11 @@
     "https://bcr.bazel.build/modules/apple_support/1.24.1/MODULE.bazel": "f46e8ddad60aef170ee92b2f3d00ef66c147ceafea68b6877cb45bd91737f5f8",
     "https://bcr.bazel.build/modules/apple_support/1.24.2/MODULE.bazel": "0e62471818affb9f0b26f128831d5c40b074d32e6dda5a0d3852847215a41ca4",
     "https://bcr.bazel.build/modules/apple_support/1.24.2/source.json": "2c22c9827093250406c5568da6c54e6fdf0ef06238def3d99c71b12feb057a8d",
+    "https://bcr.bazel.build/modules/aspect_bazel_lib/2.14.0/MODULE.bazel": "2b31ffcc9bdc8295b2167e07a757dbbc9ac8906e7028e5170a3708cecaac119f",
+    "https://bcr.bazel.build/modules/aspect_bazel_lib/2.19.3/MODULE.bazel": "253d739ba126f62a5767d832765b12b59e9f8d2bc88cc1572f4a73e46eb298ca",
+    "https://bcr.bazel.build/modules/aspect_bazel_lib/2.21.1/MODULE.bazel": "07e3ce3eaaa50dbd0be7fa0094e36890478937adc780ec53e77fd9fe543af8b1",
+    "https://bcr.bazel.build/modules/aspect_bazel_lib/2.21.1/source.json": "cb7d22ce044efa47c6e251107a35b8a919f5cd35254190d825adff1b7ae21e6e",
+    "https://bcr.bazel.build/modules/aspect_bazel_lib/2.8.1/MODULE.bazel": "812d2dd42f65dca362152101fbec418029cc8fd34cbad1a2fde905383d705838",
     "https://bcr.bazel.build/modules/bazel_features/1.1.1/MODULE.bazel": "27b8c79ef57efe08efccbd9dd6ef70d61b4798320b8d3c134fd571f78963dbcd",
     "https://bcr.bazel.build/modules/bazel_features/1.10.0/MODULE.bazel": "f75e8807570484a99be90abcd52b5e1f390362c258bcb73106f4544957a48101",
     "https://bcr.bazel.build/modules/bazel_features/1.11.0/MODULE.bazel": "f9382337dd5a474c3b7d334c2f83e50b6eaedc284253334cf823044a26de03e8",
@@ -28,6 +33,7 @@
     "https://bcr.bazel.build/modules/bazel_features/1.17.0/MODULE.bazel": "039de32d21b816b47bd42c778e0454217e9c9caac4a3cf8e15c7231ee3ddee4d",
     "https://bcr.bazel.build/modules/bazel_features/1.18.0/MODULE.bazel": "1be0ae2557ab3a72a57aeb31b29be347bcdc5d2b1eb1e70f39e3851a7e97041a",
     "https://bcr.bazel.build/modules/bazel_features/1.19.0/MODULE.bazel": "59adcdf28230d220f0067b1f435b8537dd033bfff8db21335ef9217919c7fb58",
+    "https://bcr.bazel.build/modules/bazel_features/1.20.0/MODULE.bazel": "8b85300b9c8594752e0721a37210e34879d23adc219ed9dc8f4104a4a1750920",
     "https://bcr.bazel.build/modules/bazel_features/1.21.0/MODULE.bazel": "675642261665d8eea09989aa3b8afb5c37627f1be178382c320d1b46afba5e3b",
     "https://bcr.bazel.build/modules/bazel_features/1.23.0/MODULE.bazel": "fd1ac84bc4e97a5a0816b7fd7d4d4f6d837b0047cf4cbd81652d616af3a6591a",
     "https://bcr.bazel.build/modules/bazel_features/1.27.0/MODULE.bazel": "621eeee06c4458a9121d1f104efb80f39d34deff4984e778359c60eaf1a8cb65",
@@ -36,10 +42,16 @@
     "https://bcr.bazel.build/modules/bazel_features/1.30.0/MODULE.bazel": "a14b62d05969a293b80257e72e597c2da7f717e1e69fa8b339703ed6731bec87",
     "https://bcr.bazel.build/modules/bazel_features/1.32.0/MODULE.bazel": "095d67022a58cb20f7e20e1aefecfa65257a222c18a938e2914fd257b5f1ccdc",
     "https://bcr.bazel.build/modules/bazel_features/1.33.0/MODULE.bazel": "8b8dc9d2a4c88609409c3191165bccec0e4cb044cd7a72ccbe826583303459f6",
+    "https://bcr.bazel.build/modules/bazel_features/1.34.0/MODULE.bazel": "e8475ad7c8965542e0c7aac8af68eb48c4af904be3d614b6aa6274c092c2ea1e",
     "https://bcr.bazel.build/modules/bazel_features/1.4.1/MODULE.bazel": "e45b6bb2350aff3e442ae1111c555e27eac1d915e77775f6fdc4b351b758b5d7",
     "https://bcr.bazel.build/modules/bazel_features/1.42.1/MODULE.bazel": "275a59b5406ff18c01739860aa70ad7ccb3cfb474579411decca11c93b951080",
     "https://bcr.bazel.build/modules/bazel_features/1.42.1/source.json": "fcd4396b2df85f64f2b3bb436ad870793ecf39180f1d796f913cc9276d355309",
+    "https://bcr.bazel.build/modules/bazel_features/1.9.0/MODULE.bazel": "885151d58d90d8d9c811eb75e3288c11f850e1d6b481a8c9f766adee4712358b",
     "https://bcr.bazel.build/modules/bazel_features/1.9.1/MODULE.bazel": "8f679097876a9b609ad1f60249c49d68bfab783dd9be012faf9d82547b14815a",
+    "https://bcr.bazel.build/modules/bazel_lib/3.0.0-beta.1/MODULE.bazel": "407729e232f611c3270005b016b437005daa7b1505826798ea584169a476e878",
+    "https://bcr.bazel.build/modules/bazel_lib/3.0.0-rc.0/MODULE.bazel": "d6e00979a98ac14ada5e31c8794708b41434d461e7e7ca39b59b765e6d233b18",
+    "https://bcr.bazel.build/modules/bazel_lib/3.0.0/MODULE.bazel": "22b70b80ac89ad3f3772526cd9feee2fa412c2b01933fea7ed13238a448d370d",
+    "https://bcr.bazel.build/modules/bazel_lib/3.0.0/source.json": "895f21909c6fba01d7c17914bb6c8e135982275a1b18cdaa4e62272217ef1751",
     "https://bcr.bazel.build/modules/bazel_skylib/1.0.3/MODULE.bazel": "bcb0fd896384802d1ad283b4e4eb4d718eebd8cb820b0a2c3a347fb971afd9d8",
     "https://bcr.bazel.build/modules/bazel_skylib/1.1.1/MODULE.bazel": "1add3e7d93ff2e6998f9e118022c84d163917d912f5afafb3058e3d2f1545b5e",
     "https://bcr.bazel.build/modules/bazel_skylib/1.2.0/MODULE.bazel": "44fe84260e454ed94ad326352a698422dbe372b21a1ac9f3eab76eb531223686",
@@ -56,6 +68,9 @@
     "https://bcr.bazel.build/modules/bazel_skylib/1.8.2/source.json": "34a3c8bcf233b835eb74be9d628899bb32999d3e0eadef1947a0a562a2b16ffb",
     "https://bcr.bazel.build/modules/buildozer/8.5.1/MODULE.bazel": "a35d9561b3fc5b18797c330793e99e3b834a473d5fbd3d7d7634aafc9bdb6f8f",
     "https://bcr.bazel.build/modules/buildozer/8.5.1/source.json": "e3386e6ff4529f2442800dee47ad28d3e6487f36a1f75ae39ae56c70f0cd2fbd",
+    "https://bcr.bazel.build/modules/gawk/5.3.2.bcr.1/MODULE.bazel": "cdf8cbe5ee750db04b78878c9633cc76e80dcf4416cbe982ac3a9222f80713c8",
+    "https://bcr.bazel.build/modules/gawk/5.3.2.bcr.3/MODULE.bazel": "f1b7bb2dd53e8f2ef984b39485ec8a44e9076dda5c4b8efd2fb4c6a6e856a31d",
+    "https://bcr.bazel.build/modules/gawk/5.3.2.bcr.3/source.json": "ebe931bfe362e4b41e59ee00a528db6074157ff2ced92eb9e970acab2e1089c9",
     "https://bcr.bazel.build/modules/google_benchmark/1.8.2/MODULE.bazel": "a70cf1bba851000ba93b58ae2f6d76490a9feb74192e57ab8e8ff13c34ec50cb",
     "https://bcr.bazel.build/modules/googletest/1.11.0/MODULE.bazel": "3a83f095183f66345ca86aa13c58b59f9f94a2f81999c093d4eeaa2d262d12f4",
     "https://bcr.bazel.build/modules/googletest/1.14.0.bcr.1/MODULE.bazel": "22c31a561553727960057361aa33bf20fb2e98584bc4fec007906e27053f80c6",
@@ -63,12 +78,17 @@
     "https://bcr.bazel.build/modules/googletest/1.15.2/MODULE.bazel": "6de1edc1d26cafb0ea1a6ab3f4d4192d91a312fd2d360b63adaa213cd00b2108",
     "https://bcr.bazel.build/modules/googletest/1.17.0/MODULE.bazel": "dbec758171594a705933a29fcf69293d2468c49ec1f2ebca65c36f504d72df46",
     "https://bcr.bazel.build/modules/googletest/1.17.0/source.json": "38e4454b25fc30f15439c0378e57909ab1fd0a443158aa35aec685da727cd713",
+    "https://bcr.bazel.build/modules/jq.bzl/0.1.0/MODULE.bazel": "2ce69b1af49952cd4121a9c3055faa679e748ce774c7f1fda9657f936cae902f",
+    "https://bcr.bazel.build/modules/jq.bzl/0.1.0/source.json": "746bf13cac0860f091df5e4911d0c593971cd8796b5ad4e809b2f8e133eee3d5",
     "https://bcr.bazel.build/modules/jsoncpp/1.9.5/MODULE.bazel": "31271aedc59e815656f5736f282bb7509a97c7ecb43e927ac1a37966e0578075",
     "https://bcr.bazel.build/modules/jsoncpp/1.9.6/MODULE.bazel": "2f8d20d3b7d54143213c4dfc3d98225c42de7d666011528dc8fe91591e2e17b0",
     "https://bcr.bazel.build/modules/jsoncpp/1.9.6/source.json": "a04756d367a2126c3541682864ecec52f92cdee80a35735a3cb249ce015ca000",
     "https://bcr.bazel.build/modules/libpfm/4.11.0/MODULE.bazel": "45061ff025b301940f1e30d2c16bea596c25b176c8b6b3087e92615adbd52902",
     "https://bcr.bazel.build/modules/nlohmann_json/3.6.1/MODULE.bazel": "6f7b417dcc794d9add9e556673ad25cb3ba835224290f4f848f8e2db1e1fca74",
     "https://bcr.bazel.build/modules/nlohmann_json/3.6.1/source.json": "f448c6e8963fdfa7eb831457df83ad63d3d6355018f6574fb017e8169deb43a9",
+    "https://bcr.bazel.build/modules/package_metadata/0.0.2/MODULE.bazel": "fb8d25550742674d63d7b250063d4580ca530499f045d70748b1b142081ebb92",
+    "https://bcr.bazel.build/modules/package_metadata/0.0.6/MODULE.bazel": "341dab6f417197494517d54c8e557c0baee1de7aec83543a4fbefe57900acb7e",
+    "https://bcr.bazel.build/modules/package_metadata/0.0.6/source.json": "9581d8b22db43550ac75ecc314ee4fa0a33400bfdc77d1317d8af6b18dca7756",
     "https://bcr.bazel.build/modules/platforms/0.0.10/MODULE.bazel": "8cb8efaf200bdeb2150d93e162c40f388529a25852b332cec879373771e48ed5",
     "https://bcr.bazel.build/modules/platforms/0.0.11/MODULE.bazel": "0daefc49732e227caa8bfa834d65dc52e8cc18a2faf80df25e8caea151a9413f",
     "https://bcr.bazel.build/modules/platforms/0.0.4/MODULE.bazel": "9b328e31ee156f53f3c416a64f8491f7eb731742655a47c9eec4703a71644aee",
@@ -81,6 +101,7 @@
     "https://bcr.bazel.build/modules/platforms/1.0.0/source.json": "f4ff1fd412e0246fd38c82328eb209130ead81d62dcd5a9e40910f867f733d96",
     "https://bcr.bazel.build/modules/protobuf/21.7/MODULE.bazel": "a5a29bb89544f9b97edce05642fac225a808b5b7be74038ea3640fae2f8e66a7",
     "https://bcr.bazel.build/modules/protobuf/27.0/MODULE.bazel": "7873b60be88844a0a1d8f80b9d5d20cfbd8495a689b8763e76c6372998d3f64c",
+    "https://bcr.bazel.build/modules/protobuf/27.1/MODULE.bazel": "703a7b614728bb06647f965264967a8ef1c39e09e8f167b3ca0bb1fd80449c0d",
     "https://bcr.bazel.build/modules/protobuf/29.0-rc2/MODULE.bazel": "6241d35983510143049943fc0d57937937122baf1b287862f9dc8590fc4c37df",
     "https://bcr.bazel.build/modules/protobuf/29.0-rc3/MODULE.bazel": "33c2dfa286578573afc55a7acaea3cada4122b9631007c594bf0729f41c8de92",
     "https://bcr.bazel.build/modules/protobuf/29.1/MODULE.bazel": "557c3457560ff49e122ed76c0bc3397a64af9574691cb8201b4e46d4ab2ecb95",
@@ -119,39 +140,53 @@
     "https://bcr.bazel.build/modules/rules_cc/0.2.17/source.json": "3832f45d145354049137c0090df04629d9c2b5493dc5c2bf46f1834040133a07",
     "https://bcr.bazel.build/modules/rules_cc/0.2.4/MODULE.bazel": "1ff1223dfd24f3ecf8f028446d4a27608aa43c3f41e346d22838a4223980b8cc",
     "https://bcr.bazel.build/modules/rules_cc/0.2.8/MODULE.bazel": "f1df20f0bf22c28192a794f29b501ee2018fa37a3862a1a2132ae2940a23a642",
+    "https://bcr.bazel.build/modules/rules_distroless/0.8.0/MODULE.bazel": "a3e473943b685190e20668f5149f62a116fdcbeba66c7b9778f71d2aed4533c1",
+    "https://bcr.bazel.build/modules/rules_distroless/0.8.0/source.json": "a6931e20d97a13675693adb8b6cd3a0e6eb5218db43dfc83b75566ddc4158efc",
     "https://bcr.bazel.build/modules/rules_foreign_cc/0.9.0/MODULE.bazel": "c9e8c682bf75b0e7c704166d79b599f93b72cfca5ad7477df596947891feeef6",
     "https://bcr.bazel.build/modules/rules_fuzzing/0.5.2/MODULE.bazel": "40c97d1144356f52905566c55811f13b299453a14ac7769dfba2ac38192337a8",
     "https://bcr.bazel.build/modules/rules_java/4.0.0/MODULE.bazel": "5a78a7ae82cd1a33cef56dc578c7d2a46ed0dca12643ee45edbb8417899e6f74",
     "https://bcr.bazel.build/modules/rules_java/5.3.5/MODULE.bazel": "a4ec4f2db570171e3e5eb753276ee4b389bae16b96207e9d3230895c99644b86",
+    "https://bcr.bazel.build/modules/rules_java/6.0.0/MODULE.bazel": "8a43b7df601a7ec1af61d79345c17b31ea1fedc6711fd4abfd013ea612978e39",
+    "https://bcr.bazel.build/modules/rules_java/6.3.0/MODULE.bazel": "a97c7678c19f236a956ad260d59c86e10a463badb7eb2eda787490f4c969b963",
+    "https://bcr.bazel.build/modules/rules_java/6.4.0/MODULE.bazel": "e986a9fe25aeaa84ac17ca093ef13a4637f6107375f64667a15999f77db6c8f6",
     "https://bcr.bazel.build/modules/rules_java/6.5.2/MODULE.bazel": "1d440d262d0e08453fa0c4d8f699ba81609ed0e9a9a0f02cd10b3e7942e61e31",
     "https://bcr.bazel.build/modules/rules_java/7.10.0/MODULE.bazel": "530c3beb3067e870561739f1144329a21c851ff771cd752a49e06e3dc9c2e71a",
     "https://bcr.bazel.build/modules/rules_java/7.12.2/MODULE.bazel": "579c505165ee757a4280ef83cda0150eea193eed3bef50b1004ba88b99da6de6",
     "https://bcr.bazel.build/modules/rules_java/7.2.0/MODULE.bazel": "06c0334c9be61e6cef2c8c84a7800cef502063269a5af25ceb100b192453d4ab",
+    "https://bcr.bazel.build/modules/rules_java/7.3.2/MODULE.bazel": "50dece891cfdf1741ea230d001aa9c14398062f2b7c066470accace78e412bc2",
     "https://bcr.bazel.build/modules/rules_java/7.6.1/MODULE.bazel": "2f14b7e8a1aa2f67ae92bc69d1ec0fa8d9f827c4e17ff5e5f02e91caa3b2d0fe",
     "https://bcr.bazel.build/modules/rules_java/8.3.2/MODULE.bazel": "7336d5511ad5af0b8615fdc7477535a2e4e723a357b6713af439fe8cf0195017",
     "https://bcr.bazel.build/modules/rules_java/8.5.1/MODULE.bazel": "d8a9e38cc5228881f7055a6079f6f7821a073df3744d441978e7a43e20226939",
     "https://bcr.bazel.build/modules/rules_java/8.6.1/MODULE.bazel": "f4808e2ab5b0197f094cabce9f4b006a27766beb6a9975931da07099560ca9c2",
+    "https://bcr.bazel.build/modules/rules_java/8.8.0/MODULE.bazel": "de589d0880911ac007abd521b9f0ddcd8b0dbd05c8553e6f8124a050b83acf7d",
     "https://bcr.bazel.build/modules/rules_java/9.1.0/MODULE.bazel": "ee63f27e36a3fada80342869361182f120a9819c74320e8e65b1e04ba0cd7a9d",
     "https://bcr.bazel.build/modules/rules_java/9.1.0/source.json": "da589573c1dee2c9ac4a568b301269a2e8191110ff0345c1a959fa7ea6c4dfd6",
     "https://bcr.bazel.build/modules/rules_jvm_external/4.4.2/MODULE.bazel": "a56b85e418c83eb1839819f0b515c431010160383306d13ec21959ac412d2fe7",
     "https://bcr.bazel.build/modules/rules_jvm_external/5.1/MODULE.bazel": "33f6f999e03183f7d088c9be518a63467dfd0be94a11d0055fe2d210f89aa909",
     "https://bcr.bazel.build/modules/rules_jvm_external/5.2/MODULE.bazel": "d9351ba35217ad0de03816ef3ed63f89d411349353077348a45348b096615036",
+    "https://bcr.bazel.build/modules/rules_jvm_external/5.3/MODULE.bazel": "bf93870767689637164657731849fb887ad086739bd5d360d90007a581d5527d",
+    "https://bcr.bazel.build/modules/rules_jvm_external/6.1/MODULE.bazel": "75b5fec090dbd46cf9b7d8ea08cf84a0472d92ba3585b476f44c326eda8059c4",
     "https://bcr.bazel.build/modules/rules_jvm_external/6.3/MODULE.bazel": "c998e060b85f71e00de5ec552019347c8bca255062c990ac02d051bb80a38df0",
     "https://bcr.bazel.build/modules/rules_jvm_external/6.7/MODULE.bazel": "e717beabc4d091ecb2c803c2d341b88590e9116b8bf7947915eeb33aab4f96dd",
     "https://bcr.bazel.build/modules/rules_jvm_external/6.7/source.json": "5426f412d0a7fc6b611643376c7e4a82dec991491b9ce5cb1cfdd25fe2e92be4",
+    "https://bcr.bazel.build/modules/rules_kotlin/1.9.0/MODULE.bazel": "ef85697305025e5a61f395d4eaede272a5393cee479ace6686dba707de804d59",
     "https://bcr.bazel.build/modules/rules_kotlin/1.9.6/MODULE.bazel": "d269a01a18ee74d0335450b10f62c9ed81f2321d7958a2934e44272fe82dcef3",
     "https://bcr.bazel.build/modules/rules_kotlin/1.9.6/source.json": "2faa4794364282db7c06600b7e5e34867a564ae91bda7cae7c29c64e9466b7d5",
     "https://bcr.bazel.build/modules/rules_license/0.0.3/MODULE.bazel": "627e9ab0247f7d1e05736b59dbb1b6871373de5ad31c3011880b4133cafd4bd0",
     "https://bcr.bazel.build/modules/rules_license/0.0.7/MODULE.bazel": "088fbeb0b6a419005b89cf93fe62d9517c0a2b8bb56af3244af65ecfe37e7d5d",
     "https://bcr.bazel.build/modules/rules_license/1.0.0/MODULE.bazel": "a7fda60eefdf3d8c827262ba499957e4df06f659330bbe6cdbdb975b768bb65c",
     "https://bcr.bazel.build/modules/rules_license/1.0.0/source.json": "a52c89e54cc311196e478f8382df91c15f7a2bfdf4c6cd0e2675cc2ff0b56efb",
+    "https://bcr.bazel.build/modules/rules_oci/2.3.0/MODULE.bazel": "49075197960c924c0a4d759b7c765c3d00a41d2fdd4a943b42823c1d016ab4ec",
+    "https://bcr.bazel.build/modules/rules_oci/2.3.0/source.json": "47710c28446211b5e61a24015a4669c50c6862d5f91e6bdbc710de8d750cf613",
     "https://bcr.bazel.build/modules/rules_pkg/0.7.0/MODULE.bazel": "df99f03fc7934a4737122518bb87e667e62d780b610910f0447665a7e2be62dc",
     "https://bcr.bazel.build/modules/rules_pkg/1.0.1/MODULE.bazel": "5b1df97dbc29623bccdf2b0dcd0f5cb08e2f2c9050aab1092fd39a41e82686ff",
-    "https://bcr.bazel.build/modules/rules_pkg/1.0.1/source.json": "bd82e5d7b9ce2d31e380dd9f50c111d678c3bdaca190cb76b0e1c71b05e1ba8a",
+    "https://bcr.bazel.build/modules/rules_pkg/1.2.0/MODULE.bazel": "c7db3c2b407e673c7a39e3625dc05dc9f12d6682cbd82a3a5924a13b491eda7e",
+    "https://bcr.bazel.build/modules/rules_pkg/1.2.0/source.json": "9062e00845bf91a4247465d371baa837adf9b6ff44c542f73ba084f07667e1dc",
     "https://bcr.bazel.build/modules/rules_proto/4.0.0/MODULE.bazel": "a7a7b6ce9bee418c1a760b3d84f83a299ad6952f9903c67f19e4edd964894e06",
     "https://bcr.bazel.build/modules/rules_proto/5.3.0-21.7/MODULE.bazel": "e8dff86b0971688790ae75528fe1813f71809b5afd57facb44dad9e8eca631b7",
     "https://bcr.bazel.build/modules/rules_proto/6.0.0-rc1/MODULE.bazel": "1e5b502e2e1a9e825eef74476a5a1ee524a92297085015a052510b09a1a09483",
     "https://bcr.bazel.build/modules/rules_proto/6.0.2/MODULE.bazel": "ce916b775a62b90b61888052a416ccdda405212b6aaeb39522f7dc53431a5e73",
+    "https://bcr.bazel.build/modules/rules_proto/7.0.2/MODULE.bazel": "bf81793bd6d2ad89a37a40693e56c61b0ee30f7a7fdbaf3eabbf5f39de47dea2",
     "https://bcr.bazel.build/modules/rules_proto/7.1.0/MODULE.bazel": "002d62d9108f75bb807cd56245d45648f38275cb3a99dcd45dfb864c5d74cb96",
     "https://bcr.bazel.build/modules/rules_proto/7.1.0/source.json": "39f89066c12c24097854e8f57ab8558929f9c8d474d34b2c00ac04630ad8940e",
     "https://bcr.bazel.build/modules/rules_python/0.10.2/MODULE.bazel": "cc82bc96f2997baa545ab3ce73f196d040ffb8756fd2d66125a530031cd90e5f",
@@ -161,6 +196,7 @@
     "https://bcr.bazel.build/modules/rules_python/0.31.0/MODULE.bazel": "93a43dc47ee570e6ec9f5779b2e64c1476a6ce921c48cc9a1678a91dd5f8fd58",
     "https://bcr.bazel.build/modules/rules_python/0.33.2/MODULE.bazel": "3e036c4ad8d804a4dad897d333d8dce200d943df4827cb849840055be8d2e937",
     "https://bcr.bazel.build/modules/rules_python/0.4.0/MODULE.bazel": "9208ee05fd48bf09ac60ed269791cf17fb343db56c8226a720fbb1cdf467166c",
+    "https://bcr.bazel.build/modules/rules_python/1.0.0/MODULE.bazel": "898a3d999c22caa585eb062b600f88654bf92efb204fa346fb55f6f8edffca43",
     "https://bcr.bazel.build/modules/rules_python/1.3.0/MODULE.bazel": "8361d57eafb67c09b75bf4bbe6be360e1b8f4f18118ab48037f2bd50aa2ccb13",
     "https://bcr.bazel.build/modules/rules_python/1.4.1/MODULE.bazel": "8991ad45bdc25018301d6b7e1d3626afc3c8af8aaf4bc04f23d0b99c938b73a6",
     "https://bcr.bazel.build/modules/rules_python/1.6.0/MODULE.bazel": "7e04ad8f8d5bea40451cf80b1bd8262552aa73f841415d20db96b7241bd027d8",
@@ -170,6 +206,7 @@
     "https://bcr.bazel.build/modules/rules_rust/0.70.0/source.json": "24ae6d23425359db1c3148aa22c389970fce9a06102b2b3a329a2800f9569de2",
     "https://bcr.bazel.build/modules/rules_shell/0.2.0/MODULE.bazel": "fda8a652ab3c7d8fee214de05e7a9916d8b28082234e8d2c0094505c5268ed3c",
     "https://bcr.bazel.build/modules/rules_shell/0.3.0/MODULE.bazel": "de4402cd12f4cc8fda2354fce179fdb068c0b9ca1ec2d2b17b3e21b24c1a937b",
+    "https://bcr.bazel.build/modules/rules_shell/0.4.1/MODULE.bazel": "00e501db01bbf4e3e1dd1595959092c2fadf2087b2852d3f553b5370f5633592",
     "https://bcr.bazel.build/modules/rules_shell/0.6.1/MODULE.bazel": "72e76b0eea4e81611ef5452aa82b3da34caca0c8b7b5c0c9584338aa93bae26b",
     "https://bcr.bazel.build/modules/rules_shell/0.6.1/source.json": "20ec05cd5e592055e214b2da8ccb283c7f2a421ea0dc2acbf1aa792e11c03d0c",
     "https://bcr.bazel.build/modules/rules_swift/1.16.0/MODULE.bazel": "4a09f199545a60d09895e8281362b1ff3bb08bbde69c6fc87aff5b92fcc916ca",
@@ -179,13 +216,24 @@
     "https://bcr.bazel.build/modules/rules_swift/3.1.2/source.json": "e85761f3098a6faf40b8187695e3de6d97944e98abd0d8ce579cb2daf6319a66",
     "https://bcr.bazel.build/modules/stardoc/0.5.1/MODULE.bazel": "1a05d92974d0c122f5ccf09291442580317cdd859f07a8655f1db9a60374f9f8",
     "https://bcr.bazel.build/modules/stardoc/0.5.3/MODULE.bazel": "c7f6948dae6999bf0db32c1858ae345f112cacf98f174c7a8bb707e41b974f1c",
+    "https://bcr.bazel.build/modules/stardoc/0.5.6/MODULE.bazel": "c43dabc564990eeab55e25ed61c07a1aadafe9ece96a4efabb3f8bf9063b71ef",
+    "https://bcr.bazel.build/modules/stardoc/0.6.2/MODULE.bazel": "7060193196395f5dd668eda046ccbeacebfd98efc77fed418dbe2b82ffaa39fd",
     "https://bcr.bazel.build/modules/stardoc/0.7.0/MODULE.bazel": "05e3d6d30c099b6770e97da986c53bd31844d7f13d41412480ea265ac9e8079c",
+    "https://bcr.bazel.build/modules/stardoc/0.7.1/MODULE.bazel": "3548faea4ee5dda5580f9af150e79d0f6aea934fc60c1cc50f4efdd9420759e7",
     "https://bcr.bazel.build/modules/stardoc/0.7.2/MODULE.bazel": "fc152419aa2ea0f51c29583fab1e8c99ddefd5b3778421845606ee628629e0e5",
     "https://bcr.bazel.build/modules/stardoc/0.7.2/source.json": "58b029e5e901d6802967754adf0a9056747e8176f017cfe3607c0851f4d42216",
     "https://bcr.bazel.build/modules/swift_argument_parser/1.3.1.1/MODULE.bazel": "5e463fbfba7b1701d957555ed45097d7f984211330106ccd1352c6e0af0dcf91",
     "https://bcr.bazel.build/modules/swift_argument_parser/1.3.1.2/MODULE.bazel": "75aab2373a4bbe2a1260b9bf2a1ebbdbf872d3bd36f80bff058dccd82e89422f",
     "https://bcr.bazel.build/modules/swift_argument_parser/1.3.1.2/source.json": "5fba48bbe0ba48761f9e9f75f92876cafb5d07c0ce059cc7a8027416de94a05b",
+    "https://bcr.bazel.build/modules/tar.bzl/0.2.1/MODULE.bazel": "52d1c00a80a8cc67acbd01649e83d8dd6a9dc426a6c0b754a04fe8c219c76468",
+    "https://bcr.bazel.build/modules/tar.bzl/0.5.1/MODULE.bazel": "7c2eb3dcfc53b0f3d6f9acdfd911ca803eaf92aadf54f8ca6e4c1f3aee288351",
+    "https://bcr.bazel.build/modules/tar.bzl/0.6.0/MODULE.bazel": "a3584b4edcfafcabd9b0ef9819808f05b372957bbdff41601429d5fd0aac2e7c",
+    "https://bcr.bazel.build/modules/tar.bzl/0.7.0/MODULE.bazel": "cc1acd85da33c80e430b65219a620d54d114628df24a618c3a5fa0b65e988da9",
+    "https://bcr.bazel.build/modules/tar.bzl/0.7.0/source.json": "9becb80306f42d4810bfa16379fb48aad0b01ce5342bc12fe47dcd6af3ac4d7a",
     "https://bcr.bazel.build/modules/upb/0.0.0-20220923-a547704/MODULE.bazel": "7298990c00040a0e2f121f6c32544bab27d4452f80d9ce51349b1a28f3005c43",
+    "https://bcr.bazel.build/modules/yq.bzl/0.1.1/MODULE.bazel": "9039681f9bcb8958ee2c87ffc74bdafba9f4369096a2b5634b88abc0eaefa072",
+    "https://bcr.bazel.build/modules/yq.bzl/0.3.1/MODULE.bazel": "9bcb7151b3cd4681b89d350530eaf7b45e32a44dda94843b8932b0cb1cd4594a",
+    "https://bcr.bazel.build/modules/yq.bzl/0.3.1/source.json": "f0b0f204a2a6b0e34b4c9541efe8c04f2ef1af65948daa784eccea738b21dbd2",
     "https://bcr.bazel.build/modules/zlib/1.2.11/MODULE.bazel": "07b389abc85fdbca459b69e2ec656ae5622873af3f845e1c9d80fe179f3effa0",
     "https://bcr.bazel.build/modules/zlib/1.3.1.bcr.5/MODULE.bazel": "eec517b5bbe5492629466e11dae908d043364302283de25581e3eb944326c4ca",
     "https://bcr.bazel.build/modules/zlib/1.3.1.bcr.5/source.json": "22bc55c47af97246cfc093d0acf683a7869377de362b5d1c552c2c2e16b7a806",
@@ -443,6 +491,77 @@
                 ]
               },
               "toolchain_target_settings": {}
+            }
+          }
+        }
+      }
+    },
+    "@@yq.bzl+//yq:extensions.bzl%yq": {
+      "general": {
+        "bzlTransitiveDigest": "61Uz+o5PnlY0jJfPZEUNqsKxnM/UCLeWsn5VVCc8u5Y=",
+        "usagesDigest": "1CP5kLHwnlFZ3obmnV0eEOp+80JltkcSimeCHXe8/+E=",
+        "recordedInputs": [],
+        "generatedRepoSpecs": {
+          "yq_darwin_amd64": {
+            "repoRuleId": "@@yq.bzl+//yq/toolchain:platforms.bzl%yq_platform_repo",
+            "attributes": {
+              "platform": "darwin_amd64",
+              "version": "4.45.1"
+            }
+          },
+          "yq_darwin_arm64": {
+            "repoRuleId": "@@yq.bzl+//yq/toolchain:platforms.bzl%yq_platform_repo",
+            "attributes": {
+              "platform": "darwin_arm64",
+              "version": "4.45.1"
+            }
+          },
+          "yq_linux_amd64": {
+            "repoRuleId": "@@yq.bzl+//yq/toolchain:platforms.bzl%yq_platform_repo",
+            "attributes": {
+              "platform": "linux_amd64",
+              "version": "4.45.1"
+            }
+          },
+          "yq_linux_arm64": {
+            "repoRuleId": "@@yq.bzl+//yq/toolchain:platforms.bzl%yq_platform_repo",
+            "attributes": {
+              "platform": "linux_arm64",
+              "version": "4.45.1"
+            }
+          },
+          "yq_linux_s390x": {
+            "repoRuleId": "@@yq.bzl+//yq/toolchain:platforms.bzl%yq_platform_repo",
+            "attributes": {
+              "platform": "linux_s390x",
+              "version": "4.45.1"
+            }
+          },
+          "yq_linux_riscv64": {
+            "repoRuleId": "@@yq.bzl+//yq/toolchain:platforms.bzl%yq_platform_repo",
+            "attributes": {
+              "platform": "linux_riscv64",
+              "version": "4.45.1"
+            }
+          },
+          "yq_linux_ppc64le": {
+            "repoRuleId": "@@yq.bzl+//yq/toolchain:platforms.bzl%yq_platform_repo",
+            "attributes": {
+              "platform": "linux_ppc64le",
+              "version": "4.45.1"
+            }
+          },
+          "yq_windows_amd64": {
+            "repoRuleId": "@@yq.bzl+//yq/toolchain:platforms.bzl%yq_platform_repo",
+            "attributes": {
+              "platform": "windows_amd64",
+              "version": "4.45.1"
+            }
+          },
+          "yq_toolchains": {
+            "repoRuleId": "@@yq.bzl+//yq/toolchain:toolchain.bzl%yq_toolchains_repo",
+            "attributes": {
+              "user_repository_name": "yq"
             }
           }
         }

--- a/kura/bazel/ci-oci.sh
+++ b/kura/bazel/ci-oci.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+#
+# Build the runtime OCI image with rules_oci, inside the Debian Bookworm dev container,
+# with no Docker daemon / Buildx / QEMU. Produces:
+#   1. the multi-arch index (//bazel/oci:index) — both Linux arches from this one host,
+#   2. a docker-loadable tarball for the NATIVE arch (bazel-dist/kura-oci.tar) that the
+#      workflow loads on the host to smoke-test and run the e2e suite against.
+#
+# The native tarball is built through //bazel/oci:load_linux_<arch>, which reaches the
+# image via the SAME transition oci_image_index uses (see bazel/oci/transition.bzl). So
+# the native binary is compiled ONCE in the shared transition config and reused by the
+# index, instead of a second build under the plain --platforms flag config (which lands
+# in a different, non-shared output dir — see docs/bazel-migration-plan.md, "OCI cache
+# fragmentation"). Both targets are built in one bazel invocation so they share it.
+#
+# Invoked by .github/workflows/kura-bazel.yml. SHADOW only: nothing is pushed to a
+# registry. See docs/bazel-migration-plan.md (Phase 3.5).
+set -euo pipefail
+
+cd /workspace/kura
+
+NATIVE="$(uname -m)"
+case "$NATIVE" in
+  x86_64) LOAD="//bazel/oci:load_linux_x86_64" ;;
+  aarch64) LOAD="//bazel/oci:load_linux_arm64" ;;
+  *) echo "unsupported native arch: $NATIVE" >&2; exit 1 ;;
+esac
+
+echo "::group::Build multi-arch index + native loadable tarball (shared transition config)"
+bazel build -c opt //bazel/oci:index "$LOAD" --output_groups=+tarball
+echo "::endgroup::"
+
+mkdir -p bazel-dist
+cp -L "bazel-bin/bazel/oci/${LOAD##*:}/tarball.tar" bazel-dist/kura-oci.tar
+chmod a+rw bazel-dist/kura-oci.tar
+ls -l bazel-dist/kura-oci.tar
+
+echo "OCI build complete."

--- a/kura/bazel/oci/BUILD.bazel
+++ b/kura/bazel/oci/BUILD.bazel
@@ -1,0 +1,119 @@
+# Phase 3: the runtime OCI image, assembled by rules_oci with no Docker daemon, Buildx,
+# or QEMU. The kura binary is cross-compiled per arch (see //bazel/toolchains/cc), so a
+# multi-arch image can be built from a single host.
+#
+# Build a single arch by picking the target platform, e.g. from the Linux dev container:
+#   bazel build //bazel/oci:image --platforms=//bazel/platforms:linux_arm64 -c opt
+# `bazel build //bazel/oci:load` produces a docker-loadable tarball (`docker load -i`).
+#
+# This is SHADOW only: it does not push to any registry and changes nothing in the
+# production release path. oci_push/release wiring is a later Phase 3 step.
+
+load("@rules_distroless//distroless:defs.bzl", "cacerts")
+load("@rules_oci//oci:defs.bzl", "oci_image", "oci_image_index", "oci_load")
+load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
+load(":transition.bzl", "transitioned_image")
+
+# The ca-certificates .deb ships individual certs but the bundled
+# /etc/ssl/certs/ca-certificates.crt is produced by its postinst (update-ca-certificates),
+# which rules_distroless does not run. cacerts() generates that bundle so outbound TLS
+# (analytics, peer/object-store HTTPS) verifies — matching what apt produces in production.
+cacerts(
+    name = "cacerts",
+    package = "@bookworm_apt//ca-certificates:data",
+)
+
+# The kura binary at the production path (/usr/local/bin/kura), mode 0755 so the image
+# entrypoint is executable. //:kura transitions to the target platform under --platforms.
+pkg_tar(
+    name = "kura_layer",
+    srcs = ["//:kura"],
+    mode = "0755",
+    package_dir = "/usr/local/bin",
+)
+
+# GeoIP seed: decompress the digest-pinned DB-IP Lite dump (@dbip_city_lite, see
+# MODULE.bazel) and place it at /opt/geoip/dbip-city-lite.mmdb — the path GeoIp::open
+# reads. Arch-independent data, so the one layer is shared by both arches in the index.
+genrule(
+    name = "dbip_mmdb",
+    srcs = ["@dbip_city_lite//file"],
+    outs = ["dbip-city-lite.mmdb"],
+    cmd = "gzip -dc $< > $@",
+)
+
+pkg_tar(
+    name = "geoip_layer",
+    srcs = [":dbip_mmdb"],
+    mode = "0644",
+    package_dir = "/opt/geoip",
+)
+
+# Runtime image matching the production Dockerfile: debian:bookworm-slim base + the
+# extra-packages layer (tini/curl/libstdc++6/ca-certificates) + the binary, with tini as
+# the init entrypoint. @bookworm_apt//:flat is a per-arch tar selected by the build
+# platform, so it composes with the multi-arch index below.
+oci_image(
+    name = "image",
+    base = "@debian_bookworm_slim",
+    entrypoint = [
+        "/usr/bin/tini",
+        "--",
+        "/usr/local/bin/kura",
+    ],
+    env = {"RUST_LOG": "info"},
+    exposed_ports = ["4000"],
+    tars = [
+        "@bookworm_apt//:flat",
+        ":cacerts",
+        ":geoip_layer",
+        ":kura_layer",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+oci_load(
+    name = "load",
+    image = ":image",
+    repo_tags = ["kura-bazel:oci"],
+    visibility = ["//visibility:public"],
+)
+
+# Per-arch loadable tarballs that reach :image through the SAME transition the
+# multi-arch index uses (transitioned_image, see transition.bzl). Building one of
+# these alongside :index compiles the native binary ONCE in the shared `ST-` config
+# instead of a second time under the plain --platforms flag config that `:load`
+# above uses. CI (bazel/ci-oci.sh) builds the host-arch one for the e2e; the flag
+# `:load` stays for local single-arch dev (no remote cache to fragment locally).
+[
+    transitioned_image(
+        name = "image_linux_{}".format(arch),
+        image = ":image",
+        platform = "//bazel/platforms:linux_{}".format(arch),
+    )
+    for arch in ("x86_64", "arm64")
+]
+
+[
+    oci_load(
+        name = "load_linux_{}".format(arch),
+        image = ":image_linux_{}".format(arch),
+        repo_tags = ["kura-bazel:oci"],
+        visibility = ["//visibility:public"],
+    )
+    for arch in ("x86_64", "arm64")
+]
+
+# Multi-arch manifest. With one image + a platforms list, oci_image_index transitions
+# :image to each platform and assembles the index — both arches from a single host
+# (x86_64 via the cross toolchain, arm64 native, or vice versa), no QEMU. Build with
+# `bazel build //bazel/oci:index -c opt` (no --platforms; the transition sets it).
+oci_image_index(
+    name = "index",
+    images = [":image"],
+    platforms = [
+        "//bazel/platforms:linux_x86_64",
+        "//bazel/platforms:linux_arm64",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/kura/bazel/oci/bookworm_apt.lock.json
+++ b/kura/bazel/oci/bookworm_apt.lock.json
@@ -1,0 +1,1257 @@
+{
+	"packages": [
+		{
+			"arch": "amd64",
+			"dependencies": [
+				{
+					"key": "debconf_1.5.82_amd64",
+					"name": "debconf",
+					"version": "1.5.82"
+				},
+				{
+					"key": "openssl_3.0.20-1_deb12u1_amd64",
+					"name": "openssl",
+					"version": "3.0.20-1~deb12u1"
+				},
+				{
+					"key": "libssl3_3.0.20-1_deb12u1_amd64",
+					"name": "libssl3",
+					"version": "3.0.20-1~deb12u1"
+				},
+				{
+					"key": "libc6_2.36-9-p-deb12u14_amd64",
+					"name": "libc6",
+					"version": "2.36-9+deb12u14"
+				},
+				{
+					"key": "libgcc-s1_12.2.0-14-p-deb12u1_amd64",
+					"name": "libgcc-s1",
+					"version": "12.2.0-14+deb12u1"
+				},
+				{
+					"key": "gcc-12-base_12.2.0-14-p-deb12u1_amd64",
+					"name": "gcc-12-base",
+					"version": "12.2.0-14+deb12u1"
+				}
+			],
+			"key": "ca-certificates_20230311-p-deb12u1_amd64",
+			"name": "ca-certificates",
+			"sha256": "0d5f444f594e48c1e16a41d8fc628a09b24c658916a1274025c2330f2a802bed",
+			"urls": [
+				"https://deb.debian.org/debian/pool/main/c/ca-certificates/ca-certificates_20230311+deb12u1_all.deb"
+			],
+			"version": "20230311+deb12u1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "debconf_1.5.82_amd64",
+			"name": "debconf",
+			"sha256": "74ab14194a3762b2fc717917dcfda42929ab98e3c59295a063344dc551cd7cc8",
+			"urls": [
+				"https://deb.debian.org/debian/pool/main/d/debconf/debconf_1.5.82_all.deb"
+			],
+			"version": "1.5.82"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "openssl_3.0.20-1_deb12u1_amd64",
+			"name": "openssl",
+			"sha256": "c19e67a0f6d6891df6094ea2bb6a09b85f3c9981f35c1940d4e7e68346a96d2d",
+			"urls": [
+				"https://deb.debian.org/debian/pool/main/o/openssl/openssl_3.0.20-1~deb12u1_amd64.deb"
+			],
+			"version": "3.0.20-1~deb12u1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libssl3_3.0.20-1_deb12u1_amd64",
+			"name": "libssl3",
+			"sha256": "4fae7e5825e1bb9eaeb6c2679c3d4fce93431d1105426af6de7469f000d3b7f2",
+			"urls": [
+				"https://deb.debian.org/debian/pool/main/o/openssl/libssl3_3.0.20-1~deb12u1_amd64.deb"
+			],
+			"version": "3.0.20-1~deb12u1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libc6_2.36-9-p-deb12u14_amd64",
+			"name": "libc6",
+			"sha256": "ba4f88f73dbc3ae9055f3c20f4523bfdbaf1ad13ff95e258924f77d20b4fbedf",
+			"urls": [
+				"https://deb.debian.org/debian/pool/main/g/glibc/libc6_2.36-9+deb12u14_amd64.deb"
+			],
+			"version": "2.36-9+deb12u14"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libgcc-s1_12.2.0-14-p-deb12u1_amd64",
+			"name": "libgcc-s1",
+			"sha256": "3016e62cb4b7cd8038822870601f5ed131befe942774d0f745622cc77d8a88f7",
+			"urls": [
+				"https://deb.debian.org/debian/pool/main/g/gcc-12/libgcc-s1_12.2.0-14+deb12u1_amd64.deb"
+			],
+			"version": "12.2.0-14+deb12u1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "gcc-12-base_12.2.0-14-p-deb12u1_amd64",
+			"name": "gcc-12-base",
+			"sha256": "1896a2aacf4ad681ff5eacc24a5b0ca4d5d9c9b9c9e4b6de5197bc1e116ea619",
+			"urls": [
+				"https://deb.debian.org/debian/pool/main/g/gcc-12/gcc-12-base_12.2.0-14+deb12u1_amd64.deb"
+			],
+			"version": "12.2.0-14+deb12u1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [
+				{
+					"key": "zlib1g_1-1.2.13.dfsg-1_amd64",
+					"name": "zlib1g",
+					"version": "1:1.2.13.dfsg-1"
+				},
+				{
+					"key": "libc6_2.36-9-p-deb12u14_amd64",
+					"name": "libc6",
+					"version": "2.36-9+deb12u14"
+				},
+				{
+					"key": "libgcc-s1_12.2.0-14-p-deb12u1_amd64",
+					"name": "libgcc-s1",
+					"version": "12.2.0-14+deb12u1"
+				},
+				{
+					"key": "gcc-12-base_12.2.0-14-p-deb12u1_amd64",
+					"name": "gcc-12-base",
+					"version": "12.2.0-14+deb12u1"
+				},
+				{
+					"key": "libcurl4_7.88.1-10-p-deb12u14_amd64",
+					"name": "libcurl4",
+					"version": "7.88.1-10+deb12u14"
+				},
+				{
+					"key": "libzstd1_1.5.4-p-dfsg2-5_amd64",
+					"name": "libzstd1",
+					"version": "1.5.4+dfsg2-5"
+				},
+				{
+					"key": "libssl3_3.0.20-1_deb12u1_amd64",
+					"name": "libssl3",
+					"version": "3.0.20-1~deb12u1"
+				},
+				{
+					"key": "libssh2-1_1.10.0-3-p-b1_amd64",
+					"name": "libssh2-1",
+					"version": "1.10.0-3+b1"
+				},
+				{
+					"key": "librtmp1_2.4-p-20151223.gitfa8646d.1-2-p-b2_amd64",
+					"name": "librtmp1",
+					"version": "2.4+20151223.gitfa8646d.1-2+b2"
+				},
+				{
+					"key": "libnettle8_3.8.1-2_amd64",
+					"name": "libnettle8",
+					"version": "3.8.1-2"
+				},
+				{
+					"key": "libhogweed6_3.8.1-2_amd64",
+					"name": "libhogweed6",
+					"version": "3.8.1-2"
+				},
+				{
+					"key": "libgmp10_2-6.2.1-p-dfsg1-1.1_amd64",
+					"name": "libgmp10",
+					"version": "2:6.2.1+dfsg1-1.1"
+				},
+				{
+					"key": "libgnutls30_3.7.9-2-p-deb12u7_amd64",
+					"name": "libgnutls30",
+					"version": "3.7.9-2+deb12u7"
+				},
+				{
+					"key": "libunistring2_1.0-2_amd64",
+					"name": "libunistring2",
+					"version": "1.0-2"
+				},
+				{
+					"key": "libtasn1-6_4.19.0-2-p-deb12u1_amd64",
+					"name": "libtasn1-6",
+					"version": "4.19.0-2+deb12u1"
+				},
+				{
+					"key": "libp11-kit0_0.24.1-2_amd64",
+					"name": "libp11-kit0",
+					"version": "0.24.1-2"
+				},
+				{
+					"key": "libffi8_3.4.4-1_amd64",
+					"name": "libffi8",
+					"version": "3.4.4-1"
+				},
+				{
+					"key": "libidn2-0_2.3.3-1-p-b1_amd64",
+					"name": "libidn2-0",
+					"version": "2.3.3-1+b1"
+				},
+				{
+					"key": "libpsl5_0.21.2-1_amd64",
+					"name": "libpsl5",
+					"version": "0.21.2-1"
+				},
+				{
+					"key": "libnghttp2-14_1.52.0-1-p-deb12u3_amd64",
+					"name": "libnghttp2-14",
+					"version": "1.52.0-1+deb12u3"
+				},
+				{
+					"key": "libldap-2.5-0_2.5.13-p-dfsg-5_amd64",
+					"name": "libldap-2.5-0",
+					"version": "2.5.13+dfsg-5"
+				},
+				{
+					"key": "libsasl2-2_2.1.28-p-dfsg-10_amd64",
+					"name": "libsasl2-2",
+					"version": "2.1.28+dfsg-10"
+				},
+				{
+					"key": "libsasl2-modules-db_2.1.28-p-dfsg-10_amd64",
+					"name": "libsasl2-modules-db",
+					"version": "2.1.28+dfsg-10"
+				},
+				{
+					"key": "libdb5.3_5.3.28-p-dfsg2-1_amd64",
+					"name": "libdb5.3",
+					"version": "5.3.28+dfsg2-1"
+				},
+				{
+					"key": "libgssapi-krb5-2_1.20.1-2-p-deb12u5_amd64",
+					"name": "libgssapi-krb5-2",
+					"version": "1.20.1-2+deb12u5"
+				},
+				{
+					"key": "libkrb5support0_1.20.1-2-p-deb12u5_amd64",
+					"name": "libkrb5support0",
+					"version": "1.20.1-2+deb12u5"
+				},
+				{
+					"key": "libkrb5-3_1.20.1-2-p-deb12u5_amd64",
+					"name": "libkrb5-3",
+					"version": "1.20.1-2+deb12u5"
+				},
+				{
+					"key": "libkeyutils1_1.6.3-2_amd64",
+					"name": "libkeyutils1",
+					"version": "1.6.3-2"
+				},
+				{
+					"key": "libk5crypto3_1.20.1-2-p-deb12u5_amd64",
+					"name": "libk5crypto3",
+					"version": "1.20.1-2+deb12u5"
+				},
+				{
+					"key": "libcom-err2_1.47.0-2-p-b2_amd64",
+					"name": "libcom-err2",
+					"version": "1.47.0-2+b2"
+				},
+				{
+					"key": "libbrotli1_1.0.9-2-p-b6_amd64",
+					"name": "libbrotli1",
+					"version": "1.0.9-2+b6"
+				}
+			],
+			"key": "curl_7.88.1-10-p-deb12u14_amd64",
+			"name": "curl",
+			"sha256": "e1b7edaa74085515f1837dbae792a9561de91c4b7ceab612807c72951a5af115",
+			"urls": [
+				"https://deb.debian.org/debian/pool/main/c/curl/curl_7.88.1-10+deb12u14_amd64.deb"
+			],
+			"version": "7.88.1-10+deb12u14"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "zlib1g_1-1.2.13.dfsg-1_amd64",
+			"name": "zlib1g",
+			"sha256": "d7dd1d1411fedf27f5e27650a6eff20ef294077b568f4c8c5e51466dc7c08ce4",
+			"urls": [
+				"https://deb.debian.org/debian/pool/main/z/zlib/zlib1g_1.2.13.dfsg-1_amd64.deb"
+			],
+			"version": "1:1.2.13.dfsg-1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libcurl4_7.88.1-10-p-deb12u14_amd64",
+			"name": "libcurl4",
+			"sha256": "7a203bc59523e510aa776f1b5b1798c8f65ea58be1c1f5e35f99b5e3c988f0df",
+			"urls": [
+				"https://deb.debian.org/debian/pool/main/c/curl/libcurl4_7.88.1-10+deb12u14_amd64.deb"
+			],
+			"version": "7.88.1-10+deb12u14"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libzstd1_1.5.4-p-dfsg2-5_amd64",
+			"name": "libzstd1",
+			"sha256": "6315b5ac38b724a710fb96bf1042019398cb656718b1522279a5185ed39318fa",
+			"urls": [
+				"https://deb.debian.org/debian/pool/main/libz/libzstd/libzstd1_1.5.4+dfsg2-5_amd64.deb"
+			],
+			"version": "1.5.4+dfsg2-5"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libssh2-1_1.10.0-3-p-b1_amd64",
+			"name": "libssh2-1",
+			"sha256": "d20a3ee34fa84ad8bd381e8be6e9c2c2ea32347cff5e1169c10e978d43f54f24",
+			"urls": [
+				"https://deb.debian.org/debian/pool/main/libs/libssh2/libssh2-1_1.10.0-3+b1_amd64.deb"
+			],
+			"version": "1.10.0-3+b1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "librtmp1_2.4-p-20151223.gitfa8646d.1-2-p-b2_amd64",
+			"name": "librtmp1",
+			"sha256": "e1f69020dc2c466e421ec6a58406b643be8b5c382abf0f8989011c1d3df91c87",
+			"urls": [
+				"https://deb.debian.org/debian/pool/main/r/rtmpdump/librtmp1_2.4+20151223.gitfa8646d.1-2+b2_amd64.deb"
+			],
+			"version": "2.4+20151223.gitfa8646d.1-2+b2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libnettle8_3.8.1-2_amd64",
+			"name": "libnettle8",
+			"sha256": "45922e6e289ffd92f0f92d2bb9159e84236ff202d552a461bf10e5335b3f0261",
+			"urls": [
+				"https://deb.debian.org/debian/pool/main/n/nettle/libnettle8_3.8.1-2_amd64.deb"
+			],
+			"version": "3.8.1-2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libhogweed6_3.8.1-2_amd64",
+			"name": "libhogweed6",
+			"sha256": "ed8185c28b2cb519744a5a462dcd720d3b332c9b88a1d0002eac06dc8550cb94",
+			"urls": [
+				"https://deb.debian.org/debian/pool/main/n/nettle/libhogweed6_3.8.1-2_amd64.deb"
+			],
+			"version": "3.8.1-2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libgmp10_2-6.2.1-p-dfsg1-1.1_amd64",
+			"name": "libgmp10",
+			"sha256": "187aedef2ed763f425c1e523753b9719677633c7eede660401739e9c893482bd",
+			"urls": [
+				"https://deb.debian.org/debian/pool/main/g/gmp/libgmp10_6.2.1+dfsg1-1.1_amd64.deb"
+			],
+			"version": "2:6.2.1+dfsg1-1.1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libgnutls30_3.7.9-2-p-deb12u7_amd64",
+			"name": "libgnutls30",
+			"sha256": "30abec8c824feb1d2d7e9000a34083cccd19d139625e1b21547e3ac53b922f8e",
+			"urls": [
+				"https://deb.debian.org/debian-security/pool/updates/main/g/gnutls28/libgnutls30_3.7.9-2+deb12u7_amd64.deb"
+			],
+			"version": "3.7.9-2+deb12u7"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libunistring2_1.0-2_amd64",
+			"name": "libunistring2",
+			"sha256": "d466bbfe011d764d793c1d9d777cad9c7cf65b938e11598f27408171ad95a951",
+			"urls": [
+				"https://deb.debian.org/debian/pool/main/libu/libunistring/libunistring2_1.0-2_amd64.deb"
+			],
+			"version": "1.0-2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libtasn1-6_4.19.0-2-p-deb12u1_amd64",
+			"name": "libtasn1-6",
+			"sha256": "2c27c613b69be248d09432839ea3d3382f6ee27fabaa65987aa2d884cd00afda",
+			"urls": [
+				"https://deb.debian.org/debian-security/pool/updates/main/libt/libtasn1-6/libtasn1-6_4.19.0-2+deb12u1_amd64.deb"
+			],
+			"version": "4.19.0-2+deb12u1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libp11-kit0_0.24.1-2_amd64",
+			"name": "libp11-kit0",
+			"sha256": "251330faddbf013f060fcdb41f4b0c037c8a6e89ba7c09b04bfcc4e3f0807b22",
+			"urls": [
+				"https://deb.debian.org/debian/pool/main/p/p11-kit/libp11-kit0_0.24.1-2_amd64.deb"
+			],
+			"version": "0.24.1-2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libffi8_3.4.4-1_amd64",
+			"name": "libffi8",
+			"sha256": "6d9f6c25c30efccce6d4bceaa48ea86c329a3432abb360a141f76ac223a4c34a",
+			"urls": [
+				"https://deb.debian.org/debian/pool/main/libf/libffi/libffi8_3.4.4-1_amd64.deb"
+			],
+			"version": "3.4.4-1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libidn2-0_2.3.3-1-p-b1_amd64",
+			"name": "libidn2-0",
+			"sha256": "d50716d5824083d667427817d506b45d3f59dc77e1ca52de000f3f62d4918afa",
+			"urls": [
+				"https://deb.debian.org/debian/pool/main/libi/libidn2/libidn2-0_2.3.3-1+b1_amd64.deb"
+			],
+			"version": "2.3.3-1+b1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libpsl5_0.21.2-1_amd64",
+			"name": "libpsl5",
+			"sha256": "4f0d35610204e4e754b057748719744114621f2f6f4202d846c314860a981afb",
+			"urls": [
+				"https://deb.debian.org/debian/pool/main/libp/libpsl/libpsl5_0.21.2-1_amd64.deb"
+			],
+			"version": "0.21.2-1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libnghttp2-14_1.52.0-1-p-deb12u3_amd64",
+			"name": "libnghttp2-14",
+			"sha256": "5a5736cee57e51c1baed869979e6ecdbc6495e939e33203d6cfe3b6e5a149e3f",
+			"urls": [
+				"https://deb.debian.org/debian-security/pool/updates/main/n/nghttp2/libnghttp2-14_1.52.0-1+deb12u3_amd64.deb"
+			],
+			"version": "1.52.0-1+deb12u3"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libldap-2.5-0_2.5.13-p-dfsg-5_amd64",
+			"name": "libldap-2.5-0",
+			"sha256": "4b6c30f6554149c594628d945edc6003f0eea8d0cc1341638c0e71375db147ed",
+			"urls": [
+				"https://deb.debian.org/debian/pool/main/o/openldap/libldap-2.5-0_2.5.13+dfsg-5_amd64.deb"
+			],
+			"version": "2.5.13+dfsg-5"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libsasl2-2_2.1.28-p-dfsg-10_amd64",
+			"name": "libsasl2-2",
+			"sha256": "11ee190ad39f8d7af441d2c8347388b9449434c73acc67b4b372445ac4152efa",
+			"urls": [
+				"https://deb.debian.org/debian/pool/main/c/cyrus-sasl2/libsasl2-2_2.1.28+dfsg-10_amd64.deb"
+			],
+			"version": "2.1.28+dfsg-10"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libsasl2-modules-db_2.1.28-p-dfsg-10_amd64",
+			"name": "libsasl2-modules-db",
+			"sha256": "3ac4fd6cbe3b3b06e68d24b931bf3eb9385b42f15604a37ed25310e948ca0ee6",
+			"urls": [
+				"https://deb.debian.org/debian/pool/main/c/cyrus-sasl2/libsasl2-modules-db_2.1.28+dfsg-10_amd64.deb"
+			],
+			"version": "2.1.28+dfsg-10"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libdb5.3_5.3.28-p-dfsg2-1_amd64",
+			"name": "libdb5.3",
+			"sha256": "7dc5127b8dd0da80e992ba594954c005ae4359d839a24eb65d0d8129b5235c84",
+			"urls": [
+				"https://deb.debian.org/debian/pool/main/d/db5.3/libdb5.3_5.3.28+dfsg2-1_amd64.deb"
+			],
+			"version": "5.3.28+dfsg2-1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libgssapi-krb5-2_1.20.1-2-p-deb12u5_amd64",
+			"name": "libgssapi-krb5-2",
+			"sha256": "d8b87aea91b956b416c01a28c44ff6228315ae3b73de40acddac3dc5043607d2",
+			"urls": [
+				"https://deb.debian.org/debian-security/pool/updates/main/k/krb5/libgssapi-krb5-2_1.20.1-2+deb12u5_amd64.deb"
+			],
+			"version": "1.20.1-2+deb12u5"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libkrb5support0_1.20.1-2-p-deb12u5_amd64",
+			"name": "libkrb5support0",
+			"sha256": "8b9c05f2d8d461a10d657b118f572af5bf8fd6c8f93dcef81e852c5ab0f428ab",
+			"urls": [
+				"https://deb.debian.org/debian-security/pool/updates/main/k/krb5/libkrb5support0_1.20.1-2+deb12u5_amd64.deb"
+			],
+			"version": "1.20.1-2+deb12u5"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libkrb5-3_1.20.1-2-p-deb12u5_amd64",
+			"name": "libkrb5-3",
+			"sha256": "c90801be09701af221b54dd502a59cb378b7284ff31e480738baca317d2f7653",
+			"urls": [
+				"https://deb.debian.org/debian-security/pool/updates/main/k/krb5/libkrb5-3_1.20.1-2+deb12u5_amd64.deb"
+			],
+			"version": "1.20.1-2+deb12u5"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libkeyutils1_1.6.3-2_amd64",
+			"name": "libkeyutils1",
+			"sha256": "cfac89e6a7a54ff3c6a4f843310e25efeddaa771baeae470bd98bd588c373563",
+			"urls": [
+				"https://deb.debian.org/debian/pool/main/k/keyutils/libkeyutils1_1.6.3-2_amd64.deb"
+			],
+			"version": "1.6.3-2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libk5crypto3_1.20.1-2-p-deb12u5_amd64",
+			"name": "libk5crypto3",
+			"sha256": "7b6e47d15c5c9cdcd456137533d8308aeba608a54cec73b28bd59bfc4b54cf06",
+			"urls": [
+				"https://deb.debian.org/debian-security/pool/updates/main/k/krb5/libk5crypto3_1.20.1-2+deb12u5_amd64.deb"
+			],
+			"version": "1.20.1-2+deb12u5"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libcom-err2_1.47.0-2-p-b2_amd64",
+			"name": "libcom-err2",
+			"sha256": "a2bac7015e78fbc0c504df3e441f3a22292f1d2d77f9ccda760057f3690e22f2",
+			"urls": [
+				"https://deb.debian.org/debian/pool/main/e/e2fsprogs/libcom-err2_1.47.0-2+b2_amd64.deb"
+			],
+			"version": "1.47.0-2+b2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libbrotli1_1.0.9-2-p-b6_amd64",
+			"name": "libbrotli1",
+			"sha256": "563b4caec1aa5e876bd3355b36e7a38e1484baf5a293b48d1e8bd22db786e4d7",
+			"urls": [
+				"https://deb.debian.org/debian/pool/main/b/brotli/libbrotli1_1.0.9-2+b6_amd64.deb"
+			],
+			"version": "1.0.9-2+b6"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [
+				{
+					"key": "libc6_2.36-9-p-deb12u14_amd64",
+					"name": "libc6",
+					"version": "2.36-9+deb12u14"
+				},
+				{
+					"key": "libgcc-s1_12.2.0-14-p-deb12u1_amd64",
+					"name": "libgcc-s1",
+					"version": "12.2.0-14+deb12u1"
+				},
+				{
+					"key": "gcc-12-base_12.2.0-14-p-deb12u1_amd64",
+					"name": "gcc-12-base",
+					"version": "12.2.0-14+deb12u1"
+				}
+			],
+			"key": "tini_0.19.0-1-p-b3_amd64",
+			"name": "tini",
+			"sha256": "7d1947665fa40e55f218fefad773dc6de66458d0b39eaa292cdcadfc7c996632",
+			"urls": [
+				"https://deb.debian.org/debian/pool/main/t/tini/tini_0.19.0-1+b3_amd64.deb"
+			],
+			"version": "0.19.0-1+b3"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [
+				{
+					"key": "libgcc-s1_12.2.0-14-p-deb12u1_amd64",
+					"name": "libgcc-s1",
+					"version": "12.2.0-14+deb12u1"
+				},
+				{
+					"key": "libc6_2.36-9-p-deb12u14_amd64",
+					"name": "libc6",
+					"version": "2.36-9+deb12u14"
+				},
+				{
+					"key": "gcc-12-base_12.2.0-14-p-deb12u1_amd64",
+					"name": "gcc-12-base",
+					"version": "12.2.0-14+deb12u1"
+				}
+			],
+			"key": "libstdc-p--p-6_12.2.0-14-p-deb12u1_amd64",
+			"name": "libstdc++6",
+			"sha256": "5cd3171216d4ab0fc911cfe9c35509bf2dd8f47761c43b7f6a4296701551a24d",
+			"urls": [
+				"https://deb.debian.org/debian/pool/main/g/gcc-12/libstdc++6_12.2.0-14+deb12u1_amd64.deb"
+			],
+			"version": "12.2.0-14+deb12u1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [
+				{
+					"key": "debconf_1.5.82_arm64",
+					"name": "debconf",
+					"version": "1.5.82"
+				},
+				{
+					"key": "openssl_3.0.20-1_deb12u1_arm64",
+					"name": "openssl",
+					"version": "3.0.20-1~deb12u1"
+				},
+				{
+					"key": "libssl3_3.0.20-1_deb12u1_arm64",
+					"name": "libssl3",
+					"version": "3.0.20-1~deb12u1"
+				},
+				{
+					"key": "libc6_2.36-9-p-deb12u14_arm64",
+					"name": "libc6",
+					"version": "2.36-9+deb12u14"
+				},
+				{
+					"key": "libgcc-s1_12.2.0-14-p-deb12u1_arm64",
+					"name": "libgcc-s1",
+					"version": "12.2.0-14+deb12u1"
+				},
+				{
+					"key": "gcc-12-base_12.2.0-14-p-deb12u1_arm64",
+					"name": "gcc-12-base",
+					"version": "12.2.0-14+deb12u1"
+				}
+			],
+			"key": "ca-certificates_20230311-p-deb12u1_arm64",
+			"name": "ca-certificates",
+			"sha256": "0d5f444f594e48c1e16a41d8fc628a09b24c658916a1274025c2330f2a802bed",
+			"urls": [
+				"https://deb.debian.org/debian/pool/main/c/ca-certificates/ca-certificates_20230311+deb12u1_all.deb"
+			],
+			"version": "20230311+deb12u1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "debconf_1.5.82_arm64",
+			"name": "debconf",
+			"sha256": "74ab14194a3762b2fc717917dcfda42929ab98e3c59295a063344dc551cd7cc8",
+			"urls": [
+				"https://deb.debian.org/debian/pool/main/d/debconf/debconf_1.5.82_all.deb"
+			],
+			"version": "1.5.82"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "openssl_3.0.20-1_deb12u1_arm64",
+			"name": "openssl",
+			"sha256": "2cd287d8b189f58c3901e4b03023baece8eb063ec3b7bcd6fcd9b3ef08bb7c3e",
+			"urls": [
+				"https://deb.debian.org/debian/pool/main/o/openssl/openssl_3.0.20-1~deb12u1_arm64.deb"
+			],
+			"version": "3.0.20-1~deb12u1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libssl3_3.0.20-1_deb12u1_arm64",
+			"name": "libssl3",
+			"sha256": "ddee5dde4e755bbefc894ee5776440f30ba6681443124b339140694eac643b6a",
+			"urls": [
+				"https://deb.debian.org/debian/pool/main/o/openssl/libssl3_3.0.20-1~deb12u1_arm64.deb"
+			],
+			"version": "3.0.20-1~deb12u1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libc6_2.36-9-p-deb12u14_arm64",
+			"name": "libc6",
+			"sha256": "01f4330719fd4f65580e16ea5a0527f372fca750e8f588d26deaf09f2d3b1cf4",
+			"urls": [
+				"https://deb.debian.org/debian/pool/main/g/glibc/libc6_2.36-9+deb12u14_arm64.deb"
+			],
+			"version": "2.36-9+deb12u14"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libgcc-s1_12.2.0-14-p-deb12u1_arm64",
+			"name": "libgcc-s1",
+			"sha256": "576926b283613db80168ddf76380a3bd877602778cf0d226caa7bfbfa71eacf3",
+			"urls": [
+				"https://deb.debian.org/debian/pool/main/g/gcc-12/libgcc-s1_12.2.0-14+deb12u1_arm64.deb"
+			],
+			"version": "12.2.0-14+deb12u1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "gcc-12-base_12.2.0-14-p-deb12u1_arm64",
+			"name": "gcc-12-base",
+			"sha256": "674cf6cba6d432bd200c45fe866c1652c7a53523cc2e7a613e05bc4abf7b5440",
+			"urls": [
+				"https://deb.debian.org/debian/pool/main/g/gcc-12/gcc-12-base_12.2.0-14+deb12u1_arm64.deb"
+			],
+			"version": "12.2.0-14+deb12u1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [
+				{
+					"key": "zlib1g_1-1.2.13.dfsg-1_arm64",
+					"name": "zlib1g",
+					"version": "1:1.2.13.dfsg-1"
+				},
+				{
+					"key": "libc6_2.36-9-p-deb12u14_arm64",
+					"name": "libc6",
+					"version": "2.36-9+deb12u14"
+				},
+				{
+					"key": "libgcc-s1_12.2.0-14-p-deb12u1_arm64",
+					"name": "libgcc-s1",
+					"version": "12.2.0-14+deb12u1"
+				},
+				{
+					"key": "gcc-12-base_12.2.0-14-p-deb12u1_arm64",
+					"name": "gcc-12-base",
+					"version": "12.2.0-14+deb12u1"
+				},
+				{
+					"key": "libcurl4_7.88.1-10-p-deb12u14_arm64",
+					"name": "libcurl4",
+					"version": "7.88.1-10+deb12u14"
+				},
+				{
+					"key": "libzstd1_1.5.4-p-dfsg2-5_arm64",
+					"name": "libzstd1",
+					"version": "1.5.4+dfsg2-5"
+				},
+				{
+					"key": "libssl3_3.0.20-1_deb12u1_arm64",
+					"name": "libssl3",
+					"version": "3.0.20-1~deb12u1"
+				},
+				{
+					"key": "libssh2-1_1.10.0-3-p-b1_arm64",
+					"name": "libssh2-1",
+					"version": "1.10.0-3+b1"
+				},
+				{
+					"key": "librtmp1_2.4-p-20151223.gitfa8646d.1-2-p-b2_arm64",
+					"name": "librtmp1",
+					"version": "2.4+20151223.gitfa8646d.1-2+b2"
+				},
+				{
+					"key": "libnettle8_3.8.1-2_arm64",
+					"name": "libnettle8",
+					"version": "3.8.1-2"
+				},
+				{
+					"key": "libhogweed6_3.8.1-2_arm64",
+					"name": "libhogweed6",
+					"version": "3.8.1-2"
+				},
+				{
+					"key": "libgmp10_2-6.2.1-p-dfsg1-1.1_arm64",
+					"name": "libgmp10",
+					"version": "2:6.2.1+dfsg1-1.1"
+				},
+				{
+					"key": "libgnutls30_3.7.9-2-p-deb12u7_arm64",
+					"name": "libgnutls30",
+					"version": "3.7.9-2+deb12u7"
+				},
+				{
+					"key": "libunistring2_1.0-2_arm64",
+					"name": "libunistring2",
+					"version": "1.0-2"
+				},
+				{
+					"key": "libtasn1-6_4.19.0-2-p-deb12u1_arm64",
+					"name": "libtasn1-6",
+					"version": "4.19.0-2+deb12u1"
+				},
+				{
+					"key": "libp11-kit0_0.24.1-2_arm64",
+					"name": "libp11-kit0",
+					"version": "0.24.1-2"
+				},
+				{
+					"key": "libffi8_3.4.4-1_arm64",
+					"name": "libffi8",
+					"version": "3.4.4-1"
+				},
+				{
+					"key": "libidn2-0_2.3.3-1-p-b1_arm64",
+					"name": "libidn2-0",
+					"version": "2.3.3-1+b1"
+				},
+				{
+					"key": "libpsl5_0.21.2-1_arm64",
+					"name": "libpsl5",
+					"version": "0.21.2-1"
+				},
+				{
+					"key": "libnghttp2-14_1.52.0-1-p-deb12u3_arm64",
+					"name": "libnghttp2-14",
+					"version": "1.52.0-1+deb12u3"
+				},
+				{
+					"key": "libldap-2.5-0_2.5.13-p-dfsg-5_arm64",
+					"name": "libldap-2.5-0",
+					"version": "2.5.13+dfsg-5"
+				},
+				{
+					"key": "libsasl2-2_2.1.28-p-dfsg-10_arm64",
+					"name": "libsasl2-2",
+					"version": "2.1.28+dfsg-10"
+				},
+				{
+					"key": "libsasl2-modules-db_2.1.28-p-dfsg-10_arm64",
+					"name": "libsasl2-modules-db",
+					"version": "2.1.28+dfsg-10"
+				},
+				{
+					"key": "libdb5.3_5.3.28-p-dfsg2-1_arm64",
+					"name": "libdb5.3",
+					"version": "5.3.28+dfsg2-1"
+				},
+				{
+					"key": "libgssapi-krb5-2_1.20.1-2-p-deb12u5_arm64",
+					"name": "libgssapi-krb5-2",
+					"version": "1.20.1-2+deb12u5"
+				},
+				{
+					"key": "libkrb5support0_1.20.1-2-p-deb12u5_arm64",
+					"name": "libkrb5support0",
+					"version": "1.20.1-2+deb12u5"
+				},
+				{
+					"key": "libkrb5-3_1.20.1-2-p-deb12u5_arm64",
+					"name": "libkrb5-3",
+					"version": "1.20.1-2+deb12u5"
+				},
+				{
+					"key": "libkeyutils1_1.6.3-2_arm64",
+					"name": "libkeyutils1",
+					"version": "1.6.3-2"
+				},
+				{
+					"key": "libk5crypto3_1.20.1-2-p-deb12u5_arm64",
+					"name": "libk5crypto3",
+					"version": "1.20.1-2+deb12u5"
+				},
+				{
+					"key": "libcom-err2_1.47.0-2-p-b2_arm64",
+					"name": "libcom-err2",
+					"version": "1.47.0-2+b2"
+				},
+				{
+					"key": "libbrotli1_1.0.9-2-p-b6_arm64",
+					"name": "libbrotli1",
+					"version": "1.0.9-2+b6"
+				}
+			],
+			"key": "curl_7.88.1-10-p-deb12u14_arm64",
+			"name": "curl",
+			"sha256": "bf30130b6fa7f7aeb65618452be9023929568a615fb0393cca2685f6e0d8995a",
+			"urls": [
+				"https://deb.debian.org/debian/pool/main/c/curl/curl_7.88.1-10+deb12u14_arm64.deb"
+			],
+			"version": "7.88.1-10+deb12u14"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "zlib1g_1-1.2.13.dfsg-1_arm64",
+			"name": "zlib1g",
+			"sha256": "52b8b8a145bbe1956bba82034f77022cbef0c3d0885c9e32d9817a7932fe1913",
+			"urls": [
+				"https://deb.debian.org/debian/pool/main/z/zlib/zlib1g_1.2.13.dfsg-1_arm64.deb"
+			],
+			"version": "1:1.2.13.dfsg-1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libcurl4_7.88.1-10-p-deb12u14_arm64",
+			"name": "libcurl4",
+			"sha256": "f251c00def19bb2fcece67e97459bdb0fc178ebeb2af814c437f3ea62af7c1b5",
+			"urls": [
+				"https://deb.debian.org/debian/pool/main/c/curl/libcurl4_7.88.1-10+deb12u14_arm64.deb"
+			],
+			"version": "7.88.1-10+deb12u14"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libzstd1_1.5.4-p-dfsg2-5_arm64",
+			"name": "libzstd1",
+			"sha256": "95e173c9538f96ede4fc275ec7863f395a97dd0ea62454be9bc914efa1b9be93",
+			"urls": [
+				"https://deb.debian.org/debian/pool/main/libz/libzstd/libzstd1_1.5.4+dfsg2-5_arm64.deb"
+			],
+			"version": "1.5.4+dfsg2-5"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libssh2-1_1.10.0-3-p-b1_arm64",
+			"name": "libssh2-1",
+			"sha256": "390538001122ff03bdabe3689f5b13dafbf2012dd55e3e1e26bd7a6109717250",
+			"urls": [
+				"https://deb.debian.org/debian/pool/main/libs/libssh2/libssh2-1_1.10.0-3+b1_arm64.deb"
+			],
+			"version": "1.10.0-3+b1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "librtmp1_2.4-p-20151223.gitfa8646d.1-2-p-b2_arm64",
+			"name": "librtmp1",
+			"sha256": "a3a1a6e4b02bcd3254e932b1972ed744082fd7dd5cc1545eec3dd3d539ce6c93",
+			"urls": [
+				"https://deb.debian.org/debian/pool/main/r/rtmpdump/librtmp1_2.4+20151223.gitfa8646d.1-2+b2_arm64.deb"
+			],
+			"version": "2.4+20151223.gitfa8646d.1-2+b2"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libnettle8_3.8.1-2_arm64",
+			"name": "libnettle8",
+			"sha256": "c945ff210df69cf7b95e935b8fa936e81c1c1f475355e3d5db83510b174f0cd6",
+			"urls": [
+				"https://deb.debian.org/debian/pool/main/n/nettle/libnettle8_3.8.1-2_arm64.deb"
+			],
+			"version": "3.8.1-2"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libhogweed6_3.8.1-2_arm64",
+			"name": "libhogweed6",
+			"sha256": "e653a1a7e5a44be0f7b6443dc6ac865d2504e49149660fc253655245965e157f",
+			"urls": [
+				"https://deb.debian.org/debian/pool/main/n/nettle/libhogweed6_3.8.1-2_arm64.deb"
+			],
+			"version": "3.8.1-2"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libgmp10_2-6.2.1-p-dfsg1-1.1_arm64",
+			"name": "libgmp10",
+			"sha256": "9906387c1dd806518c915bd8616d072c741061d7fa26b222e52763456060b31a",
+			"urls": [
+				"https://deb.debian.org/debian/pool/main/g/gmp/libgmp10_6.2.1+dfsg1-1.1_arm64.deb"
+			],
+			"version": "2:6.2.1+dfsg1-1.1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libgnutls30_3.7.9-2-p-deb12u7_arm64",
+			"name": "libgnutls30",
+			"sha256": "84f7f70084c9179d6670f4a6ebdf32adc36c6e4741a3a118104377e18cfa977f",
+			"urls": [
+				"https://deb.debian.org/debian-security/pool/updates/main/g/gnutls28/libgnutls30_3.7.9-2+deb12u7_arm64.deb"
+			],
+			"version": "3.7.9-2+deb12u7"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libunistring2_1.0-2_arm64",
+			"name": "libunistring2",
+			"sha256": "05b0b7700bfe269ff7af61f45e92055d7ef4c532c9584e4e2a352cf0bd4de5b1",
+			"urls": [
+				"https://deb.debian.org/debian/pool/main/libu/libunistring/libunistring2_1.0-2_arm64.deb"
+			],
+			"version": "1.0-2"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libtasn1-6_4.19.0-2-p-deb12u1_arm64",
+			"name": "libtasn1-6",
+			"sha256": "7e80513007e8a71b5e737d3307dedbb06712f9cfed05ec2fad6fc00de460cc5f",
+			"urls": [
+				"https://deb.debian.org/debian-security/pool/updates/main/libt/libtasn1-6/libtasn1-6_4.19.0-2+deb12u1_arm64.deb"
+			],
+			"version": "4.19.0-2+deb12u1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libp11-kit0_0.24.1-2_arm64",
+			"name": "libp11-kit0",
+			"sha256": "d1f1f55023e9fc085b9ebfc9c4113d2d2dab2dc6b81a337f274b75c95ad8dc0a",
+			"urls": [
+				"https://deb.debian.org/debian/pool/main/p/p11-kit/libp11-kit0_0.24.1-2_arm64.deb"
+			],
+			"version": "0.24.1-2"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libffi8_3.4.4-1_arm64",
+			"name": "libffi8",
+			"sha256": "80b5c36177dc0e29d531c7eddbed3cc7355cb490e49f8cfa5959572d161f27b3",
+			"urls": [
+				"https://deb.debian.org/debian/pool/main/libf/libffi/libffi8_3.4.4-1_arm64.deb"
+			],
+			"version": "3.4.4-1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libidn2-0_2.3.3-1-p-b1_arm64",
+			"name": "libidn2-0",
+			"sha256": "12a3efc056671bf1c1bed4c3444c2559c8d5e0c158a13316fc728f263b83ddc4",
+			"urls": [
+				"https://deb.debian.org/debian/pool/main/libi/libidn2/libidn2-0_2.3.3-1+b1_arm64.deb"
+			],
+			"version": "2.3.3-1+b1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libpsl5_0.21.2-1_arm64",
+			"name": "libpsl5",
+			"sha256": "90a68e4a6d9eb95abee32595762dbf67974f13c158e4ce4a05c7c2b54440db73",
+			"urls": [
+				"https://deb.debian.org/debian/pool/main/libp/libpsl/libpsl5_0.21.2-1_arm64.deb"
+			],
+			"version": "0.21.2-1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libnghttp2-14_1.52.0-1-p-deb12u3_arm64",
+			"name": "libnghttp2-14",
+			"sha256": "7767833033739adb2e2e374f2c4b36134d9f36fcdfe8e2aab7029bf850146da9",
+			"urls": [
+				"https://deb.debian.org/debian-security/pool/updates/main/n/nghttp2/libnghttp2-14_1.52.0-1+deb12u3_arm64.deb"
+			],
+			"version": "1.52.0-1+deb12u3"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libldap-2.5-0_2.5.13-p-dfsg-5_arm64",
+			"name": "libldap-2.5-0",
+			"sha256": "71e6ae4291a20db999c62cd0a4f30a92a799c46b99205d5e787d4acd7c343b91",
+			"urls": [
+				"https://deb.debian.org/debian/pool/main/o/openldap/libldap-2.5-0_2.5.13+dfsg-5_arm64.deb"
+			],
+			"version": "2.5.13+dfsg-5"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libsasl2-2_2.1.28-p-dfsg-10_arm64",
+			"name": "libsasl2-2",
+			"sha256": "61dcbb6560e2eb20bff256f1b445ac9af13aa61c6a6ae115ad8cb96c9c50ea38",
+			"urls": [
+				"https://deb.debian.org/debian/pool/main/c/cyrus-sasl2/libsasl2-2_2.1.28+dfsg-10_arm64.deb"
+			],
+			"version": "2.1.28+dfsg-10"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libsasl2-modules-db_2.1.28-p-dfsg-10_arm64",
+			"name": "libsasl2-modules-db",
+			"sha256": "56d9c35ac6729b02f78900175557dd36bef26611dab89584f29da15631628869",
+			"urls": [
+				"https://deb.debian.org/debian/pool/main/c/cyrus-sasl2/libsasl2-modules-db_2.1.28+dfsg-10_arm64.deb"
+			],
+			"version": "2.1.28+dfsg-10"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libdb5.3_5.3.28-p-dfsg2-1_arm64",
+			"name": "libdb5.3",
+			"sha256": "344367608d622298a3d916f4cee3dc3173286f3b21f8f497ab21e7178ba930f9",
+			"urls": [
+				"https://deb.debian.org/debian/pool/main/d/db5.3/libdb5.3_5.3.28+dfsg2-1_arm64.deb"
+			],
+			"version": "5.3.28+dfsg2-1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libgssapi-krb5-2_1.20.1-2-p-deb12u5_arm64",
+			"name": "libgssapi-krb5-2",
+			"sha256": "a00678963f692a929312968f19b77a61a8fc0011690d7dc909a8a2c4810fc7b3",
+			"urls": [
+				"https://deb.debian.org/debian-security/pool/updates/main/k/krb5/libgssapi-krb5-2_1.20.1-2+deb12u5_arm64.deb"
+			],
+			"version": "1.20.1-2+deb12u5"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libkrb5support0_1.20.1-2-p-deb12u5_arm64",
+			"name": "libkrb5support0",
+			"sha256": "3043fd4a54b945a1b503170749527f825dcfc7add2f8bf5abb4a329deeb48f4a",
+			"urls": [
+				"https://deb.debian.org/debian-security/pool/updates/main/k/krb5/libkrb5support0_1.20.1-2+deb12u5_arm64.deb"
+			],
+			"version": "1.20.1-2+deb12u5"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libkrb5-3_1.20.1-2-p-deb12u5_arm64",
+			"name": "libkrb5-3",
+			"sha256": "c3c7227f5db903a7a8b8936d47d1d79643edcda36365c4c992e1a96bcc2d4c7e",
+			"urls": [
+				"https://deb.debian.org/debian-security/pool/updates/main/k/krb5/libkrb5-3_1.20.1-2+deb12u5_arm64.deb"
+			],
+			"version": "1.20.1-2+deb12u5"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libkeyutils1_1.6.3-2_arm64",
+			"name": "libkeyutils1",
+			"sha256": "aac46cb6faec4e737502b3c2290b7b02f8ba04e8accd5af7fd07934df0c867b1",
+			"urls": [
+				"https://deb.debian.org/debian/pool/main/k/keyutils/libkeyutils1_1.6.3-2_arm64.deb"
+			],
+			"version": "1.6.3-2"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libk5crypto3_1.20.1-2-p-deb12u5_arm64",
+			"name": "libk5crypto3",
+			"sha256": "8ae2c31cde0b3e6f80c573a495b0f90bf6d9efb4455d900728278bb54d9092e5",
+			"urls": [
+				"https://deb.debian.org/debian-security/pool/updates/main/k/krb5/libk5crypto3_1.20.1-2+deb12u5_arm64.deb"
+			],
+			"version": "1.20.1-2+deb12u5"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libcom-err2_1.47.0-2-p-b2_arm64",
+			"name": "libcom-err2",
+			"sha256": "36c15f933a965b50f4c9558d792d9556934c84e532703935d8ae7e69dd3fa863",
+			"urls": [
+				"https://deb.debian.org/debian/pool/main/e/e2fsprogs/libcom-err2_1.47.0-2+b2_arm64.deb"
+			],
+			"version": "1.47.0-2+b2"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libbrotli1_1.0.9-2-p-b6_arm64",
+			"name": "libbrotli1",
+			"sha256": "3137de7f71952e710ee9f0df05026b3c6f463be9369a502d57c7696732f1ed22",
+			"urls": [
+				"https://deb.debian.org/debian/pool/main/b/brotli/libbrotli1_1.0.9-2+b6_arm64.deb"
+			],
+			"version": "1.0.9-2+b6"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [
+				{
+					"key": "libc6_2.36-9-p-deb12u14_arm64",
+					"name": "libc6",
+					"version": "2.36-9+deb12u14"
+				},
+				{
+					"key": "libgcc-s1_12.2.0-14-p-deb12u1_arm64",
+					"name": "libgcc-s1",
+					"version": "12.2.0-14+deb12u1"
+				},
+				{
+					"key": "gcc-12-base_12.2.0-14-p-deb12u1_arm64",
+					"name": "gcc-12-base",
+					"version": "12.2.0-14+deb12u1"
+				}
+			],
+			"key": "tini_0.19.0-1-p-b3_arm64",
+			"name": "tini",
+			"sha256": "335dee1e36c0bf61f11c9fe9740012966a3183bd50405b73ed19477293c28f7f",
+			"urls": [
+				"https://deb.debian.org/debian/pool/main/t/tini/tini_0.19.0-1+b3_arm64.deb"
+			],
+			"version": "0.19.0-1+b3"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [
+				{
+					"key": "libgcc-s1_12.2.0-14-p-deb12u1_arm64",
+					"name": "libgcc-s1",
+					"version": "12.2.0-14+deb12u1"
+				},
+				{
+					"key": "libc6_2.36-9-p-deb12u14_arm64",
+					"name": "libc6",
+					"version": "2.36-9+deb12u14"
+				},
+				{
+					"key": "gcc-12-base_12.2.0-14-p-deb12u1_arm64",
+					"name": "gcc-12-base",
+					"version": "12.2.0-14+deb12u1"
+				}
+			],
+			"key": "libstdc-p--p-6_12.2.0-14-p-deb12u1_arm64",
+			"name": "libstdc++6",
+			"sha256": "26e138c677a985775331373828a6c286c551ff397cb735d00e2383cb273d1cb2",
+			"urls": [
+				"https://deb.debian.org/debian/pool/main/g/gcc-12/libstdc++6_12.2.0-14+deb12u1_arm64.deb"
+			],
+			"version": "12.2.0-14+deb12u1"
+		}
+	],
+	"version": 1
+}

--- a/kura/bazel/oci/bookworm_apt.yaml
+++ b/kura/bazel/oci/bookworm_apt.yaml
@@ -1,0 +1,28 @@
+# Extra Debian Bookworm packages layered onto debian:bookworm-slim to match the
+# production Dockerfile's runtime (tini, curl, libstdc++6, ca-certificates) plus their
+# dependency closure, resolved hermetically by rules_distroless.
+#
+# After editing this file, regenerate the lockfile (pins each .deb by sha256):
+#   bazel run @bookworm_apt//:lock
+#
+# Sources mirror debian:bookworm-slim's default apt sources (bookworm + updates +
+# security) so resolved versions match a `apt-get install` in that base.
+version: 1
+
+sources:
+  - channel: bookworm main
+    url: https://deb.debian.org/debian
+  - channel: bookworm-updates main
+    url: https://deb.debian.org/debian
+  - channel: bookworm-security main
+    url: https://deb.debian.org/debian-security
+
+archs:
+  - amd64
+  - arm64
+
+packages:
+  - ca-certificates
+  - curl
+  - tini
+  - libstdc++6

--- a/kura/bazel/oci/transition.bzl
+++ b/kura/bazel/oci/transition.bzl
@@ -1,0 +1,49 @@
+"""Single-platform transition that mirrors oci_image_index's transition.
+
+`oci_image_index` reaches its per-arch images through a Starlark transition that
+sets `//command_line_option:platforms`. A config reached via that transition gets
+an `ST-<hash>`-suffixed output directory, so its action keys differ from the same
+options reached via the plain `--platforms` command-line flag (see
+docs/bazel-migration-plan.md, "OCI cache fragmentation"). That means a loadable
+tarball built with `--platforms` cannot reuse the binary the index already
+compiled — the native arch ends up built twice.
+
+`transitioned_image` re-exports an image through a transition that is byte-for-byte
+identical in effect to oci_image_index's (same single output, same value via
+`str(label)`), so the loadable image lands in the *same* `ST-` config the index
+uses for that arch and shares the compiled binary instead of forcing a second
+build under the flag config.
+"""
+
+def _platform_transition_impl(_settings, attr):
+    return {"//command_line_option:platforms": str(attr.platform)}
+
+_platform_transition = transition(
+    implementation = _platform_transition_impl,
+    inputs = [],
+    outputs = ["//command_line_option:platforms"],
+)
+
+def _transitioned_image_impl(ctx):
+    return [DefaultInfo(files = depset(ctx.files.image))]
+
+transitioned_image = rule(
+    implementation = _transitioned_image_impl,
+    doc = "Re-exports `image` built under a single-platform transition identical to " +
+          "oci_image_index's, so a loadable tarball reuses the index's compiled binary.",
+    attrs = {
+        "image": attr.label(
+            mandatory = True,
+            allow_files = True,
+            cfg = _platform_transition,
+            doc = "The oci_image to build under the platform transition.",
+        ),
+        "platform": attr.label(
+            mandatory = True,
+            doc = "Target platform, set into //command_line_option:platforms by the transition.",
+        ),
+        "_allowlist_function_transition": attr.label(
+            default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
+        ),
+    },
+)


### PR DESCRIPTION
## What

Migrates the OCI image build and the end-to-end suite from the Docker/Buildx path to the **rules_oci** build proven on `kura-bazel-phase1`. This is **Stage A, part 3** of the Kura Bazel migration.

> **Stacked PR** — base is `kura-bazel-tests` (#11166), not `main`. Merge order is #11165 (compile) → #11166 (tests) → this. The diff here is the OCI build foundation + the `e2e-images`/`e2e` job flip.

## Why

The current `e2e-images` job builds `kura/Dockerfile` with `docker compose build` and `docker save`s three images; the `e2e` job loads them and retags them per suite. This PR replaces that with the same QEMU-free rules_oci build that compile/tests already dogfood through Kura.

## What changed

**OCI build into the Bazel graph** (verbatim from `kura-bazel-phase1`):
- `MODULE.bazel`: `rules_oci`/`rules_pkg`/`rules_distroless`, the digest-pinned `debian:bookworm-slim` base (both arches), the hermetic extra-packages layer (`tini`/`curl`/`libstdc++6`/`ca-certificates`, sha256-pinned apt lock), and the digest-pinned DB-IP geoip seed.
- `//bazel/oci`: an `oci_image` matching the production Dockerfile (entrypoint `tini -- kura`, `/opt/geoip/dbip-city-lite.mmdb`, port 4000) + a multi-arch `oci_image_index`. No Docker daemon / Buildx / QEMU — both arches build from one host via the cross toolchains.
- `transition.bzl`: `transitioned_image` makes the loadable tarball reuse the index's compiled binary instead of building the native arch twice (the OCI fragmentation fix).

**`e2e-images` job** — `bazel/ci-oci.sh` builds the multi-arch index + a native-arch docker-loadable tarball, dogfooding Kura as the remote cache (same container + graceful-stop + restore/save split as compile/tests). Uploads the single image tarball as the `kura-e2e-images` artifact.

**`e2e` job** — loads that one image and points every compose service (base + overlay files) at it via `KURA_IMAGE=kura-bazel:oci` + `KURA_E2E_SKIP_BUILD=1`, which removes the per-suite retag loop the Dockerfile path needed. Keeps `rust shellspec bazel buck2` in the mise install because `clients_spec` drives Bazel and Buck2 as REAPI clients against the cluster.

## Cache namespacing

The OCI build compiles the binary under a rules_oci platform transition (an `ST-<hash>` config), a **different** action keyspace than the compile/tests jobs' `--platforms` flag config — so seeding from compile's cache yields 0 hits. This job therefore keeps its own Kura cache namespace (`kura-oci-data-`), whose key also includes `bookworm_apt.lock.json`.

## Risk / coverage

Shadow CI on `kura-bazel-phase1` only ever ran the **`cluster`** shard against the Bazel image. This PR runs **all four gating shards** against it for the first time. The overlay compose files were checked to honor `KURA_IMAGE` (discovery's extra `kura-us-2` uses `${KURA_IMAGE:-}`; extension/mtls only patch existing services and inherit the base image), but the `clients`/`discovery-faults-handoff`/`extension-mtls` shards are exercised against the Bazel image here for the first time — CI is the validation.

The DB-IP geoip URL is pinned to `2026-06`; DB-IP keeps only recent months online, so it needs periodic bumping (re-pin: curl the new dump + `sha256sum`).

## Validation

- `actionlint .github/workflows/kura.yml` and `shellcheck bazel/ci-oci.sh` pass.
- The OCI files + `MODULE.bazel.lock` are byte-identical to `kura-bazel-phase1` (where the full OCI build + `cluster` e2e are green); `MODULE.bazel` differs only in its docstring.
- CI on this PR builds the image and runs all four e2e shards against it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
