### PR TITLE
fix(tuist-ops): use GitHub App tokens for previews

### DIFF
--- a/infra/helm/tuist-ops/README.md
+++ b/infra/helm/tuist-ops/README.md
@@ -30,8 +30,10 @@ cross-call this deployment via the tailnet for the policy lookup.
 1. **Create `TUIST_OPS_BOT` 1P item** in the production vault with fields:
    - `tailscale_client_id`, `tailscale_client_secret`, `tailscale_tailnet`
    - `slack_signing_secret`, `slack_bot_token`, `slack_approvals_channel_id`
-   - `github_actions_token` — GitHub token that can dispatch and read the
-     `preview-deploy.yml` workflow in `tuist/tuist`
+   - `github_app_id`, `github_app_installation_id`, `github_app_private_key` —
+     GitHub App credentials for dispatching and reading the `preview-deploy.yml`
+     workflow in `tuist/tuist`. The App installation needs read and write access
+     to Actions for `tuist/tuist`; metadata access is always included by GitHub.
    - `secret_key_base` — generate via `mix phx.gen.secret`
 2. **Update the Slack app**'s slash command URL to
    `https://ops.tuist.dev/webhooks/slack/slash` and the interactivity

--- a/infra/helm/tuist-ops/templates/externalsecret.yaml
+++ b/infra/helm/tuist-ops/templates/externalsecret.yaml
@@ -32,7 +32,9 @@ spec:
         SLACK_SIGNING_SECRET: "{{ `{{ .slack_signing_secret | trim }}` }}"
         SLACK_BOT_TOKEN: "{{ `{{ .slack_bot_token | trim }}` }}"
         SLACK_APPROVALS_CHANNEL_ID: "{{ `{{ .slack_approvals_channel_id | trim }}` }}"
-        GITHUB_ACTIONS_TOKEN: "{{ `{{ .github_actions_token | trim }}` }}"
+        GITHUB_APP_ID: "{{ `{{ .github_app_id | trim }}` }}"
+        GITHUB_APP_INSTALLATION_ID: "{{ `{{ .github_app_installation_id | trim }}` }}"
+        GITHUB_APP_PRIVATE_KEY: "{{ `{{ .github_app_private_key }}` }}"
         # Ed25519 PRIVATE key (PEM) that signs operator project-access
         # grants; the customer server holds only the matching public
         # key. Rotating this pair is the break-glass revocation for all

--- a/infra/helm/tuist-ops/values.yaml
+++ b/infra/helm/tuist-ops/values.yaml
@@ -110,7 +110,7 @@ service:
 # Fields expected on TUIST_OPS_BOT:
 #   tailscale_client_id, tailscale_client_secret, tailscale_tailnet,
 #   slack_signing_secret, slack_bot_token, slack_approvals_channel_id,
-#   github_actions_token
+#   github_app_id, github_app_installation_id, github_app_private_key
 externalSecret:
   enabled: true
   refreshInterval: "1h"

--- a/tuist-ops/AGENTS.md
+++ b/tuist-ops/AGENTS.md
@@ -41,6 +41,8 @@ Pomerium).
 - `lib/tuist_ops/previews.ex` — request lifecycle API
 - `lib/tuist_ops/previews/` — Ecto schema, Slack Block Kit,
   and GitHub Actions workflow-dispatch client
+- `lib/tuist_ops/github/` — GitHub App installation token minting and cache for
+  preview workflow calls
 - `/preview` with no arguments opens an interactive Slack form for creating or
   deleting previews
 - `/preview create <slug> [duration] [pr:<number>|sha:<sha>] <reason>` dispatches

--- a/tuist-ops/lib/tuist_ops/environment.ex
+++ b/tuist-ops/lib/tuist_ops/environment.ex
@@ -17,7 +17,9 @@ defmodule TuistOps.Environment do
   def approvals_channel_id, do: System.get_env("SLACK_APPROVALS_CHANNEL_ID")
   def previews_channel_id, do: System.get_env("SLACK_PREVIEWS_CHANNEL_ID")
 
