### PR TITLE
fix(cli): stop SIGTRAP on missing session logs.txt and bare tuist invocation

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -56,6 +56,7 @@ var tuistDependencies: [Target.Dependency] = [
     argumentParserDependency,
     "TuistServer",
     pathDependency,
+    fileSystemDependency,
     swiftToolsSupportDependency,
 ]
 var tuistCacheCommandDependencies: [Target.Dependency] = [

--- a/cli/Sources/TuistKit/Services/TuistService.swift
+++ b/cli/Sources/TuistKit/Services/TuistService.swift
@@ -39,6 +39,10 @@ public final class TuistService: NSObject {
     ) async throws {
         var arguments = arguments
 
+        guard !arguments.isEmpty else {
+            throw TuistServiceError.taskUnavailable
+        }
+
         let commandName = "tuist-\(arguments[0])"
 
         let path = try await CommandArguments.path(in: arguments)

--- a/cli/Sources/tuist/Dependencies.swift
+++ b/cli/Sources/tuist/Dependencies.swift
@@ -1,3 +1,4 @@
+import FileSystem
 import Foundation
 import Noora
 import Path
@@ -132,8 +133,20 @@ func initNoora(jsonThroughNoora: Bool = false) -> Noora {
     }
 
     func withLoggerForNoora(logFilePath: AbsolutePath, _ action: () async throws -> Void) async throws {
-        let loggerHandler = try Logger.loggerHandlerForNoora(logFilePath: logFilePath)
-        try await Logger.$current.withValue(Logger(label: "dev.tuist.cli", factory: loggerHandler)) {
+        let loggerHandler: (@Sendable (String) -> any LogHandler)?
+        do {
+            let fileSystem = FileSystem()
+            try await fileSystem.touch(logFilePath)
+            loggerHandler = try Logger.loggerHandlerForNoora(logFilePath: logFilePath)
+        } catch {
+            loggerHandler = nil
+        }
+
+        if let loggerHandler {
+            try await Logger.$current.withValue(Logger(label: "dev.tuist.cli", factory: loggerHandler)) {
+                try await action()
+            }
+        } else {
             try await action()
         }
     }
@@ -215,8 +228,20 @@ func initNoora(jsonThroughNoora: Bool = false) -> Noora {
     }
 
     func withLoggerForNoora(logFilePath: AbsolutePath, _ action: () async throws -> Void) async throws {
-        let loggerHandler = try Logger.loggerHandlerForNoora(logFilePath: logFilePath)
-        try await Logger.$current.withValue(Logger(label: "dev.tuist.cli", factory: loggerHandler)) {
+        let loggerHandler: (@Sendable (String) -> any LogHandler)?
+        do {
+            let fileSystem = FileSystem()
+            try await fileSystem.touch(logFilePath)
+            loggerHandler = try Logger.loggerHandlerForNoora(logFilePath: logFilePath)
+        } catch {
+            loggerHandler = nil
+        }
+
+        if let loggerHandler {
+            try await Logger.$current.withValue(Logger(label: "dev.tuist.cli", factory: loggerHandler)) {
+                try await action()
+            }
+        } else {
             try await action()
         }
     }


### PR DESCRIPTION
Resolves no tracked issue.

Two adjacent fixes for fatal traps reported by CI users on recent CLI releases.

### What changed

**1. `withLoggerForNoora` in the tuist executable target now degrades gracefully when the session log file is missing.**

PR #9324 added a safe re-touch + `do/catch` to `withLoggerForNoora` in `cli/Sources/TuistKit/Utils/Dependencies.swift`. The tuist executable target (`cli/Sources/tuist/Dependencies.swift`) redeclares the same function, and Swift name resolution picked the local unguarded copy for every call from `TuistCommand` — so the TuistKit fix never took effect at the call site that actually fires. When the session directory disappeared mid-run (cleanup races, host workspace pruning), `SimpleFileLogHandler.init` threw `NSCocoaErrorDomain Code=4 "The file logs.txt doesn't exist"`, which propagated to `swift_errorInMain` and trapped the CLI with `SIGTRAP`. PR #11083 patched the cleanup race at the SessionController layer, but did not close the call-site exposure.

This PR mirrors the TuistKit-side pattern in both the macOS and Linux variants of the executable's `withLoggerForNoora`: re-`touch` the log path via `FileSystem`, and fall back to a logger-less action on failure. Also adds `fileSystemDependency` to `tuistDependencies` in `Package.swift` so `import FileSystem` resolves under SPM (`Project.swift` already declared it).

**2. `TuistService.run` guards against empty arguments.**

When `tuist` is invoked with no subcommand, `parseAsRoot` throws and `TuistCommand.executeTask` calls `TuistService().run(arguments: [], …)`. The first line builds `"tuist-\(arguments[0])"`, which traps with index-out-of-range before the outer catch can show the ArgumentParser help. The guard throws `TuistServiceError.taskUnavailable` instead so the parsing error surfaces normally.

### How to test locally

For the `withLoggerForNoora` fix:

```sh
# In any tuist-using project workspace
tuist install &
sleep 0.1
rm -rf "$XDG_STATE_HOME/tuist/sessions/"*/logs.txt 2>/dev/null \
  || rm -rf ~/.local/state/tuist/sessions/*/logs.txt
wait
```

Before this change the process terminates with `Fatal error: Error raised at top level: Error Domain=NSCocoaErrorDomain Code=4 "The file "logs.txt" doesn't exist."`. After, the command finishes cleanly (with logging disabled for that invocation).

For the `TuistService.run` guard, just run `tuist` with no arguments — it now prints help/usage instead of `trace trap`.

Compile-verified via `swift build --target tuist --replace-scm-with-registry` and an end-to-end bundle (CLI + dynamic `ProjectDescription.framework`) successfully ran a `--tuist-dump` JIT load against the project's own `Tuist.swift`.
