### PR TITLE
fix(tuist-ops): post preview completion thread replies

### DIFF
--- a/tuist-ops/lib/tuist_ops/previews/slack_blocks.ex
+++ b/tuist-ops/lib/tuist_ops/previews/slack_blocks.ex
@@ -232,6 +232,30 @@ defmodule TuistOps.Previews.SlackBlocks do
     ]
   end
 
+  def deployed_thread(%Preview{} = preview) do
+    [
+      %{
+        type: "section",
+        text: %{
+          type: "mrkdwn",
+          text: "Preview deployment completed: <https://#{preview.host}|https://#{preview.host}>"
+        }
+      }
+    ]
+  end
+
+  def failed_thread(%Preview{} = preview) do
+    [
+      %{
+        type: "section",
+        text: %{
+          type: "mrkdwn",
+          text: failed_thread_text(preview.workflow_run_url)
+        }
+      }
+    ]
+  end
+
   defp format_ref(%Preview{ref_kind: nil}), do: "`workflow default`"
   defp format_ref(%Preview{ref_kind: kind, ref_value: value}), do: "`#{kind}:#{value}`"
 
@@ -265,6 +289,10 @@ defmodule TuistOps.Previews.SlackBlocks do
   defp workflow_line(nil), do: ""
   defp workflow_line(""), do: ""
   defp workflow_line(url), do: "*Workflow:* <#{url}|GitHub Actions run>"
+
+  defp failed_thread_text(nil), do: "Preview deployment failed."
+  defp failed_thread_text(""), do: "Preview deployment failed."
+  defp failed_thread_text(url), do: "Preview deployment failed: <#{url}|GitHub Actions run>"
 
   defp format_seconds(nil), do: "n/a"
   defp format_seconds(seconds) when seconds < 3600, do: "#{div(seconds, 60)} min"

--- a/tuist-ops/lib/tuist_ops/previews/workers/monitor_workflow_worker.ex
+++ b/tuist-ops/lib/tuist_ops/previews/workers/monitor_workflow_worker.ex
@@ -116,8 +116,12 @@ defmodule TuistOps.Previews.Workers.MonitorWorkflowWorker do
     })
     |> Repo.update()
     |> case do
-      {:ok, _preview} -> :ok
-      {:error, changeset} -> {:error, changeset}
+      {:ok, preview} ->
+        post_terminal_thread(preview, SlackBlocks.deployed_thread(preview), "Preview deployed")
+        :ok
+
+      {:error, changeset} ->
+        {:error, changeset}
     end
   end
 
@@ -143,8 +147,36 @@ defmodule TuistOps.Previews.Workers.MonitorWorkflowWorker do
     })
     |> Repo.update()
     |> case do
-      {:ok, _preview} -> :ok
-      {:error, changeset} -> {:error, changeset}
+      {:ok, preview} ->
+        post_terminal_thread(
+          preview,
+          SlackBlocks.failed_thread(preview),
+          "Preview request failed"
+        )
+
+        :ok
+
+      {:error, changeset} ->
+        {:error, changeset}
     end
   end
+
+  defp post_terminal_thread(%Preview{slack_message_ts: ts} = preview, blocks, fallback_text)
+       when is_binary(ts) and ts != "" do
+    case SlackClient.post_message(
+           preview.slack_channel_id,
+           blocks,
+           fallback_text: fallback_text,
+           thread_ts: ts
+         ) do
+      {:ok, _thread_ts} ->
+        :ok
+
+      {:error, reason} ->
+        Logger.warning("preview: terminal thread post failed: #{inspect(reason)}")
+        :ok
+    end
+  end
+
+  defp post_terminal_thread(%Preview{}, _blocks, _fallback_text), do: :ok
 end

--- a/tuist-ops/test/previews/workers/monitor_workflow_worker_test.exs
+++ b/tuist-ops/test/previews/workers/monitor_workflow_worker_test.exs
@@ -48,6 +48,32 @@ defmodule TuistOps.Previews.Workers.MonitorWorkflowWorkerTest do
     end)
   end
 
+  defp expect_deployed_thread do
+    expect(SlackClient, :post_message, fn "C_PREVIEWS", blocks, opts ->
+      text = blocks |> List.first() |> get_in([:text, :text])
+
+      assert text =~ "Preview deployment completed"
+      assert text =~ "https://demo.preview.tuist.dev"
+      assert opts[:fallback_text] == "Preview deployed"
+      assert opts[:thread_ts] == "1710000000.000001"
+
+      {:ok, "1710000000.000003"}
+    end)
+  end
+
+  defp expect_failed_thread(url) do
+    expect(SlackClient, :post_message, fn "C_PREVIEWS", blocks, opts ->
+      text = blocks |> List.first() |> get_in([:text, :text])
+
+      assert text =~ "Preview deployment failed"
+      assert text =~ url
+      assert opts[:fallback_text] == "Preview request failed"
+      assert opts[:thread_ts] == "1710000000.000001"
+
+      {:ok, "1710000000.000003"}
+    end)
+  end
+
   test "snoozes while the workflow run is still in progress" do
     preview = insert_preview!()
     url = "https://github.com/tuist/tuist/actions/runs/in-progress"
@@ -79,6 +105,7 @@ defmodule TuistOps.Previews.Workers.MonitorWorkflowWorkerTest do
     end)
 
     expect_workflow_thread(url)
+    expect_deployed_thread()
 
     expect(SlackClient, :update_message, fn "C_PREVIEWS", "1710000000.000001", blocks, opts ->
       text = blocks |> List.first() |> get_in([:text, :text])
@@ -112,6 +139,7 @@ defmodule TuistOps.Previews.Workers.MonitorWorkflowWorkerTest do
     end)
 
     expect_workflow_thread(url)
+    expect_failed_thread(url)
 
     expect(SlackClient, :update_message, fn "C_PREVIEWS", "1710000000.000001", blocks, opts ->
       text = blocks |> List.first() |> get_in([:text, :text])


### PR DESCRIPTION
## What changed

- Added terminal Slack thread blocks for successful and failed preview deployments.
- Updated the preview monitor worker to post a thread reply after it records the preview as active or failed, while keeping the original Slack card update.
- Covered both success and failure terminal replies in the focused worker tests.

## Why

The preview Slack thread already receives the GitHub Actions workflow run link, so the same thread should also show whether the deployment finished. Without that reply, the parent card changes state but the thread looks incomplete.

## Root cause

The monitor worker only posted a threaded reply when it first discovered the GitHub Actions workflow run. When the workflow reached a terminal state, the worker updated the original Slack message and transitioned the preview row, but it never posted a final thread reply.

## Approach

The final reply is derived from the persisted preview row after the state transition succeeds. Slack delivery failures are logged and do not fail the worker because the database state and parent Slack card already reflect the terminal result.

## Impact

Successful preview deployments now add a threaded completion message with the preview link. Failed deployments add a threaded failure message that links back to the GitHub Actions workflow run. There are no schema or configuration changes.

## Validation

- `mix test test/previews/workers/monitor_workflow_worker_test.exs`
- Result: 4 tests, 0 failures.
