### PR TITLE
chore: tuist-macos VM network throughput probe (diagnostic)

### DIFF
--- a/.github/workflows/vm-network-probe.yml
+++ b/.github/workflows/vm-network-probe.yml
@@ -1,20 +1,15 @@
 name: VM Network Probe
 
 # Diagnostic-only workflow: measures download throughput from inside a tuist-macos
-# tart VM to isolate whether the shard-bundle download bottleneck lives in the VM
-# network path (vs the Scaleway host or Tigris, both of which measured fast).
-# Safe to delete once the investigation concludes.
+# tart VM to compare Tigris endpoints (near "storage.tuist.dev" vs far
+# "t3.tigrisfiles.io") serial-vs-parallel, isolating the shard-bundle download
+# bottleneck. Safe to delete once the investigation concludes.
 
 on:
   push:
     branches:
       - claude/vm-network-probe
   workflow_dispatch:
-    inputs:
-      bundle_url:
-        description: "Presigned Tigris URL to measure VM->Tigris throughput directly (optional)"
-        required: false
-        default: ""
 
 jobs:
   vm-network-probe:
@@ -22,13 +17,13 @@ jobs:
     runs-on: tuist-macos
     timeout-minutes: 30
     env:
-      BUNDLE_URL: ${{ github.event.inputs.bundle_url || secrets.BUNDLE_URL }}
+      NEAR_URL: ${{ secrets.BUNDLE_URL_NEAR }}
+      T3_URL: ${{ secrets.BUNDLE_URL_T3 }}
     steps:
-      - name: Probe serial vs parallel download throughput
+      - name: Probe serial vs parallel download throughput per endpoint
         run: |
           set +e +o pipefail   # GitHub injects `bash -e`; keep probing past a failed leg
-          SIZE=331525911                          # match the ~316 MB shard bundle
-          PUBLIC_URL="https://speed.hetzner.de/1GB.bin"   # Range-supporting static file near fr-par
+          SIZE=331525911       # match the ~316 MB shard bundle
 
           echo "###### VM identity ######"
           hostname; sw_vers | tr '\n' ' '; echo; uname -m
@@ -39,18 +34,18 @@ jobs:
           ifconfig "$PRIMARY" 2>/dev/null | grep -E "mtu|inet "
           echo "egress IPv4: $(curl -s4 --max-time 10 https://ifconfig.me || echo n/a)"
           echo "egress IPv6: $(curl -s6 --max-time 10 https://ifconfig.me || echo n/a)"
-          echo "DNS storage.tuist.dev:"; dig +short storage.tuist.dev 2>/dev/null | head
-          echo "DNS t3.storage.dev:";    dig +short t3.storage.dev 2>/dev/null | head
 
-          echo "###### Latency to Tigris ######"
-          echo "storage.tuist.dev:"
-          ping -c 5 storage.tuist.dev 2>/dev/null | tail -1 || echo "icmp blocked"
-          curl -so /dev/null -w '  connect=%{time_connect}s tls=%{time_appconnect}s ttfb=%{time_starttransfer}s\n' \
-            --max-time 20 https://storage.tuist.dev || true
-          echo "t3.storage.dev (endpoint the original CI failure used):"
-          ping -c 5 t3.storage.dev 2>/dev/null | tail -1 || echo "icmp blocked"
-          curl -so /dev/null -w '  connect=%{time_connect}s tls=%{time_appconnect}s ttfb=%{time_starttransfer}s\n' \
-            --max-time 20 https://t3.storage.dev || true
+          latency () {
+            local H="$1"
+            echo "$H:"
+            ping -c 5 "$H" 2>/dev/null | tail -1 || echo "  icmp blocked"
+            curl -so /dev/null -w '  connect=%{time_connect}s tls=%{time_appconnect}s ttfb=%{time_starttransfer}s\n' \
+              --max-time 20 "https://$H" || true
+          }
+          echo "###### Latency to Tigris endpoints ######"
+          latency storage.tuist.dev
+          latency t3.storage.dev
+          latency tuist-prod-storage.t3.tigrisfiles.io
 
           probe () {
             local LABEL="$1"; local URL="$2"
@@ -79,11 +74,14 @@ jobs:
             run_par 8; run_par 16; run_par 32
           }
 
