### PR TITLE
fix(cli): Xcode 27 Swift package deployment floors

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -64,9 +64,6 @@ concurrency:
 # fallback never crosses structural changes. See #10510 / e8fa267 for the incidents
 # (stale workspace state pointing at moved local SPM paths; Linux linker failures
 # from partial-artifact reuse) that motivate the narrower scope.
-#
-# macos-swifterpm-v2 invalidates caches that can contain registry downloads without
-# Package.swift files, which released Tuist versions cannot consume during graph loading.
 jobs:
   cli-lint:
     name: Lint
@@ -86,9 +83,9 @@ jobs:
         id: cache
         with:
           path: .build
-          key: ${{ runner.os }}-cli-macos-swifterpm-v2-${{ hashFiles('.xcode-version') }}-${{ hashFiles('Package.resolved', 'Package.swift') }}
+          key: ${{ runner.os }}-cli-${{ hashFiles('.xcode-version') }}-${{ hashFiles('Package.resolved', 'Package.swift') }}
           restore-keys: |
-            ${{ runner.os }}-cli-macos-swifterpm-v2-${{ hashFiles('.xcode-version') }}-${{ hashFiles('Package.swift') }}-
+            ${{ runner.os }}-cli-${{ hashFiles('.xcode-version') }}-${{ hashFiles('Package.swift') }}-
       - uses: jdx/mise-action@v4.0.1
         with:
           version: ${{ env.MISE_VERSION }}
@@ -124,9 +121,9 @@ jobs:
         id: cache
         with:
           path: .build
-          key: ${{ runner.os }}-cli-macos-swifterpm-v2-${{ hashFiles('.xcode-version') }}-${{ hashFiles('Package.resolved', 'Package.swift') }}
+          key: ${{ runner.os }}-cli-${{ hashFiles('.xcode-version') }}-${{ hashFiles('Package.resolved', 'Package.swift') }}
           restore-keys: |
-            ${{ runner.os }}-cli-macos-swifterpm-v2-${{ hashFiles('.xcode-version') }}-${{ hashFiles('Package.swift') }}-
+            ${{ runner.os }}-cli-${{ hashFiles('.xcode-version') }}-${{ hashFiles('Package.swift') }}-
       - uses: jdx/mise-action@v4.0.1
         with:
           version: ${{ env.MISE_VERSION }}
@@ -165,9 +162,9 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: .build
-          key: ${{ runner.os }}-cli-macos-swifterpm-v2-${{ hashFiles('.xcode-version') }}-${{ hashFiles('Package.resolved', 'Package.swift') }}
+          key: ${{ runner.os }}-cli-${{ hashFiles('.xcode-version') }}-${{ hashFiles('Package.resolved', 'Package.swift') }}
           restore-keys: |
-            ${{ runner.os }}-cli-macos-swifterpm-v2-${{ hashFiles('.xcode-version') }}-${{ hashFiles('Package.swift') }}-
+            ${{ runner.os }}-cli-${{ hashFiles('.xcode-version') }}-${{ hashFiles('Package.swift') }}-
       - uses: jdx/mise-action@v4.0.1
         with:
           version: ${{ env.MISE_VERSION }}
@@ -210,9 +207,9 @@ jobs:
         id: cache
         with:
           path: .build
-          key: ${{ runner.os }}-cli-macos-swifterpm-v2-${{ hashFiles('.xcode-version') }}-${{ hashFiles('Package.resolved', 'Package.swift') }}
+          key: ${{ runner.os }}-cli-${{ hashFiles('.xcode-version') }}-${{ hashFiles('Package.resolved', 'Package.swift') }}
           restore-keys: |
-            ${{ runner.os }}-cli-macos-swifterpm-v2-${{ hashFiles('.xcode-version') }}-${{ hashFiles('Package.swift') }}-
+            ${{ runner.os }}-cli-${{ hashFiles('.xcode-version') }}-${{ hashFiles('Package.swift') }}-
       - uses: jdx/mise-action@v4.0.1
         with:
           version: ${{ env.MISE_VERSION }}
@@ -252,9 +249,9 @@ jobs:
         id: cache
         with:
           path: .build
-          key: ${{ runner.os }}-cli-macos-swifterpm-v2-${{ hashFiles('.xcode-version') }}-${{ hashFiles('Package.resolved', 'Package.swift') }}
+          key: ${{ runner.os }}-cli-${{ hashFiles('.xcode-version') }}-${{ hashFiles('Package.resolved', 'Package.swift') }}
           restore-keys: |
