### PR TITLE
fix(cli): show verbose flag in inspect help

### DIFF
--- a/cli/Sources/TuistInspectCommand/Commands/InspectBuildCommand.swift
+++ b/cli/Sources/TuistInspectCommand/Commands/InspectBuildCommand.swift
@@ -12,6 +12,9 @@
             )
         }
 
+        @OptionGroup
+        var loggingOptions: LoggingOptions
+
         @Option(
             name: .shortAndLong,
             help: "The path to the directory that contains the project to inspect the latest build for.",

--- a/cli/Sources/TuistInspectCommand/Commands/InspectBuildCommand.swift
+++ b/cli/Sources/TuistInspectCommand/Commands/InspectBuildCommand.swift
@@ -12,9 +12,6 @@
             )
         }
 
-        @OptionGroup
-        var loggingOptions: LoggingOptions
-
         @Option(
             name: .shortAndLong,
             help: "The path to the directory that contains the project to inspect the latest build for.",
@@ -30,6 +27,9 @@
             envKey: .inspectBuildDerivedDataPath
         )
         var derivedDataPath: String?
+
+        @OptionGroup
+        var loggingOptions: LoggingOptions
 
         var jsonThroughNoora: Bool = false
 

--- a/cli/Sources/TuistInspectCommand/Commands/InspectBundleCommand.swift
+++ b/cli/Sources/TuistInspectCommand/Commands/InspectBundleCommand.swift
@@ -18,9 +18,6 @@ public struct InspectBundleCommand: AsyncParsableCommand {
         )
     }
 
-    @OptionGroup
-    var loggingOptions: LoggingOptions
-
     @Argument(
         help: "The path to the bundle, or the name of an app for Apple platforms to resolve from Xcode build products.",
         completion: .directory,
@@ -64,6 +61,9 @@ public struct InspectBundleCommand: AsyncParsableCommand {
         envKey: .inspectBundlePath
     )
     var path: String?
+
+    @OptionGroup
+    var loggingOptions: LoggingOptions
 
     public func run() async throws {
         #if os(macOS)

--- a/cli/Sources/TuistInspectCommand/Commands/InspectBundleCommand.swift
+++ b/cli/Sources/TuistInspectCommand/Commands/InspectBundleCommand.swift
@@ -18,6 +18,9 @@ public struct InspectBundleCommand: AsyncParsableCommand {
         )
     }
 
+    @OptionGroup
+    var loggingOptions: LoggingOptions
+
     @Argument(
         help: "The path to the bundle, or the name of an app for Apple platforms to resolve from Xcode build products.",
         completion: .directory,

--- a/cli/Sources/TuistInspectCommand/Commands/InspectCommand.swift
+++ b/cli/Sources/TuistInspectCommand/Commands/InspectCommand.swift
@@ -3,6 +3,9 @@ import ArgumentParser
 public struct InspectCommand: AsyncParsableCommand {
     public init() {}
 
+    @OptionGroup
+    var loggingOptions: LoggingOptions
+
     public static var configuration: CommandConfiguration {
         var subcommands: [ParsableCommand.Type] = [
             InspectBundleCommand.self,

--- a/cli/Sources/TuistInspectCommand/Commands/InspectDependenciesCommand.swift
+++ b/cli/Sources/TuistInspectCommand/Commands/InspectDependenciesCommand.swift
@@ -11,6 +11,9 @@
             )
         }
 
+        @OptionGroup
+        var loggingOptions: LoggingOptions
+
         @Option(
             name: .shortAndLong,
             help: "The path to the directory that contains the project.",

--- a/cli/Sources/TuistInspectCommand/Commands/InspectDependenciesCommand.swift
+++ b/cli/Sources/TuistInspectCommand/Commands/InspectDependenciesCommand.swift
@@ -11,9 +11,6 @@
             )
         }
 
-        @OptionGroup
-        var loggingOptions: LoggingOptions
-
         @Option(
             name: .shortAndLong,
             help: "The path to the directory that contains the project.",
@@ -28,6 +25,9 @@
             envKey: .inspectDependenciesOnly
         )
         var only: [DependencyInspectionType] = []
+
+        @OptionGroup
+        var loggingOptions: LoggingOptions
 
         func run() async throws {
             let inspectionTypes: Set<DependencyInspectionType> = if only.isEmpty {

--- a/cli/Sources/TuistInspectCommand/Commands/InspectImplicitImportsCommand.swift
+++ b/cli/Sources/TuistInspectCommand/Commands/InspectImplicitImportsCommand.swift
@@ -13,6 +13,9 @@
             )
         }
 
+        @OptionGroup
+        var loggingOptions: LoggingOptions
+
         @Option(
             name: .shortAndLong,
             help: "The path to the directory that contains the project.",

--- a/cli/Sources/TuistInspectCommand/Commands/InspectImplicitImportsCommand.swift
+++ b/cli/Sources/TuistInspectCommand/Commands/InspectImplicitImportsCommand.swift
@@ -13,9 +13,6 @@
             )
         }
 
-        @OptionGroup
-        var loggingOptions: LoggingOptions
-
         @Option(
             name: .shortAndLong,
             help: "The path to the directory that contains the project.",
@@ -23,6 +20,9 @@
             envKey: .lintImplicitDependenciesPath
         )
         var path: String?
+
+        @OptionGroup
+        var loggingOptions: LoggingOptions
 
         func run() async throws {
             AlertController.current

--- a/cli/Sources/TuistInspectCommand/Commands/InspectRedundantImportsCommand.swift
+++ b/cli/Sources/TuistInspectCommand/Commands/InspectRedundantImportsCommand.swift
@@ -13,6 +13,9 @@
             )
         }
 
