### PR TITLE
feat(server, noora): update table design and improve UX

### DIFF
--- a/noora/css/table.css
+++ b/noora/css/table.css
@@ -149,7 +149,7 @@
       background: transparent;
 
       & tr {
-        &[data-expanded] td {
+        &[data-state="expanded"] td {
           background-color: var(--noora-surface-background-secondary);
         }
         &[data-expandable] {
@@ -180,6 +180,17 @@
               width: 16px;
               height: 16px;
             }
+
+            /* The animated chevron (crossfade transition) wraps its two icons in a span, so the
+             * direct-svg sizing above doesn't reach them. */
+            & > .noora-icon-transition {
+              flex-shrink: 0;
+
+              & svg {
+                width: 16px;
+                height: 16px;
+              }
+            }
           }
 
           & > [data-part="expand-cell"] > [data-part="cell"] {
@@ -189,6 +200,10 @@
           &[data-part="expanded-content"] {
             position: relative;
             background-color: var(--noora-surface-background-secondary);
+            /* Vertical padding must stay zero: the expanded row is always in the DOM, collapsed
+             * to zero height, and any padding here would leave a visible sliver between rows. */
+            padding-top: 0;
+            padding-bottom: 0;
             padding-left: var(--noora-spacing-8);
 
             &::before {
@@ -199,6 +214,37 @@
               background-color: var(--noora-surface-border-primary);
               width: 1px;
               content: "";
+            }
+
+            /* Animated reveal: the row's `data-state` drives a grid-row transition 0fr <-> 1fr.
+             * A transition (not mount/unmount keyframes) means expanding starts instantly,
+             * collapsing can never be cut short by element removal, and an interrupted toggle
+             * reverses from wherever it currently is. */
+            & [data-part="expand-wrapper"] {
+              display: grid;
+              grid-template-rows: 0fr;
+
+              @media (prefers-reduced-motion: no-preference) {
+                transition: grid-template-rows 200ms var(--ease-out-cubic);
+              }
+
+              tr[data-state="expanded"] + tr & {
+                grid-template-rows: 1fr;
+              }
+
+              & > [data-part="expand-wrapper-content"] {
+                min-height: 0;
+                overflow: hidden;
+                /* Hidden from interaction and find-in-page while collapsed; the delay holds
+                 * visibility through the collapse so content doesn't vanish mid-shrink. */
+                visibility: hidden;
+                transition: visibility 0s 200ms;
+
+                tr[data-state="expanded"] + tr & {
+                  visibility: visible;
+                  transition-delay: 0s;
+                }
+              }
             }
           }
         }
@@ -213,11 +259,14 @@
           inset;
       }
 
