### PR TITLE
fix(cli): avoid prebuilts for local macro packages

### DIFF
--- a/cli/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
+++ b/cli/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
@@ -595,6 +595,7 @@ public struct PackageInfoMapper: PackageInfoMapping {
         packageType: PackageType
     ) -> Set<String> {
         guard !packageType.packagePrebuilts.isEmpty else { return [] }
+        guard !packageType.isLocalExternal else { return [] }
 
         let targetsByName = Dictionary(uniqueKeysWithValues: packageInfo.targets.map { ($0.name, $0) })
         let allTargetNames = Set(targetsByName.keys)

--- a/cli/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
+++ b/cli/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
@@ -7197,6 +7197,66 @@ struct PackageInfoMapperTests {
 
     @Test(
         .inTemporaryDirectory, .withMockedSwiftVersionProvider
+    ) func map_whenLocalMacroTargetDependsOnPrebuiltProduct_keepsSourceDependency() async throws {
+        let basePath = try #require(FileSystem.temporaryTestDirectory)
+
+        try await fileSystem.makeDirectory(
+            at: basePath.appending(try RelativePath(validating: "Package/Sources/MyMacro"))
+        )
+
+        let project = try await subject.map(
+            package: "Package",
+            basePath: basePath,
+            packageType: .external(
+                origin: .local,
+                artifactPaths: [:],
+                packagePrebuilts: [
+                    "swift-syntax": [
+                        "SwiftSyntax": SwiftPackageManagerPrebuilt(
+                            identity: "swift-syntax",
+                            version: "601.0.0",
+                            libraryName: "SwiftSyntax",
+                            path: basePath.appending(components: ".build", "prebuilts", "swift-syntax"),
+                            checkoutPath: nil,
+                            products: ["SwiftSyntax"],
+                            includePath: nil,
+                            cModules: ["_SwiftSyntaxCShims"]
+                        ),
+                    ],
+                ]
+            ),
+            packageInfos: [
+                "Package": .test(
+                    name: "Package",
+                    products: [],
+                    targets: [
+                        .test(
+                            name: "MyMacro",
+                            type: .macro,
+                            dependencies: [
+                                .product(
+                                    name: "SwiftSyntax",
+                                    package: "swift-syntax",
+                                    moduleAliases: nil,
+                                    condition: nil
+                                ),
+                            ]
+                        ),
+                    ],
+                    platforms: [.macos]
+                ),
+            ]
+        )
+
+        let target = try #require(project?.targets.first(where: { $0.name == "MyMacro" }))
+        #expect(target.dependencies == [.external(name: "SwiftSyntax", condition: nil)])
+        #expect(target.settings?.base["OTHER_SWIFT_FLAGS"] == .array(["$(inherited)"]))
+        #expect(target.settings?.base["LIBRARY_SEARCH_PATHS"] == nil)
+        #expect(target.settings?.base["OTHER_LDFLAGS"] == nil)
+    }
+
+    @Test(
+        .inTemporaryDirectory, .withMockedSwiftVersionProvider
     ) func map_whenTestTargetOnlyDependsOnPluginTarget_keepsPrebuiltProductAsSourceDependency() async throws {
         let basePath = try #require(FileSystem.temporaryTestDirectory)
 


### PR DESCRIPTION
Resolves <https://github.com/tuist/tuist/issues/YYY>

This fixes a regression in the prebuilt SwiftSyntax integration where local macro packages could be forced to import incompatible prebuilt binary modules.

The relevant context is:

- Tuist Community discussion: <https://community.tuist.dev/t/support-for-prebuilt-swift-syntax/634>
- Swift Forums discussion: <https://forums.swift.org/t/preview-swift-syntax-prebuilts-for-macros/80202>

Tuist was reading SwiftPM prebuilt metadata from `.build/workspace-state.json` and applying the resulting module and linker search paths while mapping local external packages. That metadata belongs to the remote package, for example `swift-syntax`, but when applied to user-owned local macro targets it removed SwiftPM's normal ability to select a compatible prebuilt or fall back to building SwiftSyntax from source. The result was failures such as importing `SwiftCompilerPlugin` from an incompatible `.swiftmodule` under `.build/prebuilts`.

This PR keeps local external packages on source dependencies when prebuilt metadata is present. Remote packages can still consume SwiftSyntax prebuilts, while local macro packages build their SwiftSyntax dependencies with the user's active toolchain.

It also adds a regression test covering a local macro target that depends on `SwiftSyntax`, asserting that Tuist keeps the source dependency and does not inject prebuilt search or linker settings.

### How to test locally

- `git diff --check`
- `env -u TUIST_USE_SWIFTERPM tuist install --replace-scm-with-registry`
- `env -u TUIST_USE_SWIFTERPM tuist generate TuistLoaderTests --no-open`
- `xcodebuild test -workspace Tuist.xcworkspace -scheme TuistUnitTests -only-testing TuistLoaderTests/PackageInfoMapperTests/map_whenLocalMacroTargetDependsOnPrebuiltProduct_keepsSourceDependency CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""`
