### PR TITLE
fix(infra): keep the server SA across release-manifest drift

### DIFF
--- a/infra/helm/tuist/templates/serviceaccount.yaml
+++ b/infra/helm/tuist/templates/serviceaccount.yaml
@@ -6,8 +6,15 @@ metadata:
   labels:
     {{- include "tuist.labels" . | nindent 4 }}
     app.kubernetes.io/component: server
-  {{- if or .Values.server.serviceAccount.annotations .Values.server.migrationJob.asHook }}
   annotations:
+    # Helm checks this annotation on the live object before pruning a
+    # resource that disappeared from the release manifest. Without it, a
+    # release that ever recorded this SA as a regular resource (e.g. a
+    # manual deploy rendered with asHook=false) gets it pruned mid-upgrade
+    # by the next hook-shaped deploy, stranding the server/processor pods
+    # on token mounts. Hook delete/recreate (before-hook-creation) is
+    # unaffected — helm's hook deletion does not honor resource-policy.
+    helm.sh/resource-policy: keep
     {{- if .Values.server.migrationJob.asHook }}
     # Pre-install/upgrade hook ordering (Helm applies in ASCENDING weight,
     # waiting for each to become ready before the next):
@@ -27,7 +34,6 @@ metadata:
     {{- with .Values.server.serviceAccount.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-  {{- end }}
 {{- end }}
 {{- if and .Values.server.serviceAccount.create .Values.cache.serviceAccount.create }}
 ---


### PR DESCRIPTION
## Problem

Every staging deploy on 2026-06-12 failed (run [27439047260](https://github.com/tuist/tuist/actions/runs/27439047260), both attempts): the new server pod sat in `ContainerCreating` with `MountVolume.SetUp failed ... serviceaccounts "tuist-server" not found` until the deployment's progress deadline (attempt 1) or helm's 60m timeout (attempt 2) tripped, and `--atomic` rolled the release back.

## Root cause

On managed envs the `tuist-server` ServiceAccount is a `pre-install,pre-upgrade` hook (`migrationJob.asHook=true`) so it exists before the migration-job hook on fresh installs. Hook resources are excluded from the stored release manifest. Manual staging deploys earlier that day (revisions 278–280, from `feat/kura-macos-runner-cache`) rendered with `asHook=false` — most likely a missing `-f values-managed-common.yaml` — which recorded the SA into the release manifest as a regular resource.

The next standard deploy then hit a deterministic sequence: pre-upgrade hooks recreate the SA and run migrations fine, but the apply phase sees the SA in the old manifest and not in the new one, and prunes it — seconds before the rolled server/processor pods need it for token mounts. The rollback re-applies the old manifest, restoring the SA and re-arming the trap, so retries can never succeed.

## Fix

Add `helm.sh/resource-policy: keep` to the SA's annotations (both hook and non-hook shapes). Verified against helm v4.2.0 source:

- The apply-phase prune does `info.Get()` and honors the annotation on the **live** object (`pkg/kube/client.go`), so the hook-recreated SA — which carries the annotation from the new template — survives the prune and the deploy completes unattended.
- Hook `before-hook-creation` deletion goes straight to `KubeClient.Delete` with no resource-policy check (`pkg/action/hooks.go`), so the hook's delete/recreate cycle keeps working on every deploy — no `AlreadyExists` failures.

After one successful deploy the SA leaves the stored manifest and the drift is healed. The annotation also permanently protects against reintroducing the drift (manual deploys with `asHook=false`, or self-hosted installs flipping `asHook` false→true). Only side effect: `helm uninstall` leaves the SA behind, which is inert.

Alternatives considered: restructuring the SA out of hook-land (dedicated migration-job SA) is the deeper refactor but riskier to roll out — it changes manifest membership on canary/production and relies on SSA adoption of the live hook-created SA; an ops-side `helm rollback` to a clean revision heals staging but fixes nothing structurally. The keep annotation is minimal, self-healing on the next deploy, and immunizes all envs.

## Validation

- `helm template` with `values-managed-common` + `values-managed-staging` (CI-equivalent pins): SA renders with `keep` + hook annotations; full chart renders.
- `helm template` with default values (`asHook=false`, with and without custom `serviceAccount.annotations`): SA renders with `keep`, custom annotations preserved.
- `helm lint` with managed staging values passes.

---

[![Compound Engineering v2.60.0](https://img.shields.io/badge/Compound_Engineering-v2.60.0-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Fable 5 via [Claude Code](https://claude.com/claude-code)