### PR TITLE
fix(infra): drop the xcresult-processor nvram push workarounds (real fix was tart-kubelet GC)

### DIFF
--- a/.github/workflows/server-production-deployment.yml
+++ b/.github/workflows/server-production-deployment.yml
@@ -983,45 +983,21 @@ jobs:
           TART_REGISTRY_HOSTNAME: ghcr.io
           TART_REGISTRY_USERNAME: tuist-bot
           TART_REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-          # tart's auto-prune fires opportunistically during `tart push`
-          # and races the upload of the source bundle (cirruslabs/tart#860).
-          # reclaim-tart-disk already trimmed the cache at the start of the
-          # job, so nothing needs pruning here.
-          TART_NO_AUTO_PRUNE: "1"
-          XCODE_VERSION: "26.5"
-        # Two failure modes have repeatedly broken this push, both
-        # surfacing as `Error: The file "nvram.bin" doesn't exist.`:
-        #   1. packer-plugin-tart v1.20.0 occasionally bakes a bundle
-        #      with no nvram.bin at all.
-        #   2. nvram.bin is present at push start (~33MB) but disappears
-        #      mid-push — it pushes config + disk, then dies on NVRAM.
-        #      The same-size macos-tahoe-xcode base pushes fine through a
-        #      bare 3x retry (see macos-xcode-image.yml), i.e. the vanish
-        #      is transient, not permanent.
-        # So: restore nvram.bin from a fresh clone of the base if it's
-        # missing *before each attempt* (covers both modes — a vanish on
-        # attempt N is repaired before attempt N+1), and retry the push
-        # up to 3x. No provisioner mutates guest auxiliary storage, so the
-        # base's nvram is equivalent.
+        # Direct tart push with a 3x retry — identical shape to
+        # macos-xcode-image.yml, which publishes the same-size image via
+        # the same path and is the only large tart push that pushes
+        # reliably. Earlier attempts here layered on TART_NO_AUTO_PRUNE
+        # and a clone-the-base "restore nvram.bin" step; both failed to
+        # fix the intermittent `Error: The file "nvram.bin" doesn't exist`
+        # and the disk-heavy restore made it worse (the whole VM bundle
+        # vanished mid-push). Blob uploads are content-addressed, so a
+        # re-push only re-uploads layers that didn't land last time.
         run: |
           set -euo pipefail
           VERSION="${{ needs.check-releases.outputs.xcresult-processor-image-next-version-number }}"
-          BASE_IMAGE="ghcr.io/tuist/macos-tahoe-xcode:${XCODE_VERSION//./-}"
-          BUNDLE="$HOME/.tart/vms/tuist-xcresult-processor"
-          ensure_nvram() {
-            if [ ! -f "$BUNDLE/nvram.bin" ]; then
-              echo "nvram.bin missing — restoring from ${BASE_IMAGE}" >&2
-              tart delete nvram-restore 2>/dev/null || true
-              tart clone "$BASE_IMAGE" nvram-restore
-              cp "$HOME/.tart/vms/nvram-restore/nvram.bin" "$BUNDLE/nvram.bin"
-              tart delete nvram-restore
-              echo "restored nvram.bin ($(du -h "$BUNDLE/nvram.bin" | cut -f1))" >&2
-            fi
-          }
           for dest_tag in "${VERSION}" "latest"; do
             DST="ghcr.io/tuist/tuist-xcresult-processor:${dest_tag}"
             for attempt in 1 2 3; do
-              ensure_nvram
               echo "tart push -> ${dest_tag} attempt ${attempt} at $(date -u +%H:%M:%SZ)" >&2
               if tart push tuist-xcresult-processor "$DST"; then
                 echo "Pushed ${DST} on attempt ${attempt}"

--- a/.github/workflows/xcresult-processor-image.yml
+++ b/.github/workflows/xcresult-processor-image.yml
@@ -139,47 +139,23 @@ jobs:
           TART_REGISTRY_HOSTNAME: ghcr.io
           TART_REGISTRY_USERNAME: tuist-bot
           TART_REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-          # tart's auto-prune fires opportunistically during `tart push`
