### PR TITLE
docs: document defining Swift macros natively in Project.swift

### DIFF
--- a/server/priv/docs/en/guides/features/projects/dependencies.md
+++ b/server/priv/docs/en/guides/features/projects/dependencies.md
@@ -367,11 +367,6 @@ let project = Project(
 
 Any target that links `MyLibrary` can now use the macro — Tuist propagates the plugin so the compiler can load it.
 
-> [!NOTE]
-> **Why some docs point to `Package.swift`**
->
-> Defining macros through a `Package.swift` is one valid way to integrate them, but it's not the only one. The `.macro` product type lets you keep the macro definition inside your own targets, which is usually what you want when the macro lives in your monorepo alongside the code that uses it.
-
 
 ## Static or dynamic {#static-or-dynamic}
 

--- a/server/priv/docs/en/guides/features/projects/dependencies.md
+++ b/server/priv/docs/en/guides/features/projects/dependencies.md
@@ -50,6 +50,7 @@ When instantiating a `Target`, you can pass the `dependencies` argument with any
 - `XCFramework`: Declares a dependency with a binary XCFramework.
 - `SDK`: Declares a dependency with a system SDK.
 - `XCTest`: Declares a dependency with XCTest.
+- `Macro`: Declares a dependency with a Swift macro target defined in the same project (see [Swift Macros](#swift-macros)).
 
 > [!NOTE]
 > **Dependency Conditions**
@@ -216,7 +217,7 @@ let target = .target(name: "MyTarget", dependencies: [
 ])
 ```
 
-For Swift Macros and Build Tool Plugins, you'll need to use the types `.macro` and `.plugin` respectively.
+For Swift Macros and Build Tool Plugins that are **defined in an external Swift Package**, you'll need to use the types `.macro` and `.plugin` respectively. If you want to define a Swift macro of your own instead of consuming one from a package, see [Swift Macros](#swift-macros).
 
 > [!WARNING]
 > **SPM Build Tool Plugins**
@@ -297,6 +298,79 @@ pod install
 
 > [!WARNING]
 > CocoaPods dependencies are not compatible with workflows like `build` or `test` that run `xcodebuild` right after generating the project. They are also incompatible with binary caching and selective testing since the fingerprinting logic doesn't account for the Pods dependencies.
+
+
+## Swift Macros {#swift-macros}
+
+There are two distinct scenarios when working with [Swift Macros](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/macros/) in a Tuist project, and it's worth being explicit about which one you're in:
+
+- **Consuming a macro defined in an external Swift Package.** Use Xcode's default integration and declare the dependency with `.package(product:type: .macro)`, as described in [Xcode's default integration](#xcodes-default-integration).
+- **Defining your own macro** as part of your project — for example in a shared library within your monorepo. You don't need a `Package.swift` for this: Tuist has a first-class `.macro` product type, so you can declare the macro target directly in your manifests.
+
+### Defining your own macro {#defining-your-own-macro}
+
+A Swift macro is a compiler plugin: an executable that the Swift compiler loads and runs at compile time. Tuist models this natively with the `.macro` product type. Although Apple doesn't expose a Swift Macro target type in Xcode projects, Tuist enables it by generating a command-line tool target, wiring it as a dependency of the targets that use the macro, and injecting the `-load-plugin-executable` flag into their Swift compiler settings. All of that plumbing is handled for you.
+
+A typical macro is split into two targets: the **plugin** target that implements the macro (`product: .macro`), and the **library** target that declares the macro's public interface (`@attached`/`@freestanding` declarations) and depends on the plugin via `.macro(name:)`. Because the plugin runs on the build machine, its target is host-only (macOS).
+
+The macro implementation depends on [swift-syntax](https://github.com/swiftlang/swift-syntax), which you declare as a regular external dependency in `Tuist/Package.swift`:
+
+```swift [Tuist/Package.swift]
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "PackageName",
+    dependencies: [
+        .package(url: "https://github.com/swiftlang/swift-syntax", from: "600.0.0"),
+    ]
+)
+```
+
+You can then define the macro plugin and library targets directly in your project:
+
+```swift [Project.swift]
+import ProjectDescription
+
+let project = Project(
+    name: "MyLibrary",
+    targets: [
+        // The compiler plugin that implements the macro. macOS-only, since it
+        // runs on the build machine at compile time.
+        .target(
+            name: "MyMacrosImplementation",
+            destinations: [.mac],
+            product: .macro,
+            bundleId: "dev.tuist.MyMacrosImplementation",
+            sources: ["Sources/MyMacrosImplementation/**"],
+            dependencies: [
+                .external(name: "SwiftSyntax"),
+                .external(name: "SwiftSyntaxMacros"),
+                .external(name: "SwiftCompilerPlugin"),
+            ]
+        ),
+        // The library that exposes the macro declarations to consumers and
+        // depends on the plugin via `.macro(name:)`.
+        .target(
+            name: "MyLibrary",
+            destinations: .iOS,
+            product: .framework,
+            bundleId: "dev.tuist.MyLibrary",
+            sources: ["Sources/MyLibrary/**"],
+            dependencies: [
+                .macro(name: "MyMacrosImplementation"),
+            ]
+        ),
+    ]
+)
+```
+
+Any target that links `MyLibrary` can now use the macro — Tuist propagates the plugin so the compiler can load it.
+
+> [!NOTE]
+> **Why some docs point to `Package.swift`**
+>
+> Defining macros through a `Package.swift` is one valid way to integrate them, but it's not the only one. The `.macro` product type lets you keep the macro definition inside your own targets, which is usually what you want when the macro lives in your monorepo alongside the code that uses it.
 
 
 ## Static or dynamic {#static-or-dynamic}

--- a/server/priv/docs/en/guides/features/projects/dependencies.md
+++ b/server/priv/docs/en/guides/features/projects/dependencies.md
@@ -304,7 +304,7 @@ pod install
 
 There are two distinct scenarios when working with [Swift Macros](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/macros/) in a Tuist project, and it's worth being explicit about which one you're in:
 
-- **Consuming a macro defined in an external Swift Package.** Use Xcode's default integration and declare the dependency with `.package(product:type: .macro)`, as described in [Xcode's default integration](#xcodes-default-integration).
+- **Consuming a macro defined in an external Swift Package.** Both integration mechanisms support macros. With [Tuist's XcodeProj-based integration](#tuists-xcodeprojbased-integration), you declare the package in `Tuist/Package.swift` and depend on it with `.external(name:)` — Tuist maps the macro product into a native target. With [Xcode's default integration](#xcodes-default-integration), you declare the dependency with `.package(product:type: .macro)`. Unlike build tool plugins, macros are not restricted to Xcode's default integration.
 - **Defining your own macro** as part of your project — for example in a shared library within your monorepo. You don't need a `Package.swift` for this: Tuist has a first-class `.macro` product type, so you can declare the macro target directly in your manifests.
 
 ### Defining your own macro {#defining-your-own-macro}

--- a/server/priv/docs/en/guides/features/projects/dependencies.md
+++ b/server/priv/docs/en/guides/features/projects/dependencies.md
@@ -217,7 +217,7 @@ let target = .target(name: "MyTarget", dependencies: [
 ])
 ```
 
-For Swift Macros and Build Tool Plugins that are **defined in an external Swift Package**, you'll need to use the types `.macro` and `.plugin` respectively. If you want to define a Swift macro of your own instead of consuming one from a package, see [Swift Macros](#swift-macros).
+When integrating a Swift Macro or Build Tool Plugin from an external Swift Package through Xcode's default integration, declare it with the types `.macro` and `.plugin` respectively. Macros can also be consumed through [Tuist's XcodeProj-based integration](#tuists-xcodeprojbased-integration), and if you want to define a Swift macro of your own instead of consuming one from a package, see [Swift Macros](#swift-macros).
 
 > [!WARNING]
 > **SPM Build Tool Plugins**


### PR DESCRIPTION
## What

Adds a dedicated **Swift Macros** section to the Dependencies guide (`server/priv/docs/en/guides/features/projects/dependencies.md`) that documents how to **define your own Swift macro** natively in a `Project.swift` manifest using the `.macro` product type — no `Package.swift` required for the macro itself.

## Why

A community member (Brandon Levasseur) pointed out that essentially every piece of Tuist documentation tied to macros pushes people toward Swift Package (`Package.swift`) definitions, with no mention that you can define a macro directly in `Project.swift`. He'd been doing exactly that for a while and assumed it was unsupported "secret sauce."

It isn't — it's a first-class feature:

- `Product.macro` and `TargetDependency.macro(name:)` have existed since the native macro integration landed in tuist/tuist#5542 (Nov 2023), followed by hardening in #5641, #6109, #9962, #9995, #10116, #10566, #10576, and others.
- The docs only ever showed the **consuming-an-external-package** path (`.package(product:type: .macro)`), which conflated two distinct scenarios and led users to believe a `Package.swift` was mandatory to define a macro.

## What changed

- New `## Swift Macros` section that explicitly splits the two scenarios:
  - **Consuming** a macro from an external Swift Package → `.package(product:type: .macro)` (existing path, now cross-linked).
  - **Defining your own** macro → `product: .macro` plugin target + an interface target depending on it via `.macro(name:)`, with a full `Project.swift` example.
- Explains how Tuist implements macros under the hood (generates a command-line tool target, wires it as a dependency, injects `-load-plugin-executable` into the consumer's Swift compiler flags) and notes the plugin target is host-only (macOS).
- Adds a `> [!NOTE]` addressing *why* older docs pointed at `Package.swift`.
- Adds `Macro` to the local-dependencies list so `.macro(name:)` is discoverable.
- Clarifies the existing `.package(product:type: .macro)` line to specify it applies to **externally-defined** macros, and links to the new section.

## Notes for reviewers

- In-page links use plain `[text](#anchor)` to match the file's existing convention; both anchors (`#swift-macros`, `#xcodes-default-integration`) resolve to real headings.
- The example pins swift-syntax at `from: "600.0.0"` — adjust if there's a preferred version to standardize on in docs.
- swift-syntax is still declared in `Tuist/Package.swift` in the example, but only as a genuine *external dependency* of the plugin — the macro definition itself stays in `Project.swift`. This is called out to avoid re-triggering the "why Package.swift again?" reaction.

## Validation

Docs-only change. Anchors verified to resolve against existing headings; no other content touched.

## Follow-up (not in this PR)

There's a long-stale WIP fixture at tuist/tuist#7215 ("Add Fixture app using a Tuist defined Macro"). Wiring that into the acceptance suite would let CI exercise the documented workflow and guarantee the docs stay correct over time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)