### PR TITLE
fix(infra): clone macOS runners from a golden base instead of re-pulling per job

### DIFF
--- a/infra/runners-controller/internal/podtemplate/podtemplate.go
+++ b/infra/runners-controller/internal/podtemplate/podtemplate.go
@@ -21,6 +21,8 @@
 package podtemplate
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"strings"
 
@@ -390,6 +392,7 @@ func Build(pool *tuistv1.RunnerPool, podName, saName, dispatchURL, dispatchInter
 			// container only — see the Linux branch above.
 			AutomountServiceAccountToken: ptr(automount),
 			NodeSelector:                 nodeSelector,
+			Affinity:                     goldenAffinity(pool),
 			Tolerations:                  tolerations,
 			Volumes:                      volumes,
 			InitContainers:               initContainers,
@@ -460,6 +463,55 @@ func runtimeClassName(pool *tuistv1.RunnerPool) *string {
 	}
 	rc := pool.Spec.RuntimeClass
 	return &rc
+}
+
+// goldenNodeLabelPrefix namespaces the per-digest Node labels tart-kubelet
+// publishes to advertise which golden base VMs a host already holds.
+//
+// CONTRACT: this prefix and goldenNodeAffinityKey's hashing MUST stay in
+// lockstep with tart-kubelet's `podagent.goldenNodeLabelPrefix` /
+// `goldenVMName` — the two live in separate Go modules, so they're coupled
+// by this convention, not shared code. A mismatch silently disables the
+// affinity (no node ever carries the key the controller prefers), which
+// degrades to today's image-blind placement rather than breaking
+// scheduling, so it's failure-safe but worth a test on both sides.
+const goldenNodeLabelPrefix = "tuist.dev/golden-"
+
+// goldenNodeAffinityKey is the Node-label key advertising that a host holds
+// the golden base for `image`. The suffix is the same 8-byte SHA-256 prefix
+// of the image ref that tart-kubelet embeds in the golden VM name, so both
+// sides derive an identical key from the same digest-pinned ref.
+func goldenNodeAffinityKey(image string) string {
+	sum := sha256.Sum256([]byte(image))
+	return goldenNodeLabelPrefix + hex.EncodeToString(sum[:8])
+}
+
+// goldenAffinity returns soft node-affinity steering a pool's Pods toward
+// hosts that already hold the golden base for its image, so a recycle is a
+// local APFS clonefile instead of a multi-GB cold pull. Preferred, not
+// required: when no warm host has a free slot the Pod still schedules onto
+// a cold host (and pays the one-time materialize) rather than going Pending.
+//
+// macOS only — Linux runners are kata microVMs with no golden-base concept,
+// and `image` re-pull there is a different (much smaller) story. Returns nil
+// for Linux so their Pods keep memory-bin-packed placement untouched.
+func goldenAffinity(pool *tuistv1.RunnerPool) *corev1.Affinity {
+	if pool.Spec.OS == "linux" {
+		return nil
+	}
+	return &corev1.Affinity{
+		NodeAffinity: &corev1.NodeAffinity{
+			PreferredDuringSchedulingIgnoredDuringExecution: []corev1.PreferredSchedulingTerm{{
+				Weight: 100,
+				Preference: corev1.NodeSelectorTerm{
+					MatchExpressions: []corev1.NodeSelectorRequirement{{
+						Key:      goldenNodeAffinityKey(pool.Spec.Image),
+						Operator: corev1.NodeSelectorOpExists,
+					}},
+				},
+			}},
+		},
+	}
 }
 
 // schedulingFor returns the nodeSelector + tolerations for a pool's

--- a/infra/runners-controller/internal/podtemplate/podtemplate_test.go
+++ b/infra/runners-controller/internal/podtemplate/podtemplate_test.go
@@ -58,6 +58,53 @@ func TestBuild_MacOSScheduling(t *testing.T) {
 	}
 }
 
