### PR TITLE
feat(infra): drift macOS host config on a fleet-wide config hash

### DIFF
--- a/infra/cluster-api-provider-scaleway-applesilicon/AGENTS.md
+++ b/infra/cluster-api-provider-scaleway-applesilicon/AGENTS.md
@@ -67,6 +67,18 @@ redoing finished ones. Failures requeue with backoff; only terminal
 errors (Scaleway 400s, validation failures) set
 `Status.FailureReason`.
 
+Beyond first bootstrap, a drift loop re-pushes host config to already-Ready
+hosts when the operator's `bootstrap.HostConfigHash` differs from the
+Machine's `Status.HostConfigHash`. That hash is a fleet-wide fingerprint over
+everything the operator pushes — the rendered install scripts plus the
+embedded binaries (tart-kubelet, tailscale, node_exporter) — computed once at
+startup from operator-image + fleet-config inputs with every per-host field
+zeroed. So shipping a new operator image with a changed script, fleet CIDR/tag,
+or re-baked binary rolls to existing hosts on the next reconcile, not only on a
+tart-kubelet binary change. The re-push is zero-downtime (running Tart VMs
+survive `UpdateTartKubelet`). Terminal-failed CRs are excluded until
+`Status.FailureReason` is cleared.
+
 Two auxiliary controllers run alongside it:
 
 - **OrphanReclaimer** (`controllers/orphan_reclaimer.go`) — a