+        @OptionGroup
+        var loggingOptions: LoggingOptions
+
         @Option(
             name: .shortAndLong,
             help: "The path to the directory that contains the project.",

--- a/cli/Sources/TuistInspectCommand/Commands/InspectRedundantImportsCommand.swift
+++ b/cli/Sources/TuistInspectCommand/Commands/InspectRedundantImportsCommand.swift
@@ -13,9 +13,6 @@
             )
         }
 
-        @OptionGroup
-        var loggingOptions: LoggingOptions
-
         @Option(
             name: .shortAndLong,
             help: "The path to the directory that contains the project.",
@@ -23,6 +20,9 @@
             envKey: .lintRedundantDependenciesPath
         )
         var path: String?
+
+        @OptionGroup
+        var loggingOptions: LoggingOptions
 
         func run() async throws {
             AlertController.current

--- a/cli/Sources/TuistInspectCommand/Commands/InspectTestCommand.swift
+++ b/cli/Sources/TuistInspectCommand/Commands/InspectTestCommand.swift
@@ -13,9 +13,6 @@
             )
         }
 
-        @OptionGroup
-        var loggingOptions: LoggingOptions
-
         @Option(
             name: .shortAndLong,
             help: "The path to the directory that contains the project to inspect the latest test results for.",
@@ -45,6 +42,9 @@
             envKey: .inspectTestMode
         )
         var mode: TestProcessingMode?
+
+        @OptionGroup
+        var loggingOptions: LoggingOptions
 
         var jsonThroughNoora: Bool = false
 

--- a/cli/Sources/TuistInspectCommand/Commands/InspectTestCommand.swift
+++ b/cli/Sources/TuistInspectCommand/Commands/InspectTestCommand.swift
@@ -13,6 +13,9 @@
             )
         }
 
+        @OptionGroup
+        var loggingOptions: LoggingOptions
+
         @Option(
             name: .shortAndLong,
             help: "The path to the directory that contains the project to inspect the latest test results for.",

--- a/cli/Sources/TuistInspectCommand/Commands/LoggingOptions.swift
+++ b/cli/Sources/TuistInspectCommand/Commands/LoggingOptions.swift
@@ -1,0 +1,9 @@
+import ArgumentParser
+
+struct LoggingOptions: ParsableArguments {
+    @Flag(
+        name: .long,
+        help: "Display verbose logs."
+    )
+    var verbose: Bool = false
+}


### PR DESCRIPTION
## What changed

- Added a shared `LoggingOptions` `ParsableArguments` type that declares the `--verbose` flag for help rendering.
- Attached the option group to `tuist inspect` and the inspect subcommands, including the hidden deprecated `implicit-imports` and `redundant-imports` routes.
- Declared the logging option after command-specific options so `--verbose` renders next to `--help`.

## Why

`tuist inspect dependencies --verbose` already worked because Tuist handles global logging flags before command execution, but the `inspect` command family did not declare the flag in ArgumentParser. As a result, `tuist inspect --help` and `tuist inspect dependencies --help` omitted `--verbose`, which made the supported logging path hard to discover when investigating slow graph loading.

## Root cause

The verbose flag was supported by Tuist's outer command processing, but not represented in the inspect command definitions that ArgumentParser uses to render command-specific help.

## Example help output

```console
$ tuist inspect dependencies --help
OVERVIEW: Inspects implicit and redundant dependencies in Tuist projects,
failing when issues are found.

USAGE: tuist inspect dependencies [--path <path>] [--only <only> ...] [--verbose]

OPTIONS:
  -p, --path <path>       The path to the directory that contains the project.
                          (env: TUIST_INSPECT_DEPENDENCIES_PATH)
  --only <only>           Run only specified checks. Can be repeated. Default:
                          implicit, redundant. (env:
                          TUIST_INSPECT_DEPENDENCIES_ONLY)
        implicit          - implicit, redundant
        redundant         - implicit, redundant
  --verbose               Display verbose logs.
  -h, --help              Show help information.
```

## Validation

- `swiftformat --lint` on the touched inspect command files
- `swiftlint lint --quiet` on the touched inspect command files
- `tuist install --force-resolved-versions`
- `tuist generate tuist ProjectDescription --no-open`
- `xcodebuild build -workspace Tuist.xcworkspace -scheme tuist -derivedDataPath /private/tmp/tuist-help-dd CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""`
- Built-binary smoke tests:
  - `/private/tmp/tuist-help-dd/Build/Products/Debug/tuist inspect --help`
  - `/private/tmp/tuist-help-dd/Build/Products/Debug/tuist inspect dependencies --help`
  - `/private/tmp/tuist-help-dd/Build/Products/Debug/tuist inspect build --help`
  - `/private/tmp/tuist-help-dd/Build/Products/Debug/tuist inspect test --help`
  - `/private/tmp/tuist-help-dd/Build/Products/Debug/tuist inspect bundle --help`
  - `/private/tmp/tuist-help-dd/Build/Products/Debug/tuist inspect implicit-imports --help`
  - `/private/tmp/tuist-help-dd/Build/Products/Debug/tuist inspect redundant-imports --help`
- `git diff --check`

The smoke tests confirmed `--verbose` appears exactly once in each relevant help output.
