### PR TITLE
ci(server): pin the backward-compat gate to the public cache endpoint

### DIFF
--- a/.github/workflows/server-production-deployment.yml
+++ b/.github/workflows/server-production-deployment.yml
@@ -1954,6 +1954,16 @@ jobs:
     env:
       MISE_TASK_RUN_AUTO_INSTALL: 0
       TUIST_URL: https://canary.tuist.dev
+      # Pin the cache to canary's PUBLIC endpoint instead of resolving it via
+      # /api/cache/endpoints. This job runs on the scw-fr-par macOS runner fleet,
+      # and the server routes that fleet to the regional Kura cache - an in-cluster
+      # Private Network NodePort (e.g. http://172.16.0.2:3xxxx) meant for the
+      # dispatched-runner cache data plane, which a plain `tuist cache` here can't
+      # reach (every download/upload times out). A real external customer resolves
+      # the public endpoint; pinning makes this gate use it too. Verified on the
+      # runner: with the pin the store+fetch round-trip succeeds; without it the
+      # CLI picks the PN NodePort and stalls.
+      TUIST_CACHE_ENDPOINT: https://cache-eu-central-canary.tuist.dev
       # Public canary test account, same as the HEAD acceptance scheme (Project.swift).
       TUIST_AUTH_EMAIL: tuistrocks@tuist.dev
       TUIST_AUTH_PASSWORD: tuistrocks


### PR DESCRIPTION
> Fix the Backward-Compatibility Acceptance gate, which has been timing out (15-min cancel) and blocking the production deploy cascade.

### Root cause

The gate runs the oldest supported CLI against canary on the **scw-fr-par macOS runner fleet**. When the CLI resolves the cache via `/api/cache/endpoints`, the server routes that fleet to the **regional Kura cache** — an in-cluster Private Network NodePort (e.g. `http://172.16.0.2:3xxxx`) that serves the *dispatched-runner* cache data plane. A plain `tuist cache` in this gate isn't on that data plane and can't reach the PN NodePort, so every module-cache download/upload times out and the job hangs.

Verbose trace from the runner:
```
Using regional cache endpoint: http://172.16.0.2:30815
... downloadModuleCacheArtifact ... The request timed out  (retries 0,1,2)
```

This is:
- **Not** the client `kura` feature flag (`TUIST_FEATURE_FLAG_KURA` from `mise.toml`) — the routing is server-side by where the runner is; unsetting the flag still resolved the PN NodePort.
- **Not** a runner network/MTU problem — DF-ping to the cache IP is clean at 1500, and small HTTP + the public CAS endpoints respond fine from the runner.
- **Not** the staging-endpoint leak (already removed) — that's a different resolution path.

### Fix

Pin `TUIST_CACHE_ENDPOINT` to canary's public cache. This bypasses `getCacheEndpoints` (and its fleet-specific routing) so the gate resolves the endpoint a **real external customer** would — which is exactly what this gate is meant to simulate.

### Validation

Verified on the actual `tuist-macos-26-3` runner via a temporary probe workflow (now removed):
- **Without** the pin: CLI resolves `http://172.16.0.2:30815`, download/upload time out, job hangs.
- **With** the pin: `Using regional cache endpoint: https://cache-eu-central-canary.tuist.dev`; `tuist cache` stores (`1 target stored`, rc=0); `tuist generate` pulls and links the xcframework (rc=0).
- Network probe ruled out MTU/reachability (DF-ping 1200–1472 → 0% loss; public CAS endpoints `getCacheEndpoints`/`module/start`/`module/:id` all respond fast).

### Note

This complements the earlier merged gate fixes (testing CLI `4.154.2` for Xcode-26 build compatibility, and the bats teardown-race fix). With those plus this pin, the gate exercises the real public-cache store/fetch path end to end and passes on the runner.