### PR TITLE
fix(cli): anchor SwiftPM workspace-state paths to scratch directory

### DIFF
--- a/cli/Sources/TuistLoader/Loaders/SwiftPackageManagerGraphLoader.swift
+++ b/cli/Sources/TuistLoader/Loaders/SwiftPackageManagerGraphLoader.swift
@@ -155,8 +155,11 @@ public struct SwiftPackageManagerGraphLoader: SwiftPackageManagerGraphLoading {
                     // There's a bug in the `relative` implementation that produces the wrong path when using a symbolic link.
                     // This leads to nonexisting path in the `ModuleMapMapper` that relies on that method.
                     // To get around this, we're aligning paths from `workspace-state.json` with the /var temporary directory.
+                    // Anchor against `scratchDirectory` so swifterpm's relative-path encoding resolves correctly;
+                    // absolute paths from older swifterpm output pass through unchanged.
                     packageFolder = try AbsolutePath(
-                        validating: path.replacingOccurrences(of: "/private/var", with: "/var")
+                        validating: path.replacingOccurrences(of: "/private/var", with: "/var"),
+                        relativeTo: scratchDirectory
                     )
                     hash = nil
                 case "registry":
@@ -177,7 +180,10 @@ public struct SwiftPackageManagerGraphLoader: SwiftPackageManagerGraphLoading {
                 let targetToArtifactPaths = try workspaceState.object.artifacts
                     .filter { $0.packageRef.identity == dependency.packageRef.identity }
                     .reduce(into: [:]) { result, artifact in
-                        result[artifact.targetName] = try AbsolutePath(validating: artifact.path)
+                        result[artifact.targetName] = try AbsolutePath(
+                            validating: artifact.path,
+                            relativeTo: scratchDirectory
+                        )
                     }
 
                 return SwiftPackageManagerResolvedPackageInfo(
@@ -230,7 +236,8 @@ public struct SwiftPackageManagerGraphLoader: SwiftPackageManagerGraphLoading {
         })
         let packagePrebuilts = try mapPackagePrebuilts(
             packageInfos: packageInfos,
-            prebuilts: workspaceState.object.prebuilts
+            prebuilts: workspaceState.object.prebuilts,
+            scratchDirectory: scratchDirectory
         )
 
         var mutablePackageModuleAliases: [String: [String: String]] = [:]
@@ -442,7 +449,8 @@ private struct SwiftPackageManagerResolvedPackageInfo {
 
 private func mapPackagePrebuilts(
     packageInfos: [SwiftPackageManagerResolvedPackageInfo],
-    prebuilts: [SwiftPackageManagerWorkspaceState.Prebuilt]
+    prebuilts: [SwiftPackageManagerWorkspaceState.Prebuilt],
+    scratchDirectory: AbsolutePath
 ) throws -> [String: [String: SwiftPackageManagerPrebuilt]] {
     try packageInfos.reduce(into: [:]) { result, packageInfo in
         let packagePrebuilts = prebuilts.filter { $0.identity.lowercased() == packageInfo.id.lowercased() }
@@ -461,8 +469,9 @@ private func mapPackagePrebuilts(
                 identity: prebuilt.identity,
                 version: prebuilt.version,
                 libraryName: prebuilt.libraryName,
-                path: try AbsolutePath(validating: prebuilt.path),
-                checkoutPath: try prebuilt.checkoutPath.map { try AbsolutePath(validating: $0) },
+                path: try AbsolutePath(validating: prebuilt.path, relativeTo: scratchDirectory),
+                checkoutPath: try prebuilt.checkoutPath
+                    .map { try AbsolutePath(validating: $0, relativeTo: scratchDirectory) },
                 products: prebuilt.products,
                 includePath: try prebuilt.includePath?.map { try RelativePath(validating: $0) },
                 cModules: prebuilt.cModules
@@ -503,12 +512,18 @@ private struct SwifterPMPackageInfoCache {
     }
 
     private struct CachedPackageInfo {
-        let entry: Entry
+        let packagePath: AbsolutePath
         let packageInfo: PackageInfo
     }
 
     private let root: CachedPackageInfo?
     private let packagesByPath: [String: CachedPackageInfo]
+
+    /// schema_version 1: paths in the index are absolute strings (older swifterpm output).
+    /// schema_version 2: paths are relative to `scratchDirectory` so `.build/` is portable
+    /// across hosts. `AbsolutePath(validating:relativeTo:)` accepts either form, so both
+    /// schemas are handled by the same code path.
+    private static let supportedSchemaVersions: Set<Int> = [1, 2]
 
     static func load(
         scratchDirectory: AbsolutePath,
@@ -519,18 +534,26 @@ private struct SwifterPMPackageInfoCache {
         guard (try? await fileSystem.exists(indexPath)) == true,
               let indexData = try? await fileSystem.readFile(at: indexPath),
               let index = try? JSONDecoder().decode(Index.self, from: indexData),
-              index.schemaVersion == 1
+              supportedSchemaVersions.contains(index.schemaVersion)
         else {
             return nil
         }
 
-        let root = await cachedPackageInfo(for: index.root, fileSystem: fileSystem)
+        let root = await cachedPackageInfo(
+            for: index.root,
+            scratchDirectory: scratchDirectory,
+            fileSystem: fileSystem
+        )
         var packagesByPath: [String: CachedPackageInfo] = [:]
         for entry in index.packages {
-            guard let cachedPackageInfo = await cachedPackageInfo(for: entry, fileSystem: fileSystem) else {
+            guard let cachedPackageInfo = await cachedPackageInfo(
+                for: entry,
+                scratchDirectory: scratchDirectory,
+                fileSystem: fileSystem
+            ) else {
                 continue
             }
-            packagesByPath[normalizedPackagePath(entry.packagePath)] = cachedPackageInfo
+            packagesByPath[normalizedPackagePath(cachedPackageInfo.packagePath.pathString)] = cachedPackageInfo
         }
 
         return SwifterPMPackageInfoCache(
@@ -541,7 +564,8 @@ private struct SwifterPMPackageInfoCache {
 
     func rootPackageInfo(for packagePath: AbsolutePath) -> PackageInfo? {
         guard let root,
-              Self.normalizedPackagePath(root.entry.packagePath) == Self.normalizedPackagePath(packagePath.pathString)
+              Self.normalizedPackagePath(root.packagePath.pathString)
+              == Self.normalizedPackagePath(packagePath.pathString)
         else {
             return nil
         }
@@ -554,10 +578,11 @@ private struct SwifterPMPackageInfoCache {
 
     private static func cachedPackageInfo(
         for entry: Entry,
+        scratchDirectory: AbsolutePath,
         fileSystem: FileSysteming
     ) async -> CachedPackageInfo? {
-        guard let packagePath = absolutePath(entry.packagePath),
-              let packageInfoPath = absolutePath(entry.packageInfoPath),
+        guard let packagePath = absolutePath(entry.packagePath, scratchDirectory: scratchDirectory),
+              let packageInfoPath = absolutePath(entry.packageInfoPath, scratchDirectory: scratchDirectory),
               await isFreshPackageInfo(
                   kind: entry.kind,
                   packageInfoPath: packageInfoPath,
@@ -570,7 +595,7 @@ private struct SwifterPMPackageInfoCache {
             return nil
         }
 
-        return CachedPackageInfo(entry: entry, packageInfo: packageInfo)
+        return CachedPackageInfo(packagePath: packagePath, packageInfo: packageInfo)
     }
 
     private static func isFreshPackageInfo(
@@ -598,8 +623,11 @@ private struct SwifterPMPackageInfoCache {
         }
     }
 
-    private static func absolutePath(_ path: String) -> AbsolutePath? {
-        try? AbsolutePath(validating: normalizedPackagePath(path))
+    private static func absolutePath(_ path: String, scratchDirectory: AbsolutePath) -> AbsolutePath? {
+        try? AbsolutePath(
+            validating: normalizedPackagePath(path),
+            relativeTo: scratchDirectory
+        )
     }
 
     private static func normalizedPackagePath(_ path: String) -> String {

--- a/cli/Tests/TuistLoaderTests/Loaders/SwiftPackageManagerGraphLoaderTests.swift
+++ b/cli/Tests/TuistLoaderTests/Loaders/SwiftPackageManagerGraphLoaderTests.swift
@@ -712,6 +712,137 @@ struct SwiftPackageManagerGraphLoaderTests {
     }
 
     @Test(.inTemporaryDirectory, .withMockedDependencies())
+    func load_whenWorkspaceStatePathsAreRelativeToScratchDirectory_resolvesAgainstScratchDir() async throws {
+        // Regression: swifterpm now emits paths in workspace-state.json relative to the
+        // scratch directory so a cached `.build/` stays portable across hosts. The loader
+        // must anchor those relative strings against scratchDirectory when resolving.
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+
+        let packageSettings = PackageSettings.test()
+        let workspacePath = temporaryDirectory.appending(components: [
+            ".build", "workspace-state.json",
+        ])
+        try await fileSystem.makeDirectory(at: workspacePath.parentDirectory)
+
+        let localPackagePath = temporaryDirectory.appending(component: "LocalDep")
+        try await fileSystem.makeDirectory(at: localPackagePath)
+
+        let scratchDirectory = temporaryDirectory.appending(component: ".build")
+        let expectedArtifactPath = scratchDirectory.appending(
+            try RelativePath(validating: "swifterpm/artifacts/foo/Foo/Foo.xcframework")
+        )
+
+        // packageRef.path and state.path are written by swifterpm as
+        // `localPackagePath.relative(to: scratchDirectory)` (= "../LocalDep" when
+        // scratch is `<temp>/.build`). artifact.path is "swifterpm/artifacts/...".
+        try await fileSystem.writeText(
+            """
+            {
+              "object" : {
+                "artifacts" : [
+                  {
+                    "kind" : { "xcframework" : {} },
+                    "packageRef" : {
+                      "identity" : "foo",
+                      "kind" : "remoteSourceControl",
+                      "location" : "https://github.com/example/foo.git",
+                      "name" : "foo"
+                    },
+                    "path" : "swifterpm/artifacts/foo/Foo/Foo.xcframework",
+                    "source" : {
+                      "checksum" : "deadbeef",
+                      "type" : "remote",
+                      "url" : "https://example.com/Foo.zip"
+                    },
+                    "targetName" : "Foo"
+                  }
+                ],
+                "dependencies" : [
+                  {
+                    "basedOn" : null,
+                    "packageRef" : {
+                      "identity" : "foo",
+                      "kind" : "remoteSourceControl",
+                      "location" : "https://github.com/example/foo.git",
+                      "name" : "foo"
+                    },
+                    "state" : {
+                      "checkoutState" : {
+                        "revision" : "abcdef1234567890",
+                        "version" : "1.0.0"
+                      },
+                      "name" : "sourceControlCheckout"
+                    },
+                    "subpath" : "foo"
+                  },
+                  {
+                    "basedOn" : null,
+                    "packageRef" : {
+                      "identity" : "local-dep",
+                      "kind" : "fileSystem",
+                      "path" : "../LocalDep",
+                      "name" : "LocalDep"
+                    },
+                    "state" : {
+                      "name" : "fileSystem",
+                      "path" : "../LocalDep"
+                    },
+                    "subpath" : "local-dep"
+                  }
+                ]
+              }
+            }
+            """,
+            at: workspacePath
+        )
+
+        try await fileSystem.makeDirectory(
+            at: temporaryDirectory.appending(components: [".build", "Derived"])
+        )
+        try await fileSystem.touch(
+            temporaryDirectory.appending(components: [".build", "Derived", "Package.resolved"])
+        )
+        try await fileSystem.touch(
+            temporaryDirectory.appending(component: "Package.resolved")
+        )
+
+        given(packageInfoMapper)
+            .resolveExternalDependencies(
+                path: .any,
+                packagePath: .any,
+                packageInfos: .any,
+                packageToFolder: .any,
+                packageToTargetsToArtifactPaths: .any,
+                packageModuleAliases: .any,
+                packageSettings: .any
+            )
+            .willReturn([:])
+
+        // When
+        _ = try await subject.load(
+            packagePath: temporaryDirectory.appending(component: "Package.swift"),
+            packageSettings: packageSettings,
+            disableSandbox: true
+        )
+
+        // Then: artifact paths arrive at the mapper resolved against scratchDirectory.
+        verify(packageInfoMapper)
+            .map(
+                packageInfo: .any,
+                path: .any,
+                packageType: .matching { packageType in
+                    guard case let .external(origin: _, artifactPaths: artifactPaths, packagePrebuilts: _) = packageType
+                    else { return false }
+                    return artifactPaths["Foo"] == expectedArtifactPath
+                },
+                packageSettings: .any,
+                packageModuleAliases: .any,
+                enabledTraits: .any
+            )
+            .called(1)
+    }
+
+    @Test(.inTemporaryDirectory, .withMockedDependencies())
     func load_when_dependency_via_local_registry_and_scm() async throws {
         let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
 


### PR DESCRIPTION
## Summary

Make Tuist's SwiftPM graph loader tolerant of relative paths inside `.build/workspace-state.json` and `.build/swifterpm/package-info/index.json`. Today it treats every path as absolute; this change anchors them against `scratchDirectory` via `AbsolutePath(validating:relativeTo:)`, which leaves absolute paths untouched but resolves relative ones correctly.

This is the Tuist-side half of a two-PR change. The companion swifterpm PR ([tuist/swifterpm#37](https://github.com/tuist/swifterpm/pull/37)) flips both metadata files to emit paths relative to `scratchDirectory` so a cached `.build/` is portable across hosts (and across the same host moved to a new checkout location). Landing this loader change first means today's absolute-path output keeps working unchanged, and once the swifterpm pin is bumped, the new relative-path output Just Works without further loader edits.

## Why this matters

Right after #11258 someone asked whether `.build/` could be cached. Walking through it:

- On CI, swifterpm's `replaceWithCachedDirectory` already copies the global SwifterPM cache into `.build/` (`Sources/swifterpm/FileSystemSupport.swift:122`), so symlinks pointing into `~/.cache/swifterpm/...` are not a blocker on CI.
- But `workspace-state.json` still embeds the absolute scratch-dir prefix in `Artifact.path`, fileSystem `Dependency.packageRef.path`/`location`, and pre-existing `Prebuilt.path`/`checkoutPath`. The same goes for the swifterpm package-info index. Today's loader calls `AbsolutePath(validating: path)` (without `relativeTo:`) at four sites, which throws on any relative string.
- That throw blocks the migration path. Switching to `AbsolutePath(validating: path, relativeTo: scratchDirectory)` is a no-op for absolute paths and unlocks the swifterpm-side change without forcing a coordinated cutover.

## Changes

`cli/Sources/TuistLoader/Loaders/SwiftPackageManagerGraphLoader.swift`:

- `packageFolder` resolution for local/fileSystem/localSourceControl deps (line 152): now anchored to `scratchDirectory`.
- `targetToArtifactPaths` entries (line 180): same.
- `mapPackagePrebuilts` (lines 470-471): `prebuilt.path` and `prebuilt.checkoutPath` resolved against `scratchDirectory`. The function now takes `scratchDirectory:` and the caller threads it through.
- `SwifterPMPackageInfoCache.load` (lines 522+): accepts both `schema_version: 1` (old, absolute) and `schema_version: 2` (new, relative). Each entry's `packagePath`/`packageInfoPath` is resolved against `scratchDirectory` at load time, so `packagesByPath` keys stay absolute strings and existing lookup callers don't change. The `CachedPackageInfo` struct now stores the resolved `AbsolutePath` instead of the raw `Entry`.

## Fields converted from absolute to scratch-relative

Each field below is relativized to `scratchDir` **only when the target path resolves inside the consuming project** (either under `packageDir` or under `scratchDir`). Paths that escape both — typically external `fileSystem` / `localSourceControl` deps living on another part of the disk — stay absolute, matching SwiftPM's output for entries that are inherently not portable across hosts. The `/private/var` vs `/var` symlink layer on macOS is collapsed with a string substitution rather than `realpath`, since following every symlink would resolve `<scratch>/swifterpm/artifacts/<id>/<target>` out into the global cache and make a logically-in-scratch path look like it escapes.

For reference, every field this PR touches in those two metadata files, and what each one points at on disk:

### `.build/workspace-state.json`

| Field | What the path targets on disk |
|---|---|
| `object.artifacts[].path` | The xcframework or artifactbundle binary itself, at `<scratch>/swifterpm/artifacts/<id>/<target>/<target>.xcframework` for remote / local-zip sources, or at the in-repo location for local non-zip xcframeworks |
| `object.dependencies[].packageRef.location` (kinds `root`, `fileSystem`, `localSourceControl`) | A source package directory on disk: the consuming project for `root`, an external local package for `fileSystem` / `localSourceControl` |
| `object.dependencies[].state.path` (kind `fileSystem`) | Same target as the matching `packageRef.location` |
| `object.prebuilts[].path` / `checkoutPath` / `includePath` | Extracted prebuilt libs (SwiftSyntax-style). **Forwarded as-is** — these entries are written by SwiftPM's prebuilt manager, not by swifterpm, so this PR doesn't rewrite them. Downstream loaders can still anchor them via `AbsolutePath(validating:relativeTo:)` |

Remote URLs (`packageRef.location` for `remoteSourceControl`) and registry identities (`location` for `registry`) are not paths and stay verbatim.

### `.build/swifterpm/package-info/index.json`

| Field | What the path targets on disk |
|---|---|
| `root.package_path`, `packages[].package_path` | The source package directory: under `<scratch>/checkouts/...` for SCM, `<scratch>/registry/downloads/...` for registry, or an external local path for `fileSystem` |
| `root.package_info_path`, `packages[].package_info_path` | The dumped per-package manifest JSON inside the cache directory (default `<scratch>/swifterpm/package-info/...`) |
| `root.location`, `packages[].location` (kinds `root`, `localSourceControl`, `fileSystem`) | Same target as the matching `package_path` |

## How binary artifacts are scoped

For both the cross-host caching story and reviewer sanity, this is where binaries actually live:

1. `cache.binaryArtifactDirectory(identity:, targetName:, checksum:)` (`swifterpm/Sources/swifterpm/Restore.swift:130`) returns a checksum-namespaced path under the global SwifterPM cache: `~/.cache/swifterpm/artifacts/<identity>/<target>-<checksum-prefix>/`. Two checksums of the same identity / target cannot collide.
2. `downloadBinaryArtifact` (`Restore.swift:209`) downloads the archive into `cache.binaryArtifactArchivePath` (also checksum-keyed), verifies the SHA-256, and extracts into that cached directory. Re-download is gated by `validCachedBinaryArtifactArchive` so checksum-good archives skip re-hashing.
3. `artifactDirectory(scratchDir:, packageIdentity:, targetName:)` (`Restore.swift:468`) is the per-project landing spot: `<scratch>/swifterpm/artifacts/<id>/<target>/`.
4. `replaceScratchArtifact` (`Restore.swift:197`) materialises the cached dir at that scratch path through `fileSystem.replaceWithSymlinkedDirectory`. Inside that helper (`FileSystemSupport.swift:114`) the branch is `Environment.isCI` → **copy on CI, symlink on dev**.
5. `workspaceArtifact` (`Restore.swift:972`) calls `binaryArtifact(in: directory)` against that scratch-side path and writes its location — which after this PR is `swifterpm/artifacts/<id>/<target>/<target>.xcframework` relative to `scratchDir`.

So `artifact.path` always resolves to a file inside `<scratch>/swifterpm/artifacts/<id>/<target>/`. The dev-vs-CI distinction is what makes the relative-path encoding actually useful for cross-host caching:

- **On CI:** the scratch-side directory is a real copy of the xcframework / artifactbundle. `.build/` is self-contained: the relative `artifact.path` plus the on-disk file resolves end-to-end without referencing the host's home directory at all.
- **On dev:** the scratch-side entry is a symlink into `~/.cache/swifterpm/artifacts/...`. Restoring `.build/` from another machine works at the metadata layer (the relative path still anchors against scratch), but the symlink target won't exist on the new host. Solution is either to cache `~/.cache/swifterpm/` alongside `.build/`, or to run one `tuist install` to re-create the symlinks (cheap — checksums match, no re-download).

## Considered alternatives

- **Wipe `.build/workspace-state.json` on `tuist install` when the prefix doesn't match.** Smaller surface and avoids any schema change, but it forces a re-resolve on every cross-host restore and the metadata files are derived state anyway, not the source of truth. Once swifterpm writes relative paths, no rewrite is needed at all.
- **String-replace the absolute prefix on read.** Tighter coupling to swifterpm's serialization format and brittle when scratchDir lives under `/private/var` vs `/var`. The Path-based `relative(to:)` already handles that lexically.

## Test plan

- [x] `xcodebuild test -workspace Tuist.xcworkspace -scheme Tuist-Workspace -only-testing TuistLoaderTests/SwiftPackageManagerGraphLoaderTests` — 11/11 passing locally, including the new `load_whenWorkspaceStatePathsAreRelativeToScratchDirectory_resolvesAgainstScratchDir` regression that feeds a relative-form workspace-state.json and asserts the loader produces a fully-resolved artifact `AbsolutePath` rooted at `<scratch>/swifterpm/artifacts/...`.
- [ ] CI green
- [ ] After swifterpm PR lands + is tagged: bump the pin in `cli/Package.swift` and run a fresh `tuist install` end-to-end to confirm both the new relative output and a stale absolute `.build/` from before the bump load cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


