### PR TITLE
fix(infra,kura): kubelet InternalIP address + bound Kura bootstrap tmp staging

### DIFF
--- a/infra/k8s/clusters/cluster-canary.yaml
+++ b/infra/k8s/clusters/cluster-canary.yaml
@@ -39,6 +39,12 @@ spec:
       # (`tuist-bm-canary-…`).
       - name: bareMetalCluster
         value: canary
+      # Insert InternalIP so the apiserver can reach kubelets on nodes with no
+      # ExternalIP and an unresolvable Hostname (the Scaleway Elastic Metal kura
+      # node + the macOS-PN fleet) for `kubectl logs`/`exec`. Flipping this
+      # re-renders the apiserver patch and rolls this cluster's control plane.
+      - name: kubeletPreferredAddressTypes
+        value: ExternalIP,InternalIP,Hostname,InternalDNS,ExternalDNS
     workers:
       machineDeployments:
         - class: hcloud-worker

--- a/infra/k8s/clusters/cluster-production.yaml
+++ b/infra/k8s/clusters/cluster-production.yaml
@@ -46,6 +46,12 @@ spec:
       # (`tuist-bm-production-…`).
       - name: bareMetalCluster
         value: production
+      # Insert InternalIP so the apiserver can reach kubelets on nodes with no
+      # ExternalIP and an unresolvable Hostname (the Scaleway Elastic Metal kura
+      # node + the macOS-PN fleet) for `kubectl logs`/`exec`. Flipping this
+      # re-renders the apiserver patch and rolls this cluster's control plane.
+      - name: kubeletPreferredAddressTypes
+        value: ExternalIP,InternalIP,Hostname,InternalDNS,ExternalDNS
     workers:
       machineDeployments:
         # General-purpose pool: Phoenix server, redis, system DaemonSets,

--- a/infra/k8s/clusters/cluster-staging.yaml
+++ b/infra/k8s/clusters/cluster-staging.yaml
@@ -50,6 +50,12 @@ spec:
       # (`tuist-bm-staging-…`).
       - name: bareMetalCluster
         value: staging
+      # Insert InternalIP so the apiserver can reach kubelets on nodes with no
+      # ExternalIP and an unresolvable Hostname (the Scaleway Elastic Metal kura
+      # node + the macOS-PN fleet) for `kubectl logs`/`exec`. Flipping this
+      # re-renders the apiserver patch and rolls this cluster's control plane.
+      - name: kubeletPreferredAddressTypes
+        value: ExternalIP,InternalIP,Hostname,InternalDNS,ExternalDNS
     workers:
       machineDeployments:
         # General-purpose pool: Phoenix server, system DaemonSets.

--- a/kura/src/app.rs
+++ b/kura/src/app.rs
@@ -139,6 +139,7 @@ async fn run_with_config(
     let notify = Notify::new();
 
     let bootstrap_semaphore = Arc::new(Semaphore::new(config.bootstrap_max_concurrent_peers));
+    let bootstrap_staging_budget = crate::utils::TmpBudget::new(config.tmp_dir_max_bytes);
     let state = Arc::new(AppState {
         config,
         _data_dir_lock: data_dir_lock,
@@ -157,6 +158,7 @@ async fn run_with_config(
         notify,
         readiness: tokio::sync::Mutex::new(ReadinessState::new(Instant::now())),
         bootstrap_semaphore,
+        bootstrap_staging_budget,
     });
     state.sync_runtime_metrics().await;
     let drain_completion_timeout = Duration::from_millis(state.config.drain_completion_timeout_ms);

--- a/kura/src/replication/mod.rs
+++ b/kura/src/replication/mod.rs
@@ -26,7 +26,7 @@ use crate::{
     state::SharedState,
     store::{ArtifactApplyOutcome, ManifestPage, NamespaceTombstonePage},
     telemetry::{inject_current_trace_context, record_trace_context},
-    utils::{ensure_tmp_dir_capacity, replication_target_label, temp_file_path, url_encode},
+    utils::{replication_target_label, temp_file_path, url_encode},
 };
 
 use self::{operation::ReplicationOperation, outbox_message::OutboxMessage};
@@ -401,6 +401,8 @@ async fn bootstrap_artifact_from_peer(
             .await;
     }
 
+    let reserved_bytes = manifest.size.min(MAX_REPLICATION_BODY_BYTES);
+    let _staging_reservation = state.bootstrap_staging_budget.reserve(reserved_bytes).await;
     let temp_path = temp_file_path(&state.config.tmp_dir.join("bootstrap"), "bootstrap");
     stream_response_to_temp(state, response, &temp_path).await?;
     state
@@ -436,14 +438,10 @@ async fn stream_response_to_temp(
             "bootstrap artifact response declared {content_length} bytes, exceeds limit of {MAX_REPLICATION_BODY_BYTES}"
         ));
     }
