### PR TITLE
fix(infra): drop pinned replicas from the autoscaled staging kura pool

### DIFF
--- a/infra/k8s/clusters/cluster-staging.yaml
+++ b/infra/k8s/clusters/cluster-staging.yaml
@@ -69,11 +69,11 @@ spec:
         # flag-enabled account, so demand varies with the dev-account
         # population: autoscale like the production pools instead of
         # pinning the size (see `autoscaling.tuist.dev/group` discovery
-        # in `infra/k8s/mgmt/cluster-autoscaler.yaml`). `replicas` is
-        # ignored once the autoscaler owns the group.
+        # in `infra/k8s/mgmt/cluster-autoscaler.yaml`). `replicas` must
+        # stay unset: CAPI rejects a MachineDeploymentTopology that
+        # pins replicas while carrying autoscaler annotations.
         - class: hcloud-worker
           name: kura
-          replicas: 3
           failureDomain: fsn1
           healthCheck:
             checks:


### PR DESCRIPTION
Follow-up to #11226, which the mgmt apply rejected:

```
The Cluster "tuist-staging" is invalid: spec.topology.workers.machineDeployments[kura].replicas:
Invalid value: 3: cannot be set ... if the same MachineDeploymentTopology has autoscaler annotations
```

CAPI requires the autoscaler to own the pool size exclusively — the production kura pools already omit `replicas` for this reason. The `min-size: "3"` annotation keeps the three-worker floor, so nothing scales below today's capacity.

(The other three Cluster CRs applied cleanly in [the failing run](https://github.com/tuist/tuist/actions/runs/27344506327); only `tuist-staging` was rejected, so the live staging pool is unchanged until this lands.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)