### PR TITLE
fix(server): speed up xcode cache widgets

### DIFF
--- a/server/data-export.md
+++ b/server/data-export.md
@@ -74,7 +74,7 @@ The following data is stored in ClickHouse for analytics purposes:
 - **Build files** (`build_files` table): Individual file compilation metrics
 - **Build targets** (`build_targets` table): Target/module build performance
 - **Cacheable tasks** (`cacheable_tasks` table): Xcode cache task analytics with hit/miss status
-- **CAS outputs** (`cas_outputs` table): Content-addressable storage upload/download records
+- **CAS outputs** (`cas_outputs` table): Content-addressable storage upload/download records, including the denormalized project id used for project-scoped analytics
 - **Shard plans** (`shard_plans` table): Test sharding plan data including reference, shard count, and granularity
 - **Shard plan modules** (`shard_plan_modules` table): Per-shard module assignments with estimated durations
 - **Shard plan test suites** (`shard_plan_test_suites` table): Per-shard test suite assignments with estimated durations

--- a/server/lib/tuist/builds.ex
+++ b/server/lib/tuist/builds.ex
@@ -313,10 +313,11 @@ defmodule Tuist.Builds do
   defp create_cas_outputs(build, outputs) do
     outputs =
       outputs
-      |> Enum.map(&CASOutput.changeset(build.id, &1))
+      |> Enum.map(&CASOutput.changeset(build.id, build.project_id, &1))
       |> Enum.map(&Ecto.Changeset.apply_changes/1)
       |> Enum.map(fn struct ->
         %{
+          project_id: struct.project_id,
           node_id: struct.node_id,
           checksum: struct.checksum,
           size: struct.size,

--- a/server/lib/tuist/builds/analytics.ex
+++ b/server/lib/tuist/builds/analytics.ex
@@ -1056,6 +1056,8 @@ defmodule Tuist.Builds.Analytics do
     end
   end
 
+  @cas_actions ["download", "upload"]
+
   @doc """
   Gets CAS upload analytics for a project over a time period sourced from the
   per-task `cas_outputs` data already collected by the CAS plugin.
@@ -1077,9 +1079,11 @@ defmodule Tuist.Builds.Analytics do
   split preserved. The combined total/series are sums of downloads and uploads.
   """
   def cas_transfer_analytics(project_id, opts \\ []) do
-    downloads = cas_action_metrics(project_id, "download", opts)
-    uploads = cas_action_metrics(project_id, "upload", opts)
+    %{transfer: transfer} = cas_analytics(project_id, opts)
+    transfer
+  end
 
+  defp cas_transfer_analytics_from_metrics(downloads, uploads) do
     combined_values =
       downloads.size_values
       |> Enum.zip(uploads.size_values)
@@ -1104,9 +1108,11 @@ defmodule Tuist.Builds.Analytics do
   count.
   """
   def cas_latency_analytics(project_id, opts \\ []) do
-    downloads = cas_action_metrics(project_id, "download", opts)
-    uploads = cas_action_metrics(project_id, "upload", opts)
+    %{latency: latency} = cas_analytics(project_id, opts)
+    latency
+  end
 
+  defp cas_latency_analytics_from_metrics(downloads, uploads) do
     combined_values =
       [
         downloads.duration_values,
@@ -1147,9 +1153,11 @@ defmodule Tuist.Builds.Analytics do
   the sum of recorded durations across both actions.
   """
   def cas_throughput_analytics(project_id, opts \\ []) do
-    downloads = cas_action_metrics(project_id, "download", opts)
-    uploads = cas_action_metrics(project_id, "upload", opts)
+    %{throughput: throughput} = cas_analytics(project_id, opts)
+    throughput
+  end
 
+  defp cas_throughput_analytics_from_metrics(downloads, uploads) do
     combined_values =
       [
         downloads.size_values,
@@ -1184,6 +1192,18 @@ defmodule Tuist.Builds.Analytics do
     }
   end
 
+  def cas_analytics(project_id, opts \\ []) do
+    action_metrics = cas_action_metrics_by_action(project_id, opts)
+    downloads = Map.fetch!(action_metrics, "download")
+    uploads = Map.fetch!(action_metrics, "upload")
+
+    %{
+      transfer: cas_transfer_analytics_from_metrics(downloads, uploads),
+      latency: cas_latency_analytics_from_metrics(downloads, uploads),
+      throughput: cas_throughput_analytics_from_metrics(downloads, uploads)
+    }
+  end
+
   defp to_transfer_summary(metrics) do
     %{
       trend: trend(previous_value: metrics.previous_size, current_value: metrics.total_size),
@@ -1195,21 +1215,40 @@ defmodule Tuist.Builds.Analytics do
   end
 
   defp cas_action_metrics(project_id, action, opts) do
+    project_id
+    |> cas_action_metrics_by_action(opts)
+    |> Map.fetch!(action)
+  end
+
+  defp cas_action_metrics_by_action(project_id, opts) do
     {start_datetime, end_datetime, days_delta, date_period, interval_str} =
       cas_analytics_period(opts)
 
-    current_rows =
-      cas_action_metrics_rows(project_id, action, start_datetime, end_datetime, interval_str)
-
-    current_totals = cas_action_totals(project_id, action, start_datetime, end_datetime)
-
     previous_start_datetime = DateTime.add(start_datetime, -days_delta, :day)
 
-    previous_totals =
-      cas_action_totals(project_id, action, previous_start_datetime, start_datetime)
+    rows =
+      cas_action_metrics_rows(project_id, previous_start_datetime, start_datetime, end_datetime, interval_str)
+
+    rows_by_action = Enum.group_by(rows, fn [action | _] -> action end)
+
+    Map.new(@cas_actions, fn action ->
+      metrics =
+        rows_by_action
+        |> Map.get(action, [])
+        |> cas_action_metrics_from_rows(start_datetime, end_datetime, date_period)
+
+      {action, metrics}
+    end)
+  end
+
+  defp cas_action_metrics_from_rows(rows, start_datetime, end_datetime, date_period) do
+    current_rows = Enum.filter(rows, fn [_action, period_kind | _] -> period_kind == "current" end)
+    previous_rows = Enum.filter(rows, fn [_action, period_kind | _] -> period_kind == "previous" end)
+    current_totals = cas_rows_totals(current_rows)
+    previous_totals = cas_rows_totals(previous_rows)
 
     parsed_rows =
-      Enum.map(current_rows, fn [date, total_size, total_duration_ms, event_count] ->
+      Enum.map(current_rows, fn [_action, _period_kind, date, total_size, total_duration_ms, event_count] ->
         %{
           date: date,
           size: total_size || 0,
@@ -1250,69 +1289,50 @@ defmodule Tuist.Builds.Analytics do
     }
   end
 
-  defp cas_action_metrics_rows(project_id, action, start_datetime, end_datetime, interval_str) do
+  defp cas_rows_totals(rows) do
+    Enum.reduce(rows, %{total_size: 0, total_duration_ms: 0, event_count: 0}, fn row, acc ->
+      [_action, _period_kind, _date, total_size, total_duration_ms, event_count] = row
+
+      %{
+        total_size: acc.total_size + (total_size || 0),
+        total_duration_ms: acc.total_duration_ms + (total_duration_ms || 0),
+        event_count: acc.event_count + (event_count || 0)
+      }
+    end)
+  end
+
+  defp cas_action_metrics_rows(project_id, previous_start_datetime, start_datetime, end_datetime, interval_str) do
     %{rows: rows} =
       ClickHouseRepo.query!(
         """
         SELECT
-          toStartOfInterval(toDateTime(co.inserted_at), INTERVAL #{interval_str}, 'UTC') as period,
+          toString(co.operation) AS action,
+          if(co.inserted_at >= {start_dt:DateTime}, 'current', 'previous') AS period_kind,
+          if(
+            co.inserted_at >= {start_dt:DateTime},
+            toStartOfInterval(toDateTime(co.inserted_at), INTERVAL #{interval_str}, 'UTC'),
+            toDateTime(0)
+          ) AS period,
           SUM(co.size) as total_size,
           SUM(co.duration) as total_duration_ms,
           COUNT() as event_count
         FROM cas_outputs AS co
-        INNER JOIN build_runs AS br ON br.id = co.build_run_id
-        WHERE br.project_id = {project_id:Int64}
-          AND co.operation = {action:String}
-          AND co.inserted_at >= {start_dt:DateTime}
+        WHERE co.project_id = {project_id:Int64}
+          AND co.operation IN ('download', 'upload')
+          AND co.inserted_at >= {previous_start_dt:DateTime}
           AND co.inserted_at <= {end_dt:DateTime}
-        GROUP BY period
-        ORDER BY period
+        GROUP BY action, period_kind, period
+        ORDER BY action, period_kind, period
         """,
         %{
           project_id: project_id,
-          action: action,
+          previous_start_dt: previous_start_datetime,
           start_dt: start_datetime,
           end_dt: end_datetime
         }
       )
 
     rows
-  end
-
-  defp cas_action_totals(project_id, action, start_datetime, end_datetime) do
-    %{rows: rows} =
-      ClickHouseRepo.query!(
-        """
-        SELECT
-          SUM(co.size) as total_size,
-          SUM(co.duration) as total_duration_ms,
-          COUNT() as event_count
-        FROM cas_outputs AS co
-        INNER JOIN build_runs AS br ON br.id = co.build_run_id
-        WHERE br.project_id = {project_id:Int64}
-          AND co.operation = {action:String}
-          AND co.inserted_at >= {start_dt:DateTime}
-          AND co.inserted_at <= {end_dt:DateTime}
-        """,
-        %{
-          project_id: project_id,
-          action: action,
-          start_dt: start_datetime,
-          end_dt: end_datetime
-        }
-      )
-
-    case rows do
-      [[total_size, total_duration_ms, event_count]] ->
-        %{
-          total_size: total_size || 0,
-          total_duration_ms: total_duration_ms || 0,
-          event_count: event_count || 0
-        }
-
-      _ ->
-        %{total_size: 0, total_duration_ms: 0, event_count: 0}
-    end
   end
 
   defp fill_cas_series(parsed_rows, key, start_datetime, end_datetime, date_period) do

--- a/server/lib/tuist/builds/cas_output.ex
+++ b/server/lib/tuist/builds/cas_output.ex
@@ -7,7 +7,7 @@ defmodule Tuist.Builds.CASOutput do
 
   @derive {
     Flop.Schema,
-    filterable: [:build_run_id, :node_id, :operation, :size, :compressed_size, :type],
+    filterable: [:project_id, :build_run_id, :node_id, :operation, :size, :compressed_size, :type],
     sortable: [:node_id, :size, :compressed_size]
   }
 
@@ -81,14 +81,20 @@ defmodule Tuist.Builds.CASOutput do
 
     field :type, Ch, type: "LowCardinality(String)"
 
+    field :project_id, Ch, type: "Int64"
     field :build_run_id, Ch, type: "UUID"
     field :inserted_at, Ch, type: "DateTime"
   end
 
   def changeset(build_run_id, attrs) do
+    changeset(build_run_id, Map.get(attrs, :project_id), attrs)
+  end
+
+  def changeset(build_run_id, project_id, attrs) do
     %__MODULE__{}
     |> Ecto.Changeset.cast(
       %{
+        project_id: project_id,
         build_run_id: build_run_id,
         node_id: attrs[:node_id],
         checksum: attrs[:checksum],
@@ -99,9 +105,21 @@ defmodule Tuist.Builds.CASOutput do
         type: (attrs[:type] && to_string(attrs[:type])) || "unknown",
         inserted_at: :second |> DateTime.utc_now() |> DateTime.to_naive()
       },
-      [:build_run_id, :node_id, :checksum, :size, :duration, :compressed_size, :operation, :type, :inserted_at]
+      [
+        :project_id,
+        :build_run_id,
+        :node_id,
+        :checksum,
+        :size,
+        :duration,
+        :compressed_size,
+        :operation,
+        :type,
+        :inserted_at
+      ]
     )
     |> Ecto.Changeset.validate_required([
+      :project_id,
       :build_run_id,
       :node_id,
       :checksum,

--- a/server/lib/tuist_web/live/xcode_cache_live.ex
+++ b/server/lib/tuist_web/live/xcode_cache_live.ex
@@ -189,23 +189,23 @@ defmodule TuistWeb.XcodeCacheLive do
     |> assign_async(
       [:transfer_analytics, :latency_analytics, :throughput_analytics, :hit_rate_analytics, :analytics_chart_data],
       fn ->
-        transfer_analytics = Analytics.cas_transfer_analytics(project.id, opts)
-        latency_analytics = Analytics.cas_latency_analytics(project.id, opts)
-        throughput_analytics = Analytics.cas_throughput_analytics(project.id, opts)
-        hit_rate_analytics = Analytics.build_cache_hit_rate_analytics(project.id, opts)
+        cas_task = Task.async(fn -> Analytics.cas_analytics(project.id, opts) end)
+        hit_rate_task = Task.async(fn -> Analytics.build_cache_hit_rate_analytics(project.id, opts) end)
+
+        [cas_analytics, hit_rate_analytics] = Task.await_many([cas_task, hit_rate_task], 30_000)
 
         {:ok,
          %{
-           transfer_analytics: transfer_analytics,
-           latency_analytics: latency_analytics,
-           throughput_analytics: throughput_analytics,
+           transfer_analytics: cas_analytics.transfer,
+           latency_analytics: cas_analytics.latency,
+           throughput_analytics: cas_analytics.throughput,
            hit_rate_analytics: hit_rate_analytics,
            analytics_chart_data:
              analytics_chart_data(
                analytics_selected_widget,
-               transfer_analytics,
-               latency_analytics,
-               throughput_analytics,
+               cas_analytics.transfer,
+               cas_analytics.latency,
+               cas_analytics.throughput,
                hit_rate_analytics
              )
          }}

--- a/server/priv/ingest_repo/migrations/20260609120000_denormalize_project_id_on_cas_outputs.exs
+++ b/server/priv/ingest_repo/migrations/20260609120000_denormalize_project_id_on_cas_outputs.exs
@@ -1,0 +1,110 @@
+defmodule Tuist.IngestRepo.Migrations.DenormalizeProjectIdOnCasOutputs do
+  @moduledoc """
+  Adds and backfills `project_id` on `cas_outputs` for project-level cache
+  analytics.
+
+  This table is written continuously in production, so the migration keeps
+  `cas_outputs` as the canonical table instead of copying into a shadow table
+  and swapping. The backfill is an in-place ClickHouse mutation backed by a
+  dictionary lookup, and the project-ordered access path is provided by a
+  materialized projection.
+  """
+  use Ecto.Migration
+  alias Tuist.IngestRepo
+  require Logger
+
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+  @dict_name "build_runs_project_ids_for_cas_outputs"
+  @projection_name "proj_by_project_operation_inserted_at"
+
+  def up do
+    IngestRepo.query!("DROP DICTIONARY IF EXISTS #{@dict_name}")
+
+    create_project_ids_dictionary()
+    add_project_id_column()
+
+    try do
+      backfill_project_id()
+      add_project_ordered_projection()
+      materialize_project_ordered_projection()
+    after
+      IngestRepo.query!("DROP DICTIONARY IF EXISTS #{@dict_name}")
+    end
+  end
+
+  def down do
+    IngestRepo.query!("ALTER TABLE cas_outputs DROP PROJECTION IF EXISTS #{@projection_name}")
+    IngestRepo.query!("ALTER TABLE cas_outputs DROP COLUMN IF EXISTS project_id")
+  end
+
+  defp create_project_ids_dictionary do
+    IngestRepo.query!("""
+    CREATE DICTIONARY #{@dict_name} (
+      id UUID,
+      project_id Int64
+    )
+    PRIMARY KEY id
+    SOURCE(CLICKHOUSE(TABLE 'build_runs'))
+    LAYOUT(HASHED())
+    LIFETIME(0)
+    """)
+  end
+
+  defp add_project_id_column do
+    IngestRepo.query!("""
+    ALTER TABLE cas_outputs
+    ADD COLUMN IF NOT EXISTS project_id Int64 DEFAULT 0 AFTER operation
+    """)
+  end
+
+  defp backfill_project_id do
+    Logger.info("Starting cas_outputs project_id backfill mutation")
+
+    IngestRepo.query!(
+      """
+      ALTER TABLE cas_outputs
+      UPDATE project_id = dictGetOrDefault('#{@dict_name}', 'project_id', build_run_id, toInt64(0))
+      WHERE project_id = 0
+      SETTINGS mutations_sync = 1
+      """,
+      [],
+      timeout: :infinity
+    )
+
+    Logger.info("Finished cas_outputs project_id backfill mutation")
+  end
+
+  defp add_project_ordered_projection do
+    IngestRepo.query!("""
+    ALTER TABLE cas_outputs
+    ADD PROJECTION IF NOT EXISTS #{@projection_name}
+    (
+      SELECT
+        project_id,
+        operation,
+        inserted_at,
+        size,
+        duration,
+        compressed_size
+      ORDER BY (project_id, operation, inserted_at)
+    )
+    """)
+  end
+
+  defp materialize_project_ordered_projection do
+    Logger.info("Starting cas_outputs project-ordered projection materialization")
+
+    IngestRepo.query!(
+      """
+      ALTER TABLE cas_outputs
+      MATERIALIZE PROJECTION #{@projection_name}
+      SETTINGS mutations_sync = 1
+      """,
+      [],
+      timeout: :infinity
+    )
+
+    Logger.info("Finished cas_outputs project-ordered projection materialization")
+  end
+end

--- a/server/priv/repo/seeds.exs
+++ b/server/priv/repo/seeds.exs
@@ -601,6 +601,7 @@ cas_output_generator = fn build ->
     compressed_size = trunc(size * (0.3 + :rand.uniform() * 0.6))
 
     %{
+      project_id: build.project_id,
       build_run_id: build.id,
       node_id: generate_cas_node_id.(),
       checksum: generate_checksum.(),

--- a/server/test/support/tuist_test_support/fixtures/runs_fixtures.ex
+++ b/server/test/support/tuist_test_support/fixtures/runs_fixtures.ex
@@ -158,13 +158,16 @@ defmodule TuistTestSupport.Fixtures.RunsFixtures do
   end
 
   def cas_output_fixture(attrs \\ []) do
-    build_run_id =
-      Keyword.get_lazy(attrs, :build_run_id, fn ->
+    {build_run_id, project_id} =
+      if Keyword.has_key?(attrs, :build_run_id) do
+        {Keyword.fetch!(attrs, :build_run_id), Keyword.get(attrs, :project_id, 0)}
+      else
         {:ok, build} = build_fixture()
-        build.id
-      end)
+        {build.id, Keyword.get(attrs, :project_id, build.project_id)}
+      end
 
     cas_output = %{
+      project_id: project_id,
       node_id: Keyword.get(attrs, :node_id, "node1"),
       checksum: Keyword.get(attrs, :checksum, "abc123"),
       size: Keyword.get(attrs, :size, 1000),

--- a/server/test/tuist/builds/analytics_test.exs
+++ b/server/test/tuist/builds/analytics_test.exs
@@ -2802,14 +2802,14 @@ defmodule Tuist.Builds.AnalyticsTest do
       IngestRepo.query!(
         """
         INSERT INTO cas_outputs
-          (node_id, checksum, size, duration, compressed_size, operation, build_run_id, inserted_at)
+          (node_id, checksum, size, duration, compressed_size, operation, project_id, build_run_id, inserted_at)
         VALUES
-          ('n1', 'c1', 1024, 100, 1024, 'upload',   {b1:UUID}, toDateTime('2024-04-15 12:00:00')),
-          ('n2', 'c2', 2048, 200, 2048, 'upload',   {b2:UUID}, toDateTime('2024-05-15 12:00:00')),
-          ('n3', 'c3', 4096, 400, 4096, 'upload',   {b3:UUID}, toDateTime('2024-06-15 12:00:00')),
-          ('n4', 'c4', 9999, 999, 9999, 'download', {b4:UUID}, toDateTime('2024-05-15 12:00:00'))
+          ('n1', 'c1', 1024, 100, 1024, 'upload',   {pid:Int64}, {b1:UUID}, toDateTime('2024-04-15 12:00:00')),
+          ('n2', 'c2', 2048, 200, 2048, 'upload',   {pid:Int64}, {b2:UUID}, toDateTime('2024-05-15 12:00:00')),
+          ('n3', 'c3', 4096, 400, 4096, 'upload',   {pid:Int64}, {b3:UUID}, toDateTime('2024-06-15 12:00:00')),
+          ('n4', 'c4', 9999, 999, 9999, 'download', {pid:Int64}, {b4:UUID}, toDateTime('2024-05-15 12:00:00'))
         """,
-        %{b1: build_one, b2: build_two, b3: build_three, b4: build_four}
+        %{pid: project.id, b1: build_one, b2: build_two, b3: build_three, b4: build_four}
       )
 
       # When

--- a/server/test/tuist/builds/cas_output_test.exs
+++ b/server/test/tuist/builds/cas_output_test.exs
@@ -5,6 +5,7 @@ defmodule Tuist.Builds.CASOutputTest do
 
   describe "changeset/2" do
     @valid_attrs %{
+      project_id: 1,
       node_id: "MyTarget",
       checksum: "abc123def456",
       size: 1024,
@@ -125,6 +126,14 @@ defmodule Tuist.Builds.CASOutputTest do
 
       refute changeset.valid?
       assert "can't be blank" in errors_on(changeset).build_run_id
+    end
+
+    test "requires project_id" do
+      attrs = Map.delete(@valid_attrs, :project_id)
+      changeset = CASOutput.changeset("B12673DA-1345-4077-BB30-D7576FEACE09", attrs)
+
+      refute changeset.valid?
+      assert "can't be blank" in errors_on(changeset).project_id
     end
 
     test "requires node_id" do

--- a/server/test/tuist/builds_test.exs
+++ b/server/test/tuist/builds_test.exs
@@ -1560,6 +1560,7 @@ defmodule Tuist.BuildsTest do
       assert "node1" in node_ids
       assert "node3" in node_ids
       refute "node2" in node_ids
+      assert Enum.all?(outputs, &(&1.project_id == build.project_id))
     end
 
     test "returns empty list when node_ids is empty" do


### PR DESCRIPTION
## What changed

- Denormalized `project_id` onto ClickHouse `cas_outputs` and populated it for new CAS output writes, seeds, and test fixtures.
- Added an in-place ClickHouse migration that adds `project_id`, backfills existing rows with a dictionary-backed `ALTER TABLE ... UPDATE`, and materializes a project-ordered projection.
- Added `proj_by_project_operation_inserted_at` ordered by `(project_id, operation, inserted_at)` so project-scoped CAS analytics get a prunable access path without replacing the hot table.
- Reworked CAS widget analytics to aggregate download/upload metrics from `cas_outputs` in one project-scoped query instead of issuing separate queries for each widget.
- Updated the Xcode cache LiveView to reuse the combined CAS analytics result and run the remaining hit-rate analytics concurrently.
- Updated `server/data-export.md` for the new stored analytics field.

## Why

The `/tuist/tuist/xcode-cache` page mounted quickly, but its widgets spent 20+ seconds loading because each CAS widget queried `cas_outputs` separately and joined through `build_runs` to filter by project. Since `project_id` only lived on `build_runs`, ClickHouse could not prune `cas_outputs` before the join and each widget scanned the full table.

## Root cause

The CAS analytics query shape filtered by `br.project_id` after joining from `cas_outputs`, so the most selective project predicate was unavailable to the `cas_outputs` table scan. The LiveView then amplified the cost by issuing independent CAS widget queries for transfer, latency, and throughput.

## Why this migration shape

A shadow-table rewrite plus `EXCHANGE TABLES` is unsafe for a hot ingest table unless CAS output writes are paused: rows can be written while the copy is running, and a row-count check only detects some races after the expensive work has already happened. This PR therefore keeps `cas_outputs` as the canonical table and uses an in-place ClickHouse mutation for the backfill.

The migration still does real historical backfill work. It creates a temporary dictionary over `build_runs`, updates `project_id` on existing rows where it is still `0`, then materializes a projection ordered by `(project_id, operation, inserted_at)`. New application writes include `project_id` directly, so rows written by the updated code do not depend on the dictionary.

## Impact

Project-scoped CAS analytics can use denormalized `project_id` for historical rows once the mutation completes and for new rows immediately after the application writes them. The dashboard also avoids redundant CAS queries by deriving transfer, latency, and throughput widgets from one CAS analytics result while fetching hit-rate analytics concurrently.

## Validation

- `MIX_ENV=test mix ecto.reset`
- `mix test test/tuist/builds/cas_output_test.exs test/tuist/builds/analytics_test.exs:2780 test/tuist/builds_test.exs:1519 test/tuist_web/live/xcode_cache_live_test.exs`
- `git diff --check`

Note: local `mix deps.get` currently wants unrelated patch bumps for `cowboy`, `cowlib`, and `deep_merge`; those lockfile changes were not included in this PR.
