### PR TITLE
fix(cli): skip unparseable xcactivitylogs instead of throwing

### DIFF
--- a/cli/Sources/TuistXCActivityLog/XCActivityLogController.swift
+++ b/cli/Sources/TuistXCActivityLog/XCActivityLogController.swift
@@ -106,7 +106,10 @@ public struct XCActivityLogController: XCActivityLogControlling {
                     withoutBuildSpecificInformation: false
                 )
             } catch {
-                throw XCActivityLogControllerError.wrap(error, path: activityLogPath)
+                Logger.current.warning(
+                    "Skipping unparseable activity log at \(activityLogPath.pathString): \(error.localizedDescription)"
+                )
+                continue
             }
             let buildStep: BuildStep
             do {
@@ -117,7 +120,10 @@ public struct XCActivityLogController: XCActivityLogControlling {
                 )
                 .parse(activityLog: activityLog)
             } catch {
-                throw XCActivityLogControllerError.wrap(error, path: activityLogPath)
+                Logger.current.warning(
+                    "Skipping unparseable activity log at \(activityLogPath.pathString): \(error.localizedDescription)"
+                )
+                continue
             }
 
             for (targetName, targetBuildDuration) in flattenedXCLogParserBuildStep([buildStep])

--- a/cli/Tests/TuistXCActivityLogTests/XCActivityLog/XCActivityLogControllerTests.swift
+++ b/cli/Tests/TuistXCActivityLogTests/XCActivityLog/XCActivityLogControllerTests.swift
@@ -31,6 +31,40 @@ struct XCActivityLogControllerTests {
         #expect(got == ["Framework": 4.696011543273926])
     }
 
+    @Test(.inTemporaryDirectory)
+    func buildTimesByTarget_skipsUnparseableActivityLogs() async throws {
+        // Given
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let unparseableLog = temporaryDirectory.appending(component: "corrupt.xcactivitylog")
+        try Data("not a valid xcactivitylog".utf8).write(to: unparseableLog.url)
+
+        // When
+        let got = try await subject.buildTimesByTarget(activityLogPaths: [unparseableLog])
+
+        // Then
+        #expect(got == [:])
+    }
+
+    @Test(.inTemporaryDirectory)
+    func buildTimesByTarget_skipsUnparseableLogsButProcessesValidOnes() async throws {
+        // Given
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let validLog = try AbsolutePath(validating: #file).parentDirectory
+            .appending(
+                try RelativePath(
+                    validating: "../../Fixtures/FrameworkDerivedDataWithActivityLog/Logs/Build/8C0902CE-3985-4B2E-A385-73FFD7014FC8.xcactivitylog"
+                )
+            )
+        let unparseableLog = temporaryDirectory.appending(component: "corrupt.xcactivitylog")
+        try Data("not a valid xcactivitylog".utf8).write(to: unparseableLog.url)
+
+        // When
+        let got = try await subject.buildTimesByTarget(activityLogPaths: [unparseableLog, validLog])
+
+        // Then
+        #expect(got == ["Framework": 4.696011543273926])
+    }
+
     @Test func parseCleanBuildXCActivityLog() async throws {
         // Given
         let cleanBuildXCActivityLog = try AbsolutePath(validating: #file).parentDirectory


### PR DESCRIPTION
This PR resolve an issue we have observed in CI where xcactivitylogs fail parsing and cause the entire `tuist cache` command to fail.

Example failure:
```
Failed to parse the activity log at /private/var/folders/th/9t7hnb312_5dqg6_n4vvg6g80000gn/T/CacheWarm-FE532E9A-9264-488F-ABC3-DA77F80485F6/activity-logs/53BA8EE8-A1DD-4120-8104-C3601C7C433D.xcactivitylog: /private/var/folders/th/9t7hnb312_5dqg6_n4vvg6g80000gn/T/CacheWarm-FE532E9A-9264-488F-ABC3-DA77F80485F6/activity-logs/53BA8EE8-A1DD-4120-8104-C3601C7C433D.xcactivitylog is not a valid xcactivitylog file
```

Please let me know if this change is something you would consider. I'm very open to suggestions!

- [x] Validated tests pass locally (macOS 26.5.1)