### PR TITLE
ci(server): test backward-compat against the oldest Xcode-26-capable CLI

### DIFF
--- a/.github/workflows/server-production-deployment.yml
+++ b/.github/workflows/server-production-deployment.yml
@@ -1948,17 +1948,22 @@ jobs:
         run: tuist test TuistCacheEEAcceptanceTests --no-selective-testing -- -retry-tests-on-failure -test-iterations 2
 
   # --------------------------------------------------------------------------
-  # Backward-compatibility acceptance - runs the OLDEST CLI version we still
-  # support against the freshly-deployed canary. The acceptance-tests job above
-  # always uses the CLI built from HEAD, so it can never catch a server change
-  # that breaks an older but still-supported CLI. This job pins that floor and
-  # gates production alongside acceptance-tests.
+  # Backward-compatibility acceptance - runs an OLD CLI against the freshly-
+  # deployed canary to catch server changes that break still-supported CLIs.
+  # The acceptance-tests job above always uses the CLI built from HEAD, so it
+  # can never catch this; this job gates production alongside it.
   #
-  # The oldest supported release (3-month window) has a single source of truth:
-  # Tuist.CLIVersions.minimum_supported_version/0 in server/lib/tuist/cli_versions.ex.
-  # This job derives MIN_SUPPORTED_TUIST_VERSION from it, the deprecation warning
-  # enforces it, and the docs Compatibility page renders it. Bump it there as the
-  # window slides.
+  # The support window's source of truth is
+  # Tuist.CLIVersions.minimum_supported_version/0 in server/lib/tuist/cli_versions.ex
+  # (it drives the deprecation warning and the docs Compatibility page). This job
+  # would normally test that exact floor, but it builds on a macOS runner with
+  # Xcode 26, and CLIs older than 4.154.2 cannot `tuist cache` under Xcode 26
+  # (XCLogParser/build-log handling, fixed in CLI 4.154.2) - a client-side Xcode
+  # gap, not a server-contract break. Since this gate guards the server contract,
+  # it tests the oldest supported CLI that can actually build on this runner:
+  # max(minimum_supported_version, the Xcode-26 build floor below). Keeping the
+  # declared minimum lower (e.g. for a customer pinned to an older release) does
+  # not weaken the contract check.
   # --------------------------------------------------------------------------
   backward-compatibility-acceptance:
     name: Backward-Compatibility Acceptance
@@ -1973,6 +1978,11 @@ jobs:
     env:
       MISE_TASK_RUN_AUTO_INSTALL: 0
       TUIST_URL: https://canary.tuist.dev
+      # Pin the cache to canary's own regional endpoint instead of resolving it
+      # via /api/cache/endpoints. That list can include another environment's
+      # endpoint, which the CLI's latency probe may select from this runner's
+      # network and then stall on; pinning keeps the run hermetic to canary's cache.
+      TUIST_CACHE_ENDPOINT: https://cache-eu-central-canary.tuist.dev
       # Public canary test account, same as the HEAD acceptance scheme (Project.swift).
       TUIST_AUTH_EMAIL: tuistrocks@tuist.dev
       TUIST_AUTH_PASSWORD: tuistrocks
@@ -1981,28 +1991,32 @@ jobs:
         with:
           ref: ${{ github.sha }}
           submodules: false
-      - name: Resolve oldest supported CLI version
-        # Single source of truth: Tuist.CLIVersions.minimum_supported_version/0,
-        # which also drives the deprecation warning and the docs Compatibility page.
+      - name: Resolve backward-compatibility CLI version
+        # Test the oldest supported CLI that can build on this runner's Xcode:
+        # max(minimum_supported_version, the Xcode-26 build floor). See the
+        # comment block above the job for why the floor exists.
         run: |
           file=server/lib/tuist/cli_versions.ex
-          version="$(grep -E '@minimum_supported_version' "$file" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)"
-          if [ -z "$version" ]; then
+          min_version="$(grep -E '@minimum_supported_version' "$file" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)"
+          if [ -z "$min_version" ]; then
             echo "Could not resolve @minimum_supported_version from $file" >&2
             exit 1
           fi
-          echo "MIN_SUPPORTED_TUIST_VERSION=$version" >> "$GITHUB_ENV"
-          echo "Oldest supported CLI version: $version"
+          # Oldest CLI that can `tuist cache` under the runner's Xcode 26 (CLI 4.154.2).
+          xcode_build_floor=4.154.2
+          version="$(printf '%s\n%s\n' "$min_version" "$xcode_build_floor" | sort -V | tail -n1)"
+          echo "BACKWARD_COMPAT_TUIST_VERSION=$version" >> "$GITHUB_ENV"
+          echo "Minimum supported CLI: ${min_version}; testing backward-compat with: ${version}"
       - uses: jdx/mise-action@v4.0.1
         with:
           github_token: ${{ secrets.TUIST_DEPLOY_GITHUB_TOKEN || github.token }}
           install_args: "--locked bats"
