### PR TITLE
fix(mise): give each git worktree a unique, collision-free dev server port

### DIFF
--- a/mise/tasks/claude/regenerate-launch-json.sh
+++ b/mise/tasks/claude/regenerate-launch-json.sh
@@ -4,28 +4,26 @@
 set -euo pipefail
 
 WORKTREE_ROOT="$(git rev-parse --show-toplevel)"
-INSTANCE_FILE="${WORKTREE_ROOT}/.tuist-dev-instance"
 LAUNCH_DIR="${WORKTREE_ROOT}/.claude"
 LAUNCH_FILE="${LAUNCH_DIR}/launch.json"
 
-# Force mise to load dev_instance_env.sh, which creates .tuist-dev-instance.
-if [[ ! -s "${INSTANCE_FILE}" ]]; then
-  (cd "${WORKTREE_ROOT}" && mise exec -- true) >/dev/null 2>&1 || true
+# Ports are owned by dev_instance_env.sh, which mise sources for every task via
+# mise.toml's [env]._.source. Consume the exported values so launch.json always
+# matches what the dev servers actually bind. Fall back to a nested mise exec
+# when the task is invoked outside a mise-sourced environment.
+server_port="${TUIST_SERVER_PORT:-}"
+cache_port="${TUIST_CACHE_PORT:-}"
+if [[ -z "${server_port}" || -z "${cache_port}" ]]; then
+  read -r server_port cache_port < <(
+    cd "${WORKTREE_ROOT}" &&
+      mise exec -- bash -c 'printf "%s %s" "${TUIST_SERVER_PORT:-}" "${TUIST_CACHE_PORT:-}"' 2>/dev/null || true
+  ) || true
 fi
 
-if [[ ! -s "${INSTANCE_FILE}" ]]; then
-  echo "claude:regenerate-launch-json: ${INSTANCE_FILE} missing; skipping" >&2
+if ! [[ "${server_port}" =~ ^[0-9]+$ && "${cache_port}" =~ ^[0-9]+$ ]]; then
+  echo "claude:regenerate-launch-json: could not resolve dev ports; skipping" >&2
   exit 0
 fi
-
-suffix="$(tr -d '[:space:]' < "${INSTANCE_FILE}")"
-if ! [[ "${suffix}" =~ ^[0-9]+$ ]]; then
-  echo "claude:regenerate-launch-json: invalid suffix '${suffix}'" >&2
-  exit 1
-fi
-
-server_port=$((8080 + suffix))
-cache_port=$((8087 + suffix))
 
 mkdir -p "${LAUNCH_DIR}"
 cat > "${LAUNCH_FILE}" <<EOF

--- a/mise/tasks/claude/regenerate-launch-json.sh
+++ b/mise/tasks/claude/regenerate-launch-json.sh
@@ -8,20 +8,13 @@ LAUNCH_DIR="${WORKTREE_ROOT}/.claude"
 LAUNCH_FILE="${LAUNCH_DIR}/launch.json"
 
 # Ports are owned by dev_instance_env.sh, which mise sources for every task via
-# mise.toml's [env]._.source. Consume the exported values so launch.json always
-# matches what the dev servers actually bind. Fall back to a nested mise exec
-# when the task is invoked outside a mise-sourced environment.
+# mise.toml's [env]._.source, so they are already exported in this task's
+# environment.
 server_port="${TUIST_SERVER_PORT:-}"
 cache_port="${TUIST_CACHE_PORT:-}"
-if [[ -z "${server_port}" || -z "${cache_port}" ]]; then
-  read -r server_port cache_port < <(
-    cd "${WORKTREE_ROOT}" &&
-      mise exec -- bash -c 'printf "%s %s" "${TUIST_SERVER_PORT:-}" "${TUIST_CACHE_PORT:-}"' 2>/dev/null || true
-  ) || true
-fi
 
 if ! [[ "${server_port}" =~ ^[0-9]+$ && "${cache_port}" =~ ^[0-9]+$ ]]; then
-  echo "claude:regenerate-launch-json: could not resolve dev ports; skipping" >&2
+  echo "claude:regenerate-launch-json: dev ports unset (run this via mise); skipping" >&2
   exit 0
 fi
 

