### PR TITLE
fix(infra): stop check-releases hitting the GitHub API via mise auto-install

### DIFF
--- a/.github/workflows/server-production-deployment.yml
+++ b/.github/workflows/server-production-deployment.yml
@@ -62,6 +62,13 @@ jobs:
     name: Check for releasable changes
     runs-on: tuist-linux
     timeout-minutes: 5
+    # release:check only needs the git-cliff + jq installed below, but `mise run`
+    # otherwise auto-installs the whole merged mise.toml toolset — including
+    # github/npm-backend tools that hit the rate-limited GitHub API for SLSA
+    # verification (--locked only redirects the binary download, not the
+    # provenance fetch). Block the task-run auto-install.
+    env:
+      MISE_TASK_RUN_AUTO_INSTALL: "0"
     outputs:
       cli-should-release: ${{ steps.check.outputs.cli-should-release }}
       cli-next-version: ${{ steps.check.outputs.cli-next-version }}


### PR DESCRIPTION
## What changed

Added `MISE_TASK_RUN_AUTO_INSTALL: "0"` to the `check-releases` job in `server-production-deployment.yml`.

## Why

The "Check for releasable changes" job fails intermittently with `GitHub rate limit exceeded` / `403 Forbidden`:

```
mise WARN  GitHub rate limit exceeded. Resets at 2026-06-24 13:41:05 +00:00
mise ERROR Failed to install tools: github:endevco/aube@1.6.2, github:pomerium/cli@0.32.2, github:tuist/blick@0.8.0, npm:opencode-ai@1.14.39
github:endevco/aube@1.6.2: SLSA verification error ... Failed to get release: 403 Forbidden for url (https://api.github.com/repos/endevco/aube/releases/tags/v1.6.2)
```

### Root cause

The job pre-installs only the tools `release:check` needs:

```yaml
- uses: jdx/mise-action@v4.0.1
  with:
    install_args: "--locked git-cliff jq"   # CDN, no API
- id: check
  run: mise run release:check               # re-triggers a full auto-install
```

But `mise run <task>` auto-installs the **entire merged root `mise.toml` toolset** before running the task, not just the task's tools. That pulls in the github/npm-backend tools (`aube`, `pomerium/cli`, `blick`, `opencode-ai`) on every push to main, and that auto-install is **not** `--locked`.

Crucially, the 403s come from **SLSA verification**, not the binary download. SLSA verification fetches release metadata from the rate-limited `api.github.com/repos/.../releases/tags/vX` regardless of `--locked` — `--locked` only redirects the *binary download* to the GitHub CDN, never the provenance lookup. When the shared `GITHUB_TOKEN` bucket is already drained by concurrent jobs (the log shows a hard `Resets at ...`, not a soft warning), those calls 403 and the job fails. That's why it's intermittent: on a fresh bucket it squeaks through.

### Why this job slipped through #11347

PR #11347 made tool *downloads* hit the CDN via `--locked`, and guarded the other `mise run`/`mise x` workflows (`search`, `search-deploy`, `status-deploy`) with an auto-install switch so the `mise run` full-toolset install couldn't bypass the scoping. This `check-releases` job never got that env var, so its `mise run release:check` still does a full, unlocked, SLSA-verified auto-install of 4 API-hitting tools.

## The fix

Set `MISE_TASK_RUN_AUTO_INSTALL=0` on the job. `release:check` ([mise/tasks/release/check.sh](mise/tasks/release/check.sh)) only shells out to `git cliff` and `jq`, both pre-installed in the step above, so blocking the task-run auto-install is safe.

- **Scoped to the job, not the workflow**, deliberately: the `acceptance-tests` job installs the full toolset with no `install_args` and runs `tuist test` on macOS, whose Xcode build phases need the whole mise toolset resolvable at runtime (the same hazard documented for `app.yml`). A workflow-level switch would risk breaking it.
- Uses `MISE_TASK_RUN_AUTO_INSTALL` (the task-run-specific switch) to match the precedent already in this file — `backward-compatibility-acceptance` uses it for the same `mise run` reason.

## Validation

- Confirmed `release:check`/`check.sh` only uses `git cliff` + `jq` (no other mise tools), so the pre-install fully covers it.
- Confirmed the 403s in the failed run are from the auto-installed github/npm tools' SLSA verification, not from the `--locked git-cliff jq` install (which passed) — the failure is in the `mise run release:check` step.
- Side benefit: removes 4 GitHub API calls from every push-to-main run, easing pressure on the shared token pool that other release jobs draw from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)