### PR TITLE
fix(infra): source Google OAuth from 1Password via ESO

### DIFF
--- a/infra/helm/tuist/templates/_helpers.tpl
+++ b/infra/helm/tuist/templates/_helpers.tpl
@@ -497,13 +497,6 @@ License env vars. Resolves to (in order):
 {{- end }}
 {{- end -}}
 
-{{/*
-Google OAuth client env vars, sourced from the google-external-secrets ESO
-Secret. Marked optional so the server still boots while an env's 1P vault is
-being populated during the blob→1P migration: a missing key leaves the env
-var unset and Tuist.Environment falls back to the encrypted priv/secrets blob
-(or simply hides the Google button where the blob has no entry either).
-*/}}
 {{- define "tuist.googleEnv" -}}
 {{- if and .Values.server.enabled .Values.server.google.managedSecrets }}
 {{- $secret := include "tuist.componentName" (dict "root" . "component" "google-external-secrets") -}}
@@ -512,12 +505,10 @@ var unset and Tuist.Environment falls back to the encrypted priv/secrets blob
     secretKeyRef:
       name: {{ $secret | quote }}
       key: oauth-client-id
-      optional: true
 - name: TUIST_GOOGLE_OAUTH_CLIENT_SECRET
   valueFrom:
     secretKeyRef:
       name: {{ $secret | quote }}
       key: oauth-client-secret
-      optional: true
 {{- end }}
 {{- end -}}

--- a/infra/helm/tuist/templates/_helpers.tpl
+++ b/infra/helm/tuist/templates/_helpers.tpl
@@ -496,3 +496,28 @@ License env vars. Resolves to (in order):
       key: token-update-packages
 {{- end }}
 {{- end -}}
+
+{{/*
+Google OAuth client env vars, sourced from the google-external-secrets ESO
+Secret. Marked optional so the server still boots while an env's 1P vault is
+being populated during the blob→1P migration: a missing key leaves the env
+var unset and Tuist.Environment falls back to the encrypted priv/secrets blob
+(or simply hides the Google button where the blob has no entry either).
+*/}}
+{{- define "tuist.googleEnv" -}}
+{{- if and .Values.server.enabled .Values.server.google.managedSecrets }}
+{{- $secret := include "tuist.componentName" (dict "root" . "component" "google-external-secrets") -}}
+- name: TUIST_GOOGLE_OAUTH_CLIENT_ID
+  valueFrom:
+    secretKeyRef:
+      name: {{ $secret | quote }}
+      key: oauth-client-id
+      optional: true
+- name: TUIST_GOOGLE_OAUTH_CLIENT_SECRET
+  valueFrom:
+    secretKeyRef:
+      name: {{ $secret | quote }}
+      key: oauth-client-secret
+      optional: true
+{{- end }}
+{{- end -}}

--- a/infra/helm/tuist/templates/google-external-secrets.yaml
+++ b/infra/helm/tuist/templates/google-external-secrets.yaml
@@ -1,0 +1,44 @@
+{{- if and .Values.server.enabled .Values.server.google.managedSecrets }}
+# Syncs the Google OAuth client credentials from 1Password into a dedicated
+# k8s Secret managed by ESO. The Server Deployment references this Secret as
+# env vars (TUIST_GOOGLE_OAUTH_CLIENT_ID / TUIST_GOOGLE_OAUTH_CLIENT_SECRET),
+# which Tuist.Environment reads before falling back to the encrypted
+# priv/secrets blob. Wiring these makes the "Log in with Google" button
+# appear (Environment.google_oauth_configured?/0).
+#
+# Item layout in 1Password (per-env vault):
+#   GOOGLE_OAUTH    ← multi-field
+#     client_id, client_secret
+#
+# A separate Secret (not a Merge into app-secrets) is used on purpose: helm
+# upgrade rewrites chart-managed resources, which would wipe ESO-managed keys
+# on each deploy until the next ESO reconcile cycle.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ include "tuist.componentName" (dict "root" . "component" "google-external-secrets") }}
+  labels:
+    {{- include "tuist.labels" . | nindent 4 }}
+spec:
+  refreshInterval: {{ .Values.server.google.externalSecrets.refreshInterval | default "1h" }}
+  secretStoreRef:
+    name: {{ .Values.server.google.externalSecrets.storeRef.name | default "onepassword" }}
+    kind: {{ .Values.server.google.externalSecrets.storeRef.kind | default "ClusterSecretStore" }}
+  target:
+    name: {{ include "tuist.componentName" (dict "root" . "component" "google-external-secrets") }}
+    creationPolicy: Owner
+    # Strip trailing whitespace — the 1P web UI appends a newline when pasting,
+    # and the OAuth client secret rejects the trailing \n at use time (401).
+    template:
+      engineVersion: v2
+      data:
+        oauth-client-id: "{{ `{{ .oauth_client_id | trim }}` }}"
+        oauth-client-secret: "{{ `{{ .oauth_client_secret | trim }}` }}"
+  data:
+    - secretKey: oauth_client_id
+      remoteRef:
+        key: "{{ .Values.server.google.externalSecrets.oauth.item | default "GOOGLE_OAUTH" }}/{{ .Values.server.google.externalSecrets.oauth.fields.clientId | default "client_id" }}"
+    - secretKey: oauth_client_secret
+      remoteRef:
+        key: "{{ .Values.server.google.externalSecrets.oauth.item | default "GOOGLE_OAUTH" }}/{{ .Values.server.google.externalSecrets.oauth.fields.clientSecret | default "client_secret" }}"
+{{- end }}

