### PR TITLE
ci(grafana-datasource): defer signing until the plugin is reviewed

### DIFF
--- a/.github/workflows/grafana-datasource-release.yml
+++ b/.github/workflows/grafana-datasource-release.yml
@@ -42,7 +42,7 @@ jobs:
         run: mise run release:check grafana-datasource
 
   release:
-    name: Build, sign and release
+    name: Build and release
     needs: check-releases
     if: needs.check-releases.outputs.should-release == 'true'
     runs-on: tuist-linux
@@ -51,7 +51,6 @@ jobs:
       run:
         working-directory: grafana-datasource
     env:
-      OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
       TAG: ${{ needs.check-releases.outputs.next-version }}
       VERSION: ${{ needs.check-releases.outputs.next-version-number }}
     steps:
@@ -70,7 +69,7 @@ jobs:
       - uses: jdx/mise-action@v4.0.1
         with:
           version: ${{ env.MISE_VERSION }}
-          install_args: "git-cliff 1password-cli"
+          install_args: "git-cliff"
           cache: "false"
           github_token: ${{ env.MISE_GITHUB_TOKEN }}
 
@@ -101,20 +100,10 @@ jobs:
           mage -v
           ls -la dist/gpx_tuist_datasource_* >/dev/null
 
-      # Grafana only issues a signature after the plugin is reviewed and granted a
-      # signature level, so signing fails until then. Publish unsigned and warn
-      # rather than block the release; it signs automatically once approved.
-      - name: Sign the plugin
-        if: ${{ env.OP_SERVICE_ACCOUNT_TOKEN != '' }}
-        run: |
-          GRAFANA_ACCESS_POLICY_TOKEN=$(op read "op://tuist/TUIST_GRAFANA_PLUGIN_TOKEN/password")
-          export GRAFANA_ACCESS_POLICY_TOKEN
-          if npm run sign; then
-            echo "Plugin signed."
-          else
-            echo "::warning::Plugin not signed — Grafana issues a signature only after the plugin is reviewed at grafana.com (My Plugins). Publishing unsigned; re-release to sign once a signature level is granted."
-          fi
-
+      # No signing step yet: Grafana issues a plugin signature only after the
+      # plugin is reviewed in the catalog. Releases are unsigned until then; the
+      # signing step (token from 1Password) is added back once a signature level
+      # is granted.
       - name: Package
         run: |
           id=$(node -p "require('./src/plugin.json').id")


### PR DESCRIPTION
## What

Removes plugin signing from the release workflow for now: drops the Sign step, the `OP_SERVICE_ACCOUNT_TOKEN` env, the 1Password `op read`, and `1password-cli` from the mise install. The release builds, packages, and publishes an **unsigned** plugin. Job renamed `Build, sign and release` → `Build and release`.

## Why

The initial release has to be unsigned. Per [Grafana's docs](https://grafana.com/developers/plugin-tools/publish-a-plugin/sign-a-plugin), Grafana issues a plugin signature only after the plugin is reviewed in the catalog and the org is granted a signature level. The plugin hasn't been submitted yet (My Plugins shows 0), so any signing attempt fails. The correct flow is: publish unsigned → submit the unsigned build at grafana.com → review → sign after approval.

Attempting to sign anyway blocked the unsigned release twice:
1. The expected `409 InvalidArgument` from the signing API (no signature level granted yet).
2. After making signing best-effort, transient **1Password service-account rate limits** on the `op read` of the access-policy token — and the token read is deliberately fatal, so it failed the whole release.

Neither is worth blocking the unsigned initial release on, and we don't need the token at all until there's something to sign.

## After this

- Releases publish an unsigned zip — reliably, with no 1Password dependency.
- Once Grafana grants a signature level (after catalog review), the signing step is added back (it reads the token from 1Password; that wiring is already proven working).

## Validation

- `actionlint` clean (only the expected `tuist-linux` self-hosted-label note).
- No remaining `op` / `1password` / `OP_SERVICE_ACCOUNT_TOKEN` / signing references in the workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)