### PR TITLE
fix(cli): authenticate the HTTPS fetch fallback and report every candidate

### DIFF
--- a/swifterpm/Sources/swifterpm/GitHub.swift
+++ b/swifterpm/Sources/swifterpm/GitHub.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct GitHubRepo: Sendable {
+struct GitHubRepo {
     let owner: String
     let repo: String
 
@@ -88,10 +88,10 @@ enum SourceControlLocations {
         return locations
     }
 
-    // Offer both the HTTPS and SSH forms regardless of how the location was originally
-    // declared. The original is tried first, so SSH-declared dependencies keep using
-    // ssh-agent locally while still falling back to HTTPS in environments (typically CI)
-    // that only have a token-based `git config insteadOf` rewrite or anonymous HTTPS access.
+    /// Offer both the HTTPS and SSH forms regardless of how the location was originally
+    /// declared. The original is tried first, so SSH-declared dependencies keep using
+    /// ssh-agent locally while still falling back to HTTPS in environments (typically CI)
+    /// that only have a token-based `git config insteadOf` rewrite or anonymous HTTPS access.
     private static func appendGitHubLocations(for location: String, to locations: inout [String]) {
         guard let repo = try? GitHubRepo(location: location) else { return }
         appendUnique("https://github.com/\(repo.owner)/\(repo.repo).git", to: &locations)
@@ -122,6 +122,48 @@ enum SourceControlLocations {
     fileprivate static func canonicalizesProviderPath(host: String) -> Bool {
         let host = host.lowercased()
         return host == "github.com" || GitLabRepo.isKnownHost(host)
+    }
+}
+
+/// Authenticates the HTTPS git fallback with the same token swifterpm discovers for the
+/// provider's API. Without this, the HTTPS candidate added by `fetchCandidates` only works
+/// when an ambient credential (a `url.insteadOf` token rewrite, a credential helper, or
+/// ~/.netrc) is configured, so an SSH-declared private dependency keeps failing in CI even
+/// with a usable `GITHUB_TOKEN`/`GH_TOKEN`. Emitting an `http.<base>.extraheader` via `-c`
+/// mirrors what `actions/checkout` does and keeps the token out of the on-disk git config.
+/// SSH candidates return no arguments so ssh-agent stays in charge, and when no token is
+/// available we add nothing so configured ambient credentials keep working unchanged.
+enum GitTransportAuth {
+    static func configArguments(for location: String) async -> [String] {
+        guard location.hasPrefix("https://") else { return [] }
+        if (try? GitHubRepo(location: location)) != nil {
+            guard let token = await GitHubAuth.token() else { return [] }
+            return gitHubArguments(token: token)
+        }
+        if let repo = try? GitLabRepo(location: location) {
+            guard let token = await GitLabAuth.token(host: repo.host) else { return [] }
+            return gitLabArguments(host: repo.host, token: token)
+        }
+        return []
+    }
+
+    static func gitHubArguments(token: String) -> [String] {
+        extraHeaderArguments(
+            base: "https://github.com/",
+            authorization: "Basic \(basicCredential(user: "x-access-token", token: token))"
+        )
+    }
+
+    static func gitLabArguments(host: String, token: GitLabAuth.Token) -> [String] {
+        extraHeaderArguments(base: "https://\(host)/", authorization: token.gitHTTPAuthorization)
+    }
+
+    private static func extraHeaderArguments(base: String, authorization: String) -> [String] {
+        ["-c", "http.\(base).extraheader=Authorization: \(authorization)"]
+    }
+
+    private static func basicCredential(user: String, token: String) -> String {
+        Data("\(user):\(token)".utf8).base64EncodedString()
     }
 }
 

--- a/swifterpm/Sources/swifterpm/GitLab.swift
+++ b/swifterpm/Sources/swifterpm/GitLab.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct GitLabRepo: Sendable {
+struct GitLabRepo {
     let scheme: String
     let host: String
     let pathWithNamespace: String
@@ -88,13 +88,14 @@ extension String {
 private enum GitLabURLCoding {
     static func encodePathComponent(_ value: String) -> String {
         let allowed = CharacterSet(
-            charactersIn: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~")
+            charactersIn: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~"
+        )
         return value.addingPercentEncoding(withAllowedCharacters: allowed) ?? value
     }
 }
 
 enum GitLabAuth {
-    enum Token: Sendable {
+    enum Token {
         case privateToken(String)
         case jobToken(String)
         case bearer(String)
@@ -108,6 +109,25 @@ enum GitLabAuth {
             case let .bearer(token):
                 return ["Authorization": "Bearer \(token)"]
             }
+        }
+
+        /// The `PRIVATE-TOKEN`/`JOB-TOKEN` headers authenticate GitLab's REST API but not its
+        /// git smart-HTTP endpoint, which only understands standard HTTP authentication. Map
+        /// each token kind to the credential form git transport accepts: a personal access
+        /// token authenticates as `oauth2:<token>` and a CI job token as `gitlab-ci-token:<token>`.
+        var gitHTTPAuthorization: String {
+            switch self {
+            case let .privateToken(token):
+                return "Basic \(Self.basicCredential(user: "oauth2", token: token))"
+            case let .jobToken(token):
+                return "Basic \(Self.basicCredential(user: "gitlab-ci-token", token: token))"
+            case let .bearer(token):
+                return "Bearer \(token)"
+            }
+        }
+
+        private static func basicCredential(user: String, token: String) -> String {
+            Data("\(user):\(token)".utf8).base64EncodedString()
         }
     }
 
@@ -195,7 +215,8 @@ enum GitLabAPI {
             for tag in tags {
                 if let version = RemoteMetadata.parseSwiftTagVersion(tag.name) {
                     versions.append(
-                        RemoteVersion(version: version.description, revision: tag.commit.id))
+                        RemoteVersion(version: version.description, revision: tag.commit.id)
+                    )
                 }
             }
             page += 1
@@ -232,7 +253,8 @@ extension URL {
         -> URL
     {
         URL(
-            string: ([absoluteString, "projects", projectPath] + components).joined(separator: "/"))!
+            string: ([absoluteString, "projects", projectPath] + components).joined(separator: "/")
+        )!
     }
 
     fileprivate func appending(queryItems: [URLQueryItem]) -> URL {

--- a/swifterpm/Sources/swifterpm/Remote.swift
+++ b/swifterpm/Sources/swifterpm/Remote.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct RemoteVersion: Codable, Sendable {
+struct RemoteVersion: Codable {
     let version: String
     let revision: String
 
@@ -54,19 +54,20 @@ enum RemoteMetadata {
     }
 
     private static func gitRemoteVersions(location: String) async throws -> [RemoteVersion] {
-        var lastError: (any Error)?
+        var attempts: [(candidate: String, error: any Error)] = []
         for candidate in SourceControlLocations.fetchCandidates(location) {
             do {
+                let authArguments = await GitTransportAuth.configArguments(for: candidate)
                 let output = try await SystemProcess.output(
-                    "/usr/bin/git", ["ls-remote", "--tags", candidate],
-                    environment: SystemProcess.nonInteractiveGitEnvironment)
+                    "/usr/bin/git", authArguments + ["ls-remote", "--tags", candidate],
+                    environment: SystemProcess.nonInteractiveGitEnvironment
+                )
                 return parseGitRemoteVersions(output)
             } catch {
-                lastError = error
+                attempts.append((candidate, error))
             }
         }
-        throw lastError
-            ?? ToolError.message("no source-control locations available for \(location)")
+        throw GitFetchFailure.error(location: location, attempts: attempts)
     }
 
     private static func parseGitRemoteVersions(_ output: String) -> [RemoteVersion] {
@@ -91,7 +92,8 @@ enum RemoteMetadata {
         for (tag, sha) in direct {
             guard let version = RemoteMetadata.parseSwiftTagVersion(tag) else { continue }
             versions.append(
-                RemoteVersion(version: version.description, revision: peeled[tag] ?? sha))
+                RemoteVersion(version: version.description, revision: peeled[tag] ?? sha)
+            )
         }
         return versions.sorted {
             SemVer.ascendingForSort(
@@ -113,21 +115,23 @@ enum RemoteMetadata {
         while true {
             let url = URL(
                 string:
-                    "https://api.github.com/repos/\(repo.owner)/\(repo.repo)/tags?per_page=100&page=\(page)"
+                "https://api.github.com/repos/\(repo.owner)/\(repo.repo)/tags?per_page=100&page=\(page)"
             )!
             var headers = ["User-Agent": "swifterpm/0.1"]
             if let token = await GitHubAuth.token() {
                 headers["Authorization"] = "Bearer \(token)"
             }
             let tags = try JSONDecoder().decode(
-                [TagsResponse].self, from: try await HTTPClient.data(url: url, headers: headers))
+                [TagsResponse].self, from: try await HTTPClient.data(url: url, headers: headers)
+            )
             if tags.isEmpty {
                 break
             }
             for tag in tags {
                 if let version = RemoteMetadata.parseSwiftTagVersion(tag.name) {
                     versions.append(
-                        RemoteVersion(version: version.description, revision: tag.commit.sha))
+                        RemoteVersion(version: version.description, revision: tag.commit.sha)
+                    )
                 }
             }
             page += 1
@@ -141,23 +145,25 @@ enum RemoteMetadata {
     }
 
     static func resolveNamedRef(location: String, name: String) async throws -> String {
-        var lastError: (any Error)?
+        var attempts: [(candidate: String, error: any Error)] = []
         for candidate in SourceControlLocations.fetchCandidates(location) {
             do {
+                let authArguments = await GitTransportAuth.configArguments(for: candidate)
                 let output = try await SystemProcess.output(
-                    "/usr/bin/git", ["ls-remote", candidate, name],
-                    environment: SystemProcess.nonInteractiveGitEnvironment)
+                    "/usr/bin/git", authArguments + ["ls-remote", candidate, name],
+                    environment: SystemProcess.nonInteractiveGitEnvironment
+                )
                 guard let line = output.split(separator: "\n").first,
-                    let revision = line.split(whereSeparator: \.isWhitespace).first
+                      let revision = line.split(whereSeparator: \.isWhitespace).first
                 else {
                     throw ToolError.message("\(name) was not found in \(candidate)")
                 }
                 return String(revision)
             } catch {
-                lastError = error
+                attempts.append((candidate, error))
             }
         }
-        throw lastError ?? ToolError.message("\(name) was not found in \(location)")
+        throw GitFetchFailure.error(location: location, attempts: attempts)
     }
 
     static func parseSwiftTagVersion(_ tag: String) -> SemVer? {
@@ -171,12 +177,13 @@ enum RemoteMetadata {
         let path = cache.remoteVersionsPath(location: location)
         guard try await fileSystem.exists(path.absolutePath) else { return nil }
         if let modified = try await fileSystem.fileMetadata(at: path.absolutePath)?.lastModificationDate,
-            Date().timeIntervalSince(modified) > 60 * 60
+           Date().timeIntervalSince(modified) > 60 * 60
         {
             return nil
         }
         let cached = try JSONDecoder().decode(
-            RemoteVersionsCache.self, from: try await fileSystem.readFile(at: path.absolutePath))
+            RemoteVersionsCache.self, from: try await fileSystem.readFile(at: path.absolutePath)
+        )
         guard cached.location == location else { return nil }
         return cached.versions
     }
@@ -188,8 +195,9 @@ enum RemoteMetadata {
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
         let data =
             try encoder.encode(RemoteVersionsCache(location: location, versions: versions))
-            + Data("\n".utf8)
+                + Data("\n".utf8)
         try await fileSystem.atomicWrite(
-            data, to: cache.remoteVersionsPath(location: location))
+            data, to: cache.remoteVersionsPath(location: location)
+        )
     }
 }

--- a/swifterpm/Sources/swifterpm/Restore.swift
+++ b/swifterpm/Sources/swifterpm/Restore.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum WorkspaceRestorer {
-    private struct PackageContext: Sendable {
+    private struct PackageContext {
         let packageRef: [String: String]
         let packagePath: URL
         let canonicalizeLocalBinaryPaths: Bool
@@ -26,7 +26,8 @@ enum WorkspaceRestorer {
         disableSandbox: Bool = false
     ) async throws {
         let scratchLock = try await PathLock.acquire(
-            at: scratchDir.appendingPathComponent(".swifterpm.lock"))
+            at: scratchDir.appendingPathComponent(".swifterpm.lock")
+        )
         _ = scratchLock
         let checkouts = scratchDir.appendingPathComponent("checkouts")
         let registryDownloads = scratchDir.appendingPathComponent("registry/downloads")
@@ -159,7 +160,8 @@ enum WorkspaceRestorer {
             )
 
             progress?.restoredBinaryArtifact(
-                identity: identity, target: target.name, path: cachedArtifact.path)
+                identity: identity, target: target.name, path: cachedArtifact.path
+            )
         case let .local(path):
             let artifactPath = binaryTargetPath(
                 path,
@@ -190,7 +192,8 @@ enum WorkspaceRestorer {
                 destination: scratchArtifact
             )
             progress?.restoredBinaryArtifact(
-                identity: identity, target: target.name, path: cachedArtifact.path)
+                identity: identity, target: target.name, path: cachedArtifact.path
+            )
         }
     }
 
@@ -360,7 +363,8 @@ enum WorkspaceRestorer {
                     packageRef: rootPackageRef(packageDir),
                     packagePath: packageDir,
                     canonicalizeLocalBinaryPaths: true
-                ))
+                )
+            )
             let manifest = try await ManifestLoader.dumpPackage(
                 packageDir: packageDir,
                 disableSandbox: disableSandbox
@@ -379,7 +383,8 @@ enum WorkspaceRestorer {
                         ),
                         packagePath: localPackage.packagePath,
                         canonicalizeLocalBinaryPaths: true
-                    ))
+                    )
+                )
             }
         }
 
@@ -397,7 +402,8 @@ enum WorkspaceRestorer {
                     ),
                     packagePath: packagePath,
                     canonicalizeLocalBinaryPaths: false
-                ))
+                )
+            )
         }
 
         return contexts
