### PR TITLE
fix(cli): support nib resources in SwiftPM packages

### DIFF
--- a/cli/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
+++ b/cli/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
@@ -1888,6 +1888,7 @@ extension ProjectDescription.ResourceFileElements {
     /// Check https://developer.apple.com/documentation/swift_packages/bundling_resources_with_a_swift_package
     private static let defaultSpmResourceFileExtensions = Set([
         "xib",
+        "nib",
         "storyboard",
         "xcdatamodeld",
         "xcmappingmodel",

--- a/cli/Sources/TuistSupport/Extensions/AbsolutePath+Extras.swift
+++ b/cli/Sources/TuistSupport/Extensions/AbsolutePath+Extras.swift
@@ -85,6 +85,7 @@ extension AbsolutePath {
             "mlmodelc",
             "xcmappingmodel",
             "icon",
+            "nib",
         ]
         .contains(self.extension ?? "")
     }

--- a/cli/Sources/XcodeGraph/Sources/XcodeGraph/Models/Target.swift
+++ b/cli/Sources/XcodeGraph/Sources/XcodeGraph/Models/Target.swift
@@ -28,7 +28,7 @@ public struct Target: Equatable, Hashable, Comparable, Codable, Sendable {
     ]
     public static let validHeaderExtensions: [String] = ["h", "hpp", "hh", "hxx"]
     public static let validFolderExtensions: [String] = [
-        "framework", "bundle", "app", "xcassets", "appiconset", "scnassets",
+        "framework", "bundle", "app", "xcassets", "appiconset", "scnassets", "nib",
     ]
 
     // MARK: - Attributes

--- a/cli/Tests/TuistLoaderTests/Models+ManifestMappers/ResourceFileElementManifestMapperTests.swift
+++ b/cli/Tests/TuistLoaderTests/Models+ManifestMappers/ResourceFileElementManifestMapperTests.swift
@@ -135,6 +135,42 @@ final class ResourceFileElementManifestMapperTests: TuistUnitTestCase {
         }
     }
 
+    func test_from_when_nib_wrapper_directory_is_kept_as_a_single_resource() async throws {
+        try await withMockedDependencies {
+            // Given
+            let temporaryPath = try temporaryPath()
+            let rootDirectory = temporaryPath
+            let generatorPaths = GeneratorPaths(
+                manifestDirectory: temporaryPath,
+                rootDirectory: rootDirectory
+            )
+
+            // A compiled .nib is a wrapper directory containing keyedobjects.nib and a runtime-versioned variant.
+            let nibWrapper = rootDirectory.appending(components: "Resources", "View.nib")
+            try await fileSystem.makeDirectory(at: nibWrapper)
+            try await fileSystem.touch(nibWrapper.appending(component: "keyedobjects.nib"))
+            try await fileSystem.touch(nibWrapper.appending(component: "keyedobjects-110000.nib"))
+
+            let manifest = ProjectDescription.ResourceFileElement.glob(pattern: "Resources/View.nib")
+
+            // When
+            let model = try await XcodeGraph.ResourceFileElement.from(
+                manifest: manifest,
+                generatorPaths: generatorPaths,
+                fileSystem: fileSystem,
+                includeFiles: { try await XcodeGraph.Target.isResource(path: $0, fileSystem: self.fileSystem) }
+            )
+
+            // Then
+            XCTAssertEqual(
+                model,
+                [
+                    .file(path: nibWrapper, tags: [], inclusionCondition: nil),
+                ]
+            )
+        }
+    }
+
     func test_from_when_files_found_in_opaque_directory() async throws {
         try await withMockedDependencies {
             // Given

--- a/cli/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
+++ b/cli/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
@@ -1976,6 +1976,7 @@ struct PackageInfoMapperTests {
         let basePath = try #require(FileSystem.temporaryTestDirectory)
         let sourcesPath = basePath.appending(try RelativePath(validating: "Package/Sources/Target1"))
         let defaultResourcePaths = try [
+            "nib",
             "storyboard",
             "strings",
             "xcassets",
@@ -7804,6 +7805,7 @@ private func defaultSpmResources(_ target: String, customPath: String? = nil) ->
     }
     return [
         "\(fullPath)/**/*.xib",
+        "\(fullPath)/**/*.nib",
         "\(fullPath)/**/*.storyboard",
         "\(fullPath)/**/*.xcdatamodeld",
         "\(fullPath)/**/*.xcmappingmodel",
@@ -8006,7 +8008,7 @@ extension [ProjectDescription.ResourceFileElement] {
         path: AbsolutePath,
         excluding: [Path] = []
     ) -> Self {
-        ["xib", "storyboard", "xcdatamodeld", "xcmappingmodel", "xcassets", "lproj"]
+        ["xib", "nib", "storyboard", "xcdatamodeld", "xcmappingmodel", "xcassets", "lproj"]
             .map { file -> ProjectDescription.ResourceFileElement in
                 ResourceFileElement.glob(
                     pattern: .path("\(path.appending(component: "**").pathString)/*.\(file)"),

--- a/cli/Tests/TuistSupportTests/Extensions/AbsolutePath+ExtrasTests.swift
+++ b/cli/Tests/TuistSupportTests/Extensions/AbsolutePath+ExtrasTests.swift
@@ -65,6 +65,7 @@ final class AbsolutePathExtrasTests: TuistUnitTestCase {
         XCTAssertFalse(try AbsolutePath(validating: "/test/directory.playground").isInOpaqueDirectory)
         XCTAssertFalse(try AbsolutePath(validating: "/test/directory.bundle").isInOpaqueDirectory)
         XCTAssertFalse(try AbsolutePath(validating: "/test/directory.xcmappingmodel").isInOpaqueDirectory)
+        XCTAssertFalse(try AbsolutePath(validating: "/test/View.nib").isInOpaqueDirectory)
 
         XCTAssertFalse(try AbsolutePath(validating: "/").isInOpaqueDirectory)
         XCTAssertFalse(try AbsolutePath(validating: "/test/directory.notopaque/file.notopaque").isInOpaqueDirectory)
@@ -79,6 +80,7 @@ final class AbsolutePathExtrasTests: TuistUnitTestCase {
         XCTAssertTrue(try AbsolutePath(validating: "/test/directory.docc/file.png").isInOpaqueDirectory)
         XCTAssertTrue(try AbsolutePath(validating: "/test/directory.playground/file.png").isInOpaqueDirectory)
         XCTAssertTrue(try AbsolutePath(validating: "/test/directory.xcmappingmodel/file.png").isInOpaqueDirectory)
+        XCTAssertTrue(try AbsolutePath(validating: "/test/View.nib/keyedobjects.nib").isInOpaqueDirectory)
     }
 
     func test_opaqueDirectory() async throws {
@@ -89,6 +91,7 @@ final class AbsolutePathExtrasTests: TuistUnitTestCase {
             "/test/directory.xcdatamodeld",
             "/test/directory.docc",
             "/test/directory.xcmappingmodel",
+            "/test/View.nib",
         ] as [AbsolutePath] {
             XCTAssertEqual(directory.opaqueParentDirectory(), nil)
         }
@@ -108,6 +111,7 @@ final class AbsolutePathExtrasTests: TuistUnitTestCase {
             "/test/directory.xcdatamodeld/file.png",
             "/test/directory.docc/file.png",
             "/test/directory.xcmappingmodel/file.png",
+            "/test/View.nib/keyedobjects.nib",
         ] as [AbsolutePath] {
             XCTAssertEqual(file.opaqueParentDirectory(), file.parentDirectory)
         }


### PR DESCRIPTION
## What

Adds support for `.nib` resources in Swift Packages, on par with `.xib`:

1. `PackageInfoMapper` now recognizes `.nib` in `defaultSpmResourceFileExtensions`, so packages without explicit `resources:` declarations get `.nib` files picked up by the auto-generated globs.
2. `AbsolutePath.isOpaqueDirectory` now includes `.nib`, so the compiled `.nib` wrapper is bundled as a single reference.

## Why

A compiled `.nib` is usually a directory wrapper (`wrapper.nib`) containing `keyedobjects.nib` and a runtime-versioned variant. It must be copied whole — the way SwiftPM and Xcode treat it. Without the opaque-directory handling, resource globbing descends into the wrapper and reassembles it as a group of its inner files, producing a malformed bundle that crashes at runtime when the nib is loaded.

## Impact

Swift Packages shipping `.nib` resources now have them bundled correctly as wrapper references and load without crashing.

## Validation

- `xcodebuild build … -scheme tuist` succeeds.
- `xcodebuild test … -only-testing TuistLoaderTests/PackageInfoMapperTests -only-testing TuistSupportTests/AbsolutePathExtrasTests` passes.
- Confirmed on a real project that the previously-crashing `.nib` is now bundled and loads correctly.

Tests updated: `PackageInfoMapperTests` and `AbsolutePath+ExtrasTests`.

## Scope note

Targets the SwiftPM path only. `.xib` also appears in `Target.validResourceExtensions` (buildable/synchronized folders in first-party projects); `.nib` parity there is intentionally left out to keep this PR focused.