### PR TITLE
fix(server): filter runs by command arguments

### DIFF
--- a/server/lib/tuist/command_events/event.ex
+++ b/server/lib/tuist/command_events/event.ex
@@ -10,6 +10,7 @@ defmodule Tuist.CommandEvents.Event do
       :id,
       :project_id,
       :name,
+      :command_arguments,
       :git_commit_sha,
       :git_ref,
       :git_branch,

--- a/server/lib/tuist_web/live/cache_runs_live.ex
+++ b/server/lib/tuist_web/live/cache_runs_live.ex
@@ -6,6 +6,7 @@ defmodule TuistWeb.CacheRunsLive do
   import Noora.Filter
   import TuistWeb.Components.EmptyCardSection
   import TuistWeb.Runs.CacheEndpointFormatter
+  import TuistWeb.Runs.CommandFormatter
   import TuistWeb.Runs.RanByBadge
 
   alias Noora.Filter
@@ -34,7 +35,7 @@ defmodule TuistWeb.CacheRunsLive do
     base = [
       %Filter.Filter{
         id: "name",
-        field: :name,
+        field: :command_arguments,
         display_name: dgettext("dashboard_cache", "Command"),
         type: :text,
         operator: :=~,
@@ -279,7 +280,12 @@ defmodule TuistWeb.CacheRunsLive do
 
   defp build_flop_filters(filters) do
     {ran_by, filters} = Enum.split_with(filters, &(&1.id == "ran_by"))
-    flop_filters = Filter.Operations.convert_filters_to_flop(filters)
+
+    flop_filters =
+      filters
+      |> Enum.map(&normalize_command_filter/1)
+      |> Enum.map(&normalize_text_filter_operator/1)
+      |> Filter.Operations.convert_filters_to_flop()
 
     ran_by_flop_filters =
       Enum.flat_map(ran_by, fn
@@ -295,6 +301,16 @@ defmodule TuistWeb.CacheRunsLive do
 
     flop_filters ++ ran_by_flop_filters
   end
+
+  defp normalize_command_filter(%Filter.Filter{id: "name", value: value} = filter) when is_binary(value) do
+    %{filter | value: normalize_command_filter_value(value)}
+  end
+
+  defp normalize_command_filter(filter), do: filter
+
+  defp normalize_text_filter_operator(%Filter.Filter{operator: :"!=~"} = filter), do: %{filter | operator: :not_ilike}
+
+  defp normalize_text_filter_operator(filter), do: filter
 
   def sort_icon("desc") do
     "square_rounded_arrow_down"

--- a/server/lib/tuist_web/live/cache_runs_live.html.heex
+++ b/server/lib/tuist_web/live/cache_runs_live.html.heex
@@ -62,7 +62,7 @@
           }
         >
           <:col :let={cache_run} label={dgettext("dashboard_cache", "Command")}>
-            <.text_and_description_cell label={"tuist " <> (if cache_run.command_arguments, do: (cache_run.command_arguments |> String.split(" ") |> Enum.take(2) |> Enum.join(" ")), else: "")} />
+            <.text_and_description_cell label={format_command(cache_run)} />
           </:col>
           <:col
             :let={cache_run}

--- a/server/lib/tuist_web/live/generate_runs_live.ex
+++ b/server/lib/tuist_web/live/generate_runs_live.ex
@@ -5,6 +5,7 @@ defmodule TuistWeb.GenerateRunsLive do
 
   import TuistWeb.Components.EmptyCardSection
   import TuistWeb.Runs.CacheEndpointFormatter
+  import TuistWeb.Runs.CommandFormatter
   import TuistWeb.Runs.RanByBadge
 
   alias Noora.Filter
@@ -195,6 +196,7 @@ defmodule TuistWeb.GenerateRunsLive do
 
     flop_filters =
       filters
+      |> Enum.map(&normalize_command_filter/1)
       |> Enum.map(&normalize_text_filter_operator/1)
       |> Filter.Operations.convert_filters_to_flop()
 
@@ -216,6 +218,12 @@ defmodule TuistWeb.GenerateRunsLive do
   defp normalize_text_filter_operator(%Filter.Filter{operator: :"!=~"} = filter), do: %{filter | operator: :not_ilike}
 
   defp normalize_text_filter_operator(filter), do: filter
+
+  defp normalize_command_filter(%Filter.Filter{id: "name", value: value} = filter) when is_binary(value) do
+    %{filter | value: normalize_command_filter_value(value)}
+  end
+
+  defp normalize_command_filter(filter), do: filter
 
   def sort_icon("desc") do
     "square_rounded_arrow_down"
@@ -262,7 +270,7 @@ defmodule TuistWeb.GenerateRunsLive do
     base = [
       %Filter.Filter{
         id: "name",
-        field: :name,
+        field: :command_arguments,
         display_name: dgettext("dashboard_builds", "Command"),
         type: :text,
         operator: :=~,

--- a/server/lib/tuist_web/live/generate_runs_live.html.heex
+++ b/server/lib/tuist_web/live/generate_runs_live.html.heex
@@ -56,7 +56,7 @@
         }
       >
         <:col :let={generate_run} label={dgettext("dashboard_builds", "Command")}>
-          <.text_and_description_cell label={"tuist " <> (if generate_run.command_arguments, do: (generate_run.command_arguments |> String.split(" ") |> Enum.take(2) |> Enum.join(" ")), else: generate_run.name)} />
+          <.text_and_description_cell label={format_command(generate_run)} />
         </:col>
         <:col :let={generate_run} label={dgettext("dashboard_builds", "Hit rate")}>
           <.text_cell label={

--- a/server/lib/tuist_web/runs/command_formatter.ex
+++ b/server/lib/tuist_web/runs/command_formatter.ex
@@ -1,0 +1,30 @@
+defmodule TuistWeb.Runs.CommandFormatter do
+  @moduledoc false
+
+  def format_command(%{name: name, command_arguments: command_arguments}) do
+    case normalize_arguments(command_arguments) do
+      "" -> "tuist #{name}"
+      command_arguments -> "tuist #{command_arguments}"
+    end
+  end
+
+  def normalize_command_filter_value(value) when is_binary(value) do
+    value
+    |> String.trim()
+    |> String.replace(~r/^tuist(?:\s+|$)/, "")
+  end
+
+  def normalize_command_filter_value(value), do: value
+
+  defp normalize_arguments(nil), do: ""
+
+  defp normalize_arguments(arguments) when is_binary(arguments), do: String.trim(arguments)
+
+  defp normalize_arguments(arguments) when is_list(arguments) do
+    arguments
+    |> Enum.join(" ")
+    |> String.trim()
+  end
+
+  defp normalize_arguments(_arguments), do: ""
+end

--- a/server/priv/gettext/dashboard_builds.pot
+++ b/server/priv/gettext/dashboard_builds.pot
@@ -69,7 +69,7 @@ msgstr ""
 msgid "Avg. latency writing cache keys"
 msgstr ""
 
-#: lib/tuist_web/live/generate_runs_live.ex:287
+#: lib/tuist_web/live/generate_runs_live.ex:295
 #: lib/tuist_web/live/generate_runs_live.html.heex:84
 #: lib/tuist_web/live/xcode_build_runs_live.ex:241
 #: lib/tuist_web/live/xcode_build_runs_live.html.heex:121
@@ -288,7 +288,7 @@ msgid "Clean"
 msgstr ""
 
 #: lib/tuist_web/live/build_run_live.html.heex:209
-#: lib/tuist_web/live/generate_runs_live.ex:266
+#: lib/tuist_web/live/generate_runs_live.ex:274
 #: lib/tuist_web/live/generate_runs_live.html.heex:58
 #: lib/tuist_web/live/run_detail_live.html.heex:115
 #, elixir-autogen, elixir-format
@@ -452,7 +452,7 @@ msgstr ""
 #: lib/tuist_web/live/build_run_live.ex:1001
 #: lib/tuist_web/live/build_run_live.html.heex:245
 #: lib/tuist_web/live/build_run_live.html.heex:585
-#: lib/tuist_web/live/generate_runs_live.ex:279
+#: lib/tuist_web/live/generate_runs_live.ex:287
 #: lib/tuist_web/live/generate_runs_live.html.heex:81
 #: lib/tuist_web/live/run_detail_live.html.heex:144
 #: lib/tuist_web/live/xcode_build_runs_live.ex:231
@@ -608,7 +608,7 @@ msgid "Hit"
 msgstr ""
 
 #: lib/tuist_web/live/build_run_live.html.heex:861
-#: lib/tuist_web/live/generate_runs_live.ex:295
+#: lib/tuist_web/live/generate_runs_live.ex:303
 #: lib/tuist_web/live/generate_runs_live.html.heex:61
 #, elixir-autogen, elixir-format
 msgid "Hit rate"
@@ -763,7 +763,7 @@ msgstr ""
 #: lib/tuist_web/live/build_run_live.ex:1000
 #: lib/tuist_web/live/build_run_live.html.heex:238
 #: lib/tuist_web/live/build_run_live.html.heex:580
-#: lib/tuist_web/live/generate_runs_live.ex:278
+#: lib/tuist_web/live/generate_runs_live.ex:286
 #: lib/tuist_web/live/generate_runs_live.html.heex:79
 #: lib/tuist_web/live/run_detail_live.html.heex:137
 #: lib/tuist_web/live/xcode_build_runs_live.ex:230
@@ -813,7 +813,7 @@ msgstr ""
 msgid "Ran at"
 msgstr ""
 
-#: lib/tuist_web/live/generate_runs_live.ex:322
+#: lib/tuist_web/live/generate_runs_live.ex:330
 #: lib/tuist_web/live/generate_runs_live.html.heex:87
 #: lib/tuist_web/live/run_detail_live.html.heex:152
 #: lib/tuist_web/live/xcode_build_runs_live.ex:309
@@ -921,7 +921,7 @@ msgstr ""
 #: lib/tuist_web/live/build_run_live.ex:1142
 #: lib/tuist_web/live/build_run_live.html.heex:235
 #: lib/tuist_web/live/build_run_live.html.heex:1543
-#: lib/tuist_web/live/generate_runs_live.ex:274
+#: lib/tuist_web/live/generate_runs_live.ex:282
 #: lib/tuist_web/live/run_detail_live.html.heex:134
 #: lib/tuist_web/live/xcode_build_runs_live.ex:226
 #: lib/tuist_web/live/xcode_builds_live.ex:433
@@ -1382,7 +1382,7 @@ msgstr ""
 msgid "since yesterday"
 msgstr ""
 
-#: lib/tuist_web/live/generate_runs_live.ex:303
+#: lib/tuist_web/live/generate_runs_live.ex:311
 #: lib/tuist_web/live/run_detail_live.html.heex:125
 #, elixir-autogen, elixir-format
 msgid "Cache Endpoint"
@@ -1399,7 +1399,7 @@ msgstr ""
 msgid "Custom metadata"
 msgstr ""
 
-#: lib/tuist_web/live/generate_runs_live.ex:21
+#: lib/tuist_web/live/generate_runs_live.ex:22
 #, elixir-autogen, elixir-format
 msgid "Generations"
 msgstr ""

--- a/server/priv/gettext/dashboard_cache.pot
+++ b/server/priv/gettext/dashboard_cache.pot
@@ -136,7 +136,7 @@ msgstr ""
 #: lib/tuist_web/live/bundle_live.html.heex:80
 #: lib/tuist_web/live/bundles_live.ex:943
 #: lib/tuist_web/live/bundles_live.html.heex:352
-#: lib/tuist_web/live/cache_runs_live.ex:59
+#: lib/tuist_web/live/cache_runs_live.ex:60
 #: lib/tuist_web/live/cache_runs_live.html.heex:96
 #, elixir-autogen, elixir-format
 msgid "Branch"
@@ -186,7 +186,7 @@ msgstr ""
 msgid "CI"
 msgstr ""
 
-#: lib/tuist_web/live/cache_runs_live.ex:22
+#: lib/tuist_web/live/cache_runs_live.ex:23
 #: lib/tuist_web/live/cache_runs_live.html.heex:2
 #, elixir-autogen, elixir-format
 msgid "Cache Runs"
@@ -244,7 +244,7 @@ msgstr ""
 msgid "Cache uploads"
 msgstr ""
 
-#: lib/tuist_web/live/cache_runs_live.ex:38
+#: lib/tuist_web/live/cache_runs_live.ex:39
 #: lib/tuist_web/live/cache_runs_live.html.heex:64
 #: lib/tuist_web/live/module_cache_live.html.heex:573
 #, elixir-autogen, elixir-format
@@ -322,7 +322,7 @@ msgstr ""
 msgid "Explore bundle analysis"
 msgstr ""
 
-#: lib/tuist_web/live/cache_runs_live.ex:51
+#: lib/tuist_web/live/cache_runs_live.ex:52
 #: lib/tuist_web/live/cache_runs_live.html.heex:93
 #: lib/tuist_web/live/xcode_cache_live.ex:432
 #, elixir-autogen, elixir-format
@@ -366,7 +366,7 @@ msgstr ""
 msgid "Hit Rate"
 msgstr ""
 
-#: lib/tuist_web/live/cache_runs_live.ex:67
+#: lib/tuist_web/live/cache_runs_live.ex:68
 #: lib/tuist_web/live/cache_runs_live.html.heex:10
 #: lib/tuist_web/live/cache_runs_live.html.heex:18
 #: lib/tuist_web/live/cache_runs_live.html.heex:69
@@ -501,7 +501,7 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: lib/tuist_web/live/cache_runs_live.ex:50
+#: lib/tuist_web/live/cache_runs_live.ex:51
 #: lib/tuist_web/live/cache_runs_live.html.heex:91
 #: lib/tuist_web/live/xcode_cache_live.ex:431
 #, elixir-autogen, elixir-format
@@ -536,7 +536,7 @@ msgstr ""
 msgid "Ran at"
 msgstr ""
 
-#: lib/tuist_web/live/cache_runs_live.ex:94
+#: lib/tuist_web/live/cache_runs_live.ex:95
 #: lib/tuist_web/live/cache_runs_live.html.heex:99
 #: lib/tuist_web/live/module_cache_live.html.heex:586
 #: lib/tuist_web/live/xcode_cache_live.html.heex:856
@@ -611,7 +611,7 @@ msgstr ""
 msgid "Space usage"
 msgstr ""
 
-#: lib/tuist_web/live/cache_runs_live.ex:46
+#: lib/tuist_web/live/cache_runs_live.ex:47
 #: lib/tuist_web/live/xcode_cache_live.ex:420
 #, elixir-autogen, elixir-format
 msgid "Status"
@@ -820,7 +820,7 @@ msgstr ""
 msgid "since yesterday"
 msgstr ""
 
-#: lib/tuist_web/live/cache_runs_live.ex:75
+#: lib/tuist_web/live/cache_runs_live.ex:76
 #, elixir-autogen, elixir-format
 msgid "Cache Endpoint"
 msgstr ""

--- a/server/priv/repo/seeds.exs
+++ b/server/priv/repo/seeds.exs
@@ -2269,6 +2269,54 @@ base_date = DateTime.utc_now()
 cmd_project_id = tuist_project.id
 cmd_user_id = user.id
 
+command_arguments_by_name = %{
+  "generate" => [
+    "generate",
+    "generate App",
+    "generate App Widgets",
+    "generate --configuration Debug",
+    "generate --configuration DebugStaging",
+    "generate --configuration Release --no-open",
+    "generate --configuration Debug --cache-profile development --no-open",
+    "generate tag:feature-auth --configuration DebugStaging",
+    "generate --path Examples/App --configuration Release",
+    "generate FrameworkKit --cache-profile only-external",
+    "generate --cache-profile none --no-open",
+    "generate App AppTests --configuration Debug"
+  ],
+  "cache" => [
+    "cache",
+    "cache App",
+    "cache warm",
+    "cache warm App",
+    "cache warm App FrameworkKit --configuration Debug",
+    "cache warm --configuration DebugStaging",
+    "cache warm --configuration Release --cache-profile only-external",
+    "cache warm tag:feature-auth --configuration Debug",
+    "cache warm --path Examples/App --configuration Release",
+    "cache warm AppTests --generate-only",
+    "cache warm Core Networking --cache-profile development",
+    "cache warm --print-hashes"
+  ],
+  "test" => [
+    "test App",
+    "test AppTests",
+    "test --scheme App",
+    "test --scheme App --configuration Debug",
+    "test --scheme App --test-plan Regression",
+    "test --scheme App --skip-ui-tests",
+    "test --scheme FrameworkKit --configuration DebugStaging",
+    "test --path Examples/App",
+    "test tag:unit",
+    "test tag:feature-auth --configuration Debug"
+  ]
+}
+
+command_arguments_for_name = fn name, index ->
+  arguments = Map.fetch!(command_arguments_by_name, name)
+  Enum.at(arguments, rem(index, length(arguments)))
+end
+
 event_counter = :counters.new(1, [:atomics])
 generate_cache_event_counter = :counters.new(1, [:atomics])
 
@@ -2285,7 +2333,7 @@ all_generate_cache_events = :ets.new(:generate_cache_events, [:bag, :public])
 |> Stream.chunk_every(cmd_chunk_size)
 |> Enum.each(fn chunk_indices ->
   events =
-    Enum.map(chunk_indices, fn _i ->
+    Enum.map(chunk_indices, fn i ->
       name = Enum.random(["test", "cache", "generate"])
       status = Enum.random([0, 1])
       is_ci = Enum.random([true, false])
@@ -2322,7 +2370,7 @@ all_generate_cache_events = :ets.new(:generate_cache_events, [:bag, :public])
         swift_version: "5.2",
         macos_version: "10.15",
         subcommand: "",
-        command_arguments: "",
+        command_arguments: command_arguments_for_name.(name, i),
         is_ci: is_ci,
         user_id: if(is_ci, do: nil, else: cmd_user_id),
         client_id: "client-id",

--- a/server/test/tuist_web/live/cache_runs_live_test.exs
+++ b/server/test/tuist_web/live/cache_runs_live_test.exs
@@ -113,5 +113,91 @@ defmodule TuistWeb.CacheRunsLiveTest do
       assert has_element?(lv, "span", "tuist cache UserApp")
       refute has_element?(lv, "span", "tuist cache OtherUserApp")
     end
+
+    test "filters cache runs by displayed command", %{
+      conn: conn,
+      user: user,
+      organization: organization,
+      project: project
+    } do
+      matching_run =
+        CommandEventsFixtures.command_event_fixture(
+          project_id: project.id,
+          user_id: user.id,
+          name: "cache",
+          command_arguments: ["cache", "MatchedApp"]
+        )
+
+      other_run =
+        CommandEventsFixtures.command_event_fixture(
+          project_id: project.id,
+          user_id: user.id,
+          name: "cache",
+          command_arguments: ["cache", "OtherApp"]
+        )
+
+      query =
+        URI.encode_query(%{
+          "filter_name_op" => "==",
+          "filter_name_val" => "tuist cache MatchedApp"
+        })
+
+      {:ok, lv, _html} =
+        live(
+          conn,
+          "/#{organization.account.name}/#{project.name}/module-cache/cache-runs?#{query}"
+        )
+
+      assert has_element?(lv, "tr##{matching_run.id}")
+      refute has_element?(lv, "tr##{other_run.id}")
+    end
+
+    test "filters cache runs when the command filter contains only the tuist prefix", %{
+      conn: conn,
+      user: user,
+      organization: organization,
+      project: project
+    } do
+      cache_run =
+        CommandEventsFixtures.command_event_fixture(
+          project_id: project.id,
+          user_id: user.id,
+          name: "cache",
+          command_arguments: ["cache", "warm", "--configuration", "DebugStaging"]
+        )
+
+      query =
+        URI.encode_query(%{
+          "filter_name_op" => "=~",
+          "filter_name_val" => "tuist"
+        })
+
+      {:ok, lv, _html} =
+        live(
+          conn,
+          "/#{organization.account.name}/#{project.name}/module-cache/cache-runs?#{query}"
+        )
+
+      assert has_element?(lv, "tr##{cache_run.id}")
+    end
+
+    test "displays the command name when cache run arguments are empty", %{
+      conn: conn,
+      user: user,
+      organization: organization,
+      project: project
+    } do
+      CommandEventsFixtures.command_event_fixture(
+        project_id: project.id,
+        user_id: user.id,
+        name: "cache",
+        command_arguments: []
+      )
+
+      {:ok, lv, _html} =
+        live(conn, ~p"/#{organization.account.name}/#{project.name}/module-cache/cache-runs")
+
+      assert has_element?(lv, "span", "tuist cache")
+    end
   end
 end

--- a/server/test/tuist_web/live/generate_runs_live_test.exs
+++ b/server/test/tuist_web/live/generate_runs_live_test.exs
@@ -138,6 +138,92 @@ defmodule TuistWeb.GenerateRunsLiveTest do
       refute has_element?(lv, "span", "generate OtherUserApp")
     end
 
+    test "filters generate runs by displayed command", %{
+      conn: conn,
+      user: user,
+      organization: organization,
+      project: project
+    } do
+      matching_run =
+        CommandEventsFixtures.command_event_fixture(
+          project_id: project.id,
+          user_id: user.id,
+          name: "generate",
+          command_arguments: ["generate", "--configuration", "DebugStaging"]
+        )
+
+      other_run =
+        CommandEventsFixtures.command_event_fixture(
+          project_id: project.id,
+          user_id: user.id,
+          name: "generate",
+          command_arguments: ["generate", "--configuration", "Release"]
+        )
+
+      query =
+        URI.encode_query(%{
+          "filter_name_op" => "==",
+          "filter_name_val" => "tuist generate --configuration DebugStaging"
+        })
+
+      {:ok, lv, _html} =
+        live(
+          conn,
+          "/#{organization.account.name}/#{project.name}/module-cache/generate-runs?#{query}"
+        )
+
+      assert has_element?(lv, "tr##{matching_run.id}")
+      refute has_element?(lv, "tr##{other_run.id}")
+    end
+
+    test "filters generate runs when the command filter contains only the tuist prefix", %{
+      conn: conn,
+      user: user,
+      organization: organization,
+      project: project
+    } do
+      generate_run =
+        CommandEventsFixtures.command_event_fixture(
+          project_id: project.id,
+          user_id: user.id,
+          name: "generate",
+          command_arguments: ["generate", "--configuration", "DebugStaging"]
+        )
+
+      query =
+        URI.encode_query(%{
+          "filter_name_op" => "=~",
+          "filter_name_val" => "tuist"
+        })
+
+      {:ok, lv, _html} =
+        live(
+          conn,
+          "/#{organization.account.name}/#{project.name}/module-cache/generate-runs?#{query}"
+        )
+
+      assert has_element?(lv, "tr##{generate_run.id}")
+    end
+
+    test "displays the command name when generate run arguments are empty", %{
+      conn: conn,
+      user: user,
+      organization: organization,
+      project: project
+    } do
+      CommandEventsFixtures.command_event_fixture(
+        project_id: project.id,
+        user_id: user.id,
+        name: "generate",
+        command_arguments: []
+      )
+
+      {:ok, lv, _html} =
+        live(conn, ~p"/#{organization.account.name}/#{project.name}/module-cache/generate-runs")
+
+      assert has_element?(lv, "span", "tuist generate")
+    end
+
     test "filters generate runs whose branch does not contain a substring", %{
       conn: conn,
       user: user,


### PR DESCRIPTION

<img width="783" height="536" alt="image" src="https://github.com/user-attachments/assets/83db93de-9606-4707-8d40-01ce6d869177" />


## What changed

- Filters Generate Runs and Cache Runs by `command_arguments` instead of the command `name` field.
- Normalizes displayed command filter values by stripping the UI-only `tuist` prefix before converting filters to Flop filters.
- Adds a shared command formatter so run tables render full commands consistently, with sensible fallbacks like `tuist generate` and `tuist cache` for empty arguments.
- Updates the local seed data to generate more realistic command arguments for `generate`, `cache`, and `test` events.
- Adds LiveView coverage for filtering by displayed command, prefix-only `tuist` filters, and empty command arguments.

## Why

The dashboard displays commands as full CLI invocations, but the filter was querying the short `name` field (`generate`/`cache`). A user filtering by what they saw in the UI, such as `tuist generate --configuration DebugStaging`, could therefore get no rows even when matching runs existed.

## Impact

Users can now filter run lists by the command text shown in the dashboard. Local development seed data is also easier to use when checking command filters because it includes realistic command variants instead of rows that all render as bare `tuist`.

## Validation

- `mix test test/tuist_web/live/generate_runs_live_test.exs test/tuist_web/live/cache_runs_live_test.exs`
- Local browser check at `http://localhost:8247/tuist/tuist/module-cache/generate-runs` with:
  - `filter_name_val=tuist`
  - `filter_name_val=tuist generate --configuration Debug`

Both browser checks showed matching rows with full command labels rather than the empty state.
