### PR TITLE
ci(kura): run clippy through the Bazel clippy aspect

### DIFF
--- a/.github/workflows/kura.yml
+++ b/.github/workflows/kura.yml
@@ -131,28 +131,79 @@ jobs:
           } >> "$HOME/.bazelrc"
           mise run compile --skip-tools -- --define=kura_deny_warnings=true
 
-  clippy:
-    name: Clippy
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
+  # Split non-fork / fork like bazel-compile: only trusted runs get `id-token: write` + the remote
+  # cache; forks run with `contents: read` and the local cache.
+  bazel-clippy:
+    name: Bazel Clippy
+    runs-on: tuist-linux
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      id-token: write
+    if: |
+      (github.event.pull_request.draft == false || github.event_name != 'pull_request') &&
+      (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork != true)
     steps:
       - uses: actions/checkout@v4
 
       - uses: jdx/mise-action@v4.0.1
         with:
           version: ${{ env.MISE_VERSION }}
-          install_args: --force rust
+          install_args: "rust bazel tuist"
           working_directory: kura
 
-      - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: kura-rust-${{ runner.os }}
-          workspaces: |
-            kura -> target
+      - name: Install C/C++ toolchain for -sys crates (rocksdb/aws-lc bindgen)
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends build-essential clang cmake pkg-config
+      - name: Set up the Tuist remote cache
+        run: |
+          tuist auth login
+          tuist bazel setup
+        continue-on-error: true
+      - name: Warn when the Tuist remote cache is unavailable
+        if: ${{ hashFiles('kura/.bazelrc.tuist') == '' }}
+        run: echo "::warning::Tuist remote cache unavailable (.bazelrc.tuist not written); building cold against the local cache."
 
       - name: Run clippy
-        run: env -u RUSTUP_TOOLCHAIN cargo clippy --locked --all-targets -- -D warnings
+        run: mise run --skip-tools clippy
+
+  bazel-clippy-fork:
+    name: Bazel Clippy Fork
+    runs-on: tuist-linux
+    timeout-minutes: 60
+    # Fork PRs only: `contents: read`, no OIDC token; skips auth/setup and uses the local
+    # repository/disk caches alone.
+    permissions:
+      contents: read
+    if: github.event_name == 'pull_request' && github.event.pull_request.draft == false && github.event.pull_request.head.repo.fork == true
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: jdx/mise-action@v4.0.1
+        with:
+          version: ${{ env.MISE_VERSION }}
+          install_args: "rust bazel"
+          working_directory: kura
+
+      - name: Cache Bazel repository downloads and build outputs
+        uses: actions/cache@v4
+        with:
+          path: |
+            ${{ runner.temp }}/bazel-repo
+            ${{ runner.temp }}/bazel-disk
+          key: bazel-clippy-fork-${{ hashFiles('kura/MODULE.bazel.lock') }}-${{ github.sha }}
+          restore-keys: |
+            bazel-clippy-fork-${{ hashFiles('kura/MODULE.bazel.lock') }}-
+            bazel-clippy-fork-
+
+      - name: Install C/C++ toolchain for -sys crates (rocksdb/aws-lc bindgen)
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends build-essential clang cmake pkg-config
+      - name: Run clippy
+        run: |
+          {
+            echo "common --repository_cache=${{ runner.temp }}/bazel-repo"
+            echo "build --disk_cache=${{ runner.temp }}/bazel-disk"
+          } >> "$HOME/.bazelrc"
+          mise run --skip-tools clippy
 
   # Split non-fork / fork like bazel-compile: only trusted runs get `id-token: write` + the remote
   # cache; forks run with `contents: read` and the local cache.

--- a/kura/AGENTS.md
+++ b/kura/AGENTS.md
@@ -22,10 +22,13 @@ This node covers the `kura/` workspace, a Rust service for low-latency cache mes
   (`cargo`) only as a fallback when Bazel is unavailable:
   - Compile: `mise run compile` (fallback: `mise exec -- cargo build`)
   - Test: `mise run test-unit` (runs `bazel test //...`; fallback: `mise exec -- cargo test`)
+  - Clippy: `mise run clippy` (runs the rules_rust clippy aspect over `//...`, warnings as errors;
+    fallback: `mise exec -- cargo clippy --all-targets -- -D warnings`)
 - If you have access to the `tuist/kura` project on Tuist, run `tuist bazel setup` to point Bazel at
   the closest Kura remote cache (it writes `kura/.bazelrc.tuist`); re-run it after changing physical
   location. Without access, skip it — Bazel builds fine against the local cache.
-- Consider Kura work incomplete until `mise exec -- cargo clippy --all-targets -- -D warnings` passes
+- Consider Kura work incomplete until `mise run clippy` passes (fallback when Bazel is unavailable:
+  `mise exec -- cargo clippy --all-targets -- -D warnings`)
 - rules_rs resolves the Bazel crate graph directly from `Cargo.toml`/`Cargo.lock` on each build, so
   changing Rust deps just updates `Cargo.lock` as usual and Bazel picks it up on the next build
 - Run the end-to-end suite with `docker compose build && mise exec -- shellspec`

