### PR TITLE
fix(server): clear Trivy npm dependency vulnerabilities

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -16,15 +16,17 @@
       "axios": "1.16.0",
       "mdast-util-to-hast": "13.2.1",
       "ajv": "8.18.0",
-      "dompurify": "3.4.0",
+      "dompurify": "3.4.10",
       "fast-uri": "3.1.2",
       "flatted": "3.4.2",
       "yaml": "2.8.3",
       "defu": "6.1.5",
       "follow-redirects": "1.16.0",
-      "protobufjs": "7.5.8",
+      "protobufjs": "7.6.4",
       "postcss": "8.5.10",
-      "shell-quote": "1.8.4"
+      "shell-quote": "1.8.4",
+      "form-data": "4.0.6",
+      "@opentelemetry/core": "2.8.0"
     },
     "allowBuilds": {
       "core-js": true,

--- a/server/pnpm-lock.yaml
+++ b/server/pnpm-lock.yaml
@@ -5,26 +5,33 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  '@opentelemetry/core': 2.8.0
   ajv: 8.18.0
   axios: 1.16.0
   defu: 6.1.5
-  dompurify: 3.4.0
+  dompurify: 3.4.10
   fast-uri: 3.1.2
   flatted: 3.4.2
   follow-redirects: 1.16.0
+  form-data: 4.0.6
   mdast-util-to-hast: 13.2.1
   postcss: 8.5.10
-  protobufjs: 7.5.8
+  protobufjs: 7.6.4
   shell-quote: 1.8.4
   yaml: 2.8.3
 
 time:
+  '@opentelemetry/core@2.8.0': 2026-06-11T12:36:40.276Z
   '@protobufjs/codegen@2.0.5': 2026-04-27T20:30:11.789Z
-  '@protobufjs/inquire@1.1.1': 2026-04-27T20:32:10.012Z
+  '@protobufjs/eventemitter@1.1.1': 2026-05-22T02:33:03.279Z
+  '@protobufjs/fetch@1.1.1': 2026-05-17T12:41:02.731Z
   '@protobufjs/utf8@1.1.1': 2026-04-27T20:31:28.490Z
   axios@1.16.0: 2026-05-02T15:04:00.274Z
+  dompurify@3.4.10: 2026-06-12T12:49:46.101Z
   fast-uri@3.1.2: 2026-05-05T08:31:31.849Z
-  protobufjs@7.5.8: 2026-05-12T09:40:11.300Z
+  form-data@4.0.6: 2026-06-12T17:37:53.689Z
+  hasown@2.0.4: 2026-05-28T18:11:39.940Z
+  protobufjs@7.6.4: 2026-06-12T12:10:59.442Z
   shell-quote@1.8.4: 2026-05-22T13:13:48.633Z
 
 importers:
@@ -205,14 +212,8 @@ packages:
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
     engines: {node: '>=8.0.0'}
 
-  '@opentelemetry/core@2.2.0':
-    resolution: {integrity: sha512-FuabnnUm8LflnieVxs6eP7Z383hgQU4W1e3KJS6aOG3RxWxcHyBxH8fDMHNgu/gFx/M2jvTOW/4/PHhLz6bjWw==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': '>=1.0.0 <1.10.0'
-
-  '@opentelemetry/core@2.6.1':
-    resolution: {integrity: sha512-8xHSGWpJP9wBxgBpnqGL0R3PbdWQndL1Qp50qrg71+B28zK5OQmUgcDKLJgzyAAV38t4tOyLMGDD60LneR5W8g==}
+  '@opentelemetry/core@2.8.0':
+    resolution: {integrity: sha512-hd1Lfh8p545nNz+jq1Ejfz+Mn1hyLuxYn1YzTfFNrxr8urEWMNQLPf1Th8kjOH+HxwawCrtgBp8JpBUR4ZSgww==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
@@ -287,20 +288,14 @@ packages:
   '@protobufjs/codegen@2.0.5':
     resolution: {integrity: sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==}
 
-  '@protobufjs/eventemitter@1.1.0':
-    resolution: {integrity: sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==}
+  '@protobufjs/eventemitter@1.1.1':
+    resolution: {integrity: sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==}
 
-  '@protobufjs/fetch@1.1.0':
-    resolution: {integrity: sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==}
+  '@protobufjs/fetch@1.1.1':
+    resolution: {integrity: sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==}
 
   '@protobufjs/float@1.0.2':
     resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
-
-  '@protobufjs/inquire@1.1.0':
-    resolution: {integrity: sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==}
-
-  '@protobufjs/inquire@1.1.1':
-    resolution: {integrity: sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==}
 
   '@protobufjs/path@1.1.2':
     resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
@@ -707,8 +702,8 @@ packages:
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
-  dompurify@3.4.0:
-    resolution: {integrity: sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==}
+  dompurify@3.4.10:
+    resolution: {integrity: sha512-0xzNv0e7oYC6yyuOGZIABPM4qtg3QxLFniDNPP4ZP90wR8Yq3zgwpRbrNiT4N3IKqDbbYFEJLV+JWEs19aZ//w==}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -779,8 +774,8 @@ packages:
       debug:
         optional: true
 
-  form-data@4.0.5:
-    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+  form-data@4.0.6:
+    resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
     engines: {node: '>= 6'}
 
   function-bind@1.1.2:
@@ -827,6 +822,10 @@ packages:
 
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
   hast-util-embedded@3.0.0:
@@ -1225,8 +1224,8 @@ packages:
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
 
-  protobufjs@7.5.8:
-    resolution: {integrity: sha512-dvpCIeLPbXZS/Ete7yLaO7RenOdken2NHKykBXbsaGxZT0UTltcarBciw+A78SRQs9iMAAVpsYA+l8b1hTePIA==}
+  protobufjs@7.6.4:
+    resolution: {integrity: sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==}
     engines: {node: '>=12.0.0'}
 
   proxy-from-env@2.1.0:
@@ -1737,12 +1736,7 @@ snapshots:
 
   '@opentelemetry/api@1.9.0': {}
 
-  '@opentelemetry/core@2.2.0(@opentelemetry/api@1.9.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/semantic-conventions': 1.40.0
-
-  '@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.0)':
+  '@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/semantic-conventions': 1.40.0
@@ -1751,7 +1745,7 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/api-logs': 0.208.0
-      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/otlp-exporter-base': 0.208.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/otlp-transformer': 0.208.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-logs': 0.208.0(@opentelemetry/api@1.9.0)
@@ -1759,49 +1753,49 @@ snapshots:
   '@opentelemetry/otlp-exporter-base@0.208.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/otlp-transformer': 0.208.0(@opentelemetry/api@1.9.0)
 
   '@opentelemetry/otlp-transformer@0.208.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/api-logs': 0.208.0
-      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-logs': 0.208.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-metrics': 2.2.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-base': 2.2.0(@opentelemetry/api@1.9.0)
-      protobufjs: 7.5.8
+      protobufjs: 7.6.4
 
   '@opentelemetry/resources@2.2.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.40.0
 
   '@opentelemetry/resources@2.6.1(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.40.0
 
   '@opentelemetry/sdk-logs@0.208.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/api-logs': 0.208.0
-      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.0)
 
   '@opentelemetry/sdk-metrics@2.2.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.0)
 
   '@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.40.0
 
@@ -1821,18 +1815,13 @@ snapshots:
 
   '@protobufjs/codegen@2.0.5': {}
 
-  '@protobufjs/eventemitter@1.1.0': {}
+  '@protobufjs/eventemitter@1.1.1': {}
 
-  '@protobufjs/fetch@1.1.0':
+  '@protobufjs/fetch@1.1.1':
     dependencies:
       '@protobufjs/aspromise': 1.1.2
-      '@protobufjs/inquire': 1.1.0
 
   '@protobufjs/float@1.0.2': {}
-
-  '@protobufjs/inquire@1.1.0': {}
-
-  '@protobufjs/inquire@1.1.1': {}
 
   '@protobufjs/path@1.1.2': {}
 
@@ -2376,7 +2365,7 @@ snapshots:
   axios@1.16.0:
     dependencies:
       follow-redirects: 1.16.0(debug@4.4.1)
-      form-data: 4.0.5
+      form-data: 4.0.6
       proxy-from-env: 2.1.0
 
   bail@2.0.2: {}
@@ -2452,7 +2441,7 @@ snapshots:
     dependencies:
       dequal: 2.0.3
 
-  dompurify@3.4.0:
+  dompurify@3.4.10:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -2510,12 +2499,12 @@ snapshots:
     dependencies:
       debug: 4.4.1
 
-  form-data@4.0.5:
+  form-data@4.0.6:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       es-set-tostringtag: 2.1.0
-      hasown: 2.0.2
+      hasown: 2.0.4
       mime-types: 2.1.35
 
   function-bind@1.1.2: {}
@@ -2557,6 +2546,10 @@ snapshots:
       has-symbols: 1.1.0
 
   hasown@2.0.2:
+    dependencies:
+      function-bind: 1.1.2
+
+  hasown@2.0.4:
     dependencies:
       function-bind: 1.1.2
 
@@ -3078,7 +3071,7 @@ snapshots:
 
   monaco-editor@0.54.0:
     dependencies:
-      dompurify: 3.4.0
+      dompurify: 3.4.10
       marked: 14.0.0
 
   monaco-languageserver-types@0.4.0:
@@ -3166,7 +3159,7 @@ snapshots:
       '@posthog/core': 1.24.1
       '@posthog/types': 1.363.2
       core-js: 3.49.0
-      dompurify: 3.4.0
+      dompurify: 3.4.10
       fflate: 0.4.8
       preact: 10.29.0
       query-selector-shadow-dom: 1.0.1
@@ -3195,15 +3188,14 @@ snapshots:
 
   property-information@7.1.0: {}
 
-  protobufjs@7.5.8:
+  protobufjs@7.6.4:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
       '@protobufjs/base64': 1.1.2
       '@protobufjs/codegen': 2.0.5
-      '@protobufjs/eventemitter': 1.1.0
-      '@protobufjs/fetch': 1.1.0
+      '@protobufjs/eventemitter': 1.1.1
+      '@protobufjs/fetch': 1.1.1
       '@protobufjs/float': 1.0.2
-      '@protobufjs/inquire': 1.1.1
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.1


### PR DESCRIPTION
## What changed

Bumped the pinned `pnpm.overrides` in `server/package.json` (and added overrides for the transitive `form-data` and `@opentelemetry/core`) to the fixed versions, regenerating `server/pnpm-lock.yaml`:

| Package | From | To | Advisories cleared |
| --- | --- | --- | --- |
| dompurify | 3.4.0 | 3.4.10 | CVE-2026-49458, CVE-2026-49459, CVE-2026-49978, GHSA-76mc-f452-cxcm, GHSA-gvmj-g25r-r7wr, GHSA-vxr8-fq34-vvx9, GHSA-x4vx-rjvf-j5p4 |
| protobufjs | 7.5.8 | 7.6.4 | CVE-2026-48712, CVE-2026-54269 |
| form-data (transitive) | 4.0.5 | 4.0.6 | CVE-2026-12143 (HIGH) |
| @opentelemetry/core (transitive) | 2.2.0 | 2.8.0 | CVE-2026-54285 |

## Why

The `trivy fs` scan in `server/mise/tasks/security.sh` runs with no severity filter and no `--ignore-unfixed`:

```
trivy fs --exit-code 1 --skip-files "mix.exs,mix.lock" --skip-dirs "priv/static,node_modules,deps,_build" ./
```

so it fails on **every** known CVE in `server/pnpm-lock.yaml`, regardless of severity or whether the project actually exercises the vulnerable path. Trivy refreshes its vulnerability DB on each CI run, so a batch of recently disclosed npm advisories started failing the Security job on `main` (12 findings) without any related code change. This is independent of the PR that surfaced it ([#11298](https://github.com/tuist/tuist/pull/11298)); the failure reproduces on `main`.

## Why these versions / this approach

The repo already pins security-sensitive transitive packages through `pnpm.overrides` (axios, ajv, dompurify, protobufjs, etc.), so the established fix is to advance the override to the patched version rather than ignore the finding. `form-data` and `@opentelemetry/core` were not previously overridden, so new override entries were added.

- All bumps stay within the same major version, so the bundled consumers (`@scalar/api-reference`, `typesense`, the OTLP transformer) are unaffected.
- dompurify's worst advisory (GHSA-x4vx-rjvf-j5p4) has vulnerable range `<= 3.4.6`; 3.4.10 is outside it.
- `@opentelemetry/core` 2.8.0 is required because the current Trivy DB lists CVE-2026-54285 as fixed only in 2.8.0 (the earlier 2.6.1 patch claim was revised). The bump also dedupes the two `@opentelemetry/core` copies in the lockfile to a single tree entry.

## Why not `.trivyignore`

The root `.trivyignore` is only wired into the Docker **image** scan (`trivy image --ignorefile "$GITHUB_WORKSPACE/.trivyignore"`); the `trivy fs` scan in `security.sh` reads `.trivyignore` from its cwd (`server/`), where none exists. These are all fixed upstream, so patching is preferable to suppressing.

## Validation

- `trivy fs --exit-code 1 --skip-files mix.exs,mix.lock --skip-dirs priv/static,node_modules,deps,_build ./` now exits **0** (was exit 1 with 12 findings; verified locally against a freshly downloaded Trivy DB).
- `aube install` resolves cleanly with all peer dependencies satisfied; lockfile shows single resolved versions: dompurify@3.4.10, protobufjs@7.6.4, form-data@4.0.6, @opentelemetry/core@2.8.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)