### PR TITLE
fix(cli): scope proto SPM plugins to their generation tasks

### DIFF
--- a/mise.lock
+++ b/mise.lock
@@ -547,14 +547,6 @@ url = "https://github.com/getsops/sops/releases/download/v3.9.3/sops-v3.9.3.exe"
 [tools.sops."platforms.windows-x64".provenance.slsa]
 url = "https://github.com/getsops/sops/releases/download/v3.9.3/sops-v3.9.3.intoto.jsonl"
 
-[[tools."spm:apple/swift-protobuf"]]
-version = "1.35.1"
-backend = "spm:apple/swift-protobuf"
-
-[[tools."spm:grpc/grpc-swift-protobuf"]]
-version = "2.1.1"
-backend = "spm:grpc/grpc-swift-protobuf"
-
 [[tools.swiftformat]]
 version = "0.58.7"
 backend = "asdf:https://github.com/mise-plugins/mise-swiftformat.git"

--- a/mise.toml
+++ b/mise.toml
@@ -10,11 +10,6 @@
     sops = "3.9.3"
     age = "1.2.1"
     protoc = "32.1"
-    # protoc plugins for the vendored REAPI proto (mise/tasks/cli/generate-reapi-proto.sh):
-    # protoc-gen-swift (messages) and protoc-gen-grpc-swift-2 (gRPC stubs). Versions match the
-    # SwiftProtobuf/grpc-swift-protobuf versions resolved in Package.swift.
-    "spm:apple/swift-protobuf" = "1.35.1"
-    "spm:grpc/grpc-swift-protobuf" = "2.1.1"
     "1password-cli" = "2.32.0"
     bats = "1.11.1"
     rclone = "1.73.3"

--- a/mise/tasks/cli/generate-cache-proto.sh
+++ b/mise/tasks/cli/generate-cache-proto.sh
@@ -2,7 +2,10 @@
 #MISE description="Generates Swift protobuf files for the tuist-cache-proxy executable"
 
 cd "$MISE_PROJECT_ROOT"/cli/Sources/TuistCAS
-mise x spm:grpc/grpc-swift-protobuf@2.1.1 -- protoc --plugin=$(which protoc-gen-grpc-swift-2) --grpc-swift-2_out=Generated --grpc-swift-2_opt=Visibility=Public keyvalue.proto cas.proto
-protoc --swift_out=Generated --swift_opt=Visibility=Public keyvalue.proto cas.proto
+
+# Scoped with `mise x`, not the global [tools] table: the SwiftPM backend builds these with `swift`,
+# so an unscoped `mise install` on a Swift-less Linux runner fails. Versions track Package.swift.
+mise x spm:grpc/grpc-swift-protobuf@2.1.1 -- protoc --grpc-swift-2_out=Generated --grpc-swift-2_opt=Visibility=Public keyvalue.proto cas.proto
+mise x spm:apple/swift-protobuf@1.35.1 -- protoc --swift_out=Generated --swift_opt=Visibility=Public keyvalue.proto cas.proto
 
 echo "Generated protobuf files for tuist-cache-proxy"

--- a/mise/tasks/cli/generate-reapi-proto.sh
+++ b/mise/tasks/cli/generate-reapi-proto.sh
@@ -5,8 +5,10 @@ set -euo pipefail
 
 cd "$MISE_PROJECT_ROOT"/cli/Sources/TuistREAPI
 
-protoc --swift_out=Generated --swift_opt=Visibility=Public capabilities.proto
-protoc --grpc-swift-2_out=Generated --grpc-swift-2_opt=Visibility=Public capabilities.proto
+# Scoped with `mise x`, not the global [tools] table: the SwiftPM backend builds these with `swift`,
+# so an unscoped `mise install` on a Swift-less Linux runner fails. Versions track Package.swift.
+mise x spm:apple/swift-protobuf@1.35.1 -- protoc --swift_out=Generated --swift_opt=Visibility=Public capabilities.proto
+mise x spm:grpc/grpc-swift-protobuf@2.1.1 -- protoc --grpc-swift-2_out=Generated --grpc-swift-2_opt=Visibility=Public capabilities.proto
 
 # The grpc-swift-2 generator emits a `type:` argument on MethodDescriptor that the resolved
 # grpc-swift-2 runtime does not accept yet; drop it until the runtime catches up. perl keeps this


