### PR TITLE
fix(noora): accessible sidebar and breadcrumbs focus + tab menu color states

### DIFF
--- a/noora/css/breadcrumbs.css
+++ b/noora/css/breadcrumbs.css
@@ -72,6 +72,11 @@
       color: var(--noora-breadcrumb-label);
       font: var(--noora-font-weight-medium) var(--noora-font-body-medium);
     }
+
+    &:focus-visible {
+      outline: none;
+      box-shadow: var(--noora-border-light-focus);
+    }
   }
 
   & [data-part="trigger"] {
@@ -95,6 +100,11 @@
     &:active,
     &[data-state="open"] {
       box-shadow: var(--noora-border-light-default);
+      background-color: var(--noora-breadcrumb-background);
+    }
+
+    &:focus-visible {
+      box-shadow: var(--noora-border-light-focus);
       background-color: var(--noora-breadcrumb-background);
     }
 
@@ -176,6 +186,16 @@
 
   & [data-part="item"]:not([data-selected]) [data-part="check"] {
     visibility: hidden;
+  }
+
+  /* Keyboard roving focus (see Dropdown.js handleBreadcrumbKeydown) moves real
+     DOM focus between the native <a> items (which are tabindex="-1", so only
+     reachable inside the open menu), so mirror the hover affordance on the
+     focused one. :focus rather than :focus-visible so it shows even when the
+     menu was opened by mouse and then arrowed. */
+  & [data-part="item"]:focus {
+    outline: none;
+    background: var(--noora-dropdown-hover-background);
   }
 
   & [data-part="right-icon"] {

--- a/noora/css/sidebar.css
+++ b/noora/css/sidebar.css
@@ -145,9 +145,24 @@
       user-select: none;
       text-decoration: unset;
 
+      /* The disclosure-only group renders this trigger as a native <button>;
+         strip the UA chrome so it matches the div/link tabs while keeping
+         native button semantics (Space/Enter, focus, disabled). */
+      appearance: none;
+      margin: var(--noora-spacing-0);
+      border: none;
+      background: transparent;
+      font: inherit;
+      text-align: start;
+
       &:focus-visible {
         outline: 2px solid var(--noora-surface-label-primary);
         outline-offset: -2px;
+      }
+
+      &:disabled {
+        cursor: default;
+        opacity: 0.5;
       }
 
       & [data-part="label"] {

--- a/noora/css/sidebar.css
+++ b/noora/css/sidebar.css
@@ -122,6 +122,11 @@
         color: inherit;
         user-select: none;
         text-decoration: unset;
+
+        &:focus-visible {
+          outline: 2px solid var(--noora-surface-label-primary);
+          outline-offset: -2px;
+        }
       }
 
       & > [data-part="trigger"] {
@@ -131,10 +136,6 @@
         border: none;
         background: transparent;
         padding: var(--noora-spacing-3) var(--noora-spacing-4);
-
-        &:hover [data-part="indicator"] {
-          color: var(--noora-surface-label-primary);
-        }
       }
     }
 
@@ -143,6 +144,11 @@
       border-radius: var(--noora-radius-3);
       user-select: none;
       text-decoration: unset;
+
+      &:focus-visible {
+        outline: 2px solid var(--noora-surface-label-primary);
+        outline-offset: -2px;
+      }
 
       & [data-part="label"] {
         flex-grow: 1;
@@ -155,7 +161,7 @@
            chevron below the row's vertical center. */
         display: flex;
         align-items: center;
-        color: var(--noora-surface-label-secondary);
+        color: var(--noora-surface-label-tertiary);
 
         & svg {
           width: 18px;
@@ -163,6 +169,10 @@
           display: block;
         }
       }
+    }
+
+    & .noora-tab-menu-vertical:hover [data-part="indicator"] {
+      color: var(--noora-surface-label-secondary);
     }
 
     & [data-part="root"] {
@@ -195,6 +205,15 @@
   & [data-part="item"] {
     user-select: none;
     text-decoration: none;
+
+    &:focus-visible {
+      outline: none;
+
+      & .noora-tab-menu-vertical {
+        outline: 2px solid var(--noora-surface-label-primary);
+        outline-offset: -2px;
+      }
+    }
   }
 }
 

