### PR TITLE
fix(server): reduce long-lived artifact retention

### DIFF
--- a/server/data-export.md
+++ b/server/data-export.md
@@ -26,7 +26,7 @@ Sensitive authentication data (passwords, tokens) are excluded from exports.
 - Kura deployment history (`kura_deployments` table): rollout attempts for the account's Kura servers including image tag, status, error messages, and start/finish timestamps
 - GitHub App installation metadata (`github_app_installations` table): the installation ID GitHub assigned, the GitHub instance the App lives on (`client_url`, e.g. `https://github.com` or a customer's GitHub Enterprise Server host), the App's `app_id`/`app_slug`/`client_id`, and the GitHub-side management `html_url`. The accompanying `client_secret`, `private_key` (PEM), and `webhook_secret` are stored encrypted at rest and are excluded from exports as authentication secrets.
 - VCS connections (`vcs_connections` table): the link between a Tuist project and an external repository handle (provider, repository full name, the originating GitHub App installation, and the user who created the connection)
-- Artifact retention cursors (`artifact_retention_cursors` table): per-account cleanup progress for DB-backed artifact families. Exports include the artifact type plus the last processed metadata cursor (`after_inserted_at`, `after_id`) used to avoid re-processing blobs that have already been purged from object storage.
+- Artifact retention cursors (`artifact_retention_cursors` table): per-account cleanup progress for database-backed artifact families. Exports include the artifact type plus the last processed metadata cursor (`after_inserted_at`, `after_id`) used to avoid re-processing blobs that have already been purged from object storage. The `run_session` cursor covers all run artifact blobs stored under an expired run's artifact prefix.
 
 - (Internal Tuist-team JIT elevation tables previously documented here moved out of this server's Postgres entirely. They now live in the standalone `tuist-ops` service on its own CNPG cluster in the mgmt cluster. The data is operator-side audit about Tuist staff only — never customer data — and is out of scope for this server's data export. See `tuist-ops/AGENTS.md` for where it lives now.)
 
@@ -111,7 +111,7 @@ The following data is stored in ClickHouse for analytics purposes:
 All uploaded files associated with the account are included:
 - **Cache artifacts**: Build caches and compiled binaries, including Xcode, legacy CAS, module, and Gradle artifacts
 - **App previews**: iOS app bundles (.app/.ipa files) and icons  
-- **Run sessions**: uploaded run session archives stored at `{account}/{project}/runs/{run_id}/session.zip`
+- **Run artifacts**: uploaded result bundles, invocation records, result-bundle objects, and session archives stored under `{account}/{project}/runs/{run_id}/`
 - **Shard bundles**: Shared `.xctestproducts` bundles stored at `{account_id}/{project_id}/shards/{shard_plan_id}/`
 - **Runner job log archives**: gzipped runner logs stored at `runners/{account_id}/{workflow_job_id}/runner.log.gz`
 
@@ -126,20 +126,20 @@ dashboards remain intact. Retention windows, in days, by plan:
 | Artifact | Air / Open Source | Pro | Enterprise |
 | --- | --- | --- | --- |
 | Cache artifacts (Xcode compilation, legacy CAS, module, Gradle) | 14 | 30 | 90 |
-| App preview builds and icons | 60 | 180 | 365 |
-| Build archives | 30 | 90 | 365 |
-| Run session archives | 30 | 90 | 365 |
-| Test run attachments | 30 | 90 | 365 |
+| App preview builds and icons | 60 | 90 | 180 |
+| Build archives | 30 | 90 | 180 |
+| Run artifacts | 30 | 90 | 180 |
+| Test run attachments | 30 | 90 | 180 |
 | Shard bundles | 7 | 14 | 30 |
 
 Retention status is computed when cleanup runs. Cache artifacts use the object
 storage `last_modified` timestamp, while previews, build archives, test
 attachments, and shard bundles use their database `inserted_at` timestamp. Run
-session archives use the command event `ran_at` timestamp. The active account
+artifacts use the command event `ran_at` timestamp. The active account
 plan determines the applicable window, with Air used when an account has no
 active subscription.
 
-Tuist stores per-account cleanup progress for DB-backed artifact families so
+Tuist stores per-account cleanup progress for database-backed artifact families so
 daily retention jobs can resume after previously-purged metadata rows without
 issuing repeated object-storage deletes. This is not a per-artifact purge
 ledger; retention is still derived from the timestamps and account plan above.

--- a/server/lib/tuist/storage/expired_artifacts.ex
+++ b/server/lib/tuist/storage/expired_artifacts.ex
@@ -110,7 +110,7 @@ defmodule Tuist.Storage.ExpiredArtifacts do
     end
   end
 
-  def delete_run_sessions(%Account{} = account, batch_size, opts \\ []) do
+  def delete_run_artifacts(%Account{} = account, batch_size, opts \\ []) do
     plan = RetentionPolicy.current_plan(account)
     cutoff = :run_session |> RetentionPolicy.cutoff(plan) |> DateTime.to_naive()
     projects_by_id = projects_by_id(account)
@@ -129,16 +129,24 @@ defmodule Tuist.Storage.ExpiredArtifacts do
         |> select([event], %{id: event.id, project_id: event.project_id, inserted_at: event.ran_at})
         |> ClickHouseRepo.all()
 
-      object_keys =
+      prefixes =
         Enum.flat_map(rows, fn event ->
           case Map.fetch(projects_by_id, event.project_id) do
-            {:ok, project} -> [CommandEvents.get_session_key(event.id, %{project | account: account})]
-            :error -> []
+            {:ok, project} ->
+              project = %{project | account: account}
+              ["#{CommandEvents.get_command_event_artifact_base_path_key(event.id, project)}/"]
+
+            :error ->
+              []
           end
         end)
 
-      delete_and_continue(account, object_keys, next_cursor(rows, batch_size), progress_cursor(:run_session, rows))
+      delete_prefixes_and_continue(account, prefixes, next_cursor(rows, batch_size), progress_cursor(:run_session, rows))
     end
+  end
+
+  def delete_run_sessions(%Account{} = account, batch_size, opts \\ []) do
+    delete_run_artifacts(account, batch_size, opts)
   end
 
   def delete_test_attachments(%Account{} = account, batch_size, opts \\ []) do
@@ -239,6 +247,14 @@ defmodule Tuist.Storage.ExpiredArtifacts do
 
       {:error, reason} ->
         {:error, reason}
+    end
+  end
+
+  defp delete_prefixes_and_continue(%Account{} = account, prefixes, next_cursor, progress_cursor) do
+    prefixes |> Enum.uniq() |> Enum.each(&Storage.delete_all_objects(&1, account))
+
+    with :ok <- persist_progress_cursor(account, progress_cursor) do
+      {:ok, next_cursor}
     end
   end
 

--- a/server/lib/tuist/storage/retention_policy.ex
+++ b/server/lib/tuist/storage/retention_policy.ex
@@ -10,15 +10,16 @@ defmodule Tuist.Storage.RetentionPolicy do
 
   @default_plan :air
   @known_plans [:air, :open_source, :pro, :enterprise]
+  @maximum_retention_days 180
 
   @retention_days %{
     cache_artifact: %{air: 14, open_source: 14, pro: 30, enterprise: 90},
     xcode_cache_artifact: %{air: 14, open_source: 14, pro: 30, enterprise: 90},
-    preview_app_build: %{air: 60, open_source: 60, pro: 180, enterprise: 365},
-    preview_icon: %{air: 60, open_source: 60, pro: 180, enterprise: 365},
-    build_archive: %{air: 30, open_source: 30, pro: 90, enterprise: 365},
-    run_session: %{air: 30, open_source: 30, pro: 90, enterprise: 365},
-    test_attachment: %{air: 30, open_source: 30, pro: 90, enterprise: 365},
+    preview_app_build: %{air: 60, open_source: 60, pro: 90, enterprise: 180},
+    preview_icon: %{air: 60, open_source: 60, pro: 90, enterprise: 180},
+    build_archive: %{air: 30, open_source: 30, pro: 90, enterprise: 180},
+    run_session: %{air: 30, open_source: 30, pro: 90, enterprise: 180},
+    test_attachment: %{air: 30, open_source: 30, pro: 90, enterprise: 180},
     shard_bundle: %{air: 7, open_source: 7, pro: 14, enterprise: 30}
   }
 
@@ -43,9 +44,11 @@ defmodule Tuist.Storage.RetentionPolicy do
   end
 
   def retention_days(artifact_type, plan) do
-    @retention_days
-    |> Map.fetch!(artifact_type)
-    |> Map.get(plan, Map.fetch!(@retention_days[artifact_type], @default_plan))
+    retention_by_plan = Map.fetch!(@retention_days, artifact_type)
+
+    retention_by_plan
+    |> Map.get(plan, Map.fetch!(retention_by_plan, @default_plan))
+    |> min(@maximum_retention_days)
   end
 
   def cutoff(artifact_type, plan) do

--- a/server/lib/tuist/storage/workers/delete_expired_run_sessions_worker.ex
+++ b/server/lib/tuist/storage/workers/delete_expired_run_sessions_worker.ex
@@ -23,7 +23,7 @@ defmodule Tuist.Storage.Workers.DeleteExpiredRunSessionsWorker do
 
       account ->
         account
-        |> ExpiredArtifacts.delete_run_sessions(batch_size, cursor_from_args(args))
+        |> ExpiredArtifacts.delete_run_artifacts(batch_size, cursor_from_args(args))
         |> continue(__MODULE__, account_id, batch_size)
     end
   end

--- a/server/test/tuist/storage/retention_policy_test.exs
+++ b/server/test/tuist/storage/retention_policy_test.exs
@@ -58,25 +58,30 @@ defmodule Tuist.Storage.RetentionPolicyTest do
     test "returns plan-specific app preview retention" do
       assert RetentionPolicy.retention_days(:preview_app_build, :air) == 60
       assert RetentionPolicy.retention_days(:preview_app_build, :open_source) == 60
-      assert RetentionPolicy.retention_days(:preview_app_build, :pro) == 180
-      assert RetentionPolicy.retention_days(:preview_app_build, :enterprise) == 365
+      assert RetentionPolicy.retention_days(:preview_app_build, :pro) == 90
+      assert RetentionPolicy.retention_days(:preview_app_build, :enterprise) == 180
 
       assert RetentionPolicy.retention_days(:preview_icon, :air) == 60
       assert RetentionPolicy.retention_days(:preview_icon, :open_source) == 60
-      assert RetentionPolicy.retention_days(:preview_icon, :pro) == 180
-      assert RetentionPolicy.retention_days(:preview_icon, :enterprise) == 365
+      assert RetentionPolicy.retention_days(:preview_icon, :pro) == 90
+      assert RetentionPolicy.retention_days(:preview_icon, :enterprise) == 180
     end
 
     test "returns plan-specific build and test artifact retention" do
       assert RetentionPolicy.retention_days(:build_archive, :air) == 30
       assert RetentionPolicy.retention_days(:build_archive, :open_source) == 30
       assert RetentionPolicy.retention_days(:build_archive, :pro) == 90
-      assert RetentionPolicy.retention_days(:build_archive, :enterprise) == 365
+      assert RetentionPolicy.retention_days(:build_archive, :enterprise) == 180
+
+      assert RetentionPolicy.retention_days(:run_session, :air) == 30
+      assert RetentionPolicy.retention_days(:run_session, :open_source) == 30
+      assert RetentionPolicy.retention_days(:run_session, :pro) == 90
+      assert RetentionPolicy.retention_days(:run_session, :enterprise) == 180
 
       assert RetentionPolicy.retention_days(:test_attachment, :air) == 30
       assert RetentionPolicy.retention_days(:test_attachment, :open_source) == 30
       assert RetentionPolicy.retention_days(:test_attachment, :pro) == 90
-      assert RetentionPolicy.retention_days(:test_attachment, :enterprise) == 365
+      assert RetentionPolicy.retention_days(:test_attachment, :enterprise) == 180
     end
 
     test "returns short shard bundle retention" do

--- a/server/test/tuist/storage/workers/delete_expired_artifact_workers_test.exs
+++ b/server/test/tuist/storage/workers/delete_expired_artifact_workers_test.exs
@@ -303,7 +303,7 @@ defmodule Tuist.Storage.Workers.DeleteExpiredArtifactWorkersTest do
       assert second_keys == []
     end
 
-    test "the run session worker deletes expired session archives according to the account plan" do
+    test "the run session worker deletes every expired run artifact by prefix according to the account plan" do
       project = project_fixture()
       account = project.account
       subscription_fixture(account_id: account.id, plan: :air)
@@ -321,12 +321,12 @@ defmodule Tuist.Storage.Workers.DeleteExpiredArtifactWorkersTest do
         )
 
       project = %{project | account: account}
