### PR TITLE
feat(infra): notify Slack when previews finish deploying

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -1,4 +1,5 @@
 name: Preview Deploy
+run-name: "Preview ${{ inputs.action || github.event.action || 'deploy' }} ${{ inputs.slug || inputs.pr_number || inputs.commit_sha || github.event.pull_request.number || github.sha }}${{ inputs.preview_id && format(' #{0}', inputs.preview_id) || '' }}"
 
 # Deploy / refresh / tear down an ephemeral preview environment. Single
 # workflow behind every preview lifecycle in this repo — PR labels,
@@ -27,6 +28,7 @@ name: Preview Deploy
 #       ttl_hours       Auto-delete after N hours (max 168)
 #       requester_*     Audit metadata (Slack flow)
 #       reason          Audit reason (Slack flow)
+#       preview_id      tuist-ops preview row id (Slack flow)
 #
 # Naming convention:
 #   pr_number=1234   → slug=pr-1234, release=pr-1234,
@@ -80,6 +82,9 @@ on:
         required: false
       reason:
         description: Audit reason (Slack flow)
+        required: false
+      preview_id:
+        description: tuist-ops preview row id (Slack flow)
         required: false
   pull_request:
     types: [labeled, synchronize, unlabeled, closed]

--- a/infra/helm/tuist-ops/README.md
+++ b/infra/helm/tuist-ops/README.md
@@ -21,7 +21,7 @@ cross-call this deployment via the tailnet for the policy lookup.
 - **CNPG Cluster** — single-instance Postgres, 5Gi storage, daily
   backups to Tigris under `s3://tuist-prod-pg-backups/tuist-ops`.
 - **ExternalSecrets** — three of them:
-  - `tuist-ops-runtime` — Slack + Tailscale credentials from `TUIST_OPS_BOT`
+  - `tuist-ops-runtime` — Slack, Tailscale, and GitHub credentials from `TUIST_OPS_BOT`
   - `tuist-ops-app`     — `SECRET_KEY_BASE` from the same 1P item
   - `tuist-ops-backup-credentials` — Tigris keys from the shared `S3_BACKUP_CREDENTIALS`
 
@@ -30,6 +30,8 @@ cross-call this deployment via the tailnet for the policy lookup.
 1. **Create `TUIST_OPS_BOT` 1P item** in the production vault with fields:
    - `tailscale_client_id`, `tailscale_client_secret`, `tailscale_tailnet`
    - `slack_signing_secret`, `slack_bot_token`, `slack_approvals_channel_id`
+   - `github_actions_token` — GitHub token that can dispatch and read the
+     `preview-deploy.yml` workflow in `tuist/tuist`
    - `secret_key_base` — generate via `mix phx.gen.secret`
 2. **Update the Slack app**'s slash command URL to
    `https://ops.tuist.dev/webhooks/slack/slash` and the interactivity

--- a/infra/helm/tuist-ops/templates/externalsecret.yaml
+++ b/infra/helm/tuist-ops/templates/externalsecret.yaml
@@ -32,6 +32,7 @@ spec:
         SLACK_SIGNING_SECRET: "{{ `{{ .slack_signing_secret | trim }}` }}"
         SLACK_BOT_TOKEN: "{{ `{{ .slack_bot_token | trim }}` }}"
         SLACK_APPROVALS_CHANNEL_ID: "{{ `{{ .slack_approvals_channel_id | trim }}` }}"
+        GITHUB_ACTIONS_TOKEN: "{{ `{{ .github_actions_token | trim }}` }}"
         # Ed25519 PRIVATE key (PEM) that signs operator project-access
         # grants; the customer server holds only the matching public
         # key. Rotating this pair is the break-glass revocation for all

--- a/infra/helm/tuist-ops/values.yaml
+++ b/infra/helm/tuist-ops/values.yaml
@@ -109,7 +109,8 @@ service:
 # ESO ExternalSecret for the bot's credentials. Single 1P item per
 # Fields expected on TUIST_OPS_BOT:
 #   tailscale_client_id, tailscale_client_secret, tailscale_tailnet,
-#   slack_signing_secret, slack_bot_token, slack_approvals_channel_id
+#   slack_signing_secret, slack_bot_token, slack_approvals_channel_id,
+#   github_actions_token
 externalSecret:
   enabled: true
   refreshInterval: "1h"

