### PR TITLE
fix(server): always enable Kura cross-region replication

### DIFF
--- a/server/lib/tuist/environment.ex
+++ b/server/lib/tuist/environment.ex
@@ -185,12 +185,6 @@ defmodule Tuist.Environment do
     System.get_env("TUIST_KURA_TUIST_BASE_URL")
   end
 
-  def kura_cross_region_replication_enabled? do
-    "TUIST_KURA_CROSS_REGION_REPLICATION_ENABLED"
-    |> System.get_env("0")
-    |> truthy?()
-  end
-
   def prometheus_enabled? do
     prometheus_enabled = System.get_env("TUIST_PROMETHEUS_ENABLED")
 

--- a/server/lib/tuist/kura/regions.ex
+++ b/server/lib/tuist/kura/regions.ex
@@ -143,13 +143,7 @@ defmodule Tuist.Kura.Regions do
     }
   end
 
-  defp cross_region_runtime_config do
-    if Tuist.Environment.kura_cross_region_replication_enabled?() do
-      %{peer_tls_secret_name: "kura-cross-region-peer-tls"}
-    else
-      %{}
-    end
-  end
+  defp cross_region_runtime_config, do: %{peer_tls_secret_name: "kura-cross-region-peer-tls"}
 
   defp local_controller_region do
     suffix = Tuist.Environment.dev_instance_suffix()

--- a/server/test/tuist/kura/regions_test.exs
+++ b/server/test/tuist/kura/regions_test.exs
@@ -24,6 +24,7 @@ defmodule Tuist.Kura.RegionsTest do
         assert config.cluster_id == "#{id}-1"
         assert config.hetzner_location == hetzner_locations[id]
         assert config.storage_class == "hcloud-volumes"
+        assert config.peer_tls_secret_name == "kura-cross-region-peer-tls"
       end
 
       assert Regions.get("us-east").provisioner_config.kubernetes_client == [


### PR DESCRIPTION
## What changed

- Removes `TUIST_KURA_CROSS_REGION_REPLICATION_ENABLED`.
- Always configures managed Kura regions with the shared cross-region peer TLS secret.
- Pins the managed-region configuration in `Tuist.Kura.RegionsTest`.

## Why

The flag was not a useful safe rollout lever anymore. It only gated `peerTLSSecretName`, while the 0.8.0 server still emits the new cross-region CRD fields such as `peerPublicHost` and `globalDiscoveryDNSName`. That means disabling the flag does not make old regional CRDs/controllers compatible with new server manifests.

Cross-region replication is now the intended behavior for managed Kura regions, so the control-plane configuration should be unconditional and regional clusters should be upgraded in lockstep with the 0.8.0 CRD/controller/runtime.

## Rollout notes

Regional clusters still need the 0.8.0 CRDs and Kura controller before new regional KuraInstances can be created. This PR removes the misleading partial opt-out instead of preserving a flag that cannot actually protect old regional controllers.

## Validation

- `mix format lib/tuist/environment.ex lib/tuist/kura/regions.ex test/tuist/environment_test.exs test/tuist/kura/regions_test.exs`
- `mix test test/tuist/kura/regions_test.exs` compiled the app, then failed while preparing the local test database because the local DB schema is not set up: `ERROR 42P01 (undefined_table) relation "users" does not exist`.