-      expired_session_key = CommandEvents.get_session_key(expired_run.id, project)
-      recent_session_key = CommandEvents.get_session_key(recent_run.id, project)
+      expired_run_artifact_prefix = "#{CommandEvents.get_command_event_artifact_base_path_key(expired_run.id, project)}/"
+      recent_run_artifact_prefix = "#{CommandEvents.get_command_event_artifact_base_path_key(recent_run.id, project)}/"
 
-      stub(Storage, :delete_objects, fn object_keys, %{id: account_id} ->
+      stub(Storage, :delete_all_objects, fn prefix, %{id: account_id} ->
         assert account_id == account.id
-        send(self(), {:deleted, object_keys})
+        send(self(), {:deleted, prefix})
         :ok
       end)
 
@@ -336,9 +336,8 @@ defmodule Tuist.Storage.Workers.DeleteExpiredArtifactWorkersTest do
                  "batch_size" => 20
                })
 
-      assert_received {:deleted, object_keys}
-      assert expired_session_key in object_keys
-      refute recent_session_key in object_keys
+      assert_received {:deleted, ^expired_run_artifact_prefix}
+      refute_received {:deleted, ^recent_run_artifact_prefix}
     end
 
     test "the run session worker paginates by command event run time" do
@@ -359,20 +358,19 @@ defmodule Tuist.Storage.Workers.DeleteExpiredArtifactWorkersTest do
         )
 
       project = %{project | account: account}