--- a/tuist-ops/AGENTS.md
+++ b/tuist-ops/AGENTS.md
@@ -45,6 +45,9 @@ Pomerium).
   deleting previews
 - `/preview create <slug> [duration] [pr:<number>|sha:<sha>] <reason>` dispatches
   `.github/workflows/preview-deploy.yml` with `action=deploy`
+- `TuistOps.Previews.Workers.MonitorWorkflowWorker` polls the dispatched
+  workflow run and updates the original Slack card with the live preview URL
+  or the deployment failure
 - `/preview delete <slug> [reason]` and the Slack Delete button dispatch the same
   workflow with `action=delete`
 - The app records the Slack/audit trail in Postgres; Kubernetes mutation stays

--- a/tuist-ops/config/config.exs
+++ b/tuist-ops/config/config.exs
@@ -23,7 +23,7 @@ config :tuist_ops, TuistOpsWeb.Endpoint,
 
 config :tuist_ops, Oban,
   engine: Oban.Engines.Basic,
-  queues: [revert: 1],
+  queues: [revert: 1, preview_monitor: 1],
   repo: TuistOps.Repo
 
 # Bundle the operator UI (Noora + the dead-view hook loader) with esbuild.

--- a/tuist-ops/lib/tuist_ops/previews.ex
+++ b/tuist-ops/lib/tuist_ops/previews.ex
@@ -8,6 +8,7 @@ defmodule TuistOps.Previews do
   alias TuistOps.Previews.GitHubActionsClient
   alias TuistOps.Previews.Preview
   alias TuistOps.Previews.SlackBlocks
+  alias TuistOps.Previews.Workers.MonitorWorkflowWorker
   alias TuistOps.JIT.SlackClient
   alias TuistOps.Repo
 
@@ -120,11 +121,16 @@ defmodule TuistOps.Previews do
              render.(preview),
              fallback_text: fallback_text
            ),
-         {:ok, _workflow} <- dispatch.(preview),
+         {:ok, workflow} <- dispatch.(preview),
          {:ok, preview} <-
            preview
-           |> Preview.transition_changeset(Map.put(base_attrs, :slack_message_ts, ts))
+           |> Preview.transition_changeset(
+             base_attrs
+             |> Map.put(:slack_message_ts, ts)
+             |> Map.put(:workflow_run_name, workflow[:run_name])
+           )
            |> Repo.update() do
+      maybe_schedule_monitor(preview, workflow)
       {:ok, preview}
     else
       {:error, reason} ->
@@ -133,6 +139,22 @@ defmodule TuistOps.Previews do
         {:error, reason}
     end
   end
+
+  defp maybe_schedule_monitor(%Preview{status: "creating"} = preview, %{run_name: run_name})
+       when is_binary(run_name) do
+    case %{preview_id: preview.id, run_name: run_name}
+         |> MonitorWorkflowWorker.new(schedule_in: 30)
+         |> Oban.insert() do
+      {:ok, _job} ->
+        :ok
+
+      {:error, reason} ->
+        Logger.warning("preview: monitor schedule failed: #{inspect(reason)}")
+        :ok
+    end
+  end
+
+  defp maybe_schedule_monitor(_preview, _workflow), do: :ok
 
   defp mark_failed(%Preview{} = preview, reason) do
     failure_reason = reason |> inspect() |> String.slice(0, 500)
