### PR TITLE
fix(cli): report correct error when sharding without a fullHandle

### DIFF
--- a/cli/Sources/TuistKit/Services/TestService.swift
+++ b/cli/Sources/TuistKit/Services/TestService.swift
@@ -35,6 +35,7 @@ public enum TestServiceError: FatalError, Equatable {
     case unspecifiedPlatform(target: String, platforms: [String])
     case shardPlanningRequiresBuildOnly
     case shardIndexRequiresWithoutBuilding
+    case shardingRequiresFullHandle
 
     // Error description
 
@@ -84,6 +85,9 @@ public enum TestServiceError: FatalError, Equatable {
         case .shardIndexRequiresWithoutBuilding:
             return
                 "--shard-index only applies when executing a previously built shard. Pass --without-building to run the shard, or remove --shard-index to run tests normally."
+        case .shardingRequiresFullHandle:
+            return
+                "Test sharding requires a Tuist account. The 'Tuist.swift' file is missing a fullHandle. See how to set up a Tuist project at: https://tuist.dev/en/docs/guides/server/accounts-and-projects#projects"
         }
     }
 
@@ -94,7 +98,8 @@ public enum TestServiceError: FatalError, Equatable {
         case .schemeNotFound, .schemeWithoutTestableTargets, .testPlanNotFound,
              .testIdentifierInvalid, .duplicatedTestTargets,
              .nothingToSkip, .actionInvalid, .testProductsNotFound, .unspecifiedPlatform,
-             .shardPlanningRequiresBuildOnly, .shardIndexRequiresWithoutBuilding:
+             .shardPlanningRequiresBuildOnly, .shardIndexRequiresWithoutBuilding,
+             .shardingRequiresFullHandle:
             return .abort
         }
     }
@@ -652,7 +657,7 @@ public struct TestService { // swiftlint:disable:this type_body_length
         mode: TestProcessingMode
     ) async throws {
         guard let fullHandle = config.fullHandle else {
-            throw TestServiceError.actionInvalid
+            throw TestServiceError.shardingRequiresFullHandle
         }
 
         let serverURL = try serverEnvironmentService.url(configServerURL: config.url)

--- a/cli/Tests/TuistKitTests/Services/TestServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/TestServiceTests.swift
@@ -405,6 +405,25 @@ final class TestServiceTests: TuistUnitTestCase {
         )
     }
 
+    func test_throws_when_shard_index_is_passed_without_full_handle() async throws {
+        // Given
+        given(configLoader)
+            .loadConfig(path: .any)
+            .willReturn(.test(project: .testGeneratedProject(), fullHandle: nil))
+
+        // When / Then
+        await XCTAssertThrowsSpecific(
+            {
+                try await testRun(
+                    path: try temporaryPath(),
+                    action: .testWithoutBuilding,
+                    shardIndex: 0
+                )
+            },
+            TestServiceError.shardingRequiresFullHandle
+        )
+    }
+
     func test_throws_an_error_when_config_is_not_for_generated_project() async throws {
         // Given
         givenGenerator()


### PR DESCRIPTION
## What changed

Running a sharded test execution on a project that has no `fullHandle` now fails with a message that names the real problem instead of a misleading one about flag conflicts.

Before:

```
✖ Error
  Cannot specify both --build-only and --without-building
```

After:

```
✖ Error
  Test sharding requires a Tuist account. The 'Tuist.swift' file is missing a fullHandle. See how to set up a Tuist project at: https://tuist.dev/en/docs/guides/server/accounts-and-projects#projects
```

## Why

A user reported that `tuist test --without-building --shard-index 0` instantly failed with `Cannot specify both --build-only and --without-building`, even though neither flag combination was used.

### Root cause

That message belongs to the `actionInvalid` error, which is correctly raised in command validation only when `--without-building` and `--build-only` are genuinely combined. The problem was that `runShard` **reused the same `actionInvalid` case** for an unrelated condition: the project has no `fullHandle`, i.e. it isn't connected to the Tuist backend. Sharding is server-backed, so without a `fullHandle` it bails out — but it surfaced an error about flags that were never combined.

### Why this fix

Rather than overloading `actionInvalid` for two unrelated conditions, this adds a dedicated `shardingRequiresFullHandle` error whose message points at the actual cause and links to the project setup docs (matching the phrasing already used by other fullHandle-missing errors in the CLI). `actionInvalid` keeps its original, correct meaning for the real `--without-building` + `--build-only` conflict.

## Impact

Users attempting test sharding on a non-connected project now get an actionable error instead of a confusing one. No behavior change for connected projects or for the genuine flag-conflict case.

## Validation

- Added `test_throws_when_shard_index_is_passed_without_full_handle`, which pins that a `--shard-index` run on a config with `fullHandle: nil` throws `shardingRequiresFullHandle`.
- The CLI test target can't be executed in this environment (no PTY for `xcodebuild test`); the change is otherwise verified by inspection against the existing shard-validation test patterns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)