### PR TITLE
feat: CNPG per-query latency observability (pg_stat_statements metrics + dashboard panels)

### DIFF
--- a/infra/cnpg/README.md
+++ b/infra/cnpg/README.md
@@ -8,6 +8,7 @@ The chart-rendered `Cluster` CR ([`infra/helm/tuist/templates/postgresql-cnpg.ya
 
 - [`tuist-processor-grants.sql`](./tuist-processor-grants.sql) — `oban_jobs` / `oban_peers` write grants for the `tuist_processor` role. The role itself is created declaratively by CNPG via `managed.roles[]`; this file adds the per-table privileges the worker needs.
 - [`tuist-ops-ro-grants.sql`](./tuist-ops-ro-grants.sql) — `CONNECT` on the application database for the `tuist_ops_ro` role, plus an explicit `REVOKE` of write privileges on `public` (defense-in-depth against a future grant-by-default change in Postgres widening `pg_read_all_data`). The role is for ad-hoc operator psql access; the `/ops/db` LiveView uses Tuist.Repo and enforces read-only at the app layer (see `Tuist.Ops.Database.execute/2`).
+- [`pg-stat-statements.sql`](./pg-stat-statements.sql) — `CREATE EXTENSION pg_stat_statements`, enabling the per-query latency metrics (`cnpg_tuist_query_stats_*`) that back the dashboard's query-latency panels. The library is preloaded via the chart (`postgresql.cnpg.sharedPreloadLibraries`); this creates the reading view. **Runs against `postgres`, not `tuist`** (the metrics exporter queries the instance-global view from the maintenance database). Only relevant when `postgresql.cnpg.queryStats.enabled` is set.
 
 ## When to run
 
@@ -35,6 +36,12 @@ kubectl cnpg psql -n "$NAMESPACE" "$CLUSTER" -- -d tuist -f - \
 
 kubectl cnpg psql -n "$NAMESPACE" "$CLUSTER" -- -d tuist -f - \
   < infra/cnpg/tuist-ops-ro-grants.sql
+
+# pg_stat_statements is instance-global and the metrics exporter reads it
+# from the maintenance database, so this one runs against `postgres`, not
+# `tuist`. Only needed where postgresql.cnpg.queryStats.enabled is set.
+kubectl cnpg psql -n "$NAMESPACE" "$CLUSTER" -- -d postgres -f - \
+  < infra/cnpg/pg-stat-statements.sql
 ```
 
 Each file ends with a sanity-check `SELECT … information_schema.role_table_grants …` query that prints the exact privilege set the role holds after the run. A clean run shows the expected `arwd/postgres` shape on the granted tables.

--- a/infra/cnpg/pg-stat-statements.sql
+++ b/infra/cnpg/pg-stat-statements.sql
@@ -1,0 +1,20 @@
+-- Enable pg_stat_statements so the instance metrics exporter can expose
+-- per-query latency as Prometheus metrics (cnpg_tuist_query_stats_*, via the
+-- monitoring ConfigMap rendered by
+-- infra/helm/tuist/templates/postgresql-cnpg-monitoring-queries.yaml).
+--
+-- The library is already preloaded via spec.postgresql.shared_preload_libraries
+-- (postgresql.cnpg.sharedPreloadLibraries in the chart values); this file
+-- creates the extension so the reading view exists.
+--
+-- Run against the `postgres` maintenance database, NOT `tuist`:
+-- pg_stat_statements is instance-global (one shared-memory hash across all
+-- databases) and the metrics exporter queries it from `postgres`, so the view
+-- must exist there. The query in the ConfigMap filters to the application
+-- database's statements by dbid. Idempotent and re-runnable.
+--
+-- See infra/cnpg/README.md for how to run.
+CREATE EXTENSION IF NOT EXISTS pg_stat_statements;
+
+-- Sanity check: the view resolves and is readable.
+SELECT count(*) AS statement_entries FROM pg_stat_statements;

--- a/infra/grafana-dashboards/postgresql-cnpg.json
+++ b/infra/grafana-dashboards/postgresql-cnpg.json
@@ -783,6 +783,134 @@
       },
       {
         "datasource": "$datasource",
+        "description": "Mean statement execution time by class (read/write/other) from pg_stat_statements on the primary. Needs queryStats enabled and the pg-stat-statements extension (infra/cnpg/pg-stat-statements.sql).",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "drawStyle": "line",
+              "fillOpacity": 10,
+              "lineWidth": 1,
+              "showPoints": "never",
+              "spanNulls": false
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                }
+              ]
+            },
+            "unit": "ms"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 22
+        },
+        "id": 67,
+        "options": {
+          "legend": {
+            "calcs": [
+              "lastNotNull",
+              "max"
+            ],
+            "displayMode": "table",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "multi",
+            "sort": "desc"
+          }
+        },
+        "targets": [
+          {
+            "datasource": "$datasource",
+            "editorMode": "code",
+            "expr": "sum by (op) (rate(cnpg_tuist_query_stats_total_exec_time_ms{instance_role=\"primary\", namespace=~\"$namespace\", cnpg_cluster=~\"$cnpg_cluster\", pod=~\"$pod\"}[$__rate_interval])) / clamp_min(sum by (op) (rate(cnpg_tuist_query_stats_calls{instance_role=\"primary\", namespace=~\"$namespace\", cnpg_cluster=~\"$cnpg_cluster\", pod=~\"$pod\"}[$__rate_interval])), 1)",
+            "legendFormat": "{{op}}",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "Query Latency (read/write)",
+        "type": "timeseries"
+      },
+      {
+        "datasource": "$datasource",
+        "description": "Statement execution rate by class (read/write/other) from pg_stat_statements on the primary.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "drawStyle": "line",
+              "fillOpacity": 10,
+              "lineWidth": 1,
+              "showPoints": "never",
+              "spanNulls": false
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                }
+              ]
+            },
+            "unit": "ops"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 12,
+          "y": 22
+        },
+        "id": 68,
+        "options": {
+          "legend": {
+            "calcs": [
+              "lastNotNull",
+              "max"
+            ],
+            "displayMode": "table",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "multi",
+            "sort": "desc"
+          }
+        },
+        "targets": [
+          {
+            "datasource": "$datasource",
+            "editorMode": "code",
+            "expr": "sum by (op) (rate(cnpg_tuist_query_stats_calls{instance_role=\"primary\", namespace=~\"$namespace\", cnpg_cluster=~\"$cnpg_cluster\", pod=~\"$pod\"}[$__rate_interval]))",
+            "legendFormat": "{{op}}",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "Query Throughput (read/write)",
+        "type": "timeseries"
+      },
+      {
+        "datasource": "$datasource",
         "description": "Blocked backends waiting on locks or other queries.",
         "fieldConfig": {
           "defaults": {
@@ -814,7 +942,7 @@
           "h": 8,
           "w": 12,
           "x": 0,
-          "y": 22
+          "y": 30
         },
         "id": 16,
         "options": {
@@ -888,7 +1016,7 @@
           "h": 8,
           "w": 12,
           "x": 12,
-          "y": 22
+          "y": 30
         },
         "id": 17,
         "options": {
@@ -925,7 +1053,7 @@
           "h": 1,
           "w": 24,
           "x": 0,
-          "y": 30
+          "y": 38
         },
         "id": 20,
         "panels": [],
@@ -965,7 +1093,7 @@
           "h": 8,
           "w": 12,
           "x": 0,
-          "y": 31
+          "y": 39
         },
         "id": 21,
         "options": {
@@ -1032,7 +1160,7 @@
           "h": 8,
           "w": 12,
           "x": 12,
-          "y": 31
+          "y": 39
         },
         "id": 22,
         "options": {
@@ -1097,7 +1225,7 @@
           "h": 8,
           "w": 8,
           "x": 0,
-          "y": 39
+          "y": 47
         },
         "id": 23,
         "options": {
@@ -1161,7 +1289,7 @@
           "h": 8,
           "w": 8,
           "x": 8,
-          "y": 39
+          "y": 47
         },
         "id": 24,
         "options": {
@@ -1225,7 +1353,7 @@
           "h": 8,
           "w": 8,
           "x": 16,
-          "y": 39
+          "y": 47
         },
         "id": 25,
         "options": {
@@ -1270,7 +1398,7 @@
           "h": 1,
           "w": 24,
           "x": 0,
-          "y": 47
+          "y": 55
         },
         "id": 30,
         "panels": [],
@@ -1310,7 +1438,7 @@
           "h": 8,
           "w": 8,
           "x": 0,
-          "y": 48
+          "y": 56
         },
         "id": 31,
         "options": {
@@ -1374,7 +1502,7 @@
           "h": 8,
           "w": 8,
           "x": 8,
-          "y": 48
+          "y": 56
         },
         "id": 32,
         "options": {
@@ -1438,7 +1566,7 @@
           "h": 8,
           "w": 8,
           "x": 16,
-          "y": 48
+          "y": 56
         },
         "id": 33,
         "options": {
@@ -1475,7 +1603,7 @@
           "h": 1,
           "w": 24,
           "x": 0,
-          "y": 56
+          "y": 64
         },
         "id": 40,
         "panels": [],
@@ -1523,7 +1651,7 @@
           "h": 8,
           "w": 8,
           "x": 0,
-          "y": 57
+          "y": 65
         },
         "id": 41,
         "options": {
@@ -1587,7 +1715,7 @@
           "h": 8,
           "w": 8,
           "x": 8,
-          "y": 57
+          "y": 65
         },
         "id": 42,
         "options": {
@@ -1651,7 +1779,7 @@
           "h": 8,
           "w": 8,
           "x": 16,
-          "y": 57
+          "y": 65
         },
         "id": 43,
         "options": {
@@ -1715,7 +1843,7 @@
           "h": 8,
           "w": 12,
           "x": 0,
-          "y": 65
+          "y": 73
         },
         "id": 44,
         "options": {
@@ -1803,7 +1931,7 @@
           "h": 8,
           "w": 12,
           "x": 12,
-          "y": 65
+          "y": 73
         },
         "id": 45,
         "options": {
@@ -1840,7 +1968,7 @@
           "h": 1,
           "w": 24,
           "x": 0,
-          "y": 73
+          "y": 81
         },
         "id": 50,
         "panels": [],
