### PR TITLE
chore(cli): auto-approve + self-merge Renovate Tuist CLI canary bumps

### DIFF
--- a/.github/workflows/renovate-auto-approve.yml
+++ b/.github/workflows/renovate-auto-approve.yml
@@ -1,0 +1,43 @@
+name: Renovate Auto-Approve
+
+# main requires one approving CODEOWNERS review on mise.toml (@tuist/engineering),
+# which Renovate's bot PR cannot give itself. This approves Renovate's auto-merge
+# CLI pin bumps with a @tuist/engineering machine identity so the review is
+# satisfied; Renovate (platformAutomerge off) then merges once the PR's checks pass.
+#
+# RENOVATE_APPROVE_TOKEN must be a PAT for a user that is a member of
+# @tuist/engineering (e.g. the tuistit machine account added to the team). A plain
+# GITHUB_TOKEN / github-actions[bot] approval does not count as a CODEOWNERS review.
+#
+# To cover more auto-merge Renovate rules, add their title prefixes to the `if` below.
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+permissions: {}
+
+jobs:
+  approve:
+    name: Approve Renovate CLI bumps
+    runs-on: ubuntu-latest
+    if: >-
+      github.event.pull_request.user.login == 'renovate[bot]' &&
+      startsWith(github.event.pull_request.title, 'chore(cli): Update Tuist CLI')
+    steps:
+      - name: Approve
+        env:
+          GH_TOKEN: ${{ secrets.RENOVATE_APPROVE_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          set -euo pipefail
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "RENOVATE_APPROVE_TOKEN is not set; skipping approval." >&2
+            exit 0
+          fi
+          if [ "$(gh pr view "$PR_URL" --json reviewDecision --jq '.reviewDecision')" = "APPROVED" ]; then
+            echo "PR is already approved; nothing to do."
+            exit 0
+          fi
+          gh pr review "$PR_URL" --approve \
+            --body "Auto-approving Renovate Tuist CLI bump so it can merge once checks pass."

--- a/renovate.json
+++ b/renovate.json
@@ -69,7 +69,7 @@
       "automerge": true
     },
     {
-      "description": "Tuist CLI dev-tooling pin in mise.toml (extracted by the custom regex manager above). Tracks the latest tuist/tuist release including canary prereleases (ignoreUnstable off), at any time, and auto-merges. respectLatest is off because this monorepo's GitHub `latest` marker points at whichever component released last, not the CLI; versioning is semver so the CLI's bare `X.Y.Z`/`X.Y.Z-canary.N` tags are kept and component tags like `server@1.2.3` are ignored.",
+      "description": "Tuist CLI dev-tooling pin in mise.toml (extracted by the custom regex manager above). Tracks the latest tuist/tuist release including canary prereleases (ignoreUnstable off), at any time, and auto-merges. respectLatest is off because this monorepo's GitHub `latest` marker points at whichever component released last, not the CLI; versioning is semver so the CLI's bare `X.Y.Z`/`X.Y.Z-canary.N` tags are kept and component tags like `server@1.2.3` are ignored. platformAutomerge is off so Renovate merges the PR itself only after the PR's own checks pass, instead of GitHub native auto-merge, which would merge as soon as it is mergeable because main has no required status checks. The CODEOWNERS review on mise.toml is satisfied by the renovate-auto-approve workflow.",
       "matchManagers": ["custom.regex"],
       "matchFileNames": ["mise.toml"],
       "matchPackageNames": ["tuist/tuist"],
@@ -79,7 +79,8 @@
       "schedule": ["at any time"],
       "commitMessagePrefix": "chore(cli):",
       "commitMessageTopic": "Tuist CLI",
-      "automerge": true
+      "automerge": true,
+      "platformAutomerge": false
     },
     {
       "description": "hetzner-robot-controller mgmt-cluster image pin.",


### PR DESCRIPTION
## What changed

Makes Renovate's Tuist CLI canary pin bumps (e.g. [#11334](https://github.com/tuist/tuist/pull/11334)) merge hands-off:

- **`.github/workflows/renovate-auto-approve.yml`** — approves Renovate's CLI pin PRs with a `@tuist/engineering` machine identity so the CODEOWNERS review on `mise.toml` is satisfied.
- **`renovate.json`** — sets `platformAutomerge: false` on the CLI pin rule so Renovate merges the PR itself once the PR's own checks pass.

## Why

Renovate already opens the bumps with `automerge: true` and the repo allows auto-merge, but the PR sits `MERGEABLE` / `mergeStateStatus: BLOCKED` with `reviewDecision: REVIEW_REQUIRED`. `main` requires one approving review with `require_code_owner_reviews: true`, and CODEOWNERS maps `/mise.toml` to `@tuist/engineering`. A bot PR can't give itself that review, so this has been silently blocking **every** `automerge: true` Renovate rule, not just the CLI pin.

The approval has to come from a `@tuist/engineering` member — a plain `github-actions[bot]` approval does not count as a code-owner review. Hence the machine-identity token.

## Why `platformAutomerge: false` instead of required status checks

The goal is "merge when this PR's CI passes." Native GitHub auto-merge would need required status checks to wait for CI, but:

- `main` has **no** required status checks today.
- The build/test contexts are **conditional**: `Acceptance Tests`, `Cache`, `Acceptance Tests (Fork)` report `skipping` on path filters, and `Build Acceptance Tests` is intermittently red on the pre-existing Tigris `bundle.zip` timeout.

Making those required would (a) permanently wedge any PR that skips them and (b) block the canary bump on every acceptance flake. Requiring only the always-run checks (Lint/CodeQL/Analyze) wouldn't validate the CLI bump. With native auto-merge and no required checks, the PR would instead merge the instant the review clears — before CI even runs.

`platformAutomerge: false` sidesteps all of that: Renovate waits for exactly the checks that ran on the PR to go green, then merges on its next run (~hourly cadence). No branch-protection change, no wedge.

## Required setup (one-time, by a maintainer)

Add a repo secret **`RENOVATE_APPROVE_TOKEN`** = a PAT for a GitHub user that is a member of `@tuist/engineering` (e.g. the existing `tuistit` machine account, added to the team; fine-grained PAT needs Pull requests: Read & Write on this repo). Until the secret exists, the workflow no-ops and the bumps stay manual — nothing breaks.

## Scope

The workflow only approves PRs titled `chore(cli): Update Tuist CLI` (the canary pin). To extend to the other `automerge: true` rules (runner-image, linux-runner-image, hetzner controller, gradle plugin), add their title prefixes to the `if:` condition.

## Validation

- `renovate.json` valid JSON; `platformAutomerge: false` present on the CLI rule.
- Workflow YAML parses (`yq`).
- The approval flow itself can only be verified once the token secret is set and Renovate opens the next bump.

## How to test locally

Config-only + workflow; no local runtime. After merge and setting the secret, the next Renovate CLI bump PR should get an automated approval and then merge once its checks are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)