### PR TITLE
feat(infra): ship the kura cache StorageClass with the chart

### DIFF
--- a/infra/cluster-api-provider-scaleway-applesilicon/docs/scaleway-elastic-metal-support.md
+++ b/infra/cluster-api-provider-scaleway-applesilicon/docs/scaleway-elastic-metal-support.md
@@ -180,19 +180,20 @@ cache to it needs three gates flipped together in that env's values (see
    `TUIST_RUNNERS_CLUSTER_NETWORK_PLATFORMS=linux,macos`;
 3. attach the minis to the PN: `macosFleet.vmCachePrivateNetwork.{name,cidr}`.
 
-Two prerequisites are not in the deploy pipeline and must exist per cluster, or
+One prerequisite is not in the deploy pipeline and must exist per env, or
 dispatch returns no endpoint and builds fall back to the public cache (the
-cutover degrades rather than breaks while they are missing):
+cutover degrades rather than breaks while it is missing):
 
-- **`scw-local-nvme` StorageClass** (local-path provisioner on the EM node's
-  NVMe). Apply once per cluster after the EM node joins:
-  `kubectl apply -f infra/k8s/mgmt/bootstrap/local-path-provisioner.yaml`.
-  Without it the per-account cache PVCs hang `Pending` and no KuraInstance goes
-  active.
 - **A Private Network named `tuist-runner-cache`** in the env's Scaleway
   project. The operator find-or-creates it from `172.16.0.0/22`, but rename the
   env's existing runner-cache PN to that name so the EM node and the minis share
   the one you already set up rather than landing on a fresh one.
+
+The `scw-local-nvme` StorageClass the cache PVCs bind against now ships with the
+chart (`templates/kura-fleet-storage.yaml`, gated on the same `kuraFleet.enabled`
+flag), so it no longer has to be applied by hand. The provider IAM key also needs
+`ElasticMetalFullAccess` (see the IAM note above), without which the EM order
+403s.
 
 ## Out of scope
 

--- a/infra/helm/tuist/templates/kura-fleet-storage.yaml
+++ b/infra/helm/tuist/templates/kura-fleet-storage.yaml
@@ -1,28 +1,24 @@
-# local-path-provisioner — serves per-account cache PVCs from local NVMe on
-# the `kura-scw-fr-par` Elastic Metal node(s).
-#
-# Why not scaleway-csi here: Elastic Metal bare-metal servers can't attach
-# scw-bssd block volumes (that's an Instance-only feature), so the cache PVCs
-# have to live on the node's local NVMe. Each PVC becomes a hostPath-backed PV
-# under /opt/local-path-provisioner on the node — per-account isolation by
-# directory, capacity bounded by the box's NVMe (EM-I220E = 1.92TB).
-#
-# The StorageClass name `scw-local-nvme` is load-bearing: the server's
-# `scw-fr-par-runners` kura region spec will provision PVCs with this class
-# (server/lib/tuist/kura/regions.ex, storage_class). That server-side switch
-# from `scw-bssd` to `scw-local-nvme` is handled separately — see the kura
-# region spec change in the parallel server work.
-#
-# Applied out-of-band on the workload cluster the same way as
-# scaleway-csi-values.yaml (the macOS-runner-cache bootstrap), pinned to the
-# Rancher local-path-provisioner v0.0.31 manifest with the storage path,
-# nodeSelector, taint toleration, and StorageClass adapted for this pool.
-#
-#   kubectl --kubeconfig ~/.kube/tuist-<env>.yaml apply -f \
-#     infra/k8s/mgmt/bootstrap/local-path-provisioner.yaml
-#
-# Re-apply after any pinned-version bump.
----
+{{- if and .Values.capi.enabled .Values.kuraFleet.enabled }}
+{{- /*
+local-path-provisioner for the kura runner-cache Elastic Metal pool. Elastic
+Metal can't attach scw-bssd block volumes, so per-account cache PVCs live on the
+node's local NVMe: each becomes a hostPath-backed PV under
+/opt/local-path-provisioner. The StorageClass name `scw-local-nvme` is
+load-bearing — the `scw-fr-par-runners` kura region spec provisions PVCs with
+exactly this class (server/lib/tuist/kura/regions.ex, storage_class).
+
+This used to be a manual per-cluster bootstrap (infra/k8s/mgmt/bootstrap/), which
+meant a cluster could enable the kura fleet but silently lack the StorageClass
+its cache PVCs need (the pod hangs Pending). It now ships with the chart, gated
+on the same kuraFleet.enabled flag as the fleet itself, so the two can't drift.
+
+The provisioner controller is deliberately NOT pinned to the EM pool (unlike the
+old bootstrap manifest): it only watches PVCs and launches a short-lived helper
+Pod on the *target* node to set up/tear down each PV directory, so it can run on
+any node. Pinning it to the cache pool would make the release `--wait` block on
+it whenever the EM node isn't up yet. The helper Pod (configured below) still
+tolerates the runner-cache taint so it lands on the cache node.
+*/ -}}
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -88,13 +84,9 @@ spec:
         app: local-path-provisioner
     spec:
       serviceAccountName: local-path-provisioner-service-account
