### PR TITLE
fix(infra): unwedge the xcresult-processor image release (tart-kubelet GC + workflow cleanup)

### DIFF
--- a/.github/workflows/server-production-deployment.yml
+++ b/.github/workflows/server-production-deployment.yml
@@ -983,45 +983,21 @@ jobs:
           TART_REGISTRY_HOSTNAME: ghcr.io
           TART_REGISTRY_USERNAME: tuist-bot
           TART_REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-          # tart's auto-prune fires opportunistically during `tart push`
-          # and races the upload of the source bundle (cirruslabs/tart#860).
-          # reclaim-tart-disk already trimmed the cache at the start of the
-          # job, so nothing needs pruning here.
-          TART_NO_AUTO_PRUNE: "1"
-          XCODE_VERSION: "26.5"
-        # Two failure modes have repeatedly broken this push, both
-        # surfacing as `Error: The file "nvram.bin" doesn't exist.`:
-        #   1. packer-plugin-tart v1.20.0 occasionally bakes a bundle
-        #      with no nvram.bin at all.
-        #   2. nvram.bin is present at push start (~33MB) but disappears
-        #      mid-push — it pushes config + disk, then dies on NVRAM.
-        #      The same-size macos-tahoe-xcode base pushes fine through a
-        #      bare 3x retry (see macos-xcode-image.yml), i.e. the vanish
-        #      is transient, not permanent.
-        # So: restore nvram.bin from a fresh clone of the base if it's
-        # missing *before each attempt* (covers both modes — a vanish on
-        # attempt N is repaired before attempt N+1), and retry the push
-        # up to 3x. No provisioner mutates guest auxiliary storage, so the
-        # base's nvram is equivalent.
+        # Direct tart push with a 3x retry — identical shape to
+        # macos-xcode-image.yml, which publishes the same-size image via
+        # the same path and is the only large tart push that pushes
+        # reliably. Earlier attempts here layered on TART_NO_AUTO_PRUNE
+        # and a clone-the-base "restore nvram.bin" step; both failed to
+        # fix the intermittent `Error: The file "nvram.bin" doesn't exist`
+        # and the disk-heavy restore made it worse (the whole VM bundle
+        # vanished mid-push). Blob uploads are content-addressed, so a
+        # re-push only re-uploads layers that didn't land last time.
         run: |
           set -euo pipefail
           VERSION="${{ needs.check-releases.outputs.xcresult-processor-image-next-version-number }}"
-          BASE_IMAGE="ghcr.io/tuist/macos-tahoe-xcode:${XCODE_VERSION//./-}"
-          BUNDLE="$HOME/.tart/vms/tuist-xcresult-processor"
-          ensure_nvram() {
-            if [ ! -f "$BUNDLE/nvram.bin" ]; then
-              echo "nvram.bin missing — restoring from ${BASE_IMAGE}" >&2
-              tart delete nvram-restore 2>/dev/null || true
-              tart clone "$BASE_IMAGE" nvram-restore
-              cp "$HOME/.tart/vms/nvram-restore/nvram.bin" "$BUNDLE/nvram.bin"
-              tart delete nvram-restore
-              echo "restored nvram.bin ($(du -h "$BUNDLE/nvram.bin" | cut -f1))" >&2
-            fi
-          }
           for dest_tag in "${VERSION}" "latest"; do
             DST="ghcr.io/tuist/tuist-xcresult-processor:${dest_tag}"
             for attempt in 1 2 3; do
-              ensure_nvram
               echo "tart push -> ${dest_tag} attempt ${attempt} at $(date -u +%H:%M:%SZ)" >&2
               if tart push tuist-xcresult-processor "$DST"; then
                 echo "Pushed ${DST} on attempt ${attempt}"

--- a/.github/workflows/xcresult-processor-image.yml
+++ b/.github/workflows/xcresult-processor-image.yml
@@ -139,47 +139,23 @@ jobs:
           TART_REGISTRY_HOSTNAME: ghcr.io
           TART_REGISTRY_USERNAME: tuist-bot
           TART_REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-          # tart's auto-prune fires opportunistically during `tart push`
