### PR TITLE
fix(server): normalize "does not contain" filter on generate runs page

### DIFF
--- a/server/lib/tuist_web/live/generate_runs_live.ex
+++ b/server/lib/tuist_web/live/generate_runs_live.ex
@@ -192,7 +192,11 @@ defmodule TuistWeb.GenerateRunsLive do
 
   defp build_flop_filters(filters) do
     {ran_by, filters} = Enum.split_with(filters, &(&1.id == "ran_by"))
-    flop_filters = Filter.Operations.convert_filters_to_flop(filters)
+
+    flop_filters =
+      filters
+      |> Enum.map(&normalize_text_filter_operator/1)
+      |> Filter.Operations.convert_filters_to_flop()
 
     ran_by_flop_filters =
       Enum.flat_map(ran_by, fn
@@ -208,6 +212,10 @@ defmodule TuistWeb.GenerateRunsLive do
 
     flop_filters ++ ran_by_flop_filters
   end
+
+  defp normalize_text_filter_operator(%Filter.Filter{operator: :"!=~"} = filter), do: %{filter | operator: :not_ilike}
+
+  defp normalize_text_filter_operator(filter), do: filter
 
   def sort_icon("desc") do
     "square_rounded_arrow_down"

--- a/server/package.json
+++ b/server/package.json
@@ -23,7 +23,8 @@
       "defu": "6.1.5",
       "follow-redirects": "1.16.0",
       "protobufjs": "7.5.8",
-      "postcss": "8.5.10"
+      "postcss": "8.5.10",
+      "shell-quote": "1.8.4"
     },
     "allowBuilds": {
       "core-js": true,

--- a/server/pnpm-lock.yaml
+++ b/server/pnpm-lock.yaml
@@ -15,6 +15,7 @@ overrides:
   mdast-util-to-hast: 13.2.1
   postcss: 8.5.10
   protobufjs: 7.5.8
+  shell-quote: 1.8.4
   yaml: 2.8.3
 
 time:
@@ -24,6 +25,7 @@ time:
   axios@1.16.0: 2026-05-02T15:04:00.274Z
   fast-uri@3.1.2: 2026-05-05T08:31:31.849Z
   protobufjs@7.5.8: 2026-05-12T09:40:11.300Z
+  shell-quote@1.8.4: 2026-05-22T13:13:48.633Z
 
 importers:
 
@@ -1285,8 +1287,8 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  shell-quote@1.8.3:
-    resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
+  shell-quote@1.8.4:
+    resolution: {integrity: sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==}
     engines: {node: '>= 0.4'}
 
   source-map-js@1.2.1:
@@ -1917,7 +1919,7 @@ snapshots:
       posthog-js: 1.363.2
       pretty-ms: 9.3.0
       radix-vue: 1.9.17(vue@3.5.30(typescript@5.9.3))
-      shell-quote: 1.8.3
+      shell-quote: 1.8.4
       type-fest: 5.4.4
       vite-plugin-monaco-editor: 1.1.0(monaco-editor@0.54.0)
       vue: 3.5.30(typescript@5.9.3)
@@ -3310,7 +3312,7 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shell-quote@1.8.3: {}
+  shell-quote@1.8.4: {}
 
   source-map-js@1.2.1: {}
 

--- a/server/priv/gettext/dashboard_builds.pot
+++ b/server/priv/gettext/dashboard_builds.pot
@@ -69,7 +69,7 @@ msgstr ""
 msgid "Avg. latency writing cache keys"
 msgstr ""
 
-#: lib/tuist_web/live/generate_runs_live.ex:279
+#: lib/tuist_web/live/generate_runs_live.ex:287
 #: lib/tuist_web/live/generate_runs_live.html.heex:84
 #: lib/tuist_web/live/xcode_build_runs_live.ex:241
 #: lib/tuist_web/live/xcode_build_runs_live.html.heex:121
@@ -288,7 +288,7 @@ msgid "Clean"
 msgstr ""
 
 #: lib/tuist_web/live/build_run_live.html.heex:209
-#: lib/tuist_web/live/generate_runs_live.ex:258
+#: lib/tuist_web/live/generate_runs_live.ex:266
 #: lib/tuist_web/live/generate_runs_live.html.heex:58
 #: lib/tuist_web/live/run_detail_live.html.heex:115
 #, elixir-autogen, elixir-format
@@ -452,7 +452,7 @@ msgstr ""
 #: lib/tuist_web/live/build_run_live.ex:1001
 #: lib/tuist_web/live/build_run_live.html.heex:245
 #: lib/tuist_web/live/build_run_live.html.heex:585
-#: lib/tuist_web/live/generate_runs_live.ex:271
+#: lib/tuist_web/live/generate_runs_live.ex:279
 #: lib/tuist_web/live/generate_runs_live.html.heex:81
 #: lib/tuist_web/live/run_detail_live.html.heex:144
 #: lib/tuist_web/live/xcode_build_runs_live.ex:231
@@ -608,7 +608,7 @@ msgid "Hit"
 msgstr ""
 
 #: lib/tuist_web/live/build_run_live.html.heex:861
-#: lib/tuist_web/live/generate_runs_live.ex:287
+#: lib/tuist_web/live/generate_runs_live.ex:295
 #: lib/tuist_web/live/generate_runs_live.html.heex:61
 #, elixir-autogen, elixir-format
 msgid "Hit rate"
@@ -763,7 +763,7 @@ msgstr ""
 #: lib/tuist_web/live/build_run_live.ex:1000
 #: lib/tuist_web/live/build_run_live.html.heex:238
 #: lib/tuist_web/live/build_run_live.html.heex:580
-#: lib/tuist_web/live/generate_runs_live.ex:270
+#: lib/tuist_web/live/generate_runs_live.ex:278
 #: lib/tuist_web/live/generate_runs_live.html.heex:79
 #: lib/tuist_web/live/run_detail_live.html.heex:137
 #: lib/tuist_web/live/xcode_build_runs_live.ex:230
@@ -813,7 +813,7 @@ msgstr ""
 msgid "Ran at"
 msgstr ""
 
-#: lib/tuist_web/live/generate_runs_live.ex:314
+#: lib/tuist_web/live/generate_runs_live.ex:322
 #: lib/tuist_web/live/generate_runs_live.html.heex:87
 #: lib/tuist_web/live/run_detail_live.html.heex:152
 #: lib/tuist_web/live/xcode_build_runs_live.ex:309
@@ -921,7 +921,7 @@ msgstr ""
 #: lib/tuist_web/live/build_run_live.ex:1142
 #: lib/tuist_web/live/build_run_live.html.heex:235
 #: lib/tuist_web/live/build_run_live.html.heex:1543
-#: lib/tuist_web/live/generate_runs_live.ex:266
+#: lib/tuist_web/live/generate_runs_live.ex:274
 #: lib/tuist_web/live/run_detail_live.html.heex:134
 #: lib/tuist_web/live/xcode_build_runs_live.ex:226
 #: lib/tuist_web/live/xcode_builds_live.ex:433
@@ -1382,7 +1382,7 @@ msgstr ""
 msgid "since yesterday"
 msgstr ""
 
-#: lib/tuist_web/live/generate_runs_live.ex:295
+#: lib/tuist_web/live/generate_runs_live.ex:303
 #: lib/tuist_web/live/run_detail_live.html.heex:125
 #, elixir-autogen, elixir-format
 msgid "Cache Endpoint"

--- a/server/test/tuist_web/live/generate_runs_live_test.exs
+++ b/server/test/tuist_web/live/generate_runs_live_test.exs
@@ -137,5 +137,45 @@ defmodule TuistWeb.GenerateRunsLiveTest do
       assert has_element?(lv, "span", "generate UserApp")
       refute has_element?(lv, "span", "generate OtherUserApp")
     end
+
+    test "filters generate runs whose branch does not contain a substring", %{
+      conn: conn,
+      user: user,
+      organization: organization,
+      project: project
+    } do
+      CommandEventsFixtures.command_event_fixture(
+        project_id: project.id,
+        user_id: user.id,
+        name: "generate",
+        command_arguments: ["generate", "QueuedApp"],
+        git_branch: "feature/gh-readonly-queue/main"
+      )
+
+      CommandEventsFixtures.command_event_fixture(
+        project_id: project.id,
+        user_id: user.id,
+        name: "generate",
+        command_arguments: ["generate", "RegularApp"],
+        git_branch: "feature/main"
+      )
+
+      query =
+        URI.encode_query(%{
+          "filter_git_branch_op" => "!=~",
+          "filter_git_branch_val" => "gh-readonly-queue"
+        })
+
+      # Before the fix, the UI-only `!=~` operator reached Flop and raised Flop.InvalidParamsError.
+      {:ok, lv, html} =
+        live(
+          conn,
+          "/#{organization.account.name}/#{project.name}/module-cache/generate-runs?#{query}"
+        )
+
+      assert html =~ "does not contain"
+      assert has_element?(lv, "span", "generate RegularApp")
+      refute has_element?(lv, "span", "generate QueuedApp")
+    end
   end
 end

--- a/server/test/tuist_web/live/generate_runs_live_test.exs
+++ b/server/test/tuist_web/live/generate_runs_live_test.exs
@@ -166,7 +166,6 @@ defmodule TuistWeb.GenerateRunsLiveTest do
           "filter_git_branch_val" => "gh-readonly-queue"
         })
 
