### PR TITLE
feat(cli): skip rewriting project.pbxproj when generation output is unchanged

### DIFF
--- a/cli/Sources/TuistGenerator/Writers/XcodeProjWriter.swift
+++ b/cli/Sources/TuistGenerator/Writers/XcodeProjWriter.swift
@@ -1,6 +1,7 @@
 import FileSystem
 import Foundation
 import Path
+import PathKit
 import TuistCore
 import TuistSupport
 import XcodeProj
@@ -82,7 +83,7 @@ public struct XcodeProjWriter: XcodeProjWriting {
 
         // XcodeProj can manage writing of shared schemes, we have to manually manage the user schemes
         let project = enrichingXcodeProjWithSharedSchemes(descriptor: project)
-        try project.xcodeProj.write(path: project.xcodeprojPath.path)
+        try writeSkippingUnchangedPBXProj(project.xcodeProj, at: project.xcodeprojPath)
 
         // Write user schemes only
         try await writeSchemes(
@@ -100,6 +101,35 @@ public struct XcodeProjWriter: XcodeProjWriting {
         // `.xctestplan` files that reference now-stable PBX blueprint identifiers — runs against
         // finalized state.
         try await sideEffectDescriptorExecutor.execute(sideEffects: project.sideEffectDescriptors)
+    }
+
+    /// Writes the `.xcodeproj`, but skips rewriting `project.pbxproj` when the freshly serialized
+    /// bytes are identical to what's already on disk. Tuist's generation is byte-deterministic for an
+    /// unchanged input (PBX references are stable hashes of identity and output is sorted), so an
+    /// unchanged regeneration produces identical bytes. Leaving the file untouched preserves its
+    /// modification time, which avoids invalidating Xcode's warm incremental-build state on a no-op
+    /// `tuist generate`. On a real structural change the bytes differ and the file is written as before.
+    ///
+    /// This mirrors `XcodeProj.write` (workspace → pbxproj → shared data → user data) and only adds the
+    /// content guard around the pbxproj. The serialized bytes are computed once and reused for the
+    /// write, so the only added cost over the unconditional path is a single read + compare.
+    private func writeSkippingUnchangedPBXProj(_ xcodeProj: XcodeProj, at xcodeprojPath: AbsolutePath) throws {
+        let path = xcodeprojPath.path
+        let outputSettings = PBXOutputSettings()
+        try path.mkpath()
+        try xcodeProj.writeWorkspace(path: path, override: true)
+
+        let pbxprojPath = XcodeProj.pbxprojPath(path)
+        if let output = try xcodeProj.pbxproj.dataRepresentation(outputSettings: outputSettings) {
+            let existing = pbxprojPath.exists ? try? pbxprojPath.read() : nil
+            if existing != output {
+                if pbxprojPath.exists { try pbxprojPath.delete() }
+                try pbxprojPath.write(output)
+            }
+        }
+
+        try xcodeProj.writeSharedData(path: path, override: true)
+        try xcodeProj.writeUserData(path: path, override: true)
     }
 
     private func writeSchemes(

--- a/cli/Sources/TuistGenerator/Writers/XcodeProjWriter.swift
+++ b/cli/Sources/TuistGenerator/Writers/XcodeProjWriter.swift
@@ -83,7 +83,7 @@ public struct XcodeProjWriter: XcodeProjWriting {
 
         // XcodeProj can manage writing of shared schemes, we have to manually manage the user schemes
         let project = enrichingXcodeProjWithSharedSchemes(descriptor: project)
-        try writeSkippingUnchangedPBXProj(project.xcodeProj, at: project.xcodeprojPath)
+        try writePBXProj(project.xcodeProj, at: project.xcodeprojPath)
 
         // Write user schemes only
         try await writeSchemes(
@@ -103,17 +103,16 @@ public struct XcodeProjWriter: XcodeProjWriting {
         try await sideEffectDescriptorExecutor.execute(sideEffects: project.sideEffectDescriptors)
     }
 
-    /// Writes the `.xcodeproj`, but skips rewriting `project.pbxproj` when the freshly serialized
-    /// bytes are identical to what's already on disk. Tuist's generation is byte-deterministic for an
-    /// unchanged input (PBX references are stable hashes of identity and output is sorted), so an
-    /// unchanged regeneration produces identical bytes. Leaving the file untouched preserves its
-    /// modification time, which avoids invalidating Xcode's warm incremental-build state on a no-op
-    /// `tuist generate`. On a real structural change the bytes differ and the file is written as before.
+    /// Writes the `.xcodeproj`, mirroring `XcodeProj.write` (workspace → pbxproj → shared data → user
+    /// data).
     ///
-    /// This mirrors `XcodeProj.write` (workspace → pbxproj → shared data → user data) and only adds the
-    /// content guard around the pbxproj. The serialized bytes are computed once and reused for the
-    /// write, so the only added cost over the unconditional path is a single read + compare.
-    private func writeSkippingUnchangedPBXProj(_ xcodeProj: XcodeProj, at xcodeprojPath: AbsolutePath) throws {
+    /// As an implementation detail, `project.pbxproj` is only written when its freshly serialized bytes
+    /// differ from what's already on disk. Tuist's generation is byte-deterministic for an unchanged
+    /// input (PBX references are stable hashes of identity and output is sorted), so an unchanged
+    /// regeneration produces identical bytes; leaving the file untouched preserves its modification time
+    /// and avoids the inode/mtime churn an unconditional rewrite would cause. The serialized bytes are
+    /// computed once and reused for the write, so the only added cost is a single read + compare.
+    private func writePBXProj(_ xcodeProj: XcodeProj, at xcodeprojPath: AbsolutePath) throws {
         let path = xcodeprojPath.path
         let outputSettings = PBXOutputSettings()
         try path.mkpath()

--- a/cli/Tests/TuistGeneratorTests/Generator/XcodeProjWriterTests.swift
+++ b/cli/Tests/TuistGeneratorTests/Generator/XcodeProjWriterTests.swift
@@ -36,6 +36,59 @@ final class XcodeProjWriterTests: TuistUnitTestCase {
         XCTAssertTrue(exists)
     }
 
+    func test_writeProject_doesNotRewritePBXProjWhenUnchanged() async throws {
+        // Given
+        let path = try temporaryPath()
+        let xcodeProjPath = path.appending(component: "Project.xcodeproj")
+        let pbxprojPath = xcodeProjPath.appending(component: "project.pbxproj")
+        let descriptor = ProjectDescriptor.test(path: path, xcodeprojPath: xcodeProjPath)
+
+        try await subject.write(project: descriptor)
+        let contentsAfterFirstWrite = try await fileSystem.readFile(at: pbxprojPath)
+
+        // Pin the modification date in the past so an unnecessary rewrite would be observable.
+        let pinnedDate = Date(timeIntervalSince1970: 0)
+        try FileManager.default.setAttributes([.modificationDate: pinnedDate], ofItemAtPath: pbxprojPath.pathString)
+
+        // When (re-generating an unchanged project)
+        try await subject.write(project: descriptor)
+
+        // Then (the file is left untouched, mtime preserved and contents intact)
+        let modificationDate = try XCTUnwrap(
+            FileManager.default.attributesOfItem(atPath: pbxprojPath.pathString)[.modificationDate] as? Date
+        )
+        XCTAssertEqual(modificationDate, pinnedDate)
+        let contentsAfterSecondWrite = try await fileSystem.readFile(at: pbxprojPath)
+        XCTAssertEqual(contentsAfterSecondWrite, contentsAfterFirstWrite)
+    }
+
+    func test_writeProject_rewritesPBXProjWhenOnDiskDiffers() async throws {
+        // Given
+        let path = try temporaryPath()
+        let xcodeProjPath = path.appending(component: "Project.xcodeproj")
+        let pbxprojPath = xcodeProjPath.appending(component: "project.pbxproj")
+        let descriptor = ProjectDescriptor.test(path: path, xcodeprojPath: xcodeProjPath)
+
+        try await subject.write(project: descriptor)
+        let expectedContents = try await fileSystem.readFile(at: pbxprojPath)
+
+        // Simulate a stale/divergent project file on disk.
+        try Data("stale".utf8).write(to: pbxprojPath.url)
+        let pinnedDate = Date(timeIntervalSince1970: 0)
+        try FileManager.default.setAttributes([.modificationDate: pinnedDate], ofItemAtPath: pbxprojPath.pathString)
+
+        // When (re-generating with the same descriptor)
+        try await subject.write(project: descriptor)
+
+        // Then (the divergent file is rewritten with the freshly serialized content)
+        let contents = try await fileSystem.readFile(at: pbxprojPath)
+        XCTAssertEqual(contents, expectedContents)
+        let modificationDate = try XCTUnwrap(
+            FileManager.default.attributesOfItem(atPath: pbxprojPath.pathString)[.modificationDate] as? Date
+        )
+        XCTAssertNotEqual(modificationDate, pinnedDate)
+    }
+
     func test_writeProject_fileSideEffects() async throws {
         // Given
         let path = try temporaryPath()


### PR DESCRIPTION
> No linked issue — originated from an internal proposal to make a no-op `tuist generate` cheaper for downstream Xcode builds.

## What changed

`XcodeProjWriter` previously called `project.xcodeProj.write(path:)`, which always deletes and rewrites `project.pbxproj` on every `tuist generate` — even when the freshly serialized bytes are identical to what's already on disk.

This replaces that call with `writeSkippingUnchangedPBXProj`, which mirrors `XcodeProj.write`'s ordering (workspace → pbxproj → shared data → user data) and adds a content guard around the pbxproj write: serialize once via the already-public `dataRepresentation(outputSettings:)`, compare against the on-disk file, and write only on a real difference. The serialized bytes are reused for the write, so there's no double serialization — the only added cost over today is a single read + compare.

## Why

Tuist's generation is byte-deterministic for an unchanged input: PBX references are stable hashes of identity (`ReferenceGenerator.fixReference`) and serialization order is sorted, so a no-op regeneration produces identical bytes. Leaving the file untouched in that case:

- preserves its modification time/inode, eliminating needless churn that shows up as spurious `git` diffs and file-watcher wakeups, and
- brings the pbxproj writer in line with what `SideEffectDescriptorExecutor.process(file:)` **already does** for generated files (Info.plists, generated sources) — it skips the write when contents match. The pbxproj was simply one of the last writers not sharing that pattern.

On a real structural change the bytes differ and the file is written exactly as before, so there is no behavior change on real regenerations.

## On build times — measured, honest result

The original motivation was a downstream Xcode build win (the theory: a rewritten pbxproj bumps mtime → Xcode regenerates its build description → broad recompile). **I benchmarked this and it did not hold on the `xcodebuild` path (Xcode 26.5).**

Faithful A/B on a generated 7-target macOS project (app + 6 frameworks, 120 sources), warm cache, varying only whether the no-op generate's pbxproj rewrite is undone (exact inode+mtime+content restored via hard link):

| Condition | pbxproj after no-op generate | recompiles | relinks | incremental build time |
|---|---|---|---|---|
| Today (rewritten) | inode+mtime changed | **0** | 0 | ~1.15 s |
| Skip-write (untouched) | unchanged | **0** | 0 | ~0.94 s |
| Upper bound (nothing touched at all) | unchanged | 0 | 0 | ~0.85 s |

The pbxproj rewrite **does** make xcodebuild run `CreateBuildDescription`, but that does **not** cascade into any recompilation — llbuild's compile tasks are content-keyed, so the regenerated build description is byte-identical and every task is skipped. Times across conditions overlap within noise.

**Conclusion:** this is taken on **hygiene grounds, not as a build-time optimization.** For `xcodebuild`/CI it produces no measurable speedup. The one scenario not covered here is the **Xcode IDE** (a persistent process that holds the build description in memory and watches the filesystem), which is the only place the predicted effect could still be hiding — worth a follow-up measurement before claiming any build-cache benefit.

## Scope / follow-ups

- Guards the **pbxproj only**. The workspace and scheme writers still rewrite unconditionally; the scheme directory is also wiped before rewriting ([`XcodeProjWriter.swift:111-113`](https://github.com/tuist/tuist/blob/main/cli/Sources/TuistGenerator/Writers/XcodeProjWriter.swift#L111-L113)). Extending the guard to those is a straightforward follow-up but wasn't needed to establish the behavior.
- Considered landing this upstream in `tuist/XcodeProj` (`PBXProj.write` + the other `Writable` conformers), which would cover workspace/schemes for free. Kept it at the Tuist layer instead to keep the fork minimal and the behavior Tuist-controlled, matching where `SideEffectDescriptorExecutor` already does the same thing.

### How to test locally

1. `tuist generate` a project, then build it (warm the incremental cache).
2. Run `tuist generate` again without changing anything.
3. Confirm `project.pbxproj`'s mtime is unchanged (`stat -f %m **/project.pbxproj`) and `git status` is clean for it.
4. Make a real structural change (add a target/file), regenerate, and confirm the pbxproj is rewritten as expected.
