### PR TITLE
test(cli): cover SwifterPM materialization passthrough

### DIFF
--- a/cli/Tests/TuistKitTests/Services/InstallServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/InstallServiceTests.swift
@@ -339,7 +339,10 @@ final class InstallServiceTests: TuistUnitTestCase {
             .willReturn(
                 Tuist.test(project: .generated(.test(
                     installOptions: .test(
-                        passthroughSwiftPackageManagerArguments: ["--replace-scm-with-registry"]
+                        passthroughSwiftPackageManagerArguments: [
+                            "--cached-directory-materialization",
+                            "symlink",
+                        ]
                     )
                 )))
             )
@@ -370,7 +373,14 @@ final class InstallServiceTests: TuistUnitTestCase {
             .resolve(at: .any, arguments: .any, printOutput: .any)
             .called(1)
         verify(swiftPackageManagerController)
-            .resolve(at: .any, arguments: .value(["--replace-scm-with-registry"]), printOutput: .any)
+            .resolve(
+                at: .any,
+                arguments: .value([
+                    "--cached-directory-materialization",
+                    "symlink",
+                ]),
+                printOutput: .any
+            )
             .called(1)
     }
 

--- a/cli/Tests/TuistSupportTests/SwiftPackageManager/SwiftPackageManagerControllerTests.swift
+++ b/cli/Tests/TuistSupportTests/SwiftPackageManager/SwiftPackageManagerControllerTests.swift
@@ -125,6 +125,7 @@ final class SwiftPackageManagerControllerTests: TuistUnitTestCase {
         XCTAssertTrue(request.skipUpdate)
         XCTAssertTrue(request.quiet)
         XCTAssertEqual(request.scmToRegistryTransformation, .replaceSCMWithRegistry)
+        XCTAssertNil(request.cachedDirectoryMaterialization)
     }
 
     func test_resolve_when_swifterpm_is_not_truthy_usesSwiftPackageManager() async throws {
@@ -177,6 +178,30 @@ final class SwiftPackageManagerControllerTests: TuistUnitTestCase {
         // Then
         let request = try XCTUnwrap(swifterPM.resolveRequests.first)
         XCTAssertEqual(request.packageDirectory, URL(fileURLWithPath: overriddenPath.pathString).standardizedFileURL)
+    }
+
+    func test_resolve_when_swifterpm_is_enabled_and_cached_directory_materialization_argument_is_passed_usesIt()
+        async throws
+    {
+        // Given
+        let path = try temporaryPath()
+        subject = SwiftPackageManagerController(
+            fileSystem: fileSystem,
+            commandRunner: { self.mockCommandRunner },
+            swifterPM: swifterPM,
+            environmentVariables: { ["TUIST_USE_SWIFTERPM": "1"] }
+        )
+
+        // When
+        try await subject.resolve(
+            at: path,
+            arguments: ["--cached-directory-materialization", "symlink"],
+            printOutput: true
+        )
+
+        // Then
+        let request = try XCTUnwrap(swifterPM.resolveRequests.first)
+        XCTAssertEqual(request.cachedDirectoryMaterialization, .symlink)
     }
 
     func test_resolve_when_swifterpm_is_enabled_and_printOutput_is_false_setsQuiet() async throws {
@@ -280,6 +305,7 @@ final class SwiftPackageManagerControllerTests: TuistUnitTestCase {
         XCTAssertTrue(request.forceResolvedVersions)
         XCTAssertTrue(request.quiet)
         XCTAssertEqual(request.scmToRegistryTransformation, .useRegistryIdentityForSCM)
+        XCTAssertNil(request.cachedDirectoryMaterialization)
     }
 
     func test_update() async throws {


### PR DESCRIPTION
> Covers configuring SwifterPM cached directory materialization through Tuist's existing install passthrough arguments instead of introducing a dedicated environment variable.

SwifterPM already exposes `--cached-directory-materialization` with `automatic`, `copy`, and `symlink`. Tuist also already has an install passthrough path, both from `Config.project.generatedProject.installOptions.passthroughSwiftPackageManagerArguments` and from the `TUIST_INSTALL_PASSTHROUGH_ARGUMENTS` environment variable used by `tuist install`. Reusing that path keeps the CLI surface smaller and avoids adding a second environment variable for one SwifterPM option.

- Verifies install config passthrough forwards `--cached-directory-materialization symlink` into the Swift Package Manager controller.
- Verifies the SwifterPM-backed controller parses `--cached-directory-materialization symlink` from its existing arguments array.
- Verifies the default Tuist request leaves the materialization option unset, which SwifterPM resolves as `automatic` internally.
- Keeps SwifterPM gated by the existing truthy `TUIST_USE_SWIFTERPM` opt-in, so SwiftPM fallback behavior is unchanged.

This means users can configure the strategy with the existing env path, for example `TUIST_INSTALL_PASSTHROUGH_ARGUMENTS=--cached-directory-materialization,symlink`, or through install options in `Tuist.swift`.

### How to test locally

- `swiftformat cli/Sources/TuistConstants/Constants.swift cli/Sources/TuistSupport/SwiftPackageManager/SwiftPackageManagerController.swift cli/Tests/TuistSupportTests/SwiftPackageManager/SwiftPackageManagerControllerTests.swift cli/Tests/TuistKitTests/Services/InstallServiceTests.swift`
- `TUIST_USE_SWIFTERPM=0 .build/debug/tuist generate tuist TuistSupport TuistSupportTests TuistKit TuistKitTests ProjectDescription --no-open`
- `xcodebuild test -workspace Tuist.xcworkspace -scheme Tuist-Workspace -only-testing TuistSupportTests/SwiftPackageManagerControllerTests -only-testing TuistKitTests/InstallServiceTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""`
