### PR TITLE
fix(cli): bound best-effort run metadata uploads

### DIFF
--- a/cli/Sources/TuistKit/Commands/TrackableCommand/TrackableCommand.swift
+++ b/cli/Sources/TuistKit/Commands/TrackableCommand/TrackableCommand.swift
@@ -47,6 +47,7 @@ public class TrackableCommand {
     private let serverAuthenticationController: ServerAuthenticationControlling
     private let fileSystem: FileSysteming
     private let gitHubActionsJobSummaryService: GitHubActionsJobSummaryServicing
+    private let bestEffortForegroundUploadTimeout: Duration
     private let sessionDirectory: AbsolutePath
 
     public init(
@@ -59,6 +60,7 @@ public class TrackableCommand {
         serverAuthenticationController: ServerAuthenticationControlling = ServerAuthenticationController(),
         fileSystem: FileSysteming = FileSystem(),
         gitHubActionsJobSummaryService: GitHubActionsJobSummaryServicing = GitHubActionsJobSummaryService(),
+        bestEffortForegroundUploadTimeout: Duration = .seconds(15),
         sessionDirectory: AbsolutePath
     ) {
         self.command = command
@@ -70,6 +72,7 @@ public class TrackableCommand {
         self.serverAuthenticationController = serverAuthenticationController
         self.fileSystem = fileSystem
         self.gitHubActionsJobSummaryService = gitHubActionsJobSummaryService
+        self.bestEffortForegroundUploadTimeout = bestEffortForegroundUploadTimeout
         self.sessionDirectory = sessionDirectory
     }
 
@@ -179,13 +182,14 @@ public class TrackableCommand {
                 path: path
             )
             let buildRunURL = await runMetadataStorage.buildRunURL
-            if (command as? TrackableParsableCommand)?.analyticsRequired == true || Environment.current.isCI {
+            let isAnalyticsRequired = (command as? TrackableParsableCommand)?.analyticsRequired == true
+            if isAnalyticsRequired || Environment.current.isCI {
                 Logger.current.info("Uploading run metadata...")
-                let serverCommandEvent = try await uploadAnalyticsService.upload(
-                    commandEvent: commandEvent,
+                let serverCommandEvent = try await uploadCommandEvent(
+                    commandEvent,
                     fullHandle: fullHandle,
                     serverURL: serverURL,
-                    sessionDirectory: sessionDirectory
+                    isAnalyticsRequired: isAnalyticsRequired
                 )
                 if let testRunURL = serverCommandEvent.testRunURL {
                     Logger.current
@@ -228,9 +232,46 @@ public class TrackableCommand {
             }
         } catch let error as ClientError {
             Logger.current.warning("Failed to upload run metadata: \(String(describing: error.underlyingError))")
+        } catch let error as TrackableCommandUploadError {
+            Logger.current.warning("Failed to upload run metadata: \(error.localizedDescription)")
         } catch {
             Logger.current.warning("Failed to upload run metadata: \(String(describing: error))")
         }
+    }
+
+    private func uploadCommandEvent(
+        _ commandEvent: CommandEvent,
+        fullHandle: String,
+        serverURL: URL,
+        isAnalyticsRequired: Bool
+    ) async throws -> ServerCommandEvent {
+        if isAnalyticsRequired {
+            return try await uploadAnalyticsService.upload(
+                commandEvent: commandEvent,
+                fullHandle: fullHandle,
+                serverURL: serverURL,
+                sessionDirectory: sessionDirectory
+            )
+        }
+
+        var serverCommandEvent: ServerCommandEvent?
+        try await withTimeout(
+            bestEffortForegroundUploadTimeout,
+            onTimeout: {
+                throw TrackableCommandUploadError.bestEffortUploadTimedOut
+            }
+        ) {
+            serverCommandEvent = try await self.uploadAnalyticsService.upload(
+                commandEvent: commandEvent,
+                fullHandle: fullHandle,
+                serverURL: serverURL,
+                sessionDirectory: self.sessionDirectory
+            )
+        }
+        guard let serverCommandEvent else {
+            throw TrackableCommandUploadError.bestEffortUploadTimedOut
+        }
+        return serverCommandEvent
     }
 
     private func analyticsCommandMetadata(
@@ -270,5 +311,16 @@ public class TrackableCommand {
             subcommand: fallbackSubcommand,
             commandArguments: commandArguments
         )
+    }
+}
+
+private enum TrackableCommandUploadError: LocalizedError {
+    case bestEffortUploadTimedOut
+
+    var errorDescription: String? {
+        switch self {
+        case .bestEffortUploadTimedOut:
+            return "Run metadata upload timed out."
+        }
     }
 }

--- a/cli/Sources/TuistKit/Services/AnalyticsUploadCommandService.swift
+++ b/cli/Sources/TuistKit/Services/AnalyticsUploadCommandService.swift
@@ -8,11 +8,14 @@ import TuistSupport
 
 enum AnalyticsUploadCommandServiceError: LocalizedError, Equatable {
     case invalidServerURL(String)
+    case uploadTimedOut
 
     var errorDescription: String? {
         switch self {
         case let .invalidServerURL(url):
             return "Invalid server URL: \(url)"
+        case .uploadTimedOut:
+            return "Run metadata upload timed out."
         }
     }
 }
@@ -21,15 +24,18 @@ struct AnalyticsUploadCommandService {
     private let fileSystem: FileSysteming
     private let uploadAnalyticsService: UploadAnalyticsServicing
     private let configLoader: ConfigLoading
+    private let bestEffortUploadTimeout: Duration
 
     init(
         fileSystem: FileSysteming = FileSystem(),
         uploadAnalyticsService: UploadAnalyticsServicing = UploadAnalyticsService(),
-        configLoader: ConfigLoading = ConfigLoader()
+        configLoader: ConfigLoading = ConfigLoader(),
+        bestEffortUploadTimeout: Duration = .seconds(15)
     ) {
         self.fileSystem = fileSystem
         self.uploadAnalyticsService = uploadAnalyticsService
         self.configLoader = configLoader
+        self.bestEffortUploadTimeout = bestEffortUploadTimeout
     }
 
     func run(
@@ -48,11 +54,19 @@ struct AnalyticsUploadCommandService {
             let commandEvent: CommandEvent = try await fileSystem.readJSONFile(at: eventPath)
             let optionalAuthentication = await resolveOptionalAuthentication(commandArguments: commandEvent.commandArguments)
             try await ServerAuthenticationConfig.withOptionalAuthentication(optionalAuthentication) {
-                _ = try await uploadAnalyticsService.upload(
-                    commandEvent: commandEvent,
-                    fullHandle: fullHandle,
-                    serverURL: url,
-                    sessionDirectory: sessionDirectory
+                try await withTimeout(
+                    bestEffortUploadTimeout,
+                    onTimeout: {
+                        throw AnalyticsUploadCommandServiceError.uploadTimedOut
+                    },
+                    action: {
+                        _ = try await uploadAnalyticsService.upload(
+                            commandEvent: commandEvent,
+                            fullHandle: fullHandle,
+                            serverURL: url,
+                            sessionDirectory: sessionDirectory
+                        )
+                    }
                 )
             }
         }

--- a/cli/Sources/TuistServer/Utilities/RetryProvider.swift
+++ b/cli/Sources/TuistServer/Utilities/RetryProvider.swift
@@ -19,27 +19,25 @@ public struct RetryProvider: RetryProviding {
     public func runWithRetries<T>(
         operation: @Sendable @escaping () async throws -> T
     ) async throws -> T {
-        try await Task {
-            let maxRetryCount = 3
-            for retry in 0 ..< maxRetryCount {
-                do {
-                    return try await operation()
-                } catch {
-                    #if canImport(TuistSupport)
-                        Logger.current.debug("""
-                        The following error happened for retry \(retry): \(error.localizedDescription).
-                        Retrying...
-                        """)
-                    #endif
-                    try await Task<Never, Never>.sleep(nanoseconds: delayProvider.delay(for: retry))
-
-                    continue
-                }
-            }
-
+        let maxRetryCount = 3
+        for retry in 0 ..< maxRetryCount {
             try Task<Never, Never>.checkCancellation()
-            return try await operation()
+            do {
+                return try await operation()
+            } catch let error as CancellationError {
+                throw error
+            } catch {
+                #if canImport(TuistSupport)
+                    Logger.current.debug("""
+                    The following error happened for retry \(retry): \(error.localizedDescription).
+                    Retrying...
+                    """)
+                #endif
+                try await Task<Never, Never>.sleep(nanoseconds: delayProvider.delay(for: retry))
+            }
         }
-        .value
+
+        try Task<Never, Never>.checkCancellation()
+        return try await operation()
     }
 }

--- a/cli/Tests/TuistKitTests/CommandTracking/TrackableCommandTests.swift
+++ b/cli/Tests/TuistKitTests/CommandTracking/TrackableCommandTests.swift
@@ -4,6 +4,8 @@ import Mockable
 import Path
 import TuistAlert
 import TuistCore
+import TuistEnvironment
+import TuistEnvironmentTesting
 import TuistGit
 import TuistJobSummary
 import TuistLogging
@@ -65,7 +67,9 @@ final class TrackableCommandTests: TuistTestCase {
         flag: Bool = true,
         shouldFail: Bool = false,
         analyticsRequired: Bool = false,
-        commandArguments: [String] = ["cache", "warm"]
+        commandArguments: [String] = ["cache", "warm"],
+        uploadAnalyticsService: UploadAnalyticsServicing? = nil,
+        bestEffortForegroundUploadTimeout: Duration = .seconds(15)
     ) throws {
         let temporaryPath = try temporaryPath()
         subject = TrackableCommand(
@@ -80,9 +84,10 @@ final class TrackableCommandTests: TuistTestCase {
                 gitController: gitController
             ),
             backgroundProcessRunner: backgroundProcessRunner,
-            uploadAnalyticsService: uploadAnalyticsService,
+            uploadAnalyticsService: uploadAnalyticsService ?? self.uploadAnalyticsService,
             serverAuthenticationController: serverAuthenticationController,
             gitHubActionsJobSummaryService: gitHubActionsJobSummaryService,
+            bestEffortForegroundUploadTimeout: bestEffortForegroundUploadTimeout,
             sessionDirectory: temporaryPath
         )
     }
@@ -367,6 +372,31 @@ final class TrackableCommandTests: TuistTestCase {
             .called(1)
     }
 
+    func test_whenBestEffortForegroundUploadTimesOut_doesNotWriteGitHubActionsJobSummary() async throws {
+        // Given
+        try await withMockedEnvironment {
+            Environment.mocked?.variables["CI"] = "true"
+            let delayedUploadAnalyticsService = DelayedUploadAnalyticsService(delay: .seconds(1))
+            try makeSubject(
+                analyticsRequired: false,
+                uploadAnalyticsService: delayedUploadAnalyticsService,
+                bestEffortForegroundUploadTimeout: .milliseconds(1)
+            )
+
+            // When
+            try await subject.run(
+                fullHandle: "tuist/tuist",
+                serverURL: .test(),
+                shouldTrackAnalytics: true
+            )
+
+            // Then
+            verify(gitHubActionsJobSummaryService)
+                .writeJobSummary(testRunReports: .any, buildRunReports: .any, runURL: .any)
+                .called(0)
+        }
+    }
+
     func test_whenBackgroundUpload_doesNotWriteGitHubActionsJobSummary() async throws {
         // Given
         try makeSubject(analyticsRequired: false)
@@ -382,6 +412,21 @@ final class TrackableCommandTests: TuistTestCase {
         verify(gitHubActionsJobSummaryService)
             .writeJobSummary(testRunReports: .any, buildRunReports: .any, runURL: .any)
             .called(0)
+    }
+}
+
+private struct DelayedUploadAnalyticsService: UploadAnalyticsServicing {
+    let delay: Duration
+
+    @discardableResult
+    func upload(
+        commandEvent _: CommandEvent,
+        fullHandle _: String,
+        serverURL _: URL,
+        sessionDirectory _: AbsolutePath?
+    ) async throws -> ServerCommandEvent {
+        try await Task.sleep(for: delay)
+        return .test()
     }
 }
 

--- a/cli/Tests/TuistKitTests/Services/AnalyticsUploadCommandServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/AnalyticsUploadCommandServiceTests.swift
@@ -135,6 +135,34 @@ struct AnalyticsUploadCommandServiceTests {
         #expect(exists == false)
     }
 
+    @Test(.inTemporaryDirectory) func run_whenUploadTimesOut_deletesEventFile() async throws {
+        // Given
+        let fileSystem = FileSystem()
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let eventFilePath = temporaryDirectory.appending(component: "event.json")
+
+        let event = CommandEvent.test()
+        let eventData = try JSONEncoder().encode(event)
+        try eventData.write(to: eventFilePath.url, options: .atomic)
+        let subject = AnalyticsUploadCommandService(
+            fileSystem: fileSystem,
+            uploadAnalyticsService: DelayedUploadAnalyticsService(delay: .seconds(1)),
+            configLoader: configLoader,
+            bestEffortUploadTimeout: .milliseconds(1)
+        )
+
+        // When / Then
+        await #expect(throws: AnalyticsUploadCommandServiceError.uploadTimedOut) {
+            try await subject.run(
+                eventFilePath: eventFilePath.pathString,
+                fullHandle: fullHandle,
+                serverURL: serverURL
+            )
+        }
+        let exists = try await fileSystem.exists(eventFilePath)
+        #expect(exists == false)
+    }
+
     @Test(.inTemporaryDirectory) func run_throws_error_for_invalid_server_url() async throws {
         // Given
         let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
@@ -266,6 +294,20 @@ private struct RecordingUploadAnalyticsService: UploadAnalyticsServicing {
         sessionDirectory _: AbsolutePath?
     ) async throws -> ServerCommandEvent {
         await recorder.record(ServerAuthenticationConfig.current.optionalAuthentication)
+        return .test()
+    }
+}
+
+private struct DelayedUploadAnalyticsService: UploadAnalyticsServicing {
+    let delay: Duration
+
+    func upload(
+        commandEvent _: CommandEvent,
+        fullHandle _: String,
+        serverURL _: URL,
+        sessionDirectory _: AbsolutePath?
+    ) async throws -> ServerCommandEvent {
+        try await Task.sleep(for: delay)
         return .test()
     }
 }

--- a/cli/Tests/TuistServerTests/Utilities/RetryProviderTests.swift
+++ b/cli/Tests/TuistServerTests/Utilities/RetryProviderTests.swift
@@ -67,4 +67,41 @@ final class RetryProviderTests: TuistUnitTestCase {
         // Then
         XCTAssertEqual(operationCalls, 4)
     }
+
+    func test_runWithRetries_whenOperationIsCancelled_doesNotRetry() async throws {
+        // Given / When
+        do {
+            try await subject.runWithRetries { [self] in
+                operationCalls += 1
+                throw CancellationError()
+            }
+            XCTFail("Expected cancellation")
+        } catch is CancellationError {}
+
+        // Then
+        XCTAssertEqual(operationCalls, 1)
+    }
+
+    func test_runWithRetries_whenCallerTaskIsCancelled_cancelsInFlightOperation() async throws {
+        // Given
+        let operationStarted = expectation(description: "Operation started")
+        let task = Task {
+            try await subject.runWithRetries {
+                operationStarted.fulfill()
+                try await Task.sleep(for: .seconds(2))
+            }
+        }
+        await fulfillment(of: [operationStarted], timeout: 1)
+
+        // When
+        let cancellationStartedAt = Date()
+        task.cancel()
+
+        // Then
+        do {
+            try await task.value
+            XCTFail("Expected cancellation")
+        } catch is CancellationError {}
+        XCTAssertLessThan(Date().timeIntervalSince(cancellationStartedAt), 0.5)
+    }
 }


### PR DESCRIPTION
## What changed

This caps best-effort run metadata uploads at 15 seconds in both places where they can run:

- Foreground uploads that happen in continuous integration when analytics are useful but not required.
- The hidden background `analytics-upload` command used by normal local commands.

The command tracking path still keeps report-producing uploads on the existing foreground path. The new timeout applies only to best-effort uploads, logs a warning in the foreground case, and lets the completed command finish.

The retry provider now runs work in the caller task instead of wrapping each operation in an unstructured task. That lets cancellation from the upload deadline reach retry-wrapped server calls and retry sleeps promptly.

## Why

`tuist install` can run against a self-hosted server. When that server is slow or unhealthy, the command has already done its useful work, so run metadata upload should not make the process wait much longer than users expect.

The same principle applies outside continuous integration. Local commands already put non-required analytics into a background process, but that hidden process should also have a clear budget instead of lingering on a bad connection.

Fixes #11452.

## Root cause

Non-required analytics normally upload in a background process, but continuous integration forces the same upload into the foreground so the process can finish publishing metadata before the job exits. That made best-effort metadata share the same blocking behavior as required build and test reporting.

The background upload command also had no explicit total deadline. Local command latency was protected by backgrounding, but the spawned upload process could still spend too long waiting on a slow or unhealthy server.

The first timeout implementation exposed another issue: retry-wrapped uploads went through `Task { ... }.value`, so cancelling the caller did not cancel the in-flight retry operation. The deadline could log late, after the server call or retry loop had already finished waiting.

## Approach

Required analytics still run without the new short deadline because they produce report links and job summaries. Best-effort uploads now get a 15 second total budget around the whole upload operation, whether they are foregrounded for continuous integration or executed by the hidden background upload command.

The background upload service keeps using its cleanup wrapper, so the temporary event file is removed even when the timeout fires.

Retry cancellation is preserved by keeping retry attempts in the caller task and treating `CancellationError` as a non-retryable result. That makes the upload deadline an actual upper bound for cooperative operations such as server requests and retry sleeps.

## Impact

Commands such as `tuist install` can finish promptly when their configured server is slow or unhealthy. Outside continuous integration, the user-facing command was already decoupled from upload latency, and now the hidden upload process also stops promptly.

Build and test report uploads keep their previous behavior because their analytics are marked as required.

Retry callers now stop promptly when their parent task is cancelled instead of continuing in a detached task.

## Validation

- `TUIST_CACHE_ENDPOINT=http://127.0.0.1:1 tuist install`
- `TUIST_CACHE_ENDPOINT=http://127.0.0.1:1 tuist generate TuistKitTests tuist ProjectDescription --no-open --cache-profile none`
- `TUIST_CACHE_ENDPOINT=http://127.0.0.1:1 tuist generate TuistKitTests TuistServerTests tuist ProjectDescription --no-open --cache-profile none`
- `xcodebuild test -workspace Tuist.xcworkspace -scheme Tuist-Workspace -only-testing TuistKitTests/TrackableCommandTests -only-testing TuistKitTests/AnalyticsUploadCommandServiceTests -only-testing TuistServerTests/RetryProviderTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""`
- `xcodebuild test -workspace Tuist.xcworkspace -scheme Tuist-Workspace -only-testing TuistKitTests/AnalyticsUploadCommandServiceTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""`
- `mise run cli:lint`
