### PR TITLE
fix(cli): exclude module-map xcframework headers from search paths

### DIFF
--- a/cli/Sources/TuistCore/Graph/GraphTraverser.swift
+++ b/cli/Sources/TuistCore/Graph/GraphTraverser.swift
@@ -850,7 +850,15 @@ public class GraphTraverser: GraphTraversing {
             return publicHeaders
         }
         let xcframeworkLibraryPublicHeaders = dependencies.flatMap { dependency -> [Path.AbsolutePath] in
-            guard case let GraphDependency.xcframework(xcframework) = dependency else { return [] }
+            guard case let GraphDependency.xcframework(xcframework) = dependency,
+                  // Xcode's `ProcessXCFramework` already extracts the SDK-matching slice's headers — including
+                  // any `module.modulemap` — into `$(BUILT_PRODUCTS_DIR)/include`, which is on the header search
+                  // path. Re-adding every slice's `Headers` for an xcframework that ships a module map puts
+                  // additional copies of the same module on the search path, and the compiler fails with
+                  // "redefinition of module 'X'". Such xcframeworks rely on the `include/` copy instead; only
+                  // module-map-less xcframeworks (e.g. cached Swift/library products) still need the headers.
+                  xcframework.moduleMaps.isEmpty
+            else { return [] }
             return xcframework.infoPlist.libraries.compactMap { library in
                 guard let headersPath = library.headersPath else { return nil }
                 return try? AbsolutePath(validating: library.identifier, relativeTo: xcframework.path)

--- a/cli/Tests/TuistCoreTests/Graph/GraphTraverserTests.swift
+++ b/cli/Tests/TuistCoreTests/Graph/GraphTraverserTests.swift
@@ -1914,6 +1914,56 @@ final class GraphTraverserTests: TuistUnitTestCase {
         ])
     }
 
+    func test_librariesPublicHeadersFolders_excludesHeadersOfXCFrameworksShippingAModuleMap() throws {
+        // Given
+        // An xcframework that ships a `module.modulemap` per slice. Xcode's `ProcessXCFramework` already
+        // exposes the SDK-matching slice's headers (and module map) via `$(BUILT_PRODUCTS_DIR)/include`, so
+        // re-adding the slice `Headers` would put a second copy of the module on the search path and the
+        // compiler would fail with "redefinition of module". These headers must therefore be excluded.
+        let target = Target.test(name: "Main")
+        let project = Project.test(targets: [target])
+        let xcframeworkPath = try AbsolutePath(validating: "/cache/ModularLibrary.xcframework")
+        let xcframework = GraphDependency.testXCFramework(
+            path: xcframeworkPath,
+            infoPlist: .test(libraries: [
+                .test(
+                    identifier: "ios-arm64",
+                    path: try RelativePath(validating: "libModularLibrary.a"),
+                    headersPath: try RelativePath(validating: "Headers"),
+                    platform: .iOS,
+                    architectures: [.arm64]
+                ),
+                .test(
+                    identifier: "ios-arm64-simulator",
+                    path: try RelativePath(validating: "libModularLibrary.a"),
+                    headersPath: try RelativePath(validating: "Headers"),
+                    platform: .iOS,
+                    platformVariant: .simulator,
+                    architectures: [.arm64]
+                ),
+            ]),
+            linking: .static,
+            moduleMaps: [
+                xcframeworkPath.appending(components: "ios-arm64", "Headers", "module.modulemap"),
+                xcframeworkPath.appending(components: "ios-arm64-simulator", "Headers", "module.modulemap"),
+            ]
+        )
+        let graph = Graph.test(
+            projects: [project.path: project],
+            dependencies: [
+                .target(name: target.name, path: project.path): Set([xcframework]),
+                xcframework: Set([]),
+            ]
+        )
+        let subject = GraphTraverser(graph: graph)
+
+        // When
+        let got = subject.librariesPublicHeadersFolders(path: project.path, name: target.name)
+
+        // Then
+        XCTAssertEqual(got, [])
+    }
+
     func test_librariesSearchPaths() throws {
         // Given
         let target = Target.test(name: "Main")


### PR DESCRIPTION
## Summary

Fixes a `Redefinition of module 'X'` regression introduced in `4.201.0-rc.1` when a target depends on a precompiled xcframework that ships a `module.modulemap` (reported by a user building against `4.201.0-rc.1` with no changes on their side).

> [!IMPORTANT]
> This is a regression in the current RC (`4.201.0-rc.1`), so it needs to be **backported to the current `4.201.0` RC** rather than only shipping on the next minor.

## Root cause

Xcode's `ProcessXCFramework` already extracts the SDK-matching slice's headers — including any `module.modulemap` — into `$(BUILT_PRODUCTS_DIR)/include`, which is on the header search path.

Since #11290, `GraphTraverser.librariesPublicHeadersFolders` *additionally* adds every xcframework slice's `Headers` to `HEADER_SEARCH_PATHS`. For an xcframework that ships a module map, this puts a **second** copy of the same module on the search path, so the compiler fails with:

```
.../My.xcframework/<slice>/Headers/module.modulemap:1:8: error: redefinition of module 'X'
.../Build/Products/<config>/include/module.modulemap:1:8: note: previously defined here
```

Because the headers are added for every slice, a single-platform build (e.g. macOS) also ends up with the iOS device/simulator slices' module maps on the search path.

## Fix

Skip adding an xcframework's headers when it ships a module map (`xcframework.moduleMaps.isEmpty`) — the `ProcessXCFramework` `include/` copy already exposes them. Module-map-less xcframeworks (e.g. the cached Swift/library products from #11290) keep their headers, so that feature is unaffected.

## Verification

- **Reproduced** with `4.201.0-canary.13` (= the `rc.1` regression): a target depending on a 2-slice `Greeter.xcframework` (each slice shipping `Headers/module.modulemap`) → `error: redefinition of module 'Greeter'`.
- **Unit tests** (`GraphTraverserTests`): new test asserts headers are excluded for module-map xcframeworks; the existing #11290 test still asserts module-map-less xcframeworks keep their headers. ✅ pass.
- **End-to-end**: rebuilt the CLI from this branch, regenerated the reproduction with it (0 slice headers in `HEADER_SEARCH_PATHS`, down from 2), and the project now **builds successfully**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)