### PR TITLE
fix(server): handle in-progress VCS test comments

### DIFF
--- a/server/lib/tuist/vcs.ex
+++ b/server/lib/tuist/vcs.ex
@@ -865,6 +865,10 @@ defmodule Tuist.VCS do
       "failure" -> "❌"
       "success" -> "✅"
       "skipped" -> "⏭️"
+      "in_progress" -> "⏳"
+      "processing" -> "⏳"
+      "failed_processing" -> "⚠️"
+      _ -> "❓"
     end
   end
 

--- a/server/test/tuist/vcs_test.exs
+++ b/server/test/tuist/vcs_test.exs
@@ -1459,6 +1459,71 @@ defmodule Tuist.VCSTest do
       })
     end
 
+    test "creates a comment with an in-progress test run" do
+      # Given
+      project =
+        ProjectsFixtures.project_fixture(
+          vcs_connection: [
+            repository_full_handle: "tuist/tuist",
+            provider: :github
+          ]
+        )
+
+      {:ok, test_run} =
+        RunsFixtures.test_fixture(
+          project_id: project.id,
+          account_id: project.account_id,
+          git_ref: @git_ref,
+          git_commit_sha: @git_commit_sha,
+          scheme: "AppTests",
+          status: "in_progress",
+          build_system: "xcode",
+          ran_at: ~N[2024-04-30 03:00:00],
+          test_modules: []
+        )
+
+      stub(Req, :get, fn _opts ->
+        {:ok, %Req.Response{status: 200, body: []}}
+      end)
+
+      commit_link = "[123456789](#{@git_remote_url_origin}/commit/#{@git_commit_sha})"
+
+      expected_body =
+        """
+        ### 🛠️ Tuist Run Report 🛠️
+
+        #### Tests 🧪
+
+        | Scheme | Status | Cache hit rate | Tests | Skipped | Ran | Commit |
+        |:-:|:-:|:-:|:-:|:-:|:-:|:-:|
+        | [AppTests](https://tuist.dev/test_runs/#{test_run.id}) | ⏳ | 0 % | 0 | 0 | 0 | #{commit_link} |
+
+        """
+
+      expect(Req, :post, fn opts ->
+        assert opts[:finch] == Tuist.Finch
+        assert opts[:headers] == @default_headers
+        assert opts[:url] == "https://api.github.com/repos/tuist/tuist/issues/1/comments"
+        assert opts[:json] == %{body: expected_body}
+
+        {:ok, %Req.Response{status: 200, body: %{}}}
+      end)
+
+      # When / Then
+      VCS.post_vcs_pull_request_comment(%{
+        project: project,
+        git_commit_sha: @git_commit_sha,
+        git_ref: @git_ref,
+        git_remote_url_origin: @git_remote_url_origin,
+        preview_url: fn _ -> "" end,
+        preview_qr_code_url: fn _ -> "" end,
+        command_run_url: fn _ -> "" end,
+        test_run_url: fn %{test_run: test_run} -> "https://tuist.dev/test_runs/#{test_run.id}" end,
+        bundle_url: fn _ -> "" end,
+        build_url: fn _ -> "" end
+      })
+    end
+
     test "handles different git_ref suffixes (head/merge) connected with the same PR correctly" do
       # Given
       project =


### PR DESCRIPTION
## What changed

- Added PR comment rendering coverage for an Xcode test run whose status is `in_progress`.
- Updated the VCS test-run status formatter to render non-terminal test states instead of raising:
  - `in_progress` and `processing` render as pending.
  - `failed_processing` renders as a warning.
  - unexpected statuses render as unknown.

## Why it changed

Sentry issue TUIST-ZP showed `Tuist.VCS.Workers.CommentWorker` failing in production while building the Tuist run report for a PR. The worker received a valid test-run status, `in_progress`, from the sharded test-run flow, but `Tuist.VCS.get_test_run_status_text/1` only handled terminal statuses.

## Root cause

`Tuist.Tests.Test` already accepts `in_progress`, `processing`, and `failed_processing` as valid statuses. VCS comment formatting had a narrower `case` expression with only `failure`, `success`, and `skipped`, so any in-progress sharded run crashed comment generation with a `CaseClauseError`.

## Impact

PR comments can now include in-progress or processing test runs without retrying and failing the `vcs_comments` Oban job. Unknown future statuses degrade to a visible placeholder instead of taking down comment rendering.

## Validation

- Reproduced the failure with `mix test test/tuist/vcs_test.exs:1462` before the fix.
- Ran `mix format lib/tuist/vcs.ex test/tuist/vcs_test.exs`.
- Ran `mix test test/tuist/vcs_test.exs` -> 104 tests, 0 failures.

Fixes TUIST-ZP
