### PR TITLE
fix(helm): use dedicated pingUrl for external ClickHouse readiness check

### DIFF
--- a/infra/helm/tuist/README.md
+++ b/infra/helm/tuist/README.md
@@ -85,8 +85,19 @@ Some cluster-specific fixes are intentionally opt-in:
 
 - `cache.podSecurityContext` is empty by default. Set `fsGroup` only if your storage class needs it.
 - `clickhouse.embedded.service.nativePort` defaults to ClickHouse's standard `9000` service port and can be overridden for mesh or port-allocation conflicts.
+- `clickhouse.external.pingUrl` lets the migration job wait for an external ClickHouse instance through a dedicated `/ping` URL when `clickhouse.external.url` includes a database path.
 
-Example:
+External ClickHouse example:
+
+```yaml
+clickhouse:
+  mode: external
+  external:
+    url: http://user:password@clickhouse.example.com:8123/tuist
+    pingUrl: http://clickhouse.example.com:8123/ping
+```
+
+Embedded compatibility override example:
 
 ```yaml
 cache:

--- a/infra/helm/tuist/templates/_helpers.tpl
+++ b/infra/helm/tuist/templates/_helpers.tpl
@@ -300,6 +300,8 @@ http://{{ include "tuist.componentName" (dict "root" . "component" "clickhouse")
 {{- define "tuist.clickhouseReadyUrl" -}}
 {{- if eq .Values.clickhouse.mode "embedded" -}}
 http://{{ include "tuist.componentName" (dict "root" . "component" "clickhouse") }}:8123/ping
+{{- else if .Values.clickhouse.external.pingUrl -}}
+{{- .Values.clickhouse.external.pingUrl -}}
 {{- else -}}
 {{- .Values.clickhouse.external.url -}}
 {{- end -}}

--- a/infra/helm/tuist/values.yaml
+++ b/infra/helm/tuist/values.yaml
@@ -1524,6 +1524,11 @@ clickhouse:
   mode: embedded
   external:
     url: ""
+    # Optional separate URL for the readiness probe ping check.
+    # When external.url includes a database path (e.g. http://user@host:8123/db),
+    # the /ping endpoint returns 404. Set this to http://<host>:8123/ping to use
+    # a dedicated health-check URL instead.
+    pingUrl: ""
   embedded:
     image:
       repository: clickhouse/clickhouse-server


### PR DESCRIPTION
Environment: self-hosted via k8s and ArgoCD

When clickhouse.mode is "external", the chart's init container uses clickhouse.external.url as the readiness check URL. However, that URL typically contains the database path (e.g. http://user@host:8123/db), and ClickHouse returns HTTP 404 for any path other than /ping. The migration job's init container therefore never becomes ready, causing deployments to time out.

Add an optional clickhouse.external.pingUrl value. When set, it is used for the readiness check instead of the database URL. When not set, the existing behaviour is preserved (external.url is used as-is).

