### PR TITLE
fix(infra): scope Kura load balancer targets

### DIFF
--- a/infra/helm/platform/values-tuist-canary.yaml
+++ b/infra/helm/platform/values-tuist-canary.yaml
@@ -17,6 +17,7 @@ ingress-nginx:
     service:
       annotations:
         load-balancer.hetzner.cloud/location: fsn1
+        load-balancer.hetzner.cloud/node-selector: topology.kubernetes.io/region=fsn1
 
 kura-eu-central-ingress-nginx:
   enabled: true
@@ -27,4 +28,5 @@ kura-eu-central-ingress-nginx:
       annotations:
         load-balancer.hetzner.cloud/location: fsn1
         load-balancer.hetzner.cloud/name: tuist-canary-kura-eu-central-ingress
+        load-balancer.hetzner.cloud/node-selector: node.cluster.x-k8s.io/pool=kura
         load-balancer.hetzner.cloud/uses-proxyprotocol: "true"

--- a/infra/helm/platform/values-tuist-staging.yaml
+++ b/infra/helm/platform/values-tuist-staging.yaml
@@ -17,6 +17,7 @@ ingress-nginx:
     service:
       annotations:
         load-balancer.hetzner.cloud/location: fsn1
+        load-balancer.hetzner.cloud/node-selector: topology.kubernetes.io/region=fsn1
 
 kura-eu-central-ingress-nginx:
   enabled: true
@@ -27,4 +28,5 @@ kura-eu-central-ingress-nginx:
       annotations:
         load-balancer.hetzner.cloud/location: fsn1
         load-balancer.hetzner.cloud/name: tuist-staging-kura-eu-central-ingress
+        load-balancer.hetzner.cloud/node-selector: node.cluster.x-k8s.io/pool=kura
         load-balancer.hetzner.cloud/uses-proxyprotocol: "true"

--- a/infra/helm/platform/values-tuist.yaml
+++ b/infra/helm/platform/values-tuist.yaml
@@ -23,6 +23,7 @@ ingress-nginx:
     service:
       annotations:
         load-balancer.hetzner.cloud/location: fsn1
+        load-balancer.hetzner.cloud/node-selector: topology.kubernetes.io/region=fsn1
 
 # Dedicated Kura ingress dataplanes. These are shared per region, not
 # per customer: customer-specific hosts route through the regional
@@ -38,6 +39,7 @@ kura-eu-central-ingress-nginx:
       annotations:
         load-balancer.hetzner.cloud/location: fsn1
         load-balancer.hetzner.cloud/name: tuist-kura-eu-central-ingress
+        load-balancer.hetzner.cloud/node-selector: node.cluster.x-k8s.io/pool=kura
         load-balancer.hetzner.cloud/uses-proxyprotocol: "true"
 
 kura-us-east-ingress-nginx:
@@ -49,6 +51,7 @@ kura-us-east-ingress-nginx:
       annotations:
         load-balancer.hetzner.cloud/location: ash
         load-balancer.hetzner.cloud/name: tuist-kura-us-east-ingress
+        load-balancer.hetzner.cloud/node-selector: node.cluster.x-k8s.io/pool=kura-us-east
         load-balancer.hetzner.cloud/uses-proxyprotocol: "true"
 
 kura-us-west-ingress-nginx:
@@ -60,4 +63,5 @@ kura-us-west-ingress-nginx:
       annotations:
         load-balancer.hetzner.cloud/location: hil
         load-balancer.hetzner.cloud/name: tuist-kura-us-west-ingress
+        load-balancer.hetzner.cloud/node-selector: node.cluster.x-k8s.io/pool=kura-us-west
         load-balancer.hetzner.cloud/uses-proxyprotocol: "true"

--- a/infra/kura-controller/api/v1alpha1/kuragateway_types.go
+++ b/infra/kura-controller/api/v1alpha1/kuragateway_types.go
@@ -3,6 +3,7 @@ package v1alpha1
 import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 )
 
 type KuraGatewaySpec struct {
@@ -67,6 +68,9 @@ func (in *KuraGatewaySpec) ServiceAnnotations() map[string]string {
 	annotations := map[string]string{}
 	for key, value := range in.LoadBalancerAnnotations {
 		annotations[key] = value
+	}
+	if _, ok := annotations["load-balancer.hetzner.cloud/node-selector"]; !ok && len(in.NodeSelector) > 0 {
+		annotations["load-balancer.hetzner.cloud/node-selector"] = labels.SelectorFromSet(labels.Set(in.NodeSelector)).String()
 	}
 	return annotations
 }

--- a/infra/kura-controller/controllers/kurainstance_controller_test.go
+++ b/infra/kura-controller/controllers/kurainstance_controller_test.go
@@ -405,6 +405,9 @@ func TestKuraGatewayReconcileCreatesDedicatedIngressInfrastructure(t *testing.T)
 	if got := service.Annotations["load-balancer.hetzner.cloud/uses-proxyprotocol"]; got != "true" {
 		t.Fatalf("expected proxy protocol annotation, got %q", got)
 	}
+	if got := service.Annotations["load-balancer.hetzner.cloud/node-selector"]; got != "node.cluster.x-k8s.io/pool=kura-us-east" {
+		t.Fatalf("expected Hetzner LB node selector annotation, got %q", got)
+	}
 
 	ingressClass := &networkingv1.IngressClass{}
 	if err := reconciler.Get(ctx, types.NamespacedName{Name: "kura-us-east-kgw-abc123"}, ingressClass); err != nil {


### PR DESCRIPTION
## What changed

- Adds Hetzner Cloud Controller Manager `load-balancer.hetzner.cloud/node-selector` annotations to the production, canary, and staging platform ingress services so each load balancer only targets nodes in its intended region/pool.
- Teaches `KuraGatewaySpec.ServiceAnnotations()` to derive the Hetzner node-selector annotation from `spec.nodeSelector` when callers do not provide an explicit load balancer selector.
- Extends the Kura gateway reconciliation test to assert that dedicated ingress Services carry the derived Hetzner node selector.

## Why

During the post-deploy rollout for #11192, the new production Kura ingress LoadBalancers stayed pending because HCCM attempted to attach nodes from the wrong Hetzner network zone. Hetzner requires load balancer targets to live in the same network zone as the load balancer, so the regional Kura Services need an explicit selector that matches their regional node pools.

The same issue can affect the main platform ingress after adding non-fsn1 production node pools, so this also constrains the primary platform ingress to fsn1 nodes while keeping the regional Kura ingress controllers pinned to their matching pools.

## Impact

This keeps the live manual annotations applied during rollout from drifting on the next Helm or controller reconciliation. New dynamic KuraGateway Services will also receive the correct Hetzner selector automatically from their Kubernetes node selector.

## Validation

- `GOCACHE=/private/tmp/codex-go-build-cache /Users/marekfort/.local/share/mise/installs/go/1.26.3/bin/go test ./...` from `infra/kura-controller`
- `helm lint infra/helm/platform -f infra/helm/platform/values-hetzner.yaml -f infra/helm/platform/values-tuist.yaml`
- `helm lint infra/helm/platform -f infra/helm/platform/values-hetzner.yaml -f infra/helm/platform/values-tuist-staging.yaml`
- `helm lint infra/helm/platform -f infra/helm/platform/values-hetzner.yaml -f infra/helm/platform/values-tuist-canary.yaml`
- Helm template checks for the platform and regional Kura ingress Service annotations
- `git diff --check`
