### PR TITLE
fix(cli): fail SwifterPM --force-resolved-versions on out-of-date Package.resolved

### DIFF
--- a/swifterpm/Sources/swifterpm/CLI.swift
+++ b/swifterpm/Sources/swifterpm/CLI.swift
@@ -575,6 +575,18 @@ enum CLIRunner {
                 packageDir: package, scratchDir: scratch, resolved: resolved,
                 disableSandbox: cli.disableSandbox)
         }
+
+        // `resolveOrLoad` rejected direct pins that violate the root manifest;
+        // with the checkouts materialized, extend that to the whole pinned graph
+        // (SwiftPM precomputation parity) so transitive drift fails here too.
+        if readOnly {
+            try await PackageResolver.validateResolvedGraphSatisfiesManifests(
+                packageDir: package,
+                scratchDir: scratch,
+                resolved: resolved,
+                disableSandbox: cli.disableSandbox
+            )
+        }
     }
 
     private static func maybeWritePackageInfoCache(

--- a/swifterpm/Sources/swifterpm/CLI.swift
+++ b/swifterpm/Sources/swifterpm/CLI.swift
@@ -574,18 +574,21 @@ enum CLIRunner {
             try await WorkspaceRestorer.writeWorkspaceState(
                 packageDir: package, scratchDir: scratch, resolved: resolved,
                 disableSandbox: cli.disableSandbox)
-        }
 
-        // `resolveOrLoad` rejected direct pins that violate the root manifest;
-        // with the checkouts materialized, extend that to the whole pinned graph
-        // (SwiftPM precomputation parity) so transitive drift fails here too.
-        if readOnly {
-            try await PackageResolver.validateResolvedGraphSatisfiesManifests(
-                packageDir: package,
-                scratchDir: scratch,
-                resolved: resolved,
-                disableSandbox: cli.disableSandbox
-            )
+            // With the pins restored, confirm they still satisfy the manifest the
+            // same way SwiftPM does. SwiftPM reuses the workspace state we just
+            // wrote, so this is a fast precomputation rather than a fresh resolve.
+            if readOnly {
+                try await PackageResolver.assertResolvedFileUpToDate(
+                    packageDir: package,
+                    scratchDir: scratch,
+                    cacheDir: cache.root,
+                    registryConfigurationPath: paths.resolve(cli.configPath),
+                    defaultRegistryURL: cli.defaultRegistryURL,
+                    disableSandbox: cli.disableSandbox,
+                    scmToRegistryTransformation: try scmToRegistryTransformation(cli)
+                )
+            }
         }
     }
 

--- a/swifterpm/Sources/swifterpm/Resolve.swift
+++ b/swifterpm/Sources/swifterpm/Resolve.swift
@@ -213,11 +213,10 @@ enum PackageResolver {
                     "Package.resolved is required when forcing resolved versions, but no file exists at \(resolvedFileURL.path)"
                 )
             }
-            let resolved = try await ResolvedFile.read(packageDir: packageDir)
-            try await validateResolvedFileSatisfiesManifest(
-                resolved, packageDir: packageDir, disableSandbox: disableSandbox
-            )
-            return resolved
+            // The pins are trusted as-is here; whether they're still in sync with
+            // the manifest is verified by `assertResolvedFileUpToDate`, which the
+            // resolution flow runs once the checkouts are materialized.
+            return try await ResolvedFile.read(packageDir: packageDir)
         }
         // `--skip-update` is an explicit "trust the on-disk pins" signal:
         // read the file as-is even when it predates the `originHash` field
@@ -261,225 +260,42 @@ enum PackageResolver {
         )
     }
 
-    /// SwiftPM refuses to build against a `Package.resolved` whose pins no
-    /// longer satisfy the manifest when automatic resolution is disabled
-    /// (`--force-resolved-versions` / `--disable-automatic-resolution`); it
-    /// errors with an "out-of-date resolved file" instead of silently using the
-    /// stale pins. The `readOnly` path skipped that check, so a manifest bumped
-    /// past its lockfile (e.g. an `exact:` raised without re-resolving) was
-    /// restored to the old version and reported success — diverging from
-    /// SwiftPM and masking the very drift the flag is meant to catch.
+    /// Reject an out-of-date `Package.resolved` under `--force-resolved-versions`
+    /// the same way SwiftPM does, by delegating to SwiftPM itself rather than
+    /// reimplementing its resolver precomputation.
     ///
