### PR TITLE
fix(server): ignore Mix compile lock in code reloader

### DIFF
--- a/server/lib/tuist_web/code_reloader.ex
+++ b/server/lib/tuist_web/code_reloader.ex
@@ -1,0 +1,81 @@
+defmodule TuistWeb.CodeReloader do
+  @moduledoc false
+
+  alias Mix.Tasks.Compile.Elixir, as: CompileElixir
+
+  def reload(endpoint, opts) do
+    normalize_mix_compile_lock_mtime(
+      Mix.Project.config_files(),
+      reloadable_app_manifests(endpoint)
+    )
+
+    Phoenix.CodeReloader.reload(endpoint, opts)
+  end
+
+  def stale_config_files(config_files, manifests) do
+    manifests = List.flatten(manifests)
+
+    config_files
+    |> Enum.reject(&mix_compile_lock?/1)
+    |> Mix.Utils.extract_stale(manifests)
+  end
+
+  def normalize_mix_compile_lock_mtime(config_files, manifests) do
+    manifests = List.flatten(manifests)
+    compile_locks = Enum.filter(config_files, &mix_compile_lock?/1)
+    stale_compile_locks = Mix.Utils.extract_stale(compile_locks, manifests)
+
+    # Mix 1.19 reports compile.lock as a config file; Phoenix can safely ignore it
+    # when no real config file changed because it is only a build artifact.
+    if stale_compile_locks != [] and stale_config_files(config_files, manifests) == [] do
+      oldest_manifest_mtime = oldest_manifest_mtime(manifests)
+      Enum.each(stale_compile_locks, &File.touch!(&1, oldest_manifest_mtime))
+    end
+
+    :ok
+  end
+
+  defp reloadable_app_manifests(endpoint) do
+    endpoint
+    |> reloadable_apps()
+    |> Enum.flat_map(&manifests_for_app/1)
+  end
+
+  defp reloadable_apps(endpoint) do
+    endpoint.config(:reloadable_apps) || default_reloadable_apps()
+  end
+
+  defp default_reloadable_apps do
+    if Mix.Project.umbrella?() do
+      Enum.map(Mix.Dep.Umbrella.cached(), & &1.app)
+    else
+      [Mix.Project.config()[:app]]
+    end
+  end
+
+  defp manifests_for_app(app) do
+    current_app = Mix.Project.config()[:app]
+    dep = Enum.find(Mix.Dep.cached(), &(&1.app == app))
+
+    cond do
+      app == current_app ->
+        [CompileElixir.manifests()]
+
+      dep ->
+        [Mix.Dep.in_dependency(dep, fn _ -> CompileElixir.manifests() end)]
+
+      true ->
+        []
+    end
+  end
+
+  defp mix_compile_lock?(path) do
+    Path.basename(path) == "compile.lock" and path |> Path.dirname() |> Path.basename() == ".mix"
+  end
+
+  defp oldest_manifest_mtime(manifests) do
+    manifests
+    |> Enum.map(&Mix.Utils.last_modified/1)
+    |> Enum.min()
+  end
+end

--- a/server/lib/tuist_web/endpoint.ex
+++ b/server/lib/tuist_web/endpoint.ex
@@ -5,6 +5,7 @@ defmodule TuistWeb.Endpoint do
   # The session will be stored in the cookie and signed,
   # this means its contents can be read but not tampered with.
   # Set :encryption_salt if you would also like to encrypt it.
+  alias TuistWeb.CodeReloader
   alias TuistWeb.Plugs.GitHubWebhookLoggingPlug
   alias TuistWeb.Plugs.WebhookPlug
   alias TuistWeb.Webhooks.BillingController
@@ -46,7 +47,7 @@ defmodule TuistWeb.Endpoint do
   if code_reloading? do
     socket "/phoenix/live_reload/socket", Phoenix.LiveReloader.Socket
     plug Phoenix.LiveReloader