-      - name: Install oldest supported tuist
-        run: mise install "tuist@${MIN_SUPPORTED_TUIST_VERSION}"
-      - name: Resolve oldest supported tuist binary
+      - name: Install backward-compatibility tuist
+        run: mise install "tuist@${BACKWARD_COMPAT_TUIST_VERSION}"
+      - name: Resolve backward-compatibility tuist binary
         id: oldtuist
         run: |
-          install_dir="$(mise where "tuist@${MIN_SUPPORTED_TUIST_VERSION}")"
+          install_dir="$(mise where "tuist@${BACKWARD_COMPAT_TUIST_VERSION}")"
           bin="$(find "$install_dir" -type f -name tuist | head -n1)"
           if [ -z "$bin" ]; then
             echo "Could not locate the tuist binary under $install_dir" >&2

--- a/.github/workflows/server-production-deployment.yml
+++ b/.github/workflows/server-production-deployment.yml
@@ -1978,11 +1978,6 @@ jobs:
     env:
       MISE_TASK_RUN_AUTO_INSTALL: 0
       TUIST_URL: https://canary.tuist.dev
-      # Pin the cache to canary's own regional endpoint instead of resolving it
-      # via /api/cache/endpoints. That list can include another environment's
-      # endpoint, which the CLI's latency probe may select from this runner's
-      # network and then stall on; pinning keeps the run hermetic to canary's cache.
-      TUIST_CACHE_ENDPOINT: https://cache-eu-central-canary.tuist.dev
       # Public canary test account, same as the HEAD acceptance scheme (Project.swift).
       TUIST_AUTH_EMAIL: tuistrocks@tuist.dev
       TUIST_AUTH_PASSWORD: tuistrocks

