### PR TITLE
fix(server): preserve docs code snippet spacing

### DIFF
--- a/server/assets/shared/css/code-window.css
+++ b/server/assets/shared/css/code-window.css
@@ -100,12 +100,16 @@ html[data-theme="dark"] .code-window {
 .code-window > [data-part="code"] pre {
   margin: 0;
   background: none !important;
+  font: inherit;
+  white-space: pre;
 }
 
 .code-window > [data-part="code"] code {
   display: block;
   background: none;
   color: inherit;
+  font: inherit;
+  white-space: pre;
 }
 
 .code-window > [data-part="code"] code .line {

--- a/server/lib/tuist/docs/html.ex
+++ b/server/lib/tuist/docs/html.ex
@@ -5,9 +5,13 @@ defmodule Tuist.Docs.HTML do
 
   @noora_icons_path Path.expand("../noora/lib/noora/icons", File.cwd!())
   @copy_icon @noora_icons_path |> Path.join("copy.svg") |> File.read!() |> String.trim()
-  @copy_check_icon @noora_icons_path |> Path.join("copy-check.svg") |> File.read!() |> String.trim()
+  @copy_check_icon @noora_icons_path
+                   |> Path.join("copy-check.svg")
+                   |> File.read!()
+                   |> String.trim()
 
   @code_block_regex ~r/<pre[^>]*><code(?:[^>]*class="language-(\w+)")?[^>]*>(.*?)<\/code><\/pre>/s
+  @code_window_content_regex ~r/(<div data-part="code"><code>)(.*?)(<\/code>\s*<\/div>)/s
   @heading_anchor_regex ~r/(<h[2-4]>)(<a href="#[^"]*" aria-hidden="true" class="anchor" id="[^"]*"><\/a>)(.*?)(<\/h[2-4]>)/s
 
   @code_block_template """
@@ -42,6 +46,7 @@ defmodule Tuist.Docs.HTML do
   end
 
   def wrap_tables(html) do
+    {html, code_contents} = protect_code_contents(html)
     {html, component_tags} = protect_component_tags(html)
 
     {html, _table_index} =
@@ -52,6 +57,7 @@ defmodule Tuist.Docs.HTML do
     html
     |> Floki.raw_html()
     |> restore_component_tags(component_tags)
+    |> restore_protected_blocks(code_contents)
   end
 
   def add_heading_anchors(html) do
@@ -72,6 +78,40 @@ defmodule Tuist.Docs.HTML do
 
   defp strip_links(html) do
     Regex.replace(~r/<a[^>]*>(.*?)<\/a>/s, html, "\\1")
+  end
+
+  defp protect_code_contents(html) do
+    {html, code_contents} = do_protect_code_contents(html, 0, [])
+
+    {IO.iodata_to_binary(html), code_contents}
+  end
+
+  defp do_protect_code_contents("", _index, code_contents), do: {[], code_contents}
+
+  defp do_protect_code_contents(html, index, code_contents) do
+    case Regex.run(@code_window_content_regex, html, return: :index) do
+      nil ->
+        {[html], code_contents}
+
+      [
+        {full_start, full_length},
+        {open_start, open_length},
+        {content_start, content_length},
+        {close_start, close_length}
+      ] ->
+        before = binary_part(html, 0, full_start)
+        open_tag = binary_part(html, open_start, open_length)
+        code_content = binary_part(html, content_start, content_length)
+        close_tag = binary_part(html, close_start, close_length)
+        rest_start = full_start + full_length
+        rest = binary_part(html, rest_start, byte_size(html) - rest_start)
+        placeholder = "__TUIST_DOCS_HTML_CODE_CONTENT_#{index}__"
+
+        {rest, code_contents} =
+          do_protect_code_contents(rest, index + 1, [{placeholder, code_content} | code_contents])
+
+        {[before, open_tag, placeholder, close_tag | rest], code_contents}
+    end
   end
 
   # Floki normalizes custom component tag names, so keep those exact tags as
@@ -99,11 +139,15 @@ defmodule Tuist.Docs.HTML do
 
           end_index ->
             tag = binary_part(tag_and_rest, 0, end_index + 1)
-            rest = binary_part(tag_and_rest, end_index + 1, byte_size(tag_and_rest) - end_index - 1)
+
+            rest =
+              binary_part(tag_and_rest, end_index + 1, byte_size(tag_and_rest) - end_index - 1)
 
             if component_tag?(tag) do
               placeholder = "__TUIST_DOCS_HTML_COMPONENT_TAG_#{index}__"
-              {rest, component_tags} = do_protect_component_tags(rest, index + 1, [{placeholder, tag} | component_tags])
+
+              {rest, component_tags} =
+                do_protect_component_tags(rest, index + 1, [{placeholder, tag} | component_tags])
 
               {[before_tag, placeholder | rest], component_tags}
             else
@@ -144,14 +188,23 @@ defmodule Tuist.Docs.HTML do
   end
 
   defp restore_component_tags(html, component_tags) do
-    Enum.reduce(component_tags, html, fn {placeholder, tag}, html ->
-      String.replace(html, placeholder, tag)
+    restore_protected_blocks(html, component_tags)
+  end
+
+  defp restore_protected_blocks(html, blocks) do
+    Enum.reduce(blocks, html, fn {placeholder, block}, html ->
+      String.replace(html, placeholder, block)
     end)
   end
 
   defp wrap_table_node({"table", attrs, children}, table_index) do
     {
-      {"div", [{"id", "docs-markdown-table-#{table_index}"}, {"class", "noora-table"}, {"phx-hook", "NooraTable"}],
+      {"div",
+       [
+         {"id", "docs-markdown-table-#{table_index}"},
+         {"class", "noora-table"},
+         {"phx-hook", "NooraTable"}
+       ],
        [
          {"div", [{"data-part", "scroll-container"}],
           [

--- a/server/test/tuist/docs/html_test.exs
+++ b/server/test/tuist/docs/html_test.exs
@@ -17,9 +17,14 @@ defmodule Tuist.Docs.HTMLTest do
 
       assert wrapped =~ ~s(<Noora.Alert.alert status="warning" title="1 > 0">)
       assert wrapped =~ ~s(<.localized_link href="/guides/install-tuist">)
-      assert wrapped =~ ~s(<div id="docs-markdown-table-0" class="noora-table" phx-hook="NooraTable">)
+
+      assert wrapped =~
+               ~s(<div id="docs-markdown-table-0" class="noora-table" phx-hook="NooraTable">)
+
       assert wrapped =~ ~s(<div data-part="scroll-container"><table>)
-      assert wrapped =~ ~s(<div data-part="scrollbar" aria-hidden="true"><div data-part="scrollbar-content"></div></div>)
+
+      assert wrapped =~
+               ~s(<div data-part="scrollbar" aria-hidden="true"><div data-part="scrollbar-content"></div></div>)
 
       assert wrapped =~
                ~s(<div data-part="overlay-scrollbar" aria-hidden="true"><div data-part="overlay-thumb"></div></div>)
@@ -38,9 +43,34 @@ defmodule Tuist.Docs.HTMLTest do
       wrapped = HTML.wrap_tables(html)
 
       assert wrapped =~ ~s(<Noora.Alert.alert status="warning">)
-      assert wrapped =~ ~s(<div id="docs-markdown-table-0" class="noora-table" phx-hook="NooraTable">)
+
+      assert wrapped =~
+               ~s(<div id="docs-markdown-table-0" class="noora-table" phx-hook="NooraTable">)
+
       assert wrapped =~ ~s(<div data-part="scroll-container"><table>)
       assert wrapped =~ ~s(</Noora.Alert.alert>)
+    end
+
+    test "wraps table nodes without mutating code window contents" do
+      code_window = """
+      <div class="code-window"><div data-part="bar"><div data-part="language">swift</div><div data-part="copy"></div></div><div data-part="code"><code><span style="color:#CF222E">let</span> target <span style="color:#0550AE">=</span> <span style="color:#8250DF">Target</span>(
+        name: <span style="color:#0A3069">&quot;App&quot;</span>
+      )</code></div></div>
+      """
+
+      html = """
+      #{code_window}
+      <table><tbody><tr><td>Value</td></tr></tbody></table>
+      """
+
+      wrapped = HTML.wrap_tables(html)
+
+      assert wrapped =~ String.trim(code_window)
+
+      assert wrapped =~
+               ~s(<div id="docs-markdown-table-0" class="noora-table" phx-hook="NooraTable">)
+
+      assert wrapped =~ ~s(<div data-part="scroll-container"><table>)
     end
   end
 end


### PR DESCRIPTION
## What changed

- Kept code-window `pre` and `code` elements inheriting the code font and preserving whitespace.
- Protected only the generated code-window `<code>` contents before Floki wraps tables, then restored those contents afterward.
- Added a regression test covering table wrapping next to code windows.

## Visual check

After: code snippets keep the spaces between `let`, `target`, `=`, and `Target(...)`.

![After: code snippet spacing preserved](https://github.com/user-attachments/assets/3ef060bc-c5d4-4350-80ca-29a46b333d36)

Before: syntax-highlighted spans were serialized without whitespace between adjacent tokens, so examples rendered as glued text like `lettarget=Target(`.

![Before: code snippet spacing collapsed](https://github.com/user-attachments/assets/6a744c1c-454b-4584-9edf-5c0c86623e20)

## Why

Docs snippets lost spaces between highlighted tokens, making commands and Swift examples hard to read. This affected the Projects best practices page and any page with code windows processed by the table wrapper.

## Root cause

The table wrapper parses rendered docs through Floki so it can wrap markdown tables. When code window contents passed through the same parser, whitespace-only text around syntax-highlighted spans could be normalized away.

## Approach

Keep the table wrapping behavior, but replace code-window contents with temporary placeholders before Floki sees the markup. After tables are wrapped, restore the original code contents exactly. This avoids parsing nested code-window markup by hand and keeps the fix scoped to the text that needs verbatim preservation.

## Impact

Docs code snippets keep their original spacing, including tabbed examples and single code blocks. Table wrapping behavior is unchanged.

## Validation

- `git diff --check`
- `elixir -e 'for path <- ["server/lib/tuist/docs/html.ex", "server/test/tuist/docs/html_test.exs"] do formatted = path |> Code.format_file!() |> IO.iodata_to_binary(); File.write!(path, formatted) end'`
- `MIX_ENV=test mix run --no-start -e 'ExUnit.start(); Code.require_file("test/tuist/docs/html_test.exs"); result = ExUnit.run(); if result.failures > 0, do: System.halt(1)'`, which reported `3 tests, 0 failures`.
