### PR TITLE
fix(cli): show scheme test configuration in build runs

### DIFF
--- a/cli/Sources/TuistKit/Services/TestService.swift
+++ b/cli/Sources/TuistKit/Services/TestService.swift
@@ -1658,7 +1658,7 @@ public struct TestService { // swiftlint:disable:this type_body_length
                 projectPath: graphTraverser.workspace.xcWorkspacePath,
                 config: config,
                 scheme: scheme.name,
-                configuration: configuration
+                configuration: configuration ?? scheme.testAction?.configurationName
             )
             let summary = mode == .local
                 ? await testSummary(resultBundlePath: resultBundlePath, quarantinedTests: quarantinedTests)
@@ -1681,7 +1681,7 @@ public struct TestService { // swiftlint:disable:this type_body_length
             projectPath: graphTraverser.workspace.xcWorkspacePath,
             config: config,
             scheme: scheme.name,
-            configuration: configuration
+            configuration: configuration ?? scheme.testAction?.configurationName
         )
         let summary = mode == .local
             ? await testSummary(resultBundlePath: resultBundlePath, quarantinedTests: quarantinedTests)

--- a/cli/Tests/TuistKitTests/Services/TestServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/TestServiceTests.swift
@@ -803,7 +803,8 @@ final class TestServiceTests: TuistUnitTestCase {
             testAction: .test(
                 targets: [
                     .test(target: TargetReference(projectPath: projectPath, name: "AppTests")),
-                ]
+                ],
+                configurationName: "App Debug"
             )
         )
 
@@ -889,7 +890,7 @@ final class TestServiceTests: TuistUnitTestCase {
                 projectPath: .any,
                 config: .any,
                 scheme: .any,
-                configuration: .any
+                configuration: .value("App Debug")
             )
             .called(1)
     }


### PR DESCRIPTION
## What changed

- Use the scheme test-action configuration when uploading `tuist test` build runs and no explicit CLI `--configuration` was provided.
- Keep the explicit CLI configuration as the highest-priority value when it is present.
- Update the focused `TestService` test to assert that the uploaded build-run metadata receives the scheme configuration.

## Why

`tuist test` can run with a concrete configuration from the selected scheme even when the user does not pass `--configuration`. The build-run upload path only forwarded the CLI argument, so those runs were uploaded with a nil configuration and the Build Runs UI displayed `Unknown`.

## Root cause

The test service already had access to the resolved scheme, including `scheme.testAction?.configurationName`, but `uploadBuildRunIfNeeded` was called with only the optional CLI `configuration` argument. When that argument was absent, the metadata upload lost the scheme configuration.

## Approach

The upload call now falls back from the CLI configuration to `scheme.testAction?.configurationName`. This keeps command-line overrides intact while preserving the scheme default for build-run metadata.

## Impact

Build Runs created by `tuist test` should show the scheme test configuration more consistently instead of `Unknown` when the configuration comes from the scheme.

## Validation

- Ran `git diff --check`.
- Ran `xcsiftbuild test -workspace Tuist.xcworkspace -scheme Tuist-Workspace -only-testing TuistKitTests/TestServiceTests/test_run_uploads_build_run_using_passthrough_derived_data_path CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" COMPILATION_CACHE_ENABLE_CACHING=NO` — 1 passed, 0 failed.
