### PR TITLE
fix(cli): prefer netrc over the ambient GitHub token for private artifact downloads

### DIFF
--- a/swifterpm/Sources/swifterpm/Support.swift
+++ b/swifterpm/Sources/swifterpm/Support.swift
@@ -213,14 +213,51 @@ enum HTTPClient {
 enum HTTPAuthorization {
     static func header(for url: URL) async -> String? {
         let environment = ProcessInfo.processInfo.environment
-        if isGitHub(url), let token = nonEmpty(environment["GITHUB_TOKEN"] ?? environment["GH_TOKEN"]) {
+
+        // Explicit, host-scoped credentials win over an ambient GitHub token. A
+        // `machine api.github.com` entry in ~/.netrc (or SWIFTPM_NETRC_DATA) is a
+        // deliberate per-host credential, so it must beat a generic GITHUB_TOKEN /
+        // GH_TOKEN that may be scoped to an unrelated repository — otherwise a
+        // repo-scoped CI token shadows the netrc credential that can actually read
+        // a private release asset. This mirrors SwiftPM, whose download
+        // AuthorizationProvider resolves netrc and never consults GITHUB_TOKEN.
+        if let header = prioritizedHeader(
+            isGitHub: isGitHub(url),
+            netrcCredential: await netrcCredential(for: url, environment: environment),
+            gitHubEnvToken: environment["GITHUB_TOKEN"] ?? environment["GH_TOKEN"]
+        ) {
+            return header
+        }
+
+        if isGitHub(url), let token = await GitHubAuth.token() {
             return bearerHeader(token)
         }
 
+        return nil
+    }
+
+    static func prioritizedHeader(
+        isGitHub: Bool,
+        netrcCredential: RegistryCredential?,
+        gitHubEnvToken: String?
+    ) -> String? {
+        if let credential = netrcCredential {
+            return basicHeader(credential)
+        }
+        if isGitHub, let token = nonEmpty(gitHubEnvToken) {
+            return bearerHeader(token)
+        }
+        return nil
+    }
+
+    private static func netrcCredential(
+        for url: URL,
+        environment: [String: String]
+    ) async -> RegistryCredential? {
         if let netrcData = nonEmpty(environment["SWIFTPM_NETRC_DATA"]),
            let credential = RegistryNetrc(content: netrcData).credential(for: url)
         {
-            return basicHeader(credential)
+            return credential
         }
 
         if let home = environment["HOME"] {
@@ -229,12 +266,8 @@ enum HTTPAuthorization {
                let content = String(data: data, encoding: .utf8),
                let credential = RegistryNetrc(content: content).credential(for: url)
             {
-                return basicHeader(credential)
+                return credential
             }
-        }
-
-        if isGitHub(url), let token = await GitHubAuth.token() {
-            return bearerHeader(token)
         }
 
         return nil

--- a/swifterpm/Tests/swifterpmTests/SupportTests.swift
+++ b/swifterpm/Tests/swifterpmTests/SupportTests.swift
@@ -57,26 +57,33 @@ struct SupportTests {
             try await fileSystem.makeDirectory(at: source.absolutePath, options: [.createTargetParentDirectories])
             try await fileSystem.makeDirectory(at: nested.absolutePath, options: [.createTargetParentDirectories])
             try await fileSystem.atomicWrite(
-                "value", to: source.appendingPathComponent("file.txt"))
+                "value", to: source.appendingPathComponent("file.txt")
+            )
             try await fileSystem.atomicWrite(
-                "nested", to: nested.appendingPathComponent("nested.txt"))
+                "nested", to: nested.appendingPathComponent("nested.txt")
+            )
 
             try await fileSystem.flattenSingleDirectory(root.appendingPathComponent("outer"))
             #expect(
-                try await fileSystem.exists(root.appendingPathComponent("outer/nested.txt").absolutePath))
+                try await fileSystem.exists(root.appendingPathComponent("outer/nested.txt").absolutePath)
+            )
 
             let destination = root.appendingPathComponent("destination")
             try await fileSystem.replaceWithSymlinkedDirectory(
-                source: source, destination: destination)
+                source: source, destination: destination
+            )
             #expect(try await fileSystem.exists(destination.absolutePath))
             #expect(!(fileSystem.isDirectoryAndNotSymlink(destination)))
             #expect(
-                try await fileSystem.exists(destination.appendingPathComponent("file.txt").absolutePath))
+                try await fileSystem.exists(destination.appendingPathComponent("file.txt").absolutePath)
+            )
             let data = try await fileSystem.readFile(at: destination.appendingPathComponent("file.txt").absolutePath)
             #expect(String(data: data, encoding: .utf8) == "value")
             #expect(
                 !(fileSystem.isDirectoryAndNotSymlink(
-                    destination.appendingPathComponent("file.txt"))))
+                    destination.appendingPathComponent("file.txt")
+                ))
+            )
         }
     }
 
