### PR TITLE
fix(swifterpm): add HTTPS fetch fallback for SSH-declared dependencies

### DIFF
--- a/swifterpm/Sources/swifterpm/GitHub.swift
+++ b/swifterpm/Sources/swifterpm/GitHub.swift
@@ -83,24 +83,30 @@ enum SourceControlLocations {
 
     static func fetchCandidates(_ location: String) -> [String] {
         var locations = [location]
-        appendGitHubSSHLocation(for: location, to: &locations)
-        appendGitLabSSHLocation(for: location, to: &locations)
+        appendGitHubLocations(for: location, to: &locations)
+        appendGitLabLocations(for: location, to: &locations)
         return locations
     }
 
-    private static func appendGitHubSSHLocation(for location: String, to locations: inout [String]) {
+    // Offer both the HTTPS and SSH forms regardless of how the location was originally
+    // declared. The original is tried first, so SSH-declared dependencies keep using
+    // ssh-agent locally while still falling back to HTTPS in environments (typically CI)
+    // that only have a token-based `git config insteadOf` rewrite or anonymous HTTPS access.
+    private static func appendGitHubLocations(for location: String, to locations: inout [String]) {
         guard let repo = try? GitHubRepo(location: location) else { return }
-        let ssh = "git@github.com:\(repo.owner)/\(repo.repo).git"
-        if !locations.contains(ssh) {
-            locations.append(ssh)
-        }
+        appendUnique("https://github.com/\(repo.owner)/\(repo.repo).git", to: &locations)
+        appendUnique("git@github.com:\(repo.owner)/\(repo.repo).git", to: &locations)
     }
 
-    private static func appendGitLabSSHLocation(for location: String, to locations: inout [String]) {
+    private static func appendGitLabLocations(for location: String, to locations: inout [String]) {
         guard let repo = try? GitLabRepo(location: location) else { return }
-        let ssh = "git@\(repo.host):\(repo.pathWithNamespace).git"
-        if !locations.contains(ssh) {
-            locations.append(ssh)
+        appendUnique("https://\(repo.host)/\(repo.pathWithNamespace).git", to: &locations)
+        appendUnique("git@\(repo.host):\(repo.pathWithNamespace).git", to: &locations)
+    }
+
+    private static func appendUnique(_ location: String, to locations: inout [String]) {
+        if !locations.contains(location) {
+            locations.append(location)
         }
     }
 

--- a/swifterpm/Sources/swifterpm/Remote.swift
+++ b/swifterpm/Sources/swifterpm/Remote.swift
@@ -58,7 +58,8 @@ enum RemoteMetadata {
         for candidate in SourceControlLocations.fetchCandidates(location) {
             do {
                 let output = try await SystemProcess.output(
-                    "/usr/bin/git", ["ls-remote", "--tags", candidate])
+                    "/usr/bin/git", ["ls-remote", "--tags", candidate],
+                    environment: SystemProcess.nonInteractiveGitEnvironment)
                 return parseGitRemoteVersions(output)
             } catch {
                 lastError = error
@@ -144,7 +145,8 @@ enum RemoteMetadata {
         for candidate in SourceControlLocations.fetchCandidates(location) {
             do {
                 let output = try await SystemProcess.output(
-                    "/usr/bin/git", ["ls-remote", candidate, name])
+                    "/usr/bin/git", ["ls-remote", candidate, name],
+                    environment: SystemProcess.nonInteractiveGitEnvironment)
                 guard let line = output.split(separator: "\n").first,
                     let revision = line.split(whereSeparator: \.isWhitespace).first
                 else {

--- a/swifterpm/Sources/swifterpm/Restore.swift
+++ b/swifterpm/Sources/swifterpm/Restore.swift
@@ -795,7 +795,8 @@ enum WorkspaceRestorer {
                 )
                 try await SystemProcess.run(
                     "/usr/bin/git",
-                    ["-C", destination.path, "fetch", "--depth=1", "origin", revision]
+                    ["-C", destination.path, "fetch", "--depth=1", "origin", revision],
+                    environment: SystemProcess.nonInteractiveGitEnvironment
                 )
                 try await SystemProcess.run(
                     "/usr/bin/git", ["-C", destination.path, "checkout", "--detach", "FETCH_HEAD"]

--- a/swifterpm/Sources/swifterpm/Support.swift
+++ b/swifterpm/Sources/swifterpm/Support.swift
@@ -37,6 +37,13 @@ enum ToolError: Error, CustomStringConvertible {
 }
 
 enum SystemProcess {
+    // swifterpm invokes git non-interactively: output is captured and fetches run
+    // in parallel, so a built-in credential prompt (git opens /dev/tty directly)
+    // would block invisibly in any environment, not just CI. Force git to fail fast
+    // on a missing credential instead. Credential helpers, ssh-agent, and ~/.netrc
+    // are unaffected, so configured authentication still works.
+    static let nonInteractiveGitEnvironment = ["GIT_TERMINAL_PROMPT": "0"]
+
     struct Result {
         let stdout: Data
         let stderr: Data

--- a/swifterpm/Tests/swifterpmTests/GitHubTests.swift
+++ b/swifterpm/Tests/swifterpmTests/GitHubTests.swift
@@ -26,20 +26,34 @@ struct GitHubTests {
     }
 
     @Test
-    func sourceControlFetchLocationsPreferOriginalThenProviderSSH() {
+    func sourceControlFetchLocationsPreferOriginalThenProviderAlternatives() {
         #expect(
             SourceControlLocations.fetchCandidates("https://github.com/tuist/swifterpm") == [
                 "https://github.com/tuist/swifterpm",
+                "https://github.com/tuist/swifterpm.git",
                 "git@github.com:tuist/swifterpm.git",
             ])
         #expect(
             SourceControlLocations.fetchCandidates("git@github.com:tuist/swifterpm.git") == [
                 "git@github.com:tuist/swifterpm.git",
+                "https://github.com/tuist/swifterpm.git",
             ])
         #expect(
             SourceControlLocations.fetchCandidates("https://gitlab.com/tuist/swifterpm") == [
                 "https://gitlab.com/tuist/swifterpm",
+                "https://gitlab.com/tuist/swifterpm.git",
                 "git@gitlab.com:tuist/swifterpm.git",
+            ])
+    }
+
+    @Test
+    func sourceControlFetchLocationsAddHTTPSFallbackForSSHOrigin() {
+        #expect(
+            SourceControlLocations.fetchCandidates(
+                "git@github.com:acme/private-lib") == [
+                "git@github.com:acme/private-lib",
+                "https://github.com/acme/private-lib.git",
+                "git@github.com:acme/private-lib.git",
             ])
     }
 


### PR DESCRIPTION
## What changed

`SourceControlLocations.fetchCandidates` now offers **both** the HTTPS and SSH forms for every GitHub/GitLab location (original tried first), instead of only ever appending an SSH alternative. SSH-declared dependencies now gain an HTTPS fetch fallback.

`git ls-remote` / `git fetch` invocations also set `GIT_TERMINAL_PROMPT=0` so the new HTTPS fallback fails fast on a missing credential rather than hanging on an interactive prompt in CI. The variable is merged onto the inherited environment, so ssh-agent, global git config, and `~/.netrc` continue to apply.

## Why

`tuist install` fails in CI when restoring a private dependency whose resolved location is the SSH form (it works locally):

```
failed to restore <package>
  from git@github.com:<owner>/<repo> at <sha>:
  git@github.com: Permission denied (publickey).
  fatal: Could not read from remote repository.
```

### Root cause

Restoring a source pin (`WorkspaceRestorer.ensureSource`) tries two paths:

1. **GitHub-API tarball over HTTPS** — only taken when a `GITHUB_TOKEN`/`GH_TOKEN` env var or a logged-in `gh` session is reachable.
2. **`git fetch` fallback** over `fetchCandidates(location)`.

The old `fetchCandidates` appended an SSH alternative for HTTPS-origin locations but never the reverse — so an SSH-origin location (`git@github.com:owner/repo`) produced **only SSH candidates**. The old test even locked this in (`fetchCandidates("git@github.com:tuist/swifterpm.git") == ["git@github.com:tuist/swifterpm.git"]`).

On a CI runner with no token swifterpm can see *and* no SSH deploy key authorized for that private repo, the only remaining path was `git fetch` over SSH → `Permission denied (publickey)`.

### Why local passed but CI failed

Locally the developer has either an authorized SSH key (SSH fetch succeeds) or a logged-in `gh` (HTTPS tarball path succeeds). The runner has neither, and swifterpm never tried HTTPS for the SSH-origin location.

### Why this fix over the alternatives

Adding the HTTPS candidate (rather than, say, forcing the API path) keeps swifterpm's behavior aligned with how CI normally authenticates to private SPM dependencies — a token-based `git config --global url."https://x-access-token:$TOKEN@github.com/".insteadOf` rewrite, which only takes effect if an HTTPS URL is actually attempted. Public repos also resolve anonymously over HTTPS. The original location is still tried first, so local SSH-key / ssh-agent flows are unchanged.

## Relationship to upstream Swift Package Manager

Upstream SPM (`swiftlang/swift-package-manager`) does **not** do scheme fallback at all, so this change makes swifterpm deliberately more forgiving than SPM rather than matching it:

- For source-control dependencies SPM always clones/fetches through the **`git` CLI** (`GitRepositoryProvider` in `Sources/SourceControl/GitRepository.swift`, shelling out to git with the inherited environment). It has no tarball/API path — archive downloads in SPM exist only for the **Swift package registry** (SE-0292), a separate mechanism.
- SPM uses the manifest / `Package.resolved` URL **verbatim**. An `git@github.com:…` dependency is cloned over SSH, period; there is no automatic HTTPS fallback (nor the reverse). Auth is delegated entirely to git, so global `git config` — `url.<base>.insteadOf`, credential helpers, ssh-agent, `~/.netrc` — is what makes it work.
- The official SPM answers to the exact "CI can't SSH to a private dep" problem are **explicit configuration**, not fallback: a `git config insteadOf` rewrite, or **dependency mirrors** ([SE-0219](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0219-package-manager-dependency-mirroring.md), `swift package config set-mirror --package-url <ssh-url> --mirror-url <https-url>`). Mirrors are matched by **exact URL string** (including the `.git` suffix), which reinforces that SPM does no scheme normalization.

swifterpm already diverged from SPM in this area before this PR — it prefers a GitHub/GitLab tarball over the HTTPS API when a token is present, its git fallback is a shallow `--depth=1` fetch (SPM intentionally avoids shallow clones), and it already appended an SSH candidate for HTTPS-origin URLs. This PR just makes that last bit **symmetric**. The trade-off is the divergence itself (swifterpm no longer treats the declared scheme as authoritative); it is bounded by trying the original location first and by `GIT_TERMINAL_PROMPT=0` so the extra candidate fails fast. The SPM-aligned alternative — rely only on mirrors / `insteadOf` — was rejected because it pushes per-consumer config burden for what is, in practice, the standard token-rewrite CI setup.

## Impact

- SSH-declared private dependencies resolve in CI when a token rewrite or token env is configured, matching local behavior.
- No behavior change for HTTPS-declared dependencies beyond an extra (harmless, fallback-only) `.git` HTTPS candidate.

## Note for consumers

This makes swifterpm *able* to use HTTPS auth, but CI still needs **some** credential for the private repo (a PAT/App token with `contents:read`, exposed via `insteadOf` rewrite or `GH_TOKEN`/`GITHUB_TOKEN`, or an SSH deploy key). The default `secrets.GITHUB_TOKEN` is scoped to the workflow's own repo and cannot read a different private repo.

## Validation

- `swift build --replace-scm-with-registry` — clean.
- `swift test --replace-scm-with-registry --filter "GitHubTests|RemoteTests|RestoreTests"` — 21 tests pass, including a new test for the SSH-origin HTTPS fallback and the updated symmetric-candidates expectations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)