### PR TITLE
chore(server): trial kimi-k2p7-code for Blick reviews

### DIFF
--- a/blick.toml
+++ b/blick.toml
@@ -1,6 +1,6 @@
 [agent]
 kind = "opencode"
-model = "fireworks-ai/accounts/fireworks/models/kimi-k2p5"
+model = "fireworks-ai/accounts/fireworks/models/kimi-k2p7-code"
 
 [defaults]
 base = "origin/main"


### PR DESCRIPTION
## What

Bumps the Blick reviewer model in `blick.toml` from `kimi-k2p5` (Kimi K2.5) to `kimi-k2p7-code` (Kimi K2.7 Code) on Fireworks.

Verified Fireworks model path: `accounts/fireworks/models/kimi-k2p7-code`.

## Why

Blick runs as an agentic code reviewer through the `opencode` harness, so the workload is multi-turn tool use + coding comprehension on a per-PR cost budget. The Kimi K2 line is tuned for exactly that agentic-coding pattern, which is why it was chosen over a generalist like Mistral Medium (the latter's main draw is self-hosting, which we don't capture on Fireworks-hosted weights).

We were two versions behind. K2.7 Code is Moonshot's coding-specialized variant (built on K2.6), available day-0 on Fireworks. It reportedly uses ~30% fewer reasoning tokens than K2.6 at higher coding-benchmark scores. For a reviewer that fires on every `server/`, `cache/`, `noora/` PR, that translates fairly directly to lower cost-per-review at equal or better finding quality.

## Why this over the alternatives

- Mistral: lags the K2 line on agentic coding; its advantage (self-hosting) is irrelevant here. Not an upgrade for this job.
- Staying on K2.5 / moving to K2.6: K2.7 Code is the coding-tuned, cheaper-per-task option in the same family, so the upgrade path stays within Kimi rather than going sideways.

## Validation

This is a trial. Blick already uploads per-run artifacts under `.blick/runs/`, so we can diff finding quality against recent K2.5 runs on the next batch of PRs and revert the one-line change if quality regresses.