### PR TITLE
fix(cli): require truthy SwifterPM flag

### DIFF
--- a/cli/Sources/TuistSupport/SwiftPackageManager/SwiftPackageManagerController.swift
+++ b/cli/Sources/TuistSupport/SwiftPackageManager/SwiftPackageManagerController.swift
@@ -274,7 +274,7 @@ public struct SwiftPackageManagerController: SwiftPackageManagerControlling {
     }
 
     private var swifterPMIsEnabled: Bool {
-        environmentVariables()[Constants.EnvironmentVariables.useSwifterPM] != nil
+        Environment(variables: environmentVariables()).isVariableTruthy(Constants.EnvironmentVariables.useSwifterPM)
     }
 
     private func swifterPMRequest(

--- a/cli/Tests/TuistSupportTests/SwiftPackageManager/SwiftPackageManagerControllerTests.swift
+++ b/cli/Tests/TuistSupportTests/SwiftPackageManager/SwiftPackageManagerControllerTests.swift
@@ -127,6 +127,35 @@ final class SwiftPackageManagerControllerTests: TuistUnitTestCase {
         XCTAssertEqual(request.scmToRegistryTransformation, .replaceSCMWithRegistry)
     }
 
+    func test_resolve_when_swifterpm_is_not_truthy_usesSwiftPackageManager() async throws {
+        // Given
+        let path = try temporaryPath()
+        subject = SwiftPackageManagerController(
+            fileSystem: fileSystem,
+            commandRunner: { self.mockCommandRunner },
+            swifterPM: swifterPM,
+            environmentVariables: { ["TUIST_USE_SWIFTERPM": "0"] }
+        )
+        mockCommandRunner.succeedCommand([
+            "swift",
+            "package",
+            "--package-path",
+            path.pathString,
+            "--replace-scm-with-registry",
+            "resolve",
+        ])
+
+        // When
+        try await subject.resolve(
+            at: path,
+            arguments: ["--replace-scm-with-registry"],
+            printOutput: false
+        )
+
+        // Then
+        XCTAssertTrue(swifterPM.resolveRequests.isEmpty)
+    }
+
     func test_resolve_when_swifterpm_is_enabled_and_packagePathArgument_is_passed_usesIt() async throws {
         // Given
         let path = try temporaryPath()


### PR DESCRIPTION
## Summary
- Require `TUIST_USE_SWIFTERPM` to use the shared truthy environment-variable check instead of enabling SwifterPM by mere presence.
- Preserve existing truthy values like `1`, `true`, `TRUE`, `yes`, and `YES` through `Environment.isVariableTruthy`.
- Add a regression test proving `TUIST_USE_SWIFTERPM=0` falls back to the standard `swift package` path.

## Testing
- `tuist install`
- `tuist generate tuist TuistSupport TuistSupportTests ProjectDescription --no-open`
- `xcodebuild test -workspace Tuist.xcworkspace -scheme Tuist-Workspace -only-testing TuistSupportTests/SwiftPackageManagerControllerTests/test_resolve_when_swifterpm_is_not_truthy_usesSwiftPackageManager CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""`
- `mise run cli:lint --fix`
