### PR TITLE
fix(infra): harden tuist-ops postgres + document engineer kubectl read access

### DIFF
--- a/infra/AGENTS.md
+++ b/infra/AGENTS.md
@@ -77,7 +77,7 @@ This section is normative for agents (Claude, Codex, anything driving `kubectl` 
 
 The team's Google Workspace identity carries through to every workload cluster via Pomerium fronting `https://kube-<env>.tuist.dev`. From an agent running on a teammate's laptop, `kubectl --context tuist-k8s-<env>` works for any read operation: `get pods`, `logs`, `describe`, `get configmap`, `get events`. The `pomerium-cli` exec credential plugin handles the bearer; the teammate's existing browser-cached session is used silently. Each request then flows through the `kube-impersonator` sidecar in the Pomerium pod, which calls tuist-ops's `/api/v1/policy` over the tailnet; the policy returns `Impersonate-User: <email>` + `Impersonate-Group: tuist-eng` (or `tuist-admins` for Owner/Admin tailnet roles). RBAC binds those groups to `view`, which **excludes `Secret`s** — deliberate, so `MASTER_KEY`, `DATABASE_URL`, and ESO-synced secrets stay out of agent context.
 
-For anything an agent typically needs (looking at a failing pod, tailing logs, sanity-checking a deploy), this is the right path. Use it freely.
+For anything an agent typically needs (looking at a failing pod, tailing logs, sanity-checking a deploy), this is the right path. Use it freely. The one-time local kubeconfig setup (install `pomerium-cli`, merge the three per-env contexts) is in [`k8s/onboarding.md` → Engineer read access](k8s/onboarding.md#engineer-read-access-pomerium-kubeconfig).
 
 ### Writes: never escalate without explicit human approval
 

--- a/infra/helm/tuist-ops/templates/backup-credentials.yaml
+++ b/infra/helm/tuist-ops/templates/backup-credentials.yaml
@@ -2,7 +2,7 @@
 ESO ExternalSecret syncing the Tigris credentials barman uses to
 write WAL + base backups. Same 1P item the main Tuist server's
 CNPG cluster reads — `S3_BACKUP_CREDENTIALS` in the production vault.
-Granted just write-access to the tuist-cnpg-backups bucket under
+Granted just write-access to the tuist-prod-pg-backups bucket under
 the tuist-ops prefix.
 */}}
 {{- if .Values.postgresql.backup.enabled }}

--- a/infra/helm/tuist-ops/templates/cnpg-cluster.yaml
+++ b/infra/helm/tuist-ops/templates/cnpg-cluster.yaml
@@ -58,6 +58,11 @@ spec:
         secretAccessKey:
           name: {{ .Values.postgresql.backup.credentialsSecretName }}
           key: ACCESS_SECRET_KEY
+      wal:
+        compression: gzip
+        maxParallel: 8
+      data:
+        compression: gzip
     retentionPolicy: {{ .Values.postgresql.backup.retentionPolicy | quote }}
   {{- end }}
 {{- if .Values.postgresql.backup.enabled }}

--- a/infra/helm/tuist-ops/values.yaml
+++ b/infra/helm/tuist-ops/values.yaml
@@ -27,7 +27,12 @@ tailnetHostname: ops
 # Backups go to S3 (Tigris).
 postgresql:
   instances: 1
-  storageSize: 5Gi
+  # Sized for headroom against WAL backlog, not data volume: with
+  # archiving healthy, pg_wal stays small, but a stalled archive must
+  # not fill the disk fast enough to wedge the instance before it's
+  # noticed. CNPG storage can only grow, so this also matches the
+  # live 20Gi a helm upgrade would otherwise reject as a shrink.
+  storageSize: 20Gi
   storageClass: ""
   database: tuist_ops
   owner: tuist_ops

