### PR TITLE
fix(server): run release deploy dispatch on GitHub-hosted runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2020,9 +2020,9 @@ jobs:
         needs.check-releases.outputs.xcresult-processor-image-should-release == 'true' ||
         needs.check-releases.outputs.kura-should-release == 'true'
       )
-    # gh ships in the tuist-linux runner image; the dispatch needs no
-    # checkout, so the repo is targeted explicitly via --repo.
-    runs-on: tuist-linux
+    # GitHub-hosted Ubuntu includes gh; the dispatch needs no checkout, so
+    # the repo is targeted explicitly via --repo.
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     env:
       GH_TOKEN: ${{ secrets.TUIST_RELEASE_GITHUB_TOKEN }}


### PR DESCRIPTION
## What changed

- Move `release.yml` trigger-deploy job from the self-hosted `tuist-linux` runner to `ubuntu-latest`.
- Update the nearby comment to reflect that GitHub-hosted Ubuntu provides `gh` for the workflow dispatch call.

## Why

The server production deployment workflow intentionally skips push-triggered deploys when `release:check` detects a fleet/runtime image release. In that path, `release.yml` is responsible for building/tagging the image and then dispatching `server-production-deployment.yml` with the target commit SHA.

For the `6e9a13209918` push, the server deployment run passed with only the `Gate` job because `xcresult-processor-image` needed a release. The matching `release.yml` run built and tagged the image, but the final dispatch job failed with `gh: command not found`, so the actual server production deploy was never triggered.

## Impact

Fleet/runtime-image releases should now reliably dispatch the follow-up server production deployment instead of leaving the green, skipped push workflow as the last server deployment signal.

## Validation

- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "ok"'`
