### PR TITLE
fix(infra): restore the production deploy cascade skipped since the release/deploy merge

### DIFF
--- a/.github/workflows/server-production-deployment.yml
+++ b/.github/workflows/server-production-deployment.yml
@@ -1848,7 +1848,11 @@ jobs:
   # cascade.
   canary:
     needs: build
-    if: ${{ !contains(github.event.head_commit.message, '(hotfix)') }}
+    # `build` runs under `if: always()` so it survives the many skipped sibling
+    # release jobs. A plain-`if` dependent of an `always()`-guarded job gets
+    # caught by skip-propagation and is itself skipped even when `build`
+    # succeeded, so the whole deploy tail must re-assert success explicitly.
+    if: ${{ always() && needs.build.result == 'success' && !contains(github.event.head_commit.message, '(hotfix)') }}
     uses: ./.github/workflows/server-deployment.yml
     with:
       environment: canary
@@ -1859,6 +1863,7 @@ jobs:
   acceptance-tests:
     name: Acceptance Tests
     needs: canary
+    if: ${{ always() && needs.canary.result == 'success' }}
     runs-on: tuist-macos
     timeout-minutes: 15
     environment: server-k8s-canary
@@ -1905,6 +1910,7 @@ jobs:
   backward-compatibility-acceptance:
     name: Backward-Compatibility Acceptance
     needs: canary
+    if: ${{ always() && needs.canary.result == 'success' }}
     runs-on: tuist-macos-26-3
     timeout-minutes: 15
     environment: server-k8s-canary
@@ -1957,10 +1963,21 @@ jobs:
         run: mise run --no-deps e2e module_cache_backward_compat
 
   # Production leg - standard path: canary ready + tests green. Promotes the
-  # same image bytes tests ran against. Skipped on a hotfix.
+  # same image bytes tests ran against. Skipped on a hotfix. The
+  # `always() && needs.*.result == 'success'` guard is required for the
+  # skip-propagation reason documented on `canary` above.
   production:
-    needs: [build, acceptance-tests, backward-compatibility-acceptance]
-    if: ${{ !contains(github.event.head_commit.message, '(hotfix)') }}
+    # `canary` is listed explicitly (not just relied on transitively through the
+    # acceptance jobs) so the "canary must be green before prod" invariant is
+    # encoded in this job's own gate, not in the acceptance jobs' needs.
+    needs: [build, canary, acceptance-tests, backward-compatibility-acceptance]
+    if: >-
+      always() &&
+      needs.build.result == 'success' &&
+      needs.canary.result == 'success' &&
+      needs.acceptance-tests.result == 'success' &&
+      needs.backward-compatibility-acceptance.result == 'success' &&
+      !contains(github.event.head_commit.message, '(hotfix)')
     uses: ./.github/workflows/server-deployment.yml
     with:
       environment: production
@@ -1971,10 +1988,12 @@ jobs:
   # Hotfix fast-path: "(hotfix)" in the commit subject ships production without
   # waiting for canary + acceptance tests. Kept independent of the cascade so a
   # flaky acceptance test can't block an urgent fix; canary is skipped above on
-  # hotfix so the fast-path is the only deploy in flight.
+  # hotfix so the fast-path is the only deploy in flight. The
+  # `always() && needs.build.result == 'success'` guard mirrors `canary`
+  # (see its comment) so this leg is not skip-propagated away.
   production-hotfix:
     needs: build
-    if: ${{ contains(github.event.head_commit.message, '(hotfix)') }}
+    if: ${{ always() && needs.build.result == 'success' && contains(github.event.head_commit.message, '(hotfix)') }}
     uses: ./.github/workflows/server-deployment.yml
     with:
       environment: production


### PR DESCRIPTION
## What changed

Adds an `always() && needs.<upstream>.result == 'success'` guard to every job in the production deploy cascade tail of `server-production-deployment.yml`:

- **canary** and **production-hotfix** re-assert `needs.build.result == 'success'`
- **acceptance-tests** and **backward-compatibility-acceptance** re-assert `needs.canary.result == 'success'`
- **production** re-asserts `build` + both acceptance jobs succeeded