--- a/mise/utilities/dev_instance_env.sh
+++ b/mise/utilities/dev_instance_env.sh
@@ -53,17 +53,65 @@ persist_suffix() {
   printf '%s' "${suffix}" | tee "${target}" >/dev/null 2>&1
 }
 
+collect_used_suffixes() {
+  # Suffixes already assigned to the main checkout and every linked worktree, so
+  # a freshly generated one can avoid colliding on ports and database names.
+  local common_dir="" f
+  if command -v git >/dev/null 2>&1 && git -C "${PROJECT_ROOT}" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    common_dir="$(git -C "${PROJECT_ROOT}" rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)"
+  fi
+  [[ -n "${common_dir}" && -d "${common_dir}" ]] || return 0
+
+  for f in "${common_dir}/tuist-dev-instance" "${common_dir}"/worktrees/*/tuist-dev-instance; do
+    [[ -s "${f}" ]] || continue
+    [[ "${f}" -ef "${INSTANCE_FILE}" ]] 2>/dev/null && continue
+    tr -d '[:space:]' < "${f}"
+    printf '\n'
+  done
+}
+
+generate_suffix() {
+  # Pick a suffix in [100, 999] not used by any other instance. Seed awk's RNG
+  # with the PID so worktrees bootstrapped within the same second diverge instead
+  # of sharing awk's default time(0) seed.
+  local used
+  used="$(collect_used_suffixes | tr '\n' ' ')"
+  awk -v used="${used}" -v seed="$$" '
+    BEGIN {
+      srand(seed)
+      n = split(used, list, " ")
+      for (i = 1; i <= n; i++) taken[list[i]] = 1
+      for (attempt = 0; attempt < 100000; attempt++) {
+        candidate = int(100 + rand() * 900)
+        if (!(candidate in taken)) { print candidate; exit 0 }
+      }
+      exit 1
+    }
+  '
+}
+
 ensure_suffix() {
   local suffix=""
 
-  if [[ -n "${TUIST_DEV_INSTANCE:-}" ]]; then
-    suffix="${TUIST_DEV_INSTANCE}"
-  elif [[ -s "${INSTANCE_FILE}" ]]; then
+  # This instance's own persisted suffix wins over everything else. Worktrees
+  # live nested under the main checkout, so mise loads both mise.toml files and
+  # runs this script once per project root; the parent run exports its own
+  # TUIST_DEV_INSTANCE, which would otherwise leak into the worktree. Reading our
+  # own file first keeps each worktree on its distinct suffix regardless of what
+  # a parent (or stale env) provides.
+  if [[ -s "${INSTANCE_FILE}" ]]; then
     suffix="$(tr -d '[:space:]' < "${INSTANCE_FILE}")"
+  # No file yet: trust TUIST_DEV_INSTANCE only when it belongs to THIS project
+  # root, or when it was set externally with no provenance marker (an explicit
+  # override such as CI's TUIST_DEV_INSTANCE=1). A value carrying a different
+  # root leaked from a parent checkout and must be ignored.
+  elif [[ -n "${TUIST_DEV_INSTANCE:-}" ]] &&
+    { [[ "${TUIST_DEV_INSTANCE_ROOT:-}" == "${PROJECT_ROOT}" ]] || [[ -z "${TUIST_DEV_INSTANCE_ROOT:-}" ]]; }; then
+    suffix="${TUIST_DEV_INSTANCE}"
   elif [[ -s "${ROOT_INSTANCE_FILE}" ]]; then
     suffix="$(tr -d '[:space:]' < "${ROOT_INSTANCE_FILE}")"
   else
-    suffix="$(awk 'BEGIN { srand(); print int(100 + rand() * 900) }')"
+    suffix="$(generate_suffix)"
   fi
 
   validate_suffix "${suffix}" || {
@@ -93,6 +141,7 @@ project_basename="$(basename "${PROJECT_ROOT}")"
 project_hostname="$(printf '%s' "${project_basename}" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]/-/g; s/^-*//; s/-*$//')"
 
 export TUIST_DEV_INSTANCE="${suffix}"
+export TUIST_DEV_INSTANCE_ROOT="${PROJECT_ROOT}"
 export TUIST_SERVER_PORT="$((8080 + suffix))"
 export TUIST_SERVER_HOSTNAME="${project_hostname}.localhost"
 export TUIST_SERVER_URL="http://localhost:${TUIST_SERVER_PORT}"


### PR DESCRIPTION
## What changed

Reworks the per-worktree dev instance tooling so every git worktree gets a distinct dev server port (and database) instead of all colliding on one.

- `mise/utilities/dev_instance_env.sh`
  - `ensure_suffix` now reads the worktree's own persisted instance file **first**, so a worktree keeps its distinct suffix regardless of any inherited or stale `TUIST_DEV_INSTANCE`. It only trusts the env var when it carries a matching provenance marker (`TUIST_DEV_INSTANCE_ROOT == PROJECT_ROOT`) or was set externally with no marker (a genuine override such as CI's `TUIST_DEV_INSTANCE=1`).
  - New `generate_suffix` seeds awk's RNG with the PID and excludes suffixes already used by the main checkout and every worktree, replacing the old single `awk srand()` draw.
  - Exports a new `TUIST_DEV_INSTANCE_ROOT` provenance marker.