-    ensure_tmp_dir_capacity(
-        &state.config.tmp_dir,
-        response
-            .content_length()
-            .unwrap_or(MAX_REPLICATION_BODY_BYTES),
-        state.config.tmp_dir_max_bytes,
-    )
-    .await?;
+    // Peak tmp staging is bounded by the caller's `bootstrap_staging_budget`
+    // reservation, so concurrent bootstraps can never collectively overshoot
+    // the budget. The per-body `MAX_REPLICATION_BODY_BYTES` ceiling below still
+    // caps each individual artifact.
     let mut destination = state.io.create_file(path).await?;
     let mut stream = response.bytes_stream();
     let mut total: u64 = 0;
@@ -1363,5 +1361,184 @@ mod tests {
                 .expect("artifact fetch should succeed")
                 .is_none()
         );
+    }
+
+    #[tokio::test]
+    async fn bootstrap_succeeds_when_total_artifacts_exceed_tmp_budget() {
+        // A large account whose cached artifacts dwarf the tmp budget must still
+        // bootstrap from a single peer: peak tmp staging is bounded by the
+        // per-artifact reservation, so the budget is never exhausted regardless
+        // of total account size.
+        let artifact_bytes = vec![7_u8; 256 * 1024];
+        let artifact_count = 24_usize;
+        let tmp_budget = (artifact_bytes.len() as u64) * 2;
+
+        let remote = test_context(|_| {}).await;
+        for index in 0..artifact_count {
+            remote
+                .state
+                .store
+                .persist_artifact_from_bytes(
+                    ArtifactProducer::Gradle,
+                    "ios",
+                    &format!("artifact-{index}"),
+                    "application/octet-stream",
+                    &artifact_bytes,
+                )
+                .await
+                .expect("remote artifact should persist");
+        }
+        let (remote_url, _server) = spawn_server(router(remote.state.clone())).await;
+
+        let local = test_context(move |config| {
+            config.tmp_dir_max_bytes = tmp_budget;
+        })
+        .await;
+        assert!(
+            (artifact_bytes.len() as u64) * (artifact_count as u64) > tmp_budget,
+            "test should stage far more than the tmp budget allows at once"
+        );
+
+        let stats = bootstrap_from_peer(&local.state, &remote_url)
+            .await
+            .expect("bootstrap should converge under a fixed tmp budget");
+        assert_eq!(stats.artifacts_applied, artifact_count as u64);
+
+        for index in 0..artifact_count {
+            let manifest = local
+                .state
+                .store
+                .fetch_artifact(
+                    ArtifactProducer::Gradle,
+                    "ios",
+                    &format!("artifact-{index}"),
+                )
+                .await
+                .expect("artifact fetch should succeed")
+                .expect("every bootstrapped artifact should be present");
+            assert_eq!(manifest.size, artifact_bytes.len() as u64);
+        }
+
+        // The reservation is fully released once bootstrap drains.
+        let drained = local
+            .state
+            .bootstrap_staging_budget
+            .reserve(tmp_budget)
+            .await;
+        drop(drained);
+    }
+
+    #[tokio::test]
+    async fn concurrent_peer_bootstraps_converge_and_bound_peak_tmp() {
+        // Reproduces the production failure mode: many peers bootstrap
+        // concurrently into the shared tmp dir while their network fetches are
+        // slow, so each holds a partially-written temp file open at the same
+        // time. The peer streams every body in small chunks with a delay between
+        // them, so absent the reservation all stagers would pass the racy
+        // point-in-time capacity check at once and pile far more than the budget
+        // into the tmp dir. The reservation bounds how many stage concurrently,
+        // so peak tmp usage stays within the budget while every artifact still
+        // applies. A watcher samples the on-disk tmp size throughout.
+        let peer_count = 8_usize;
+        let artifact_len = 256 * 1024_usize;
+        let tmp_budget = (artifact_len as u64) * 2;
+        let chunk = vec![3_u8; 32 * 1024];
+        let chunks_per_artifact = artifact_len / chunk.len();
+
+        let app = Router::new().route(
+            "/_internal/bootstrap/artifacts/{artifact_id}",
+            get({
+                let chunk = chunk.clone();
+                move |AxumPath(_artifact_id): AxumPath<String>| {
+                    let chunk = chunk.clone();
+                    async move {
+                        let stream =
+                            futures_util::stream::iter(0..chunks_per_artifact).then(move |_| {
+                                let chunk = chunk.clone();
+                                async move {
+                                    sleep(Duration::from_millis(5)).await;
+                                    Ok::<_, std::io::Error>(chunk)
+                                }
+                            });
+                        axum::body::Body::from_stream(stream)
+                    }
+                }
+            }),
+        );
+        let (remote_url, _server) = spawn_server(app).await;
+
+        let local = test_context(move |config| {
+            config.tmp_dir_max_bytes = tmp_budget;
+        })
+        .await;
+        let tmp_dir = local.state.config.tmp_dir.clone();
+
+        let stop = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let peak = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
+        let watcher = {
+            let tmp_dir = tmp_dir.clone();
+            let stop = stop.clone();
+            let peak = peak.clone();
+            tokio::spawn(async move {
+                while !stop.load(std::sync::atomic::Ordering::Relaxed) {
+                    let staged = crate::utils::directory_size_bytes(&tmp_dir);
+                    peak.fetch_max(staged, std::sync::atomic::Ordering::Relaxed);
+                    sleep(Duration::from_millis(1)).await;
+                }
+            })
+        };
+
+        let tasks: Vec<_> = (0..peer_count)
+            .map(|index| {
+                let manifest = bootstrap_test_manifest(
+                    ArtifactProducer::Gradle,
+                    false,
+                    "ios",
+                    &format!("artifact-{index}"),
+                    "application/octet-stream",
+                    artifact_len as u64,
+                    100 + index as u64,
+                );
+                let state = local.state.clone();
+                let remote_url = remote_url.clone();
+                tokio::spawn(async move {
+                    bootstrap_artifact_from_peer(&state, &remote_url, &manifest).await
+                })
+            })
+            .collect();
+
+        for task in tasks {
+            let outcome = task
+                .await
+                .expect("bootstrap task should not panic")
+                .expect("concurrent bootstrap staging should stay within the budget");
+            assert_eq!(outcome, ArtifactApplyOutcome::Applied);
+        }
+
+        stop.store(true, std::sync::atomic::Ordering::Relaxed);
+        watcher.await.expect("watcher task should finish");
+
+        let observed_peak = peak.load(std::sync::atomic::Ordering::Relaxed);
+        assert!(
+            observed_peak <= tmp_budget,
+            "peak staged tmp bytes {observed_peak} exceeded budget {tmp_budget}"
+        );
+
+        for index in 0..peer_count {
+            assert!(
+                local
+                    .state
+                    .store
+                    .fetch_artifact(
+                        ArtifactProducer::Gradle,
+                        "ios",
+                        &format!("artifact-{index}")
+                    )
+                    .await
+                    .expect("artifact fetch should succeed")
+                    .is_some(),
+                "every concurrently bootstrapped artifact should be present"
+            );
+        }
     }
 }

