### PR TITLE
fix(infra): rebind running VMs after a kubelet restart instead of looping on "already running"

### DIFF
--- a/infra/tart-kubelet/cmd/tart-kubelet/main.go
+++ b/infra/tart-kubelet/cmd/tart-kubelet/main.go
@@ -609,17 +609,26 @@ func recoverState(
 	if err != nil {
 		return err
 	}
-	// Probe each local VM with `tart ip` — that's the only reliable
-	// liveness signal under Tart 2.32 (the on-disk State field stays
-	// "stopped" for backgrounded VMs even when they're running).
-	// Stopped clones (left over from a previous kubelet kill) get
-	// skipped here; createPod will pick them up and start them.
+	// A VM is live if its `tart run` process is still executing. The VM is
+	// Setsid-detached so it survives a kubelet restart, and pgrep is the
+	// canonical liveness signal (see tart.Client.IsRunning) — fast, and
+	// false the instant the VM exits.
+	//
+	// This used to probe each local VM with `tart ip`, which blocks up to
+	// 30s waiting for an IP that a stopped VM never gets. The golden-base
+	// feature then added stopped golden VMs to `tart list`, so a single
+	// golden could burn the whole 30s recovery budget before the
+	// actually-running workload VM was reached — leaving it unbound.
+	// createPod would `tart run` it again, hit "VM is already running",
+	// and loop forever (this wedged the xcresult-processor and blocked a
+	// prod deploy). IsRunning returns false instantly for stopped goldens
+	// and stopped clones, which createPod re-runs as before.
 	live := make(map[string]bool, len(vms))
 	for _, vm := range vms {
 		if vm.Source != "local" {
 			continue
 		}
-		if ip, ipErr := tartClient.IP(ctx, vm.Name); ipErr == nil && ip != "" {
+		if running, rErr := tartClient.IsRunning(ctx, vm.Name); rErr == nil && running {
 			live[vm.Name] = true
 		}
 	}

--- a/infra/tart-kubelet/internal/podagent/reconciler.go
+++ b/infra/tart-kubelet/internal/podagent/reconciler.go
@@ -328,10 +328,11 @@ func (r *Reconciler) createPod(ctx context.Context, pod *corev1.Pod) error {
 		}
 	}
 
-	// Reuse an existing local clone if one is on disk: a kubelet
-	// restart kills the running VM (launchctl bootout signals the
-	// process group) but the cloned image stays. Re-running it skips
-	// the clone cycle entirely.
+	// Reuse an existing local clone if one is on disk. A kubelet restart
+	// leaves the cloned image behind — and because `tart run` is
+	// Setsid-detached, usually the running VM itself — so we skip the
+	// clone cycle and either adopt the running VM (below) or re-run a
+	// stopped clone.
 	existingClone, _ := r.Tart.Get(ctx, vmName)
 
 	if existingClone == nil {
@@ -366,6 +367,23 @@ func (r *Reconciler) createPod(ctx context.Context, pod *corev1.Pod) error {
 		// warm clonefile from a cold re-pull so a slow provision can be
 		// attributed to one or the other instead of guessed at.
 		RecordVMProvisionWork(pool, provisionPath, time.Since(cloneStart))
+	}
+
+	// If the clone is already running — it survived a kubelet restart and
+	// recoverState didn't rebind it — adopt it instead of starting it
+	// again. A duplicate `tart run` exits immediately with "VM is already
+	// running", which loops here and strands the Pod (the failure mode
+	// that wedged the xcresult-processor and blocked a prod deploy).
+	// Register a Store entry with no RunHandle; podStatus then tracks
+	// liveness via IsRunning, exactly like recoverState's recovered
+	// entries. BootObserved is set because we didn't witness this boot.
+	if running, _ := r.Tart.IsRunning(ctx, vmName); running {
+		r.Store.Put(pod.Namespace, pod.Name, &Entry{
+			VMName:       vmName,
+			StartTS:      metav1.Now(),
+			BootObserved: true,
+		})
+		return nil
 	}
 
 	// Resize the cloned VM to match the Pod's resource requests.


### PR DESCRIPTION
## What this fixes

A tart-kubelet restart could strand long-lived VM workloads — concretely the **xcresult-processor**, which wedged at `0/2` and blocked a production deploy (`helm --wait` on an `--atomic` release, which then risks rolling the whole `tuist` release back).

The VM survives a kubelet restart on purpose (`tart run` is `Setsid`-detached). But the restarted kubelet failed to rebind it, so `createPod` called `tart run` on the already-running VM, got `VM is already running` (exit status 2), and looped every ~30s. The Pod never reported Ready:

```
error: tart run …xcresult-processor…: exited immediately: exit status 2
/var/log/tart-vms/…: VM "…xcresult-processor…" is already running!
```

## Root cause

Two issues, both fixed:

1. **`recoverState` burned its budget probing stopped goldens.** It probed *every* local VM with `tart ip` (which blocks up to 30s waiting for an IP a stopped VM never gets) under a single shared 30s context. The golden-base feature added stopped golden VMs to `tart list`, so one golden could exhaust the whole 30s before the actually-running workload VM was reached — leaving it unbound. So the golden-base work regressed restart recovery. Switched to `IsRunning` (a fast `pgrep` — the same canonical liveness signal `podStatus` already uses): instant, and false for stopped goldens/clones (which `createPod` still re-runs as before).

2. **`createPod` re-ran an already-running clone.** As defense-in-depth, it now adopts a running clone — registers a `Store` entry with no `RunHandle`, exactly like a `recoverState`-recovered entry (`podStatus` tracks liveness via `IsRunning`) — instead of `tart run`-ing it. A missed recovery now self-heals on the next reconcile rather than looping forever.

## Why it surfaced now

Not caused by the runner OCI/Size fixes — it's a pre-existing restart-recovery gap. But those PRs' back-to-back operator rolls restarted tart-kubelet on the macOS fleet several times, and each restart re-orphaned the xcresult-processor VM, finally wedging a deploy.

## Impact

tart-kubelet restarts (every operator roll) become non-disruptive to long-lived VM workloads: the running VM is rebound at startup and the Pod stays Ready, so deploys stop hanging on the xcresult-processor.

## Validation

- `go build`, `go vet`, `gofmt`, full module test suite pass.
- No unit-test seam: both paths use the concrete `tart.Client` and `pgrep`/`tart` shell-outs (consistent with the existing untested `recoverState`/`createPod` shell paths). Plan to verify on a host post-deploy: restart tart-kubelet with a running VM present and confirm `recovered VM state … matched_pods≥1` and no `already running` loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
