### PR TITLE
docs(infra): require ElasticMetalFullAccess on the provider IAM key

### DIFF
--- a/infra/cluster-api-provider-scaleway-applesilicon/AGENTS.md
+++ b/infra/cluster-api-provider-scaleway-applesilicon/AGENTS.md
@@ -146,15 +146,24 @@ Day-1 operator runbook:
    Each env gets its own Scaleway IAM application scoped to that
    cluster's needs; a leaked staging key rotates without disrupting
    production. The IAM policy attached to that application needs
-   exactly two permission sets:
+   these permission sets, all at project scope:
 
-   - `AppleSiliconFullAccess` (project scope) — order/release Mac
-     minis, list server types and OS images.
-   - `SSHKeysFullAccess` (project scope) — register the per-fleet
-     Ed25519 public key the operator generates on first reconcile.
-     **Do not use `IAMManager`** despite the name suggesting it
-     covers SSH keys; Scaleway gates `ssh_key` write under
-     `SSHKeysFullAccess` specifically.
+   - `AppleSiliconFullAccess` — order/release Mac minis, list server
+     types and OS images (the Apple Silicon fleets).
+   - `ElasticMetalFullAccess` — list/order/release Elastic Metal
+     servers (the kura runner-cache fleet). Elastic Metal is a
+     **separate Scaleway product** from Apple Silicon; without this
+     set the EM reconciler 403s on its first `list elastic metal
+     servers` call and never orders a node, so the cache stays down
+     and a deploy waiting on the fleet hangs.
+   - `PrivateNetworksFullAccess` — attach servers to the runner-cache
+     Private Network (find-or-created by name).
+   - `IPAMReadOnly` — read the PN-assigned address the self-join uses.
+   - `SSHKeysFullAccess` — register the per-fleet Ed25519 public key
+     the operator generates on first reconcile. **Do not use
+     `IAMManager`** despite the name suggesting it covers SSH keys;
+     Scaleway gates `ssh_key` write under `SSHKeysFullAccess`
+     specifically.
 
    Each cluster's pre-configured `ClusterSecretStore "onepassword"` is
    already scoped to the right vault, so the chart references the

--- a/infra/cluster-api-provider-scaleway-applesilicon/docs/scaleway-elastic-metal-support.md
+++ b/infra/cluster-api-provider-scaleway-applesilicon/docs/scaleway-elastic-metal-support.md
@@ -149,8 +149,14 @@ attached to the caph cluster, not a ClusterClass topology entry.
 - **Naming**: the provider binary/repo is `...-applesilicon`; with a Linux kind
   alongside Apple Silicon that's a misnomer, kept for now (a rename is broad
   churn: image, chart, RBAC, CRD group). Revisit if it keeps growing.
-- **IAM**: each env's provider key carries `PrivateNetworksFullAccess` +
-  `IPAMReadOnly`.
+- **IAM**: each env's provider key carries `ElasticMetalFullAccess` (list /
+  order / release the EM server), `PrivateNetworksFullAccess` + `IPAMReadOnly`
+  (attach the PN and read its address), plus `AppleSiliconFullAccess` +
+  `SSHKeysFullAccess` shared with the macOS fleet. `ElasticMetalFullAccess` is
+  the easy one to miss: it's a separate Scaleway product from Apple Silicon, so
+  a key with `AppleSiliconFullAccess` but not `ElasticMetalFullAccess` 403s on
+  the EM reconciler's first `list elastic metal servers` call and never orders a
+  node.
 
 ## End-to-end path
 


### PR DESCRIPTION
## Why

The canary macOS runner-cache cutover wedged because the EM node never provisioned. The operator logs showed the reconciler 403ing on every cycle:

```
ScalewayElasticMetalMachine: tuist-tuist-kura-fleet-...
error: list elastic metal servers by name "...": scaleway-sdk-go: http error 403 Forbidden: Permission denied
```

The canary provider IAM policy had `AppleSiliconFullAccess`, `IPAMReadOnly`, `PrivateNetworksFullAccess`, `SSHKeysFullAccess` but **not** an Elastic Metal set. Elastic Metal is a separate Scaleway product from Apple Silicon (the name is the trap), so the operator could manage PNs/IPAM/Mac minis but got 403 on its first `list elastic metal servers` call and never ordered a node. The fix was adding `ElasticMetalFullAccess` to the policy.

## What

- `infra/cluster-api-provider-scaleway-applesilicon/AGENTS.md`: the IAM section claimed "exactly two permission sets" (`AppleSiliconFullAccess` + `SSHKeysFullAccess`), which predated the Elastic Metal kind and didn't match the real policy. Replaced with the full set (`AppleSiliconFullAccess`, `ElasticMetalFullAccess`, `PrivateNetworksFullAccess`, `IPAMReadOnly`, `SSHKeysFullAccess`) and the role each plays.
- `docs/scaleway-elastic-metal-support.md`: the IAM bullet listed only `PrivateNetworksFullAccess` + `IPAMReadOnly`; added `ElasticMetalFullAccess` with the 403 failure mode called out.

## Note

Production's `tuist-production-capi` policy needs the same `ElasticMetalFullAccess` grant before the cutover reaches it, or it will 403 identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)