### PR TITLE
ci(mise): skip full tool auto-install on scoped jobs

### DIFF
--- a/.github/workflows/app-release.yml
+++ b/.github/workflows/app-release.yml
@@ -65,7 +65,7 @@ jobs:
           cache: "false"
           github_token: ${{ env.MISE_GITHUB_TOKEN }}
       - id: check
-        run: mise run release:check
+        run: mise run --skip-tools release:check
 
   release-app:
     name: Release App
@@ -95,7 +95,7 @@ jobs:
       - uses: jdx/mise-action@v4.0.1
         with:
           version: ${{ env.MISE_VERSION }}
-          install_args: "--locked tuist git-cliff 1password-cli"
+          install_args: "--locked tuist git-cliff 1password-cli jq"
           cache: "false"
           github_token: ${{ env.MISE_GITHUB_TOKEN }}
       - name: Authenticate with Tuist
@@ -139,7 +139,7 @@ jobs:
         run: git cliff --include-path "app/**/*" --include-path "mise/tasks/app/**/*" --config cliff.toml --repository "../" --tag "${{ needs.check-releases.outputs.app-next-version }}" -o CHANGELOG.md 2>/dev/null
 
       - name: Bundle macOS app
-        run: mise run --no-deps app:bundle
+        run: mise run --no-deps --skip-tools app:bundle
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
 
@@ -203,7 +203,7 @@ jobs:
       - name: Generate TuistApp
         run: tuist generate TuistApp --no-binary-cache
       - name: Upload iOS App to App Store Connect
-        run: mise run --no-deps app:upload-ios
+        run: mise run --no-deps --skip-tools app:upload-ios
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
 
@@ -315,4 +315,4 @@ jobs:
       - name: Trigger Homebrew Cask Update
         run: |
           SHA256=$(cat app/build/artifacts/SHASUMS256.txt | grep Tuist.dmg | awk '{print $1}')
-          mise run --no-deps app:release:homebrew-cask --version "${{ needs.check-releases.outputs.app-next-version-number }}" --github-token "${{ secrets.TUIST_RELEASE_GITHUB_TOKEN }}" --sha256 "$SHA256"
+          mise run --no-deps --skip-tools app:release:homebrew-cask --version "${{ needs.check-releases.outputs.app-next-version-number }}" --github-token "${{ secrets.TUIST_RELEASE_GITHUB_TOKEN }}" --sha256 "$SHA256"

--- a/.github/workflows/cache-release.yml
+++ b/.github/workflows/cache-release.yml
@@ -53,7 +53,7 @@ jobs:
           cache: "false"
           github_token: ${{ env.MISE_GITHUB_TOKEN }}
       - id: check
-        run: mise run release:check cache
+        run: mise run --skip-tools release:check cache
 
   release:
     name: Release Cache

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -54,9 +54,9 @@ jobs:
           install_args: "erlang elixir ruby"
           working_directory: cache
       - name: Install dependencies
-        run: mise run install
+        run: mise run --skip-tools install
       - name: Check format
-        run: mise run format --check
+        run: mise run --skip-tools format --check
 
   credo:
     name: Credo
@@ -78,9 +78,9 @@ jobs:
           install_args: "erlang elixir ruby"
           working_directory: cache
       - name: Install dependencies
-        run: mise run install
+        run: mise run --skip-tools install
       - name: Run Credo
-        run: mise run credo
+        run: mise run --skip-tools credo
 
   test:
     name: Test
@@ -102,9 +102,9 @@ jobs:
           install_args: "erlang elixir ruby"
           working_directory: cache
       - name: Install dependencies
-        run: mise run install
+        run: mise run --skip-tools install
       - name: Run tests
-        run: mise run test
+        run: mise run --skip-tools test
 
   compile-prod:
     name: Compile (prod)
@@ -126,7 +126,7 @@ jobs:
           install_args: "erlang elixir ruby"
           working_directory: cache
       - name: Install dependencies
-        run: mise run install
+        run: mise run --skip-tools install
       - name: Compile with MIX_ENV=prod
         run: MIX_ENV=prod mix compile --warnings-as-errors
 

