### PR TITLE
fix(server): improve storage artifact retention

### DIFF
--- a/server/data-export.md
+++ b/server/data-export.md
@@ -109,7 +109,7 @@ The following data is stored in ClickHouse for analytics purposes:
 ## Binary Files
 
 All uploaded files associated with the account are included:
-- **Cache artifacts**: Build caches and compiled binaries
+- **Cache artifacts**: Build caches and compiled binaries, including Xcode, legacy CAS, module, and Gradle artifacts
 - **App previews**: iOS app bundles (.app/.ipa files) and icons  
 - **Shard bundles**: Shared `.xctestproducts` bundles stored at `{account_id}/{project_id}/shards/{shard_plan_id}/`
 - **Runner job log archives**: gzipped runner logs stored at `runners/{account_id}/{workflow_job_id}/runner.log.gz`
@@ -124,7 +124,7 @@ intact. Retention windows, in days, by plan:
 
 | Artifact | Air / Open Source | Pro | Enterprise |
 | --- | --- | --- | --- |
-| Cache artifacts (Xcode compilation, module, Gradle) | 14 | 30 | 90 |
+| Cache artifacts (Xcode compilation, legacy CAS, module, Gradle) | 14 | 30 | 90 |
 | App preview builds and icons | 60 | 180 | 365 |
 | Build archives | 30 | 90 | 365 |
 | Test run attachments | 30 | 90 | 365 |

--- a/server/data-export.md
+++ b/server/data-export.md
@@ -111,6 +111,7 @@ The following data is stored in ClickHouse for analytics purposes:
 All uploaded files associated with the account are included:
 - **Cache artifacts**: Build caches and compiled binaries, including Xcode, legacy CAS, module, and Gradle artifacts
 - **App previews**: iOS app bundles (.app/.ipa files) and icons  
+- **Run sessions**: uploaded run session archives stored at `{account}/{project}/runs/{run_id}/session.zip`
 - **Shard bundles**: Shared `.xctestproducts` bundles stored at `{account_id}/{project_id}/shards/{shard_plan_id}/`
 - **Runner job log archives**: gzipped runner logs stored at `runners/{account_id}/{workflow_job_id}/runner.log.gz`
 
@@ -119,22 +120,24 @@ All uploaded files associated with the account are included:
 Stored artifact blobs are subject to plan-based retention. Once an artifact is
 older than its retention window, its binary is removed from object storage by a
 daily cleanup process; the associated metadata rows (build runs, test runs,
-preview records, shard plans) are kept so analytics and dashboards remain
-intact. Retention windows, in days, by plan:
+command events, preview records, shard plans) are kept so analytics and
+dashboards remain intact. Retention windows, in days, by plan:
 
 | Artifact | Air / Open Source | Pro | Enterprise |
 | --- | --- | --- | --- |
 | Cache artifacts (Xcode compilation, legacy CAS, module, Gradle) | 14 | 30 | 90 |
 | App preview builds and icons | 60 | 180 | 365 |
 | Build archives | 30 | 90 | 365 |
+| Run session archives | 30 | 90 | 365 |
 | Test run attachments | 30 | 90 | 365 |
 | Shard bundles | 7 | 14 | 30 |
 
 Retention status is computed when cleanup runs. Cache artifacts use the object
 storage `last_modified` timestamp, while previews, build archives, test
-attachments, and shard bundles use their database `inserted_at` timestamp. The
-active account plan determines the applicable window, with Air used when an
-account has no active subscription.
+attachments, and shard bundles use their database `inserted_at` timestamp. Run
+session archives use the command event `ran_at` timestamp. The active account
+plan determines the applicable window, with Air used when an account has no
+active subscription.
 
 Tuist stores per-account cleanup progress for DB-backed artifact families so
 daily retention jobs can resume after previously-purged metadata rows without

--- a/server/lib/tuist/oban/runtime_config.ex
+++ b/server/lib/tuist/oban/runtime_config.ex
@@ -30,6 +30,7 @@ defmodule Tuist.Oban.RuntimeConfig do
     {"0 3 * * *", Tuist.Storage.Workers.DeleteExpiredXcodeCacheArtifactsWorker},
     {"15 3 * * *", Tuist.Storage.Workers.DeleteExpiredXcodeModuleCacheArtifactsWorker},
     {"30 3 * * *", Tuist.Storage.Workers.DeleteExpiredGradleCacheArtifactsWorker},
+    {"45 3 * * *", Tuist.Storage.Workers.DeleteExpiredCasCacheArtifactsWorker},
     {"* * * * *", Tuist.Kura.Reconciler},
     {"* * * * *", Tuist.Runners.Workers.StaleClaimsWorker},
     {"* * * * *", Tuist.Runners.Workers.OrphanedRunnersWorker},

--- a/server/lib/tuist/storage.ex
+++ b/server/lib/tuist/storage.ex
@@ -295,6 +295,8 @@ defmodule Tuist.Storage do
 
   defp delete_objects_from_bucket(object_keys, bucket_name, config, opts) do
     max_concurrency = Keyword.get(opts, :max_concurrency, @delete_objects_max_concurrency)
+    request_opts = fast_api_req_opts(opts)
+    task_timeout = Keyword.get(opts, :task_timeout, request_timeout(request_opts))
 
     object_keys
     |> Enum.chunk_every(1000)
@@ -302,11 +304,13 @@ defmodule Tuist.Storage do
       fn object_keys_chunk ->
         bucket_name
         |> ExAws.S3.delete_multiple_objects(object_keys_chunk)
-        |> ExAws.request(Map.merge(config, fast_api_req_opts()))
+        |> ExAws.request(Map.merge(config, request_opts))
         |> handle_delete_objects_response()
       end,
       max_concurrency: max_concurrency,