@@ -608,7 +614,8 @@ enum WorkspaceRestorer {
                 cache: cache, registryConfig: registryConfig, pin: pin
             )
             let download = try registryDownloads.appendingPathComponent(
-                PinKind.registryDownloadSubpath(pin))
+                PinKind.registryDownloadSubpath(pin)
+            )
             try await fileSystem.replaceWithSymlinkedDirectory(
                 source: source, destination: download
             )
@@ -728,7 +735,8 @@ enum WorkspaceRestorer {
             return
         }
         throw ToolError.message(
-            "no authenticated source archive endpoint available for \(pin.location)")
+            "no authenticated source archive endpoint available for \(pin.location)"
+        )
     }
 
     private static func downloadGitHubArchive(cache: Cache, pin: ResolvedPin, destination: URL)
@@ -785,7 +793,7 @@ enum WorkspaceRestorer {
 
     private static func shallowFetchCheckout(pin: ResolvedPin, destination: URL) async throws {
         let revision = try pin.revision()
-        var lastError: (any Error)?
+        var attempts: [(candidate: String, error: any Error)] = []
         for location in SourceControlLocations.fetchCandidates(pin.location) {
             do {
                 try await resetDirectory(destination)
@@ -793,9 +801,11 @@ enum WorkspaceRestorer {
                 try await SystemProcess.run(
                     "/usr/bin/git", ["-C", destination.path, "remote", "add", "origin", location]
                 )
+                let authArguments = await GitTransportAuth.configArguments(for: location)
                 try await SystemProcess.run(
                     "/usr/bin/git",
-                    ["-C", destination.path, "fetch", "--depth=1", "origin", revision],
+                    authArguments
+                        + ["-C", destination.path, "fetch", "--depth=1", "origin", revision],
                     environment: SystemProcess.nonInteractiveGitEnvironment
                 )
                 try await SystemProcess.run(
@@ -809,10 +819,10 @@ enum WorkspaceRestorer {
                 }
                 return
             } catch {
-                lastError = error
+                attempts.append((location, error))
             }
         }
-        throw lastError ?? ToolError.message("failed to fetch \(pin.location)")
+        throw GitFetchFailure.error(location: pin.location, attempts: attempts)
     }
 
     private static func rejectArchiveWithSubmodules(_ destination: URL) async throws {
@@ -1049,13 +1059,13 @@ enum WorkspaceRestorer {
                 "path": artifact.path.path,
                 "source": source,
                 "targetName": target.name,
-            ])
+            ]
+        )
     }
 
     private static func jsonPackageIdentity(_ object: [String: Any]) -> String {
-        guard
-            let packageRef = object["packageRef"] as? [String: Any],
-            let identity = packageRef["identity"] as? String
+        guard let packageRef = object["packageRef"] as? [String: Any],
+              let identity = packageRef["identity"] as? String
         else {
             return ""
         }

--- a/swifterpm/Sources/swifterpm/Support.swift
+++ b/swifterpm/Sources/swifterpm/Support.swift
@@ -30,18 +30,38 @@ enum ToolError: Error, CustomStringConvertible {
 
     var description: String {
         switch self {
-        case .message(let message):
+        case let .message(message):
             return message
         }
     }
 }
 
+/// Reports every candidate location that was tried and how each failed, instead of only the
+/// last error. The previous behaviour surfaced just `lastError`, which for an SSH-declared
+/// dependency is always the trailing SSH candidate, masking whether the HTTPS fallback was
+/// even attempted and why it failed. Listing each attempt makes the actual cause diagnosable.
+enum GitFetchFailure {
+    static func error(location: String, attempts: [(candidate: String, error: any Error)])
+        -> ToolError
+    {
+        guard !attempts.isEmpty else {
+            return ToolError.message("no source-control locations available for \(location)")
+        }
+        let details = attempts
+            .map { "  - \($0.candidate): \($0.error)" }
+            .joined(separator: "\n")
+        return ToolError.message(
+            "could not fetch any candidate location for \(location):\n\(details)"
+        )
+    }
+}
+
 enum SystemProcess {
-    // swifterpm invokes git non-interactively: output is captured and fetches run
-    // in parallel, so a built-in credential prompt (git opens /dev/tty directly)
-    // would block invisibly in any environment, not just CI. Force git to fail fast
-    // on a missing credential instead. Credential helpers, ssh-agent, and ~/.netrc
-    // are unaffected, so configured authentication still works.
+    /// swifterpm invokes git non-interactively: output is captured and fetches run
+    /// in parallel, so a built-in credential prompt (git opens /dev/tty directly)
+    /// would block invisibly in any environment, not just CI. Force git to fail fast
+    /// on a missing credential instead. Credential helpers, ssh-agent, and ~/.netrc
+    /// are unaffected, so configured authentication still works.
     static let nonInteractiveGitEnvironment = ["GIT_TERMINAL_PROMPT": "0"]
 
     struct Result {
@@ -97,7 +117,8 @@ enum SystemProcess {
             let stdoutText = String(data: Data(result.standardOutput), encoding: .utf8) ?? ""
             let message = stderrText.isEmpty ? stdoutText : stderrText
             throw ToolError.message(
-                message.isEmpty ? result.terminationStatus.description : message)
+                message.isEmpty ? result.terminationStatus.description : message
+            )
         }
 
         return Result(stdout: Data(result.standardOutput), stderr: Data(result.standardError))
@@ -161,7 +182,7 @@ enum HTTPClient {
         }
         let (data, response) = try await URLSession.shared.data(for: request)
         if let httpResponse = response as? HTTPURLResponse,
-            !(200..<300).contains(httpResponse.statusCode)
+           !(200 ..< 300).contains(httpResponse.statusCode)
         {
             throw ToolError.message("HTTP \(httpResponse.statusCode) for \(url.absoluteString)")
         }
@@ -175,7 +196,7 @@ enum HTTPClient {
         }
         let (downloaded, response) = try await URLSession.shared.download(for: request)
         if let httpResponse = response as? HTTPURLResponse,
-            !(200..<300).contains(httpResponse.statusCode)
+           !(200 ..< 300).contains(httpResponse.statusCode)
         {
             try? await fileSystem.remove(downloaded.absolutePath)
             throw ToolError.message("HTTP \(httpResponse.statusCode) for \(url.absoluteString)")
@@ -279,7 +300,7 @@ enum ConcurrentTasks {
         return try await withThrowingTaskGroup(of: (Int, Output).self) { group in
             var iterator = elements.enumerated().makeIterator()
             var activeTasks = 0
-            var results = Array<Output?>(repeating: nil, count: elements.count)
+            var results = [Output?](repeating: nil, count: elements.count)
 
             while activeTasks < limit, let (index, element) = iterator.next() {
                 group.addTask {
@@ -320,7 +341,7 @@ enum ConcurrentTasks {
     ) async throws {
         _ =
             try await map(elements, maxConcurrentTasks: maxConcurrentTasks, operation: operation)
-            as [Void]
+                as [Void]
     }
 }
 
@@ -329,7 +350,8 @@ final class PathLock: @unchecked Sendable {
 
     init(path: URL) throws {
         fd = open(
-            path.path, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH)
+            path.path, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH
+        )
         if fd < 0 {
             throw ToolError.message("failed to open lock \(path.path)")
         }
@@ -361,7 +383,8 @@ enum JSONFormatter {
     static func prettyData(_ object: Any) throws -> Data {
         let data = try JSONSerialization.data(
             withJSONObject: object,
-            options: [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes])
+            options: [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        )
         return data + Data("\n".utf8)
     }
 }
@@ -370,15 +393,16 @@ enum SafeFileName {
     static func make(_ name: String) -> String {
         String(
             name.map { character in
-                if character.isASCII
-                    && (character.isLetter || character.isNumber || character == "-"
-                        || character == "_"
-                        || character == ".")
+                if character.isASCII,
+                   character.isLetter || character.isNumber || character == "-"
+                   || character == "_"
+                   || character == "."
                 {
                     return character
                 }
                 return "_"
-            })
+            }
+        )
     }
 }
 

--- a/swifterpm/Tests/swifterpmTests/GitHubTests.swift
+++ b/swifterpm/Tests/swifterpmTests/GitHubTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 @testable import SwifterPMCore
 
@@ -32,52 +33,107 @@ struct GitHubTests {
                 "https://github.com/tuist/swifterpm",
                 "https://github.com/tuist/swifterpm.git",
                 "git@github.com:tuist/swifterpm.git",
-            ])
+            ]
+        )
         #expect(
             SourceControlLocations.fetchCandidates("git@github.com:tuist/swifterpm.git") == [
                 "git@github.com:tuist/swifterpm.git",
                 "https://github.com/tuist/swifterpm.git",
-            ])
+            ]
+        )
         #expect(
             SourceControlLocations.fetchCandidates("https://gitlab.com/tuist/swifterpm") == [
                 "https://gitlab.com/tuist/swifterpm",
                 "https://gitlab.com/tuist/swifterpm.git",
                 "git@gitlab.com:tuist/swifterpm.git",
-            ])
+            ]
+        )
     }
 
     @Test
     func sourceControlFetchLocationsAddHTTPSFallbackForSSHOrigin() {
         #expect(
             SourceControlLocations.fetchCandidates(
-                "git@github.com:acme/private-lib") == [
+                "git@github.com:acme/private-lib"
+            ) == [
                 "git@github.com:acme/private-lib",
                 "https://github.com/acme/private-lib.git",
                 "git@github.com:acme/private-lib.git",
-            ])
+            ]
+        )
+    }
+
+    @Test
+    func gitHubTransportAuthInjectsBearerTokenAsBasicExtraHeader() {
+        let encoded = Data("x-access-token:ghp_secret".utf8).base64EncodedString()
+        #expect(
+            GitTransportAuth.gitHubArguments(token: "ghp_secret") == [
+                "-c", "http.https://github.com/.extraheader=Authorization: Basic \(encoded)",
+            ]
+        )
+    }
+
+    @Test
+    func gitLabTransportAuthMapsTokenKindsToGitHTTPCredentials() {
+        let privateEncoded = Data("oauth2:glpat_secret".utf8).base64EncodedString()
+        #expect(
+            GitTransportAuth.gitLabArguments(
+                host: "gitlab.com", token: .privateToken("glpat_secret")
+            ) == [
+                "-c", "http.https://gitlab.com/.extraheader=Authorization: Basic \(privateEncoded)",
+            ]
+        )
+
+        let jobEncoded = Data("gitlab-ci-token:job_secret".utf8).base64EncodedString()
+        #expect(
+            GitTransportAuth.gitLabArguments(host: "gitlab.com", token: .jobToken("job_secret")) == [
+                "-c", "http.https://gitlab.com/.extraheader=Authorization: Basic \(jobEncoded)",
+            ]
+        )
+
+        #expect(
+            GitTransportAuth.gitLabArguments(host: "gitlab.com", token: .bearer("oauth_secret")) == [
+                "-c", "http.https://gitlab.com/.extraheader=Authorization: Bearer oauth_secret",
+            ]
+        )
+    }
+
+    @Test
+    func gitTransportAuthAddsNoArgumentsForSSHLocations() async {
+        #expect(await GitTransportAuth.configArguments(for: "git@github.com:acme/private-lib.git") == [])
     }
 
     @Test
     func canonicalResolvedFileLocationsStabilizeProviderLocations() {
         #expect(
             SourceControlLocations.canonicalResolvedFileLocation(
-                "https://github.com/CombineCommunity/CombineExt.git")
-                == "https://github.com/combinecommunity/combineext")
+                "https://github.com/CombineCommunity/CombineExt.git"
+            )
+                == "https://github.com/combinecommunity/combineext"
+        )
         #expect(
             SourceControlLocations.canonicalResolvedFileLocation(
-                "git@github.com:DataDog/dd-sdk-ios.git")
-                == "git@github.com:datadog/dd-sdk-ios")
+                "git@github.com:DataDog/dd-sdk-ios.git"
+            )
+                == "git@github.com:datadog/dd-sdk-ios"
+        )
         #expect(
             SourceControlLocations.canonicalResolvedFileLocation(
-                "https://gitlab.com/Tuist/SwifterPM.git")
-                == "https://gitlab.com/tuist/swifterpm")
+                "https://gitlab.com/Tuist/SwifterPM.git"
+            )
+                == "https://gitlab.com/tuist/swifterpm"
+        )
         #expect(
             SourceControlLocations.canonicalResolvedFileLocation(
-                "HTTPS://Source.Example.com/Tuist/SwifterPM.git")
-                == "https://source.example.com/Tuist/SwifterPM.git")
+                "HTTPS://Source.Example.com/Tuist/SwifterPM.git"
+            )
+                == "https://source.example.com/Tuist/SwifterPM.git"
+        )
         #expect(
             SourceControlLocations.canonicalResolvedFileLocation(
-                "git@Source.Example.com:Tuist/SwifterPM.git")
-                == "git@source.example.com:Tuist/SwifterPM.git")
+                "git@Source.Example.com:Tuist/SwifterPM.git"
+            )
+                == "git@source.example.com:Tuist/SwifterPM.git"
+        )
     }
 }