--- a/kura/src/replication/mod.rs
+++ b/kura/src/replication/mod.rs
@@ -1635,8 +1635,7 @@ mod tests {
         })
         .await;
 
-        std::fs::create_dir_all(&local.state.config.tmp_dir)
-            .expect("tmp dir should be creatable");
+        std::fs::create_dir_all(&local.state.config.tmp_dir).expect("tmp dir should be creatable");
         std::fs::write(
             local.state.config.tmp_dir.join("upload-in-progress"),
             vec![1_u8; (tmp_budget - artifact_len / 2) as usize],

--- a/kura/src/replication/mod.rs
+++ b/kura/src/replication/mod.rs
@@ -26,7 +26,7 @@ use crate::{
     state::SharedState,
     store::{ArtifactApplyOutcome, ManifestPage, NamespaceTombstonePage},
     telemetry::{inject_current_trace_context, record_trace_context},
-    utils::{replication_target_label, temp_file_path, url_encode},
+    utils::{ensure_tmp_dir_capacity, replication_target_label, temp_file_path, url_encode},
 };
 
 use self::{operation::ReplicationOperation, outbox_message::OutboxMessage};
@@ -401,10 +401,32 @@ async fn bootstrap_artifact_from_peer(
             .await;
     }
 
-    let reserved_bytes = manifest.size.min(MAX_REPLICATION_BODY_BYTES);
+    let declared_bytes = response.content_length();
+    if let Some(declared) = declared_bytes
+        && declared > MAX_REPLICATION_BODY_BYTES
+    {
+        return Err(format!(
+            "bootstrap artifact response declared {declared} bytes, exceeds limit of {MAX_REPLICATION_BODY_BYTES}"
+        ));
+    }
+    // Reserve for the larger of the manifest size and the peer's declared body
+    // so an inconsistent peer can't stage more bytes than we accounted for.
+    let reserved_bytes = manifest
+        .size
+        .max(declared_bytes.unwrap_or(0))
+        .min(MAX_REPLICATION_BODY_BYTES);
     let _staging_reservation = state.bootstrap_staging_budget.reserve(reserved_bytes).await;
+    // The reservation bounds concurrent bootstraps against each other; this
+    // guards the shared tmp dir against non-bootstrap occupants (uploads,
+    // multipart assembly, leftovers) so the on-disk total can't exceed budget.
+    ensure_tmp_dir_capacity(
+        &state.config.tmp_dir,
+        reserved_bytes,
+        state.config.tmp_dir_max_bytes,
+    )
+    .await?;
     let temp_path = temp_file_path(&state.config.tmp_dir.join("bootstrap"), "bootstrap");
-    stream_response_to_temp(state, response, &temp_path).await?;
+    stream_response_to_temp(state, response, &temp_path, reserved_bytes).await?;
     state
         .store
         .hit_failpoint(FailpointName::AfterBootstrapArtifactFetchBeforePersist)
@@ -426,33 +448,26 @@ async fn stream_response_to_temp(
     state: &SharedState,
     response: reqwest::Response,
     path: &Path,
+    staging_limit: u64,
 ) -> Result<(), String> {
     let parent = path
         .parent()
         .ok_or_else(|| "bootstrap temp path is missing a parent directory".to_string())?;
     state.io.create_dir_all(parent).await?;
-    if let Some(content_length) = response.content_length()
-        && content_length > MAX_REPLICATION_BODY_BYTES
-    {
-        return Err(format!(
-            "bootstrap artifact response declared {content_length} bytes, exceeds limit of {MAX_REPLICATION_BODY_BYTES}"
-        ));
-    }
-    // Peak tmp staging is bounded by the caller's `bootstrap_staging_budget`
-    // reservation, so concurrent bootstraps can never collectively overshoot
-    // the budget. The per-body `MAX_REPLICATION_BODY_BYTES` ceiling below still
-    // caps each individual artifact.
+    // The staged file must not exceed the caller's `bootstrap_staging_budget`
+    // reservation: an inconsistent peer serving a body larger than its manifest
+    // advertised is rejected here instead of overrunning the budget.
     let mut destination = state.io.create_file(path).await?;
     let mut stream = response.bytes_stream();
     let mut total: u64 = 0;
     while let Some(chunk) = stream.next().await {
         let chunk = chunk.map_err(|error| format!("failed to stream bootstrap body: {error}"))?;
         total = total.saturating_add(chunk.len() as u64);
-        if total > MAX_REPLICATION_BODY_BYTES {
+        if total > staging_limit {
             drop(destination);
             state.io.remove_file_if_exists(path).await;
             return Err(format!(
-                "bootstrap artifact response exceeded limit of {MAX_REPLICATION_BODY_BYTES} bytes"
+                "bootstrap artifact response exceeded reserved {staging_limit} bytes"
             ));
         }
         if let Some(limiter) = state.replication_bandwidth_limiter.as_ref() {
@@ -1540,5 +1555,110 @@ mod tests {
                 "every concurrently bootstrapped artifact should be present"
             );
         }
+    }
+
+    #[tokio::test]
+    async fn bootstrap_rejects_body_larger_than_reserved() {
+        // An inconsistent peer streams a chunked body larger than its manifest
+        // advertised (no Content-Length). The staged file is capped at the
+        // reservation, so it is rejected instead of overrunning the tmp budget.
+        let declared_len = 64 * 1024_u64;
+        let chunk = vec![7_u8; declared_len as usize];
+        let app = Router::new().route(
+            "/_internal/bootstrap/artifacts/{artifact_id}",
+            get({
+                let chunk = chunk.clone();
+                move |AxumPath(_artifact_id): AxumPath<String>| {
+                    let chunk = chunk.clone();
+                    async move {
+                        let stream = futures_util::stream::iter(0..4).then(move |_| {
+                            let chunk = chunk.clone();
+                            async move { Ok::<_, std::io::Error>(chunk) }
+                        });
+                        axum::body::Body::from_stream(stream)
+                    }
+                }
+            }),
+        );
+        let (remote_url, _server) = spawn_server(app).await;
+
+        let local = test_context(|_config| {}).await;
+        let manifest = bootstrap_test_manifest(
+            ArtifactProducer::Gradle,
+            false,
+            "ios",
+            "oversized",
+            "application/octet-stream",
+            declared_len,
+            100,
+        );
+
+        let error = bootstrap_artifact_from_peer(&local.state, &remote_url, &manifest)
+            .await
+            .expect_err("a body larger than the manifest must be rejected");
+        assert!(
+            error.contains("exceeded reserved"),
+            "expected a reservation-overflow rejection, got: {error}"
+        );
+        assert!(
+            local
+                .state
+                .store
+                .fetch_artifact(ArtifactProducer::Gradle, "ios", "oversized")
+                .await
+                .expect("artifact fetch should succeed")
+                .is_none(),
+            "the rejected artifact must not be persisted"
+        );
+    }
+
+    #[tokio::test]
+    async fn bootstrap_accounts_for_non_bootstrap_tmp_usage() {
+        // A non-bootstrap occupant already fills most of the tmp dir. The
+        // bootstrap reservation alone would admit the artifact, but the
+        // whole-dir guard must refuse it so the shared tmp dir can't exceed
+        // its budget.
+        let artifact_len = 64 * 1024_u64;
+        let tmp_budget = artifact_len * 2;
+        let chunk = vec![5_u8; artifact_len as usize];
+        let app = Router::new().route(
+            "/_internal/bootstrap/artifacts/{artifact_id}",
+            get(move |AxumPath(_artifact_id): AxumPath<String>| {
+                let chunk = chunk.clone();
+                async move { chunk }
+            }),
+        );
+        let (remote_url, _server) = spawn_server(app).await;
+
+        let local = test_context(move |config| {
+            config.tmp_dir_max_bytes = tmp_budget;
+        })
+        .await;
+
+        std::fs::create_dir_all(&local.state.config.tmp_dir)
+            .expect("tmp dir should be creatable");
+        std::fs::write(
+            local.state.config.tmp_dir.join("upload-in-progress"),
+            vec![1_u8; (tmp_budget - artifact_len / 2) as usize],
+        )
+        .expect("filler write should succeed");
+
+        let manifest = bootstrap_test_manifest(
+            ArtifactProducer::Gradle,
+            false,
+            "ios",
+            "blocked",
+            "application/octet-stream",
+            artifact_len,
+            100,
+        );
+
+        let error = bootstrap_artifact_from_peer(&local.state, &remote_url, &manifest)
+            .await
+            .expect_err("bootstrap must refuse to overrun the shared tmp budget");
+        assert!(
+            error.contains("tmp dir budget exhausted"),
+            "expected a tmp-dir budget rejection, got: {error}"
+        );
     }
 }

--- a/kura/src/state.rs
+++ b/kura/src/state.rs
@@ -22,6 +22,7 @@ use crate::{
     runtime::{DataDirLock, HttpTrafficClass, InflightGuard, RuntimeState, TrafficState},
     store::Store,
     usage::Usage,
+    utils::TmpBudget,
 };
 
 const READINESS_SETTLE_WINDOW: Duration = Duration::from_secs(5);
@@ -44,6 +45,7 @@ pub struct AppState {
     pub notify: Notify,
     pub readiness: Mutex<ReadinessState>,
     pub bootstrap_semaphore: Arc<Semaphore>,
+    pub bootstrap_staging_budget: Arc<TmpBudget>,
 }
 
 pub type SharedState = Arc<AppState>;

--- a/kura/src/test_support.rs
+++ b/kura/src/test_support.rs
@@ -138,6 +138,7 @@ where
     )
     .map(Arc::new);
     let bootstrap_semaphore = Arc::new(Semaphore::new(config.bootstrap_max_concurrent_peers));
+    let bootstrap_staging_budget = crate::utils::TmpBudget::new(config.tmp_dir_max_bytes);
     let state = Arc::new(AppState {
         config,
         _data_dir_lock: data_dir_lock,
@@ -156,6 +157,7 @@ where
         notify: Notify::new(),
         readiness: tokio::sync::Mutex::new(ReadinessState::new(Instant::now())),
         bootstrap_semaphore,
+        bootstrap_staging_budget,
     });
     state.sync_runtime_metrics().await;
 

--- a/kura/src/utils.rs
+++ b/kura/src/utils.rs
@@ -1,16 +1,101 @@
 use std::{
     path::{Path, PathBuf},
-    sync::Arc,
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
 use axum::extract::Request;
 use futures_util::StreamExt;
 use sha2::{Digest, Sha256};
-use tokio::io::AsyncWriteExt;
+use tokio::{io::AsyncWriteExt, sync::Notify};
 use uuid::Uuid;
 
 use crate::{artifact::producer::ArtifactProducer, bandwidth::BandwidthLimiter, io::IoController};
+
+/// Byte-accounted reservation over the shared tmp-dir budget.
+///
+/// Bootstrap stages every non-inline artifact it pulls from a peer into the
+/// shared tmp dir before appending it to a segment. Multiple peers (and the
+/// sequential artifacts within a single peer) stage concurrently, so without a
+/// shared accounting the combined in-flight bytes scale with the number of
+/// concurrent stagers rather than the budget. This reserves a staging slot
+/// sized to the artifact and waits when the budget is full, so peak staged
+/// bytes stay bounded by the budget regardless of total account size.
+#[derive(Debug)]
+pub struct TmpBudget {
+    capacity: u64,
+    reserved: AtomicU64,
+    available: Notify,
+}
+
+impl TmpBudget {
+    pub fn new(capacity: u64) -> Arc<Self> {
+        Arc::new(Self {
+            capacity: capacity.max(1),
+            reserved: AtomicU64::new(0),
+            available: Notify::new(),
+        })
+    }
+
+    /// Reserve `bytes` against the budget, waiting until the reservation fits.
+    ///
+    /// A request larger than the whole budget is clamped to the budget so a
+    /// single oversized artifact can still make progress once the dir drains
+    /// (the hard per-body byte ceiling is still enforced while streaming).
+    pub async fn reserve(self: &Arc<Self>, bytes: u64) -> TmpReservation {
+        let bytes = bytes.clamp(1, self.capacity);
+        loop {
+            let notified = self.available.notified();
+            tokio::pin!(notified);
+            // Register before checking capacity: notify_waiters() only wakes
+            // already-registered waiters and stores no permit, so without this
+            // a release racing the check below would be a lost wakeup.
+            notified.as_mut().enable();
+            let mut current = self.reserved.load(Ordering::Acquire);
+            loop {
+                if current.saturating_add(bytes) > self.capacity {
+                    break;
+                }
+                match self.reserved.compare_exchange_weak(
+                    current,
+                    current + bytes,
+                    Ordering::AcqRel,
+                    Ordering::Acquire,
+                ) {
+                    Ok(_) => {
+                        return TmpReservation {
+                            budget: self.clone(),
+                            bytes,
+                        };
+                    }
+                    Err(observed) => current = observed,
+                }
+            }
+            notified.await;
+        }
+    }
+
+    fn release(&self, bytes: u64) {
+        self.reserved.fetch_sub(bytes, Ordering::AcqRel);
+        self.available.notify_waiters();
+    }
+}
+
+/// RAII guard that releases its tmp-budget reservation on drop.
+#[derive(Debug)]
+pub struct TmpReservation {
+    budget: Arc<TmpBudget>,
+    bytes: u64,
+}
+
+impl Drop for TmpReservation {
+    fn drop(&mut self) {
+        self.budget.release(self.bytes);
+    }
+}
 
 #[derive(Debug)]
 pub struct TempBodyFile {
@@ -405,5 +490,54 @@ mod tests {
                 .expect("failed to read seeded file"),
             "hello"
         );
+    }
+
+    #[tokio::test]
+    async fn tmp_budget_caps_concurrent_reservations() {
+        let budget = TmpBudget::new(100);
+        let first = budget.reserve(60).await;
+        let second = budget.reserve(40).await;
+        assert_eq!(budget.reserved.load(Ordering::Acquire), 100);
+
+        // A third reservation cannot fit until one of the held ones drops.
+        let pending = tokio::spawn({
+            let budget = budget.clone();
+            async move { budget.reserve(40).await }
+        });
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        assert!(!pending.is_finished(), "reservation should wait for budget");
+
+        drop(first);
+        let third = pending.await.expect("pending reservation should resolve");
+        assert!(budget.reserved.load(Ordering::Acquire) <= 100);
+        drop(second);
+        drop(third);
+        assert_eq!(budget.reserved.load(Ordering::Acquire), 0);
+    }
+
+    #[tokio::test]
+    async fn tmp_budget_serializes_total_far_exceeding_capacity() {
+        // Stage a total volume far larger than the budget through a tiny budget;
+        // every reservation must eventually succeed (peak never exceeds budget),
+        // proving bootstrap convergence is independent of total account size.
+        let budget = TmpBudget::new(100);
+        let mut total = 0_u64;
+        for _ in 0..50 {
+            let reservation = budget.reserve(80).await;
+            assert!(budget.reserved.load(Ordering::Acquire) <= 100);
+            total += 80;
+            drop(reservation);
+        }
+        assert_eq!(total, 4000);
+        assert_eq!(budget.reserved.load(Ordering::Acquire), 0);
+    }
+
+    #[tokio::test]
+    async fn tmp_budget_clamps_oversized_request_to_capacity() {
+        let budget = TmpBudget::new(100);
+        let reservation = budget.reserve(10_000).await;
+        assert_eq!(budget.reserved.load(Ordering::Acquire), 100);
+        drop(reservation);
+        assert_eq!(budget.reserved.load(Ordering::Acquire), 0);
     }
 }


### PR DESCRIPTION
Combines two changes that we want to deploy together so the Kura bootstrap fix can be observed end to end (the InternalIP flip is what makes the stuck EM/macOS-PN kura pods log-readable; the Kura fix is what lets them finish bootstrap). Absorbs #11380.

## 1. Kura: bound bootstrap tmp-dir staging (the prod fix)

Freshly-started kura pods for a large account never became Ready (`GET /ready` 503 forever) after the StatefulSets rolled. Bootstrap stages each peer's artifacts into a shared tmp dir, and for an account whose cache exceeds `KURA_TMP_DIR_MAX_BYTES` the staging exhausted the budget, failed, retried from scratch, and readiness (gated on bootstrap) never settled:

```
bootstrap from <peer> failed: tmp dir budget exhausted: 7887454208 bytes staged, 784550880 bytes remaining
```

Root cause is unbounded concurrent staging, not a leak: up to `DEFAULT_BOOTSTRAP_MAX_CONCURRENT_PEERS` bootstrap tasks each streamed into the same tmp dir, guarded only by a point-in-time, non-reserving capacity check. Peak tmp scaled with peers × artifact size, not with the budget. This was **not** the 0.10.4 segment-ring change (that tests correct in isolation); the new pods just happened to roll onto 0.10.4 and bootstrap the now-large cache — a fresh 0.10.3 pod would fail identically, so rollback would not have helped.

Fix: a held byte reservation (`TmpBudget` + RAII `TmpReservation`) — each artifact reserves before streaming and releases on drop after persist; `reserve()` waits instead of failing when full. Peak tmp is now O(in-flight), not O(account size). The waiter registers (`Notified::enable`) before the capacity check so a release racing the check is not a lost wakeup.

Review hardening (two findings):
- **Other tmp occupants:** the reservation only tracked bootstrap stagers, so concurrent uploads/multipart/leftovers could push the shared tmp dir past budget on top of a full bootstrap reservation. Re-added the whole-dir `ensure_tmp_dir_capacity` guard in the bootstrap path — the reservation bounds bootstrap against itself, this bounds the on-disk total against all occupants. Can't reintroduce the original failure because the reservation already keeps bootstrap's own files within budget.
- **Reservation vs staged body:** sized the reservation from `max(manifest.size, declared Content-Length)` and cap the streamed body at the reserved size, so an inconsistent peer serving a body larger than its manifest is rejected instead of overrunning the budget.

Validation: full kura suite **258 passing**, fmt + clippy clean. Regression tests: 8 concurrent slow peers stay under budget (fails against pre-fix code with the exact prod error); an oversized chunked body is rejected; a pre-filled tmp dir blocks a bootstrap the reservation alone would admit.

## 2. infra: kubelet InternalIP address (the observability flip)

Adds `InternalIP` to `kubeletPreferredAddressTypes` on all three workload clusters so the apiserver can reach kubelets on nodes with no ExternalIP and an unresolvable Hostname (the Scaleway Elastic Metal kura node + the macOS-PN fleet). Without it, `kubectl logs`/`exec` on those nodes fails with no-such-host — which is exactly why the stuck `scw-fr-par` EM pod's logs were unreadable during this incident. Flipping the variable re-renders the apiserver patch and rolls each cluster's control plane (applied by `mgmt-cluster-apply` on merge).

## Deploy ordering

On merge to main: `release.yml` publishes a new `ghcr.io/tuist/kura:<version>` (kura-should-release picks up the `fix(kura)` commits) and `mgmt-cluster-apply` flips InternalIP. The Kura runtime image must be published before any deploy resolves the new `kura@` tag — deploy staging with an explicit `kura_runtime_image_tag` once the release job's image push completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)