-      & tr:not(:last-child) td {
+      /* Expanded rows are excluded: they are always in the DOM, collapsed to zero height,
+       * and these paddings would otherwise win the cascade over the expanded-content cell's
+       * zero padding (same specificity, later in source) and leave a sliver between rows. */
+      & tr:not(:last-child):not([data-part="expanded-row"]) td {
         padding-bottom: 2px;
       }
 
-      & tr:not(:first-child) td {
+      & tr:not(:first-child):not([data-part="expanded-row"]) td {
         padding-top: 2px;
       }
 
@@ -232,6 +281,21 @@
       }
 
       & tr:last-child {
+        & td:first-child {
+          border-bottom-left-radius: var(--noora-radius-4);
+        }
+        & td:last-child {
+          border-bottom-right-radius: var(--noora-radius-4);
+        }
+      }
+
+      /* When the last row is expandable, the final tbody child is its always-rendered expanded
+       * row. While that row is collapsed to zero height, the visible row above it carries the
+       * bottom radius instead. */
+      &
+        tr[data-state="collapsed"]:nth-last-child(2):has(
+          + tr[data-part="expanded-row"]
+        ) {
         & td:first-child {
           border-bottom-left-radius: var(--noora-radius-4);
         }

--- a/noora/css/table.css
+++ b/noora/css/table.css
@@ -243,6 +243,9 @@
   }
 
   & th {
+    /* Border-box so the hook's measured column widths (which include padding) can be pinned
+     * back as `min-width` without compounding. */
+    box-sizing: border-box;
     position: sticky;
     top: 0;
     background-color: var(--noora-surface-table-header);

--- a/noora/css/table.css
+++ b/noora/css/table.css
@@ -1,12 +1,127 @@
 .noora-table {
   box-sizing: border-box;
-  border-radius: var(--noora-radius-8);
+  position: relative;
+  box-shadow: var(--noora-border-light-default);
+  border-radius: var(--noora-radius-4);
   background: var(--noora-surface-table-header);
-  padding: var(--noora-spacing-2);
+  padding: var(--noora-spacing-0);
   width: 100%;
-  overflow-x: auto;
-  overscroll-behavior-x: none;
-  scroll-padding-right: var(--noora-spacing-2);
+
+  /* The horizontal scroll lives on an inner wrapper rather than `.noora-table` itself, so the
+   * scrollbar (and the space it occupies) only exist when the table actually overflows. The wrapper
+   * is auto-height and grows to fit the scrollbar below the content, so the last row is never
+   * clipped, and non-scrolling tables get no scrollbar gutter at all. */
+  & [data-part="scroll-container"] {
+    border-radius: var(--noora-radius-4);
+    width: 100%;
+    overflow-x: auto;
+    overscroll-behavior-x: none;
+  }
+
+  /* Floating horizontal scrollbar, driven by the `NooraTable` hook. While the table is on screen
+   * but its native scrollbar is below the viewport, this proxy is fixed to the viewport bottom and
+   * synced with the scroll container; once the table's bottom scrolls into view, it hides and the
+   * native scrollbar takes over. Hidden whenever JS is unavailable. */
+  & [data-part="scrollbar"] {
+    display: none;
+    position: fixed;
+    bottom: 0;
+    z-index: 2;
+    overflow-x: auto;
+    overscroll-behavior-x: none;
+
+    &[data-visible] {
+      display: block;
+    }
+
+    & > [data-part="scrollbar-content"] {
+      height: 1px;
+    }
+  }
+
+  /* Custom scrollbar, used where the native one cannot match the webkit-styled design: Firefox
+   * (no `::-webkit-scrollbar` support, so no thumb insets) and overlay-scrollbar platforms
+   * (the bar paints over content and hides at rest). The `NooraTable` hook suppresses the native
+   * bar, keeps the thumb in sync, and — mirroring the proxy scrollbar in webkit browsers — pins
+   * this bar to the viewport bottom while the table extends below it. */
+  & [data-part="overlay-scrollbar"] {
+    display: none;
+    position: absolute;
+    right: var(--noora-spacing-4);
+    /* With the 16px lane the hook pads below the body plus the root's 4px, this centers the 8px
+     * thumb — 6px to the last row above and 6px to the table edge below, matching webkit. */
+    bottom: 6px;
+    left: var(--noora-spacing-4);
+    z-index: 2;
+    height: 8px;
+
+    &[data-visible] {
+      display: block;
+    }
+
+    & > [data-part="overlay-thumb"] {
+      position: absolute;
+      top: 0;
+      height: 100%;
+      border-radius: var(--noora-radius-4);
+      background-color: light-dark(
+        var(--noora-neutral-light-600),
+        var(--noora-neutral-dark-600)
+      );
+      touch-action: none;
+    }
+  }
+
+  & [data-part="scroll-container"],
+  & [data-part="scrollbar"] {
+    /* `scrollbar-color` is inherited, and any non-`auto` value (e.g. an app-level global on
+     * `html`) makes Chromium ignore the `::-webkit-scrollbar` styling below, falling back to a
+     * full-width scrollbar. Reset both standard properties so the detailed styling applies
+     * regardless of the host app's globals. */
+    scrollbar-color: auto;
+    scrollbar-width: auto;
+
+    /* Firefox cannot style the scrollbar through `::-webkit-scrollbar`, and Chromium ignores those
+     * pseudo-elements whenever the standard `scrollbar-*` properties are set. Scoping the standard
+     * properties to Firefox lets Chromium/Safari fall through to the detailed styling below. */
+    @supports (scrollbar-width: thin) and (not selector(::-webkit-scrollbar)) {
+      /* #c1c1c1/#6b6b6b are the browser's default scrollbar thumb grays, so the table scrollbar
+       * matches the native ones elsewhere on the page. */
+      scrollbar-color: light-dark(
+          var(--noora-neutral-light-600),
+          var(--noora-neutral-dark-600)
+        )
+        transparent;
+      scrollbar-width: thin;
+    }
+
+    &::-webkit-scrollbar {
+      width: 12px;
+      height: 12px;
+      background: transparent;
+    }
+
+    &::-webkit-scrollbar-corner {
+      background: transparent;
+    }
+
+    &::-webkit-scrollbar-track {
+      margin: 0 var(--noora-spacing-2);
+      background: transparent;
+    }
+
+    &::-webkit-scrollbar-thumb {
+      border-color: transparent;
+      border-style: solid;
+      border-width: 2px 4px;
+      border-radius: var(--noora-radius-4);
+      background-color: light-dark(
+        var(--noora-neutral-light-600),
+        var(--noora-neutral-dark-600)
+      );
+      background-clip: padding-box;
+    }
+  }
 
   & table {
     position: relative;
@@ -19,32 +134,19 @@
     *  adding a pseudo element with standard layouting around the table and add a box-shadow around it. */
     &:has(td):after {
       position: absolute;
-      top: 40px;
+      top: 44px;
       right: 0;
       bottom: 0;
       left: 0;
       z-index: 1;
       box-shadow: var(--noora-border-light-default);
-      border-radius: var(--noora-radius-6);
+      border-radius: var(--noora-radius-4);
       pointer-events: none;
       content: "";
     }
 
     & tbody {
       background: transparent;
-
-      /* Using `overflow` set to `auto` or `scroll`, most browsers collapse the right padding when overflowing. This visually removes the
-      *  border around the body, which is unintended. To solve this, we are adding a pseudo element of the width of the padding to
-      *  the right of the table. This does not get collapsed and serves as a padding. */
-      &:after {
-        display: block;
-        position: absolute;
-        right: calc(var(--noora-spacing-2) * -1);
-        width: var(--noora-spacing-2);
-        height: 1px;
-        pointer-events: none;
-        content: "";
-      }
 
       & tr {
         &[data-expanded] td {
@@ -122,19 +224,19 @@
       /* Border radius on the `tbody` itself is unsupported, so we're selectively adding radius to specific cells. */
       & tr:first-child {
         & td:first-child {
-          border-top-left-radius: var(--noora-radius-6);
+          border-top-left-radius: var(--noora-radius-4);
         }
         & td:last-child {
-          border-top-right-radius: var(--noora-radius-6);
+          border-top-right-radius: var(--noora-radius-4);
         }
       }
 
       & tr:last-child {
         & td:first-child {
-          border-bottom-left-radius: var(--noora-radius-6);
+          border-bottom-left-radius: var(--noora-radius-4);
         }
         & td:last-child {
-          border-bottom-right-radius: var(--noora-radius-6);
+          border-bottom-right-radius: var(--noora-radius-4);
         }
       }
     }
@@ -144,7 +246,7 @@
     position: sticky;
     top: 0;
     background-color: var(--noora-surface-table-header);
-    padding: var(--noora-spacing-4) var(--noora-spacing-7)
+    padding: var(--noora-spacing-5) var(--noora-spacing-7)
       var(--noora-spacing-5) var(--noora-spacing-7);
     color: var(--noora-surface-label-primary);
     font: var(--noora-font-weight-medium) var(--noora-font-body-medium);
@@ -157,6 +259,12 @@
 
       &:hover [data-part="icon"] {
         color: var(--noora-surface-label-primary);
+      }
+
+      /* The sort-direction arrow (the only header icon carrying `data-state`) is an indicator,
+       * not a button, so it stays `label-secondary` even while the header is hovered. */
+      &:hover [data-part="icon"][data-state] {
+        color: var(--noora-surface-label-secondary);
       }
     }
 
@@ -175,6 +283,26 @@
         width: 100%;
         height: 100%;
       }
+    }
+  }
+
+  /* Floating header, driven by the `NooraTable` hook: a fixed-position clone of the `thead`,
+   * appended to `body`, pinned to the viewport top while the table is scrolled past it. It also
+   * carries the `noora-table` class so the cloned header cells pick up the regular styling. */
+  &.noora-table-floating-header {
+    display: none;
+    position: fixed;
+    top: 0;
+    z-index: 2;
+    box-shadow: 0 1px 0 0
+      light-dark(var(--noora-neutral-light-400), var(--noora-neutral-dark-900));
+    /* Keep the table's top corner radius while detached, for consistency with the resting
+     * header. */
+    border-radius: 0;
+    overflow: hidden;
+
+    &[data-visible] {
+      display: block;
     }
   }
 

--- a/noora/css/table.css
+++ b/noora/css/table.css
@@ -16,6 +16,19 @@
     width: 100%;
     overflow-x: auto;
     overscroll-behavior-x: none;
+
+    /* Browsers make a horizontally scrollable region keyboard-focusable so it can be scrolled
+     * with the arrow keys. Replace the default full-bleed focus ring with a restrained inset
+     * one that follows the table's rounded corners, so a focused scroll area reads as a focused
+     * control rather than a selected table. */
+    &:focus-visible {
+      outline: 2px solid
+        light-dark(
+          var(--noora-neutral-light-1000),
+          var(--noora-neutral-dark-1200)
+        );
+      outline-offset: -2px;
+    }
   }
 
   /* Floating horizontal scrollbar, driven by the `NooraTable` hook. While the table is on screen
@@ -152,9 +165,9 @@
         &[data-state="expanded"] td {
           background-color: var(--noora-surface-background-secondary);
         }
+        /* No pointer cursor: the row is passive and only the disclosure button toggles it.
+         * The hover tint stays as a lightweight affordance that the row is interactive. */
         &[data-expandable] {
-          cursor: pointer;
-
           &:hover td {
             background-color: var(--noora-surface-background-secondary);
           }
@@ -175,17 +188,30 @@
             align-items: center;
             gap: var(--noora-spacing-5);
             padding-left: var(--noora-spacing-5);
-            & > svg {
-              flex-shrink: 0;
-              width: 16px;
-              height: 16px;
-            }
 
-            /* The animated chevron (crossfade transition) wraps its two icons in a span, so the
-             * direct-svg sizing above doesn't reach them. */
-            & > .noora-icon-transition {
+            /* The disclosure trigger: a bare, icon-only button wrapping the chevron. It carries
+             * the interaction (focus, click) so the row can stay passive. */
+            & > [data-part="expand-toggle"] {
+              display: inline-flex;
               flex-shrink: 0;
+              align-items: center;
+              justify-content: center;
+              margin: 0;
+              padding: 0;
+              border: 0;
+              border-radius: var(--noora-radius-2);
+              background: none;
+              color: inherit;
+              cursor: pointer;
+              appearance: none;
 
+              &:focus-visible {
+                outline: none;
+                box-shadow: var(--noora-button-border-secondary-focus);
+              }
+
+              /* The chevron is a 16px icon; the crossfade transition wraps it in a span, so the
+               * size is applied to the nested svg rather than a direct child. */
               & svg {
                 width: 16px;
                 height: 16px;
@@ -373,8 +399,45 @@
     }
   }
 
-  & [data-part="link"] {
+  /* Whole-row navigation. A single anchor in the first cell carries the link; its `::after`
+   * overlay stretches across the row (which is the positioning context) so the entire row is the
+   * click target, while the DOM holds just one link per row. Trade-off: the overlay sits over the
+   * row's text, so text in navigable rows isn't selectable. */
+  & tr:has([data-part="row-link"]) {
+    position: relative;
+  }
+
+  & [data-part="row-link"] {
+    color: inherit;
     text-decoration: none;
+
+    &::after {
+      position: absolute;
+      inset: 0;
+      z-index: 0;
+      content: "";
+    }
+
+    &:focus-visible {
+      outline: none;
+
+      &::after {
+        outline: 2px solid
+          light-dark(
+            var(--noora-neutral-light-1000),
+            var(--noora-neutral-dark-1200)
+          );
+        outline-offset: -2px;
+      }
+    }
+  }
+
+  /* Controls in the row's other cells must sit above the overlay to stay clickable. */
+  &
+    tr:has([data-part="row-link"])
+    :is(a, button, input, select, [tabindex]):not([data-part="row-link"]) {
+    position: relative;
+    z-index: 1;
   }
 
   & [data-part="cell"] {

--- a/noora/js/IconTransition.js
+++ b/noora/js/IconTransition.js
@@ -94,19 +94,39 @@ function pad(rings, count, c) {
   return out;
 }
 
+// Mean distance of a ring's points from its centroid — a scale signature for matching.
+const sizeOf = (ring, c) => {
+  let s = 0;
+  for (const p of ring) {
+    const dx = p[0] - c[0];
+    const dy = p[1] - c[1];
+    s += Math.sqrt(dx * dx + dy * dy);
+  }
+  return s / ring.length;
+};
+
+// Pairs rings between the two icons. Centroid distance alone mispairs concentric subpaths —
+// e.g. an arrow inside a boundary ring sits closer to the (identically centered) boundary of the
+// other icon than to its own moved counterpart — so ring size is part of the cost, which keeps
+// small glyphs matched to small glyphs and boundaries to boundaries.
 function matchRings(A, B) {
   const used = new Array(B.length).fill(false);
+  const bInfo = B.map((rb) => {
+    const c = cOf(rb);
+    return { c, size: sizeOf(rb, c) };
+  });
   const order = [];
   for (const ra of A) {
     const ca = cOf(ra);
+    const sa = sizeOf(ra, ca);
     let best = -1;
     let bd = Infinity;
     for (let j = 0; j < B.length; j++) {
       if (used[j]) continue;
-      const cb = cOf(B[j]);
-      const dx = ca[0] - cb[0];
-      const dy = ca[1] - cb[1];
-      const dd = dx * dx + dy * dy;
+      const dx = ca[0] - bInfo[j].c[0];
+      const dy = ca[1] - bInfo[j].c[1];
+      const ds = sa - bInfo[j].size;
+      const dd = dx * dx + dy * dy + ds * ds;
       if (dd < bd) {
         bd = dd;
         best = j;

--- a/noora/js/Table.js
+++ b/noora/js/Table.js
@@ -112,9 +112,20 @@ export default {
       capture: true,
       passive: true,
     });
-    window.addEventListener("resize", this.onViewportChange, {
-      passive: true,
-    });
+
+    // A resize can change which ancestor scrolls — content that fit at load (so the window was
+    // the scroller) can start overflowing the content pane when the window shrinks, making the
+    // pane the scroller. Re-resolve the scroll parent on resize (kept off the scroll path, which
+    // must stay cheap, since scrolling never changes the scroller). Throttled to one frame.
+    this.onResize = () => {
+      if (this.resizeFrame) return;
+      this.resizeFrame = requestAnimationFrame(() => {
+        this.resizeFrame = null;
+        this.scrollParent = this.findScrollParent();
+        this.sync();
+      });
+    };
+    window.addEventListener("resize", this.onResize, { passive: true });
 
     // Header widths only depend on horizontal geometry, and syncing them measures every header
     // cell and writes to the body-level clone — a forced full-page reflow. Height-only resizes
@@ -150,19 +161,26 @@ export default {
     this.sync();
   },
 
-  // Nearest ancestor that scrolls vertically. The search starts above `.noora-table` so it skips
-  // the table's own horizontal scroll container (whose `overflow-y` computes to `auto` but never
-  // scrolls). Returns null when nothing between here and the document scrolls — i.e. the window
-  // is the scroller — in which case the viewport edges are used.
+  // Nearest ancestor that actually scrolls vertically. The search starts above `.noora-table` so
+  // it skips the table's own horizontal scroll container. Returns null when nothing between here
+  // and the document scrolls — i.e. the window is the scroller — in which case the viewport edges
+  // are used.
+  //
+  // Two false positives have to be filtered out, both stemming from the CSS rule that a non-
+  // `visible` value on one axis forces the other axis from `visible` to `auto`: the table's own
+  // `overflow-x: auto` container, and any ancestor with `overflow-x: hidden` (a card that only
+  // clips horizontally). Both report a computed `overflow-y: auto` while having no vertical scroll
+  // room. Requiring `scrollHeight > clientHeight` excludes them — otherwise the floating header
+  // would pin to a box that merely scrolls away with the table and would never detach.
   findScrollParent() {
     let el = this.el.parentElement;
     while (el && el !== document.body && el !== document.documentElement) {
       const overflowY = getComputedStyle(el).overflowY;
-      if (
+      const scrollable =
         overflowY === "auto" ||
         overflowY === "scroll" ||
-        overflowY === "overlay"
-      ) {
+        overflowY === "overlay";
+      if (scrollable && el.scrollHeight > el.clientHeight) {
         return el;
       }
       el = el.parentElement;
@@ -172,13 +190,14 @@ export default {
 
   destroyed() {
     if (this.frame) cancelAnimationFrame(this.frame);
+    if (this.resizeFrame) cancelAnimationFrame(this.resizeFrame);
     this.resizeObserver?.disconnect();
     this.container?.removeEventListener("scroll", this.onContainerScroll);
     this.scrollbar?.removeEventListener("scroll", this.onScrollbarScroll);
     window.removeEventListener("scroll", this.onViewportChange, {
       capture: true,
     });
-    window.removeEventListener("resize", this.onViewportChange);
+    window.removeEventListener("resize", this.onResize);
     this.overlayThumb?.removeEventListener("pointerdown", this.onThumbDown);
     this.overlayThumb?.removeEventListener("pointermove", this.onThumbMove);
     this.overlayThumb?.removeEventListener("pointerup", this.onThumbUp);
@@ -339,8 +358,17 @@ export default {
         const headerHeight = this.thead.offsetHeight;
         this.header.style.left = `${rect.left}px`;
         this.header.style.width = `${rect.width}px`;
-        // Let the table's end push the header up out of the scroll area as it scrolls past.
-        this.header.style.top = `${Math.min(viewTop, contentBottom - headerHeight)}px`;
+        // As the table's end scrolls up to meet the header, push the header up with it so it
+        // leaves with the table rather than hovering over the content below. Its top can rise
+        // above the scroll area's top edge — but the clone lives on `document.body`, where the
+        // scroll area can't clip it, so it would otherwise paint over the navbar/chrome above.
+        // Pin the top no higher than `viewTop` and clip the overshoot, so the header slides up
+        // under the top edge instead.
+        const top = contentBottom - headerHeight;
+        const clipTop = Math.max(0, viewTop - top);
+        this.header.style.top = `${Math.min(viewTop, top)}px`;
+        this.header.style.clipPath =
+          clipTop > 0 ? `inset(${clipTop}px 0 0 0)` : "";
         this.header.setAttribute("data-visible", "");
       } else {
         this.header.removeAttribute("data-visible");

--- a/noora/js/Table.js
+++ b/noora/js/Table.js
@@ -1,16 +1,20 @@
 // Floating header and horizontal scrollbar for tables.
 //
-// Header: once the table's top scrolls past the viewport, a fixed-position clone of the `thead`
-// is pinned to the viewport top, until the table's end pushes it back out. `position: fixed` is
-// pinned by the compositor, so the header doesn't wobble during scrolling the way a JS-translated
+// Both pin to the edges of the element that actually scrolls the table (the app's content pane,
+// or the window when nothing else scrolls — see `findScrollParent`), not to the window's edges,
+// so they sit within the scroll area rather than over the navbar or chrome around it.
+//
+// Header: once the table's top scrolls past the scroll area's top, a fixed-position clone of the
+// `thead` is pinned there, until the table's end pushes it back out. `position: fixed` is pinned
+// by the compositor, so the header doesn't wobble during scrolling the way a JS-translated
 // element does (scroll happens on the compositor thread; JS catches up a frame late). The clone
 // lives on `document.body` so LiveView patches never touch it, and its column widths and
 // horizontal scroll position are synced from the real table.
 //
 // Scrollbar: while a horizontally scrollable table is on screen but its own scrollbar is below
-// the viewport, a proxy scrollbar is fixed to the viewport bottom and kept in sync with the
-// table. Once the table's bottom (and its native scrollbar) scrolls into view, the proxy hides
-// and the native scrollbar takes over.
+// the scroll area's bottom, a proxy scrollbar is fixed there and kept in sync with the table.
+// Once the table's bottom (and its native scrollbar) scrolls into view, the proxy hides and the
+// native scrollbar takes over.
 //
 // Both use `position: fixed` with measured coordinates instead of `position: sticky`, since
 // sticky breaks whenever any ancestor has a non-visible overflow (as app layouts commonly do).
@@ -30,6 +34,12 @@ export default {
     // doesn't (Firefox), the native bar cannot match the design and the custom bar takes over.
     this.webkitScrollbars = CSS.supports("selector(::-webkit-scrollbar)");
     if (!this.container || !this.scrollbar || !this.spacer) return;
+
+    // The element that actually scrolls the table vertically — the app's content pane, not the
+    // window, in the current shell. The floating header and scrollbar pin to this element's
+    // viewport edges (just below a fixed navbar, say), not to the window's, so they don't land
+    // on top of the chrome around the scroll area. Cached here and refreshed on patch.
+    this.scrollParent = this.findScrollParent();
 
     if (this.overlayThumb) {
       this.onThumbDown = (e) => {
@@ -61,7 +71,13 @@ export default {
 
     this.header = document.createElement("div");
     this.header.className = "noora-table noora-table-floating-header";
+    // The clone is purely decorative — the real header stays the accessible, interactive one.
+    // `inert` removes the clone's cloned sort links/controls from the focus order and a11y tree
+    // and blocks pointer events on them (without it, focus could land on AT-hidden controls, and
+    // a cloned `patch` link — living outside the LiveView root — would full-navigate on click).
+    // `aria-hidden` stays as a fallback for engines without `inert`.
     this.header.setAttribute("aria-hidden", "true");
+    this.header.inert = true;
     document.body.appendChild(this.header);
 
     this.onContainerScroll = () => {
@@ -128,9 +144,30 @@ export default {
 
   updated() {
     this.thead = this.container?.querySelector("thead");
+    this.scrollParent = this.findScrollParent();
     this.applyColumnWidths();
     if (this.header?.hasAttribute("data-visible")) this.refreshHeader();
     this.sync();
+  },
+
+  // Nearest ancestor that scrolls vertically. The search starts above `.noora-table` so it skips
+  // the table's own horizontal scroll container (whose `overflow-y` computes to `auto` but never
+  // scrolls). Returns null when nothing between here and the document scrolls — i.e. the window
+  // is the scroller — in which case the viewport edges are used.
+  findScrollParent() {
+    let el = this.el.parentElement;
+    while (el && el !== document.body && el !== document.documentElement) {
+      const overflowY = getComputedStyle(el).overflowY;
+      if (
+        overflowY === "auto" ||
+        overflowY === "scroll" ||
+        overflowY === "overlay"
+      ) {
+        return el;
+      }
+      el = el.parentElement;
+    }
+    return null;
   },
 
   destroyed() {
@@ -154,6 +191,14 @@ export default {
   // columns never shrink back on an update, and longer content can still widen them, so nothing
   // is ever clipped. Runs after every patch since LiveView wipes the inline styles, and before
   // paint, so no shifted frame is visible.
+  //
+  // The pin is deliberately ONE-WAY (grow-only). It tracks the widest content a column has shown
+  // for the lifetime of this hook instance and never lowers the pin, which is what stops the
+  // back-and-forth jitter across stream/sort/filter updates. The trade-off: once a batch widens
+  // a column, a later batch with narrower content stays at the wider width rather than tightening
+  // back. That's intended — re-tightening is exactly the shift this is here to prevent — but it
+  // means column widths reflect the widest data seen, not the current page's data. The pin only
+  // resets when the hook remounts (full navigation) or the column count changes.
   applyColumnWidths() {
     const cells = this.thead?.rows[0]?.cells ?? [];
     if (cells.length === 0) return;
@@ -189,7 +234,15 @@ export default {
     }
     const table = document.createElement("table");
     table.style.tableLayout = "fixed";
-    table.appendChild(this.thead.cloneNode(true));
+    const clonedThead = this.thead.cloneNode(true);
+    // Strip IDs from the decorative clone so it can't duplicate the real header's IDs (sort
+    // indicators, icon SVGs), which would otherwise break ID lookups, ARIA references, and SVG
+    // `<use href="#…">` resolution.
+    if (clonedThead.id) clonedThead.removeAttribute("id");
+    for (const node of clonedThead.querySelectorAll("[id]")) {
+      node.removeAttribute("id");
+    }
+    table.appendChild(clonedThead);
     this.header.replaceChildren(table);
     this.headerTable = table;
     this.syncHeaderWidths();
@@ -267,15 +320,27 @@ export default {
     const gutter = this.container.offsetHeight - this.container.clientHeight;
     const contentBottom = rect.bottom - gutter;
 
+    // Top and bottom edges of the scrolling viewport, in viewport coordinates. When a content
+    // pane scrolls (rather than the window), these are its edges — below the navbar and above
+    // the window bottom — so the floating header and scrollbar stay within the scroll area
+    // instead of pinning to the window and overlapping the surrounding chrome.
+    let viewTop = 0;
+    let viewBottom = window.innerHeight;
+    if (this.scrollParent) {
+      const parentRect = this.scrollParent.getBoundingClientRect();
+      viewTop = parentRect.top;
+      viewBottom = parentRect.bottom;
+    }
+
     if (this.thead) {
-      const floatingHeader = rect.top < 0 && contentBottom > 0;
+      const floatingHeader = rect.top < viewTop && contentBottom > viewTop;
       if (floatingHeader) {
         if (!this.header.hasAttribute("data-visible")) this.refreshHeader();
         const headerHeight = this.thead.offsetHeight;
         this.header.style.left = `${rect.left}px`;
         this.header.style.width = `${rect.width}px`;
-        // Let the table's end push the header out of the viewport as it scrolls past.
-        this.header.style.top = `${Math.min(0, contentBottom - headerHeight)}px`;
+        // Let the table's end push the header up out of the scroll area as it scrolls past.
+        this.header.style.top = `${Math.min(viewTop, contentBottom - headerHeight)}px`;
         this.header.setAttribute("data-visible", "");
       } else {
         this.header.removeAttribute("data-visible");
@@ -283,9 +348,7 @@ export default {
     }
 
     const floating =
-      scrollable &&
-      contentBottom > window.innerHeight &&
-      rect.top < window.innerHeight;
+      scrollable && contentBottom > viewBottom && rect.top < viewBottom;
 
     if (this.overlayBar) {
       if (custom) {
@@ -297,7 +360,9 @@ export default {
           this.overlayBar.style.left = `${rect.left + 8}px`;
           this.overlayBar.style.right = "auto";
           this.overlayBar.style.width = `${rect.width - 16}px`;
-          this.overlayBar.style.bottom = "2px";
+          // `bottom` is measured from the window bottom; offset by the gap between the window
+          // and the scroll area's bottom so the bar sits at the scroll area's edge.
+          this.overlayBar.style.bottom = `${window.innerHeight - viewBottom + 2}px`;
         } else {
           this.overlayBar.style.position = "";
           this.overlayBar.style.left = "";
@@ -316,6 +381,7 @@ export default {
       this.spacer.style.width = `${this.container.scrollWidth}px`;
       this.scrollbar.style.left = `${rect.left}px`;
       this.scrollbar.style.width = `${rect.width}px`;
+      this.scrollbar.style.bottom = `${window.innerHeight - viewBottom}px`;
       this.scrollbar.setAttribute("data-visible", "");
       if (this.scrollbar.scrollLeft !== this.container.scrollLeft) {
         this.scrollbar.scrollLeft = this.container.scrollLeft;

--- a/noora/js/Table.js
+++ b/noora/js/Table.js
@@ -108,11 +108,13 @@ export default {
     const table = this.container.querySelector("table");
     if (table) this.resizeObserver.observe(table);
 
+    this.applyColumnWidths();
     this.sync();
   },
 
   updated() {
     this.thead = this.container?.querySelector("thead");
+    this.applyColumnWidths();
     if (this.header?.hasAttribute("data-visible")) this.refreshHeader();
     this.sync();
   },
@@ -130,6 +132,39 @@ export default {
     this.overlayThumb?.removeEventListener("pointermove", this.onThumbMove);
     this.overlayThumb?.removeEventListener("pointerup", this.onThumbUp);
     this.header?.remove();
+  },
+
+  // Keeps columns from shifting when a LiveView update swaps the rows (sorting, pagination):
+  // auto table layout re-derives column widths from the new content, so columns jump left and
+  // right. Each column's rendered width is ratcheted into a `min-width` that only grows —
+  // columns never shrink back on an update, and longer content can still widen them, so nothing
+  // is ever clipped. Runs after every patch since LiveView wipes the inline styles, and before
+  // paint, so no shifted frame is visible.
+  applyColumnWidths() {
+    const cells = this.thead?.rows[0]?.cells ?? [];
+    if (cells.length === 0) return;
+    if (this.columnWidths?.length !== cells.length) {
+      this.columnWidths = new Array(cells.length).fill(0);
+    }
+    // Only engage once the table actually overflows its frame. In a fitting table the columns
+    // are stretched to fill it, and pinning those slack-inflated widths would force a scrollbar
+    // and break the fill behavior; in an overflowing one the rendered widths are the content
+    // widths. Once engaged, the pins are kept (LiveView wipes the inline styles on each patch).
+    const engaged =
+      this.container.scrollWidth > this.container.clientWidth ||
+      this.columnWidths.some((w) => w > 0);
+    if (!engaged) return;
+    const widths = Array.from(cells, (c) => c.getBoundingClientRect().width);
+    for (let i = 0; i < cells.length; i++) {
+      // Exact fractional widths, with jitter tolerance: rounding up would make the pinned sum
+      // exceed the container and manufacture an overflow on its own.
+      if (widths[i] > this.columnWidths[i] + 0.5) {
+        this.columnWidths[i] = widths[i];
+      }
+      if (this.columnWidths[i] > 0) {
+        cells[i].style.minWidth = `${this.columnWidths[i]}px`;
+      }
+    }
   },
 
   refreshHeader() {

--- a/noora/js/Table.js
+++ b/noora/js/Table.js
@@ -100,8 +100,22 @@ export default {
       passive: true,
     });
 
-    this.resizeObserver = new ResizeObserver(() => {
-      this.syncHeaderWidths();
+    // Header widths only depend on horizontal geometry, and syncing them measures every header
+    // cell and writes to the body-level clone — a forced full-page reflow. Height-only resizes
+    // (a row expanding frame-by-frame, content loading in) must skip it, or the expand animation
+    // pays an extra synchronous layout on every frame. `contentRect` comes with the entry, so
+    // detecting the width change costs no layout read.
+    this.observedWidths = new Map();
+    this.resizeObserver = new ResizeObserver((entries) => {
+      let widthChanged = false;
+      for (const entry of entries) {
+        const width = entry.contentRect.width;
+        if (this.observedWidths.get(entry.target) !== width) {
+          this.observedWidths.set(entry.target, width);
+          widthChanged = true;
+        }
+      }
+      if (widthChanged) this.syncHeaderWidths();
       this.sync();
     });
     this.resizeObserver.observe(this.container);

--- a/noora/js/Table.js
+++ b/noora/js/Table.js
@@ -1,0 +1,278 @@
+// Floating header and horizontal scrollbar for tables.
+//
+// Header: once the table's top scrolls past the viewport, a fixed-position clone of the `thead`
+// is pinned to the viewport top, until the table's end pushes it back out. `position: fixed` is
+// pinned by the compositor, so the header doesn't wobble during scrolling the way a JS-translated
+// element does (scroll happens on the compositor thread; JS catches up a frame late). The clone
+// lives on `document.body` so LiveView patches never touch it, and its column widths and
+// horizontal scroll position are synced from the real table.
+//
+// Scrollbar: while a horizontally scrollable table is on screen but its own scrollbar is below
+// the viewport, a proxy scrollbar is fixed to the viewport bottom and kept in sync with the
+// table. Once the table's bottom (and its native scrollbar) scrolls into view, the proxy hides
+// and the native scrollbar takes over.
+//
+// Both use `position: fixed` with measured coordinates instead of `position: sticky`, since
+// sticky breaks whenever any ancestor has a non-visible overflow (as app layouts commonly do).
+export default {
+  mounted() {
+    this.container = this.el.querySelector('[data-part="scroll-container"]');
+    this.scrollbar = this.el.querySelector('[data-part="scrollbar"]');
+    this.spacer = this.scrollbar?.querySelector(
+      '[data-part="scrollbar-content"]',
+    );
+    this.thead = this.container?.querySelector("thead");
+    this.overlayBar = this.el.querySelector('[data-part="overlay-scrollbar"]');
+    this.overlayThumb = this.overlayBar?.querySelector(
+      '[data-part="overlay-thumb"]',
+    );
+    // Whether the browser supports `::-webkit-scrollbar` styling (Chrome/Safari). Where it
+    // doesn't (Firefox), the native bar cannot match the design and the custom bar takes over.
+    this.webkitScrollbars = CSS.supports("selector(::-webkit-scrollbar)");
+    if (!this.container || !this.scrollbar || !this.spacer) return;
+
+    if (this.overlayThumb) {
+      this.onThumbDown = (e) => {
+        e.preventDefault();
+        this.thumbDrag = {
+          x: e.clientX,
+          scrollLeft: this.container.scrollLeft,
+        };
+        this.overlayThumb.setPointerCapture(e.pointerId);
+      };
+      this.onThumbMove = (e) => {
+        if (!this.thumbDrag) return;
+        const maxScroll =
+          this.container.scrollWidth - this.container.clientWidth;
+        const maxLeft =
+          this.overlayBar.clientWidth - this.overlayThumb.offsetWidth;
+        if (maxLeft <= 0) return;
+        this.container.scrollLeft =
+          this.thumbDrag.scrollLeft +
+          (e.clientX - this.thumbDrag.x) * (maxScroll / maxLeft);
+      };
+      this.onThumbUp = () => {
+        this.thumbDrag = null;
+      };
+      this.overlayThumb.addEventListener("pointerdown", this.onThumbDown);
+      this.overlayThumb.addEventListener("pointermove", this.onThumbMove);
+      this.overlayThumb.addEventListener("pointerup", this.onThumbUp);
+    }
+
+    this.header = document.createElement("div");
+    this.header.className = "noora-table noora-table-floating-header";
+    this.header.setAttribute("aria-hidden", "true");
+    document.body.appendChild(this.header);
+
+    this.onContainerScroll = () => {
+      if (this.scrollbar.scrollLeft !== this.container.scrollLeft) {
+        this.scrollbar.scrollLeft = this.container.scrollLeft;
+      }
+      this.syncHeaderScroll();
+      this.syncOverlayThumb();
+    };
+    this.onScrollbarScroll = () => {
+      if (this.container.scrollLeft !== this.scrollbar.scrollLeft) {
+        this.container.scrollLeft = this.scrollbar.scrollLeft;
+      }
+    };
+    this.container.addEventListener("scroll", this.onContainerScroll, {
+      passive: true,
+    });
+    this.scrollbar.addEventListener("scroll", this.onScrollbarScroll, {
+      passive: true,
+    });
+
+    // Capture-phase listener so scrolling any ancestor (not just the window) re-positions the
+    // floating elements. Throttled to one sync per frame.
+    this.onViewportChange = () => {
+      if (this.frame) return;
+      this.frame = requestAnimationFrame(() => {
+        this.frame = null;
+        this.sync();
+      });
+    };
+    window.addEventListener("scroll", this.onViewportChange, {
+      capture: true,
+      passive: true,
+    });
+    window.addEventListener("resize", this.onViewportChange, {
+      passive: true,
+    });
+
+    this.resizeObserver = new ResizeObserver(() => {
+      this.syncHeaderWidths();
+      this.sync();
+    });
+    this.resizeObserver.observe(this.container);
+    const table = this.container.querySelector("table");
+    if (table) this.resizeObserver.observe(table);
+
+    this.sync();
+  },
+
+  updated() {
+    this.thead = this.container?.querySelector("thead");
+    if (this.header?.hasAttribute("data-visible")) this.refreshHeader();
+    this.sync();
+  },
+
+  destroyed() {
+    if (this.frame) cancelAnimationFrame(this.frame);
+    this.resizeObserver?.disconnect();
+    this.container?.removeEventListener("scroll", this.onContainerScroll);
+    this.scrollbar?.removeEventListener("scroll", this.onScrollbarScroll);
+    window.removeEventListener("scroll", this.onViewportChange, {
+      capture: true,
+    });
+    window.removeEventListener("resize", this.onViewportChange);
+    this.overlayThumb?.removeEventListener("pointerdown", this.onThumbDown);
+    this.overlayThumb?.removeEventListener("pointermove", this.onThumbMove);
+    this.overlayThumb?.removeEventListener("pointerup", this.onThumbUp);
+    this.header?.remove();
+  },
+
+  refreshHeader() {
+    if (!this.thead) {
+      this.header.replaceChildren();
+      this.headerTable = null;
+      return;
+    }
+    const table = document.createElement("table");
+    table.style.tableLayout = "fixed";
+    table.appendChild(this.thead.cloneNode(true));
+    this.header.replaceChildren(table);
+    this.headerTable = table;
+    this.syncHeaderWidths();
+    this.syncHeaderScroll();
+  },
+
+  syncHeaderWidths() {
+    if (!this.headerTable || !this.thead) return;
+    const sourceCells = this.thead.rows[0]?.cells ?? [];
+    const cloneCells = this.headerTable.rows[0]?.cells ?? [];
+    this.headerTable.style.width = `${this.container.querySelector("table").getBoundingClientRect().width}px`;
+    for (let i = 0; i < cloneCells.length; i++) {
+      cloneCells[i].style.boxSizing = "border-box";
+      cloneCells[i].style.width =
+        `${sourceCells[i]?.getBoundingClientRect().width ?? 0}px`;
+    }
+  },
+
+  syncHeaderScroll() {
+    if (!this.headerTable) return;
+    this.headerTable.style.transform = `translateX(${-this.container.scrollLeft}px)`;
+  },
+
+  syncOverlayThumb() {
+    if (!this.overlayBar?.hasAttribute("data-visible")) return;
+    const track = this.overlayBar.clientWidth;
+    const { scrollWidth, clientWidth, scrollLeft } = this.container;
+    const width = Math.max((clientWidth / scrollWidth) * track, 24);
+    const maxScroll = scrollWidth - clientWidth;
+    const left = maxScroll > 0 ? (scrollLeft / maxScroll) * (track - width) : 0;
+    this.overlayThumb.style.width = `${width}px`;
+    this.overlayThumb.style.transform = `translateX(${left}px)`;
+  },
+
+  sync() {
+    if (!this.container || !this.scrollbar || !this.spacer) return;
+    const scrollable = this.container.scrollWidth > this.container.clientWidth;
+
+    // The custom bar replaces the native one wherever native cannot match the webkit-styled
+    // design: Firefox (no `::-webkit-scrollbar`, so no insets), and overlay-scrollbar platforms
+    // (the bar paints over content and hides at rest).
+    const custom =
+      scrollable &&
+      (!this.webkitScrollbars ||
+        this.container.offsetHeight - this.container.clientHeight === 0);
+
+    // Separate the last row from the scrollbar lane with real padding rather than scrollbar
+    // styling, so every engine gets the same gap. Only applied when the table actually scrolls,
+    // so non-scrolling tables keep their flush bottom edge. With the custom bar (native one
+    // suppressed), the padding is the whole lane.
+    // 16px + the root's 4px make a 20px strip, putting 6px on both sides of the 8px thumb —
+    // the same spacing the webkit-styled native lane produces.
+    const paddingBottom = scrollable
+      ? custom
+        ? "16px"
+        : "var(--noora-spacing-2)"
+      : "";
+    if (this.container.style.paddingBottom !== paddingBottom) {
+      this.container.style.paddingBottom = paddingBottom;
+    }
+    const nativeWidth = custom ? "none" : "";
+    if (this.container.style.scrollbarWidth !== nativeWidth) {
+      this.container.style.scrollbarWidth = nativeWidth;
+    }
+    // Matching padding below the scrollbar lane (on the root, since nothing can render below a
+    // native scrollbar inside its own scroll container), so the pill sits vertically centered
+    // between the last row and the table's bottom edge.
+    const rootPadding = scrollable ? "var(--noora-spacing-2)" : "";
+    if (this.el.style.paddingBottom !== rootPadding) {
+      this.el.style.paddingBottom = rootPadding;
+    }
+
+    const rect = this.container.getBoundingClientRect();
+    // The container's bottom edge includes the native scrollbar gutter; the content ends above it.
+    const gutter = this.container.offsetHeight - this.container.clientHeight;
+    const contentBottom = rect.bottom - gutter;
+
+    if (this.thead) {
+      const floatingHeader = rect.top < 0 && contentBottom > 0;
+      if (floatingHeader) {
+        if (!this.header.hasAttribute("data-visible")) this.refreshHeader();
+        const headerHeight = this.thead.offsetHeight;
+        this.header.style.left = `${rect.left}px`;
+        this.header.style.width = `${rect.width}px`;
+        // Let the table's end push the header out of the viewport as it scrolls past.
+        this.header.style.top = `${Math.min(0, contentBottom - headerHeight)}px`;
+        this.header.setAttribute("data-visible", "");
+      } else {
+        this.header.removeAttribute("data-visible");
+      }
+    }
+
+    const floating =
+      scrollable &&
+      contentBottom > window.innerHeight &&
+      rect.top < window.innerHeight;
+
+    if (this.overlayBar) {
+      if (custom) {
+        // While the table extends below the viewport, pin the bar to the viewport bottom — the
+        // same behavior the proxy scrollbar provides in webkit browsers. Otherwise it settles
+        // into the lane below the body via its stylesheet position.
+        if (floating) {
+          this.overlayBar.style.position = "fixed";
+          this.overlayBar.style.left = `${rect.left + 8}px`;
+          this.overlayBar.style.right = "auto";
+          this.overlayBar.style.width = `${rect.width - 16}px`;
+          this.overlayBar.style.bottom = "2px";
+        } else {
+          this.overlayBar.style.position = "";
+          this.overlayBar.style.left = "";
+          this.overlayBar.style.right = "";
+          this.overlayBar.style.width = "";
+          this.overlayBar.style.bottom = "";
+        }
+        this.overlayBar.setAttribute("data-visible", "");
+        this.syncOverlayThumb();
+      } else {
+        this.overlayBar.removeAttribute("data-visible");
+      }
+    }
+
+    if (floating && !custom) {
+      this.spacer.style.width = `${this.container.scrollWidth}px`;
+      this.scrollbar.style.left = `${rect.left}px`;
+      this.scrollbar.style.width = `${rect.width}px`;
+      this.scrollbar.setAttribute("data-visible", "");
+      if (this.scrollbar.scrollLeft !== this.container.scrollLeft) {
+        this.scrollbar.scrollLeft = this.container.scrollLeft;
+      }
+    } else {
+      this.scrollbar.removeAttribute("data-visible");
+    }
+  },
+};

--- a/noora/js/index.js
+++ b/noora/js/index.js
@@ -14,6 +14,7 @@ import NooraModal from "./Modal.js";
 import NooraPopover from "./Popover.js";
 import NooraScrollArea from "./ScrollArea.js";
 import NooraSelect from "./Select.js";
+import NooraTable from "./Table.js";
 import NooraTabs from "./Tabs.js";
 import NooraTagsInput from "./TagsInput.js";
 import NooraToggle from "./Toggle.js";
@@ -34,6 +35,7 @@ const Hooks = {
   NooraPopover,
   NooraScrollArea,
   NooraSelect,
+  NooraTable,
   NooraTabs,
   NooraTagsInput,
   NooraToggle,

--- a/noora/lib/noora/table.ex
+++ b/noora/lib/noora/table.ex
@@ -106,6 +106,11 @@ defmodule Noora.Table do
     doc: "A list of row keys/IDs that are currently expanded."
   )
 
+  attr(:expand_label, :string,
+    default: "Toggle row details",
+    doc: "Accessible label for the disclosure button that expands/collapses a row."
+  )
+
   slot(:empty_state, required: false)
 
   slot :col, required: true do
@@ -178,15 +183,16 @@ defmodule Noora.Table do
               <% is_expandable = @row_expandable && @row_expandable.(row) %>
               <% is_expanded = row_key in @expanded_rows %>
 
-              <%!-- Expansion is purely presentational, so it's toggled client-side: one
-              attribute flip on this row, no round trip and no patch. The expanded sibling
-              row, the row background, and the chevron all derive from this attribute. --%>
+              <%!-- Expansion is presentational, toggled client-side via the disclosure button
+              in the first cell — not a click handler on the row. A passive row keeps text
+              selectable (so cache keys can be copied without collapsing), lets controls inside
+              the row work without double-firing, and routes keyboard users through a real
+              focusable button. The button flips `data-state` on this row; the expanded sibling
+              row, the row background, and the chevron all derive from that attribute. --%>
               <tr
                 id={row_key}
                 {if is_expandable,
-               do: %{
-                 "phx-click" => JS.toggle_attribute({"data-state", "expanded", "collapsed"})
-               },
+               do: %{},
                else: if(@row_click, do: @row_click.(row) || %{}, else: %{})}
                 data-expandable={is_expandable}
                 data-state={is_expandable && if(is_expanded, do: "expanded", else: "collapsed")}
@@ -199,26 +205,43 @@ defmodule Noora.Table do
                          (not is_nil(@row_click) && not is_nil(@row_click.(row))))
                   }
                 >
-                  <%= if is_expandable && index == 0 do %>
-                    <div data-part="expand-cell">
-                      <.icon
-                        id={"#{row_key}-expand-chevron"}
-                        name="chevron_right"
-                        active_name="chevron_down"
-                        transition="crossfade_rotate"
-                        watch="tr[data-expandable]"
-                        active_state="expanded"
-                      />
-                      {render_slot(col, row)}
-                    </div>
-                  <% else %>
-                    <%= if @row_navigate do %>
-                      <.link navigate={@row_navigate.(row)} data-part="link">
+                  <%= cond do %>
+                    <% is_expandable && index == 0 -> %>
+                      <div data-part="expand-cell">
+                        <button
+                          type="button"
+                          data-part="expand-toggle"
+                          aria-expanded={to_string(is_expanded)}
+                          aria-controls={"#{row_key}-expanded"}
+                          aria-label={@expand_label}
+                          phx-click={
+                            JS.toggle_attribute({"data-state", "expanded", "collapsed"},
+                              to: "##{row_key}"
+                            )
+                            |> JS.toggle_attribute({"aria-expanded", "true", "false"})
+                          }
+                        >
+                          <.icon
+                            id={"#{row_key}-expand-chevron"}
+                            name="chevron_right"
+                            active_name="chevron_down"
+                            transition="crossfade_rotate"
+                            watch="tr[data-expandable]"
+                            active_state="expanded"
+                          />
+                        </button>
+                        {render_slot(col, row)}
+                      </div>
+                    <% @row_navigate && index == 0 -> %>
+                      <%!-- Whole-row navigation via a single stretched anchor: only the first
+                      cell carries the link, and its `::after` overlay (see table.css) extends the
+                      hit area across the row. The row reads as one link — one tab stop, announced
+                      once — instead of one duplicate link per cell. --%>
+                      <.link navigate={@row_navigate.(row)} data-part="row-link">
                         {render_slot(col, row)}
                       </.link>
-                    <% else %>
+                    <% true -> %>
                       {render_slot(col, row)}
-                    <% end %>
                   <% end %>
                 </td>
               </tr>

--- a/noora/lib/noora/table.ex
+++ b/noora/lib/noora/table.ex
@@ -34,13 +34,19 @@ defmodule Noora.Table do
   Tables can have expandable rows that reveal additional content when clicked. Use the `row_expandable` attribute to determine which rows can be expanded,
   and the `expanded_content` slot to define what content to show.
 
+  Expansion is handled entirely client-side: clicking a row toggles it without a server
+  round trip, so the reveal animation starts instantly. The expanded content is always
+  rendered (collapsed to zero height), and `expanded_rows` only sets which rows start out
+  expanded. No `handle_event` is needed. Note that a LiveView re-render of the table (for
+  example sorting or searching) resets rows to that initial state.
+
   ```
   <.table
     id="expandable-table"
     rows={@tasks}
     row_key={fn task -> task.key end}
     row_expandable={fn task -> not Enum.empty?(task.details) end}
-    expanded_rows={MapSet.to_list(@expanded_task_keys)}
+    expanded_rows={[]}
   >
     <:col :let={task} label="Task">
       <.text_cell label={task.description} />
@@ -57,23 +63,6 @@ defmodule Noora.Table do
     </:expanded_content>
   </.table>
   ```
-
-  In your LiveView, handle the expand/collapse interaction:
-
-  ```
-  def handle_event("toggle-expand", %{"row-key" => row_key}, socket) do
-    expanded_keys = socket.assigns.expanded_task_keys
-
-    updated_keys =
-      if MapSet.member?(expanded_keys, row_key) do
-        MapSet.delete(expanded_keys, row_key)
-      else
-        MapSet.put(expanded_keys, row_key)
-      end
-
-    {:noreply, assign(socket, expanded_task_keys: updated_keys)}
-  end
-  ```
   """
 
   use Phoenix.Component
@@ -84,6 +73,8 @@ defmodule Noora.Table do
   import Noora.Tag
   import Noora.Time
   import Noora.Utils
+
+  alias Phoenix.LiveView.JS
 
   attr(:id, :string, required: true, doc: "A uniqie identifier for the table")
 
@@ -187,16 +178,18 @@ defmodule Noora.Table do
               <% is_expandable = @row_expandable && @row_expandable.(row) %>
               <% is_expanded = row_key in @expanded_rows %>
 
+              <%!-- Expansion is purely presentational, so it's toggled client-side: one
+              attribute flip on this row, no round trip and no patch. The expanded sibling
+              row, the row background, and the chevron all derive from this attribute. --%>
               <tr
                 id={row_key}
                 {if is_expandable,
                do: %{
-                 "phx-click" => "toggle-expand",
-                 "phx-value-row-key" => row_key
+                 "phx-click" => JS.toggle_attribute({"data-state", "expanded", "collapsed"})
                },
                else: if(@row_click, do: @row_click.(row) || %{}, else: %{})}
                 data-expandable={is_expandable}
-                data-expanded={is_expanded}
+                data-state={is_expandable && if(is_expanded, do: "expanded", else: "collapsed")}
               >
                 <td
                   :for={{col, index} <- Enum.with_index(@col)}
@@ -208,8 +201,14 @@ defmodule Noora.Table do
                 >
                   <%= if is_expandable && index == 0 do %>
                     <div data-part="expand-cell">
-                      <.chevron_down :if={is_expanded} />
-                      <.chevron_right :if={!is_expanded} />
+                      <.icon
+                        id={"#{row_key}-expand-chevron"}
+                        name="chevron_right"
+                        active_name="chevron_down"
+                        transition="crossfade_rotate"
+                        watch="tr[data-expandable]"
+                        active_state="expanded"
+                      />
                       {render_slot(col, row)}
                     </div>
                   <% else %>
@@ -224,13 +223,21 @@ defmodule Noora.Table do
                 </td>
               </tr>
 
+              <%!-- Always rendered (collapsed to zero height) rather than inserted/removed on
+              toggle: the reveal is a plain CSS transition keyed off the preceding row's
+              `data-state`, so there's no mount cost before the animation can start and no
+              removal timer racing the collapse. --%>
               <tr
-                :if={is_expandable && is_expanded}
+                :if={is_expandable && @expanded_content != []}
                 data-part="expanded-row"
                 id={"#{row_key}-expanded"}
               >
                 <td colspan={length(@col)} data-part="expanded-content">
-                  {render_slot(@expanded_content, row)}
+                  <div data-part="expand-wrapper">
+                    <div data-part="expand-wrapper-content">
+                      {render_slot(@expanded_content, row)}
+                    </div>
+                  </div>
                 </td>
               </tr>
             <% end %>

--- a/noora/lib/noora/table.ex
+++ b/noora/lib/noora/table.ex
@@ -121,6 +121,11 @@ defmodule Noora.Table do
     attr(:label, :string, required: false, doc: "The label of the column")
     attr(:icon, :string, doc: "An icon to render next to the label")
     attr(:patch, :string, doc: "A patch to apply to the column")
+
+    attr(:sort_order, :any,
+      doc:
+        ~s(When set to "asc" or "desc", renders a sort-direction arrow that morphs between the two directions as the value changes. Mirror your sort-state gating, e.g. `sort_order={@sort_by == "duration" && @sort_order}`.)
+    )
   end
 
   slot(:expanded_content, required: false, doc: "Content to display when a row is expanded")
@@ -145,84 +150,127 @@ defmodule Noora.Table do
       end
 
     ~H"""
-    <div id={@id} class="noora-table">
-      <table>
-        <thead>
-          <tr>
-            <th :for={col <- @col}>
-              <%= if col[:patch] do %>
-                <.link patch={col[:patch]} data-part="sort-link">
+    <div id={@id} class="noora-table" phx-hook="NooraTable">
+      <div data-part="scroll-container">
+        <table>
+          <thead>
+            <tr>
+              <th :for={{col, col_index} <- Enum.with_index(@col)}>
+                <%= if col[:patch] do %>
+                  <.link patch={col[:patch]} data-part="sort-link">
+                    <span>{col[:label]}</span>
+                    <span :if={col[:icon]} data-part="icon"><.icon name={col[:icon]} /></span>
+                    <.sort_indicator
+                      :if={col[:sort_order]}
+                      id={"#{@id}-sort-#{col_index}"}
+                      order={col[:sort_order]}
+                    />
+                  </.link>
+                <% else %>
                   <span>{col[:label]}</span>
                   <span :if={col[:icon]} data-part="icon"><.icon name={col[:icon]} /></span>
-                </.link>
-              <% else %>
-                <span>{col[:label]}</span>
-                <span :if={col[:icon]} data-part="icon"><.icon name={col[:icon]} /></span>
-              <% end %>
-            </th>
-          </tr>
-        </thead>
-        <tbody
-          id={"#{@id}-body"}
-          phx-update={match?(%Phoenix.LiveView.LiveStream{}, @rows) && "stream"}
-        >
-          <%= for row <- @rows do %>
-            <% row_key = @row_key && @row_key.(row) %>
-            <% is_expandable = @row_expandable && @row_expandable.(row) %>
-            <% is_expanded = row_key in @expanded_rows %>
+                  <.sort_indicator
+                    :if={col[:sort_order]}
+                    id={"#{@id}-sort-#{col_index}"}
+                    order={col[:sort_order]}
+                  />
+                <% end %>
+              </th>
+            </tr>
+          </thead>
+          <tbody
+            id={"#{@id}-body"}
+            phx-update={match?(%Phoenix.LiveView.LiveStream{}, @rows) && "stream"}
+          >
+            <%= for row <- @rows do %>
+              <% row_key = @row_key && @row_key.(row) %>
+              <% is_expandable = @row_expandable && @row_expandable.(row) %>
+              <% is_expanded = row_key in @expanded_rows %>
 
-            <tr
-              id={row_key}
-              {if is_expandable,
+              <tr
+                id={row_key}
+                {if is_expandable,
                do: %{
                  "phx-click" => "toggle-expand",
                  "phx-value-row-key" => row_key
                },
                else: if(@row_click, do: @row_click.(row) || %{}, else: %{})}
-              data-expandable={is_expandable}
-              data-expanded={is_expanded}
-            >
-              <td
-                :for={{col, index} <- Enum.with_index(@col)}
-                data-selectable={
-                  !is_expandable &&
-                    (not is_nil(@row_navigate) or
-                       (not is_nil(@row_click) && not is_nil(@row_click.(row))))
-                }
+                data-expandable={is_expandable}
+                data-expanded={is_expanded}
               >
-                <%= if is_expandable && index == 0 do %>
-                  <div data-part="expand-cell">
-                    <.chevron_down :if={is_expanded} />
-                    <.chevron_right :if={!is_expanded} />
-                    {render_slot(col, row)}
-                  </div>
-                <% else %>
-                  <%= if @row_navigate do %>
-                    <.link navigate={@row_navigate.(row)} data-part="link">
+                <td
+                  :for={{col, index} <- Enum.with_index(@col)}
+                  data-selectable={
+                    !is_expandable &&
+                      (not is_nil(@row_navigate) or
+                         (not is_nil(@row_click) && not is_nil(@row_click.(row))))
+                  }
+                >
+                  <%= if is_expandable && index == 0 do %>
+                    <div data-part="expand-cell">
+                      <.chevron_down :if={is_expanded} />
+                      <.chevron_right :if={!is_expanded} />
                       {render_slot(col, row)}
-                    </.link>
+                    </div>
                   <% else %>
-                    {render_slot(col, row)}
+                    <%= if @row_navigate do %>
+                      <.link navigate={@row_navigate.(row)} data-part="link">
+                        {render_slot(col, row)}
+                      </.link>
+                    <% else %>
+                      {render_slot(col, row)}
+                    <% end %>
                   <% end %>
-                <% end %>
+                </td>
+              </tr>
+
+              <tr
+                :if={is_expandable && is_expanded}
+                data-part="expanded-row"
+                id={"#{row_key}-expanded"}
+              >
+                <td colspan={length(@col)} data-part="expanded-content">
+                  {render_slot(@expanded_content, row)}
+                </td>
+              </tr>
+            <% end %>
+
+            <tr :if={has_slot_content?(@empty_state, assigns) && Enum.empty?(@rows)}>
+              <td colspan={length(@col)}>
+                {render_slot(@empty_state)}
               </td>
             </tr>
-
-            <tr :if={is_expandable && is_expanded} data-part="expanded-row" id={"#{row_key}-expanded"}>
-              <td colspan={length(@col)} data-part="expanded-content">
-                {render_slot(@expanded_content, row)}
-              </td>
-            </tr>
-          <% end %>
-
-          <tr :if={has_slot_content?(@empty_state, assigns) && Enum.empty?(@rows)}>
-            <td colspan={length(@col)}>
-              {render_slot(@empty_state)}
-            </td>
-          </tr>
-        </tbody>
-      </table>
+          </tbody>
+        </table>
+      </div>
+      <div data-part="scrollbar" aria-hidden="true">
+        <div data-part="scrollbar-content"></div>
+      </div>
+      <div data-part="overlay-scrollbar" aria-hidden="true">
+        <div data-part="overlay-thumb"></div>
+      </div>
     </div>
+    """
+  end
+
+  attr(:id, :string, required: true, doc: "A unique identifier for the morphing icon")
+  attr(:order, :string, required: true, doc: ~s(The current sort order: "asc" or "desc"))
+
+  # A sort-direction arrow that morphs between descending (down) and ascending (up) as `order`
+  # changes. The `order` is mirrored onto the wrapping `data-part="icon"` element as `data-state`,
+  # which the icon's morph hook watches.
+  defp sort_indicator(assigns) do
+    ~H"""
+    <span data-part="icon" data-state={@order}>
+      <.icon
+        id={@id}
+        name="square_rounded_arrow_down"
+        active_name="square_rounded_arrow_up"
+        transition="morph"
+        watch="[data-part='icon']"
+        active_state="asc"
+      />
+    </span>
     """
   end
 

--- a/noora/storybook/config/config.exs
+++ b/noora/storybook/config/config.exs
@@ -25,8 +25,11 @@ config :noora_storybook, NooraStorybookWeb.Endpoint,
 config :esbuild,
   version: "0.17.11",
   noora_storybook: [
+    # The JS entries import noora's CSS, so esbuild emits sibling .css files next to the .js
+    # output. Those must not land in /assets directly, where they would overwrite the
+    # Tailwind-built storybook.css (which carries the base font and imports the same noora CSS).
     args:
-      ~w(js/app.js js/storybook.js --bundle --target=es2017 --outdir=../priv/static/assets --external:/fonts/* --external:/images/*),
+      ~w(js/app.js js/storybook.js --bundle --target=es2017 --outdir=../priv/static/assets/js --external:/fonts/* --external:/images/*),
     cd: Path.expand("../assets", __DIR__),
     env: %{"NODE_PATH" => Path.expand("../../node_modules", __DIR__) <> ":" <> Path.expand("../deps", __DIR__)}
   ]

--- a/noora/storybook/lib/noora_storybook_web/components/layouts/root.html.heex
+++ b/noora/storybook/lib/noora_storybook_web/components/layouts/root.html.heex
@@ -7,8 +7,7 @@
     <.live_title default="NooraStorybook" suffix=" · Phoenix Framework">
       {assigns[:page_title]}
     </.live_title>
-    <link phx-track-static rel="stylesheet" href={~p"/assets/app.css"} />
-    <script defer phx-track-static type="text/javascript" src={~p"/assets/app.js"}>
+    <script defer phx-track-static type="text/javascript" src={~p"/assets/js/app.js"}>
     </script>
   </head>
   <body class="bg-white noora-storybook-web">

--- a/noora/storybook/lib/noora_storybook_web/storybook.ex
+++ b/noora/storybook/lib/noora_storybook_web/storybook.ex
@@ -9,7 +9,7 @@ defmodule NooraStorybookWeb.Storybook do
     })",
     content_path: Path.expand("../../storybook", __DIR__),
     css_path: "/assets/storybook.css",
-    js_path: "/assets/storybook.js",
+    js_path: "/assets/js/storybook.js",
     sandbox_class: "noora-storybook-web",
     color_mode: true,
     color_mode_sandbox_dark_class: "noora-dark"

--- a/noora/storybook/storybook/table.story.exs
+++ b/noora/storybook/storybook/table.story.exs
@@ -121,6 +121,30 @@ defmodule TuistWeb.Storybook.Table do
         ]
       },
       %Variation{
+        id: :sortable_columns,
+        description:
+          "Sortable columns render a sort-direction arrow (via `sort_order`) that morphs between ascending and descending when the value changes at runtime.",
+        attributes: %{
+          rows: [
+            %{id: 1, name: "Row One", duration: "5s"},
+            %{id: 2, name: "Row Two", duration: "12s"}
+          ]
+        },
+        slots: [
+          """
+          <:col :let={i} label="Name">
+            <.text_cell label={i.name} />
+          </:col>
+          <:col :let={i} label="Duration (desc)" patch="#" sort_order="desc">
+            <.text_cell label={i.duration} />
+          </:col>
+          <:col :let={i} label="Created at (asc)" patch="#" sort_order="asc">
+            <.text_cell sublabel="2 hours ago" />
+          </:col>
+          """
+        ]
+      },
+      %Variation{
         id: :expandable_rows,
         description: "Table with expandable rows showing additional details",
         attributes: %{

--- a/server/lib/tuist_web/components/runs/module_cache_tab.ex
+++ b/server/lib/tuist_web/components/runs/module_cache_tab.ex
@@ -160,10 +160,7 @@ defmodule TuistWeb.Runs.ModuleCacheTab do
                 |> Query.put("binary-cache-sort-order", sort_order_patch_value("name", @binary_cache_sort_by, @binary_cache_sort_order))
                 |> Query.drop("binary-cache-page")}"
               }
-              icon={
-                @binary_cache_sort_by == "name" &&
-                  sort_icon(@binary_cache_sort_order)
-              }
+              sort_order={@binary_cache_sort_by == "name" && @binary_cache_sort_order}
             >
               <.text_and_description_cell label={binary_cache_module.name} />
             </:col>
@@ -347,9 +344,6 @@ defmodule TuistWeb.Runs.ModuleCacheTab do
     </div>
     """
   end
-
-  defp sort_icon("desc"), do: "square_rounded_arrow_down"
-  defp sort_icon("asc"), do: "square_rounded_arrow_up"
 
   defp sort_order_patch_value(category, current_category, current_order) do
     if category == current_category do

--- a/server/lib/tuist_web/components/runs/selective_testing_tab.ex
+++ b/server/lib/tuist_web/components/runs/selective_testing_tab.ex
@@ -130,10 +130,7 @@ defmodule TuistWeb.Runs.SelectiveTestingTab do
                 |> Query.put("selective-testing-sort-order", sort_order_patch_value("name", @selective_testing_sort_by, @selective_testing_sort_order))
                 |> Query.drop("selective-testing-page")}"
               }
-              icon={
-                @selective_testing_sort_by == "name" &&
-                  sort_icon(@selective_testing_sort_order)
-              }
+              sort_order={@selective_testing_sort_by == "name" && @selective_testing_sort_order}
             >
               <.text_and_description_cell label={test_module.name} />
             </:col>
@@ -216,9 +213,6 @@ defmodule TuistWeb.Runs.SelectiveTestingTab do
       Map.get(test_module, :product_name, "") not in [nil, ""] or
       Map.get(test_module, :bundle_id, "") not in [nil, ""]
   end
-
-  defp sort_icon("desc"), do: "square_rounded_arrow_down"
-  defp sort_icon("asc"), do: "square_rounded_arrow_up"
 
   defp sort_order_patch_value(category, current_category, current_order) do
     if category == current_category do

--- a/server/lib/tuist_web/live/build_run_live.ex
+++ b/server/lib/tuist_web/live/build_run_live.ex
@@ -848,14 +848,6 @@ defmodule TuistWeb.BuildRunLive do
     issue_title(title, issue, run)
   end
 
-  def sort_icon("desc") do
-    "square_rounded_arrow_down"
-  end
-
-  def sort_icon("asc") do
-    "square_rounded_arrow_up"
-  end
-
   def file_breakdown_column_patch_sort(
         %{uri: uri, file_breakdown_sort_by: file_breakdown_sort_by, file_breakdown_sort_order: file_breakdown_sort_order} =
           _assigns,

--- a/server/lib/tuist_web/live/build_run_live.ex
+++ b/server/lib/tuist_web/live/build_run_live.ex
@@ -373,36 +373,6 @@ defmodule TuistWeb.BuildRunLive do
     {:noreply, socket}
   end
 
-  def handle_event(
-        "toggle-expand",
-        %{"row-key" => row_key},
-        %{assigns: %{selected_tab: "module-cache", expanded_target_names: expanded_target_names}} = socket
-      ) do
-    updated_expanded_names =
-      if MapSet.member?(expanded_target_names, row_key) do
-        MapSet.delete(expanded_target_names, row_key)
-      else
-        MapSet.put(expanded_target_names, row_key)
-      end
-
-    {:noreply, assign(socket, :expanded_target_names, updated_expanded_names)}
-  end
-
-  def handle_event(
-        "toggle-expand",
-        %{"row-key" => task_key},
-        %{assigns: %{expanded_task_keys: expanded_task_keys}} = socket
-      ) do
-    updated_expanded_keys =
-      if MapSet.member?(expanded_task_keys, task_key) do
-        MapSet.delete(expanded_task_keys, task_key)
-      else
-        MapSet.put(expanded_task_keys, task_key)
-      end
-
-    {:noreply, assign(socket, :expanded_task_keys, updated_expanded_keys)}
-  end
-
   defp handle_event_xcode(
          "search-cacheable-tasks",
          %{"search" => search},

--- a/server/lib/tuist_web/live/build_run_live.html.heex
+++ b/server/lib/tuist_web/live/build_run_live.html.heex
@@ -525,10 +525,7 @@
                 @module_breakdown_sort_by == "name" &&
                   module_breakdown_column_patch_sort(assigns, "name")
               }
-              icon={
-                @module_breakdown_sort_by == "name" &&
-                  sort_icon(@module_breakdown_sort_order)
-              }
+              sort_order={@module_breakdown_sort_by == "name" && @module_breakdown_sort_order}
             >
               <.text_and_description_cell label={module.name} />
             </:col>
@@ -539,9 +536,8 @@
                 @module_breakdown_sort_by == "build-duration" &&
                   module_breakdown_column_patch_sort(assigns, "build-duration")
               }
-              icon={
-                @module_breakdown_sort_by == "build-duration" &&
-                  sort_icon(@module_breakdown_sort_order)
+              sort_order={
+                @module_breakdown_sort_by == "build-duration" && @module_breakdown_sort_order
               }
             >
               <.text_cell
@@ -560,9 +556,9 @@
                 @module_breakdown_sort_by == "compilation-duration" &&
                   module_breakdown_column_patch_sort(assigns, "compilation-duration")
               }
-              icon={
+              sort_order={
                 @module_breakdown_sort_by == "compilation-duration" &&
-                  sort_icon(@module_breakdown_sort_order)
+                  @module_breakdown_sort_order
               }
             >
               <.text_cell
@@ -674,10 +670,7 @@
                 @file_breakdown_sort_by == "file" &&
                   file_breakdown_column_patch_sort(assigns, "file")
               }
-              icon={
-                @file_breakdown_sort_by == "file" &&
-                  sort_icon(@file_breakdown_sort_order)
-              }
+              sort_order={@file_breakdown_sort_by == "file" && @file_breakdown_sort_order}
             >
               <.text_and_description_cell label={file.path} />
             </:col>
@@ -708,9 +701,8 @@
                 @file_breakdown_sort_by == "compilation-duration" &&
                   file_breakdown_column_patch_sort(assigns, "compilation-duration")
               }
-              icon={
-                @file_breakdown_sort_by == "compilation-duration" &&
-                  sort_icon(@file_breakdown_sort_order)
+              sort_order={
+                @file_breakdown_sort_by == "compilation-duration" && @file_breakdown_sort_order
               }
             >
               <.text_cell
@@ -1193,9 +1185,8 @@
                     @cacheable_tasks_sort_by == "description" &&
                       cacheable_tasks_column_patch_sort(assigns, "description")
                   }
-                  icon={
-                    @cacheable_tasks_sort_by == "description" &&
-                      sort_icon(@cacheable_tasks_sort_order)
+                  sort_order={
+                    @cacheable_tasks_sort_by == "description" && @cacheable_tasks_sort_order
                   }
                 >
                   <.text_cell label={task.description || dgettext("dashboard_builds", "Unknown")} />
@@ -1230,10 +1221,7 @@
                     @cacheable_tasks_sort_by == "key" &&
                       cacheable_tasks_column_patch_sort(assigns, "key")
                   }
-                  icon={
-                    @cacheable_tasks_sort_by == "key" &&
-                      sort_icon(@cacheable_tasks_sort_order)
-                  }
+                  sort_order={@cacheable_tasks_sort_by == "key" && @cacheable_tasks_sort_order}
                 >
                   <.text_cell label={String.slice(task.key, 0, 30) <> if(String.length(task.key) > 30, do: "...", else: "")} />
                 </:col>
@@ -1533,10 +1521,7 @@
                     @cas_outputs_sort_by == "node-id" &&
                       cas_outputs_column_patch_sort(assigns, "node-id")
                   }
-                  icon={
-                    @cas_outputs_sort_by == "node-id" &&
-                      sort_icon(@cas_outputs_sort_order)
-                  }
+                  sort_order={@cas_outputs_sort_by == "node-id" && @cas_outputs_sort_order}
                 >
                   <.text_cell label={String.slice(output.node_id, 0, 30) <> if(String.length(output.node_id) > 30, do: "...", else: "")} />
                 </:col>
@@ -1564,10 +1549,7 @@
                     @cas_outputs_sort_by == "size" &&
                       cas_outputs_column_patch_sort(assigns, "size")
                   }
-                  icon={
-                    @cas_outputs_sort_by == "size" &&
-                      sort_icon(@cas_outputs_sort_order)
-                  }
+                  sort_order={@cas_outputs_sort_by == "size" && @cas_outputs_sort_order}
                 >
                   <.text_cell label={Tuist.Utilities.ByteFormatter.format_bytes(output.size)} />
                 </:col>
@@ -1578,9 +1560,8 @@
                     @cas_outputs_sort_by == "compressed-size" &&
                       cas_outputs_column_patch_sort(assigns, "compressed-size")
                   }
-                  icon={
-                    @cas_outputs_sort_by == "compressed-size" &&
-                      sort_icon(@cas_outputs_sort_order)
+                  sort_order={
+                    @cas_outputs_sort_by == "compressed-size" && @cas_outputs_sort_order
                   }
                 >
                   <.text_cell label={

--- a/server/lib/tuist_web/live/build_run_live.html.heex
+++ b/server/lib/tuist_web/live/build_run_live.html.heex
@@ -1234,7 +1234,6 @@
                         size="small"
                         icon_only
                         phx-hook="Clipboard"
-                        phx-click={JS.exec("event.stopPropagation()", to: "window")}
                         data-clipboard-value={task.key}
                       >
                         <.copy />

--- a/server/lib/tuist_web/live/bundle_live.ex
+++ b/server/lib/tuist_web/live/bundle_live.ex
@@ -560,14 +560,6 @@ defmodule TuistWeb.BundleLive do
     }
   end
 
-  def sort_icon("desc") do
-    "square_rounded_arrow_down"
-  end
-
-  def sort_icon("asc") do
-    "square_rounded_arrow_up"
-  end
-
   defp sort_file_breakdown_artifacts(artifacts, "path", "asc") do
     Enum.sort_by(artifacts, & &1.path, :desc)
   end

--- a/server/lib/tuist_web/live/bundle_live.html.heex
+++ b/server/lib/tuist_web/live/bundle_live.html.heex
@@ -532,10 +532,7 @@
             @file_breakdown_sort_by == "path" &&
               file_breakdown_column_patch_sort(assigns, "path")
           }
-          icon={
-            @file_breakdown_sort_by == "path" &&
-              sort_icon(@file_breakdown_sort_order)
-          }
+          sort_order={@file_breakdown_sort_by == "path" && @file_breakdown_sort_order}
         >
           <.text_and_description_cell label={
             artifact.path |> String.split("/") |> Enum.drop(1) |> Enum.join("/")
@@ -574,10 +571,7 @@
             @file_breakdown_sort_by == "size" &&
               file_breakdown_column_patch_sort(assigns, "size")
           }
-          icon={
-            @file_breakdown_sort_by == "size" &&
-              sort_icon(@file_breakdown_sort_order)
-          }
+          sort_order={@file_breakdown_sort_by == "size" && @file_breakdown_sort_order}
         >
           <.text_cell label={format_bytes(artifact.size)} />
         </:col>
@@ -659,10 +653,7 @@
             @module_breakdown_sort_by == "name" &&
               module_breakdown_column_patch_sort(assigns, "name")
           }
-          icon={
-            @module_breakdown_sort_by == "name" &&
-              sort_icon(@module_breakdown_sort_order)
-          }
+          sort_order={@module_breakdown_sort_by == "name" && @module_breakdown_sort_order}
         >
           <.text_and_description_cell label={module.name} />
         </:col>
@@ -673,10 +664,7 @@
             @module_breakdown_sort_by == "size" &&
               module_breakdown_column_patch_sort(assigns, "size")
           }
-          icon={
-            @module_breakdown_sort_by == "size" &&
-              sort_icon(@module_breakdown_sort_order)
-          }
+          sort_order={@module_breakdown_sort_by == "size" && @module_breakdown_sort_order}
         >
           <.text_cell label={format_bytes(module.size)} />
         </:col>

--- a/server/lib/tuist_web/live/bundles_live.ex
+++ b/server/lib/tuist_web/live/bundles_live.ex
@@ -326,14 +326,6 @@ defmodule TuistWeb.BundlesLive do
     "?#{URI.encode_query(query_params)}"
   end
 
-  def sort_icon("desc") do
-    "square_rounded_arrow_down"
-  end
-
-  def sort_icon("asc") do
-    "square_rounded_arrow_up"
-  end
-
   def handle_event("add_filter", %{"value" => filter_id}, socket) do
     updated_params =
       filter_id

--- a/server/lib/tuist_web/live/bundles_live.html.heex
+++ b/server/lib/tuist_web/live/bundles_live.html.heex
@@ -361,10 +361,7 @@
               patch={
                 @bundles_sort_by == "install-size" && column_patch_sort(assigns, "install-size")
               }
-              icon={
-                @bundles_sort_by == "install-size" &&
-                  sort_icon(@bundles_sort_order)
-              }
+              sort_order={@bundles_sort_by == "install-size" && @bundles_sort_order}
             >
               <.text_cell label={format_bytes(bundle.install_size)} />
             </:col>
@@ -374,10 +371,7 @@
               patch={
                 @bundles_sort_by == "download-size" && column_patch_sort(assigns, "download-size")
               }
-              icon={
-                @bundles_sort_by == "download-size" &&
-                  sort_icon(@bundles_sort_order)
-              }
+              sort_order={@bundles_sort_by == "download-size" && @bundles_sort_order}
             >
               <.text_cell label={
                 if bundle.download_size,
@@ -398,10 +392,7 @@
               :let={bundle}
               label={dgettext("dashboard_cache", "Created at")}
               patch={@bundles_sort_by == "created-at" && column_patch_sort(assigns, "created-at")}
-              icon={
-                @bundles_sort_by == "created-at" &&
-                  sort_icon(@bundles_sort_order)
-              }
+              sort_order={@bundles_sort_by == "created-at" && @bundles_sort_order}
             >
               <.text_cell sublabel={DateFormatter.from_now(bundle.inserted_at)} />
             </:col>

--- a/server/lib/tuist_web/live/cache_runs_live.ex
+++ b/server/lib/tuist_web/live/cache_runs_live.ex
@@ -312,14 +312,6 @@ defmodule TuistWeb.CacheRunsLive do
 
   defp normalize_text_filter_operator(filter), do: filter
 
-  def sort_icon("desc") do
-    "square_rounded_arrow_down"
-  end
-
-  def sort_icon("asc") do
-    "square_rounded_arrow_up"
-  end
-
   def column_patch_sort(
         %{uri: uri, cache_runs_sort_by: cache_runs_sort_by, cache_runs_sort_order: cache_runs_sort_order} = _assigns,
         column_value

--- a/server/lib/tuist_web/live/cache_runs_live.html.heex
+++ b/server/lib/tuist_web/live/cache_runs_live.html.heex
@@ -68,10 +68,7 @@
             :let={cache_run}
             label={dgettext("dashboard_cache", "Hit rate")}
             patch={@cache_runs_sort_by == "hit_rate" && column_patch_sort(assigns, "hit_rate")}
-            icon={
-              @cache_runs_sort_by == "hit_rate" &&
-                sort_icon(@cache_runs_sort_order)
-            }
+            sort_order={@cache_runs_sort_by == "hit_rate" && @cache_runs_sort_order}
           >
             <.text_cell label={
               dgettext("dashboard_cache", "%{hit_rate}%",
@@ -103,10 +100,7 @@
             :let={cache_run}
             label={dgettext("dashboard_cache", "Duration")}
             patch={@cache_runs_sort_by == "duration" && column_patch_sort(assigns, "duration")}
-            icon={
-              @cache_runs_sort_by == "duration" &&
-                sort_icon(@cache_runs_sort_order)
-            }
+            sort_order={@cache_runs_sort_by == "duration" && @cache_runs_sort_order}
           >
             <.text_cell
               label={
@@ -122,10 +116,7 @@
             :let={cache_run}
             label={dgettext("dashboard_cache", "Ran at")}
             patch={@cache_runs_sort_by == "ran_at" && column_patch_sort(assigns, "ran_at")}
-            icon={
-              @cache_runs_sort_by == "ran_at" &&
-                sort_icon(@cache_runs_sort_order)
-            }
+            sort_order={@cache_runs_sort_by == "ran_at" && @cache_runs_sort_order}
           >
             <.text_cell sublabel={Tuist.Utilities.DateFormatter.from_now(cache_run.ran_at)} />
           </:col>

--- a/server/lib/tuist_web/live/flaky_tests_live.ex
+++ b/server/lib/tuist_web/live/flaky_tests_live.ex
@@ -287,9 +287,6 @@ defmodule TuistWeb.FlakyTestsLive do
   defp environment_label("local"), do: dgettext("dashboard_tests", "Local")
   defp environment_label("ci"), do: dgettext("dashboard_tests", "CI")
 
-  defp sort_icon("asc"), do: "square_rounded_arrow_up"
-  defp sort_icon("desc"), do: "square_rounded_arrow_down"
-
   defp toggle_sort_order("asc"), do: "desc"
   defp toggle_sort_order("desc"), do: "asc"
 

--- a/server/lib/tuist_web/live/flaky_tests_live.html.heex
+++ b/server/lib/tuist_web/live/flaky_tests_live.html.heex
@@ -400,10 +400,7 @@
               @flaky_tests_sort_by == "name" &&
                 column_sort_patch(assigns, "name")
             }
-            icon={
-              @flaky_tests_sort_by == "name" &&
-                sort_icon(@flaky_tests_sort_order)
-            }
+            sort_order={@flaky_tests_sort_by == "name" && @flaky_tests_sort_order}
           >
             <.text_and_description_cell
               label={test_case.name}
@@ -428,10 +425,7 @@
               @flaky_tests_sort_by == "flaky_runs_count" &&
                 column_sort_patch(assigns, "flaky_runs_count")
             }
-            icon={
-              @flaky_tests_sort_by == "flaky_runs_count" &&
-                sort_icon(@flaky_tests_sort_order)
-            }
+            sort_order={@flaky_tests_sort_by == "flaky_runs_count" && @flaky_tests_sort_order}
           >
             <.text_cell label={test_case.flaky_runs_count} />
           </:col>
@@ -442,10 +436,7 @@
               @flaky_tests_sort_by == "last_flaky_at" &&
                 column_sort_patch(assigns, "last_flaky_at")
             }
-            icon={
-              @flaky_tests_sort_by == "last_flaky_at" &&
-                sort_icon(@flaky_tests_sort_order)
-            }
+            sort_order={@flaky_tests_sort_by == "last_flaky_at" && @flaky_tests_sort_order}
           >
             <.link_button
               :if={test_case.flaky_runs_count > 0}

--- a/server/lib/tuist_web/live/generate_runs_live.ex
+++ b/server/lib/tuist_web/live/generate_runs_live.ex
@@ -225,14 +225,6 @@ defmodule TuistWeb.GenerateRunsLive do
 
   defp normalize_command_filter(filter), do: filter
 
-  def sort_icon("desc") do
-    "square_rounded_arrow_down"
-  end
-
-  def sort_icon("asc") do
-    "square_rounded_arrow_up"
-  end
-
   def column_patch_sort(
         %{uri: uri, generate_runs_sort_by: generate_runs_sort_by, generate_runs_sort_order: generate_runs_sort_order} =
           _assigns,

--- a/server/lib/tuist_web/live/generate_runs_live.html.heex
+++ b/server/lib/tuist_web/live/generate_runs_live.html.heex
@@ -91,10 +91,7 @@
           :let={generate_run}
           label={dgettext("dashboard_builds", "Duration")}
           patch={@generate_runs_sort_by == "duration" && column_patch_sort(assigns, "duration")}
-          icon={
-            @generate_runs_sort_by == "duration" &&
-              sort_icon(@generate_runs_sort_order)
-          }
+          sort_order={@generate_runs_sort_by == "duration" && @generate_runs_sort_order}
         >
           <.text_cell
             label={
@@ -110,10 +107,7 @@
           :let={generate_run}
           label={dgettext("dashboard_builds", "Ran at")}
           patch={@generate_runs_sort_by == "ran_at" && column_patch_sort(assigns, "ran_at")}
-          icon={
-            @generate_runs_sort_by == "ran_at" &&
-              sort_icon(@generate_runs_sort_order)
-          }
+          sort_order={@generate_runs_sort_by == "ran_at" && @generate_runs_sort_order}
         >
           <.text_cell sublabel={Tuist.Utilities.DateFormatter.from_now(generate_run.ran_at)} />
         </:col>

--- a/server/lib/tuist_web/live/gradle_build_live.ex
+++ b/server/lib/tuist_web/live/gradle_build_live.ex
@@ -307,9 +307,6 @@ defmodule TuistWeb.GradleBuildLive do
 
   defp ensure_allowed_cacheable_sort_by(_), do: :duration_ms
 
-  def sort_icon("desc"), do: "square_rounded_arrow_down"
-  def sort_icon("asc"), do: "square_rounded_arrow_up"
-
   def sort_order_patch_value(category, current_category, current_order) do
     if category == current_category do
       if current_order == "asc", do: "desc", else: "asc"

--- a/server/lib/tuist_web/live/gradle_build_live.html.heex
+++ b/server/lib/tuist_web/live/gradle_build_live.html.heex
@@ -241,7 +241,7 @@
               @tasks_sort_by == "task_path" &&
                 "?#{@uri.query |> Query.put("tasks-sort-by", "task_path") |> Query.put("tasks-sort-order", sort_order_patch_value("task_path", @tasks_sort_by, @tasks_sort_order)) |> Query.drop("tasks-page")}"
             }
-            icon={@tasks_sort_by == "task_path" && sort_icon(@tasks_sort_order)}
+            sort_order={@tasks_sort_by == "task_path" && @tasks_sort_order}
           >
             <.text_cell label={task.task_path} />
           </:col>
@@ -259,7 +259,7 @@
               @tasks_sort_by == "started_at" &&
                 "?#{@uri.query |> Query.put("tasks-sort-by", "started_at") |> Query.put("tasks-sort-order", sort_order_patch_value("started_at", @tasks_sort_by, @tasks_sort_order)) |> Query.drop("tasks-page")}"
             }
-            icon={@tasks_sort_by == "started_at" && sort_icon(@tasks_sort_order)}
+            sort_order={@tasks_sort_by == "started_at" && @tasks_sort_order}
           >
             <.text_cell label={started_after(task, @build_started_at)} />
           </:col>
@@ -270,7 +270,7 @@
               @tasks_sort_by == "duration_ms" &&
                 "?#{@uri.query |> Query.put("tasks-sort-by", "duration_ms") |> Query.put("tasks-sort-order", sort_order_patch_value("duration_ms", @tasks_sort_by, @tasks_sort_order)) |> Query.drop("tasks-page")}"
             }
-            icon={@tasks_sort_by == "duration_ms" && sort_icon(@tasks_sort_order)}
+            sort_order={@tasks_sort_by == "duration_ms" && @tasks_sort_order}
           >
             <.text_cell label={format_duration(task.duration_ms)} icon="history" />
           </:col>
@@ -617,9 +617,8 @@
                 @cacheable_tasks_sort_by == "cache_artifact_size" &&
                   "?#{@uri.query |> Query.put("cacheable-tasks-sort-by", "cache_artifact_size") |> Query.put("cacheable-tasks-sort-order", sort_order_patch_value("cache_artifact_size", @cacheable_tasks_sort_by, @cacheable_tasks_sort_order)) |> Query.drop("cacheable-tasks-page")}"
               }
-              icon={
-                @cacheable_tasks_sort_by == "cache_artifact_size" &&
-                  sort_icon(@cacheable_tasks_sort_order)
+              sort_order={
+                @cacheable_tasks_sort_by == "cache_artifact_size" && @cacheable_tasks_sort_order
               }
             >
               <.text_cell label={
@@ -635,9 +634,8 @@
                 @cacheable_tasks_sort_by == "duration_ms" &&
                   "?#{@uri.query |> Query.put("cacheable-tasks-sort-by", "duration_ms") |> Query.put("cacheable-tasks-sort-order", sort_order_patch_value("duration_ms", @cacheable_tasks_sort_by, @cacheable_tasks_sort_order)) |> Query.drop("cacheable-tasks-page")}"
               }
-              icon={
-                @cacheable_tasks_sort_by == "duration_ms" &&
-                  sort_icon(@cacheable_tasks_sort_order)
+              sort_order={
+                @cacheable_tasks_sort_by == "duration_ms" && @cacheable_tasks_sort_order
               }
             >
               <.text_cell label={format_duration(task.duration_ms)} icon="history" />

--- a/server/lib/tuist_web/live/gradle_build_runs_live.ex
+++ b/server/lib/tuist_web/live/gradle_build_runs_live.ex
@@ -182,9 +182,6 @@ defmodule TuistWeb.GradleBuildRunsLive do
     |> assign(:build_runs_page_count, meta.total_pages)
   end
 
-  def sort_icon("desc"), do: "square_rounded_arrow_down"
-  def sort_icon("asc"), do: "square_rounded_arrow_up"
-
   def column_patch_sort(
         %{uri: uri, build_runs_sort_by: build_runs_sort_by, build_runs_sort_order: build_runs_sort_order},
         column_value

--- a/server/lib/tuist_web/live/gradle_build_runs_live.html.heex
+++ b/server/lib/tuist_web/live/gradle_build_runs_live.html.heex
@@ -120,10 +120,7 @@
               @build_runs_sort_by == "duration" &&
                 TuistWeb.GradleBuildRunsLive.column_patch_sort(assigns, "duration")
             }
-            icon={
-              @build_runs_sort_by == "duration" &&
-                TuistWeb.GradleBuildRunsLive.sort_icon(@build_runs_sort_order)
-            }
+            sort_order={@build_runs_sort_by == "duration" && @build_runs_sort_order}
           >
             <.text_cell
               label={
@@ -168,10 +165,7 @@
               @build_runs_sort_by == "ran-at" &&
                 TuistWeb.GradleBuildRunsLive.column_patch_sort(assigns, "ran-at")
             }
-            icon={
-              @build_runs_sort_by == "ran-at" &&
-                TuistWeb.GradleBuildRunsLive.sort_icon(@build_runs_sort_order)
-            }
+            sort_order={@build_runs_sort_by == "ran-at" && @build_runs_sort_order}
           >
             <.text_cell sublabel={Tuist.Utilities.DateFormatter.from_now(build.inserted_at)} />
           </:col>

--- a/server/lib/tuist_web/live/quarantined_tests_live.ex
+++ b/server/lib/tuist_web/live/quarantined_tests_live.ex
@@ -287,9 +287,6 @@ defmodule TuistWeb.QuarantinedTestsLive do
   defp selected_values(%{muted_values: values}, "muted"), do: values
   defp selected_values(%{skipped_values: values}, "skipped"), do: values
 
-  defp sort_icon("asc"), do: "square_rounded_arrow_up"
-  defp sort_icon("desc"), do: "square_rounded_arrow_down"
-
   defp toggle_sort_order("asc"), do: "desc"
   defp toggle_sort_order("desc"), do: "asc"
 

--- a/server/lib/tuist_web/live/quarantined_tests_live.html.heex
+++ b/server/lib/tuist_web/live/quarantined_tests_live.html.heex
@@ -316,10 +316,7 @@
               @quarantined_tests_sort_by == "name" &&
                 column_sort_patch(assigns, "name")
             }
-            icon={
-              @quarantined_tests_sort_by == "name" &&
-                sort_icon(@quarantined_tests_sort_order)
-            }
+            sort_order={@quarantined_tests_sort_by == "name" && @quarantined_tests_sort_order}
           >
             <.text_and_description_cell
               label={test_case.name}
@@ -394,9 +391,8 @@
               @quarantined_tests_sort_by == "last_ran_at" &&
                 column_sort_patch(assigns, "last_ran_at")
             }
-            icon={
-              @quarantined_tests_sort_by == "last_ran_at" &&
-                sort_icon(@quarantined_tests_sort_order)
+            sort_order={
+              @quarantined_tests_sort_by == "last_ran_at" && @quarantined_tests_sort_order
             }
           >
             <.text_cell sublabel={Tuist.Utilities.DateFormatter.from_now(test_case.last_ran_at)} />

--- a/server/lib/tuist_web/live/run_detail_live.ex
+++ b/server/lib/tuist_web/live/run_detail_live.ex
@@ -127,21 +127,6 @@ defmodule TuistWeb.RunDetailLive do
      |> push_event("close-popover", %{id: "all", all: true})}
   end
 
-  def handle_event(
-        "toggle-expand",
-        %{"row-key" => target_name},
-        %{assigns: %{expanded_target_names: expanded_target_names}} = socket
-      ) do
-    updated_expanded_names =
-      if MapSet.member?(expanded_target_names, target_name) do
-        MapSet.delete(expanded_target_names, target_name)
-      else
-        MapSet.put(expanded_target_names, target_name)
-      end
-
-    {:noreply, assign(socket, :expanded_target_names, updated_expanded_names)}
-  end
-
   defp selected_tab(params) do
     tab = params["tab"]
 

--- a/server/lib/tuist_web/live/run_detail_live.ex
+++ b/server/lib/tuist_web/live/run_detail_live.ex
@@ -142,14 +142,6 @@ defmodule TuistWeb.RunDetailLive do
     {:noreply, assign(socket, :expanded_target_names, updated_expanded_names)}
   end
 
-  def sort_icon("desc") do
-    "square_rounded_arrow_down"
-  end
-
-  def sort_icon("asc") do
-    "square_rounded_arrow_up"
-  end
-
   defp selected_tab(params) do
     tab = params["tab"]
 

--- a/server/lib/tuist_web/live/runner_jobs_live.ex
+++ b/server/lib/tuist_web/live/runner_jobs_live.ex
@@ -585,9 +585,6 @@ defmodule TuistWeb.RunnerJobsLive do
   def sort_by_label("duration"), do: dgettext("dashboard_runners", "Duration")
   def sort_by_label(_enqueued_default), do: dgettext("dashboard_runners", "Enqueued at")
 
-  def sort_icon("asc"), do: "square_rounded_arrow_up"
-  def sort_icon(_desc), do: "square_rounded_arrow_down"
-
   @doc """
   Builds the patch URL for a sortable column header. Clicking the
   already-active column toggles asc/desc; clicking a different

--- a/server/lib/tuist_web/live/runner_jobs_live.html.heex
+++ b/server/lib/tuist_web/live/runner_jobs_live.html.heex
@@ -577,7 +577,7 @@
             :let={job}
             label={dgettext("dashboard_runners", "Job")}
             patch={TuistWeb.RunnerJobsLive.column_sort_patch(assigns, "job")}
-            icon={@sort_by == "job" && TuistWeb.RunnerJobsLive.sort_icon(@sort_order)}
+            sort_order={@sort_by == "job" && @sort_order}
           >
             <.text_cell label={if(job.job_name == "", do: "–", else: job.job_name)} />
           </:col>
@@ -585,7 +585,7 @@
             :let={job}
             label={dgettext("dashboard_runners", "Workflow")}
             patch={TuistWeb.RunnerJobsLive.column_sort_patch(assigns, "workflow")}
-            icon={@sort_by == "workflow" && TuistWeb.RunnerJobsLive.sort_icon(@sort_order)}
+            sort_order={@sort_by == "workflow" && @sort_order}
           >
             <.text_cell label={
               if(job.workflow_name == "",
@@ -638,7 +638,7 @@
             :let={job}
             label={dgettext("dashboard_runners", "Duration")}
             patch={TuistWeb.RunnerJobsLive.column_sort_patch(assigns, "duration")}
-            icon={@sort_by == "duration" && TuistWeb.RunnerJobsLive.sort_icon(@sort_order)}
+            sort_order={@sort_by == "duration" && @sort_order}
           >
             <.text_cell
               icon="history"
@@ -653,7 +653,7 @@
             :let={job}
             label={dgettext("dashboard_runners", "Enqueued at")}
             patch={TuistWeb.RunnerJobsLive.column_sort_patch(assigns, "enqueued")}
-            icon={@sort_by == "enqueued" && TuistWeb.RunnerJobsLive.sort_icon(@sort_order)}
+            sort_order={@sort_by == "enqueued" && @sort_order}
           >
             <.text_cell label={Tuist.Utilities.DateFormatter.from_now(job.enqueued_at)} />
           </:col>

--- a/server/lib/tuist_web/live/runner_workflow_live.ex
+++ b/server/lib/tuist_web/live/runner_workflow_live.ex
@@ -267,9 +267,6 @@ defmodule TuistWeb.RunnerWorkflowLive do
   def sort_by_label("duration"), do: dgettext("dashboard_runners", "Duration")
   def sort_by_label(_enqueued_default), do: dgettext("dashboard_runners", "Enqueued at")
 
-  def sort_icon("asc"), do: "square_rounded_arrow_up"
-  def sort_icon(_desc), do: "square_rounded_arrow_down"
-
   def column_sort_patch(assigns, column) do
     new_order =
       cond do

--- a/server/lib/tuist_web/live/runner_workflow_live.html.heex
+++ b/server/lib/tuist_web/live/runner_workflow_live.html.heex
@@ -321,7 +321,7 @@
             :let={job}
             label={dgettext("dashboard_runners", "Job")}
             patch={TuistWeb.RunnerWorkflowLive.column_sort_patch(assigns, "job")}
-            icon={@sort_by == "job" && TuistWeb.RunnerWorkflowLive.sort_icon(@sort_order)}
+            sort_order={@sort_by == "job" && @sort_order}
           >
             <.text_cell label={if(job.job_name == "", do: "–", else: job.job_name)} />
           </:col>
@@ -354,7 +354,7 @@
             :let={job}
             label={dgettext("dashboard_runners", "Duration")}
             patch={TuistWeb.RunnerWorkflowLive.column_sort_patch(assigns, "duration")}
-            icon={@sort_by == "duration" && TuistWeb.RunnerWorkflowLive.sort_icon(@sort_order)}
+            sort_order={@sort_by == "duration" && @sort_order}
           >
             <.text_cell
               icon="history"
@@ -369,7 +369,7 @@
             :let={job}
             label={dgettext("dashboard_runners", "Enqueued at")}
             patch={TuistWeb.RunnerWorkflowLive.column_sort_patch(assigns, "enqueued")}
-            icon={@sort_by == "enqueued" && TuistWeb.RunnerWorkflowLive.sort_icon(@sort_order)}
+            sort_order={@sort_by == "enqueued" && @sort_order}
           >
             <.text_cell label={Tuist.Utilities.DateFormatter.from_now(job.enqueued_at)} />
           </:col>

--- a/server/lib/tuist_web/live/runner_workflows_live.ex
+++ b/server/lib/tuist_web/live/runner_workflows_live.ex
@@ -268,9 +268,6 @@ defmodule TuistWeb.RunnerWorkflowsLive do
   defp toggle_sort_order("asc"), do: "desc"
   defp toggle_sort_order(_desc), do: "asc"
 
-  def sort_icon("asc"), do: "square_rounded_arrow_up"
-  def sort_icon(_desc), do: "square_rounded_arrow_down"
-
   def sort_by_label("jobs"), do: dgettext("dashboard_runners", "Jobs")
   def sort_by_label("success_rate"), do: dgettext("dashboard_runners", "Success rate")
   def sort_by_label("avg_duration"), do: dgettext("dashboard_runners", "Avg duration")

--- a/server/lib/tuist_web/live/runner_workflows_live.html.heex
+++ b/server/lib/tuist_web/live/runner_workflows_live.html.heex
@@ -353,7 +353,7 @@
             :let={w}
             label={dgettext("dashboard_runners", "Workflow")}
             patch={TuistWeb.RunnerWorkflowsLive.column_sort_patch(assigns, "workflow")}
-            icon={@sort_by == "workflow" && TuistWeb.RunnerWorkflowsLive.sort_icon(@sort_order)}
+            sort_order={@sort_by == "workflow" && @sort_order}
           >
             <.text_cell label={
               if(w.workflow_name == "",
@@ -374,7 +374,7 @@
             :let={w}
             label={dgettext("dashboard_runners", "Jobs")}
             patch={TuistWeb.RunnerWorkflowsLive.column_sort_patch(assigns, "jobs")}
-            icon={@sort_by == "jobs" && TuistWeb.RunnerWorkflowsLive.sort_icon(@sort_order)}
+            sort_order={@sort_by == "jobs" && @sort_order}
           >
             <.text_cell label={Integer.to_string(w.total_jobs)} />
           </:col>
@@ -382,9 +382,7 @@
             :let={w}
             label={dgettext("dashboard_runners", "Success rate")}
             patch={TuistWeb.RunnerWorkflowsLive.column_sort_patch(assigns, "success_rate")}
-            icon={
-              @sort_by == "success_rate" && TuistWeb.RunnerWorkflowsLive.sort_icon(@sort_order)
-            }
+            sort_order={@sort_by == "success_rate" && @sort_order}
           >
             <.text_cell label={TuistWeb.RunnerWorkflowsLive.success_rate(w)} />
           </:col>
@@ -392,9 +390,7 @@
             :let={w}
             label={dgettext("dashboard_runners", "Avg duration")}
             patch={TuistWeb.RunnerWorkflowsLive.column_sort_patch(assigns, "avg_duration")}
-            icon={
-              @sort_by == "avg_duration" && TuistWeb.RunnerWorkflowsLive.sort_icon(@sort_order)
-            }
+            sort_order={@sort_by == "avg_duration" && @sort_order}
           >
             <.text_cell
               icon="history"

--- a/server/lib/tuist_web/live/test_case_live.ex
+++ b/server/lib/tuist_web/live/test_case_live.ex
@@ -443,9 +443,6 @@ defmodule TuistWeb.TestCaseLive do
     "?#{uri.query |> Query.put("sort_by", sort_by) |> Query.drop("page")}"
   end
 
-  defp sort_icon("asc"), do: "square_rounded_arrow_up"
-  defp sort_icon("desc"), do: "square_rounded_arrow_down"
-
   defp toggle_sort_order("asc"), do: "desc"
   defp toggle_sort_order("desc"), do: "asc"
 

--- a/server/lib/tuist_web/live/test_case_live.html.heex
+++ b/server/lib/tuist_web/live/test_case_live.html.heex
@@ -567,10 +567,7 @@
             @test_case_runs_sort_by == "duration" &&
               column_sort_patch(assigns, "duration")
           }
-          icon={
-            @test_case_runs_sort_by == "duration" &&
-              sort_icon(@test_case_runs_sort_order)
-          }
+          sort_order={@test_case_runs_sort_by == "duration" && @test_case_runs_sort_order}
         >
           <.text_cell
             label={
@@ -588,10 +585,7 @@
             @test_case_runs_sort_by == "ran_at" &&
               column_sort_patch(assigns, "ran_at")
           }
-          icon={
-            @test_case_runs_sort_by == "ran_at" &&
-              sort_icon(@test_case_runs_sort_order)
-          }
+          sort_order={@test_case_runs_sort_by == "ran_at" && @test_case_runs_sort_order}
         >
           <.text_cell sublabel={Tuist.Utilities.DateFormatter.from_now(test_case_run.ran_at)} />
         </:col>

--- a/server/lib/tuist_web/live/test_cases_live.ex
+++ b/server/lib/tuist_web/live/test_cases_live.ex
@@ -481,9 +481,6 @@ defmodule TuistWeb.TestCasesLive do
 
   defp convert_trait_filter(filter), do: filter
 
-  defp sort_icon("asc"), do: "square_rounded_arrow_up"
-  defp sort_icon("desc"), do: "square_rounded_arrow_down"
-
   defp toggle_sort_order("asc"), do: "desc"
   defp toggle_sort_order("desc"), do: "asc"
 

--- a/server/lib/tuist_web/live/test_cases_live.html.heex
+++ b/server/lib/tuist_web/live/test_cases_live.html.heex
@@ -554,10 +554,7 @@
               @test_cases_sort_by == "name" &&
                 column_sort_patch(assigns, "name")
             }
-            icon={
-              @test_cases_sort_by == "name" &&
-                sort_icon(@test_cases_sort_order)
-            }
+            sort_order={@test_cases_sort_by == "name" && @test_cases_sort_order}
           >
             <div data-part="cell" data-type="text_and_description">
               <div data-part="column">
@@ -607,10 +604,7 @@
               @test_cases_sort_by == "avg_duration" &&
                 column_sort_patch(assigns, "avg_duration")
             }
-            icon={
-              @test_cases_sort_by == "avg_duration" &&
-                sort_icon(@test_cases_sort_order)
-            }
+            sort_order={@test_cases_sort_by == "avg_duration" && @test_cases_sort_order}
           >
             <.text_cell
               label={
@@ -644,10 +638,7 @@
               @test_cases_sort_by == "last_ran_at" &&
                 column_sort_patch(assigns, "last_ran_at")
             }
-            icon={
-              @test_cases_sort_by == "last_ran_at" &&
-                sort_icon(@test_cases_sort_order)
-            }
+            sort_order={@test_cases_sort_by == "last_ran_at" && @test_cases_sort_order}
           >
             <.text_cell sublabel={Tuist.Utilities.DateFormatter.from_now(test_case.last_ran_at)} />
           </:col>

--- a/server/lib/tuist_web/live/test_run_live.ex
+++ b/server/lib/tuist_web/live/test_run_live.ex
@@ -248,14 +248,6 @@ defmodule TuistWeb.TestRunLive do
      |> push_event("close-popover", %{id: "all", all: true})}
   end
 
-  def sort_icon("desc") do
-    "square_rounded_arrow_down"
-  end
-
-  def sort_icon("asc") do
-    "square_rounded_arrow_up"
-  end
-
   defp selected_tab(params) do
     tab = params["tab"]
 

--- a/server/lib/tuist_web/live/test_run_live.ex
+++ b/server/lib/tuist_web/live/test_run_live.ex
@@ -201,21 +201,6 @@ defmodule TuistWeb.TestRunLive do
     {:noreply, socket}
   end
 
-  def handle_event(
-        "toggle-expand",
-        %{"row-key" => target_name},
-        %{assigns: %{expanded_target_names: expanded_target_names}} = socket
-      ) do
-    updated_expanded_names =
-      if MapSet.member?(expanded_target_names, target_name) do
-        MapSet.delete(expanded_target_names, target_name)
-      else
-        MapSet.put(expanded_target_names, target_name)
-      end
-
-    {:noreply, assign(socket, :expanded_target_names, updated_expanded_names)}
-  end
-
   def handle_event("add_filter", %{"value" => filter_id}, socket) do
     updated_params =
       filter_id

--- a/server/lib/tuist_web/live/test_run_live.html.heex
+++ b/server/lib/tuist_web/live/test_run_live.html.heex
@@ -1131,10 +1131,7 @@
               @test_cases_sort_by == "name" &&
                 test_cases_column_patch_sort(assigns, "name")
             }
-            icon={
-              @test_cases_sort_by == "name" &&
-                sort_icon(@test_cases_sort_order)
-            }
+            sort_order={@test_cases_sort_by == "name" && @test_cases_sort_order}
           >
             <div data-part="cell" data-type="text_and_description">
               <div data-part="column">
@@ -1194,10 +1191,7 @@
               @test_cases_sort_by == "duration" &&
                 test_cases_column_patch_sort(assigns, "duration")
             }
-            icon={
-              @test_cases_sort_by == "duration" &&
-                sort_icon(@test_cases_sort_order)
-            }
+            sort_order={@test_cases_sort_by == "duration" && @test_cases_sort_order}
           >
             <.text_cell
               label={
@@ -1338,10 +1332,7 @@
               @test_suites_sort_by == "name" &&
                 test_suites_column_patch_sort(assigns, "name")
             }
-            icon={
-              @test_suites_sort_by == "name" &&
-                sort_icon(@test_suites_sort_order)
-            }
+            sort_order={@test_suites_sort_by == "name" && @test_suites_sort_order}
           >
             <div data-part="cell" data-type="text_and_description">
               <div data-part="column">
@@ -1374,10 +1365,7 @@
               @test_suites_sort_by == "test_case_count" &&
                 test_suites_column_patch_sort(assigns, "test_case_count")
             }
-            icon={
-              @test_suites_sort_by == "test_case_count" &&
-                sort_icon(@test_suites_sort_order)
-            }
+            sort_order={@test_suites_sort_by == "test_case_count" && @test_suites_sort_order}
           >
             <.text_cell label={"#{test_suite.test_case_count}"} />
           </:col>
@@ -1388,9 +1376,8 @@
               @test_suites_sort_by == "avg_test_case_duration" &&
                 test_suites_column_patch_sort(assigns, "avg_test_case_duration")
             }
-            icon={
-              @test_suites_sort_by == "avg_test_case_duration" &&
-                sort_icon(@test_suites_sort_order)
+            sort_order={
+              @test_suites_sort_by == "avg_test_case_duration" && @test_suites_sort_order
             }
           >
             <.text_cell
@@ -1426,10 +1413,7 @@
               @test_suites_sort_by == "duration" &&
                 test_suites_column_patch_sort(assigns, "duration")
             }
-            icon={
-              @test_suites_sort_by == "duration" &&
-                sort_icon(@test_suites_sort_order)
-            }
+            sort_order={@test_suites_sort_by == "duration" && @test_suites_sort_order}
           >
             <.text_cell
               label={
@@ -1564,10 +1548,7 @@
               @test_modules_sort_by == "name" &&
                 test_modules_column_patch_sort(assigns, "name")
             }
-            icon={
-              @test_modules_sort_by == "name" &&
-                sort_icon(@test_modules_sort_order)
-            }
+            sort_order={@test_modules_sort_by == "name" && @test_modules_sort_order}
           >
             <div data-part="cell" data-type="text_and_description">
               <div data-part="column">
@@ -1600,10 +1581,7 @@
               @test_modules_sort_by == "test_suite_count" &&
                 test_modules_column_patch_sort(assigns, "test_suite_count")
             }
-            icon={
-              @test_modules_sort_by == "test_suite_count" &&
-                sort_icon(@test_modules_sort_order)
-            }
+            sort_order={@test_modules_sort_by == "test_suite_count" && @test_modules_sort_order}
           >
             <.text_cell label={"#{test_module.test_suite_count}"} />
           </:col>
@@ -1614,10 +1592,7 @@
               @test_modules_sort_by == "test_case_count" &&
                 test_modules_column_patch_sort(assigns, "test_case_count")
             }
-            icon={
-              @test_modules_sort_by == "test_case_count" &&
-                sort_icon(@test_modules_sort_order)
-            }
+            sort_order={@test_modules_sort_by == "test_case_count" && @test_modules_sort_order}
           >
             <.text_cell label={"#{test_module.test_case_count}"} />
           </:col>
@@ -1628,9 +1603,8 @@
               @test_modules_sort_by == "avg_test_case_duration" &&
                 test_modules_column_patch_sort(assigns, "avg_test_case_duration")
             }
-            icon={
-              @test_modules_sort_by == "avg_test_case_duration" &&
-                sort_icon(@test_modules_sort_order)
+            sort_order={
+              @test_modules_sort_by == "avg_test_case_duration" && @test_modules_sort_order
             }
           >
             <.text_cell
@@ -1661,10 +1635,7 @@
               @test_modules_sort_by == "duration" &&
                 test_modules_column_patch_sort(assigns, "duration")
             }
-            icon={
-              @test_modules_sort_by == "duration" &&
-                sort_icon(@test_modules_sort_order)
-            }
+            sort_order={@test_modules_sort_by == "duration" && @test_modules_sort_order}
           >
             <.text_cell
               label={

--- a/server/lib/tuist_web/live/xcode_build_runs_live.ex
+++ b/server/lib/tuist_web/live/xcode_build_runs_live.ex
@@ -143,9 +143,6 @@ defmodule TuistWeb.XcodeBuildRunsLive do
     end
   end
 
-  def sort_icon("desc"), do: "square_rounded_arrow_down"
-  def sort_icon("asc"), do: "square_rounded_arrow_up"
-
   def column_patch_sort(
         %{uri: uri, build_runs_sort_by: build_runs_sort_by, build_runs_sort_order: build_runs_sort_order},
         column_value

--- a/server/lib/tuist_web/live/xcode_build_runs_live.html.heex
+++ b/server/lib/tuist_web/live/xcode_build_runs_live.html.heex
@@ -137,10 +137,7 @@
               @build_runs_sort_by == "duration" &&
                 TuistWeb.XcodeBuildRunsLive.column_patch_sort(assigns, "duration")
             }
-            icon={
-              @build_runs_sort_by == "duration" &&
-                TuistWeb.XcodeBuildRunsLive.sort_icon(@build_runs_sort_order)
-            }
+            sort_order={@build_runs_sort_by == "duration" && @build_runs_sort_order}
           >
             <.text_cell
               label={
@@ -167,10 +164,7 @@
               @build_runs_sort_by == "ran-at" &&
                 TuistWeb.XcodeBuildRunsLive.column_patch_sort(assigns, "ran-at")
             }
-            icon={
-              @build_runs_sort_by == "ran-at" &&
-                TuistWeb.XcodeBuildRunsLive.sort_icon(@build_runs_sort_order)
-            }
+            sort_order={@build_runs_sort_by == "ran-at" && @build_runs_sort_order}
           >
             <.text_cell sublabel={Tuist.Utilities.DateFormatter.from_now(build_run.inserted_at)} />
           </:col>

--- a/server/priv/gettext/dashboard_builds.pot
+++ b/server/priv/gettext/dashboard_builds.pot
@@ -11,13 +11,13 @@
 msgid ""
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.html.heex:875
+#: lib/tuist_web/live/build_run_live.html.heex:867
 #: lib/tuist_web/live/generate_runs_live.html.heex:63
 #, elixir-autogen, elixir-format
 msgid "%{hit_rate}%"
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.ex:716
+#: lib/tuist_web/live/build_run_live.ex:686
 #, elixir-autogen, elixir-format
 msgid "%{message} in %{link}"
 msgstr ""
@@ -27,13 +27,13 @@ msgstr ""
 msgid "%{percentage}%"
 msgstr ""
 
-#: lib/tuist_web/live/generate_runs_live.html.heex:101
+#: lib/tuist_web/live/generate_runs_live.html.heex:98
 #: lib/tuist_web/live/run_detail_live.html.heex:180
 #, elixir-autogen, elixir-format
 msgid "%{run_duration}s"
 msgstr ""
 
-#: lib/tuist_web/components/runs/module_cache_tab.ex:341
+#: lib/tuist_web/components/runs/module_cache_tab.ex:338
 #, elixir-autogen, elixir-format
 msgid "Additional strings"
 msgstr ""
@@ -59,19 +59,19 @@ msgstr ""
 msgid "Avg. build duration"
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.html.heex:1043
+#: lib/tuist_web/live/build_run_live.html.heex:1035
 #, elixir-autogen, elixir-format
 msgid "Avg. latency reading cache keys"
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.html.heex:1099
+#: lib/tuist_web/live/build_run_live.html.heex:1091
 #, elixir-autogen, elixir-format
 msgid "Avg. latency writing cache keys"
 msgstr ""
 
-#: lib/tuist_web/live/generate_runs_live.ex:295
+#: lib/tuist_web/live/generate_runs_live.ex:287
 #: lib/tuist_web/live/generate_runs_live.html.heex:84
-#: lib/tuist_web/live/xcode_build_runs_live.ex:241
+#: lib/tuist_web/live/xcode_build_runs_live.ex:238
 #: lib/tuist_web/live/xcode_build_runs_live.html.heex:121
 #, elixir-autogen, elixir-format
 msgid "Branch"
@@ -94,11 +94,11 @@ msgstr ""
 msgid "Build Runs"
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.ex:964
+#: lib/tuist_web/live/build_run_live.ex:926
 #: lib/tuist_web/live/build_run_live.html.heex:268
 #: lib/tuist_web/live/build_run_live.html.heex:475
 #: lib/tuist_web/live/build_run_live.html.heex:491
-#: lib/tuist_web/live/build_run_live.html.heex:537
+#: lib/tuist_web/live/build_run_live.html.heex:534
 #: lib/tuist_web/live/xcode_builds_live.html.heex:662
 #: lib/tuist_web/live/xcode_builds_live.html.heex:716
 #, elixir-autogen, elixir-format
@@ -127,7 +127,7 @@ msgstr ""
 msgid "Build:"
 msgstr ""
 
-#: lib/tuist_web/components/runs/module_cache_tab.ex:335
+#: lib/tuist_web/components/runs/module_cache_tab.ex:332
 #, elixir-autogen, elixir-format
 msgid "Buildable folders"
 msgstr ""
@@ -148,32 +148,32 @@ msgstr ""
 msgid "Built by"
 msgstr ""
 
-#: lib/tuist_web/components/runs/module_cache_tab.ex:241
+#: lib/tuist_web/components/runs/module_cache_tab.ex:238
 #, elixir-autogen, elixir-format
 msgid "Bundle ID"
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.html.heex:908
+#: lib/tuist_web/live/build_run_live.html.heex:900
 #, elixir-autogen, elixir-format
 msgid "CAS Outputs"
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.html.heex:1265
+#: lib/tuist_web/live/build_run_live.html.heex:1253
 #, elixir-autogen, elixir-format
 msgid "CAS output"
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.html.heex:1377
+#: lib/tuist_web/live/build_run_live.html.heex:1365
 #, elixir-autogen, elixir-format
 msgid "CAS outputs"
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.html.heex:1611
+#: lib/tuist_web/live/build_run_live.html.heex:1592
 #, elixir-autogen, elixir-format
 msgid "CAS outputs will appear here when using Tuist cache"
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.html.heex:1329
+#: lib/tuist_web/live/build_run_live.html.heex:1317
 #, elixir-autogen, elixir-format
 msgid "CAS outputs:"
 msgstr ""
@@ -196,12 +196,12 @@ msgstr ""
 msgid "Cache Runs"
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.html.heex:833
+#: lib/tuist_web/live/build_run_live.html.heex:825
 #, elixir-autogen, elixir-format
 msgid "Cache Summary"
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.html.heex:884
+#: lib/tuist_web/live/build_run_live.html.heex:876
 #, elixir-autogen, elixir-format
 msgid "Cache downloads"
 msgstr ""
@@ -216,7 +216,7 @@ msgstr ""
 msgid "Cache hits"
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.html.heex:1228
+#: lib/tuist_web/live/build_run_live.html.heex:1219
 #, elixir-autogen, elixir-format
 msgid "Cache key"
 msgstr ""
@@ -226,17 +226,17 @@ msgstr ""
 msgid "Cache misses"
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.html.heex:892
+#: lib/tuist_web/live/build_run_live.html.heex:884
 #, elixir-autogen, elixir-format
 msgid "Cache uploads"
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.html.heex:903
+#: lib/tuist_web/live/build_run_live.html.heex:895
 #, elixir-autogen, elixir-format
 msgid "Cacheable Tasks"
 msgstr ""
 
-#: lib/tuist_web/components/runs/module_cache_tab.ex:401
+#: lib/tuist_web/components/runs/module_cache_tab.ex:395
 #, elixir-autogen, elixir-format
 msgid "Cacheable targets"
 msgstr ""
@@ -246,34 +246,34 @@ msgstr ""
 msgid "Cacheable targets:"
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.html.heex:974
+#: lib/tuist_web/live/build_run_live.html.heex:966
 #, elixir-autogen, elixir-format
 msgid "Cacheable tasks"
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.html.heex:852
+#: lib/tuist_web/live/build_run_live.html.heex:844
 #, elixir-autogen, elixir-format
 msgid "Cacheable tasks that were not found in cache."
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.html.heex:841
+#: lib/tuist_web/live/build_run_live.html.heex:833
 #, elixir-autogen, elixir-format
 msgid "Cacheable tasks that were retrieved from cache (local + remote)."
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.html.heex:1303
+#: lib/tuist_web/live/build_run_live.html.heex:1291
 #, elixir-autogen, elixir-format
 msgid "Cacheable tasks will appear here when using Tuist cache"
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.html.heex:926
+#: lib/tuist_web/live/build_run_live.html.heex:918
 #, elixir-autogen, elixir-format
 msgid "Cacheable tasks:"
 msgstr ""
 
 #: lib/tuist_web/live/build_run_live.html.heex:286
-#: lib/tuist_web/live/xcode_build_runs_live.ex:249
-#: lib/tuist_web/live/xcode_build_runs_live.html.heex:154
+#: lib/tuist_web/live/xcode_build_runs_live.ex:246
+#: lib/tuist_web/live/xcode_build_runs_live.html.heex:151
 #: lib/tuist_web/live/xcode_builds_live.ex:435
 #: lib/tuist_web/live/xcode_builds_live.html.heex:357
 #: lib/tuist_web/live/xcode_builds_live.html.heex:887
@@ -281,14 +281,14 @@ msgstr ""
 msgid "Category"
 msgstr ""
 
-#: lib/tuist_web/live/xcode_build_runs_live.ex:254
+#: lib/tuist_web/live/xcode_build_runs_live.ex:251
 #: lib/tuist_web/live/xcode_builds_live.html.heex:105
 #, elixir-autogen, elixir-format
 msgid "Clean"
 msgstr ""
 
 #: lib/tuist_web/live/build_run_live.html.heex:209
-#: lib/tuist_web/live/generate_runs_live.ex:274
+#: lib/tuist_web/live/generate_runs_live.ex:266
 #: lib/tuist_web/live/generate_runs_live.html.heex:58
 #: lib/tuist_web/live/run_detail_live.html.heex:115
 #, elixir-autogen, elixir-format
@@ -301,33 +301,33 @@ msgstr ""
 msgid "Commit SHA"
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.ex:935
-#: lib/tuist_web/live/build_run_live.ex:972
+#: lib/tuist_web/live/build_run_live.ex:897
+#: lib/tuist_web/live/build_run_live.ex:934
 #: lib/tuist_web/live/build_run_live.html.heex:476
 #: lib/tuist_web/live/build_run_live.html.heex:499
-#: lib/tuist_web/live/build_run_live.html.heex:558
-#: lib/tuist_web/live/build_run_live.html.heex:633
-#: lib/tuist_web/live/build_run_live.html.heex:640
-#: lib/tuist_web/live/build_run_live.html.heex:706
+#: lib/tuist_web/live/build_run_live.html.heex:554
+#: lib/tuist_web/live/build_run_live.html.heex:629
+#: lib/tuist_web/live/build_run_live.html.heex:636
+#: lib/tuist_web/live/build_run_live.html.heex:699
 #, elixir-autogen, elixir-format
 msgid "Compilation duration"
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.html.heex:1483
-#: lib/tuist_web/live/build_run_live.html.heex:1484
-#: lib/tuist_web/live/build_run_live.html.heex:1510
-#: lib/tuist_web/live/build_run_live.html.heex:1576
+#: lib/tuist_web/live/build_run_live.html.heex:1471
+#: lib/tuist_web/live/build_run_live.html.heex:1472
+#: lib/tuist_web/live/build_run_live.html.heex:1498
+#: lib/tuist_web/live/build_run_live.html.heex:1558
 #, elixir-autogen, elixir-format
 msgid "Compressed Size"
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.ex:1173
+#: lib/tuist_web/live/build_run_live.ex:1135
 #, elixir-autogen, elixir-format
 msgid "Compressed Size (MB)"
 msgstr ""
 
 #: lib/tuist_web/live/build_run_live.html.heex:224
-#: lib/tuist_web/live/xcode_build_runs_live.ex:216
+#: lib/tuist_web/live/xcode_build_runs_live.ex:213
 #: lib/tuist_web/live/xcode_build_runs_live.html.heex:91
 #, elixir-autogen, elixir-format
 msgid "Configuration"
@@ -343,7 +343,7 @@ msgstr ""
 msgid "Configuration:"
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.html.heex:1283
+#: lib/tuist_web/live/build_run_live.html.heex:1271
 #, elixir-autogen, elixir-format
 msgid "Copy"
 msgstr ""
@@ -353,41 +353,41 @@ msgstr ""
 msgid "Copy as JSON"
 msgstr ""
 
-#: lib/tuist_web/components/runs/module_cache_tab.ex:271
+#: lib/tuist_web/components/runs/module_cache_tab.ex:268
 #, elixir-autogen, elixir-format
 msgid "Copy files"
 msgstr ""
 
-#: lib/tuist_web/components/runs/module_cache_tab.ex:277
+#: lib/tuist_web/components/runs/module_cache_tab.ex:274
 #, elixir-autogen, elixir-format
 msgid "Core data models"
 msgstr ""
 
-#: lib/tuist_web/components/runs/module_cache_tab.ex:317
+#: lib/tuist_web/components/runs/module_cache_tab.ex:314
 #, elixir-autogen, elixir-format
 msgid "Dependencies"
 msgstr ""
 
-#: lib/tuist_web/components/runs/module_cache_tab.ex:299
+#: lib/tuist_web/components/runs/module_cache_tab.ex:296
 #, elixir-autogen, elixir-format
 msgid "Deployment target"
 msgstr ""
 
-#: lib/tuist_web/components/runs/module_cache_tab.ex:247
+#: lib/tuist_web/components/runs/module_cache_tab.ex:244
 #, elixir-autogen, elixir-format
 msgid "Destinations"
 msgstr ""
 
-#: lib/tuist_web/live/xcode_build_runs_live.html.heex:193
+#: lib/tuist_web/live/xcode_build_runs_live.html.heex:187
 #: lib/tuist_web/live/xcode_builds_live.ex:390
 #: lib/tuist_web/live/xcode_builds_live.html.heex:631
 #, elixir-autogen, elixir-format
 msgid "Device"
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.ex:1146
-#: lib/tuist_web/live/build_run_live.html.heex:1390
-#: lib/tuist_web/live/build_run_live.html.heex:1546
+#: lib/tuist_web/live/build_run_live.ex:1108
+#: lib/tuist_web/live/build_run_live.html.heex:1378
+#: lib/tuist_web/live/build_run_live.html.heex:1531
 #, elixir-autogen, elixir-format
 msgid "Download"
 msgstr ""
@@ -398,7 +398,7 @@ msgstr ""
 msgid "Download result"
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.html.heex:1431
+#: lib/tuist_web/live/build_run_live.html.heex:1419
 #, elixir-autogen, elixir-format
 msgid "Download throughput"
 msgstr ""
@@ -414,12 +414,12 @@ msgstr ""
 msgid "Duration"
 msgstr ""
 
-#: lib/tuist_web/components/runs/module_cache_tab.ex:311
+#: lib/tuist_web/components/runs/module_cache_tab.ex:308
 #, elixir-autogen, elixir-format
 msgid "Entitlements"
 msgstr ""
 
-#: lib/tuist_web/components/runs/module_cache_tab.ex:289
+#: lib/tuist_web/components/runs/module_cache_tab.ex:286
 #: lib/tuist_web/live/xcode_builds_live.ex:434
 #: lib/tuist_web/live/xcode_builds_live.html.heex:356
 #, elixir-autogen, elixir-format
@@ -433,8 +433,8 @@ msgstr ""
 
 #: lib/tuist_web/live/build_run_live.html.heex:188
 #: lib/tuist_web/live/build_run_live.html.heex:364
-#: lib/tuist_web/live/build_run_live.html.heex:789
-#: lib/tuist_web/live/build_run_live.html.heex:796
+#: lib/tuist_web/live/build_run_live.html.heex:781
+#: lib/tuist_web/live/build_run_live.html.heex:788
 #, elixir-autogen, elixir-format
 msgid "Errors"
 msgstr ""
@@ -444,18 +444,18 @@ msgstr ""
 msgid "Errors and Warnings"
 msgstr ""
 
-#: lib/tuist_web/components/runs/module_cache_tab.ex:256
+#: lib/tuist_web/components/runs/module_cache_tab.ex:253
 #, elixir-autogen, elixir-format
 msgid "External"
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.ex:1001
+#: lib/tuist_web/live/build_run_live.ex:963
 #: lib/tuist_web/live/build_run_live.html.heex:245
-#: lib/tuist_web/live/build_run_live.html.heex:585
-#: lib/tuist_web/live/generate_runs_live.ex:287
+#: lib/tuist_web/live/build_run_live.html.heex:581
+#: lib/tuist_web/live/generate_runs_live.ex:279
 #: lib/tuist_web/live/generate_runs_live.html.heex:81
 #: lib/tuist_web/live/run_detail_live.html.heex:144
-#: lib/tuist_web/live/xcode_build_runs_live.ex:231
+#: lib/tuist_web/live/xcode_build_runs_live.ex:228
 #: lib/tuist_web/live/xcode_build_runs_live.html.heex:107
 #: lib/tuist_web/live/xcode_builds_live.ex:446
 #: lib/tuist_web/live/xcode_builds_live.html.heex:864
@@ -470,110 +470,110 @@ msgstr ""
 msgid "Failed builds"
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.ex:732
+#: lib/tuist_web/live/build_run_live.ex:702
 #, elixir-autogen, elixir-format
 msgid "Failed compiling C file %{path}"
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.ex:735
-#: lib/tuist_web/live/build_run_live.ex:771
+#: lib/tuist_web/live/build_run_live.ex:705
+#: lib/tuist_web/live/build_run_live.ex:741
 #, elixir-autogen, elixir-format
 msgid "Failed compiling Swift file %{path}"
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.ex:768
+#: lib/tuist_web/live/build_run_live.ex:738
 #, elixir-autogen, elixir-format
 msgid "Failed compiling XIB file %{path}"
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.ex:750
+#: lib/tuist_web/live/build_run_live.ex:720
 #, elixir-autogen, elixir-format
 msgid "Failed compiling assets catalog %{path}"
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.ex:753
+#: lib/tuist_web/live/build_run_live.ex:723
 #, elixir-autogen, elixir-format
 msgid "Failed compiling storyboard %{path}"
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.ex:747
+#: lib/tuist_web/live/build_run_live.ex:717
 #, elixir-autogen, elixir-format
 msgid "Failed copying Swift libraries %{path}"
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.ex:762
+#: lib/tuist_web/live/build_run_live.ex:732
 #, elixir-autogen, elixir-format
 msgid "Failed copying resource file %{path}"
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.ex:741
+#: lib/tuist_web/live/build_run_live.ex:711
 #, elixir-autogen, elixir-format
 msgid "Failed creating static library %{path}"
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.ex:738
+#: lib/tuist_web/live/build_run_live.ex:708
 #, elixir-autogen, elixir-format
 msgid "Failed executing script %{script_name}"
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.ex:744
+#: lib/tuist_web/live/build_run_live.ex:714
 #, elixir-autogen, elixir-format
 msgid "Failed linking %{path}"
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.ex:759
+#: lib/tuist_web/live/build_run_live.ex:729
 #, elixir-autogen, elixir-format
 msgid "Failed linking storyboards %{path}"
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.ex:765
+#: lib/tuist_web/live/build_run_live.ex:735
 #, elixir-autogen, elixir-format
 msgid "Failed merging Swift module %{path}"
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.ex:774
+#: lib/tuist_web/live/build_run_live.ex:744
 #, elixir-autogen, elixir-format
 msgid "Failed precompiling bridging header %{path}"
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.ex:786
+#: lib/tuist_web/live/build_run_live.ex:756
 #, elixir-autogen, elixir-format
 msgid "Failed processing %{path}"
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.ex:780
+#: lib/tuist_web/live/build_run_live.ex:750
 #, elixir-autogen, elixir-format
 msgid "Failed validating %{path}"
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.ex:777
+#: lib/tuist_web/live/build_run_live.ex:747
 #, elixir-autogen, elixir-format
 msgid "Failed validating embedded binary %{path}"
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.ex:756
+#: lib/tuist_web/live/build_run_live.ex:726
 #, elixir-autogen, elixir-format
 msgid "Failed writing auxiliary file %{path}"
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.html.heex:632
-#: lib/tuist_web/live/build_run_live.html.heex:648
-#: lib/tuist_web/live/build_run_live.html.heex:672
+#: lib/tuist_web/live/build_run_live.html.heex:628
+#: lib/tuist_web/live/build_run_live.html.heex:644
+#: lib/tuist_web/live/build_run_live.html.heex:668
 #, elixir-autogen, elixir-format
 msgid "File"
 msgstr ""
 
 #: lib/tuist_web/live/build_run_live.html.heex:446
-#: lib/tuist_web/live/build_run_live.html.heex:611
+#: lib/tuist_web/live/build_run_live.html.heex:607
 #, elixir-autogen, elixir-format
 msgid "File Breakdown"
 msgstr ""
 
 #: lib/tuist_web/components/runs/module_cache_tab.ex:136
 #: lib/tuist_web/live/build_run_live.html.heex:508
-#: lib/tuist_web/live/build_run_live.html.heex:657
-#: lib/tuist_web/live/build_run_live.html.heex:1166
-#: lib/tuist_web/live/build_run_live.html.heex:1516
+#: lib/tuist_web/live/build_run_live.html.heex:653
+#: lib/tuist_web/live/build_run_live.html.heex:1158
+#: lib/tuist_web/live/build_run_live.html.heex:1504
 #: lib/tuist_web/live/generate_runs_live.html.heex:38
 #: lib/tuist_web/live/xcode_build_runs_live.html.heex:38
 #, elixir-autogen, elixir-format
@@ -586,62 +586,62 @@ msgstr ""
 msgid "Generate Runs"
 msgstr ""
 
-#: lib/tuist_web/components/runs/module_cache_tab.ex:192
+#: lib/tuist_web/components/runs/module_cache_tab.ex:189
 #, elixir-autogen, elixir-format
 msgid "Hash"
 msgstr ""
 
-#: lib/tuist_web/components/runs/module_cache_tab.ex:294
+#: lib/tuist_web/components/runs/module_cache_tab.ex:291
 #, elixir-autogen, elixir-format
 msgid "Headers"
 msgstr ""
 
-#: lib/tuist_web/components/runs/module_cache_tab.ex:170
-#: lib/tuist_web/live/build_run_live.ex:1121
-#: lib/tuist_web/live/build_run_live.ex:1364
-#: lib/tuist_web/live/build_run_live.html.heex:1203
-#: lib/tuist_web/live/run_detail_live.ex:356
-#: lib/tuist_web/live/run_detail_live.ex:389
-#: lib/tuist_web/live/test_run_live.ex:1119
+#: lib/tuist_web/components/runs/module_cache_tab.ex:167
+#: lib/tuist_web/live/build_run_live.ex:1083
+#: lib/tuist_web/live/build_run_live.ex:1326
+#: lib/tuist_web/live/build_run_live.html.heex:1194
+#: lib/tuist_web/live/run_detail_live.ex:333
+#: lib/tuist_web/live/run_detail_live.ex:366
+#: lib/tuist_web/live/test_run_live.ex:1096
 #, elixir-autogen, elixir-format
 msgid "Hit"
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.html.heex:861
-#: lib/tuist_web/live/generate_runs_live.ex:303
+#: lib/tuist_web/live/build_run_live.html.heex:853
+#: lib/tuist_web/live/generate_runs_live.ex:295
 #: lib/tuist_web/live/generate_runs_live.html.heex:61
 #, elixir-autogen, elixir-format
 msgid "Hit rate"
 msgstr ""
 
-#: lib/tuist_web/live/xcode_build_runs_live.ex:253
+#: lib/tuist_web/live/xcode_build_runs_live.ex:250
 #: lib/tuist_web/live/xcode_builds_live.html.heex:97
 #, elixir-autogen, elixir-format
 msgid "Incremental"
 msgstr ""
 
-#: lib/tuist_web/components/runs/module_cache_tab.ex:305
+#: lib/tuist_web/components/runs/module_cache_tab.ex:302
 #, elixir-autogen, elixir-format
 msgid "Info.plist"
 msgstr ""
 
 #: lib/tuist_web/live/build_run_live.html.heex:331
-#: lib/tuist_web/live/build_run_live.html.heex:1481
-#: lib/tuist_web/live/build_run_live.html.heex:1494
-#: lib/tuist_web/live/build_run_live.html.heex:1531
+#: lib/tuist_web/live/build_run_live.html.heex:1469
+#: lib/tuist_web/live/build_run_live.html.heex:1482
+#: lib/tuist_web/live/build_run_live.html.heex:1519
 #, elixir-autogen, elixir-format
 msgid "Key"
 msgstr ""
 
-#: lib/tuist_web/components/runs/module_cache_tab.ex:180
-#: lib/tuist_web/components/runs/module_cache_tab.ex:416
-#: lib/tuist_web/live/build_run_live.ex:1125
-#: lib/tuist_web/live/build_run_live.ex:1369
-#: lib/tuist_web/live/build_run_live.html.heex:991
-#: lib/tuist_web/live/build_run_live.html.heex:1206
-#: lib/tuist_web/live/run_detail_live.ex:361
-#: lib/tuist_web/live/run_detail_live.ex:394
-#: lib/tuist_web/live/test_run_live.ex:1124
+#: lib/tuist_web/components/runs/module_cache_tab.ex:177
+#: lib/tuist_web/components/runs/module_cache_tab.ex:410
+#: lib/tuist_web/live/build_run_live.ex:1087
+#: lib/tuist_web/live/build_run_live.ex:1331
+#: lib/tuist_web/live/build_run_live.html.heex:983
+#: lib/tuist_web/live/build_run_live.html.heex:1197
+#: lib/tuist_web/live/run_detail_live.ex:338
+#: lib/tuist_web/live/run_detail_live.ex:371
+#: lib/tuist_web/live/test_run_live.ex:1101
 #: lib/tuist_web/live/xcode_builds_live.ex:383
 #: lib/tuist_web/live/xcode_builds_live.ex:386
 #: lib/tuist_web/live/xcode_builds_live.html.heex:127
@@ -649,8 +649,8 @@ msgstr ""
 msgid "Local"
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.html.heex:781
-#: lib/tuist_web/live/build_run_live.html.heex:824
+#: lib/tuist_web/live/build_run_live.html.heex:773
+#: lib/tuist_web/live/build_run_live.html.heex:816
 #, elixir-autogen, elixir-format
 msgid "Looks like you're having a great day!"
 msgstr ""
@@ -660,15 +660,15 @@ msgstr ""
 msgid "Mac device"
 msgstr ""
 
-#: lib/tuist_web/components/runs/module_cache_tab.ex:186
-#: lib/tuist_web/components/runs/module_cache_tab.ex:442
-#: lib/tuist_web/live/build_run_live.ex:1127
-#: lib/tuist_web/live/build_run_live.ex:1370
-#: lib/tuist_web/live/build_run_live.html.heex:1019
-#: lib/tuist_web/live/build_run_live.html.heex:1218
-#: lib/tuist_web/live/run_detail_live.ex:362
-#: lib/tuist_web/live/run_detail_live.ex:395
-#: lib/tuist_web/live/test_run_live.ex:1125
+#: lib/tuist_web/components/runs/module_cache_tab.ex:183
+#: lib/tuist_web/components/runs/module_cache_tab.ex:436
+#: lib/tuist_web/live/build_run_live.ex:1089
+#: lib/tuist_web/live/build_run_live.ex:1332
+#: lib/tuist_web/live/build_run_live.html.heex:1011
+#: lib/tuist_web/live/build_run_live.html.heex:1209
+#: lib/tuist_web/live/run_detail_live.ex:339
+#: lib/tuist_web/live/run_detail_live.ex:372
+#: lib/tuist_web/live/test_run_live.ex:1102
 #, elixir-autogen, elixir-format
 msgid "Missed"
 msgstr ""
@@ -694,31 +694,31 @@ msgstr ""
 msgid "Module Cache"
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.ex:980
+#: lib/tuist_web/live/build_run_live.ex:942
 #, elixir-autogen, elixir-format
 msgid "Name"
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.html.heex:1609
+#: lib/tuist_web/live/build_run_live.html.heex:1590
 #, elixir-autogen, elixir-format
 msgid "No CAS outputs found"
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.html.heex:1301
+#: lib/tuist_web/live/build_run_live.html.heex:1289
 #, elixir-autogen, elixir-format
 msgid "No cacheable tasks found"
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.html.heex:1093
-#: lib/tuist_web/live/build_run_live.html.heex:1149
-#: lib/tuist_web/live/build_run_live.html.heex:1445
-#: lib/tuist_web/live/build_run_live.html.heex:1462
+#: lib/tuist_web/live/build_run_live.html.heex:1085
+#: lib/tuist_web/live/build_run_live.html.heex:1141
+#: lib/tuist_web/live/build_run_live.html.heex:1433
+#: lib/tuist_web/live/build_run_live.html.heex:1450
 #, elixir-autogen, elixir-format
 msgid "No data"
 msgstr ""
 
-#: lib/tuist_web/live/generate_runs_live.html.heex:131
-#: lib/tuist_web/live/xcode_build_runs_live.html.heex:215
+#: lib/tuist_web/live/generate_runs_live.html.heex:125
+#: lib/tuist_web/live/xcode_build_runs_live.html.heex:209
 #: lib/tuist_web/live/xcode_builds_live.html.heex:598
 #: lib/tuist_web/live/xcode_builds_live.html.heex:732
 #: lib/tuist_web/live/xcode_builds_live.html.heex:903
@@ -726,23 +726,23 @@ msgstr ""
 msgid "No data yet"
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.html.heex:822
+#: lib/tuist_web/live/build_run_live.html.heex:814
 #, elixir-autogen, elixir-format
 msgid "No errors detected"
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.html.heex:728
+#: lib/tuist_web/live/build_run_live.html.heex:720
 #, elixir-autogen, elixir-format
 msgid "No files found"
 msgstr ""
 
-#: lib/tuist_web/components/runs/module_cache_tab.ex:203
-#: lib/tuist_web/live/build_run_live.html.heex:592
+#: lib/tuist_web/components/runs/module_cache_tab.ex:200
+#: lib/tuist_web/live/build_run_live.html.heex:588
 #, elixir-autogen, elixir-format
 msgid "No modules found"
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.html.heex:779
+#: lib/tuist_web/live/build_run_live.html.heex:771
 #, elixir-autogen, elixir-format
 msgid "No warnings detected"
 msgstr ""
@@ -760,13 +760,13 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.ex:1000
+#: lib/tuist_web/live/build_run_live.ex:962
 #: lib/tuist_web/live/build_run_live.html.heex:238
-#: lib/tuist_web/live/build_run_live.html.heex:580
-#: lib/tuist_web/live/generate_runs_live.ex:286
+#: lib/tuist_web/live/build_run_live.html.heex:576
+#: lib/tuist_web/live/generate_runs_live.ex:278
 #: lib/tuist_web/live/generate_runs_live.html.heex:79
 #: lib/tuist_web/live/run_detail_live.html.heex:137
-#: lib/tuist_web/live/xcode_build_runs_live.ex:230
+#: lib/tuist_web/live/xcode_build_runs_live.ex:227
 #: lib/tuist_web/live/xcode_build_runs_live.html.heex:102
 #: lib/tuist_web/live/xcode_builds_live.ex:445
 #: lib/tuist_web/live/xcode_builds_live.html.heex:859
@@ -779,44 +779,44 @@ msgstr ""
 msgid "Percentage of modules that were successfully retrieved from the cache."
 msgstr ""
 
-#: lib/tuist_web/components/runs/module_cache_tab.ex:230
+#: lib/tuist_web/components/runs/module_cache_tab.ex:227
 #, elixir-autogen, elixir-format
 msgid "Product"
 msgstr ""
 
-#: lib/tuist_web/components/runs/module_cache_tab.ex:235
+#: lib/tuist_web/components/runs/module_cache_tab.ex:232
 #, elixir-autogen, elixir-format
 msgid "Product name"
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.ex:951
-#: lib/tuist_web/live/build_run_live.ex:988
-#: lib/tuist_web/live/build_run_live.html.heex:701
+#: lib/tuist_web/live/build_run_live.ex:913
+#: lib/tuist_web/live/build_run_live.ex:950
+#: lib/tuist_web/live/build_run_live.html.heex:694
 #, elixir-autogen, elixir-format
 msgid "Project"
 msgstr ""
 
-#: lib/tuist_web/components/runs/module_cache_tab.ex:323
+#: lib/tuist_web/components/runs/module_cache_tab.ex:320
 #, elixir-autogen, elixir-format
 msgid "Project settings"
 msgstr ""
 
 #: lib/tuist_web/live/generate_runs_live.html.heex:14
 #: lib/tuist_web/live/generate_runs_live.html.heex:29
-#: lib/tuist_web/live/generate_runs_live.html.heex:111
+#: lib/tuist_web/live/generate_runs_live.html.heex:108
 #: lib/tuist_web/live/run_detail_live.html.heex:156
 #: lib/tuist_web/live/xcode_build_runs_live.html.heex:14
 #: lib/tuist_web/live/xcode_build_runs_live.html.heex:29
-#: lib/tuist_web/live/xcode_build_runs_live.html.heex:165
+#: lib/tuist_web/live/xcode_build_runs_live.html.heex:162
 #: lib/tuist_web/live/xcode_builds_live.html.heex:896
 #, elixir-autogen, elixir-format
 msgid "Ran at"
 msgstr ""
 
-#: lib/tuist_web/live/generate_runs_live.ex:330
+#: lib/tuist_web/live/generate_runs_live.ex:322
 #: lib/tuist_web/live/generate_runs_live.html.heex:87
 #: lib/tuist_web/live/run_detail_live.html.heex:152
-#: lib/tuist_web/live/xcode_build_runs_live.ex:309
+#: lib/tuist_web/live/xcode_build_runs_live.ex:306
 #: lib/tuist_web/live/xcode_build_runs_live.html.heex:130
 #: lib/tuist_web/live/xcode_builds_live.html.heex:876
 #, elixir-autogen, elixir-format
@@ -828,20 +828,20 @@ msgstr ""
 msgid "Recent Builds"
 msgstr ""
 
-#: lib/tuist_web/components/runs/module_cache_tab.ex:174
-#: lib/tuist_web/components/runs/module_cache_tab.ex:429
-#: lib/tuist_web/live/build_run_live.ex:1126
-#: lib/tuist_web/live/build_run_live.ex:1368
-#: lib/tuist_web/live/build_run_live.html.heex:1005
-#: lib/tuist_web/live/build_run_live.html.heex:1212
-#: lib/tuist_web/live/run_detail_live.ex:360
-#: lib/tuist_web/live/run_detail_live.ex:393
-#: lib/tuist_web/live/test_run_live.ex:1123
+#: lib/tuist_web/components/runs/module_cache_tab.ex:171
+#: lib/tuist_web/components/runs/module_cache_tab.ex:423
+#: lib/tuist_web/live/build_run_live.ex:1088
+#: lib/tuist_web/live/build_run_live.ex:1330
+#: lib/tuist_web/live/build_run_live.html.heex:997
+#: lib/tuist_web/live/build_run_live.html.heex:1203
+#: lib/tuist_web/live/run_detail_live.ex:337
+#: lib/tuist_web/live/run_detail_live.ex:370
+#: lib/tuist_web/live/test_run_live.ex:1100
 #, elixir-autogen, elixir-format
 msgid "Remote"
 msgstr ""
 
-#: lib/tuist_web/components/runs/module_cache_tab.ex:265
+#: lib/tuist_web/components/runs/module_cache_tab.ex:262
 #, elixir-autogen, elixir-format
 msgid "Resources"
 msgstr ""
@@ -856,7 +856,7 @@ msgstr ""
 msgid "Run duration"
 msgstr ""
 
-#: lib/tuist_web/live/xcode_build_runs_live.ex:205
+#: lib/tuist_web/live/xcode_build_runs_live.ex:202
 #: lib/tuist_web/live/xcode_build_runs_live.html.heex:58
 #: lib/tuist_web/live/xcode_builds_live.ex:432
 #: lib/tuist_web/live/xcode_builds_live.html.heex:355
@@ -872,9 +872,9 @@ msgstr ""
 
 #: lib/tuist_web/components/runs/module_cache_tab.ex:128
 #: lib/tuist_web/live/build_run_live.html.heex:464
-#: lib/tuist_web/live/build_run_live.html.heex:622
-#: lib/tuist_web/live/build_run_live.html.heex:1158
-#: lib/tuist_web/live/build_run_live.html.heex:1471
+#: lib/tuist_web/live/build_run_live.html.heex:618
+#: lib/tuist_web/live/build_run_live.html.heex:1150
+#: lib/tuist_web/live/build_run_live.html.heex:1459
 #: lib/tuist_web/live/xcode_builds_live.html.heex:35
 #, elixir-autogen, elixir-format
 msgid "Search..."
@@ -885,21 +885,21 @@ msgstr ""
 msgid "Selective Testing"
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.html.heex:1482
-#: lib/tuist_web/live/build_run_live.html.heex:1502
-#: lib/tuist_web/live/build_run_live.html.heex:1562
+#: lib/tuist_web/live/build_run_live.html.heex:1470
+#: lib/tuist_web/live/build_run_live.html.heex:1490
+#: lib/tuist_web/live/build_run_live.html.heex:1547
 #, elixir-autogen, elixir-format
 msgid "Size"
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.ex:1165
+#: lib/tuist_web/live/build_run_live.ex:1127
 #, elixir-autogen, elixir-format
 msgid "Size (MB)"
 msgstr ""
 
 #: lib/tuist_web/live/build_run_live.html.heex:479
-#: lib/tuist_web/live/build_run_live.html.heex:636
-#: lib/tuist_web/live/build_run_live.html.heex:1487
+#: lib/tuist_web/live/build_run_live.html.heex:632
+#: lib/tuist_web/live/build_run_live.html.heex:1475
 #: lib/tuist_web/live/generate_runs_live.html.heex:17
 #: lib/tuist_web/live/xcode_build_runs_live.html.heex:17
 #, elixir-autogen, elixir-format
@@ -912,18 +912,18 @@ msgstr ""
 msgid "Source"
 msgstr ""
 
-#: lib/tuist_web/components/runs/module_cache_tab.ex:260
+#: lib/tuist_web/components/runs/module_cache_tab.ex:257
 #, elixir-autogen, elixir-format
 msgid "Sources"
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.ex:996
-#: lib/tuist_web/live/build_run_live.ex:1142
+#: lib/tuist_web/live/build_run_live.ex:958
+#: lib/tuist_web/live/build_run_live.ex:1104
 #: lib/tuist_web/live/build_run_live.html.heex:235
-#: lib/tuist_web/live/build_run_live.html.heex:1543
-#: lib/tuist_web/live/generate_runs_live.ex:282
+#: lib/tuist_web/live/build_run_live.html.heex:1528
+#: lib/tuist_web/live/generate_runs_live.ex:274
 #: lib/tuist_web/live/run_detail_live.html.heex:134
-#: lib/tuist_web/live/xcode_build_runs_live.ex:226
+#: lib/tuist_web/live/xcode_build_runs_live.ex:223
 #: lib/tuist_web/live/xcode_builds_live.ex:433
 #, elixir-autogen, elixir-format
 msgid "Status"
@@ -944,33 +944,33 @@ msgstr ""
 msgid "Swift version"
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.ex:943
-#: lib/tuist_web/live/build_run_live.html.heex:698
+#: lib/tuist_web/live/build_run_live.ex:905
+#: lib/tuist_web/live/build_run_live.html.heex:691
 #, elixir-autogen, elixir-format
 msgid "Target"
 msgstr ""
 
-#: lib/tuist_web/components/runs/module_cache_tab.ex:283
+#: lib/tuist_web/components/runs/module_cache_tab.ex:280
 #, elixir-autogen, elixir-format
 msgid "Target scripts"
 msgstr ""
 
-#: lib/tuist_web/components/runs/module_cache_tab.ex:329
+#: lib/tuist_web/components/runs/module_cache_tab.ex:326
 #, elixir-autogen, elixir-format
 msgid "Target settings"
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.html.heex:1191
+#: lib/tuist_web/live/build_run_live.html.heex:1183
 #, elixir-autogen, elixir-format
 msgid "Task"
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.html.heex:839
+#: lib/tuist_web/live/build_run_live.html.heex:831
 #, elixir-autogen, elixir-format
 msgid "Task hits"
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.html.heex:850
+#: lib/tuist_web/live/build_run_live.html.heex:842
 #, elixir-autogen, elixir-format
 msgid "Task misses"
 msgstr ""
@@ -1005,7 +1005,7 @@ msgstr ""
 msgid "The percentage of builds that succeeded."
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.html.heex:863
+#: lib/tuist_web/live/build_run_live.html.heex:855
 #, elixir-autogen, elixir-format
 msgid "The percentage of cacheable tasks that were cache hits (local + remote)."
 msgstr ""
@@ -1015,22 +1015,22 @@ msgstr ""
 msgid "The total number of builds."
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.html.heex:1050
+#: lib/tuist_web/live/build_run_live.html.heex:1042
 #, elixir-autogen, elixir-format
 msgid "Time to read cache keys, which uniquely identify cacheable tasks, from cache."
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.html.heex:1106
+#: lib/tuist_web/live/build_run_live.html.heex:1098
 #, elixir-autogen, elixir-format
 msgid "Time to write cache keys, which uniquely identify cacheable tasks, to cache."
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.html.heex:1433
+#: lib/tuist_web/live/build_run_live.html.heex:1421
 #, elixir-autogen, elixir-format
 msgid "Time-weighted average download throughput in megabits per second."
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.html.heex:1450
+#: lib/tuist_web/live/build_run_live.html.heex:1438
 #, elixir-autogen, elixir-format
 msgid "Time-weighted average upload throughput in megabits per second."
 msgstr ""
@@ -1050,23 +1050,23 @@ msgstr ""
 msgid "Total number of modules that could have been taken from the cache if it was fully populated."
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.html.heex:886
+#: lib/tuist_web/live/build_run_live.html.heex:878
 #, elixir-autogen, elixir-format
 msgid "Total size of cache artifacts downloaded."
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.html.heex:894
+#: lib/tuist_web/live/build_run_live.html.heex:886
 #, elixir-autogen, elixir-format
 msgid "Total size of cache artifacts uploaded."
 msgstr ""
 
-#: lib/tuist_web/components/runs/module_cache_tab.ex:204
+#: lib/tuist_web/components/runs/module_cache_tab.ex:201
 #, elixir-autogen, elixir-format
 msgid "Try changing your search term"
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.html.heex:593
-#: lib/tuist_web/live/build_run_live.html.heex:729
+#: lib/tuist_web/live/build_run_live.html.heex:589
+#: lib/tuist_web/live/build_run_live.html.heex:721
 #, elixir-autogen, elixir-format
 msgid "Try updating your search"
 msgstr ""
@@ -1076,11 +1076,11 @@ msgstr ""
 msgid "Tuist version"
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.ex:1108
-#: lib/tuist_web/live/build_run_live.ex:1155
-#: lib/tuist_web/live/build_run_live.html.heex:684
-#: lib/tuist_web/live/build_run_live.html.heex:1223
-#: lib/tuist_web/live/build_run_live.html.heex:1557
+#: lib/tuist_web/live/build_run_live.ex:1070
+#: lib/tuist_web/live/build_run_live.ex:1117
+#: lib/tuist_web/live/build_run_live.html.heex:677
+#: lib/tuist_web/live/build_run_live.html.heex:1214
+#: lib/tuist_web/live/build_run_live.html.heex:1542
 #, elixir-autogen, elixir-format
 msgid "Type"
 msgstr ""
@@ -1090,17 +1090,17 @@ msgstr ""
 msgid "Type:"
 msgstr ""
 
-#: lib/tuist_web/components/runs/module_cache_tab.ex:194
+#: lib/tuist_web/components/runs/module_cache_tab.ex:191
 #: lib/tuist_web/live/build_run_live.html.heex:71
 #: lib/tuist_web/live/build_run_live.html.heex:227
 #: lib/tuist_web/live/build_run_live.html.heex:290
-#: lib/tuist_web/live/build_run_live.html.heex:1201
+#: lib/tuist_web/live/build_run_live.html.heex:1192
 #: lib/tuist_web/live/xcode_build_runs_live.html.heex:94
-#: lib/tuist_web/live/xcode_build_runs_live.html.heex:158
-#: lib/tuist_web/live/xcode_build_runs_live.html.heex:180
-#: lib/tuist_web/live/xcode_build_runs_live.html.heex:188
-#: lib/tuist_web/live/xcode_build_runs_live.html.heex:196
-#: lib/tuist_web/live/xcode_build_runs_live.html.heex:199
+#: lib/tuist_web/live/xcode_build_runs_live.html.heex:155
+#: lib/tuist_web/live/xcode_build_runs_live.html.heex:174
+#: lib/tuist_web/live/xcode_build_runs_live.html.heex:182
+#: lib/tuist_web/live/xcode_build_runs_live.html.heex:190
+#: lib/tuist_web/live/xcode_build_runs_live.html.heex:193
 #: lib/tuist_web/live/xcode_builds_live.ex:405
 #: lib/tuist_web/live/xcode_builds_live.ex:439
 #: lib/tuist_web/live/xcode_builds_live.ex:442
@@ -1116,14 +1116,14 @@ msgstr ""
 msgid "Unknown scheme"
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.ex:1147
-#: lib/tuist_web/live/build_run_live.html.heex:1407
-#: lib/tuist_web/live/build_run_live.html.heex:1552
+#: lib/tuist_web/live/build_run_live.ex:1109
+#: lib/tuist_web/live/build_run_live.html.heex:1395
+#: lib/tuist_web/live/build_run_live.html.heex:1537
 #, elixir-autogen, elixir-format
 msgid "Upload"
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.html.heex:1448
+#: lib/tuist_web/live/build_run_live.html.heex:1436
 #, elixir-autogen, elixir-format
 msgid "Upload throughput"
 msgstr ""
@@ -1134,109 +1134,109 @@ msgstr ""
 msgid "View more"
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.ex:790
+#: lib/tuist_web/live/build_run_live.ex:760
 #, elixir-autogen, elixir-format
 msgid "Warning when compiling C file %{path}"
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.ex:793
-#: lib/tuist_web/live/build_run_live.ex:829
+#: lib/tuist_web/live/build_run_live.ex:763
+#: lib/tuist_web/live/build_run_live.ex:799
 #, elixir-autogen, elixir-format
 msgid "Warning when compiling Swift file %{path}"
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.ex:826
+#: lib/tuist_web/live/build_run_live.ex:796
 #, elixir-autogen, elixir-format
 msgid "Warning when compiling XIB file %{path}"
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.ex:808
+#: lib/tuist_web/live/build_run_live.ex:778
 #, elixir-autogen, elixir-format
 msgid "Warning when compiling assets catalog %{path}"
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.ex:811
+#: lib/tuist_web/live/build_run_live.ex:781
 #, elixir-autogen, elixir-format
 msgid "Warning when compiling storyboard %{path}"
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.ex:805
+#: lib/tuist_web/live/build_run_live.ex:775
 #, elixir-autogen, elixir-format
 msgid "Warning when copying Swift libraries %{path}"
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.ex:820
+#: lib/tuist_web/live/build_run_live.ex:790
 #, elixir-autogen, elixir-format
 msgid "Warning when copying resource file %{path}"
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.ex:799
+#: lib/tuist_web/live/build_run_live.ex:769
 #, elixir-autogen, elixir-format
 msgid "Warning when creating static library %{path}"
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.ex:796
+#: lib/tuist_web/live/build_run_live.ex:766
 #, elixir-autogen, elixir-format
 msgid "Warning when executing script %{script_name}"
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.ex:802
+#: lib/tuist_web/live/build_run_live.ex:772
 #, elixir-autogen, elixir-format
 msgid "Warning when linking %{path}"
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.ex:817
+#: lib/tuist_web/live/build_run_live.ex:787
 #, elixir-autogen, elixir-format
 msgid "Warning when linking storyboards %{path}"
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.ex:823
+#: lib/tuist_web/live/build_run_live.ex:793
 #, elixir-autogen, elixir-format
 msgid "Warning when merging Swift module %{path}"
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.ex:832
+#: lib/tuist_web/live/build_run_live.ex:802
 #, elixir-autogen, elixir-format
 msgid "Warning when precompiling bridging header %{path}"
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.ex:844
+#: lib/tuist_web/live/build_run_live.ex:814
 #, elixir-autogen, elixir-format
 msgid "Warning when processing %{path}"
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.ex:838
+#: lib/tuist_web/live/build_run_live.ex:808
 #, elixir-autogen, elixir-format
 msgid "Warning when validating %{path}"
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.ex:835
+#: lib/tuist_web/live/build_run_live.ex:805
 #, elixir-autogen, elixir-format
 msgid "Warning when validating embedded binary %{path}"
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.ex:814
+#: lib/tuist_web/live/build_run_live.ex:784
 #, elixir-autogen, elixir-format
 msgid "Warning when writing auxiliary file %{path}"
 msgstr ""
 
 #: lib/tuist_web/live/build_run_live.html.heex:183
 #: lib/tuist_web/live/build_run_live.html.heex:401
-#: lib/tuist_web/live/build_run_live.html.heex:748
-#: lib/tuist_web/live/build_run_live.html.heex:755
+#: lib/tuist_web/live/build_run_live.html.heex:740
+#: lib/tuist_web/live/build_run_live.html.heex:747
 #, elixir-autogen, elixir-format
 msgid "Warnings"
 msgstr ""
 
 #: lib/tuist_web/live/build_run_live.html.heex:178
-#: lib/tuist_web/live/build_run_live.html.heex:915
+#: lib/tuist_web/live/build_run_live.html.heex:907
 #, elixir-autogen, elixir-format
 msgid "Xcode Cache"
 msgstr ""
 
 #: lib/tuist_web/live/build_run_live.html.heex:308
-#: lib/tuist_web/live/xcode_build_runs_live.ex:262
-#: lib/tuist_web/live/xcode_build_runs_live.html.heex:177
+#: lib/tuist_web/live/xcode_build_runs_live.ex:259
+#: lib/tuist_web/live/xcode_build_runs_live.html.heex:171
 #: lib/tuist_web/live/xcode_builds_live.ex:388
 #: lib/tuist_web/live/xcode_builds_live.html.heex:621
 #: lib/tuist_web/live/xcode_builds_live.html.heex:868
@@ -1246,8 +1246,8 @@ msgstr ""
 
 #: lib/tuist_web/live/build_run_live.html.heex:314
 #: lib/tuist_web/live/run_detail_live.html.heex:202
-#: lib/tuist_web/live/xcode_build_runs_live.ex:270
-#: lib/tuist_web/live/xcode_build_runs_live.html.heex:185
+#: lib/tuist_web/live/xcode_build_runs_live.ex:267
+#: lib/tuist_web/live/xcode_build_runs_live.html.heex:179
 #: lib/tuist_web/live/xcode_builds_live.ex:389
 #: lib/tuist_web/live/xcode_builds_live.html.heex:639
 #, elixir-autogen, elixir-format
@@ -1264,12 +1264,12 @@ msgstr ""
 msgid "p50 build duration"
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.html.heex:1046
+#: lib/tuist_web/live/build_run_live.html.heex:1038
 #, elixir-autogen, elixir-format
 msgid "p50 latency reading cache keys"
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.html.heex:1102
+#: lib/tuist_web/live/build_run_live.html.heex:1094
 #, elixir-autogen, elixir-format
 msgid "p50 latency writing cache keys"
 msgstr ""
@@ -1284,12 +1284,12 @@ msgstr ""
 msgid "p90 build duration"
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.html.heex:1045
+#: lib/tuist_web/live/build_run_live.html.heex:1037
 #, elixir-autogen, elixir-format
 msgid "p90 latency reading cache keys"
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.html.heex:1101
+#: lib/tuist_web/live/build_run_live.html.heex:1093
 #, elixir-autogen, elixir-format
 msgid "p90 latency writing cache keys"
 msgstr ""
@@ -1304,12 +1304,12 @@ msgstr ""
 msgid "p99 build duration"
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.html.heex:1044
+#: lib/tuist_web/live/build_run_live.html.heex:1036
 #, elixir-autogen, elixir-format
 msgid "p99 latency reading cache keys"
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.html.heex:1100
+#: lib/tuist_web/live/build_run_live.html.heex:1092
 #, elixir-autogen, elixir-format
 msgid "p99 latency writing cache keys"
 msgstr ""
@@ -1331,8 +1331,8 @@ msgstr ""
 
 #: lib/tuist_web/live/build_run_live.html.heex:367
 #: lib/tuist_web/live/build_run_live.html.heex:404
-#: lib/tuist_web/live/build_run_live.html.heex:758
-#: lib/tuist_web/live/build_run_live.html.heex:799
+#: lib/tuist_web/live/build_run_live.html.heex:750
+#: lib/tuist_web/live/build_run_live.html.heex:791
 #, elixir-autogen, elixir-format
 msgid "•"
 msgstr ""
@@ -1382,7 +1382,7 @@ msgstr ""
 msgid "since yesterday"
 msgstr ""
 
-#: lib/tuist_web/live/generate_runs_live.ex:311
+#: lib/tuist_web/live/generate_runs_live.ex:303
 #: lib/tuist_web/live/run_detail_live.html.heex:125
 #, elixir-autogen, elixir-format
 msgid "Cache Endpoint"
@@ -1409,7 +1409,7 @@ msgstr ""
 msgid "Tag:"
 msgstr ""
 
-#: lib/tuist_web/live/xcode_build_runs_live.ex:285
+#: lib/tuist_web/live/xcode_build_runs_live.ex:282
 #, elixir-autogen, elixir-format
 msgid "Tags"
 msgstr ""
@@ -1431,14 +1431,14 @@ msgid "Download build"
 msgstr ""
 
 #: lib/tuist_web/live/build_run_live.html.heex:252
-#: lib/tuist_web/live/xcode_build_runs_live.ex:233
+#: lib/tuist_web/live/xcode_build_runs_live.ex:230
 #: lib/tuist_web/live/xcode_build_runs_live.html.heex:117
 #, elixir-autogen, elixir-format
 msgid "Failed processing"
 msgstr ""
 
 #: lib/tuist_web/live/build_run_live.html.heex:258
-#: lib/tuist_web/live/xcode_build_runs_live.ex:232
+#: lib/tuist_web/live/xcode_build_runs_live.ex:229
 #: lib/tuist_web/live/xcode_build_runs_live.html.heex:112
 #, elixir-autogen, elixir-format
 msgid "Processing"

--- a/server/priv/gettext/dashboard_builds.pot
+++ b/server/priv/gettext/dashboard_builds.pot
@@ -158,22 +158,22 @@ msgstr ""
 msgid "CAS Outputs"
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.html.heex:1253
+#: lib/tuist_web/live/build_run_live.html.heex:1252
 #, elixir-autogen, elixir-format
 msgid "CAS output"
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.html.heex:1365
+#: lib/tuist_web/live/build_run_live.html.heex:1364
 #, elixir-autogen, elixir-format
 msgid "CAS outputs"
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.html.heex:1592
+#: lib/tuist_web/live/build_run_live.html.heex:1591
 #, elixir-autogen, elixir-format
 msgid "CAS outputs will appear here when using Tuist cache"
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.html.heex:1317
+#: lib/tuist_web/live/build_run_live.html.heex:1316
 #, elixir-autogen, elixir-format
 msgid "CAS outputs:"
 msgstr ""
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Cacheable tasks that were retrieved from cache (local + remote)."
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.html.heex:1291
+#: lib/tuist_web/live/build_run_live.html.heex:1290
 #, elixir-autogen, elixir-format
 msgid "Cacheable tasks will appear here when using Tuist cache"
 msgstr ""
@@ -313,10 +313,10 @@ msgstr ""
 msgid "Compilation duration"
 msgstr ""
 
+#: lib/tuist_web/live/build_run_live.html.heex:1470
 #: lib/tuist_web/live/build_run_live.html.heex:1471
-#: lib/tuist_web/live/build_run_live.html.heex:1472
-#: lib/tuist_web/live/build_run_live.html.heex:1498
-#: lib/tuist_web/live/build_run_live.html.heex:1558
+#: lib/tuist_web/live/build_run_live.html.heex:1497
+#: lib/tuist_web/live/build_run_live.html.heex:1557
 #, elixir-autogen, elixir-format
 msgid "Compressed Size"
 msgstr ""
@@ -343,7 +343,7 @@ msgstr ""
 msgid "Configuration:"
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.html.heex:1271
+#: lib/tuist_web/live/build_run_live.html.heex:1270
 #, elixir-autogen, elixir-format
 msgid "Copy"
 msgstr ""
@@ -386,8 +386,8 @@ msgid "Device"
 msgstr ""
 
 #: lib/tuist_web/live/build_run_live.ex:1108
-#: lib/tuist_web/live/build_run_live.html.heex:1378
-#: lib/tuist_web/live/build_run_live.html.heex:1531
+#: lib/tuist_web/live/build_run_live.html.heex:1377
+#: lib/tuist_web/live/build_run_live.html.heex:1530
 #, elixir-autogen, elixir-format
 msgid "Download"
 msgstr ""
@@ -398,7 +398,7 @@ msgstr ""
 msgid "Download result"
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.html.heex:1419
+#: lib/tuist_web/live/build_run_live.html.heex:1418
 #, elixir-autogen, elixir-format
 msgid "Download throughput"
 msgstr ""
@@ -573,7 +573,7 @@ msgstr ""
 #: lib/tuist_web/live/build_run_live.html.heex:508
 #: lib/tuist_web/live/build_run_live.html.heex:653
 #: lib/tuist_web/live/build_run_live.html.heex:1158
-#: lib/tuist_web/live/build_run_live.html.heex:1504
+#: lib/tuist_web/live/build_run_live.html.heex:1503
 #: lib/tuist_web/live/generate_runs_live.html.heex:38
 #: lib/tuist_web/live/xcode_build_runs_live.html.heex:38
 #, elixir-autogen, elixir-format
@@ -626,9 +626,9 @@ msgid "Info.plist"
 msgstr ""
 
 #: lib/tuist_web/live/build_run_live.html.heex:331
-#: lib/tuist_web/live/build_run_live.html.heex:1469
-#: lib/tuist_web/live/build_run_live.html.heex:1482
-#: lib/tuist_web/live/build_run_live.html.heex:1519
+#: lib/tuist_web/live/build_run_live.html.heex:1468
+#: lib/tuist_web/live/build_run_live.html.heex:1481
+#: lib/tuist_web/live/build_run_live.html.heex:1518
 #, elixir-autogen, elixir-format
 msgid "Key"
 msgstr ""
@@ -699,20 +699,20 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.html.heex:1590
+#: lib/tuist_web/live/build_run_live.html.heex:1589
 #, elixir-autogen, elixir-format
 msgid "No CAS outputs found"
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.html.heex:1289
+#: lib/tuist_web/live/build_run_live.html.heex:1288
 #, elixir-autogen, elixir-format
 msgid "No cacheable tasks found"
 msgstr ""
 
 #: lib/tuist_web/live/build_run_live.html.heex:1085
 #: lib/tuist_web/live/build_run_live.html.heex:1141
-#: lib/tuist_web/live/build_run_live.html.heex:1433
-#: lib/tuist_web/live/build_run_live.html.heex:1450
+#: lib/tuist_web/live/build_run_live.html.heex:1432
+#: lib/tuist_web/live/build_run_live.html.heex:1449
 #, elixir-autogen, elixir-format
 msgid "No data"
 msgstr ""
@@ -874,7 +874,7 @@ msgstr ""
 #: lib/tuist_web/live/build_run_live.html.heex:464
 #: lib/tuist_web/live/build_run_live.html.heex:618
 #: lib/tuist_web/live/build_run_live.html.heex:1150
-#: lib/tuist_web/live/build_run_live.html.heex:1459
+#: lib/tuist_web/live/build_run_live.html.heex:1458
 #: lib/tuist_web/live/xcode_builds_live.html.heex:35
 #, elixir-autogen, elixir-format
 msgid "Search..."
@@ -885,9 +885,9 @@ msgstr ""
 msgid "Selective Testing"
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.html.heex:1470
-#: lib/tuist_web/live/build_run_live.html.heex:1490
-#: lib/tuist_web/live/build_run_live.html.heex:1547
+#: lib/tuist_web/live/build_run_live.html.heex:1469
+#: lib/tuist_web/live/build_run_live.html.heex:1489
+#: lib/tuist_web/live/build_run_live.html.heex:1546
 #, elixir-autogen, elixir-format
 msgid "Size"
 msgstr ""
@@ -899,7 +899,7 @@ msgstr ""
 
 #: lib/tuist_web/live/build_run_live.html.heex:479
 #: lib/tuist_web/live/build_run_live.html.heex:632
-#: lib/tuist_web/live/build_run_live.html.heex:1475
+#: lib/tuist_web/live/build_run_live.html.heex:1474
 #: lib/tuist_web/live/generate_runs_live.html.heex:17
 #: lib/tuist_web/live/xcode_build_runs_live.html.heex:17
 #, elixir-autogen, elixir-format
@@ -920,7 +920,7 @@ msgstr ""
 #: lib/tuist_web/live/build_run_live.ex:958
 #: lib/tuist_web/live/build_run_live.ex:1104
 #: lib/tuist_web/live/build_run_live.html.heex:235
-#: lib/tuist_web/live/build_run_live.html.heex:1528
+#: lib/tuist_web/live/build_run_live.html.heex:1527
 #: lib/tuist_web/live/generate_runs_live.ex:274
 #: lib/tuist_web/live/run_detail_live.html.heex:134
 #: lib/tuist_web/live/xcode_build_runs_live.ex:223
@@ -1025,12 +1025,12 @@ msgstr ""
 msgid "Time to write cache keys, which uniquely identify cacheable tasks, to cache."
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.html.heex:1421
+#: lib/tuist_web/live/build_run_live.html.heex:1420
 #, elixir-autogen, elixir-format
 msgid "Time-weighted average download throughput in megabits per second."
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.html.heex:1438
+#: lib/tuist_web/live/build_run_live.html.heex:1437
 #, elixir-autogen, elixir-format
 msgid "Time-weighted average upload throughput in megabits per second."
 msgstr ""
@@ -1080,7 +1080,7 @@ msgstr ""
 #: lib/tuist_web/live/build_run_live.ex:1117
 #: lib/tuist_web/live/build_run_live.html.heex:677
 #: lib/tuist_web/live/build_run_live.html.heex:1214
-#: lib/tuist_web/live/build_run_live.html.heex:1542
+#: lib/tuist_web/live/build_run_live.html.heex:1541
 #, elixir-autogen, elixir-format
 msgid "Type"
 msgstr ""
@@ -1117,13 +1117,13 @@ msgid "Unknown scheme"
 msgstr ""
 
 #: lib/tuist_web/live/build_run_live.ex:1109
-#: lib/tuist_web/live/build_run_live.html.heex:1395
-#: lib/tuist_web/live/build_run_live.html.heex:1537
+#: lib/tuist_web/live/build_run_live.html.heex:1394
+#: lib/tuist_web/live/build_run_live.html.heex:1536
 #, elixir-autogen, elixir-format
 msgid "Upload"
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.html.heex:1436
+#: lib/tuist_web/live/build_run_live.html.heex:1435
 #, elixir-autogen, elixir-format
 msgid "Upload throughput"
 msgstr ""

--- a/server/priv/gettext/dashboard_cache.pot
+++ b/server/priv/gettext/dashboard_cache.pot
@@ -22,7 +22,7 @@ msgstr ""
 msgid "%{duration}s"
 msgstr ""
 
-#: lib/tuist_web/live/cache_runs_live.html.heex:77
+#: lib/tuist_web/live/cache_runs_live.html.heex:74
 #: lib/tuist_web/live/module_cache_live.html.heex:123
 #: lib/tuist_web/live/module_cache_live.html.heex:141
 #: lib/tuist_web/live/module_cache_live.html.heex:148
@@ -41,7 +41,7 @@ msgstr ""
 msgid "%{hit_rate}%"
 msgstr ""
 
-#: lib/tuist_web/live/cache_runs_live.html.heex:113
+#: lib/tuist_web/live/cache_runs_live.html.heex:107
 #, elixir-autogen, elixir-format
 msgid "%{run_duration}s"
 msgstr ""
@@ -51,7 +51,7 @@ msgstr ""
 msgid "%{savings} %"
 msgstr ""
 
-#: lib/tuist_web/live/bundle_live.ex:880
+#: lib/tuist_web/live/bundle_live.ex:872
 #, elixir-autogen, elixir-format
 msgid "%{space_usage} %"
 msgstr ""
@@ -61,7 +61,7 @@ msgstr ""
 msgid "0 MB"
 msgstr ""
 
-#: lib/tuist_web/live/bundle_live.ex:878
+#: lib/tuist_web/live/bundle_live.ex:870
 #, elixir-autogen, elixir-format
 msgid "< 0.1 %"
 msgstr ""
@@ -72,7 +72,7 @@ msgstr ""
 msgid "Analytics"
 msgstr ""
 
-#: lib/tuist_web/live/bundles_live.ex:420
+#: lib/tuist_web/live/bundles_live.ex:412
 #: lib/tuist_web/live/bundles_live.html.heex:40
 #: lib/tuist_web/live/bundles_live.html.heex:55
 #: lib/tuist_web/live/bundles_live.html.heex:69
@@ -82,10 +82,10 @@ msgstr ""
 msgid "Any"
 msgstr ""
 
-#: lib/tuist_web/live/bundle_live.ex:1003
-#: lib/tuist_web/live/bundles_live.ex:409
-#: lib/tuist_web/live/bundles_live.ex:416
-#: lib/tuist_web/live/bundles_live.ex:1007
+#: lib/tuist_web/live/bundle_live.ex:995
+#: lib/tuist_web/live/bundles_live.ex:401
+#: lib/tuist_web/live/bundles_live.ex:408
+#: lib/tuist_web/live/bundles_live.ex:999
 #, elixir-autogen, elixir-format
 msgid "App bundle"
 msgstr ""
@@ -95,8 +95,8 @@ msgstr ""
 msgid "App:"
 msgstr ""
 
-#: lib/tuist_web/live/bundle_live.ex:1020
-#: lib/tuist_web/live/bundle_live.html.heex:550
+#: lib/tuist_web/live/bundle_live.ex:1012
+#: lib/tuist_web/live/bundle_live.html.heex:547
 #, elixir-autogen, elixir-format
 msgid "Asset"
 msgstr ""
@@ -127,17 +127,17 @@ msgstr ""
 msgid "Binaries"
 msgstr ""
 
-#: lib/tuist_web/live/bundle_live.ex:1018
-#: lib/tuist_web/live/bundle_live.html.heex:548
+#: lib/tuist_web/live/bundle_live.ex:1010
+#: lib/tuist_web/live/bundle_live.html.heex:545
 #, elixir-autogen, elixir-format
 msgid "Binary"
 msgstr ""
 
 #: lib/tuist_web/live/bundle_live.html.heex:80
-#: lib/tuist_web/live/bundles_live.ex:943
+#: lib/tuist_web/live/bundles_live.ex:935
 #: lib/tuist_web/live/bundles_live.html.heex:352
 #: lib/tuist_web/live/cache_runs_live.ex:60
-#: lib/tuist_web/live/cache_runs_live.html.heex:96
+#: lib/tuist_web/live/cache_runs_live.html.heex:93
 #, elixir-autogen, elixir-format
 msgid "Branch"
 msgstr ""
@@ -167,7 +167,7 @@ msgstr ""
 msgid "Bundle Size Analysis"
 msgstr ""
 
-#: lib/tuist_web/live/bundle_live.ex:855
+#: lib/tuist_web/live/bundle_live.ex:847
 #, elixir-autogen, elixir-format
 msgid "Bundle not found."
 msgstr ""
@@ -252,7 +252,7 @@ msgid "Command"
 msgstr ""
 
 #: lib/tuist_web/live/bundle_live.html.heex:159
-#: lib/tuist_web/live/bundles_live.html.heex:388
+#: lib/tuist_web/live/bundles_live.html.heex:382
 #, elixir-autogen, elixir-format
 msgid "Commit SHA"
 msgstr ""
@@ -260,7 +260,7 @@ msgstr ""
 #: lib/tuist_web/live/bundle_live.html.heex:86
 #: lib/tuist_web/live/bundles_live.html.heex:297
 #: lib/tuist_web/live/bundles_live.html.heex:304
-#: lib/tuist_web/live/bundles_live.html.heex:399
+#: lib/tuist_web/live/bundles_live.html.heex:393
 #, elixir-autogen, elixir-format
 msgid "Created at"
 msgstr ""
@@ -270,9 +270,9 @@ msgstr ""
 msgid "Delete bundle"
 msgstr ""
 
-#: lib/tuist_web/live/bundle_live.ex:1023
+#: lib/tuist_web/live/bundle_live.ex:1015
 #: lib/tuist_web/live/bundle_live.html.heex:201
-#: lib/tuist_web/live/bundle_live.html.heex:553
+#: lib/tuist_web/live/bundle_live.html.heex:550
 #, elixir-autogen, elixir-format
 msgid "Directory"
 msgstr ""
@@ -284,12 +284,12 @@ msgstr ""
 
 #: lib/tuist_web/live/bundle_live.html.heex:104
 #: lib/tuist_web/live/bundle_live.html.heex:107
-#: lib/tuist_web/live/bundles_live.html.heex:373
+#: lib/tuist_web/live/bundles_live.html.heex:370
 #, elixir-autogen, elixir-format
 msgid "Download size"
 msgstr ""
 
-#: lib/tuist_web/live/bundles_live.ex:969
+#: lib/tuist_web/live/bundles_live.ex:961
 #: lib/tuist_web/live/bundles_live.html.heex:163
 #: lib/tuist_web/live/bundles_live.html.heex:205
 #: lib/tuist_web/live/bundles_live.html.heex:296
@@ -305,7 +305,7 @@ msgstr ""
 
 #: lib/tuist_web/live/cache_runs_live.html.heex:9
 #: lib/tuist_web/live/cache_runs_live.html.heex:26
-#: lib/tuist_web/live/cache_runs_live.html.heex:104
+#: lib/tuist_web/live/cache_runs_live.html.heex:101
 #: lib/tuist_web/live/module_cache_live.html.heex:592
 #: lib/tuist_web/live/xcode_cache_live.html.heex:862
 #, elixir-autogen, elixir-format
@@ -323,15 +323,15 @@ msgid "Explore bundle analysis"
 msgstr ""
 
 #: lib/tuist_web/live/cache_runs_live.ex:52
-#: lib/tuist_web/live/cache_runs_live.html.heex:93
+#: lib/tuist_web/live/cache_runs_live.html.heex:90
 #: lib/tuist_web/live/xcode_cache_live.ex:432
 #, elixir-autogen, elixir-format
 msgid "Failed"
 msgstr ""
 
-#: lib/tuist_web/live/bundle_live.ex:1022
+#: lib/tuist_web/live/bundle_live.ex:1014
 #: lib/tuist_web/live/bundle_live.html.heex:225
-#: lib/tuist_web/live/bundle_live.html.heex:552
+#: lib/tuist_web/live/bundle_live.html.heex:549
 #, elixir-autogen, elixir-format
 msgid "File"
 msgstr ""
@@ -349,8 +349,8 @@ msgstr ""
 msgid "Filter"
 msgstr ""
 
-#: lib/tuist_web/live/bundle_live.ex:1021
-#: lib/tuist_web/live/bundle_live.html.heex:551
+#: lib/tuist_web/live/bundle_live.ex:1013
+#: lib/tuist_web/live/bundle_live.html.heex:548
 #, elixir-autogen, elixir-format
 msgid "Font"
 msgstr ""
@@ -379,10 +379,10 @@ msgstr ""
 msgid "Hits"
 msgstr ""
 
-#: lib/tuist_web/live/bundle_live.ex:1002
-#: lib/tuist_web/live/bundles_live.ex:408
-#: lib/tuist_web/live/bundles_live.ex:415
-#: lib/tuist_web/live/bundles_live.ex:1008
+#: lib/tuist_web/live/bundle_live.ex:994
+#: lib/tuist_web/live/bundles_live.ex:400
+#: lib/tuist_web/live/bundles_live.ex:407
+#: lib/tuist_web/live/bundles_live.ex:1000
 #, elixir-autogen, elixir-format
 msgid "IPA"
 msgstr ""
@@ -395,7 +395,7 @@ msgstr ""
 msgid "Install size"
 msgstr ""
 
-#: lib/tuist_web/live/bundles_live.ex:961
+#: lib/tuist_web/live/bundles_live.ex:953
 #: lib/tuist_web/live/bundles_live.html.heex:136
 #: lib/tuist_web/live/bundles_live.html.heex:206
 #: lib/tuist_web/live/bundles_live.html.heex:295
@@ -417,8 +417,8 @@ msgstr ""
 msgid "Local"
 msgstr ""
 
-#: lib/tuist_web/live/bundle_live.ex:1019
-#: lib/tuist_web/live/bundle_live.html.heex:549
+#: lib/tuist_web/live/bundle_live.ex:1011
+#: lib/tuist_web/live/bundle_live.html.heex:546
 #, elixir-autogen, elixir-format
 msgid "Localization"
 msgstr ""
@@ -434,7 +434,7 @@ msgid "Misses"
 msgstr ""
 
 #: lib/tuist_web/live/bundle_live.html.heex:184
-#: lib/tuist_web/live/bundle_live.html.heex:609
+#: lib/tuist_web/live/bundle_live.html.heex:603
 #, elixir-autogen, elixir-format
 msgid "Module Breakdown"
 msgstr ""
@@ -445,10 +445,10 @@ msgid "Module Cache"
 msgstr ""
 
 #: lib/tuist_web/live/bundle_live.html.heex:60
-#: lib/tuist_web/live/bundle_live.html.heex:631
-#: lib/tuist_web/live/bundle_live.html.heex:638
-#: lib/tuist_web/live/bundle_live.html.heex:657
-#: lib/tuist_web/live/bundles_live.ex:935
+#: lib/tuist_web/live/bundle_live.html.heex:625
+#: lib/tuist_web/live/bundle_live.html.heex:632
+#: lib/tuist_web/live/bundle_live.html.heex:651
+#: lib/tuist_web/live/bundles_live.ex:927
 #: lib/tuist_web/live/bundles_live.html.heex:349
 #, elixir-autogen, elixir-format
 msgid "Name"
@@ -459,8 +459,8 @@ msgstr ""
 msgid "No bundles yet"
 msgstr ""
 
-#: lib/tuist_web/live/bundles_live.html.heex:419
-#: lib/tuist_web/live/cache_runs_live.html.heex:144
+#: lib/tuist_web/live/bundles_live.html.heex:410
+#: lib/tuist_web/live/cache_runs_live.html.heex:135
 #: lib/tuist_web/live/module_cache_live.html.heex:478
 #: lib/tuist_web/live/module_cache_live.html.heex:613
 #: lib/tuist_web/live/xcode_cache_live.html.heex:740
@@ -469,7 +469,7 @@ msgstr ""
 msgid "No data yet"
 msgstr ""
 
-#: lib/tuist_web/live/bundle_live.html.heex:590
+#: lib/tuist_web/live/bundle_live.html.heex:584
 #, elixir-autogen, elixir-format
 msgid "No files found"
 msgstr ""
@@ -479,19 +479,19 @@ msgstr ""
 msgid "No insights yet"
 msgstr ""
 
-#: lib/tuist_web/live/bundle_live.html.heex:689
+#: lib/tuist_web/live/bundle_live.html.heex:677
 #, elixir-autogen, elixir-format
 msgid "No modules found"
 msgstr ""
 
 #: lib/tuist_web/live/bundle_live.html.heex:125
-#: lib/tuist_web/live/bundles_live.html.heex:385
+#: lib/tuist_web/live/bundles_live.html.heex:379
 #, elixir-autogen, elixir-format
 msgid "Not available"
 msgstr ""
 
-#: lib/tuist_web/live/bundle_live.ex:1024
-#: lib/tuist_web/live/bundle_live.html.heex:554
+#: lib/tuist_web/live/bundle_live.ex:1016
+#: lib/tuist_web/live/bundle_live.html.heex:551
 #, elixir-autogen, elixir-format
 msgid "Other"
 msgstr ""
@@ -502,7 +502,7 @@ msgid "Overview"
 msgstr ""
 
 #: lib/tuist_web/live/cache_runs_live.ex:51
-#: lib/tuist_web/live/cache_runs_live.html.heex:91
+#: lib/tuist_web/live/cache_runs_live.html.heex:88
 #: lib/tuist_web/live/xcode_cache_live.ex:431
 #, elixir-autogen, elixir-format
 msgid "Passed"
@@ -516,8 +516,8 @@ msgid "Path"
 msgstr ""
 
 #: lib/tuist_web/live/bundle_live.html.heex:76
-#: lib/tuist_web/live/bundles_live.ex:986
-#: lib/tuist_web/live/bundles_live.html.heex:391
+#: lib/tuist_web/live/bundles_live.ex:978
+#: lib/tuist_web/live/bundles_live.html.heex:385
 #, elixir-autogen, elixir-format
 msgid "Platform"
 msgstr ""
@@ -529,7 +529,7 @@ msgstr ""
 
 #: lib/tuist_web/live/cache_runs_live.html.heex:11
 #: lib/tuist_web/live/cache_runs_live.html.heex:34
-#: lib/tuist_web/live/cache_runs_live.html.heex:123
+#: lib/tuist_web/live/cache_runs_live.html.heex:117
 #: lib/tuist_web/live/module_cache_live.html.heex:605
 #: lib/tuist_web/live/xcode_cache_live.html.heex:875
 #, elixir-autogen, elixir-format
@@ -537,7 +537,7 @@ msgid "Ran at"
 msgstr ""
 
 #: lib/tuist_web/live/cache_runs_live.ex:95
-#: lib/tuist_web/live/cache_runs_live.html.heex:99
+#: lib/tuist_web/live/cache_runs_live.html.heex:96
 #: lib/tuist_web/live/module_cache_live.html.heex:586
 #: lib/tuist_web/live/xcode_cache_live.html.heex:856
 #, elixir-autogen, elixir-format
@@ -582,31 +582,31 @@ msgid "Scheme"
 msgstr ""
 
 #: lib/tuist_web/live/bundle_live.html.heex:484
-#: lib/tuist_web/live/bundle_live.html.heex:620
+#: lib/tuist_web/live/bundle_live.html.heex:614
 #, elixir-autogen, elixir-format
 msgid "Search..."
 msgstr ""
 
 #: lib/tuist_web/live/bundle_live.html.heex:494
 #: lib/tuist_web/live/bundle_live.html.heex:510
-#: lib/tuist_web/live/bundle_live.html.heex:572
-#: lib/tuist_web/live/bundle_live.html.heex:630
-#: lib/tuist_web/live/bundle_live.html.heex:646
-#: lib/tuist_web/live/bundle_live.html.heex:671
+#: lib/tuist_web/live/bundle_live.html.heex:569
+#: lib/tuist_web/live/bundle_live.html.heex:624
+#: lib/tuist_web/live/bundle_live.html.heex:640
+#: lib/tuist_web/live/bundle_live.html.heex:662
 #, elixir-autogen, elixir-format
 msgid "Size"
 msgstr ""
 
 #: lib/tuist_web/live/bundle_live.html.heex:498
-#: lib/tuist_web/live/bundle_live.html.heex:634
+#: lib/tuist_web/live/bundle_live.html.heex:628
 #: lib/tuist_web/live/bundles_live.html.heex:300
 #: lib/tuist_web/live/cache_runs_live.html.heex:14
 #, elixir-autogen, elixir-format
 msgid "Sort by:"
 msgstr ""
 
-#: lib/tuist_web/live/bundle_live.html.heex:584
-#: lib/tuist_web/live/bundle_live.html.heex:683
+#: lib/tuist_web/live/bundle_live.html.heex:578
+#: lib/tuist_web/live/bundle_live.html.heex:671
 #, elixir-autogen, elixir-format
 msgid "Space usage"
 msgstr ""
@@ -627,16 +627,16 @@ msgstr ""
 msgid "The bundle install size. This is the uncompressed app size and represents how much space the app takes on the device."
 msgstr ""
 
-#: lib/tuist_web/live/bundle_live.html.heex:591
-#: lib/tuist_web/live/bundle_live.html.heex:690
+#: lib/tuist_web/live/bundle_live.html.heex:585
+#: lib/tuist_web/live/bundle_live.html.heex:678
 #, elixir-autogen, elixir-format
 msgid "Try changing your search term"
 msgstr ""
 
-#: lib/tuist_web/live/bundle_live.ex:1014
+#: lib/tuist_web/live/bundle_live.ex:1006
 #: lib/tuist_web/live/bundle_live.html.heex:52
-#: lib/tuist_web/live/bundle_live.html.heex:544
-#: lib/tuist_web/live/bundles_live.ex:951
+#: lib/tuist_web/live/bundle_live.html.heex:541
+#: lib/tuist_web/live/bundles_live.ex:943
 #: lib/tuist_web/live/bundles_live.html.heex:355
 #, elixir-autogen, elixir-format
 msgid "Type"
@@ -647,11 +647,11 @@ msgstr ""
 msgid "Type:"
 msgstr ""
 
-#: lib/tuist_web/live/bundle_live.ex:1007
+#: lib/tuist_web/live/bundle_live.ex:999
 #: lib/tuist_web/live/bundle_live.html.heex:82
 #: lib/tuist_web/live/bundle_live.html.heex:162
 #: lib/tuist_web/live/bundle_live.html.heex:229
-#: lib/tuist_web/live/bundles_live.ex:413
+#: lib/tuist_web/live/bundles_live.ex:405
 #: lib/tuist_web/live/xcode_cache_live.ex:428
 #, elixir-autogen, elixir-format
 msgid "Unknown"
@@ -672,10 +672,10 @@ msgstr ""
 msgid "View more"
 msgstr ""
 
-#: lib/tuist_web/live/bundle_live.ex:1004
-#: lib/tuist_web/live/bundles_live.ex:410
-#: lib/tuist_web/live/bundles_live.ex:417
-#: lib/tuist_web/live/bundles_live.ex:1009
+#: lib/tuist_web/live/bundle_live.ex:996
+#: lib/tuist_web/live/bundles_live.ex:402
+#: lib/tuist_web/live/bundles_live.ex:409
+#: lib/tuist_web/live/bundles_live.ex:1001
 #, elixir-autogen, elixir-format
 msgid "XCArchive"
 msgstr ""
@@ -840,28 +840,28 @@ msgstr ""
 msgid "Tuist documentation"
 msgstr ""
 
-#: lib/tuist_web/live/bundle_live.ex:1032
+#: lib/tuist_web/live/bundle_live.ex:1024
 #, elixir-autogen, elixir-format
 msgid "Size (KB)"
 msgstr ""
 
-#: lib/tuist_web/live/bundle_live.ex:1040
+#: lib/tuist_web/live/bundle_live.ex:1032
 #, elixir-autogen, elixir-format
 msgid "Space usage (%)"
 msgstr ""
 
-#: lib/tuist_web/live/bundle_live.ex:1005
-#: lib/tuist_web/live/bundles_live.ex:411
-#: lib/tuist_web/live/bundles_live.ex:418
-#: lib/tuist_web/live/bundles_live.ex:1001
+#: lib/tuist_web/live/bundle_live.ex:997
+#: lib/tuist_web/live/bundles_live.ex:403
+#: lib/tuist_web/live/bundles_live.ex:410
+#: lib/tuist_web/live/bundles_live.ex:993
 #, elixir-autogen, elixir-format
 msgid "AAB"
 msgstr ""
 
-#: lib/tuist_web/live/bundle_live.ex:1006
-#: lib/tuist_web/live/bundles_live.ex:412
-#: lib/tuist_web/live/bundles_live.ex:419
-#: lib/tuist_web/live/bundles_live.ex:1002
+#: lib/tuist_web/live/bundle_live.ex:998
+#: lib/tuist_web/live/bundles_live.ex:404
+#: lib/tuist_web/live/bundles_live.ex:411
+#: lib/tuist_web/live/bundles_live.ex:994
 #, elixir-autogen, elixir-format
 msgid "APK"
 msgstr ""

--- a/server/priv/gettext/dashboard_gradle.pot
+++ b/server/priv/gettext/dashboard_gradle.pot
@@ -11,7 +11,7 @@
 msgid ""
 msgstr ""
 
-#: lib/tuist_web/live/gradle_build_runs_live.html.heex:130
+#: lib/tuist_web/live/gradle_build_runs_live.html.heex:127
 #: lib/tuist_web/live/gradle_builds_live.html.heex:692
 #: lib/tuist_web/live/gradle_cache_live.html.heex:633
 #: lib/tuist_web/live/gradle_overview_live.html.heex:131
@@ -22,7 +22,7 @@ msgid "%{duration}s"
 msgstr ""
 
 #: lib/tuist_web/live/gradle_build_live.html.heex:336
-#: lib/tuist_web/live/gradle_build_runs_live.html.heex:147
+#: lib/tuist_web/live/gradle_build_runs_live.html.heex:144
 #: lib/tuist_web/live/gradle_cache_live.html.heex:151
 #: lib/tuist_web/live/gradle_cache_live.html.heex:169
 #: lib/tuist_web/live/gradle_cache_live.html.heex:176
@@ -62,7 +62,7 @@ msgid "Avg. cache hit rate"
 msgstr ""
 
 #: lib/tuist_web/live/gradle_build_live.html.heex:134
-#: lib/tuist_web/live/gradle_build_runs_live.ex:228
+#: lib/tuist_web/live/gradle_build_runs_live.ex:225
 #: lib/tuist_web/live/gradle_build_runs_live.html.heex:89
 #, elixir-autogen, elixir-format
 msgid "Branch"
@@ -79,7 +79,7 @@ msgstr ""
 msgid "Build not found."
 msgstr ""
 
-#: lib/tuist_web/live/gradle_build_runs_live.ex:248
+#: lib/tuist_web/live/gradle_build_runs_live.ex:245
 #: lib/tuist_web/live/gradle_builds_live.ex:177
 #: lib/tuist_web/live/gradle_builds_live.html.heex:26
 #: lib/tuist_web/live/gradle_cache_live.ex:208
@@ -93,7 +93,7 @@ msgstr ""
 msgid "CI"
 msgstr ""
 
-#: lib/tuist_web/live/gradle_build_runs_live.html.heex:140
+#: lib/tuist_web/live/gradle_build_runs_live.html.heex:137
 #: lib/tuist_web/live/gradle_cache_live.html.heex:591
 #, elixir-autogen, elixir-format
 msgid "Cache Hit Rate"
@@ -158,7 +158,7 @@ msgid "Cancel"
 msgstr ""
 
 #: lib/tuist_web/live/gradle_build_live.html.heex:100
-#: lib/tuist_web/live/gradle_build_runs_live.ex:220
+#: lib/tuist_web/live/gradle_build_runs_live.ex:217
 #: lib/tuist_web/live/gradle_build_runs_live.html.heex:85
 #: lib/tuist_web/live/gradle_builds_live.html.heex:682
 #, elixir-autogen, elixir-format
@@ -184,7 +184,7 @@ msgstr ""
 #: lib/tuist_web/live/gradle_build_live.html.heex:268
 #: lib/tuist_web/live/gradle_build_live.html.heex:544
 #: lib/tuist_web/live/gradle_build_live.html.heex:551
-#: lib/tuist_web/live/gradle_build_live.html.heex:633
+#: lib/tuist_web/live/gradle_build_live.html.heex:632
 #: lib/tuist_web/live/gradle_build_runs_live.html.heex:24
 #: lib/tuist_web/live/gradle_build_runs_live.html.heex:32
 #: lib/tuist_web/live/gradle_build_runs_live.html.heex:118
@@ -195,14 +195,14 @@ msgid "Duration"
 msgstr ""
 
 #: lib/tuist_web/live/gradle_build_live.ex:245
-#: lib/tuist_web/live/gradle_build_live.ex:331
+#: lib/tuist_web/live/gradle_build_live.ex:328
 #, elixir-autogen, elixir-format
 msgid "Executed"
 msgstr ""
 
 #: lib/tuist_web/live/gradle_build_live.ex:246
-#: lib/tuist_web/live/gradle_build_live.ex:332
-#: lib/tuist_web/live/gradle_build_runs_live.ex:219
+#: lib/tuist_web/live/gradle_build_live.ex:329
+#: lib/tuist_web/live/gradle_build_runs_live.ex:216
 #: lib/tuist_web/live/gradle_build_runs_live.html.heex:80
 #: lib/tuist_web/live/gradle_builds_live.html.heex:677
 #, elixir-autogen, elixir-format
@@ -226,7 +226,7 @@ msgid "Gradle Cache"
 msgstr ""
 
 #: lib/tuist_web/live/gradle_build_live.html.heex:126
-#: lib/tuist_web/live/gradle_build_runs_live.html.heex:156
+#: lib/tuist_web/live/gradle_build_runs_live.html.heex:153
 #, elixir-autogen, elixir-format
 msgid "Gradle Version"
 msgstr ""
@@ -274,7 +274,7 @@ msgid "Last 7 days"
 msgstr ""
 
 #: lib/tuist_web/live/gradle_build_live.ex:242
-#: lib/tuist_web/live/gradle_build_live.ex:328
+#: lib/tuist_web/live/gradle_build_live.ex:325
 #, elixir-autogen, elixir-format
 msgid "Local hit"
 msgstr ""
@@ -286,7 +286,7 @@ msgstr ""
 msgid "Missed"
 msgstr ""
 
-#: lib/tuist_web/live/gradle_build_runs_live.html.heex:192
+#: lib/tuist_web/live/gradle_build_runs_live.html.heex:186
 #: lib/tuist_web/live/gradle_builds_live.html.heex:447
 #: lib/tuist_web/live/gradle_builds_live.html.heex:569
 #: lib/tuist_web/live/gradle_builds_live.html.heex:709
@@ -298,7 +298,7 @@ msgid "No data yet"
 msgstr ""
 
 #: lib/tuist_web/live/gradle_build_live.ex:248
-#: lib/tuist_web/live/gradle_build_live.ex:334
+#: lib/tuist_web/live/gradle_build_live.ex:331
 #, elixir-autogen, elixir-format
 msgid "No source"
 msgstr ""
@@ -325,7 +325,7 @@ msgstr ""
 
 #: lib/tuist_web/live/gradle_build_runs_live.html.heex:25
 #: lib/tuist_web/live/gradle_build_runs_live.html.heex:40
-#: lib/tuist_web/live/gradle_build_runs_live.html.heex:166
+#: lib/tuist_web/live/gradle_build_runs_live.html.heex:163
 #: lib/tuist_web/live/gradle_builds_live.html.heex:702
 #: lib/tuist_web/live/gradle_cache_live.html.heex:643
 #, elixir-autogen, elixir-format
@@ -339,7 +339,7 @@ msgid "Recent Builds"
 msgstr ""
 
 #: lib/tuist_web/live/gradle_build_live.ex:243
-#: lib/tuist_web/live/gradle_build_live.ex:329
+#: lib/tuist_web/live/gradle_build_live.ex:326
 #, elixir-autogen, elixir-format
 msgid "Remote hit"
 msgstr ""
@@ -350,7 +350,7 @@ msgid "Set up Gradle cache for your project"
 msgstr ""
 
 #: lib/tuist_web/live/gradle_build_live.ex:247
-#: lib/tuist_web/live/gradle_build_live.ex:333
+#: lib/tuist_web/live/gradle_build_live.ex:330
 #, elixir-autogen, elixir-format
 msgid "Skipped"
 msgstr ""
@@ -358,7 +358,7 @@ msgstr ""
 #: lib/tuist_web/live/gradle_build_live.ex:282
 #: lib/tuist_web/live/gradle_build_live.html.heex:83
 #: lib/tuist_web/live/gradle_build_live.html.heex:593
-#: lib/tuist_web/live/gradle_build_runs_live.ex:214
+#: lib/tuist_web/live/gradle_build_runs_live.ex:211
 #: lib/tuist_web/live/gradle_build_runs_live.html.heex:72
 #, elixir-autogen, elixir-format
 msgid "Status"
@@ -385,7 +385,7 @@ msgid "Tuist documentation"
 msgstr ""
 
 #: lib/tuist_web/live/gradle_build_live.ex:244
-#: lib/tuist_web/live/gradle_build_live.ex:330
+#: lib/tuist_web/live/gradle_build_live.ex:327
 #, elixir-autogen, elixir-format
 msgid "Up-to-date"
 msgstr ""
@@ -481,7 +481,7 @@ msgstr ""
 #: lib/tuist_web/live/gradle_build_live.ex:286
 #: lib/tuist_web/live/gradle_build_live.html.heex:439
 #: lib/tuist_web/live/gradle_build_live.html.heex:596
-#: lib/tuist_web/live/gradle_build_runs_live.ex:249
+#: lib/tuist_web/live/gradle_build_runs_live.ex:246
 #: lib/tuist_web/live/gradle_builds_live.ex:176
 #: lib/tuist_web/live/gradle_builds_live.html.heex:18
 #: lib/tuist_web/live/gradle_cache_live.ex:207
@@ -547,7 +547,7 @@ msgstr ""
 msgid "Hit rate"
 msgstr ""
 
-#: lib/tuist_web/live/gradle_build_live.html.heex:651
+#: lib/tuist_web/live/gradle_build_live.html.heex:649
 #, elixir-autogen, elixir-format
 msgid "No cacheable tasks"
 msgstr ""
@@ -572,7 +572,7 @@ msgstr ""
 msgid "The percentage of cacheable tasks that were cache hits (local + remote)."
 msgstr ""
 
-#: lib/tuist_web/live/gradle_build_live.html.heex:652
+#: lib/tuist_web/live/gradle_build_live.html.heex:650
 #, elixir-autogen, elixir-format
 msgid "This build has no cacheable task data."
 msgstr ""
@@ -620,9 +620,9 @@ msgstr ""
 msgid "Upload throughput"
 msgstr ""
 
-#: lib/tuist_web/live/gradle_build_live.ex:346
-#: lib/tuist_web/live/gradle_build_live.html.heex:628
-#: lib/tuist_web/live/gradle_build_live.html.heex:646
+#: lib/tuist_web/live/gradle_build_live.ex:343
+#: lib/tuist_web/live/gradle_build_live.html.heex:627
+#: lib/tuist_web/live/gradle_build_live.html.heex:644
 #, elixir-autogen, elixir-format
 msgid "—"
 msgstr ""
@@ -667,7 +667,7 @@ msgstr ""
 msgid "Built at"
 msgstr ""
 
-#: lib/tuist_web/live/gradle_build_live.html.heex:645
+#: lib/tuist_web/live/gradle_build_live.html.heex:643
 #, elixir-autogen, elixir-format
 msgid "Cache key"
 msgstr ""
@@ -684,7 +684,7 @@ msgstr ""
 
 #: lib/tuist_web/live/gradle_build_live.html.heex:42
 #: lib/tuist_web/live/gradle_build_runs_live.html.heex:102
-#: lib/tuist_web/live/gradle_build_runs_live.html.heex:159
+#: lib/tuist_web/live/gradle_build_runs_live.html.heex:156
 #: lib/tuist_web/live/gradle_cache_live.ex:238
 #, elixir-autogen, elixir-format
 msgid "Unknown"
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Configuration Insights"
 msgstr ""
 
-#: lib/tuist_web/live/gradle_build_runs_live.ex:244
+#: lib/tuist_web/live/gradle_build_runs_live.ex:241
 #: lib/tuist_web/live/gradle_cache_live.ex:234
 #: lib/tuist_web/live/gradle_cache_live.html.heex:288
 #, elixir-autogen, elixir-format
@@ -755,14 +755,14 @@ msgstr ""
 msgid "Failed builds"
 msgstr ""
 
-#: lib/tuist_web/live/gradle_build_runs_live.ex:257
+#: lib/tuist_web/live/gradle_build_runs_live.ex:254
 #: lib/tuist_web/live/gradle_builds_live.ex:241
 #: lib/tuist_web/live/gradle_builds_live.html.heex:470
 #, elixir-autogen, elixir-format
 msgid "Gradle version"
 msgstr ""
 
-#: lib/tuist_web/live/gradle_build_runs_live.ex:265
+#: lib/tuist_web/live/gradle_build_runs_live.ex:262
 #: lib/tuist_web/live/gradle_builds_live.ex:240
 #: lib/tuist_web/live/gradle_builds_live.html.heex:480
 #, elixir-autogen, elixir-format
@@ -774,7 +774,7 @@ msgstr ""
 msgid "Last 30 runs"
 msgstr ""
 
-#: lib/tuist_web/live/gradle_build_runs_live.html.heex:144
+#: lib/tuist_web/live/gradle_build_runs_live.html.heex:141
 #, elixir-autogen, elixir-format
 msgid "N/A"
 msgstr ""
@@ -789,7 +789,7 @@ msgstr ""
 msgid "No recent builds yet"
 msgstr ""
 
-#: lib/tuist_web/live/gradle_build_runs_live.ex:218
+#: lib/tuist_web/live/gradle_build_runs_live.ex:215
 #: lib/tuist_web/live/gradle_build_runs_live.html.heex:75
 #: lib/tuist_web/live/gradle_builds_live.html.heex:672
 #, elixir-autogen, elixir-format
@@ -900,7 +900,7 @@ msgid "Tests"
 msgstr ""
 
 #: lib/tuist_web/live/gradle_build_live.html.heex:147
-#: lib/tuist_web/live/gradle_build_runs_live.ex:236
+#: lib/tuist_web/live/gradle_build_runs_live.ex:233
 #: lib/tuist_web/live/gradle_build_runs_live.html.heex:98
 #, elixir-autogen, elixir-format
 msgid "Requested tasks"
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Machine Metrics"
 msgstr ""
 
-#: lib/tuist_web/live/gradle_build_runs_live.ex:282
+#: lib/tuist_web/live/gradle_build_runs_live.ex:279
 #, elixir-autogen, elixir-format
 msgid "Ran by"
 msgstr ""

--- a/server/priv/gettext/dashboard_runners.pot
+++ b/server/priv/gettext/dashboard_runners.pot
@@ -26,9 +26,9 @@ msgstr ""
 msgid "Apply"
 msgstr ""
 
-#: lib/tuist_web/live/runner_workflows_live.ex:276
+#: lib/tuist_web/live/runner_workflows_live.ex:273
 #: lib/tuist_web/live/runner_workflows_live.html.heex:335
-#: lib/tuist_web/live/runner_workflows_live.html.heex:393
+#: lib/tuist_web/live/runner_workflows_live.html.heex:391
 #, elixir-autogen, elixir-format
 msgid "Avg duration"
 msgstr ""
@@ -72,7 +72,7 @@ msgstr ""
 #: lib/tuist_web/live/runner_jobs_live.ex:499
 #: lib/tuist_web/live/runner_jobs_live.ex:524
 #: lib/tuist_web/live/runner_workflow_live.ex:178
-#: lib/tuist_web/live/runner_workflow_live.ex:319
+#: lib/tuist_web/live/runner_workflow_live.ex:316
 #: lib/tuist_web/live/runners_live.ex:301
 #: lib/tuist_web/live/runners_live.ex:491
 #, elixir-autogen, elixir-format
@@ -83,7 +83,7 @@ msgstr ""
 #: lib/tuist_web/live/runner_jobs_live.ex:495
 #: lib/tuist_web/live/runner_jobs_live.ex:517
 #: lib/tuist_web/live/runner_workflow_live.ex:174
-#: lib/tuist_web/live/runner_workflow_live.ex:312
+#: lib/tuist_web/live/runner_workflow_live.ex:309
 #: lib/tuist_web/live/runners_live.ex:484
 #, elixir-autogen, elixir-format
 msgid "Claimed"
@@ -96,7 +96,7 @@ msgid "Commit"
 msgstr ""
 
 #: lib/tuist_web/live/runner_jobs_live.ex:519
-#: lib/tuist_web/live/runner_workflow_live.ex:314
+#: lib/tuist_web/live/runner_workflow_live.ex:311
 #: lib/tuist_web/live/runners_live.ex:486
 #, elixir-autogen, elixir-format
 msgid "Completed"
@@ -128,7 +128,7 @@ msgid "Duration"
 msgstr ""
 
 #: lib/tuist_web/live/runner_job_live.ex:126
-#: lib/tuist_web/live/runner_jobs_live.ex:669
+#: lib/tuist_web/live/runner_jobs_live.ex:666
 #: lib/tuist_web/live/runner_jobs_live.html.heex:193
 #: lib/tuist_web/live/runner_workflow_live.html.heex:218
 #: lib/tuist_web/live/runners_live.html.heex:331
@@ -146,7 +146,7 @@ msgstr ""
 #: lib/tuist_web/live/runner_jobs_live.ex:498
 #: lib/tuist_web/live/runner_jobs_live.ex:523
 #: lib/tuist_web/live/runner_workflow_live.ex:177
-#: lib/tuist_web/live/runner_workflow_live.ex:318
+#: lib/tuist_web/live/runner_workflow_live.ex:315
 #: lib/tuist_web/live/runners_live.ex:300
 #: lib/tuist_web/live/runners_live.ex:490
 #, elixir-autogen, elixir-format
@@ -178,7 +178,7 @@ msgstr ""
 #: lib/tuist_web/live/runner_jobs_live.html.heex:465
 #: lib/tuist_web/live/runner_workflow_live.html.heex:179
 #: lib/tuist_web/live/runner_workflow_live.html.heex:248
-#: lib/tuist_web/live/runner_workflows_live.ex:274
+#: lib/tuist_web/live/runner_workflows_live.ex:271
 #: lib/tuist_web/live/runner_workflows_live.html.heex:319
 #: lib/tuist_web/live/runner_workflows_live.html.heex:375
 #: lib/tuist_web/live/runners_live.html.heex:263
@@ -229,7 +229,7 @@ msgstr ""
 msgid "Last 7 days"
 msgstr ""
 
-#: lib/tuist_web/live/runner_workflows_live.html.heex:406
+#: lib/tuist_web/live/runner_workflows_live.html.heex:402
 #, elixir-autogen, elixir-format
 msgid "Last run"
 msgstr ""
@@ -241,7 +241,7 @@ msgstr ""
 
 #: lib/tuist_web/live/runner_jobs_live.html.heex:672
 #: lib/tuist_web/live/runner_workflow_live.html.heex:388
-#: lib/tuist_web/live/runner_workflows_live.html.heex:421
+#: lib/tuist_web/live/runner_workflows_live.html.heex:417
 #, elixir-autogen, elixir-format
 msgid "Next"
 msgstr ""
@@ -263,14 +263,14 @@ msgstr ""
 msgid "No jobs yet for this workflow"
 msgstr ""
 
-#: lib/tuist_web/live/runner_workflows_live.html.heex:433
+#: lib/tuist_web/live/runner_workflows_live.html.heex:429
 #, elixir-autogen, elixir-format
 msgid "No workflows yet"
 msgstr ""
 
 #: lib/tuist_web/live/runner_jobs_live.html.heex:664
 #: lib/tuist_web/live/runner_workflow_live.html.heex:380
-#: lib/tuist_web/live/runner_workflows_live.html.heex:413
+#: lib/tuist_web/live/runner_workflows_live.html.heex:409
 #, elixir-autogen, elixir-format
 msgid "Prev"
 msgstr ""
@@ -280,7 +280,7 @@ msgstr ""
 #: lib/tuist_web/live/runner_jobs_live.ex:516
 #: lib/tuist_web/live/runner_jobs_live.html.heex:489
 #: lib/tuist_web/live/runner_workflow_live.ex:173
-#: lib/tuist_web/live/runner_workflow_live.ex:311
+#: lib/tuist_web/live/runner_workflow_live.ex:308
 #: lib/tuist_web/live/runners_live.ex:483
 #, elixir-autogen, elixir-format
 msgid "Queued"
@@ -311,7 +311,7 @@ msgstr ""
 #: lib/tuist_web/live/runner_jobs_live.ex:518
 #: lib/tuist_web/live/runner_jobs_live.html.heex:472
 #: lib/tuist_web/live/runner_workflow_live.ex:175
-#: lib/tuist_web/live/runner_workflow_live.ex:313
+#: lib/tuist_web/live/runner_workflow_live.ex:310
 #: lib/tuist_web/live/runners_live.ex:485
 #, elixir-autogen, elixir-format
 msgid "Running"
@@ -322,7 +322,7 @@ msgstr ""
 #: lib/tuist_web/live/runner_jobs_live.ex:500
 #: lib/tuist_web/live/runner_jobs_live.ex:525
 #: lib/tuist_web/live/runner_workflow_live.ex:179
-#: lib/tuist_web/live/runner_workflow_live.ex:320
+#: lib/tuist_web/live/runner_workflow_live.ex:317
 #: lib/tuist_web/live/runners_live.ex:302
 #: lib/tuist_web/live/runners_live.ex:492
 #, elixir-autogen, elixir-format
@@ -347,14 +347,14 @@ msgstr ""
 #: lib/tuist_web/live/runner_jobs_live.ex:497
 #: lib/tuist_web/live/runner_jobs_live.ex:522
 #: lib/tuist_web/live/runner_workflow_live.ex:176
-#: lib/tuist_web/live/runner_workflow_live.ex:317
+#: lib/tuist_web/live/runner_workflow_live.ex:314
 #: lib/tuist_web/live/runners_live.ex:299
 #: lib/tuist_web/live/runners_live.ex:489
 #, elixir-autogen, elixir-format
 msgid "Success"
 msgstr ""
 
-#: lib/tuist_web/live/runner_workflows_live.ex:275
+#: lib/tuist_web/live/runner_workflows_live.ex:272
 #: lib/tuist_web/live/runner_workflows_live.html.heex:327
 #: lib/tuist_web/live/runner_workflows_live.html.heex:383
 #, elixir-autogen, elixir-format
@@ -411,14 +411,14 @@ msgstr ""
 #: lib/tuist_web/live/runner_job_live.ex:153
 #: lib/tuist_web/live/runner_job_live.ex:157
 #: lib/tuist_web/live/runner_jobs_live.ex:520
-#: lib/tuist_web/live/runner_jobs_live.ex:630
-#: lib/tuist_web/live/runner_jobs_live.ex:634
+#: lib/tuist_web/live/runner_jobs_live.ex:627
+#: lib/tuist_web/live/runner_jobs_live.ex:631
 #: lib/tuist_web/live/runner_jobs_live.html.heex:592
 #: lib/tuist_web/live/runner_jobs_live.html.heex:600
 #: lib/tuist_web/live/runner_jobs_live.html.heex:621
-#: lib/tuist_web/live/runner_workflow_live.ex:307
-#: lib/tuist_web/live/runner_workflow_live.ex:308
-#: lib/tuist_web/live/runner_workflow_live.ex:315
+#: lib/tuist_web/live/runner_workflow_live.ex:304
+#: lib/tuist_web/live/runner_workflow_live.ex:305
+#: lib/tuist_web/live/runner_workflow_live.ex:312
 #: lib/tuist_web/live/runner_workflow_live.html.heex:344
 #: lib/tuist_web/live/runner_workflows_live.html.heex:360
 #: lib/tuist_web/live/runner_workflows_live.html.heex:368
@@ -444,7 +444,7 @@ msgstr ""
 #: lib/tuist_web/live/runner_jobs_live.ex:584
 #: lib/tuist_web/live/runner_jobs_live.html.heex:543
 #: lib/tuist_web/live/runner_jobs_live.html.heex:586
-#: lib/tuist_web/live/runner_workflows_live.ex:277
+#: lib/tuist_web/live/runner_workflows_live.ex:274
 #: lib/tuist_web/live/runner_workflows_live.html.heex:311
 #: lib/tuist_web/live/runner_workflows_live.html.heex:354
 #: lib/tuist_web/live/runners_live.html.heex:392
@@ -515,35 +515,35 @@ msgstr ""
 #: lib/tuist_web/live/runner_workflow_live.html.heex:73
 #: lib/tuist_web/live/runner_workflow_live.html.heex:115
 #: lib/tuist_web/live/runner_workflow_live.html.heex:160
-#: lib/tuist_web/live/runner_workflows_live.ex:286
+#: lib/tuist_web/live/runner_workflows_live.ex:283
 #: lib/tuist_web/live/runners_live.ex:326
 #, elixir-autogen, elixir-format
 msgid "since last month"
 msgstr ""
 
 #: lib/tuist_web/live/runner_jobs_live.ex:257
-#: lib/tuist_web/live/runner_workflows_live.ex:285
+#: lib/tuist_web/live/runner_workflows_live.ex:282
 #: lib/tuist_web/live/runners_live.ex:325
 #, elixir-autogen, elixir-format
 msgid "since last period"
 msgstr ""
 
 #: lib/tuist_web/live/runner_jobs_live.ex:255
-#: lib/tuist_web/live/runner_workflows_live.ex:283
+#: lib/tuist_web/live/runner_workflows_live.ex:280
 #: lib/tuist_web/live/runners_live.ex:323
 #, elixir-autogen, elixir-format
 msgid "since last week"
 msgstr ""
 
 #: lib/tuist_web/live/runner_jobs_live.ex:256
-#: lib/tuist_web/live/runner_workflows_live.ex:284
+#: lib/tuist_web/live/runner_workflows_live.ex:281
 #: lib/tuist_web/live/runners_live.ex:324
 #, elixir-autogen, elixir-format
 msgid "since last year"
 msgstr ""
 
 #: lib/tuist_web/live/runner_jobs_live.ex:254
-#: lib/tuist_web/live/runner_workflows_live.ex:282
+#: lib/tuist_web/live/runner_workflows_live.ex:279
 #: lib/tuist_web/live/runners_live.ex:322
 #, elixir-autogen, elixir-format
 msgid "since yesterday"
@@ -635,7 +635,7 @@ msgstr ""
 msgid "Search..."
 msgstr ""
 
-#: lib/tuist_web/live/runner_workflows_live.html.heex:435
+#: lib/tuist_web/live/runner_workflows_live.html.heex:431
 #, elixir-autogen, elixir-format
 msgid "No workflows match the current search"
 msgstr ""
@@ -672,19 +672,19 @@ msgstr ""
 msgid "Workflow jobs received in the window, broken down by outcome."
 msgstr ""
 
-#: lib/tuist_web/live/runner_jobs_live.ex:680
+#: lib/tuist_web/live/runner_jobs_live.ex:677
 #, elixir-autogen, elixir-format
 msgid "Failed job runs"
 msgstr ""
 
 #: lib/tuist_web/live/runner_job_live.ex:123
-#: lib/tuist_web/live/runner_jobs_live.ex:668
+#: lib/tuist_web/live/runner_jobs_live.ex:665
 #: lib/tuist_web/live/runner_jobs_live.html.heex:176
 #, elixir-autogen, elixir-format
 msgid "Passed"
 msgstr ""
 
-#: lib/tuist_web/live/runner_jobs_live.ex:679
+#: lib/tuist_web/live/runner_jobs_live.ex:676
 #, elixir-autogen, elixir-format
 msgid "Passed job runs"
 msgstr ""
@@ -694,7 +694,7 @@ msgstr ""
 msgid "All"
 msgstr ""
 
-#: lib/tuist_web/live/runner_jobs_live.ex:681
+#: lib/tuist_web/live/runner_jobs_live.ex:678
 #, elixir-autogen, elixir-format
 msgid "All job runs"
 msgstr ""
@@ -702,7 +702,7 @@ msgstr ""
 #: lib/tuist/runners/analytics.ex:926
 #: lib/tuist_web/live/runner_job_live.ex:150
 #: lib/tuist_web/live/runner_jobs_live.ex:580
-#: lib/tuist_web/live/runner_jobs_live.ex:627
+#: lib/tuist_web/live/runner_jobs_live.ex:624
 #: lib/tuist_web/live/runner_profiles_live.ex:332
 #: lib/tuist_web/live/runner_profiles_live.ex:349
 #: lib/tuist_web/live/runner_workflows_live.ex:241
@@ -728,7 +728,7 @@ msgstr ""
 #: lib/tuist/runners/analytics.ex:923
 #: lib/tuist_web/live/runner_job_live.ex:147
 #: lib/tuist_web/live/runner_jobs_live.ex:579
-#: lib/tuist_web/live/runner_jobs_live.ex:624
+#: lib/tuist_web/live/runner_jobs_live.ex:621
 #: lib/tuist_web/live/runner_profiles_live.ex:333
 #: lib/tuist_web/live/runner_profiles_live.ex:350
 #: lib/tuist_web/live/runner_workflows_live.ex:240

--- a/server/priv/gettext/dashboard_tests.pot
+++ b/server/priv/gettext/dashboard_tests.pot
@@ -22,7 +22,7 @@ msgid "%{selective_test_effectiveness}%"
 msgstr ""
 
 #: lib/tuist_web/live/test_case_run_live.html.heex:1094
-#: lib/tuist_web/live/test_run_live.html.heex:1952
+#: lib/tuist_web/live/test_run_live.html.heex:1923
 #, elixir-autogen, elixir-format
 msgid "All tests passed!"
 msgstr ""
@@ -63,7 +63,7 @@ msgstr ""
 msgid "Attachments"
 msgstr ""
 
-#: lib/tuist_web/live/test_case_live.ex:503
+#: lib/tuist_web/live/test_case_live.ex:500
 #, elixir-autogen, elixir-format
 msgid "Automatically by Tuist"
 msgstr ""
@@ -100,20 +100,20 @@ msgstr ""
 
 #: lib/tuist_web/live/test_cases_live.html.heex:486
 #: lib/tuist_web/live/test_cases_live.html.heex:510
-#: lib/tuist_web/live/test_cases_live.html.heex:605
+#: lib/tuist_web/live/test_cases_live.html.heex:602
 #, elixir-autogen, elixir-format
 msgid "Avg. duration"
 msgstr ""
 
-#: lib/tuist_web/live/test_run_live.ex:994
-#: lib/tuist_web/live/test_run_live.ex:1051
+#: lib/tuist_web/live/test_run_live.ex:971
+#: lib/tuist_web/live/test_run_live.ex:1028
 #: lib/tuist_web/live/test_run_live.html.heex:384
-#: lib/tuist_web/live/test_run_live.html.heex:1279
-#: lib/tuist_web/live/test_run_live.html.heex:1308
-#: lib/tuist_web/live/test_run_live.html.heex:1386
-#: lib/tuist_web/live/test_run_live.html.heex:1497
-#: lib/tuist_web/live/test_run_live.html.heex:1534
-#: lib/tuist_web/live/test_run_live.html.heex:1626
+#: lib/tuist_web/live/test_run_live.html.heex:1273
+#: lib/tuist_web/live/test_run_live.html.heex:1302
+#: lib/tuist_web/live/test_run_live.html.heex:1374
+#: lib/tuist_web/live/test_run_live.html.heex:1481
+#: lib/tuist_web/live/test_run_live.html.heex:1518
+#: lib/tuist_web/live/test_run_live.html.heex:1601
 #, elixir-autogen, elixir-format
 msgid "Avg. test case duration"
 msgstr ""
@@ -227,7 +227,7 @@ msgstr ""
 #: lib/tuist_web/helpers/attachment_helpers.ex:28
 #: lib/tuist_web/live/test_case_run_live.html.heex:443
 #: lib/tuist_web/live/test_run_live.html.heex:773
-#: lib/tuist_web/live/test_run_live.html.heex:1877
+#: lib/tuist_web/live/test_run_live.html.heex:1848
 #, elixir-autogen, elixir-format
 msgid "Crash Report"
 msgstr ""
@@ -254,20 +254,20 @@ msgstr ""
 #: lib/tuist_web/live/test_case_live.html.heex:489
 #: lib/tuist_web/live/test_case_live.html.heex:565
 #: lib/tuist_web/live/test_case_run_live.html.heex:149
-#: lib/tuist_web/live/test_run_live.ex:940
-#: lib/tuist_web/live/test_run_live.ex:1002
-#: lib/tuist_web/live/test_run_live.ex:1059
+#: lib/tuist_web/live/test_run_live.ex:917
+#: lib/tuist_web/live/test_run_live.ex:979
+#: lib/tuist_web/live/test_run_live.ex:1036
 #: lib/tuist_web/live/test_run_live.html.heex:278
 #: lib/tuist_web/live/test_run_live.html.heex:475
 #: lib/tuist_web/live/test_run_live.html.heex:1084
 #: lib/tuist_web/live/test_run_live.html.heex:1099
-#: lib/tuist_web/live/test_run_live.html.heex:1192
-#: lib/tuist_web/live/test_run_live.html.heex:1282
-#: lib/tuist_web/live/test_run_live.html.heex:1316
-#: lib/tuist_web/live/test_run_live.html.heex:1424
-#: lib/tuist_web/live/test_run_live.html.heex:1500
-#: lib/tuist_web/live/test_run_live.html.heex:1542
-#: lib/tuist_web/live/test_run_live.html.heex:1659
+#: lib/tuist_web/live/test_run_live.html.heex:1189
+#: lib/tuist_web/live/test_run_live.html.heex:1276
+#: lib/tuist_web/live/test_run_live.html.heex:1310
+#: lib/tuist_web/live/test_run_live.html.heex:1411
+#: lib/tuist_web/live/test_run_live.html.heex:1484
+#: lib/tuist_web/live/test_run_live.html.heex:1526
+#: lib/tuist_web/live/test_run_live.html.heex:1633
 #: lib/tuist_web/live/test_runs_live.html.heex:500
 #: lib/tuist_web/live/tests_live.html.heex:973
 #, elixir-autogen, elixir-format
@@ -282,19 +282,19 @@ msgstr ""
 msgid "Environment:"
 msgstr ""
 
-#: lib/tuist_web/live/test_case_live.ex:496
+#: lib/tuist_web/live/test_case_live.ex:493
 #, elixir-autogen, elixir-format
 msgid "Event"
 msgstr ""
 
-#: lib/tuist_web/live/test_case_live.html.heex:656
+#: lib/tuist_web/live/test_case_live.html.heex:650
 #, elixir-autogen, elixir-format
 msgid "Events will appear here when the test case status changes."
 msgstr ""
 
 #: lib/tuist_web/live/test_case_run_live.html.heex:466
 #: lib/tuist_web/live/test_run_live.html.heex:792
-#: lib/tuist_web/live/test_run_live.html.heex:1895
+#: lib/tuist_web/live/test_run_live.html.heex:1866
 #, elixir-autogen, elixir-format
 msgid "Exception"
 msgstr ""
@@ -319,7 +319,7 @@ msgstr ""
 msgid "Expectation failed: %{message}"
 msgstr ""
 
-#: lib/tuist_web/live/quarantined_tests_live.html.heex:381
+#: lib/tuist_web/live/quarantined_tests_live.html.heex:378
 #: lib/tuist_web/live/shards_live.ex:32
 #: lib/tuist_web/live/shards_live.html.heex:573
 #: lib/tuist_web/live/test_case_live.ex:95
@@ -339,10 +339,10 @@ msgstr ""
 #: lib/tuist_web/live/test_case_run_live.html.heex:1007
 #: lib/tuist_web/live/test_case_run_live.html.heex:1044
 #: lib/tuist_web/live/test_cases_live.ex:45
-#: lib/tuist_web/live/test_cases_live.html.heex:632
-#: lib/tuist_web/live/test_run_live.ex:953
-#: lib/tuist_web/live/test_run_live.ex:1015
-#: lib/tuist_web/live/test_run_live.ex:1072
+#: lib/tuist_web/live/test_cases_live.html.heex:626
+#: lib/tuist_web/live/test_run_live.ex:930
+#: lib/tuist_web/live/test_run_live.ex:992
+#: lib/tuist_web/live/test_run_live.ex:1049
 #: lib/tuist_web/live/test_run_live.html.heex:244
 #: lib/tuist_web/live/test_run_live.html.heex:499
 #: lib/tuist_web/live/test_run_live.html.heex:607
@@ -350,12 +350,12 @@ msgstr ""
 #: lib/tuist_web/live/test_run_live.html.heex:722
 #: lib/tuist_web/live/test_run_live.html.heex:960
 #: lib/tuist_web/live/test_run_live.html.heex:1005
-#: lib/tuist_web/live/test_run_live.html.heex:1219
-#: lib/tuist_web/live/test_run_live.html.heex:1413
-#: lib/tuist_web/live/test_run_live.html.heex:1653
-#: lib/tuist_web/live/test_run_live.html.heex:1827
-#: lib/tuist_web/live/test_run_live.html.heex:2065
-#: lib/tuist_web/live/test_run_live.html.heex:2110
+#: lib/tuist_web/live/test_run_live.html.heex:1213
+#: lib/tuist_web/live/test_run_live.html.heex:1400
+#: lib/tuist_web/live/test_run_live.html.heex:1627
+#: lib/tuist_web/live/test_run_live.html.heex:1798
+#: lib/tuist_web/live/test_run_live.html.heex:2036
+#: lib/tuist_web/live/test_run_live.html.heex:2081
 #: lib/tuist_web/live/test_runs_live.ex:43
 #: lib/tuist_web/live/test_runs_live.html.heex:468
 #: lib/tuist_web/live/tests_live.ex:487
@@ -409,8 +409,8 @@ msgstr ""
 #: lib/tuist_web/live/test_run_live.html.heex:210
 #: lib/tuist_web/live/test_run_live.html.heex:514
 #: lib/tuist_web/live/test_run_live.html.heex:521
-#: lib/tuist_web/live/test_run_live.html.heex:1734
-#: lib/tuist_web/live/test_run_live.html.heex:1741
+#: lib/tuist_web/live/test_run_live.html.heex:1705
+#: lib/tuist_web/live/test_run_live.html.heex:1712
 #, elixir-autogen, elixir-format
 msgid "Failures"
 msgstr ""
@@ -427,14 +427,14 @@ msgstr ""
 #: lib/tuist_web/live/test_case_live.html.heex:498
 #: lib/tuist_web/live/test_cases_live.html.heex:519
 #: lib/tuist_web/live/test_run_live.html.heex:1108
-#: lib/tuist_web/live/test_run_live.html.heex:1325
-#: lib/tuist_web/live/test_run_live.html.heex:1551
+#: lib/tuist_web/live/test_run_live.html.heex:1319
+#: lib/tuist_web/live/test_run_live.html.heex:1535
 #: lib/tuist_web/live/test_runs_live.html.heex:434
 #, elixir-autogen, elixir-format
 msgid "Filter"
 msgstr ""
 
-#: lib/tuist_web/live/test_case_live.ex:489
+#: lib/tuist_web/live/test_case_live.ex:486
 #, elixir-autogen, elixir-format
 msgid "First run of this test"
 msgstr ""
@@ -447,12 +447,12 @@ msgstr ""
 #: lib/tuist_web/live/test_case_live.html.heex:524
 #: lib/tuist_web/live/test_case_run_live.html.heex:40
 #: lib/tuist_web/live/test_cases_live.ex:74
-#: lib/tuist_web/live/test_cases_live.html.heex:568
-#: lib/tuist_web/live/test_run_live.ex:967
+#: lib/tuist_web/live/test_cases_live.html.heex:565
+#: lib/tuist_web/live/test_run_live.ex:944
 #: lib/tuist_web/live/test_run_live.html.heex:55
-#: lib/tuist_web/live/test_run_live.html.heex:1145
-#: lib/tuist_web/live/test_run_live.html.heex:1352
-#: lib/tuist_web/live/test_run_live.html.heex:1578
+#: lib/tuist_web/live/test_run_live.html.heex:1142
+#: lib/tuist_web/live/test_run_live.html.heex:1343
+#: lib/tuist_web/live/test_run_live.html.heex:1559
 #, elixir-autogen, elixir-format
 msgid "Flaky"
 msgstr ""
@@ -463,8 +463,8 @@ msgstr ""
 #: lib/tuist_web/live/test_run_live.html.heex:217
 #: lib/tuist_web/live/test_run_live.html.heex:857
 #: lib/tuist_web/live/test_run_live.html.heex:864
-#: lib/tuist_web/live/test_run_live.html.heex:1969
-#: lib/tuist_web/live/test_run_live.html.heex:1976
+#: lib/tuist_web/live/test_run_live.html.heex:1940
+#: lib/tuist_web/live/test_run_live.html.heex:1947
 #, elixir-autogen, elixir-format
 msgid "Flaky Runs"
 msgstr ""
@@ -477,7 +477,7 @@ msgstr ""
 
 #: lib/tuist_web/live/flaky_tests_live.html.heex:343
 #: lib/tuist_web/live/flaky_tests_live.html.heex:350
-#: lib/tuist_web/live/flaky_tests_live.html.heex:426
+#: lib/tuist_web/live/flaky_tests_live.html.heex:423
 #, elixir-autogen, elixir-format
 msgid "Flaky runs"
 msgstr ""
@@ -495,13 +495,13 @@ msgstr ""
 msgid "Flaky test runs"
 msgstr ""
 
-#: lib/tuist_web/components/runs/selective_testing_tab.ex:160
+#: lib/tuist_web/components/runs/selective_testing_tab.ex:157
 #, elixir-autogen, elixir-format
 msgid "Hash"
 msgstr ""
 
-#: lib/tuist_web/components/runs/selective_testing_tab.ex:140
-#: lib/tuist_web/live/test_run_live.ex:1138
+#: lib/tuist_web/components/runs/selective_testing_tab.ex:137
+#: lib/tuist_web/live/test_run_live.ex:1115
 #, elixir-autogen, elixir-format
 msgid "Hit"
 msgstr ""
@@ -579,7 +579,7 @@ msgstr ""
 
 #: lib/tuist_web/live/flaky_tests_live.html.heex:342
 #: lib/tuist_web/live/flaky_tests_live.html.heex:366
-#: lib/tuist_web/live/flaky_tests_live.html.heex:440
+#: lib/tuist_web/live/flaky_tests_live.html.heex:434
 #, elixir-autogen, elixir-format
 msgid "Last flaky run"
 msgstr ""
@@ -587,14 +587,14 @@ msgstr ""
 #: lib/tuist_web/live/test_case_live.html.heex:186
 #: lib/tuist_web/live/test_cases_live.html.heex:487
 #: lib/tuist_web/live/test_cases_live.html.heex:494
-#: lib/tuist_web/live/test_cases_live.html.heex:642
+#: lib/tuist_web/live/test_cases_live.html.heex:636
 #, elixir-autogen, elixir-format
 msgid "Last ran at"
 msgstr ""
 
 #: lib/tuist_web/live/quarantined_tests_live.html.heex:267
 #: lib/tuist_web/live/quarantined_tests_live.html.heex:274
-#: lib/tuist_web/live/quarantined_tests_live.html.heex:392
+#: lib/tuist_web/live/quarantined_tests_live.html.heex:389
 #, elixir-autogen, elixir-format
 msgid "Last run"
 msgstr ""
@@ -604,29 +604,29 @@ msgstr ""
 msgid "Last run duration"
 msgstr ""
 
-#: lib/tuist_web/live/quarantined_tests_live.html.heex:373
-#: lib/tuist_web/live/test_cases_live.html.heex:624
+#: lib/tuist_web/live/quarantined_tests_live.html.heex:370
+#: lib/tuist_web/live/test_cases_live.html.heex:618
 #, elixir-autogen, elixir-format
 msgid "Last status"
 msgstr ""
 
-#: lib/tuist_web/live/test_case_live.html.heex:666
+#: lib/tuist_web/live/test_case_live.html.heex:660
 #, elixir-autogen, elixir-format
 msgid "Load more"
 msgstr ""
 
 #: lib/tuist_web/live/test_case_run_live.ex:217
-#: lib/tuist_web/live/test_run_live.ex:1303
+#: lib/tuist_web/live/test_run_live.ex:1280
 #, elixir-autogen, elixir-format
 msgid "Loading..."
 msgstr ""
 
-#: lib/tuist_web/components/runs/selective_testing_tab.ex:149
+#: lib/tuist_web/components/runs/selective_testing_tab.ex:146
 #: lib/tuist_web/live/flaky_tests_live.ex:287
 #: lib/tuist_web/live/flaky_tests_live.html.heex:18
 #: lib/tuist_web/live/test_cases_live.ex:391
 #: lib/tuist_web/live/test_cases_live.html.heex:18
-#: lib/tuist_web/live/test_run_live.ex:1143
+#: lib/tuist_web/live/test_run_live.ex:1120
 #: lib/tuist_web/live/test_runs_live.ex:365
 #: lib/tuist_web/live/tests_live.ex:422
 #: lib/tuist_web/live/tests_live.ex:425
@@ -645,7 +645,7 @@ msgstr ""
 msgid "Mac device"
 msgstr ""
 
-#: lib/tuist_web/live/test_case_live.ex:505
+#: lib/tuist_web/live/test_case_live.ex:502
 #, elixir-autogen, elixir-format
 msgid "Manually by @%{name}"
 msgstr ""
@@ -655,13 +655,13 @@ msgstr ""
 msgid "Mark as flaky"
 msgstr ""
 
-#: lib/tuist_web/live/test_case_live.ex:490
+#: lib/tuist_web/live/test_case_live.ex:487
 #, elixir-autogen, elixir-format
 msgid "Marked as flaky"
 msgstr ""
 
-#: lib/tuist_web/components/runs/selective_testing_tab.ex:155
-#: lib/tuist_web/live/test_run_live.ex:1144
+#: lib/tuist_web/components/runs/selective_testing_tab.ex:152
+#: lib/tuist_web/live/test_run_live.ex:1121
 #, elixir-autogen, elixir-format
 msgid "Missed"
 msgstr ""
@@ -689,8 +689,8 @@ msgid "Most occurring flaky tests"
 msgstr ""
 
 #: lib/tuist_web/live/test_case_run_live.html.heex:47
-#: lib/tuist_web/live/test_run_live.ex:966
-#: lib/tuist_web/live/test_run_live.html.heex:1152
+#: lib/tuist_web/live/test_run_live.ex:943
+#: lib/tuist_web/live/test_run_live.html.heex:1149
 #, elixir-autogen, elixir-format
 msgid "New"
 msgstr ""
@@ -708,7 +708,7 @@ msgstr ""
 #: lib/tuist_web/live/flaky_tests_live.html.heex:316
 #: lib/tuist_web/live/quarantined_tests_live.html.heex:234
 #: lib/tuist_web/live/test_cases_live.html.heex:458
-#: lib/tuist_web/live/test_cases_live.html.heex:672
+#: lib/tuist_web/live/test_cases_live.html.heex:663
 #: lib/tuist_web/live/test_runs_live.html.heex:409
 #: lib/tuist_web/live/test_runs_live.html.heex:523
 #: lib/tuist_web/live/tests_live.html.heex:620
@@ -718,37 +718,37 @@ msgid "No data yet"
 msgstr ""
 
 #: lib/tuist_web/live/test_case_run_live.html.heex:1093
-#: lib/tuist_web/live/test_run_live.html.heex:1951
+#: lib/tuist_web/live/test_run_live.html.heex:1922
 #, elixir-autogen, elixir-format
 msgid "No failures detected"
 msgstr ""
 
-#: lib/tuist_web/live/flaky_tests_live.html.heex:478
+#: lib/tuist_web/live/flaky_tests_live.html.heex:469
 #, elixir-autogen, elixir-format
 msgid "No flaky tests"
 msgstr ""
 
-#: lib/tuist_web/live/test_case_live.html.heex:654
+#: lib/tuist_web/live/test_case_live.html.heex:648
 #, elixir-autogen, elixir-format
 msgid "No history available"
 msgstr ""
 
-#: lib/tuist_web/components/runs/selective_testing_tab.ex:171
+#: lib/tuist_web/components/runs/selective_testing_tab.ex:168
 #, elixir-autogen, elixir-format
 msgid "No modules found"
 msgstr ""
 
-#: lib/tuist_web/live/quarantined_tests_live.html.heex:419
+#: lib/tuist_web/live/quarantined_tests_live.html.heex:415
 #, elixir-autogen, elixir-format
 msgid "No quarantined tests"
 msgstr ""
 
-#: lib/tuist_web/live/test_case_live.html.heex:601
+#: lib/tuist_web/live/test_case_live.html.heex:595
 #, elixir-autogen, elixir-format
 msgid "No test case runs found"
 msgstr ""
 
-#: lib/tuist_web/live/test_run_live.html.heex:1231
+#: lib/tuist_web/live/test_run_live.html.heex:1225
 #, elixir-autogen, elixir-format
 msgid "No test cases found"
 msgstr ""
@@ -758,12 +758,12 @@ msgstr ""
 msgid "No test cases yet"
 msgstr ""
 
-#: lib/tuist_web/live/test_run_live.html.heex:1681
+#: lib/tuist_web/live/test_run_live.html.heex:1652
 #, elixir-autogen, elixir-format
 msgid "No test modules found"
 msgstr ""
 
-#: lib/tuist_web/live/test_run_live.html.heex:1446
+#: lib/tuist_web/live/test_run_live.html.heex:1430
 #, elixir-autogen, elixir-format
 msgid "No test suites found"
 msgstr ""
@@ -795,7 +795,7 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: lib/tuist_web/live/quarantined_tests_live.html.heex:376
+#: lib/tuist_web/live/quarantined_tests_live.html.heex:373
 #: lib/tuist_web/live/shards_live.ex:31
 #: lib/tuist_web/live/shards_live.html.heex:568
 #: lib/tuist_web/live/test_case_live.ex:94
@@ -814,22 +814,22 @@ msgstr ""
 #: lib/tuist_web/live/test_case_run_live.html.heex:1000
 #: lib/tuist_web/live/test_case_run_live.html.heex:1037
 #: lib/tuist_web/live/test_cases_live.ex:44
-#: lib/tuist_web/live/test_cases_live.html.heex:628
-#: lib/tuist_web/live/test_run_live.ex:952
-#: lib/tuist_web/live/test_run_live.ex:1014
-#: lib/tuist_web/live/test_run_live.ex:1071
+#: lib/tuist_web/live/test_cases_live.html.heex:622
+#: lib/tuist_web/live/test_run_live.ex:929
+#: lib/tuist_web/live/test_run_live.ex:991
+#: lib/tuist_web/live/test_run_live.ex:1048
 #: lib/tuist_web/live/test_run_live.html.heex:237
 #: lib/tuist_web/live/test_run_live.html.heex:494
 #: lib/tuist_web/live/test_run_live.html.heex:659
 #: lib/tuist_web/live/test_run_live.html.heex:715
 #: lib/tuist_web/live/test_run_live.html.heex:953
 #: lib/tuist_web/live/test_run_live.html.heex:998
-#: lib/tuist_web/live/test_run_live.html.heex:1214
-#: lib/tuist_web/live/test_run_live.html.heex:1408
-#: lib/tuist_web/live/test_run_live.html.heex:1648
-#: lib/tuist_web/live/test_run_live.html.heex:1820
-#: lib/tuist_web/live/test_run_live.html.heex:2058
-#: lib/tuist_web/live/test_run_live.html.heex:2103
+#: lib/tuist_web/live/test_run_live.html.heex:1208
+#: lib/tuist_web/live/test_run_live.html.heex:1395
+#: lib/tuist_web/live/test_run_live.html.heex:1622
+#: lib/tuist_web/live/test_run_live.html.heex:1791
+#: lib/tuist_web/live/test_run_live.html.heex:2029
+#: lib/tuist_web/live/test_run_live.html.heex:2074
 #: lib/tuist_web/live/test_runs_live.ex:42
 #: lib/tuist_web/live/test_runs_live.html.heex:463
 #: lib/tuist_web/live/tests_live.ex:486
@@ -856,9 +856,9 @@ msgstr ""
 #: lib/tuist_web/live/test_case_run_live.html.heex:54
 #: lib/tuist_web/live/test_run_live.html.heex:556
 #: lib/tuist_web/live/test_run_live.html.heex:901
-#: lib/tuist_web/live/test_run_live.html.heex:1159
-#: lib/tuist_web/live/test_run_live.html.heex:1770
-#: lib/tuist_web/live/test_run_live.html.heex:2006
+#: lib/tuist_web/live/test_run_live.html.heex:1156
+#: lib/tuist_web/live/test_run_live.html.heex:1741
+#: lib/tuist_web/live/test_run_live.html.heex:1977
 #, elixir-autogen, elixir-format
 msgid "Quarantined"
 msgstr ""
@@ -870,7 +870,7 @@ msgid "Quarantined Tests"
 msgstr ""
 
 #: lib/tuist_web/live/quarantined_tests_live.ex:75
-#: lib/tuist_web/live/quarantined_tests_live.html.heex:356
+#: lib/tuist_web/live/quarantined_tests_live.html.heex:353
 #, elixir-autogen, elixir-format
 msgid "Quarantined by"
 msgstr ""
@@ -884,7 +884,7 @@ msgstr ""
 #: lib/tuist_web/live/shards_live.html.heex:610
 #: lib/tuist_web/live/test_case_live.html.heex:474
 #: lib/tuist_web/live/test_case_live.html.heex:481
-#: lib/tuist_web/live/test_case_live.html.heex:586
+#: lib/tuist_web/live/test_case_live.html.heex:583
 #: lib/tuist_web/live/test_case_run_live.html.heex:158
 #: lib/tuist_web/live/test_run_live.html.heex:293
 #: lib/tuist_web/live/test_run_live.html.heex:429
@@ -910,8 +910,8 @@ msgstr ""
 msgid "Recent Test Runs"
 msgstr ""
 
-#: lib/tuist_web/components/runs/selective_testing_tab.ex:143
-#: lib/tuist_web/live/test_run_live.ex:1142
+#: lib/tuist_web/components/runs/selective_testing_tab.ex:140
+#: lib/tuist_web/live/test_run_live.ex:1119
 #, elixir-autogen, elixir-format
 msgid "Remote"
 msgstr ""
@@ -941,8 +941,8 @@ msgstr ""
 #: lib/tuist_web/live/test_case_live.html.heex:463
 #: lib/tuist_web/live/test_cases_live.html.heex:475
 #: lib/tuist_web/live/test_run_live.html.heex:1073
-#: lib/tuist_web/live/test_run_live.html.heex:1262
-#: lib/tuist_web/live/test_run_live.html.heex:1477
+#: lib/tuist_web/live/test_run_live.html.heex:1256
+#: lib/tuist_web/live/test_run_live.html.heex:1461
 #: lib/tuist_web/live/test_runs_live.html.heex:426
 #: lib/tuist_web/live/tests_live.html.heex:11
 #, elixir-autogen, elixir-format
@@ -988,31 +988,31 @@ msgstr ""
 
 #: lib/tuist_web/live/test_case_run_live.html.heex:473
 #: lib/tuist_web/live/test_run_live.html.heex:802
-#: lib/tuist_web/live/test_run_live.html.heex:1904
+#: lib/tuist_web/live/test_run_live.html.heex:1875
 #, elixir-autogen, elixir-format
 msgid "Signal"
 msgstr ""
 
 #: lib/tuist_web/live/quarantined_tests_live.ex:64
-#: lib/tuist_web/live/quarantined_tests_live.html.heex:350
-#: lib/tuist_web/live/quarantined_tests_live.html.heex:386
+#: lib/tuist_web/live/quarantined_tests_live.html.heex:347
+#: lib/tuist_web/live/quarantined_tests_live.html.heex:383
 #: lib/tuist_web/live/shards_live.html.heex:583
 #: lib/tuist_web/live/test_case_live.ex:96
-#: lib/tuist_web/live/test_case_live.ex:464
-#: lib/tuist_web/live/test_case_live.ex:494
+#: lib/tuist_web/live/test_case_live.ex:461
+#: lib/tuist_web/live/test_case_live.ex:491
 #: lib/tuist_web/live/test_case_live.html.heex:84
 #: lib/tuist_web/live/test_case_live.html.heex:170
 #: lib/tuist_web/live/test_case_live.html.heex:546
 #: lib/tuist_web/live/test_case_run_live.html.heex:136
 #: lib/tuist_web/live/test_cases_live.ex:46
 #: lib/tuist_web/live/test_cases_live.ex:76
-#: lib/tuist_web/live/test_cases_live.html.heex:582
-#: lib/tuist_web/live/test_cases_live.html.heex:635
-#: lib/tuist_web/live/test_run_live.ex:954
-#: lib/tuist_web/live/test_run_live.ex:1016
+#: lib/tuist_web/live/test_cases_live.html.heex:579
+#: lib/tuist_web/live/test_cases_live.html.heex:629
+#: lib/tuist_web/live/test_run_live.ex:931
+#: lib/tuist_web/live/test_run_live.ex:993
 #: lib/tuist_web/live/test_run_live.html.heex:258
-#: lib/tuist_web/live/test_run_live.html.heex:1224
-#: lib/tuist_web/live/test_run_live.html.heex:1418
+#: lib/tuist_web/live/test_run_live.html.heex:1218
+#: lib/tuist_web/live/test_run_live.html.heex:1405
 #: lib/tuist_web/live/test_runs_live.ex:44
 #: lib/tuist_web/live/test_runs_live.html.heex:473
 #: lib/tuist_web/live/tests_live.html.heex:956
@@ -1030,8 +1030,8 @@ msgstr ""
 #: lib/tuist_web/live/test_case_live.html.heex:477
 #: lib/tuist_web/live/test_cases_live.html.heex:490
 #: lib/tuist_web/live/test_run_live.html.heex:1087
-#: lib/tuist_web/live/test_run_live.html.heex:1288
-#: lib/tuist_web/live/test_run_live.html.heex:1506
+#: lib/tuist_web/live/test_run_live.html.heex:1282
+#: lib/tuist_web/live/test_run_live.html.heex:1490
 #, elixir-autogen, elixir-format
 msgid "Sort by:"
 msgstr ""
@@ -1042,13 +1042,13 @@ msgstr ""
 #: lib/tuist_web/live/test_case_live.html.heex:533
 #: lib/tuist_web/live/test_case_run_live.html.heex:119
 #: lib/tuist_web/live/test_case_run_live.html.heex:845
-#: lib/tuist_web/live/test_run_live.ex:948
-#: lib/tuist_web/live/test_run_live.ex:1010
-#: lib/tuist_web/live/test_run_live.ex:1067
+#: lib/tuist_web/live/test_run_live.ex:925
+#: lib/tuist_web/live/test_run_live.ex:987
+#: lib/tuist_web/live/test_run_live.ex:1044
 #: lib/tuist_web/live/test_run_live.html.heex:234
 #: lib/tuist_web/live/test_run_live.html.heex:491
-#: lib/tuist_web/live/test_run_live.html.heex:1405
-#: lib/tuist_web/live/test_run_live.html.heex:1645
+#: lib/tuist_web/live/test_run_live.html.heex:1392
+#: lib/tuist_web/live/test_run_live.html.heex:1619
 #: lib/tuist_web/live/test_runs_live.ex:38
 #: lib/tuist_web/live/tests_live.ex:471
 #, elixir-autogen, elixir-format
@@ -1057,7 +1057,7 @@ msgstr ""
 
 #: lib/tuist_web/live/test_case_run_live.html.heex:480
 #: lib/tuist_web/live/test_run_live.html.heex:809
-#: lib/tuist_web/live/test_run_live.html.heex:1911
+#: lib/tuist_web/live/test_run_live.html.heex:1882
 #, elixir-autogen, elixir-format
 msgid "Subtype"
 msgstr ""
@@ -1087,7 +1087,7 @@ msgstr ""
 #: lib/tuist_web/live/test_cases_live.html.heex:485
 #: lib/tuist_web/live/test_cases_live.html.heex:502
 #: lib/tuist_web/live/test_cases_live.html.heex:552
-#: lib/tuist_web/live/test_run_live.ex:962
+#: lib/tuist_web/live/test_run_live.ex:939
 #, elixir-autogen, elixir-format
 msgid "Test Case"
 msgstr ""
@@ -1128,7 +1128,7 @@ msgid "Test Details"
 msgstr ""
 
 #: lib/tuist_web/live/test_case_live.html.heex:135
-#: lib/tuist_web/live/test_case_live.html.heex:621
+#: lib/tuist_web/live/test_case_live.html.heex:615
 #, elixir-autogen, elixir-format
 msgid "Test History"
 msgstr ""
@@ -1197,15 +1197,15 @@ msgstr ""
 
 #: lib/tuist_web/live/test_cases_live.ex:329
 #: lib/tuist_web/live/test_cases_live.html.heex:220
-#: lib/tuist_web/live/test_run_live.ex:986
-#: lib/tuist_web/live/test_run_live.ex:1043
+#: lib/tuist_web/live/test_run_live.ex:963
+#: lib/tuist_web/live/test_run_live.ex:1020
 #: lib/tuist_web/live/test_run_live.html.heex:364
-#: lib/tuist_web/live/test_run_live.html.heex:1276
-#: lib/tuist_web/live/test_run_live.html.heex:1300
-#: lib/tuist_web/live/test_run_live.html.heex:1372
-#: lib/tuist_web/live/test_run_live.html.heex:1494
-#: lib/tuist_web/live/test_run_live.html.heex:1526
-#: lib/tuist_web/live/test_run_live.html.heex:1612
+#: lib/tuist_web/live/test_run_live.html.heex:1270
+#: lib/tuist_web/live/test_run_live.html.heex:1294
+#: lib/tuist_web/live/test_run_live.html.heex:1363
+#: lib/tuist_web/live/test_run_live.html.heex:1478
+#: lib/tuist_web/live/test_run_live.html.heex:1510
+#: lib/tuist_web/live/test_run_live.html.heex:1590
 #, elixir-autogen, elixir-format
 msgid "Test cases"
 msgstr ""
@@ -1293,21 +1293,21 @@ msgstr ""
 msgid "Total number of times this test case has been executed."
 msgstr ""
 
-#: lib/tuist_web/components/runs/selective_testing_tab.ex:172
+#: lib/tuist_web/components/runs/selective_testing_tab.ex:169
 #, elixir-autogen, elixir-format
 msgid "Try changing your search term"
 msgstr ""
 
-#: lib/tuist_web/live/test_case_live.html.heex:602
-#: lib/tuist_web/live/test_run_live.html.heex:1232
-#: lib/tuist_web/live/test_run_live.html.heex:1447
-#: lib/tuist_web/live/test_run_live.html.heex:1682
+#: lib/tuist_web/live/test_case_live.html.heex:596
+#: lib/tuist_web/live/test_run_live.html.heex:1226
+#: lib/tuist_web/live/test_run_live.html.heex:1431
+#: lib/tuist_web/live/test_run_live.html.heex:1653
 #, elixir-autogen, elixir-format
 msgid "Try updating your search"
 msgstr ""
 
 #: lib/tuist_web/live/quarantined_tests_live.ex:80
-#: lib/tuist_web/live/quarantined_tests_live.html.heex:359
+#: lib/tuist_web/live/quarantined_tests_live.html.heex:356
 #, elixir-autogen, elixir-format
 msgid "Tuist"
 msgstr ""
@@ -1317,7 +1317,7 @@ msgstr ""
 msgid "Tuist version"
 msgstr ""
 
-#: lib/tuist_web/components/runs/selective_testing_tab.ex:162
+#: lib/tuist_web/components/runs/selective_testing_tab.ex:159
 #: lib/tuist_web/live/shards_live.html.heex:555
 #: lib/tuist_web/live/shards_live.html.heex:562
 #: lib/tuist_web/live/test_case_live.html.heex:521
@@ -1350,7 +1350,7 @@ msgstr ""
 msgid "Unmark as flaky"
 msgstr ""
 
-#: lib/tuist_web/live/test_case_live.ex:491
+#: lib/tuist_web/live/test_case_live.ex:488
 #, elixir-autogen, elixir-format
 msgid "Unmarked as flaky"
 msgstr ""
@@ -1492,8 +1492,8 @@ msgstr ""
 
 #: lib/tuist_web/live/test_run_live.html.heex:524
 #: lib/tuist_web/live/test_run_live.html.heex:867
-#: lib/tuist_web/live/test_run_live.html.heex:1744
-#: lib/tuist_web/live/test_run_live.html.heex:1979
+#: lib/tuist_web/live/test_run_live.html.heex:1715
+#: lib/tuist_web/live/test_run_live.html.heex:1950
 #, elixir-autogen, elixir-format
 msgid "•"
 msgstr ""
@@ -1550,21 +1550,21 @@ msgid "Pending"
 msgstr ""
 
 #: lib/tuist_web/live/test_case_run_live.html.heex:197
-#: lib/tuist_web/live/test_run_live.ex:1105
+#: lib/tuist_web/live/test_run_live.ex:1082
 #: lib/tuist_web/live/test_run_live.html.heex:459
-#: lib/tuist_web/live/test_run_live.html.heex:1184
-#: lib/tuist_web/live/test_run_live.html.heex:1364
-#: lib/tuist_web/live/test_run_live.html.heex:1590
+#: lib/tuist_web/live/test_run_live.html.heex:1181
+#: lib/tuist_web/live/test_run_live.html.heex:1355
+#: lib/tuist_web/live/test_run_live.html.heex:1571
 #, elixir-autogen, elixir-format
 msgid "Shard"
 msgstr ""
 
 #: lib/tuist_web/live/test_case_run_live.html.heex:201
-#: lib/tuist_web/live/test_run_live.ex:1099
+#: lib/tuist_web/live/test_run_live.ex:1076
 #: lib/tuist_web/live/test_run_live.html.heex:461
-#: lib/tuist_web/live/test_run_live.html.heex:1187
-#: lib/tuist_web/live/test_run_live.html.heex:1367
-#: lib/tuist_web/live/test_run_live.html.heex:1593
+#: lib/tuist_web/live/test_run_live.html.heex:1184
+#: lib/tuist_web/live/test_run_live.html.heex:1358
+#: lib/tuist_web/live/test_run_live.html.heex:1574
 #, elixir-autogen, elixir-format
 msgid "Shard %{index}"
 msgstr ""
@@ -1692,9 +1692,9 @@ msgstr ""
 msgid "The 10,000 entry limit has been reached, data is only included up to %{date}. Try filtering to narrow down the dataset."
 msgstr ""
 
-#: lib/tuist_web/live/test_case_live.ex:465
-#: lib/tuist_web/live/test_case_live.ex:493
-#: lib/tuist_web/live/test_case_live.ex:495
+#: lib/tuist_web/live/test_case_live.ex:462
+#: lib/tuist_web/live/test_case_live.ex:490
+#: lib/tuist_web/live/test_case_live.ex:492
 #: lib/tuist_web/live/test_case_live.html.heex:66
 #, elixir-autogen, elixir-format
 msgid "Enabled"
@@ -1706,18 +1706,18 @@ msgid "Number of distinct test cases with at least one run in the 14 days ending
 msgstr ""
 
 #: lib/tuist_web/live/quarantined_tests_live.ex:59
-#: lib/tuist_web/live/quarantined_tests_live.html.heex:340
+#: lib/tuist_web/live/quarantined_tests_live.html.heex:337
 #, elixir-autogen, elixir-format
 msgid "Mode"
 msgstr ""
 
 #: lib/tuist_web/live/quarantined_tests_live.ex:63
-#: lib/tuist_web/live/quarantined_tests_live.html.heex:343
-#: lib/tuist_web/live/test_case_live.ex:463
-#: lib/tuist_web/live/test_case_live.ex:492
+#: lib/tuist_web/live/quarantined_tests_live.html.heex:340
+#: lib/tuist_web/live/test_case_live.ex:460
+#: lib/tuist_web/live/test_case_live.ex:489
 #: lib/tuist_web/live/test_case_live.html.heex:75
 #: lib/tuist_web/live/test_cases_live.ex:75
-#: lib/tuist_web/live/test_cases_live.html.heex:575
+#: lib/tuist_web/live/test_cases_live.html.heex:572
 #, elixir-autogen, elixir-format
 msgid "Muted"
 msgstr ""
@@ -1792,7 +1792,7 @@ msgstr ""
 msgid "Skipped tests"
 msgstr ""
 
-#: lib/tuist_web/live/test_case_live.ex:501
+#: lib/tuist_web/live/test_case_live.ex:498
 #, elixir-autogen, elixir-format
 msgid "By automation %{name}"
 msgstr ""


### PR DESCRIPTION
A set of UX improvements to the Noora table component, applied across all dashboard tables:

* Floating header & scrollbar — on long tables, the header pins to the viewport top and a proxy scrollbar pins to the viewport bottom until the table's own edge scrolls into view. Scrollbar styling is now consistent across engines: webkit-styled native bar in Chrome/Safari, and a custom synced, draggable bar on Firefox/overlay-scrollbar platforms.

https://github.com/user-attachments/assets/ddd46f97-54aa-4078-98e4-77503fad67e8

* Sortable columns — sortable headers take a sort_order attr and render a morphing arrow indicator (spring-animated path morph between up/down). Column widths are "ratcheted" (pinned as ever-growing min-width, only once a table overflows) so sorting no longer shifts columns left/right.

https://github.com/user-attachments/assets/f9299bcb-89c5-4cb1-ae87-6fc0f42b1b61

* Expandable rows — the expand chevron crossfades/rotates, and expanded content reveals with a 200ms ease-out-cubic grid-template-rows: 0fr ⟷ 1fr transition.

https://github.com/user-attachments/assets/4910b266-bf72-4e92-9bed-076bf0168dbd