### PR TITLE
fix(server): scale flaky-alert rolling recovery query so alerts don't wedge

### DIFF
--- a/server/lib/tuist/automations/workers/alert_evaluation_worker.ex
+++ b/server/lib/tuist/automations/workers/alert_evaluation_worker.ex
@@ -15,6 +15,11 @@ defmodule Tuist.Automations.Workers.AlertEvaluationWorker do
 
   require Logger
 
+  # Recovery candidates are counted in ClickHouse in batches of this size so the
+  # `Array(UUID)` parameter and the run scan stay within the engine's request
+  # limits no matter how many tests an alert has quarantined.
+  @recovery_candidate_batch_size 500
+
   @impl Oban.Worker
   def perform(%Oban.Job{args: %{"alert_id" => alert_id} = args}) do
     case Automations.get_alert(alert_id) do
@@ -234,13 +239,14 @@ defmodule Tuist.Automations.Workers.AlertEvaluationWorker do
     end)
   end
 
-  # Each candidate has its own `triggered_at` cutoff, so we can't push the
-  # per-candidate filter cleanly into a single SQL `GROUP BY` without a
-  # cross-join. Instead, one query pulls every run for the candidate test
-  # cases above the global minimum `triggered_at`, and the per-candidate
-  # cutoff is applied in Elixir. That trades a small over-fetch (rows
-  # between `min(triggered_at)` and each candidate's own `triggered_at`)
-  # for one round-trip instead of one-per-candidate.
+  # Counts, per candidate, the runs that followed its own `triggered_at`. The
+  # count is aggregated inside ClickHouse (one row per candidate) rather than
+  # streaming every run back to be tallied in Elixir — a long-muted,
+  # high-frequency test would otherwise return millions of rows. Candidates are
+  # processed in batches because a bare `test_case_id in ^ids` over a large
+  # quarantined set overflows ClickHouse's request limits (the same reason
+  # `Tests.test_case_ids_with_successful_default_branch_run` batches with an
+  # `Array(UUID)` parameter); each batch bounds the parameter and the scan.
   #
   # We don't use `FINAL` here for the same reason as in the rolling-window
   # monitor: `test_case_runs` is a ReplacingMergeTree on a hot table where
@@ -250,30 +256,46 @@ defmodule Tuist.Automations.Workers.AlertEvaluationWorker do
   defp batch_runs_since_trigger(_project_id, []), do: %{}
 
   defp batch_runs_since_trigger(project_id, candidates) do
-    test_case_ids = Enum.map(candidates, & &1.test_case_id)
-    trigger_by_id = Map.new(candidates, &{&1.test_case_id, &1.triggered_at})
-    min_triggered_at = candidates |> Enum.map(& &1.triggered_at) |> Enum.min(NaiveDateTime)
+    candidates
+    |> Enum.chunk_every(@recovery_candidate_batch_size)
+    |> Enum.reduce(%{}, fn batch, acc ->
+      Map.merge(acc, batch_run_counts(project_id, batch))
+    end)
+  end
+
+  # `cutoffs` is positionally aligned with `test_case_ids`, so for each run row
+  # `arrayElement(cutoffs, indexOf(test_case_ids, test_case_id))` resolves the
+  # candidate's own `triggered_at` (in microseconds) and the count only includes
+  # runs strictly after it. The `ran_at > min_triggered_at` clause narrows the
+  # primary-key scan to runs after the earliest trigger in the batch.
+  defp batch_run_counts(project_id, batch) do
+    test_case_ids = Enum.map(batch, & &1.test_case_id)
+    cutoffs = Enum.map(batch, &triggered_at_micros(&1.triggered_at))
+    min_triggered_at = batch |> Enum.map(& &1.triggered_at) |> Enum.min(NaiveDateTime)
 
     from(r in TestCaseRun,
       where: r.project_id == ^project_id,
-      where: r.test_case_id in ^test_case_ids,
+      where: fragment("? IN (?)", r.test_case_id, type(^test_case_ids, {:array, Ecto.UUID})),
       where: r.ran_at > ^min_triggered_at,
-      select: {r.test_case_id, r.ran_at}
+      where:
+        fragment(
+          "toUnixTimestamp64Micro(?) > arrayElement(?, indexOf(?, ?))",
+          r.ran_at,
+          type(^cutoffs, {:array, :integer}),
+          type(^test_case_ids, {:array, Ecto.UUID}),
+          r.test_case_id
+        ),
+      group_by: r.test_case_id,
+      select: {r.test_case_id, fragment("count(*)")}
     )
