### PR TITLE
fix(cli): include release scripts in CLI release paths

### DIFF
--- a/.github/workflows/cli-build-publish.yml
+++ b/.github/workflows/cli-build-publish.yml
@@ -89,8 +89,18 @@ jobs:
           if [ -z "$LATEST_VERSION" ]; then
             LATEST_VERSION=$(git tag -l | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -n1 || echo "0.0.0")
           fi
+          INCLUDE_PATHS=(
+            --include-path "cli/**/*"
+            --include-path "mise/tasks/cli/**/*"
+            --include-path "mise/tasks/release/components.json"
+            --include-path ".github/workflows/cli-release.yml"
+            --include-path ".github/workflows/cli-build-publish.yml"
+            --include-path ".xcode-version-releases"
+            --include-path "Package.swift"
+            --include-path "Package.resolved"
+          )
           echo "RELEASE_NOTES<<EOF" >> "$GITHUB_OUTPUT"
-          git cliff --include-path "cli/**/*" --include-path ".xcode-version-releases" --include-path "Package.swift" --include-path "Package.resolved" --config cliff.toml --repository "../" 2>/dev/null -- ${LATEST_VERSION}..HEAD | sed -n '/<!-- RELEASE NOTES START -->/,$p' | tail -n +2 >> "$GITHUB_OUTPUT"
+          git cliff "${INCLUDE_PATHS[@]}" --config cliff.toml --repository "../" 2>/dev/null -- ${LATEST_VERSION}..HEAD | sed -n '/<!-- RELEASE NOTES START -->/,$p' | tail -n +2 >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
 
       - name: Update version in Constants.swift
@@ -103,7 +113,18 @@ jobs:
         # --bump. Full-history --bump can't anchor on CLI tags that landed on
         # non-cli commits (it filters them out), so it froze the top heading at
         # an old version while real releases advanced.
-        run: git cliff --include-path "cli/**/*" --include-path ".xcode-version-releases" --include-path "Package.swift" --include-path "Package.resolved" --config cliff.toml --repository "../" --tag "${{ inputs.version }}" -o CHANGELOG.md 2>/dev/null
+        run: |
+          INCLUDE_PATHS=(
+            --include-path "cli/**/*"
+            --include-path "mise/tasks/cli/**/*"
+            --include-path "mise/tasks/release/components.json"
+            --include-path ".github/workflows/cli-release.yml"
+            --include-path ".github/workflows/cli-build-publish.yml"
+            --include-path ".xcode-version-releases"
+            --include-path "Package.swift"
+            --include-path "Package.resolved"
+          )
+          git cliff "${INCLUDE_PATHS[@]}" --config cliff.toml --repository "../" --tag "${{ inputs.version }}" -o CHANGELOG.md 2>/dev/null
 
       - name: Bundle CLI
         run: mise run --no-deps cli:bundle

--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -6,6 +6,10 @@ on:
       - main
     paths:
       - cli/**
+      - mise/tasks/cli/**
+      - mise/tasks/release/components.json
+      - .github/workflows/cli-release.yml
+      - .github/workflows/cli-build-publish.yml
       - .xcode-version-releases
       - Package.swift
       - Package.resolved

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,9 @@ on:
       - main
     paths-ignore:
       - cli/**
+      - mise/tasks/cli/**
+      - .github/workflows/cli-release.yml
+      - .github/workflows/cli-build-publish.yml
       - app/**
       - mise/tasks/app/**
       - Package.swift

--- a/mise/tasks/release/components.json
+++ b/mise/tasks/release/components.json
@@ -8,6 +8,10 @@
       "initial_version": "0.0.0",
       "include_paths": [
         "cli/**/*",
+        "mise/tasks/cli/**/*",
+        "mise/tasks/release/components.json",
+        ".github/workflows/cli-release.yml",
+        ".github/workflows/cli-build-publish.yml",
         ".xcode-version-releases",
         "Package.swift",
         "Package.resolved"


### PR DESCRIPTION
## What changed

The dedicated `CLI Release` workflow now triggers when CLI release infrastructure changes, not only when CLI source/package files change. The trigger now includes:

- `mise/tasks/cli/**`
- `mise/tasks/release/components.json`
- `.github/workflows/cli-release.yml`
- `.github/workflows/cli-build-publish.yml`

The CLI component in `mise/tasks/release/components.json` uses the same additional paths, so `mise run release:check cli` marks these changes as releasable.

The CLI release notes and changelog generation in `cli-build-publish.yml` now use the expanded include-path set too. The broad `Release` workflow ignores CLI-only release script/workflow changes so future CLI packaging-only changes do not wake the non-CLI release pipeline unnecessarily.

## Why

`tuist/tuist#11235` changed only `mise/tasks/cli/bundle.sh`. The broad `Release` workflow ran and `release:check` correctly identified `cli` as releasable, but that workflow does not publish CLI artifacts. The dedicated `CLI Release` workflow did not run because its `paths` filter excluded `mise/tasks/cli/**`.

That meant the packaging fix merged without a post-fix CLI release being built.

## Impact

Future CLI packaging or CLI release workflow changes will trigger the dedicated CLI release pipeline and produce a release. Merging this PR should also trigger a CLI release because it changes paths now owned by the CLI component.

## Validation

- `git diff --check`
- `ruby -e 'require "yaml"; ARGV.each { |path| YAML.load_file(path); puts "ok #{path}" }' .github/workflows/cli-release.yml .github/workflows/cli-build-publish.yml .github/workflows/release.yml`
- `mise run release:check cli`
  - confirmed latest tag `4.199.0`
  - confirmed next version `4.199.1`
  - confirmed `release? true`
