### PR TITLE
feat(kura): enable runner-cache Kura nodes in production and canary

### DIFF
--- a/infra/helm/tuist/values-managed-canary.yaml
+++ b/infra/helm/tuist/values-managed-canary.yaml
@@ -68,8 +68,13 @@ server:
       value: "30"
     - name: TUIST_OTEL_EXPORTER_OTLP_ENDPOINT
       value: http://k8s-monitoring-alloy-receiver.observability.svc.cluster.local:4317
+    # `hetzner-canary-runners` is the private (runner-cache) region:
+    # customers can't select it, the RunnerCache reconciler provisions
+    # nodes on this cluster's `kura` pool for accounts with runner
+    # profiles, and runner dispatch routes their build-cache traffic to
+    # it in-cluster.
     - name: TUIST_KURA_AVAILABLE_REGIONS
-      value: eu-central
+      value: eu-central,hetzner-canary-runners
 
 objectStorage:
   external:

--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -31,9 +31,13 @@ server:
       value: http://k8s-monitoring-alloy-receiver.observability.svc.cluster.local:4317
     # Exposes the managed Kura regions in account settings. Regions now
     # reconcile inside this workload cluster; per-region Kura node pools
-    # decide placement.
+    # decide placement. `hetzner-production-runners` is the private
+    # (runner-cache) region: customers can't select it, the RunnerCache
+    # reconciler provisions nodes on this cluster's `kura` pool for
+    # accounts with runner profiles, and runner dispatch routes their
+    # build-cache traffic to it in-cluster.
     - name: TUIST_KURA_AVAILABLE_REGIONS
-      value: eu-central,us-east,us-west
+      value: eu-central,us-east,us-west,hetzner-production-runners
     # Operator project-access grants. The public key verifies grants
     # signed by ops (private half: TUIST_OPS_BOT 1P `project_access_signing_key`,
     # which MUST be stored before this deploys). The reason-form URL turns

--- a/server/lib/tuist/kura/regions.ex
+++ b/server/lib/tuist/kura/regions.ex
@@ -65,7 +65,7 @@ defmodule Tuist.Kura.Regions do
       node_pool: "kura"
     }
   ]
-  # Private runner-cache regions. Both share the same model: a single-
+  # Private runner-cache regions. They all share the same model: a single-
   # replica `KuraInstance` pinned to a specific node pool of the umbrella
   # cluster, exposed only as a `ClusterIP` Service (no public host, no
   # ingress, no certificate, no LoadBalancer). The runner pool reaches
@@ -73,6 +73,17 @@ defmodule Tuist.Kura.Regions do
   # leaves the cluster. The control plane provisions exactly one of
   # these per account that turns runners on (see `Tuist.Kura.RunnerCache`)
   # and the runner dispatch hands the URL back as `cache_endpoint_url`.
