### PR TITLE
feat(infra): add worker node CPU usage chart to Kura Grafana dashboard

### DIFF
--- a/infra/grafana-dashboards/tuist-kura.json
+++ b/infra/grafana-dashboards/tuist-kura.json
@@ -4626,10 +4626,10 @@
           "allowCustomValue": true,
           "current": {
             "text": [
-              "All"
+              "tuist-production"
             ],
             "value": [
-              "$__all"
+              "tuist-production"
             ]
           },
           "definition": "label_values(kura_node_info, cluster)",
@@ -4665,10 +4665,10 @@
           "allowCustomValue": true,
           "current": {
             "text": [
-              "tuist"
+              "All"
             ],
             "value": [
-              "tuist"
+              "$__all"
             ]
           },
           "definition": "label_values(kura_node_info{cluster=~\"$cluster\"}, tenant_id)",

--- a/infra/grafana-dashboards/tuist-kura.json
+++ b/infra/grafana-dashboards/tuist-kura.json
@@ -3881,7 +3881,7 @@
               "transformations": []
             }
           },
-          "description": "CPU utilisation % per worker node (left axis). Flat dashed lines on the right axis show total allocatable cores per node.",
+          "description": "CPU utilisation % per worker node running Kura pods for the selected tenant, region, and cluster.",
           "id": 60,
           "links": [],
           "title": "Worker Node CPU Usage",

--- a/infra/grafana-dashboards/tuist-kura.json
+++ b/infra/grafana-dashboards/tuist-kura.json
@@ -2413,7 +2413,7 @@
                       "group": "prometheus",
                       "kind": "DataQuery",
                       "spec": {
-                        "editorMode": "code",
+                        "app": "grafana-assistant-app",
                         "expr": "sum by (pod) (rate(container_cpu_usage_seconds_total{namespace=\"kura\", container=\"kura\", cluster=~\"$cluster\", pod=~\"kura-(${tenant})-.*\"}[$__rate_interval]))",
                         "instant": false,
                         "legendFormat": "{{pod}}",
@@ -3845,6 +3845,126 @@
             "version": "13.1.0-27822252871"
           }
         }
+      },
+      "panel-60": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "$datasource"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "app": "grafana-assistant-app",
+                        "expr": "(\n  sum by (instance) (rate(node_cpu_seconds_total{mode!=\"idle\", cluster=~\"$cluster\"}[$__rate_interval]))\n  / on(instance)\n  count by (instance) (node_cpu_seconds_total{mode=\"idle\", cluster=~\"$cluster\"})\n  * 100\n)\n* on(instance) group_left()\nlabel_replace(\n  group by (node) (kube_pod_info{namespace=\"kura\", pod=~\"kura-(${tenant})-(${region})-.*\", cluster=~\"$cluster\"}),\n  \"instance\", \"$1\", \"node\", \"(.*)\"\n)",
+                        "instant": false,
+                        "legendFormat": "{{instance}}",
+                        "queryType": "range",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "CPU utilisation % per worker node (left axis). Flat dashed lines on the right axis show total allocatable cores per node.",
+          "id": 60,
+          "links": [],
+          "title": "Worker Node CPU Usage",
+          "vizConfig": {
+            "group": "timeseries",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 10,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "showValues": false,
+                    "spanNulls": true,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "max": 100,
+                  "min": 0,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "percent"
+                },
+                "overrides": []
+              },
+              "options": {
+                "annotations": {
+                  "clustering": -1,
+                  "multiLane": false
+                },
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "enableFacetedFilter": false,
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              }
+            },
+            "version": "13.1.0-27822252871"
+          }
+        }
       }
     },
     "layout": {
@@ -4253,11 +4373,24 @@
                         "x": 16,
                         "y": 8
                       }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-60"
+                        },
+                        "height": 8,
+                        "width": 12,
+                        "x": 0,
+                        "y": 16
+                      }
                     }
                   ]
                 }
               },
-              "title": "Host Health"
+              "title": "Kura Instance Health"
             }
           },
           {
@@ -4419,7 +4552,7 @@
         "1d"
       ],
       "fiscalYearStartMonth": 0,
-      "from": "now-6h",
+      "from": "now-3h",
       "hideTimepicker": false,
       "timezone": "browser",
       "to": "now"
@@ -4493,10 +4626,10 @@
           "allowCustomValue": true,
           "current": {
             "text": [
-              "tuist-production"
+              "All"
             ],
             "value": [
-              "tuist-production"
+              "$__all"
             ]
           },
           "definition": "label_values(kura_node_info, cluster)",
