### PR TITLE
fix(cli): propagate trait-conditional build settings from SPM manifests

### DIFF
--- a/cli/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
+++ b/cli/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
@@ -1558,7 +1558,8 @@ extension ProjectDescription.Settings {
         let mapper = SettingsMapper(
             headerSearchPaths: dependencyHeaderSearchPaths,
             mainRelativePath: mainRelativePath,
-            settings: settings
+            settings: settings,
+            enabledTraits: enabledTraits
         )
 
         var settingsDictionary: XcodeGraph.SettingsDictionary = [
@@ -1601,7 +1602,19 @@ extension ProjectDescription.Settings {
         ]
 
         let resolvedSettings = try mapper.mapSettings()
-        settingsDictionary.merge(resolvedSettings) { $1 }
+        settingsDictionary.merge(resolvedSettings) { current, new in
+            // Trait names and trait-conditional swift defines both end up in
+            // SWIFT_ACTIVE_COMPILATION_CONDITIONS — union them so neither side is lost.
+            if case let .array(currentArray) = current, case let .array(newArray) = new {
+                var seen = Set<String>()
+                var merged: [String] = []
+                for value in currentArray + newArray where seen.insert(value).inserted {
+                    merged.append(value)
+                }
+                return .array(merged)
+            }
+            return new
+        }
 
         if moduleName != productName {
             settingsDictionary["PRODUCT_MODULE_NAME"] = .string(moduleName)

--- a/cli/Sources/TuistLoader/SwiftPackageManager/SettingsMapper.swift
+++ b/cli/Sources/TuistLoader/SwiftPackageManager/SettingsMapper.swift
@@ -8,16 +8,19 @@ struct SettingsMapper {
     init(
         headerSearchPaths: [String],
         mainRelativePath: RelativePath,
-        settings: [PackageInfo.Target.TargetBuildSettingDescription.Setting]
+        settings: [PackageInfo.Target.TargetBuildSettingDescription.Setting],
+        enabledTraits: Set<String> = []
     ) {
         self.headerSearchPaths = headerSearchPaths
         self.settings = settings
         self.mainRelativePath = mainRelativePath
+        self.enabledTraits = enabledTraits
     }
 
     private let headerSearchPaths: [String]
     private let mainRelativePath: RelativePath
     private let settings: [PackageInfo.Target.TargetBuildSettingDescription.Setting]
+    private let enabledTraits: Set<String>
 
     func mapSettings() throws -> XcodeGraph.SettingsDictionary {
         var resolvedSettings = try settingsDictionary()
@@ -193,24 +196,45 @@ struct SettingsMapper {
         return settingsDictionary
     }
 
-    /// `nil` means settings without a condition.
+    /// `nil` means settings without a platform restriction.
+    ///
+    /// A setting is included when both its platform and trait conditions are
+    /// satisfied by the current context. A `.when(traits:)` setting whose trait
+    /// intersects `enabledTraits` is treated as unconditional w.r.t. traits,
+    /// mirroring SwiftPM's own evaluation of trait-conditional build settings
+    /// (SE-0450).
     private func settings(for platformName: String?) throws
         -> [PackageInfo.Target.TargetBuildSettingDescription.Setting]
     {
         settings.filter { setting in
-            if let platformName, setting.hasConditions {
-                let hasMacCatalystPlatform = setting.condition?.platformNames.contains("maccatalyst") == true
-                let platformNames: [String]
-                if hasMacCatalystPlatform {
-                    platformNames = (setting.condition?.platformNames ?? []) + ["ios"]
-                } else {
-                    platformNames = setting.condition?.platformNames ?? []
-                }
-                return platformNames.contains(platformName)
+            // Config-conditional settings are handled by `settingsForBuildConfiguration`.
+            if setting.condition?.config != nil { return false }
+            guard traitConditionMatches(setting.condition) else { return false }
+
+            let platformNames = expandedPlatformNames(in: setting.condition)
+            let hasPlatformRestriction = !platformNames.isEmpty
+
+            if let platformName {
+                return !hasPlatformRestriction || platformNames.contains(platformName)
             } else {
-                return !setting.hasConditions
+                return !hasPlatformRestriction
             }
         }
+    }
+
+    private func traitConditionMatches(_ condition: PackageInfo.PackageConditionDescription?) -> Bool {
+        guard let traits = condition?.traits, !traits.isEmpty else { return true }
+        return !enabledTraits.isDisjoint(with: traits)
+    }
+
+    private func expandedPlatformNames(
+        in condition: PackageInfo.PackageConditionDescription?
+    ) -> [String] {
+        let platformNames = condition?.platformNames ?? []
+        if platformNames.contains("maccatalyst") {
+            return platformNames + ["ios"]
+        }
+        return platformNames
     }
 }
 

--- a/cli/Tests/TuistLoaderTests/SwiftPackageManager/SettingsMapperTests.swift
+++ b/cli/Tests/TuistLoaderTests/SwiftPackageManager/SettingsMapperTests.swift
@@ -527,6 +527,108 @@ final class SettingsMapperTests: XCTestCase {
             ])
         )
     }
+
+    func test_trait_define_included_when_trait_enabled() throws {
+        let settings: [PackageInfo.Target.TargetBuildSettingDescription.Setting] = [
+            .init(
+                tool: .swift,
+                name: .define,
+                condition: PackageInfo.PackageConditionDescription(
+                    platformNames: [],
+                    config: nil,
+                    traits: ["EnableFoo"]
+                ),
+                value: ["FOO_DEFINE"]
+            ),
+        ]
+
+        let mapper = SettingsMapper(
+            headerSearchPaths: [],
+            mainRelativePath: try RelativePath(validating: "path"),
+            settings: settings,
+            enabledTraits: ["EnableFoo"]
+        )
+
+        let allPlatformSettings = try mapper.settingsDictionary()
+
+        XCTAssertEqual(
+            allPlatformSettings["SWIFT_ACTIVE_COMPILATION_CONDITIONS"],
+            .array(["$(inherited)", "FOO_DEFINE"])
+        )
+
+        let iosPlatformSettings = try mapper.settingsDictionary(for: .iOS)
+
+        XCTAssertEqual(
+            iosPlatformSettings["SWIFT_ACTIVE_COMPILATION_CONDITIONS"],
+            .array(["$(inherited)", "FOO_DEFINE"])
+        )
+    }
+
+    func test_trait_define_dropped_when_trait_disabled() throws {
+        let settings: [PackageInfo.Target.TargetBuildSettingDescription.Setting] = [
+            .init(
+                tool: .swift,
+                name: .define,
+                condition: PackageInfo.PackageConditionDescription(
+                    platformNames: [],
+                    config: nil,
+                    traits: ["EnableFoo"]
+                ),
+                value: ["FOO_DEFINE"]
+            ),
+        ]
+
+        let mapper = SettingsMapper(
+            headerSearchPaths: [],
+            mainRelativePath: try RelativePath(validating: "path"),
+            settings: settings,
+            enabledTraits: []
+        )
+
+        let allPlatformSettings = try mapper.settingsDictionary()
+        let iosPlatformSettings = try mapper.settingsDictionary(for: .iOS)
+
+        XCTAssertNil(allPlatformSettings["SWIFT_ACTIVE_COMPILATION_CONDITIONS"])
+        XCTAssertNil(iosPlatformSettings["SWIFT_ACTIVE_COMPILATION_CONDITIONS"])
+    }
+
+    func test_trait_define_with_platform_intersection() throws {
+        let settings: [PackageInfo.Target.TargetBuildSettingDescription.Setting] = [
+            .init(
+                tool: .swift,
+                name: .define,
+                condition: PackageInfo.PackageConditionDescription(
+                    platformNames: ["ios"],
+                    config: nil,
+                    traits: ["EnableFoo"]
+                ),
+                value: ["FOO_IOS"]
+            ),
+        ]
+
+        let mapper = SettingsMapper(
+            headerSearchPaths: [],
+            mainRelativePath: try RelativePath(validating: "path"),
+            settings: settings,
+            enabledTraits: ["EnableFoo"]
+        )
+
+        XCTAssertNil(try mapper.settingsDictionary()["SWIFT_ACTIVE_COMPILATION_CONDITIONS"])
+        XCTAssertEqual(
+            try mapper.settingsDictionary(for: .iOS)["SWIFT_ACTIVE_COMPILATION_CONDITIONS"],
+            .array(["$(inherited)", "FOO_IOS"])
+        )
+        XCTAssertNil(try mapper.settingsDictionary(for: .tvOS)["SWIFT_ACTIVE_COMPILATION_CONDITIONS"])
+
+        let traitOff = SettingsMapper(
+            headerSearchPaths: [],
+            mainRelativePath: try RelativePath(validating: "path"),
+            settings: settings,
+            enabledTraits: []
+        )
+
+        XCTAssertNil(try traitOff.settingsDictionary(for: .iOS)["SWIFT_ACTIVE_COMPILATION_CONDITIONS"])
+    }
 }
 
 // OTHER_LDFLAGS


### PR DESCRIPTION
Reproducer: <https://github.com/NAD777/tuist-traits-define-repro>

> Resolves trait-conditional `swiftSettings` defines from SPM manifests being silently dropped when Tuist generates the Xcode project.

## What changed

- Thread the consumer's `enabledTraits` set through to `SettingsMapper`.
- Rewrite the platform filter in `SettingsMapper.settings(for:)` so platform, trait and config conditions all participate in the include/exclude decision, in line with SwiftPM's SE-0450 semantics.
- In `PackageInfoMapper.Settings.from(...)`, change the merge between the trait-name code path and `SettingsMapper.mapSettings()` output from `{ $1 }` to an array union so trait names and trait-conditional swift defines coexist in `SWIFT_ACTIVE_COMPILATION_CONDITIONS`.
- Add focused `SettingsMapperTests` coverage for trait-on, trait-off, and trait + platform combinations.

## Problem

When a Swift package maps a trait to a Swift compile-time define via `swiftSettings`:

```swift
traits: [
    .default(enabledTraits: []),
    .trait(name: "EnableFoo"),
],
targets: [
    .target(
        name: "MyKit",
        swiftSettings: [
            .define("FOO_DEFINE", .when(traits: ["EnableFoo"])),
        ]
    ),
]
```

and a consumer's `Tuist/Package.swift` enables that trait:

```swift
.package(path: "../LocalPackages/MyKit", traits: ["EnableFoo"])
```

`tuist generate` produces a `MyKit.xcodeproj` whose `MyKit` target build settings contain `EnableFoo` (the trait name) in `SWIFT_ACTIVE_COMPILATION_CONDITIONS`, but **no** `FOO_DEFINE` anywhere — not in `SWIFT_ACTIVE_COMPILATION_CONDITIONS`, not in `GCC_PREPROCESSOR_DEFINITIONS`, not in `OTHER_SWIFT_FLAGS`. Code under `#if FOO_DEFINE` is excluded from compilation; consumers referencing the gated symbols fail to build with `cannot find ... in scope`.

Plain SwiftPM (`swift build`) on the same package + same trait set propagates `FOO_DEFINE` correctly, so the divergence is Tuist-specific.

A self-contained repro that exhibits both paths (broken Tuist generation + working SwiftPM control consumer) is in <https://github.com/NAD777/tuist-traits-define-repro>.

## Root cause

`cli/Sources/TuistLoader/SwiftPackageManager/SettingsMapper.swift` has two coordinated issues:

1. `SettingsMapper.init` did not take `enabledTraits` — it had no way to evaluate `.when(traits:)` conditions in principle.
2. `settings(for platformName:)` filtered only by platform:

   ```swift
   if let platformName, setting.hasConditions {
       // ... compare platformNames ...
   } else {
       return !setting.hasConditions
   }
   ```

   A trait-only `.define("FOO_DEFINE", .when(traits: ["EnableFoo"]))` has `setting.hasConditions == true` and an empty `platformNames`. In the no-platform pass it falls into the `else` branch and is dropped because `!true`. In every per-platform pass the `platformNames.contains(...)` check is `false` and it is dropped too. So the setting never reaches `map(...)`.

The trait NAMES that do reach `SWIFT_ACTIVE_COMPILATION_CONDITIONS` are added by a separate block in `PackageInfoMapper.Settings.from(...)` that writes the active trait set directly, bypassing `SettingsMapper` entirely. That kept `#if EnableFoo` working and made the bug easy to miss for packages that use the trait name directly, and easy to hit for packages that map trait names to `*_DEFINE` macros via `swiftSettings`.

## Fix

- Add `enabledTraits: Set<String> = []` to `SettingsMapper.init`. The default keeps existing call sites and tests source-compatible.
- Rewrite `SettingsMapper.settings(for platformName:)` so each setting is included iff:
  - it is not config-conditional (config-conditional settings remain routed through `settingsForBuildConfiguration`),
  - its trait condition (if any) intersects `enabledTraits`, and
  - its platform condition (if any) matches the current pass.
- Pass `enabledTraits` into `SettingsMapper` from `PackageInfoMapper.Settings.from(...)`.
- Change the merge between `settingsDictionary` (which already holds the trait names injected by the trait-name code path) and `mapper.mapSettings()` from `{ $1 }` to an array union. Conflicting `SettingValue.array` values are concatenated and deduped so trait names and trait-conditional defines coexist; non-array conflicts keep the previous "new wins" behaviour. The union pattern matches the existing one at lines 1693–1700 of the same file.

## Regression coverage

Three new `SettingsMapperTests` cases:

- `test_trait_define_included_when_trait_enabled` — `.define("FOO_DEFINE", .when(traits: ["EnableFoo"]))` with `enabledTraits: ["EnableFoo"]` produces `SWIFT_ACTIVE_COMPILATION_CONDITIONS = ["$(inherited)", "FOO_DEFINE"]` in both the all-platform and the per-platform passes.
- `test_trait_define_dropped_when_trait_disabled` — the same setting with `enabledTraits: []` produces no `SWIFT_ACTIVE_COMPILATION_CONDITIONS` entry.
- `test_trait_define_with_platform_intersection` — `.when(platforms: [.iOS], traits: ["EnableFoo"])` requires both conditions; toggling either one in or out flips the result.

`PackageInfoMapperTests/map_whenSettingsDefinesContainsQuotes` doubles as regression coverage: it caught a mid-iteration of the fix when config-conditional settings were briefly allowed into the no-platform pass, and was used to drive the final form of `settings(for:)`.

## Validation

- `xcodebuild build -workspace Tuist.xcworkspace -scheme tuist` succeeded.
- `TuistLoaderTests/SettingsMapperTests`: **24/24 passing** (21 existing + 3 new).
- `TuistLoaderTests/PackageInfoMapperTests`: **137/137 passing**.
- End-to-end against the reproducer (<https://github.com/NAD777/tuist-traits-define-repro>):
  - Stock `tuist 4.200.5`: `xcodebuild` for the iOS app fails with `cannot find 'FooFeature' in scope`; `grep -c FOO_DEFINE LocalPackages/MyKit/MyKit.xcodeproj/project.pbxproj` → `0`.
  - Patched binary built from this branch: generation produces `SWIFT_ACTIVE_COMPILATION_CONDITIONS` containing both `EnableFoo` and `FOO_DEFINE`; the iOS app target builds; the gated `FooFeature` type is reachable from the consumer.
- Plain SwiftPM control consumer in the same reproducer (`ControlSPMConsumer/`) used as ground truth: `swift run ControlConsumer` prints `FOO_DEFINE seen by MyKit: true` and `Foo feature exists: Foo-gated-by-FOO_DEFINE`, confirming the bug is Tuist-specific and that this fix aligns Tuist's behaviour with SwiftPM.

## Local validation notes

- Reproduced and verified on Tuist `4.142.0` and `4.200.5`, Swift 6.2.4 / Xcode 26.3, macOS 15 (Darwin 24.6.0, arm64).
- `swift-tools-version: 6.1` is used in both consumer and dependency `Package.swift` files — the bug is independent of toolchain version because the same manifest works under `swift build`.
- During iteration, `tuist install` occasionally re-resolved transitive SPM dependencies (e.g. `swift-foundation`) to versions whose newer products were not known to the locally installed `4.200.5` binary, producing an unrelated `BasicContainers is not a valid configured external dependency` error. Restoring `Package.resolved` and re-running `tuist install` cleared this and is unrelated to the changes in this PR.