### PR TITLE
fix(infra): retry xcresult-processor push, restoring nvram before each attempt

### DIFF
--- a/.github/workflows/server-production-deployment.yml
+++ b/.github/workflows/server-production-deployment.yml
@@ -978,47 +978,63 @@ jobs:
             -var "release_tarball=/tmp/release.tar.gz" \
             xcresult-processor.pkr.hcl
 
-      - name: Restore nvram.bin if missing
-        env:
-          XCODE_VERSION: "26.5"
-        # See `runner-image.yml` for the rationale: packer-plugin-tart
-        # v1.20.0 sometimes drops `nvram.bin` from the built bundle,
-        # so the subsequent `tart push` uploads config + disk then
-        # fails with `Error: The file "nvram.bin" doesn't exist.`
-        # Restore it from a fresh clone of the base image (no
-        # provisioner mutates auxiliary storage from inside the guest,
-        # so the base's nvram is equivalent for our purposes).
-        run: |
-          set -euo pipefail
-          BUNDLE="$HOME/.tart/vms/tuist-xcresult-processor"
-          echo "pre-push bundle contents:"
-          ls -la "$BUNDLE"
-          if [ ! -f "$BUNDLE/nvram.bin" ]; then
-            BASE_IMAGE="ghcr.io/tuist/macos-tahoe-xcode:${XCODE_VERSION//./-}"
-            echo "nvram.bin missing — restoring from ${BASE_IMAGE}"
-            tart delete nvram-restore 2>/dev/null || true
-            tart clone "$BASE_IMAGE" nvram-restore
-            cp "$HOME/.tart/vms/nvram-restore/nvram.bin" "$BUNDLE/nvram.bin"
-            tart delete nvram-restore
-            echo "restored nvram.bin ($(du -h "$BUNDLE/nvram.bin" | cut -f1))"
-          fi
-
       - name: Push image to GHCR
         env:
           TART_REGISTRY_HOSTNAME: ghcr.io
           TART_REGISTRY_USERNAME: tuist-bot
           TART_REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-          # See runner-image.yml's matching step for the rationale —
-          # tart's auto-prune races mid-push and truncates nvram.bin
-          # (cirruslabs/tart#860). reclaim-tart-disk already trimmed
-          # the cache at the start of the job.
+          # tart's auto-prune fires opportunistically during `tart push`
+          # and races the upload of the source bundle (cirruslabs/tart#860).
+          # reclaim-tart-disk already trimmed the cache at the start of the
+          # job, so nothing needs pruning here.
           TART_NO_AUTO_PRUNE: "1"
+          XCODE_VERSION: "26.5"
+        # Two failure modes have repeatedly broken this push, both
+        # surfacing as `Error: The file "nvram.bin" doesn't exist.`:
+        #   1. packer-plugin-tart v1.20.0 occasionally bakes a bundle
+        #      with no nvram.bin at all.
+        #   2. nvram.bin is present at push start (~33MB) but disappears
+        #      mid-push — it pushes config + disk, then dies on NVRAM.
+        #      The same-size macos-tahoe-xcode base pushes fine through a
+        #      bare 3x retry (see macos-xcode-image.yml), i.e. the vanish
+        #      is transient, not permanent.
+        # So: restore nvram.bin from a fresh clone of the base if it's
+        # missing *before each attempt* (covers both modes — a vanish on
+        # attempt N is repaired before attempt N+1), and retry the push
+        # up to 3x. No provisioner mutates guest auxiliary storage, so the
+        # base's nvram is equivalent.
         run: |
           set -euo pipefail
           VERSION="${{ needs.check-releases.outputs.xcresult-processor-image-next-version-number }}"
