### PR TITLE
fix(infra): hold kura PN address statically instead of renew-forever dhclient

### DIFF
--- a/infra/cluster-api-provider-scaleway-applesilicon/controllers/linux_cloudinit.go
+++ b/infra/cluster-api-provider-scaleway-applesilicon/controllers/linux_cloudinit.go
@@ -181,11 +181,20 @@ curl -fsSL https://pkgs.k8s.io/core:/stable:/%[1]s/deb/Release.key | %[2]sgpg --
 // never renewed if that dhclient process dies, so the node silently loses its PN
 // address (and with it the runner-cache NodePort) while still reporting Ready on
 // its public NIC — invisible to the control plane, since kubelet binds the
-// public InternalIP. The unit re-creates pn0 on every boot (ExecStartPre) and
-// holds the DHCP lease in the foreground under Restart=always, making the PN
-// address durable across reboots and lease churn. The heredocs keep this on the
-// SSH (non-indented) bootstrap path; the Instance/cloud-init path always passes
-// vlan==0 and renders nothing here.
+// public InternalIP.
+//
+// The unit holds the address STATICALLY rather than leasing it for the life of
+// the node. Scaleway's PN DHCP has been observed to stop ACKing renewals: a
+// renew-forever dhclient (`dhclient -d` under Restart=always) keeps running, so
+// Restart never fires, yet the lease still expires and the kernel drops the
+// address — the exact silent-blackhole this unit exists to prevent. Instead the
+// script DHCPs once to discover the IPAM-assigned address (the PN allocates it
+// per attachment, so it is stable), caches it, and then re-asserts it as a
+// static address with no expiry. pn0 is re-created on every boot, and the cached
+// address re-applied, making the PN address durable across reboots, lease churn,
+// and a silent DHCP server. The heredocs keep this on the SSH (non-indented)
+// bootstrap path; the Instance/cloud-init path always passes vlan==0 and renders
+// nothing here.
 func vlanBringUp(sudo string, vlan uint32) string {
 	if vlan == 0 {
 		return ""
@@ -199,6 +208,26 @@ if [ -z "$PRIMARY_NIC" ]; then
 fi
 ip link show pn0 >/dev/null 2>&1 || ip link add link "$PRIMARY_NIC" name pn0 type vlan id %[2]d
 ip link set pn0 up
+CIDR_CACHE=/var/lib/tuist/pn0-cidr
+if [ ! -s "$CIDR_CACHE" ]; then
+  mkdir -p /var/lib/tuist
+  for _ in $(seq 1 30); do
+    timeout 15 dhclient -1 pn0 >/dev/null 2>&1 || true
+    discovered="$(ip -4 -o addr show pn0 2>/dev/null | awk '{print $4; exit}' || true)"
+    if [ -n "$discovered" ]; then printf '%%s\n' "$discovered" > "$CIDR_CACHE"; break; fi
+    sleep 10
+  done
+fi
+pkill -f 'dhclient.*pn0' >/dev/null 2>&1 || true
+cidr="$(cat "$CIDR_CACHE" 2>/dev/null || true)"
+if [ -z "$cidr" ]; then
+  echo "pn0: PN address not assigned yet (IPAM lag); will retry" >&2
+  exit 1
+fi
+while true; do
+  ip addr replace "$cidr" dev pn0 2>/dev/null || true
+  sleep 60
+done
 TUIST_PN_EOF
 %[1]schmod 0755 /usr/local/sbin/tuist-pn0-up.sh
 %[1]stee /etc/systemd/system/tuist-pn0.service > /dev/null <<'TUIST_PN_EOF'
@@ -208,8 +237,7 @@ Wants=network-online.target
 After=network-online.target
 [Service]
 Type=exec
-ExecStartPre=/usr/local/sbin/tuist-pn0-up.sh
-ExecStart=/usr/bin/env dhclient -d pn0
+ExecStart=/usr/local/sbin/tuist-pn0-up.sh
 Restart=always
 RestartSec=5
 [Install]

--- a/infra/cluster-api-provider-scaleway-applesilicon/controllers/linux_cloudinit_test.go
+++ b/infra/cluster-api-provider-scaleway-applesilicon/controllers/linux_cloudinit_test.go
@@ -96,7 +96,7 @@ func TestRenderLinuxCloudInit_ClusterDNS(t *testing.T) {
 	}
 }
 
-func TestRenderLinuxBootstrapScript_PNVlanIsPersistentAndSupervised(t *testing.T) {
+func TestRenderLinuxBootstrapScript_PNVlanIsPersistentAndStatic(t *testing.T) {
 	script := renderLinuxBootstrapScript(linuxCloudInitOptions{
 		NodeName:           "node-a",
 		KubeconfigYAML:     "apiVersion: v1\nkind: Config\n",
@@ -105,16 +105,16 @@ func TestRenderLinuxBootstrapScript_PNVlanIsPersistentAndSupervised(t *testing.T
 		PrivateNetworkVLAN: 3250,
 	})
 
-	// The VLAN must be installed as a reboot-durable, lease-renewing systemd
-	// unit rather than a one-shot. Assert the unit, its supervised dhclient, and
-	// the VLAN id wired through.
+	// The VLAN must be installed as a reboot-durable systemd unit that holds the
+	// PN address STATICALLY (DHCP-discover once, then pin it). Assert the unit,
+	// the static re-assert, and the VLAN id wired through.
 	for _, want := range []string{
 		"/etc/systemd/system/tuist-pn0.service",
 		"/usr/local/sbin/tuist-pn0-up.sh",
-		"ExecStartPre=/usr/local/sbin/tuist-pn0-up.sh",
-		"ExecStart=/usr/bin/env dhclient -d pn0",
+		"ExecStart=/usr/local/sbin/tuist-pn0-up.sh",
 		"Restart=always",
 		"name pn0 type vlan id 3250",
+		"ip addr replace",
 		"systemctl enable --now tuist-pn0.service",
 	} {
 		if !strings.Contains(script, want) {
@@ -122,10 +122,14 @@ func TestRenderLinuxBootstrapScript_PNVlanIsPersistentAndSupervised(t *testing.T
 		}
 	}
 
-	// The fragile one-shot bring-up (backgrounded, unrenewed, lost on reboot)
-	// must be gone — it is the bug this unit replaces.
-	if strings.Contains(script, "dhclient -nw pn0") {
-		t.Fatalf("expected the one-shot `dhclient -nw` bring-up to be removed, got:\n%s", script)
+	// Liveness must NOT hang on a renew-forever dhclient: neither the old
+	// one-shot `dhclient -nw` nor a supervised `dhclient -d` survives the PN DHCP
+	// server going silent (the lease expires and the address is dropped while the
+	// process keeps running). That is the bug this static hold replaces.
+	for _, banned := range []string{"dhclient -nw pn0", "dhclient -d pn0"} {
+		if strings.Contains(script, banned) {
+			t.Fatalf("expected no renew-forever dhclient %q, got:\n%s", banned, script)
+		}
 	}
 
 	// The Instance/cloud-init path never sets a VLAN, so it must render nothing


### PR DESCRIPTION
## What

Replace the renew-forever `dhclient -d pn0` unit on the runner-cache Elastic Metal nodes with one that discovers the PN address via DHCP once and then holds it as a static address.

## Why

A production runner-cache node silently lost its `pn0` Private Network address (`172.16.0.2/22`), blackholing every macOS runner's module-cache request to the cache NodePort for 12+ hours. macOS CI builds hung at "Fetching remote binaries via module cache. Hold tight..." with roughly 5-minute timeouts per module.

### Root cause

On-node diagnosis showed `pn0` UP but carrying only a link-local IPv6 address. `dhclient` was alive and repeatedly sending DHCPREQUEST to the Scaleway PN DHCP server (169.254.169.254) with no DHCPACK ever returned: the lease had expired and could not be renewed. With the route to `172.16.0.2` falling through to the public default gateway, the node never answered ARP for its own PN IP, so runner SYNs to the cache NodePort were blackholed. The node kept reporting Ready on its public NIC, so the loss was invisible to the control plane.

The existing supervised unit (`ExecStart=dhclient -d pn0`, `Restart=always`) does not help this failure mode: the dhclient process stays alive while the server is silent, so `Restart=always` never fires, yet the lease still lapses and the address is dropped.

### Fix

The PN IP is stable per attachment (IPAM-assigned), so there is no need to keep leasing it. The unit now:

1. Brings up `pn0`, recreating the VLAN interface on every boot.
2. On first boot, DHCPs once to discover the assigned address and caches it (retrying while IPAM lags).
3. Holds that address statically (`ip addr replace`, no expiry) and re-asserts it.

This makes the PN address durable across reboots, lease churn, and a silent DHCP server.

## Impact

- New runner-cache EM nodes provisioned from this code are immune to the PN-DHCP-renewal failure that caused the outage.
- Existing live nodes are not retroactively updated: Linux node bootstrap is one-shot at provision with no drift re-push, so the affected node was hand-patched live and needs either a re-provision or the unit installed to converge.

## Validation

- `go test ./controllers/` passes, including the updated render test asserting the static-hold unit and the absence of a renew-forever dhclient.
- The static-hold mechanism is confirmed working on the live affected node: the address was restored with `ip addr replace`, the cache NodePort then served `/up` in under 1ms, and public-request traffic recovered from zero.
- Not yet validated on a fresh EM provision end-to-end. The DHCP-once discovery plus cache path should be exercised on a staging EM node before relying on it fleet-wide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)