-          # and races the upload of the source bundle (cirruslabs/tart#860).
-          # reclaim-tart-disk already trimmed the cache at the start of the
-          # job, so nothing needs pruning here.
-          TART_NO_AUTO_PRUNE: "1"
-          XCODE_VERSION: ${{ inputs.xcode_version }}
-        # Two failure modes have repeatedly broken this push, both
-        # surfacing as `Error: The file "nvram.bin" doesn't exist.`:
-        #   1. packer-plugin-tart v1.20.0 occasionally bakes a bundle
-        #      with no nvram.bin at all.
-        #   2. nvram.bin is present at push start (~33MB) but disappears
-        #      mid-push — it pushes config + disk, then dies on NVRAM.
-        #      The same-size macos-tahoe-xcode base pushes fine through a
-        #      bare 3x retry (see macos-xcode-image.yml), i.e. the vanish
-        #      is transient, not permanent.
-        # So: restore nvram.bin from a fresh clone of the base if it's
-        # missing *before each attempt* (covers both modes — a vanish on
-        # attempt N is repaired before attempt N+1), and retry the push
-        # up to 3x. No provisioner mutates guest auxiliary storage, so the
-        # base's nvram is equivalent.
+        # Direct tart push with a 3x retry — identical shape to
+        # macos-xcode-image.yml, which publishes the same-size image via
+        # the same path and is the only large tart push that pushes
+        # reliably. Earlier attempts here layered on TART_NO_AUTO_PRUNE
+        # and a clone-the-base "restore nvram.bin" step; both failed to
+        # fix the intermittent `Error: The file "nvram.bin" doesn't exist`
+        # and the disk-heavy restore made it worse (the whole VM bundle
+        # vanished mid-push). Blob uploads are content-addressed, so a
+        # re-push only re-uploads layers that didn't land last time.
         run: |
           # SHA-tagged builds for ad-hoc deploys; semver tags + `:latest`
           # are owned by server-production-deployment.yml's release-xcresult-processor job.
           set -euo pipefail
           GIT_SHA="${GITHUB_SHA::8}"
           DST="ghcr.io/tuist/tuist-xcresult-processor:${GIT_SHA}"
-          BASE_IMAGE="ghcr.io/tuist/macos-tahoe-xcode:${XCODE_VERSION//./-}"
-          BUNDLE="$HOME/.tart/vms/tuist-xcresult-processor"
-          ensure_nvram() {
-            if [ ! -f "$BUNDLE/nvram.bin" ]; then
-              echo "nvram.bin missing — restoring from ${BASE_IMAGE}" >&2
-              tart delete nvram-restore 2>/dev/null || true
-              tart clone "$BASE_IMAGE" nvram-restore
-              cp "$HOME/.tart/vms/nvram-restore/nvram.bin" "$BUNDLE/nvram.bin"
-              tart delete nvram-restore
-              echo "restored nvram.bin ($(du -h "$BUNDLE/nvram.bin" | cut -f1))" >&2
-            fi
-          }
           for attempt in 1 2 3; do
-            ensure_nvram
-            echo "tart push attempt ${attempt} at $(date -u +%H:%M:%SZ)" >&2
+            echo "tart push attempt ${attempt} starting at $(date -u +%H:%M:%SZ)" >&2
             if tart push tuist-xcresult-processor "$DST"; then
               echo "Pushed ${DST} on attempt ${attempt}"
               exit 0

