### PR TITLE
docs(handbook): document engineer read access via Pomerium kubeconfig

### DIFF
--- a/infra/AGENTS.md
+++ b/infra/AGENTS.md
@@ -77,7 +77,7 @@ This section is normative for agents (Claude, Codex, anything driving `kubectl` 
 
 The team's Google Workspace identity carries through to every workload cluster via Pomerium fronting `https://kube-<env>.tuist.dev`. From an agent running on a teammate's laptop, `kubectl --context tuist-k8s-<env>` works for any read operation: `get pods`, `logs`, `describe`, `get configmap`, `get events`. The `pomerium-cli` exec credential plugin handles the bearer; the teammate's existing browser-cached session is used silently. Each request then flows through the `kube-impersonator` sidecar in the Pomerium pod, which calls tuist-ops's `/api/v1/policy` over the tailnet; the policy returns `Impersonate-User: <email>` + `Impersonate-Group: tuist-eng` (or `tuist-admins` for Owner/Admin tailnet roles). RBAC binds those groups to `view`, which **excludes `Secret`s** — deliberate, so `MASTER_KEY`, `DATABASE_URL`, and ESO-synced secrets stay out of agent context.
 
-For anything an agent typically needs (looking at a failing pod, tailing logs, sanity-checking a deploy), this is the right path. Use it freely.
+For anything an agent typically needs (looking at a failing pod, tailing logs, sanity-checking a deploy), this is the right path. Use it freely. The one-time local kubeconfig setup (install `pomerium-cli`, merge the three per-env contexts) is in [`k8s/onboarding.md` → Engineer read access](k8s/onboarding.md#engineer-read-access-pomerium-kubeconfig).
 
 ### Writes: never escalate without explicit human approval
 

--- a/infra/k8s/onboarding.md
+++ b/infra/k8s/onboarding.md
@@ -6,6 +6,65 @@ We run a **management cluster** (a single-node Talos VM in Hetzner project `tuis
 
 This doc is the runbook for onboarding **a new workload cluster** end-to-end. The mgmt cluster itself is bootstrapped by the migration PR's runbook; re-bootstrapping it is documented inline in [`mgmt/tailscale.yaml`](mgmt/tailscale.yaml).
 
+If you just want to **read** an existing cluster (the day-to-day case — `kubectl get pods`, `logs`, `describe`), you don't need any of the cluster-provisioning steps below. Jump to [Engineer read access](#engineer-read-access-pomerium-kubeconfig).
+
+---
+
+## Engineer read access (Pomerium kubeconfig)
+
+Every engineer's Google Workspace identity already carries `view`-tier read access to all three workload clusters through the Pomerium gateway — no grant, no per-person provisioning. There's nothing secret to download: you assemble a small kubeconfig locally that registers `pomerium-cli` as an [exec credential plugin](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#client-go-credential-plugins). On the first call the plugin opens a browser for Google OIDC and caches the session for ~24h. The full identity flow is documented in [`infra/helm/pomerium/NOTES.md`](../helm/pomerium/NOTES.md); the agent-facing rules (read is always allowed, writes go through the JIT Slack flow) are in [`infra/AGENTS.md`](../AGENTS.md#cluster-access-for-agents).
+
+`view` deliberately excludes `Secret`s, so `MASTER_KEY`, `DATABASE_URL`, and ESO-synced secrets stay out of reach on this path. Mutating operations (`apply`, `delete`, `scale`, `patch`, `create`) return `403` until you elevate via `/elevate <env>` in Slack.
+
+### Setup
+
+1. `pomerium-cli` is pinned in the root [`mise.toml`](../../mise.toml) — `mise install` from the repo root puts it on your `PATH`.
+2. Merge the three contexts below into your `~/.kube/config`. They contain no secrets — the hostnames are public and all auth happens at call time. Each env needs its own gateway host in the exec `args`, so there's one user per env. Production's host is `kube-prod`, not `kube-production`.
+
+   ```yaml
+   clusters:
+     - name: tuist-k8s-staging
+       cluster: { server: https://kube-staging.tuist.dev }
+     - name: tuist-k8s-canary
+       cluster: { server: https://kube-canary.tuist.dev }
+     - name: tuist-k8s-production
+       cluster: { server: https://kube-prod.tuist.dev }
+   contexts:
+     - name: tuist-k8s-staging
+       context: { cluster: tuist-k8s-staging, user: pomerium-staging }
+     - name: tuist-k8s-canary
+       context: { cluster: tuist-k8s-canary, user: pomerium-canary }
+     - name: tuist-k8s-production
+       context: { cluster: tuist-k8s-production, user: pomerium-production }
+   users:
+     - name: pomerium-staging
+       user:
+         exec:
+           apiVersion: client.authentication.k8s.io/v1beta1
+           command: pomerium-cli
+           args: ["k8s", "exec-credential", "https://kube-staging.tuist.dev"]
+     - name: pomerium-canary
+       user:
+         exec:
+           apiVersion: client.authentication.k8s.io/v1beta1
+           command: pomerium-cli
+           args: ["k8s", "exec-credential", "https://kube-canary.tuist.dev"]
+     - name: pomerium-production
+       user:
+         exec:
+           apiVersion: client.authentication.k8s.io/v1beta1
+           command: pomerium-cli
+           args: ["k8s", "exec-credential", "https://kube-prod.tuist.dev"]
+   ```
+
+3. Verify (a browser opens once per env for the Google login):
+
+   ```bash
+   kubectl --context tuist-k8s-staging get pods -A
+   ```
+
+> **This is not the admin kubeconfig.** The cluster-admin kubeconfigs in the `tuist-k8s-<env>` 1Password vaults bypass Pomerium and impersonation entirely; they're break-glass only and gated behind 1Password biometric on purpose. Don't reach for them for routine reads, and never have an agent fetch one. See [Workload-cluster incident recovery](#workload-cluster-incident-recovery).
+
 ---
 
 ## Prerequisites


### PR DESCRIPTION
## What changed

Adds a self-contained **Engineer read access (Pomerium kubeconfig)** section to `infra/k8s/onboarding.md` with the ready-to-merge three-context kubeconfig (staging / canary / production), and cross-links it from the cluster-access section in `infra/AGENTS.md`.

## Why

The read path — Google Workspace identity → Pomerium gateway (`kube-<env>.tuist.dev`) → `view`-tier impersonation via the `kube-impersonator` sidecar — was already *described* in `infra/helm/pomerium/NOTES.md` and `infra/AGENTS.md`, but there was no copy-paste kubeconfig artifact anywhere. Onboarding a new engineer therefore meant "ask a teammate to hand you their stanza," which is exactly the tribal-knowledge step the repo convention calls out:

> When a new managed-cluster operational step becomes reproducible, document it in `k8s/onboarding.md`.

A client-side kubeconfig that's identical for every engineer is precisely that.

## Why a documented snippet rather than a checked-in kubeconfig file

The three contexts contain **no secrets** — just public hostnames plus a `pomerium-cli k8s exec-credential` exec plugin; all authentication happens at call time through Google OIDC and the cached Pomerium session. So a documented, ready-to-merge snippet is safe and is the right form. We deliberately do **not** check in anyone's real `~/.kube/config` (those mix in the break-glass 1Password admin contexts, CAPI/mgmt contexts, and personal `current-context` state).

The section also draws an explicit line against the cluster-admin kubeconfigs in the `tuist-k8s-<env>` 1Password vaults: those bypass Pomerium/impersonation entirely, are break-glass only, and are biometric-gated on purpose — not for routine reads, and never to be fetched by an agent.

## Impact

A new engineer (or anyone re-setting-up a laptop) can get `view` access to all three workload clusters by installing `pomerium-cli` (already pinned in the root `mise.toml`) and pasting one block — no grant, no provisioning, no asking around.

## Validation

Docs-only change. Verified the gateway hostnames against `infra/helm/pomerium/values-*.yaml` (note production is `kube-prod`, not `kube-production`), the `pomerium-cli` pin against the root `mise.toml`, and the exec-plugin invocation against `infra/helm/pomerium/NOTES.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)