### PR TITLE
fix(server): give each build-processing job a unique download path

### DIFF
--- a/server/lib/tuist/builds/workers/process_build_worker.ex
+++ b/server/lib/tuist/builds/workers/process_build_worker.ex
@@ -75,7 +75,12 @@ defmodule Tuist.Builds.Workers.ProcessBuildWorker do
   # with a different personal account.
   defp process_build(build_id, storage_key, project_id, xcode_cache_upload_enabled) do
     with {:ok, account} <- storage_account(project_id) do
-      temp_path = Path.join(System.tmp_dir!(), "build_#{build_id}.zip")
+      # Unique per execution: the duplicate-enqueue race in `get_or_create_build`
+      # can leave two jobs running for the same build_id concurrently. A path
+      # keyed only on build_id makes them share one file — one job's download (or
+      # its `File.rm` cleanup) corrupts/removes the archive the other is mid-read,
+      # surfacing as a spurious xcactivitylog parse error.
+      temp_path = Path.join(System.tmp_dir!(), "build_#{build_id}_#{System.unique_integer([:positive])}.zip")
 
       try do
         case Storage.download_to_file(storage_key, temp_path, account) do

--- a/server/test/tuist/builds/workers/process_build_worker_test.exs
+++ b/server/test/tuist/builds/workers/process_build_worker_test.exs
@@ -431,4 +431,29 @@ defmodule Tuist.Builds.Workers.ProcessBuildWorkerTest do
                ProcessBuildWorker.perform(oban_job(job_args(build.id, account.id, project.id)))
     end
   end
+
+  describe "perform/1 concurrency" do
+    test "downloads to a distinct temp path per execution so concurrent jobs for the same build don't clobber each other",
+         %{account: account, project: project, build: build} do
+      test_pid = self()
+
+      expect(Tuist.Storage, :download_to_file, 2, fn _key, path, _account ->
+        send(test_pid, {:download_path, path})
+        {:ok, :done}
+      end)
+
+      expect(BuildProcessor, :process_build, 2, fn _, _ -> {:ok, parsed_data()} end)
+      expect(Tuist.Builds, :create_build, 2, fn _attrs -> {:ok, %{id: build.id}} end)
+
+      job = oban_job(job_args(build.id, account.id, project.id))
+      ProcessBuildWorker.perform(job)
+      ProcessBuildWorker.perform(job)
+
+      assert_receive {:download_path, path1}
+      assert_receive {:download_path, path2}
+
+      assert path1 != path2,
+             "two jobs for the same build must use distinct download paths so one cannot overwrite/delete the other's archive mid-read"
+    end
+  end
 end


### PR DESCRIPTION
## Symptom

Sentry [TUIST-10H](https://tuist.sentry.io/issues/130210055/): `ProcessBuildWorker` failed with

```
{:error, "The line lications/Xcode.app/C doesn't seem like a valid SLF line"}
```

It looks like a corrupt xcactivitylog, but it isn't.

## Root cause — verified against the real artifact

I pulled the actual archive (Notion build `8fce77ae`) and confirmed:

- The xcactivitylog is **valid** — it parses cleanly with XCLogParser `0.2.48` (the exact version prod resolves, byte-identical to the registry source) on macOS, stock Linux, and a faithful reconstruction of the prod `debian:bookworm-slim` runtime. gzip intact, 0 NUL bytes.
- The build was processed **successfully**: the `build_runs` row has `status=success`, `duration=4658`, inserted at **07:27:22.091** — ~1 second **before** the 07:27:23 error.

A success written *before* the error means two jobs ran concurrently for the same build (the `get_or_create_build` duplicate-enqueue race that Oban uniqueness only mostly absorbs). Both download to `Path.join(System.tmp_dir!(), "build_#{build_id}.zip")` — a path keyed **only on `build_id`**. One job's download (or its `File.rm` cleanup in the `after` block) overwrites/deletes the archive the other job is still unzipping, so the victim parses a truncated/garbage **local** copy and throws `invalidLine`. The artifact in storage is fine; only the shared temp file was corrupted.

This explains why it's a single self-healed occurrence, why it can't be reproduced standalone, and why it's neither a corrupt file nor an XCLogParser bug.

## Fix

Add a per-execution `System.unique_integer/1` to the temp download path so concurrent jobs for the same build never share a file. The unzip directory was already unique (`make_temp_dir`); only this download path was shared.

## Test

TDD: a new test invokes `perform/1` twice for the same build and asserts the two download paths differ. Red against the shared-path code, green after the fix. Full worker suite passes; `mix format` / `mix credo` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)