### PR TITLE
fix(stable-egress-controller): stop hammering the Hetzner API on node heartbeats

### DIFF
--- a/infra/stable-egress-controller/AGENTS.md
+++ b/infra/stable-egress-controller/AGENTS.md
@@ -61,7 +61,7 @@ The Deployment + RBAC are rendered by the platform Helm chart
 | `--candidate-label` | `tuist.dev/stable-egress-candidate=server` | egress candidate pool selector |
 | `--active-label` | `tuist.dev/stable-egress-gateway=server` | label placed on the single active node (Cilium + host-configurer select on it) |
 | `--hcloud-token-path` | `/etc/hcloud/token` | token file, mounted from `kube-system/hcloud` |
-| `--resync-interval` | `30s` | periodic reconcile; Node events trigger reconciles in between |
+| `--resync-interval` | `30s` | periodic reconcile floor; only Node events that change gateway eligibility (Ready transition, candidate/active label, termination) trigger reconciles in between — kubelet status heartbeats are filtered out so the per-reconcile Hetzner read stays well under the API rate limit |
 | `--leader-elect` | `true` | required when `replicas > 1` |
 
 ## Tests
@@ -72,8 +72,9 @@ go test ./...
 ```
 
 Covers `selectActive` (sticky / failover / lexical / none), `providerID`
-parsing, the egress-IP allowlist guard, and full reconcile (failover moves IP +
-label, stale cluster-wide labels are stripped, steady state is no-op) against
+parsing, the egress-IP allowlist guard, the Node event predicate (heartbeats
+dropped, eligibility changes let through), and full reconcile (failover moves IP
++ label, stale cluster-wide labels are stripped, steady state is no-op) against
 controller-runtime's fake client + a fake Floating IP manager.
 
 ## Releasing

--- a/infra/stable-egress-controller/controllers/failover.go
+++ b/infra/stable-egress-controller/controllers/failover.go
@@ -12,20 +12,24 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 // FloatingIPManager assigns a Hetzner Cloud Floating IP to a server. Kept as an
 // interface so the reconciler is testable without the Hetzner API.
 type FloatingIPManager interface {
-	// CurrentServerID returns the server id the Floating IP is currently
-	// assigned to, or 0 if it is unassigned.
-	CurrentServerID(ctx context.Context, floatingIPName string) (int64, error)
-	// Address returns the Floating IP's address (e.g. "116.202.0.10").
-	Address(ctx context.Context, floatingIPName string) (string, error)
+	// Get returns the Floating IP's address (e.g. "116.202.0.10") and the
+	// server id it is currently assigned to (0 if unassigned), read together in
+	// a single Hetzner API call. The reconciler runs on every relevant node
+	// event against a rate-limited token shared with cluster-api, so collapsing
+	// the per-reconcile reads to one call keeps it well under the budget.
+	Get(ctx context.Context, floatingIPName string) (address string, serverID int64, err error)
 	// Assign assigns the Floating IP to the given server id and waits for the
 	// assignment to take effect.
 	Assign(ctx context.Context, floatingIPName string, serverID int64) error
@@ -91,14 +95,18 @@ func (r *FailoverReconciler) Reconcile(ctx context.Context, _ reconcile.Request)
 		return ctrl.Result{}, fmt.Errorf("resolving server id for node %q: %w", desiredNode.Name, err)
 	}
 
+	// Read the Floating IP's address and current assignment in one API call:
+	// both the allowlist gate and the assignment check need it, and this read is
+	// the controller's hot path against a rate-limited, shared Hetzner token.
+	addr, currentServer, err := r.FIP.Get(ctx, r.FloatingIPName)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("reading Floating IP: %w", err)
+	}
+
 	// Fail closed if the Floating IP is not within the documented egress set —
 	// activating an un-allowlisted source IP would silently break customers
 	// who allowlist our egress. Better a gap than a leak.
 	if len(r.EgressIPAllowlist) > 0 {
-		addr, err := r.FIP.Address(ctx, r.FloatingIPName)
-		if err != nil {
-			return ctrl.Result{}, fmt.Errorf("reading Floating IP address: %w", err)
-		}
 		ok, err := ipInAllowlist(addr, r.EgressIPAllowlist)
 		if err != nil {
 			return ctrl.Result{}, err
@@ -112,10 +120,6 @@ func (r *FailoverReconciler) Reconcile(ctx context.Context, _ reconcile.Request)
 	}
 
 	// 1) Make the Floating IP follow the elected node (idempotent).
-	currentServer, err := r.FIP.CurrentServerID(ctx, r.FloatingIPName)
-	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("reading Floating IP assignment: %w", err)
-	}
 	if currentServer != serverID {
 		logger.Info("reassigning Floating IP", "floatingIP", r.FloatingIPName,
 			"fromServer", currentServer, "toServer", serverID, "node", desiredNode.Name)
@@ -176,8 +180,32 @@ func (r *FailoverReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	}
 	return ctrl.NewControllerManagedBy(mgr).
 		Named("stable-egress-failover").
-		Watches(&corev1.Node{}, handler.EnqueueRequestsFromMapFunc(mapToSingleton)).
+		Watches(&corev1.Node{},
+			handler.EnqueueRequestsFromMapFunc(mapToSingleton),
+			builder.WithPredicates(r.nodeEventPredicate())).
 		Complete(r)
+}
+
+// nodeEventPredicate drops the Node updates the reconciler does not key on —
+// chiefly the kubelet status heartbeats and lease renewals that fire every few
+// seconds per node — so a reconcile (and its Hetzner API read against a shared,
+// rate-limited token) only runs when gateway eligibility can actually change: a
+// Ready transition, a candidate/active label change, or the node entering
+// termination. Create, Delete, and Generic events always reconcile.
+func (r *FailoverReconciler) nodeEventPredicate() predicate.Predicate {
+	return predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			oldNode, ok1 := e.ObjectOld.(*corev1.Node)
+			newNode, ok2 := e.ObjectNew.(*corev1.Node)
+			if !ok1 || !ok2 {
+				return true
+			}
+			return isNodeReady(oldNode) != isNodeReady(newNode) ||
+				oldNode.Labels[r.CandidateLabelKey] != newNode.Labels[r.CandidateLabelKey] ||
+				oldNode.Labels[r.ActiveLabelKey] != newNode.Labels[r.ActiveLabelKey] ||
+				(oldNode.DeletionTimestamp == nil) != (newNode.DeletionTimestamp == nil)
+		},
+	}
 }
 
 // selectGateway picks the node that should hold the egress gateway. It adopts a

--- a/infra/stable-egress-controller/controllers/failover_test.go
+++ b/infra/stable-egress-controller/controllers/failover_test.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -77,8 +78,7 @@ type fakeFIP struct {
 	assigns   []int64
 }
 
-func (f *fakeFIP) CurrentServerID(context.Context, string) (int64, error) { return f.server, nil }
-func (f *fakeFIP) Address(context.Context, string) (string, error)        { return f.addr, nil }
+func (f *fakeFIP) Get(context.Context, string) (string, int64, error) { return f.addr, f.server, nil }
 func (f *fakeFIP) Assign(_ context.Context, _ string, serverID int64) error {
 	if f.assignErr != nil {
 		return f.assignErr
@@ -239,6 +239,77 @@ func TestReconcileStripsDeadNonCandidateLabelOnFailover(t *testing.T) {
 	}
 	if fip.server != 222 {
 		t.Fatalf("Floating IP on server %d, want 222", fip.server)
+	}
+}
+
+// The Node watch predicate must let through only the changes that affect
+// gateway selection, and drop the kubelet status heartbeats that otherwise
+// reconcile (and hit the Hetzner API) every few seconds per node.
+func TestNodeEventPredicate(t *testing.T) {
+	r := newReconciler(&fakeFIP{})
+	pred := r.nodeEventPredicate()
+
+	withHeartbeat := func(n *corev1.Node, beat string) *corev1.Node {
+		n = n.DeepCopy()
+		n.ResourceVersion = beat
+		for i := range n.Status.Conditions {
+			if n.Status.Conditions[i].Type == corev1.NodeReady {
+				n.Status.Conditions[i].LastHeartbeatTime = metav1.Now()
+			}
+		}
+		return n
+	}
+	withReady := func(n *corev1.Node, ready bool) *corev1.Node {
+		n = n.DeepCopy()
+		st := corev1.ConditionFalse
+		if ready {
+			st = corev1.ConditionTrue
+		}
+		n.Status.Conditions = []corev1.NodeCondition{{Type: corev1.NodeReady, Status: st}}
+		return n
+	}
+	withLabel := func(n *corev1.Node, k, v string) *corev1.Node {
+		n = n.DeepCopy()
+		if n.Labels == nil {
+			n.Labels = map[string]string{}
+		}
+		n.Labels[k] = v
+		return n
+	}
+	withDeletion := func(n *corev1.Node) *corev1.Node {
+		n = n.DeepCopy()
+		now := metav1.Now()
+		n.DeletionTimestamp = &now
+		return n
+	}
+
+	base := candidateNode("egress-a", "hcloud://111", true, false)
+
+	tests := []struct {
+		name     string
+		old, new *corev1.Node
+		want     bool
+	}{
+		{"heartbeat-only update is dropped", base, withHeartbeat(base, "2"), false},
+		{"ready transition reconciles", base, withReady(base, false), true},
+		{"candidate label change reconciles", base, withLabel(base, candKey, "other"), true},
+		{"active label added reconciles", base, withLabel(base, actKey, actVal), true},
+		{"deletion timestamp reconciles", base, withDeletion(base), true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := pred.Update(event.UpdateEvent{ObjectOld: tt.old, ObjectNew: tt.new})
+			if got != tt.want {
+				t.Fatalf("predicate.Update = %v, want %v", got, tt.want)
+			}
+		})
+	}
+
+	if !pred.Create(event.CreateEvent{Object: base}) {
+		t.Fatal("Create events must reconcile")
+	}
+	if !pred.Delete(event.DeleteEvent{Object: base}) {
+		t.Fatal("Delete events must reconcile")
 	}
 }
 

--- a/infra/stable-egress-controller/internal/hcloud/client.go
+++ b/infra/stable-egress-controller/internal/hcloud/client.go
@@ -18,23 +18,15 @@ func New(token string) *Manager {
 	return &Manager{client: hcloud.NewClient(hcloud.WithToken(token))}
 }
 
-func (m *Manager) CurrentServerID(ctx context.Context, floatingIPName string) (int64, error) {
+func (m *Manager) Get(ctx context.Context, floatingIPName string) (address string, serverID int64, err error) {
 	fip, err := m.lookup(ctx, floatingIPName)
 	if err != nil {
-		return 0, err
+		return "", 0, err
 	}
-	if fip.Server == nil {
-		return 0, nil
+	if fip.Server != nil {
+		serverID = fip.Server.ID
 	}
-	return fip.Server.ID, nil
-}
-
-func (m *Manager) Address(ctx context.Context, floatingIPName string) (string, error) {
-	fip, err := m.lookup(ctx, floatingIPName)
-	if err != nil {
-		return "", err
-	}
-	return fip.IP.String(), nil
+	return fip.IP.String(), serverID, nil
 }
 
 func (m *Manager) Assign(ctx context.Context, floatingIPName string, serverID int64) error {


### PR DESCRIPTION
## What

Cuts the stable-egress failover controller's Hetzner Cloud API call rate by ~20x in steady state, via two changes in `infra/stable-egress-controller`:

1. **Coalesce the per-reconcile reads.** Each reconcile made two `FloatingIP.GetByName` calls — one for `Address` (allowlist gate) and one for `CurrentServerID` (assignment check). The `FloatingIPManager` interface now exposes a single `Get` that returns both the address and the current server id from one lookup; the reconciler reads the IP once and uses it for both.
2. **Filter the Node watch.** The controller watched `corev1.Node` and funneled *every* event to a reconcile. A new event predicate drops the updates that can't change gateway eligibility — chiefly the kubelet status heartbeats and lease renewals that fire every few seconds per node — and only lets through Ready transitions, candidate/active label changes, and node termination. Create/Delete/Generic events still always reconcile.

## Why

During this Sunday's tuist.dev scare I was checking the egress path (the June 14 outage's root cause) and found the controller logs full of:

```
Reconciler error ... looking up Floating IP "tuist-production-server-egress":
Limit of '3600' requests per hour for token '...' reached. (rate_limit_exceeded)
```

### Root cause

The controller reconciled every ~2-3s (visible in the logs), far above its 30s resync floor, because the `Watches(&corev1.Node{})` source enqueued a reconcile on every node event — and in a fleet of Mac minis, runners, and workers, kubelet status/lease heartbeats are near-constant. At **2** `GetByName` calls per reconcile that's ~2,880 calls/hr from this controller alone, and the `hcloud` token is **shared with cluster-api** (caph node lifecycle). Together they exceed Hetzner's 3,600 req/hr cap.

### Impact

- In steady state it's just log noise — reconciles are idempotent and the IP stays put.
- The real risk: if a gateway node dies while the controller is in a rate-limited window, the `FloatingIP.Assign` failover call can stall or fail, **prolonging an egress gap** — the exact failure mode (no stable egress → server can't reach Keygen → CrashLoopBackOff → 503) that took prod down on June 14.
- It also burns the shared Hetzner token budget that caph needs for node provisioning/autoscaling.

### Why this approach

The two reads were trivially mergeable (the Hetzner `FloatingIP` object already carries both the address and the assigned server), so coalescing is free. The bigger lever is the watch predicate: node heartbeats carry no information the election keys on, so filtering them removes the dominant trigger without weakening failover — a node going NotReady still flips its Ready condition (caught by the predicate), and deletions still always reconcile. Lowering the resync interval would have been the blunt alternative, but it doesn't fix event-driven churn and trades away the gap-detection floor.

## Effect

Steady-state Hetzner reads drop from ~2,880/hr to ~120/hr (one read per 30s resync), with meaningful node events reconciling on top. Well under the shared 3,600/hr cap.

## Validation

- `go build ./... && go vet ./...` — clean.
- `go test ./...` — all pass, including a new `TestNodeEventPredicate` (heartbeat-only update dropped; Ready transition, candidate/active label change, and termination let through; Create/Delete always reconcile) and the existing reconcile/failover/allowlist suite updated for the `Get` interface.
- `gofmt -l` — clean.

No production change is applied by this PR. The deployed image tag is resolved at deploy time from the highest `stable-egress-controller@<semver>` reachable from the merged commit, so this ships on the next `stable-egress-controller@…` release once merged. Filed as a draft for review.

## Note (separate, not addressed here)

The thing that actually made tuist.dev look "down" this time was **not** an outage — production was 5/5 healthy throughout. It was stale client-side browser state (clearing storage / incognito fixed it); the site loaded fine on mobile and from CI. The `AGENTS.md` "Future work" item about alerting when no Ready candidate exists is still worth doing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
