### PR TITLE
feat(server): add copy invite link to members dashboard

### DIFF
--- a/server/assets/app/css/pages/members.css
+++ b/server/assets/app/css/pages/members.css
@@ -80,6 +80,67 @@
     }
   }
 
+  /* Invite-member modal: padded form body and the post-create invite-link
+     reveal, mirroring the webhook signing-secret disclosure. */
+  & .noora-modal {
+    & [data-part="modal-content-wrapper"] {
+      display: flex;
+      flex-direction: column;
+
+      & > .noora-line-divider {
+        flex-shrink: 0;
+      }
+    }
+
+    & [data-part="modal-body"] {
+      display: flex;
+      flex-direction: column;
+      gap: var(--noora-spacing-5);
+      padding: var(--noora-spacing-7) var(--noora-spacing-4);
+
+      & [data-part="modal-message"] {
+        display: flex;
+        flex-direction: column;
+        gap: var(--noora-spacing-2);
+
+        & > [data-part="title"] {
+          color: var(--noora-surface-label-primary);
+          font: var(--noora-font-weight-medium) var(--noora-font-body-medium);
+        }
+
+        & > [data-part="subtitle"] {
+          color: var(--noora-surface-label-secondary);
+          font: var(--noora-font-weight-regular) var(--noora-font-body-small);
+        }
+      }
+    }
+
+    & [data-part="read-only-value"] {
+      display: flex;
+      flex-direction: row;
+      align-items: center;
+      gap: var(--noora-spacing-3);
+      border-radius: var(--noora-radius-3);
+      background: var(--noora-surface-background-tertiary);
+      padding: var(--noora-spacing-3) var(--noora-spacing-3) var(--noora-spacing-3) var(--noora-spacing-5);
+      min-width: 0;
+
+      & > code {
+        flex-grow: 1;
+        overflow: hidden;
+        color: var(--noora-surface-label-primary);
+        font: var(--noora-font-weight-regular) var(--noora-font-body-small);
+        font-family: "Geist Mono", monospace;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+
+      & > .noora-button {
+        flex-shrink: 0;
+      }
+    }
+  }
+
   /* & #invite-members-input { */
   /*   display: flex; */
   /*   width: 280px; */

--- a/server/lib/tuist_web/live/members_live.ex
+++ b/server/lib/tuist_web/live/members_live.ex
@@ -7,6 +7,7 @@ defmodule TuistWeb.MembersLive do
   alias Tuist.Accounts
   alias Tuist.Accounts.User
   alias Tuist.Authorization
+  alias Tuist.Environment
 
   @impl true
   def mount(_params, _session, %{assigns: %{selected_account: account}} = socket) do
@@ -367,11 +368,19 @@ defmodule TuistWeb.MembersLive do
                   {dgettext("dashboard_account", "Invitation link")}
                 </span>
                 <span data-part="subtitle">
-                  {dgettext(
-                    "dashboard_account",
-                    "Share this link with %{email} so they can join — you'll also find it in the invitations list.",
-                    email: @invitation_disclosure.email
-                  )}
+                  <%= if @invitation_disclosure.email_delivered do %>
+                    {dgettext(
+                      "dashboard_account",
+                      "We've emailed this invitation to %{email}. You can also share the link directly — it stays in the invitations list.",
+                      email: @invitation_disclosure.email
+                    )}
+                  <% else %>
+                    {dgettext(
+                      "dashboard_account",
+                      "No email was sent, so share this link with %{email} so they can join — you'll also find it in the invitations list.",
+                      email: @invitation_disclosure.email
+                    )}
+                  <% end %>
                 </span>
               </div>
               <div data-part="read-only-value">
@@ -604,7 +613,10 @@ defmodule TuistWeb.MembersLive do
           search_query: "",
           invitation_disclosure: %{
             url: url(~p"/auth/invitations/#{invitation.token}"),
-            email: invitation.invitee_email
+            email: invitation.invitee_email,
+            # `invite_user_to_organization/3` only delivers the email when mail
+            # is configured, so this mirrors whether the invitee was notified.
+            email_delivered: Environment.mail_configured?()
           }
         )
         # Reveal the link in the always-present header modal: close the

--- a/server/lib/tuist_web/live/members_live.ex
+++ b/server/lib/tuist_web/live/members_live.ex
@@ -371,13 +371,13 @@ defmodule TuistWeb.MembersLive do
                   <%= if @invitation_disclosure.email_delivered do %>
                     {dgettext(
                       "dashboard_account",
-                      "We've emailed this invitation to %{email}. You can also share the link directly — it stays in the invitations list.",
+                      "We've emailed this invitation to %{email}. You can also share the link directly. It stays in the invitations list.",
                       email: @invitation_disclosure.email
                     )}
                   <% else %>
                     {dgettext(
                       "dashboard_account",
-                      "No email was sent, so share this link with %{email} so they can join — you'll also find it in the invitations list.",
+                      "Share this link with %{email} so they can join. You'll also find it in the invitations list.",
                       email: @invitation_disclosure.email
                     )}
                   <% end %>

--- a/server/lib/tuist_web/live/members_live.ex
+++ b/server/lib/tuist_web/live/members_live.ex
@@ -20,7 +20,8 @@ defmodule TuistWeb.MembersLive do
         form: to_form(%{}, as: :invitation),
         selected_inner_tab: "members",
         search_query: "",
-        managing_member: nil
+        managing_member: nil,
+        invitation_disclosure: nil
         # invite_role: :user,
         # invite_emails: []
       )
@@ -52,6 +53,7 @@ defmodule TuistWeb.MembersLive do
             :if={Authorization.authorize(:invitation_create, @current_user, @selected_account) == :ok}
             id="invite-member-form"
             form={@form}
