### PR TITLE
fix(server): surface SSO on the self-hosted login page and add a GitHub sign-in lever

### DIFF
--- a/server/lib/tuist/accounts.ex
+++ b/server/lib/tuist/accounts.ex
@@ -1270,6 +1270,16 @@ defmodule Tuist.Accounts do
   def sso_enforced_for_email?(_email), do: false
 
   @doc """
+  Returns true when at least one organization on this instance has an SSO
+  provider configured. Drives whether the login page surfaces the SSO entry
+  point: the generic login form has no email yet, so it can't resolve a single
+  organization and instead asks whether SSO is reachable on the instance at all.
+  """
+  def sso_configured? do
+    Repo.exists?(from(o in Organization, where: not is_nil(o.sso_provider)))
+  end
+
+  @doc """
   Returns true when `user` is a Tuist operator: in dev, or an account whose
   email belongs to the operator email domain
   (`Tuist.Environment.operator_email_domain/0`).

--- a/server/lib/tuist/accounts.ex
+++ b/server/lib/tuist/accounts.ex
@@ -1270,13 +1270,18 @@ defmodule Tuist.Accounts do
   def sso_enforced_for_email?(_email), do: false
 
   @doc """
-  Returns true when at least one organization on this instance has an SSO
-  provider configured. Drives whether the login page surfaces the SSO entry
-  point: the generic login form has no email yet, so it can't resolve a single
-  organization and instead asks whether SSO is reachable on the instance at all.
+  Returns true when at least one organization on this instance has an Okta or
+  generic OAuth2 SSO provider configured. Drives whether the login page surfaces
+  the SSO entry point: the generic login form has no email yet, so it can't
+  resolve a single organization and instead asks whether SSO is reachable on the
+  instance at all.
+
+  Scoped to `:okta`/`:oauth2` because those are the providers the email-based
+  `/users/log_in/sso` flow resolves by domain. Google SSO logs in through the
+  regular Google button instead, so it must not surface a dead-end SSO entry.
   """
   def sso_configured? do
-    Repo.exists?(from(o in Organization, where: not is_nil(o.sso_provider)))
+    Repo.exists?(from(o in Organization, where: o.sso_provider in [:okta, :oauth2]))
   end
 
   @doc """

--- a/server/lib/tuist/environment.ex
+++ b/server/lib/tuist/environment.ex
@@ -658,6 +658,14 @@ defmodule Tuist.Environment do
     github_app_client_id(secrets) != nil and github_app_client_secret(secrets) != nil
   end
 
+  # The GitHub App used for VCS integration shares its client id/secret with
+  # GitHub sign-in, so configuring VCS otherwise forces GitHub onto the login
+  # page. This lever lets a self-hosted operator keep the App while turning the
+  # sign-in method off.
+  def github_auth_enabled? do
+    truthy?(System.get_env("TUIST_GITHUB_AUTH_ENABLED", "1"))
+  end
+
   def github_app_configured?(secrets \\ secrets()) do
     github_app_name(secrets) != nil and github_oauth_configured?(secrets) and
       github_app_private_key(secrets) != nil

--- a/server/lib/tuist_web/controllers/auth_controller.ex
+++ b/server/lib/tuist_web/controllers/auth_controller.ex
@@ -9,6 +9,7 @@ defmodule TuistWeb.AuthController do
   alias Tuist.Accounts.Organization
   alias Tuist.OAuth2.SSOClient
   alias TuistWeb.Authentication
+  alias TuistWeb.Errors.NotFoundError
   alias TuistWeb.Errors.UnauthorizedError
   alias Ueberauth.Auth
   alias Ueberauth.Auth.Credentials
@@ -25,7 +26,7 @@ defmodule TuistWeb.AuthController do
   end
 
   def request(_conn, _params) do
-    raise TuistWeb.Errors.NotFoundError,
+    raise NotFoundError,
           dgettext("dashboard", "The authentication URL is not supported")
   end
 
@@ -134,6 +135,11 @@ defmodule TuistWeb.AuthController do
   end
 
   def callback(%{assigns: %{ueberauth_auth: auth}} = conn, _params) do
