### PR TITLE
docs(server): rename self-hosting server docs

### DIFF
--- a/server/lib/tuist/docs/redirects.ex
+++ b/server/lib/tuist/docs/redirects.ex
@@ -39,10 +39,10 @@ defmodule Tuist.Docs.Redirects do
     {:exact, "/tutorials/tuist/install", "/tutorials/xcode/create-a-generated-project"},
     {:exact, "/tutorials/tuist/create-project", "/tutorials/xcode/create-a-generated-project"},
     {:exact, "/tutorials/tuist/external-dependencies", "/tutorials/xcode/create-a-generated-project"},
-    {:exact, "/tutorials/tuist-cloud-tutorials", "/guides/server/self-host/control-plane"},
-    {:exact, "/tutorials/tuist/enterprise-infrastructure-requirements", "/guides/server/self-host/control-plane"},
-    {:exact, "/tutorials/tuist/enterprise-environment", "/guides/server/self-host/control-plane"},
-    {:exact, "/tutorials/tuist/enterprise-deployment", "/guides/server/self-host/control-plane"},
+    {:exact, "/tutorials/tuist-cloud-tutorials", "/guides/server/self-host/server"},
+    {:exact, "/tutorials/tuist/enterprise-infrastructure-requirements", "/guides/server/self-host/server"},
+    {:exact, "/tutorials/tuist/enterprise-environment", "/guides/server/self-host/server"},
+    {:exact, "/tutorials/tuist/enterprise-deployment", "/guides/server/self-host/server"},
 
     # Legacy guide structure
     {:exact, "/contributors/get-started", "/contributors/code"},
@@ -84,7 +84,7 @@ defmodule Tuist.Docs.Redirects do
     {:exact, "/cloud/binary-caching", "/guides/features/cache"},
     {:exact, "/cloud/selective-testing", "/guides/features/selective-testing"},
     {:exact, "/cloud/hashing", "/guides/features/projects/hashing"},
-    {:exact, "/cloud/on-premise", "/guides/server/self-host/control-plane"},
+    {:exact, "/cloud/on-premise", "/guides/server/self-host/server"},
     {:exact, "/cloud/on-premise/metrics", "/guides/server/self-host/telemetry"},
 
     # Examples and project description references
@@ -103,7 +103,7 @@ defmodule Tuist.Docs.Redirects do
 
     # VitePress docs reorganizations
     {:exact, "/guides/develop/workflows", "/guides/integrations/continuous-integration"},
-    {:exact, "/guides/dashboard/on-premise/install", "/guides/server/self-host/control-plane"},
+    {:exact, "/guides/dashboard/on-premise/install", "/guides/server/self-host/server"},
     {:exact, "/guides/dashboard/on-premise/metrics", "/guides/server/self-host/telemetry"},
     {:exact, "/guides/start/new-project", "/guides/features/projects/adoption/new-project"},
     {:exact, "/guides/start/swift-package", "/guides/features/projects/adoption/swift-package"},
@@ -123,7 +123,8 @@ defmodule Tuist.Docs.Redirects do
     {:exact, "/guides/develop/selective-testing/xcodebuild", "/guides/features/selective-testing"},
     {:exact, "/guides/features/mcp", "/guides/features/agentic-coding/mcp"},
     {:exact, "/guides/features/agentic-building/mcp", "/guides/features/agentic-coding/mcp"},
-    {:exact, "/guides/server/self-host/install", "/guides/server/self-host/control-plane"},
+    {:exact, "/guides/server/self-host/control-plane", "/guides/server/self-host/server"},
+    {:exact, "/guides/server/self-host/install", "/guides/server/self-host/server"},
     {:exact, "/guides/server/self-host/kura", "/guides/features/cache/self-hosting"},
     {:exact, "/guides/environments/continuous-integration", "/guides/integrations/continuous-integration"},
     {:exact, "/guides/environments/automate/continuous-integration", "/guides/integrations/continuous-integration"},
@@ -132,9 +133,9 @@ defmodule Tuist.Docs.Redirects do
     {:exact, "/server/introduction/accounts-and-projects", "/guides/server/accounts-and-projects"},
     {:exact, "/server/introduction/authentication", "/guides/server/authentication"},
     {:exact, "/server/introduction/integrations", "/guides/integrations/gitforge/github"},
