### PR TITLE
feat(server): allow accounts to opt out of Kura cache

### DIFF
--- a/server/lib/tuist/accounts.ex
+++ b/server/lib/tuist/accounts.ex
@@ -26,6 +26,7 @@ defmodule Tuist.Accounts do
   alias Tuist.CommandEvents
   alias Tuist.Ecto.Utils
   alias Tuist.Environment
+  alias Tuist.FeatureFlags
   alias Tuist.Namespace
   alias Tuist.Repo
   alias Tuist.Runners.Profiles, as: RunnerProfiles
@@ -1944,10 +1945,10 @@ defmodule Tuist.Accounts do
   @doc """
   Returns cache endpoint URLs for the given account handle.
 
-  Ready account Kura endpoints are preferred when present. Kura servers mirror
-  their public URL into `account_cache_endpoints` only after the public endpoint
-  is ready, so clients do not need explicit opt-in once an account has an
-  available server.
+  Ready account Kura endpoints are preferred when present unless the account is
+  opted out through `:kura_cache_opt_out`. Kura servers mirror their public URL
+  into `account_cache_endpoints` only after the public endpoint is ready, so
+  clients do not need explicit opt-in once an account has an available server.
 
   When there is no ready account Kura endpoint, custom endpoints are only returned when:
   - The account exists
@@ -1998,7 +1999,13 @@ defmodule Tuist.Accounts do
 
   defp custom_cache_endpoints(_), do: []
 
-  defp kura_cache_endpoints(%Account{} = account), do: list_account_cache_endpoints(account, :kura)
+  defp kura_cache_endpoints(%Account{} = account) do
+    if FeatureFlags.kura_cache_opted_out?(account) do
+      []
+    else
+      list_account_cache_endpoints(account, :kura)
+    end
+  end
 
   defp kura_cache_endpoints(_), do: []
 

--- a/server/lib/tuist/feature_flags.ex
+++ b/server/lib/tuist/feature_flags.ex
@@ -25,6 +25,15 @@ defmodule Tuist.FeatureFlags do
     Environment.dev?() or FunWithFlags.enabled?(:kura, for: account)
   end
 
+  @doc """
+  Whether cache clients should avoid Kura endpoints for the given account.
+  This is intentionally separate from `:kura`, which controls access to the
+  managed Kura UI and provisioning surface.
+  """
+  def kura_cache_opted_out?(account) do
+    FunWithFlags.enabled?(:kura_cache_opt_out, for: account)
+  end
+
   defimpl FunWithFlags.Actor, for: Tuist.Accounts.User do
     def id(%{id: id}) do
       "user:#{id}"

--- a/server/test/tuist/accounts_test.exs
+++ b/server/test/tuist/accounts_test.exs
@@ -21,6 +21,7 @@ defmodule Tuist.AccountsTest do
   alias Tuist.Base64
   alias Tuist.Billing
   alias Tuist.Environment
+  alias Tuist.FeatureFlags
   alias Tuist.Projects
   alias Tuist.Runners.Profiles, as: RunnerProfiles
   alias TuistTestSupport.Fixtures.AccountsFixtures
@@ -4067,6 +4068,54 @@ defmodule Tuist.AccountsTest do
 
       # Then
       assert endpoints == ["https://kura-cache.example.com"]
+    end
+
+    test "returns custom endpoints when account is opted out of Kura cache endpoints" do
+      # Given
+      stub(Environment, :tuist_hosted?, fn -> true end)
+      user = AccountsFixtures.user_fixture()
+      account = Accounts.get_account_from_user(user)
+      BillingFixtures.subscription_fixture(account_id: account.id, plan: :enterprise)
+      {:ok, account} = Accounts.update_account(account, %{custom_cache_endpoints_enabled: true})
+
+      {:ok, _} = Accounts.create_account_cache_endpoint(account, %{url: "https://custom-cache.example.com"})
+
+      {:ok, _} =
+        Accounts.create_account_cache_endpoint(account, %{
+          url: "https://kura-cache.example.com",
+          technology: :kura
+        })
+
+      stub(FeatureFlags, :kura_cache_opted_out?, fn %{id: account_id} -> account_id == account.id end)
+
+      # When
+      endpoints = Accounts.get_cache_endpoints_for_handle(account.name)
+
+      # Then
+      assert endpoints == ["https://custom-cache.example.com"]
+    end
+
+    test "returns default endpoints when account is opted out of Kura and has no custom endpoints" do
+      # Given
+      stub(Environment, :tuist_hosted?, fn -> true end)
+      user = AccountsFixtures.user_fixture()
+      account = Accounts.get_account_from_user(user)
+      default_endpoints = ["https://default.tuist.dev"]
+      stub(Environment, :cache_endpoints, fn -> default_endpoints end)
+
+      {:ok, _} =
+        Accounts.create_account_cache_endpoint(account, %{
+          url: "https://kura-cache.example.com",
+          technology: :kura
+        })
+
+      stub(FeatureFlags, :kura_cache_opted_out?, fn %{id: account_id} -> account_id == account.id end)
+
+      # When
+      endpoints = Accounts.get_cache_endpoints_for_handle(account.name)
+
+      # Then
+      assert endpoints == default_endpoints
     end
 
     test "returns default endpoints when account has no custom endpoints" do


### PR DESCRIPTION
## What changed

- Added a `:kura_cache_opt_out` account-level feature flag helper.
- Updated cache endpoint resolution so opted-out accounts ignore mirrored Kura endpoints and fall back to custom cache endpoints or the default hosted endpoints.
- Added account endpoint tests for both fallback paths.

## Why

Accounts are automatically routed to Kura once a ready Kura server mirrors its public URL into `account_cache_endpoints`. We need an operational escape hatch for accounts that should keep using the existing cache path even if they have a Kura server available.

## Impact

Operators can enable `:kura_cache_opt_out` for a specific account in FunWithFlags. The Kura UI and provisioning flag remains separate, so this only affects which cache endpoint the CLI receives.

## Validation

- `git diff --check -- server/lib/tuist/accounts.ex server/lib/tuist/feature_flags.ex server/test/tuist/accounts_test.exs`
- Started `mix test test/tuist/accounts_test.exs`, but it was interrupted before completion while preparing the PR.
