### PR TITLE
feat(cli): update SwifterPM for resolver progress and artifact restoration fixes

### DIFF
--- a/cli/cliff.toml
+++ b/cli/cliff.toml
@@ -73,7 +73,7 @@ commit_parsers = [
     { message = "^refactor\\([^)]*\\bcli\\b[^)]*\\)", group = "<!-- 2 -->🚜 Refactor" },
     { message = "^style\\([^)]*\\bcli\\b[^)]*\\)", group = "<!-- 5 -->🎨 Styling" },
     { message = "^test\\([^)]*\\bcli\\b[^)]*\\)", group = "<!-- 6 -->🧪 Testing" },
-    { message = "^chore\\([^)]*\\bcli\\b[^)]*\\)", skip = true },
+    { message = "^chore\\([^)]*\\bcli\\b[^)]*\\)", group = "<!-- 7 -->🧹 Maintenance" },
     { message = "^ci\\([^)]*\\bcli\\b[^)]*\\)", skip = true },
     # Skip any other scoped commits
     { message = "^[a-z]+\\([^)]+\\)", skip = true },


### PR DESCRIPTION
## What changed

Updates `cli/cliff.toml` so `chore(cli)` commits are included in CLI release notes under a Maintenance section instead of being skipped.

## Why

PR #11174 updated SwifterPM for resolver progress and artifact restoration fixes, but it merged as `chore(cli)`. The CLI release detector uses `cli/cliff.toml`, where `chore(cli)` was skipped, so that change did not produce a CLI release. Treating CLI maintenance commits as release entries lets dependency and tooling updates ship without requiring an artificial follow-up change.

## Impact

Merging this PR should make the CLI Release workflow detect a releasable CLI change and publish the next CLI version containing the SwifterPM update. `git cliff` currently computes the next CLI version as `4.198.0` from `4.197.1`.

## Validation

- `git cliff --include-path "cli/**/*" --include-path ".xcode-version-releases" --include-path "Package.swift" --include-path "Package.resolved" --config cli/cliff.toml --repository . --bumped-version -- 4.197.1..HEAD` returned `4.198.0`.

Note: I did not run `mise run release:check` locally because macOS ships Bash 3.2 and the script uses associative arrays that require newer Bash. CI runs the check on Linux.