-    /// SwiftPM implements this in `ResolverPrecomputationProvider`: it runs the
-    /// resolver with each package's *only* available version fixed to its pin
-    /// (`LocalPackageContainer.versionsAscending` returns `[pinnedVersion]`), so
-    /// a `.required` result — and the error — fires when a pin can't satisfy a
-    /// constraint, not merely because a newer version exists within a still-
-    /// satisfied range.
-    ///
-    /// This is the fast, fail-fast half: it validates only the root manifest's
-    /// direct dependencies, so it needs no checkouts and runs before the restore.
-    /// `validateResolvedGraphSatisfiesManifests` runs after the restore and
-    /// extends the same satisfiability check across the whole pinned graph
-    /// (transitive constraints included) for full SwiftPM parity.
-    private static func validateResolvedFileSatisfiesManifest(
-        _ resolved: ResolvedPins,
+    /// The `readOnly` path restores the pins verbatim, so a manifest that has
+    /// drifted from its lockfile (an `exact:` bumped without re-resolving, a new
+    /// dependency added, a version requirement changed to a branch, …) would
+    /// otherwise be built against the stale pins and exit successfully — whereas
+    /// `swift package resolve --force-resolved-versions` fails closed with an
+    /// "out-of-date resolved file" error. We run exactly that command once the
+    /// checkouts are materialized: SwiftPM reuses the restored workspace state,
+    /// so the check is a fast precomputation (no fetch) and inherits SwiftPM's
+    /// full out-of-date semantics — direct, transitive, added/removed packages,
+    /// and version/branch/revision requirement changes alike. The command's
+    /// output is captured (not forwarded) so that, on the non-zero exit, the
+    /// SwiftPM out-of-date diagnostic on stderr becomes the `ToolError` message
+    /// instead of a bare exit code.
+    static func assertResolvedFileUpToDate(
         packageDir: URL,
-        disableSandbox: Bool
+        scratchDir: URL?,
+        cacheDir: URL,
+        registryConfigurationPath: URL?,
+        defaultRegistryURL: String?,
+        disableSandbox: Bool,
+        scmToRegistryTransformation: SCMToRegistryTransformation
     ) async throws {
-        let manifest = try await ManifestLoader.dumpPackage(
-            packageDir: packageDir, disableSandbox: disableSandbox
-        )
-        var dependencies = try ManifestParser.dependencies(manifest)
-        let localPackages = try await ManifestFileSystemDependencyGraph.collect(
-            rootPackageDir: packageDir,
-            rootManifest: manifest,
-            disableSandbox: disableSandbox
-        )
-        for localPackage in localPackages {
-            dependencies.append(contentsOf: try ManifestParser.dependencies(localPackage.manifest))
-        }
-
-        let pinsByIdentity = pinsByIdentity(resolved)
-        try validateConstraints(
-            dependencies, pinsByIdentity: pinsByIdentity, packageDir: packageDir, requiredBy: "Package.swift"
-        )
-    }
-
-    /// Whole-graph counterpart to `validateResolvedFileSatisfiesManifest`,
-    /// matching SwiftPM's `ResolverPrecomputationProvider`: it walks the pinned
-    /// dependency graph (root + every reachable pinned package's own manifest)
-    /// and fails when any pin can't satisfy a constraint placed on it —
-    /// including transitive ones the root manifest never names directly. It
-    /// reuses the checkouts a `readOnly` restore already materialized; a package
-    /// whose source isn't on disk (e.g. `--print-only`, which skips restore)
-    /// simply isn't recursed into, so the walk degrades to the direct check
-    /// rather than failing spuriously.
-    static func validateResolvedGraphSatisfiesManifests(
-        packageDir: URL,
-        scratchDir: URL,
-        resolved: ResolvedPins,
-        disableSandbox: Bool
-    ) async throws {
-        let pinsByIdentity = pinsByIdentity(resolved)
-
-        let rootManifest = try await ManifestLoader.dumpPackage(
-            packageDir: packageDir, disableSandbox: disableSandbox
-        )
-        var worklist = try ManifestParser.dependencies(rootManifest).map {
-            PendingConstraint(requiredBy: "Package.swift", dependency: $0)
-        }
-        let localPackages = try await ManifestFileSystemDependencyGraph.collect(
-            rootPackageDir: packageDir,
-            rootManifest: rootManifest,
-            disableSandbox: disableSandbox
-        )
-        for localPackage in localPackages {
-            let requiredBy = "'\(localPackage.dependency.identity)'"
-            worklist.append(
-                contentsOf: try ManifestParser.dependencies(localPackage.manifest).map {
-                    PendingConstraint(requiredBy: requiredBy, dependency: $0)
-                }
-            )
-        }
-
-        var expanded = Set<String>()
-        while let pending = worklist.popLast() {
-            let dependency = pending.dependency
-            let identity = dependency.identity.lowercased()
-            // Skip pins we can't confidently match (e.g. an SCM->registry
-            // identity remap) to avoid a false positive; the resolver only fails
-            // on pins it can prove unsatisfiable.
-            guard let pin = pinsByIdentity[identity] else { continue }
-            guard pinSatisfies(dependency.requirement, pin: pin) else {
-                throw ToolError.message(
-                    outOfDateMessage(
-                        packageDir: packageDir, dependency: dependency, pin: pin, requiredBy: pending.requiredBy
-                    )
-                )
-            }
-            guard expanded.insert(identity).inserted else { continue }
-
-            // Recurse into the pinned package's own manifest to validate its
-            // transitive constraints. This needs the materialized source; if the
-            // checkout/registry download is absent we can't (and don't) descend.
-            let sourcePath = materializedPackagePath(scratchDir: scratchDir, pin: pin)
-            guard let sourcePath,
-                  try await fileSystem.exists(sourcePath.appendingPathComponent("Package.swift").absolutePath)
-            else { continue }
-            let manifest = try await ManifestLoader.dumpPackage(
-                packageDir: sourcePath, disableSandbox: disableSandbox
-            )
-            let requiredBy = "'\(pin.identity)'"
-            worklist.append(
-                contentsOf: try ManifestParser.dependencies(manifest).map {
-                    PendingConstraint(requiredBy: requiredBy, dependency: $0)
-                }
-            )
-        }
-    }
-
-    private struct PendingConstraint {
-        let requiredBy: String
-        let dependency: ManifestDependency
-    }
-
-    private static func pinsByIdentity(_ resolved: ResolvedPins) -> [String: ResolvedPin] {
-        var pinsByIdentity: [String: ResolvedPin] = [:]
-        for pin in resolved.pins {
-            pinsByIdentity[pin.identity.lowercased()] = pin
-        }
-        return pinsByIdentity
-    }
-
-    /// Validate a single package's direct dependency constraints against the
-    /// pins. Only pins we can match by identity are checked; an unmatched
-    /// dependency may be an SCM->registry identity remap rather than genuine
-    /// drift, so it's skipped instead of risking a false positive that would
-    /// break a working lockfile.
-    private static func validateConstraints(
-        _ dependencies: [ManifestDependency],
-        pinsByIdentity: [String: ResolvedPin],
-        packageDir: URL,
-        requiredBy: String
-    ) throws {
-        for dependency in dependencies {
-            guard let pin = pinsByIdentity[dependency.identity.lowercased()] else { continue }
-            guard pinSatisfies(dependency.requirement, pin: pin) else {
-                throw ToolError.message(
-                    outOfDateMessage(
-                        packageDir: packageDir, dependency: dependency, pin: pin, requiredBy: requiredBy
-                    )
-                )
-            }
-        }
-    }
-
-    /// Whether `pin` satisfies `requirement`, mirroring SwiftPM precomputation
-    /// where each package offers only its pinned version. Version constraints
-    /// are checked strictly; branch/revision are checked leniently (a missing
-    /// field on the pin is treated as "no contradiction") so we never fail a
-    /// lockfile on an ambiguous short/long revision or unrecorded branch.
-    private static func pinSatisfies(_ requirement: Requirement, pin: ResolvedPin) -> Bool {
-        switch requirement {
-        case .exact, .range:
-            guard let range = ManifestParser.versionRange(for: requirement) else { return true }
-            // A version requirement against a branch/revision pin is genuine
-            // drift (the manifest no longer asks for a versioned dependency).
-            guard let versionString = pin.state.version else { return false }
-            // An unparseable pin version is not proof of drift; don't fail on it.
-            guard let version = try? SemVer(versionString) else { return true }
-            return range.contains(version)
-        case let .revision(revision):
-            guard let pinned = pin.state.revision, !pinned.isEmpty, !revision.isEmpty else { return true }
-            return pinned.hasPrefix(revision) || revision.hasPrefix(pinned)
-        case let .branch(branch):
-            guard let pinned = pin.state.branch else { return true }
-            return pinned == branch
-        }
-    }
-
-    /// On-disk source location a `readOnly` restore materializes a pin into,
-    /// mirroring `WorkspaceRestorer`: registry downloads live under
-    /// `registry/downloads/<scope>/<name>/<version>`, source-control checkouts
-    /// under `checkouts/<name>`.
-    private static func materializedPackagePath(scratchDir: URL, pin: ResolvedPin) -> URL? {
-        if PinKind.isRegistry(pin.kind) {
-            guard let subpath = try? PinKind.registryDownloadSubpath(pin) else { return nil }
-            return scratchDir.appendingPathComponent("registry/downloads").appendingPathComponent(subpath)
-        }
-        guard PinKind.isSourceControl(pin.kind) else { return nil }
-        return scratchDir.appendingPathComponent("checkouts")
-            .appendingPathComponent(PinKind.checkoutDirectoryName(pin))
-    }
-
-    private static func outOfDateMessage(
-        packageDir: URL,
-        dependency: ManifestDependency,
-        pin: ResolvedPin,
-        requiredBy: String
-    ) -> String {
-        let resolvedPath = packageDir.appendingPathComponent("Package.resolved").path
-        let pinned = pin.state.version ?? pin.state.branch ?? pin.state.revision ?? "<unknown>"
-        return """
-        an out-of-date Package.resolved was detected at \(resolvedPath), which is not allowed when \
-        --force-resolved-versions is set: '\(dependency.identity)' is pinned to \(pinned) but \(requiredBy) \
-        requires \(requirementDescription(dependency.requirement)). Update the resolved file (e.g. run \
-        `tuist install` or `swift package resolve`) and commit it.
-        """
-    }
-
-    private static func requirementDescription(_ requirement: Requirement) -> String {
-        switch requirement {
-        case let .exact(version):
-            return "exactly \(version)"
-        case let .range(lower, upper):
-            return "\(lower)..<\(upper)"
-        case let .revision(revision):
-            return "revision \(revision)"
-        case let .branch(branch):
-            return "branch \(branch)"
-        }
+        let arguments = swiftPackageResolveArguments(
+            packageDir: packageDir,
+            scratchDir: scratchDir,
+            cacheDir: cacheDir,
+            registryConfigurationPath: registryConfigurationPath,
+            defaultRegistryURL: defaultRegistryURL,
+            disableSandbox: disableSandbox,
+            scmToRegistryTransformation: scmToRegistryTransformation
+        ) + ["--force-resolved-versions"]
+        try await SystemProcess.run("swift", arguments, workingDirectory: packageDir)
     }
 
     private static func normalizeLoadedResolvedFile(

--- a/swifterpm/Sources/swifterpm/Resolve.swift
+++ b/swifterpm/Sources/swifterpm/Resolve.swift
@@ -213,7 +213,11 @@ enum PackageResolver {
                     "Package.resolved is required when forcing resolved versions, but no file exists at \(resolvedFileURL.path)"
                 )
             }
-            return try await ResolvedFile.read(packageDir: packageDir)
+            let resolved = try await ResolvedFile.read(packageDir: packageDir)
+            try await validateResolvedFileSatisfiesManifest(
+                resolved, packageDir: packageDir, disableSandbox: disableSandbox
+            )
+            return resolved
         }
         // `--skip-update` is an explicit "trust the on-disk pins" signal:
         // read the file as-is even when it predates the `originHash` field
