### PR TITLE
fix(infra): release Helm charts for infra-scoped changes

### DIFF
--- a/infra/helm/cliff.toml
+++ b/infra/helm/cliff.toml
@@ -65,18 +65,18 @@ commit_preprocessors = [
 ]
 # regex for parsing and grouping commits
 commit_parsers = [
-    # Include commits with (helm) scope (supports multi-scope like "feat(helm,server)")
-    { message = "^feat\\([^)]*\\bhelm\\b[^)]*\\)", group = "<!-- 0 -->⛰️  Features" },
-    { message = "^fix\\([^)]*\\bhelm\\b[^)]*\\)", group = "<!-- 1 -->🐛 Bug Fixes" },
-    { message = "^docs?\\([^)]*\\bhelm\\b[^)]*\\)", group = "<!-- 3 -->📚 Documentation" },
-    { message = "^perf\\([^)]*\\bhelm\\b[^)]*\\)", group = "<!-- 4 -->⚡ Performance" },
-    { message = "^refactor\\([^)]*\\bhelm\\b[^)]*\\)", group = "<!-- 2 -->🚜 Refactor" },
-    { message = "^style\\([^)]*\\bhelm\\b[^)]*\\)", group = "<!-- 5 -->🎨 Styling" },
-    { message = "^test\\([^)]*\\bhelm\\b[^)]*\\)", group = "<!-- 6 -->🧪 Testing" },
-    { message = "^chore\\([^)]*\\bhelm\\b[^)]*\\)", skip = true },
-    { message = "^ci\\([^)]*\\bhelm\\b[^)]*\\)", skip = true },
-    # Skip any other scoped commits
-    { message = "^[a-z]+\\([^)]+\\)", skip = true },
+    # The release workflow already restricts this changelog to chart paths,
+    # so accept conventional commits regardless of their scope. Chart changes
+    # often land under broader scopes such as `infra` or `kura`.
+    { message = "^feat(\\([^)]*\\))?!?:", group = "<!-- 0 -->⛰️  Features" },
+    { message = "^fix(\\([^)]*\\))?!?:", group = "<!-- 1 -->🐛 Bug Fixes" },
+    { message = "^docs?(\\([^)]*\\))?!?:", group = "<!-- 3 -->📚 Documentation" },
+    { message = "^perf(\\([^)]*\\))?!?:", group = "<!-- 4 -->⚡ Performance" },
+    { message = "^refactor(\\([^)]*\\))?!?:", group = "<!-- 2 -->🚜 Refactor" },
+    { message = "^style(\\([^)]*\\))?!?:", group = "<!-- 5 -->🎨 Styling" },
+    { message = "^test(\\([^)]*\\))?!?:", group = "<!-- 6 -->🧪 Testing" },
+    { message = "^chore(\\([^)]*\\))?!?:", skip = true },
+    { message = "^ci(\\([^)]*\\))?!?:", skip = true },
 ]
 # protect breaking changes from being skipped due to matching a skipping commit_parser
 protect_breaking_commits = false

--- a/mise/tasks/release/check.sh
+++ b/mise/tasks/release/check.sh
@@ -73,22 +73,37 @@ check_component() {
   return 0
 }
 
-declare -A WANTED=()
-for name in "$@"; do WANTED[$name]=1; done
+WANTED=("$@")
+
+wants_component() {
+  local name=$1 wanted
+  if (( ${#WANTED[@]} == 0 )); then
+    return 0
+  fi
+  for wanted in "${WANTED[@]}"; do
+    if [[ "$wanted" == "$name" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
 
 # Iterate the components config. Each iteration receives one component as a JSON
 # blob on stdin; per-field jq calls keep the script easy to read and the cost
 # (~7 jq invocations × 15 components × <50ms) is negligible next to cliff.
 while IFS= read -r component_json; do
   name=$(jq -r '.name' <<< "$component_json")
-  if (( ${#WANTED[@]} > 0 )) && [[ -z "${WANTED[$name]:-}" ]]; then
+  if ! wants_component "$name"; then
     continue
   fi
   tag_prefix=$(jq -r '.tag_prefix' <<< "$component_json")
   tag_regex=$(jq -r '.tag_regex' <<< "$component_json")
   cliff_config=$(jq -r '.cliff_config' <<< "$component_json")
   initial=$(jq -r '.initial_version' <<< "$component_json")
-  mapfile -t include_paths < <(jq -r '.include_paths[]?' <<< "$component_json")
+  include_paths=()
+  while IFS= read -r include_path; do
+    include_paths+=("$include_path")
+  done < <(jq -r '.include_paths[]?' <<< "$component_json")
 
   if (( ${#include_paths[@]} > 0 )); then
     check_component "$name" "$tag_prefix" "$tag_regex" "$cliff_config" "$initial" "${include_paths[@]}"


### PR DESCRIPTION
Resolves no tracked issue.

Fixes the Helm chart release detection so chart-path changes with broader conventional scopes, such as `infra` or `kura`, trigger the automatic Helm publishing job.

The root cause was that the Helm component already filtered commits to chart paths, but `infra/helm/cliff.toml` only counted commits explicitly scoped as `(helm)`. PR #11367 changed `infra/helm/tuist/**` with the subject `feat(infra): support external PostgreSQL existing secrets`, so `release:check` ignored it, `helm-should-release` stayed false, and the `release-helm` job never published a chart containing the change.

The chosen fix keeps the existing path-based component boundary as the source of truth and lets the Helm changelog parser accept normal conventional commit scopes for commits that already matched those paths. That avoids requiring every infra chart change to use a special `(helm)` scope while still keeping unrelated repository changes out of Helm releases.

The shared `release:check` script also no longer depends on Bash 4-only features, so the same release check can run from a local macOS worktree as well as Linux CI.

User impact: future chart changes under `infra/helm/**/*` and `kura/ops/helm/kura/**/*` will trigger the automatic Helm chart release as expected. In the current range, the check now selects `helm@0.3.0`, which includes the external PostgreSQL existing secret support.

### How to test locally

- `mise run release:check -- helm`
- `git cliff --include-path "infra/helm/**/*" --include-path "kura/ops/helm/kura/**/*" --config infra/helm/cliff.toml --repository . --bumped-version -- helm@0.2.1..HEAD`
- `git diff --check`