-    {:exact, "/server/on-premise/install", "/guides/server/self-host/control-plane"},
+    {:exact, "/server/on-premise/install", "/guides/server/self-host/server"},
     {:exact, "/server/on-premise/metrics", "/guides/server/self-host/telemetry"},
-    {:exact, "/guides/server/install", "/guides/server/self-host/control-plane"},
+    {:exact, "/guides/server/install", "/guides/server/self-host/server"},
     {:exact, "/guides/server/metrics", "/guides/server/self-host/telemetry"},
     {:exact, "/server", "/guides/server/accounts-and-projects"},
     {:exact, "/guides/quick-start/install-tuist", "/guides/install-tuist"},

--- a/server/lib/tuist/docs_sidebar.ex
+++ b/server/lib/tuist/docs_sidebar.ex
@@ -378,7 +378,7 @@ defmodule Tuist.Docs.Sidebar do
           %Item{
             label: "Self-hosting",
             items: [
-              %Item{label: "Server", slug: "/en/guides/server/self-host/control-plane"},
+              %Item{label: "Server", slug: "/en/guides/server/self-host/server"},
               %Item{label: "Cache", slug: "/en/guides/features/cache/self-hosting"},
               %Item{label: "Telemetry", slug: "/en/guides/server/self-host/telemetry"}
             ]

--- a/server/lib/tuist/docs_sidebar.ex
+++ b/server/lib/tuist/docs_sidebar.ex
@@ -378,8 +378,8 @@ defmodule Tuist.Docs.Sidebar do
           %Item{
             label: "Self-hosting",
             items: [
-              %Item{label: "Control plane", slug: "/en/guides/server/self-host/control-plane"},
-              %Item{label: "Cache", slug: "/en/guides/features/cache/self-hosting"},
+              %Item{label: "Server", slug: "/en/guides/server/self-host/control-plane"},
+              %Item{label: "Cache server", slug: "/en/guides/features/cache/self-hosting"},
               %Item{label: "Telemetry", slug: "/en/guides/server/self-host/telemetry"}
             ]
           }

--- a/server/lib/tuist/docs_sidebar.ex
+++ b/server/lib/tuist/docs_sidebar.ex
@@ -379,7 +379,7 @@ defmodule Tuist.Docs.Sidebar do
             label: "Self-hosting",
             items: [
               %Item{label: "Server", slug: "/en/guides/server/self-host/control-plane"},
-              %Item{label: "Cache server", slug: "/en/guides/features/cache/self-hosting"},
+              %Item{label: "Cache", slug: "/en/guides/features/cache/self-hosting"},
               %Item{label: "Telemetry", slug: "/en/guides/server/self-host/telemetry"}
             ]
           }

--- a/server/priv/docs/en/guides/cache/self-host.md
+++ b/server/priv/docs/en/guides/cache/self-host.md
@@ -13,7 +13,7 @@ The Tuist cache service can be self-hosted to provide a private binary cache for
 > [!NOTE]
 > Self-hosting cache nodes requires an **Enterprise plan**.
 >
-> You can connect self-hosted cache nodes to either the hosted Tuist server (`https://tuist.dev`) or a self-hosted Tuist server. Self-hosting the Tuist server itself requires a separate server license. See the <.localized_link href="/guides/server/self-host/control-plane">server self-hosting guide</.localized_link>.
+> You can connect self-hosted cache nodes to either the hosted Tuist server (`https://tuist.dev`) or a self-hosted Tuist server. Self-hosting the Tuist server itself requires a separate server license. See the <.localized_link href="/guides/server/self-host/server">server self-hosting guide</.localized_link>.
 
 
 ## Prerequisites {#prerequisites}

--- a/server/priv/docs/en/guides/server/self-host/control-plane.md
+++ b/server/priv/docs/en/guides/server/self-host/control-plane.md
@@ -1,11 +1,11 @@
 ---
 {
-  "title": "Control plane",
+  "title": "Server",
   "titleTemplate": ":title | Self-hosting | Server | Guides | Tuist",
-  "description": "Learn how to deploy the Tuist control plane on your infrastructure."
+  "description": "Learn how to deploy the Tuist server on your infrastructure."
 }
 ---
-# Control plane {#control-plane}
+# Server {#control-plane}
 
 We offer a self-hosted version of the Tuist server for organizations that require more control over their infrastructure. This version allows you to host Tuist on your own infrastructure, ensuring that your data remains secure and private.
 

