### PR TITLE
fix(server): correct run attribution and harden xcresult processing

### DIFF
--- a/server/lib/tuist/builds/workers/process_build_worker.ex
+++ b/server/lib/tuist/builds/workers/process_build_worker.ex
@@ -26,8 +26,8 @@ defmodule Tuist.Builds.Workers.ProcessBuildWorker do
       period: :infinity
     ]
 
-  alias Tuist.Accounts
   alias Tuist.Builds
+  alias Tuist.Projects
   alias Tuist.Storage
 
   require Logger
@@ -49,7 +49,7 @@ defmodule Tuist.Builds.Workers.ProcessBuildWorker do
     xcode_cache_upload_enabled = Map.get(args, "xcode_cache_upload_enabled", false)
     build_metadata = Map.get(args, "build_metadata", %{})
 
-    case process_build(build_id, storage_key, account_id, xcode_cache_upload_enabled) do
+    case process_build(build_id, storage_key, project_id, xcode_cache_upload_enabled) do
       {:ok, parsed_data} ->
         parsed_data = Map.put(parsed_data, "project_id", project_id)
         replace_build_run(build_id, parsed_data, account_id, project_id, build_metadata)
@@ -69,8 +69,12 @@ defmodule Tuist.Builds.Workers.ProcessBuildWorker do
     end
   end
 
-  defp process_build(build_id, storage_key, account_id, xcode_cache_upload_enabled) do
-    with {:ok, account} <- Accounts.get_account_by_id(account_id) do
+  # Storage routes per account, so the download backend must be the project's
+  # account (where the artifact was uploaded and the key is namespaced), not
+  # the run's `account_id`, which records who ran the build and can be a member
+  # with a different personal account.
+  defp process_build(build_id, storage_key, project_id, xcode_cache_upload_enabled) do
+    with {:ok, account} <- storage_account(project_id) do
       temp_path = Path.join(System.tmp_dir!(), "build_#{build_id}.zip")
 
       try do
@@ -84,6 +88,13 @@ defmodule Tuist.Builds.Workers.ProcessBuildWorker do
       after
         File.rm(temp_path)
       end
+    end
+  end
+
+  defp storage_account(project_id) do
+    case Projects.get_project_by_id(project_id) do
+      nil -> {:error, :project_not_found}
+      project -> {:ok, project.account}
     end
   end
 

--- a/server/lib/tuist/tests/workers/process_xcresult_worker.ex
+++ b/server/lib/tuist/tests/workers/process_xcresult_worker.ex
@@ -19,7 +19,7 @@ defmodule Tuist.Tests.Workers.ProcessXcresultWorker do
     max_attempts: 5,
     unique: [keys: [:test_run_id, :shard_index]]
 
-  alias Tuist.Accounts
+  alias Tuist.Projects
   alias Tuist.Storage
   alias Tuist.Tests
 
@@ -35,11 +35,11 @@ defmodule Tuist.Tests.Workers.ProcessXcresultWorker do
 
   @impl Oban.Worker
   def perform(%Oban.Job{
-        args: %{"test_run_id" => test_run_id, "storage_key" => storage_key, "account_id" => account_id} = args,
+        args: %{"test_run_id" => test_run_id, "storage_key" => storage_key} = args,
         attempt: attempt,
         max_attempts: max_attempts
       }) do
-    case process_xcresult(test_run_id, storage_key, account_id, args) do
+    case process_xcresult(test_run_id, storage_key, args) do
       {:ok, parsed_data} ->
         replace_test_run(parsed_data, args)
 
@@ -71,8 +71,12 @@ defmodule Tuist.Tests.Workers.ProcessXcresultWorker do
     end
   end
 
-  defp process_xcresult(test_run_id, storage_key, account_id, args) do
-    with {:ok, account} <- Accounts.get_account_by_id(account_id) do
+  # Storage routes per account, so the download backend must be the project's
+  # account (where the xcresult was uploaded and the key is namespaced), not
+  # the run's `account_id`, which records who ran the tests and can be a member
+  # with a different personal account.
+  defp process_xcresult(test_run_id, storage_key, args) do
+    with {:ok, account} <- storage_account(args["project_id"]) do
       # For sharded runs, multiple workers share the same merged
       # test_run_id and can run concurrently. Suffix the temp path with
       # the shard index so they never clobber each other's download
@@ -104,6 +108,13 @@ defmodule Tuist.Tests.Workers.ProcessXcresultWorker do
       after
         File.rm(temp_path)
       end
+    end
+  end
+
+  defp storage_account(project_id) do
+    case Projects.get_project_by_id(project_id) do
+      nil -> {:error, :project_not_found}
+      project -> {:ok, project.account}
     end
   end
 

--- a/server/lib/tuist_web/controllers/api/builds_controller.ex
+++ b/server/lib/tuist_web/controllers/api/builds_controller.ex
@@ -14,6 +14,7 @@ defmodule TuistWeb.API.BuildsController do
   alias TuistWeb.API.Schemas.Builds.Build
   alias TuistWeb.API.Schemas.Error
   alias TuistWeb.API.Schemas.PaginationMetadata
