### PR TITLE
feat(infra): re-emit abnormal runner death logs before the reap

### DIFF
--- a/infra/helm/tuist/templates/runners-controller-deployment.yaml
+++ b/infra/helm/tuist/templates/runners-controller-deployment.yaml
@@ -120,6 +120,12 @@ rules:
     resources: [pods]
     verbs: [get, list, watch, create, patch, delete]
   - apiGroups: [""]
+    # Read a terminated runner's container log to re-emit its final
+    # RUNNER_VITALS/_diag trail to the controller's own durable stdout
+    # before the reap deletes the Pod (mid-job death forensics).
+    resources: [pods/log]
+    verbs: [get]
+  - apiGroups: [""]
     # Sibling SAs of each Pod; created and deleted alongside, never
     # patched.
     resources: [serviceaccounts]

--- a/infra/runners-controller/AGENTS.md
+++ b/infra/runners-controller/AGENTS.md
@@ -311,6 +311,20 @@ customer job's runtime. macOS keeps the single-container shape (the
 Tart VM is the isolation boundary; tart-kubelet projects the token
 into it).
 
+**Death-cause backstop:** the same reconciler also re-emits a
+runner's final log on an abnormal end — a non-zero/SIGKILLed exit, or
+a Pod reaped while still `Running` (the "lost communication" /
+torn-down-microVM shape). It reads the `runner` container's tail via
+`pods/log` and logs it to the controller's own (durable, long-lived)
+stdout before the reap. Without this the trail (the `RUNNER_VITALS`
+samples from `vitals.sh` + the streamed `_diag`) lives only in the
+kubelet container log, which is GC'd the instant the Pod is deleted —
+and `alloy` doesn't reliably win that race on a churning node, so
+mid-job deaths otherwise leave nothing in Loki. A clean exit 0 (job
+done, or no JIT claimed — and note a workflow that fails its own tests
+still exits the runner 0) is skipped, so this fires only for runner
+*infrastructure* deaths, not job outcomes.
+
 **Rollout ordering:** ship the runner image carrying `run-job.sh`
 + the poller-mode `dispatch-poll.sh` (and pin
 `runnersFleetLinux.pools[].runnerImage` to it) **before** the

