### PR TITLE
feat(cli): backport patch-release workflow + semver-correct latest-version

### DIFF
--- a/.github/workflows/cli-backport.yml
+++ b/.github/workflows/cli-backport.yml
@@ -1,0 +1,161 @@
+name: CLI Backport Release
+
+# Cut a patch release on an older CLI line (e.g. 4.192.x) without touching main
+# or moving the "latest" pointers (GitHub "Latest" badge, Homebrew formula).
+#
+# Prerequisite (done by a human/agent, outside CI): create the release branch
+# off the base tag and apply the fix(es) onto it, resolving any conflicts there:
+#
+#   git switch -c releases/4.192.x 4.192.0
+#   git cherry-pick <fix-sha>          # resolve conflicts here, not in CI
+#   git push -u origin releases/4.192.x
+#
+# Then dispatch this workflow (it lives on and runs from main) with
+# branch=releases/4.192.x. It derives the next PATCH version (patch only —
+# never a minor/major bump), builds the branch HEAD, and publishes the release.
+#
+# What runs from where: this workflow YAML and the reusable build/publish
+# workflow resolve from main (current tooling), while the source and build
+# scripts (cli:bundle, bundle-linux.sh, .xcode-version-releases,
+# Package.resolved, the TuistCacheEE submodule pointer) come from the checked-out
+# branch — i.e. the version being patched builds with its own scripts. If the
+# line's pinned Xcode is not on the macos-26 runner image (or the submodule
+# pointer no longer resolves), the build fails; that means the line is too old
+# to build on current infra.
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Release branch to cut from (e.g. releases/4.192.x)"
+        required: true
+        type: string
+      version:
+        description: "Optional explicit version override (must stay on the branch's major.minor)"
+        required: false
+        type: string
+        default: ""
+
+permissions:
+  contents: write
+  pull-requests: read
+  statuses: write
+  packages: write
+  # Capped down into the reusable workflow's release-cli job (which mints an
+  # OIDC token); a called workflow's job permissions can't exceed the caller's.
+  id-token: write
+
+concurrency:
+  # Shared with cli-release.yml so a backport and a normal release never create
+  # tags or push the Homebrew formula at the same time.
+  group: cli-publish
+  cancel-in-progress: false
+
+env:
+  MISE_VERSION: "2026.5.15"
+  MISE_GITHUB_TOKEN: ${{ secrets.TUIST_RELEASE_GITHUB_TOKEN || github.token }}
+  GITHUB_TOKEN: ${{ secrets.TUIST_RELEASE_GITHUB_TOKEN || github.token }}
+  MISE_GITHUB_ATTESTATIONS: 0
+
+jobs:
+  prepare:
+    name: Resolve backport version
+    runs-on: tuist-linux
+    timeout-minutes: 10
+    outputs:
+      version: ${{ steps.resolve.outputs.version }}
+      sha: ${{ steps.resolve.outputs.sha }}
+      changelog_from: ${{ steps.resolve.outputs.changelog_from }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch }}
+          fetch-depth: 0
+          token: ${{ secrets.TUIST_RELEASE_GITHUB_TOKEN }}
+      - id: resolve
+        env:
+          BRANCH: ${{ inputs.branch }}
+          VERSION_OVERRIDE: ${{ inputs.version }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          set -euo pipefail
+
+          # 1. Guard the ref: never cut a "patch" off main / the default branch.
+          if [ "$BRANCH" = "main" ] || [ "$BRANCH" = "$DEFAULT_BRANCH" ]; then
+            echo "::error::Refusing to backport from '$BRANCH'. Dispatch with a release branch (e.g. releases/4.192.x)." >&2
+            exit 1
+          fi
+
+          # 2. Latest CLI semver tag reachable from the branch HEAD. The
+          #    '[0-9]*' glob excludes scoped component tags (server@1.2.3 etc.).
+          BASE_TAG=$(git describe --tags --abbrev=0 --match '[0-9]*.[0-9]*.[0-9]*' HEAD 2>/dev/null || true)
+          if [ -z "$BASE_TAG" ]; then
+            echo "::error::No CLI semver tag is reachable from '$BRANCH'. Is it rooted on a CLI release?" >&2
+            exit 1
+          fi
+          if ! printf '%s' "$BASE_TAG" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::Nearest tag '$BASE_TAG' is not a bare CLI semver tag." >&2
+            exit 1
+          fi
+          MAJOR=$(printf '%s' "$BASE_TAG" | cut -d. -f1)
+          MINOR=$(printf '%s' "$BASE_TAG" | cut -d. -f2)
+
+          # 3. Force a PATCH bump off the highest tag on this line. Never use
+          #    git-cliff/--bumped-version (a feat: would bump minor/major).
+          LATEST_ON_LINE=$(git tag -l | grep -E "^${MAJOR}\.${MINOR}\.[0-9]+$" | sort -V | tail -n1)
+          LATEST_PATCH=$(printf '%s' "$LATEST_ON_LINE" | cut -d. -f3)
+          NEXT_VERSION="${MAJOR}.${MINOR}.$((LATEST_PATCH + 1))"
+
+          # 4. Optional explicit override, pinned to the same line and higher
+          #    than the latest existing tag on it.
+          if [ -n "$VERSION_OVERRIDE" ]; then
+            if ! printf '%s' "$VERSION_OVERRIDE" | grep -qE "^${MAJOR}\.${MINOR}\.[0-9]+$"; then
+              echo "::error::Override '$VERSION_OVERRIDE' must stay on ${MAJOR}.${MINOR}.x" >&2
+              exit 1
+            fi
+            HIGHEST=$(printf '%s\n%s\n' "$LATEST_ON_LINE" "$VERSION_OVERRIDE" | sort -V | tail -n1)
+            if [ "$HIGHEST" != "$VERSION_OVERRIDE" ] || [ "$VERSION_OVERRIDE" = "$LATEST_ON_LINE" ]; then
+              echo "::error::Override '$VERSION_OVERRIDE' must be greater than the latest tag on the line ($LATEST_ON_LINE)." >&2
+              exit 1
+            fi
+            NEXT_VERSION="$VERSION_OVERRIDE"
+          fi
+
+          # 5. Hard guard: a releases/<maj>.<min>.x branch must match the derived
+          #    line, and the computed tag must not already exist.
+          case "$BRANCH" in
+            releases/*.*.x)
+              BRANCH_LINE=${BRANCH#releases/}
+              BRANCH_LINE=${BRANCH_LINE%.x}
+              if [ "$BRANCH_LINE" != "${MAJOR}.${MINOR}" ]; then
+                echo "::error::Branch '$BRANCH' is line $BRANCH_LINE but HEAD resolves to ${MAJOR}.${MINOR}." >&2
+                exit 1
+              fi
+              ;;
+          esac
+          if git rev-parse --verify --quiet "refs/tags/${NEXT_VERSION}" >/dev/null; then
+            echo "::error::Tag ${NEXT_VERSION} already exists." >&2
+            exit 1
+          fi
+
+          SHA=$(git rev-parse HEAD)
+          echo "Backporting ${BASE_TAG} -> ${NEXT_VERSION} at ${SHA} (branch ${BRANCH})"
+          {
+            echo "version=${NEXT_VERSION}"
+            echo "sha=${SHA}"
+            echo "changelog_from=${BASE_TAG}"
+          } >> "$GITHUB_OUTPUT"
+
+  build-publish:
+    name: Build and publish backport
+    needs: prepare
+    uses: ./.github/workflows/cli-build-publish.yml
+    with:
+      version: ${{ needs.prepare.outputs.version }}
+      # An immutable SHA so every job (macOS build, Linux build, publish) builds
+      # and tags the identical commit, with no branch-advance race.
+      ref: ${{ needs.prepare.outputs.sha }}
+      changelog_from: ${{ needs.prepare.outputs.changelog_from }}
+      # Backports never move GitHub's "Latest" pointer or the Homebrew formula.
+      make_latest: false
+      update_homebrew: false
+    secrets: inherit

--- a/.github/workflows/cli-backport.yml
+++ b/.github/workflows/cli-backport.yml
@@ -3,12 +3,20 @@ name: CLI Backport Release
 # Cut a patch release on an older CLI line (e.g. 4.192.x) without touching main
 # or moving the "latest" pointers (GitHub "Latest" badge, Homebrew formula).
 #
-# Prerequisite (done by a human/agent, outside CI): create the release branch
-# off the base tag and apply the fix(es) onto it, resolving any conflicts there:
+# Prerequisite (done by humans/agents, outside CI): land the fix(es) on the
+# protected release branch via PR — never a direct push. CI never cherry-picks
+# and never resolves conflicts; that happens in the PR.
 #
+#   # 1. One-time: create the line's release branch off the base tag.
 #   git switch -c releases/4.192.x 4.192.0
-#   git cherry-pick <fix-sha>          # resolve conflicts here, not in CI
 #   git push -u origin releases/4.192.x
+#
+#   # 2. Cherry-pick the fix on a topic branch, then open a PR INTO the release
+#   #    branch (resolve any conflicts here). Review and merge it.
+#   git switch -c backport/<fix>-4.192.x releases/4.192.x
+#   git cherry-pick <fix-sha>
+#   git push -u origin backport/<fix>-4.192.x
+#   gh pr create --base releases/4.192.x --head backport/<fix>-4.192.x
 #
 # Then dispatch this workflow (it lives on and runs from main) with
 # branch=releases/4.192.x. It derives the next PATCH version (patch only —

--- a/.github/workflows/cli-backport.yml
+++ b/.github/workflows/cli-backport.yml
@@ -93,27 +93,46 @@ jobs:
             exit 1
           fi
 
-          # 2. Latest CLI semver tag reachable from the branch HEAD. The
-          #    '[0-9]*' glob excludes scoped component tags (server@1.2.3 etc.).
-          BASE_TAG=$(git describe --tags --abbrev=0 --match '[0-9]*.[0-9]*.[0-9]*' HEAD 2>/dev/null || true)
-          if [ -z "$BASE_TAG" ]; then
-            echo "::error::No CLI semver tag is reachable from '$BRANCH'. Is it rooted on a CLI release?" >&2
+          # 2. The branch must follow the releases/<major>.<minor>.x convention.
+          #    The line is taken from the branch name (authoritative), not
+          #    inferred from tags — a non-matching name (typo, arbitrary branch)
+          #    must never be allowed to publish an official CLI release.
+          if ! printf '%s' "$BRANCH" | grep -qE '^releases/[0-9]+\.[0-9]+\.x$'; then
+            echo "::error::Branch must be named releases/<major>.<minor>.x (got '$BRANCH')." >&2
             exit 1
           fi
-          if ! printf '%s' "$BASE_TAG" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
-            echo "::error::Nearest tag '$BASE_TAG' is not a bare CLI semver tag." >&2
-            exit 1
-          fi
-          MAJOR=$(printf '%s' "$BASE_TAG" | cut -d. -f1)
-          MINOR=$(printf '%s' "$BASE_TAG" | cut -d. -f2)
+          LINE=${BRANCH#releases/}; LINE=${LINE%.x}
+          MAJOR=${LINE%.*}
+          MINOR=${LINE#*.}
 
-          # 3. Force a PATCH bump off the highest tag on this line. Never use
-          #    git-cliff/--bumped-version (a feat: would bump minor/major).
+          # 3. Highest tag on the line (must exist).
           LATEST_ON_LINE=$(git tag -l | grep -E "^${MAJOR}\.${MINOR}\.[0-9]+$" | sort -V | tail -n1)
-          LATEST_PATCH=$(printf '%s' "$LATEST_ON_LINE" | cut -d. -f3)
+          if [ -z "$LATEST_ON_LINE" ]; then
+            echo "::error::No CLI release exists on line ${LINE}." >&2
+            exit 1
+          fi
+
+          # 4. The branch HEAD must be rooted exactly on that latest patch: the
+          #    nearest semver tag reachable from HEAD must equal LATEST_ON_LINE.
+          #    git describe only considers ancestors, so equality proves HEAD
+          #    descends from the line's latest patch and no newer patch exists
+          #    that the branch is missing. This rejects both a branch cut from an
+          #    older base (would build code missing shipped patches and publish a
+          #    downgrade, e.g. 4.192.5 from 4.192.0) and a branch whose HEAD sits
+          #    on a newer/other line than its name claims (main is linear, so a
+          #    releases/4.197.x rooted on 4.198.1 would otherwise slip through).
+          BASE_TAG=$(git describe --tags --abbrev=0 --match '[0-9]*.[0-9]*.[0-9]*' HEAD 2>/dev/null || true)
+          if [ "$BASE_TAG" != "$LATEST_ON_LINE" ]; then
+            echo "::error::Branch HEAD is rooted on '${BASE_TAG:-<none>}' but the latest release on line ${LINE} is ${LATEST_ON_LINE}. Recreate or rebase the branch on top of ${LATEST_ON_LINE} so the backport stacks on every shipped patch." >&2
+            exit 1
+          fi
+
+          # 5. Force a PATCH bump off the highest tag on the line. Never use
+          #    git-cliff/--bumped-version (a feat: would bump minor/major).
+          LATEST_PATCH=${LATEST_ON_LINE##*.}
           NEXT_VERSION="${MAJOR}.${MINOR}.$((LATEST_PATCH + 1))"
 
-          # 4. Optional explicit override, pinned to the same line and higher
+          # 6. Optional explicit override, pinned to the same line and higher
           #    than the latest existing tag on it.
           if [ -n "$VERSION_OVERRIDE" ]; then
             if ! printf '%s' "$VERSION_OVERRIDE" | grep -qE "^${MAJOR}\.${MINOR}\.[0-9]+$"; then
@@ -128,29 +147,18 @@ jobs:
             NEXT_VERSION="$VERSION_OVERRIDE"
           fi
 
-          # 5. Hard guard: a releases/<maj>.<min>.x branch must match the derived
-          #    line, and the computed tag must not already exist.
-          case "$BRANCH" in
-            releases/*.*.x)
-              BRANCH_LINE=${BRANCH#releases/}
-              BRANCH_LINE=${BRANCH_LINE%.x}
-              if [ "$BRANCH_LINE" != "${MAJOR}.${MINOR}" ]; then
-                echo "::error::Branch '$BRANCH' is line $BRANCH_LINE but HEAD resolves to ${MAJOR}.${MINOR}." >&2
-                exit 1
-              fi
-              ;;
-          esac
+          # 7. The computed tag must not already exist.
           if git rev-parse --verify --quiet "refs/tags/${NEXT_VERSION}" >/dev/null; then
             echo "::error::Tag ${NEXT_VERSION} already exists." >&2
             exit 1
           fi
 
           SHA=$(git rev-parse HEAD)
-          echo "Backporting ${BASE_TAG} -> ${NEXT_VERSION} at ${SHA} (branch ${BRANCH})"
+          echo "Backporting ${LATEST_ON_LINE} -> ${NEXT_VERSION} at ${SHA} (branch ${BRANCH})"
           {
             echo "version=${NEXT_VERSION}"
             echo "sha=${SHA}"
-            echo "changelog_from=${BASE_TAG}"
+            echo "changelog_from=${LATEST_ON_LINE}"
           } >> "$GITHUB_OUTPUT"
 
   build-publish:

--- a/.github/workflows/cli-build-publish.yml
+++ b/.github/workflows/cli-build-publish.yml
@@ -1,0 +1,240 @@
+name: CLI Build & Publish
+
+# Reusable build+publish pipeline for the CLI, shared by the normal release
+# (cli-release.yml) and the backport release (cli-backport.yml). The caller
+# computes the version and the exact commit to build; this workflow only builds,
+# packages, and publishes.
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: "Version string to stamp into the binary and tag (e.g. 4.192.1)"
+        required: true
+        type: string
+      ref:
+        description: "Resolved commit SHA to check out, build, and tag (not a branch name)"
+        required: true
+        type: string
+      changelog_from:
+        description: "Tag to diff release notes from; empty falls back to the latest CLI semver tag"
+        required: false
+        type: string
+        default: ""
+      make_latest:
+        description: "Whether GitHub marks this release as 'Latest'"
+        required: false
+        type: boolean
+        default: true
+      update_homebrew:
+        description: "Whether to trigger the Homebrew formula update"
+        required: false
+        type: boolean
+        default: true
+
+# Top-level env does not cross the workflow_call boundary, so it is redeclared
+# here rather than inherited from the caller.
+env:
+  MISE_VERSION: "2026.5.15"
+  MISE_GITHUB_TOKEN: ${{ secrets.TUIST_RELEASE_GITHUB_TOKEN || github.token }}
+  GITHUB_TOKEN: ${{ secrets.TUIST_RELEASE_GITHUB_TOKEN || github.token }}
+  TUIST_ENABLE_CACHING: "true"
+  MISE_GITHUB_ATTESTATIONS: 0
+
+jobs:
+  release-cli:
+    name: Release CLI
+    runs-on: macos-26
+    timeout-minutes: 75
+    permissions:
+      contents: write
+      id-token: write
+      pull-requests: read
+      statuses: write
+      packages: write
+    env:
+      GITHUB_TOKEN: ${{ secrets.TUIST_RELEASE_GITHUB_TOKEN }}
+    outputs:
+      release-notes: ${{ steps.release-notes.outputs.RELEASE_NOTES }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+          fetch-depth: 0
+          token: ${{ secrets.TUIST_RELEASE_GITHUB_TOKEN }}
+      - name: Select Xcode
+        run: sudo xcode-select -switch /Applications/Xcode_$(cat .xcode-version-releases).app
+      - uses: jdx/mise-action@v4.0.1
+        with:
+          version: ${{ env.MISE_VERSION }}
+          install_args: "tuist git-cliff 1password-cli"
+          cache: "false"
+          github_token: ${{ env.MISE_GITHUB_TOKEN }}
+      - name: Authenticate with Tuist
+        run: tuist auth login
+      - name: Setup Tuist
+        run: tuist setup
+      - name: Install Tuist dependencies
+        run: tuist install --force-resolved-versions
+      - name: Initialize TuistCacheEE submodule
+        env:
+          TUIST_GITHUB_TOKEN: ${{ secrets.TUIST_RELEASE_GITHUB_TOKEN }}
+        run: mise run --no-deps cli:ee
+      - name: Get release notes
+        id: release-notes
+        working-directory: cli
+        run: |
+          # Use the explicit changelog base when provided (backports pass the
+          # base tag); otherwise fall back to the latest CLI semver tag.
+          LATEST_VERSION="${{ inputs.changelog_from }}"
+          if [ -z "$LATEST_VERSION" ]; then
+            LATEST_VERSION=$(git tag -l | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -n1 || echo "0.0.0")
+          fi
+          echo "RELEASE_NOTES<<EOF" >> "$GITHUB_OUTPUT"
+          git cliff --include-path "cli/**/*" --include-path ".xcode-version-releases" --include-path "Package.swift" --include-path "Package.resolved" --config cliff.toml --repository "../" 2>/dev/null -- ${LATEST_VERSION}..HEAD | sed -n '/<!-- RELEASE NOTES START -->/,$p' | tail -n +2 >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
+      - name: Update version in Constants.swift
+        run: |
+          sed -i '' -e "s/@TaskLocal public static var version: String! = \".*\"/@TaskLocal public static var version: String! = \"${{ inputs.version }}\"/" "cli/Sources/TuistConstants/Constants.swift"
+
+      - name: Update CHANGELOG.md
+        working-directory: cli
+        # Use the authoritative version from the caller via --tag instead of
+        # --bump. Full-history --bump can't anchor on CLI tags that landed on
+        # non-cli commits (it filters them out), so it froze the top heading at
+        # an old version while real releases advanced.
+        run: git cliff --include-path "cli/**/*" --include-path ".xcode-version-releases" --include-path "Package.swift" --include-path "Package.resolved" --config cliff.toml --repository "../" --tag "${{ inputs.version }}" -o CHANGELOG.md 2>/dev/null
+
+      - name: Bundle CLI
+        run: mise run --no-deps cli:bundle
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+
+      - name: Upload CLI artifacts
+        id: upload
+        uses: actions/upload-artifact@v4
+        with:
+          name: cli-artifacts
+          path: |
+            cli/CHANGELOG.md
+            cli/Sources/TuistConstants/Constants.swift
+            mise.toml
+            build/ProjectDescription.xcframework.zip
+            build/tuist.zip
+            build/tuist.spec.json
+            build/SHASUMS256.txt
+            build/SHASUMS512.txt
+          retention-days: 1
+
+  release-cli-linux:
+    name: Release CLI (Linux ${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
+    container:
+      image: swift:6.2
+    timeout-minutes: 30
+    strategy:
+      matrix:
+        include:
+          - arch: x86_64
+            runner: ubuntu-latest
+          - arch: aarch64
+            runner: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+          token: ${{ secrets.TUIST_RELEASE_GITHUB_TOKEN }}
+
+      - name: Update version in Constants.swift
+        run: |
+          sed -i "s/@TaskLocal public static var version: String! = \".*\"/@TaskLocal public static var version: String! = \"${{ inputs.version }}\"/" "cli/Sources/TuistConstants/Constants.swift"
+
+      - name: Bundle CLI
+        run: ./mise/tasks/cli/bundle-linux.sh
+
+      - name: Upload CLI Linux artifacts
+        id: upload
+        uses: actions/upload-artifact@v4
+        with:
+          name: cli-linux-${{ matrix.arch }}-artifacts
+          path: |
+            build/tuist-linux-${{ matrix.arch }}.tar.gz
+            build/SHASUMS256.txt
+            build/SHASUMS512.txt
+          retention-days: 1
+
+  publish-cli:
+    name: Publish CLI release
+    needs: [release-cli, release-cli-linux]
+    if: needs.release-cli.result == 'success' && needs.release-cli-linux.result == 'success'
+    runs-on: tuist-linux
+    timeout-minutes: 15
+    env:
+      GITHUB_TOKEN: ${{ secrets.TUIST_RELEASE_GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+          fetch-depth: 0
+          token: ${{ secrets.TUIST_RELEASE_GITHUB_TOKEN }}
+      - uses: jdx/mise-action@v4.0.1
+        with:
+          version: ${{ env.MISE_VERSION }}
+          install_args: "git-cliff"
+          cache: "false"
+          github_token: ${{ env.MISE_GITHUB_TOKEN }}
+      - name: Download CLI artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: cli-artifacts
+      - name: Download CLI Linux x86_64 artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: cli-linux-x86_64-artifacts
+          path: build-linux-x86_64
+      - name: Download CLI Linux aarch64 artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: cli-linux-aarch64-artifacts
+          path: build-linux-aarch64
+      - name: Merge Linux artifacts into build directory
+        run: |
+          # Append Linux checksums to main checksum files
+          cat build-linux-x86_64/SHASUMS256.txt >> build/SHASUMS256.txt
+          cat build-linux-x86_64/SHASUMS512.txt >> build/SHASUMS512.txt
+          cat build-linux-aarch64/SHASUMS256.txt >> build/SHASUMS256.txt
+          cat build-linux-aarch64/SHASUMS512.txt >> build/SHASUMS512.txt
+          # Move Linux tarballs to build directory
+          mv build-linux-x86_64/tuist-linux-x86_64.tar.gz build/
+          mv build-linux-aarch64/tuist-linux-aarch64.tar.gz build/
+      - name: Create CLI GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          draft: false
+          repository: tuist/tuist
+          # Pin the tag to the exact commit that was built, passed in as a
+          # resolved SHA. github.sha would resolve to the caller's triggering
+          # commit under workflow_call (main HEAD for a backport), not the
+          # release branch we actually built.
+          target_commitish: ${{ inputs.ref }}
+          # Backports publish off an older line and must not move GitHub's
+          # "Latest" pointer; the caller passes "false" for those.
+          make_latest: ${{ inputs.make_latest }}
+          name: CLI ${{ inputs.version }}
+          tag_name: ${{ inputs.version }}
+          body: ${{ needs.release-cli.outputs.release-notes }}
+          files: |
+            build/tuist.zip
+            build/tuist-linux-x86_64.tar.gz
+            build/tuist-linux-aarch64.tar.gz
+            build/SHASUMS256.txt
+            build/SHASUMS512.txt
+            build/ProjectDescription.xcframework.zip
+            build/tuist.spec.json
+      - name: Trigger Homebrew Formula Update
+        # Skipped for backports: brew install tuist must keep pointing at the
+        # true latest version, never an older patched line.
+        if: ${{ inputs.update_homebrew }}
+        run: |
+          SHA256=$(cat build/SHASUMS256.txt | grep tuist.zip | awk '{print $1}')
+          mise run --no-deps cli:release:homebrew-formula --version "${{ inputs.version }}" --github-token "${{ secrets.TUIST_RELEASE_GITHUB_TOKEN }}" --sha256 "$SHA256"

--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -15,12 +15,17 @@ permissions:
   pull-requests: read
   statuses: write
   packages: write
+  # Required so the reusable cli-build-publish.yml's release-cli job can mint an
+  # OIDC token: a called workflow's job permissions are capped by the caller's.
+  id-token: write
 
 concurrency:
-  # Serialize CLI releases against each other (check-releases derives the
-  # next version from the latest cli tag), queueing rather than cancelling so
-  # each release publishes atomically.
-  group: cli-release-${{ github.ref }}
+  # Serialize all CLI publishing — normal releases AND backports — through one
+  # ref-independent group. check-releases derives the next version from the
+  # latest cli tag, and both paths create tags and push the Homebrew formula,
+  # so they must never run concurrently. Queue rather than cancel so each
+  # release publishes atomically. cli-backport.yml shares this group.
+  group: cli-publish
   cancel-in-progress: false
 
 env:
@@ -52,192 +57,15 @@ jobs:
       - id: check
         run: mise run release:check
 
-  release-cli:
-    name: Release CLI
+  build-publish:
+    name: Build and publish CLI
     needs: check-releases
     if: needs.check-releases.outputs.cli-should-release == 'true'
-    runs-on: macos-26
-    timeout-minutes: 75
-    permissions:
-      contents: write
-      id-token: write
-      pull-requests: read
-      statuses: write
-      packages: write
-    env:
-      GITHUB_TOKEN: ${{ secrets.TUIST_RELEASE_GITHUB_TOKEN }}
-    outputs:
-      artifacts-uploaded: ${{ steps.upload.outputs.uploaded }}
-      release-notes: ${{ steps.release-notes.outputs.RELEASE_NOTES }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          token: ${{ secrets.TUIST_RELEASE_GITHUB_TOKEN }}
-      - name: Select Xcode
-        run: sudo xcode-select -switch /Applications/Xcode_$(cat .xcode-version-releases).app
-      - uses: jdx/mise-action@v4.0.1
-        with:
-          version: ${{ env.MISE_VERSION }}
-          install_args: "tuist git-cliff 1password-cli"
-          cache: "false"
-          github_token: ${{ env.MISE_GITHUB_TOKEN }}
-      - name: Authenticate with Tuist
-        run: tuist auth login
-      - name: Setup Tuist
-        run: tuist setup
-      - name: Install Tuist dependencies
-        run: tuist install --force-resolved-versions
-      - name: Initialize TuistCacheEE submodule
-        env:
-          TUIST_GITHUB_TOKEN: ${{ secrets.TUIST_RELEASE_GITHUB_TOKEN }}
-        run: mise run --no-deps cli:ee
-      - name: Get release notes
-        id: release-notes
-        working-directory: cli
-        run: |
-          # Get the latest CLI version tag dynamically
-          LATEST_VERSION=$(git tag -l | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -n1 || echo "0.0.0")
-          echo "RELEASE_NOTES<<EOF" >> "$GITHUB_OUTPUT"
-          git cliff --include-path "cli/**/*" --include-path ".xcode-version-releases" --include-path "Package.swift" --include-path "Package.resolved" --config cliff.toml --repository "../" 2>/dev/null -- ${LATEST_VERSION}..HEAD | sed -n '/<!-- RELEASE NOTES START -->/,$p' | tail -n +2 >> "$GITHUB_OUTPUT"
-          echo "EOF" >> "$GITHUB_OUTPUT"
-
-      - name: Update version in Constants.swift
-        run: |
-          sed -i '' -e "s/@TaskLocal public static var version: String! = \".*\"/@TaskLocal public static var version: String! = \"${{ needs.check-releases.outputs.cli-next-version }}\"/" "cli/Sources/TuistConstants/Constants.swift"
-
-      - name: Update CHANGELOG.md
-        working-directory: cli
-        # Use the authoritative version from check-releases via --tag instead of
-        # --bump. Full-history --bump can't anchor on CLI tags that landed on
-        # non-cli commits (it filters them out), so it froze the top heading at
-        # an old version while real releases advanced.
-        run: git cliff --include-path "cli/**/*" --include-path ".xcode-version-releases" --include-path "Package.swift" --include-path "Package.resolved" --config cliff.toml --repository "../" --tag "${{ needs.check-releases.outputs.cli-next-version }}" -o CHANGELOG.md 2>/dev/null
-
-      - name: Bundle CLI
-        run: mise run --no-deps cli:bundle
-        env:
-          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-
-      - name: Upload CLI artifacts
-        id: upload
-        uses: actions/upload-artifact@v4
-        with:
-          name: cli-artifacts
-          path: |
-            cli/CHANGELOG.md
-            cli/Sources/TuistConstants/Constants.swift
-            mise.toml
-            build/ProjectDescription.xcframework.zip
-            build/tuist.zip
-            build/tuist.spec.json
-            build/SHASUMS256.txt
-            build/SHASUMS512.txt
-          retention-days: 1
-
-  release-cli-linux:
-    name: Release CLI (Linux ${{ matrix.arch }})
-    needs: check-releases
-    if: needs.check-releases.outputs.cli-should-release == 'true'
-    runs-on: ${{ matrix.runner }}
-    container:
-      image: swift:6.2
-    timeout-minutes: 30
-    strategy:
-      matrix:
-        include:
-          - arch: x86_64
-            runner: ubuntu-latest
-          - arch: aarch64
-            runner: ubuntu-24.04-arm
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.TUIST_RELEASE_GITHUB_TOKEN }}
-
-      - name: Update version in Constants.swift
-        run: |
-          sed -i "s/@TaskLocal public static var version: String! = \".*\"/@TaskLocal public static var version: String! = \"${{ needs.check-releases.outputs.cli-next-version }}\"/" "cli/Sources/TuistConstants/Constants.swift"
-
-      - name: Bundle CLI
-        run: ./mise/tasks/cli/bundle-linux.sh
-
-      - name: Upload CLI Linux artifacts
-        id: upload
-        uses: actions/upload-artifact@v4
-        with:
-          name: cli-linux-${{ matrix.arch }}-artifacts
-          path: |
-            build/tuist-linux-${{ matrix.arch }}.tar.gz
-            build/SHASUMS256.txt
-            build/SHASUMS512.txt
-          retention-days: 1
-
-  publish-cli:
-    name: Publish CLI release
-    needs: [check-releases, release-cli, release-cli-linux]
-    if: needs.check-releases.outputs.cli-should-release == 'true' && needs.release-cli.result == 'success' && needs.release-cli-linux.result == 'success'
-    runs-on: tuist-linux
-    timeout-minutes: 15
-    env:
-      GITHUB_TOKEN: ${{ secrets.TUIST_RELEASE_GITHUB_TOKEN }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          token: ${{ secrets.TUIST_RELEASE_GITHUB_TOKEN }}
-      - uses: jdx/mise-action@v4.0.1
-        with:
-          version: ${{ env.MISE_VERSION }}
-          install_args: "git-cliff"
-          cache: "false"
-          github_token: ${{ env.MISE_GITHUB_TOKEN }}
-      - name: Download CLI artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: cli-artifacts
-      - name: Download CLI Linux x86_64 artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: cli-linux-x86_64-artifacts
-          path: build-linux-x86_64
-      - name: Download CLI Linux aarch64 artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: cli-linux-aarch64-artifacts
-          path: build-linux-aarch64
-      - name: Merge Linux artifacts into build directory
-        run: |
-          # Append Linux checksums to main checksum files
-          cat build-linux-x86_64/SHASUMS256.txt >> build/SHASUMS256.txt
-          cat build-linux-x86_64/SHASUMS512.txt >> build/SHASUMS512.txt
-          cat build-linux-aarch64/SHASUMS256.txt >> build/SHASUMS256.txt
-          cat build-linux-aarch64/SHASUMS512.txt >> build/SHASUMS512.txt
-          # Move Linux tarballs to build directory
-          mv build-linux-x86_64/tuist-linux-x86_64.tar.gz build/
-          mv build-linux-aarch64/tuist-linux-aarch64.tar.gz build/
-      - name: Create CLI GitHub Release
-        uses: softprops/action-gh-release@v2
-        with:
-          draft: false
-          repository: tuist/tuist
-          # Pin the tag to the commit this run built, not main's HEAD. Without
-          # this, action-gh-release defaults target_commitish to the default
-          # branch, so a push landing during the run drifts the tag onto a
-          # newer commit than the one the release notes and binaries describe.
-          target_commitish: ${{ github.sha }}
-          name: CLI ${{ needs.check-releases.outputs.cli-next-version-number }}
-          tag_name: ${{ needs.check-releases.outputs.cli-next-version }}
-          body: ${{ needs.release-cli.outputs.release-notes }}
-          files: |
-            build/tuist.zip
-            build/tuist-linux-x86_64.tar.gz
-            build/tuist-linux-aarch64.tar.gz
-            build/SHASUMS256.txt
-            build/SHASUMS512.txt
-            build/ProjectDescription.xcframework.zip
-            build/tuist.spec.json
-      - name: Trigger Homebrew Formula Update
-        run: |
-          SHA256=$(cat build/SHASUMS256.txt | grep tuist.zip | awk '{print $1}')
-          mise run --no-deps cli:release:homebrew-formula --version "${{ needs.check-releases.outputs.cli-next-version }}" --github-token "${{ secrets.TUIST_RELEASE_GITHUB_TOKEN }}" --sha256 "$SHA256"
+    uses: ./.github/workflows/cli-build-publish.yml
+    with:
+      version: ${{ needs.check-releases.outputs.cli-next-version }}
+      # Build and tag the exact commit that triggered this run.
+      ref: ${{ github.sha }}
+      make_latest: true
+      update_homebrew: true
+    secrets: inherit

--- a/server/lib/tuist/docs/cli.ex
+++ b/server/lib/tuist/docs/cli.ex
@@ -73,7 +73,7 @@ defmodule Tuist.Docs.CLI do
   end
 
   defp fetch_latest_cli_tag do
-    url = "https://api.github.com/repos/#{@repo}/releases?per_page=20"
+    url = "https://api.github.com/repos/#{@repo}/releases?per_page=100"
 
     case Req.get(url, headers: @headers) do
       {:ok, %{status: 200, body: releases}} ->

--- a/server/lib/tuist/docs/cli.ex
+++ b/server/lib/tuist/docs/cli.ex
@@ -77,11 +77,14 @@ defmodule Tuist.Docs.CLI do
 
     case Req.get(url, headers: @headers) do
       {:ok, %{status: 200, body: releases}} ->
+        # Pick the highest-semver CLI release rather than the first one GitHub
+        # returns: the endpoint is ordered by publish date, so a backport patch
+        # published after a newer minor would otherwise win. Bare-semver CLI
+        # tags parse as a Version; scoped component tags ("server@1.2.3") don't.
         cli_release =
-          Enum.find(releases, fn release ->
-            tag = release["tag_name"] || ""
-            not String.contains?(tag, "@")
-          end)
+          releases
+          |> Enum.filter(&match?({:ok, _}, Version.parse(&1["tag_name"] || "")))
+          |> Enum.max_by(&Version.parse!(&1["tag_name"]), Version, fn -> nil end)
 
         case cli_release do
           nil -> {:error, :no_cli_release}

--- a/server/lib/tuist/github/releases.ex
+++ b/server/lib/tuist/github/releases.ex
@@ -80,7 +80,11 @@ defmodule Tuist.GitHub.Releases do
 
   defp req_releases do
     headers = github_auth_headers()
-    req_opts = [finch: Tuist.Finch, headers: headers] ++ Retry.retry_options()
+    # Request the API max (100) on a single page so the highest-semver CLI
+    # release isn't pushed off the page by component releases or backports
+    # published after it (the list is ordered by publish date and we take the
+    # semver-max from whatever we fetch).
+    req_opts = [finch: Tuist.Finch, headers: headers, params: [per_page: 100]] ++ Retry.retry_options()
 
     case Req.get(releases_url(), req_opts) do
       {:ok, %Req.Response{status: 200, body: releases}} ->

--- a/server/lib/tuist/github/releases.ex
+++ b/server/lib/tuist/github/releases.ex
@@ -38,14 +38,16 @@ defmodule Tuist.GitHub.Releases do
           [__MODULE__, "github_releases"] |> KeyValueStore.get() |> List.wrap()
         end
 
-      # Filter on tag_name, not name: CLI tags are bare semver (e.g. "4.196.0")
-      # while component tags are scoped (e.g. "runners-controller@0.11.0"). The
-      # human-readable `name` field never contains "@" (it is a title like
-      # "Runners Controller 0.11.0"), so filtering on name lets component
-      # releases through and the latest one wins regardless of type.
-      case Enum.find(releases, fn release ->
-             not String.contains?(release["tag_name"] || "", "@")
-           end) do
+      # Pick the highest-semver CLI release, not the first one GitHub returns.
+      # The releases endpoint is ordered by publish date, so a backport patch
+      # (e.g. 4.192.1) published after a newer minor (4.195.0) would otherwise
+      # be mistaken for the latest. CLI tags are bare semver ("4.196.0") while
+      # component tags are scoped ("runners-controller@0.11.0") and don't parse
+      # as a Version, so Version.parse/1 also filters those out.
+      releases
+      |> Enum.filter(&match?({:ok, _}, Version.parse(&1["tag_name"] || "")))
+      |> Enum.max_by(&Version.parse!(&1["tag_name"]), Version, fn -> nil end)
+      |> case do
         nil -> nil
         release -> map_release(release)
       end

--- a/server/test/tuist/github/releases_test.exs
+++ b/server/test/tuist/github/releases_test.exs
@@ -94,6 +94,39 @@ defmodule Tuist.GitHub.ReleasesTest do
       assert release.name == "CLI 4.196.0"
     end
 
+    test "returns the highest-semver release even when a lower backport was published most recently" do
+      # Given: GitHub orders releases by publish date, so a backport patch
+      # (4.192.1) cut after a newer minor (4.195.1) is listed first. The latest
+      # CLI version must be selected by semver, not by publish recency.
+      backport = %{
+        "published_at" => Timex.format!(DateTime.utc_now(), "{ISO:Extended}"),
+        "name" => "CLI 4.192.1",
+        "tag_name" => "4.192.1",
+        "html_url" => "https://github.com/tuist/tuist/releases/tag/4.192.1",
+        "assets" => []
+      }
+
+      newer = %{
+        "published_at" => Timex.format!(DateTime.add(DateTime.utc_now(), -7, :day), "{ISO:Extended}"),
+        "name" => "CLI 4.195.1",
+        "tag_name" => "4.195.1",
+        "html_url" => "https://github.com/tuist/tuist/releases/tag/4.195.1",
+        "assets" => []
+      }
+
+      releases_url = Releases.releases_url()
+
+      stub(Req, :get, fn ^releases_url, _opts ->
+        {:ok, %Req.Response{status: 200, body: [backport, newer]}}
+      end)
+
+      # When
+      release = Releases.get_latest_cli_release()
+
+      # Then
+      assert release.tag_name == "4.195.1"
+    end
+
     test "returns cached release when update: false and cache exists" do
       # Given
       published_at = DateTime.utc_now()


### PR DESCRIPTION
> Addresses a customer support request: teams pinned to an older CLI line need a fix that only shipped in a newer minor (which broke something else for them), with no way to get a patch on their current line.

## What changed

Two coupled pieces:

**1. A CLI backport patch-release mechanism** (release-branch model, Rails/Kubernetes-style)
- `cli-build-publish.yml` — new reusable (`workflow_call`) workflow extracted from `cli-release.yml`'s `release-cli` / `release-cli-linux` / `publish-cli` jobs. Both the normal release and the backport call it, so there is one source of truth and no drift.
- `cli-backport.yml` — new `workflow_dispatch` (runs from `main`) taking a release branch (e.g. `releases/4.192.x`) that a human/agent has already cherry-picked the fix(es) onto. It derives the next version by **force-bumping the patch only** (major.minor pinned to the branch's line, never a git-cliff minor/major bump), resolves the branch HEAD to an immutable SHA, and publishes with `make_latest=false` + `update_homebrew=false`.
- `cli-release.yml` — rewired to call the reusable workflow; normal-path behavior is unchanged.

**2. Semver-correct "latest CLI version" on the server** (hard prerequisite)
- `Tuist.GitHub.Releases.get_latest_cli_release/1` and `Tuist.Docs.CLI.fetch_latest_cli_tag/0` now select the **highest-semver** CLI release instead of the first one returned by GitHub.

## Why

The only way to deliver a fix to a customer on an old version was to push them to a newer minor that might break something else. A patch release on the old line (e.g. `4.192.1`) lets them stay on a known-good baseline and pick up only the fix.

## Root cause of the server fix

GitHub's `/releases` endpoint orders releases by **publish date**, and the server took the *first* CLI release in that list. A backport (`4.192.1`) is published *after* a newer minor (`4.195.x`) but is semantically lower, so it would be mistaken for "latest" — the dashboard banner, the deprecation-warning upgrade text, and the docs CLI spec would all regress to the backported version. Selecting by semver (bare-semver CLI tags parse as a `Version`; scoped component tags like `server@1.2.3` don't, so `Version.parse/1` also filters them out) fixes all three call sites.

## Design notes / alternatives

- **Release-branch + dispatch, not in-CI cherry-pick.** Conflict resolution lives on the branch (humans/agents own its contents); CI never cherry-picks. Matches how other projects backport.
- **Dispatch from `main` with a `branch` input**, not "on" the branch: GitHub resolves a `workflow_dispatch`'s file from the dispatched ref, and old release branches predate this feature, so they can't host the workflow.
- **`workflow_call` correctness:** top-level `env` is redeclared in the reusable workflow (it doesn't cross the boundary); `inputs.ref` is threaded into every checkout; the tag's `target_commitish` uses `inputs.ref` (a resolved SHA) rather than `github.sha`, which under `workflow_call` resolves to the caller's commit (main), not the backport branch. `cli-release.yml` gains top-level `id-token: write` (a called workflow's job permissions are capped by the caller's) and shares a ref-independent `cli-publish` concurrency group with the backport so the two never tag/publish concurrently.
- **mise needs no change.** mise resolves versions by semver from the tag list (scoped `@` tags filtered), not by publish date, so a backport slots into semver order and only wins its own line (`tuist@4.192`), never `tuist@4` or highest-semver latest. Proven live: the `4.192` line already carries `4.192.0`–`4.192.4` yet `tuist@4` resolves to the true latest. `make_latest=false` covers the one chronological path (bare `mise latest tuist`); `update_homebrew=false` keeps the Homebrew formula pointed at true latest.

## Impact

- New capability: cut a patch on any older CLI line without touching `main` or moving "latest" pointers.
- Customers can pin (`mise.toml: tuist = "4.192.5"`, or `tuist@4.192`) to get exactly the backport.
- Server stops mis-advertising a backport as the latest version.
- Operational caveat: a backport builds with that line's own scripts and pinned Xcode; if the line's `.xcode-version-releases` Xcode is not on the `macos-26` runner image, the build fails (signal that the line is too old for current infra). Documented in the `cli-backport.yml` header.

### How to test locally

Server fix (fast):

```
cd server
mix test test/tuist/github/releases_test.exs   # incl. new regression: 4.195.1 published before 4.192.1 -> 4.195.1 wins
mix test test/tuist/docs/cli_test.exs
```

Validation run in this PR: `releases_test.exs` 13/13, `docs/cli_test.exs` 8/8, `mix format --check` clean, `mix credo` no issues, `actionlint` 0 real findings on the three workflows (only pre-existing repo-wide `tuist-linux` label / shellcheck warnings, which CI does not gate).

Backport dry run (needs a pushed branch + dispatch): create a throwaway `releases/X.Y.x` branch off a recent tag with a trivial commit, dispatch `cli-backport.yml` with that `branch`, and confirm the derived version stays on the line's major.minor and bumps only the patch, the tag points at the branch HEAD (not `main`), the release is not marked "Latest", the Homebrew workflow is not dispatched, and `main` is untouched.