-          tart push tuist-xcresult-processor "ghcr.io/tuist/tuist-xcresult-processor:${VERSION}"
-          tart push tuist-xcresult-processor "ghcr.io/tuist/tuist-xcresult-processor:latest"
-          echo "Pushed ghcr.io/tuist/tuist-xcresult-processor:${VERSION}"
+          BASE_IMAGE="ghcr.io/tuist/macos-tahoe-xcode:${XCODE_VERSION//./-}"
+          BUNDLE="$HOME/.tart/vms/tuist-xcresult-processor"
+          ensure_nvram() {
+            if [ ! -f "$BUNDLE/nvram.bin" ]; then
+              echo "nvram.bin missing — restoring from ${BASE_IMAGE}" >&2
+              tart delete nvram-restore 2>/dev/null || true
+              tart clone "$BASE_IMAGE" nvram-restore
+              cp "$HOME/.tart/vms/nvram-restore/nvram.bin" "$BUNDLE/nvram.bin"
+              tart delete nvram-restore
+              echo "restored nvram.bin ($(du -h "$BUNDLE/nvram.bin" | cut -f1))" >&2
+            fi
+          }
+          for dest_tag in "${VERSION}" "latest"; do
+            DST="ghcr.io/tuist/tuist-xcresult-processor:${dest_tag}"
+            for attempt in 1 2 3; do
+              ensure_nvram
+              echo "tart push -> ${dest_tag} attempt ${attempt} at $(date -u +%H:%M:%SZ)" >&2
+              if tart push tuist-xcresult-processor "$DST"; then
+                echo "Pushed ${DST} on attempt ${attempt}"
+                break
+              fi
+              if [ "$attempt" = 3 ]; then
+                echo "tart push failed three times for ${dest_tag}" >&2
+                exit 1
+              fi
+              echo "tart push attempt ${attempt} failed; sleeping 60s before retry" >&2
+              sleep 60
+            done
+          done
 
       - name: Upload xcresult-processor-image artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/xcresult-processor-image.yml
+++ b/.github/workflows/xcresult-processor-image.yml
@@ -134,48 +134,61 @@ jobs:
             -var "release_tarball=/tmp/release.tar.gz" \
             xcresult-processor.pkr.hcl
 
-      - name: Restore nvram.bin if missing
-        env:
-          XCODE_VERSION: ${{ inputs.xcode_version }}
-        # See `runner-image.yml` for the rationale: packer-plugin-tart
-        # v1.20.0 sometimes drops `nvram.bin` from the built bundle,
-        # so the subsequent `tart push` uploads config + disk then
-        # fails with `Error: The file "nvram.bin" doesn't exist.`
-        # Restore it from a fresh clone of the base image (no
-        # provisioner mutates auxiliary storage from inside the guest,
-        # so the base's nvram is equivalent for our purposes).
-        run: |
-          set -euo pipefail
-          BUNDLE="$HOME/.tart/vms/tuist-xcresult-processor"
-          echo "pre-push bundle contents:"
-          ls -la "$BUNDLE"
-          if [ ! -f "$BUNDLE/nvram.bin" ]; then
-            BASE_IMAGE="ghcr.io/tuist/macos-tahoe-xcode:${XCODE_VERSION//./-}"
-            echo "nvram.bin missing — restoring from ${BASE_IMAGE}"
-            tart delete nvram-restore 2>/dev/null || true
-            tart clone "$BASE_IMAGE" nvram-restore
-            cp "$HOME/.tart/vms/nvram-restore/nvram.bin" "$BUNDLE/nvram.bin"
-            tart delete nvram-restore
-            echo "restored nvram.bin ($(du -h "$BUNDLE/nvram.bin" | cut -f1))"
-          fi
-
       - name: Push image to GHCR
         env:
           TART_REGISTRY_HOSTNAME: ghcr.io
           TART_REGISTRY_USERNAME: tuist-bot
           TART_REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-          # See runner-image.yml's matching step for the rationale —
-          # tart's auto-prune races mid-push and truncates nvram.bin
-          # (cirruslabs/tart#860). reclaim-tart-disk already trimmed
-          # the cache at the start of the job.
+          # tart's auto-prune fires opportunistically during `tart push`
+          # and races the upload of the source bundle (cirruslabs/tart#860).
+          # reclaim-tart-disk already trimmed the cache at the start of the
+          # job, so nothing needs pruning here.
           TART_NO_AUTO_PRUNE: "1"
+          XCODE_VERSION: ${{ inputs.xcode_version }}
+        # Two failure modes have repeatedly broken this push, both
+        # surfacing as `Error: The file "nvram.bin" doesn't exist.`:
+        #   1. packer-plugin-tart v1.20.0 occasionally bakes a bundle
+        #      with no nvram.bin at all.
+        #   2. nvram.bin is present at push start (~33MB) but disappears
+        #      mid-push — it pushes config + disk, then dies on NVRAM.
+        #      The same-size macos-tahoe-xcode base pushes fine through a
+        #      bare 3x retry (see macos-xcode-image.yml), i.e. the vanish
+        #      is transient, not permanent.
+        # So: restore nvram.bin from a fresh clone of the base if it's
+        # missing *before each attempt* (covers both modes — a vanish on
+        # attempt N is repaired before attempt N+1), and retry the push
+        # up to 3x. No provisioner mutates guest auxiliary storage, so the
+        # base's nvram is equivalent.
         run: |
           # SHA-tagged builds for ad-hoc deploys; semver tags + `:latest`
           # are owned by server-production-deployment.yml's release-xcresult-processor job.
           set -euo pipefail
           GIT_SHA="${GITHUB_SHA::8}"
