### PR TITLE
fix(server): process runs with project account

### DIFF
--- a/server/lib/tuist_web/controllers/api/builds_controller.ex
+++ b/server/lib/tuist_web/controllers/api/builds_controller.ex
@@ -14,7 +14,6 @@ defmodule TuistWeb.API.BuildsController do
   alias TuistWeb.API.Schemas.Builds.Build
   alias TuistWeb.API.Schemas.Error
   alias TuistWeb.API.Schemas.PaginationMetadata
-  alias TuistWeb.Authentication
 
   plug(TuistWeb.Plugs.CastAndValidate,
     json_render_error_v2: true,
@@ -850,12 +849,10 @@ defmodule TuistWeb.API.BuildsController do
   )
 
   def create(%{assigns: %{selected_project: selected_project}, body_params: body_params} = conn, _params) do
-    account = Authentication.authenticated_subject_account(conn)
-
     run_params =
       body_params
       |> Map.put(:project, selected_project)
-      |> Map.put(:account, account)
+      |> Map.put(:account, selected_project.account)
 
     {:ok, build} = get_or_create_build(run_params)
 

--- a/server/lib/tuist_web/controllers/api/tests_controller.ex
+++ b/server/lib/tuist_web/controllers/api/tests_controller.ex
@@ -9,7 +9,6 @@ defmodule TuistWeb.API.TestsController do
   alias TuistWeb.API.Schemas.Error
   alias TuistWeb.API.Schemas.PaginationMetadata
   alias TuistWeb.API.Schemas.Tests.Test
