### PR TITLE
fix(cli): de-duplicate buildable-folder references and add cross-target membership

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -664,7 +664,7 @@
       "kind" : "registry",
       "location" : "",
       "state" : {
-        "version" : "9.9.0"
+        "version" : "9.13.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -1728,7 +1728,7 @@ let package = Package(
         .package(id: "kishikawakatsumi.KeychainAccess", from: "4.2.2"),
         .package(id: "stencilproject.Stencil", exact: "0.15.1"),
         .package(id: "tuist.GraphViz", exact: "0.4.2"),
-        .package(id: "tuist.XcodeProj", .upToNextMajor(from: "9.9.0")),
+        .package(id: "tuist.XcodeProj", .upToNextMajor(from: "9.13.0")),
         .package(id: "cpisciotta.xcbeautify", from: "3.1.0"),
         .package(id: "krzysztofzablocki.Difference", from: "1.0.2"),
         .package(id: "kolos65.Mockable", .upToNextMajor(from: "0.6.1")),

--- a/cli/Sources/ProjectDescription/BuildableFolderException.swift
+++ b/cli/Sources/ProjectDescription/BuildableFolderException.swift
@@ -16,31 +16,39 @@ public struct BuildableFolderException: Sendable, Codable, Equatable, Hashable {
     /// Use this to restrict specific files to certain platforms (e.g., iOS-only or tvOS-only resources).
     public var platformFilters: [String: Set<PlatformFilter>]
 
-    /// Creates a new exception for a buildable folder.
-    /// - Parameters:
-    ///   - exclued: An array of absolute paths to files that should be excluded from the buildable folder.
-    ///   - compilerFlags: A dictionary mapping absolute file paths to specific compiler flags to apply to those files.
-    ///   - publicHeaders: A list of relative paths to headers that should be public (by dkefault they have project access level)
-    ///   - privateHeaders: A list of relative paths to headers that should be private (by default they have project access level)
-    ///   - platformFilters: A dictionary mapping relative file paths to platform filters.
+    /// The name of a target, other than the folder's owning target, that the `included` files should be members of.
+    /// When `nil` (the default) the exception applies to the folder's owning target and `excluded` files are removed
+    /// from it. When set, the `included` files are added to that target instead.
+    public var target: String?
+
+    /// A list of relative paths, within the buildable folder, of files to add to `target`. Only meaningful when
+    /// `target` is set.
+    public var included: [String]
+
     private init(
         excluded: [String],
         compilerFlags: [String: String],
         publicHeaders: [String],
         privateHeaders: [String],
-        platformFilters: [String: Set<PlatformFilter>]
+        platformFilters: [String: Set<PlatformFilter>],
+        target: String?,
+        included: [String]
     ) {
         self.excluded = excluded
         self.compilerFlags = compilerFlags
         self.publicHeaders = publicHeaders
         self.privateHeaders = privateHeaders
         self.platformFilters = platformFilters
+        self.target = target
+        self.included = included
     }
 
     /// Creates a new BuildableFolderException using the given excluded files and compiler flags.
     /// - Parameters:
     ///   - excluded: An array of absolute paths to files that should be excluded from the buildable folder.
     ///   - compilerFlags: A dictionary mapping absolute file paths to specific compiler flags to apply to those files.
+    ///   - publicHeaders: A list of relative paths to headers that should be public (by default they have project access level)
+    ///   - privateHeaders: A list of relative paths to headers that should be private (by default they have project access level)
     ///   - platformFilters: A dictionary mapping relative file paths within the buildable folder to platform filters.
     public static func exception(
         excluded: [String] = [],
@@ -54,7 +62,37 @@ public struct BuildableFolderException: Sendable, Codable, Equatable, Hashable {
             compilerFlags: compilerFlags,
             publicHeaders: publicHeaders,
             privateHeaders: privateHeaders,
-            platformFilters: platformFilters
+            platformFilters: platformFilters,
+            target: nil,
+            included: []
+        )
+    }
+
+    /// Creates a new BuildableFolderException that adds files living inside this buildable folder to another target.
+    ///
+    /// Xcode 16 lets a file inside one target's buildable folder be a member of a different target. Use this to express
+    /// "also compile/copy these files into `target`" without an explicit `sources:`/`resources:` glob, which would
+    /// otherwise materialise a duplicate flat file reference at the project root.
+    ///
+    /// - Parameters:
+    ///   - target: The name of the target the `included` files should be added to.
+    ///   - included: Relative paths, within the buildable folder, of the files to add to `target`.
+    ///   - compilerFlags: A dictionary mapping relative file paths within the buildable folder to compiler flags.
+    ///   - platformFilters: A dictionary mapping relative file paths within the buildable folder to platform filters.
+    public static func exception(
+        target: String,
+        included: [String] = [],
+        compilerFlags: [String: String] = [:],
+        platformFilters: [String: Set<PlatformFilter>] = [:]
+    ) -> BuildableFolderException {
+        BuildableFolderException(
+            excluded: [],
+            compilerFlags: compilerFlags,
+            publicHeaders: [],
+            privateHeaders: [],
+            platformFilters: platformFilters,
+            target: target,
+            included: included
         )
     }
 }

--- a/cli/Sources/TuistGenerator/Generator/ConfigGenerator.swift
+++ b/cli/Sources/TuistGenerator/Generator/ConfigGenerator.swift
@@ -149,8 +149,7 @@ struct ConfigGenerator: ConfigGenerating {
         if let variantConfig = configuration {
             settingsHelper.extend(buildSettings: &settings, with: variantConfig.settings)
             if let xcconfig = variantConfig.xcconfig {
-                let fileReference = fileElements.file(path: xcconfig)
-                variantBuildConfiguration.baseConfiguration = fileReference
+                setBaseConfiguration(variantBuildConfiguration, xcconfig: xcconfig, fileElements: fileElements)
             }
         }
         variantBuildConfiguration.buildSettings = settings.toBuildSettings()
@@ -220,8 +219,7 @@ struct ConfigGenerator: ConfigGenerating {
             buildSettings: [:]
         )
         if let variantConfig = configuration, let xcconfig = variantConfig.xcconfig {
-            let fileReference = fileElements.file(path: xcconfig)
-            variantBuildConfiguration.baseConfiguration = fileReference
+            setBaseConfiguration(variantBuildConfiguration, xcconfig: xcconfig, fileElements: fileElements)
         }
 
         variantBuildConfiguration.buildSettings = settings.toBuildSettings()
@@ -252,13 +250,28 @@ struct ConfigGenerator: ConfigGenerating {
             buildSettings: [:]
         )
         if let variantConfig = configuration, let xcconfig = variantConfig.xcconfig {
-            let fileReference = fileElements.file(path: xcconfig)
-            variantBuildConfiguration.baseConfiguration = fileReference
+            setBaseConfiguration(variantBuildConfiguration, xcconfig: xcconfig, fileElements: fileElements)
         }
 
         variantBuildConfiguration.buildSettings = settings.toBuildSettings()
         pbxproj.add(object: variantBuildConfiguration)
         configurationList.buildConfigurations.append(variantBuildConfiguration)
+    }
+
+    /// Points a build configuration at its base xcconfig. When the xcconfig lives inside a buildable folder (Xcode 16+
+    /// synchronized root group), it is referenced through `baseConfigurationReferenceAnchor` + a relative path so no
+    /// duplicate flat file reference is created at the project root. Otherwise it falls back to a plain file reference.
+    private func setBaseConfiguration(
+        _ buildConfiguration: XCBuildConfiguration,
+        xcconfig: AbsolutePath,
+        fileElements: ProjectFileElements
+    ) {
+        if let synchronized = fileElements.synchronizedRootGroup(containing: xcconfig) {
+            buildConfiguration.baseConfigurationAnchor = synchronized.group
+            buildConfiguration.baseConfigurationReferenceRelativePath = synchronized.relativePath
+        } else {
+            buildConfiguration.baseConfiguration = fileElements.file(path: xcconfig)
+        }
     }
 
     private func updateTargetDerived(

--- a/cli/Sources/TuistGenerator/Generator/ProjectDescriptorGenerator.swift
+++ b/cli/Sources/TuistGenerator/Generator/ProjectDescriptorGenerator.swift
@@ -262,6 +262,14 @@ struct ProjectDescriptorGenerator: ProjectDescriptorGenerating {
             graphTraverser: graphTraverser
         )
         Logger.current.debug("Finished generating target dependencies for project \(project.name)")
+
+        // Additive cross-target buildable-folder memberships need every PBXTarget to exist, so they run after the loop.
+        try targetGenerator.generateBuildableFolderForeignExceptions(
+            targets: Array(project.targets.values),
+            nativeTargets: nativeTargets,
+            fileElements: fileElements,
+            pbxproj: pbxproj
+        )
         return (nativeTargets, sideEffects)
     }
 

--- a/cli/Sources/TuistGenerator/Generator/ProjectFileElements.swift
+++ b/cli/Sources/TuistGenerator/Generator/ProjectFileElements.swift
@@ -144,7 +144,11 @@ class ProjectFileElements {
         var fileElements = Set<GroupFileElement>()
 
         // Config files
+        // xcconfigs inside a buildable folder are referenced through an anchored baseConfigurationReference, so a flat
+        // file reference would duplicate them at the project root (see `targetFiles`).
+        let buildableFolderPaths = project.targets.values.flatMap { $0.buildableFolders.map(\.path) }
         let configFiles = project.settings.configurations.values.compactMap { $0?.xcconfig }
+            .filter { xcconfig in !buildableFolderPaths.contains { xcconfig.isDescendant(of: $0) } }
 
         fileElements.formUnion(
             configFiles.map {
@@ -212,16 +216,21 @@ class ProjectFileElements {
         }
 
         // Support files
-        if let infoPlist = target.infoPlist, let path = infoPlist.path {
+        // Info.plist, entitlements and xcconfig paths are surfaced to Xcode through build settings
+        // (INFOPLIST_FILE, CODE_SIGN_ENTITLEMENTS) or an anchored baseConfigurationReference, so when they live inside
+        // a buildable folder they are already visible nested in the synchronized group. Adding a flat file reference
+        // here would duplicate them at the project root.
+        if let infoPlist = target.infoPlist, let path = infoPlist.path, !isInsideBuildableFolder(path, of: target) {
             files.insert(path)
         }
 
-        if let entitlements = target.entitlements, let path = entitlements.path {
+        if let entitlements = target.entitlements, let path = entitlements.path, !isInsideBuildableFolder(path, of: target) {
             files.insert(path)
         }
 
         // Config files
         target.settings?.configurations.xcconfigs().forEach { configFilePath in
+            guard !isInsideBuildableFolder(configFilePath, of: target) else { return }
             files.insert(configFilePath)
         }
 
@@ -843,6 +852,29 @@ class ProjectFileElements {
 
     func file(path: AbsolutePath) -> PBXFileReference? {
         elements[path] as? PBXFileReference ?? folderReferences[path]
+    }
+
+    /// Returns the synchronized root group (buildable folder) that contains the given path, together with the path of
+    /// the file relative to that group. When the path is contained in nested buildable folders, the most specific
+    /// (deepest) one is returned. Used to reference xcconfig files through an anchored `baseConfigurationReference`
+    /// instead of a flat file reference.
+    func synchronizedRootGroup(containing path: AbsolutePath)
+        -> (group: PBXFileSystemSynchronizedRootGroup, relativePath: String)?
+    {
+        var match: (folderPath: AbsolutePath, group: PBXFileSystemSynchronizedRootGroup)?
+        for (folderPath, element) in elements {
+            guard let group = element as? PBXFileSystemSynchronizedRootGroup,
+                  path.isDescendant(of: folderPath) else { continue }
+            if match == nil || folderPath.pathString.count > match!.folderPath.pathString.count {
+                match = (folderPath, group)
+            }
+        }
+        guard let match else { return nil }
+        return (match.group, path.relative(to: match.folderPath).pathString)
+    }
+
+    private func isInsideBuildableFolder(_ path: AbsolutePath, of target: Target) -> Bool {
+        target.buildableFolders.contains { path.isDescendant(of: $0.path) }
     }
 
     func isLocalized(path: AbsolutePath) -> Bool {

--- a/cli/Sources/TuistGenerator/Generator/TargetGenerator.swift
+++ b/cli/Sources/TuistGenerator/Generator/TargetGenerator.swift
@@ -25,6 +25,13 @@ protocol TargetGenerating {
         nativeTargets: [String: PBXTarget],
         graphTraverser: GraphTraversing
     ) throws
+
+    func generateBuildableFolderForeignExceptions(
+        targets: [Target],
+        nativeTargets: [String: PBXTarget],
+        fileElements: ProjectFileElements,
+        pbxproj: PBXProj
+    ) throws
 }
 
 struct TargetGenerator: TargetGenerating {
@@ -193,7 +200,10 @@ struct TargetGenerator: TargetGenerating {
 
             var explicitFolders: [String] = []
 
-            for exception in buildableFolder.exceptions {
+            // Exceptions addressed to a foreign target (additive cross-target membership) are handled after every
+            // target has been generated, in `generateBuildableFolderForeignExceptions`, where the foreign PBXTarget
+            // exists.
+            for exception in buildableFolder.exceptions where exception.target == nil {
                 let membershipExceptions = exception.excluded.compactMap {
                     $0.isDescendant(of: buildableFolder.path) ? $0.relative(to: buildableFolder.path).pathString : nil
                 }
@@ -260,6 +270,66 @@ struct TargetGenerator: TargetGenerating {
 
             if !explicitFolders.isEmpty {
                 synchronizedGroup.explicitFolders = explicitFolders
+            }
+        }
+    }
+
+    func generateBuildableFolderForeignExceptions(
+        targets: [Target],
+        nativeTargets: [String: PBXTarget],
+        fileElements: ProjectFileElements,
+        pbxproj: PBXProj
+    ) throws {
+        for target in targets {
+            for buildableFolder in target.buildableFolders {
+                guard let fileElement = fileElements.elements[buildableFolder.path],
+                      let synchronizedGroup = fileElement as? PBXFileSystemSynchronizedRootGroup else { continue }
+
+                for exception in buildableFolder.exceptions {
+                    guard let foreignTargetName = exception.target else { continue }
+                    guard let foreignTarget = nativeTargets[foreignTargetName] else {
+                        Logger.current
+                            .warning(
+                                "Target '\(target.name)' references unknown target '\(foreignTargetName)' in a buildable folder exception. Skipping."
+                            )
+                        continue
+                    }
+
+                    let membershipExceptions = exception.included.compactMap {
+                        $0.isDescendant(of: buildableFolder.path) ? $0.relative(to: buildableFolder.path).pathString : nil
+                    }
+
+                    let additionalCompilerFlagsByRelativePath = Dictionary(
+                        uniqueKeysWithValues: exception.compilerFlags.compactMap { path, compilerFlags -> (String, String)? in
+                            guard path.isDescendant(of: buildableFolder.path) else { return nil }
+                            return (path.relative(to: buildableFolder.path).pathString, compilerFlags)
+                        }
+                    )
+
+                    let platformFiltersByRelativePath = Dictionary(
+                        uniqueKeysWithValues: exception.platformFilters.compactMap { path, condition -> (String, [String])? in
+                            guard path.isDescendant(of: buildableFolder.path) else { return nil }
+                            return (path.relative(to: buildableFolder.path).pathString, condition.platformFilters.xcodeprojValue)
+                        }
+                    )
+
+                    guard !membershipExceptions.isEmpty || !additionalCompilerFlagsByRelativePath.isEmpty else { continue }
+
+                    let exceptionSet = PBXFileSystemSynchronizedBuildFileExceptionSet(
+                        target: foreignTarget,
+                        membershipExceptions: membershipExceptions,
+                        publicHeaders: [],
+                        privateHeaders: [],
+                        additionalCompilerFlagsByRelativePath: additionalCompilerFlagsByRelativePath,
+                        attributesByRelativePath: nil,
+                        platformFiltersByRelativePath: platformFiltersByRelativePath.isEmpty ? nil : platformFiltersByRelativePath
+                    )
+                    pbxproj.add(object: exceptionSet)
+                    if synchronizedGroup.exceptions == nil {
+                        synchronizedGroup.exceptions = []
+                    }
+                    synchronizedGroup.exceptions?.append(exceptionSet)
+                }
             }
         }
     }

--- a/cli/Sources/TuistHasher/TargetContentHasher.swift
+++ b/cli/Sources/TuistHasher/TargetContentHasher.swift
@@ -259,9 +259,49 @@ public struct TargetContentHasher: TargetContentHashing {
                 }.sorted()
             }
 
-        let buildableFoldersHash: String? = buildableFolderHashes.isEmpty
+        // Files contributed to this target from sibling targets' buildable folders via additive cross-target
+        // membership (`.exception(target:included:)`). Without folding these in, adding/removing such a membership —
+        // or changing an included file's content or compiler flags — would not change this target's hash, so stale
+        // cache artifacts could be reused.
+        let targetName = graphTarget.target.name
+        let foreignBuildableFolderHashes: [String] = try await graphTarget.project.targets.values
+            .filter { $0.name != targetName }
+            .sorted(by: { $0.name < $1.name })
+            .concurrentFlatMap { (otherTarget: Target) -> [String] in
+                try await otherTarget.buildableFolders
+                    .sorted(by: { $0.path < $1.path })
+                    .concurrentFlatMap { (folder: BuildableFolder) -> [String] in
+                        let inclusions = folder.exceptions
+                            .filter { $0.target == targetName }
+                            .flatMap { exception in exception.included.map { (path: $0, exception: exception) } }
+                            .filter { hashingFilesFilter($0.path) }
+                            .sorted(by: { $0.path < $1.path })
+                        return try await inclusions.concurrentMap { inclusion in
+                            let fileHash = try await contentHasher.hash(path: inclusion.path)
+                            let compilerFlagsHash = try contentHasher.hash(
+                                inclusion.exception.compilerFlags[inclusion.path] ?? ""
+                            )
+                            var inclusionStrings = [
+                                otherTarget.name,
+                                inclusion.path.relative(to: folder.path).pathString,
+                                fileHash,
+                                compilerFlagsHash,
+                            ]
+                            if let condition = inclusion.exception.platformFilters[inclusion.path] {
+                                inclusionStrings.append(
+                                    contentsOf: condition.platformFilters.map(\.xcodeprojValue).sorted()
+                                )
+                            }
+                            return try contentHasher.hash(inclusionStrings)
+                        }
+                    }
+            }
+            .sorted()
+
+        let combinedBuildableFolderHashes = buildableFolderHashes + foreignBuildableFolderHashes
+        let buildableFoldersHash: String? = combinedBuildableFolderHashes.isEmpty
             ? nil
-            : try contentHasher.hash(buildableFolderHashes)
+            : try contentHasher.hash(combinedBuildableFolderHashes)
 
         var stringsToHash =
             [

--- a/cli/Sources/TuistLoader/Models+ManifestMappers/BuildableFolderException+ManifestMapper.swift
+++ b/cli/Sources/TuistLoader/Models+ManifestMappers/BuildableFolderException+ManifestMapper.swift
@@ -17,6 +17,12 @@ extension XcodeGraph.BuildableFolderException {
             excluded.append(contentsOf: expandedPaths)
         }
 
+        var included: [AbsolutePath] = []
+        for pattern in manifest.included {
+            let expandedPaths = try await fileSystem.glob(directory: buildableFolder, include: [pattern]).collect()
+            included.append(contentsOf: expandedPaths)
+        }
+
         let compilerFlags = Dictionary(uniqueKeysWithValues: try manifest.compilerFlags.map {
             (buildableFolder.appending(try RelativePath(validating: $0.0)), $0.1)
         })
@@ -32,7 +38,9 @@ extension XcodeGraph.BuildableFolderException {
             compilerFlags: compilerFlags,
             publicHeaders: publicHeaders,
             privateHeaders: privateHeaders,
-            platformFilters: platformFilters
+            platformFilters: platformFilters,
+            target: manifest.target,
+            included: included
         )
     }
 }

--- a/cli/Sources/XcodeGraph/Sources/XcodeGraph/Models/BuildableFolderException.swift
+++ b/cli/Sources/XcodeGraph/Sources/XcodeGraph/Models/BuildableFolderException.swift
@@ -17,6 +17,16 @@ public struct BuildableFolderException: Sendable, Codable, Equatable, Hashable {
     /// A dictionary mapping files (referenced by their absolute path) to the platform condition to apply.
     public var platformFilters: [AbsolutePath: PlatformCondition]
 
+    /// The name of a target, other than the folder's owning target, that the `included` files should be members of.
+    /// When `nil` the exception applies to the owning target and `excluded` files are removed from it. When set, the
+    /// `included` files are added to that target instead, mapping to a `PBXFileSystemSynchronizedBuildFileExceptionSet`
+    /// whose `target` is the foreign target.
+    public var target: String?
+
+    /// A list of absolute paths, within the buildable folder, of files to add to `target`. Only meaningful when
+    /// `target` is set.
+    public var included: [AbsolutePath]
+
     /// Creates a new exception for a buildable folder.
     /// - Parameters:
     ///   - excluded: An array of absolute paths to files that should be excluded from the buildable folder.
@@ -24,17 +34,23 @@ public struct BuildableFolderException: Sendable, Codable, Equatable, Hashable {
     ///   - publicHeaders: The list of public headers.
     ///   - privateHeaders: The list of private headers.
     ///   - platformFilters: A dictionary mapping absolute file paths to platform conditions.
+    ///   - target: The name of the foreign target the `included` files are added to, or `nil` for the owning target.
+    ///   - included: Absolute paths, within the buildable folder, of files to add to `target`.
     public init(
         excluded: [AbsolutePath],
         compilerFlags: [AbsolutePath: String],
         publicHeaders: [AbsolutePath],
         privateHeaders: [AbsolutePath],
-        platformFilters: [AbsolutePath: PlatformCondition] = [:]
+        platformFilters: [AbsolutePath: PlatformCondition] = [:],
+        target: String? = nil,
+        included: [AbsolutePath] = []
     ) {
         self.excluded = excluded
         self.compilerFlags = compilerFlags
         self.publicHeaders = publicHeaders
         self.privateHeaders = privateHeaders
         self.platformFilters = platformFilters
+        self.target = target
+        self.included = included
     }
 }

--- a/cli/Tests/TuistGeneratorAcceptanceTests/GenerateAcceptanceTests.swift
+++ b/cli/Tests/TuistGeneratorAcceptanceTests/GenerateAcceptanceTests.swift
@@ -1736,6 +1736,45 @@ struct GenerateAcceptanceTestiOSAppWithSandboxDisabled {
 //    }
 }
 
+struct GenerateAcceptanceTestAppWithBuildableFolderMembership {
+    @Test(.withFixture("generated_app_with_buildable_folder_membership"), .inTemporaryDirectory)
+    func app_with_buildable_folder_membership() async throws {
+        let fixturePath = try fixtureDirectory()
+
+        // When
+        try await run(GenerateCommand.self)
+
+        // Then
+        let xcodeprojPath = try await TuistAcceptanceTest.xcodeprojPath(in: fixturePath)
+        let pbxproj = try XcodeProj(pathString: xcodeprojPath.pathString).pbxproj
+        let appTarget = try #require(pbxproj.nativeTargets.first { $0.name == "App" })
+
+        // xcconfigs inside the buildable folder are referenced through the synchronized-group anchor, not a flat reference.
+        let debugConfiguration = try #require(appTarget.buildConfigurationList?.configuration(name: "Debug"))
+        #expect(debugConfiguration.baseConfiguration == nil)
+        #expect(debugConfiguration.baseConfigurationReferenceRelativePath == "Supporting/Configurations/App-Debug.xcconfig")
+
+        // SharedStub.swift is added to AppTests via a foreign-target exception set, not a flat reference.
+        let synchronizedGroup = try #require(
+            appTarget.fileSystemSynchronizedGroups?
+                .compactMap { $0 as? PBXFileSystemSynchronizedRootGroup }
+                .first { $0.path == "App" }
+        )
+        let foreignException = try #require(
+            synchronizedGroup.exceptions?
+                .compactMap { $0 as? PBXFileSystemSynchronizedBuildFileExceptionSet }
+                .first { $0.target?.name == "AppTests" }
+        )
+        #expect(foreignException.membershipExceptions == ["SharedStub.swift"])
+
+        // None of the buildable-folder files leak as flat file references at the project root.
+        let fileReferenceNames = pbxproj.fileReferences.compactMap(\.path) + pbxproj.fileReferences.compactMap(\.name)
+        #expect(!fileReferenceNames.contains { $0.hasSuffix("App-Debug.xcconfig") })
+        #expect(!fileReferenceNames.contains { $0.hasSuffix("App-Info.plist") })
+        #expect(!fileReferenceNames.contains { $0.hasSuffix("SharedStub.swift") })
+    }
+}
+
 private enum AcceptanceTestError: Error {
     case missingProduct
     case missingResource

--- a/cli/Tests/TuistGeneratorTests/Generator/ConfigGeneratorTests.swift
+++ b/cli/Tests/TuistGeneratorTests/Generator/ConfigGeneratorTests.swift
@@ -102,6 +102,83 @@ struct ConfigGeneratorTests {
     }
 
     @Test(.withMockedXcodeController, .inTemporaryDirectory)
+    func generateTargetConfig_whenXcconfigInsideBuildableFolder_usesAnchoredReference() async throws {
+        // Given
+        let dir = try #require(FileSystem.temporaryTestDirectory)
+        let buildableFolder = dir.appending(component: "App")
+        let configurationsDir = buildableFolder.appending(components: "Supporting", "Configurations")
+        try FileManager.default.createDirectory(at: configurationsDir.url, withIntermediateDirectories: true)
+        let debugXcconfig = configurationsDir.appending(component: "App-Debug.xcconfig")
+        let releaseXcconfig = configurationsDir.appending(component: "App-Release.xcconfig")
+        try "".write(to: debugXcconfig.url, atomically: true, encoding: .utf8)
+        try "".write(to: releaseXcconfig.url, atomically: true, encoding: .utf8)
+
+        let target = Target.test(
+            name: "App",
+            product: .app,
+            settings: Settings(
+                base: [:],
+                configurations: [
+                    .debug: Configuration(settings: [:], xcconfig: debugXcconfig),
+                    .release: Configuration(settings: [:], xcconfig: releaseXcconfig),
+                ]
+            ),
+            buildableFolders: [
+                BuildableFolder(
+                    path: buildableFolder,
+                    exceptions: BuildableFolderExceptions(exceptions: []),
+                    resolvedFiles: []
+                ),
+            ]
+        )
+        let project = Project.test(
+            path: dir,
+            sourceRootPath: dir,
+            xcodeProjPath: dir.appending(component: "Project.xcodeproj"),
+            name: "App",
+            settings: .default,
+            targets: [target]
+        )
+        let graph = Graph.test(path: project.path)
+        let graphTraverser = GraphTraverser(graph: graph)
+        let fileElements = ProjectFileElements()
+        let groups = ProjectGroups.generate(project: project, pbxproj: pbxproj)
+        try fileElements.generateProjectFiles(
+            project: project,
+            graphTraverser: graphTraverser,
+            groups: groups,
+            pbxproj: pbxproj
+        )
+
+        // When
+        try await subject.generateTargetConfig(
+            target,
+            project: project,
+            pbxTarget: pbxTarget,
+            pbxproj: pbxproj,
+            projectSettings: project.settings,
+            fileElements: fileElements,
+            graphTraverser: graphTraverser,
+            sourceRootPath: dir
+        )
+
+        // Then
+        let debugConfig = pbxTarget.buildConfigurationList?.configuration(name: "Debug")
+        #expect(debugConfig?.baseConfiguration == nil)
+        #expect(debugConfig?.baseConfigurationReferenceRelativePath == "Supporting/Configurations/App-Debug.xcconfig")
+        #expect(try #require(debugConfig?.baseConfigurationAnchor).path == "App")
+
+        let releaseConfig = pbxTarget.buildConfigurationList?.configuration(name: "Release")
+        #expect(releaseConfig?.baseConfiguration == nil)
+        #expect(releaseConfig?.baseConfigurationReferenceRelativePath == "Supporting/Configurations/App-Release.xcconfig")
+        #expect(try #require(releaseConfig?.baseConfigurationAnchor).path == "App")
+
+        // No flat file reference is created for the xcconfigs.
+        #expect(fileElements.file(path: debugXcconfig) == nil)
+        #expect(fileElements.file(path: releaseXcconfig) == nil)
+    }
+
+    @Test(.withMockedXcodeController, .inTemporaryDirectory)
     func generateTargetConfig_whenAggregateTarget_clearsVersioningSystem() async throws {
         // Given
         let dir = try #require(FileSystem.temporaryTestDirectory)

--- a/cli/Tests/TuistGeneratorTests/Generator/Mocks/MockTargetGenerator.swift
+++ b/cli/Tests/TuistGeneratorTests/Generator/Mocks/MockTargetGenerator.swift
@@ -28,4 +28,11 @@ class MockTargetGenerator: TargetGenerating {
         nativeTargets _: [String: PBXTarget],
         graphTraverser _: GraphTraversing
     ) throws {}
+
+    func generateBuildableFolderForeignExceptions(
+        targets _: [Target],
+        nativeTargets _: [String: PBXTarget],
+        fileElements _: ProjectFileElements,
+        pbxproj _: PBXProj
+    ) throws {}
 }

--- a/cli/Tests/TuistGeneratorTests/Generator/ProjectDescriptorGeneratorTests.swift
+++ b/cli/Tests/TuistGeneratorTests/Generator/ProjectDescriptorGeneratorTests.swift
@@ -92,6 +92,101 @@ struct ProjectDescriptorGeneratorTests {
         .withMockedSwiftVersionProvider,
         .inTemporaryDirectory,
         .withMockedXcodeController
+    ) func generate_buildableFolders_anchorsConfigsAndAddsCrossTargetMembership() async throws {
+        // Given
+        let temporaryPath = try #require(FileSystem.temporaryTestDirectory)
+        let buildableFolder = temporaryPath.appending(component: "App")
+        let xcconfig = buildableFolder.appending(components: "Supporting", "Configurations", "App-Debug.xcconfig")
+        let infoPlist = buildableFolder.appending(components: "Supporting", "App-Info.plist")
+        let sharedStub = buildableFolder.appending(component: "SharedStub.swift")
+
+        let app = Target.test(
+            name: "App",
+            platform: .iOS,
+            product: .app,
+            infoPlist: .file(path: infoPlist),
+            settings: Settings(
+                base: [:],
+                configurations: [.debug: Configuration(settings: [:], xcconfig: xcconfig)]
+            ),
+            buildableFolders: [
+                BuildableFolder(
+                    path: buildableFolder,
+                    exceptions: BuildableFolderExceptions(exceptions: [
+                        BuildableFolderException(
+                            excluded: [],
+                            compilerFlags: [:],
+                            publicHeaders: [],
+                            privateHeaders: [],
+                            platformFilters: [:],
+                            target: "AppTests",
+                            included: [sharedStub]
+                        ),
+                    ]),
+                    resolvedFiles: [BuildableFolderFile(path: sharedStub, compilerFlags: nil)]
+                ),
+            ]
+        )
+        let appTests = Target.test(name: "AppTests", platform: .iOS, product: .unitTests)
+        let project = Project.test(
+            path: temporaryPath,
+            sourceRootPath: temporaryPath,
+            name: "Project",
+            targets: [app, appTests]
+        )
+        let appGraphTarget = GraphTarget(path: project.path, target: app, project: project)
+        let appTestsGraphTarget = GraphTarget(path: project.path, target: appTests, project: project)
+        let graph = Graph.test(
+            projects: [project.path: project],
+            dependencies: [
+                .target(name: appTestsGraphTarget.target.name, path: appTestsGraphTarget.path): [
+                    .target(name: appGraphTarget.target.name, path: appGraphTarget.path),
+                ],
+            ]
+        )
+        let graphTraverser = GraphTraverser(graph: graph)
+
+        let xcodeControllerMock = try #require(XcodeController.mocked)
+        given(xcodeControllerMock)
+            .selectedVersion()
+            .willReturn(Version(15, 0, 0))
+
+        // When
+        let generatedProject = try await subject.generate(project: project, graphTraverser: graphTraverser)
+
+        // Then
+        let pbxproj = generatedProject.xcodeProj.pbxproj
+        let appTarget = try #require(pbxproj.nativeTargets.first { $0.name == "App" })
+
+        // The xcconfig is referenced through the synchronized root group anchor, not a flat file reference.
+        let debugConfig = try #require(appTarget.buildConfigurationList?.configuration(name: "Debug"))
+        #expect(debugConfig.baseConfiguration == nil)
+        #expect(debugConfig.baseConfigurationReferenceRelativePath == "Supporting/Configurations/App-Debug.xcconfig")
+
+        // The cross-target membership is a foreign-target exception set, not a flat reference.
+        let group = try #require(
+            appTarget.fileSystemSynchronizedGroups?
+                .compactMap { $0 as? PBXFileSystemSynchronizedRootGroup }
+                .first { $0.path == "App" }
+        )
+        let foreignSet = try #require(
+            group.exceptions?
+                .compactMap { $0 as? PBXFileSystemSynchronizedBuildFileExceptionSet }
+                .first { $0.target?.name == "AppTests" }
+        )
+        #expect(foreignSet.membershipExceptions == ["SharedStub.swift"])
+
+        // None of the buildable-folder files leak as flat file references at the project root.
+        let fileReferenceNames = pbxproj.fileReferences.compactMap(\.path) + pbxproj.fileReferences.compactMap(\.name)
+        #expect(!fileReferenceNames.contains { $0.hasSuffix("App-Debug.xcconfig") })
+        #expect(!fileReferenceNames.contains { $0.hasSuffix("App-Info.plist") })
+        #expect(!fileReferenceNames.contains { $0.hasSuffix("SharedStub.swift") })
+    }
+
+    @Test(
+        .withMockedSwiftVersionProvider,
+        .inTemporaryDirectory,
+        .withMockedXcodeController
     ) func objectVersion_when_xcode11_and_spm() async throws {
         let xcodeControllerMock = try #require(XcodeController.mocked)
         given(xcodeControllerMock)

--- a/cli/Tests/TuistGeneratorTests/Generator/ProjectFileElementsTests.swift
+++ b/cli/Tests/TuistGeneratorTests/Generator/ProjectFileElementsTests.swift
@@ -642,6 +642,83 @@ final class ProjectFileElementsTests: TuistUnitTestCase {
         ])
     }
 
+    func test_generateProjectFiles_whenInfoPlistIsInsideBuildableFolder_doesNotCreateFlatReference() throws {
+        // Given
+        let infoPlistPath = try AbsolutePath(validating: "/project/App/Supporting/App-Info.plist")
+        let target = Target.test(
+            infoPlist: .file(path: infoPlistPath),
+            buildableFolders: [
+                BuildableFolder(
+                    path: "/project/App",
+                    exceptions: BuildableFolderExceptions(exceptions: []),
+                    resolvedFiles: []
+                ),
+            ]
+        )
+        let project = Project.test(
+            path: "/project",
+            sourceRootPath: "/project",
+            xcodeProjPath: "/project/Project.xcodeproj",
+            targets: [target]
+        )
+        let graph = Graph.test()
+        let graphTraverser = GraphTraverser(graph: graph)
+        let groups = ProjectGroups.generate(project: project, pbxproj: pbxproj)
+
+        // When
+        try subject.generateProjectFiles(
+            project: project,
+            graphTraverser: graphTraverser,
+            groups: groups,
+            pbxproj: pbxproj
+        )
+
+        // Then
+        XCTAssertNil(subject.file(path: infoPlistPath))
+        let projectGroup = groups.sortedMain.group(named: "Project")
+        XCTAssertEqual(projectGroup?.flattenedChildren.sorted(), ["App"])
+    }
+
+    func test_generateProjectFiles_whenXcconfigIsInsideBuildableFolder_doesNotCreateFlatReference() throws {
+        // Given
+        let xcconfigPath = try AbsolutePath(validating: "/project/App/Supporting/Configurations/App-Debug.xcconfig")
+        let target = Target.test(
+            settings: Settings(
+                base: [:],
+                configurations: [.debug: Configuration(settings: [:], xcconfig: xcconfigPath)]
+            ),
+            buildableFolders: [
+                BuildableFolder(
+                    path: "/project/App",
+                    exceptions: BuildableFolderExceptions(exceptions: []),
+                    resolvedFiles: []
+                ),
+            ]
+        )
+        let project = Project.test(
+            path: "/project",
+            sourceRootPath: "/project",
+            xcodeProjPath: "/project/Project.xcodeproj",
+            targets: [target]
+        )
+        let graph = Graph.test()
+        let graphTraverser = GraphTraverser(graph: graph)
+        let groups = ProjectGroups.generate(project: project, pbxproj: pbxproj)
+
+        // When
+        try subject.generateProjectFiles(
+            project: project,
+            graphTraverser: graphTraverser,
+            groups: groups,
+            pbxproj: pbxproj
+        )
+
+        // Then
+        XCTAssertNil(subject.file(path: xcconfigPath))
+        let projectGroup = groups.sortedMain.group(named: "Project")
+        XCTAssertEqual(projectGroup?.flattenedChildren.sorted(), ["App"])
+    }
+
     func test_generateProducts_stableOrder() throws {
         for _ in 0 ..< 5 {
             let pbxproj = PBXProj()

--- a/cli/Tests/TuistGeneratorTests/Generator/TargetGeneratorTests.swift
+++ b/cli/Tests/TuistGeneratorTests/Generator/TargetGeneratorTests.swift
@@ -234,6 +234,68 @@ struct TargetGeneratorTests {
         #expect(exception.membershipExceptions == ["ExcludedFolder", "ExcludedFile.swift"])
     }
 
+    @Test func generateBuildableFolderForeignExceptions_addsMembershipForForeignTarget() async throws {
+        // Given
+        let buildableFolderPath = path.appending(component: "App")
+        let sharedStub = buildableFolderPath.appending(component: "SharedStub.swift")
+        let appTarget = Target.test(
+            name: "App",
+            product: .app,
+            buildableFolders: [
+                BuildableFolder(
+                    path: buildableFolderPath,
+                    exceptions: BuildableFolderExceptions(exceptions: [
+                        BuildableFolderException(
+                            excluded: [],
+                            compilerFlags: [:],
+                            publicHeaders: [],
+                            privateHeaders: [],
+                            platformFilters: [:],
+                            target: "AppTests",
+                            included: [sharedStub]
+                        ),
+                    ]),
+                    resolvedFiles: []
+                ),
+            ]
+        )
+        let testsTarget = Target.test(name: "AppTests", product: .unitTests)
+        let project = Project.test(
+            path: path,
+            sourceRootPath: path,
+            xcodeProjPath: path.appending(component: "Test.xcodeproj"),
+            targets: [appTarget, testsTarget]
+        )
+        let graph = Graph.test()
+        let graphTraverser = GraphTraverser(graph: graph)
+        let groups = ProjectGroups.generate(project: project, pbxproj: pbxproj)
+        try fileElements.generateProjectFiles(
+            project: project,
+            graphTraverser: graphTraverser,
+            groups: groups,
+            pbxproj: pbxproj
+        )
+        let appPBXTarget = PBXNativeTarget(name: "App")
+        let testsPBXTarget = PBXNativeTarget(name: "AppTests")
+        pbxproj.add(object: appPBXTarget)
+        pbxproj.add(object: testsPBXTarget)
+
+        // When
+        try subject.generateBuildableFolderForeignExceptions(
+            targets: [appTarget, testsTarget],
+            nativeTargets: ["App": appPBXTarget, "AppTests": testsPBXTarget],
+            fileElements: fileElements,
+            pbxproj: pbxproj
+        )
+
+        // Then: the foreign exception set lives on the App folder but targets AppTests, with no flat file reference.
+        let group = try #require(fileElements.elements[buildableFolderPath] as? PBXFileSystemSynchronizedRootGroup)
+        let exception = try #require(group.exceptions?.first as? PBXFileSystemSynchronizedBuildFileExceptionSet)
+        #expect(exception.membershipExceptions == ["SharedStub.swift"])
+        #expect(exception.target?.name == "AppTests")
+        #expect(fileElements.file(path: sharedStub) == nil)
+    }
+
     @Test func generateTarget_productName() async throws {
         // Given
         let target = Target.test(

--- a/cli/Tests/TuistHasherTests/TargetContentHasherTests.swift
+++ b/cli/Tests/TuistHasherTests/TargetContentHasherTests.swift
@@ -268,6 +268,55 @@ struct TargetContentHasherTests {
         )
     }
 
+    @Test func hash_changes_when_sibling_target_adds_cross_target_membership() async throws {
+        // Given: target "B" has no buildable folders of its own; sibling "A" optionally adds one of its
+        // buildable-folder files to "B" via an additive cross-target membership exception.
+        let includedPath = try AbsolutePath(validating: "/test/A/Shared.swift")
+        let folderPath = try AbsolutePath(validating: "/test/A")
+        let targetB = Target.test(name: "B", buildableFolders: [])
+
+        func graphTarget(includingIntoB: Bool) -> GraphTarget {
+            let exceptions: BuildableFolderExceptions = includingIntoB
+                ? BuildableFolderExceptions(exceptions: [
+                    BuildableFolderException(
+                        excluded: [],
+                        compilerFlags: [:],
+                        publicHeaders: [],
+                        privateHeaders: [],
+                        target: "B",
+                        included: [includedPath]
+                    ),
+                ])
+                : BuildableFolderExceptions(exceptions: [])
+            let targetA = Target.test(name: "A", buildableFolders: [
+                BuildableFolder(
+                    path: folderPath,
+                    exceptions: exceptions,
+                    resolvedFiles: [BuildableFolderFile(path: includedPath, compilerFlags: nil)]
+                ),
+            ])
+            return GraphTarget.test(target: targetB, project: .test(targets: [targetA, targetB]))
+        }
+
+        // When
+        let withMembership = try await subject.contentHash(
+            for: graphTarget(includingIntoB: true),
+            hashedTargets: [:],
+            hashedPaths: [:],
+            destination: nil
+        )
+        let withoutMembership = try await subject.contentHash(
+            for: graphTarget(includingIntoB: false),
+            hashedTargets: [:],
+            hashedPaths: [:],
+            destination: nil
+        )
+
+        // Then: B's hash reflects the file added to it from A's folder.
+        #expect(withMembership.hash != withoutMembership.hash)
+        #expect(withMembership.subhashes.buildableFolders != withoutMembership.subhashes.buildableFolders)
+    }
+
     @Test func hash_with_buildable_folders_ignores_ds_store_files() async throws {
         // Given
         let targetWithDSStore = GraphTarget.test(target: .test(buildableFolders: [

--- a/cli/Tests/TuistLoaderTests/Models+ManifestMappers/BuildableFolderException+ManifestMapperTests.swift
+++ b/cli/Tests/TuistLoaderTests/Models+ManifestMappers/BuildableFolderException+ManifestMapperTests.swift
@@ -48,6 +48,23 @@ struct BuildableFolderExceptionManifestMapperTests {
         )
     }
 
+    @Test(.inTemporaryDirectory) func from_withForeignTargetInclusion() async throws {
+        let buildableFolder = try #require(FileSystem.temporaryTestDirectory)
+
+        try await fileSystem.touch(buildableFolder.appending(component: "SharedStub.swift"))
+
+        let got = try await XcodeGraph.BuildableFolderException.from(
+            manifest: ProjectDescription.BuildableFolderException
+                .exception(target: "AppTests", included: ["SharedStub.swift"]),
+            buildableFolder: buildableFolder,
+            fileSystem: fileSystem
+        )
+
+        #expect(got.target == "AppTests")
+        #expect(got.included == [buildableFolder.appending(component: "SharedStub.swift")])
+        #expect(got.excluded.isEmpty)
+    }
+
     @Test(.inTemporaryDirectory) func from_withGlobPattern() async throws {
         let buildableFolder = try #require(FileSystem.temporaryTestDirectory)
 

--- a/examples/xcode/generated_app_with_buildable_folder_membership/.gitignore
+++ b/examples/xcode/generated_app_with_buildable_folder_membership/.gitignore
@@ -1,0 +1,4 @@
+*.xcodeproj
+*.xcworkspace
+Derived/
+.build/

--- a/examples/xcode/generated_app_with_buildable_folder_membership/App/SharedStub.swift
+++ b/examples/xcode/generated_app_with_buildable_folder_membership/App/SharedStub.swift
@@ -1,0 +1,3 @@
+public enum SharedStub {
+    public static let value = 42
+}

--- a/examples/xcode/generated_app_with_buildable_folder_membership/App/Sources/App.swift
+++ b/examples/xcode/generated_app_with_buildable_folder_membership/App/Sources/App.swift
@@ -1,0 +1,1 @@
+public enum App {}

--- a/examples/xcode/generated_app_with_buildable_folder_membership/App/Supporting/App-Info.plist
+++ b/examples/xcode/generated_app_with_buildable_folder_membership/App/Supporting/App-Info.plist
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+  <key>CFBundleExecutable</key><string>$(EXECUTABLE_NAME)</string>
+  <key>CFBundleIdentifier</key><string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+</dict></plist>

--- a/examples/xcode/generated_app_with_buildable_folder_membership/App/Supporting/Configurations/App-Debug.xcconfig
+++ b/examples/xcode/generated_app_with_buildable_folder_membership/App/Supporting/Configurations/App-Debug.xcconfig
@@ -1,0 +1,1 @@
+OTHER_SWIFT_FLAGS = $(inherited)

--- a/examples/xcode/generated_app_with_buildable_folder_membership/App/Supporting/Configurations/App-Release.xcconfig
+++ b/examples/xcode/generated_app_with_buildable_folder_membership/App/Supporting/Configurations/App-Release.xcconfig
@@ -1,0 +1,1 @@
+OTHER_SWIFT_FLAGS = $(inherited)

--- a/examples/xcode/generated_app_with_buildable_folder_membership/AppTests/AppTests.swift
+++ b/examples/xcode/generated_app_with_buildable_folder_membership/AppTests/AppTests.swift
@@ -1,0 +1,7 @@
+import XCTest
+
+final class AppTests: XCTestCase {
+    func testSharedStub() {
+        XCTAssertEqual(SharedStub.value, 42)
+    }
+}

--- a/examples/xcode/generated_app_with_buildable_folder_membership/Project.swift
+++ b/examples/xcode/generated_app_with_buildable_folder_membership/Project.swift
@@ -1,0 +1,39 @@
+import ProjectDescription
+
+let project = Project(
+    name: "App",
+    targets: [
+        // The App target's buildable folder holds its xcconfigs and Info.plist (which must not be duplicated as flat
+        // root-level references) and SharedStub.swift, which is also a member of the AppTests target.
+        .target(
+            name: "App",
+            destinations: .macOS,
+            product: .app,
+            bundleId: "dev.tuist.app-with-buildable-folder-membership",
+            infoPlist: .file(path: "App/Supporting/App-Info.plist"),
+            buildableFolders: [
+                .folder("App", exceptions: [
+                    .exception(excluded: ["Supporting/App-Info.plist"]),
+                    .exception(target: "AppTests", included: ["SharedStub.swift"]),
+                ]),
+            ],
+            settings: .settings(
+                configurations: [
+                    .debug(name: "Debug", xcconfig: "App/Supporting/Configurations/App-Debug.xcconfig"),
+                    .release(name: "Release", xcconfig: "App/Supporting/Configurations/App-Release.xcconfig"),
+                ]
+            )
+        ),
+        .target(
+            name: "AppTests",
+            destinations: .macOS,
+            product: .unitTests,
+            bundleId: "dev.tuist.app-with-buildable-folder-membership-tests",
+            infoPlist: .default,
+            buildableFolders: ["AppTests"],
+            dependencies: [
+                .target(name: "App"),
+            ]
+        ),
+    ]
+)

--- a/examples/xcode/generated_app_with_buildable_folder_membership/Tuist.swift
+++ b/examples/xcode/generated_app_with_buildable_folder_membership/Tuist.swift
@@ -1,0 +1,3 @@
+import ProjectDescription
+
+let tuist = Tuist(project: .tuist())


### PR DESCRIPTION
## What

Fixes the two related `buildableFolders:` gaps reported for the iAuditor migration, both of which materialise stray, duplicated flat `PBXFileReference` entries at the generated project root.

**Issue A — xcconfig / Info.plist inside a buildable folder get flat root-level references.**
When a target's xcconfigs or `infoPlist: .file(...)` live inside a `buildableFolders:` folder, the generated project added a flat root-level `PBXFileReference` for each, duplicating files already shown nested inside the synchronized folder. With xcconfig-per-target-per-configuration setups this produced dozens of stray entries.

- xcconfigs inside a buildable folder now use Xcode 16's anchored reference (`baseConfigurationReferenceAnchor` + `baseConfigurationReferenceRelativePath`) — exactly what Xcode writes for the same layout — instead of a plain `baseConfigurationReference` plus a flat file reference.
- Info.plist and entitlements inside a buildable folder no longer get a flat reference; they are surfaced through the `INFOPLIST_FILE` / `CODE_SIGN_ENTITLEMENTS` build settings (unchanged).

**Issue B — no API for additive cross-target buildable-folder membership.**
A file inside target A's folder that must also compile into target B previously required an explicit `sources:`/`resources:` glob on B, which materialises another flat root-level reference. Adds an additive, target-addressed exception form:

```swift
buildableFolders: [
  .folder("App", exceptions: [
    .exception(excluded: ["Supporting/App-Info.plist"]),          // existing, subtractive (owning target)
    .exception(target: "AppTests", included: ["SharedStub.swift"]), // new, additive (foreign target)
  ]),
]
```

This generates a `PBXFileSystemSynchronizedBuildFileExceptionSet` whose `target` is the foreign target, so the file is compiled into it without any standalone `PBXFileReference`/`PBXBuildFile` — the navigator shows it once, inside the folder.

**How it maps to the pbxproj.** A buildable folder (`PBXFileSystemSynchronizedRootGroup`) holds one `PBXFileSystemSynchronizedBuildFileExceptionSet` per target. The set's `membershipExceptions` is a list of folder-relative paths whose meaning is *relative to the set's `target`*: for the folder's **owning** target the paths are **exclusions**, for any **other** target they are **inclusions**. So `excluded:` and `included:` both serialize to the same `membershipExceptions` field — only the set's `target` (owner vs foreign) distinguishes a removal from an addition, which is why the API needs two inputs. The included file gets no standalone `PBXFileReference`/`PBXBuildFile`, and it stays a member of its owning target unless also excluded.

```
App /* PBXFileSystemSynchronizedRootGroup, owned by target App */
  ├─ exception set { target = App,      membershipExceptions = ("Supporting/App-Info.plist") }  // excluded from App
  └─ exception set { target = AppTests, membershipExceptions = ("SharedStub.swift") }            // included into AppTests
```

Per-file `compilerFlags` / `platformFilters` on the exception map to `additionalCompilerFlagsByRelativePath` / `platformFiltersByRelativePath` on the same set.

## Why / root cause

A single code path in `ProjectFileElements.generate(fileElement:)` creates a flat `PBXFileReference` for any explicitly-referenced file that lives inside a synchronized root group, and `ConfigGenerator` points `baseConfigurationReference` at that flat reference. That one path produced all three symptoms (stray xcconfig refs, stray Info.plist refs, and stray cross-target source refs). Xcode 16 instead uses anchored base-configuration references and foreign-target exception sets, which `XcodeProj` already round-trips.

## Approach notes

- **xcconfig:** suppressed flat-reference collection for xcconfigs inside a buildable folder; `ConfigGenerator` looks up the enclosing synchronized root group and sets the anchor + relative path (deepest enclosing folder wins for nested folders).
- **Info.plist / entitlements:** suppressed flat-reference collection only; build settings already carry the path.
- **Cross-target:** the existing `sources:` glob behaviour is intentionally left intact (backward compatible); the new `.exception(target:included:)` is the clean opt-in. Foreign-target exception sets are created in a post-pass after every `PBXTarget` exists.
- **Cache hashing:** `TargetContentHasher` folds files added to a target from sibling targets' folders (identity, content, compiler flags, platform filters) into that target's content hash, so adding/removing a cross-target inclusion or changing an included file invalidates the consuming target's cache. Targets without foreign inclusions hash unchanged.
- Required the anchored-reference API, so **XcodeProj is bumped 9.9.0 → 9.13.0** (#1037 / #1016; additive only, no breaking changes).

## Validation

**Reproduced both issues e2e** with `tuist 4.198.1` against the minimal repro (`gutiago/tuist-buildable-folder-bundle-module-bug@repro/buildable-folder-issues`): the root `Project` group held the `App`/`AppTests` synchronized folders plus four stray flat refs (`App-Debug.xcconfig`, `App-Info.plist`, `App-Release.xcconfig`, `SharedStub.swift`), `baseConfigurationReference` pointed at the flat xcconfigs, and the only exception set targeted the owning `App` target.

**Verified the fix e2e** by building this branch (`swift build --product tuist`, compiles cleanly against XcodeProj 9.13.0) and regenerating an equivalent fixture that uses the new API:

| | Before (`4.198.1`) | After (this branch) |
|---|---|---|
| Root `Project` group | App, AppTests, **App-Debug.xcconfig, App-Info.plist, App-Release.xcconfig, SharedStub.swift** | `Derived, App, AppTests` — zero stray refs |
| xcconfig | `baseConfigurationReference` → flat ref | `baseConfigurationReferenceAnchor = /* App */` + relative path, no flat ref |
| Info.plist | flat ref + `INFOPLIST_FILE` | `INFOPLIST_FILE` string only, no flat ref |
| `SharedStub.swift` | flat `PBXFileReference` + `PBXBuildFile` | exception set `target = /* AppTests */`, `membershipExceptions = (SharedStub.swift)`, no flat ref |

The owning Info.plist exclusion still targets `App`; the new additive set targets `AppTests`.

**Unit tests** added at every layer (TDD): `ProjectFileElementsTests` (no flat ref for Info.plist/xcconfig inside a folder), `ConfigGeneratorTests` (anchored base-config + no flat ref), `TargetGeneratorTests` (foreign-target exception set), `BuildableFolderException+ManifestMapperTests` (new manifest form maps `target` + globbed `included`). `swiftformat --lint` clean; `swiftlint` adds no new violations in production code.

**Integration + acceptance tests** (e2e):
- `ProjectDescriptorGeneratorTests` runs the full project generation and asserts, in one pass, the anchored config reference, the foreign-target exception set, and the absence of flat xcconfig/Info.plist/source references — guarding the orchestrator wiring (that `generateProject` invokes the foreign-exception pass), which the per-layer unit tests don't exercise.
- `GenerateAcceptanceTests` + a new `generated_app_with_buildable_folder_membership` fixture exercise the real public manifest API (`.exception(target:included:)`, xcconfig/Info.plist inside the folder) through `tuist generate`, asserting the same pbxproj outcomes. Generate-only, so it stays in the fast acceptance lane. The fixture's generated output was verified against a locally built `tuist`.

> [!NOTE]
> The unit tests live in `TuistGeneratorTests`/`TuistLoaderTests`, which are defined only in the Tuist project (not `Package.swift`), so they are executed by CI rather than locally. The fix itself was verified locally end-to-end (built `tuist`, regenerated the fixture, inspected the `.pbxproj` — table above).
>
> `Package.resolved` was bumped surgically for the XcodeProj pin. A full `tuist install` re-resolve currently conflicts on an unrelated package (`apple.swift-protobuf`, reproducible on `main`), so the local build used `swift build --replace-scm-with-registry --force-resolved-versions` to honour the committed lockfile. Worth regenerating `Package.resolved` via `tuist install` in CI so `originHash` is recomputed.

Closes the two reports: "Generated project adds flat root-level file references for xcconfigs living inside buildable folders" and "No API to compile a file from another target's buildable folder (additive exception sets)".

🤖 Generated with [Claude Code](https://claude.com/claude-code)


