### PR TITLE
fix(infra): pin server migrations to server nodes

### DIFF
--- a/infra/helm/tuist/templates/server-migration-job.yaml
+++ b/infra/helm/tuist/templates/server-migration-job.yaml
@@ -31,6 +31,14 @@ spec:
     spec:
       serviceAccountName: {{ include "tuist.componentServiceAccountName" (dict "root" . "component" "server") }}
       {{- include "tuist.podScheduling" . | nindent 6 }}
+      {{- with .Values.server.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.server.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       restartPolicy: Never
       {{- if not .Values.server.managedSecrets }}
       # Only wait for embedded Postgres / ClickHouse to come up when chart


### PR DESCRIPTION
## What changed

- Apply the server `nodeSelector` and `tolerations` to the Helm pre-upgrade server migration Job.

## Why

The production deployment is currently blocking before the server rollout because the migration hook can schedule away from the server node pool. In the observed run, the migration pods landed on `tuist-kura-*` nodes while the existing server pods run on the general server pool.

## Root cause

The server Deployment already consumes `.Values.server.nodeSelector` and `.Values.server.tolerations`, but `server-migration-job.yaml` only inherited the chart-wide scheduling helper. That made the migration hook less constrained than the workload it prepares.

## Impact

Future server migrations should run on the intended server-capable node pool, reducing the chance that Helm gets stuck in the pre-upgrade hook before rolling out the new server image.

This intentionally does not inherit `server.affinity`: the Deployment's affinity is tuned for replicated server pods, while the migration hook is a single one-shot Job.

## Validation

- Rendered `templates/server-migration-job.yaml` with managed production values and confirmed the migration Job now includes `nodeSelector: node.cluster.x-k8s.io/pool: general`.
- Ran `git diff --check`.