+func TestBuild_MacOSGoldenAffinity(t *testing.T) {
+	p := basePool("")
+	pod := build(t, p)
+
+	aff := pod.Spec.Affinity
+	if aff == nil || aff.NodeAffinity == nil {
+		t.Fatal("macOS pod is missing golden node affinity")
+	}
+	terms := aff.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution
+	if len(terms) != 1 {
+		t.Fatalf("preferred terms = %d, want 1", len(terms))
+	}
+	exprs := terms[0].Preference.MatchExpressions
+	if len(exprs) != 1 {
+		t.Fatalf("match expressions = %d, want 1", len(exprs))
+	}
+	if got, want := exprs[0].Key, goldenNodeAffinityKey(p.Spec.Image); got != want {
+		t.Fatalf("affinity key = %q, want %q", got, want)
+	}
+	if exprs[0].Operator != corev1.NodeSelectorOpExists {
+		t.Fatalf("affinity operator = %q, want Exists", exprs[0].Operator)
+	}
+	// Soft, not required: a Pod must still schedule onto a cold host when
+	// no warm one is free.
+	if aff.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution != nil {
+		t.Fatal("golden affinity must be preferred, never required")
+	}
+}
+
+func TestBuild_LinuxHasNoGoldenAffinity(t *testing.T) {
+	pod := build(t, basePool("linux"))
+	if pod.Spec.Affinity != nil {
+		t.Fatalf("linux pod got affinity %+v, want nil (no golden-base concept)", pod.Spec.Affinity)
+	}
+}
+
+// Pins the golden Node-label key to the exact value tart-kubelet derives for
+// the same image (asserted on the other side in podagent's TestGoldenNodeLabel).
+// The two live in separate Go modules; this shared literal is the contract.
+func TestGoldenNodeAffinityKey_MatchesTartKubelet(t *testing.T) {
+	img := "ghcr.io/tuist/tuist-runner@sha256:" + strings.Repeat("a", 64)
+	const wantKey = "tuist.dev/golden-9c8af651fdf30b10"
+	if got := goldenNodeAffinityKey(img); got != wantKey {
+		t.Fatalf("goldenNodeAffinityKey = %q, want %q", got, wantKey)
+	}
+}
+
 func TestBuild_LinuxScheduling(t *testing.T) {
 	pod := build(t, basePool("linux"))
 	// Linux pools must use the in-cluster URL — the public path

--- a/infra/tart-kubelet/cmd/tart-kubelet/main.go
+++ b/infra/tart-kubelet/cmd/tart-kubelet/main.go
@@ -232,6 +232,10 @@ func main() {
 			NodeName: nodeName,
 			Interval: 5 * time.Minute,
 			Store:    store,
+			// Keep an idle host's golden base for a day so the next
+			// burst clones from it instead of re-pulling the whole VM
+			// image. Zero would fall back to the same default.
+			GoldenRetention: 24 * time.Hour,
 		}
 		if err := mgr.Add(gcCollector); err != nil {
 			setupLog.Error(err, "add gc collector")

--- a/infra/tart-kubelet/cmd/tart-kubelet/main.go
+++ b/infra/tart-kubelet/cmd/tart-kubelet/main.go
@@ -287,6 +287,27 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Publish which golden base VMs this host holds as
+	// `tuist.dev/golden-<hash>` Node labels so the runners-controller can
+	// steer a pool's Pods toward hosts that can clone its image locally
+	// instead of cold-pulling it. Mask a transient `tart list` failure
+	// with the last good result so a momentary hiccup doesn't flap the
+	// labels off (and briefly drop the affinity). The maintainer calls
+	// this serially from its single heartbeat goroutine, so the closed-over
+	// cache needs no lock.
+	var lastGoldenLabels map[string]string
+	goldenLabelProvider := func(ctx context.Context) (map[string]string, error) {
+		labels, err := podagent.GoldenNodeLabels(ctx, tartClient)
+		if err != nil {
+			if lastGoldenLabels != nil {
+				return lastGoldenLabels, nil
+			}
+			return nil, err
+		}
+		lastGoldenLabels = labels
+		return labels, nil
+	}
+
 	if err := mgr.Add(&nodeagent.Maintainer{
 		Client:     mgr.GetClient(),
 		NodeName:   nodeName,
@@ -300,6 +321,7 @@ func main() {
 		DiskPressure: func(ctx context.Context) (bool, string, error) {
 			return diskPressureFromGuests(ctx, tartClient, diskPressureThresholdPercent)
 		},
+		DynamicLabels: goldenLabelProvider,
 	}); err != nil {
 		setupLog.Error(err, "add node maintainer")
 		os.Exit(1)

--- a/infra/tart-kubelet/internal/nodeagent/node.go
+++ b/infra/tart-kubelet/internal/nodeagent/node.go
@@ -65,7 +65,23 @@ type Maintainer struct {
 	// a full guest disk from the scheduler and from alerting. nil keeps
 	// the condition at its False default.
 	DiskPressure DiskPressureProbe
+
+	// DynamicLabels, when non-nil, is evaluated each heartbeat for Node
+	// labels the agent owns that change at runtime (today: the
+	// `tuist.dev/golden-<hash>` advertisements of which golden base VMs
+	// this host holds). They're merged alongside NodeLabels and pruned
+	// the same way — a key that stops being returned (golden GC'd) is
+	// dropped on the next heartbeat. A probe error contributes nothing
+	// this round; the provider is expected to mask transient failures
+	// (e.g. return its last good result) so a momentary `tart list`
+	// hiccup doesn't flap the labels off.
+	DynamicLabels DynamicLabelProvider
 }
+
+// DynamicLabelProvider returns the agent-owned labels to publish this
+// heartbeat. A non-nil error means the probe failed; the maintainer then
+// publishes no dynamic labels for the round rather than guessing.
+type DynamicLabelProvider func(ctx context.Context) (map[string]string, error)
 
 // DiskPressureProbe reports whether the node is under disk pressure plus
 // a human-readable detail for the condition message. A non-nil error
@@ -108,7 +124,7 @@ func (m *Maintainer) ensureNode(ctx context.Context) error {
 		if m.ProviderID != "" {
 			node.Spec.ProviderID = m.ProviderID
 		}
-		m.configureNode(node)
+		m.configureNode(node, m.evalDynamicLabels(ctx))
 		return m.Client.Create(ctx, node)
 	}
 	if err != nil {
@@ -133,7 +149,7 @@ func (m *Maintainer) refresh(ctx context.Context) error {
 	if err := m.Client.Get(ctx, types.NamespacedName{Name: m.NodeName}, node); err != nil {
 		return err
 	}
-	m.configureNode(node)
+	m.configureNode(node, m.evalDynamicLabels(ctx))
 	m.applyDiskPressure(ctx, node)
 	for i, c := range node.Status.Conditions {
 		if c.Type == corev1.NodeReady {
@@ -141,6 +157,22 @@ func (m *Maintainer) refresh(ctx context.Context) error {
 		}
 	}
 	return m.Client.Status().Update(ctx, node)
+}
+
+// evalDynamicLabels runs the DynamicLabels provider for this heartbeat,
+// returning nil (publish no dynamic labels) when unset or on error. The
+// provider is responsible for masking transient failures so a probe error
+// here is genuinely "no opinion this round", not "flap the labels off".
+func (m *Maintainer) evalDynamicLabels(ctx context.Context) map[string]string {
+	if m.DynamicLabels == nil {
+		return nil
+	}
+	labels, err := m.DynamicLabels(ctx)
+	if err != nil {
+		log.FromContext(ctx).Error(err, "dynamic node labels")
+		return nil
+	}
+	return labels
 }
 
 // applyDiskPressure refreshes the DiskPressure condition from the probe.
@@ -166,7 +198,7 @@ func (m *Maintainer) applyDiskPressure(ctx context.Context, node *corev1.Node) {
 // configureNode sets labels, taints, capacity, and Node info. Mirrors
 // what a real kubelet reports — minus cAdvisor metrics, which we
 // don't need.
-func (m *Maintainer) configureNode(node *corev1.Node) {
+func (m *Maintainer) configureNode(node *corev1.Node, dynamicLabels map[string]string) {
 	if node.Labels == nil {
 		node.Labels = map[string]string{}
 	}
@@ -178,12 +210,20 @@ func (m *Maintainer) configureNode(node *corev1.Node) {
 	// excluded from the prune below.
 	node.Labels["tuist.dev/runtime"] = "tart"
 
-	// Apply operator-set labels. Any tuist.dev/* label not in the
-	// current NodeLabels map gets dropped — gives the operator a
-	// clean retire path: flip --node-labels and the Node sheds
-	// the old labels on the next heartbeat. The runtime label is
-	// excluded from prune (intrinsic, not operator-tunable).
+	// Effective owned set: operator-set NodeLabels plus the agent-owned
+	// dynamic labels (golden advertisements) this heartbeat. Used for
+	// both apply and prune so a tuist.dev/* label that's no longer owned
+	// — a retired --node-labels entry or a GC'd golden — is dropped on
+	// the next heartbeat. The runtime label is excluded from prune
+	// (intrinsic, not tunable).
+	owned := make(map[string]string, len(m.NodeLabels)+len(dynamicLabels))
 	for k, v := range m.NodeLabels {
+		owned[k] = v
+	}
+	for k, v := range dynamicLabels {
+		owned[k] = v
+	}
+	for k, v := range owned {
 		node.Labels[k] = v
 	}
 	for k := range node.Labels {
@@ -193,7 +233,7 @@ func (m *Maintainer) configureNode(node *corev1.Node) {
 		if k == "tuist.dev/runtime" {
 			continue
 		}
-		if _, kept := m.NodeLabels[k]; !kept {
+		if _, kept := owned[k]; !kept {
 			delete(node.Labels, k)
 		}
 	}

--- a/infra/tart-kubelet/internal/nodeagent/node.go
+++ b/infra/tart-kubelet/internal/nodeagent/node.go
@@ -149,7 +149,22 @@ func (m *Maintainer) refresh(ctx context.Context) error {
 	if err := m.Client.Get(ctx, types.NamespacedName{Name: m.NodeName}, node); err != nil {
 		return err
 	}
+
+	// configureNode edits labels (metadata) and taints (spec); the
+	// Status().Update below writes only the status subresource and the API
+	// server drops any metadata/spec it carries. Static labels survive
+	// because they're set at Create, but the dynamic golden-base labels
+	// first appear here on a heartbeat — without a separate metadata write
+	// they'd never reach etcd, so no Node would carry the label and the
+	// controller's golden node-affinity would silently match nothing. Patch
+	// metadata/spec first (merge patch persists label deletions as null),
+	// then update status.
+	base := node.DeepCopy()
 	m.configureNode(node, m.evalDynamicLabels(ctx))
+	if err := m.Client.Patch(ctx, node, client.MergeFrom(base)); err != nil {
+		return err
+	}
+
 	m.applyDiskPressure(ctx, node)
 	for i, c := range node.Status.Conditions {
 		if c.Type == corev1.NodeReady {

--- a/infra/tart-kubelet/internal/nodeagent/node_test.go
+++ b/infra/tart-kubelet/internal/nodeagent/node_test.go
@@ -71,6 +71,52 @@ func TestEnsureNodeDoesNotOverwriteExistingProviderID(t *testing.T) {
 	}
 }
 
+// Regression guard for the golden-affinity no-op: refresh() must persist
+// dynamic labels to the API server, not just mutate the in-memory Node.
+// Status().Update writes only the status subresource (the fake client honors
+// that split via WithStatusSubresource), so without the metadata patch the
+// `tuist.dev/golden-*` labels never reach etcd and the controller's
+// node-affinity matches nothing.
+func TestRefreshPersistsDynamicLabels(t *testing.T) {
+	const goldenKey = "tuist.dev/golden-9c8af651fdf30b10"
+	c := newNodeFakeClient(&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "mac-1"}})
+	m := &Maintainer{
+		Client:    c,
+		NodeName:  "mac-1",
+		Heartbeat: time.Second,
+		DynamicLabels: func(context.Context) (map[string]string, error) {
+			return map[string]string{goldenKey: "true"}, nil
+		},
+	}
+
+	if err := m.refresh(context.Background()); err != nil {
+		t.Fatalf("refresh: %v", err)
+	}
+
+	persisted := &corev1.Node{}
+	if err := c.Get(context.Background(), types.NamespacedName{Name: "mac-1"}, persisted); err != nil {
+		t.Fatalf("get node: %v", err)
+	}
+	if got := persisted.Labels[goldenKey]; got != "true" {
+		t.Fatalf("golden label not persisted to the API server: labels=%v", persisted.Labels)
+	}
+
+	// A later heartbeat that no longer advertises the golden must prune it
+	// from the persisted Node (merge patch deletes via null), not just in
+	// memory.
+	m.DynamicLabels = func(context.Context) (map[string]string, error) { return nil, nil }
+	if err := m.refresh(context.Background()); err != nil {
+		t.Fatalf("refresh (prune): %v", err)
+	}
+	persisted = &corev1.Node{}
+	if err := c.Get(context.Background(), types.NamespacedName{Name: "mac-1"}, persisted); err != nil {
+		t.Fatalf("get node: %v", err)
+	}
+	if _, present := persisted.Labels[goldenKey]; present {
+		t.Fatalf("stale golden label not pruned from persisted node: labels=%v", persisted.Labels)
+	}
+}
+
 func conditionByType(conds []corev1.NodeCondition, t corev1.NodeConditionType) (corev1.NodeCondition, bool) {
 	for _, c := range conds {
 		if c.Type == t {

--- a/infra/tart-kubelet/internal/nodeagent/node_test.go
+++ b/infra/tart-kubelet/internal/nodeagent/node_test.go
@@ -84,7 +84,7 @@ func TestConfigureNodeSeedsDiskPressureFalse(t *testing.T) {
 	m := &Maintainer{NodeName: "mac-mini-1"}
 	node := &corev1.Node{}
 
-	m.configureNode(node)
+	m.configureNode(node, nil)
 
 	dp, ok := conditionByType(node.Status.Conditions, corev1.NodeDiskPressure)
 	if !ok {
@@ -95,6 +95,66 @@ func TestConfigureNodeSeedsDiskPressureFalse(t *testing.T) {
 	}
 }
 
+func TestConfigureNodeMergesDynamicLabels(t *testing.T) {
+	m := &Maintainer{
+		NodeName:   "mac-mini-1",
+		NodeLabels: map[string]string{"tuist.dev/fleet": "runners"},
+	}
+	node := &corev1.Node{}
+
+	m.configureNode(node, map[string]string{"tuist.dev/golden-deadbeefdeadbeef": "true"})
+
+	if got := node.Labels["tuist.dev/fleet"]; got != "runners" {
+		t.Fatalf("operator label dropped: tuist.dev/fleet = %q", got)
+	}
+	if got := node.Labels["tuist.dev/golden-deadbeefdeadbeef"]; got != "true" {
+		t.Fatalf("dynamic golden label missing: got %q", got)
+	}
+	if got := node.Labels["tuist.dev/runtime"]; got != "tart" {
+		t.Fatalf("intrinsic runtime label = %q", got)
+	}
+}
+
+// A golden label present on the Node but no longer returned by the provider
+// (golden GC'd, or a different digest now) must be pruned — same retire path
+// as a dropped operator label.
+func TestConfigureNodePrunesStaleDynamicLabels(t *testing.T) {
+	m := &Maintainer{NodeName: "mac-mini-1"}
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{"tuist.dev/golden-0000000000000000": "true"},
+		},
+	}
+
+	m.configureNode(node, map[string]string{"tuist.dev/golden-1111111111111111": "true"})
+
+	if _, present := node.Labels["tuist.dev/golden-0000000000000000"]; present {
+		t.Fatal("stale golden label was not pruned")
+	}
+	if got := node.Labels["tuist.dev/golden-1111111111111111"]; got != "true" {
+		t.Fatalf("current golden label missing: got %q", got)
+	}
+}
+
+// When the provider yields nothing (unset, or a probe error that the
+// maintainer treats as "no opinion"), any previously-published golden labels
+// are pruned. The production provider masks transient errors with its last
+// good result, so a real empty means "this host holds no goldens".
+func TestConfigureNodePrunesAllDynamicLabelsWhenNone(t *testing.T) {
+	m := &Maintainer{NodeName: "mac-mini-1"}
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{"tuist.dev/golden-0000000000000000": "true"},
+		},
+	}
+
+	m.configureNode(node, nil)
+
+	if _, present := node.Labels["tuist.dev/golden-0000000000000000"]; present {
+		t.Fatal("golden label survived an empty provider result")
+	}
+}
+
 func TestApplyDiskPressureSetsTrueWithDetail(t *testing.T) {
 	m := &Maintainer{
 		DiskPressure: func(context.Context) (bool, string, error) {
@@ -102,7 +162,7 @@ func TestApplyDiskPressureSetsTrueWithDetail(t *testing.T) {
 		},
 	}
 	node := &corev1.Node{}
-	m.configureNode(node)
+	m.configureNode(node, nil)
 
 	m.applyDiskPressure(context.Background(), node)
 
@@ -125,7 +185,7 @@ func TestApplyDiskPressureSetsFalse(t *testing.T) {
 		},
 	}
 	node := &corev1.Node{}
-	m.configureNode(node)
+	m.configureNode(node, nil)
 
 	m.applyDiskPressure(context.Background(), node)
 
@@ -142,7 +202,7 @@ func TestApplyDiskPressureKeepsPriorValueOnProbeError(t *testing.T) {
 		},
 	}
 	node := &corev1.Node{}
-	m.configureNode(node)
+	m.configureNode(node, nil)
 	// Simulate a prior heartbeat that observed pressure.
 	setCondition(&node.Status.Conditions, corev1.NodeDiskPressure, corev1.ConditionTrue, "TartKubeletHasDiskPressure", "vm-x at 100%")
 
@@ -157,7 +217,7 @@ func TestApplyDiskPressureKeepsPriorValueOnProbeError(t *testing.T) {
 func TestApplyDiskPressureNilProbeIsNoop(t *testing.T) {
 	m := &Maintainer{} // no probe
 	node := &corev1.Node{}
-	m.configureNode(node)
+	m.configureNode(node, nil)
 
 	m.applyDiskPressure(context.Background(), node)
 

--- a/infra/tart-kubelet/internal/podagent/garbage.go
+++ b/infra/tart-kubelet/internal/podagent/garbage.go
@@ -48,8 +48,34 @@ type Collector struct {
 	Interval time.Duration
 	Store    *Store
 
+	// GoldenRetention is how long a golden base VM with no current Pod
+	// referencing its digest is kept before reaping. It lets a golden
+	// survive idle troughs — an overnight-quiet host clones the morning
+	// burst from its golden instead of re-pulling the whole image — and
+	// a digest's golden linger briefly after a roll. Zero falls back to
+	// defaultGoldenRetention. Disk-pressure reclaim (RunOnceReclaim)
+	// ignores it.
+	GoldenRetention time.Duration
+
+	// Now is overridable in tests; defaults to time.Now.
+	Now func() time.Time
+
 	mu sync.Mutex
+
+	// goldenSeen tracks the last time each golden base VM was seen
+	// referenced (or first seen unreferenced), powering GoldenRetention.
+	// In-memory: on kubelet restart it reseeds on first sight, erring
+	// toward keeping a golden one extra window — safe (a re-pull avoided,
+	// disk reclaimed slightly later).
+	goldenSeenMu sync.Mutex
+	goldenSeen   map[string]time.Time
 }
+
+// defaultGoldenRetention keeps an unreferenced golden base for a day —
+// long enough to span an overnight idle trough so the next burst clones
+// from it rather than re-pulling, short enough that a rolled-out digest's
+// golden is reclaimed within a day.
+const defaultGoldenRetention = 24 * time.Hour
 
 // Start blocks until ctx is cancelled. Conforms to manager.Runnable.
 func (c *Collector) Start(ctx context.Context) error {
@@ -66,10 +92,19 @@ func (c *Collector) Start(ctx context.Context) error {
 	}
 }
 
-// RunOnce performs a single GC pass. Safe to call concurrently with
-// itself (mutex serializes). Logs but doesn't return errors — there's
-// nothing the caller can usefully do with them.
-func (c *Collector) RunOnce(ctx context.Context) {
+// RunOnce performs a single GC pass, keeping unreferenced golden base
+// VMs within GoldenRetention. Safe to call concurrently with itself
+// (mutex serializes). Logs but doesn't return errors — there's nothing
+// the caller can usefully do with them.
+func (c *Collector) RunOnce(ctx context.Context) { c.runOnce(ctx, false) }
+
+// RunOnceReclaim is the aggressive variant the reconciler calls when a
+// pull fails for lack of space: it additionally evicts unreferenced
+// golden bases regardless of GoldenRetention, since a golden held only
+// as a warm-clone source must yield to an actual out-of-disk provision.
+func (c *Collector) RunOnceReclaim(ctx context.Context) { c.runOnce(ctx, true) }
+
+func (c *Collector) runOnce(ctx context.Context, aggressive bool) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -87,10 +122,32 @@ func (c *Collector) RunOnce(ctx context.Context) {
 		return
 	}
 
-	var droppedClones, droppedImages int
+	now := c.now()
+	retention := c.GoldenRetention
+	if retention <= 0 {
+		retention = defaultGoldenRetention
+	}
+
+	var droppedClones, droppedImages, droppedGoldens int
 	for _, vm := range vms {
 		switch vm.Source {
 		case "local":
+			// Golden bases survive the no-Pod recycle gap (and idle
+			// troughs) so recycles clone from them instead of re-pulling.
+			// A non-golden local VM with no backing Pod is an orphan
+			// clone, reaped immediately as before.
+			if isGoldenVMName(vm.Name) {
+				if c.keepGolden(vm.Name, expected, now, retention, aggressive) {
+					continue
+				}
+				if err := c.Tart.Delete(ctx, vm.Name); err != nil {
+					logger.Error(err, "delete stale golden base", "name", vm.Name)
+					continue
+				}
+				c.forgetGolden(vm.Name)
+				droppedGoldens++
+				continue
+			}
 			if _, want := expected.vms[vm.Name]; want {
 				continue
 			}
@@ -111,9 +168,58 @@ func (c *Collector) RunOnce(ctx context.Context) {
 			droppedImages++
 		}
 	}
-	if droppedClones > 0 || droppedImages > 0 {
-		logger.Info("reclaimed disk", "orphan_clones", droppedClones, "stale_oci_images", droppedImages)
+	if droppedClones > 0 || droppedImages > 0 || droppedGoldens > 0 {
+		logger.Info("reclaimed disk",
+			"orphan_clones", droppedClones,
+			"stale_oci_images", droppedImages,
+			"stale_golden_bases", droppedGoldens)
 	}
+}
+
+// keepGolden decides whether to retain a golden base VM this pass and
+// stamps its last-seen time. A golden whose digest a current Pod still
+// references is always kept (and its retention clock reset). An
+// unreferenced golden is kept until GoldenRetention elapses since it was
+// last seen — except under `aggressive` reclaim, where unreferenced
+// always means reap. First unreferenced sighting starts the clock now
+// (covers a just-materialized golden the Pod List hasn't caught up to,
+// and pre-restart goldens), so it's never reaped on the very pass that
+// discovers it.
+func (c *Collector) keepGolden(name string, expected *expectedSet, now time.Time, retention time.Duration, aggressive bool) bool {
+	c.goldenSeenMu.Lock()
+	defer c.goldenSeenMu.Unlock()
+	if c.goldenSeen == nil {
+		c.goldenSeen = map[string]time.Time{}
+	}
+
+	if _, referenced := expected.vms[name]; referenced {
+		c.goldenSeen[name] = now
+		return true
+	}
+	if aggressive {
+		return false
+	}
+	last, ok := c.goldenSeen[name]
+	if !ok {
+		c.goldenSeen[name] = now
+		return true
+	}
+	return now.Sub(last) < retention
+}
+
+// forgetGolden drops a reaped golden's last-seen entry so the map
+// doesn't grow without bound across digest rolls.
+func (c *Collector) forgetGolden(name string) {
+	c.goldenSeenMu.Lock()
+	delete(c.goldenSeen, name)
+	c.goldenSeenMu.Unlock()
+}
+
+func (c *Collector) now() time.Time {
+	if c.Now != nil {
+		return c.Now()
+	}
+	return time.Now()
 }
 
 // IsNoSpaceError matches the stderr signature Tart returns when a
@@ -156,6 +262,11 @@ func (c *Collector) expectedSet(ctx context.Context) (*expectedSet, error) {
 		}
 		out.vms[VMNameForPod(pod)] = struct{}{}
 		out.images[pod.Spec.Containers[0].Image] = struct{}{}
+		// Keep the golden base this image clones from. Without this the
+		// "local" GC branch would see the golden VM, find no Pod named
+		// after it, and reap it as an orphan clone — forcing the next
+		// recycle to re-pull the whole image.
+		out.vms[goldenVMName(pod.Spec.Containers[0].Image)] = struct{}{}
 	}
 	// Store-side entries cover Pods the reconciler has already started
 	// a VM for but that haven't shown up on this List response yet

--- a/infra/tart-kubelet/internal/podagent/golden_test.go
+++ b/infra/tart-kubelet/internal/podagent/golden_test.go
@@ -45,6 +45,32 @@ func TestGoldenVMName(t *testing.T) {
 	}
 }
 
+// goldenNodeLabel turns a golden VM name into the Node-label key the
+// runners-controller's affinity matches on. The pinned literal is the
+// cross-module contract: runners-controller's podtemplate test asserts its
+// goldenNodeAffinityKey produces this same key for the same image, so a
+// drift on either side fails a test rather than silently disabling affinity.
+func TestGoldenNodeLabel(t *testing.T) {
+	img := "ghcr.io/tuist/tuist-runner@sha256:" + strings.Repeat("a", 64)
+	const wantKey = "tuist.dev/golden-9c8af651fdf30b10"
+
+	if got := goldenVMName(img); got != "tuist-golden-9c8af651fdf30b10" {
+		t.Fatalf("goldenVMName = %q, want tuist-golden-9c8af651fdf30b10", got)
+	}
+
+	key, ok := goldenNodeLabel(goldenVMName(img))
+	if !ok {
+		t.Fatal("goldenNodeLabel returned ok=false for a golden VM name")
+	}
+	if key != wantKey {
+		t.Fatalf("goldenNodeLabel = %q, want %q (must match runners-controller)", key, wantKey)
+	}
+
+	if _, ok := goldenNodeLabel("tuist-runners-runner-abc123"); ok {
+		t.Fatal("goldenNodeLabel returned ok=true for a non-golden VM name")
+	}
+}
+
 // The golden base a Pod's image clones from must land in expectedSet so
 // the GC's "local" branch retains it instead of reaping it as an orphan
 // clone — the bug that would force a full re-pull on the next recycle.

--- a/infra/tart-kubelet/internal/podagent/golden_test.go
+++ b/infra/tart-kubelet/internal/podagent/golden_test.go
@@ -1,0 +1,145 @@
+package podagent
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestGoldenVMName(t *testing.T) {
+	const img = "ghcr.io/tuist/tuist-runner@sha256:" + "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+
+	name := goldenVMName(img)
+
+	if !isGoldenVMName(name) {
+		t.Fatalf("goldenVMName(%q) = %q is not recognised as a golden name", img, name)
+	}
+	if !strings.HasPrefix(name, goldenBaseVMPrefix) {
+		t.Fatalf("name %q missing prefix %q", name, goldenBaseVMPrefix)
+	}
+	if got := goldenVMName(img); got != name {
+		t.Fatalf("goldenVMName not deterministic: %q != %q", got, name)
+	}
+	if len(name) > 63 {
+		t.Fatalf("name %q exceeds Tart's 63-char limit (%d)", name, len(name))
+	}
+
+	// A different digest must map to a different golden so a runner-image
+	// roll materialises a fresh base instead of reusing the old one.
+	other := goldenVMName("ghcr.io/tuist/tuist-runner@sha256:" + strings.Repeat("f", 64))
+	if other == name {
+		t.Fatalf("distinct images collided on golden name %q", name)
+	}
+
+	// A per-Pod runner clone name must never be mistaken for a golden.
+	runnerClone := "tuist-runners-runner-abc123"
+	if isGoldenVMName(runnerClone) {
+		t.Fatalf("runner clone %q misclassified as golden", runnerClone)
+	}
+}
+
+// The golden base a Pod's image clones from must land in expectedSet so
+// the GC's "local" branch retains it instead of reaping it as an orphan
+// clone — the bug that would force a full re-pull on the next recycle.
+func TestExpectedSetRetainsGoldenBase(t *testing.T) {
+	const node = "mini-1"
+	img := "ghcr.io/tuist/tuist-runner@sha256:" + strings.Repeat("a", 64)
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "tuist-runners", Name: "runner-xyz"},
+		Spec: corev1.PodSpec{
+			NodeName:   node,
+			Containers: []corev1.Container{{Name: "runner", Image: img}},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add core scheme: %v", err)
+	}
+	k := fake.NewClientBuilder().WithScheme(scheme).
+		WithIndex(&corev1.Pod{}, "spec.nodeName", func(o client.Object) []string {
+			return []string{o.(*corev1.Pod).Spec.NodeName}
+		}).
+		WithObjects(pod).Build()
+
+	c := &Collector{K8s: k, NodeName: node}
+	expected, err := c.expectedSet(context.Background())
+	if err != nil {
+		t.Fatalf("expectedSet: %v", err)
+	}
+
+	if _, ok := expected.vms[VMNameForPod(pod)]; !ok {
+		t.Fatalf("runner clone %q missing from expected.vms", VMNameForPod(pod))
+	}
+	if _, ok := expected.vms[goldenVMName(img)]; !ok {
+		t.Fatalf("golden base %q missing from expected.vms", goldenVMName(img))
+	}
+	if _, ok := expected.images[img]; !ok {
+		t.Fatalf("image %q missing from expected.images", img)
+	}
+}
+
+func TestKeepGolden(t *testing.T) {
+	now := time.Date(2026, 6, 24, 12, 0, 0, 0, time.UTC)
+	const golden = goldenBaseVMPrefix + "deadbeef"
+	const retention = time.Hour
+
+	referenced := &expectedSet{vms: map[string]struct{}{golden: {}}, images: map[string]struct{}{}}
+	unreferenced := &expectedSet{vms: map[string]struct{}{}, images: map[string]struct{}{}}
+
+	t.Run("referenced is kept and clock reset", func(t *testing.T) {
+		c := &Collector{}
+		if !c.keepGolden(golden, referenced, now, retention, false) {
+			t.Fatal("referenced golden was not kept")
+		}
+		if got := c.goldenSeen[golden]; !got.Equal(now) {
+			t.Fatalf("last-seen = %v, want %v", got, now)
+		}
+	})
+
+	t.Run("unreferenced first sighting is kept on grace", func(t *testing.T) {
+		c := &Collector{}
+		if !c.keepGolden(golden, unreferenced, now, retention, false) {
+			t.Fatal("first-sight unreferenced golden was reaped immediately")
+		}
+		if got := c.goldenSeen[golden]; !got.Equal(now) {
+			t.Fatalf("last-seen = %v, want %v", got, now)
+		}
+	})
+
+	t.Run("unreferenced within retention is kept", func(t *testing.T) {
+		c := &Collector{goldenSeen: map[string]time.Time{golden: now.Add(-30 * time.Minute)}}
+		if !c.keepGolden(golden, unreferenced, now, retention, false) {
+			t.Fatal("golden last seen 30m ago (retention 1h) was reaped")
+		}
+	})
+
+	t.Run("unreferenced past retention is reaped", func(t *testing.T) {
+		c := &Collector{goldenSeen: map[string]time.Time{golden: now.Add(-2 * time.Hour)}}
+		if c.keepGolden(golden, unreferenced, now, retention, false) {
+			t.Fatal("golden last seen 2h ago (retention 1h) was kept")
+		}
+	})
+
+	t.Run("aggressive reaps unreferenced even when fresh", func(t *testing.T) {
+		c := &Collector{goldenSeen: map[string]time.Time{golden: now}}
+		if c.keepGolden(golden, unreferenced, now, retention, true) {
+			t.Fatal("aggressive reclaim kept an unreferenced golden")
+		}
+	})
+
+	t.Run("aggressive still keeps a referenced golden", func(t *testing.T) {
+		c := &Collector{}
+		if !c.keepGolden(golden, referenced, now, retention, true) {
+			t.Fatal("aggressive reclaim reaped a golden a Pod still references")
+		}
+	})
+}

--- a/infra/tart-kubelet/internal/podagent/metrics.go
+++ b/infra/tart-kubelet/internal/podagent/metrics.go
@@ -32,6 +32,22 @@ var vmBootDurationSeconds = prometheus.NewHistogramVec(
 	[]string{"pool"},
 )
 
+// goldenBaseMaterializedTotal counts golden base VMs materialized via a
+// full `tart pull` + `tart clone` (the multi-GB image download + extract).
+// Recycles clone from the host's per-digest golden base — an APFS
+// clonefile that touches the network zero times — so in steady state this
+// counter is flat. It ticks up only when a host first sees a digest (and
+// once per host on a runner-image roll). A rising rate between rolls is the
+// "goldens aren't sticking, we're re-pulling per job" regression signal the
+// whole golden-base scheme exists to kill.
+var goldenBaseMaterializedTotal = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "tart_kubelet_golden_base_materialized_total",
+		Help: "Golden base VMs materialized via full image pull+clone (per pool). Flat in steady state; ticks on first-sight of a digest.",
+	},
+	[]string{"pool"},
+)
+
 // guestDiskUsagePercent is the percent-used of each running VM's guest
 // root volume, as read by the node maintainer's DiskPressure probe. It's
 // the gradient signal behind the binary DiskPressure node condition:
@@ -70,7 +86,18 @@ var podProvisionDelaySeconds = prometheus.NewHistogramVec(
 )
 
 func init() {
-	metrics.Registry.MustRegister(vmBootDurationSeconds, guestDiskUsagePercent, podProvisionDelaySeconds)
+	metrics.Registry.MustRegister(vmBootDurationSeconds, guestDiskUsagePercent, podProvisionDelaySeconds, goldenBaseMaterializedTotal)
+}
+
+// RecordGoldenMaterialized increments the per-pool count of golden base
+// VMs materialized via a full image pull+clone. Called once per cold
+// `ensureGolden` (first-sight of a digest on this host), not on the
+// clonefile recycle path.
+func RecordGoldenMaterialized(pool string) {
+	if pool == "" {
+		pool = "unknown"
+	}
+	goldenBaseMaterializedTotal.WithLabelValues(pool).Inc()
 }
 
 // RecordGuestDiskUsage publishes a VM's guest root-volume usage percent.

--- a/infra/tart-kubelet/internal/podagent/reconciler.go
+++ b/infra/tart-kubelet/internal/podagent/reconciler.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"net"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -86,6 +87,15 @@ type Reconciler struct {
 	// an IP — is visible in `kubectl describe`. Optional; nil skips
 	// event emission.
 	Recorder record.EventRecorder
+
+	// goldenMu guards goldenLocks; goldenLocks serializes golden-base
+	// materialization per image digest so two Pods admitted close
+	// together don't both run the one-time pull+clone for the same
+	// golden (the second `tart clone` would fail "VM exists"). Reconcile
+	// concurrency is 1 today, but the lock keeps ensureGolden correct if
+	// that's ever raised, and costs nothing on the warm fast path.
+	goldenMu    sync.Mutex
+	goldenLocks map[string]*sync.Mutex
 }
 
 // MetricsScrapeAnnotation is the pod annotation that tells
@@ -283,7 +293,7 @@ func (r *Reconciler) createPod(ctx context.Context, pod *corev1.Pod) error {
 	// longer a silent dead zone in `kubectl describe`. k8s aggregates
 	// duplicate events, so a retried createPod doesn't spam.
 	if r.Recorder != nil {
-		r.Recorder.Event(pod, corev1.EventTypeNormal, "CreatingVM", "starting Tart VM provisioning (pull + clone + run)")
+		r.Recorder.Event(pod, corev1.EventTypeNormal, "CreatingVM", "starting Tart VM provisioning (clone from golden base; pulls only on a new image digest)")
 	}
 
 	c := pod.Spec.Containers[0]
@@ -317,27 +327,29 @@ func (r *Reconciler) createPod(ctx context.Context, pod *corev1.Pod) error {
 	// Reuse an existing local clone if one is on disk: a kubelet
 	// restart kills the running VM (launchctl bootout signals the
 	// process group) but the cloned image stays. Re-running it skips
-	// the multi-minute pull + clone cycle.
+	// the clone cycle entirely.
 	existingClone, _ := r.Tart.Get(ctx, vmName)
 
 	if existingClone == nil {
-		if err := r.Tart.Pull(ctx, c.Image); err != nil {
-			// On disk-pressure failures, free space (orphan VMs / stale
-			// OCI caches from terminated Pods) and retry once. Without
-			// this the host fills with leftovers and every subsequent
-			// reconcile fails the same way until something cleans up
-			// by hand.
-			if r.GC != nil && IsNoSpaceError(err) {
-				r.GC.RunOnce(ctx)
-				if err2 := r.Tart.Pull(ctx, c.Image); err2 != nil {
-					return fmt.Errorf("tart pull (after gc): %w", err2)
-				}
-			} else {
-				return fmt.Errorf("tart pull: %w", err)
-			}
+		// Clone the runner from this host's golden base for the image's
+		// digest — a local APFS clonefile (sub-second, zero network),
+		// not a fresh OCI pull. ensureGolden pays the full multi-GB pull
+		// at most once per digest per host; back-to-back recycles take
+		// only the clonefile path. This is what stops the fleet
+		// re-downloading the whole VM image between jobs.
+		base, materialized, err := r.ensureGolden(ctx, c.Image)
+		if err != nil {
+			return err
 		}
-		if err := r.Tart.Clone(ctx, c.Image, vmName); err != nil {
-			return fmt.Errorf("tart clone: %w", err)
+		if materialized {
+			RecordGoldenMaterialized(pod.Labels["tuist.dev/runner-pool"])
+		}
+		if err := r.Tart.Clone(ctx, base, vmName); err != nil {
+			// The golden was reaped out from under us (GC race) or is
+			// corrupt. Drop it so the next reconcile re-materializes a
+			// fresh one, and surface the error to requeue.
+			_ = r.Tart.Delete(ctx, base)
+			return fmt.Errorf("tart clone from golden: %w", err)
 		}
 	}
 
@@ -393,6 +405,97 @@ func (r *Reconciler) createPod(ctx context.Context, pod *corev1.Pod) error {
 	// the forwarder needs at least an upstream to dial when the
 	// scraper hits it.
 	return nil
+}
+
+// goldenBaseVMPrefix marks a Tart VM as a per-digest golden base: a
+// once-materialized, never-run image clone that every runner on this
+// host clones from. The prefix lets the GC tell goldens apart from
+// per-Pod runner clones (which are namespace-prefixed, e.g.
+// `tuist-runners-…`) so it retains them across the no-Pod recycle gap
+// instead of reaping them as orphan clones.
+const goldenBaseVMPrefix = "tuist-golden-"
+
+// goldenVMName derives the deterministic golden base VM name for an
+// image ref. Runner images are digest-pinned, so the hash changes only
+// when the digest rolls — a new digest gets its own golden and the
+// superseded one ages out of the GC. An 8-byte SHA-256 prefix is
+// collision-safe for the handful of digests a host ever sees and keeps
+// the name well inside Tart's 63-char limit.
+func goldenVMName(image string) string {
+	sum := sha256.Sum256([]byte(image))
+	return goldenBaseVMPrefix + hex.EncodeToString(sum[:8])
+}
+
+// isGoldenVMName reports whether a Tart VM name is a golden base.
+func isGoldenVMName(name string) bool {
+	return strings.HasPrefix(name, goldenBaseVMPrefix)
+}
+
+// ensureGolden materializes this host's golden base VM for `image`
+// exactly once and returns its name. The first call for a digest pays
+// the full `tart pull` + `tart clone` (download + extract the multi-GB
+// image into a runnable bundle); every later call returns immediately
+// off the on-disk golden, and the runner clones the caller makes from
+// it are APFS clonefiles that touch the network zero times. `materialized`
+// is true only on the cold path so the caller can count real pulls.
+//
+// The golden is never run; it's a stable copy-on-write base. Deleting
+// its source OCI cache later is safe — APFS keeps the shared blocks
+// alive as long as the golden references them.
+func (r *Reconciler) ensureGolden(ctx context.Context, image string) (name string, materialized bool, err error) {
+	name = goldenVMName(image)
+
+	unlock := r.lockGolden(name)
+	defer unlock()
+
+	// Warm path: golden already on disk for this digest — no network.
+	if vm, getErr := r.Tart.Get(ctx, name); getErr == nil && vm != nil {
+		return name, false, nil
+	}
+
+	// Cold path: pull + materialize once. Mirror the disk-pressure
+	// handling the per-recycle pull used to have so a full host frees
+	// space and retries rather than wedging the digest's first
+	// provision. RunOnceReclaim is the aggressive variant: under genuine
+	// no-space it evicts even within-retention unreferenced goldens,
+	// which a non-aggressive pass would keep.
+	if pullErr := r.Tart.Pull(ctx, image); pullErr != nil {
+		if r.GC != nil && IsNoSpaceError(pullErr) {
+			r.GC.RunOnceReclaim(ctx)
+			if pullErr2 := r.Tart.Pull(ctx, image); pullErr2 != nil {
+				return "", false, fmt.Errorf("tart pull (after gc): %w", pullErr2)
+			}
+		} else {
+			return "", false, fmt.Errorf("tart pull: %w", pullErr)
+		}
+	}
+	if cloneErr := r.Tart.Clone(ctx, image, name); cloneErr != nil {
+		// A half-created golden (clone failed mid-way) would make every
+		// later clone-from-golden fail. Best-effort delete so the next
+		// provision re-materializes from scratch.
+		_ = r.Tart.Delete(ctx, name)
+		return "", false, fmt.Errorf("materialize golden base: %w", cloneErr)
+	}
+	return name, true, nil
+}
+
+// lockGolden returns the unlock func for the per-golden-name mutex,
+// lazily creating the lock map on first use (the Reconciler is built as
+// a struct literal, so the map starts nil).
+func (r *Reconciler) lockGolden(name string) func() {
+	r.goldenMu.Lock()
+	if r.goldenLocks == nil {
+		r.goldenLocks = map[string]*sync.Mutex{}
+	}
+	m, ok := r.goldenLocks[name]
+	if !ok {
+		m = &sync.Mutex{}
+		r.goldenLocks[name] = m
+	}
+	r.goldenMu.Unlock()
+
+	m.Lock()
+	return m.Unlock
 }
 
 // startMetricsForwarder spins up the host-side TCP relay declared by

--- a/infra/tart-kubelet/internal/podagent/reconciler.go
+++ b/infra/tart-kubelet/internal/podagent/reconciler.go
@@ -431,6 +431,48 @@ func isGoldenVMName(name string) bool {
 	return strings.HasPrefix(name, goldenBaseVMPrefix)
 }
 
+// goldenNodeLabelPrefix namespaces the per-digest Node labels that advertise
+// which golden bases a host holds. The runners-controller adds soft
+// node-affinity toward `goldenNodeLabelPrefix + <digest-hash>` so a pool's
+// Pods prefer hosts that can clone its image locally instead of cold-pulling.
+//
+// CONTRACT: this prefix and the hash (the same 8-byte SHA-256 prefix of the
+// image ref that goldenVMName embeds) MUST match the runners-controller's
+// `podtemplate.goldenNodeLabelPrefix` / `goldenNodeAffinityKey`. They live in
+// separate Go modules, coupled by convention, not shared code.
+const goldenNodeLabelPrefix = "tuist.dev/golden-"
+
+// goldenNodeLabel returns the Node-label key advertising that this host holds
+// the golden base named `vmName`, and false when the name isn't a golden.
+func goldenNodeLabel(vmName string) (string, bool) {
+	if !isGoldenVMName(vmName) {
+		return "", false
+	}
+	return goldenNodeLabelPrefix + strings.TrimPrefix(vmName, goldenBaseVMPrefix), true
+}
+
+// GoldenNodeLabels lists this host's golden base VMs and returns the Node
+// labels that advertise them, for the node maintainer to publish. Driven off
+// `tart list` (the on-disk truth) so the labels self-heal across kubelet
+// restarts and GC evictions without any shared in-memory state to keep
+// consistent.
+func GoldenNodeLabels(ctx context.Context, t *tart.Client) (map[string]string, error) {
+	vms, err := t.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+	labels := map[string]string{}
+	for _, vm := range vms {
+		if vm.Source != "local" {
+			continue
+		}
+		if key, ok := goldenNodeLabel(vm.Name); ok {
+			labels[key] = "true"
+		}
+	}
+	return labels, nil
+}
+
 // ensureGolden materializes this host's golden base VM for `image`
 // exactly once and returns its name. The first call for a digest pays
 // the full `tart pull` + `tart clone` (download + extract the multi-GB


### PR DESCRIPTION
## What changed

macOS runner provisioning gets two coordinated changes so a single-shot VM recycle becomes a local clone instead of a multi-GB cold pull, and so Pods actually land on the hosts where that's possible.

### 1. Clone runners from a per-host golden base (not a per-recycle pull)

`tart-kubelet` now provisions each macOS runner VM by cloning from a per-host, per-digest **golden base VM** (a local APFS clonefile, zero network) instead of `tart pull <oci-ref>` + `tart clone <oci-ref>` on every recycle.

- `reconciler.go` — `createPod` calls `ensureGolden(image)` (pull + materialize **once per image digest per host**, guarded by a per-digest lock) and then `tart clone <golden> <vmName>`. A clone failure drops the golden so the next reconcile re-materializes; cold-path disk pressure falls back to aggressive GC reclaim.
- `garbage.go` — the GC keeps each pod-image's golden in `expectedSet` (so it is never reaped as an orphan clone) and retains *unreferenced* goldens for `GoldenRetention` (24h) so an idle host clones the next burst from its golden rather than re-pulling. `RunOnceReclaim` evicts goldens aggressively only under genuine disk pressure.
- `metrics.go` — new `tart_kubelet_golden_base_materialized_total{pool}`: flat in steady state, ticks once per host on a digest roll.

### 2. Steer Pods toward hosts that already hold the golden

A golden only avoids a cold pull if the Pod lands on a host that has it. Today every macOS Xcode pool shares one `tuist.dev/fleet` nodeSelector with no image awareness, so the scheduler treats all hosts as fungible — a `26.3` job can land on a host that has only ever served `26.5` and pay a full materialize even while another idle host holds the `26.3` golden.

- `tart-kubelet` publishes which golden bases a host holds as `tuist.dev/golden-<digest-hash>` Node labels, driven off `tart list` (the on-disk truth, so they self-heal across restarts and GC evictions). The node maintainer gains a generic `DynamicLabels` provider that merges and prunes them like operator `NodeLabels`; the provider masks transient `tart list` errors with its last good result so a hiccup doesn't flap the labels off.
- The runners-controller adds soft node-affinity (`preferredDuringScheduling`, weight 100) toward the label key for the pool's image. **Preferred, not required**: with no warm host free a Pod still schedules onto a cold one and pays the one-time materialize rather than going Pending. macOS only; Linux kata pools are untouched.

The label key is the same 8-byte SHA-256 prefix of the image ref the golden VM name embeds, derived independently in each module (they are separate Go modules). A pinned cross-module test on both sides guards the contract; a drift fails a test rather than silently disabling affinity — which itself degrades safely to today's image-blind placement.

## Why

The macOS runner fleet (9 hosts) routinely ran only ~4 builds concurrently while the queue held 6-8. It was **not** an autoscaler cap — the autoscaler correctly sets desired = claimed + queued and hands out the full 9-slot host budget. The bottleneck was provisioning: each single-shot VM halts after one job, and bringing up its replacement took a median **~7.4 min**.

Breaking that down with production metrics:

- `tart_kubelet_pod_provision_delay_seconds` (pod creation → `tart run`: scheduling + pull + clone) p50 ≈ **441s**, and **flat at ~450s across 24h including the overnight window when the fleet was nearly idle** — which rules out host-slot-wait (that would collapse to ~0 when free hosts exist).
- `tart_kubelet_vm_boot_duration_seconds` (`tart run` → IP) is only **5-9s**, so boot and the host are fine.
- Decisive: the macOS minis ingested **14.4 TB over 24h across 349 provisions = ~41 GB per recycle** (`node_network_receive_bytes_total{job=\"tuist-macos-node-exporter\"}`), each of the 9 runner minis pulling 325-464 GB per 3h. A macOS+Xcode image is ~40 GB, so the image was being re-downloaded on essentially every recycle.

### Root cause

No image reuse across recycles. Every clone was from the OCI ref (re-materialize), and the OCI cache did not survive the no-Pod recycle gap — the GC kept images only while a Pod referenced them, on a 5-min interval. So a single-shot recycle paid a full ~40 GB pull. And even with goldens, image-blind scheduling would re-pay the materialize whenever a minority Xcode version got shuffled onto a fresh host.

### Why this solution

Cloning from a pinned, already-materialized **local** golden VM is a guaranteed APFS clonefile (sub-second, zero network), whereas cloning from the OCI ref re-materializes every time and `tart pull` re-downloads whenever the cache lapses. The 24h retention lets the golden survive idle troughs so the morning burst clones instantly. Image-aware placement then keeps each Xcode version packed onto the hosts that hold its golden, so cold materializations are rare and localized to the (Xcode, host) pairs actually used, and the retention has far less work to do.

## Impact

- Provision delay ~7 min → seconds.
- ~14 TB/day of redundant image pulls eliminated.
- Steady-state concurrent macOS builds ~4 → ~9 (the independent 2-VMs-per-host lever can push this toward ~18 on top).

## Rollout ordering

Order-independent. The affinity references node labels that only exist once tart-kubelet publishes them; until then the soft affinity is a no-op and placement is exactly as today. The feature fully activates once both the controller and tart-kubelet are out.

## How to test locally

This is host-level `tart-kubelet` behavior (drives the local `tart` CLI on a Mac mini) plus controller pod-template construction, so the substrate behavior cannot be exercised in CI without a Tart host. Validated by:

- `go build ./...`, `go vet ./...`, `gofmt -l` (clean), and `go test ./...` in both `infra/tart-kubelet` and `infra/runners-controller` — all green, including the new golden-base, golden-retention, node-label merge/prune, golden-affinity, and the pinned cross-module label-key tests.

Post-deploy verification on the fleet:

1. `rate(tart_kubelet_golden_base_materialized_total[5m])` drops to ~0 between image rolls.
2. `tart_kubelet_pod_provision_delay_seconds` p50 falls from ~450s to seconds.
3. macOS ingress (`node_network_receive_bytes_total{job=\"tuist-macos-node-exporter\"}`) drops toward near-zero between rolls.
4. `max by (fleet)(tuist_runners_claims_count{lifecycle_state=\"running\", fleet=~\".*macos-26-5\"})` steady-state running climbs from ~4 toward ~9.
5. Mac mini nodes carry `tuist.dev/golden-<hash>` labels matching the Xcode images they have served (`kubectl get nodes -l kubernetes.io/os=darwin --show-labels`).