--- a/kura/MODULE.bazel
+++ b/kura/MODULE.bazel
@@ -41,6 +41,13 @@ use_repo(toolchains, "default_rust_toolchains")
 
 register_toolchains("@default_rust_toolchains//:all")
 
+# Make @rules_rust visible here so the clippy aspect label
+# (@rules_rust//rust:defs.bzl%rust_clippy_aspect) resolves on the `mise run clippy` command line.
+# rules_rs already provisions this repo; re-importing its extension only adds it to our repo mapping,
+# it does not create a second copy.
+rules_rust = use_extension("@rules_rs//rs:rules_rust.bzl", "rules_rust")
+use_repo(rules_rust, "rules_rust")
+
 crate = use_extension("@rules_rs//rs:extensions.bzl", "crate")
 
 # mlua's `vendored` feature compiles Lua from sources shipped in the `lua-src` crate, whose build

--- a/kura/mise/tasks/clippy.sh
+++ b/kura/mise/tasks/clippy.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+#MISE description="Lint all kura targets with clippy via Bazel (rules_rust clippy aspect; warnings are errors). Pass extra bazel flags through, e.g. mise run clippy -- -c opt. Fall back to cargo clippy only if Bazel is unavailable."
+set -euo pipefail
+
+# The aspect lints only the first-party //... targets (it doesn't propagate to the crate graph) and,
+# given no explicit flags, treats warnings as errors — equivalent to the old
+# `cargo clippy --all-targets -- -D warnings` gate.
+bazel build //... \
+  --aspects=@rules_rust//rust:defs.bzl%rust_clippy_aspect \
+  --output_groups=clippy_checks \
+  "$@"


### PR DESCRIPTION
## What changed

The kura `clippy` CI job is moved off `cargo clippy` onto the rules_rust clippy aspect, so linting rides the same Bazel graph and Tuist remote cache the compile/test jobs already use.

- **`kura/MODULE.bazel`** — imports the `@rules_rust` repo that rules_rs provisions (`use_extension` + `use_repo`) so the clippy aspect label resolves on the `bazel build --aspects` command line.
- **`kura/mise/tasks/clippy.sh`** (new) — `mise run clippy` runs `bazel build //... --aspects=@rules_rust//rust:defs.bzl%rust_clippy_aspect --output_groups=clippy_checks`.
- **`.github/workflows/kura.yml`** — the single `clippy` job (ubuntu-latest, cargo + `Swatinem/rust-cache`) is replaced by `bazel-clippy` (tuist-linux, `id-token: write` + remote cache) and `bazel-clippy-fork` (forks, local disk/repo cache), mirroring the existing `bazel-compile` / `bazel-compile-fork` split.
- **`kura/AGENTS.md`** — documents `mise run clippy` as the primary path with the cargo fallback, matching the compile/test entries.

## Why

The old job ran `cargo clippy` on `ubuntu-latest` under its own Rust toolchain and `Swatinem/rust-cache`, completely separate from the Bazel graph the `bazel-compile`/`bazel-test` jobs build and cache. That meant a **second cold compile of the `-sys` crates (rocksdb, aws-lc) just to lint**, with zero reuse of the Tuist remote cache. Folding clippy onto the Bazel aspect means the crate graph is compiled once and shared across compile, test, and lint — on a warm cache, clippy only re-lints changed crates.

## Behavioral equivalence

The `rust_clippy_aspect` has no `attr_aspects`, so it applies clippy **only to the first-party `//...` targets** (kura_lib, kura, kura_lib_test) and not the third-party crate graph. With no explicit clippy flags, the aspect turns every clippy/rustc warning into an error. Together that is a faithful equivalent of the previous `cargo clippy --all-targets -- -D warnings` gate. The Rust toolchain is pinned to the same 1.94.1 in both `mise.toml` and the Bazel toolchain, so clippy versions match.

## Fork vs non-fork

Mirrors the established pattern: only trusted (non-fork) runs get `id-token: write` and authenticate to the remote cache; fork PRs run with `contents: read` alone and fall back to the local repository/disk caches, never seeing the OIDC token.

## Validation

Run locally against the current tree:
- Analysis-only run (`--nobuild`) resolves the aspect label via the new MODULE.bazel mapping and reports **3 aspect applications** over exactly the first-party targets (not the ~30k third-party targets).
- A full cold build executes clippy on `kura_lib`, `kura`, and `kura_lib_test` (after compiling rocksdb/aws-lc from source) and **passes under `-Dwarnings`**.

Also caught and fixed a mise arg-ordering bug during validation: the invocation must be `mise run --skip-tools clippy` (flag before the task); `mise run clippy --skip-tools` without a trailing `--` forwards `--skip-tools` to bazel and fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)