### PR TITLE
perf(infra): buffer Kura REST cache responses to decouple concurrent downloads

### DIFF
--- a/infra/kura-controller/controllers/kurainstance_controller.go
+++ b/infra/kura-controller/controllers/kurainstance_controller.go
@@ -1426,7 +1426,27 @@ func defaultResources() corev1.ResourceRequirements {
 }
 
 func publicIngressAnnotations() map[string]string {
-	return streamingIngressAnnotations("HTTP")
+	annotations := streamingIngressAnnotations("HTTP")
+	// Enable response buffering on the REST cache location only (the gRPC Ingress
+	// keeps it off — streaming RPCs must not be buffered). With proxy-buffering
+	// off, ingress-nginx relays Kura's response at the client's pace and
+	// backpressures the upstream, so a slow or highly-concurrent client throttles
+	// Kura's splice/sendfile serving. Benchmarks showed ~15-20% lower aggregate
+	// download throughput than the legacy static-file path under concurrency,
+	// while single-stream was at parity. Buffering lets nginx drain Kura quickly
+	// and free the upstream connection, decoupling concurrent downloads from
+	// per-client pace. proxy-request-buffering stays off so multipart uploads
+	// keep streaming.
+	//
+	// Buffer sizes are an initial value to tune under load in staging:
+	// proxy-max-temp-file-size is 0 (disabled) on the gateway, so responses
+	// larger than the in-memory buffers still stream to the client; raising the
+	// buffers (or enabling temp files) is the lever for fully decoupling large
+	// artifacts.
+	annotations["nginx.ingress.kubernetes.io/proxy-buffering"] = "on"
+	annotations["nginx.ingress.kubernetes.io/proxy-buffers-number"] = "8"
+	annotations["nginx.ingress.kubernetes.io/proxy-buffer-size"] = "256k"
+	return annotations
 }
 
 func grpcIngressAnnotations() map[string]string {

--- a/infra/kura-controller/controllers/kurainstance_controller_test.go
+++ b/infra/kura-controller/controllers/kurainstance_controller_test.go
@@ -124,6 +124,9 @@ func TestKuraInstanceReconcileCreatesWorkloadResources(t *testing.T) {
 	if got := ingress.Annotations["nginx.ingress.kubernetes.io/proxy-request-buffering"]; got != "off" {
 		t.Fatalf("expected request buffering disabled for streaming uploads, got %q", got)
 	}
+	if got := ingress.Annotations["nginx.ingress.kubernetes.io/proxy-buffering"]; got != "on" {
+		t.Fatalf("expected response buffering enabled on the REST cache ingress to decouple concurrent downloads, got %q", got)
+	}
 	if got := ingress.Annotations["nginx.ingress.kubernetes.io/proxy-body-size"]; got != "0" {
 		t.Fatalf("expected unlimited public ingress body size, got %q", got)
 	}
@@ -1026,6 +1029,9 @@ func TestKuraInstanceReconcileExposesGRPCWhenHostSet(t *testing.T) {
 	}
 	if got := grpcIngress.Annotations["nginx.ingress.kubernetes.io/use-regex"]; got != "true" {
 		t.Fatalf("expected gRPC ingress to enable regex path matching, got %q", got)
+	}
+	if got := grpcIngress.Annotations["nginx.ingress.kubernetes.io/proxy-buffering"]; got != "off" {
+		t.Fatalf("expected response buffering to stay off on the gRPC ingress (streaming RPCs must not be buffered), got %q", got)
 	}
 
 	// The pre-seeded dedicated gRPC certificate and its Secret are retired;


### PR DESCRIPTION
## What

Enable nginx **response buffering** on the Kura **REST cache** Ingress only
(`publicIngressAnnotations`), leaving the gRPC Ingress and request-body buffering
untouched.

```
nginx.ingress.kubernetes.io/proxy-buffering: "on"      # was "off" (inherited)
nginx.ingress.kubernetes.io/proxy-buffers-number: "8"
nginx.ingress.kubernetes.io/proxy-buffer-size: "256k"
```

`proxy-request-buffering` stays `off` (uploads keep streaming) and the gRPC Ingress
keeps `proxy-buffering: off` (streaming RPCs must not be buffered). Because ingress-nginx
applies these annotations per-location when the two Ingresses share a host, this affects
only the REST `proxy_pass` location.

> **Draft / experiment** — intended to be validated under load in staging before merge.

## Why

I benchmarked download performance of the Kura cache node vs the legacy node for
`tuist/tuist` (eu-central, same region, selected via `TUIST_FEATURE_FLAG_KURA`):

| Dimension | legacy | kura | |
| --- | --- | --- | --- |
| Latency — CAS TTFB p50 | 30.6 ms | 31.4 ms | tie |
| Bandwidth — single stream | ~55 MB/s | ~55–59 MB/s | **tie** |
| Bandwidth — 8 connections | 55–60 MB/s | 46–48 MB/s | legacy +~17% |
| Real 372 MB restore, parallel ×50 | 86.6 MB/s | 72.0 MB/s | legacy +~17% |

**Single-stream is at parity; Kura only trails under concurrency.** Root cause (verified):

- Kura already serves bodies with zero-copy `sendfile`/`splice` (`kura/src/accelerated_file_serving.rs`) — its core is not the bottleneck.
- The Kura gateway runs `proxy-buffering: off`. With buffering off, nginx relays the
  response at the client's pace and **backpressures the upstream**, so a slow or highly
  concurrent client throttles Kura's serving. Grafana confirms the coupling:
  `kura_artifact_egress_throughput_bytes_per_second` during the run matched the client
  (p99 ≈ 66 MB/s), i.e. Kura's measured serving rate is capped by the downstream path.
- Legacy is faster under concurrency because it serves artifacts as **buffered static
  files** (`X-Accel-Redirect` → nginx `sendfile`; it returns `ETag`/`Accept-Ranges`,
  Kura returns neither and ignores `Range` — confirmed: legacy `206`, Kura `200`).

Response buffering lets nginx drain Kura quickly and serve concurrent clients from its
buffers, decoupling Kura's serving from per-client pace.

## Caveats / what to validate in staging

- `proxy-max-temp-file-size` is `0` (disabled) on the gateway, so responses larger than
  the in-memory buffers (here 8×256k ≈ 2 MB) still stream to the client. This fully
  decouples the **many small artifacts** (the latency-sensitive CAS/keyvalue path) but
  only partially the **large** ones. Tuning the buffer sizes — or enabling temp files —
  is the lever for large artifacts; that's the main thing to dial in under load.
- Watch gateway nginx pod CPU/memory and aggregate download throughput under a concurrent
  restore (e.g. the `kura/test/e2e/grpc-upload-throughput` harness + a download
  counterpart) before/after.

## Follow-up (separate change, not in this PR)

Give Kura's HTTP download responses static-file semantics — `Accept-Ranges`/`ETag` +
`Range` support in `get_module`/`get_xcode` — so clients can range-parallelize large
artifacts and resume. That's protocol-routing-agnostic (survives any future Ingress
consolidation) and complements this change.

## Test

Added assertions in `kurainstance_controller_test.go`: the REST Ingress carries
`proxy-buffering: on`, the gRPC Ingress keeps `proxy-buffering: off`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
