### PR TITLE
fix(noora): keep multi-select dropdowns open on toggle

### DIFF
--- a/noora/js/DropdownCheckbox.js
+++ b/noora/js/DropdownCheckbox.js
@@ -9,10 +9,11 @@ export default {
       const checkbox = this.el.querySelector('[data-part="checkbox"]');
       const clickedOnCheckbox = checkbox && checkbox.contains(event.target);
 
-      // Close dropdown if clicked on label (not checkbox)
+      // Close dropdown if clicked on label (not checkbox), unless the
+      // dropdown opted out of close-on-select (e.g. multi-select menus).
       if (!clickedOnCheckbox) {
         const dropdown = this.el.closest(".noora-dropdown");
-        if (dropdown) {
+        if (dropdown && dropdown.dataset.closeOnSelect !== "false") {
           window.dispatchEvent(
             new CustomEvent("phx:close-dropdown", {
               detail: { id: dropdown.id },

--- a/noora/lib/noora/button_dropdown.ex
+++ b/noora/lib/noora/button_dropdown.ex
@@ -96,7 +96,7 @@ defmodule Noora.ButtonDropdown do
       data-size={@size}
       data-loop-focus
       data-typeahead
-      data-close-on-select={@close_on_select}
+      data-close-on-select={to_string(@close_on_select)}
       data-on-open-change={@on_open_change}
       data-on-highlight-change={@on_highlight_change}
       data-on-select={@on_select}

--- a/noora/lib/noora/dropdown.ex
+++ b/noora/lib/noora/dropdown.ex
@@ -101,7 +101,7 @@ defmodule Noora.Dropdown do
       data-size={@size}
       data-loop-focus
       data-typeahead
-      data-close-on-select={@close_on_select}
+      data-close-on-select={to_string(@close_on_select)}
       data-on-open-change={@on_open_change}
       data-on-highlight-change={@on_highlight_change}
       data-on-select={@on_select}


### PR DESCRIPTION
> Describe here the purpose of your PR.

A user reported on Slack that the days-of-the-week dropdown in the project notifications "Configure schedule" modal closes after every checkbox toggle, which makes selecting more than one day painful. They have to reopen the dropdown each time and lose their place.

The schedule-days dropdown is rendered with `close_on_select={false}` and Noora's Zag-based menu honors that for plain items, but the items have checkboxes (`checked={...}`) so they also mount the `NooraDropdownCheckbox` hook. That hook was hard-coded to dispatch `phx:close-dropdown` whenever the click target was the label rather than the checkbox box, overriding the parent's `close_on_select` setting and closing the menu after every toggle.

Two small changes fix it:

- `NooraDropdownCheckbox` now reads the parent dropdown's `data-close-on-select` and skips the close dispatch when it's `"false"`. Checkbox dropdowns behave like the rest of the menu: Zag's `closeOnSelect: false` keeps the menu open, the hook no longer fights it.
- `dropdown.ex` and `button_dropdown.ex` now render `data-close-on-select` as an explicit `to_string(@close_on_select)`. Phoenix would otherwise drop the attribute entirely when the value is `false`, leaving `dataset.closeOnSelect` as `undefined` on the JS side; rendering it as `"true"` / `"false"` makes the dataset value reliable for the new check (and is still compatible with `getBooleanOption` used by `Dropdown.js`).

The Noora JS bundle (`priv/static/noora.js`) is generated by `aube run build`, which the server's asset pipeline runs during `mix assets.setup` / `mix assets.build`, so no committed bundle change is needed.

<img width="1558" height="1236" alt="2026-06-12 17 13 13" src="https://github.com/user-attachments/assets/1bec5701-1605-4f2a-9b8c-6268bd93e104" />


### How to test locally

1. Run the server (`mise run dev`) and open a project's Notifications page.
2. Click "Configure" next to the Schedule row to open the modal.
3. Open the "Repeat" dropdown and tick several days in a row. The dropdown should stay open and the selection should accumulate; clicking outside the menu still closes it as before.
4. Confirm other dropdowns that select a single value (Frequency, Time, and any non-checkbox dropdown in the app) still close on selection.