--- a/.github/workflows/cli-build-publish.yml
+++ b/.github/workflows/cli-build-publish.yml
@@ -71,7 +71,7 @@ jobs:
       - uses: jdx/mise-action@v4.0.1
         with:
           version: ${{ env.MISE_VERSION }}
-          install_args: "--locked tuist git-cliff 1password-cli"
+          install_args: "--locked tuist git-cliff 1password-cli jq"
           cache: "false"
           github_token: ${{ env.MISE_GITHUB_TOKEN }}
       - name: Authenticate with Tuist
@@ -83,7 +83,7 @@ jobs:
       - name: Initialize TuistCacheEE submodule
         env:
           TUIST_GITHUB_TOKEN: ${{ secrets.TUIST_RELEASE_GITHUB_TOKEN }}
-        run: mise run --no-deps cli:ee
+        run: mise run --no-deps --skip-tools cli:ee
       - name: Get release notes
         id: release-notes
         working-directory: cli
@@ -136,7 +136,7 @@ jobs:
           git cliff "${INCLUDE_PATHS[@]}" --config cliff.toml --repository "../" --tag "${{ inputs.version }}" -o CHANGELOG.md 2>/dev/null
 
       - name: Bundle CLI
-        run: mise run --no-deps cli:bundle
+        run: mise run --no-deps --skip-tools cli:bundle
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
 
@@ -271,4 +271,4 @@ jobs:
         if: ${{ inputs.update_homebrew }}
         run: |
           SHA256=$(cat build/SHASUMS256.txt | grep tuist.zip | awk '{print $1}')
-          mise run --no-deps cli:release:homebrew-formula --version "${{ inputs.version }}" --github-token "${{ secrets.TUIST_RELEASE_GITHUB_TOKEN }}" --sha256 "$SHA256"
+          mise run --no-deps --skip-tools cli:release:homebrew-formula --version "${{ inputs.version }}" --github-token "${{ secrets.TUIST_RELEASE_GITHUB_TOKEN }}" --sha256 "$SHA256"

--- a/.github/workflows/cli-promote.yml
+++ b/.github/workflows/cli-promote.yml
@@ -63,7 +63,7 @@ jobs:
           BRANCH: ${{ inputs.branch }}
         run: |
           set -euo pipefail
-          mise run --no-deps cli:release:channel-version -- promote "$BRANCH"
+          mise run --no-deps --skip-tools cli:release:channel-version -- promote "$BRANCH"
 
   build-publish:
     name: Build and publish stable

--- a/.github/workflows/cli-rc.yml
+++ b/.github/workflows/cli-rc.yml
@@ -77,9 +77,9 @@ jobs:
         run: |
           set -euo pipefail
           if [ -z "$BRANCH" ]; then
-            mise run --no-deps cli:release:channel-version -- rc-new
+            mise run --no-deps --skip-tools cli:release:channel-version -- rc-new
           else
-            mise run --no-deps cli:release:channel-version -- rc "$BRANCH"
+            mise run --no-deps --skip-tools cli:release:channel-version -- rc "$BRANCH"
           fi
 
   build-publish:

--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -82,7 +82,7 @@ jobs:
             exit 0
           fi
           echo "should_publish=true" >> "$GITHUB_OUTPUT"
-          mise run --no-deps cli:release:channel-version -- canary
+          mise run --no-deps --skip-tools cli:release:channel-version -- canary
 
   build-publish:
     name: Build and publish canary

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -102,9 +102,9 @@ jobs:
         run: tuist install --force-resolved-versions
       - name: Lint
         run: |
-          mise x swiftformat -- swiftformat cli/ app/ --lint
-          mise x swiftlint -- swiftlint lint --quiet --config .swiftlint.yml cli/Sources
-          mise x swiftlint -- swiftlint lint --quiet --config .swiftlint.yml --only-rule no_fatal_error_in_tests cli/Tests
+          "$(mise which swiftformat)" cli/ app/ --lint
+          "$(mise which swiftlint)" lint --quiet --config .swiftlint.yml cli/Sources
+          "$(mise which swiftlint)" lint --quiet --config .swiftlint.yml --only-rule no_fatal_error_in_tests cli/Tests
           tuist inspect dependencies --only implicit
 
   cli-spm-build:

--- a/.github/workflows/gradle-release.yml
+++ b/.github/workflows/gradle-release.yml
@@ -52,7 +52,7 @@ jobs:
           cache: "false"
           github_token: ${{ env.MISE_GITHUB_TOKEN }}
       - id: check
-        run: mise run release:check gradle
+        run: mise run --skip-tools release:check gradle
 
   release:
     name: Release Gradle Plugin

--- a/.github/workflows/grafana-datasource-release.yml
+++ b/.github/workflows/grafana-datasource-release.yml
@@ -42,7 +42,7 @@ jobs:
           cache: "false"
           github_token: ${{ env.MISE_GITHUB_TOKEN }}
       - id: check
-        run: mise run release:check grafana-datasource
+        run: mise run --skip-tools release:check grafana-datasource
 
   release:
     name: Build and release

--- a/.github/workflows/hetzner-robot-controller-release.yml
+++ b/.github/workflows/hetzner-robot-controller-release.yml
@@ -55,7 +55,7 @@ jobs:
           cache: "false"
           github_token: ${{ env.MISE_GITHUB_TOKEN }}
       - id: check
-        run: mise run release:check hetzner-robot-controller
+        run: mise run --skip-tools release:check hetzner-robot-controller
 
   release:
     name: Release hetzner-robot-controller

--- a/.github/workflows/skills-release.yml
+++ b/.github/workflows/skills-release.yml
@@ -52,7 +52,7 @@ jobs:
           cache: "false"
           github_token: ${{ env.MISE_GITHUB_TOKEN }}
       - id: check
-        run: mise run release:check skills
+        run: mise run --skip-tools release:check skills
 
   release:
     name: Release Skills

--- a/.github/workflows/slack.yml
+++ b/.github/workflows/slack.yml
@@ -55,9 +55,9 @@ jobs:
           cache_key: "{{default}}-{{env.NSC_BASE_IMAGE_REF_ID}}"
           working_directory: slack
       - name: Install dependencies
-        run: mise run install
+        run: mise run --skip-tools install
       - name: Check format
-        run: mise run format --check
+        run: mise run --skip-tools format --check
 
   credo:
     name: Credo
@@ -82,9 +82,9 @@ jobs:
           cache_key: "{{default}}-{{env.NSC_BASE_IMAGE_REF_ID}}"
           working_directory: slack
       - name: Install dependencies
-        run: mise run install
+        run: mise run --skip-tools install
       - name: Run Credo
-        run: mise run credo
+        run: mise run --skip-tools credo
 
   test:
     name: Test
@@ -109,9 +109,9 @@ jobs:
           cache_key: "{{default}}-{{env.NSC_BASE_IMAGE_REF_ID}}"
           working_directory: slack
       - name: Install dependencies
-        run: mise run install
+        run: mise run --skip-tools install
       - name: Run tests
-        run: mise run test
+        run: mise run --skip-tools test
 
   compile-prod:
     name: Compile (prod)
@@ -136,6 +136,6 @@ jobs:
           cache_key: "{{default}}-{{env.NSC_BASE_IMAGE_REF_ID}}"
           working_directory: slack
       - name: Install dependencies
-        run: mise run install
+        run: mise run --skip-tools install
       - name: Compile with MIX_ENV=prod
         run: MIX_ENV=prod mix compile --warnings-as-errors


### PR DESCRIPTION
## What

Audit of **all** `.github/workflows/*.yml`: where a job scopes its mise-action install via `install_args` but a later `mise run` auto-installs the entire `mise.toml` `[tools]` table anyway, add `--skip-tools` so the run honors the scoped install. (Originally release-jobs only; broadened to every workflow exhibiting the pattern.)

## Why

**Auto-install before a task ignores `install_args`** — a `mise run` first resolves the *whole* `[tools]` table. So a job that scoped to, say, `git-cliff jq` still builds erlang, elixir, gradle, the SwiftPM plugins, etc. just to run its task.