- `mise/tasks/claude/regenerate-launch-json.sh`
  - Derives ports from the already-exported `TUIST_SERVER_PORT` / `TUIST_CACHE_PORT` (single source of truth) instead of re-reading a divergent path and recomputing the offsets itself.

## Why

Every worktree's dev server bound the same port (8977 / suffix 897), so starting a second worktree's server failed because the port was already held by another session.

Root causes:

1. **Nested-worktree env leak (dominant).** Worktrees live under the main checkout (`.claude/worktrees/<name>/`), so mise loads **both** `mise.toml` files and runs `dev_instance_env.sh` once per project root. The main checkout runs first and exports `TUIST_DEV_INSTANCE=897`. The old `ensure_suffix` had `if [[ -n TUIST_DEV_INSTANCE ]]` as its first branch, so every worktree adopted main's value and even overwrote its own instance file with it. The suffix distribution showed the damage: clusters of 18 worktrees at 897, 18 at 76, 7 at 898.
2. **Same-second random collisions (secondary).** New suffixes came from `awk 'BEGIN { srand(); ... }'`. Argless `srand()` seeds from whole epoch seconds, so worktrees bootstrapped in the same second got identical values, with no check against suffixes already taken by siblings.
3. **Regeneration silently skipped.** `regenerate-launch-json.sh` read the working-tree `.tuist-dev-instance` while the env script persists to the git-dir path, so for linked worktrees it hit its "skipping" branch and never rewrote `launch.json`. Worktrees just inherited main's copied `launch.json`. Editing `launch.json` by hand also reverted every session, because the `SessionStart` hook rewrites it from the suffix file.

## Why this approach

The provenance marker keeps the legitimate `TUIST_DEV_INSTANCE` override working (CI sets it, and server code reads it) while rejecting the value that leaks in from the parent repo's config. Own-file-first additionally makes a worktree robust even against a parent that has not yet picked up this change.

## Validation

- This worktree was assigned the free suffix `905`; `mise exec` resolves `TUIST_SERVER_PORT=8985`, `TUIST_CACHE_PORT=8992`, and the instance file is no longer clobbered.
- `generate_suffix` across 8 separate processes returned 8 distinct unused values, confirming both the PID seeding (kills same-second collisions) and the used-set avoidance.
- `regenerate-launch-json.sh` produced `launch.json` with ports 8985 / 8992 through the fixed path.
- `bash -n` passes on both scripts; the only shellcheck items are pre-existing (the zsh expansion line, the no-shebang sourced file, an unused var).
- End to end: the dev server started successfully on the worktree's own port 8985.

## Migration note

Existing worktrees stuck on a clobbered suffix keep it until they pull this change (the old script re-clobbers on every mise invocation). Afterwards, delete `.git/worktrees/<name>/tuist-dev-instance` and re-bootstrap to pick a fresh unique suffix; `server`'s `mise run install` creates the new per-worktree database when missing.