### PR TITLE
fix(server): give the xcresult-processor rollout time to replace its Tart VMs

### DIFF
--- a/infra/helm/tuist/templates/xcresult-processor-deployment.yaml
+++ b/infra/helm/tuist/templates/xcresult-processor-deployment.yaml
@@ -11,6 +11,15 @@ metadata:
     app.kubernetes.io/component: xcresult-processor
 spec:
   replicas: {{ .Values.xcresultProcessor.replicaCount }}
+  # maxSurge: 0 (below) replaces one Tart VM at a time: terminate the
+  # old VM to free hostPort 9091, then boot a fresh one. A full macOS
+  # VM teardown + boot routinely overruns the 600s k8s default, which
+  # flips the Deployment to Progress-deadline-exceeded mid-roll. The
+  # deploy's `helm upgrade --atomic` then rolls back the whole release,
+  # so a slow processor image bump (e.g. 0.23.1 -> 0.24.0) blocks every
+  # prod deploy until it lands. Give a single VM cycle ample headroom,
+  # still well under helm's 60m --timeout.
+  progressDeadlineSeconds: 1800
   strategy:
     {{- toYaml .Values.xcresultProcessor.strategy | nindent 4 }}
   selector:


### PR DESCRIPTION
## What

Set `progressDeadlineSeconds: 1800` on the `xcresult-processor` Deployment in the Tuist chart.

## Why

The production deploy ([run 27622525158](https://github.com/tuist/tuist/actions/runs/27622525158/job/81691215332)) has been failing on `helm upgrade --atomic`:

```
Error: UPGRADE FAILED: release tuist failed, and has been rolled back due to
rollback-on-failure being set: resource Deployment/tuist/tuist-tuist-xcresult-processor
not ready. status: Failed, message: Progress deadline exceeded
```

This is not the server change failing — it is the `xcresult-processor` macOS rollout, and `--atomic` drags the whole release (server included) back down with it. It had already failed this way on revisions 210 and 212 the same day.

### Root cause

The deploy resolves component image tags from git tags. This run resolved a **new** xcresult-processor VM image, `0.23.1 -> 0.24.0`, so the Deployment had to replace both macOS pods.

That rollout is `maxSurge: 0 / maxUnavailable: 1` **by design**:

- each pod binds `hostPort: 9091` (single owner of the tart-kubelet metrics forwarder per Mac mini),
- the production fleet has exactly **two** Mac mini nodes,
- a `DoNotSchedule maxSkew: 1` topology spread pins one replica per node.

So there is no spare host to surge onto. The roll terminates one Tart VM to free hostPort 9091, then boots a fresh VM in its place. A full macOS VM teardown + boot routinely overruns the **600s** default `progressDeadlineSeconds`. The new pod sat `FailedScheduling` ("no free ports for the requested pod ports") waiting for the old VM to release 9091, and at ~10 minutes the Deployment flipped to `Progress deadline exceeded`, tripping the atomic rollback.

Consequence: every future processor image bump blocks all prod deploys the same way.

### Why this fix

The rollout is sequential and feasible — there is no surge deadlock, and the rollback proved the fleet can hold two healthy pods. It simply needs more than ten minutes per VM on this fleet. `1800s` gives a single VM teardown→boot→ready cycle generous headroom while staying well under helm's `60m --timeout` (two serial VM cycles still finish comfortably inside it).

`progressDeadlineSeconds` is hardcoded in the template rather than exposed as a value: this Deployment is hard-pinned to `darwin`/`tart` nodes, so every consumer runs it on a slow macOS VM fleet — there is no faster-fleet branch where a shorter deadline would be correct.

## Validation

- `helm template ... --show-only templates/xcresult-processor-deployment.yaml` renders the field in the right place.
- `helm lint` with managed-common + managed-production values passes (0 charts failed).

## Follow-up

Merge, then re-run the production deployment so the `0.24.0` processor roll can complete within the new deadline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)