### PR TITLE
fix(kura): harden segment disk accounting at rotation and startup

### DIFF
--- a/kura/src/app.rs
+++ b/kura/src/app.rs
@@ -122,6 +122,11 @@ async fn run_with_config(
         config.memory_hard_limit_bytes,
     );
     let store = Store::open(&config, io.clone(), memory.clone())?;
+    match store.sweep_orphaned_segments().await {
+        Ok(0) => {}
+        Ok(swept) => tracing::info!(swept, "removed orphaned segment files"),
+        Err(error) => tracing::warn!("failed to sweep orphaned segments: {error}"),
+    }
     let peer_client_factory = crate::peer_tls::PeerClientFactory::from_config(&config).await?;
     let client = peer_client_factory.build()?;
     let runtime = RuntimeState::new();

--- a/kura/src/store.rs
+++ b/kura/src/store.rs
@@ -1061,7 +1061,7 @@ impl Store {
         };
 
         if needs_new_segment {
-            let required_bytes = MAX_SEGMENT_BYTES.saturating_mul(SEGMENT_FREE_SPACE_MARGIN);
+            let required_bytes = segment_rotation_required_bytes(incoming_size);
             if let Some(available) = available_disk_bytes(&self.data_dir)
                 && available < required_bytes
             {
@@ -1184,6 +1184,58 @@ impl Store {
         }
 
         Ok(())
+    }
+
+    /// Removes segment files that the segment ring state no longer
+    /// references, along with any metadata still pointing at them.
+    ///
+    /// Rotation persists the ring state without the evicted segment before
+    /// the file is unlinked, so a crash (or an error) in that window strands
+    /// the file — and the manifests of the artifacts inside it — with no code
+    /// path left to reclaim them. Must run at startup, under the data-dir
+    /// writer lock and before any traffic, so it cannot race a rotation
+    /// creating a segment whose state entry is not yet visible.
+    pub async fn sweep_orphaned_segments(&self) -> Result<usize, String> {
+        let segments_dir = self.data_dir.join("segments");
+        let mut entries = match tokio::fs::read_dir(&segments_dir).await {
+            Ok(entries) => entries,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(0),
+            Err(error) => {
+                return Err(format!(
+                    "failed to list segments directory {}: {error}",
+                    segments_dir.display()
+                ));
+            }
+        };
+
+        let state = self.load_segment_state()?;
+        let mut swept = 0;
+        loop {
+            let entry = entries.next_entry().await.map_err(|error| {
+                format!(
+                    "failed to read segments directory {}: {error}",
+                    segments_dir.display()
+                )
+            })?;
+            let Some(entry) = entry else {
+                break;
+            };
+            let file_name = entry.file_name();
+            let Some(segment_id) = file_name
+                .to_str()
+                .and_then(|name| name.strip_suffix(".seg"))
+            else {
+                continue;
+            };
+            if state.generation_of(segment_id).is_some() {
+                continue;
+            }
+            tracing::warn!(segment_id, "removing orphaned segment");
+            self.evict_segment(segment_id).await?;
+            swept += 1;
+        }
+
+        Ok(swept)
     }
 
     fn segment_path(&self, segment_id: &str) -> PathBuf {
@@ -2563,6 +2615,19 @@ pub const DISK_FULL_MARKER: &str = "disk_full";
 
 pub fn is_disk_full_error(error: &str) -> bool {
     error.contains(DISK_FULL_MARKER)
+}
+
+/// Free bytes a rotation must see before creating a new segment: room for the
+/// incoming artifact, which is appended whole and can exceed
+/// `MAX_SEGMENT_BYTES`, plus the same again as slack for writers the rotation
+/// check cannot see (metadata store flushes and compactions, the evicted
+/// segment that is not yet unlinked, and tmp staging when it shares the
+/// filesystem — the staged source and the segment copy coexist during the
+/// append).
+fn segment_rotation_required_bytes(incoming_size: u64) -> u64 {
+    MAX_SEGMENT_BYTES
+        .max(incoming_size)
+        .saturating_mul(SEGMENT_FREE_SPACE_MARGIN)
 }
 
 #[cfg(unix)]
@@ -4261,5 +4326,104 @@ mod tests {
         assert_eq!(second_manifest.version_ms, 200);
         assert_eq!(read_manifest_bytes(&first, &first_manifest).await, b"v2");
         assert_eq!(read_manifest_bytes(&second, &second_manifest).await, b"v2");
+    }
+
+    #[test]
+    fn segment_rotation_requires_margin_for_oversized_artifacts() {
+        assert_eq!(
+            segment_rotation_required_bytes(0),
+            MAX_SEGMENT_BYTES * SEGMENT_FREE_SPACE_MARGIN
+        );
+        assert_eq!(
+            segment_rotation_required_bytes(MAX_SEGMENT_BYTES),
+            MAX_SEGMENT_BYTES * SEGMENT_FREE_SPACE_MARGIN
+        );
+        assert_eq!(
+            segment_rotation_required_bytes(3 * MAX_SEGMENT_BYTES),
+            3 * MAX_SEGMENT_BYTES * SEGMENT_FREE_SPACE_MARGIN
+        );
+    }
+
+    #[tokio::test]
+    async fn sweep_orphaned_segments_returns_zero_without_segments_dir() {
+        let (_temp_dir, _config, store) = temp_store();
+
+        let swept = store
+            .sweep_orphaned_segments()
+            .await
+            .expect("sweep should succeed");
+
+        assert_eq!(swept, 0);
+    }
+
+    #[tokio::test]
+    async fn sweep_orphaned_segments_removes_stray_files_and_keeps_live_segments() {
+        let (_temp_dir, config, store) = temp_store();
+        let manifest = store
+            .persist_artifact_from_bytes(
+                ArtifactProducer::Xcode,
+                "ios",
+                "artifact",
+                "application/octet-stream",
+                b"payload",
+            )
+            .await
+            .expect("artifact should persist");
+        let stray_path = config.data_dir.join("segments").join("stray.seg");
+        std::fs::write(&stray_path, b"junk").expect("stray segment should be written");
+
+        let swept = store
+            .sweep_orphaned_segments()
+            .await
+            .expect("sweep should succeed");
+
+        assert_eq!(swept, 1);
+        assert!(!stray_path.exists());
+        let bytes = store
+            .read_artifact_bytes(&manifest)
+            .await
+            .expect("live artifact should remain readable");
+        assert_eq!(bytes, b"payload");
+    }
+
+    #[tokio::test]
+    async fn sweep_orphaned_segments_reclaims_crash_window_segment_and_metadata() {
+        let (_temp_dir, _config, store) = temp_store();
+        let manifest = store
+            .persist_artifact_from_bytes(
+                ArtifactProducer::Xcode,
+                "ios",
+                "artifact",
+                "application/octet-stream",
+                b"payload",
+            )
+            .await
+            .expect("artifact should persist");
+        let segment_id = manifest
+            .segment_id
+            .clone()
+            .expect("artifact should be segment-backed");
+        let segment_file = store.segment_path(&segment_id);
+        assert!(segment_file.exists());
+
+        // Simulate the crash window: rotation saved the ring state without
+        // the evicted segment, but the process died before the unlink.
+        let mut state = store.load_segment_state().expect("state should load");
+        assert!(state.remove_segment(&segment_id));
+        store.save_segment_state(&state).expect("state should save");
+
+        let swept = store
+            .sweep_orphaned_segments()
+            .await
+            .expect("sweep should succeed");
+
+        assert_eq!(swept, 1);
+        assert!(!segment_file.exists());
+        assert!(
+            store
+                .manifest(&manifest.artifact_id)
+                .expect("manifest lookup should succeed")
+                .is_none()
+        );
     }
 }


### PR DESCRIPTION
Two disk-safety hardening fixes for the CAS segment ring, surfaced while stress-testing the margin assumptions behind #11222 (the disk-derived capacity work). Both matter more as that PR ships: larger rings mean far more rotations, so more chances to crash inside the rotation window and more traffic through the free-space guard.

## What changed

1. **The rotation free-space check now scales with the incoming artifact.** Previously it demanded a fixed `MAX_SEGMENT_BYTES * SEGMENT_FREE_SPACE_MARGIN` (1 GiB) no matter what was about to be written. The required bytes are now `max(MAX_SEGMENT_BYTES, incoming_size) * SEGMENT_FREE_SPACE_MARGIN`. Behavior is bit-for-bit identical for artifacts ≤ 512 MiB.
2. **Startup sweep for orphaned segment files.** `Store::sweep_orphaned_segments` runs once at startup (after `Store::open`, before any traffic): it lists `data_dir/segments/`, and every `.seg` file not referenced by the persisted ring state is routed through the existing `evict_segment` path. A failed sweep logs a warning and does not block startup.

## Root causes

**Oversized artifacts under-provisioned the guard.** Rotation triggers when `current_size + incoming > MAX_SEGMENT_BYTES`, and then the *whole* incoming artifact is appended into the fresh segment — segment files can legitimately exceed 512 MiB (e.g. a 2 GiB replication body, `MAX_REPLICATION_BODY_BYTES`). The rotation check is the **only** free-space checkpoint (appends between rotations are unchecked), so a 2 GiB append could pass a 1 GiB guard and hit raw ENOSPC mid-append — made worse by the fact that during `append_to_segment` the artifact's bytes transiently exist twice when the tmp dir shares the filesystem (the staged source is deleted only after the copy completes). The fix keeps the same 2× proportionality the margin has always encoded: one width for the new segment's guaranteed growth, one width of slack for unchecked co-writers.

**Crash-window orphans had no reclamation path.** Rotation is deliberately ordered for crash consistency: persist ring state *without* the evicted segment → append → commit metadata → unlink the evicted file. The safe direction of that ordering means a crash (or an error return) between the state save and the unlink strands the segment file — **and** the manifests and index entries of every artifact inside it — with nothing referencing them and no code path that will ever clean them up. Each such event leaks up to a segment's worth of disk permanently. The repo had no startup sweep of the segments directory at all.

## Why this shape

- The sweep reuses `evict_segment` rather than just unlinking files: that path already (atomically, with the tested batch logic) deletes the stranded manifests, the namespace and segment index entries, and the cached FD handle — so the crash-window case cleans up *metadata-consistently*, never leaving manifests pointing at deleted bytes.
- It is safe by construction: it runs under the `DataDirLock` writer lock (acquired before `Store::open` in `app.rs`), before any rotation can run, so it cannot race the legitimate "state references a segment whose file does not exist yet" window of a fresh rotation. The inverse direction (state entry without a file) is untouched, as is everything outside `segments/` (blob files, RocksDB).
- The required-bytes computation is extracted as a pure function so the policy is unit-testable.

## Rollout safety

Node-local only: no on-disk format, wire format, or replication protocol changes. Segment files are still reclaimed exclusively by unlink (the mmap SIGBUS invariant in `kura/AGENTS.md` is upheld). Mixed-version meshes are unaffected. For existing deployments the sweep is a no-op unless a node has accumulated orphans, in which case it frees disk on the next restart.

## Validation

- New unit tests:
  - `segment_rotation_requires_margin_for_oversized_artifacts` — fixed floor for small/equal sizes, scaled requirement for oversized ones.
  - `sweep_orphaned_segments_returns_zero_without_segments_dir` — first-boot no-op.
  - `sweep_orphaned_segments_removes_stray_files_and_keeps_live_segments` — stray file deleted, live segment and its artifact untouched and still readable.
  - `sweep_orphaned_segments_reclaims_crash_window_segment_and_metadata` — simulates the exact crash window (ring state saved without the segment, file still on disk) and asserts both the file and the stranded manifest are reclaimed.
- `cargo test --lib` — 238 passed, 0 failed; `cargo clippy --all-targets -- -D warnings` — clean; `cargo fmt` — no changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