The existing `contains(github.event.head_commit.message, '(hotfix)')` routing (hotfix → `production-hotfix`, non-hotfix → `canary`/`production`) is preserved unchanged.

## Why it changed — the cascade has been building but never deploying

Since #11309 merged, **every** push run of `Server Production Deployment` succeeds at `Build server image` and then **skips `canary` → `acceptance-tests` → `backward-compatibility-acceptance` → `production` / `production-hotfix`**. Net effect: canary and production have not received an automatic deploy at all since that PR landed.

Confirmed across multiple unrelated runs, all `build` ✅ → `canary` ⏭️ skipped:
- [`27686787421`](https://github.com/tuist/tuist/actions/runs/27686787421) — `fix(infra,kura): restore Kura gRPC upload throughput (#11266)`
- [`27674912119`](https://github.com/tuist/tuist/actions/runs/27674912119) — `fix(server): surface SSO on the self-hosted login page`
- [`27672187464`](https://github.com/tuist/tuist/actions/runs/27672187464) — `feat(server): surface and configure a project's default branch`

The flurry of failed/cancelled manual `server-deployment.yml` dispatches over the last day was people working around this.

## Root cause

#11309 folded the deploy cascade into the release pipeline and rewrote `build` and `tag-infra-releases` to run under `if: always() && …` so they survive the many **skipped** sibling release jobs (`release-capi-scaleway`, `release-runners-controller`, `release-xcresult-processor-image`, the kura jobs, …) that don't fire on a given push.

But the deploy-tail jobs kept their original **plain `if`s** — no `always()`, no explicit `needs.<job>.result == 'success'`:

```yaml
canary:
  needs: build
  if: ${{ !contains(github.event.head_commit.message, '(hotfix)') }}
```

A plain-`if` job that depends on an `always()`-guarded job sitting on top of a graph full of skipped jobs gets caught by GitHub Actions' skip-propagation and is **itself skipped — even though `build` succeeded**. The pre-#11309 cascade (`gate → build → canary`) had no `always()` anywhere in the chain (`build.if` was simply `needs.gate.outputs.should_deploy == 'true'`), so the identical plain `if`s worked. Adding `always()` to `build`/`tag-infra-releases` without propagating the explicit success guard downstream is the regression.

## Why this solution over the alternatives

Re-asserting success explicitly with `always() && needs.<upstream>.result == 'success'` is the standard remedy for this footgun and mirrors exactly what `build` and `tag-infra-releases` already do in this same file — it keeps the cascade resilient to skipped *sibling release jobs* while still hard-gating each leg on its real upstream. Dropping `always()` from `build` instead would re-break `build` itself against the skipped release siblings it was changed to tolerate.

## Impact

Restores automatic canary → acceptance → production deploys on every deployable push. Until this merges, production is running whatever was last deployed *before* #11309; targeted deploys must go through `server-deployment.yml`'s `workflow_dispatch`.

## Validation

Workflow-only change; not runnable locally. `actionlint` is clean on the changed expressions (only the two pre-existing `steps.upload.outputs.uploaded` warnings remain, unrelated to this change). Hyphenated `needs.acceptance-tests.result` dot-notation is valid GitHub Actions expression syntax and already used in this file (`needs.check-releases.result`, `needs.tag-infra-releases.result`). End-to-end exercise happens on the next deployable merge to `main`: the run should reach `canary` → acceptance → `production` instead of stopping at `Build server image`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Review hardening (post-`/ce-review`)

A multi-persona review (correctness + reliability tracing all four paths — normal push, hotfix, canary-failure, build-skipped) found no bugs and confirmed exactly one production leg fires per push, failures correctly block production, and the hyphenated `needs.*.result` syntax is valid. Two changes were folded in from it:

- **`production` now depends on `canary` explicitly.** Previously the "canary must be green before prod" invariant was only enforced *transitively* (the acceptance jobs `needs: canary`). `canary` is now in `production`'s `needs` with an explicit `needs.canary.result == 'success'` clause, so the invariant lives in production's own gate. Behavior-preserving defense-in-depth.
- **`production`'s condition moved to the multi-line `if: >-` form** the `build` job already uses, for readability.

Pre-existing follow-up (not in scope here): the `(hotfix)` string is matched inline in three jobs with no single source of truth — tracked in #11343.
