### PR TITLE
feat(server): add Xcode 26.3 runner profile

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1232,7 +1232,7 @@ jobs:
       # pin doesn't move to a partially-published set.
       fail-fast: true
       matrix:
-        xcode: ["26.5", "26.4.1"]
+        xcode: ["26.5", "26.4.1", "26.3"]
     env:
       MISE_GITHUB_TOKEN: ${{ github.token }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/infra/helm/tuist/values-managed-canary.yaml
+++ b/infra/helm/tuist/values-managed-canary.yaml
@@ -275,6 +275,11 @@ runnersFleet:
         enabled: true
         minWarmPoolFloor: 0
         maxReplicas: 1
+    "26.3":
+      autoscaling:
+        enabled: true
+        minWarmPoolFloor: 0
+        maxReplicas: 1
   # Resolved at deploy time from the latest `runner-image@` git tag.
   runnerImageSemver: ""
   pools: []

--- a/infra/helm/tuist/values-managed-common.yaml
+++ b/infra/helm/tuist/values-managed-common.yaml
@@ -359,3 +359,4 @@ runnersFleet:
     - xcodeVersion: "26.5"
       default: true
     - xcodeVersion: "26.4.1"
+    - xcodeVersion: "26.3"

--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -374,9 +374,9 @@ runnersFleet:
   # so the pools don't double-book.
   #
   # Floors sum to 3 of the 9-slot budget; the remaining 6 slots are
-  # dynamically apportioned by queue depth across the two pools.
+  # dynamically apportioned by queue depth across the pools.
   # The default (26.5) keeps the warm baseline since most traffic
-  # lands there; 26.4.1 sits cold (floor 0) so an unused runner
+  # lands there; older Xcodes sit cold (floor 0) so an unused runner
   # doesn't tie up a host. Revisit once we open the runners to
   # general signups where the pool mix is unpredictable in advance.
   xcodeOverrides:
@@ -386,6 +386,11 @@ runnersFleet:
         minWarmPoolFloor: 3
         maxReplicas: 9
     "26.4.1":
+      autoscaling:
+        enabled: true
+        minWarmPoolFloor: 0
+        maxReplicas: 9
+    "26.3":
       autoscaling:
         enabled: true
         minWarmPoolFloor: 0

--- a/infra/helm/tuist/values-managed-staging.yaml
+++ b/infra/helm/tuist/values-managed-staging.yaml
@@ -354,6 +354,11 @@ runnersFleet:
         enabled: true
         minWarmPoolFloor: 0
         maxReplicas: 1
+    "26.3":
+      autoscaling:
+        enabled: true
+        minWarmPoolFloor: 0
+        maxReplicas: 1
   # Resolved at deploy time from the latest `runner-image@` git tag
   # (server-deployment.yml passes it via --set). The chart template
   # constructs each pool's image as

--- a/infra/helm/tuist/values.yaml
+++ b/infra/helm/tuist/values.yaml
@@ -826,6 +826,7 @@ runnersFleet:
     - xcodeVersion: "26.5"
       default: true
     - xcodeVersion: "26.4.1"
+    - xcodeVersion: "26.3"
   # Per-Xcode fleet tuning, keyed by `xcodeVersion` string. The
   # catalog stays in `xcodeVersions` above so it's shared via the
   # common values file; each managed env layers its overrides here

--- a/infra/macos-xcode-image/AGENTS.md
+++ b/infra/macos-xcode-image/AGENTS.md
@@ -25,6 +25,7 @@ Published to `ghcr.io/tuist/macos-tahoe-xcode:<xcode-version-dashes>`:
 |-----------------|--------------------|--------------------------------------|--------------------------------|
 | 26.5            | `:26-5`            | `/Applications/Xcode_26.5.app`       | _(none — already major-minor)_ |
 | 26.4.1          | `:26-4-1`          | `/Applications/Xcode_26.4.1.app`     | `Xcode_26.4.app` → `Xcode_26.4.1.app` |
+| 26.3            | `:26-3`            | `/Applications/Xcode_26.3.app`       | _(none — already major-minor)_ |
 | 26.0.1          | `:26-0-1`          | `/Applications/Xcode_26.0.1.app`     | `Xcode_26.0.app` → `Xcode_26.0.1.app` |
 
 When `xcode_version` carries a patch component (three-segment
@@ -144,10 +145,11 @@ gets the same toolchain.
 
 ```
 gh workflow run macos-xcode-image.yml -f xcode_version=26.4.1
+gh workflow run macos-xcode-image.yml -f xcode_version=26.3
 gh workflow run macos-xcode-image.yml -f xcode_version=26.5
 ```
 
-Push tag: 26.4.1 → `:26-4-1`, 26.5 → `:26-5`. Each invocation
+Push tag: 26.4.1 → `:26-4-1`, 26.3 → `:26-3`, 26.5 → `:26-5`. Each invocation
 publishes a fresh image — multiple Xcode versions exist in GHCR
 side-by-side under their respective tags, and the customer
 fleet's profile picker chooses between them.
@@ -155,7 +157,7 @@ fleet's profile picker chooses between them.
 The current Tahoe-era profile set is:
 - `:26-5` (latest 26.5.x, no patch released yet)
 - `:26-4-1`
-- `:26-3-y` (latest 26.3 patch — bump the workflow input as Apple ships patches)
+- `:26-3`
 - `:26-2-y`
 - `:26-1-y`
 - `:26-0-y`

--- a/server/config/config.exs
+++ b/server/config/config.exs
@@ -368,7 +368,8 @@ config :tuist, :runner_macos_shapes, [
 # entry should carry `default: true`.
 config :tuist, :runner_macos_xcode_versions, [
   %{xcode_version: "26.5", default: true},
-  %{xcode_version: "26.4.1"}
+  %{xcode_version: "26.4.1"},
+  %{xcode_version: "26.3"}
 ]
 
 config :tuist, :urls,

--- a/server/test/tuist/runners/catalog_test.exs
+++ b/server/test/tuist/runners/catalog_test.exs
@@ -52,6 +52,9 @@ defmodule Tuist.Runners.CatalogTest do
 
       assert Catalog.pool_name(%{platform: :macos, xcode_version: "26.4.1"}) ==
                "#{Tuist.Environment.runners_macos_pool_name_prefix()}-26-4-1"
+
+      assert Catalog.pool_name(%{platform: :macos, xcode_version: "26.3"}) ==
+               "#{Tuist.Environment.runners_macos_pool_name_prefix()}-26-3"
     end
   end
 
@@ -84,14 +87,23 @@ defmodule Tuist.Runners.CatalogTest do
 
   describe "parse_xcode_versions_json/1" do
     test "parses the Helm-injected JSON into the config shape" do
-      json = ~s([{"xcodeVersion":"26.5","default":true},{"xcodeVersion":"26.4.1"}])
+      json =
+        """
+        [
+          {"xcodeVersion":"26.5","default":true},
+          {"xcodeVersion":"26.4.1"},
+          {"xcodeVersion":"26.3"}
+        ]
+        """
 
       assert [
                %{xcode_version: "26.5", default: true},
-               %{xcode_version: "26.4.1"} = second
+               %{xcode_version: "26.4.1"} = second,
+               %{xcode_version: "26.3"} = third
              ] = Catalog.parse_xcode_versions_json(json)
 
       refute Map.has_key?(second, :default)
+      refute Map.has_key?(third, :default)
     end
 
     test "returns :error on malformed JSON" do


### PR DESCRIPTION
Resolves N/A

Adds Xcode 26.3 as an active macOS runner profile across the release matrix, server fallback catalog, and Helm runner pool catalog.

The default remains Xcode 26.5. Xcode 26.3 is configured with a cold warm-pool floor in managed environments, so the profile is available without reserving standing Mac capacity.

The macOS Xcode image runbook now documents the 26.3 base image tag and workflow dispatch command.

### How to test locally

- `git diff --check`
- `helm template tuist infra/helm/tuist -f infra/helm/tuist/values-managed-common.yaml -f infra/helm/tuist/values-managed-staging.yaml -f infra/helm/tuist/values-ci.yaml`
- `helm template tuist infra/helm/tuist -f infra/helm/tuist/values-managed-common.yaml -f infra/helm/tuist/values-managed-canary.yaml -f infra/helm/tuist/values-ci.yaml`
- `helm template tuist infra/helm/tuist -f infra/helm/tuist/values-managed-common.yaml -f infra/helm/tuist/values-managed-production.yaml -f infra/helm/tuist/values-ci.yaml`
- `mix test test/tuist/runners/catalog_test.exs` could not run because this worktree has not installed the server Mix dependencies.
