### PR TITLE
fix(linux-runner-image): bake gh CLI into the runner image

### DIFF
--- a/infra/linux-runner-image/Dockerfile
+++ b/infra/linux-runner-image/Dockerfile
@@ -127,9 +127,11 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-# kubectl + helm: GitHub's Ubuntu runner image pre-installs both
-# via `install-kubernetes-tools.sh` so every k8s deploy / sweep
-# workflow in the repo assumes they're on `/usr/local/bin`.
+# kubectl + helm + gh: GitHub's Ubuntu runner image pre-installs all
+# three (kubectl/helm via `install-kubernetes-tools.sh`, gh via
+# `install-github-cli.sh`), so workflow steps assume they're on
+# `/usr/local/bin` — k8s deploy / sweep jobs reach for kubectl/helm,
+# and jobs that dispatch workflows or comment on PRs reach for gh.
 # Mirror that posture here. Versions are Renovate-managed; bumps
 # land as `fix(linux-runner-image): …` and route through the
 # release flow same as `RUNNER_VERSION`.
@@ -137,6 +139,8 @@ RUN apt-get update \
 ARG KUBECTL_VERSION=1.36.1
 # renovate: datasource=github-releases depName=helm/helm
 ARG HELM_VERSION=4.2.0
+# renovate: datasource=github-releases depName=cli/cli
+ARG GH_VERSION=2.93.0
 RUN ARCH="$(dpkg --print-architecture)" \
     && curl -fSL "https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl" \
          -o /usr/local/bin/kubectl \
@@ -148,7 +152,14 @@ RUN ARCH="$(dpkg --print-architecture)" \
     && mv "/tmp/linux-${ARCH}/helm" /usr/local/bin/helm \
     && rm -rf /tmp/helm.tgz "/tmp/linux-${ARCH}" \
     && chmod 0755 /usr/local/bin/helm \
-    && helm version --short
+    && helm version --short \
+    && curl -fSL "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_${ARCH}.tar.gz" \
+         -o /tmp/gh.tgz \
+    && tar -xzf /tmp/gh.tgz -C /tmp \
+    && mv "/tmp/gh_${GH_VERSION}_linux_${ARCH}/bin/gh" /usr/local/bin/gh \
+    && rm -rf /tmp/gh.tgz "/tmp/gh_${GH_VERSION}_linux_${ARCH}" \
+    && chmod 0755 /usr/local/bin/gh \
+    && gh --version
 
 # Docker CLI + buildx + compose plugins. The daemon runs in the
 # `dind` native sidecar (`docker:dind`); this image carries only

--- a/renovate.json
+++ b/renovate.json
@@ -14,7 +14,7 @@
     },
     {
       "customType": "regex",
-      "description": "ARG-based version pins in the Linux runner image (actions/runner, kubectl, helm). Bumps land as `fix(linux-runner-image): …` commits which release.yml's release-linux-runner-image flow picks up to rebuild the image and push a new `linux-runner-image@<semver>` tag; server-deployment.yml resolves that version at deploy time.",
+      "description": "ARG-based version pins in the Linux runner image (actions/runner, kubectl, helm, gh). Bumps land as `fix(linux-runner-image): …` commits which release.yml's release-linux-runner-image flow picks up to rebuild the image and push a new `linux-runner-image@<semver>` tag; server-deployment.yml resolves that version at deploy time.",
       "fileMatch": ["^infra/linux-runner-image/Dockerfile$"],
       "matchStrings": [
         "# renovate: datasource=(?<datasource>[a-z-]+) depName=(?<depName>[^\\s]+)\\s+ARG\\s+[A-Z_]+=(?<currentValue>[^\\s]+)"
@@ -53,10 +53,10 @@
       "automerge": true
     },
     {
-      "description": "Linux-runner-image ARG bumps (actions/runner, kubectl, helm): route through the linux-runner-image release flow.",
+      "description": "Linux-runner-image ARG bumps (actions/runner, kubectl, helm, gh): route through the linux-runner-image release flow.",
       "matchManagers": ["custom.regex"],
       "matchFileNames": ["infra/linux-runner-image/Dockerfile"],
-      "matchPackageNames": ["actions/runner", "kubernetes/kubernetes", "helm/helm"],
+      "matchPackageNames": ["actions/runner", "kubernetes/kubernetes", "helm/helm", "cli/cli"],
       "commitMessagePrefix": "fix(linux-runner-image):",
       "automerge": true
     },


### PR DESCRIPTION
## What

Installs the GitHub CLI (`gh`) into the Linux runner image, alongside the `kubectl` + `helm` tools it already carries, Renovate-managed via the existing `linux-runner-image` ARG manager.

## Why

The image's stated design is to *"close the gap against GitHub's Ubuntu hosted-runner image"* so workflow steps can assume standard tooling is on `/usr/local/bin`. It already bakes in `kubectl` + `helm` with exactly that reasoning. GitHub's hosted image also ships `gh` (`install-github-cli.sh`), and the repo already depends on it on `tuist-linux` jobs:

- `release.yml`'s `trigger-deploy` dispatches the production deployment with `gh workflow run`.
- `preview-deploy.yml` posts GitHub Deployment statuses and PR comments with `gh api` / `gh pr comment`.

Neither installs `gh` (nothing installs it via mise anywhere in the repo), so on the current image they fail with `gh: command not found`. This was caught when `trigger-deploy` died on exit 127, stranding a fleet-image release without a production deploy.

## How

`gh` is pulled from the `cli/cli` release tarball in the same `RUN` layer as `kubectl`/`helm`, ARCH-aware via `dpkg --print-architecture` (matches `gh`'s `linux_amd64`/`linux_arm64` asset names). `GH_VERSION` carries a `# renovate: datasource=github-releases depName=cli/cli` annotation picked up by the existing generic Dockerfile ARG manager, and `cli/cli` is added to the packageRule that routes these bumps through the `fix(linux-runner-image):` commit prefix (required — the release is scope-gated, so a mis-scoped bump would silently never rebuild the image) with automerge.

## Rollout dependency (important)

`linux-runner-image` is itself a fleet image, so a release of it defers the push-deploy to `release.yml`'s `trigger-deploy` — which is the very job that needs `gh`. Merging this PR builds and tags the new image but cannot deploy it through the normal path until a working `gh` is already on the fleet. A one-time manual `workflow_dispatch` of `server-production-deployment.yml` (which goes straight to gate → build → cascade and never touches `trigger-deploy`) breaks the cycle: it rolls the gh-bearing image onto the fleet, after which `trigger-deploy` on `tuist-linux` works for all future cycles.

## Validation

- `gh release view --repo cli/cli` confirms `v2.93.0` and the `gh_<ver>_linux_<arch>.tar.gz` asset names the install relies on.
- `renovate.json` parses (`jq`); the new `GH_VERSION` matches the existing custom-manager regex and the `fix(linux-runner-image):` routing rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)