### PR TITLE
test(server): stabilize in-memory rate limit tests

### DIFF
--- a/server/test/tuist_web/rate_limit/in_memory_test.exs
+++ b/server/test/tuist_web/rate_limit/in_memory_test.exs
@@ -9,6 +9,7 @@ defmodule TuistWeb.RateLimit.InMemoryTest do
   describe "rate_limit/2" do
     test "allows the request when the rate limit is not reached" do
       # Given
+      expect(Environment, :tuist_hosted?, fn -> true end)
       expect(FixWindow, :hit, fn _table, _ip, _window, _limit, _increment -> {:allow, 1} end)
       conn = build_conn()
 
@@ -21,6 +22,7 @@ defmodule TuistWeb.RateLimit.InMemoryTest do
 
     test "raises TooManyRequestsError when the rate limit is reached" do
       # Given
+      expect(Environment, :tuist_hosted?, fn -> true end)
       expect(FixWindow, :hit, fn _table, _ip, _window, _limit, _increment -> {:deny, 1} end)
       conn = build_conn()
 


### PR DESCRIPTION
## What changed

- Updated the in-memory rate limit tests to explicitly stub `Tuist.Environment.tuist_hosted?/0` as `true` for the two hosted-path examples.
- Kept the existing on-premise test covering the `false` branch where Hammer should not be called.

## Why

The failing CI job exercised the tests in an environment where `TUIST_HOSTED` was not set. In that state, `TuistWeb.RateLimit.InMemory.rate_limit/2` returns the connection early and never calls `Hammer.ETS.FixWindow.hit/5`.

The first two tests expected hosted behavior but inherited that behavior from ambient environment configuration instead of declaring it in the test. When the environment differed, Mimic correctly failed because the expected `FixWindow.hit/5` call never happened.

## Impact

This makes the rate-limit tests deterministic across local, macOS, and Linux CI environments without changing production behavior.

## Validation

- `MIX_ENV=test mix test test/tuist_web/rate_limit/in_memory_test.exs --warnings-as-errors` passed with `3 tests, 0 failures`.
- Reproduced the Linux/no-`TUIST_HOSTED` case in Docker before the fix and validated the targeted test afterward with `3 tests, 0 failures`.
- `git diff --check -- server/test/tuist_web/rate_limit/in_memory_test.exs` passed.
