### PR TITLE
fix(infra): unblock tuist-ops deploy + alert Slack on its failure

### DIFF
--- a/.github/workflows/notify-failure.yml
+++ b/.github/workflows/notify-failure.yml
@@ -27,6 +27,7 @@ on:
       - Server Deployment
       - Server Kura Regional Deployment
       - Server Production Deployment
+      - Tuist Ops Deployment
       - Xcode Processor
       - Xcode Processor Deploy
     branches: [main]

--- a/infra/helm/tuist-ops/values.yaml
+++ b/infra/helm/tuist-ops/values.yaml
@@ -50,7 +50,13 @@ postgresql:
   owner: tuist_ops
   image:
     repository: ghcr.io/cloudnative-pg/postgresql
-    tag: "16.6"
+    # Pinned to the live cluster's image. #11224 bumped this to 16.6 AND
+    # added max_connections in one change, but CNPG's webhook rejects
+    # changing the image and parameters in the same apply — which is why
+    # tuist-ops hasn't deployed since 2026-06-11. Apply the parameters
+    # first (image unchanged = config-only change); the 16.6 bump lands in
+    # a follow-up once this is live (image-only change, also allowed).
+    tag: "16.4"
   parameters:
     max_connections: "40"
   resources:


### PR DESCRIPTION
## What changed

Two things, both about tuist-ops deploy reliability.

### 1. Unblock the tuist-ops deploy (CNPG)

The tuist-ops deploy has failed on **every push since 2026-06-11** — including the operator project-access merge (#11212), which left that cutover half-applied (server + Pomerium deployed, tuist-ops not, so `ops.tuist.dev/grants` 404s and two Ingresses briefly claim the host).

Root cause: #11224 bumped the CNPG Postgres image `16.4` → `16.6` **and** added `max_connections: 40` in one change. CNPG's admission webhook forbids that:

```
Cluster "tuist-ops-pg" is invalid: spec.imageName: Can't change image name
and configuration at the same time. {"max_connections":["","40"]}
```

The live cluster is still `16.4` + default `max_connections` (the last successful deploy, #10988). The chart wants `16.6` + `40`, i.e. both at once → rejected → rollback → no deploy.

**Fix:** split it. Pin the image back to the live `16.4` and keep `max_connections: 40`. The image is then unchanged vs the running cluster, so CNPG sees a **config-only** change and accepts it. That deploys the app (the operator-grant tuist-ops, which also drops its own `ops.tuist.dev` Ingress now that Pomerium fronts the host) and applies the connection cap #11224 wanted.

**Follow-up (separate PR, once this is live):** bump the image `16.4` → `16.6` on its own — an image-only change, which CNPG also allows.

### 2. Slack alert on tuist-ops deploy failure

This silent failure went unnoticed for four days. Added `Tuist Ops Deployment` to `notify-failure.yml`'s `workflow_run` watch list, exactly like the server deploy, so the next one pings Slack.

## Validation

`helm template` renders the CNPG `Cluster` with `imageName: …16.4` + `parameters.max_connections: "40"` (image unchanged vs live → config-only). `notify-failure.yml` is valid YAML with the new entry.

## Watch on deploy

The CNPG no-op-image inference is from the deploy error (live = 16.4 + default). Worst case if that's stale: the deploy fails again like today — but now the Slack alert fires, which is the other half of this PR. Worth a glance at the tuist-ops deploy run once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)