### PR TITLE
fix(cli): cache XCTest and Swift Testing support frameworks

### DIFF
--- a/cli/Sources/TuistCache/AGENTS.md
+++ b/cli/Sources/TuistCache/AGENTS.md
@@ -12,6 +12,6 @@ This module handles CLI integration with the cache service and cache features.
 
 ## Invariants
 - Only cacheable products are hashed (frameworks, static frameworks, bundles, macros).
-- Targets that depend on XCTest are excluded from cache hashing.
+- Test bundles are excluded from binary cache hashing, but test-support frameworks that link XCTest or Swift Testing can be hashed.
 - Explicit cache warm target selection scopes transitive cache candidates from non-test roots only.
 - Cache version bumps invalidate incompatible artifacts.

--- a/cli/Sources/TuistCache/CacheGraphContentHasher.swift
+++ b/cli/Sources/TuistCache/CacheGraphContentHasher.swift
@@ -68,7 +68,6 @@ public struct CacheGraphContentHasher: CacheGraphContentHashing {
             Logger.current.debug("Graph used for hashing exported to \(exportPath.pathString)")
         }
 
-        let graphTraverser = GraphTraverser(graph: graph)
         let version = versionFetcher.version()
         let configuration = try defaultConfigurationFetcher.fetch(
             configuration: configuration,
@@ -81,7 +80,6 @@ public struct CacheGraphContentHasher: CacheGraphContentHashing {
             include: {
                 isGraphTargetHashable(
                     $0,
-                    graphTraverser: graphTraverser,
                     excludedTargets: excludedTargets
                 )
             },
@@ -98,7 +96,6 @@ public struct CacheGraphContentHasher: CacheGraphContentHashing {
 
     private func isGraphTargetHashable(
         _ target: GraphTarget,
-        graphTraverser: GraphTraversing,
         excludedTargets: Set<String>
     ) -> Bool {
         let product = target.target.product
@@ -107,10 +104,10 @@ public struct CacheGraphContentHasher: CacheGraphContentHashing {
         // The second condition is to exclude the resources bundle associated to the given target name
         let isExcluded = excludedTargets.contains(name) || excludedTargets
             .contains(target.target.name.dropPrefix("\(target.project.name)_"))
-        let dependsOnXCTest = graphTraverser.dependsOnXCTest(path: target.path, name: name)
+        let isTestBundle = target.target.product.testsBundle
         let isHashableProduct = CacheGraphContentHasher.cachableProducts.contains(product)
 
-        return isHashableProduct && !isExcluded && !dependsOnXCTest
+        return isHashableProduct && !isExcluded && !isTestBundle
     }
 
     private func isMacro(_ target: GraphTarget, graphTraverser: GraphTraversing) -> Bool {

--- a/cli/Sources/TuistCache/CacheWarmTargetGraphSelector.swift
+++ b/cli/Sources/TuistCache/CacheWarmTargetGraphSelector.swift
@@ -28,7 +28,7 @@ public enum CacheWarmTargetGraphSelector {
         }
 
         let nonTestRoots = requestedGraphTargets.filter {
-            !graphTraverser.dependsOnXCTest(path: $0.path, name: $0.target.name)
+            !$0.target.product.testsBundle
         }
         guard !nonTestRoots.isEmpty else {
             return .noNonTestRoots

--- a/cli/Sources/TuistHasher/GraphContentHasher.swift
+++ b/cli/Sources/TuistHasher/GraphContentHasher.swift
@@ -25,8 +25,8 @@ public protocol GraphContentHashing {
 }
 
 /// `GraphContentHasher`
-/// is responsible for computing an hash that uniquely identifies a Tuist `Graph`.
-/// It considers only targets that are considered cacheable: frameworks without dependencies on XCTest or on non-cacheable targets
+/// is responsible for computing a hash that uniquely identifies a Tuist `Graph`.
+/// It hashes targets included by the caller when their target dependencies are hashable too.
 public struct GraphContentHasher: GraphContentHashing {
     private let contentHasher: ContentHashing
     private let targetContentHasher: TargetContentHashing

--- a/cli/Tests/TuistCacheEEAcceptanceTests/TuistCacheEEAcceptanceTests.swift
+++ b/cli/Tests/TuistCacheEEAcceptanceTests/TuistCacheEEAcceptanceTests.swift
@@ -194,6 +194,73 @@ struct TuistCacheEEAcceptanceTests {
     }
 
     @Test(
+        .inTemporaryDirectory,
+        .withMockedEnvironment(inheritingVariables: ["PATH"]),
+        .withMockedNoora,
+        .withMockedLogger(forwardLogs: true),
+        .withFixture("generated_ios_app_with_cached_xctest_support")
+    ) func generated_ios_app_with_cached_xctest_support() async throws {
+        let fixtureDirectory = try #require(TuistTest.fixtureDirectory)
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let mockedEnvironment = try #require(Environment.mocked)
+        let fileSystem = FileSystem()
+        let xcodeprojPath = fixtureDirectory.appending(component: "CachedXCTestSupport.xcodeproj")
+
+        try await TuistTest.run(
+            CacheCommand.self,
+            ["--path", fixtureDirectory.pathString]
+        )
+
+        let cachedFeatureArtifacts = try await fileSystem.glob(
+            directory: mockedEnvironment.cacheDirectory,
+            include: ["**/Feature.xcframework"]
+        ).collect()
+        let cachedTestSupportArtifacts = try await fileSystem.glob(
+            directory: mockedEnvironment.cacheDirectory,
+            include: ["**/TestSupport.xcframework"]
+        ).collect()
+        let cachedSwiftTestingSupportArtifacts = try await fileSystem.glob(
+            directory: mockedEnvironment.cacheDirectory,
+            include: ["**/SwiftTestingSupport.xcframework"]
+        ).collect()
+        let cachedTestBundleArtifacts = try await fileSystem.glob(
+            directory: mockedEnvironment.cacheDirectory,
+            include: ["**/AppTests.xcframework"]
+        ).collect()
+        #expect(!cachedFeatureArtifacts.isEmpty)
+        #expect(!cachedTestSupportArtifacts.isEmpty)
+        #expect(!cachedSwiftTestingSupportArtifacts.isEmpty)
+        #expect(cachedTestBundleArtifacts.isEmpty)
+
+        try await TuistTest.run(
+            TestCommand.self,
+            [
+                "App",
+                "--build-only",
+                "--no-upload",
+                "--no-selective-testing",
+                "--path",
+                fixtureDirectory.pathString,
+                "--",
+                "-destination",
+                "generic/platform=iOS Simulator",
+                "-derivedDataPath",
+                temporaryDirectory.pathString,
+                "CODE_SIGN_IDENTITY=",
+                "CODE_SIGNING_REQUIRED=NO",
+                "CODE_SIGNING_ALLOWED=NO",
+            ]
+        )
+
+        try TuistAcceptanceTest.expectXCFrameworkLinked("Feature", by: "App", xcodeprojPath: xcodeprojPath)
+        try TuistAcceptanceTest.expectXCFrameworkLinked("Feature", by: "AppTests", xcodeprojPath: xcodeprojPath)
+        try TuistAcceptanceTest.expectXCFrameworkLinked("TestSupport", by: "AppTests", xcodeprojPath: xcodeprojPath)
+        try TuistAcceptanceTest.expectXCFrameworkLinked("SwiftTestingSupport", by: "AppTests", xcodeprojPath: xcodeprojPath)
+        try TuistAcceptanceTest.expectXCFrameworkNotLinked("TestSupport", by: "App", xcodeprojPath: xcodeprojPath)
+        try TuistAcceptanceTest.expectXCFrameworkNotLinked("SwiftTestingSupport", by: "App", xcodeprojPath: xcodeprojPath)
+    }
+
+    @Test(
         .disabled("Requires SPM install"),
         .inTemporaryDirectory,
         .withMockedEnvironment(inheritingVariables: ["PATH"]),

--- a/cli/Tests/TuistCacheTests/CacheGraphContentHasherIntegrationTests.swift
+++ b/cli/Tests/TuistCacheTests/CacheGraphContentHasherIntegrationTests.swift
@@ -158,6 +158,80 @@ struct ContentHashingIntegrationTests {
         .inTemporaryDirectory,
         .withMockedSwiftVersionProvider,
         .withMockedXcodeController
+    ) func contentHashes_xctestSupportFrameworkUsedByTestsIsComputed() async throws {
+        // Given
+        let temporaryPath = try #require(FileSystem.temporaryTestDirectory)
+        let testSupportTarget = makeFramework(
+            name: "TestSupport",
+            sources: [source1],
+            dependencies: [.xctest]
+        )
+        let featureTarget = makeFramework(
+            name: "Feature",
+            sources: [source2]
+        )
+        let testsTarget = Target.test(
+            name: "FeatureTests",
+            product: .unitTests,
+            dependencies: [
+                .target(name: featureTarget.name),
+                .target(name: testSupportTarget.name),
+            ]
+        )
+        let project = Project.test(
+            path: temporaryPath.appending(component: "Project"),
+            settings: .default,
+            targets: [testSupportTarget, featureTarget, testsTarget]
+        )
+        let testSupport = GraphTarget(
+            path: project.path,
+            target: project.targets["TestSupport"]!,
+            project: project
+        )
+        let feature = GraphTarget(
+            path: project.path,
+            target: project.targets["Feature"]!,
+            project: project
+        )
+        let tests = GraphTarget(
+            path: project.path,
+            target: project.targets["FeatureTests"]!,
+            project: project
+        )
+        let graph = Graph.test(
+            projects: [
+                project.path: project,
+            ],
+            dependencies: [
+                .target(name: testSupportTarget.name, path: project.path): [
+                    .testSDK(name: "XCTest.framework"),
+                ],
+                .target(name: testsTarget.name, path: project.path): [
+                    .target(name: featureTarget.name, path: project.path),
+                    .target(name: testSupportTarget.name, path: project.path),
+                ],
+            ]
+        )
+
+        // When
+        let contentHash = try await subject.contentHashes(
+            for: graph,
+            configuration: "Debug",
+            defaultConfiguration: nil,
+            excludedTargets: [],
+            destination: nil
+        )
+
+        // Then
+        #expect(contentHash[testSupport] != nil)
+        #expect(contentHash[feature] != nil)
+        #expect(contentHash[tests] == nil)
+    }
+
+    @Test(
+        .inTemporaryDirectory,
+        .withMockedSwiftVersionProvider,
+        .withMockedXcodeController
     ) func contentHashes_hashIsConsistent() async throws {
         // Given
         let temporaryPath = try #require(FileSystem.temporaryTestDirectory)
@@ -549,7 +623,8 @@ struct ContentHashingIntegrationTests {
         sources: [SourceFile] = [],
         resources: ResourceFileElements = .init([]),
         coreDataModels: [CoreDataModel] = [],
-        targetScripts: [TargetScript] = []
+        targetScripts: [TargetScript] = [],
+        dependencies: [TargetDependency] = []
     ) -> Target {
         .test(
             name: name,
@@ -559,7 +634,8 @@ struct ContentHashingIntegrationTests {
             sources: sources,
             resources: resources,
             coreDataModels: coreDataModels,
-            scripts: targetScripts
+            scripts: targetScripts,
+            dependencies: dependencies
         )
     }
 }

--- a/cli/Tests/TuistCacheTests/CacheGraphContentHasherTests.swift
+++ b/cli/Tests/TuistCacheTests/CacheGraphContentHasherTests.swift
@@ -184,7 +184,7 @@ struct CacheGraphContentHasherTests {
 
     @Test(
         .withMockedSwiftVersionProvider
-    ) func contentHashes_when_target_depends_on_XCTest_hashes_are_not_computed() async throws {
+    ) func contentHashes_when_target_is_test_bundle_hashes_are_not_computed() async throws {
         // Given
         let included = Target.test(name: "Included", product: .framework)
         let testSupport = Target.test(name: "TestSupport", product: .uiTests)
@@ -238,6 +238,131 @@ struct CacheGraphContentHasherTests {
                 for: .any,
                 include: .matching { filter in
                     filter(includedTarget) && !filter(xctestTarget)
+                },
+                destination: .any,
+                additionalStrings: .any
+            )
+            .called(1)
+    }
+
+    @Test(
+        .withMockedSwiftVersionProvider
+    ) func contentHashes_when_framework_depends_on_XCTest_hashes_are_computed() async throws {
+        // Given
+        let testSupport = Target.test(name: "TestSupport", product: .framework)
+        let project = Project.test(
+            path: "/Project/Path",
+            targets: [testSupport]
+        )
+        let testSupportTarget = GraphTarget(
+            path: project.path,
+            target: project.targets["TestSupport"]!,
+            project: project
+        )
+        let graph = Graph.test(
+            path: project.path,
+            projects: [
+                project.path: project,
+            ],
+            dependencies: [
+                .target(name: testSupport.name, path: project.path): [
+                    .testSDK(name: "XCTest.framework"),
+                ],
+            ]
+        )
+
+        given(graphContentHasher)
+            .contentHashes(
+                for: .any,
+                include: .any,
+                destination: .any,
+                additionalStrings: .any
+            )
+            .willReturn([:])
+        given(defaultConfigurationFetcher)
+            .fetch(configuration: .any, defaultConfiguration: .any, graph: .any)
+            .willReturn("Debug")
+        let swiftVersionProviderMock = try #require(SwiftVersionProvider.mocked)
+        given(swiftVersionProviderMock).swiftlangVersion().willReturn("5.10.0")
+
+        // When
+        _ = try await subject.contentHashes(
+            for: graph,
+            configuration: "Debug",
+            defaultConfiguration: nil,
+            excludedTargets: [],
+            destination: nil
+        )
+
+        // Then
+        verify(graphContentHasher)
+            .contentHashes(
+                for: .any,
+                include: .matching { filter in
+                    filter(testSupportTarget)
+                },
+                destination: .any,
+                additionalStrings: .any
+            )
+            .called(1)
+    }
+
+    @Test(
+        .withMockedSwiftVersionProvider
+    ) func contentHashes_when_framework_enables_testing_search_paths_hashes_are_computed() async throws {
+        // Given
+        let testSupport = Target.test(
+            name: "TestSupport",
+            product: .framework,
+            settings: .test(base: [
+                "ENABLE_TESTING_SEARCH_PATHS": "YES",
+            ])
+        )
+        let project = Project.test(
+            path: "/Project/Path",
+            targets: [testSupport]
+        )
+        let testSupportTarget = GraphTarget(
+            path: project.path,
+            target: project.targets["TestSupport"]!,
+            project: project
+        )
+        let graph = Graph.test(
+            path: project.path,
+            projects: [
+                project.path: project,
+            ]
+        )
+
+        given(graphContentHasher)
+            .contentHashes(
+                for: .any,
+                include: .any,
+                destination: .any,
+                additionalStrings: .any
+            )
+            .willReturn([:])
+        given(defaultConfigurationFetcher)
+            .fetch(configuration: .any, defaultConfiguration: .any, graph: .any)
+            .willReturn("Debug")
+        let swiftVersionProviderMock = try #require(SwiftVersionProvider.mocked)
+        given(swiftVersionProviderMock).swiftlangVersion().willReturn("5.10.0")
+
+        // When
+        _ = try await subject.contentHashes(
+            for: graph,
+            configuration: "Debug",
+            defaultConfiguration: nil,
+            excludedTargets: [],
+            destination: nil
+        )
+
+        // Then
+        verify(graphContentHasher)
+            .contentHashes(
+                for: .any,
+                include: .matching { filter in
+                    filter(testSupportTarget)
                 },
                 destination: .any,
                 additionalStrings: .any

--- a/cli/Tests/TuistCacheTests/CacheWarmTargetGraphSelectorTests.swift
+++ b/cli/Tests/TuistCacheTests/CacheWarmTargetGraphSelectorTests.swift
@@ -58,6 +58,24 @@ struct CacheWarmTargetGraphSelectorTests {
     }
 
     @Test
+    func selection_when_requested_target_is_xctest_support_framework_keeps_it_as_non_test_root() {
+        let graph = makeGraph()
+        let graphTraverser = GraphTraverser(graph: graph)
+        let localPath = try! AbsolutePath(validating: "/Local") // swiftlint:disable:this force_try
+        let localProject = graph.projects[localPath]!
+        let expectedTargets: Set<GraphTarget> = [
+            GraphTarget(path: localPath, target: localProject.targets["TestSupport"]!, project: localProject),
+        ]
+
+        let selection = CacheWarmTargetGraphSelector.selection(
+            graphTraverser: graphTraverser,
+            requestedTargets: [.named("TestSupport")]
+        )
+
+        #expect(selection == .explicit(expectedTargets))
+    }
+
+    @Test
     func selection_when_requested_targets_are_only_tests_returns_noNonTestRoots() {
         let graphTraverser = GraphTraverser(graph: makeGraph())
 
@@ -85,6 +103,11 @@ struct CacheWarmTargetGraphSelectorTests {
             product: .framework,
             dependencies: [.project(target: "ApolloTestSupport", path: externalPath)]
         )
+        let testSupport = Target.test(
+            name: "TestSupport",
+            product: .framework,
+            dependencies: [.xctest]
+        )
         let appUITests = Target.test(
             name: "AppUITests",
             product: .uiTests,
@@ -98,7 +121,7 @@ struct CacheWarmTargetGraphSelectorTests {
         let localProject = Project.test(
             path: localPath,
             name: "Local",
-            targets: [app, appCore, buildingDetailsMocks, appUITests]
+            targets: [app, appCore, buildingDetailsMocks, testSupport, appUITests]
         )
 
         let apolloAPI = Target.test(name: "ApolloAPI", product: .staticFramework)
@@ -126,6 +149,9 @@ struct CacheWarmTargetGraphSelectorTests {
                 ],
                 .target(name: buildingDetailsMocks.name, path: localPath): [
                     .target(name: apolloTestSupport.name, path: externalPath),
+                ],
+                .target(name: testSupport.name, path: localPath): [
+                    .testSDK(name: "XCTest.framework"),
                 ],
                 .target(name: appUITests.name, path: localPath): [
                     .target(name: app.name, path: localPath),

--- a/examples/xcode/generated_ios_app_with_cached_xctest_support/App/Sources/AppDelegate.swift
+++ b/examples/xcode/generated_ios_app_with_cached_xctest_support/App/Sources/AppDelegate.swift
@@ -1,0 +1,11 @@
+import UIKit
+
+@main
+final class AppDelegate: UIResponder, UIApplicationDelegate {
+    func application(
+        _: UIApplication,
+        didFinishLaunchingWithOptions _: [UIApplication.LaunchOptionsKey: Any]?
+    ) -> Bool {
+        true
+    }
+}

--- a/examples/xcode/generated_ios_app_with_cached_xctest_support/App/Tests/AppTests.swift
+++ b/examples/xcode/generated_ios_app_with_cached_xctest_support/App/Tests/AppTests.swift
@@ -1,0 +1,21 @@
+import Feature
+import SwiftTestingSupport
+import Testing
+import TestSupport
+import XCTest
+
+final class AppTests: XCTestCase {
+    func testFeatureMessageWithXCTestSupport() {
+        TestSupport.assertMessage(Feature().message)
+    }
+}
+
+@Suite struct AppSwiftTestingTests {
+    @Test func featureMessageMatchesFixture() {
+        #expect(Feature().message == TestSupport.expectedMessage)
+    }
+
+    @Test func featureMessageMatchesSwiftTestingSupportFixture() {
+        SwiftTestingSupport.expectMessage(Feature().message)
+    }
+}

--- a/examples/xcode/generated_ios_app_with_cached_xctest_support/Feature/Resources/message.txt
+++ b/examples/xcode/generated_ios_app_with_cached_xctest_support/Feature/Resources/message.txt
@@ -1,0 +1,1 @@
+cached-xctest-support

--- a/examples/xcode/generated_ios_app_with_cached_xctest_support/Feature/Sources/Feature.swift
+++ b/examples/xcode/generated_ios_app_with_cached_xctest_support/Feature/Sources/Feature.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+public struct Feature {
+    public let message: String
+
+    public init(message: String = "cached-xctest-support") {
+        self.message = message
+    }
+}

--- a/examples/xcode/generated_ios_app_with_cached_xctest_support/Project.swift
+++ b/examples/xcode/generated_ios_app_with_cached_xctest_support/Project.swift
@@ -1,0 +1,72 @@
+import ProjectDescription
+
+let project = Project(
+    name: "CachedXCTestSupport",
+    organizationName: "tuist.dev",
+    targets: [
+        .target(
+            name: "App",
+            destinations: .iOS,
+            product: .app,
+            bundleId: "io.tuist.CachedXCTestSupport",
+            infoPlist: .default,
+            sources: ["App/Sources/**"],
+            dependencies: [
+                .target(name: "Feature"),
+            ]
+        ),
+        .target(
+            name: "Feature",
+            destinations: .iOS,
+            product: .framework,
+            bundleId: "io.tuist.CachedXCTestSupport.Feature",
+            infoPlist: .default,
+            sources: ["Feature/Sources/**"],
+            resources: ["Feature/Resources/**"]
+        ),
+        .target(
+            name: "TestSupport",
+            destinations: .iOS,
+            product: .framework,
+            bundleId: "io.tuist.CachedXCTestSupport.TestSupport",
+            infoPlist: .default,
+            sources: ["TestSupport/Sources/**"],
+            resources: ["TestSupport/Resources/**"],
+            dependencies: [
+                .xctest,
+            ],
+            settings: .settings(base: [
+                "ENABLE_TESTING_SEARCH_PATHS": "YES",
+            ])
+        ),
+        .target(
+            name: "SwiftTestingSupport",
+            destinations: .iOS,
+            product: .framework,
+            bundleId: "io.tuist.CachedXCTestSupport.SwiftTestingSupport",
+            infoPlist: .default,
+            sources: ["SwiftTestingSupport/Sources/**"],
+            resources: ["SwiftTestingSupport/Resources/**"],
+            dependencies: [
+                .sdk(name: "Testing", type: .framework),
+            ],
+            settings: .settings(base: [
+                "ENABLE_TESTING_SEARCH_PATHS": "YES",
+            ])
+        ),
+        .target(
+            name: "AppTests",
+            destinations: .iOS,
+            product: .unitTests,
+            bundleId: "io.tuist.CachedXCTestSupport.AppTests",
+            infoPlist: .default,
+            sources: ["App/Tests/**"],
+            dependencies: [
+                .target(name: "App"),
+                .target(name: "Feature"),
+                .target(name: "TestSupport"),
+                .target(name: "SwiftTestingSupport"),
+            ]
+        ),
+    ]
+)

--- a/examples/xcode/generated_ios_app_with_cached_xctest_support/SwiftTestingSupport/Resources/fixture.json
+++ b/examples/xcode/generated_ios_app_with_cached_xctest_support/SwiftTestingSupport/Resources/fixture.json
@@ -1,0 +1,1 @@
+{"message":"cached-xctest-support"}

--- a/examples/xcode/generated_ios_app_with_cached_xctest_support/SwiftTestingSupport/Sources/SwiftTestingSupport.swift
+++ b/examples/xcode/generated_ios_app_with_cached_xctest_support/SwiftTestingSupport/Sources/SwiftTestingSupport.swift
@@ -1,0 +1,9 @@
+import Testing
+
+public enum SwiftTestingSupport {
+    public static let expectedMessage = "cached-xctest-support"
+
+    public static func expectMessage(_ message: String) {
+        #expect(message == expectedMessage)
+    }
+}

--- a/examples/xcode/generated_ios_app_with_cached_xctest_support/TestSupport/Resources/fixture.json
+++ b/examples/xcode/generated_ios_app_with_cached_xctest_support/TestSupport/Resources/fixture.json
@@ -1,0 +1,1 @@
+{"message":"cached-xctest-support"}

--- a/examples/xcode/generated_ios_app_with_cached_xctest_support/TestSupport/Sources/TestSupport.swift
+++ b/examples/xcode/generated_ios_app_with_cached_xctest_support/TestSupport/Sources/TestSupport.swift
@@ -1,0 +1,10 @@
+import Foundation
+import XCTest
+
+public enum TestSupport {
+    public static let expectedMessage = "cached-xctest-support"
+
+    public static func assertMessage(_ message: String, file: StaticString = #filePath, line: UInt = #line) {
+        XCTAssertEqual(message, expectedMessage, file: file, line: line)
+    }
+}

--- a/examples/xcode/generated_ios_app_with_cached_xctest_support/Tuist.swift
+++ b/examples/xcode/generated_ios_app_with_cached_xctest_support/Tuist.swift
@@ -1,0 +1,3 @@
+import ProjectDescription
+
+let tuist = Tuist()

--- a/server/priv/docs/en/guides/features/cache/module-cache.md
+++ b/server/priv/docs/en/guides/features/cache/module-cache.md
@@ -117,11 +117,11 @@ Precedence when resolving the effective behavior (highest to lowest):
 
 Only the following target products are cacheable by Tuist:
 
-- Frameworks (static and dynamic) that don't depend on [XCTest](https://developer.apple.com/documentation/xctest)
+- Frameworks (static and dynamic), including test-support frameworks that depend on [XCTest](https://developer.apple.com/documentation/xctest) or Swift Testing
 - Bundles
 - Swift Macros
 
-We are working on supporting libraries and targets that depend on XCTest.
+Test bundles remain excluded from the module cache. This means `unitTests` and `uiTests` targets are not cached as binaries, but regular framework targets that tests depend on can be cached even when they link XCTest or Swift Testing.
 
 > [!NOTE]
 > **Upstream Dependencies**

--- a/server/priv/marketing/changelog/2026.06.15-module-cache-test-support-frameworks.md
+++ b/server/priv/marketing/changelog/2026.06.15-module-cache-test-support-frameworks.md
@@ -1,0 +1,10 @@
+---
+title: Module Cache support for test helper frameworks
+description: "Cache XCTest and Swift Testing helper frameworks without turning test bundles into cache artifacts."
+category: "Product"
+pull_request: 11281
+---
+
+Module Cache can now cache framework targets that support your tests, even when they link XCTest or Swift Testing. This helps projects with shared assertion helpers, fixtures, or test utilities reuse binary cache artifacts instead of rebuilding those helper modules from source every time.
+
+Test bundles themselves are still left out of the binary cache. The change only applies to regular framework products that tests depend on, so your test targets keep their normal behavior while their reusable support modules can benefit from local and remote cache hits.


### PR DESCRIPTION
Resolves N/A

This changes binary cache selection so XCTest-backed and Swift Testing-backed test-support frameworks can be cached while actual test bundles remain excluded.

The previous predicate treated every target that depended on XCTest, or enabled testing search paths, as non-cacheable. That was broader than the product-level constraint we need: test bundles should not become cache artifacts, but framework products used by tests can be hashed, warmed, and consumed from the local cache.

The implementation now filters cache candidates by cacheable product type plus `testsBundle`, and explicit cache warm selection keeps XCTest support frameworks as non-test roots. The tests cover direct XCTest dependencies, testing search paths, test bundle exclusion, transitive test usage, and a local-cache acceptance fixture with both an XCTest support framework and a Swift Testing support framework.

### How to test locally

- `swiftformat cli/Sources/TuistCache/CacheGraphContentHasher.swift cli/Sources/TuistCache/CacheWarmTargetGraphSelector.swift cli/Tests/TuistCacheTests/CacheGraphContentHasherTests.swift cli/Tests/TuistCacheTests/CacheGraphContentHasherIntegrationTests.swift cli/Tests/TuistCacheTests/CacheWarmTargetGraphSelectorTests.swift cli/Tests/TuistCacheEEAcceptanceTests/TuistCacheEEAcceptanceTests.swift examples/xcode/generated_ios_app_with_cached_xctest_support/Project.swift examples/xcode/generated_ios_app_with_cached_xctest_support/Tuist.swift examples/xcode/generated_ios_app_with_cached_xctest_support/App/Sources/AppDelegate.swift examples/xcode/generated_ios_app_with_cached_xctest_support/App/Tests/AppTests.swift examples/xcode/generated_ios_app_with_cached_xctest_support/Feature/Sources/Feature.swift examples/xcode/generated_ios_app_with_cached_xctest_support/TestSupport/Sources/TestSupport.swift examples/xcode/generated_ios_app_with_cached_xctest_support/SwiftTestingSupport/Sources/SwiftTestingSupport.swift`
- `.build/debug/tuist cache warm --path examples/xcode/generated_ios_app_with_cached_xctest_support --generate-only --print-hashes`
- `.build/debug/tuist test App --build-only --no-binary-cache --no-upload --no-selective-testing --path examples/xcode/generated_ios_app_with_cached_xctest_support -- -destination 'generic/platform=iOS Simulator' -derivedDataPath /tmp/tuist-cached-xctest-support-derived-data CODE_SIGN_IDENTITY= CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- `swift build --target TuistCache --replace-scm-with-registry`
- `git diff --check`