-    |> ClickHouseRepo.all()
-    |> Enum.reduce(%{}, fn {test_case_id, ran_at}, acc ->
-      case Map.get(trigger_by_id, test_case_id) do
-        nil ->
-          acc
+    |> ClickHouseRepo.all(multipart: true)
+    |> Map.new()
+  end
 
-        triggered_at ->
-          if NaiveDateTime.after?(ran_at, triggered_at) do
-            Map.update(acc, test_case_id, 1, &(&1 + 1))
-          else
-            acc
-          end
-      end
-    end)
+  defp triggered_at_micros(%NaiveDateTime{} = triggered_at) do
+    triggered_at
+    |> DateTime.from_naive!("Etc/UTC")
+    |> DateTime.to_unix(:microsecond)
   end
 
   defp parse_rolling_size(size) when is_integer(size) and size > 0, do: min(size, Alert.max_rolling_window_size())

--- a/server/test/tuist/automations/workers/alert_evaluation_worker_test.exs
+++ b/server/test/tuist/automations/workers/alert_evaluation_worker_test.exs
@@ -7,8 +7,11 @@ defmodule Tuist.Automations.Workers.AlertEvaluationWorkerTest do
   alias Tuist.Automations.Monitors.FlakyTestsMonitor
   alias Tuist.Automations.Workers.AlertEvaluationWorker
   alias Tuist.ClickHouseRepo
+  alias Tuist.IngestRepo
   alias Tuist.Tests
+  alias Tuist.Tests.TestCaseRun
   alias TuistTestSupport.Fixtures.AutomationsFixtures
+  alias TuistTestSupport.Fixtures.ProjectsFixtures
 
   setup do
     # By default, treat every triggered test case as validated on the default
@@ -288,10 +291,7 @@ defmodule Tuist.Automations.Workers.AlertEvaluationWorkerTest do
     end)
 
     # 7 runs have happened since the trigger, exceeds the rolling window of 5.
-    expect(ClickHouseRepo, :all, fn _query ->
-      now = NaiveDateTime.utc_now()
-      Enum.map(1..7, fn i -> {recovered_id, NaiveDateTime.add(now, i, :second)} end)
-    end)
+    expect(ClickHouseRepo, :all, fn _query, _opts -> [{recovered_id, 7}] end)
 
     expected_entity = %{type: :test_case, id: recovered_id}
     expect(ActionExecutor, :execute_actions, fn _actions, ^automation, ^expected_entity -> :ok end)
@@ -327,10 +327,7 @@ defmodule Tuist.Automations.Workers.AlertEvaluationWorkerTest do
 
     # Only 2 runs since the trigger — below the rolling window of 5, so recovery
     # should not fire.
-    expect(ClickHouseRepo, :all, fn _query ->
-      now = NaiveDateTime.utc_now()
-      Enum.map(1..2, fn i -> {recovered_id, NaiveDateTime.add(now, i, :second)} end)
-    end)
+    expect(ClickHouseRepo, :all, fn _query, _opts -> [{recovered_id, 2}] end)
 
     reject(&ActionExecutor.execute_actions/3)
     reject(&Automations.create_alert_event/1)
@@ -355,12 +352,96 @@ defmodule Tuist.Automations.Workers.AlertEvaluationWorkerTest do
       Enum.map(ids, fn id -> %{test_case_id: id, triggered_at: NaiveDateTime.utc_now()} end)
     end)
 
-    # Exactly one ClickHouseRepo.all/1 call regardless of candidate count — no
-    # N+1.
-    expect(ClickHouseRepo, :all, 1, fn _query -> [] end)
+    # A single batched query regardless of candidate count — no N+1.
+    expect(ClickHouseRepo, :all, 1, fn _query, _opts -> [] end)
 
     reject(&ActionExecutor.execute_actions/3)
     reject(&Automations.create_alert_event/1)
