### PR TITLE
fix(cli): isolate hostless tests in workspace schemes

### DIFF
--- a/cli/Sources/TuistKit/Services/TestService.swift
+++ b/cli/Sources/TuistKit/Services/TestService.swift
@@ -1,6 +1,7 @@
 import FileSystem
 import Foundation
 import Path
+import struct TSCUtility.Version
 import TuistAlert
 import TuistAutomation
 import TuistCI
@@ -20,8 +21,6 @@ import TuistXcodeBuildProducts
 import TuistXCResultService
 import XcodeGraph
 import XCResultParser
-
-import struct TSCUtility.Version
 
 public enum TestServiceError: FatalError, Equatable {
     case schemeNotFound(scheme: String, existing: [String])
@@ -458,7 +457,17 @@ public struct TestService { // swiftlint:disable:this type_body_length
 
             schemes = [scheme]
         } else {
-            schemes = buildGraphInspector.workspaceSchemes(graphTraverser: graphTraverser)
+            let workspaceSchemes = buildGraphInspector.workspaceSchemes(graphTraverser: graphTraverser)
+            let testableSchemes =
+                buildGraphInspector.testableSchemes(graphTraverser: graphTraverser)
+                    + workspaceSchemes
+            schemes = defaultSchemes(
+                testableSchemes: testableSchemes,
+                workspaceSchemes: workspaceSchemes,
+                graphTraverser: graphTraverser,
+                testPlanConfiguration: testPlanConfiguration,
+                action: action
+            )
             await updateTestServiceAnalytics(
                 mapperEnvironment: mapperEnvironment,
                 schemes: schemes,
@@ -499,19 +508,8 @@ public struct TestService { // swiftlint:disable:this type_body_length
             passthroughXcodeBuildArguments += ["-testProductsPath", productsPath.pathString]
         }
 
-        let schemeTestTargetNames = Set(
-            schemes.flatMap {
-                testActionTargetReferences(
-                    scheme: $0,
-                    testPlanConfiguration: testPlanConfiguration,
-                    action: action
-                )
-            }.map(\.name)
-        )
-        let testTargets = testTargets.filter { schemeTestTargetNames.contains($0.target) }
-
         do {
-            try await testSchemes(
+            let didRunTests = try await testSchemes(
                 schemes,
                 graph: graph,
                 mapperEnvironment: mapperEnvironment,
@@ -535,6 +533,19 @@ public struct TestService { // swiftlint:disable:this type_body_length
                 quarantinedTests: mutedQuarantinedTests,
                 mode: mode
             )
+            if !didRunTests {
+                if action == .build {
+                    try await outputEmptyShardMatrixIfNeeded(isSharding: isSharding, action: action)
+                } else {
+                    let timer = clock.startTimer()
+                    try await uploadSkippedTestSummary(
+                        schemeName: schemes.first?.name,
+                        config: config,
+                        timer: timer
+                    )
+                }
+                return
+            }
         } catch {
             try await copyResultBundlePathIfNeeded(
                 runResultBundlePath: runResultBundlePath,
@@ -1147,20 +1158,11 @@ public struct TestService { // swiftlint:disable:this type_body_length
         config: Tuist,
         quarantinedTests: [TestIdentifier],
         mode: TestProcessingMode = .local
-    ) async throws {
-        let timer = clock.startTimer()
+    ) async throws -> Bool {
         let graphTraverser = GraphTraverser(graph: graph)
-        let testSchemes =
-            schemes
-                .filter {
-                    !testActionTargetReferences(
-                        scheme: $0, testPlanConfiguration: testPlanConfiguration,
-                        action: action
-                    ).isEmpty
-                }
 
-        guard !testSchemes.isEmpty else {
-            return
+        guard !schemes.isEmpty else {
+            return false
         }
 
         let uploadCacheStorage: CacheStoring
@@ -1171,7 +1173,29 @@ public struct TestService { // swiftlint:disable:this type_body_length
         }
 
         do {
-            for testScheme in testSchemes {
+            var didRunTests = false
+            for testScheme in schemes {
+                let testSchemeTargetNames = Set(
+                    testActionTargetReferences(
+                        scheme: testScheme,
+                        testPlanConfiguration: testPlanConfiguration,
+                        action: action
+                    )
+                    .map(\.name)
+                )
+                if testSchemeTargetNames.isEmpty {
+                    continue
+                }
+
+                let testSchemeTestTargets = testTargets.filter {
+                    testSchemeTargetNames.contains($0.target)
+                }
+
+                if !testTargets.isEmpty, testSchemeTestTargets.isEmpty {
+                    continue
+                }
+
+                didRunTests = true
                 try await self.testScheme(
                     scheme: testScheme,
                     graphTraverser: graphTraverser,
@@ -1185,7 +1209,7 @@ public struct TestService { // swiftlint:disable:this type_body_length
                     resultBundlePath: resultBundlePath,
                     derivedDataPath: derivedDataPath,
                     retryCount: retryCount,
-                    testTargets: testTargets,
+                    testTargets: testSchemeTestTargets,
                     skipTestTargets: skipTestTargets,
                     testPlanConfiguration: testPlanConfiguration,
                     passthroughXcodeBuildArguments: passthroughXcodeBuildArguments,
@@ -1193,6 +1217,9 @@ public struct TestService { // swiftlint:disable:this type_body_length
                     quarantinedTests: quarantinedTests,
                     mode: mode
                 )
+            }
+            guard didRunTests else {
+                return false
             }
         } catch {
             guard action != .build, let resultBundlePath else { throw error }
@@ -1218,7 +1245,7 @@ public struct TestService { // swiftlint:disable:this type_body_length
             )
 
             if testQuarantineService.onlyQuarantinedTestsFailed(testStatuses: testStatuses, quarantinedTests: quarantinedTests) {
-                return
+                return true
             }
 
             throw error
@@ -1250,6 +1277,8 @@ public struct TestService { // swiftlint:disable:this type_body_length
         } else {
             AlertController.current.success(.alert("The project tests \(verb) successfully"))
         }
+
+        return true
     }
 
     private func updateTestServiceAnalytics(
@@ -1310,6 +1339,100 @@ public struct TestService { // swiftlint:disable:this type_body_length
         }
     }
 
+    private func defaultSchemes(
+        testableSchemes: [Scheme],
+        workspaceSchemes: [Scheme],
+        graphTraverser: GraphTraversing,
+        testPlanConfiguration: TestPlanConfiguration?,
+        action: XcodeBuildTestAction
+    ) -> [Scheme] {
+        guard action != .build,
+              containsMixedHostedAndHostlessUnitTests(
+                  schemes: workspaceSchemes,
+                  graphTraverser: graphTraverser,
+                  testPlanConfiguration: testPlanConfiguration,
+                  action: action
+              )
+        else {
+            return workspaceSchemes
+        }
+
+        let workspaceSchemeNames = Set(workspaceSchemes.map(\.name))
+        let workspaceTestTargets = Set(
+            workspaceSchemes.flatMap {
+                testActionTargetReferences(
+                    scheme: $0,
+                    testPlanConfiguration: testPlanConfiguration,
+                    action: action
+                )
+            }
+        )
+        let projectSchemes = testableSchemes.filter {
+            guard !workspaceSchemeNames.contains($0.name) else {
+                return false
+            }
+
+            let schemeTestTargets = Set(
+                testActionTargetReferences(
+                    scheme: $0,
+                    testPlanConfiguration: testPlanConfiguration,
+                    action: action
+                )
+            )
+            return !schemeTestTargets.isDisjoint(with: workspaceTestTargets)
+        }
+        guard !projectSchemes.isEmpty else {
+            return workspaceSchemes
+        }
+
+        Logger.current.debug(
+            "Workspace schemes include hosted tests and host-less unit tests; running generated project schemes separately."
+        )
+        return projectSchemes
+    }
+
+    private func containsMixedHostedAndHostlessUnitTests(
+        schemes: [Scheme],
+        graphTraverser: GraphTraversing,
+        testPlanConfiguration: TestPlanConfiguration?,
+        action: XcodeBuildTestAction
+    ) -> Bool {
+        schemes.contains { scheme in
+            let testTargets = testActionTargetReferences(
+                scheme: scheme,
+                testPlanConfiguration: testPlanConfiguration,
+                action: action
+            )
+
+            var hasHostedTests = false
+            var hasHostlessUnitTests = false
+
+            for targetReference in testTargets {
+                guard let graphTarget = graphTraverser.target(
+                    path: targetReference.projectPath,
+                    name: targetReference.name
+                ) else {
+                    continue
+                }
+
+                let dependencies = graphTraverser
+                    .directTargetDependencies(path: graphTarget.path, name: graphTarget.target.name)
+
+                if dependencies.contains(where: { $0.target.product.canHostTests() }) {
+                    hasHostedTests = true
+                } else if graphTarget.target.product == .unitTests, !dependencies.isEmpty {
+                    hasHostlessUnitTests = true
+                }
+
+                if hasHostedTests, hasHostlessUnitTests {
+                    return true
+                }
+            }
+
+            return false
+        }
+    }
+
     private func shouldRunTest(
         for schemes: [Scheme],
         testPlanConfiguration: TestPlanConfiguration?,
@@ -1327,15 +1450,7 @@ public struct TestService { // swiftlint:disable:this type_body_length
         )
         .map(\.target)
 
-        let testSchemes =
-            schemes
-                .filter {
-                    !testActionTargetReferences(
-                        scheme: $0, testPlanConfiguration: testPlanConfiguration, action: action
-                    ).isEmpty
-                }
-
-        if testSchemes.isEmpty {
+        if schemes.isEmpty {
             Logger.current.log(level: .info, "There are no tests to run, finishing early")
             return false
         }
@@ -1453,28 +1568,25 @@ public struct TestService { // swiftlint:disable:this type_body_length
         testPlanConfiguration: TestPlanConfiguration?,
         action: XcodeBuildTestAction
     ) -> [TargetReference] {
-        let targets =
-            if let testPlanConfiguration {
-                scheme.testAction?.testPlans?
-                    .first(
-                        where: { $0.name == testPlanConfiguration.testPlan }
-                    )?.testTargets.map(\.target) ?? []
-            } else if action == .build, let testPlans = scheme.testAction?.testPlans {
-                // If we are building a scheme that has testplans but none specified then we should return all test targets
-                testPlans.flatMap(\.testTargets).map(\.target)
-            } else if let defaultTestPlan = scheme.testAction?.testPlans?.first(where: {
-                $0.isDefault
-            }) {
-                defaultTestPlan.testTargets.map(\.target)
-            } else if let testActionTargets = scheme.testAction?.targets.map(\.target),
-                      !testActionTargets.isEmpty
-            {
-                testActionTargets
-            } else {
-                [TargetReference]()
-            }
-
-        return targets
+        return if let testPlanConfiguration {
+            scheme.testAction?.testPlans?
+                .first(
+                    where: { $0.name == testPlanConfiguration.testPlan }
+                )?.testTargets.map(\.target) ?? []
+        } else if action == .build, let testPlans = scheme.testAction?.testPlans {
+            // If we are building a scheme that has testplans but none specified then we should return all test targets
+            testPlans.flatMap(\.testTargets).map(\.target)
+        } else if let defaultTestPlan = scheme.testAction?.testPlans?.first(where: {
+            $0.isDefault
+        }) {
+            defaultTestPlan.testTargets.map(\.target)
+        } else if let testActionTargets = scheme.testAction?.targets.map(\.target),
+                  !testActionTargets.isEmpty
+        {
+            testActionTargets
+        } else {
+            [TargetReference]()
+        }
     }
 
     private func storeSuccessfulTestHashes(

--- a/cli/Tests/TuistKitTests/Services/TestServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/TestServiceTests.swift
@@ -2,6 +2,7 @@ import Command
 import Foundation
 import Mockable
 import Path
+import struct TSCUtility.Version
 import TuistAlert
 import TuistAutomation
 import TuistCache
@@ -23,9 +24,6 @@ import TuistXCResultService
 import XcodeGraph
 import XCResultParser
 import XCTest
-
-import struct TSCUtility.Version
-
 @testable import TuistKit
 @testable import TuistTesting
 
@@ -381,7 +379,7 @@ final class TestServiceTests: TuistUnitTestCase {
         )
     }
 
-    func test_throws_when_shard_planning_flags_are_passed_without_build_only() async throws {
+    func test_throws_when_shard_planning_flags_are_passed_without_build_only() async {
         await XCTAssertThrowsSpecific(
             {
                 try await testRun(
@@ -394,7 +392,7 @@ final class TestServiceTests: TuistUnitTestCase {
         )
     }
 
-    func test_throws_when_shard_index_is_passed_without_without_building() async throws {
+    func test_throws_when_shard_index_is_passed_without_without_building() async {
         await XCTAssertThrowsSpecific(
             {
                 try await testRun(
@@ -407,7 +405,7 @@ final class TestServiceTests: TuistUnitTestCase {
         )
     }
 
-    func test_throws_when_shard_index_is_passed_without_full_handle() async throws {
+    func test_throws_when_shard_index_is_passed_without_full_handle() async {
         // Given
         given(configLoader)
             .loadConfig(path: .any)
@@ -843,7 +841,7 @@ final class TestServiceTests: TuistUnitTestCase {
                 .test(
                     project: .testGeneratedProject(),
                     fullHandle: "tuist/tuist",
-                    url: URL(string: "https://example.com")!
+                    url: try XCTUnwrap(URL(string: "https://example.com"))
                 )
             )
 
@@ -869,7 +867,7 @@ final class TestServiceTests: TuistUnitTestCase {
                 scheme: .any,
                 configuration: .any
             )
-            .willReturn(URL(string: "https://tuist.dev/test")!)
+            .willReturn(try XCTUnwrap(URL(string: "https://tuist.dev/test")))
 
         // When
         try await testRun(
@@ -2576,6 +2574,175 @@ final class TestServiceTests: TuistUnitTestCase {
         // Then — only TargetA should be passed to xcodebuild, PrunedTarget should be filtered out
         XCTAssertEqual(testedSchemes, ["App-Workspace"])
         XCTAssertEqual(capturedTestTargets, [try TestIdentifier(target: "TargetA", class: nil)])
+    }
+
+    func test_run_skips_xcodebuild_when_all_requested_test_targets_are_pruned_from_scheme() async throws {
+        // Given
+        let projectPath = try temporaryPath().appending(component: "Project")
+        let scheme = Scheme.test(
+            name: "App-Workspace",
+            testAction: .test(
+                targets: [
+                    .test(target: TargetReference(projectPath: projectPath, name: "TargetA")),
+                ]
+            )
+        )
+
+        given(configLoader)
+            .loadConfig(path: .any)
+            .willReturn(.test(project: .testGeneratedProject()))
+        given(generatorFactory)
+            .testing(
+                config: .any,
+                testPlan: .any,
+                includedTargets: .any,
+                excludedTargets: .any,
+                skipUITests: .any,
+                skipUnitTests: .any,
+                configuration: .any,
+                ignoreBinaryCache: .any,
+                ignoreSelectiveTesting: .any,
+                cacheStorage: .any,
+                destination: .any,
+                schemeName: .any
+            )
+            .willReturn(generator)
+        given(generator)
+            .generateWithGraph(path: .any, options: .any)
+            .willProduce { path, _ in
+                (
+                    path,
+                    .test(
+                        projects: [
+                            projectPath: .test(
+                                path: projectPath,
+                                targets: [.test(name: "TargetA")],
+                                schemes: [scheme]
+                            ),
+                        ]
+                    ),
+                    MapperEnvironment()
+                )
+            }
+        given(buildGraphInspector)
+            .testableSchemes(graphTraverser: .any)
+            .willReturn([])
+        given(buildGraphInspector)
+            .workspaceSchemes(graphTraverser: .any)
+            .willReturn([scheme])
+
+        // When
+        try await testRun(
+            path: try temporaryPath(),
+            testTargets: [try .init(target: "PrunedTarget", class: nil)]
+        )
+
+        // Then
+        XCTAssertEqual(testedSchemes, [])
+    }
+
+    func test_run_without_scheme_uses_project_schemes_when_workspace_scheme_contains_hostless_unit_tests() async throws {
+        // Given
+        let appProjectPath = try temporaryPath().appending(component: "App")
+        let featureProjectPath = try temporaryPath().appending(component: "Feature")
+        let app = Target.test(name: "App", product: .app)
+        let appTests = Target.test(name: "AppTests", product: .unitTests)
+        let feature = Target.test(name: "Feature", product: .framework)
+        let featureTests = Target.test(name: "FeatureTests", product: .unitTests)
+        let appTestsReference = TargetReference(projectPath: appProjectPath, name: appTests.name)
+        let featureTestsReference = TargetReference(projectPath: featureProjectPath, name: featureTests.name)
+        let appScheme = Scheme.test(
+            name: "App",
+            testAction: .test(targets: [.test(target: appTestsReference)])
+        )
+        let featureScheme = Scheme.test(
+            name: "Feature",
+            testAction: .test(targets: [.test(target: featureTestsReference)])
+        )
+        let workspaceScheme = Scheme.test(
+            name: "Sample-Workspace",
+            testAction: .test(
+                targets: [
+                    .test(target: appTestsReference),
+                    .test(target: featureTestsReference),
+                ]
+            )
+        )
+        let appProject = Project.test(
+            path: appProjectPath,
+            targets: [app, appTests],
+            schemes: [appScheme]
+        )
+        let featureProject = Project.test(
+            path: featureProjectPath,
+            targets: [feature, featureTests],
+            schemes: [featureScheme]
+        )
+        let workspace = Workspace.test(
+            name: "Sample",
+            projects: [appProjectPath, featureProjectPath],
+            schemes: [workspaceScheme]
+        )
+        let graph = Graph.test(
+            workspace: workspace,
+            projects: [
+                appProjectPath: appProject,
+                featureProjectPath: featureProject,
+            ],
+            dependencies: [
+                .target(name: appTests.name, path: appProjectPath): [
+                    .target(name: app.name, path: appProjectPath),
+                ],
+                .target(name: featureTests.name, path: featureProjectPath): [
+                    .target(name: feature.name, path: featureProjectPath),
+                ],
+            ]
+        )
+
+        given(configLoader)
+            .loadConfig(path: .any)
+            .willReturn(.test(project: .testGeneratedProject()))
+        given(generatorFactory)
+            .testing(
+                config: .any,
+                testPlan: .any,
+                includedTargets: .any,
+                excludedTargets: .any,
+                skipUITests: .any,
+                skipUnitTests: .any,
+                configuration: .any,
+                ignoreBinaryCache: .any,
+                ignoreSelectiveTesting: .any,
+                cacheStorage: .any,
+                destination: .any,
+                schemeName: .any
+            )
+            .willReturn(generator)
+        given(generator)
+            .generateWithGraph(path: .any, options: .any)
+            .willProduce { path, _ in (path, graph, MapperEnvironment()) }
+        given(buildGraphInspector)
+            .testableSchemes(graphTraverser: .any)
+            .willReturn([appScheme, featureScheme, workspaceScheme])
+        given(buildGraphInspector)
+            .workspaceSchemes(graphTraverser: .any)
+            .willReturn([workspaceScheme])
+
+        // When
+        try await testRun(path: try temporaryPath())
+
+        // Then
+        XCTAssertEqual(testedSchemes, ["App", "Feature"])
+
+        // When
+        testedSchemes = []
+        try await testRun(
+            path: try temporaryPath(),
+            testTargets: [try TestIdentifier(target: "FeatureTests", class: nil)]
+        )
+
+        // Then
+        XCTAssertEqual(testedSchemes, ["Feature"])
     }
 
     func test_run_skips_xcodebuild_when_passthrough_skip_testing_removes_all_selective_targets() async throws {
@@ -4678,7 +4845,7 @@ final class TestServiceTests: TuistUnitTestCase {
                 .test(
                     project: .testGeneratedProject(),
                     fullHandle: "tuist/tuist",
-                    url: URL(string: "https://tuist.dev")!
+                    url: try XCTUnwrap(URL(string: "https://tuist.dev"))
                 )
             )
         given(xcodebuildController)


### PR DESCRIPTION
## What changed

- Keep explicit `tuist test --scheme ...` behavior unchanged.
- For default `tuist test` runs, continue using the autogenerated workspace scheme unless that workspace scheme contains host-less unit test bundles.
- When host-less unit tests are present, run the generated project test schemes that cover the workspace scheme's test targets instead of running the mixed workspace aggregate.
- Filter `--test-targets` and `--skip-test-targets` per split scheme so a request for `FeatureTests` does not accidentally run `AppTests`.
- Preserve the existing selective-testing behavior that skips generated schemes with no remaining test-action targets.

## Why

This fixes the behavior reported in [Tuist test runs host-less module unit tests in the app launch context - xctest crashes at bootstrap](https://community.tuist.dev/t/tuist-test-runs-host-less-module-unit-tests-in-the-app-launch-context-xctest-crashes-at-bootstrap/993).

The community repro has one app-hosted test bundle and one host-less framework test bundle in the autogenerated `Sample-Workspace` scheme. With Xcode 26.5, the aggregate scheme builds both bundles, runs the app-hosted test, then crashes while bootstrapping the host-less `FeatureTests` bundle:

`Early unexpected exit, operation never finished bootstrapping - no restart will be attempted. (Underlying Error: The test runner crashed while preparing to run tests: xctest at <external symbol>)`

I first tried making the workspace scheme use a host-less module as macro expansion / launch context, but the sample still crashed in the aggregate run. The passing path is the one Xcode already handles correctly: run the generated project schemes separately (`App`, then `Feature`) instead of mixing app-hosted and host-less bundles in the workspace aggregate.

## Validation

- `swiftformat 0.58.7` on the touched Swift files.
- `swiftlint 0.59.1 lint --no-cache` on the touched source files: exited 0. It still reports existing warnings for large functions / legacy disables in these files.
- `git diff --check`
- Xcode 26.5 (`17F42`) unit coverage:
  - `xcodebuild test -workspace Tuist.xcworkspace -scheme TuistUnitTests -only-testing:TuistKitTests/TestServiceTests/test_run_tests_when_part_is_cached -only-testing:TuistKitTests/TestServiceTests/test_run_filters_test_targets_not_in_scheme -only-testing:TuistKitTests/TestServiceTests/test_run_skips_xcodebuild_when_all_requested_test_targets_are_pruned_from_scheme -only-testing:TuistKitTests/TestServiceTests/test_run_without_scheme_uses_project_schemes_when_workspace_scheme_contains_hostless_unit_tests -only-testing:TuistKitTests/TestServiceTests/test_run_tests_all_project_schemes -only-testing:TuistKitTests/TestServiceTests/test_run_build_infersSimulatorDestinationForSuiteShardPlanning CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=`
  - `xcodebuild test -workspace Tuist.xcworkspace -scheme TuistUnitTests -only-testing:TuistKitTests/TestServiceTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=`
- Xcode 26.5 (`17F42`) e2e sample verification on iPhone 17 Pro iOS 26.5 simulator (`4A6DAF88-CBE5-4391-8DB5-0FA655B68F59`):
  - Regenerated `/private/tmp/tuist-hostless-test-repro/tuist-hostless-test-repro` with Tuist 4.198.1.
  - `xcodebuild test -scheme Sample-Workspace`: failed, `passedTests=1`, `failedTests=1`, failure target `FeatureTests`, matching the xctest bootstrap crash.
  - `xcodebuild test -scheme App`: passed, `passedTests=1`, `failedTests=0`.
  - `xcodebuild test -scheme Feature`: passed, `passedTests=1`, `failedTests=0`.
