### PR TITLE
fix(cli): open the Tuist CLI bump PR with a GitHub App token

### DIFF
--- a/.github/workflows/update-tuist-cli.yml
+++ b/.github/workflows/update-tuist-cli.yml
@@ -75,14 +75,23 @@ jobs:
           install_args: "tuist"
           cache: "false"
           github_token: ${{ env.MISE_GITHUB_TOKEN }}
+      - name: Mint a GitHub App token
+        id: app-token
+        if: steps.resolve.outputs.changed == 'true'
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.TUIST_AUTOMATION_APP_ID }}
+          private-key: ${{ secrets.TUIST_AUTOMATION_APP_PRIVATE_KEY }}
       - name: Open pull request
         id: pr
         if: steps.resolve.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@v6
         with:
-          # A PAT (not GITHUB_TOKEN) so the PR's checks run; GITHUB_TOKEN-authored
-          # PRs don't trigger workflows. Reuses the release pipeline's token.
-          token: ${{ secrets.TUIST_RELEASE_GITHUB_TOKEN }}
+          # A GitHub App installation token, not GITHUB_TOKEN (whose pushes don't
+          # trigger checks) and not a tuistit PAT (whose account-wide REST limit is
+          # drained by deployments, so PR creation here failed every run). The App
+          # has its own rate-limit pool and its commits/PRs do trigger checks.
+          token: ${{ steps.app-token.outputs.token }}
           branch: automation/update-tuist-cli
           delete-branch: true
           commit-message: "chore(cli): update Tuist CLI to ${{ steps.resolve.outputs.version }}"
@@ -99,5 +108,5 @@ jobs:
       - name: Enable auto-merge
         if: steps.resolve.outputs.changed == 'true' && steps.pr.outputs.pull-request-number
         env:
-          GH_TOKEN: ${{ secrets.TUIST_RELEASE_GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: gh pr merge --squash --auto "${{ steps.pr.outputs.pull-request-number }}" || true

--- a/.github/workflows/update-tuist-cli.yml
+++ b/.github/workflows/update-tuist-cli.yml
@@ -72,16 +72,28 @@ jobs:
           # Installing tuist unlocked rewrites its mise.lock entry across all
           # platforms (checksums come from the release SHASUMS, so one host
           # covers macOS and Linux).
-          install_args: "tuist"
+          install_args: "tuist 1password-cli"
           cache: "false"
           github_token: ${{ env.MISE_GITHUB_TOKEN }}
+      - name: Load GitHub App credentials from 1Password
+        if: steps.resolve.outputs.changed == 'true'
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+        run: |
+          set -euo pipefail
+          {
+            echo "APP_ID=$(op read 'op://tuist/Tuist Automation GitHub App/app-id')"
+            echo "APP_PRIVATE_KEY<<__OP_PEM__"
+            op read 'op://tuist/Tuist Automation GitHub App/private-key'
+            echo "__OP_PEM__"
+          } >> "$GITHUB_ENV"
       - name: Mint a GitHub App token
         id: app-token
         if: steps.resolve.outputs.changed == 'true'
         uses: actions/create-github-app-token@v1
         with:
-          app-id: ${{ secrets.TUIST_AUTOMATION_APP_ID }}
-          private-key: ${{ secrets.TUIST_AUTOMATION_APP_PRIVATE_KEY }}
+          app-id: ${{ env.APP_ID }}
+          private-key: ${{ env.APP_PRIVATE_KEY }}
       - name: Open pull request
         id: pr
         if: steps.resolve.outputs.changed == 'true'


### PR DESCRIPTION
## What changed

The `update-tuist-cli` workflow now opens its bump PR (and enables auto-merge) using a **GitHub App installation token**, with the App's credentials read at runtime from **1Password** (`op read` + the existing `OP_SERVICE_ACCOUNT_TOKEN`) — not from new GitHub Actions secrets.

## Why

After the workflow shipped, it ran hourly on `main` and **failed at the "Open pull request" step on every run for 12+ hours**, at all hours:

```
##[error]API rate limit exceeded for user ID 187030322
```

User `187030322` is **tuistit**, the account behind every `TUIST_*` PAT. Its account-wide REST limit is drained by deployments (each `main` merge triggers the production-deployment cascade, which shares that account), so the `POST /pulls` call had no headroom. Git pushes always succeeded; only content creation was blocked. Because all the repo's check-triggering tokens are tuistit PATs, no PAT swap fixes it.

A GitHub App installation token solves it: it has its **own rate-limit pool** (independent of tuistit), and like a PAT it **triggers the required checks** (unlike `GITHUB_TOKEN`).

## Required setup (one-time, before this helps)

Create a GitHub App and store its credentials in 1Password — **no new GitHub Actions secrets**.

1. Create an org-owned GitHub App (`https://github.com/organizations/tuist/settings/apps/new`):
   - **Contents: Read and write**, **Pull requests: Read and write**
   - Uncheck Webhook → Active; "Only on this account"
2. Install it on `tuist/tuist` (select repositories → `tuist/tuist`).
3. Note the **App ID** and **Generate a private key** (`.pem`).
4. In 1Password, in the **`tuist` vault**, create an item named **`Tuist Automation GitHub App`** with two fields:
   - `app-id` = the numeric App ID
   - `private-key` = the full `.pem` contents
   (The existing `OP_SERVICE_ACCOUNT_TOKEN`, already scoped to the `tuist` vault, reads these at runtime.)

If you'd prefer a different vault/item/field naming, tell me and I'll update the `op://` references.

## Validation

- The rest of the workflow is proven green in production (resolve → `4.201.0-canary.8`, bump `mise.toml`, regenerate `mise.lock` across all 6 platforms, push branch); only the tuistit-rate-limited PR call failed.
- YAML parses; step order is mise-install (now incl. `1password-cli`) → load creds from 1Password → mint App token → open PR → auto-merge; the App token feeds both the PR and auto-merge steps; no `TUIST_*` PAT and no new GHA secret are referenced.
- Once the App + 1Password item exist, dispatching the workflow should open the bump PR and enable auto-merge with no rate-limit failure.

## Note

The currently-live hourly workflow keeps failing harmlessly (no Slack alerts; "Update Tuist CLI" isn't in `notify-failure.yml`) until this merges and the App + 1Password item are in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)