### PR TITLE
fix(server): sort module cache destinations for stable dashboard ordering

### DIFF
--- a/server/lib/tuist_web/components/runs/module_cache_tab.ex
+++ b/server/lib/tuist_web/components/runs/module_cache_tab.ex
@@ -245,6 +245,7 @@ defmodule TuistWeb.Runs.ModuleCacheTab do
         </span>
         <span data-part="subhash-value">
           {@target.destinations
+          |> Enum.sort()
           |> Enum.map(&Xcode.humanize_xcode_target_destination/1)
           |> Enum.join(", ")}
         </span>
@@ -503,7 +504,7 @@ defmodule TuistWeb.Runs.ModuleCacheTab do
       project_settings_hash: target.project_settings_hash,
       target_settings_hash: target.target_settings_hash,
       buildable_folders_hash: target.buildable_folders_hash,
-      destinations: target.destinations,
+      destinations: Enum.sort(target.destinations || []),
       additional_strings: target.additional_strings
     }
     |> Enum.reject(fn {_k, v} -> empty_value?(v) end)

--- a/server/priv/gettext/dashboard_builds.pot
+++ b/server/priv/gettext/dashboard_builds.pot
@@ -33,7 +33,7 @@ msgstr ""
 msgid "%{run_duration}s"
 msgstr ""
 
-#: lib/tuist_web/components/runs/module_cache_tab.ex:338
+#: lib/tuist_web/components/runs/module_cache_tab.ex:339
 #, elixir-autogen, elixir-format
 msgid "Additional strings"
 msgstr ""
@@ -127,7 +127,7 @@ msgstr ""
 msgid "Build:"
 msgstr ""
 
-#: lib/tuist_web/components/runs/module_cache_tab.ex:332
+#: lib/tuist_web/components/runs/module_cache_tab.ex:333
 #, elixir-autogen, elixir-format
 msgid "Buildable folders"
 msgstr ""
@@ -236,7 +236,7 @@ msgstr ""
 msgid "Cacheable Tasks"
 msgstr ""
 
-#: lib/tuist_web/components/runs/module_cache_tab.ex:395
+#: lib/tuist_web/components/runs/module_cache_tab.ex:396
 #, elixir-autogen, elixir-format
 msgid "Cacheable targets"
 msgstr ""
@@ -353,22 +353,22 @@ msgstr ""
 msgid "Copy as JSON"
 msgstr ""
 
-#: lib/tuist_web/components/runs/module_cache_tab.ex:268
+#: lib/tuist_web/components/runs/module_cache_tab.ex:269
 #, elixir-autogen, elixir-format
 msgid "Copy files"
 msgstr ""
 
-#: lib/tuist_web/components/runs/module_cache_tab.ex:274
+#: lib/tuist_web/components/runs/module_cache_tab.ex:275
 #, elixir-autogen, elixir-format
 msgid "Core data models"
 msgstr ""
 
-#: lib/tuist_web/components/runs/module_cache_tab.ex:314
+#: lib/tuist_web/components/runs/module_cache_tab.ex:315
 #, elixir-autogen, elixir-format
 msgid "Dependencies"
 msgstr ""
 
-#: lib/tuist_web/components/runs/module_cache_tab.ex:296
+#: lib/tuist_web/components/runs/module_cache_tab.ex:297
 #, elixir-autogen, elixir-format
 msgid "Deployment target"
 msgstr ""
@@ -414,12 +414,12 @@ msgstr ""
 msgid "Duration"
 msgstr ""
 
-#: lib/tuist_web/components/runs/module_cache_tab.ex:308
+#: lib/tuist_web/components/runs/module_cache_tab.ex:309
 #, elixir-autogen, elixir-format
 msgid "Entitlements"
 msgstr ""
 
-#: lib/tuist_web/components/runs/module_cache_tab.ex:286
+#: lib/tuist_web/components/runs/module_cache_tab.ex:287
 #: lib/tuist_web/live/xcode_builds_live.ex:434
 #: lib/tuist_web/live/xcode_builds_live.html.heex:356
 #, elixir-autogen, elixir-format
