### PR TITLE
fix(server): add Russian pricing translation guidance

### DIFF
--- a/server/L10N/ru.md
+++ b/server/L10N/ru.md
@@ -1,0 +1,4 @@
+## Russian-specific translation rules
+
+- In pricing and billing contexts, translate "pay as you go" as "платите по мере использования" or "оплачивайте по факту использования". Never use forms of "плакать" such as "плачьте".
+- Translate usage-based pricing as "ценообразование на основе использования" or a shorter natural equivalent when the UI needs concise copy.


### PR DESCRIPTION
Resolves N/A

Adds Russian localization guidance for the server translation pipeline so pricing copy treats "pay as you go" as usage-based billing instead of translating it literally. The override gives preferred Russian wording and explicitly rejects forms of "плакать", which lets the l10n workflow regenerate the Russian `.po` file through `tuistit` instead of manual catalog edits.

### How to test locally

- `git diff --check -- server/L10N/ru.md .github/workflows/l10n.yml server/L10N.md`
