### PR TITLE
chore(blick): update Kimi model

### DIFF
--- a/blick.toml
+++ b/blick.toml
@@ -1,6 +1,6 @@
 [agent]
 kind = "opencode"
-model = "fireworks-ai/accounts/fireworks/models/kimi-k2p5"
+model = "fireworks-ai/accounts/fireworks/models/kimi-k2p7-code"
 
 [defaults]
 base = "origin/main"


### PR DESCRIPTION
No linked issue.

> Updates blick to use Fireworks' Kimi K2.7 Code model instead of Kimi K2.5. This keeps the review agent on the latest Kimi coding model while preserving the existing Fireworks provider prefix used by blick.

### How to test locally

- `mise exec -- blick config`