--- a/infra/runners-controller/cmd/manager/main.go
+++ b/infra/runners-controller/cmd/manager/main.go
@@ -14,6 +14,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
@@ -146,10 +147,20 @@ func main() {
 	// keeps its max-lifetime safety clamp, which bounds the
 	// over-bill while we get the controller plumbed in.
 	if sessionsURL != "" {
+		// Typed clientset for the `pods/log` subresource: the cached
+		// controller-runtime client can't read container logs, and the
+		// PodLifecycle reconciler re-emits an abnormally-ended runner's
+		// log before the reap deletes it.
+		clientset, err := kubernetes.NewForConfig(cfg)
+		if err != nil {
+			setupLog.Error(err, "build clientset for log capture")
+			os.Exit(1)
+		}
 		if err := (&controllers.PodLifecycleReconciler{
 			Client:         mgr.GetClient(),
 			Scheme:         mgr.GetScheme(),
 			SessionsClient: sessions.NewClient(sessionsURL),
+			Logs:           clientset,
 		}).SetupWithManager(mgr); err != nil {
 			setupLog.Error(err, "setup PodLifecycle reconciler")
 			os.Exit(1)

--- a/infra/runners-controller/controllers/pod_lifecycle_controller.go
+++ b/infra/runners-controller/controllers/pod_lifecycle_controller.go
@@ -2,18 +2,31 @@ package controllers
 
 import (
 	"context"
+	"io"
 	"sync"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/tuist/tuist/infra/runners-controller/internal/sessions"
+)
+
+const (
+	// deathLogTailLines / deathLogLimitBytes bound how much of an
+	// abnormally-ended runner's log we re-emit. The runner container is
+	// otherwise quiet (job output goes to GitHub server-side), so its
+	// stdout is just the periodic RUNNER_VITALS samples plus the _diag
+	// tail — a couple hundred lines covers the run-up to a death without
+	// flooding the controller's own log stream.
+	deathLogTailLines  = 200
+	deathLogLimitBytes = 64 * 1024
 )
 
 // PodLifecycleReconciler watches runner Pods and reports
@@ -42,6 +55,17 @@ type PodLifecycleReconciler struct {
 	// reaching for in-cluster machinery.
 	SessionsClient *sessions.Client
 
+	// Logs reads runner container logs via the `pods/log` subresource
+	// (which the controller-runtime client.Client can't serve). When a
+	// runner Pod ends abnormally, its final RUNNER_VITALS/_diag trail
+	// lives only in the kubelet's container log, which is GC'd the
+	// moment the reap deletes the Pod — and alloy doesn't reliably win
+	// that race on a churning node, so mid-job deaths leave nothing in
+	// Loki. This re-emits that tail to the controller's own (durable,
+	// long-lived) stdout before the reap. nil disables capture; the
+	// billing path still runs.
+	Logs kubernetes.Interface
+
 	// Now defaults to time.Now; overridable for deterministic
 	// fallback-timestamp tests when the Pod carries no
 	// finishedAt / deletionTimestamp.
@@ -55,9 +79,16 @@ type PodLifecycleReconciler struct {
 	// we'll re-emit on the next reconcile; the server's
 	// idempotency + under-bill bias makes that safe.
 	reported sync.Map
+
+	// captured tracks pod_names whose death log we've already
+	// re-emitted, so repeated reconciles for the same terminal Pod
+	// don't duplicate the trail. Same churn-bounded lifetime as
+	// `reported`.
+	captured sync.Map
 }
 
 // +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=pods/log,verbs=get
 
 func (r *PodLifecycleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := log.FromContext(ctx).WithValues("pod", req.NamespacedName)
@@ -82,6 +113,12 @@ func (r *PodLifecycleReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	if !isEnding(pod) {
 		return ctrl.Result{}, nil
 	}
+
+	// Forensics backstop, independent of and ahead of the billing
+	// dedup below: re-emit an abnormally-ended runner's final log to
+	// the controller's own durable stdout before the reap deletes the
+	// Pod. Best-effort — never fails or requeues the reconcile.
+	r.captureDeathLog(ctx, pod)
 
 	key := req.NamespacedName.String()
 	if _, already := r.reported.Load(key); already {
@@ -159,6 +196,92 @@ func (r *PodLifecycleReconciler) now() time.Time {
 		return r.Now()
 	}
 	return time.Now()
+}
+
+// captureDeathLog re-emits an abnormally-ended runner's container log
+// to the controller's own stdout, so the final RUNNER_VITALS/_diag
+// trail survives the reap that deletes the Pod (and the kubelet log
+// with it). Best-effort: a disabled capturer, a healthy exit, an
+// already-captured Pod, or an unreadable log all return without
+// touching the billing path or requeueing.
+func (r *PodLifecycleReconciler) captureDeathLog(ctx context.Context, pod *corev1.Pod) {
+	if r.Logs == nil || !abnormalEnd(pod) {
+		return
+	}
+	key := pod.Namespace + "/" + pod.Name
+	if _, seen := r.captured.Load(key); seen {
+		return
+	}
+
+	logger := log.FromContext(ctx)
+	tail, err := r.fetchRunnerLog(ctx, pod.Namespace, pod.Name)
+	if err != nil {
+		// Leave unmarked so a later event (e.g. the deletion) retries
+		// while the kubelet log still exists. A persistent failure just
+		// means the trail was already gone — nothing we can recover.
+		logger.V(1).Info("capture runner death log failed", "pod", pod.Name, "err", err)
+		return
+	}
+
+	// Mark captured even when empty so an irrecoverable (never-written
+	// or already-reaped) log isn't re-fetched on every reconcile.
+	r.captured.Store(key, struct{}{})
+	if tail == "" {
+		return
+	}
+	logger.Info("runner death log captured",
+		"pod", pod.Name,
+		"pool", pod.Labels["tuist.dev/runner-pool"],
+		"endedAt", r.endedAt(pod),
+		"deathLog", tail,
+	)
+}
+
+// fetchRunnerLog returns the tail of the `runner` container's log,
+// bounded by line count and bytes so a runaway log can't flood the
+// controller's stream.
+func (r *PodLifecycleReconciler) fetchRunnerLog(ctx context.Context, namespace, name string) (string, error) {
+	tail := int64(deathLogTailLines)
+	limit := int64(deathLogLimitBytes)
+	req := r.Logs.CoreV1().Pods(namespace).GetLogs(name, &corev1.PodLogOptions{
+		Container:  "runner",
+		TailLines:  &tail,
+		LimitBytes: &limit,
+	})
+	stream, err := req.Stream(ctx)
+	if err != nil {
+		return "", err
+	}
+	defer stream.Close()
+	body, err := io.ReadAll(stream)
+	if err != nil {
+		return "", err
+	}
+	return string(body), nil
+}
+
+// abnormalEnd reports whether the runner container ended in a way
+// worth preserving its log for. A clean ephemeral run exits 0 (job
+// done, or no JIT claimed) and is skipped — note a workflow that fails
+// its own tests still exits the runner 0, so this targets runner
+// *infrastructure* deaths, not job outcomes. A non-zero/secondary-
+// killed exit, or a Pod reaped while the runner never recorded a clean
+// exit (the "lost communication" / torn-down-microVM shape), is
+// abnormal.
+func abnormalEnd(pod *corev1.Pod) bool {
+	if rs := runnerContainerStatus(pod); rs != nil && rs.State.Terminated != nil {
+		return rs.State.Terminated.ExitCode != 0
+	}
+	return pod.Status.Phase == corev1.PodFailed || !pod.DeletionTimestamp.IsZero()
+}
+
+func runnerContainerStatus(pod *corev1.Pod) *corev1.ContainerStatus {
+	for i := range pod.Status.ContainerStatuses {
+		if pod.Status.ContainerStatuses[i].Name == "runner" {
+			return &pod.Status.ContainerStatuses[i]
+		}
+	}
+	return nil
 }
 
 func (r *PodLifecycleReconciler) SetupWithManager(mgr ctrl.Manager) error {

--- a/infra/runners-controller/controllers/pod_lifecycle_controller_test.go
+++ b/infra/runners-controller/controllers/pod_lifecycle_controller_test.go
@@ -14,6 +14,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -204,6 +205,115 @@ func TestPodLifecycle_FallsBackToDeletionTimestamp(t *testing.T) {
 	}
 	if !reqs[0].EndedAt.Equal(deletion) {
 		t.Errorf("ended_at = %v, want deletionTimestamp %v", reqs[0].EndedAt, deletion)
+	}
+}
+
+func runnerPodExit(name string, exitCode int32, phase corev1.PodPhase) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "tuist-runners",
+			Labels:    map[string]string{"tuist.dev/runner": "true"},
+		},
+		Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "runner"}}},
+		Status: corev1.PodStatus{
+			Phase: phase,
+			ContainerStatuses: []corev1.ContainerStatus{{
+				Name: "runner",
+				State: corev1.ContainerState{
+					Terminated: &corev1.ContainerStateTerminated{
+						ExitCode:   exitCode,
+						FinishedAt: metav1.NewTime(time.Date(2026, 6, 23, 9, 37, 0, 0, time.UTC)),
+					},
+				},
+			}},
+		},
+	}
+}
+
+func podLogGets(cs *k8sfake.Clientset) int {
+	n := 0
+	for _, a := range cs.Actions() {
+		if a.GetVerb() == "get" && a.GetResource().Resource == "pods" && a.GetSubresource() == "log" {
+			n++
+		}
+	}
+	return n
+}
+
+func TestAbnormalEnd(t *testing.T) {
+	deleting := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{DeletionTimestamp: &metav1.Time{Time: time.Now()}},
+		Status:     corev1.PodStatus{Phase: corev1.PodRunning},
+	}
+	tests := []struct {
+		name string
+		pod  *corev1.Pod
+		want bool
+	}{
+		{"clean exit 0", runnerPodExit("p", 0, corev1.PodSucceeded), false},
+		{"non-zero exit", runnerPodExit("p", 1, corev1.PodFailed), true},
+		{"sigkilled microVM teardown", runnerPodExit("p", 137, corev1.PodFailed), true},
+		{"reaped while running (lost comm)", deleting, true},
+		{"alive, not ending", &corev1.Pod{Status: corev1.PodStatus{Phase: corev1.PodRunning}}, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := abnormalEnd(tc.pod); got != tc.want {
+				t.Errorf("abnormalEnd = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPodLifecycle_CapturesDeathLogOnAbnormalExit(t *testing.T) {
+	pod := runnerPodExit("tuist-pod-dead", 137, corev1.PodFailed)
+
+	r, _, stop := newReconciler(t, []*corev1.Pod{pod})
+	defer stop()
+	cs := k8sfake.NewSimpleClientset(pod)
+	r.Logs = cs
+
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: nn("tuist-runners", "tuist-pod-dead")}); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	if got := podLogGets(cs); got != 1 {
+		t.Fatalf("pods/log gets = %d, want 1", got)
+	}
+}
+
+func TestPodLifecycle_NoCaptureOnCleanExit(t *testing.T) {
+	pod := runnerPodExit("tuist-pod-clean", 0, corev1.PodSucceeded)
+
+	r, _, stop := newReconciler(t, []*corev1.Pod{pod})
+	defer stop()
+	cs := k8sfake.NewSimpleClientset(pod)
+	r.Logs = cs
+
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: nn("tuist-runners", "tuist-pod-clean")}); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	if got := podLogGets(cs); got != 0 {
+		t.Fatalf("pods/log gets = %d, want 0 (clean exit)", got)
+	}
+}
+
+func TestPodLifecycle_DeduplicatesDeathLogCapture(t *testing.T) {
+	pod := runnerPodExit("tuist-pod-dead-dup", 1, corev1.PodFailed)
+
+	r, _, stop := newReconciler(t, []*corev1.Pod{pod})
+	defer stop()
+	cs := k8sfake.NewSimpleClientset(pod)
+	r.Logs = cs
+
+	req := ctrl.Request{NamespacedName: nn("tuist-runners", "tuist-pod-dead-dup")}
+	for i := 0; i < 2; i++ {
+		if _, err := r.Reconcile(context.Background(), req); err != nil {
+			t.Fatalf("Reconcile %d: %v", i, err)
+		}
+	}
+	if got := podLogGets(cs); got != 1 {
+		t.Errorf("pods/log gets = %d, want 1 (second reconcile should dedupe)", got)
 	}
 }
 


