### PR TITLE
fix(cli): support SwiftPM warning control settings

### DIFF
--- a/cli/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
+++ b/cli/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
@@ -849,6 +849,7 @@ public struct PackageInfoMapper: PackageInfoMapping {
                         .define
                     ),
                     (.linker, .unsafeFlags), (.linker, .disableWarning), (_, .enableExperimentalFeature), (_, .swiftLanguageMode),
+                    (.linker, .treatAllWarnings), (.linker, .treatWarning), (.linker, .enableWarning),
                     (
                         _,
                         .defaultIsolation
@@ -1480,6 +1481,15 @@ extension ProjectDescription.TargetDependency {
                     .define
                 ),
                 (.linker, .unsafeFlags), (.linker, .disableWarning), (_, .enableExperimentalFeature), (_, .swiftLanguageMode), (
+                    .linker,
+                    .treatAllWarnings
+                ), (
+                    .linker,
+                    .treatWarning
+                ), (
+                    .linker,
+                    .enableWarning
+                ), (
                     _,
                     .defaultIsolation
                 ), (

--- a/cli/Sources/TuistLoader/SwiftPackageManager/SettingsMapper.swift
+++ b/cli/Sources/TuistLoader/SwiftPackageManager/SettingsMapper.swift
@@ -105,6 +105,25 @@ struct SettingsMapper {
                 swiftFlags.append(contentsOf: setting.value)
             case (.swift, .disableWarning):
                 swiftFlags.append("-Wno-\(setting.value[0])")
+            case (.c, .treatAllWarnings):
+                cFlags.append(setting.treatAllWarningsFlag(errorFlag: "-Werror", warningFlag: "-Wno-error"))
+            case (.cxx, .treatAllWarnings):
+                cxxFlags.append(setting.treatAllWarningsFlag(errorFlag: "-Werror", warningFlag: "-Wno-error"))
+            case (.swift, .treatAllWarnings):
+                swiftFlags.append(setting.treatAllWarningsFlag(
+                    errorFlag: "-warnings-as-errors",
+                    warningFlag: "-no-warnings-as-errors"
+                ))
+            case (.c, .treatWarning):
+                cFlags.append(setting.treatWarningFlag(errorPrefix: "-Werror=", warningPrefix: "-Wno-error="))
+            case (.cxx, .treatWarning):
+                cxxFlags.append(setting.treatWarningFlag(errorPrefix: "-Werror=", warningPrefix: "-Wno-error="))
+            case (.swift, .treatWarning):
+                swiftFlags.append(contentsOf: setting.treatSwiftWarningFlags())
+            case (.c, .enableWarning):
+                cFlags.append("-W\(setting.value[0])")
+            case (.cxx, .enableWarning):
+                cxxFlags.append("-W\(setting.value[0])")
             case (.swift, .enableUpcomingFeature):
                 swiftFlags.append("-enable-upcoming-feature \"\(setting.value[0])\"")
             case (.swift, .enableExperimentalFeature):
@@ -132,7 +151,8 @@ struct SettingsMapper {
                  (.swift, .headerSearchPath), (.swift, .linkedFramework), (.swift, .linkedLibrary),
                  (.linker, .headerSearchPath), (.linker, .define), (.linker, .disableWarning),
                  (_, .enableUpcomingFeature), (_, .enableExperimentalFeature), (_, .swiftLanguageMode),
-                 (_, .strictMemorySafety):
+                 (_, .strictMemorySafety), (.linker, .treatAllWarnings), (.linker, .treatWarning),
+                 (.swift, .enableWarning), (.linker, .enableWarning):
                 throw PackageInfoMapperError.unsupportedSetting(setting.tool, setting.name)
             }
         }
@@ -203,5 +223,19 @@ extension PackageInfo.Target.TargetBuildSettingDescription.Setting {
         } else {
             return (name: define, value: "1")
         }
+    }
+
+    fileprivate func treatAllWarningsFlag(errorFlag: String, warningFlag: String) -> String {
+        value[0] == "error" ? errorFlag : warningFlag
+    }
+
+    fileprivate func treatWarningFlag(errorPrefix: String, warningPrefix: String) -> String {
+        let prefix = value[1] == "error" ? errorPrefix : warningPrefix
+        return "\(prefix)\(value[0])"
+    }
+
+    fileprivate func treatSwiftWarningFlags() -> [String] {
+        let flag = value[1] == "error" ? "-Werror" : "-Wwarning"
+        return [flag, value[0]]
     }
 }