@@ -4532,10 +4665,10 @@
           "allowCustomValue": true,
           "current": {
             "text": [
-              "All"
+              "tuist"
             ],
             "value": [
-              "$__all"
+              "tuist"
             ]
           },
           "definition": "label_values(kura_node_info{cluster=~\"$cluster\"}, tenant_id)",

--- a/infra/grafana-dashboards/tuist-kura.json
+++ b/infra/grafana-dashboards/tuist-kura.json
@@ -4552,7 +4552,7 @@
         "1d"
       ],
       "fiscalYearStartMonth": 0,
-      "from": "now-3h",
+      "from": "now-6h",
       "hideTimepicker": false,
       "timezone": "browser",
       "to": "now"


### PR DESCRIPTION
## What changed

Adds a new **"Worker Node CPU Usage"** time-series panel (`panel-60`) to the `tuist-kura` Grafana dashboard, placed in the renamed **"Kura Instance Health"** row (previously "Host Health"). It plots per-node CPU utilisation %, scoped to the worker nodes that are actually running Kura pods for the selected `$tenant`/`$region`/`$cluster`.

The panel query:

```promql
(
  sum by (instance) (rate(node_cpu_seconds_total{mode!="idle", cluster=~"$cluster"}[$__rate_interval]))
  / on(instance)
  count by (instance) (node_cpu_seconds_total{mode="idle", cluster=~"$cluster"})
  * 100
)
* on(instance) group_left()
label_replace(
  group by (node) (kube_pod_info{namespace="kura", pod=~"kura-(${tenant})-(${region})-.*", cluster=~"$cluster"}),
  "instance", "$1", "node", "(.*)"
)
```

The diff also includes a non-functional metadata flip on an unrelated existing panel's query (`editorMode: code` → `app: grafana-assistant-app`); the expression itself is unchanged.

## Why

The dashboard already covered Kura's application-level signals (HTTP traffic, RocksDB cache, replication, PVC usage) but had no view of the underlying host CPU headroom on the nodes Kura runs on. This panel answers "how much CPU is the fleet actually burning, per node?" so we can spot saturation / right-size the nodes.

## Is the formula correct?

Yes — it's the standard node-exporter utilisation idiom:

- **Numerator** `sum by (instance)(rate(node_cpu_seconds_total{mode!="idle"}[...]))` — non-idle CPU-seconds per second summed across every core and every busy mode = number of cores actively in use on the node.
- **Denominator** `count by (instance)(node_cpu_seconds_total{mode="idle"})` — counts the idle series, one per core, i.e. the node's total core count.
- `used cores / total cores * 100` = average non-idle fraction = CPU utilisation %, consistent with the panel's `unit: percent`, `min: 0`, `max: 100`. This is algebraically equivalent to the more common `100 - avg(rate(idle))*100`.

> **Note on the denominator.** The two halves use different operations. The numerator is a `rate` (it reads the counter's value), but the denominator is a `count` (it ignores values and counts matching series). `node_cpu_seconds_total` has one series per `(cpu, mode)` pair, so `mode="idle"` yields exactly one series per core. `count` of those therefore equals the node's **total core count** — not its idle/unused cores. The `mode="idle"` filter is just a "one series per core" selector (any single mode would do; idle is always present); whether a core is busy or idle, its idle series still exists and is still counted.

The `* on(instance) group_left() label_replace(group by (node)(kube_pod_info{...}), "instance","$1","node","(.*)")` clause computes CPU% for all nodes in the cluster and then filters down to only those running a Kura pod: `kube_pod_info` is reduced to one series per node, the node name is copied into an `instance` label, and the multiply-by-1 join keeps only matching instances. The `kura-(${tenant})-(${region})-.*` pod regex and the `$region`/`$tenant` template variables match the convention already used by the PVC panels.

## Validation

- Reviewed the JSON diff and the PromQL by hand (analysis above).
- Confirmed `$region`/`$tenant` template variables exist and the pod regex matches the existing PVC panels in the same dashboard.
- Confirmed the change vs `main` touches only `infra/grafana-dashboards/tuist-kura.json`.
- Not yet rendered live in Grafana — worth one visual confirmation that the node-exporter `instance` ↔ node-name join resolves (it assumes node-exporter's `instance` equals the Kubernetes node name).