That is wasteful, and it is exactly how the CLI Canary Release **Resolve canary version** job broke when [#11466](https://github.com/tuist/tuist/pull/11466) added Swift-only SwiftPM plugins to the global `[tools]` table: the job runs on `tuist-linux` (no Swift), and the pre-task auto-install failed before the version could be computed. ([#11498](https://github.com/tuist/tuist/pull/11498) removes those plugins from the global table — the root cause; this PR is the complementary hardening so a scoped job never silently re-installs everything again.)

`--skip-tools` makes `mise run` use the already-installed (scoped) tools. This mirrors two existing repo conventions: `kura.yml` (`mise run … --skip-tools`) and `server-production-deployment.yml` / `server.yml` / `gradle-cache-acceptance.yml` (`MISE_TASK_RUN_AUTO_INSTALL=0`).

## Jobs covered

| Area | Workflows | Task(s) |
|---|---|---|
| Release version/check (git + changelog only) | `cli-release`, `cli-rc`, `cli-promote` | `cli:release:channel-version` |
| | `app-release`, `cache-release`, `gradle-release`, `grafana-datasource-release`, `hetzner-robot-controller-release`, `skills-release` | `release:check` |
| Elixir CI (mix only) | `slack.yml`, `cache.yml` | `install` / `format` / `credo` / `test` |
| CLI/app build & publish | `cli-build-publish` | `cli:ee`, `cli:bundle`, `cli:release:homebrew-formula` |
| | `app-release` | `app:bundle`, `app:upload-ios`, `app:release:homebrew-cask` |

Each was verified to need only tools within its `install_args`. The one exception: **`cli:bundle` and `app:bundle` invoke `jq`** (a mise tool), so `jq` is added to those two jobs' `install_args`. Everything else they use (`xcodebuild`, `xcrun`, `security`, …) comes from Xcode on the macOS runners, not mise.

**`cli.yml` lint job — different mechanism.** It called `mise x swiftformat`/`swiftlint`, which pins the mise-managed version (the `tuist-macos` runner also ships Homebrew copies) but, per `mise x` semantics, *loads the whole `mise.toml` tool set and auto-installs the missing ones* — the same over-install. It can't be dropped (version skew would make lint nondeterministic) and `--skip-tools` doesn't apply to `mise x`. Replaced with `"$(mise which swiftformat)" …` / `"$(mise which swiftlint)" …`, which resolves the exact pinned binary (`0.58.7` / `0.59.1`) without loading or installing the rest of the table.

## Postponed follow-ups (NOT in this PR)

These exhibit a related issue but need a different fix or carry more risk, so they are intentionally left for a separate, focused change:

- [ ] **`cache-deploy.yml`, `cache-staging-deploy.yml`, `handbook.yml`** — these pass **no** `install_args` (full install intended), so `--skip-tools` alone wouldn't help. The fix is the `search.yml`/`status-deploy.yml` pattern: a scoped `install:` + `MISE_AUTO_INSTALL=0`. Deferred because `cache-deploy`/`cache-staging-deploy` are **production deploys** and warrant a dedicated, carefully-reviewed change.
- [ ] **`server-production-deployment.yml`** acceptance-tests `cli:ee` (line ~1927) — no `install_args`, and the broader acceptance-tests job likely needs the full toolchain, so scoping it requires verifying every step in that job first.

_Already protected (no action needed): `kura.yml` (`--skip-tools`); `server.yml`, `gradle-cache-acceptance.yml`, `server-production-deployment.yml` release-check/e2e (`MISE_TASK_RUN_AUTO_INSTALL=0`); `search.yml`, `status-deploy.yml` (`MISE_AUTO_INSTALL=0`)._

## Validation

- Confirmed `--skip-tools` does not eat task args: `mise run --skip-tools release:check cache` still passes `cache` (output shows only the `cache` component); flag-like args forward without `--` as well — matching the repo's existing `homebrew-cask --version …` calls.
- Ran `release:check` and `cli:release:channel-version` with `--skip-tools` locally — correct output using only the scoped tools, no missing-tool errors.
- `mise which swiftformat`/`swiftlint` resolve the pinned `0.58.7`/`0.59.1` binaries and run correctly.
- `yq` validates all 13 changed workflow files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
