### PR TITLE
chore(cli): adding acceptance test for modulemap setting generation

### DIFF
--- a/cli/Tests/TuistAutomationAcceptanceTests/BuildAcceptanceTests.swift
+++ b/cli/Tests/TuistAutomationAcceptanceTests/BuildAcceptanceTests.swift
@@ -278,6 +278,29 @@ struct BuildAcceptanceTestAppWithPreviews {
     }
 }
 
+struct BuildAcceptanceTestAppWithSPMModuleMap {
+    @Test(
+        .withFixture("generated_app_with_spm_module_map"),
+        .inTemporaryDirectory,
+        .withMockedEnvironment()
+    )
+    func app_with_spm_module_map() async throws {
+        let fixtureDirectory = try #require(TuistTest.fixtureDirectory)
+        let derivedDataPath = try #require(FileSystem.temporaryTestDirectory)
+        try await TuistTest.run(InstallCommand.self, ["--path", fixtureDirectory.pathString])
+        try await TuistTest.run(GenerateCommand.self, ["--no-open", "--path", fixtureDirectory.pathString])
+        try await TuistTest.run(
+            BuildCommand.self,
+            [
+                "App Target",
+                "--platform", "macos",
+                "--path", fixtureDirectory.pathString,
+                "--derived-data-path", derivedDataPath.pathString,
+            ]
+        )
+    }
+}
+
 struct BuildAcceptanceTestAppWithFrameworkAndTests {
     @Test(.withFixture("generated_app_with_framework_and_tests"), .inTemporaryDirectory)
     func with_framework_and_tests() async throws {

--- a/examples/xcode/generated_app_with_spm_module_map/App/Sources/AppApp.swift
+++ b/examples/xcode/generated_app_with_spm_module_map/App/Sources/AppApp.swift
@@ -1,0 +1,13 @@
+import LocalLib
+import SwiftUI
+
+@main
+struct AppApp: App {
+    let lib = LocalLib()
+
+    var body: some Scene {
+        WindowGroup {
+            Text("Hello, World!")
+        }
+    }
+}

--- a/examples/xcode/generated_app_with_spm_module_map/LocalPackage/Package.swift
+++ b/examples/xcode/generated_app_with_spm_module_map/LocalPackage/Package.swift
@@ -1,0 +1,14 @@
+// swift-tools-version: 5.10
+import PackageDescription
+
+let package = Package(
+    name: "LocalPackage",
+    platforms: [.macOS(.v13)],
+    products: [
+        .library(name: "LocalLib", targets: ["LocalLib"]),
+    ],
+    targets: [
+        .target(name: "LocalLib", dependencies: ["LocalObjcLib"]),
+        .target(name: "LocalObjcLib"),
+    ]
+)

--- a/examples/xcode/generated_app_with_spm_module_map/LocalPackage/Sources/LocalLib/LocalLib.swift
+++ b/examples/xcode/generated_app_with_spm_module_map/LocalPackage/Sources/LocalLib/LocalLib.swift
@@ -1,0 +1,3 @@
+public struct LocalLib {
+    public init() {}
+}

--- a/examples/xcode/generated_app_with_spm_module_map/LocalPackage/Sources/LocalObjcLib/LocalObjcLib.m
+++ b/examples/xcode/generated_app_with_spm_module_map/LocalPackage/Sources/LocalObjcLib/LocalObjcLib.m
@@ -1,0 +1,9 @@
+#import "include/LocalObjcLib.h"
+
+@implementation LocalObjcLib
+
+- (NSString *)hello {
+    return @"Hello from LocalObjcLib";
+}
+
+@end

--- a/examples/xcode/generated_app_with_spm_module_map/LocalPackage/Sources/LocalObjcLib/include/LocalObjcLib.h
+++ b/examples/xcode/generated_app_with_spm_module_map/LocalPackage/Sources/LocalObjcLib/include/LocalObjcLib.h
@@ -1,0 +1,5 @@
+#import <Foundation/Foundation.h>
+
+@interface LocalObjcLib : NSObject
+- (NSString *)hello;
+@end

--- a/examples/xcode/generated_app_with_spm_module_map/Project.swift
+++ b/examples/xcode/generated_app_with_spm_module_map/Project.swift
@@ -1,0 +1,19 @@
+import ProjectDescription
+
+let project = Project(
+    name: "App",
+    targets: [
+        .target(
+            name: "App Target",
+            destinations: [.mac],
+            product: .app,
+            bundleId: "dev.tuist.App",
+            deploymentTargets: .macOS("13.0"),
+            infoPlist: .default,
+            sources: "App/Sources/**",
+            dependencies: [
+                .external(name: "LocalLib"),
+            ]
+        ),
+    ]
+)

--- a/examples/xcode/generated_app_with_spm_module_map/Tuist.swift
+++ b/examples/xcode/generated_app_with_spm_module_map/Tuist.swift
@@ -1,0 +1,3 @@
+import ProjectDescription
+
+let tuist = Tuist(project: .tuist())

--- a/examples/xcode/generated_app_with_spm_module_map/Tuist/Package.swift
+++ b/examples/xcode/generated_app_with_spm_module_map/Tuist/Package.swift
@@ -1,0 +1,15 @@
+// swift-tools-version: 5.10
+import PackageDescription
+
+#if TUIST
+    import struct ProjectDescription.PackageSettings
+
+    let packageSettings = PackageSettings(productTypes: [:])
+#endif
+
+let package = Package(
+    name: "App",
+    dependencies: [
+        .package(path: "../LocalPackage"),
+    ]
+)


### PR DESCRIPTION
Update to #11239

> Describe here the purpose of your PR.

Adds test case to validate module map setting generation works for targets with whitespace in the name.