@@ -89,14 +96,17 @@ struct SupportTests {
                 let destination = root.appendingPathComponent("destination")
                 try await fileSystem.makeDirectory(at: nested.absolutePath, options: [.createTargetParentDirectories])
                 try await fileSystem.atomicWrite(
-                    "value", to: nested.appendingPathComponent("file.txt"))
+                    "value", to: nested.appendingPathComponent("file.txt")
+                )
 
                 try await fileSystem.replaceWithCachedDirectory(
-                    source: source, destination: destination)
+                    source: source, destination: destination
+                )
 
                 #expect(fileSystem.isDirectoryAndNotSymlink(destination))
                 #expect(
-                    try await fileSystem.exists(destination.appendingPathComponent("nested/file.txt").absolutePath))
+                    try await fileSystem.exists(destination.appendingPathComponent("nested/file.txt").absolutePath)
+                )
                 let data = try await fileSystem.readFile(at: destination.appendingPathComponent("nested/file.txt").absolutePath)
                 #expect(String(data: data, encoding: .utf8) == "value")
             }
@@ -112,14 +122,17 @@ struct SupportTests {
                 let destination = root.appendingPathComponent("destination")
                 try await fileSystem.makeDirectory(at: nested.absolutePath, options: [.createTargetParentDirectories])
                 try await fileSystem.atomicWrite(
-                    "value", to: nested.appendingPathComponent("file.txt"))
+                    "value", to: nested.appendingPathComponent("file.txt")
+                )
 
                 try await fileSystem.replaceWithCachedDirectory(
-                    source: source, destination: destination)
+                    source: source, destination: destination
+                )
 
                 #expect(!(fileSystem.isDirectoryAndNotSymlink(destination)))
                 #expect(
-                    try await fileSystem.exists(destination.appendingPathComponent("nested/file.txt").absolutePath))
+                    try await fileSystem.exists(destination.appendingPathComponent("nested/file.txt").absolutePath)
+                )
                 let data = try await fileSystem.readFile(at: destination.appendingPathComponent("nested/file.txt").absolutePath)
                 #expect(String(data: data, encoding: .utf8) == "value")
             }
@@ -138,14 +151,17 @@ struct SupportTests {
                     let destination = root.appendingPathComponent("destination")
                     try await fileSystem.makeDirectory(at: nested.absolutePath, options: [.createTargetParentDirectories])
                     try await fileSystem.atomicWrite(
-                        "value", to: nested.appendingPathComponent("file.txt"))
+                        "value", to: nested.appendingPathComponent("file.txt")
+                    )
 
                     try await fileSystem.replaceWithCachedDirectory(
-                        source: source, destination: destination)
+                        source: source, destination: destination
+                    )
 
                     #expect(!(fileSystem.isDirectoryAndNotSymlink(destination)))
                     #expect(
-                        try await fileSystem.exists(destination.appendingPathComponent("nested/file.txt").absolutePath))
+                        try await fileSystem.exists(destination.appendingPathComponent("nested/file.txt").absolutePath)
+                    )
                 }
             }
         }
@@ -159,20 +175,23 @@ struct SupportTests {
                 let destination = root.appendingPathComponent("destination")
                 try await fileSystem.makeDirectory(at: source.absolutePath, options: [.createTargetParentDirectories])
                 try await fileSystem.atomicWrite(
-                    "value", to: source.appendingPathComponent("file.txt"))
+                    "value", to: source.appendingPathComponent("file.txt")
+                )
 
                 try await fileSystem.replaceWithCachedDirectory(
-                    source: source, destination: destination)
+                    source: source, destination: destination
+                )
 
                 #expect(fileSystem.isDirectoryAndNotSymlink(destination))
                 #expect(
-                    try await fileSystem.exists(destination.appendingPathComponent("file.txt").absolutePath))
+                    try await fileSystem.exists(destination.appendingPathComponent("file.txt").absolutePath)
+                )
             }
         }
     }
 
     @Test