+    if auth.provider == :github and not Tuist.Environment.github_auth_enabled?() do
+      raise NotFoundError,
+            dgettext("dashboard", "The authentication URL is not supported")
+    end
+
     complete_oauth_callback(conn, auth)
   end
 

--- a/server/lib/tuist_web/live/user_login_live.ex
+++ b/server/lib/tuist_web/live/user_login_live.ex
@@ -6,6 +6,7 @@ defmodule TuistWeb.UserLoginLive do
   import TuistWeb.AppAuthComponents
 
   alias Phoenix.Flash
+  alias Tuist.Accounts
   alias Tuist.Environment
 
   def mount(_params, _session, socket) do
@@ -16,10 +17,11 @@ defmodule TuistWeb.UserLoginLive do
       socket
       |> assign(:head_title, "#{dgettext("dashboard_auth", "Log in")} · Tuist")
       |> assign(:form, form)
-      |> assign(:github_configured?, Environment.github_oauth_configured?())
+      |> assign(:github_configured?, Environment.github_oauth_configured?() and Environment.github_auth_enabled?())
       |> assign(:google_configured?, Environment.google_oauth_configured?())
       |> assign(:okta_configured?, Environment.okta_oauth_configured?())
       |> assign(:apple_configured?, Environment.apple_oauth_configured?())
+      |> assign(:sso_configured?, Accounts.sso_configured?())
       |> assign(:tuist_hosted?, Environment.tuist_hosted?())
       |> assign(:dev?, Environment.dev?())
 
@@ -50,7 +52,7 @@ defmodule TuistWeb.UserLoginLive do
               {dgettext("dashboard_auth", "Welcome back! Please log in to continue")}
             </span>
           </div>
-          <div :if={oauth_configured?()} data-part="oauth-providers">
+          <div :if={oauth_configured?(assigns)} data-part="oauth-providers">
             <div
               :if={social_oauth_configured?(assigns)}
               data-part="oauth"
@@ -96,7 +98,7 @@ defmodule TuistWeb.UserLoginLive do
                 </:icon_left>
               </.button>
             </div>
-            <div :if={@okta_configured? or @tuist_hosted?} data-part="sso">
+            <div :if={sso_login_available?(assigns)} data-part="sso">
               <.button
                 href={~p"/users/log_in/sso"}
                 variant="secondary"
@@ -109,7 +111,7 @@ defmodule TuistWeb.UserLoginLive do
               </.button>
             </div>
           </div>
-          <.line_divider :if={oauth_configured?()} text="OR" />
+          <.line_divider :if={oauth_configured?(assigns)} text="OR" />
           <.alert
             :if={Flash.get(@flash, :info)}
             id="flash"