--- a/infra/k8s/onboarding.md
+++ b/infra/k8s/onboarding.md
@@ -6,6 +6,65 @@ We run a **management cluster** (a single-node Talos VM in Hetzner project `tuis
 
 This doc is the runbook for onboarding **a new workload cluster** end-to-end. The mgmt cluster itself is bootstrapped by the migration PR's runbook; re-bootstrapping it is documented inline in [`mgmt/tailscale.yaml`](mgmt/tailscale.yaml).
 
+If you just want to **read** an existing cluster (the day-to-day case — `kubectl get pods`, `logs`, `describe`), you don't need any of the cluster-provisioning steps below. Jump to [Engineer read access](#engineer-read-access-pomerium-kubeconfig).
+
+---
+
+## Engineer read access (Pomerium kubeconfig)
+
+Every engineer's Google Workspace identity already carries `view`-tier read access to all three workload clusters through the Pomerium gateway — no grant, no per-person provisioning. There's nothing secret to download: you assemble a small kubeconfig locally that registers `pomerium-cli` as an [exec credential plugin](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#client-go-credential-plugins). On the first call the plugin opens a browser for Google OIDC and caches the session for ~24h. The full identity flow is documented in [`infra/helm/pomerium/NOTES.md`](../helm/pomerium/NOTES.md); the agent-facing rules (read is always allowed, writes go through the JIT Slack flow) are in [`infra/AGENTS.md`](../AGENTS.md#cluster-access-for-agents).
+
+`view` deliberately excludes `Secret`s, so `MASTER_KEY`, `DATABASE_URL`, and ESO-synced secrets stay out of reach on this path. Mutating operations (`apply`, `delete`, `scale`, `patch`, `create`) return `403` until you elevate via `/elevate <env>` in Slack.
+
+### Setup
+
+1. `pomerium-cli` is pinned in the root [`mise.toml`](../../mise.toml) — `mise install` from the repo root puts it on your `PATH`.
+2. Merge the three contexts below into your `~/.kube/config`. They contain no secrets — the hostnames are public and all auth happens at call time. Each env needs its own gateway host in the exec `args`, so there's one user per env. Production's host is `kube-prod`, not `kube-production`.
+
+   ```yaml
+   clusters:
+     - name: tuist-k8s-staging
+       cluster: { server: https://kube-staging.tuist.dev }
+     - name: tuist-k8s-canary
+       cluster: { server: https://kube-canary.tuist.dev }
+     - name: tuist-k8s-production
+       cluster: { server: https://kube-prod.tuist.dev }
+   contexts:
+     - name: tuist-k8s-staging
+       context: { cluster: tuist-k8s-staging, user: pomerium-staging }
+     - name: tuist-k8s-canary
+       context: { cluster: tuist-k8s-canary, user: pomerium-canary }
+     - name: tuist-k8s-production
+       context: { cluster: tuist-k8s-production, user: pomerium-production }
+   users:
+     - name: pomerium-staging
+       user:
+         exec:
+           apiVersion: client.authentication.k8s.io/v1beta1
+           command: pomerium-cli
+           args: ["k8s", "exec-credential", "https://kube-staging.tuist.dev"]
+     - name: pomerium-canary
+       user:
+         exec:
+           apiVersion: client.authentication.k8s.io/v1beta1
+           command: pomerium-cli
+           args: ["k8s", "exec-credential", "https://kube-canary.tuist.dev"]
+     - name: pomerium-production
+       user:
+         exec:
+           apiVersion: client.authentication.k8s.io/v1beta1
+           command: pomerium-cli
+           args: ["k8s", "exec-credential", "https://kube-prod.tuist.dev"]
+   ```
+
+3. Verify (a browser opens once per env for the Google login):
+
+   ```bash
+   kubectl --context tuist-k8s-staging get pods -A
+   ```
+
+> **This is not the admin kubeconfig.** The cluster-admin kubeconfigs in the `tuist-k8s-<env>` 1Password vaults bypass Pomerium and impersonation entirely; they're break-glass only and gated behind 1Password biometric on purpose. Don't reach for them for routine reads, and never have an agent fetch one. See [Workload-cluster incident recovery](#workload-cluster-incident-recovery).
+
 ---
 
 ## Prerequisites


### PR DESCRIPTION
Both changes here came out of one incident: an all-cluster `kubectl` outage that first looked like a new engineer's onboarding/kubeconfig problem but turned out to be the tuist-ops Postgres taking down the impersonation policy endpoint. This PR fixes the root cause **and** removes the onboarding ambiguity that made the symptom confusing.

---

## Part 1 — Harden tuist-ops Postgres WAL archiving and disk headroom

### Incident summary

view-tier `kubectl` to **staging, canary, and production simultaneously** failed with `an error on the server ("impersonation policy unavailable")`. Root cause was not the kubectl gateway — it was the tuist-ops Postgres.

The `tuist-ops` CNPG cluster's WAL archiving had **never once succeeded** since creation (`pg_stat_archiver.archived_count = 0`, failing on the first segment). `pg_wal` grew unbounded, filled the 5Gi volume, and CNPG's low-disk guard then refused to start Postgres. tuist-ops runs Ecto migrations at boot and hard-exits when the DB is unreachable, so it crash-looped — taking down `/api/v1/policy`, which **every env's `kube-impersonator` sidecar depends on**. One single-replica internal Postgres took out kubectl for all three clusters at once.

### Root cause

**1. Archive destination collision.** The live cluster archived to `s3://tuist-cnpg-backups/tuist-ops`, a path that already held data from a prior cluster incarnation. `barman-cloud-check-wal-archive`'s first-WAL guard refused to write into a non-empty path:

```
ERROR: WAL archive check failed for server tuist-ops-pg: Expected empty archive
```

#11224 ("fix(infra): stabilize tuist-ops postgres") already renamed the bucket to `tuist-prod-pg-backups` + endpoint `t3.storage.dev` in the chart — but that fix **never took effect on the live cluster** (its pod still runs #10988's image / old config). The corrected config sat in `main` undeployed while the live cluster kept failing and filling its disk. Likely the helm upgrade in #11224 couldn't complete `--wait` against an already-wedged Postgres and rolled back; worth confirming via `helm history tuist-ops -n tuist-ops`.

**2. No headroom and slow drain.** `storageSize` was 5Gi with no disk alerting, so a stalled archive filled the volume and wedged the instance before anyone noticed. The backup block also lacked the WAL parallelism/compression the main server's CNPG cluster has, so once archiving was repaired the backlog drained one 16MB segment at a time.

### What this PR changes (the chart half; #11224 already fixed bucket/endpoint)

- **`storageSize` 5Gi → 20Gi** — headroom against WAL backlog, and matches the live volume (CNPG storage can only grow, so a chart still at 5Gi would make the next helm upgrade reject the shrink).
- **Add `wal: { compression: gzip, maxParallel: 8 }` + `data: { compression: gzip }`** to `barmanObjectStore`, mirroring `helm/tuist/templates/postgresql-cnpg.yaml`.
- **Fix the stale `tuist-cnpg-backups` reference** in the backup-credentials comment that #11224's rename left behind.

### Live remediation already applied (this PR makes it permanent)

Production was recovered by hand during the incident: volume expanded to 20Gi, `barmanObjectStore` patched to `t3.storage.dev` + `tuist-prod-pg-backups/tuist-ops`, `maxParallel: 8` applied, then `CHECKPOINT;` to recycle the archived backlog. Archiving went `0 → 495+` segments; `pg_wal` dropped 9.5G → 1.3G and disk 91% → 7%. This PR reconciles the chart so a redeploy keeps that state instead of reverting it.

---

## Part 2 — Document engineer kubectl read access (Pomerium kubeconfig)

The reason the outage first read as an onboarding problem: there was no copy-paste kubeconfig artifact for the Pomerium read path, only prose in `helm/pomerium/NOTES.md` and `AGENTS.md`. Onboarding someone meant "ask a teammate for their stanza."

- Adds an **Engineer read access** section to `infra/k8s/onboarding.md` with the ready-to-merge three-context kubeconfig (staging/canary/production), the `pomerium-cli` install step, and a callout drawing the line against the break-glass 1Password admin kubeconfigs.
- Cross-links it from the cluster-access section in `infra/AGENTS.md`.

The three contexts contain no secrets (public hostnames + a `pomerium-cli` exec plugin; all auth happens at call time), so a documented snippet is the right form rather than a checked-in personal kubeconfig.

(Supersedes #11260, folded in here.)

---

## Validation

- Confirmed live `pg_stat_archiver.archived_count` climbing from 0 after pointing archiving at the empty path; `df`/`du` showing `pg_wal` draining off the 20Gi volume.
- End-user confirmed: kubectl access to all three clusters restored.
- Gateway hostnames in the doc verified against `infra/helm/pomerium/values-*.yaml` (production is `kube-prod`, not `kube-production`); `pomerium-cli` pin verified against root `mise.toml`.

## Follow-ups (not in this PR)

- **Deploy gap:** understand why #11224 never reached the live cluster (`helm --wait` deadlock on a sick DB).
- **First base backup:** tuist-ops has zero usable backups; take one once stable.
- **Disk-usage + WAL-archiving alerts in Grafana** (alert rules aren't tracked in git): a volume-fill safety net (filesystem-level, NOT `cnpg_pg_database_size_bytes` — that excludes WAL and would have stayed green) plus a WAL-archiving-failure alert that would have caught this on day 1 instead of day 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)