-    plug Phoenix.CodeReloader
+    plug Phoenix.CodeReloader, reloader: &CodeReloader.reload/2
     plug Phoenix.Ecto.CheckRepoStatus, otp_app: :tuist
   end
 

--- a/server/test/tuist_web/code_reloader_test.exs
+++ b/server/test/tuist_web/code_reloader_test.exs
@@ -1,0 +1,90 @@
+defmodule TuistWeb.CodeReloaderTest do
+  use ExUnit.Case, async: true
+
+  alias TuistWeb.CodeReloader
+
+  describe "stale_config_files/2" do
+    test "ignores Mix compile.lock when it is newer than the compile manifest" do
+      %{compile_lock: compile_lock, config: config, manifest: manifest} = stale_paths()
+
+      assert CodeReloader.stale_config_files([compile_lock, config], [manifest]) == []
+    end
+
+    test "keeps real config files in the stale set" do
+      %{compile_lock: compile_lock, config: config, manifest: manifest} = stale_paths()
+      File.touch!(config, 300)
+
+      assert CodeReloader.stale_config_files([compile_lock, config], [manifest]) == [config]
+    end
+
+    test "does not ignore unrelated files named compile.lock" do
+      %{config: config, manifest: manifest} = stale_paths()
+      unrelated_lock = Path.join(Path.dirname(config), "compile.lock")
+      File.write!(unrelated_lock, "")
+      File.touch!(unrelated_lock, 300)
+
+      assert CodeReloader.stale_config_files([unrelated_lock, config], [manifest]) == [unrelated_lock]
+    end
+  end
+
+  describe "normalize_mix_compile_lock_mtime/2" do
+    test "moves a stale Mix compile.lock back to the compile manifest mtime" do
+      %{compile_lock: compile_lock, config: config, manifest: manifest} = stale_paths()
+
+      assert :ok = CodeReloader.normalize_mix_compile_lock_mtime([compile_lock, config], [manifest])
+
+      assert Mix.Utils.last_modified(compile_lock) == Mix.Utils.last_modified(manifest)
+    end
+
+    test "moves compile.lock behind every reloadable app manifest" do
+      %{compile_lock: compile_lock, config: config, manifest: manifest} = stale_paths()
+      reloadable_app_manifest = Path.join(Path.dirname(manifest), "noora.compile.elixir")
+      File.write!(reloadable_app_manifest, "")
+      File.touch!(manifest, 150)
+      File.touch!(reloadable_app_manifest, 100)
+
+      assert :ok =
+               CodeReloader.normalize_mix_compile_lock_mtime(
+                 [compile_lock, config],
+                 [[manifest], [reloadable_app_manifest]]
+               )
+
+      assert Mix.Utils.last_modified(compile_lock) == 100
+      assert CodeReloader.stale_config_files([compile_lock, config], [reloadable_app_manifest]) == []
+    end
+
+    test "leaves compile.lock alone when a real config file is stale" do
+      %{compile_lock: compile_lock, config: config, manifest: manifest} = stale_paths()
+      File.touch!(config, 300)
+
+      assert :ok = CodeReloader.normalize_mix_compile_lock_mtime([compile_lock, config], [manifest])
+
+      assert Mix.Utils.last_modified(compile_lock) == 200
+    end
+  end
+
+  defp stale_paths do
+    root = Path.join(System.tmp_dir!(), "tuist-code-reloader-#{System.unique_integer([:positive])}")
+    build_path = Path.join([root, "_build", "dev", "lib", "tuist", ".mix"])
+    config_path = Path.join(root, "config")
+
+    File.mkdir_p!(build_path)
+    File.mkdir_p!(config_path)
+
+    manifest = Path.join(build_path, "compile.elixir")
+    compile_lock = Path.join(build_path, "compile.lock")
+    config = Path.join(config_path, "dev.exs")
+
+    on_exit(fn -> File.rm_rf!(root) end)
+
+    File.write!(manifest, "")
+    File.write!(compile_lock, "")
+    File.write!(config, "")
+
+    File.touch!(manifest, 100)
+    File.touch!(compile_lock, 200)
+    File.touch!(config, 90)
+
+    %{compile_lock: compile_lock, config: config, manifest: manifest}
+  end
+end


