### PR TITLE
fix(server): grant runtime role EXECUTE only on migration-owned functions

### DIFF
--- a/server/lib/tuist/release.ex
+++ b/server/lib/tuist/release.ex
@@ -162,7 +162,7 @@ defmodule Tuist.Release do
         "REVOKE CREATE ON SCHEMA public FROM #{role}",
         "GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO #{role}",
         "GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO #{role}",
-        "GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA public TO #{role}",
+        grant_execute_on_owned_functions(role),
         "REVOKE INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER ON TABLE public.schema_migrations FROM #{role}",
         "GRANT SELECT ON TABLE public.schema_migrations TO #{role}",
         "ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO #{role}",
@@ -171,6 +171,38 @@ defmodule Tuist.Release do
       ],
       &SQL.query!(repo, &1, [])
     )
+  end
+
+  # `GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA public` requires the
+  # migration role to own every function in the schema, and aborts the
+  # whole statement otherwise. The CNPG PgBouncer pooler installs a
+  # superuser-owned `user_search` auth function into public, so the
+  # blanket grant fails with `permission denied for function user_search`.
+  # Grant only on functions the migration role owns — the runtime role
+  # never calls operator-owned functions, and `ALTER DEFAULT PRIVILEGES`
+  # above already covers functions the role creates from here on.
+  defp grant_execute_on_owned_functions(role) do
+    """
+    DO $tuist_grant$
+    DECLARE
+      function_signature text;
+    BEGIN
+      FOR function_signature IN
+        SELECT format(
+          '%I.%I(%s)', n.nspname, p.proname,
+          pg_catalog.pg_get_function_identity_arguments(p.oid)
+        )
+        FROM pg_catalog.pg_proc p
+        JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
+        WHERE n.nspname = 'public'
+          AND p.prokind <> 'p'
+          AND p.proowner = current_user::regrole
+      LOOP
+        EXECUTE 'GRANT EXECUTE ON FUNCTION ' || function_signature || ' TO #{role}';
+      END LOOP;
+    END
+    $tuist_grant$;
+    """
   end
 
   defp quote_identifier(identifier) do


### PR DESCRIPTION
## What changed

The post-migration runtime-role grant in `Tuist.Release` no longer uses the blanket `GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA public`. It now iterates the functions the migration role owns and grants `EXECUTE` on each individually.

## Why (root cause)

The database role split ([#11408](https://github.com/tuist/tuist/pull/11408)) added a step that, after migrations run, grants the narrow runtime role (`tuist_web`) the privileges it needs on the objects migrations manage. For functions it ran:

```sql
GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA public TO <runtime_role>
```

`GRANT ... ON ALL FUNCTIONS IN SCHEMA` requires the granting role to own **every** function in the schema; if it hits one it doesn't own, the entire statement aborts. On CNPG-managed clusters the built-in PgBouncer pooler integration installs a **superuser-owned** `user_search` auth function into `public`. The migration role (`tuist_app`, the `<cluster>-app` owner) doesn't own it, so the statement failed with:

```
** (Postgrex.Error) ERROR 42501 (insufficient_privilege) permission denied for function user_search
```

The migration runs as a **pre-upgrade Helm hook**, so this failed the hook, rolled the release back (`rollback-on-failure`), and wedged the `Deploy to tuist-canary` step. Because the production cascade runs canary → acceptance → production, **every** cascade stalled at canary, and the cut release would have hit production the same way once it got there.

Note: the chart comment / `infra/cnpg/README.md` state that CNPG installs `user_search` in the `postgres` database. In practice it also lands in the application database's `public` schema (the failing `GRANT` ran against the `tuist` DB), which is why this wasn't caught in review.

### Not the runners-controller

The failure surfaced alongside `runners: desired_replicas failed` / tokenreview `401` log lines and a momentarily missing runners-controller pod (transient `DiskPressure` eviction). Those are "Diagnostics on failure" noise from the *old* server pod, not the cause — the helm step failed solely on the pre-upgrade migration hook.

## Why this solution

- The runtime role only needs `EXECUTE` on functions the app calls, all of which are created by migrations and owned by the migration role. It never calls operator-owned functions like `user_search`.
- Scoping by ownership (`proowner = current_user::regrole`) is the correct semantics for "grant access to the objects migrations manage" and is robust against any future operator/extension function landing in `public`.
- Procedures are excluded (`prokind <> 'p'`) because `GRANT EXECUTE ON FUNCTION` rejects them, matching the original `ALL FUNCTIONS` behavior.
- Tables and sequences keep the blanket grant: `public` has no views or foreign-owned relations, so those statements already only touch migration-owned objects. Converting them would risk dropping grants on view/matview classes for no benefit.
- `ALTER DEFAULT PRIVILEGES ... GRANT EXECUTE ON FUNCTIONS` is unchanged and continues to cover functions the migration role creates from here on.

## Impact

Unblocks the canary step (and therefore the whole production cascade). Prevents the same failure from reaching production. No effect on environments that don't set `TUIST_DATABASE_RUNTIME_ROLE` (dev, self-host) — the grant step is skipped there.

## Validation

- `mix format --check-formatted` and `mix compile` pass.
- Rendered the generated SQL to confirm well-formed dollar-quoted PL/pgSQL with the role identifier safely interpolated (role is already regex-validated as a bare identifier).
- End-to-end validation is the canary cascade itself once this lands: the migrate Job runs the fixed `Release.migrate`, the grant succeeds, and the pre-upgrade hook passes.