### PR TITLE
fix(infra): use cpx22 for md-egress pools (cpx21 not creatable in fsn1)

### DIFF
--- a/infra/k8s/clusters/cluster-canary.yaml
+++ b/infra/k8s/clusters/cluster-canary.yaml
@@ -59,7 +59,7 @@ spec:
           variables:
             overrides:
               - name: hcloudWorkerMachineType
-                value: cpx21
+                value: cpx22
               - name: workerNodeLabels
                 value: tuist.dev/stable-egress-candidate=server
         # Dedicated Kura pool. Kura StatefulSets default to this node

--- a/infra/k8s/clusters/cluster-production.yaml
+++ b/infra/k8s/clusters/cluster-production.yaml
@@ -90,7 +90,7 @@ spec:
               # workload, so it doesn't need the general pool's dedicated
               # vCPU shape.
               - name: hcloudWorkerMachineType
-                value: cpx21
+                value: cpx22
               - name: workerNodeLabels
                 value: tuist.dev/stable-egress-candidate=server
         # Dedicated processor pool: xcactivitylog parsing.

--- a/infra/k8s/clusters/cluster-staging.yaml
+++ b/infra/k8s/clusters/cluster-staging.yaml
@@ -75,7 +75,7 @@ spec:
           variables:
             overrides:
               - name: hcloudWorkerMachineType
-                value: cpx21
+                value: cpx22
               - name: workerNodeLabels
                 value: tuist.dev/stable-egress-candidate=server
         # Dedicated Kura pool. Staging exposes eu-central so the


### PR DESCRIPTION
## What

Change the `md-egress` MachineDeployment server type from `cpx21` to `cpx22` in all three cluster topologies (production, canary, staging).

## Why

The stable-egress `md-egress` pools added in #11272 override `hcloudWorkerMachineType` to `cpx21` to keep the SNAT-only gateway nodes cheap. Hetzner rejects that type/location combination — every `md-egress` Machine across all three clusters is stuck `Provisioning`:

```
Server creation failed with an irrecoverable error: failed to create HCloud server
... in "fsn1" (type "cpx21"): unsupported location for server type (invalid_input)
```

### Root cause

`cpx21` is the **previous** CPX generation. It is still *priced* for `fsn1` (so it passes validation and shows in `hcloud server-type describe`), but it is **no longer creatable in `fsn1-dc14`**. The cluster's live `fsn1` nodes all run the current generation (`cpx22` ×13, `cpx32` ×14, `cpx42`, `cpx62`; the ClusterClass default is `cx23`). `md-egress` was the only pool overriding the type, to the dead `cpx21`.

### Why cpx22

It's the smallest current-generation shared type already proven in `fsn1-dc14`, and far more than an egress/SNAT-only node needs. Keeps the original cost-minimization intent without picking an over-sized shape.

## Post-merge — expected to self-heal

When this merges, `mgmt-cluster-apply` re-applies and the changed type rolls a new `cpx22` MachineSet. The stuck `cpx21` Machines are *unavailable* (not terminally `failed` — no `status.failureReason`), so scaling them down does not consume the `maxUnavailable=0` budget; with the default `maxSurge`, CAPI should replace them with `cpx22` automatically. No manual step is expected.

**Fallback** — only if the rollout wedges (old Machines linger and no `cpx22` appears after ~10 min), delete the stuck Machines to unstick it:

```bash
kubectl -n org-tuist delete machine -l cluster.x-k8s.io/deployment-name=tuist-md-egress-5ql7b          # production
kubectl -n org-tuist delete machine -l cluster.x-k8s.io/deployment-name=tuist-canary-md-egress-p75zm   # canary
kubectl -n org-tuist delete machine -l cluster.x-k8s.io/deployment-name=tuist-staging-md-egress-pprwb  # staging
```

Note: an MHC already covers these pools but has not recycled them — at `0/2 healthy` it trips its max-unhealthy short-circuit and declines to mass-delete, which is why they have sat `Provisioning` rather than being recreated. The template change (not the MHC) is what drives replacement.

## Impact

**No production impact.** The failover controller has been correctly *adopting* the existing hand-provisioned gateway nodes the whole time, so server egress was never at risk. This only unblocks the standby candidate pool that makes the egress failover automatic — until those nodes join, each cluster has a single active gateway with no automated standby.

## Validation

- Confirmed via the mgmt cluster: `TopologyReconciled=True` (the MDs were created correctly), Machines stuck `Provisioning` with the `unsupported location for server type` error, no terminal `failureReason`, single up-to-date MachineSet per pool.
- Confirmed `cpx22` is live and healthy in `fsn1-dc14` (13 instances) via `hcloud server list`.