@@ -1880,7 +2008,7 @@
           "h": 8,
           "w": 8,
           "x": 0,
-          "y": 74
+          "y": 82
         },
         "id": 51,
         "options": {
@@ -1959,7 +2087,7 @@
           "h": 8,
           "w": 8,
           "x": 8,
-          "y": 74
+          "y": 82
         },
         "id": 52,
         "options": {
@@ -2031,7 +2159,7 @@
           "h": 8,
           "w": 8,
           "x": 16,
-          "y": 74
+          "y": 82
         },
         "id": 53,
         "options": {
@@ -2076,7 +2204,7 @@
           "h": 1,
           "w": 24,
           "x": 0,
-          "y": 82
+          "y": 90
         },
         "id": 60,
         "panels": [],
@@ -2116,7 +2244,7 @@
           "h": 8,
           "w": 8,
           "x": 0,
-          "y": 83
+          "y": 91
         },
         "id": 61,
         "options": {
@@ -2204,7 +2332,7 @@
           "h": 8,
           "w": 8,
           "x": 8,
-          "y": 83
+          "y": 91
         },
         "id": 62,
         "options": {
@@ -2300,7 +2428,7 @@
           "h": 8,
           "w": 8,
           "x": 16,
-          "y": 83
+          "y": 91
         },
         "id": 63,
         "options": {
@@ -2364,7 +2492,7 @@
           "h": 8,
           "w": 8,
           "x": 0,
-          "y": 91
+          "y": 99
         },
         "id": 64,
         "options": {
@@ -2436,7 +2564,7 @@
           "h": 8,
           "w": 8,
           "x": 8,
-          "y": 91
+          "y": 99
         },
         "id": 65,
         "options": {
@@ -2516,7 +2644,7 @@
           "h": 8,
           "w": 8,
           "x": 16,
-          "y": 91
+          "y": 99
         },
         "id": 66,
         "options": {

--- a/infra/helm/tuist/templates/postgresql-cnpg-monitoring-queries.yaml
+++ b/infra/helm/tuist/templates/postgresql-cnpg-monitoring-queries.yaml
@@ -1,0 +1,57 @@
+{{- if and (or .Values.postgresql.cnpg.enabled (eq .Values.postgresql.mode "cnpg")) .Values.postgresql.cnpg.queryStats.enabled }}
+# Custom CNPG monitoring query: exposes pg_stat_statements as per-query
+# latency metrics (cnpg_tuist_query_stats_*) so the dashboard can chart
+# read/write query latency, the signal that was missing during the
+# oban_jobs bloat incident.
+#
+# Prerequisites:
+#   * pg_stat_statements preloaded (postgresql.cnpg.sharedPreloadLibraries).
+#   * The extension created in the `postgres` database, one-time via
+#     infra/cnpg/pg-stat-statements.sql (see infra/cnpg/README.md). Until
+#     then the exporter query errors and the metric is simply absent.
+#
+# The exporter runs this against `postgres` (target_databases). Because
+# pg_stat_statements is instance-global, a single target database yields
+# cluster-wide stats; the query filters to the application database by dbid
+# and buckets statements read/write/other, so the metric has 3 series (low
+# cardinality). Mean latency is derived in the dashboard as
+# rate(total_exec_time_ms) / rate(calls).
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "tuist.componentName" (dict "root" . "component" "pg-monitoring-queries") }}
+  labels:
+    {{- include "tuist.labels" . | nindent 4 }}
+    app.kubernetes.io/component: postgresql
+data:
+  queries: |
+    tuist_query_stats:
+      query: |
+        SELECT
+          CASE
+            WHEN query ILIKE 'select%' THEN 'read'
+            WHEN query ~* '^(insert|update|delete)' THEN 'write'
+            ELSE 'other'
+          END AS op,
+          sum(calls)::bigint AS calls,
+          sum(total_exec_time) AS total_exec_time_ms,
+          sum(rows)::bigint AS rows
+        FROM pg_stat_statements
+        WHERE dbid = (SELECT oid FROM pg_database WHERE datname = '{{ .Values.postgresql.cnpg.database }}')
+        GROUP BY 1
+      metrics:
+        - op:
+            usage: "LABEL"
+            description: "Statement class derived from the normalized query text"
+        - calls:
+            usage: "COUNTER"
+            description: "Cumulative statement executions"
+        - total_exec_time_ms:
+            usage: "COUNTER"
+            description: "Cumulative statement execution time in milliseconds"
+        - rows:
+            usage: "COUNTER"
+            description: "Cumulative rows processed by the statements"
+      target_databases:
+        - postgres
+{{- end }}

