### PR TITLE
fix(cli): forward TUIST_CACHE_ENDPOINT to the Xcode cache daemon

### DIFF
--- a/cli/Sources/TuistKit/Services/Setup/SetupCacheCommandService.swift
+++ b/cli/Sources/TuistKit/Services/Setup/SetupCacheCommandService.swift
@@ -75,12 +75,21 @@ struct SetupCacheCommandService {
         }
 
         // The cache daemon runs as a launchd agent that does not inherit the
-        // caller's environment, so forward the client feature flags. Without
-        // them the daemon cannot signal the "kura" flag on getCacheEndpoints, so
-        // it resolves the default (public) cache endpoint instead of the kura
-        // private-network one the rest of the CLI uses.
+        // caller's environment. Forward the client feature flags so it behaves
+        // consistently with the rest of the CLI.
         for (key, value) in ClientFeatureFlags.environmentVariables() {
             environmentVariables[key] = value
+        }
+
+        // Forward the cache-endpoint override. The runner-cache dispatch hands
+        // runners the private-network cache as a hard TUIST_CACHE_ENDPOINT
+        // override (which the module cache already honors); the daemon needs it
+        // explicitly, or the Xcode CAS keeps resolving the public endpoint via
+        // getCacheEndpoints while the module cache uses the private one. The
+        // feature flags above are not enough on their own: getCacheEndpoints
+        // returns the public, CLI-facing endpoint regardless of the kura flag.
+        if let cacheEndpoint = Environment.current.variables["TUIST_CACHE_ENDPOINT"] {
+            environmentVariables["TUIST_CACHE_ENDPOINT"] = cacheEndpoint
         }
 
         let label = Environment.current.cacheLaunchAgentLabel(for: fullHandle)

--- a/cli/Tests/TuistKitTests/Services/Setup/SetupCacheCommandServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/Setup/SetupCacheCommandServiceTests.swift
@@ -255,6 +255,39 @@ struct SetupCacheCommandServiceTests {
             .called(1)
     }
 
+    @Test(.inTemporaryDirectory, .withMockedEnvironment()) func setupCache_forwardsCacheEndpointOverride() async throws {
+        // Given
+        let environment = try #require(Environment.mocked)
+        environment.currentExecutablePathStub = AbsolutePath("/usr/local/bin/tuist")
+        let token = "test-auth-token-123"
+        environment.variables[Constants.EnvironmentVariables.token] = token
+        environment.variables["TUIST_CACHE_ENDPOINT"] = "http://172.16.0.2:30815"
+
+        let config = Tuist.test(fullHandle: "organization/project")
+        configLoader.reset()
+        given(configLoader)
+            .loadConfig(path: .any)
+            .willReturn(config)
+
+        // When
+        try await subject.run(path: nil)
+
+        // Then: the runner-cache dispatch sets TUIST_CACHE_ENDPOINT as a hard
+        // override, but the launchd agent does not inherit it, so it must be
+        // forwarded or the CAS keeps resolving the public endpoint.
+        verify(launchAgentService)
+            .setupLaunchAgent(
+                label: .any,
+                plistFileName: .any,
+                programArguments: .any,
+                environmentVariables: .value([
+                    "TUIST_TOKEN": token,
+                    "TUIST_CACHE_ENDPOINT": "http://172.16.0.2:30815",
+                ])
+            )
+            .called(1)
+    }
+
     @Test(
         .inTemporaryDirectory,
         .withMockedEnvironment()


### PR DESCRIPTION
## What

Forward `TUIST_CACHE_ENDPOINT` into the Xcode compilation cache (CAS) daemon's launchd-agent environment.

## Why

The runner-cache dispatch hands runners the private-network cache endpoint as a hard `TUIST_CACHE_ENDPOINT` override (`runners_controller` exports `runner_cache_endpoint_url` as `TUIST_CACHE_ENDPOINT`), and the binary module cache honors it. The CAS daemon is started by `tuist setup cache` as a launchd agent, which does not inherit the caller's environment, so it never saw `TUIST_CACHE_ENDPOINT` and kept resolving the public endpoint via `getCacheEndpoints`. Result: the module cache used the private-network node while the CAS round-tripped every compilation unit to a public endpoint, leaving the Xcode cache net-negative on a full compile.

`#11481` forwarded the client feature flags, on the theory that the `kura` flag would make `getCacheEndpoints` return the private endpoint. It does not: `getCacheEndpoints` returns `account_cache_endpoints`, which is deliberately the public, CLI-facing endpoint (a developer machine must be able to reach it); the private node is only ever handed out as the `TUIST_CACHE_ENDPOINT` dispatch override. A benchmark on a canary with `#11481` plus the kura flag confirmed it: the CAS sent zero traffic to the private node and stayed at ~90s, identical to baseline.

## Fix

Forward `TUIST_CACHE_ENDPOINT` into the agent environment when set, alongside the feature flags. No runner-side change is needed: the runner already receives the override for the module cache. Also corrects the `#11481` comment, which claimed the feature flags alone route the CAS to the private network.

## Validation

- New unit test asserts the override is forwarded into the agent environment.
- Existing tests unaffected (the override is only added when set).
- Re-running the benchmark on a canary with this change is the end-to-end check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)