### PR DESCRIPTION
> Make mid-job Linux runner deaths diagnosable.

## What changed

When a runner Pod ends abnormally, the `pod-lifecycle` reconciler now reads the `runner` container's log tail via `pods/log` and re-emits it to the controller's own stdout (`"runner death log captured"`, tagged with pod/pool/endedAt), so the trail survives the reap that deletes the Pod.

- `infra/runners-controller/controllers/pod_lifecycle_controller.go` — capture logic (`captureDeathLog` / `fetchRunnerLog` / `abnormalEnd`), bounded to 200 lines / 64 KB, deduped via a `sync.Map`, best-effort (never fails or requeues the reconcile).
- `infra/runners-controller/cmd/manager/main.go` — wire a typed clientset (the cached controller-runtime client cannot serve the logs subresource).
- `infra/helm/tuist/templates/runners-controller-deployment.yaml` — grant `pods/log: get` on the controller Role (namespaced to `tuist-runners`).
- Tests + `AGENTS.md`.

## Why

A `tuist-linux-large` runner died mid-job and surfaced to GitHub as "self-hosted runner lost communication". Investigation showed the in-guest `RUNNER_VITALS` probe (the thing built to make these deaths diagnosable) captured nothing: across 17M+ vitals lines in 24h, not one showed distress, and that dead Pod shipped zero vitals despite running for 12 minutes.

