### PR TITLE
fix(server): make table row navigation work in Safari

### DIFF
--- a/noora/css/table.css
+++ b/noora/css/table.css
@@ -399,45 +399,25 @@
     }
   }
 
-  /* Whole-row navigation. A single anchor in the first cell carries the link; its `::after`
-   * overlay stretches across the row (which is the positioning context) so the entire row is the
-   * click target, while the DOM holds just one link per row. Trade-off: the overlay sits over the
-   * row's text, so text in navigable rows isn't selectable. */
-  & tr:has([data-part="row-link"]) {
-    position: relative;
-  }
-
+  /* Whole-row navigation. A single real anchor lives in the first cell — one tab stop, announced
+   * once — and the `NooraTable` hook forwards clicks on the rest of the row to it. We drive this
+   * from JS rather than a stretched CSS overlay: an absolutely-positioned `::after` needs the
+   * `<tr>` as its containing block, but Safari/WebKit never makes a `<tr>` one, so the overlay
+   * escaped to the `<table>` and covered the whole grid — the topmost row's overlay then swallowed
+   * every click and hover. The JS hit area is row-wide in every engine and leaves text selectable. */
   & [data-part="row-link"] {
+    display: block;
     color: inherit;
     text-decoration: none;
 
-    &::after {
-      position: absolute;
-      inset: 0;
-      z-index: 0;
-      content: "";
-    }
-
     &:focus-visible {
-      outline: none;
-
-      &::after {
-        outline: 2px solid
-          light-dark(
-            var(--noora-neutral-light-1000),
-            var(--noora-neutral-dark-1200)
-          );
-        outline-offset: -2px;
-      }
+      outline: 2px solid
+        light-dark(
+          var(--noora-neutral-light-1000),
+          var(--noora-neutral-dark-1200)
+        );
+      outline-offset: -2px;
     }
-  }
-
-  /* Controls in the row's other cells must sit above the overlay to stay clickable. */
-  &
-    tr:has([data-part="row-link"])
-    :is(a, button, input, select, [tabindex]):not([data-part="row-link"]) {
-    position: relative;
-    z-index: 1;
   }
 
   & [data-part="cell"] {

--- a/noora/js/Table.js
+++ b/noora/js/Table.js
@@ -149,6 +149,40 @@ export default {
     const table = this.container.querySelector("table");
     if (table) this.resizeObserver.observe(table);
 
+    // Whole-row navigation. Each navigable row carries a single real anchor
+    // (`[data-part="row-link"]`) in its first cell for keyboard and assistive tech; here we widen
+    // the pointer hit area to the whole row by forwarding a click on any passive part of the row
+    // to that anchor (LiveView's document-level listener picks up the synthetic click and performs
+    // the live navigation). This is done in JS rather than with a stretched CSS overlay because an
+    // absolutely-positioned overlay needs the `<tr>` as its containing block, and Safari/WebKit
+    // never makes a `<tr>` one — there the overlay escaped to cover the entire table and hijacked
+    // every click and hover.
+    this.onRowClick = (e) => {
+      // Genuine interactive targets (the anchor itself, buttons, inputs, nested links) keep their
+      // own behavior instead of triggering row navigation.
+      if (
+        e.target.closest(
+          'a, button, input, select, textarea, label, [role="button"], [tabindex]',
+        )
+      ) {
+        return;
+      }
+      // Don't hijack a click that's completing a text selection.
+      const selection = window.getSelection();
+      if (selection && !selection.isCollapsed) return;
+      const link = e.target.closest("tr")?.querySelector('[data-part="row-link"]');
+      if (!link) return;
+      // Preserve the open-in-new-tab gesture (Cmd/Ctrl-click) across the whole row, not just the
+      // real anchor in the first cell. A forwarded plain click would drop the modifier and
+      // navigate in place, so open the row's destination in a new tab directly instead.
+      if (e.metaKey || e.ctrlKey) {
+        window.open(link.href, "_blank", "noopener");
+        return;
+      }
+      link.click();
+    };
+    this.el.addEventListener("click", this.onRowClick);
+
     this.applyColumnWidths();
     this.sync();
   },
@@ -201,6 +235,7 @@ export default {
     this.overlayThumb?.removeEventListener("pointerdown", this.onThumbDown);
     this.overlayThumb?.removeEventListener("pointermove", this.onThumbMove);
     this.overlayThumb?.removeEventListener("pointerup", this.onThumbUp);
+    this.el.removeEventListener("click", this.onRowClick);
     this.header?.remove();
   },
 

--- a/noora/js/Table.js
+++ b/noora/js/Table.js
@@ -170,7 +170,9 @@ export default {
       // Don't hijack a click that's completing a text selection.
       const selection = window.getSelection();
       if (selection && !selection.isCollapsed) return;
-      const link = e.target.closest("tr")?.querySelector('[data-part="row-link"]');
+      const link = e.target
+        .closest("tr")
+        ?.querySelector('[data-part="row-link"]');
       if (!link) return;
       // Preserve the open-in-new-tab gesture (Cmd/Ctrl-click) across the whole row, not just the
       // real anchor in the first cell. A forwarded plain click would drop the modifier and


### PR DESCRIPTION
Whole-row navigation relied on a `position: absolute` `::after` overlay on the first cell's link, stretched across a `position: relative` <tr>. Safari never establishes a containing block on a <tr>, so every row's overlay resolved against the <table> and covered the whole grid — the topmost row's overlay swallowed every click and hover, so clicking any row always opened the same one and hover states stuck.

Drive the whole-row click from the NooraTable hook instead: a single real anchor stays in the first cell (one tab stop, announced once) and clicks on the rest of the row are forwarded to it. The hit area is row-wide in every engine, Cmd/Ctrl-click still opens a new tab, and row text is now selectable.

<img width="1254" height="549" alt="Screenshot 2026-06-22 at 10 34 09" src="https://github.com/user-attachments/assets/a9a1a8b7-18f5-4de4-bbd9-98b0c88e096b" />
