### PR TITLE
fix(server): restore project settings padding

### DIFF
--- a/server/assets/app/css/pages/project_automations.css
+++ b/server/assets/app/css/pages/project_automations.css
@@ -2,6 +2,7 @@
   display: flex;
   flex-direction: column;
   gap: var(--noora-spacing-9);
+  padding: var(--noora-spacing-7) var(--noora-spacing-5);
 
   .noora-tab-menu-horizontal {
     padding: var(--noora-spacing-0);
@@ -9,7 +10,6 @@
 
   & > [data-part="title"] {
     margin: 0;
-    padding-top: var(--noora-spacing-7);
     color: var(--noora-surface-label-primary);
     font: var(--noora-font-weight-medium) var(--noora-font-heading-xlarge);
   }

--- a/server/assets/app/css/pages/project_bundle_settings.css
+++ b/server/assets/app/css/pages/project_bundle_settings.css
@@ -2,6 +2,7 @@
   display: flex;
   flex-direction: column;
   gap: var(--noora-spacing-9);
+  padding: var(--noora-spacing-7) var(--noora-spacing-5);
 
   .noora-tab-menu-horizontal {
     padding: var(--noora-spacing-0);
@@ -9,7 +10,6 @@
 
   & > [data-part="title"] {
     margin: 0;
-    padding-top: var(--noora-spacing-7);
     color: var(--noora-surface-label-primary);
     font: var(--noora-font-weight-medium) var(--noora-font-heading-xlarge);
   }

--- a/server/assets/app/css/pages/project_notifications.css
+++ b/server/assets/app/css/pages/project_notifications.css
@@ -2,6 +2,7 @@
   display: flex;
   flex-direction: column;
   gap: var(--noora-spacing-9);
+  padding: var(--noora-spacing-7) var(--noora-spacing-5);
 
   .noora-tab-menu-horizontal {
     padding: var(--noora-spacing-0);
@@ -9,7 +10,6 @@
 
   & > [data-part="title"] {
     margin: 0;
-    padding-top: var(--noora-spacing-7);
     color: var(--noora-surface-label-primary);
     font: var(--noora-font-weight-medium) var(--noora-font-heading-xlarge);
   }

--- a/server/assets/app/css/pages/project_settings.css
+++ b/server/assets/app/css/pages/project_settings.css
@@ -2,6 +2,7 @@
   display: flex;
   flex-direction: column;
   gap: var(--noora-spacing-9);
+  padding: var(--noora-spacing-7) var(--noora-spacing-5);
 
   .noora-tab-menu-horizontal {
     padding: var(--noora-spacing-0);
@@ -9,7 +10,6 @@
 
   & > [data-part="title"] {
     margin: 0;
-    padding-top: var(--noora-spacing-7);
     color: var(--noora-surface-label-primary);
     font: var(--noora-font-weight-medium) var(--noora-font-heading-xlarge);
   }


### PR DESCRIPTION
## What changed

- Restored page-level padding on the project settings pages: General, Notifications, Automations, and Bundles.
- Moved the existing top spacing from the title element to the page root so the title, tabs, and settings content share the same horizontal gutter.

## Why

The project settings layout was flush against the left edge because these pages relied on shared `.layout__content` padding instead of owning their page gutter. The settings tab menu intentionally resets its own padding to zero, so once the shared layout padding was removed there was no horizontal spacing left for the settings surface.

Comparable project pages already apply `var(--noora-spacing-7) var(--noora-spacing-5)` at the page root. Applying the same root padding here keeps the settings pages aligned with the rest of the app while preserving the intended vertical spacing.

## Root cause

The latent issue was introduced with project settings in PR #8197 (`3418fd5123b9`, merged 2025-09-15 12:29:24 UTC): `project_settings.css` used title-only `padding-top` and did not define page-level horizontal padding.

The visible regression happened in PR #11138 (`6d2d49f0709e`, merged 2026-06-08 12:16:43 UTC), which removed `padding: var(--noora-spacing-5)` from `.layout__content`. Pages that already owned their root padding kept their gutter; project settings did not, so it became flush with the sidebar boundary.

## Impact

Project settings no longer render flush against the sidebar boundary. The fix applies consistently across all project settings tabs that share the same layout pattern.

## Validation

- Ran `git diff --cached --check`.
- Rebuilt the app CSS bundle locally.
- Ran Phoenix locally on `http://localhost:8523` and verified `/` responds with the expected redirect to `/users/log_in`.
- Verified the served CSS contains `#project-settings { padding: var(--noora-spacing-7) var(--noora-spacing-5); }`.
- Confirmed the in-app browser loads `http://localhost:8523/tuist/public/settings` with the padding restored.