-      ordered: false
+      ordered: false,
+      timeout: task_timeout,
+      on_timeout: :kill_task
     )
     |> Enum.reduce_while(:ok, fn
       {:ok, :ok}, :ok ->
@@ -446,11 +450,19 @@ defmodule Tuist.Storage do
     end
   end
 
-  defp fast_api_req_opts do
+  defp fast_api_req_opts(opts \\ []) do
     %{
-      receive_timeout: 5_000,
-      pool_timeout: 1_000
+      receive_timeout: Keyword.get(opts, :receive_timeout, 5_000),
+      pool_timeout: Keyword.get(opts, :pool_timeout, 1_000)
     }
+  end
+
+  defp request_timeout(request_opts) do
+    case {Map.fetch!(request_opts, :receive_timeout), Map.fetch!(request_opts, :pool_timeout)} do
+      {:infinity, _pool_timeout} -> :infinity
+      {_receive_timeout, :infinity} -> :infinity
+      {receive_timeout, pool_timeout} -> receive_timeout + pool_timeout + 1_000
+    end
   end
 
   defp region_headers(actor) do

--- a/server/lib/tuist/storage/artifact_retention_cursor.ex
+++ b/server/lib/tuist/storage/artifact_retention_cursor.ex
@@ -7,7 +7,7 @@ defmodule Tuist.Storage.ArtifactRetentionCursor do
 
   alias Tuist.Accounts.Account
 
-  @artifact_types [:preview_app_build, :build_archive, :test_attachment, :shard_bundle]
+  @artifact_types [:preview_app_build, :build_archive, :run_session, :test_attachment, :shard_bundle]
 
   @primary_key {:id, UUIDv7, autogenerate: true}
   schema "artifact_retention_cursors" do

--- a/server/lib/tuist/storage/cache_artifact_retention.ex
+++ b/server/lib/tuist/storage/cache_artifact_retention.ex
@@ -10,7 +10,9 @@ defmodule Tuist.Storage.CacheArtifactRetention do
   alias Tuist.Storage.RetentionPolicy
 
   @default_page_size 1000
-  @artifact_types [:xcode_cache, :xcode_module, :gradle]
+  @delete_receive_timeout 60_000
+  @delete_task_timeout 65_000
+  @artifact_types [:xcode_cache, :cas, :xcode_module, :gradle]
 
   def artifact_types, do: @artifact_types
 
@@ -37,7 +39,9 @@ defmodule Tuist.Storage.CacheArtifactRetention do
             |> Enum.filter(&matches_retention_target?(&1, target))
             |> expired_objects(target)
 
-          with :ok <- Storage.delete_objects_from_bucket(Enum.map(objects_to_delete, & &1.key), bucket_name) do
+          delete_opts = [receive_timeout: @delete_receive_timeout, task_timeout: @delete_task_timeout]
+
+          with :ok <- Storage.delete_objects_from_bucket(Enum.map(objects_to_delete, & &1.key), bucket_name, delete_opts) do
             {:ok, next_continuation_token(body)}
           end
 
@@ -54,7 +58,7 @@ defmodule Tuist.Storage.CacheArtifactRetention do
     Enum.filter(objects, fn object ->
       # Managed retention only deletes objects whose account resolves to the
       # managed storage path. Unknown and custom-storage accounts are skipped.
-      case Map.get(plans_by_account_handle, account_handle(object)) do
+      case plan_for_object(object, plans_by_account_handle) do
         nil ->
           false
 
@@ -73,6 +77,7 @@ defmodule Tuist.Storage.CacheArtifactRetention do
       objects
       |> Enum.map(&account_handle/1)
       |> Enum.reject(&is_nil/1)
+      |> Enum.flat_map(fn account_handle -> [account_handle, normalize_account_handle(account_handle)] end)
       |> Enum.uniq()
 
     Account
@@ -84,8 +89,23 @@ defmodule Tuist.Storage.CacheArtifactRetention do
       # keeping this at two queries per S3 page instead of one query per account.
       plans_by_account_id = RetentionPolicy.current_plans(accounts)
 
-      Map.new(accounts, fn account -> {account.name, Map.fetch!(plans_by_account_id, account.id)} end)
+      exact_plans_by_account_handle =
+        Map.new(accounts, fn account -> {account.name, Map.fetch!(plans_by_account_id, account.id)} end)
+
+      normalized_plans_by_account_handle =
+        Map.new(accounts, fn account ->
+          {normalize_account_handle(account.name), Map.fetch!(plans_by_account_id, account.id)}
+        end)
+
+      Map.merge(normalized_plans_by_account_handle, exact_plans_by_account_handle)
     end)
+  end
+
+  defp plan_for_object(object, plans_by_account_handle) do
+    account_handle = account_handle(object)
+
+    Map.get(plans_by_account_handle, account_handle) ||
+      Map.get(plans_by_account_handle, normalize_account_handle(account_handle))
   end
 
   defp matches_retention_target?(object, target) do
@@ -103,6 +123,9 @@ defmodule Tuist.Storage.CacheArtifactRetention do
       _ -> nil
     end
   end
+
+  defp normalize_account_handle(nil), do: nil
+  defp normalize_account_handle(account_handle), do: String.downcase(account_handle)
 
   defp last_modified(%{last_modified: %DateTime{} = last_modified}), do: last_modified
 
@@ -122,6 +145,14 @@ defmodule Tuist.Storage.CacheArtifactRetention do
     %{
       bucket_name: Environment.cache_xcode_s3_bucket_name(),
       object_path_segment: "xcode",
+      retention_artifact_type: :xcode_cache_artifact
+    }
+  end
+
+  defp retention_target(:cas) do
+    %{
+      bucket_name: Environment.cache_s3_bucket_name(),
+      object_path_segment: "cas",
       retention_artifact_type: :xcode_cache_artifact
     }
   end

--- a/server/lib/tuist/storage/expired_artifacts.ex
+++ b/server/lib/tuist/storage/expired_artifacts.ex
@@ -22,6 +22,8 @@ defmodule Tuist.Storage.ExpiredArtifacts do
   alias Tuist.Builds
   alias Tuist.Builds.Build
   alias Tuist.ClickHouseRepo
+  alias Tuist.CommandEvents
+  alias Tuist.CommandEvents.Event
   alias Tuist.Projects.Project
   alias Tuist.Repo
   alias Tuist.Shards
@@ -105,6 +107,37 @@ defmodule Tuist.Storage.ExpiredArtifacts do
         end)
 
       delete_and_continue(account, object_keys, next_cursor(rows, batch_size), progress_cursor(:build_archive, rows))
