### PR TITLE
fix(server): make Elixir tests deterministic

### DIFF
--- a/server/lib/tuist/processor/xcresult_nif.ex
+++ b/server/lib/tuist/processor/xcresult_nif.ex
@@ -47,8 +47,12 @@ defmodule Tuist.Processor.XCResultNIF do
           File.exists?(nif_so) ->
             {:error, message}
 
-          Tuist.Environment.env() in [:dev, :test] ->
-            :logger.warning(message <> " — .so missing, skipping (dev/test only)")
+          Tuist.Environment.env() == :test ->
+            :logger.debug(message <> " — .so missing, skipping (test only)")
+            :ok
+
+          Tuist.Environment.env() == :dev ->
+            :logger.warning(message <> " — .so missing, skipping (dev only)")
             :ok
 
           :os.type() != {:unix, :darwin} ->

--- a/server/test/test_helper.exs
+++ b/server/test/test_helper.exs
@@ -139,6 +139,42 @@ Mimic.copy(Tuist.Runners.RunnerSessions)
 Mimic.copy(Tuist.Kubernetes.Client)
 Mimic.copy(Tuist.Tasks)
 
-ExUnit.start(exclude: [:skip])
+defmodule TuistTestSupport.LoggerFilters do
+  @moduledoc false
+
+  def filter_db_connection_sandbox_teardown(%{level: :error} = log_event, _extra) do
+    message = log_event_message(log_event)
+
+    if String.contains?(message, "disconnected: ** (DBConnection.ConnectionError)") and
+         String.contains?(message, " exited") and
+         (String.contains?(message, "client #PID<") or String.contains?(message, "owner #PID<")) do
+      :stop
+    else
+      :ignore
+    end
+  end
+
+  def filter_db_connection_sandbox_teardown(_log_event, _extra), do: :ignore
+
+  defp log_event_message(%{msg: {:string, message}}), do: IO.iodata_to_binary(message)
+
+  defp log_event_message(%{msg: {:report, report}}), do: inspect(report)
+
+  defp log_event_message(%{msg: {:format, format, args}}) do
+    format
+    |> :io_lib.format(args)
+    |> IO.iodata_to_binary()
+  end
+
+  defp log_event_message(%{msg: message}) when is_binary(message), do: message
+  defp log_event_message(log_event), do: inspect(log_event)
+end
+
+:logger.add_primary_filter(
+  :db_connection_sandbox_teardown,
+  {&TuistTestSupport.LoggerFilters.filter_db_connection_sandbox_teardown/2, []}
+)
+
+ExUnit.start(capture_log: true, exclude: [:skip])
 Sandbox.mode(Tuist.Repo, :manual)
 Sandbox.mode(Tuist.IngestRepo, :manual)

--- a/server/test/tuist/accounts_test.exs
+++ b/server/test/tuist/accounts_test.exs
@@ -468,25 +468,15 @@ defmodule Tuist.AccountsTest do
     test "organization_user? returns true if the user's sso matches the organization's when the sso is Google" do
       # Given
       stub(Environment, :tuist_hosted?, fn -> true end)
+      provider_organization_id = unique_sso_domain("okta")
 
       user =
-        Accounts.find_or_create_user_from_oauth2(%{
-          provider: :okta,
-          uid: 123,
-          info: %{
-            email: "tuist@tuist.dev"
-          },
-          extra: %{
-            raw_info: %{
-              provider_organization_id: "tuist.okta.com"
-            }
-          }
-        })
+        Accounts.find_or_create_user_from_oauth2(okta_oauth_identity(provider_organization_id))
 
       organization =
         AccountsFixtures.organization_fixture(
           sso_provider: :okta,
-          sso_organization_id: "tuist.okta.com",
+          sso_organization_id: provider_organization_id,
           oauth2_client_id: "client-id",
           oauth2_client_secret: "client-secret"
         )
@@ -498,27 +488,15 @@ defmodule Tuist.AccountsTest do
     test "organization_user? returns true if the user's sso matches the organization's when the sso is Okta" do
       # Given
       stub(Environment, :tuist_hosted?, fn -> true end)
+      domain = unique_sso_domain()
 
       user =
-        Accounts.find_or_create_user_from_oauth2(%{
-          provider: :google,
-          uid: 123,
-          info: %{
-            email: "tuist@tuist.dev"
-          },
-          extra: %{
-            raw_info: %{
-              user: %{
-                "hd" => "tuist.io"
-              }
-            }
-          }
-        })
+        Accounts.find_or_create_user_from_oauth2(google_oauth_identity(domain))
 
       organization =
         AccountsFixtures.organization_fixture(
           sso_provider: :google,
-          sso_organization_id: "tuist.io"
+          sso_organization_id: domain
         )
 
       # When
@@ -528,27 +506,15 @@ defmodule Tuist.AccountsTest do
     test "organization_user? returns false if the user's sso domain matches the organization's but the providers are different" do
       # Given
       stub(Environment, :tuist_hosted?, fn -> true end)
+      domain = unique_sso_domain()
 
       user =
-        Accounts.find_or_create_user_from_oauth2(%{
-          provider: :google,
-          uid: 123,
-          info: %{
-            email: "tuist@tuist.dev"
-          },
-          extra: %{
-            raw_info: %{
-              user: %{
-                "hd" => "tuist.io"
-              }
-            }
-          }
-        })
+        Accounts.find_or_create_user_from_oauth2(google_oauth_identity(domain))
 
       organization =
         AccountsFixtures.organization_fixture(
           sso_provider: :okta,
-          sso_organization_id: "tuist.io",
+          sso_organization_id: domain,
           oauth2_client_id: "client-id",
           oauth2_client_secret: "client-secret"
         )
@@ -560,27 +526,16 @@ defmodule Tuist.AccountsTest do
     test "organization_user? returns false if the user's sso does not match the organization's when both are Google" do
       # Given
       stub(Environment, :tuist_hosted?, fn -> true end)
+      user_domain = unique_sso_domain("tools")
+      organization_domain = unique_sso_domain()
 
       user =
-        Accounts.find_or_create_user_from_oauth2(%{
-          provider: :google,
-          uid: 123,
-          info: %{
-            email: "tuist@tools.io"
-          },
-          extra: %{
-            raw_info: %{
-              user: %{
-                "hd" => "tools.io"
-              }
-            }
-          }
-        })
+        Accounts.find_or_create_user_from_oauth2(google_oauth_identity(user_domain))
 
       organization =
         AccountsFixtures.organization_fixture(
           sso_provider: :google,
-          sso_organization_id: "tuist.io"
+          sso_organization_id: organization_domain
         )
 
       # When
@@ -618,27 +573,15 @@ defmodule Tuist.AccountsTest do
     test "returns true if the user's sso matches the organization's" do
       # Given
       stub(Environment, :tuist_hosted?, fn -> true end)
+      domain = unique_sso_domain()
 
       user =
-        Accounts.find_or_create_user_from_oauth2(%{
-          provider: :google,
-          uid: 123,
-          info: %{
-            email: "tuist@tuist.dev"
-          },
-          extra: %{
-            raw_info: %{
-              user: %{
-                "hd" => "tuist.io"
-              }
-            }
-          }
-        })
+        Accounts.find_or_create_user_from_oauth2(google_oauth_identity(domain))
 
       organization =
         AccountsFixtures.organization_fixture(
           sso_provider: :google,
-          sso_organization_id: "tuist.io"
+          sso_organization_id: domain
         )
 
       # When
@@ -699,27 +642,15 @@ defmodule Tuist.AccountsTest do
     test "returns true if the user's sso matches the organization's" do
       # Given
       stub(Environment, :tuist_hosted?, fn -> true end)
+      domain = unique_sso_domain()
 
       user =
-        Accounts.find_or_create_user_from_oauth2(%{
-          provider: :google,
-          uid: 123,
-          info: %{
-            email: "tuist@tuist.dev"
-          },
-          extra: %{
-            raw_info: %{
-              user: %{
-                "hd" => "tuist.io"
-              }
-            }
-          }
-        })
+        Accounts.find_or_create_user_from_oauth2(google_oauth_identity(domain))
 
       organization =
         AccountsFixtures.organization_fixture(
           sso_provider: :google,
-          sso_organization_id: "tuist.io"
+          sso_organization_id: domain
         )
 
       # When
