### PR TITLE
fix(cli): forward TUIST_CACHE_ENDPOINT to the Xcode cache daemon

### DIFF
--- a/cli/Sources/TuistKit/Services/Setup/SetupCacheCommandService.swift
+++ b/cli/Sources/TuistKit/Services/Setup/SetupCacheCommandService.swift
@@ -74,6 +74,15 @@ struct SetupCacheCommandService {
             environmentVariables["TUIST_TOKEN"] = token
         }
 
+        // The cache daemon runs as a launchd agent that does not inherit the
+        // caller's environment, so forward the cache-endpoint override explicitly.
+        // Otherwise the CAS daemon never sees TUIST_CACHE_ENDPOINT and falls back
+        // to the default (public) endpoint, even when the caller pinned a
+        // private-network cache.
+        if let cacheEndpoint = Environment.current.variables["TUIST_CACHE_ENDPOINT"] {
+            environmentVariables["TUIST_CACHE_ENDPOINT"] = cacheEndpoint
+        }
+
         let label = Environment.current.cacheLaunchAgentLabel(for: fullHandle)
 
         try await launchAgentService.setupLaunchAgent(

--- a/cli/Tests/TuistKitTests/Services/Setup/SetupCacheCommandServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/Setup/SetupCacheCommandServiceTests.swift
@@ -222,6 +222,38 @@ struct SetupCacheCommandServiceTests {
             .called(1)
     }
 
+    @Test(.inTemporaryDirectory, .withMockedEnvironment()) func setupCache_forwardsCacheEndpointOverride() async throws {
+        // Given
+        let environment = try #require(Environment.mocked)
+        environment.currentExecutablePathStub = AbsolutePath("/usr/local/bin/tuist")
+        let token = "test-auth-token-123"
+        environment.variables[Constants.EnvironmentVariables.token] = token
+        environment.variables["TUIST_CACHE_ENDPOINT"] = "http://10.0.0.2:30815"
+
+        let config = Tuist.test(fullHandle: "organization/project")
+        configLoader.reset()
+        given(configLoader)
+            .loadConfig(path: .any)
+            .willReturn(config)
+
+        // When
+        try await subject.run(path: nil)
+
+        // Then: the launchd agent does not inherit the caller's environment, so
+        // the override must be passed explicitly or the CAS daemon ignores it.
+        verify(launchAgentService)
+            .setupLaunchAgent(
+                label: .any,
+                plistFileName: .any,
+                programArguments: .any,
+                environmentVariables: .value([
+                    "TUIST_TOKEN": token,
+                    "TUIST_CACHE_ENDPOINT": "http://10.0.0.2:30815",
+                ])
+            )
+            .called(1)
+    }
+
     @Test(
         .inTemporaryDirectory,
         .withMockedEnvironment()


### PR DESCRIPTION
## What

Forward `TUIST_CACHE_ENDPOINT` into the environment of the Xcode compilation cache (CAS) daemon that `tuist setup cache` installs as a launchd agent.

## Why

The CAS daemon (`cache-start`) is installed as a launchd agent. Launchd agents do not inherit the invoking process's environment, and `SetupCacheCommandService` only forwarded `TUIST_TOKEN`. So `TUIST_CACHE_ENDPOINT` never reached the daemon: `CacheURLStore` reads it from the daemon's environment, found nothing, and fell back to the default (public) cache endpoints resolved via `getCacheEndpoints`.

On runners that can reach a private-network cache, this produced an asymmetry: the binary module cache is dispatched the fast private-network endpoint directly by the server, but the CAS daemon round-trips every compilation unit to a public endpoint over the WAN. Connections are pooled, so it is not a per-request handshake cost, but on a full compile (thousands of units) the per-unit round-trip latency makes the Xcode cache net-negative versus no cache.

### Evidence

Benchmarking the Xcode cache with `TUIST_CACHE_ENDPOINT` pinned to the private-network endpoint produced no change (88.96s vs 87.91s baseline), and the private-network cache node recorded zero CAS traffic during the run. The override was being silently dropped at the launchd boundary, which is exactly this bug.

## Fix

Add `TUIST_CACHE_ENDPOINT` to the launchd agent's `environmentVariables` when it is set, mirroring how `TUIST_TOKEN` is already forwarded. A runner (or any caller) that pins the cache endpoint now has it honored by the CAS daemon, not just the binary cache.

## Validation

- New unit test asserts the override is forwarded into the agent environment.
- Existing tests (token-only and no-token) are unaffected, since the override is only added when present.
- Built and tested in CI (the change mirrors the existing token-forwarding path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)