### PR TITLE
chore(cli): let SwiftPM own registry transformation via SwifterPM 0.8.10

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "fb63814b5660a44481fdae901870534abfcee409b16582033509810242edb677",
+  "originHash" : "653b4dcf38b38dc03e00ddd5e3196a3813c2c5e91a120df622a1ae7e04adc4b2",
   "pins" : [
     {
       "identity" : "1024jp.gzipswift",
@@ -566,8 +566,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tuist/swifterpm",
       "state" : {
-        "revision" : "f75a054d40c0ca0c414864e98d125f23eb22f4f5",
-        "version" : "0.8.9"
+        "revision" : "39479a1f50b647f36713b488969a2c6c3b696f26",
+        "version" : "0.8.10"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -1819,7 +1819,7 @@ let package = Package(
         .package(id: "swiftlang.swift-docc-plugin", from: "1.4.6"),
         .package(name: "XCResultNIF", path: "server/native/xcresult_nif"),
         .package(id: "stephencelis.SQLite_swift", from: "0.16.0"),
-        .package(url: "https://github.com/tuist/swifterpm", exact: "0.8.9"),
+        .package(url: "https://github.com/tuist/swifterpm", exact: "0.8.10"),
     ],
     targets: targets,
     swiftLanguageModes: [.v5]


### PR DESCRIPTION
## What changed

Bumps the exact SwifterPM dependency from `0.8.9` to `0.8.10` and refreshes the resolved revision in `Package.resolved`.

The main improvement from `0.8.10` is that SwifterPM now defers SCM-to-registry transformation to SwiftPM itself, from tuist/swifterpm#38.

## Why

Keeping that transformation inside SwiftPM reduces the amount of resolution behavior SwifterPM has to mirror. That should make the opt-in SwifterPM path behave closer to vanilla SwiftPM and avoid divergence around registry replacement and `Package.resolved` stability.

## Impact

Tuist’s `TUIST_USE_SWIFTERPM` flow picks up the upstream resolver behavior without changing Tuist’s integration code.

## Validation

- `swift package resolve --replace-scm-with-registry`
- `tuist generate tuist TuistSupport TuistSupportTests ProjectDescription --no-open`
- `xcodebuild test -workspace Tuist.xcworkspace -scheme Tuist-Workspace -only-testing TuistSupportTests/SwiftPackageManagerControllerTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" COMPILATION_CACHE_ENABLE_CACHING=NO`

The targeted test run executed 12 tests with 0 failures.