### PR TITLE
fix(cli): force sign bundled runtime libraries

### DIFF
--- a/mise/tasks/cli/bundle.sh
+++ b/mise/tasks/cli/bundle.sh
@@ -121,11 +121,11 @@ echo "$(format_section "Bundling")"
     echo "$(format_subsection "Signing")"
     if [ -d vendor ]; then
         find vendor -type f -name "*.dylib" -print0 | while IFS= read -r -d '' library; do
-            /usr/bin/codesign --sign "$CERTIFICATE_NAME" --timestamp --options runtime --verbose "$library"
+            /usr/bin/codesign --force --sign "$CERTIFICATE_NAME" --timestamp --options runtime --verbose "$library"
         done
     fi
-    /usr/bin/codesign --sign "$CERTIFICATE_NAME" --timestamp --options runtime --verbose tuist
-    /usr/bin/codesign --sign "$CERTIFICATE_NAME" --timestamp --options runtime --verbose ProjectDescription.framework
+    /usr/bin/codesign --force --sign "$CERTIFICATE_NAME" --timestamp --options runtime --verbose tuist
+    /usr/bin/codesign --force --sign "$CERTIFICATE_NAME" --timestamp --options runtime --verbose ProjectDescription.framework
 
     echo "$(format_subsection "Notarizing")"
     zip -q -r --symlinks "notarization-bundle.zip" tuist ProjectDescription.framework vendor


### PR DESCRIPTION
## What changed

- Adds `--force` to the macOS CLI bundle signing commands.
- Applies the same idempotent signing behavior to bundled Swift runtime dylibs, the `tuist` executable, and `ProjectDescription.framework`.

## Why

The post-runtime-packaging CLI release run for `8528c1d8374ea107d32183ee34affdf7e994c977` failed in the macOS `Bundle CLI` step after the Swift runtime library was successfully copied into `build/vendor`.

The raw job log shows:

```text
Bundling Swift runtime libraries
Signing
vendor/libswiftCompatibilitySpan.dylib: is already signed
[cli:bundle] ERROR task failed
Process completed with exit code 1.
```

`swift-stdlib-tool` can copy already-signed Swift runtime dylibs from the selected Xcode toolchain. The release bundle then signs all packaged code with the Tuist Developer ID identity, but `codesign` refuses to replace an existing signature unless `--force` is passed.

## Impact

This should allow the next CLI release to finish macOS artifact creation while preserving the runtime-library packaging fix needed for consumers that do not have `libswiftCompatibilitySpan.dylib` available on the target machine.

## Validation

- `bash -n mise/tasks/cli/bundle.sh`
- `git diff --check`