### PR DESCRIPTION
## What changed

- Added `TuistWeb.CodeReloader`, a small wrapper around Phoenix's development code reloader.
- Wired the dev endpoint's `Phoenix.CodeReloader` plug to use the wrapper.
- The wrapper normalizes Mix's `_build/.../.mix/compile.lock` mtime when that build artifact is the only stale "config" file.
- The normalization now uses every configured reloadable app manifest, including path deps such as `:noora`, not just the main `:tuist` manifest.
- Added focused regression tests for lock filtering, real config staleness, unrelated `compile.lock` files, and multi-reloadable-app manifest mtimes.

## Why it changed

Phoenix runs a stale-config guard before recompiling on each development request. With Elixir/Mix 1.19, `Mix.Project.config_files()` can include `_build/.../.mix/compile.lock`. That file is a build artifact, but if it is touched by an out-of-band Mix command while the server is alive, Phoenix treats it like config drift and returns the persistent "You must restart your server" 500 page.

The live repro also showed an extra wrinkle: Tuist reloads both `:tuist` and `:noora` in dev. Touching the lock back to the `:tuist` manifest was not enough if the lock was still newer than `:noora`'s manifest; Phoenix then failed while compiling `noora`.

## Approach

The wrapper keeps Phoenix's safety behavior for real config changes. Before delegating to `Phoenix.CodeReloader.reload/2`, it gathers manifests for all reloadable apps using the endpoint's `:reloadable_apps` config and `Mix.Dep.in_dependency/2` for path deps. If the only stale config entry is a Mix `.mix/compile.lock`, it touches that lock back to the oldest reloadable app manifest mtime. If any real config file is stale, the wrapper leaves everything alone and Phoenix still asks for a restart.

This keeps the fix local to Tuist's development endpoint and avoids patching Phoenix internals.

## Impact

Server preview sessions should stop getting wedged by Mix 1.19's build lock artifact after local Mix commands touch `compile.lock`. Actual config changes remain restart-gated.

## Validation

- Red regression: the new multi-manifest test failed before the fix because `compile.lock` stayed newer than the simulated `noora` manifest.
- `MIX_ENV=test MIX_DEPS_PATH=/Users/marekfort/Developer/tuist/server/deps mise exec -- mix run --no-start -e 'ExUnit.start(); Code.require_file("test/tuist_web/code_reloader_test.exs"); %{failures: failures} = ExUnit.run(); System.halt(if failures == 0, do: 0, else: 1)'` -> 6 tests, 0 failures.
- `MIX_ENV=test MIX_DEPS_PATH=/Users/marekfort/Developer/tuist/server/deps mise exec -- mix format --check-formatted lib/tuist_web/code_reloader.ex test/tuist_web/code_reloader_test.exs lib/tuist_web/endpoint.ex`.
- Attempted the normal `MIX_TEST_PARTITION=_code_reloader MIX_DEPS_PATH=/Users/marekfort/Developer/tuist/server/deps mise exec -- mix test test/tuist_web/code_reloader_test.exs`; it was blocked by local DB setup failing with `relation "users" does not exist` before ExUnit ran.
- Live e2e: trusted the root and server mise configs, started the dev server with `MIX_DEPS_PATH=/Users/marekfort/Developer/tuist/server/deps mise exec -- mix phx.server` on the worktree port `8501`, and requested `GET /robots.txt`.
- Live e2e before widening the fix: after touching `_build/dev/lib/tuist/.mix/compile.lock`, the request returned the stale-config 500: `could not compile application: noora` / `You must restart your server`.
- Live e2e after the fix: baseline `GET /robots.txt` returned 503 because the local worktree DB `tuist_development_421` is missing; after touching `compile.lock` newer than both `noora` and `tuist` manifests, the same request stayed at the baseline 503, the body did not contain the stale-config/restart message, and `compile.lock` was normalized older than both manifests.
