### PR TITLE
fix(infra): allow cache deploy SSH from runners

### DIFF
--- a/infra/helm/tuist/templates/runners-namespace.yaml
+++ b/infra/helm/tuist/templates/runners-namespace.yaml
@@ -248,6 +248,19 @@ spec:
           port: 443
         - protocol: TCP
           port: 80
+    {{- with .Values.runnersFleet.networkPolicy.sshAllowedCIDRs }}
+    # SSH egress for deploy jobs that run on Tuist Linux runners and
+    # use Kamal to connect to the cache fleet. Keep this scoped to
+    # explicit host CIDRs instead of allowing SSH to the public internet.
+    - to:
+        {{- range $cidr := . }}
+        - ipBlock:
+            cidr: {{ $cidr | quote }}
+        {{- end }}
+      ports:
+        - protocol: TCP
+          port: 22
+    {{- end }}
 ---
 # Dispatch-egress policy: lets a runner Pod reach the in-cluster
 # Tuist server's dispatch endpoint. Split out from the base policy

--- a/infra/helm/tuist/values-managed-canary.yaml
+++ b/infra/helm/tuist/values-managed-canary.yaml
@@ -247,6 +247,18 @@ runnersFleet:
       - "10.0.0.0/8"
       - "172.16.0.0/12"
       - "192.168.0.0/16"
+    sshAllowedCIDRs:
+      - "23.88.35.139/32" # cache-eu-central-canary.tuist.dev
+      - "91.98.153.89/32" # cache-eu-central.tuist.dev
+      - "89.167.56.215/32" # cache-eu-north.tuist.dev
+      - "5.161.104.150/32" # cache-us-east.tuist.dev
+      - "5.161.59.218/32" # cache-us-east-2.tuist.dev
+      - "178.156.142.121/32" # cache-us-east-3.tuist.dev
+      - "5.78.141.100/32" # cache-us-west.tuist.dev
+      - "5.223.58.97/32" # cache-ap-southeast.tuist.dev
+      - "64.176.21.188/32" # cache-sa-west.tuist.dev
+      - "149.28.189.13/32" # cache-au-east.tuist.dev
+      - "216.128.150.29/32" # cache-us-central.tuist.dev
   # macOS catalog (shapes + xcodeVersions) is shared across managed
   # envs via `values-managed-common.yaml`. Per-env tuning lives in
   # `xcodeOverrides`, a map keyed by `xcodeVersion`; the chart

--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -342,6 +342,18 @@ runnersFleet:
       - "10.0.0.0/8"
       - "172.16.0.0/12"
       - "192.168.0.0/16"
+    sshAllowedCIDRs:
+      - "23.88.35.139/32" # cache-eu-central-canary.tuist.dev
+      - "91.98.153.89/32" # cache-eu-central.tuist.dev
+      - "89.167.56.215/32" # cache-eu-north.tuist.dev
+      - "5.161.104.150/32" # cache-us-east.tuist.dev
+      - "5.161.59.218/32" # cache-us-east-2.tuist.dev
+      - "178.156.142.121/32" # cache-us-east-3.tuist.dev
+      - "5.78.141.100/32" # cache-us-west.tuist.dev
+      - "5.223.58.97/32" # cache-ap-southeast.tuist.dev
+      - "64.176.21.188/32" # cache-sa-west.tuist.dev
+      - "149.28.189.13/32" # cache-au-east.tuist.dev
+      - "216.128.150.29/32" # cache-us-central.tuist.dev
   # macOS catalog (shapes + xcodeVersions) is shared across managed
   # envs via `values-managed-common.yaml`. Per-env tuning lives in
   # `xcodeOverrides`, a map keyed by `xcodeVersion`; the chart

--- a/infra/helm/tuist/values-managed-staging.yaml
+++ b/infra/helm/tuist/values-managed-staging.yaml
@@ -328,6 +328,18 @@ runnersFleet:
       - "10.0.0.0/8"
       - "172.16.0.0/12"
       - "192.168.0.0/16"
+    sshAllowedCIDRs:
+      - "23.88.35.139/32" # cache-eu-central-canary.tuist.dev
+      - "91.98.153.89/32" # cache-eu-central.tuist.dev
+      - "89.167.56.215/32" # cache-eu-north.tuist.dev
+      - "5.161.104.150/32" # cache-us-east.tuist.dev
+      - "5.161.59.218/32" # cache-us-east-2.tuist.dev
+      - "178.156.142.121/32" # cache-us-east-3.tuist.dev
+      - "5.78.141.100/32" # cache-us-west.tuist.dev
+      - "5.223.58.97/32" # cache-ap-southeast.tuist.dev
+      - "64.176.21.188/32" # cache-sa-west.tuist.dev
+      - "149.28.189.13/32" # cache-au-east.tuist.dev
+      - "216.128.150.29/32" # cache-us-central.tuist.dev
   # macOS catalog (shapes + xcodeVersions) is shared across managed
   # envs via `values-managed-common.yaml`. Per-env tuning lives in
   # `xcodeOverrides`, a map keyed by `xcodeVersion`; the chart

--- a/infra/helm/tuist/values.yaml
+++ b/infra/helm/tuist/values.yaml
@@ -827,6 +827,10 @@ runnersFleet:
     # ranges (Pod CIDR, Service CIDR, Node CIDR, in-cluster
     # databases). Override per-env with the real cluster ranges.
     exceptCIDRs: []
+    # Public host CIDRs that runner Pods may reach over SSH. This is
+    # intentionally separate from the HTTP(S) egress rule so deploy
+    # workflows can allow only the hosts they manage.
+    sshAllowedCIDRs: []
   # macOS shape catalog. Symmetric with `runnersFleetLinux.shapes`:
   # single source of truth for the Profiles dropdown and the server's
   # `:runner_macos_shapes` validation. Injected into the server as


### PR DESCRIPTION
## What changed

- Adds `runnersFleet.networkPolicy.sshAllowedCIDRs` to the Tuist Helm chart.
- Renders a dedicated TCP/22 egress rule for runner Pods when that list is configured.
- Configures the managed staging, canary, and production values with the current cache canary and production node `/32` IPs.

## Why

Cache deploys run Kamal from `tuist-linux-large` runners. Those runners are selected by the runner namespace NetworkPolicy, whose public internet egress currently only allows TCP 80 and 443. Kamal can build and push the cache image to GHCR over HTTPS, but then it needs to SSH to `cache-eu-central-canary.tuist.dev` and the production cache nodes on TCP 22.

The failed `cache@0.32.7` deploy showed exactly that: the image built and pushed, then Kamal timed out connecting to `cache-eu-central-canary.tuist.dev`. The canary host did not record a `github-actions` SSH attempt during the deploy window, which points to network egress being blocked before the connection reached the host.

## Why this solution

The broad alternative would be allowing TCP 22 to `0.0.0.0/0` for all runner Pods. This keeps the existing constrained posture and only allows SSH to the cache fleet hosts that Kamal manages.

## Validation

- Confirmed SSH from this machine to `cache-eu-central-canary.tuist.dev` as `pedro` works.
- Rendered staging, canary, and production Helm output with deploy-time image values supplied, and confirmed the TCP/22 rule appears with the cache `/32` CIDRs.
- Ran:

```bash
helm lint infra/helm/tuist \
  -f infra/helm/tuist/values-managed-common.yaml \
  -f infra/helm/tuist/values-managed-production.yaml \
  --set runnersFleet.runnerImageSemver=0.0.0 \
  --set runnersFleetLinux.shapeRunnerImage=ghcr.io/tuist/tuist-linux-runner:test \
  --set kuraController.image.tag=test
```
