### PR TITLE
fix(cli): support SwiftPM static library artifact bundles

### DIFF
--- a/cli/Sources/TuistLoader/Loaders/SwiftPackageManagerGraphLoader.swift
+++ b/cli/Sources/TuistLoader/Loaders/SwiftPackageManagerGraphLoader.swift
@@ -291,7 +291,11 @@ public struct SwiftPackageManagerGraphLoader: SwiftPackageManagerGraphLoading {
                     packageType: .external(
                         origin: Self.packageOrigin(for: packageInfo.kind),
                         artifactPaths: packageToTargetsToArtifactPaths[packageInfo.name] ?? [:],
-                        packagePrebuilts: packagePrebuilts
+                        packagePrebuilts: packagePrebuilts,
+                        derivedXCFrameworksPath: scratchDirectory.appending(
+                            components: Constants.DerivedDirectory.dependenciesDerivedDirectory,
+                            Constants.DerivedDirectory.dependenciesXCFrameworkDirectory
+                        )
                     ),
                     packageSettings: packageSettings,
                     packageModuleAliases: packageModuleAliases,

--- a/cli/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
+++ b/cli/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
@@ -4,6 +4,7 @@ import Mockable
 import Path
 import ProjectDescription
 import TSCUtility
+import TuistConstants
 import TuistCore
 import TuistLogging
 import TuistRootDirectoryLocator
@@ -84,12 +85,13 @@ public enum PackageType {
     case external(
         origin: ExternalOrigin = .remote,
         artifactPaths: [String: AbsolutePath],
-        packagePrebuilts: [String: [String: SwiftPackageManagerPrebuilt]] = [:]
+        packagePrebuilts: [String: [String: SwiftPackageManagerPrebuilt]] = [:],
+        derivedXCFrameworksPath: AbsolutePath? = nil
     )
 
     fileprivate var includesTestTargets: Bool {
         switch self {
-        case .local, .external(origin: .local, artifactPaths: _, packagePrebuilts: _):
+        case .local, .external(origin: .local, artifactPaths: _, packagePrebuilts: _, derivedXCFrameworksPath: _):
             return true
         case .external:
             return false
@@ -97,14 +99,14 @@ public enum PackageType {
     }
 
     fileprivate var isLocalExternal: Bool {
-        if case .external(origin: .local, artifactPaths: _, packagePrebuilts: _) = self {
+        if case .external(origin: .local, artifactPaths: _, packagePrebuilts: _, derivedXCFrameworksPath: _) = self {
             return true
         }
         return false
     }
 
     fileprivate var isRemoteExternal: Bool {
-        if case .external(origin: .remote, artifactPaths: _, packagePrebuilts: _) = self {
+        if case .external(origin: .remote, artifactPaths: _, packagePrebuilts: _, derivedXCFrameworksPath: _) = self {
             return true
         }
         return false
@@ -114,7 +116,7 @@ public enum PackageType {
         switch self {
         case .local:
             return [:]
-        case let .external(origin: _, artifactPaths: _, packagePrebuilts: packagePrebuilts):
+        case let .external(origin: _, artifactPaths: _, packagePrebuilts: packagePrebuilts, derivedXCFrameworksPath: _):
             return packagePrebuilts
         }
     }
@@ -193,26 +195,38 @@ public struct PackageInfoMapper: PackageInfoMapping {
         packageModuleAliases: [String: [String: String]],
         packageSettings: TuistCore.PackageSettings
     ) async throws -> [String: [ProjectDescription.TargetDependency]] {
-        let targetDependencyToFramework: [String: Path] = try packageInfos.reduce(into: [:]) { result, packageInfo in
-            try packageInfo.value.targets.forEach { target in
-                guard target.type == .binary else { return }
+        var targetDependencyToFramework: [String: Path] = [:]
+        let derivedXCFrameworksPath = path.appending(
+            components: Constants.DerivedDirectory.dependenciesDerivedDirectory,
+            Constants.DerivedDirectory.dependenciesXCFrameworkDirectory
+        )
+        for packageInfo in packageInfos {
+            for target in packageInfo.value.targets {
+                guard target.type == .binary else { continue }
                 if let path = target.path, !path.hasSuffix(".zip") {
                     // local non .zip binary
-                    result[target.name] = .path(
-                        packageToFolder[packageInfo.key]!.appending(try RelativePath(validating: path))
-                            .pathString
+                    targetDependencyToFramework[target.name] = try await binaryArtifactDependencyPath(
+                        targetName: target.name,
+                        packageName: packageInfo.value.name,
+                        artifactPath: packageToFolder[packageInfo.key]!.appending(try RelativePath(validating: path)),
+                        derivedXCFrameworksPath: derivedXCFrameworksPath
                     )
                 }
                 // remote or .zip binaries are checked out by SPM in artifacts/<Package.name>/<Target>.xcframework
                 // or in artifacts/<Package.identity>/<Target>.xcframework when using SPM 5.6 and later
                 else if let artifactPath = packageToTargetsToArtifactPaths[packageInfo.key]?[target.name] {
-                    result[target.name] = .path(artifactPath.pathString)
+                    targetDependencyToFramework[target.name] = try await binaryArtifactDependencyPath(
+                        targetName: target.name,
+                        packageName: packageInfo.value.name,
+                        artifactPath: artifactPath,
+                        derivedXCFrameworksPath: derivedXCFrameworksPath
+                    )
                 }
                 // If the binary path is not present in the `.build/workspace-state.json`, we try to use a default path.
                 // If the target is not used by a downstream target, the generation will ignore a missing binary artifact.
                 // Otherwise, users will get an error that the xcframework was not found.
                 else {
-                    result[target.name] = .path(
+                    targetDependencyToFramework[target.name] = .path(
                         packageToFolder[packageInfo.key]!.appending(
                             components: target.name,
                             "\(target.name).xcframework"
@@ -863,8 +877,8 @@ public struct PackageInfoMapper: PackageInfoMapping {
                 }
             }
 
-            dependencies = try linkerDependencies + target.dependencies.compactMap {
-                switch $0 {
+            for dependency in target.dependencies {
+                switch dependency {
                 case let .product(name: name, package: package, moduleAliases: moduleAliases, condition: condition):
                     if prebuiltEligibleTargets.contains(target.name),
                        let prebuilt = try prebuiltDependency(
@@ -876,9 +890,9 @@ public struct PackageInfoMapper: PackageInfoMapping {
                        )
                     {
                         targetPrebuilts.append(prebuilt)
-                        return nil
+                        continue
                     }
-                    return try mapDependency(
+                    if let dependency = try await mapDependency(
                         name: name,
                         targetPackage: package,
                         sourceTargetName: target.name,
@@ -889,13 +903,15 @@ public struct PackageInfoMapper: PackageInfoMapping {
                         moduleAliases: moduleAliases,
                         dependencyModuleAliases: &dependencyModuleAliases,
                         enabledTraits: enabledTraits
-                    )
+                    ) {
+                        dependencies.append(dependency)
+                    }
                 case let .byName(name: name, condition: condition),
                      let .target(
                          name: name,
                          condition: condition
                      ):
-                    return try mapDependency(
+                    if let dependency = try await mapDependency(
                         name: name,
                         packageInfo: packageInfo,
                         packageType: packageType,
@@ -904,9 +920,12 @@ public struct PackageInfoMapper: PackageInfoMapping {
                         moduleAliases: packageModuleAliases[packageInfo.name],
                         dependencyModuleAliases: &dependencyModuleAliases,
                         enabledTraits: enabledTraits
-                    )
+                    ) {
+                        dependencies.append(dependency)
+                    }
                 }
             }
+            dependencies = linkerDependencies + dependencies
         }
 
         let targetName = packageModuleAliases[packageInfo.name]?[target.name] ?? target.name
@@ -996,7 +1015,7 @@ public struct PackageInfoMapper: PackageInfoMapping {
         moduleAliases: [String: String]?,
         dependencyModuleAliases: inout [String: String],
         enabledTraits: Set<String>
-    ) throws -> ProjectDescription.TargetDependency? {
+    ) async throws -> ProjectDescription.TargetDependency? {
         // If the condition has traits, check if any of them are enabled
         // If none are enabled, skip this dependency
         if let traits = condition?.traits, !traits.isEmpty {
@@ -1024,11 +1043,22 @@ public struct PackageInfoMapper: PackageInfoMapping {
 
         if let target = packageInfo.targets.first(where: { $0.name == name }) {
             if target.type == .binary,
-               case let .external(origin: _, artifactPaths: artifactPaths, packagePrebuilts: _) = packageType,
+               case let .external(
+                   origin: _,
+                   artifactPaths: artifactPaths,
+                   packagePrebuilts: _,
+                   derivedXCFrameworksPath: derivedXCFrameworksPath
+               ) = packageType,
                let artifactPath = artifactPaths[target.name]
             {
+                let dependencyPath = try await binaryArtifactDependencyPath(
+                    targetName: target.name,
+                    packageName: packageInfo.name,
+                    artifactPath: artifactPath,
+                    derivedXCFrameworksPath: derivedXCFrameworksPath
+                )
                 return .xcframework(
-                    path: .path(artifactPath.pathString),
+                    path: dependencyPath,
                     expectedSignature: packageSettings.expectedSignatures[target.name]
                         .map(ProjectDescription.XCFrameworkSignature.from),
                     status: .required,
@@ -1049,6 +1079,194 @@ public struct PackageInfoMapper: PackageInfoMapping {
                 return .external(name: name, condition: platformCondition)
             }
         }
+    }
+
+    private func binaryArtifactDependencyPath(
+        targetName: String,
+        packageName: String,
+        artifactPath: AbsolutePath,
+        derivedXCFrameworksPath: AbsolutePath?
+    ) async throws -> Path {
+        let xcframeworkPath = try await staticLibraryArtifactBundleXCFrameworkPath(
+            targetName: targetName,
+            packageName: packageName,
+            artifactBundlePath: artifactPath,
+            derivedXCFrameworksPath: derivedXCFrameworksPath
+        ) ?? artifactPath
+        return .path(xcframeworkPath.pathString)
+    }
+
+    private func staticLibraryArtifactBundleXCFrameworkPath(
+        targetName: String,
+        packageName: String,
+        artifactBundlePath: AbsolutePath,
+        derivedXCFrameworksPath: AbsolutePath?
+    ) async throws -> AbsolutePath? {
+        guard artifactBundlePath.extension == "artifactbundle" else { return nil }
+        let infoPath = artifactBundlePath.appending(component: "info.json")
+        guard try await fileSystem.exists(infoPath) else { return nil }
+
+        let info: StaticLibraryArtifactBundleInfo = try await fileSystem.readJSONFile(at: infoPath)
+        guard let artifact = info.artifacts[targetName] ?? (info.artifacts.count == 1 ? info.artifacts.values.first : nil),
+              artifact.type == "staticLibrary"
+        else {
+            return nil
+        }
+
+        guard let derivedXCFrameworksPath = derivedXCFrameworksPath
+            ?? Self.derivedXCFrameworksPath(containingArtifact: artifactBundlePath)
+        else { return nil }
+        let xcframeworkPath = derivedXCFrameworksPath
+            .appending(component: Self.sanitize(targetName: packageName))
+            .appending(component: "\(Self.sanitize(targetName: targetName)).xcframework")
+        let infoPlistPath = xcframeworkPath.appending(component: "Info.plist")
+        if try await fileSystem.exists(infoPlistPath) {
+            return xcframeworkPath
+        }
+
+        if try await fileSystem.exists(xcframeworkPath) {
+            try await fileSystem.remove(xcframeworkPath)
+        }
+        try await fileSystem.makeDirectory(at: xcframeworkPath)
+
+        var libraries: [XCFrameworkInfoPlist.Library] = []
+        var usedIdentifiers: Set<String> = []
+
+        for variant in artifact.variants {
+            let sourceLibrary = artifactBundlePath.appending(try RelativePath(validating: variant.path))
+            let slices = Dictionary(
+                grouping: variant.supportedTriples.compactMap { StaticLibraryArtifactBundleSlice(supportedTriple: $0) },
+                by: \.identifier
+            )
+            for sliceIdentifier in slices.keys.sorted() {
+                let sliceArchitectures = slices[sliceIdentifier, default: []].map(\.architecture).uniqued().sorted(by: {
+                    $0.rawValue < $1.rawValue
+                })
+                guard !sliceArchitectures.isEmpty else { continue }
+
+                let identifier = uniqueXCFrameworkLibraryIdentifier(
+                    preferredIdentifier: sourceLibrary.parentDirectory.basename,
+                    usedIdentifiers: &usedIdentifiers
+                )
+                let slicePath = xcframeworkPath.appending(component: identifier)
+                try await fileSystem.makeDirectory(at: slicePath)
+                try await fileSystem.createSymbolicLink(
+                    from: slicePath.appending(component: sourceLibrary.basename),
+                    to: sourceLibrary
+                )
+
+                let headersPath = try await linkStaticLibraryArtifactBundleHeaders(
+                    metadata: variant.staticLibraryMetadata,
+                    artifactBundlePath: artifactBundlePath,
+                    slicePath: slicePath
+                )
+
+                libraries.append(XCFrameworkInfoPlist.Library(
+                    identifier: identifier,
+                    path: try RelativePath(validating: sourceLibrary.basename),
+                    headersPath: headersPath,
+                    mergeable: false,
+                    platform: sliceIdentifier.platform,
+                    platformVariant: sliceIdentifier.platformVariant,
+                    architectures: sliceArchitectures
+                ))
+            }
+        }
+
+        guard !libraries.isEmpty else {
+            try await fileSystem.remove(xcframeworkPath)
+            return nil
+        }
+
+        let plistEncoder = PropertyListEncoder()
+        plistEncoder.outputFormat = .xml
+        try await fileSystem.writeAsPlist(
+            XCFrameworkInfoPlist(libraries: libraries),
+            at: infoPlistPath,
+            encoder: plistEncoder
+        )
+        return xcframeworkPath
+    }
+
+    private static func derivedXCFrameworksPath(containingArtifact artifactPath: AbsolutePath) -> AbsolutePath? {
+        var current = artifactPath
+        while current != .root {
+            if current.basename == "artifacts" {
+                return current.parentDirectory.appending(
+                    components: Constants.DerivedDirectory.dependenciesDerivedDirectory,
+                    Constants.DerivedDirectory.dependenciesXCFrameworkDirectory
+                )
+            }
+            current = current.parentDirectory
+        }
+        return nil
+    }
+
+    private func linkStaticLibraryArtifactBundleHeaders(
+        metadata: StaticLibraryArtifactBundleInfo.Artifact.Variant.StaticLibraryMetadata?,
+        artifactBundlePath: AbsolutePath,
+        slicePath: AbsolutePath
+    ) async throws -> RelativePath? {
+        let headersPath = slicePath.appending(component: "Headers")
+        var linkedHeaders = false
+
+        for headerPath in metadata?.headerPaths ?? [] {
+            let sourceHeaderPath = artifactBundlePath.appending(try RelativePath(validating: headerPath))
+            if !linkedHeaders {
+                try await fileSystem.makeDirectory(at: headersPath)
+                linkedHeaders = true
+            }
+
+            if try await fileSystem.exists(sourceHeaderPath, isDirectory: true) {
+                for header in try await fileSystem.contentsOfDirectory(sourceHeaderPath) {
+                    try await linkStaticLibraryArtifactBundleHeader(
+                        from: header,
+                        to: headersPath.appending(component: header.basename)
+                    )
+                }
+            } else {
+                try await linkStaticLibraryArtifactBundleHeader(
+                    from: sourceHeaderPath,
+                    to: headersPath.appending(component: sourceHeaderPath.basename)
+                )
+            }
+        }
+
+        if let moduleMapPath = metadata?.moduleMapPath {
+            let sourceModuleMapPath = artifactBundlePath.appending(try RelativePath(validating: moduleMapPath))
+            if !linkedHeaders {
+                try await fileSystem.makeDirectory(at: headersPath)
+                linkedHeaders = true
+            }
+            try await linkStaticLibraryArtifactBundleHeader(
+                from: sourceModuleMapPath,
+                to: headersPath.appending(component: sourceModuleMapPath.basename)
+            )
+        }
+
+        return linkedHeaders ? try RelativePath(validating: "Headers") : nil
+    }
+
+    private func linkStaticLibraryArtifactBundleHeader(
+        from sourcePath: AbsolutePath,
+        to destinationPath: AbsolutePath
+    ) async throws {
+        guard try await !fileSystem.exists(destinationPath) else { return }
+        try await fileSystem.createSymbolicLink(from: destinationPath, to: sourcePath)
+    }
+
+    private func uniqueXCFrameworkLibraryIdentifier(
+        preferredIdentifier: String,
+        usedIdentifiers: inout Set<String>
+    ) -> String {
+        var identifier = preferredIdentifier
+        var suffix = 1
+        while usedIdentifiers.contains(identifier) {
+            suffix += 1
+            identifier = "\(preferredIdentifier)-\(suffix)"
+        }
+        usedIdentifiers.insert(identifier)
+        return identifier
     }
 
     /// Returns a union of products' destinations.
@@ -1108,6 +1326,119 @@ public struct PackageInfoMapper: PackageInfoMapping {
                 return []
             }
         }
+    }
+}
+
+private struct StaticLibraryArtifactBundleInfo: Decodable {
+    let artifacts: [String: Artifact]
+
+    struct Artifact: Decodable {
+        let type: String
+        let variants: [Variant]
+
+        struct Variant: Decodable {
+            let path: String
+            let supportedTriples: [String]
+            let staticLibraryMetadata: StaticLibraryMetadata?
+
+            struct StaticLibraryMetadata: Decodable {
+                let headerPaths: [String]
+                let moduleMapPath: String?
+
+                private enum CodingKeys: String, CodingKey {
+                    case headerPaths
+                    case moduleMapPath
+                }
+
+                init(from decoder: Decoder) throws {
+                    let container = try decoder.container(keyedBy: CodingKeys.self)
+                    headerPaths = try container.decodeIfPresent([String].self, forKey: .headerPaths) ?? []
+                    moduleMapPath = try container.decodeIfPresent(String.self, forKey: .moduleMapPath)
+                }
+            }
+        }
+    }
+}
+
+private struct StaticLibraryArtifactBundleSlice: Hashable, Comparable {
+    let platform: XCFrameworkInfoPlist.Library.Platform
+    let platformVariant: XCFrameworkInfoPlist.Library.PlatformVariant?
+    let architecture: BinaryArchitecture
+
+    var identifier: StaticLibraryArtifactBundleSliceIdentifier {
+        StaticLibraryArtifactBundleSliceIdentifier(platform: platform, platformVariant: platformVariant)
+    }
+
+    init?(supportedTriple: String) {
+        let components = supportedTriple.split(separator: "-").map(String.init)
+        guard let architectureName = components.first,
+              let architecture = BinaryArchitecture(rawValue: architectureName)
+        else {
+            return nil
+        }
+
+        let lowercasedTriple = supportedTriple.lowercased()
+        let platform: XCFrameworkInfoPlist.Library.Platform
+        let platformVariant: XCFrameworkInfoPlist.Library.PlatformVariant?
+
+        if lowercasedTriple.contains("-apple-ios-macabi") {
+            platform = .iOS
+            platformVariant = .maccatalyst
+        } else if lowercasedTriple.contains("-apple-ios-simulator") {
+            platform = .iOS
+            platformVariant = .simulator
+        } else if lowercasedTriple.contains("-apple-ios") {
+            platform = .iOS
+            platformVariant = nil
+        } else if lowercasedTriple.contains("-apple-macos") {
+            platform = .macOS
+            platformVariant = nil
+        } else if lowercasedTriple.contains("-apple-tvos-simulator") {
+            platform = .tvOS
+            platformVariant = .simulator
+        } else if lowercasedTriple.contains("-apple-tvos") {
+            platform = .tvOS
+            platformVariant = nil
+        } else if lowercasedTriple.contains("-apple-watchos-simulator") {
+            platform = .watchOS
+            platformVariant = .simulator
+        } else if lowercasedTriple.contains("-apple-watchos") {
+            platform = .watchOS
+            platformVariant = nil
+        } else if lowercasedTriple.contains("-apple-xros-simulator") {
+            platform = .visionOS
+            platformVariant = .simulator
+        } else if lowercasedTriple.contains("-apple-xros") {
+            platform = .visionOS
+            platformVariant = nil
+        } else {
+            return nil
+        }
+
+        self.platform = platform
+        self.platformVariant = platformVariant
+        self.architecture = architecture
+    }
+
+    static func < (lhs: StaticLibraryArtifactBundleSlice, rhs: StaticLibraryArtifactBundleSlice) -> Bool {
+        lhs.sortKey < rhs.sortKey
+    }
+
+    private var sortKey: String {
+        "\(platform.rawValue)-\(platformVariant?.rawValue ?? "")-\(architecture.rawValue)"
+    }
+}
+
+private struct StaticLibraryArtifactBundleSliceIdentifier: Hashable, Comparable {
+    let platform: XCFrameworkInfoPlist.Library.Platform
+    let platformVariant: XCFrameworkInfoPlist.Library.PlatformVariant?
+
+    static func < (lhs: StaticLibraryArtifactBundleSliceIdentifier, rhs: StaticLibraryArtifactBundleSliceIdentifier) -> Bool {
+        lhs.sortKey < rhs.sortKey
+    }
+
+    private var sortKey: String {
+        "\(platform.rawValue)-\(platformVariant?.rawValue ?? "")"
     }
 }
 

--- a/cli/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
+++ b/cli/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
@@ -1106,7 +1106,8 @@ public struct PackageInfoMapper: PackageInfoMapping {
         let infoPath = artifactBundlePath.appending(component: "info.json")
         guard try await fileSystem.exists(infoPath) else { return nil }
 
-        let info: StaticLibraryArtifactBundleInfo = try await fileSystem.readJSONFile(at: infoPath)
+        let infoData = try await fileSystem.readFile(at: infoPath)
+        let info = try JSONDecoder().decode(StaticLibraryArtifactBundleInfo.self, from: infoData)
         guard let artifact = info.artifacts[targetName] ?? (info.artifacts.count == 1 ? info.artifacts.values.first : nil),
               artifact.type == "staticLibrary"
         else {
@@ -1116,9 +1117,14 @@ public struct PackageInfoMapper: PackageInfoMapping {
         guard let derivedXCFrameworksPath = derivedXCFrameworksPath
             ?? Self.derivedXCFrameworksPath(containingArtifact: artifactBundlePath)
         else { return nil }
+        let contentHasher = ContentHasher()
+        let sourceFingerprint = try contentHasher.hash([
+            artifactBundlePath.pathString,
+            contentHasher.hash(infoData),
+        ])
         let xcframeworkPath = derivedXCFrameworksPath
             .appending(component: Self.sanitize(targetName: packageName))
-            .appending(component: "\(Self.sanitize(targetName: targetName)).xcframework")
+            .appending(component: "\(Self.sanitize(targetName: targetName))-\(sourceFingerprint).xcframework")
         let infoPlistPath = xcframeworkPath.appending(component: "Info.plist")
         if try await fileSystem.exists(infoPlistPath) {
             return xcframeworkPath

--- a/cli/Sources/XcodeGraph/Sources/XcodeGraph/Models/XCFrameworkInfoPlist.swift
+++ b/cli/Sources/XcodeGraph/Sources/XcodeGraph/Models/XCFrameworkInfoPlist.swift
@@ -5,6 +5,8 @@ import Path
 public struct XCFrameworkInfoPlist: Codable, Hashable, Equatable, Sendable {
     private enum CodingKeys: String, CodingKey {
         case libraries = "AvailableLibraries"
+        case bundlePackageType = "CFBundlePackageType"
+        case formatVersion = "XCFrameworkFormatVersion"
     }
 
     /// It represents a library inside an .xcframework
@@ -25,6 +27,7 @@ public struct XCFrameworkInfoPlist: Codable, Hashable, Equatable, Sendable {
         private enum CodingKeys: String, CodingKey {
             case identifier = "LibraryIdentifier"
             case path = "LibraryPath"
+            case binaryPath = "BinaryPath"
             case headersPath = "HeadersPath"
             case platform = "SupportedPlatform"
             case platformVariant = "SupportedPlatformVariant"
@@ -61,6 +64,7 @@ public struct XCFrameworkInfoPlist: Codable, Hashable, Equatable, Sendable {
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(identifier, forKey: .identifier)
             try container.encode(path, forKey: .path)
+            try container.encode(binaryPath, forKey: .binaryPath)
             try container.encodeIfPresent(headersPath, forKey: .headersPath)
             try container.encode(mergeable, forKey: .mergeable)
             try container.encode(architectures, forKey: .architectures)
@@ -84,6 +88,16 @@ public struct XCFrameworkInfoPlist: Codable, Hashable, Equatable, Sendable {
             self.platform = platform
             self.platformVariant = platformVariant
             self.architectures = architectures
+        }
+
+        private var binaryPath: RelativePath {
+            get throws {
+                if path.extension == "framework" {
+                    try RelativePath(validating: "\(path.pathString)/\(path.basenameWithoutExt)")
+                } else {
+                    path
+                }
+            }
         }
 
         public init(from decoder: Decoder) throws {
@@ -126,6 +140,18 @@ public struct XCFrameworkInfoPlist: Codable, Hashable, Equatable, Sendable {
 
     public init(libraries: [Library]) {
         self.libraries = libraries
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        libraries = try container.decode([Library].self, forKey: .libraries)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(libraries, forKey: .libraries)
+        try container.encode("XFWK", forKey: .bundlePackageType)
+        try container.encode("1.0", forKey: .formatVersion)
     }
 
     #if DEBUG

--- a/cli/Tests/TuistLoaderTests/Loaders/SwiftPackageManagerGraphLoaderTests.swift
+++ b/cli/Tests/TuistLoaderTests/Loaders/SwiftPackageManagerGraphLoaderTests.swift
@@ -5,6 +5,7 @@ import Path
 import Synchronization
 import Testing
 import TSCBasic
+import TuistConstants
 import TuistCore
 import TuistNooraTesting
 import TuistSupport
@@ -578,7 +579,12 @@ struct SwiftPackageManagerGraphLoaderTests {
                         packageInfo: .any,
                         path: .any,
                         packageType: .matching { packageType in
-                            if case .external(origin: .remote, artifactPaths: _, packagePrebuilts: _) = packageType {
+                            if case .external(
+                                origin: .remote,
+                                artifactPaths: _,
+                                packagePrebuilts: _,
+                                derivedXCFrameworksPath: _
+                            ) = packageType {
                                 return true
                             }
                             return false
@@ -691,7 +697,8 @@ struct SwiftPackageManagerGraphLoaderTests {
                             guard case let .external(
                                 origin: .remote,
                                 artifactPaths: _,
-                                packagePrebuilts: packagePrebuilts
+                                packagePrebuilts: packagePrebuilts,
+                                derivedXCFrameworksPath: _
                             ) = packageType,
                                 let prebuilt = packagePrebuilts["swift-syntax"]?["SwiftSyntax"]
                             else {
@@ -826,14 +833,25 @@ struct SwiftPackageManagerGraphLoaderTests {
         )
 
         // Then: artifact paths arrive at the mapper resolved against scratchDirectory.
+        let expectedDerivedXCFrameworksPath = temporaryDirectory.appending(
+            components: ".build",
+            Constants.DerivedDirectory.dependenciesDerivedDirectory,
+            Constants.DerivedDirectory.dependenciesXCFrameworkDirectory
+        )
         verify(packageInfoMapper)
             .map(
                 packageInfo: .any,
                 path: .any,
                 packageType: .matching { packageType in
-                    guard case let .external(origin: _, artifactPaths: artifactPaths, packagePrebuilts: _) = packageType
+                    guard case let .external(
+                        origin: _,
+                        artifactPaths: artifactPaths,
+                        packagePrebuilts: _,
+                        derivedXCFrameworksPath: derivedXCFrameworksPath
+                    ) = packageType
                     else { return false }
                     return artifactPaths["Foo"] == expectedArtifactPath
+                        && derivedXCFrameworksPath == expectedDerivedXCFrameworksPath
                 },
                 packageSettings: .any,
                 packageModuleAliases: .any,
@@ -956,7 +974,12 @@ struct SwiftPackageManagerGraphLoaderTests {
                 packageInfo: .any,
                 path: .any,
                 packageType: .matching { packageType in
-                    if case .external(origin: .local, artifactPaths: _, packagePrebuilts: _) = packageType {
+                    if case .external(
+                        origin: .local,
+                        artifactPaths: _,
+                        packagePrebuilts: _,
+                        derivedXCFrameworksPath: _
+                    ) = packageType {
                         return true
                     }
                     return false

--- a/cli/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
+++ b/cli/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
@@ -78,11 +78,11 @@ struct PackageInfoMapperTests {
             components: "artifacts", "Package", "Target_1", "Target_1.artifactbundle"
         )
         try await makeStaticLibraryArtifactBundle(at: artifactBundlePath, targetName: "Target_1")
-        let generatedXCFrameworkPath = basePath.appending(
-            components: Constants.DerivedDirectory.dependenciesDerivedDirectory,
-            Constants.DerivedDirectory.dependenciesXCFrameworkDirectory,
-            "Package",
-            "Target_1.xcframework"
+        let generatedXCFrameworkPath = try await generatedStaticLibraryArtifactBundleXCFrameworkPath(
+            basePath: basePath,
+            packageName: "Package",
+            targetName: "Target_1",
+            artifactBundlePath: artifactBundlePath
         )
 
         let resolvedDependencies = try await subject.resolveExternalDependencies(
@@ -158,6 +158,53 @@ struct PackageInfoMapperTests {
                 generatedXCFrameworkPath.appending(components: "apple-ios-device", "Headers", "Target_1.h")
             ) ==
                 artifactBundlePath.appending(components: "include", "Target_1.h")
+        )
+
+        let updatedInfo = try await fileSystem.readTextFile(at: artifactBundlePath.appending(component: "info.json"))
+            .replacingOccurrences(of: "\"version\": \"1.0.0\"", with: "\"version\": \"2.0.0\"")
+        try await fileSystem.writeText(updatedInfo, at: artifactBundlePath.appending(component: "info.json"))
+        let updatedGeneratedXCFrameworkPath = try await generatedStaticLibraryArtifactBundleXCFrameworkPath(
+            basePath: basePath,
+            packageName: "Package",
+            targetName: "Target_1",
+            artifactBundlePath: artifactBundlePath
+        )
+        #expect(updatedGeneratedXCFrameworkPath != generatedXCFrameworkPath)
+
+        let updatedResolvedDependencies = try await subject.resolveExternalDependencies(
+            path: basePath,
+            packageInfos: [
+                "Package": .test(
+                    name: "Package",
+                    products: [
+                        .init(name: "Product1", type: .library(.automatic), targets: ["Target_1", "Target_2"]),
+                    ],
+                    targets: [
+                        .test(
+                            name: "Target_1",
+                            type: .binary,
+                            url: "https://binary.target.com/target1.artifactbundle.zip"
+                        ),
+                        .test(name: "Target_2"),
+                    ],
+                    platforms: [.ios]
+                ),
+            ],
+            packageToFolder: ["Package": basePath],
+            packageToTargetsToArtifactPaths: ["Package": [
+                "Target_1": artifactBundlePath,
+            ]],
+            packageModuleAliases: [:],
+            packageSettings: .test()
+        )
+        #expect(
+            updatedResolvedDependencies ==
+                [
+                    "Product1": [
+                        .xcframework(path: .path(updatedGeneratedXCFrameworkPath.pathString)),
+                        .project(target: "Target_2", path: .relativeToManifest(basePath.pathString)),
+                    ],
+                ]
         )
     }
 
@@ -3915,11 +3962,11 @@ struct PackageInfoMapperTests {
         try await fileSystem.makeDirectory(at: sourcesPath)
         try await fileSystem.makeDirectory(at: dependenciesPath)
         try await makeStaticLibraryArtifactBundle(at: artifactBundlePath, targetName: "Dependency1")
-        let generatedXCFrameworkPath = basePath.appending(
-            components: Constants.DerivedDirectory.dependenciesDerivedDirectory,
-            Constants.DerivedDirectory.dependenciesXCFrameworkDirectory,
-            "Package",
-            "Dependency1.xcframework"
+        let generatedXCFrameworkPath = try await generatedStaticLibraryArtifactBundleXCFrameworkPath(
+            basePath: basePath,
+            packageName: "Package",
+            targetName: "Dependency1",
+            artifactBundlePath: artifactBundlePath
         )
 
         let project = try await subject.map(
@@ -7540,6 +7587,26 @@ struct PackageInfoMapperTests {
 }
 
 extension PackageInfoMapperTests {
+    private func generatedStaticLibraryArtifactBundleXCFrameworkPath(
+        basePath: AbsolutePath,
+        packageName: String,
+        targetName: String,
+        artifactBundlePath: AbsolutePath
+    ) async throws -> AbsolutePath {
+        let infoData = try await fileSystem.readFile(at: artifactBundlePath.appending(component: "info.json"))
+        let contentHasher = ContentHasher()
+        let sourceFingerprint = try contentHasher.hash([
+            artifactBundlePath.pathString,
+            contentHasher.hash(infoData),
+        ])
+        return basePath.appending(
+            components: Constants.DerivedDirectory.dependenciesDerivedDirectory,
+            Constants.DerivedDirectory.dependenciesXCFrameworkDirectory,
+            packageName,
+            "\(targetName)-\(sourceFingerprint).xcframework"
+        )
+    }
+
     private func makeStaticLibraryArtifactBundle(
         at artifactBundlePath: AbsolutePath,
         targetName: String

--- a/cli/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
+++ b/cli/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
@@ -1,10 +1,12 @@
 import FileSystem
 import FileSystemTesting
+import Foundation
 import Mockable
 import Path
 import ProjectDescription
 import Testing
 import TSCUtility
+import TuistConstants
 import TuistCore
 import TuistSupport
 import XcodeGraph
@@ -63,6 +65,99 @@ struct PackageInfoMapperTests {
                         .project(target: "Target_2", path: .relativeToManifest(basePath.pathString)),
                     ],
                 ]
+        )
+    }
+
+    @Test(
+        .inTemporaryDirectory,
+        .withMockedSwiftVersionProvider
+    ) func resolveDependencies_whenProductContainsStaticLibraryArtifactBundleWithUrl_mapsToGeneratedXcframework(
+    ) async throws {
+        let basePath = try #require(FileSystem.temporaryTestDirectory)
+        let artifactBundlePath = basePath.appending(
+            components: "artifacts", "Package", "Target_1", "Target_1.artifactbundle"
+        )
+        try await makeStaticLibraryArtifactBundle(at: artifactBundlePath, targetName: "Target_1")
+        let generatedXCFrameworkPath = basePath.appending(
+            components: Constants.DerivedDirectory.dependenciesDerivedDirectory,
+            Constants.DerivedDirectory.dependenciesXCFrameworkDirectory,
+            "Package",
+            "Target_1.xcframework"
+        )
+
+        let resolvedDependencies = try await subject.resolveExternalDependencies(
+            path: basePath,
+            packageInfos: [
+                "Package": .test(
+                    name: "Package",
+                    products: [
+                        .init(name: "Product1", type: .library(.automatic), targets: ["Target_1", "Target_2"]),
+                    ],
+                    targets: [
+                        .test(
+                            name: "Target_1",
+                            type: .binary,
+                            url: "https://binary.target.com/target1.artifactbundle.zip"
+                        ),
+                        .test(name: "Target_2"),
+                    ],
+                    platforms: [.ios]
+                ),
+            ],
+            packageToFolder: ["Package": basePath],
+            packageToTargetsToArtifactPaths: ["Package": [
+                "Target_1": artifactBundlePath,
+            ]],
+            packageModuleAliases: [:],
+            packageSettings: .test()
+        )
+
+        #expect(
+            resolvedDependencies ==
+                [
+                    "Product1": [
+                        .xcframework(path: .path(generatedXCFrameworkPath.pathString)),
+                        .project(target: "Target_2", path: .relativeToManifest(basePath.pathString)),
+                    ],
+                ]
+        )
+
+        let infoPlist: XCFrameworkInfoPlist = try await fileSystem.readPlistFile(
+            at: generatedXCFrameworkPath.appending(component: "Info.plist")
+        )
+        let rawInfoPlist = try #require(
+            PropertyListSerialization.propertyList(
+                from: Data(
+                    contentsOf: URL(
+                        fileURLWithPath: generatedXCFrameworkPath.appending(component: "Info.plist").pathString
+                    )
+                ),
+                options: [],
+                format: nil
+            ) as? [String: Any]
+        )
+        let availableLibraries = try #require(rawInfoPlist["AvailableLibraries"] as? [[String: Any]])
+        #expect(infoPlist.libraries.map(\.identifier).sorted() == ["apple-ios-device", "apple-ios-simulator"])
+        #expect(infoPlist.libraries.map(\.headersPath) == [
+            try RelativePath(validating: "Headers"),
+            try RelativePath(validating: "Headers"),
+        ])
+        #expect(rawInfoPlist["CFBundlePackageType"] as? String == "XFWK")
+        #expect(rawInfoPlist["XCFrameworkFormatVersion"] as? String == "1.0")
+        #expect(availableLibraries.allSatisfy { $0["BinaryPath"] as? String == $0["LibraryPath"] as? String })
+        #expect(try await fileSystem.exists(generatedXCFrameworkPath.appending(components: "apple-ios-device", "Headers")))
+        #expect(try await fileSystem.exists(generatedXCFrameworkPath.appending(components: "apple-ios-simulator", "Headers")))
+        #expect(
+            try await fileSystem.resolveSymbolicLink(
+                generatedXCFrameworkPath.appending(components: "apple-ios-device", "libTarget_1.a")
+            ) ==
+                artifactBundlePath.appending(components: "apple-ios-device", "libTarget_1.a")
+        )
+        #expect(
+            try await fileSystem.resolveSymbolicLink(
+                generatedXCFrameworkPath.appending(components: "apple-ios-device", "Headers", "Target_1.h")
+            ) ==
+                artifactBundlePath.appending(components: "include", "Target_1.h")
         )
     }
 
@@ -3810,6 +3905,67 @@ struct PackageInfoMapperTests {
     @Test(
         .inTemporaryDirectory,
         .withMockedSwiftVersionProvider
+    ) func map_whenBinaryTargetStaticLibraryArtifactBundleDependency_mapsToGeneratedXcframework() async throws {
+        let basePath = try #require(FileSystem.temporaryTestDirectory)
+        let sourcesPath = basePath.appending(try RelativePath(validating: "Package/Sources/Target1"))
+        let dependenciesPath = basePath.appending(try RelativePath(validating: "Package/Sources/Dependency1"))
+        let artifactBundlePath = basePath.appending(
+            try RelativePath(validating: "artifacts/Package/Dependency1/Dependency1.artifactbundle")
+        )
+        try await fileSystem.makeDirectory(at: sourcesPath)
+        try await fileSystem.makeDirectory(at: dependenciesPath)
+        try await makeStaticLibraryArtifactBundle(at: artifactBundlePath, targetName: "Dependency1")
+        let generatedXCFrameworkPath = basePath.appending(
+            components: Constants.DerivedDirectory.dependenciesDerivedDirectory,
+            Constants.DerivedDirectory.dependenciesXCFrameworkDirectory,
+            "Package",
+            "Dependency1.xcframework"
+        )
+
+        let project = try await subject.map(
+            package: "Package",
+            basePath: basePath,
+            packageType: .external(artifactPaths: ["Dependency1": artifactBundlePath]),
+            packageInfos: [
+                "Package": .test(
+                    name: "Package",
+                    products: [
+                        .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
+                    ],
+                    targets: [
+                        .test(
+                            name: "Target1",
+                            dependencies: [.target(name: "Dependency1", condition: nil)]
+                        ),
+                        .test(name: "Dependency1", type: .binary),
+                    ],
+                    platforms: [.ios],
+                    cLanguageStandard: nil,
+                    cxxLanguageStandard: nil,
+                    swiftLanguageVersions: nil
+                ),
+            ]
+        )
+        #expect(
+            project ==
+                .testWithDefaultConfigs(
+                    name: "Package",
+                    targets: [
+                        .test(
+                            "Target1",
+                            basePath: basePath,
+                            dependencies: [
+                                .xcframework(path: .path(generatedXCFrameworkPath.pathString)),
+                            ]
+                        ),
+                    ]
+                )
+        )
+    }
+
+    @Test(
+        .inTemporaryDirectory,
+        .withMockedSwiftVersionProvider
     ) func map_whenTargetByNameDependency_mapsToTargetDependency() async throws {
         let basePath = try #require(FileSystem.temporaryTestDirectory)
         let sourcesPath = basePath.appending(try RelativePath(validating: "Package/Sources/Target1"))
@@ -7380,6 +7536,79 @@ struct PackageInfoMapperTests {
         #expect(target.settings?.base["OTHER_SWIFT_FLAGS"] == .array(["$(inherited)"]))
         #expect(target.settings?.base["LIBRARY_SEARCH_PATHS"] == nil)
         #expect(target.settings?.base["OTHER_LDFLAGS"] == nil)
+    }
+}
+
+extension PackageInfoMapperTests {
+    private func makeStaticLibraryArtifactBundle(
+        at artifactBundlePath: AbsolutePath,
+        targetName: String
+    ) async throws {
+        try await fileSystem.makeDirectory(at: artifactBundlePath.appending(component: "include"))
+        try await fileSystem.makeDirectory(at: artifactBundlePath.appending(component: "apple-ios-device"))
+        try await fileSystem.makeDirectory(at: artifactBundlePath.appending(component: "apple-ios-simulator"))
+        try await fileSystem.makeDirectory(at: artifactBundlePath.appending(component: "linux-x86_64"))
+
+        try await fileSystem.writeText(
+            "",
+            at: artifactBundlePath.appending(components: "apple-ios-device", "lib\(targetName).a")
+        )
+        try await fileSystem.writeText(
+            "",
+            at: artifactBundlePath.appending(components: "apple-ios-simulator", "lib\(targetName).a")
+        )
+        try await fileSystem.writeText(
+            "",
+            at: artifactBundlePath.appending(components: "linux-x86_64", "lib\(targetName).a")
+        )
+        try await fileSystem.writeText(
+            "",
+            at: artifactBundlePath.appending(components: "include", "\(targetName).h")
+        )
+        try await fileSystem.writeText(
+            "module \(targetName) { header \"\(targetName).h\" export * }",
+            at: artifactBundlePath.appending(components: "include", "module.modulemap")
+        )
+        try await fileSystem.writeText(
+            """
+            {
+              "schemaVersion": "1.0",
+              "artifacts": {
+                "\(targetName)": {
+                  "type": "staticLibrary",
+                  "version": "1.0.0",
+                  "variants": [
+                    {
+                      "path": "apple-ios-device/lib\(targetName).a",
+                      "supportedTriples": ["arm64-apple-ios"],
+                      "staticLibraryMetadata": {
+                        "headerPaths": ["include"],
+                        "moduleMapPath": "include/module.modulemap"
+                      }
+                    },
+                    {
+                      "path": "apple-ios-simulator/lib\(targetName).a",
+                      "supportedTriples": ["arm64-apple-ios-simulator", "x86_64-apple-ios-simulator"],
+                      "staticLibraryMetadata": {
+                        "headerPaths": ["include"],
+                        "moduleMapPath": "include/module.modulemap"
+                      }
+                    },
+                    {
+                      "path": "linux-x86_64/lib\(targetName).a",
+                      "supportedTriples": ["x86_64-unknown-linux-gnu"],
+                      "staticLibraryMetadata": {
+                        "headerPaths": ["include"],
+                        "moduleMapPath": "include/module.modulemap"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+            """,
+            at: artifactBundlePath.appending(component: "info.json")
+        )
     }
 }
 


### PR DESCRIPTION
## Summary
- Teach `PackageInfoMapper` to recognize SE-0482 `staticLibrary` `.artifactbundle` artifacts instead of treating every binary artifact path as an `.xcframework`.
- Materialize a lightweight XCFramework-compatible wrapper for Apple static-library variants under SwiftPM scratch derived state: `tuist-derived/XCFrameworks/<package>/<target>-<source-fingerprint>.xcframework`.
- Symlink static archives, headers, and module maps from the derived wrapper back to the immutable artifact bundle contents, and emit the XCFramework plist keys Xcode expects.

Fixes #11322.

## Why
`swift-hf-api` ships its Rust backend as an SE-0482 `staticLibrary` artifact bundle. SwiftPM resolves that artifact correctly, but Tuist previously passed the resolved `.artifactbundle` path into the existing XCFramework path, which made generation fail before the project could be produced.

This matters for packages that adopt static library artifact bundles instead of wrapping their Apple binaries as XCFrameworks. They should be usable from Tuist projects without package authors having to republish binaries in a Tuist-specific layout.

## Root Cause
Tuist's SwiftPM mapping code assumed binary artifact paths resolved from the workspace state were XCFrameworks. That was true for the older binary target shape, but SE-0482 adds artifact bundles whose `info.json` can describe static libraries for multiple triples.

When one of those artifact bundle paths reached `XCFrameworkMetadataProvider`, Tuist looked for `Info.plist` inside the `.artifactbundle` and failed with the reported error because the artifact bundle uses `info.json` instead.

## Solution
The mapper now detects static-library artifact bundles by reading `info.json`, filters their variants down to Apple triples, maps those triples to XCFramework library metadata, and returns a generated `.xcframework` path to the rest of the graph.

The generated wrapper is intentionally only a compatibility layer for Xcode and the existing Tuist graph model. Xcode still expects a physical `.xcframework` root with `LibraryIdentifier` directories and relative `LibraryPath` entries, so modeling this purely as arbitrary external paths would bypass the XCFramework contract.

The wrapper is treated as Tuist derived state rather than mutating SwiftPM-owned package or artifact folders. Production mapping passes the SwiftPM scratch-derived location into the mapper, and test-only fallback infers that same location for artifacts under `.../artifacts/...`. The wrapper name includes a source fingerprint derived from the artifact bundle path and `info.json` contents, so artifact updates for the same package and target do not reuse stale generated wrappers. To avoid duplicating potentially large static archives, the wrapper symlinks the archive, headers, and module map back to the artifact bundle contents.

I also updated `XCFrameworkInfoPlist` encoding to include the plist fields produced by `xcodebuild -create-xcframework`. Without those top-level keys, a minimal plist can be decoded by Tuist but rejected by Xcode's `ProcessXCFramework` step.

## User Impact
Projects depending on packages like `swift-hf-api` can run `tuist generate` successfully when the package contains Apple-compatible static library artifact bundle variants.

Existing XCFramework binary targets keep using the previous flow. Non-Apple artifact variants are ignored because they cannot be represented in an Xcode project.

## Validation
- `swift build --replace-scm-with-registry --target TuistLoader`
- `xcodebuild test -workspace Tuist.xcworkspace -scheme Tuist-Workspace -only-testing TuistLoaderTests/PackageInfoMapperTests -only-testing TuistLoaderTests/SwiftPackageManagerGraphLoaderTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" COMPILATION_CACHE_ENABLE_CACHING=NO`
- `xcodebuild -scheme Probe -destination 'generic/platform=macOS' -derivedDataPath DerivedData ARCHS=arm64 ONLY_ACTIVE_ARCH=YES build` on a throwaway Swift package whose XCFramework wrapper symlinked its library and headers to an artifact-bundle-like layout
- `mise run cli:lint --fix`
- `git diff --check`
