### PR TITLE
fix(cli): avoid per-target `swift --version` subprocess storm when mapping large SwiftPM graphs

### DIFF
--- a/cli/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
+++ b/cli/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
@@ -385,6 +385,7 @@ public struct PackageInfoMapper: PackageInfoMapping {
                 return try await map(
                     target: target,
                     targetToProducts: targetToProducts,
+                    targetsByName: targetsByName,
                     packageInfo: packageInfo,
                     packageType: packageType,
                     packageSettings: packageSettings,
@@ -464,7 +465,7 @@ public struct PackageInfoMapper: PackageInfoMapping {
     private static func effectiveProductName(
         targetName: String,
         products: Set<PackageInfo.Product>,
-        packageTargets: [PackageInfo.Target]
+        targetsByName: [String: PackageInfo.Target]
     ) -> String {
         guard products.count == 1,
               let singleProduct = products.first,
@@ -474,7 +475,7 @@ public struct PackageInfoMapper: PackageInfoMapping {
 
         let productName = singleProduct.name
         let wrapsProductFramework = wrapsProductNamedFramework(
-            targetName: targetName, productName: productName, packageTargets: packageTargets
+            targetName: targetName, productName: productName, targetsByName: targetsByName
         )
 
         if targetName == productName {
@@ -495,7 +496,7 @@ public struct PackageInfoMapper: PackageInfoMapping {
     private static func effectiveModuleName(
         targetName: String,
         products: Set<PackageInfo.Product>,
-        packageTargets: [PackageInfo.Target]
+        targetsByName: [String: PackageInfo.Target]
     ) -> String {
         guard products.count == 1,
               let singleProduct = products.first,
@@ -505,7 +506,7 @@ public struct PackageInfoMapper: PackageInfoMapping {
 
         let productName = singleProduct.name
         let wrapsProductFramework = wrapsProductNamedFramework(
-            targetName: targetName, productName: productName, packageTargets: packageTargets
+            targetName: targetName, productName: productName, targetsByName: targetsByName
         )
 
         if targetName == productName {
@@ -525,9 +526,8 @@ public struct PackageInfoMapper: PackageInfoMapping {
     private static func wrapsProductNamedFramework(
         targetName: String,
         productName: String,
-        packageTargets: [PackageInfo.Target]
+        targetsByName: [String: PackageInfo.Target]
     ) -> Bool {
-        let targetsByName = Dictionary(uniqueKeysWithValues: packageTargets.map { ($0.name, $0) })
         var visited = Set<String>()
         var queue = [targetName]
 
@@ -681,6 +681,7 @@ public struct PackageInfoMapper: PackageInfoMapping {
     private func map(
         target: PackageInfo.Target,
         targetToProducts: [String: Set<PackageInfo.Product>],
+        targetsByName: [String: PackageInfo.Target],
         packageInfo: PackageInfo,
         packageType: PackageType,
         packageSettings: TuistCore.PackageSettings,
@@ -752,7 +753,7 @@ public struct PackageInfoMapper: PackageInfoMapping {
             moduleMap = ModuleMap.custom(moduleMapPath, umbrellaHeaderPath: nil)
         case .regular, .test:
             let moduleName = PackageInfoMapper.effectiveModuleName(
-                targetName: target.name, products: products, packageTargets: packageInfo.targets
+                targetName: target.name, products: products, targetsByName: targetsByName
             )
             let swiftPackageManagerScratchDirectory: AbsolutePath? = if packageType.isRemoteExternal {
                 SwiftPackageManagerPaths.scratchDirectory(containingCheckout: path)
@@ -911,13 +912,13 @@ public struct PackageInfoMapper: PackageInfoMapping {
         let targetName = packageModuleAliases[packageInfo.name]?[target.name] ?? target.name
         let sanitizedTargetName = PackageInfoMapper.sanitize(targetName: targetName)
         let effectiveModuleName = PackageInfoMapper.effectiveModuleName(
-            targetName: target.name, products: products, packageTargets: packageInfo.targets
+            targetName: target.name, products: products, targetsByName: targetsByName
         )
         let aliasedEffectiveModuleName = packageModuleAliases[packageInfo.name]?[effectiveModuleName] ?? effectiveModuleName
         let moduleName = PackageInfoMapper.sanitize(targetName: aliasedEffectiveModuleName)
             .replacingOccurrences(of: "-", with: "_")
         let effectiveProductName = PackageInfoMapper.effectiveProductName(
-            targetName: target.name, products: products, packageTargets: packageInfo.targets
+            targetName: target.name, products: products, targetsByName: targetsByName
         )
         let aliasedEffectiveProductName = packageModuleAliases[packageInfo.name]?[effectiveProductName] ?? effectiveProductName
         let productName = PackageInfoMapper.sanitize(targetName: aliasedEffectiveProductName)

--- a/cli/Sources/TuistSupport/Swift/SwiftVersionProvider.swift
+++ b/cli/Sources/TuistSupport/Swift/SwiftVersionProvider.swift
@@ -91,6 +91,7 @@ public struct SwiftVersionProvider: SwiftVersionProviding {
 
 private actor AsyncThrowableCaching<T: Sendable> {
     private var cachedValue: T?
+    private var inFlightTask: Task<T, Error>?
     private let builder: @Sendable () async throws -> T
 
     init(_ builder: @Sendable @escaping () async throws -> T) {
@@ -101,8 +102,22 @@ private actor AsyncThrowableCaching<T: Sendable> {
         if let cachedValue {
             return cachedValue
         }
-        let realizedValue = try await builder()
-        cachedValue = realizedValue
-        return realizedValue
+        // Coalesce concurrent first-callers onto a single task. Storing the task synchronously
+        // (before any suspension point) ensures callers that arrive while the builder is running
+        // await the same result instead of each kicking off a duplicate `builder()`.
+        if let inFlightTask {
+            return try await inFlightTask.value
+        }
+        let task = Task { try await builder() }
+        inFlightTask = task
+        do {
+            let realizedValue = try await task.value
+            cachedValue = realizedValue
+            inFlightTask = nil
+            return realizedValue
+        } catch {
+            inFlightTask = nil
+            throw error
+        }
     }
 }


### PR DESCRIPTION
> Reported internally: `tuist generate` hangs for a very long time on a project that depends on the AWS SDK for Swift (~800 targets in one SwiftPM package). The last visible output is the per-target `Target … of type test ignored` lines, then a long silent stall. It was fast on 4.152.0 and slow on 4.192.0+.

## What changed

Two fixes in `PackageInfoMapper`'s mapping path, both of which scale with the number of targets in an external SwiftPM package:

1. **`SwiftVersionProvider` — dedupe concurrent `swiftVersion()` calls (the dominant fix).** `map(target:)` runs over every package target via `concurrentCompactMap`, and each regular/test target calls `SwiftVersionProvider.current.swiftVersion()`. That value is cached by the `AsyncThrowableCaching` actor, but its `value()` checked `cachedValue` and *then* `await`ed `builder()` — the cache is only populated after the await resolves, so all concurrent first-callers pass the nil check before any of them caches. With ~800 concurrently-mapped targets this fans out into ~800 concurrent `xcrun swift --version` launches for one invariant value. The actor now coalesces callers onto a single `Task` stored synchronously before the first suspension point, so only one subprocess runs.

2. **`PackageInfoMapper` — reuse the package targets dictionary in name resolution (secondary).** `wrapsProductNamedFramework` (called from `effectiveModuleName`/`effectiveProductName`, 2-3× per target) rebuilt a `Dictionary` over all package targets on every call — O(T²) per package, copying the heavy `PackageInfo.Target` value type repeatedly. The dictionary that `map(packageInfo:)` already builds is now threaded through; the traversal logic and resolved names are unchanged.

## Why / root cause

The regression came from `swiftVersion()` being converted from synchronous (which deduplicated naturally) to async behind an actor cache that doesn't coalesce in-flight requests. The signature is a huge **sys time** from process spawning (forking ~800 `swift --version`). The O(T²) dictionary rebuild was a real-but-minor second contributor that PR #10309 amplified by removing the early-return guards in the common `target == product` case.

The "obvious" suspect (the O(T²) mapper) turned out to be the minor one — profiling the reproducer is what surfaced the subprocess storm as the dominant cost.

## How to test locally

Reproduced and validated with a synthetic local SwiftPM package of 800 single-target/single-product modules (each module's target name equals its product name, all depending on a shared `Runtime`), with the app depending on a single external so that mapping processes all 800 targets while generation stays small. Measured with `/usr/bin/time -l tuist generate --no-open` and `sample`:

| | wall | user CPU | sys |
|---|---|---|---|
| before (4.198.1) | 14.6s | 70.9s | 31.1s |
| after | 2.6s | 1.75s | 1.1s |

~40× less user CPU and ~29× less sys time, back to the 4.152.0 baseline, with all 800 modules still mapped and the project generated identically. A profiler confirms the `wrapsProductNamedFramework`, `SwiftVersionProvider.swiftVersion`, and `CommandRunner.run` frames are gone after the change.

## Notes for reviewers

- A regression test asserting `SwiftVersionProvider` invokes its builder only once under N concurrent `swiftVersion()` calls would be a good guard; happy to add it.
- A smaller secondary cost remains (Regex-based `FileSystem.glob`/`expandBraces` runs per target, from the FileHandler→FileSystem migration). It lives in the external `tuist/FileSystem` package and is now a minor relative contributor — worth a separate look, out of scope here.