### PR TITLE
chore(cli): track latest Tuist CLI canary in mise via Renovate

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,7 +1,6 @@
 [tools]
     aube = "1.6.2"
-    # Temporarily pinned to 4.192.4 until the SwiftPM deadlock from PR #10729 is released.
-    # See https://github.com/tuist/tuist/issues/10754.
+    # Auto-bumped by Renovate to the latest Tuist CLI release, including canary prereleases.
     tuist = "4.197.1"
     swiftlint = "0.59.1"
     "elixir" = "1.19.5"

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "description": "Non-CLI dependencies are batched on a weekly schedule; the tuist CLI pin overrides this to run at any time (see its packageRule) so the dev-tooling version tracks releases quickly.",
+  "description": "Non-CLI dependencies are batched on a weekly schedule; the tuist CLI pin overrides this (see its custom regex manager + packageRule) to track the latest CLI release, including canary prereleases, at any time so the dev-tooling version tracks releases quickly.",
   "schedule": ["before 6am on monday"],
   "customManagers": [
     {
@@ -40,6 +40,14 @@
       "datasourceTemplate": "maven",
       "depNameTemplate": "dev.tuist:dev.tuist.gradle.plugin",
       "registryUrlTemplate": "https://plugins.gradle.org/m2/"
+    },
+    {
+      "customType": "regex",
+      "description": "Tuist CLI dev-tooling pin in mise.toml. Renovate's native mise manager can't resolve `tuist` (its aqua backend has no built-in short-name mapping), so it never produced a bump. Track tuist/tuist GitHub releases directly; the packageRule turns ignoreUnstable off so the pin rides the latest canary, matching the release-channels flow where main only cuts `X.Y.0-canary.N`.",
+      "fileMatch": ["^mise\\.toml$"],
+      "matchStrings": ["\\n\\s*tuist = \"(?<currentValue>[^\"]+)\""],
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "tuist/tuist"
     }
   ],
   "packageRules": [
@@ -61,9 +69,13 @@
       "automerge": true
     },
     {
-      "description": "Tuist CLI dev-tooling pin in mise.toml. Runs at any time (more often than the weekly default) so the pin tracks new CLI releases quickly, and auto-merges.",
-      "matchManagers": ["mise"],
-      "matchPackageNames": ["tuist"],
+      "description": "Tuist CLI dev-tooling pin in mise.toml (extracted by the custom regex manager above). Tracks the latest tuist/tuist release including canary prereleases (ignoreUnstable off), at any time, and auto-merges. respectLatest is off because this monorepo's GitHub `latest` marker points at whichever component released last, not the CLI; versioning is semver so the CLI's bare `X.Y.Z`/`X.Y.Z-canary.N` tags are kept and component tags like `server@1.2.3` are ignored.",
+      "matchManagers": ["custom.regex"],
+      "matchFileNames": ["mise.toml"],
+      "matchPackageNames": ["tuist/tuist"],
+      "versioning": "semver",
+      "ignoreUnstable": false,
+      "respectLatest": false,
       "schedule": ["at any time"],
       "commitMessagePrefix": "chore(cli):",
       "commitMessageTopic": "Tuist CLI",


### PR DESCRIPTION
## What changed

The `tuist` dev-tooling pin in `mise.toml` now tracks the latest Tuist CLI release (including canary prereleases) via Renovate, instead of being stuck on a stable version that nothing was advancing.

- New regex `customManager` in `renovate.json` extracts the `tuist =` line from `mise.toml` and points at the `tuist/tuist` `github-releases` datasource directly.
- The accompanying `packageRule` sets `ignoreUnstable: false` (ride canary), `respectLatest: false`, and `versioning: semver`; keeps the `at any time` schedule and `automerge`.
- Replaces the now-dead `matchManagers: ["mise"]` rule.
- Drops the stale `# Temporarily pinned to 4.192.4 …` comment in `mise.toml` for a one-line note on the auto-bump behavior.

## Why

The pin had silently stopped tracking releases: it sat at stable `4.197.1` while the latest stable was `4.200.5` and canary had advanced to `4.201.0-canary.7`. All day-to-day CLI fixes land on canary within the hour, so the monorepo's dev tooling was running several versions behind and missing them.

### Root cause

Renovate's native `mise` manager only updates aqua-backed tools when the short name is in its built-in tooling list. The docs are explicit: "`aqua:helm/helm` is not supported, but `helm` or `aqua:helm` is supported." `tuist` resolves via `aqua:tuist/tuist` and is **not** in that list, so the existing `matchManagers: ["mise"]` rule produced **zero** updates, ever. The pin had only ever moved via the old release `[Release]` commit-to-`main`; once the release-channels redesign removed that commit, nothing advanced the pin and it orphaned at stable.

### Why this approach

The same `customManager` (regex → explicit datasource) pattern this repo already uses for the runner-image, `Constants.swift` gradle plugin, and the hetzner controller. It bypasses the broken native mise resolution entirely rather than depending on Renovate adding `tuist` to its short-name list.

- `ignoreUnstable: false` makes Renovate offer the highest release including prereleases, so the pin rides the latest canary, matching the release-channels flow where `main` only cuts `X.Y.0-canary.N`. When a stable later outranks the open canary it briefly tracks that until the next canary cuts. Net effect: always the bleeding edge.
- `respectLatest: false` because this monorepo's GitHub "latest" marker points at whichever component released last (e.g. `xcresult-processor-image@…`), not the CLI.
- `versioning: semver` keeps the CLI's bare `X.Y.Z` / `X.Y.Z-canary.N` tags and ignores component tags like `server@1.2.3`, which aren't valid bare semver.

## Reviewer notes / trade-offs

- **Unstable channel:** the dev tooling (local `tuist generate`, CI) will ride canary, so a regressed canary could break things until the next bump. This is gated automatically: with required status checks on PRs, Renovate's default automerge waits for them to go green before merging. Drop `automerge` from that one rule if you'd rather click merge manually.
- **Cadence:** the hosted Mend app polls roughly hourly (best-effort); `at any time` removes the window restriction so any poll can ship the bump. A guaranteed strict-hourly cadence would require self-hosting Renovate as a workflow, which this PR does not add.
- Please confirm the Mend app has write/automerge enabled for this repo.

## How to test locally

Renovate config is validated as part of the Renovate run rather than locally, but you can sanity-check:

```sh
jq -e . renovate.json          # valid JSON
# regex matches exactly the pin line and nothing else (e.g. not "github:tuist/blick")
python3 -c 'import re; print([m.group(1) for m in re.finditer(r"\n\s*tuist = \"([^\"]+)\"", open("mise.toml").read())])'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)