### PR TITLE
fix(kura): serialize segment ring state mutations

### DIFF
--- a/kura/src/store.rs
+++ b/kura/src/store.rs
@@ -73,6 +73,7 @@ pub struct Store {
     rocksdb_write_buffer_manager: WriteBufferManager,
     segment_write_lock: Mutex<()>,
     segment_refresh_lock: Mutex<()>,
+    segment_state_lock: Mutex<()>,
     // Wrapped in `Arc` so readers clone the snapshot under a brief lock and then
     // use it without holding the mutex (unlike the sibling caches below, which
     // are read and mutated in place under their lock).
@@ -359,6 +360,7 @@ impl Store {
             rocksdb_write_buffer_manager,
             segment_write_lock: Mutex::new(()),
             segment_refresh_lock: Mutex::new(()),
+            segment_state_lock: Mutex::new(()),
             segment_state_cache: StdMutex::new(Arc::new(SegmentStateSnapshot::default())),
             segment_handles: Mutex::new(SegmentHandleCache::new(config.segment_handle_cache_size)),
             manifest_cache: StdMutex::new(ManifestCache::new(config.manifest_cache_max_bytes)),
@@ -1096,14 +1098,19 @@ impl Store {
                 ));
             }
             let segment = SegmentReference::new(Uuid::now_v7().to_string(), now_ms());