--- a/infra/cluster-api-provider-scaleway-applesilicon/controllers/scalewayapplesiliconmachine_controller.go
+++ b/infra/cluster-api-provider-scaleway-applesilicon/controllers/scalewayapplesiliconmachine_controller.go
@@ -721,11 +721,18 @@ func (r *ScalewayAppleSiliconMachineReconciler) reconcileNormal(
 			// node_exporter silently skip on every drift update —
 			// installNodeExporter short-circuits when its binary is
 			// empty.
-			NodeExporterBinary:   r.NodeExporterBinary,
-			HostCPU:              hostCPUFor(machine, r.TartKubeletHostCPU),
-			HostMemoryMB:         hostMemoryMBFor(machine, r.TartKubeletHostMemoryMB),
-			MaxPods:              r.TartKubeletMaxPods,
-			NodeLabels:           machineNodeLabels(machine),
+			NodeExporterBinary: r.NodeExporterBinary,
+			HostCPU:            hostCPUFor(machine, r.TartKubeletHostCPU),
+			HostMemoryMB:       hostMemoryMBFor(machine, r.TartKubeletHostMemoryMB),
+			MaxPods:            r.TartKubeletMaxPods,
+			NodeLabels:         machineNodeLabels(machine),
+			// Builder hosts must keep `--disable-vm-gc` across binary
+			// rolls. This path re-renders the plist but doesn't re-resolve
+			// GHActionsRunner (which renderLaunchdPlist otherwise keys the
+			// flag off), so carry the builder signal explicitly — without
+			// it the roll strips the flag and the orphan-VM GC reaps the
+			// in-flight image-bake VM mid-`tart push`.
+			DisableVMGC:          machine.Spec.GHActionsRunner != nil,
 			KnownHostFingerprint: bootstrapCreds.HostFingerprint,
 		})
 		if fingerprint != "" && fingerprint != bootstrapCreds.HostFingerprint {

--- a/infra/macos-host-bootstrap/bootstrap.go
+++ b/infra/macos-host-bootstrap/bootstrap.go
@@ -242,6 +242,19 @@ type Config struct {
 	// token from a Secret before populating
 	// GHActionsRunner.GHRunnerRegistrationToken.
 	GHActionsRunner *GHActionsRunnerConfig
+
+	// DisableVMGC passes `--disable-vm-gc` to tart-kubelet when true.
+	// It exists so the drift-update path can preserve the flag without
+	// re-resolving GHActionsRunner: `Run` always sets GHActionsRunner on
+	// builder hosts (and renderLaunchdPlist follows that), but
+	// `UpdateTartKubelet` re-renders the plist on every binary roll
+	// without re-resolving the runner config — resolving it would mint a
+	// fresh registration token on each drift loop for no reason. Without
+	// this field the roll renders a flag-less plist and the orphan-VM GC
+	// comes back, reaping the in-flight build VM mid-`tart push`. The
+	// reconciler sets it from `machine.Spec.GHActionsRunner != nil` on
+	// both the bootstrap and update paths.
+	DisableVMGC bool
 }
 
 // Run executes the bootstrap. Idempotent: re-running on a partially-
@@ -608,15 +621,19 @@ func renderLaunchdPlist(cfg Config) string {
 	if cfg.ProviderID != "" {
 		providerIDArg = fmt.Sprintf("\n    <string>--provider-id=%s</string>", cfg.ProviderID)
 	}
-	// Builder-fleet hosts (GHActionsRunner set) never have Pods
-	// scheduled but bake images with a host-level Packer/`tart`
-	// process. tart-kubelet's orphan-VM GC treats every local VM not
-	// backed by a Pod as collectable, so it would reap the in-flight
-	// build VM mid-`tart push` (the push then fails at the NVRAM layer
-	// with `nvram.bin doesn't exist`). Disable the GC there; the
-	// image-bake workflow reclaims its own Tart disk.
+	// Builder-fleet hosts never have Pods scheduled but bake images with
+	// a host-level Packer/`tart` process. tart-kubelet's orphan-VM GC
+	// treats every local VM not backed by a Pod as collectable, so it
+	// would reap the in-flight build VM mid-`tart push` (the push then
+	// fails at the NVRAM layer with `nvram.bin doesn't exist`). Disable
+	// the GC there; the image-bake workflow reclaims its own Tart disk.
+	//
+	// GHActionsRunner != nil identifies a builder on the bootstrap path;
+	// DisableVMGC carries the same intent on the drift-update path, which
+	// re-renders the plist without re-resolving the runner config (see
+	// the field comment). Either is sufficient.
 	disableVMGCArg := ""
-	if cfg.GHActionsRunner != nil {
+	if cfg.GHActionsRunner != nil || cfg.DisableVMGC {
 		disableVMGCArg = "\n    <string>--disable-vm-gc</string>"
 	}
 	// Run tart-kubelet as the SSH user (m1). Apple's

--- a/infra/macos-host-bootstrap/bootstrap_test.go
+++ b/infra/macos-host-bootstrap/bootstrap_test.go
@@ -89,6 +89,21 @@ func TestRenderLaunchdPlist_RendersDisableVMGCForBuilder(t *testing.T) {
 	}
 }
 
+// The drift-update path re-renders the plist without re-resolving
+// GHActionsRunner, so it sets DisableVMGC directly. Without honoring it
+// here, a binary roll would strip --disable-vm-gc from a builder and the
+// orphan-VM GC would reap the in-flight image-bake VM mid-`tart push`.
+func TestRenderLaunchdPlist_RendersDisableVMGCWhenSet(t *testing.T) {
+	out := renderLaunchdPlist(Config{
+		NodeName:    "n1",
+		SSHUser:     "m1",
+		DisableVMGC: true,
+	})
+	if !strings.Contains(out, "<string>--disable-vm-gc</string>") {
+		t.Fatalf("expected --disable-vm-gc in plist when DisableVMGC is set\n%s", out)
+	}
+}
+
 // HostKeyState is the SSH-side TOFU primitive. The first observation
 // of a host key on a fresh state is captured; later observations
 // against a state seeded with KnownHostFingerprint must match.


### PR DESCRIPTION
Combines the two follow-ups to the xcresult-processor image release wedge into one PR (supersedes #11427).

## Background

The xcresult-processor push failed ~10× in a row with `Error: The file "nvram.bin" doesn't exist`. The cause was **not** the workflow: the builder-fleet hosts run `tart-kubelet` alongside the GitHub Actions runner, and `tart-kubelet`'s orphan-VM GC was reaping the in-flight Packer build VM mid-`tart push`. The fix flag `--disable-vm-gc` was added in [#11072](https://github.com/tuist/tuist/pull/11072), but the running builders had a stale, flag-less plist. I patched both live builders out-of-band to unblock the release (verified: a dispatch build then pushed green on attempt 1).

This PR makes the fix durable and cleans up the workflow.

## 1. Durability — stop binary rolls from stripping `--disable-vm-gc`

`renderLaunchdPlist` keys the flag off `cfg.GHActionsRunner != nil`:

- **Bootstrap (`Run`)** sets `GHActionsRunner` → flag rendered. ✅
- **Drift-update (`UpdateTartKubelet`)**, fired on every `tart-kubelet` binary roll, re-renders the plist from a Config that never sets `GHActionsRunner` (deliberately — it doesn't reinstall the runner, and resolving the config would mint a fresh registration token each loop) → flag **stripped**. ❌

Since binaries stream independently of full bootstrap rolls ([#11065](https://github.com/tuist/tuist/pull/11065)), a host ends up with a fresh binary and a flag-less plist — exactly the wedged state.

**Fix:** add an explicit `Config.DisableVMGC bool`. `renderLaunchdPlist` renders the flag when `GHActionsRunner != nil` (bootstrap, unchanged) **or** `DisableVMGC` is true (update path). The reconciler sets `DisableVMGC: machine.Spec.GHActionsRunner != nil` on the update Config. Additive and backward-compatible; bootstrap path and its tests untouched.

## 2. Workflow cleanup — drop the nvram push workarounds

[#11417](https://github.com/tuist/tuist/pull/11417) / [#11419](https://github.com/tuist/tuist/pull/11419) chased the wrong layer, adding `TART_NO_AUTO_PRUNE` and a clone-the-base "restore nvram.bin" step to the push. With the GC reaping the whole bundle, the restore's `cp` failed and the base-clone only added disk pressure. This reverts both push steps to a plain 3× retry — identical to `macos-xcode-image.yml`, which publishes the same-size image via the same path. Applied to the production release job and the dispatch workflow. (The `runner-image-build` job's own `TART_NO_AUTO_PRUNE` is left alone.)

## Verification

- Dispatch build on this branch's workflow: pushed `tuist-xcresult-processor` on attempt 1, NVRAM layer included.
- `go build`/`go vet`/`go test` clean in `infra/macos-host-bootstrap` and the CAPI controller module; added `TestRenderLaunchdPlist_RendersDisableVMGCWhenSet`.

## Live hosts

The two current builders (`…-rg4h9-xqzbl`, `…-rg4h9-kgp8s`) were patched live and re-verified (flag present in plist + running process). With this merged, future binary rolls keep `--disable-vm-gc` instead of stripping it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)