--- a/server/priv/docs/en/guides/server/self-host/server.md
+++ b/server/priv/docs/en/guides/server/self-host/server.md
@@ -5,7 +5,7 @@
   "description": "Learn how to deploy the Tuist server on your infrastructure."
 }
 ---
-# Server {#control-plane}
+# Server {#server}
 
 We offer a self-hosted version of the Tuist server for organizations that require more control over their infrastructure. This version allows you to host Tuist on your own infrastructure, ensuring that your data remains secure and private.
 

--- a/server/priv/docs/strings/en.json
+++ b/server/priv/docs/strings/en.json
@@ -478,7 +478,7 @@
                   "text": "Server"
                 },
                 "kura": {
-                  "text": "Cache server"
+                  "text": "Cache"
                 },
                 "telemetry": {
                   "text": "Telemetry"

--- a/server/priv/docs/strings/en.json
+++ b/server/priv/docs/strings/en.json
@@ -477,7 +477,7 @@
                 "server": {
                   "text": "Server"
                 },
-                "kura": {
+                "cache": {
                   "text": "Cache"
                 },
                 "telemetry": {

--- a/server/priv/docs/strings/en.json
+++ b/server/priv/docs/strings/en.json
@@ -475,10 +475,10 @@
               "text": "Self-hosting",
               "items": {
                 "control-plane": {
-                  "text": "Control plane"
+                  "text": "Server"
                 },
                 "kura": {
-                  "text": "Kura"
+                  "text": "Cache server"
                 },
                 "telemetry": {
                   "text": "Telemetry"

--- a/server/priv/docs/strings/en.json
+++ b/server/priv/docs/strings/en.json
@@ -474,7 +474,7 @@
             "self-hosting": {
               "text": "Self-hosting",
               "items": {
-                "control-plane": {
+                "server": {
                   "text": "Server"
                 },
                 "kura": {

--- a/server/test/tuist/docs/redirects_test.exs
+++ b/server/test/tuist/docs/redirects_test.exs
@@ -24,9 +24,14 @@ defmodule Tuist.Docs.RedirectsTest do
                {:ok, "/en/docs/guides/integrations/authentication/sso"}
     end
 
-    test "redirects the old self-host installation route to control plane" do
+    test "redirects the old self-host installation route to server" do
       assert Redirects.resolve("/en/docs/guides/server/self-host/install") ==
-               {:ok, "/en/docs/guides/server/self-host/control-plane"}
+               {:ok, "/en/docs/guides/server/self-host/server"}
+    end
+
+    test "redirects the old self-host control plane route to server" do
+      assert Redirects.resolve("/en/docs/guides/server/self-host/control-plane") ==
+               {:ok, "/en/docs/guides/server/self-host/server"}
     end
 
     test "redirects the old Kura self-hosting route to cache self-hosting" do


### PR DESCRIPTION
## What changed

- Renamed the self-hosting page title and heading from "Control plane" to "Server".
- Updated the self-hosting sidebar label from "Control plane" to "Server".
- Updated the English docs navigation string to match the new server label.
- Moved the canonical page slug from `/guides/server/self-host/control-plane` to `/guides/server/self-host/server`.
- Added a redirect from the old `/control-plane` slug and retargeted legacy self-hosting redirects to the new `/server` slug.

## Why

The page documents deploying and configuring the self-hosted Tuist server. "Control plane" was technically adjacent to the cache/server architecture, but it was more abstract than the terminology we use with users and internally. "Server" makes the self-hosting docs easier to scan while keeping the existing "Cache" label unchanged.

## Root cause

The self-hosted server guide had inherited the control-plane wording while the actual content describes the Tuist server deployment. That made the page title feel disconnected from the content.

## Impact

Users see clearer labels in the docs sidebar and page metadata. The canonical self-hosted server guide now lives at `/guides/server/self-host/server`, while the old `/guides/server/self-host/control-plane` URL redirects to it for link compatibility.

## Validation

- `jq empty server/priv/docs/strings/en.json`
- `git diff --check HEAD~1 HEAD`
- `/Users/marekfort/.local/share/mise/installs/elixir/1.19.5/bin/mix format lib/tuist/docs/redirects.ex lib/tuist/docs_sidebar.ex test/tuist/docs/redirects_test.exs`
- `/Users/marekfort/.local/share/mise/installs/elixir/1.19.5/bin/mix test test/tuist/docs/redirects_test.exs`
