### PR TITLE
fix(infra): parse tart get's string Size so the golden warm-path probe stops re-pulling

### DIFF
--- a/infra/tart-kubelet/internal/tart/tart.go
+++ b/infra/tart-kubelet/internal/tart/tart.go
@@ -67,7 +67,31 @@ type VM struct {
 	State  string `json:"State"`
 	CPU    int    `json:"CPU"`
 	Memory int    `json:"Memory"`
-	Size   int64  `json:"Size"`
+	Size   vmSize `json:"Size"`
+}
+
+// vmSize tolerates Tart's inconsistent Size encoding across subcommands:
+// `tart list --format json` emits an integer (72), while `tart get
+// --format json` emits a quoted decimal string ("72.660"). A plain int64
+// field unmarshals the former but errors on the latter — and because Get()
+// surfaces that error, ensureGolden's warm-path probe (`tart get <golden>`)
+// failed on EVERY call, fell through to the cold path, and re-pulled the
+// golden each recycle instead of cloning from it. The GC/label path was
+// unaffected because it reads `tart list`. Size isn't load-bearing; this
+// type just keeps VM unmarshal from failing on either form.
+type vmSize int64
+
+func (s *vmSize) UnmarshalJSON(b []byte) error {
+	str := strings.Trim(string(b), `"`)
+	if str == "" || str == "null" {
+		return nil
+	}
+	f, err := strconv.ParseFloat(str, 64)
+	if err != nil {
+		return nil
+	}
+	*s = vmSize(f)
+	return nil
 }
 
 // Per-operation timeouts bound how long a single `tart` invocation may

--- a/infra/tart-kubelet/internal/tart/tart_test.go
+++ b/infra/tart-kubelet/internal/tart/tart_test.go
@@ -2,6 +2,7 @@ package tart
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
@@ -9,6 +10,30 @@ import (
 	"testing"
 	"time"
 )
+
+// Regression for the warm-path miss: `tart list` encodes Size as an
+// integer while `tart get` encodes it as a quoted decimal string. A plain
+// int64 field errored on the latter, which made Get() fail on every golden
+// and forced a re-pull each recycle. VM must unmarshal both forms.
+func TestVMUnmarshalSizeAcceptsListAndGetEncodings(t *testing.T) {
+	cases := map[string]string{
+		"tart list (integer)":       `{"Name":"tuist-golden-abc","Source":"local","Size":72}`,
+		"tart get (quoted decimal)": `{"Name":"tuist-golden-abc","Source":"local","Size":"72.660"}`,
+		"tart get (quoted integer)": `{"Name":"tuist-golden-abc","Source":"local","Size":"72"}`,
+		"bare decimal (defensive)":  `{"Name":"tuist-golden-abc","Source":"local","Size":72.66}`,
+	}
+	for name, payload := range cases {
+		t.Run(name, func(t *testing.T) {
+			var vm VM
+			if err := json.Unmarshal([]byte(payload), &vm); err != nil {
+				t.Fatalf("unmarshal %s failed: %v", name, err)
+			}
+			if vm.Name != "tuist-golden-abc" {
+				t.Fatalf("Name = %q, want tuist-golden-abc", vm.Name)
+			}
+		})
+	}
+}
 
 // TestCloneTimeoutKillsHungProcess verifies the per-op watchdog: a
 // `tart` invocation that hangs (here a fake binary that sleeps well


### PR DESCRIPTION
## What this fixes

The root cause of "the golden base re-materializes on every recycle" — found in production within minutes of the warm-path-miss logging from #11517 going live.

`tart` encodes a VM's `Size` field **inconsistently across subcommands**:
- `tart list --format json` → `"Size": 72` (integer)
- `tart get --format json` → `"Size": "72.660"` (quoted decimal string)

The Go `VM` struct declared `Size int64`, so `json.Unmarshal` of a `tart get` response **errored on every call**. `Client.Get()` returns that error, and `ensureGolden` treats any non-nil `Get` error as "golden absent" → cold path → full multi-GB re-pull. So the per-host golden was rebuilt on essentially every provision **even though it was sitting on disk**.

The asymmetry is why this was so hard to spot from metrics/static analysis: the GC and node-label path read `tart list` (integer `Size`) and parsed fine — goldens were correctly kept and advertised — while only the warm-path probe (`tart get`) failed. On-host, `tart get <golden>` "worked" when run by hand (I was reading the JSON myself); it's the Go unmarshal that broke.

The new warm-path-miss log from #11517 surfaced it directly on the first updated host:
```
parse tart get tuist-golden-29a6ff6e...: json: cannot unmarshal string
into Go struct field VM.Size of type int64
```

## The fix

Make `Size` a small custom type whose `UnmarshalJSON` accepts Tart's integer, quoted-decimal, and bare-decimal forms (and null). `Size` is **never read anywhere** in the codebase — the type exists purely to keep `VM` unmarshal (and therefore `Get`) from failing on either encoding.

## Impact

Once deployed, `ensureGolden`'s warm-path probe will actually find the on-disk golden, so recycles clone from it (APFS clonefile, no network) instead of re-pulling. This is the change that makes the golden-base scheme finally deliver: `golden_base_reused_total` should climb, `golden_base_materialized_total` should go flat, and provision delay should drop from minutes to seconds. (Combined with #11517, which already stopped the GC from deleting the cached OCI image and made the cold path cheap — verified on the fleet: OCI churn stopped, cached image now survives GC passes.)

## Validation

- `go build`, `go vet`, `gofmt`, full module test suite pass.
- New `TestVMUnmarshalSizeAcceptsListAndGetEncodings` pins both real Tart encodings (`72` and `"72.660"`) plus quoted-integer and bare-decimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
