### PR TITLE
fix(server): deploy when release workflow changes

### DIFF
--- a/.github/workflows/server-production-deployment.yml
+++ b/.github/workflows/server-production-deployment.yml
@@ -49,6 +49,7 @@ on:
       - infra/kura-controller/**
       - infra/helm/tuist/**
       - infra/helm/k8s-monitoring/**
+      - .github/workflows/release.yml
       - .github/workflows/server-deployment.yml
       - .github/workflows/server-production-deployment.yml
       - server/pnpm-lock.yaml


### PR DESCRIPTION
## What changed

- Add `.github/workflows/release.yml` to the `server-production-deployment.yml` push path filter.

## Why

The server production deploy workflow already runs when server code, Helm values, or the server deployment workflows change. However, `release.yml` also owns part of the deploy path: after a fleet/runtime image release, it dispatches `server-production-deployment.yml` for the target commit.

The recent dispatch-runner fix changed `release.yml`, but that did not start a server production deployment. That left us with a green release workflow and no deploy attempt, even though production was behind current `main`.

## Impact

Future changes to the release-to-deploy handoff will trigger the server production deployment cascade, so deployment plumbing fixes are more likely to reconcile production instead of only fixing the next future release event.

## Validation

- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/server-production-deployment.yml"); puts "ok"'`
