### PR TITLE
fix(cli): bundle Swift runtime libraries

### DIFF
--- a/mise/tasks/cli/bundle.sh
+++ b/mise/tasks/cli/bundle.sh
@@ -78,6 +78,22 @@ build_cli() {
     mv $BINARY_PATH $BUILD_DIRECTORY/tuist
 }
 
+bundle_swift_runtime_libraries() {
+    VENDOR_DIRECTORY=$BUILD_DIRECTORY/vendor
+    mkdir -p "$VENDOR_DIRECTORY"
+
+    xcrun swift-stdlib-tool --copy \
+        --scan-executable "$BUILD_DIRECTORY/tuist" \
+        --scan-executable "$BUILD_DIRECTORY/ProjectDescription.framework/ProjectDescription" \
+        --platform macosx \
+        --destination "$VENDOR_DIRECTORY"
+
+    if find "$VENDOR_DIRECTORY" -type f -name "*.dylib" -print -quit | grep -q .; then
+        install_name_tool -add_rpath "@executable_path/vendor" "$BUILD_DIRECTORY/tuist"
+        install_name_tool -add_rpath "@loader_path/../../../vendor" "$BUILD_DIRECTORY/ProjectDescription.framework/ProjectDescription"
+    fi
+}
+
 echo "$(format_section "Building")"
 
 echo "$(format_subsection "Generating Xcode project")"
@@ -88,6 +104,9 @@ build_cli
 
 echo "$(format_subsection "Building ProjectDescription framework")"
 build_project_desscription
+
+echo "$(format_subsection "Bundling Swift runtime libraries")"
+bundle_swift_runtime_libraries
 
 echo "$(format_section "Copying assets")"
 
@@ -100,11 +119,16 @@ echo "$(format_section "Bundling")"
     cd $BUILD_DIRECTORY || exit 1
 
     echo "$(format_subsection "Signing")"
+    if [ -d vendor ]; then
+        find vendor -type f -name "*.dylib" -print0 | while IFS= read -r -d '' library; do
+            /usr/bin/codesign --sign "$CERTIFICATE_NAME" --timestamp --options runtime --verbose "$library"
+        done
+    fi
     /usr/bin/codesign --sign "$CERTIFICATE_NAME" --timestamp --options runtime --verbose tuist
     /usr/bin/codesign --sign "$CERTIFICATE_NAME" --timestamp --options runtime --verbose ProjectDescription.framework
 
     echo "$(format_subsection "Notarizing")"
-    zip -q -r --symlinks "notarization-bundle.zip" tuist ProjectDescription.framework
+    zip -q -r --symlinks "notarization-bundle.zip" tuist ProjectDescription.framework vendor
 
     RAW_JSON=$(xcrun notarytool submit "notarization-bundle.zip" \
         --apple-id "$APPLE_ID" \


### PR DESCRIPTION
## What changed

The macOS CLI release bundler now runs `swift-stdlib-tool` against the shipped `tuist` executable and `ProjectDescription.framework`, copies any required Swift runtime libraries into `build/vendor`, and adds rpaths so dyld can resolve vendored libraries next to the executable.

The release script also signs any copied dylibs before signing `tuist` and `ProjectDescription.framework`, and includes `vendor` in the notarization bundle.

## Why

Tuist 4.199.0 includes the SwifterPM revision that removes the raw SwiftPM library dependency, but the released macOS binary can still require Swift runtime compatibility libraries from the Xcode 26 toolchain. In particular, `otool -L` on the 4.199.0 binary still shows `@rpath/libswiftCompatibilitySpan.dylib`, and `swift-stdlib-tool --print` reports that the binary needs `libswiftCompatibilitySpan.dylib`.

On machines that already have `/usr/lib/swift/libswiftCompatibilitySpan.dylib`, the binary launches. On older CI images, dyld fails before `main` because the release artifact does not bundle that compatibility dylib.

## Root cause

The release archive already includes `vendor` in `tuist.zip`, but the macOS release path never populated it with Swift runtime dylibs or added an rpath for it. With Xcode 26, parts of the statically linked CLI graph can autolink Swift span compatibility symbols, so the binary must either find those symbols in the host OS Swift runtime or in the release artifact.

## Impact

This makes the macOS CLI artifact self-contained for Swift runtime compatibility dylibs required by the toolchain, which should unblock consumers running Tuist on CI images that do not yet have the Xcode 26 Swift runtime shim installed system-wide.

## Validation

- `bash -n mise/tasks/cli/bundle.sh`
- `git diff --check`
- Installed released `tuist@4.199.0` with mise and verified `tuist version` prints `4.199.0`
- Confirmed `otool -L` on 4.199.0 still lists `@rpath/libswiftCompatibilitySpan.dylib`
- Confirmed `xcrun swift-stdlib-tool --print --scan-executable ... --platform macosx` reports `libswiftCompatibilitySpan.dylib`
- Replayed the copy and rpath flow against the installed 4.199.0 artifact in `/private/tmp`
- Confirmed the replayed artifact contains `vendor/libswiftCompatibilitySpan.dylib`
- Confirmed `tuist` has `@executable_path/vendor` in its rpaths after the replay
- After ad-hoc signing the replayed temp artifact, confirmed `/private/tmp/.../tuist version` prints `4.199.0`
