### PR TITLE
fix(server): surface cache store failures + harden S3 boundary

### DIFF
--- a/cache/lib/cache_web/api/schemas/multipart_upload/start_multipart_upload_response.ex
+++ b/cache/lib/cache_web/api/schemas/multipart_upload/start_multipart_upload_response.ex
@@ -11,7 +11,9 @@ defmodule CacheWeb.API.Schemas.StartMultipartUploadResponse do
     properties: %{
       upload_id: %Schema{
         type: :string,
-        description: "The upload ID to use for subsequent part uploads."
+        nullable: true,
+        description:
+          "The upload ID to use for subsequent part uploads. Null on the legacy cache-hit response returned to CLIs that predate the 204 No Content signal."
       }
     },
     required: [:upload_id]

--- a/cache/lib/cache_web/api/schemas/multipart_upload/start_multipart_upload_response.ex
+++ b/cache/lib/cache_web/api/schemas/multipart_upload/start_multipart_upload_response.ex
@@ -13,6 +13,11 @@ defmodule CacheWeb.API.Schemas.StartMultipartUploadResponse do
         type: :string,
         nullable: true,
         description: "The upload ID to use for subsequent part uploads. Null if artifact already exists."
+      },
+      already_cached: %Schema{
+        type: :boolean,
+        description:
+          "Whether the artifact is already cached. When true, upload_id is null and no upload is needed; when false, upload_id carries the id for the parts. Lets clients tell a cache hit apart from a failure instead of inferring it from a null upload_id. Optional so clients stay compatible with older servers that don't send it."
       }
     },
     required: [:upload_id]

--- a/cache/lib/cache_web/api/schemas/multipart_upload/start_multipart_upload_response.ex
+++ b/cache/lib/cache_web/api/schemas/multipart_upload/start_multipart_upload_response.ex
@@ -11,13 +11,7 @@ defmodule CacheWeb.API.Schemas.StartMultipartUploadResponse do
     properties: %{
       upload_id: %Schema{
         type: :string,
-        nullable: true,
-        description: "The upload ID to use for subsequent part uploads. Null if artifact already exists."
-      },
-      already_cached: %Schema{
-        type: :boolean,
-        description:
-          "Whether the artifact is already cached. When true, upload_id is null and no upload is needed; when false, upload_id carries the id for the parts. Lets clients tell a cache hit apart from a failure instead of inferring it from a null upload_id. Optional so clients stay compatible with older servers that don't send it."
+        description: "The upload ID to use for subsequent part uploads."
       }
     },
     required: [:upload_id]

--- a/cache/lib/cache_web/controllers/xcode_module_controller.ex
+++ b/cache/lib/cache_web/controllers/xcode_module_controller.ex
@@ -23,6 +23,13 @@ defmodule CacheWeb.XcodeModuleController do
 
   @max_part_size 10 * 1024 * 1024
 
+  # First CLI version that understands a 204 on `start_multipart` as "already
+  # cached, skip the upload". Older clients only know the legacy 200 + null
+  # upload id, so they keep getting that. The header is sent only by clients
+  # that carry this change, so any parseable version here is new enough; the
+  # floor is a conservative lower bound (latest released CLI is 4.200.5).
+  @min_cli_version_for_no_content Version.parse!("4.200.6")
+
   operation(:download,
     summary: "Download a module cache artifact",
     operation_id: "downloadModuleCacheArtifact",
@@ -233,7 +240,11 @@ defmodule CacheWeb.XcodeModuleController do
     category = Map.get(params, :cache_category, "builds")
 
     if Disk.exists?(account_handle, project_handle, category, hash, name) do
-      send_resp(conn, :no_content, "")
+      if no_content_supported?(conn) do
+        send_resp(conn, :no_content, "")
+      else
+        json(conn, %{upload_id: nil})
+      end
     else
       case MultipartUploads.start_upload(account_handle, project_handle, category, hash, name) do
         {:ok, upload_id} ->
@@ -243,6 +254,15 @@ defmodule CacheWeb.XcodeModuleController do
         {:error, _reason} ->
           {:error, :persist_error}
       end
+    end
+  end
+
+  defp no_content_supported?(conn) do
+    with [version_string | _] <- get_req_header(conn, "x-tuist-cli-version"),
+         {:ok, version} <- Version.parse(version_string) do
+      Version.compare(version, @min_cli_version_for_no_content) != :lt
+    else
+      _ -> false
     end
   end
 

--- a/cache/lib/cache_web/controllers/xcode_module_controller.ex
+++ b/cache/lib/cache_web/controllers/xcode_module_controller.ex
@@ -232,12 +232,12 @@ defmodule CacheWeb.XcodeModuleController do
     category = Map.get(params, :cache_category, "builds")
 
     if Disk.exists?(account_handle, project_handle, category, hash, name) do
-      json(conn, %{upload_id: nil})
+      json(conn, %{upload_id: nil, already_cached: true})
     else
       case MultipartUploads.start_upload(account_handle, project_handle, category, hash, name) do
         {:ok, upload_id} ->
           :telemetry.execute([:cache, :xcode_module, :multipart, :start], %{}, %{})
-          json(conn, %{upload_id: upload_id})
+          json(conn, %{upload_id: upload_id, already_cached: false})
 
         {:error, _reason} ->
           {:error, :persist_error}

--- a/cache/lib/cache_web/controllers/xcode_module_controller.ex
+++ b/cache/lib/cache_web/controllers/xcode_module_controller.ex
@@ -25,10 +25,14 @@ defmodule CacheWeb.XcodeModuleController do
 
   # First CLI version that understands a 204 on `start_multipart` as "already
   # cached, skip the upload". Older clients only know the legacy 200 + null
-  # upload id, so they keep getting that. The header is sent only by clients
-  # that carry this change, so any parseable version here is new enough; the
-  # floor is a conservative lower bound (latest released CLI is 4.200.5).
-  @min_cli_version_for_no_content Version.parse!("4.200.6")
+  # upload id, so they keep getting that. This change lands on `main`, which
+  # currently cuts the 4.202.0 release line (canaries/RCs of the next minor).
+  # The `-0` pre-release sentinel is deliberate: `4.202.0-canary.N` and
+  # `4.202.0-rc.N` sort *below* `4.202.0` in semver, so a plain `4.202.0` floor
+  # would exclude the canaries and RCs that first carry this change. `-0` is the
+  # lowest possible pre-release, so every 4.202.0 build (canary, rc, stable) and
+  # anything newer qualifies, while 4.201.x and earlier do not.
+  @min_cli_version_for_no_content Version.parse!("4.202.0-0")
 
   operation(:download,
     summary: "Download a module cache artifact",

--- a/cache/lib/cache_web/controllers/xcode_module_controller.ex
+++ b/cache/lib/cache_web/controllers/xcode_module_controller.ex
@@ -219,6 +219,7 @@ defmodule CacheWeb.XcodeModuleController do
     ],
     responses: %{
       ok: {"Upload started", "application/json", StartMultipartUploadResponse},
+      no_content: {"Artifact already cached, no upload needed", nil, nil},
       unauthorized: {"Unauthorized", "application/json", Error},
       forbidden: {"Forbidden", "application/json", Error},
       unprocessable_entity: {"Invalid request parameters", "application/json", Error}
@@ -232,12 +233,12 @@ defmodule CacheWeb.XcodeModuleController do
     category = Map.get(params, :cache_category, "builds")
 
     if Disk.exists?(account_handle, project_handle, category, hash, name) do
-      json(conn, %{upload_id: nil, already_cached: true})
+      send_resp(conn, :no_content, "")
     else
       case MultipartUploads.start_upload(account_handle, project_handle, category, hash, name) do
         {:ok, upload_id} ->
           :telemetry.execute([:cache, :xcode_module, :multipart, :start], %{}, %{})
-          json(conn, %{upload_id: upload_id, already_cached: false})
+          json(conn, %{upload_id: upload_id})
 
         {:error, _reason} ->
           {:error, :persist_error}

--- a/cache/test/cache_web/controllers/xcode_module_controller_test.exs
+++ b/cache/test/cache_web/controllers/xcode_module_controller_test.exs
@@ -291,6 +291,7 @@ defmodule CacheWeb.XcodeModuleControllerTest do
       response = json_response(conn, 200)
       assert is_binary(response["upload_id"])
       assert String.length(response["upload_id"]) == 36
+      assert response["already_cached"] == false
     end
 
     test "returns null upload_id when artifact already exists", %{conn: conn} do
@@ -317,6 +318,7 @@ defmodule CacheWeb.XcodeModuleControllerTest do
       assert conn.status == 200
       response = json_response(conn, 200)
       assert response["upload_id"] == nil
+      assert response["already_cached"] == true
     end
 
     test "uses cache_category parameter when provided", %{conn: conn} do

--- a/cache/test/cache_web/controllers/xcode_module_controller_test.exs
+++ b/cache/test/cache_web/controllers/xcode_module_controller_test.exs
@@ -293,7 +293,33 @@ defmodule CacheWeb.XcodeModuleControllerTest do
       assert String.length(response["upload_id"]) == 36
     end
 
-    test "returns 204 when artifact already exists", %{conn: conn} do
+    test "returns 204 when the artifact exists and the CLI advertises a new enough version", %{conn: conn} do
+      account_handle = "test-account"
+      project_handle = "test-project"
+      hash = "abc123"
+      name = "MyModule.xcframework.zip"
+
+      expect(Authentication, :ensure_project_accessible, fn _conn, "test-account", "test-project" ->
+        {:ok, "Bearer valid-token"}
+      end)
+
+      expect(XcodeModule.Disk, :exists?, fn "test-account", "test-project", "builds", ^hash, ^name ->
+        true
+      end)
+
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer valid-token")
+        |> put_req_header("x-tuist-cli-version", "4.200.6")
+        |> post(
+          "/api/cache/module/start?account_handle=#{account_handle}&project_handle=#{project_handle}&hash=#{hash}&name=#{name}"
+        )
+
+      assert conn.status == 204
+      assert response(conn, 204) == ""
+    end
+
+    test "returns a null upload_id when the artifact exists but no CLI version is advertised", %{conn: conn} do
       account_handle = "test-account"
       project_handle = "test-project"
       hash = "abc123"
@@ -314,8 +340,34 @@ defmodule CacheWeb.XcodeModuleControllerTest do
           "/api/cache/module/start?account_handle=#{account_handle}&project_handle=#{project_handle}&hash=#{hash}&name=#{name}"
         )
 
-      assert conn.status == 204
-      assert response(conn, 204) == ""
+      assert conn.status == 200
+      assert json_response(conn, 200)["upload_id"] == nil
+    end
+
+    test "returns a null upload_id when the artifact exists but the CLI predates the 204 signal", %{conn: conn} do
+      account_handle = "test-account"
+      project_handle = "test-project"
+      hash = "abc123"
+      name = "MyModule.xcframework.zip"
+
+      expect(Authentication, :ensure_project_accessible, fn _conn, "test-account", "test-project" ->
+        {:ok, "Bearer valid-token"}
+      end)
+
+      expect(XcodeModule.Disk, :exists?, fn "test-account", "test-project", "builds", ^hash, ^name ->
+        true
+      end)
+
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer valid-token")
+        |> put_req_header("x-tuist-cli-version", "4.200.5")
+        |> post(
+          "/api/cache/module/start?account_handle=#{account_handle}&project_handle=#{project_handle}&hash=#{hash}&name=#{name}"
+        )
+
+      assert conn.status == 200
+      assert json_response(conn, 200)["upload_id"] == nil
     end
 
     test "uses cache_category parameter when provided", %{conn: conn} do

--- a/cache/test/cache_web/controllers/xcode_module_controller_test.exs
+++ b/cache/test/cache_web/controllers/xcode_module_controller_test.exs
@@ -293,7 +293,9 @@ defmodule CacheWeb.XcodeModuleControllerTest do
       assert String.length(response["upload_id"]) == 36
     end
 
-    test "returns 204 when the artifact exists and the CLI advertises a new enough version", %{conn: conn} do
+    test "returns 204 when the artifact exists and the CLI advertises a new enough version (incl. canary)", %{
+      conn: conn
+    } do
       account_handle = "test-account"
       project_handle = "test-project"
       hash = "abc123"
@@ -310,7 +312,7 @@ defmodule CacheWeb.XcodeModuleControllerTest do
       conn =
         conn
         |> put_req_header("authorization", "Bearer valid-token")
-        |> put_req_header("x-tuist-cli-version", "4.200.6")
+        |> put_req_header("x-tuist-cli-version", "4.202.0-canary.7")
         |> post(
           "/api/cache/module/start?account_handle=#{account_handle}&project_handle=#{project_handle}&hash=#{hash}&name=#{name}"
         )
@@ -361,7 +363,7 @@ defmodule CacheWeb.XcodeModuleControllerTest do
       conn =
         conn
         |> put_req_header("authorization", "Bearer valid-token")
-        |> put_req_header("x-tuist-cli-version", "4.200.5")
+        |> put_req_header("x-tuist-cli-version", "4.201.0-rc.2")
         |> post(
           "/api/cache/module/start?account_handle=#{account_handle}&project_handle=#{project_handle}&hash=#{hash}&name=#{name}"
         )

--- a/cache/test/cache_web/controllers/xcode_module_controller_test.exs
+++ b/cache/test/cache_web/controllers/xcode_module_controller_test.exs
@@ -291,10 +291,9 @@ defmodule CacheWeb.XcodeModuleControllerTest do
       response = json_response(conn, 200)
       assert is_binary(response["upload_id"])
       assert String.length(response["upload_id"]) == 36
-      assert response["already_cached"] == false
     end
 
-    test "returns null upload_id when artifact already exists", %{conn: conn} do
+    test "returns 204 when artifact already exists", %{conn: conn} do
       account_handle = "test-account"
       project_handle = "test-project"
       hash = "abc123"
@@ -315,10 +314,8 @@ defmodule CacheWeb.XcodeModuleControllerTest do
           "/api/cache/module/start?account_handle=#{account_handle}&project_handle=#{project_handle}&hash=#{hash}&name=#{name}"
         )
 