Root cause: the trail lives only on the `runner` container's stdout, which flows to the kubelet container log and is GC'd the instant the reap deletes the Pod. `alloy` does not reliably win that race on a churning node, and the final abrupt-kill sample never flushes. So the trail dies with the Pod.

This is distinct from the earlier host-OOM/SIGBUS incident. Host-side telemetry (node-exporter + journald, shipped in #11324 / #11114) confirms this death was not host memory exhaustion: the node peaked at ~59% RAM with `node_vmstat_oom_kill` at 0 and no QEMU/kata fault in the journal. The likely cause was transient in-guest CPU/IO contention dropping the GitHub heartbeat — exactly the kind of thing the vitals trail should have recorded.

## Why this approach over the obvious alternative

The obvious fix is to write vitals to a host-backed path so they outlive the Pod. But the only place to write from is the `runner` container, which runs untrusted workflow code and whose kata-qemu microVM is the isolation boundary. A writable `hostPath` there would let customer code fill the shared node's disk and inject log content. Rejected.

Capturing the trail from the controller keeps it entirely off the untrusted boundary: the controller has a durable, long-lived stdout, and `PodLifecycleReconciler` already fires on the terminal transition ~60s before the `RunnerPoolReconciler` reap, so the kubelet log still exists to pull.

Capture is gated on the runner's exit code, so a workflow that fails its own tests (the runner still exits 0) is skipped — this captures runner infrastructure deaths, not job outcomes, keeping the volume low.

## Limitation

If the guest console never wrote to the kubelet log at all (a kata-console failure), the fetch returns an empty log too. The hard guarantee against that is host-side cgroup sampling (a DaemonSet sampling each Pod's QEMU/cgroup from the node, independent of the guest), deferred until we observe blind deaths persisting after this ships.

## User/developer impact

No runtime behavior change for jobs. Operators gain a durable forensic record for infrastructure deaths. Needs a runners-controller image release to land; the RBAC rides the same chart; only active where the reconciler is already enabled (`sessionsURL` set, already true in prod).

### How to test locally

- `cd infra/runners-controller && go test ./... && go vet ./...` (new cases: `TestAbnormalEnd`, `TestPodLifecycle_CapturesDeathLogOnAbnormalExit`, `TestPodLifecycle_NoCaptureOnCleanExit`, `TestPodLifecycle_DeduplicatesDeathLogCapture`).
- After deploy, the next abnormal death is queryable in Loki (`grafanacloud-logs`): `{pod=~".*runners-controller.*"} |= "runner death log captured"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)