### PR DESCRIPTION
## What

Move the SwiftPM-backed protoc plugins (`spm:apple/swift-protobuf`, `spm:grpc/grpc-swift-protobuf`) out of the global `mise.toml` `[tools]` table (and `mise.lock`) and resolve them per-invocation with `mise x` inside the proto-generation tasks.

## Why

[#11466](https://github.com/tuist/tuist/pull/11466) added those two plugins to the global `[tools]` table so the new `TuistREAPI` proto-generation task could invoke `protoc` with the plugins on `PATH`. The mise SwiftPM backend builds these tools from source with `swift`, and **any** `mise install` / `mise run` / `mise x` resolves the entire `[tools]` table before doing anything else. On a runner without a Swift toolchain that resolution hard-fails:

```
mise WARN  swift may be required but was not found.
mise ERROR Failed to install tools: spm:apple/swift-protobuf@1.35.1, spm:grpc/grpc-swift-protobuf@2.1.1
spm:apple/swift-protobuf@1.35.1: No such file or directory (os error 2)
spm:grpc/grpc-swift-protobuf@2.1.1: No such file or directory (os error 2)
```

## Root cause

The plugins are dev-only codegen tools needed solely when regenerating the vendored protos, but they were placed in the global tool set that every job auto-installs. That broke the **CLI Canary Release → Resolve canary version** job on `tuist-linux` ([failed run](https://github.com/tuist/tuist/actions/runs/28173222524/job/83442626687)): a 5-minute job that only reads git tags to compute the next version, yet auto-installs the full toolchain — including two tools that cannot build without Swift. The previous canary release (06-24) was green; the merge of #11466 introduced the break.

The blast radius is wider than canary: every other workflow that runs `mise install` unscoped on a Swift-less Linux runner is exposed the next time it runs — `blick-learn`, `cache-deploy`, `cache-staging-deploy`, `handbook`, `helm`.

## Why this fix over the alternatives

- **`mise run --skip-tools` on the canary step** would unblock that one job (and is reasonable hygiene there — it has no business installing erlang/elixir/gradle to read a git tag), but it is a per-call `mise run` flag and cannot help an unscoped `mise install`, so the other five Linux workflows stay broken.
- **`mise use`** is the wrong primitive: it *writes* the tool back into a `mise.toml`, reintroducing exactly the global dependency this removes.
- **`mise x`** is ephemeral — it puts the tool on `PATH` for one command and never touches `mise.toml`. Scoping the plugins to the tasks that actually need them fixes the root cause for all runners with a two-line removal, and matches the convention `generate-cache-proto.sh` already used.

`generate-cache-proto.sh` is updated in the same change: it had quietly come to depend on the same global `protoc-gen-swift` (its bare `protoc --swift_out`) and on a parent-shell `$(which protoc-gen-grpc-swift-2)` — both break once the globals are gone — so each `protoc` call is now scoped with `mise x` to make the task self-contained.

## Impact

- CLI Canary Release (and every unscoped `mise install` on a Swift-less Linux runner) no longer attempts to build the SwiftPM plugins.
- No change for developers regenerating protos: `mise run cli:generate-reapi-proto` / `cli:generate-cache-proto` resolve the plugins on demand.

## Validation

- Ran both `cli:generate-reapi-proto` and `cli:generate-cache-proto` with the scoped `mise x` form; generated output is **byte-identical** to the previous global-tool form (`protoc` output depends on the plugin version + proto input, not on how `PATH` was assembled).
- `mise ls --current` no longer lists the SwiftPM plugins, confirming a plain `mise install` will not reference them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
