### PR TITLE
fix(kura): group-commit segment fsyncs to complete cold-mesh-bootstrap write throughput

### DIFF
--- a/kura/src/app.rs
+++ b/kura/src/app.rs
@@ -457,6 +457,9 @@ fn spawn_snapshot_task(state: Arc<AppState>) {
                         state
                             .metrics
                             .update_multipart_uploads(snapshot.multipart_uploads);
+                        state
+                            .metrics
+                            .update_segment_fsyncs(snapshot.segment_fsync_count);
                         for (generation, count) in snapshot.segment_counts {
                             state
                                 .metrics

--- a/kura/src/failpoints.rs
+++ b/kura/src/failpoints.rs
@@ -2,6 +2,7 @@ use std::{collections::BTreeMap, sync::Mutex, time::Duration};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub(crate) enum FailpointName {
+    BeforeSegmentFsync,
     AfterArtifactBytesDurableBeforeMetadata,
     AfterMetadataCommitBeforeReturn,
     AfterReadArtifactBytesBeforeReturn,
@@ -15,6 +16,7 @@ pub(crate) enum FailpointName {
 impl FailpointName {
     fn as_str(self) -> &'static str {
         match self {
+            Self::BeforeSegmentFsync => "before_segment_fsync",
             Self::AfterArtifactBytesDurableBeforeMetadata => {
                 "after_artifact_bytes_durable_before_metadata"
             }

--- a/kura/src/metrics.rs
+++ b/kura/src/metrics.rs
@@ -46,6 +46,10 @@ pub struct Metrics {
     segment_refresh_bytes: Family<ArtifactOpLabels, Counter>,
     segment_refresh_duration: Family<ArtifactRouteLabels, Histogram>,
     segment_evicted_artifacts: Family<ArtifactOpLabels, Counter>,
+    // Cumulative segment fsyncs (group-commit durability + rotation). Compared
+    // against kura_artifact_writes_total, its rate shows how hard concurrent
+    // writes batch their durability fsyncs (≪ 1 fsync per write under load).
+    segment_fsyncs: Counter,
     replication_requests: Family<ReplicationLabels, Counter>,
     replication_request_duration: Family<ReplicationRouteLabels, Histogram>,
     replication_apply_results: Family<ReplicationApplyLabels, Counter>,
@@ -152,6 +156,7 @@ impl Metrics {
         let http_exceptions = Family::<HttpExceptionLabels, Counter>::default();
         let artifact_reads = Family::<ArtifactOpLabels, Counter>::default();
         let artifact_writes = Family::<ArtifactOpLabels, Counter>::default();
+        let segment_fsyncs = Counter::default();
         let artifact_read_bytes = Family::<ArtifactOpLabels, Counter>::default();
         let artifact_write_bytes = Family::<ArtifactOpLabels, Counter>::default();
         let artifact_egress_completions = Family::<ArtifactOpLabels, Counter>::default();
@@ -312,6 +317,11 @@ impl Metrics {
             "kura_artifact_writes_total",
             "Artifact writes by producer and result",
             artifact_writes.clone(),
+        );
+        registry.register(
+            "kura_segment_fsyncs_total",
+            "Segment durability fsyncs (group-commit + rotation); compare its rate to kura_artifact_writes_total to see fsync batching under concurrent writes",
+            segment_fsyncs.clone(),
         );
         registry.register(
             "kura_artifact_read_bytes_total",
@@ -766,6 +776,7 @@ impl Metrics {
             http_exceptions,
             artifact_reads,
             artifact_writes,
+            segment_fsyncs,
             artifact_read_bytes,
             artifact_write_bytes,
             artifact_egress_completions,
@@ -1226,6 +1237,16 @@ impl Metrics {
         self.rollout_snapshot
             .outbox_messages
             .store(count as u64, Ordering::Relaxed);
+    }
+
+    pub fn update_segment_fsyncs(&self, total: u64) {
+        // The store tracks the cumulative fsync count as a process-local atomic
+        // that resets to 0 on restart, exactly like this Counter. Advance the
+        // Counter by the delta since the last sample so `rate()` is well-defined.
+        let recorded = self.segment_fsyncs.get();
+        if total > recorded {
+            self.segment_fsyncs.inc_by(total - recorded);
+        }
     }
 
     pub fn update_multipart_uploads(&self, count: usize) {

--- a/kura/src/store.rs
+++ b/kura/src/store.rs
@@ -78,6 +78,14 @@ pub struct Store {
     // Counts segment fsyncs so tests can assert durability is batched across
     // concurrent writers rather than one fsync per write under the global lock.
     segment_fsync_count: Arc<AtomicU64>,
+    // Group-commit durability. Writers reserve a monotonic `pending_seq` while
+    // holding `segment_write_lock` (so their bytes are appended in order), then
+    // a single fsync — serialized by `fsync_lock` — advances `durable_seq` to
+    // cover every writer that appended before it. A writer whose seq is already
+    // <= `durable_seq` skips the fsync entirely.
+    pending_seq: AtomicU64,
+    durable_seq: AtomicU64,
+    fsync_lock: Mutex<()>,
     segment_refresh_lock: Mutex<()>,
     segment_state_lock: Mutex<()>,
     // Wrapped in `Arc` so readers clone the snapshot under a brief lock and then
@@ -366,6 +374,9 @@ impl Store {
             rocksdb_write_buffer_manager,
             segment_write_lock: Mutex::new(()),
             segment_fsync_count: Arc::new(AtomicU64::new(0)),
+            pending_seq: AtomicU64::new(0),
+            durable_seq: AtomicU64::new(0),
+            fsync_lock: Mutex::new(()),
             segment_refresh_lock: Mutex::new(()),
             segment_state_lock: Mutex::new(()),
             segment_state_cache: StdMutex::new(Arc::new(SegmentStateSnapshot::default())),
@@ -1060,59 +1071,114 @@ impl Store {
     where
         R: AsyncRead + Unpin,
     {
-        let _guard = self.segment_write_lock.lock().await;
-        let (segment, evicted_segments) = self.active_segment(size).await?;
-        let segment_path = self.segment_path(&segment.segment_id);
-        let segment_dir = segment_path
-            .parent()
-            .ok_or_else(|| "missing segment parent directory".to_string())?;
-        self.io.create_dir_all(segment_dir).await?;
+        // Append the bytes under the write lock (which also fsyncs the outgoing
+        // segment on rotation), then reserve a durability sequence. The fsync
+        // itself happens after the lock so concurrent writers coalesce into a
+        // single group-commit fsync rather than serializing one fsync each.
+        let (location, evicted_segments, durability_seq) = {
+            let _guard = self.segment_write_lock.lock().await;
+            let (segment, evicted_segments) = self.active_segment(size).await?;
+            let segment_path = self.segment_path(&segment.segment_id);
+            let segment_dir = segment_path
+                .parent()
+                .ok_or_else(|| "missing segment parent directory".to_string())?;
+            self.io.create_dir_all(segment_dir).await?;
 
-        let segment_already_exists = self.io.path_exists(&segment_path).await?;
-        let offset = if segment_already_exists {
-            self.io.metadata_len(&segment_path).await?
-        } else {
-            0
-        };
+            let segment_already_exists = self.io.path_exists(&segment_path).await?;
+            let offset = if segment_already_exists {
+                self.io.metadata_len(&segment_path).await?
+            } else {
+                0
+            };
 
-        let mut destination = self.io.open_append_file(&segment_path).await?;
-        let copied = tokio::io::copy(source, &mut destination)
-            .await
-            .map_err(|error| {
+            let mut destination = self.io.open_append_file(&segment_path).await?;
+            let copied = tokio::io::copy(source, &mut destination)
+                .await
+                .map_err(|error| {
+                    format!(
+                        "failed to append into segment {}: {error}",
+                        segment_path.display()
+                    )
+                })?;
+            if copied != size {
+                return Err(format!(
+                    "appended {copied} bytes into segment {}, expected {size}",
+                    segment_path.display()
+                ));
+            }
+            destination.flush().await.map_err(|error| {
                 format!(
-                    "failed to append into segment {}: {error}",
+                    "failed to flush segment {}: {error}",
                     segment_path.display()
                 )
             })?;
-        if copied != size {
-            return Err(format!(
-                "appended {copied} bytes into segment {}, expected {size}",
-                segment_path.display()
-            ));
-        }
-        destination.flush().await.map_err(|error| {
-            format!(
-                "failed to flush segment {}: {error}",
-                segment_path.display()
-            )
-        })?;
-        self.hit_failpoint(FailpointName::BeforeSegmentFsync).await?;
-        self.segment_fsync_count.fetch_add(1, Ordering::Relaxed);
-        destination.sync_data().await.map_err(|error| {
-            format!("failed to sync segment {}: {error}", segment_path.display())
-        })?;
-        drop(destination);
-        if !segment_already_exists {
-            self.io.sync_directory(segment_dir).await?;
-        }
+            drop(destination);
+            if !segment_already_exists {
+                self.io.sync_directory(segment_dir).await?;
+            }
 
-        Ok((
-            SegmentLocation {
-                segment_id: segment.segment_id,
-                offset,
-            },
-            evicted_segments,
-        ))
+            let durability_seq = self.pending_seq.fetch_add(1, Ordering::AcqRel) + 1;
+            (
+                SegmentLocation {
+                    segment_id: segment.segment_id,
+                    offset,
+                },
+                evicted_segments,
+                durability_seq,
+            )
+        };
+
+        self.ensure_segment_durable(durability_seq).await?;
+
+        Ok((location, evicted_segments))
+    }
+
+    /// Group-commit fsync: makes every append with sequence `<= seq` durable.
+    ///
+    /// Writers reserve `pending_seq` in append order while holding the write
+    /// lock, then call this. The first writer to win `fsync_lock` performs one
+    /// fsync of the active segment and advances `durable_seq` to the latest
+    /// reserved sequence. That is correct because a segment is fsynced when it
+    /// rotates out (see `active_segment`), so only the active segment can hold
+    /// un-synced bytes — and if the active segment rotated between a writer's
+    /// append and this fsync, that writer's bytes were already made durable by
+    /// the rotation. Writers already covered by a prior fsync return without
+    /// syncing.
+    async fn ensure_segment_durable(&self, seq: u64) -> Result<(), String> {
+        if self.durable_seq.load(Ordering::Acquire) >= seq {
+            return Ok(());
+        }
+        let _commit = self.fsync_lock.lock().await;
+        if self.durable_seq.load(Ordering::Acquire) >= seq {
+            return Ok(());
+        }
+        self.hit_failpoint(FailpointName::BeforeSegmentFsync)
+            .await?;
+        // Capture after winning the commit lock so the fsync covers writers that
+        // appended while we queued.
+        let target = self.pending_seq.load(Ordering::Acquire);
+        self.fsync_active_segment().await?;
+        self.durable_seq.store(target, Ordering::Release);
+        Ok(())
+    }
+
+    /// Fsyncs the current active segment file. A fresh handle is fine: `sync_data`
+    /// flushes the inode's dirty pages regardless of which descriptor wrote them.
+    async fn fsync_active_segment(&self) -> Result<(), String> {
+        let snapshot = self.segment_state_snapshot();
+        let Some(active) = snapshot.state.active() else {
+            return Ok(());
+        };
+        let path = self.segment_path(&active.segment_id);
+        if !self.io.path_exists(&path).await? {
+            return Ok(());
+        }
+        let file = self.io.open_append_file(&path).await?;
+        self.segment_fsync_count.fetch_add(1, Ordering::Relaxed);
+        file.sync_data()
+            .await
+            .map_err(|error| format!("failed to sync segment {}: {error}", path.display()))?;
+        Ok(())
     }
 
     async fn active_segment(
@@ -1142,6 +1208,22 @@ impl Store {
                     "{DISK_FULL_MARKER}: insufficient free space for segment rotation: \
                     {available} bytes available, {required_bytes} required"
                 ));
+            }
+            // Group commit no longer fsyncs each write, so the outgoing active
+            // segment may hold un-synced appends; make them durable before it
+            // stops being the fsync target.
+            if let Some(active) = snapshot.state.active() {
+                let path = self.segment_path(&active.segment_id);
+                if self.io.path_exists(&path).await? {
+                    let file = self.io.open_append_file(&path).await?;
+                    self.segment_fsync_count.fetch_add(1, Ordering::Relaxed);
+                    file.sync_data().await.map_err(|error| {
+                        format!(
+                            "failed to sync rotating segment {}: {error}",
+                            path.display()
+                        )
+                    })?;
+                }
             }
             let segment = SegmentReference::new(Uuid::now_v7().to_string(), now_ms());
             // The rotate decision above used a snapshot taken before the

--- a/kura/src/store.rs
+++ b/kura/src/store.rs
@@ -103,6 +103,7 @@ pub struct StoreSnapshot {
     pub outbox_messages: usize,
     pub multipart_uploads: usize,
     pub segment_counts: Vec<(&'static str, usize)>,
+    pub segment_fsync_count: u64,
     pub rocksdb_block_cache_usage_bytes: u64,
     pub rocksdb_block_cache_pinned_usage_bytes: u64,
     pub rocksdb_block_cache_capacity_bytes: u64,
@@ -2189,6 +2190,7 @@ impl Store {
             outbox_messages,
             multipart_uploads,
             segment_counts,
+            segment_fsync_count: self.segment_fsync_count.load(Ordering::Relaxed),
             rocksdb_block_cache_usage_bytes: self.rocksdb_block_cache.get_usage() as u64,
             rocksdb_block_cache_pinned_usage_bytes: self.rocksdb_block_cache.get_pinned_usage()
                 as u64,
@@ -4464,6 +4466,56 @@ mod tests {
             fsyncs <= 4,
             "expected concurrent writes to batch segment fsyncs (<=4) but observed {fsyncs} \
              for {writers} writers — every write is fsyncing under the global segment write lock"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn concurrent_replicated_artifact_applies_batch_segment_fsyncs() {
+        let (_temp_dir, _config, store) = temp_store();
+        let store = Arc::new(store);
+
+        // A fresh node bootstrapping an account applies inbound artifacts
+        // concurrently (BOOTSTRAP_ARTIFACT_FETCH_CONCURRENCY at a time). Inbound
+        // applies share the foreground write's segment-append + durability path
+        // (`persist_artifact_from_path_with_version`), so group commit must
+        // coalesce their fsyncs too — otherwise the parallel bootstrap fetch just
+        // re-serializes one fsync per inbound write and gains nothing. Slow every
+        // fsync so all appliers reach the durability barrier within one window.
+        store.failpoints().set_always(
+            FailpointName::BeforeSegmentFsync,
+            FailpointAction::Sleep(std::time::Duration::from_millis(50)),
+        );
+
+        let appliers = 16u64;
+        let mut handles = Vec::new();
+        for i in 0..appliers {
+            let store = store.clone();
+            handles.push(tokio::spawn(async move {
+                store
+                    .apply_replicated_artifact_from_bytes(
+                        ArtifactProducer::Xcode,
+                        "ns",
+                        &format!("key-{i}"),
+                        "application/octet-stream",
+                        format!("artifact-body-{i}").as_bytes(),
+                        1_000 + i,
+                    )
+                    .await
+                    .expect("replicated artifact should apply");
+            }));
+        }
+        for handle in handles {
+            handle.await.expect("applier task should complete");
+        }
+
+        let fsyncs = store
+            .segment_fsync_count
+            .load(std::sync::atomic::Ordering::Relaxed);
+        assert!(
+            fsyncs <= 4,
+            "expected concurrent replicated applies to batch segment fsyncs (<=4) but observed \
+             {fsyncs} for {appliers} appliers — inbound bootstrap writes are fsyncing per write \
+             under the global segment write lock"
         );
     }
 

--- a/kura/src/store.rs
+++ b/kura/src/store.rs
@@ -2,7 +2,10 @@ use std::{
     collections::{BTreeMap, HashMap},
     path::{Path, PathBuf},
     pin::Pin,
-    sync::{Arc, Mutex as StdMutex},
+    sync::{
+        Arc, Mutex as StdMutex,
+        atomic::{AtomicU64, Ordering},
+    },
     task::{Context, Poll},
     time::{Duration, Instant},
 };
@@ -72,6 +75,9 @@ pub struct Store {
     rocksdb_block_cache: Cache,
     rocksdb_write_buffer_manager: WriteBufferManager,
     segment_write_lock: Mutex<()>,
+    // Counts segment fsyncs so tests can assert durability is batched across
+    // concurrent writers rather than one fsync per write under the global lock.
+    segment_fsync_count: Arc<AtomicU64>,
     segment_refresh_lock: Mutex<()>,
     segment_state_lock: Mutex<()>,
     // Wrapped in `Arc` so readers clone the snapshot under a brief lock and then
@@ -359,6 +365,7 @@ impl Store {
             rocksdb_block_cache,
             rocksdb_write_buffer_manager,
             segment_write_lock: Mutex::new(()),
+            segment_fsync_count: Arc::new(AtomicU64::new(0)),
             segment_refresh_lock: Mutex::new(()),
             segment_state_lock: Mutex::new(()),
             segment_state_cache: StdMutex::new(Arc::new(SegmentStateSnapshot::default())),
@@ -1089,6 +1096,8 @@ impl Store {
                 segment_path.display()
             )
         })?;
+        self.hit_failpoint(FailpointName::BeforeSegmentFsync).await?;
+        self.segment_fsync_count.fetch_add(1, Ordering::Relaxed);
         destination.sync_data().await.map_err(|error| {
             format!("failed to sync segment {}: {error}", segment_path.display())
         })?;
@@ -4326,6 +4335,54 @@ mod tests {
                 }
             );
         }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn concurrent_artifact_writes_batch_segment_fsyncs() {
+        let (_temp_dir, config, store) = temp_store();
+        let store = Arc::new(store);
+
+        // Slow every segment fsync so all writers reach the durability barrier
+        // within one window. With one fsync per write under the global segment
+        // write lock these serialize (one fsync each); group commit must
+        // coalesce them into far fewer.
+        store.failpoints().set_always(
+            FailpointName::BeforeSegmentFsync,
+            FailpointAction::Sleep(std::time::Duration::from_millis(50)),
+        );
+
+        let writers = 16u64;
+        let mut handles = Vec::new();
+        for i in 0..writers {
+            let store = store.clone();
+            let path = config.tmp_dir.join(format!("artifact-{i}"));
+            std::fs::write(&path, format!("artifact-body-{i}")).expect("write artifact body");
+            handles.push(tokio::spawn(async move {
+                store
+                    .persist_artifact_from_path_and_enqueue(
+                        ArtifactProducer::Xcode,
+                        "ns",
+                        &format!("key-{i}"),
+                        "application/octet-stream",
+                        &path,
+                        &[],
+                    )
+                    .await
+                    .expect("artifact should persist");
+            }));
+        }
+        for handle in handles {
+            handle.await.expect("writer task should complete");
+        }
+
+        let fsyncs = store
+            .segment_fsync_count
+            .load(std::sync::atomic::Ordering::Relaxed);
+        assert!(
+            fsyncs <= 4,
+            "expected concurrent writes to batch segment fsyncs (<=4) but observed {fsyncs} \
+             for {writers} writers — every write is fsyncing under the global segment write lock"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What

Group-commit the segment durability fsync in the kura store so concurrent artifact writes share a single fsync instead of one fsync per write. This removes the last serialization point on the cold-mesh-bootstrap write path that the parallel bootstrap fetch (#11464) left in place.

## Why

Every artifact write (`put_blob_artifact` → `append_reader_to_segment`) held the global `segment_write_lock` across an `fsync` (`sync_data`). So all writes — foreground CAS saves and inbound peer replication alike — serialized at one fsync per write, capping write throughput at roughly `1 / fsync_latency`, single-threaded, no matter how many writers were in flight.

This is the missing half of the cold-mesh-bootstrap throughput work. #11464 made a fresh node fetch bootstrap artifacts concurrently (`buffer_unordered(BOOTSTRAP_ARTIFACT_FETCH_CONCURRENCY)`, 16 at a time) so it can finish a full bootstrap within `KURA_BOOTSTRAP_TIMEOUT_MS` instead of streaming serially. But all 16 of those concurrent fetches converge on the same per-write fsync and re-serialize there — the fetch is parallel, the durability is not, so the intended speedup is throttled back down to one-fsync-at-a-time. The same ceiling bites the cold-start replication storm, where many segments replicate into a recovering node at once.

Group-commit lets those N concurrent bootstrap/replication writes share ~1 fsync, so a fresh node finishes bootstrap — and a degraded mesh re-converges — materially faster, and the win grows with how much write concurrency is in flight (i.e. exactly the cold-start regime #11464 targets).

Reads were never the problem; this is purely the write/durability path.

> Out of scope: this is unrelated to the Xcode-CAS-vs-public-endpoint benchmark. That slowness was a client-side routing issue (the launchd CAS daemon never reached the PN node), fixed separately in #11501; the warm-cache benchmark is read-mostly and does not exercise this path.

## How

- Appends stay serialized and ordered under `segment_write_lock` (and still fsync the outgoing segment on rotation) but no longer fsync per write. Each append reserves a monotonic `pending_seq`.
- Durability happens after the lock in `ensure_segment_durable`: the first writer to win a separate `fsync_lock` performs a single fsync of the active segment and advances a `durable_seq` watermark to the latest reserved sequence. Writers already `<= durable_seq` return without syncing.
- Correctness across rotation and the lock-free fsync race rests on one invariant: a segment is fsynced when it rotates out, so only the active segment can ever hold un-synced bytes. If the active segment rotated between a writer's append and the group fsync, the rotation already made that writer's bytes durable; otherwise the group fsync covers them. Either way every append `<= durable_seq` is durable.

Net effect: N concurrent writes produce ~1 fsync instead of N, and it batches harder under more load.

## Validation

- TDD test `concurrent_artifact_writes_batch_segment_fsyncs`: slows the fsync via a `BeforeSegmentFsync` failpoint, fires **16** concurrent writes (matching `BOOTSTRAP_ARTIFACT_FETCH_CONCURRENCY`) and asserts they batch. It fails on the first commit (16 fsyncs, RED) and passes here (GREEN); its wall-clock drops ~0.92s → ~0.10s.
- Companion test `concurrent_replicated_artifact_applies_batch_segment_fsyncs` proves the same batching on the **replication-apply** path a bootstrapping node actually drives (`apply_replicated_artifact_from_bytes` → the shared `persist_artifact_from_path_with_version`), so the parallel bootstrap fetch isn't silently re-serialized at the fsync.
- New metric `kura_segment_fsyncs_total` (group-commit + rotation fsyncs), sampled from the store snapshot. Its rate against `kura_artifact_writes_total` is the on-node signal for the cold-node gate below — fsyncs should track *batches*, not writes.
- All 276 unit tests pass, including the durability/persistence/rotation tests (`segment_state_snapshot_survives_reopen`, `sweep_orphaned_segments_reclaims_crash_window_segment_and_metadata`, `bytestream_writes_persist_completely_under_concurrency`).
- `cargo fmt --check` and `cargo clippy --all-targets` both clean.

## Reviewer notes

- This is the durability-critical write path; the watermark/rotation reasoning above is what to scrutinize. The load-bearing invariant is "rotation fsyncs the outgoing segment."
- Not yet load-tested on a real node. Kept as a draft pending a **cold-node validation**: bring up a fresh node against a populated account (or replay a replication storm into a recovering mesh) and confirm the bootstrap/replication wall-clock drops (existing `kura_bootstrap_duration_seconds`) while `rate(kura_segment_fsyncs_total)` stays well below `rate(kura_artifact_writes_total)` under concurrent inbound writes. The warm-cache CAS benchmark is the wrong instrument here — it's read-mostly and exercises the separate routing path fixed in #11501.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
