### PR TITLE
fix(infra): align staging Kura node pool max-size with production

### DIFF
--- a/infra/k8s/clusters/cluster-staging.yaml
+++ b/infra/k8s/clusters/cluster-staging.yaml
@@ -94,9 +94,9 @@ spec:
               autoscaling.tuist.dev/group: kura-staging
             annotations:
               cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size: "3"
-              cluster.x-k8s.io/cluster-api-autoscaler-node-group-max-size: "8"
+              cluster.x-k8s.io/cluster-api-autoscaler-node-group-max-size: "12"
               cluster.x-k8s.io/cluster-autoscaler-node-group-min-size: "3"
-              cluster.x-k8s.io/cluster-autoscaler-node-group-max-size: "8"
+              cluster.x-k8s.io/cluster-autoscaler-node-group-max-size: "12"
           variables:
             overrides:
               - name: hcloudWorkerMachineType


### PR DESCRIPTION
## Summary

Bumps the staging Kura `MachineDeployment` autoscaler max from 8 to 12 so it matches `cluster-production.yaml`. Staging was hitting the ceiling once the existing dev-account Kura StatefulSets and the new 3-replica `eu-central-1` deployment for the `tuist` account were on the cluster at the same time.

## What was happening

While Eduardo was getting set up to monitor a Kura deployment on staging, the controller created the `kura-tuist-eu-central-1` StatefulSet with three replicas. Pods 0 and 1 scheduled fine, but pod 2 went Pending. Cluster autoscaler tried to scale the kura `MachineDeployment` (`tuist-staging-kura-cfqrn`) from 6 to 8, succeeded, and then logged `pod didn't trigger scale-up: 1 max node group size reached`. The kura pool was already at its configured cap.

Pod 2's affinity (`node.cluster.x-k8s.io/pool=kura`) plus the hard hostname `topologySpreadConstraint` (Kura's RWO PVCs + per-account anti-affinity) means a third replica needs a distinct kura node. With every account that has Kura enabled now running 3 replicas in eu-central, 8 workers is no longer enough to keep at least one usable spot per account.

## Why match production rather than picking a new number

Production already runs at `max-size: 12` for exactly this reason (the comment block in `cluster-production.yaml:87-90` explains the three-workers-per-account floor). Staging existed at 8 only because there hadn't been enough simultaneous Kura accounts on it to need more, not because staging had different constraints. Keeping the two pools at parity is the simpler invariant going forward; we can revisit if the staging dev population diverges meaningfully from the production account profile.

Alternatives considered:
- Dropping the StatefulSet replicas from 3 to 2 on staging. Rejected because the topology spread + RWO PVC + hostname spread are the things we want to exercise end to end before the same chart/controller lands on production. Lowering replicas would mask the failure mode.
- Reducing per-pod CPU requests. Rejected for the same reason: production runs at the current requests and we want staging to actually rehearse that.
- An incident-style `kubectl patch` on the mgmt cluster. Unblocks faster but drifts from the repo. Going through the GitOps path keeps `infra/k8s/clusters/*.yaml` as the single source of truth.

## Rollout

`.github/workflows/mgmt-cluster-apply.yml` watches `infra/k8s/clusters/**` and `kubectl apply`s the Cluster CR to the mgmt cluster on push to main. The CAPI topology controller reconciles the annotations onto the live `MachineDeployment`; no Helm release, no workload-side restart. As soon as the new max takes effect, cluster-autoscaler will provision the additional Hetzner node and the pending pod will schedule.

## Verification

- Pre-change, `kubectl -n kura describe pod kura-tuist-eu-central-1-2` on staging shows: `pod triggered scale-up: [{MachineDeployment/org-tuist/tuist-staging-kura-cfqrn 6->8 (max: 8)}]` followed by `pod didn't trigger scale-up: 1 max node group size reached`.
- Pre-change diff is a four-character edit limited to the kura pool's autoscaler annotations on `cluster-staging.yaml` (both the `cluster-api-autoscaler-node-group-max-size` and the legacy `cluster-autoscaler-node-group-max-size` annotation, kept in sync to mirror production).
- Post-merge, `kubectl -n kura get sts kura-tuist-eu-central-1` should reach `3/3 READY` once the autoscaler provisions the additional kura node.

🤖 Generated with [Claude Code](https://claude.com/claude-code)