--- a/cli/Sources/XcodeGraph/Sources/XcodeGraph/PackageInfo.swift
+++ b/cli/Sources/XcodeGraph/Sources/XcodeGraph/PackageInfo.swift
@@ -585,6 +585,11 @@ public struct PackageInfo: Equatable, Hashable, Codable { // swiftlint:disable:t
                 case linker
             }
 
+            public enum WarningLevel: String, Codable, Hashable {
+                case warning
+                case error
+            }
+
             /// The name of the build setting.
             public enum SettingName: String, Codable, Hashable {
                 case swiftLanguageMode
@@ -599,6 +604,9 @@ public struct PackageInfo: Equatable, Hashable, Codable { // swiftlint:disable:t
                 case defaultIsolation
                 case strictMemorySafety
                 case disableWarning
+                case treatAllWarnings
+                case treatWarning
+                case enableWarning
             }
 
             /// An individual build setting.
@@ -652,6 +660,9 @@ public struct PackageInfo: Equatable, Hashable, Codable { // swiftlint:disable:t
                     case defaultIsolation(String)
                     case strictMemorySafety(String?)
                     case disableWarning(String)
+                    case treatAllWarnings(WarningLevel)
+                    case treatWarning(String, WarningLevel)
+                    case enableWarning(String)
                 }
 
                 enum SettingDecodingError: LocalizedError {
@@ -716,6 +727,15 @@ public struct PackageInfo: Equatable, Hashable, Codable { // swiftlint:disable:t
                         case let .disableWarning(value):
                             name = .disableWarning
                             self.value = [value]
+                        case let .treatAllWarnings(level):
+                            name = .treatAllWarnings
+                            value = [level.rawValue]
+                        case let .treatWarning(warningName, level):
+                            name = .treatWarning
+                            value = [warningName, level.rawValue]
+                        case let .enableWarning(value):
+                            name = .enableWarning
+                            self.value = [value]
                         }
                     } else {
                         // Legacy format - try to decode name
@@ -764,6 +784,12 @@ public struct PackageInfo: Equatable, Hashable, Codable { // swiftlint:disable:t
                         try container.encode(Kind.strictMemorySafety(value.first), forKey: .kind)
                     case .disableWarning:
                         try container.encode(Kind.disableWarning(value.first!), forKey: .kind)
+                    case .treatAllWarnings:
+                        try container.encode(Kind.treatAllWarnings(WarningLevel(rawValue: value.first!)!), forKey: .kind)
+                    case .treatWarning:
+                        try container.encode(Kind.treatWarning(value[0], WarningLevel(rawValue: value[1])!), forKey: .kind)
+                    case .enableWarning:
+                        try container.encode(Kind.enableWarning(value.first!), forKey: .kind)
                     }
                 }
             }

--- a/cli/Tests/TuistLoaderTests/SwiftPackageManager/SettingsMapperTests.swift
+++ b/cli/Tests/TuistLoaderTests/SwiftPackageManager/SettingsMapperTests.swift
@@ -478,6 +478,55 @@ final class SettingsMapperTests: XCTestCase {
             .array(["$(inherited)", "-Wno-unused-parameter"])
         )
     }