@@ -732,27 +663,16 @@ defmodule Tuist.AccountsTest do
     test "returns false if the user's sso does not match the organization's" do
       # Given
       stub(Environment, :tuist_hosted?, fn -> true end)
+      user_domain = unique_sso_domain("tools")
+      organization_domain = unique_sso_domain()
 
       user =
-        Accounts.find_or_create_user_from_oauth2(%{
-          provider: :google,
-          uid: 123,
-          info: %{
-            email: "tuist@tools.io"
-          },
-          extra: %{
-            raw_info: %{
-              user: %{
-                "hd" => "tools.io"
-              }
-            }
-          }
-        })
+        Accounts.find_or_create_user_from_oauth2(google_oauth_identity(user_domain))
 
       organization =
         AccountsFixtures.organization_fixture(
           sso_provider: :google,
-          sso_organization_id: "tuist.io"
+          sso_organization_id: organization_domain
         )
 
       # When
@@ -1384,6 +1304,7 @@ defmodule Tuist.AccountsTest do
       # Given
       stub(Environment, :tuist_hosted?, fn -> true end)
       user = AccountsFixtures.user_fixture()
+      domain = unique_sso_domain()
 
       # When
       {:ok, organization} =
@@ -1393,7 +1314,7 @@ defmodule Tuist.AccountsTest do
             creator: user
           },
           sso_provider: :google,
-          sso_organization_id: "tuist.io"
+          sso_organization_id: domain
         )
 
       # Then
@@ -1401,7 +1322,7 @@ defmodule Tuist.AccountsTest do
                Accounts.get_organization_by_id(organization.id, preload: [:account])
 
       assert organization.sso_provider == :google
-      assert organization.sso_organization_id == "tuist.io"
+      assert organization.sso_organization_id == domain
       assert Accounts.organization_admin?(user, organization) == true
     end
 
@@ -1462,13 +1383,13 @@ defmodule Tuist.AccountsTest do
 
       first_oauth_identity = %{
         provider: :github,
-        uid: 123,
+        uid: System.unique_integer([:positive]),
         info: %{email: "find_or_create_user_from_oauth2@tuist.io"}
       }
 
       second_oauth_identity = %{
         provider: :github,
-        uid: 456,
+        uid: System.unique_integer([:positive]),
         info: %{email: "find_or_create_user_from_oauth1@tuist.test.io"}
       }
 
@@ -1486,25 +1407,17 @@ defmodule Tuist.AccountsTest do
 
     test "assigns user role to SSO users for Google SSO" do
       # Given
+      domain = unique_sso_domain()
+
       organization =
         AccountsFixtures.organization_fixture(
           sso_provider: :google,
-          sso_organization_id: "tuist.io"
+          sso_organization_id: domain
         )
 
-      oauth_identity = %{
-        provider: :google,
-        uid: System.unique_integer([:positive]),
-        info: %{email: "google-sso@tuist.io"},
-        extra: %{
-          raw_info: %{
-            user: %{"hd" => "tuist.io"}
-          }
-        }
-      }
-
       # When
-      user = Accounts.find_or_create_user_from_oauth2(oauth_identity)
+      user =
+        Accounts.find_or_create_user_from_oauth2(google_oauth_identity(domain, email: unique_email(domain, "google-sso")))
 
       # Then
       assert Accounts.belongs_to_organization?(user, organization)
@@ -1513,27 +1426,21 @@ defmodule Tuist.AccountsTest do
 
     test "assigns user role to SSO users for Okta SSO" do
       # Given
+      provider_organization_id = unique_sso_domain("okta")
+
       organization =
         AccountsFixtures.organization_fixture(
           sso_provider: :okta,
-          sso_organization_id: "tuist.okta.com",
+          sso_organization_id: provider_organization_id,
           oauth2_client_id: "client-id",
           oauth2_client_secret: "client-secret"
         )
 
-      oauth_identity = %{
-        provider: :okta,
-        uid: 890,
-        info: %{email: "okta-sso@tuist.io"},
-        extra: %{
-          raw_info: %{
-            provider_organization_id: "tuist.okta.com"
-          }
-        }
-      }
-
       # When
-      user = Accounts.find_or_create_user_from_oauth2(oauth_identity)
+      user =
+        Accounts.find_or_create_user_from_oauth2(
+          okta_oauth_identity(provider_organization_id, email: unique_email("tuist.dev", "okta-sso"))
+        )
 
       # Then
       assert Accounts.belongs_to_organization?(user, organization)
