### PR TITLE
fix(kura): wait for cross-node module replication in the extension e2e

### DIFF
--- a/kura/spec/e2e/extension_spec.sh
+++ b/kura/spec/e2e/extension_spec.sh
@@ -91,6 +91,11 @@ Describe 'extension hooks'
       -d '{"parts":[1,2]}')"
     The variable complete_status should eq 204
 
+    wait_for_status_with \
+      "${KURA_EU_URL}/api/cache/module/module-1?tenant_id=acme&namespace_id=ios&hash=hash-1&name=Module.framework&cache_category=builds" \
+      200 \
+      -H "authorization: Bearer ${ios_token}" >/dev/null || return 1
+
     headers_file="${SUITE_TMP_DIR}/module.headers"
     body_file="${SUITE_TMP_DIR}/module.body"
     capture_into curl_output \

--- a/kura/spec/e2e/support.sh
+++ b/kura/spec/e2e/support.sh
@@ -171,6 +171,31 @@ wait_for_status() {
   return 1
 }
 
+# Like wait_for_status but forwards trailing arguments to status_only (and thus
+# curl), so callers can attach an auth header or method. The extension suite needs
+# this: every cache request must carry a Bearer token, so the bare wait_for_status
+# (which only sends an unauthenticated GET) can never reach a 2xx there.
+wait_for_status_with() {
+  local url="$1"
+  local expected_status="$2"
+  shift 2
+  local attempts=45
+  local sleep_seconds=2
+  local actual_status
+
+  for _ in $(seq 1 "$attempts"); do
+    actual_status="$(status_only "$url" "$@" 2>/dev/null || true)"
+    if [ "$actual_status" = "$expected_status" ]; then
+      printf '%s' "$actual_status"
+      return 0
+    fi
+    sleep "$sleep_seconds"
+  done
+
+  printf 'Timed out waiting for %s to return %s (last status %s)\n' "$url" "$expected_status" "${actual_status:-unknown}" >&2
+  return 1
+}
+
 wait_for_head_status() {
   local url="$1"
   local expected_status="$2"


### PR DESCRIPTION
## What changed

The Kura `E2E (extension-mtls)` suite's example `extension hooks enforces authz and signs module cache responses` (`kura/spec/e2e/extension_spec.sh`) was failing intermittently on `main` with `Example aborted (exit status: 1)` — for example, https://github.com/tuist/tuist/actions/runs/28094467954/job/83182305789.

The example uploads a multipart module to `kura-us`, then reads it back from `kura-eu` to verify the cross-node body and the `x-cache-signature` header. The EU read was issued immediately after the upload completed on US, with no wait for replication.

This change gates the signature-capturing EU read behind a poll for the authorized EU `GET` to return `200`, mirroring how the equivalent test in `cluster_spec.sh` already waits before reading cross-node. Because the extension nodes require a Bearer token on every cache request, a new `wait_for_status_with` helper is added to `support.sh` — a `wait_for_status` that forwards trailing args to `curl`, so the poll can carry the token (the bare `wait_for_status` only sends an unauthenticated GET and could never reach a 2xx on these nodes).

## Why

US→EU replication is asynchronous: `complete_multipart_upload_and_enqueue` enqueues to the outbox and wakes the replication worker, it does not block. A `GET` for an artifact a node does not yet hold returns 404 with no on-demand peer fetch (`fetch_artifact_for_serving` returns `None` on a local miss). So reading from EU immediately after completing the upload on US raced replication: when the module had not propagated yet, `curl -fsS` exited non-zero on the 404 and the example aborted before any assertion ran. The latent race was likely tipped over the edge by the replication-path changes in #11464.

The other EU read in this test (the `403` forbidden check) is not racy: `authorize` denies on namespace mismatch before any storage lookup, so it returns 403 regardless of replication.

## Reviewer notes

- The fix makes the cross-node read deterministic. If replication were genuinely broken (rather than merely slow), the test now fails with a clear `Timed out waiting for ... to return 200` instead of a cryptic abort.
- `wait_for_status_with` reuses the same default budget as `wait_for_status` (45 attempts x 2s), matching what `cluster_spec.sh` relies on for the same cross-node module scenario.
- No production Kura code changes; this is test-harness only.

### How to test locally

From `kura/`:

```
docker compose build && mise exec -- shellspec spec/e2e/extension_spec.sh spec/e2e/mtls_spec.sh
```

I was unable to run the Docker-based suite or shellcheck in this environment, so validation here is by code analysis and by matching the established pattern in `cluster_spec.sh`.
