### PR TITLE
fix(kura): fallback legacy project auth after inactive introspection

### DIFF
--- a/kura/ops/helm/kura/hooks/tuist.lua
+++ b/kura/ops/helm/kura/hooks/tuist.lua
@@ -323,6 +323,11 @@ local function authenticate_via_introspection_endpoint(token, authorization, tar
       }
     end
 
+    -- Legacy CLI compatibility: older clients can hold a token whose
+    -- embedded grants predate a newly-created project. The server's
+    -- /api/cache/access path still authorizes those project-scoped
+    -- requests, so keep this fallback until those CLI versions are no
+    -- longer supported.
     if target.scope == "project" then
       return authenticate_via_cache_access_endpoint(authorization)
     end

--- a/kura/ops/helm/kura/hooks/tuist.lua
+++ b/kura/ops/helm/kura/hooks/tuist.lua
@@ -296,7 +296,9 @@ local function introspection_client_configured()
   return client_id ~= nil and client_id ~= "" and client_secret ~= nil and client_secret ~= ""
 end
 
-local function authenticate_via_introspection_endpoint(token)
+local authenticate_via_cache_access_endpoint
+
+local function authenticate_via_introspection_endpoint(token, authorization, target)
   local client_id = env_value("KURA_CONTROL_PLANE_CLIENT_ID") or env_value("KURA_EXTENSION_TUIST_INTROSPECT_CLIENT_ID")
   local client_secret = env_value("KURA_CONTROL_PLANE_CLIENT_SECRET") or env_value("KURA_EXTENSION_TUIST_INTROSPECT_CLIENT_SECRET")
   local response = kura.http_json("tuist", {
@@ -321,6 +323,10 @@ local function authenticate_via_introspection_endpoint(token)
       }
     end
 
+    if target.scope == "project" then
+      return authenticate_via_cache_access_endpoint(authorization)
+    end
+
     return {
       deny = { status = 401, message = "Invalid or expired token" },
       ttl_seconds = 3,
@@ -333,7 +339,7 @@ local function authenticate_via_introspection_endpoint(token)
   }
 end
 
-local function authenticate_via_cache_access_endpoint(authorization)
+authenticate_via_cache_access_endpoint = function(authorization)
   local response = kura.http_json("tuist", {
     method = "GET",
     path = "/api/cache/access",
@@ -417,7 +423,7 @@ function authenticate(ctx)
   end
 
   if introspection_client_configured() then
-    return authenticate_via_introspection_endpoint(token)
+    return authenticate_via_introspection_endpoint(token, authorization, target)
   end
 
   if target.scope == "project" then

--- a/kura/src/extension/mod.rs
+++ b/kura/src/extension/mod.rs
@@ -2178,10 +2178,42 @@ end
         }
 
         #[tokio::test]
+        async fn falls_back_to_legacy_cache_access_when_introspection_marks_project_token_inactive()
+        {
+            let calls = Arc::new(Mutex::new(0usize));
+            let calls_for_handler = calls.clone();
+            let base = spawn_tuist_auth_mock(
+                |_headers, _payload| (StatusCode::OK, json!({ "active": false })),
+                move |_| {
+                    *calls_for_handler.lock().unwrap() += 1;
+                    (StatusCode::OK, cache_access_payload(&[], &["acme/ios"]))
+                },
+            )
+            .await;
+            let engine = engine_pointing_at(&base, true).await;
+
+            let mut context = ctx();
+            context.tenant_id = Some("acme".into());
+            context
+                .headers
+                .insert("authorization".into(), "Bearer legacy-token".into());
+            context.namespace_id = Some("ios".into());
+
+            let decision = engine.evaluate_access(&context).await;
+            assert!(matches!(decision, AccessDecision::Allow(Some(_))));
+            assert_eq!(*calls.lock().unwrap(), 1);
+        }
+
+        #[tokio::test]
         async fn denies_when_introspection_returns_inactive() {
             let base = spawn_tuist_auth_mock(
                 |_headers, _payload| (StatusCode::OK, json!({ "active": false })),
-                |_| (StatusCode::OK, cache_access_payload(&[], &[])),
+                |_| {
+                    (
+                        StatusCode::UNAUTHORIZED,
+                        json!({ "message": "Invalid or expired token" }),
+                    )
+                },
             )
             .await;
             let engine = engine_pointing_at(&base, true).await;


### PR DESCRIPTION
> Fixes the Kura compatibility regression where project-scoped cache requests from older CLIs can be rejected after Kura introspection reports the token inactive.

Kura now falls back to the existing `/api/cache/access` authorization path for project-scoped requests when `/oauth2/introspect` returns `active: false`. This matches the legacy cache path that older CLIs already rely on, while keeping account-scoped Kura authorization tied to introspection and preserving 401s when the fallback endpoint also rejects the token.

This fixes the backward-compat acceptance failure where a CLI logs in before creating a throwaway project, receives a token whose embedded cache grants do not include that project, then gets a Kura 401 on the first artifact request.

### How to test locally

- `cd kura && mise exec -- cargo fmt --check`
- `cd kura && mise exec -- cargo test extension::tests::tuist_hook -- --nocapture`

Note: `mise` emitted a postinstall warning about `apple.swift-protobuf` while resolving the repo toolchain, but the Kura test command completed successfully.
