### PR TITLE
feat(cli): resolve Bazel remote cache to the Kura gRPC endpoint

### DIFF
--- a/cli/Sources/TuistBazelCommand/BazelSetupCommandService.swift
+++ b/cli/Sources/TuistBazelCommand/BazelSetupCommandService.swift
@@ -55,26 +55,18 @@ public struct BazelSetupCommandService: BazelSetupCommandServicing {
             throw BazelSetupCommandServiceError.notAuthenticated
         }
 
-        let cacheURL = try await cacheURLStore.getCacheURL(for: serverURL, accountHandle: accountHandle)
-        guard let host = cacheURL.host else {
-            throw BazelSetupCommandServiceError.invalidCacheEndpoint(cacheURL.absoluteString)
-        }
-        let endpoint = if let port = cacheURL.port {
-            "\(host):\(port)"
-        } else {
-            host
-        }
-        // Plaintext cache endpoints (e.g. local development deployments) expose
-        // plaintext gRPC, while TLS endpoints terminate TLS for gRPC too.
-        let remoteCacheScheme = cacheURL.scheme == "http" ? "grpc" : "grpcs"
+        let (remoteCache, credentialHelperHost) = try await resolveRemoteCache(
+            serverURL: serverURL,
+            accountHandle: accountHandle
+        )
 
         let credentialHelperPath = try await createCredentialHelperScriptIfNeeded()
 
         let bazelrcPath = directoryPath.appending(component: ".bazelrc.tuist")
         let bazelrcContent = """
-        build --remote_cache=\(remoteCacheScheme)://\(endpoint)
+        build --remote_cache=\(remoteCache)
         build --remote_header=x-tuist-account-handle=\(accountHandle)
-        build --credential_helper=\(host)=\(credentialHelperPath.pathString)
+        build --credential_helper=\(credentialHelperHost)=\(credentialHelperPath.pathString)
         build --remote_instance_name=\(projectHandle)
 
         """
@@ -88,6 +80,40 @@ public struct BazelSetupCommandService: BazelSetupCommandServicing {
                 ]
             )
         )
