### PR TITLE
fix(infra): avoid runner context in preview workflow env

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -464,7 +464,7 @@ jobs:
       cancel-in-progress: false
     timeout-minutes: 30
     env:
-      KUBECONFIG: ${{ runner.temp }}/preview-kubeconfig
+      KUBECONFIG: /tmp/tuist-preview-kubeconfig-${{ github.run_id }}-${{ github.run_attempt }}
       RELEASE: ${{ needs.resolve.outputs.release }}
       NAMESPACE: ${{ needs.resolve.outputs.namespace }}
       HOST: ${{ needs.resolve.outputs.host }}
@@ -708,7 +708,7 @@ jobs:
       cancel-in-progress: false
     timeout-minutes: 15
     env:
-      KUBECONFIG: ${{ runner.temp }}/preview-kubeconfig
+      KUBECONFIG: /tmp/tuist-preview-kubeconfig-${{ github.run_id }}-${{ github.run_attempt }}
       RELEASE: ${{ needs.resolve.outputs.release }}
       NAMESPACE: ${{ needs.resolve.outputs.namespace }}
     steps:


### PR DESCRIPTION
Resolves N/A

## What changed

This replaces the preview workflow's job-level `KUBECONFIG` value from `${{ runner.temp }}/preview-kubeconfig` to a `/tmp` path that is unique per workflow run and attempt.

## Why

Slack-triggered preview requests now reach GitHub with the GitHub App installation token, but GitHub rejects the workflow dispatch with a 422 before creating a run.

## Root cause

The workflow used the `runner` context inside `jobs.<job>.env` for both deploy and delete jobs. GitHub does not expose that context while parsing job-level environment values, so the dispatch endpoint fails with `Unrecognized named-value: 'runner'`.

## Approach

Use `github.run_id` and `github.run_attempt`, which are available while GitHub parses the workflow, to build a unique kubeconfig path under `/tmp`. The existing steps still write and read the kubeconfig through `KUBECONFIG`.

## Impact

Preview workflow dispatches should pass GitHub's workflow parser and create runs again. The kubeconfig file remains scoped to the current run attempt path and is not checked into the workspace.

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/preview-deploy.yml"); puts "yaml ok"'`
- `rg -n "runner\.temp|tuist-preview-kubeconfig" .github/workflows/preview-deploy.yml`
- `git diff --check`

### How to test locally

The workflow can be syntax-checked locally with the validation commands above. The end-to-end validation is to merge this and request a preview from Slack, because the failing parser is GitHub's workflow dispatch endpoint.