-      assert conn.status == 200
-      response = json_response(conn, 200)
-      assert response["upload_id"] == nil
-      assert response["already_cached"] == true
+      assert conn.status == 204
+      assert response(conn, 204) == ""
     end
 
     test "uses cache_category parameter when provided", %{conn: conn} do

--- a/cli/Sources/TuistCache/Client/Client+Cache.swift
+++ b/cli/Sources/TuistCache/Client/Client+Cache.swift
@@ -20,6 +20,10 @@ extension Client {
             transport: TuistURLSessionTransport(),
             middlewares: HARRecordingMiddlewareFactory.middlewares() + [
                 RequestIdMiddleware(),
+                // Advertise the CLI version so the cache server can return 204 on an
+                // already-cached upload start only to CLIs new enough to understand it,
+                // falling back to the legacy 200 + null upload id for older clients.
+                ServerClientCLIMetadataHeadersMiddleware(),
                 CacheClientAuthenticationMiddleware(
                     authenticationURL: authenticationURL,
                     serverAuthenticationController: serverAuthenticationController

--- a/cli/Sources/TuistCache/OpenAPI/Client.swift
+++ b/cli/Sources/TuistCache/OpenAPI/Client.swift
@@ -1261,6 +1261,8 @@ public struct Client: APIProtocol {
                         preconditionFailure("bestContentType chose an invalid content type.")
                     }
                     return .ok(.init(body: body))
+                case 204:
+                    return .noContent(.init())
                 case 400:
                     let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
                     let body: Operations.startModuleCacheMultipartUpload.Output.BadRequest.Body

--- a/cli/Sources/TuistCache/OpenAPI/Types.swift
+++ b/cli/Sources/TuistCache/OpenAPI/Types.swift
@@ -3057,6 +3057,41 @@ public enum Operations {
                     }
                 }
             }
+            public struct NoContent: Sendable, Hashable {
+                /// Creates a new `NoContent`.
+                public init() {}
+            }
+            /// Artifact already cached, no upload needed
+            ///
+            /// - Remark: Generated from `#/paths//api/cache/module/start/post(startModuleCacheMultipartUpload)/responses/204`.
+            ///
+            /// HTTP response code: `204 noContent`.
+            case noContent(Operations.startModuleCacheMultipartUpload.Output.NoContent)
+            /// Artifact already cached, no upload needed
+            ///
+            /// - Remark: Generated from `#/paths//api/cache/module/start/post(startModuleCacheMultipartUpload)/responses/204`.
+            ///
+            /// HTTP response code: `204 noContent`.
+            public static var noContent: Self {
+                .noContent(.init())
+            }
+            /// The associated value of the enum case if `self` is `.noContent`.
+            ///
+            /// - Throws: An error if `self` is not `.noContent`.
+            /// - SeeAlso: `.noContent`.
+            public var noContent: Operations.startModuleCacheMultipartUpload.Output.NoContent {
+                get throws {
+                    switch self {
+                    case let .noContent(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "noContent",
+                            response: self
+                        )
+                    }
+                }
+            }
             public struct BadRequest: Sendable, Hashable {
                 /// - Remark: Generated from `#/paths/api/cache/module/start/POST/responses/400/content`.
                 @frozen public enum Body: Sendable, Hashable {

--- a/cli/Sources/TuistCache/OpenAPI/cache.yml
+++ b/cli/Sources/TuistCache/OpenAPI/cache.yml
@@ -62,7 +62,8 @@ components:
       description: Response from starting a multipart upload
       properties:
         upload_id:
-          description: The upload ID to use for subsequent part uploads.
+          description: The upload ID to use for subsequent part uploads. Null on the legacy cache-hit response returned to CLIs that predate the 204 No Content signal.
+          nullable: true
           type: string
           x-struct:
           x-validate:

--- a/cli/Sources/TuistCache/OpenAPI/cache.yml
+++ b/cli/Sources/TuistCache/OpenAPI/cache.yml
@@ -61,14 +61,8 @@ components:
     StartMultipartUploadResponse:
       description: Response from starting a multipart upload
       properties:
-        already_cached:
-          description: Whether the artifact is already cached. When true, upload_id is null and no upload is needed; when false, upload_id carries the id for the parts. Lets clients tell a cache hit apart from a failure instead of inferring it from a null upload_id. Optional so clients stay compatible with older servers that don't send it.
-          type: boolean
-          x-struct:
-          x-validate:
         upload_id:
-          description: The upload ID to use for subsequent part uploads. Null if artifact already exists.
-          nullable: true
+          description: The upload ID to use for subsequent part uploads.
           type: string
           x-struct:
           x-validate:
@@ -610,6 +604,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/StartMultipartUploadResponse'
           description: Upload started
+        '204':
+          description: Artifact already cached, no upload needed
         '400':
           content:
             application/json:

--- a/cli/Sources/TuistCache/OpenAPI/cache.yml
+++ b/cli/Sources/TuistCache/OpenAPI/cache.yml
@@ -61,6 +61,11 @@ components:
     StartMultipartUploadResponse:
       description: Response from starting a multipart upload
       properties:
+        already_cached:
+          description: Whether the artifact is already cached. When true, upload_id is null and no upload is needed; when false, upload_id carries the id for the parts. Lets clients tell a cache hit apart from a failure instead of inferring it from a null upload_id. Optional so clients stay compatible with older servers that don't send it.
+          type: boolean
+          x-struct:
+          x-validate:
         upload_id:
           description: The upload ID to use for subsequent part uploads. Null if artifact already exists.
           nullable: true

--- a/cli/Sources/TuistCache/Services/MultipartModuleCacheUploadService.swift
+++ b/cli/Sources/TuistCache/Services/MultipartModuleCacheUploadService.swift
@@ -61,73 +61,85 @@ public struct MultipartModuleCacheUploadService: MultipartModuleCacheUploadServi
         authenticationURL: URL,
         serverAuthenticationController: ServerAuthenticationControlling
     ) async throws {
-        guard let uploadId = try await startUploadService.startUpload(
-            accountHandle: accountHandle,
-            projectHandle: projectHandle,
-            hash: hash,
-            name: name,
-            cacheCategory: cacheCategory,
-            serverURL: serverURL,
-            authenticationURL: authenticationURL,
-            serverAuthenticationController: serverAuthenticationController
-        ) else {
-            return
-        }
+        do {
+            guard let uploadId = try await startUploadService.startUpload(
+                accountHandle: accountHandle,
+                projectHandle: projectHandle,
+                hash: hash,
+                name: name,
+                cacheCategory: cacheCategory,
+                serverURL: serverURL,
+                authenticationURL: authenticationURL,
+                serverAuthenticationController: serverAuthenticationController
+            ) else {
+                // A nil upload id is the server's "already cached, nothing to upload"
+                // signal, not a failure.
+                Logger.current.debug("Module cache artifact \(name) is already stored remotely; skipping upload.")
+                return
+            }
 
-        guard FileManager.default.fileExists(atPath: artifactPath.pathString) else {
-            throw MultipartModuleCacheUploadServiceError.fileNotFound(artifactPath)
-        }
+            guard FileManager.default.fileExists(atPath: artifactPath.pathString) else {
+                throw MultipartModuleCacheUploadServiceError.fileNotFound(artifactPath)
+            }
 
-        guard let inputStream = InputStream(fileAtPath: artifactPath.pathString) else {
-            throw MultipartModuleCacheUploadServiceError.fileNotFound(artifactPath)
-        }
+            guard let inputStream = InputStream(fileAtPath: artifactPath.pathString) else {
+                throw MultipartModuleCacheUploadServiceError.fileNotFound(artifactPath)
+            }
 
-        inputStream.open()
-        defer { inputStream.close() }
+            inputStream.open()
+            defer { inputStream.close() }
 
-        var partNumber = 1
-        var uploadedParts: [Int] = []
-        var buffer = [UInt8](repeating: 0, count: Self.partSize)
+            var partNumber = 1
+            var uploadedParts: [Int] = []
+            var buffer = [UInt8](repeating: 0, count: Self.partSize)
 
-        while inputStream.hasBytesAvailable {
-            let bytesRead = inputStream.read(&buffer, maxLength: Self.partSize)
+            while inputStream.hasBytesAvailable {
+                let bytesRead = inputStream.read(&buffer, maxLength: Self.partSize)
 
-            if bytesRead < 0 {
-                if let error = inputStream.streamError {
-                    throw MultipartModuleCacheUploadServiceError.fileReadError(artifactPath, error)
+                if bytesRead < 0 {
+                    if let error = inputStream.streamError {
+                        throw MultipartModuleCacheUploadServiceError.fileReadError(artifactPath, error)
+                    }
+                    break
                 }
-                break
+
+                if bytesRead == 0 {
+                    break
+                }
+
+                let partData = Data(bytes: buffer, count: bytesRead)
+
+                try await uploadPartService.uploadPart(
+                    accountHandle: accountHandle,
+                    projectHandle: projectHandle,
+                    uploadId: uploadId,
+                    partNumber: partNumber,
+                    data: partData,
+                    serverURL: serverURL,
+                    authenticationURL: authenticationURL,
+                    serverAuthenticationController: serverAuthenticationController
+                )
+
+                uploadedParts.append(partNumber)
+                partNumber += 1
             }
 
-            if bytesRead == 0 {
-                break
-            }
-
-            let partData = Data(bytes: buffer, count: bytesRead)
-
-            try await uploadPartService.uploadPart(
+            try await completeUploadService.completeUpload(
                 accountHandle: accountHandle,
                 projectHandle: projectHandle,
                 uploadId: uploadId,
-                partNumber: partNumber,
-                data: partData,
+                parts: uploadedParts,
                 serverURL: serverURL,
                 authenticationURL: authenticationURL,
                 serverAuthenticationController: serverAuthenticationController
             )
-
-            uploadedParts.append(partNumber)
-            partNumber += 1
+        } catch {
+            // Storing to the remote module cache is best-effort: a failed store must
+            // surface a clear diagnostic instead of being silently dropped (the
+            // failure mode that made this hard to debug). We log a warning and
+            // rethrow so the caller still decides whether the build should continue.
+            Logger.current.warning("Failed to store the module cache artifact \(name): \(error.localizedDescription)")
+            throw error
         }
-
-        try await completeUploadService.completeUpload(
-            accountHandle: accountHandle,
-            projectHandle: projectHandle,
-            uploadId: uploadId,
-            parts: uploadedParts,
-            serverURL: serverURL,
-            authenticationURL: authenticationURL,
-            serverAuthenticationController: serverAuthenticationController
-        )
     }
 }

--- a/cli/Sources/TuistCache/Services/StartModuleCacheMultipartUploadService.swift
+++ b/cli/Sources/TuistCache/Services/StartModuleCacheMultipartUploadService.swift
@@ -74,6 +74,9 @@ public struct StartModuleCacheMultipartUploadService: StartModuleCacheMultipartU
             case let .json(body):
                 return body.upload_id
             }
+        case .noContent:
+            // 204 is the server's "already cached, nothing to upload" signal.
+            return nil
         case let .unauthorized(unauthorized):
             switch unauthorized.body {
             case let .json(error):

--- a/cli/Sources/TuistServer/Client/ServerClientCLIMetadataHeadersMiddleware.swift
+++ b/cli/Sources/TuistServer/Client/ServerClientCLIMetadataHeadersMiddleware.swift
@@ -8,10 +8,12 @@ import OpenAPIRuntime
 
 /// This middleware includes the release date of the CLI in the headers so that we can show
 /// warnings if the on-premise installation is too old.
-struct ServerClientCLIMetadataHeadersMiddleware: ClientMiddleware {
+public struct ServerClientCLIMetadataHeadersMiddleware: ClientMiddleware {
     let releaseDate = "2024.09.26"
 
-    func intercept(
+    public init() {}
+
+    public func intercept(
         _ request: HTTPRequest,
         body: HTTPBody?,
         baseURL: URL,

--- a/kura/src/http.rs
+++ b/kura/src/http.rs
@@ -1494,7 +1494,12 @@ async fn start_module_upload(
         )
         .await
     {
+        // A null `upload_id` is the contract for "the artifact is already cached,
+        // skip the upload" — not a failure. The metric below lets operators tell
+        // already-cached starts apart from genuine failures so a write that never
+        // lands is observable instead of looking like a silent success.
         Ok(true) => {
+            state.metrics.record_multipart_start("already_exists");
             Json(serde_json::json!({ "upload_id": serde_json::Value::Null })).into_response()
         }
         Ok(false) => match state.store.start_multipart_upload(
@@ -1504,16 +1509,37 @@ async fn start_module_upload(
             &query.hash,
             &query.name,
         ) {
-            Ok(upload_id) => Json(serde_json::json!({ "upload_id": upload_id })).into_response(),
-            Err(error) => error_response(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to start upload: {error}"),
-            ),
+            Ok(upload_id) => {
+                state.metrics.record_multipart_start("started");
+                Json(serde_json::json!({ "upload_id": upload_id })).into_response()
+            }
+            Err(error) => {
+                state.metrics.record_multipart_start("start_failed");
+                tracing::warn!(
+                    namespace_id = %query.namespace.namespace_id,
+                    hash = %query.hash,
+                    name = %query.name,
+                    "failed to start module cache multipart upload: {error}"
+                );
+                error_response(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    format!("Failed to start upload: {error}"),
+                )
+            }
         },
-        Err(error) => error_response(
-            StatusCode::SERVICE_UNAVAILABLE,
-            format!("Failed to inspect artifact: {error}"),
-        ),
+        Err(error) => {
+            state.metrics.record_multipart_start("exists_check_failed");
+            tracing::warn!(
+                namespace_id = %query.namespace.namespace_id,
+                hash = %query.hash,
+                name = %query.name,
+                "failed to inspect module cache artifact before upload: {error}"
+            );
+            error_response(
+                StatusCode::SERVICE_UNAVAILABLE,
+                format!("Failed to inspect artifact: {error}"),
+            )
+        }
     }
 }
 

--- a/kura/src/http.rs
+++ b/kura/src/http.rs
@@ -1478,20 +1478,25 @@ async fn get_module(
 
 /// First CLI version that understands a 204 on module upload start as "already
 /// cached, skip the upload". Older clients only know the legacy 200 + null
-/// `upload_id`, so they keep getting that. The `x-tuist-cli-version` header is
-/// sent only by clients that carry this change; the floor is a conservative
-/// lower bound (latest released CLI is 4.200.5).
-const MIN_CLI_VERSION_FOR_NO_CONTENT: (u64, u64, u64) = (4, 200, 6);
+/// `upload_id`, so they keep getting that. This change lands on `main`, which
+/// currently cuts the 4.202.0 release line (canaries/RCs of the next minor).
+///
+/// We compare on `major.minor.patch` only and ignore the pre-release suffix, so
+/// every 4.202.0 build — `4.202.0-canary.N`, `4.202.0-rc.N`, and the eventual
+/// `4.202.0` stable — qualifies, while 4.201.x and earlier do not. (Comparing
+/// the full semver would rank the canaries/RCs *below* `4.202.0` and wrongly
+/// exclude the very builds that first carry this change.)
+const MIN_CLI_VERSION_FOR_NO_CONTENT: (u64, u64, u64) = (4, 202, 0);
 
 fn cli_supports_no_content(headers: &HeaderMap) -> bool {
     headers
         .get("x-tuist-cli-version")
         .and_then(|value| value.to_str().ok())
-        .and_then(parse_semver)
+        .and_then(parse_version_core)
         .is_some_and(|version| version >= MIN_CLI_VERSION_FOR_NO_CONTENT)
 }
 
-fn parse_semver(value: &str) -> Option<(u64, u64, u64)> {
+fn parse_version_core(value: &str) -> Option<(u64, u64, u64)> {
     // Parse a leading `major.minor.patch`, ignoring any pre-release/build suffix.
     let core = value.split(|c| c == '-' || c == '+').next().unwrap_or(value);
     let mut parts = core.split('.');
@@ -3764,13 +3769,14 @@ mod tests {
         // Starting an upload for an already-cached artifact returns 204 No Content
         // to a CLI new enough to understand it (advertised via x-tuist-cli-version),
         // so a cache hit can't be confused with a failure that returns an empty body.
+        // A canary of the carrying release line qualifies (pre-release suffix ignored).
         let restart = app
             .clone()
             .oneshot(
                 Request::builder()
                     .method("POST")
                     .uri("/api/cache/module/start?tenant_id=acme&namespace_id=ios&hash=hash-1&name=Module.framework&cache_category=builds")
-                    .header("x-tuist-cli-version", "4.200.6")
+                    .header("x-tuist-cli-version", "4.202.0-canary.7")
                     .body(Body::empty())
                     .expect("failed to build restart request"),
             )

--- a/kura/src/http.rs
+++ b/kura/src/http.rs
@@ -1476,7 +1476,36 @@ async fn get_module(
     .await
 }
 
+/// First CLI version that understands a 204 on module upload start as "already
+/// cached, skip the upload". Older clients only know the legacy 200 + null
+/// `upload_id`, so they keep getting that. The `x-tuist-cli-version` header is
+/// sent only by clients that carry this change; the floor is a conservative
+/// lower bound (latest released CLI is 4.200.5).
+const MIN_CLI_VERSION_FOR_NO_CONTENT: (u64, u64, u64) = (4, 200, 6);
+
+fn cli_supports_no_content(headers: &HeaderMap) -> bool {
+    headers
+        .get("x-tuist-cli-version")
+        .and_then(|value| value.to_str().ok())
+        .and_then(parse_semver)
+        .is_some_and(|version| version >= MIN_CLI_VERSION_FOR_NO_CONTENT)
+}
+
+fn parse_semver(value: &str) -> Option<(u64, u64, u64)> {
+    // Parse a leading `major.minor.patch`, ignoring any pre-release/build suffix.
+    let core = value.split(|c| c == '-' || c == '+').next().unwrap_or(value);
+    let mut parts = core.split('.');
+    let major = parts.next()?.parse().ok()?;
+    let minor = parts.next()?.parse().ok()?;
+    let patch = parts.next()?.parse().ok()?;
+    if parts.next().is_some() {
+        return None;
+    }
+    Some((major, minor, patch))
+}
+
 async fn start_module_upload(
+    headers: HeaderMap,
     Query(params): Query<HashMap<String, String>>,
     State(state): State<SharedState>,
 ) -> Response {
@@ -1498,11 +1527,17 @@ async fn start_module_upload(
         // skip the upload" — not a failure. A distinct status (rather than a 200
         // with a null `upload_id`) lets clients and operators tell a cache hit
         // apart from a genuine failure that returns an empty body, so a write
-        // that never lands can't masquerade as success. The metric records the
-        // same distinction for observability.
+        // that never lands can't masquerade as success. It is gated on the CLI
+        // version: clients that predate the 204 signal keep getting the legacy
+        // 200 + null `upload_id` so the change stays backward compatible. The
+        // metric records the cache hit either way.
         Ok(true) => {
             state.metrics.record_multipart_start("already_exists");
-            StatusCode::NO_CONTENT.into_response()
+            if cli_supports_no_content(&headers) {
+                StatusCode::NO_CONTENT.into_response()
+            } else {
+                Json(serde_json::json!({ "upload_id": serde_json::Value::Null })).into_response()
+            }
         }
         Ok(false) => match state.store.start_multipart_upload(
             &query.namespace.tenant_id,
@@ -3727,19 +3762,39 @@ mod tests {
         assert_eq!(response_text(get).await, "part-one-part-two");
 
         // Starting an upload for an already-cached artifact returns 204 No Content
-        // (not a 200 with a null upload id), so a cache hit can't be confused with
-        // a failure that returns an empty body.
+        // to a CLI new enough to understand it (advertised via x-tuist-cli-version),
+        // so a cache hit can't be confused with a failure that returns an empty body.
         let restart = app
+            .clone()
             .oneshot(
                 Request::builder()
                     .method("POST")
                     .uri("/api/cache/module/start?tenant_id=acme&namespace_id=ios&hash=hash-1&name=Module.framework&cache_category=builds")
+                    .header("x-tuist-cli-version", "4.200.6")
                     .body(Body::empty())
                     .expect("failed to build restart request"),
             )
             .await
             .expect("restart request failed");
         assert_eq!(restart.status(), StatusCode::NO_CONTENT);
+
+        // A CLI that predates the 204 signal (no x-tuist-cli-version header) still
+        // gets the legacy 200 with a null upload id, keeping the change backward
+        // compatible.
+        let legacy_restart = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/cache/module/start?tenant_id=acme&namespace_id=ios&hash=hash-1&name=Module.framework&cache_category=builds")
+                    .body(Body::empty())
+                    .expect("failed to build legacy restart request"),
+            )
+            .await
+            .expect("legacy restart request failed");
+        assert_eq!(legacy_restart.status(), StatusCode::OK);
+        let legacy_payload: Value = serde_json::from_str(&response_text(legacy_restart).await)
+            .expect("failed to decode legacy restart payload");
+        assert_eq!(legacy_payload["upload_id"], Value::Null);
     }
 
     #[tokio::test]

--- a/kura/src/http.rs
+++ b/kura/src/http.rs
@@ -1494,17 +1494,15 @@ async fn start_module_upload(
         )
         .await
     {
-        // `already_cached: true` (with a null `upload_id`) is the contract for
-        // "the artifact is already cached, skip the upload" — not a failure. The
-        // explicit flag, plus the metric, lets clients and operators tell a cache
-        // hit apart from a genuine failure instead of inferring it from a null
-        // upload_id, so a write that never lands can't masquerade as success.
+        // A 204 No Content is the contract for "the artifact is already cached,
+        // skip the upload" — not a failure. A distinct status (rather than a 200
+        // with a null `upload_id`) lets clients and operators tell a cache hit
+        // apart from a genuine failure that returns an empty body, so a write
+        // that never lands can't masquerade as success. The metric records the
+        // same distinction for observability.
         Ok(true) => {
             state.metrics.record_multipart_start("already_exists");
-            Json(
-                serde_json::json!({ "upload_id": serde_json::Value::Null, "already_cached": true }),
-            )
-            .into_response()
+            StatusCode::NO_CONTENT.into_response()
         }
         Ok(false) => match state.store.start_multipart_upload(
             &query.namespace.tenant_id,
@@ -1515,8 +1513,7 @@ async fn start_module_upload(
         ) {
             Ok(upload_id) => {
                 state.metrics.record_multipart_start("started");
-                Json(serde_json::json!({ "upload_id": upload_id, "already_cached": false }))
-                    .into_response()
+                Json(serde_json::json!({ "upload_id": upload_id })).into_response()
             }
             Err(error) => {
                 state.metrics.record_multipart_start("start_failed");
@@ -3652,13 +3649,9 @@ mod tests {
             )
             .await
             .expect("start request failed");
+        assert_eq!(start.status(), StatusCode::OK);
         let payload: Value = serde_json::from_str(&response_text(start).await)
             .expect("failed to decode start payload");
-        assert_eq!(
-            payload["already_cached"],
-            Value::Bool(false),
-            "a fresh start should report already_cached=false"
-        );
         let upload_id = payload["upload_id"]
             .as_str()
             .expect("upload id should be present");
@@ -3715,6 +3708,7 @@ mod tests {
         assert_eq!(head.status(), StatusCode::NO_CONTENT);
 
         let get = app
+            .clone()
             .oneshot(
                 Request::builder()
                     .uri("/api/cache/module/module-1?tenant_id=acme&namespace_id=ios&hash=hash-1&name=Module.framework&cache_category=builds")
@@ -3731,6 +3725,21 @@ mod tests {
             Some("17")
         );
         assert_eq!(response_text(get).await, "part-one-part-two");
+
+        // Starting an upload for an already-cached artifact returns 204 No Content
+        // (not a 200 with a null upload id), so a cache hit can't be confused with
+        // a failure that returns an empty body.
+        let restart = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/cache/module/start?tenant_id=acme&namespace_id=ios&hash=hash-1&name=Module.framework&cache_category=builds")
+                    .body(Body::empty())
+                    .expect("failed to build restart request"),
+            )
+            .await
+            .expect("restart request failed");
+        assert_eq!(restart.status(), StatusCode::NO_CONTENT);
     }
 
     #[tokio::test]

--- a/kura/src/http.rs
+++ b/kura/src/http.rs
@@ -1494,13 +1494,17 @@ async fn start_module_upload(
         )
         .await
     {
-        // A null `upload_id` is the contract for "the artifact is already cached,
-        // skip the upload" — not a failure. The metric below lets operators tell
-        // already-cached starts apart from genuine failures so a write that never
-        // lands is observable instead of looking like a silent success.
+        // `already_cached: true` (with a null `upload_id`) is the contract for
+        // "the artifact is already cached, skip the upload" — not a failure. The
+        // explicit flag, plus the metric, lets clients and operators tell a cache
+        // hit apart from a genuine failure instead of inferring it from a null
+        // upload_id, so a write that never lands can't masquerade as success.
         Ok(true) => {
             state.metrics.record_multipart_start("already_exists");
-            Json(serde_json::json!({ "upload_id": serde_json::Value::Null })).into_response()
+            Json(
+                serde_json::json!({ "upload_id": serde_json::Value::Null, "already_cached": true }),
+            )
+            .into_response()
         }
         Ok(false) => match state.store.start_multipart_upload(
             &query.namespace.tenant_id,
@@ -1511,7 +1515,8 @@ async fn start_module_upload(
         ) {
             Ok(upload_id) => {
                 state.metrics.record_multipart_start("started");
-                Json(serde_json::json!({ "upload_id": upload_id })).into_response()
+                Json(serde_json::json!({ "upload_id": upload_id, "already_cached": false }))
+                    .into_response()
             }
             Err(error) => {
                 state.metrics.record_multipart_start("start_failed");
@@ -3649,6 +3654,11 @@ mod tests {
             .expect("start request failed");
         let payload: Value = serde_json::from_str(&response_text(start).await)
             .expect("failed to decode start payload");
+        assert_eq!(
+            payload["already_cached"],
+            Value::Bool(false),
+            "a fresh start should report already_cached=false"
+        );
         let upload_id = payload["upload_id"]
             .as_str()
             .expect("upload id should be present");

--- a/kura/src/metrics.rs
+++ b/kura/src/metrics.rs
@@ -53,6 +53,7 @@ pub struct Metrics {
     replication_bandwidth_effective_limit_bytes_per_second: Gauge,
     replication_bandwidth_public_latency_target_ms: Gauge,
     multipart_parts: Family<MultipartLabels, Counter>,
+    multipart_starts: Family<MultipartLabels, Counter>,
     node_info: Family<NodeInfoLabels, Gauge>,
     node_geo: Family<NodeGeoLabels, Gauge>,
     file_descriptor_wait: Family<FileDescriptorWaitLabels, Histogram>,
@@ -181,6 +182,7 @@ impl Metrics {
         let replication_bandwidth_effective_limit_bytes_per_second = Gauge::default();
         let replication_bandwidth_public_latency_target_ms = Gauge::default();
         let multipart_parts = Family::<MultipartLabels, Counter>::default();
+        let multipart_starts = Family::<MultipartLabels, Counter>::default();
         let node_info = Family::<NodeInfoLabels, Gauge>::default();
         let node_geo = Family::<NodeGeoLabels, Gauge>::default();
         let file_descriptor_wait =
@@ -397,6 +399,11 @@ impl Metrics {
             "kura_multipart_parts_total",
             "Multipart part uploads by result",
             multipart_parts.clone(),
+        );
+        registry.register(
+            "kura_multipart_starts_total",
+            "Multipart module cache upload starts by result",
+            multipart_starts.clone(),
         );
         registry.register(
             "kura_node_info",
@@ -783,6 +790,7 @@ impl Metrics {
             replication_bandwidth_effective_limit_bytes_per_second,
             replication_bandwidth_public_latency_target_ms,
             multipart_parts,
+            multipart_starts,
             node_info,
             node_geo,
             file_descriptor_wait,
@@ -1072,6 +1080,14 @@ impl Metrics {
 
     pub fn record_multipart_part(&self, result: &str) {
         self.multipart_parts
+            .get_or_create(&MultipartLabels {
+                result: result.to_owned(),
+            })
+            .inc();
+    }
+
+    pub fn record_multipart_start(&self, result: &str) {
+        self.multipart_starts
             .get_or_create(&MultipartLabels {
                 result: result.to_owned(),
             })
@@ -1754,6 +1770,7 @@ mod tests {
         metrics.record_replication_apply("bootstrap", "namespace_delete", "ignored_older");
         metrics.update_replication_bandwidth_limits(10_485_760, 5_242_880, 100);
         metrics.record_multipart_part("ok");
+        metrics.record_multipart_start("started");
         metrics.record_file_descriptor_wait("ok", Duration::from_millis(1));
         metrics.record_file_operation("open_read", "ok", Duration::from_millis(2), 42);
         metrics.update_file_descriptor_pool(64, 3, 61, 1);
@@ -1852,6 +1869,7 @@ mod tests {
         assert!(rendered.contains("outcome=\"applied\""));
         assert!(rendered.contains("outcome=\"ignored_older\""));
         assert!(rendered.contains("kura_multipart_parts_total"));
+        assert!(rendered.contains("kura_multipart_starts_total"));
         assert!(rendered.contains("kura_node_info"));
         assert!(rendered.contains("kura_node_geo_info"));
         assert!(rendered.contains("kura_file_descriptor_wait_seconds"));

--- a/server/lib/tuist/shards.ex
+++ b/server/lib/tuist/shards.ex
@@ -98,8 +98,7 @@ defmodule Tuist.Shards do
   end
 
   def start_upload_for_plan_id(%Project{} = project, %Account{} = account, plan_id) do
-    upload_id = Storage.multipart_start(bundle_object_key(account, project, plan_id), account)
-    {:ok, upload_id}
+    Storage.multipart_start(bundle_object_key(account, project, plan_id), account)
   end
 
   def get_shard(%Project{} = project, %Account{} = account, reference, shard_index) do

--- a/server/lib/tuist/storage.ex
+++ b/server/lib/tuist/storage.ex
@@ -8,6 +8,8 @@ defmodule Tuist.Storage do
   alias Tuist.Environment
   alias Tuist.Performance
 
+  require Logger
+
   @delete_objects_max_concurrency 4
 
   def multipart_generate_url(object_key, upload_id, part_number, actor, opts \\ []) do
@@ -198,8 +200,17 @@ defmodule Tuist.Storage do
     end
   end
 
+  @doc """
+  Starts a multi-part upload for `object_key`.
+
+  Returns `{:ok, upload_id}` once the storage backend has acknowledged the
+  upload, or `{:error, reason}` when the backend rejects the request (for
+  example an improperly signed request reaching S3) or returns a success
+  response without an upload id. Surfacing the error lets callers respond with a
+  real failure instead of silently handing the client a `nil` upload id.
+  """
   def multipart_start(object_key, actor) do
-    {time, upload_id} =
+    {time, result} =
       Performance.measure_time_in_milliseconds(fn ->
         {config, bucket_name} = s3_config_and_bucket(actor)
         headers = region_headers(actor)
@@ -209,18 +220,37 @@ defmodule Tuist.Storage do
           |> ExAws.S3.initiate_multipart_upload(object_key)
           |> Map.put(:headers, Map.new(headers))
 
-        %{body: %{upload_id: upload_id}} = ExAws.request!(operation, Map.merge(config, fast_api_req_opts()))
+        case ExAws.request(operation, Map.merge(config, fast_api_req_opts())) do
+          {:ok, %{body: %{upload_id: upload_id}}} when is_binary(upload_id) and upload_id != "" ->
+            {:ok, upload_id}
 
-        upload_id
+          {:ok, response} ->
+            {:error, {:missing_upload_id, response}}
+
+          {:error, reason} ->
+            {:error, reason}
+        end
       end)
 
-    :telemetry.execute(
-      Tuist.Telemetry.event_name_storage_multipart_start_upload(),
-      %{duration: time},
-      %{object_key: object_key}
-    )
+    case result do
+      {:ok, _upload_id} ->
+        :telemetry.execute(
+          Tuist.Telemetry.event_name_storage_multipart_start_upload(),
+          %{duration: time},
+          %{object_key: object_key}
+        )
 
-    upload_id
+      {:error, reason} ->
+        :telemetry.execute(
+          Tuist.Telemetry.event_name_storage_multipart_start_upload_error(),
+          %{duration: time},
+          %{object_key: object_key, reason: reason}
+        )
+
+        Logger.error("Failed to start multi-part upload for #{object_key}: #{inspect(reason)}")
+    end
+
+    result
   end
 
   def delete_all_objects(prefix, actor) do

--- a/server/lib/tuist/storage/prom_ex_plugin.ex
+++ b/server/lib/tuist/storage/prom_ex_plugin.ex
@@ -117,6 +117,18 @@ defmodule Tuist.Storage.PromExPlugin do
             ],
             event_name: Telemetry.event_name_storage_multipart_start_upload(),
             description: "The count of multi-part uploads that have been started."
+          ),
+          counter(
+            [
+              :tuist,
+              :storage,
+              :multipart,
+              :start_upload,
+              :error,
+              :count
+            ],
+            event_name: Telemetry.event_name_storage_multipart_start_upload_error(),
+            description: "The count of multi-part uploads that failed to start."
           )
         ]
       ),

--- a/server/lib/tuist/telemetry.ex
+++ b/server/lib/tuist/telemetry.ex
@@ -28,6 +28,10 @@ defmodule Tuist.Telemetry do
     [:tuist, :storage, :multipart, :start_upload]
   end
 
+  def event_name_storage_multipart_start_upload_error do
+    [:tuist, :storage, :multipart, :start_upload_error]
+  end
+
   def event_name_storage_get_object_as_string do
     [:tuist, :storage, :get_object_as_string]
   end

--- a/server/lib/tuist_web/controllers/api/analytics_controller.ex
+++ b/server/lib/tuist_web/controllers/api/analytics_controller.ex
@@ -666,8 +666,15 @@ defmodule TuistWeb.API.AnalyticsController do
       ) do
     with {:ok, object_key} <-
            get_object_key(%{type: type, run_id: run_id, name: command_event_artifact.name}, conn) do
-      upload_id = Storage.multipart_start(object_key, selected_project.account)
-      json(conn, %{status: "success", data: %{upload_id: upload_id}})
+      case Storage.multipart_start(object_key, selected_project.account) do
+        {:ok, upload_id} ->
+          json(conn, %{status: "success", data: %{upload_id: upload_id}})
+
+        {:error, _reason} ->
+          conn
+          |> put_status(:bad_gateway)
+          |> json(%{status: "error", message: "The storage backend could not start the upload."})
+      end
     end
   end
 

--- a/server/lib/tuist_web/controllers/api/builds_controller.ex
+++ b/server/lib/tuist_web/controllers/api/builds_controller.ex
@@ -1024,9 +1024,15 @@ defmodule TuistWeb.API.BuildsController do
       ) do
     object_key = Builds.build_storage_key(selected_project.account.name, selected_project.name, build_id)
 
-    multipart_upload_id = Storage.multipart_start(object_key, selected_project.account)
+    case Storage.multipart_start(object_key, selected_project.account) do
+      {:ok, multipart_upload_id} ->
+        json(conn, %{status: "success", data: %{upload_id: multipart_upload_id}})
 
-    json(conn, %{status: "success", data: %{upload_id: multipart_upload_id}})
+      {:error, _reason} ->
+        conn
+        |> put_status(:bad_gateway)
+        |> json(%{status: "error", message: "The storage backend could not start the upload."})
+    end
   end
 
   operation(:multipart_generate_url,

--- a/server/lib/tuist_web/controllers/api/cache_controller.ex
+++ b/server/lib/tuist_web/controllers/api/cache_controller.ex
@@ -467,21 +467,23 @@ defmodule TuistWeb.API.CacheController do
         } = conn,
         _params
       ) do
-    json(conn, %{
-      status: "success",
-      data: %{
-        upload_id:
-          Storage.multipart_start(
-            get_object_key(%{
-              hash: hash,
-              name: name,
-              project_slug: project_slug,
-              cache_category: cache_category
-            }),
-            selected_project.account
-          )
-      }
-    })
+    object_key =
+      get_object_key(%{
+        hash: hash,
+        name: name,
+        project_slug: project_slug,
+        cache_category: cache_category
+      })
+
+    case Storage.multipart_start(object_key, selected_project.account) do
+      {:ok, upload_id} ->
+        json(conn, %{status: "success", data: %{upload_id: upload_id}})
+
+      {:error, _reason} ->
+        conn
+        |> put_status(:bad_gateway)
+        |> json(%{status: "error", message: "The storage backend could not start the upload."})
+    end
   end
 
   def multipart_start(conn, _params) do

--- a/server/lib/tuist_web/controllers/api/previews_controller.ex
+++ b/server/lib/tuist_web/controllers/api/previews_controller.ex
@@ -193,21 +193,7 @@ defmodule TuistWeb.API.PreviewsController do
            build_version: build_version
          }) do
       {:ok, app_build} ->
-        upload_id =
-          Storage.multipart_start(
-            AppBuilds.storage_key(%{
-              account_handle: account_handle,
-              project_handle: project_handle,
-              app_build: app_build
-            }),
-            selected_project.account
-          )
-
-        # We're returning app_build.id as preview_id, so we don't break CLI pre-4.54.0 version.
-        json(conn, %{
-          status: "success",
-          data: %{upload_id: upload_id, preview_id: app_build.id, app_build_id: app_build.id}
-        })
+        start_app_build_upload(conn, app_build, account_handle, project_handle, selected_project)
 
       {:error, %Ecto.Changeset{errors: errors}} ->
         if Keyword.has_key?(errors, :binary_id) do
@@ -222,6 +208,29 @@ defmodule TuistWeb.API.PreviewsController do
         else
           raise "Unexpected error creating app build: #{inspect(errors)}"
         end
+    end
+  end
+
+  defp start_app_build_upload(conn, app_build, account_handle, project_handle, selected_project) do
+    object_key =
+      AppBuilds.storage_key(%{
+        account_handle: account_handle,
+        project_handle: project_handle,
+        app_build: app_build
+      })
+
+    case Storage.multipart_start(object_key, selected_project.account) do
+      {:ok, upload_id} ->
+        # We're returning app_build.id as preview_id, so we don't break CLI pre-4.54.0 version.
+        json(conn, %{
+          status: "success",
+          data: %{upload_id: upload_id, preview_id: app_build.id, app_build_id: app_build.id}
+        })
+
+      {:error, _reason} ->
+        conn
+        |> put_status(:bad_gateway)
+        |> json(%{status: "error", message: "The storage backend could not start the upload."})
     end
   end
 

--- a/server/lib/tuist_web/controllers/api/shards_controller.ex
+++ b/server/lib/tuist_web/controllers/api/shards_controller.ex
@@ -194,6 +194,11 @@ defmodule TuistWeb.API.ShardsController do
         conn
         |> put_status(:bad_request)
         |> json(%{message: "Either shard_plan_id or reference is required."})
+
+      {:error, _reason} ->
+        conn
+        |> put_status(:bad_gateway)
+        |> json(%{message: "The storage backend could not start the upload."})
     end
   end
 

--- a/server/priv/docs/en/guides/server/self-host/server.md
+++ b/server/priv/docs/en/guides/server/self-host/server.md
@@ -266,6 +266,30 @@ You can use any S3-compliant storage provider to store artifacts. The following 
 >
 > If your storage provider is AWS and you'd like to authenticate using a web identity token, you can set the environment variable `TUIST_S3_AUTHENTICATION_METHOD` to `aws_web_identity_token_from_env_vars`, and Tuist will use that method using the conventional AWS environment variables.
 
+#### Reverse-proxying cache traffic to object storage {#reverse-proxying-cache}
+
+Some self-hosted setups put their own reverse proxy (for example nginx) in front of the cache routes and proxy them straight to an S3-compatible bucket. This works, but two boundary details trip people up and cause cache reads or writes to fail while the server keeps reporting success:
+
+- **Strip the inbound `Authorization` header on the route that proxies to object storage.** Requests to Tuist carry the client's `Authorization: Bearer <token>`. If your proxy forwards that header to S3 *and* signs the upstream request with SigV4, S3 sees two authentication mechanisms and rejects the request with `400 Bad Request` (`InvalidArgument: Only one auth mechanism allowed`). Drop the client header before the request leaves your proxy so only the SigV4 signature reaches S3.
+- **Allow a large enough request body for multipart part uploads.** Cache artifacts are uploaded in multipart chunks. A low body-size limit (nginx's default `client_max_body_size` is `1m`) silently rejects part uploads. Raise it comfortably above your part size.
+
+```nginx
+# Example: a route that proxies cache traffic to S3
+location /cache/ {
+    # Don't forward the client's bearer token to S3 — the upstream request is
+    # signed with SigV4 and S3 allows only one auth mechanism per request.
+    proxy_set_header Authorization "";
+
+    # Multipart cache part uploads can be large; raise the body limit so they
+    # aren't rejected before reaching the bucket.
+    client_max_body_size 2g;
+
+    proxy_pass https://your-bucket.s3.your-region.amazonaws.com/;
+}
+```
+
+> [!NOTE]
+> If you don't terminate cache traffic with your own proxy (the default deployment lets Tuist talk to object storage directly), you don't need any of this.
 
 #### Google Cloud Storage {#google-cloud-storage}
 For Google Cloud Storage, follow [these docs](https://cloud.google.com/storage/docs/authentication/managing-hmackeys) to get the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` pair. The `AWS_ENDPOINT` should be set to `https://storage.googleapis.com`. Other environment variables are the same as for any other S3-compliant storage.

--- a/server/test/tuist/shards_test.exs
+++ b/server/test/tuist/shards_test.exs
@@ -266,7 +266,7 @@ defmodule Tuist.ShardsTest do
       stub(Tuist.Storage, :multipart_start, fn key, _account ->
         assert key =~ "shards/"
         assert key =~ "/bundle.zip"
-        "test-upload-id"
+        {:ok, "test-upload-id"}
       end)
 
       assert {:ok, "test-upload-id"} = Shards.start_upload(project, account, "upload-ref-1")
@@ -284,7 +284,7 @@ defmodule Tuist.ShardsTest do
 
       stub(Tuist.Storage, :multipart_start, fn key, _account ->
         assert key == Shards.bundle_object_key(account, project, plan.id)
-        "test-upload-id"
+        {:ok, "test-upload-id"}
       end)
 
       assert {:ok, "test-upload-id"} = Shards.start_upload_for_plan(project, account, plan)
@@ -297,7 +297,7 @@ defmodule Tuist.ShardsTest do
 
       stub(Tuist.Storage, :multipart_start, fn key, _account ->
         assert key == Shards.bundle_object_key(account, project, plan_id)
-        "test-upload-id"
+        {:ok, "test-upload-id"}
       end)
 
       assert {:ok, "test-upload-id"} = Shards.start_upload_for_plan_id(project, account, plan_id)

--- a/server/test/tuist/storage_test.exs
+++ b/server/test/tuist/storage_test.exs
@@ -469,21 +469,70 @@ defmodule Tuist.StorageTest do
         operation
       end)
 
-      expect(ExAws, :request!, fn ^operation, opts ->
+      expect(ExAws, :request, fn ^operation, opts ->
         # Verify fast_api_req_opts are included
         assert Map.get(opts, :receive_timeout) == 5_000
         assert Map.get(opts, :pool_timeout) == 1_000
         assert Map.get(opts, :test) == :config
-        %{body: %{upload_id: upload_id}}
+        {:ok, %{body: %{upload_id: upload_id}}}
       end)
 
       # When
-      assert Storage.multipart_start(object_key, :test) == upload_id
+      assert Storage.multipart_start(object_key, :test) == {:ok, upload_id}
 
       # Then
       assert_received {^event_name, ^event_ref, %{duration: duration}, %{object_key: ^object_key}}
 
       assert is_number(duration)
+    end
+
+    test "returns an error and emits the error telemetry event when the backend rejects the request" do
+      # Given
+      event_name = Tuist.Telemetry.event_name_storage_multipart_start_upload_error()
+      event_ref = :telemetry_test.attach_event_handlers(self(), [event_name])
+
+      object_key = UUIDv7.generate()
+      bucket_name = UUIDv7.generate()
+
+      expect(Environment, :s3_bucket_name, fn -> bucket_name end)
+      expect(ExAws.Config, :new, fn :s3 -> %{} end)
+
+      operation = %S3{headers: %{}}
+
+      expect(ExAws.S3, :initiate_multipart_upload, fn ^bucket_name, ^object_key -> operation end)
+
+      expect(ExAws, :request, fn ^operation, _opts ->
+        {:error, {:http_error, 400, %{body: "AuthorizationHeaderMalformed"}}}
+      end)
+
+      # When / Then
+      assert ExUnit.CaptureLog.capture_log(fn ->
+               assert Storage.multipart_start(object_key, :test) ==
+                        {:error, {:http_error, 400, %{body: "AuthorizationHeaderMalformed"}}}
+             end) =~ "Failed to start multi-part upload"
+
+      assert_received {^event_name, ^event_ref, %{duration: duration}, %{object_key: ^object_key}}
+      assert is_number(duration)
+    end
+
+    test "returns an error when the backend responds without an upload id" do
+      # Given
+      object_key = UUIDv7.generate()
+      bucket_name = UUIDv7.generate()
+
+      expect(Environment, :s3_bucket_name, fn -> bucket_name end)
+      expect(ExAws.Config, :new, fn :s3 -> %{} end)
+
+      operation = %S3{headers: %{}}
+
+      expect(ExAws.S3, :initiate_multipart_upload, fn ^bucket_name, ^object_key -> operation end)
+
+      expect(ExAws, :request, fn ^operation, _opts -> {:ok, %{body: %{upload_id: nil}}} end)
+
+      # When / Then
+      ExUnit.CaptureLog.capture_log(fn ->
+        assert {:error, {:missing_upload_id, _response}} = Storage.multipart_start(object_key, :test)
+      end)
     end
   end
 
@@ -871,14 +920,14 @@ defmodule Tuist.StorageTest do
         operation
       end)
 
-      expect(ExAws, :request!, fn updated_operation, _opts ->
+      expect(ExAws, :request, fn updated_operation, _opts ->
         # Verify region header is added
         assert updated_operation.headers == %{"X-Tigris-Regions" => "eur"}
-        %{body: %{upload_id: upload_id}}
+        {:ok, %{body: %{upload_id: upload_id}}}
       end)
 
       # When
-      assert Storage.multipart_start(object_key, account) == upload_id
+      assert Storage.multipart_start(object_key, account) == {:ok, upload_id}
 
       # Then
       assert_received {^event_name, ^event_ref, %{duration: duration}, %{object_key: ^object_key}}
@@ -905,14 +954,14 @@ defmodule Tuist.StorageTest do
         operation
       end)
 
-      expect(ExAws, :request!, fn updated_operation, _opts ->
+      expect(ExAws, :request, fn updated_operation, _opts ->
         # Verify region header is added
         assert updated_operation.headers == %{"X-Tigris-Regions" => "usa"}
-        %{body: %{upload_id: upload_id}}
+        {:ok, %{body: %{upload_id: upload_id}}}
       end)
 
       # When
-      assert Storage.multipart_start(object_key, account) == upload_id
+      assert Storage.multipart_start(object_key, account) == {:ok, upload_id}
 
       # Then
       assert_received {^event_name, ^event_ref, %{duration: duration}, %{object_key: ^object_key}}
@@ -939,14 +988,14 @@ defmodule Tuist.StorageTest do
         operation
       end)
 
-      expect(ExAws, :request!, fn ^operation, _opts ->
+      expect(ExAws, :request, fn ^operation, _opts ->
         # Verify no region headers are added
         assert operation.headers == %{}
-        %{body: %{upload_id: upload_id}}
+        {:ok, %{body: %{upload_id: upload_id}}}
       end)
 
       # When
-      assert Storage.multipart_start(object_key, account) == upload_id
+      assert Storage.multipart_start(object_key, account) == {:ok, upload_id}
 
       # Then
       assert_received {^event_name, ^event_ref, %{duration: duration}, %{object_key: ^object_key}}
@@ -1106,16 +1155,16 @@ defmodule Tuist.StorageTest do
         operation
       end)
 
-      expect(ExAws, :request!, fn updated_operation, _opts ->
+      expect(ExAws, :request, fn updated_operation, _opts ->
         assert updated_operation.headers == %{}
-        %{body: %{upload_id: upload_id}}
+        {:ok, %{body: %{upload_id: upload_id}}}
       end)
 
       # When
       result = Storage.multipart_start(object_key, account)
 
       # Then
-      assert result == upload_id
+      assert result == {:ok, upload_id}
     end
 
     test "object_exists? uses custom S3 config" do

--- a/server/test/tuist_web/controllers/analytics_controller_test.exs
+++ b/server/test/tuist_web/controllers/analytics_controller_test.exs
@@ -843,7 +843,7 @@ defmodule TuistWeb.AnalyticsControllerTest do
         "#{account.name}/#{project.name}/runs/#{command_event.id}/result_bundle.zip"
 
       expect(Storage, :multipart_start, fn ^object_key, _account ->
-        upload_id
+        {:ok, upload_id}
       end)
 
       conn = Authentication.put_current_project(conn, project)
@@ -874,7 +874,7 @@ defmodule TuistWeb.AnalyticsControllerTest do
         "#{account.name}/#{project.name}/runs/#{command_event.id}/some-id.json"
 
       expect(Storage, :multipart_start, fn ^object_key, _account ->
-        upload_id
+        {:ok, upload_id}
       end)
 
       conn = Authentication.put_current_project(conn, project)
@@ -906,7 +906,7 @@ defmodule TuistWeb.AnalyticsControllerTest do
         "#{account.name}/#{project.name}/runs/#{command_event.id}/session.zip"
 
       expect(Storage, :multipart_start, fn ^object_key, _account ->
-        upload_id
+        {:ok, upload_id}
       end)
 
       conn = Authentication.put_current_project(conn, project)
@@ -1288,7 +1288,7 @@ defmodule TuistWeb.AnalyticsControllerTest do
         "#{account.name}/#{project.name}/runs/#{command_event.id}/result_bundle.zip"
 
       expect(Storage, :multipart_start, fn ^object_key, _account ->
-        upload_id
+        {:ok, upload_id}
       end)
 
       # Authenticate with user instead of project token
@@ -1320,7 +1320,7 @@ defmodule TuistWeb.AnalyticsControllerTest do
         "#{account.name}/#{project.name}/runs/#{command_event.id}/some-id.json"
 
       expect(Storage, :multipart_start, fn ^object_key, _account ->
-        upload_id
+        {:ok, upload_id}
       end)
 
       # Authenticate with user instead of project token
@@ -1353,7 +1353,7 @@ defmodule TuistWeb.AnalyticsControllerTest do
         "#{account.name}/#{project.name}/runs/#{command_event.id}/session.zip"
 
       expect(Storage, :multipart_start, fn ^object_key, _account ->
-        upload_id
+        {:ok, upload_id}
       end)
 
       conn = Authentication.put_current_user(conn, user)
@@ -1388,7 +1388,7 @@ defmodule TuistWeb.AnalyticsControllerTest do
       object_key = "#{account.name}/#{project.name}/runs/#{nonexistent_run_id}/result_bundle.zip"
 
       expect(Storage, :multipart_start, fn ^object_key, _account ->
-        upload_id
+        {:ok, upload_id}
       end)
 
       conn = Authentication.put_current_user(conn, user)
@@ -1686,7 +1686,7 @@ defmodule TuistWeb.AnalyticsControllerTest do
         "#{account.name}/#{project.name}/runs/#{command_event.id}/result_bundle.zip"
 
       expect(Storage, :multipart_start, fn ^object_key, _account ->
-        upload_id
+        {:ok, upload_id}
       end)
 
       # Using project authentication (old way)

--- a/server/test/tuist_web/controllers/api/builds_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/builds_controller_test.exs
@@ -570,7 +570,7 @@ defmodule TuistWeb.API.BuildsControllerTest do
       build_id = Ecto.UUID.generate()
 
       stub(Storage, :multipart_start, fn _key, _account ->
-        "multipart-upload-id-123"
+        {:ok, "multipart-upload-id-123"}
       end)
 
       conn =
@@ -609,7 +609,7 @@ defmodule TuistWeb.API.BuildsControllerTest do
 
       stub(Storage, :multipart_start, fn _key, account ->
         send(test_pid, {:multipart_start_account, account.id})
-        "multipart-upload-id-123"
+        {:ok, "multipart-upload-id-123"}
       end)
 
       conn

--- a/server/test/tuist_web/controllers/api/cache_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/cache_controller_test.exs
@@ -789,7 +789,7 @@ defmodule TuistWeb.API.CacheControllerTest do
       object_key = "#{project_id}/#{cache_category}/#{hash}/#{name}"
 
       expect(Storage, :multipart_start, fn ^object_key, _actor ->
-        upload_id
+        {:ok, upload_id}
       end)
 
       conn = Authentication.put_current_project(conn, project)
@@ -807,6 +807,39 @@ defmodule TuistWeb.API.CacheControllerTest do
       assert response["status"] == "success"
       response_data = response["data"]
       assert response_data["upload_id"] == upload_id
+    end
+
+    test "returns a bad gateway error when the storage backend fails to start the upload", %{
+      conn: conn,
+      cache: cache
+    } do
+      # Given
+      project = ProjectsFixtures.project_fixture()
+      {:ok, account} = Accounts.get_account_by_id(project.account_id)
+      hash = "hash"
+      name = "name"
+      project_id = "#{account.name}/#{project.name}"
+      cache_category = "builds"
+      object_key = "#{project_id}/#{cache_category}/#{hash}/#{name}"
+
+      expect(Storage, :multipart_start, fn ^object_key, _actor ->
+        {:error, {:http_error, 400, %{body: "AuthorizationHeaderMalformed"}}}
+      end)
+
+      conn = Authentication.put_current_project(conn, project)
+
+      # When
+      conn =
+        conn
+        |> assign(:cache, cache)
+        |> post(
+          ~p"/api/cache/multipart/start?hash=#{hash}&name=#{name}&project_id=#{project_id}&cache_category=#{cache_category}"
+        )
+
+      # Then
+      response = json_response(conn, 502)
+      assert response["status"] == "error"
+      assert response["message"] =~ "could not start the upload"
     end
 
     test "returns a payment_required error if the account has no subscription and they've gone above the threshold",

--- a/server/test/tuist_web/controllers/api/previews_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/previews_controller_test.exs
@@ -25,7 +25,7 @@ defmodule TuistWeb.PreviewsControllerTest do
       upload_id = "upload-id"
 
       expect(Storage, :multipart_start, fn _object_key, _actor ->
-        upload_id
+        {:ok, upload_id}
       end)
 
       # When
@@ -82,7 +82,7 @@ defmodule TuistWeb.PreviewsControllerTest do
       upload_id = "upload-id"
 
       expect(Storage, :multipart_start, fn _object_key, _actor ->
-        upload_id
+        {:ok, upload_id}
       end)
 
       # When
@@ -115,7 +115,7 @@ defmodule TuistWeb.PreviewsControllerTest do
       upload_id = "upload-id"
 
       expect(Storage, :multipart_start, fn _object_key, _actor ->
-        upload_id
+        {:ok, upload_id}
       end)
 
       conn = Authentication.put_current_user(conn, user)
@@ -145,7 +145,7 @@ defmodule TuistWeb.PreviewsControllerTest do
       upload_id = "upload-id"
 
       expect(Storage, :multipart_start, fn _object_key, _actor ->
-        upload_id
+        {:ok, upload_id}
       end)
 
       conn = Authentication.put_current_user(conn, user)
@@ -174,7 +174,7 @@ defmodule TuistWeb.PreviewsControllerTest do
       upload_id = "upload-id"
 
       expect(Storage, :multipart_start, fn _object_key, _actor ->
-        upload_id
+        {:ok, upload_id}
       end)
 
       conn = Authentication.put_current_user(conn, user)
@@ -219,7 +219,7 @@ defmodule TuistWeb.PreviewsControllerTest do
         )
 
       expect(Storage, :multipart_start, fn _object_key, _actor ->
-        upload_id
+        {:ok, upload_id}
       end)
 
       conn = Authentication.put_current_user(conn, user)
@@ -256,7 +256,7 @@ defmodule TuistWeb.PreviewsControllerTest do
       binary_id = "550E8400-E29B-41D4-A716-446655440000"
 
       expect(Storage, :multipart_start, fn _object_key, _actor ->
-        upload_id
+        {:ok, upload_id}
       end)
 
       # When
@@ -290,7 +290,7 @@ defmodule TuistWeb.PreviewsControllerTest do
       build_version = "123"
 
       expect(Storage, :multipart_start, fn _object_key, _actor ->
-        upload_id
+        {:ok, upload_id}
       end)
 
       # When
@@ -372,7 +372,7 @@ defmodule TuistWeb.PreviewsControllerTest do
         )
 
       expect(Storage, :multipart_start, fn _object_key, _actor ->
-        upload_id
+        {:ok, upload_id}
       end)
 
       # When

--- a/server/test/tuist_web/controllers/api/shards_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/shards_controller_test.exs
@@ -10,7 +10,7 @@ defmodule TuistWeb.API.ShardsControllerTest do
     user = AccountsFixtures.user_fixture(preload: [:account])
     project = ProjectsFixtures.project_fixture(preload: [:account], account_id: user.account.id)
 
-    stub(Tuist.Storage, :multipart_start, fn _key, _account -> "upload-id-123" end)
+    stub(Tuist.Storage, :multipart_start, fn _key, _account -> {:ok, "upload-id-123"} end)
 
     %{user: user, project: project}
   end
@@ -258,6 +258,30 @@ defmodule TuistWeb.API.ShardsControllerTest do
 
       response = json_response(conn, :bad_request)
       assert response["message"] =~ "shard_plan_id or reference"
+    end
+
+    test "returns bad gateway when the storage backend fails to start the upload", %{
+      conn: conn,
+      user: user,
+      project: project
+    } do
+      plan_id = Ecto.UUID.generate()
+
+      stub(Tuist.Shards, :start_upload_for_plan_id, fn _project, _account, ^plan_id ->
+        {:error, {:http_error, 400, %{body: "AuthorizationHeaderMalformed"}}}
+      end)
+
+      conn =
+        conn
+        |> Authentication.put_current_user(user)
+        |> put_req_header("content-type", "application/json")
+        |> post(
+          ~p"/api/projects/#{project.account.name}/#{project.name}/tests/shards/upload/start",
+          %{shard_plan_id: plan_id}
+        )
+
+      response = json_response(conn, :bad_gateway)
+      assert response["message"] =~ "could not start the upload"
     end
   end
 

--- a/tuist_common/lib/tuist_common/aws/client.ex
+++ b/tuist_common/lib/tuist_common/aws/client.ex
@@ -11,6 +11,19 @@ defmodule TuistCommon.AWS.Client do
         receive_timeout: 30_000
 
   The default config handles setting the above.
+
+  ## Redirects
+
+  Req follows redirects by default, but AWS requests are signed with SigV4 for a
+  specific host. If Req transparently follows a redirect (for example S3
+  answering a region mismatch with a 301/307 to a different endpoint), it resends
+  the request to the new host while reusing the `Authorization` header signed for
+  the original host, which the new host rejects as an improperly signed request.
+
+  We disable Req's automatic redirect handling so that redirects surface to ExAws
+  (which knows how to re-sign and retry against the right region) instead of being
+  followed with a stale signature. We also drop the legacy `:follow_redirect`
+  option so it never leaks into `Req.request/1`.
   """
 
   @behaviour ExAws.Request.HttpClient
@@ -35,6 +48,7 @@ defmodule TuistCommon.AWS.Client do
       |> Keyword.merge(req_opts)
       |> Keyword.merge(http_opts_list)
       |> Keyword.delete(:follow_redirect)
+      |> Keyword.put(:redirect, false)
 
     opts =
       if Keyword.get(opts, :finch) do

--- a/tuist_common/test/tuist_common/aws/client_test.exs
+++ b/tuist_common/test/tuist_common/aws/client_test.exs
@@ -79,7 +79,7 @@ defmodule TuistCommon.AWS.ClientTest do
       Application.delete_env(:ex_aws, :req_opts)
     end
 
-    test "removes follow_redirect from options" do
+    test "removes follow_redirect from options and disables Req redirect following" do
       Application.put_env(:tuist_common, :finch_name, TestFinch)
       Application.put_env(:ex_aws, :req_opts, [])
 
@@ -87,12 +87,29 @@ defmodule TuistCommon.AWS.ClientTest do
 
       expect(Req, :request, fn opts ->
         refute Keyword.has_key?(opts, :follow_redirect)
+        assert Keyword.get(opts, :redirect) == false
 
         {:ok, %Req.Response{status: 200, headers: %{}, body: "ok"}}
       end)
 
       assert {:ok, %{status_code: 200}} =
                Client.request(:get, "https://example.com", "", [], http_opts)
+    after
+      Application.delete_env(:tuist_common, :finch_name)
+      Application.delete_env(:ex_aws, :req_opts)
+    end
+
+    test "keeps Req redirect following disabled even if req_opts try to enable it" do
+      Application.put_env(:tuist_common, :finch_name, TestFinch)
+      Application.put_env(:ex_aws, :req_opts, redirect: true)
+
+      expect(Req, :request, fn opts ->
+        assert Keyword.get(opts, :redirect) == false
+
+        {:ok, %Req.Response{status: 200, headers: %{}, body: "ok"}}
+      end)
+
+      assert {:ok, %{status_code: 200}} = Client.request(:get, "https://example.com")
     after
       Application.delete_env(:tuist_common, :finch_name)
       Application.delete_env(:ex_aws, :req_opts)


### PR DESCRIPTION
## Context

Follow-ups from a self-hosted module-cache incident (server `1.219.0`, AWS S3 backend): `POST /api/cache/module/start` returned `200 {"upload_id": null}` while the object was never stored, so later fetches 404'd and the cache was effectively write-only. The root cause turned out to be in a self-managed ingress/reverse-proxy that fronts the S3-backed cache routes. These changes make that class of failure **loud and observable** across the stack and document the proxy gotchas for self-hosters.

This PR addresses the agreed follow-ups except single-artifact eviction (explicitly out of scope for now).

## What's here

**`fix(server)` — surface multipart upload start failures**
- `Storage.multipart_start/2` no longer swallows S3 errors / a missing upload id. It returns `{:ok, upload_id} | {:error, reason}`, emits a `…multipart.start_upload_error` telemetry event + `tuist_storage_multipart_start_upload_error` PromEx counter, and logs the rejected request.
- The cache, build-insights, build-archive, preview, and shard upload endpoints now return `502` when the backend rejects the start request instead of reporting a fake `200` success.

**`fix(server)` — stop following redirects on signed S3 requests** (`tuist_common`)
- The ExAws Req client deleted a non-existent `:follow_redirect` option (Req uses `:redirect`), so Req still auto-followed redirects and resent them with the SigV4 `Authorization` header signed for the *original* host → improperly-signed request. Redirects are now disabled so they surface to ExAws for proper re-signing.

**`feat(kura)` — record module cache upload start outcomes**
- A `null` upload id from `/api/cache/module/start` is the legitimate "already cached, skip upload" contract — indistinguishable from a failure without instrumentation. Added `kura_multipart_starts_total` labelled by outcome (`already_exists` / `started` / `start_failed` / `exists_check_failed`) and a warning log on the failure paths.

**`fix(cli)` — warn when a module cache store fails**
- The upload service logged nothing on failure, which is what made the silent write-only cache hard to diagnose. It now warns on start/part/complete failure (and debug-logs the already-cached case) while keeping the existing throwing behaviour.

**`docs(server)` — reverse-proxying cache traffic to object storage**
- Documents the two boundary issues to watch for: strip the inbound `Authorization` header on the S3-bound proxy route (S3 rejects two auth mechanisms), and raise `client_max_body_size` for multipart part uploads. Includes an nginx example.

## Testing

- **server**: `mix compile --warnings-as-errors` ✅, `mix credo` (changed files) ✅, affected suites green (storage, shards, cache/analytics/builds/previews/shards controllers — 229 tests). Added error-path coverage for `Storage.multipart_start` and the `502` responses.
- **tuist_common**: `client_test.exs` ✅ (new redirect-disabled assertions).
- **kura**: `cargo check --tests` ✅, `cargo clippy --tests` ✅, `cargo fmt` ✅, `metrics` + `http multipart_module` tests ✅.
- **cli**: not compiled locally (heavy Swift build); change is conservative and matches existing `Logger.current` usage.

## Notes for reviewers

- **CLI non-blocking policy**: the build-blocking-vs-warning decision lives at the `uploadArtifact` call site in the private `TuistCacheEE` submodule, which can't change in this monorepo PR. This PR adds the missing diagnostic in the open service and preserves throw semantics; flipping a failed store to strictly non-blocking is a small follow-up in `TuistCacheEE`.
- **OpenAPI spec**: I intentionally did **not** add `bad_gateway` to the OpenApiSpex `responses:` maps / regenerate `cli/Sources/TuistServer/OpenAPI/server.yml`. The committed spec is already far out of sync with `mix openapi.spec.yaml` output (the freshness check is currently commented out), so regenerating would bury this change under a ~29k-line reordering diff. The `502` is handled by the generated client's `undocumented` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
