### PR TITLE
fix(docs): Improve Docker Compose readiness checks

### DIFF
--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.8'
 services:
   db:
     image: postgres:16
@@ -27,7 +26,8 @@ services:
     environment:
       PGWEB_DATABASE_URL: postgres://postgres:postgres@db:5432/postgres?sslmode=disable
     depends_on:
-      - db
+      db:
+        condition: service_healthy
 
   tuist:
     build:
@@ -35,7 +35,8 @@ services:
       dockerfile: Dockerfile
     container_name: tuist
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     ports:
       - "80:80"
       - "8080:8080"

--- a/server/priv/static/server/self-host/docker-compose.yml
+++ b/server/priv/static/server/self-host/docker-compose.yml
@@ -58,7 +58,11 @@ services:
       - ./clickhouse-config.xml:/etc/clickhouse-server/config.d/tuist.xml:ro
       - clickhouse-data:/var/lib/clickhouse
     healthcheck:
-      test: ["CMD-SHELL", "wget --spider --quiet http://127.0.0.1:8123/ping"]
+      test:
+        [
+          "CMD-SHELL",
+          "wget --quiet --output-document=- --user \"$$CLICKHOUSE_USER\" --password \"$$CLICKHOUSE_PASSWORD\" \"http://127.0.0.1:8123/?database=$$CLICKHOUSE_DB&query=SELECT%201\" | grep -q '^1$'",
+        ]
       interval: 5s
       timeout: 5s
       retries: 30


### PR DESCRIPTION
## What changed

- Removed the obsolete `version` marker from `server/docker-compose.yml`.
- Updated the local server compose file so `pgweb` and `tuist` wait for Postgres to become healthy before starting.
- Strengthened the self-host ClickHouse healthcheck to run an authenticated HTTP `SELECT 1` against the configured database instead of only checking `/ping`.

## Why

The compose files already define healthchecks, but one path still used short-form `depends_on`, which only waits for container startup. That can start dependent services while Postgres is still initializing.

For ClickHouse, `/ping` proves that the HTTP server is alive, but it does not prove that the database and credentials Tuist uses are ready. The new check covers the same authenticated database path that Tuist depends on at boot.

## Impact

Local and self-hosted startup should be less prone to transient boot failures when databases take longer to initialize. There is no application code or schema change.

## Validation

- `docker compose -f server/docker-compose.yml config --quiet`
- `docker compose -f server/priv/static/server/self-host/docker-compose.yml config --quiet` with `.env.example` copied to a temporary `.env`
- Started a temporary `clickhouse/clickhouse-server:25.8` container and verified the new healthcheck command passed against the actual image
- `git diff --check`