-          # and races the upload of the source bundle (cirruslabs/tart#860).
-          # reclaim-tart-disk already trimmed the cache at the start of the
-          # job, so nothing needs pruning here.
-          TART_NO_AUTO_PRUNE: "1"
-          XCODE_VERSION: ${{ inputs.xcode_version }}
-        # Two failure modes have repeatedly broken this push, both
-        # surfacing as `Error: The file "nvram.bin" doesn't exist.`:
-        #   1. packer-plugin-tart v1.20.0 occasionally bakes a bundle
-        #      with no nvram.bin at all.
-        #   2. nvram.bin is present at push start (~33MB) but disappears
-        #      mid-push — it pushes config + disk, then dies on NVRAM.
-        #      The same-size macos-tahoe-xcode base pushes fine through a
-        #      bare 3x retry (see macos-xcode-image.yml), i.e. the vanish
-        #      is transient, not permanent.
-        # So: restore nvram.bin from a fresh clone of the base if it's
-        # missing *before each attempt* (covers both modes — a vanish on
-        # attempt N is repaired before attempt N+1), and retry the push
-        # up to 3x. No provisioner mutates guest auxiliary storage, so the
-        # base's nvram is equivalent.
+        # Direct tart push with a 3x retry — identical shape to
+        # macos-xcode-image.yml, which publishes the same-size image via
+        # the same path and is the only large tart push that pushes
+        # reliably. Earlier attempts here layered on TART_NO_AUTO_PRUNE
+        # and a clone-the-base "restore nvram.bin" step; both failed to
+        # fix the intermittent `Error: The file "nvram.bin" doesn't exist`
+        # and the disk-heavy restore made it worse (the whole VM bundle
+        # vanished mid-push). Blob uploads are content-addressed, so a
+        # re-push only re-uploads layers that didn't land last time.
         run: |
           # SHA-tagged builds for ad-hoc deploys; semver tags + `:latest`
           # are owned by server-production-deployment.yml's release-xcresult-processor job.
           set -euo pipefail
           GIT_SHA="${GITHUB_SHA::8}"
           DST="ghcr.io/tuist/tuist-xcresult-processor:${GIT_SHA}"
-          BASE_IMAGE="ghcr.io/tuist/macos-tahoe-xcode:${XCODE_VERSION//./-}"
-          BUNDLE="$HOME/.tart/vms/tuist-xcresult-processor"
-          ensure_nvram() {
-            if [ ! -f "$BUNDLE/nvram.bin" ]; then
-              echo "nvram.bin missing — restoring from ${BASE_IMAGE}" >&2
-              tart delete nvram-restore 2>/dev/null || true
-              tart clone "$BASE_IMAGE" nvram-restore
-              cp "$HOME/.tart/vms/nvram-restore/nvram.bin" "$BUNDLE/nvram.bin"
-              tart delete nvram-restore
-              echo "restored nvram.bin ($(du -h "$BUNDLE/nvram.bin" | cut -f1))" >&2
-            fi
-          }
           for attempt in 1 2 3; do
-            ensure_nvram
-            echo "tart push attempt ${attempt} at $(date -u +%H:%M:%SZ)" >&2
+            echo "tart push attempt ${attempt} starting at $(date -u +%H:%M:%SZ)" >&2
             if tart push tuist-xcresult-processor "$DST"; then
               echo "Pushed ${DST} on attempt ${attempt}"
               exit 0


### PR DESCRIPTION
## TL;DR

The repeated `Error: The file "nvram.bin" doesn't exist` on the xcresult-processor push was **never a workflow bug**. The builder-fleet hosts run `tart-kubelet` *and* the GitHub Actions runner; `tart-kubelet`'s orphan-VM garbage collector was reaping the in-flight Packer build VM mid-`tart push` (every local VM looks orphaned on a builder node). Its own flag help says exactly this:

> The GC deletes every local Tart VM not backed by a Pod scheduled to this Node. On builder-fleet Nodes … the GC reaps the in-flight build VM mid-`tart push` (it fails at the NVRAM layer with `nvram.bin doesn't exist`). Set this on builder Nodes.

The fix is operational — `--disable-vm-gc` on the builders' `tart-kubelet` (already rendered by `infra/macos-host-bootstrap` per #11072, but the running hosts had a stale plist: binaries stream independently of bootstrap rolls since #11065, so they got the newer binary without the re-rendered plist). Applied to both builders; a verification build then pushed green **on attempt 1**.

## What this PR does

Two earlier PRs (#11417, #11419) chased the wrong layer, adding `TART_NO_AUTO_PRUNE` and a clone-the-base "restore nvram.bin" step to the push. With the GC reaping the *whole* bundle mid-push, the restore's `cp` failed (`No such file or directory` on the bundle dir) and the base-clone added ~10 min of disk pressure. None of it helped.

This strips both push steps back to a plain 3× retry — identical to `macos-xcode-image.yml`, which publishes the same-size image via the same path. Applied to the production release job (`server-production-deployment.yml`) and the dispatch workflow (`xcresult-processor-image.yml`).

## Verification

Dispatch build on this branch: [run 27983133232](https://github.com/tuist/tuist/actions/runs/27983133232) — `Pushed ghcr.io/tuist/tuist-xcresult-processor:e1554ce6 on attempt 1`.

## Follow-up (not in this PR)

The live plist edit on the two builders is operational, not durable. A full `macos-host-bootstrap` roll (not just a binary stream) is needed so re-rolled hosts keep `--disable-vm-gc` — worth checking why binary streams don't re-render the plist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)