### PR TITLE
fix(server): contain wide docs tables

### DIFF
--- a/server/lib/tuist/docs/cli/renderer.ex
+++ b/server/lib/tuist/docs/cli/renderer.ex
@@ -109,7 +109,7 @@ defmodule Tuist.Docs.CLI.Renderer do
       )
       |> HTML.wrap_code_blocks()
       |> HTML.add_heading_anchors()
-      |> wrap_tables()
+      |> HTML.wrap_tables()
 
     headings = extract_headings_from_html(html)
 
@@ -226,12 +226,6 @@ defmodule Tuist.Docs.CLI.Renderer do
   end
 
   defp render_usage(_full_command, _arg), do: ""
-
-  defp wrap_tables(html) do
-    html
-    |> String.replace("<table>", ~s(<div class="noora-table"><table>))
-    |> String.replace("</table>", "</table></div>")
-  end
 
   @heading_extract_from_html_regex ~r/<h([2-4])>.*?class="heading-anchor"\s+id="([^"]+)"[^>]*>.*?data-part="heading-text"[^>]*>(.*?)<\/span>/s
 

--- a/server/lib/tuist/docs/html.ex
+++ b/server/lib/tuist/docs/html.ex
@@ -41,6 +41,19 @@ defmodule Tuist.Docs.HTML do
     end)
   end
 
+  def wrap_tables(html) do
+    {html, component_tags} = protect_component_tags(html)
+
+    {html, _table_index} =
+      html
+      |> Floki.parse_fragment!()
+      |> Floki.traverse_and_update(0, &wrap_table_node/2)
+
+    html
+    |> Floki.raw_html()
+    |> restore_component_tags(component_tags)
+  end
+
   def add_heading_anchors(html) do
     Regex.replace(@heading_anchor_regex, html, fn _, open_tag, anchor, text, close_tag ->
       href = ~r/href="([^"]*)"/ |> Regex.run(anchor, capture: :all_but_first) |> List.first()
@@ -60,4 +73,102 @@ defmodule Tuist.Docs.HTML do
   defp strip_links(html) do
     Regex.replace(~r/<a[^>]*>(.*?)<\/a>/s, html, "\\1")
   end
+
+  # Floki normalizes custom component tag names, so keep those exact tags as
+  # placeholders while traversing regular document nodes.
+  defp protect_component_tags(html) do
+    {html, component_tags} = do_protect_component_tags(html, 0, [])
+
+    {IO.iodata_to_binary(html), component_tags}
+  end
+
+  defp do_protect_component_tags("", _index, component_tags), do: {[], component_tags}
+
+  defp do_protect_component_tags(html, index, component_tags) do
+    case :binary.match(html, "<") do
+      :nomatch ->
+        {[html], component_tags}
+
+      {start_index, 1} ->
+        before_tag = binary_part(html, 0, start_index)
+        tag_and_rest = binary_part(html, start_index, byte_size(html) - start_index)
+
+        case tag_end_index(tag_and_rest) do
+          nil ->
+            {[html], component_tags}
+
+          end_index ->
+            tag = binary_part(tag_and_rest, 0, end_index + 1)
+            rest = binary_part(tag_and_rest, end_index + 1, byte_size(tag_and_rest) - end_index - 1)
+
+            if component_tag?(tag) do
+              placeholder = "__TUIST_DOCS_HTML_COMPONENT_TAG_#{index}__"
+              {rest, component_tags} = do_protect_component_tags(rest, index + 1, [{placeholder, tag} | component_tags])
+
+              {[before_tag, placeholder | rest], component_tags}
+            else
+              {rest, component_tags} = do_protect_component_tags(rest, index, component_tags)
+
+              {[before_tag, tag | rest], component_tags}
+            end
+        end
+    end
+  end
+
+  defp tag_end_index(tag), do: tag_end_index(tag, 1, nil)
+
+  defp tag_end_index(tag, index, quote) when index < byte_size(tag) do
+    case :binary.at(tag, index) do
+      ?' when quote == nil -> tag_end_index(tag, index + 1, ?')
+      ?' when quote == ?' -> tag_end_index(tag, index + 1, nil)
+      ?" when quote == nil -> tag_end_index(tag, index + 1, ?")
+      ?" when quote == ?" -> tag_end_index(tag, index + 1, nil)
+      ?> when quote == nil -> index
+      _other -> tag_end_index(tag, index + 1, quote)
+    end
+  end
+
+  defp tag_end_index(_tag, _index, _quote), do: nil
+
+  defp component_tag?("<" <> tag) do
+    tag =
+      tag
+      |> String.trim_leading()
+      |> String.trim_leading("/")
+
+    case tag do
+      "." <> _rest -> true
+      <<first_character::utf8, _rest::binary>> when first_character in ?A..?Z -> true
+      _other -> false
+    end
+  end
+
+  defp restore_component_tags(html, component_tags) do
+    Enum.reduce(component_tags, html, fn {placeholder, tag}, html ->
+      String.replace(html, placeholder, tag)
+    end)
+  end
+
+  defp wrap_table_node({"table", attrs, children}, table_index) do
+    {
+      {"div", [{"id", "docs-markdown-table-#{table_index}"}, {"class", "noora-table"}, {"phx-hook", "NooraTable"}],
+       [
+         {"div", [{"data-part", "scroll-container"}],
+          [
+            {"table", attrs, children}
+          ]},
+         {"div", [{"data-part", "scrollbar"}, {"aria-hidden", "true"}],
+          [
+            {"div", [{"data-part", "scrollbar-content"}], []}
+          ]},
+         {"div", [{"data-part", "overlay-scrollbar"}, {"aria-hidden", "true"}],
+          [
+            {"div", [{"data-part", "overlay-thumb"}], []}
+          ]}
+       ]},
+      table_index + 1
+    }
+  end
+
+  defp wrap_table_node(node, table_index), do: {node, table_index}
 end

