### PR TITLE
fix(infra): use trusted platform source for previews

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -131,6 +131,7 @@ jobs:
       namespace: ${{ steps.r.outputs.namespace }}
       host: ${{ steps.r.outputs.host }}
       ref: ${{ steps.r.outputs.ref }}
+      platform_ref: ${{ steps.r.outputs.platform_ref }}
       short_sha: ${{ steps.r.outputs.short_sha }}
       ttl_hours: ${{ steps.r.outputs.ttl_hours }}
       expires_at: ${{ steps.r.outputs.expires_at }}
@@ -140,8 +141,10 @@ jobs:
         env:
           EVENT: ${{ github.event_name }}
           EVENT_ACTION: ${{ github.event.action }}
+          EVENT_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           EVENT_PR: ${{ github.event.pull_request.number }}
           EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
           DISPATCH_ACTION: ${{ inputs.action }}
           DISPATCH_SLUG: ${{ inputs.slug }}
           DISPATCH_PR: ${{ inputs.pr_number }}
@@ -235,6 +238,11 @@ jobs:
           HOST="${SLUG}.${PREVIEW_BASE_DOMAIN}"
           SHORT_SHA="${REF:0:12}"
           EXPIRES_AT=$(( $(date +%s) + TTL_HOURS * 3600 ))
+          if [ "$EVENT" = "pull_request" ]; then
+            PLATFORM_REF="$EVENT_BASE_SHA"
+          else
+            PLATFORM_REF="$DEFAULT_BRANCH"
+          fi
 
           {
             echo "action=$ACTION"
@@ -244,6 +252,7 @@ jobs:
             echo "namespace=$NAMESPACE"
             echo "host=$HOST"
             echo "ref=$REF"
+            echo "platform_ref=$PLATFORM_REF"
             echo "short_sha=$SHORT_SHA"
             echo "ttl_hours=$TTL_HOURS"
             echo "expires_at=$EXPIRES_AT"
@@ -258,6 +267,7 @@ jobs:
             echo "- Host: https://$HOST"
             if [ "$ACTION" = "deploy" ]; then
               echo "- Ref: \`$REF\`"
+              echo "- Platform ref: \`$PLATFORM_REF\`"
               echo "- Expires: $(date -u -d "@$EXPIRES_AT" '+%Y-%m-%d %H:%M UTC')"
             fi
           } >> "$GITHUB_STEP_SUMMARY"
@@ -454,7 +464,7 @@ jobs:
       cancel-in-progress: false
     timeout-minutes: 30
     env:
-      KUBECONFIG: ${{ github.workspace }}/.kube/config
+      KUBECONFIG: ${{ runner.temp }}/preview-kubeconfig
       RELEASE: ${{ needs.resolve.outputs.release }}
       NAMESPACE: ${{ needs.resolve.outputs.namespace }}
       HOST: ${{ needs.resolve.outputs.host }}
@@ -467,9 +477,10 @@ jobs:
       KURA_INSTANCE: ${{ needs.resolve.outputs.release }}-kura
       KURA_HOST: kura-${{ needs.resolve.outputs.slug }}.preview.tuist.dev
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout platform source
+        uses: actions/checkout@v4
         with:
-          ref: ${{ needs.resolve.outputs.ref }}
+          ref: ${{ needs.resolve.outputs.platform_ref }}
           fetch-depth: 0
       - uses: jdx/mise-action@v3.2.0
         with:
@@ -483,6 +494,13 @@ jobs:
       - name: Re-apply preview node label
         run: |
           kubectl label nodes -l '!node-role.kubernetes.io/control-plane' role=preview --overwrite
+      - name: Verify platform bootstrap
+        run: |
+          set -euo pipefail
+          if ! kubectl -n platform get secret cloudflare-api-token >/dev/null 2>&1; then
+            echo "::error::Missing platform/cloudflare-api-token in the preview cluster. Restore the cluster bootstrap secret before deploying previews."
+            exit 1
+          fi
       - name: Reconcile platform chart
         run: |
           set -euo pipefail
@@ -493,6 +511,11 @@ jobs:
         run: |
           set -euo pipefail
           mise -C infra run k8s:install-kura-platform "$KUBECONFIG"
+      - name: Checkout preview source
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.resolve.outputs.ref }}
+          fetch-depth: 0
       - name: Mark namespace as creating
         env:
           REQUESTER_EMAIL: ${{ inputs.requester_email }}
