### PR TITLE
fix(cli): SwifterPM 0.8.12 (skip __MACOSX, stream resolve output)

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -566,8 +566,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tuist/swifterpm",
       "state" : {
-        "revision" : "39479a1f50b647f36713b488969a2c6c3b696f26",
-        "version" : "0.8.10"
+        "revision" : "d48e02d2991e4020764fc93bd5d7189549f34767",
+        "version" : "0.8.12"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -1819,7 +1819,7 @@ let package = Package(
         .package(id: "swiftlang.swift-docc-plugin", from: "1.4.6"),
         .package(name: "XCResultNIF", path: "server/native/xcresult_nif"),
         .package(id: "stephencelis.SQLite_swift", from: "0.16.0"),
-        .package(url: "https://github.com/tuist/swifterpm", exact: "0.8.10"),
+        .package(url: "https://github.com/tuist/swifterpm", exact: "0.8.12"),
     ],
     targets: targets,
     swiftLanguageModes: [.v5]


### PR DESCRIPTION
## Summary

Bumps the pinned [SwifterPM](https://github.com/tuist/swifterpm) dependency from `0.8.10` to [`0.8.12`](https://github.com/tuist/swifterpm/releases/tag/0.8.12). Two fixes ship with the bump, both reaching `tuist install` / `tuist generate` through our SwifterPM-backed SwiftPM integration:

### 🐛 Strip `__MACOSX` shadow bundles from extracted archives ([swifterpm#41](https://github.com/tuist/swifterpm/pull/41))

A user reported on Slack that, on a clean checkout, `tuist generate` aborted with:

```
.../swifterpm/artifacts/plaid-link-ios-spm/LinkKit/__MACOSX/LinkKit.xcframework/Info.plist doesn't contain an Info.plist
```

Plaid ships LinkKit as a Finder-zipped binary artifact. Those zips carry a `__MACOSX/` AppleDouble sidecar with a shadow copy of every bundle inside. `unzip` happily wrote both the real `LinkKit.xcframework/` and `__MACOSX/LinkKit.xcframework/` into the cache, and two compounding things made the shadow win in our scanner:

1. `binaryArtifacts(in:)` descended into any directory without an artifact extension, so `__MACOSX/` was walked and its shadow `LinkKit.xcframework` was added to the results.
2. `binaryArtifact(in:)` returned `artifacts.last` after sorting by path. `_` (0x5F) sorts after `L` (0x4C), so the shadow won.

The fix:
- Strips top-level `__MACOSX/` directories right after `unzip`, before the existing flatten-single-toplevel logic.
- Skips `__MACOSX` entries while recursing in `binaryArtifacts(in:)` so any path the scanner is pointed at (fresh extract, local artifact path, pre-populated cache) is defensive.

### 🐛 Forward delegated SwiftPM output during resolution ([swifterpm#39](https://github.com/tuist/swifterpm/pull/39))

Stream stdout and stderr from delegated `swift package resolve` runs so normal resolution surfaces SwiftPM progress to the user instead of appearing stalled. Captured output is still preserved for callers that need it, and quiet resolution stays quiet by forwarding only when progress output is enabled.

## Verification

- `swift package resolve --replace-scm-with-registry` against this checkout resolves cleanly and writes the new revision (`d48e02d2991e4020764fc93bd5d7189549f34767`, `0.8.12`) to `Package.resolved`.
- Upstream PRs include their own regression tests: [swifterpm#41](https://github.com/tuist/swifterpm/pull/41) adds `restorePackageIgnoresMacOSResourceForkShadowFramework` (zips a real `Foo.xcframework` plus a `__MACOSX/Foo.xcframework/._Info.plist` shadow, runs `restorePackage` + `writeWorkspaceState`, asserts that the workspace state and on-disk artifact resolve to the real framework with no `__MACOSX` left behind) and confirms the test fails against pre-fix `main` exactly the way the Slack user saw it.