### PR TITLE
feat(server): internal Atlas read-only database API

### DIFF
--- a/infra/cnpg/tuist-ops-ro-grants.sql
+++ b/infra/cnpg/tuist-ops-ro-grants.sql
@@ -29,6 +29,13 @@ GRANT USAGE ON SCHEMA :"tuist_schema" TO tuist_ops_ro;
 GRANT USAGE ON SCHEMA pg_catalog TO tuist_ops_ro;
 GRANT USAGE ON SCHEMA information_schema TO tuist_ops_ro;
 
+-- Let the web runtime role assume tuist_ops_ro via `SET ROLE` for the internal
+-- Atlas query runner (Tuist.Ops.Database.execute with role: "tuist_ops_ro"),
+-- which drops to this least-privilege role before running operator-supplied
+-- SQL. `INHERIT FALSE` keeps tuist_web from passively gaining pg_read_all_data
+-- — it must explicitly SET ROLE. `SET TRUE` permits that switch. Requires PG16+.
+GRANT tuist_ops_ro TO tuist_web WITH INHERIT FALSE, SET TRUE;
+
 REVOKE INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER
   ON ALL TABLES IN SCHEMA :"tuist_schema" FROM tuist_ops_ro;
 ALTER DEFAULT PRIVILEGES IN SCHEMA :"tuist_schema"

--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -71,6 +71,10 @@ server:
       value: tuist-server
     - name: TUIST_ATLAS_TOKEN_MAX_TTL_SECONDS
       value: "3600"
+    # Least-privilege role the internal Atlas SQL runner drops to via SET ROLE
+    # (requires the GRANT in infra/cnpg/tuist-ops-ro-grants.sql).
+    - name: TUIST_ATLAS_DB_READONLY_ROLE
+      value: tuist_ops_ro
     - name: TUIST_ATLAS_TOKEN_JWKS
       value: >-
         {"keys":[{"use":"sig","kty":"RSA","kid":"RlVpaMmFrqqIHY46_HT42inm4mfvqBKfwLVJiPCcl7g","alg":"RS256","n":"urnlzTgGSYHPHyc-sjXI7lzdx3ChfMpqUMpwuj1vgBMywpvdjFEKZ-5xWBBfS_GIna4q--YBau4zo21xFw0Jd-Ye8l4daXozFTwB1oOv-xOoIL7YITR8dtXsXzqeGIKx1rt90jE2vgvYQDBnkIf9ohgDIApbLICYGSAko5MfdypYhiO52KOxum8nB5dwIaKhr2-DiLQtFQbl__c6Uk2dFpW0_5u4d-uO6yspp5iVo54sc7XIlFNxPBlx2uVQZe8tvTH9Ipc_sovDjMfoKH7g0fG14q6xQU5CkQD1pNS__6J3xFvFYQEp3wXu4i_Rin65EI9GvNKtbZkH-sQ5e8jzLw","e":"AQAB"}]}

--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -71,10 +71,16 @@ server:
       value: tuist-server
     - name: TUIST_ATLAS_TOKEN_MAX_TTL_SECONDS
       value: "3600"
