### PR TITLE
fix(cli): resolve suite shard enumeration destination

### DIFF
--- a/cli/Sources/TuistKit/Services/TestService.swift
+++ b/cli/Sources/TuistKit/Services/TestService.swift
@@ -2045,7 +2045,7 @@ public struct TestService { // swiftlint:disable:this type_body_length
         case let .device(udid):
             return "\(platform.xcodebuildPlatformDestination),id=\(udid)"
         case .mac:
-            return try await simulatorController.macOSDestination()
+            return try await simulatorController.macOSDestination(catalyst: false)
         case .macCatalyst:
             return try await simulatorController.macOSDestination(catalyst: true)
         }

--- a/cli/Sources/TuistKit/Services/TestService.swift
+++ b/cli/Sources/TuistKit/Services/TestService.swift
@@ -1944,7 +1944,7 @@ public struct TestService { // swiftlint:disable:this type_body_length
             }
 
             let destinationVersion = xcodebuildDestinationParameter("OS", in: explicitDestination)?.version() ?? version
-            return try await concreteShardPlanDestination(
+            return await concreteShardPlanDestinationIfAvailable(
                 schemes: schemes,
                 platform: simulatorPlatform,
                 version: destinationVersion,
@@ -1955,40 +1955,50 @@ public struct TestService { // swiftlint:disable:this type_body_length
 
         if let platform {
             let buildPlatform = try XcodeGraph.Platform.from(commandLineValue: platform)
-            return try await concreteShardPlanDestination(
+            return await concreteShardPlanDestinationIfAvailable(
                 schemes: schemes,
                 platform: buildPlatform,
                 version: version,
                 deviceName: deviceName,
                 graphTraverser: graphTraverser
-            )
+            ) ?? buildPlatform.xcodebuildPlatformDestination
         }
 
-        for scheme in schemes {
-            guard let target = buildGraphInspector.testableTarget(
-                scheme: scheme,
-                testPlan: nil,
-                testTargets: [],
-                skipTestTargets: [],
-                graphTraverser: graphTraverser,
-                action: .build
-            ) else { continue }
+        if let inferredDestination = inferPlatformDestination(schemes: schemes, graphTraverser: graphTraverser) {
+            guard let inferredPlatform = xcodebuildPlatform(from: inferredDestination) else {
+                return inferredDestination
+            }
 
-            guard let resolvedPlatform = target.target.destinations.first?.platform,
-                  target.target.destinations.platforms.count == 1
-            else { continue }
+            return await concreteShardPlanDestinationIfAvailable(
+                schemes: schemes,
+                platform: inferredPlatform,
+                version: version,
+                deviceName: deviceName,
+                graphTraverser: graphTraverser
+            ) ?? inferredDestination
+        }
 
-            return try await xcodebuildDestination(
-                for: target,
-                scheme: scheme,
-                platform: resolvedPlatform,
+        return nil
+    }
+
+    private func concreteShardPlanDestinationIfAvailable(
+        schemes: [Scheme],
+        platform: XcodeGraph.Platform,
+        version: Version?,
+        deviceName: String?,
+        graphTraverser: GraphTraversing
+    ) async -> String? {
+        do {
+            return try await concreteShardPlanDestination(
+                schemes: schemes,
+                platform: platform,
                 version: version,
                 deviceName: deviceName,
                 graphTraverser: graphTraverser
             )
+        } catch {
+            return nil
         }
-
-        return nil
     }
 
     private func concreteShardPlanDestination(
@@ -2052,9 +2062,16 @@ public struct TestService { // swiftlint:disable:this type_body_length
     }
 
     private func simulatorPlatform(from destination: String) -> XcodeGraph.Platform? {
+        guard let platform = xcodebuildPlatform(from: destination), platform != .macOS else { return nil }
+        return platform
+    }
+
+    private func xcodebuildPlatform(from destination: String) -> XcodeGraph.Platform? {
         switch xcodebuildDestinationParameter("platform", in: destination)?.lowercased() {
         case "ios simulator":
             return .iOS
+        case "macos":
+            return .macOS
         case "tvos simulator":
             return .tvOS
         case "watchos simulator":
@@ -2080,7 +2097,7 @@ public struct TestService { // swiftlint:disable:this type_body_length
             guard pair.count == 2 else { continue }
 
             let key = pair[0].lowercased()
-            if key == expectedKey || key.hasSuffix("/\(expectedKey)") {
+            if key == expectedKey {
                 return pair[1]
             }
         }

--- a/cli/Sources/TuistKit/Services/TestService.swift
+++ b/cli/Sources/TuistKit/Services/TestService.swift
@@ -564,9 +564,14 @@ public struct TestService { // swiftlint:disable:this type_body_length
                 if isSharding,
                    let fullHandle = config.fullHandle
                 {
-                    let shardDestination = passedValue(for: "-destination", arguments: passthroughXcodeBuildArguments)
-                        ?? platform.map { "platform=\($0)" }
-                        ?? inferPlatformDestination(schemes: schemes, graphTraverser: graphTraverser)
+                    let shardDestination = try await shardPlanDestination(
+                        schemes: schemes,
+                        platform: platform,
+                        version: version,
+                        deviceName: deviceName,
+                        passthroughXcodeBuildArguments: passthroughXcodeBuildArguments,
+                        graphTraverser: graphTraverser
+                    )
 
                     let serverURL = try serverEnvironmentService.url(configServerURL: config.url)
                     let buildRunId = await RunMetadataStorage.current.buildRunId
@@ -1920,6 +1925,166 @@ public struct TestService { // swiftlint:disable:this type_body_length
 
             return resolvedPlatform.xcodebuildPlatformDestination
         }
+        return nil
+    }
+
+    private func shardPlanDestination(
+        schemes: [Scheme],
+        platform: String?,
+        version: Version?,
+        deviceName: String?,
+        passthroughXcodeBuildArguments: [String],
+        graphTraverser: GraphTraversing
+    ) async throws -> String? {
+        if let explicitDestination = passedValue(for: "-destination", arguments: passthroughXcodeBuildArguments) {
+            guard let simulatorPlatform = simulatorPlatform(from: explicitDestination),
+                  !hasConcreteDevice(in: explicitDestination)
+            else {
+                return explicitDestination
+            }
+
+            let destinationVersion = xcodebuildDestinationParameter("OS", in: explicitDestination)?.version() ?? version
+            return try await concreteShardPlanDestination(
+                schemes: schemes,
+                platform: simulatorPlatform,
+                version: destinationVersion,
+                deviceName: deviceName,
+                graphTraverser: graphTraverser
+            ) ?? explicitDestination
+        }
+
+        if let platform {
+            let buildPlatform = try XcodeGraph.Platform.from(commandLineValue: platform)
+            return try await concreteShardPlanDestination(
+                schemes: schemes,
+                platform: buildPlatform,
+                version: version,
+                deviceName: deviceName,
+                graphTraverser: graphTraverser
+            )
+        }
+
+        for scheme in schemes {
+            guard let target = buildGraphInspector.testableTarget(
+                scheme: scheme,
+                testPlan: nil,
+                testTargets: [],
+                skipTestTargets: [],
+                graphTraverser: graphTraverser,
+                action: .build
+            ) else { continue }
+
+            guard let resolvedPlatform = target.target.destinations.first?.platform,
+                  target.target.destinations.platforms.count == 1
+            else { continue }
+
+            return try await xcodebuildDestination(
+                for: target,
+                scheme: scheme,
+                platform: resolvedPlatform,
+                version: version,
+                deviceName: deviceName,
+                graphTraverser: graphTraverser
+            )
+        }
+
+        return nil
+    }
+
+    private func concreteShardPlanDestination(
+        schemes: [Scheme],
+        platform: XcodeGraph.Platform,
+        version: Version?,
+        deviceName: String?,
+        graphTraverser: GraphTraversing
+    ) async throws -> String? {
+        for scheme in schemes {
+            guard let target = buildGraphInspector.testableTarget(
+                scheme: scheme,
+                testPlan: nil,
+                testTargets: [],
+                skipTestTargets: [],
+                graphTraverser: graphTraverser,
+                action: .build
+            ) else { continue }
+
+            guard target.target.supportedPlatforms.contains(platform) else { continue }
+
+            return try await xcodebuildDestination(
+                for: target,
+                scheme: scheme,
+                platform: platform,
+                version: version,
+                deviceName: deviceName,
+                graphTraverser: graphTraverser
+            )
+        }
+
+        return platform.xcodebuildPlatformDestination
+    }
+
+    private func xcodebuildDestination(
+        for target: GraphTarget,
+        scheme: Scheme,
+        platform: XcodeGraph.Platform,
+        version: Version?,
+        deviceName: String?,
+        graphTraverser: GraphTraversing
+    ) async throws -> String {
+        let destination = try await XcodeBuildDestination.find(
+            for: target.target,
+            on: platform,
+            scheme: scheme,
+            version: version,
+            deviceName: deviceName,
+            graphTraverser: graphTraverser,
+            simulatorController: simulatorController
+        )
+
+        switch destination {
+        case let .device(udid):
+            return "\(platform.xcodebuildPlatformDestination),id=\(udid)"
+        case .mac:
+            return try await simulatorController.macOSDestination()
+        case .macCatalyst:
+            return try await simulatorController.macOSDestination(catalyst: true)
+        }
+    }
+
+    private func simulatorPlatform(from destination: String) -> XcodeGraph.Platform? {
+        switch xcodebuildDestinationParameter("platform", in: destination)?.lowercased() {
+        case "ios simulator":
+            return .iOS
+        case "tvos simulator":
+            return .tvOS
+        case "watchos simulator":
+            return .watchOS
+        case "visionos simulator":
+            return .visionOS
+        default:
+            return nil
+        }
+    }
+
+    private func hasConcreteDevice(in destination: String) -> Bool {
+        xcodebuildDestinationParameter("id", in: destination) != nil
+            || xcodebuildDestinationParameter("name", in: destination) != nil
+    }
+
+    private func xcodebuildDestinationParameter(_ parameter: String, in destination: String) -> String? {
+        let expectedKey = parameter.lowercased()
+        for component in destination.components(separatedBy: ",") {
+            let pair = component.split(separator: "=", maxSplits: 1).map {
+                String($0).trimmingCharacters(in: .whitespaces)
+            }
+            guard pair.count == 2 else { continue }
+
+            let key = pair[0].lowercased()
+            if key == expectedKey || key.hasSuffix("/\(expectedKey)") {
+                return pair[1]
+            }
+        }
+
         return nil
     }
 }

--- a/cli/Tests/TuistKitTests/Services/TestServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/TestServiceTests.swift
@@ -4964,8 +4964,8 @@ final class TestServiceTests: TuistUnitTestCase {
                 "-testProductsPath", testProductsPath.pathString,
                 "-destination", "platform=iOS Simulator",
             ],
-            shardTotal: 2,
-            shardGranularity: .suite
+            shardGranularity: .suite,
+            shardTotal: 2
         )
 
         // Then

--- a/cli/Tests/TuistKitTests/Services/TestServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/TestServiceTests.swift
@@ -4878,7 +4878,7 @@ final class TestServiceTests: TuistUnitTestCase {
         verify(shardPlanService)
             .plan(
                 xctestproductsPath: .value(testProductsPath),
-                destination: .value("platform=iOS"),
+                destination: .value("platform=iOS Simulator,id=3A8C9673-C1FD-4E33-8EFA-AEEBF43161CC"),
                 reference: .any,
                 shardGranularity: .any,
                 shardMin: .any,
@@ -4890,6 +4890,100 @@ final class TestServiceTests: TuistUnitTestCase {
                 buildRunId: .any,
                 skipUpload: .value(false),
                 archivePath: .value(shardArchivePath)
+            )
+            .called(1)
+    }
+
+    func test_run_build_resolvesPlatformOnlySimulatorDestinationForSuiteShardPlanning() async throws {
+        // Given
+        givenGenerator()
+        let path = try temporaryPath()
+        let testProductsPath = path.appending(component: "TestProducts.xctestproducts")
+        let projectPath = AbsolutePath.root.appending(component: "Project")
+        let scheme = Scheme.test(name: "ProjectScheme")
+        let graph: Graph = .test(
+            workspace: .test(schemes: [scheme]),
+            projects: [
+                projectPath: .test(
+                    path: projectPath,
+                    targets: [
+                        .test(name: "AppTests", product: .unitTests),
+                    ]
+                ),
+            ]
+        )
+        try await fileSystem.makeDirectory(at: testProductsPath)
+
+        given(configLoader)
+            .loadConfig(path: .any)
+            .willReturn(.test(project: .testGeneratedProject(), fullHandle: "tuist/tuist"))
+
+        given(generator)
+            .generateWithGraph(path: .any, options: .any)
+            .willProduce { path, _ in
+                (
+                    path, graph,
+                    MapperEnvironment()
+                )
+            }
+
+        given(buildGraphInspector)
+            .workspaceSchemes(graphTraverser: .any)
+            .willReturn([scheme])
+
+        given(shardPlanService)
+            .plan(
+                xctestproductsPath: .any,
+                destination: .any,
+                reference: .any,
+                shardGranularity: .any,
+                shardMin: .any,
+                shardMax: .any,
+                shardTotal: .any,
+                shardMaxDuration: .any,
+                fullHandle: .any,
+                serverURL: .any,
+                buildRunId: .any,
+                skipUpload: .any,
+                archivePath: .any
+            )
+            .willReturn(
+                Components.Schemas.ShardPlan(
+                    id: "plan-id",
+                    reference: "ref",
+                    shard_count: 2,
+                    shards: []
+                )
+            )
+
+        // When
+        try await testRun(
+            path: path,
+            action: .build,
+            passthroughXcodeBuildArguments: [
+                "-testProductsPath", testProductsPath.pathString,
+                "-destination", "platform=iOS Simulator",
+            ],
+            shardTotal: 2,
+            shardGranularity: .suite
+        )
+
+        // Then
+        verify(shardPlanService)
+            .plan(
+                xctestproductsPath: .value(testProductsPath),
+                destination: .value("platform=iOS Simulator,id=3A8C9673-C1FD-4E33-8EFA-AEEBF43161CC"),
+                reference: .any,
+                shardGranularity: .value(.suite),
+                shardMin: .any,
+                shardMax: .any,
+                shardTotal: .value(2),
+                shardMaxDuration: .any,
+                fullHandle: .value("tuist/tuist"),
+                serverURL: .any,
+                buildRunId: .any,
+                skipUpload: .value(false),
+                archivePath: .value(nil)
             )
             .called(1)
     }
@@ -5379,6 +5473,7 @@ final class TestServiceTests: TuistUnitTestCase {
         passthroughXcodeBuildArguments: [String] = [],
         skipQuarantine: Bool = false,
         shardReference: String? = nil,
+        shardGranularity: ShardGranularity = .module,
         shardMin: Int? = nil,
         shardMax: Int? = nil,
         shardTotal: Int? = nil,
@@ -5415,6 +5510,7 @@ final class TestServiceTests: TuistUnitTestCase {
                 passthroughXcodeBuildArguments: passthroughXcodeBuildArguments,
                 skipQuarantine: skipQuarantine,
                 shardReference: shardReference,
+                shardGranularity: shardGranularity,
                 shardMin: shardMin,
                 shardMax: shardMax,
                 shardTotal: shardTotal,

--- a/cli/Tests/TuistKitTests/Services/TestServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/TestServiceTests.swift
@@ -24,6 +24,8 @@ import XcodeGraph
 import XCResultParser
 import XCTest
 
+import struct TSCUtility.Version
+
 @testable import TuistKit
 @testable import TuistTesting
 
@@ -4262,6 +4264,76 @@ final class TestServiceTests: TuistUnitTestCase {
             .willReturn(generator)
     }
 
+    private struct ShardPlanBuildFixture {
+        let path: AbsolutePath
+        let testProductsPath: AbsolutePath
+    }
+
+    private func givenShardPlanBuild(onShardPlanDestination: ((String?) -> Void)? = nil) async throws -> ShardPlanBuildFixture {
+        givenGenerator()
+        let path = try temporaryPath()
+        let testProductsPath = path.appending(component: "TestProducts.xctestproducts")
+        let projectPath = AbsolutePath.root.appending(component: "Project")
+        let scheme = Scheme.test(name: "ProjectScheme")
+        let graph: Graph = .test(
+            workspace: .test(schemes: [scheme]),
+            projects: [
+                projectPath: .test(
+                    path: projectPath,
+                    targets: [
+                        .test(name: "AppTests", product: .unitTests),
+                    ]
+                ),
+            ]
+        )
+        try await fileSystem.makeDirectory(at: testProductsPath)
+
+        given(configLoader)
+            .loadConfig(path: .any)
+            .willReturn(.test(project: .testGeneratedProject(), fullHandle: "tuist/tuist"))
+
+        given(generator)
+            .generateWithGraph(path: .any, options: .any)
+            .willProduce { path, _ in
+                (
+                    path, graph,
+                    MapperEnvironment()
+                )
+            }
+
+        given(buildGraphInspector)
+            .workspaceSchemes(graphTraverser: .any)
+            .willReturn([scheme])
+
+        given(shardPlanService)
+            .plan(
+                xctestproductsPath: .any,
+                destination: .any,
+                reference: .any,
+                shardGranularity: .any,
+                shardMin: .any,
+                shardMax: .any,
+                shardTotal: .any,
+                shardMaxDuration: .any,
+                fullHandle: .any,
+                serverURL: .any,
+                buildRunId: .any,
+                skipUpload: .any,
+                archivePath: .any
+            )
+            .willProduce { _, destination, _, _, _, _, _, _, _, _, _, _, _ in
+                onShardPlanDestination?(destination)
+                return Components.Schemas.ShardPlan(
+                    id: "plan-id",
+                    reference: "ref",
+                    shard_count: 2,
+                    shards: []
+                )
+            }
+
+        return ShardPlanBuildFixture(path: path, testProductsPath: testProductsPath)
+    }
+
     func test_run_testWithoutBuilding_skipsGeneration_whenSelectiveTestingGraphExists() async throws {
         // Given
         let path = try temporaryPath()
@@ -4973,6 +5045,247 @@ final class TestServiceTests: TuistUnitTestCase {
             .plan(
                 xctestproductsPath: .value(testProductsPath),
                 destination: .value("platform=iOS Simulator,id=3A8C9673-C1FD-4E33-8EFA-AEEBF43161CC"),
+                reference: .any,
+                shardGranularity: .value(.suite),
+                shardMin: .any,
+                shardMax: .any,
+                shardTotal: .value(2),
+                shardMaxDuration: .any,
+                fullHandle: .value("tuist/tuist"),
+                serverURL: .any,
+                buildRunId: .any,
+                skipUpload: .value(false),
+                archivePath: .value(nil)
+            )
+            .called(1)
+    }
+
+    func test_run_build_preservesConcreteSimulatorDestinationForSuiteShardPlanning() async throws {
+        // Given
+        let fixture = try await givenShardPlanBuild()
+        given(simulatorController)
+            .findAvailableDevice(udid: .any)
+            .willReturn(.test(device: .test(name: "Test iPhone")))
+
+        // When
+        try await testRun(
+            path: fixture.path,
+            action: .build,
+            passthroughXcodeBuildArguments: [
+                "-testProductsPath", fixture.testProductsPath.pathString,
+                "-destination", "platform=iOS Simulator,id=existing-device-id",
+            ],
+            shardGranularity: .suite,
+            shardTotal: 2
+        )
+
+        // Then
+        verify(shardPlanService)
+            .plan(
+                xctestproductsPath: .value(fixture.testProductsPath),
+                destination: .value("platform=iOS Simulator,id=existing-device-id"),
+                reference: .any,
+                shardGranularity: .value(.suite),
+                shardMin: .any,
+                shardMax: .any,
+                shardTotal: .value(2),
+                shardMaxDuration: .any,
+                fullHandle: .value("tuist/tuist"),
+                serverURL: .any,
+                buildRunId: .any,
+                skipUpload: .value(false),
+                archivePath: .value(nil)
+            )
+            .called(1)
+    }
+
+    func test_run_build_preservesMacOSDestinationForSuiteShardPlanning() async throws {
+        // Given
+        let fixture = try await givenShardPlanBuild()
+
+        // When
+        try await testRun(
+            path: fixture.path,
+            action: .build,
+            passthroughXcodeBuildArguments: [
+                "-testProductsPath", fixture.testProductsPath.pathString,
+                "-destination", "platform=macOS",
+            ],
+            shardGranularity: .suite,
+            shardTotal: 2
+        )
+
+        // Then
+        verify(shardPlanService)
+            .plan(
+                xctestproductsPath: .value(fixture.testProductsPath),
+                destination: .value("platform=macOS"),
+                reference: .any,
+                shardGranularity: .value(.suite),
+                shardMin: .any,
+                shardMax: .any,
+                shardTotal: .value(2),
+                shardMaxDuration: .any,
+                fullHandle: .value("tuist/tuist"),
+                serverURL: .any,
+                buildRunId: .any,
+                skipUpload: .value(false),
+                archivePath: .value(nil)
+            )
+            .called(1)
+    }
+
+    func test_run_build_usesExplicitSimulatorOSVersionForSuiteShardPlanning() async throws {
+        // Given
+        let fixture = try await givenShardPlanBuild()
+
+        // When
+        try await testRun(
+            path: fixture.path,
+            action: .build,
+            passthroughXcodeBuildArguments: [
+                "-testProductsPath", fixture.testProductsPath.pathString,
+                "-destination", "platform=iOS Simulator,OS=18.0",
+            ],
+            shardGranularity: .suite,
+            shardTotal: 2
+        )
+
+        // Then
+        verify(shardPlanService)
+            .plan(
+                xctestproductsPath: .value(fixture.testProductsPath),
+                destination: .value("platform=iOS Simulator,id=3A8C9673-C1FD-4E33-8EFA-AEEBF43161CC"),
+                reference: .any,
+                shardGranularity: .value(.suite),
+                shardMin: .any,
+                shardMax: .any,
+                shardTotal: .value(2),
+                shardMaxDuration: .any,
+                fullHandle: .value("tuist/tuist"),
+                serverURL: .any,
+                buildRunId: .any,
+                skipUpload: .value(false),
+                archivePath: .value(nil)
+            )
+            .called(1)
+        verify(simulatorController)
+            .findAvailableDevice(
+                platform: .value(.iOS),
+                version: .value(Version(18, 0, 0)),
+                minVersion: .any,
+                deviceName: .any
+            )
+            .called(1)
+    }
+
+    func test_run_build_infersSimulatorDestinationForSuiteShardPlanning() async throws {
+        // Given
+        let fixture = try await givenShardPlanBuild()
+
+        // When
+        try await testRun(
+            path: fixture.path,
+            action: .build,
+            passthroughXcodeBuildArguments: [
+                "-testProductsPath", fixture.testProductsPath.pathString,
+            ],
+            shardGranularity: .suite,
+            shardTotal: 2
+        )
+
+        // Then
+        verify(shardPlanService)
+            .plan(
+                xctestproductsPath: .value(fixture.testProductsPath),
+                destination: .value("platform=iOS Simulator,id=3A8C9673-C1FD-4E33-8EFA-AEEBF43161CC"),
+                reference: .any,
+                shardGranularity: .value(.suite),
+                shardMin: .any,
+                shardMax: .any,
+                shardTotal: .value(2),
+                shardMaxDuration: .any,
+                fullHandle: .value("tuist/tuist"),
+                serverURL: .any,
+                buildRunId: .any,
+                skipUpload: .value(false),
+                archivePath: .value(nil)
+            )
+            .called(1)
+    }
+
+    func test_run_build_fallsBackToExplicitDestinationWhenSimulatorResolutionFailsForSuiteShardPlanning() async throws {
+        // Given
+        var plannedDestination: String?
+        let fixture = try await givenShardPlanBuild { destination in
+            plannedDestination = destination
+        }
+        simulatorController.reset()
+        given(simulatorController)
+            .findAvailableDevice(
+                platform: .any,
+                version: .any,
+                minVersion: .any,
+                deviceName: .any
+            )
+            .willThrow(TestError("Simulator unavailable"))
+
+        // When
+        try await testRun(
+            path: fixture.path,
+            action: .build,
+            passthroughXcodeBuildArguments: [
+                "-testProductsPath", fixture.testProductsPath.pathString,
+                "-destination", "platform=iOS Simulator",
+            ],
+            shardGranularity: .suite,
+            shardTotal: 2
+        )
+
+        // Then
+        XCTAssertEqual(plannedDestination, "platform=iOS Simulator")
+    }
+
+    func test_run_build_fallsBackToPlatformDestinationWhenSimulatorResolutionFailsForSuiteShardPlanning() async throws {
+        // Given
+        let fixture = try await givenShardPlanBuild()
+        let macOSTarget = Target.test(
+            name: "AppTests",
+            destinations: [.mac],
+            product: .unitTests,
+            deploymentTargets: .macOS("13.0")
+        )
+        given(buildGraphInspector)
+            .testableTarget(
+                scheme: .any,
+                testPlan: .any,
+                testTargets: .any,
+                skipTestTargets: .any,
+                graphTraverser: .any,
+                action: .any
+            )
+            .willReturn(.test(target: macOSTarget))
+        given(simulatorController)
+            .macOSDestination(catalyst: .any)
+            .willThrow(TestError("macOS destination unavailable"))
+
+        // When
+        try await testRun(
+            path: fixture.path,
+            platform: "macOS",
+            action: .build,
+            passthroughXcodeBuildArguments: [
+                "-testProductsPath", fixture.testProductsPath.pathString,
+            ],
+            shardGranularity: .suite,
+            shardTotal: 2
+        )
+
+        // Then
+        verify(shardPlanService)
+            .plan(
+                xctestproductsPath: .value(fixture.testProductsPath),
+                destination: .value("platform=macOS"),
                 reference: .any,
                 shardGranularity: .value(.suite),
                 shardMin: .any,


### PR DESCRIPTION
## What changed

- Normalizes shard-plan destinations before suite-level test enumeration.
- Resolves platform-only simulator destinations such as `platform=iOS Simulator` into concrete simulator destinations with an `id`.
- Preserves already-concrete destinations that include `id` or `name`.
- Adds regression coverage for suite shard planning with a platform-only iOS simulator destination.

## Why

Suite granularity calls `xcodebuild test-without-building -enumerate-tests` after the build-for-testing phase. The build run succeeded, but enumeration failed because Tuist passed only `platform=iOS Simulator`, and Xcode could not match that broad destination from `.xctestproducts`.

## Root Cause

The normal build path resolves a concrete simulator destination before invoking Xcode, but shard planning discarded that shape and sent only a platform-level simulator destination into `XCTestEnumerator`. Xcode accepts enough information to build the test products, but `test-without-building -enumerate-tests -testProductsPath` needs a concrete simulator destination to enumerate suites reliably.

## Impact

Suite-level sharding now enumerates tests using the same kind of concrete simulator destination that the build/test path already resolves, avoiding error 70 for platform-only simulator destinations.

## Validation

- Ran `swiftformat` on the two touched files.
- Ran `git diff --check` successfully.
- Built the committed iOS fixture:
  - `xcodebuild -project examples/xcode/xcode_project_with_tests/App.xcodeproj -scheme App build-for-testing -destination "platform=iOS Simulator,id=99A1ADBF-B5DD-402F-B8DB-BDEBA7220E04" -derivedDataPath /private/tmp/tuist-suite-shard-e2e.ogeIBI/DerivedData -testProductsPath /private/tmp/tuist-suite-shard-e2e.ogeIBI/TestProducts.xctestproducts CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=`
- Reproduced the reported failure:
  - `xcodebuild test-without-building -enumerate-tests -testProductsPath /private/tmp/tuist-suite-shard-e2e.ogeIBI/TestProducts.xctestproducts -destination "platform=iOS Simulator"`
  - Result: exit 70 with `Unable to find a device matching the provided destination specifier: { platform:iOS Simulator }`.
- Verified the fixed destination shape:
  - Booted simulator `99A1ADBF-B5DD-402F-B8DB-BDEBA7220E04`.
  - `xcodebuild test-without-building -enumerate-tests -testProductsPath /private/tmp/tuist-suite-shard-e2e.ogeIBI/TestProducts.xctestproducts -destination "platform=iOS Simulator,id=99A1ADBF-B5DD-402F-B8DB-BDEBA7220E04"`
  - Result: exit 0 and full suite enumeration:
    - `AppFrameworkTests/AppFrameworkTests/example()`
    - `AppTests/AppTests/example()`
    - `AppTests/AppTests/parameterized(value:)`