+
+    func test_set_warning_control_settings() throws {
+        let settings: [PackageInfo.Target.TargetBuildSettingDescription.Setting] = [
+            .init(tool: .swift, name: .treatAllWarnings, condition: nil, value: ["error"]),
+            .init(tool: .swift, name: .treatAllWarnings, condition: nil, value: ["warning"]),
+            .init(tool: .swift, name: .treatWarning, condition: nil, value: ["DeprecatedDeclaration", "warning"]),
+            .init(tool: .swift, name: .treatWarning, condition: nil, value: ["StrictConcurrency", "error"]),
+            .init(tool: .c, name: .treatAllWarnings, condition: nil, value: ["warning"]),
+            .init(tool: .c, name: .treatAllWarnings, condition: nil, value: ["error"]),
+            .init(tool: .c, name: .treatWarning, condition: nil, value: ["unused-variable", "error"]),
+            .init(tool: .c, name: .treatWarning, condition: nil, value: ["deprecated-declarations", "warning"]),
+            .init(tool: .c, name: .enableWarning, condition: nil, value: ["all"]),
+            .init(tool: .cxx, name: .treatAllWarnings, condition: nil, value: ["error"]),
+            .init(tool: .cxx, name: .treatAllWarnings, condition: nil, value: ["warning"]),
+            .init(tool: .cxx, name: .treatWarning, condition: nil, value: ["unused", "warning"]),
+            .init(tool: .cxx, name: .treatWarning, condition: nil, value: ["deprecated-declarations", "error"]),
+            .init(tool: .cxx, name: .enableWarning, condition: nil, value: ["extra"]),
+        ]
+
+        let mapper = SettingsMapper(
+            headerSearchPaths: [],
+            mainRelativePath: try RelativePath(validating: "path"),
+            settings: settings
+        )
+
+        let resolvedSettings = try mapper.settingsDictionary()
+
+        XCTAssertEqual(
+            resolvedSettings["OTHER_SWIFT_FLAGS"],
+            .array([
+                "$(inherited)", "-warnings-as-errors", "-no-warnings-as-errors",
+                "-Wwarning", "DeprecatedDeclaration", "-Werror", "StrictConcurrency",
+            ])
+        )
+        XCTAssertEqual(
+            resolvedSettings["OTHER_CFLAGS"],
+            .array([
+                "$(inherited)", "-Wno-error", "-Werror",
+                "-Werror=unused-variable", "-Wno-error=deprecated-declarations", "-Wall",
+            ])
+        )
+        XCTAssertEqual(
+            resolvedSettings["OTHER_CPLUSPLUSFLAGS"],
+            .array([
+                "$(inherited)", "-Werror", "-Wno-error",
+                "-Wno-error=unused", "-Werror=deprecated-declarations", "-Wextra",
+            ])
+        )
+    }
 }
 
 // OTHER_LDFLAGS

--- a/cli/Tests/XcodeGraphTests/Models/PackageInfoTests.swift
+++ b/cli/Tests/XcodeGraphTests/Models/PackageInfoTests.swift
@@ -76,4 +76,66 @@ struct PackageInfoTests {
         // Then
         #expect(subject == decoded)
     }
+
+    @Test
+    func packageInfo_decodesWarningControlSettings() throws {
+        let json = """
+        {
+          "name": "Package",
+          "products": [],
+          "targets": [
+            {
+              "name": "Target",
+              "resources": [],
+              "exclude": [],
+              "dependencies": [],
+              "type": "regular",
+              "settings": [
+                {
+                  "kind": {
+                    "treatAllWarnings": {
+                      "_0": "error"
+                    }
+                  },
+                  "tool": "swift"
+                },
+                {
+                  "kind": {
+                    "treatWarning": {
+                      "_0": "DeprecatedDeclaration",
+                      "_1": "warning"
+                    }
+                  },
+                  "tool": "swift"
+                },
+                {
+                  "kind": {
+                    "enableWarning": {
+                      "_0": "all"
+                    }
+                  },
+                  "tool": "c"
+                }
+              ],
+              "checksum": null
+            }
+          ],
+          "traits": [],
+          "dependencies": [],
+          "platforms": [],
+          "toolsVersion": {
+            "_version": "6.4.0"
+          }
+        }
+        """
+        let data = try #require(json.data(using: .utf8))
+
+        let decoded = try JSONDecoder().decode(PackageInfo.self, from: data)
+
+        #expect(decoded.targets.first?.settings == [
+            .init(tool: .swift, name: .treatAllWarnings, condition: nil, value: ["error"]),
+            .init(tool: .swift, name: .treatWarning, condition: nil, value: ["DeprecatedDeclaration", "warning"]),
+            .init(tool: .c, name: .enableWarning, condition: nil, value: ["all"]),
+        ])
+    }
 }