-    # Least-privilege role the internal Atlas SQL runner drops to via SET ROLE
-    # (requires the GRANT in infra/cnpg/tuist-ops-ro-grants.sql).
-    - name: TUIST_ATLAS_DB_READONLY_ROLE
-      value: tuist_ops_ro
+    # The internal Atlas SQL runner can drop to the least-privilege tuist_ops_ro
+    # role via `SET LOCAL ROLE` by setting:
+    #   - name: TUIST_ATLAS_DB_READONLY_ROLE
+    #     value: tuist_ops_ro
+    # Left unset on purpose: that switch requires `GRANT tuist_ops_ro TO
+    # tuist_web` from infra/cnpg/tuist-ops-ro-grants.sql, which is a manual CNPG
+    # bootstrap/restore step — NOT applied by the Helm deploy. Enabling the env
+    # var before the grant is (re-)applied would make every Atlas DB query raise
+    # on `SET LOCAL ROLE`. Until then the runner stays on the web role behind the
+    # read-only transaction; flip this on in a follow-up once the grant has run.
     - name: TUIST_ATLAS_TOKEN_JWKS
       value: >-
         {"keys":[{"use":"sig","kty":"RSA","kid":"RlVpaMmFrqqIHY46_HT42inm4mfvqBKfwLVJiPCcl7g","alg":"RS256","n":"urnlzTgGSYHPHyc-sjXI7lzdx3ChfMpqUMpwuj1vgBMywpvdjFEKZ-5xWBBfS_GIna4q--YBau4zo21xFw0Jd-Ye8l4daXozFTwB1oOv-xOoIL7YITR8dtXsXzqeGIKx1rt90jE2vgvYQDBnkIf9ohgDIApbLICYGSAko5MfdypYhiO52KOxum8nB5dwIaKhr2-DiLQtFQbl__c6Uk2dFpW0_5u4d-uO6yspp5iVo54sc7XIlFNxPBlx2uVQZe8tvTH9Ipc_sovDjMfoKH7g0fG14q6xQU5CkQD1pNS__6J3xFvFYQEp3wXu4i_Rin65EI9GvNKtbZkH-sQ5e8jzLw","e":"AQAB"}]}

--- a/server/lib/tuist/environment.ex
+++ b/server/lib/tuist/environment.ex
@@ -1266,6 +1266,20 @@ defmodule Tuist.Environment do
   end
 
   @doc """
+  Least-privilege database role the internal Atlas query runner drops to via
+  `SET LOCAL ROLE` before executing operator-supplied SQL. Set to `tuist_ops_ro`
+  by the chart in managed environments (requires `GRANT tuist_ops_ro TO
+  tuist_web` — see `infra/cnpg/tuist-ops-ro-grants.sql`). Unset in dev/test, where
+  queries run as the default role.
+  """
+  def atlas_db_readonly_role do
+    case System.get_env("TUIST_ATLAS_DB_READONLY_ROLE") do
+      role when role in [nil, ""] -> nil
+      role -> role
+    end
+  end
+
+  @doc """
   Cross-cluster trust policy for Atlas workload tokens.
   """
   def atlas_workload_identity_policy do

--- a/server/lib/tuist/ops/database.ex
+++ b/server/lib/tuist/ops/database.ex
@@ -570,29 +570,36 @@ defmodule Tuist.Ops.Database do
   defp validate_grammar(_), do: {:error, "Query must be a string"}
 
   defp run_read_only(sql, limit, role) do
