### PR TITLE
fix(server): re-arm flaky-test alerts when the condition clears, regardless of recovery

### DIFF
--- a/server/lib/tuist/automations/alerts/alert.ex
+++ b/server/lib/tuist/automations/alerts/alert.ex
@@ -6,7 +6,9 @@ defmodule Tuist.Automations.Alerts.Alert do
 
   alias Tuist.Projects.Project
 
-  @monitor_types ~w(flakiness_rate flaky_run_count reliability_rate test_updated)
+  @event_driven_monitor_types ~w(test_updated)
+  @recovery_ledger_monitor_types ~w(flakiness_rate flaky_run_count reliability_rate)
+  @monitor_types @recovery_ledger_monitor_types ++ @event_driven_monitor_types
   @comparisons ~w(gte gt lt lte)
   @valid_states ~w(enabled muted skipped)
   @test_updated_events ~w(
@@ -37,6 +39,25 @@ defmodule Tuist.Automations.Alerts.Alert do
   can apply the same constraint at the input level.
   """
   def max_rolling_window_size, do: @max_rolling_window_size
+
+  @doc """
+  Event-driven monitors (`test_updated`) fire from
+  `Tuist.Automations.dispatch_test_case_event/2` the instant a test case
+  changes and keep their own one-shot ledger. They are not scheduled and have
+  no dwell or recovery semantics. Accepts an alert struct or a monitor-type
+  string.
+  """
+  def event_driven?(%{monitor_type: monitor_type}), do: event_driven?(monitor_type)
+  def event_driven?(monitor_type), do: monitor_type in @event_driven_monitor_types
+
+  @doc """
+  Metric monitors evaluated by the scheduled `AlertEvaluationWorker` via
+  `FlakyTestsMonitor`. These drive the triggered/recovered ledger this worker
+  maintains (baseline, transition firing, re-arming). Accepts an alert struct
+  or a monitor-type string.
+  """
+  def recovery_ledger?(%{monitor_type: monitor_type}), do: recovery_ledger?(monitor_type)
+  def recovery_ledger?(monitor_type), do: monitor_type in @recovery_ledger_monitor_types
 
   @primary_key {:id, UUIDv7, autogenerate: true}
   @foreign_key_type UUIDv7

--- a/server/lib/tuist/automations/monitors/flaky_tests_monitor.ex
+++ b/server/lib/tuist/automations/monitors/flaky_tests_monitor.ex
@@ -41,7 +41,6 @@ defmodule Tuist.Automations.Monitors.FlakyTestsMonitor do
   import Ecto.Query
 
   alias Tuist.ClickHouseRepo
-  alias Tuist.Tests.TestCase
   alias Tuist.Tests.TestCaseRunDailyStatsPerCase
 
   @comparisons ~w(gte gt lt lte)
@@ -70,10 +69,7 @@ defmodule Tuist.Automations.Monitors.FlakyTestsMonitor do
           rolling_triggered_test_case_ids(project_id, "flakiness_rate", size, threshold, comparison, test_case_ids)
       end
 
-    %{
-      triggered: triggered_test_case_ids,
-      all: load_all_test_case_ids(project_id, alert.recovery_enabled, test_case_ids)
-    }
+    %{triggered: triggered_test_case_ids}
   end
 
   def evaluate_by_run_count(alert, test_case_ids \\ nil) do
@@ -94,10 +90,7 @@ defmodule Tuist.Automations.Monitors.FlakyTestsMonitor do
           rolling_triggered_test_case_ids(project_id, "flaky_run_count", size, threshold, comparison, test_case_ids)
       end
 
-    %{
-      triggered: triggered_test_case_ids,
-      all: load_all_test_case_ids(project_id, alert.recovery_enabled, test_case_ids)
-    }
+    %{triggered: triggered_test_case_ids}
   end
 
   def evaluate_by_reliability_rate(alert, test_case_ids \\ nil) do
@@ -118,10 +111,7 @@ defmodule Tuist.Automations.Monitors.FlakyTestsMonitor do
           rolling_triggered_test_case_ids(project_id, "reliability_rate", size, threshold, comparison, test_case_ids)
       end
 
-    %{
-      triggered: triggered_test_case_ids,
-      all: load_all_test_case_ids(project_id, alert.recovery_enabled, test_case_ids)
-    }
+    %{triggered: triggered_test_case_ids}
   end
 
   # The MV is keyed on `(project_id, date, test_case_id)`, so we round the
@@ -438,25 +428,6 @@ defmodule Tuist.Automations.Monitors.FlakyTestsMonitor do
 
   defp filter_test_case_ids(query, test_case_ids) do
     where(query, [row], row.test_case_id in ^test_case_ids)
-  end
-
-  defp load_all_test_case_ids(_project_id, false, _test_case_ids), do: []
-
-  defp load_all_test_case_ids(_project_id, _recovery_enabled, test_case_ids) when is_list(test_case_ids) do
-    test_case_ids
-  end
-
-  # `project_id` is the leading sort key; `DISTINCT` on `id` collapses
-  # duplicate row versions from unmerged parts cheaply, avoiding the
-  # multi-part full-row merge `FINAL` would force.
-  defp load_all_test_case_ids(project_id, _recovery_enabled, _test_case_ids) do
-    ClickHouseRepo.all(
-      from(tc in TestCase,
-        where: tc.project_id == ^project_id,
-        distinct: true,
-        select: tc.id
-      )
-    )
   end
 
   # Persisted alerts always carry an explicit `window_type` after the backfill

--- a/server/lib/tuist/automations/workers/alert_evaluation_worker.ex
+++ b/server/lib/tuist/automations/workers/alert_evaluation_worker.ex
@@ -15,13 +15,6 @@ defmodule Tuist.Automations.Workers.AlertEvaluationWorker do
 
   require Logger
 
-  # Re-arm dwell applied when recovery is disabled. There is no per-alert knob
-  # for this case (recovery_config is only validated when recovery is on), so a
-  # disabled alert always falls back to this fixed window. Kept explicit rather
-  # than relying on filter_recovered_candidates' default so the value is
-  # discoverable; revisit if a customer needs "never re-arm" or a faster one.
-  @disabled_recovery_rearm_window "14d"
-
   @impl Oban.Worker
   def perform(%Oban.Job{args: %{"alert_id" => alert_id} = args}) do
     case Automations.get_alert(alert_id) do
@@ -163,21 +156,19 @@ defmodule Tuist.Automations.Workers.AlertEvaluationWorker do
       |> reject_unevaluated_this_tick(scoped_test_case_ids)
 
     # Re-arming (appending the "recovered" event so the next rising edge can
-    # fire again) is unconditional — an alert that never re-arms is latched in
-    # `triggered` forever and silently stops acting. The dwell window and the
-    # undo side effects, however, stay opt-in: `Alert.changeset` only validates
-    # `recovery_config`/`recovery_actions` when recovery is enabled, so for a
-    # disabled alert we ignore the persisted (possibly stale) config — falling
-    # back to the default re-arm dwell — and run no undo actions. The test case
-    # re-arms but keeps its effect until a human clears it.
-    {recovery_config, recovery_actions} =
+    # fire again) happens for every alert once its condition clears — without
+    # it, an alert latches in `triggered` forever and silently stops acting.
+    # When recovery is enabled the user's dwell and undo actions apply; when
+    # it's disabled we re-arm the moment the condition clears (no dwell, no
+    # undo) and leave any effect in place until a human clears it. The
+    # persisted recovery_config is intentionally ignored on the disabled path
+    # because `Alert.changeset` only validates it when recovery is on.
+    {recovered, recovery_actions} =
       if alert.recovery_enabled do
-        {alert.recovery_config || %{}, alert.recovery_actions}
+        {filter_recovered_candidates(alert, candidates, alert.recovery_config || %{}), alert.recovery_actions}
       else
-        {%{"window" => @disabled_recovery_rearm_window}, []}
+        {candidates, []}
       end
-
-    recovered = filter_recovered_candidates(alert, candidates, recovery_config)
 
     Enum.each(recovered, fn event ->
       entity = %{type: :test_case, id: event.test_case_id}

--- a/server/lib/tuist/automations/workers/alert_evaluation_worker.ex
+++ b/server/lib/tuist/automations/workers/alert_evaluation_worker.ex
@@ -131,8 +131,18 @@ defmodule Tuist.Automations.Workers.AlertEvaluationWorker do
       end
     end)
 
-    handle_recovery(alert, triggered_ids, active_events, scoped_test_case_ids)
+    # Event-driven monitors (`test_updated`) have no triggered/recovered ledger
+    # — each event is a discrete one-shot (see
+    # `Automations.dispatch_test_case_event/2`). They never accrue `triggered`
+    # events through this worker, so recovery bookkeeping must not run for them,
+    # even if a monitor-type change left stale events behind.
+    if !event_driven_monitor?(alert) do
+      handle_recovery(alert, triggered_ids, active_events, scoped_test_case_ids)
+    end
   end
+
+  defp event_driven_monitor?(%{monitor_type: "test_updated"}), do: true
+  defp event_driven_monitor?(_alert), do: false
 
   defp active_alert_events(alert, nil), do: Automations.list_active_alert_events(alert.id)
 
@@ -141,22 +151,28 @@ defmodule Tuist.Automations.Workers.AlertEvaluationWorker do
 
   defp handle_recovery(alert, currently_triggered_ids, active_events, scoped_test_case_ids) do
     currently_triggered_set = MapSet.new(currently_triggered_ids)
-    recovery_config = alert.recovery_config || %{}
 
     candidates =
       active_events
       |> Enum.reject(&MapSet.member?(currently_triggered_set, &1.test_case_id))
       |> reject_unevaluated_this_tick(scoped_test_case_ids)
 
-    recovered = filter_recovered_candidates(alert, candidates, recovery_config)
-
     # Re-arming (appending the "recovered" event so the next rising edge can
     # fire again) is unconditional — an alert that never re-arms is latched in
-    # `triggered` forever and silently stops acting. The undo side effects are
-    # opt-in: only `recovery_enabled` alerts reverse their trigger actions
-    # (unmute, remove label). A recovery-disabled alert still re-arms but
-    # leaves its effect in place until a human clears it.
-    recovery_actions = if alert.recovery_enabled, do: alert.recovery_actions, else: []
+    # `triggered` forever and silently stops acting. The dwell window and the
+    # undo side effects, however, stay opt-in: `Alert.changeset` only validates
+    # `recovery_config`/`recovery_actions` when recovery is enabled, so for a
+    # disabled alert we ignore the persisted (possibly stale) config — falling
+    # back to the default re-arm dwell — and run no undo actions. The test case
+    # re-arms but keeps its effect until a human clears it.
+    {recovery_config, recovery_actions} =
+      if alert.recovery_enabled do
+        {alert.recovery_config || %{}, alert.recovery_actions}
+      else
+        {%{}, []}
+      end
+
+    recovered = filter_recovered_candidates(alert, candidates, recovery_config)
 
     Enum.each(recovered, fn event ->
       entity = %{type: :test_case, id: event.test_case_id}

--- a/server/lib/tuist/automations/workers/alert_evaluation_worker.ex
+++ b/server/lib/tuist/automations/workers/alert_evaluation_worker.ex
@@ -15,6 +15,13 @@ defmodule Tuist.Automations.Workers.AlertEvaluationWorker do
 
   require Logger
 
+  # Re-arm dwell applied when recovery is disabled. There is no per-alert knob
+  # for this case (recovery_config is only validated when recovery is on), so a
+  # disabled alert always falls back to this fixed window. Kept explicit rather
+  # than relying on filter_recovered_candidates' default so the value is
+  # discoverable; revisit if a customer needs "never re-arm" or a faster one.
+  @disabled_recovery_rearm_window "14d"
+
   @impl Oban.Worker
   def perform(%Oban.Job{args: %{"alert_id" => alert_id} = args}) do
     case Automations.get_alert(alert_id) do
@@ -131,18 +138,16 @@ defmodule Tuist.Automations.Workers.AlertEvaluationWorker do
       end
     end)
 
-    # Event-driven monitors (`test_updated`) have no triggered/recovered ledger
-    # — each event is a discrete one-shot (see
-    # `Automations.dispatch_test_case_event/2`). They never accrue `triggered`
-    # events through this worker, so recovery bookkeeping must not run for them,
-    # even if a monitor-type change left stale events behind.
-    if !event_driven_monitor?(alert) do
+    # Only metric monitors use this worker's scheduled triggered/recovered
+    # ledger. Event-driven (`test_updated`) monitors keep their own ledger via
+    # `Automations.dispatch_test_case_event/2` — discrete one-shots with no
+    # dwell or recovery — and unknown/legacy monitor types have no evaluator
+    # here, so neither participates in recovery. Gating positively also stops a
+    # monitor-type change from running recovery over stale `triggered` events.
+    if Alert.recovery_ledger?(alert) do
       handle_recovery(alert, triggered_ids, active_events, scoped_test_case_ids)
     end
   end
-
-  defp event_driven_monitor?(%{monitor_type: "test_updated"}), do: true
-  defp event_driven_monitor?(_alert), do: false
 
   defp active_alert_events(alert, nil), do: Automations.list_active_alert_events(alert.id)
 
@@ -169,7 +174,7 @@ defmodule Tuist.Automations.Workers.AlertEvaluationWorker do
       if alert.recovery_enabled do
         {alert.recovery_config || %{}, alert.recovery_actions}
       else
-        {%{}, []}
+        {%{"window" => @disabled_recovery_rearm_window}, []}
       end
 
     recovered = filter_recovered_candidates(alert, candidates, recovery_config)

--- a/server/lib/tuist/automations/workers/alert_evaluation_worker.ex
+++ b/server/lib/tuist/automations/workers/alert_evaluation_worker.ex
@@ -59,9 +59,9 @@ defmodule Tuist.Automations.Workers.AlertEvaluationWorker do
       triggered_ids = reject_unvalidated_test_cases(alert, triggered_ids)
       establish_baseline(alert, triggered_ids)
     else
-      %{triggered: triggered_ids, all: all_ids} = evaluate_monitor(alert, test_case_ids)
+      %{triggered: triggered_ids} = evaluate_monitor(alert, test_case_ids)
       triggered_ids = reject_unvalidated_test_cases(alert, triggered_ids)
-      run_transitions(alert, triggered_ids, all_ids, test_case_ids)
+      run_transitions(alert, triggered_ids, test_case_ids)
     end
 
     :ok
@@ -108,7 +108,7 @@ defmodule Tuist.Automations.Workers.AlertEvaluationWorker do
     {:ok, _} = Automations.establish_alert_baseline(alert)
   end
 
-  defp run_transitions(alert, triggered_ids, all_ids, scoped_test_case_ids) do
+  defp run_transitions(alert, triggered_ids, scoped_test_case_ids) do
     active_events = active_alert_events(alert, scoped_test_case_ids)
     already_triggered_ids = MapSet.new(active_events, & &1.test_case_id)
 
@@ -131,26 +131,32 @@ defmodule Tuist.Automations.Workers.AlertEvaluationWorker do
       end
     end)
 
-    if alert.recovery_enabled do
-      handle_recovery(alert, triggered_ids, active_events, all_ids)
-    end
+    handle_recovery(alert, triggered_ids, active_events, scoped_test_case_ids)
   end
 
   defp active_alert_events(alert, nil), do: Automations.list_active_alert_events(alert.id)
-  defp active_alert_events(alert, all_ids), do: Automations.list_active_alert_events(alert.id, all_ids)
 
-  defp handle_recovery(alert, currently_triggered_ids, active_events, all_ids) do
+  defp active_alert_events(alert, scoped_test_case_ids),
+    do: Automations.list_active_alert_events(alert.id, scoped_test_case_ids)
+
+  defp handle_recovery(alert, currently_triggered_ids, active_events, scoped_test_case_ids) do
     currently_triggered_set = MapSet.new(currently_triggered_ids)
-    all_ids_set = MapSet.new(all_ids)
     recovery_config = alert.recovery_config || %{}
 
     candidates =
-      Enum.filter(active_events, fn event ->
-        MapSet.member?(all_ids_set, event.test_case_id) and
-          not MapSet.member?(currently_triggered_set, event.test_case_id)
-      end)
+      active_events
+      |> Enum.reject(&MapSet.member?(currently_triggered_set, &1.test_case_id))
+      |> reject_unevaluated_this_tick(scoped_test_case_ids)
 
     recovered = filter_recovered_candidates(alert, candidates, recovery_config)
+
+    # Re-arming (appending the "recovered" event so the next rising edge can
+    # fire again) is unconditional — an alert that never re-arms is latched in
+    # `triggered` forever and silently stops acting. The undo side effects are
+    # opt-in: only `recovery_enabled` alerts reverse their trigger actions
+    # (unmute, remove label). A recovery-disabled alert still re-arms but
+    # leaves its effect in place until a human clears it.
+    recovery_actions = if alert.recovery_enabled, do: alert.recovery_actions, else: []
 
     Enum.each(recovered, fn event ->
       entity = %{type: :test_case, id: event.test_case_id}
@@ -159,7 +165,7 @@ defmodule Tuist.Automations.Workers.AlertEvaluationWorker do
       # flipped the order, a failure in the Slack ping / label removal /
       # state reset would leave the rule visually resolved while the user's
       # intended side effects never happened.
-      case ActionExecutor.execute_actions(alert.recovery_actions, alert, entity) do
+      case ActionExecutor.execute_actions(recovery_actions, alert, entity) do
         :ok ->
           now = NaiveDateTime.utc_now()
 
@@ -177,6 +183,18 @@ defmodule Tuist.Automations.Workers.AlertEvaluationWorker do
           )
       end
     end)
+  end
+
+  # A scoped evaluation only re-checked `scoped_test_case_ids`, so a triggered
+  # test case outside that set wasn't measured this tick — leave its event
+  # alone rather than treating "absent from the triggered set" as "cleared." A
+  # full evaluation (nil) re-checks every test case, so every active event is
+  # fair game.
+  defp reject_unevaluated_this_tick(candidates, nil), do: candidates
+
+  defp reject_unevaluated_this_tick(candidates, scoped_test_case_ids) do
+    evaluated = MapSet.new(scoped_test_case_ids)
+    Enum.filter(candidates, &MapSet.member?(evaluated, &1.test_case_id))
   end
 
   # In `last_days` mode the recovery cooldown is "wait this long without a
@@ -289,12 +307,12 @@ defmodule Tuist.Automations.Workers.AlertEvaluationWorker do
   # (see `Tuist.Automations.dispatch_test_case_event/2`), so the scheduled
   # evaluator has nothing to do for them.
   defp evaluate_monitor(%{monitor_type: "test_updated"}, _test_case_ids) do
-    %{triggered: [], all: []}
+    %{triggered: []}
   end
 
   defp evaluate_monitor(alert, _test_case_ids) do
     Logger.warning("Unknown monitor type: #{alert.monitor_type}")
-    %{triggered: [], all: []}
+    %{triggered: []}
   end
 
   defp scoped_test_case_ids(%{"test_case_ids" => test_case_ids}) when is_list(test_case_ids) do

--- a/server/lib/tuist/automations/workers/automation_scheduler.ex
+++ b/server/lib/tuist/automations/workers/automation_scheduler.ex
@@ -41,16 +41,22 @@ defmodule Tuist.Automations.Workers.AutomationScheduler do
     :ok
   end
 
-  defp scheduled_alert?(%{monitor_type: "test_updated"}), do: false
+  defp scheduled_alert?(alert) do
+    cond do
+      Alert.event_driven?(alert) -> false
+      rolling_with_baseline?(alert) -> false
+      true -> true
+    end
+  end
 
-  defp scheduled_alert?(%{
+  defp rolling_with_baseline?(%{
          monitor_type: monitor_type,
          trigger_config: %{"window_type" => "rolling"},
          baseline_established_at: %DateTime{}
        })
-       when monitor_type in ["flakiness_rate", "flaky_run_count", "reliability_rate"], do: false
+       when monitor_type in ["flakiness_rate", "flaky_run_count", "reliability_rate"], do: true
 
-  defp scheduled_alert?(_alert), do: true
+  defp rolling_with_baseline?(_alert), do: false
 
   defp cadence_seconds(cadence) when is_binary(cadence) do
     case Integer.parse(cadence) do

--- a/server/lib/tuist_web/live/project_automations_live.ex
+++ b/server/lib/tuist_web/live/project_automations_live.ex
@@ -549,8 +549,7 @@ defmodule TuistWeb.ProjectAutomationsLive do
 
   defp strip_redundant_actions(actions, _), do: actions
 
-  def event_driven_monitor_type?("test_updated"), do: true
-  def event_driven_monitor_type?(_), do: false
+  def event_driven_monitor_type?(monitor_type), do: Alert.event_driven?(monitor_type)
 
   defp parse_threshold(metric, value) when metric in ["flakiness_rate", "reliability_rate"] do
     case Float.parse(value) do

--- a/server/priv/gettext/dashboard_projects.pot
+++ b/server/priv/gettext/dashboard_projects.pot
@@ -622,7 +622,7 @@ msgstr ""
 msgid "Test duration"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:738
+#: lib/tuist_web/live/project_automations_live.ex:737
 #: lib/tuist_web/live/project_automations_live.html.heex:229
 #: lib/tuist_web/live/project_automations_live.html.heex:635
 #: lib/tuist_web/live/project_notifications_live.html.heex:392
@@ -1030,12 +1030,12 @@ msgstr ""
 msgid "Add automation"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:641
+#: lib/tuist_web/live/project_automations_live.ex:640
 #, elixir-autogen, elixir-format
 msgid "Add label"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:662
+#: lib/tuist_web/live/project_automations_live.ex:661
 #, elixir-autogen, elixir-format
 msgid "Add label: %{label}"
 msgstr ""
@@ -1051,7 +1051,7 @@ msgstr ""
 msgid "Available variables:"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:639
+#: lib/tuist_web/live/project_automations_live.ex:638
 #: lib/tuist_web/live/project_automations_live.html.heex:340
 #: lib/tuist_web/live/project_automations_live.html.heex:569
 #, elixir-autogen, elixir-format
@@ -1089,12 +1089,12 @@ msgstr ""
 msgid "Edit automation"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:631
+#: lib/tuist_web/live/project_automations_live.ex:630
 #, elixir-autogen, elixir-format
 msgid "Enable"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:636
+#: lib/tuist_web/live/project_automations_live.ex:635
 #: lib/tuist_web/live/project_automations_live.html.heex:420
 #: lib/tuist_web/live/project_automations_live.html.heex:708
 #, elixir-autogen, elixir-format
@@ -1107,13 +1107,13 @@ msgstr ""
 msgid "Enter message template..."
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:578
+#: lib/tuist_web/live/project_automations_live.ex:577
 #: lib/tuist_web/live/project_automations_live.html.heex:111
 #, elixir-autogen, elixir-format
 msgid "Flakiness rate"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:579
+#: lib/tuist_web/live/project_automations_live.ex:578
 #: lib/tuist_web/live/project_automations_live.html.heex:119
 #, elixir-autogen, elixir-format
 msgid "Flaky runs"
@@ -1147,12 +1147,12 @@ msgstr ""
 msgid "Recovery"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:642
+#: lib/tuist_web/live/project_automations_live.ex:641
 #, elixir-autogen, elixir-format
 msgid "Remove label"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:665
+#: lib/tuist_web/live/project_automations_live.ex:664
 #, elixir-autogen, elixir-format
 msgid "Remove label: %{label}"
 msgstr ""
@@ -1167,7 +1167,7 @@ msgstr ""
 msgid "Run these actions for each test case that meets the condition"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:640
+#: lib/tuist_web/live/project_automations_live.ex:639
 #: lib/tuist_web/live/project_automations_live.html.heex:379
 #: lib/tuist_web/live/project_automations_live.html.heex:433
 #: lib/tuist_web/live/project_automations_live.html.heex:608
@@ -1176,7 +1176,7 @@ msgstr ""
 msgid "Send Slack notification"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:659
+#: lib/tuist_web/live/project_automations_live.ex:658
 #, elixir-autogen, elixir-format
 msgid "Slack: not configured"
 msgstr ""
@@ -1202,12 +1202,12 @@ msgstr ""
 msgid "Trigger the automation when this condition is met"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:582
-#: lib/tuist_web/live/project_automations_live.ex:593
-#: lib/tuist_web/live/project_automations_live.ex:616
-#: lib/tuist_web/live/project_automations_live.ex:632
-#: lib/tuist_web/live/project_automations_live.ex:637
-#: lib/tuist_web/live/project_automations_live.ex:643
+#: lib/tuist_web/live/project_automations_live.ex:581
+#: lib/tuist_web/live/project_automations_live.ex:592
+#: lib/tuist_web/live/project_automations_live.ex:615
+#: lib/tuist_web/live/project_automations_live.ex:631
+#: lib/tuist_web/live/project_automations_live.ex:636
+#: lib/tuist_web/live/project_automations_live.ex:642
 #, elixir-autogen, elixir-format
 msgid "Unknown"
 msgstr ""
@@ -1245,24 +1245,24 @@ msgstr ""
 msgid "formatting."
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:629
+#: lib/tuist_web/live/project_automations_live.ex:628
 #, elixir-autogen, elixir-format
 msgid "Mute"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:634
+#: lib/tuist_web/live/project_automations_live.ex:633
 #: lib/tuist_web/live/project_automations_live.html.heex:402
 #: lib/tuist_web/live/project_automations_live.html.heex:717
 #, elixir-autogen, elixir-format
 msgid "Muted"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:630
+#: lib/tuist_web/live/project_automations_live.ex:629
 #, elixir-autogen, elixir-format
 msgid "Skip"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:635
+#: lib/tuist_web/live/project_automations_live.ex:634
 #: lib/tuist_web/live/project_automations_live.html.heex:411
 #: lib/tuist_web/live/project_automations_live.html.heex:726
 #, elixir-autogen, elixir-format
@@ -1274,52 +1274,52 @@ msgstr ""
 msgid "Comparison"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:626
+#: lib/tuist_web/live/project_automations_live.ex:625
 #, elixir-autogen, elixir-format
 msgid "Count"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:612
+#: lib/tuist_web/live/project_automations_live.ex:611
 #: lib/tuist_web/live/project_automations_live.html.heex:157
 #, elixir-autogen, elixir-format
 msgid "Greater or equal"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:613
+#: lib/tuist_web/live/project_automations_live.ex:612
 #: lib/tuist_web/live/project_automations_live.html.heex:165
 #, elixir-autogen, elixir-format
 msgid "Greater than"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:615
+#: lib/tuist_web/live/project_automations_live.ex:614
 #: lib/tuist_web/live/project_automations_live.html.heex:181
 #, elixir-autogen, elixir-format
 msgid "Less or equal"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:614
+#: lib/tuist_web/live/project_automations_live.ex:613
 #: lib/tuist_web/live/project_automations_live.html.heex:173
 #, elixir-autogen, elixir-format
 msgid "Less than"
 msgstr ""
 
+#: lib/tuist_web/live/project_automations_live.ex:623
 #: lib/tuist_web/live/project_automations_live.ex:624
-#: lib/tuist_web/live/project_automations_live.ex:625
 #, elixir-autogen, elixir-format
 msgid "Percent"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:627
+#: lib/tuist_web/live/project_automations_live.ex:626
 #, elixir-autogen, elixir-format
 msgid "Threshold"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:673
+#: lib/tuist_web/live/project_automations_live.ex:672
 #, elixir-autogen, elixir-format
 msgid "When flakiness rate %{symbol} %{threshold}% over %{window}"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:686
+#: lib/tuist_web/live/project_automations_live.ex:685
 #, elixir-autogen, elixir-format
 msgid "When flaky runs %{symbol} %{threshold} over %{window}"
 msgstr ""
@@ -1330,7 +1330,7 @@ msgstr ""
 msgid "Last N runs"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:739
+#: lib/tuist_web/live/project_automations_live.ex:738
 #: lib/tuist_web/live/project_automations_live.html.heex:221
 #: lib/tuist_web/live/project_automations_live.html.heex:625
 #, elixir-autogen, elixir-format
@@ -1348,42 +1348,42 @@ msgstr ""
 msgid "Window"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:726
+#: lib/tuist_web/live/project_automations_live.ex:725
 #, elixir-autogen, elixir-format
 msgid "the last %{size} runs"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:772
+#: lib/tuist_web/live/project_automations_live.ex:771
 #, elixir-autogen, elixir-format
 msgid "1–%{max}"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:596
+#: lib/tuist_web/live/project_automations_live.ex:595
 #, elixir-autogen, elixir-format
 msgid "Fires when a test is manually flagged as flaky."
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:605
+#: lib/tuist_web/live/project_automations_live.ex:604
 #, elixir-autogen, elixir-format
 msgid "Fires when a test is muted (still runs, failures ignored)."
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:608
+#: lib/tuist_web/live/project_automations_live.ex:607
 #, elixir-autogen, elixir-format
 msgid "Fires when a test is skipped entirely."
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:602
+#: lib/tuist_web/live/project_automations_live.ex:601
 #, elixir-autogen, elixir-format
 msgid "Fires when a test returns to the default enabled state."
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:599
+#: lib/tuist_web/live/project_automations_live.ex:598
 #, elixir-autogen, elixir-format
 msgid "Fires when the flaky flag is manually removed."
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:584
+#: lib/tuist_web/live/project_automations_live.ex:583
 #, elixir-autogen, elixir-format
 msgid "Marked as flaky"
 msgstr ""
@@ -1393,38 +1393,38 @@ msgstr ""
 msgid "On these events"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:587
+#: lib/tuist_web/live/project_automations_live.ex:586
 #, elixir-autogen, elixir-format
 msgid "State changed to Enabled"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:589
+#: lib/tuist_web/live/project_automations_live.ex:588
 #, elixir-autogen, elixir-format
 msgid "State changed to Muted"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:591
+#: lib/tuist_web/live/project_automations_live.ex:590
 #, elixir-autogen, elixir-format
 msgid "State changed to Skipped"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:581
+#: lib/tuist_web/live/project_automations_live.ex:580
 #: lib/tuist_web/live/project_automations_live.html.heex:135
 #, elixir-autogen, elixir-format
 msgid "Test updated"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:585
+#: lib/tuist_web/live/project_automations_live.ex:584
 #, elixir-autogen, elixir-format
 msgid "Unmarked as flaky"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:713
+#: lib/tuist_web/live/project_automations_live.ex:712
 #, elixir-autogen, elixir-format
 msgid "When a test is updated"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:717
+#: lib/tuist_web/live/project_automations_live.ex:716
 #, elixir-autogen, elixir-format
 msgid "When a test is updated: %{events}"
 msgstr ""
@@ -1434,13 +1434,13 @@ msgstr ""
 msgid "New Project"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:580
+#: lib/tuist_web/live/project_automations_live.ex:579
 #: lib/tuist_web/live/project_automations_live.html.heex:127
 #, elixir-autogen, elixir-format
 msgid "Test reliability"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:699
+#: lib/tuist_web/live/project_automations_live.ex:698
 #, elixir-autogen, elixir-format
 msgid "When test reliability across branches %{symbol} %{threshold}% over %{window}"
 msgstr ""

--- a/server/test/tuist/automations/alerts/alert_test.exs
+++ b/server/test/tuist/automations/alerts/alert_test.exs
@@ -628,4 +628,25 @@ defmodule Tuist.Automations.Alerts.AlertTest do
       assert "does not exist" in errors_on(changeset_with_error).project_id
     end
   end
+
+  describe "event_driven?/1 and recovery_ledger?/1" do
+    test "test_updated is event-driven and not part of the recovery ledger" do
+      assert Alert.event_driven?("test_updated")
+      assert Alert.event_driven?(%Alert{monitor_type: "test_updated"})
+      refute Alert.recovery_ledger?("test_updated")
+    end
+
+    test "metric monitors drive the recovery ledger and are not event-driven" do
+      for monitor_type <- ~w(flakiness_rate flaky_run_count reliability_rate) do
+        assert Alert.recovery_ledger?(monitor_type)
+        assert Alert.recovery_ledger?(%Alert{monitor_type: monitor_type})
+        refute Alert.event_driven?(monitor_type)
+      end
+    end
+
+    test "unknown monitor types are neither event-driven nor recovery-ledger" do
+      refute Alert.event_driven?("legacy_unknown")
+      refute Alert.recovery_ledger?("legacy_unknown")
+    end
+  end
 end

--- a/server/test/tuist/automations/workers/alert_evaluation_worker_test.exs
+++ b/server/test/tuist/automations/workers/alert_evaluation_worker_test.exs
@@ -365,11 +365,63 @@ defmodule Tuist.Automations.Workers.AlertEvaluationWorkerTest do
     assert :ok = run(automation.id)
   end
 
-  test "does not run recovery when recovery_enabled is false" do
+  test "re-arms a cleared test case but withholds recovery actions when recovery is disabled" do
+    automation =
+      AutomationsFixtures.automation_alert_fixture(
+        recovery_enabled: false,
+        recovery_actions: [%{"type" => "change_state", "state" => "enabled"}]
+      )
+
+    recovered_id = Ecto.UUID.generate()
+
+    expect(FlakyTestsMonitor, :evaluate, fn _automation ->
+      %{triggered: [], all: [recovered_id]}
+    end)
+
+    # Triggered long enough ago to clear the default 14d re-arm dwell.
+    triggered_long_ago = NaiveDateTime.add(NaiveDateTime.utc_now(), -30, :day)
+
+    expect(Automations, :list_active_alert_events, fn _id ->
+      [%{test_case_id: recovered_id, triggered_at: triggered_long_ago}]
+    end)
+
+    # The opt-in undo actions are withheld (empty list) even though the alert
+    # defines recovery_actions, because recovery is disabled.
+    expect(ActionExecutor, :execute_actions, fn actions, ^automation, %{type: :test_case, id: ^recovered_id} ->
+      assert actions == []
+      :ok
+    end)
+
+    # Re-arm bookkeeping still happens so the alert can fire again later.
+    expect(Automations, :create_alert_event, fn %{
+                                                  alert_id: id,
+                                                  test_case_id: ^recovered_id,
+                                                  status: "recovered"
+                                                } ->
+      assert id == automation.id
+      :ok
+    end)
+
+    assert :ok = run(automation.id)
+  end
+
+  test "does not re-arm a cleared test case until the dwell elapses, even with recovery disabled" do
     automation = AutomationsFixtures.automation_alert_fixture(recovery_enabled: false)
 
-    expect(FlakyTestsMonitor, :evaluate, fn _automation -> %{triggered: [], all: []} end)
-    expect(Automations, :list_active_alert_events, fn _id -> [] end)
+    recovered_id = Ecto.UUID.generate()
+
+    expect(FlakyTestsMonitor, :evaluate, fn _automation ->
+      %{triggered: [], all: [recovered_id]}
+    end)
+
+    # Triggered 1 day ago — inside the default 14d re-arm dwell.
+    triggered_recently = NaiveDateTime.add(NaiveDateTime.utc_now(), -1, :day)
+
+    expect(Automations, :list_active_alert_events, fn _id ->
+      [%{test_case_id: recovered_id, triggered_at: triggered_recently}]
+    end)
+
+    reject(&ActionExecutor.execute_actions/3)
     reject(&Automations.create_alert_event/1)
 
     assert :ok = run(automation.id)

--- a/server/test/tuist/automations/workers/alert_evaluation_worker_test.exs
+++ b/server/test/tuist/automations/workers/alert_evaluation_worker_test.exs
@@ -365,7 +365,7 @@ defmodule Tuist.Automations.Workers.AlertEvaluationWorkerTest do
     assert :ok = run(automation.id)
   end
 
-  test "re-arms a cleared test case but withholds recovery actions when recovery is disabled" do
+  test "re-arms a cleared test case immediately, without recovery actions, when recovery is disabled" do
     automation =
       AutomationsFixtures.automation_alert_fixture(
         recovery_enabled: false,
@@ -375,14 +375,15 @@ defmodule Tuist.Automations.Workers.AlertEvaluationWorkerTest do
     recovered_id = Ecto.UUID.generate()
 
     expect(FlakyTestsMonitor, :evaluate, fn _automation ->
-      %{triggered: [], all: [recovered_id]}
+      %{triggered: []}
     end)
 
-    # Triggered long enough ago to clear the default 14d re-arm dwell.
-    triggered_long_ago = NaiveDateTime.add(NaiveDateTime.utc_now(), -30, :day)
+    # Just triggered — with recovery off there is no dwell, so it re-arms as
+    # soon as the condition clears, no matter how recent the trigger is.
+    triggered_just_now = NaiveDateTime.utc_now()
 
     expect(Automations, :list_active_alert_events, fn _id ->
-      [%{test_case_id: recovered_id, triggered_at: triggered_long_ago}]
+      [%{test_case_id: recovered_id, triggered_at: triggered_just_now}]
     end)
 
     # The opt-in undo actions are withheld (empty list) even though the alert
@@ -392,7 +393,7 @@ defmodule Tuist.Automations.Workers.AlertEvaluationWorkerTest do
       :ok
     end)
 
-    # Re-arm bookkeeping still happens so the alert can fire again later.
+    # Re-arm bookkeeping happens so the alert can fire again later.
     expect(Automations, :create_alert_event, fn %{
                                                   alert_id: id,
                                                   test_case_id: ^recovered_id,
@@ -405,33 +406,11 @@ defmodule Tuist.Automations.Workers.AlertEvaluationWorkerTest do
     assert :ok = run(automation.id)
   end
 
-  test "does not re-arm a cleared test case until the dwell elapses, even with recovery disabled" do
-    automation = AutomationsFixtures.automation_alert_fixture(recovery_enabled: false)
-
-    recovered_id = Ecto.UUID.generate()
-
-    expect(FlakyTestsMonitor, :evaluate, fn _automation ->
-      %{triggered: [], all: [recovered_id]}
-    end)
-
-    # Triggered 1 day ago — inside the default 14d re-arm dwell.
-    triggered_recently = NaiveDateTime.add(NaiveDateTime.utc_now(), -1, :day)
-
-    expect(Automations, :list_active_alert_events, fn _id ->
-      [%{test_case_id: recovered_id, triggered_at: triggered_recently}]
-    end)
-
-    reject(&ActionExecutor.execute_actions/3)
-    reject(&Automations.create_alert_event/1)
-
-    assert :ok = run(automation.id)
-  end
-
-  test "ignores a persisted rolling recovery_config when recovery is disabled" do
+  test "never consults a persisted recovery_config when recovery is disabled" do
     # `Alert.changeset` only validates recovery_config when recovery is enabled,
-    # so a disabled alert can carry a stale rolling window. The worker must not
-    # honor it — using it would issue a runs-since-trigger query and apply the
-    # wrong dwell instead of the default re-arm fallback.
+    # so a disabled alert can carry a stale rolling window. The disabled path
+    # re-arms directly and must never reach filter_recovered_candidates, so the
+    # rolling runs-since-trigger query is never issued.
     automation =
       AutomationsFixtures.automation_alert_fixture(
         recovery_enabled: false,
@@ -444,15 +423,12 @@ defmodule Tuist.Automations.Workers.AlertEvaluationWorkerTest do
       %{triggered: []}
     end)
 
-    # Triggered 30d ago — past the default 14d fallback dwell, so it re-arms.
-    triggered_long_ago = NaiveDateTime.add(NaiveDateTime.utc_now(), -30, :day)
-
     expect(Automations, :list_active_alert_events, fn _id ->
-      [%{test_case_id: recovered_id, triggered_at: triggered_long_ago}]
+      [%{test_case_id: recovered_id, triggered_at: NaiveDateTime.utc_now()}]
     end)
 
-    # The rolling path would batch-query runs-since-trigger; the fallback dwell
-    # must not, proving the stale rolling config is ignored.
+    # No dwell evaluation at all on the disabled path → no runs-since-trigger
+    # query, proving the stale rolling config is ignored.
     reject(&ClickHouseRepo.all/1)
 
     expect(ActionExecutor, :execute_actions, fn actions, ^automation, %{type: :test_case, id: ^recovered_id} ->

--- a/server/test/tuist/automations/workers/alert_evaluation_worker_test.exs
+++ b/server/test/tuist/automations/workers/alert_evaluation_worker_test.exs
@@ -427,6 +427,66 @@ defmodule Tuist.Automations.Workers.AlertEvaluationWorkerTest do
     assert :ok = run(automation.id)
   end
 
+  test "ignores a persisted rolling recovery_config when recovery is disabled" do
+    # `Alert.changeset` only validates recovery_config when recovery is enabled,
+    # so a disabled alert can carry a stale rolling window. The worker must not
+    # honor it — using it would issue a runs-since-trigger query and apply the
+    # wrong dwell instead of the default re-arm fallback.
+    automation =
+      AutomationsFixtures.automation_alert_fixture(
+        recovery_enabled: false,
+        recovery_config: %{"window_type" => "rolling", "rolling_window_size" => 1000}
+      )
+
+    recovered_id = Ecto.UUID.generate()
+
+    expect(FlakyTestsMonitor, :evaluate, fn _automation ->
+      %{triggered: []}
+    end)
+
+    # Triggered 30d ago — past the default 14d fallback dwell, so it re-arms.
+    triggered_long_ago = NaiveDateTime.add(NaiveDateTime.utc_now(), -30, :day)
+
+    expect(Automations, :list_active_alert_events, fn _id ->
+      [%{test_case_id: recovered_id, triggered_at: triggered_long_ago}]
+    end)
+
+    # The rolling path would batch-query runs-since-trigger; the fallback dwell
+    # must not, proving the stale rolling config is ignored.
+    reject(&ClickHouseRepo.all/1)
+
+    expect(ActionExecutor, :execute_actions, fn actions, ^automation, %{type: :test_case, id: ^recovered_id} ->
+      assert actions == []
+      :ok
+    end)
+
+    expect(Automations, :create_alert_event, fn %{test_case_id: ^recovered_id, status: "recovered"} -> :ok end)
+
+    assert :ok = run(automation.id)
+  end
+
+  test "test_updated alerts skip recovery bookkeeping even with stale active triggered events" do
+    # A monitor-type change to test_updated can leave `triggered` events behind.
+    # Event-driven monitors have no recovery semantics, so those must never get
+    # a `recovered` event appended.
+    automation =
+      AutomationsFixtures.automation_alert_fixture(
+        monitor_type: "test_updated",
+        trigger_config: %{"events" => ["marked_flaky"]}
+      )
+
+    stale_id = Ecto.UUID.generate()
+
+    expect(Automations, :list_active_alert_events, fn _id ->
+      [%{test_case_id: stale_id, triggered_at: NaiveDateTime.add(NaiveDateTime.utc_now(), -30, :day)}]
+    end)
+
+    reject(&ActionExecutor.execute_actions/3)
+    reject(&Automations.create_alert_event/1)
+
+    assert :ok = run(automation.id)
+  end
+
   test "no-ops for event-driven test_updated alerts without invoking the monitor" do
     automation =
       AutomationsFixtures.automation_alert_fixture(


### PR DESCRIPTION
> Describe here the purpose of your PR.

## What this fixes

Automation alerts fire their trigger actions only on a **transition** into the triggered set:

```elixir
newly_triggered = triggered_ids \ already_triggered   # already_triggered = latest event is "triggered"
```

A test case leaves `already_triggered` only when a `recovered` event is appended — and today that append is gated entirely behind `recovery_enabled`. So a **recovery-disabled** alert (for example the default per-project "Flaky test detection") latches in `triggered` the first time a test case matches and never acts on it again, even after:

- the condition clears and later returns, or
- a *different* alert undoes the side effect (e.g. "Auto-mute flaky tests" recovery clearing `is_flaky`).

This surfaced on a real test case that kept flaking but was never re-marked: the alert responsible for marking it flaky was permanently latched, so it silently stopped acting.

## What changed

Re-arming (the bookkeeping that lets the next rising edge fire) is now **decoupled** from the opt-in undo actions:

- `handle_recovery` always runs. When a triggered test case clears its condition and the recovery dwell elapses, the alert appends a `recovered` event so it can fire again on the next rising edge.
- Undo side effects stay **opt-in**: only `recovery_enabled` alerts pass their `recovery_actions` (unmute, remove label). A recovery-disabled alert re-arms but leaves its effect in place until a human clears it — a legitimate, intentional config, not a bug.

### Why the recovery scope was reworked (avoiding a ClickHouse regression)

The recovery candidate set previously used the monitor's `all` field. For recovery-disabled alerts that field was `[]` (cheap); populating it would have meant a per-tick `SELECT DISTINCT id FROM test_cases` for **every project's default flaky alert**, because `AutomationScheduler` enqueues full evaluations for `last_days` alerts every cadence. Given the canary pool / alert-contention history, that's not acceptable.

Instead, the recovery scope is now derived from the worker's `scoped_test_case_ids`:

- **Scoped tick** → only re-arm test cases in the evaluated chunk.
- **Full tick** → every active event was measured, so all are fair game.

The `all` field was a no-op filter anyway (active events are always real test cases), so it and `load_all_test_case_ids` are removed entirely. Net result: **cheaper than before**, including for recovery-enabled alerts, with no new per-tick query.

## Notes for reviewers

- Re-arming still respects the recovery **dwell** (hysteresis) to avoid flapping re-fires on notification alerts. For recovery-disabled alerts with no `recovery_config` it falls back to the existing 14-day default — moot in practice for the affected alerts (Flaky-detection's condition only clears after 30d clean; Auto-disable's re-fire is an idempotent no-op).
- This fixes the **latching** class of bug (alerts that silently stop acting). It does not, by itself, re-mark a test whose condition never went false — that case is two alerts contending over the same `is_flaky` field, which is a separate single-writer / desired-state change.

### How to test locally

\`\`\`bash
cd server
mix test test/tuist/automations/workers/alert_evaluation_worker_test.exs \
         test/tuist/automations/monitors/flaky_tests_monitor_test.exs
\`\`\`

Validation run in this branch:

- `alert_evaluation_worker_test.exs` — 23 pass (incl. two new tests: re-arms-but-withholds-actions when recovery is disabled, and respects-the-dwell)
- `flaky_tests_monitor_test.exs` — 18 pass
- Full `test/tuist/automations/` — 113 pass
- `mix format --check-formatted` clean, `mix credo` no issues

## Behavior change / migration note

Before this change, `recovery_enabled: false` effectively meant "fire the trigger actions once, then stay latched forever." With re-arming decoupled from recovery, a recovery-disabled alert now re-arms **as soon as its condition no longer holds** (no dwell — recovery means exactly that). Practical impact:

- For idempotent trigger actions (mute, mark-flaky, disable) the re-fire is a no-op.
- For a **`send_slack`** trigger on a flaky condition, this introduces a re-ping on the natural flap cycle (each time the test goes clean and then flaky again). Anyone relying on the old fire-once behavior can move to `recovery_enabled: true` with empty `recovery_actions` to keep the alert latched until they act.
