### PR TITLE
fix(infra): stabilize tuist-ops postgres

### DIFF
--- a/infra/helm/tuist-ops/README.md
+++ b/infra/helm/tuist-ops/README.md
@@ -19,7 +19,7 @@ cross-call this deployment via the tailnet for the policy lookup.
   (`/api/v1/policy`) and any future LiveView paths (`/db`, etc.) are
   reachable only on the tailnet, never publicly.
 - **CNPG Cluster** — single-instance Postgres, 5Gi storage, daily
-  backups to Tigris under `s3://tuist-cnpg-backups/tuist-ops`.
+  backups to Tigris under `s3://tuist-prod-pg-backups/tuist-ops`.
 - **ExternalSecrets** — three of them:
   - `tuist-ops-runtime` — Slack + Tailscale credentials from `TUIST_OPS_BOT`
   - `tuist-ops-app`     — `SECRET_KEY_BASE` from the same 1P item

--- a/infra/helm/tuist-ops/templates/backup-credentials.yaml
+++ b/infra/helm/tuist-ops/templates/backup-credentials.yaml
@@ -25,7 +25,7 @@ spec:
       engineVersion: v2
       data:
         ACCESS_KEY_ID: "{{ `{{ .access_key_id | trim }}` }}"
-        SECRET_ACCESS_KEY: "{{ `{{ .secret_access_key | trim }}` }}"
+        ACCESS_SECRET_KEY: "{{ `{{ .secret_access_key | trim }}` }}"
   dataFrom:
     - extract:
         key: S3_BACKUP_CREDENTIALS

--- a/infra/helm/tuist-ops/templates/cnpg-cluster.yaml
+++ b/infra/helm/tuist-ops/templates/cnpg-cluster.yaml
@@ -21,6 +21,14 @@ spec:
 
   enableSuperuserAccess: true
 
+  {{- with .Values.postgresql.parameters }}
+  postgresql:
+    parameters:
+      {{- range $key, $value := . }}
+      {{ $key }}: {{ $value | quote }}
+      {{- end }}
+  {{- end }}
+
   bootstrap:
     initdb:
       database: {{ .Values.postgresql.database | quote }}
@@ -35,6 +43,9 @@ spec:
     storageClass: {{ . | quote }}
     {{- end }}
 
+  resources:
+    {{- toYaml .Values.postgresql.resources | nindent 4 }}
+
   {{- if .Values.postgresql.backup.enabled }}
   backup:
     barmanObjectStore:
@@ -46,7 +57,7 @@ spec:
           key: ACCESS_KEY_ID
         secretAccessKey:
           name: {{ .Values.postgresql.backup.credentialsSecretName }}
-          key: SECRET_ACCESS_KEY
+          key: ACCESS_SECRET_KEY
     retentionPolicy: {{ .Values.postgresql.backup.retentionPolicy | quote }}
   {{- end }}
 {{- if .Values.postgresql.backup.enabled }}

--- a/infra/helm/tuist-ops/values.yaml
+++ b/infra/helm/tuist-ops/values.yaml
@@ -33,12 +33,22 @@ postgresql:
   owner: tuist_ops
   image:
     repository: ghcr.io/cloudnative-pg/postgresql
-    tag: "16.4"
+    tag: "16.6"
+  parameters:
+    max_connections: "40"
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 1000m
+      memory: 1Gi
   backup:
     enabled: true
-    # Tuist-wide CNPG backup bucket; tuist-ops gets its own prefix.
-    destinationPath: s3://tuist-cnpg-backups/tuist-ops
-    endpointURL: https://fly.storage.tigris.dev
+    # Production CNPG backup bucket; tuist-ops gets its own prefix
+    # while reusing the production S3_BACKUP_CREDENTIALS item.
+    destinationPath: s3://tuist-prod-pg-backups/tuist-ops
+    endpointURL: https://t3.storage.dev
     retentionPolicy: "30d"
     # Credentials are ESO-synced from the shared
     # `S3_BACKUP_CREDENTIALS` 1P item — same one the main Tuist
@@ -108,12 +118,12 @@ podAnnotations: {}
 
 probes:
   startup:
-    path: /api/v1/healthz
+    path: /api/v1/readyz
     initialDelaySeconds: 5
     periodSeconds: 5
     failureThreshold: 24
   readiness:
-    path: /api/v1/healthz
+    path: /api/v1/readyz
     initialDelaySeconds: 5
     periodSeconds: 10
     failureThreshold: 3