@@ -168,6 +190,7 @@ defmodule TuistOps.Previews do
     inputs =
       %{
         slug: preview.slug,
+        preview_id: Integer.to_string(preview.id),
         ttl_hours: Integer.to_string(ceil_hours(preview.ttl_seconds)),
         requester_email: preview.requester_email,
         requester_slack_id: preview.requester_slack_id,

--- a/tuist-ops/lib/tuist_ops/previews/github_actions_client.ex
+++ b/tuist-ops/lib/tuist_ops/previews/github_actions_client.ex
@@ -9,17 +9,45 @@ defmodule TuistOps.Previews.GitHubActionsClient do
     repo = Environment.github_repository()
     workflow_id = Environment.preview_workflow_id()
     ref = Environment.github_workflow_ref()
+    inputs = Map.put(inputs, :action, action)
+    run_name = workflow_run_name(action, inputs)
 
     url = "https://api.github.com/repos/#{repo}/actions/workflows/#{workflow_id}/dispatches"
 
     body = %{
       ref: ref,
-      inputs: Map.put(inputs, :action, action)
+      inputs: inputs
     }
 
     url
     |> Req.post(headers: headers(), body: JSON.encode!(body))
-    |> handle_dispatch(workflow_id, ref)
+    |> handle_dispatch(workflow_id, ref, run_name)
+  end
+
+  def workflow_run_name(action, inputs) when action in ["deploy", "delete"] and is_map(inputs) do
+    identifier =
+      Map.get(inputs, :slug) ||
+        Map.get(inputs, "slug") ||
+        Map.get(inputs, :pr_number) ||
+        Map.get(inputs, "pr_number") ||
+        Map.get(inputs, :commit_sha) ||
+        Map.get(inputs, "commit_sha")
+
+    preview_id = Map.get(inputs, :preview_id) || Map.get(inputs, "preview_id")
+
+    ["Preview", action, identifier, preview_id && "##{preview_id}"]
+    |> Enum.reject(&is_nil/1)
+    |> Enum.join(" ")
+  end
+
+  def workflow_run(run_name) when is_binary(run_name) do
+    repo = Environment.github_repository()
+    workflow_id = Environment.preview_workflow_id()
+    url = "https://api.github.com/repos/#{repo}/actions/workflows/#{workflow_id}/runs"
+
+    url
+    |> Req.get(headers: headers(), params: [event: "workflow_dispatch", per_page: 50])
+    |> handle_workflow_run(run_name)
   end
 
   defp headers do
@@ -31,16 +59,51 @@ defmodule TuistOps.Previews.GitHubActionsClient do
     ]
   end
 
-  defp handle_dispatch({:ok, %Req.Response{status: status}}, workflow_id, ref)
+  defp handle_dispatch({:ok, %Req.Response{status: status}}, workflow_id, ref, run_name)
        when status in 200..299 do
-    {:ok, %{workflow_id: workflow_id, workflow_ref: ref}}
+    {:ok, %{workflow_id: workflow_id, workflow_ref: ref, run_name: run_name}}
   end
 
-  defp handle_dispatch({:ok, %Req.Response{status: status, body: body}}, _workflow_id, _ref) do
+  defp handle_dispatch(
+         {:ok, %Req.Response{status: status, body: body}},
+         _workflow_id,
+         _ref,
+         _run_name
+       ) do
     {:error, {:github_status, status, body}}
   end
 
-  defp handle_dispatch({:error, reason}, _workflow_id, _ref) do
+  defp handle_dispatch({:error, reason}, _workflow_id, _ref, _run_name) do
+    {:error, {:github_error, reason}}
+  end
+
+  defp handle_workflow_run({:ok, %Req.Response{status: status, body: body}}, run_name)
+       when status in 200..299 do
+    run =
+      body
+      |> Map.get("workflow_runs", [])
+      |> Enum.find(&(Map.get(&1, "display_title") == run_name))
+
+    case run do
+      nil ->
+        {:error, :not_found}
+
+      run ->
+        {:ok,
+         %{
+           id: run["id"],
+           status: run["status"],
+           conclusion: run["conclusion"],
+           html_url: run["html_url"]
+         }}
+    end
+  end
+
+  defp handle_workflow_run({:ok, %Req.Response{status: status, body: body}}, _run_name) do
+    {:error, {:github_status, status, body}}
+  end
+
+  defp handle_workflow_run({:error, reason}, _run_name) do
     {:error, {:github_error, reason}}
   end
 end

--- a/tuist-ops/lib/tuist_ops/previews/preview.ex
+++ b/tuist-ops/lib/tuist_ops/previews/preview.ex
@@ -21,6 +21,8 @@ defmodule TuistOps.Previews.Preview do
     field :host, :string
     field :slack_channel_id, :string
     field :slack_message_ts, :string
+    field :workflow_run_name, :string
+    field :workflow_run_url, :string
     field :deleted_at, :utc_datetime
     field :failed_at, :utc_datetime
     field :failure_reason, :string
@@ -49,6 +51,8 @@ defmodule TuistOps.Previews.Preview do
       :host,
       :slack_channel_id,
       :slack_message_ts,
+      :workflow_run_name,
+      :workflow_run_url,
       :deleted_at,
       :failed_at,
       :failure_reason
@@ -76,6 +80,8 @@ defmodule TuistOps.Previews.Preview do
       :ttl_seconds,
       :slack_channel_id,
       :slack_message_ts,
