### PR TITLE
feat(infra): support external PostgreSQL existing secrets

### DIFF
--- a/infra/helm/tuist/README.md
+++ b/infra/helm/tuist/README.md
@@ -13,6 +13,26 @@ Noora Storybook ships from the standalone `infra/helm/noora-storybook/` chart so
 
 Each dependency defaults to `embedded` (deployed within the chart). To use an external provider instead, set its `mode` to `external` and configure the connection details under the corresponding section in `values.yaml`.
 
+External PostgreSQL with an existing Secret:
+
+```yaml
+postgresql:
+  mode: external
+  external:
+    port: 5432
+    database: tuist
+    existingSecret: tuist-postgresql
+    existingSecretKeys:
+      host: host
+      username: username
+      password: password
+```
+
+The chart reads `host`, `username`, and `password` from the named Secret and
+builds `DATABASE_URL` through Kubernetes env-var substitution, so the password
+does not appear in the rendered manifest. The Secret value for `password`
+should be URL-safe because it is interpolated into a database URL.
+
 ## Local validation
 
 Render manifests:

--- a/infra/helm/tuist/templates/_helpers.tpl
+++ b/infra/helm/tuist/templates/_helpers.tpl
@@ -239,11 +239,49 @@ carries `username`, `password`, `uri`, `jdbc-uri`, `host`, `port`,
 {{- printf "%s-pooler-rw" (include "tuist.cnpgClusterName" .) -}}
 {{- end -}}
 
+{{- define "tuist.externalPostgresqlHostEnv" -}}
+TUIST_POSTGRESQL_HOST
+{{- end -}}
+
+{{- define "tuist.externalPostgresqlUsernameEnv" -}}
+TUIST_POSTGRESQL_USERNAME
+{{- end -}}
+
+{{- define "tuist.externalPostgresqlPasswordEnv" -}}
+TUIST_POSTGRESQL_PASSWORD
+{{- end -}}
+
+{{- define "tuist.externalPostgresqlSecretEnv" -}}
+{{- if and (eq .Values.postgresql.mode "external") .Values.postgresql.external.existingSecret -}}
+{{- $secretName := .Values.postgresql.external.existingSecret -}}
+{{- $keys := .Values.postgresql.external.existingSecretKeys | default dict -}}
+- name: {{ include "tuist.externalPostgresqlHostEnv" . }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ $secretName | quote }}
+      key: {{ required "postgresql.external.existingSecretKeys.host is required when postgresql.external.existingSecret is set" $keys.host | quote }}
+- name: {{ include "tuist.externalPostgresqlUsernameEnv" . }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ $secretName | quote }}
+      key: {{ required "postgresql.external.existingSecretKeys.username is required when postgresql.external.existingSecret is set" $keys.username | quote }}
+- name: {{ include "tuist.externalPostgresqlPasswordEnv" . }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ $secretName | quote }}
+      key: {{ required "postgresql.external.existingSecretKeys.password is required when postgresql.external.existingSecret is set" $keys.password | quote }}
+{{- end -}}
+{{- end -}}
+
 {{- define "tuist.databaseUrl" -}}
 {{- if eq .Values.postgresql.mode "embedded" -}}
 ecto://{{ .Values.postgresql.embedded.username }}:{{ .Values.postgresql.embedded.password }}@{{ include "tuist.componentName" (dict "root" . "component" "postgresql") }}:5432/{{ .Values.postgresql.embedded.database }}
 {{- else if eq .Values.postgresql.mode "external" -}}
+{{- if .Values.postgresql.external.existingSecret -}}
+ecto://$({{ include "tuist.externalPostgresqlUsernameEnv" . }}):$({{ include "tuist.externalPostgresqlPasswordEnv" . }})@$({{ include "tuist.externalPostgresqlHostEnv" . }}):{{ .Values.postgresql.external.port }}/{{ .Values.postgresql.external.database }}
+{{- else -}}
 ecto://{{ .Values.postgresql.external.username }}:{{ .Values.postgresql.external.password }}@{{ .Values.postgresql.external.host }}:{{ .Values.postgresql.external.port }}/{{ .Values.postgresql.external.database }}
