### PR TITLE
fix(cli): forward client feature flags to the Xcode cache daemon

### DIFF
--- a/cli/Sources/TuistKit/Services/Setup/SetupCacheCommandService.swift
+++ b/cli/Sources/TuistKit/Services/Setup/SetupCacheCommandService.swift
@@ -74,6 +74,15 @@ struct SetupCacheCommandService {
             environmentVariables["TUIST_TOKEN"] = token
         }
 
+        // The cache daemon runs as a launchd agent that does not inherit the
+        // caller's environment, so forward the client feature flags. Without
+        // them the daemon cannot signal the "kura" flag on getCacheEndpoints, so
+        // it resolves the default (public) cache endpoint instead of the kura
+        // private-network one the rest of the CLI uses.
+        for (key, value) in ClientFeatureFlags.environmentVariables() {
+            environmentVariables[key] = value
+        }
+
         let label = Environment.current.cacheLaunchAgentLabel(for: fullHandle)
 
         try await launchAgentService.setupLaunchAgent(

--- a/cli/Sources/TuistServer/ClientFeatureFlags.swift
+++ b/cli/Sources/TuistServer/ClientFeatureFlags.swift
@@ -22,6 +22,12 @@ public enum ClientFeatureFlags {
         featureFlags(environment: environment).contains { $0.caseInsensitiveCompare(featureName) == .orderedSame }
     }
 
+    /// The raw `TUIST_FEATURE_FLAG_*` variables, for forwarding the client
+    /// feature flags to a process that does not inherit the environment.
+    public static func environmentVariables(environment: Environmenting = Environment.current) -> [String: String] {
+        environment.variables.filter { $0.key.hasPrefix(environmentPrefix) }
+    }
+
     static func featureFlags(environment: Environmenting = Environment.current) -> [String] {
         Array(
             Set(

--- a/cli/Tests/TuistKitTests/Services/Setup/SetupCacheCommandServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/Setup/SetupCacheCommandServiceTests.swift
@@ -222,6 +222,39 @@ struct SetupCacheCommandServiceTests {
             .called(1)
     }
 
+    @Test(.inTemporaryDirectory, .withMockedEnvironment()) func setupCache_forwardsClientFeatureFlags() async throws {
+        // Given
+        let environment = try #require(Environment.mocked)
+        environment.currentExecutablePathStub = AbsolutePath("/usr/local/bin/tuist")
+        let token = "test-auth-token-123"
+        environment.variables[Constants.EnvironmentVariables.token] = token
+        environment.variables["TUIST_FEATURE_FLAG_KURA"] = "1"
+
+        let config = Tuist.test(fullHandle: "organization/project")
+        configLoader.reset()
+        given(configLoader)
+            .loadConfig(path: .any)
+            .willReturn(config)
+
+        // When
+        try await subject.run(path: nil)
+
+        // Then: the launchd agent does not inherit the caller's environment, so
+        // the feature flags must be forwarded or the daemon resolves the default
+        // (public) cache endpoint instead of the kura private-network one.
+        verify(launchAgentService)
+            .setupLaunchAgent(
+                label: .any,
+                plistFileName: .any,
+                programArguments: .any,
+                environmentVariables: .value([
+                    "TUIST_TOKEN": token,
+                    "TUIST_FEATURE_FLAG_KURA": "1",
+                ])
+            )
+            .called(1)
+    }
+
     @Test(
         .inTemporaryDirectory,
         .withMockedEnvironment()


### PR DESCRIPTION
## What

Forward the client feature flags (`TUIST_FEATURE_FLAG_*`) into the Xcode compilation cache (CAS) daemon's launchd-agent environment, so it resolves cache endpoints the same way the rest of the CLI does.

## Why

`tuist setup cache` starts the CAS daemon (`cache-start`) as a launchd agent, which does not inherit the caller's environment. Setup only forwarded `TUIST_TOKEN`, so `ClientFeatureFlags` was always empty inside the daemon.

Endpoint resolution (`CacheURLStore` then `getCacheEndpoints`) relies on the server's technology selection, which keys off the `x-tuist-feature-flags` request header (auto-injected from `ClientFeatureFlags`). With the `kura` flag the server returns the private-network (kura) endpoint; without it, the default (public) endpoint. Because the daemon never saw the flags, it always resolved the public endpoint, even on runners that can reach a private-network cache.

The binary module cache is unaffected because the server dispatches its endpoint directly, so only the CAS round-tripped every compilation unit to a public endpoint over the WAN, which makes the Xcode cache net-negative on a full compile.

## Fix

Forward `TUIST_FEATURE_FLAG_*` into the agent environment via a new `ClientFeatureFlags.environmentVariables()` helper. A client flagged for kura now has its CAS daemon request the kura endpoints and resolve the private-network cache.

## Validation

- New unit test asserts the feature flags are forwarded into the agent environment.
- Existing tests (token-only and no-token) are unaffected, since the forward only adds flags that are set.
- Built and tested in CI.

## Note

This is the client half. For a runner to actually use the private-network CAS, `TUIST_FEATURE_FLAG_KURA` must be set on the runner job (server/dispatch), which nothing does today. That runner-side change is tracked separately.

Replaces #11480, which forwarded a `TUIST_CACHE_ENDPOINT` override instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)