--- a/infra/helm/tuist/templates/server-deployment.yaml
+++ b/infra/helm/tuist/templates/server-deployment.yaml
@@ -228,6 +228,7 @@ spec:
             {{- include "tuist.licenseEnv" . | nindent 12 }}
             {{- include "tuist.kuraIntrospectionEnv" . | nindent 12 }}
             {{- include "tuist.githubEnv" . | nindent 12 }}
+            {{- include "tuist.googleEnv" . | nindent 12 }}
             {{- if or .Values.server.masterKey .Values.server.managedSecrets }}
             - name: MASTER_KEY
               valueFrom:

--- a/infra/helm/tuist/values-managed-common.yaml
+++ b/infra/helm/tuist/values-managed-common.yaml
@@ -97,9 +97,7 @@ server:
   # ESO-synced Google OAuth client credentials, replacing the google entry in
   # the encrypted priv/secrets blob (the gradual move of OAuth secrets into
   # 1Password, following GitHub). Each env reads GOOGLE_OAUTH (fields
-  # client_id / client_secret) from its tuist-k8s-<env> vault; the env refs
-  # are optional so a not-yet-populated vault degrades to a hidden Google
-  # button instead of crash-looping.
+  # client_id / client_secret) from its tuist-k8s-<env> vault.
   google:
     managedSecrets: true
 

--- a/infra/helm/tuist/values-managed-common.yaml
+++ b/infra/helm/tuist/values-managed-common.yaml
@@ -94,6 +94,15 @@ server:
   github:
     managedSecrets: true
 
+  # ESO-synced Google OAuth client credentials, replacing the google entry in
+  # the encrypted priv/secrets blob (the gradual move of OAuth secrets into
+  # 1Password, following GitHub). Each env reads GOOGLE_OAUTH (fields
+  # client_id / client_secret) from its tuist-k8s-<env> vault; the env refs
+  # are optional so a not-yet-populated vault degrades to a hidden Google
+  # button instead of crash-looping.
+  google:
+    managedSecrets: true
+
   database:
     ssl: true
 

--- a/infra/helm/tuist/values.yaml
+++ b/infra/helm/tuist/values.yaml
@@ -206,6 +206,25 @@ server:
       tokenUpdatePackages:
         item: GITHUB_TOKEN_UPDATE_PACKAGES
         field: password
+  # Google OAuth client credentials. When `google.managedSecrets: true`, ESO
+  # syncs them from 1Password into a dedicated Secret and the Server
+  # Deployment mounts them as TUIST_GOOGLE_OAUTH_CLIENT_ID /
+  # TUIST_GOOGLE_OAUTH_CLIENT_SECRET env vars, which enable the "Log in with
+  # Google" button. The env refs are optional so a not-yet-populated vault
+  # falls back to the encrypted priv/secrets blob instead of crash-looping.
+  google:
+    managedSecrets: false
+    externalSecrets:
+      refreshInterval: "1h"
+      storeRef:
+        kind: ClusterSecretStore
+        name: onepassword
+      oauth:
+        # The single 1P item carrying the OAuth client credentials.
+        item: GOOGLE_OAUTH
+        fields:
+          clientId: client_id
+          clientSecret: client_secret
   license:
     key: ""
     certificateBase64: ""

