### PR TITLE
fix(cli): refresh Bazel credential-helper token before the expiry boundary

### DIFF
--- a/cli/Sources/TuistBazelCommand/BazelCredentialHelperCommandService.swift
+++ b/cli/Sources/TuistBazelCommand/BazelCredentialHelperCommandService.swift
@@ -15,15 +15,27 @@ public struct BazelCredentialHelperCommandService: BazelCredentialHelperCommandS
     private let serverEnvironmentService: ServerEnvironmentServicing
     private let serverAuthenticationController: ServerAuthenticationControlling
     private let configLoader: ConfigLoading
+    private let date: () -> Date
+
+    /// How far before a token's real expiry Bazel is asked to come back for a fresh
+    /// credential. Bazel caches the credential we return until `expires` and only
+    /// re-invokes this helper lazily, on the first request issued after that
+    /// timestamp. Bringing the reported expiry forward — and refreshing proactively
+    /// once the token is within this window — guarantees Bazel always rotates to a
+    /// fresh token before the current one is rejected by the server, covering
+    /// in-flight requests and clock skew between the developer machine and the cache.
+    private static let expirySafetyMargin: TimeInterval = 60
 
     public init(
         serverEnvironmentService: ServerEnvironmentServicing = ServerEnvironmentService(),
         serverAuthenticationController: ServerAuthenticationControlling = ServerAuthenticationController(),
-        configLoader: ConfigLoading = ConfigLoader()
+        configLoader: ConfigLoading = ConfigLoader(),
+        date: @escaping () -> Date = { Date() }
     ) {
         self.serverEnvironmentService = serverEnvironmentService
         self.serverAuthenticationController = serverAuthenticationController
         self.configLoader = configLoader
+        self.date = date
     }
 
     public func run(
@@ -46,14 +58,35 @@ public struct BazelCredentialHelperCommandService: BazelCredentialHelperCommandS
         let config = try await configLoader.loadConfig(path: directoryPath)
         let serverURL = try serverEnvironmentService.url(configServerURL: config.url)
 
-        guard let token = try await serverAuthenticationController.authenticationToken(serverURL: serverURL)
+        guard var token = try await serverAuthenticationController.authenticationToken(serverURL: serverURL)
         else {
             throw BazelCredentialHelperCommandServiceError.notAuthenticated
         }
 
+        // If a refreshable user token is already within the safety margin of expiring,
+        // refresh it now so Bazel caches a token with a full lifetime ahead of it
+        // rather than one about to be rejected mid-build. Project tokens never expire
+        // and account tokens cannot be refreshed, so they are returned as-is.
+        if case let .user(accessToken, _) = token,
+           accessToken.expiryDate.timeIntervalSince(date()) <= Self.expirySafetyMargin
+        {
+            do {
+                try await serverAuthenticationController.refreshToken(serverURL: serverURL)
+                if let refreshedToken = try await serverAuthenticationController
+                    .authenticationToken(serverURL: serverURL)
+                {
+                    token = refreshedToken
+                }
+            } catch {
+                // Best effort: if the proactive refresh fails (e.g. a transient network
+                // error) fall back to the token we already have, which remains valid for
+                // up to the safety margin.
+            }
+        }
+
         let expiryDate: Date? = switch token {
         case let .user(accessToken: accessToken, refreshToken: _):
-            accessToken.expiryDate
+            accessToken.expiryDate.addingTimeInterval(-Self.expirySafetyMargin)
         case let .account(accessToken):
             accessToken.expiryDate
         case .project:

--- a/cli/Tests/TuistBazelCommandTests/BazelCredentialHelperCommandServiceTests.swift
+++ b/cli/Tests/TuistBazelCommandTests/BazelCredentialHelperCommandServiceTests.swift
@@ -13,7 +13,11 @@ import TuistTesting
 struct BazelCredentialHelperCommandServiceTests {
     private let serverURL = URL(string: "https://test.tuist.dev")!
 
-    private func makeSubject() -> (
+    private struct RefreshError: Error {}
+
+    private func makeSubject(
+        date: @escaping () -> Date = { Date() }
+    ) -> (
         subject: BazelCredentialHelperCommandService,
         serverAuthenticationController: MockServerAuthenticationControlling
     ) {
@@ -32,7 +36,8 @@ struct BazelCredentialHelperCommandServiceTests {
         let subject = BazelCredentialHelperCommandService(
             serverEnvironmentService: serverEnvironmentService,
             serverAuthenticationController: serverAuthenticationController,
-            configLoader: configLoader
+            configLoader: configLoader,
+            date: date
         )
 
         return (subject, serverAuthenticationController)
@@ -41,7 +46,9 @@ struct BazelCredentialHelperCommandServiceTests {
     @Test(.withMockedEnvironment())
     func credentials_returns_authorization_header_and_expiry_for_user_tokens() async throws {
         // Given
-        let (subject, serverAuthenticationController) = makeSubject()
+        let (subject, serverAuthenticationController) = makeSubject(
+            date: { Date(timeIntervalSince1970: 1_750_000_000 - 3600) }
+        )
         given(serverAuthenticationController)
             .authenticationToken(serverURL: .value(serverURL))
             .willReturn(
@@ -58,10 +65,95 @@ struct BazelCredentialHelperCommandServiceTests {
         let response = try await subject.credentials(helperCommand: "get", directory: nil)
 
         // Then
+        // The reported expiry is brought forward by the 60s safety margin so Bazel
+        // re-invokes the helper before the token is actually rejected by the server.
         #expect(
             response == BazelCredentialHelperResponse(
                 headers: ["Authorization": ["Bearer access-token"]],
-                expires: "2025-06-15T15:06:40Z"
+                expires: "2025-06-15T15:05:40Z"
+            )
+        )
+        verify(serverAuthenticationController)
+            .refreshToken(serverURL: .value(serverURL))
+            .called(0)
+    }
+
+    @Test(.withMockedEnvironment())
+    func credentials_refreshes_user_token_within_safety_margin() async throws {
+        // Given
+        let (subject, serverAuthenticationController) = makeSubject(
+            date: { Date(timeIntervalSince1970: 1_750_000_000 - 10) }
+        )
+        given(serverAuthenticationController)
+            .authenticationToken(serverURL: .value(serverURL))
+            .willReturn(
+                .user(
+                    accessToken: .test(
+                        token: "access-token",
+                        expiryDate: Date(timeIntervalSince1970: 1_750_000_000)
+                    ),
+                    refreshToken: .test(token: "refresh-token")
+                )
+            )
+        given(serverAuthenticationController)
+            .authenticationToken(serverURL: .value(serverURL))
+            .willReturn(
+                .user(
+                    accessToken: .test(
+                        token: "fresh-access-token",
+                        expiryDate: Date(timeIntervalSince1970: 1_750_000_600)
+                    ),
+                    refreshToken: .test(token: "fresh-refresh-token")
+                )
+            )
+        given(serverAuthenticationController)
+            .refreshToken(serverURL: .value(serverURL))
+            .willReturn()
+
+        // When
+        let response = try await subject.credentials(helperCommand: "get", directory: nil)
+
+        // Then
+        #expect(
+            response == BazelCredentialHelperResponse(
+                headers: ["Authorization": ["Bearer fresh-access-token"]],
+                expires: "2025-06-15T15:15:40Z"
+            )
+        )
+        verify(serverAuthenticationController)
+            .refreshToken(serverURL: .value(serverURL))
+            .called(1)
+    }
+
+    @Test(.withMockedEnvironment())
+    func credentials_falls_back_to_current_token_when_proactive_refresh_fails() async throws {
+        // Given
+        let (subject, serverAuthenticationController) = makeSubject(
+            date: { Date(timeIntervalSince1970: 1_750_000_000 - 10) }
+        )
+        given(serverAuthenticationController)
+            .authenticationToken(serverURL: .value(serverURL))
+            .willReturn(
+                .user(
+                    accessToken: .test(
+                        token: "access-token",
+                        expiryDate: Date(timeIntervalSince1970: 1_750_000_000)
+                    ),
+                    refreshToken: .test(token: "refresh-token")
+                )
+            )
+        given(serverAuthenticationController)
+            .refreshToken(serverURL: .value(serverURL))
+            .willThrow(RefreshError())
+
+        // When
+        let response = try await subject.credentials(helperCommand: "get", directory: nil)
+
+        // Then
+        #expect(
+            response == BazelCredentialHelperResponse(
+                headers: ["Authorization": ["Bearer access-token"]],
+                expires: "2025-06-15T15:05:40Z"
             )
         )
     }
@@ -89,7 +181,9 @@ struct BazelCredentialHelperCommandServiceTests {
     @Test(.withMockedEnvironment())
     func credentials_returns_expiry_for_account_tokens() async throws {
         // Given
-        let (subject, serverAuthenticationController) = makeSubject()
+        let (subject, serverAuthenticationController) = makeSubject(
+            date: { Date(timeIntervalSince1970: 1_750_000_000 - 3600) }
+        )
         given(serverAuthenticationController)
             .authenticationToken(serverURL: .value(serverURL))
             .willReturn(
@@ -105,6 +199,7 @@ struct BazelCredentialHelperCommandServiceTests {
         let response = try await subject.credentials(helperCommand: "get", directory: nil)
 
         // Then
+        // Account tokens cannot be refreshed, so their exact expiry is reported unchanged.
         #expect(
             response == BazelCredentialHelperResponse(
                 headers: ["Authorization": ["Bearer account-token"]],


### PR DESCRIPTION
## What changed

The `tuist bazel credential-helper` now refreshes a user's access token **proactively** when it is within a 60s safety margin of expiring, and reports `expires` to Bazel brought forward by that same margin (`exp − 60s`). Project tokens (no expiry) and account tokens (cannot be refreshed) are reported unchanged.

## Why

Bazel remote-cache builds against Kura burst with `UNAUTHENTICATED` a few minutes into a build — on whichever operation dominates at that instant — and then recover. In two captured gRPC logs:

- `bazel-grpc-4`: 104× `UNAUTHENTICATED` on **Write** in a 2.0s burst at +348s
- `bazel-grpc-6`: 1089× `UNAUTHENTICATED` on **Read** in a 0.6s burst at +414s

Both bursts are tight and land on the access token's **10-minute (600s) TTL** boundary (the token was already partially aged at build start).

## Root cause

Bazel's `CredentialCacheExpiry` caches the credential-helper response until exactly the `expires` we report and only re-invokes the helper **lazily, on the first request issued after** that timestamp — it never refreshes early (the `--credential_helper_cache_duration` flag is only the no-`expires` fallback). The helper reported the access token's **exact `exp`**, leaving zero margin, so Bazel kept attaching the token to requests right up to the boundary. The in-flight batch of remote-cache RPCs around the boundary then reached Kura *after* `exp` and was rejected.

Kura validates the Tuist JWT **statelessly** (signature + `exp`, locally, via `kura.jwt_verify`), so issuing a new access token via refresh **never revokes** a previously issued one — the only thing that produces `UNAUTHENTICATED` is `exp` passing. This rules out the alternative theory (parallel credential-helper calls minting tokens that invalidate each other): stateless JWTs are not revoked on refresh.

## Why this solution

The boundary failure is fundamentally that Bazel reuses a cached credential up to the instant it expires. Reporting an earlier `expires` makes Bazel reload the helper ~60s before the real expiry; pairing that with a proactive refresh at the same threshold means the helper hands back a token with a full lifetime ahead of it. The result: no in-flight request can ever carry a token within 60s of being rejected, which comfortably covers request latency and clock skew between a developer machine and the cache. The 60s margin is well under the 600s TTL, so it costs roughly one extra refresh per ~9 minutes of continuous building.

The refresh is best-effort: if it fails (e.g. a transient network error) the helper falls back to the token it already has, which is still valid for up to the safety margin, rather than failing the request outright.

## User impact

Developers running long Bazel builds against the Tuist/Kura remote cache no longer hit a mid-build wave of `UNAUTHENTICATED` errors (and the costly stall/retry that followed) when their short-lived access token crosses its expiry.

## Validation

- Unit tests cover the margin reporting, the proactive refresh within the margin, and the best-effort fallback when the refresh fails (plus existing project/account/error paths). All pass; swiftformat + swiftlint clean.
- The built binary against staging returns a freshly refreshed token and reports `expires` exactly 60s before the JWT `exp`.
- A real build issuing 2400+ authenticated gRPC requests across a token reported-expiry boundary completed with **zero `UNAUTHENTICATED`**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)