### PR TITLE
fix(cli): add xcframework Headers root for cached static-objc-behind-dynamic deps (ARCore) [4.201.x backport]

### DIFF
--- a/cli/Sources/TuistKit/Mappers/Graph/StaticXCFrameworkModuleMapGraphMapper.swift
+++ b/cli/Sources/TuistKit/Mappers/Graph/StaticXCFrameworkModuleMapGraphMapper.swift
@@ -144,9 +144,26 @@ public struct StaticXCFrameworkModuleMapGraphMapper: GraphMapping {
                     staticObjcXCFrameworksWithLibrariesLinkedByDynamicXCFrameworkDependencies.flatMap { xcframework -> [String] in
                         guard let moduleMap = xcframework.moduleMaps.first
                         else { return [] }
-                        return [
-                            "\"$(SRCROOT)/\(moduleMap.parentDirectory.relative(to: project.path).pathString)\"",
-                        ]
+                        // The module map's own directory lets the rewritten umbrella header resolve its
+                        // (now unprefixed) imports. ARCore-style headers additionally re-import each other
+                        // with the framework prefix (e.g. `#import <ARCoreGARSession/GARTrackingState.h>`),
+                        // which only resolves when the xcframework's `Headers` root is on the search path too.
+                        // That root is otherwise dropped for module-map-bearing xcframeworks (see
+                        // `GraphTraverser.librariesPublicHeadersFolders`) because directly-linked xcframeworks
+                        // pick it up from `ProcessXCFramework`'s `include/` copy — but static xcframeworks
+                        // reached behind a dynamic one are never processed, so we add it back here.
+                        let moduleMapSearchPath =
+                            "\"$(SRCROOT)/\(moduleMap.parentDirectory.relative(to: project.path).pathString)\""
+                        let headerRootSearchPaths = xcframework.infoPlist.libraries.compactMap { library -> String? in
+                            guard target.supportedPlatforms.contains(library.platform.graphPlatform),
+                                  let headersPath = library.headersPath
+                            else { return nil }
+                            let headersRoot = xcframework.path
+                                .appending(component: library.identifier)
+                                .appending(headersPath)
+                            return "\"$(SRCROOT)/\(headersRoot.relative(to: project.path).pathString)\""
+                        }
+                        return [moduleMapSearchPath] + headerRootSearchPaths
                     }
                 )
             }

--- a/cli/Tests/TuistKitTests/Mappers/Graph/StaticXCFrameworkModuleMapGraphMapperTests.swift
+++ b/cli/Tests/TuistKitTests/Mappers/Graph/StaticXCFrameworkModuleMapGraphMapperTests.swift
@@ -182,6 +182,150 @@ final class StaticXCFrameworkModuleMapGraphMapperTests: TuistUnitTestCase {
         )
     }
 
