### PR TITLE
fix(server): unblock recent bucket production deploy

### DIFF
--- a/infra/helm/tuist/templates/external-secrets.yaml
+++ b/infra/helm/tuist/templates/external-secrets.yaml
@@ -1,13 +1,21 @@
 {{- $syncMaster := and .Values.server.enabled .Values.server.managedSecrets -}}
 {{- $syncLicense := and .Values.server.enabled (ne (.Values.server.externalSecrets.license.item | default "") "") -}}
-{{- $syncKuraIntrospection := and .Values.server.enabled (ne (.Values.server.externalSecrets.kuraIntrospection.item | default "") "") -}}
-{{- $kuraIntrospectionClientIdValue := .Values.server.externalSecrets.kuraIntrospection.clientIdValue | default "" -}}
+{{- $serverKuraIntrospection := .Values.server.externalSecrets.kuraIntrospection -}}
+{{- $kuraSharedSecrets := .Values.kuraController.sharedSecrets -}}
+{{- $kuraSharedSecretsExternalSecret := $kuraSharedSecrets.externalSecret -}}
+{{- $syncServerKuraIntrospection := and .Values.server.enabled (ne ($serverKuraIntrospection.item | default "") "") -}}
+{{- $syncSharedKuraIntrospection := and .Values.server.enabled .Values.kuraController.enabled $kuraSharedSecrets.enabled $kuraSharedSecrets.kuraIntrospection.enabled $kuraSharedSecretsExternalSecret.enabled (ne ($kuraSharedSecretsExternalSecret.item | default "") "") -}}
+{{- $syncKuraIntrospection := or $syncServerKuraIntrospection $syncSharedKuraIntrospection -}}
+{{- $kuraIntrospectionClientIdValue := $serverKuraIntrospection.clientIdValue | default $kuraSharedSecrets.kuraIntrospection.clientId | default "" -}}
+{{- $kuraIntrospectionItem := ternary $serverKuraIntrospection.item $kuraSharedSecretsExternalSecret.item $syncServerKuraIntrospection -}}
+{{- $kuraIntrospectionClientIdField := ternary ($serverKuraIntrospection.fields.clientId | default "KURA_CONTROL_PLANE_CLIENT_ID") ($kuraSharedSecretsExternalSecret.fields.introspectionClientId | default "KURA_CONTROL_PLANE_CLIENT_ID") $syncServerKuraIntrospection -}}
+{{- $kuraIntrospectionClientSecretField := ternary ($serverKuraIntrospection.fields.clientSecret | default "KURA_CONTROL_PLANE_CLIENT_SECRET") ($kuraSharedSecretsExternalSecret.fields.introspectionClientSecret | default "KURA_CONTROL_PLANE_CLIENT_SECRET") $syncServerKuraIntrospection -}}
 {{- if or $syncMaster $syncLicense $syncKuraIntrospection }}
 # ESO syncs secrets from the configured SecretStore (1Password by default)
 # into a dedicated Secret that this ExternalSecret owns. The Deployment /
-# Migration Job reference this Secret for MASTER_KEY (managed shape) and the
+# Migration Job reference this Secret for MASTER_KEY (managed shape), the
 # Tuist license (any shape that opts into license sync — e.g. preview envs
-# without the encrypted priv/secrets blob).
+# without the encrypted priv/secrets blob), and legacy Kura OAuth env refs.
 #
 # A separate Secret (not a Merge into app-secrets) is used on purpose: helm
 # upgrade rewrites chart-managed resources, which would wipe ESO-managed keys
@@ -76,10 +84,10 @@ spec:
     {{- if eq $kuraIntrospectionClientIdValue "" }}
     - secretKey: kura_introspection_client_id
       remoteRef:
-        key: "{{ .Values.server.externalSecrets.kuraIntrospection.item }}/{{ .Values.server.externalSecrets.kuraIntrospection.fields.clientId | default "KURA_CONTROL_PLANE_CLIENT_ID" }}"
+        key: "{{ $kuraIntrospectionItem }}/{{ $kuraIntrospectionClientIdField }}"
     {{- end }}
     - secretKey: kura_introspection_client_secret
       remoteRef:
-        key: "{{ .Values.server.externalSecrets.kuraIntrospection.item }}/{{ .Values.server.externalSecrets.kuraIntrospection.fields.clientSecret | default "KURA_CONTROL_PLANE_CLIENT_SECRET" }}"
+        key: "{{ $kuraIntrospectionItem }}/{{ $kuraIntrospectionClientSecretField }}"
     {{- end }}
 {{- end }}

--- a/server/priv/ingest_repo/migrations/20260515100000_create_test_case_runs_recent_buckets_per_case_mvs.exs
+++ b/server/priv/ingest_repo/migrations/20260515100000_create_test_case_runs_recent_buckets_per_case_mvs.exs
@@ -22,27 +22,17 @@ defmodule Tuist.IngestRepo.Migrations.CreateTestCaseRunsRecentBucketsPerCaseMvs 
   @disable_migration_lock true
 
   @window_sizes [100, 250, 500, 750]
-  @project_chunk_size 10
+  @max_window_size 1000
+  @project_chunk_size 25
   @chunk_throttle_ms 100
 
   def up do
-    migration_started_at = DateTime.utc_now()
-
     for window_size <- @window_sizes do
       IngestRepo.query!("DROP VIEW IF EXISTS #{mv(window_size)}")
       IngestRepo.query!("DROP TABLE IF EXISTS #{table_name(window_size)}")
       create_table(window_size)
-    end
-
-    for window_size <- @window_sizes do
-      backfill_by_partition(window_size, migration_started_at)
+      backfill_from_recent_per_case(window_size)
       create_materialized_view(window_size)
-
-      backfill_until_materialized_view_start(
-        window_size,
-        migration_started_at,
-        DateTime.utc_now()
-      )
     end
   end
 
@@ -78,93 +68,61 @@ defmodule Tuist.IngestRepo.Migrations.CreateTestCaseRunsRecentBucketsPerCaseMvs 
     """)
   end
 
-  defp backfill_by_partition(window_size, migration_started_at) do
-    cutoff = DateTime.to_iso8601(migration_started_at)
+  defp backfill_from_recent_per_case(window_size) do
+    project_ids = source_project_ids()
 
-    {:ok, %{rows: partitions}} =
-      IngestRepo.query(
-        """
-        SELECT DISTINCT partition
-        FROM system.parts
-        WHERE database = currentDatabase() AND table = {table:String} AND active
-        ORDER BY partition
-        """,
-        %{table: "test_case_runs"}
-      )
+    Logger.info(
+      "Backfilling #{table_name(window_size)} from test_case_runs_recent_per_case " <>
+        "(#{length(project_ids)} projects in #{div(length(project_ids) + @project_chunk_size - 1, @project_chunk_size)} chunk(s))"
+    )
 
-    for [partition] <- partitions do
-      partition_int = String.to_integer(partition)
-      project_ids = project_ids_for_partition(partition_int, cutoff)
+    project_ids
+    |> Enum.chunk_every(@project_chunk_size)
+    |> Enum.with_index(1)
+    |> Enum.each(fn {chunk, idx} ->
+      backfill_recent_per_case_chunk_with_fallback(window_size, chunk, idx)
 
-      Logger.info(
-        "Backfilling partition #{partition} into #{table_name(window_size)} " <>
-          "(#{length(project_ids)} projects in #{div(length(project_ids) + @project_chunk_size - 1, @project_chunk_size)} chunk(s))"
-      )
-
-      project_ids
-      |> Enum.chunk_every(@project_chunk_size)
-      |> Enum.with_index(1)
-      |> Enum.each(fn {chunk, idx} ->
-        backfill_chunk_with_daily_fallback(window_size, partition_int, chunk, idx, cutoff)
-
-        Process.sleep(@chunk_throttle_ms)
-      end)
-    end
+      Process.sleep(@chunk_throttle_ms)
+    end)
   end
 
-  defp project_ids_for_partition(partition, cutoff) do
+  defp source_project_ids do
     {:ok, %{rows: rows}} =
       IngestRepo.query(
         """
         SELECT DISTINCT project_id