+    end
+  end
+
+  def delete_run_sessions(%Account{} = account, batch_size, opts \\ []) do
+    plan = RetentionPolicy.current_plan(account)
+    cutoff = :run_session |> RetentionPolicy.cutoff(plan) |> DateTime.to_naive()
+    projects_by_id = projects_by_id(account)
+    project_ids = Map.keys(projects_by_id)
+    cursor = initial_cursor(account, :run_session, opts, :naive)
+
+    if project_ids == [] do
+      {:ok, nil}
+    else
+      rows =
+        Event
+        |> where([event], event.project_id in ^project_ids and event.ran_at < ^cutoff)
+        |> apply_cursor(cursor, :ran_at)
+        |> order_by([event], asc: event.ran_at, asc: event.id)
+        |> limit(^batch_size)
+        |> select([event], %{id: event.id, project_id: event.project_id, inserted_at: event.ran_at})
+        |> ClickHouseRepo.all()
+
+      object_keys =
+        Enum.flat_map(rows, fn event ->
+          case Map.fetch(projects_by_id, event.project_id) do
+            {:ok, project} -> [CommandEvents.get_session_key(event.id, %{project | account: account})]
+            :error -> []
+          end
+        end)
+
+      delete_and_continue(account, object_keys, next_cursor(rows, batch_size), progress_cursor(:run_session, rows))
     end
   end
 
@@ -216,13 +249,15 @@ defmodule Tuist.Storage.ExpiredArtifacts do
     |> Map.new(&{&1.id, &1})
   end
 
-  defp apply_cursor(query, nil), do: query
+  defp apply_cursor(query, cursor), do: apply_cursor(query, cursor, :inserted_at)
 
-  defp apply_cursor(query, {inserted_at, id}) do
+  defp apply_cursor(query, nil, _field), do: query
+
+  defp apply_cursor(query, {inserted_at, id}, field) do
     where(
       query,
       [row],
-      row.inserted_at > ^inserted_at or (row.inserted_at == ^inserted_at and row.id > ^id)
+      field(row, ^field) > ^inserted_at or (field(row, ^field) == ^inserted_at and row.id > ^id)
     )
   end
 

--- a/server/lib/tuist/storage/retention_policy.ex
+++ b/server/lib/tuist/storage/retention_policy.ex
@@ -17,6 +17,7 @@ defmodule Tuist.Storage.RetentionPolicy do
     preview_app_build: %{air: 60, open_source: 60, pro: 180, enterprise: 365},
     preview_icon: %{air: 60, open_source: 60, pro: 180, enterprise: 365},
     build_archive: %{air: 30, open_source: 30, pro: 90, enterprise: 365},
+    run_session: %{air: 30, open_source: 30, pro: 90, enterprise: 365},
     test_attachment: %{air: 30, open_source: 30, pro: 90, enterprise: 365},
     shard_bundle: %{air: 7, open_source: 7, pro: 14, enterprise: 30}
   }

--- a/server/lib/tuist/storage/workers/delete_expired_cas_cache_artifacts_worker.ex
+++ b/server/lib/tuist/storage/workers/delete_expired_cas_cache_artifacts_worker.ex
@@ -1,0 +1,31 @@
+defmodule Tuist.Storage.Workers.DeleteExpiredCasCacheArtifactsWorker do
+  @moduledoc false
+  use Oban.Worker,
+    queue: :storage_retention,
+    max_attempts: 3,
+    unique: [keys: [:continuation_token], states: [:available, :scheduled, :executing, :retryable]]
+
+  alias Tuist.Storage.CacheArtifactRetention
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{args: args}) do
+    continuation_token = Map.get(args, "continuation_token")
+
+    with {:ok, next_continuation_token} <-
+           CacheArtifactRetention.delete_expired(:cas, continuation_token: continuation_token) do
+      maybe_enqueue_next_page(next_continuation_token)
+    end
+  end
+
+  defp maybe_enqueue_next_page(nil), do: :ok
+
+  defp maybe_enqueue_next_page(continuation_token) do
+    %{"continuation_token" => continuation_token}
+    |> __MODULE__.new()
+    |> Oban.insert()
+    |> case do
+      {:ok, _job} -> :ok
+      error -> error
+    end
+  end
+end

--- a/server/lib/tuist/storage/workers/delete_expired_run_sessions_worker.ex
+++ b/server/lib/tuist/storage/workers/delete_expired_run_sessions_worker.ex
@@ -1,0 +1,30 @@
+defmodule Tuist.Storage.Workers.DeleteExpiredRunSessionsWorker do
+  @moduledoc false
+  use Oban.Worker,
+    queue: :storage_retention,
+    max_attempts: 3,
+    unique: [keys: [:account_id, :after_inserted_at, :after_id], states: [:available, :scheduled, :executing, :retryable]]
+
+  import Tuist.Storage.Workers.ExpiredArtifactWorker
+
+  alias Tuist.Accounts.Account
+  alias Tuist.Repo
+  alias Tuist.Storage.ExpiredArtifacts
+
+  @default_batch_size 500
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{args: %{"account_id" => account_id} = args}) do
+    batch_size = Map.get(args, "batch_size", @default_batch_size)
+
+    case Repo.get(Account, account_id) do
+      nil ->
+        :ok
+
+      account ->
+        account
+        |> ExpiredArtifacts.delete_run_sessions(batch_size, cursor_from_args(args))
+        |> continue(__MODULE__, account_id, batch_size)
+    end
+  end
+end