### PR DESCRIPTION
## What changed

Two follow-ups to #11490, which added an HTTPS fetch fallback for SSH-declared dependencies:

1. **The HTTPS fallback now carries a credential.** When a fetch candidate is an HTTPS GitHub/GitLab URL and swifterpm can discover a token (`GITHUB_TOKEN`/`GH_TOKEN`/`gh`, or `GITLAB_TOKEN`/`CI_JOB_TOKEN`/`glab`), it injects `-c http.<base>.extraheader=Authorization: …` into the `git fetch`/`ls-remote` invocation — the same mechanism `actions/checkout` uses. Wired into all three git paths: `shallowFetchCheckout` and both `ls-remote` resolution paths.
2. **The fetch error now lists every attempted candidate** and its individual failure, instead of only the last one.

## Why

The fallback from #11490 added a *route* but not a *credential*. `shallowFetchCheckout`/`ls-remote` shelled out to plain `git`, so the HTTPS candidate only authenticated when an ambient credential happened to be configured (a `url.<base>.insteadOf` token rewrite, a credential helper, or `~/.netrc`). A private dependency declared over SSH therefore kept failing in CI **even with a usable `GITHUB_TOKEN`/`GH_TOKEN` in the environment**, because the authenticated API-tarball path and the `git` fetch path drew their credentials from different sources. The fallback was weaker than it looked.

