### PR TITLE
fix(cli): remove cache target build time tracking

### DIFF
--- a/cli/Sources/TuistCore/Analytics/RunCacheTargetMetadata.swift
+++ b/cli/Sources/TuistCore/Analytics/RunCacheTargetMetadata.swift
@@ -1,20 +1,15 @@
-import Foundation
-
 public struct RunCacheTargetMetadata: Codable, Hashable {
     public let hash: String
     public let hit: RunCacheHit
-    public let buildDuration: TimeInterval?
     public let subhashes: TargetContentHashSubhashes?
 
     public init(
         hash: String,
         hit: RunCacheHit,
-        buildDuration: TimeInterval? = nil,
         subhashes: TargetContentHashSubhashes? = nil
     ) {
         self.hash = hash
         self.hit = hit
-        self.buildDuration = buildDuration
         self.subhashes = subhashes
     }
 }

--- a/cli/Sources/TuistCore/Cache/CacheItem.swift
+++ b/cli/Sources/TuistCore/Cache/CacheItem.swift
@@ -1,6 +1,3 @@
-import Foundation
-import Path
-
 public struct CacheItem: Hashable, Equatable, Codable {
     /// Cache items can either come from a local or a remote cache
     public enum Source: Hashable, Equatable, Codable {
@@ -11,20 +8,17 @@ public struct CacheItem: Hashable, Equatable, Codable {
     public let hash: String
     public let source: Source
     public let cacheCategory: RemoteCacheCategory
-    public let buildDuration: TimeInterval?
 
     public init(
         name: String,
         hash: String,
         source: Source,
-        cacheCategory: RemoteCacheCategory,
-        buildDuration: TimeInterval? = nil
+        cacheCategory: RemoteCacheCategory
     ) {
         self.name = name
         self.hash = hash
         self.source = source
         self.cacheCategory = cacheCategory
-        self.buildDuration = buildDuration
     }
 
     public func hash(into hasher: inout Hasher) {
@@ -37,15 +31,13 @@ public struct CacheItem: Hashable, Equatable, Codable {
             name: String = "Target",
             hash: String = "cache-item-hash",
             source: Source = .local,
-            cacheCategory: RemoteCacheCategory = .selectiveTests,
-            buildDuration: TimeInterval? = nil
+            cacheCategory: RemoteCacheCategory = .selectiveTests
         ) -> Self {
             .init(
                 name: name,
                 hash: hash,
                 source: source,
-                cacheCategory: cacheCategory,
-                buildDuration: buildDuration
+                cacheCategory: cacheCategory
             )
         }
     #endif

--- a/cli/Sources/TuistKit/Commands/Cache/CacheWarmCommandService.swift
+++ b/cli/Sources/TuistKit/Commands/Cache/CacheWarmCommandService.swift
@@ -14,7 +14,6 @@ import TuistLoader
 import TuistPlugin
 import TuistServer
 import TuistSupport
-import TuistXCActivityLog
 import TuistXcodeBuildProducts
 import XcodeGraph
 #if canImport(TuistCacheEE)
@@ -42,7 +41,6 @@ import XcodeGraph
         private let fileSystem: FileSysteming
         private let contentHasher: ContentHashing
         private let cacheGraphContentHasher: CacheGraphContentHashing
-        private let activityLogController: XCActivityLogControlling
 
         public init() {
             let contentHasher = ContentHasher()
@@ -55,8 +53,7 @@ import XcodeGraph
                 xcodeProjectBuildDirectoryLocator: XcodeProjectBuildDirectoryLocator(),
                 fileSystem: FileSystem(),
                 contentHasher: contentHasher,
-                cacheGraphContentHasher: CacheGraphContentHasher(contentHasher: contentHasher),
-                activityLogController: XCActivityLogController()
+                cacheGraphContentHasher: CacheGraphContentHasher(contentHasher: contentHasher)
             )
         }
 
@@ -69,8 +66,7 @@ import XcodeGraph
             xcodeProjectBuildDirectoryLocator: XcodeProjectBuildDirectoryLocating,
             fileSystem: FileSysteming,
             contentHasher: ContentHashing,
-            cacheGraphContentHasher: CacheGraphContentHashing,
-            activityLogController: XCActivityLogControlling
+            cacheGraphContentHasher: CacheGraphContentHashing
         ) {
             configLoader = ConfigLoader()
             manifestLoader = ManifestLoader.current
@@ -84,7 +80,6 @@ import XcodeGraph
             self.fileSystem = fileSystem
             self.contentHasher = contentHasher
             self.cacheGraphContentHasher = cacheGraphContentHasher
-            self.activityLogController = activityLogController
         }
 
         // swiftlint:disable:next function_body_length
@@ -230,10 +225,8 @@ import XcodeGraph
                 var artifactsToStore: [CacheGraphTargetBuiltArtifact] = []
 
                 let derivedDataPath = temporaryDirectory.appending(component: "derived-data")
-                let activityLogsDirectory = temporaryDirectory.appending(component: "activity-logs")
 
                 try await fileSystem.makeDirectory(at: derivedDataPath)
-                try await fileSystem.makeDirectory(at: activityLogsDirectory)
 
                 let xcodebuildTarget = XcodeBuildTarget(with: projectPath)
 
@@ -263,8 +256,6 @@ import XcodeGraph
                     )
                 }
 
