### PR TITLE
fix(kura): fall back for stale token grants

### DIFF
--- a/kura/ops/helm/kura/hooks/tuist.lua
+++ b/kura/ops/helm/kura/hooks/tuist.lua
@@ -289,6 +289,10 @@ local function grant_allows(grants, scope, action, identifier)
   return false
 end
 
+local function grants_allow_target(grants, target, action)
+  return grants_present(grants) and grant_allows(grants, target.scope, action, target.identifier)
+end
+
 local function introspection_client_configured()
   local client_id = env_value("KURA_CONTROL_PLANE_CLIENT_ID") or env_value("KURA_EXTENSION_TUIST_INTROSPECT_CLIENT_ID")
   local client_secret = env_value("KURA_CONTROL_PLANE_CLIENT_SECRET") or env_value("KURA_EXTENSION_TUIST_INTROSPECT_CLIENT_SECRET")
@@ -298,7 +302,7 @@ end
 
 local authenticate_via_cache_access_endpoint
 
-local function authenticate_via_introspection_endpoint(token, authorization, target)
+local function authenticate_via_introspection_endpoint(token, authorization, target, action)
   local client_id = env_value("KURA_CONTROL_PLANE_CLIENT_ID") or env_value("KURA_EXTENSION_TUIST_INTROSPECT_CLIENT_ID")
   local client_secret = env_value("KURA_CONTROL_PLANE_CLIENT_SECRET") or env_value("KURA_EXTENSION_TUIST_INTROSPECT_CLIENT_SECRET")
   local response = kura.http_json("tuist", {
@@ -313,21 +317,28 @@ local function authenticate_via_introspection_endpoint(token, authorization, tar
 
   if response.status == 200 and response.body then
     if response.body.active == true then
+      local grants = cache_grants(response.body)
+
+      -- Legacy CLI compatibility: older clients can hold a token whose
+      -- embedded grants predate a newly-created project. Introspection can
+      -- also surface grant sets that do not prove the requested project action.
+      -- The server's /api/cache/access path still authorizes those
+      -- project-scoped requests, so keep this fallback until those CLI versions
+      -- are no longer supported.
+      if target.scope == "project" and not grants_allow_target(grants, target, action) then
+        return authenticate_via_cache_access_endpoint(authorization)
+      end
+
       return {
         principal = principal_from_grants(
           response.body.sub,
           response.body.principal_kind,
-          cache_grants(response.body)
+          grants
         ),
         ttl_seconds = 60,
       }
     end
 
-    -- Legacy CLI compatibility: older clients can hold a token whose
-    -- embedded grants predate a newly-created project. The server's
-    -- /api/cache/access path still authorizes those project-scoped
-    -- requests, so keep this fallback until those CLI versions are no
-    -- longer supported.
     if target.scope == "project" then
       return authenticate_via_cache_access_endpoint(authorization)
     end
@@ -404,7 +415,7 @@ function authenticate(ctx)
     local grants = cache_grants(claims)
     local action = request_action(ctx)
 
-    if grants_present(grants) and grant_allows(grants, target.scope, action, target.identifier) then
+    if grants_allow_target(grants, target, action) then
       return {
         principal = principal_from_grants(claims.sub, claims.type, grants),
         ttl_seconds = 60,
@@ -428,7 +439,7 @@ function authenticate(ctx)
   end
 
   if introspection_client_configured() then
-    return authenticate_via_introspection_endpoint(token, authorization, target)
+    return authenticate_via_introspection_endpoint(token, authorization, target, request_action(ctx))
   end
 
   if target.scope == "project" then

--- a/kura/src/extension/mod.rs
+++ b/kura/src/extension/mod.rs
@@ -2000,6 +2000,43 @@ end
         }
 
         #[tokio::test]
+        async fn falls_back_to_legacy_cache_access_when_active_introspection_grants_do_not_cover_project()
+         {
+            let calls = Arc::new(Mutex::new(0usize));
+            let calls_for_handler = calls.clone();
+            let base = spawn_tuist_auth_mock(
+                |_headers, _payload| {
+                    (
+                        StatusCode::OK,
+                        introspection_payload(cache_grants_payload(
+                            &[],
+                            &[],
+                            &["acme/android"],
+                            &["acme/android"],
+                        )),
+                    )
+                },
+                move |_| {
+                    *calls_for_handler.lock().unwrap() += 1;
+                    (StatusCode::OK, cache_access_payload(&[], &["acme/ios"]))
+                },
+            )
+            .await;
+            let engine = engine_pointing_at(&base, true).await;
+
+            let mut context = ctx();
+            context.tenant_id = Some("acme".into());
+            context
+                .headers
+                .insert("authorization".into(), "Bearer opaque-token".into());
+            context.namespace_id = Some("ios".into());
+
+            let decision = engine.evaluate_access(&context).await;
+            assert!(matches!(decision, AccessDecision::Allow(Some(_))));
+            assert_eq!(*calls.lock().unwrap(), 1);
+        }
+
+        #[tokio::test]
         async fn retries_introspection_transport_failures_once() {
             let calls = Arc::new(Mutex::new(0usize));
             let calls_for_handler = calls.clone();


### PR DESCRIPTION
## What changed

- Kura's Tuist auth hook now falls back to `/api/cache/access` for project-scoped requests when OAuth introspection returns an active token but the returned cache grants do not authorize the requested project/action.
- Added Kura coverage for the stale-grants path: active introspection grants for a different project, followed by successful legacy project access fallback.
- Account-scoped requests remain strict and do not use the legacy project fallback.

## Why

Older or stale tokens can miss a newly-created project in their embedded cache grants. Kura already intended to support that by falling back to Tuist's legacy `/api/cache/access` endpoint for project-scoped requests. However, the hook only used that fallback when introspection returned `active: false` or when the introspection client was missing.

If introspection returned `active: true` with grants that still did not prove access to the requested project/action, Kura skipped the legacy fallback and denied the request. This breaks the compatibility path where the server can still authorize the project through `/api/cache/access` even though the token grants are stale or incomplete.

## Root cause

Kura's project-scoped legacy fallback was too narrow. It handled inactive introspection responses and missing introspection-client configuration, but not active introspection responses whose grants did not authorize the requested project/action.

## Impact

Kura now honors the intended legacy project-access fallback when introspection grants are stale or incomplete for the requested project, while keeping account-scoped requests strict so the fallback cannot widen account-level access.

## Validation

- `mise exec -- cargo test falls_back_to_legacy_cache_access_when_active_introspection_grants_do_not_cover_project` from `kura/`
- `mise exec -- cargo test tuist_hook` from `kura/`