+{{- end -}}
 {{- else if eq .Values.postgresql.mode "cnpg" -}}
 {{- fail "tuist.databaseUrl is not literal under postgresql.mode=cnpg — wire DATABASE_URL from the CNPG-generated Secret via envFrom or secretKeyRef instead." -}}
 {{- end -}}
@@ -254,8 +292,12 @@ ecto://{{ .Values.postgresql.external.username }}:{{ .Values.postgresql.external
 {{ include "tuist.componentName" (dict "root" . "component" "postgresql") }}
 {{- else if eq .Values.postgresql.mode "cnpg" -}}
 {{ include "tuist.cnpgServiceRW" . }}
+{{- else if eq .Values.postgresql.mode "external" -}}
+{{- if .Values.postgresql.external.existingSecret -}}
+$({{ include "tuist.externalPostgresqlHostEnv" . }})
 {{- else -}}
 {{- .Values.postgresql.external.host -}}
+{{- end -}}
 {{- end -}}
 {{- end -}}
 
@@ -284,8 +326,12 @@ ecto://{{ .Values.postgresql.external.username }}:{{ .Values.postgresql.external
 {{- .Values.postgresql.embedded.username -}}
 {{- else if eq .Values.postgresql.mode "cnpg" -}}
 {{- .Values.postgresql.cnpg.owner -}}
+{{- else if eq .Values.postgresql.mode "external" -}}
+{{- if .Values.postgresql.external.existingSecret -}}
+$({{ include "tuist.externalPostgresqlUsernameEnv" . }})
 {{- else -}}
 {{- .Values.postgresql.external.username -}}
+{{- end -}}
 {{- end -}}
 {{- end -}}
 

--- a/infra/helm/tuist/templates/app-secrets.yaml
+++ b/infra/helm/tuist/templates/app-secrets.yaml
@@ -24,7 +24,9 @@ stringData:
   server-secret-key-base: {{ .Values.server.secretKeyBase | default (get $existingData "server-secret-key-base" | default "" | b64dec) | default (randAlphaNum 64) | quote }}
   cache-secret-key-base: {{ .Values.cache.secretKeyBase | default (get $existingData "cache-secret-key-base" | default "" | b64dec) | default (randAlphaNum 64) | quote }}
   cache-guardian-secret-key: {{ .Values.cache.guardianSecretKey | default (get $existingData "cache-guardian-secret-key" | default "" | b64dec) | default (randAlphaNum 64) | quote }}
+  {{- if not (and (eq .Values.postgresql.mode "external") .Values.postgresql.external.existingSecret) }}
   postgres-password: {{ ternary .Values.postgresql.embedded.password .Values.postgresql.external.password (eq .Values.postgresql.mode "embedded") | quote }}
+  {{- end }}
   object-storage-access-key: {{ include "tuist.objectStorageAccessKey" . | quote }}
   object-storage-secret-key: {{ include "tuist.objectStorageSecretKey" . | quote }}
   {{- if .Values.server.license.key }}

--- a/infra/helm/tuist/templates/server-deployment.yaml
+++ b/infra/helm/tuist/templates/server-deployment.yaml
@@ -95,6 +95,7 @@ spec:
             {{- end }}
             {{- if not .Values.server.managedSecrets }}
             {{- if ne .Values.postgresql.mode "cnpg" }}
+            {{- include "tuist.externalPostgresqlSecretEnv" . | nindent 12 }}
             - name: DATABASE_URL
               value: {{ include "tuist.databaseUrl" . | quote }}
             - name: TUIST_USE_SSL_FOR_DATABASE

--- a/infra/helm/tuist/templates/server-migration-job.yaml
+++ b/infra/helm/tuist/templates/server-migration-job.yaml
@@ -88,6 +88,7 @@ spec:
                 sleep 2
               done
           env:
+            {{- include "tuist.externalPostgresqlSecretEnv" . | nindent 12 }}
             - name: PGHOST
               value: {{ include "tuist.databaseHost" . | quote }}
             - name: PGPORT
@@ -119,6 +120,7 @@ spec:
             {{- end }}
             {{- if not .Values.server.managedSecrets }}
             {{- if ne .Values.postgresql.mode "cnpg" }}
