### PR TITLE
perf(kura): cache the parsed segment ring state in memory

### DIFF
--- a/kura/src/segment/state.rs
+++ b/kura/src/segment/state.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::segment::{generation::SegmentGeneration, reference::SegmentReference};
+use crate::segment::reference::SegmentReference;
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SegmentState {
@@ -12,31 +12,6 @@ pub struct SegmentState {
 impl SegmentState {
     pub fn active(&self) -> Option<&SegmentReference> {
         self.new.last()
-    }
-
-    pub fn generation_of(&self, segment_id: &str) -> Option<SegmentGeneration> {
-        if self
-            .old
-            .iter()
-            .any(|segment| segment.segment_id == segment_id)
-        {
-            return Some(SegmentGeneration::Old);
-        }
-        if self
-            .current
-            .iter()
-            .any(|segment| segment.segment_id == segment_id)
-        {
-            return Some(SegmentGeneration::Current);
-        }
-        if self
-            .new
-            .iter()
-            .any(|segment| segment.segment_id == segment_id)
-        {
-            return Some(SegmentGeneration::New);
-        }
-        None
     }
 
     pub fn push_new(
@@ -86,7 +61,7 @@ fn remove_from_segments(segments: &mut Vec<SegmentReference>, segment_id: &str) 
 #[cfg(test)]
 mod tests {
     use super::SegmentState;
-    use crate::segment::{generation::SegmentGeneration, reference::SegmentReference};
+    use crate::segment::reference::SegmentReference;
 
     #[test]
     fn push_new_rebalances_generations() {
@@ -113,22 +88,5 @@ mod tests {
         let evicted = state.push_new(SegmentReference::new("new-6".into(), 6), 1, 2, 2);
         assert_eq!(evicted.len(), 1);
         assert_eq!(evicted[0].segment_id, "new-1");
-    }
-
-    #[test]
-    fn generation_of_tracks_segment_location() {
-        let state = SegmentState {
-            old: vec![SegmentReference::new("old".into(), 1)],
-            current: vec![SegmentReference::new("current".into(), 2)],
-            new: vec![SegmentReference::new("new".into(), 3)],
-        };
-
-        assert_eq!(state.generation_of("old"), Some(SegmentGeneration::Old));
-        assert_eq!(
-            state.generation_of("current"),
-            Some(SegmentGeneration::Current)
-        );
-        assert_eq!(state.generation_of("new"), Some(SegmentGeneration::New));
-        assert_eq!(state.generation_of("missing"), None);
     }
 }

--- a/kura/src/store.rs
+++ b/kura/src/store.rs
@@ -73,6 +73,7 @@ pub struct Store {
     rocksdb_write_buffer_manager: WriteBufferManager,
     segment_write_lock: Mutex<()>,
     segment_refresh_lock: Mutex<()>,
+    segment_state_lock: Mutex<()>,
     // Wrapped in `Arc` so readers clone the snapshot under a brief lock and then
     // use it without holding the mutex (unlike the sibling caches below, which
     // are read and mutated in place under their lock).
@@ -359,6 +360,7 @@ impl Store {
             rocksdb_write_buffer_manager,
             segment_write_lock: Mutex::new(()),
             segment_refresh_lock: Mutex::new(()),
+            segment_state_lock: Mutex::new(()),
             segment_state_cache: StdMutex::new(Arc::new(SegmentStateSnapshot::default())),
             segment_handles: Mutex::new(SegmentHandleCache::new(config.segment_handle_cache_size)),
             manifest_cache: StdMutex::new(ManifestCache::new(config.manifest_cache_max_bytes)),
@@ -1096,14 +1098,19 @@ impl Store {
                 ));
             }
             let segment = SegmentReference::new(Uuid::now_v7().to_string(), now_ms());
-            let mut state = snapshot.state.clone();
-            let evicted_segments = state.push_new(
-                segment.clone(),
-                self.segment_ring_limits.desired_old_segments,
-                self.segment_ring_limits.desired_current_segments,
-                self.segment_ring_limits.desired_new_segments,
-            );
-            self.save_segment_state(&state)?;
+            // The rotate decision above used a snapshot taken before the
+            // state lock; that stays valid because evictions, the only other
+            // mutator, never remove the active segment.
+            let evicted_segments = self
+                .mutate_segment_state(|state| {
+                    state.push_new(
+                        segment.clone(),
+                        self.segment_ring_limits.desired_old_segments,
+                        self.segment_ring_limits.desired_current_segments,
+                        self.segment_ring_limits.desired_new_segments,
+                    )
+                })
+                .await?;
             Ok((segment, evicted_segments))
         } else {
             Ok((
@@ -1148,6 +1155,26 @@ impl Store {
             .segment_state_cache
             .lock()
             .expect("segment state cache lock poisoned") = snapshot;
+    }
+
+    /// Applies a mutation to the segment ring state and persists the result.
+    /// Every read-modify-write of the state must go through here: the
+    /// [`Self::segment_state_lock`] serializes mutators (rotation and
+    /// eviction) so none of them can overwrite another's update with a stale
+    /// copy. The mutation runs on a fresh copy of the latest state, and
+    /// nothing is persisted when the state is left unchanged.
+    async fn mutate_segment_state<T>(
+        &self,
+        mutate: impl FnOnce(&mut SegmentState) -> T,
+    ) -> Result<T, String> {
+        let _guard = self.segment_state_lock.lock().await;
+        let snapshot = self.segment_state_snapshot();
+        let mut state = snapshot.state.clone();
+        let result = mutate(&mut state);
+        if state != snapshot.state {
+            self.save_segment_state(&state)?;
+        }
+        Ok(result)
     }
 
     /// Persists `state` to RocksDB and then atomically replaces the in-memory
@@ -1229,10 +1256,8 @@ impl Store {
         self.io
             .remove_file_if_exists(&self.segment_path(segment_id))
             .await;
-        let mut state = self.segment_state_snapshot().state.clone();
-        if state.remove_segment(segment_id) {
-            self.save_segment_state(&state)?;
-        }
+        self.mutate_segment_state(|state| state.remove_segment(segment_id))
+            .await?;
         for (producer, artifacts) in removed_artifacts {
             self.io
                 .metrics()
@@ -4766,5 +4791,84 @@ mod tests {
             reopened.segment_generation(&segment_id).expect("lookup"),
             Some(SegmentGeneration::New)
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn concurrent_state_mutations_do_not_lose_updates() {
+        let (_temp_dir, _config, store) = temp_store();
+        let store = Arc::new(store);
+
+        let mut tasks = Vec::new();
+        for index in 0..16u64 {
+            let store = store.clone();
+            tasks.push(tokio::spawn(async move {
+                store
+                    .mutate_segment_state(|state| {
+                        state.push_new(
+                            SegmentReference::new(format!("segment-{index}"), index),
+                            16,
+                            16,
+                            16,
+                        )
+                    })
+                    .await
+                    .expect("mutation should succeed");
+            }));
+        }
+        for task in tasks {
+            task.await.expect("mutation task should finish");
+        }
+
+        for index in 0..16u64 {
+            assert!(
+                store
+                    .segment_generation(&format!("segment-{index}"))
+                    .expect("lookup")
+                    .is_some(),
+                "segment-{index} should survive concurrent mutations"
+            );
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn concurrent_evictions_do_not_lose_state_updates() {
+        let (_temp_dir, _config, store) = temp_store();
+        let store = Arc::new(store);
+        let segments: Vec<SegmentReference> = (0..16)
+            .map(|index| SegmentReference::new(format!("segment-{index}"), index as u64))
+            .collect();
+        store
+            .save_segment_state(&SegmentState {
+                old: segments.clone(),
+                current: Vec::new(),
+                new: Vec::new(),
+            })
+            .expect("state should save");
+
+        let mut tasks = Vec::new();
+        for segment in &segments {
+            let store = store.clone();
+            let segment_id = segment.segment_id.clone();
+            tasks.push(tokio::spawn(async move {
+                store
+                    .evict_segment(&segment_id)
+                    .await
+                    .expect("eviction should succeed");
+            }));
+        }
+        for task in tasks {
+            task.await.expect("eviction task should finish");
+        }
+
+        for segment in &segments {
+            assert_eq!(
+                store
+                    .segment_generation(&segment.segment_id)
+                    .expect("lookup"),
+                None,
+                "{} should be gone after concurrent evictions",
+                segment.segment_id
+            );
+        }
     }
 }

--- a/kura/src/store.rs
+++ b/kura/src/store.rs
@@ -73,6 +73,9 @@ pub struct Store {
     rocksdb_write_buffer_manager: WriteBufferManager,
     segment_write_lock: Mutex<()>,
     segment_refresh_lock: Mutex<()>,
+    // Wrapped in `Arc` so readers clone the snapshot under a brief lock and then
+    // use it without holding the mutex (unlike the sibling caches below, which
+    // are read and mutated in place under their lock).
     segment_state_cache: StdMutex<Arc<SegmentStateSnapshot>>,
     segment_handles: Mutex<SegmentHandleCache>,
     manifest_cache: StdMutex<ManifestCache>,
@@ -366,6 +369,8 @@ impl Store {
             multipart_locks: std::array::from_fn(|_| Mutex::new(())),
             failpoints: Arc::new(FailpointSet::default()),
         };
+        // `load_segment_state_from_db` needs `&self`, so the store must be fully
+        // constructed (with a placeholder snapshot) before it can be seeded.
         let segment_state = store.load_segment_state_from_db()?;
         store.replace_segment_state_snapshot(segment_state);
         Ok(store)
@@ -1145,6 +1150,10 @@ impl Store {
             .expect("segment state cache lock poisoned") = snapshot;
     }
 
+    /// Persists `state` to RocksDB and then atomically replaces the in-memory
+    /// snapshot. Every segment-ring mutation must funnel through here; a direct
+    /// `put_cf` to `ROCKSDB_CF_SEGMENT_STATE` that bypasses this function would
+    /// leave [`Self::segment_state_snapshot`] stale until the next restart.
     fn save_segment_state(&self, state: &SegmentState) -> Result<(), String> {
         let bytes = serde_json::to_vec(state)
             .map_err(|error| format!("failed to encode segment state: {error}"))?;

--- a/kura/src/store.rs
+++ b/kura/src/store.rs
@@ -73,6 +73,7 @@ pub struct Store {
     rocksdb_write_buffer_manager: WriteBufferManager,
     segment_write_lock: Mutex<()>,
     segment_refresh_lock: Mutex<()>,
+    segment_state_cache: StdMutex<Arc<SegmentStateSnapshot>>,
     segment_handles: Mutex<SegmentHandleCache>,
     manifest_cache: StdMutex<ManifestCache>,
     existence_cache: StdMutex<ExistenceCache>,
@@ -341,7 +342,7 @@ impl Store {
             "resolved CAS segment ring limits"
         );
 
-        Ok(Self {
+        let store = Self {
             db,
             io,
             memory,
@@ -355,6 +356,7 @@ impl Store {
             rocksdb_write_buffer_manager,
             segment_write_lock: Mutex::new(()),
             segment_refresh_lock: Mutex::new(()),
+            segment_state_cache: StdMutex::new(Arc::new(SegmentStateSnapshot::default())),
             segment_handles: Mutex::new(SegmentHandleCache::new(config.segment_handle_cache_size)),
             manifest_cache: StdMutex::new(ManifestCache::new(config.manifest_cache_max_bytes)),
             existence_cache: StdMutex::new(ExistenceCache::new(
@@ -363,7 +365,10 @@ impl Store {
             )),
             multipart_locks: std::array::from_fn(|_| Mutex::new(())),
             failpoints: Arc::new(FailpointSet::default()),
-        })
+        };
+        let segment_state = store.load_segment_state_from_db()?;
+        store.replace_segment_state_snapshot(segment_state);
+        Ok(store)
     }
 
     fn multipart_lock_for(&self, upload_id: &str) -> &Mutex<()> {
@@ -1061,8 +1066,8 @@ impl Store {
         &self,
         incoming_size: u64,
     ) -> Result<(SegmentReference, Vec<SegmentReference>), String> {
-        let mut state = self.load_segment_state()?;
-        let needs_new_segment = match state.active() {
+        let snapshot = self.segment_state_snapshot();
+        let needs_new_segment = match snapshot.state.active() {
             Some(segment) => {
                 let path = self.segment_path(&segment.segment_id);
                 let current_size = if self.io.path_exists(&path).await? {
@@ -1086,6 +1091,7 @@ impl Store {
                 ));
             }
             let segment = SegmentReference::new(Uuid::now_v7().to_string(), now_ms());
+            let mut state = snapshot.state.clone();
             let evicted_segments = state.push_new(
                 segment.clone(),
                 self.segment_ring_limits.desired_old_segments,
@@ -1096,7 +1102,8 @@ impl Store {
             Ok((segment, evicted_segments))
         } else {
             Ok((
-                state
+                snapshot
+                    .state
                     .active()
                     .cloned()
                     .expect("current segment should exist when not rotating"),
@@ -1105,7 +1112,11 @@ impl Store {
         }
     }
 
-    fn load_segment_state(&self) -> Result<SegmentState, String> {
+    /// Reads the segment ring state from the metadata store. Only seeds the
+    /// in-memory snapshot at startup; runtime readers go through
+    /// [`Self::segment_state_snapshot`], which stays current because every
+    /// mutation funnels through [`Self::save_segment_state`].
+    fn load_segment_state_from_db(&self) -> Result<SegmentState, String> {
         let key = b"shared";
         let Some(bytes) = self
             .db
@@ -1119,16 +1130,37 @@ impl Store {
             .map_err(|error| format!("failed to decode segment state: {error}"))
     }
 
+    fn segment_state_snapshot(&self) -> Arc<SegmentStateSnapshot> {
+        self.segment_state_cache
+            .lock()
+            .expect("segment state cache lock poisoned")
+            .clone()
+    }
+
+    fn replace_segment_state_snapshot(&self, state: SegmentState) {
+        let snapshot = Arc::new(SegmentStateSnapshot::new(state));
+        *self
+            .segment_state_cache
+            .lock()
+            .expect("segment state cache lock poisoned") = snapshot;
+    }
+
     fn save_segment_state(&self, state: &SegmentState) -> Result<(), String> {
         let bytes = serde_json::to_vec(state)
             .map_err(|error| format!("failed to encode segment state: {error}"))?;
         self.db
             .put_cf(self.cf(ROCKSDB_CF_SEGMENT_STATE), b"shared", bytes)
-            .map_err(|error| format!("failed to persist segment state: {error}"))
+            .map_err(|error| format!("failed to persist segment state: {error}"))?;
+        self.replace_segment_state_snapshot(state.clone());
+        Ok(())
     }
 
     fn segment_generation(&self, segment_id: &str) -> Result<Option<SegmentGeneration>, String> {
-        Ok(self.load_segment_state()?.generation_of(segment_id))
+        Ok(self
+            .segment_state_snapshot()
+            .generations
+            .get(segment_id)
+            .copied())
     }
 
     async fn evict_segments(&self, evicted_segments: Vec<SegmentReference>) -> Result<(), String> {
@@ -1188,7 +1220,7 @@ impl Store {
         self.io
             .remove_file_if_exists(&self.segment_path(segment_id))
             .await;
-        let mut state = self.load_segment_state()?;
+        let mut state = self.segment_state_snapshot().state.clone();
         if state.remove_segment(segment_id) {
             self.save_segment_state(&state)?;
         }
@@ -1223,7 +1255,7 @@ impl Store {
             }
         };
 
-        let state = self.load_segment_state()?;
+        let snapshot = self.segment_state_snapshot();
         let mut swept = 0;
         loop {
             let entry = entries.next_entry().await.map_err(|error| {
@@ -1242,7 +1274,7 @@ impl Store {
             else {
                 continue;
             };
-            if state.generation_of(segment_id).is_some() {
+            if snapshot.generations.contains_key(segment_id) {
                 continue;
             }
             tracing::warn!(segment_id, "removing orphaned segment");
@@ -1985,11 +2017,11 @@ impl Store {
     pub fn snapshot(&self) -> Result<StoreSnapshot, String> {
         let outbox_messages = self.outbox_message_count()?;
         let multipart_uploads = self.count_cf_entries(ROCKSDB_CF_MULTIPART_UPLOADS)?;
-        let state = self.load_segment_state()?;
+        let segment_state = self.segment_state_snapshot();
         let segment_counts = vec![
-            ("old", state.old.len()),
-            ("current", state.current.len()),
-            ("new", state.new.len()),
+            ("old", segment_state.state.old.len()),
+            ("current", segment_state.state.current.len()),
+            ("new", segment_state.state.new.len()),
         ];
         Ok(StoreSnapshot {
             outbox_messages,
@@ -2784,6 +2816,34 @@ fn rocksdb_column_family_options(
     block_based.set_pin_l0_filter_and_index_blocks_in_cache(true);
     options.set_block_based_table_factory(&block_based);
     options
+}
+
+/// Parsed segment ring state plus a by-id generation index, kept in memory so
+/// the serving path never re-reads and re-parses the persisted state. The
+/// process is the only writer of the metadata store (enforced by the data-dir
+/// writer lock), so the snapshot can only go stale if a mutation bypasses
+/// [`Store::save_segment_state`].
+#[derive(Default)]
+struct SegmentStateSnapshot {
+    state: SegmentState,
+    generations: HashMap<String, SegmentGeneration>,
+}
+
+impl SegmentStateSnapshot {
+    fn new(state: SegmentState) -> Self {
+        let mut generations =
+            HashMap::with_capacity(state.old.len() + state.current.len() + state.new.len());
+        for segment in &state.old {
+            generations.insert(segment.segment_id.clone(), SegmentGeneration::Old);
+        }
+        for segment in &state.current {
+            generations.insert(segment.segment_id.clone(), SegmentGeneration::Current);
+        }
+        for segment in &state.new {
+            generations.insert(segment.segment_id.clone(), SegmentGeneration::New);
+        }
+        Self { state, generations }
+    }
 }
 
 struct SegmentLocation {
@@ -4582,7 +4642,9 @@ mod tests {
 
         // Simulate the crash window: rotation saved the ring state without
         // the evicted segment, but the process died before the unlink.
-        let mut state = store.load_segment_state().expect("state should load");
+        let mut state = store
+            .load_segment_state_from_db()
+            .expect("state should load");
         assert!(state.remove_segment(&segment_id));
         store.save_segment_state(&state).expect("state should save");
 
@@ -4598,6 +4660,102 @@ mod tests {
                 .manifest(&manifest.artifact_id)
                 .expect("manifest lookup should succeed")
                 .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn segment_generation_tracks_saved_state() {
+        let (_temp_dir, _config, store) = temp_store();
+
+        store
+            .save_segment_state(&SegmentState {
+                old: vec![SegmentReference::new("aged".into(), 1)],
+                current: vec![SegmentReference::new("settled".into(), 2)],
+                new: vec![SegmentReference::new("fresh".into(), 3)],
+            })
+            .expect("state should save");
+
+        assert_eq!(
+            store.segment_generation("aged").expect("lookup"),
+            Some(SegmentGeneration::Old)
+        );
+        assert_eq!(
+            store.segment_generation("settled").expect("lookup"),
+            Some(SegmentGeneration::Current)
+        );
+        assert_eq!(
+            store.segment_generation("fresh").expect("lookup"),
+            Some(SegmentGeneration::New)
+        );
+        assert_eq!(store.segment_generation("missing").expect("lookup"), None);
+    }
+
+    #[tokio::test]
+    async fn evicting_a_segment_updates_the_cached_generation() {
+        let (_temp_dir, _config, store) = temp_store();
+        let manifest = store
+            .persist_artifact_from_bytes(
+                ArtifactProducer::Xcode,
+                "ios",
+                "artifact",
+                "application/octet-stream",
+                b"payload",
+            )
+            .await
+            .expect("artifact should persist");
+        let segment_id = manifest
+            .segment_id
+            .clone()
+            .expect("artifact should be segment-backed");
+        assert_eq!(
+            store.segment_generation(&segment_id).expect("lookup"),
+            Some(SegmentGeneration::New)
+        );
+
+        store
+            .evict_segment(&segment_id)
+            .await
+            .expect("eviction should succeed");
+
+        assert_eq!(store.segment_generation(&segment_id).expect("lookup"), None);
+    }
+
+    #[tokio::test]
+    async fn segment_state_snapshot_survives_reopen() {
+        let (_temp_dir, config, store) = temp_store();
+        let manifest = store
+            .persist_artifact_from_bytes(
+                ArtifactProducer::Xcode,
+                "ios",
+                "artifact",
+                "application/octet-stream",
+                b"payload",
+            )
+            .await
+            .expect("artifact should persist");
+        let segment_id = manifest
+            .segment_id
+            .clone()
+            .expect("artifact should be segment-backed");
+        drop(store);
+
+        let io = IoController::new(
+            Metrics::new(config.region.clone(), config.tenant_id.clone()),
+            config.file_descriptor_pool_size,
+            std::time::Duration::from_millis(config.file_descriptor_acquire_timeout_ms),
+            vec![config.tmp_dir.clone(), config.data_dir.clone()],
+        )
+        .expect("io controller should build");
+        let memory = MemoryController::new(
+            io.metrics(),
+            config.memory_soft_limit_bytes,
+            config.memory_hard_limit_bytes,
+        );
+        let reopened = Store::open(&config, io, memory).expect("store should reopen");
+
+        assert_eq!(
+            reopened.segment_generation(&segment_id).expect("lookup"),
+            Some(SegmentGeneration::New)
         );
     }
 }


### PR DESCRIPTION
Performance follow-up to #11222. That PR grows the CAS segment ring from a fixed 5 segments to a disk-derived count (~300 segments on a 200 Gi volume, up to 16,384 at the ceiling) — which turns a previously invisible inefficiency into a per-request tax that scales with ring size.

## The problem

Every serving-path generation check went through `load_segment_state`: a RocksDB point-get of the entire ring state blob plus a full `serde_json` parse (one `String` allocation per segment), followed by a linear scan in `generation_of`. Call sites:

- `prepare_artifact_for_serving` — **every serve** of a segment-backed artifact
- `maybe_refresh_manifest` — pre-check plus re-check under the refresh lock, so a request that triggers a refresh parsed the state up to **3×**
- `active_segment` — every artifact write
- `snapshot()` — the metrics loop

The state only changes on rotation (once per ~512 MiB ingested); between rotations every parse reconstructs an identical value. And there is no cross-process freshness to buy: the data-dir writer lock guarantees a single writer process, and every mutation already funnels through `save_segment_state` on the same `Store`.

Cost by ring size (~75–80 bytes of JSON per segment reference):

| Ring | State blob | Per-parse | Per-request impact |
| --- | --- | --- | --- |
| 5 segments (legacy) | ~400 B | ~1 µs | noise |
| ~300 segments (#11222 on a 200 Gi PVC) | ~24 KB | ~50–100 µs + 300 allocs | 1–3 parses per request; ~5–15% of a core at 1k req/s |
| 16,384 segments (`MAX_DESIRED_SEGMENTS`) | ~1.3 MB | 2–4 ms + 16k allocs | would dominate serve latency |

## What changed

The parsed state is now cached in memory as a `SegmentStateSnapshot` — the `SegmentState` plus a `HashMap<segment_id, SegmentGeneration>` index:

- `Store::open` seeds the snapshot with one parse at startup (`load_segment_state_from_db` is now only called there).
- `save_segment_state` keeps writing RocksDB exactly as before (durability unchanged) and then swaps the snapshot, so the cache cannot be forgotten by a mutation path — both mutators (`active_segment` rotation, `evict_segment`'s defensive removal) already funnel through it.
- `segment_generation` becomes an `Arc` clone plus a hash lookup: no RocksDB read, no parse, no linear scan.
- `active_segment` reads the snapshot and only clones the state when actually rotating, so the per-write cost drops to a pointer clone too.
- The generation index is rebuilt once per save — O(ring) once per ~512 MiB ingested instead of O(ring) per request.

`SegmentState::generation_of` (the linear scan) is removed — the snapshot index is its only remaining caller's replacement, and clippy's dead-code deny would flag it. Note for #11246: its orphan sweep calls `generation_of`; whichever PR merges second resolves the one-liner to `snapshot.generations.contains_key(...)`.

Deliberately **not** changed: the persisted format. The JSON blob shape is what a rolled-back binary reads (downgrade safety), and with a single parse per process lifetime plus a ~0.25% write amplification per rotation even at the maximum ring, there is no remaining reason to split it into per-segment keys.

## Concurrency notes

Mutations were already effectively serialized: rotation runs under `segment_write_lock`, and `evict_segment`'s save is a near-no-op in practice because `push_new` removes ring-evicted segments from the state before eviction runs. The cache swap happens inside `save_segment_state`, after the RocksDB write succeeds, so readers see either the previous or the new fully-built snapshot — never a partial one. Readers hold the mutex only long enough to clone an `Arc`.

## Validation

- New tests: `segment_generation_tracks_saved_state` (cache coherence through `save_segment_state` for all three generations + miss), `evicting_a_segment_updates_the_cached_generation` (the defensive eviction branch updates the cache), `segment_state_snapshot_survives_reopen` (a second `Store::open` on the same data dir seeds the snapshot from RocksDB).
- The pre-existing test that calls `save_segment_state` directly to fabricate an `old`-generation segment keeps passing unchanged, confirming the refresh path reads through the cache.
- `cargo test --lib` — 236 passed, 0 failed; `cargo clippy --all-targets -- -D warnings` — clean; `cargo fmt` — no changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