@@ -255,6 +259,227 @@ enum PackageResolver {
             writeResolvedFile: writeResolvedFile,
             progress: progress
         )
+    }
+
+    /// SwiftPM refuses to build against a `Package.resolved` whose pins no
+    /// longer satisfy the manifest when automatic resolution is disabled
+    /// (`--force-resolved-versions` / `--disable-automatic-resolution`); it
+    /// errors with an "out-of-date resolved file" instead of silently using the
+    /// stale pins. The `readOnly` path skipped that check, so a manifest bumped
+    /// past its lockfile (e.g. an `exact:` raised without re-resolving) was
+    /// restored to the old version and reported success — diverging from
+    /// SwiftPM and masking the very drift the flag is meant to catch.
+    ///
+    /// SwiftPM implements this in `ResolverPrecomputationProvider`: it runs the
+    /// resolver with each package's *only* available version fixed to its pin
+    /// (`LocalPackageContainer.versionsAscending` returns `[pinnedVersion]`), so
+    /// a `.required` result — and the error — fires when a pin can't satisfy a
+    /// constraint, not merely because a newer version exists within a still-
+    /// satisfied range.
+    ///
+    /// This is the fast, fail-fast half: it validates only the root manifest's
+    /// direct dependencies, so it needs no checkouts and runs before the restore.
+    /// `validateResolvedGraphSatisfiesManifests` runs after the restore and
+    /// extends the same satisfiability check across the whole pinned graph
+    /// (transitive constraints included) for full SwiftPM parity.
+    private static func validateResolvedFileSatisfiesManifest(
+        _ resolved: ResolvedPins,
+        packageDir: URL,
+        disableSandbox: Bool
+    ) async throws {
+        let manifest = try await ManifestLoader.dumpPackage(
+            packageDir: packageDir, disableSandbox: disableSandbox
+        )
+        var dependencies = try ManifestParser.dependencies(manifest)
+        let localPackages = try await ManifestFileSystemDependencyGraph.collect(
+            rootPackageDir: packageDir,
+            rootManifest: manifest,
+            disableSandbox: disableSandbox
+        )
+        for localPackage in localPackages {
+            dependencies.append(contentsOf: try ManifestParser.dependencies(localPackage.manifest))
+        }
+
+        let pinsByIdentity = pinsByIdentity(resolved)
+        try validateConstraints(
+            dependencies, pinsByIdentity: pinsByIdentity, packageDir: packageDir, requiredBy: "Package.swift"
+        )
+    }
+
+    /// Whole-graph counterpart to `validateResolvedFileSatisfiesManifest`,
+    /// matching SwiftPM's `ResolverPrecomputationProvider`: it walks the pinned
+    /// dependency graph (root + every reachable pinned package's own manifest)
+    /// and fails when any pin can't satisfy a constraint placed on it —
+    /// including transitive ones the root manifest never names directly. It
+    /// reuses the checkouts a `readOnly` restore already materialized; a package
+    /// whose source isn't on disk (e.g. `--print-only`, which skips restore)
+    /// simply isn't recursed into, so the walk degrades to the direct check
+    /// rather than failing spuriously.
+    static func validateResolvedGraphSatisfiesManifests(
+        packageDir: URL,
+        scratchDir: URL,
+        resolved: ResolvedPins,
+        disableSandbox: Bool
+    ) async throws {
+        let pinsByIdentity = pinsByIdentity(resolved)
+
+        let rootManifest = try await ManifestLoader.dumpPackage(
+            packageDir: packageDir, disableSandbox: disableSandbox
+        )
+        var worklist = try ManifestParser.dependencies(rootManifest).map {
+            PendingConstraint(requiredBy: "Package.swift", dependency: $0)
+        }
+        let localPackages = try await ManifestFileSystemDependencyGraph.collect(
+            rootPackageDir: packageDir,
+            rootManifest: rootManifest,
+            disableSandbox: disableSandbox
+        )
+        for localPackage in localPackages {
+            let requiredBy = "'\(localPackage.dependency.identity)'"
+            worklist.append(
+                contentsOf: try ManifestParser.dependencies(localPackage.manifest).map {
+                    PendingConstraint(requiredBy: requiredBy, dependency: $0)
+                }
+            )
+        }
+
+        var expanded = Set<String>()
+        while let pending = worklist.popLast() {
+            let dependency = pending.dependency
+            let identity = dependency.identity.lowercased()
+            // Skip pins we can't confidently match (e.g. an SCM->registry
+            // identity remap) to avoid a false positive; the resolver only fails
+            // on pins it can prove unsatisfiable.
+            guard let pin = pinsByIdentity[identity] else { continue }
+            guard pinSatisfies(dependency.requirement, pin: pin) else {
+                throw ToolError.message(
+                    outOfDateMessage(
+                        packageDir: packageDir, dependency: dependency, pin: pin, requiredBy: pending.requiredBy
+                    )
+                )
+            }
+            guard expanded.insert(identity).inserted else { continue }
+
+            // Recurse into the pinned package's own manifest to validate its
+            // transitive constraints. This needs the materialized source; if the
+            // checkout/registry download is absent we can't (and don't) descend.
+            let sourcePath = materializedPackagePath(scratchDir: scratchDir, pin: pin)
+            guard let sourcePath,
+                  try await fileSystem.exists(sourcePath.appendingPathComponent("Package.swift").absolutePath)
+            else { continue }
+            let manifest = try await ManifestLoader.dumpPackage(
+                packageDir: sourcePath, disableSandbox: disableSandbox
+            )
+            let requiredBy = "'\(pin.identity)'"
+            worklist.append(
+                contentsOf: try ManifestParser.dependencies(manifest).map {
+                    PendingConstraint(requiredBy: requiredBy, dependency: $0)
+                }
+            )
+        }
+    }
+
+    private struct PendingConstraint {
+        let requiredBy: String
+        let dependency: ManifestDependency
+    }
+
+    private static func pinsByIdentity(_ resolved: ResolvedPins) -> [String: ResolvedPin] {
+        var pinsByIdentity: [String: ResolvedPin] = [:]
+        for pin in resolved.pins {
+            pinsByIdentity[pin.identity.lowercased()] = pin
+        }
+        return pinsByIdentity
+    }
+
+    /// Validate a single package's direct dependency constraints against the
+    /// pins. Only pins we can match by identity are checked; an unmatched
+    /// dependency may be an SCM->registry identity remap rather than genuine
+    /// drift, so it's skipped instead of risking a false positive that would
+    /// break a working lockfile.
+    private static func validateConstraints(
+        _ dependencies: [ManifestDependency],
+        pinsByIdentity: [String: ResolvedPin],
+        packageDir: URL,
+        requiredBy: String
+    ) throws {
+        for dependency in dependencies {
+            guard let pin = pinsByIdentity[dependency.identity.lowercased()] else { continue }
+            guard pinSatisfies(dependency.requirement, pin: pin) else {
+                throw ToolError.message(
+                    outOfDateMessage(
+                        packageDir: packageDir, dependency: dependency, pin: pin, requiredBy: requiredBy
+                    )
+                )
+            }
+        }
+    }
+
+    /// Whether `pin` satisfies `requirement`, mirroring SwiftPM precomputation
+    /// where each package offers only its pinned version. Version constraints
+    /// are checked strictly; branch/revision are checked leniently (a missing
+    /// field on the pin is treated as "no contradiction") so we never fail a
+    /// lockfile on an ambiguous short/long revision or unrecorded branch.
+    private static func pinSatisfies(_ requirement: Requirement, pin: ResolvedPin) -> Bool {
+        switch requirement {
+        case .exact, .range:
+            guard let range = ManifestParser.versionRange(for: requirement) else { return true }
+            // A version requirement against a branch/revision pin is genuine
+            // drift (the manifest no longer asks for a versioned dependency).
+            guard let versionString = pin.state.version else { return false }
+            // An unparseable pin version is not proof of drift; don't fail on it.
+            guard let version = try? SemVer(versionString) else { return true }
+            return range.contains(version)
+        case let .revision(revision):
+            guard let pinned = pin.state.revision, !pinned.isEmpty, !revision.isEmpty else { return true }
+            return pinned.hasPrefix(revision) || revision.hasPrefix(pinned)
+        case let .branch(branch):
+            guard let pinned = pin.state.branch else { return true }
+            return pinned == branch
+        }
+    }
+
+    /// On-disk source location a `readOnly` restore materializes a pin into,
+    /// mirroring `WorkspaceRestorer`: registry downloads live under
+    /// `registry/downloads/<scope>/<name>/<version>`, source-control checkouts
+    /// under `checkouts/<name>`.
+    private static func materializedPackagePath(scratchDir: URL, pin: ResolvedPin) -> URL? {
+        if PinKind.isRegistry(pin.kind) {
+            guard let subpath = try? PinKind.registryDownloadSubpath(pin) else { return nil }
+            return scratchDir.appendingPathComponent("registry/downloads").appendingPathComponent(subpath)
+        }
+        guard PinKind.isSourceControl(pin.kind) else { return nil }
+        return scratchDir.appendingPathComponent("checkouts")
+            .appendingPathComponent(PinKind.checkoutDirectoryName(pin))
+    }
+
+    private static func outOfDateMessage(
+        packageDir: URL,
+        dependency: ManifestDependency,
+        pin: ResolvedPin,
+        requiredBy: String
+    ) -> String {
+        let resolvedPath = packageDir.appendingPathComponent("Package.resolved").path
+        let pinned = pin.state.version ?? pin.state.branch ?? pin.state.revision ?? "<unknown>"
+        return """
+        an out-of-date Package.resolved was detected at \(resolvedPath), which is not allowed when \
+        --force-resolved-versions is set: '\(dependency.identity)' is pinned to \(pinned) but \(requiredBy) \
+        requires \(requirementDescription(dependency.requirement)). Update the resolved file (e.g. run \
+        `tuist install` or `swift package resolve`) and commit it.
+        """
+    }
+
+    private static func requirementDescription(_ requirement: Requirement) -> String {
+        switch requirement {
+        case let .exact(version):
+            return "exactly \(version)"
+        case let .range(lower, upper):
+            return "\(lower)..<\(upper)"
+        case let .revision(revision):
+            return "revision \(revision)"
+        case let .branch(branch):
+            return "branch \(branch)"
+        }
     }
 
     private static func normalizeLoadedResolvedFile(

--- a/swifterpm/Sources/swifterpm/SwifterPM.swift
+++ b/swifterpm/Sources/swifterpm/SwifterPM.swift
@@ -246,16 +246,19 @@ public struct SwifterPM: Sendable {
             )
         }
 
