### PR TITLE
fix(grafana-datasource): anchor cliff ignore_tags so the release tag isn't ignored

### DIFF
--- a/grafana-datasource/cliff.toml
+++ b/grafana-datasource/cliff.toml
@@ -73,6 +73,9 @@ protect_breaking_commits = false
 filter_commits = true
 tag_pattern = "grafana-datasource@[0-9].*"
 skip_tags = "beta|alpha"
-ignore_tags = "rc"
+# Match the release-candidate version suffix only. An unanchored "rc" also
+# matches the "rc" in "datasou(rc)e", so git-cliff ignored the
+# grafana-datasource@x.y.z tags and never bumped past the initial version.
+ignore_tags = "-rc"
 topo_order = false
 sort_commits = "newest"


### PR DESCRIPTION
## What

Changes the plugin's `git-cliff` `ignore_tags` from `"rc"` to `"-rc"`.

## Why (root cause)

After merging the Go 1.26.4 security fix ([#11283](https://github.com/tuist/tuist/pull/11283)), the auto-release **did not cut 0.1.1** — `release:check` reported `release? false` despite a `fix:` commit touching `grafana-datasource/**`.

The cause: `grafana-datasource/cliff.toml` had `ignore_tags = "rc"`, an **unanchored** regex copied from `infra/runners-controller`. The component's tags are `grafana-datasource@x.y.z`, and `grafana-datasou`**`rc`**`e` contains the substring "rc". git-cliff matched the tag against `ignore_tags` and discarded it, so `git cliff --bumped-version` had no base version and returned the initial `0.1.0` unchanged.

This was latent because every previous 0.1.0 release ran from a "no tag" state (the tag kept being deleted and re-cut during the catalog-submission iterations). The **first real bump** is what exposed it.

`-rc` matches only the release-candidate version suffix (e.g. `0.1.0-rc.1`), not the "rc" inside "datasource".

## Scope

Only `grafana-datasource` is affected — it's the sole release component in `mise/tasks/release/components.json` whose tag prefix contains an `rc`/`beta`/`alpha` substring. The other 15 cliff configs carry the same unanchored `ignore_tags = "rc"` but their names don't trip it, so they're left as-is.

## Validation

`mise run release:check grafana-datasource` now reports `next: grafana-datasource@0.1.1, release? true` (was `0.1.0 / false`).

## Effect

Merging this cuts the unsigned **0.1.1** (built from main, which already has the Go 1.26.4 binaries + provenance attestation from #11283) — the artifact to resubmit to the Grafana catalog review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)