--- a/infra/helm/tuist/templates/postgresql-cnpg.yaml
+++ b/infra/helm/tuist/templates/postgresql-cnpg.yaml
@@ -114,9 +114,19 @@ spec:
     topologyKey: kubernetes.io/hostname
     podAntiAffinityType: required
 
-  {{- with .Values.postgresql.cnpg.monitoring }}
+  {{- if or .Values.postgresql.cnpg.monitoring .Values.postgresql.cnpg.queryStats.enabled }}
   monitoring:
+    {{- with .Values.postgresql.cnpg.monitoring }}
     {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- if .Values.postgresql.cnpg.queryStats.enabled }}
+    # pg_stat_statements latency metrics (cnpg_tuist_query_stats_*). The
+    # ConfigMap and its prerequisites are described in
+    # templates/postgresql-cnpg-monitoring-queries.yaml.
+    customQueriesConfigMap:
+      - name: {{ include "tuist.componentName" (dict "root" . "component" "pg-monitoring-queries") }}
+        key: queries
+    {{- end }}
   {{- end }}
 
   # Managed roles. CNPG creates the role on bootstrap and rotates the

--- a/infra/helm/tuist/values-managed-canary.yaml
+++ b/infra/helm/tuist/values-managed-canary.yaml
@@ -143,6 +143,10 @@ postgresql:
     # an entry under `parameters`.
     sharedPreloadLibraries:
       - pg_stat_statements
