### PR TITLE
feat(server, infra): make runner pool allocation and cold-boot risk observable

### DIFF
--- a/infra/grafana-dashboards/runners.json
+++ b/infra/grafana-dashboards/runners.json
@@ -39,6 +39,39 @@
           "type": "datasource"
         },
         {
+          "current": {
+            "selected": true,
+            "text": "production",
+            "value": "production"
+          },
+          "hide": 0,
+          "includeAll": false,
+          "label": "Environment",
+          "multi": false,
+          "name": "env",
+          "options": [
+            {
+              "selected": true,
+              "text": "production",
+              "value": "production"
+            },
+            {
+              "selected": false,
+              "text": "canary",
+              "value": "canary"
+            },
+            {
+              "selected": false,
+              "text": "staging",
+              "value": "staging"
+            }
+          ],
+          "query": "production,canary,staging",
+          "queryValue": "",
+          "skipUrlSync": false,
+          "type": "custom"
+        },
+        {
           "allValue": ".*",
           "current": {
             "selected": true,
@@ -139,7 +172,7 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "sum(sum by (platform) (label_replace(max by (fleet) (tuist_runners_queue_length{fleet=~\".*$platform.*\"}), \"platform\", \"$1\", \"fleet\", \".*runner-pool-(linux|macos).*\")))",
+            "expr": "sum(sum by (platform) (label_replace(max by (fleet) (tuist_runners_queue_length{fleet=~\".*$platform.*\", env=\"$env\"}), \"platform\", \"$1\", \"fleet\", \".*runner-pool-(linux|macos).*\")))",
             "instant": true,
             "refId": "A"
           }
@@ -198,7 +231,7 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "sum(max by (fleet) (tuist_runners_claims_count{lifecycle_state=\"claimed\"}))",
+            "expr": "sum(max by (fleet) (tuist_runners_claims_count{lifecycle_state=\"claimed\", env=\"$env\"}))",
             "instant": true,
             "refId": "A"
           }
@@ -249,7 +282,7 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "sum(max by (fleet) (tuist_runners_claims_count{lifecycle_state=\"running\"}))",
+            "expr": "sum(max by (fleet) (tuist_runners_claims_count{lifecycle_state=\"running\", env=\"$env\"}))",
             "instant": true,
             "refId": "A"
           }
@@ -300,7 +333,7 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "sum(max by (fleet) (tuist_runners_pool_replicas_desired))",
+            "expr": "sum(max by (fleet) (tuist_runners_pool_replicas_desired{env=\"$env\"}))",
             "instant": true,
             "refId": "A"
           }
@@ -651,14 +684,14 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "sum by (platform) (label_replace(max by (fleet) (tuist_runners_pool_replicas_desired{fleet=~\".*$platform.*\"}), \"platform\", \"$1\", \"fleet\", \".*runner-pool-(linux|macos).*\"))",
+            "expr": "sum by (platform) (label_replace(max by (fleet) (tuist_runners_pool_replicas_desired{fleet=~\".*$platform.*\", env=\"$env\"}), \"platform\", \"$1\", \"fleet\", \".*runner-pool-(linux|macos).*\"))",
             "legendFormat": "{{platform}} desired",
             "refId": "A"
           },
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "sum by (platform) (label_replace(kube_pod_status_phase{namespace=\"tuist-runners\", phase=~\"Pending|Running\", pod=~\".*runner-pool-(linux|macos).*\", pod=~\".*$platform.*\"}, \"platform\", \"$1\", \"pod\", \".*runner-pool-(linux|macos).*\"))",
+            "expr": "sum by (platform) (label_replace(kube_pod_status_phase{namespace=\"tuist-runners\", phase=~\"Pending|Running\", pod=~\".*runner-pool-(linux|macos).*\", pod=~\".*$platform.*\", env=\"$env\"}, \"platform\", \"$1\", \"pod\", \".*runner-pool-(linux|macos).*\"))",
             "legendFormat": "{{platform}} alive",
             "refId": "B"
           }
