### PR TITLE
ci(cli): trigger CLI canary release on swifterpm source changes

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -17,6 +17,9 @@ on:
       - main
     paths:
       - cli/**
+      # swifterpm/Sources/swifterpm is compiled into the CLI binary (SwifterPMCore
+      # -> TuistSupport), so its changes must cut a canary just like cli/** does.
+      - swifterpm/**
       - mise/tasks/cli/**
       - mise/tasks/release/components.json
       - .github/workflows/cli-release.yml

--- a/mise/tasks/release/components.json
+++ b/mise/tasks/release/components.json
@@ -8,6 +8,7 @@
       "initial_version": "0.0.0",
       "include_paths": [
         "cli/**/*",
+        "swifterpm/**/*",
         "mise/tasks/cli/**/*",
         "mise/tasks/release/components.json",
         ".github/workflows/cli-release.yml",


### PR DESCRIPTION
## What changed

Added `swifterpm/**` to the path allowlist that gates the CLI canary release, in both places that allowlist is maintained:

- [`.github/workflows/cli-release.yml`](https://github.com/tuist/tuist/blob/main/.github/workflows/cli-release.yml) → `on.push.paths` (the canary trigger)
- [`mise/tasks/release/components.json`](https://github.com/tuist/tuist/blob/main/mise/tasks/release/components.json) → `cli.include_paths` (the per-component changelog/version path detection, also consumed by the RC/promote/backport flows)

## Why

`swifterpm/Sources/swifterpm` is compiled into the shipped `tuist` binary: `Package.swift` defines `SwifterPMCore` with `path: "swifterpm/Sources/swifterpm"`, and `SwifterPMCore` is a dependency of `TuistSupport` — the foundational target nearly the whole CLI links against. So a change under `swifterpm/` rebuilds the CLI exactly like a change under `cli/`.

But the canary release watches a path allowlist (`cli/**`, `Package.swift`, `Package.resolved`, the CLI workflow files, `.xcode-version-releases`) that **did not include `swifterpm/**`**. A swifterpm-only commit therefore matched none of the watched paths, and the `push` event never triggered `cli-release.yml` — the workflow didn't skip a step, it never started.

### Root cause / symptom

Commit `fcde94f1` (the squash of #11505) changed **only** files under `swifterpm/Sources/swifterpm/`, so it published no canary. swifterpm was recently moved into the monorepo and the CLI release path filters were never extended to cover it. The practical symptom — already observed — is that a swifterpm-only commit silently doesn't release, and the change only ships once a *later* `cli/**` commit cuts a canary that sweeps it along (which is why the swifterpm auth change could only be tested once it rode into `4.202.0-canary.4`).

## Scope

- `cli-rc.yml`, `cli-promote.yml`, `cli-backport.yml` are `workflow_dispatch`-only (no path filters), so they need no trigger change — they pick up the shared `components.json` update automatically.
- This fixes the **path** gate only. There is a second, independent **scope** gate: the `resolve` job derives the version from `cli/cliff.toml` via git-cliff, which is scope-gated. CLI-affecting swifterpm changes must still be scoped `feat(cli)`/`fix(cli)` to appear in the changelog and bump the version — a `fix(swifterpm)`-scoped commit is skipped by the cli cliff parser even with the path now watched. Worth a short contributor note, but out of scope for this PR.
- This PR is scoped `ci(cli)`, which `cli/cliff.toml` deliberately skips, so it won't cut a canary for itself (correct for a release-infra change). It does **not** retroactively publish `fcde94f1`; that change will be included in the next canary cut by any subsequent `cli/**` or `swifterpm/**` commit.

## Validation

- `components.json` re-parsed with `jq`; `cli.include_paths` now contains `swifterpm/**/*`.
- `cli-release.yml` re-parsed as YAML; `on.push.paths` now contains `swifterpm/**`.
- Confirmed via `Package.swift` that `SwifterPMCore` (`path: swifterpm/Sources/swifterpm`) is a dependency of `TuistSupport`, i.e. swifterpm source is in the CLI binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)