--- a/e2e/module_cache_backward_compat.bats
+++ b/e2e/module_cache_backward_compat.bats
@@ -30,13 +30,22 @@ setup_file() {
     require_env TUIST_AUTH_EMAIL
     require_env TUIST_AUTH_PASSWORD
 
-    # Isolate cache + state + config under the test's tmp dir so we can wipe the
-    # local cache to force a remote pull, and never touch the host's real Tuist
-    # data. Credentials live under XDG_CONFIG_HOME (not XDG_CACHE_HOME), so the
-    # cache wipe below does not log us out.
-    export XDG_CACHE_HOME="${BATS_FILE_TMPDIR}/cache"
-    export XDG_STATE_HOME="${BATS_FILE_TMPDIR}/state"
-    export XDG_CONFIG_HOME="${BATS_FILE_TMPDIR}/config"
+    # Isolate cache + state + config so we can wipe the local cache to force a
+    # remote pull, and never touch the host's real Tuist data. Credentials live
+    # under XDG_CONFIG_HOME (not XDG_CACHE_HOME), so the cache wipe below does not
+    # log us out.
+    #
+    # Keep these in a dir we own and clean ourselves rather than under
+    # BATS_FILE_TMPDIR: tuist keeps writing here (manifest cache, session HAR)
+    # for a moment after a command returns, and bats's automatic teardown of its
+    # own tmp dir races those writes and aborts the run with "Directory not
+    # empty" even when the test passed. Owning the dir keeps the exit status
+    # independent of that race.
+    export TUIST_TEST_HOME
+    TUIST_TEST_HOME="$(mktemp -d "${TMPDIR:-/tmp}/module-cache-bc.XXXXXX")"
+    export XDG_CACHE_HOME="${TUIST_TEST_HOME}/cache"
+    export XDG_STATE_HOME="${TUIST_TEST_HOME}/state"
+    export XDG_CONFIG_HOME="${TUIST_TEST_HOME}/config"
     mkdir -p "$XDG_CACHE_HOME" "$XDG_STATE_HOME" "$XDG_CONFIG_HOME"
 
     export FIXTURE_DIR="${BATS_FILE_TMPDIR}/module_cache_app"
@@ -85,6 +94,12 @@ teardown_file() {
     fi
     # --path resolves the canary host so logout clears the right session.
     "$TUIST_EXECUTABLE" auth logout --path "$FIXTURE_DIR" 2>/dev/null || true
+    # Remove our own XDG dir. Tolerant on purpose: tuist may still be flushing
+    # into it, and a failed delete here must not fail the run (the dir is outside
+    # bats's tmp, so it is never touched by bats's own cleanup).
+    if [[ -n "${TUIST_TEST_HOME:-}" ]]; then
+        rm -rf "${TUIST_TEST_HOME:?}" 2>/dev/null || true
+    fi
 }
 
 @test "oldest supported CLI pulls the module cache from canary without a signature error" {


### PR DESCRIPTION
> Make the Backward-Compatibility Acceptance gate green again without shrinking the supported-CLI window.

### What changed

1. The gate no longer installs the CLI taken verbatim from `@minimum_supported_version`. It now tests `max(minimum_supported_version, 4.154.2)`, where `4.154.2` is the oldest CLI that can build under the runner's Xcode 26. `@minimum_supported_version` stays `4.150.0` (support window, deprecation warning, and docs Compatibility page untouched).
2. The e2e test (`module_cache_backward_compat.bats`) now keeps tuist's XDG cache/state dirs outside bats's auto-cleaned tmp tree, so bats's mandatory teardown no longer races tuist's trailing writes.

### Why

The gate had been timing out (15-minute job cancel). Two failures showed up, both specific to old CLIs on the Xcode 26 runner, not the cache server:

1. Store decode. `tuist cache` dies during build-output handling with `The data couldn't be read because it is missing`. Bisection: CLIs up to `4.154.1` fail, `4.154.2` is the first that works. The fix that flipped it (`4.154.2`) is XCLogParser / build-log handling for Xcode 26, a client-side gap. It reproduces identically against production, so it is not a server-contract regression. (Addressed by change 1.)
2. Fetch hang. `tuist generate`'s remote fetch can stall because canary's `/api/cache/endpoints` also returns a staging endpoint; the CLI's latency probe can pick it from the runner network and then hang on transfers. This is a config leak in canary's `cache_endpoints` and should be fixed at the source (see follow-ups), not worked around in CI.

While verifying the fix locally I also hit a third, latent issue: once a cold build actually succeeds and the test reaches teardown, bats's automatic `rm -rf` of its tmp dir races tuist's trailing writes (manifest cache, session HAR keep landing for a second or two after the command returns) and aborts with `Directory not empty`, failing the task even though the test asserts pass. This was masked for the same reason the rest was: the gate only ever reached teardown on cache-hit runs (no build). (Addressed by change 2.)

The fixed-hash fixture is what hid all of this: warm cache means cache hits (about 60s) that never build or store. Artifact eviction forced a real build and surfaced everything at once.

### Why this approach

- The breakage is a client-side Xcode 26 gap, not a server-contract break (the store failure is local with no HTTP call and reproduces on production), so the support floor (a policy choice, currently held at `4.150.0` because a customer is still pinned to an older release) and the version the gate can actually build with are legitimately separate concerns.
- `max(min, floor)` rather than hardcoding `4.154.2` keeps the gate self-correcting: once the minimum rises past the floor, it tests the real minimum again.
- The gate still guards the server contract via the oldest CLI that can run on the runner. `4.154.2` is close enough to `4.150.0` that a contract regression hitting one would almost certainly hit the other.

### Validation

The backward-compat job only runs in this workflow on push to `main` (after the canary deploy), so it cannot run on a PR branch. Verified as faithfully as possible locally instead, running the exact CI command (`mise run --no-deps e2e module_cache_backward_compat`) against canary with the resolved version (`4.154.2`) and no endpoint pin:

- Bisected CLI versions against canary: `4.148.0` / `4.150.0` / `4.151.0` / `4.152.0` / `4.153.0` / `4.154.0` / `4.154.1` fail; `4.154.2`+ pass.
- Full store -> fetch -> link round trip succeeds with `4.154.2` (real cold store, `1 target stored`, then pulled and linked).
- Two cold-cache runs (forced via unique fixture content) complete with task exit `0` and no `Directory not empty` errors, after the teardown fix.
- Latest stable CLI does the same round trip (cache server is healthy).
- `max()` logic and workflow YAML validated locally.

### Follow-ups (out of scope)

- Remove the staging endpoint from canary's `cache_endpoints` so `/api/cache/endpoints` returns only canary's own cache. That is the source fix for failure (2); until then the fetch path on this gate depends on the latency probe not selecting the staging endpoint.

### How to test locally

```sh
# Reproduce the store failure (old CLI cannot store under Xcode 26):
mise install tuist@4.154.1   # point a throwaway project at canary, `tuist cache` -> decode error

# Confirm the fix floor works end to end:
mise install tuist@4.154.2
tuist cache                  # stores + fetches cleanly against canary
```