### PR TITLE
ci(kura): register Kura runtime image dispatch trigger (stub)

### DIFF
--- a/.github/workflows/kura-runtime-image.yml
+++ b/.github/workflows/kura-runtime-image.yml
@@ -1,83 +1,22 @@
 name: Kura Runtime Image
 
-# Builds and pushes an ad-hoc Kura runtime image (`ghcr.io/tuist/kura`) from a
-# specific commit, so a feature branch can be deployed to staging before it is
-# merged and the push-to-main `release-kura-docker` job cuts a `kura@` release.
-#
-# The release pipeline builds a multi-arch image from natively-compiled amd64 +
-# arm64 binaries. This dispatch build is amd64-only (the Hetzner managed-region
-# and staging runner nodes are amd64), compiling the binary inline rather than
-# pulling release artifacts. Pair it with a `Server Deployment` dispatch:
-# pass the printed `sha-<sha>` tag as `kura_runtime_image_tag` and the same
-# commit as `commit_sha`.
+# Stub. This only registers the workflow_dispatch trigger on the default branch
+# (GitHub requires a dispatch workflow to exist on the default branch before it
+# can be triggered against any other ref). The real dispatchable build — which
+# compiles the Kura binary at a chosen commit and pushes ghcr.io/tuist/kura —
+# ships in #11294, where it gets a proper review. Because workflow_dispatch runs
+# the workflow file from the dispatched ref, dispatching this against the #11294
+# branch executes that real build.
 
 on:
   workflow_dispatch: {}
 
 permissions:
   contents: read
-  packages: write
-
-env:
-  MISE_VERSION: "2026.4.18"
-  MISE_GITHUB_TOKEN: ${{ secrets.TUIST_CLI_GITHUB_TOKEN || github.token }}
-  REGISTRY: ghcr.io
-  IMAGE_NAME: tuist/kura
 
 jobs:
-  build-and-push:
-    name: Build and push (amd64)
+  noop:
+    name: Stub
     runs-on: ubuntu-latest
-    timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
-
-      - uses: jdx/mise-action@v4.0.1
-        with:
-          version: ${{ env.MISE_VERSION }}
-          install_args: --force rust
-          working_directory: kura
-
-      - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: kura-rust-${{ runner.os }}
-          workspaces: |
-            kura -> target
-
-      - name: Build Kura binary
-        working-directory: kura
-        run: env -u RUSTUP_TOOLCHAIN cargo build --release --locked
-
-      - name: Stage binary for Docker build
-        working-directory: kura
-        run: |
-          mkdir -p bin/amd64
-          cp target/release/kura bin/amd64/kura
-          chmod +x bin/amd64/kura
-
-      - uses: docker/setup-buildx-action@v3
-
-      - uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Compute tag
-        id: tag
-        run: echo "tag=sha-${GITHUB_SHA::12}" >> "$GITHUB_OUTPUT"
-
-      - uses: docker/build-push-action@v6
-        with:
-          context: ./kura
-          file: ./kura/Dockerfile.release
-          platforms: linux/amd64
-          push: true
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.tag }}
-          cache-from: type=gha,scope=kura-runtime
-          cache-to: type=gha,mode=max,scope=kura-runtime
-
-      - name: Print deploy hint
-        run: |
-          echo "Pushed ${REGISTRY}/${IMAGE_NAME}:${{ steps.tag.outputs.tag }}"
-          echo "Deploy with: Server Deployment (staging) commit_sha=${GITHUB_SHA} kura_runtime_image_tag=${{ steps.tag.outputs.tag }}"
+      - run: echo "Stub. The real Kura runtime image build ships in #11294."

--- a/.github/workflows/kura-runtime-image.yml
+++ b/.github/workflows/kura-runtime-image.yml
@@ -1,0 +1,83 @@
+name: Kura Runtime Image
+
+# Builds and pushes an ad-hoc Kura runtime image (`ghcr.io/tuist/kura`) from a
+# specific commit, so a feature branch can be deployed to staging before it is
+# merged and the push-to-main `release-kura-docker` job cuts a `kura@` release.
+#
+# The release pipeline builds a multi-arch image from natively-compiled amd64 +
+# arm64 binaries. This dispatch build is amd64-only (the Hetzner managed-region
+# and staging runner nodes are amd64), compiling the binary inline rather than
+# pulling release artifacts. Pair it with a `Server Deployment` dispatch:
+# pass the printed `sha-<sha>` tag as `kura_runtime_image_tag` and the same
+# commit as `commit_sha`.
+
+on:
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  MISE_VERSION: "2026.4.18"
+  MISE_GITHUB_TOKEN: ${{ secrets.TUIST_CLI_GITHUB_TOKEN || github.token }}
+  REGISTRY: ghcr.io
+  IMAGE_NAME: tuist/kura
+
+jobs:
+  build-and-push:
+    name: Build and push (amd64)
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: jdx/mise-action@v4.0.1
+        with:
+          version: ${{ env.MISE_VERSION }}
+          install_args: --force rust
+          working_directory: kura
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: kura-rust-${{ runner.os }}
+          workspaces: |
+            kura -> target
+
+      - name: Build Kura binary
+        working-directory: kura
+        run: env -u RUSTUP_TOOLCHAIN cargo build --release --locked
+
+      - name: Stage binary for Docker build
+        working-directory: kura
+        run: |
+          mkdir -p bin/amd64
+          cp target/release/kura bin/amd64/kura
+          chmod +x bin/amd64/kura
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute tag
+        id: tag
+        run: echo "tag=sha-${GITHUB_SHA::12}" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: ./kura
+          file: ./kura/Dockerfile.release
+          platforms: linux/amd64
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.tag }}
+          cache-from: type=gha,scope=kura-runtime
+          cache-to: type=gha,mode=max,scope=kura-runtime
+
+      - name: Print deploy hint
+        run: |
+          echo "Pushed ${REGISTRY}/${IMAGE_NAME}:${{ steps.tag.outputs.tag }}"
+          echo "Deploy with: Server Deployment (staging) commit_sha=${GITHUB_SHA} kura_runtime_image_tag=${{ steps.tag.outputs.tag }}"


### PR DESCRIPTION
## What

Adds a **stub** `.github/workflows/kura-runtime-image.yml` whose only purpose is to register a `workflow_dispatch` trigger on the default branch. The job is a no-op `echo`.

## Why a separate, stubbed PR

GitHub only lets you dispatch a `workflow_dispatch` workflow once the file exists on the **default branch** — a new dispatch workflow on a feature branch can't be triggered. Because `workflow_dispatch` executes the workflow file from the *dispatched ref*, merging this stub lets us dispatch the workflow against the feature branch in [#11294](https://github.com/tuist/tuist/pull/11294), which runs the real build defined there.

This keeps the actual build (compile Kura at a chosen commit, push `ghcr.io/tuist/kura:sha-<sha>`) where it can be reviewed properly — in #11294 — while unblocking pre-merge staging testing now.

## Safety

Inert until dispatched: no `push`/`pull_request` triggers, and the default-branch job only echoes. Merging it changes nothing automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)