### PR TITLE
feat(cli): Support library products in the module cache

### DIFF
--- a/cli/Sources/TuistCache/AGENTS.md
+++ b/cli/Sources/TuistCache/AGENTS.md
@@ -11,7 +11,7 @@ This module handles CLI integration with the cache service and cache features.
 - Cache service: `cache/AGENTS.md`
 
 ## Invariants
-- Only cacheable products are hashed (frameworks, static frameworks, bundles, macros).
-- Test bundles are excluded from binary cache hashing, but test-support frameworks that link XCTest or Swift Testing can be hashed.
+- Only cacheable products are hashed (frameworks, static frameworks, static libraries, dynamic libraries, bundles, macros).
+- Test bundles are excluded from binary cache hashing, but test-support frameworks and libraries that link XCTest or Swift Testing can be hashed.
 - Explicit cache warm target selection scopes transitive cache candidates from non-test roots only.
 - Cache version bumps invalidate incompatible artifacts.

--- a/cli/Sources/TuistCache/CacheGraphContentHasher.swift
+++ b/cli/Sources/TuistCache/CacheGraphContentHasher.swift
@@ -24,7 +24,14 @@ public struct CacheGraphContentHasher: CacheGraphContentHashing {
     private let graphContentHasher: GraphContentHashing
     private let contentHasher: ContentHashing
     private let versionFetcher: CacheVersionFetching
-    private static let cachableProducts: Set<Product> = [.framework, .staticFramework, .bundle, .macro]
+    private static let cachableProducts: Set<Product> = [
+        .framework,
+        .staticFramework,
+        .staticLibrary,
+        .dynamicLibrary,
+        .bundle,
+        .macro,
+    ]
     private let defaultConfigurationFetcher: DefaultConfigurationFetching
     private let fileSystem: FileSysteming
 

--- a/cli/Sources/TuistCore/Graph/GraphTraverser.swift
+++ b/cli/Sources/TuistCore/Graph/GraphTraverser.swift
@@ -841,14 +841,24 @@ public class GraphTraverser: GraphTraversing {
     public func librariesPublicHeadersFolders(path: Path.AbsolutePath, name: String) -> Set<
         Path.AbsolutePath
     > {
-        let dependencies = graph.dependencies[.target(name: name, path: path), default: []]
+        let targetDependency = GraphDependency.target(name: name, path: path)
+        let dependencies = graph.dependencies[targetDependency, default: []]
+            .union(filterDependencies(from: targetDependency))
         let libraryPublicHeaders = dependencies.compactMap { dependency -> Path.AbsolutePath? in
             guard case let GraphDependency.library(_, publicHeaders, _, _, _) = dependency else {
                 return nil
             }
             return publicHeaders
         }
-        return Set(libraryPublicHeaders)
+        let xcframeworkLibraryPublicHeaders = dependencies.flatMap { dependency -> [Path.AbsolutePath] in
+            guard case let GraphDependency.xcframework(xcframework) = dependency else { return [] }
+            return xcframework.infoPlist.libraries.compactMap { library in
+                guard let headersPath = library.headersPath else { return nil }
+                return try? AbsolutePath(validating: library.identifier, relativeTo: xcframework.path)
+                    .appending(headersPath)
+            }
+        }
+        return Set(libraryPublicHeaders + xcframeworkLibraryPublicHeaders)
     }
 
     public func librariesSearchPaths(path: Path.AbsolutePath, name: String) throws -> Set<
@@ -888,14 +898,35 @@ public class GraphTraverser: GraphTraversing {
     public func librariesSwiftIncludePaths(path: Path.AbsolutePath, name: String) -> Set<
         Path.AbsolutePath
     > {
-        let dependencies = graph.dependencies[.target(name: name, path: path), default: []]
+        let targetDependency = GraphDependency.target(name: name, path: path)
+        let dependencies = graph.dependencies[targetDependency, default: []]
+            .union(filterDependencies(from: targetDependency))
         let librarySwiftModuleMapPaths = dependencies.compactMap {
             dependency -> Path.AbsolutePath? in
             guard case let GraphDependency.library(_, _, _, _, swiftModuleMapPath) = dependency
             else { return nil }
             return swiftModuleMapPath
         }
-        return Set(librarySwiftModuleMapPaths.compactMap { $0.removingLastComponent() })
+        let xcframeworkLibrarySwiftModulePaths = dependencies.flatMap {
+            dependency -> [Path.AbsolutePath] in
+            guard case let GraphDependency.xcframework(xcframework) = dependency,
+                  xcframework.infoPlist.libraries.contains(where: {
+                      ["a", "dylib"].contains($0.path.extension)
+                  })
+            else { return [] }
+
+            return xcframework.swiftModules.map { swiftModulePath in
+                if swiftModulePath.parentDirectory.extension == "swiftmodule" {
+                    return swiftModulePath.parentDirectory.parentDirectory
+                } else {
+                    return swiftModulePath.parentDirectory
+                }
+            }
+        }
+        return Set(
+            librarySwiftModuleMapPaths.map { $0.removingLastComponent() }
+                + xcframeworkLibrarySwiftModulePaths
+        )
     }
 
     public func runPathSearchPaths(path: Path.AbsolutePath, name: String) -> Set<Path.AbsolutePath> {

--- a/cli/Sources/TuistKit/Commands/Cache/CacheWarmCommandService.swift
+++ b/cli/Sources/TuistKit/Commands/Cache/CacheWarmCommandService.swift
@@ -496,14 +496,24 @@ import XcodeGraph
             temporaryDirectory: AbsolutePath
         ) async throws -> [CacheGraphTargetBuiltArtifact] {
             var xcframeworks: [CacheGraphTargetBuiltArtifact] = []
-            let cacheableTargets = cacheableTargets.filter { $0.0.target.product.isFramework && !$0.0.target.isAggregate }
+            let cacheableTargets = cacheableTargets.filter {
+                $0.0.target.isXCFrameworkCacheableProduct && !$0.0.target.isAggregate
+            }
 
             for cacheableTarget in cacheableTargets {
                 let platforms = Array(cacheableTarget.0.target.supportedPlatforms)
                 let platformBinaryArtifacts = platforms.flatMap { Array(binaryArtifactDirectories[$0, default: Set()]) }
                 let artifactsIncludingTarget = try await platformBinaryArtifacts.concurrentCompactMap {
-                    let artifactPath = $0.appending(components: [cacheableTarget.0.target.productNameWithExtension])
-                    return try await fileSystem.exists(artifactPath) ? artifactPath : nil
+                    artifactDirectory -> (artifactPath: AbsolutePath, publicHeadersPath: AbsolutePath?)? in
+                    let artifactPath = artifactDirectory.appending(
+                        components: [cacheableTarget.0.target.productNameWithExtension]
+                    )
+                    guard try await fileSystem.exists(artifactPath) else { return nil }
+                    let publicHeadersPath = try await libraryPublicHeadersPath(
+                        for: cacheableTarget.0.target,
+                        artifactDirectory: artifactDirectory
+                    )
+                    return (artifactPath: artifactPath, publicHeadersPath: publicHeadersPath)
                 }
 
                 let xcframeworkPath = temporaryDirectory.appending(components: [
@@ -512,8 +522,19 @@ import XcodeGraph
                 ])
 
                 let xcodebuildArguments: [String] = artifactsIncludingTarget
-                    .flatMap { artifactPath in
-                        ["-framework", artifactPath.pathString]
+                    .flatMap { artifactPath -> [String] in
+                        switch cacheableTarget.0.target.product {
+                        case .framework, .staticFramework:
+                            return ["-framework", artifactPath.artifactPath.pathString]
+                        case .staticLibrary, .dynamicLibrary:
+                            var arguments = ["-library", artifactPath.artifactPath.pathString]
+                            if let publicHeadersPath = artifactPath.publicHeadersPath {
+                                arguments.append(contentsOf: ["-headers", publicHeadersPath.pathString])
+                            }
+                            return arguments
+                        default:
+                            return []
+                        }
                     } + ["-allow-internal-distribution"]
 
                 Logger.current.info("Creating XCFramework for \(cacheableTarget.0.target.name)", metadata: .section)
@@ -562,6 +583,27 @@ import XcodeGraph
             }
 
             return xcframeworks
+        }
+
+        private func libraryPublicHeadersPath(
+            for target: Target,
+            artifactDirectory: AbsolutePath
+        ) async throws -> AbsolutePath? {
+            guard [.staticLibrary, .dynamicLibrary].contains(target.product),
+                  let publicHeaders = target.headers?.public,
+                  !publicHeaders.isEmpty
+            else { return nil }
+
+            let builtHeadersPath = artifactDirectory.appending(components: "usr", "local", "include")
+            if try await fileSystem.exists(builtHeadersPath, isDirectory: true) {
+                return builtHeadersPath
+            }
+
+            return publicHeaders
+                .map(\.parentDirectory)
+                .reduce(publicHeaders[0].parentDirectory) { commonAncestor, headerDirectory in
+                    commonAncestor.commonAncestor(with: headerDirectory)
+                }
         }
 
         private func collectForeignBuildArtifacts(
@@ -947,6 +989,19 @@ import XcodeGraph
             return cacheableTargets.compactMap {
                 existingTargetHashes.contains($0.hash) ? nil : ($0.target, $0.hash)
             }
+        }
+    }
+#endif
+
+#if canImport(TuistCacheEE)
+    extension Target {
+        fileprivate var isXCFrameworkCacheableProduct: Bool {
+            [
+                .framework,
+                .staticFramework,
+                .staticLibrary,
+                .dynamicLibrary,
+            ].contains(product)
         }
     }
 #endif

--- a/cli/Sources/XcodeGraph/Sources/XcodeGraph/Models/XCFrameworkInfoPlist.swift
+++ b/cli/Sources/XcodeGraph/Sources/XcodeGraph/Models/XCFrameworkInfoPlist.swift
@@ -25,6 +25,7 @@ public struct XCFrameworkInfoPlist: Codable, Hashable, Equatable, Sendable {
         private enum CodingKeys: String, CodingKey {
             case identifier = "LibraryIdentifier"
             case path = "LibraryPath"
+            case headersPath = "HeadersPath"
             case platform = "SupportedPlatform"
             case platformVariant = "SupportedPlatformVariant"
             case architectures = "SupportedArchitectures"
@@ -42,6 +43,9 @@ public struct XCFrameworkInfoPlist: Codable, Hashable, Equatable, Sendable {
         /// Path to the library.
         public let path: RelativePath
 
+        /// Path to the library headers.
+        public let headersPath: RelativePath?
+
         /// Declares if the library is mergeable or not
         public let mergeable: Bool
 
@@ -57,6 +61,7 @@ public struct XCFrameworkInfoPlist: Codable, Hashable, Equatable, Sendable {
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(identifier, forKey: .identifier)
             try container.encode(path, forKey: .path)
+            try container.encodeIfPresent(headersPath, forKey: .headersPath)
             try container.encode(mergeable, forKey: .mergeable)
             try container.encode(architectures, forKey: .architectures)
             try container.encode(platform, forKey: .platform)
@@ -66,6 +71,7 @@ public struct XCFrameworkInfoPlist: Codable, Hashable, Equatable, Sendable {
         public init(
             identifier: String,
             path: RelativePath,
+            headersPath: RelativePath? = nil,
             mergeable: Bool,
             platform: Platform,
             platformVariant: PlatformVariant? = nil,
@@ -73,6 +79,7 @@ public struct XCFrameworkInfoPlist: Codable, Hashable, Equatable, Sendable {
         ) {
             self.identifier = identifier
             self.path = path
+            self.headersPath = headersPath
             self.mergeable = mergeable
             self.platform = platform
             self.platformVariant = platformVariant
@@ -83,6 +90,7 @@ public struct XCFrameworkInfoPlist: Codable, Hashable, Equatable, Sendable {
             let container = try decoder.container(keyedBy: CodingKeys.self)
             identifier = try container.decode(String.self, forKey: .identifier)
             path = try container.decode(RelativePath.self, forKey: .path)
+            headersPath = try container.decodeIfPresent(RelativePath.self, forKey: .headersPath)
             platform = try container.decode(Platform.self, forKey: .platform)
             platformVariant = try container.decodeIfPresent(PlatformVariant.self, forKey: .platformVariant)
             architectures = try container.decode([BinaryArchitecture].self, forKey: .architectures)
@@ -94,6 +102,7 @@ public struct XCFrameworkInfoPlist: Codable, Hashable, Equatable, Sendable {
                 identifier: String = "test",
                 // swiftlint:disable:next force_try
                 path: RelativePath = try! RelativePath(validating: "relative/to/library"),
+                headersPath: RelativePath? = nil,
                 mergeable: Bool = false,
                 platform: Platform = .iOS,
                 platformVariant: PlatformVariant? = nil,
@@ -102,6 +111,7 @@ public struct XCFrameworkInfoPlist: Codable, Hashable, Equatable, Sendable {
                 XCFrameworkInfoPlist.Library(
                     identifier: identifier,
                     path: path,
+                    headersPath: headersPath,
                     mergeable: mergeable,
                     platform: platform,
                     platformVariant: platformVariant,

--- a/cli/Tests/TuistCacheEEAcceptanceTests/TuistCacheEEAcceptanceTests.swift
+++ b/cli/Tests/TuistCacheEEAcceptanceTests/TuistCacheEEAcceptanceTests.swift
@@ -261,6 +261,65 @@ struct TuistCacheEEAcceptanceTests {
     }
 
     @Test(
+        .inTemporaryDirectory,
+        .withMockedEnvironment(inheritingVariables: ["PATH"]),
+        .withMockedNoora,
+        .withMockedLogger(forwardLogs: true),
+        .withFixture("generated_macos_tool_with_cached_libraries_and_frameworks")
+    ) func generated_macos_tool_with_cached_libraries_and_frameworks() async throws {
+        let fixtureDirectory = try #require(TuistTest.fixtureDirectory)
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let mockedEnvironment = try #require(Environment.mocked)
+        let fileSystem = FileSystem()
+        let xcodeprojPath = fixtureDirectory.appending(component: "CachedLibrariesAndFrameworks.xcodeproj")
+
+        try await TuistTest.run(
+            CacheCommand.self,
+            ["--path", fixtureDirectory.pathString]
+        )
+
+        for target in [
+            "CoreCLibrary",
+            "CoreStaticLibrary",
+            "DiagnosticsDynamicLibrary",
+            "FeatureStaticLibrary",
+            "FeatureFramework",
+            "ModelsStaticFramework",
+            "NetworkingFramework",
+        ] {
+            let cachedArtifacts = try await fileSystem.glob(
+                directory: mockedEnvironment.cacheDirectory,
+                include: ["**/\(target).xcframework"]
+            ).collect()
+            #expect(!cachedArtifacts.isEmpty, "\(target) should be stored as an xcframework")
+        }
+
+        try await TuistTest.run(
+            GenerateCommand.self,
+            ["--no-open", "--path", fixtureDirectory.pathString, "Tool"]
+        )
+
+        try TuistAcceptanceTest.expectXCFrameworkLinked("FeatureFramework", by: "Tool", xcodeprojPath: xcodeprojPath)
+        try TuistAcceptanceTest.expectXCFrameworkLinked("DiagnosticsDynamicLibrary", by: "Tool", xcodeprojPath: xcodeprojPath)
+        try TuistAcceptanceTest.expectXCFrameworkLinked("CoreCLibrary", by: "Tool", xcodeprojPath: xcodeprojPath)
+
+        try await TuistTest.run(
+            XcodeBuildBuildCommand.self,
+            [
+                "-project",
+                xcodeprojPath.pathString,
+                "-scheme",
+                "Tool",
+                "-derivedDataPath",
+                temporaryDirectory.pathString,
+                "CODE_SIGN_IDENTITY=",
+                "CODE_SIGNING_REQUIRED=NO",
+                "CODE_SIGNING_ALLOWED=NO",
+            ]
+        )
+    }
+
+    @Test(
         .disabled("Requires SPM install"),
         .inTemporaryDirectory,
         .withMockedEnvironment(inheritingVariables: ["PATH"]),

--- a/cli/Tests/TuistCacheEETests/Generator/GenerateCacheableSchemesGraphMapperTests.swift
+++ b/cli/Tests/TuistCacheEETests/Generator/GenerateCacheableSchemesGraphMapperTests.swift
@@ -15,19 +15,21 @@ final class GenerateCacheableSchemesGraphMapperTests: TuistUnitTestCase {
         let targetA = Target.test(name: "A", destinations: [.iPhone], product: .framework)
         let targetB = Target.test(name: "B", destinations: [.iPhone], product: .app)
         let targetC = Target.test(name: "C", destinations: [.mac], product: .framework)
+        let staticLibrary = Target.test(name: "StaticLibrary", destinations: [.iPhone], product: .staticLibrary)
+        let dynamicLibrary = Target.test(name: "DynamicLibrary", destinations: [.mac], product: .dynamicLibrary)
         let bundle = Target.test(name: "Bundle", destinations: [.appleTv], product: .bundle)
         let macro = Target.test(name: "Macro", destinations: [.appleTv], product: .macro)
 
-        let includedTargets = [targetA, targetC, bundle, macro].map(\.name)
+        let includedTargets = [targetA, staticLibrary, targetC, dynamicLibrary, bundle, macro].map(\.name)
         let subject = GenerateCacheableSchemesGraphMapper(targets: [
-            .iOS: Set([.named(targetA.name)]),
-            .macOS: Set([.named(targetC.name)]),
+            .iOS: Set([.named(targetA.name), .named(staticLibrary.name)]),
+            .macOS: Set([.named(targetC.name), .named(dynamicLibrary.name)]),
             .tvOS: Set([.named(bundle.name), .named(macro.name)]),
         ])
         let projectAPath = directory.appending(component: "ProjectA")
         let projectBPath = directory.appending(component: "ProjectB")
-        let projectA = Project.test(path: projectAPath, name: "A", targets: [targetA, bundle, macro])
-        let projectB = Project.test(path: projectBPath, name: "B", targets: [targetB, targetC])
+        let projectA = Project.test(path: projectAPath, name: "A", targets: [targetA, staticLibrary, bundle, macro])
+        let projectB = Project.test(path: projectBPath, name: "B", targets: [targetB, targetC, dynamicLibrary])
 
         let graph = Graph.test(
             workspace: Workspace.test(projects: [projectAPath, projectBPath]),
@@ -68,6 +70,7 @@ final class GenerateCacheableSchemesGraphMapperTests: TuistUnitTestCase {
                 .map(\.name),
             [
                 "A",
+                "StaticLibrary",
             ]
         )
         XCTAssertEqual(
@@ -76,6 +79,7 @@ final class GenerateCacheableSchemesGraphMapperTests: TuistUnitTestCase {
                 .map(\.name),
             [
                 "C",
+                "DynamicLibrary",
             ]
         )
         XCTAssertEqual(

--- a/cli/Tests/TuistCacheEETests/Generator/TargetsToCacheBinariesGraphMapperTests.swift
+++ b/cli/Tests/TuistCacheEETests/Generator/TargetsToCacheBinariesGraphMapperTests.swift
@@ -250,6 +250,89 @@ final class TargetsToCacheBinariesGraphMapperTests: TuistUnitTestCase {
         )
     }
 
+    func test_map_when_library_binaries_are_fetched_successfully() async throws {
+        let path = try temporaryPath()
+
+        // Given
+        let staticLibrary = Target.test(name: "StaticLibrary", platform: .iOS, product: .staticLibrary)
+        let dynamicLibrary = Target.test(name: "DynamicLibrary", platform: .iOS, product: .dynamicLibrary)
+        let app = Target.test(name: "App", platform: .iOS, product: .app)
+        let project = Project.test(path: path, targets: [app, staticLibrary, dynamicLibrary])
+        let staticLibraryGraphTarget = GraphTarget(
+            path: path,
+            target: project.targets["StaticLibrary"]!,
+            project: project
+        )
+        let dynamicLibraryGraphTarget = GraphTarget(
+            path: path,
+            target: project.targets["DynamicLibrary"]!,
+            project: project
+        )
+        let staticLibraryHash = "StaticLibrary"
+        let dynamicLibraryHash = "DynamicLibrary"
+        let staticLibraryXCFrameworkPath = path.appending(component: "StaticLibrary.xcframework")
+        let dynamicLibraryXCFrameworkPath = path.appending(component: "DynamicLibrary.xcframework")
+        let inputGraph = Graph.test(
+            name: "input",
+            projects: [path: project],
+            dependencies: [
+                .target(name: app.name, path: path): [
+                    .target(name: staticLibrary.name, path: path),
+                    .target(name: dynamicLibrary.name, path: path),
+                ],
+            ]
+        )
+        let outputGraph = Graph.test(
+            name: "output",
+            projects: inputGraph.projects,
+            dependencies: inputGraph.dependencies
+        )
+
+        given(cacheGraphContentHasher)
+            .contentHashes(
+                for: .any,
+                configuration: .any,
+                defaultConfiguration: .any,
+                excludedTargets: .any,
+                destination: .any
+            )
+            .willReturn([
+                staticLibraryGraphTarget: .test(hash: staticLibraryHash),
+                dynamicLibraryGraphTarget: .test(hash: dynamicLibraryHash),
+            ])
+        given(cacheStorage).fetch(
+            .value(
+                Set([
+                    CacheStorableItem(name: "StaticLibrary", hash: staticLibraryHash),
+                    CacheStorableItem(name: "DynamicLibrary", hash: dynamicLibraryHash),
+                ])
+            ),
+            cacheCategory: .value(.binaries)
+        ).willReturn([
+            .test(name: "StaticLibrary", hash: staticLibraryHash): staticLibraryXCFrameworkPath,
+            .test(name: "DynamicLibrary", hash: dynamicLibraryHash): dynamicLibraryXCFrameworkPath,
+        ])
+        given(cacheGraphMutator)
+            .map(
+                graph: .value(inputGraph),
+                precompiledArtifacts: .value([
+                    staticLibraryGraphTarget: staticLibraryXCFrameworkPath,
+                    dynamicLibraryGraphTarget: dynamicLibraryXCFrameworkPath,
+                ]),
+                sources: .any,
+                keepSourceTargets: .value(
+                    config.project.generatedProject?.cacheOptions.keepSourceTargets ?? false
+                )
+            )
+            .willReturn(outputGraph)
+
+        // When
+        let (got, _, _) = try await subject.map(graph: inputGraph, environment: MapperEnvironment())
+
+        // Then
+        XCTAssertEqual(got, outputGraph)
+    }
+
     func test_map_hashes_preserved_sources_graph_and_scopes_hashes_to_current_graph() async throws {
         let path = try temporaryPath()
 

--- a/cli/Tests/TuistCacheTests/CacheGraphContentHasherIntegrationTests.swift
+++ b/cli/Tests/TuistCacheTests/CacheGraphContentHasherIntegrationTests.swift
@@ -232,6 +232,58 @@ struct ContentHashingIntegrationTests {
         .inTemporaryDirectory,
         .withMockedSwiftVersionProvider,
         .withMockedXcodeController
+    ) func contentHashes_librariesAreComputed() async throws {
+        // Given
+        let temporaryPath = try #require(FileSystem.temporaryTestDirectory)
+        let staticLibraryTarget = makeLibrary(
+            name: "StaticLibrary",
+            product: .staticLibrary,
+            sources: [source1]
+        )
+        let dynamicLibraryTarget = makeLibrary(
+            name: "DynamicLibrary",
+            product: .dynamicLibrary,
+            sources: [source2]
+        )
+        let project = Project.test(
+            path: temporaryPath.appending(component: "Project"),
+            settings: .default,
+            targets: [staticLibraryTarget, dynamicLibraryTarget]
+        )
+        let staticLibrary = GraphTarget(
+            path: project.path,
+            target: project.targets["StaticLibrary"]!,
+            project: project
+        )
+        let dynamicLibrary = GraphTarget(
+            path: project.path,
+            target: project.targets["DynamicLibrary"]!,
+            project: project
+        )
+        let graph = Graph.test(
+            projects: [
+                project.path: project,
+            ]
+        )
+
+        // When
+        let contentHash = try await subject.contentHashes(
+            for: graph,
+            configuration: "Debug",
+            defaultConfiguration: nil,
+            excludedTargets: [],
+            destination: nil
+        )
+
+        // Then
+        #expect(contentHash[staticLibrary] != nil)
+        #expect(contentHash[dynamicLibrary] != nil)
+    }
+
+    @Test(
+        .inTemporaryDirectory,
+        .withMockedSwiftVersionProvider,
+        .withMockedXcodeController
     ) func contentHashes_hashIsConsistent() async throws {
         // Given
         let temporaryPath = try #require(FileSystem.temporaryTestDirectory)
@@ -636,6 +688,18 @@ struct ContentHashingIntegrationTests {
             coreDataModels: coreDataModels,
             scripts: targetScripts,
             dependencies: dependencies
+        )
+    }
+
+    private func makeLibrary(
+        name: String,
+        product: Product,
+        sources: [SourceFile] = []
+    ) -> Target {
+        .test(
+            name: name,
+            product: product,
+            sources: sources
         )
     }
 }

--- a/cli/Tests/TuistCacheTests/CacheGraphContentHasherTests.swift
+++ b/cli/Tests/TuistCacheTests/CacheGraphContentHasherTests.swift
@@ -369,4 +369,67 @@ struct CacheGraphContentHasherTests {
             )
             .called(1)
     }
+
+    @Test(
+        .withMockedSwiftVersionProvider
+    ) func contentHashes_when_targets_are_libraries_hashes_are_computed() async throws {
+        // Given
+        let staticLibrary = Target.test(name: "StaticLibrary", product: .staticLibrary)
+        let dynamicLibrary = Target.test(name: "DynamicLibrary", product: .dynamicLibrary)
+        let project = Project.test(
+            path: "/Project/Path",
+            targets: [staticLibrary, dynamicLibrary]
+        )
+        let staticLibraryTarget = GraphTarget(
+            path: project.path,
+            target: project.targets["StaticLibrary"]!,
+            project: project
+        )
+        let dynamicLibraryTarget = GraphTarget(
+            path: project.path,
+            target: project.targets["DynamicLibrary"]!,
+            project: project
+        )
+        let graph = Graph.test(
+            path: project.path,
+            projects: [
+                project.path: project,
+            ]
+        )
+
+        given(graphContentHasher)
+            .contentHashes(
+                for: .any,
+                include: .any,
+                destination: .any,
+                additionalStrings: .any
+            )
+            .willReturn([:])
+        given(defaultConfigurationFetcher)
+            .fetch(configuration: .any, defaultConfiguration: .any, graph: .any)
+            .willReturn("Debug")
+        let swiftVersionProviderMock = try #require(SwiftVersionProvider.mocked)
+        given(swiftVersionProviderMock).swiftlangVersion().willReturn("5.10.0")
+
+        // When
+        _ = try await subject.contentHashes(
+            for: graph,
+            configuration: "Debug",
+            defaultConfiguration: nil,
+            excludedTargets: [],
+            destination: nil
+        )
+
+        // Then
+        verify(graphContentHasher)
+            .contentHashes(
+                for: .any,
+                include: .matching { filter in
+                    filter(staticLibraryTarget) && filter(dynamicLibraryTarget)
+                },
+                destination: .any,
+                additionalStrings: .any
+            )
+            .called(1)
+    }
 }

--- a/cli/Tests/TuistCoreTests/Graph/GraphTraverserTests.swift
+++ b/cli/Tests/TuistCoreTests/Graph/GraphTraverserTests.swift
@@ -1862,6 +1862,58 @@ final class GraphTraverserTests: TuistUnitTestCase {
         XCTAssertEqual(got.first, publicHeadersPath)
     }
 
+    func test_librariesPublicHeadersFolders_includesLibraryXCFrameworkHeaders() throws {
+        // Given
+        let target = Target.test(name: "Main")
+        let project = Project.test(targets: [target])
+        let dynamicLibraryPath = try AbsolutePath(validating: "/cache/DynamicLibrary.xcframework")
+        let staticLibraryPath = try AbsolutePath(validating: "/cache/StaticLibrary.xcframework")
+        let dynamicLibrary = GraphDependency.testXCFramework(
+            path: dynamicLibraryPath,
+            infoPlist: .test(libraries: [
+                .test(
+                    identifier: "macos-arm64_x86_64",
+                    path: try RelativePath(validating: "libDynamicLibrary.dylib"),
+                    headersPath: try RelativePath(validating: "Headers"),
+                    platform: .macOS,
+                    architectures: [.arm64, .x8664]
+                ),
+            ]),
+            linking: .dynamic
+        )
+        let staticLibrary = GraphDependency.testXCFramework(
+            path: staticLibraryPath,
+            infoPlist: .test(libraries: [
+                .test(
+                    identifier: "macos-arm64_x86_64",
+                    path: try RelativePath(validating: "libStaticLibrary.a"),
+                    headersPath: try RelativePath(validating: "Headers"),
+                    platform: .macOS,
+                    architectures: [.arm64, .x8664]
+                ),
+            ]),
+            linking: .static
+        )
+        let graph = Graph.test(
+            projects: [project.path: project],
+            dependencies: [
+                .target(name: target.name, path: project.path): Set([dynamicLibrary]),
+                dynamicLibrary: Set([staticLibrary]),
+                staticLibrary: Set([]),
+            ]
+        )
+        let subject = GraphTraverser(graph: graph)
+
+        // When
+        let got = subject.librariesPublicHeadersFolders(path: project.path, name: target.name).sorted()
+
+        // Then
+        XCTAssertEqual(got, [
+            dynamicLibraryPath.appending(components: "macos-arm64_x86_64", "Headers"),
+            staticLibraryPath.appending(components: "macos-arm64_x86_64", "Headers"),
+        ])
+    }
+
     func test_librariesSearchPaths() throws {
         // Given
         let target = Target.test(name: "Main")
@@ -3936,6 +3988,94 @@ final class GraphTraverserTests: TuistUnitTestCase {
 
         // Then
         XCTAssertEqual(got, try [AbsolutePath(validating: "/test/modules")])
+    }
+
+    func test_librariesSwiftIncludePaths_includesLibraryXCFrameworkSwiftModules() throws {
+        // Given
+        let target = Target.test(name: "Main")
+        let project = Project.test(targets: [target])
+        let dynamicLibraryPath = try AbsolutePath(validating: "/cache/DynamicLibrary.xcframework")
+        let staticLibraryPath = try AbsolutePath(validating: "/cache/StaticLibrary.xcframework")
+        let frameworkPath = try AbsolutePath(validating: "/cache/Framework.xcframework")
+        let dynamicLibraryModulePath = dynamicLibraryPath.appending(
+            components: "macos-arm64_x86_64",
+            "DynamicLibrary.swiftmodule"
+        )
+        let staticLibraryModulePath = staticLibraryPath.appending(
+            components: "macos-arm64_x86_64",
+            "StaticLibrary.swiftmodule"
+        )
+        let dynamicLibrary = GraphDependency.testXCFramework(
+            path: dynamicLibraryPath,
+            infoPlist: .test(libraries: [
+                .test(
+                    identifier: "macos-arm64_x86_64",
+                    path: try RelativePath(validating: "libDynamicLibrary.dylib"),
+                    platform: .macOS,
+                    architectures: [.arm64, .x8664]
+                ),
+            ]),
+            linking: .dynamic,
+            swiftModules: [
+                dynamicLibraryModulePath,
+                dynamicLibraryModulePath.appending(component: "arm64-apple-macos.swiftmodule"),
+            ]
+        )
+        let staticLibrary = GraphDependency.testXCFramework(
+            path: staticLibraryPath,
+            infoPlist: .test(libraries: [
+                .test(
+                    identifier: "macos-arm64_x86_64",
+                    path: try RelativePath(validating: "libStaticLibrary.a"),
+                    platform: .macOS,
+                    architectures: [.arm64, .x8664]
+                ),
+            ]),
+            linking: .static,
+            swiftModules: [
+                staticLibraryModulePath,
+                staticLibraryModulePath.appending(component: "arm64-apple-macos.swiftmodule"),
+            ]
+        )
+        let framework = GraphDependency.testXCFramework(
+            path: frameworkPath,
+            infoPlist: .test(libraries: [
+                .test(
+                    identifier: "macos-arm64_x86_64",
+                    path: try RelativePath(validating: "Framework.framework"),
+                    platform: .macOS,
+                    architectures: [.arm64, .x8664]
+                ),
+            ]),
+            linking: .dynamic,
+            swiftModules: [
+                frameworkPath.appending(
+                    components: "macos-arm64_x86_64",
+                    "Framework.framework",
+                    "Modules",
+                    "Framework.swiftmodule"
+                ),
+            ]
+        )
+        let graph = Graph.test(
+            projects: [project.path: project],
+            dependencies: [
+                .target(name: target.name, path: project.path): Set([dynamicLibrary, framework]),
+                dynamicLibrary: Set([staticLibrary]),
+                staticLibrary: Set([]),
+                framework: Set([]),
+            ]
+        )
+        let subject = GraphTraverser(graph: graph)
+
+        // When
+        let got = subject.librariesSwiftIncludePaths(path: project.path, name: target.name).sorted()
+
+        // Then
+        XCTAssertEqual(got, [
+            dynamicLibraryPath.appending(component: "macos-arm64_x86_64"),
+            staticLibraryPath.appending(component: "macos-arm64_x86_64"),
+        ])
     }
 
     func test_runPathSearchPaths() throws {

--- a/examples/xcode/generated_macos_tool_with_cached_libraries_and_frameworks/CoreCLibrary/Sources/CoreCLibrary.c
+++ b/examples/xcode/generated_macos_tool_with_cached_libraries_and_frameworks/CoreCLibrary/Sources/CoreCLibrary.c
@@ -1,0 +1,5 @@
+#include "CoreCLibrary.h"
+
+const char *CoreCLibraryMessage(void) {
+    return "core-c";
+}

--- a/examples/xcode/generated_macos_tool_with_cached_libraries_and_frameworks/CoreCLibrary/Sources/CoreCLibrary.h
+++ b/examples/xcode/generated_macos_tool_with_cached_libraries_and_frameworks/CoreCLibrary/Sources/CoreCLibrary.h
@@ -1,0 +1,6 @@
+#ifndef CORE_C_LIBRARY_H
+#define CORE_C_LIBRARY_H
+
+const char *CoreCLibraryMessage(void);
+
+#endif

--- a/examples/xcode/generated_macos_tool_with_cached_libraries_and_frameworks/CoreStaticLibrary/Sources/CoreStaticLibrary.swift
+++ b/examples/xcode/generated_macos_tool_with_cached_libraries_and_frameworks/CoreStaticLibrary/Sources/CoreStaticLibrary.swift
@@ -1,0 +1,3 @@
+public enum CoreStaticLibrary {
+    public static let message = "core"
+}

--- a/examples/xcode/generated_macos_tool_with_cached_libraries_and_frameworks/DiagnosticsDynamicLibrary/Sources/DiagnosticsDynamicLibrary.swift
+++ b/examples/xcode/generated_macos_tool_with_cached_libraries_and_frameworks/DiagnosticsDynamicLibrary/Sources/DiagnosticsDynamicLibrary.swift
@@ -1,0 +1,5 @@
+public enum DiagnosticsDynamicLibrary {
+    public static func decorate(_ value: String) -> String {
+        "\(value):diagnostics"
+    }
+}

--- a/examples/xcode/generated_macos_tool_with_cached_libraries_and_frameworks/FeatureFramework/Sources/FeatureFramework.swift
+++ b/examples/xcode/generated_macos_tool_with_cached_libraries_and_frameworks/FeatureFramework/Sources/FeatureFramework.swift
@@ -1,0 +1,6 @@
+import FeatureStaticLibrary
+import NetworkingFramework
+
+public enum FeatureFramework {
+    public static let message = "\(FeatureStaticLibrary.message):\(NetworkingFramework.message):feature-framework"
+}

--- a/examples/xcode/generated_macos_tool_with_cached_libraries_and_frameworks/FeatureStaticLibrary/Sources/FeatureStaticLibrary.swift
+++ b/examples/xcode/generated_macos_tool_with_cached_libraries_and_frameworks/FeatureStaticLibrary/Sources/FeatureStaticLibrary.swift
@@ -1,0 +1,5 @@
+import CoreStaticLibrary
+
+public enum FeatureStaticLibrary {
+    public static let message = "\(CoreStaticLibrary.message):feature-static"
+}

--- a/examples/xcode/generated_macos_tool_with_cached_libraries_and_frameworks/ModelsStaticFramework/Sources/ModelsStaticFramework.swift
+++ b/examples/xcode/generated_macos_tool_with_cached_libraries_and_frameworks/ModelsStaticFramework/Sources/ModelsStaticFramework.swift
@@ -1,0 +1,5 @@
+import CoreStaticLibrary
+
+public enum ModelsStaticFramework {
+    public static let message = "\(CoreStaticLibrary.message):models"
+}

--- a/examples/xcode/generated_macos_tool_with_cached_libraries_and_frameworks/NetworkingFramework/Sources/NetworkingFramework.swift
+++ b/examples/xcode/generated_macos_tool_with_cached_libraries_and_frameworks/NetworkingFramework/Sources/NetworkingFramework.swift
@@ -1,0 +1,5 @@
+import ModelsStaticFramework
+
+public enum NetworkingFramework {
+    public static let message = "\(ModelsStaticFramework.message):networking"
+}

--- a/examples/xcode/generated_macos_tool_with_cached_libraries_and_frameworks/Project.swift
+++ b/examples/xcode/generated_macos_tool_with_cached_libraries_and_frameworks/Project.swift
@@ -1,0 +1,94 @@
+import ProjectDescription
+
+let project = Project(
+    name: "CachedLibrariesAndFrameworks",
+    organizationName: "tuist.dev",
+    settings: .settings(base: [
+        "SWIFT_ENABLE_EXPLICIT_MODULES": false,
+    ]),
+    targets: [
+        .target(
+            name: "Tool",
+            destinations: .macOS,
+            product: .commandLineTool,
+            bundleId: "io.tuist.CachedLibrariesAndFrameworks.Tool",
+            infoPlist: .default,
+            sources: ["Tool/Sources/**"],
+            dependencies: [
+                .target(name: "FeatureFramework"),
+                .target(name: "DiagnosticsDynamicLibrary"),
+                .target(name: "CoreCLibrary"),
+            ]
+        ),
+        .target(
+            name: "FeatureFramework",
+            destinations: .macOS,
+            product: .framework,
+            bundleId: "io.tuist.CachedLibrariesAndFrameworks.FeatureFramework",
+            infoPlist: .default,
+            sources: ["FeatureFramework/Sources/**"],
+            dependencies: [
+                .target(name: "FeatureStaticLibrary"),
+                .target(name: "NetworkingFramework"),
+            ]
+        ),
+        .target(
+            name: "NetworkingFramework",
+            destinations: .macOS,
+            product: .framework,
+            bundleId: "io.tuist.CachedLibrariesAndFrameworks.NetworkingFramework",
+            infoPlist: .default,
+            sources: ["NetworkingFramework/Sources/**"],
+            dependencies: [
+                .target(name: "ModelsStaticFramework"),
+            ]
+        ),
+        .target(
+            name: "ModelsStaticFramework",
+            destinations: .macOS,
+            product: .staticFramework,
+            bundleId: "io.tuist.CachedLibrariesAndFrameworks.ModelsStaticFramework",
+            infoPlist: .default,
+            sources: ["ModelsStaticFramework/Sources/**"],
+            dependencies: [
+                .target(name: "CoreStaticLibrary"),
+            ]
+        ),
+        .target(
+            name: "FeatureStaticLibrary",
+            destinations: .macOS,
+            product: .staticLibrary,
+            bundleId: "io.tuist.CachedLibrariesAndFrameworks.FeatureStaticLibrary",
+            infoPlist: nil,
+            sources: ["FeatureStaticLibrary/Sources/**"],
+            dependencies: [
+                .target(name: "CoreStaticLibrary"),
+            ]
+        ),
+        .target(
+            name: "DiagnosticsDynamicLibrary",
+            destinations: .macOS,
+            product: .dynamicLibrary,
+            bundleId: "io.tuist.CachedLibrariesAndFrameworks.DiagnosticsDynamicLibrary",
+            infoPlist: .default,
+            sources: ["DiagnosticsDynamicLibrary/Sources/**"]
+        ),
+        .target(
+            name: "CoreStaticLibrary",
+            destinations: .macOS,
+            product: .staticLibrary,
+            bundleId: "io.tuist.CachedLibrariesAndFrameworks.CoreStaticLibrary",
+            infoPlist: nil,
+            sources: ["CoreStaticLibrary/Sources/**"]
+        ),
+        .target(
+            name: "CoreCLibrary",
+            destinations: .macOS,
+            product: .staticLibrary,
+            bundleId: "io.tuist.CachedLibrariesAndFrameworks.CoreCLibrary",
+            infoPlist: nil,
+            sources: ["CoreCLibrary/Sources/**"],
+            headers: .headers(public: "CoreCLibrary/Sources/**/*.h")
+        ),
+    ]
+)

--- a/examples/xcode/generated_macos_tool_with_cached_libraries_and_frameworks/Tool/Sources/header_smoke.m
+++ b/examples/xcode/generated_macos_tool_with_cached_libraries_and_frameworks/Tool/Sources/header_smoke.m
@@ -1,0 +1,5 @@
+#include "CoreCLibrary.h"
+
+const char *ToolHeaderSmoke(void) {
+    return CoreCLibraryMessage();
+}

--- a/examples/xcode/generated_macos_tool_with_cached_libraries_and_frameworks/Tool/Sources/main.swift
+++ b/examples/xcode/generated_macos_tool_with_cached_libraries_and_frameworks/Tool/Sources/main.swift
@@ -1,0 +1,4 @@
+import DiagnosticsDynamicLibrary
+import FeatureFramework
+
+print(DiagnosticsDynamicLibrary.decorate(FeatureFramework.message))

--- a/examples/xcode/generated_macos_tool_with_cached_libraries_and_frameworks/Tuist.swift
+++ b/examples/xcode/generated_macos_tool_with_cached_libraries_and_frameworks/Tuist.swift
@@ -1,0 +1,3 @@
+import ProjectDescription
+
+let tuist = Tuist()

--- a/server/priv/docs/en/guides/features/cache/module-cache.md
+++ b/server/priv/docs/en/guides/features/cache/module-cache.md
@@ -118,10 +118,13 @@ Precedence when resolving the effective behavior (highest to lowest):
 Only the following target products are cacheable by Tuist:
 
 - Frameworks (static and dynamic), including test-support frameworks that depend on [XCTest](https://developer.apple.com/documentation/xctest) or Swift Testing
+- Libraries (static and dynamic), including test-support libraries that depend on XCTest or Swift Testing
 - Bundles
 - Swift Macros
 
-Test bundles remain excluded from the module cache. This means `unitTests` and `uiTests` targets are not cached as binaries, but regular framework targets that tests depend on can be cached even when they link XCTest or Swift Testing.
+Test bundles remain excluded from the module cache. This means `unitTests` and `uiTests` targets are not cached as binaries, but regular framework and library targets that tests depend on can be cached even when they link XCTest or Swift Testing.
+
+Cached library `.xcframework`s preserve the metadata needed by generated projects to import them, including Swift modules and public C/Objective-C headers when the source target declares public headers.
 
 > [!NOTE]
 > **Upstream Dependencies**

--- a/server/priv/marketing/changelog/2026.06.15-module-cache-library-products.md
+++ b/server/priv/marketing/changelog/2026.06.15-module-cache-library-products.md
@@ -1,0 +1,9 @@
+---
+title: Module Cache support for library products
+description: "Cache static and dynamic library targets as XCFramework artifacts with modules and headers."
+category: "Product"
+---
+
+Module Cache can now cache static and dynamic library targets, not only framework targets. Library products are warmed, stored, and consumed as XCFramework artifacts, including Swift modules and public headers, so projects with mixed framework and library graphs can reuse binary cache artifacts across local and CI builds.
+
+Test bundles remain excluded from the binary cache, but reusable library targets that support tests can now benefit from the same cache flow as test-support frameworks.


### PR DESCRIPTION
Adds Module Cache support for static and dynamic library products, building on the XCTest and Swift Testing support framework cache work from #11281.

## Related PRs

- Companion TuistCacheEE PR: https://github.com/tuist/TuistCacheEE/pull/65
- Builds on XCTest and Swift Testing support framework caching: https://github.com/tuist/tuist/pull/11281

## What changed

- Static and dynamic library targets are now treated as cacheable binary products in hashing, EE binary target selection, and warm generation.
- Cache warm now creates library XCFrameworks with `xcodebuild -create-xcframework -library`, and passes `-headers` when the source target declares public headers.
- XCFramework `Info.plist` decoding now preserves `HeadersPath`, and graph traversal exposes cached library Swift module directories and public header directories to generated targets.
- Added a complex acceptance fixture that combines static libraries, dynamic libraries, static frameworks, dynamic frameworks, Swift imports, and a public C header smoke build.
- Updated the Module Cache guide and changelog to document library support, including Swift modules and public C/Objective-C headers.

## Why it changed

`.xcframework` artifacts support both frameworks and libraries, but the module cache flow only selected framework products for binary caching. That meant projects using static or dynamic library targets still had to rebuild those modules from source, even when their graph could otherwise be restored from cached binaries.

The missing piece was not just selecting libraries. Generated projects also need the metadata required to compile against a cached library artifact. Swift libraries need their `.swiftmodule` directories in the include paths, and C/Objective-C libraries need public headers from the XCFramework slice.

## Root cause

The cacheable product lists and EE binary scheme selection were framework-centric. The warm step always emitted `-framework` arguments when creating XCFrameworks, so library products were never produced as cache artifacts. On restore, graph traversal only propagated public headers and Swift include paths for direct `.library` dependencies, not for library-based `.xcframework` dependencies.

## Solution rationale

The implementation uses Xcode's native XCFramework library support instead of introducing a custom artifact format or wrapping libraries as frameworks. For library products, cache warm now emits `-library` arguments and includes `-headers` when public headers exist. On restore, Tuist reads the standard `HeadersPath` metadata that Xcode writes into XCFramework `Info.plist` files and maps it back into header search paths.

This keeps the artifact format aligned with Xcode, preserves the existing framework cache behavior, and lets mixed framework/library graphs use the same binary cache pipeline.

## User and developer impact

Projects with static or dynamic library targets can now reuse module cache binaries across local and CI builds. Mixed graphs can cache reusable library modules without forcing those modules to become frameworks. Test bundles remain excluded from binary caching, but framework and library targets that tests depend on can be cached.

## How to test locally

- `TUIST_EE=1 TUIST_ENABLE_CACHING=1 tuist install --path .`
- `TUIST_EE=1 TUIST_ENABLE_CACHING=1 tuist generate run --no-open --cache-profile none --path . tuist ProjectDescription TuistCoreTests TuistCacheTests TuistCacheEETests TuistCacheEEAcceptanceTests`
- `TUIST_EE=1 TUIST_ENABLE_CACHING=1 tuist generate run --no-open --cache-profile none --path . tuist ProjectDescription TuistCacheEETests`
- `xcodebuild test -workspace Tuist.xcworkspace -scheme TuistUnitTests '-only-testing:TuistCoreTests/GraphTraverserTests/test_librariesPublicHeadersFolders_includesLibraryXCFrameworkHeaders' '-only-testing:TuistCoreTests/GraphTraverserTests/test_librariesSwiftIncludePaths_includesLibraryXCFrameworkSwiftModules' CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""`
- `xcodebuild test -workspace Tuist.xcworkspace -scheme TuistUnitTests '-only-testing:TuistCacheEETests/GenerateCacheableSchemesGraphMapperTests/test_map_when_cacheable_schemes_are_generated' '-only-testing:TuistCacheEETests/TargetsToCacheBinariesGraphMapperTests/test_map_when_library_binaries_are_fetched_successfully' CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""`
- `xcodebuild test -workspace Tuist.xcworkspace -scheme TuistCacheEEAcceptanceTests '-only-testing:TuistCacheEEAcceptanceTests/TuistCacheEEAcceptanceTests/generated_macos_tool_with_cached_libraries_and_frameworks()' CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""`
- `git diff --check`
