### PR TITLE
docs(server): explain bundle size computation and App Store Connect comparison

### DIFF
--- a/server/priv/docs/en/guides/features/bundle-size.md
+++ b/server/priv/docs/en/guides/features/bundle-size.md
@@ -55,6 +55,26 @@ The `tuist inspect bundle` command analyzes the bundle and provides you with a l
 
 ![Analyzed bundle](/images/guides/features/bundle-size/analyzed-bundle.png)
 
+## Understanding bundle sizes {#understanding-sizes}
+
+For every analyzed bundle, Tuist reports two values:
+
+- **Install size**: the space the app takes up once installed on a device.
+- **Download size**: the compressed size users download. For Apple bundles, this is only available when you analyze an `.ipa` (it is the size of the `.ipa` archive); it is not reported for `.xcarchive` or `.app` inputs.
+
+Sizes are stored in bytes and displayed using the decimal convention, where 1 MB is 1,000,000 bytes and 1 GB is 1,000,000,000 bytes. This is the same convention Apple uses to report storage and app sizes (see [How storage capacity is measured on Apple devices](https://support.apple.com/en-us/102119)). For example, an install size of 733,446,863 bytes is shown as 733.4 MB.
+
+### Comparing with App Store Connect {#app-store-connect}
+
+Tuist measures the bundle exactly as you provide it and does not apply [app thinning](https://developer.apple.com/documentation/xcode/reducing-your-app-s-size). The reported sizes therefore correspond to the **universal** (unthinned) variant, the row labeled "Universal" in App Store Connect's app file sizes report, rather than the per-device variants.
+
+When comparing the two, expect the numbers to be in the same range as the Universal row, but not identical:
+
+- **Install size** is close to the Universal install size. App Store Connect reports a slightly higher value because it includes on-device overhead, such as filesystem block allocation and Apple's own estimation, that a raw file-size measurement does not capture.
+- **Download size** is lower than the Universal download size. Apple encrypts the app binary after you upload it, and encrypted data compresses less efficiently, so the App Store's compressed download ends up larger than the `.ipa` archive Tuist measures. This happens on Apple's side after upload, so it is not reflected in Tuist's number.
+
+The per-device rows in App Store Connect are smaller again, because app thinning removes the CPU architectures and asset variants that a specific device does not need. Tuist does not currently report per-device (thinned) sizes.
+
 ## Continuous integration {#continuous-integration}
 
 To track bundle size over time, you will need to analyze the bundle on the CI. First, you will need to ensure that your CI is <.localized_link href="/guides/integrations/continuous-integration#authentication">authenticated</.localized_link>:


### PR DESCRIPTION
## What changed

Adds an **"Understanding bundle sizes"** section to the [Bundle insights](https://docs.tuist.dev/en/guides/features/bundle-size) docs (`server/priv/docs/en/guides/features/bundle-size.md`). The section documents:

- **What the values mean** — install size vs download size, and that download size is only reported for `.ipa` inputs (not `.xcarchive` or `.app`).
- **The unit** — sizes are stored in bytes and displayed as decimal MB (1 MB = 1,000,000 bytes), matching the convention Apple uses for storage and app sizes, with a worked example (733,446,863 bytes → 733.4 MB).
- **A "Comparing with App Store Connect" subsection** — how Tuist's numbers relate to App Store Connect's report.

## Why

Users repeatedly ask why Tuist's reported bundle sizes differ from what they see in App Store Connect, and the existing page only covered *how to use* the feature, never what the numbers represent or how to compare them. The docs are the durable place to answer this.

## The reasoning captured

The page now explains the actual mechanics behind the discrepancy:

- Tuist measures the bundle exactly as provided and does **not** apply app thinning, so its numbers correspond to App Store Connect's **Universal** (unthinned) row, not the per-device variants.
- **Install size** lands close to the Universal install size; App Store Connect reports slightly higher because it includes on-device overhead (filesystem block allocation and Apple's own estimation) that a raw file-size measurement doesn't capture.
- **Download size** reads lower than the Universal download size because Apple encrypts the binary *after* upload, and encrypted data compresses less efficiently — a step that happens on Apple's side and isn't visible to Tuist.
- Per-device rows are smaller again due to app thinning, which Tuist does not currently apply.

These mechanics were derived from the open-source [Rosalind](https://github.com/tuist/Rosalind) analyzer (which the CLI uses): `install_size` is the summed logical size of the unzipped `.app`, and `download_size` is the size of the `.ipa` archive itself.

## Scope notes

- English source only. The other-language `bundle-size.md` files are intentionally left untouched — those sync via Weblate / the `tuistit` bot.
- Pure-markdown addition using only constructs already present in the file (headings with `{#anchor}`, lists, inline code, standard links); no custom components or code-groups.
- A follow-up opportunity (not in this PR): adding per-device (thinned) size support to Rosalind, validated against App Store Connect's per-device rows.

## Validation

Not rendered in a running server — the change is pure markdown matching the file's existing conventions, and booting the full Phoenix + Postgres + ClickHouse stack was disproportionate for this. Happy to render and screenshot on request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)