### PR TITLE
fix(server): normalize "does not contain" filter operator on build-runs dashboard

### DIFF
--- a/server/lib/tuist_web/live/gradle_build_runs_live.ex
+++ b/server/lib/tuist_web/live/gradle_build_runs_live.ex
@@ -110,7 +110,11 @@ defmodule TuistWeb.GradleBuildRunsLive do
     {ran_by_filters, remaining_filters} = Enum.split_with(filters, &(&1.id == "ran_by"))
     {is_ci_filters, remaining_filters} = Enum.split_with(remaining_filters, &(&1.id == "is_ci"))
     {requested_tasks_filters, remaining_filters} = Enum.split_with(remaining_filters, &(&1.id == "requested_tasks"))
-    filter_flop_filters = Filter.Operations.convert_filters_to_flop(remaining_filters)
+
+    filter_flop_filters =
+      remaining_filters
+      |> Enum.map(&normalize_text_filter_operator/1)
+      |> Filter.Operations.convert_filters_to_flop()
 
     ran_by_flop_filters =
       Enum.flat_map(ran_by_filters, fn
@@ -181,6 +185,10 @@ defmodule TuistWeb.GradleBuildRunsLive do
     |> assign(:build_runs_page, meta.current_page)
     |> assign(:build_runs_page_count, meta.total_pages)
   end
+
+  defp normalize_text_filter_operator(%Filter.Filter{operator: :"!=~"} = filter), do: %{filter | operator: :not_ilike}
+
+  defp normalize_text_filter_operator(filter), do: filter
 
   def column_patch_sort(
         %{uri: uri, build_runs_sort_by: build_runs_sort_by, build_runs_sort_order: build_runs_sort_order},

--- a/server/lib/tuist_web/live/xcode_build_runs_live.ex
+++ b/server/lib/tuist_web/live/xcode_build_runs_live.ex
@@ -167,7 +167,11 @@ defmodule TuistWeb.XcodeBuildRunsLive do
   defp build_flop_filters(filters) do
     {ran_by, filters} = Enum.split_with(filters, &(&1.id == "ran_by"))
     {tags_filters, filters} = Enum.split_with(filters, &(&1.id == "custom_tags"))
-    flop_filters = Filter.Operations.convert_filters_to_flop(filters)
+
+    flop_filters =
+      filters
+      |> Enum.map(&normalize_text_filter_operator/1)
+      |> Filter.Operations.convert_filters_to_flop()
 
     ran_by_flop_filters =
       Enum.flat_map(ran_by, fn
@@ -193,6 +197,10 @@ defmodule TuistWeb.XcodeBuildRunsLive do
 
     flop_filters ++ ran_by_flop_filters ++ tag_flop_filters
   end
+
+  defp normalize_text_filter_operator(%Filter.Filter{operator: :"!=~"} = filter), do: %{filter | operator: :not_ilike}
+
+  defp normalize_text_filter_operator(filter), do: filter
 
   defp define_filters(project, schemes, configurations, tags) do
     base = [

--- a/server/priv/gettext/dashboard_builds.pot
+++ b/server/priv/gettext/dashboard_builds.pot
@@ -71,7 +71,7 @@ msgstr ""
 
 #: lib/tuist_web/live/generate_runs_live.ex:287
 #: lib/tuist_web/live/generate_runs_live.html.heex:84
-#: lib/tuist_web/live/xcode_build_runs_live.ex:238
+#: lib/tuist_web/live/xcode_build_runs_live.ex:246
 #: lib/tuist_web/live/xcode_build_runs_live.html.heex:121
 #, elixir-autogen, elixir-format
 msgid "Branch"
@@ -272,7 +272,7 @@ msgid "Cacheable tasks:"
 msgstr ""
 
 #: lib/tuist_web/live/build_run_live.html.heex:286
-#: lib/tuist_web/live/xcode_build_runs_live.ex:246
+#: lib/tuist_web/live/xcode_build_runs_live.ex:254
 #: lib/tuist_web/live/xcode_build_runs_live.html.heex:151
 #: lib/tuist_web/live/xcode_builds_live.ex:435
 #: lib/tuist_web/live/xcode_builds_live.html.heex:357
@@ -281,7 +281,7 @@ msgstr ""
 msgid "Category"
 msgstr ""
 
-#: lib/tuist_web/live/xcode_build_runs_live.ex:251
+#: lib/tuist_web/live/xcode_build_runs_live.ex:259
 #: lib/tuist_web/live/xcode_builds_live.html.heex:105
 #, elixir-autogen, elixir-format
 msgid "Clean"
@@ -327,7 +327,7 @@ msgid "Compressed Size (MB)"
 msgstr ""
 
 #: lib/tuist_web/live/build_run_live.html.heex:224
-#: lib/tuist_web/live/xcode_build_runs_live.ex:213
+#: lib/tuist_web/live/xcode_build_runs_live.ex:221
 #: lib/tuist_web/live/xcode_build_runs_live.html.heex:91
 #, elixir-autogen, elixir-format
 msgid "Configuration"
@@ -455,7 +455,7 @@ msgstr ""
 #: lib/tuist_web/live/generate_runs_live.ex:279
 #: lib/tuist_web/live/generate_runs_live.html.heex:81
 #: lib/tuist_web/live/run_detail_live.html.heex:144
-#: lib/tuist_web/live/xcode_build_runs_live.ex:228
+#: lib/tuist_web/live/xcode_build_runs_live.ex:236
 #: lib/tuist_web/live/xcode_build_runs_live.html.heex:107
 #: lib/tuist_web/live/xcode_builds_live.ex:446
 #: lib/tuist_web/live/xcode_builds_live.html.heex:864
@@ -614,7 +614,7 @@ msgstr ""
 msgid "Hit rate"
 msgstr ""
 
-#: lib/tuist_web/live/xcode_build_runs_live.ex:250
+#: lib/tuist_web/live/xcode_build_runs_live.ex:258
 #: lib/tuist_web/live/xcode_builds_live.html.heex:97
 #, elixir-autogen, elixir-format
 msgid "Incremental"
@@ -766,7 +766,7 @@ msgstr ""
 #: lib/tuist_web/live/generate_runs_live.ex:278
 #: lib/tuist_web/live/generate_runs_live.html.heex:79
 #: lib/tuist_web/live/run_detail_live.html.heex:137
-#: lib/tuist_web/live/xcode_build_runs_live.ex:227
+#: lib/tuist_web/live/xcode_build_runs_live.ex:235
 #: lib/tuist_web/live/xcode_build_runs_live.html.heex:102
 #: lib/tuist_web/live/xcode_builds_live.ex:445
 #: lib/tuist_web/live/xcode_builds_live.html.heex:859
@@ -816,7 +816,7 @@ msgstr ""
 #: lib/tuist_web/live/generate_runs_live.ex:322
 #: lib/tuist_web/live/generate_runs_live.html.heex:87
 #: lib/tuist_web/live/run_detail_live.html.heex:152
-#: lib/tuist_web/live/xcode_build_runs_live.ex:306
+#: lib/tuist_web/live/xcode_build_runs_live.ex:314
 #: lib/tuist_web/live/xcode_build_runs_live.html.heex:130
 #: lib/tuist_web/live/xcode_builds_live.html.heex:876
 #, elixir-autogen, elixir-format
@@ -856,7 +856,7 @@ msgstr ""
 msgid "Run duration"
 msgstr ""
 
-#: lib/tuist_web/live/xcode_build_runs_live.ex:202
+#: lib/tuist_web/live/xcode_build_runs_live.ex:210
 #: lib/tuist_web/live/xcode_build_runs_live.html.heex:58
 #: lib/tuist_web/live/xcode_builds_live.ex:432
 #: lib/tuist_web/live/xcode_builds_live.html.heex:355
@@ -923,7 +923,7 @@ msgstr ""
 #: lib/tuist_web/live/build_run_live.html.heex:1527
 #: lib/tuist_web/live/generate_runs_live.ex:274
 #: lib/tuist_web/live/run_detail_live.html.heex:134
-#: lib/tuist_web/live/xcode_build_runs_live.ex:223
+#: lib/tuist_web/live/xcode_build_runs_live.ex:231
 #: lib/tuist_web/live/xcode_builds_live.ex:433
 #, elixir-autogen, elixir-format
 msgid "Status"
@@ -1235,7 +1235,7 @@ msgid "Xcode Cache"
 msgstr ""
 
 #: lib/tuist_web/live/build_run_live.html.heex:308
-#: lib/tuist_web/live/xcode_build_runs_live.ex:259
+#: lib/tuist_web/live/xcode_build_runs_live.ex:267
 #: lib/tuist_web/live/xcode_build_runs_live.html.heex:171
 #: lib/tuist_web/live/xcode_builds_live.ex:388
 #: lib/tuist_web/live/xcode_builds_live.html.heex:621
@@ -1246,7 +1246,7 @@ msgstr ""
 
 #: lib/tuist_web/live/build_run_live.html.heex:314
 #: lib/tuist_web/live/run_detail_live.html.heex:202
-#: lib/tuist_web/live/xcode_build_runs_live.ex:267
+#: lib/tuist_web/live/xcode_build_runs_live.ex:275
 #: lib/tuist_web/live/xcode_build_runs_live.html.heex:179
 #: lib/tuist_web/live/xcode_builds_live.ex:389
 #: lib/tuist_web/live/xcode_builds_live.html.heex:639
@@ -1409,7 +1409,7 @@ msgstr ""
 msgid "Tag:"
 msgstr ""
 
-#: lib/tuist_web/live/xcode_build_runs_live.ex:282
+#: lib/tuist_web/live/xcode_build_runs_live.ex:290
 #, elixir-autogen, elixir-format
 msgid "Tags"
 msgstr ""
@@ -1431,14 +1431,14 @@ msgid "Download build"
 msgstr ""
 
 #: lib/tuist_web/live/build_run_live.html.heex:252
-#: lib/tuist_web/live/xcode_build_runs_live.ex:230
+#: lib/tuist_web/live/xcode_build_runs_live.ex:238
 #: lib/tuist_web/live/xcode_build_runs_live.html.heex:117
 #, elixir-autogen, elixir-format
 msgid "Failed processing"
 msgstr ""
 
 #: lib/tuist_web/live/build_run_live.html.heex:258
-#: lib/tuist_web/live/xcode_build_runs_live.ex:229
+#: lib/tuist_web/live/xcode_build_runs_live.ex:237
 #: lib/tuist_web/live/xcode_build_runs_live.html.heex:112
 #, elixir-autogen, elixir-format
 msgid "Processing"

--- a/server/priv/gettext/dashboard_gradle.pot
+++ b/server/priv/gettext/dashboard_gradle.pot
@@ -62,7 +62,7 @@ msgid "Avg. cache hit rate"
 msgstr ""
 
 #: lib/tuist_web/live/gradle_build_live.html.heex:134
-#: lib/tuist_web/live/gradle_build_runs_live.ex:225
+#: lib/tuist_web/live/gradle_build_runs_live.ex:233
 #: lib/tuist_web/live/gradle_build_runs_live.html.heex:89
 #, elixir-autogen, elixir-format
 msgid "Branch"
@@ -79,7 +79,7 @@ msgstr ""
 msgid "Build not found."
 msgstr ""
 
-#: lib/tuist_web/live/gradle_build_runs_live.ex:245
+#: lib/tuist_web/live/gradle_build_runs_live.ex:253
 #: lib/tuist_web/live/gradle_builds_live.ex:177
 #: lib/tuist_web/live/gradle_builds_live.html.heex:26
 #: lib/tuist_web/live/gradle_cache_live.ex:208
@@ -158,7 +158,7 @@ msgid "Cancel"
 msgstr ""
 
 #: lib/tuist_web/live/gradle_build_live.html.heex:100
-#: lib/tuist_web/live/gradle_build_runs_live.ex:217
+#: lib/tuist_web/live/gradle_build_runs_live.ex:225
 #: lib/tuist_web/live/gradle_build_runs_live.html.heex:85
 #: lib/tuist_web/live/gradle_builds_live.html.heex:682
 #, elixir-autogen, elixir-format
@@ -202,7 +202,7 @@ msgstr ""
 
 #: lib/tuist_web/live/gradle_build_live.ex:246
 #: lib/tuist_web/live/gradle_build_live.ex:329
-#: lib/tuist_web/live/gradle_build_runs_live.ex:216
+#: lib/tuist_web/live/gradle_build_runs_live.ex:224
 #: lib/tuist_web/live/gradle_build_runs_live.html.heex:80
 #: lib/tuist_web/live/gradle_builds_live.html.heex:677
 #, elixir-autogen, elixir-format
@@ -358,7 +358,7 @@ msgstr ""
 #: lib/tuist_web/live/gradle_build_live.ex:282
 #: lib/tuist_web/live/gradle_build_live.html.heex:83
 #: lib/tuist_web/live/gradle_build_live.html.heex:593
-#: lib/tuist_web/live/gradle_build_runs_live.ex:211
+#: lib/tuist_web/live/gradle_build_runs_live.ex:219
 #: lib/tuist_web/live/gradle_build_runs_live.html.heex:72
 #, elixir-autogen, elixir-format
 msgid "Status"
@@ -481,7 +481,7 @@ msgstr ""
 #: lib/tuist_web/live/gradle_build_live.ex:286
 #: lib/tuist_web/live/gradle_build_live.html.heex:439
 #: lib/tuist_web/live/gradle_build_live.html.heex:596
-#: lib/tuist_web/live/gradle_build_runs_live.ex:246
+#: lib/tuist_web/live/gradle_build_runs_live.ex:254
 #: lib/tuist_web/live/gradle_builds_live.ex:176
 #: lib/tuist_web/live/gradle_builds_live.html.heex:18
 #: lib/tuist_web/live/gradle_cache_live.ex:207
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Configuration Insights"
 msgstr ""
 
-#: lib/tuist_web/live/gradle_build_runs_live.ex:241
+#: lib/tuist_web/live/gradle_build_runs_live.ex:249
 #: lib/tuist_web/live/gradle_cache_live.ex:234
 #: lib/tuist_web/live/gradle_cache_live.html.heex:288
 #, elixir-autogen, elixir-format
@@ -755,14 +755,14 @@ msgstr ""
 msgid "Failed builds"
 msgstr ""
 
-#: lib/tuist_web/live/gradle_build_runs_live.ex:254
+#: lib/tuist_web/live/gradle_build_runs_live.ex:262
 #: lib/tuist_web/live/gradle_builds_live.ex:241
 #: lib/tuist_web/live/gradle_builds_live.html.heex:470
 #, elixir-autogen, elixir-format
 msgid "Gradle version"
 msgstr ""
 
-#: lib/tuist_web/live/gradle_build_runs_live.ex:262
+#: lib/tuist_web/live/gradle_build_runs_live.ex:270
 #: lib/tuist_web/live/gradle_builds_live.ex:240
 #: lib/tuist_web/live/gradle_builds_live.html.heex:480
 #, elixir-autogen, elixir-format
@@ -789,7 +789,7 @@ msgstr ""
 msgid "No recent builds yet"
 msgstr ""
 
-#: lib/tuist_web/live/gradle_build_runs_live.ex:215
+#: lib/tuist_web/live/gradle_build_runs_live.ex:223
 #: lib/tuist_web/live/gradle_build_runs_live.html.heex:75
 #: lib/tuist_web/live/gradle_builds_live.html.heex:672
 #, elixir-autogen, elixir-format
@@ -900,7 +900,7 @@ msgid "Tests"
 msgstr ""
 
 #: lib/tuist_web/live/gradle_build_live.html.heex:147
-#: lib/tuist_web/live/gradle_build_runs_live.ex:233
+#: lib/tuist_web/live/gradle_build_runs_live.ex:241
 #: lib/tuist_web/live/gradle_build_runs_live.html.heex:98
 #, elixir-autogen, elixir-format
 msgid "Requested tasks"
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Machine Metrics"
 msgstr ""
 
-#: lib/tuist_web/live/gradle_build_runs_live.ex:279
+#: lib/tuist_web/live/gradle_build_runs_live.ex:287
 #, elixir-autogen, elixir-format
 msgid "Ran by"
 msgstr ""

--- a/server/test/tuist_web/live/build_runs_live_test.exs
+++ b/server/test/tuist_web/live/build_runs_live_test.exs
@@ -89,4 +89,36 @@ defmodule TuistWeb.BuildRunsLiveTest do
     assert has_element?(lv, "[data-part='build-runs-table'] span", "App")
     refute has_element?(lv, "[data-part='build-runs-table'] span", "Framework")
   end
+
+  test "filters build runs whose branch does not contain a substring", %{
+    conn: conn,
+    organization: organization,
+    project: project
+  } do
+    RunsFixtures.build_fixture(
+      project_id: project.id,
+      scheme: "Queued",
+      git_branch: "gh-readonly-queue/main"
+    )
+
+    RunsFixtures.build_fixture(
+      project_id: project.id,
+      scheme: "Regular",
+      git_branch: "feature/main"
+    )
+
+    query =
+      URI.encode_query(%{
+        "filter_git_branch_op" => "!=~",
+        "filter_git_branch_val" => "gh-readonly-queue"
+      })
+
+    {:ok, lv, html} =
+      live(conn, "/#{organization.account.name}/#{project.name}/builds/build-runs?#{query}")
+
+    assert has_element?(lv, "[data-part='build-runs-table']")
+    assert html =~ "does not contain"
+    assert has_element?(lv, "[data-part='build-runs-table'] span", "Regular")
+    refute has_element?(lv, "[data-part='build-runs-table'] span", "Queued")
+  end
 end

--- a/server/test/tuist_web/live/gradle_build_runs_live_test.exs
+++ b/server/test/tuist_web/live/gradle_build_runs_live_test.exs
@@ -97,6 +97,37 @@ defmodule TuistWeb.GradleBuildRunsLiveTest do
     refute has_element?(lv, "span", "feature-build")
   end
 
+  test "filters build runs whose branch does not contain a substring", %{
+    conn: conn,
+    organization: organization,
+    project: project
+  } do
+    GradleFixtures.build_fixture(
+      project_id: project.id,
+      root_project_name: "queued-build",
+      git_branch: "gh-readonly-queue/main"
+    )
+
+    GradleFixtures.build_fixture(
+      project_id: project.id,
+      root_project_name: "feature-build",
+      git_branch: "feature/main"
+    )
+
+    query =
+      URI.encode_query(%{
+        "filter_git_branch_op" => "!=~",
+        "filter_git_branch_val" => "gh-readonly-queue"
+      })
+
+    {:ok, lv, html} =
+      live(conn, "/#{organization.account.name}/#{project.name}/builds/build-runs?#{query}")
+
+    assert html =~ "does not contain"
+    assert has_element?(lv, "span", "feature-build")
+    refute has_element?(lv, "span", "queued-build")
+  end
+
   test "filters build runs by environment (CI)", %{
     conn: conn,
     organization: organization,


### PR DESCRIPTION
Resolves the production crash tracked in Sentry [TUIST-ZY](https://tuist.sentry.io/issues/TUIST-ZY).

### What changed

`XcodeBuildRunsLive` and `GradleBuildRunsLive` (both reached through `BuildRunsLive`) now normalize the `:"!=~"` ("does not contain") text-filter operator to `:not_ilike` before handing filters to Flop, matching the pattern already used by `test_runs_live`, `generate_runs_live`, and `cache_runs_live`.

### Why

The build-runs dashboard raised `Flop.InvalidParamsError` whenever a user selected **"does not contain"** on a text filter (Branch, Xcode/Gradle version, macOS/Java version, etc.).

Root cause: Noora exposes that filter operator as the atom `:"!=~"` (a valid Noora text/list operator), but Noora's `to_flop_filter` passes the operator verbatim to Flop. Flop has no `:"!=~"` operator — its equivalent is `:not_ilike`. The codebase convention is that each LiveView translates `:"!=~"` to `:not_ilike` before calling Flop. Both build-runs variants were missing that translation, so the crash was latent for every text filter on that page. The Sentry report came from the Xcode variant (a Branch filter); the Gradle variant had the identical latent bug, so both are fixed here.

### Why this approach

Kept the fix consistent with the existing `normalize_text_filter_operator/1` pattern used by the other run dashboards rather than changing Noora's shared `to_flop_filter`. Fixing it in Noora would be the cleaner long-term home for the now-duplicated helper, but it touches the design system's Flop semantics for every consumer and is broader than this bug fix.

### Impact

Users can again filter build runs with "does not contain" instead of hitting a 500.

### How to test locally

1. Open the build-runs dashboard for a project (`/<account>/<project>/builds/build-runs`).
2. Add a **Branch** filter, switch its operator to **"does not contain"**, and enter a value.
3. Before this change the page crashes with `Flop.InvalidParamsError`; now it filters correctly.

Automated coverage: added regression tests to `build_runs_live_test.exs` and `gradle_build_runs_live_test.exs` that drive the `!=~` git-branch filter and assert the matching/non-matching rows. Both reproduced the exact production stacktrace before the fix and pass after it. `mix format` and `mix credo` are clean.
