### PR TITLE
fix(cache): deduplicate registry manifest variants

### DIFF
--- a/cache/lib/cache/registry/alternate_manifests.ex
+++ b/cache/lib/cache/registry/alternate_manifests.ex
@@ -40,15 +40,25 @@ defmodule Cache.Registry.AlternateManifests do
 
     case Cachex.get(cache_name, key) do
       {:ok, nil} ->
-        manifests = discover(scope, name, version)
-        Cachex.put(cache_name, key, manifests, ttl: @ttl)
-        manifests
+        discover_and_maybe_cache(cache_name, key, scope, name, version)
 
       {:ok, manifests} ->
         manifests
 
       _ ->
-        discover(scope, name, version)
+        {_status, manifests} = discover(scope, name, version)
+        manifests
+    end
+  end
+
+  defp discover_and_maybe_cache(cache_name, key, scope, name, version) do
+    case discover(scope, name, version) do
+      {:ok, manifests} ->
+        Cachex.put(cache_name, key, manifests, ttl: @ttl)
+        manifests
+
+      {:error, manifests} ->
+        manifests
     end
   end
 
@@ -72,7 +82,7 @@ defmodule Cache.Registry.AlternateManifests do
             inspect(error)
         )
 
-        []
+        {:error, []}
     end
   end
 
@@ -80,28 +90,49 @@ defmodule Cache.Registry.AlternateManifests do
     alternate_objects =
       Enum.filter(objects, fn {_key, filename} -> ManifestVariants.alternate_manifest?(filename) end)
 
-    if alternate_objects == [] do
-      []
-    else
-      descriptors_with_alternates(objects, alternate_objects, bucket, scope, name, version)
-    end
+    if alternate_objects == [],
+      do: {:ok, []},
+      else: descriptors_with_alternates(objects, alternate_objects, bucket, scope, name, version)
   end
 
   defp descriptors_with_alternates(objects, alternate_objects, bucket, scope, name, version) do
-    default_descriptor =
-      objects
-      |> Enum.find(fn {_key, filename} -> filename == "Package.swift" end)
-      |> case do
-        nil -> []
-        {key, filename} -> descriptor_for(bucket, key, filename, scope, name, version)
-      end
+    default_object = Enum.find(objects, fn {_key, filename} -> filename == "Package.swift" end)
 
-    alternates =
-      Enum.flat_map(alternate_objects, fn {key, filename} ->
-        descriptor_for(bucket, key, filename, scope, name, version)
-      end)
+    case default_descriptor_for(default_object, bucket, scope, name, version) do
+      {:ok, default_descriptor} ->
+        alternates =
+          Enum.flat_map(alternate_objects, fn {key, filename} ->
+            descriptor_for(bucket, key, filename, scope, name, version)
+          end)
 
-    ManifestVariants.linkable_alternates(default_descriptor ++ alternates)
+        {:ok, ManifestVariants.linkable_alternates(default_descriptor ++ alternates)}
+
+      {:error, _reason} ->
+        {:error, []}
+    end
+  end
+
+  defp default_descriptor_for(nil, _bucket, _scope, _name, _version), do: {:ok, []}
+
+  defp default_descriptor_for({key, filename}, bucket, scope, name, version) do
+    case fetch_content(bucket, key) do
+      {:ok, content} ->
+        {:ok,
+         [
+           %{
+             "swift_version" => filename_swift_version(filename),
+             "swift_tools_version" => ManifestVariants.swift_tools_version(content)
+           }
+         ]}
+
+      {:error, reason} ->
+        Logger.warning(
+          "Failed to fetch default manifest #{key} for #{scope}/#{name}@#{version}: " <>
+            inspect(reason)
+        )
+
+        {:error, reason}
+    end
   end
 
   defp descriptor_for(bucket, key, filename, scope, name, version) do

--- a/cache/lib/cache/registry/alternate_manifests.ex
+++ b/cache/lib/cache/registry/alternate_manifests.ex
@@ -19,14 +19,12 @@ defmodule Cache.Registry.AlternateManifests do
 
   alias Cache.Config
   alias Cache.Registry.KeyNormalizer
+  alias Cache.Registry.ManifestVariants
 
   require Logger
 
   @cache_name :registry_alternate_manifests_cache
   @ttl to_timeout(minute: 10)
