### PR TITLE
fix(server): convert S3 download timeouts into retryable errors

### DIFF
--- a/server/lib/tuist/storage.ex
+++ b/server/lib/tuist/storage.ex
@@ -174,6 +174,11 @@ defmodule Tuist.Storage do
     bucket_name
     |> ExAws.S3.download_file(object_key, file_path)
     |> ExAws.request(Map.merge(config, fast_api_req_opts()))
+  catch
+    # ExAws downloads each chunk in a Task.async_stream whose per-chunk timeout
+    # exits rather than raising, so a stalled S3 chunk escapes ExAws' own rescue
+    # and would crash the calling job. Surface it as a retryable error instead.
+    :exit, reason -> {:error, reason}
   end
 
   def get_object_as_string(object_key, actor) do

--- a/server/test/tuist/storage_test.exs
+++ b/server/test/tuist/storage_test.exs
@@ -3,6 +3,7 @@ defmodule Tuist.StorageTest do
   use Mimic
 
   alias ExAws.Operation.S3
+  alias ExAws.S3.Download
   alias Tuist.Accounts.Account
   alias Tuist.Environment
   alias Tuist.Storage
@@ -324,6 +325,55 @@ defmodule Tuist.StorageTest do
       # Then
       assert got == stream
       assert_received {^event_name, ^event_ref, %{}, %{object_key: ^object_key}}
+    end
+  end
+
+  describe "download_to_file/3" do
+    test "returns the downloaded file when the request succeeds" do
+      # Given
+      object_key = UUIDv7.generate()
+      file_path = Path.join(System.tmp_dir!(), "#{UUIDv7.generate()}.zip")
+      bucket_name = UUIDv7.generate()
+      config = %{test: :config}
+
+      expect(Environment, :s3_bucket_name, fn -> bucket_name end)
+      expect(ExAws.Config, :new, fn :s3 -> config end)
+
+      operation = %Download{bucket: bucket_name, path: object_key, dest: file_path}
+
+      expect(ExAws.S3, :download_file, fn ^bucket_name, ^object_key, ^file_path -> operation end)
+      expect(ExAws, :request, fn ^operation, _opts -> {:ok, :done} end)
+
+      # When / Then
+      assert {:ok, :done} = Storage.download_to_file(object_key, file_path, :test)
+    end
+
+    test "returns an error tuple instead of exiting when an S3 chunk download times out" do
+      # Given
+      object_key = UUIDv7.generate()
+      file_path = Path.join(System.tmp_dir!(), "#{UUIDv7.generate()}.zip")
+      bucket_name = UUIDv7.generate()
+      config = %{test: :config}
+
+      expect(Environment, :s3_bucket_name, fn -> bucket_name end)
+      expect(ExAws.Config, :new, fn :s3 -> config end)
+
+      operation = %Download{bucket: bucket_name, path: object_key, dest: file_path}
+
+      expect(ExAws.S3, :download_file, fn ^bucket_name, ^object_key, ^file_path -> operation end)
+
+      # ExAws downloads each chunk in a Task.async_stream whose per-chunk timeout
+      # exits rather than raising, so a stalled chunk would otherwise escape as an
+      # uncaught exit and crash the calling job (observed as an Oban.CrashError).
+      expect(ExAws, :request, fn ^operation, _opts ->
+        exit({:timeout, {Task.Supervised, :stream, [60_000]}})
+      end)
+
+      # When
+      result = Storage.download_to_file(object_key, file_path, :test)
+
+      # Then
+      assert {:error, {:timeout, {Task.Supervised, :stream, [60_000]}}} = result
     end
   end
 


### PR DESCRIPTION
## Problem

[TUIST-10S](https://tuist.sentry.io/issues/TUIST-10S): `ProcessBuildWorker` crashes with `Oban.CrashError: ** (exit) exited in: Task.Supervised.stream(60000) ** (EXIT) time out`.

`ExAws.S3.download_file` pulls each chunk through a `Task.async_stream` with a per-chunk `timeout: 60_000` and the default `on_timeout: :exit`. When an S3 chunk stalls past 60s the stream **exits** rather than raising. ExAws' own `download_to/3` only `rescue`s *exceptions*, not exits, so the exit escaped `Storage.download_to_file/3`, propagated through the worker, and Oban surfaced it as a crash.

## Fix

Catch the exit at the storage boundary and return `{:error, reason}`. `download_to_file/3`'s contract is now `{:ok, _} | {:error, _}` — never an uncaught exit.

Both `ProcessBuildWorker` and `ProcessXcResultWorker` call `download_to_file/3` with the same `{:error, _} = error -> error` pattern, so the timeout now flows through their existing failure handling: the job retries, and the build is marked `failed_processing` after the final attempt instead of crashing.

## Tests (TDD)

- New `download_to_file/3` test stubs `ExAws.request` to `exit({:timeout, {Task.Supervised, :stream, [60_000]}})` — reproduced the exact Sentry exit before the fix, passes after.
- Added a happy-path test guarding the normal `{:ok, _}` return.

Verified: `storage_test.exs` (37 tests), `process_build_worker_test.exs` + `process_xcresult_worker_test.exs` (36 tests), `mix compile --warnings-as-errors`, and `mix credo` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)