-  def github_actions_token, do: System.get_env("GITHUB_ACTIONS_TOKEN")
+  def github_app_id, do: System.get_env("GITHUB_APP_ID")
+  def github_app_installation_id, do: System.get_env("GITHUB_APP_INSTALLATION_ID")
+  def github_app_private_key, do: System.get_env("GITHUB_APP_PRIVATE_KEY")
   def github_repository, do: System.get_env("GITHUB_REPOSITORY") || "tuist/tuist"
   def github_workflow_ref, do: System.get_env("GITHUB_WORKFLOW_REF") || "main"
 

--- a/tuist-ops/lib/tuist_ops/github/app_token.ex
+++ b/tuist-ops/lib/tuist_ops/github/app_token.ex
@@ -1,0 +1,148 @@
+defmodule TuistOps.GitHub.AppToken do
+  @moduledoc """
+  Mints and caches GitHub App installation tokens for GitHub workflow calls.
+  """
+
+  alias TuistOps.Environment
+
+  @cache_key {__MODULE__, :installation_token}
+  @github_api_url "https://api.github.com"
+  @jwt_ttl_seconds 600
+  @refresh_margin_seconds 60
+
+  def token(opts \\ []) do
+    cache_key = cache_key(opts)
+
+    case cached_token(cache_key) do
+      {:ok, token} -> {:ok, token}
+      :miss -> refresh_token(cache_key)
+    end
+  end
+
+  def clear_cache(opts \\ []) do
+    opts
+    |> cache_key()
+    |> :persistent_term.erase()
+
+    :ok
+  rescue
+    ArgumentError -> :ok
+  end
+
+  defp cache_key(opts) do
+    Keyword.get(opts, :cache_key, @cache_key)
+  end
+
+  defp cached_token(cache_key) do
+    case :persistent_term.get(cache_key, nil) do
+      {token, expires_at} when is_binary(token) ->
+        refresh_after = DateTime.add(DateTime.utc_now(), @refresh_margin_seconds, :second)
+
+        if DateTime.compare(expires_at, refresh_after) == :gt do
+          {:ok, token}
+        else
+          :miss
+        end
+
+      _ ->
+        :miss
+    end
+  end
+
+  defp refresh_token(cache_key) do
+    with {:ok, credentials} <- credentials(),
+         {:ok, jwt} <- app_jwt(credentials) do
+      credentials.installation_id
+      |> token_url()
+      |> Req.post(headers: app_headers(jwt))
+      |> handle_token_response(cache_key)
+    end
+  end
+
+  defp credentials do
+    with {:ok, app_id} <- required_env(Environment.github_app_id(), "GITHUB_APP_ID"),
+         {:ok, installation_id} <-
+           required_env(Environment.github_app_installation_id(), "GITHUB_APP_INSTALLATION_ID"),
+         {:ok, private_key} <-
+           required_env(Environment.github_app_private_key(), "GITHUB_APP_PRIVATE_KEY") do
+      {:ok,
+       %{
+         app_id: app_id,
+         installation_id: installation_id,
+         private_key: normalize_private_key(private_key)
+       }}
+    end
+  end
+
+  defp required_env(value, name) when is_binary(value) do
+    case String.trim(value) do
+      "" -> {:error, {:missing_env, name}}
+      trimmed_value -> {:ok, trimmed_value}
+    end
+  end
+
+  defp required_env(_value, name), do: {:error, {:missing_env, name}}
+
+  defp normalize_private_key(private_key) do
+    String.replace(private_key, "\\n", "\n")
+  end
+
+  defp app_jwt(%{app_id: app_id, private_key: private_key}) do
+    private_key = JOSE.JWK.from_pem(private_key)
+    now = DateTime.to_unix(DateTime.utc_now())
+
+    claims = %{
+      "iat" => now - 60,
+      "exp" => now + @jwt_ttl_seconds,
+      "iss" => app_id
+    }
+
+    {_meta, jwt} =
+      private_key
+      |> JOSE.JWT.sign(%{"alg" => "RS256"}, claims)
+      |> JOSE.JWS.compact()
+
+    {:ok, jwt}
+  rescue
+    error -> {:error, {:invalid_private_key, Exception.message(error)}}
+  end
+
+  defp token_url(installation_id) do
+    "#{@github_api_url}/app/installations/#{installation_id}/access_tokens"
+  end
+
+  defp app_headers(jwt) do
+    [
+      {"Accept", "application/vnd.github+json"},
+      {"Authorization", "Bearer #{jwt}"},
+      {"X-GitHub-Api-Version", "2022-11-28"}
+    ]
+  end
+
+  defp handle_token_response(
+         {:ok, %Req.Response{status: 201, body: %{"token" => token, "expires_at" => expires_at}}},
+         cache_key
+       )
+       when is_binary(token) do
+    case DateTime.from_iso8601(expires_at) do
+      {:ok, expires_at, _offset} ->
+        :persistent_term.put(cache_key, {token, expires_at})
+        {:ok, token}
+
+      {:error, reason} ->
+        {:error, {:invalid_expires_at, reason}}
+    end
+  end
+
+  defp handle_token_response({:ok, %Req.Response{status: 201, body: body}}, _cache_key) do
+    {:error, {:invalid_response, body}}
+  end
+
+  defp handle_token_response({:ok, %Req.Response{status: status, body: body}}, _cache_key) do
+    {:error, {:github_status, status, body}}
+  end
+
+  defp handle_token_response({:error, reason}, _cache_key) do
+    {:error, {:github_error, reason}}
+  end
+end