-      older_session_key = CommandEvents.get_session_key(older_run.id, project)
-      newer_session_key = CommandEvents.get_session_key(newer_run.id, project)
+      older_run_artifact_prefix = "#{CommandEvents.get_command_event_artifact_base_path_key(older_run.id, project)}/"
+      newer_run_artifact_prefix = "#{CommandEvents.get_command_event_artifact_base_path_key(newer_run.id, project)}/"
 
-      stub(Storage, :delete_objects, fn object_keys, _account ->
-        send(self(), {:deleted, object_keys})
+      stub(Storage, :delete_all_objects, fn prefix, _account ->
+        send(self(), {:deleted, prefix})
         :ok
       end)
 
       assert :ok =
                perform_job(DeleteExpiredRunSessionsWorker, %{"account_id" => account.id, "batch_size" => 1})
 
-      assert_received {:deleted, first_keys}
-      assert older_session_key in first_keys
-      refute newer_session_key in first_keys
+      assert_received {:deleted, ^older_run_artifact_prefix}
+      refute_received {:deleted, ^newer_run_artifact_prefix}
 
       assert_enqueued(
         worker: DeleteExpiredRunSessionsWorker,
@@ -392,9 +390,7 @@ defmodule Tuist.Storage.Workers.DeleteExpiredArtifactWorkersTest do
                  "after_id" => older_run.id
                })
 