@@ -758,7 +791,7 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "sum by (platform) (label_replace(max by (fleet) (tuist_runners_claims_count{fleet=~\".*$platform.*\", lifecycle_state=\"running\"}), \"platform\", \"$1\", \"fleet\", \".*runner-pool-(linux|macos).*\")) / clamp_min(sum by (platform) (label_replace(max by (fleet) (tuist_runners_pool_replicas_max{fleet=~\".*$platform.*\"}), \"platform\", \"$1\", \"fleet\", \".*runner-pool-(linux|macos).*\")), 1)",
+            "expr": "sum by (platform) (label_replace(max by (fleet) (tuist_runners_claims_count{fleet=~\".*$platform.*\", lifecycle_state=\"running\", env=\"$env\"}), \"platform\", \"$1\", \"fleet\", \".*runner-pool-(linux|macos).*\")) / clamp_min(sum by (platform) (label_replace(max by (fleet) (tuist_runners_pool_replicas_max{fleet=~\".*$platform.*\", env=\"$env\"}), \"platform\", \"$1\", \"fleet\", \".*runner-pool-(linux|macos).*\")), 1)",
             "legendFormat": "{{platform}}",
             "refId": "A"
           }
@@ -812,7 +845,7 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "sum by (platform) (label_replace(max by (fleet) (tuist_runners_queue_length{fleet=~\".*$platform.*\"}), \"platform\", \"$1\", \"fleet\", \".*runner-pool-(linux|macos).*\"))",
+            "expr": "sum by (platform) (label_replace(max by (fleet) (tuist_runners_queue_length{fleet=~\".*$platform.*\", env=\"$env\"}), \"platform\", \"$1\", \"fleet\", \".*runner-pool-(linux|macos).*\"))",
             "legendFormat": "{{platform}}",
             "refId": "A"
           }
@@ -866,7 +899,7 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "sum by (platform) (label_replace(max by (fleet) (tuist_runners_claims_count{fleet=~\".*$platform.*\", lifecycle_state=\"running\"}), \"platform\", \"$1\", \"fleet\", \".*runner-pool-(linux|macos).*\"))",
+            "expr": "sum by (platform) (label_replace(max by (fleet) (tuist_runners_claims_count{fleet=~\".*$platform.*\", lifecycle_state=\"running\", env=\"$env\"}), \"platform\", \"$1\", \"fleet\", \".*runner-pool-(linux|macos).*\"))",
             "legendFormat": "{{platform}}",
             "refId": "A"
           }
@@ -1122,13 +1155,130 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "sum(kube_pod_status_unschedulable{namespace=\"tuist-runners\"}) or vector(0)",
+            "expr": "sum(kube_pod_status_unschedulable{namespace=\"tuist-runners\", env=\"$env\"}) or vector(0)",
             "instant": true,
             "refId": "A"
           }
         ],
         "title": "Unscheduled",
         "type": "stat"
+      },
+      {
+        "collapsed": false,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 48
+        },
+        "id": 130,
+        "panels": [],
+        "title": "Allocation (cold-boot risk)",
+        "type": "row"
+      },
+      {
+        "datasource": "$datasource",
+        "description": "Warm Pods the fleet allocator WANTED to keep ready (minWarmPoolFloor above real load) but could not fund because the shared bare-metal node pool was memory-contended. Emitted by the runners-controller (tuist_runners_autoscaler_warm_deficit_replicas). 0 = warm pool fully funded. A sustained non-zero value means this shape's warm buffer is reaped toward its raw load, so the next demand burst pays cold-start. This is the leading indicator for cold boots that alive/desired can't surface.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "drawStyle": "line",
+              "fillOpacity": 20,
+              "lineWidth": 2,
+              "stacking": {
+                "mode": "normal"
+              }
+            },
+            "min": 0,
+            "unit": "short"
+          }
+        },
+        "gridPos": {
+          "h": 9,
+          "w": 12,
+          "x": 0,
+          "y": 49
+        },
+        "id": 131,
+        "options": {
+          "legend": {
+            "calcs": ["max", "lastNotNull"],
+            "displayMode": "table",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "multi",
+            "sort": "desc"
+          }
+        },
+        "targets": [
+          {
+            "datasource": "$datasource",
+            "editorMode": "code",
+            "expr": "sum by (platform) (label_replace(max by (pool) (tuist_runners_autoscaler_warm_deficit_replicas{pool=~\".*$platform.*\", env=\"$env\"}), \"platform\", \"$1\", \"pool\", \".*runner-pool-(linux|macos).*\"))",
+            "legendFormat": "{{platform}}",
+            "refId": "A"
+          }
+        ],
+        "title": "Warm-pool deficit (unfunded warm replicas) by platform",
+        "type": "timeseries"
+      },
+      {
+        "datasource": "$datasource",
+        "description": "What the autoscaler wanted (target = DesiredReplicas, the pool's full ask incl. warm floor + p95 headroom) vs what the fleet allocator granted (allocated = spec.replicas) after splitting shared capacity across sibling shapes. A persistent gap is the squeeze: warm pool and headroom yielding to other pools' real queued work under contention. Both emitted by the runners-controller.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "drawStyle": "line",
+              "fillOpacity": 10,
+              "lineWidth": 2
+            },
+            "min": 0,
+            "unit": "short"
+          }
+        },
+        "gridPos": {
+          "h": 9,
+          "w": 12,
+          "x": 12,
+          "y": 49
+        },
+        "id": 132,
+        "options": {
+          "legend": {
+            "calcs": ["lastNotNull"],
+            "displayMode": "table",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "multi",
+            "sort": "desc"
+          }
+        },
+        "targets": [
+          {
+            "datasource": "$datasource",
+            "editorMode": "code",
+            "expr": "sum by (platform) (label_replace(max by (pool) (tuist_runners_autoscaler_target_replicas{pool=~\".*$platform.*\", env=\"$env\"}), \"platform\", \"$1\", \"pool\", \".*runner-pool-(linux|macos).*\"))",
+            "legendFormat": "{{platform}} target",
+            "refId": "A"
+          },
+          {
+            "datasource": "$datasource",
+            "editorMode": "code",
+            "expr": "sum by (platform) (label_replace(max by (pool) (tuist_runners_autoscaler_allocated_replicas{pool=~\".*$platform.*\", env=\"$env\"}), \"platform\", \"$1\", \"pool\", \".*runner-pool-(linux|macos).*\"))",
+            "legendFormat": "{{platform}} allocated",
+            "refId": "B"
+          }
+        ],
+        "title": "Autoscaler target vs allocated by platform",
+        "type": "timeseries"
       }
     ]
   }