--- a/server/lib/tuist/storage/workers/schedule_expired_artifacts_worker.ex
+++ b/server/lib/tuist/storage/workers/schedule_expired_artifacts_worker.ex
@@ -11,6 +11,7 @@ defmodule Tuist.Storage.Workers.ScheduleExpiredArtifactsWorker do
   alias Tuist.Repo
   alias Tuist.Storage.Workers.DeleteExpiredBuildArchivesWorker
   alias Tuist.Storage.Workers.DeleteExpiredPreviewArtifactsWorker
+  alias Tuist.Storage.Workers.DeleteExpiredRunSessionsWorker
   alias Tuist.Storage.Workers.DeleteExpiredShardBundlesWorker
   alias Tuist.Storage.Workers.DeleteExpiredTestAttachmentsWorker
 
@@ -18,6 +19,7 @@ defmodule Tuist.Storage.Workers.ScheduleExpiredArtifactsWorker do
   @deletion_workers [
     DeleteExpiredPreviewArtifactsWorker,
     DeleteExpiredBuildArchivesWorker,
+    DeleteExpiredRunSessionsWorker,
     DeleteExpiredTestAttachmentsWorker,
     DeleteExpiredShardBundlesWorker
   ]

--- a/server/package.json
+++ b/server/package.json
@@ -26,7 +26,8 @@
       "postcss": "8.5.10",
       "shell-quote": "1.8.4",
       "form-data": "4.0.6",