-    func ciDetectionMatchesAubeEnvironmentLogic() async throws {
+    func ciDetectionMatchesAubeEnvironmentLogic() {
         Environment.$values.withValue([:]) {
             #expect(!Environment.isCI)
         }
@@ -196,5 +215,40 @@ struct SupportTests {
             #expect(try await fileSystem.exists(temp.absolutePath))
             #expect(SafeFileName.make("a/b:c") == "a_b_c")
         }
+    }
+
+    @Test
+    func netrcCredentialBeatsGitHubEnvToken() {
+        let credential = RegistryCredential(user: "x-access-token", password: "harbor-token")
+        let header = HTTPAuthorization.prioritizedHeader(
+            isGitHub: true,
+            netrcCredential: credential,
+            gitHubEnvToken: "ghs_repo_scoped_token"
+        )
+
+        let expected = "Basic " + Data("x-access-token:harbor-token".utf8).base64EncodedString()
+        #expect(header == expected)
+    }
+
+    @Test
+    func gitHubEnvTokenUsedWhenNoNetrcCredential() {
+        let header = HTTPAuthorization.prioritizedHeader(
+            isGitHub: true,
+            netrcCredential: nil,
+            gitHubEnvToken: "ghs_repo_scoped_token"
+        )
+
+        #expect(header == "Bearer ghs_repo_scoped_token")
+    }
+
+    @Test
+    func gitHubEnvTokenIgnoredForNonGitHubHostWithoutNetrc() {
+        #expect(
+            HTTPAuthorization.prioritizedHeader(
+                isGitHub: false,
+                netrcCredential: nil,
+                gitHubEnvToken: "ghs_repo_scoped_token"
+            ) == nil
+        )
     }
 }


### PR DESCRIPTION
## What changed

swifterpm's authenticated HTTP download path (`HTTPAuthorization.header`, used for binary target xcframeworks and GitHub release assets) now resolves an explicit `~/.netrc` / `SWIFTPM_NETRC_DATA` credential **before** falling back to an ambient `GITHUB_TOKEN`/`GH_TOKEN` from the environment. Previously the env token was checked first.

## Why

In GitHub Actions the default `GITHUB_TOKEN` is present in the job environment and is scoped only to the repository running the workflow. A private `binaryTarget` hosted in a *different* private repo therefore could not be downloaded under swifterpm:

1. swifterpm saw `GITHUB_TOKEN` and sent it as `Authorization: Bearer ...`.
2. The token has no access to the other private repo, so GitHub returned **404** (it returns 404, not 403, to avoid revealing that a private repo exists).
3. The `~/.netrc` entry that *could* read the asset was never consulted.

This diverged from SwiftPM, whose download `AuthorizationProvider` resolves credentials from netrc (and the keychain) and **never looks at `GITHUB_TOKEN`**. So a plain `tuist install` (SwiftPM) succeeded against the same `Package.swift` while a swifterpm install failed on the binary asset with:

```
HTTP 404 for https://api.github.com/repos/<org>/<repo>/releases/assets/<id>.zip
```

The repo had configured exactly the netrc SwiftPM expects:

```
machine api.github.com login x-access-token password <github-app-installation-token>
```

with an app token scoped to include the private binary repo — but swifterpm bypassed it in favor of the repo-scoped `GITHUB_TOKEN`.

## The fix

`HTTPAuthorization.header` now orders credential resolution as:

1. `SWIFTPM_NETRC_DATA` (explicit, host-scoped)
2. `~/.netrc` (explicit, host-scoped)
3. `GITHUB_TOKEN` / `GH_TOKEN` (ambient GitHub fallback)
4. `gh auth token` (ambient GitHub fallback)

A `machine api.github.com` entry is a deliberate per-host credential, so it should beat a generic environment token that may be scoped to an unrelated repository — matching SwiftPM. The zero-config case (a usable token in the env and no netrc) is unchanged. The precedence decision is extracted into a pure `prioritizedHeader` so it is unit-tested without mutating the process environment.

## Validation

- `swift build` + `swift test` on `main`: clean. Three new `SupportTests` cover netrc-beats-env-token, env-token-used-when-no-netrc, and the non-GitHub-host no-op.
- Confirmed against the real failing CI environment: `echo "GH_TOKEN=${GH_TOKEN:+set} GITHUB_TOKEN=${GITHUB_TOKEN:+set}"` printed `GH_TOKEN= GITHUB_TOKEN=set`, and re-running the install as `env -u GH_TOKEN -u GITHUB_TOKEN tuist install` (which forces the netrc path the same way this change does) resolved and fetched successfully.

## Scope / follow-up

- Source (git) dependency auth is unaffected; this only touches HTTP artifact/tarball downloads.
- A follow-up can extend this same path to consult the macOS keychain (swifterpm's registry path already does), for full parity with SwiftPM's `AuthorizationProvider`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)