### PR TITLE
fix(server): handle streamed runner log redirects

### DIFF
--- a/server/lib/tuist/runners/workers/fetch_logs_worker.ex
+++ b/server/lib/tuist/runners/workers/fetch_logs_worker.ex
@@ -101,10 +101,10 @@ defmodule Tuist.Runners.Workers.FetchLogsWorker do
 
   defp stream_log(api_url, repository, workflow_job_id, account_id, token) do
     url = "#{api_url}/repos/#{repository}/actions/jobs/#{workflow_job_id}/logs"
-    stream_log_url(url, github_log_headers(token), workflow_job_id, account_id, 0)
+    stream_log_url(url, github_log_headers(token), workflow_job_id, account_id, 0, false)
   end
 
-  defp stream_log_url(url, headers, workflow_job_id, account_id, redirect_count) do
+  defp stream_log_url(url, headers, workflow_job_id, account_id, redirect_count, stream?) do
     initial = new_stream_state(workflow_job_id, account_id)
 
     req_opts =
@@ -116,19 +116,16 @@ defmodule Tuist.Runners.Workers.FetchLogsWorker do
         # archive body streams from that URL.
         redirect: false,
         # Logs come back as plain text, not JSON.
-        decode_body: false,
-        into: fn {:data, chunk}, {req, resp} ->
-          state = Req.Response.get_private(resp, :log_stream, initial)
-          state = consume_chunk(state, chunk)
-          {:cont, {req, Req.Response.put_private(resp, :log_stream, state)}}
-        end
-      ] ++ Retry.retry_options()
+        decode_body: false
+      ]
+      |> with_log_stream(stream?, initial)
+      |> Keyword.merge(Retry.retry_options())
 
-    case Req.get(req_opts) do
+    case fetch_log_response(req_opts) do
       {:ok, %{status: 200} = resp} ->
         state =
           resp
-          |> Req.Response.get_private(:log_stream, initial)
+          |> response_stream_state(initial, stream?)
           |> consume_remainder()
           |> flush_batch()
 
@@ -160,6 +157,33 @@ defmodule Tuist.Runners.Workers.FetchLogsWorker do
     ]
   end
 
+  defp with_log_stream(req_opts, false, _initial), do: req_opts
+
+  defp with_log_stream(req_opts, true, initial) do
+    Keyword.put(req_opts, :into, fn {:data, chunk}, {req, resp} ->
+      state = Req.Response.get_private(resp, :log_stream, initial)
+      state = consume_chunk(state, chunk)
+      {:cont, {req, Req.Response.put_private(resp, :log_stream, state)}}
+    end)
+  end
+
+  defp fetch_log_response(req_opts) do
+    case Req.get(req_opts) do
+      {:ok, {_req, %Req.Response{} = resp}} -> {:ok, resp}
+      {:ok, %Req.Response{} = resp} -> {:ok, resp}
+      {:error, {_req, reason}} -> {:error, reason}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp response_stream_state(resp, initial, true), do: Req.Response.get_private(resp, :log_stream, initial)
+
+  defp response_stream_state(%{body: body}, initial, false) when is_binary(body) do
+    consume_body(body, initial)
+  end
+
+  defp response_stream_state(_resp, initial, false), do: initial
+
   defp follow_log_redirect(_url, _resp, _workflow_job_id, _account_id, redirect_count)
        when redirect_count >= @max_log_redirects do
     {:error, :too_many_log_redirects}
@@ -174,7 +198,7 @@ defmodule Tuist.Runners.Workers.FetchLogsWorker do
           |> URI.merge(URI.parse(location))
           |> URI.to_string()
 
-        stream_log_url(redirected_url, [], workflow_job_id, account_id, redirect_count + 1)
+        stream_log_url(redirected_url, [], workflow_job_id, account_id, redirect_count + 1, true)
 
       [] ->
         {:error, {:unexpected_status, resp.status, resp.body}}
@@ -208,6 +232,16 @@ defmodule Tuist.Runners.Workers.FetchLogsWorker do
     }
 
     if state.batch_count >= @batch_lines, do: flush_batch(state), else: state
+  end
+
+  defp consume_body(body, state) do
+    {rows, state} = parse_chunk(body, state)
+
+    %{
+      state
+      | batch: state.batch ++ rows,
+        batch_count: state.batch_count + length(rows)
+    }
   end
 
   # End-of-stream: parse whatever's left in `:partial` as one final

--- a/server/test/tuist/runners/workers/fetch_logs_worker_test.exs
+++ b/server/test/tuist/runners/workers/fetch_logs_worker_test.exs
@@ -53,16 +53,37 @@ defmodule Tuist.Runners.Workers.FetchLogsWorkerTest do
   # arrives in chunks. Drive the callback synthetically with one or
   # more chunks and return the resulting (mutated) `Req.Response`.
   defp stub_req_stream(chunks) when is_list(chunks) do
