### PR TITLE
fix(server): fix status bar link on hover

### DIFF
--- a/noora/css/table.css
+++ b/noora/css/table.css
@@ -173,6 +173,12 @@
           }
         }
 
+        /* Navigable/clickable cells are the containing block for the stretched row-link overlay
+         * (`<td>` works in every engine; `<tr>` does not, which is why the overlay is per-cell). */
+        & td[data-selectable] {
+          position: relative;
+        }
+
         &:hover {
           & td[data-selectable] {
             background: var(--noora-surface-background-secondary);
@@ -399,16 +405,25 @@
     }
   }
 
-  /* Whole-row navigation. A single real anchor lives in the first cell — one tab stop, announced
-   * once — and the `NooraTable` hook forwards clicks on the rest of the row to it. We drive this
-   * from JS rather than a stretched CSS overlay: an absolutely-positioned `::after` needs the
-   * `<tr>` as its containing block, but Safari/WebKit never makes a `<tr>` one, so the overlay
-   * escaped to the `<table>` and covered the whole grid — the topmost row's overlay then swallowed
-   * every click and hover. The JS hit area is row-wide in every engine and leaves text selectable. */
+  /* Whole-row navigation, built from real anchors so browsers keep their native link affordances
+   * (hover URL preview, Safari/Firefox link previews, Cmd/middle-click → new tab) with no JS.
+   *
+   * The first cell holds the one focusable, announced link wrapping its content; its `::after`
+   * stretches the hit area over that cell. Every other cell holds an empty, `aria-hidden` overlay
+   * anchor that stretches over its own cell, widening the pointer/hover target to the whole row
+   * while staying out of the focus order and a11y tree. Each overlay is scoped to a `<td>` rather
+   * than spanning the `<tr>` because only `<td>` is a valid containing block in WebKit — a single
+   * `<tr>`-spanning overlay escapes to the `<table>` and swallows the whole grid. */
   & [data-part="row-link"] {
     display: block;
     color: inherit;
     text-decoration: none;
+
+    &::after {
+      position: absolute;
+      inset: 0;
+      content: "";
+    }
 
     &:focus-visible {
       outline: 2px solid
@@ -418,6 +433,23 @@
         );
       outline-offset: -2px;
     }