-        // `resolveOrLoad` already rejected a `Package.resolved` whose direct
-        // pins violate the root manifest. With the checkouts now materialized we
-        // can extend that to the whole pinned graph (SwiftPM's precomputation
-        // parity), catching transitive constraints the root never names.
-        if request.forceResolvedVersions {
-            try await PackageResolver.validateResolvedGraphSatisfiesManifests(
+        // With the pins restored, confirm they still satisfy the manifest the
+        // same way SwiftPM would. We only do this once the checkouts exist so
+        // SwiftPM reuses the restored workspace state and the check stays a fast
+        // precomputation rather than a fresh resolve.
+        if request.forceResolvedVersions, request.restorePackage {
+            try await PackageResolver.assertResolvedFileUpToDate(
                 packageDir: package,
                 scratchDir: scratch,
-                resolved: resolved,
-                disableSandbox: request.disableSandbox
+                cacheDir: cache.root,
+                registryConfigurationPath: request.registryConfigurationPath,
+                defaultRegistryURL: request.defaultRegistryURL,
+                disableSandbox: request.disableSandbox,
+                scmToRegistryTransformation: request.scmToRegistryTransformation
             )
         }
 

--- a/swifterpm/Sources/swifterpm/SwifterPM.swift
+++ b/swifterpm/Sources/swifterpm/SwifterPM.swift
@@ -246,6 +246,19 @@ public struct SwifterPM: Sendable {
             )
         }
 
+        // `resolveOrLoad` already rejected a `Package.resolved` whose direct
+        // pins violate the root manifest. With the checkouts now materialized we
+        // can extend that to the whole pinned graph (SwiftPM's precomputation
+        // parity), catching transitive constraints the root never names.
+        if request.forceResolvedVersions {
+            try await PackageResolver.validateResolvedGraphSatisfiesManifests(
+                packageDir: package,
+                scratchDir: scratch,
+                resolved: resolved,
+                disableSandbox: request.disableSandbox
+            )
+        }
+
         return SwifterPMResolutionResult(resolved)
     }
 

