### PR TITLE
fix(swifterpm): match SwiftPM submodule checkout behavior

### DIFF
--- a/swifterpm/Sources/swifterpm/FileSystemSupport.swift
+++ b/swifterpm/Sources/swifterpm/FileSystemSupport.swift
@@ -57,6 +57,10 @@ extension FileSystem {
 
     /// Remove the item at `url`. No-op if absent.
     func removePath(_ url: URL) async throws {
+        if isSymlink(url) {
+            try unlinkPath(url)
+            return
+        }
         try await remove(url.absolutePath)
     }
 
@@ -80,6 +84,26 @@ extension FileSystem {
     func existsIncludingSymlinks(_ url: URL) -> Bool {
         var stats = stat()
         return url.path.withCString { lstat($0, &stats) } == 0
+    }
+
+    func isSymlink(_ url: URL) -> Bool {
+        var stats = stat()
+        let result = url.path.withCString { lstat($0, &stats) }
+        guard result == 0 else { return false }
+        return (stats.st_mode & S_IFMT) == S_IFLNK
+    }
+
+    private func unlinkPath(_ url: URL) throws {
+        let result = url.path.withCString { unlink($0) }
+        guard result != -1 || errno == ENOENT else {
+            let message: String
+            if let cString = strerror(errno) {
+                message = String(cString: cString)
+            } else {
+                message = "unknown error"
+            }
+            throw ToolError.message("failed to remove \(url.path): \(message)")
+        }
     }
 
     /// Create a temporary directory underneath `parent` and return its URL.

--- a/swifterpm/Sources/swifterpm/Restore.swift
+++ b/swifterpm/Sources/swifterpm/Restore.swift
@@ -576,14 +576,25 @@ enum WorkspaceRestorer {
         cache: Cache
     ) async throws -> [(String, URL)] {
         let results = try await ConcurrentTasks.map(pins) { pin in
-            let source = try await ensureSource(cache: cache, pin: pin)
-            let checkout = checkouts.appendingPathComponent(PinKind.checkoutDirectoryName(pin))
-            try await fileSystem.replaceWithSymlinkedDirectory(
-                source: source, destination: checkout
-            )
-            return (pin.identity, source)
+            do {
+                let source = try await ensureSource(cache: cache, pin: pin)
+                let checkout = checkouts.appendingPathComponent(PinKind.checkoutDirectoryName(pin))
+                try await fileSystem.replaceWithSymlinkedDirectory(
+                    source: source, destination: checkout
+                )
+                return (pin.identity, source)
+            } catch {
+                throw sourceRestoreError(pin: pin, error: error)
+            }
         }
         return results.sorted { $0.0 < $1.0 }
+    }
+
+    private static func sourceRestoreError(pin: ResolvedPin, error: any Error) -> ToolError {
+        let revision = (try? pin.revision()).map { " at \($0)" } ?? ""
+        return ToolError.message(
+            "failed to restore \(pin.identity) from \(pin.location)\(revision): \(error)"
+        )
     }
 
     private static func restoreRegistryPins(
@@ -788,10 +799,6 @@ enum WorkspaceRestorer {
                 )
                 try await SystemProcess.run(
                     "/usr/bin/git", ["-C", destination.path, "checkout", "--detach", "FETCH_HEAD"]
-                )
-                try await SystemProcess.run(
-                    "/usr/bin/git",
-                    ["-C", destination.path, "submodule", "update", "--init", "--recursive"]
                 )
                 let gitDir = destination.appendingPathComponent(".git")
                 if try await PackageResolver.localSourceControlPackageLocation(pin.location) == nil,

--- a/swifterpm/Tests/swifterpmTests/FileSystemSupportTests.swift
+++ b/swifterpm/Tests/swifterpmTests/FileSystemSupportTests.swift
@@ -69,4 +69,22 @@ struct FileSystemSupportTests {
             #expect(!(try await fileSystem.currentWorkingDirectory().pathString.isEmpty))
         }
     }
+
+    @Test
+    func removePathRemovesBrokenSymlink() async throws {
+        try await withTemporaryDirectory { root in
+            let link = root.appendingPathComponent("broken-link")
+            try await fileSystem.createSymbolicLink(
+                from: link.absolutePath,
+                to: try RelativePath(validating: "missing-target")
+            )
+
+            #expect(fileSystem.existsIncludingSymlinks(link))
+            #expect(!(try await fileSystem.exists(link.absolutePath)))
+
+            try await fileSystem.removePath(link)
+
+            #expect(!fileSystem.existsIncludingSymlinks(link))
+        }
+    }
 }

--- a/swifterpm/Tests/swifterpmTests/RestoreTests.swift
+++ b/swifterpm/Tests/swifterpmTests/RestoreTests.swift
@@ -24,6 +24,36 @@ struct RestoreTests {
     }
 
     @Test
+    func restorePackageDoesNotInitializeGitSubmodules() async throws {
+        try await withTemporaryDirectory { root in
+            let repo = root.appendingPathComponent("BrokenSubmodule")
+            let scratch = root.appendingPathComponent("scratch")
+            let cache = try await Cache(root: root.appendingPathComponent("cache"))
+            let revision = try await writeGitPackageWithBrokenSubmodule(at: repo)
+            let pin = ResolvedPin(
+                identity: "broken-submodule",
+                kind: "localSourceControl",
+                location: repo.path,
+                state: ResolvedState(branch: nil, revision: revision, version: nil)
+            )
+            let resolved = ResolvedPins(originHash: "origin", pins: [pin], version: 3)
+
+            try await WorkspaceRestorer.restorePackage(
+                scratchDir: scratch,
+                cache: cache,
+                registryConfig: RegistryConfig(),
+                resolved: resolved,
+                progress: nil,
+                disableSandbox: true
+            )
+
+            let checkout = scratch.appendingPathComponent("checkouts/BrokenSubmodule")
+            #expect(try await fileSystem.exists(checkout.appendingPathComponent("DevOnly").absolutePath))
+            #expect(fileSystem.existsIncludingSymlinks(checkout.appendingPathComponent(".ruby_version")))
+        }
+    }
+
+    @Test
     func writeWorkspaceStateWritesSourceControlAndRegistryDependencies() async throws {
         try await withTemporaryDirectory { root in
             let package = root.appendingPathComponent("Package")
@@ -512,6 +542,48 @@ struct RestoreTests {
             #expect(artifacts.count == 1)
             #expect(artifact["path"] as? String == artifactPath.path)
         }
+    }
+
+    private func writeGitPackageWithBrokenSubmodule(at repo: URL) async throws -> String {
+        try await writeMinimalPackageManifest(at: repo, name: "BrokenSubmodule")
+        try await fileSystem.write(
+            Data("public enum BrokenSubmodule {}\n".utf8),
+            to: repo.appendingPathComponent("Sources/BrokenSubmodule/BrokenSubmodule.swift")
+        )
+        try await SystemProcess.run(
+            "/bin/ln", ["-s", "DevOnly/ruby", ".ruby_version"], workingDirectory: repo)
+        try await SystemProcess.run("/usr/bin/git", ["init", "-q"], workingDirectory: repo)
+        try await SystemProcess.run("/usr/bin/git", ["add", "."], workingDirectory: repo)
+        try await SystemProcess.run(
+            "/usr/bin/git",
+            [
+                "-c", "user.name=Repro",
+                "-c", "user.email=repro@example.com",
+                "commit", "-q", "-m", "initial",
+            ],
+            workingDirectory: repo
+        )
+        try await SystemProcess.run(
+            "/usr/bin/git",
+            [
+                "update-index", "--add", "--cacheinfo",
+                "160000,1111111111111111111111111111111111111111,DevOnly",
+            ],
+            workingDirectory: repo
+        )
+        try await SystemProcess.run(
+            "/usr/bin/git",
+            [
+                "-c", "user.name=Repro",
+                "-c", "user.email=repro@example.com",
+                "commit", "-q", "-m", "broken-submodule",
+            ],
+            workingDirectory: repo
+        )
+        return try await SystemProcess.output(
+            "/usr/bin/git", ["rev-parse", "HEAD"], workingDirectory: repo
+        )
+        .trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
     private func makeXCFrameworkZip(


### PR DESCRIPTION
Resolves user-reported SwifterPM restore failures with invalid submodule gitlinks and tracked symlinks that point into missing local-only directories.

> Describe here the purpose of your PR.

This aligns SwifterPM's Git fallback checkout behavior with SwiftPM:

- Stops running `git submodule update --init --recursive` after a fallback checkout. SwiftPM resolves and builds a package with a malformed submodule gitlink without initializing submodules, leaving the gitlink path as an empty directory.
- Keeps broken symlinks such as `.ruby_version -> DevOnly/ruby` in successful checkouts, matching SwiftPM's working copy behavior.
- Adds retry cleanup hardening so broken symlinks are unlinked correctly if a temporary checkout needs to be reset before trying another source-control URL candidate.
- Wraps source restore failures with package identity, location, and revision so future restore errors identify the dependency that failed.

The root cause was that SwifterPM's fallback path did more than SwiftPM does. It checked out the requested revision and then recursively initialized submodules. For repositories that use gitlinks as local-development-only placeholders, that extra command fails with `fatal: No url found for submodule path ... in .gitmodules`. When a tracked symlink pointed into that missing local-only directory, the retry cleanup could leave the broken symlink behind, causing the next checkout attempt to fail with a misleading untracked-file overwrite error.

The chosen fix is to remove recursive submodule initialization rather than special-case `.gitmodules`, `.ruby_version`, or a specific filename. That matches SwiftPM semantics and avoids making SwifterPM responsible for materializing submodule contents that SwiftPM itself does not restore.

For users, packages with malformed or intentionally local-only submodule gitlinks restore the same way they do under SwiftPM, and genuine restore failures now include the package context needed for debugging.

### How to test locally

- `swift test --replace-scm-with-registry --filter FileSystemSupportTests --filter RestoreTests`
- `mise run test:unit`
- Manual SwiftPM comparison using a temporary package with a bad gitlink and `.ruby_version -> DevOnly/ruby`.
- Manual SwifterPM reproduction against the same repository shape, confirming restore now exits 0 and preserves the broken symlink in the checkout.
