### PR TITLE
fix(infra): scope xcresult image release to server/lib/tuist

### DIFF
--- a/mise/tasks/release/components.json
+++ b/mise/tasks/release/components.json
@@ -123,7 +123,7 @@
       "initial_version": "0.1.0",
       "include_paths": [
         "infra/xcresult-processor-image/**/*",
-        "server/lib/**/*",
+        "server/lib/tuist/**/*",
         "server/native/xcresult_nif/**/*",
         "server/mix.exs",
         "server/mix.lock"


### PR DESCRIPTION
## What changed

Narrowed the `xcresult-processor-image` release gate in `mise/tasks/release/components.json` from `server/lib/**/*` to `server/lib/tuist/**/*`.

## Why

The xcresult-processor image bakes a full `mix release` of the server and boots it with `TUIST_MODE=xcresult_processor`. In that mode the app starts the whole supervision tree but runs only the `:process_xcresult` Oban queue — it never serves the Phoenix endpoint. So `server/lib/tuist_web/**` (controllers, LiveViews, marketing site) is dead code for this artifact, yet it was triggering a fresh image release on every web-layer commit.

This surfaced on [#11272](https://github.com/tuist/tuist/pull/11272): a `feat(infra)` commit (HA stable-egress gateway) that also reverted a `server/lib/tuist/license.ex` hotfix, which dragged the xcresult image build along. That particular case still triggers correctly under the new glob (it's under `tuist/`), but it prompted the audit — and the real waste is web-only commits.

## Why not narrower

The processor is thin at the entrypoint (one ~190-line worker) but its dependency closure is the whole business layer. The worker's one-hop reach already spans ~35 core modules — `Accounts`, `Tests`, `Storage`, `VCS`, `Processor`, `Repo`, `CommandEvents`, `Billing`, `Projects`, ClickHouse ingest, etc. — and the transitive closure is essentially all of `server/lib/tuist/`. A hand-curated subset would be incorrect today and would rot the moment the worker gains a call (it only recently picked up `VCS`). Worse, the failure mode of an over-narrow glob is silent: the image would keep shipping stale server code against a migrated DB.

`tuist_web` is the one boundary that is both meaningful and stable: the processor provably never enters it. So that's where the cut stops.

## Impact

- Web-only changes (`server/lib/tuist_web/**`) no longer cut a new xcresult image — roughly 38% of recent `server/lib`-touching commits on main (23 of ~60 over the last 200 commits were web-only).
- Every change that can affect the processor at runtime — business logic, schemas, storage, VCS, the NIF, `mix.exs`/`mix.lock` — still triggers a release.
- Saves ~10 min of CI (server release build + Packer Tart image) per skipped run.

## Validation

- `jq empty` confirms the JSON is still valid.
- `mise run release:check xcresult-processor-image` reproduces the old behavior on the #11272 commit (release? true → 0.23.0, because the license revert is under `tuist/`), confirming business-layer changes still trigger.
- Manual `git log` over the last 200 commits confirms the web-only commits that would now be skipped never touch `server/lib/tuist/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)