-      # The provisioner only manages PVs for the kura Elastic Metal pool, so
-      # pin it there. It runs a helper Pod per provision/delete on the target
-      # node (the node where the consuming pod is scheduled), so it must
-      # tolerate the runner-cache taint to land its helper Pods on the cache
-      # node alongside the cache pods.
-      nodeSelector:
-        node.cluster.x-k8s.io/pool: kura-scw-fr-par
+      # Tolerate the runner-cache taint so the controller is free to land on
+      # the cache node if the scheduler picks it, but it is not pinned there —
+      # it runs its helper Pods on the target node regardless of where it sits.
       tolerations:
         - key: tuist.dev/runner-cache
           operator: Exists
@@ -132,8 +124,7 @@ spec:
 # (the kura pod's nodeSelector + toleration already pin it to this pool).
 # reclaimPolicy: Delete — cache volumes are disposable; the kura RunnerCache
 # reconciler tears instances down when accounts lose runner profiles, and a
-# retained orphan dir wastes NVMe until hand-deleted. Mirrors the scw-bssd
-# class the Instance path used.
+# retained orphan dir wastes NVMe until hand-deleted.
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
@@ -154,7 +145,7 @@ data:
   # Single path on the Elastic Metal NVMe root filesystem. The provisioner
   # creates one sub-directory per PV here. nodePathMap with a single
   # DEFAULT_PATH_FOR_NON_LISTED_NODES entry applies to every node the
-  # provisioner runs on (gated to this pool by the Deployment nodeSelector).
+  # provisioner runs on (gated to this pool by the helper Pod's placement).
   config.json: |-
     {
       "nodePathMap": [
@@ -179,7 +170,7 @@ data:
       name: helper-pod
     spec:
       # The helper Pod runs on the target cache node to create/remove the PV
-      # directory, so it has to tolerate the runner-cache taint too.
+      # directory, so it has to tolerate the runner-cache taint.
       tolerations:
         - key: tuist.dev/runner-cache
           operator: Exists
@@ -188,3 +179,4 @@ data:
         - name: helper-pod
           image: busybox
           imagePullPolicy: IfNotPresent
+{{- end }}

--- a/infra/k8s/mgmt/bootstrap/scaleway-csi-values.yaml
+++ b/infra/k8s/mgmt/bootstrap/scaleway-csi-values.yaml
@@ -12,7 +12,7 @@
 # Only needed while the `kura-scw-fr-par` pool runs Scaleway Instances. The
 # managed envs moved this pool to Elastic Metal (bare metal can't attach
 # scw-bssd), where the cache PVCs come from local NVMe via the
-# local-path-provisioner (local-path-provisioner.yaml, StorageClass
+# local-path-provisioner (chart `templates/kura-fleet-storage.yaml`, StorageClass
 # `scw-local-nvme`) instead. Keep this installed only on clusters whose
 # kuraFleet still uses `machine.kind: instance`.
 storageClasses:


### PR DESCRIPTION
> Draft — opening for review of the approach before merge.

## Problem

The `scw-local-nvme` StorageClass + local-path-provisioner that the kura runner-cache PVCs bind against was a **manual, per-workload-cluster bootstrap** (`infra/k8s/mgmt/bootstrap/local-path-provisioner.yaml`) with zero automation:

- `mgmt-cluster-apply.yml` doesn't apply it — that workflow targets the **management** cluster and only applies a fixed allowlist (`infra/k8s/clusters/**` + four specific mgmt files); `infra/k8s/mgmt/bootstrap/**` is excluded.
- No other workflow applies it. The file's header literally says "apply with `kubectl apply -f …`".

So a cluster could enable the kura fleet but silently lack the StorageClass its cache PVCs need. That's exactly what happened on **production** during the macOS-runner-cache cutover: the EM node joined and the `kura-tuist-scw-fr-par` KuraInstance + pod were created, but the pod hung `Pending` on an unbound `scw-local-nvme` PVC (`FailedScheduling: pod has unbound immediate PersistentVolumeClaims. not found`).

## Change

Move the provisioner into the tuist chart as `templates/kura-fleet-storage.yaml`, gated on the same `kuraFleet.enabled` flag as the fleet itself, and delete the standalone bootstrap manifest. Now the StorageClass ships wherever the fleet that needs it ships — they can't drift, and a fresh env can't miss it.

The StorageClass name `scw-local-nvme` is load-bearing (the `scw-fr-par-runners` kura region spec provisions PVCs with exactly that name) and is unchanged.

## One behavior change worth a look

The bootstrap manifest pinned the provisioner controller to the EM pool with a `nodeSelector`. I **removed that** in the chart version: the controller only watches PVCs and launches a helper Pod on the *target* node (which still tolerates the runner-cache taint), so it doesn't need to live on the cache node. Pinning it would make the release `helm --wait` block on the controller being `Available` whenever the EM node isn't up yet (e.g. a cold deploy), which is a regression we don't want. Flagging it explicitly since it diverges from the validated bootstrap.

## Validation

- `helm template` renders all 7 resources (Namespace, SA, ClusterRole/Binding, Deployment, StorageClass, ConfigMap) when `kuraFleet.enabled`, and nothing when disabled.
- Deployment renders with no `nodeSelector` (unpinned); StorageClass `scw-local-nvme` present.

## Note

This doesn't retro-fix the live clusters — staging already has the bootstrap applied; production still needs the one-time `kubectl apply` (or this merged + redeployed) to unstick the currently-Pending cache pod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)