@@ -444,7 +444,7 @@ msgstr ""
 msgid "Errors and Warnings"
 msgstr ""
 
-#: lib/tuist_web/components/runs/module_cache_tab.ex:253
+#: lib/tuist_web/components/runs/module_cache_tab.ex:254
 #, elixir-autogen, elixir-format
 msgid "External"
 msgstr ""
@@ -591,7 +591,7 @@ msgstr ""
 msgid "Hash"
 msgstr ""
 
-#: lib/tuist_web/components/runs/module_cache_tab.ex:291
+#: lib/tuist_web/components/runs/module_cache_tab.ex:292
 #, elixir-autogen, elixir-format
 msgid "Headers"
 msgstr ""
@@ -620,7 +620,7 @@ msgstr ""
 msgid "Incremental"
 msgstr ""
 
-#: lib/tuist_web/components/runs/module_cache_tab.ex:302
+#: lib/tuist_web/components/runs/module_cache_tab.ex:303
 #, elixir-autogen, elixir-format
 msgid "Info.plist"
 msgstr ""
@@ -634,7 +634,7 @@ msgid "Key"
 msgstr ""
 
 #: lib/tuist_web/components/runs/module_cache_tab.ex:177
-#: lib/tuist_web/components/runs/module_cache_tab.ex:410
+#: lib/tuist_web/components/runs/module_cache_tab.ex:411
 #: lib/tuist_web/live/build_run_live.ex:1087
 #: lib/tuist_web/live/build_run_live.ex:1331
 #: lib/tuist_web/live/build_run_live.html.heex:983
@@ -661,7 +661,7 @@ msgid "Mac device"
 msgstr ""
 
 #: lib/tuist_web/components/runs/module_cache_tab.ex:183
-#: lib/tuist_web/components/runs/module_cache_tab.ex:436
+#: lib/tuist_web/components/runs/module_cache_tab.ex:437
 #: lib/tuist_web/live/build_run_live.ex:1089
 #: lib/tuist_web/live/build_run_live.ex:1332
 #: lib/tuist_web/live/build_run_live.html.heex:1011
@@ -796,7 +796,7 @@ msgstr ""
 msgid "Project"
 msgstr ""
 
-#: lib/tuist_web/components/runs/module_cache_tab.ex:320
+#: lib/tuist_web/components/runs/module_cache_tab.ex:321
 #, elixir-autogen, elixir-format
 msgid "Project settings"
 msgstr ""
@@ -829,7 +829,7 @@ msgid "Recent Builds"
 msgstr ""
 
 #: lib/tuist_web/components/runs/module_cache_tab.ex:171
-#: lib/tuist_web/components/runs/module_cache_tab.ex:423
+#: lib/tuist_web/components/runs/module_cache_tab.ex:424
 #: lib/tuist_web/live/build_run_live.ex:1088
 #: lib/tuist_web/live/build_run_live.ex:1330
 #: lib/tuist_web/live/build_run_live.html.heex:997
@@ -841,7 +841,7 @@ msgstr ""
 msgid "Remote"
 msgstr ""
 
-#: lib/tuist_web/components/runs/module_cache_tab.ex:262
+#: lib/tuist_web/components/runs/module_cache_tab.ex:263
 #, elixir-autogen, elixir-format
 msgid "Resources"
 msgstr ""
@@ -912,7 +912,7 @@ msgstr ""
 msgid "Source"
 msgstr ""
 
-#: lib/tuist_web/components/runs/module_cache_tab.ex:257
+#: lib/tuist_web/components/runs/module_cache_tab.ex:258
 #, elixir-autogen, elixir-format
 msgid "Sources"
 msgstr ""
@@ -950,12 +950,12 @@ msgstr ""
 msgid "Target"
 msgstr ""
 
-#: lib/tuist_web/components/runs/module_cache_tab.ex:280
+#: lib/tuist_web/components/runs/module_cache_tab.ex:281
 #, elixir-autogen, elixir-format
 msgid "Target scripts"
 msgstr ""
 
-#: lib/tuist_web/components/runs/module_cache_tab.ex:326
+#: lib/tuist_web/components/runs/module_cache_tab.ex:327
 #, elixir-autogen, elixir-format
 msgid "Target settings"
 msgstr ""

