### PR TITLE
ci(kura): run rustfmt check through the Bazel rustfmt aspect

### DIFF
--- a/.github/workflows/kura.yml
+++ b/.github/workflows/kura.yml
@@ -41,17 +41,11 @@ jobs:
       - uses: jdx/mise-action@v4.0.1
         with:
           version: ${{ env.MISE_VERSION }}
-          install_args: --force rust
+          install_args: "bazel"
           working_directory: kura
 
-      - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: kura-rust-${{ runner.os }}
-          workspaces: |
-            kura -> target
-
       - name: Check formatting
-        run: env -u RUSTUP_TOOLCHAIN cargo fmt --check
+        run: mise run --skip-tools format -- --check
 
   # Split non-fork / fork (like gradle.yml / android.yml): only trusted runs get `id-token: write`
   # and authenticate; forks get `contents: read` alone and never see the OIDC token.

--- a/kura/AGENTS.md
+++ b/kura/AGENTS.md
@@ -24,6 +24,8 @@ This node covers the `kura/` workspace, a Rust service for low-latency cache mes
   - Test: `mise run test-unit` (runs `bazel test //...`; fallback: `mise exec -- cargo test`)
   - Clippy: `mise run clippy` (runs the rules_rust clippy aspect over `//...`, warnings as errors;
     fallback: `mise exec -- cargo clippy --all-targets -- -D warnings`)
+  - Format: `mise run format` fixes files in place (cargo fmt); `mise run format -- --check`
+    verifies only (rules_rust rustfmt aspect, what CI runs)
 - If you have access to the `tuist/kura` project on Tuist, run `tuist bazel setup` to point Bazel at
   the closest Kura remote cache (it writes `kura/.bazelrc.tuist`); re-run it after changing physical
   location. Without access, skip it — Bazel builds fine against the local cache.

--- a/kura/mise/tasks/format.sh
+++ b/kura/mise/tasks/format.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+#MISE description="Format Rust sources with rustfmt. Fixes files in place via cargo fmt by default; pass --check to verify only via the rules_rust rustfmt aspect (what CI runs)."
+#USAGE flag "--check" help="Verify formatting only (rustfmt aspect) instead of fixing files in place"
+set -euo pipefail
+
+# Check and fix use different tools by necessity: the rustfmt aspect is a sandboxed Bazel action that
+# can only verify — it can't write back to the source tree — so fixing falls back to cargo fmt.
+# (env -u RUSTUP_TOOLCHAIN keeps cargo on the rust-toolchain.toml channel, matching the repo's other
+# cargo invocations.)
+if [ "${usage_check:-false}" = "true" ]; then
+  exec bazel build //... \
+    --aspects=@rules_rust//rust:defs.bzl%rustfmt_aspect \
+    --output_groups=rustfmt_checks
+fi
+
+exec env -u RUSTUP_TOOLCHAIN cargo fmt


### PR DESCRIPTION
> **Stacked on #11503** (the clippy → Bazel conversion). The base is the `tuist-kura-bazel-workflow` branch because this change relies on the `@rules_rust` repo import added there; GitHub will auto-retarget this PR to `main` once #11503 merges. Review the diff here for the format change in isolation.

## What changed

The kura `format` CI check is moved off `cargo fmt --check` onto the rules_rust rustfmt aspect, so it runs through the same toolchain as the compile/test/clippy jobs.

- **`kura/mise/tasks/format.sh`** (new) — `mise run format` is dual-mode (see below).
- **`.github/workflows/kura.yml`** — the `format` job drops the Rust toolchain + `Swatinem/rust-cache` and runs `mise run --skip-tools format -- --check`.
- **`kura/AGENTS.md`** — documents both modes.

No `MODULE.bazel` change: the `@rules_rust` import added in #11503 already makes the aspect label resolve.

## `mise run format` is dual-mode

- **`mise run format`** → fixes files in place via `cargo fmt`.
- **`mise run format -- --check`** → verifies only via `bazel build //... --aspects=@rules_rust//rust:defs.bzl%rustfmt_aspect --output_groups=rustfmt_checks`. This is what CI runs.

**Why two tools for one task:** rules_rust splits formatting deliberately. The rustfmt aspect is a *sandboxed Bazel build action* — it can only verify, because an action's `srcs` are read-only inputs and its outputs land in `bazel-out/`, never back on the source tree. rules_rust does ship a fix-capable `bazel run` binary (`@rules_rust//tools/rustfmt:target_aware_rustfmt`, which discovers sources via a nested `bazel query`), but it is fix-only (no `--check`) and pulls in a second mechanism, so the fix path uses `cargo fmt` instead — same rustfmt, same 1.94.1 toolchain, same edition 2024, no extra label.

## Why a single job (not the fork/non-fork split clippy uses)

clippy needs two jobs because it compiles the entire dependency graph — including the expensive rocksdb/aws-lc `-sys` crates — so it wants the `tuist-linux` runner + Tuist remote cache, with a fork fallback. **rustfmt compiles nothing**: the aspect only reads crate sources and runs `rustfmt --check` with the rustfmt toolchain — no `collect_inputs`, no rustc, no rlibs. Confirmed in a live run: the check **configures ~21 targets and runs 0 compile actions**, vs **~31k targets** for clippy. So it stays a **single `ubuntu-latest` job** — no fork split, no `tuist-linux`, no `build-essential/clang/cmake` step.

## Validation

- `mise run --skip-tools format -- --check` passes on the current tree with zero compile actions; the aspect applies to exactly the three first-party targets.
- `mise run --skip-tools format` (cargo fmt) exits cleanly and leaves the already-formatted tree unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