-      assert_received {:deleted, second_keys}
-      assert newer_session_key in second_keys
-      refute older_session_key in second_keys
+      assert_received {:deleted, ^newer_run_artifact_prefix}
     end
 
     test "the test attachment worker deletes expired test attachments according to the account plan" do


### PR DESCRIPTION
## Overview

This reduces long-lived artifact retention without making Enterprise identical to Pro. Pro remains capped at 90 days for the affected artifact classes, while Enterprise moves from 365 days to 180 days for app previews, build archives, run artifacts, and test attachments.

The change also broadens expired run cleanup so every file generated for an expired run is removed together, instead of only deleting the session archive.

## What changed

- Set a central maximum artifact retention window of 180 days.
- Kept cache artifact retention unchanged at 14 days for Air and Open Source, 30 days for Pro, and 90 days for Enterprise.
- Kept shard bundle retention unchanged at 7 days for Air and Open Source, 14 days for Pro, and 30 days for Enterprise.
- Updated Enterprise retention from 365 days to 180 days for app previews, build archives, run artifacts, and test attachments.
- Changed the run cleanup worker to delete the whole expired run artifact prefix instead of only the session archive.
- Kept the existing `run_session` retention cursor for compatibility while making it cover all blobs under an expired run prefix.
- Updated focused tests and the data export documentation to describe the new retention behavior.