+
+    assert :ok = run(automation.id)
+  end
+
+  test "rolling recovery fires only for candidates with enough runs since their own trigger" do
+    automation =
+      AutomationsFixtures.automation_alert_fixture(
+        recovery_enabled: true,
+        recovery_config: %{"window_type" => "rolling", "rolling_window_size" => 5},
+        recovery_actions: [%{"type" => "change_state", "state" => "enabled"}]
+      )
+
+    [ready_id, not_ready_id] = Enum.map(1..2, fn _ -> Ecto.UUID.generate() end)
+
+    expect(FlakyTestsMonitor, :evaluate, fn _automation ->
+      %{triggered: [], all: [ready_id, not_ready_id]}
+    end)
+
+    expect(Automations, :list_active_alert_events, fn _id ->
+      now = NaiveDateTime.utc_now()
+
+      [
+        %{test_case_id: ready_id, triggered_at: now},
+        %{test_case_id: not_ready_id, triggered_at: now}
+      ]
+    end)
+
+    # The aggregated query returns a per-candidate count: ready_id cleared the
+    # rolling window of 5, not_ready_id did not.
+    expect(ClickHouseRepo, :all, fn _query, _opts -> [{ready_id, 6}, {not_ready_id, 3}] end)
+
+    expected_entity = %{type: :test_case, id: ready_id}
+    expect(ActionExecutor, :execute_actions, fn _actions, ^automation, ^expected_entity -> :ok end)
+
+    expect(Automations, :create_alert_event, fn %{test_case_id: ^ready_id, status: "recovered"} -> :ok end)
+
+    assert :ok = run(automation.id)
+  end
+
+  test "rolling recovery counts only runs after each candidate's own trigger (real ClickHouse)" do
+    project = ProjectsFixtures.project_fixture()
+
+    automation =
+      AutomationsFixtures.automation_alert_fixture(
+        project: project,
+        recovery_enabled: true,
+        recovery_config: %{"window_type" => "rolling", "rolling_window_size" => 3},
+        recovery_actions: [%{"type" => "change_state", "state" => "enabled"}]
+      )
+
+    ready_id = UUIDv7.generate()
+    not_ready_id = UUIDv7.generate()
+    base = NaiveDateTime.utc_now()
+    ready_triggered_at = base
+    not_ready_triggered_at = NaiveDateTime.add(base, 10, :second)
+
+    insert_test_case_runs([
+      # ready_id: a pre-trigger run that must be ignored, then 4 post-trigger
+      # runs — clears the rolling window of 3.
+      run_attrs(project.id, ready_id, NaiveDateTime.add(base, -5, :second)),
+      run_attrs(project.id, ready_id, NaiveDateTime.add(base, 1, :second)),
+      run_attrs(project.id, ready_id, NaiveDateTime.add(base, 2, :second)),
+      run_attrs(project.id, ready_id, NaiveDateTime.add(base, 3, :second)),
+      run_attrs(project.id, ready_id, NaiveDateTime.add(base, 4, :second)),
+      # not_ready_id: 3 runs that fall after the batch's earliest trigger but
+      # before this candidate's own trigger (must be excluded), and only 1 run
+      # after its own trigger — stays below the window of 3.
+      run_attrs(project.id, not_ready_id, NaiveDateTime.add(base, 5, :second)),
+      run_attrs(project.id, not_ready_id, NaiveDateTime.add(base, 6, :second)),
+      run_attrs(project.id, not_ready_id, NaiveDateTime.add(base, 7, :second)),
+      run_attrs(project.id, not_ready_id, NaiveDateTime.add(base, 11, :second))
+    ])
+
+    expect(FlakyTestsMonitor, :evaluate, fn _automation -> %{triggered: []} end)
+
+    expect(Automations, :list_active_alert_events, fn _id ->
+      [
+        %{test_case_id: ready_id, triggered_at: ready_triggered_at},
+        %{test_case_id: not_ready_id, triggered_at: not_ready_triggered_at}
+      ]
+    end)
+
+    expected_entity = %{type: :test_case, id: ready_id}
+    expect(ActionExecutor, :execute_actions, fn _actions, ^automation, ^expected_entity -> :ok end)
+    expect(Automations, :create_alert_event, fn %{test_case_id: ^ready_id, status: "recovered"} -> :ok end)
 
     assert :ok = run(automation.id)
   end