-      # Before the fix, the UI-only `!=~` operator reached Flop and raised Flop.InvalidParamsError.
       {:ok, lv, html} =
         live(
           conn,


### PR DESCRIPTION
Fixes [TUIST-TT](https://tuist.sentry.io/issues/126573249/)

## What changed

The Generations dashboard (`TuistWeb.GenerateRunsLive`) crashed with `Flop.InvalidParamsError` whenever a user applied a **"does not contain"** text filter (e.g. on Command or Branch). This normalizes the UI-only `:"!=~"` operator to `:not_ilike` before the filters reach Flop.

## Why it crashed

The Noora filter UI exposes `:"!=~"` ("does not contain") as a valid operator for text filters. Flop, however, only recognizes `=~` — `!=~` is not in its operator set. So the UI-only operator flowed straight through `Filter.Operations.convert_filters_to_flop/1` into `Flop.validate!/2` and raised:

```
Flop.InvalidParamsError: invalid Flop parameters
  at Flop.validate!/2 (lib/flop.ex:1437)
  at Tuist.CommandEvents.list_command_events/2 (lib/tuist/command_events.ex:25)
  at TuistWeb.GenerateRunsLive.assign_generate_runs/2 (lib/tuist_web/live/generate_runs_live.ex:129)
  at TuistWeb.GenerateRunsLive.handle_params/3 (lib/tuist_web/live/generate_runs_live.ex:62)
```

## Root cause and why this fix

The sibling pages already handle this: `test_runs_live.ex` and `gradle_build_runs_live.ex` both normalize `:"!=~"` to Flop's `:not_ilike` before building Flop filters. `generate_runs_live.ex` was the only one missing that normalization step. The fix mirrors the existing `normalize_text_filter_operator/1` pattern from `test_runs_live.ex` rather than inventing a new mechanism, keeping operator handling consistent across the three pages.

## User impact

Before: applying a "does not contain" filter on the Generations dashboard returned a 500 / crashed the LiveView. After: the filter works and excludes matching runs.

## Validation

Written test-first (the new test reproduced the exact production stacktrace before the fix):

- Added `test/tuist_web/live/generate_runs_live_test.exs` — "filters generate runs whose branch does not contain a substring" — applies `filter_git_branch_op=!=~` and asserts only the non-matching run is shown.
- `mix test test/tuist_web/live/generate_runs_live_test.exs` → 4 tests, 0 failures.
- `mix credo lib/tuist_web/live/generate_runs_live.ex` → no issues.
- `mix format` applied.

### How to test locally

1. Open a project's `module-cache/generate-runs` dashboard with some generate runs.
2. Add a text filter (Command or Branch) and set its operator to "does not contain".
3. Before this change the page errored; now it filters out matching runs.