--- a/swifterpm/Tests/swifterpmTests/ResolveTests.swift
+++ b/swifterpm/Tests/swifterpmTests/ResolveTests.swift
@@ -8,7 +8,7 @@ struct ResolveTests {
         try await withTemporaryDirectory { root in
             let dependency = root.appendingPathComponent("Dependency")
             try await writeLibraryPackageManifest(at: dependency, name: "Dependency")
-            try await initGitDependency(at: dependency, tag: "1.0.0")
+            try await initGitDependency(at: dependency, tags: ["1.0.0"])
 
             let package = root.appendingPathComponent("App")
             try await writeAppPackageManifest(
@@ -95,16 +95,16 @@ struct ResolveTests {
     }
 
     @Test
-    func resolveOrLoadReadOnlyFailsWhenAPinNoLongerSatisfiesTheManifest() async throws {
-        // Pre-PR the readOnly branch read Package.resolved verbatim with no
-        // manifest check, so a manifest bumped past its lockfile (here an
-        // `exact:` raised from 1.0.0 to 2.0.0 without re-resolving) was restored
-        // to the stale 1.0.0 and reported success — where pure SwiftPM
-        // `swift package resolve --force-resolved-versions` errors out-of-date.
+    func forceResolvedVersionsRejectsAnOutOfDateLockfileViaSwiftPM() async throws {
+        // The readOnly path restores the pins verbatim; out-of-date detection is
+        // delegated to `swift package resolve --force-resolved-versions` rather
+        // than reimplementing SwiftPM's resolver precomputation. Bumping the
+        // manifest past the committed pin must surface SwiftPM's out-of-date
+        // error, while an in-sync lockfile must pass.
         try await withTemporaryDirectory { root in
             let dependency = root.appendingPathComponent("Dependency")
             try await writeLibraryPackageManifest(at: dependency, name: "Dependency")
-            try await initGitDependency(at: dependency, tag: "1.0.0")
+            try await initGitDependency(at: dependency, tags: ["1.0.0", "2.0.0"])
 
             let package = root.appendingPathComponent("App")
             try await writeAppPackageManifest(
@@ -112,200 +112,46 @@ struct ResolveTests {
             )
 
             let cache = try await Cache(root: root.appendingPathComponent("cache"))
+            let scratch = root.appendingPathComponent("scratch")
             _ = try await PackageResolver.resolve(
                 packageDir: package,
-                scratchDir: root.appendingPathComponent("scratch"),
+                scratchDir: scratch,
                 cache: cache,
                 registryConfig: RegistryConfig(),
                 disableSandbox: true,
                 writeResolvedFile: true
             )
 
-            // Bump the manifest past the lockfile; clear the manifest dump cache
-            // so the readOnly validation re-reads the changed requirement rather
-            // than a same-second mtime-stale cache.
+            // In sync: the pinned 1.0.0 satisfies the manifest, so the check passes.
+            try await PackageResolver.assertResolvedFileUpToDate(
+                packageDir: package,
+                scratchDir: scratch,
+                cacheDir: cache.root,
+                registryConfigurationPath: nil,
+                defaultRegistryURL: nil,
+                disableSandbox: true,
+                scmToRegistryTransformation: .disabled
+            )
+
+            // Bump the manifest past the lockfile: SwiftPM rejects the stale pin.
             try await writeAppPackageManifest(
                 at: package, dependencyURL: dependency.path, exactVersion: "2.0.0"
             )
-            try? await fileSystem.removePath(ManifestLoader.cacheFilePath(packageDir: package))
-
             await #expect(throws: ToolError.self) {
-                try await PackageResolver.resolveOrLoad(
+                try await PackageResolver.assertResolvedFileUpToDate(
                     packageDir: package,
-                    scratchDir: root.appendingPathComponent("scratch"),
-                    cache: cache,
-                    registryConfig: RegistryConfig(),
+                    scratchDir: scratch,
+                    cacheDir: cache.root,
+                    registryConfigurationPath: nil,
+                    defaultRegistryURL: nil,
                     disableSandbox: true,
-                    scmToRegistryTransformation: .disabled,
-                    preferResolvedFile: true,
-                    readOnly: true,
-                    skipUpdate: false,
-                    writeResolvedFile: false,
-                    progress: nil
+                    scmToRegistryTransformation: .disabled
                 )
             }
         }
     }
 
-    @Test
-    func resolveOrLoadReadOnlyReturnsPinsWhenTheyStillSatisfyTheManifest() async throws {
-        // Guard against a false positive: an in-sync lockfile must still load in
-        // readOnly mode without re-resolving.
-        try await withTemporaryDirectory { root in
-            let dependency = root.appendingPathComponent("Dependency")
-            try await writeLibraryPackageManifest(at: dependency, name: "Dependency")
-            try await initGitDependency(at: dependency, tag: "1.0.0")
-
-            let package = root.appendingPathComponent("App")
-            try await writeAppPackageManifest(
-                at: package, dependencyURL: dependency.path, exactVersion: "1.0.0"
-            )
-
-            let cache = try await Cache(root: root.appendingPathComponent("cache"))
-            _ = try await PackageResolver.resolve(
-                packageDir: package,
-                scratchDir: root.appendingPathComponent("scratch"),
-                cache: cache,
-                registryConfig: RegistryConfig(),
-                disableSandbox: true,
-                writeResolvedFile: true
-            )
-
-            let resolved = try await PackageResolver.resolveOrLoad(
-                packageDir: package,
-                scratchDir: root.appendingPathComponent("scratch"),
-                cache: cache,
-                registryConfig: RegistryConfig(),
-                disableSandbox: true,
-                scmToRegistryTransformation: .disabled,
-                preferResolvedFile: true,
-                readOnly: true,
-                skipUpdate: false,
-                writeResolvedFile: false,
-                progress: nil
-            )
-
-            let pin = try #require(resolved.pins.first { $0.identity == "dependency" })
-            #expect(pin.state.version == "1.0.0")
-        }
-    }
-
-    @Test
-    func validateResolvedGraphFailsWhenATransitivePinViolatesAnIntermediateManifest() async throws {
-        // Closes the gap with SwiftPM's whole-graph precomputation: the root
-        // manifest is in sync (root -> A exact 1.0.0, pinned 1.0.0) but A's own
-        // manifest requires B exact 2.0.0 while Package.resolved pins B at 1.0.0.
-        // The direct-only check can't see this; the graph walk must.
-        try await withTemporaryDirectory { root in
-            let scratch = root.appendingPathComponent(".build")
-            try await writeManifestWithExactDependency(
-                at: root, name: "Root",
-                dependencyURL: "https://example.com/A.git", dependencyPackage: "A", exactVersion: "1.0.0"
-            )
-            try await writeManifestWithExactDependency(
-                at: scratch.appendingPathComponent("checkouts/A"), name: "A",
-                dependencyURL: "https://example.com/B.git", dependencyPackage: "B", exactVersion: "2.0.0"
-            )
-
-            let resolved = ResolvedPins(
-                originHash: nil,
-                pins: [
-                    ResolvedPin(
-                        identity: "a", kind: "remoteSourceControl", location: "https://example.com/A.git",
-                        state: ResolvedState(branch: nil, revision: "a000", version: "1.0.0")
-                    ),
-                    ResolvedPin(
-                        identity: "b", kind: "remoteSourceControl", location: "https://example.com/B.git",
-                        state: ResolvedState(branch: nil, revision: "b000", version: "1.0.0")
-                    ),
-                ],
-                version: 3
-            )
-
-            await #expect(throws: ToolError.self) {
-                try await PackageResolver.validateResolvedGraphSatisfiesManifests(
-                    packageDir: root, scratchDir: scratch, resolved: resolved, disableSandbox: true
-                )
-            }
-        }
-    }
-
-    @Test
-    func validateResolvedGraphAcceptsAnInSyncTransitiveGraph() async throws {
-        // Guard against a false positive: the same graph with B pinned at the
-        // 2.0.0 that A requires must validate cleanly.
-        try await withTemporaryDirectory { root in
-            let scratch = root.appendingPathComponent(".build")
-            try await writeManifestWithExactDependency(
-                at: root, name: "Root",
-                dependencyURL: "https://example.com/A.git", dependencyPackage: "A", exactVersion: "1.0.0"
-            )
-            try await writeManifestWithExactDependency(
-                at: scratch.appendingPathComponent("checkouts/A"), name: "A",
-                dependencyURL: "https://example.com/B.git", dependencyPackage: "B", exactVersion: "2.0.0"
-            )
-
-            let resolved = ResolvedPins(
-                originHash: nil,
-                pins: [
-                    ResolvedPin(
-                        identity: "a", kind: "remoteSourceControl", location: "https://example.com/A.git",
-                        state: ResolvedState(branch: nil, revision: "a000", version: "1.0.0")
-                    ),
-                    ResolvedPin(
-                        identity: "b", kind: "remoteSourceControl", location: "https://example.com/B.git",
-                        state: ResolvedState(branch: nil, revision: "b000", version: "2.0.0")
-                    ),
-                ],
-                version: 3
-            )
-
-            try await PackageResolver.validateResolvedGraphSatisfiesManifests(
-                packageDir: root, scratchDir: scratch, resolved: resolved, disableSandbox: true
-            )
-        }
-    }
-
-    private func writeManifestWithExactDependency(
-        at packageDir: URL,
-        name: String,
-        dependencyURL: String,
-        dependencyPackage: String,
-        exactVersion: String
-    ) async throws {
-        try await fileSystem.makeDirectory(
-            at: packageDir.appendingPathComponent("Sources/\(name)").absolutePath,
-            options: [.createTargetParentDirectories]
-        )
-        try await fileSystem.atomicWrite(
-            """
-            // swift-tools-version: 6.0
-            import PackageDescription
-
-            let package = Package(
-                name: "\(name)",
-                products: [
-                    .library(name: "\(name)", targets: ["\(name)"]),
-                ],
-                dependencies: [
-                    .package(url: "\(dependencyURL)", exact: "\(exactVersion)"),
-                ],
-                targets: [
-                    .target(name: "\(name)", dependencies: [
-                        .product(name: "\(dependencyPackage)", package: "\(dependencyPackage)"),
-                    ]),
-                ]
-            )
-            """,
-            to: packageDir.appendingPathComponent("Package.swift")
-        )
-        try await fileSystem.atomicWrite(
-            "public struct \(name) {}\n",
-            to: packageDir.appendingPathComponent("Sources/\(name)/\(name).swift")
-        )
-    }
-
-    private func initGitDependency(at dependency: URL, tag: String) async throws {
+    private func initGitDependency(at dependency: URL, tags: [String]) async throws {
         try await SystemProcess.run("git", ["init"], workingDirectory: dependency)
         try await SystemProcess.run(
             "git", ["config", "user.name", "SwifterPM Tests"], workingDirectory: dependency)
@@ -314,7 +160,9 @@ struct ResolveTests {
         try await SystemProcess.run(
             "git", ["add", "Package.swift", "Sources"], workingDirectory: dependency)
         try await SystemProcess.run("git", ["commit", "-m", "Initial"], workingDirectory: dependency)
-        try await SystemProcess.run("git", ["tag", tag], workingDirectory: dependency)
+        for tag in tags {
+            try await SystemProcess.run("git", ["tag", tag], workingDirectory: dependency)
+        }
     }
 
     private func writeLibraryPackageManifest(at packageDir: URL, name: String) async throws {

--- a/swifterpm/Tests/swifterpmTests/ResolveTests.swift
+++ b/swifterpm/Tests/swifterpmTests/ResolveTests.swift
@@ -8,15 +8,7 @@ struct ResolveTests {
         try await withTemporaryDirectory { root in
             let dependency = root.appendingPathComponent("Dependency")
             try await writeLibraryPackageManifest(at: dependency, name: "Dependency")
-            try await SystemProcess.run("git", ["init"], workingDirectory: dependency)
-            try await SystemProcess.run(
-                "git", ["config", "user.name", "SwifterPM Tests"], workingDirectory: dependency)
-            try await SystemProcess.run(
-                "git", ["config", "user.email", "tests@example.com"], workingDirectory: dependency)
-            try await SystemProcess.run(
-                "git", ["add", "Package.swift", "Sources"], workingDirectory: dependency)
-            try await SystemProcess.run("git", ["commit", "-m", "Initial"], workingDirectory: dependency)
-            try await SystemProcess.run("git", ["tag", "1.0.0"], workingDirectory: dependency)
+            try await initGitDependency(at: dependency, tag: "1.0.0")
 
             let package = root.appendingPathComponent("App")
             try await writeAppPackageManifest(
@@ -102,6 +94,229 @@ struct ResolveTests {
         }
     }
 
+    @Test
+    func resolveOrLoadReadOnlyFailsWhenAPinNoLongerSatisfiesTheManifest() async throws {
+        // Pre-PR the readOnly branch read Package.resolved verbatim with no
+        // manifest check, so a manifest bumped past its lockfile (here an
+        // `exact:` raised from 1.0.0 to 2.0.0 without re-resolving) was restored
+        // to the stale 1.0.0 and reported success — where pure SwiftPM
+        // `swift package resolve --force-resolved-versions` errors out-of-date.
+        try await withTemporaryDirectory { root in
+            let dependency = root.appendingPathComponent("Dependency")
+            try await writeLibraryPackageManifest(at: dependency, name: "Dependency")
+            try await initGitDependency(at: dependency, tag: "1.0.0")
+
+            let package = root.appendingPathComponent("App")
+            try await writeAppPackageManifest(
+                at: package, dependencyURL: dependency.path, exactVersion: "1.0.0"
+            )
+
+            let cache = try await Cache(root: root.appendingPathComponent("cache"))
+            _ = try await PackageResolver.resolve(
+                packageDir: package,
+                scratchDir: root.appendingPathComponent("scratch"),
+                cache: cache,
+                registryConfig: RegistryConfig(),
+                disableSandbox: true,
+                writeResolvedFile: true
+            )
+
+            // Bump the manifest past the lockfile; clear the manifest dump cache
+            // so the readOnly validation re-reads the changed requirement rather
+            // than a same-second mtime-stale cache.
+            try await writeAppPackageManifest(
+                at: package, dependencyURL: dependency.path, exactVersion: "2.0.0"
+            )
+            try? await fileSystem.removePath(ManifestLoader.cacheFilePath(packageDir: package))
+
+            await #expect(throws: ToolError.self) {
+                try await PackageResolver.resolveOrLoad(
+                    packageDir: package,
+                    scratchDir: root.appendingPathComponent("scratch"),
+                    cache: cache,
+                    registryConfig: RegistryConfig(),
+                    disableSandbox: true,
+                    scmToRegistryTransformation: .disabled,
+                    preferResolvedFile: true,
+                    readOnly: true,
+                    skipUpdate: false,
+                    writeResolvedFile: false,
+                    progress: nil
+                )
+            }
+        }
+    }
+
+    @Test
+    func resolveOrLoadReadOnlyReturnsPinsWhenTheyStillSatisfyTheManifest() async throws {
+        // Guard against a false positive: an in-sync lockfile must still load in
+        // readOnly mode without re-resolving.
+        try await withTemporaryDirectory { root in
+            let dependency = root.appendingPathComponent("Dependency")
+            try await writeLibraryPackageManifest(at: dependency, name: "Dependency")
+            try await initGitDependency(at: dependency, tag: "1.0.0")
+
+            let package = root.appendingPathComponent("App")
+            try await writeAppPackageManifest(
+                at: package, dependencyURL: dependency.path, exactVersion: "1.0.0"
+            )
+
+            let cache = try await Cache(root: root.appendingPathComponent("cache"))
+            _ = try await PackageResolver.resolve(
+                packageDir: package,
+                scratchDir: root.appendingPathComponent("scratch"),
+                cache: cache,
+                registryConfig: RegistryConfig(),
+                disableSandbox: true,
+                writeResolvedFile: true
+            )
+
+            let resolved = try await PackageResolver.resolveOrLoad(
+                packageDir: package,
+                scratchDir: root.appendingPathComponent("scratch"),
+                cache: cache,
+                registryConfig: RegistryConfig(),
+                disableSandbox: true,
+                scmToRegistryTransformation: .disabled,
+                preferResolvedFile: true,
+                readOnly: true,
+                skipUpdate: false,
+                writeResolvedFile: false,
+                progress: nil
+            )
+
+            let pin = try #require(resolved.pins.first { $0.identity == "dependency" })
+            #expect(pin.state.version == "1.0.0")
+        }
+    }
+
+    @Test
+    func validateResolvedGraphFailsWhenATransitivePinViolatesAnIntermediateManifest() async throws {
+        // Closes the gap with SwiftPM's whole-graph precomputation: the root
+        // manifest is in sync (root -> A exact 1.0.0, pinned 1.0.0) but A's own
+        // manifest requires B exact 2.0.0 while Package.resolved pins B at 1.0.0.
+        // The direct-only check can't see this; the graph walk must.
+        try await withTemporaryDirectory { root in
+            let scratch = root.appendingPathComponent(".build")
+            try await writeManifestWithExactDependency(
+                at: root, name: "Root",
+                dependencyURL: "https://example.com/A.git", dependencyPackage: "A", exactVersion: "1.0.0"
+            )
+            try await writeManifestWithExactDependency(
+                at: scratch.appendingPathComponent("checkouts/A"), name: "A",
+                dependencyURL: "https://example.com/B.git", dependencyPackage: "B", exactVersion: "2.0.0"
+            )
+
+            let resolved = ResolvedPins(
+                originHash: nil,
+                pins: [
+                    ResolvedPin(
+                        identity: "a", kind: "remoteSourceControl", location: "https://example.com/A.git",
+                        state: ResolvedState(branch: nil, revision: "a000", version: "1.0.0")
+                    ),
+                    ResolvedPin(
+                        identity: "b", kind: "remoteSourceControl", location: "https://example.com/B.git",
+                        state: ResolvedState(branch: nil, revision: "b000", version: "1.0.0")
+                    ),
+                ],
+                version: 3
+            )
+
+            await #expect(throws: ToolError.self) {
+                try await PackageResolver.validateResolvedGraphSatisfiesManifests(
+                    packageDir: root, scratchDir: scratch, resolved: resolved, disableSandbox: true
+                )
+            }
+        }
+    }
+
+    @Test
+    func validateResolvedGraphAcceptsAnInSyncTransitiveGraph() async throws {
+        // Guard against a false positive: the same graph with B pinned at the
+        // 2.0.0 that A requires must validate cleanly.
+        try await withTemporaryDirectory { root in
+            let scratch = root.appendingPathComponent(".build")
+            try await writeManifestWithExactDependency(
+                at: root, name: "Root",
+                dependencyURL: "https://example.com/A.git", dependencyPackage: "A", exactVersion: "1.0.0"
+            )
+            try await writeManifestWithExactDependency(
+                at: scratch.appendingPathComponent("checkouts/A"), name: "A",
+                dependencyURL: "https://example.com/B.git", dependencyPackage: "B", exactVersion: "2.0.0"
+            )
+
+            let resolved = ResolvedPins(
+                originHash: nil,
+                pins: [
+                    ResolvedPin(
+                        identity: "a", kind: "remoteSourceControl", location: "https://example.com/A.git",
+                        state: ResolvedState(branch: nil, revision: "a000", version: "1.0.0")
+                    ),
+                    ResolvedPin(
+                        identity: "b", kind: "remoteSourceControl", location: "https://example.com/B.git",
+                        state: ResolvedState(branch: nil, revision: "b000", version: "2.0.0")
+                    ),
+                ],
+                version: 3
+            )
+
+            try await PackageResolver.validateResolvedGraphSatisfiesManifests(
+                packageDir: root, scratchDir: scratch, resolved: resolved, disableSandbox: true
+            )
+        }
+    }
+
+    private func writeManifestWithExactDependency(
+        at packageDir: URL,
+        name: String,
+        dependencyURL: String,
+        dependencyPackage: String,
+        exactVersion: String
+    ) async throws {
+        try await fileSystem.makeDirectory(
+            at: packageDir.appendingPathComponent("Sources/\(name)").absolutePath,
+            options: [.createTargetParentDirectories]
+        )
+        try await fileSystem.atomicWrite(
+            """
+            // swift-tools-version: 6.0
+            import PackageDescription
+
+            let package = Package(
+                name: "\(name)",
+                products: [
+                    .library(name: "\(name)", targets: ["\(name)"]),
+                ],
+                dependencies: [
+                    .package(url: "\(dependencyURL)", exact: "\(exactVersion)"),
+                ],
+                targets: [
+                    .target(name: "\(name)", dependencies: [
+                        .product(name: "\(dependencyPackage)", package: "\(dependencyPackage)"),
+                    ]),
+                ]
+            )
+            """,
+            to: packageDir.appendingPathComponent("Package.swift")
+        )
+        try await fileSystem.atomicWrite(
+            "public struct \(name) {}\n",
+            to: packageDir.appendingPathComponent("Sources/\(name)/\(name).swift")
+        )
+    }
+
+    private func initGitDependency(at dependency: URL, tag: String) async throws {
+        try await SystemProcess.run("git", ["init"], workingDirectory: dependency)
+        try await SystemProcess.run(
+            "git", ["config", "user.name", "SwifterPM Tests"], workingDirectory: dependency)
+        try await SystemProcess.run(
+            "git", ["config", "user.email", "tests@example.com"], workingDirectory: dependency)
+        try await SystemProcess.run(
+            "git", ["add", "Package.swift", "Sources"], workingDirectory: dependency)
+        try await SystemProcess.run("git", ["commit", "-m", "Initial"], workingDirectory: dependency)
+        try await SystemProcess.run("git", ["tag", tag], workingDirectory: dependency)
+    }
+
     private func writeLibraryPackageManifest(at packageDir: URL, name: String) async throws {
         try await fileSystem.makeDirectory(
             at: packageDir.appendingPathComponent("Sources/\(name)").absolutePath,
@@ -130,7 +345,11 @@ struct ResolveTests {
         )
     }
 
-    private func writeAppPackageManifest(at packageDir: URL, dependencyURL: String) async throws {
+    private func writeAppPackageManifest(
+        at packageDir: URL,
+        dependencyURL: String,
+        exactVersion: String = "1.0.0"
+    ) async throws {
         try await fileSystem.makeDirectory(
             at: packageDir.appendingPathComponent("Sources/App").absolutePath,
             options: [.createTargetParentDirectories]
@@ -146,7 +365,7 @@ struct ResolveTests {
                     .library(name: "App", targets: ["App"]),
                 ],
                 dependencies: [
-                    .package(url: "\(dependencyURL)", exact: "1.0.0"),
+                    .package(url: "\(dependencyURL)", exact: "\(exactVersion)"),
                 ],
                 targets: [
                     .target(name: "App", dependencies: [


### PR DESCRIPTION
> Describe here the purpose of your PR.

## What changed

SwifterPM's `--force-resolved-versions` (a.k.a. `--disable-automatic-resolution` / `--only-use-versions-from-resolved-file`) now fails when `Package.resolved` is out of date with `Package.swift`, instead of silently restoring the stale pins.

Two layers, both calling a shared satisfiability check:

- **`validateResolvedFileSatisfiesManifest`** — fast, fail-fast check of the root manifest's **direct** dependencies in `resolveOrLoad` (runs before the restore, needs no checkouts).
- **`validateResolvedGraphSatisfiesManifests`** — post-restore walk of the **whole pinned graph**, recursing into each pinned package's manifest (dumped from its materialized checkout / registry download) to validate **transitive** constraints. The error names the requiring package.

Wired into both resolution paths: `SwifterPM.runResolution` (used by tuist) and `CLIRunner.runResolutionCommand` (the standalone `swifterpm` binary).

## Why

A customer running a SwifterPM-enabled `build_and_ut` shadow CI job (alongside the default SwiftPM one) hit a silent failure: a direct dependency was declared `exact: "1.16.0-ALPHA"` in `Package.swift` while the committed `Package.resolved` still pinned `1.15.1-ALPHA`. With `--force-resolved-versions`, SwifterPM restored the stale `1.15.1-ALPHA` and exited 0, so the build compiled against the wrong version.

### Root cause

The `readOnly` branch of `PackageResolver.resolveOrLoad` read `Package.resolved` verbatim and returned it with **no validation against the manifest's requirements** — it failed open. Pure SwiftPM fails closed in the same situation:

```
error: an out-of-date resolved file was detected at .../Package.resolved,
which is not allowed when automatic dependency resolution is disabled
```

So this was a genuine SwiftPM-parity gap, and it also swallowed exactly the drift signal the flag is meant to surface.

### Why this solution

I verified against the SwiftPM source (`swiftlang/swift-package-manager`, `ResolverPrecomputationProvider`): SwiftPM runs the resolver with each package's *only* available version fixed to its pin (`LocalPackageContainer.versionsAscending` returns `[pinnedVersion]`), so the out-of-date error fires when a pin **cannot satisfy a constraint** — and notably **not** merely because a newer version exists within a still-satisfied range. This PR reproduces that satisfiability semantics rather than, say, an `originHash` comparison (which can't be shared across tools) or a `git diff` heuristic.

### Deliberate, documented divergences (to stay false-positive-free)

A wrong "out-of-date" error would break a working lockfile, so the check is conservative:

- Version constraints are strict (`VersionRange.contains`); branch/revision are checked leniently.
- Pins that can't be matched by identity (e.g. an SCM→registry identity remap) or carry an unparseable version are skipped.
- A pin that still satisfies a loose range is **not** flagged just because a newer version exists — matching SwiftPM. That class of drift still wants a `swift package resolve` + `git diff --exit-code Package.resolved` guard.
- Missing/superfluous packages are not flagged (SwiftPM does), again to avoid identity-remap false positives.

## User impact

CI using `--force-resolved-versions` now fails fast with an actionable message when `Package.swift` and `Package.resolved` drift, instead of silently building stale versions:

```
an out-of-date Package.resolved was detected at .../Package.resolved, which is not
allowed when --force-resolved-versions is set: 'swift-collections' is pinned to 1.0.0
but 'swift-async-algorithms' requires 1.0.4..<2.0.0. Update the resolved file
(e.g. run `tuist install` or `swift package resolve`) and commit it.
```

In-sync lockfiles are unaffected.

### How to test locally

End-to-end against a real graph (`swift-async-algorithms` → `swift-collections`):

1. Build the CLI: `swift build --replace-scm-with-registry --product swifterpm` in `swifterpm/`.
2. In a package whose `Package.swift` declares a versioned dependency, seed a lockfile: `swifterpm resolve --write --package-path <pkg>`.
3. Bump the dependency's `exact:`/range in `Package.swift` past the pin (or hand-edit `Package.resolved` to pin a transitive dep out of range), then run `swifterpm resolve --force-resolved-versions --package-path <pkg>` → exits 1 with the out-of-date error.
4. Restore the lockfile to a satisfying state → exits 0.

Automated: `swift test --replace-scm-with-registry --filter ResolveTests` (adds 4 regression tests: direct fail / direct in-sync / transitive fail / transitive in-sync).

🤖 Generated with [Claude Code](https://claude.com/claude-code)