+    }
+
+    /// Resolves the gRPC remote cache endpoint for the `--remote_cache` flag and
+    /// the host the credential helper should be registered for.
+    ///
+    /// `TUIST_CACHE_GRPC_ENDPOINT` short-circuits resolution and is used verbatim
+    /// as the remote cache. Otherwise the endpoint returned by `CacheURLStore` is
+    /// converted to its gRPC form: the scheme becomes `grpc` (plaintext, e.g.
+    /// local development deployments) or `grpcs` (TLS), and the host is prefixed
+    /// with `grpc.` — e.g. `https://acme-eu-central-1.kura.tuist.dev` becomes
+    /// `grpcs://grpc.acme-eu-central-1.kura.tuist.dev`.
+    private func resolveRemoteCache(
+        serverURL: URL,
+        accountHandle: String?
+    ) async throws -> (remoteCache: String, credentialHelperHost: String) {
+        if let grpcEndpoint = Environment.current.variables["TUIST_CACHE_GRPC_ENDPOINT"] {
+            guard let host = URL(string: grpcEndpoint)?.host else {
+                throw BazelSetupCommandServiceError.invalidCacheEndpoint(grpcEndpoint)
+            }
+            return (grpcEndpoint, host)
+        }
+
+        let cacheURL = try await cacheURLStore.getCacheURL(for: serverURL, accountHandle: accountHandle)
+        guard let host = cacheURL.host else {
+            throw BazelSetupCommandServiceError.invalidCacheEndpoint(cacheURL.absoluteString)
+        }
+        let grpcHost = "grpc.\(host)"
+        let endpoint = if let port = cacheURL.port {
+            "\(grpcHost):\(port)"
+        } else {
+            grpcHost
+        }
+        let scheme = cacheURL.scheme == "http" ? "grpc" : "grpcs"
+        return ("\(scheme)://\(endpoint)", grpcHost)
     }
 
     private func createCredentialHelperScriptIfNeeded() async throws -> AbsolutePath {

--- a/cli/Sources/TuistBazelCommand/BazelSetupCommandService.swift
+++ b/cli/Sources/TuistBazelCommand/BazelSetupCommandService.swift
@@ -76,6 +76,7 @@ public struct BazelSetupCommandService: BazelSetupCommandServicing {
             .alert(
                 "Generated \(bazelrcPath.pathString)",
                 takeaways: [
+                    "Bazel remote cache: \(remoteCache)",
                     "Add 'try-import %workspace%/.bazelrc.tuist' to your .bazelrc to enable the Tuist remote cache",
                 ]
             )
@@ -96,7 +97,10 @@ public struct BazelSetupCommandService: BazelSetupCommandServicing {
         accountHandle: String?
     ) async throws -> (remoteCache: String, credentialHelperHost: String) {
         if let grpcEndpoint = Environment.current.variables["TUIST_CACHE_GRPC_ENDPOINT"] {
-            guard let host = URL(string: grpcEndpoint)?.host else {
+            guard let url = URL(string: grpcEndpoint),
+                  let host = url.host,
+                  url.scheme == "grpc" || url.scheme == "grpcs"
+            else {
                 throw BazelSetupCommandServiceError.invalidCacheEndpoint(grpcEndpoint)
             }
             return (grpcEndpoint, host)
@@ -156,7 +160,8 @@ public enum BazelSetupCommandServiceError: LocalizedError, Equatable {
             return
                 "The project full handle is required. Set 'project' in your tuist.toml or 'fullHandle' in your Tuist.swift."
         case let .invalidCacheEndpoint(endpoint):
-            return "The cache endpoint \(endpoint) is invalid."
+            return
+                "The cache endpoint \(endpoint) is invalid. Expected a valid URL with a host; gRPC overrides (TUIST_CACHE_GRPC_ENDPOINT) must use the grpc:// or grpcs:// scheme."
         }
     }
 }

--- a/cli/Tests/TuistBazelCommandTests/BazelSetupCommandServiceTests.swift
+++ b/cli/Tests/TuistBazelCommandTests/BazelSetupCommandServiceTests.swift
@@ -187,6 +187,46 @@ struct BazelSetupCommandServiceTests {
     }
 
     @Test(.withMockedEnvironment(), .withMockedDependencies(), .inTemporaryDirectory)
+    func run_short_circuits_to_the_grpc_endpoint_override_without_a_port() async throws {
+        // Given
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let (subject, serverAuthenticationController, _) = makeSubject()
+        given(serverAuthenticationController)
+            .authenticationToken(serverURL: .any)
+            .willReturn(.project("token"))
+        Environment.mocked?.variables["TUIST_CACHE_GRPC_ENDPOINT"] = "grpcs://custom-grpc.example.com"
+
+        // When
+        try await subject.run(directory: temporaryDirectory.pathString)
+
+        // Then
+        let scriptPath = try credentialHelperPath()
+        let bazelrcContent = try await fileSystem.readTextFile(
+            at: temporaryDirectory.appending(component: ".bazelrc.tuist")
+        )
+        #expect(bazelrcContent.contains("build --remote_cache=grpcs://custom-grpc.example.com"))
+        #expect(bazelrcContent.contains("build --credential_helper=custom-grpc.example.com=\(scriptPath.pathString)"))
+    }
+
+    @Test(.withMockedEnvironment(), .withMockedDependencies(), .inTemporaryDirectory)
+    func run_throws_when_the_grpc_endpoint_override_uses_a_non_grpc_scheme() async throws {
+        // Given
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let (subject, serverAuthenticationController, _) = makeSubject()
+        given(serverAuthenticationController)
+            .authenticationToken(serverURL: .any)
+            .willReturn(.project("token"))
+        // An http(s):// override would otherwise be written verbatim as the remote cache,
+        // sending credentials over a non-gRPC (and potentially plaintext) channel.
+        Environment.mocked?.variables["TUIST_CACHE_GRPC_ENDPOINT"] = "https://custom-grpc.example.com"
+
+        // When/Then
+        await #expect(throws: BazelSetupCommandServiceError.invalidCacheEndpoint("https://custom-grpc.example.com")) {
+            try await subject.run(directory: temporaryDirectory.pathString)
+        }
+    }
+
+    @Test(.withMockedEnvironment(), .withMockedDependencies(), .inTemporaryDirectory)
     func run_does_not_overwrite_an_existing_credential_helper_script() async throws {
         // Given
         let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)

--- a/cli/Tests/TuistBazelCommandTests/BazelSetupCommandServiceTests.swift
+++ b/cli/Tests/TuistBazelCommandTests/BazelSetupCommandServiceTests.swift
@@ -82,9 +82,9 @@ struct BazelSetupCommandServiceTests {
         )
         #expect(
             bazelrcContent == """
-            build --remote_cache=grpcs://cache.tuist.dev
+            build --remote_cache=grpcs://grpc.cache.tuist.dev
             build --remote_header=x-tuist-account-handle=my-account
-            build --credential_helper=cache.tuist.dev=\(scriptPath.pathString)
+            build --credential_helper=grpc.cache.tuist.dev=\(scriptPath.pathString)
             build --remote_instance_name=my-project
 
             """
@@ -120,8 +120,8 @@ struct BazelSetupCommandServiceTests {
         let bazelrcContent = try await fileSystem.readTextFile(
             at: temporaryDirectory.appending(component: ".bazelrc.tuist")
         )
-        #expect(bazelrcContent.contains("build --remote_cache=grpcs://cache.tuist.dev:8443"))
-        #expect(bazelrcContent.contains("build --credential_helper=cache.tuist.dev=\(scriptPath.pathString)"))
+        #expect(bazelrcContent.contains("build --remote_cache=grpcs://grpc.cache.tuist.dev:8443"))
+        #expect(bazelrcContent.contains("build --credential_helper=grpc.cache.tuist.dev=\(scriptPath.pathString)"))
     }
 
     @Test(.withMockedEnvironment(), .withMockedDependencies(), .inTemporaryDirectory)
@@ -143,8 +143,47 @@ struct BazelSetupCommandServiceTests {
         let bazelrcContent = try await fileSystem.readTextFile(
             at: temporaryDirectory.appending(component: ".bazelrc.tuist")
         )
-        #expect(bazelrcContent.contains("build --remote_cache=grpc://localhost:5091"))
-        #expect(bazelrcContent.contains("build --credential_helper=localhost=\(scriptPath.pathString)"))
+        #expect(bazelrcContent.contains("build --remote_cache=grpc://grpc.localhost:5091"))
+        #expect(bazelrcContent.contains("build --credential_helper=grpc.localhost=\(scriptPath.pathString)"))
+    }
+
+    @Test(.withMockedEnvironment(), .withMockedDependencies(), .inTemporaryDirectory)
+    func run_short_circuits_to_the_grpc_endpoint_override() async throws {
+        // Given
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let (subject, serverAuthenticationController, _) = makeSubject()
+        given(serverAuthenticationController)
+            .authenticationToken(serverURL: .any)
+            .willReturn(.project("token"))
+        Environment.mocked?.variables["TUIST_CACHE_GRPC_ENDPOINT"] = "grpcs://custom-grpc.example.com:9999"
+
+        // When
+        try await subject.run(directory: temporaryDirectory.pathString)
+
+        // Then
+        let scriptPath = try credentialHelperPath()
+        let bazelrcContent = try await fileSystem.readTextFile(
+            at: temporaryDirectory.appending(component: ".bazelrc.tuist")
+        )
+        // The override is used verbatim: no `grpc.` prefix or scheme conversion is applied.
+        #expect(bazelrcContent.contains("build --remote_cache=grpcs://custom-grpc.example.com:9999"))
+        #expect(bazelrcContent.contains("build --credential_helper=custom-grpc.example.com=\(scriptPath.pathString)"))
+    }
+
+    @Test(.withMockedEnvironment(), .withMockedDependencies(), .inTemporaryDirectory)
+    func run_throws_when_the_grpc_endpoint_override_has_no_host() async throws {
+        // Given
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let (subject, serverAuthenticationController, _) = makeSubject()
+        given(serverAuthenticationController)
+            .authenticationToken(serverURL: .any)
+            .willReturn(.project("token"))
+        Environment.mocked?.variables["TUIST_CACHE_GRPC_ENDPOINT"] = ""
+
+        // When/Then
+        await #expect(throws: BazelSetupCommandServiceError.invalidCacheEndpoint("")) {
+            try await subject.run(directory: temporaryDirectory.pathString)
+        }
     }
 
     @Test(.withMockedEnvironment(), .withMockedDependencies(), .inTemporaryDirectory)
@@ -185,7 +224,7 @@ struct BazelSetupCommandServiceTests {
 
         // Then
         let bazelrcContent = try await fileSystem.readTextFile(at: bazelrcPath)
-        #expect(bazelrcContent.contains("build --remote_cache=grpcs://cache.tuist.dev"))
+        #expect(bazelrcContent.contains("build --remote_cache=grpcs://grpc.cache.tuist.dev"))
     }
 
     @Test(.withMockedEnvironment(), .withMockedDependencies(), .inTemporaryDirectory)


### PR DESCRIPTION
## What changed

`tuist bazel setup` generates `.bazelrc.tuist` with a `--remote_cache` flag pointing at a Kura cache node. `CacheURLStore` returns the node's **HTTP(S)** URL, but Kura serves the Bazel REAPI over **gRPC** on a separate `grpc.`-prefixed host. The generated config therefore pointed Bazel at a host that doesn't serve gRPC.

This change resolves the remote cache to the correct gRPC endpoint entirely on the client, in `BazelSetupCommandService`:

- **gRPC conversion of the resolved endpoint** — the scheme becomes `grpc` (plaintext, e.g. local development deployments) or `grpcs` (TLS), and the host is prefixed with `grpc.`. For example, `https://acme-eu-central-1.kura.tuist.dev` becomes `grpcs://grpc.acme-eu-central-1.kura.tuist.dev`. The `http→grpc` / `https→grpcs` scheme conversion already existed; the **`grpc.` host prefix is the new piece**.
- **`TUIST_CACHE_GRPC_ENDPOINT` override** — when set, it short-circuits resolution and is used verbatim as `--remote_cache` (no scheme conversion, no `grpc.` prefix). This mirrors the existing `TUIST_CACHE_ENDPOINT` HTTP override and is useful for local/self-hosted gRPC endpoints.

## Why this approach

The endpoint-to-gRPC mapping is deterministic, so it can live next to where `.bazelrc.tuist` is written rather than being threaded through the server's `/api/cache/endpoints` response. Keeping it client-side means **no server change and no API/OpenAPI contract change**, and the override env var gives an escape hatch without round-tripping through the server.

## Notable detail: credential helper host must track the cache host

`--credential_helper` is now registered for the **same `grpc.`-prefixed host** as `--remote_cache`. Bazel matches the credential helper against the host it actually connects to, so the two must stay in sync — otherwise the prefixed gRPC host would have no registered helper and authentication would fail. Both the resolved-endpoint path and the override path return a single `(remoteCache, credentialHelperHost)` pair to guarantee this.

## User impact

`tuist bazel setup` now produces a `.bazelrc.tuist` whose `--remote_cache` actually reaches Kura's gRPC REAPI endpoint, so Bazel remote caching works against Kura nodes. Users can override the endpoint with `TUIST_CACHE_GRPC_ENDPOINT`.

## Validation

- `swift build --replace-scm-with-registry --target TuistBazelCommand` compiles cleanly.
- `swiftformat --lint` clean on the changed files.
- Updated the existing `BazelSetupCommandServiceTests` assertions for the `grpc.` prefix on both `--remote_cache` and `--credential_helper`, and added tests for the `TUIST_CACHE_GRPC_ENDPOINT` verbatim short-circuit and its invalid-URL error path. Note: this test target runs via the Xcode workspace on macOS CI (it is not an SPM target), so the suite was not executed locally — the production target's compilation and the format check were verified locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)