### PR TITLE
fix(cli): resolve suite shard destination from test plan

### DIFF
--- a/cli/Sources/TuistKit/Services/TestService.swift
+++ b/cli/Sources/TuistKit/Services/TestService.swift
@@ -571,6 +571,7 @@ public struct TestService { // swiftlint:disable:this type_body_length
                 {
                     let shardDestination = try await shardPlanDestination(
                         schemes: schemes,
+                        testPlan: testPlanConfiguration?.testPlan,
                         platform: platform,
                         version: version,
                         deviceName: deviceName,
@@ -1913,11 +1914,15 @@ public struct TestService { // swiftlint:disable:this type_body_length
         return arguments[valueIndex]
     }
 
-    func inferPlatformDestination(schemes: [Scheme], graphTraverser: GraphTraversing) -> String? {
+    func inferPlatformDestination(
+        schemes: [Scheme],
+        testPlan: String? = nil,
+        graphTraverser: GraphTraversing
+    ) -> String? {
         for scheme in schemes {
             guard let target = buildGraphInspector.testableTarget(
                 scheme: scheme,
-                testPlan: nil,
+                testPlan: testPlan,
                 testTargets: [],
                 skipTestTargets: [],
                 graphTraverser: graphTraverser,
@@ -1933,8 +1938,9 @@ public struct TestService { // swiftlint:disable:this type_body_length
         return nil
     }
 
-    private func shardPlanDestination(
+    func shardPlanDestination(
         schemes: [Scheme],
+        testPlan: String?,
         platform: String?,
         version: Version?,
         deviceName: String?,
@@ -1951,6 +1957,7 @@ public struct TestService { // swiftlint:disable:this type_body_length
             let destinationVersion = xcodebuildDestinationParameter("OS", in: explicitDestination)?.version() ?? version
             return await concreteShardPlanDestinationIfAvailable(
                 schemes: schemes,
+                testPlan: testPlan,
                 platform: simulatorPlatform,
                 version: destinationVersion,
                 deviceName: deviceName,
@@ -1962,6 +1969,7 @@ public struct TestService { // swiftlint:disable:this type_body_length
             let buildPlatform = try XcodeGraph.Platform.from(commandLineValue: platform)
             return await concreteShardPlanDestinationIfAvailable(
                 schemes: schemes,
+                testPlan: testPlan,
                 platform: buildPlatform,
                 version: version,
                 deviceName: deviceName,
@@ -1969,13 +1977,18 @@ public struct TestService { // swiftlint:disable:this type_body_length
             ) ?? buildPlatform.xcodebuildPlatformDestination
         }
 
-        if let inferredDestination = inferPlatformDestination(schemes: schemes, graphTraverser: graphTraverser) {
+        if let inferredDestination = inferPlatformDestination(
+            schemes: schemes,
+            testPlan: testPlan,
+            graphTraverser: graphTraverser
+        ) {
             guard let inferredPlatform = xcodebuildPlatform(from: inferredDestination) else {
                 return inferredDestination
             }
 
             return await concreteShardPlanDestinationIfAvailable(
                 schemes: schemes,
+                testPlan: testPlan,
                 platform: inferredPlatform,
                 version: version,
                 deviceName: deviceName,
@@ -1988,6 +2001,7 @@ public struct TestService { // swiftlint:disable:this type_body_length
 
     private func concreteShardPlanDestinationIfAvailable(
         schemes: [Scheme],
+        testPlan: String?,
         platform: XcodeGraph.Platform,
         version: Version?,
         deviceName: String?,
@@ -1996,6 +2010,7 @@ public struct TestService { // swiftlint:disable:this type_body_length
         do {
             return try await concreteShardPlanDestination(
                 schemes: schemes,
+                testPlan: testPlan,
                 platform: platform,
                 version: version,
                 deviceName: deviceName,
@@ -2008,6 +2023,7 @@ public struct TestService { // swiftlint:disable:this type_body_length
 
     private func concreteShardPlanDestination(
         schemes: [Scheme],
+        testPlan: String?,
         platform: XcodeGraph.Platform,
         version: Version?,
         deviceName: String?,
@@ -2016,7 +2032,7 @@ public struct TestService { // swiftlint:disable:this type_body_length
         for scheme in schemes {
             guard let target = buildGraphInspector.testableTarget(
                 scheme: scheme,
-                testPlan: nil,
+                testPlan: testPlan,
                 testTargets: [],
                 skipTestTargets: [],
                 graphTraverser: graphTraverser,

--- a/cli/Tests/TuistKitTests/Services/TestServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/TestServiceTests.swift
@@ -4288,6 +4288,12 @@ final class TestServiceTests: TuistUnitTestCase {
         let testProductsPath: AbsolutePath
     }
 
+    private struct RequestedTestPlanShardDestinationFixture {
+        let graph: Graph
+        let scheme: Scheme
+        let requestedTestPlan: String
+    }
+
     private func givenShardPlanBuild(onShardPlanDestination: ((String?) -> Void)? = nil) async throws -> ShardPlanBuildFixture {
         givenGenerator()
         let path = try temporaryPath()
@@ -4351,6 +4357,77 @@ final class TestServiceTests: TuistUnitTestCase {
             }
 
         return ShardPlanBuildFixture(path: path, testProductsPath: testProductsPath)
+    }
+
+    private func givenRequestedTestPlanShardDestination() -> RequestedTestPlanShardDestinationFixture {
+        let projectPath = AbsolutePath.root.appending(component: "Project")
+        let requestedTestPlan = "TradeMeCombinedTests"
+        let iOSTarget = Target.test(
+            name: "IOSTests",
+            destinations: [.iPhone],
+            product: .unitTests,
+            deploymentTargets: .iOS("16.0")
+        )
+        let macOSTarget = Target.test(
+            name: "MacTests",
+            destinations: [.mac],
+            product: .unitTests,
+            deploymentTargets: .macOS("13.0")
+        )
+        let iOSTargetReference = TargetReference(projectPath: projectPath, name: iOSTarget.name)
+        let macOSTargetReference = TargetReference(projectPath: projectPath, name: macOSTarget.name)
+        let scheme = Scheme.test(
+            name: "ProjectScheme",
+            testAction: TestAction.test(
+                targets: [],
+                testPlans: [
+                    TestPlan(
+                        path: projectPath.appending(component: "MacOnly.xctestplan"),
+                        testTargets: [TestableTarget(target: macOSTargetReference)],
+                        isDefault: false
+                    ),
+                    TestPlan(
+                        path: projectPath.appending(component: "\(requestedTestPlan).xctestplan"),
+                        testTargets: [TestableTarget(target: iOSTargetReference)],
+                        isDefault: true
+                    ),
+                ]
+            )
+        )
+        let project: Project = .test(
+            path: projectPath,
+            targets: [
+                iOSTarget,
+                macOSTarget,
+            ],
+            schemes: [scheme]
+        )
+        let graph: Graph = .test(
+            workspace: .test(schemes: [scheme]),
+            projects: [projectPath: project]
+        )
+        let iOSGraphTarget = GraphTarget(path: projectPath, target: iOSTarget, project: project)
+        let macOSGraphTarget = GraphTarget(path: projectPath, target: macOSTarget, project: project)
+
+        buildGraphInspector.reset()
+        given(buildGraphInspector)
+            .testableTarget(
+                scheme: .any,
+                testPlan: .any,
+                testTargets: .any,
+                skipTestTargets: .any,
+                graphTraverser: .any,
+                action: .any
+            )
+            .willProduce { _, testPlan, _, _, _, _ in
+                return testPlan == requestedTestPlan ? iOSGraphTarget : macOSGraphTarget
+            }
+
+        return RequestedTestPlanShardDestinationFixture(
+            graph: graph,
+            scheme: scheme,
+            requestedTestPlan: requestedTestPlan
+        )
     }
 
     func test_run_testWithoutBuilding_skipsGeneration_whenSelectiveTestingGraphExists() async throws {
@@ -5077,6 +5154,26 @@ final class TestServiceTests: TuistUnitTestCase {
                 archivePath: .value(nil)
             )
             .called(1)
+    }
+
+    func test_shardPlanDestination_usesRequestedTestPlanWhenResolvingSuiteShardPlanningDestination() async throws {
+        // Given
+        let fixture = givenRequestedTestPlanShardDestination()
+        let graphTraverser = GraphTraverser(graph: fixture.graph)
+
+        // When
+        let destination = try await subject.shardPlanDestination(
+            schemes: [fixture.scheme],
+            testPlan: fixture.requestedTestPlan,
+            platform: nil,
+            version: nil,
+            deviceName: "iPhone SE Test",
+            passthroughXcodeBuildArguments: [],
+            graphTraverser: graphTraverser
+        )
+
+        // Then
+        XCTAssertEqual(destination, "platform=iOS Simulator,id=3A8C9673-C1FD-4E33-8EFA-AEEBF43161CC")
     }
 
     func test_run_build_preservesConcreteSimulatorDestinationForSuiteShardPlanning() async throws {


### PR DESCRIPTION
## What changed

- Thread the selected test plan through suite shard destination resolution.
- Use that test plan when:
  - inferring the platform from the scheme's testable target,
  - deciding whether a platform-only simulator destination can be made concrete,
  - resolving the concrete simulator destination/id used by suite-level test enumeration.
- Add focused regression coverage for a scheme with multiple test plans where the first plan is macOS-only and the requested plan is iOS-only.

## Problem

Suite sharding creates a shard plan by enumerating tests from the built `.xctestproducts` bundle. For suite granularity, that enumeration runs through `xcodebuild test-without-building -enumerate-tests`.

Users can invoke Tuist with a device through `tuist test -d`, which gives `build-for-testing` enough information to build for a concrete simulator. However, shard planning later recomputed its own enumeration destination. In the failing case, that later step still produced:

```sh
-destination platform=iOS Simulator
```

instead of a concrete simulator destination such as:

```sh
-destination platform=iOS Simulator,id=<simulator-udid>
```

Xcode can reject the platform-only destination during test enumeration with exit code 70, even though the build itself had enough destination context.

## Root cause

The suite shard destination resolver re-looked up a testable target without carrying the requested test plan.

That matters for schemes with multiple test plans because the resolver can inspect a different test target than the one used for the actual `build-for-testing` invocation. For example:

- `MacOnly.xctestplan` contains a macOS test target.
- `TradeMeCombinedTests.xctestplan` contains the iOS test target requested by the user.
- The build path receives `TradeMeCombinedTests`.
- The shard destination resolver previously looked up a testable target with `testPlan: nil`.

When that lookup sees the wrong target/platform, the resolver cannot reliably convert `platform=iOS Simulator` into `platform=iOS Simulator,id=...`, so suite enumeration falls back to the generic platform destination.

## Fix

The fix keeps the requested test plan attached to the entire shard destination resolution path:

- `TestService.run` now passes `testPlanConfiguration?.testPlan` into `shardPlanDestination`.
- `shardPlanDestination` passes that plan into `inferPlatformDestination`.
- Platform-only destination concretization also passes the plan into `concreteShardPlanDestinationIfAvailable` and `concreteShardPlanDestination`.
- The concrete resolver now asks `buildGraphInspector.testableTarget(..., testPlan: requestedPlan, ...)`, so it resolves the simulator from the same target/platform family as the build.

This keeps already-concrete destinations unchanged, but makes inferred/platform-only iOS simulator destinations concrete when Tuist can resolve a matching simulator.

## Regression coverage

The new regression exercises the resolver with a scheme containing two test plans:

- a first macOS-only plan,
- a requested iOS-only plan.

The test calls the shard destination resolver with the requested iOS plan and no passthrough `-destination`. It expects:

```sh
platform=iOS Simulator,id=3A8C9673-C1FD-4E33-8EFA-AEEBF43161CC
```

Without threading the test plan through the resolver, this setup resolves the wrong plan/target and fails to produce the concrete iOS simulator destination.

## Validation

- `git diff --check` passed.
- Hosted CLI workflow passed on commit `b04d17096a37a7550263c0f67ebdb4f1eb277229`: https://github.com/tuist/tuist/actions/runs/27703309396
- Passing CLI jobs included:
  - `Lint`
  - `SwiftPM Build`
  - macOS `Unit Tests`
  - `Linux Build`
  - `Linux Unit Tests`
  - `Build Acceptance Tests`
  - `Acceptance Tests (0)`
  - `Acceptance Tests (1)`
- The macOS `Unit Tests` job is the important regression signal here because earlier iterations failed in that lane before the final focused resolver coverage passed.

## Local validation notes

- `tuist generate tuist ProjectDescription --no-open` remained blocked locally because external dependencies were not installed.
- `tuist install` remained blocked locally by SwiftPM registry resolution with `duplicate key found: 'Package@swift-5.9.0.swift'`.
- Because local workspace generation was blocked, the hosted CLI workflow was used as the end-to-end validation gate.