+  #
+  # Each environment reconciles `KuraInstance`s into its own workload
+  # cluster (the provisioner uses the in-cluster Kubernetes API), so the
+  # Hetzner regions differ only by `cluster_id`, which names the instance
+  # (`kura-<handle>-<cluster_id>`) and audits placement. Every environment
+  # pins to its `kura` node pool, co-located with the in-cluster Linux
+  # runner fleet so cache traffic stays on the cluster network. The
+  # Scaleway region is a separate, not-yet-activated target: its
+  # `kura-scw-fr-par` pool lives in a different cluster than the Hetzner
+  # runners, so it needs the dispatch-time cluster-locality check before
+  # any runner can be handed its in-cluster URL.
   @private_region_specs [
     %{
       id: "scw-fr-par-runners",
@@ -81,6 +92,22 @@ defmodule Tuist.Kura.Regions do
       node_pool: "kura-scw-fr-par",
       storage_class: "scw-bssd",
       storage_size: "50Gi"
+    },
+    %{
+      id: "hetzner-production-runners",
+      display_name: "Hetzner production (runner cache)",
+      cluster_id: "production",
+      node_pool: "kura",
+      storage_class: @managed_region_storage_class,
+      storage_size: "20Gi"
+    },
+    %{
+      id: "hetzner-canary-runners",
+      display_name: "Hetzner canary (runner cache)",
+      cluster_id: "canary",
+      node_pool: "kura",
+      storage_class: @managed_region_storage_class,
+      storage_size: "20Gi"
     },
     %{
       id: "hetzner-staging-runners",

--- a/server/test/tuist/kura/regions_test.exs
+++ b/server/test/tuist/kura/regions_test.exs
@@ -176,7 +176,7 @@ defmodule Tuist.Kura.RegionsTest do
   end
 
   describe "private runner-cache regions" do
-    test "scaleway and hetzner-staging runner regions are registered as private" do
+    test "scaleway and hetzner runner regions are registered as private" do
       assert %Regions{provisioner_config: scw_config} = Regions.get("scw-fr-par-runners")
       assert scw_config.private == true
       assert scw_config.storage_class == "scw-bssd"
@@ -185,17 +185,43 @@ defmodule Tuist.Kura.RegionsTest do
       refute Map.has_key?(scw_config, :public_host_template)
       refute Map.has_key?(scw_config, :ingress_class_name)
 
-      assert %Regions{provisioner_config: hetzner_config} = Regions.get("hetzner-staging-runners")
-      assert hetzner_config.private == true
-      assert hetzner_config.storage_class == "hcloud-volumes"
-      assert hetzner_config.replicas == 1
-      assert hetzner_config.node_selector == %{"node.cluster.x-k8s.io/pool" => "kura"}
+      for {id, cluster_id} <- [
+            {"hetzner-production-runners", "production"},
+            {"hetzner-canary-runners", "canary"},
+            {"hetzner-staging-runners", "staging"}
+          ] do
+        assert %Regions{provisioner_config: config} = Regions.get(id)
+        assert config.private == true
+        assert config.cluster_id == cluster_id
+        assert config.storage_class == "hcloud-volumes"
+        assert config.replicas == 1
+        assert config.node_selector == %{"node.cluster.x-k8s.io/pool" => "kura"}
+        refute Map.has_key?(config, :public_host_template)
+        refute Map.has_key?(config, :ingress_class_name)
+      end
+    end
+
+    test "every Hetzner runner-cache region pins a node pool that exists in its cluster manifest" do
+      cluster_manifests = %{
+        "hetzner-production-runners" => "infra/k8s/clusters/cluster-production.yaml",
+        "hetzner-canary-runners" => "infra/k8s/clusters/cluster-canary.yaml",
+        "hetzner-staging-runners" => "infra/k8s/clusters/cluster-staging.yaml"
+      }
+
+      for {id, manifest_path} <- cluster_manifests do
+        node_pool = Regions.get(id).provisioner_config.node_selector["node.cluster.x-k8s.io/pool"]
+
+        assert node_pool in cluster_node_pools(read_repo_yaml(manifest_path)),
+               "#{id} pins node pool #{inspect(node_pool)}, missing from #{manifest_path}"
+      end
     end
   end
 
   describe "private?/1" do
     test "is true only for private regions" do
       assert Regions.private?(Regions.get("scw-fr-par-runners"))
+      assert Regions.private?(Regions.get("hetzner-production-runners"))
+      assert Regions.private?(Regions.get("hetzner-canary-runners"))
       assert Regions.private?(Regions.get("hetzner-staging-runners"))
       refute Regions.private?(Regions.get("eu-central"))
       refute Regions.private?(Regions.get("local-controller"))
@@ -302,6 +328,12 @@ defmodule Tuist.Kura.RegionsTest do
     |> Path.join(path)
     |> File.read!()
     |> YamlElixir.read_from_string!()
+  end
+
+  defp cluster_node_pools(cluster) do
+    cluster
+    |> get_in(["spec", "topology", "workers", "machineDeployments"])
+    |> Enum.map(&get_in(&1, ["metadata", "labels", "node.cluster.x-k8s.io/pool"]))
   end
 
   defp production_node_pool_location(production_cluster, node_pool) do


### PR DESCRIPTION
## What changed

Extends the runner-cache Kura node setup from [#10982](https://github.com/tuist/tuist/pull/10982) (which enabled it for staging only) to **production** and **canary**.

- `server/lib/tuist/kura/regions.ex` — adds two private region specs, `hetzner-production-runners` (`cluster_id: "production"`) and `hetzner-canary-runners` (`cluster_id: "canary"`), mirroring the existing `hetzner-staging-runners`. Both pin to their cluster's `kura` node pool, `hcloud-volumes`, single replica, `ClusterIP`-only (no public host/ingress/certificate).
- `infra/helm/tuist/values-managed-production.yaml` — adds `hetzner-production-runners` to `TUIST_KURA_AVAILABLE_REGIONS`.
- `infra/helm/tuist/values-managed-canary.yaml` — adds `hetzner-canary-runners` to `TUIST_KURA_AVAILABLE_REGIONS`.
- `server/test/tuist/kura/regions_test.exs` — extends coverage to the new regions, plus a guard that each Hetzner runner-cache region pins a node pool that actually exists in its cluster manifest.

## Why

Accounts with runner profiles get an in-cluster Kura build cache co-located with their runner fleet, so build-cache traffic stays on the cluster's internal Service DNS instead of round-tripping the public ingress. Staging proved the topology end-to-end (#10982); this brings the same benefit to the environments that actually serve customer runners.

## Why this approach

Each environment's server reconciles `KuraInstance`s into **its own** workload cluster (the provisioner uses the in-cluster Kubernetes API; `cluster_id` is only an instance-name/audit field). Production and canary clusters already carry the `kura` and `runners-linux` node pools, and Linux fleets pass `fleet_on_cluster_network?`, so the staging topology (Kura cache node + Linux runners in the same Hetzner cluster, reached over `*.svc.cluster.local`) replicates cleanly with no infra changes.

The existing `scw-fr-par-runners` Scaleway region is deliberately **not** the lever here: its `kura-scw-fr-par` pool lives in a different cluster than the Hetzner prod runners, and the dispatch-time cluster-locality check it depends on (the PR's Phase 3) has not landed, so it would never schedule in the Hetzner prod cluster. This is documented in the region catalog comment.

## Rollout / reviewer notes

- **No manual CRD step.** The `spec.private` field is already committed to `infra/helm/tuist/crds/kura.tuist.dev_kurainstances.yaml` (by #10982). The deploy pipeline's `kubectl apply CRDs` step in `server-deployment.yml` re-applies `crds/` on every run, before the helm upgrade, for each leg of the production cascade (canary + production). So the field reaches both clusters automatically on their next deploy. (The "one-time manual apply" mentioned in #10982's description was the author seeding staging out-of-band for live testing, not a pipeline requirement.)
- **Provisioning scope.** Once enabled, the RunnerCache reconciler provisions a single-replica Kura node on the `kura` pool for every account that has runner profiles **and** the `:runners` FunWithFlags gate explicitly enabled. Worth a glance at how many accounts that is in prod/canary before merging.

## Validation

- `mix test test/tuist/kura/regions_test.exs` — 25 tests, 0 failures
- `mix test test/tuist/kura/provisioner/kubernetes_controller_test.exs` — 23 tests, 0 failures
- `mix format --check-formatted` clean on the changed files