@@ -1608,7 +1515,7 @@ defmodule Tuist.AccountsTest do
 
       Accounts.find_or_create_user_from_oauth2(%{
         provider: :github,
-        uid: 123,
+        uid: System.unique_integer([:positive]),
         info: %{
           email: user.email
         }
@@ -1616,7 +1523,7 @@ defmodule Tuist.AccountsTest do
 
       Accounts.find_or_create_user_from_oauth2(%{
         provider: :google,
-        uid: 123,
+        uid: System.unique_integer([:positive]),
         info: %{
           email: user.email
         },
@@ -1640,7 +1547,7 @@ defmodule Tuist.AccountsTest do
 
       Accounts.find_or_create_user_from_oauth2(%{
         provider: :google,
-        uid: 123,
+        uid: System.unique_integer([:positive]),
         info: %{
           email: user.email
         },
@@ -1664,13 +1571,13 @@ defmodule Tuist.AccountsTest do
 
       Accounts.find_or_create_user_from_oauth2(%{
         provider: :okta,
-        uid: "uid",
+        uid: "uid-#{System.unique_integer([:positive])}",
         info: %{
           email: user.email
         },
         extra: %{
           raw_info: %{
-            provider_organization_id: "tuist.okta.com"
+            provider_organization_id: unique_sso_domain("okta")
           }
         }
       })
@@ -1688,7 +1595,7 @@ defmodule Tuist.AccountsTest do
 
       Accounts.find_or_create_user_from_oauth2(%{
         provider: :github,
-        uid: 123,
+        uid: System.unique_integer([:positive]),
         info: %{
           email: user.email
         }
@@ -1711,7 +1618,7 @@ defmodule Tuist.AccountsTest do
 
       Accounts.find_or_create_user_from_oauth2(%{
         provider: :github,
-        uid: 123,
+        uid: System.unique_integer([:positive]),
         info: %{
           email: user.email
         }
@@ -2251,6 +2158,7 @@ defmodule Tuist.AccountsTest do
   describe "update_organization/2" do
     test "updates organization with a google hosted domain" do
       # Given
+      domain = unique_sso_domain()
       user = AccountsFixtures.user_fixture()
       organization = AccountsFixtures.organization_fixture(creator: user)
 
@@ -2258,16 +2166,17 @@ defmodule Tuist.AccountsTest do
       {:ok, organization} =
         Accounts.update_organization(organization, %{
           sso_provider: :google,
-          sso_organization_id: "tuist.io"
+          sso_organization_id: domain
         })
 
       # Then
-      assert organization.sso_organization_id == "tuist.io"
+      assert organization.sso_organization_id == domain
       assert organization.sso_provider == :google
     end
 
     test "updates organization with an okta hosted domain" do
       # Given
+      provider_organization_id = unique_sso_domain("okta")
       user = AccountsFixtures.user_fixture()
       organization = AccountsFixtures.organization_fixture(creator: user)
 
@@ -2275,37 +2184,29 @@ defmodule Tuist.AccountsTest do
       {:ok, organization} =
         Accounts.update_organization(organization, %{
           sso_provider: :okta,
-          sso_organization_id: "tuist.okta.com",
+          sso_organization_id: provider_organization_id,
           oauth2_client_id: "client-id",
           oauth2_encrypted_client_secret: "client-secret",
-          oauth2_authorize_url: "https://tuist.okta.com/oauth2/v1/authorize",
-          oauth2_token_url: "https://tuist.okta.com/oauth2/v1/token",
-          oauth2_user_info_url: "https://tuist.okta.com/oauth2/v1/userinfo"
+          oauth2_authorize_url: "https://#{provider_organization_id}/oauth2/v1/authorize",
+          oauth2_token_url: "https://#{provider_organization_id}/oauth2/v1/token",
+          oauth2_user_info_url: "https://#{provider_organization_id}/oauth2/v1/userinfo"
         })
 
       # Then
-      assert organization.sso_organization_id == "tuist.okta.com"
+      assert organization.sso_organization_id == provider_organization_id
       assert organization.sso_provider == :okta
     end
 
     test "assigns existing SSO users when enabling Google SSO" do
       # Given
       stub(Environment, :tuist_hosted?, fn -> true end)
+      domain = unique_sso_domain()
 
       organization = AccountsFixtures.organization_fixture()
 
       # Create an existing user with Google OAuth2 identity
       existing_user =
-        Accounts.find_or_create_user_from_oauth2(%{
-          provider: :google,
-          uid: System.unique_integer([:positive]),
-          info: %{email: "user@tuist.io"},
-          extra: %{
-            raw_info: %{
-              user: %{"hd" => "tuist.io"}
-            }
-          }
-        })
+        Accounts.find_or_create_user_from_oauth2(google_oauth_identity(domain, email: unique_email(domain, "user")))
 
       # Verify user is not yet assigned to organization
       refute Accounts.belongs_to_organization?(existing_user, organization)
@@ -2314,12 +2215,12 @@ defmodule Tuist.AccountsTest do
       {:ok, updated_organization} =
         Accounts.update_organization(organization, %{
           sso_provider: :google,
-          sso_organization_id: "tuist.io"
+          sso_organization_id: domain
         })
 
       # Then
       assert updated_organization.sso_provider == :google
-      assert updated_organization.sso_organization_id == "tuist.io"
+      assert updated_organization.sso_organization_id == domain
 
       # Existing SSO user should now be assigned to the organization with explicit role
       assert Accounts.belongs_to_organization?(existing_user, updated_organization)
@@ -2331,21 +2232,15 @@ defmodule Tuist.AccountsTest do
     test "assigns existing SSO users when enabling Okta SSO" do
       # Given
       stub(Environment, :tuist_hosted?, fn -> true end)
+      provider_organization_id = unique_sso_domain("okta")
 
       organization = AccountsFixtures.organization_fixture()
 
       # Create an existing user with Okta OAuth2 identity
       existing_user =
-        Accounts.find_or_create_user_from_oauth2(%{
-          provider: :okta,
-          uid: System.unique_integer([:positive]),
-          info: %{email: "user@tuist.io"},
-          extra: %{
-            raw_info: %{
-              provider_organization_id: "tuist.okta.com"
-            }
-          }
-        })
+        Accounts.find_or_create_user_from_oauth2(
+          okta_oauth_identity(provider_organization_id, email: unique_email("tuist.dev", "user"))
+        )
 
       # Verify user is not yet assigned to organization
       refute Accounts.belongs_to_organization?(existing_user, organization)
@@ -2354,17 +2249,17 @@ defmodule Tuist.AccountsTest do
       {:ok, updated_organization} =
         Accounts.update_organization(organization, %{
           sso_provider: :okta,
-          sso_organization_id: "tuist.okta.com",
+          sso_organization_id: provider_organization_id,
           oauth2_client_id: "client-id",
           oauth2_encrypted_client_secret: "client-secret",
-          oauth2_authorize_url: "https://tuist.okta.com/oauth2/v1/authorize",
-          oauth2_token_url: "https://tuist.okta.com/oauth2/v1/token",
-          oauth2_user_info_url: "https://tuist.okta.com/oauth2/v1/userinfo"
+          oauth2_authorize_url: "https://#{provider_organization_id}/oauth2/v1/authorize",
+          oauth2_token_url: "https://#{provider_organization_id}/oauth2/v1/token",
+          oauth2_user_info_url: "https://#{provider_organization_id}/oauth2/v1/userinfo"
         })
 
       # Then
       assert updated_organization.sso_provider == :okta
-      assert updated_organization.sso_organization_id == "tuist.okta.com"
+      assert updated_organization.sso_organization_id == provider_organization_id
 
       # Existing SSO user should now be assigned to the organization with explicit role
       assert Accounts.belongs_to_organization?(existing_user, updated_organization)
@@ -2376,26 +2271,21 @@ defmodule Tuist.AccountsTest do
     test "does not assign users when SSO is updated but not newly enabled" do
       # Given
       stub(Environment, :tuist_hosted?, fn -> true end)
+      existing_domain = unique_sso_domain("existing")
+      new_domain = unique_sso_domain()
 
       # Create organization with SSO already enabled
       organization =
         AccountsFixtures.organization_fixture(
           sso_provider: :google,
-          sso_organization_id: "existing.io"
+          sso_organization_id: existing_domain
         )
 
       # Create a user with a domain that doesn't match any SSO organization yet
       other_user =
-        Accounts.find_or_create_user_from_oauth2(%{
-          provider: :google,
-          uid: System.unique_integer([:positive]),
-          info: %{email: "user@tuist.io"},
-          extra: %{
-            raw_info: %{
-              user: %{"hd" => "tuist.io"}
-            }
-          }
-        })
+        Accounts.find_or_create_user_from_oauth2(
+          google_oauth_identity(new_domain, email: unique_email(new_domain, "user"))
+        )
 
       # Verify user is not assigned to organization (different domain)
       refute Accounts.belongs_to_organization?(other_user, organization)
@@ -2403,11 +2293,11 @@ defmodule Tuist.AccountsTest do
       # When - Update SSO organization ID (not newly enabling)
       {:ok, updated_organization} =
         Accounts.update_organization(organization, %{
-          sso_organization_id: "tuist.io"
+          sso_organization_id: new_domain
         })
 
       # Then
-      assert updated_organization.sso_organization_id == "tuist.io"
+      assert updated_organization.sso_organization_id == new_domain
 
       # User should have SSO-based access (automatic through belongs_to_sso_organization)
       assert Accounts.belongs_to_sso_organization?(other_user, updated_organization)
@@ -2419,33 +2309,16 @@ defmodule Tuist.AccountsTest do
     test "assigns multiple existing SSO users when enabling SSO" do
       # Given
       stub(Environment, :tuist_hosted?, fn -> true end)
+      domain = unique_sso_domain()
 
       organization = AccountsFixtures.organization_fixture()
 
       # Create multiple existing users with Google OAuth2 identities
       user1 =
-        Accounts.find_or_create_user_from_oauth2(%{
-          provider: :google,
-          uid: System.unique_integer([:positive]),
-          info: %{email: "user1@tuist.io"},
-          extra: %{
-            raw_info: %{
-              user: %{"hd" => "tuist.io"}
-            }
-          }
-        })
+        Accounts.find_or_create_user_from_oauth2(google_oauth_identity(domain, email: unique_email(domain, "user1")))
 
       user2 =
-        Accounts.find_or_create_user_from_oauth2(%{
-          provider: :google,
-          uid: System.unique_integer([:positive]),
-          info: %{email: "user2@tuist.io"},
-          extra: %{
-            raw_info: %{
-              user: %{"hd" => "tuist.io"}
-            }
-          }
-        })
+        Accounts.find_or_create_user_from_oauth2(google_oauth_identity(domain, email: unique_email(domain, "user2")))
 
       # Verify users are not yet assigned to organization
       refute Accounts.belongs_to_organization?(user1, organization)
@@ -2455,7 +2328,7 @@ defmodule Tuist.AccountsTest do
       {:ok, updated_organization} =
         Accounts.update_organization(organization, %{
           sso_provider: :google,
-          sso_organization_id: "tuist.io"
+          sso_organization_id: domain
         })
 
       # Then
@@ -2471,59 +2344,52 @@ defmodule Tuist.AccountsTest do
     test "creates a user from a github identity" do
       # Given
       stub(Environment, :tuist_hosted?, fn -> true end)
+      email = unique_user_email()
 
       # When
       user =
         Accounts.find_or_create_user_from_oauth2(%{
           provider: :github,
-          uid: 123,
+          uid: System.unique_integer([:positive]),
           info: %{
-            email: "tuist@tuist.dev"
+            email: email
           }
         })
 
       # Then
-      assert user.email == "tuist@tuist.dev"
+      assert user.email == email
     end
 
     test "creates a user from a google identity with a hosted domain" do
       # Given
       stub(Environment, :tuist_hosted?, fn -> true end)
+      domain = unique_sso_domain()
+      uid = System.unique_integer([:positive])
+      email = unique_email(domain)
 
       # When
       user =
-        Accounts.find_or_create_user_from_oauth2(%{
-          provider: :google,
-          uid: 123,
-          info: %{
-            email: "tuist@tuist.dev"
-          },
-          extra: %{
-            raw_info: %{
-              user: %{
-                "hd" => "tuist.io"
-              }
-            }
-          }
-        })
+        Accounts.find_or_create_user_from_oauth2(google_oauth_identity(domain, uid: uid, email: email))
 
       # Then
-      assert user.email == "tuist@tuist.dev"
-      oauth2_identity = Accounts.get_oauth2_identity_by_provider_and_id(:google, 123)
-      assert oauth2_identity.provider_organization_id == "tuist.io"
+      assert user.email == email
+      oauth2_identity = Accounts.get_oauth2_identity_by_provider_and_id(:google, uid)
+      assert oauth2_identity.provider_organization_id == domain
     end
 
     test "creates a user from a google identity without a hosted domain" do
       # Given
       stub(Environment, :tuist_hosted?, fn -> true end)
+      uid = System.unique_integer([:positive])
+      email = unique_user_email()
 
       # When
       user =
         Accounts.find_or_create_user_from_oauth2(%{
           provider: :google,
-          uid: 123,
+          uid: uid,
           info: %{
-            email: "tuist@tuist.dev"
+            email: email
           },
           extra: %{
             raw_info: %{
@@ -2535,20 +2401,21 @@ defmodule Tuist.AccountsTest do
         })
 
       # Then
-      assert user.email == "tuist@tuist.dev"
-      oauth2_identity = Accounts.get_oauth2_identity_by_provider_and_id(:google, 123)
+      assert user.email == email
+      oauth2_identity = Accounts.get_oauth2_identity_by_provider_and_id(:google, uid)
       assert oauth2_identity.provider_organization_id == nil
     end
 
     test "updates an existing user with a new github identity" do
-      user = user_fixture(email: "tuist@tuist.dev")
+      email = unique_user_email()
+      user = user_fixture(email: email)
 
       got =
         Accounts.find_or_create_user_from_oauth2(%{
           provider: :github,
-          uid: 123,
+          uid: System.unique_integer([:positive]),
           info: %{
-            email: "tuist@tuist.dev"
+            email: email
           }
         })
 
@@ -2557,21 +2424,12 @@ defmodule Tuist.AccountsTest do
     end
 
     test "updates an existing user with a new okta identity" do
-      user = user_fixture(email: "tuist@tuist.dev")
+      email = unique_user_email()
+      provider_organization_id = unique_sso_domain("okta")
+      user = user_fixture(email: email)
 
       got =
-        Accounts.find_or_create_user_from_oauth2(%{
-          provider: :okta,
-          uid: 123,
-          info: %{
-            email: "tuist@tuist.dev"
-          },
-          extra: %{
-            raw_info: %{
-              provider_organization_id: "tuist.okta.com"
-            }
-          }
-        })
+        Accounts.find_or_create_user_from_oauth2(okta_oauth_identity(provider_organization_id, email: email))
 
       assert user.email == got.email
       assert Accounts.find_oauth2_identity(%{user: user, provider: :okta})
@@ -2582,7 +2440,7 @@ defmodule Tuist.AccountsTest do
       user =
         Accounts.find_or_create_user_from_oauth2(%{
           provider: :github,
-          uid: 123,
+          uid: System.unique_integer([:positive]),
           info: %{
             email: "admin@example.com"
           }
@@ -2657,28 +2515,16 @@ defmodule Tuist.AccountsTest do
     test "deletes a user when a user belongs to the SSO organization" do
       # Given
       stub(Environment, :tuist_hosted?, fn -> true end)
+      domain = unique_sso_domain()
 
       organization =
         AccountsFixtures.organization_fixture(
           sso_provider: :google,
-          sso_organization_id: "tuist.io"
+          sso_organization_id: domain
         )
 
       user =
-        Accounts.find_or_create_user_from_oauth2(%{
-          provider: :google,
-          uid: 123,
-          info: %{
-            email: "tuist@tuist.dev"
-          },
-          extra: %{
-            raw_info: %{
-              user: %{
-                "hd" => "tuist.io"
-              }
-            }
-          }
-        })
+        Accounts.find_or_create_user_from_oauth2(google_oauth_identity(domain))
 
       # When
       :ok = Accounts.remove_user_from_organization(user, organization)
@@ -2807,11 +2653,12 @@ defmodule Tuist.AccountsTest do
     test "returns users of an organization" do
       # Given
       user_one = AccountsFixtures.user_fixture()
+      domain = unique_sso_domain()
 
       organization =
         AccountsFixtures.organization_fixture(
           sso_provider: :google,
-          sso_organization_id: "tuist.io"
+          sso_organization_id: domain
         )
 
       Accounts.add_user_to_organization(user_one, organization, role: :user)
@@ -2834,46 +2681,24 @@ defmodule Tuist.AccountsTest do
       # Given
       stub(Environment, :tuist_hosted?, fn -> true end)
       user_one = AccountsFixtures.user_fixture()
+      domain = unique_sso_domain()
+      other_domain = unique_sso_domain("tools")
 
       organization =
         AccountsFixtures.organization_fixture(
           sso_provider: :google,
-          sso_organization_id: "tuist.io"
+          sso_organization_id: domain
         )
 
       Accounts.add_user_to_organization(user_one, organization, role: :user)
       AccountsFixtures.user_fixture()
 
       user_three =
-        Accounts.find_or_create_user_from_oauth2(%{
-          provider: :google,
-          uid: 123,
-          info: %{
-            email: "tuist@tuist.dev"
-          },
-          extra: %{
-            raw_info: %{
-              user: %{
-                "hd" => "tuist.io"
-              }
-            }
-          }
-        })
+        Accounts.find_or_create_user_from_oauth2(google_oauth_identity(domain))
 
-      Accounts.find_or_create_user_from_oauth2(%{
-        provider: :google,
-        uid: 1234,
-        info: %{
-          email: "tuist-tools@tools.io"
-        },
-        extra: %{
-          raw_info: %{
-            user: %{
-              "hd" => "tools.io"
-            }
-          }
-        }
-      })
+      Accounts.find_or_create_user_from_oauth2(
+        google_oauth_identity(other_domain, email: unique_email(other_domain, "tools"))
+      )
 
       # When
       got = Accounts.get_organization_members(organization, :user)
@@ -2886,11 +2711,13 @@ defmodule Tuist.AccountsTest do
       # Given
       stub(Environment, :tuist_hosted?, fn -> true end)
       user_one = AccountsFixtures.user_fixture()
+      provider_organization_id = unique_sso_domain("okta")
+      other_provider_organization_id = unique_sso_domain("different-org")
 
       organization =
         AccountsFixtures.organization_fixture(
           sso_provider: :okta,
-          sso_organization_id: "tuist.okta.com",
+          sso_organization_id: provider_organization_id,
           oauth2_client_id: "client-id",
           oauth2_client_secret: "client-secret"
         )
@@ -2899,31 +2726,11 @@ defmodule Tuist.AccountsTest do
       AccountsFixtures.user_fixture()
 
       user_three =
-        Accounts.find_or_create_user_from_oauth2(%{
-          provider: :okta,
-          uid: 123,
-          info: %{
-            email: "tuist@tuist.dev"
-          },
-          extra: %{
-            raw_info: %{
-              provider_organization_id: "tuist.okta.com"
-            }
-          }
-        })
+        Accounts.find_or_create_user_from_oauth2(okta_oauth_identity(provider_organization_id))
 
-      Accounts.find_or_create_user_from_oauth2(%{
-        provider: :okta,
-        uid: 1234,
-        info: %{
-          email: "tuist-tools@tools.io"
-        },
-        extra: %{
-          raw_info: %{
-            provider_organization_id: "different-org.okta.com"
-          }
-        }
-      })
+      Accounts.find_or_create_user_from_oauth2(
+        okta_oauth_identity(other_provider_organization_id, email: unique_email("tuist.dev", "tools"))
+      )
 
       # When
       got = Accounts.get_organization_members(organization, :user)
@@ -2957,26 +2764,18 @@ defmodule Tuist.AccountsTest do
 
     test "includes SSO users for organizations with Google SSO" do
       user_one = AccountsFixtures.user_fixture()
+      domain = unique_sso_domain()
 
       organization =
         AccountsFixtures.organization_fixture(
           creator: user_one,
           sso_provider: :google,
-          sso_organization_id: "tuist.io"
+          sso_organization_id: domain
         )
 
       # Create an SSO user
       sso_user =
-        Accounts.find_or_create_user_from_oauth2(%{
-          provider: :google,
-          uid: 123,
-          info: %{email: "sso@tuist.io"},
-          extra: %{
-            raw_info: %{
-              user: %{"hd" => "tuist.io"}
-            }
-          }
-        })
+        Accounts.find_or_create_user_from_oauth2(google_oauth_identity(domain, email: unique_email(domain, "sso")))
 
       # Add a regular user
       user_two = AccountsFixtures.user_fixture()
@@ -2997,28 +2796,22 @@ defmodule Tuist.AccountsTest do
 
     test "includes SSO users for organizations with Okta SSO" do
       user_one = AccountsFixtures.user_fixture()
+      provider_organization_id = unique_sso_domain("okta")
 
       organization =
         AccountsFixtures.organization_fixture(
           creator: user_one,
           sso_provider: :okta,
-          sso_organization_id: "tuist.okta.com",
+          sso_organization_id: provider_organization_id,
           oauth2_client_id: "client-id",
           oauth2_client_secret: "client-secret"
         )
 
       # Create an SSO user
       sso_user =
-        Accounts.find_or_create_user_from_oauth2(%{
-          provider: :okta,
-          uid: 456,
-          info: %{email: "okta@tuist.io"},
-          extra: %{
-            raw_info: %{
-              provider_organization_id: "tuist.okta.com"
-            }
-          }
-        })
+        Accounts.find_or_create_user_from_oauth2(
+          okta_oauth_identity(provider_organization_id, email: unique_email("tuist.dev", "okta"))
+        )
 
       # When
       got =
@@ -3348,35 +3141,18 @@ defmodule Tuist.AccountsTest do
     test "finds users with matching SSO credentials not assigned to organization" do
       # Given
       stub(Environment, :tuist_hosted?, fn -> true end)
+      domain = unique_sso_domain()
 
       # Create organization without SSO initially
       organization = AccountsFixtures.organization_fixture()
 
       # Create a user with matching Google OAuth2 identity
       unassigned_user =
-        Accounts.find_or_create_user_from_oauth2(%{
-          provider: :google,
-          uid: System.unique_integer([:positive]),
-          info: %{email: "unassigned@tuist.io"},
-          extra: %{
-            raw_info: %{
-              user: %{"hd" => "tuist.io"}
-            }
-          }
-        })
+        Accounts.find_or_create_user_from_oauth2(google_oauth_identity(domain, email: unique_email(domain, "unassigned")))
 
       # Create a user already assigned to the organization
       assigned_user =
-        Accounts.find_or_create_user_from_oauth2(%{
-          provider: :google,
-          uid: System.unique_integer([:positive]),
-          info: %{email: "assigned@tuist.io"},
-          extra: %{
-            raw_info: %{
-              user: %{"hd" => "tuist.io"}
-            }
-          }
-        })
+        Accounts.find_or_create_user_from_oauth2(google_oauth_identity(domain, email: unique_email(domain, "assigned")))
 
       Accounts.add_user_to_organization(assigned_user, organization, role: :user)
 
@@ -3385,11 +3161,11 @@ defmodule Tuist.AccountsTest do
         Accounts.find_or_create_user_from_oauth2(%{
           provider: :github,
           uid: System.unique_integer([:positive]),
-          info: %{email: "github@tuist.io"}
+          info: %{email: unique_email(domain, "github")}
         })
 
       # When
-      unassigned_users = Accounts.find_unassigned_sso_users(organization, :google, "tuist.io")
+      unassigned_users = Accounts.find_unassigned_sso_users(organization, :google, domain)
 
       # Then
       user_ids = Enum.map(unassigned_users, & &1.id)
@@ -3400,14 +3176,16 @@ defmodule Tuist.AccountsTest do
 
     test "returns empty list when no matching users exist" do
       # Given
+      domain = unique_sso_domain()
+
       organization =
         AccountsFixtures.organization_fixture(
           sso_provider: :google,
-          sso_organization_id: "tuist.io"
+          sso_organization_id: domain
         )
 
       # When
-      unassigned_users = Accounts.find_unassigned_sso_users(organization, :google, "tuist.io")
+      unassigned_users = Accounts.find_unassigned_sso_users(organization, :google, domain)
 
       # Then
       assert unassigned_users == []
@@ -3418,33 +3196,16 @@ defmodule Tuist.AccountsTest do
     test "assigns matching SSO users to organization and returns count" do
       # Given
       stub(Environment, :tuist_hosted?, fn -> true end)
+      domain = unique_sso_domain()
 
       organization = AccountsFixtures.organization_fixture()
 
       # Create multiple users with matching Google OAuth2 identities
       user1 =
-        Accounts.find_or_create_user_from_oauth2(%{
-          provider: :google,
-          uid: System.unique_integer([:positive]),
-          info: %{email: "user1@tuist.io"},
-          extra: %{
-            raw_info: %{
-              user: %{"hd" => "tuist.io"}
-            }
-          }
-        })
+        Accounts.find_or_create_user_from_oauth2(google_oauth_identity(domain, email: unique_email(domain, "user1")))
 
       user2 =
-        Accounts.find_or_create_user_from_oauth2(%{
-          provider: :google,
-          uid: System.unique_integer([:positive]),
-          info: %{email: "user2@tuist.io"},
-          extra: %{
-            raw_info: %{
-              user: %{"hd" => "tuist.io"}
-            }
-          }
-        })
+        Accounts.find_or_create_user_from_oauth2(google_oauth_identity(domain, email: unique_email(domain, "user2")))
 
       # Verify users are not assigned to organization
       refute Accounts.belongs_to_organization?(user1, organization)
@@ -3452,7 +3213,7 @@ defmodule Tuist.AccountsTest do
 
       # When
       count =
-        Accounts.assign_existing_sso_users_to_organization(organization, :google, "tuist.io")
+        Accounts.assign_existing_sso_users_to_organization(organization, :google, domain)
 
       # Then
       assert count == 2
@@ -3464,11 +3225,12 @@ defmodule Tuist.AccountsTest do
 
     test "returns 0 when no matching users exist" do
       # Given
+      domain = unique_sso_domain()
       organization = AccountsFixtures.organization_fixture()
 
       # When
       count =
-        Accounts.assign_existing_sso_users_to_organization(organization, :google, "tuist.io")
+        Accounts.assign_existing_sso_users_to_organization(organization, :google, domain)
 
       # Then
       assert count == 0
@@ -4963,6 +4725,46 @@ defmodule Tuist.AccountsTest do
   defp extract_claim_view_token(html_body) do
     [_, encoded_token] = Regex.run(~r{/agent/auth/claim/view\?token=([^"&]+)}, html_body)
     URI.decode_www_form(encoded_token)
+  end
+
+  defp unique_sso_domain(prefix \\ "tuist") do
+    "#{prefix}-#{TuistTestSupport.Utilities.unique_integer(6)}.io"
+  end
+
+  defp unique_email(domain, local \\ "tuist") do
+    "#{local}-#{TuistTestSupport.Utilities.unique_integer(6)}@#{domain}"
+  end
+
+  defp google_oauth_identity(domain, opts \\ []) do
+    %{
+      provider: :google,
+      uid: Keyword.get_lazy(opts, :uid, fn -> System.unique_integer([:positive]) end),
+      info: %{
+        email: Keyword.get_lazy(opts, :email, fn -> unique_email(domain) end)
+      },
+      extra: %{
+        raw_info: %{
+          user: %{
+            "hd" => domain
+          }
+        }
+      }
+    }
+  end
+
+  defp okta_oauth_identity(provider_organization_id, opts \\ []) do
+    %{
+      provider: :okta,
+      uid: Keyword.get_lazy(opts, :uid, fn -> System.unique_integer([:positive]) end),
+      info: %{
+        email: Keyword.get_lazy(opts, :email, fn -> unique_email("tuist.dev") end)
+      },
+      extra: %{
+        raw_info: %{
+          provider_organization_id: provider_organization_id
+        }
+      }
+    }
   end
 
   defp agent_registration_events(agent_registration_id) do

--- a/server/test/tuist/docs/cli_test.exs
+++ b/server/test/tuist/docs/cli_test.exs
@@ -4,6 +4,8 @@ defmodule Tuist.Docs.CLITest do
 
   alias Tuist.Docs.CLI
 
+  @moduletag capture_log: true
+
   @spec_fixture %{
     "command" => %{
       "commandName" => "tuist",

--- a/server/test/tuist/github/releases_test.exs
+++ b/server/test/tuist/github/releases_test.exs
@@ -4,6 +4,8 @@ defmodule Tuist.GitHub.ReleasesTest do
 
   alias Tuist.GitHub.Releases
 
+  @moduletag capture_log: true
+
   setup do
     stub(Tuist.KeyValueStore, :get_or_update, fn _, _, func -> func.() end)
     :ok

--- a/server/test/tuist/kura/reconciler_test.exs
+++ b/server/test/tuist/kura/reconciler_test.exs
@@ -11,6 +11,8 @@ defmodule Tuist.Kura.ReconcilerTest do
   alias Tuist.Repo
   alias TuistTestSupport.Fixtures.AccountsFixtures
 
+  @moduletag capture_log: true
+
   setup :set_mimic_from_context
 
   setup do

--- a/server/test/tuist/processor/xcresult_processor_test.exs
+++ b/server/test/tuist/processor/xcresult_processor_test.exs
@@ -431,11 +431,13 @@ defmodule Tuist.Processor.XCResultProcessorTest do
         project_handle: "MyProject"
       ]
 
-      assert {:ok, result} = XCResultProcessor.process_local(fixture_zip, opts)
+      capture_log(fn ->
+        assert {:ok, result} = XCResultProcessor.process_local(fixture_zip, opts)
 
-      [module] = result["test_modules"]
-      [test_case] = module["test_cases"]
-      assert test_case["attachments"] == []
+        [module] = result["test_modules"]
+        [test_case] = module["test_cases"]
+        assert test_case["attachments"] == []
+      end)
 
       state = Agent.get(counters, & &1)
       assert state.part == 3

--- a/server/test/tuist/projects_test.exs
+++ b/server/test/tuist/projects_test.exs
@@ -100,10 +100,12 @@ defmodule Tuist.ProjectsTest do
 
   test "returns all projects associated with a user's based on a google hosted domain" do
     # Given
+    domain = "tuist-#{TuistTestSupport.Utilities.unique_integer(6)}.io"
+
     organization =
       AccountsFixtures.organization_fixture(
         sso_provider: :google,
-        sso_organization_id: "tuist.io"
+        sso_organization_id: domain
       )
 
     account = Accounts.get_account_from_organization(organization)
@@ -112,14 +114,14 @@ defmodule Tuist.ProjectsTest do
     user =
       Accounts.find_or_create_user_from_oauth2(%{
         provider: :google,
-        uid: 123,
+        uid: System.unique_integer([:positive]),
         info: %{
-          email: "tuist@tuist.dev"
+          email: "tuist-#{TuistTestSupport.Utilities.unique_integer(6)}@#{domain}"
         },
         extra: %{
           raw_info: %{
             user: %{
-              "hd" => "tuist.io"
+              "hd" => domain
             }
           }
         }

--- a/server/test/tuist/runners/workers/webhook_redelivery_worker_test.exs
+++ b/server/test/tuist/runners/workers/webhook_redelivery_worker_test.exs
@@ -6,6 +6,8 @@ defmodule Tuist.Runners.Workers.WebhookRedeliveryWorkerTest do
   alias Tuist.GitHub.Client, as: GitHubClient
   alias Tuist.Runners.Workers.WebhookRedeliveryWorker
 
+  @moduletag capture_log: true
+
   setup :verify_on_exit!
 
   defp delivery(opts) do

--- a/server/test/tuist/tests/workers/process_xcresult_worker_test.exs
+++ b/server/test/tuist/tests/workers/process_xcresult_worker_test.exs
@@ -5,6 +5,8 @@ defmodule Tuist.Tests.Workers.ProcessXcresultWorkerTest do
   alias Tuist.Processor.XCResultProcessor
   alias Tuist.Tests.Workers.ProcessXcresultWorker
 
+  @moduletag capture_log: true
+
   setup :verify_on_exit!
 
   @storage_key "tuist/tests/test-xcresult.zip"

--- a/server/test/tuist_web/controllers/api/organizations_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/organizations_controller_test.exs
@@ -11,7 +11,7 @@ defmodule TuistWeb.API.OrganizationsControllerTest do
   alias TuistWeb.Authentication
 
   setup do
-    user = AccountsFixtures.user_fixture(email: "tuist@tuist.dev", preload: [:account])
+    user = AccountsFixtures.user_fixture(preload: [:account])
     %{user: user}
   end
 
@@ -346,7 +346,7 @@ defmodule TuistWeb.API.OrganizationsControllerTest do
       response = json_response(conn, :bad_request)
 
       assert response["message"] ==
-               "A user or organization with the handle tuist already exists"
+               "A user or organization with the handle #{user.account.name} already exists"
     end
 
     test "returns bad request when organization contains a dot", %{conn: conn, user: user} do
@@ -388,21 +388,8 @@ defmodule TuistWeb.API.OrganizationsControllerTest do
     test "updates an organization with SSO settings when user's google hosted domain is equal to the new value",
          %{conn: conn} do
       # Given
-      user =
-        Accounts.find_or_create_user_from_oauth2(%{
-          provider: :google,
-          uid: 123,
-          info: %{
-            email: "tuist@tuist.dev"
-          },
-          extra: %{
-            raw_info: %{
-              user: %{
-                "hd" => "tuist.io"
-              }
-            }
-          }
-        })
+      domain = unique_sso_domain()
+      user = Accounts.find_or_create_user_from_oauth2(google_oauth_identity(domain))
 
       conn = Authentication.put_current_user(conn, user)
 
@@ -414,14 +401,14 @@ defmodule TuistWeb.API.OrganizationsControllerTest do
         |> put_req_header("content-type", "application/json")
         |> put(~p"/api/organizations/tuist-org",
           sso_provider: "google",
-          sso_organization_id: "tuist.io"
+          sso_organization_id: domain
         )
 
       # Then
       response = json_response(conn, :ok)
       assert response["name"] == "tuist-org"
       assert response["sso_provider"] == "google"
-      assert response["sso_organization_id"] == "tuist.io"
+      assert response["sso_organization_id"] == domain
       assert response["sso_enforced"] == false
     end
 
@@ -429,12 +416,13 @@ defmodule TuistWeb.API.OrganizationsControllerTest do
          %{conn: conn, user: user} do
       # Given
       conn = Authentication.put_current_user(conn, user)
+      domain = unique_sso_domain()
 
       AccountsFixtures.organization_fixture(
         name: "tuist-org",
         creator: user,
         sso_provider: :google,
-        sso_organization_id: "tuist.io"
+        sso_organization_id: domain
       )
 
       # When
@@ -458,6 +446,7 @@ defmodule TuistWeb.API.OrganizationsControllerTest do
       user: user
     } do
       conn = Authentication.put_current_user(conn, user)
+      domain = unique_sso_domain()
 
       organization = AccountsFixtures.organization_fixture(name: "tuist-org")
       Accounts.add_user_to_organization(user, organization)
@@ -468,7 +457,7 @@ defmodule TuistWeb.API.OrganizationsControllerTest do
         |> put_req_header("content-type", "application/json")
         |> put(~p"/api/organizations/tuist-org",
           sso_provider: "google",
-          sso_organization_id: "tuist.io"
+          sso_organization_id: domain
         )
 
       # Then
@@ -482,28 +471,15 @@ defmodule TuistWeb.API.OrganizationsControllerTest do
          %{
            conn: conn
          } do
-      user =
-        Accounts.find_or_create_user_from_oauth2(%{
-          provider: :google,
-          uid: 123,
-          info: %{
-            email: "tuist@tuist.dev"
-          },
-          extra: %{
-            raw_info: %{
-              user: %{
-                "hd" => "tuist.io"
-              }
-            }
-          }
-        })
+      domain = unique_sso_domain()
+      user = Accounts.find_or_create_user_from_oauth2(google_oauth_identity(domain))
 
       conn = Authentication.put_current_user(conn, user)
 
       AccountsFixtures.organization_fixture(
         creator: user,
         sso_provider: :google,
-        sso_organization_id: "tuist.io"
+        sso_organization_id: domain
       )
 
       AccountsFixtures.organization_fixture(name: "tuist-org", creator: user)
@@ -514,7 +490,7 @@ defmodule TuistWeb.API.OrganizationsControllerTest do
         |> put_req_header("content-type", "application/json")
         |> put(~p"/api/organizations/tuist-org",
           sso_provider: "google",
-          sso_organization_id: "tuist.io"
+          sso_organization_id: domain
         )
 
       # Then
@@ -527,21 +503,9 @@ defmodule TuistWeb.API.OrganizationsControllerTest do
     test "returns :bad_request when user's google hosted domain is not equal to the new value", %{
       conn: conn
     } do
-      user =
-        Accounts.find_or_create_user_from_oauth2(%{
-          provider: :google,
-          uid: 123,
-          info: %{
-            email: "tuist@tuist.dev"
-          },
-          extra: %{
-            raw_info: %{
-              user: %{
-                "hd" => "tuist.io"
-              }
-            }
-          }
-        })
+      domain = unique_sso_domain()
+      other_domain = unique_sso_domain("tools")
+      user = Accounts.find_or_create_user_from_oauth2(google_oauth_identity(domain))
 
       conn = Authentication.put_current_user(conn, user)
 
@@ -553,7 +517,7 @@ defmodule TuistWeb.API.OrganizationsControllerTest do
         |> put_req_header("content-type", "application/json")
         |> put(~p"/api/organizations/tuist-org",
           sso_provider: "google",
-          sso_organization_id: "tools.io"
+          sso_organization_id: other_domain
         )
 
       # Then
@@ -599,32 +563,20 @@ defmodule TuistWeb.API.OrganizationsControllerTest do
     test "removes a member with a google hosted domain", %{conn: conn, user: user} do
       # Given
       conn = Authentication.put_current_user(conn, user)
+      domain = unique_sso_domain()
 
       AccountsFixtures.organization_fixture(
         name: "tuist-org",
         creator: user,
         sso_provider: :google,
-        sso_organization_id: "tuist.io"
+        sso_organization_id: domain
       )
 
-      member =
-        Accounts.find_or_create_user_from_oauth2(%{
-          provider: :google,
-          uid: 123,
-          info: %{
-            email: "tuist-member@tuist.io"
-          },
-          extra: %{
-            raw_info: %{
-              user: %{
-                "hd" => "tuist.io"
-              }
-            }
-          }
-        })
+      member = Accounts.find_or_create_user_from_oauth2(google_oauth_identity(domain, "tuist-member"))
+      member_account = Accounts.get_account_from_user(member)
 
       # When
-      conn = delete(conn, ~p"/api/organizations/tuist-org/members/tuist-member")
+      conn = delete(conn, ~p"/api/organizations/tuist-org/members/#{member_account.name}")
 
       # Then
       response = json_response(conn, :no_content)
@@ -710,40 +662,28 @@ defmodule TuistWeb.API.OrganizationsControllerTest do
     } do
       # Given
       conn = Authentication.put_current_user(conn, user)
+      domain = unique_sso_domain()
 
       organization =
         AccountsFixtures.organization_fixture(
           name: "tuist-org",
           creator: user,
           sso_provider: :google,
-          sso_organization_id: "tuist.io"
+          sso_organization_id: domain
         )
 
-      member =
-        Accounts.find_or_create_user_from_oauth2(%{
-          provider: :google,
-          uid: 123,
-          info: %{
-            email: "tuist-member@tuist.io"
-          },
-          extra: %{
-            raw_info: %{
-              user: %{
-                "hd" => "tuist.io"
-              }
-            }
-          }
-        })
+      member = Accounts.find_or_create_user_from_oauth2(google_oauth_identity(domain, "tuist-member"))
+      member_account = Accounts.get_account_from_user(member)
 
       # When
       conn =
         conn
         |> put_req_header("content-type", "application/json")
-        |> put(~p"/api/organizations/tuist-org/members/tuist-member", role: "admin")
+        |> put(~p"/api/organizations/tuist-org/members/#{member_account.name}", role: "admin")
 
       # Then
       response = json_response(conn, :ok)
-      assert response["name"] == "tuist-member"
+      assert response["name"] == member_account.name
       assert response["role"] == "admin"
       assert Accounts.organization_admin?(Accounts.get_user!(member.id), organization) == true
     end
@@ -805,5 +745,26 @@ defmodule TuistWeb.API.OrganizationsControllerTest do
       assert response["message"] ==
                "User tuist-member is not a member of the organization tuist-org"
     end
+  end
+
+  defp unique_sso_domain(prefix \\ "tuist") do
+    "#{prefix}-#{TuistTestSupport.Utilities.unique_integer(6)}.io"
+  end
+
+  defp google_oauth_identity(domain, local \\ "tuist") do
+    %{
+      provider: :google,
+      uid: System.unique_integer([:positive]),
+      info: %{
+        email: "#{local}-#{TuistTestSupport.Utilities.unique_integer(6)}@#{domain}"
+      },
+      extra: %{
+        raw_info: %{
+          user: %{
+            "hd" => domain
+          }
+        }
+      }
+    }
   end
 end

--- a/server/test/tuist_web/controllers/api/projects_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/projects_controller_test.exs
@@ -11,7 +11,7 @@ defmodule TuistWeb.API.ProjectsControllerTest do
   alias TuistWeb.Authentication
 
   setup do
-    user = AccountsFixtures.user_fixture(email: "tuist@tuist.dev", preload: [:account])
+    user = AccountsFixtures.user_fixture(preload: [:account])
     %{user: user}
   end
 
@@ -63,7 +63,7 @@ defmodule TuistWeb.API.ProjectsControllerTest do
 
       assert response == %{
                "id" => response["id"],
-               "full_name" => "tuist/my-project",
+               "full_name" => "#{user.account.name}/my-project",
                "default_branch" => "main",
                "repository_url" => nil,
                "visibility" => "private",
@@ -350,7 +350,7 @@ defmodule TuistWeb.API.ProjectsControllerTest do
       assert Enum.find_value(response["projects"], fn value ->
                value == %{
                  "id" => project_two.id,
-                 "full_name" => "tuist/#{project_two.name}",
+                 "full_name" => "#{user_account.name}/#{project_two.name}",
                  "default_branch" => project_two.default_branch,
                  "visibility" => Atom.to_string(project_two.visibility),
                  "build_system" => Atom.to_string(project_two.build_system),
@@ -364,21 +364,8 @@ defmodule TuistWeb.API.ProjectsControllerTest do
 
     test "lists all user projects when associated with a google hosted domain", %{conn: conn} do
       # Given
-      user =
-        Accounts.find_or_create_user_from_oauth2(%{
-          provider: :google,
-          uid: 123,
-          info: %{
-            email: "tuist@tuist.dev"
-          },
-          extra: %{
-            raw_info: %{
-              user: %{
-                "hd" => "tuist.io"
-              }
-            }
-          }
-        })
+      domain = unique_sso_domain()
+      user = Accounts.find_or_create_user_from_oauth2(google_oauth_identity(domain))
 
       conn = Authentication.put_current_user(conn, user)
 
@@ -388,7 +375,7 @@ defmodule TuistWeb.API.ProjectsControllerTest do
 
       Accounts.update_organization(organization, %{
         sso_provider: :google,
-        sso_organization_id: "tuist.io"
+        sso_organization_id: domain
       })
 
       organization_account = Accounts.get_account_from_organization(organization)
@@ -416,7 +403,7 @@ defmodule TuistWeb.API.ProjectsControllerTest do
       assert Enum.find_value(response["projects"], fn value ->
                value == %{
                  "id" => project_two.id,
-                 "full_name" => "tuist/#{project_two.name}",
+                 "full_name" => "#{user_account.name}/#{project_two.name}",
                  "default_branch" => project_two.default_branch,
                  "visibility" => Atom.to_string(project_two.visibility),
                  "build_system" => Atom.to_string(project_two.build_system),
@@ -597,7 +584,7 @@ defmodule TuistWeb.API.ProjectsControllerTest do
       response = json_response(conn, :not_found)
 
       assert response == %{
-               "message" => "Project tuist/non-existing-project not found."
+               "message" => "Project #{account.name}/non-existing-project not found."
              }
     end
 
@@ -696,9 +683,9 @@ defmodule TuistWeb.API.ProjectsControllerTest do
       user =
         Accounts.find_or_create_user_from_oauth2(%{
           provider: :github,
-          uid: 123,
+          uid: System.unique_integer([:positive]),
           info: %{
-            email: "tuist@tuist.dev"
+            email: AccountsFixtures.unique_user_email()
           }
         })
 
@@ -754,12 +741,12 @@ defmodule TuistWeb.API.ProjectsControllerTest do
       conn =
         conn
         |> put_req_header("content-type", "application/json")
-        |> put(~p"/api/projects/tuist/non-existing-project",
+        |> put(~p"/api/projects/#{user.account.name}/non-existing-project",
           default_branch: "new-default-branch"
         )
 
       response = json_response(conn, :not_found)
-      assert response["message"] == "Project tuist/non-existing-project was not found."
+      assert response["message"] == "Project #{user.account.name}/non-existing-project was not found."
     end
   end
 
@@ -819,5 +806,26 @@ defmodule TuistWeb.API.ProjectsControllerTest do
                "message" => "You don't have permission to delete the #{account.name}/#{project.name} project."
              }
     end
+  end
+
+  defp unique_sso_domain do
+    "tuist-#{TuistTestSupport.Utilities.unique_integer(6)}.io"
+  end
+
+  defp google_oauth_identity(domain) do
+    %{
+      provider: :google,
+      uid: System.unique_integer([:positive]),
+      info: %{
+        email: "tuist-#{TuistTestSupport.Utilities.unique_integer(6)}@#{domain}"
+      },
+      extra: %{
+        raw_info: %{
+          user: %{
+            "hd" => domain
+          }
+        }
+      }
+    }
   end
 end


### PR DESCRIPTION
## What changed

- Replaced shared SSO/OAuth fixture values in async Elixir tests with unique domains, emails, provider IDs, and OAuth UIDs.
- Updated affected Accounts, Projects, and API controller tests so assertions use generated account handles where needed.
- Enabled global ExUnit log capture for the server test suite so expected warning/error logs stay out of passing CI output.
- Added a test-only Logger primary filter for DBConnection sandbox teardown logs emitted by Postgrex/ClickHouse connection processes after sandbox clients exit.
- Kept targeted log cleanup for noisy xcresult, worker, Kura, docs, and GitHub releases tests.
- Downgraded the missing `xcresult_nif` message in test from warning to debug while keeping the dev warning behavior.

## Why

The Elixir test job was intermittently deadlocking in PostgreSQL while concurrent async tests inserted users and OAuth identities using the same globally unique values, especially `tuist@tuist.dev`, `uid: 123`, `tuist.io`, and shared Okta organization IDs. SQL sandbox rollback does not avoid unique-index coordination between overlapping transactions, so different tests could block each other and occasionally form a deadlock.

The logs were also noisy because many tests intentionally exercise retry, authorization failure, teardown, and worker-failure paths. Global `capture_log` keeps successful test output readable while still making captured logs available when a test fails.

After the first cleanup pass, CI still showed many red `DBConnection.ConnectionError` lines from `Ch.Connection` and `Postgrex.Protocol` processes. Those happen when a sandbox client exits and the owning connection logs the disconnect outside the individual test process capture. The new test-only Logger filter drops only that expected teardown shape: an error-level DBConnection disconnect whose message says the `client #PID` or `owner #PID` exited.

## Impact

This keeps the tests async while making the SSO/OAuth data isolated per test. CI output should be quieter and more useful: expected failure-path logs are captured, expected sandbox teardown disconnects no longer show as red annotations, and the test-only missing NIF warning no longer shows as a warning.

## Validation

- `env MIX_TEST_PARTITION=_codex_loaded2 TUIST_SKIP_DATA_MIGRATION=1 mix test test/tuist/accounts_test.exs test/tuist/projects_test.exs test/tuist_web/controllers/api/projects_controller_test.exs test/tuist_web/controllers/api/organizations_controller_test.exs test/tuist/runners/workers/webhook_redelivery_worker_test.exs test/tuist/kura/reconciler_test.exs test/tuist/processor/xcresult_processor_test.exs test/tuist/tests/workers/process_xcresult_worker_test.exs test/tuist/docs/cli_test.exs test/tuist/github/releases_test.exs`
  - 500 tests, 0 failures
- `env MIX_TEST_PARTITION=_codex_loaded2 TUIST_SKIP_DATA_MIGRATION=1 mix test --warnings-as-errors test/tuist/tests_test.exs test/tuist/builds_test.exs test/tuist/command_events_test.exs test/tuist/gradle_test.exs test/tuist/app_builds_test.exs`
  - 457 tests, 0 failures
- `env MIX_TEST_PARTITION=_codex_loaded2 TUIST_SKIP_DATA_MIGRATION=1 mix test --warnings-as-errors test/tuist_web/operator_grant_test.exs test/tuist_web/controllers/github_app_manifest_controller_test.exs test/tuist_web/controllers/runner_pods_controller_test.exs test/tuist_web/controllers/runners_controller_test.exs test/tuist_web/live/run_detail_live_test.exs test/tuist_web/live/build_run_live_test.exs test/tuist_web/live/test_run_live_test.exs test/tuist_web/plugs/github_webhook_logging_plug_test.exs test/tuist_web/unit/oauth/controllers/authorize_controller_test.exs test/tuist/clickhouse_retry_test.exs test/tuist/bundles_test.exs test/tuist/builds/workers/process_build_worker_test.exs test/tuist/webhooks/workers/delivery_worker_test.exs test/tuist/automations/action_executor_test.exs test/tuist/automations/workers/alert_evaluation_worker_test.exs test/tuist/automations_test.exs test/tuist/automations/actions/send_slack_action_test.exs test/tuist/slack/workers/report_worker_test.exs test/tuist/runners/dispatch_test.exs test/tuist/runners/workers/orphaned_runners_worker_test.exs test/tuist/runners/workers/fetch_logs_worker_test.exs test/tuist/runners/workers/prune_archived_logs_worker_test.exs test/tuist/runners/workers/orphaned_stamped_pods_worker_test.exs test/tuist/runners/workers/webhook_redelivery_worker_test.exs test/tuist/processor/xcresult_processor_test.exs`
  - 342 tests, 0 failures
- `git diff --check`

`TUIST_SKIP_DATA_MIGRATION=1` was needed locally because replaying a historical ClickHouse xcode_graph data migration on a custom test partition tries to connect to a derived Postgres database name that does not exist in that local verification setup.