-          tart push tuist-xcresult-processor "ghcr.io/tuist/tuist-xcresult-processor:${GIT_SHA}"
-          echo "Pushed ghcr.io/tuist/tuist-xcresult-processor:${GIT_SHA}"
+          DST="ghcr.io/tuist/tuist-xcresult-processor:${GIT_SHA}"
+          BASE_IMAGE="ghcr.io/tuist/macos-tahoe-xcode:${XCODE_VERSION//./-}"
+          BUNDLE="$HOME/.tart/vms/tuist-xcresult-processor"
+          ensure_nvram() {
+            if [ ! -f "$BUNDLE/nvram.bin" ]; then
+              echo "nvram.bin missing — restoring from ${BASE_IMAGE}" >&2
+              tart delete nvram-restore 2>/dev/null || true
+              tart clone "$BASE_IMAGE" nvram-restore
+              cp "$HOME/.tart/vms/nvram-restore/nvram.bin" "$BUNDLE/nvram.bin"
+              tart delete nvram-restore
+              echo "restored nvram.bin ($(du -h "$BUNDLE/nvram.bin" | cut -f1))" >&2
+            fi
+          }
+          for attempt in 1 2 3; do
+            ensure_nvram
+            echo "tart push attempt ${attempt} at $(date -u +%H:%M:%SZ)" >&2
+            if tart push tuist-xcresult-processor "$DST"; then
+              echo "Pushed ${DST} on attempt ${attempt}"
+              exit 0
+            fi
+            echo "tart push attempt ${attempt} failed; sleeping 60s before retry" >&2
+            sleep 60
+          done
+          echo "tart push failed three times in a row" >&2
+          exit 1
 
       - name: Cleanup
         if: always()


### PR DESCRIPTION
## Why the previous fix wasn't enough

[#11417](https://github.com/tuist/tuist/pull/11417) added a one-shot *"restore nvram.bin if missing"* step + `TART_NO_AUTO_PRUNE`, but the push **still failed on main** ([run 27964658995](https://github.com/tuist/tuist/actions/runs/27964658995)).

The logs tell the real story. Right before push, the bundle was healthy:

```
pre-push bundle contents:
-rw-r--r--  1 m1  staff  140000000000 disk.img
-rw-r--r--  1 m1  staff      33579164 nvram.bin   # present, 33MB
...
TART_NO_AUTO_PRUNE: 1                              # was set
pushing config...
pushing disk... this will take a while...
0% ... 98%
pushing NVRAM...
Error: The file "nvram.bin" doesn't exist.
```

So `nvram.bin` is present at push start and **vanishes mid-push**, after the ~4 min disk upload. A one-shot pre-push restore can't help with that, and `TART_NO_AUTO_PRUNE` alone didn't prevent it.

Crucially, the **same-size `macos-tahoe-xcode` base image** pushes reliably via the **identical path** in `macos-xcode-image.yml` with **just a 3× retry loop** — no restore, no prune flag. That proves the vanish is *transient*: a retry clears it. The xcresult job was the only image push without that retry (it was dropped during #11417 review).

## Fix

Fold restore + retry into one push step. Before each of 3 attempts, restore `nvram.bin` from a fresh clone of the base **if missing**, then push. This covers both failure modes seen in production:

1. `packer-plugin-tart` v1.20.0 baking a bundle with no `nvram.bin` at all → restored before attempt 1.
2. `nvram.bin` disappearing mid-push → attempt fails, file is restored, next attempt succeeds.

Applied to both the production release job (`server-production-deployment.yml`) and the on-demand dispatch workflow (`xcresult-processor-image.yml`). `TART_NO_AUTO_PRUNE` is kept as a cheap extra guard.

## Verification

`actionlint` (with shellcheck) is clean on the new steps. Can be smoke-tested before merge via `gh workflow run xcresult-processor-image.yml --ref claude/fix-xcresult-nvram-retry -f xcode_version=26.5`, which exercises the same build + retry-push path (SHA-tagged, not consumed by the chart).

🤖 Generated with [Claude Code](https://claude.com/claude-code)