This was hard to see because the thrown error only surfaced `lastError`. For an SSH-declared dependency the candidate order is `[ssh, https, ssh.git]`, so the reported error was always the trailing SSH candidate (`Permission denied (publickey)`) — masking whether the HTTPS candidate was even attempted and how it failed.

## How

- New `GitTransportAuth.configArguments(for:)` returns the `-c http.<base>.extraheader=Authorization: …` arguments for an HTTPS candidate when a provider token is available. Token kind maps to the credential form git transport accepts:
  - GitHub → `Basic base64(x-access-token:<token>)`
  - GitLab personal access token → `Basic base64(oauth2:<token>)`; CI job token → `Basic base64(gitlab-ci-token:<token>)`; OAuth → `Bearer <token>`
- The token is passed with `-c`, so it is **never written to the on-disk git config**. SSH candidates get no arguments (ssh-agent stays in charge), and when no token is available nothing is added, so configured ambient credentials keep working unchanged. `GIT_TERMINAL_PROMPT=0` still makes a wrong/expired credential fail fast instead of prompting.
- New `GitFetchFailure` aggregates the per-candidate errors into a single message, e.g.:

  ```
  could not fetch any candidate location for git@github.com:owner/private-lib:
    - git@github.com:owner/private-lib: …Permission denied (publickey).
    - https://github.com/owner/private-lib.git: …HTTP 403 / Authentication failed
    - git@github.com:owner/private-lib.git: …Permission denied (publickey).
  ```