--- a/server/lib/tuist/docs_loader.ex
+++ b/server/lib/tuist/docs_loader.ex
@@ -208,7 +208,7 @@ defmodule Tuist.Docs.Loader do
       |> MDEx.to_html!()
       |> convert_github_alerts()
       |> HTML.wrap_code_blocks()
-      |> wrap_tables()
+      |> HTML.wrap_tables()
       |> strip_unsupported_tags()
       |> rewrite_image_paths()
       |> replace_heading_ids(custom_ids)
@@ -335,12 +335,6 @@ defmodule Tuist.Docs.Loader do
     |> String.replace(~r/<HomeCards[^>]*>.*?<\/HomeCards>/s, "")
     |> String.replace(~r/<HomeVideos[^>]*\/>/, "")
     |> String.replace(~r/<HomeCommunity[^>]*>.*?<\/HomeCommunity>/s, "")
-  end
-
-  defp wrap_tables(html) do
-    html
-    |> String.replace("<table>", ~s(<div class="noora-table"><table>))
-    |> String.replace("</table>", "</table></div>")
   end
 
   defp rewrite_image_paths(html) do

--- a/server/test/tuist/docs/cli/renderer_test.exs
+++ b/server/test/tuist/docs/cli/renderer_test.exs
@@ -156,6 +156,20 @@ defmodule Tuist.Docs.CLI.RendererTest do
 
       assert generate_page.title_template == ":title · CLI · Tuist"
     end
+
+    test "wraps generated tables in a scroll container" do
+      pages = Renderer.build_pages(@spec_fixture)
+      cache_page = Enum.find(pages, &(&1.slug == "/en/cli/cache"))
+
+      assert cache_page.body =~ ~s(<div id="docs-markdown-table-0" class="noora-table" phx-hook="NooraTable">)
+      assert cache_page.body =~ ~s(<div data-part="scroll-container"><table>)
+
+      assert cache_page.body =~
+               ~s(<div data-part="scrollbar" aria-hidden="true"><div data-part="scrollbar-content"></div></div>)
+
+      assert cache_page.body =~
+               ~s(<div data-part="overlay-scrollbar" aria-hidden="true"><div data-part="overlay-thumb"></div></div>)
+    end
   end
 
   describe "build_sidebar/1" do

--- a/server/test/tuist/docs/html_test.exs
+++ b/server/test/tuist/docs/html_test.exs
@@ -1,0 +1,46 @@
+defmodule Tuist.Docs.HTMLTest do
+  use ExUnit.Case, async: true
+
+  alias Tuist.Docs.HTML
+
+  describe "wrap_tables/1" do
+    test "wraps table nodes without mutating Phoenix component tags around them" do
+      html = """
+      <Noora.Alert.alert status="warning" title="1 > 0">
+        <p>Read this first.</p>
+      </Noora.Alert.alert>
+      <table><thead><tr><th>Name</th></tr></thead><tbody><tr><td>Value</td></tr></tbody></table>
+      <.localized_link href="/guides/install-tuist">Install Tuist</.localized_link>
+      """
+
+      wrapped = HTML.wrap_tables(html)
+
+      assert wrapped =~ ~s(<Noora.Alert.alert status="warning" title="1 > 0">)
+      assert wrapped =~ ~s(<.localized_link href="/guides/install-tuist">)
+      assert wrapped =~ ~s(<div id="docs-markdown-table-0" class="noora-table" phx-hook="NooraTable">)
+      assert wrapped =~ ~s(<div data-part="scroll-container"><table>)
+      assert wrapped =~ ~s(<div data-part="scrollbar" aria-hidden="true"><div data-part="scrollbar-content"></div></div>)
+
+      assert wrapped =~
+               ~s(<div data-part="overlay-scrollbar" aria-hidden="true"><div data-part="overlay-thumb"></div></div>)
+
+      refute wrapped =~ "<noora.alert.alert"
+      refute wrapped =~ "&lt;.localized_link"
+    end
+
+    test "wraps table nodes inside Phoenix component tags" do
+      html = """
+      <Noora.Alert.alert status="warning">
+        <table><tbody><tr><td>Warning</td></tr></tbody></table>
+      </Noora.Alert.alert>
+      """
+
+      wrapped = HTML.wrap_tables(html)
+
+      assert wrapped =~ ~s(<Noora.Alert.alert status="warning">)
+      assert wrapped =~ ~s(<div id="docs-markdown-table-0" class="noora-table" phx-hook="NooraTable">)
+      assert wrapped =~ ~s(<div data-part="scroll-container"><table>)
+      assert wrapped =~ ~s(</Noora.Alert.alert>)
+    end
+  end
+end

