### PR TITLE
Fix CI upload timeout handling

### DIFF
--- a/cli/Sources/TuistServer/Services/CreateCommandEventService.swift
+++ b/cli/Sources/TuistServer/Services/CreateCommandEventService.swift
@@ -30,29 +30,9 @@
     }
 
     public struct CreateCommandEventService: CreateCommandEventServicing {
-        private let retryProvider: RetryProviding
-
-        public init(
-            retryProvider: RetryProviding = RetryProvider()
-        ) {
-            self.retryProvider = retryProvider
-        }
+        public init() {}
 
         public func createCommandEvent(
-            commandEvent: CommandEvent,
-            projectId: String,
-            serverURL: URL
-        ) async throws -> ServerCommandEvent {
-            try await retryProvider.runWithRetries {
-                try await sendCreateCommandEvent(
-                    commandEvent: commandEvent,
-                    projectId: projectId,
-                    serverURL: serverURL
-                )
-            }
-        }
-
-        private func sendCreateCommandEvent(
             commandEvent: CommandEvent,
             projectId: String,
             serverURL: URL

--- a/infra/helm/tuist/templates/server-hpa.yaml
+++ b/infra/helm/tuist/templates/server-hpa.yaml
@@ -13,6 +13,10 @@ spec:
     name: {{ include "tuist.componentName" (dict "root" . "component" "server") }}
   minReplicas: {{ .Values.server.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.server.autoscaling.maxReplicas }}
+  {{- with .Values.server.autoscaling.behavior }}
+  behavior:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   metrics:
     {{- with .Values.server.autoscaling.targetCPUUtilizationPercentage }}
     - type: Resource

--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -56,6 +56,14 @@ server:
     maxReplicas: 5
     targetCPUUtilizationPercentage: 70
     targetMemoryUtilizationPercentage: 80
+    behavior:
+      scaleDown:
+        stabilizationWindowSeconds: 900
+        policies:
+          - type: Pods
+            value: 1
+            periodSeconds: 300
+        selectPolicy: Min
 
   podDisruptionBudget:
     enabled: true

--- a/infra/helm/tuist/values.yaml
+++ b/infra/helm/tuist/values.yaml
@@ -224,6 +224,10 @@ server:
     maxReplicas: 5
     targetCPUUtilizationPercentage: 70
     targetMemoryUtilizationPercentage: 80
+    # Optional autoscaling/v2 behavior block. Managed production uses this
+    # to dampen scale-down churn so in-flight HTTP requests are less likely
+    # to land on pods that are terminating.
+    behavior: {}
   podDisruptionBudget:
     enabled: false
     minAvailable: 1

--- a/server/lib/tuist_web/endpoint.ex
+++ b/server/lib/tuist_web/endpoint.ex
@@ -99,7 +99,7 @@ defmodule TuistWeb.Endpoint do
   # The /api/runs endpoint can receive large payloads (files, cacheable_tasks, cas_outputs)
   # for projects with thousands of files. 50MB should accommodate most projects.
   # TODO: Consider streaming large arrays instead of loading everything into memory.
-  plug Plug.Parsers,
+  plug TuistWeb.Plugs.RequestBodyParserPlug,
     parsers: [:urlencoded, :multipart, :json],
     pass: ["*/*"],
     json_decoder: Phoenix.json_library(),

--- a/server/lib/tuist_web/plugs/request_body_parser_plug.ex
+++ b/server/lib/tuist_web/plugs/request_body_parser_plug.ex
@@ -1,0 +1,28 @@
+defmodule TuistWeb.Plugs.RequestBodyParserPlug do
+  @moduledoc """
+  Wraps `Plug.Parsers` so request body timeouts become client-facing 408s.
+  """
+
+  @behaviour Plug
+
+  import Plug.Conn
+
+  @impl true
+  def init(options) do
+    Plug.Parsers.init(options)
+  end
+
+  @impl true
+  def call(conn, parser_opts) do
+    Plug.Parsers.call(conn, parser_opts)
+  rescue
+    error in Bandit.HTTPError ->
+      if error.plug_status == :request_timeout do
+        conn
+        |> send_resp(408, "Request Timeout")
+        |> halt()
+      else
+        reraise error, __STACKTRACE__
+      end
+  end
+end

--- a/server/test/tuist_web/plugs/request_body_parser_plug_test.exs
+++ b/server/test/tuist_web/plugs/request_body_parser_plug_test.exs
@@ -1,0 +1,88 @@
+defmodule TuistWeb.Plugs.RequestBodyParserPlugTest do
+  use ExUnit.Case, async: true
+
+  import Plug.Conn
+  import Plug.Test
+
+  alias TuistWeb.Plugs.RequestBodyParserPlug
+
+  defmodule TimeoutBodyReader do
+    @moduledoc false
+
+    def read_body(_conn, _opts) do
+      raise Bandit.HTTPError, message: "Body read timeout", plug_status: :request_timeout
+    end
+  end
+
+  defmodule InternalErrorBodyReader do
+    @moduledoc false
+
+    def read_body(_conn, _opts) do
+      raise Bandit.HTTPError, message: "Internal error", plug_status: :internal_server_error
+    end
+  end
+
+  test "parses request bodies with Plug.Parsers" do
+    # Given
+    opts =
+      RequestBodyParserPlug.init(
+        parsers: [:json],
+        json_decoder: Phoenix.json_library()
+      )
+
+    conn =
+      :post
+      |> conn("/", ~s({"name":"tuist"}))
+      |> put_req_header("content-type", "application/json")
+
+    # When
+    result = RequestBodyParserPlug.call(conn, opts)
+
+    # Then
+    assert result.body_params == %{"name" => "tuist"}
+    refute result.halted
+  end
+
+  test "returns 408 when the request body read times out" do
+    # Given
+    opts =
+      RequestBodyParserPlug.init(
+        parsers: [:json],
+        body_reader: {TimeoutBodyReader, :read_body, []},
+        json_decoder: Phoenix.json_library()
+      )
+
+    conn =
+      :post
+      |> conn("/", ~s({"name":"tuist"}))
+      |> put_req_header("content-type", "application/json")
+
+    # When
+    result = RequestBodyParserPlug.call(conn, opts)
+
+    # Then
+    assert result.status == 408
+    assert result.resp_body == "Request Timeout"
+    assert result.halted
+  end
+
+  test "reraises non-timeout Bandit HTTP errors" do
+    # Given
+    opts =
+      RequestBodyParserPlug.init(
+        parsers: [:json],
+        body_reader: {InternalErrorBodyReader, :read_body, []},
+        json_decoder: Phoenix.json_library()
+      )
+
+    conn =
+      :post
+      |> conn("/", ~s({"name":"tuist"}))
+      |> put_req_header("content-type", "application/json")
+
+    # When/Then
+    assert_raise Bandit.HTTPError, "Internal error", fn ->
+      RequestBodyParserPlug.call(conn, opts)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Return `408 Request Timeout` from the Phoenix body parser when Bandit raises a request body timeout during `Plug.Parsers`.
- Dampen production server HPA scale-down so fewer in-flight CI uploads are dropped during pod termination.
- Remove nested command-event retries in the CLI so analytics uploads rely on the shared OpenAPI retry middleware instead of multiplying attempts.

## Testing
- `mise run cli:lint --fix`
- `helm template tuist infra/helm/tuist -n tuist -f infra/helm/tuist/values-managed-common.yaml -f infra/helm/tuist/values-managed-production.yaml --set server.image.tag=test --set kuraController.image.tag=test --set kuraRuntime.image.tag=test --set runnersController.image.tag=test --set runnersFleet.enabled=false --set runnersFleetLinux.enabled=false --set buildersFleet.replicas=0 --set macosFleet.replicas=0`
- `mix format lib/tuist_web/endpoint.ex lib/tuist_web/plugs/request_body_parser_plug.ex test/tuist_web/plugs/request_body_parser_plug_test.exs`
- `MIX_ENV=test mix ecto.reset`
- `mix test test/tuist_web/plugs/request_body_parser_plug_test.exs`
- `git diff --check`