## Why

Operational review showed that some artifact categories can outlive a practical retention window. Run artifacts were a notable gap because files stored under the same run prefix were not all covered by the previous cleanup path.

A 365-day Enterprise window is too large for these artifact blobs, but a universal 90-day policy removes the product distinction between Pro and Enterprise. The new policy reduces the longest-lived artifacts to 180 days for Enterprise while keeping Pro at 90 days.

## Storage breakdown

The aggregate category-level usage that motivated this change was:

| Artifact category | Approximate usage | Relationship | What this change addresses |
| --- | ---: | --- | --- |
| Run artifacts | 44.02 tebibytes | Total category | The cleanup now removes the whole expired run artifact prefix. |
| Result bundle archives | 27.19 tebibytes | Included in run artifacts | Previously not covered by the session-only cleanup path. |
| Session archives | 9.16 tebibytes | Included in run artifacts | Already targeted by the old worker, now removed with the rest of the run. |
| Result-bundle object files | 7.15 tebibytes | Included in run artifacts | Now covered by prefix deletion for expired runs. |
| Invocation records | 0.53 tebibytes | Included in run artifacts | Now covered by prefix deletion for expired runs. |
| Build archives | 29.37 tebibytes | Separate artifact category | Enterprise retention is reduced from 365 days to 180 days. |
| App preview archives | 9.00 tebibytes | Separate artifact category | Enterprise retention is reduced from 365 days to 180 days. |

## Root cause

The existing run cleanup path only deleted the `session.zip` object for expired command events. Other files under the same run artifact prefix, including result bundles, invocation records, and result-bundle objects, were not removed by that worker.

Some Enterprise retention windows also allowed artifact blobs to remain for 365 days.

## Approach

The retention policy now applies a central 180-day maximum when resolving plan-specific retention windows. This keeps lower limits unchanged for Air, Open Source, Pro cache artifacts, and shard bundles while preventing the affected Enterprise artifact families from staying at 365 days.

For run artifacts, the existing worker now resolves each expired command event to its run artifact prefix and deletes every object below that prefix. The old `delete_run_sessions` entry point remains as a compatibility wrapper around the broader `delete_run_artifacts` behavior.

## Impact

Expired run cleanup will remove all blobs stored under `{account}/{project}/runs/{run_id}/`, including session archives, result bundles, invocation records, and result-bundle objects. Build archives, app previews, run artifacts, and test attachments are now capped at 90 days for Pro and 180 days for Enterprise.

Metadata rows are still retained so analytics, dashboards, and export behavior remain intact.

## Validation

- `mix format lib/tuist/storage/expired_artifacts.ex lib/tuist/storage/retention_policy.ex lib/tuist/storage/workers/delete_expired_run_sessions_worker.ex test/tuist/storage/retention_policy_test.exs test/tuist/storage/workers/delete_expired_artifact_workers_test.exs`
- `mix test test/tuist/storage/retention_policy_test.exs test/tuist/storage/workers/delete_expired_artifact_workers_test.exs`, 20 tests, 0 failures
- `git diff --check`