### PR TITLE
fix(server, noora): truncate long table text-and-description cells by default

### DIFF
--- a/noora/css/table.css
+++ b/noora/css/table.css
@@ -539,6 +539,23 @@
         color: var(--noora-surface-label-secondary);
         font: var(--noora-font-body-small);
       }
+
+      /* Truncation, on by default (opt out with `truncate={false}`). The table is
+       * `min-width: max-content`, so an unbounded value (e.g. a generate command with dozens of
+       * target arguments) would otherwise size its column to the full text and push every other
+       * column off-screen. Capping the column and clipping each line with an ellipsis keeps the
+       * rest of the row visible. */
+      &[data-truncate] [data-part="column"] {
+        min-width: 0;
+        max-width: 30rem;
+      }
+
+      &[data-truncate] [data-part="label"],
+      &[data-truncate] [data-part="description"] {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
     }
 
     &[data-type="badge"],

--- a/noora/lib/noora/table.ex
+++ b/noora/lib/noora/table.ex
@@ -361,6 +361,13 @@ defmodule Noora.Table do
 
   attr(:description, :string, default: nil, doc: "The description of the cell")
   attr(:secondary_description, :string, default: nil, doc: "The secondary description of the cell")
+
+  attr(:truncate, :boolean,
+    default: true,
+    doc:
+      "Cap the cell to a single line per row and clip overflow with an ellipsis, instead of letting free-form content (e.g. a command with many target arguments) widen the column unbounded. On by default; pass `truncate={false}` to opt out."
+  )
+
   attr(:rest, :global)
 
   slot(:image,
@@ -370,7 +377,7 @@ defmodule Noora.Table do
 
   def text_and_description_cell(assigns) do
     ~H"""
-    <div data-part="cell" data-type="text_and_description" {@rest}>
+    <div data-part="cell" data-type="text_and_description" data-truncate={@truncate} {@rest}>
       <div :if={@icon || has_slot_content?(@image, assigns)} data-part="icon">
         <.icon :if={@icon && !has_slot_content?(@image, assigns)} name={@icon} />
         <%= if has_slot_content?(@image, assigns) do %>

--- a/server/test/tuist_web/live/cache_runs_live_test.exs
+++ b/server/test/tuist_web/live/cache_runs_live_test.exs
@@ -81,6 +81,36 @@ defmodule TuistWeb.CacheRunsLiveTest do
       assert has_element?(lv, "span", "tuist cache App")
     end
 
+    test "truncates the command column for runs with a long argument list", %{
+      conn: conn,
+      user: user,
+      organization: organization,
+      project: project
+    } do
+      # Given - a cache run with many target arguments, which otherwise widens the command
+      # column unbounded and pushes every other column off-screen.
+      targets = Enum.map(1..40, &"Target#{&1}")
+
+      CommandEventsFixtures.command_event_fixture(
+        project_id: project.id,
+        user_id: user.id,
+        name: "cache",
+        command_arguments: ["cache" | targets]
+      )
+
+      # When
+      {:ok, lv, _html} =
+        live(conn, ~p"/#{organization.account.name}/#{project.name}/module-cache/cache-runs")
+
+      # Then - the command cell truncates (the default for text_and_description cells) so the
+      # column can no longer grow unbounded.
+      assert has_element?(
+               lv,
+               ~s([data-part="cell"][data-type="text_and_description"][data-truncate]),
+               "cache Target1"
+             )
+    end
+
     test "filters cache runs by user with ran_by filter", %{
       conn: conn,
       user: user,

--- a/server/test/tuist_web/live/generate_runs_live_test.exs
+++ b/server/test/tuist_web/live/generate_runs_live_test.exs
@@ -224,6 +224,36 @@ defmodule TuistWeb.GenerateRunsLiveTest do
       assert has_element?(lv, "span", "tuist generate")
     end
 
+    test "truncates the command column for runs with a long argument list", %{
+      conn: conn,
+      user: user,
+      organization: organization,
+      project: project
+    } do
+      # Given - a generate run with many target arguments, which otherwise widens the command
+      # column unbounded and pushes every other column off-screen.
+      targets = Enum.map(1..40, &"Target#{&1}")
+
+      CommandEventsFixtures.command_event_fixture(
+        project_id: project.id,
+        user_id: user.id,
+        name: "generate",
+        command_arguments: ["generate" | targets]
+      )
+
+      # When
+      {:ok, lv, _html} =
+        live(conn, ~p"/#{organization.account.name}/#{project.name}/module-cache/generate-runs")
+
+      # Then - the command cell truncates (the default for text_and_description cells) so the
+      # column can no longer grow unbounded.
+      assert has_element?(
+               lv,
+               ~s([data-part="cell"][data-type="text_and_description"][data-truncate]),
+               "generate Target1"
+             )
+    end
+
     test "filters generate runs whose branch does not contain a substring", %{
       conn: conn,
       user: user,


### PR DESCRIPTION
> Reported in Slack: the tables on **Module Cache → Generations** and **Module Cache → Cache Runs** look "all messed up" for projects with very long target lists.

<img width="1138" height="816" alt="image" src="https://github.com/user-attachments/assets/7b539244-3231-4464-86e9-cbe1e36a9fcd" />


### What changed

Truncation is now the **default** for Noora's `text_and_description_cell`:

- New `truncate` attr (default `true`, opt out with `truncate={false}`) renders `data-truncate` on the cell.
- The cell's **column** is capped at `30rem` and the label + description are clipped with an ellipsis.

### Why

The first column of both tables renders the full `tuist generate …` command via `text_and_description_cell`. Unlike `text_cell`, that cell had no truncation, and the table is `min-width: max-content` — so a command with dozens of target arguments sized the column to the entire string and pushed every other column (Hit rate, Status, Branch, Ran at…) off-screen.

Rather than patch only those two columns, the fix makes truncation the default so the same blow-up can't recur on any other table that uses this cell (~20 usages: previews, bundles, members, build runs, flaky/quarantined tests, etc.). The cap lives on the **column** rather than the label, so a long *description* can't widen the column either.

Short labels never reach the cap, so typical cells are visually unchanged — only unbounded values get clipped.

### Why this over the alternatives

- **Server-side string truncation** would lose information, pick an arbitrary character cutoff, and wouldn't fix the underlying CSS issue (a different long column would still overflow). CSS clipping keeps the full text in the DOM and the full command on the run detail page.
- **Opt-in per column** (the first iteration) fixed only the reported pages; making it the default prevents recurrence elsewhere, which was the explicit ask.

### Developer impact

Any table cell that genuinely needs to grow can opt out with `truncate={false}`.

### How to test locally

1. Open a project with generate/cache runs that have many target arguments, e.g. `/<account>/<project>/module-cache/generate-runs`.
2. The Command column now clips with an ellipsis and the remaining columns stay visible; horizontal scroll still works for the rest of the row.

### Validation

- TDD regression tests on the generate-runs and cache-runs LiveViews render a run with 40 target arguments and assert the command cell truncates — confirmed **red** before the change, **green** after.
- `mix test` across generate-runs, cache-runs, previews, bundles, and members LiveViews: **43 tests, 0 failures** (the new default attribute breaks nothing).
- Verified the layout in a standalone repro of the real table markup + CSS: long label clips with an ellipsis, a long description is capped too, and a short/typical cell is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)