### PR TITLE
chore(cli): update SwifterPM for resolver progress and artifact restoration fixes

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "8d5d9c04eaae33643ec455b899e85a539fe7d9acda97c6a261b39abac12d9f0e",
+  "originHash" : "7969cd97504f4607f1c601fb1a986530586ffd979794dfbb194247f1e6456baf",
   "pins" : [
     {
       "identity" : "1024jp.gzipswift",
@@ -519,8 +519,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tuist/swifterpm",
       "state" : {
-        "revision" : "97693fc545e5f75cf3cae8aef7a9210e303b01c7",
-        "version" : "0.7.1"
+        "revision" : "853af08195f54031df9d74d46ca00e1c7050cfcf",
+        "version" : "0.8.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -1779,7 +1779,7 @@ let package = Package(
         .package(id: "swiftlang.swift-docc-plugin", from: "1.4.6"),
         .package(name: "XCResultNIF", path: "server/native/xcresult_nif"),
         .package(id: "stephencelis.SQLite_swift", from: "0.16.0"),
-        .package(url: "https://github.com/tuist/swifterpm", exact: "0.7.1"),
+        .package(url: "https://github.com/tuist/swifterpm", exact: "0.8.1"),
     ],
     targets: targets,
     swiftLanguageModes: [.v5]


### PR DESCRIPTION
## What changed

Updates SwifterPM from 0.7.1 to 0.8.1 and refreshes the root Package.resolved entry for the new tag.

## Why

SwifterPM 0.8.1 includes fixes for resolver progress reporting and binary artifact restoration. This keeps Tuist on the latest SwifterPM release after the 0.8.0 changes for generated package path sanitization, test-only dependency resolution, private registry authentication, and CI cache restoration.

## Impact

Tuist picks up the latest SwifterPM resolver and artifact restoration behavior used by the CLI.

## Validation

- `swift package resolve --replace-scm-with-registry`
- `xcodebuild build -workspace Tuist.xcworkspace -scheme tuist CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""`
