### PR TITLE
fix(cli): restore GitHub release asset binary artifacts

### DIFF
--- a/swifterpm/Sources/swifterpm/Support.swift
+++ b/swifterpm/Sources/swifterpm/Support.swift
@@ -140,14 +140,10 @@ enum HTTPClient {
     }
 
     /// Headers for downloading a binary artifact archive. GitHub's release-asset
-    /// API (and similar release-asset proxies) returns the asset metadata JSON
-    /// with HTTP 200 unless the request accepts the raw bytes, so we ask for
-    /// `application/octet-stream`. The `*/*;q=0.9` fallback keeps non-GitHub
-    /// mirrors that strictly honor `Accept` (some self-hosted artifact stores
-    /// reply 406 to a single-type request) able to serve the archive.
+    /// endpoint returns asset metadata unless the request accepts the raw bytes.
     static func binaryArtifactHeaders(for url: URL) async -> [String: String] {
         var headers = await defaultHeaders(for: url)
-        headers["Accept"] = "application/octet-stream, */*;q=0.9"
+        headers["Accept"] = "application/octet-stream"
         return headers
     }
 

--- a/swifterpm/Tests/swifterpmTests/SupportTests.swift
+++ b/swifterpm/Tests/swifterpmTests/SupportTests.swift
@@ -31,6 +31,14 @@ struct SupportTests {
     }
 
     @Test
+    func binaryArtifactHeadersAskForRawBytesExactly() async throws {
+        let url = try #require(URL(string: "https://api.github.com/repos/tuist/tuist/releases/assets/1.zip"))
+        let headers = await HTTPClient.binaryArtifactHeaders(for: url)
+
+        #expect(headers["Accept"] == "application/octet-stream")
+    }
+
+    @Test
     func concurrentTaskMapPreservesInputOrder() async throws {
         let values = [0, 1, 2, 3]
         let mapped = try await ConcurrentTasks.map(values, maxConcurrentTasks: 4) { value in


### PR DESCRIPTION
Resolves no tracked issue.

## What changed

SwifterPM now sends `Accept: application/octet-stream` exactly when downloading remote binary artifact archives.

A focused regression test covers the header construction so the fallback value does not drift back into this path.

## Why

Some packages point binary targets at GitHub release asset endpoints. Those endpoints return asset metadata unless the request asks for the raw bytes with the exact `Accept` value. When SwifterPM receives metadata instead of the archive, checksum verification fails before the artifact can be restored.

## Root cause

The previous header value was `application/octet-stream, */*;q=0.9`. GitHub treats that as a metadata request for release assets, even though it includes `application/octet-stream`. The result is a downloaded metadata payload whose checksum does not match the binary target checksum declared by the package.

## Approach

The download path keeps the existing default headers, including authorization, but replaces the binary artifact `Accept` value with exactly `application/octet-stream`.

This keeps the fix scoped to binary artifact downloads. Source archive downloads and registry downloads keep their existing headers.

## Impact

Projects using SwifterPM through `TUIST_USE_SWIFTERPM=1` can restore GitHub-hosted binary artifacts without hitting checksum mismatches caused by metadata responses.

## Validation

- `swift test --replace-scm-with-registry --filter SupportTests/binaryArtifactHeadersAskForRawBytesExactly`
- `swift test --replace-scm-with-registry --filter RestoreTests/restorePackageRedownloadsRemoteBinaryArtifactWhenCachedArchiveChecksumMismatches`
- Reproduced the failure with `tuist 4.201.0-rc.1` using a GitHub release asset endpoint ending in `.zip`, then verified the patched local SwifterPM restores the same asset successfully.
- `git diff --check`
