### PR TITLE
feat(server): let founders self-approve operator admin access to customer orgs

### DIFF
--- a/infra/k8s/operator-project-access-audit.md
+++ b/infra/k8s/operator-project-access-audit.md
@@ -20,7 +20,11 @@ customer's SSO enforcement, which is how SSO-enforced orgs become reachable.
   was authorized by the grant.
 - **Identities**: `requester_email` = the operator's `@tuist.dev` Google Workspace
   identity (from Pomerium's `X-Pomerium-Claim-Email`). `approver_email`/`approver_slack_id`
-  (admin tier only) is the second human.
+  (admin tier only) is who approved. Normally a second human, but Owners/Admins (the
+  founders) may self-approve, mirroring the JIT elevation policy where Owner/Admin can
+  self-approve any env. When `approver_email == requester_email` on an admin grant, it
+  was a founder self-approval: segregation of duties did not apply, but the grant row
+  still records it for the audit.
 
 ## Trail 1: Slack thread (admin tier only)
 

--- a/tuist-ops/lib/tuist_ops/project_access/approvals.ex
+++ b/tuist-ops/lib/tuist_ops/project_access/approvals.ex
@@ -8,10 +8,10 @@ defmodule TuistOps.ProjectAccess.Approvals do
       Grant inline (returns `{:ok, :granted, grant}`). For `admin` it
       creates a `pending` Request and posts a Slack approval card
       (returns `{:ok, :pending, request}`).
-    * `approve/2` — a second human clicked Approve on an admin
-      request in Slack. Gates self-approval out entirely (admin
-      access always needs a second human) and requires the approver
-      to be an Owner/Admin on the tailnet, then spawns the Grant.
+    * `approve/2` — someone clicked Approve on an admin request in
+      Slack. The approver must be an Owner/Admin on the tailnet.
+      Owners/Admins (the founders) may self-approve; every other
+      role needs a second human. Spawns the Grant.
     * `deny/2` — a second human clicked Deny.
 
   The Grant row is the audit record; the signed token the customer
@@ -108,9 +108,9 @@ defmodule TuistOps.ProjectAccess.Approvals do
 
   @doc """
   Approves an admin request. `actor` is the Slack user who clicked
-  Approve. Admin access to a customer org always needs a second
-  human, so the requester can never self-approve, and the approver
-  must be an Owner/Admin on the tailnet. Idempotent on replay.
+  Approve. The approver must be an Owner/Admin on the tailnet.
+  Owners/Admins may self-approve (mirroring JIT elevation); every
+  other role needs a second human. Idempotent on replay.
   """
   def approve(request_id, %{slack_id: actor_slack_id, email: actor_email}) do
     fn ->
@@ -136,7 +136,8 @@ defmodule TuistOps.ProjectAccess.Approvals do
               notify_closed(expired, "expired")
               {:expired, expired}
 
-            String.downcase(req.requester_email) == String.downcase(actor_email) ->
+            String.downcase(req.requester_email) == String.downcase(actor_email) and
+                not Policy.self_approval_allowed?(actor_email) ->
               Repo.rollback(:cannot_self_approve)
 
             not Policy.admin_approver_allowed?(actor_email) ->

--- a/tuist-ops/lib/tuist_ops/project_access/policy.ex
+++ b/tuist-ops/lib/tuist_ops/project_access/policy.ex
@@ -11,9 +11,11 @@ defmodule TuistOps.ProjectAccess.Policy do
 
     * `admin` — acting with admin privileges on a customer org
       ("sign in as admins"). Treated like a production kubectl write:
-      it always needs a **second human** to approve in Slack, and
-      that approver must be an Owner or Admin on the tailnet. The
-      requester can never self-approve.
+      the approver must be an Owner or Admin on the tailnet. A second
+      human normally clicks Approve, but Owners/Admins (the founders)
+      may self-approve, mirroring the JIT elevation policy where
+      Owner/Admin can self-approve any env. Members and every other
+      role still need a second human.
 
   Source of truth for the approver gate is the Tailscale tailnet role
   (`TuistOps.JIT.TailscaleClient.user_role/1`), the same one the JIT
@@ -48,12 +50,22 @@ defmodule TuistOps.ProjectAccess.Policy do
   Members (engineers) and any other role cannot approve admin access
   to a customer org.
   """
-  def admin_approver_allowed?(approver_email) when is_binary(approver_email) do
-    case TailscaleClient.user_role(approver_email) do
+  def admin_approver_allowed?(approver_email), do: owner_or_admin?(approver_email)
+
+  @doc """
+  Returns true if `requester_email` may approve their own admin-tier
+  request. Mirrors the JIT elevation policy: only Owners/Admins (the
+  founders) can self-approve. Members and every other role still need
+  a second human.
+  """
+  def self_approval_allowed?(requester_email), do: owner_or_admin?(requester_email)
+
+  defp owner_or_admin?(email) when is_binary(email) do
+    case TailscaleClient.user_role(email) do
       {:ok, role} -> role in [:owner, :admin]
       _ -> false
     end
   end
 
-  def admin_approver_allowed?(_), do: false
+  defp owner_or_admin?(_), do: false
 end

--- a/tuist-ops/lib/tuist_ops/project_access/request.ex
+++ b/tuist-ops/lib/tuist_ops/project_access/request.ex
@@ -9,8 +9,10 @@ defmodule TuistOps.ProjectAccess.Request do
       moment the reason is recorded (the request is created already
       `approved` and immediately spawns a `Grant`).
     * `admin` — act with admin privileges on the customer's org
-      ("sign in as admins"). Stays `pending` until a second human
-      approves in Slack, exactly like a production kubectl write.
+      ("sign in as admins"). Stays `pending` until an Owner/Admin
+      approves in Slack, like a production kubectl write. An
+      Owner/Admin requester may self-approve; anyone else needs a
+      second human.
 
   Goes through: `pending → approved | denied | expired | failed`.
   An approved request spawns a `TuistOps.ProjectAccess.Grant`; the
@@ -48,7 +50,7 @@ defmodule TuistOps.ProjectAccess.Request do
 
   @doc """
   Changeset for a brand-new request. For the `admin` tier
-  `expires_at` is the deadline by which a second human must approve
+  `expires_at` is the deadline by which an Owner/Admin must approve
   in Slack; for the `read` tier it equals the grant's own expiry
   since there is no approval step.
   """

--- a/tuist-ops/lib/tuist_ops/project_access/slack_blocks.ex
+++ b/tuist-ops/lib/tuist_ops/project_access/slack_blocks.ex
@@ -48,7 +48,7 @@ defmodule TuistOps.ProjectAccess.SlackBlocks do
           %{
             type: "mrkdwn",
             text:
-              "Admin access to a customer org needs a second human. Approval expires <!date^#{expiry_unix}^{date_short_pretty} at {time}|soon>. The requester cannot approve their own request, and only Owners/Admins may approve."
+              "Only Owners/Admins may approve admin access to a customer org. Approval expires <!date^#{expiry_unix}^{date_short_pretty} at {time}|soon>. An Owner/Admin requester may self-approve; anyone else needs a second human."
           }
         ]
       },

--- a/tuist-ops/lib/tuist_ops_web/controllers/grant_html.ex
+++ b/tuist-ops/lib/tuist_ops_web/controllers/grant_html.ex
@@ -76,7 +76,7 @@ defmodule TuistOpsWeb.GrantHTML do
     <div class="ops-centered">
       <div class="ops-page__header">
         <h1 class="ops-page__title">Waiting for approval</h1>
-        <p class="ops-page__subtitle">Admin access to a customer org needs a second human.</p>
+        <p class="ops-page__subtitle">Admin access to a customer org needs an Owner/Admin to approve.</p>
       </div>
 
       <.card icon="clock_hour_4" title={"Access #{@account}"}>

--- a/tuist-ops/lib/tuist_ops_web/controllers/slack_controller.ex
+++ b/tuist-ops/lib/tuist_ops_web/controllers/slack_controller.ex
@@ -219,7 +219,7 @@ defmodule TuistOpsWeb.SlackController do
               conn,
               channel_id,
               actor_slack_id,
-              ":no_entry: A second human has to approve admin access to a customer org. You can't approve your own request."
+              ":no_entry: Only Owners/Admins can self-approve admin access to a customer org. You'll need a second human to click Approve."
             )
 
           {:error, :approver_not_authorized} ->

--- a/tuist-ops/test/project_access/approvals_test.exs
+++ b/tuist-ops/test/project_access/approvals_test.exs
@@ -102,12 +102,28 @@ defmodule TuistOps.ProjectAccess.ApprovalsTest do
       assert grant.account_handle == "acme"
     end
 
-    test "the requester cannot self-approve", %{request: request} do
+    test "an Owner/Admin requester can self-approve", %{request: request} do
+      stub(TailscaleClient, :user_role, fn "marek@tuist.dev" -> {:ok, :owner} end)
+
+      assert {:ok, approved, grant} =
+               Approvals.approve(request.id, %{slack_id: "U_MAREK", email: "marek@tuist.dev"})
+
+      assert approved.status == "approved"
+      assert approved.approver_email == "marek@tuist.dev"
+      assert grant.tier == "admin"
+      assert grant.status == "active"
+    end
+
+    test "a Member requester cannot self-approve", %{request: request} do
+      stub(TailscaleClient, :user_role, fn "marek@tuist.dev" -> {:ok, :member} end)
+
       assert {:error, :cannot_self_approve} =
                Approvals.approve(request.id, %{slack_id: "U_MAREK", email: "marek@tuist.dev"})
     end
 
-    test "self-approval is rejected case-insensitively", %{request: request} do
+    test "a Member's self-approval is rejected case-insensitively", %{request: request} do
+      stub(TailscaleClient, :user_role, fn _ -> {:ok, :member} end)
+
       assert {:error, :cannot_self_approve} =
                Approvals.approve(request.id, %{slack_id: "U_MAREK", email: "Marek@TUIST.dev"})
     end

--- a/tuist-ops/test/project_access/policy_test.exs
+++ b/tuist-ops/test/project_access/policy_test.exs
@@ -47,4 +47,28 @@ defmodule TuistOps.ProjectAccess.PolicyTest do
       refute Policy.admin_approver_allowed?(nil)
     end
   end
+
+  describe "self_approval_allowed?/1" do
+    test "true for Owner and Admin tailnet roles (the founders)" do
+      stub(TailscaleClient, :user_role, fn _ -> {:ok, :owner} end)
+      assert Policy.self_approval_allowed?("owner@tuist.dev")
+
+      stub(TailscaleClient, :user_role, fn _ -> {:ok, :admin} end)
+      assert Policy.self_approval_allowed?("admin@tuist.dev")
+    end
+
+    test "false for a Member (engineer)" do
+      stub(TailscaleClient, :user_role, fn _ -> {:ok, :member} end)
+      refute Policy.self_approval_allowed?("eng@tuist.dev")
+    end
+
+    test "false when the tailnet lookup fails" do
+      stub(TailscaleClient, :user_role, fn _ -> {:error, :not_found} end)
+      refute Policy.self_approval_allowed?("ghost@tuist.dev")
+    end
+
+    test "false for a nil requester" do
+      refute Policy.self_approval_allowed?(nil)
+    end
+  end
 end


### PR DESCRIPTION
## Purpose

Mirror the JIT/k8s elevation policy in the operator project-access flow: **Owners/Admins (the founders) can now self-approve an admin-tier ("sign in as admins") access request to a customer org.** Members and every other tailnet role still require a second human, and the `read` tier remains self-serve.

### Why

Previously admin-tier self-approval was blocked unconditionally, on the rationale that customer-org admin access should always need a second human. The k8s JIT elevation flow already trusts Owner/Admin to self-approve any env. This extends the same trust tier to operator admin access, scoped to the founders only.

### What changed

- **Policy** (`project_access/policy.ex`): added `self_approval_allowed?/1` gated on the `Owner`/`Admin` tailnet role, using the same source of truth as JIT (`TailscaleClient.user_role/1`). The shared Owner/Admin check is factored into a private `owner_or_admin?/1` used by both `admin_approver_allowed?/1` and `self_approval_allowed?/1`.
- **Approval gate** (`project_access/approvals.ex`): `approve/2` now rolls back the self-approval branch only when `requester == actor AND not self_approval_allowed?(actor)`. A founder self-approving passes both that branch and the existing `admin_approver_allowed?` gate, then mints the grant. The grant records the founder as their own approver, preserving the audit trail.
- **User-facing copy**: Slack approval card, the self-approve rejection hint, the pending page, and docstrings updated from "always needs a second human" to "Owners/Admins may self-approve; anyone else needs a second human."
- **Audit runbook** (`infra/k8s/operator-project-access-audit.md`): documents the founder self-approval exception so a reviewer who sees `approver_email == requester_email` on an admin grant understands what it means.

### Reviewer note / tradeoff

This intentionally drops the segregation-of-duties property for the two founders on customer-org admin access (initiation is no longer separated from authorization). This was a deliberate decision. The grant row still logs `requester == approver`, so a founder self-approval remains detectable in the audit trail, and the audit doc now calls it out explicitly. Worth keeping in mind for any SOC 2 / customer security review of operator access controls.

### How to test locally

From `tuist-ops/`:

```sh
mix test test/project_access/policy_test.exs test/project_access/approvals_test.exs test/tuist_ops_web/controllers/slack_controller_test.exs
```

Covers: Owner/Admin requester can self-approve (grant minted, approver == requester), Member requester cannot self-approve, Member self-approval rejected case-insensitively, and the new `self_approval_allowed?/1` policy suite. 33 passing, credo clean.