+      :workflow_run_name,
+      :workflow_run_url,
       :deleted_at,
       :failed_at,
       :failure_reason

--- a/tuist-ops/lib/tuist_ops/previews/slack_blocks.ex
+++ b/tuist-ops/lib/tuist_ops/previews/slack_blocks.ex
@@ -168,6 +168,39 @@ defmodule TuistOps.Previews.SlackBlocks do
     ]
   end
 
+  def deployed(%Preview{} = preview) do
+    [
+      %{
+        type: "section",
+        text: %{
+          type: "mrkdwn",
+          text: """
+          *Preview deployed*
+          *Requester:* <@#{preview.requester_slack_id}>
+          *Preview:* `#{preview.slug}`
+          *URL:* <https://#{preview.host}|https://#{preview.host}>
+          *Ref:* #{format_ref(preview)}
+          *TTL:* #{format_seconds(preview.ttl_seconds)}
+          #{workflow_line(preview.workflow_run_url)}
+          """
+        }
+      },
+      %{
+        type: "actions",
+        block_id: "preview_actions",
+        elements: [
+          %{
+            type: "button",
+            style: "danger",
+            text: %{type: "plain_text", text: "Delete"},
+            action_id: "preview_delete",
+            value: preview.slug
+          }
+        ]
+      }
+    ]
+  end
+
   def failed(%Preview{} = preview, reason) do
     [
       %{
@@ -179,6 +212,7 @@ defmodule TuistOps.Previews.SlackBlocks do
           *Requester:* <@#{preview.requester_slack_id}>
           *Preview:* `#{preview.slug}`
           *Reason:* #{preview.reason}
+          #{workflow_line(preview.workflow_run_url)}
           *Error:* #{inspect(reason)}
           """
         }
@@ -215,6 +249,10 @@ defmodule TuistOps.Previews.SlackBlocks do
   end
 
   defp preview_expiration(%Preview{}), do: nil
+
+  defp workflow_line(nil), do: ""
+  defp workflow_line(""), do: ""
+  defp workflow_line(url), do: "*Workflow:* <#{url}|GitHub Actions run>"
 
   defp format_seconds(nil), do: "n/a"
   defp format_seconds(seconds) when seconds < 3600, do: "#{div(seconds, 60)} min"

--- a/tuist-ops/lib/tuist_ops/previews/workers/monitor_workflow_worker.ex
+++ b/tuist-ops/lib/tuist_ops/previews/workers/monitor_workflow_worker.ex
@@ -1,0 +1,108 @@
+defmodule TuistOps.Previews.Workers.MonitorWorkflowWorker do
+  @moduledoc """
+  Polls the GitHub Actions preview deploy run and updates the Slack card when it
+  reaches a terminal state.
+  """
+
+  use Oban.Worker,
+    queue: :preview_monitor,
+    unique: [
+      period: :infinity,
+      fields: [:args],
+      keys: [:preview_id, :run_name],
+      states: Oban.Job.states() -- [:completed, :discarded, :cancelled]
+    ],
+    max_attempts: 240
+
+  alias TuistOps.JIT.SlackClient
+  alias TuistOps.Previews.GitHubActionsClient
+  alias TuistOps.Previews.Preview
+  alias TuistOps.Previews.SlackBlocks
+  alias TuistOps.Repo
+
+  @poll_interval_seconds 30
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{args: %{"preview_id" => preview_id, "run_name" => run_name}}) do
+    case Repo.get(Preview, preview_id) do
+      nil ->
+        :ok
+
+      %Preview{workflow_run_name: ^run_name, status: "creating"} = preview ->
+        monitor(preview)
+
+      %Preview{} ->
+        :ok
+    end
+  end
+
+  defp monitor(%Preview{workflow_run_name: run_name} = preview) do
+    case GitHubActionsClient.workflow_run(run_name) do
+      {:ok, %{status: "completed", conclusion: "success"} = run} ->
+        mark_deployed(preview, run)
+
+      {:ok, %{status: "completed"} = run} ->
+        mark_failed(preview, run)
+
+      {:ok, _run} ->
+        {:snooze, @poll_interval_seconds}
+
+      {:error, :not_found} ->
+        {:snooze, @poll_interval_seconds}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp mark_deployed(%Preview{} = preview, run) do
+    workflow_run_url = run[:html_url]
+    slack_preview = %{preview | workflow_run_url: workflow_run_url}
+
+    :ok =
+      SlackClient.update_message(
+        preview.slack_channel_id,
+        preview.slack_message_ts,
+        SlackBlocks.deployed(slack_preview),
+        fallback_text: "Preview deployed"
+      )
+
+    preview
+    |> Preview.transition_changeset(%{
+      status: "active",
+      workflow_run_url: workflow_run_url
+    })
+    |> Repo.update()
+    |> case do
+      {:ok, _preview} -> :ok
+      {:error, changeset} -> {:error, changeset}
+    end
+  end
+
+  defp mark_failed(%Preview{} = preview, run) do
+    reason = {:workflow_failed, run[:conclusion] || "unknown"}
+    workflow_run_url = run[:html_url]
+    slack_preview = %{preview | workflow_run_url: workflow_run_url}
+
+    :ok =
+      SlackClient.update_message(
+        preview.slack_channel_id,
+        preview.slack_message_ts,
+        SlackBlocks.failed(slack_preview, reason),
+        fallback_text: "Preview request failed"
+      )
+
+    preview
+    |> Preview.transition_changeset(%{
+      status: "failed",
+      failed_at: DateTime.utc_now() |> DateTime.truncate(:second),
+      failure_reason: inspect(reason),
+      workflow_run_url: workflow_run_url
+    })
+    |> Repo.update()
+    |> case do
+      {:ok, _preview} -> :ok
+      {:error, changeset} -> {:error, changeset}
+    end
+  end
+end

--- a/tuist-ops/priv/repo/migrations/20260623103000_add_workflow_run_metadata_to_previews.exs
+++ b/tuist-ops/priv/repo/migrations/20260623103000_add_workflow_run_metadata_to_previews.exs
@@ -1,0 +1,10 @@
+defmodule TuistOps.Repo.Migrations.AddWorkflowRunMetadataToPreviews do
+  use Ecto.Migration
+
+  def change do
+    alter table(:previews) do
+      add :workflow_run_name, :string
+      add :workflow_run_url, :string
+    end
+  end
+end

--- a/tuist-ops/test/previews/github_actions_client_test.exs
+++ b/tuist-ops/test/previews/github_actions_client_test.exs
@@ -1,0 +1,62 @@
+defmodule TuistOps.Previews.GitHubActionsClientTest do
+  use ExUnit.Case, async: true
+  use Mimic
+
+  alias TuistOps.Environment
+  alias TuistOps.Previews.GitHubActionsClient
+
+  setup :verify_on_exit!
+
+  test "workflow_run_name matches the workflow run-name shape" do
+    assert GitHubActionsClient.workflow_run_name("deploy", %{
+             slug: "demo",
+             preview_id: "123"
+           }) == "Preview deploy demo #123"
+  end
+
+  test "workflow_run finds the matching workflow run by display title" do
+    stub(Environment, :github_repository, fn -> "tuist/tuist" end)
+    stub(Environment, :preview_workflow_id, fn -> "preview-deploy.yml" end)
+    stub(Environment, :github_actions_token, fn -> "token" end)
+
+    expect(
+      Req,
+      :get,
+      fn "https://api.github.com/repos/tuist/tuist/actions/workflows/preview-deploy.yml/runs",
+         opts ->
+        assert opts[:params] == [event: "workflow_dispatch", per_page: 50]
+
+        {:ok,
+         %Req.Response{
+           status: 200,
+           body: %{
+             "workflow_runs" => [
+               %{
+                 "display_title" => "Preview deploy other #122",
+                 "status" => "completed",
+                 "conclusion" => "success",
+                 "html_url" => "https://github.com/other",
+                 "id" => 122
+               },
+               %{
+                 "display_title" => "Preview deploy demo #123",
+                 "status" => "completed",
+                 "conclusion" => "success",
+                 "html_url" => "https://github.com/match",
+                 "id" => 123
+               }
+             ]
+           }
+         }}
+      end
+    )
+
+    assert {:ok,
+            %{
+              id: 123,
+              status: "completed",
+              conclusion: "success",
+              html_url: "https://github.com/match"
+            }} = GitHubActionsClient.workflow_run("Preview deploy demo #123")
+  end
+end

--- a/tuist-ops/test/previews/workers/monitor_workflow_worker_test.exs
+++ b/tuist-ops/test/previews/workers/monitor_workflow_worker_test.exs
@@ -1,0 +1,118 @@
+defmodule TuistOps.Previews.Workers.MonitorWorkflowWorkerTest do
+  use TuistOps.DataCase, async: true
+  use Mimic
+
+  alias TuistOps.JIT.SlackClient
+  alias TuistOps.Previews.GitHubActionsClient
+  alias TuistOps.Previews.Preview
+  alias TuistOps.Previews.Workers.MonitorWorkflowWorker
+
+  setup :verify_on_exit!
+
+  defp insert_preview!(overrides \\ %{}) do
+    attrs =
+      %{
+        slug: "demo",
+        status: "creating",
+        requester_email: "marek@tuist.dev",
+        requester_slack_id: "U_MAREK",
+        reason: "test branch with Kura",
+        ttl_seconds: 7200,
+        host: "demo.preview.tuist.dev",
+        slack_channel_id: "C_PREVIEWS",
+        slack_message_ts: "1710000000.000001",
+        workflow_run_name: "Preview deploy demo #1"
+      }
+      |> Map.merge(overrides)
+
+    attrs
+    |> Preview.create_changeset()
+    |> Repo.insert!()
+  end
+
+  defp perform(preview) do
+    %Oban.Job{args: %{"preview_id" => preview.id, "run_name" => preview.workflow_run_name}}
+    |> MonitorWorkflowWorker.perform()
+  end
+
+  test "snoozes while the workflow run is still in progress" do
+    preview = insert_preview!()
+
+    expect(GitHubActionsClient, :workflow_run, fn "Preview deploy demo #1" ->
+      {:ok, %{status: "in_progress", conclusion: nil, html_url: "https://github.com/run"}}
+    end)
+
+    assert {:snooze, 30} = perform(preview)
+  end
+
+  test "marks the preview active and updates Slack when the workflow succeeds" do
+    preview = insert_preview!()
+
+    expect(GitHubActionsClient, :workflow_run, fn "Preview deploy demo #1" ->
+      {:ok,
+       %{
+         status: "completed",
+         conclusion: "success",
+         html_url: "https://github.com/tuist/tuist/actions/runs/1"
+       }}
+    end)
+
+    expect(SlackClient, :update_message, fn "C_PREVIEWS", "1710000000.000001", blocks, opts ->
+      text = blocks |> List.first() |> get_in([:text, :text])
+
+      assert text =~ "Preview deployed"
+      assert text =~ "https://demo.preview.tuist.dev"
+      assert text =~ "https://github.com/tuist/tuist/actions/runs/1"
+      assert opts[:fallback_text] == "Preview deployed"
+
+      :ok
+    end)
+
+    assert :ok = perform(preview)
+
+    preview = Repo.reload!(preview)
+    assert preview.status == "active"
+    assert preview.workflow_run_url == "https://github.com/tuist/tuist/actions/runs/1"
+  end
+
+  test "marks the preview failed and updates Slack when the workflow fails" do
+    preview = insert_preview!()
+
+    expect(GitHubActionsClient, :workflow_run, fn "Preview deploy demo #1" ->
+      {:ok,
+       %{
+         status: "completed",
+         conclusion: "failure",
+         html_url: "https://github.com/tuist/tuist/actions/runs/2"
+       }}
+    end)
+
+    expect(SlackClient, :update_message, fn "C_PREVIEWS", "1710000000.000001", blocks, opts ->
+      text = blocks |> List.first() |> get_in([:text, :text])
+
+      assert text =~ "Preview request failed"
+      assert text =~ "workflow_failed"
+      assert text =~ "https://github.com/tuist/tuist/actions/runs/2"
+      assert opts[:fallback_text] == "Preview request failed"
+
+      :ok
+    end)
+
+    assert :ok = perform(preview)
+
+    preview = Repo.reload!(preview)
+    assert preview.status == "failed"
+    assert preview.failure_reason == ~s({:workflow_failed, "failure"})
+    assert preview.workflow_run_url == "https://github.com/tuist/tuist/actions/runs/2"
+  end
+
+  test "ignores stale jobs for previews that no longer match the workflow run name" do
+    preview = insert_preview!(%{workflow_run_name: "Preview deploy demo #2"})
+
+    assert :ok =
+             %Oban.Job{
+               args: %{"preview_id" => preview.id, "run_name" => "Preview deploy demo #1"}
+             }
+             |> MonitorWorkflowWorker.perform()
+  end
+end

--- a/tuist-ops/test/previews_test.exs
+++ b/tuist-ops/test/previews_test.exs
@@ -1,0 +1,48 @@
+defmodule TuistOps.PreviewsTest do
+  use TuistOps.DataCase, async: true
+  use Mimic
+
+  alias TuistOps.JIT.SlackClient
+  alias TuistOps.Previews
+  alias TuistOps.Previews.GitHubActionsClient
+  alias TuistOps.Previews.Workers.MonitorWorkflowWorker
+
+  setup :verify_on_exit!
+
+  describe "create/1" do
+    test "dispatches the preview workflow with the preview id and schedules monitoring" do
+      stub(SlackClient, :post_message, fn "C_PREVIEWS", _blocks, _opts ->
+        {:ok, "1710000000.000001"}
+      end)
+
+      expect(GitHubActionsClient, :dispatch, fn "deploy", inputs ->
+        assert inputs.slug == "demo"
+        assert inputs.preview_id =~ ~r/^\d+$/
+
+        {:ok, %{run_name: "Preview deploy demo ##{inputs.preview_id}"}}
+      end)
+
+      assert {:ok, preview} =
+               Previews.create(%{
+                 slug: "demo",
+                 requester_email: "marek@tuist.dev",
+                 requester_slack_id: "U_MAREK",
+                 slack_channel_id: "C_PREVIEWS",
+                 reason: "test branch with Kura"
+               })
+
+      assert preview.workflow_run_name == "Preview deploy demo ##{preview.id}"
+
+      job =
+        Repo.one!(
+          from job in Oban.Job,
+            where: job.worker == ^inspect(MonitorWorkflowWorker)
+        )
+
+      assert job.args == %{
+               "preview_id" => preview.id,
+               "run_name" => preview.workflow_run_name
+             }
+    end
+  end
+end


### PR DESCRIPTION
## What changed

This wires the Slack-requested preview flow all the way through to a final Slack update.

- Exposes `github_actions_token` from the `TUIST_OPS_BOT` 1Password item as `GITHUB_ACTIONS_TOKEN` in the `tuist-ops` runtime secret.
- Adds a `preview_id` input and stable run name to `preview-deploy.yml`, so `tuist-ops` can find the workflow run it just dispatched.
- Stores workflow run metadata on preview rows and adds a `preview_monitor` Oban queue with a worker that polls GitHub Actions.
- Updates the original Slack preview card when deployment succeeds, including the live preview link and the GitHub Actions run link. Failed workflow runs update the card with the failure state.
- Covers the dispatch, run lookup, monitor worker, and preview enqueue path with focused tests.

## Why

The `/preview` Slack form was reaching `tuist-ops`, but the GitHub workflow dispatch failed with `401 Bad credentials`. Even after fixing that token path, the Slack message would still stay in the provisioning state because GitHub workflow dispatch does not hand back a run identifier.

## Root cause

`tuist-ops` already read `GITHUB_ACTIONS_TOKEN`, but the Helm chart did not project any 1Password field into that environment variable. The app also had no durable way to connect a Slack preview request to the asynchronously created GitHub Actions run.

## Approach

The GitHub token stays with `tuist-ops`, and Slack credentials stay out of GitHub Actions. `tuist-ops` tags each dispatched workflow with the preview row id, then a background worker polls the workflow run list by that stable run name and updates the existing Slack card when the run completes.

This keeps the completion notification close to the original Slack request and avoids introducing another Slack secret into the GitHub repository environment.

## Impact

After this deploy, the `github_actions_token` field you added to `TUIST_OPS_BOT` will be synced into the running pod, so `/preview` can dispatch `preview-deploy.yml`. Slack-requested previews will then move from requested to deployed or failed in the same Slack card.

The database migration adds nullable workflow metadata columns to the internal `previews` table only.

## Validation

- `helm template tuist-ops infra/helm/tuist-ops --set image.tag=test`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/preview-deploy.yml"); puts "workflow yaml ok"'`
- `mix test test/previews_test.exs test/previews/github_actions_client_test.exs test/previews/workers/monitor_workflow_worker_test.exs test/tuist_ops_web/controllers/slack_controller_test.exs test/previews/slack_blocks_test.exs`
- `mix test`
- `git diff --check`
