### PR TITLE
fix(infra): load pf anchor directly (macOS firewall install fails reloading whole pf.conf)

### DIFF
--- a/infra/macos-host-bootstrap/bootstrap.go
+++ b/infra/macos-host-bootstrap/bootstrap.go
@@ -1142,48 +1142,24 @@ load anchor "tuist.runners" from "/etc/pf.anchors/tuist.runners"
 # END tuist.runners
 PFCONFENTRY
 
-# Reset the anchor's kernel-resident ruleset before the validate.
-# Hosts that previously ran an older version of this script left
-# persist-flagged 'vm_sources' / 'blocked_dst' tables in the
-# kernel, and 'pfctl -nf' on a config that redefines them dies on
-# EBUSY ("cannot define table vm_sources: Resource busy") — the
-# validate doesn't tolerate redefinition while a prior persist
-# table is still in kernel state.
+# Enable pf (idempotent; -E pins the enable token so an unrelated disable
+# can't silently drop the filter), then load the anchor.
 #
-# pfctl(8) defines '-T kill' as "Kill a table" — i.e. destroy it
-# from kernel state — and that's the only command that removes a
-# persist'd table. '-F all' / '-F Tables' explicitly preserve
-# persist tables (they only flush addresses), so they can't repair
-# this on their own. We do '-T kill' at both anchor scope AND
-# top-level scope: in practice older versions of this script have
-# at various times placed these tables in either location, and the
-# 2>/dev/null swallows the "no such table" error for the location
-# that doesn't apply on a given host.
-#
-# ORDER MATTERS: a table still referenced by active rules cannot be killed
-# ('-T kill' fails with "table in use"), so flush the anchor's rules FIRST by
-# loading an empty ruleset, which drops every reference, THEN '-T kill' the
-# tables at both anchor and top-level scope (older script versions placed them
-# in either). Running the kills before the flush, as this used to, leaves the
-# tables resident, and 'pfctl -nf' below then re-processes the load-anchor
-# directive and dies with EBUSY ("cannot define table vm_sources: busy"),
-# which fails the whole firewall install and terminal-fails the drift loop.
-echo "" | sudo pfctl -a tuist.runners -f - 2>/dev/null || true
-sudo pfctl -a tuist.runners -t vm_sources -T kill 2>/dev/null || true
-sudo pfctl -a tuist.runners -t blocked_dst -T kill 2>/dev/null || true
-sudo pfctl -t vm_sources -T kill 2>/dev/null || true
-sudo pfctl -t blocked_dst -T kill 2>/dev/null || true
-
-# Validate the ruleset before activating. -nf parses without
-# loading; if this fails we want a clear bootstrap error rather
-# than a half-loaded filter.
-sudo pfctl -nf /etc/pf.conf
-
-# Enable pf (no-op if already enabled) and reload the ruleset.
-# -E enables and pins the token so a subsequent disable from
-# elsewhere doesn't silently drop our rules; -f reloads.
+# Load the tuist.runners anchor DIRECTLY rather than re-running the whole
+# /etc/pf.conf. On a live host (pf already enabled), 'pfctl -f /etc/pf.conf'
+# collides with macOS's system-managed main ruleset: pfctl warns it would flush
+# the system's startup rules and aborts when the embedded 'load anchor'
+# re-defines the vm_sources/blocked_dst tables ("cannot define table
+# vm_sources: Resource busy"). That aborts the whole firewall install and, on
+# the drift-update path, terminal-fails the machine once the retry cap is hit,
+# freezing all further host-config updates. An anchor-scoped load applies the
+# same rules atomically without touching the system ruleset, so it succeeds at
+# bootstrap AND on every reconcile. The 'anchor'/'load anchor' lines written
+# into /etc/pf.conf above still re-activate the filter across reboots via the
+# pfctl-runners LaunchDaemon's boot-time load, when pf is freshly disabled and
+# there is no live ruleset to collide with.
 sudo pfctl -E 2>/dev/null || true
-sudo pfctl -f /etc/pf.conf
+sudo pfctl -a tuist.runners -f /etc/pf.anchors/tuist.runners
 
 # launchd job to re-arm pf on every boot. macOS doesn't persist
 # the -E enable across reboots in all configurations; an

