### PR TITLE
fix(infra): restore nvram.bin before pushing the xcresult-processor image

### DIFF
--- a/.github/workflows/server-production-deployment.yml
+++ b/.github/workflows/server-production-deployment.yml
@@ -1016,22 +1016,9 @@ jobs:
         run: |
           set -euo pipefail
           VERSION="${{ needs.check-releases.outputs.xcresult-processor-image-next-version-number }}"
-          for dest_tag in "${VERSION}" "latest"; do
-            DST="ghcr.io/tuist/tuist-xcresult-processor:${dest_tag}"
-            for attempt in 1 2 3; do
-              echo "tart push -> ${dest_tag} attempt ${attempt} at $(date -u +%H:%M:%SZ)" >&2
-              if tart push tuist-xcresult-processor "$DST"; then
-                echo "Pushed ${DST} on attempt ${attempt}"
-                break
-              fi
-              if [ "$attempt" = 3 ]; then
-                echo "tart push failed three times for ${dest_tag}" >&2
-                exit 1
-              fi
-              echo "tart push attempt ${attempt} failed; sleeping 60s before retry" >&2
-              sleep 60
-            done
-          done
+          tart push tuist-xcresult-processor "ghcr.io/tuist/tuist-xcresult-processor:${VERSION}"
+          tart push tuist-xcresult-processor "ghcr.io/tuist/tuist-xcresult-processor:latest"
+          echo "Pushed ghcr.io/tuist/tuist-xcresult-processor:${VERSION}"
 
       - name: Upload xcresult-processor-image artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/server-production-deployment.yml
+++ b/.github/workflows/server-production-deployment.yml
@@ -978,17 +978,60 @@ jobs:
             -var "release_tarball=/tmp/release.tar.gz" \
             xcresult-processor.pkr.hcl
 
+      - name: Restore nvram.bin if missing
+        env:
+          XCODE_VERSION: "26.5"
+        # See `runner-image.yml` for the rationale: packer-plugin-tart
+        # v1.20.0 sometimes drops `nvram.bin` from the built bundle,
+        # so the subsequent `tart push` uploads config + disk then
+        # fails with `Error: The file "nvram.bin" doesn't exist.`
+        # Restore it from a fresh clone of the base image (no
+        # provisioner mutates auxiliary storage from inside the guest,
+        # so the base's nvram is equivalent for our purposes).
+        run: |
+          set -euo pipefail
+          BUNDLE="$HOME/.tart/vms/tuist-xcresult-processor"
+          echo "pre-push bundle contents:"
+          ls -la "$BUNDLE"
+          if [ ! -f "$BUNDLE/nvram.bin" ]; then
+            BASE_IMAGE="ghcr.io/tuist/macos-tahoe-xcode:${XCODE_VERSION//./-}"
+            echo "nvram.bin missing — restoring from ${BASE_IMAGE}"
+            tart delete nvram-restore 2>/dev/null || true
+            tart clone "$BASE_IMAGE" nvram-restore
+            cp "$HOME/.tart/vms/nvram-restore/nvram.bin" "$BUNDLE/nvram.bin"
+            tart delete nvram-restore
+            echo "restored nvram.bin ($(du -h "$BUNDLE/nvram.bin" | cut -f1))"
+          fi
+
       - name: Push image to GHCR
         env:
           TART_REGISTRY_HOSTNAME: ghcr.io
           TART_REGISTRY_USERNAME: tuist-bot
           TART_REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+          # See runner-image.yml's matching step for the rationale —
+          # tart's auto-prune races mid-push and truncates nvram.bin
+          # (cirruslabs/tart#860). reclaim-tart-disk already trimmed
+          # the cache at the start of the job.
+          TART_NO_AUTO_PRUNE: "1"
         run: |
           set -euo pipefail
           VERSION="${{ needs.check-releases.outputs.xcresult-processor-image-next-version-number }}"
-          tart push tuist-xcresult-processor "ghcr.io/tuist/tuist-xcresult-processor:${VERSION}"
-          tart push tuist-xcresult-processor "ghcr.io/tuist/tuist-xcresult-processor:latest"
-          echo "Pushed ghcr.io/tuist/tuist-xcresult-processor:${VERSION}"
+          for dest_tag in "${VERSION}" "latest"; do
+            DST="ghcr.io/tuist/tuist-xcresult-processor:${dest_tag}"
+            for attempt in 1 2 3; do
+              echo "tart push -> ${dest_tag} attempt ${attempt} at $(date -u +%H:%M:%SZ)" >&2
+              if tart push tuist-xcresult-processor "$DST"; then
+                echo "Pushed ${DST} on attempt ${attempt}"
+                break
+              fi
+              if [ "$attempt" = 3 ]; then
+                echo "tart push failed three times for ${dest_tag}" >&2
+                exit 1
+              fi
+              echo "tart push attempt ${attempt} failed; sleeping 60s before retry" >&2
+              sleep 60
+            done
+          done
 
       - name: Upload xcresult-processor-image artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/xcresult-processor-image.yml