-    expect(Req, :get, fn opts ->
-      resp = %Req.Response{status: 200, private: %{}}
+    expect(Req, :get, 2, fn opts ->
+      case Keyword.fetch!(opts, :url) do
+        "https://api.github.com/repos/tuist/tuist/actions/jobs/" <> workflow_job_id_and_suffix ->
+          refute Keyword.has_key?(opts, :into)
+          assert {"Authorization", "Bearer ghs_test_token"} in opts[:headers]
 
-      resp =
-        Enum.reduce(chunks, resp, fn chunk, acc ->
-          {:cont, {_req, acc}} = opts[:into].({:data, chunk}, {opts, acc})
-          acc
-        end)
+          workflow_job_id = String.replace_suffix(workflow_job_id_and_suffix, "/logs", "")
+          signed_url = "https://objects.githubusercontent.com/logs/#{workflow_job_id}.txt"
 
-      {:ok, resp}
+          {:ok,
+           %Req.Response{
+             status: 302,
+             headers: %{"location" => [signed_url]},
+             body: "",
+             private: %{}
+           }}
+
+        "https://objects.githubusercontent.com/logs/" <> _path ->
+          assert Keyword.has_key?(opts, :into)
+          refute Enum.any?(opts[:headers], fn {name, _value} -> String.downcase(name) == "authorization" end)
+
+          resp = %Req.Response{status: 200, private: %{}}
+
+          resp =
+            Enum.reduce(chunks, resp, fn chunk, acc ->
+              {:cont, {_req, acc}} = opts[:into].({:data, chunk}, {opts, acc})
+              acc
+            end)
+
+          {:ok, {opts, resp}}
+      end
     end)
   end
 
@@ -85,10 +106,9 @@ defmodule Tuist.Runners.Workers.FetchLogsWorkerTest do
                  "https://api.github.com/repos/tuist/tuist/actions/jobs/9910001/logs"
 
         assert {"Authorization", "Bearer ghs_test_token"} in opts[:headers]
+        refute Keyword.has_key?(opts, :into)
 
-        resp = %Req.Response{status: 200, private: %{}}
-        {:cont, {_req, resp}} = opts[:into].({:data, body}, {opts, resp})
-        {:ok, resp}
+        {:ok, %Req.Response{status: 200, body: body, private: %{}}}
       end)
 
       assert :ok = FetchLogsWorker.perform(%Oban.Job{args: args(9_910_001, account.id)})
@@ -118,22 +138,25 @@ defmodule Tuist.Runners.Workers.FetchLogsWorkerTest do
           "https://api.github.com/repos/tuist/tuist/actions/jobs/9910005/logs" ->
             assert opts[:redirect] == false
             assert {"Authorization", "Bearer ghs_test_token"} in opts[:headers]
+            refute Keyword.has_key?(opts, :into)
 
             {:ok,
-             %Req.Response{
-               status: 302,
-               headers: %{"location" => [signed_url]},
-               body: "",
-               private: %{}
-             }}
+             {opts,
+              %Req.Response{
+                status: 302,
+                headers: %{"location" => [signed_url]},
+                body: "",
+                private: %{}
+              }}}
 
           ^signed_url ->
             assert opts[:redirect] == false
+            assert Keyword.has_key?(opts, :into)
             refute Enum.any?(opts[:headers], fn {name, _value} -> String.downcase(name) == "authorization" end)
 
             resp = %Req.Response{status: 200, private: %{}}
             {:cont, {_req, resp}} = opts[:into].({:data, body}, {opts, resp})
-            {:ok, resp}
+            {:ok, {opts, resp}}
         end
       end)
 


### PR DESCRIPTION
## What changed

- Avoid installing the streaming `:into` callback on the initial GitHub Actions logs API request.
- Stream only the redirected signed log archive URL, where the actual log body is returned.
- Normalize Req's streamed `{:ok, {%Req.Request{}, %Req.Response{}}}` result shape before status handling.
- Update the worker tests to mimic the real production flow: GitHub API `302` first, signed URL stream second, and tuple-shaped streamed responses.

## Why

#11126 correctly stopped Req from automatically following GitHub's log redirect, which avoided forwarding the GitHub App installation token to the signed archive URL. However, the worker still attached the streaming callback to the initial GitHub API request and still matched only plain `%Req.Response{}` values.

In production Req returned the 302 as `{:ok, {%Req.Request{}, %Req.Response{status: 302}}}`. That prevented the manual redirect branch from matching and produced the `case_clause` Sentry issues. The same tuple shape also tripped Req telemetry, producing the paired `badmap` alerts.

## Impact

Runner job log ingestion should now follow GitHub's signed archive redirect without leaking the installation token and without generating paired Sentry notifications for every completed job log fetch.

## Validation

- `mix test test/tuist/runners/workers/fetch_logs_worker_test.exs` passed: 10 tests, 0 failures.
- `git diff --check` passed.
