### PR TITLE
chore(infra): bump CloudNativePG operator 1.25 -> 1.26 (step 1 of 4 toward 1.29)

### DIFF
--- a/infra/cnpg/README.md
+++ b/infra/cnpg/README.md
@@ -102,3 +102,44 @@ kubectl cnpg backup-status -n "$NAMESPACE" "$CLUSTER"
 # Then build a restore manifest using `kubectl cnpg restore` (see the
 # CNPG docs); destroy it once the validation queries finish.
 ```
+
+## Operator version & upgrade path
+
+The CNPG operator version is pinned by the `cloudnative-pg` dependency in
+[`infra/helm/platform/Chart.yaml`](../helm/platform/Chart.yaml). The chart
+version maps to the operator `appVersion`: chart `0.23.x` is operator `1.25.x`,
+`0.24.0` is `1.26.0`, `0.25.0` is `1.26.1`. The platform chart is re-applied on
+every deploy, so bumping that pin upgrades the operator on the next merge.
+
+CNPG must be upgraded one minor at a time. The project only tests and supports
+sequential minor upgrades, not skips
+(<https://cloudnative-pg.io/docs/current/installation_upgrade/>). As of 2026-06
+we are catching up from an end-of-life `1.25` to the only supported line,
+`1.29.x`, in four steps, each its own PR:
+
+`1.25 -> 1.26 -> 1.27 -> 1.28 -> 1.29`
+
+The operand Postgres image (`postgresql.cnpg.image.tag`) stays pinned and out
+of the operator-bump PR. CNPG's admission webhook rejects changing the image
+and `postgresql.parameters` in the same apply, and keeping the operand fixed
+makes each step a clean instance-manager-only roll.
+
+### What an operator bump does to a running cluster
+
+Upgrading the operator triggers a rolling update of every CNPG cluster it
+manages, one instance at a time, ending in a primary switchover governed by
+`primaryUpdateStrategy` (currently `unsupervised`, the CNPG default, so the
+switchover completes automatically). With synchronous replication the promotion
+is fast and lossless (RPO 0); the write path sees a few seconds of dropped
+connections and errors during the switchover. Because the operator is
+cluster-wide, a bump on the production cluster rolls both the main `tuist`
+cluster and the single-instance `tuist-ops` cluster (the latter takes a brief
+restart, since it has no replica to fail over to).
+
+Merge an operator-bump PR at the start of a low-traffic window wider than the
+deploy lag (the prod step runs after the canary deploy and acceptance tests, so
+roughly 20-40 min after merge), so the switchover lands inside the quiet period.
+
+In-tree `barmanObjectStore` backups (deprecated since 1.26 in favor of the
+Barman Cloud Plugin) still work through 1.29, so this catch-up does not require
+a backup migration. Moving to the Barman Cloud Plugin is separate, later work.

--- a/infra/helm/platform/Chart.yaml
+++ b/infra/helm/platform/Chart.yaml
@@ -46,6 +46,6 @@ dependencies:
     repository: https://kubernetes-sigs.github.io/metrics-server/
     condition: metrics-server.enabled
   - name: cloudnative-pg
-    version: 0.23.0
+    version: 0.25.0  # operator 1.26.1; step minors 1.25->1.29 one at a time (see infra/cnpg/README.md)
     repository: https://cloudnative-pg.github.io/charts
     condition: cloudnative-pg.enabled


### PR DESCRIPTION
## What this does

Bumps the CloudNativePG operator from `1.25.0` to `1.26.1` by moving the `cloudnative-pg` dependency in the platform chart from chart `0.23.0` to `0.25.0` (`infra/helm/platform/Chart.yaml`). This is the first of four sequential minor upgrades.

## Why

We are running operator `1.25.0`, and the entire `1.25` line is end-of-life: no more security or bugfix releases. The only currently supported CNPG line is `1.29.x`. This bump starts the catch-up off EOL. Secondary benefit: `1.26+` adds declarative `Database.spec.extensions`, which lets us eventually retire the manual per-cluster extension/grant SQL in favor of declarative management.

## Path to the latest version

CNPG only supports upgrading one minor at a time (the project tests and supports N to N+1 upgrades, not skips: https://cloudnative-pg.io/docs/current/installation_upgrade/), so we step rather than jump:

`1.25 (now) -> 1.26 (this PR) -> 1.27 -> 1.28 -> 1.29`

Each step is its own PR with the same shape: bump the chart pin, deploy, observe a brief prod switchover. We deliberately do not jump straight to 1.29. The switchover is the cheap, controlled part; a four-minor jump runs untested operator upgrade logic against prod, which is the genuinely risky failure mode. Chart-to-operator mapping for reference: `0.23.x` = `1.25.x`, `0.24.0` = `1.26.0`, `0.25.0` = `1.26.1`, up to `0.28.1` = `1.29.1`. The chart and the operator are versioned independently: each chart records the operator version it ships in its `appVersion` field, published in the upstream Helm index (https://cloudnative-pg.io/charts/index.yaml, or `helm search repo cloudnative-pg --versions`). That `appVersion` is what actually runs in the cluster; `Chart.yaml` only takes the chart `version`.

In-tree `barmanObjectStore` backups (deprecated since 1.26 in favor of the Barman Cloud Plugin) still work through 1.29, so this catch-up needs no backup migration. The eventual move to the Barman Cloud Plugin is separate, later work, outlined under "Follow-up" below.

## How it deploys and the production impact

The platform chart is re-applied on every merge to main (the `platform-install` job runs `helm upgrade --install platform`), cascading canary -> acceptance tests -> production. An operator upgrade triggers a rolling update of every CNPG cluster the operator manages, one instance at a time, ending in a primary switchover:

- Main `tuist` cluster (prod, 3 instances, synchronous replication): a fast, lossless (RPO 0) switchover. The write path sees a few seconds of dropped connections and errors while the new primary is promoted; the 15s `pool_timeout` cushions requests that arrive mid-window. `primaryUpdateStrategy` stays `unsupervised` (the CNPG default), so the switchover completes automatically. This is the standard CNPG update path.
- `tuist-ops` cluster (prod, single instance): a brief restart, since it has no replica to fail over to. Acceptable downtime.
- Canary and staging: same switchover behavior, and they run first, so canary is the dress rehearsal before the prod step.

The operand Postgres image stays pinned at its current tag and is intentionally out of this PR: CNPG's admission webhook rejects changing the image and `postgresql.parameters` in the same apply, and keeping the operand fixed makes this a clean instance-manager-only roll. `1.26` requires operand Barman >= 3.4, which the pinned operand image already satisfies.

## Merge guidance (low-traffic window)

Because the deploy auto-cascades to prod, merge this at the start of a low-traffic window wider than the deploy lag (the prod step runs after the canary deploy and acceptance tests, roughly 20-40 min after merge), so the brief prod switchover lands inside the quiet period. Optionally have eyes on the prod deploy when it runs.

## Validation

- Helm CI (`helm lint` + `helm template` + kubeconform) renders the platform chart with the new dependency.
- `helm dependency update infra/helm/platform` resolves `cloudnative-pg 0.25.0` (appVersion 1.26.1) from the upstream chart repo, confirmed against the published index.
- On deploy, watch the canary CNPG cluster roll and switch over cleanly before the prod step; confirm `kubectl cnpg status` reports every instance on the new operator and the cluster healthy.

Docs: adds an "Operator version & upgrade path" section to `infra/cnpg/README.md` capturing the sequential plan, the per-step rules, and the switchover behavior.

## Follow-up: Barman Cloud Plugin migration (not in this PR)

In-tree `barmanObjectStore` is deprecated since 1.26 but still works through 1.29, so it stays as-is here. It will eventually move to the Barman Cloud Plugin (CNPG-I). The migration is officially supported and lossless, but it is a multi-step project across both CNPG clusters (`tuist` + `tuist-ops`) and all envs, sequenced **after** the 1.29 catch-up (the plugin requires operator >= 1.26; no rush since in-tree works through 1.29; reversible while in-tree is still supported).

Outline:

1. Install the pinned `plugin-barman-cloud` manifest into the operator's namespace (ours is `platform`, not the docs' default `cnpg-system`), lockstep with the operator version. Adds the `ObjectStore` CRD (`barmancloud.cnpg.io/v1`), a `barman-cloud` Deployment, RBAC, and cert-manager mTLS. cert-manager is already present.
2. Add an `ObjectStore` CR per cluster, translating the current `barmanObjectStore` fields into `ObjectStore.spec.configuration` and reusing the same `S3_BACKUP_CREDENTIALS` ESO secret. Retention moves from `backup.retentionPolicy` (Cluster) to `ObjectStore.spec.retentionPolicy`.
3. Switch the Cluster in one atomic edit: remove `backup.barmanObjectStore`, add a `plugins` entry (`isWALArchiver: true`) referencing the ObjectStore. This triggers a rolling update, i.e. another prod switchover, so the same low-traffic-window discipline applies.
4. Update `ScheduledBackup` to `method: plugin` + `pluginConfiguration.name: barman-cloud.cloudnative-pg.io`.
5. Update restore/recovery (`externalClusters` and the `infra/cnpg/README.md` restore drill) to the plugin form, preserving `serverName` so the existing archive path is kept.
6. Update observability: backup metrics rename from `cnpg_collector_*` to `barman_cloud_cloudnative_pg_io_*`; repoint panels and backup-failure alerts.

Key risks: WAL continuity hinges on reusing the same bucket and `serverName` (otherwise the existing PITR history is orphaned); the metric rename can blind backup-failure alerting; the acceptance gate is a restore-validation drill from a plugin-written backup, per env. This is also the leg that already caused a WAL-archiving incident, so it warrants explicit verification rather than assumption. Refs: https://cloudnative-pg.io/plugin-barman-cloud/docs/migration/ , https://cloudnative-pg.io/plugin-barman-cloud/docs/installation/

## Notes for reviewers

This is opened as a draft. It is Option 3 (the standard unsupervised auto-switchover) by deliberate choice: it is the CNPG default and exactly what the chart already configures, so it changes nothing about how updates behave, only the operator version. The brief prod blip is timed via the merge window rather than eliminated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