+++ b/.github/workflows/xcresult-processor-image.yml
@@ -134,11 +134,41 @@ jobs:
             -var "release_tarball=/tmp/release.tar.gz" \
             xcresult-processor.pkr.hcl
 
+      - name: Restore nvram.bin if missing
+        env:
+          XCODE_VERSION: ${{ inputs.xcode_version }}
+        # See `runner-image.yml` for the rationale: packer-plugin-tart
+        # v1.20.0 sometimes drops `nvram.bin` from the built bundle,
+        # so the subsequent `tart push` uploads config + disk then
+        # fails with `Error: The file "nvram.bin" doesn't exist.`
+        # Restore it from a fresh clone of the base image (no
+        # provisioner mutates auxiliary storage from inside the guest,
+        # so the base's nvram is equivalent for our purposes).
+        run: |
+          set -euo pipefail
+          BUNDLE="$HOME/.tart/vms/tuist-xcresult-processor"
+          echo "pre-push bundle contents:"
+          ls -la "$BUNDLE"
+          if [ ! -f "$BUNDLE/nvram.bin" ]; then
+            BASE_IMAGE="ghcr.io/tuist/macos-tahoe-xcode:${XCODE_VERSION//./-}"
+            echo "nvram.bin missing — restoring from ${BASE_IMAGE}"
+            tart delete nvram-restore 2>/dev/null || true
+            tart clone "$BASE_IMAGE" nvram-restore
+            cp "$HOME/.tart/vms/nvram-restore/nvram.bin" "$BUNDLE/nvram.bin"
+            tart delete nvram-restore
+            echo "restored nvram.bin ($(du -h "$BUNDLE/nvram.bin" | cut -f1))"
+          fi
+
       - name: Push image to GHCR
         env:
           TART_REGISTRY_HOSTNAME: ghcr.io
           TART_REGISTRY_USERNAME: tuist-bot
           TART_REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+          # See runner-image.yml's matching step for the rationale —
+          # tart's auto-prune races mid-push and truncates nvram.bin
+          # (cirruslabs/tart#860). reclaim-tart-disk already trimmed
+          # the cache at the start of the job.
+          TART_NO_AUTO_PRUNE: "1"
         run: |
           # SHA-tagged builds for ad-hoc deploys; semver tags + `:latest`
           # are owned by server-production-deployment.yml's release-xcresult-processor job.


### PR DESCRIPTION
## Problem

The `Release xcresult processor image` job in `server-production-deployment.yml` fails repeatedly at the **Push image to GHCR** step:

```
pushing disk... this will take a while...
pushing NVRAM...
Error: The file "nvram.bin" doesn't exist.
```

Example failure: https://github.com/tuist/tuist/actions/runs/27957702970/job/82739429133

**Root cause:** `packer-plugin-tart` v1.20.0 intermittently produces a VM bundle without `nvram.bin`, so `tart push` uploads `config` + `disk` and then dies on the NVRAM step. There's also a related auto-prune race ([cirruslabs/tart#860](https://github.com/cirruslabs/tart/issues/860)) that can truncate `nvram.bin` mid-push.

The `runner-image` jobs already work around this with a *"Restore nvram.bin if missing"* step plus `TART_NO_AUTO_PRUNE: "1"`, but **both** xcresult-processor workflows were never given the same treatment — which is why this one keeps failing.

## Fix

Mirror the proven `runner-image` pattern into both lagging workflows:

- **`server-production-deployment.yml`** (`release-xcresult-processor-image` — the failing job): add the *Restore nvram.bin if missing* step before push, set `TART_NO_AUTO_PRUNE: "1"`, and wrap the two-tag push in the same 3×-retry loop the `runner-image-build` job uses.
- **`xcresult-processor-image.yml`** (the on-demand dispatch workflow, which has the identical latent bug): same restore step + prune guard.

The restore step clones the base image and copies its `nvram.bin` into the bundle — safe because no provisioner mutates guest auxiliary storage, so the base NVRAM is equivalent.

## Verification

`actionlint` is clean on the added steps (only pre-existing custom-runner-label / SC2086 warnings elsewhere remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)