-                try await moveActivityLogs(derivedDataPath: derivedDataPath, activityLogsDirectory: activityLogsDirectory)
-
                 for (scheme, _) in bundlesSchemes {
                     artifactsToStore.append(contentsOf: try await buildBundles(
                         scheme,
@@ -274,8 +265,6 @@ import XcodeGraph
                         cacheableTargets: hashesByTargetToBeCached
                     ))
                 }
-
-                try await moveActivityLogs(derivedDataPath: derivedDataPath, activityLogsDirectory: activityLogsDirectory)
 
                 for (scheme, _) in macroSchemes {
                     artifactsToStore.append(contentsOf: try await buildMacros(
@@ -287,8 +276,6 @@ import XcodeGraph
                         temporaryDirectory: temporaryDirectory
                     ))
                 }
-
-                try await moveActivityLogs(derivedDataPath: derivedDataPath, activityLogsDirectory: activityLogsDirectory)
 
                 Logger.current.info("Creating XCFrameworks", metadata: .section)
                 artifactsToStore.append(contentsOf: try await buildXCFrameworks(
@@ -305,11 +292,7 @@ import XcodeGraph
                 Logger.current.info("Storing binaries to speed up workflows", metadata: .section)
 
                 let successfullyStoredTargets = try await store(
-                    try await artifactsWithBuildTimes(
-                        artifacts: artifactsToStore,
-                        projectDerivedDataDirectory: derivedDataPath,
-                        activityLogsDirectory: activityLogsDirectory
-                    ),
+                    artifactsToStore,
                     cacheStorage: cacheStorage,
                     temporaryDirectory: temporaryDirectory
                 )
@@ -322,17 +305,6 @@ import XcodeGraph
                 } else {
                     Logger.current.info("\(successfullyStoredTargets.count) targets stored: \(targetsStored)")
                 }
-            }
-        }
-
-        /// xcodebuild invocations might delete old activity logs, so to prevent that from happening, we copy them into a
-        /// temporary
-        /// directory.
-        private func moveActivityLogs(derivedDataPath: AbsolutePath, activityLogsDirectory: AbsolutePath) async throws {
-            let activityLogs = try await fileSystem.glob(directory: derivedDataPath, include: ["Logs/Build/*.xcactivitylog"])
-                .collect()
-            for activityLog in activityLogs {
-                try await fileSystem.move(from: activityLog, to: activityLogsDirectory.appending(component: activityLog.basename))
             }
         }
 
@@ -793,31 +765,6 @@ import XcodeGraph
             )
         }
 
