### PR TITLE
fix(cli): stop cache-start respawn loop when not authenticated

### DIFF
--- a/cli/Sources/TuistKit/Services/Cache/CacheStartCommandService.swift
+++ b/cli/Sources/TuistKit/Services/Cache/CacheStartCommandService.swift
@@ -15,15 +15,18 @@ import TuistSupport
 
 struct CacheStartCommandService {
     private let serverEnvironmentService: ServerEnvironmentServicing
+    private let serverAuthenticationController: ServerAuthenticationControlling
     private let fileSystem: FileSysteming
     private let cacheURLStore: CacheURLStoring
 
     init(
         serverEnvironmentService: ServerEnvironmentServicing = ServerEnvironmentService(),
+        serverAuthenticationController: ServerAuthenticationControlling = ServerAuthenticationController(),
         cacheURLStore: CacheURLStoring = CacheURLStore(),
         fileSystem: FileSysteming = FileSystem()
     ) {
         self.serverEnvironmentService = serverEnvironmentService
+        self.serverAuthenticationController = serverAuthenticationController
         self.cacheURLStore = cacheURLStore
         self.fileSystem = fileSystem
     }
@@ -38,6 +41,20 @@ struct CacheStartCommandService {
 
         // Run the cache server with the cache-specific logger
         try await Logger.$current.withValue(cacheLogger) {
+            let serverURL = try resolveServerURL(url: url)
+
+            // When the daemon is launched without valid credentials (e.g. the user is
+            // logged out), exit cleanly instead of erroring out. The LaunchAgent only
+            // respawns the daemon on an unsuccessful exit, so returning here prevents
+            // launchd from restarting it every ~10 seconds — and creating a new session
+            // directory on each attempt — until the user authenticates.
+            guard try await serverAuthenticationController.authenticationToken(serverURL: serverURL) != nil else {
+                Logger.current.debug(
+                    "Not authenticated against \(serverURL.absoluteString). The cache daemon will exit without starting. Authenticate with `tuist auth login` or set TUIST_TOKEN, then re-run `tuist setup cache`."
+                )
+                return
+            }
+
             let analyticsDatabase = try CASAnalyticsDatabase()
             try analyticsDatabase.migrate()
             AnalyticsStateController(database: analyticsDatabase)
@@ -47,11 +64,6 @@ struct CacheStartCommandService {
             if try await !fileSystem.exists(socketPath.parentDirectory, isDirectory: true) {
                 try await fileSystem.makeDirectory(at: socketPath.parentDirectory)
             }
-
-            let configURL = url.flatMap { URL(string: $0) }
-            let serverURL = try configURL
-                .map { try serverEnvironmentService.url(configServerURL: $0) } ?? serverEnvironmentService
-                .url()
 
             Logger.current.debug("Warming cache endpoint URL for \(serverURL.absoluteString)")
             let accountHandle = fullHandle.split(separator: "/").first.map(String.init)
@@ -86,5 +98,11 @@ struct CacheStartCommandService {
                 }
             }
         }
+    }
+
+    private func resolveServerURL(url: String?) throws -> URL {
+        let configURL = url.flatMap { URL(string: $0) }
+        return try configURL
+            .map { try serverEnvironmentService.url(configServerURL: $0) } ?? serverEnvironmentService.url()
     }
 }

--- a/cli/Sources/TuistKit/Services/Setup/SetupCacheCommandService.swift
+++ b/cli/Sources/TuistKit/Services/Setup/SetupCacheCommandService.swift
@@ -14,12 +14,16 @@ import TuistSupport
 
 enum SetupCacheCommandServiceError: Equatable, LocalizedError {
     case missingFullHandle
+    case notAuthenticated
 
     var errorDescription: String? {
         switch self {
         case .missingFullHandle:
             return
                 "The 'Tuist.swift' file is missing a fullHandle. See how to set up a Tuist project at: https://tuist.dev/en/docs/guides/server/accounts-and-projects#projects"
+        case .notAuthenticated:
+            return
+                "You must be authenticated to set up the cache. Run `tuist auth login` (or set the `TUIST_TOKEN` environment variable) and run `tuist setup cache` again."
         }
     }
 }