+            invitation_disclosure={@invitation_disclosure}
           />
         </div>
         <div id="members-tabs">
@@ -328,7 +330,11 @@ defmodule TuistWeb.MembersLive do
                     <div data-part="subtitle">
                       {dgettext("dashboard_account", "Invite members to your organization")}
                     </div>
-                    <.invite_member_form id="invite-member-form-empty-state" form={@form} />
+                    <.invite_member_form
+                      id="invite-member-form-empty-state"
+                      form={@form}
+                      invitation_disclosure={@invitation_disclosure}
+                    />
                   </.table_empty_state>
                 </:empty_state>
               </.table>
@@ -351,27 +357,71 @@ defmodule TuistWeb.MembersLive do
         <:trigger :let={attrs}>
           <.button variant="primary" label={dgettext("dashboard_account", "Invite members")} {attrs} />
         </:trigger>
-        <.line_divider />
-        <.text_input
-          id={"#{@id}-input"}
-          field={@form[:invitee_email]}
-          type="email"
-          label={dgettext("dashboard_account", "Email address")}
-          show_prefix={false}
-        />
-        <.line_divider />
+
+        <div data-part="modal-content-wrapper">
+          <.line_divider />
+          <div data-part="modal-body">
+            <%= if @invitation_disclosure do %>
+              <div data-part="modal-message">
+                <span data-part="title">
+                  {dgettext("dashboard_account", "Invitation link")}
+                </span>
+                <span data-part="subtitle">
+                  {dgettext(
+                    "dashboard_account",
+                    "Share this link with %{email} so they can join — you'll also find it in the invitations list.",
+                    email: @invitation_disclosure.email
+                  )}
+                </span>
+              </div>
+              <div data-part="read-only-value">
+                <code id={"#{@id}-invitation-link"}>{@invitation_disclosure.url}</code>
+                <.button
+                  id={"#{@id}-copy-invitation-link"}
+                  variant="secondary"
+                  size="small"
+                  icon_only
+                  type="button"
+                  phx-hook="Clipboard"
+                  data-clipboard-value={@invitation_disclosure.url}
+                  aria-label={dgettext("dashboard_account", "Copy invite link")}
+                >
+                  <.copy />
+                </.button>
+              </div>
+            <% else %>
+              <.text_input
+                id={"#{@id}-input"}
+                field={@form[:invitee_email]}
+                type="email"
+                label={dgettext("dashboard_account", "Email address")}
+                show_prefix={false}
+              />
+            <% end %>
+          </div>
+          <.line_divider />
+        </div>
+
         <:footer>
           <.modal_footer>
-            <:action>
+            <:action :if={@invitation_disclosure}>
               <.button
-                label="Cancel"
+                label={dgettext("dashboard_account", "Done")}
+                variant="primary"
+                type="button"
+                phx-click="close-invite-members"
+              />
+            </:action>
+            <:action :if={is_nil(@invitation_disclosure)}>
+              <.button
+                label={dgettext("dashboard_account", "Cancel")}
                 variant="secondary"
                 type="button"
                 phx-click="close-invite-members"
               />
             </:action>
-            <:action>
-              <.button label="Save" type="submit" tabindex="1" />
+            <:action :if={is_nil(@invitation_disclosure)}>
+              <.button label={dgettext("dashboard_account", "Invite")} type="submit" tabindex="1" />
             </:action>
           </.modal_footer>
         </:footer>
@@ -471,6 +521,7 @@ defmodule TuistWeb.MembersLive do
   def handle_event("close-invite-members", _, socket) do
     socket =
       socket
+      |> assign(invitation_disclosure: nil, form: to_form(%{}, as: :invitation))
       |> push_event("close-modal", %{id: "invite-member-form-modal"})
       |> push_event("close-modal", %{id: "invite-member-form-empty-state-modal"})
 
@@ -529,7 +580,7 @@ defmodule TuistWeb.MembersLive do
     #   url: &url(~p"/auth/invitations/#{&1}")
     # })
 