-      "@opentelemetry/core": "2.8.0"
+      "@opentelemetry/core": "2.8.0",
+      "ts-deepmerge": "8.0.0"
     },
     "allowBuilds": {
       "core-js": true,

--- a/server/pnpm-lock.yaml
+++ b/server/pnpm-lock.yaml
@@ -18,6 +18,7 @@ overrides:
   postcss: 8.5.10
   protobufjs: 7.6.4
   shell-quote: 1.8.4
+  ts-deepmerge: 8.0.0
   yaml: 2.8.3
 
 time:
@@ -1351,8 +1352,8 @@ packages:
     resolution: {integrity: sha512-QVsbr1WhGLq2F0oDyYbqtOXcf3gcnL8C9H5EX8bBwAr8ZWvWGJzukpPrDrWgJMrNtgDbo74BIjI4kJu3q2xQWw==}
     engines: {node: '>=18.18.0'}
 
-  ts-deepmerge@7.0.3:
-    resolution: {integrity: sha512-Du/ZW2RfwV/D4cmA5rXafYjBQVuvu4qGiEEla4EmEHVHgRdx68Gftx7i66jn2bzHPwSVZY36Ae6OuDn9el4ZKA==}
+  ts-deepmerge@8.0.0:
+    resolution: {integrity: sha512-133O+10nJmVI8w5xeVZPEv5PIrv7iaUae07wv1aH8XJH95Ur6YIhWAPhPyP1YPlbPS9fCVcNIZTu7m8urRVF0A==}
     engines: {node: '>=14.13.1'}
 
   tslib@2.3.0:
@@ -2067,7 +2068,7 @@ snapshots:
       '@scalar/helpers': 0.4.3
       flatted: 3.4.2
       just-clone: 6.2.0
-      ts-deepmerge: 7.0.3
+      ts-deepmerge: 8.0.0
 
   '@scalar/openapi-parser@0.25.8':
     dependencies:
@@ -3360,7 +3361,7 @@ snapshots:
       string-byte-length: 3.0.1
       string-byte-slice: 3.0.1
 
-  ts-deepmerge@7.0.3: {}
+  ts-deepmerge@8.0.0: {}
 
   tslib@2.3.0: {}
 

--- a/server/test/tuist/oban/runtime_config_test.exs
+++ b/server/test/tuist/oban/runtime_config_test.exs
@@ -12,6 +12,7 @@ defmodule Tuist.Oban.RuntimeConfigTest do
   alias Tuist.Ops.HourlySlackReportWorker
   alias Tuist.Runners.Workers.PruneArchivedLogsWorker
   alias Tuist.Slack.Workers.ReportWorker
+  alias Tuist.Storage.Workers.DeleteExpiredCasCacheArtifactsWorker
   alias Tuist.Storage.Workers.DeleteExpiredGradleCacheArtifactsWorker
   alias Tuist.Storage.Workers.DeleteExpiredXcodeCacheArtifactsWorker
   alias Tuist.Storage.Workers.DeleteExpiredXcodeModuleCacheArtifactsWorker
@@ -67,6 +68,7 @@ defmodule Tuist.Oban.RuntimeConfigTest do
         refute HourlySlackReportWorker in workers
         refute UpdateAllAccountsUsageWorker in workers
         refute ScheduleExpiredArtifactsWorker in workers
+        refute DeleteExpiredCasCacheArtifactsWorker in workers
         refute DeleteExpiredXcodeCacheArtifactsWorker in workers
         refute DeleteExpiredXcodeModuleCacheArtifactsWorker in workers
         refute DeleteExpiredGradleCacheArtifactsWorker in workers
@@ -92,6 +94,7 @@ defmodule Tuist.Oban.RuntimeConfigTest do
         assert HourlySlackReportWorker in workers
         assert UpdateAllAccountsUsageWorker in workers
         assert ScheduleExpiredArtifactsWorker in workers
+        assert DeleteExpiredCasCacheArtifactsWorker in workers
         assert DeleteExpiredXcodeCacheArtifactsWorker in workers
         assert DeleteExpiredXcodeModuleCacheArtifactsWorker in workers
         assert DeleteExpiredGradleCacheArtifactsWorker in workers

--- a/server/test/tuist/storage/cache_artifact_retention_test.exs
+++ b/server/test/tuist/storage/cache_artifact_retention_test.exs
@@ -35,11 +35,38 @@ defmodule Tuist.Storage.CacheArtifactRetentionTest do
 
       expect_accounts_and_plans([%Account{id: 1, name: "tuist"}])
 
-      expect(Storage, :delete_objects_from_bucket, fn [^expired_xcode_key], "xcode-cache-bucket" ->
-        :ok
-      end)
+      expect_delete_objects([expired_xcode_key], "xcode-cache-bucket")
 
       assert CacheArtifactRetention.delete_expired(:xcode_cache) == {:ok, "next-page"}
+    end
+
+    test "deletes expired legacy CAS objects from the cache bucket" do
+      expired_cas_key = "tuist/app/cas/AB/CD/ABCD"
+      recent_cas_key = "tuist/app/cas/EF/GH/EFGH"
+      expired_module_key = "tuist/app/module/builds/AB/CD/ABCD/module.zip"
+
+      expect(Environment, :cache_s3_bucket_name, fn -> "cache-bucket" end)
+
+      expect(Storage, :list_objects_from_bucket, fn "cache-bucket",
+                                                    [prefix: "", max_keys: 1000, continuation_token: nil] ->
+        {:ok,
+         %{
+           body: %{
+             contents: [
+               %{key: expired_cas_key, last_modified: DateTime.add(DateTime.utc_now(), -15, :day)},
+               %{key: recent_cas_key, last_modified: DateTime.add(DateTime.utc_now(), -13, :day)},
+               %{key: expired_module_key, last_modified: DateTime.add(DateTime.utc_now(), -15, :day)}
+             ],
+             is_truncated: false
+           }
+         }}
+      end)
+
+      expect_accounts_and_plans([%Account{id: 1, name: "tuist"}])
+
+      expect_delete_objects([expired_cas_key], "cache-bucket")
+
+      assert CacheArtifactRetention.delete_expired(:cas) == {:ok, nil}
     end
 
     test "uses the cache bucket for module artifacts" do
@@ -64,9 +91,7 @@ defmodule Tuist.Storage.CacheArtifactRetentionTest do
 
       expect_accounts_and_plans([%Account{id: 1, name: "tuist"}])
 
-      expect(Storage, :delete_objects_from_bucket, fn [^expired_module_key], "cache-bucket" ->
-        :ok
-      end)
+      expect_delete_objects([expired_module_key], "cache-bucket")
 
       assert CacheArtifactRetention.delete_expired(:xcode_module, continuation_token: "cursor") == {:ok, nil}
     end
@@ -93,9 +118,7 @@ defmodule Tuist.Storage.CacheArtifactRetentionTest do
 
       expect_accounts_and_plans([%Account{id: 1, name: "tuist"}])
 
-      expect(Storage, :delete_objects_from_bucket, fn [^expired_gradle_key], "cache-bucket" ->
-        :ok
-      end)
+      expect_delete_objects([expired_gradle_key], "cache-bucket")
 
       assert CacheArtifactRetention.delete_expired(:gradle) == {:ok, nil}
     end
@@ -121,9 +144,7 @@ defmodule Tuist.Storage.CacheArtifactRetentionTest do
 
       expect_accounts_and_plans([%Account{id: 1, name: "tuist"}])
 
-      expect(Storage, :delete_objects_from_bucket, fn [^expired_xcode_key], "xcode-cache-bucket" ->
-        :ok
-      end)
+      expect_delete_objects([expired_xcode_key], "xcode-cache-bucket")
 
       assert CacheArtifactRetention.delete_expired(:xcode_cache) == {:ok, "next-page"}
     end
@@ -148,7 +169,7 @@ defmodule Tuist.Storage.CacheArtifactRetentionTest do
 
       expect(Repo, :all, fn _query -> [] end)
 
-      expect(Storage, :delete_objects_from_bucket, fn [], "xcode-cache-bucket" -> :ok end)
+      expect_delete_objects([], "xcode-cache-bucket")
 
       assert CacheArtifactRetention.delete_expired(:xcode_cache) == {:ok, nil}
     end
@@ -184,7 +205,32 @@ defmodule Tuist.Storage.CacheArtifactRetentionTest do
         %Account{id: 2, name: "managed-storage-account"}
       ])
 
-      expect(Storage, :delete_objects_from_bucket, fn [^managed_storage_key], "xcode-cache-bucket" -> :ok end)
+      expect_delete_objects([managed_storage_key], "xcode-cache-bucket")
+
+      assert CacheArtifactRetention.delete_expired(:xcode_cache) == {:ok, nil}
+    end
+
+    test "resolves mixed-case object account handles to managed accounts" do
+      mixed_case_key = "TUIST/app/xcode/AB/CD/ABCD"
+
+      expect(Environment, :cache_xcode_s3_bucket_name, fn -> "xcode-cache-bucket" end)
+
+      expect(Storage, :list_objects_from_bucket, fn "xcode-cache-bucket",
+                                                    [prefix: "", max_keys: 1000, continuation_token: nil] ->
+        {:ok,
+         %{
+           body: %{
+             contents: [
+               %{key: mixed_case_key, last_modified: DateTime.add(DateTime.utc_now(), -15, :day)}
+             ],
+             is_truncated: false
+           }
+         }}
+      end)
+
+      expect_accounts_and_plans([%Account{id: 1, name: "tuist"}])
+
+      expect_delete_objects([mixed_case_key], "xcode-cache-bucket")
 
       assert CacheArtifactRetention.delete_expired(:xcode_cache) == {:ok, nil}
     end