--- a/noora/css/tab_menu.css
+++ b/noora/css/tab_menu.css
@@ -5,7 +5,7 @@
   cursor: pointer;
   border-radius: var(--noora-radius-3);
   padding: var(--noora-spacing-3) var(--noora-spacing-4);
-  color: var(--noora-surface-label-primary);
+  color: var(--noora-surface-label-secondary);
 
   & [data-part="icon-left"],
   & [data-part="icon-right"] {
@@ -23,11 +23,13 @@
   }
 
   &:hover {
-    background: var(--noora-surface-background-tertiary);
+    background: var(--noora-surface-background-secondary);
+    color: var(--noora-surface-label-primary);
   }
 
   &[data-selected] {
     background: var(--noora-surface-background-secondary);
+    color: var(--noora-surface-label-primary);
   }
 }
 

--- a/noora/js/Dropdown.js
+++ b/noora/js/Dropdown.js
@@ -95,6 +95,12 @@ export default {
   mounted() {
     this.metadata = {};
 
+    // Breadcrumb dropdowns can't use zag's item props (see Menu.renderItems —
+    // they conflict with LiveView's DOM patching), so they get no built-in
+    // arrow-key navigation. We drive roving focus over the native <a> items
+    // ourselves instead.
+    this.isBreadcrumb = this.el.classList.contains("noora-breadcrumb");
+
     for (const key in this.el.dataset) {
       if (key.startsWith("meta")) {
         const metaKey = key.charAt(4).toLowerCase() + key.slice(5);
@@ -123,6 +129,7 @@ export default {
         })(),
       },
       onOpenChange: (details) => {
+        if (this.isBreadcrumb) this.handleBreadcrumbOpenChange(details.open);
         if (this.el.dataset.onOpenChange) {
           this.pushEvent(this.el.dataset.onOpenChange, details);
         }
@@ -193,6 +200,109 @@ export default {
     };
     window.addEventListener("phx:open-dropdown", this.handleOpenDropdown);
     window.addEventListener("phx:close-dropdown", this.handleCloseDropdown);
+
+    if (this.isBreadcrumb) {
+      this.breadcrumbKeydown = (event) => this.handleBreadcrumbKeydown(event);
+      // Capture phase so zag's content keydown handler doesn't consume the
+      // arrow keys before we move focus.
+      this.el.addEventListener("keydown", this.breadcrumbKeydown, true);
+    }
+  },
+
+  breadcrumbItems() {
+    return [...this.el.querySelectorAll('[data-part="item"]')].filter(
+      (item) => item.style.display !== "none",
+    );
+  },
+
+  handleBreadcrumbOpenChange(open) {
+    if (open) {
+      // Defer until zag has shown the positioner so the items are focusable.
+      window.requestAnimationFrame(() => {
+        const items = this.breadcrumbItems();
+        if (!items.length) return;
+        const selected = items.find((item) => item.hasAttribute("data-selected"));
+        (selected || items[0]).focus();
+      });
+    } else if (this.el.contains(document.activeElement)) {
+      this.el.querySelector('[data-part="trigger"]')?.focus();
+    }
+  },
+
+  handleBreadcrumbKeydown(event) {
+    if (!this.menu.api.open) return;
+    // Don't hijack typing in a dropdown search field.
+    if (event.target.matches('[data-part="search-input"]')) return;
+
+    const items = this.breadcrumbItems();
+    if (!items.length) return;
+
+    const current = items.indexOf(document.activeElement);
+    let next;
+
+    switch (event.key) {
+      case "ArrowDown":
+        next = current < 0 ? 0 : (current + 1) % items.length;
+        break;
+      case "ArrowUp":
+        next = current < 0 ? items.length - 1 : (current - 1 + items.length) % items.length;
+        break;
+      case "Home":
+        next = 0;
+        break;
+      case "End":
+        next = items.length - 1;
+        break;
+      case "Enter":
+      case " ":
+        // The items aren't registered with zag, so its content handler
+        // swallows Enter/Space (it has no highlighted item to select) and the
+        // native <a> activation never fires. Trigger the focused item's click
+        // ourselves — LiveView's delegated click listener handles navigation.
+        if (current < 0) return;
+        event.preventDefault();
+        event.stopPropagation();
+        items[current].click();
+        return;
+      case "Tab":
+        // A menu is a single tab stop: the items are tabindex="-1", so close
+        // the menu and hand focus back to the trigger instead of letting Tab
+        // strand focus on a now-hidden item.
+        event.preventDefault();
+        event.stopPropagation();
+        this.menu.api.setOpen(false);
+        this.el.querySelector('[data-part="trigger"]')?.focus();
+        return;
+      default:
+        // Typeahead: jump to the item whose label matches the typed characters.
+        if (event.key.length === 1 && !event.metaKey && !event.ctrlKey && !event.altKey) {
+          event.preventDefault();
+          event.stopPropagation();
+          this.breadcrumbTypeahead(event.key, items);
+        }
+        return;
+    }
+
+    event.preventDefault();
+    event.stopPropagation();
+    items[next].focus();
+  },
+
+  breadcrumbTypeahead(char, items) {
+    clearTimeout(this.typeaheadTimer);
+    this.typeaheadQuery = (this.typeaheadQuery || "") + char.toLowerCase();
+    this.typeaheadTimer = setTimeout(() => {
+      this.typeaheadQuery = "";
+    }, 500);
+
+    const labelOf = (item) =>
+      (item.dataset.label || item.textContent || "").trim().toLowerCase();
+
+    const match =
+      items.find((item) => labelOf(item).startsWith(this.typeaheadQuery)) ||
+      items.find((item) => labelOf(item).includes(this.typeaheadQuery));
+
+    if (match) match.focus();
   },
 
   applySearchFilter() {
@@ -241,6 +351,10 @@ export default {
   destroyed() {
     this.el.removeEventListener("input", this.handleSearchInput);
     this.el.removeEventListener("keydown", this.handleSearchKeydown);
+    if (this.breadcrumbKeydown) {
+      this.el.removeEventListener("keydown", this.breadcrumbKeydown, true);
+    }
+    clearTimeout(this.typeaheadTimer);
     window.removeEventListener("phx:open-dropdown", this.handleOpenDropdown);
     window.removeEventListener("phx:close-dropdown", this.handleCloseDropdown);
   },

--- a/noora/js/Dropdown.js
+++ b/noora/js/Dropdown.js
@@ -221,7 +221,9 @@ export default {
       window.requestAnimationFrame(() => {
         const items = this.breadcrumbItems();
         if (!items.length) return;
-        const selected = items.find((item) => item.hasAttribute("data-selected"));
+        const selected = items.find((item) =>
+          item.hasAttribute("data-selected"),
+        );
         (selected || items[0]).focus();
       });
     } else if (this.el.contains(document.activeElement)) {
@@ -245,7 +247,10 @@ export default {
         next = current < 0 ? 0 : (current + 1) % items.length;
         break;
       case "ArrowUp":
-        next = current < 0 ? items.length - 1 : (current - 1 + items.length) % items.length;
+        next =
+          current < 0
+            ? items.length - 1
+            : (current - 1 + items.length) % items.length;
         break;
       case "Home":
         next = 0;
@@ -275,7 +280,12 @@ export default {
         return;
       default:
         // Typeahead: jump to the item whose label matches the typed characters.
-        if (event.key.length === 1 && !event.metaKey && !event.ctrlKey && !event.altKey) {
+        if (
+          event.key.length === 1 &&
+          !event.metaKey &&
+          !event.ctrlKey &&
+          !event.altKey
+        ) {
           event.preventDefault();
           event.stopPropagation();
           this.breadcrumbTypeahead(event.key, items);

--- a/noora/lib/noora/breadcrumbs.ex
+++ b/noora/lib/noora/breadcrumbs.ex
@@ -175,7 +175,14 @@ defmodule Noora.Breadcrumbs do
 
   def breadcrumb_item(assigns) do
     ~H"""
-    <.dropdown_item value={@value} label={@label} href={@href} data-selected={@selected}>
+    <.dropdown_item
+      value={@value}
+      label={@label}
+      href={@href}
+      data-selected={@selected}
+      role="menuitem"
+      tabindex="-1"
+    >
       <:left_icon :if={@show_avatar or not is_nil(@icon)}>
         <.avatar
           :if={@show_avatar and is_nil(@icon)}

--- a/noora/lib/noora/sidebar.ex
+++ b/noora/lib/noora/sidebar.ex
@@ -101,9 +101,16 @@ defmodule Noora.Sidebar do
               </button>
             </div>
           <% else %>
-            <.tab_menu_vertical label={@label} data-part="trigger" data-selected={@selected}>
-              <:icon_left><.icon name={@icon} /></:icon_left>
-              <:icon_right>
+            <button
+              type="button"
+              class="noora-tab-menu-vertical"
+              data-part="trigger"
+              data-selected={@selected}
+              disabled={@disabled}
+            >
+              <div data-part="icon-left"><.icon name={@icon} /></div>
+              <span data-part="label">{@label}</span>
+              <div data-part="icon-right">
                 <div data-part="indicator">
                   <.icon
                     id={@id <> "-indicator"}
@@ -113,8 +120,8 @@ defmodule Noora.Sidebar do
                     active_state="open"
                   />
                 </div>
-              </:icon_right>
-            </.tab_menu_vertical>
+              </div>
+            </button>
           <% end %>
           <div data-part="content" hidden={!@default_open}>
             {render_slot(@inner_block)}

--- a/server/assets/shared/css/components/account_dropdown.css
+++ b/server/assets/shared/css/components/account_dropdown.css
@@ -20,6 +20,7 @@
       display: flex;
     }
 
+    &:focus-visible .noora-avatar,
     &[data-state="open"] .noora-avatar {
       box-shadow: var(--noora-border-light-focus);
     }

--- a/server/lib/tuist_web/components/app_layout_components.ex
+++ b/server/lib/tuist_web/components/app_layout_components.ex
@@ -576,11 +576,16 @@ defmodule TuistWeb.AppLayoutComponents do
         >
           <:icon><.git_branch /></:icon>
         </.badge>
-        <.link href={Tuist.Environment.get_url(:documentation)} target="_blank">
-          <.button variant="secondary" icon_only>
-            <.book />
-          </.button>
-        </.link>
+        <.button
+          variant="secondary"
+          icon_only
+          href={Tuist.Environment.get_url(:documentation)}
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label={dgettext("dashboard", "Documentation")}
+        >
+          <.book />
+        </.button>
         <%= if not is_nil(@current_user) do %>
           <.account_dropdown
             id="account-dropdown"

--- a/server/package.json
+++ b/server/package.json
@@ -26,7 +26,8 @@
       "postcss": "8.5.10",
       "shell-quote": "1.8.4",
       "form-data": "4.0.6",
-      "@opentelemetry/core": "2.8.0"
+      "@opentelemetry/core": "2.8.0",
+      "ts-deepmerge": "8.0.0"
     },
     "allowBuilds": {
       "core-js": true,

--- a/server/pnpm-lock.yaml
+++ b/server/pnpm-lock.yaml
@@ -18,6 +18,7 @@ overrides:
   postcss: 8.5.10
   protobufjs: 7.6.4
   shell-quote: 1.8.4
+  ts-deepmerge: 8.0.0
   yaml: 2.8.3
 
 time:
@@ -33,6 +34,7 @@ time:
   hasown@2.0.4: 2026-05-28T18:11:39.940Z
   protobufjs@7.6.4: 2026-06-12T12:10:59.442Z
   shell-quote@1.8.4: 2026-05-22T13:13:48.633Z
+  ts-deepmerge@8.0.0: 2026-05-22T00:15:00.073Z
 
 importers:
 
@@ -1351,8 +1353,8 @@ packages:
     resolution: {integrity: sha512-QVsbr1WhGLq2F0oDyYbqtOXcf3gcnL8C9H5EX8bBwAr8ZWvWGJzukpPrDrWgJMrNtgDbo74BIjI4kJu3q2xQWw==}
     engines: {node: '>=18.18.0'}
 
-  ts-deepmerge@7.0.3:
-    resolution: {integrity: sha512-Du/ZW2RfwV/D4cmA5rXafYjBQVuvu4qGiEEla4EmEHVHgRdx68Gftx7i66jn2bzHPwSVZY36Ae6OuDn9el4ZKA==}
+  ts-deepmerge@8.0.0:
+    resolution: {integrity: sha512-133O+10nJmVI8w5xeVZPEv5PIrv7iaUae07wv1aH8XJH95Ur6YIhWAPhPyP1YPlbPS9fCVcNIZTu7m8urRVF0A==}
     engines: {node: '>=14.13.1'}
 
   tslib@2.3.0:
@@ -2067,7 +2069,7 @@ snapshots:
       '@scalar/helpers': 0.4.3
       flatted: 3.4.2
       just-clone: 6.2.0
-      ts-deepmerge: 7.0.3
+      ts-deepmerge: 8.0.0
 
   '@scalar/openapi-parser@0.25.8':
     dependencies:
@@ -3360,7 +3362,7 @@ snapshots:
       string-byte-length: 3.0.1
       string-byte-slice: 3.0.1
 
-  ts-deepmerge@7.0.3: {}
+  ts-deepmerge@8.0.0: {}
 
   tslib@2.3.0: {}
 

--- a/server/priv/gettext/dashboard.pot
+++ b/server/priv/gettext/dashboard.pot
@@ -389,7 +389,7 @@ msgid "Too many requests."
 msgstr ""
 
 #: lib/tuist_web/components/app_layout_components.ex:562
-#: lib/tuist_web/components/app_layout_components.ex:599
+#: lib/tuist_web/components/app_layout_components.ex:604
 #, elixir-autogen, elixir-format
 msgid "Tuist Icon"
 msgstr ""
@@ -1827,4 +1827,9 @@ msgstr ""
 #: lib/tuist_web/components/app_layout_components.ex:421
 #, elixir-autogen, elixir-format
 msgid "Usage"
+msgstr ""
+
+#: lib/tuist_web/components/app_layout_components.ex:585
+#, elixir-autogen, elixir-format
+msgid "Documentation"
 msgstr ""


### PR DESCRIPTION
## What changed

- **Keyboard focus on sidebar tabs is now visible.** A collapsible group header is two tab stops — the navigate link and the chevron toggle — but only the chevron showed the browser default ring, so tabbing onto the actual nav item gave no visible indicator. Added consistent `:focus-visible` outlines to the group link, the chevron/trigger, and leaf items.
- **Tab menu color states.** Text and left icon are now `surface/label/secondary` by default and `surface/label/primary` on hover/selected. Hover background moved from `surface/background/tertiary` to `surface/background/secondary`.
- **Chevron indicator** is `surface/label/tertiary` by default and `surface/label/secondary` on hover, giving the expand/collapse arrow its own (quieter) scale, distinct from the label.

<img width="229" height="448" alt="Screenshot 2026-06-19 at 15 16 57" src="https://github.com/user-attachments/assets/21d98bd7-f8b0-4d1a-b805-c0e7ba1f9cb2" />


## Why

Tabbing through the sidebar highlighted only the chevron, not the whole tab — keyboard users couldn't tell which nav item was focused. The color tweaks make the inactive/hover/active states read consistently across the sidebar (and the docs nav, which shares the component).

## Where

- Generic text/icon coloring + hover background → `noora/css/tab_menu.css` (applies to every tab menu).
- Focus rings and the chevron indicator coloring → `noora/css/sidebar.css` (the chevron is created by the sidebar, not the shared tab-menu component).

## Validation

Verified in the browser (light/dark): focus rings appear on Tab for the nav link, chevron, and sub-items; hover/selected states transition text and arrow as expected. CSS only — no markup or component API changes.