@@ -28,17 +32,20 @@ struct SetupCacheCommandService {
     private let launchAgentService: LaunchAgentServicing
     private let configLoader: ConfigLoading
     private let serverEnvironmentService: ServerEnvironmentServicing
+    private let serverAuthenticationController: ServerAuthenticationControlling
     private let manifestLoader: ManifestLoading
 
     init(
         launchAgentService: LaunchAgentServicing = LaunchAgentService(),
         configLoader: ConfigLoading = ConfigLoader(),
         serverEnvironmentService: ServerEnvironmentServicing = ServerEnvironmentService(),
+        serverAuthenticationController: ServerAuthenticationControlling = ServerAuthenticationController(),
         manifestLoader: ManifestLoading = ManifestLoader.current
     ) {
         self.launchAgentService = launchAgentService
         self.configLoader = configLoader
         self.serverEnvironmentService = serverEnvironmentService
+        self.serverAuthenticationController = serverAuthenticationController
         self.manifestLoader = manifestLoader
     }
 
@@ -53,6 +60,13 @@ struct SetupCacheCommandService {
         }
 
         let serverURL = try serverEnvironmentService.url(configServerURL: config.url)
+
+        // Fail fast when the user is not authenticated. Otherwise we would install a
+        // LaunchAgent whose `cache-start` daemon immediately exits (cleanly) for lack of
+        // credentials, leaving setup looking successful while no cache daemon is running.
+        guard try await serverAuthenticationController.authenticationToken(serverURL: serverURL) != nil else {
+            throw SetupCacheCommandServiceError.notAuthenticated
+        }
 
         var programArguments = [
             "cache-start",

--- a/cli/Sources/TuistLaunchctl/LaunchAgentService.swift
+++ b/cli/Sources/TuistLaunchctl/LaunchAgentService.swift
@@ -225,7 +225,10 @@ public struct LaunchAgentService: LaunchAgentServicing {
             <key>RunAtLoad</key>
             <true/>
             <key>KeepAlive</key>
-            <true/>
+            <dict>
+                <key>SuccessfulExit</key>
+                <false/>
+            </dict>
         </dict>
         </plist>
         """

--- a/cli/Tests/TuistKitTests/Services/Cache/CacheStartCommandServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/Cache/CacheStartCommandServiceTests.swift
@@ -1,0 +1,48 @@
+import Foundation
+import Mockable
+import Testing
+import TuistCAS
+import TuistEnvironment
+import TuistLoggerTesting
+import TuistServer
+import TuistTesting
+
+@testable import TuistKit
+
+struct CacheStartCommandServiceTests {
+    private let serverURL = URL(string: "https://test.tuist.dev")!
+    private let serverEnvironmentService = MockServerEnvironmentServicing()
+    private let serverAuthenticationController = MockServerAuthenticationControlling()
+    private let cacheURLStore = MockCacheURLStoring()
+    private let subject: CacheStartCommandService
+
+    init() {
+        subject = CacheStartCommandService(
+            serverEnvironmentService: serverEnvironmentService,
+            serverAuthenticationController: serverAuthenticationController,
+            cacheURLStore: cacheURLStore
+        )
+    }
+
+    @Test(.withMockedEnvironment(), .withMockedLogger())
+    func run_exitsCleanlyWithoutStartingServer_whenNotAuthenticated() async throws {
+        // Given
+        given(serverEnvironmentService)
+            .url()
+            .willReturn(serverURL)
+        given(serverAuthenticationController)
+            .authenticationToken(serverURL: .value(serverURL))
+            .willReturn(nil)
+
+        // When
+        // A clean return (no thrown error, no started gRPC server) lets the daemon
+        // exit with status 0 so the KeepAlive LaunchAgent does not respawn it every
+        // ~10 seconds while the user is logged out.
+        try await subject.run(fullHandle: "tuist/tuist", url: nil)
+
+        // Then
+        verify(cacheURLStore)
+            .getCacheURL(for: .any, accountHandle: .any)
+            .called(0)
+    }
+}

--- a/cli/Tests/TuistKitTests/Services/Setup/SetupCacheCommandServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/Setup/SetupCacheCommandServiceTests.swift
@@ -24,6 +24,7 @@ struct SetupCacheCommandServiceTests {
     private let launchAgentService = MockLaunchAgentServicing()
     private let configLoader = MockConfigLoading()
     private let serverEnvironmentService = MockServerEnvironmentServicing()
+    private let serverAuthenticationController = MockServerAuthenticationControlling()
     private let manifestLoader = MockManifestLoading()
 
     init() {
@@ -31,6 +32,7 @@ struct SetupCacheCommandServiceTests {
             launchAgentService: launchAgentService,
             configLoader: configLoader,
             serverEnvironmentService: serverEnvironmentService,
+            serverAuthenticationController: serverAuthenticationController,
             manifestLoader: manifestLoader
         )
 
@@ -41,6 +43,10 @@ struct SetupCacheCommandServiceTests {
         given(serverEnvironmentService)
             .url(configServerURL: .any)
             .willReturn(Constants.URLs.production)
+
+        given(serverAuthenticationController)
+            .authenticationToken(serverURL: .any)
+            .willReturn(.project("token"))
 
         given(manifestLoader)
             .hasRootManifest(at: .any)
@@ -193,6 +199,27 @@ struct SetupCacheCommandServiceTests {
         await #expect(throws: SetupCacheCommandServiceError.missingFullHandle) {
             try await subject.run(path: nil)
         }
+    }
+
+    @Test(.withMockedEnvironment()) func setupCache_notAuthenticated() async throws {
+        // Given
+        let environment = try #require(Environment.mocked)
+        environment.currentExecutablePathStub = AbsolutePath("/usr/local/bin/tuist")
+
+        serverAuthenticationController.reset()
+        given(serverAuthenticationController)
+            .authenticationToken(serverURL: .any)
+            .willReturn(nil)
+
+        // When/Then: setup must fail fast rather than installing a LaunchAgent whose
+        // daemon would immediately exit because there are no credentials.
+        await #expect(throws: SetupCacheCommandServiceError.notAuthenticated) {
+            try await subject.run(path: nil)
+        }
+
+        verify(launchAgentService)
+            .setupLaunchAgent(label: .any, plistFileName: .any, programArguments: .any, environmentVariables: .any)
+            .called(0)
     }
 
     @Test(.inTemporaryDirectory, .withMockedEnvironment()) func setupCache_includesEnvironmentToken() async throws {

--- a/cli/Tests/TuistLaunchctlTests/LaunchAgentServiceTests.swift
+++ b/cli/Tests/TuistLaunchctlTests/LaunchAgentServiceTests.swift
@@ -53,6 +53,12 @@ struct LaunchAgentServiceTests {
         #expect(plistContent.contains(stateDirectory.appending(component: "tuist.test.stdout.log").pathString))
         #expect(plistContent.contains("<key>StandardErrorPath</key>"))
         #expect(plistContent.contains(stateDirectory.appending(component: "tuist.test.stderr.log").pathString))
+        // KeepAlive must only respawn the daemon on an unsuccessful (crash) exit. A clean
+        // exit — e.g. when cache-start detects it is not authenticated — must NOT trigger a
+        // respawn, otherwise launchd restarts it every ~10 seconds in an endless loop.
+        #expect(plistContent.contains("<key>KeepAlive</key>"))
+        #expect(plistContent.contains("<key>SuccessfulExit</key>"))
+        #expect(!plistContent.contains("<key>KeepAlive</key>\n            <true/>"))
 
         verify(launchctlController)
             .bootstrap(plistPath: .value(expectedPlistPath))


### PR DESCRIPTION
> Describe here the purpose of your PR.

## What changed

`tuist setup cache` installs a `KeepAlive` LaunchAgent that runs `cache-start`. When the user is **logged out**, `cache-start` threw while resolving the cache endpoint, exited non-zero, and launchd respawned it every ~10 seconds. Each respawn created a brand-new session directory under `~/.local/state/tuist/sessions/` and re-ran work that could never succeed.

Three coupled changes:

1. **`CacheStartCommandService`** — resolve the server URL and check authentication *first*. When there is no credential, log a hint and **return cleanly (exit 0)** instead of throwing, so a logged-out daemon does no work and leaves no session directory. A transient refresh/network error still throws, so launchd keeps retrying in that case.
2. **`LaunchAgentService`** — the plist's `KeepAlive` changes from `<true/>` to `<dict><key>SuccessfulExit</key><false/></dict>`, so launchd only respawns the daemon on an *unsuccessful* (crash) exit, not on the clean "nothing to do" exit. This is what actually stops the 10s respawn storm.
3. **`SetupCacheCommandService`** — **fail fast**: check authentication up front and abort with an actionable error *before* installing the LaunchAgent. Without this, setup looked successful while the daemon it installed immediately exited for lack of credentials. (1) + (2) make the storm impossible; (3) makes the logged-out outcome explicit at the moment the user runs setup.

## Why this approach

- `KeepAlive = true` ignores the exit code and respawns unconditionally, so making `cache-start` exit cleanly is not enough on its own — the plist must also stop respawning on a successful exit. Hence (1) + (2).
- `SuccessfulExit = false` is the canonical launchd policy for "run, and if there's nothing to do, exit and stay down until next login/setup," while still self-healing on a real crash.
- The `metrics-sampler` daemon shares this plist generation. It runs an infinite loop and never exits 0 on its own, so under `SuccessfulExit = false` its behavior is unchanged (still restarts only on crash).
- Failing setup fast (3) is preferable to installing a dead agent: the daemon does not auto-start on a later login (a clean exit is never respawned), so silently no-op'ing would leave the user thinking caching is on when it isn't.

## Behavior after this change

- **`setup cache` while logged out** → fails immediately with "You must be authenticated…", installs nothing.
- **Logged out while the daemon is already running** → the daemon stays up (per-request auth fails gracefully per [`CacheClientAuthenticationMiddleware`] + the gRPC handlers catch per request); logging back in recovers automatically, because the token is read fresh from the credentials store on every request. No restart needed.
- **Authenticated / CI (`TUIST_TOKEN`)** → unaffected; the env-token path satisfies the up-front check.

## Root cause

The session directory is created for every CLI invocation before the command runs, and `cache-start` only failed *after* that, deep in the cache-endpoint lookup — so an unauthenticated respawn-loop left one empty session dir per 10s tick. The daemon had no early, clean "not authenticated" path, the LaunchAgent treated a permanent auth failure the same as a transient crash, and `setup cache` never checked auth at all.

## User impact

Running `tuist setup cache` while logged out no longer (a) pins a background process that wakes every ~10s and accumulates session directories, nor (b) silently reports success while installing a daemon that can't run. The user gets a clear instruction to authenticate and re-run.

### How to test locally

1. Log out (remove server credentials; ensure `TUIST_TOKEN` is unset).
2. Run `tuist setup cache` in a project with a `fullHandle` → it now **fails fast** with "You must be authenticated to set up the cache. Run `tuist auth login` …" and installs no LaunchAgent (`~/Library/LaunchAgents/tuist.cache.*.plist` is not created; `launchctl list | grep tuist.cache` is empty).
3. `tuist auth login`, then re-run `tuist setup cache` → the agent installs and `cache-start` serves normally.
4. (Daemon resilience) With the daemon running, remove credentials, trigger a cache request → requests fail gracefully and the daemon stays up; log back in → caching resumes without restarting the daemon.

Automated coverage:
- `CacheStartCommandServiceTests.run_exitsCleanlyWithoutStartingServer_whenNotAuthenticated`
- `SetupCacheCommandServiceTests.setupCache_notAuthenticated` (asserts no LaunchAgent is installed)
- `LaunchAgentServiceTests.setupLaunchAgent_createsDirectoryAndPlist` (asserts the `SuccessfulExit` KeepAlive form)

🤖 Generated with [Claude Code](https://claude.com/claude-code)