### PR TITLE
ci(grafana-datasource): publish unsigned until Grafana grants a signature

### DIFF
--- a/.github/workflows/grafana-datasource-release.yml
+++ b/.github/workflows/grafana-datasource-release.yml
@@ -101,12 +101,19 @@ jobs:
           mage -v
           ls -la dist/gpx_tuist_datasource_* >/dev/null
 
+      # Grafana only issues a signature after the plugin is reviewed and granted a
+      # signature level, so signing fails until then. Publish unsigned and warn
+      # rather than block the release; it signs automatically once approved.
       - name: Sign the plugin
         if: ${{ env.OP_SERVICE_ACCOUNT_TOKEN != '' }}
         run: |
           GRAFANA_ACCESS_POLICY_TOKEN=$(op read "op://tuist/TUIST_GRAFANA_PLUGIN_TOKEN/password")
           export GRAFANA_ACCESS_POLICY_TOKEN
-          npm run sign
+          if npm run sign; then
+            echo "Plugin signed."
+          else
+            echo "::warning::Plugin not signed — Grafana issues a signature only after the plugin is reviewed at grafana.com (My Plugins). Publishing unsigned; re-release to sign once a signature level is granted."
+          fi
 
       - name: Package
         run: |


### PR DESCRIPTION
## What

Makes the plugin release's "Sign the plugin" step best-effort: it still reads the access-policy token from 1Password and runs `npm run sign`, but on failure it logs a `::warning::` and continues so the (unsigned) plugin still publishes. Token-read failures still hard-fail — those are a real infra problem, not the expected state.

## Why

The signed re-cut of 0.1.0 failed with:

```
sign-plugin  Error signing manifest.  Server responded with status code 409  (InvalidArgument)
```

This is **not** a misconfiguration. Per Grafana's docs, [the Grafana team reviews public plugins before you can sign them](https://grafana.com/developers/plugin-tools/publish-a-plugin/sign-a-plugin) — you only sign *after* approval, once granted a signature level. The plugin has never been submitted (My Plugins shows 0), so the signing API returns 409. Grafana staff guidance for this exact case is ["if you don't have an assigned plugin signature you should skip the signature step"](https://community.grafana.com/t/the-pipeline-verifying-the-plugin-build-source-returns-a-409-error/162132).

So the initial release is meant to be **unsigned**: you publish the unsigned build, submit it at grafana.com → My Plugins → Submit New Plugin for review, and sign only after approval. Hard-failing the release on the not-yet-signable state blocked even producing that first artifact.

The org/token side is all correct and verified: org slug `tuist` (stack `tuist.grafana.net`) matches the `tuist-metrics-datasource` id prefix, and the 1Password wiring works (the failing run proved `op read` → `npm run sign` reaches the Grafana API).

## Behavior after this change

- Pre-approval: release publishes an unsigned zip + a CI warning. This is the artifact you submit for catalog review.
- Post-approval (signature level granted): `npm run sign` succeeds on its own and the release is signed — no further workflow changes.

## Validation

- `actionlint` clean (only the expected `tuist-linux` self-hosted-label note).
- The `if npm run sign; then … else …` form keeps `op read` failures fatal under `bash -e` while making only the signing itself non-fatal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)