### PR TITLE
fix(cli): quote `-fmodule-map-file` paths to account for whitespace

### DIFF
--- a/cli/Sources/TuistGenerator/Mappers/ModuleMapMapper.swift
+++ b/cli/Sources/TuistGenerator/Mappers/ModuleMapMapper.swift
@@ -407,7 +407,7 @@ public struct ModuleMapMapper: GraphMapping { // swiftlint:disable:this type_bod
         )
         mappedOtherSwiftFlags.append(contentsOf: [
             "-Xcc",
-            "-fmodule-map-file=\(reference)",
+            "-fmodule-map-file=\"\(reference)\"",
         ])
 
         return .array(mappedOtherSwiftFlags)
@@ -437,7 +437,7 @@ public struct ModuleMapMapper: GraphMapping { // swiftlint:disable:this type_bod
             xcodeProjParent: xcodeProjParent
         )
         mappedOtherCFlags.append(
-            "-fmodule-map-file=\(reference)"
+            "-fmodule-map-file=\"\(reference)\""
         )
 
         return .array(mappedOtherCFlags)

--- a/cli/Tests/TuistDependenciesAcceptanceTests/DependenciesAcceptanceTests.swift
+++ b/cli/Tests/TuistDependenciesAcceptanceTests/DependenciesAcceptanceTests.swift
@@ -21,6 +21,7 @@ import TuistTesting
 @Suite(.serialized)
 struct DependenciesAcceptanceTests {
     @Test(
+        .disabled(),
         .inTemporaryDirectory,
         .withMockedEnvironment(inheritingVariables: ["PATH"]),
         .withMockedNoora,

--- a/cli/Tests/TuistDependenciesAcceptanceTests/DependenciesAcceptanceTests.swift
+++ b/cli/Tests/TuistDependenciesAcceptanceTests/DependenciesAcceptanceTests.swift
@@ -21,7 +21,6 @@ import TuistTesting
 @Suite(.serialized)
 struct DependenciesAcceptanceTests {
     @Test(
-        .disabled(),
         .inTemporaryDirectory,
         .withMockedEnvironment(inheritingVariables: ["PATH"]),
         .withMockedNoora,
@@ -63,7 +62,7 @@ struct DependenciesAcceptanceTests {
         try await TuistTest.run(
             TestCommand.self,
             [
-                "AppKit",
+                "App Kit",
                 "--device",
                 simulator.name,
                 "--path",

--- a/cli/Tests/TuistGeneratorTests/ProjectMappers/ModuleMapMapperTests.swift
+++ b/cli/Tests/TuistGeneratorTests/ProjectMappers/ModuleMapMapperTests.swift
@@ -99,12 +99,12 @@ final class ModuleMapMapperTests: TuistUnitTestCase {
             settings: .test(base: [
                 "OTHER_CFLAGS": .array([
                     "Other",
-                    "-fmodule-map-file=$(SRCROOT)/Derived/ModuleMaps/A-deps.modulemap",
+                    "-fmodule-map-file=\"$(SRCROOT)/Derived/ModuleMaps/A-deps.modulemap\"",
                 ]),
                 "OTHER_SWIFT_FLAGS": .array([
                     "Other",
                     "-Xcc",
-                    "-fmodule-map-file=$(SRCROOT)/Derived/ModuleMaps/A-deps.modulemap",
+                    "-fmodule-map-file=\"$(SRCROOT)/Derived/ModuleMaps/A-deps.modulemap\"",
                 ]),
                 "HEADER_SEARCH_PATHS": .array(["$(inherited)", "$(SRCROOT)/../B/B1/include", "$(SRCROOT)/../B/B2/include"]),
             ]),
@@ -125,12 +125,12 @@ final class ModuleMapMapperTests: TuistUnitTestCase {
             settings: .test(base: [
                 "OTHER_CFLAGS": .array([
                     "$(inherited)",
-                    "-fmodule-map-file=$(SRCROOT)/Derived/ModuleMaps/B1-deps.modulemap",
+                    "-fmodule-map-file=\"$(SRCROOT)/Derived/ModuleMaps/B1-deps.modulemap\"",
                 ]),
                 "OTHER_SWIFT_FLAGS": .array([
                     "$(inherited)",
                     "-Xcc",
-                    "-fmodule-map-file=$(SRCROOT)/Derived/ModuleMaps/B1-deps.modulemap",
+                    "-fmodule-map-file=\"$(SRCROOT)/Derived/ModuleMaps/B1-deps.modulemap\"",
                 ]),
                 "HEADER_SEARCH_PATHS": .array(["$(SRCROOT)/B1/include", "$(SRCROOT)/B2/include"]),
             ]),
@@ -257,12 +257,12 @@ final class ModuleMapMapperTests: TuistUnitTestCase {
                 base: [
                     "OTHER_CFLAGS": .array([
                         "$(inherited)",
-                        "-fmodule-map-file=$(SRCROOT)/Derived/ModuleMaps/A-deps.modulemap",
+                        "-fmodule-map-file=\"$(SRCROOT)/Derived/ModuleMaps/A-deps.modulemap\"",
                     ]),
                     "OTHER_SWIFT_FLAGS": .array([
                         "$(inherited)",
                         "-Xcc",
-                        "-fmodule-map-file=$(SRCROOT)/Derived/ModuleMaps/A-deps.modulemap",
+                        "-fmodule-map-file=\"$(SRCROOT)/Derived/ModuleMaps/A-deps.modulemap\"",
                     ]),
                     "HEADER_SEARCH_PATHS": .array(["$(inherited)", "$(SRCROOT)/../B/B/include"]),
                 ],
@@ -405,14 +405,14 @@ final class ModuleMapMapperTests: TuistUnitTestCase {
             .array([
                 "Other",
                 "-Xcc",
-                "-fmodule-map-file=$(SRCROOT)/Derived/ModuleMaps/A-deps.modulemap",
+                "-fmodule-map-file=\"$(SRCROOT)/Derived/ModuleMaps/A-deps.modulemap\"",
             ])
         )
         XCTAssertBetterEqual(
             gotTargetA.settings?.base["OTHER_CFLAGS"],
             .array([
                 "Other",
-                "-fmodule-map-file=$(SRCROOT)/Derived/ModuleMaps/A-deps.modulemap",
+                "-fmodule-map-file=\"$(SRCROOT)/Derived/ModuleMaps/A-deps.modulemap\"",
             ])
         )
 
@@ -426,14 +426,14 @@ final class ModuleMapMapperTests: TuistUnitTestCase {
                 "-D",
                 "FEATURE",
                 "-Xcc",
-                "-fmodule-map-file=$(SRCROOT)/Derived/ModuleMaps/A-deps.modulemap",
+                "-fmodule-map-file=\"$(SRCROOT)/Derived/ModuleMaps/A-deps.modulemap\"",
             ])
         )
         XCTAssertBetterEqual(
             debugConfiguration.settings["OTHER_CFLAGS"],
             .array([
                 "-DDEBUG",
-                "-fmodule-map-file=$(SRCROOT)/Derived/ModuleMaps/A-deps.modulemap",
+                "-fmodule-map-file=\"$(SRCROOT)/Derived/ModuleMaps/A-deps.modulemap\"",
             ])
         )
 
@@ -545,14 +545,14 @@ final class ModuleMapMapperTests: TuistUnitTestCase {
             .array([
                 "Other",
                 "-Xcc",
-                "-fmodule-map-file=$(PROJECT_DIR)/../../ModuleMaps/A/A-deps.modulemap",
+                "-fmodule-map-file=\"$(PROJECT_DIR)/../../ModuleMaps/A/A-deps.modulemap\"",
             ])
         )
         XCTAssertBetterEqual(
             gotTargetA.settings?.base["OTHER_CFLAGS"],
             .array([
                 "Other",
-                "-fmodule-map-file=$(PROJECT_DIR)/../../ModuleMaps/A/A-deps.modulemap",
+                "-fmodule-map-file=\"$(PROJECT_DIR)/../../ModuleMaps/A/A-deps.modulemap\"",
             ])
         )
         XCTAssertBetterEqual(
@@ -698,7 +698,7 @@ final class ModuleMapMapperTests: TuistUnitTestCase {
             gotCoreA.settings?.base["OTHER_CFLAGS"],
             .array([
                 "Other",
-                "-fmodule-map-file=$(PROJECT_DIR)/../../ModuleMaps/PackageA/Core-deps.modulemap",
+                "-fmodule-map-file=\"$(PROJECT_DIR)/../../ModuleMaps/PackageA/Core-deps.modulemap\"",
             ])
         )
 
@@ -707,7 +707,7 @@ final class ModuleMapMapperTests: TuistUnitTestCase {
             gotCoreB.settings?.base["OTHER_CFLAGS"],
             .array([
                 "Other",
-                "-fmodule-map-file=$(PROJECT_DIR)/../../ModuleMaps/PackageB/Core-deps.modulemap",
+                "-fmodule-map-file=\"$(PROJECT_DIR)/../../ModuleMaps/PackageB/Core-deps.modulemap\"",
             ])
         )
 

--- a/examples/xcode/generated_app_with_spm_dependencies/Project.swift
+++ b/examples/xcode/generated_app_with_spm_dependencies/Project.swift
@@ -11,7 +11,7 @@ let project = Project(
             infoPlist: .default,
             sources: "Sources/App/**",
             dependencies: [
-                .target(name: "AppKit"),
+                .target(name: "App Kit"),
                 .target(name: "CrashManager"),
             ]
         ),
@@ -27,9 +27,10 @@ let project = Project(
             ]
         ),
         .target(
-            name: "AppKit",
+            name: "App Kit",
             destinations: .iOS,
             product: .staticFramework,
+            productName: "AppKit",
             bundleId: "dev.tuist.app.kit",
             infoPlist: .default,
             sources: "Sources/AppKit/**",
@@ -47,7 +48,7 @@ let project = Project(
             infoPlist: .default,
             sources: "Tests/AppKit/**",
             dependencies: [
-                .target(name: "AppKit"),
+                .target(name: "App Kit"),
                 .external(name: "Nimble"),
             ]
         ),


### PR DESCRIPTION
The new generated module map files would break the `-fmodule-map-file` build setting if the target name contained spaces.  This led to a path with a space in it and the command line build invocation would split on that newline causing the build to fail. 

### How to test locally

Includes an update to `generated_app_with_spm_dependencies` to exhibit the bug in 4.198.2 and validate the fix correctly allows it to build.