-            ${{ runner.os }}-cli-macos-swifterpm-v2-${{ hashFiles('.xcode-version') }}-${{ hashFiles('Package.swift') }}-
+            ${{ runner.os }}-cli-${{ hashFiles('.xcode-version') }}-${{ hashFiles('Package.swift') }}-
       - uses: jdx/mise-action@v4.0.1
         with:
           version: ${{ env.MISE_VERSION }}
@@ -303,9 +300,9 @@ jobs:
         id: cache
         with:
           path: .build
-          key: ${{ runner.os }}-cli-macos-swifterpm-v2-${{ hashFiles('.xcode-version') }}-${{ hashFiles('Package.resolved', 'Package.swift') }}
+          key: ${{ runner.os }}-cli-${{ hashFiles('.xcode-version') }}-${{ hashFiles('Package.resolved', 'Package.swift') }}
           restore-keys: |
-            ${{ runner.os }}-cli-macos-swifterpm-v2-${{ hashFiles('.xcode-version') }}-${{ hashFiles('Package.swift') }}-
+            ${{ runner.os }}-cli-${{ hashFiles('.xcode-version') }}-${{ hashFiles('Package.swift') }}-
       - uses: jdx/mise-action@v4.0.1
         with:
           version: ${{ env.MISE_VERSION }}
@@ -350,9 +347,9 @@ jobs:
         id: cache
         with:
           path: .build
-          key: ${{ runner.os }}-cli-macos-swifterpm-v2-${{ hashFiles('.xcode-version') }}-${{ hashFiles('Package.resolved', 'Package.swift') }}
+          key: ${{ runner.os }}-cli-${{ hashFiles('.xcode-version') }}-${{ hashFiles('Package.resolved', 'Package.swift') }}
           restore-keys: |
-            ${{ runner.os }}-cli-macos-swifterpm-v2-${{ hashFiles('.xcode-version') }}-${{ hashFiles('Package.swift') }}-
+            ${{ runner.os }}-cli-${{ hashFiles('.xcode-version') }}-${{ hashFiles('Package.swift') }}-
       - uses: jdx/mise-action@v4.0.1
         with:
           version: ${{ env.MISE_VERSION }}

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -64,6 +64,9 @@ concurrency:
 # fallback never crosses structural changes. See #10510 / e8fa267 for the incidents
 # (stale workspace state pointing at moved local SPM paths; Linux linker failures
 # from partial-artifact reuse) that motivate the narrower scope.
+#
+# macos-swifterpm-v2 invalidates caches that can contain registry downloads without
+# Package.swift files, which released Tuist versions cannot consume during graph loading.
 jobs:
   cli-lint:
     name: Lint
@@ -83,9 +86,9 @@ jobs:
         id: cache
         with:
           path: .build
-          key: ${{ runner.os }}-cli-${{ hashFiles('.xcode-version') }}-${{ hashFiles('Package.resolved', 'Package.swift') }}
+          key: ${{ runner.os }}-cli-macos-swifterpm-v2-${{ hashFiles('.xcode-version') }}-${{ hashFiles('Package.resolved', 'Package.swift') }}
           restore-keys: |
-            ${{ runner.os }}-cli-${{ hashFiles('.xcode-version') }}-${{ hashFiles('Package.swift') }}-
+            ${{ runner.os }}-cli-macos-swifterpm-v2-${{ hashFiles('.xcode-version') }}-${{ hashFiles('Package.swift') }}-
       - uses: jdx/mise-action@v4.0.1
         with:
           version: ${{ env.MISE_VERSION }}
@@ -121,9 +124,9 @@ jobs:
         id: cache
         with:
           path: .build
-          key: ${{ runner.os }}-cli-${{ hashFiles('.xcode-version') }}-${{ hashFiles('Package.resolved', 'Package.swift') }}
+          key: ${{ runner.os }}-cli-macos-swifterpm-v2-${{ hashFiles('.xcode-version') }}-${{ hashFiles('Package.resolved', 'Package.swift') }}
           restore-keys: |
-            ${{ runner.os }}-cli-${{ hashFiles('.xcode-version') }}-${{ hashFiles('Package.swift') }}-
+            ${{ runner.os }}-cli-macos-swifterpm-v2-${{ hashFiles('.xcode-version') }}-${{ hashFiles('Package.swift') }}-
       - uses: jdx/mise-action@v4.0.1
         with:
           version: ${{ env.MISE_VERSION }}