--- a/infra/helm/tuist/values.yaml
+++ b/infra/helm/tuist/values.yaml
@@ -210,8 +210,9 @@ server:
   # syncs them from 1Password into a dedicated Secret and the Server
   # Deployment mounts them as TUIST_GOOGLE_OAUTH_CLIENT_ID /
   # TUIST_GOOGLE_OAUTH_CLIENT_SECRET env vars, which enable the "Log in with
-  # Google" button. The env refs are optional so a not-yet-populated vault
-  # falls back to the encrypted priv/secrets blob instead of crash-looping.
+  # Google" button. Leave managedSecrets false (the default) for self-hosted
+  # installs that don't use Google sign-in — no Secret or env refs are then
+  # rendered.
   google:
     managedSecrets: false
     externalSecrets:


### PR DESCRIPTION
## What changed

Wires the Google OAuth client credentials (`TUIST_GOOGLE_OAUTH_CLIENT_ID` / `TUIST_GOOGLE_OAUTH_CLIENT_SECRET`) through External Secrets Operator from 1Password for all managed environments, the same way the GitHub App credentials already are.

- New `templates/google-external-secrets.yaml` — an `ExternalSecret` syncing `GOOGLE_OAUTH/client_id` and `GOOGLE_OAUTH/client_secret` from each cluster's `tuist-k8s-<env>` 1P vault into a dedicated Secret.
- New `tuist.googleEnv` helper in `_helpers.tpl`, included on the **server** Deployment only (the processors don't render the login page or handle the OAuth callback).
- `server.google` schema in `values.yaml`, default `managedSecrets: false`.
- Enabled for all managed envs via `values-managed-common.yaml`.

## Why

The "Log in with Google" button was missing on **canary** only. The button is gated on `Environment.google_oauth_configured?/0`, which is true only when both `TUIST_GOOGLE_OAUTH_*` resolve. Those values are read from the encrypted `priv/secrets/<env>.yml.enc` blob, and production + staging carry a `google:` block in theirs while `can.yml.enc` never did, so canary alone hid the button. Verified against the live login pages: prod and staging show Google, canary does not.

## Root cause

A per-env secrets gap, not a code bug. The gating function and its env-var/secret resolution have been unchanged since the server entered the monorepo, and `Environment.get/3` reads the `TUIST_*` env var before the decrypted blob — so injecting the env var via ESO is sufficient to surface the button.

## Why this approach over patching the blob

Patching `can.yml.enc` would fix canary but keep Google credentials in the mix-secrets blob. Sourcing them from 1Password instead both fixes canary and continues the ongoing migration of OAuth secrets out of the blob (GitHub already lives in 1P). Because the env var takes precedence over the blob, each env transparently switches to 1P as its vault is populated.

## Notable decisions

- **Enabled in `values-managed-common.yaml`** (all managed envs) rather than canary-only, since the goal is to move Google fully off the blob.
- **Hard-required secret refs (not `optional`), matching the GitHub pattern.** The two cases a lenient ref would cover are handled elsewhere: a self-hosted install that doesn't use Google leaves `managedSecrets` at its `false` default, so no Secret or env refs are rendered at all; and every managed env's vault already carries the `GOOGLE_OAUTH` item, so there's no not-yet-populated gap at deploy time. Failing loud on a missing/unsynced secret is consistent with how the GitHub App credentials behave in the same helper.

## Validation

`helm template` across `values-managed-{canary,staging,production}.yaml`: each renders the `ExternalSecret` and both env refs. The chart is inert (no resources, no env refs) when `server.google.managedSecrets` is false — confirmed against the default `values.yaml`.

## Rollout (manual, per env)

1. Create a `GOOGLE_OAUTH` item (fields `client_id`, `client_secret`) in each `tuist-k8s-<env>` 1P vault. For staging/production, copy the values already in their blob so their existing registered redirect URIs keep working. **Done for all three envs.**
2. For canary, register the new client's redirect URI `https://canary.tuist.dev/users/auth/google/callback` in Google Cloud Console.
3. Deploy. ESO syncs the Secret and the pods roll with the env vars; if a vault is populated after deploy, `kubectl rollout restart deploy/tuist-tuist-server -n <ns>` to pick it up.
4. Once verified, drop the now-dead `google:` block from each env's encrypted blob (`mix secrets.edit --env <env>`).

Draft until the canary redirect URI is confirmed in place and the chart change is verified on a managed env.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
