### PR TITLE
feat(server): cap local kind Kura CAS capacity at 10Gi

### DIFF
--- a/server/lib/tuist/kura/provisioner/kubernetes_controller.ex
+++ b/server/lib/tuist/kura/provisioner/kubernetes_controller.ex
@@ -19,7 +19,7 @@ defmodule Tuist.Kura.Provisioner.KubernetesController do
   alias Tuist.Kura.Server
 
   @namespace "kura"
-  @manifest_revision "2026-06-10-uuid-kura-introspection-v1"
+  @manifest_revision "2026-06-12-local-cas-capacity-v1"
   @manifest_revision_annotation "tuist.dev/kura-manifest-revision"
   @gateway_annotation "tuist.dev/kura-gateway"
   @gateway_controller_image "registry.k8s.io/ingress-nginx/controller:v1.11.3"
@@ -283,8 +283,16 @@ defmodule Tuist.Kura.Provisioner.KubernetesController do
         "KURA_CONTROL_PLANE_CLIENT_ID",
         Environment.kura_control_plane_client_id()
       ) ++
-      telemetry_env(region)
+      telemetry_env(region) ++
+      cas_capacity_env(region)
   end
+
+  defp cas_capacity_env(%Regions{provisioner_config: %{cas_capacity_bytes: bytes}})
+       when is_integer(bytes) and bytes > 0 do
+    [env_var("KURA_CAS_CAPACITY_BYTES", Integer.to_string(bytes))]
+  end
+
+  defp cas_capacity_env(_), do: []
 
   defp telemetry_env(%Regions{provisioner_config: %{otlp_traces_endpoint: endpoint}})
        when is_binary(endpoint) and endpoint != "" do

--- a/server/lib/tuist/kura/regions.ex
+++ b/server/lib/tuist/kura/regions.ex
@@ -218,7 +218,12 @@ defmodule Tuist.Kura.Regions do
         otlp_traces_endpoint: "http://127.0.0.1:4318/v1/traces",
         public_url: "http://localhost:#{@local_controller_kura_base_port + suffix}",
         replicas: 1,
-        storage_size: "10Gi"
+        storage_size: "10Gi",
+        # kind's local-path provisioner is hostPath-backed and doesn't
+        # enforce the PVC request, so without an explicit cap Kura would
+        # derive the CAS segment-ring budget from the host disk instead
+        # of the nominal 10Gi volume.
+        cas_capacity_bytes: 10 * 1024 * 1024 * 1024
       }
     }
   end

--- a/server/test/tuist/kura/provisioner/kubernetes_controller_test.exs
+++ b/server/test/tuist/kura/provisioner/kubernetes_controller_test.exs
@@ -60,6 +60,10 @@ defmodule Tuist.Kura.Provisioner.KubernetesControllerTest do
 
       refute Map.has_key?(env, "KURA_PEERS")
 
+      # Managed regions run on real hcloud volumes, so the runtime derives
+      # the CAS budget from the volume size instead of an explicit cap.
+      refute Map.has_key?(env, "KURA_CAS_CAPACITY_BYTES")
+
       # Tuist platform secrets (JWT verifier) live in the
       # kura-shared-secrets Kubernetes Secret; the controller envFroms
       # them into the pod. They must NEVER appear in the spec, since
@@ -229,6 +233,7 @@ defmodule Tuist.Kura.Provisioner.KubernetesControllerTest do
       refute Map.has_key?(env, "KURA_EXTENSION_TUIST_INTROSPECT_CLIENT_ID")
 
       assert env["KURA_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"] == "http://127.0.0.1:4318/v1/traces"
+      assert env["KURA_CAS_CAPACITY_BYTES"] == "10737418240"
     end
   end
 
@@ -467,7 +472,8 @@ defmodule Tuist.Kura.Provisioner.KubernetesControllerTest do
         otlp_traces_endpoint: "http://127.0.0.1:4318/v1/traces",
         public_url: "http://localhost:4100",
         replicas: 1,
-        storage_size: "10Gi"
+        storage_size: "10Gi",
+        cas_capacity_bytes: 10 * 1024 * 1024 * 1024
       }
     }
   end

--- a/server/test/tuist/kura/regions_test.exs
+++ b/server/test/tuist/kura/regions_test.exs
@@ -65,6 +65,7 @@ defmodule Tuist.Kura.RegionsTest do
       assert String.starts_with?(config.kubernetes_client[:context], "kind-kura-dev-")
       assert config.replicas == 1
       assert config.storage_size == "10Gi"
+      assert config.cas_capacity_bytes == 10 * 1024 * 1024 * 1024
       assert config.node_selector == %{"kubernetes.io/os" => "linux"}
     end
 


### PR DESCRIPTION
## What changed

Sets `KURA_CAS_CAPACITY_BYTES` to 10Gi (`10737418240`) for the local kind dev Kura region (`local-controller`), via a new `cas_capacity_bytes` knob in the region's `provisioner_config` that the Kubernetes provisioner emits through the `KuraInstance` `extraEnv`. Also bumps the provisioner's manifest revision (`2026-06-12-local-cas-capacity-v1`) so the reconciler re-applies the updated manifest to existing instances.

## Why

#11222 made the Kura runtime derive the CAS segment-ring budget from the data volume's filesystem size (50% of capacity, capped at 80%) when `KURA_CAS_CAPACITY_BYTES` is unset. That works on managed regions, where the data dir is a real `hcloud-volumes` block device sized by the PVC. But on the local kind dev cluster the default storage class is the hostPath-backed local-path provisioner, which does **not** enforce the PVC's `10Gi` request — `statvfs` on the data dir reports the developer machine's whole disk, so the derived CAS budget would be half the host disk rather than the nominal 10Gi volume.

Capping it explicitly keeps local dev cache usage bounded to match the region's declared `storage_size`.

## Why this shape

There is no dedicated `KuraInstance` CRD field for CAS capacity, and adding one isn't warranted for a dev-only knob: the existing `extraEnv` passthrough (`extension_env/1`) is the established channel for non-secret per-region runtime configuration. Managed regions intentionally do not set the variable, so they keep the disk-derived budget — a test now pins that behavior.

The manifest revision bump is required for the change to reach already-provisioned instances: the reconciler only re-applies a manifest when the desired revision differs from the `tuist.dev/kura-manifest-revision` annotation on the live CR. For managed regions the re-apply is a no-op (their manifest is unchanged).

## Validation

- `mix test test/tuist/kura/regions_test.exs test/tuist/kura/provisioner/kubernetes_controller_test.exs` — 45 tests, 0 failures
- `mix credo` on the changed lib files — no issues
- New assertions: local-controller manifest carries `KURA_CAS_CAPACITY_BYTES=10737418240`; the managed eu-central manifest does not carry the variable
- Applied end-to-end on a live local kind cluster (`kura-dev-991`): ran `Tuist.Kura.reconcile_orphaned_deployments()` with this branch's code, confirmed the KuraInstance picked up the new revision annotation and env var, the controller propagated it into the StatefulSet, and the restarted pod runs with `KURA_CAS_CAPACITY_BYTES=10737418240` in its environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)