### PR TITLE
fix(server): cancel unprocessable build jobs instead of retrying

### DIFF
--- a/server/lib/tuist/builds/workers/process_build_worker.ex
+++ b/server/lib/tuist/builds/workers/process_build_worker.ex
@@ -59,6 +59,17 @@ defmodule Tuist.Builds.Workers.ProcessBuildWorker do
           _ -> :ok
         end
 
+      {:error, {:unprocessable, reason}} ->
+        # The archive can't be parsed (e.g. a corrupt/truncated xcactivitylog).
+        # Re-downloading the same bytes and re-parsing always fails the same
+        # way, so cancel the job instead of retrying: this marks the build
+        # failed once, skips the remaining attempts, and keeps the permanent
+        # failure out of error tracking (cancelled jobs don't alert).
+        Logger.warning("Build #{build_id} archive is unprocessable, not retrying: #{inspect(reason)}")
+        mark_failed_build_processing(build_id, project_id, account_id, build_metadata)
+
+        {:cancel, reason}
+
       {:error, reason} ->
         if attempt >= max_attempts do
           Logger.error("Build processing failed permanently for build #{build_id}: #{inspect(reason)}")
@@ -80,7 +91,13 @@ defmodule Tuist.Builds.Workers.ProcessBuildWorker do
       try do
         case Storage.download_to_file(storage_key, temp_path, account) do
           {:ok, _} ->
-            Tuist.Processor.BuildProcessor.process_build(temp_path, xcode_cache_upload_enabled)
+            case Tuist.Processor.BuildProcessor.process_build(temp_path, xcode_cache_upload_enabled) do
+              {:ok, _} = ok -> ok
+              # The download succeeded, so a parse failure is about the archive
+              # bytes themselves — deterministic and unrecoverable on retry.
+              # Tag it so `perform/1` can stop instead of re-running the job.
+              {:error, reason} -> {:error, {:unprocessable, reason}}
+            end
 
           {:error, _} = error ->
             error

--- a/server/test/tuist/builds/workers/process_build_worker_test.exs
+++ b/server/test/tuist/builds/workers/process_build_worker_test.exs
@@ -172,24 +172,30 @@ defmodule Tuist.Builds.Workers.ProcessBuildWorkerTest do
                ProcessBuildWorker.perform(oban_job(job_args(build.id, account.id, project.id), 3, 3))
     end
 
-    test "marks build as failed when parse errors on final attempt", %{
+    test "cancels and marks build failed immediately when the archive is unparseable", %{
       account: account,
       project: project,
       build: build
     } do
+      # Real error from the Swift xcactivitylog parser on a corrupt/truncated
+      # archive (see Sentry TUIST-10H). The same bytes will never parse, so
+      # retrying just burns processor slots and floods error tracking.
+      parse_error = "The line lications/Xcode.app/C doesn't seem like a valid SLF line"
+
       expect(Tuist.Storage, :download_to_file, fn _, _, _ -> {:ok, :done} end)
 
       expect(BuildProcessor, :process_build, fn _path, _ ->
-        {:error, "NIF not loaded"}
+        {:error, parse_error}
       end)
 
+      # Marked failed on the very first attempt, not after exhausting retries.
       expect(Tuist.Builds, :create_build, fn attrs ->
         assert attrs.status == "failed_processing"
         {:ok, %{id: build.id}}
       end)
 
-      assert {:error, "NIF not loaded"} =
-               ProcessBuildWorker.perform(oban_job(job_args(build.id, account.id, project.id), 3, 3))
+      assert {:cancel, ^parse_error} =
+               ProcessBuildWorker.perform(oban_job(job_args(build.id, account.id, project.id), 1, 5))
     end
 
     test "marks build as failed when project is not found on final attempt", %{
@@ -263,7 +269,7 @@ defmodule Tuist.Builds.Workers.ProcessBuildWorkerTest do
       expect(Tuist.Builds, :create_build, fn _attrs -> {:ok, %{id: build.id}} end)
       reject(&Tuist.VCS.enqueue_vcs_pull_request_comment/1)
 
-      assert {:error, _} =
+      assert {:cancel, "boom"} =
                ProcessBuildWorker.perform(oban_job(job_args(build.id, account.id, project.id), 3, 3))
     end
   end


### PR DESCRIPTION
## Context

Sentry [TUIST-10H](https://tuist.sentry.io/issues/130210055/) fired with:

```
Oban.PerformError: Tuist.Builds.Workers.ProcessBuildWorker failed with
{:error, "The line lications/Xcode.app/C doesn't seem like a valid SLF line"}
```

The fragment `lications/Xcode.app/C` is a truncated slice of `/Applications/Xcode.app/C…` — the uploaded `.xcactivitylog` archive was corrupt/truncated, so the Swift `XCLogParser` lexer (via `Tuist.Processor.XCActivityLogNIF`) can't parse it.

## Problem

The download had already succeeded, so the same bytes get re-downloaded and re-parsed on every retry and fail identically. `ProcessBuildWorker` returned `{:error, reason}`, which Oban treats as a `:failure`:

- it retries **up to 5×**, all guaranteed to fail the same way, and
- each attempt emits `[:oban, :job, :exception]`, which the Sentry logger handler captures — so a single bad upload floods error tracking.

## Fix

Distinguish a **permanent** parse failure from a **transient** one (download / project lookup):

- `process_build/4` tags a post-download parse error as `{:error, {:unprocessable, reason}}`.
- `perform/1` handles that by marking the build `failed_processing` **once** and returning `{:cancel, reason}`. Per Oban's executor, cancelled jobs don't retry and emit `[:oban, :job, :stop]` (not an exception), so they don't alert.
- Download/project-lookup errors keep their existing retry-until-final-attempt behaviour.

A truly truncated archive has no recoverable data, so handling it at the worker layer (mark failed, stop, don't alert) is the right place — making the upstream Swift parser tolerant wouldn't change the outcome.

## Tests

TDD: added a test replaying the exact Sentry error on attempt 1/5 — it must mark the build failed immediately and return `{:cancel, reason}`. Updated the VCS-comment-on-failed-processing test, whose intent is unchanged, to the new `{:cancel, _}` semantics. All worker tests pass; `mix format`, `mix credo`, and `mix compile --warnings-as-errors` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)