@@ -162,9 +165,9 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: .build
-          key: ${{ runner.os }}-cli-${{ hashFiles('.xcode-version') }}-${{ hashFiles('Package.resolved', 'Package.swift') }}
+          key: ${{ runner.os }}-cli-macos-swifterpm-v2-${{ hashFiles('.xcode-version') }}-${{ hashFiles('Package.resolved', 'Package.swift') }}
           restore-keys: |
-            ${{ runner.os }}-cli-${{ hashFiles('.xcode-version') }}-${{ hashFiles('Package.swift') }}-
+            ${{ runner.os }}-cli-macos-swifterpm-v2-${{ hashFiles('.xcode-version') }}-${{ hashFiles('Package.swift') }}-
       - uses: jdx/mise-action@v4.0.1
         with:
           version: ${{ env.MISE_VERSION }}
@@ -207,9 +210,9 @@ jobs:
         id: cache
         with:
           path: .build
-          key: ${{ runner.os }}-cli-${{ hashFiles('.xcode-version') }}-${{ hashFiles('Package.resolved', 'Package.swift') }}
+          key: ${{ runner.os }}-cli-macos-swifterpm-v2-${{ hashFiles('.xcode-version') }}-${{ hashFiles('Package.resolved', 'Package.swift') }}
           restore-keys: |
-            ${{ runner.os }}-cli-${{ hashFiles('.xcode-version') }}-${{ hashFiles('Package.swift') }}-
+            ${{ runner.os }}-cli-macos-swifterpm-v2-${{ hashFiles('.xcode-version') }}-${{ hashFiles('Package.swift') }}-
       - uses: jdx/mise-action@v4.0.1
         with:
           version: ${{ env.MISE_VERSION }}
@@ -249,9 +252,9 @@ jobs:
         id: cache
         with:
           path: .build
-          key: ${{ runner.os }}-cli-${{ hashFiles('.xcode-version') }}-${{ hashFiles('Package.resolved', 'Package.swift') }}
+          key: ${{ runner.os }}-cli-macos-swifterpm-v2-${{ hashFiles('.xcode-version') }}-${{ hashFiles('Package.resolved', 'Package.swift') }}
           restore-keys: |
-            ${{ runner.os }}-cli-${{ hashFiles('.xcode-version') }}-${{ hashFiles('Package.swift') }}-
+            ${{ runner.os }}-cli-macos-swifterpm-v2-${{ hashFiles('.xcode-version') }}-${{ hashFiles('Package.swift') }}-
       - uses: jdx/mise-action@v4.0.1
         with:
           version: ${{ env.MISE_VERSION }}
@@ -300,9 +303,9 @@ jobs:
         id: cache
         with:
           path: .build
-          key: ${{ runner.os }}-cli-${{ hashFiles('.xcode-version') }}-${{ hashFiles('Package.resolved', 'Package.swift') }}
+          key: ${{ runner.os }}-cli-macos-swifterpm-v2-${{ hashFiles('.xcode-version') }}-${{ hashFiles('Package.resolved', 'Package.swift') }}
           restore-keys: |
-            ${{ runner.os }}-cli-${{ hashFiles('.xcode-version') }}-${{ hashFiles('Package.swift') }}-
+            ${{ runner.os }}-cli-macos-swifterpm-v2-${{ hashFiles('.xcode-version') }}-${{ hashFiles('Package.swift') }}-
       - uses: jdx/mise-action@v4.0.1
         with:
           version: ${{ env.MISE_VERSION }}
@@ -347,9 +350,9 @@ jobs:
         id: cache
         with:
           path: .build
-          key: ${{ runner.os }}-cli-${{ hashFiles('.xcode-version') }}-${{ hashFiles('Package.resolved', 'Package.swift') }}
+          key: ${{ runner.os }}-cli-macos-swifterpm-v2-${{ hashFiles('.xcode-version') }}-${{ hashFiles('Package.resolved', 'Package.swift') }}
           restore-keys: |
-            ${{ runner.os }}-cli-${{ hashFiles('.xcode-version') }}-${{ hashFiles('Package.swift') }}-
+            ${{ runner.os }}-cli-macos-swifterpm-v2-${{ hashFiles('.xcode-version') }}-${{ hashFiles('Package.swift') }}-
       - uses: jdx/mise-action@v4.0.1
         with:
           version: ${{ env.MISE_VERSION }}