-          if [ -n "${BUNDLE_URL:-}" ]; then
-            probe "Tigris (shard bundle)" "$BUNDLE_URL"
+          if [ -n "${NEAR_URL:-}" ]; then
+            probe "NEAR endpoint (storage.tuist.dev, ~1.4ms)" "$NEAR_URL"
           else
-            echo "###### Tigris (shard bundle) ######"
-            echo "  skipped: dispatch with a fresh bundle_url input (or set a BUNDLE_URL secret) for the exact VM->Tigris number"
+            echo "###### NEAR endpoint ######"; echo "  skipped: no BUNDLE_URL_NEAR secret"
           fi
 
-          probe "Public baseline (Hetzner, Range)" "$PUBLIC_URL"
+          if [ -n "${T3_URL:-}" ]; then
+            probe "T3 endpoint (t3.tigrisfiles.io, far)" "$T3_URL"
+          else
+            echo "###### T3 endpoint ######"; echo "  skipped: no BUNDLE_URL_T3 secret"
+          fi

--- a/.github/workflows/vm-network-probe.yml
+++ b/.github/workflows/vm-network-probe.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - name: Probe serial vs parallel download throughput
         run: |
-          set -uo pipefail
+          set +e +o pipefail   # GitHub injects `bash -e`; keep probing past a failed leg
           SIZE=331525911                          # match the ~316 MB shard bundle
           PUBLIC_URL="https://speed.hetzner.de/1GB.bin"   # Range-supporting static file near fr-par
 
@@ -42,16 +42,21 @@ jobs:
           echo "DNS storage.tuist.dev:"; dig +short storage.tuist.dev 2>/dev/null | head
           echo "DNS t3.storage.dev:";    dig +short t3.storage.dev 2>/dev/null | head
 
-          echo "###### Latency to Tigris (storage.tuist.dev) ######"
-          ping -c 5 storage.tuist.dev 2>/dev/null | tail -2 || echo "icmp blocked"
-          curl -so /dev/null -w 'connect=%{time_connect}s tls=%{time_appconnect}s ttfb=%{time_starttransfer}s\n' \
+          echo "###### Latency to Tigris ######"
+          echo "storage.tuist.dev:"
+          ping -c 5 storage.tuist.dev 2>/dev/null | tail -1 || echo "icmp blocked"
+          curl -so /dev/null -w '  connect=%{time_connect}s tls=%{time_appconnect}s ttfb=%{time_starttransfer}s\n' \
             --max-time 20 https://storage.tuist.dev || true
+          echo "t3.storage.dev (endpoint the original CI failure used):"
+          ping -c 5 t3.storage.dev 2>/dev/null | tail -1 || echo "icmp blocked"
+          curl -so /dev/null -w '  connect=%{time_connect}s tls=%{time_appconnect}s ttfb=%{time_starttransfer}s\n' \
+            --max-time 20 https://t3.storage.dev || true
 
           probe () {
             local LABEL="$1"; local URL="$2"
             echo "###### $LABEL ######"
             local code
-            code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 20 -r 0-0 "$URL" 2>/dev/null)
+            code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 20 -r 0-0 "$URL" 2>/dev/null || true)
             case "$code" in
               200|206) ;;
               *) echo "  unreachable (HTTP ${code:-000})"; return ;;
@@ -74,11 +79,11 @@ jobs:
             run_par 8; run_par 16; run_par 32
           }
 
-          probe "Public baseline (Hetzner, Range)" "$PUBLIC_URL"
-
           if [ -n "${BUNDLE_URL:-}" ]; then
             probe "Tigris (shard bundle)" "$BUNDLE_URL"
           else
             echo "###### Tigris (shard bundle) ######"
             echo "  skipped: dispatch with a fresh bundle_url input (or set a BUNDLE_URL secret) for the exact VM->Tigris number"
           fi
