### PR TITLE
fix(cli): Treat proto files as sources

### DIFF
--- a/cli/Sources/XcodeGraph/Sources/XcodeGraph/Models/Target.swift
+++ b/cli/Sources/XcodeGraph/Sources/XcodeGraph/Models/Target.swift
@@ -11,7 +11,7 @@ public struct Target: Equatable, Hashable, Comparable, Codable, Sendable {
         "playground", "rcproject", "mlpackage", "docc",
     ]
     public static let validSourceExtensions: [String] = [
-        "m", "swift", "mm", "cpp", "c++", "cc", "c", "d", "s", "intentdefinition", "metal", "mlmodel", "clp",
+        "m", "swift", "mm", "cpp", "c++", "cc", "c", "d", "s", "intentdefinition", "metal", "mlmodel", "clp", "proto",
     ]
     public static let validResourceExtensions: [String] = [
         // Resource


### PR DESCRIPTION
No linked issue.

Treat `.proto` files as valid source extensions so Tuist places protobuf definitions in Xcode's Sources phase instead of routing them through resource handling. This gives Xcode build tool plugins, including the gRPC Swift protobuf generator, the target input files they expect.

This PR intentionally does not add a synthetic build rule to suppress Xcode's `no rule to process file` warning. The plugin code generation works with `.proto` files in Sources, and suppressing that warning would be a separate workaround.

### How to test locally

- `swift build --package-path /Users/pepicrft/.superconductor/worktrees/tuist/sc-zero-phonon-a444 --replace-scm-with-registry`
- `/Users/pepicrft/.superconductor/worktrees/tuist/sc-zero-phonon-a444/.build/debug/tuist generate --path /tmp/tuist-grpc-static-framework-test --no-open`
- `xcodebuild build -project /tmp/tuist-grpc-static-framework-test/GrpcStaticFrameworkTest.xcodeproj -scheme GrpcModels -skipPackagePluginValidation CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""`

The static framework fixture builds successfully and compiles protobuf output generated from `HelloWorld.proto`. With the local Xcode installed on this machine, the generated project still emits Xcode's `.proto` `no rule to process file` warning.