--- a/server/test/tuist/docs_test.exs
+++ b/server/test/tuist/docs_test.exs
@@ -65,6 +65,19 @@ defmodule Tuist.DocsTest do
       assert migration_page.body_template
       assert migration_page.body =~ "localized_link"
     end
+
+    test "wraps Markdown tables in a scroll container" do
+      page = Docs.get_page("/en/guides/server/self-host/server")
+
+      assert page.body =~ ~s(<div id="docs-markdown-table-0" class="noora-table" phx-hook="NooraTable">)
+      assert page.body =~ ~s(<div data-part="scroll-container"><table>)
+
+      assert page.body =~
+               ~s(<div data-part="scrollbar" aria-hidden="true"><div data-part="scrollbar-content"></div></div>)
+
+      assert page.body =~
+               ~s(<div data-part="overlay-scrollbar" aria-hidden="true"><div data-part="overlay-thumb"></div></div>)
+    end
   end
 
   describe "get_page/2" do


### PR DESCRIPTION
Resolves no linked issue.

## What changed

This contains wide documentation tables inside the article column instead of letting them overlap the right-side "On this page" navigation.

![Broken documentation table layout](https://github.com/user-attachments/assets/0ab01884-8b19-4bd6-8f84-61558b1c1e9b)

The table wrapping is now shared by static documentation pages and generated command reference pages. `Tuist.Docs.HTML.wrap_tables/1` parses the rendered document fragment with Floki and uses `Floki.traverse_and_update/2` to wrap every `table` node in the same shell emitted by the Noora table component: the `noora-table` root, `NooraTable` hook, scroll container, proxy scrollbar, and overlay scrollbar.

## Why

The screenshot shows wide environment-variable tables escaping the documentation content column. That makes the page hard to read and covers the page navigation, especially on pages with long variable names and descriptions.

## Root cause

Markdown tables were rendered with the outer `noora-table` wrapper but without the rest of the Noora table shell. The missing scroll container and scrollbar elements meant the table could expand beyond the content area instead of behaving like other Noora tables.

## Approach

Markdown tables cannot call the Noora `<.table>` component directly because the component expects row data and column slots, while Markdown produces raw table markup. Instead, the renderer preserves the Markdown-generated `table` and wraps it in Noora's table shell so it uses the same styling and client-side table hook as first-class Noora tables.

The first implementation used text matching around table fragments. This version lets Floki identify actual table nodes during traversal, which avoids table-specific regular expression matching and handles each table as part of the parsed tree.

The docs renderer can include Phoenix component tags such as `<.localized_link>` and `Noora.Alert.alert`. Floki normalizes those custom tag names when parsing, so the implementation temporarily protects component tag boundaries as placeholders, runs the Floki traversal over regular document nodes, and then restores the original component tags before the template is compiled.

## Impact

Documentation pages with wide tables now keep the table inside the article layout and expose horizontal scrolling through Noora's existing table behavior. Generated command reference pages receive the same behavior through the shared helper.

## Validation

- `mix format --check-formatted lib/tuist/docs/html.ex test/tuist/docs/html_test.exs test/tuist/docs_test.exs test/tuist/docs/cli/renderer_test.exs`
- `MIX_ENV=test mix run --no-start -e 'Application.ensure_all_started(:mimic); Application.ensure_all_started(:cachex); case Cachex.start_link(:tuist, []) do {:ok, _pid} -> :ok; {:error, {:already_started, _pid}} -> :ok end; Cachex.put(:tuist, :cli_spec_data, %{pages: [], pages_by_slug: %{}, sidebar_items: []}); ExUnit.start(capture_log: true); Mimic.copy(Tuist.Docs.CLI); Code.require_file("test/tuist/docs/html_test.exs"); Code.require_file("test/tuist/docs_test.exs"); Code.require_file("test/tuist/docs/cli/renderer_test.exs"); result = ExUnit.run(); if result.failures > 0, do: System.halt(1)'` ran 27 tests with 0 failures.
- `git diff --check`
- `mix test test/tuist/docs/html_test.exs` still fails before running assertions because the local `tuist_test` database in this worktree is stale and the alias migration cannot find the `users` table. The no-start run above exercises the same assertions without touching the database.
