### PR TITLE
feat(server): base shard timing on p90 of all CI runs, not default-branch avg

### DIFF
--- a/server/lib/tuist/shards.ex
+++ b/server/lib/tuist/shards.ex
@@ -23,6 +23,7 @@ defmodule Tuist.Shards do
   @default_module_duration_ms 30_000
   @default_suite_duration_ms 5_000
   @timing_lookback_days 30
+  @timing_quantile 0.90
 
   def create_shard_plan(%Project{} = project, params) do
     granularity = Map.get(params, :granularity, "module")
@@ -242,13 +243,12 @@ defmodule Tuist.Shards do
     from(mr in TestModuleRun,
       where: mr.project_id == ^project.id,
       where: mr.is_ci == true,
-      where: mr.git_branch == ^project.default_branch,
       where: mr.ran_at >= ^cutoff,
       group_by: mr.name,
-      select: %{name: mr.name, avg_duration: fragment("avg(?)", mr.duration)}
+      select: %{name: mr.name, duration: fragment("quantile(?)(?)", ^@timing_quantile, mr.duration)}
     )
     |> ClickHouseRepo.all()
-    |> Map.new(fn %{name: name, avg_duration: avg} -> {name, round(avg)} end)
+    |> Map.new(fn %{name: name, duration: duration} -> {name, round(duration)} end)
   end
 
   defp fetch_timing_data(project, "suite") do
@@ -257,13 +257,12 @@ defmodule Tuist.Shards do
     from(sr in TestSuiteRun,
       where: sr.project_id == ^project.id,
       where: sr.is_ci == true,
-      where: sr.git_branch == ^project.default_branch,
       where: sr.ran_at >= ^cutoff,
       group_by: sr.name,
-      select: %{name: sr.name, avg_duration: fragment("avg(?)", sr.duration)}
+      select: %{name: sr.name, duration: fragment("quantile(?)(?)", ^@timing_quantile, sr.duration)}
     )
     |> ClickHouseRepo.all()
-    |> Map.new(fn %{name: name, avg_duration: avg} -> {name, round(avg)} end)
+    |> Map.new(fn %{name: name, duration: duration} -> {name, round(duration)} end)
   end
 
   defp assign_durations(unit_names, timing_data, granularity) do

--- a/server/test/tuist/shards_test.exs
+++ b/server/test/tuist/shards_test.exs
@@ -54,6 +54,32 @@ defmodule Tuist.ShardsTest do
       assert result.shard_count == 2
     end
 
+    test "uses timing data from non-default branches" do
+      project = ProjectsFixtures.project_fixture()
+
+      RunsFixtures.test_fixture(
+        project_id: project.id,
+        is_ci: true,
+        git_branch: "feature/some-branch",
+        test_modules: [
+          %{name: "SlowTests", status: "success", duration: 100_000, test_cases: []}
+        ]
+      )
+
+      RunsFixtures.optimize_test_runs()
+
+      params = %{
+        reference: "session-non-default",
+        modules: ["SlowTests"],
+        shard_total: 1
+      }
+
+      result = Shards.create_shard_plan(project, params)
+
+      [assignment] = result.shard_assignments
+      assert assignment["estimated_duration_ms"] == 100_000
+    end
+
     test "creates a shard plan with suite-level granularity" do
       project = ProjectsFixtures.project_fixture()
 


### PR DESCRIPTION
### What changed

Shard timing used for bin-packing was computed from the **average** test module/suite duration over the last 30 days, filtered to the project's **`default_branch`**. This PR drops the branch filter and switches the estimator from `avg` to `quantile(0.90)`.

### Why

- **Branch filter discarded most of the sample for no real signal.** Sharding happens overwhelmingly on PR/feature branches, but timing was sourced only from `default_branch`. Any unit not recently run on the default branch (a brand-new module, or one skipped by selective testing on `main`) wasn't found in the timing map and fell back to the *global median* of all units, not its own history. A heavy module assigned the median badly unbalances shards, which is exactly what bin-packing exists to prevent. Since a test's duration is essentially branch-independent, filtering to one branch threw away the large majority of usable samples for marginal noise reduction.
- **`avg` is outlier-sensitive.** A single slow or flaky run inflates the estimate. `quantile(0.90)` is robust to that while still being conservative (slightly high), which is the safer bias for shard balancing.

### Design / precedent

This aligns the timing model with how mature test-splitters work, in particular [Buildkite Test Engine](https://buildkite.com/resources/blog/beyond-basic-test-splitting-buildkite-s-approach-to-test-suite-parallelization/), which uses a **bounded time window + a percentile estimator + a median fallback** for units without history. We keep all three; the existing **30-day window is retained** rather than widening it.

A count-based window (last *N* runs) was considered and rejected in favor of keeping the date window. `quantile(0.90)(?)` matches the established ClickHouse pattern already used in `builds.ex` and `tests/analytics.ex`. The `is_ci`, lookback, and median/hardcoded fallback behavior are unchanged.

### Impact

Shard plans get a real per-unit p90 estimate from the full CI sample instead of falling back to the median for anything the default branch didn't cover, so shard balancing should improve, especially for projects whose `main` runs are sparse relative to PR runs.

### How to test locally

`mix test test/tuist/shards_test.exs`

Includes a new test asserting that a run on a non-default branch now feeds the timing estimate (`estimated_duration_ms == 100_000`). Full suite: 19 tests, 0 failures; `mix credo lib/tuist/shards.ex` clean.