@@ -694,5 +775,31 @@ defmodule Tuist.Automations.Workers.AlertEvaluationWorkerTest do
     end)
 
     assert :ok = run(automation.id)
+  end
+
+  defp insert_test_case_runs(rows), do: IngestRepo.insert_all(TestCaseRun, rows)
+
+  defp run_attrs(project_id, test_case_id, ran_at) do
+    %{
+      id: UUIDv7.generate(),
+      test_run_id: UUIDv7.generate(),
+      test_module_run_id: UUIDv7.generate(),
+      test_case_id: test_case_id,
+      project_id: project_id,
+      is_ci: false,
+      scheme: "",
+      git_branch: "main",
+      git_commit_sha: "",
+      module_name: "MyTests",
+      suite_name: "TestSuite",
+      name: "testExample",
+      status: 0,
+      is_flaky: false,
+      is_new: false,
+      is_quarantined: false,
+      duration: 100,
+      ran_at: ran_at,
+      inserted_at: ran_at
+    }
   end
 end


### PR DESCRIPTION
### Purpose

Recovery-enabled rolling flaky-test alerts were silently going dormant: they stopped marking, muting, and recovering tests entirely, while the rest of the automation engine kept running. The highest-volume alerts (those quarantining the most tests) were the ones that died.

### Root cause

Rolling-window alerts that have a baseline are not cadence-scheduled; they run only through the scoped/incremental evaluation path, and only `recovery_enabled` rolling alerts execute `batch_runs_since_trigger`. That query had two problems that both scale with the number of quarantined tests:

1. It used `where: r.test_case_id in ^ids`, the `IN ^list` form that overflows ClickHouse's request limits for large sets. This is exactly why `Tests.test_case_ids_with_successful_default_branch_run` batches with an `Array(UUID)` parameter instead.
2. It streamed every run since the oldest candidate's `triggered_at` back to the app to count in Elixir — millions of rows for a long-muted, high-frequency test.

When the query raised, the scoped cursor (`last_scoped_evaluation_inserted_at`) — which is advanced only after all chunks process successfully — never moved. The next tick then re-fetched an ever-growing window since the last success, raised again, and so on: a permanent, worsening wedge. Because only recovery-enabled rolling alerts hit this query, low-volume and recovery-disabled alerts were unaffected, which matched the observed pattern (high-recovery-count alerts dead, everything else healthy).

### What changed

`batch_runs_since_trigger` now:

- Aggregates the run count inside ClickHouse (`GROUP BY test_case_id`, one row per candidate) instead of streaming raw runs back to count in Elixir.
- Applies each candidate's own `triggered_at` cutoff exactly, via `toUnixTimestamp64Micro(ran_at) > arrayElement(cutoffs, indexOf(ids, test_case_id))` where `cutoffs` is positionally aligned with the id list.
- Processes candidates in batches (`@recovery_candidate_batch_size`) using the `Array(UUID)` fragment + `multipart: true`, so the parameter and scan stay within ClickHouse's request limits regardless of how many tests an alert has quarantined.

Recovery semantics are unchanged (the per-candidate count is still exact); only the scale characteristics change. With the recovery query bounded, the cursor advances normally and an already-wedged alert self-heals on its next tick, so no cursor-side change is needed.

### How to test locally

`cd server && mix test test/tuist/automations/workers/alert_evaluation_worker_test.exs`

This includes a new real-ClickHouse integration test (`rolling recovery counts only runs after each candidate's own trigger`) that seeds `test_case_runs` and executes the rewritten query end to end. It asserts the per-candidate cutoff is honored: a candidate whose extra runs fall after the batch's earliest trigger but before its own trigger is correctly not counted, so it stays below the rolling window. The other recovery tests mock the repo, so this is the only test that exercises the actual SQL.

### Verifying impact after deploy

The previously-dormant high-recovery alerts should resume producing `triggered`/`recovered` events in `automation_alert_events`, and chronically flaky tests should get re-muted while they remain flaky.
