### PR TITLE
fix(cli): pin SwifterPM revision

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "6f9fa5f78b90466b8bc72adaa8cc8c70ae3d3e9108a4e8f6e17756ddc2f59c8b",
+  "originHash" : "ea0afab334cf343ec89bbc8f4f74364353e3480b9a63b9b61911801a52864480",
   "pins" : [
     {
       "identity" : "1024jp.gzipswift",
@@ -519,8 +519,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tuist/swifterpm",
       "state" : {
-        "revision" : "f080e74fec1865a42d25bfa6e200d144cfe43b56",
-        "version" : "0.8.3"
+        "revision" : "672a723f962cf243f1b6de65274c744c51e82acc"
       }
     },
     {
@@ -616,7 +615,7 @@
       "kind" : "registry",
       "location" : "",
       "state" : {
-        "version" : "0.17.3"
+        "version" : "0.18.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -1796,7 +1796,10 @@ let package = Package(
         .package(id: "swiftlang.swift-docc-plugin", from: "1.4.6"),
         .package(name: "XCResultNIF", path: "server/native/xcresult_nif"),
         .package(id: "stephencelis.SQLite_swift", from: "0.16.0"),
-        .package(url: "https://github.com/tuist/swifterpm", exact: "0.8.3"),
+        .package(
+            url: "https://github.com/tuist/swifterpm",
+            revision: "672a723f962cf243f1b6de65274c744c51e82acc"
+        ),
     ],
     targets: targets,
     swiftLanguageModes: [.v5]


### PR DESCRIPTION
## What changed

Tuist now temporarily depends on SwifterPM revision `672a723f962cf243f1b6de65274c744c51e82acc` instead of the tagged `0.8.3` release.

`Package.resolved` was updated to reflect that revision pin and the `tuist.FileSystem` `0.18.0` transitive requirement introduced by the SwifterPM fix.

## Why

The current CLI release path needs the SwifterPM change that shells out to SwiftPM and removes the raw SwiftPM library dependency before a tagged SwifterPM release is available. Pinning the revision lets Tuist consume that fix immediately while keeping the change easy to revert once SwifterPM publishes a tag.

## Root cause

The Tuist binary regression came from pulling in SwiftPM as a library through SwifterPM, which changed the packaged CLI binary shape and introduced Swift runtime compatibility library expectations on CI. The SwifterPM fix restores a consumable path that avoids inheriting that raw SwiftPM revision dependency.

## Impact

This is intentionally temporary. Tuist can unblock the CLI fix now, and we should switch back to a tagged SwifterPM release as soon as one containing the FileSystem/shell-out fix is published.

## Validation

- `swift package --disable-sandbox --scratch-path /private/tmp/tuist-spm-scratch-672a --cache-path /private/tmp/tuist-spm-cache --config-path .swiftpm/configuration --security-path /private/tmp/tuist-spm-security --manifest-cache local --replace-scm-with-registry --force-resolved-versions resolve`
- `git diff --check`
