### PR TITLE
fix(server): skip large recent bucket backfills

### DIFF
--- a/infra/helm/tuist/templates/external-secrets.yaml
+++ b/infra/helm/tuist/templates/external-secrets.yaml
@@ -15,7 +15,7 @@
 # into a dedicated Secret that this ExternalSecret owns. The Deployment /
 # Migration Job reference this Secret for MASTER_KEY (managed shape), the
 # Tuist license (any shape that opts into license sync — e.g. preview envs
-# without the encrypted priv/secrets blob), and legacy Kura OAuth env refs.
+# without the encrypted priv/secrets blob), and Kura OAuth env refs.
 #
 # A separate Secret (not a Merge into app-secrets) is used on purpose: helm
 # upgrade rewrites chart-managed resources, which would wipe ESO-managed keys
@@ -61,10 +61,13 @@ spec:
         {{- if $syncKuraIntrospection }}
         {{- if ne $kuraIntrospectionClientIdValue "" }}
         KURA_CONTROL_PLANE_CLIENT_ID: {{ $kuraIntrospectionClientIdValue | quote }}
+        TUIST_KURA_INTROSPECTION_CLIENT_ID: {{ $kuraIntrospectionClientIdValue | quote }}
         {{- else }}
         KURA_CONTROL_PLANE_CLIENT_ID: "{{ `{{ .kura_introspection_client_id | trim }}` }}"
+        TUIST_KURA_INTROSPECTION_CLIENT_ID: "{{ `{{ .kura_introspection_client_id | trim }}` }}"
         {{- end }}
         KURA_CONTROL_PLANE_CLIENT_SECRET: "{{ `{{ .kura_introspection_client_secret | trim }}` }}"
+        TUIST_KURA_INTROSPECTION_CLIENT_SECRET: "{{ `{{ .kura_introspection_client_secret | trim }}` }}"
         {{- end }}
   data:
     {{- if $syncMaster }}

--- a/server/priv/ingest_repo/migrations/20260515100000_create_test_case_runs_recent_buckets_per_case_mvs.exs
+++ b/server/priv/ingest_repo/migrations/20260515100000_create_test_case_runs_recent_buckets_per_case_mvs.exs
@@ -22,6 +22,7 @@ defmodule Tuist.IngestRepo.Migrations.CreateTestCaseRunsRecentBucketsPerCaseMvs 
   @disable_migration_lock true
 
   @window_sizes [100, 250, 500, 750]
+  @historical_backfill_window_sizes [100, 250]
   @max_window_size 1000
   @project_chunk_size 25
   @chunk_throttle_ms 100
@@ -31,7 +32,16 @@ defmodule Tuist.IngestRepo.Migrations.CreateTestCaseRunsRecentBucketsPerCaseMvs 
       IngestRepo.query!("DROP VIEW IF EXISTS #{mv(window_size)}")
       IngestRepo.query!("DROP TABLE IF EXISTS #{table_name(window_size)}")
       create_table(window_size)
-      backfill_from_recent_per_case(window_size)
+
+      if window_size in @historical_backfill_window_sizes do
+        backfill_from_recent_per_case(window_size)
+      else
+        Logger.info(
+          "Skipping historical backfill for #{table_name(window_size)}; " <>
+            "the materialized view will populate it with new test case runs"
+        )
+      end
+
       create_materialized_view(window_size)
     end
   end


### PR DESCRIPTION
## What changed

- Skip the historical backfill for the 500 and 750 test-case recent bucket aggregate tables in the ClickHouse migration.
- Keep creating the 500 and 750 aggregate tables and materialized views, so new test case runs will populate them going forward.
- Restore the legacy `TUIST_KURA_INTROSPECTION_CLIENT_ID` and `TUIST_KURA_INTROSPECTION_CLIENT_SECRET` keys in the server ExternalSecret template alongside the newer `KURA_CONTROL_PLANE_*` keys.

## Why

The production deploy is still getting stuck in the migration hook. The 100 and 250 bucket backfills complete, but the 500 bucket historical backfill can still exceed ClickHouse's memory cap even after the previous chunking changes. We do not need to force that larger historical backfill as part of the hotfix release; allowing those tables to populate from new data lets the deploy proceed without dropping the future-facing views.

The server rollout can also wedge because existing pods still reference the legacy Kura introspection env var names. The ExternalSecret currently renders only the newer control-plane aliases, so fresh pods can fail secret-key resolution before the release completes.

## Impact

- The release should no longer spend migration-hook time trying to backfill the 500/750 historical buckets.
- The 500/750 bucket tables will be empty for historical data until we run a safer offline backfill later, but they will receive new rows through the materialized views.
- Existing and new server specs can resolve both Kura env var naming schemes during the rollout.

## Validation

- Parsed and format-checked `server/priv/ingest_repo/migrations/20260515100000_create_test_case_runs_recent_buckets_per_case_mvs.exs` with Elixir.
- Rendered `infra/helm/tuist/templates/external-secrets.yaml` for production and confirmed the server ExternalSecret includes both `KURA_CONTROL_PLANE_*` and `TUIST_KURA_INTROSPECTION_*` keys.
- Ran `helm lint` for production values.
- Ran `helm lint` for canary values.
- Ran `git diff --check`.