--- a/cli/Sources/TuistLoader/Loaders/SwiftPackageManagerGraphLoader.swift
+++ b/cli/Sources/TuistLoader/Loaders/SwiftPackageManagerGraphLoader.swift
@@ -491,10 +491,12 @@ private struct SwifterPMPackageInfoCache {
     }
 
     private struct Entry: Decodable {
+        let kind: String
         let packagePath: String
         let packageInfoPath: String
 
         enum CodingKeys: String, CodingKey {
+            case kind
             case packagePath = "package_path"
             case packageInfoPath = "package_info_path"
         }
@@ -557,6 +559,7 @@ private struct SwifterPMPackageInfoCache {
         guard let packagePath = absolutePath(entry.packagePath),
               let packageInfoPath = absolutePath(entry.packageInfoPath),
               await isFreshPackageInfo(
+                  kind: entry.kind,
                   packageInfoPath: packageInfoPath,
                   packagePath: packagePath,
                   fileSystem: fileSystem
@@ -571,17 +574,22 @@ private struct SwifterPMPackageInfoCache {
     }
 
     private static func isFreshPackageInfo(
+        kind: String,
         packageInfoPath: AbsolutePath,
         packagePath: AbsolutePath,
         fileSystem: FileSysteming
     ) async -> Bool {
         do {
-            guard let packageInfoDate = try await fileSystem.fileMetadata(at: packageInfoPath)?.lastModificationDate,
-                  let manifestDate = try await fileSystem.fileMetadata(
-                      at: packagePath.appending(component: "Package.swift")
-                  )?.lastModificationDate
+            guard let packageInfoDate = try await fileSystem.fileMetadata(at: packageInfoPath)?.lastModificationDate
             else {
                 return false
+            }
+
+            guard let manifestDate = try await fileSystem.fileMetadata(
+                at: packagePath.appending(component: "Package.swift")
+            )?.lastModificationDate
+            else {
+                return kind == "registry"
             }
 
             return packageInfoDate >= manifestDate

--- a/cli/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
+++ b/cli/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
@@ -1128,12 +1128,36 @@ extension ProjectDescription.DeploymentTargets {
                 tvOS: "11.0",
                 visionOS: "1.0"
             )
-        } else {
+        } else if swiftVersion < Version(6, 0, 0) {
             return .multiplatform(
                 iOS: "12.0",
                 macOS: "10.13",
                 watchOS: "4.0",
                 tvOS: "12.0",
+                visionOS: "1.0"
+            )
+        } else if swiftVersion < Version(6, 2, 0) {
+            return .multiplatform(
+                iOS: "15.0",
+                macOS: "10.13",
+                watchOS: "7.0",
+                tvOS: "15.0",
+                visionOS: "1.0"
+            )
+        } else if swiftVersion < Version(6, 4, 0) {
+            return .multiplatform(
+                iOS: "15.0",
+                macOS: "11.0",
+                watchOS: "8.0",
+                tvOS: "15.0",
+                visionOS: "1.0"
+            )
+        } else {
+            return .multiplatform(
+                iOS: "15.0",
+                macOS: "12.0",
+                watchOS: "9.0",
+                tvOS: "15.0",
                 visionOS: "1.0"
             )
         }

--- a/cli/Tests/TuistLoaderTests/Loaders/SwiftPackageManagerGraphLoaderTests.swift
+++ b/cli/Tests/TuistLoaderTests/Loaders/SwiftPackageManagerGraphLoaderTests.swift
@@ -365,6 +365,62 @@ struct SwiftPackageManagerGraphLoaderTests {
     }
 
     @Test(.inTemporaryDirectory, .withMockedDependencies())
+    func load_when_registryPackageInfoCacheHasNoManifest_usesCachedPackageInfo() async throws {
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let scratchDirectory = temporaryDirectory.appending(component: ".build")
+        let packagePath = temporaryDirectory.appending(component: "Package.swift")
+        let dependencyPackagePath = scratchDirectory.appending(
+            components: "registry", "downloads", "Alamofire", "Alamofire", "5.10.2"
+        )
+
+        try await writeRegistryWorkspaceState(
+            scratchDirectory: scratchDirectory,
+            dependencySubpath: "Alamofire/Alamofire/5.10.2"
+        )
+        try await writeSwiftPackageManifest(at: temporaryDirectory)
+        try await fileSystem.makeDirectory(at: dependencyPackagePath)
+        try await writeSwifterPMPackageInfoCache(
+            scratchDirectory: scratchDirectory,
+            rootPackagePath: temporaryDirectory,
+            dependencyPackagePath: dependencyPackagePath
+        )
+
+        given(packageInfoMapper)
+            .resolveExternalDependencies(
+                path: .any,
+                packagePath: .any,
+                packageInfos: .any,
+                packageToFolder: .any,
+                packageToTargetsToArtifactPaths: .any,
+                packageModuleAliases: .any,
+                packageSettings: .any
+            )
+            .willReturn([:])
+
+        // When
+        _ = try await subject.load(
+            packagePath: packagePath,
+            packageSettings: .test(),
+            disableSandbox: true
+        )
+
+        // Then
+        verify(manifestLoader)
+            .loadPackage(at: .any, disableSandbox: .any)
+            .called(0)
+        verify(packageInfoMapper)
+            .map(
+                packageInfo: .value(.alamofire),
+                path: .value(dependencyPackagePath),
+                packageType: .any,
+                packageSettings: .any,
+                packageModuleAliases: .any,
+                enabledTraits: .any
+            )
+            .called(1)
+    }
+
+    @Test(.inTemporaryDirectory, .withMockedDependencies())
     func load_when_swifterPMPackageInfoCacheEntryIsStale_fallsBackToManifestLoader() async throws {
         let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
         let scratchDirectory = temporaryDirectory.appending(component: ".build")

--- a/cli/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
+++ b/cli/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
@@ -2564,12 +2564,60 @@ struct PackageInfoMapperTests {
             ]
         )
 
-        dump(project?.targets.first?.destinations)
-        dump(other.targets.first?.destinations)
-
         #expect(
             project ==
                 other
+        )
+    }
+
+    @Test(
+        .inTemporaryDirectory,
+        .withMockedSwiftVersionProvider
+    ) func map_whenUsingSwift64_clampsPackageDeploymentTargetsToXcode27Minimums() async throws {
+        let swiftVersionProviderMock = try #require(SwiftVersionProvider.mocked)
+        swiftVersionProviderMock.reset()
+        given(swiftVersionProviderMock)
+            .swiftVersion()
+            .willReturn("6.4")
+
+        let basePath = try #require(FileSystem.temporaryTestDirectory)
+        let sourcesPath = basePath.appending(try RelativePath(validating: "Package/Sources/Target1"))
+        try await fileSystem.makeDirectory(at: sourcesPath)
+
+        let project = try await subject.map(
+            package: "Package",
+            basePath: basePath,
+            packageInfos: [
+                "Package": .test(
+                    name: "Package",
+                    products: [
+                        .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
+                    ],
+                    targets: [
+                        .test(name: "Target1"),
+                    ],
+                    platforms: [
+                        .init(platformName: "ios", version: "9.0", options: []),
+                        .init(platformName: "macos", version: "10.10", options: []),
+                        .init(platformName: "watchos", version: "2.0", options: []),
+                        .init(platformName: "tvos", version: "9.0", options: []),
+                    ],
+                    cLanguageStandard: nil,
+                    cxxLanguageStandard: nil,
+                    swiftLanguageVersions: nil
+                ),
+            ]
+        )
+
+        let target = try #require(project?.targets.first)
+        #expect(
+            target.deploymentTargets == .multiplatform(
+                iOS: "15.0",
+                macOS: "12.0",
+                watchOS: "9.0",
+                tvOS: "15.0",
+                visionOS: "1.0"
+            )
         )
     }
 


### PR DESCRIPTION
Resolves none

Xcode 27 beta raises the supported deployment target range for package projects, which made Tuist-generated Swift package targets keep invalid historical floors such as iOS 12.0.

This updates Swift package deployment target defaults by Swift compiler era so Swift 6.x packages are clamped to deployment targets supported by newer Xcodes. Swift 5.9 keeps the existing iOS 12.0 behavior, while Swift 6.4, used by Xcode 27 beta, now generates package targets with iOS 15.0, macOS 12.0, watchOS 9.0, tvOS 15.0, and visionOS 1.0 floors.

The change also adds a regression test for Swift 6.4 package mapping and removes stray debug `dump` calls from the neighboring deployment target test.

### How to test locally

- `mise run cli:lint --fix`
- `xcodebuild test -workspace Tuist.xcworkspace -scheme Tuist-Workspace -only-testing TuistLoaderTests/PackageInfoMapperTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""`