-            let mut state = snapshot.state.clone();
-            let evicted_segments = state.push_new(
-                segment.clone(),
-                self.segment_ring_limits.desired_old_segments,
-                self.segment_ring_limits.desired_current_segments,
-                self.segment_ring_limits.desired_new_segments,
-            );
-            self.save_segment_state(&state)?;
+            // The rotate decision above used a snapshot taken before the
+            // state lock; that stays valid because evictions, the only other
+            // mutator, never remove the active segment.
+            let evicted_segments = self
+                .mutate_segment_state(|state| {
+                    state.push_new(
+                        segment.clone(),
+                        self.segment_ring_limits.desired_old_segments,
+                        self.segment_ring_limits.desired_current_segments,
+                        self.segment_ring_limits.desired_new_segments,
+                    )
+                })
+                .await?;
             Ok((segment, evicted_segments))
         } else {
             Ok((
@@ -1148,6 +1155,26 @@ impl Store {
             .segment_state_cache
             .lock()
             .expect("segment state cache lock poisoned") = snapshot;
+    }
+
+    /// Applies a mutation to the segment ring state and persists the result.
+    /// Every read-modify-write of the state must go through here: the
+    /// [`Self::segment_state_lock`] serializes mutators (rotation and
+    /// eviction) so none of them can overwrite another's update with a stale
+    /// copy. The mutation runs on a fresh copy of the latest state, and
+    /// nothing is persisted when the state is left unchanged.
+    async fn mutate_segment_state<T>(
+        &self,
+        mutate: impl FnOnce(&mut SegmentState) -> T,
+    ) -> Result<T, String> {
+        let _guard = self.segment_state_lock.lock().await;
+        let snapshot = self.segment_state_snapshot();
+        let mut state = snapshot.state.clone();
+        let result = mutate(&mut state);
+        if state != snapshot.state {
+            self.save_segment_state(&state)?;
+        }
+        Ok(result)
     }
 
     /// Persists `state` to RocksDB and then atomically replaces the in-memory
@@ -1229,10 +1256,8 @@ impl Store {
         self.io
             .remove_file_if_exists(&self.segment_path(segment_id))
             .await;
-        let mut state = self.segment_state_snapshot().state.clone();
-        if state.remove_segment(segment_id) {
-            self.save_segment_state(&state)?;
-        }
+        self.mutate_segment_state(|state| state.remove_segment(segment_id))
+            .await?;
         for (producer, artifacts) in removed_artifacts {
             self.io
                 .metrics()
@@ -4766,5 +4791,84 @@ mod tests {
             reopened.segment_generation(&segment_id).expect("lookup"),
             Some(SegmentGeneration::New)
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn concurrent_state_mutations_do_not_lose_updates() {
+        let (_temp_dir, _config, store) = temp_store();
+        let store = Arc::new(store);
+
+        let mut tasks = Vec::new();
+        for index in 0..16u64 {
+            let store = store.clone();
+            tasks.push(tokio::spawn(async move {
+                store
+                    .mutate_segment_state(|state| {
+                        state.push_new(
+                            SegmentReference::new(format!("segment-{index}"), index),
+                            16,
+                            16,
+                            16,
+                        )
+                    })
+                    .await
+                    .expect("mutation should succeed");
+            }));
+        }
+        for task in tasks {
+            task.await.expect("mutation task should finish");
+        }
+
+        for index in 0..16u64 {
+            assert!(
+                store
+                    .segment_generation(&format!("segment-{index}"))
+                    .expect("lookup")
+                    .is_some(),
+                "segment-{index} should survive concurrent mutations"
+            );
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn concurrent_evictions_do_not_lose_state_updates() {
+        let (_temp_dir, _config, store) = temp_store();
+        let store = Arc::new(store);
+        let segments: Vec<SegmentReference> = (0..16)
+            .map(|index| SegmentReference::new(format!("segment-{index}"), index as u64))
+            .collect();
+        store
+            .save_segment_state(&SegmentState {
+                old: segments.clone(),
+                current: Vec::new(),
+                new: Vec::new(),
+            })
+            .expect("state should save");
+
+        let mut tasks = Vec::new();
+        for segment in &segments {
+            let store = store.clone();
+            let segment_id = segment.segment_id.clone();
+            tasks.push(tokio::spawn(async move {
+                store
+                    .evict_segment(&segment_id)
+                    .await
+                    .expect("eviction should succeed");
+            }));
+        }
+        for task in tasks {
+            task.await.expect("eviction task should finish");
+        }
+
+        for segment in &segments {
+            assert_eq!(
+                store
+                    .segment_generation(&segment.segment_id)
+                    .expect("lookup"),
+                None,
+                "{} should be gone after concurrent evictions",
+                segment.segment_id
+            );
+        }
     }
 }


### PR DESCRIPTION
## Problem

`active_segment` (rotation, under `segment_write_lock`) and `evict_segment` (previously unlocked) both perform read-modify-write cycles on the segment ring state: clone the latest state, mutate the clone, save it. With no common lock, a stale clone can overwrite a concurrent save, either resurrecting an evicted segment in the ring or orphaning a freshly rotated one.

Today this race is **latent, not live**. Eviction and rotation overlap routinely on a busy node — eviction runs outside the write lock, and its RocksDB index scan plus 512 MB unlink take long enough for the next rotation to start — but during that overlap only the rotation ever writes state, because of an accidental invariant chain:

1. `push_new` removes the evicted segment from the ring before the producing rotation saves,
2. so by the time `evict_segment` runs, its conditional save (`if state.remove_segment(...)`) is always a no-op in the rotation-produced flow,
3. so every save that actually executes is a rotation save, serialized by `segment_write_lock`.

None of that is written down or enforced — review flagged this as a live P1 lost-update race precisely because a careful reader cannot tell the code is safe. And the chain breaks the moment anything evicts a segment that is still in the ring. With disk-sized rings (#11221, `kura-cas-capacity-from-disk`), pressure-eviction of ring members is the natural next caller, and at that point the interleavings become real:

- An eviction save landing inside rotation's clone-to-save window gets overwritten by the rotation's stale clone, resurrecting the evicted segment: file unlinked and manifests deleted, but the ring and capacity accounting count a phantom segment, pushing the next pressure pass to evict a live segment early — dangling REAPI action-cache references, the #11221 failure class back as an intermittent race.
- The mirror ordering orphans the freshly rotated segment from the ring: its artifacts still serve via manifests, but it never ages out (a permanent segment-sized disk leak), and `active()` reverts to the already-full previous segment, forcing an immediate spurious re-rotation.

## Fix

Every segment-state read-modify-write now funnels through a new `mutate_segment_state` helper guarded by a dedicated `segment_state_lock`: acquire the lock, copy the latest cached snapshot, apply the mutation, persist only when the state actually changed. Both rotation and eviction call it. This replaces a global, fragile correctness argument ("audit every caller and the ring semantics") with a local, enforced one ("all RMW goes through the helper; the helper holds the lock") — before the capacity work invalidates the old argument.

Design notes:

- A dedicated mutex was chosen over reusing `segment_write_lock` because that lock is held across whole segment appends; evictions are awaited on the persist hot path and would otherwise queue behind unrelated bulk writes. Lock ordering stays an acyclic hierarchy (`segment_refresh_lock` → `segment_write_lock` → `segment_state_lock`), and the state lock is a leaf with a synchronous-only critical section, so it cannot participate in a deadlock cycle.
- `active_segment`'s rotate decision still reads a snapshot taken before the state lock is acquired. That stays valid because eviction — the only other mutator — never removes the active segment (documented in a code comment). This is also a standing constraint on any future pressure-evictor: it must only target non-active generations.

## Validation

The two new multi-threaded tests simulate exactly the future caller that activates the race — they operate on ring members directly instead of rotation overflow (today's only production flow, where the race cannot fire):

- 16 concurrent `mutate_segment_state` pushes — every pushed segment survives in the final state.
- 16 concurrent `evict_segment` calls against a pre-seeded ring — every segment is gone from the final state, none resurrected by a stale save.

Both pass locally (`cargo test do_not_lose`).

Stacked on #11247; only the top commit is new here.

---

[![Compound Engineering v2.60.0](https://img.shields.io/badge/Compound_Engineering-v2.60.0-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Fable 5 via [Claude Code](https://claude.com/claude-code)