--- a/tuist-ops/lib/tuist_ops/previews/github_actions_client.ex
+++ b/tuist-ops/lib/tuist_ops/previews/github_actions_client.ex
@@ -4,6 +4,7 @@ defmodule TuistOps.Previews.GitHubActionsClient do
   """
 
   alias TuistOps.Environment
+  alias TuistOps.GitHub.AppToken
 
   def dispatch(action, inputs) when action in ["deploy", "delete"] and is_map(inputs) do
     repo = Environment.github_repository()
@@ -19,9 +20,11 @@ defmodule TuistOps.Previews.GitHubActionsClient do
       inputs: inputs
     }
 
-    url
-    |> Req.post(headers: headers(), body: JSON.encode!(body))
-    |> handle_dispatch(workflow_id, ref, run_name)
+    with {:ok, headers} <- headers() do
+      url
+      |> Req.post(headers: headers, body: JSON.encode!(body))
+      |> handle_dispatch(workflow_id, ref, run_name)
+    end
   end
 
   def workflow_run_name(action, inputs) when action in ["deploy", "delete"] and is_map(inputs) do
@@ -45,18 +48,27 @@ defmodule TuistOps.Previews.GitHubActionsClient do
     workflow_id = Environment.preview_workflow_id()
     url = "https://api.github.com/repos/#{repo}/actions/workflows/#{workflow_id}/runs"
 
-    url
-    |> Req.get(headers: headers(), params: [event: "workflow_dispatch", per_page: 50])
-    |> handle_workflow_run(run_name)
+    with {:ok, headers} <- headers() do
+      url
+      |> Req.get(headers: headers, params: [event: "workflow_dispatch", per_page: 50])
+      |> handle_workflow_run(run_name)
+    end
   end
 
   defp headers do
-    [
-      {"Accept", "application/vnd.github+json"},
-      {"Authorization", "Bearer #{Environment.github_actions_token()}"},
-      {"Content-Type", "application/json; charset=utf-8"},
-      {"X-GitHub-Api-Version", "2022-11-28"}
-    ]
+    case AppToken.token() do
+      {:ok, token} ->
+        {:ok,
+         [
+           {"Accept", "application/vnd.github+json"},
+           {"Authorization", "Bearer #{token}"},
+           {"Content-Type", "application/json; charset=utf-8"},
+           {"X-GitHub-Api-Version", "2022-11-28"}
+         ]}
+
+      {:error, reason} ->
+        {:error, {:github_app_token, reason}}
+    end
   end
 
   defp handle_dispatch({:ok, %Req.Response{status: status}}, workflow_id, ref, run_name)

--- a/tuist-ops/test/github/app_token_test.exs
+++ b/tuist-ops/test/github/app_token_test.exs
@@ -1,0 +1,114 @@
+defmodule TuistOps.GitHub.AppTokenTest do
+  use ExUnit.Case, async: true
+  use Mimic
+
+  alias TuistOps.Environment
+  alias TuistOps.GitHub.AppToken
+
+  setup :verify_on_exit!
+
+  setup context do
+    token_opts = [cache_key: {__MODULE__, context.test}]
+
+    AppToken.clear_cache(token_opts)
+    on_exit(fn -> AppToken.clear_cache(token_opts) end)
+
+    {:ok, token_opts: token_opts}
+  end
+
+  test "mints and caches an installation token", %{token_opts: token_opts} do
+    stub_credentials()
+    stub_jose()
+
+    expect(Req, :post, fn "https://api.github.com/app/installations/456/access_tokens", opts ->
+      assert Enum.member?(opts[:headers], {"Authorization", "Bearer app-jwt"})
+
+      {:ok,
+       %Req.Response{
+         status: 201,
+         body: %{
+           "token" => "installation-token",
+           "expires_at" => "2099-01-01T00:00:00Z"
+         }
+       }}
+    end)
+
+    assert {:ok, "installation-token"} = AppToken.token(token_opts)
+    assert {:ok, "installation-token"} = AppToken.token(token_opts)
+  end
+
+  test "normalizes escaped newlines in the private key", %{token_opts: token_opts} do
+    stub(Environment, :github_app_id, fn -> "123" end)
+    stub(Environment, :github_app_installation_id, fn -> "456" end)
+
+    stub(Environment, :github_app_private_key, fn ->
+      "-----BEGIN RSA PRIVATE KEY-----\\ntest\\n-----END RSA PRIVATE KEY-----"
+    end)
+
+    stub(JOSE.JWK, :from_pem, fn private_key ->
+      assert private_key == "-----BEGIN RSA PRIVATE KEY-----\ntest\n-----END RSA PRIVATE KEY-----"
+      :jwk
+    end)
+
+    stub(JOSE.JWT, :sign, fn :jwk, %{"alg" => "RS256"}, %{"iss" => "123"} -> :signed end)
+    stub(JOSE.JWS, :compact, fn :signed -> {%{}, "app-jwt"} end)
+
+    expect(Req, :post, fn _url, _opts ->
+      {:ok,
+       %Req.Response{
+         status: 201,
+         body: %{"token" => "installation-token", "expires_at" => "2099-01-01T00:00:00Z"}
+       }}
+    end)
+
+    assert {:ok, "installation-token"} = AppToken.token(token_opts)
+  end
+
+  test "returns a missing environment error when credentials are incomplete", %{
+    token_opts: token_opts
+  } do
+    stub(Environment, :github_app_id, fn -> "" end)
+    stub(Environment, :github_app_installation_id, fn -> "456" end)
+    stub(Environment, :github_app_private_key, fn -> "key" end)
+
+    assert {:error, {:missing_env, "GITHUB_APP_ID"}} = AppToken.token(token_opts)
+  end
+
+  test "returns GitHub response errors without caching a token", %{token_opts: token_opts} do
+    stub_credentials()
+    stub_jose()
+
+    expect(Req, :post, fn _url, _opts ->
+      {:ok, %Req.Response{status: 403, body: %{"message" => "Resource not accessible"}}}
+    end)
+
+    assert {:error, {:github_status, 403, %{"message" => "Resource not accessible"}}} =
+             AppToken.token(token_opts)
+  end
+
+  defp stub_credentials do
+    stub(Environment, :github_app_id, fn -> "123" end)
+    stub(Environment, :github_app_installation_id, fn -> "456" end)
+
+    stub(Environment, :github_app_private_key, fn ->
+      "-----BEGIN RSA PRIVATE KEY-----\ntest\n-----END RSA PRIVATE KEY-----"
+    end)
+  end
+
+  defp stub_jose do
+    stub(
+      JOSE.JWK,
+      :from_pem,
+      fn "-----BEGIN RSA PRIVATE KEY-----\ntest\n-----END RSA PRIVATE KEY-----" ->
+        :jwk
+      end
+    )
+
+    stub(JOSE.JWT, :sign, fn :jwk, %{"alg" => "RS256"}, %{"iss" => "123"} = claims ->
+      assert claims["iat"] < claims["exp"]
+      :signed
+    end)
+
+    stub(JOSE.JWS, :compact, fn :signed -> {%{}, "app-jwt"} end)
+  end
+end

--- a/tuist-ops/test/previews/github_actions_client_test.exs
+++ b/tuist-ops/test/previews/github_actions_client_test.exs
@@ -3,6 +3,7 @@ defmodule TuistOps.Previews.GitHubActionsClientTest do
   use Mimic
 
   alias TuistOps.Environment
+  alias TuistOps.GitHub.AppToken
   alias TuistOps.Previews.GitHubActionsClient
 
   setup :verify_on_exit!
@@ -17,7 +18,7 @@ defmodule TuistOps.Previews.GitHubActionsClientTest do
   test "workflow_run finds the matching workflow run by display title" do
     stub(Environment, :github_repository, fn -> "tuist/tuist" end)
     stub(Environment, :preview_workflow_id, fn -> "preview-deploy.yml" end)
-    stub(Environment, :github_actions_token, fn -> "token" end)
+    stub(AppToken, :token, fn -> {:ok, "installation-token"} end)
 
     expect(
       Req,
@@ -25,6 +26,7 @@ defmodule TuistOps.Previews.GitHubActionsClientTest do
       fn "https://api.github.com/repos/tuist/tuist/actions/workflows/preview-deploy.yml/runs",
          opts ->
         assert opts[:params] == [event: "workflow_dispatch", per_page: 50]
+        assert Enum.member?(opts[:headers], {"Authorization", "Bearer installation-token"})
 
         {:ok,
          %Req.Response{
@@ -58,5 +60,48 @@ defmodule TuistOps.Previews.GitHubActionsClientTest do
               conclusion: "success",
               html_url: "https://github.com/match"
             }} = GitHubActionsClient.workflow_run("Preview deploy demo #123")
+  end
+
+  test "dispatch triggers the preview workflow with an installation token" do
+    stub(Environment, :github_repository, fn -> "tuist/tuist" end)
+    stub(Environment, :preview_workflow_id, fn -> "preview-deploy.yml" end)
+    stub(Environment, :github_workflow_ref, fn -> "main" end)
+    stub(AppToken, :token, fn -> {:ok, "installation-token"} end)
+
+    expect(
+      Req,
+      :post,
+      fn "https://api.github.com/repos/tuist/tuist/actions/workflows/preview-deploy.yml/dispatches",
+         opts ->
+        assert Enum.member?(opts[:headers], {"Authorization", "Bearer installation-token"})
+
+        assert JSON.decode!(opts[:body]) == %{
+                 "ref" => "main",
+                 "inputs" => %{
+                   "action" => "deploy",
+                   "preview_id" => "123",
+                   "slug" => "demo"
+                 }
+               }
+
+        {:ok, %Req.Response{status: 204, body: ""}}
+      end
+    )
+
+    assert {:ok,
+            %{
+              workflow_id: "preview-deploy.yml",
+              workflow_ref: "main",
+              run_name: "Preview deploy demo #123"
+            }} = GitHubActionsClient.dispatch("deploy", %{slug: "demo", preview_id: "123"})
+  end
+
+  test "returns token errors before calling GitHub" do
+    stub(Environment, :github_repository, fn -> "tuist/tuist" end)
+    stub(Environment, :preview_workflow_id, fn -> "preview-deploy.yml" end)
+    stub(AppToken, :token, fn -> {:error, {:missing_env, "GITHUB_APP_ID"}} end)
+
+    assert {:error, {:github_app_token, {:missing_env, "GITHUB_APP_ID"}}} =
+             GitHubActionsClient.workflow_run("Preview deploy demo #123")
   end
 end

--- a/tuist-ops/test/test_helper.exs
+++ b/tuist-ops/test/test_helper.exs
@@ -4,11 +4,15 @@ alias Ecto.Adapters.SQL.Sandbox
 # Tailscale HTTP, env var reads). Mirrors server's test_helper
 # shape so tests can stub via `stub(Module, :fun, fn ... -> ... end)`.
 Mimic.copy(TuistOps.Environment)
+Mimic.copy(TuistOps.GitHub.AppToken)
 Mimic.copy(TuistOps.Previews)
 Mimic.copy(TuistOps.Previews.GitHubActionsClient)
 Mimic.copy(TuistOps.JIT.Approvals)
 Mimic.copy(TuistOps.JIT.SlackClient)
 Mimic.copy(TuistOps.JIT.TailscaleClient)
+Mimic.copy(JOSE.JWK)
+Mimic.copy(JOSE.JWT)
+Mimic.copy(JOSE.JWS)
 Mimic.copy(Req)
 
 ExUnit.start(exclude: [:skip])


### PR DESCRIPTION
Resolves N/A

## What changed

This changes preview workflow calls in `tuist-ops` to use a GitHub App installation token instead of the long-lived `GITHUB_ACTIONS_TOKEN` value.

The new `TuistOps.GitHub.AppToken` module:
- reads the GitHub App identifier, installation identifier, and private key from the runtime environment
- signs an app token and exchanges it for a short-lived installation token
- caches the installation token until shortly before its GitHub expiry
- accepts private keys stored with real newlines or escaped newlines

The preview GitHub Actions client now asks that module for its bearer token before dispatching or polling preview workflow runs. The Helm chart now maps `github_app_id`, `github_app_installation_id`, and `github_app_private_key` from the existing `TUIST_OPS_BOT` 1Password item.

## Why

Preview requests were failing while publishing progress back to Slack because the existing token authenticated as the shared `tuistit` user and hit GitHub's user-level rate limit. Re-minting the same kind of token did not help, because the limit follows the authenticated user rather than the string value of the token.

## Root cause

`tuist-ops` used one long-lived personal token for preview workflow dispatch and run polling. That made preview provisioning share rate-limit capacity with every other use of the same GitHub user.

## Approach

A GitHub App installation token is the standard fit here because it is scoped to the installed app and repository permissions, it is short lived, and it avoids coupling preview operations to a human or shared bot user's rate-limit bucket.

The implementation keeps the current GitHub Actions workflow boundary intact. `tuist-ops` still does not carry workload-cluster credentials. It only dispatches and reads the existing `preview-deploy.yml` workflow.

## Impact

New preview requests need the `TUIST_OPS_BOT` 1Password item to contain the GitHub App fields before deployment. Once deployed, preview workflow calls should use the app installation's quota and permissions instead of the `tuistit` user's quota.

## Validation

- `cd tuist-ops && mix test`
- `cd tuist-ops && mix credo --strict lib/tuist_ops/github/app_token.ex lib/tuist_ops/previews/github_actions_client.ex`
- `helm template tuist-ops infra/helm/tuist-ops -f infra/helm/tuist-ops/values-managed-production.yaml --set image.tag=sha-test`
- `git diff --check`

### How to test locally

Run the validation commands above. To exercise the live path, configure the GitHub App fields in `TUIST_OPS_BOT`, deploy `tuist-ops`, and request a preview from Slack.
