### PR TITLE
fix(cli): pin release tags to the built commit's SHA

### DIFF
--- a/.github/workflows/app-release.yml
+++ b/.github/workflows/app-release.yml
@@ -282,6 +282,8 @@ jobs:
         with:
           draft: false
           repository: tuist/tuist
+          # Pin the tag to the commit this run built (see cli-release.yml).
+          target_commitish: ${{ github.sha }}
           name: App ${{ needs.check-releases.outputs.app-next-version-number }}
           tag_name: ${{ needs.check-releases.outputs.app-next-version }}
           body: ${{ needs.release-app.outputs.release-notes }}

--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -221,6 +221,11 @@ jobs:
         with:
           draft: false
           repository: tuist/tuist
+          # Pin the tag to the commit this run built, not main's HEAD. Without
+          # this, action-gh-release defaults target_commitish to the default
+          # branch, so a push landing during the run drifts the tag onto a
+          # newer commit than the one the release notes and binaries describe.
+          target_commitish: ${{ github.sha }}
           name: CLI ${{ needs.check-releases.outputs.cli-next-version-number }}
           tag_name: ${{ needs.check-releases.outputs.cli-next-version }}
           body: ${{ needs.release-cli.outputs.release-notes }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1738,6 +1738,11 @@ jobs:
         with:
           draft: false
           repository: tuist/tuist
+          # Pin every component tag to the commit this run built, not main's
+          # HEAD. Without this, action-gh-release defaults target_commitish to
+          # the default branch, so a push landing during the run drifts the tag
+          # onto a newer commit than the release notes and artifacts describe.
+          target_commitish: ${{ github.sha }}
           name: Server ${{ needs.check-releases.outputs.server-next-version-number }}
           tag_name: ${{ needs.check-releases.outputs.server-next-version }}
           body: |
@@ -1751,6 +1756,7 @@ jobs:
         with:
           draft: false
           repository: tuist/tuist
+          target_commitish: ${{ github.sha }}
           name: Cache ${{ needs.check-releases.outputs.cache-next-version-number }}
           tag_name: ${{ needs.check-releases.outputs.cache-next-version }}
           body: |
@@ -1764,6 +1770,7 @@ jobs:
         with:
           draft: false
           repository: tuist/tuist
+          target_commitish: ${{ github.sha }}
           name: Skills ${{ needs.check-releases.outputs.skills-next-version-number }}
           tag_name: ${{ needs.check-releases.outputs.skills-next-version }}
           body: |
@@ -1777,6 +1784,7 @@ jobs:
         with:
           draft: false
           repository: tuist/tuist
+          target_commitish: ${{ github.sha }}
           name: Noora ${{ needs.check-releases.outputs.noora-next-version-number }}
           tag_name: ${{ needs.check-releases.outputs.noora-next-version }}
           body: |
@@ -1790,6 +1798,7 @@ jobs:
         with:
           draft: false
           repository: tuist/tuist
+          target_commitish: ${{ github.sha }}
           name: Helm Chart ${{ needs.check-releases.outputs.helm-next-version-number }}
           tag_name: ${{ needs.check-releases.outputs.helm-next-version }}
           body: |
@@ -1805,6 +1814,7 @@ jobs:
         with:
           draft: false
           repository: tuist/tuist
+          target_commitish: ${{ github.sha }}
           name: CAPI Scaleway ${{ needs.check-releases.outputs.capi-scaleway-next-version-number }}
           tag_name: ${{ needs.check-releases.outputs.capi-scaleway-next-version }}
           body: |
@@ -1818,6 +1828,7 @@ jobs:
         with:
           draft: false
           repository: tuist/tuist
+          target_commitish: ${{ github.sha }}
           name: Runners Controller ${{ needs.check-releases.outputs.runners-controller-next-version-number }}
           tag_name: ${{ needs.check-releases.outputs.runners-controller-next-version }}
           body: |
@@ -1831,6 +1842,7 @@ jobs:
         with:
           draft: false
           repository: tuist/tuist
+          target_commitish: ${{ github.sha }}
           name: Hetzner Robot Controller ${{ needs.check-releases.outputs.hetzner-robot-controller-next-version-number }}
           tag_name: ${{ needs.check-releases.outputs.hetzner-robot-controller-next-version }}
           body: |
@@ -1844,6 +1856,7 @@ jobs:
         with:
           draft: false
           repository: tuist/tuist
+          target_commitish: ${{ github.sha }}
           name: xcresult Processor ${{ needs.check-releases.outputs.xcresult-processor-image-next-version-number }}
           tag_name: ${{ needs.check-releases.outputs.xcresult-processor-image-next-version }}
           body: |
@@ -1857,6 +1870,7 @@ jobs:
         with:
           draft: false
           repository: tuist/tuist
+          target_commitish: ${{ github.sha }}
           name: Runner Image ${{ needs.check-releases.outputs.runner-image-next-version-number }}
           tag_name: ${{ needs.check-releases.outputs.runner-image-next-version }}
           body: |
@@ -1871,6 +1885,7 @@ jobs:
         with:
           draft: false
           repository: tuist/tuist
+          target_commitish: ${{ github.sha }}
           name: Linux Runner Image ${{ needs.check-releases.outputs.linux-runner-image-next-version-number }}
           tag_name: ${{ needs.check-releases.outputs.linux-runner-image-next-version }}
           body: |
@@ -1896,6 +1911,7 @@ jobs:
         with:
           draft: false
           repository: tuist/tuist
+          target_commitish: ${{ github.sha }}
           name: Kura ${{ needs.check-releases.outputs.kura-next-version-number }}
           tag_name: ${{ needs.check-releases.outputs.kura-next-version }}
           body: |

--- a/cli/Sources/TuistConstants/Constants.swift
+++ b/cli/Sources/TuistConstants/Constants.swift
@@ -1,8 +1,8 @@
 import Foundation
 
 public enum Constants {
-    // Overridden at build time by the release pipeline (cli-release.yml); the value committed here lags real releases.
-    @TaskLocal public static var version: String! = "4.197.1"
+    // Sentinel for local builds; the release pipeline (cli-release.yml) replaces it with the real version at build time.
+    @TaskLocal public static var version: String! = "x.y.z"
     public static let versionFileName = ".tuist-version"
     public static let binFolderName = ".tuist-bin"
     public static let binName = "tuist"

--- a/cli/Sources/TuistConstants/Constants.swift
+++ b/cli/Sources/TuistConstants/Constants.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 public enum Constants {
+    // Overridden at build time by the release pipeline (cli-release.yml); the value committed here lags real releases.
     @TaskLocal public static var version: String! = "4.197.1"
     public static let versionFileName = ".tuist-version"
     public static let binFolderName = ".tuist-bin"


### PR DESCRIPTION
## What

Two related fixes to the release pipeline, plus the `cli/**` touch that lets this PR cut a fresh CLI release on merge.

### 1. Pin release tags to the built commit

Pins `target_commitish: ${{ github.sha }}` on every `softprops/action-gh-release` step that creates a component tag through the GitHub API — across `cli-release.yml`, `app-release.yml`, and the 12 published components in `release.yml` (server, cache, skills, noora, helm, capi-scaleway, runners-controller, hetzner-robot-controller, xcresult-processor-image, runner-image, linux-runner-image, kura). Gradle and the fleet-image tags already pre-create their tags locally via `git tag` (so they're pinned), and the app's `appcast` pointer tag is intentionally left unpinned.

### 2. Reset the committed CLI version to the `x.y.z` sentinel

`Constants.version` was committed as `4.197.1` — stale residue from the old release flow that committed version bumps back to `main`. Since #11160 stopped committing to `main`, that value just freezes at whatever shipped last and silently lags real releases. It's reset to `x.y.z`, the sentinel `InitCommandService` already checks for. This is also the deliberate `cli/**` touch that makes merging this PR fire `cli-release.yml`, cutting `4.198.2` from the latest `main`.

## Why

### Tag pinning

Release tags were created without a `target_commitish`, so the GitHub API defaulted it to the repository's default branch. When another push lands on `main` during a release run's window between version computation and tag creation, GitHub resolves the default branch to its newer HEAD and stamps the tag there instead of on the commit the run actually built.

Concretely (the CLI 4.198.1 incident):

- Run for [#11140](https://github.com/tuist/tuist/pull/11140) (`0058746d701`) computed and built CLI `4.198.1`.
- While it was running, [#11191](https://github.com/tuist/tuist/pull/11191) (`45be052b221`) landed on `main`.
- The publish step created the `4.198.1` release with `target_commitish: main`, which GitHub resolved to the new HEAD — so the lightweight tag `4.198.1` was stamped onto `45be052b221` instead of `0058746d701`.

Result: the `4.198.1` release notes and binaries describe #11140, but the tag points at #11191. Worse, the next run (triggered by #11191) found the latest CLI tag already sitting on its own commit, computed an empty `4.198.1..HEAD` range, and **skipped** — which is why #11191 never produced a release.

### Version sentinel

With a real-looking stale version committed, the `Constants.version == "x.y.z"` branch in `InitCommandService` never matched, so `tuist init` from a source build pinned mise to the stale version instead of falling back to `tuist@latest`. Resetting to the sentinel restores that intended behavior and makes source/dev builds report a clearly-unreleased version. Released binaries are unaffected — the pipeline's `sed` still replaces the value with the real version at build time (verified the regex matches `x.y.z`).

## Impact

- Future release tags agree with their notes and artifacts. For a `push` event `github.sha` is the triggering commit, which each release job already checks out, builds, and derives its release notes from.
- Merging this PR fires `cli-release.yml` and cuts `4.198.2` from the current `main` HEAD, so #11191's code (and everything else since `4.198.1`) ships in that release.
- `tuist init` from a source build pins mise to `latest` again.

## Validation

- All 14 tag-pin insertions verified to sit inside the correct `action-gh-release` step (directly above each component's `name:`), with `appcast` confirmed unpinned. `actionlint` parses all three workflows; the only findings are pre-existing (custom self-hosted runner labels, shellcheck style hints).
- Confirmed `x.y.z` is the single canonical sentinel (one reference, in `InitCommandService`), the release `sed` still matches it, and the `InitCommandService` tests assert only `contains("mise")` (not the version arg), so they're unaffected.

## Note on the 4.198.1 tag

The mis-placed `4.198.1` tag is being left as-is. `4.198.2` (cut when this PR merges) is built from the latest `main` and contains #11191's fix, so the fix reaches users regardless. The only cosmetic residue is that #11191 has no dedicated changelog line and the `4.198.1` tag points one commit further than its notes — neither worth a public-tag rewrite.