+    # Expose pg_stat_statements as query-latency metrics. The library above
+    # is loaded; create the extension once via infra/cnpg/pg-stat-statements.sql.
+    queryStats:
+      enabled: true
     # Route the processor through the transaction-mode PgBouncer pooler so
     # this soak env matches production's post-CNPG-cutover topology
     # (processor pooled, web tier direct on -rw). CNPG's built-in

--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -176,6 +176,11 @@ postgresql:
     # chart renders them to `spec.postgresql.shared_preload_libraries`.
     sharedPreloadLibraries:
       - pg_stat_statements
+    # Expose pg_stat_statements as query-latency metrics. The library above
+    # is loaded; create the extension once via infra/cnpg/pg-stat-statements.sql.
+    # Powers the dashboard's read/write query-latency panels.
+    queryStats:
+      enabled: true
     storage:
       # Steady-state usage is ~30-40 GiB; oversized to absorb WAL spikes
       # during large background operations (REINDEX, VACUUM FULL, bulk

--- a/infra/helm/tuist/values-managed-staging.yaml
+++ b/infra/helm/tuist/values-managed-staging.yaml
@@ -172,6 +172,10 @@ postgresql:
     # an entry under `parameters`.
     sharedPreloadLibraries:
       - pg_stat_statements
+    # Expose pg_stat_statements as query-latency metrics. The library above
+    # is loaded; create the extension once via infra/cnpg/pg-stat-statements.sql.
+    queryStats:
+      enabled: true
     # Route the processor through the transaction-mode PgBouncer pooler so
     # this soak env matches production's post-CNPG-cutover topology
     # (processor pooled, web tier direct on -rw). CNPG's built-in

