### PR TITLE
fix(swifterpm): stabilize Package.resolved locations

### DIFF
--- a/swifterpm/Sources/swifterpm/GitHub.swift
+++ b/swifterpm/Sources/swifterpm/GitHub.swift
@@ -7,8 +7,8 @@ struct GitHubRepo: Sendable {
     init(location: String) throws {
         let normalized =
             location.hasPrefix("git@github.com:")
-            ? location.replacingOccurrences(of: "git@github.com:", with: "https://github.com/")
-            : location
+                ? location.replacingOccurrences(of: "git@github.com:", with: "https://github.com/")
+                : location
         guard let url = URL(string: normalized), url.host == "github.com" else {
             throw ToolError.message("not a GitHub URL")
         }
@@ -33,7 +33,7 @@ private actor GitHubTokenCache {
 
         let env = ProcessInfo.processInfo.environment
         if let token = env["GITHUB_TOKEN"] ?? env["GH_TOKEN"],
-            !token.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+           !token.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         {
             cachedToken = token
             return token
@@ -62,6 +62,25 @@ enum GitHubAuth {
 }
 
 enum SourceControlLocations {
+    static func canonicalResolvedFileLocation(_ location: String) -> String {
+        if let shorthandLocation = ColonSeparatedGitLocation(location) {
+            return shorthandLocation.canonicalString
+        }
+        guard var components = URLComponents(string: location),
+              let host = components.host
+        else {
+            return location
+        }
+
+        components.scheme = components.scheme?.lowercased()
+        let normalizedHost = host.lowercased()
+        components.host = normalizedHost
+        if canonicalizesProviderPath(host: normalizedHost) {
+            components.path = canonicalProviderPath(components.path)
+        }
+        return components.string ?? location
+    }
+
     static func fetchCandidates(_ location: String) -> [String] {
         var locations = [location]
         appendGitHubSSHLocation(for: location, to: &locations)
@@ -69,8 +88,7 @@ enum SourceControlLocations {
         return locations
     }
 
-    private static func appendGitHubSSHLocation(for location: String, to locations: inout [String])
-    {
+    private static func appendGitHubSSHLocation(for location: String, to locations: inout [String]) {
         guard let repo = try? GitHubRepo(location: location) else { return }
         let ssh = "git@github.com:\(repo.owner)/\(repo.repo).git"
         if !locations.contains(ssh) {
@@ -78,12 +96,60 @@ enum SourceControlLocations {
         }
     }
 
-    private static func appendGitLabSSHLocation(for location: String, to locations: inout [String])
-    {
+    private static func appendGitLabSSHLocation(for location: String, to locations: inout [String]) {
         guard let repo = try? GitLabRepo(location: location) else { return }
         let ssh = "git@\(repo.host):\(repo.pathWithNamespace).git"
         if !locations.contains(ssh) {
             locations.append(ssh)
         }
+    }
+
+    fileprivate static func canonicalProviderPath(_ path: String) -> String {
+        let trimmed = path.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        let withoutGit =
+            trimmed.lowercased().hasSuffix(".git")
+                ? String(trimmed.dropLast(4)) : trimmed
+        let path = withoutGit.lowercased()
+        return path.isEmpty ? "" : "/\(path)"
+    }
+
+    fileprivate static func canonicalizesProviderPath(host: String) -> Bool {
+        let host = host.lowercased()
+        return host == "github.com" || GitLabRepo.isKnownHost(host)
+    }
+}
+
+private struct ColonSeparatedGitLocation {
+    let user: String
+    let host: String
+    let path: String
+
+    init?(_ location: String) {
+        guard !location.contains("://"),
+              let at = location.firstIndex(of: "@"),
+              let colon = location[location.index(after: at)...].firstIndex(of: ":")
+        else {
+            return nil
+        }
+
+        let user = String(location[..<at])
+        let host = String(location[location.index(after: at) ..< colon])
+        let path = String(location[location.index(after: colon)...])
+        guard !user.isEmpty, !host.isEmpty, !path.isEmpty else { return nil }
+
+        self.user = user
+        self.host = host
+        self.path = path
+    }
+
+    var canonicalString: String {
+        let normalizedHost = host.lowercased()
+        let normalizedPath = if SourceControlLocations.canonicalizesProviderPath(host: normalizedHost) {
+            SourceControlLocations.canonicalProviderPath(path)
+                .trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        } else {
+            path
+        }
+        return "\(user)@\(normalizedHost):\(normalizedPath)"
     }
 }

--- a/swifterpm/Sources/swifterpm/GitLab.swift
+++ b/swifterpm/Sources/swifterpm/GitLab.swift
@@ -8,7 +8,7 @@ struct GitLabRepo: Sendable {
     init(location: String) throws {
         let normalized = Self.normalize(location)
         guard let url = URL(string: normalized),
-            let host = url.host?.lowercased()
+              let host = url.host?.lowercased()
         else {
             throw ToolError.message("not a GitLab URL")
         }
@@ -17,8 +17,8 @@ struct GitLabRepo: Sendable {
             .split(separator: "/")
             .map(String.init)
             .joined(separator: "/")
-        guard Self.isKnownGitLabHost(host),
-            path.split(separator: "/").count >= 2
+        guard Self.isKnownHost(host),
+              path.split(separator: "/").count >= 2
         else {
             throw ToolError.message("not a GitLab URL")
         }
@@ -33,8 +33,8 @@ struct GitLabRepo: Sendable {
         let apiHost = env["GITLAB_API_HOST"]?.gitLabNormalizedHost ?? host
         let apiScheme =
             env["GITLAB_URI"].flatMap(URL.init(string:))?.scheme
-            ?? env["GITLAB_HOST"].flatMap(URL.init(string:))?.scheme
-            ?? scheme
+                ?? env["GITLAB_HOST"].flatMap(URL.init(string:))?.scheme
+                ?? scheme
         return URL(string: "\(apiScheme)://\(apiHost)/api/v4")!
     }
 
@@ -55,12 +55,12 @@ struct GitLabRepo: Sendable {
         if location.hasPrefix("ssh://git@") {
             return
                 location
-                .replacingOccurrences(of: "ssh://git@", with: "https://")
+                    .replacingOccurrences(of: "ssh://git@", with: "https://")
         }
         return location
     }
 
-    private static func isKnownGitLabHost(_ host: String) -> Bool {
+    static func isKnownHost(_ host: String) -> Bool {
         if host == "gitlab.com" || host.contains("gitlab") {
             return true
         }
@@ -101,11 +101,11 @@ enum GitLabAuth {
 
         var header: [String: String] {
             switch self {
-            case .privateToken(let token):
+            case let .privateToken(token):
                 return ["PRIVATE-TOKEN": token]
-            case .jobToken(let token):
+            case let .jobToken(token):
                 return ["JOB-TOKEN": token]
-            case .bearer(let token):
+            case let .bearer(token):
                 return ["Authorization": "Bearer \(token)"]
             }
         }
@@ -145,11 +145,10 @@ private actor GitLabTokenCache {
             return .jobToken(token)
         }
 
-        guard
-            let output = try? await SystemProcess.output(
-                "/usr/bin/env",
-                ["glab", "config", "get", "token", "--host", host]
-            )
+        guard let output = try? await SystemProcess.output(
+            "/usr/bin/env",
+            ["glab", "config", "get", "token", "--host", host]
+        )
         else {
             return nil
         }
@@ -159,7 +158,7 @@ private actor GitLabTokenCache {
 
     private func nonEmpty(_ value: String?) -> String? {
         guard let token = value?.trimmingCharacters(in: .whitespacesAndNewlines),
-            !token.isEmpty
+              !token.isEmpty
         else {
             return nil
         }
@@ -213,10 +212,11 @@ enum GitLabAPI {
                 repo.encodedProjectPath, ["repository", "archive.tar.gz"]
             )
             .appending(queryItems: [
-                URLQueryItem(name: "sha", value: revision)
+                URLQueryItem(name: "sha", value: revision),
             ])
         try await HTTPClient.download(
-            url: url, destination: destination, headers: try await headers(for: repo))
+            url: url, destination: destination, headers: try await headers(for: repo)
+        )
     }
 
     private static func headers(for repo: GitLabRepo) async throws -> [String: String] {

--- a/swifterpm/Sources/swifterpm/Models.swift
+++ b/swifterpm/Sources/swifterpm/Models.swift
@@ -37,6 +37,21 @@ struct ResolvedPins: Codable, Sendable {
         case pins
         case version
     }
+
+    func normalizedForResolvedFile() -> ResolvedPins {
+        var normalized = self
+        normalized.pins = pins
+            .map { $0.normalizedForResolvedFile() }
+            .sorted {
+                let lhsIdentity = $0.identity.lowercased()
+                let rhsIdentity = $1.identity.lowercased()
+                if lhsIdentity == rhsIdentity {
+                    return $0.location.lowercased() < $1.location.lowercased()
+                }
+                return lhsIdentity < rhsIdentity
+            }
+        return normalized
+    }
 }
 
 struct ResolvedPin: Codable, Equatable, Sendable {
@@ -118,6 +133,29 @@ struct ResolvedPin: Codable, Equatable, Sendable {
         case state
     }
 
+    func normalizedForResolvedFile() -> ResolvedPin {
+        var normalized = self
+        if let originalLocation {
+            normalized.originalLocation = Self.normalizedRemoteSourceControlLocation(originalLocation)
+        }
+        guard PinKind.isSourceControl(kind),
+              kind != "localSourceControl",
+              !location.hasPrefix("/"),
+              URL(string: location)?.isFileURL != true
+        else { return normalized }
+
+        normalized.identity = identity.lowercased()
+        normalized.location = Self.normalizedRemoteSourceControlLocation(location)
+        return normalized
+    }
+
+    private static func normalizedRemoteSourceControlLocation(_ location: String) -> String {
+        guard !location.hasPrefix("/"),
+              URL(string: location)?.isFileURL != true
+        else { return location }
+        return SourceControlLocations.canonicalResolvedFileLocation(location)
+    }
+
     func revision() throws -> String {
         guard let revision = state.revision else {
             throw ToolError.message("\(identity) does not have a source-control revision")
@@ -164,6 +202,7 @@ enum ResolvedFile {
             try await fileSystem.removePath(path)
             return
         }
+        let resolved = resolved.normalizedForResolvedFile()
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
         let data = try encoder.encode(resolved) + Data("\n".utf8)

--- a/swifterpm/Sources/swifterpm/Resolve.swift
+++ b/swifterpm/Sources/swifterpm/Resolve.swift
@@ -5,7 +5,7 @@ enum PackageResolver {
         packageDir: URL,
         scratchDir: URL? = nil,
         cache: Cache,
-        registryConfig: RegistryConfig,
+        registryConfig _: RegistryConfig,
         registryConfigurationPath: URL? = nil,
         defaultRegistryURL: String? = nil,
         disableSandbox: Bool,
@@ -15,7 +15,8 @@ enum PackageResolver {
         progress: ResolutionProgressReporter? = nil
     ) async throws -> ResolvedPins {
         let manifest = try await ManifestLoader.dumpPackage(
-            packageDir: packageDir, disableSandbox: disableSandbox)
+            packageDir: packageDir, disableSandbox: disableSandbox
+        )
         var manifestDependencies = try ManifestParser.dependencies(manifest)
         let localPackages = try await ManifestFileSystemDependencyGraph.collect(
             rootPackageDir: packageDir,
@@ -68,9 +69,7 @@ enum PackageResolver {
         )
         resolved.originHash = originHash
         resolved.pins = dedupePinsByIdentity(resolved.pins)
-        // Match SwiftPM's case-insensitive identity sort so the lockfile is
-        // byte-equivalent regardless of which tool wrote it.
-        resolved.pins.sort { $0.identity.lowercased() < $1.identity.lowercased() }
+        resolved = resolved.normalizedForResolvedFile()
         if writeResolvedFile {
             // SwiftPM writes Package.resolved with its own originHash; rewrite
             // with ours so consumers can detect manifest changes.
@@ -99,7 +98,7 @@ enum PackageResolver {
         let resolvedPath = packageDir.appendingPathComponent("Package.resolved")
         let snapshot =
             (!writeResolvedFile || !useExistingResolvedFile)
-            ? try await snapshotResolvedFile(at: resolvedPath) : nil
+                ? try await snapshotResolvedFile(at: resolvedPath) : nil
         if !useExistingResolvedFile {
             try? await fileSystem.removePath(resolvedPath)
         }
@@ -226,7 +225,9 @@ enum PackageResolver {
         if preferResolvedFile,
            let existing = try await ResolvedFile.readIfCurrent(packageDir: packageDir)
         {
-            return existing
+            return try await normalizeLoadedResolvedFile(
+                existing, packageDir: packageDir, writeResolvedFile: writeResolvedFile
+            )
         }
         // Mirror SwiftPM: `resolve` seeds the solver with the existing
         // Package.resolved (even a stale one) so only pins that no longer
@@ -256,13 +257,25 @@ enum PackageResolver {
         )
     }
 
+    private static func normalizeLoadedResolvedFile(
+        _ resolved: ResolvedPins,
+        packageDir: URL,
+        writeResolvedFile: Bool
+    ) async throws -> ResolvedPins {
+        let normalized = resolved.normalizedForResolvedFile()
+        if writeResolvedFile {
+            try await ResolvedFile.write(packageDir: packageDir, resolved: normalized)
+        }
+        return normalized
+    }
+
     static func dedupePinsByIdentity(_ pins: [ResolvedPin]) -> [ResolvedPin] {
         var order: [String] = []
         var chosen: [String: ResolvedPin] = [:]
         for pin in pins {
             let key = pin.identity.lowercased()
             if let existing = chosen[key] {
-                if existing.state.version == nil && pin.state.version != nil {
+                if existing.state.version == nil, pin.state.version != nil {
                     chosen[key] = pin
                 }
             } else {
@@ -313,10 +326,10 @@ enum PackageResolver {
         let prefix = "swift-tools-version"
         guard let colon = firstLine.range(of: prefix),
               let version = firstLine[colon.upperBound...]
-                .drop(while: { $0 == ":" || $0.isWhitespace })
-                .split(separator: ".", maxSplits: 2, omittingEmptySubsequences: false)
-                .prefix(2)
-                .map(String.init) as [String]?,
+              .drop(while: { $0 == ":" || $0.isWhitespace })
+              .split(separator: ".", maxSplits: 2, omittingEmptySubsequences: false)
+              .prefix(2)
+              .map(String.init) as [String]?,
               version.count >= 2,
               let major = Int(version[0]),
               let minor = Int(version[1].prefix(while: { $0.isNumber }))
@@ -329,7 +342,7 @@ enum PackageResolver {
         if toolsVersion.major > 5 || (toolsVersion.major == 5 && toolsVersion.minor > 9) {
             return 3
         }
-        if toolsVersion.major == 5 && toolsVersion.minor >= 6 {
+        if toolsVersion.major == 5, toolsVersion.minor >= 6 {
             return 2
         }
         return 1

--- a/swifterpm/Tests/swifterpmTests/GitHubTests.swift
+++ b/swifterpm/Tests/swifterpmTests/GitHubTests.swift
@@ -34,12 +34,36 @@ struct GitHubTests {
             ])
         #expect(
             SourceControlLocations.fetchCandidates("git@github.com:tuist/swifterpm.git") == [
-                "git@github.com:tuist/swifterpm.git"
+                "git@github.com:tuist/swifterpm.git",
             ])
         #expect(
             SourceControlLocations.fetchCandidates("https://gitlab.com/tuist/swifterpm") == [
                 "https://gitlab.com/tuist/swifterpm",
                 "git@gitlab.com:tuist/swifterpm.git",
             ])
+    }
+
+    @Test
+    func canonicalResolvedFileLocationsStabilizeProviderLocations() {
+        #expect(
+            SourceControlLocations.canonicalResolvedFileLocation(
+                "https://github.com/CombineCommunity/CombineExt.git")
+                == "https://github.com/combinecommunity/combineext")
+        #expect(
+            SourceControlLocations.canonicalResolvedFileLocation(
+                "git@github.com:DataDog/dd-sdk-ios.git")
+                == "git@github.com:datadog/dd-sdk-ios")
+        #expect(
+            SourceControlLocations.canonicalResolvedFileLocation(
+                "https://gitlab.com/Tuist/SwifterPM.git")
+                == "https://gitlab.com/tuist/swifterpm")
+        #expect(
+            SourceControlLocations.canonicalResolvedFileLocation(
+                "HTTPS://Source.Example.com/Tuist/SwifterPM.git")
+                == "https://source.example.com/Tuist/SwifterPM.git")
+        #expect(
+            SourceControlLocations.canonicalResolvedFileLocation(
+                "git@Source.Example.com:Tuist/SwifterPM.git")
+                == "git@source.example.com:Tuist/SwifterPM.git")
     }
 }

--- a/swifterpm/Tests/swifterpmTests/ModelsTests.swift
+++ b/swifterpm/Tests/swifterpmTests/ModelsTests.swift
@@ -103,7 +103,7 @@ struct ModelsTests {
     }
 
     @Test
-    func resolvedPinRoundTripsOriginalLocationFromReplaceSCMWithRegistry() async throws {
+    func registryPinNormalizesOriginalLocationFromReplaceSCMWithRegistry() async throws {
         // SwiftPM emits `originalLocation` on pins it rewrote via
         // --replace-scm-with-registry so the next resolve can skip the
         // registry identifier lookup. Dropping it on the read/write
@@ -119,7 +119,14 @@ struct ModelsTests {
                         kind: "registry",
                         location: "",
                         state: ResolvedState(branch: nil, revision: nil, version: "1.5.0"),
-                        originalLocation: "https://github.com/apple/swift-log.git"
+                        originalLocation: "https://github.com/Apple/swift-log.git"
+                    ),
+                    ResolvedPin(
+                        identity: "example.package",
+                        kind: "registry",
+                        location: "",
+                        state: ResolvedState(branch: nil, revision: nil, version: "2.0.0"),
+                        originalLocation: "HTTPS://Source.Example.com/Tuist/SwifterPM.git"
                     ),
                 ],
                 version: 3
@@ -127,49 +134,114 @@ struct ModelsTests {
 
             try await ResolvedFile.write(packageDir: root, resolved: resolved)
             let readBack = try await ResolvedFile.read(packageDir: root)
-            #expect(readBack.pins.first?.originalLocation == "https://github.com/apple/swift-log.git")
+            let readBackByIdentity = Dictionary(uniqueKeysWithValues: readBack.pins.map {
+                ($0.identity, $0)
+            })
+            #expect(readBackByIdentity["apple.swift-log"]?.originalLocation == "https://github.com/apple/swift-log")
+            #expect(readBackByIdentity["example.package"]?.originalLocation == "https://source.example.com/Tuist/SwifterPM.git")
 
             let resolvedFilePath = root.appendingPathComponent("Package.resolved")
             let rawData = try await fileSystem.readFile(at: resolvedFilePath.absolutePath)
-            let rawContents = try #require(String(data: rawData, encoding: .utf8))
-            #expect(rawContents.contains("\"originalLocation\""))
+            let rawPayload = try #require(
+                JSONSerialization.jsonObject(with: rawData) as? [String: Any]
+            )
+            let rawPins = try #require(rawPayload["pins"] as? [[String: Any]])
+            let rawPinsByIdentity = Dictionary(
+                uniqueKeysWithValues: rawPins.compactMap { pin -> (String, [String: Any])? in
+                    guard let identity = pin["identity"] as? String else { return nil }
+                    return (identity, pin)
+                }
+            )
+            #expect(rawPinsByIdentity["apple.swift-log"]?["originalLocation"] as? String == "https://github.com/apple/swift-log")
+            #expect(rawPinsByIdentity["example.package"]?["originalLocation"] as? String ==
+                "https://source.example.com/Tuist/SwifterPM.git")
         }
     }
 
     @Test
-    func writePreservesDeclaredLocationsAndSkipsIdenticalRewrites() async throws {
+    func writeNormalizesRemoteLocationsAndSkipsIdenticalRewrites() async throws {
         try await withTemporaryDirectory { root in
             try await writeMinimalPackageManifest(at: root, name: "Fixture")
-            // Locations must be persisted exactly as declared in manifests:
-            // ssh form, mixed case, and the .git suffix all stay untouched so
-            // Package.resolved stays interchangeable with SwiftPM's output.
-            let locations = [
-                "git@github.com:riversidefm/Riverside-Mobile-Shared.git",
-                "https://github.com/openid/AppAuth-iOS.git",
-                "https://github.com/jpsim/Yams",
+            let pins = [
+                ResolvedPin(
+                    identity: "CombineExt",
+                    kind: "remoteSourceControl",
+                    location: "https://github.com/CombineCommunity/CombineExt.git",
+                    state: ResolvedState(
+                        branch: nil, revision: "abcdef123456", version: "1.0.0"
+                    )
+                ),
+                ResolvedPin(
+                    identity: "dd-sdk-ios",
+                    kind: "remoteSourceControl",
+                    location: "git@github.com:DataDog/dd-sdk-ios.git",
+                    state: ResolvedState(
+                        branch: nil, revision: "abcdef123456", version: "1.0.0"
+                    )
+                ),
+                ResolvedPin(
+                    identity: "swifterpm",
+                    kind: "remoteSourceControl",
+                    location: "https://gitlab.com/Tuist/SwifterPM.git",
+                    state: ResolvedState(
+                        branch: nil, revision: "abcdef123456", version: "1.0.0"
+                    )
+                ),
+                ResolvedPin(
+                    identity: "generic",
+                    kind: "remoteSourceControl",
+                    location: "HTTPS://Source.Example.com/Tuist/SwifterPM.git",
+                    state: ResolvedState(
+                        branch: nil, revision: "abcdef123456", version: "1.0.0"
+                    )
+                ),
+                ResolvedPin(
+                    identity: "LocalPackage",
+                    kind: "localSourceControl",
+                    location: "file:///tmp/LocalPackage.git",
+                    state: ResolvedState(
+                        branch: nil, revision: "abcdef123456", version: "1.0.0"
+                    )
+                ),
             ]
             let resolved = try ResolvedPins(
                 originHash: await ResolvedFile.packageOriginHash(packageDir: root),
-                pins: locations.enumerated().map { index, location in
-                    ResolvedPin(
-                        identity: "dependency-\(index)",
-                        kind: "remoteSourceControl",
-                        location: location,
-                        state: ResolvedState(
-                            branch: nil, revision: "abcdef123456", version: "1.0.0"
-                        )
-                    )
-                },
+                pins: pins,
                 version: 3
             )
 
             try await ResolvedFile.write(packageDir: root, resolved: resolved)
             let resolvedFilePath = try root.appendingPathComponent("Package.resolved").absolutePath
             let rawData = try await fileSystem.readFile(at: resolvedFilePath)
-            let rawContents = try #require(String(data: rawData, encoding: .utf8))
-            for location in locations {
-                #expect(rawContents.contains("\"\(location)\""))
-            }
+            let rawPayload = try #require(
+                JSONSerialization.jsonObject(with: rawData) as? [String: Any]
+            )
+            let rawPins = try #require(rawPayload["pins"] as? [[String: Any]])
+            let rawPinsByIdentity = Dictionary(
+                uniqueKeysWithValues: rawPins.compactMap { pin -> (String, [String: Any])? in
+                    guard let identity = pin["identity"] as? String else { return nil }
+                    return (identity, pin)
+                }
+            )
+            let rawLocations = Set(rawPins.compactMap { $0["location"] as? String })
+            #expect(
+                try await ResolvedFile.read(packageDir: root).pins
+                    == resolved.normalizedForResolvedFile().pins)
+            #expect(Set(rawPinsByIdentity.keys) == Set([
+                "LocalPackage",
+                "combineext",
+                "dd-sdk-ios",
+                "generic",
+                "swifterpm",
+            ]))
+            #expect(rawPinsByIdentity["combineext"]?["location"] as? String == "https://github.com/combinecommunity/combineext")
+            #expect(rawPinsByIdentity["dd-sdk-ios"]?["location"] as? String == "git@github.com:datadog/dd-sdk-ios")
+            #expect(rawPinsByIdentity["swifterpm"]?["location"] as? String == "https://gitlab.com/tuist/swifterpm")
+            #expect(rawPinsByIdentity["generic"]?["location"] as? String == "https://source.example.com/Tuist/SwifterPM.git")
+            #expect(rawPinsByIdentity["LocalPackage"]?["location"] as? String == "file:///tmp/LocalPackage.git")
+            #expect(!rawLocations.contains("https://github.com/CombineCommunity/CombineExt.git"))
+            #expect(!rawLocations.contains("git@github.com:DataDog/dd-sdk-ios.git"))
+            #expect(!rawLocations.contains("HTTPS://Source.Example.com/Tuist/SwifterPM.git"))
 
             // Rewriting unchanged content must leave the file untouched.
             let modificationDate = try await fileSystem.fileMetadata(at: resolvedFilePath)?


### PR DESCRIPTION
## What changed

SwifterPM now canonicalizes remote source-control locations before encoding `Package.resolved`. For GitHub and GitLab locations, normalization removes trailing `.git` suffixes, lowercases repository paths, and handles colon-separated Git locations. For generic Git hosts, it only lowercases the scheme and host, preserving repository path casing and `.git` suffixes so private hosts keep their declared fetch path.

Registry pins now normalize `originalLocation` when [Swift Package Manager](https://www.swift.org/package-manager/) rewrites source-control dependencies through `--replace-scm-with-registry`. Local source-control paths, file-based locations, and registry pin locations are intentionally left untouched.

## Why

Teams are using `Package.resolved` as both a review artifact and a cache key. Equivalent dependency locations with different spelling, for example mixed casing or a `.git` suffix on provider-hosted repositories, create repeated lockfile churn and reduce cache reuse even when the resolved dependency did not change.

## Root cause

[Swift Package Manager](https://www.swift.org/package-manager/) already compares source-control dependencies through canonical package locations, but when it rewrites `Package.resolved` it serializes the active dependency spelling. Registry-rewritten pins can carry that same spelling under `originalLocation`, so normalizing only `location` still leaves a source of lockfile churn.

## Approach

The normalization happens at SwifterPM's resolved-file boundary instead of changing restore or checkout behavior. Provider-hosted repositories get the stable spelling that those providers accept, while generic Git hosts keep their path spelling to avoid breaking private servers where casing or `.git` may be part of the fetch path.

`originalLocation` reuses the same source-control normalization helper, so registry-rewritten pins become stable without changing the registry pin schema.

## Impact

`Package.resolved` becomes more stable across machines, package graph rewrites, and dependency declaration formats. Existing local package workflows, registry dependency locations, and private Git hosts with path-sensitive fetch routes remain protected.

## Validation

- `swiftformat swifterpm/Sources/swifterpm/GitHub.swift swifterpm/Sources/swifterpm/GitLab.swift swifterpm/Sources/swifterpm/Models.swift swifterpm/Sources/swifterpm/Resolve.swift swifterpm/Tests/swifterpmTests/GitHubTests.swift swifterpm/Tests/swifterpmTests/ModelsTests.swift`
- `swift test --replace-scm-with-registry` from `swifterpm/`
- `swift test --filter WorkspaceTests.testResolvedFileStableCanonicalLocation` from a temporary Swift Package Manager clone
