### PR TITLE
fix(server): default an unselected operator access tier to read instead of 400ing

### DIFF
--- a/tuist-ops/lib/tuist_ops_web/controllers/grant_controller.ex
+++ b/tuist-ops/lib/tuist_ops_web/controllers/grant_controller.ex
@@ -79,7 +79,12 @@ defmodule TuistOpsWeb.GrantController do
     subject = subject(conn)
     account = params["account_handle"]
     return_to = params["return_to"]
-    tier = params["tier"]
+    # The Noora select's zag hook leaves the hidden <select> empty unless the
+    # operator opens the dropdown and actively picks an option, so a blank or
+    # absent tier means they kept the default. Coerce anything outside @tiers to
+    # "read" (the default and lowest-privilege, self-serve tier), matching
+    # new/2; admin still requires an explicit selection that writes "admin".
+    tier = if params["tier"] in @tiers, do: params["tier"], else: "read"
     reason = params |> Map.get("reason", "") |> to_string() |> String.trim()
     ttl_seconds = parse_ttl(params["ttl_minutes"])
 
@@ -95,9 +100,6 @@ defmodule TuistOpsWeb.GrantController do
 
       not valid_account_handle?(account) ->
         render_error(conn, 400, "Bad request", "Invalid account handle.")
-
-      tier not in @tiers ->
-        render_error(conn, 400, "Bad request", "Unknown access tier.")
 
       String.length(reason) < 5 ->
         conn


### PR DESCRIPTION
## What changed

`GrantController.create/2` in tuist-ops now coerces a `tier` value outside `~w(read admin)` to `"read"`, instead of returning `400 "Unknown access tier"`. This matches what `new/2` already does — the inconsistency between the two was the bug.

## Why

Submitting the operator reason form at `ops.tuist.dev/grants/new` failed with **"Unknown access tier"** when the operator left the pre-selected **Read** default untouched and hit Continue — but explicitly picking **Admin** worked.

Both `read` and `admin` are valid tiers, so the asymmetry pointed at what the form *submits*, not the controller's allow-list. Root cause: the Noora `select` renders a hidden native `<select name="tier">` (the submittable field) driven by a zag-js hook (`phx-hook="NooraSelect"`). The hook builds its machine context (`noora/js/Select.js`) with `id` / `collection` / `name` / `onValueChange` but **never seeds the initial value**, so on mount the empty machine overwrites the server-rendered `selected="read"` in the hidden `<select>`. Result:

- **Untouched default** → hidden select reset to `""` → submits empty → `400 "Unknown access tier"`.
- **Explicitly picked Admin** → hook writes `admin` on selection → submits `admin` → works.

## Why this fix

The form's documented default is `read`, and `new/2` already coerces an unknown tier to `read`. Making `create/2` consistent recovers the intended behavior immediately. `read` is the lowest-privilege, self-serve tier (granted instantly), and `admin` still requires an explicit dropdown selection that writes `admin` — so coercing anything else to `read` cannot escalate privilege. Every other request validation (Pomerium identity, `requester_allowed?`, return_to allow-list, account-handle charset, reason length) is unchanged.

## The deeper fix (separate)

The real root cause is in the Noora design system: the select hook should seed the zag machine's initial value from the rendered `selected` option so an untouched default submits correctly. That belongs in Noora and needs a release to reach this Hex-consuming app, so it's tracked separately rather than bundled here. This controller change is the immediate, contained unblock for the operator flow.

## Validation

`mix compile` clean; `mix format`; existing `grant_controller_test.exs` (6 tests) green. The `create` action had no prior tests and adding one means establishing the first CSRF-handling POST test in tuist-ops — called out as a follow-up rather than bundled into this hotfix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)