### PR TITLE
feat(infra): thread preview workflow links in Slack

### DIFF
--- a/tuist-ops/lib/tuist_ops/jit/slack_client.ex
+++ b/tuist-ops/lib/tuist_ops/jit/slack_client.ex
@@ -59,13 +59,15 @@ defmodule TuistOps.JIT.SlackClient do
   Block Kit card.
   """
   def post_message(channel_id, blocks, opts \\ []) do
-    body = %{
-      channel: channel_id,
-      blocks: blocks,
-      text: Keyword.get(opts, :fallback_text, "Tailscale JIT request"),
-      unfurl_links: false,
-      unfurl_media: false
-    }
+    body =
+      %{
+        channel: channel_id,
+        blocks: blocks,
+        text: Keyword.get(opts, :fallback_text, "Tailscale JIT request"),
+        unfurl_links: false,
+        unfurl_media: false
+      }
+      |> maybe_put(:thread_ts, Keyword.get(opts, :thread_ts))
 
     @chat_post_message_url
     |> Req.post(headers: headers(), body: JSON.encode!(body))
@@ -125,6 +127,9 @@ defmodule TuistOps.JIT.SlackClient do
       {"Content-Type", "application/json; charset=utf-8"}
     ]
   end
+
+  defp maybe_put(map, _key, nil), do: map
+  defp maybe_put(map, key, value), do: Map.put(map, key, value)
 
   defp handle_post({:ok, %Req.Response{status: status, body: body}}, return)
        when status in 200..299 do

--- a/tuist-ops/lib/tuist_ops/previews/slack_blocks.ex
+++ b/tuist-ops/lib/tuist_ops/previews/slack_blocks.ex
@@ -220,6 +220,18 @@ defmodule TuistOps.Previews.SlackBlocks do
     ]
   end
 
+  def workflow_run_thread(url) when is_binary(url) do
+    [
+      %{
+        type: "section",
+        text: %{
+          type: "mrkdwn",
+          text: "GitHub Actions run: <#{url}|follow the deployment progress>"
+        }
+      }
+    ]
+  end
+
   defp format_ref(%Preview{ref_kind: nil}), do: "`workflow default`"
   defp format_ref(%Preview{ref_kind: kind, ref_value: value}), do: "`#{kind}:#{value}`"
 

--- a/tuist-ops/lib/tuist_ops/previews/workers/monitor_workflow_worker.ex
+++ b/tuist-ops/lib/tuist_ops/previews/workers/monitor_workflow_worker.ex
@@ -20,6 +20,8 @@ defmodule TuistOps.Previews.Workers.MonitorWorkflowWorker do
   alias TuistOps.Previews.SlackBlocks
   alias TuistOps.Repo
 
+  require Logger
+
   @poll_interval_seconds 30
 
   @impl Oban.Worker
@@ -39,12 +41,15 @@ defmodule TuistOps.Previews.Workers.MonitorWorkflowWorker do
   defp monitor(%Preview{workflow_run_name: run_name} = preview) do
     case GitHubActionsClient.workflow_run(run_name) do
       {:ok, %{status: "completed", conclusion: "success"} = run} ->
+        preview = maybe_announce_workflow_run(preview, run)
         mark_deployed(preview, run)
 
       {:ok, %{status: "completed"} = run} ->
+        preview = maybe_announce_workflow_run(preview, run)
         mark_failed(preview, run)
 
-      {:ok, _run} ->
+      {:ok, run} ->
+        maybe_announce_workflow_run(preview, run)
         {:snooze, @poll_interval_seconds}
 
       {:error, :not_found} ->
@@ -54,6 +59,43 @@ defmodule TuistOps.Previews.Workers.MonitorWorkflowWorker do
         {:error, reason}
     end
   end
+
+  defp maybe_announce_workflow_run(%Preview{workflow_run_url: url} = preview, _run)
+       when is_binary(url) and url != "" do
+    preview
+  end
+
+  defp maybe_announce_workflow_run(%Preview{} = preview, %{html_url: url})
+       when is_binary(url) and url != "" do
+    if is_binary(preview.slack_message_ts) do
+      case SlackClient.post_message(
+             preview.slack_channel_id,
+             SlackBlocks.workflow_run_thread(url),
+             fallback_text: "Preview deployment started",
+             thread_ts: preview.slack_message_ts
+           ) do
+        {:ok, _thread_ts} ->
+          :ok
+
+        {:error, reason} ->
+          Logger.warning("preview: workflow thread post failed: #{inspect(reason)}")
+      end
+    end
+
+    preview
+    |> Preview.transition_changeset(%{workflow_run_url: url})
+    |> Repo.update()
+    |> case do
+      {:ok, preview} ->
+        preview
+
+      {:error, changeset} ->
+        Logger.warning("preview: workflow run URL persist failed: #{inspect(changeset)}")
+        %{preview | workflow_run_url: url}
+    end
+  end
+
+  defp maybe_announce_workflow_run(%Preview{} = preview, _run), do: preview
 
   defp mark_deployed(%Preview{} = preview, run) do
     workflow_run_url = run[:html_url]

--- a/tuist-ops/test/jit/slack_client_test.exs
+++ b/tuist-ops/test/jit/slack_client_test.exs
@@ -1,0 +1,32 @@
+defmodule TuistOps.JIT.SlackClientTest do
+  use ExUnit.Case, async: true
+  use Mimic
+
+  alias TuistOps.Environment
+  alias TuistOps.JIT.SlackClient
+
+  setup :verify_on_exit!
+
+  test "post_message sends thread_ts when present" do
+    stub(Environment, :slack_bot_token, fn -> "token" end)
+
+    expect(Req, :post, fn "https://slack.com/api/chat.postMessage", opts ->
+      body = JSON.decode!(opts[:body])
+
+      assert {"Authorization", "Bearer token"} in opts[:headers]
+      assert body["channel"] == "C_PREVIEWS"
+      assert body["thread_ts"] == "1710000000.000001"
+      assert body["text"] == "Preview deployment started"
+
+      {:ok, %Req.Response{status: 200, body: %{"ok" => true, "ts" => "1710000000.000002"}}}
+    end)
+
+    assert {:ok, "1710000000.000002"} =
+             SlackClient.post_message(
+               "C_PREVIEWS",
+               [],
+               fallback_text: "Preview deployment started",
+               thread_ts: "1710000000.000001"
+             )
+  end
+end

--- a/tuist-ops/test/previews/workers/monitor_workflow_worker_test.exs
+++ b/tuist-ops/test/previews/workers/monitor_workflow_worker_test.exs
@@ -35,34 +35,57 @@ defmodule TuistOps.Previews.Workers.MonitorWorkflowWorkerTest do
     |> MonitorWorkflowWorker.perform()
   end
 
+  defp expect_workflow_thread(url) do
+    expect(SlackClient, :post_message, fn "C_PREVIEWS", blocks, opts ->
+      text = blocks |> List.first() |> get_in([:text, :text])
+
+      assert text =~ "GitHub Actions run"
+      assert text =~ url
+      assert opts[:fallback_text] == "Preview deployment started"
+      assert opts[:thread_ts] == "1710000000.000001"
+
+      {:ok, "1710000000.000002"}
+    end)
+  end
+
   test "snoozes while the workflow run is still in progress" do
     preview = insert_preview!()
+    url = "https://github.com/tuist/tuist/actions/runs/in-progress"
 
     expect(GitHubActionsClient, :workflow_run, fn "Preview deploy demo #1" ->
-      {:ok, %{status: "in_progress", conclusion: nil, html_url: "https://github.com/run"}}
+      {:ok, %{status: "in_progress", conclusion: nil, html_url: url}}
     end)
 
+    expect_workflow_thread(url)
+
     assert {:snooze, 30} = perform(preview)
+
+    preview = Repo.reload!(preview)
+    assert preview.status == "creating"
+    assert preview.workflow_run_url == url
   end
 
   test "marks the preview active and updates Slack when the workflow succeeds" do
     preview = insert_preview!()
+    url = "https://github.com/tuist/tuist/actions/runs/1"
 
     expect(GitHubActionsClient, :workflow_run, fn "Preview deploy demo #1" ->
       {:ok,
        %{
          status: "completed",
          conclusion: "success",
-         html_url: "https://github.com/tuist/tuist/actions/runs/1"
+         html_url: url
        }}
     end)
+
+    expect_workflow_thread(url)
 
     expect(SlackClient, :update_message, fn "C_PREVIEWS", "1710000000.000001", blocks, opts ->
       text = blocks |> List.first() |> get_in([:text, :text])
 
       assert text =~ "Preview deployed"
       assert text =~ "https://demo.preview.tuist.dev"
-      assert text =~ "https://github.com/tuist/tuist/actions/runs/1"
+      assert text =~ url
       assert opts[:fallback_text] == "Preview deployed"
 
       :ok
@@ -72,27 +95,30 @@ defmodule TuistOps.Previews.Workers.MonitorWorkflowWorkerTest do
 
     preview = Repo.reload!(preview)
     assert preview.status == "active"
-    assert preview.workflow_run_url == "https://github.com/tuist/tuist/actions/runs/1"
+    assert preview.workflow_run_url == url
   end
 
   test "marks the preview failed and updates Slack when the workflow fails" do
     preview = insert_preview!()
+    url = "https://github.com/tuist/tuist/actions/runs/2"
 
     expect(GitHubActionsClient, :workflow_run, fn "Preview deploy demo #1" ->
       {:ok,
        %{
          status: "completed",
          conclusion: "failure",
-         html_url: "https://github.com/tuist/tuist/actions/runs/2"
+         html_url: url
        }}
     end)
+
+    expect_workflow_thread(url)
 
     expect(SlackClient, :update_message, fn "C_PREVIEWS", "1710000000.000001", blocks, opts ->
       text = blocks |> List.first() |> get_in([:text, :text])
 
       assert text =~ "Preview request failed"
       assert text =~ "workflow_failed"
-      assert text =~ "https://github.com/tuist/tuist/actions/runs/2"
+      assert text =~ url
       assert opts[:fallback_text] == "Preview request failed"
 
       :ok
@@ -103,7 +129,7 @@ defmodule TuistOps.Previews.Workers.MonitorWorkflowWorkerTest do
     preview = Repo.reload!(preview)
     assert preview.status == "failed"
     assert preview.failure_reason == ~s({:workflow_failed, "failure"})
-    assert preview.workflow_run_url == "https://github.com/tuist/tuist/actions/runs/2"
+    assert preview.workflow_run_url == url
   end
 
   test "ignores stale jobs for previews that no longer match the workflow run name" do


### PR DESCRIPTION
Resolves no tracked issue.

This updates the preview request flow in `tuist-ops` so the first monitor poll that sees a GitHub Actions run posts a threaded Slack reply on the original preview request card. The reply links directly to the run, and the run link is persisted immediately so later polls do not post duplicates.

The final success or failure card still updates as before and keeps showing the same GitHub Actions run link. The shared Slack client now accepts `thread_ts` for threaded posts, with coverage for both request serialization and monitor-worker behavior.

### How to test locally

- `mix format lib/tuist_ops/jit/slack_client.ex lib/tuist_ops/previews/slack_blocks.ex lib/tuist_ops/previews/workers/monitor_workflow_worker.ex test/jit/slack_client_test.exs test/previews/workers/monitor_workflow_worker_test.exs`
- `mix test test/jit/slack_client_test.exs test/previews_test.exs test/previews/slack_blocks_test.exs test/previews/workers/monitor_workflow_worker_test.exs`
- `mix test`
- `mix credo`
