### PR TITLE
fix(kura): key extension hook caches on credential headers only

### DIFF
--- a/kura/README.md
+++ b/kura/README.md
@@ -570,3 +570,11 @@ documented with the hook implementation rather than in the generic
 runtime contract.
 
 The runtime keeps decision caching, metrics, timeouts, and cryptographic primitives in Rust, while the script supplies policy.
+
+Hook results are cached per credentials: the cache key fingerprints only the
+credential-bearing request headers (`authorization`, `proxy-authorization`,
+`cookie`, `x-api-key`), so per-request noise such as gRPC deadlines
+(`grpc-timeout`) or trace propagation (`traceparent`) does not defeat the
+cache. Hooks that authenticate from other inputs must return a short
+`ttl_seconds` (or none) instead of relying on the cache key to separate
+requests.

--- a/kura/src/extension/mod.rs
+++ b/kura/src/extension/mod.rs
@@ -1187,15 +1187,18 @@ fn ttl_for_authorize(config: &ExtensionConfig, result: &AuthorizeOutcome) -> Dur
     }
 }
 
+// Hook results are cached per credentials, so the fingerprint must only cover
+// headers that can carry credentials. Hashing the remaining headers instead
+// would key the cache on per-request noise such as `grpc-timeout` (REAPI
+// clients send the remaining deadline on every RPC) or `traceparent`, turning
+// almost every request into a cache miss and an authentication backend call.
+const CREDENTIAL_HEADER_NAMES: [&str; 4] =
+    ["authorization", "proxy-authorization", "cookie", "x-api-key"];
+
 fn credentials_fingerprint(headers: &BTreeMap<String, String>) -> String {
     let filtered = headers
         .iter()
-        .filter(|(name, _)| {
-            !matches!(
-                name.as_str(),
-                "accept" | "content-length" | "host" | "user-agent" | "x-request-id"
-            )
-        })
+        .filter(|(name, _)| CREDENTIAL_HEADER_NAMES.contains(&name.as_str()))
         .collect::<BTreeMap<_, _>>();
     fingerprint(&filtered)
 }
@@ -1505,6 +1508,31 @@ end
         let second = engine.evaluate_access(&context).await;
         assert!(matches!(second, AccessDecision::Allow(Some(_))));
         assert_eq!(calls.load(Ordering::SeqCst), 1);
+
+        // Per-request noise headers (REAPI deadlines, trace propagation) must
+        // not key the cache: same credentials, varying noise → still cached.
+        for (noise_name, noise_value) in [
+            ("grpc-timeout", "119999996u"),
+            ("grpc-timeout", "119231422u"),
+            ("traceparent", "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"),
+        ] {
+            let mut noisy = context.clone();
+            noisy
+                .headers
+                .insert(noise_name.into(), noise_value.into());
+            let decision = engine.evaluate_access(&noisy).await;
+            assert!(matches!(decision, AccessDecision::Allow(Some(_))));
+        }
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+
+        // Different credentials must not share the cached result.
+        let mut other_credentials = context.clone();
+        other_credentials
+            .headers
+            .insert("authorization".into(), "Bearer other".into());
+        let decision = engine.evaluate_access(&other_credentials).await;
+        assert!(matches!(decision, AccessDecision::Allow(Some(_))));
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
     }
 
     #[tokio::test]

--- a/kura/src/extension/mod.rs
+++ b/kura/src/extension/mod.rs
@@ -1192,8 +1192,12 @@ fn ttl_for_authorize(config: &ExtensionConfig, result: &AuthorizeOutcome) -> Dur
 // would key the cache on per-request noise such as `grpc-timeout` (REAPI
 // clients send the remaining deadline on every RPC) or `traceparent`, turning
 // almost every request into a cache miss and an authentication backend call.
-const CREDENTIAL_HEADER_NAMES: [&str; 4] =
-    ["authorization", "proxy-authorization", "cookie", "x-api-key"];
+const CREDENTIAL_HEADER_NAMES: [&str; 4] = [
+    "authorization",
+    "proxy-authorization",
+    "cookie",
+    "x-api-key",
+];
 
 fn credentials_fingerprint(headers: &BTreeMap<String, String>) -> String {
     let filtered = headers
@@ -1514,12 +1518,13 @@ end
         for (noise_name, noise_value) in [
             ("grpc-timeout", "119999996u"),
             ("grpc-timeout", "119231422u"),
-            ("traceparent", "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"),
+            (
+                "traceparent",
+                "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
+            ),
         ] {
             let mut noisy = context.clone();
-            noisy
-                .headers
-                .insert(noise_name.into(), noise_value.into());
+            noisy.headers.insert(noise_name.into(), noise_value.into());
             let decision = engine.evaluate_access(&noisy).await;
             assert!(matches!(decision, AccessDecision::Allow(Some(_))));
         }


### PR DESCRIPTION
## What changed

The extension authenticate/authorize cache key now fingerprints only credential-bearing request headers (`authorization`, `proxy-authorization`, `cookie`, `x-api-key`) instead of hashing every header minus a small noise denylist (`accept`, `content-length`, `host`, `user-agent`, `x-request-id`).

## Root cause

REAPI clients attach a deadline to every RPC, which arrives as a `grpc-timeout` header whose value is the remaining time at send — effectively unique on every request. Because the old fingerprint hashed all-headers-minus-denylist, every deadline-carrying request produced a fresh cache key, so the authenticate cache missed almost permanently. Trace propagation headers (`traceparent`) have the same effect on HTTP traffic.

Every miss re-runs the `authenticate` hook; with the Tuist hook that means a `POST /oauth2/introspect` round-trip to the control plane per miss.

Observed during a single cold `bazel build` of the Kura crate graph against a dev node (no local JWT verifier, so each miss introspects):

- authenticate cache: 15,340 misses vs 13,174 hits (~54% miss rate)
- ~6,800 introspection requests hit the control plane, pinning the Phoenix server's BEAM at ~300% CPU for the duration of the build

Production nodes are affected the same way — real traffic carries `grpc-timeout` and `traceparent` — just with the introspection volume spread across the fleet.

## Why this solution

The function is named `credentials_fingerprint` and the cache is documented as "per credentials"; the denylist approach was an under-approximation of that intent that silently broke whenever clients sent any per-request header. An allowlist of credential headers makes the intent hold structurally. Hooks that authenticate from non-standard inputs can still opt out of caching via a short/absent `ttl_seconds` — documented in the README.

## Validation

- New regression test: same credentials with varying `grpc-timeout`/`traceparent` reuse the cached result (identity backend called once); a different `authorization` value does not share the cache entry.
- `cargo test extension::` — 24 passed.
- `cargo clippy --all-targets -- -D warnings` — clean.
- Live validation on a dev kind node running this patch, driving comparable Bazel build volume (a full re-upload pass plus incremental/no-op builds): authenticate cache went to **11,444 hits / 14 misses (99.9% hit rate)** and total introspection calls for the whole session dropped from ~6,800 to **14**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)