### PR TITLE
fix(kura): recover the wedged replication mesh and make fresh-node bootstrap fast (read timeout + parallel fetch)

### DIFF
--- a/.github/workflows/kura-runtime-image.yml
+++ b/.github/workflows/kura-runtime-image.yml
@@ -23,7 +23,7 @@ permissions:
   packages: write
 
 env:
-  MISE_VERSION: "2026.4.18"
+  MISE_VERSION: "2026.5.15"
   MISE_GITHUB_TOKEN: ${{ secrets.TUIST_CLI_GITHUB_TOKEN || github.token }}
   REGISTRY: ghcr.io
   IMAGE_NAME: tuist/kura

--- a/.github/workflows/kura-runtime-image.yml
+++ b/.github/workflows/kura-runtime-image.yml
@@ -1,22 +1,87 @@
 name: Kura Runtime Image
 
-# Stub. This only registers the workflow_dispatch trigger on the default branch
-# (GitHub requires a dispatch workflow to exist on the default branch before it
-# can be triggered against any other ref). The real dispatchable build — which
-# compiles the Kura binary at a chosen commit and pushes ghcr.io/tuist/kura —
-# ships in #11294, where it gets a proper review. Because workflow_dispatch runs
-# the workflow file from the dispatched ref, dispatching this against the #11294
-# branch executes that real build.
+# Builds and pushes an ad-hoc Kura runtime image (`ghcr.io/tuist/kura`) from a
+# specific commit, so a feature branch can be deployed to staging before it is
+# merged and the push-to-main `release-kura-docker` job cuts a `kura@` release.
+#
+# The release pipeline builds a multi-arch image from natively-compiled amd64 +
+# arm64 binaries. This dispatch build is amd64-only (the Hetzner managed-region
+# and staging runner nodes are amd64), compiling the binary inline rather than
+# pulling release artifacts. Pair it with a `Server Deployment` dispatch:
+# pass the printed `sha-<sha>` tag as `kura_runtime_image_tag` and the same
+# commit as `commit_sha`.
+#
+# A matching stub registers this workflow_dispatch trigger on the default branch
+# (GitHub requires that before the workflow can be dispatched against any ref);
+# dispatching against this branch runs the real build below.
 
 on:
   workflow_dispatch: {}
 
 permissions:
   contents: read
+  packages: write
+
+env:
+  MISE_VERSION: "2026.4.18"
+  MISE_GITHUB_TOKEN: ${{ secrets.TUIST_CLI_GITHUB_TOKEN || github.token }}
+  REGISTRY: ghcr.io
+  IMAGE_NAME: tuist/kura
 
 jobs:
-  noop:
-    name: Stub
+  build-and-push:
+    name: Build and push (amd64)
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
-      - run: echo "Stub. The real Kura runtime image build ships in #11294."
+      - uses: actions/checkout@v4
+
+      - uses: jdx/mise-action@v4.0.1
+        with:
+          version: ${{ env.MISE_VERSION }}
+          install_args: --force rust
+          working_directory: kura
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: kura-rust-${{ runner.os }}
+          workspaces: |
+            kura -> target
+
+      - name: Build Kura binary
+        working-directory: kura
+        run: env -u RUSTUP_TOOLCHAIN cargo build --release --locked
+
+      - name: Stage binary for Docker build
+        working-directory: kura
+        run: |
+          mkdir -p bin/amd64
+          cp target/release/kura bin/amd64/kura
+          chmod +x bin/amd64/kura
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute tag
+        id: tag
+        run: echo "tag=sha-${GITHUB_SHA::12}" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: ./kura
+          file: ./kura/Dockerfile.release
+          platforms: linux/amd64
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.tag }}
+          cache-from: type=gha,scope=kura-runtime
+          cache-to: type=gha,mode=max,scope=kura-runtime
+
+      - name: Print deploy hint
+        run: |
+          echo "Pushed ${REGISTRY}/${IMAGE_NAME}:${{ steps.tag.outputs.tag }}"
+          echo "Deploy with: Server Deployment (staging) commit_sha=${GITHUB_SHA} kura_runtime_image_tag=${{ steps.tag.outputs.tag }}"

