### PR TITLE
feat(infra): autoscale the staging Kura node pool

### DIFF
--- a/infra/k8s/clusters/cluster-staging.yaml
+++ b/infra/k8s/clusters/cluster-staging.yaml
@@ -64,11 +64,25 @@ spec:
         # controller-backed provisioning path can be exercised end to
         # end before the production regional pools receive the same
         # chart/controller changes. Kura defaults to three replicas with
-        # hard hostname spreading, so keep three workers.
+        # hard hostname spreading, so three workers is the floor.
+        # Runner-cache provisioning adds a single-replica instance per
+        # flag-enabled account, so demand varies with the dev-account
+        # population: autoscale like the production pools instead of
+        # pinning the size (see `autoscaling.tuist.dev/group` discovery
+        # in `infra/k8s/mgmt/cluster-autoscaler.yaml`). `replicas` is
+        # ignored once the autoscaler owns the group.
         - class: hcloud-worker
           name: kura
           replicas: 3
           failureDomain: fsn1
+          metadata:
+            labels:
+              autoscaling.tuist.dev/group: kura-staging
+            annotations:
+              cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size: "3"
+              cluster.x-k8s.io/cluster-api-autoscaler-node-group-max-size: "8"
+              cluster.x-k8s.io/cluster-autoscaler-node-group-min-size: "3"
+              cluster.x-k8s.io/cluster-autoscaler-node-group-max-size: "8"
           healthCheck:
             checks:
               nodeStartupTimeoutSeconds: 600

--- a/infra/k8s/clusters/cluster-staging.yaml
+++ b/infra/k8s/clusters/cluster-staging.yaml
@@ -75,14 +75,6 @@ spec:
           name: kura
           replicas: 3
           failureDomain: fsn1
-          metadata:
-            labels:
-              autoscaling.tuist.dev/group: kura-staging
-            annotations:
-              cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size: "3"
-              cluster.x-k8s.io/cluster-api-autoscaler-node-group-max-size: "8"
-              cluster.x-k8s.io/cluster-autoscaler-node-group-min-size: "3"
-              cluster.x-k8s.io/cluster-autoscaler-node-group-max-size: "8"
           healthCheck:
             checks:
               nodeStartupTimeoutSeconds: 600
@@ -99,6 +91,12 @@ spec:
           metadata:
             labels:
               node.cluster.x-k8s.io/pool: kura
+              autoscaling.tuist.dev/group: kura-staging
+            annotations:
+              cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size: "3"
+              cluster.x-k8s.io/cluster-api-autoscaler-node-group-max-size: "8"
+              cluster.x-k8s.io/cluster-autoscaler-node-group-min-size: "3"
+              cluster.x-k8s.io/cluster-autoscaler-node-group-max-size: "8"
           variables:
             overrides:
               - name: hcloudWorkerMachineType

--- a/infra/k8s/mgmt/cluster-autoscaler.yaml
+++ b/infra/k8s/mgmt/cluster-autoscaler.yaml
@@ -117,3 +117,71 @@ spec:
         - name: workload-kubeconfig
           secret:
             secretName: tuist-kubeconfig
+---
+# Staging gets its own autoscaler instance because each autoscaler
+# watches exactly one workload cluster for pending pods (via the
+# mounted kubeconfig). Staging's Kura pool sizes with the
+# runner-cache identity rule — one single-replica instance per
+# flag-enabled account — so its demand tracks the dev-account
+# population rather than a fixed replica count.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cluster-autoscaler-tuist-staging
+  namespace: org-tuist
+  labels:
+    app.kubernetes.io/name: cluster-autoscaler
+    app.kubernetes.io/instance: tuist-staging
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: cluster-autoscaler
+      app.kubernetes.io/instance: tuist-staging
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: cluster-autoscaler
+        app.kubernetes.io/instance: tuist-staging
+    spec:
+      serviceAccountName: cluster-autoscaler
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: cluster-autoscaler
+          image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.34.0
+          imagePullPolicy: IfNotPresent
+          command:
+            - /cluster-autoscaler
+          args:
+            - --cloud-provider=clusterapi
+            - --clusterapi-cloud-config-authoritative
+            - --kubeconfig=/etc/cluster-autoscaler/workload/value
+            - --node-group-auto-discovery=clusterapi:namespace=org-tuist,clusterName=tuist-staging,autoscaling.tuist.dev/group=kura-staging
+            - --scale-down-unneeded-time=10m
+            - --scale-down-delay-after-add=10m
+            - --max-node-provision-time=15m
+            - --v=4
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              memory: 512Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 65532
+          volumeMounts:
+            - name: workload-kubeconfig
+              mountPath: /etc/cluster-autoscaler/workload
+              readOnly: true
+      volumes:
+        - name: workload-kubeconfig
+          secret:
+            secretName: tuist-staging-kubeconfig


### PR DESCRIPTION
## Problem

The staging Kura pool is pinned at 3× 2-vCPU workers, sized for the single three-replica regional smoke instance. Runner-cache provisioning (#11210) adds a single-replica KuraInstance per `:runners`-flag-enabled account. With the flag now default-enabled on staging, ~16 Kura pods × 500m contend for ~6 allocatable CPUs — newly provisioned instances (including `kura-tuist-staging`, needed for the Scaleway A/B benchmark) sit Pending indefinitely, and reconciler-driven churn turns scheduling into musical chairs.

## Change

Mirror the production pools' autoscaling setup for staging:

- Label the staging `kura` MachineDeployment as autoscaling group `kura-staging` with min 3 / max 8 (prod pools run min 3 / max 12–32).
- Add a `cluster-autoscaler-tuist-staging` Deployment alongside the existing prod one. A second instance is required because each autoscaler watches exactly one workload cluster for pending pods via its mounted CAPI kubeconfig (`tuist-staging-kubeconfig`, auto-generated in `org-tuist`).

Applied automatically by `mgmt-cluster-apply` on merge.

## Verification

- Both manifests parse as valid multi-doc YAML.
- New Deployment's selector is disjoint from prod's (`app.kubernetes.io/instance: tuist-staging` vs `tuist`); existing selectors untouched (selectors are immutable).
- RBAC/ServiceAccount shared with the prod instance — the Role already grants MachineDeployment scale in `org-tuist`, which holds both clusters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)