+
+          probe "Public baseline (Hetzner, Range)" "$PUBLIC_URL"

--- a/.github/workflows/vm-network-probe.yml
+++ b/.github/workflows/vm-network-probe.yml
@@ -1,0 +1,81 @@
+name: VM Network Probe
+
+# Diagnostic-only workflow: measures download throughput from inside a tuist-macos
+# tart VM to isolate whether the shard-bundle download bottleneck lives in the VM
+# network path (vs the Scaleway host or Tigris, both of which measured fast).
+# Safe to delete once the investigation concludes.
+
+on:
+  push:
+    branches:
+      - claude/vm-network-probe
+  workflow_dispatch:
+    inputs:
+      bundle_url:
+        description: "Presigned Tigris URL to measure VM->Tigris throughput directly (optional)"
+        required: false
+        default: ""
+
+jobs:
+  vm-network-probe:
+    name: VM network throughput probe
+    runs-on: tuist-macos
+    timeout-minutes: 30
+    env:
+      BUNDLE_URL: ${{ github.event.inputs.bundle_url || secrets.BUNDLE_URL }}
+    steps:
+      - name: Probe serial vs parallel download throughput
+        run: |
+          set -uo pipefail
+          SIZE=331525911                          # match the ~316 MB shard bundle
+          PUBLIC_URL="https://speed.hetzner.de/1GB.bin"   # Range-supporting static file near fr-par
+
+          echo "###### VM identity ######"
+          hostname; sw_vers | tr '\n' ' '; echo; uname -m
+
+          echo "###### Network config ######"
+          route -n get default 2>/dev/null | grep -E "interface|gateway"
+          PRIMARY=$(route -n get default 2>/dev/null | awk '/interface:/{print $2}')
+          ifconfig "$PRIMARY" 2>/dev/null | grep -E "mtu|inet "
+          echo "egress IPv4: $(curl -s4 --max-time 10 https://ifconfig.me || echo n/a)"
+          echo "egress IPv6: $(curl -s6 --max-time 10 https://ifconfig.me || echo n/a)"
+          echo "DNS storage.tuist.dev:"; dig +short storage.tuist.dev 2>/dev/null | head
+          echo "DNS t3.storage.dev:";    dig +short t3.storage.dev 2>/dev/null | head
+
+          echo "###### Latency to Tigris (storage.tuist.dev) ######"
+          ping -c 5 storage.tuist.dev 2>/dev/null | tail -2 || echo "icmp blocked"
+          curl -so /dev/null -w 'connect=%{time_connect}s tls=%{time_appconnect}s ttfb=%{time_starttransfer}s\n' \
+            --max-time 20 https://storage.tuist.dev || true
+
+          probe () {
+            local LABEL="$1"; local URL="$2"
+            echo "###### $LABEL ######"
+            if ! curl -sI --max-time 20 -r 0-0 "$URL" >/dev/null 2>&1; then
+              echo "  unreachable / no Range support"; return
+            fi
+            curl -so /dev/null \
+              -w "  SERIAL    : %{speed_download} B/s  (HTTP %{http_code})  total=%{time_total}s\n" \
+              --max-time 300 -r 0-$((SIZE-1)) "$URL"
+            run_par () {
+              local N=$1; local C=$(((SIZE+N-1)/N)); local s i lo hi e
+              s=$(date +%s.%N)
+              for i in $(seq 0 $((N-1))); do
+                lo=$((i*C)); hi=$((lo+C-1)); [ $hi -ge $SIZE ] && hi=$((SIZE-1))
+                curl -s --max-time 300 -r ${lo}-${hi} -o /dev/null "$URL" &
+              done
+              wait
+              e=$(date +%s.%N)
+              awk -v s="$s" -v e="$e" -v z="$SIZE" -v n="$N" \
+                'BEGIN{t=e-s; if(t<=0)t=0.001; printf "  PARALLEL %2d: %.2f MB/s  total=%.1fs\n", n, z/t/1048576, t}'
+            }
+            run_par 8; run_par 16; run_par 32
+          }
+
+          probe "Public baseline (Hetzner, Range)" "$PUBLIC_URL"
+
+          if [ -n "${BUNDLE_URL:-}" ]; then
+            probe "Tigris (shard bundle)" "$BUNDLE_URL"
+          else
+            echo "###### Tigris (shard bundle) ######"
+            echo "  skipped: dispatch with a fresh bundle_url input (or set a BUNDLE_URL secret) for the exact VM->Tigris number"
+          fi

