### PR TITLE
fix(kura): exempt the final partial page from the mmap residency gate

### DIFF
--- a/kura/src/metrics.rs
+++ b/kura/src/metrics.rs
@@ -122,6 +122,7 @@ pub struct Metrics {
     initial_discovery_completed: Gauge,
     writer_lock_owned: Gauge,
     writer_lock_acquire_failures: Counter,
+    mmap_partial_page_exemptions: Counter,
 }
 
 #[derive(Default)]
@@ -268,6 +269,7 @@ impl Metrics {
         let initial_discovery_completed = Gauge::default();
         let writer_lock_owned = Gauge::default();
         let writer_lock_acquire_failures = Counter::default();
+        let mmap_partial_page_exemptions = Counter::default();
         let process_start_time_seconds = Gauge::<i64>::default();
         process_start_time_seconds.set(
             SystemTime::now()
@@ -742,6 +744,11 @@ impl Metrics {
             writer_lock_acquire_failures.clone(),
         );
         registry.register(
+            "kura_mmap_partial_page_exemptions_total",
+            "Times an artifact was served via mmap only because the file's final partial page was exempted from the residency gate while its mincore bit was clear (the path that may fault one cold page on a worker)",
+            mmap_partial_page_exemptions.clone(),
+        );
+        registry.register(
             "kura_process_start_time_seconds",
             "Unix timestamp when the current Kura process started",
             process_start_time_seconds.clone(),
@@ -845,6 +852,7 @@ impl Metrics {
             initial_discovery_completed,
             writer_lock_owned,
             writer_lock_acquire_failures,
+            mmap_partial_page_exemptions,
         };
 
         metrics
@@ -1462,6 +1470,10 @@ impl Metrics {
         self.writer_lock_acquire_failures.inc();
     }
 
+    pub fn record_mmap_partial_page_exemption(&self) {
+        self.mmap_partial_page_exemptions.inc();
+    }
+
     pub fn rollout_metrics_snapshot(&self) -> RolloutMetricsSnapshot {
         RolloutMetricsSnapshot {
             outbox_messages: self
@@ -1897,6 +1909,7 @@ mod tests {
         assert!(rendered.contains("kura_initial_discovery_completed"));
         assert!(rendered.contains("kura_writer_lock_owned"));
         assert!(rendered.contains("kura_writer_lock_acquire_failures_total"));
+        assert!(rendered.contains("kura_mmap_partial_page_exemptions_total"));
         assert!(rendered.contains("kura_process_start_time_seconds"));
         assert!(rendered.contains("region=\"eu-west\""));
         assert!(rendered.contains("tenant_id=\"acme\""));

--- a/kura/src/mmap.rs
+++ b/kura/src/mmap.rs
@@ -85,7 +85,7 @@ pub fn map_file_region(
             .map_err(|error| format!("failed to mmap file region {offset}..{end}: {error}"))?
     };
 
-    if !mapping_is_resident(&mmap) {
+    if !mapping_is_resident(&mmap, offset, file_len) {
         return Ok(None);
     }
 
@@ -105,12 +105,22 @@ pub fn map_file_region(
     Ok(None)
 }
 
-/// Reports whether every page backing `mmap` is currently resident in the page
-/// cache, so reading the mapping will not fault disk I/O. A conservative `false`
-/// (page size unavailable, `mincore` failure) routes the caller to the reader
-/// path, which is always correct.
+/// Reports whether every page of `mmap` that is **fully backed by file data** is
+/// currently resident in the page cache, so reading the mapping will not fault
+/// disk I/O. A conservative `false` (page size unavailable, `mincore` failure)
+/// routes the caller to the reader path, which is always correct.
+///
+/// `file_offset` is the file offset the mapping starts at (`map_file_region`'s
+/// `offset`) and `file_len` the file's size; together they identify the file's
+/// final **partial** page. A file whose size is not a multiple of the page size
+/// has a last page that extends past EOF, and some filesystems — notably
+/// virtio-fs — report that partial page as non-resident even when its bytes are
+/// cached. Requiring it would needlessly disable mmap serving for sub-page (and
+/// unaligned-tail) files, so the partial page is exempt: at worst its data
+/// faults once as a single small read, while every fully-backed page still gates
+/// normally.
 #[cfg(unix)]
-fn mapping_is_resident(mmap: &Mmap) -> bool {
+fn mapping_is_resident(mmap: &Mmap, file_offset: u64, file_len: u64) -> bool {
     let len = mmap.len();
     if len == 0 {
         return true;
@@ -138,8 +148,29 @@ fn mapping_is_resident(mmap: &Mmap) -> bool {
     // not touch (fault) the mapped pages.
     let result =
         unsafe { libc::mincore(aligned as *mut c_void, total, residency.as_mut_ptr().cast()) };
+    if result != 0 {
+        return false;
+    }
 
-    result == 0 && residency.iter().all(|page| page & 1 == 1)
+    // The mapping's first queried page starts at this page-aligned file offset.
+    let aligned_file_offset = file_offset & !((page_size as u64) - 1);
+    fully_backed_pages_resident(&residency, aligned_file_offset, file_len, page_size as u64)
+}
+
+/// Returns true when every page that is **fully backed by file data** has its
+/// `mincore` resident bit set. The file's final partial page (one whose end
+/// exceeds `file_len`) is exempt — see [`mapping_is_resident`].
+#[cfg(unix)]
+fn fully_backed_pages_resident(
+    residency: &[u8],
+    aligned_file_offset: u64,
+    file_len: u64,
+    page_size: u64,
+) -> bool {
+    residency.iter().enumerate().all(|(index, page)| {
+        let page_end = aligned_file_offset + (index as u64 + 1) * page_size;
+        page_end > file_len || page & 1 == 1
+    })
 }
 
 #[cfg(unix)]
@@ -170,7 +201,7 @@ mod tests {
     use tempfile::NamedTempFile;
     use tokio::sync::Semaphore;
 
-    use super::map_file_region;
+    use super::{fully_backed_pages_resident, map_file_region};
 
     #[test]
     fn maps_unaligned_file_regions() {
@@ -189,6 +220,47 @@ mod tests {
             .expect("freshly written region should be page-cache resident");
 
         assert_eq!(&bytes[..], b"3456789a");
+    }
+
+    #[test]
+    fn fully_backed_pages_must_all_be_resident() {
+        let page_size = 4096;
+        // Three full pages, all resident.
+        assert!(fully_backed_pages_resident(
+            &[1, 1, 1],
+            0,
+            3 * page_size,
+            page_size
+        ));
+        // A cold fully-backed page disqualifies the mapping.
+        assert!(!fully_backed_pages_resident(
+            &[1, 0, 1],
+            0,
+            3 * page_size,
+            page_size
+        ));
+    }
+
+    #[test]
+    fn final_partial_page_is_exempt() {
+        let page_size = 4096;
+        // A 16-byte file's only page extends past EOF, so a cleared resident bit
+        // (as virtio-fs reports it) is tolerated. This is the regression case.
+        assert!(fully_backed_pages_resident(&[0], 0, 16, page_size));
+        // 1.5-page file: the fully-backed first page is still required, the
+        // partial tail page is exempt.
+        assert!(fully_backed_pages_resident(
+            &[1, 0],
+            0,
+            page_size + page_size / 2,
+            page_size
+        ));
+        assert!(!fully_backed_pages_resident(
+            &[0, 0],
+            0,
+            page_size + page_size / 2,
+            page_size
+        ));
     }
 
     #[test]

--- a/kura/src/mmap.rs
+++ b/kura/src/mmap.rs
@@ -9,6 +9,20 @@ use std::os::raw::c_void;
 #[cfg(unix)]
 use memmap2::{Mmap, MmapOptions};
 
+/// A region mapped for zero-copy serving plus a note on *why* the residency
+/// gate admitted it.
+#[derive(Debug)]
+pub struct MmapServe {
+    /// The mapped, page-cache-resident bytes (owns the mapping and the
+    /// memory-budget permit).
+    pub bytes: Bytes,
+    /// True when the only reason this region passed the residency gate is that
+    /// the file's final partial page was exempted while its `mincore` bit was
+    /// clear. This is the one path that can fault a single cold page on a tokio
+    /// worker, so the store meters how often it happens.
+    pub partial_page_exempted: bool,
+}
+
 /// Maps `len` bytes of `file` starting at `offset` into a read-only `Bytes`
 /// whose lifetime owns both the mapping and the memory-budget `permit`.
 ///
@@ -53,9 +67,12 @@ pub fn map_file_region(
     offset: u64,
     len: u64,
     permit: OwnedSemaphorePermit,
-) -> Result<Option<Bytes>, String> {
+) -> Result<Option<MmapServe>, String> {
     if len == 0 {
-        return Ok(Some(Bytes::new()));
+        return Ok(Some(MmapServe {
+            bytes: Bytes::new(),
+            partial_page_exempted: false,
+        }));
     }
 
     let file_len = file
@@ -85,14 +102,18 @@ pub fn map_file_region(
             .map_err(|error| format!("failed to mmap file region {offset}..{end}: {error}"))?
     };
 
-    if !mapping_is_resident(&mmap, offset, file_len) {
+    let verdict = mapping_is_resident(&mmap, offset, file_len);
+    if !verdict.serve {
         return Ok(None);
     }
 
-    Ok(Some(Bytes::from_owner(MmapRegion {
-        mmap,
-        _permit: permit,
-    })))
+    Ok(Some(MmapServe {
+        bytes: Bytes::from_owner(MmapRegion {
+            mmap,
+            _permit: permit,
+        }),
+        partial_page_exempted: verdict.partial_page_exempted,
+    }))
 }
 
 #[cfg(not(unix))]
@@ -101,14 +122,16 @@ pub fn map_file_region(
     _offset: u64,
     _len: u64,
     _permit: OwnedSemaphorePermit,
-) -> Result<Option<Bytes>, String> {
+) -> Result<Option<MmapServe>, String> {
     Ok(None)
 }
 
-/// Reports whether every page of `mmap` that is **fully backed by file data** is
-/// currently resident in the page cache, so reading the mapping will not fault
-/// disk I/O. A conservative `false` (page size unavailable, `mincore` failure)
-/// routes the caller to the reader path, which is always correct.
+/// Computes a residency verdict for `mmap`: whether every page **fully backed by
+/// file data** is currently resident in the page cache (so reading the mapping
+/// will not fault disk I/O), and whether the final partial-page exemption was
+/// the deciding factor. A conservative non-serving verdict (page size
+/// unavailable, `mincore` failure) routes the caller to the reader path, which
+/// is always correct.
 ///
 /// `file_offset` is the file offset the mapping starts at (`map_file_region`'s
 /// `offset`) and `file_len` the file's size; together they identify the file's
@@ -120,13 +143,29 @@ pub fn map_file_region(
 /// faults once as a single small read, while every fully-backed page still gates
 /// normally.
 #[cfg(unix)]
-fn mapping_is_resident(mmap: &Mmap, file_offset: u64, file_len: u64) -> bool {
+struct ResidencyVerdict {
+    /// Every fully-backed page is resident, so the mapping can be served zero-copy.
+    serve: bool,
+    /// `serve` is true only because the final partial page was exempted while its
+    /// `mincore` bit was clear. Surfaced for observability.
+    partial_page_exempted: bool,
+}
+
+#[cfg(unix)]
+fn mapping_is_resident(mmap: &Mmap, file_offset: u64, file_len: u64) -> ResidencyVerdict {
+    const NOT_RESIDENT: ResidencyVerdict = ResidencyVerdict {
+        serve: false,
+        partial_page_exempted: false,
+    };
     let len = mmap.len();
     if len == 0 {
-        return true;
+        return ResidencyVerdict {
+            serve: true,
+            partial_page_exempted: false,
+        };
     }
     let Some(page_size) = page_size() else {
-        return false;
+        return NOT_RESIDENT;
     };
 
     // `mincore` requires a page-aligned base. memmap2 maps from the page-aligned
@@ -137,7 +176,7 @@ fn mapping_is_resident(mmap: &Mmap, file_offset: u64, file_len: u64) -> bool {
     let aligned = addr & !(page_size - 1);
     let prefix = addr - aligned;
     let Some(total) = prefix.checked_add(len) else {
-        return false;
+        return NOT_RESIDENT;
     };
     let pages = total.div_ceil(page_size);
     let mut residency = vec![0u8; pages];
@@ -149,12 +188,19 @@ fn mapping_is_resident(mmap: &Mmap, file_offset: u64, file_len: u64) -> bool {
     let result =
         unsafe { libc::mincore(aligned as *mut c_void, total, residency.as_mut_ptr().cast()) };
     if result != 0 {
-        return false;
+        return NOT_RESIDENT;
     }
 
     // The mapping's first queried page starts at this page-aligned file offset.
-    let aligned_file_offset = file_offset & !((page_size as u64) - 1);
-    fully_backed_pages_resident(&residency, aligned_file_offset, file_len, page_size as u64)
+    let page_size = page_size as u64;
+    let aligned_file_offset = file_offset & !(page_size - 1);
+    let serve = fully_backed_pages_resident(&residency, aligned_file_offset, file_len, page_size);
+    let partial_page_exempted = serve
+        && partial_page_exemption_applied(&residency, aligned_file_offset, file_len, page_size);
+    ResidencyVerdict {
+        serve,
+        partial_page_exempted,
+    }
 }
 
 /// Returns true when every page that is **fully backed by file data** has its
@@ -168,8 +214,28 @@ fn fully_backed_pages_resident(
     page_size: u64,
 ) -> bool {
     residency.iter().enumerate().all(|(index, page)| {
-        let page_end = aligned_file_offset + (index as u64 + 1) * page_size;
+        let page_end =
+            aligned_file_offset.saturating_add((index as u64 + 1).saturating_mul(page_size));
         page_end > file_len || page & 1 == 1
+    })
+}
+
+/// Returns true when the final partial page (one whose end exceeds `file_len`)
+/// has a **clear** `mincore` resident bit — i.e. the partial-page exemption in
+/// [`fully_backed_pages_resident`] is what admitted the mapping, rather than the
+/// page being resident on its own. The store meters this for observability: it
+/// is the path that may fault one cold page on a tokio worker.
+#[cfg(unix)]
+fn partial_page_exemption_applied(
+    residency: &[u8],
+    aligned_file_offset: u64,
+    file_len: u64,
+    page_size: u64,
+) -> bool {
+    residency.iter().enumerate().any(|(index, page)| {
+        let page_end =
+            aligned_file_offset.saturating_add((index as u64 + 1).saturating_mul(page_size));
+        page_end > file_len && page & 1 == 0
     })
 }
 
@@ -201,7 +267,7 @@ mod tests {
     use tempfile::NamedTempFile;
     use tokio::sync::Semaphore;
 
-    use super::{fully_backed_pages_resident, map_file_region};
+    use super::{fully_backed_pages_resident, map_file_region, partial_page_exemption_applied};
 
     #[test]
     fn maps_unaligned_file_regions() {
@@ -215,11 +281,11 @@ mod tests {
             .try_acquire_many_owned(8)
             .expect("permit should be acquired");
 
-        let bytes = map_file_region(file.as_file(), 3, 8, permit)
+        let serve = map_file_region(file.as_file(), 3, 8, permit)
             .expect("region should map")
             .expect("freshly written region should be page-cache resident");
 
-        assert_eq!(&bytes[..], b"3456789a");
+        assert_eq!(&serve.bytes[..], b"3456789a");
     }
 
     #[test]
@@ -264,17 +330,67 @@ mod tests {
     }
 
     #[test]
+    fn non_zero_offset_anchors_the_partial_page_exemption() {
+        let page_size = 4096;
+        // A mapping into a 2.5-page file that starts at the second page: the
+        // residency slice is anchored at `aligned_file_offset == page_size`, so
+        // residency[0] is the fully-backed page [page_size, 2*page_size) and
+        // residency[1] is the partial tail [2*page_size, 3*page_size) past EOF.
+        let aligned_file_offset = page_size;
+        let file_len = 2 * page_size + 100;
+        assert!(fully_backed_pages_resident(
+            &[1, 0],
+            aligned_file_offset,
+            file_len,
+            page_size
+        ));
+        // A cold fully-backed page is still disqualifying at a non-zero offset.
+        assert!(!fully_backed_pages_resident(
+            &[0, 0],
+            aligned_file_offset,
+            file_len,
+            page_size
+        ));
+        // Boundary: a page ending exactly at `file_len` is fully backed, not
+        // exempt, so a cleared resident bit disqualifies it.
+        assert!(!fully_backed_pages_resident(&[0], 0, page_size, page_size));
+    }
+
+    #[test]
+    fn partial_page_exemption_is_flagged_only_when_it_decides() {
+        let page_size = 4096;
+        // 16-byte file, its sole page cold: the exemption is the deciding factor.
+        assert!(partial_page_exemption_applied(&[0], 0, 16, page_size));
+        // Same file but the page is resident: the exemption changed nothing.
+        assert!(!partial_page_exemption_applied(&[1], 0, 16, page_size));
+        // 1.5-page file, fully-backed page warm, partial tail cold: exemption fired.
+        assert!(partial_page_exemption_applied(
+            &[1, 0],
+            0,
+            page_size + page_size / 2,
+            page_size
+        ));
+        // Page-aligned file: no partial page exists, so the exemption never fires.
+        assert!(!partial_page_exemption_applied(
+            &[0, 0],
+            0,
+            2 * page_size,
+            page_size
+        ));
+    }
+
+    #[test]
     fn maps_empty_regions_without_mmap() {
         let file = NamedTempFile::new().expect("temp file should be created");
         let permit = Arc::new(Semaphore::new(1))
             .try_acquire_owned()
             .expect("permit should be acquired");
 
-        let bytes = map_file_region(file.as_file(), 0, 0, permit)
+        let serve = map_file_region(file.as_file(), 0, 0, permit)
             .expect("empty region should map")
             .expect("empty region is trivially resident");
 
-        assert!(bytes.is_empty());
+        assert!(serve.bytes.is_empty());
     }
 
     #[test]

--- a/kura/src/store.rs
+++ b/kura/src/store.rs
@@ -686,21 +686,27 @@ impl Store {
                 .segment_offset
                 .ok_or_else(|| "segment-backed manifest is missing segment offset".to_string())?;
             let handle = self.segment_handle(segment_id).await?;
-            let Some(bytes) = map_file_region(handle.as_std(), offset, manifest.size, permit)?
+            let Some(serve) = map_file_region(handle.as_std(), offset, manifest.size, permit)?
             else {
                 return Ok(None);
             };
+            if serve.partial_page_exempted {
+                self.io.metrics().record_mmap_partial_page_exemption();
+            }
             self.note_artifact_exists(&manifest.artifact_id);
-            return Ok(Some(bytes));
+            return Ok(Some(serve.bytes));
         }
 
         if let Some(blob_path) = &manifest.blob_path {
             let handle = self.blob_handle(blob_path).await?;
-            let Some(bytes) = map_file_region(handle.as_std(), 0, manifest.size, permit)? else {
+            let Some(serve) = map_file_region(handle.as_std(), 0, manifest.size, permit)? else {
                 return Ok(None);
             };
+            if serve.partial_page_exempted {
+                self.io.metrics().record_mmap_partial_page_exemption();
+            }
             self.note_artifact_exists(&manifest.artifact_id);
-            return Ok(Some(bytes));
+            return Ok(Some(serve.bytes));
         }
 
         Ok(None)


### PR DESCRIPTION
## What

`map_file_region` gates mmap serving on `mincore` residency (`mapping_is_resident`). It required **every** page queried by `mincore` to be resident — including the file's **final partial page**, the page that extends past EOF when the file size isn't a multiple of the page size.

This change exempts that final partial page: only pages **fully backed by file data** must be resident. A small pure helper, `fully_backed_pages_resident`, makes the rule unit-testable.

## Why

On **virtio-fs**, `mincore` reports the partial past-EOF page as **non-resident even when its bytes are cached**. So the gate needlessly returned `Ok(None)` and fell back to the streaming reader for any **sub-page (or unaligned-tail) file**. On a native filesystem (ext4) the partial page reports resident, so this was invisible — until Kura's Bazel tests ran on the virtio-fs-backed **Kata microVM `tuist-linux`** runners, where three mmap tests (mapping 16-byte / 5-byte / 23-byte files) panicked on `freshly written region should be page-cache resident`.

Full investigation and reproduction: #11430.

## Impact

- **Not a correctness change.** The reader fallback was always correct; this only restores the mmap fast path for sub-page files where `mincore` under-reports residency.
- The only behavioral change: the exempted partial page could fault once as a **single small read** if it were genuinely cold. Every fully-backed page still gates strictly, so large artifacts are essentially unaffected (only the ≤1-page tail is exempt).
- Makes the residency gate correct on virtio-fs-backed data dirs, not just native filesystems.

## Validation

- `cargo test --lib mmap::tests` — all pass, including the existing `maps_unaligned_file_regions` (the 16-byte sub-page case) and two new deterministic tests for `fully_backed_pages_resident` (the virtio-fs partial-page case, plus the fully-backed-must-be-resident case).
- `cargo clippy --lib -- -D warnings` and `cargo fmt --check` clean.

Refs #11430

🤖 Generated with [Claude Code](https://claude.com/claude-code)