+    func test_map_when_static_xcframework_library_with_nested_module_headers_linked_via_dynamic_xcframework() async throws {
+        // Given
+        // ARCore-like layout: the headers live in a `<Module>` subdirectory and re-import each other with the
+        // framework prefix (`#import <ARCoreGARSession/GARTrackingState.h>`). Resolving those prefixed imports
+        // requires the xcframework's `Headers` root on the search path, not only the module map's directory.
+        let projectPath = try temporaryPath()
+            .appending(component: "Project")
+        given(manifestFilesLocator)
+            .locatePackageManifest(at: .any)
+            .willReturn(
+                projectPath.appending(components: Constants.tuistDirectoryName, Constants.SwiftPackageManager.packageSwiftName)
+            )
+        let arcorePath = projectPath
+            .parentDirectory
+            .appending(component: "ARCoreGARSession.xcframework")
+        let arcoreHeadersRoot = arcorePath.appending(components: "ios-arm64", "Headers")
+        let arcoreModuleHeadersPath = arcoreHeadersRoot.appending(component: "ARCoreGARSession")
+        try await fileSystem.makeDirectory(at: arcoreModuleHeadersPath)
+        try await fileSystem.writeText(
+            "modulemap",
+            at: arcoreModuleHeadersPath.appending(component: "module.modulemap")
+        )
+        try await fileSystem.writeText(
+            """
+            #import <ARCoreGARSession/GARAnchor.h>
+            #import <ARCoreGARSession/GARTrackingState.h>
+            """,
+            at: arcoreModuleHeadersPath.appending(component: "ARCoreGARSession.h")
+        )
+
+        let derivedDirectory = projectPath.appending(
+            components: [
+                Constants.tuistDirectoryName,
+                Constants.SwiftPackageManager.packageBuildDirectoryName,
+                Constants.DerivedDirectory.dependenciesDerivedDirectory,
+                Constants.DerivedDirectory.dependenciesXCFrameworkDirectory,
+            ]
+        )
+
+        let graph: Graph = .test(
+            name: "App",
+            path: projectPath,
+            projects: [
+                projectPath: .test(
+                    path: projectPath,
+                    targets: [
+                        .test(
+                            name: "App"
+                        ),
+                    ]
+                ),
+            ],
+            dependencies: [
+                .target(name: "App", path: projectPath): [
+                    .testXCFramework(
+                        path: try temporaryPath()
+                            .appending(component: "DynamicFramework.xcframework")
+                    ),
+                ],
+                .testXCFramework(
+                    path: try temporaryPath()
+                        .appending(component: "DynamicFramework.xcframework")
+                ): [
+                    .testXCFramework(
+                        path: arcorePath,
+                        infoPlist: .test(
+                            libraries: [
+                                .test(
+                                    identifier: "ios-arm64",
+                                    path: try RelativePath(validating: "ARCoreGARSession.a"),
+                                    headersPath: try RelativePath(validating: "Headers"),
+                                    platform: .iOS
+                                ),
+                            ]
+                        ),
+                        linking: .static,
+                        moduleMaps: [
+                            arcoreModuleHeadersPath.appending(component: "module.modulemap"),
+                        ]
+                    ),
+                ],
+            ]
+        )
+
+        var expectedGraph = graph
+        expectedGraph.projects = [
+            projectPath: .test(
+                path: projectPath,
+                targets: [
+                    .test(
+                        name: "App",
+                        settings: .test(
+                            base: [
+                                "OTHER_SWIFT_FLAGS": [
+                                    "-Xcc",
+                                    "-fmodule-map-file=\"$(SRCROOT)/Tuist/.build/tuist-derived/XCFrameworks/ARCoreGARSession/Headers/module.modulemap\"",
+                                ],
+                                "OTHER_C_FLAGS": [
+                                    "-fmodule-map-file=\"$(SRCROOT)/Tuist/.build/tuist-derived/XCFrameworks/ARCoreGARSession/Headers/module.modulemap\"",
+                                ],
+                                "HEADER_SEARCH_PATHS": [
+                                    "\"$(SRCROOT)/../ARCoreGARSession.xcframework/ios-arm64/Headers/ARCoreGARSession\"",
+                                    "\"$(SRCROOT)/../ARCoreGARSession.xcframework/ios-arm64/Headers\"",
+                                ],
+                            ]
+                        )
+                    ),
+                ]
+            ),
+        ]
+
+        // When
+        let (gotGraph, gotSideEffects, _) = try await subject.map(graph: graph, environment: MapperEnvironment())
+
+        // Then
+        XCTAssertBetterEqual(
+            expectedGraph,
+            gotGraph
+        )
+        XCTAssertBetterEqual(
+            [
+                .directory(
+                    DirectoryDescriptor(path: derivedDirectory.appending(components: "ARCoreGARSession", "Headers"))
+                ),
+                .file(
+                    FileDescriptor(
+                        path: derivedDirectory.appending(components: "ARCoreGARSession", "Headers", "module.modulemap"),
+                        contents: "modulemap".data(using: .utf8)
+                    )
+                ),
+                .file(
+                    FileDescriptor(
+                        path: derivedDirectory.appending(components: "ARCoreGARSession", "Headers", "ARCoreGARSession.h"),
+                        contents: """
+                        #import <GARAnchor.h>
+                        #import <GARTrackingState.h>
+                        """.data(using: .utf8)
+                    )
+                ),
+            ],
+            gotSideEffects
+        )
+    }
+
     func test_map_when_static_xcframework_framework_linked_via_dynamic_xcframework() async throws {
         // Given
         let projectPath = try temporaryPath()


### PR DESCRIPTION
Backport of #11506 to `releases/4.201.x`.

> Fixes ARCore (and similarly-shaped Google SDK xcframeworks) failing to build when consumed from the binary cache.

### What changed

`StaticXCFrameworkModuleMapGraphMapper` now also adds each matching slice's `Headers` **root** to a consuming target's `HEADER_SEARCH_PATHS`, in addition to the module map's own directory. Clean cherry-pick of the squashed merge commit `addbf41` (patch-id verified identical; no conflicts).

### Why this is needed on the RC line

The regression chain that produced the customer-reported error lives entirely on this release line:

- rc.1 (#11290) added all xcframework `Headers` → `redefinition of module 'ARCoreGARSession'`.
- rc.2 (#11472 → backport #11482) excluded module-map xcframework headers → fixed the redefinition, but removed the `Headers` **root** the cached static-objc-behind-dynamic path needs, surfacing `'ARCoreGARSession/GARTrackingState.h' file not found`.
- This PR restores that root for the cached static-behind-dynamic path only — nested layouts (ARCore) resolve prefixed sibling imports without re-introducing a second discoverable module map, and flat layouts (GoogleMaps) dedupe to no-op.

Without this backport, anyone on 4.201.0-rc.x that caches ARCore is still broken. With #11482 already on this branch, this is the completing fix for the rc.2 trade-off.

### How to test locally

1. `tuist generate TuistKit TuistKitTests --no-open`
2. `xcodebuild test -workspace Tuist.xcworkspace -scheme Tuist-Workspace -only-testing TuistKitTests/StaticXCFrameworkModuleMapGraphMapperTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""`

The new test `test_map_when_static_xcframework_library_with_nested_module_headers_linked_via_dynamic_xcframework` asserts both the module-map dir and the `Headers` root land on `HEADER_SEARCH_PATHS`. Full suite green on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)