### PR TITLE
fix(kura): bump quinn-proto to 0.11.15 for RUSTSEC-2026-0185

### DIFF
--- a/kura/Cargo.lock
+++ b/kura/Cargo.lock
@@ -2278,9 +2278,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",


### PR DESCRIPTION
## What changed

Bumps the transitive dependency `quinn-proto` from `0.11.14` to `0.11.15` in `kura/Cargo.lock`. Single 2-line lockfile change; no `Cargo.toml` edit since `quinn-proto` is pulled in transitively via the QUIC/HTTP3 stack.

## Why

The `Audit` job in `.github/workflows/kura.yml` (`cargo audit`) was failing on:

```
Crate:     quinn-proto  v0.11.14
Title:     Remote memory exhaustion from unbounded out-of-order stream reassembly
ID:        RUSTSEC-2026-0185   Severity: 7.5 (high)
Solution:  Upgrade to >=0.11.15
```

`cargo audit` fails its exit code only on *vulnerabilities*, so this advisory alone was breaking the gate.

## Root cause

`quinn-proto` 0.11.14 performs unbounded out-of-order QUIC stream reassembly, letting a remote peer exhaust memory. The upstream fix landed in 0.11.15. Resolved with:

```
cargo update -p quinn-proto --precise 0.11.15
```

## Why this approach

A targeted `--precise` lockfile bump is the minimal, lowest-risk fix: it patches exactly the affected crate to the first non-vulnerable patch release without touching unrelated dependencies or any manifest. 0.11.15 is a patch-level release, so it is API-compatible.

## Impact

No source or behavior change. This is a security patch to a transitive QUIC dependency that clears the failing audit gate.

## Validation

- `cargo audit` now exits `0` (the RUSTSEC-2026-0185 vulnerability is gone).
- `cargo build --locked` compiles cleanly, confirming the lockfile is consistent and the bump is a drop-in patch.

## Note on remaining audit output

Two `warning`-level advisories remain and do **not** fail the gate (they were already tolerated before this change):
- `rustls-pemfile` unmaintained — RUSTSEC-2025-0134
- `memmap2` unsound (unchecked pointer offset) — RUSTSEC-2026-0186

These are intentionally left out of scope to keep this change minimal; a follow-up can address them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)