-        FROM test_case_runs
-        WHERE toYYYYMM(inserted_at) = {partition:UInt32}
-          AND inserted_at < parseDateTime64BestEffort({cutoff:String}, 6)
-          AND test_case_id IS NOT NULL
+        FROM test_case_runs_recent_per_case
         ORDER BY project_id
         """,
-        %{partition: partition, cutoff: cutoff},
+        %{},
         timeout: 600_000
       )
 
     Enum.map(rows, fn [project_id] -> project_id end)
   end
 
-  defp days_for_partition_chunk(partition, project_ids, cutoff) do
-    {:ok, %{rows: rows}} =
-      IngestRepo.query(
-        """
-        SELECT DISTINCT toString(toDate(inserted_at)) AS day
-        FROM test_case_runs
-        WHERE toYYYYMM(inserted_at) = {partition:UInt32}
-          AND inserted_at < parseDateTime64BestEffort({cutoff:String}, 6)
-          AND project_id IN {project_ids:Array(Int64)}
-          AND test_case_id IS NOT NULL
-        ORDER BY day
-        """,
-        %{partition: partition, cutoff: cutoff, project_ids: project_ids},
-        timeout: 600_000
-      )
-
-    Enum.map(rows, fn [day] -> day end)
-  end
-
-  defp backfill_chunk_with_daily_fallback(window_size, partition, project_ids, idx, cutoff) do
-    backfill_chunk(window_size, partition, project_ids, idx, cutoff)
+  defp backfill_recent_per_case_chunk_with_fallback(window_size, project_ids, idx) do
+    backfill_recent_per_case_chunk(window_size, project_ids, idx)
   rescue
     e in Ch.Error ->
       cond do
-        memory_limit_exceeded?(e) ->
+        memory_limit_exceeded?(e) and length(project_ids) > 1 ->
           Logger.warning(
-            "Backfilling chunk #{idx} of partition #{partition} into #{table_name(window_size)} " <>
-              "exceeded ClickHouse memory; retrying with day-sized chunks"
+            "Backfilling chunk #{idx} into #{table_name(window_size)} exceeded ClickHouse memory; " <>
+              "retrying per project"
           )
 
-          backfill_chunk_by_day(window_size, partition, project_ids, idx, cutoff)
+          Enum.each(project_ids, fn project_id ->
+            retry_on_transient_failure(fn ->
+              backfill_recent_per_case_chunk(window_size, [project_id], idx)
+            end)
+
+            Process.sleep(@chunk_throttle_ms)
+          end)
 
         table_is_read_only?(e) ->
           retry_on_transient_failure(fn ->
-            backfill_chunk(window_size, partition, project_ids, idx, cutoff)
+            backfill_recent_per_case_chunk(window_size, project_ids, idx)
           end)
 
         true ->
@@ -172,29 +130,9 @@ defmodule Tuist.IngestRepo.Migrations.CreateTestCaseRunsRecentBucketsPerCaseMvs 
       end
   end
 
-  defp backfill_chunk_by_day(window_size, partition, project_ids, idx, cutoff) do
-    days = days_for_partition_chunk(partition, project_ids, cutoff)
-
-    days
-    |> Enum.with_index(1)
-    |> Enum.each(fn {day, day_idx} ->
-      backfill_day_chunk_with_project_fallback(
-        window_size,
-        partition,
-        project_ids,
-        idx,
-        day,
-        day_idx,
-        cutoff
-      )
-
-      Process.sleep(@chunk_throttle_ms)
-    end)
-  end
-
-  defp backfill_chunk(window_size, partition, project_ids, idx, cutoff) do
+  defp backfill_recent_per_case_chunk(window_size, project_ids, idx) do
     Logger.debug(
-      "Backfilling chunk #{idx} of partition #{partition} into #{table_name(window_size)} " <>
+      "Backfilling chunk #{idx} into #{table_name(window_size)} " <>
         "(#{length(project_ids)} projects: #{Enum.at(project_ids, 0)}..#{List.last(project_ids)})"
     )
 
@@ -203,145 +141,35 @@ defmodule Tuist.IngestRepo.Migrations.CreateTestCaseRunsRecentBucketsPerCaseMvs 
       INSERT INTO #{table_name(window_size)}
       SELECT
         project_id,
-        assumeNotNull(test_case_id) AS test_case_id,
-        groupArraySortedState(#{window_size})((-toUnixTimestamp64Micro(ran_at), toUInt8(is_flaky))) AS recent_runs
-      FROM test_case_runs
-      WHERE toYYYYMM(inserted_at) = {partition:UInt32}
-        AND inserted_at < parseDateTime64BestEffort({cutoff:String}, 6)
-        AND project_id IN {project_ids:Array(Int64)}
-        AND test_case_id IS NOT NULL
-      GROUP BY project_id, test_case_id
-      SETTINGS
-        optimize_aggregation_in_order = 1,
-        max_threads = 1,
-        max_memory_usage = 6000000000,
-        max_bytes_before_external_group_by = 2500000000
-      """,
-      %{partition: partition, cutoff: cutoff, project_ids: project_ids},
-      timeout: 1_200_000
-    )
-  end
-
-  defp backfill_day_chunk(window_size, partition, project_ids, idx, day, day_idx, cutoff) do
-    day_start = "#{day} 00:00:00"
-    day_end = "#{Date.add(Date.from_iso8601!(day), 1)} 00:00:00"
-
-    Logger.debug(
-      "Backfilling day chunk #{day_idx} (#{day}) for chunk #{idx} of partition #{partition} " <>
-        "into #{table_name(window_size)}"
-    )
-
-    IngestRepo.query!(
-      """
-      INSERT INTO #{table_name(window_size)}
-      SELECT
-        project_id,
-        assumeNotNull(test_case_id) AS test_case_id,
-        groupArraySortedState(#{window_size})((-toUnixTimestamp64Micro(ran_at), toUInt8(is_flaky))) AS recent_runs
-      FROM test_case_runs
-      WHERE toYYYYMM(inserted_at) = {partition:UInt32}
-        AND inserted_at >= parseDateTime64BestEffort({day_start:String}, 6)
-        AND inserted_at < parseDateTime64BestEffort({day_end:String}, 6)
-        AND inserted_at < parseDateTime64BestEffort({cutoff:String}, 6)
-        AND project_id IN {project_ids:Array(Int64)}
-        AND test_case_id IS NOT NULL
-      GROUP BY project_id, test_case_id
-      SETTINGS
-        optimize_aggregation_in_order = 1,
-        max_threads = 1,
-        max_memory_usage = 6000000000,
-        max_bytes_before_external_group_by = 2500000000
-      """,
-      %{
-        partition: partition,
-        day_start: day_start,
-        day_end: day_end,
-        cutoff: cutoff,
-        project_ids: project_ids
-      },
-      timeout: 1_200_000
-    )
-  end
-
-  defp backfill_day_chunk_with_project_fallback(
-         window_size,
-         partition,
-         project_ids,
-         idx,
-         day,
-         day_idx,
-         cutoff
-       ) do
-    backfill_day_chunk(window_size, partition, project_ids, idx, day, day_idx, cutoff)
-  rescue
-    e in Ch.Error ->
-      cond do
-        memory_limit_exceeded?(e) and length(project_ids) > 1 ->
-          Logger.warning(
-            "Backfilling day #{day} for chunk #{idx} of partition #{partition} " <>
-              "into #{table_name(window_size)} exceeded ClickHouse memory; retrying per project"
-          )
-
-          project_ids
-          |> Enum.each(fn project_id ->
-            retry_on_transient_failure(fn ->
-              backfill_day_chunk(
-                window_size,
-                partition,
-                [project_id],
-                idx,
-                day,
-                day_idx,
-                cutoff
-              )
-            end)
-
-            Process.sleep(@chunk_throttle_ms)
-          end)
-
-        table_is_read_only?(e) ->
-          retry_on_transient_failure(fn ->
-            backfill_day_chunk(window_size, partition, project_ids, idx, day, day_idx, cutoff)
-          end)
-
-        true ->
-          reraise e, __STACKTRACE__
-      end
-  end
-
-  defp backfill_until_materialized_view_start(
-         window_size,
-         migration_started_at,
-         materialized_view_started_at
-       ) do
-    start_cutoff = DateTime.to_iso8601(migration_started_at)
-    end_cutoff = DateTime.to_iso8601(materialized_view_started_at)
-
-    Logger.info("Backfilling rows inserted while #{table_name(window_size)} was being built")
-
-    retry_on_transient_failure(fn ->
-      IngestRepo.query!(
-        """
-        INSERT INTO #{table_name(window_size)}
+        test_case_id,
+        groupArraySortedState(#{window_size})((
+          -toUnixTimestamp64Micro(tupleElement(recent_run, 1)),
+          toUInt8(tupleElement(recent_run, 2))
+        )) AS recent_runs
+      FROM (
         SELECT
           project_id,
-          assumeNotNull(test_case_id) AS test_case_id,
-          groupArraySortedState(#{window_size})((-toUnixTimestamp64Micro(ran_at), toUInt8(is_flaky))) AS recent_runs
-        FROM test_case_runs
-        WHERE inserted_at >= parseDateTime64BestEffort({start_cutoff:String}, 6)
-          AND inserted_at < parseDateTime64BestEffort({end_cutoff:String}, 6)
-          AND test_case_id IS NOT NULL
+          test_case_id,
+          arrayJoin(
+            arraySlice(
+              arrayReverseSort(run -> tupleElement(run, 1), groupArrayLastMerge(#{@max_window_size})(recent_runs)),
+              1,
+              #{window_size}
+            )
+          ) AS recent_run
+        FROM test_case_runs_recent_per_case
+        WHERE project_id IN {project_ids:Array(Int64)}
         GROUP BY project_id, test_case_id
-        SETTINGS
-          optimize_aggregation_in_order = 1,
-          max_threads = 1,
-          max_memory_usage = 6000000000,
-          max_bytes_before_external_group_by = 2500000000
-        """,
-        %{start_cutoff: start_cutoff, end_cutoff: end_cutoff},
-        timeout: 1_200_000
       )
-    end)
+      GROUP BY project_id, test_case_id
+      SETTINGS
+        max_threads = 1,
+        max_memory_usage = 6000000000,
+        max_bytes_before_external_group_by = 2500000000
+      """,
+      %{project_ids: project_ids},
+      timeout: 1_200_000
+    )
   end
 
   defp table_name(window_size), do: "test_case_runs_recent_#{window_size}_per_case"


### PR DESCRIPTION
## What changed

- Reworked the `20260515100000` ClickHouse migration so the 100/250/500/750 recent-run bucket tables are backfilled from the existing `test_case_runs_recent_per_case` aggregate instead of rescanning raw `test_case_runs` partitions.
- Kept the backfill chunked by project and retained an immediate per-project fallback if ClickHouse still reports memory pressure for a chunk.
- Mirrored the Kura introspection OAuth keys into `server-external-secrets` when the managed deployment uses the newer `kura-shared-secrets` path, preserving compatibility with old server ReplicaSets during failed or partial upgrades.

## Why

The previous chunking fix changed the failure mode but did not unblock production: the migration continued scanning historical raw rows for each smaller bucket, so Helm hit its pre-upgrade hook timeout while the job was still backfilling. Because the migration drops and recreates the bucket tables at the start, every retry could restart from zero.

The same failed upgrade also exposed a secret compatibility gap. New server pods read Kura OAuth credentials from `kura-shared-secrets`, but old ReplicaSet pods still referenced `server-external-secrets`. The pre-upgrade ExternalSecret hook had stopped writing those legacy keys, so old pods could get stuck in `CreateContainerConfigError` while Helm was still trying to complete the release.

## Impact

The migration now reshapes the already-maintained 1000-run per-case aggregate into smaller sorted bucket states, avoiding the raw historical table scan that was blowing through deploy time. The server ExternalSecret remains backward-compatible long enough for old pods to roll away cleanly.

## Validation

- `helm template` for production and canary managed values, confirming `server-external-secrets` now contains `KURA_CONTROL_PLANE_CLIENT_ID` and `KURA_CONTROL_PLANE_CLIENT_SECRET` from `kura-introspection-oauth-client` while new server pods still reference `kura-shared-secrets`.
- `helm lint` for production and canary managed values.
- `clickhouse local` smoke test using the exact aggregate-state backfill query against sample data.
- `mix format --check-formatted priv/ingest_repo/migrations/20260515100000_create_test_case_runs_recent_buckets_per_case_mvs.exs` after fetching deps; local lockfile refresh was restored before committing.
- Elixir syntax parse and standard formatter check for the changed migration file.
