### PR TITLE
fix(server): correct runners dashboard platform series

### DIFF
--- a/infra/grafana-dashboards/runners.json
+++ b/infra/grafana-dashboards/runners.json
@@ -139,7 +139,7 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "sum(max by (fleet) (tuist_runners_queue_length))",
+            "expr": "sum(sum by (platform) (label_replace(max by (fleet) (tuist_runners_queue_length{fleet=~\".*$platform.*\"}), \"platform\", \"$1\", \"fleet\", \".*runner-pool-(linux|macos).*\")))",
             "instant": true,
             "refId": "A"
           }
@@ -702,7 +702,39 @@
             },
             "unit": "percentunit",
             "min": 0
-          }
+          },
+          "overrides": [
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "linux"
+              },
+              "properties": [
+                {
+                  "id": "color",
+                  "value": {
+                    "fixedColor": "green",
+                    "mode": "fixed"
+                  }
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "macos"
+              },
+              "properties": [
+                {
+                  "id": "color",
+                  "value": {
+                    "fixedColor": "yellow",
+                    "mode": "fixed"
+                  }
+                }
+              ]
+            }
+          ]
         },
         "gridPos": {
           "h": 8,
@@ -752,7 +784,7 @@
               "spanNulls": false,
               "stacking": {
                 "group": "A",
-                "mode": "normal"
+                "mode": "none"
               }
             },
             "unit": "short"
@@ -806,7 +838,7 @@
               "spanNulls": false,
               "stacking": {
                 "group": "A",
-                "mode": "normal"
+                "mode": "none"
               }
             },
             "unit": "short"


### PR DESCRIPTION
## What changed

- Disabled normal stacking for the Queue length by platform and Running builds by platform Grafana time series panels.
- Added explicit Linux/macOS color overrides to the pool utilisation panel so the platform series remain visually distinct.
- Updated the Queued jobs stat tile to sum the same platform-filtered queue expression used by the queue length chart.

## Why

The runners dashboard was visually misrepresenting platform values. Grafana stacking drew the macOS series cumulatively on top of Linux, making macOS look close to Linux even when the tooltip showed much smaller macOS values. The pool utilisation panel also colored both platform series from thresholds, so low-utilization Linux and macOS both appeared green. Finally, the queued jobs tile used a separate unfiltered aggregation, so it could drift from the platform queue chart.

## Impact

Operators can now compare Linux and macOS runner capacity signals directly without Grafana visual settings inflating or conflating the platform series. The overview queued count now matches the total of the visible platform queue series at the latest point.

## Validation

- Ran jq empty infra/grafana-dashboards/runners.json to verify the dashboard JSON remains valid.