### PR TITLE
chore(server): make Kura cache endpoints opt-in via feature flag

### DIFF
--- a/server/lib/tuist/accounts.ex
+++ b/server/lib/tuist/accounts.ex
@@ -1945,12 +1945,13 @@ defmodule Tuist.Accounts do
   @doc """
   Returns cache endpoint URLs for the given account handle.
 
-  Ready account Kura endpoints are preferred when present unless the account is
-  opted out through `:kura_cache_opt_out`. Kura servers mirror their public URL
-  into `account_cache_endpoints` only after the public endpoint is ready, so
-  clients do not need explicit opt-in once an account has an available server.
+  Kura endpoints are only returned when the account has explicitly opted in
+  through the `:kura_cache` flag and has at least one ready Kura endpoint.
+  Otherwise the previous custom endpoint and default endpoint fallback
+  behavior is preserved.
 
-  When there is no ready account Kura endpoint, custom endpoints are only returned when:
+  When the account is not opted in to Kura (or has no ready Kura endpoint),
+  custom endpoints are only returned when:
   - The account exists
   - The account is on the enterprise plan when Tuist-hosted
   - The account has `custom_cache_endpoints_enabled` set to `true`
@@ -2000,10 +2001,10 @@ defmodule Tuist.Accounts do
   defp custom_cache_endpoints(_), do: []
 
   defp kura_cache_endpoints(%Account{} = account) do
-    if FeatureFlags.kura_cache_opted_out?(account) do
-      []
-    else
+    if FeatureFlags.kura_cache_enabled?(account) do
       list_account_cache_endpoints(account, :kura)
+    else
+      []
     end
   end
 

--- a/server/lib/tuist/accounts.ex
+++ b/server/lib/tuist/accounts.ex
@@ -1943,42 +1943,48 @@ defmodule Tuist.Accounts do
   end
 
   @doc """
-  Returns cache endpoint URLs for the given account handle.
+  Returns cache endpoint URLs for the given account handle and cache technology.
 
-  Kura endpoints are only returned when the account has explicitly opted in
-  through the `:kura_cache` flag and has at least one ready Kura endpoint.
-  Otherwise the previous custom endpoint and default endpoint fallback
-  behavior is preserved.
+  The `technology` argument is driven by the `kura` client feature flag header.
+  When `:kura`, ready account Kura endpoints are returned only if the account
+  has the `:kura_cache` flag enabled. In every other case (technology is
+  `:default`, no opt-in, or no ready Kura endpoint), the custom and default
+  endpoint fallback behavior is preserved.
 
-  When the account is not opted in to Kura (or has no ready Kura endpoint),
-  custom endpoints are only returned when:
+  Custom endpoints are only returned when:
   - The account exists
   - The account is on the enterprise plan when Tuist-hosted
   - The account has `custom_cache_endpoints_enabled` set to `true`
   - The account has at least one custom cache endpoint configured
   """
-  def get_cache_endpoints_for_handle(account_handle) when is_binary(account_handle) do
+  def get_cache_endpoints_for_handle(account_handle, technology \\ :default)
+
+  def get_cache_endpoints_for_handle(account_handle, technology) when is_binary(account_handle) do
     if Environment.tuist_hosted?() do
-      hosted_cache_endpoints_for_handle(account_handle)
+      hosted_cache_endpoints_for_handle(account_handle, technology)
     else
       CacheEndpoints.active_endpoint_urls()
     end
   end
 
-  def get_cache_endpoints_for_handle(_), do: CacheEndpoints.active_endpoint_urls()
+  def get_cache_endpoints_for_handle(_, _), do: CacheEndpoints.active_endpoint_urls()
 
-  defp hosted_cache_endpoints_for_handle(account_handle) do
+  defp hosted_cache_endpoints_for_handle(account_handle, technology) do
     case get_account_by_handle(account_handle) do
-      %Account{} = account -> cache_endpoint_urls(account)
+      %Account{} = account -> cache_endpoint_urls(account, technology)
       _ -> CacheEndpoints.active_endpoint_urls()
     end
   end
 
-  defp cache_endpoint_urls(%Account{} = account) do
+  defp cache_endpoint_urls(%Account{} = account, :kura) do
     case kura_cache_endpoint_urls(account) do
       [] -> custom_cache_endpoint_urls(account)
       endpoints -> endpoints
     end
+  end
+
+  defp cache_endpoint_urls(%Account{} = account, :default) do
+    custom_cache_endpoint_urls(account)
   end
 
   defp custom_cache_endpoint_urls(%Account{} = account) do

--- a/server/lib/tuist/feature_flags.ex
+++ b/server/lib/tuist/feature_flags.ex
@@ -26,12 +26,13 @@ defmodule Tuist.FeatureFlags do
   end
 
   @doc """
