### PR TITLE
fix(kura): run mgmt apply on GitHub-hosted runner

### DIFF
--- a/.github/workflows/mgmt-cluster-apply.yml
+++ b/.github/workflows/mgmt-cluster-apply.yml
@@ -59,7 +59,11 @@ permissions: {}
 jobs:
   apply:
     name: kubectl apply
-    runs-on: tuist-linux
+    # The self-hosted tuist-linux runners are customer runner Pods
+    # governed by a NetworkPolicy that only allows public egress on
+    # ports 80/443. The mgmt apiserver is reached on 6443, so this
+    # deploy job needs a GitHub-hosted runner outside that policy.
+    runs-on: ubuntu-latest
     environment:
       name: mgmt-cluster-apply
     # `kubectl diff` can be slow against the Cluster API CRDs when many


### PR DESCRIPTION
## What changed

- Moved the `Mgmt Cluster Apply` workflow from the self-hosted `tuist-linux` runner pool to `ubuntu-latest`.
- Added an inline comment explaining why the workflow must run outside the customer runner pod network policy.

## Why

The workflow applies Cluster API manifests to the management Kubernetes cluster, whose API server is reached on `178.105.79.109:6443`. The self-hosted `tuist-linux` runners run as customer runner pods and are governed by the runners namespace `NetworkPolicy`, which allows public egress on ports `80` and `443` only.

As a result, the workflow could fetch the repository and 1Password assets, but every `kubectl diff` and `kubectl apply` call timed out when connecting to the management API server on port `6443`.

## Impact

Future `Mgmt Cluster Apply` runs should be able to reach the management API server and apply the mgmt/CAPI manifests instead of timing out before validation.

## Validation

- `git diff --check`
- Parsed `.github/workflows/mgmt-cluster-apply.yml` with `/usr/bin/ruby` + `YAML.load_file`
- Confirmed the management API endpoint is reachable from this machine with `curl -k https://178.105.79.109:6443/version` returning `401`, narrowing the failure to the self-hosted runner path.