### PR DESCRIPTION
## What changed

- Added `PackageInfo` decoding and encoding support for SwiftPM warning-control target build settings: `treatAllWarnings`, `treatWarning`, and `enableWarning`.
- Mapped the decoded settings into Tuist's generated Xcode settings using the same build setting declarations and flags that SwiftPM uses.
- Updated the package dependency extraction switches so linker-only dependency collection ignores these warning-control settings instead of becoming non-exhaustive.
- Added focused tests for decoding the new SwiftPM `kind` JSON payloads and for mapping every supported Swift, C, and C++ warning-control level.

Fixes #8543.

## Why

Point-Free's `swift-dependencies` 1.13.0 started using newer SwiftPM warning-control APIs in `Package.swift`. With recent SwiftPM output, those APIs appear in `swift package dump-package` as `kind` payloads such as `treatAllWarnings`, `treatWarning`, and `enableWarning`.

Tuist already understands the Xcode 14+ `kind` format for many target build settings, but it did not know these newer warning-control cases. As a result, loading packages that emit them failed during `PackageInfo` decoding before Tuist could map the package graph into Xcode projects.

## Root cause

The decoder in `PackageInfo.Target.TargetBuildSettingDescription.Setting` only modeled the existing SwiftPM build setting cases. When SwiftPM emitted a target setting like:

```json
{
  "kind": {
    "treatAllWarnings": {
      "_0": "error"
    }
  },
  "tool": "swift"
}
```

Tuist could not decode it into a known `SettingName`, which surfaced as a target build setting decoding failure.

## Why this approach

I checked SwiftPM's current `PackageBuilder` implementation and its warning-control tests, then mirrored that behavior in Tuist instead of inventing separate Xcode settings. SwiftPM deliberately lowers these APIs into `OTHER_*FLAGS`, including Swift warning controls, so Tuist now does the same.

| SwiftPM setting | Tool | Xcode setting | Flags |
|---|---|---|---|
| `treatAllWarnings(.error/.warning)` | Swift | `OTHER_SWIFT_FLAGS` | `-warnings-as-errors` / `-no-warnings-as-errors` |
| `treatAllWarnings(.error/.warning)` | C/C++ | `OTHER_CFLAGS` / `OTHER_CPLUSPLUSFLAGS` | `-Werror` / `-Wno-error` |
| `treatWarning(name, .error/.warning)` | Swift | `OTHER_SWIFT_FLAGS` | `-Werror name` / `-Wwarning name` |
| `treatWarning(name, .error/.warning)` | C/C++ | `OTHER_CFLAGS` / `OTHER_CPLUSPLUSFLAGS` | `-Werror=name` / `-Wno-error=name` |
| `enableWarning(name)` | C/C++ only | `OTHER_CFLAGS` / `OTHER_CPLUSPLUSFLAGS` | `-Wname` |

The main alternative would have been to map all-warning controls to broad Xcode warning build settings where possible, but that would diverge from SwiftPM and would not represent the per-warning Swift cases correctly. Keeping the mapping flag-based also preserves the exact warning names coming from package manifests.

## Impact

Users can load packages that use SwiftPM's newer warning-control APIs, including `swift-dependencies` 1.13.0, without Tuist failing during package decoding. The generated Xcode projects preserve the package author's warning behavior for supported Swift, C, and C++ settings.

Unsupported combinations remain explicit. For example, linker warning-control settings and Swift `enableWarning` are still rejected because SwiftPM itself does not support those combinations.

## Testing

- `swiftformat cli/Sources/TuistLoader/SwiftPackageManager/SettingsMapper.swift cli/Tests/TuistLoaderTests/SwiftPackageManager/SettingsMapperTests.swift`
- `git diff --check`
- `xcodebuild test -workspace Tuist.xcworkspace -scheme TuistUnitTests '-only-testing:XcodeGraphTests/PackageInfoTests/packageInfo_decodesWarningControlSettings()' '-only-testing:TuistLoaderTests/SettingsMapperTests/test_set_warning_control_settings' CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""`
