### PR TITLE
fix(server): handle streamed Req telemetry results

### DIFF
--- a/server/lib/tuist/http/prom_ex_plugin.ex
+++ b/server/lib/tuist/http/prom_ex_plugin.ex
@@ -229,18 +229,22 @@ defmodule Tuist.HTTP.PromExPlugin do
   end
 
   defp request_metadata_to_tag_values(metadata) do
-    response_attrs =
-      case metadata[:result] do
-        {:ok, %{status: status}} -> %{response_status: status}
-        {:error, exception} -> %{error: Sanitizer.sanitize_value(exception)}
-      end
-
     %{
       name: metadata.name
     }
-    |> Map.merge(response_attrs)
+    |> Map.merge(result_to_tag_values(metadata[:result]))
     |> Map.merge(request_to_tag_values(metadata.request))
   end
+
+  defp result_to_tag_values({:ok, {_request, %{status: status}}}), do: %{response_status: status}
+  defp result_to_tag_values({:ok, %{status: status}}), do: %{response_status: status}
+
+  defp result_to_tag_values({:error, exception, {_request, _response}}), do: %{error: Sanitizer.sanitize_value(exception)}
+
+  defp result_to_tag_values({:error, {_request, exception}}), do: %{error: Sanitizer.sanitize_value(exception)}
+
+  defp result_to_tag_values({:error, exception}), do: %{error: Sanitizer.sanitize_value(exception)}
+  defp result_to_tag_values(result), do: %{error: Sanitizer.sanitize_value(result)}
 
   defp queue_metadata_to_tag_values(metadata) do
     Map.merge(%{name: metadata.name}, request_to_tag_values(metadata.request))

--- a/server/test/tuist/http/prom_ex_plugin_test.exs
+++ b/server/test/tuist/http/prom_ex_plugin_test.exs
@@ -1,0 +1,71 @@
+defmodule Tuist.HTTP.PromExPluginTest do
+  use ExUnit.Case, async: true
+
+  alias Tuist.HTTP.PromExPlugin
+
+  describe "request event tag values" do
+    test "extracts the response status from streamed Req responses" do
+      tag_values = request_stop_tag_values()
+
+      request = %{
+        method: "GET",
+        host: "productionresultssa11.blob.core.windows.net",
+        path: "/actions-results/job-logs.txt",
+        scheme: :https,
+        query: "sv=2025-11-05",
+        port: 443
+      }
+
+      req = Req.Request.new(method: :get, url: "https://productionresultssa11.blob.core.windows.net/job-logs.txt")
+      resp = %Req.Response{status: 200}
+
+      assert tag_values.(%{name: :pipeline, request: request, result: {:ok, {req, resp}}}) == %{
+               name: :pipeline,
+               response_status: 200,
+               request_method: "GET",
+               request_host: "productionresultssa11.blob.core.windows.net",
+               request_path: "/actions-results/job-logs.txt",
+               request_scheme: :https,
+               request_query: "sv=2025-11-05",
+               request_port: 443
+             }
+    end
+
+    test "extracts the error from streamed Req failures" do
+      tag_values = request_stop_tag_values()
+
+      request = %{
+        method: "GET",
+        host: "productionresultssa0.blob.core.windows.net",
+        path: "/actions-results/job-logs.txt",
+        scheme: :https,
+        query: "sv=2025-11-05",
+        port: 443
+      }
+
+      req = Req.Request.new(method: :get, url: "https://productionresultssa0.blob.core.windows.net/job-logs.txt")
+      resp = %Req.Response{status: 200}
+      exception = %Mint.TransportError{reason: :timeout}
+
+      assert tag_values.(%{name: :pipeline, request: request, result: {:error, exception, {req, resp}}}) == %{
+               name: :pipeline,
+               error: "Mint.TransportError",
+               request_method: "GET",
+               request_host: "productionresultssa0.blob.core.windows.net",
+               request_path: "/actions-results/job-logs.txt",
+               request_scheme: :https,
+               request_query: "sv=2025-11-05",
+               request_port: 443
+             }
+    end
+  end
+
+  defp request_stop_tag_values do
+    []
+    |> PromExPlugin.event_metrics()
+    |> Enum.find(&(&1.group_name == :tuist_http_request_event_metrics))
+    |> Map.fetch!(:metrics)
+    |> Enum.find(&(&1.event_name == [:finch, :request, :stop]))
+    |> Map.fetch!(:tag_values)
+  end
+end


### PR DESCRIPTION
## What changed

- Normalized the Req/Finch telemetry `result` values in `Tuist.HTTP.PromExPlugin` before deriving PromEx request tags.
- Added focused regressions for streamed Req success and streamed timeout/error result shapes.

## Why

Sentry was reporting telemetry handler crashes for outbound job-log requests. The PromEx request tag extractor only handled plain results like `{:ok, %Req.Response{}}` and `{:error, exception}`. Req telemetry can also report streamed `into` results as tuple shapes such as `{:ok, {%Req.Request{}, %Req.Response{}}}` and `{:error, exception, {%Req.Request{}, %Req.Response{}}}`.

Because those shapes were not matched, the telemetry handler itself crashed with a `CaseClauseError`, producing issues like https://tuist.sentry.io/issues/127401699/.

## Impact

HTTP request metrics continue to be emitted for the streamed Req cases instead of turning telemetry into a production exception source. Successful streamed responses keep their status tag, and streamed failures keep a sanitized error tag.

## Validation

- Added the regression first and reproduced the `CaseClauseError` locally.
- Ran `mix format lib/tuist/http/prom_ex_plugin.ex test/tuist/http/prom_ex_plugin_test.exs`.
- Ran `mix test test/tuist/http/prom_ex_plugin_test.exs`.
- Ran `git diff --check`.