-  alias TuistWeb.Authentication
 
   plug(TuistWeb.Plugs.CastAndValidate,
     json_render_error_v2: true,
@@ -521,7 +520,7 @@ defmodule TuistWeb.API.TestsController do
     run_params =
       body_params
       |> Map.put(:project, selected_project)
-      |> Map.put(:account, Authentication.authenticated_subject_account(conn))
+      |> Map.put(:account, selected_project.account)
 
     case get_or_create_test(run_params) do
       {:ok, test_run} ->

--- a/server/test/tuist_web/controllers/api/builds_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/builds_controller_test.exs
@@ -3,6 +3,8 @@ defmodule TuistWeb.API.BuildsControllerTest do
   use Mimic
 
   alias Tuist.Builds
+  alias Tuist.Builds.Build
+  alias Tuist.Builds.Workers.ProcessBuildWorker
   alias Tuist.Storage
   alias TuistTestSupport.Fixtures.AccountsFixtures
   alias TuistTestSupport.Fixtures.ProjectsFixtures
@@ -487,7 +489,7 @@ defmodule TuistWeb.API.BuildsControllerTest do
 
       stub(Builds, :create_build, fn _attrs ->
         {:ok,
-         %Tuist.Builds.Build{
+         %Build{
            id: build_id,
            status: "success",
            duration: 1000,
@@ -508,6 +510,50 @@ defmodule TuistWeb.API.BuildsControllerTest do
 
       response = json_response(conn, 200)
       assert response["id"] == build_id
+    end
+
+    test "enqueues processing with the project account for organization projects", %{conn: conn} do
+      user = AccountsFixtures.user_fixture(preload: [:account])
+      organization = AccountsFixtures.organization_fixture(creator: user, preload: [:account])
+      project = ProjectsFixtures.project_fixture(account_id: organization.account.id)
+      conn = Authentication.put_current_user(conn, user)
+      build_id = UUIDv7.generate()
+
+      stub(Builds, :get_build, fn _id, _opts -> {:error, :not_found} end)
+
+      stub(Builds, :create_build, fn attrs ->
+        assert attrs.account_id == organization.account.id
+
+        {:ok,
+         %Build{
+           id: build_id,
+           status: "processing",
+           duration: 0,
+           project_id: project.id,
+           account_id: attrs.account_id,
+           project: %{project | account: organization.account}
+         }}
+      end)
+
+      conn =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> post("/api/projects/#{organization.account.name}/#{project.name}/builds", %{
+          id: build_id,
+          status: "processing",
+          is_ci: false
+        })
+
+      assert json_response(conn, 200)
+
+      assert_enqueued(
+        worker: ProcessBuildWorker,
+        args: %{
+          "build_id" => build_id,
+          "account_id" => organization.account.id,
+          "storage_key" => "#{organization.account.name}/#{project.name}/builds/#{build_id}/build.zip"
+        }
+      )
     end
   end
 

--- a/server/test/tuist_web/controllers/api/tests_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/tests_controller_test.exs
@@ -709,6 +709,57 @@ defmodule TuistWeb.API.TestsControllerTest do
       )
     end
 
+    test "enqueues processing with the project account for organization projects", %{conn: conn} do
+      user = AccountsFixtures.user_fixture(preload: [:account])
+      organization = AccountsFixtures.organization_fixture(creator: user, preload: [:account])
+      project = ProjectsFixtures.project_fixture(account_id: organization.account.id)
+      conn = Authentication.put_current_user(conn, user)
+      test_run_id = UUIDv7.generate()
+
+      expect(Tests, :get_test, fn _id, _opts -> {:error, :not_found} end)
+
+      expect(Tests, :create_test, fn attrs ->
+        assert attrs.account_id == organization.account.id
+
+        {:ok,
+         %Test{
+           id: attrs.id,
+           duration: attrs.duration,
+           project_id: project.id,
+           account_id: attrs.account_id,
+           is_ci: false,
+           build_system: "xcode",
+           status: "processing",
+           test_case_runs: []
+         }}
+      end)
+
+      conn =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> post(
+          "/api/projects/#{organization.account.name}/#{project.name}/tests",
+          %{
+            id: test_run_id,
+            duration: 0,
+            is_ci: false,
+            status: "processing",
+            test_modules: []
+          }
+        )
+
+      assert json_response(conn, 200)
+
+      assert_enqueued(
+        worker: ProcessXcresultWorker,
+        args: %{
+          "test_run_id" => test_run_id,
+          "account_id" => organization.account.id,
+          "storage_key" => "#{organization.account.name}/#{project.name}/runs/#{test_run_id}/result_bundle.zip"
+        }
+      )
+    end
+
     test "uses the request body id (not the merged run id) for storage_key on sharded runs", %{
       conn: conn,
       user: user,


### PR DESCRIPTION
## What

This changes the build and test run creation endpoints to attach the selected project's account to the run params instead of the authenticated user's account. It also adds regression coverage for organization-owned projects so the processing workers are enqueued with the organization account and the storage key under that organization/project namespace.

## Why

The upload routes already resolve storage through the selected project's account. The create/enqueue path needs to preserve that same account context so server-side processing reads artifacts from the same storage backend that received them.

## Root Cause

For organization projects, the authenticated subject can be a user whose personal account differs from the project's owning account. The build/test create endpoints were using that authenticated subject account when creating the run params.

That account id then flowed into processing worker args, which meant workers could resolve storage through the wrong account backend even though the artifacts had been uploaded through the project owner's storage backend.

## Approach

Both create endpoints now use `selected_project.account`, matching the upload routes and keeping the account context consistent from upload through processing. The regression tests simulate a user creating processing runs for an organization-owned project and assert that both the create attrs and worker args use the organization account.

## Impact

New build and test runs for organization projects with account-specific storage should process against the same account-backed storage where their artifacts were uploaded. Existing failed-processing runs may still need a retry or requeue after deploy.

## Validation

- Ran `mix format` on the touched files.
- Ran focused controller coverage:
  - `mix test test/tuist_web/controllers/api/builds_controller_test.exs test/tuist_web/controllers/api/tests_controller_test.exs`
  - Result: `46 tests, 0 failures`
