### PR TITLE
ci(grafana-datasource): read the signing token from 1Password

### DIFF
--- a/.github/workflows/grafana-datasource-release.yml
+++ b/.github/workflows/grafana-datasource-release.yml
@@ -51,7 +51,7 @@ jobs:
       run:
         working-directory: grafana-datasource
     env:
-      GRAFANA_ACCESS_POLICY_TOKEN: ${{ secrets.GRAFANA_ACCESS_POLICY_TOKEN }}
+      OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
       TAG: ${{ needs.check-releases.outputs.next-version }}
       VERSION: ${{ needs.check-releases.outputs.next-version-number }}
     steps:
@@ -70,7 +70,7 @@ jobs:
       - uses: jdx/mise-action@v4.0.1
         with:
           version: ${{ env.MISE_VERSION }}
-          install_args: "git-cliff"
+          install_args: "git-cliff 1password-cli"
           cache: "false"
           github_token: ${{ env.MISE_GITHUB_TOKEN }}
 
@@ -102,8 +102,11 @@ jobs:
           ls -la dist/gpx_tuist_datasource_* >/dev/null
 
       - name: Sign the plugin
-        if: ${{ env.GRAFANA_ACCESS_POLICY_TOKEN != '' }}
-        run: npm run sign
+        if: ${{ env.OP_SERVICE_ACCOUNT_TOKEN != '' }}
+        run: |
+          GRAFANA_ACCESS_POLICY_TOKEN=$(op read "op://tuist/TUIST_GRAFANA_PLUGIN_TOKEN/password")
+          export GRAFANA_ACCESS_POLICY_TOKEN
+          npm run sign
 
       - name: Package
         run: |


### PR DESCRIPTION
## What

The Grafana data source release workflow no longer needs a standalone `GRAFANA_ACCESS_POLICY_TOKEN` GitHub Actions secret. It now reads the token from 1Password at signing time, the same way every other release/deploy workflow in the repo handles its secrets.

- `OP_SERVICE_ACCOUNT_TOKEN` (already present, used by 20+ workflows) is exposed to the release job.
- `1password-cli` is installed via mise.
- The "Sign the plugin" step does `op read "op://tuist/TUIST_GRAFANA_PLUGIN_TOKEN/password"` right before `npm run sign`.
- The signing step is gated on `OP_SERVICE_ACCOUNT_TOKEN` being present, so forks (which don't have it) still build the plugin, just unsigned — same fail-open behavior the old `GRAFANA_ACCESS_POLICY_TOKEN != ''` guard provided.

## Why

The previous design (PR #11210) required a manual post-merge step: create a one-off repo secret holding the Grafana access-policy token. That's exactly the per-secret toil the repo's 1Password + `OP_SERVICE_ACCOUNT_TOKEN` convention exists to avoid (`app-release.yml` reads the Sparkle key and Play keystore this way; `cli-build-publish.yml`, the server/cache deploys, etc. all follow the same pattern). Loading from 1Password keeps the credential in one source of truth and removes the standalone secret from the repo's surface.

## Vault move

The `TUIST_GRAFANA_PLUGIN_TOKEN` item was relocated from the **Founders** vault to the **tuist** vault. The CI service account can only read `tuist` and `cache` (verified: every `op://` reference across all workflows targets one of those two), and a Grafana publish credential is a CI/team secret rather than a founders-personal one, so the tuist vault is its natural home.

## Validation

- `actionlint` clean (only the expected `tuist-linux` self-hosted-label warning, which every Tuist workflow emits).
- Fixed an SC2155 shellcheck warning by splitting the `op read` assignment from the `export` so a 1Password read failure isn't masked and correctly fails the step.
- Verified locally that `op read "op://tuist/TUIST_GRAFANA_PLUGIN_TOKEN/password"` resolves to the `glc_…` access-policy token after the vault move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)