### PR TITLE
fix(kura): install rustls provider for gRPC TLS

### DIFF
--- a/kura/Cargo.toml
+++ b/kura/Cargo.toml
@@ -41,7 +41,7 @@ time = { version = "0.3.47", default-features = false, features = ["std"] }
 tokio = { version = "1.48.0", features = ["fs", "macros", "rt-multi-thread", "signal", "sync", "time"] }
 tokio-stream = { version = "0.1.17", features = ["net"] }
 tokio-util = { version = "0.7.17", features = ["io"] }
-tonic = { version = "0.14.2", features = ["tls-ring"] }
+tonic = { version = "0.14.2", features = ["tls-aws-lc"] }
 tower = { version = "0.5.2", features = ["util"] }
 tracing = "0.1.41"
 tracing-opentelemetry = "0.32.1"

--- a/kura/src/peer_tls.rs
+++ b/kura/src/peer_tls.rs
@@ -125,7 +125,7 @@ pub async fn build_public_rustls_config(
     Ok(RustlsConfig::from_config(Arc::new(server_config)))
 }
 
-fn install_default_crypto_provider() {
+pub(crate) fn install_default_crypto_provider() {
     let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
 }
 

--- a/kura/src/reapi/mod.rs
+++ b/kura/src/reapi/mod.rs
@@ -49,6 +49,7 @@ use crate::{
     constants::MAX_MODULE_TOTAL_BYTES,
     extension::{AccessDecision, ExtensionContext, Principal},
     io::is_fd_pool_exhausted_error,
+    peer_tls::install_default_crypto_provider,
     replication::replication_targets,
     state::SharedState,
     utils::{action_cache_key, blob_key, temp_file_path},
@@ -176,6 +177,7 @@ where
 }
 
 async fn load_grpc_tls_config(tls: &GrpcTlsConfig) -> Result<ServerTlsConfig, String> {
+    install_default_crypto_provider();
     let cert = tokio::fs::read(&tls.cert_path).await.map_err(|error| {
         format!(
             "failed to read gRPC TLS cert at {}: {error}",


### PR DESCRIPTION
Resolves Sentry issue 126476031.

This fixes a production panic in Kura's gRPC TLS startup. rustls could not infer the process-level crypto provider because the final binary can enable both aws-lc and ring through transitive TLS features. The peer and public TLS paths already installed Kura's aws-lc provider explicitly, but the gRPC TLS path went through tonic before doing that.

Changes:
- Reuse Kura's rustls provider installer before tonic builds the gRPC server TLS config.
- Align Kura's direct tonic TLS feature with `tls-aws-lc`, matching the provider selected by the rest of the Kura TLS code.

### How to test locally

- `cd kura && mise exec -- cargo check`
- `cd kura && mise exec -- cargo test`
- `cd kura && mise exec -- cargo clippy --all-targets -- -D warnings`