@@ -685,7 +708,7 @@ jobs:
       cancel-in-progress: false
     timeout-minutes: 15
     env:
-      KUBECONFIG: ${{ github.workspace }}/.kube/config
+      KUBECONFIG: ${{ runner.temp }}/preview-kubeconfig
       RELEASE: ${{ needs.resolve.outputs.release }}
       NAMESPACE: ${{ needs.resolve.outputs.namespace }}
     steps:

--- a/infra/mise/tasks/k8s/install-platform.sh
+++ b/infra/mise/tasks/k8s/install-platform.sh
@@ -11,8 +11,8 @@
 # downstream installs that depend on cert-manager.io/v1 Certificate.
 #
 # Reads the Cloudflare DNS-01 API token from `CLOUDFLARE_API_TOKEN` if
-# set (CI wires it from the workflow's 1Password integration). Falls
-# back to `op read` for local invocations from bootstrap-workload.
+# set. Falls back to `op read` only for local invocations from
+# bootstrap-workload.
 
 set -euo pipefail
 
@@ -44,6 +44,11 @@ KUBECONFIG="$WL_KUBECONFIG" kubectl create namespace platform \
 if ! KUBECONFIG="$WL_KUBECONFIG" kubectl -n platform get secret cloudflare-api-token >/dev/null 2>&1; then
   log "cloudflare-api-token Secret missing — provisioning it"
   if [ -z "${CLOUDFLARE_API_TOKEN:-}" ]; then
+    if [ "${GITHUB_ACTIONS:-}" = "true" ]; then
+      echo "ERROR: platform/cloudflare-api-token is missing and CLOUDFLARE_API_TOKEN is not set." >&2
+      echo "Restore the workload cluster bootstrap secret before running deploys." >&2
+      exit 1
+    fi
     CLOUDFLARE_API_TOKEN="$(op read --account tuist.1password.com \
       "op://Founders/cloudflare-tuist-dns/credential")"
   fi


### PR DESCRIPTION
Resolves no tracked issue.

## What changed

The preview deployment workflow now separates shared cluster reconciliation from preview application deployment.

For cluster-wide work, the deploy job checks out a trusted platform ref first:

- pull request previews use the pull request base commit
- Slack and manual dispatches use the repository default branch

From that trusted checkout, the workflow reconciles both the platform chart and the cluster-wide Kura controller. After that, it checks out the requested preview ref and deploys the preview application, runtime hook, seed data, and preview-specific resources from that ref.

The workflow also stores the preview kubeconfig under the runner temp directory so the second checkout cannot remove it, and it verifies that `platform/cloudflare-api-token` exists before platform reconciliation runs.

## Why

The failing Slack-requested preview did not mean the preview cluster had definitely lost its bootstrap secret. A successful preview run earlier in the day logged `cloudflare-api-token Secret already present`.

The failure happened because preview deploys ran shared cluster installers from the previewed branch. The requested ref still had an older `install-platform.sh` that always called `op read`, even when the cluster already had `cloudflare-api-token`.

## Root cause

The preview workflow intentionally checks out the requested ref to build and deploy the preview application. That checkout was also used for shared cluster operations, which let older previewed branches run older platform installer behavior against the shared preview cluster.

## Approach

Use the standard checkout pattern, but split the job into two phases:

- trusted checkout, tool setup, kubeconfig load, platform chart reconciliation, and Kura controller reconciliation
- preview checkout, namespace setup, application chart deployment, Kura instance creation, smoke test, and seed step

The shared platform installer also refuses to fall through to local 1Password behavior inside GitHub Actions when `platform/cloudflare-api-token` is missing and `CLOUDFLARE_API_TOKEN` is not set. That turns missing cluster configuration into a clear bootstrap error.

## Impact

Preview deploys no longer need Cloudflare or 1Password access just to reconcile an already bootstrapped preview cluster. Older previewed branches can still deploy their application code, but they no longer get to run stale shared cluster installer code.

### How to test locally

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/preview-deploy.yml"); puts "yaml ok"'`
- `bash -n infra/mise/tasks/k8s/install-platform.sh`
- `bash -n infra/mise/tasks/k8s/install-kura-platform.sh`
- `git diff --check origin/main...HEAD`
