### PR TITLE
feat(noora): update dark mode badge colors for better readability

### DIFF
--- a/noora/css/tokens.css
+++ b/noora/css/tokens.css
@@ -486,8 +486,8 @@
   );
 
   --noora-badge-light-fill-neutral-background: light-dark(
-    var(--noora-neutral-light-400),
-    color-mix(in oklch, var(--noora-neutral-dark-900) 50%, transparent)
+    var(--noora-neutral-light-300),
+    var(--noora-neutral-gray-50)
   );
   --noora-badge-light-fill-neutral-label: light-dark(
     var(--noora-neutral-light-1100),
@@ -495,39 +495,39 @@
   );
   --noora-badge-light-fill-destructive-background: light-dark(
     var(--noora-red-50),
-    color-mix(in oklch, var(--noora-red-500) 16%, transparent)
+    var(--noora-alpha-red)
   );
   --noora-badge-light-fill-destructive-label: light-dark(
     var(--noora-red-600),
-    var(--noora-red-500)
+    var(--noora-red-400)
   );
   --noora-badge-light-fill-warning-background: light-dark(
     var(--noora-orange-50),
-    color-mix(in oklch, var(--noora-orange-500) 16%, transparent)
+    var(--noora-alpha-orange)
   );
   --noora-badge-light-fill-warning-label: light-dark(
     var(--noora-orange-600),
-    var(--noora-orange-500)
+    var(--noora-orange-400)
   );
   --noora-badge-light-fill-attention-background: light-dark(
     var(--noora-yellow-50),
-    color-mix(in oklch, var(--noora-yellow-500) 16%, transparent)
+    var(--noora-alpha-yellow)
   );
   --noora-badge-light-fill-attention-label: light-dark(
     var(--noora-yellow-700),
-    var(--noora-yellow-500)
+    var(--noora-yellow-400)
   );
   --noora-badge-light-fill-success-background: light-dark(
     var(--noora-green-50),
-    color-mix(in oklch, var(--noora-green-500) 16%, transparent)
+    var(--noora-alpha-green)
   );
   --noora-badge-light-fill-success-label: light-dark(
     var(--noora-green-700),
-    var(--noora-green-500)
+    var(--noora-green-400)
   );
   --noora-badge-light-fill-information-background: light-dark(
     var(--noora-azure-50),
-    color-mix(in oklch, var(--noora-azure-500) 16%, transparent)
+    var(--noora-alpha-azure)
   );
   --noora-badge-light-fill-information-label: light-dark(
     var(--noora-azure-700),
@@ -535,15 +535,15 @@
   );
   --noora-badge-light-fill-focus-background: light-dark(
     var(--noora-blue-50),
-    color-mix(in oklch, var(--noora-blue-700) 16%, transparent)
+    var(--noora-alpha-blue)
   );
   --noora-badge-light-fill-focus-label: light-dark(
     var(--noora-blue-700),
-    var(--noora-blue-500)
+    var(--noora-blue-400)
   );
   --noora-badge-light-fill-primary-background: light-dark(
     var(--noora-purple-50),
-    color-mix(in oklch, var(--noora-purple-700) 16%, transparent)
+    var(--noora-alpha-purple)
   );
   --noora-badge-light-fill-primary-label: light-dark(
     var(--noora-purple-700),
@@ -551,11 +551,11 @@
   );
   --noora-badge-light-fill-secondary-background: light-dark(
     var(--noora-pink-50),
-    color-mix(in oklch, var(--noora-pink-700) 16%, transparent)
+    var(--noora-alpha-pink)
   );
   --noora-badge-light-fill-secondary-label: light-dark(
     var(--noora-pink-600),
-    var(--noora-pink-500)
+    var(--noora-pink-400)
   );
 
   --noora-badge-disabled-background: light-dark(


### PR DESCRIPTION
Update badge colors in dark mode to match Figma design
<img width="335" height="560" alt="Screenshot 2026-06-22 at 19 52 00" src="https://github.com/user-attachments/assets/ec0266a9-85d2-440c-acf0-0c2d7a5fb186" />