-        private func artifactsWithBuildTimes(
-            artifacts: [CacheGraphTargetBuiltArtifact],
-            projectDerivedDataDirectory _: AbsolutePath,
-            xcresultPaths _: [AbsolutePath] = [],
-            activityLogsDirectory: AbsolutePath
-        ) async throws -> [CacheGraphTargetBuiltArtifact] {
-            let activityLogs = try await fileSystem.glob(directory: activityLogsDirectory, include: ["*.xcactivitylog"]).collect()
-            let buildTimes = try await activityLogController
-                .buildTimesByTarget(activityLogPaths: activityLogs)
-            return artifacts.map { artifact in
-                if let buildTime = buildTimes[artifact.graphTarget.target.name] {
-                    var metadata = artifact.metadata
-                    metadata
-                        .buildTime = buildTime /
-                        1.5 // Divide by a factor to account for the additional time to build for multiple architectures or
-                    // destinations.
-                    var artifact = artifact
-                    artifact.metadata = metadata
-                    return artifact
-                } else {
-                    return artifact
-                }
-            }
-        }
-
         private func copyDerivedDataArtifacts(
             into: AbsolutePath,
             productsDirectory: AbsolutePath,
@@ -845,15 +792,14 @@ import XcodeGraph
             let storableTargets = Dictionary(
                 uniqueKeysWithValues: try await artifacts
                     .reduce(into: [CacheStorableTarget: [AbsolutePath]]()) { acc, next in
-                        acc[CacheStorableTarget(target: next.graphTarget, hash: next.hash, time: next.metadata.buildTime)] =
-                            [next.path]
+                        acc[CacheStorableTarget(target: next.graphTarget, hash: next.hash)] = [next.path]
                     }.concurrentMap { storableTarget, paths in
                         let metadataFilePath = temporaryDirectory.appending(
                             components: "Metadatas",
                             "\(storableTarget.name)-\(storableTarget.hash)",
                             "Metadata.plist"
                         )
-                        let metadata = CacheStorableItemMetadata(time: storableTarget.time)
+                        let metadata = CacheStorableItemMetadata()
                         try await fileSystem.makeDirectory(at: metadataFilePath.parentDirectory)
                         try await fileSystem.writeAsPlist(metadata, at: metadataFilePath)
                         var paths = paths

--- a/cli/Sources/TuistKit/Commands/TrackableCommand/CommandEventFactory.swift
+++ b/cli/Sources/TuistKit/Commands/TrackableCommand/CommandEventFactory.swift
@@ -92,7 +92,6 @@ public struct CommandEventFactory {
                         binaryCacheMetadata = RunCacheTargetMetadata(
                             hash: cacheItem.hash,
                             hit: hit,
-                            buildDuration: cacheItem.buildDuration,
                             subhashes: targetContentHashSubhashes[cacheItem.hash]
                         )
                     } else {

--- a/cli/Sources/TuistServer/CacheStoring.swift
+++ b/cli/Sources/TuistServer/CacheStoring.swift
@@ -8,13 +8,11 @@
     public struct CacheStorableTarget: Hashable, Equatable {
         public let target: GraphTarget
         public let hash: String
-        public let time: Double?
         public var name: String { target.target.name }
 
-        public init(target: GraphTarget, hash: String, time: Double? = nil) {
+        public init(target: GraphTarget, hash: String) {
             self.target = target
             self.hash = hash
-            self.time = time
         }
 
         public func hash(into hasher: inout Hasher) {
@@ -49,10 +47,7 @@
     }
 
     public struct CacheStorableItemMetadata: Hashable, Equatable, Codable {
-        public let time: Double?
-        public init(time: Double? = nil) {
-            self.time = time
-        }
+        public init() {}
     }
 
     @Mockable
@@ -96,8 +91,7 @@
                     (
                         CacheStorableItem(
                             name: target.name,
-                            hash: target.hash,
-                            metadata: CacheStorableItemMetadata(time: target.time)
+                            hash: target.hash
                         ),
                         paths
                     )

--- a/cli/Sources/TuistServer/Services/CreateCommandEventService.swift
+++ b/cli/Sources/TuistServer/Services/CreateCommandEventService.swift
@@ -148,7 +148,6 @@
                                             .miss
                                         }
                                         return .init(
-                                            build_duration: binaryCacheMetadata.buildDuration.map { Int($0) },
                                             hash: binaryCacheMetadata.hash,
                                             hit: hit,
                                             subhashes: binaryCacheMetadata.subhashes.map { subhashes in

--- a/cli/Sources/TuistXCActivityLog/XCActivityLogController.swift
+++ b/cli/Sources/TuistXCActivityLog/XCActivityLogController.swift
@@ -9,7 +9,6 @@ import TuistLogging
 import TuistRootDirectoryLocator
 import TuistSupport
 import XCActivityLogParser
-import XCLogParser
 
 enum XCActivityLogControllerError: LocalizedError, Equatable {
     case failedToParseActivityLog(path: AbsolutePath, reason: String)
@@ -33,11 +32,6 @@ public protocol XCActivityLogControlling {
         filter: @escaping (XCActivityLogFile) -> Bool
     )
         async throws -> XCActivityLogFile?
-    func buildTimesByTarget(projectDerivedDataDirectory: AbsolutePath) async throws -> [
-        String: Double
-    ]
-    func buildTimesByTarget(activityLogPaths: [AbsolutePath]) async throws
-        -> [String: Double]
     func parse(_ path: AbsolutePath) async throws -> XCActivityLog
 }
 
@@ -65,87 +59,6 @@ public struct XCActivityLogController: XCActivityLogControlling {
         self.fileSystem = fileSystem
         self.rootDirectoryLocator = rootDirectoryLocator
         self.gitController = gitController
-    }
-
-    public func buildTimesByTarget(projectDerivedDataDirectory: AbsolutePath) async throws
-        -> [String: Double]
-    {
-        let buildLogsPath = projectDerivedDataDirectory.appending(components: [
-            "Logs",
-            "Build",
-        ])
-        let logStoreManifestPlistPath = buildLogsPath.appending(components: [
-            "LogStoreManifest.plist",
-        ])
-        let logStoreManifest: XCLogStoreManifestPlist
-        do {
-            logStoreManifest = try await fileSystem.readPlistFile(
-                at: logStoreManifestPlistPath
-            )
-        } catch {
-            throw XCActivityLogControllerError.wrap(error, path: logStoreManifestPlistPath)
-        }
-
-        let activityLogPaths = logStoreManifest.logs.keys.map {
-            buildLogsPath.appending(components: ["\($0).xcactivitylog"])
-        }
-
-        return try await buildTimesByTarget(activityLogPaths: activityLogPaths)
-    }
-
-    public func buildTimesByTarget(activityLogPaths: [AbsolutePath]) async throws
-        -> [String: Double]
-    {
-        var buildTimes: [String: Double] = [:]
-        for activityLogPath in activityLogPaths {
-            let activityLog: IDEActivityLog
-            do {
-                activityLog = try XCLogParser.ActivityParser().parseActivityLogInURL(
-                    activityLogPath.url,
-                    redacted: false,
-                    withoutBuildSpecificInformation: false
-                )
-            } catch {
-                throw XCActivityLogControllerError.wrap(error, path: activityLogPath)
-            }
-            let buildStep: BuildStep
-            do {
-                buildStep = try XCLogParser.ParserBuildSteps(
-                    omitWarningsDetails: true,
-                    omitNotesDetails: true,
-                    truncLargeIssues: true
-                )
-                .parse(activityLog: activityLog)
-            } catch {
-                throw XCActivityLogControllerError.wrap(error, path: activityLogPath)
-            }
-
-            for (targetName, targetBuildDuration) in flattenedXCLogParserBuildStep([buildStep])
-                .filter({ $0.title.starts(with: "Build target") }).map({
-                    ($0.signature, $0.subSteps.reduce(into: 0) { duration, subStep in
-                        duration += subStep.compilationDuration * 1000 // From seconds to miliseconds
-                    })
-                })
-            {
-                // If a target supports multiple platforms, the time will persist is the time of the latest platform that we
-                // built.
-                buildTimes[targetName] = targetBuildDuration
-            }
-        }
-
-        return buildTimes
-    }
-
-    private func flattenedXCLogParserBuildStep(_ buildSteps: [XCLogParser.BuildStep])
-        -> [XCLogParser.BuildStep]
-    {
-        return buildSteps.flatMap { step in
-            var flattened = [step]
-            if !step.subSteps.isEmpty {
-                flattened.append(contentsOf: flattenedXCLogParserBuildStep(step.subSteps))
-            }
-            return flattened
-        }
     }
 
     public func mostRecentActivityLogFile(

--- a/cli/Tests/TuistServerTests/CacheStorableItemTests.swift
+++ b/cli/Tests/TuistServerTests/CacheStorableItemTests.swift
@@ -11,18 +11,15 @@ struct CacheStorableItemTests {
             [
                 CacheStorableItem(
                     name: "name_one",
-                    hash: "hash_one",
-                    metadata: CacheStorableItemMetadata(time: 100)
+                    hash: "hash_one"
                 ),
                 CacheStorableItem(
                     name: "name_one",
-                    hash: "hash_one",
-                    metadata: CacheStorableItemMetadata(time: 200)
+                    hash: "hash_one"
                 ),
                 CacheStorableItem(
                     name: "name_two",
-                    hash: "hash_one",
-                    metadata: CacheStorableItemMetadata(time: 100)
+                    hash: "hash_one"
                 ),
             ]
         )

--- a/cli/Tests/TuistXCActivityLogTests/XCActivityLog/XCActivityLogControllerTests.swift
+++ b/cli/Tests/TuistXCActivityLogTests/XCActivityLog/XCActivityLogControllerTests.swift
@@ -19,18 +19,6 @@ struct XCActivityLogControllerTests {
         )
     }
 
-    @Test func buildTimesByTarget() async throws {
-        // Given
-        let projectDerivedDataDirectory = try AbsolutePath(validating: #file).parentDirectory
-            .appending(try RelativePath(validating: "../../Fixtures/FrameworkDerivedDataWithActivityLog"))
-
-        // When
-        let got = try await subject.buildTimesByTarget(projectDerivedDataDirectory: projectDerivedDataDirectory)
-
-        // Then
-        #expect(got == ["Framework": 4.696011543273926])
-    }
-
     @Test func parseCleanBuildXCActivityLog() async throws {
         // Given
         let cleanBuildXCActivityLog = try AbsolutePath(validating: #file).parentDirectory


### PR DESCRIPTION
## What changed

- Removed the cache warm path that copied and parsed `.xcactivitylog` files to infer per-target build times.
- Removed target build duration from cache storable metadata, cache items, and command event binary cache metadata emitted by the CLI.
- Removed the now-unused `XCLogParser`-based target build-time parser and its test coverage.

## Why

The per-target cache build duration was collected only to annotate cache artifacts and command event metadata, but we do not currently surface that information in the product. Keeping the parser in the `tuist cache` path made cache warming depend on successfully parsing Xcode activity logs for metadata that was not used by users.

## Root cause

`tuist cache warm` parsed Xcode activity logs after each build group to estimate target build durations. When activity logs were missing, rotated, or unparseable, that optional metadata path could fail the cache command even though the artifacts themselves had been built successfully.

## Approach

This removes the CLI-side production of target build-time metadata instead of making parsing more permissive. Existing server/OpenAPI fields are left in place for backward compatibility with older clients, but the new CLI no longer sends `binary_cache_metadata.build_duration`.

## Impact

Cache warming no longer has to read or parse `.xcactivitylog` files for target timing. Binary artifacts are still built, packaged, uploaded, and tracked as before, just without the unused target duration value.

## Validation

- `tuist install`
- `tuist generate tuist TuistKit TuistKitTests TuistServer TuistServerTests TuistCore TuistCoreTests TuistXCActivityLog TuistXCActivityLogTests ProjectDescription --no-open`
- `xcodebuild test -workspace Tuist.xcworkspace -scheme Tuist-Workspace -only-testing TuistXCActivityLogTests/XCActivityLogControllerTests -only-testing TuistServerTests/CacheStorableItemTests -only-testing TuistKitTests/CommandEventFactoryTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" COMPILATION_CACHE_ENABLE_CACHING=NO`
- `git diff --check`
