### PR TITLE
fix(cli): Swift package plugin product graph edges

### DIFF
--- a/cli/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
+++ b/cli/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
@@ -241,7 +241,13 @@ public struct PackageInfoMapper: PackageInfoMapping {
             .reduce(into: [:]) { result, packageInfo in
                 let moduleAliases = packageModuleAliases[packageInfo.value.name]
                 for product in packageInfo.value.products {
-                    result[moduleAliases?[product.name] ?? product.name] = try product.targets.flatMap { target in
+                    let productName = moduleAliases?[product.name] ?? product.name
+                    if case .plugin = product.type {
+                        result[productName] = []
+                        continue
+                    }
+
+                    result[productName] = try product.targets.flatMap { target in
                         try ResolvedDependency.fromTarget(
                             name: moduleAliases?[target] ?? target,
                             targetDependencyToFramework: targetDependencyToFramework,

--- a/cli/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
+++ b/cli/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
@@ -343,6 +343,36 @@ struct PackageInfoMapperTests {
     @Test(
         .inTemporaryDirectory,
         .withMockedSwiftVersionProvider
+    ) func resolveDependencies_whenProductIsPlugin_mapsToNoDependencies() async throws {
+        let basePath = try #require(FileSystem.temporaryTestDirectory)
+        let packagePath = basePath.appending(component: "PluginPkg")
+
+        let resolvedDependencies = try await subject.resolveExternalDependencies(
+            path: basePath,
+            packageInfos: [
+                "PluginPkg": .test(
+                    name: "PluginPkg",
+                    products: [
+                        .init(name: "MyBuildToolPlugin", type: .plugin, targets: ["MyBuildToolPlugin"]),
+                    ],
+                    targets: [
+                        .test(name: "MyBuildToolPlugin", type: .plugin),
+                    ],
+                    platforms: [.macos]
+                ),
+            ],
+            packageToFolder: ["PluginPkg": packagePath],
+            packageToTargetsToArtifactPaths: [:],
+            packageModuleAliases: [:],
+            packageSettings: .test()
+        )
+
+        #expect(resolvedDependencies == ["MyBuildToolPlugin": []])
+    }
+
+    @Test(
+        .inTemporaryDirectory,
+        .withMockedSwiftVersionProvider
     ) func resolveDependencies_whenArtifactsContainMACOSXFolder_filtersThemOut() async throws {
         let basePath = try #require(FileSystem.temporaryTestDirectory)
         let artifactsPath = basePath.appending(components: "Tuist", ".build", "artifacts", "tuist")


### PR DESCRIPTION
Fixes #11453.

## What changed

This changes the external dependency resolver so plugin products from [Swift Package Manager](https://www.swift.org/package-manager/) packages are kept as resolvable product names, but map to an empty dependency list instead of framework or project dependencies.

It also adds regression coverage for a plugin-only package product.

## Why

Packages can depend on build-tool plugins transitively. Those plugin targets are intentionally not generated as Xcode projects, but consumers can still see the plugin product during external dependency resolution.

## Root cause

`PackageInfoMapper.resolveExternalDependencies` treated plugin products like normal products and resolved their targets into project dependencies. Later project generation filters plugin targets out, so the generated graph could point to a project that does not exist and fail with "Could not locate project at path".

## Approach

Plugin products remain in the product dependency map to avoid treating them as unknown products. Their value is an empty dependency list because there is no runtime or linkable graph edge to generate for a build-tool plugin product.

## Impact

`tuist generate` can handle external packages that depend transitively on build-tool plugin products without creating invalid project references. There is no migration impact.

## Validation

- `TUIST_CACHE_ENDPOINT=https://tuist.dev mise x -- tuist generate run tuist TuistLoader TuistLoaderTests ProjectDescription --no-open --no-binary-cache --cache-profile none`
- `xcodebuild test -workspace Tuist.xcworkspace -scheme Tuist-Workspace -only-testing 'TuistLoaderTests/PackageInfoMapperTests/resolveDependencies_whenProductIsPlugin_mapsToNoDependencies()' CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" COMPILATION_CACHE_ENABLE_CACHING=NO`
