### PR TITLE
fix(kura): let a degraded mesh recover instead of deadlocking or wedging out-of-space

### DIFF
--- a/kura/src/config.rs
+++ b/kura/src/config.rs
@@ -1356,8 +1356,25 @@ impl Config {
     }
 
     pub async fn ensure_directories(&self) -> Result<(), std::io::Error> {
+        // Reclaim transient staging from a previous run before opening the store.
+        // Everything under tmp_dir (in-flight uploads, multipart parts, bootstrap
+        // staging) is dead once the process restarts, and a failed transfer can
+        // leave a partial file behind. Left to accumulate they fill the data disk
+        // and RocksDB then fails to open with "No space left on device", wedging
+        // the pod in a crash loop. Clearing them here — before Store::open — lets
+        // such a pod free space and recover on the next start instead of staying
+        // stuck out-of-space.
+        for staging in ["uploads", "parts", "bootstrap"] {
+            let path = self.tmp_dir.join(staging);
+            match fs::remove_dir_all(&path).await {
+                Ok(()) => {}
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                Err(error) => return Err(error),
+            }
+        }
         fs::create_dir_all(self.tmp_dir.join("uploads")).await?;
         fs::create_dir_all(self.tmp_dir.join("parts")).await?;
+        fs::create_dir_all(self.tmp_dir.join("bootstrap")).await?;
         fs::create_dir_all(self.data_dir.join("rocksdb")).await?;
         fs::create_dir_all(self.data_dir.join("blobs")).await?;
         fs::create_dir_all(self.data_dir.join("segments")).await?;
@@ -2493,6 +2510,16 @@ mod tests {
         config.tmp_dir = temp_dir.path().join("tmp");
         config.data_dir = temp_dir.path().join("data");
 
+        // Pre-seed stale staging (as a crashed previous run leaves behind) plus a
+        // real data file, to prove ensure_directories reclaims the former without
+        // touching the latter.
+        let stale = config.tmp_dir.join("bootstrap").join("leftover");
+        let kept = config.data_dir.join("rocksdb").join("CURRENT");
+        fs::create_dir_all(stale.parent().unwrap()).await.unwrap();
+        fs::create_dir_all(kept.parent().unwrap()).await.unwrap();
+        fs::write(&stale, b"stale").await.unwrap();
+        fs::write(&kept, b"keep").await.unwrap();
+
         config
             .ensure_directories()
             .await
@@ -2500,9 +2527,16 @@ mod tests {
 
         assert!(config.tmp_dir.join("uploads").exists());
         assert!(config.tmp_dir.join("parts").exists());
+        assert!(config.tmp_dir.join("bootstrap").exists());
         assert!(config.data_dir.join("rocksdb").exists());
         assert!(config.data_dir.join("blobs").exists());
         assert!(config.data_dir.join("segments").exists());
         assert!(config.data_dir.join("multipart").exists());
+
+        assert!(
+            !stale.exists(),
+            "stale staging must be reclaimed on startup"
+        );
+        assert!(kept.exists(), "persistent data must be preserved");
     }
 }

--- a/kura/src/replication/mod.rs
+++ b/kura/src/replication/mod.rs
@@ -488,31 +488,43 @@ async fn stream_response_to_temp(
     // reservation: an inconsistent peer serving a body larger than its manifest
     // advertised is rejected here instead of overrunning the budget.
     let mut destination = state.io.create_file(path).await?;
-    let mut stream = response.bytes_stream();
-    let mut total: u64 = 0;
-    while let Some(chunk) = stream.next().await {
-        let chunk = chunk.map_err(|error| format!("failed to stream bootstrap body: {error}"))?;
-        total = total.saturating_add(chunk.len() as u64);
-        if total > staging_limit {
-            drop(destination);
-            state.io.remove_file_if_exists(path).await;
-            return Err(format!(
-                "bootstrap artifact response exceeded reserved {staging_limit} bytes"
-            ));
+    let dest = &mut destination;
+    let outcome = async move {
+        let mut stream = response.bytes_stream();
+        let mut total: u64 = 0;
+        while let Some(chunk) = stream.next().await {
+            let chunk =
+                chunk.map_err(|error| format!("failed to stream bootstrap body: {error}"))?;
+            total = total.saturating_add(chunk.len() as u64);
+            if total > staging_limit {
+                return Err(format!(
+                    "bootstrap artifact response exceeded reserved {staging_limit} bytes"
+                ));
+            }
+            if let Some(limiter) = state.replication_bandwidth_limiter.as_ref() {
+                limiter.acquire(chunk.len()).await;
+            }
+            dest.write_all(&chunk)
+                .await
+                .map_err(|error| format!("failed to persist bootstrap body: {error}"))?;
         }
-        if let Some(limiter) = state.replication_bandwidth_limiter.as_ref() {
-            limiter.acquire(chunk.len()).await;
-        }
-        destination
-            .write_all(&chunk)
+        dest.flush()
             .await
-            .map_err(|error| format!("failed to persist bootstrap body: {error}"))?;
+            .map_err(|error| format!("failed to flush bootstrap body: {error}"))?;
+        Ok::<(), String>(())
     }
-    destination
-        .flush()
-        .await
-        .map_err(|error| format!("failed to flush bootstrap body: {error}"))?;
-    Ok(())
+    .await;
+
+    // Drop the handle, then remove the partially-staged file on any failure. A
+    // peer serving incomplete data or a dropped connection (the bootstrap deadlock
+    // case) would otherwise leave one temp file per attempt; a retrying bootstrap
+    // accumulates them until the data disk fills and RocksDB can no longer open,
+    // wedging the pod out-of-space.
+    drop(destination);
+    if outcome.is_err() {
+        state.io.remove_file_if_exists(path).await;
+    }
+    outcome
 }
 
 async fn fetch_bootstrap_manifests_page(

--- a/kura/src/replication/mod.rs
+++ b/kura/src/replication/mod.rs
@@ -315,6 +315,7 @@ async fn bootstrap_namespace_tombstones_from_peer(
 async fn bootstrap_manifests_from_peer(state: &SharedState, peer: &str) -> Result<u64, String> {
     let mut after = None;
     let mut applied = 0_u64;
+    let mut failed = 0_u64;
 
     loop {
         let page = fetch_bootstrap_manifests_page(state, peer, after.as_deref()).await?;
@@ -336,26 +337,55 @@ async fn bootstrap_manifests_from_peer(state: &SharedState, peer: &str) -> Resul
                 continue;
             }
 
-            let outcome = bootstrap_artifact_from_peer(state, peer, manifest)
-                .await
-                .inspect_err(|_| {
+            // A single artifact failing must not abort the whole peer bootstrap.
+            // Aborting strands every later artifact behind the first gap, and when
+            // peers bootstrap from each other simultaneously (e.g. a full-mesh
+            // restart) each one serves still-incomplete data, so every bootstrap
+            // breaks at its first gap and the mesh deadlocks with none reaching a
+            // serving state. Record the failure, keep going so we still apply the
+            // artifacts we can fetch this pass, and report partial completion at
+            // the end so the peer is retried — already-applied artifacts are
+            // skipped on the retry, so successive passes converge as data
+            // propagates outward from the data-bearing replicas.
+            match bootstrap_artifact_from_peer(state, peer, manifest).await {
+                Ok(outcome) => {
+                    state.metrics.record_replication_apply(
+                        "bootstrap",
+                        "artifact",
+                        outcome.as_str(),
+                    );
+                    if outcome.applied() {
+                        applied += 1;
+                    }
+                }
+                Err(error) => {
                     state
                         .metrics
                         .record_replication_apply("bootstrap", "artifact", "error");
-                })?;
-            state
-                .metrics
-                .record_replication_apply("bootstrap", "artifact", outcome.as_str());
-            if outcome.applied() {
-                applied += 1;
+                    warn!("bootstrap artifact from {peer} failed, continuing: {error}");
+                    failed += 1;
+                }
             }
         }
 
         match page.next_after {
             Some(next_after) => after = Some(next_after),
-            None => return Ok(applied),
+            None => break,
         }
     }
+
+    // Surfaced as a failed bootstrap so the peer is retried, but only after this
+    // pass has applied everything it could — that forward progress is what lets
+    // a mutually-bootstrapping mesh converge instead of deadlocking. A peer is
+    // marked bootstrapped (and the node allowed to serve) only on a fully clean
+    // pass, so readiness still implies complete data.
+    if failed > 0 {
+        return Err(format!(
+            "bootstrap from {peer} incomplete: {failed} artifact(s) failed this pass, {applied} applied; will retry"
+        ));
+    }
+
+    Ok(applied)
 }
 
 async fn bootstrap_artifact_from_peer(
@@ -1381,6 +1411,96 @@ mod tests {
             .await
             .expect("artifact bytes should read");
         assert_eq!(bytes, b"local-v2");
+    }
+
+    #[tokio::test]
+    async fn bootstrap_continues_past_a_failing_artifact_and_reports_partial() {
+        use axum::{
+            body::Body,
+            extract::Request,
+            middleware::{self, Next},
+            response::Response,
+        };
+
+        let remote = test_context(|_| {}).await;
+        remote
+            .state
+            .store
+            .persist_artifact_from_bytes(
+                ArtifactProducer::Gradle,
+                "ios",
+                "good",
+                "application/octet-stream",
+                b"good-data",
+            )
+            .await
+            .expect("good artifact should persist");
+        let bad = remote
+            .state
+            .store
+            .persist_artifact_from_bytes(
+                ArtifactProducer::Gradle,
+                "ios",
+                "bad",
+                "application/octet-stream",
+                b"bad-data",
+            )
+            .await
+            .expect("bad artifact should persist");
+
+        // Serve the real bootstrap endpoints, but 500 the "bad" artifact the way
+        // a peer that hasn't finished bootstrapping it yet would.
+        let poison_path = format!(
+            "/_internal/bootstrap/artifacts/{}",
+            url_encode(&bad.artifact_id)
+        );
+        let app = router(remote.state.clone()).layer(middleware::from_fn(
+            move |request: Request, next: Next| {
+                let poison_path = poison_path.clone();
+                async move {
+                    if request.uri().path() == poison_path {
+                        return Response::builder()
+                            .status(StatusCode::INTERNAL_SERVER_ERROR)
+                            .body(Body::from("incomplete"))
+                            .unwrap();
+                    }
+                    next.run(request).await
+                }
+            },
+        ));
+        let (remote_url, _server) = spawn_server(app).await;
+
+        let local = test_context(|_| {}).await;
+        let result = bootstrap_manifests_from_peer(&local.state, &remote_url).await;
+
+        // The peer bootstrap surfaces failure so it gets retried ...
+        assert!(
+            result.is_err(),
+            "a failed artifact must surface as a retryable bootstrap failure"
+        );
+        // ... but the good artifact was still applied — forward progress, not an
+        // abort at the first failure (which is what deadlocks a mutually
+        // bootstrapping mesh).
+        assert!(
+            local
+                .state
+                .store
+                .fetch_artifact(ArtifactProducer::Gradle, "ios", "good")
+                .await
+                .expect("good fetch should succeed")
+                .is_some(),
+            "the good artifact must apply even though another failed"
+        );
+        assert!(
+            local
+                .state
+                .store
+                .fetch_artifact(ArtifactProducer::Gradle, "ios", "bad")
+                .await
+                .expect("bad fetch should succeed")
+                .is_none(),
+            "the failed artifact must not be applied"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
> Draft — captures the fixes for the failure modes surfaced while recovering a degraded mesh live. Not required to fix anything live; once released, a degraded/restarted mesh recovers on its own instead of getting stuck.

Two compounding failure modes turned a recoverable mesh into a stuck one when every replica was restarted at once (e.g. cycling the whole StatefulSet onto a new image). This PR fixes both.

## 1. Bootstrap deadlock — abort on first failed artifact

`bootstrap_manifests_from_peer` did `bootstrap_artifact_from_peer(...).await...?` — a single artifact error aborted the whole peer bootstrap, stranding every artifact after it and never marking the peer bootstrapped, so the node never reached serving.

Harmless with healthy peers; **deadlocks a mesh bootstrapping from itself**: when every replica restarts together, each serves still-incomplete data while bootstrapping, so every bootstrap breaks at its first gap, none makes progress, and the mesh sits at `0/N` ready with a flat stream of `error decoding response body`.

**Fix:** record per-artifact failures, keep going so each pass applies everything it can, and return an error only at the end so the peer is retried (already-applied artifacts are skipped). Successive passes make forward progress and converge as data propagates from the data-bearing replicas. A peer is marked bootstrapped — node allowed to serve — only on a fully clean pass, so readiness still implies complete data.

## 2. Out-of-space wedge — leaked staging fills the disk

Each failed transfer **leaked its staging file**: `stream_response_to_temp` removed the temp file on the size-overrun path but returned via `?` on stream/write errors, leaving the partial file. A retrying bootstrap (the deadlock above produced these en masse) accumulated one file per attempt until the data disk filled and RocksDB failed to open with `No space left on device` — crashlooping the pod with no way out.

**Fixes:**
- `stream_response_to_temp` removes the partial file on **any** error, not just overrun.
- `ensure_directories` clears transient staging (`tmp_dir`'s `uploads`/`parts`/`bootstrap`) on startup, **before `Store::open`** — everything there is dead after a restart, so a pod whose disk already filled with stale staging reclaims space and reopens RocksDB instead of staying wedged. Data dirs are untouched.

## Observed in production

After recovering a degraded mesh by cycling all replicas onto `0.10.7`, every pod came up `Running` — no crashloops, no version skew — but stayed `0/9` ready for 10+ min with a non-decreasing `error decoding response body` rate. Separately, the replicas that had been failing for days had filled their data PVCs with leaked staging and crashlooped on `No space left`. Both are the failure modes above.

## Validation

- `bootstrap_continues_past_a_failing_artifact_and_reports_partial` — a sibling artifact 500s mid-flight; asserts the bootstrap surfaces failure (for retry) **and** the healthy artifact is still applied rather than stranded.
- `ensure_directories_creates_expected_layout` extended — seeds stale staging + a real data file; asserts the staging is reclaimed and the data preserved.
- `cargo test --lib replication` — 18 passed; `cargo clippy --lib --tests` + `cargo fmt` clean.

## Deliberately not in this PR

- **Serving-side 404 for not-yet-complete artifacts.** A peer could return `404` (client already treats it as `IgnoredStale` and skips cleanly) for an artifact whose body it doesn't yet hold, turning the noisy partial-stream failure into a clean skip. Lower value now that the client side both converges (fix 1) and no longer leaks (fix 2), and it needs care around the serving handler's completeness semantics — left as a follow-up.
- **node-exporter `priorityClassName: system-node-critical`** (the DiskPressure-eviction wedge that blocked deploys) — infra/helm, separate area; the values key needs render-validation against the grafana/k8s-monitoring v4 chart with deps built.