--- a/infra/cluster-api-provider-scaleway-applesilicon/api/v1alpha1/scalewayapplesiliconmachine_types.go
+++ b/infra/cluster-api-provider-scaleway-applesilicon/api/v1alpha1/scalewayapplesiliconmachine_types.go
@@ -205,6 +205,16 @@ type ScalewayAppleSiliconMachineStatus struct {
 	// +optional
 	TartKubeletBinarySHA string `json:"tartKubeletBinarySHA,omitempty"`
 
+	// HostConfigHash is the fleet-wide canonical hash of every host
+	// config the operator pushes — the rendered install scripts plus the
+	// embedded binaries (bootstrap.HostConfigHash). Drift between this
+	// and the operator's own computed hash re-pushes the host config on
+	// the next reconcile, so a change to ANY pushed config (a script
+	// tweak, a fleet CIDR, or a re-baked binary) rolls to existing hosts
+	// instead of only a tart-kubelet binary change.
+	// +optional
+	HostConfigHash string `json:"hostConfigHash,omitempty"`
+
 	// TartKubeletUpdateAttempts counts consecutive failures of the
 	// drift-loop's UpdateTartKubelet call. Reset to zero on success.
 	// Once it crosses the operator's max-attempts threshold the CR

--- a/infra/cluster-api-provider-scaleway-applesilicon/cmd/manager/main.go
+++ b/infra/cluster-api-provider-scaleway-applesilicon/cmd/manager/main.go
@@ -45,6 +45,7 @@ import (
 	"github.com/tuist/tuist/infra/cluster-api-provider-scaleway-applesilicon/internal/kubeconfig"
 	"github.com/tuist/tuist/infra/cluster-api-provider-scaleway-applesilicon/internal/runner"
 	"github.com/tuist/tuist/infra/cluster-api-provider-scaleway-applesilicon/internal/scaleway"
+	bootstrap "github.com/tuist/tuist/infra/macos-host-bootstrap"
 )
 
 var (
@@ -340,6 +341,29 @@ func main() {
 		setupLog.Info("loaded node_exporter binary", "path", nodeExporterBinaryPath, "bytes", len(nodeExporterBinary), "sha", sha256Hex(nodeExporterBinary))
 	}
 
+	// Canonical host-config hash: a single fleet-wide fingerprint over
+	// everything the operator pushes (rendered install scripts +
+	// embedded binaries). Computed once here, like the binary SHA, from
+	// a Config carrying ONLY operator-image + fleet-config inputs — every
+	// per-host field (NodeName, IP, kubeconfig, VLAN, auth key, ...) is
+	// left empty so the hash is identical across the fleet and drift is a
+	// config change, not a host identity. The reconciler stamps it on
+	// each Machine and re-pushes the host config when it moves.
+	hostConfigHash := bootstrap.HostConfigHash(bootstrap.Config{
+		TartKubeletBinary:     tartKubeletBinary,
+		TailscaleBinaries:     tailscaleBinaries,
+		NodeExporterBinary:    nodeExporterBinary,
+		TailscaleTags:         parseCommaList(tailscaleTagsRaw),
+		TailscaleAcceptRoutes: tailscaleAcceptRoutes,
+		VMKuraEgressCIDR:      vmKuraEgressCIDR,
+		VMClusterDNSIP:        vmClusterDNSIP,
+		VMCachePNCIDR:         vmCachePNCIDR,
+		HostCPU:               tartKubeletHostCPU,
+		HostMemoryMB:          tartKubeletHostMemory,
+		MaxPods:               tartKubeletMaxPods,
+	})
+	setupLog.Info("computed host config hash", "hash", hostConfigHash)
+
 	restConfig := ctrl.GetConfigOrDie()
 
 	if apiServerURL == "" {
@@ -432,6 +456,7 @@ func main() {
 		Kubeconfig:           kubeconfigBuilder,
 		TartKubeletBinary:    tartKubeletBinary,
 		TartKubeletBinarySHA: binarySHA,
+		HostConfigHash:       hostConfigHash,
 		TartTarball:          tartTarball,
 		TailscaleBinaries:    tailscaleBinaries,
 		NodeExporterBinary:   nodeExporterBinary,

--- a/infra/cluster-api-provider-scaleway-applesilicon/controllers/scalewayapplesiliconmachine_controller.go
+++ b/infra/cluster-api-provider-scaleway-applesilicon/controllers/scalewayapplesiliconmachine_controller.go
@@ -77,6 +77,16 @@ type ScalewayAppleSiliconMachineReconciler struct {
 	// re-uploads + reloads launchd.
 	TartKubeletBinarySHA string
 
+	// HostConfigHash is the fleet-wide canonical hash of every host
+	// config the operator pushes (bootstrap.HostConfigHash over the
+	// rendered install scripts + embedded binaries). It's the version
+	// stamp that drives the host-config drift loop: when
+	// status.hostConfigHash != this value the reconciler re-pushes the
+	// host config. Broader than TartKubeletBinarySHA, which only catches
+	// a tart-kubelet binary change — this also catches a script tweak or
+	// a fleet-config (CIDR/tags/accept-routes) change.
+	HostConfigHash string
+
 	// TartTarball is the gzipped tar of the upstream `tart.app` bundle
 	// pinned in the operator's Dockerfile and read at startup. Uploaded
 	// to each Mac mini over SSH at first bootstrap. We do not run a
@@ -639,7 +649,13 @@ func (r *ScalewayAppleSiliconMachineReconciler) reconcileNormal(
 	// Running Tart VMs survive an agent restart (`nohup`-detached) and
 	// the kubelet's startup state-recovery pass re-binds them, so the
 	// rollout is zero-downtime for workloads.
-	binaryDrift := r.TartKubeletBinarySHA != "" && machine.Status.TartKubeletBinarySHA != r.TartKubeletBinarySHA
+	// Drift on the fleet-wide host-config hash, not just the tart-kubelet
+	// binary SHA: a change to ANY pushed config — an install-script tweak,
+	// a fleet CIDR / tag / accept-routes flip, or any re-baked binary —
+	// moves the hash and re-pushes the host config. Existing machines
+	// carry an empty Status.HostConfigHash, so the first reconcile after
+	// this upgrade drifts once and re-pushes — the intended migration.
+	configDrift := hostConfigDrift(r.HostConfigHash, machine.Status.HostConfigHash)
 	// Once a CR enters the terminal-failed state (FailureReason set
 	// and FailureMessage describes the underlying error) we stop
 	// firing the drift loop. CAPI core takes over: surfaces the
@@ -647,7 +663,7 @@ func (r *ScalewayAppleSiliconMachineReconciler) reconcileNormal(
 	// without operator action. Recovery: clear FailureReason +
 	// reset TartKubeletUpdateAttempts to resume the loop.
 	terminalFailure := machine.Status.FailureReason != nil
-	if binaryDrift && !terminalFailure {
+	if configDrift && !terminalFailure {
 		ip := machineIP(machine)
 		if ip == "" {
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
@@ -748,10 +764,12 @@ func (r *ScalewayAppleSiliconMachineReconciler) reconcileNormal(
 			return ctrl.Result{RequeueAfter: 60 * time.Second}, nil
 		}
 		machine.Status.TartKubeletBinarySHA = r.TartKubeletBinarySHA
+		machine.Status.HostConfigHash = r.HostConfigHash
 		machine.Status.TartKubeletUpdateAttempts = 0
 		r.Recorder.Eventf(machine, corev1.EventTypeNormal, "AgentRolled",
 			"Rolled tart-kubelet to %s", r.TartKubeletBinarySHA)
-		logger.Info("rolled new tart-kubelet", "host", ip, "sha", r.TartKubeletBinarySHA)
+		logger.Info("rolled new tart-kubelet", "host", ip, "sha", r.TartKubeletBinarySHA,
+			"hostConfigHash", r.HostConfigHash)
 	}
 
 	// Stage 4: materialise the per-machine Tailscale egress Service
@@ -972,6 +990,15 @@ func (r *ScalewayAppleSiliconMachineReconciler) reconcileTailscaleEgressService(
 		return nil
 	})
 	return err
+}
+
+// hostConfigDrift reports whether the host config the operator would
+// push (operatorHash) differs from what the Machine last recorded
+// (machineHash). An empty operatorHash (hash not computed) never drifts.
+// An empty machineHash on a non-empty operatorHash drifts once — the
+// migration case for machines provisioned before the hash existed.
+func hostConfigDrift(operatorHash, machineHash string) bool {
+	return operatorHash != "" && machineHash != operatorHash
 }
 
 // recordUpdateFailure increments the drift-loop retry counter and,

--- a/infra/cluster-api-provider-scaleway-applesilicon/controllers/scalewayapplesiliconmachine_controller_test.go
+++ b/infra/cluster-api-provider-scaleway-applesilicon/controllers/scalewayapplesiliconmachine_controller_test.go
@@ -40,6 +40,33 @@ func fakeRecorder() record.EventRecorder {
 	return record.NewFakeRecorder(32)
 }
 
+// hostConfigDrift gates the host-config re-push: it fires when the
+// operator's computed hash differs from what the Machine last recorded,
+// which is what makes a script/fleet-config/binary change roll to
+// existing hosts. The migration case (empty machine hash on upgrade)
+// must drift exactly once.
+func TestHostConfigDrift(t *testing.T) {
+	cases := []struct {
+		name         string
+		operatorHash string
+		machineHash  string
+		want         bool
+	}{
+		{"matching hashes do not drift", "abc", "abc", false},
+		{"differing hashes drift", "abc", "def", true},
+		{"empty machine hash drifts once (migration)", "abc", "", true},
+		{"empty operator hash never drifts", "", "abc", false},
+		{"both empty does not drift", "", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := hostConfigDrift(tc.operatorHash, tc.machineHash); got != tc.want {
+				t.Fatalf("hostConfigDrift(%q, %q) = %v, want %v", tc.operatorHash, tc.machineHash, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestRecordUpdateFailure_IncrementsAttempts(t *testing.T) {
 	machine := &infrav1.ScalewayAppleSiliconMachine{}
 	recordUpdateFailure(machine, errors.New("boom"), 5, logr.Discard(), fakeRecorder())

--- a/infra/helm/tuist/crds/infrastructure.cluster.x-k8s.io_scalewayapplesiliconmachines.yaml
+++ b/infra/helm/tuist/crds/infrastructure.cluster.x-k8s.io_scalewayapplesiliconmachines.yaml
@@ -317,6 +317,16 @@ spec:
                     mini. The Machine reconciler uses this for delete + status
                     polling against Scaleway's API.
                   type: string
+                hostConfigHash:
+                  description: |-
+                    HostConfigHash is the fleet-wide canonical hash of every host
+                    config the operator pushes — the rendered install scripts plus
+                    the embedded binaries (bootstrap.HostConfigHash). Drift between
+                    this and the operator's own computed hash re-pushes the host
+                    config on the next reconcile, so a change to ANY pushed config (a
+                    script tweak, a fleet CIDR, or a re-baked binary) rolls to
+                    existing hosts instead of only a tart-kubelet binary change.
+                  type: string
                 tartKubeletBinarySHA:
                   description: |-
                     TartKubeletBinarySHA is the SHA-256 of the tart-kubelet binary

--- a/infra/macos-host-bootstrap/bootstrap.go
+++ b/infra/macos-host-bootstrap/bootstrap.go
@@ -42,7 +42,9 @@ package bootstrap
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"encoding/base64"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"net"
@@ -402,6 +404,99 @@ func UpdateTartKubelet(ctx context.Context, cfg Config) (string, error) {
 	return hk.Observed(), nil
 }
 
+// HostConfigHash is a fleet-wide canonical fingerprint of everything the
+// operator pushes to a host: the rendered install scripts (firewall +
+// vmnat, PN interface, launchd job + plist, Tailscale, node_exporter,
+// tart-kubelet install) plus the bytes of every embedded binary. The
+// reconciler stamps it on each Machine and re-pushes when it drifts, so
+// a change to ANY pushed config — a script tweak, a fleet-config CIDR, or
+// a re-baked binary in the operator image — reaches existing hosts on the
+// next reconcile rather than only on a tart-kubelet binary roll.
+//
+// It is computed once at operator startup from a Config that carries
+// operator-image + fleet-config inputs. The hash must be identical across
+// every host in a fleet or it would falsely drift on each one, so this
+// function neutralizes every per-host / volatile field before rendering
+// (NodeName, IP, VLAN, kubeconfig, auth key, ...) regardless of what the
+// caller passed — the canonical Config built in the manager already
+// leaves them empty; zeroing them here makes that a guarantee rather than
+// a caller obligation. The renderers are plain string templates, so an
+// empty per-host substitution is well-formed; none slice or index a value
+// that must be non-empty.
+func HostConfigHash(cfg Config) string {
+	// Strip per-host / volatile fields so the fingerprint is fleet-wide.
+	// Fleet-config fields (CIDRs, tags, accept-routes, host CPU/mem/pods)
+	// and the embedded binaries are kept.
+	cfg.IP = ""
+	cfg.SSHUser = ""
+	cfg.UserPassword = ""
+	cfg.SSHPrivateKey = nil
+	cfg.NodeName = ""
+	cfg.ProviderID = ""
+	cfg.Kubeconfig = ""
+	cfg.TailscaleAuthKey = ""
+	cfg.VMCachePNVLAN = 0
+	cfg.KnownHostFingerprint = ""
+	cfg.GHActionsRunner = nil
+	cfg.NodeLabels = nil
+
+	var b strings.Builder
+
+	// (a) Rendered scripts, concatenated in a fixed order. A
+	// label prefixes each so two scripts can't alias into one
+	// another's bytes and hide a change.
+	firewall, err := renderVMEgressFirewallScript(cfg)
+	if err != nil {
+		// A malformed canonical CIDR can't render a script. Fold the
+		// error text in instead so the hash stays deterministic and
+		// distinct rather than panicking — the operator already
+		// validates these inputs before they reach a host.
+		firewall = "ERROR:" + err.Error()
+	}
+	for _, part := range []struct{ name, script string }{
+		{"firewall", firewall},
+		{"vmnat", renderVMNATScript(cfg)},
+		{"pn-interface", renderVMCachePNInterfaceScript(cfg)},
+		{"launchd", renderTartKubeletLaunchdScript(cfg)},
+		{"launchd-plist", renderLaunchdPlist(cfg)},
+		{"tailscale", renderTailscaleScript(cfg)},
+		{"node-exporter", renderNodeExporterScript()},
+		{"tart-kubelet-install", renderTartKubeletInstallScript()},
+	} {
+		b.WriteString(part.name)
+		b.WriteByte('\x00')
+		b.WriteString(part.script)
+		b.WriteByte('\x00')
+	}
+
+	// (b) SHA of each embedded binary the drift loop actually re-pushes.
+	// The bytes themselves ride SSH stdin (not the scripts), so their
+	// drift is only visible to the hash through their content SHA.
+	//
+	// TartTarball is intentionally omitted: Tart is bootstrap-only (the
+	// hypervisor can't be swapped under running VMs, so UpdateTartKubelet
+	// never re-installs it). Hashing it would force a pointless re-push on
+	// a Tart bump that couldn't actually update Tart anyway — that bump
+	// rolls via Machine replacement, not config drift.
+	for _, bin := range []struct {
+		name  string
+		bytes []byte
+	}{
+		{"tart-kubelet", cfg.TartKubeletBinary},
+		{"tailscale-binaries", cfg.TailscaleBinaries},
+		{"node-exporter-binary", cfg.NodeExporterBinary},
+	} {
+		b.WriteString(bin.name)
+		b.WriteByte('\x00')
+		if bin.bytes != nil {
+			b.WriteString(sha256Hex(bin.bytes))
+		}
+		b.WriteByte('\x00')
+	}
+
+	return sha256Hex([]byte(b.String()))
+}
+
 // SetHostname makes the macOS hostname match the CR name, so
 // `os.Hostname()` inside tart-kubelet (the default --node-name) lines
 // up with the inventory. The operator passes --node-name explicitly
@@ -443,7 +538,16 @@ func installTartKubelet(ctx context.Context, client *ssh.Client, binary []byte) 
 	if len(binary) == 0 {
 		return fmt.Errorf("tart-kubelet binary is empty")
 	}
-	script := `set -euo pipefail
+	return RunCommandWithStdin(ctx, client, renderTartKubeletInstallScript(), bytes.NewReader(binary))
+}
+
+// renderTartKubeletInstallScript is the static SSH script that lands the
+// uploaded tart-kubelet binary. The binary bytes themselves ride stdin;
+// their drift is tracked by the binary SHA, so this script carries no
+// host- or binary-specific input and is included verbatim in the host
+// config hash.
+func renderTartKubeletInstallScript() string {
+	return `set -euo pipefail
 sudo mkdir -p /usr/local/bin
 sudo tee /usr/local/bin/tart-kubelet >/dev/null
 sudo chmod 0755 /usr/local/bin/tart-kubelet
@@ -456,7 +560,6 @@ sudo chmod 0755 /usr/local/bin/tart-kubelet
 # stale cache so the rolled binary actually runs.
 sudo codesign --force --sign - /usr/local/bin/tart-kubelet
 `
-	return RunCommandWithStdin(ctx, client, script, bytes.NewReader(binary))
 }
 
 // loadTartKubeletLaunchd writes /Library/LaunchDaemons/dev.tuist.tart-kubelet.plist
@@ -490,7 +593,16 @@ sudo codesign --force --sign - /usr/local/bin/tart-kubelet
 //     took.
 func loadTartKubeletLaunchd(ctx context.Context, client *ssh.Client, cfg Config) error {
 	plist := renderLaunchdPlist(cfg)
-	script := fmt.Sprintf(`set -euo pipefail
+	return RunCommandWithStdin(ctx, client, renderTartKubeletLaunchdScript(cfg), strings.NewReader(plist))
+}
+
+// renderTartKubeletLaunchdScript is the SSH script that installs +
+// reloads the launchd job. The plist content rides stdin (see
+// renderLaunchdPlist); this script only substitutes the SSH user that
+// owns kubelet's writable paths, so it is config-shaped and folds into
+// the host config hash.
+func renderTartKubeletLaunchdScript(cfg Config) string {
+	return fmt.Sprintf(`set -euo pipefail
 PLIST=/Library/LaunchDaemons/dev.tuist.tart-kubelet.plist
 NEW="$(mktemp)"
 trap 'rm -f "$NEW"' EXIT
@@ -549,7 +661,6 @@ settled && exit 0
 echo "tart-kubelet did not reach a running state after launchd reload" >&2
 exit 1
 `, shellQuote(cfg.SSHUser))
-	return RunCommandWithStdin(ctx, client, script, strings.NewReader(plist))
 }
 
 func renderLaunchdPlist(cfg Config) string {
@@ -1069,11 +1180,30 @@ sudo chmod 0755 /usr/local/bin/tart
 // pf if not already enabled. The launchd plist re-loads the
 // rules on every boot so a reboot doesn't drop the filter.
 func installVMEgressFirewall(ctx context.Context, client *ssh.Client, cfg Config) error {
+	script, err := renderVMEgressFirewallScript(cfg)
+	if err != nil {
+		return err
+	}
+	if err := RunCommand(ctx, client, script); err != nil {
+		return err
+	}
+	if cfg.VMKuraEgressCIDR == "" && cfg.VMCachePNCIDR == "" {
+		return nil
+	}
+	return RunCommand(ctx, client, renderVMNATScript(cfg))
+}
+
+// renderVMEgressFirewallScript builds the pf-anchor install script. It
+// validates the carve-out CIDRs/IP as IPv4 literals and fails closed on
+// a bad value (a chart typo must never produce an unparseable — or
+// creative — ruleset), which is why it returns an error. Folded into the
+// host config hash so a carve-out values change re-pushes the filter.
+func renderVMEgressFirewallScript(cfg Config) (string, error) {
 	carveOut := ""
 	if cfg.VMKuraEgressCIDR != "" {
 		ip, _, err := net.ParseCIDR(cfg.VMKuraEgressCIDR)
 		if err != nil || ip.To4() == nil {
-			return fmt.Errorf("vm kura egress cidr %q is not an IPv4 CIDR: %v", cfg.VMKuraEgressCIDR, err)
+			return "", fmt.Errorf("vm kura egress cidr %q is not an IPv4 CIDR: %v", cfg.VMKuraEgressCIDR, err)
 		}
 		carveOut = fmt.Sprintf(`
 # Runner-cache carve-out: VMs may dial the cluster's Kura cache
@@ -1089,19 +1219,19 @@ pass out quick proto tcp from <vm_sources> to %s port { 4000, 50051 } keep state
 		if cfg.VMClusterDNSIP != "" {
 			dnsIP := net.ParseIP(cfg.VMClusterDNSIP)
 			if dnsIP == nil || dnsIP.To4() == nil {
-				return fmt.Errorf("vm cluster dns ip %q is not an IPv4 address", cfg.VMClusterDNSIP)
+				return "", fmt.Errorf("vm cluster dns ip %q is not an IPv4 address", cfg.VMClusterDNSIP)
 			}
 			carveOut += fmt.Sprintf(`pass out quick proto { tcp, udp } from <vm_sources> to %s port 53 keep state
 `, cfg.VMClusterDNSIP)
 		}
 	} else if cfg.VMClusterDNSIP != "" {
-		return fmt.Errorf("vm cluster dns ip set without vm kura egress cidr; refusing a DNS-only carve-out")
+		return "", fmt.Errorf("vm cluster dns ip set without vm kura egress cidr; refusing a DNS-only carve-out")
 	}
 
 	if cfg.VMCachePNCIDR != "" {
 		ip, _, err := net.ParseCIDR(cfg.VMCachePNCIDR)
 		if err != nil || ip.To4() == nil {
-			return fmt.Errorf("vm cache pn cidr %q is not an IPv4 CIDR: %v", cfg.VMCachePNCIDR, err)
+			return "", fmt.Errorf("vm cache pn cidr %q is not an IPv4 CIDR: %v", cfg.VMCachePNCIDR, err)
 		}
 		carveOut += fmt.Sprintf(`
 # Runner-cache Private Network carve-out: VMs dial per-account Kura
@@ -1208,13 +1338,16 @@ sudo launchctl bootout system/dev.tuist.pfctl-runners 2>/dev/null || true
 sudo launchctl bootstrap system /Library/LaunchDaemons/dev.tuist.pfctl-runners.plist
 `
 	script = strings.Replace(script, "@CARVEOUT@", carveOut, 1)
-	if err := RunCommand(ctx, client, script); err != nil {
-		return err
-	}
-	if cfg.VMKuraEgressCIDR == "" && cfg.VMCachePNCIDR == "" {
-		return nil
-	}
-	natScript := fmt.Sprintf(`set -euo pipefail
+	return script, nil
+}
+
+// renderVMNATScript builds the VM->cache NAT helper + its launchd
+// supervisor. Only the configured carve-out CIDRs vary; the derived
+// interface is resolved at runtime on the host. Folded into the host
+// config hash. Callers gate this on at least one of VMKuraEgressCIDR /
+// VMCachePNCIDR being set, matching installVMEgressFirewall.
+func renderVMNATScript(cfg Config) string {
+	return fmt.Sprintf(`set -euo pipefail
 sudo tee /usr/local/bin/tuist-pf-vmnat >/dev/null <<'VMNAT'
 #!/bin/sh
 # Loads the VM->cache NAT rules into the com.apple/tuist.vmnat pf
@@ -1311,7 +1444,6 @@ sudo chmod 0644 /Library/LaunchDaemons/dev.tuist.pfctl-vmnat.plist
 sudo launchctl bootout system/dev.tuist.pfctl-vmnat 2>/dev/null || true
 sudo launchctl bootstrap system /Library/LaunchDaemons/dev.tuist.pfctl-vmnat.plist
 `, cfg.VMKuraEgressCIDR, cfg.VMCachePNCIDR)
-	return RunCommand(ctx, client, natScript)
 }
 
 // installVMCachePNInterface materializes the macOS side of the
@@ -1327,7 +1459,16 @@ func installVMCachePNInterface(ctx context.Context, client *ssh.Client, cfg Conf
 	if cfg.VMCachePNCIDR == "" || cfg.VMCachePNVLAN == 0 {
 		return nil
 	}
-	script := fmt.Sprintf(`set -euo pipefail
+	return RunCommand(ctx, client, renderVMCachePNInterfaceScript(cfg))
+}
+
+// renderVMCachePNInterfaceScript materializes the per-host VLAN
+// interface. VMCachePNVLAN is a per-host Scaleway-assigned value;
+// HostConfigHash zeroes it before rendering, so the host config hash
+// fingerprints this script's template (a fix here re-pushes to existing
+// hosts) without the per-host VLAN making the hash host-specific.
+func renderVMCachePNInterfaceScript(cfg Config) string {
+	return fmt.Sprintf(`set -euo pipefail
 VLAN_TAG=%d
 CURRENT_TAG=$(networksetup -listVLANs 2>/dev/null | awk '/^VLAN User Defined Name: pn$/{found=1; next} found && /^Tag: /{print $2; exit} found && /^VLAN User Defined Name: /{exit}')
 if [ "${CURRENT_TAG:-}" != "$VLAN_TAG" ]; then
@@ -1342,7 +1483,6 @@ fi
 # version ("pn Configuration" on Tahoe). Force DHCP either way.
 sudo networksetup -setdhcp "pn Configuration" 2>/dev/null || sudo networksetup -setdhcp pn
 `, cfg.VMCachePNVLAN)
-	return RunCommand(ctx, client, script)
 }
 
 // installTailscale joins the Mac mini to the cluster's tailnet using
@@ -1386,6 +1526,16 @@ sudo chmod 0600 /etc/tuist/tailscale-auth-key`
 		return fmt.Errorf("stage tailscale auth key: %w", err)
 	}
 
+	return RunCommandWithStdin(ctx, client, renderTailscaleScript(cfg), bytes.NewReader(cfg.TailscaleBinaries))
+}
+
+// renderTailscaleScript builds the stage-2 SSH script (extract binaries,
+// register the daemon, `tailscale up`). The auth key never appears in
+// the script — it's read on the host from the stage-1 file — so only the
+// fleet-wide tags / accept-routes and the per-host hostname vary. Folded
+// into the host config hash; the canonical config leaves NodeName empty,
+// so the hostname arg drops out and the hash stays host-independent.
+func renderTailscaleScript(cfg Config) string {
 	tagsArg := ""
 	if len(cfg.TailscaleTags) > 0 {
 		// Tailscale accepts a comma-separated list — auth-key-bound
@@ -1417,7 +1567,7 @@ sudo chmod 0600 /etc/tuist/tailscale-auth-key`
 	// kubectl) and the controller log stream (which ships to Loki).
 	// Per-step diagnostics come from explicit log-file capture on the
 	// failure branches below.
-	script := fmt.Sprintf(`set -euo pipefail
+	return fmt.Sprintf(`set -euo pipefail
 # Always remove the auth key file when this script exits — success
 # or failure. Set the trap first thing so a later abort still cleans
 # up.
@@ -1545,7 +1695,6 @@ echo "tailscale up returned but no tailnet IPv4 within 30s; current status:" >&2
 sudo /usr/local/bin/tailscale status >&2 || true
 exit 1
 `, hostnameArg, tagsArg, acceptRoutesArg)
-	return RunCommandWithStdin(ctx, client, script, bytes.NewReader(cfg.TailscaleBinaries))
 }
 
 // installNodeExporter drops the cross-compiled darwin/arm64 binary,
@@ -1564,7 +1713,15 @@ func installNodeExporter(ctx context.Context, client *ssh.Client, cfg Config) er
 	if len(cfg.NodeExporterBinary) == 0 || cfg.TailscaleAuthKey == "" {
 		return nil
 	}
-	script := `set -euo pipefail
+	return RunCommandWithStdin(ctx, client, renderNodeExporterScript(), bytes.NewReader(cfg.NodeExporterBinary))
+}
+
+// renderNodeExporterScript is the static SSH script that installs the
+// node_exporter wrapper + launchd job. The binary rides stdin and its
+// drift is tracked by its own SHA in the host config hash, so this
+// script carries no per-host or per-binary input.
+func renderNodeExporterScript() string {
+	return `set -euo pipefail
 sudo mkdir -p /usr/local/bin
 sudo tee /usr/local/bin/node_exporter >/dev/null
 sudo chmod 0755 /usr/local/bin/node_exporter
@@ -1621,7 +1778,6 @@ sudo chmod 0644 /Library/LaunchDaemons/dev.tuist.node-exporter.plist
 sudo launchctl bootout system /Library/LaunchDaemons/dev.tuist.node-exporter.plist 2>/dev/null || true
 sudo launchctl bootstrap system /Library/LaunchDaemons/dev.tuist.node-exporter.plist
 `
-	return RunCommandWithStdin(ctx, client, script, bytes.NewReader(cfg.NodeExporterBinary))
 }
 
 // === SSH helpers ===========================================================
@@ -1667,4 +1823,9 @@ func RunCommandWithStdin(ctx context.Context, client *ssh.Client, cmd string, st
 
 func b64(b []byte) string {
 	return base64.StdEncoding.EncodeToString(b)
+}
+
+func sha256Hex(b []byte) string {
+	h := sha256.Sum256(b)
+	return hex.EncodeToString(h[:])
 }

--- a/infra/macos-host-bootstrap/bootstrap.go
+++ b/infra/macos-host-bootstrap/bootstrap.go
@@ -439,6 +439,9 @@ func HostConfigHash(cfg Config) string {
 	cfg.KnownHostFingerprint = ""
 	cfg.GHActionsRunner = nil
 	cfg.NodeLabels = nil
+	// Per-host role signal (builder hosts set it); the launchd plist
+	// renderer keys --disable-vm-gc off it, so neutralize it too.
+	cfg.DisableVMGC = false
 
 	var b strings.Builder
 

--- a/infra/macos-host-bootstrap/bootstrap_test.go
+++ b/infra/macos-host-bootstrap/bootstrap_test.go
@@ -121,6 +121,81 @@ func newTestPubKey(t *testing.T) ssh.PublicKey {
 	return pk
 }
 
+func TestHostConfigHash_StableForSameConfig(t *testing.T) {
+	cfg := Config{
+		TartKubeletBinary:  []byte("kubelet-v1"),
+		TailscaleBinaries:  []byte("ts-v1"),
+		NodeExporterBinary: []byte("ne-v1"),
+		TailscaleAuthKey:   "auth-key",
+		TailscaleTags:      []string{"tag:tuist-macmini"},
+		VMKuraEgressCIDR:   "10.96.0.0/12",
+		VMCachePNCIDR:      "172.16.0.0/22",
+		HostCPU:            8,
+		HostMemoryMB:       16384,
+		MaxPods:            3,
+	}
+	if HostConfigHash(cfg) != HostConfigHash(cfg) {
+		t.Fatalf("HostConfigHash must be stable for the same config")
+	}
+}
+
+func TestHostConfigHash_IndependentOfPerHostFields(t *testing.T) {
+	base := Config{
+		TartKubeletBinary: []byte("kubelet-v1"),
+		VMKuraEgressCIDR:  "10.96.0.0/12",
+	}
+	perHost := base
+	// Per-host fields must not move the canonical hash, or every host in
+	// a fleet would falsely drift.
+	perHost.NodeName = "macmini-7"
+	perHost.IP = "51.15.1.2"
+	perHost.Kubeconfig = "kubeconfig-yaml"
+	perHost.ProviderID = "scw-applesilicon://fr-par-1/abc"
+	perHost.VMCachePNVLAN = 4242
+	perHost.KnownHostFingerprint = "SHA256:zzz"
+	if HostConfigHash(base) != HostConfigHash(perHost) {
+		t.Fatalf("HostConfigHash must ignore per-host fields")
+	}
+}
+
+func TestHostConfigHash_ChangesWhenFleetConfigChanges(t *testing.T) {
+	base := Config{
+		TartKubeletBinary: []byte("kubelet-v1"),
+		VMKuraEgressCIDR:  "10.96.0.0/12",
+	}
+	changed := base
+	changed.VMCachePNCIDR = "172.16.0.0/22"
+	if HostConfigHash(base) == HostConfigHash(changed) {
+		t.Fatalf("HostConfigHash must change when a fleet-config field changes")
+	}
+
+	tags := base
+	tags.TailscaleTags = []string{"tag:tuist-macmini-staging"}
+	if HostConfigHash(base) == HostConfigHash(tags) {
+		t.Fatalf("HostConfigHash must change when TailscaleTags change")
+	}
+
+	routes := base
+	routes.TailscaleAcceptRoutes = true
+	if HostConfigHash(base) == HostConfigHash(routes) {
+		t.Fatalf("HostConfigHash must change when TailscaleAcceptRoutes changes")
+	}
+}
+
+func TestHostConfigHash_ChangesWhenBinaryChanges(t *testing.T) {
+	base := Config{TartKubeletBinary: []byte("kubelet-v1")}
+	changed := Config{TartKubeletBinary: []byte("kubelet-v2")}
+	if HostConfigHash(base) == HostConfigHash(changed) {
+		t.Fatalf("HostConfigHash must change when the tart-kubelet binary changes")
+	}
+
+	ne := base
+	ne.NodeExporterBinary = []byte("ne-v1")
+	if HostConfigHash(base) == HostConfigHash(ne) {
+		t.Fatalf("HostConfigHash must change when the node_exporter binary changes")
+	}
+}
+
 func TestHostKeyState_TOFUCapturesFingerprint(t *testing.T) {
 	hk := NewHostKeyState("")
 	pk := newTestPubKey(t)

--- a/infra/macos-host-bootstrap/bootstrap_test.go
+++ b/infra/macos-host-bootstrap/bootstrap_test.go
@@ -153,6 +153,7 @@ func TestHostConfigHash_IndependentOfPerHostFields(t *testing.T) {
 	perHost.ProviderID = "scw-applesilicon://fr-par-1/abc"
 	perHost.VMCachePNVLAN = 4242
 	perHost.KnownHostFingerprint = "SHA256:zzz"
+	perHost.DisableVMGC = true
 	if HostConfigHash(base) != HostConfigHash(perHost) {
 		t.Fatalf("HostConfigHash must ignore per-host fields")
 	}


### PR DESCRIPTION
## What

The Scaleway Apple Silicon CAPI provider's drift loop re-pushes host config to already-Ready Mac minis only when the **tart-kubelet binary SHA** changes. This PR broadens the trigger to a fleet-wide **host-config hash** so a change to *anything the operator pushes* propagates on the next reconcile:

- New `bootstrap.HostConfigHash(cfg)` — a sha256 over every rendered install script (firewall + vmnat, PN interface, launchd job + plist, tailscale, node_exporter, tart-kubelet install) plus the SHA of each embedded binary (tart-kubelet, tailscale, node_exporter).
- The manager computes it once at startup (like the binary SHA) from a `Config` carrying only operator-image + fleet-config inputs, with **every per-host field zeroed** (NodeName, IP, kubeconfig, VLAN, auth key, `DisableVMGC`, ...), so the fingerprint is identical across the fleet.
- New `Status.HostConfigHash` on the CR (Go type **and** the helm-chart CRD schema — see below); the reconciler stamps it on a successful re-push.
- The drift gate moves from `binaryDrift` (tart-kubelet SHA only) to `configDrift` (the host-config hash). `TartKubeletBinarySHA` is still computed and stamped for observability.
- The install functions' inlined `script :=` strings are extracted into pure `render*(cfg) string` helpers shared by the installer and the hash — **what gets pushed to hosts is byte-for-byte unchanged**.

## Why

Last week's macOS runner cache outage needed three host-config fixes (a NAT vlan-detection fix, a pfctl direct-anchor-load fix, an EM pn0 hardening). Each landed in the operator image, but the drift loop ignored them: it only re-pushes on a tart-kubelet *binary* change, so a firewall/script-only or fleet-config-only fix never reached the already-provisioned hosts. The fix had to be hand-applied over SSH to all 9 hosts and the CRs force-patched to re-trigger the loop. This closes that gap: a script tweak, a fleet CIDR/tag/accept-routes change, or a re-baked tailscale/node_exporter binary now rolls to existing hosts automatically.

### Why a fleet-wide canonical hash (over per-host or operator-binary)

- **Per-host hash** would have to exclude volatile fields (kubeconfig token, auth key) by hand or it re-pushes on every token rotation. Zeroing *all* per-host fields and computing one fleet-wide hash sidesteps that entirely — there are no per-host inputs left to churn.
- **Hashing the operator binary** would fire on every unrelated provider code change (controller bugfixes, base-image bumps), re-pushing for no host-config reason. Hashing the rendered scripts + pushed binaries is the right granularity.

`TartTarball` is deliberately excluded from the binary set: Tart is bootstrap-only (the hypervisor can't be swapped under running VMs, so `UpdateTartKubelet` never re-installs it); a Tart bump rolls via Machine replacement, not config drift.

## CRD registration (important)

The `ScalewayAppleSiliconMachine` CRD status schema is **structural** and enumerates its properties with no `x-kubernetes-preserve-unknown-fields`, so the API server **prunes** any status field not in the schema. The new `hostConfigHash` is therefore added to the checked-in CRD (`infra/helm/tuist/crds/...scalewayapplesiliconmachines.yaml`, auto-applied per-env by the deploy pipeline). Without it, `Status.HostConfigHash` would be silently dropped on write → read back empty every reconcile → `configDrift` stays true → the loop re-pushes the host config **on every reconcile**. (The helm CRD is a hand-maintained artifact — it carries chart labels beyond raw controller-gen output — so the field is added surgically rather than by a lossy raw regen.)

## Migration

Existing Machines have an empty `Status.HostConfigHash`, so the first reconcile after this operator image rolls out drifts once and re-pushes — the intended one-time migration. The re-push is zero-downtime: running Tart VMs survive `UpdateTartKubelet` (`nohup`-detached, re-bound by the kubelet's startup state recovery). Terminal-failed CRs stay excluded until `Status.FailureReason` is cleared.

## Validation

- Both Go modules (`macos-host-bootstrap`, `cluster-api-provider-scaleway-applesilicon`): `go build ./...`, `go vet ./...`, `gofmt -l .` (clean), `go test ./...` all pass.
- New `bootstrap` tests: hash is stable for the same config, **independent of per-host fields** (incl. `VMCachePNVLAN`, `DisableVMGC`), **changes** on a fleet-config field (CIDR/tags/accept-routes) and on any embedded-binary change.
- New controller test `TestHostConfigDrift` covers match / mismatch / the empty-machine-hash migration case / empty-operator-hash (never drifts).
- CRD YAML re-parsed: `status.properties.hostConfigHash` present as a string alongside `tartKubeletBinarySHA`.
- Verified the `render*` extraction is byte-faithful via `git diff` (only `script :=` assignments and `RunCommand*` wrappers moved; no heredoc body changed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)