--- a/infra/helm/tuist/values.yaml
+++ b/infra/helm/tuist/values.yaml
@@ -1466,6 +1466,14 @@ postgresql:
     # annotation-emit support on the instance Pods (it doesn't today).
     monitoring:
       enablePodMonitor: false
+    # Per-query latency observability. When enabled, the chart renders a
+    # custom CNPG monitoring query over pg_stat_statements
+    # (cnpg_tuist_query_stats_*) for the dashboard's query-latency panels.
+    # Requires `pg_stat_statements` in sharedPreloadLibraries above and the
+    # extension created once via infra/cnpg/pg-stat-statements.sql. Off by
+    # default (local/preview clusters do not preload the library).
+    queryStats:
+      enabled: false
     roles:
       # Least-privilege Oban-queue consumer. CNPG creates the role;
       # per-table GRANTs run via the bootstrap SQL in


### PR DESCRIPTION
> Draft. Stacked on #11336 (base is `fix/server-oban-jobs-bloat`) so it inherits the dashboard fixes; retarget to `main` once that merges.

## Why

During the `oban_jobs` bloat incident, the one signal we never had was **per-query latency**. The CNPG cluster already preloads `pg_stat_statements` (the values comment even says "for per-query latency observability"), but the extension was never created and nothing exported it, so `SELECT … FROM pg_stat_statements` just errored. We had to infer slow queries from `pg_stat_user_tables` scan counts. This wires that observability up.

## What

Behind `postgresql.cnpg.queryStats.enabled` (on in managed envs, off in base/preview where the library isn't preloaded):

1. **`infra/cnpg/pg-stat-statements.sql`** — re-runnable `CREATE EXTENSION pg_stat_statements`, run once against the **`postgres`** database (the view is instance-global; the exporter reads it from the maintenance DB). Documented in `infra/cnpg/README.md`.
2. **Custom CNPG monitoring query** (ConfigMap → `monitoring.customQueriesConfigMap`) that buckets `pg_stat_statements` read/write/other for the app database and exports `cnpg_tuist_query_stats_{calls,total_exec_time_ms,rows}`. 3 series, low cardinality. Metrics scrape via the existing Alloy autodiscovery (no PodMonitor needed).
3. **Two dashboard panels**: `Query Latency (read/write)` (mean ms = `rate(total_exec_time_ms)/rate(calls)`) and `Query Throughput (read/write)` (ops), both `op`-split and scoped to the primary instance (same primary-scoping as the rate-panel fix in #11336).

## Rollout / ordering

- `shared_preload_libraries` already includes `pg_stat_statements`, so **no Postgres restart** is needed — adding the custom query is a live exporter-config reload.
- The extension must exist before the exporter query returns data. Until `pg-stat-statements.sql` is run once per cluster, the exporter query errors and the metric is simply absent (panels show "No data"); not harmful. Run it per the `infra/cnpg/README.md` runbook (it's a DDL write, so it's a deliberate operator step, not something the pipeline does).

## Validation

- `helm template` against `values-managed-production.yaml` renders the ConfigMap and the `customQueriesConfigMap` reference with matching names.
- Parsed the rendered ConfigMap's embedded `queries` block as YAML to confirm CNPG can consume it.
- Dashboard JSON validated (round-trip stable; panels parse; non-overlapping gridPos).
- Note: the live metric could not be exercised end-to-end yet because creating the extension is a prod DDL write (out of scope for an automated run) and the chart isn't deployed.

## Follow-up captured from the incident

The dashboard's `Database Size` stat and `Connections` count still sum across the 3 instances (same over-aggregation class as the gauge/rate fixes in #11336); worth the same primary-scoping in a later pass.