@@ -218,10 +220,12 @@ defmodule TuistWeb.UserLoginLive do
     """
   end
 
-  defp oauth_configured? do
-    Environment.github_oauth_configured?() || Environment.google_oauth_configured?() ||
-      Environment.okta_oauth_configured?() || Environment.apple_oauth_configured?() ||
-      Environment.tuist_hosted?()
+  defp oauth_configured?(assigns) do
+    social_oauth_configured?(assigns) or sso_login_available?(assigns)
+  end
+
+  defp sso_login_available?(assigns) do
+    assigns.okta_configured? or assigns.tuist_hosted? or assigns.sso_configured?
   end
 
   defp social_oauth_configured?(assigns) do

--- a/server/priv/docs/en/guides/server/self-host/server.md
+++ b/server/priv/docs/en/guides/server/self-host/server.md
@@ -197,6 +197,7 @@ You'll then need to expose the following environment variables in the environmen
 | --- | --- | --- | --- | --- |
 | `TUIST_GITHUB_APP_CLIENT_ID` | The client ID of the GitHub application | Yes | | `Iv1.a629723000043722` |
 | `TUIST_GITHUB_APP_CLIENT_SECRET` | The client secret of the application | Yes | | `232f972951033b89799b0fd24566a04d83f44ccc` |
+| `TUIST_GITHUB_AUTH_ENABLED` | Whether GitHub can be used to sign in. The GitHub App you configure for platform integrations (PR comments, etc.) shares its client credentials with sign-in, so it otherwise appears as a login option. Set to `0` to keep the App while removing GitHub from the login page | No | `1` | `0` |
 
 #### Google {#google}
 

--- a/server/priv/gettext/dashboard.pot
+++ b/server/priv/gettext/dashboard.pot
@@ -339,7 +339,8 @@ msgstr ""
 msgid "The account you are looking for doesn't exist or has been moved."
 msgstr ""
 
-#: lib/tuist_web/controllers/auth_controller.ex:29
+#: lib/tuist_web/controllers/auth_controller.ex:30
+#: lib/tuist_web/controllers/auth_controller.ex:140
 #, elixir-autogen, elixir-format
 msgid "The authentication URL is not supported"
 msgstr ""
@@ -522,8 +523,8 @@ msgstr ""
 msgid "Authentication failed"
 msgstr ""
 
-#: lib/tuist_web/controllers/auth_controller.ex:343
-#: lib/tuist_web/controllers/auth_controller.ex:515
+#: lib/tuist_web/controllers/auth_controller.ex:349
+#: lib/tuist_web/controllers/auth_controller.ex:521
 #, elixir-autogen, elixir-format
 msgid "Your identity provider denied access. Please ask your organization admin to assign you to the Tuist application."
 msgstr ""
@@ -534,42 +535,42 @@ msgstr ""
 msgid "Shards"
 msgstr ""
 
-#: lib/tuist_web/controllers/auth_controller.ex:352
+#: lib/tuist_web/controllers/auth_controller.ex:358
 #, elixir-autogen, elixir-format
 msgid "Authentication with the identity provider failed. Please try again."
 msgstr ""
 
-#: lib/tuist_web/controllers/auth_controller.ex:599
+#: lib/tuist_web/controllers/auth_controller.ex:605
 #, elixir-autogen, elixir-format
 msgid "Failed to authenticate with the SSO provider. Please try again."
 msgstr ""
 
-#: lib/tuist_web/controllers/auth_controller.ex:494
+#: lib/tuist_web/controllers/auth_controller.ex:500
 #, elixir-autogen, elixir-format
 msgid "SSO is not fully configured for this organization. Ask an organization admin to review the SSO settings."
 msgstr ""
 
-#: lib/tuist_web/controllers/auth_controller.ex:557
+#: lib/tuist_web/controllers/auth_controller.ex:563
 #, elixir-autogen, elixir-format
 msgid "The SSO authorization code is invalid or expired. Please restart the sign-in flow."
 msgstr ""
 
-#: lib/tuist_web/controllers/auth_controller.ex:529
+#: lib/tuist_web/controllers/auth_controller.ex:535
 #, elixir-autogen, elixir-format
 msgid "The SSO provider callback is missing an authorization code. Please restart the sign-in flow."
 msgstr ""
 
-#: lib/tuist_web/controllers/auth_controller.ex:480
+#: lib/tuist_web/controllers/auth_controller.ex:486
 #, elixir-autogen, elixir-format
 msgid "The SSO request is missing an organization identifier. Please start the sign-in flow again from the login page."
 msgstr ""
 
-#: lib/tuist_web/controllers/auth_controller.ex:508
+#: lib/tuist_web/controllers/auth_controller.ex:514
 #, elixir-autogen, elixir-format
 msgid "The SSO response could not be validated because the request state did not match. Please try again."
 msgstr ""
 
-#: lib/tuist_web/controllers/auth_controller.ex:536
+#: lib/tuist_web/controllers/auth_controller.ex:542
 #, elixir-autogen, elixir-format
 msgid "The configured SSO endpoints are invalid. Ask your organization admin to review the SSO settings."
 msgstr ""
@@ -579,52 +580,52 @@ msgstr ""
 msgid "Tuist Ops"
 msgstr ""
 
-#: lib/tuist_web/controllers/auth_controller.ex:543
+#: lib/tuist_web/controllers/auth_controller.ex:549
 #, elixir-autogen, elixir-format
 msgid "Tuist couldn't exchange the authorization code with your identity provider. Ask your organization admin to verify the SSO credentials and callback URL."
 msgstr ""
 
-#: lib/tuist_web/controllers/auth_controller.ex:550
+#: lib/tuist_web/controllers/auth_controller.ex:556
 #, elixir-autogen, elixir-format
 msgid "Tuist couldn't fetch your profile from your identity provider. Ask your organization admin to verify the user info endpoint and configured scopes."
 msgstr ""
 
-#: lib/tuist_web/controllers/auth_controller.ex:592
+#: lib/tuist_web/controllers/auth_controller.ex:598
 #, elixir-autogen, elixir-format
 msgid "We couldn't complete the SSO callback for this request. Please try again."
 msgstr ""
 
-#: lib/tuist_web/controllers/auth_controller.ex:487
+#: lib/tuist_web/controllers/auth_controller.ex:493
 #, elixir-autogen, elixir-format
 msgid "We couldn't find the organization for this SSO request. Please verify that you are using the correct SSO link."
 msgstr ""
 
-#: lib/tuist_web/controllers/auth_controller.ex:585
+#: lib/tuist_web/controllers/auth_controller.ex:591
 #, elixir-autogen, elixir-format
 msgid "We couldn't start the SSO flow for this organization. Please verify the SSO configuration and try again."
 msgstr ""
 
-#: lib/tuist_web/controllers/auth_controller.ex:501
+#: lib/tuist_web/controllers/auth_controller.ex:507
 #, elixir-autogen, elixir-format
 msgid "Your SSO session has expired. Please restart the sign-in flow from the login page."
 msgstr ""
 
-#: lib/tuist_web/controllers/auth_controller.ex:578
+#: lib/tuist_web/controllers/auth_controller.ex:584
 #, elixir-autogen, elixir-format
 msgid "Your Tuist account already exists, but it isn't a member of this organization. Ask an organization admin to add you, then sign in with SSO again."
 msgstr ""
 
-#: lib/tuist_web/controllers/auth_controller.ex:564
+#: lib/tuist_web/controllers/auth_controller.ex:570
 #, elixir-autogen, elixir-format
 msgid "Your identity provider response is missing a stable user identifier. Ask your organization admin to review the user info claims."
 msgstr ""
 
-#: lib/tuist_web/controllers/auth_controller.ex:571
+#: lib/tuist_web/controllers/auth_controller.ex:577
 #, elixir-autogen, elixir-format
 msgid "Your identity provider response is missing an email address. Ask your organization admin to include the email claim."
 msgstr ""
 
-#: lib/tuist_web/controllers/auth_controller.ex:522
+#: lib/tuist_web/controllers/auth_controller.ex:528
 #, elixir-autogen, elixir-format
 msgid "Your identity provider returned an authentication error. Please try again or contact your organization admin."
 msgstr ""

--- a/server/priv/gettext/dashboard_auth.pot
+++ b/server/priv/gettext/dashboard_auth.pot
@@ -121,14 +121,14 @@ msgstr ""
 msgid "Discover how selective testing is reducing your test time."
 msgstr ""
 
-#: lib/tuist_web/live/user_login_live.ex:202
+#: lib/tuist_web/live/user_login_live.ex:204
 #, elixir-autogen, elixir-format
 msgid "Don't have an account?"
 msgstr ""
 
 #: lib/tuist_web/live/sso_login_live.ex:88
 #: lib/tuist_web/live/user_forgot_password_live.ex:54
-#: lib/tuist_web/live/user_login_live.ex:139
+#: lib/tuist_web/live/user_login_live.ex:141
 #: lib/tuist_web/live/user_registration_live.ex:148
 #, elixir-autogen, elixir-format
 msgid "Email address"
@@ -149,7 +149,7 @@ msgstr ""
 msgid "Explore how binary caching is enhancing your build times."
 msgstr ""
 
-#: lib/tuist_web/live/user_login_live.ex:171
+#: lib/tuist_web/live/user_login_live.ex:173
 #, elixir-autogen, elixir-format
 msgid "Forgot password?"
 msgstr ""
@@ -179,21 +179,21 @@ msgstr ""
 msgid "Interested in SSO?"
 msgstr ""
 
-#: lib/tuist_web/live/user_login_live.ex:164
+#: lib/tuist_web/live/user_login_live.ex:166
 #, elixir-autogen, elixir-format
 msgid "Keep me logged in"
 msgstr ""
 
 #: lib/tuist_web/live/sso_login_live.ex:96
-#: lib/tuist_web/live/user_login_live.ex:17
-#: lib/tuist_web/live/user_login_live.ex:177
+#: lib/tuist_web/live/user_login_live.ex:18
+#: lib/tuist_web/live/user_login_live.ex:179
 #: lib/tuist_web/live/user_registration_live.ex:193
 #, elixir-autogen, elixir-format
 msgid "Log in"
 msgstr ""
 
 #: lib/tuist_web/live/sso_login_live.ex:71
-#: lib/tuist_web/live/user_login_live.ex:48
+#: lib/tuist_web/live/user_login_live.ex:50
 #, elixir-autogen, elixir-format
 msgid "Log in to Tuist"
 msgstr ""
@@ -218,7 +218,7 @@ msgstr ""
 msgid "OR"
 msgstr ""
 
-#: lib/tuist_web/live/user_login_live.ex:150
+#: lib/tuist_web/live/user_login_live.ex:152
 #: lib/tuist_web/live/user_registration_live.ex:158
 #, elixir-autogen, elixir-format
 msgid "Password"
@@ -260,7 +260,7 @@ msgstr ""
 msgid "Selective testing"
 msgstr ""
 
-#: lib/tuist_web/live/user_login_live.ex:207
+#: lib/tuist_web/live/user_login_live.ex:209
 #: lib/tuist_web/live/user_registration_live.ex:182
 #: lib/tuist_web/live/user_registration_live.ex:265
 #, elixir-autogen, elixir-format
@@ -287,7 +287,7 @@ msgstr ""
 #: lib/tuist_web/live/sso_login_live.ex:63
 #: lib/tuist_web/live/user_confirmation_live.ex:18
 #: lib/tuist_web/live/user_forgot_password_live.ex:23
-#: lib/tuist_web/live/user_login_live.ex:40
+#: lib/tuist_web/live/user_login_live.ex:42
 #: lib/tuist_web/live/user_registration_live.ex:67
 #: lib/tuist_web/live/user_registration_live.ex:211
 #: lib/tuist_web/live/user_reset_password_live.ex:25
@@ -342,7 +342,7 @@ msgstr ""
 msgid "We'll send a password reset link to your inbox"
 msgstr ""
 
-#: lib/tuist_web/live/user_login_live.ex:50
+#: lib/tuist_web/live/user_login_live.ex:52
 #, elixir-autogen, elixir-format
 msgid "Welcome back! Please log in to continue"
 msgstr ""
@@ -424,7 +424,7 @@ msgstr ""
 msgid "and"
 msgstr ""
 
-#: lib/tuist_web/live/user_login_live.ex:197
+#: lib/tuist_web/live/user_login_live.ex:199
 #, elixir-autogen, elixir-format
 msgid "Log in as test user"
 msgstr ""
@@ -434,7 +434,7 @@ msgstr ""
 msgid "Choose a username for your account"
 msgstr ""
 
-#: lib/tuist_web/live/user_login_live.ex:104
+#: lib/tuist_web/live/user_login_live.ex:106
 #, elixir-autogen, elixir-format
 msgid "Log in with SSO"
 msgstr ""
@@ -444,7 +444,7 @@ msgstr ""
 msgid "No SSO organization is configured for this email. Check the address and ask your organization admin to verify the SSO domain setup."
 msgstr ""
 
-#: lib/tuist_web/controllers/auth_controller.ex:332
+#: lib/tuist_web/controllers/auth_controller.ex:338
 #, elixir-autogen, elixir-format
 msgid "An account with this email already exists. Please log in instead."
 msgstr ""

--- a/server/test/tuist/accounts_test.exs
+++ b/server/test/tuist/accounts_test.exs
@@ -3504,6 +3504,45 @@ defmodule Tuist.AccountsTest do
     end
   end
 
+  describe "sso_configured?/0" do
+    test "returns false when no organization has SSO configured" do
+      AccountsFixtures.organization_fixture()
+
+      refute Accounts.sso_configured?()
+    end
+
+    test "returns true when an organization has Okta SSO configured" do
+      AccountsFixtures.organization_fixture(
+        sso_provider: :okta,
+        sso_organization_id: "company.okta.com",
+        oauth2_client_id: "client-id",
+        oauth2_client_secret: "client-secret"
+      )
+
+      assert Accounts.sso_configured?()
+    end
+
+    test "returns true when an organization has generic OAuth2 SSO configured" do
+      AccountsFixtures.organization_fixture(
+        sso_provider: :oauth2,
+        sso_organization_id: "https://id.company.com",
+        oauth2_client_id: "client-id",
+        oauth2_client_secret: "client-secret",
+        oauth2_authorize_url: "https://id.company.com/authorize",
+        oauth2_token_url: "https://id.company.com/token",
+        oauth2_user_info_url: "https://id.company.com/userinfo"
+      )
+
+      assert Accounts.sso_configured?()
+    end
+
+    test "returns false when the only SSO organization uses Google" do
+      AccountsFixtures.organization_fixture(sso_provider: :google, sso_organization_id: "company.com")
+
+      refute Accounts.sso_configured?()
+    end
+  end
+
   describe "sso_organization_for_user_email/1" do
     test "returns organization when user exists and has okta organization" do
       user = AccountsFixtures.user_fixture()

--- a/server/test/tuist_web/controllers/auth_controller_test.exs
+++ b/server/test/tuist_web/controllers/auth_controller_test.exs
@@ -791,6 +791,23 @@ defmodule TuistWeb.AuthControllerTest do
       assert get_session(conn, :pending_oauth_signup)
     end
 
+    test "rejects the GitHub callback when GitHub auth is disabled", %{conn: conn} do
+      stub(Tuist.Environment, :github_auth_enabled?, fn -> false end)
+
+      auth = %Ueberauth.Auth{
+        provider: :github,
+        uid: "github-uid-123",
+        info: %Info{email: "github-user@example.com"},
+        extra: %{raw_info: %{user: %{}}}
+      }
+
+      conn = conn |> init_test_session(%{}) |> assign(:ueberauth_auth, auth)
+
+      assert_raise TuistWeb.Errors.NotFoundError, fn ->
+        TuistWeb.AuthController.callback(conn, %{})
+      end
+    end
+
     test "logs in existing OAuth user directly", %{conn: conn} do
       # Given: A user with an existing OAuth identity
       user = AccountsFixtures.user_fixture(email: "oauth-user@example.com")

--- a/server/test/tuist_web/live/user_login_live_test.exs
+++ b/server/test/tuist_web/live/user_login_live_test.exs
@@ -51,6 +51,31 @@ defmodule TuistWeb.UserLoginLiveTest do
       assert html =~ "SSO"
     end
 
+    test "renders SSO button if an organization has SSO configured even when not tuist hosted", %{conn: conn} do
+      stub(Tuist.Environment, :okta_oauth_configured?, fn -> false end)
+      stub(Tuist.Environment, :tuist_hosted?, fn -> false end)
+      stub(Tuist.Accounts, :sso_configured?, fn -> true end)
+      {:ok, _lv, html} = live(conn, ~p"/users/log_in")
+
+      assert html =~ "SSO"
+    end
+
+    test "renders GitHub button when GitHub OAuth is configured and GitHub auth is enabled", %{conn: conn} do
+      stub(Tuist.Environment, :github_oauth_configured?, fn -> true end)
+      stub(Tuist.Environment, :github_auth_enabled?, fn -> true end)
+      {:ok, _lv, html} = live(conn, ~p"/users/log_in")
+
+      assert html =~ "GitHub"
+    end
+
+    test "hides GitHub button when GitHub auth is disabled even if GitHub OAuth is configured", %{conn: conn} do
+      stub(Tuist.Environment, :github_oauth_configured?, fn -> true end)
+      stub(Tuist.Environment, :github_auth_enabled?, fn -> false end)
+      {:ok, _lv, html} = live(conn, ~p"/users/log_in")
+
+      refute html =~ "GitHub"
+    end
+
     test "renders email and password fields regardless of mail configuration", %{conn: conn} do
       {:ok, lv, _html} = live(conn, ~p"/users/log_in")
 


### PR DESCRIPTION
> Describe here the purpose of your PR.

Fixes two SSO discrepancies reported by a self-hosted instance running OAuth2 SSO with **Enforce SSO** enabled (and nothing else on the Authentication tab).

## What changed

- **SSO button now appears on the login page.** Added `Accounts.sso_configured?/0` (any organization with an SSO provider) and surfaced the "Log in with SSO" button through a new `sso_login_available?/1` helper in `UserLoginLive`.
- **GitHub sign-in is now a real lever.** Added `Environment.github_auth_enabled?/0` backed by `TUIST_GITHUB_AUTH_ENABLED` (default `1`). Set it to `0` to keep the GitHub App for VCS while removing GitHub as a sign-in method. The button hides **and** the GitHub OAuth callback in `AuthController` is rejected.
- Documented `TUIST_GITHUB_AUTH_ENABLED` in the English self-hosting guide.

## Why

The login page (`/users/log_in`) decided which auth methods to show from **global environment config**, but generic OAuth2 SSO is configured **per-organization** (`sso_provider` on the organization, set in the Authentication tab). On a self-hosted instance with OAuth2 SSO and no global Okta env vars, `okta_oauth_configured? or tuist_hosted?` was false, so the SSO button never rendered — the only way to reach the SSO flow was to type `/users/log_in/sso` by hand. The login form has no email yet so it can't resolve a single org; instead it now asks whether SSO is reachable on the instance at all.

Separately, the GitHub **App** used for VCS integration (PR comments, etc.) shares its `TUIST_GITHUB_APP_CLIENT_ID`/`_SECRET` with GitHub **sign-in** (see `config/runtime.exs` ueberauth Github + `github_oauth_configured?`). Configuring VCS therefore forced a "Log in with GitHub" button onto the login page with no opt-out. Gating sign-in does **not** affect VCS integration, which uses installation tokens / webhooks / the App JWT rather than the user sign-in callback.

## Why this approach over the alternatives

- The GitHub lever defaults to `1`, so existing instances are unchanged; only operators who explicitly want GitHub-for-VCS-without-GitHub-login flip it.
- The lever gates the **callback**, not just the button, so disabling sign-in actually closes the path rather than hiding it cosmetically.
- The **password form is intentionally left in place** when SSO is enforced. Removing it carries a lockout risk if the IdP is unavailable and is ambiguous on multi-org self-hosted instances. Per-org SSO enforcement is already applied at the dashboard boundary by `require_sso_authentication/2`.

## User / developer impact

- Self-hosted instances with per-org OAuth2/Okta SSO now see the SSO button on the login page automatically.
- Self-hosted operators can set `TUIST_GITHUB_AUTH_ENABLED=0` to remove GitHub from the login page while keeping the GitHub App for VCS.
- No change for tuist.dev (still `tuist_hosted?`) or for instances that haven't set the new variable.

### How to test locally

1. Configure an organization with OAuth2 SSO in the Authentication settings tab (no global Okta env vars, `TUIST_HOSTED` unset).
2. Log out and visit `/users/log_in` — the **Log in with SSO** button now appears.
3. Set `TUIST_GITHUB_APP_CLIENT_ID` / `TUIST_GITHUB_APP_CLIENT_SECRET` (as for VCS) and reload — **Log in with GitHub** appears.
4. Set `TUIST_GITHUB_AUTH_ENABLED=0` and reload — the GitHub button is gone, and hitting `/users/auth/github/callback` returns 404.

Automated: `mix test test/tuist_web/live/user_login_live_test.exs test/tuist_web/controllers/auth_controller_test.exs` (48 tests, 0 failures). `mix format` + `mix credo` clean on the touched modules.