### PR TITLE
fix(infra): tart-kubelet GC deletes the live runner image; add golden-base reuse observability

### DIFF
--- a/infra/tart-kubelet/internal/podagent/garbage.go
+++ b/infra/tart-kubelet/internal/podagent/garbage.go
@@ -158,7 +158,15 @@ func (c *Collector) runOnce(ctx context.Context, aggressive bool) {
 			_ = c.Tart.CleanupVMUserData(vm.Name)
 			droppedClones++
 		case "OCI":
-			if _, want := expected.images[vm.Name]; want {
+			// Keep a cached image whose repository a Pod still references.
+			// Pods name images by tag and Tart lists them by digest, so the
+			// match is on the repository the two share — without it the GC
+			// reaped the live runner image every pass. Under aggressive
+			// (disk-pressure) reclaim, reap it anyway: the OCI cache is
+			// reconstructible by re-pull, so an actual out-of-disk provision
+			// must win over keeping it warm (mirrors the golden policy, and
+			// bounds the superseded-digest tail a referenced repo accrues).
+			if _, want := expected.imageRepos[ociRepository(vm.Name)]; want && !aggressive {
 				continue
 			}
 			if err := c.Tart.Delete(ctx, vm.Name); err != nil {
@@ -237,8 +245,17 @@ func IsNoSpaceError(err error) bool {
 }
 
 type expectedSet struct {
-	vms    map[string]struct{}
-	images map[string]struct{}
+	vms map[string]struct{}
+	// imageRepos holds the repository (registry/name with the tag and
+	// digest stripped) of every referenced Pod image. The OCI branch
+	// matches against this rather than the full ref: a Pod requests its
+	// image by tag (`…/tuist-runner:macos-26-5-0.7.0`), but Tart caches
+	// it under — and `tart list` reports it by — the resolved digest
+	// (`…/tuist-runner@sha256:…`). The old full-ref comparison never
+	// matched, so the GC marked the live runner image stale and deleted
+	// it on every pass, forcing the next golden materialization into a
+	// full multi-GB re-pull instead of a clonefile from the warm cache.
+	imageRepos map[string]struct{}
 }
 
 func (c *Collector) expectedSet(ctx context.Context) (*expectedSet, error) {
@@ -247,8 +264,8 @@ func (c *Collector) expectedSet(ctx context.Context) (*expectedSet, error) {
 		return nil, err
 	}
 	out := &expectedSet{
-		vms:    map[string]struct{}{},
-		images: map[string]struct{}{},
+		vms:        map[string]struct{}{},
+		imageRepos: map[string]struct{}{},
 	}
 	for i := range pods.Items {
 		pod := &pods.Items[i]
@@ -261,7 +278,7 @@ func (c *Collector) expectedSet(ctx context.Context) (*expectedSet, error) {
 			continue
 		}
 		out.vms[VMNameForPod(pod)] = struct{}{}
-		out.images[pod.Spec.Containers[0].Image] = struct{}{}
+		out.imageRepos[ociRepository(pod.Spec.Containers[0].Image)] = struct{}{}
 		// Keep the golden base this image clones from. Without this the
 		// "local" GC branch would see the golden VM, find no Pod named
 		// after it, and reap it as an orphan clone — forcing the next
@@ -271,13 +288,28 @@ func (c *Collector) expectedSet(ctx context.Context) (*expectedSet, error) {
 	// Store-side entries cover Pods the reconciler has already started
 	// a VM for but that haven't shown up on this List response yet
 	// (e.g. just-admitted Pods, or pods re-bound to this Node by
-	// startup recovery). Image set is intentionally not augmented from
-	// Store: Store doesn't track the originating image, and the OCI
-	// cache GC is allowed to be one cycle behind reality.
+	// startup recovery). The image-repo set is intentionally not
+	// augmented from Store: Store doesn't track the originating image,
+	// and the OCI cache GC is allowed to be one cycle behind reality.
 	if c.Store != nil {
 		for _, e := range c.Store.Snapshot() {
 			out.vms[e.VMName] = struct{}{}
 		}
 	}
 	return out, nil
+}
+
+// ociRepository strips the tag and/or digest from an OCI image
+// reference, returning the bare `registry[:port]/name`. Pods reference
+// images by tag while Tart caches and lists them by digest, so the GC
+// has to compare on the repository the two share. A registry port (a
+// ':' whose suffix still contains a '/') must survive the tag strip.
+func ociRepository(ref string) string {
+	if i := strings.IndexByte(ref, '@'); i >= 0 {
+		ref = ref[:i]
+	}
+	if i := strings.LastIndexByte(ref, ':'); i >= 0 && !strings.Contains(ref[i+1:], "/") {
+		ref = ref[:i]
+	}
+	return ref
 }

--- a/infra/tart-kubelet/internal/podagent/golden_test.go
+++ b/infra/tart-kubelet/internal/podagent/golden_test.go
@@ -108,8 +108,77 @@ func TestExpectedSetRetainsGoldenBase(t *testing.T) {
 	if _, ok := expected.vms[goldenVMName(img)]; !ok {
 		t.Fatalf("golden base %q missing from expected.vms", goldenVMName(img))
 	}
-	if _, ok := expected.images[img]; !ok {
-		t.Fatalf("image %q missing from expected.images", img)
+	if _, ok := expected.imageRepos[ociRepository(img)]; !ok {
+		t.Fatalf("image repo %q missing from expected.imageRepos", ociRepository(img))
+	}
+}
+
+// Regression for the tag-vs-digest GC bug: a Pod requests its image by
+// tag, but `tart list` reports the cached OCI image by digest. expectedSet
+// must record the repository the two share so the OCI branch keeps the
+// live image instead of deleting it on every pass (which forced the next
+// golden materialization into a full re-pull).
+func TestExpectedSetMatchesOCIImageByRepository(t *testing.T) {
+	const node = "mini-1"
+	const podImage = "ghcr.io/tuist/tuist-runner:macos-26-5-0.7.0"                                                              // what the Pod requests (tag)
+	const ociListed = "ghcr.io/tuist/tuist-runner@sha256:" + "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef" // what `tart list` reports (digest)
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "tuist-runners", Name: "runner-xyz"},
+		Spec: corev1.PodSpec{
+			NodeName:   node,
+			Containers: []corev1.Container{{Name: "runner", Image: podImage}},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add core scheme: %v", err)
+	}
+	k := fake.NewClientBuilder().WithScheme(scheme).
+		WithIndex(&corev1.Pod{}, "spec.nodeName", func(o client.Object) []string {
+			return []string{o.(*corev1.Pod).Spec.NodeName}
+		}).
+		WithObjects(pod).Build()
+
+	c := &Collector{K8s: k, NodeName: node}
+	expected, err := c.expectedSet(context.Background())
+	if err != nil {
+		t.Fatalf("expectedSet: %v", err)
+	}
+
+	// The digest-form entry the GC sees in `tart list` must resolve into
+	// the kept set via its repository — otherwise it's reaped while live.
+	if _, ok := expected.imageRepos[ociRepository(ociListed)]; !ok {
+		t.Fatalf("live OCI image %q would be reaped: repo %q absent from %v", ociListed, ociRepository(ociListed), expected.imageRepos)
+	}
+
+	// A genuinely-unreferenced repository must still be reapable.
+	otherRepo := ociRepository("ghcr.io/tuist/some-removed-pool@sha256:" + strings.Repeat("b", 64))
+	if _, ok := expected.imageRepos[otherRepo]; ok {
+		t.Fatalf("unreferenced repo %q unexpectedly retained", otherRepo)
+	}
+}
+
+func TestOCIRepository(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"tag", "ghcr.io/tuist/tuist-runner:macos-26-5-0.7.0", "ghcr.io/tuist/tuist-runner"},
+		{"digest", "ghcr.io/tuist/tuist-runner@sha256:" + strings.Repeat("a", 64), "ghcr.io/tuist/tuist-runner"},
+		{"bare", "ghcr.io/tuist/tuist-runner", "ghcr.io/tuist/tuist-runner"},
+		{"port and tag", "registry.example.com:5000/team/img:v1.2.3", "registry.example.com:5000/team/img"},
+		{"port no tag", "registry.example.com:5000/team/img", "registry.example.com:5000/team/img"},
+		{"port and digest", "registry.example.com:5000/team/img@sha256:" + strings.Repeat("c", 64), "registry.example.com:5000/team/img"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ociRepository(tc.in); got != tc.want {
+				t.Fatalf("ociRepository(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
 	}
 }
 
@@ -118,8 +187,8 @@ func TestKeepGolden(t *testing.T) {
 	const golden = goldenBaseVMPrefix + "deadbeef"
 	const retention = time.Hour
 
-	referenced := &expectedSet{vms: map[string]struct{}{golden: {}}, images: map[string]struct{}{}}
-	unreferenced := &expectedSet{vms: map[string]struct{}{}, images: map[string]struct{}{}}
+	referenced := &expectedSet{vms: map[string]struct{}{golden: {}}, imageRepos: map[string]struct{}{}}
+	unreferenced := &expectedSet{vms: map[string]struct{}{}, imageRepos: map[string]struct{}{}}
 
 	t.Run("referenced is kept and clock reset", func(t *testing.T) {
 		c := &Collector{}

--- a/infra/tart-kubelet/internal/podagent/metrics.go
+++ b/infra/tart-kubelet/internal/podagent/metrics.go
@@ -1,6 +1,8 @@
 package podagent
 
 import (
+	"time"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 )
@@ -48,6 +50,24 @@ var goldenBaseMaterializedTotal = prometheus.NewCounterVec(
 	[]string{"pool"},
 )
 
+// goldenBaseReusedTotal counts provisions that cloned from an existing
+// golden base — the APFS clonefile fast path that touches the network
+// zero times. It's the counterpart to goldenBaseMaterializedTotal:
+// reused/(reused+materialized) is the golden-base hit rate, and a
+// materialized rate that climbs while reused stays flat is the
+// "goldens aren't sticking, we're re-pulling per job" regression the
+// whole golden-base scheme exists to kill. Without this counter that
+// regression is invisible — a silent warm-path miss (a `tart get` that
+// errors and falls through to a cold re-pull) looks identical to a
+// legitimate first-sight materialization.
+var goldenBaseReusedTotal = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "tart_kubelet_golden_base_reused_total",
+		Help: "Provisions that cloned from an existing golden base (APFS clonefile, no network), per pool.",
+	},
+	[]string{"pool"},
+)
+
 // guestDiskUsagePercent is the percent-used of each running VM's guest
 // root volume, as read by the node maintainer's DiskPressure probe. It's
 // the gradient signal behind the binary DiskPressure node condition:
@@ -85,8 +105,33 @@ var podProvisionDelaySeconds = prometheus.NewHistogramVec(
 	[]string{"pool"},
 )
 
+// vmProvisionWorkSeconds isolates the on-host provisioning work a fresh
+// Pod triggers — ensureGolden (warm clonefile or cold pull+clone) plus
+// the runner `tart clone` — from podProvisionDelaySeconds, which starts
+// at Pod creation and so also folds in scheduling/queue wait (a Pod can
+// sit Pending behind the host's previous single-VM job for minutes).
+// The `path` label ("warm" = golden reused, "cold" = golden
+// materialized) makes the cold-pull tail explicit, so a high
+// podProvisionDelaySeconds can be attributed to queue wait vs. a genuine
+// re-pull at a glance rather than guessed at.
+var vmProvisionWorkSeconds = prometheus.NewHistogramVec(
+	prometheus.HistogramOpts{
+		Name:    "tart_kubelet_vm_provision_work_seconds",
+		Help:    "Wall-clock for on-host provisioning work (ensureGolden + runner clone), per pool and path (warm=clonefile, cold=pull).",
+		Buckets: []float64{1, 5, 10, 20, 30, 60, 120, 180, 300, 600},
+	},
+	[]string{"pool", "path"},
+)
+
 func init() {
-	metrics.Registry.MustRegister(vmBootDurationSeconds, guestDiskUsagePercent, podProvisionDelaySeconds, goldenBaseMaterializedTotal)
+	metrics.Registry.MustRegister(
+		vmBootDurationSeconds,
+		guestDiskUsagePercent,
+		podProvisionDelaySeconds,
+		goldenBaseMaterializedTotal,
+		goldenBaseReusedTotal,
+		vmProvisionWorkSeconds,
+	)
 }
 
 // RecordGoldenMaterialized increments the per-pool count of golden base
@@ -98,6 +143,25 @@ func RecordGoldenMaterialized(pool string) {
 		pool = "unknown"
 	}
 	goldenBaseMaterializedTotal.WithLabelValues(pool).Inc()
+}
+
+// RecordGoldenReused increments the per-pool count of provisions that
+// cloned from an already-present golden base (the warm clonefile path).
+func RecordGoldenReused(pool string) {
+	if pool == "" {
+		pool = "unknown"
+	}
+	goldenBaseReusedTotal.WithLabelValues(pool).Inc()
+}
+
+// RecordVMProvisionWork records the wall-clock of the on-host
+// provisioning work for one Pod. path is "warm" (golden reused) or
+// "cold" (golden materialized via pull).
+func RecordVMProvisionWork(pool, path string, d time.Duration) {
+	if pool == "" {
+		pool = "unknown"
+	}
+	vmProvisionWorkSeconds.WithLabelValues(pool, path).Observe(d.Seconds())
 }
 
 // RecordGuestDiskUsage publishes a VM's guest root-volume usage percent.

--- a/infra/tart-kubelet/internal/podagent/reconciler.go
+++ b/infra/tart-kubelet/internal/podagent/reconciler.go
@@ -297,6 +297,10 @@ func (r *Reconciler) createPod(ctx context.Context, pod *corev1.Pod) error {
 	}
 
 	c := pod.Spec.Containers[0]
+	pool := pod.Labels["tuist.dev/runner-pool"]
+	if pool == "" {
+		pool = "unknown"
+	}
 	env, err := r.Resolver.Resolve(ctx, pod, c)
 	if err != nil {
 		return fmt.Errorf("resolve env: %w", err)
@@ -337,12 +341,17 @@ func (r *Reconciler) createPod(ctx context.Context, pod *corev1.Pod) error {
 		// at most once per digest per host; back-to-back recycles take
 		// only the clonefile path. This is what stops the fleet
 		// re-downloading the whole VM image between jobs.
+		cloneStart := time.Now()
 		base, materialized, err := r.ensureGolden(ctx, c.Image)
 		if err != nil {
 			return err
 		}
+		provisionPath := "warm"
 		if materialized {
-			RecordGoldenMaterialized(pod.Labels["tuist.dev/runner-pool"])
+			provisionPath = "cold"
+			RecordGoldenMaterialized(pool)
+		} else {
+			RecordGoldenReused(pool)
 		}
 		if err := r.Tart.Clone(ctx, base, vmName); err != nil {
 			// The golden was reaped out from under us (GC race) or is
@@ -351,6 +360,12 @@ func (r *Reconciler) createPod(ctx context.Context, pod *corev1.Pod) error {
 			_ = r.Tart.Delete(ctx, base)
 			return fmt.Errorf("tart clone from golden: %w", err)
 		}
+		// Split the on-host provisioning segment (golden probe +
+		// pull/clone + runner clone) out from podProvisionDelaySeconds,
+		// which also folds in scheduling/queue wait. `path` separates a
+		// warm clonefile from a cold re-pull so a slow provision can be
+		// attributed to one or the other instead of guessed at.
+		RecordVMProvisionWork(pool, provisionPath, time.Since(cloneStart))
 	}
 
 	// Resize the cloned VM to match the Pod's resource requests.
@@ -371,10 +386,6 @@ func (r *Reconciler) createPod(ctx context.Context, pod *corev1.Pod) error {
 	// createPod retry and skew the metric toward retry delay; here it
 	// fires exactly once per Pod that reaches `tart run`, and captures the
 	// pull/clone time the boot histogram (which starts at `tart run`) can't.
-	pool := pod.Labels["tuist.dev/runner-pool"]
-	if pool == "" {
-		pool = "unknown"
-	}
 	podProvisionDelaySeconds.WithLabelValues(pool).Observe(time.Since(pod.CreationTimestamp.Time).Seconds())
 
 	// Record the Pod ↔ VM mapping before kicking the VM off so the
@@ -491,8 +502,18 @@ func (r *Reconciler) ensureGolden(ctx context.Context, image string) (name strin
 	defer unlock()
 
 	// Warm path: golden already on disk for this digest — no network.
-	if vm, getErr := r.Tart.Get(ctx, name); getErr == nil && vm != nil {
+	vm, getErr := r.Tart.Get(ctx, name)
+	if getErr == nil && vm != nil {
 		return name, false, nil
+	}
+	if getErr != nil {
+		// Not the (nil, nil) "not found" case — `tart get` actually
+		// errored (timeout, lock contention, parse). The golden may well
+		// exist on disk; falling through to the cold path re-pulls the
+		// whole image needlessly, so surface the probe failure instead
+		// of silently churning. A run of these lines is the signal that
+		// a rising materialized rate is a warm-path miss, not first-sight.
+		log.FromContext(ctx).Error(getErr, "golden warm-path probe failed; taking cold path (may re-pull)", "golden", name)
 	}
 
 	// Cold path: pull + materialize once. Mirror the disk-pressure


### PR DESCRIPTION
## Context

Follow-up to #11484 (golden-base VMs, now merged). After that landed, the macOS runner fleet was **still re-pulling per provision**: `tart_kubelet_golden_base_materialized_total / pod_provision_delay_seconds_count` ≈ **0.98** (≈one cold pull per provision) and provision-delay p50 stuck at **~450s**, with the hot pool `macos-26-5` doing ~36 materializations/2h while idle pools (`26-3`, `26-4-1`) reused their golden fine (1 each). The golden base wasn't delivering.

I investigated on a production host (`mndbc-hz6vv`, SSH over the tailnet) and **ruled out the obvious culprits**: 200–348 GB disk free + 86% memory free (no disk-pressure eviction, no OOM), only 14 tart-kubelet restarts since May, golden VM present on disk, `tart get <golden>` succeeds, and the golden name matches `sha256(image)[:8]`. So eviction / capacity / OOM / restart / name-mismatch are all out.

## What this PR fixes

### 1. GC was deleting the live runner image every pass (root cause of the expensive cold path)

On the host, `tart list` showed **zero** cached OCI images, and the log repeated every ~15 min:

```
gc "delete stale OCI cache entry" image="ghcr.io/tuist/tuist-runner@sha256:9fac136a…"
gc "reclaimed disk" stale_oci_images:1
```

**Root cause:** `expectedSet.images` was keyed by the Pod's image ref — a **tag** (`ghcr.io/tuist/tuist-runner:macos-26-5-0.7.0`). But Tart caches and `tart list`s images by their **resolved digest** (`…@sha256:…`). The tag↔digest comparison never matched, so the GC marked the *live* image stale and deleted it on every pass. With the cache gone, every golden (re)materialization paid a full multi-GB re-pull instead of the sub-second APFS clonefile the golden scheme is built around — exactly the cost #11484 set out to eliminate.

**Fix:** key `expectedSet` on the image **repository** (`ociRepository()` strips tag and/or digest, preserving a registry port) and match the cached entry's repository against it. The aggressive disk-pressure `RunOnceReclaim` path still reaps OCI images regardless of the match — the cache is reconstructible by re-pull, so a genuine out-of-disk provision must win, and this bounds the superseded-digest tail a long-lived repository would otherwise accrue.

*Why repository-match over digest resolution:* matching tag→digest would require a registry round-trip (auth, network) on every GC pass; the repository is the stable key both refs already share, and a golden VM is the durable artifact anyway, so the OCI cache only needs to survive as a re-materialization shortcut.

### 2. Observability to close the remaining question

The deeper question — *why a cold path is entered at all when the golden is present* — was **unobservable**: a `tart get` that errors and falls through to a cold re-pull looks identical to a legitimate first-sight materialization, and `pod_provision_delay_seconds` (measured from Pod creation) folds scheduling/queue wait into the same number as the pull. Added:

- `tart_kubelet_golden_base_reused_total{pool}` — warm clonefile hits. `reused/(reused+materialized)` is the golden hit rate.
- `tart_kubelet_vm_provision_work_seconds{pool,path=warm|cold}` — the on-host pull/clone segment, isolated from queue wait and split by warm vs. cold.
- an error log in `ensureGolden` when `tart get` fails for a reason other than not-found.

Together these will show, post-deploy, whether the ~450s is a genuine re-pull (`path="cold"` rate high) or single-VM-per-host queue wait (`vm_provision_work` low while `pod_provision_delay` stays high) — without SSHing a host.

## Impact

- Stops the ~every-15-min deletion of the live runner image, so a golden re-materialization becomes a clonefile from a warm OCI cache rather than a ~70 GB re-download.
- Makes the golden-base hit rate and the pull-vs-queue split first-class metrics.
- No behavior change for warm-path provisions (they already clone from the golden without the OCI cache).

## Validation

- `go build ./...`, `go vet ./internal/podagent/`, `gofmt -l`, and the full module test suite pass.
- New tests: `TestExpectedSetMatchesOCIImageByRepository` (regression — a tag-referenced Pod image keeps the digest-listed cache entry) and `TestOCIRepository` (tag/digest/port parsing).

## Note

This does **not** by itself prove the median-provision warm-path miss is gone — fix #2 is what closes that loop once deployed. Fix #1 is an unambiguous correctness fix regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
