### PR TITLE
fix(kura): reserve full 2Gi memory limit in KuraInstance pod requests

### DIFF
--- a/infra/kura-controller/controllers/kurainstance_controller.go
+++ b/infra/kura-controller/controllers/kurainstance_controller.go
@@ -1084,11 +1084,15 @@ func sharedSecretsEnvFrom() []corev1.EnvFromSource {
 	}}
 }
 
+// The memory request matches the limit because Kura sizes its memory
+// budget from the cgroup limit (soft limit 70%, hard limit 85% of it)
+// and routinely operates above 1Gi, so the full 2Gi must be reserved
+// at scheduling time to avoid node overcommit.
 func defaultResources() corev1.ResourceRequirements {
 	return corev1.ResourceRequirements{
 		Requests: corev1.ResourceList{
 			corev1.ResourceCPU:    resource.MustParse("500m"),
-			corev1.ResourceMemory: resource.MustParse("1Gi"),
+			corev1.ResourceMemory: resource.MustParse("2Gi"),
 		},
 		Limits: corev1.ResourceList{
 			corev1.ResourceMemory: resource.MustParse("2Gi"),


### PR DESCRIPTION
## What changed

`defaultResources()` in the Kura controller (`infra/kura-controller/controllers/kurainstance_controller.go`) now sets the memory **request** to `2Gi`, matching the existing `2Gi` limit. Previously the request was `1Gi`. The CPU request (`500m`, no limit) is unchanged. These values apply unconditionally to every controller-managed Kura runtime pod — the `KuraInstance` CRD has no resources override, and the in-tree Helm chart leaves `resources: {}`, so this function is the single source of truth.

## Why

If we expect the pod to consume up to 2GB — and it is likely to use more than 1GB — the request should be 2GB so that memory is reserved at scheduling time. With a 1Gi request the scheduler only accounts for half of what the pod will actually use, which overcommits the node, and a Burstable pod running above its request is among the first eviction candidates under node memory pressure.

For Kura specifically, running above 1Gi is not a burst scenario — it's the designed steady state:

- On boot, Kura detects the container memory limit from the cgroup (`detect_memory_limit_bytes` in `kura/src/config.rs`, min of cgroup limit and physical memory) and derives its memory budget from it: **soft limit = 70%** of the limit (~1433Mi at 2Gi) and **hard limit = 85%** (~1740Mi at 2Gi).
- The `MemoryController` (`kura/src/memory/mod.rs`) treats any resident size below the soft limit as `Normal` pressure. Backpressure (`Constrained`) only kicks in above ~1.4Gi, and load shedding (`Critical`) above ~1.7Gi.
- Kura sizes its caches and pools off the same budget — mmap serving pool (up to 512Mi), RocksDB read cache and write-buffer pool (up to 128Mi each), REAPI materialization pool (up to 128Mi), manifest cache (up to 64Mi) — and fills them as the working set grows.

In other words, a healthy Kura pod under load is expected to sit somewhere between 1Gi and ~1.7Gi of RSS, intentionally above the old request. Setting request = limit makes the scheduler reserve what the process is actually built to use, and since usage can never exceed the request anymore, usage-above-request eviction is off the table.

## Trade-off considered

This reduces bin-packing density on the Kura node pool (each pod now reserves 2Gi instead of 1Gi). That is the point: the previous density was an illusion built on overcommit, because the pods genuinely use that memory. An alternative would have been lowering Kura's derived soft/hard limits to fit a 1Gi request, but that would shrink the caches and serving pools that exist to keep cache-hit latency low.

## Impact

Controller-managed Kura pods (runtime `StatefulSet` pods, not the gateway pods, which keep their 128Mi/512Mi settings) reconcile to the new requests on the next rollout. Scheduling pressure on the Kura node pool may increase if nodes were previously overcommitted — pods that no longer fit will stay `Pending` and surface the capacity shortfall explicitly instead of risking evictions.

## Validation

From `infra/kura-controller/` with Go 1.25 (same checks as the `kura-controller-image.yml` CI workflow):

- `go build ./...` — pass
- `go vet ./...` — pass
- `go test ./...` — pass (`ok github.com/tuist/tuist/infra/kura-controller/controllers`)

No test pins the old values, so no test changes were needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)