@@ -203,6 +249,14 @@ defmodule Tuist.Storage.CacheArtifactRetentionTest do
 
       %Ecto.Query{from: %{source: {"subscriptions", Subscription}}} ->
         Map.to_list(plans_by_account_id)
+    end)
+  end
+
+  defp expect_delete_objects(keys, bucket_name) do
+    expect(Storage, :delete_objects_from_bucket, fn ^keys, ^bucket_name, opts ->
+      assert opts[:receive_timeout] == 60_000
+      assert opts[:task_timeout] == 65_000
+      :ok
     end)
   end
 end

--- a/server/test/tuist/storage/workers/delete_expired_artifact_workers_test.exs
+++ b/server/test/tuist/storage/workers/delete_expired_artifact_workers_test.exs
@@ -4,6 +4,7 @@ defmodule Tuist.Storage.Workers.DeleteExpiredArtifactWorkersTest do
 
   import TuistTestSupport.Fixtures.AppBuildsFixtures
   import TuistTestSupport.Fixtures.BillingFixtures
+  import TuistTestSupport.Fixtures.CommandEventsFixtures
   import TuistTestSupport.Fixtures.ProjectsFixtures
   import TuistTestSupport.Fixtures.RunsFixtures
   import TuistTestSupport.Fixtures.ShardsFixtures
@@ -11,12 +12,14 @@ defmodule Tuist.Storage.Workers.DeleteExpiredArtifactWorkersTest do
   alias Tuist.AppBuilds
   alias Tuist.AppBuilds.AppBuild
   alias Tuist.Builds
+  alias Tuist.CommandEvents
   alias Tuist.Repo
   alias Tuist.Shards
   alias Tuist.Storage
   alias Tuist.Storage.ArtifactRetentionCursor
   alias Tuist.Storage.Workers.DeleteExpiredBuildArchivesWorker
   alias Tuist.Storage.Workers.DeleteExpiredPreviewArtifactsWorker
+  alias Tuist.Storage.Workers.DeleteExpiredRunSessionsWorker
   alias Tuist.Storage.Workers.DeleteExpiredShardBundlesWorker
   alias Tuist.Storage.Workers.DeleteExpiredTestAttachmentsWorker
   alias Tuist.Tests
@@ -298,6 +301,100 @@ defmodule Tuist.Storage.Workers.DeleteExpiredArtifactWorkersTest do
 
       assert_received {:deleted, second_keys}
       assert second_keys == []
+    end
+
+    test "the run session worker deletes expired session archives according to the account plan" do
+      project = project_fixture()
+      account = project.account
+      subscription_fixture(account_id: account.id, plan: :air)
+
+      expired_run =
+        command_event_fixture(
+          project_id: project.id,
+          ran_at: DateTime.add(DateTime.utc_now(), -31, :day)
+        )
+
+      recent_run =
+        command_event_fixture(
+          project_id: project.id,
+          ran_at: DateTime.add(DateTime.utc_now(), -29, :day)
+        )
+
+      project = %{project | account: account}
+      expired_session_key = CommandEvents.get_session_key(expired_run.id, project)
+      recent_session_key = CommandEvents.get_session_key(recent_run.id, project)
+
+      stub(Storage, :delete_objects, fn object_keys, %{id: account_id} ->
+        assert account_id == account.id
+        send(self(), {:deleted, object_keys})
+        :ok
+      end)
+
+      assert :ok =
+               perform_job(DeleteExpiredRunSessionsWorker, %{
+                 "account_id" => account.id,
+                 "batch_size" => 20
+               })
+
+      assert_received {:deleted, object_keys}
+      assert expired_session_key in object_keys
+      refute recent_session_key in object_keys
+    end
+
+    test "the run session worker paginates by command event run time" do
+      project = project_fixture()
+      account = project.account
+      subscription_fixture(account_id: account.id, plan: :air)
+
+      older_run =
+        command_event_fixture(
+          project_id: project.id,
+          ran_at: DateTime.add(DateTime.utc_now(), -33, :day)
+        )
+
+      newer_run =
+        command_event_fixture(
+          project_id: project.id,
+          ran_at: DateTime.add(DateTime.utc_now(), -32, :day)
+        )
+
+      project = %{project | account: account}
+      older_session_key = CommandEvents.get_session_key(older_run.id, project)
+      newer_session_key = CommandEvents.get_session_key(newer_run.id, project)
+
+      stub(Storage, :delete_objects, fn object_keys, _account ->
+        send(self(), {:deleted, object_keys})
+        :ok
+      end)
+
+      assert :ok =
+               perform_job(DeleteExpiredRunSessionsWorker, %{"account_id" => account.id, "batch_size" => 1})
+
+      assert_received {:deleted, first_keys}
+      assert older_session_key in first_keys
+      refute newer_session_key in first_keys
+
+      assert_enqueued(
+        worker: DeleteExpiredRunSessionsWorker,
+        args: %{
+          "account_id" => account.id,
+          "batch_size" => 1,
+          "after_inserted_at" => NaiveDateTime.to_iso8601(older_run.ran_at),
+          "after_id" => older_run.id
+        }
+      )
+
+      assert :ok =
+               perform_job(DeleteExpiredRunSessionsWorker, %{
+                 "account_id" => account.id,
+                 "batch_size" => 1,
+                 "after_inserted_at" => NaiveDateTime.to_iso8601(older_run.ran_at),
+                 "after_id" => older_run.id
+               })
+
+      assert_received {:deleted, second_keys}
+      assert newer_session_key in second_keys
+      refute older_session_key in second_keys
     end
 
     test "the test attachment worker deletes expired test attachments according to the account plan" do