+  alias TuistWeb.Authentication
 
   plug(TuistWeb.Plugs.CastAndValidate,
     json_render_error_v2: true,
@@ -852,7 +853,7 @@ defmodule TuistWeb.API.BuildsController do
     run_params =
       body_params
       |> Map.put(:project, selected_project)
-      |> Map.put(:account, selected_project.account)
+      |> Map.put(:account, Authentication.authenticated_subject_account(conn))
 
     {:ok, build} = get_or_create_build(run_params)
 

--- a/server/lib/tuist_web/controllers/api/builds_controller.ex
+++ b/server/lib/tuist_web/controllers/api/builds_controller.ex
@@ -853,7 +853,7 @@ defmodule TuistWeb.API.BuildsController do
     run_params =
       body_params
       |> Map.put(:project, selected_project)
-      |> Map.put(:account, Authentication.authenticated_subject_account(conn))
+      |> Map.put(:ran_by_account, Authentication.authenticated_subject_account(conn))
 
     {:ok, build} = get_or_create_build(run_params)
 
@@ -896,7 +896,7 @@ defmodule TuistWeb.API.BuildsController do
           scheme: Map.get(params, :scheme),
           configuration: Map.get(params, :configuration),
           project_id: params.project.id,
-          account_id: params.account.id,
+          account_id: params.ran_by_account.id,
           status: Map.get(params, :status, "success"),
           category: Map.get(params, :category),
           git_branch: Map.get(params, :git_branch),
@@ -926,7 +926,7 @@ defmodule TuistWeb.API.BuildsController do
           %{
             build_id: build.id,
             storage_key: storage_key,
-            account_id: params.account.id,
+            account_id: params.ran_by_account.id,
             project_id: params.project.id,
             xcode_cache_upload_enabled: Map.get(params, :xcode_cache_upload_enabled, false),
             build_metadata: %{

--- a/server/lib/tuist_web/controllers/api/runs_controller.ex
+++ b/server/lib/tuist_web/controllers/api/runs_controller.ex
@@ -778,7 +778,7 @@ defmodule TuistWeb.API.RunsController do
     run_params =
       body_params
       |> Map.put(:project, selected_project)
-      |> Map.put(:account, Authentication.authenticated_subject_account(conn))
+      |> Map.put(:ran_by_account, Authentication.authenticated_subject_account(conn))
 
     case Map.get(body_params, :type, "build") do
       "build" ->
@@ -845,7 +845,7 @@ defmodule TuistWeb.API.RunsController do
           scheme: Map.get(params, :scheme),
           configuration: Map.get(params, :configuration),
           project_id: params.project.id,
-          account_id: params.account.id,
+          account_id: params.ran_by_account.id,
           status: Map.get(params, :status, "success"),
           category: Map.get(params, :category),
           git_branch: Map.get(params, :git_branch),
@@ -900,7 +900,7 @@ defmodule TuistWeb.API.RunsController do
           model_identifier: Map.get(params, :model_identifier),
           scheme: Map.get(params, :scheme),
           project_id: params.project.id,
-          account_id: params.account.id,
+          account_id: params.ran_by_account.id,
           status: Map.get(params, :status),
           git_branch: Map.get(params, :git_branch),
           git_commit_sha: Map.get(params, :git_commit_sha),

--- a/server/lib/tuist_web/controllers/api/tests_controller.ex
+++ b/server/lib/tuist_web/controllers/api/tests_controller.ex
@@ -9,6 +9,7 @@ defmodule TuistWeb.API.TestsController do
   alias TuistWeb.API.Schemas.Error
   alias TuistWeb.API.Schemas.PaginationMetadata
   alias TuistWeb.API.Schemas.Tests.Test
+  alias TuistWeb.Authentication
 
   plug(TuistWeb.Plugs.CastAndValidate,
     json_render_error_v2: true,
@@ -520,7 +521,7 @@ defmodule TuistWeb.API.TestsController do
     run_params =
       body_params
       |> Map.put(:project, selected_project)
-      |> Map.put(:account, selected_project.account)
+      |> Map.put(:account, Authentication.authenticated_subject_account(conn))
 
     case get_or_create_test(run_params) do
       {:ok, test_run} ->

--- a/server/lib/tuist_web/controllers/api/tests_controller.ex
+++ b/server/lib/tuist_web/controllers/api/tests_controller.ex
@@ -521,7 +521,7 @@ defmodule TuistWeb.API.TestsController do
     run_params =
       body_params
       |> Map.put(:project, selected_project)
-      |> Map.put(:account, Authentication.authenticated_subject_account(conn))
+      |> Map.put(:ran_by_account, Authentication.authenticated_subject_account(conn))
 
     case get_or_create_test(run_params) do
       {:ok, test_run} ->
@@ -738,7 +738,7 @@ defmodule TuistWeb.API.TestsController do
           model_identifier: Map.get(params, :model_identifier),
           scheme: Map.get(params, :scheme),
           project_id: params.project.id,
-          account_id: params.account.id,
+          account_id: params.ran_by_account.id,
           status: Map.get(params, :status),
           git_branch: Map.get(params, :git_branch),
           git_commit_sha: Map.get(params, :git_commit_sha),

--- a/server/native/xcresult_nif/Sources/XCResultNIF/XCResultNIF.swift
+++ b/server/native/xcresult_nif/Sources/XCResultNIF/XCResultNIF.swift
@@ -42,9 +42,10 @@ public func parseXCResult(
         semaphore.signal()
     }
 
-    let timeout = semaphore.wait(timeout: .now() + .seconds(600))
+    let timeoutSeconds = 600
+    let timeout = semaphore.wait(timeout: .now() + .seconds(timeoutSeconds))
     if timeout == .timedOut {
-        result = .failure(XCResultParserError.failedToParseOutput(try! AbsolutePath(validating: path)))
+        result = .failure(XCResultParserError.timedOut(try! AbsolutePath(validating: path), seconds: timeoutSeconds))
     }
 
     switch result {

--- a/server/native/xcresult_nif/Sources/XCResultParser/ActionLogSection.swift
+++ b/server/native/xcresult_nif/Sources/XCResultParser/ActionLogSection.swift
@@ -11,6 +11,17 @@ struct ActionLogSection: Codable, Sendable {
     let title: String?
     let location: Location?
 
+    static let empty = ActionLogSection(
+        subsections: nil,
+        commandInvocationDetails: nil,
+        testDetails: nil,
+        messages: nil,
+        duration: nil,
+        startTime: nil,
+        title: nil,
+        location: nil
+    )
+
     struct CommandInvocationDetails: Codable, Sendable {
         let emittedOutput: String?
     }

--- a/server/native/xcresult_nif/Sources/XCResultParser/XCResultParser.swift
+++ b/server/native/xcresult_nif/Sources/XCResultParser/XCResultParser.swift
@@ -5,13 +5,50 @@ import Path
 
 public enum XCResultParserError: LocalizedError, Equatable {
     case failedToParseOutput(AbsolutePath)
+    case timedOut(AbsolutePath, seconds: Int)
+    case decodingFailed(step: String, path: AbsolutePath, detail: String)
 
     public var errorDescription: String? {
         switch self {
         case let .failedToParseOutput(path):
             return "Failed to parse xcresult output at \(path.pathString)"
+        case let .timedOut(path, seconds):
+            return "xcresult parsing timed out after \(seconds)s at \(path.pathString)"
+        case let .decodingFailed(step, path, detail):
+            return "Failed to decode xcresult \(step) at \(path.pathString): \(detail)"
         }
     }
+}
+
+/// Renders a decoding failure into a single Sentry-friendly line: the
+/// `DecodingError` kind, the JSON key path it choked on, and a short head of
+/// the offending output. The default `localizedDescription` collapses every
+/// `DecodingError` to "The data couldn't be read because it isn't in the
+/// correct format.", which tells us nothing about which xcresulttool output
+/// drifted from the schema.
+func describeDecodingFailure(_ error: Error, output: String) -> String {
+    let head = output.prefix(200).replacingOccurrences(of: "\n", with: " ")
+    let snippet = output.isEmpty ? "<empty>" : "\"\(head)\""
+
+    func path(_ context: DecodingError.Context) -> String {
+        context.codingPath.map(\.stringValue).joined(separator: ".")
+    }
+
+    let reason: String
+    switch error {
+    case let DecodingError.dataCorrupted(context):
+        reason = "dataCorrupted at [\(path(context))]: \(context.debugDescription)"
+    case let DecodingError.keyNotFound(key, context):
+        reason = "keyNotFound \(key.stringValue) at [\(path(context))]"
+    case let DecodingError.typeMismatch(type, context):
+        reason = "typeMismatch \(type) at [\(path(context))]: \(context.debugDescription)"
+    case let DecodingError.valueNotFound(type, context):
+        reason = "valueNotFound \(type) at [\(path(context))]"
+    default:
+        reason = error.localizedDescription
+    }
+
+    return "\(reason) (\(output.count) bytes: \(snippet))"
 }
 
 public struct XCResultParser: Sendable {
@@ -120,7 +157,14 @@ public struct XCResultParser: Sendable {
                 guard let jsonData = jsonString.data(using: .utf8) else {
                     throw XCResultParserError.failedToParseOutput(path)
                 }
-                return try JSONDecoder().decode(XCResultTestOutput.self, from: jsonData)
+                do {
+                    return try JSONDecoder().decode(XCResultTestOutput.self, from: jsonData)
+                } catch {
+                    throw XCResultParserError.decodingFailed(
+                        step: "test-results", path: path,
+                        detail: describeDecodingFailure(error, output: jsonString)
+                    )
+                }
             }
     }
 
@@ -562,7 +606,20 @@ public struct XCResultParser: Sendable {
             ).concatenatedString()
 
             let logData = try await fileSystem.readFile(at: tempFile)
-            return try JSONDecoder().decode(ActionLogSection.self, from: logData)
+            // An aborted or test-less xcresult has no action log: `xcresulttool
+            // get log --type action` prints "No action log available" and writes
+            // nothing. The action log only enriches durations and failure
+            // locations, so treat its absence as empty rather than failing the
+            // whole parse with an opaque decode error.
+            guard !logData.isEmpty else { return .empty }
+            do {
+                return try JSONDecoder().decode(ActionLogSection.self, from: logData)
+            } catch {
+                throw XCResultParserError.decodingFailed(
+                    step: "action-log", path: xcresultPath,
+                    detail: describeDecodingFailure(error, output: String(decoding: logData, as: UTF8.self))
+                )
+            }
         }
     }
 

--- a/server/native/xcresult_nif/Sources/XCResultParser/XCResultParser.swift
+++ b/server/native/xcresult_nif/Sources/XCResultParser/XCResultParser.swift
@@ -20,37 +20,6 @@ public enum XCResultParserError: LocalizedError, Equatable {
     }
 }
 
-/// Renders a decoding failure into a single Sentry-friendly line: the
-/// `DecodingError` kind, the JSON key path it choked on, and a short head of
-/// the offending output. The default `localizedDescription` collapses every
-/// `DecodingError` to "The data couldn't be read because it isn't in the
-/// correct format.", which tells us nothing about which xcresulttool output
-/// drifted from the schema.
-func describeDecodingFailure(_ error: Error, output: String) -> String {
-    let head = output.prefix(200).replacingOccurrences(of: "\n", with: " ")
-    let snippet = output.isEmpty ? "<empty>" : "\"\(head)\""
-
-    func path(_ context: DecodingError.Context) -> String {
-        context.codingPath.map(\.stringValue).joined(separator: ".")
-    }
-
-    let reason: String
-    switch error {
-    case let DecodingError.dataCorrupted(context):
-        reason = "dataCorrupted at [\(path(context))]: \(context.debugDescription)"
-    case let DecodingError.keyNotFound(key, context):
-        reason = "keyNotFound \(key.stringValue) at [\(path(context))]"
-    case let DecodingError.typeMismatch(type, context):
-        reason = "typeMismatch \(type) at [\(path(context))]: \(context.debugDescription)"
-    case let DecodingError.valueNotFound(type, context):
-        reason = "valueNotFound \(type) at [\(path(context))]"
-    default:
-        reason = error.localizedDescription
-    }
-
-    return "\(reason) (\(output.count) bytes: \(snippet))"
-}
-
 public struct XCResultParser: Sendable {
     private let fileSystem: FileSysteming
     private let commandRunner: CommandRunning
@@ -198,6 +167,37 @@ public struct XCResultParser: Sendable {
             return output
         }
         return String(output[jsonStartIndex ... jsonEndIndex])
+    }
+
+    /// Renders a decoding failure into a single Sentry-friendly line: the
+    /// `DecodingError` kind, the JSON key path it choked on, and a short head of
+    /// the offending output. The default `localizedDescription` collapses every
+    /// `DecodingError` to "The data couldn't be read because it isn't in the
+    /// correct format.", which tells us nothing about which xcresulttool output
+    /// drifted from the schema.
+    private func describeDecodingFailure(_ error: Error, output: String) -> String {
+        let head = output.prefix(200).replacingOccurrences(of: "\n", with: " ")
+        let snippet = output.isEmpty ? "<empty>" : "\"\(head)\""
+
+        func path(_ context: DecodingError.Context) -> String {
+            context.codingPath.map(\.stringValue).joined(separator: ".")
+        }
+
+        let reason: String
+        switch error {
+        case let DecodingError.dataCorrupted(context):
+            reason = "dataCorrupted at [\(path(context))]: \(context.debugDescription)"
+        case let DecodingError.keyNotFound(key, context):
+            reason = "keyNotFound \(key.stringValue) at [\(path(context))]"
+        case let DecodingError.typeMismatch(type, context):
+            reason = "typeMismatch \(type) at [\(path(context))]: \(context.debugDescription)"
+        case let DecodingError.valueNotFound(type, context):
+            reason = "valueNotFound \(type) at [\(path(context))]"
+        default:
+            reason = error.localizedDescription
+        }
+
+        return "\(reason) (\(output.count) bytes: \(snippet))"
     }
 
     private func parseTestOutput(

--- a/server/native/xcresult_nif/Tests/XCResultParserTests/XCResultParserTests.swift
+++ b/server/native/xcresult_nif/Tests/XCResultParserTests/XCResultParserTests.swift
@@ -30,6 +30,40 @@ private struct XCResultToolStub: CommandRunning {
     }
 }
 
+/// Routes the two xcresulttool reads `parse` performs (`get test-results
+/// tests` and `get log --type action`) to separate canned payloads, so tests
+/// can exercise an empty/absent action log independently of the test results.
+private struct RoutingXCResultToolStub: CommandRunning {
+    let testResultsJSON: String
+    let actionLogJSON: String
+
+    func run(
+        arguments: [String],
+        environment _: [String: String],
+        workingDirectory _: AbsolutePath?
+    ) -> AsyncThrowingStream<CommandEvent, any Error> {
+        let command = arguments.last ?? ""
+        let payload =
+            if command.contains("get log --type action") {
+                actionLogJSON
+            } else if command.contains("test-results tests") {
+                testResultsJSON
+            } else {
+                ""
+            }
+
+        return AsyncThrowingStream { continuation in
+            if let redirect = command.range(of: "> '") {
+                let tail = command[redirect.upperBound...]
+                if let close = tail.firstIndex(of: "'") {
+                    try? payload.write(toFile: String(tail[..<close]), atomically: true, encoding: .utf8)
+                }
+            }
+            continuation.finish()
+        }
+    }
+}
+
 struct XCResultParserTests {
     let fileSystem = FileSystem()
     let parser = XCResultParser()
@@ -78,6 +112,27 @@ struct XCResultParserTests {
             // attachments dir so its wholesale cleanup reclaims them.
             #expect(try await fileSystem.exists(attachmentsDirectory.appending(component: "xcresult-attachments")))
         }
+    }
+
+    @Test
+    func parse_treatsAnAbsentActionLogAsEmptyInsteadOfFailing() async throws {
+        // An aborted or test-less run uploads an xcresult with zero test nodes
+        // and no action log: `xcresulttool get log --type action` prints "No
+        // action log available" and writes nothing. Decoding that empty output
+        // used to throw the opaque "The data couldn't be read because it isn't
+        // in the correct format.", failing processing for the whole run. The
+        // action log is auxiliary, so its absence must not abort the parse.
+        let emptyTestResults = """
+        {"devices": [], "testNodes": [], "testPlanConfigurations": []}
+        """
+        let parser = XCResultParser(
+            commandRunner: RoutingXCResultToolStub(testResultsJSON: emptyTestResults, actionLogJSON: "")
+        )
+
+        let summary = try await parser.parse(path: try AbsolutePath(validating: "/tmp/empty.xcresult"), rootDirectory: nil)
+
+        let resolved = try #require(summary)
+        #expect(resolved.testModules.isEmpty)
     }
 
     @Test

--- a/server/test/tuist/builds/workers/process_build_worker_test.exs
+++ b/server/test/tuist/builds/workers/process_build_worker_test.exs
@@ -85,7 +85,8 @@ defmodule Tuist.Builds.Workers.ProcessBuildWorkerTest do
       project: project,
       build: build
     } do
-      expect(Tuist.Storage, :download_to_file, fn @storage_key, path, ^account ->
+      expect(Tuist.Storage, :download_to_file, fn @storage_key, path, download_account ->
+        assert download_account.id == project.account_id
         assert String.ends_with?(path, ".zip")
         {:ok, :done}
       end)
@@ -191,19 +192,17 @@ defmodule Tuist.Builds.Workers.ProcessBuildWorkerTest do
                ProcessBuildWorker.perform(oban_job(job_args(build.id, account.id, project.id), 3, 3))
     end
 
-    test "marks build as failed when account is not found on final attempt", %{
-      project: project,
+    test "marks build as failed when project is not found on final attempt", %{
+      account: account,
       build: build
     } do
-      expect(Tuist.Accounts, :get_account_by_id, fn _id -> {:error, :not_found} end)
-
       expect(Tuist.Builds, :create_build, fn attrs ->
         assert attrs.status == "failed_processing"
         {:ok, %{id: build.id}}
       end)
 
-      assert {:error, :not_found} =
-               ProcessBuildWorker.perform(oban_job(job_args(build.id, "999999", project.id), 3, 3))
+      assert {:error, :project_not_found} =
+               ProcessBuildWorker.perform(oban_job(job_args(build.id, account.id, "999999"), 3, 3))
     end
   end
 

--- a/server/test/tuist/tests/workers/process_xcresult_worker_test.exs
+++ b/server/test/tuist/tests/workers/process_xcresult_worker_test.exs
@@ -126,8 +126,7 @@ defmodule Tuist.Tests.Workers.ProcessXcresultWorkerTest do
     }
   end
 
-  defp expect_local_parse(account, parsed) do
-    expect(Tuist.Accounts, :get_account_by_id, fn _id -> {:ok, account} end)
+  defp expect_local_parse(parsed) do
     expect(Tuist.Storage, :download_to_file, fn _key, _path, _account -> {:ok, :done} end)
     expect(XCResultProcessor, :process_local, fn _path, _opts -> {:ok, parsed} end)
   end
@@ -135,7 +134,7 @@ defmodule Tuist.Tests.Workers.ProcessXcresultWorkerTest do
   describe "perform/1 success path" do
     test "downloads + parses + creates the test run", %{account: account, project: project} do
       test_run_id = Ecto.UUID.generate()
-      expect_local_parse(account, parsed_data())
+      expect_local_parse(parsed_data())
 
       expect(Tuist.Tests, :create_test, fn attrs ->
         assert attrs.id == test_run_id
@@ -168,7 +167,7 @@ defmodule Tuist.Tests.Workers.ProcessXcresultWorkerTest do
 
     test "passes failure status through unchanged", %{account: account, project: project} do
       test_run_id = Ecto.UUID.generate()
-      expect_local_parse(account, parsed_data_with_failure())
+      expect_local_parse(parsed_data_with_failure())
 
       expect(Tuist.Tests, :create_test, fn attrs ->
         assert attrs.status == "failure"
@@ -201,7 +200,7 @@ defmodule Tuist.Tests.Workers.ProcessXcresultWorkerTest do
           %{"name" => "Mac", "platform" => "macOS", "os_version" => "26.3"}
         ])
 
-      expect_local_parse(account, parsed)
+      expect_local_parse(parsed)
 
       expect(Tuist.Tests, :create_test, fn attrs ->
         assert attrs.run_destinations == [
@@ -226,7 +225,7 @@ defmodule Tuist.Tests.Workers.ProcessXcresultWorkerTest do
           %{"name" => "Mystery Box", "platform" => "linuxOS", "os_version" => "1.0"}
         ])
 
-      expect_local_parse(account, parsed)
+      expect_local_parse(parsed)
 
       expect(Tuist.Tests, :create_test, fn attrs ->
         assert [%{platform: "unknown"}] = attrs.run_destinations
@@ -242,7 +241,7 @@ defmodule Tuist.Tests.Workers.ProcessXcresultWorkerTest do
       project: project
     } do
       test_run_id = Ecto.UUID.generate()
-      expect_local_parse(account, parsed_data())
+      expect_local_parse(parsed_data())
 
       expect(Tuist.Tests, :create_test, fn attrs ->
         assert attrs.run_destinations == []
@@ -255,7 +254,7 @@ defmodule Tuist.Tests.Workers.ProcessXcresultWorkerTest do
 
     test "uses test_plan_name from parsed data as scheme", %{account: account, project: project} do
       test_run_id = Ecto.UUID.generate()
-      expect_local_parse(account, parsed_data())
+      expect_local_parse(parsed_data())
 
       expect(Tuist.Tests, :create_test, fn attrs ->
         assert attrs.scheme == "AppTests"
@@ -269,7 +268,7 @@ defmodule Tuist.Tests.Workers.ProcessXcresultWorkerTest do
     test "falls back to job args scheme when test_plan_name is nil", %{account: account, project: project} do
       test_run_id = Ecto.UUID.generate()
       parsed_without_plan_name = %{parsed_data() | "test_plan_name" => nil}
-      expect_local_parse(account, parsed_without_plan_name)
+      expect_local_parse(parsed_without_plan_name)
 
       expect(Tuist.Tests, :create_test, fn attrs ->
         assert attrs.scheme == "App"
@@ -295,7 +294,7 @@ defmodule Tuist.Tests.Workers.ProcessXcresultWorkerTest do
         "shard_index" => 2
       }
 
-      expect_local_parse(account, parsed_data())
+      expect_local_parse(parsed_data())
 
       expect(Tuist.Tests, :create_test, fn attrs ->
         assert attrs.ci_project_handle == "tuist/tuist"
@@ -314,7 +313,6 @@ defmodule Tuist.Tests.Workers.ProcessXcresultWorkerTest do
     test "returns error when the parser fails", %{account: account, project: project} do
       test_run_id = Ecto.UUID.generate()
 
-      expect(Tuist.Accounts, :get_account_by_id, fn _id -> {:ok, account} end)
       expect(Tuist.Storage, :download_to_file, fn _key, _path, _account -> {:ok, :done} end)
 
       expect(XCResultProcessor, :process_local, fn _path, _opts ->
@@ -328,8 +326,6 @@ defmodule Tuist.Tests.Workers.ProcessXcresultWorkerTest do
     test "returns error when S3 download fails", %{account: account, project: project} do
       test_run_id = Ecto.UUID.generate()
 
-      expect(Tuist.Accounts, :get_account_by_id, fn _id -> {:ok, account} end)
-
       expect(Tuist.Storage, :download_to_file, fn _key, _path, _account ->
         {:error, {:http_error, 500, "server error"}}
       end)
@@ -341,7 +337,6 @@ defmodule Tuist.Tests.Workers.ProcessXcresultWorkerTest do
     test "marks test run as failed_processing on max attempts", %{account: account, project: project} do
       test_run_id = Ecto.UUID.generate()
 
-      expect(Tuist.Accounts, :get_account_by_id, fn _id -> {:ok, account} end)
       expect(Tuist.Storage, :download_to_file, fn _key, _path, _account -> {:ok, :done} end)
 
       expect(XCResultProcessor, :process_local, fn _path, _opts ->
@@ -369,7 +364,6 @@ defmodule Tuist.Tests.Workers.ProcessXcresultWorkerTest do
         "ci_provider" => "github"
       }
 
-      expect(Tuist.Accounts, :get_account_by_id, fn _id -> {:ok, account} end)
       expect(Tuist.Storage, :download_to_file, fn _key, _path, _account -> {:ok, :done} end)
 
       expect(XCResultProcessor, :process_local, fn _path, _opts ->
@@ -389,7 +383,6 @@ defmodule Tuist.Tests.Workers.ProcessXcresultWorkerTest do
     test "does not mark as failed_processing on non-final attempt", %{account: account, project: project} do
       test_run_id = Ecto.UUID.generate()
 
-      expect(Tuist.Accounts, :get_account_by_id, fn _id -> {:ok, account} end)
       expect(Tuist.Storage, :download_to_file, fn _key, _path, _account -> {:ok, :done} end)
 
       expect(XCResultProcessor, :process_local, fn _path, _opts ->
@@ -409,7 +402,6 @@ defmodule Tuist.Tests.Workers.ProcessXcresultWorkerTest do
       } do
         test_run_id = Ecto.UUID.generate()
 
-        expect(Tuist.Accounts, :get_account_by_id, fn _id -> {:ok, account} end)
         expect(Tuist.Storage, :download_to_file, fn _key, _path, _account -> {:ok, :done} end)
         expect(XCResultProcessor, :process_local, fn _path, _opts -> {:error, unquote(reason)} end)
 
@@ -431,7 +423,7 @@ defmodule Tuist.Tests.Workers.ProcessXcresultWorkerTest do
       project: project
     } do
       test_run_id = Ecto.UUID.generate()
-      expect_local_parse(account, parsed_data())
+      expect_local_parse(parsed_data())
 
       expect(Tuist.Tests, :create_test, fn _attrs -> {:ok, %{id: test_run_id}} end)
 
@@ -463,7 +455,7 @@ defmodule Tuist.Tests.Workers.ProcessXcresultWorkerTest do
       project: project
     } do
       test_run_id = Ecto.UUID.generate()
-      expect_local_parse(account, parsed_data())
+      expect_local_parse(parsed_data())
 
       expect(Tuist.Tests, :create_test, fn _attrs -> {:ok, %{id: test_run_id}} end)
       reject(&Tuist.VCS.enqueue_vcs_pull_request_comment/1)
@@ -478,7 +470,6 @@ defmodule Tuist.Tests.Workers.ProcessXcresultWorkerTest do
     } do
       test_run_id = Ecto.UUID.generate()
 
-      expect(Tuist.Accounts, :get_account_by_id, fn _id -> {:ok, account} end)
       expect(Tuist.Storage, :download_to_file, fn _key, _path, _account -> {:ok, :done} end)
 
       expect(XCResultProcessor, :process_local, fn _path, _opts ->
@@ -509,8 +500,6 @@ defmodule Tuist.Tests.Workers.ProcessXcresultWorkerTest do
       # not race on the same temp file. Otherwise a concurrent download
       # can clobber the bundle another worker is still reading.
       test_run_id = Ecto.UUID.generate()
-
-      stub(Tuist.Accounts, :get_account_by_id, fn _id -> {:ok, account} end)
 
       paths = :ets.new(:paths, [:set, :public])
 
@@ -543,8 +532,6 @@ defmodule Tuist.Tests.Workers.ProcessXcresultWorkerTest do
 
     test "keeps the original temp path for non-sharded runs", %{account: account, project: project} do
       test_run_id = Ecto.UUID.generate()
-
-      stub(Tuist.Accounts, :get_account_by_id, fn _id -> {:ok, account} end)
 
       parent = self()
 

--- a/server/test/tuist_web/controllers/api/builds_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/builds_controller_test.exs
@@ -512,7 +512,7 @@ defmodule TuistWeb.API.BuildsControllerTest do
       assert response["id"] == build_id
     end
 
-    test "enqueues processing with the project account for organization projects", %{conn: conn} do
+    test "attributes the run to the authenticated user while keeping storage under the project account", %{conn: conn} do
       user = AccountsFixtures.user_fixture(preload: [:account])
       organization = AccountsFixtures.organization_fixture(creator: user, preload: [:account])
       project = ProjectsFixtures.project_fixture(account_id: organization.account.id)
@@ -522,7 +522,7 @@ defmodule TuistWeb.API.BuildsControllerTest do
       stub(Builds, :get_build, fn _id, _opts -> {:error, :not_found} end)
 
       stub(Builds, :create_build, fn attrs ->
-        assert attrs.account_id == organization.account.id
+        assert attrs.account_id == user.account.id
 
         {:ok,
          %Build{
@@ -550,7 +550,8 @@ defmodule TuistWeb.API.BuildsControllerTest do
         worker: ProcessBuildWorker,
         args: %{
           "build_id" => build_id,
-          "account_id" => organization.account.id,
+          "account_id" => user.account.id,
+          "project_id" => project.id,
           "storage_key" => "#{organization.account.name}/#{project.name}/builds/#{build_id}/build.zip"
         }
       )

--- a/server/test/tuist_web/controllers/api/tests_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/tests_controller_test.exs
@@ -709,7 +709,7 @@ defmodule TuistWeb.API.TestsControllerTest do
       )
     end
 
-    test "enqueues processing with the project account for organization projects", %{conn: conn} do
+    test "attributes the run to the authenticated user while keeping storage under the project account", %{conn: conn} do
       user = AccountsFixtures.user_fixture(preload: [:account])
       organization = AccountsFixtures.organization_fixture(creator: user, preload: [:account])
       project = ProjectsFixtures.project_fixture(account_id: organization.account.id)
@@ -719,7 +719,7 @@ defmodule TuistWeb.API.TestsControllerTest do
       expect(Tests, :get_test, fn _id, _opts -> {:error, :not_found} end)
 
       expect(Tests, :create_test, fn attrs ->
-        assert attrs.account_id == organization.account.id
+        assert attrs.account_id == user.account.id
 
         {:ok,
          %Test{
@@ -754,7 +754,8 @@ defmodule TuistWeb.API.TestsControllerTest do
         worker: ProcessXcresultWorker,
         args: %{
           "test_run_id" => test_run_id,
-          "account_id" => organization.account.id,
+          "account_id" => user.account.id,
+          "project_id" => project.id,
           "storage_key" => "#{organization.account.name}/#{project.name}/runs/#{test_run_id}/result_bundle.zip"
         }
       )


### PR DESCRIPTION
> Describe here the purpose of your PR.

## What

Two related fixes to build/test run processing:

1. Run attribution no longer shows the organization name in the "Ran by" badge for organization-project runs. The run's `account_id` is stamped with the authenticated user's account again, while the processing workers resolve the storage backend from the project's account.
2. xcresult processing no longer hard-fails (and Sentry-spams) when an uploaded bundle has no action log, and parse failures now carry actionable diagnostics.

## Why / root cause

### Attribution

The build/test run `account_id` column is dual-purpose: it backs the `ran_by_account` "Ran by" badge AND was being used to route the processing worker's S3 download. A prior fix (#11307 / #11381) set `account_id` to the project's account so the worker would download from an account-specific (custom S3) bucket. That fixed storage but regressed attribution: every organization-project run started showing the organization's name instead of the developer who ran it.

This PR decouples the two concerns:

- `builds_controller` / `tests_controller` `create` stamp `account_id` with `Authentication.authenticated_subject_account(conn)` (attribution), matching the existing `runs_controller` convention.
- `ProcessBuildWorker` / `ProcessXcresultWorker` resolve the storage backend from `Projects.get_project_by_id(project_id).account`. The storage key and custom S3 config are both namespaced under the project's account, so storage is intrinsically a function of the project, not of who ran the build.

This keeps the storage-routing fix from #11307 / #11381 intact while restoring correct attribution.

### xcresult processing

After the storage fix, artifacts download correctly and reach the parse stage, so the remaining "failed processing" reports are genuine xcresult parse failures in the Swift NIF. One class was reproduced end to end: an aborted or test-less run uploads an xcresult with zero test nodes and no action log. `xcresulttool get log --type action` then prints "No action log available" and writes nothing, and the parser fed that empty output into `JSONDecoder().decode(ActionLogSection)`, which throws the opaque "The data couldn't be read because it isn't in the correct format." That failed the whole run, retried five times, and alerted Sentry each time.

The action log only enriches durations and failure locations, so its absence must not abort the parse. `XCResultParser.actionLog` now returns an empty section when xcresulttool emits nothing.

A second class (`Failed to parse xcresult output`, most likely the 600s parse timeout on large bundles) could not be reproduced from logs, so this PR also improves diagnostics:

- Decode failures now report the step (test-results / action-log), the `DecodingError` kind and key path, and a short head of the offending output, instead of the schema-blind "data couldn't be read".
- The 600s NIF timeout reports a distinct "timed out after 600s" message instead of reusing `failedToParseOutput`.

## Impact

- New organization-project build/test runs attribute correctly to the developer ("Ran by <user>") while continuing to upload and process through the project account's storage backend.
- Aborted or empty xcresult bundles process to a zero-test run instead of looping on `failed_processing` and alerting Sentry.
- Future parse failures surface actionable detail in Sentry.
- Existing runs already written with the organization account are historical data and remain unchanged.

### How to test locally

Server (attribution + storage decoupling):

```
cd server
mix test test/tuist/builds/workers/process_build_worker_test.exs \
         test/tuist/tests/workers/process_xcresult_worker_test.exs \
         test/tuist_web/controllers/api/builds_controller_test.exs \
         test/tuist_web/controllers/api/tests_controller_test.exs
```

35 worker + 46 controller tests pass. The controller suite needs hosted mode if your local test license is stale: `TUIST_HOSTED=1 mix test ...`.

xcresult NIF (action-log resilience + diagnostics):

```
cd server/native/xcresult_nif && rm -rf .build && swift test --replace-scm-with-registry --filter XCResultParserTests
```

9 tests pass, including a new regression test that routes the two xcresulttool reads to an empty test-results payload and an empty action log and asserts the parse succeeds.
