### PR TITLE
fix(cli): use SwifterPM artifact scratch path for restores

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "653b4dcf38b38dc03e00ddd5e3196a3813c2c5e91a120df622a1ae7e04adc4b2",
+  "originHash" : "08647d27cacbf70bddfa11e8e3c2c05469f4f5401de80b8cd769e3e0cee42f6e",
   "pins" : [
     {
       "identity" : "1024jp.gzipswift",
@@ -566,8 +566,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tuist/swifterpm",
       "state" : {
-        "revision" : "d48e02d2991e4020764fc93bd5d7189549f34767",
-        "version" : "0.8.12"
+        "revision" : "39bf0b3e02ed4b43f3d61463d76107bec2b3894f",
+        "version" : "0.8.13"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -1819,7 +1819,7 @@ let package = Package(
         .package(id: "swiftlang.swift-docc-plugin", from: "1.4.6"),
         .package(name: "XCResultNIF", path: "server/native/xcresult_nif"),
         .package(id: "stephencelis.SQLite_swift", from: "0.16.0"),
-        .package(url: "https://github.com/tuist/swifterpm", exact: "0.8.12"),
+        .package(url: "https://github.com/tuist/swifterpm", exact: "0.8.13"),
     ],
     targets: targets,
     swiftLanguageModes: [.v5]


### PR DESCRIPTION
## What changed

Updates the Tuist CLI `swifterpm` dependency from `0.8.12` to `0.8.13` and refreshes `Package.resolved` to the `0.8.13` tag revision `39bf0b3e02ed4b43f3d61463d76107bec2b3894f`.

## Why

`0.8.13` includes tuist/swifterpm#42, which fixes restore path handling by using SwiftPM's artifact scratch path. This keeps Tuist on a released `swifterpm` version instead of depending on an unreleased commit.

## Impact

Tuist picks up the upstream restore fix through the normal package release flow.

## Validation

- Confirmed GitHub release `0.8.13` was published on 2026-06-17 and its tag points to `39bf0b3e02ed4b43f3d61463d76107bec2b3894f`, the merge commit for tuist/swifterpm#42.
- Ran `swift package resolve --replace-scm-with-registry`.
- Ran `git diff --check`.