--- a/server/test/tuist_web/live/module_cache_live_test.exs
+++ b/server/test/tuist_web/live/module_cache_live_test.exs
@@ -7,6 +7,7 @@ defmodule TuistWeb.ModuleCacheLiveTest do
   import Phoenix.LiveViewTest
 
   alias TuistTestSupport.Fixtures.CommandEventsFixtures
+  alias TuistWeb.Runs.ModuleCacheTab
 
   describe "module cache page" do
     test "displays analytics widgets", %{
@@ -33,5 +34,52 @@ defmodule TuistWeb.ModuleCacheLiveTest do
       assert has_element?(lv, "#widget-cache-hits")
       assert has_element?(lv, "#widget-cache-misses")
     end
+  end
+
+  describe "subhashes_list/1" do
+    test "renders destinations in a deterministic sorted order regardless of input order" do
+      # Given
+      target_a = target_fixture(destinations: ["mac_with_ipad_design", "iphone", "ipad"])
+      target_b = target_fixture(destinations: ["ipad", "mac_with_ipad_design", "iphone"])
+
+      # When
+      html_a = render_component(&ModuleCacheTab.subhashes_list/1, target: target_a)
+      html_b = render_component(&ModuleCacheTab.subhashes_list/1, target: target_b)
+
+      # Then
+      assert html_a =~ "iPad, iPhone, Mac with iPad design"
+      assert html_a == html_b
+    end
+  end
+
+  defp target_fixture(attrs) do
+    Map.merge(
+      %{
+        name: "AnalyticsSharedTypes",
+        binary_cache_hit: 0,
+        binary_cache_hash: "hash",
+        product: "",
+        product_name: "",
+        bundle_id: "",
+        external_hash: "",
+        sources_hash: "",
+        resources_hash: "",
+        copy_files_hash: "",
+        core_data_models_hash: "",
+        target_scripts_hash: "",
+        environment_hash: "",
+        headers_hash: "",
+        deployment_target_hash: "",
+        info_plist_hash: "",
+        entitlements_hash: "",
+        dependencies_hash: "",
+        project_settings_hash: "",
+        target_settings_hash: "",
+        buildable_folders_hash: "",
+        destinations: [],
+        additional_strings: []
+      },
+      Map.new(attrs)
+    )
   end
 end


### PR DESCRIPTION
### What changed

The Module Cache view in a build/test run dashboard now renders each target's `Destinations` in a deterministic, sorted order. Both the visible `Destinations` row and the "Copy as JSON" export sort the destinations by their raw value before display.

### Why

Destinations are stored as an unordered ClickHouse `Array(LowCardinality(String))`, so the dashboard previously showed them in whatever order the CLI happened to send. The same module then appeared with a different ordering across builds, e.g.:

- `iPad, iPhone, Mac with iPad design`
- `Mac with iPad design, iPhone, iPad`

This reads as if the target changed between builds when it did not, which is confusing for users investigating cache misses.

### Important: this is cosmetic only

The cache key is unaffected. The CLI already sorts destinations before hashing (`TargetContentHasher` does `.map(\.rawValue).sorted()`), which is why the module hash stays identical across builds regardless of display order. So this change does not alter anyone's cache hit/miss outcome; it only makes the displayed order stable and consistent.

Sorting by the raw enum value (`ipad` < `iphone` < `mac_with_ipad_design`) keeps the display aligned with the CLI's canonical hash order. The JSON export is sorted too, so the visible list and the copied JSON never disagree.

### Validation

Added a `subhashes_list/1` component test that renders the same destination set in two different input orders and asserts the output is identical and sorted (`iPad, iPhone, Mac with iPad design`).

```
mix test test/tuist_web/live/module_cache_live_test.exs
# 2 tests, 0 failures
```

### How to test locally

1. Open a build run's Module Cache tab for a target that has multiple destinations.
2. Confirm the `Destinations` row is shown in a stable, sorted order and matches across different builds of the same module.
3. Use "Copy as JSON" and confirm the `destinations` array is sorted the same way.
