### PR TITLE
fix(cli): graph recursion overflow

### DIFF
--- a/cli/Sources/TuistCore/Graph/CircularDependencyLinter.swift
+++ b/cli/Sources/TuistCore/Graph/CircularDependencyLinter.swift
@@ -15,21 +15,47 @@ public struct CircularDependencyLinter: CircularDependencyLinting {
     public func lintWorkspace(workspace: Workspace, projects: [Project]) throws {
         let cycleDetector = GraphCircularDetector()
         let cache = GraphLoader.Cache(projects: projects)
-        for project in workspace.projects {
-            try lintProject(
-                path: project,
-                cache: cache,
-                cycleDetector: cycleDetector
-            )
+
+        var stack = workspace.projects
+            .reversed()
+            .map { LintFrame.project(path: $0) }
+
+        while let frame = stack.popLast() {
+            switch frame {
+            case let .project(path):
+                try lintProject(path: path, cache: cache, stack: &stack)
+
+            case let .target(path, name):
+                try lintTarget(path: path, name: name, cache: cache, stack: &stack)
+
+            case let .dependency(path, fromTarget, dependency):
+                lintDependency(
+                    path: path,
+                    fromTarget: fromTarget,
+                    dependency: dependency,
+                    stack: &stack,
+                    cycleDetector: cycleDetector
+                )
+
+            case .completeTarget:
+                try cycleDetector.complete()
+            }
         }
     }
 
     // MARK: - Private
 
+    private enum LintFrame {
+        case project(path: AbsolutePath)
+        case target(path: AbsolutePath, name: String)
+        case dependency(path: AbsolutePath, fromTarget: String, dependency: TargetDependency)
+        case completeTarget
+    }
+
     private func lintProject(
         path: AbsolutePath,
         cache: GraphLoader.Cache,
-        cycleDetector: GraphCircularDetector
+        stack: inout [LintFrame]
     ) throws {
         guard !cache.projectLoaded(path: path) else {
             return
@@ -39,13 +65,8 @@ public struct CircularDependencyLinter: CircularDependencyLinting {
         }
         cache.add(project: project)
 
-        for target in project.targets.values.sorted() {
-            try lintTarget(
-                path: path,
-                name: target.name,
-                cache: cache,
-                cycleDetector: cycleDetector
-            )
+        for target in project.targets.values.sorted(by: >) {
+            stack.append(.target(path: path, name: target.name))
         }
     }
 
@@ -53,7 +74,7 @@ public struct CircularDependencyLinter: CircularDependencyLinting {
         path: AbsolutePath,
         name: String,
         cache: GraphLoader.Cache,
-        cycleDetector: GraphCircularDetector
+        stack: inout [LintFrame]
     ) throws {
         guard !cache.targetLoaded(path: path, name: name) else {
             return
@@ -69,50 +90,41 @@ public struct CircularDependencyLinter: CircularDependencyLinting {
 
         cache.add(target: target, path: path)
 
-        for item in target.dependencies {
-            try lintDependency(
-                path: path,
-                fromTarget: target.name,
-                dependency: item,
-                cache: cache,
-                cycleDetector: cycleDetector
+        stack.append(.completeTarget)
+        for item in target.dependencies.reversed() {
+            stack.append(
+                .dependency(
+                    path: path,
+                    fromTarget: target.name,
+                    dependency: item
+                )
             )
         }
-
-        try cycleDetector.complete()
     }
 
     private func lintDependency(
         path: AbsolutePath,
         fromTarget: String,
         dependency: TargetDependency,
-        cache: GraphLoader.Cache,
+        stack: inout [LintFrame],
         cycleDetector: GraphCircularDetector
-    ) throws {
+    ) {
         switch dependency {
         case let .target(toTarget, _, _):
             // A target within the same project.
             let circularFrom = GraphCircularDetectorNode(path: path, name: fromTarget)
             let circularTo = GraphCircularDetectorNode(path: path, name: toTarget)
             cycleDetector.start(from: circularFrom, to: circularTo)
-            try lintTarget(
-                path: path,
-                name: toTarget,
-                cache: cache,
-                cycleDetector: cycleDetector
-            )
+            stack.append(.target(path: path, name: toTarget))
+
         case let .project(toTarget, projectPath, _, _):
-            // A target from another project
+            // A target from another project.
             let circularFrom = GraphCircularDetectorNode(path: path, name: fromTarget)
             let circularTo = GraphCircularDetectorNode(path: projectPath, name: toTarget)
             cycleDetector.start(from: circularFrom, to: circularTo)
-            try lintProject(path: projectPath, cache: cache, cycleDetector: cycleDetector)
-            try lintTarget(
-                path: projectPath,
-                name: toTarget,
-                cache: cache,
-                cycleDetector: cycleDetector
-            )
+            stack.append(.target(path: projectPath, name: toTarget))
+            stack.append(.project(path: projectPath))
+
         case .framework, .xcframework, .library, .package, .sdk, .xctest:
             break
         }

--- a/cli/Sources/TuistCore/Graph/GraphCircularDetector.swift
+++ b/cli/Sources/TuistCore/Graph/GraphCircularDetector.swift
@@ -1,5 +1,4 @@
 import Path
-import TSCBasic
 
 struct GraphCircularDetectorNode: Hashable, CustomDebugStringConvertible {
     let path: Path.AbsolutePath
@@ -37,45 +36,65 @@ public final class GraphCircularDetector: GraphCircularDetecting {
 
     // MARK: - Private
 
-    /// Depth first search to detect cycles
-    ///
-    /// For a given node, a full path through adjacent nodes is explored one by one.
-    ///  - The history of visited nodes along a path is stored in `currentPath`
-    ///  - In the event a node we are visiting already exists in `currentPath` we have a cycle!
-    ///
-    /// To optimize this process, we also keep a list of nodes that had all outgoing paths inspected to completion
-    ///  - Nodes that have had all adjacent nodes traversed are added to `inspectedNodes`
-    ///  - In the event a node we are visiting already exists in `inspectedNodes` we can skip it
-    ///
-    /// - Parameter node: The node to visit
-    /// - Parameter currentPath: The current path of nodes we are inspecting
-    /// - Parameter inspectedNodes: History of nodes that have had all their adjacent nodes traversed to completion
+    private struct VisitFrame {
+        let node: Node
+        let successors: [Node]
+        var nextSuccessorIndex: Int
+    }
+
     private func visit(
         node: Node,
-        currentPath: OrderedSet<Node> = OrderedSet(),
         inspectedNodes: inout Set<Node>
     ) throws {
         guard !inspectedNodes.contains(node) else {
             return
         }
 
-        if currentPath.contains(node) {
-            let cyclePath = currentPath + [node]
-            throw GraphLoadingError.circularDependency(cyclePath.map(\.element))
-        }
-
-        var currentPath = currentPath
+        var activeNodes = Set<Node>()
+        var currentPath: [Node] = []
+        var stack = [
+            VisitFrame(
+                node: node,
+                successors: Array(node.to),
+                nextSuccessorIndex: 0
+            ),
+        ]
+        activeNodes.insert(node)
         currentPath.append(node)
 
-        for nextNode in node.to {
-            try visit(
-                node: nextNode,
-                currentPath: currentPath,
-                inspectedNodes: &inspectedNodes
-            )
-        }
+        while !stack.isEmpty {
+            let frameIndex = stack.count - 1
+            let frame = stack[frameIndex]
 
-        inspectedNodes.insert(node)
+            if frame.nextSuccessorIndex < frame.successors.count {
+                let nextNode = frame.successors[frame.nextSuccessorIndex]
+                stack[frameIndex].nextSuccessorIndex += 1
+
+                if activeNodes.contains(nextNode) {
+                    let cyclePath = currentPath + [nextNode]
+                    throw GraphLoadingError.circularDependency(cyclePath.map(\.element))
+                }
+
+                guard !inspectedNodes.contains(nextNode) else {
+                    continue
+                }
+
+                activeNodes.insert(nextNode)
+                currentPath.append(nextNode)
+                stack.append(
+                    VisitFrame(
+                        node: nextNode,
+                        successors: Array(nextNode.to),
+                        nextSuccessorIndex: 0
+                    )
+                )
+            } else {
+                inspectedNodes.insert(frame.node)
+                activeNodes.remove(frame.node)
+                currentPath.removeLast()
+                stack.removeLast()
+            }
+        }
     }
 
     private final class Node: Hashable, CustomDebugStringConvertible {

--- a/cli/Sources/TuistCore/Graph/GraphTraverser.swift
+++ b/cli/Sources/TuistCore/Graph/GraphTraverser.swift
@@ -5,7 +5,6 @@ import TuistSupport
 import TuistThreadSafe
 import XcodeGraph
 
-import func TSCBasic.topologicalSort
 import func TSCBasic.transitiveClosure
 
 // swiftlint:disable type_body_length

--- a/cli/Sources/TuistGenerator/Linter/StaticProductsGraphLinter.swift
+++ b/cli/Sources/TuistGenerator/Linter/StaticProductsGraphLinter.swift
@@ -37,8 +37,7 @@ struct StaticProductsGraphLinter: StaticProductsGraphLinting {
             let results = buildStaticProductsMap(
                 visiting: dependency,
                 graphTraverser: graphTraverser,
-                cache: cache,
-                configGeneratedProjectOptions: configGeneratedProjectOptions
+                cache: cache
             )
 
             warnings.formUnion(results.linked.flatMap {
@@ -72,28 +71,80 @@ struct StaticProductsGraphLinter: StaticProductsGraphLinting {
     private func buildStaticProductsMap(
         visiting dependency: GraphDependency,
         graphTraverser: GraphTraversing,
-        cache: Cache,
-        configGeneratedProjectOptions: TuistGeneratedProjectOptions
+        cache: Cache
     ) -> StaticProducts {
         if let cachedResult = cache.results(for: dependency) {
             return cachedResult
         }
 
-        // Collect dependency results traversing the graph (dfs)
-        var results = dependencies(for: dependency, graphTraverser: graphTraverser).reduce(StaticProducts()) { results, dep in
-            buildStaticProductsMap(
-                visiting: dep,
-                graphTraverser: graphTraverser,
-                cache: cache,
-                configGeneratedProjectOptions: configGeneratedProjectOptions
-            )
-            .merged(with: results)
+        var activeDependencies = Set<GraphDependency>()
+        var stack = [
+            StaticProductsFrame(
+                dependency: dependency,
+                dependencies: dependencies(for: dependency, graphTraverser: graphTraverser),
+                nextDependencyIndex: 0,
+                results: StaticProducts()
+            ),
+        ]
+        activeDependencies.insert(dependency)
+
+        while let frame = stack.last {
+            let frameIndex = stack.count - 1
+            if frame.nextDependencyIndex < frame.dependencies.count {
+                let childDependency = frame.dependencies[frame.nextDependencyIndex]
+
+                if let cachedResult = cache.results(for: childDependency) {
+                    stack[frameIndex].nextDependencyIndex += 1
+                    stack[frameIndex].results = cachedResult.merged(with: stack[frameIndex].results)
+                    continue
+                }
+
+                if activeDependencies.contains(childDependency) {
+                    stack[frameIndex].nextDependencyIndex += 1
+                    continue
+                }
+
+                activeDependencies.insert(childDependency)
+                stack.append(
+                    StaticProductsFrame(
+                        dependency: childDependency,
+                        dependencies: dependencies(for: childDependency, graphTraverser: graphTraverser),
+                        nextDependencyIndex: 0,
+                        results: StaticProducts()
+                    )
+                )
+            } else {
+                let completedFrame = stack.removeLast()
+                let results = finalize(
+                    results: completedFrame.results,
+                    for: completedFrame.dependency,
+                    graphTraverser: graphTraverser
+                )
+                cache.cache(results: results, for: completedFrame.dependency)
+                activeDependencies.remove(completedFrame.dependency)
+
+                if let parentFrameIndex = stack.indices.last {
+                    stack[parentFrameIndex].nextDependencyIndex += 1
+                    stack[parentFrameIndex].results = results.merged(with: stack[parentFrameIndex].results)
+                } else {
+                    return results
+                }
+            }
         }
+
+        return cache.results(for: dependency) ?? StaticProducts()
+    }
+
+    private func finalize(
+        results: StaticProducts,
+        for dependency: GraphDependency,
+        graphTraverser: GraphTraversing
+    ) -> StaticProducts {
+        var results = results
 
         // Static node case
         if isStaticProduct(dependency, graphTraverser: graphTraverser) {
             results.unlinked.insert(dependency)
-            cache.cache(results: results, for: dependency)
             return results
         }
 
@@ -102,21 +153,12 @@ struct StaticProductsGraphLinter: StaticProductsGraphLinting {
               let dependencyTarget = graphTraverser.target(path: targetPath, name: targetName),
               dependencyTarget.target.canLinkStaticProducts()
         else {
-            cache.cache(
-                results: results,
-                for: dependency
-            )
             return results
         }
 
         while let staticProduct = results.unlinked.popFirst() {
             results.linked[staticProduct, default: Set()].insert(dependency)
         }
-
-        cache.cache(
-            results: results,
-            for: dependency
-        )
 
         return results
     }
@@ -276,6 +318,13 @@ struct StaticProductsGraphLinter: StaticProductsGraphLinting {
     }
 
     // MARK: - Helper Types
+
+    private struct StaticProductsFrame {
+        let dependency: GraphDependency
+        let dependencies: [GraphDependency]
+        var nextDependencyIndex: Int
+        var results: StaticProducts
+    }
 
     private struct StaticDependencyWarning: Hashable, Comparable {
         var staticProduct: GraphDependency

--- a/cli/Sources/TuistGenerator/Mappers/ModuleMapMapper.swift
+++ b/cli/Sources/TuistGenerator/Mappers/ModuleMapMapper.swift
@@ -30,6 +30,13 @@ public struct ModuleMapMapper: GraphMapping { // swiftlint:disable:this type_bod
         let headerSearchPaths: [String]
     }
 
+    private struct DependenciesModuleMapsFrame {
+        let targetID: TargetID
+        let dependencies: [GraphTargetReference]
+        var nextDependencyIndex: Int
+        var dependenciesMetadata: Set<DependencyMetadata>
+    }
+
     public init() {}
 
     // swiftlint:disable function_body_length
@@ -43,7 +50,7 @@ public struct ModuleMapMapper: GraphMapping { // swiftlint:disable:this type_bod
         let graphTraverser = GraphTraverser(graph: graph)
         for target in graphTraverser.allTargets() {
             try Self.dependenciesModuleMaps(
-                graph: graph,
+                graphTraverser: graphTraverser,
                 target: target,
                 targetToDependenciesMetadata: &targetToDependenciesMetadata
             )
@@ -177,52 +184,110 @@ public struct ModuleMapMapper: GraphMapping { // swiftlint:disable:this type_bod
     /// Each target must link the module map of its direct and indirect dependencies.
     /// The `targetToDependenciesMetadata` is also used as cache to avoid recomputing the set for already computed targets.
     private static func dependenciesModuleMaps( // swiftlint:disable:this function_body_length
-        graph: Graph,
+        graphTraverser: GraphTraverser,
         target: GraphTarget,
         targetToDependenciesMetadata: inout [TargetID: Set<DependencyMetadata>]
     ) throws {
-        let targetID = TargetID(projectPath: target.path, targetName: target.target.name)
+        let targetID = Self.targetID(target)
         if targetToDependenciesMetadata[targetID] != nil {
             // already computed
             return
         }
 
-        let graphTraverser = GraphTraverser(graph: graph)
+        var activeTargetIDs = Set<TargetID>()
+        var stack = [
+            DependenciesModuleMapsFrame(
+                targetID: targetID,
+                dependencies: Self.directTargetDependencies(graphTraverser: graphTraverser, target: target),
+                nextDependencyIndex: 0,
+                dependenciesMetadata: []
+            ),
+        ]
+        activeTargetIDs.insert(targetID)
 
-        var dependenciesMetadata: Set<DependencyMetadata> = []
-        for dependency in graphTraverser.directTargetDependencies(path: target.path, name: target.target.name) {
-            try Self.dependenciesModuleMaps(
-                graph: graph,
-                target: dependency.graphTarget,
-                targetToDependenciesMetadata: &targetToDependenciesMetadata
-            )
+        while let frame = stack.last {
+            let frameIndex = stack.count - 1
+            if frame.nextDependencyIndex < frame.dependencies.count {
+                let dependency = frame.dependencies[frame.nextDependencyIndex]
+                let dependencyTargetID = Self.targetID(dependency.graphTarget)
 
-            // direct dependency module map
-            let dependencyModuleMapPath: AbsolutePath?
+                if let indirectDependencyMetadata = targetToDependenciesMetadata[dependencyTargetID] {
+                    stack[frameIndex].nextDependencyIndex += 1
+                    stack[frameIndex].dependenciesMetadata.formUnion(indirectDependencyMetadata)
+                    stack[frameIndex].dependenciesMetadata.insert(
+                        try Self.dependencyMetadata(for: dependency)
+                    )
+                    continue
+                }
 
-            if case let .string(dependencyModuleMap) = dependency.target.settings?.base[Self.modulemapFileSetting] {
-                let pathString = dependency.graphTarget.path.pathString
-                dependencyModuleMapPath = try AbsolutePath(
-                    validating: dependencyModuleMap
-                        .replacingOccurrences(of: "$(PROJECT_DIR)", with: pathString)
-                        .replacingOccurrences(of: "$(SRCROOT)", with: pathString)
-                        .replacingOccurrences(of: "$(SOURCE_ROOT)", with: pathString)
+                if activeTargetIDs.contains(dependencyTargetID) {
+                    throw GraphAlgorithmError.unexpectedCycle
+                }
+
+                activeTargetIDs.insert(dependencyTargetID)
+                stack.append(
+                    DependenciesModuleMapsFrame(
+                        targetID: dependencyTargetID,
+                        dependencies: Self.directTargetDependencies(
+                            graphTraverser: graphTraverser,
+                            target: dependency.graphTarget
+                        ),
+                        nextDependencyIndex: 0,
+                        dependenciesMetadata: []
+                    )
                 )
             } else {
-                dependencyModuleMapPath = nil
+                let completedFrame = stack.removeLast()
+                targetToDependenciesMetadata[completedFrame.targetID] = completedFrame.dependenciesMetadata
+                activeTargetIDs.remove(completedFrame.targetID)
             }
+        }
+    }
 
-            var headerSearchPaths: [String]
-            switch dependency.target.settings?.base[Self.headerSearchPaths] ?? .array([]) {
-            case let .array(values):
-                headerSearchPaths = values
-            case let .string(value):
-                headerSearchPaths = [value]
-            }
+    private static func targetID(_ target: GraphTarget) -> TargetID {
+        TargetID(projectPath: target.path, targetName: target.target.name)
+    }
 
-            headerSearchPaths = headerSearchPaths.map {
-                let pathString = dependency.graphTarget.path.pathString
-                return (
+    private static func directTargetDependencies(
+        graphTraverser: GraphTraverser,
+        target: GraphTarget
+    ) -> [GraphTargetReference] {
+        Array(
+            graphTraverser.directTargetDependencies(
+                path: target.path,
+                name: target.target.name
+            )
+        )
+    }
+
+    private static func dependencyMetadata(for dependency: GraphTargetReference) throws -> DependencyMetadata {
+        let dependencyModuleMapPath: AbsolutePath?
+        let pathString = dependency.graphTarget.path.pathString
+
+        if case let .string(dependencyModuleMap) = dependency.target.settings?.base[Self.modulemapFileSetting] {
+            dependencyModuleMapPath = try AbsolutePath(
+                validating: dependencyModuleMap
+                    .replacingOccurrences(of: "$(PROJECT_DIR)", with: pathString)
+                    .replacingOccurrences(of: "$(SRCROOT)", with: pathString)
+                    .replacingOccurrences(of: "$(SOURCE_ROOT)", with: pathString)
+            )
+        } else {
+            dependencyModuleMapPath = nil
+        }
+
+        let headerSearchPaths: [String]
+        switch dependency.target.settings?.base[Self.headerSearchPaths] ?? .array([]) {
+        case let .array(values):
+            headerSearchPaths = values
+        case let .string(value):
+            headerSearchPaths = [value]
+        }
+
+        return DependencyMetadata(
+            moduleName: dependency.target.productName,
+            moduleMapPath: dependencyModuleMapPath,
+            headerSearchPaths: headerSearchPaths.map {
+                (
                     try? AbsolutePath(
                         validating: $0
                             .replacingOccurrences(of: "$(PROJECT_DIR)", with: pathString)
@@ -231,23 +296,7 @@ public struct ModuleMapMapper: GraphMapping { // swiftlint:disable:this type_bod
                     ).pathString
                 ) ?? $0
             }
-
-            // indirect dependency module maps
-            let dependentTargetID = TargetID(projectPath: dependency.graphTarget.path, targetName: dependency.target.name)
-            if let indirectDependencyMetadata = targetToDependenciesMetadata[dependentTargetID] {
-                dependenciesMetadata.formUnion(indirectDependencyMetadata)
-            }
-
-            dependenciesMetadata.insert(
-                DependencyMetadata(
-                    moduleName: dependency.target.productName,
-                    moduleMapPath: dependencyModuleMapPath,
-                    headerSearchPaths: headerSearchPaths
-                )
-            )
-        }
-
-        targetToDependenciesMetadata[targetID] = dependenciesMetadata
+        )
     }
 
     // We apply module map flags to both the base settings and per-configuration overrides.

--- a/cli/Sources/TuistKit/Mappers/FocusTargetsGraphMappers.swift
+++ b/cli/Sources/TuistKit/Mappers/FocusTargetsGraphMappers.swift
@@ -1,5 +1,4 @@
 import Foundation
-import TSCBasic
 import TuistConfig
 import TuistCore
 import TuistLogging

--- a/cli/Sources/TuistMigration/Utilities/TargetsExtractor.swift
+++ b/cli/Sources/TuistMigration/Utilities/TargetsExtractor.swift
@@ -1,7 +1,6 @@
 import FileSystem
 import Foundation
 import Path
-import TSCBasic
 import TuistLogging
 import TuistSupport
 import XcodeProj

--- a/cli/Sources/TuistSupport/Utils/GraphAlgorithms.swift
+++ b/cli/Sources/TuistSupport/Utils/GraphAlgorithms.swift
@@ -1,0 +1,68 @@
+private struct TopologicalSortFrame<Node> {
+    let node: Node
+    let successors: [Node]
+    var nextSuccessorIndex: Int
+}
+
+public enum GraphAlgorithmError: Error, Equatable {
+    case unexpectedCycle
+}
+
+/// Perform a topological sort of a graph.
+///
+/// The implementation mirrors TSCBasic's reverse-postorder DFS behavior while
+/// using an explicit stack to avoid overflowing the call stack on deep graphs.
+public func topologicalSort<T: Hashable>(
+    _ nodes: [T],
+    successors: (T) throws -> [T]
+) throws -> [T] {
+    var visited = Set<T>()
+    var active = Set<T>()
+    var result: [T] = []
+
+    for node in nodes {
+        guard visited.insert(node).inserted else {
+            continue
+        }
+
+        active.insert(node)
+        var stack = [
+            TopologicalSortFrame(
+                node: node,
+                successors: try successors(node),
+                nextSuccessorIndex: 0
+            ),
+        ]
+
+        while !stack.isEmpty {
+            let frameIndex = stack.count - 1
+            let frame = stack[frameIndex]
+
+            if frame.nextSuccessorIndex < frame.successors.count {
+                let successor = frame.successors[frame.nextSuccessorIndex]
+                stack[frameIndex].nextSuccessorIndex += 1
+
+                if active.contains(successor) {
+                    throw GraphAlgorithmError.unexpectedCycle
+                }
+
+                if visited.insert(successor).inserted {
+                    active.insert(successor)
+                    stack.append(
+                        TopologicalSortFrame(
+                            node: successor,
+                            successors: try successors(successor),
+                            nextSuccessorIndex: 0
+                        )
+                    )
+                }
+            } else {
+                result.append(frame.node)
+                active.remove(frame.node)
+                stack.removeLast()
+            }
+        }
+    }
+
+    return result.reversed()
+}

--- a/cli/Tests/TuistCoreTests/Utils/GraphCircularDetectorTests.swift
+++ b/cli/Tests/TuistCoreTests/Utils/GraphCircularDetectorTests.swift
@@ -146,6 +146,20 @@ final class GraphCircularDetectorTests: XCTestCase {
         XCTAssertNoThrow(try subject.complete())
     }
 
+    func test_noCycleDetected_longChainDoesNotRecurse() throws {
+        // Given
+        let nodeCount = 20000
+        let nodes = (0 ..< nodeCount).map { node("\($0)") }
+
+        // When
+        for index in 0 ..< nodeCount - 1 {
+            subject.start(from: nodes[index], to: nodes[index + 1])
+        }
+
+        // Then
+        XCTAssertNoThrow(try subject.complete())
+    }
+
     func test_cycleDetected_detachedGraphs() throws {
         // Given
         let a = node("a")

--- a/cli/Tests/TuistGeneratorTests/Linter/StaticProductsGraphLinterTests.swift
+++ b/cli/Tests/TuistGeneratorTests/Linter/StaticProductsGraphLinterTests.swift
@@ -1235,6 +1235,55 @@ class StaticProductsGraphLinterTests: XCTestCase {
 //        XCTAssertEqual(results, [])
 //    }
 
+    func test_lint_whenLongDependencyChainDoesNotRecurse() throws {
+        // Given
+        let path: AbsolutePath = "/project"
+        let frameworkCount = 20000
+        let app = Target.test(name: "App")
+        let frameworkNames = (0 ..< frameworkCount).map { "Framework\($0)" }
+        let frameworks = frameworkNames.map { Target.test(name: $0, product: .framework) }
+        let staticFramework = Target.test(name: "StaticFramework", product: .staticFramework)
+        let project = Project.test(
+            path: path,
+            name: "Project",
+            targets: [app] + frameworks + [staticFramework]
+        )
+
+        let targetDependency: (String) -> GraphDependency = {
+            GraphDependency.target(name: $0, path: path)
+        }
+        let appDependency = targetDependency(app.name)
+        let staticFrameworkDependency = targetDependency(staticFramework.name)
+        let frameworkDependencies = frameworkNames.map(targetDependency)
+
+        var dependencies: [GraphDependency: Set<GraphDependency>] = [:]
+        dependencies[appDependency] = [frameworkDependencies[0]]
+        dependencies[staticFrameworkDependency] = []
+
+        for index in 0 ..< frameworkCount {
+            let successor: GraphDependency
+            if index == frameworkCount - 1 {
+                successor = staticFrameworkDependency
+            } else {
+                successor = frameworkDependencies[index + 1]
+            }
+            dependencies[frameworkDependencies[index]] = [successor]
+        }
+
+        let graph = Graph.test(
+            path: path,
+            projects: [path: project],
+            dependencies: dependencies
+        )
+        let graphTraverser = GraphTraverser(graph: graph)
+
+        // When
+        let results = subject.lint(graphTraverser: graphTraverser, configGeneratedProjectOptions: .test())
+
+        // Then
+        XCTAssertEqual(results, [LintingIssue]())
+    }
+
     // MARK: - Helpers
 
     private func warning(product node: String, type: String = "Target", linkedBy: [GraphDependency]) -> LintingIssue {

--- a/cli/Tests/TuistGeneratorTests/ProjectMappers/ModuleMapMapperTests.swift
+++ b/cli/Tests/TuistGeneratorTests/ProjectMappers/ModuleMapMapperTests.swift
@@ -724,4 +724,44 @@ final class ModuleMapMapperTests: TuistUnitTestCase {
             ]
         )
     }
+
+    func test_maps_long_dependency_chain_without_recursion() throws {
+        // Given
+        let workspace = Workspace.test()
+        let projectPath = try temporaryPath()
+        let nodeCount = 20000
+        let targets = (0 ..< nodeCount).map { index in
+            Target.test(
+                name: "Target\(index)",
+                dependencies: index + 1 < nodeCount ? [.target(name: "Target\(index + 1)")] : []
+            )
+        }
+        let project = Project.test(
+            path: projectPath,
+            name: "Project",
+            targets: targets
+        )
+        let dependencies = Dictionary(
+            uniqueKeysWithValues: (0 ..< nodeCount - 1).map { index in
+                (
+                    GraphDependency.target(name: "Target\(index)", path: projectPath),
+                    Set([GraphDependency.target(name: "Target\(index + 1)", path: projectPath)])
+                )
+            }
+        )
+
+        // Then
+        XCTAssertNoThrow(
+            try subject.map(
+                graph: .test(
+                    workspace: workspace,
+                    projects: [
+                        projectPath: project,
+                    ],
+                    dependencies: dependencies
+                ),
+                environment: MapperEnvironment()
+            )
+        )
+    }
 }

--- a/cli/Tests/TuistSupportTests/Utils/GraphAlgorithmsTests.swift
+++ b/cli/Tests/TuistSupportTests/Utils/GraphAlgorithmsTests.swift
@@ -1,0 +1,66 @@
+import XCTest
+
+@testable import TuistSupport
+
+final class GraphAlgorithmsTests: XCTestCase {
+    func test_topologicalSort_returnsReversePostorder() throws {
+        let graph = [
+            "A": ["B", "C"],
+            "B": ["D"],
+            "C": ["D"],
+            "D": [],
+        ]
+
+        let got = try topologicalSort(["A"]) { node in
+            graph[node] ?? []
+        }
+
+        XCTAssertEqual(got, ["A", "C", "B", "D"])
+    }
+
+    func test_topologicalSort_ignoresAlreadyVisitedRoots() throws {
+        let graph = [
+            "A": ["B"],
+            "B": [],
+        ]
+
+        let got = try topologicalSort(["A", "B", "A"]) { node in
+            graph[node] ?? []
+        }
+
+        XCTAssertEqual(got, ["A", "B"])
+    }
+
+    func test_topologicalSort_throwsWhenCycleIsDetected() throws {
+        let graph = [
+            "A": ["B"],
+            "B": ["C"],
+            "C": ["A"],
+        ]
+
+        XCTAssertThrowsError(
+            try topologicalSort(["A"]) { node in
+                graph[node] ?? []
+            }
+        ) { error in
+            guard let graphError = error as? GraphAlgorithmError,
+                  case .unexpectedCycle = graphError
+            else {
+                XCTFail("Expected GraphAlgorithmError.unexpectedCycle, got \(error)")
+                return
+            }
+        }
+    }
+
+    func test_topologicalSort_handlesLongChainsWithoutRecursion() throws {
+        let nodeCount = 20000
+
+        let got = try topologicalSort([0]) { node in
+            node + 1 < nodeCount ? [node + 1] : []
+        }
+
+        XCTAssertEqual(got.count, nodeCount)
+        XCTAssertEqual(got.first, 0)
+        XCTAssertEqual(got.last, nodeCount - 1)
+    }
+}


### PR DESCRIPTION
Hello Tuist team!

## Problem

Large valid Tuist dependency graphs can crash `tuist generate` with a stack overflow when graph-processing code uses recursive traversal.

For most projects this is unlikely to be noticeable because their target graphs are small or shallow. However, we hit this in a sufficiently large generated target graph on Tuist `4.182.0`: after a routine project change, the graph shape changed enough to increase traversal depth, and `tuist generate` started crashing. The graph was valid and acyclic; the crash was caused by recursive graph processing, not by circular dependencies or invalid manifests.

Despite that we originally hit this in our project on Tuist `4.182.0`, the same class of issue is still reproducible on current `main` at the time of validation (`4.201.0-canary.9`).

## What Changed

This PR replaces several recursive graph traversals with iterative implementations:

- `CircularDependencyLinter`
- `GraphCircularDetector`
- `topologicalSort`, moved into `TuistSupport`
- `ModuleMapMapper`
- `StaticProductsGraphLinter`

The local `topologicalSort` replaces the implementation imported from TSC. The upstream source, [swiftlang/swift-tools-support-core](https://github.com/swiftlang/swift-tools-support-core), is already deprecated, so fixing it there would not be useful for Tuist.

The changes keep existing behavior and diagnostics, but use explicit stacks instead of relying on the process call stack.

## Why This Helps

The affected code now handles deep dependency paths without growing the Swift call stack per graph node. This makes graph processing stack-safe for large acyclic workspaces while preserving existing caching, ordering, and linting behavior where relevant.

## Validation

I created a standalone fixture generator to validate the fix:

[igooor-bb/tuist-large-dag-repro](https://github.com/igooor-bb/tuist-large-dag-repro)

The fixture generates a large valid DAG that is intentionally closer to a real large workspace than a single linked list: multiple projects, feature layers, shared infrastructure, bridge targets with high fan-in, and no dependency cycles.

Primary validation command:

```bash
TUIST_BIN=/path/to/tuist ./scripts/reproduce.sh stress --no-focus
```

Focused-target validation path:

```
TUIST_BIN=/path/to/tuist ./scripts/reproduce.sh stress --focus
```

For more details about the fixture structure, available presets, and reproduction commands, see the fixture repository README.

Expected result:
- unpatched binary crashes with stack overflow in one of the recursive graph-processing paths;
- patched binary: generation completes successfully on the same fixture.

## Test Coverage
The new long-chain tests in `ModuleMapMapper` and `StaticProductsGraphLinter` mostly verify that traversal no longer crashes due to recursion depth. They do not try to fully prove result equivalence on a very long chain.
Existing shorter tests already cover preservation of transitive metadata and warning behavior, so I would not treat this as a blocker. I can still add stronger long-chain result assertions in this PR, or follow up separately with an issue.

## Notes
- The original issue in our project appeared on Tuist 4.182.0 and first surfaced in `CircularDependencyLinter`. I could not perfectly reproduce our production graph shape in a standalone fixture, but the fixture became a stronger stress test. After fixing the first crash, it exposed the next recursive risks one by one in later graph-processing stages.

- I could not reproduce a stack overflow specifically through `GraphCircularDetector`, but it used recursive graph traversal as well and had the same potential failure mode on sufficiently deep dependency paths.