### PR TITLE
fix(infra): persist Elastic Metal kura node PN VLAN across reboots

### DIFF
--- a/infra/cluster-api-provider-scaleway-applesilicon/controllers/linux_cloudinit.go
+++ b/infra/cluster-api-provider-scaleway-applesilicon/controllers/linux_cloudinit.go
@@ -175,17 +175,48 @@ curl -fsSL https://pkgs.k8s.io/core:/stable:/%[1]s/deb/Release.key | %[2]sgpg --
 // default-route interface, else the first non-lo physical NIC. Empty (and
 // therefore a no-op) for the Instance kind, whose PN auto-DHCPs as a second
 // interface.
+//
+// The bring-up is installed as a supervised systemd unit, not run once inline. A
+// bare `ip link` + backgrounded `dhclient -nw` does not survive a reboot and is
+// never renewed if that dhclient process dies, so the node silently loses its PN
+// address (and with it the runner-cache NodePort) while still reporting Ready on
+// its public NIC — invisible to the control plane, since kubelet binds the
+// public InternalIP. The unit re-creates pn0 on every boot (ExecStartPre) and
+// holds the DHCP lease in the foreground under Restart=always, making the PN
+// address durable across reboots and lease churn. The heredocs keep this on the
+// SSH (non-indented) bootstrap path; the Instance/cloud-init path always passes
+// vlan==0 and renders nothing here.
 func vlanBringUp(sudo string, vlan uint32) string {
 	if vlan == 0 {
 		return ""
 	}
-	return fmt.Sprintf(`PRIMARY_NIC="$(ip -o route get 1.1.1.1 2>/dev/null | sed -n 's/.* dev \([^ ]*\).*/\1/p' | head -n1)"
+	return fmt.Sprintf(`%[1]stee /usr/local/sbin/tuist-pn0-up.sh > /dev/null <<'TUIST_PN_EOF'
+#!/usr/bin/env bash
+set -eu
+PRIMARY_NIC="$(ip -o route get 1.1.1.1 2>/dev/null | sed -n 's/.* dev \([^ ]*\).*/\1/p' | head -n1)"
 if [ -z "$PRIMARY_NIC" ]; then
   PRIMARY_NIC="$(for n in /sys/class/net/*; do ifn="$(basename "$n")"; case "$ifn" in lo|pn*) continue;; esac; if [ -e "$n/device" ]; then echo "$ifn"; break; fi; done)"
 fi
-%[1]sip link add link "$PRIMARY_NIC" name pn0 type vlan id %[2]d || true
-%[1]sip link set pn0 up
-%[1]sdhclient -nw pn0 || %[1]sdhclient pn0 || true
+ip link show pn0 >/dev/null 2>&1 || ip link add link "$PRIMARY_NIC" name pn0 type vlan id %[2]d
+ip link set pn0 up
+TUIST_PN_EOF
+%[1]schmod 0755 /usr/local/sbin/tuist-pn0-up.sh
+%[1]stee /etc/systemd/system/tuist-pn0.service > /dev/null <<'TUIST_PN_EOF'
+[Unit]
+Description=Tuist runner-cache Private Network VLAN (pn0)
+Wants=network-online.target
+After=network-online.target
+[Service]
+Type=exec
+ExecStartPre=/usr/local/sbin/tuist-pn0-up.sh
+ExecStart=/usr/bin/env dhclient -d pn0
+Restart=always
+RestartSec=5
+[Install]
+WantedBy=multi-user.target
+TUIST_PN_EOF
+%[1]ssystemctl daemon-reload
+%[1]ssystemctl enable --now tuist-pn0.service || true
 `, sudo, vlan)
 }
 

--- a/infra/cluster-api-provider-scaleway-applesilicon/controllers/linux_cloudinit_test.go
+++ b/infra/cluster-api-provider-scaleway-applesilicon/controllers/linux_cloudinit_test.go
@@ -95,3 +95,44 @@ func TestRenderLinuxCloudInit_ClusterDNS(t *testing.T) {
 		t.Fatalf("expected clusterDNS list entry in bootstrap script, got:\n%s", script)
 	}
 }
+
+func TestRenderLinuxBootstrapScript_PNVlanIsPersistentAndSupervised(t *testing.T) {
+	script := renderLinuxBootstrapScript(linuxCloudInitOptions{
+		NodeName:           "node-a",
+		KubeconfigYAML:     "apiVersion: v1\nkind: Config\n",
+		K8sMinor:           "v1.34",
+		BootstrapUser:      "ubuntu",
+		PrivateNetworkVLAN: 3250,
+	})
+
+	// The VLAN must be installed as a reboot-durable, lease-renewing systemd
+	// unit rather than a one-shot. Assert the unit, its supervised dhclient, and
+	// the VLAN id wired through.
+	for _, want := range []string{
+		"/etc/systemd/system/tuist-pn0.service",
+		"/usr/local/sbin/tuist-pn0-up.sh",
+		"ExecStartPre=/usr/local/sbin/tuist-pn0-up.sh",
+		"ExecStart=/usr/bin/env dhclient -d pn0",
+		"Restart=always",
+		"name pn0 type vlan id 3250",
+		"systemctl enable --now tuist-pn0.service",
+	} {
+		if !strings.Contains(script, want) {
+			t.Fatalf("expected bootstrap script to contain %q, got:\n%s", want, script)
+		}
+	}
+
+	// The fragile one-shot bring-up (backgrounded, unrenewed, lost on reboot)
+	// must be gone — it is the bug this unit replaces.
+	if strings.Contains(script, "dhclient -nw pn0") {
+		t.Fatalf("expected the one-shot `dhclient -nw` bring-up to be removed, got:\n%s", script)
+	}
+
+	// The Instance/cloud-init path never sets a VLAN, so it must render nothing
+	// PN-related (and must not emit heredocs that the indented YAML form can't
+	// host).
+	instance := renderLinuxCloudInit("node-a", "apiVersion: v1\nkind: Config\n", "v1.34", nil)
+	if strings.Contains(instance, "pn0") || strings.Contains(instance, "tuist-pn0.service") {
+		t.Fatalf("expected no PN-VLAN setup when no VLAN is set, got:\n%s", instance)
+	}
+}


### PR DESCRIPTION
## What

Make the runner-cache Elastic Metal node's Private Network VLAN (`pn0`) durable. Replaces the one-shot `ip link` + backgrounded `dhclient -nw` in the self-join with a supervised `tuist-pn0.service` systemd unit:

- `ExecStartPre` re-creates `pn0` on every boot (idempotent, same runtime NIC detection as before),
- `ExecStart` runs `dhclient -d pn0` in the foreground under `Restart=always`, so the lease is always held and renewed.

Only the Elastic Metal self-join (the SSH, non-indented bootstrap path) renders this; the Instance/cloud-init path always passes `vlan == 0` and renders nothing PN-related. A new test (`TestRenderLinuxBootstrapScript_PNVlanIsPersistentAndSupervised`) locks in the unit, the supervised dhclient, the VLAN-id wiring, the absence of the old one-shot, and that the Instance path stays clean.

## Why / root cause

The macOS runners reach the Paris Kura cache over the PN NodePort (`172.16.0.2:30815`). On 2026-06-22, macOS-runner CI builds hung indefinitely at `Fetching remote binaries via module cache. Hold tight...`.

The cache pod was healthy and fully meshed the whole time. Prometheus confirmed it: `kura-tuist-scw-fr-par-0` served heavy **internal** traffic (`/_internal/status`, `/_internal/replicate/artifact`, bootstrap routes) over the cluster pod network, but **zero public/runner-facing requests** (`kura_public_request_latency_seconds_count` never incremented for it, while every other tuist pod served 1k-7k in the same window). So the runners simply could not reach it over the PN.

Root cause: the VLAN bring-up was non-persistent. `vlanBringUp` ran `ip link add ... pn0` + `ip link set up` + `dhclient -nw pn0` exactly once during the self-join, with no systemd/netplan persistence. A reboot drops `pn0` entirely, and the backgrounded `dhclient -nw` is not supervised, so if it dies or the lease lapses the address is gone with nothing to renew it. Either way the node keeps reporting `Ready` (kubelet binds the public `InternalIP`, not the PN), and all k8s state stays correct-but-stale (`tuist.dev/pn-ipv4` label, `KuraInstance.status.nodeAddress`, the NodePort, the NetworkPolicy that allows `172.16.0.0/22`). The runner's SYN to the dead NodePort is blackholed, and the CLI module-cache fetch has no timeout, so a PN-reachability loss becomes an indefinite build hang.

## Why this approach

A systemd unit reuses the exact `ip link` + `dhclient` commands already proven to work at provision time, so it introduces no new netplan/networkd behavior on the Scaleway EM image, while fixing both failure modes (reboot loss via `enable`d unit + `ExecStartPre`; lease/process death via foreground `dhclient -d` under `Restart=always`). A netplan `vlans:` stanza would also work but changes the network-management stack on a stock image we can't easily revalidate.

## Impact

- New Elastic Metal kura nodes get a PN address that survives reboots and lease churn.
- No change to the Instance kind or the macOS fleet bootstrap.
- The **already-provisioned** Paris node is not retroactively fixed by this PR (it bootstrapped with the old code). It needs the live `pn0` re-materialized (or a re-provision once this ships) to recover. Tracked separately.

## Validation

- `go build ./...`, `go vet ./controllers/`, full `controllers` test suite green, `gofmt` clean.
- New unit test asserts the rendered script.
- **NOT yet validated on a real host.** This touches prod node bootstrap networking and must be exercised on a staging Elastic Metal node (provision, confirm `pn0`/`172.16.0.2` comes up, reboot, confirm it returns) before merging. Draft until then.

## Follow-ups (separate)

- The Mac-host client leg (`scalewayapplesiliconmachine_controller.go` "materializes the VLAN interface + firewall pass + VM NAT") uses the same one-shot pattern and has the same latent bug.
- The CLI module-cache fetch should time out and degrade to a cache miss rather than hang indefinitely when the cache endpoint is unreachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)