-    Repo.transaction(fn ->
-      {:ok, _} = Repo.query("SET TRANSACTION READ ONLY")
-      {:ok, _} = Repo.query("SET LOCAL statement_timeout = #{@statement_timeout_ms}")
-      # When a `role` is given (the internal Atlas runner passes `tuist_ops_ro`),
-      # drop to it for the duration of the transaction so the statement executes
-      # with a least-privilege role that has no write grants at all — writes are
-      # then blocked by privileges, not only by `SET TRANSACTION READ ONLY`.
-      # Resets automatically at transaction end.
-      maybe_set_local_role(role)
-
+    # Pin one connection for the whole operation so the advisory-lock cleanup
+    # below runs on the same backend that executed the statement — whether the
+    # transaction committed or rolled back.
+    Repo.checkout(fn ->
       result =
-        if cursorable?(sql) do
-          fetch_via_cursor(sql, limit)
-        else
-          build_result(Repo.query(sql), limit)
-        end
+        Repo.transaction(fn ->
+          {:ok, _} = Repo.query("SET TRANSACTION READ ONLY")
+          {:ok, _} = Repo.query("SET LOCAL statement_timeout = #{@statement_timeout_ms}")
+          # When a `role` is given (the internal Atlas runner passes `tuist_ops_ro`),
+          # drop to it for the duration of the transaction so the statement
+          # executes with a least-privilege role that has no write grants at all —
+          # writes are then blocked by privileges, not only by `SET TRANSACTION
+          # READ ONLY`. Resets automatically at transaction end.
+          maybe_set_local_role(role)
+
+          if cursorable?(sql) do
+            fetch_via_cursor(sql, limit)
+          else
+            build_result(Repo.query(sql), limit)
+          end
+        end)
 
       # `SET TRANSACTION READ ONLY` blocks writes but still permits side-effecting
       # functions like `SELECT pg_advisory_lock(...)`, whose session-level lock
-      # survives commit and would ride a pooled connection into the next caller
-      # (or collide with Oban's advisory locks). Release any such locks before
-      # the connection returns to the pool.
-      {:ok, _} = Repo.query("SELECT pg_advisory_unlock_all()")
+      # survives both COMMIT and ROLLBACK and would ride a pooled connection into
+      # the next caller (or collide with Oban's advisory locks). Release any such
+      # locks here, outside the transaction on the same checked-out connection,
+      # so it runs on every path — including the rollback from a lock-taking
+      # query that then fails.
+      Repo.query("SELECT pg_advisory_unlock_all()")
       result
     end)
   end

--- a/server/lib/tuist/ops/database.ex
+++ b/server/lib/tuist/ops/database.ex
@@ -118,6 +118,34 @@ defmodule Tuist.Ops.Database do
   end
 
   @doc """
+  Like `table_exists?/2` but scoped to the same application-owned schemas
+  `list_table_overviews/0` exposes — `information_schema.tables` would
+  otherwise let a caller describe `pg_catalog` / operator relations the table
+  list hides. Used by the internal Atlas describe endpoint so listing and
+  describing share one visibility predicate.
+  """
+  def app_table_exists?(schema, name) do
+    {:ok, %{num_rows: n}} =
+      Repo.query(
+        """
+        SELECT 1
+        FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE c.relkind = 'r'
+          AND n.nspname = $1
+          AND c.relname = $2
+          AND n.nspname NOT IN ('pg_catalog', 'information_schema')
+          AND n.nspname NOT LIKE 'pg_%'
+          AND n.nspname NOT LIKE 'cnpg_%'
+          AND n.nspname NOT LIKE '%timescaledb%'
+        """,
+        [schema, name]
+      )
+
+    n > 0
+  end
+
+  @doc """
   Paginated preview of a table's rows. Same read-only enforcement as
   the ad-hoc SQL runner: `BEGIN READ ONLY` + `statement_timeout`.
 
@@ -500,12 +528,13 @@ defmodule Tuist.Ops.Database do
   truncated?: bool}}` or `{:error, reason}`.
   """
   def execute(sql, opts \\ []) do
-    limit = Keyword.get(opts, :limit, @max_rows)
+    limit = opts |> Keyword.get(:limit, @max_rows) |> clamp_limit()
+    role = Keyword.get(opts, :role)
 
     with :ok <- validate_grammar(sql) do
       started = System.monotonic_time(:microsecond)
 
-      case run_read_only(sql, limit) do
+      case run_read_only(sql, limit, role) do
         {:ok, result} ->
           {:ok, Map.put(result, :duration_us, System.monotonic_time(:microsecond) - started)}
 
@@ -514,6 +543,12 @@ defmodule Tuist.Ops.Database do
       end
     end
   end
+
+  # The row cap is a server-side maximum, never something the caller can lift —
+  # an oversized `:limit` would otherwise make the cursor pull `limit + 1` rows
+  # and force the web process to build a huge response.
+  defp clamp_limit(limit) when is_integer(limit) and limit > 0, do: min(limit, @max_rows)
+  defp clamp_limit(_limit), do: @max_rows
 
   defp validate_grammar(sql) when is_binary(sql) do
     trimmed = sql |> String.trim() |> String.trim_trailing(";")
@@ -534,17 +569,43 @@ defmodule Tuist.Ops.Database do
 
   defp validate_grammar(_), do: {:error, "Query must be a string"}
 
-  defp run_read_only(sql, limit) do
+  defp run_read_only(sql, limit, role) do
     Repo.transaction(fn ->
       {:ok, _} = Repo.query("SET TRANSACTION READ ONLY")
       {:ok, _} = Repo.query("SET LOCAL statement_timeout = #{@statement_timeout_ms}")
+      # When a `role` is given (the internal Atlas runner passes `tuist_ops_ro`),
+      # drop to it for the duration of the transaction so the statement executes
+      # with a least-privilege role that has no write grants at all — writes are
+      # then blocked by privileges, not only by `SET TRANSACTION READ ONLY`.
+      # Resets automatically at transaction end.
+      maybe_set_local_role(role)
 
-      if cursorable?(sql) do
-        fetch_via_cursor(sql, limit)
-      else
-        build_result(Repo.query(sql), limit)
-      end
+      result =
+        if cursorable?(sql) do
+          fetch_via_cursor(sql, limit)
+        else
+          build_result(Repo.query(sql), limit)
+        end
+
+      # `SET TRANSACTION READ ONLY` blocks writes but still permits side-effecting
+      # functions like `SELECT pg_advisory_lock(...)`, whose session-level lock
+      # survives commit and would ride a pooled connection into the next caller
+      # (or collide with Oban's advisory locks). Release any such locks before
+      # the connection returns to the pool.
+      {:ok, _} = Repo.query("SELECT pg_advisory_unlock_all()")
+      result
     end)
+  end
+
+  defp maybe_set_local_role(nil), do: :ok
+
+  defp maybe_set_local_role(role) when is_binary(role) do
+    if !Regex.match?(~r/\A[a-zA-Z_][a-zA-Z0-9_]*\z/, role) do
+      raise ArgumentError, "invalid database role: #{inspect(role)}"
+    end
+
+    {:ok, _} = Repo.query(~s(SET LOCAL ROLE "#{role}"))
+    :ok
   end
 
   # SELECT / WITH go through a server-side cursor so we pull only `limit + 1`

--- a/server/lib/tuist/ops/database.ex
+++ b/server/lib/tuist/ops/database.ex
@@ -635,6 +635,21 @@ defmodule Tuist.Ops.Database do
     |> JSON.encode!()
   end
 
+  @doc """
+  JSON-safe structured view of an `execute/2` result, for API responses.
+  Rows become column-keyed maps with datetime/other values coerced the same
+  way as `to_json/1`; preserves the `columns` order and the `num_rows` /
+  `truncated?` metadata that a bare row list would drop.
+  """
+  def to_json_map(%{columns: cols, rows: rows} = result) do
+    %{
+      columns: cols,
+      rows: Enum.map(rows, fn row -> Map.new(cols, fn c -> {c, json_safe(Map.get(row, c))} end) end),
+      num_rows: Map.get(result, :num_rows, length(rows)),
+      truncated: Map.get(result, :truncated?, false)
+    }
+  end
+
   @doc "Render the result rows as RFC 4180 CSV with a header row."
   def to_csv(%{columns: cols, rows: rows}) do
     header = Enum.map_join(cols, ",", &csv_escape/1)

--- a/server/lib/tuist_web/controllers/internal/atlas_database_controller.ex
+++ b/server/lib/tuist_web/controllers/internal/atlas_database_controller.ex
@@ -11,17 +11,22 @@ defmodule TuistWeb.Internal.AtlasDatabaseController do
 
   use TuistWeb, :controller
 
+  alias Tuist.Environment
   alias Tuist.Ops.Database
 
   @doc """
   Run a read-only SQL statement. Body: `{"query": "...", "limit": n}`.
+
+  Runs through the least-privilege `tuist_ops_ro` role (when configured) so a
+  write is blocked by role privileges, not only by the read-only transaction.
   """
   def query(conn, %{"query" => sql} = params) when is_binary(sql) do
     opts =
-      case params do
-        %{"limit" => limit} when is_integer(limit) and limit > 0 -> [limit: limit]
-        _ -> []
-      end
+      [role: Environment.atlas_db_readonly_role()] ++
+        case params do
+          %{"limit" => limit} when is_integer(limit) and limit > 0 -> [limit: limit]
+          _ -> []
+        end
 
     case Database.execute(sql, opts) do
       {:ok, result} ->
@@ -43,7 +48,7 @@ defmodule TuistWeb.Internal.AtlasDatabaseController do
 
   @doc "Describe a single table's columns. 404 when the table is not visible."
   def describe(conn, %{"schema" => schema, "name" => name}) do
-    if Database.table_exists?(schema, name) do
+    if Database.app_table_exists?(schema, name) do
       json(conn, %{schema: schema, name: name, columns: Database.list_table_columns(schema, name)})
     else
       conn |> put_status(:not_found) |> json(%{error: "table_not_found"})

--- a/server/lib/tuist_web/controllers/internal/atlas_database_controller.ex
+++ b/server/lib/tuist_web/controllers/internal/atlas_database_controller.ex
@@ -1,0 +1,52 @@
+defmodule TuistWeb.Internal.AtlasDatabaseController do
+  @moduledoc """
+  Internal Atlas read-only access to the Tuist application database.
+
+  Backed by `Tuist.Ops.Database` — the same read-only query engine that powers
+  the `/ops/db` LiveView: a SELECT/WITH/EXPLAIN/SHOW grammar gate, a
+  `BEGIN READ ONLY` transaction, and a clamped `statement_timeout`. The caller
+  is authenticated by `TuistWeb.Plugs.InternalAtlasAuthPlug` (Atlas workload
+  identity), so these endpoints are reachable only by the Atlas service account.
+  """
+
+  use TuistWeb, :controller
+
+  alias Tuist.Ops.Database
+
+  @doc """
+  Run a read-only SQL statement. Body: `{"query": "...", "limit": n}`.
+  """
+  def query(conn, %{"query" => sql} = params) when is_binary(sql) do
+    opts =
+      case params do
+        %{"limit" => limit} when is_integer(limit) and limit > 0 -> [limit: limit]
+        _ -> []
+      end
+
+    case Database.execute(sql, opts) do
+      {:ok, result} ->
+        json(conn, Database.to_json_map(result))
+
+      {:error, reason} ->
+        conn |> put_status(:unprocessable_entity) |> json(%{error: to_string(reason)})
+    end
+  end
+
+  def query(conn, _params) do
+    conn |> put_status(:bad_request) |> json(%{error: "missing query"})
+  end
+
+  @doc "List app-owned tables with size + estimated-row stats."
+  def tables(conn, _params) do
+    json(conn, %{tables: Database.list_table_overviews()})
+  end
+
+  @doc "Describe a single table's columns. 404 when the table is not visible."
+  def describe(conn, %{"schema" => schema, "name" => name}) do
+    if Database.table_exists?(schema, name) do
+      json(conn, %{schema: schema, name: name, columns: Database.list_table_columns(schema, name)})
+    else
+      conn |> put_status(:not_found) |> json(%{error: "table_not_found"})
+    end
+  end
+end

--- a/server/lib/tuist_web/router.ex
+++ b/server/lib/tuist_web/router.ex
@@ -749,6 +749,10 @@ defmodule TuistWeb.Router do
     pipe_through [:atlas_internal_api]
 
     get "/atlas/accounts/:account_handle/usage", AtlasUsageController, :usage
+
+    post "/atlas/db/query", AtlasDatabaseController, :query
+    get "/atlas/db/tables", AtlasDatabaseController, :tables
+    get "/atlas/db/tables/:schema/:name", AtlasDatabaseController, :describe
   end
 
   scope "/_internal", TuistWeb.Internal do

--- a/server/test/tuist_web/controllers/internal/atlas_database_controller_test.exs
+++ b/server/test/tuist_web/controllers/internal/atlas_database_controller_test.exs
@@ -1,0 +1,106 @@
+defmodule TuistWeb.Internal.AtlasDatabaseControllerTest do
+  use TuistTestSupport.Cases.ConnCase, async: false
+  use Mimic
+
+  alias Tuist.AtlasWorkloadIdentity
+  alias TuistWeb.RateLimit
+
+  setup :set_mimic_from_context
+
+  setup do
+    stub(RateLimit.Atlas, :hit, fn _conn -> {:allow, 1} end)
+    :ok
+  end
+
+  defp ok_workload_identity_stub do
+    stub(AtlasWorkloadIdentity, :verify, fn "valid-token" ->
+      {:ok, %{namespace: "atlas-production", name: "atlas"}}
+    end)
+  end
+
+  defp authed(conn) do
+    put_req_header(conn, "authorization", "Bearer valid-token")
+  end
+
+  describe "POST /api/internal/atlas/db/query" do
+    test "runs a read-only query and returns column-keyed rows", %{conn: conn} do
+      ok_workload_identity_stub()
+
+      conn =
+        conn
+        |> authed()
+        |> post("/api/internal/atlas/db/query", %{"query" => "SELECT 1 AS one, 'x' AS letter"})
+
+      assert %{"columns" => ["one", "letter"], "rows" => [%{"one" => 1, "letter" => "x"}], "truncated" => false} =
+               json_response(conn, 200)
+    end
+
+    test "rejects non-read-only statements with 422", %{conn: conn} do
+      ok_workload_identity_stub()
+
+      conn =
+        conn
+        |> authed()
+        |> post("/api/internal/atlas/db/query", %{"query" => "DELETE FROM accounts"})
+
+      assert %{"error" => error} = json_response(conn, 422)
+      assert error =~ "Only SELECT"
+    end
+
+    test "returns 400 when query is missing", %{conn: conn} do
+      ok_workload_identity_stub()
+
+      conn = conn |> authed() |> post("/api/internal/atlas/db/query", %{})
+
+      assert %{"error" => "missing query"} = json_response(conn, 400)
+    end
+
+    test "returns 401 without a bearer token", %{conn: conn} do
+      conn = post(conn, "/api/internal/atlas/db/query", %{"query" => "SELECT 1"})
+
+      assert json_response(conn, 401)
+    end
+
+    test "returns 401 when workload identity rejects the token", %{conn: conn} do
+      stub(AtlasWorkloadIdentity, :verify, fn _ -> {:error, :invalid_signature} end)
+
+      conn =
+        conn
+        |> authed()
+        |> post("/api/internal/atlas/db/query", %{"query" => "SELECT 1"})
+
+      assert json_response(conn, 401)
+    end
+  end
+
+  describe "GET /api/internal/atlas/db/tables" do
+    test "lists tables", %{conn: conn} do
+      ok_workload_identity_stub()
+
+      conn = conn |> authed() |> get("/api/internal/atlas/db/tables")
+
+      assert %{"tables" => tables} = json_response(conn, 200)
+      assert is_list(tables)
+    end
+  end
+
+  describe "GET /api/internal/atlas/db/tables/:schema/:name" do
+    test "describes an existing table", %{conn: conn} do
+      ok_workload_identity_stub()
+
+      conn = conn |> authed() |> get("/api/internal/atlas/db/tables/public/accounts")
+
+      assert %{"schema" => "public", "name" => "accounts", "columns" => columns} = json_response(conn, 200)
+      assert is_list(columns)
+      assert Enum.any?(columns, &(&1["name"] == "id"))
+    end
+
+    test "returns 404 for an unknown table", %{conn: conn} do
+      ok_workload_identity_stub()
+
+      conn = conn |> authed() |> get("/api/internal/atlas/db/tables/public/does_not_exist")
+
+      assert %{"error" => "table_not_found"} = json_response(conn, 404)
+    end
+  end
+end

--- a/server/test/tuist_web/controllers/internal/atlas_database_controller_test.exs
+++ b/server/test/tuist_web/controllers/internal/atlas_database_controller_test.exs
@@ -1,5 +1,5 @@
 defmodule TuistWeb.Internal.AtlasDatabaseControllerTest do
-  use TuistTestSupport.Cases.ConnCase, async: false
+  use TuistTestSupport.Cases.ConnCase, async: true
   use Mimic
 
   alias Tuist.AtlasWorkloadIdentity

--- a/server/test/tuist_web/controllers/internal/atlas_database_controller_test.exs
+++ b/server/test/tuist_web/controllers/internal/atlas_database_controller_test.exs
@@ -47,6 +47,21 @@ defmodule TuistWeb.Internal.AtlasDatabaseControllerTest do
       assert error =~ "Only SELECT"
     end
 
+    test "clamps an oversized limit to the server-side maximum", %{conn: conn} do
+      ok_workload_identity_stub()
+
+      conn =
+        conn
+        |> authed()
+        |> post("/api/internal/atlas/db/query", %{
+          "query" => "SELECT generate_series(1, 1000) AS n",
+          "limit" => 100_000
+        })
+
+      assert %{"rows" => rows, "truncated" => true} = json_response(conn, 200)
+      assert length(rows) == 200
+    end
+
     test "returns 400 when query is missing", %{conn: conn} do
       ok_workload_identity_stub()
 
@@ -99,6 +114,14 @@ defmodule TuistWeb.Internal.AtlasDatabaseControllerTest do
       ok_workload_identity_stub()
 
       conn = conn |> authed() |> get("/api/internal/atlas/db/tables/public/does_not_exist")
+
+      assert %{"error" => "table_not_found"} = json_response(conn, 404)
+    end
+
+    test "returns 404 for catalog tables outside the app-owned schemas", %{conn: conn} do
+      ok_workload_identity_stub()
+
+      conn = conn |> authed() |> get("/api/internal/atlas/db/tables/pg_catalog/pg_class")
 
       assert %{"error" => "table_not_found"} = json_response(conn, 404)
     end


### PR DESCRIPTION
## What

Adds read-only database endpoints under `/api/internal/atlas/db`, for Atlas' MCP to consume:

- `POST /api/internal/atlas/db/query` — run a single read-only SQL statement
- `GET  /api/internal/atlas/db/tables` — list app-owned tables (size + estimated rows)
- `GET  /api/internal/atlas/db/tables/:schema/:name` — describe a table's columns

## How

Backed by `Tuist.Ops.Database` — the **same read-only engine behind `/ops/db`**: a SELECT/WITH/EXPLAIN/SHOW grammar gate, a `BEGIN READ ONLY` transaction, and a clamped `statement_timeout`. Reachable only by the Atlas service account through the existing `InternalAtlasAuthPlug` (workload identity / pinned JWKS) — the same `:atlas_internal_api` pipeline as the existing `/api/internal/atlas/accounts/:handle/usage` endpoint.

Adds `Tuist.Ops.Database.to_json_map/1` for JSON-safe API responses (preserves column order + truncation metadata).

## Companion

Atlas adds the executive-gated `*_tuist_postgres*` MCP tools that call these endpoints in tuist/atlas#344.

## Tests

Controller test added, mirroring the existing `AtlasUsageController` test. I couldn't get ExUnit to finish locally (the fresh worktree's cold CLDR compile wedged), so **relying on CI** to validate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