## Relation to swift-package-manager

SwiftPM's `GitRepositoryProvider` shells out to the system `git` binary (via `GitShellHelper`/`AsyncProcess`), just like swifterpm — it does not use libgit2. It clones the *exact* resolved URL without deriving SSH/HTTPS alternates, injects only `-c http.lowSpeedLimit`/`http.lowSpeedTime` network-stall guards, and delegates *all* authentication to git's own credential resolution (credential helpers, `url.<base>.insteadOf` rewrites, `~/.netrc`, ssh-agent) inherited from the environment and global git config.

swifterpm already honours every one of those ambient mechanisms — it inherits the environment and global git config — so it matches SwiftPM whenever git itself can resolve the credential for the remote. The gap this PR closes is the one case SwiftPM punts entirely to user configuration: a provider token that is present in the environment (`GH_TOKEN`/`GITLAB_TOKEN`/etc.) but has no corresponding git credential configured. swifterpm discovers that token for its API-tarball path already; this wires the same token into the `git` HTTPS fetch so the two paths stop drawing credentials from different sources.

## Scope / limitation

This widens what *authenticates*; it cannot grant *access*. The provided token must actually be able to read the private dependency. In particular, the default GitHub Actions `GITHUB_TOKEN` cannot reach a different private repository — that requires a PAT, a GitHub App installation token, or an SSH deploy key. With these changes, exposing such a token as `GH_TOKEN`/`GITHUB_TOKEN` is sufficient; without one, no code change can help.

## Validation

- `swift build --replace-scm-with-registry` on `main`: clean.
- Full swifterpm suite (112 tests) passes; added unit tests for the GitHub/GitLab argument builders and the SSH no-op case.
- Confirmed real `git` parses the emitted `-c http.https://github.com/.extraheader=…` form correctly (subsection extracted, header value preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