+  }
+
+  & [data-part="row-link-overlay"] {
+    position: absolute;
+    inset: 0;
+  }
+
+  /* The stretched overlays paint above static cell content (so clicks on text navigate the row),
+   * so any genuinely interactive control inside a navigable cell must be lifted above them to stay
+   * clickable — mirrors the interactive-target allowlist the JS forwarder used to honor. */
+  & td[data-selectable]
+    :is(a, button, input, select, textarea, label, [role="button"], [tabindex]):not(
+      [data-part="row-link"],
+      [data-part="row-link-overlay"]
+    ) {
+    position: relative;
+    z-index: 1;
   }
 
   & [data-part="cell"] {
@@ -461,8 +493,7 @@
       display: flex;
       align-items: center;
       gap: var(--noora-spacing-5);
-      padding: var(--noora-spacing-5) var(--noora-spacing-7)
-        var(--noora-spacing-5) var(--noora-spacing-5);
+      padding: var(--noora-spacing-5) var(--noora-spacing-7);
 
       & [data-part="icon"] {
         display: flex;

--- a/noora/css/table.css
+++ b/noora/css/table.css
@@ -443,11 +443,18 @@
   /* The stretched overlays paint above static cell content (so clicks on text navigate the row),
    * so any genuinely interactive control inside a navigable cell must be lifted above them to stay
    * clickable — mirrors the interactive-target allowlist the JS forwarder used to honor. */
-  & td[data-selectable]
-    :is(a, button, input, select, textarea, label, [role="button"], [tabindex]):not(
-      [data-part="row-link"],
-      [data-part="row-link-overlay"]
-    ) {
+  &
+    td[data-selectable]
+    :is(
+      a,
+      button,
+      input,
+      select,
+      textarea,
+      label,
+      [role="button"],
+      [tabindex]
+    ):not([data-part="row-link"], [data-part="row-link-overlay"]) {
     position: relative;
     z-index: 1;
   }

--- a/noora/js/Table.js
+++ b/noora/js/Table.js
@@ -149,42 +149,6 @@ export default {
     const table = this.container.querySelector("table");
     if (table) this.resizeObserver.observe(table);
 
-    // Whole-row navigation. Each navigable row carries a single real anchor
-    // (`[data-part="row-link"]`) in its first cell for keyboard and assistive tech; here we widen
-    // the pointer hit area to the whole row by forwarding a click on any passive part of the row
-    // to that anchor (LiveView's document-level listener picks up the synthetic click and performs
-    // the live navigation). This is done in JS rather than with a stretched CSS overlay because an
-    // absolutely-positioned overlay needs the `<tr>` as its containing block, and Safari/WebKit
-    // never makes a `<tr>` one — there the overlay escaped to cover the entire table and hijacked
-    // every click and hover.
-    this.onRowClick = (e) => {
-      // Genuine interactive targets (the anchor itself, buttons, inputs, nested links) keep their
-      // own behavior instead of triggering row navigation.
-      if (
-        e.target.closest(
-          'a, button, input, select, textarea, label, [role="button"], [tabindex]',
-        )
-      ) {
-        return;
-      }
-      // Don't hijack a click that's completing a text selection.
-      const selection = window.getSelection();
-      if (selection && !selection.isCollapsed) return;
-      const link = e.target
-        .closest("tr")
-        ?.querySelector('[data-part="row-link"]');
-      if (!link) return;
-      // Preserve the open-in-new-tab gesture (Cmd/Ctrl-click) across the whole row, not just the
-      // real anchor in the first cell. A forwarded plain click would drop the modifier and
-      // navigate in place, so open the row's destination in a new tab directly instead.
-      if (e.metaKey || e.ctrlKey) {
-        window.open(link.href, "_blank", "noopener");
-        return;
-      }
-      link.click();
-    };
-    this.el.addEventListener("click", this.onRowClick);
-
     this.applyColumnWidths();
     this.sync();
   },
@@ -237,7 +201,6 @@ export default {
     this.overlayThumb?.removeEventListener("pointerdown", this.onThumbDown);
     this.overlayThumb?.removeEventListener("pointermove", this.onThumbMove);
     this.overlayThumb?.removeEventListener("pointerup", this.onThumbUp);
-    this.el.removeEventListener("click", this.onRowClick);
     this.header?.remove();
   },
 

--- a/noora/lib/noora/table.ex
+++ b/noora/lib/noora/table.ex
@@ -232,13 +232,30 @@ defmodule Noora.Table do
                         </button>
                         {render_slot(col, row)}
                       </div>
-                    <% @row_navigate && index == 0 -> %>
-                      <%!-- Whole-row navigation via a single stretched anchor: only the first
-                      cell carries the link, and its `::after` overlay (see table.css) extends the
-                      hit area across the row. The row reads as one link — one tab stop, announced
-                      once — instead of one duplicate link per cell. --%>
+                    <% @row_navigate && !is_expandable && index == 0 -> %>
+                      <%!-- Whole-row navigation, built from real anchors so browsers keep their
+                      native link affordances (hover URL preview, Safari/Firefox link previews,
+                      Cmd/middle-click to open in a new tab) with no JS. The first cell carries the
+                      one focusable, announced link wrapping its content, stretched over its own
+                      cell by a `::after` overlay (see table.css); every other cell gets a decorative
+                      empty overlay anchor below. The row reads as one link — one tab stop, announced
+                      once. --%>
                       <.link navigate={@row_navigate.(row)} data-part="row-link">
                         {render_slot(col, row)}
+                      </.link>
+                    <% @row_navigate && !is_expandable -> %>
+                      <%!-- Decorative per-cell overlay: an empty real anchor stretched over the
+                      cell (`<td>` IS a valid containing block in every engine — only `<tr>` is not,
+                      which is why a single row-spanning overlay can't work in WebKit). It widens the
+                      pointer/hover hit area to the whole row while staying out of the focus order and
+                      a11y tree, so only the first cell's link is announced. --%>
+                      {render_slot(col, row)}
+                      <.link
+                        navigate={@row_navigate.(row)}
+                        data-part="row-link-overlay"
+                        tabindex="-1"
+                        aria-hidden="true"
+                      >
                       </.link>
                     <% true -> %>
                       {render_slot(col, row)}


### PR DESCRIPTION
Fixed the alignment between table header and cell

<img width="213" height="225" alt="Screenshot 2026-06-22 at 12 32 08" src="https://github.com/user-attachments/assets/892d146c-fdce-40c8-b3b7-ec94f9ec0bd8" />


Fix link previews and page preview (in Safari)
<img width="701" height="234" alt="Screenshot 2026-06-22 at 12 53 29" src="https://github.com/user-attachments/assets/52dc15c0-1d8d-4a14-9697-c0d9f87c56c7" />
<img width="1484" height="636" alt="Screenshot 2026-06-22 at 12 58 46" src="https://github.com/user-attachments/assets/ae2dc1af-b725-44cd-b5f6-585c185bd629" />


## What the hook does, and whether a browser capability can replace it 

|  JS responsibility  | Native replacement?  |  Verdict | Image |
|---|---|---|---|
| Whole-row navigation | Real `<a href>` | ✅ Done — already removed | <img width="523" height="41" alt="Screenshot 2026-06-22 at 12 47 54" src="https://github.com/user-attachments/assets/033241c7-96b9-45dd-a7f9-fa4b775e439e" /> |
| Floating header (fixed clone of thead) | `position: sticky` — but the thead sits inside `[data-part="scroll-container"]`'s `overflow-x: auto`, which becomes the sticky scrollport. That box is auto-height (the page scrolls vertically), so a sticky header has no vertical travel and just scrolls away.| ❌ Load-bearing in the current scroll model| <img width="1226" height="94" alt="Screenshot 2026-06-22 at 12 48 26" src="https://github.com/user-attachments/assets/fab60286-c297-4bd6-92bb-9b28a40adf6e" /> |
| Floating scrollbar proxy (webkit, pinned to viewport bottom) | None — browsers can't relocate a scrollbar to the viewport edge | ❌ Load-bearing | <img width="943" height="48" alt="Screenshot 2026-06-22 at 12 49 16" src="https://github.com/user-attachments/assets/ab38b9f1-7673-4aae-8bca-f08a0b3b396c" />|
| Custom overlay scrollbar (Firefox / overlay-scrollbar platforms) | Partial — `scrollbar-width/color` already does the in-place bar; the floating version has no native equivalent | ❌ Load-bearing | <img width="685" height="60" alt="Screenshot 2026-06-22 at 12 49 53" src="https://github.com/user-attachments/assets/8eed9e59-b2b5-4a6f-a308-a98240b430ce" /> |
| Column-width pinning (grow-only anti-jump across LiveView swaps) | None — no CSS remembers the widest column across DOM patches| ❌ Load-bearing | <img width="109" height="57" alt="Screenshot 2026-06-22 at 12 50 36" src="https://github.com/user-attachments/assets/d274d8bd-dc79-44f5-b3c8-c32ed74916ed" /> when you sort the columns, the column width stays consistent |
| `findScrollParent` | No native "which ancestor scrolls" API | ❌ Load-bearing |

The row navigation was the only piece with a clean native swap. Everything else backs behavior the browser has no native equivalent for given the current layout (page scrolls, header floats at the navbar, table can be any height). 