-    with {:ok, _invitation} <-
+    with {:ok, invitation} <-
            Accounts.invite_user_to_organization(
              email,
              %{
@@ -550,10 +601,18 @@ defmodule TuistWeb.MembersLive do
           invite_emails: [],
           form: to_form(%{}, as: :invitation),
           selected_inner_tab: "invitations",
-          search_query: ""
+          search_query: "",
+          invitation_disclosure: %{
+            url: url(~p"/auth/invitations/#{invitation.token}"),
+            email: invitation.invitee_email
+          }
         )
-        |> push_event("close-modal", %{id: "invite-member-form-modal"})
+        # Reveal the link in the always-present header modal: close the
+        # empty-state modal in case it triggered the invite, and nudge the
+        # header modal open since submitting the form doesn't change the
+        # dialog's open state on its own.
         |> push_event("close-modal", %{id: "invite-member-form-empty-state-modal"})
+        |> push_event("open-modal", %{id: "invite-member-form-modal"})
 
       {:noreply, socket}
     else

--- a/server/lib/tuist_web/live/members_live.ex
+++ b/server/lib/tuist_web/live/members_live.ex
@@ -292,6 +292,15 @@ defmodule TuistWeb.MembersLive do
                   <.dropdown id={"invite-actions-#{invitation.id}"} icon_only>
                     <:icon><.dots_vertical /></:icon>
                     <.dropdown_item
+                      id={"copy-invite-link-#{invitation.id}"}
+                      label={dgettext("dashboard_account", "Copy invite link")}
+                      value="copy_invite_link"
+                      phx-hook="Clipboard"
+                      data-clipboard-value={url(~p"/auth/invitations/#{invitation.token}")}
+                    >
+                      <:left_icon><.copy /></:left_icon>
+                    </.dropdown_item>
+                    <.dropdown_item
                       label={dgettext("dashboard_account", "Revoke invite")}
                       value="revoke"
                       on_click="revoke_invite"

--- a/server/priv/gettext/dashboard_account.pot
+++ b/server/priv/gettext/dashboard_account.pot
@@ -43,8 +43,8 @@ msgstr ""
 msgid "Add payment method"
 msgstr ""
 
-#: lib/tuist_web/live/members_live.ex:130
-#: lib/tuist_web/live/members_live.ex:148
+#: lib/tuist_web/live/members_live.ex:131
+#: lib/tuist_web/live/members_live.ex:149
 #, elixir-autogen, elixir-format
 msgid "Admin"
 msgstr ""
@@ -67,7 +67,7 @@ msgstr ""
 msgid "All features, no credit card required"
 msgstr ""
 
-#: lib/tuist_web/live/members_live.ex:63
+#: lib/tuist_web/live/members_live.ex:64
 #, elixir-autogen, elixir-format
 msgid "All members"
 msgstr ""
@@ -83,7 +83,7 @@ msgstr ""
 msgid "Are you sure you want to delete this?"
 msgstr ""
 
-#: lib/tuist_web/live/members_live.ex:204
+#: lib/tuist_web/live/members_live.ex:205
 #, elixir-autogen, elixir-format
 msgid "Are you sure you want to remove %{name} from this organization?"
 msgstr ""
@@ -108,9 +108,9 @@ msgstr ""
 #: lib/tuist_web/live/cache_live.ex:741
 #: lib/tuist_web/live/cache_live.ex:806
 #: lib/tuist_web/live/create_organization_live.ex:83
-#: lib/tuist_web/live/members_live.ex:165
-#: lib/tuist_web/live/members_live.ex:214
-#: lib/tuist_web/live/members_live.ex:417
+#: lib/tuist_web/live/members_live.ex:166
+#: lib/tuist_web/live/members_live.ex:215
+#: lib/tuist_web/live/members_live.ex:426
 #: lib/tuist_web/live/webhook_live.html.heex:116
 #: lib/tuist_web/live/webhook_live.html.heex:343
 #: lib/tuist_web/live/webhooks_live.html.heex:111
@@ -324,18 +324,18 @@ msgstr ""
 msgid "Downgrade"
 msgstr ""
 
-#: lib/tuist_web/live/members_live.ex:96
+#: lib/tuist_web/live/members_live.ex:97
 #, elixir-autogen, elixir-format
 msgid "E-mail"
 msgstr ""
 
 #: lib/tuist_web/live/billing_live.html.heex:331
-#: lib/tuist_web/live/members_live.ex:284
+#: lib/tuist_web/live/members_live.ex:285
 #, elixir-autogen, elixir-format
 msgid "Email"
 msgstr ""
 
-#: lib/tuist_web/live/members_live.ex:397
+#: lib/tuist_web/live/members_live.ex:406
 #, elixir-autogen, elixir-format
 msgid "Email address"
 msgstr ""
@@ -443,22 +443,22 @@ msgstr ""
 msgid "Invitation to %{organization_name}"
 msgstr ""
 
-#: lib/tuist_web/live/members_live.ex:72
+#: lib/tuist_web/live/members_live.ex:73
 #, elixir-autogen, elixir-format
 msgid "Invitations"
 msgstr ""
 
-#: lib/tuist_web/live/members_live.ex:354
+#: lib/tuist_web/live/members_live.ex:355
 #, elixir-autogen, elixir-format
 msgid "Invite member"
 msgstr ""
 
-#: lib/tuist_web/live/members_live.ex:358
+#: lib/tuist_web/live/members_live.ex:359
 #, elixir-autogen, elixir-format
 msgid "Invite members"
 msgstr ""
 
-#: lib/tuist_web/live/members_live.ex:331
+#: lib/tuist_web/live/members_live.ex:332
 #, elixir-autogen, elixir-format
 msgid "Invite members to your organization"
 msgstr ""
@@ -478,19 +478,19 @@ msgstr ""
 msgid "Like, totally free: All features, no credit card required"
 msgstr ""
 
-#: lib/tuist_web/live/members_live.ex:105
-#: lib/tuist_web/live/members_live.ex:244
+#: lib/tuist_web/live/members_live.ex:106
+#: lib/tuist_web/live/members_live.ex:245
 #, elixir-autogen, elixir-format
 msgid "Manage role"
 msgstr ""
 
-#: lib/tuist_web/live/members_live.ex:84
+#: lib/tuist_web/live/members_live.ex:85
 #, elixir-autogen, elixir-format
 msgid "Member"
 msgstr ""
 
-#: lib/tuist_web/live/members_live.ex:17
-#: lib/tuist_web/live/members_live.ex:38
+#: lib/tuist_web/live/members_live.ex:18
+#: lib/tuist_web/live/members_live.ex:39
 #, elixir-autogen, elixir-format
 msgid "Members"
 msgstr ""
@@ -515,12 +515,12 @@ msgstr ""
 msgid "No credit card required"
 msgstr ""
 
-#: lib/tuist_web/live/members_live.ex:328
+#: lib/tuist_web/live/members_live.ex:329
 #, elixir-autogen, elixir-format
 msgid "No invitations created"
 msgstr ""
 
-#: lib/tuist_web/live/members_live.ex:270
+#: lib/tuist_web/live/members_live.ex:271
 #, elixir-autogen, elixir-format
 msgid "No members found"
 msgstr ""
@@ -578,7 +578,7 @@ msgstr ""
 #: lib/tuist_web/live/cache_live.ex:361
 #: lib/tuist_web/live/cache_live.ex:368
 #: lib/tuist_web/live/cache_live.ex:371
-#: lib/tuist_web/live/members_live.ex:289
+#: lib/tuist_web/live/members_live.ex:290
 #, elixir-autogen, elixir-format
 msgid "Pending"
 msgstr ""
@@ -634,13 +634,13 @@ msgstr ""
 msgid "Remote cache hits:"
 msgstr ""
 
-#: lib/tuist_web/live/members_live.ex:222
+#: lib/tuist_web/live/members_live.ex:223
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr ""
 
-#: lib/tuist_web/live/members_live.ex:186
-#: lib/tuist_web/live/members_live.ex:254
+#: lib/tuist_web/live/members_live.ex:187
+#: lib/tuist_web/live/members_live.ex:255
 #, elixir-autogen, elixir-format
 msgid "Remove member"
 msgstr ""
@@ -683,23 +683,23 @@ msgstr ""
 msgid "Reset your password"
 msgstr ""
 
-#: lib/tuist_web/live/members_live.ex:306
+#: lib/tuist_web/live/members_live.ex:307
 #, elixir-autogen, elixir-format
 msgid "Revoke invite"
 msgstr ""
 
-#: lib/tuist_web/live/members_live.ex:99
-#: lib/tuist_web/live/members_live.ex:124
+#: lib/tuist_web/live/members_live.ex:100
+#: lib/tuist_web/live/members_live.ex:125
 #, elixir-autogen, elixir-format
 msgid "Role"
 msgstr ""
 
-#: lib/tuist_web/live/members_live.ex:173
+#: lib/tuist_web/live/members_live.ex:174
 #, elixir-autogen, elixir-format
 msgid "Save"
 msgstr ""
 
-#: lib/tuist_web/live/members_live.ex:47
+#: lib/tuist_web/live/members_live.ex:48
 #, elixir-autogen, elixir-format
 msgid "Search members..."
 msgstr ""
@@ -739,7 +739,7 @@ msgstr ""
 
 #: lib/tuist_web/live/cache_live.ex:538
 #: lib/tuist_web/live/cache_live.ex:863
-#: lib/tuist_web/live/members_live.ex:287
+#: lib/tuist_web/live/members_live.ex:288
 #: lib/tuist_web/live/webhook_event_live.html.heex:28
 #: lib/tuist_web/live/webhook_live.ex:265
 #: lib/tuist_web/live/webhook_live.html.heex:274
@@ -780,8 +780,8 @@ msgstr ""
 msgid "Total"
 msgstr ""
 
-#: lib/tuist_web/live/members_live.ex:271
-#: lib/tuist_web/live/members_live.ex:320
+#: lib/tuist_web/live/members_live.ex:272
+#: lib/tuist_web/live/members_live.ex:321
 #, elixir-autogen, elixir-format
 msgid "Try changing your search term"
 msgstr ""
@@ -889,8 +889,8 @@ msgstr ""
 msgid "Use all Tuist features as long as you stay open source."
 msgstr ""
 
-#: lib/tuist_web/live/members_live.ex:129
-#: lib/tuist_web/live/members_live.ex:136
+#: lib/tuist_web/live/members_live.ex:130
+#: lib/tuist_web/live/members_live.ex:137
 #, elixir-autogen, elixir-format
 msgid "User"
 msgstr ""
@@ -1226,7 +1226,7 @@ msgstr ""
 
 #: lib/tuist_web/live/authentication_settings_live.html.heex:512
 #: lib/tuist_web/live/cache_live.ex:733
-#: lib/tuist_web/live/members_live.ex:409
+#: lib/tuist_web/live/members_live.ex:418
 #: lib/tuist_web/live/webhook_live.html.heex:404
 #: lib/tuist_web/live/webhooks_live.html.heex:104
 #, elixir-autogen, elixir-format
@@ -1761,7 +1761,7 @@ msgstr ""
 msgid "You were added to the %{organization_name} Tuist organization"
 msgstr ""
 
-#: lib/tuist_web/live/members_live.ex:319
+#: lib/tuist_web/live/members_live.ex:320
 #, elixir-autogen, elixir-format
 msgid "No invitations found"
 msgstr ""
@@ -1981,23 +1981,28 @@ msgstr ""
 msgid "Revoke %{name}? Self-hosted nodes using it will stop authenticating."
 msgstr ""
 
-#: lib/tuist_web/live/members_live.ex:298
-#: lib/tuist_web/live/members_live.ex:387
+#: lib/tuist_web/live/members_live.ex:299
+#: lib/tuist_web/live/members_live.ex:396
 #, elixir-autogen, elixir-format
 msgid "Copy invite link"
 msgstr ""
 
-#: lib/tuist_web/live/members_live.ex:367
+#: lib/tuist_web/live/members_live.ex:368
 #, elixir-autogen, elixir-format
 msgid "Invitation link"
 msgstr ""
 
-#: lib/tuist_web/live/members_live.ex:424
+#: lib/tuist_web/live/members_live.ex:433
 #, elixir-autogen, elixir-format
 msgid "Invite"
 msgstr ""
 
-#: lib/tuist_web/live/members_live.ex:370
+#: lib/tuist_web/live/members_live.ex:378
 #, elixir-autogen, elixir-format
-msgid "Share this link with %{email} so they can join — you'll also find it in the invitations list."
+msgid "No email was sent, so share this link with %{email} so they can join — you'll also find it in the invitations list."
+msgstr ""
+
+#: lib/tuist_web/live/members_live.ex:372
+#, elixir-autogen, elixir-format
+msgid "We've emailed this invitation to %{email}. You can also share the link directly — it stays in the invitations list."
 msgstr ""

--- a/server/priv/gettext/dashboard_account.pot
+++ b/server/priv/gettext/dashboard_account.pot
@@ -334,7 +334,7 @@ msgstr ""
 msgid "Email"
 msgstr ""
 
-#: lib/tuist_web/live/members_live.ex:350
+#: lib/tuist_web/live/members_live.ex:359
 #, elixir-autogen, elixir-format
 msgid "Email address"
 msgstr ""
@@ -447,17 +447,17 @@ msgstr ""
 msgid "Invitations"
 msgstr ""
 
-#: lib/tuist_web/live/members_live.ex:339
+#: lib/tuist_web/live/members_live.ex:348
 #, elixir-autogen, elixir-format
 msgid "Invite member"
 msgstr ""
 
-#: lib/tuist_web/live/members_live.ex:343
+#: lib/tuist_web/live/members_live.ex:352
 #, elixir-autogen, elixir-format
 msgid "Invite members"
 msgstr ""
 
-#: lib/tuist_web/live/members_live.ex:320
+#: lib/tuist_web/live/members_live.ex:329
 #, elixir-autogen, elixir-format
 msgid "Invite members to your organization"
 msgstr ""
@@ -514,7 +514,7 @@ msgstr ""
 msgid "No credit card required"
 msgstr ""
 
-#: lib/tuist_web/live/members_live.ex:317
+#: lib/tuist_web/live/members_live.ex:326
 #, elixir-autogen, elixir-format
 msgid "No invitations created"
 msgstr ""
@@ -682,7 +682,7 @@ msgstr ""
 msgid "Reset your password"
 msgstr ""
 
-#: lib/tuist_web/live/members_live.ex:295
+#: lib/tuist_web/live/members_live.ex:304
 #, elixir-autogen, elixir-format
 msgid "Revoke invite"
 msgstr ""
@@ -780,7 +780,7 @@ msgid "Total"
 msgstr ""
 
 #: lib/tuist_web/live/members_live.ex:269
-#: lib/tuist_web/live/members_live.ex:309
+#: lib/tuist_web/live/members_live.ex:318
 #, elixir-autogen, elixir-format
 msgid "Try changing your search term"
 msgstr ""
@@ -1759,7 +1759,7 @@ msgstr ""
 msgid "You were added to the %{organization_name} Tuist organization"
 msgstr ""
 
-#: lib/tuist_web/live/members_live.ex:308
+#: lib/tuist_web/live/members_live.ex:317
 #, elixir-autogen, elixir-format
 msgid "No invitations found"
 msgstr ""
@@ -1977,4 +1977,9 @@ msgstr ""
 #: lib/tuist_web/live/cache_live.ex:796
 #, elixir-autogen, elixir-format
 msgid "Revoke %{name}? Self-hosted nodes using it will stop authenticating."
+msgstr ""
+
+#: lib/tuist_web/live/members_live.ex:296
+#, elixir-autogen, elixir-format
+msgid "Copy invite link"
 msgstr ""

--- a/server/priv/gettext/dashboard_account.pot
+++ b/server/priv/gettext/dashboard_account.pot
@@ -1999,10 +1999,10 @@ msgstr ""
 
 #: lib/tuist_web/live/members_live.ex:378
 #, elixir-autogen, elixir-format
-msgid "No email was sent, so share this link with %{email} so they can join — you'll also find it in the invitations list."
+msgid "Share this link with %{email} so they can join. You'll also find it in the invitations list."
 msgstr ""
 
 #: lib/tuist_web/live/members_live.ex:372
 #, elixir-autogen, elixir-format
-msgid "We've emailed this invitation to %{email}. You can also share the link directly — it stays in the invitations list."
+msgid "We've emailed this invitation to %{email}. You can also share the link directly. It stays in the invitations list."
 msgstr ""

--- a/server/priv/gettext/dashboard_account.pot
+++ b/server/priv/gettext/dashboard_account.pot
@@ -43,8 +43,8 @@ msgstr ""
 msgid "Add payment method"
 msgstr ""
 
-#: lib/tuist_web/live/members_live.ex:128
-#: lib/tuist_web/live/members_live.ex:146
+#: lib/tuist_web/live/members_live.ex:130
+#: lib/tuist_web/live/members_live.ex:148
 #, elixir-autogen, elixir-format
 msgid "Admin"
 msgstr ""
@@ -67,7 +67,7 @@ msgstr ""
 msgid "All features, no credit card required"
 msgstr ""
 
-#: lib/tuist_web/live/members_live.ex:61
+#: lib/tuist_web/live/members_live.ex:63
 #, elixir-autogen, elixir-format
 msgid "All members"
 msgstr ""
@@ -83,7 +83,7 @@ msgstr ""
 msgid "Are you sure you want to delete this?"
 msgstr ""
 
-#: lib/tuist_web/live/members_live.ex:202
+#: lib/tuist_web/live/members_live.ex:204
 #, elixir-autogen, elixir-format
 msgid "Are you sure you want to remove %{name} from this organization?"
 msgstr ""
@@ -108,8 +108,9 @@ msgstr ""
 #: lib/tuist_web/live/cache_live.ex:741
 #: lib/tuist_web/live/cache_live.ex:806
 #: lib/tuist_web/live/create_organization_live.ex:83
-#: lib/tuist_web/live/members_live.ex:163
-#: lib/tuist_web/live/members_live.ex:212
+#: lib/tuist_web/live/members_live.ex:165
+#: lib/tuist_web/live/members_live.ex:214
+#: lib/tuist_web/live/members_live.ex:417
 #: lib/tuist_web/live/webhook_live.html.heex:116
 #: lib/tuist_web/live/webhook_live.html.heex:343
 #: lib/tuist_web/live/webhooks_live.html.heex:111
@@ -323,18 +324,18 @@ msgstr ""
 msgid "Downgrade"
 msgstr ""
 
-#: lib/tuist_web/live/members_live.ex:94
+#: lib/tuist_web/live/members_live.ex:96
 #, elixir-autogen, elixir-format
 msgid "E-mail"
 msgstr ""
 
 #: lib/tuist_web/live/billing_live.html.heex:331
-#: lib/tuist_web/live/members_live.ex:282
+#: lib/tuist_web/live/members_live.ex:284
 #, elixir-autogen, elixir-format
 msgid "Email"
 msgstr ""
 
-#: lib/tuist_web/live/members_live.ex:359
+#: lib/tuist_web/live/members_live.ex:397
 #, elixir-autogen, elixir-format
 msgid "Email address"
 msgstr ""
@@ -442,22 +443,22 @@ msgstr ""
 msgid "Invitation to %{organization_name}"
 msgstr ""
 
-#: lib/tuist_web/live/members_live.ex:70
+#: lib/tuist_web/live/members_live.ex:72
 #, elixir-autogen, elixir-format
 msgid "Invitations"
 msgstr ""
 
-#: lib/tuist_web/live/members_live.ex:348
+#: lib/tuist_web/live/members_live.ex:354
 #, elixir-autogen, elixir-format
 msgid "Invite member"
 msgstr ""
 
-#: lib/tuist_web/live/members_live.ex:352
+#: lib/tuist_web/live/members_live.ex:358
 #, elixir-autogen, elixir-format
 msgid "Invite members"
 msgstr ""
 
-#: lib/tuist_web/live/members_live.ex:329
+#: lib/tuist_web/live/members_live.ex:331
 #, elixir-autogen, elixir-format
 msgid "Invite members to your organization"
 msgstr ""
@@ -477,19 +478,19 @@ msgstr ""
 msgid "Like, totally free: All features, no credit card required"
 msgstr ""
 
-#: lib/tuist_web/live/members_live.ex:103
-#: lib/tuist_web/live/members_live.ex:242
+#: lib/tuist_web/live/members_live.ex:105
+#: lib/tuist_web/live/members_live.ex:244
 #, elixir-autogen, elixir-format
 msgid "Manage role"
 msgstr ""
 
-#: lib/tuist_web/live/members_live.ex:82
+#: lib/tuist_web/live/members_live.ex:84
 #, elixir-autogen, elixir-format
 msgid "Member"
 msgstr ""
 
 #: lib/tuist_web/live/members_live.ex:17
-#: lib/tuist_web/live/members_live.ex:37
+#: lib/tuist_web/live/members_live.ex:38
 #, elixir-autogen, elixir-format
 msgid "Members"
 msgstr ""
@@ -514,12 +515,12 @@ msgstr ""
 msgid "No credit card required"
 msgstr ""
 
-#: lib/tuist_web/live/members_live.ex:326
+#: lib/tuist_web/live/members_live.ex:328
 #, elixir-autogen, elixir-format
 msgid "No invitations created"
 msgstr ""
 
-#: lib/tuist_web/live/members_live.ex:268
+#: lib/tuist_web/live/members_live.ex:270
 #, elixir-autogen, elixir-format
 msgid "No members found"
 msgstr ""
@@ -577,7 +578,7 @@ msgstr ""
 #: lib/tuist_web/live/cache_live.ex:361
 #: lib/tuist_web/live/cache_live.ex:368
 #: lib/tuist_web/live/cache_live.ex:371
-#: lib/tuist_web/live/members_live.ex:287
+#: lib/tuist_web/live/members_live.ex:289
 #, elixir-autogen, elixir-format
 msgid "Pending"
 msgstr ""
@@ -633,13 +634,13 @@ msgstr ""
 msgid "Remote cache hits:"
 msgstr ""
 
-#: lib/tuist_web/live/members_live.ex:220
+#: lib/tuist_web/live/members_live.ex:222
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr ""
 
-#: lib/tuist_web/live/members_live.ex:184
-#: lib/tuist_web/live/members_live.ex:252
+#: lib/tuist_web/live/members_live.ex:186
+#: lib/tuist_web/live/members_live.ex:254
 #, elixir-autogen, elixir-format
 msgid "Remove member"
 msgstr ""
@@ -682,23 +683,23 @@ msgstr ""
 msgid "Reset your password"
 msgstr ""
 
-#: lib/tuist_web/live/members_live.ex:304
+#: lib/tuist_web/live/members_live.ex:306
 #, elixir-autogen, elixir-format
 msgid "Revoke invite"
 msgstr ""
 
-#: lib/tuist_web/live/members_live.ex:97
-#: lib/tuist_web/live/members_live.ex:122
+#: lib/tuist_web/live/members_live.ex:99
+#: lib/tuist_web/live/members_live.ex:124
 #, elixir-autogen, elixir-format
 msgid "Role"
 msgstr ""
 
-#: lib/tuist_web/live/members_live.ex:171
+#: lib/tuist_web/live/members_live.ex:173
 #, elixir-autogen, elixir-format
 msgid "Save"
 msgstr ""
 
-#: lib/tuist_web/live/members_live.ex:46
+#: lib/tuist_web/live/members_live.ex:47
 #, elixir-autogen, elixir-format
 msgid "Search members..."
 msgstr ""
@@ -738,7 +739,7 @@ msgstr ""
 
 #: lib/tuist_web/live/cache_live.ex:538
 #: lib/tuist_web/live/cache_live.ex:863
-#: lib/tuist_web/live/members_live.ex:285
+#: lib/tuist_web/live/members_live.ex:287
 #: lib/tuist_web/live/webhook_event_live.html.heex:28
 #: lib/tuist_web/live/webhook_live.ex:265
 #: lib/tuist_web/live/webhook_live.html.heex:274
@@ -779,8 +780,8 @@ msgstr ""
 msgid "Total"
 msgstr ""
 
-#: lib/tuist_web/live/members_live.ex:269
-#: lib/tuist_web/live/members_live.ex:318
+#: lib/tuist_web/live/members_live.ex:271
+#: lib/tuist_web/live/members_live.ex:320
 #, elixir-autogen, elixir-format
 msgid "Try changing your search term"
 msgstr ""
@@ -888,8 +889,8 @@ msgstr ""
 msgid "Use all Tuist features as long as you stay open source."
 msgstr ""
 
-#: lib/tuist_web/live/members_live.ex:127
-#: lib/tuist_web/live/members_live.ex:134
+#: lib/tuist_web/live/members_live.ex:129
+#: lib/tuist_web/live/members_live.ex:136
 #, elixir-autogen, elixir-format
 msgid "User"
 msgstr ""
@@ -1225,6 +1226,7 @@ msgstr ""
 
 #: lib/tuist_web/live/authentication_settings_live.html.heex:512
 #: lib/tuist_web/live/cache_live.ex:733
+#: lib/tuist_web/live/members_live.ex:409
 #: lib/tuist_web/live/webhook_live.html.heex:404
 #: lib/tuist_web/live/webhooks_live.html.heex:104
 #, elixir-autogen, elixir-format
@@ -1759,7 +1761,7 @@ msgstr ""
 msgid "You were added to the %{organization_name} Tuist organization"
 msgstr ""
 
-#: lib/tuist_web/live/members_live.ex:317
+#: lib/tuist_web/live/members_live.ex:319
 #, elixir-autogen, elixir-format
 msgid "No invitations found"
 msgstr ""
@@ -1979,7 +1981,23 @@ msgstr ""
 msgid "Revoke %{name}? Self-hosted nodes using it will stop authenticating."
 msgstr ""
 
-#: lib/tuist_web/live/members_live.ex:296
+#: lib/tuist_web/live/members_live.ex:298
+#: lib/tuist_web/live/members_live.ex:387
 #, elixir-autogen, elixir-format
 msgid "Copy invite link"
+msgstr ""
+
+#: lib/tuist_web/live/members_live.ex:367
+#, elixir-autogen, elixir-format
+msgid "Invitation link"
+msgstr ""
+
+#: lib/tuist_web/live/members_live.ex:424
+#, elixir-autogen, elixir-format
+msgid "Invite"
+msgstr ""
+
+#: lib/tuist_web/live/members_live.ex:370
+#, elixir-autogen, elixir-format
+msgid "Share this link with %{email} so they can join — you'll also find it in the invitations list."
 msgstr ""

--- a/server/test/tuist_web/live/members_live_test.exs
+++ b/server/test/tuist_web/live/members_live_test.exs
@@ -6,6 +6,7 @@ defmodule TuistWeb.MembersLiveTest do
   import Phoenix.LiveViewTest
 
   alias Tuist.Accounts
+  alias Tuist.Environment
   alias TuistTestSupport.Fixtures.AccountsFixtures
 
   setup %{conn: conn} do
@@ -87,12 +88,13 @@ defmodule TuistWeb.MembersLiveTest do
       assert html =~ "/auth/invitations/#{invitation.token}"
     end
 
-    test "reveals the invite link in the modal after creating an invitation", %{
+    test "reveals the invite link and notes no email was sent when mail is not configured", %{
       conn: conn,
       organization: organization,
       account: account
     } do
-      # When: submitting the invite form from the members page
+      stub(Environment, :mail_configured?, fn -> false end)
+
       {:ok, lv, _html} = live(conn, ~p"/#{account.name}/members")
 
       html =
@@ -110,6 +112,25 @@ defmodule TuistWeb.MembersLiveTest do
       assert html =~ "Invitation link"
       assert html =~ "/auth/invitations/#{invitation.token}"
       assert html =~ "invite-member-form-copy-invitation-link"
+      assert html =~ "No email was sent"
+    end
+
+    test "tells the inviter an email was sent when mail is configured", %{
+      conn: conn,
+      account: account
+    } do
+      stub(Environment, :mail_configured?, fn -> true end)
+      stub(Accounts.UserNotifier, :deliver_invitation, fn _email, _opts -> :ok end)
+
+      {:ok, lv, _html} = live(conn, ~p"/#{account.name}/members")
+
+      html =
+        lv
+        |> form("#invite-member-form", invitation: %{invitee_email: "emailed@example.com"})
+        |> render_submit()
+
+      assert html =~ "Invitation link"
+      assert html =~ "emailed this invitation to emailed@example.com"
     end
   end
 

--- a/server/test/tuist_web/live/members_live_test.exs
+++ b/server/test/tuist_web/live/members_live_test.exs
@@ -86,6 +86,31 @@ defmodule TuistWeb.MembersLiveTest do
       assert html =~ "copy-invite-link-#{invitation.id}"
       assert html =~ "/auth/invitations/#{invitation.token}"
     end
+
+    test "reveals the invite link in the modal after creating an invitation", %{
+      conn: conn,
+      organization: organization,
+      account: account
+    } do
+      # When: submitting the invite form from the members page
+      {:ok, lv, _html} = live(conn, ~p"/#{account.name}/members")
+
+      html =
+        lv
+        |> form("#invite-member-form", invitation: %{invitee_email: "newcomer@example.com"})
+        |> render_submit()
+
+      # Then: the modal swaps to a confirmation that surfaces the acceptance link
+      invitation =
+        Accounts.get_invitation_by_invitee_email_and_organization(
+          "newcomer@example.com",
+          organization
+        )
+
+      assert html =~ "Invitation link"
+      assert html =~ "/auth/invitations/#{invitation.token}"
+      assert html =~ "invite-member-form-copy-invitation-link"
+    end
   end
 
   describe "members table" do

--- a/server/test/tuist_web/live/members_live_test.exs
+++ b/server/test/tuist_web/live/members_live_test.exs
@@ -56,6 +56,38 @@ defmodule TuistWeb.MembersLiveTest do
     end
   end
 
+  describe "invitations table" do
+    test "surfaces a copy-able invite link so members can be onboarded without email delivery", %{
+      conn: conn,
+      user: user,
+      organization: organization,
+      account: account
+    } do
+      # Given: a pending invitation to the current organization
+      {:ok, invitation} =
+        Accounts.invite_user_to_organization(
+          "invitee@example.com",
+          %{
+            inviter: user,
+            to: organization,
+            url: &"/auth/invitations/#{&1}"
+          }
+        )
+
+      # When: visiting the members page and switching to the invitations tab
+      {:ok, lv, _html} = live(conn, ~p"/#{account.name}/members")
+
+      html =
+        lv
+        |> element("[phx-value-tab='invitations']")
+        |> render_click()
+
+      # Then: the invitation row exposes the acceptance link for the clipboard action
+      assert html =~ "copy-invite-link-#{invitation.id}"
+      assert html =~ "/auth/invitations/#{invitation.token}"
+    end
+  end
+
   describe "members table" do
     test "renders members table with admin and regular users", %{
       conn: conn,

--- a/server/test/tuist_web/live/members_live_test.exs
+++ b/server/test/tuist_web/live/members_live_test.exs
@@ -112,7 +112,7 @@ defmodule TuistWeb.MembersLiveTest do
       assert html =~ "Invitation link"
       assert html =~ "/auth/invitations/#{invitation.token}"
       assert html =~ "invite-member-form-copy-invitation-link"
-      assert html =~ "No email was sent"
+      assert html =~ "Share this link with newcomer@example.com so they can join"
     end
 
     test "tells the inviter an email was sent when mail is configured", %{


### PR DESCRIPTION
## What changed

Adds a **"Copy invite link"** action to each pending invitation's `⋯` dropdown in the organization Members dashboard (alongside "Revoke invite"). It copies the acceptance URL `<server>/auth/invitations/<token>` to the clipboard.

## Why

Organization member invitations create a valid invitation row **and token regardless of whether outbound mail is configured** — only the *notification email* is gated behind `Environment.mail_configured?()` ([accounts.ex:1134](https://github.com/tuist/tuist/blob/main/server/lib/tuist/accounts.ex#L1134)). On a self-hosted instance without Mailgun/SMTP, the invite is created but the invitee never gets the acceptance link, so they stay stuck "pending" with no way to join.

The **CLI already prints this link** (`tuist organization invite` → "You can also share with them the invite link directly: …"), so admins on air-gapped instances had a path — but **the dashboard had no equivalent**. The invitations table only exposed "Revoke invite". This PR closes that gap so the dashboard matches the CLI.

This came out of a self-hosted alpha user report: with `TUIST_SKIP_EMAIL_CONFIRMATION=true` signup works offline, but dashboard-created invitations were a dead end because no email is sent and the link wasn't surfaced anywhere.

## How it works

- Reuses the existing `Clipboard` phx-hook — the same pattern used for the Connect command snippet and the SCIM token copy button — via `phx-hook="Clipboard"` + `data-clipboard-value`.
- Builds the URL with `url(~p"/auth/invitations/#{invitation.token}")`, the exact route the email and CLI use. The `token` is already preloaded on each invitation, so there are **no query or data-loading changes**.
- Shown **unconditionally** (not gated on `mail_configured?`), matching the CLI which always prints the link. Consistent with the existing trust model: anyone with `invitation_read` (org admins) can already view and revoke these invitations, and the CLI already returns the token to the inviter.

## User/developer impact

- Self-hosted instances without SMTP/Mailgun can now onboard org members entirely through the dashboard: invite → copy link → share → invitee signs up (works via `TUIST_SKIP_EMAIL_CONFIRMATION`) and opens the link to accept.
- No behavior change for hosted/tuist.dev users beyond an extra convenient "copy link" action.

## Validation

- `mix test test/tuist_web/live/members_live_test.exs` → **8 tests, 0 failures**, including a new test asserting the invitations tab renders the copy element with the acceptance URL.
- `mix format --check-formatted` on the changed files → clean.
- Translatable string `"Copy invite link"` extracted into `dashboard_account.pot` (template only; no `.po` files touched, per the gettext workflow).

### How to test locally

1. Run the server **without** mail configured (no Mailgun key / SMTP), e.g. a fresh dev instance.
2. As an org admin, go to **Members → Invitations**, invite an email address.
3. Open the new invitation's `⋯` menu → **Copy invite link**.
4. Paste the link — it should be `<server>/auth/invitations/<token>`. Opening it while logged in as the invitee (matching email) lets them accept without any email being sent.