-  @alternate_manifest_regex ~r/\APackage@swift-(\d+)(?:\.(\d+))?(?:\.(\d+))?\.swift\z/
-  @swift_tools_version_regex ~r/^\/\/ swift-tools-version:\s?(\d+)(?:\.(\d+))?(?:\.(\d+))?/
-
   def child_spec(_opts) do
     %{
       id: __MODULE__,
@@ -65,10 +63,8 @@ defmodule Cache.Registry.AlternateManifests do
       |> ExAws.S3.list_objects_v2(prefix: prefix)
       |> ExAws.stream!()
       |> Stream.map(fn %{key: key} -> {key, Path.basename(key)} end)
-      |> Stream.filter(fn {_key, filename} -> alternate_manifest?(filename) end)
-      |> Enum.flat_map(fn {key, filename} ->
-        descriptor_for(bucket, key, filename, scope, name, version)
-      end)
+      |> Enum.to_list()
+      |> descriptors(bucket, scope, name, version)
     rescue
       error ->
         Logger.warning(
@@ -80,7 +76,33 @@ defmodule Cache.Registry.AlternateManifests do
     end
   end
 
-  defp alternate_manifest?(filename), do: Regex.match?(@alternate_manifest_regex, filename)
+  defp descriptors(objects, bucket, scope, name, version) do
+    alternate_objects =
+      Enum.filter(objects, fn {_key, filename} -> ManifestVariants.alternate_manifest?(filename) end)
+
+    if alternate_objects == [] do
+      []
+    else
+      descriptors_with_alternates(objects, alternate_objects, bucket, scope, name, version)
+    end
+  end
+
+  defp descriptors_with_alternates(objects, alternate_objects, bucket, scope, name, version) do
+    default_descriptor =
+      objects
+      |> Enum.find(fn {_key, filename} -> filename == "Package.swift" end)
+      |> case do
+        nil -> []
+        {key, filename} -> descriptor_for(bucket, key, filename, scope, name, version)
+      end
+
+    alternates =
+      Enum.flat_map(alternate_objects, fn {key, filename} ->
+        descriptor_for(bucket, key, filename, scope, name, version)
+      end)
+
+    ManifestVariants.linkable_alternates(default_descriptor ++ alternates)
+  end
 
   defp descriptor_for(bucket, key, filename, scope, name, version) do
     case fetch_content(bucket, key) do
@@ -88,7 +110,7 @@ defmodule Cache.Registry.AlternateManifests do
         [
           %{
             "swift_version" => filename_swift_version(filename),
-            "swift_tools_version" => parse_swift_tools_version(content)
+            "swift_tools_version" => ManifestVariants.swift_tools_version(content)
           }
         ]
 
@@ -111,21 +133,6 @@ defmodule Cache.Registry.AlternateManifests do
     end
   end
 
-  defp filename_swift_version(filename) do
-    case Regex.run(@alternate_manifest_regex, filename) do
-      [_, major] -> major
-      [_, major, minor] -> "#{major}.#{minor}"
-      [_, major, minor, patch] -> "#{major}.#{minor}.#{patch}"
-      _ -> nil
-    end
-  end
-
-  defp parse_swift_tools_version(content) do
-    case Regex.run(@swift_tools_version_regex, content) do
-      [_, major] -> major
-      [_, major, minor] -> "#{major}.#{minor}"
-      [_, major, minor, patch] -> "#{major}.#{minor}.#{patch}"
-      _ -> nil
-    end
-  end
+  defp filename_swift_version("Package.swift"), do: nil
+  defp filename_swift_version(filename), do: ManifestVariants.filename_swift_version(filename)
 end

--- a/cache/lib/cache/registry/manifest_variants.ex
+++ b/cache/lib/cache/registry/manifest_variants.ex
@@ -1,0 +1,70 @@
+defmodule Cache.Registry.ManifestVariants do
+  @moduledoc false
+
+  @alternate_manifest_regex ~r/\APackage@swift-(\d+)(?:\.(\d+))?(?:\.(\d+))?\.swift\z/
+  @swift_tools_version_regex ~r/^\/\/ swift-tools-version:\s?(\d+)(?:\.(\d+))?(?:\.(\d+))?/
+
+  def alternate_manifest?(filename), do: Regex.match?(@alternate_manifest_regex, filename)
+
+  def filename_swift_version(filename) do
+    case Regex.run(@alternate_manifest_regex, filename) do
+      [_, major] -> major
+      [_, major, minor] -> "#{major}.#{minor}"
+      [_, major, minor, patch] -> "#{major}.#{minor}.#{patch}"
+      _ -> nil
+    end
+  end
+
+  def swift_tools_version(content) do
+    case Regex.run(@swift_tools_version_regex, content) do
+      [_, major] -> major
+      [_, major, minor] -> "#{major}.#{minor}"
+      [_, major, minor, patch] -> "#{major}.#{minor}.#{patch}"
+      _ -> nil
+    end
+  end
+
+  def deduplicate_by_tools_version(manifests) do
+    defaults = Enum.filter(manifests, &is_nil(&1["swift_version"]))
+    defaults ++ linkable_alternates(manifests)
+  end
+
+  def linkable_alternates(manifests) do
+    default_tools_versions =
+      manifests
+      |> Enum.filter(&is_nil(&1["swift_version"]))
+      |> Enum.map(&canonical_tools_version(&1["swift_tools_version"]))
+      |> Enum.reject(&is_nil/1)
+      |> MapSet.new()
+
+    manifests
+    |> Enum.reject(&is_nil(&1["swift_version"]))
+    |> Enum.reduce({default_tools_versions, []}, fn manifest, {seen_tools_versions, alternates} ->
+      canonical_tools_version = canonical_tools_version(manifest["swift_tools_version"])
+
+      cond do
+        is_nil(canonical_tools_version) ->
+          {seen_tools_versions, [manifest | alternates]}
+
+        MapSet.member?(seen_tools_versions, canonical_tools_version) ->
+          {seen_tools_versions, alternates}
+
+        true ->
+          {MapSet.put(seen_tools_versions, canonical_tools_version), [manifest | alternates]}
+      end
+    end)
+    |> elem(1)
+    |> Enum.reverse()
+  end
+
+  defp canonical_tools_version(nil), do: nil
+
+  defp canonical_tools_version(version) when is_binary(version) do
+    case Regex.run(~r/\A(\d+)(?:\.(\d+))?(?:\.(\d+))?\z/, version) do
+      [_, major] -> "#{major}.0.0"
+      [_, major, minor] -> "#{major}.#{minor}.0"
+      [_, major, minor, patch] -> "#{major}.#{minor}.#{patch}"
+      _ -> version
+    end
+  end
+end

--- a/cache/lib/cache/registry/release_worker.ex
+++ b/cache/lib/cache/registry/release_worker.ex
@@ -8,6 +8,7 @@ defmodule Cache.Registry.ReleaseWorker do
   alias Cache.Config
   alias Cache.Registry.KeyNormalizer
   alias Cache.Registry.Lock
+  alias Cache.Registry.ManifestVariants
   alias Cache.Registry.Metadata
   alias Cache.S3
 
@@ -15,7 +16,6 @@ defmodule Cache.Registry.ReleaseWorker do
 
   @github_opts [finch: Cache.Finch, retry: false]
 
-  @alternate_manifest_regex ~r/\APackage@swift-(\d+)(?:\.(\d+))?(?:\.(\d+))?\.swift\z/
   @lock_ttl_seconds 1_800
   @metadata_lock_ttl_seconds 300
   @skippable_submodule_failure_markers [
@@ -660,6 +660,7 @@ defmodule Cache.Registry.ReleaseWorker do
         end
       end)
       |> Enum.reject(&is_nil/1)
+      |> ManifestVariants.deduplicate_by_tools_version()
 
     {:ok, manifests}
   end
@@ -807,29 +808,15 @@ defmodule Cache.Registry.ReleaseWorker do
 
   defp manifest_path?("Package.swift"), do: true
 
-  defp manifest_path?(path) when is_binary(path), do: Regex.match?(@alternate_manifest_regex, Path.basename(path))
+  defp manifest_path?(path) when is_binary(path), do: ManifestVariants.alternate_manifest?(Path.basename(path))
 
   defp manifest_path?(_), do: false
 
   defp manifest_swift_version("Package.swift"), do: nil
 
-  defp manifest_swift_version(filename) do
-    case Regex.run(@alternate_manifest_regex, filename) do
-      [_, major] -> major
-      [_, major, minor] -> "#{major}.#{minor}"
-      [_, major, minor, patch] -> "#{major}.#{minor}.#{patch}"
-      _ -> nil
-    end
-  end
+  defp manifest_swift_version(filename), do: ManifestVariants.filename_swift_version(filename)
 
-  defp swift_tools_version(content) do
-    case Regex.run(~r/^\/\/ swift-tools-version:\s?(\d+)(?:\.(\d+))?(?:\.(\d+))?/, content) do
-      [_, major] -> major
-      [_, major, minor] -> "#{major}.#{minor}"
-      [_, major, minor, patch] -> "#{major}.#{minor}.#{patch}"
-      _ -> nil
-    end
-  end
+  defp swift_tools_version(content), do: ManifestVariants.swift_tools_version(content)
 
   defp checksum_for_file(path) do
     hash =

--- a/cache/lib/cache_web/controllers/registry_controller.ex
+++ b/cache/lib/cache_web/controllers/registry_controller.ex
@@ -7,6 +7,7 @@ defmodule CacheWeb.RegistryController do
   alias Cache.Registry.AlternateManifests
   alias Cache.Registry.EventsPipeline
   alias Cache.Registry.KeyNormalizer
+  alias Cache.Registry.ManifestVariants
   alias Cache.Registry.Metadata
   alias Cache.Registry.RepositoryURL
   alias Cache.S3
@@ -415,7 +416,7 @@ defmodule CacheWeb.RegistryController do
 
   defp build_alternate_manifests_link(scope, name, version, manifests) do
     manifests
-    |> Enum.filter(fn manifest -> not is_nil(manifest["swift_version"]) end)
+    |> ManifestVariants.linkable_alternates()
     |> Enum.map_join(", ", fn manifest ->
       swift_version = manifest["swift_version"]
       swift_tools_version = manifest["swift_tools_version"]

--- a/cache/test/cache/registry/alternate_manifests_test.exs
+++ b/cache/test/cache/registry/alternate_manifests_test.exs
@@ -176,6 +176,37 @@ defmodule Cache.Registry.AlternateManifestsTest do
     assert log =~ "Failed to fetch alternate manifest"
   end
 
+  test "does not cache fallback results when the listed root manifest fails to fetch",
+       %{cache_name: cache_name} do
+    expect(ExAws.S3, :list_objects_v2, 2, fn "test-bucket", _opts ->
+      %S3{bucket: "test-bucket", path: "list"}
+    end)
+
+    expect(ExAws, :stream!, 2, fn %S3{} ->
+      [
+        %{key: "registry/swift/foo/bar/1.0.0/Package.swift"},
+        %{key: "registry/swift/foo/bar/1.0.0/Package@swift-6.0.swift"}
+      ]
+    end)
+
+    expect(ExAws.S3, :get_object, 2, fn "test-bucket", key ->
+      assert String.ends_with?(key, "/Package.swift")
+      %S3{bucket: "test-bucket", path: key}
+    end)
+
+    expect(ExAws, :request, 2, fn %S3{} ->
+      {:error, {:http_error, 503, %{}}}
+    end)
+
+    log =
+      ExUnit.CaptureLog.capture_log(fn ->
+        assert AlternateManifests.list("foo", "bar", "1.0.0", cache_name: cache_name) == []
+        assert AlternateManifests.list("foo", "bar", "1.0.0", cache_name: cache_name) == []
+      end)
+
+    assert log =~ "Failed to fetch default manifest"
+  end
+
   test "returns empty list and logs warning when S3 raises", %{cache_name: cache_name} do
     expect(ExAws.S3, :list_objects_v2, fn "test-bucket", _opts ->
       %S3{bucket: "test-bucket", path: "list"}

--- a/cache/test/cache/registry/alternate_manifests_test.exs
+++ b/cache/test/cache/registry/alternate_manifests_test.exs
@@ -36,13 +36,14 @@ defmodule Cache.Registry.AlternateManifestsTest do
       ]
     end)
 
-    expect(ExAws.S3, :get_object, 3, fn "test-bucket", key ->
+    expect(ExAws.S3, :get_object, 4, fn "test-bucket", key ->
       %S3{bucket: "test-bucket", path: key}
     end)
 
-    expect(ExAws, :request, 3, fn %S3{path: path} ->
+    expect(ExAws, :request, 4, fn %S3{path: path} ->
       tools_version =
         cond do
+          String.ends_with?(path, "/Package.swift") -> "5.7"
           String.ends_with?(path, "/Package@swift-4.2.swift") -> "4.2"
           String.ends_with?(path, "/Package@swift-5.0.swift") -> "5.0"
           String.ends_with?(path, "/Package@swift-5.3.swift") -> "5.3"
@@ -57,6 +58,45 @@ defmodule Cache.Registry.AlternateManifestsTest do
              %{"swift_version" => "4.2", "swift_tools_version" => "4.2"},
              %{"swift_version" => "5.0", "swift_tools_version" => "5.0"},
              %{"swift_version" => "5.3", "swift_tools_version" => "5.3"}
+           ]
+  end
+
+  test "omits alternates whose tools version matches the root manifest",
+       %{cache_name: cache_name} do
+    scope = "pointfreeco"
+    name = "swift-snapshot-testing"
+    version = "1.18.7"
+
+    expect(ExAws.S3, :list_objects_v2, fn "test-bucket", opts ->
+      assert Keyword.get(opts, :prefix) == "registry/swift/#{scope}/#{name}/#{version}/"
+      %S3{bucket: "test-bucket", path: "list"}
+    end)
+
+    expect(ExAws, :stream!, fn %S3{path: "list"} ->
+      [
+        %{key: "registry/swift/#{scope}/#{name}/#{version}/Package.swift"},
+        %{key: "registry/swift/#{scope}/#{name}/#{version}/Package@swift-6.0.swift"},
+        %{key: "registry/swift/#{scope}/#{name}/#{version}/Package@swift-5.9.swift"}
+      ]
+    end)
+
+    expect(ExAws.S3, :get_object, 3, fn "test-bucket", key ->
+      %S3{bucket: "test-bucket", path: key}
+    end)
+
+    expect(ExAws, :request, 3, fn %S3{path: path} ->
+      tools_version =
+        cond do
+          String.ends_with?(path, "/Package.swift") -> "6.0"
+          String.ends_with?(path, "/Package@swift-6.0.swift") -> "6.0"
+          String.ends_with?(path, "/Package@swift-5.9.swift") -> "5.9"
+        end
+
+      {:ok, %{body: "// swift-tools-version:#{tools_version}\n"}}
+    end)
+
+    assert AlternateManifests.list(scope, name, version, cache_name: cache_name) == [
+             %{"swift_version" => "5.9", "swift_tools_version" => "5.9"}
            ]
   end
 

--- a/cache/test/cache/registry/manifest_variants_test.exs
+++ b/cache/test/cache/registry/manifest_variants_test.exs
@@ -1,0 +1,59 @@
+defmodule Cache.Registry.ManifestVariantsTest do
+  use ExUnit.Case, async: true
+
+  alias Cache.Registry.ManifestVariants
+
+  test "parses alternate manifest filenames" do
+    assert ManifestVariants.alternate_manifest?("Package@swift-6.swift")
+    assert ManifestVariants.alternate_manifest?("Package@swift-6.0.swift")
+    assert ManifestVariants.alternate_manifest?("Package@swift-6.0.0.swift")
+
+    assert ManifestVariants.filename_swift_version("Package@swift-6.swift") == "6"
+    assert ManifestVariants.filename_swift_version("Package@swift-6.0.swift") == "6.0"
+    assert ManifestVariants.filename_swift_version("Package@swift-6.0.0.swift") == "6.0.0"
+    assert ManifestVariants.filename_swift_version("Package.swift") == nil
+  end
+
+  test "drops alternates whose tools version canonicalizes to the default manifest" do
+    assert ManifestVariants.linkable_alternates([
+             %{"swift_version" => nil, "swift_tools_version" => "6.0"},
+             %{"swift_version" => "6.0.0", "swift_tools_version" => "6.0.0"},
+             %{"swift_version" => "5.9", "swift_tools_version" => "5.9"}
+           ]) == [
+             %{"swift_version" => "5.9", "swift_tools_version" => "5.9"}
+           ]
+
+    assert ManifestVariants.linkable_alternates([
+             %{"swift_version" => nil, "swift_tools_version" => "6"},
+             %{"swift_version" => "6.0.0", "swift_tools_version" => "6.0.0"}
+           ]) == []
+  end
+
+  test "keeps the first alternate when alternates canonicalize to the same tools version" do
+    first_swift_six_manifest = %{"swift_version" => "6", "swift_tools_version" => "6"}
+
+    assert ManifestVariants.linkable_alternates([
+             first_swift_six_manifest,
+             %{"swift_version" => "6.0", "swift_tools_version" => "6.0"},
+             %{"swift_version" => "6.0.0", "swift_tools_version" => "6.0.0"},
+             %{"swift_version" => "5.9", "swift_tools_version" => "5.9"}
+           ]) == [
+             first_swift_six_manifest,
+             %{"swift_version" => "5.9", "swift_tools_version" => "5.9"}
+           ]
+  end
+
+  test "preserves alternates when tools versions are missing or malformed" do
+    missing_tools_version = %{"swift_version" => "5.10", "swift_tools_version" => nil}
+    malformed_tools_version = %{"swift_version" => "6.0-beta", "swift_tools_version" => "6.0.0-beta"}
+
+    assert ManifestVariants.linkable_alternates([
+             %{"swift_version" => nil, "swift_tools_version" => "6.0"},
+             missing_tools_version,
+             malformed_tools_version
+           ]) == [
+             missing_tools_version,
+             malformed_tools_version
+           ]
+  end
+end

--- a/cache/test/cache/registry/release_worker_test.exs
+++ b/cache/test/cache/registry/release_worker_test.exs
@@ -486,6 +486,89 @@ defmodule Cache.Registry.ReleaseWorkerTest do
              })
   end
 
+  test "omits duplicate alternate manifests from metadata when tools versions match" do
+    default_manifest = "// swift-tools-version:6.0\nimport PackageDescription"
+    alternate_manifest = "// swift-tools-version:6.0\nimport PackageDescription"
+
+    expect(Lock, :try_acquire, fn {:release, "pointfreeco", "swift-snapshot-testing", "1.18.7"}, _ ->
+      {:ok, :acquired}
+    end)
+
+    expect(Metadata, :get_package, fn "pointfreeco", "swift-snapshot-testing", [fresh: true] ->
+      {:error, :not_found}
+    end)
+
+    expect(TuistCommon.GitHub, :download_zipball, fn "pointfreeco/swift-snapshot-testing",
+                                                     "token",
+                                                     "1.18.7",
+                                                     archive_path,
+                                                     _ ->
+      write_basic_zipball(archive_path)
+      :ok
+    end)
+
+    expect(Upload, :stream_file, fn path ->
+      assert File.exists?(path)
+      [File.read!(path)]
+    end)
+
+    expect(ExAws.S3, :upload, fn _stream, _bucket, _key, _opts ->
+      %S3{http_method: :put, bucket: "test", path: "key"}
+    end)
+
+    expect(ExAws, :request, 3, fn _op -> {:ok, %{status_code: 200, body: ""}} end)
+
+    expect(TuistCommon.GitHub, :list_repository_contents, fn "pointfreeco/swift-snapshot-testing",
+                                                             "token",
+                                                             "1.18.7",
+                                                             _ ->
+      {:ok,
+       [
+         %{"path" => "Package.swift", "type" => "file"},
+         %{"path" => "Package@swift-6.0.swift", "type" => "file"}
+       ]}
+    end)
+
+    expect(TuistCommon.GitHub, :get_file_content, 3, fn
+      "pointfreeco/swift-snapshot-testing", "token", ".gitmodules", "1.18.7", _ ->
+        {:error, :not_found}
+
+      "pointfreeco/swift-snapshot-testing", "token", "Package.swift", "1.18.7", _ ->
+        {:ok, default_manifest}
+
+      "pointfreeco/swift-snapshot-testing", "token", "Package@swift-6.0.swift", "1.18.7", _ ->
+        {:ok, alternate_manifest}
+    end)
+
+    expect(Lock, :try_acquire, fn {:package, "pointfreeco", "swift-snapshot-testing"}, _ ->
+      {:ok, :acquired}
+    end)
+
+    expect(Metadata, :get_package, fn "pointfreeco", "swift-snapshot-testing", [fresh: true] ->
+      {:error, :not_found}
+    end)
+
+    expect(Metadata, :put_package, fn "pointfreeco", "swift-snapshot-testing", metadata ->
+      release = metadata["releases"]["1.18.7"]
+
+      assert release["manifests"] == [
+               %{"swift_version" => nil, "swift_tools_version" => "6.0"}
+             ]
+
+      :ok
+    end)
+
+    assert :ok =
+             ReleaseWorker.perform(%Oban.Job{
+               args: %{
+                 "scope" => "pointfreeco",
+                 "name" => "swift-snapshot-testing",
+                 "repository_full_handle" => "pointfreeco/swift-snapshot-testing",
+                 "tag" => "1.18.7"
+               }
+             })
+  end
+
   test "marks releases without root manifests as skipped" do
     expect(Lock, :try_acquire, 2, fn
       {:release, "newrelic", "newrelic-ios-agent-spm", "7.0.0"}, _ -> {:ok, :acquired}

--- a/cache/test/cache_web/controllers/registry_controller_test.exs
+++ b/cache/test/cache_web/controllers/registry_controller_test.exs
@@ -923,6 +923,42 @@ defmodule CacheWeb.RegistryControllerTest do
       assert link_header =~ "swift-version=5.9"
     end
 
+    test "omits alternate link when its tools version matches the default manifest", %{conn: conn} do
+      scope = "pointfreeco"
+      name = "swift-snapshot-testing"
+      version = "1.18.7"
+
+      metadata = %{
+        "scope" => scope,
+        "name" => name,
+        "releases" => %{
+          version => %{
+            "checksum" => "abc123",
+            "manifests" => [
+              %{"swift_version" => nil, "swift_tools_version" => "6.0"},
+              %{"swift_version" => "6.0", "swift_tools_version" => "6.0"}
+            ]
+          }
+        }
+      }
+
+      expect(Registry.Disk, :exists?, fn ^scope, ^name, ^version, "Package.swift" -> true end)
+
+      expect(Registry.Disk, :local_accel_path, fn ^scope, ^name, ^version, "Package.swift" ->
+        "/internal/local/registry/swift/pointfreeco/swift-snapshot-testing/1.18.7/Package.swift"
+      end)
+
+      expect(Metadata, :get_package, fn ^scope, ^name -> {:ok, metadata} end)
+
+      conn =
+        conn
+        |> registry_swift_conn()
+        |> get("/api/registry/swift/#{scope}/#{name}/#{version}/Package.swift")
+
+      assert conn.status == 200
+      assert get_resp_header(conn, "link") == []
+    end
+
     test "serves two-component manifest from disk when three-component swift-version is requested", %{conn: conn} do
       scope = "pointfreeco"
       name = "swift-custom-dump"


### PR DESCRIPTION
## Summary

This fixes a SwiftPM registry-resolution failure that could block fresh worktrees before the CLI workspace could even be generated.

The change makes the cache registry treat Swift package manifest variants by their canonical Swift tools version instead of only by their filename. When a package has both a default `Package.swift` manifest and an alternate `Package@swift-X.Y.swift` manifest that resolve to the same Swift tools version, the registry now keeps the default manifest and stops advertising or persisting the redundant alternate.

## Motivation

New Codex worktrees were repeatedly getting stuck in this sequence:

1. A focused CLI build or Xcode test needs the generated workspace.
2. `tuist generate tuist ProjectDescription --no-open` fails because external dependencies have not been installed yet.
3. `tuist install` delegates to SwiftPM registry resolution with `--replace-scm-with-registry`.
4. SwiftPM aborts while resolving registry metadata with errors like:

```text
duplicate key found: 'Package@swift-5.5.0.swift'
duplicate key found: 'Package@swift-6.0.0.swift'
```

I reproduced the failure locally while trying to build the CLI. One concrete case was `pointfreeco.swift-snapshot-testing`, where SwiftPM failed with `duplicate key found: 'Package@swift-6.0.0.swift'`. A similar failure showed up earlier for `swiftlang.swift-docc-symbolkit` with `Package@swift-5.5.0.swift`.

This was especially frustrating because the error happens before the CLI code is compiled or tested. It makes agents report that they cannot run focused tests because the worktree cannot get past dependency resolution.

## Root Cause

The registry was returning alternate manifest links based on the manifest filenames in metadata or S3:

```text
Package.swift
Package@swift-6.0.swift
```

That is valid only if the alternate manifest represents a distinct Swift tools version. Some packages, however, publish an alternate manifest whose declared tools version is equivalent to the default manifest after SwiftPM canonicalization.

For `pointfreeco/swift-snapshot-testing`, the default manifest and `Package@swift-6.0.swift` both declare Swift tools version `6.0`. Newer SwiftPM/Xcode canonicalizes that to a three-component key such as `6.0.0`, so the two manifests collide internally as:

```text
Package@swift-6.0.0.swift
```

The archive itself does not need to contain two literal `Package@swift-6.0.0.swift` files. The duplicate is created by SwiftPM while normalizing equivalent manifest versions from the registry response.

## Approach

I added `Cache.Registry.ManifestVariants` as the single place that understands package manifest variants:

- parses alternate filenames such as `Package@swift-5.9.swift`
- parses `// swift-tools-version:` declarations
- canonicalizes tools versions to `major.minor.patch`
- filters alternates whose canonical tools version matches the default `Package.swift`
- filters duplicate alternates that canonicalize to the same tools version

That logic is applied in three places:

- `RegistryController` uses it before generating `Link` headers for alternate manifests. This fixes the active registry response path that SwiftPM consumes.
- `ReleaseWorker` uses it before persisting release manifest metadata. This prevents newly indexed packages from storing redundant manifest variants.
- `AlternateManifests` uses it in the S3 fallback path. When metadata is missing or stale, fallback discovery now reads the root manifest alongside alternates so it can make the same canonical-version decision.

Unknown or unparsable tools versions are still preserved. The filter only drops an alternate when it can prove that the canonical tools version was already represented by the default manifest or by an earlier alternate.

## Alternatives Considered

I considered treating this as a CLI/worktree issue and relying on `tuist install --force-resolved-versions`, which did unblock this one local checkout. That is only a workaround: fresh worktrees without a usable resolved file still hit the registry response and fail before generation or testing.

I also considered suppressing all alternate manifests. That would be too broad because alternate manifests are still useful for packages that genuinely need different manifests across Swift tools versions.

Exact filename de-duplication was not enough either. The observed failures are caused by SwiftPM canonicalization, so `6`, `6.0`, and `6.0.0` need to be compared as the same tools version.

## Impact

After this cache service change is deployed, fresh worktrees should be able to run `tuist install`, generate the CLI workspace, and run focused CLI builds/tests without hitting this duplicate-manifest SwiftPM failure.

The change is intentionally cache-side rather than CLI-side because the registry is the source of the invalid manifest variant set. Fixing the response also helps every SwiftPM client that resolves through the Tuist registry, not just Codex worktrees.

## Validation

I validated the cache change with focused tests:

```sh
mix test test/cache/registry/alternate_manifests_test.exs test/cache/registry/release_worker_test.exs test/cache_web/controllers/registry_controller_test.exs
```

Result:

```text
89 tests, 0 failures
```

I also formatted the touched cache files:

```sh
mix format lib/cache/registry/manifest_variants.ex lib/cache/registry/alternate_manifests.ex lib/cache/registry/release_worker.ex lib/cache_web/controllers/registry_controller.ex test/cache/registry/alternate_manifests_test.exs test/cache/registry/release_worker_test.exs test/cache_web/controllers/registry_controller_test.exs
```

Finally, I verified the original developer workflow after unblocking this local checkout with the resolved-file workaround that is needed until the live cache service is deployed:

```sh
tuist generate tuist ProjectDescription --no-open
xcodebuild build -workspace Tuist.xcworkspace -scheme tuist CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""
```

Result:

```text
** BUILD SUCCEEDED ** [422.510 sec]
```