--- a/server/test/tuist/storage/workers/delete_expired_cache_artifact_workers_test.exs
+++ b/server/test/tuist/storage/workers/delete_expired_cache_artifact_workers_test.exs
@@ -3,6 +3,7 @@ defmodule Tuist.Storage.Workers.DeleteExpiredCacheArtifactWorkersTest do
   use Mimic
 
   alias Tuist.Storage.CacheArtifactRetention
+  alias Tuist.Storage.Workers.DeleteExpiredCasCacheArtifactsWorker
   alias Tuist.Storage.Workers.DeleteExpiredGradleCacheArtifactsWorker
   alias Tuist.Storage.Workers.DeleteExpiredXcodeCacheArtifactsWorker
   alias Tuist.Storage.Workers.DeleteExpiredXcodeModuleCacheArtifactsWorker
@@ -43,6 +44,19 @@ defmodule Tuist.Storage.Workers.DeleteExpiredCacheArtifactWorkersTest do
 
       assert_enqueued(
         worker: DeleteExpiredGradleCacheArtifactsWorker,
+        args: %{"continuation_token" => "next-cursor"}
+      )
+    end
+
+    test "the CAS cache worker deletes expired legacy CAS artifacts and schedules the next page" do
+      expect(CacheArtifactRetention, :delete_expired, fn :cas, [continuation_token: "cursor"] ->
+        {:ok, "next-cursor"}
+      end)
+
+      assert :ok = perform_job(DeleteExpiredCasCacheArtifactsWorker, %{"continuation_token" => "cursor"})
+
+      assert_enqueued(
+        worker: DeleteExpiredCasCacheArtifactsWorker,
         args: %{"continuation_token" => "next-cursor"}
       )
     end

--- a/server/test/tuist/storage_test.exs
+++ b/server/test/tuist/storage_test.exs
@@ -597,6 +597,36 @@ defmodule Tuist.StorageTest do
       assert Storage.delete_object(object_key, :test) == :ok
     end
 
+    test "passes custom timeout options to the bulk deletion API" do
+      # Given
+      object_key = UUIDv7.generate()
+      bucket_name = UUIDv7.generate()
+      config = %{test: :config}
+
+      stub(Environment, :s3_bucket_name, fn -> bucket_name end)
+      stub(ExAws.Config, :new, fn :s3 -> config end)
+
+      delete_operation = %S3{body: UUIDv7.generate()}
+
+      expect(ExAws.S3, :delete_multiple_objects, fn ^bucket_name, [^object_key] ->
+        delete_operation
+      end)
+
+      expect(ExAws, :request, fn ^delete_operation, opts ->
+        assert Map.get(opts, :receive_timeout) == 60_000
+        assert Map.get(opts, :pool_timeout) == 2_000
+        assert Map.get(opts, :test) == :config
+        {:ok, %{status_code: 204}}
+      end)
+
+      # When/Then
+      assert Storage.delete_objects([object_key], :test,
+               receive_timeout: 60_000,
+               pool_timeout: 2_000,
+               task_timeout: 65_000
+             ) == :ok
+    end
+
     test "returns an error on unexpected S3 responses" do
       # Given
       object_key = UUIDv7.generate()

--- a/tuist_common/lib/tuist_common/oban_telemetry.ex
+++ b/tuist_common/lib/tuist_common/oban_telemetry.ex
@@ -5,7 +5,7 @@ defmodule TuistCommon.ObanTelemetry do
 
   def attach do
     :telemetry.attach(
-      "oban-discard-error-reporter",
+      "oban-exception-reporter",
       [:oban, :job, :exception],
       &__MODULE__.handle_exception/4,
       :no_config
@@ -15,16 +15,20 @@ defmodule TuistCommon.ObanTelemetry do
   def handle_exception(
         [:oban, :job, :exception],
         _measurements,
-        %{state: :discard, job: job, kind: kind, reason: reason, stacktrace: stacktrace},
+        %{state: state, job: job, kind: kind, reason: reason, stacktrace: stacktrace},
         :no_config
-      ) do
+      )
+      when state in [:failure, :discard] do
     exception = Exception.normalize(kind, reason, stacktrace)
 
     Sentry.capture_exception(exception,
       stacktrace: stacktrace,
-      tags: %{oban_worker: job.worker, oban_queue: job.queue},
+      tags: %{oban_worker: job.worker, oban_queue: job.queue, oban_state: to_string(state)},
       fingerprint: [job.worker, "{{ default }}"],
-      extra: Map.take(job, [:args, :attempt, :id, :max_attempts, :queue, :worker])
+      extra:
+        job
+        |> Map.take([:args, :attempt, :id, :max_attempts, :queue, :worker])
+        |> Map.put(:oban_state, state)
     )
   end
 

--- a/tuist_common/test/tuist_common/oban_telemetry_test.exs
+++ b/tuist_common/test/tuist_common/oban_telemetry_test.exs
@@ -8,7 +8,7 @@ defmodule TuistCommon.ObanTelemetryTest do
     TuistCommon.ObanTelemetry.attach()
 
     on_exit(fn ->
-      :telemetry.detach("oban-discard-error-reporter")
+      :telemetry.detach("oban-exception-reporter")
     end)
   end
 
@@ -41,9 +41,16 @@ defmodule TuistCommon.ObanTelemetryTest do
     test "reports to Sentry when a job exhausts all attempts" do
       expect(Sentry, :capture_exception, fn exception, opts ->
         assert %RuntimeError{message: "boom"} = exception
-        assert opts[:tags] == %{oban_worker: "MyApp.Worker", oban_queue: "default"}
+
+        assert opts[:tags] == %{
+                 oban_worker: "MyApp.Worker",
+                 oban_queue: "default",
+                 oban_state: "discard"
+               }
+
         assert opts[:extra][:attempt] == 3
         assert opts[:extra][:max_attempts] == 3
+        assert opts[:extra][:oban_state] == :discard
         {:ok, "event-id"}
       end)
 