--- a/infra/runners-controller/AGENTS.md
+++ b/infra/runners-controller/AGENTS.md
@@ -66,6 +66,20 @@ independent workqueues:
   scale-down. A pool with an unrecognised `OS` (or without autoscaling
   enabled) skips the allocator entirely.
 
+  **Allocation observability (`internal/metrics`).** Each tick the
+  reconciler publishes the squeeze on the controller's existing
+  `--metrics-bind-address` endpoint, per `pool`:
+  `tuist_runners_autoscaler_target_replicas` (the pool's full ask, pre-
+  allocation), `..._allocated_replicas` (what it got = `spec.replicas`),
+  `..._min_warm_floor_replicas` (configured `minWarmPoolFloor`), and
+  `..._warm_deficit_replicas` — the warm floor the allocator wanted to
+  fund but couldn't under contention (`max(0, min(load+floor, target) −
+  allocated)`, clamped so load starvation isn't counted). The deficit is
+  the leading indicator for cold boots: alive-vs-desired only shows the
+  pool converging to the *already-squeezed* target, never the squeeze
+  itself. Series are dropped (`metrics.Clear`) when a pool is deleted or
+  opts out of autoscaling.
+
   Pod-level autoscaling only — bare-metal Host count is operator-
   managed via the CAPI cluster topology, since Hetzner Robot hosts
   are monthly-billed and can't be auto-ordered. To grow capacity,

--- a/infra/runners-controller/controllers/autoscaler_controller.go
+++ b/infra/runners-controller/controllers/autoscaler_controller.go
@@ -15,6 +15,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	tuistv1 "github.com/tuist/tuist/infra/runners-controller/api/v1alpha1"
+	"github.com/tuist/tuist/infra/runners-controller/internal/metrics"
 	"github.com/tuist/tuist/infra/runners-controller/internal/scaling"
 )
 
@@ -100,6 +101,9 @@ func (r *AutoscalerReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	pool := &tuistv1.RunnerPool{}
 	if err := r.Get(ctx, req.NamespacedName, pool); err != nil {
 		if apierrors.IsNotFound(err) {
+			// Pool is gone — drop its allocation series so the
+			// dashboard doesn't keep charting a stale warm deficit.
+			metrics.Clear(req.Name)
 			return ctrl.Result{}, nil
 		}
 		return ctrl.Result{}, err
@@ -109,6 +113,7 @@ func (r *AutoscalerReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		// Pool is being drained by the RunnerPoolReconciler's
 		// finalizer. Don't patch replicas on a Terminating CR, and
 		// don't requeue — the drain owns its lifecycle from here.
+		metrics.Clear(pool.Name)
 		return ctrl.Result{}, nil
 	}
 
@@ -116,6 +121,7 @@ func (r *AutoscalerReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		// Pool opted out (or never opted in) — don't requeue.
 		// A future patch that flips `enabled` true will trigger
 		// a fresh reconcile via the For() watch.
+		metrics.Clear(pool.Name)
 		return ctrl.Result{}, nil
 	}
 
@@ -217,7 +223,28 @@ func (r *AutoscalerReconciler) desiredForPool(
 	logger logr.Logger,
 ) int32 {
 	perPool := scaling.DesiredReplicas(signals, knobs)
+	allocated := r.allocate(ctx, pool, signals, knobs, perPool, logger)
 
+	// Publish the allocation outcome so the warm-pool squeeze (target
+	// reaped down to `allocated` under fleet contention) is observable
+	// on its own series, not inferred from alive-vs-desired.
+	metrics.RecordAllocation(pool.Name, signals.Claimed+signals.Queued, knobs.MinWarmPoolFloor, perPool, allocated)
+
+	return allocated
+}
+
+// allocate runs the shared-capacity fleet allocator for `pool`,
+// returning the (possibly squeezed) replica target. Any failure
+// gathering the fleet view falls back to the per-pool target — a
+// node-read blip must never trigger a mass scale-down.
+func (r *AutoscalerReconciler) allocate(
+	ctx context.Context,
+	pool *tuistv1.RunnerPool,
+	signals scaling.Signals,
+	knobs scaling.PolicyKnobs,
+	perPool int32,
+	logger logr.Logger,
+) int32 {
 	if knobs.MaxReplicas <= 0 {
 		return perPool
 	}

--- a/infra/runners-controller/go.mod
+++ b/infra/runners-controller/go.mod
@@ -3,6 +3,8 @@ module github.com/tuist/tuist/infra/runners-controller
 go 1.25
 
 require (
+	github.com/go-logr/logr v1.4.2
+	github.com/prometheus/client_golang v1.19.1
 	k8s.io/api v0.32.1
 	k8s.io/apimachinery v0.32.1
 	k8s.io/client-go v0.32.0
@@ -17,7 +19,6 @@ require (
 	github.com/evanphx/json-patch/v5 v5.9.0 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.7.0 // indirect
-	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-logr/zapr v1.3.0 // indirect
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
 	github.com/go-openapi/jsonreference v0.20.2 // indirect
@@ -36,7 +37,6 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/prometheus/client_golang v1.19.1 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.55.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect

--- a/infra/runners-controller/internal/metrics/metrics.go
+++ b/infra/runners-controller/internal/metrics/metrics.go
@@ -1,0 +1,118 @@
+// Package metrics holds the runners-controller's custom Prometheus
+// collectors. They register against controller-runtime's global
+// registry, so they're scraped on the manager's existing
+// `--metrics-bind-address` endpoint alongside the controller-runtime
+// and Go runtime metrics.
+//
+// These exist because alive/desired replica counts only show the pool
+// converging to its target — they can't reveal that the target itself
+// was squeezed below the configured warm floor by the fleet allocator.
+// That squeeze is the leading indicator for cold boots, so it gets its
+// own series.
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+const poolLabel = "pool"
+
+var (
+	// target is the per-pool replica count the autoscaler policy wants
+	// BEFORE the fleet allocator apportions shared capacity
+	// (scaling.DesiredReplicas). Pair with `allocated` to see how much
+	// of the ask the shared-capacity allocator could fund this tick.
+	target = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "tuist_runners_autoscaler_target_replicas",
+		Help: "Per-pool replicas the autoscaler policy wants before fleet-capacity allocation (DesiredReplicas).",
+	}, []string{poolLabel})
+
+	// allocated is what the pool got after AllocateFleet split the
+	// shared capacity domain across sibling shapes — the value patched
+	// to spec.replicas. Equals `target` when the pool isn't contended
+	// (or the allocator fell back to the per-pool policy).
+	allocated = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "tuist_runners_autoscaler_allocated_replicas",
+		Help: "Per-pool replicas granted after fleet-capacity allocation (patched to spec.replicas).",
+	}, []string{poolLabel})
+
+	// warmDeficitReplicas is the warm-pool capacity the allocator
+	// wanted to fund for this pool but couldn't because the shared
+	// domain was contended: the part of (load + minWarmPoolFloor),
+	// capped at the pool's target, left unfunded. >0 means the shape's
+	// warm buffer is being reaped toward its raw load, so the next
+	// demand burst on it pays cold-start. This is the leading indicator
+	// for cold boots that alive/desired can't surface.
+	warmDeficitReplicas = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "tuist_runners_autoscaler_warm_deficit_replicas",
+		Help: "Warm-pool replicas the fleet allocator could not fund under capacity contention (cold-boot risk).",
+	}, []string{poolLabel})
+
+	// minWarmFloor mirrors the configured
+	// spec.autoscaling.minWarmPoolFloor so a dashboard can chart
+	// configured-vs-funded warm pool from a single source.
+	minWarmFloor = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "tuist_runners_autoscaler_min_warm_floor_replicas",
+		Help: "Configured minWarmPoolFloor per pool (spec.autoscaling.minWarmPoolFloor).",
+	}, []string{poolLabel})
+)
+
+func init() {
+	ctrlmetrics.Registry.MustRegister(target, allocated, warmDeficitReplicas, minWarmFloor)
+}
+
+// RecordAllocation publishes one pool's allocation outcome for this
+// reconcile tick. `load` is claimed+queued, `floor` is
+// minWarmPoolFloor, `targetReplicas` is the pre-allocation
+// DesiredReplicas, `allocatedReplicas` is the post-allocation value
+// patched to spec.replicas.
+func RecordAllocation(pool string, load, floor, targetReplicas, allocatedReplicas int32) {
+	target.WithLabelValues(pool).Set(float64(targetReplicas))
+	allocated.WithLabelValues(pool).Set(float64(allocatedReplicas))
+	minWarmFloor.WithLabelValues(pool).Set(float64(floor))
+	warmDeficitReplicas.WithLabelValues(pool).Set(float64(warmDeficit(load, floor, targetReplicas, allocatedReplicas)))
+}
+
+// Clear drops a pool's series so a deleted (or opted-out) pool stops
+// reporting stale gauges. Safe to call for an unknown pool.
+func Clear(pool string) {
+	target.DeleteLabelValues(pool)
+	allocated.DeleteLabelValues(pool)
+	warmDeficitReplicas.DeleteLabelValues(pool)
+	minWarmFloor.DeleteLabelValues(pool)
+}
+
+// warmDeficit is the warm-pool capacity the fleet allocator wanted to
+// fund but couldn't under contention. The allocator funds real load
+// (claimed+queued) inviolably, then the warm floor above it; the floor
+// is what yields first. So the deficit is the floor portion — (load +
+// floor), capped at the pool's target — left unfunded by `allocated`.
+// Headroom (the speculative p95 buffer above the floor) is excluded:
+// only the warm *guarantee* counts toward cold-boot risk.
+func warmDeficit(load, floor, target, allocated int32) int32 {
+	if load < 0 {
+		load = 0
+	}
+	if floor < 0 {
+		floor = 0
+	}
+	want := load + floor
+	if want > target {
+		want = target
+	}
+	// Measure only the warm-floor shortfall. The allocator funds load
+	// inviolably, so clamp `allocated` up to `load` first — a
+	// (degenerate) allocated < load is load starvation, a different
+	// signal surfaced by Pending/unschedulable Pods, not warm-pool
+	// reaping.
+	funded := allocated
+	if funded < load {
+		funded = load
+	}
+	deficit := want - funded
+	if deficit < 0 {
+		deficit = 0
+	}
+	return deficit
+}

--- a/infra/runners-controller/internal/metrics/metrics_test.go
+++ b/infra/runners-controller/internal/metrics/metrics_test.go
@@ -1,0 +1,54 @@
+package metrics
+
+import "testing"
+
+func TestWarmDeficit(t *testing.T) {
+	tests := []struct {
+		name                    string
+		load, floor, tgt, alloc int32
+		want                    int32
+	}{
+		{
+			// Fully funded: allocated covers load + floor, no deficit.
+			name: "fully funded", load: 17, floor: 30, tgt: 60, alloc: 60, want: 0,
+		},
+		{
+			// Squeezed to load + partial floor: only 9 of the 30-pod
+			// floor funded (the June 2026 linux-2vcpu-8gb incident shape).
+			name: "floor reaped to load+9", load: 17, floor: 30, tgt: 60, alloc: 26, want: 21,
+		},
+		{
+			// Allocated below even raw load (shouldn't happen — load is
+			// inviolable — but the metric must never go negative).
+			name: "allocated below load clamps at floor want", load: 17, floor: 30, tgt: 60, alloc: 10, want: 30,
+		},
+		{
+			// Headroom (p95 buffer above the floor) is NOT counted: target
+			// 60 but only load+floor = 47 is the warm guarantee, and that's
+			// funded, so deficit is 0 even though allocated < target.
+			name: "headroom reaped is not a deficit", load: 17, floor: 30, tgt: 60, alloc: 47, want: 0,
+		},
+		{
+			// No floor configured: nothing speculative to reap.
+			name: "zero floor", load: 5, floor: 0, tgt: 5, alloc: 5, want: 0,
+		},
+		{
+			// want is capped at target: a floor larger than the target
+			// can't manufacture a deficit beyond what was asked for.
+			name: "want capped at target", load: 0, floor: 30, tgt: 10, alloc: 4, want: 6,
+		},
+		{
+			// Defensive: negative inputs are clamped to 0.
+			name: "negative load clamped", load: -3, floor: 5, tgt: 5, alloc: 5, want: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := warmDeficit(tt.load, tt.floor, tt.tgt, tt.alloc); got != tt.want {
+				t.Errorf("warmDeficit(%d,%d,%d,%d) = %d, want %d",
+					tt.load, tt.floor, tt.tgt, tt.alloc, got, tt.want)
+			}
+		})
+	}
+}

--- a/server/lib/tuist/runners.ex
+++ b/server/lib/tuist/runners.ex
@@ -141,52 +141,77 @@ defmodule Tuist.Runners do
   """
   def dispatch_for_sa(namespace, sa_name) when is_binary(namespace) and is_binary(sa_name) do
     :telemetry.span(Telemetry.event_name_dispatch_request(), %{}, fn ->
-      result = do_dispatch_for_sa(namespace, sa_name)
-      {result, %{outcome: dispatch_outcome(result)}}
+      {result, fleet_name} = do_dispatch_for_sa(namespace, sa_name)
+      {to_caller_result(result), %{outcome: dispatch_outcome(result), fleet: fleet_name || "unknown"}}
     end)
   end
 
+  # Returns `{result, fleet_name}`. `result` carries the *granular*
+  # reason (`:empty`, `:lost_race`, `:pod_in_use`, …) so the dispatch
+  # telemetry can tell "queue was empty" apart from "lost the claim
+  # race" — the old blanket `:no_work_yet` hid that distinction and
+  # made a real dispatch stall indistinguishable from an idle warm
+  # pool polling. `fleet_name` is the resolved pool label (or `nil`
+  # when the SA / label lookup failed) so the dispatch metric is
+  # sliceable per fleet. The web-facing collapse back to `:no_work_yet`
+  # happens in `to_caller_result/1`.
   defp do_dispatch_for_sa(namespace, sa_name) do
     with {:ok, sa} <- K8sClient.get_service_account(namespace, sa_name),
-         {:ok, fleet_name} <- pool_label(sa),
-         :ok <- check_not_stale(namespace, sa_name, fleet_name) do
-      with {:ok, candidate} <- Jobs.pick_queued(fleet_name, []),
-           {:ok, claim} <-
-             Claims.attempt(
-               candidate.workflow_job_id,
-               candidate.account_id,
-               fleet_name,
-               sa_name
-             ) do
-        Jobs.record_claimed(candidate, sa_name, claim.claimed_at)
-        serve_claim(namespace, sa_name, fleet_name, candidate, claim)
-      else
-        {:error, :empty} ->
-          {:error, :no_work_yet}
-
-        {:error, reason} when reason in [:lost_race, :pod_in_use] ->
-          # All transactional-claim outcomes that mean "this poll
-          # gets nothing right now" — collapsed for the caller.
-          # The candidate (if we had one) stays queued in CH for
-          # the next poll on this fleet to pick up.
-          Logger.debug("runners: claim attempt declined",
-            reason: reason,
-            fleet: fleet_name,
-            sa: sa_name
-          )
-
-          {:error, :no_work_yet}
-
-        {:error, reason} ->
-          Logger.warning("runners: dispatch_for_sa failed",
-            reason: inspect(reason),
-            fleet: fleet_name
-          )
-
-          {:error, :no_work_yet}
+         {:ok, fleet_name} <- pool_label(sa) do
+      case check_not_stale(namespace, sa_name, fleet_name) do
+        :ok -> {claim_and_serve(namespace, sa_name, fleet_name), fleet_name}
+        {:error, reason} -> {{:error, reason}, fleet_name}
       end
+    else
+      {:error, reason} -> {{:error, reason}, nil}
     end
   end
+
+  defp claim_and_serve(namespace, sa_name, fleet_name) do
+    with {:ok, candidate} <- Jobs.pick_queued(fleet_name, []),
+         {:ok, claim} <-
+           Claims.attempt(
+             candidate.workflow_job_id,
+             candidate.account_id,
+             fleet_name,
+             sa_name
+           ) do
+      Jobs.record_claimed(candidate, sa_name, claim.claimed_at)
+      serve_claim(namespace, sa_name, fleet_name, candidate, claim)
+    else
+      {:error, :empty} ->
+        {:error, :empty}
+
+      {:error, reason} when reason in [:lost_race, :pod_in_use] ->
+        # Lost the Postgres claim race (or the Pod already holds a
+        # claim). The candidate stays queued in CH for the next poll.
+        Logger.debug("runners: claim attempt declined",
+          reason: reason,
+          fleet: fleet_name,
+          sa: sa_name
+        )
+
+        {:error, reason}
+
+      {:error, reason} ->
+        Logger.warning("runners: dispatch_for_sa failed",
+          reason: inspect(reason),
+          fleet: fleet_name
+        )
+
+        {:error, reason}
+    end
+  end
+
+  # The dispatch poll loop only needs "nothing for you this tick", so
+  # the empty-queue / claim-contention family collapses to the single
+  # `:no_work_yet` the web layer and the polling Pod already handle.
+  # Every other reason — `:drain`, `:no_pool_label`, `:github_mint_failed`,
+  # … — passes through untouched.
+  defp to_caller_result({:error, reason}) when reason in [:empty, :lost_race, :pod_in_use],
+    do: {:error, :no_work_yet}
+
+  defp to_caller_result(result), do: result
 
   defp dispatch_outcome({:ok, _}), do: "served"
   defp dispatch_outcome({:error, reason}) when is_atom(reason), do: Atom.to_string(reason)

--- a/server/lib/tuist/runners.ex
+++ b/server/lib/tuist/runners.ex
@@ -208,8 +208,7 @@ defmodule Tuist.Runners do
   # `:no_work_yet` the web layer and the polling Pod already handle.
   # Every other reason — `:drain`, `:no_pool_label`, `:github_mint_failed`,
   # … — passes through untouched.
-  defp to_caller_result({:error, reason}) when reason in [:empty, :lost_race, :pod_in_use],
-    do: {:error, :no_work_yet}
+  defp to_caller_result({:error, reason}) when reason in [:empty, :lost_race, :pod_in_use], do: {:error, :no_work_yet}
 
   defp to_caller_result(result), do: result
 

--- a/server/lib/tuist/runners/prom_ex_plugin.ex
+++ b/server/lib/tuist/runners/prom_ex_plugin.ex
@@ -11,9 +11,10 @@ defmodule Tuist.Runners.PromExPlugin do
       `claim`, `running`, `completed`); histograms cover wall-clock
       durations (`queue_time_ms` at claim, `queue_to_running_ms` at
       mint, `run_time_ms` / `total_time_ms` at completion). The
-      dispatch endpoint emits its own latency histogram tagged by
-      outcome so a saturating poll loop is visible separately from
-      a slow CH/PG.
+      dispatch endpoint emits its own count + latency histogram
+      tagged by fleet and outcome so a real dispatch stall on one
+      shape is visible separately from an idle warm pool polling, and
+      separately from a slow CH/PG.
 
     * **Polling metrics.** Three poll loops at a coarse 30s cadence
       query authoritative state and emit gauges: queue length per
@@ -26,9 +27,9 @@ defmodule Tuist.Runners.PromExPlugin do
       boot duration histogram).
 
   Cardinality budget: `fleet` is bounded by the number of
-  RunnerPool CRs (currently 1 — `default`). Per-account fan-out is
-  *not* tagged on event metrics; account-level views are exposed
-  as polled aggregates only.
+  RunnerPool CRs (one per Linux shape + macOS Xcode image, O(10)).
+  Per-account fan-out is *not* tagged on event metrics; account-level
+  views are exposed as polled aggregates only.
   """
 
   use PromEx.Plugin
@@ -170,8 +171,11 @@ defmodule Tuist.Runners.PromExPlugin do
           counter(
             @metric_prefix ++ [:dispatch, :request, :count],
             event_name: Telemetry.event_name_dispatch_request() ++ [:stop],
-            description: "Polling Pod dispatch requests bucketed by outcome.",
-            tags: [:outcome]
+            description:
+              "Polling Pod dispatch requests bucketed by fleet and outcome. " <>
+                "`outcome` is granular: served, drain, empty (queue had nothing), " <>
+                "lost_race / pod_in_use (claim contention), plus SA/label errors.",
+            tags: [:fleet, :outcome]
           ),
           distribution(
             @metric_prefix ++ [:dispatch, :request, :duration, :milliseconds],
@@ -179,7 +183,7 @@ defmodule Tuist.Runners.PromExPlugin do
             measurement: :duration,
             description: "Wall-clock time the dispatch endpoint spent serving a polling Pod.",
             reporter_options: [buckets: @dispatch_duration_buckets],
-            tags: [:outcome],
+            tags: [:fleet, :outcome],
             unit: {:native, :millisecond}
           )
         ]


### PR DESCRIPTION
## What changed

Three coherent changes that make the Tuist-managed runner fleet's **pool allocation** observable and fix two metrics that actively mislead.

### 1. Dispatch telemetry (server)
`Tuist.Runners.dispatch_for_sa/2` collapsed three distinct failure reasons — `:empty` (queue genuinely had nothing), `:lost_race`, and `:pod_in_use` (claim contention) — into a single `:no_work_yet` outcome, and the dispatch metric carried **no `fleet` tag**. That combination makes a real per-shape dispatch stall indistinguishable from an idle warm pool just polling.

- `do_dispatch_for_sa` now returns `{result, fleet_name}` with the granular reason preserved for telemetry. A new `to_caller_result/1` collapses the no-work family back to `:no_work_yet` only at the boundary, so the HTTP contract (204 to the polling Pod) and all existing tests are untouched.
- The dispatch count + latency metrics gain a `:fleet` tag (`prom_ex_plugin.ex`).

Outcomes are now `served / drain / empty / lost_race / pod_in_use / …`, sliceable per fleet.

### 2. New allocation metrics (runners-controller)
alive/desired replicas is a weak signal: it only shows the pool converging to its target, never that the target itself was squeezed below the configured warm floor by the fleet allocator. That squeeze is the leading indicator for cold boots.

New `internal/metrics` package, emitted per pool from `desiredForPool` on the controller's existing metrics endpoint:

| metric | meaning |
| --- | --- |
| `tuist_runners_autoscaler_target_replicas` | the pool's full ask, pre-allocation (DesiredReplicas) |
| `tuist_runners_autoscaler_allocated_replicas` | what the allocator granted (= spec.replicas) |
| `tuist_runners_autoscaler_min_warm_floor_replicas` | configured minWarmPoolFloor |
| `tuist_runners_autoscaler_warm_deficit_replicas` | warm floor the allocator could not fund under contention — the cold-boot leading indicator |

`warm_deficit = max(0, min(load+floor, target) − allocated)`, clamped so load starvation (a separate signal surfaced by Pending/unschedulable Pods) is not miscounted as warm-pool reaping. Series are cleared on pool delete / autoscaling opt-out.

### 3. Dashboard (infra/grafana-dashboards/runners.json)
- Added an `env` template variable (default production) and scoped the headline + capacity selectors with `env="$env"`. This kills the cross-env `max by (fleet)` aliasing: the Helm release name is identical across canary/staging/production, so the fleet label collides and `max by (fleet)` silently merged environments — the root reason a "queued vs running" snapshot looked impossible. Dispatch panels are intentionally left unscoped because that metric's `env` is collapsed to `<aggregated>` by Grafana Cloud Adaptive Metrics.
- New "Allocation (cold-boot risk)" row charting warm deficit and target-vs-allocated by platform.

## Why

This came out of investigating a transient production backlog on the `linux-2vcpu-8gb` shape. The fleet allocator (allocate.go) deliberately reaps a pool's speculative warm floor to fund other pools' real queued work under shared-capacity contention. That tradeoff is sound, but it was invisible — no metric showed the warm floor being squeezed, and the dashboard's env aliasing made the symptom look like a capacity or dispatch bug when it was neither. These changes make the allocation behavior legible and stop the headline tiles from lying.

## Reviewer notes

- The `:no_work_yet` HTTP behavior is unchanged on purpose; only the telemetry outcome is now granular. `to_caller_result/1` is the single collapse point.
- `warm_deficit` excludes headroom (the speculative p95 buffer above the floor) — only the warm guarantee counts toward cold-boot risk. See the new `warmDeficit` table test for the edge cases.
- Adding `fleet` to the dispatch metric raises its series count to fleet × outcome (~O(10) × ~6), still bounded.
- The lagging cold-start *rate* (fraction of claims that waited > ~10s) is derivable from the existing `tuist_runners_job_queue_time_milliseconds` histogram; a panel for it was deliberately not added pending confirmation that `env` survives on that histogram (it may be Adaptive-Metrics-aggregated like the dispatch counter).

## Validation

- runners-controller: `go build`, `go vet`, full `go test`, `gofmt` all clean. Added a `warmDeficit` table test (which caught a real bug — it was counting load starvation as warm deficit; fixed by clamping allocated up to load).
- Dashboard JSON validated (parses; `env` var present; selectors env-scoped).
- Server: both changed files parse clean. A full `mix compile` was **not** run — this git worktree has no `deps/` fetched (separate from the main checkout); CI will compile-verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)