--- a/tuist-ops/lib/tuist_ops_web/controllers/health_controller.ex
+++ b/tuist-ops/lib/tuist_ops_web/controllers/health_controller.ex
@@ -1,18 +1,19 @@
 defmodule TuistOpsWeb.HealthController do
   @moduledoc """
-  Single liveness/readiness endpoint. Returns 200 with the build
-  version when the Phoenix endpoint is up and the Repo can serve a
-  trivial query.
+  Health endpoints for Kubernetes probes.
 
-  Used by Kubernetes startup / readiness / liveness probes (see
-  `infra/helm/tuist-ops/values.yaml`).
+  Liveness only proves that the Phoenix endpoint is serving. Readiness
+  checks the database too, so a transient Postgres issue removes the
+  pod from Service endpoints without forcing a BEAM restart.
   """
 
   use TuistOpsWeb, :controller
 
   alias TuistOps.Repo
 
-  def show(conn, _params) do
+  def show(conn, _params), do: json(conn, %{status: "ok"})
+
+  def ready(conn, _params) do
     case Repo.query("SELECT 1") do
       {:ok, _} ->
         json(conn, %{status: "ok"})

--- a/tuist-ops/lib/tuist_ops_web/router.ex
+++ b/tuist-ops/lib/tuist_ops_web/router.ex
@@ -43,5 +43,6 @@ defmodule TuistOpsWeb.Router do
     pipe_through :health
 
     get "/healthz", HealthController, :show
+    get "/readyz", HealthController, :ready
   end
 end

--- a/tuist-ops/test/tuist_ops_web/controllers/health_controller_test.exs
+++ b/tuist-ops/test/tuist_ops_web/controllers/health_controller_test.exs
@@ -1,0 +1,17 @@
+defmodule TuistOpsWeb.HealthControllerTest do
+  use TuistOpsWeb.ConnCase, async: true
+
+  test "healthz does not require the database", %{conn: conn} do
+    conn = get(conn, "/api/v1/healthz")
+
+    assert conn.status == 200
+    assert Jason.decode!(conn.resp_body) == %{"status" => "ok"}
+  end
+
+  test "readyz checks the database", %{conn: conn} do
+    conn = get(conn, "/api/v1/readyz")
+
+    assert conn.status == 200
+    assert Jason.decode!(conn.resp_body) == %{"status" => "ok"}
+  end
+end


### PR DESCRIPTION
## What changed

- Pointed the tuist-ops CNPG backup configuration at the production Tigris backup endpoint and bucket prefix used by the production backup credentials.
- Aligned the backup Secret key shape with the main CNPG chart.
- Added explicit CPU/memory requests and limits for the tuist-ops Postgres instance, capped its Postgres connection budget, and bumped the Postgres image to 16.6.
- Split health checks so /api/v1/healthz only proves the Phoenix process is alive while /api/v1/readyz still verifies database access.
- Moved startup/readiness probes to /readyz and left liveness on /healthz.

## Why

The production alert showed both the CNPG Postgres pod and the tuist-ops app pod restarting frequently. The chart had two fragile edges: the Postgres pod had no declared resource budget, and the app liveness probe depended on the database. That meant a transient or repeated Postgres issue could cascade into app restarts as well.

While reviewing the chart, I also found that tuist-ops backups were configured against an older Tigris endpoint and a separate bucket path, despite reusing the production S3_BACKUP_CREDENTIALS item. If WAL archiving cannot write to the configured destination, a small 5Gi Postgres volume can fill quickly, which is a plausible root cause for the Postgres restart loop.

## Impact

Tuist Ops should stop being killed by Kubernetes merely because Postgres is temporarily unavailable. During DB trouble it will leave Service endpoints through readiness, but the BEAM process can recover when DB access returns. The Postgres pod also gets an explicit scheduling/eviction budget and backup configuration aligned with the production CNPG setup.

## Validation

- helm template tuist-ops infra/helm/tuist-ops -n tuist-ops -f infra/helm/tuist-ops/values-managed-production.yaml --set image.tag=test
- helm lint infra/helm/tuist-ops -f infra/helm/tuist-ops/values-managed-production.yaml --set image.tag=test
- mix format --check-formatted
- mix test test/tuist_ops_web/controllers/health_controller_test.exs

I could not inspect or mutate the live production pods from the local machine because only a staging kube context was configured locally.