--- a/infra/macos-host-bootstrap/bootstrap.go
+++ b/infra/macos-host-bootstrap/bootstrap.go
@@ -1160,15 +1160,19 @@ PFCONFENTRY
 # 2>/dev/null swallows the "no such table" error for the location
 # that doesn't apply on a given host.
 #
-# Belt-and-suspenders: after the kills, load an empty ruleset into
-# the anchor so any leftover anchor-level rules referencing the
-# old tables get cleared too, before pf(4) sees the redefinition
-# attempt in the validate below.
+# ORDER MATTERS: a table still referenced by active rules cannot be killed
+# ('-T kill' fails with "table in use"), so flush the anchor's rules FIRST by
+# loading an empty ruleset, which drops every reference, THEN '-T kill' the
+# tables at both anchor and top-level scope (older script versions placed them
+# in either). Running the kills before the flush, as this used to, leaves the
+# tables resident, and 'pfctl -nf' below then re-processes the load-anchor
+# directive and dies with EBUSY ("cannot define table vm_sources: busy"),
+# which fails the whole firewall install and terminal-fails the drift loop.
+echo "" | sudo pfctl -a tuist.runners -f - 2>/dev/null || true
 sudo pfctl -a tuist.runners -t vm_sources -T kill 2>/dev/null || true
 sudo pfctl -a tuist.runners -t blocked_dst -T kill 2>/dev/null || true
 sudo pfctl -t vm_sources -T kill 2>/dev/null || true
 sudo pfctl -t blocked_dst -T kill 2>/dev/null || true
-echo "" | sudo pfctl -a tuist.runners -f - 2>/dev/null || true
 
 # Validate the ruleset before activating. -nf parses without
 # loading; if this fails we want a clear bootstrap error rather


### PR DESCRIPTION
## What

`installVMEgressFirewall` activated the egress filter by re-running the whole `pfctl -f /etc/pf.conf`. On a live host that fails. Load the `tuist.runners` anchor directly instead: `pfctl -a tuist.runners -f /etc/pf.anchors/tuist.runners`.

## Root cause (validated live on a runner host)

Re-running `pfctl -f /etc/pf.conf` on a live host (pf already enabled) collides with macOS's system-managed main ruleset. pfctl warns it "could result in flushing of rules present in the main ruleset added by the system at startup" and aborts when the embedded `load anchor` re-defines the `vm_sources`/`blocked_dst` tables:

```
/etc/pf.anchors/tuist.runners:11: cannot define table vm_sources: Resource busy
pfctl: Syntax error in config file: pf rules not loaded
```

`set -euo pipefail` then aborts the install. The `pfctl -nf` validate makes it worse: `load anchor` runs even under `-n`, so the validate itself loads the tables the subsequent `-f` then can't redefine. (My first commit reordered the table reset; that was a red herring, hence the second commit replacing the whole approach.)

## Impact

On the drift-update path this retried to the cap and transitioned every `runners-fleet` machine to `failureReason=TartKubeletUpdateExceededRetries` (terminal), which gates the drift loop off entirely. The fleet's host-config update path was dead, so no firewall/NAT change reached the hosts, including #11423 — which is why deploying #11423 alone didn't fix the cache hang.

## Fix

Load the anchor directly. An anchor-scoped load applies the rules atomically without touching the system main ruleset, so it succeeds at bootstrap AND on every reconcile. Boot persistence is unchanged: the pfctl-runners LaunchDaemon loads the whole config at boot, when pf is freshly disabled and there is nothing to collide with.

## Validation

- go build / vet / gofmt / package tests green.
- **Validated live on production runner hosts.** The direct anchor load restored the filter + loaded the corrected NAT on all 9 `runners-fleet` hosts, where `pfctl -f /etc/pf.conf` fails. `kura_public_request_latency_seconds_count` for `scw-fr-par` went from 0 (all day) to 300+/25min — runners are reaching the private cache.

## Related / follow-up

- Stacks on #11423 (NAT interface detection) and #11418 (EM pn0 persistence).
- The 9 hosts were hand-fixed to unblock CI now; for durability across reboots/re-provisions this must ship, then the terminal CRs be cleared so the drift re-pushes the now-succeeding install.
- Make the drift key on a host-config hash, not just the tart-kubelet binary SHA, so firewall/script fixes propagate on deploy without a force-patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)