### PR TITLE
fix(infra): use existing Kura introspection items

### DIFF
--- a/infra/helm/tuist/values-managed-canary.yaml
+++ b/infra/helm/tuist/values-managed-canary.yaml
@@ -101,6 +101,12 @@ registryCache:
     rootDirectory: docker-mirror
 
 kuraController:
+  sharedSecrets:
+    externalSecret:
+      item: kura-introspection-oauth-client
+      fields:
+        introspectionClientId: client_id
+        introspectionClientSecret: client_secret
   telemetry:
     deploymentEnvironment: canary
   sentry:

--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -85,6 +85,12 @@ server:
     node.cluster.x-k8s.io/pool: general
 
 kuraController:
+  sharedSecrets:
+    externalSecret:
+      item: kura-introspection-oauth-client
+      fields:
+        introspectionClientId: client_id
+        introspectionClientSecret: client_secret
   telemetry:
     deploymentEnvironment: production
   sentry:


### PR DESCRIPTION
## What changed

- Point the managed canary and production Tuist Helm overlays at the existing `kura-introspection-oauth-client` 1Password item.
- Override the ExternalSecret field mapping for those two environments to read `client_id` and `client_secret`.
- Leave staging unchanged because its vault already contains the canonical `kura-introspection` item with `KURA_CONTROL_PLANE_CLIENT_ID` / `KURA_CONTROL_PLANE_CLIENT_SECRET`.

## Why

The canary deploy from `Server Production Deployment` run `27292019563` reached the app rollout but failed in `canary / Deploy to tuist-canary`. The migration hook completed successfully, then Helm waited until timeout because the new server pod could not start:

- `ExternalSecret/tuist-canary/kura-shared-secrets` could not resolve `kura-introspection/KURA_CONTROL_PLANE_CLIENT_ID`.
- The pod then failed with `couldn't find key KURA_CONTROL_PLANE_CLIENT_ID in Secret tuist-canary/kura-shared-secrets`.

I checked 1Password item metadata without printing secret values. Staging has the canonical item, but canary and production currently have the existing OAuth client item named `kura-introspection-oauth-client` with `client_id` / `client_secret` fields. The chart already supports per-environment item and field overrides, so this keeps the secret store as-is and makes the managed overlays match reality.

## Impact

Canary should be able to sync `kura-shared-secrets` and start the server pod on the next deploy. Production is updated at the same time so it does not hit the same missing-item failure after canary passes.

## Validation

- Inspected the failed job logs from `27292019563 / 80618234543`.
- Confirmed 1Password item presence and field labels only, without printing secret values.
- Rendered `templates/kura-controller.yaml` for managed canary, production, and staging with dummy CI image values.
- Verified canary and production render `kura-introspection-oauth-client/client_id` and `kura-introspection-oauth-client/client_secret`.
- Verified staging still renders `kura-introspection/KURA_CONTROL_PLANE_CLIENT_ID` and `kura-introspection/KURA_CONTROL_PLANE_CLIENT_SECRET`.
- Ran `helm lint` for managed canary, production, and staging overlays.
- Ran `git diff --check`.
