### PR TITLE
fix(cli): exclude module-map xcframework headers from search paths [4.201.x backport]

### DIFF
--- a/cli/Sources/TuistCore/Graph/GraphTraverser.swift
+++ b/cli/Sources/TuistCore/Graph/GraphTraverser.swift
@@ -850,7 +850,15 @@ public class GraphTraverser: GraphTraversing {
             return publicHeaders
         }
         let xcframeworkLibraryPublicHeaders = dependencies.flatMap { dependency -> [Path.AbsolutePath] in
-            guard case let GraphDependency.xcframework(xcframework) = dependency else { return [] }
+            guard case let GraphDependency.xcframework(xcframework) = dependency,
+                  // Xcode's `ProcessXCFramework` already extracts the SDK-matching slice's headers — including
+                  // any `module.modulemap` — into `$(BUILT_PRODUCTS_DIR)/include`, which is on the header search
+                  // path. Re-adding every slice's `Headers` for an xcframework that ships a module map puts
+                  // additional copies of the same module on the search path, and the compiler fails with
+                  // "redefinition of module 'X'". Such xcframeworks rely on the `include/` copy instead; only
+                  // module-map-less xcframeworks (e.g. cached Swift/library products) still need the headers.
+                  xcframework.moduleMaps.isEmpty
+            else { return [] }
             return xcframework.infoPlist.libraries.compactMap { library in
                 guard let headersPath = library.headersPath else { return nil }
                 return try? AbsolutePath(validating: library.identifier, relativeTo: xcframework.path)

--- a/cli/Tests/TuistCoreTests/Graph/GraphTraverserTests.swift
+++ b/cli/Tests/TuistCoreTests/Graph/GraphTraverserTests.swift
@@ -1914,6 +1914,56 @@ final class GraphTraverserTests: TuistUnitTestCase {
         ])
     }
 
+    func test_librariesPublicHeadersFolders_excludesHeadersOfXCFrameworksShippingAModuleMap() throws {
+        // Given
+        // An xcframework that ships a `module.modulemap` per slice. Xcode's `ProcessXCFramework` already
+        // exposes the SDK-matching slice's headers (and module map) via `$(BUILT_PRODUCTS_DIR)/include`, so
+        // re-adding the slice `Headers` would put a second copy of the module on the search path and the
+        // compiler would fail with "redefinition of module". These headers must therefore be excluded.
+        let target = Target.test(name: "Main")
+        let project = Project.test(targets: [target])
+        let xcframeworkPath = try AbsolutePath(validating: "/cache/ModularLibrary.xcframework")
+        let xcframework = GraphDependency.testXCFramework(
+            path: xcframeworkPath,
+            infoPlist: .test(libraries: [
+                .test(
+                    identifier: "ios-arm64",
+                    path: try RelativePath(validating: "libModularLibrary.a"),
+                    headersPath: try RelativePath(validating: "Headers"),
+                    platform: .iOS,
+                    architectures: [.arm64]
+                ),
+                .test(
+                    identifier: "ios-arm64-simulator",
+                    path: try RelativePath(validating: "libModularLibrary.a"),
+                    headersPath: try RelativePath(validating: "Headers"),
+                    platform: .iOS,
+                    platformVariant: .simulator,
+                    architectures: [.arm64]
+                ),
+            ]),
+            linking: .static,
+            moduleMaps: [
+                xcframeworkPath.appending(components: "ios-arm64", "Headers", "module.modulemap"),
+                xcframeworkPath.appending(components: "ios-arm64-simulator", "Headers", "module.modulemap"),
+            ]
+        )
+        let graph = Graph.test(
+            projects: [project.path: project],
+            dependencies: [
+                .target(name: target.name, path: project.path): Set([xcframework]),
+                xcframework: Set([]),
+            ]
+        )
+        let subject = GraphTraverser(graph: graph)
+
+        // When
+        let got = subject.librariesPublicHeadersFolders(path: project.path, name: target.name)
+
+        // Then
+        XCTAssertEqual(got, [])
+    }
+
     func test_librariesSearchPaths() throws {
         // Given
         let target = Target.test(name: "Main")


### PR DESCRIPTION
Backport of #11472 to the `releases/4.201.x` line.

This is a regression introduced in `4.201.0-rc.1` (via #11290), so the fix needs to ship in the current `4.201.0` RC rather than only on the next minor. Cherry-picked cleanly from `main` (`cherry picked from commit 58cea1eb167...`).

## Summary

Targets depending on a precompiled xcframework that ships a `module.modulemap` fail to compile with `Redefinition of module 'X'`.

Xcode's `ProcessXCFramework` already extracts the SDK-matching slice's headers — including any `module.modulemap` — into `$(BUILT_PRODUCTS_DIR)/include`, which is on the header search path. Since #11290, `GraphTraverser.librariesPublicHeadersFolders` *additionally* adds every xcframework slice's `Headers` to `HEADER_SEARCH_PATHS`, putting a second copy of the same module on the search path → `redefinition of module 'X'`.

The fix skips those headers when the xcframework ships a module map; module-map-less xcframeworks (the cached Swift/library products from #11290) keep their headers, so that feature is unaffected.

See #11472 for the full root-cause analysis and end-to-end verification (reproduced on `4.201.0-canary.13`, unit tests, and a clean rebuild with the patched CLI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)