--- a/.github/workflows/vm-network-probe.yml
+++ b/.github/workflows/vm-network-probe.yml
@@ -50,9 +50,12 @@ jobs:
           probe () {
             local LABEL="$1"; local URL="$2"
             echo "###### $LABEL ######"
-            if ! curl -sI --max-time 20 -r 0-0 "$URL" >/dev/null 2>&1; then
-              echo "  unreachable / no Range support"; return
-            fi
+            local code
+            code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 20 -r 0-0 "$URL" 2>/dev/null)
+            case "$code" in
+              200|206) ;;
+              *) echo "  unreachable (HTTP ${code:-000})"; return ;;
+            esac
             curl -so /dev/null \
               -w "  SERIAL    : %{speed_download} B/s  (HTTP %{http_code})  total=%{time_total}s\n" \
               --max-time 300 -r 0-$((SIZE-1)) "$URL"


### PR DESCRIPTION
## What

Draft, diagnostic-only workflow ([.github/workflows/vm-network-probe.yml](https://github.com/tuist/tuist/blob/claude/vm-network-probe/.github/workflows/vm-network-probe.yml)) that runs **inside a `tuist-macos` tart VM** and measures download throughput serial vs parallel (8/16/32 connections), plus VM network diagnostics (primary iface + MTU, egress IPv4/IPv6, DNS for `storage.tuist.dev` / `t3.storage.dev`, RTT + TTFB to Tigris).

It probes two targets:
- a secret-free public baseline (Hetzner static file near `fr-par`, supports HTTP Range), so every push produces a number;
- an optional exact `VM -> Tigris` leg when a fresh presigned URL is supplied via the `bundle_url` dispatch input or a `BUNDLE_URL` secret.

Not meant to merge. Delete once the investigation concludes.

## Why

A CI run timed out downloading a 316 MB selective-testing shard bundle from Tigris after **exactly 90s** — the global `URLSession.timeoutIntervalForResource = 90` cap in `cli/Sources/TuistHTTP/URLSession+Tuist.swift`. The shard download is also single-stream with no retry (`FileClient.download` -> `ShardService`), unlike the multipart, parallel, retried upload path.

Measuring the same object from three vantage points:

| Vantage | RTT | Serial | Parallel (best) |
|---|---|---|---|
| Local laptop | 30ms | 19 MB/s | 16 MB/s (uplink-capped) |
| Scaleway mac mini **host** (fr-par) | **1.3ms** | **61 MB/s** | **104 MB/s** (~1 Gbit cap) |
| CI run **inside tart VM** | - | **~3.5 MB/s -> timed out** | - |

So neither Tigris (1.3ms PoP in Paris, serves at 60-100 MB/s) nor the Scaleway host/link (saturates 1 Gbit) is the bottleneck. The ~17x loss must live in the **tart VM network path** (tart-cri CNI/NAT) or host contention. This workflow confirms that from inside the VM and shows whether parallelizing the download rescues it.

## How to read the result

- VM ~= host (50-100 MB/s) -> the original 3.5 MB/s was transient host contention; fix is the timeout bump + retry.
- VM ~= 3.5 MB/s, parallel >> serial -> VM path throttles per-connection; parallel ranged download is the fix.
- VM ~= 3.5 MB/s, parallel ~= serial -> VM path has an aggregate cap; it's a tart-cri networking fix, and the CLI timeout bump is the interim mitigation.

## Validation

Workflow runs on push to this branch. Results will appear in the `VM network throughput probe` job logs.