-  Whether cache clients should avoid Kura endpoints for the given account.
+  Whether cache clients should use Kura endpoints for the given account.
   This is intentionally separate from `:kura`, which controls access to the
-  managed Kura UI and provisioning surface.
+  managed Kura UI and provisioning surface. Kura is opt-in: accounts continue
+  to use the default cache endpoints unless this flag is explicitly enabled.
   """
-  def kura_cache_opted_out?(account) do
-    FunWithFlags.enabled?(:kura_cache_opt_out, for: account)
+  def kura_cache_enabled?(account) do
+    FunWithFlags.enabled?(:kura_cache, for: account)
   end
 
   defimpl FunWithFlags.Actor, for: Tuist.Accounts.User do

--- a/server/lib/tuist_web/controllers/api/cache_controller.ex
+++ b/server/lib/tuist_web/controllers/api/cache_controller.ex
@@ -15,6 +15,7 @@ defmodule TuistWeb.API.CacheController do
   alias TuistWeb.API.Schemas.CacheCategory
   alias TuistWeb.API.Schemas.Error
   alias TuistWeb.Authentication
+  alias TuistWeb.Headers
 
   plug(
     TuistWeb.Plugs.CastAndValidate,
@@ -72,10 +73,18 @@ defmodule TuistWeb.API.CacheController do
   def endpoints(conn, params) do
     endpoints =
       params[:account_handle]
-      |> Accounts.get_cache_endpoints_for_handle()
+      |> Accounts.get_cache_endpoints_for_handle(technology(conn))
       |> Enum.reject(&is_nil/1)
 
     json(conn, %{endpoints: endpoints})
+  end
+
+  defp technology(conn) do
+    if Headers.get_client_feature_flag(conn, "kura") do
+      :kura
+    else
+      :default
+    end
   end
 
   operation(:access,

--- a/server/test/tuist/accounts_test.exs
+++ b/server/test/tuist/accounts_test.exs
@@ -4044,7 +4044,7 @@ defmodule Tuist.AccountsTest do
       assert Enum.sort(endpoints) == Enum.sort(["https://cache1.example.com", "https://cache2.example.com"])
     end
 
-    test "returns account Kura endpoints by default when the account has ready Kura endpoints" do
+    test "returns account Kura endpoints when the account is opted in and has ready Kura endpoints" do
       # Given
       stub(Environment, :tuist_hosted?, fn -> true end)
       user = AccountsFixtures.user_fixture()
@@ -4062,6 +4062,7 @@ defmodule Tuist.AccountsTest do
 
       default_endpoints = ["https://default.tuist.dev"]
       stub(Environment, :cache_endpoints, fn -> default_endpoints end)
+      stub(FeatureFlags, :kura_cache_enabled?, fn %{id: account_id} -> account_id == account.id end)
 
       # When
       endpoints = Accounts.get_cache_endpoints_for_handle(account.name)
@@ -4070,7 +4071,7 @@ defmodule Tuist.AccountsTest do
       assert endpoints == ["https://kura-cache.example.com"]
     end
 
-    test "returns custom endpoints when account is opted out of Kura cache endpoints" do
+    test "returns custom endpoints by default when the account is not opted in to Kura" do
       # Given
       stub(Environment, :tuist_hosted?, fn -> true end)
       user = AccountsFixtures.user_fixture()
@@ -4086,8 +4087,6 @@ defmodule Tuist.AccountsTest do
           technology: :kura
         })
 
-      stub(FeatureFlags, :kura_cache_opted_out?, fn %{id: account_id} -> account_id == account.id end)
-
       # When
       endpoints = Accounts.get_cache_endpoints_for_handle(account.name)
 
@@ -4095,7 +4094,7 @@ defmodule Tuist.AccountsTest do
       assert endpoints == ["https://custom-cache.example.com"]
     end
 
-    test "returns default endpoints when account is opted out of Kura and has no custom endpoints" do
+    test "returns default endpoints when the account is not opted in to Kura and has no custom endpoints" do
       # Given
       stub(Environment, :tuist_hosted?, fn -> true end)
       user = AccountsFixtures.user_fixture()
@@ -4108,8 +4107,6 @@ defmodule Tuist.AccountsTest do
           url: "https://kura-cache.example.com",
           technology: :kura
         })
-
-      stub(FeatureFlags, :kura_cache_opted_out?, fn %{id: account_id} -> account_id == account.id end)
 
       # When
       endpoints = Accounts.get_cache_endpoints_for_handle(account.name)

--- a/server/test/tuist/accounts_test.exs
+++ b/server/test/tuist/accounts_test.exs
@@ -4044,7 +4044,7 @@ defmodule Tuist.AccountsTest do
       assert Enum.sort(endpoints) == Enum.sort(["https://cache1.example.com", "https://cache2.example.com"])
     end
 
-    test "returns account Kura endpoints when the account is opted in and has ready Kura endpoints" do
+    test "returns account Kura endpoints when the client requests Kura and the account is opted in" do
       # Given
       stub(Environment, :tuist_hosted?, fn -> true end)
       user = AccountsFixtures.user_fixture()
@@ -4065,13 +4065,13 @@ defmodule Tuist.AccountsTest do
       stub(FeatureFlags, :kura_cache_enabled?, fn %{id: account_id} -> account_id == account.id end)
 
       # When
-      endpoints = Accounts.get_cache_endpoints_for_handle(account.name)
+      endpoints = Accounts.get_cache_endpoints_for_handle(account.name, :kura)
 
       # Then
       assert endpoints == ["https://kura-cache.example.com"]
     end
 
-    test "returns custom endpoints by default when the account is not opted in to Kura" do
+    test "returns custom endpoints when the client requests Kura but the account is not opted in" do
       # Given
       stub(Environment, :tuist_hosted?, fn -> true end)
       user = AccountsFixtures.user_fixture()
@@ -4086,6 +4086,31 @@ defmodule Tuist.AccountsTest do
           url: "https://kura-cache.example.com",
           technology: :kura
         })
+
+      # When
+      endpoints = Accounts.get_cache_endpoints_for_handle(account.name, :kura)
+
+      # Then
+      assert endpoints == ["https://custom-cache.example.com"]
+    end
+
+    test "returns custom endpoints when the client does not request Kura even if the account is opted in" do
+      # Given
+      stub(Environment, :tuist_hosted?, fn -> true end)
+      user = AccountsFixtures.user_fixture()
+      account = Accounts.get_account_from_user(user)
+      BillingFixtures.subscription_fixture(account_id: account.id, plan: :enterprise)
+      {:ok, account} = Accounts.update_account(account, %{custom_cache_endpoints_enabled: true})
+
+      {:ok, _} = Accounts.create_account_cache_endpoint(account, %{url: "https://custom-cache.example.com"})
+
+      {:ok, _} =
+        Accounts.create_account_cache_endpoint(account, %{
+          url: "https://kura-cache.example.com",
+          technology: :kura
+        })
+
+      stub(FeatureFlags, :kura_cache_enabled?, fn %{id: account_id} -> account_id == account.id end)
 
       # When
       endpoints = Accounts.get_cache_endpoints_for_handle(account.name)
@@ -4109,7 +4134,7 @@ defmodule Tuist.AccountsTest do
         })
 
       # When
-      endpoints = Accounts.get_cache_endpoints_for_handle(account.name)
+      endpoints = Accounts.get_cache_endpoints_for_handle(account.name, :kura)
 
       # Then
       assert endpoints == default_endpoints

--- a/server/test/tuist_web/controllers/api/cache_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/cache_controller_test.exs
@@ -14,6 +14,7 @@ defmodule TuistWeb.API.CacheControllerTest do
   alias TuistTestSupport.Fixtures.BillingFixtures
   alias TuistTestSupport.Fixtures.ProjectsFixtures
   alias TuistWeb.Authentication
+  alias TuistWeb.Headers
 
   setup do
     cache = String.to_atom(UUIDv7.generate())
@@ -137,7 +138,46 @@ defmodule TuistWeb.API.CacheControllerTest do
                ])
     end
 
-    test "returns ready account Kura endpoints when the account is opted in", %{conn: conn} do
+    test "returns ready account Kura endpoints when the client requests Kura and the account is opted in", %{
+      conn: conn
+    } do
+      # Given
+      stub(Tuist.Environment, :tuist_hosted?, fn -> true end)
+      user = AccountsFixtures.user_fixture()
+      account = Accounts.get_account_from_user(user)
+      BillingFixtures.subscription_fixture(account_id: account.id, plan: :enterprise)
+      {:ok, account} = Accounts.update_account(account, %{custom_cache_endpoints_enabled: true})
+
+      {:ok, _} =
+        Accounts.create_account_cache_endpoint(account, %{
+          url: "https://custom-cache.example.com"
+        })
+
+      {:ok, _} =
+        Accounts.create_account_cache_endpoint(account, %{
+          url: "https://kura-cache.example.com",
+          technology: :kura
+        })
+
+      stub(Tuist.Environment, :cache_endpoints, fn -> ["https://default-cache.example.com"] end)
+      stub(FeatureFlags, :kura_cache_enabled?, fn %{id: account_id} -> account_id == account.id end)
+
+      conn =
+        conn
+        |> Authentication.put_current_user(user)
+        |> Headers.put_client_feature_flags(["kura"])
+
+      # When
+      conn = get(conn, ~p"/api/cache/endpoints?account_handle=#{account.name}")
+
+      # Then
+      response = json_response(conn, 200)
+      assert response["endpoints"] == ["https://kura-cache.example.com"]
+    end
+
+    test "returns custom endpoints when the client does not request Kura even if the account is opted in", %{
+      conn: conn
+    } do
       # Given
       stub(Tuist.Environment, :tuist_hosted?, fn -> true end)
       user = AccountsFixtures.user_fixture()
@@ -166,10 +206,10 @@ defmodule TuistWeb.API.CacheControllerTest do
 
       # Then
       response = json_response(conn, 200)
-      assert response["endpoints"] == ["https://kura-cache.example.com"]
+      assert response["endpoints"] == ["https://custom-cache.example.com"]
     end
 
-    test "returns custom endpoints by default when the account is not opted in to Kura", %{conn: conn} do
+    test "returns custom endpoints when the client requests Kura but the account is not opted in", %{conn: conn} do
       # Given
       stub(Tuist.Environment, :tuist_hosted?, fn -> true end)
       user = AccountsFixtures.user_fixture()
@@ -190,7 +230,10 @@ defmodule TuistWeb.API.CacheControllerTest do
 
       stub(Tuist.Environment, :cache_endpoints, fn -> ["https://default-cache.example.com"] end)
 
-      conn = Authentication.put_current_user(conn, user)
+      conn =
+        conn
+        |> Authentication.put_current_user(user)
+        |> Headers.put_client_feature_flags(["kura"])
 
       # When
       conn = get(conn, ~p"/api/cache/endpoints?account_handle=#{account.name}")
@@ -222,7 +265,7 @@ defmodule TuistWeb.API.CacheControllerTest do
       assert response["endpoints"] == expected_endpoints
     end
 
-    test "returns Kura endpoints when the account is opted in and has ready Kura endpoints", %{conn: conn} do
+    test "returns Kura endpoints when the client requests Kura and the account is opted in", %{conn: conn} do
       # Given
       user = AccountsFixtures.user_fixture()
       account = Accounts.get_account_from_user(user)
@@ -241,7 +284,10 @@ defmodule TuistWeb.API.CacheControllerTest do
 
       stub(FeatureFlags, :kura_cache_enabled?, fn %{id: account_id} -> account_id == account.id end)
 
-      conn = Authentication.put_current_user(conn, user)
+      conn =
+        conn
+        |> Authentication.put_current_user(user)
+        |> Headers.put_client_feature_flags(["kura"])
 
       # When
       conn = get(conn, ~p"/api/cache/endpoints?account_handle=#{account.name}")
@@ -253,7 +299,7 @@ defmodule TuistWeb.API.CacheControllerTest do
                Enum.sort(["https://kura-cache-1.example.com", "https://kura-cache-2.example.com"])
     end
 
-    test "returns the tuist account Kura endpoints when the account is opted in and has ready Kura endpoints", %{
+    test "returns the tuist account Kura endpoints when the client requests Kura and the account is opted in", %{
       conn: conn
     } do
       # Given
@@ -280,7 +326,10 @@ defmodule TuistWeb.API.CacheControllerTest do
 
       stub(FeatureFlags, :kura_cache_enabled?, fn %{id: account_id} -> account_id == account.id end)
 
-      conn = Authentication.put_current_user(conn, user)
+      conn =
+        conn
+        |> Authentication.put_current_user(user)
+        |> Headers.put_client_feature_flags(["kura"])
 
       # When
       conn = get(conn, ~p"/api/cache/endpoints?account_handle=tuist")

--- a/server/test/tuist_web/controllers/api/cache_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/cache_controller_test.exs
@@ -6,6 +6,7 @@ defmodule TuistWeb.API.CacheControllerTest do
   alias Tuist.Accounts.AuthenticatedAccount
   alias Tuist.API.Pipeline
   alias Tuist.CacheActionItems
+  alias Tuist.FeatureFlags
   alias Tuist.Projects.Workers.CleanProjectWorker
   alias Tuist.Repo
   alias Tuist.Storage
@@ -136,7 +137,39 @@ defmodule TuistWeb.API.CacheControllerTest do
                ])
     end
 
-    test "returns ready account Kura endpoints by default", %{conn: conn} do
+    test "returns ready account Kura endpoints when the account is opted in", %{conn: conn} do
+      # Given
+      stub(Tuist.Environment, :tuist_hosted?, fn -> true end)
+      user = AccountsFixtures.user_fixture()
+      account = Accounts.get_account_from_user(user)
+      BillingFixtures.subscription_fixture(account_id: account.id, plan: :enterprise)
+      {:ok, account} = Accounts.update_account(account, %{custom_cache_endpoints_enabled: true})
+
+      {:ok, _} =
+        Accounts.create_account_cache_endpoint(account, %{
+          url: "https://custom-cache.example.com"
+        })
+
+      {:ok, _} =
+        Accounts.create_account_cache_endpoint(account, %{
+          url: "https://kura-cache.example.com",
+          technology: :kura
+        })
+
+      stub(Tuist.Environment, :cache_endpoints, fn -> ["https://default-cache.example.com"] end)
+      stub(FeatureFlags, :kura_cache_enabled?, fn %{id: account_id} -> account_id == account.id end)
+
+      conn = Authentication.put_current_user(conn, user)
+
+      # When
+      conn = get(conn, ~p"/api/cache/endpoints?account_handle=#{account.name}")
+
+      # Then
+      response = json_response(conn, 200)
+      assert response["endpoints"] == ["https://kura-cache.example.com"]
+    end
+
+    test "returns custom endpoints by default when the account is not opted in to Kura", %{conn: conn} do
       # Given
       stub(Tuist.Environment, :tuist_hosted?, fn -> true end)
       user = AccountsFixtures.user_fixture()
@@ -164,7 +197,7 @@ defmodule TuistWeb.API.CacheControllerTest do
 
       # Then
       response = json_response(conn, 200)
-      assert response["endpoints"] == ["https://kura-cache.example.com"]
+      assert response["endpoints"] == ["https://custom-cache.example.com"]
     end
 
     test "returns default endpoints when account_handle does not exist",
@@ -189,7 +222,7 @@ defmodule TuistWeb.API.CacheControllerTest do
       assert response["endpoints"] == expected_endpoints
     end
 
-    test "returns Kura endpoints when account has ready Kura endpoints", %{conn: conn} do
+    test "returns Kura endpoints when the account is opted in and has ready Kura endpoints", %{conn: conn} do
       # Given
       user = AccountsFixtures.user_fixture()
       account = Accounts.get_account_from_user(user)
@@ -206,6 +239,8 @@ defmodule TuistWeb.API.CacheControllerTest do
           technology: :kura
         })
 
+      stub(FeatureFlags, :kura_cache_enabled?, fn %{id: account_id} -> account_id == account.id end)
+
       conn = Authentication.put_current_user(conn, user)
 
       # When
@@ -218,7 +253,9 @@ defmodule TuistWeb.API.CacheControllerTest do
                Enum.sort(["https://kura-cache-1.example.com", "https://kura-cache-2.example.com"])
     end
 
-    test "returns the tuist account Kura endpoints when the account has ready Kura endpoints", %{conn: conn} do
+    test "returns the tuist account Kura endpoints when the account is opted in and has ready Kura endpoints", %{
+      conn: conn
+    } do
       # Given
       user = AccountsFixtures.user_fixture()
       organization = AccountsFixtures.organization_fixture(name: "tuist", creator: user)
@@ -240,6 +277,8 @@ defmodule TuistWeb.API.CacheControllerTest do
           url: "https://kura-cache-2.example.com",
           technology: :kura
         })
+
+      stub(FeatureFlags, :kura_cache_enabled?, fn %{id: account_id} -> account_id == account.id end)
 
       conn = Authentication.put_current_user(conn, user)
 


### PR DESCRIPTION
Make Kura cache endpoints opt-in instead of preferred-by-default.

Previously, `Accounts.get_cache_endpoints_for_handle/1` preferred ready account Kura endpoints whenever they were present, with `:kura_cache_opt_out` as an escape hatch. This PR inverts the polarity: Kura endpoints are only returned when the account has explicitly opted in through the new `:kura_cache` feature flag. Without the opt-in, the previous custom endpoint and default endpoint fallback behavior is preserved, even when a ready Kura endpoint is already mirrored into `account_cache_endpoints`.

This lets us roll Kura out per-account on the cache control plane without flipping the default behavior for accounts that happen to have a Kura server provisioned.

### How to test locally

- `mix format --check-formatted lib/tuist/accounts.ex lib/tuist/feature_flags.ex test/tuist/accounts_test.exs test/tuist_web/controllers/api/cache_controller_test.exs`
- `mix test test/tuist/accounts_test.exs:4047 test/tuist/accounts_test.exs:4074 test/tuist/accounts_test.exs:4097 test/tuist_web/controllers/api/cache_controller_test.exs:140 test/tuist_web/controllers/api/cache_controller_test.exs:172 test/tuist_web/controllers/api/cache_controller_test.exs:225 test/tuist_web/controllers/api/cache_controller_test.exs:256 test/tuist_web/controllers/api/cache_controller_test.exs:295`
