### PR TITLE
fix(cli): retry run metadata upload on transient errors

### DIFF
--- a/cli/Sources/TuistServer/Services/CreateCommandEventService.swift
+++ b/cli/Sources/TuistServer/Services/CreateCommandEventService.swift
@@ -30,9 +30,29 @@
     }
 
     public struct CreateCommandEventService: CreateCommandEventServicing {
-        public init() {}
+        private let retryProvider: RetryProviding
+
+        public init(
+            retryProvider: RetryProviding = RetryProvider()
+        ) {
+            self.retryProvider = retryProvider
+        }
 
         public func createCommandEvent(
+            commandEvent: CommandEvent,
+            projectId: String,
+            serverURL: URL
+        ) async throws -> ServerCommandEvent {
+            try await retryProvider.runWithRetries {
+                try await sendCreateCommandEvent(
+                    commandEvent: commandEvent,
+                    projectId: projectId,
+                    serverURL: serverURL
+                )
+            }
+        }
+
+        private func sendCreateCommandEvent(
             commandEvent: CommandEvent,
             projectId: String,
             serverURL: URL


### PR DESCRIPTION
Backport of [#10842](https://github.com/tuist/tuist/pull/10842) to the `4.192.x` release line.

## What

Cherry-picks `5cece141d22` (originally [#10842](https://github.com/tuist/tuist/pull/10842)) onto `releases/4.192.x`. It wraps `CreateCommandEventService.createCommandEvent` in `RetryProvider.runWithRetries`, so run metadata / analytics uploads retry through transient upstream errors instead of failing the command.

## Why

CI runs on the `4.192` line surface intermittent `502` responses from `POST /api/analytics` and `POST /api/projects/.../runs/.../start`. The retry behavior shipped in `4.195.1`; this backports it so the `4.192` line tolerates the same transient errors without a forced minor upgrade.

## Notes

- Clean cherry-pick (1 file). `RetryProvider`/`RetryProviding` already exists on the `4.192.x` base (also used by `MultipartUploadArtifactService`), so it compiles unchanged.
- Targets the protected `releases/4.192.x` branch; merging requires 1 approval. Once this and the #11205 backport land, a `4.192.5` release is cut via the `cli-backport.yml` dispatch.
