### PR TITLE
fix(infra): configure cache nginx upload limit

### DIFF
--- a/infra/helm/tuist/README.md
+++ b/infra/helm/tuist/README.md
@@ -104,6 +104,7 @@ Embedded PostgreSQL, ClickHouse, and MinIO continue to use the namespace default
 Some cluster-specific fixes are intentionally opt-in:
 
 - `cache.podSecurityContext` is empty by default. Set `fsGroup` only if your storage class needs it.
+- `cache.nginx.clientMaxBodySize` defaults to `10m`, matching the cache application's module part size limit. Raise it only when the application limit is raised too.
 - `clickhouse.embedded.service.nativePort` defaults to ClickHouse's standard `9000` service port and can be overridden for mesh or port-allocation conflicts.
 - `clickhouse.external.pingUrl` lets the migration job wait for an external ClickHouse instance through a dedicated `/ping` URL when `clickhouse.external.url` includes a database path.
 
@@ -121,6 +122,8 @@ Embedded compatibility override example:
 
 ```yaml
 cache:
+  nginx:
+    clientMaxBodySize: 10m
   podSecurityContext:
     fsGroup: 990
 

--- a/infra/helm/tuist/templates/cache-nginx-configmap.yaml
+++ b/infra/helm/tuist/templates/cache-nginx-configmap.yaml
@@ -19,9 +19,11 @@ data:
       }
       server {
         listen 80;
+        client_max_body_size {{ .Values.cache.nginx.clientMaxBodySize }};
 
         location /up {
           proxy_pass http://cache_upstream;
+          proxy_request_buffering off;
           proxy_set_header Host $host;
           proxy_set_header X-Forwarded-Proto $scheme;
           proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -34,6 +36,7 @@ data:
 
         location / {
           proxy_pass http://cache_upstream;
+          proxy_request_buffering off;
           proxy_set_header Host $host;
           proxy_set_header X-Forwarded-Proto $scheme;
           proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/infra/helm/tuist/values.yaml
+++ b/infra/helm/tuist/values.yaml
@@ -1307,6 +1307,8 @@ cache:
     pullPolicy: IfNotPresent
   nginx:
     enabled: true
+    # Keep this aligned with the cache application's module part size limit.
+    clientMaxBodySize: "10m"
     image:
       repository: nginx
       tag: "1.29-alpine"


### PR DESCRIPTION
## What changed

The Tuist Helm chart now exposes `cache.nginx.clientMaxBodySize` for the cache nginx sidecar and renders it as `client_max_body_size` in the generated nginx configuration.

The upload proxy paths also disable request buffering so module upload parts stream through nginx to the cache application.

The chart README documents the new cache nginx value alongside the existing compatibility overrides.

## Why

Remote Cache module uploads can send framework parts through the cache nginx sidecar. Without an explicit body size setting, nginx applies its default request body limit and can reject valid uploads before the cache application receives them.

## Root cause

The managed server ingress already configures a larger request body limit, but the cache deployment has a separate nginx sidecar with its own configuration. That sidecar did not set `client_max_body_size`, so uploads larger than nginx's default limit could fail with `413 Request Entity Too Large`.

## Approach

The default value is `10m`, which matches the cache application's module part size limit. Keeping the sidecar and application limits aligned avoids accepting larger requests at nginx only for the application to reject them later.

Request buffering is disabled on the upload proxy paths to match the intended streaming behavior for request bodies.

## Impact

Self-hosted and managed deployments get a configurable cache nginx upload limit. Valid module upload parts should no longer be rejected by nginx before reaching the cache application.

## Validation

- `helm template tuist infra/helm/tuist --show-only templates/cache-nginx-configmap.yaml`
- `helm lint infra/helm/tuist`