--- a/kura/src/peer_tls.rs
+++ b/kura/src/peer_tls.rs
@@ -74,7 +74,15 @@ impl PeerClientFactory {
     fn builder(&self) -> Result<reqwest::ClientBuilder, String> {
         let mut builder = Client::builder()
             .connect_timeout(Duration::from_secs(5))
-            .timeout(Duration::from_secs(30));
+            // Idle/read timeout, NOT a total request timeout. A bootstrap
+            // artifact streams its whole body over this client; under
+            // cold-start load (bandwidth-limited + congested) a large
+            // artifact's transfer can exceed any fixed total cap, which
+            // aborts it mid-body and surfaces to the peer as an undecodable
+            // (incomplete) response — silently wedging bootstrap. read_timeout
+            // resets on each chunk, so a slow-but-progressing transfer
+            // completes while a genuinely stalled connection still fails fast.
+            .read_timeout(Duration::from_secs(30));
 
         if let (Some(identity_pem), Some(ca_pem)) = (&self.identity_pem, &self.ca_pem) {
             let identity = Identity::from_pem(identity_pem)

--- a/kura/src/replication/mod.rs
+++ b/kura/src/replication/mod.rs
@@ -8,7 +8,7 @@ use std::{
     time::Duration,
 };
 
-use futures_util::StreamExt;
+use futures_util::stream::{self, StreamExt};
 use reqwest::header::{CONTENT_TYPE, HeaderValue};
 use serde::Deserialize;
 use tokio::{
@@ -35,6 +35,10 @@ use crate::{
 use self::{operation::ReplicationOperation, outbox_message::OutboxMessage};
 
 const BOOTSTRAP_PAGE_LIMIT: usize = 256;
+
+// Artifact bodies fetched from a peer concurrently within a bootstrap page. Caps
+// open peer connections; staged bytes stay bounded by bootstrap_staging_budget.
+const BOOTSTRAP_ARTIFACT_FETCH_CONCURRENCY: usize = 16;
 
 #[derive(Debug, Deserialize)]
 struct PeerStatusPayload {
@@ -323,6 +327,11 @@ async fn bootstrap_manifests_from_peer(state: &SharedState, peer: &str) -> Resul
             .store
             .hit_failpoint(FailpointName::AfterBootstrapManifestPageFetchBeforeApply)
             .await?;
+
+        // Cheap local pre-check first: skip artifacts we already hold without a
+        // network fetch, and propagate a real store error instead of masking it as
+        // a per-artifact fetch failure below.
+        let mut to_fetch = Vec::new();
         for manifest in &page.manifests {
             let outcome = state.store.artifact_apply_outcome(
                 manifest.producer,
@@ -330,41 +339,62 @@ async fn bootstrap_manifests_from_peer(state: &SharedState, peer: &str) -> Resul
                 &manifest.key,
                 manifest.version_ms,
             )?;
-            if !outcome.applied() {
+            if outcome.applied() {
+                to_fetch.push(manifest.clone());
+            } else {
                 state
                     .metrics
                     .record_replication_apply("bootstrap", "artifact", outcome.as_str());
-                continue;
             }
+        }
 
-            // A single artifact failing must not abort the whole peer bootstrap.
-            // Aborting strands every later artifact behind the first gap, and when
-            // peers bootstrap from each other simultaneously (e.g. a full-mesh
-            // restart) each one serves still-incomplete data, so every bootstrap
-            // breaks at its first gap and the mesh deadlocks with none reaching a
-            // serving state. Record the failure, keep going so we still apply the
-            // artifacts we can fetch this pass, and report partial completion at
-            // the end so the peer is retried — already-applied artifacts are
-            // skipped on the retry, so successive passes converge as data
-            // propagates outward from the data-bearing replicas.
-            match bootstrap_artifact_from_peer(state, peer, manifest).await {
-                Ok(outcome) => {
-                    state.metrics.record_replication_apply(
-                        "bootstrap",
-                        "artifact",
-                        outcome.as_str(),
-                    );
-                    if outcome.applied() {
-                        applied += 1;
+        // Fetch the page's artifacts concurrently. A fresh node bootstraps the
+        // whole dataset over the WAN, where one serial stream leaves the link idle
+        // between requests and can't finish a large cache inside the bootstrap
+        // timeout. Concurrency caps open connections; staged bytes stay bounded by
+        // the bootstrap_staging_budget each fetch reserves against, and the
+        // segment-append lock still serializes the on-disk write, so only the
+        // network transfers overlap.
+        let outcomes: Vec<Result<bool, String>> = stream::iter(to_fetch)
+            .map(|manifest| async move {
+                // A single artifact failing must not abort the whole peer
+                // bootstrap. Aborting strands every later artifact behind the first
+                // gap, and when peers bootstrap from each other simultaneously
+                // (e.g. a full-mesh restart) each one serves still-incomplete data,
+                // so every bootstrap breaks at its first gap and the mesh deadlocks
+                // with none reaching a serving state. Record the failure, keep
+                // going so we still apply the artifacts we can fetch this pass, and
+                // report partial completion at the end so the peer is retried —
+                // already-applied artifacts are skipped on the retry, so successive
+                // passes converge as data propagates outward from the data-bearing
+                // replicas.
+                match bootstrap_artifact_from_peer(state, peer, &manifest).await {
+                    Ok(outcome) => {
+                        state.metrics.record_replication_apply(
+                            "bootstrap",
+                            "artifact",
+                            outcome.as_str(),
+                        );
+                        Ok(outcome.applied())
+                    }
+                    Err(error) => {
+                        state
+                            .metrics
+                            .record_replication_apply("bootstrap", "artifact", "error");
+                        warn!("bootstrap artifact from {peer} failed, continuing: {error}");
+                        Err(error)
                     }
                 }
-                Err(error) => {
-                    state
-                        .metrics
-                        .record_replication_apply("bootstrap", "artifact", "error");
-                    warn!("bootstrap artifact from {peer} failed, continuing: {error}");
-                    failed += 1;
-                }
+            })
+            .buffer_unordered(BOOTSTRAP_ARTIFACT_FETCH_CONCURRENCY)
+            .collect()
+            .await;
+
+        for outcome in outcomes {
+            match outcome {
+                Ok(true) => applied += 1,
+                Ok(false) => {}
+                Err(_) => failed += 1,
             }
         }
 

--- a/kura/src/replication/mod.rs
+++ b/kura/src/replication/mod.rs
@@ -402,7 +402,7 @@ async fn bootstrap_artifact_from_peer(
         .get(&url)
         .send()
         .await
-        .map_err(|error| format!("bootstrap artifact request failed: {error}"))?;
+        .map_err(|error| format!("bootstrap artifact request failed: {error:?}"))?;
     if response.status() == reqwest::StatusCode::NOT_FOUND {
         return Ok(ArtifactApplyOutcome::IgnoredStale);
     }
@@ -494,7 +494,7 @@ async fn stream_response_to_temp(
         let mut total: u64 = 0;
         while let Some(chunk) = stream.next().await {
             let chunk =
-                chunk.map_err(|error| format!("failed to stream bootstrap body: {error}"))?;
+                chunk.map_err(|error| format!("failed to stream bootstrap body: {error:?}"))?;
             total = total.saturating_add(chunk.len() as u64);
             if total > staging_limit {
                 return Err(format!(
@@ -829,7 +829,7 @@ async fn replicate_message(state: &SharedState, message: &OutboxMessage) -> Resu
                     .body(body)
                     .send()
                     .await
-                    .map_err(|error| format!("artifact replication request failed: {error}"))?;
+                    .map_err(|error| format!("artifact replication request failed: {error:?}"))?;
                 response_span.record("http.response.status_code", response.status().as_u16());
                 if response.status().is_server_error() {
                     response_span.record("otel.status_code", "ERROR");

--- a/kura/src/segment/reader.rs
+++ b/kura/src/segment/reader.rs
@@ -69,8 +69,22 @@ impl AsyncRead for SegmentReader {
                     Poll::Ready(Ok(Ok(bytes))) => {
                         self.pending_read = None;
                         if bytes.is_empty() {
-                            self.remaining = 0;
-                            return Poll::Ready(Ok(()));
+                            // EOF before `remaining` bytes: the backing file is
+                            // shorter than the artifact's manifested length (the
+                            // never-truncated invariant was violated). Fail loudly
+                            // instead of streaming a short body as if complete —
+                            // a silent short body reads as a corrupt/undecodable
+                            // response to peers. The pre-serve length guard in
+                            // `Store::open_manifest_reader_with_range` normally
+                            // 404s these before any bytes are sent; this catches a
+                            // file truncated mid-stream.
+                            return Poll::Ready(Err(io::Error::new(
+                                io::ErrorKind::UnexpectedEof,
+                                format!(
+                                    "segment truncated: {} bytes short of the artifact's manifested length",
+                                    self.remaining
+                                ),
+                            )));
                         }
                         self.buffered = Some(bytes);
                         self.buffered_offset = 0;

--- a/kura/src/store.rs
+++ b/kura/src/store.rs
@@ -809,6 +809,25 @@ impl Store {
                 .segment_offset
                 .ok_or_else(|| "segment-backed manifest is missing segment offset".to_string())?;
             let handle = self.segment_handle(segment_id).await?;
+            // Guard the append-only / never-truncated invariant the serving path
+            // relies on (see `try_mmap_artifact_bytes`). A truncated segment would
+            // otherwise yield a short read that streams a body shorter than the
+            // declared Content-Length — peers see an undecodable response and
+            // bootstrap silently wedges. Surface a truncated artifact as missing
+            // so the serve 404s it; the bootstrap client then skips it
+            // (IgnoredStale) and the lost entry re-populates on cache miss.
+            let needed = offset.saturating_add(read_offset).saturating_add(limit);
+            let have = handle
+                .as_std()
+                .metadata()
+                .map_err(|error| format!("failed to stat segment {segment_id}: {error}"))?
+                .len();
+            if have < needed {
+                return Err(format!(
+                    "segment {segment_id} truncated: holds {have} bytes but artifact {} needs {needed}",
+                    manifest.artifact_id
+                ));
+            }
             self.note_artifact_exists(&manifest.artifact_id);
             return Ok(ArtifactReader::FileRange(SegmentReader::new(
                 handle,
@@ -819,6 +838,18 @@ impl Store {
 
         if let Some(blob_path) = &manifest.blob_path {
             let handle = self.blob_handle(blob_path).await?;
+            let needed = read_offset.saturating_add(limit);
+            let have = handle
+                .as_std()
+                .metadata()
+                .map_err(|error| format!("failed to stat blob {blob_path}: {error}"))?
+                .len();
+            if have < needed {
+                return Err(format!(
+                    "blob {blob_path} truncated: holds {have} bytes but artifact {} needs {needed}",
+                    manifest.artifact_id
+                ));
+            }
             self.note_artifact_exists(&manifest.artifact_id);
             return Ok(ArtifactReader::FileRange(SegmentReader::new(
                 handle,


### PR DESCRIPTION
## What

The tuist Kura replication mesh wedged: every tuist node sat `0/1` not-ready for hours, bootstrap stuck at "N artifact(s) failed this pass, 0 applied", peers logging `failed to stream bootstrap body: error decoding response body` with no error on the serve side. That took down the macOS CI cache (the runner cache) and the cross-region tuist mesh, while customer single-region instances stayed healthy because they were idle and never re-bootstrapping.

This PR carries the two source fixes, a defensive hardening guard, and the standalone image-build workflow that let the branch be rolled to production for validation before merge.

## Bug 1: a total request timeout cut streaming bootstrap bodies mid-transfer

The inter-peer mTLS client (`peer_tls.rs`) used a hard 30s **total** request timeout. Bootstrap streams an artifact's entire body over this client. Under cold-start load, when all mesh nodes re-bootstrap at once and the path is bandwidth-limited and congested, a large artifact's transfer exceeds 30s and is aborted **mid-body**. The requesting peer sees an incomplete, undecodable response (`error decoding response body`); the serve side just sees the connection drop, so it logs nothing. Because bootstrap marks a peer done only on a fully clean pass, those few large artifacts that cannot transfer in 30s block every node from ever becoming ready.

Fix: switch the peer client from `.timeout(30s)` (total) to `.read_timeout(30s)` (idle, resets on each chunk), keeping the 5s connect timeout. A slow but progressing transfer now completes; a genuinely stalled connection still fails fast. The bootstrap loop's own 30-minute cap remains the backstop. The peer request and stream errors now log the source chain (`{error:?}`) so the nested transport cause is visible instead of only reqwest's top-level Display.

## Bug 2: serial bootstrap fetch could not replicate a full dataset within the timeout

Once the mesh was recoverable, a second problem surfaced: a fresh or rebuilt regional node has to bootstrap the **entire** dataset from a peer, and `bootstrap_manifests_from_peer` fetched artifact bodies strictly **serially** (one GET, await the whole body, apply, next). Over the WAN that leaves the link idle between every request, so a large cache cannot finish a bootstrap pass inside the 30-minute `KURA_BOOTSTRAP_TIMEOUT_MS`. The pass is cancelled (`bootstrap timed out after 1800000 ms`, a mid-transfer cancel rather than "0 applied") and retried from where it left off, so the node converges only after many 30-minute passes: hours for a large cache, which is why a destroyed-and-rebuilt regional node sat `Pending` indefinitely.

The ceiling was confirmed to be the serial fetch, not bandwidth or apply: the replication bandwidth limiter was at its 512 MiB/s default (verified in prod via `kura_replication_bandwidth_configured_limit_bytes_per_second`, far above the link), and apply writes to a local SSD segment behind `segment_write_lock`.

Fix: fetch up to `BOOTSTRAP_ARTIFACT_FETCH_CONCURRENCY` (16) artifact bodies per page concurrently with `buffer_unordered`. This reuses machinery the path already had: `bootstrap_staging_budget` reserves bytes per fetch and back-pressures when concurrent bodies would exceed the tmp budget, and the segment-append lock still serializes the on-disk write, so only the WAN transfers overlap. The cheap local already-have pre-check runs first so a real store error still aborts the pass rather than being masked as a per-artifact fetch failure, and the partial-failure / clean-pass-serves semantics are unchanged: a failed body still increments the failed count, a non-clean pass is still retried, and already-applied artifacts are skipped on retry.

## Hardening (investigated, not the cause here)

A guard for the documented "segments are append-only / never truncated" invariant: `open_manifest_reader_with_range` now verifies the backing file actually covers the artifact before serving (a truncated file returns `Err`, becomes a 404, and the bootstrap client skips it as `IgnoredStale` rather than streaming a silent short body), and `SegmentReader` errors loudly on EOF-before-`remaining` instead of ending silently. This was a candidate during the incident; it turned out not to be the cause (the guard logged zero times in prod, segments were intact), but it is a correct hardening: a short body must never be served as complete.

## What it took to get here

This took several wrong turns before the cause was nailed, worth recording so the next incident skips them:

- `0.10.10` / mmap residency gate (#11431): deployed plus a full mesh restart, no effect.
- Segment truncation: built and deployed the guard above, the guard logged zero times across all pods, so segments were not truncated.
- `kura-tuist-peers` headless Service deadlock: disproven, the Service has `publishNotReadyAddresses: true` with all pods in its endpoints and each peer's mTLS listener up.

The actual operational unblock during the incident was removing the failing peers (the regional servers were destroyed), which let the runner cache recover on the old image. The fixes in this PR are what prevent the deadlock from recurring on a full-mesh cold-start and what make a fresh node's bootstrap fast.

## Impact

- The runner cache and cross-region mesh recover from a full-mesh cold-start instead of deadlocking.
- A fresh or rebuilt regional node replicates the full cache in minutes instead of hours, or never when the dataset exceeded the 30-minute cap.

## Validation

- `cargo check` plus `cargo test --lib` clean (264 tests, including the bootstrap partial-failure, failpoint, and concurrent-staging-budget cases), `clippy` and `fmt` clean.
- Built the ad-hoc image `ghcr.io/tuist/kura:sha-866c922579a2` via the standalone `Kura Runtime Image` workflow (build only, no staging deploy).
- Rolled kura-only to production (server pinned, kura image swapped) and watched it converge:
  - `09:16:27` the runner cache and a regional pod restart onto the fix image (briefly not-ready)
  - `09:17:16` the runner cache is Ready again, under a minute of not-ready, no deadlock
  - `09:18:03` all 4 tuist kura pods Ready on the fix image, deploy success
- A freshly rebuilt regional instance had independently completed its bootstrap on the prior image over roughly 1.5 hours, confirming the bootstrap does converge given enough time and that the only remaining gap was speed, which is what Bug 2's fix closes. It retained its volume across the rolling image update, so it re-readied on a delta bootstrap.

## Follow-ups

- Production is pinned to the ad-hoc `sha-866c922579a2`. After this merges, the push-to-main pipeline cuts a `kura@` release and the next regular deploy moves prod off the ad-hoc tag onto it.
- #11461 (server-side readiness fallback to the public cache) ships next as the graceful-degradation net, now that the source fix is in prod.
- The bundled `Kura Runtime Image` workflow matches #11294's except for a one-line mise version bump to the repo standard `2026.5.15` (#11294 was still on the stale `2026.4.18`, and should pick up the same bump). They reconcile with a trivial one-line conflict at most.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