+            {{- include "tuist.externalPostgresqlSecretEnv" . | nindent 12 }}
             - name: DATABASE_URL
               value: {{ include "tuist.databaseUrl" . | quote }}
             - name: TUIST_USE_SSL_FOR_DATABASE

--- a/infra/helm/tuist/values.yaml
+++ b/infra/helm/tuist/values.yaml
@@ -1436,6 +1436,17 @@ postgresql:
     database: tuist
     username: tuist
     password: tuist
+    # Name of an existing Kubernetes Secret containing the external
+    # Postgres connection values. When set, server and migration pods
+    # read host, username, and password from this Secret and compose
+    # DATABASE_URL through Kubernetes env-var substitution so the password
+    # is not rendered into the Helm manifest. `port` and `database` remain
+    # chart values. Leave empty to keep the legacy literal DATABASE_URL path.
+    existingSecret: ""
+    existingSecretKeys:
+      host: host
+      username: username
+      password: password
   embedded:
     image:
       repository: postgres
@@ -1771,4 +1782,3 @@ observability:
       accessModes:
         - ReadWriteOnce
       size: 20Gi
-

--- a/server/priv/docs/en/guides/server/self-host/server.md
+++ b/server/priv/docs/en/guides/server/self-host/server.md
@@ -418,6 +418,28 @@ postgresql:
     password: your-password
 ```
 
+If you manage the PostgreSQL credentials outside Helm, point the chart at an
+existing Kubernetes Secret instead:
+
+```yaml
+# values.yaml
+postgresql:
+  mode: external
+  external:
+    port: 5432
+    database: tuist
+    existingSecret: tuist-postgresql
+    existingSecretKeys:
+      host: host
+      username: username
+      password: password
+```
+
+The chart reads the host, username, and password from the Secret and composes
+`DATABASE_URL` through Kubernetes env-var substitution, so the password is not
+rendered into the Helm manifest. The Secret's password value should be URL-safe
+because it is interpolated into a database URL.
+
 The same pattern applies to `clickhouse` and `objectStorage`. See the `external` block under each section in the chart's `values.yaml` for the full set of configurable fields.
 
 ### Shared scheduling and labels {#helm-shared-scheduling-and-labels}


### PR DESCRIPTION
Resolves no tracked issue.

> Allows self-hosted operators to use an externally managed PostgreSQL Secret without rendering the password into Helm manifests.

The Helm chart now exposes `postgresql.external.existingSecret` and `postgresql.external.existingSecretKeys` for external PostgreSQL deployments. When configured, the server and migration pods read the host, username, and password through `secretKeyRef` entries and compose `DATABASE_URL` through Kubernetes env-var substitution, so the database password is not materialized in the rendered manifest.

The migration job uses the same secret-backed values for its `pg_isready` wait step, and the chart-owned `app-secrets` Secret skips the legacy `postgres-password` entry for this path. The chart README and English self-hosting guide document the new configuration shape.

### How to test locally

- `helm lint infra/helm/tuist -f infra/helm/tuist/values-ci.yaml`
- `helm template tuist infra/helm/tuist -f infra/helm/tuist/values-ci.yaml`
- `helm template tuist infra/helm/tuist -f infra/helm/tuist/values-ci.yaml --set postgresql.mode=external --set postgresql.external.host=rendered-host-should-not-appear --set postgresql.external.username=rendered-user-should-not-appear --set postgresql.external.password=rendered-password-should-not-appear --set postgresql.external.existingSecret=tuist-postgresql --set postgresql.external.existingSecretKeys.host=hostname --set postgresql.external.existingSecretKeys.username=user --set postgresql.external.existingSecretKeys.password=pass`
- `helm template tuist infra/helm/tuist -f infra/helm/tuist/values-managed-common.yaml -f infra/helm/tuist/values-managed-production.yaml -f infra/helm/tuist/values-ci.yaml`
- `helm template tuist infra/helm/tuist -f infra/helm/tuist/values-managed-common.yaml -f infra/helm/tuist/values-managed-staging.yaml -f infra/helm/tuist/values-ci.yaml`
- `helm template tuist infra/helm/tuist -f infra/helm/tuist/values-managed-common.yaml -f infra/helm/tuist/values-managed-canary.yaml -f infra/helm/tuist/values-ci.yaml`
- `git diff --check`