@@ -62,10 +69,29 @@ defmodule TuistCommon.ObanTelemetryTest do
       })
     end
 
-    test "does not report to Sentry when a job has remaining attempts" do
-      reject(&Sentry.capture_exception/2)
+    test "reports to Sentry when a job has remaining attempts" do
+      expect(Sentry, :capture_exception, fn exception, opts ->
+        assert %RuntimeError{message: "boom"} = exception
+
+        assert opts[:tags] == %{
+                 oban_worker: "MyApp.Worker",
+                 oban_queue: "default",
+                 oban_state: "failure"
+               }
+
+        assert opts[:extra][:attempt] == 1
+        assert opts[:extra][:max_attempts] == 3
+        assert opts[:extra][:oban_state] == :failure
+        {:ok, "event-id"}
+      end)
 
       emit_exception(%{state: :failure})
+    end
+
+    test "does not report non-failure states" do
+      reject(&Sentry.capture_exception/2)
+
+      emit_exception(%{state: :cancelled})
     end
   end
 end


### PR DESCRIPTION
## What changed

- Added hosted retention coverage for legacy CAS cache artifacts and scheduled it alongside the existing cache retention workers.
- Kept Xcode, CAS, module, and Gradle cache artifacts on the shared plan-based cache retention policy, including case-insensitive managed account handle resolution for object prefixes.
- Increased bulk object-delete timeouts and made async delete timeouts return tagged errors so Oban can retry and surface them instead of crashing the worker process.
- Report Oban retry failures to Sentry with worker, queue, and state tags, not only final discards.
- Added an account-scoped run session archive retention worker that deletes expired session archives from primary storage while preserving command event metadata.
- Updated the server JS lockfile resolution for `ts-deepmerge` to `8.0.0` after CI exposed a Trivy vulnerability in the previous transitive version.

## Why

The production storage investigation showed that Tigris usage was still higher than expected even though old-object deletion workers were running. The first expectation gap was cache-related: Xcode cache objects were covered, but legacy CAS cache objects did not have equivalent hosted retention coverage, and some managed account prefixes could be skipped when object handle casing differed from the database row.

The bucket review also found run session archives in primary storage that were not covered by the existing daily artifact-retention scheduler. Those archives are user-generated blobs with the same retention expectations as other run artifacts, so leaving them out meant storage could keep growing even when build archives, previews, test attachments, shard bundles, and cache artifacts were cleaned up.

Operationally, storage-retention failures also needed earlier visibility. A retrying Oban job could fail repeatedly without a Sentry event until final discard, which made it too easy to miss transient storage provider, timeout, or batch-size problems.

## Root cause

Legacy CAS cache objects were not scheduled through their own hosted retention worker, so the cache cleanup surface did not match the actual object families in the cache bucket. Managed account resolution also depended on exact handle casing from object keys, which could skip valid hosted accounts when the stored prefix differed in case.

Run session archives are keyed from command events and stored under the run artifact prefix, but the retention scheduler only covered the DB-backed artifact families that already had workers. Since command event metadata lives separately from the object blob, the object needed its own retention worker keyed by command event run time.

The CI failure had a separate root cause: the server lockfile still resolved transitive `ts-deepmerge@7.0.3`, and Trivy flagged `CVE-2026-12644`, which is fixed in `8.0.0`.

## Approach

The cleanup changes stay inside the existing retention architecture rather than adding a one-off bucket scanner. Plan windows remain centralized in `Tuist.Storage.RetentionPolicy`, account-scoped progress continues to use persisted artifact retention cursors, and deletion still goes through the existing storage abstraction.

For run sessions, the worker queries command events by `ran_at`, derives the existing session object key, deletes only the archive blob, and keeps the command event row intact for dashboards and analytics. That matches the behavior of the other artifact-retention workers, where old blobs are removed without deleting historical metadata.

For the dependency vulnerability, the fix uses the existing `pnpm.overrides` mechanism and updates only the targeted `ts-deepmerge` lockfile entries instead of re-resolving the broader JavaScript dependency graph.

## Impact

Hosted storage retention now covers the cache and run-session object families found during the bucket review, which should reduce retained Tigris data according to the existing plan windows. Retryable retention failures should show up in Sentry earlier, making timeout or provider issues easier to diagnose before a job reaches final discard.

The metadata users see in dashboards remains intact; this changes deletion of expired blobs, not historical run, build, test, preview, or command event records. Production object keys, account handles, credentials, and cluster-specific continuation tokens are intentionally omitted from this description.

## Validation

- `cd server && mix test test/tuist/storage/cache_artifact_retention_test.exs test/tuist/storage/workers/delete_expired_cache_artifact_workers_test.exs test/tuist/oban/runtime_config_test.exs test/tuist/storage_test.exs`
- `cd tuist_common && mix test test/tuist_common/oban_telemetry_test.exs`
- `cd server && mix test test/tuist/storage/workers/delete_expired_artifact_workers_test.exs test/tuist/storage/workers/schedule_expired_artifacts_worker_test.exs test/tuist/storage/artifact_retention_cursor_test.exs test/tuist/storage/cache_artifact_retention_test.exs test/tuist/storage/workers/delete_expired_cache_artifact_workers_test.exs`
- `cd server && aube install --frozen-lockfile`
- `cd server && ./mise/tasks/security.sh`
- `git diff --check`
- `gh pr checks 11398` shows the current head's visible checks passing, including `Lint PR` and CodeQL. The earlier `Server / Security` failure was tied to the pre-rebase SHA and is covered locally by the security task above.
