### PR TITLE
fix(infra): macos-fleet resilience — recover Unknown nodes + unwedge xcresult processors (tailscale/NAT)

### DIFF
--- a/infra/macos-host-bootstrap/bootstrap.go
+++ b/infra/macos-host-bootstrap/bootstrap.go
@@ -1355,7 +1355,7 @@ sudo tee /usr/local/bin/tuist-pf-vmnat >/dev/null <<'VMNAT'
 #!/bin/sh
 # Loads the VM->cache NAT rules into the com.apple/tuist.vmnat pf
 # sub-anchor (see installVMEgressFirewall in macos-host-bootstrap).
-# Two legs, each skipped when unconfigured or its route is absent:
+# Three legs, each skipped when unconfigured or its route is absent:
 #   - tailnet: VM -> cluster Service CIDR via the tailscale utun.
 #     MSS-clamped: the utun MTU (1280) is smaller than the VM's
 #     vmnet MTU (1500) and pf-NAT'd flows don't reliably deliver
@@ -1365,10 +1365,20 @@ sudo tee /usr/local/bin/tuist-pf-vmnat >/dev/null <<'VMNAT'
 #   - Private Network: VM -> PN subnet via the macOS VLAN
 #     interface (installVMCachePNInterface). No clamp: the VLAN
 #     runs at the same 1500 MTU as vmnet.
-# vmnet's built-in NAT only translates toward the default-route
-# interface, so both legs need explicit pf NAT. Idempotent and
-# cheap; re-run on an interval so a tailscaled restart (utun
-# renumber) or VLAN recreation re-converges within a minute.
+#   - General internet: VM -> public internet via the default-route
+#     NIC. vmnet/InternetSharing is *supposed* to own this leg, but on
+#     2026-06-26 its en0 NAT silently stopped translating after heavy
+#     VM churn — VMs egressed with their 192.168.64.x source, the
+#     upstream gateway dropped it, in-VM tailscaled never reached the
+#     control plane (SYN_SENT forever), and the release never booted
+#     while the pod still showed Ready. We now assert this leg here
+#     too, in this proven-enforced anchor, so it survives a churn that
+#     clobbers InternetSharing's separate anchor.
+# vmnet's built-in NAT only reliably translates toward the
+# default-route interface when freshly set up, so all three legs get
+# explicit pf NAT here. Idempotent and cheap; re-run on an interval so
+# a tailscaled restart (utun renumber), VLAN recreation, or a
+# clobbered default-route NAT re-converges within a minute.
 CIDR="%s"
 PNCIDR="%s"
 RULES=""
@@ -1408,10 +1418,29 @@ if [ -n "$PNCIDR" ]; then
     RULES="${RULES}nat on $PNIF from 192.168.64.0/22 to $PNCIDR -> ($PNIF)${NL}"
   fi
 fi
+# General internet leg (see header): NAT VM egress on the default
+# route so a VM that lost vmnet's en0 translation still reaches the
+# control plane. "to any" on the default NIC only catches
+# internet-bound egress — tailnet/PN traffic leaves via utun/vlan and
+# is translated by the interface-scoped legs above (pf nat is
+# first-match and interface-scoped, so this never shadows them).
+DEFIF=$(route -n get default 2>/dev/null | awk '/interface/{print $2}')
+if [ -n "$DEFIF" ]; then
+  RULES="${RULES}nat on $DEFIF from 192.168.64.0/22 to any -> ($DEFIF)${NL}"
+fi
 [ -z "$RULES" ] && exit 0
 # pf requires normalization (scrub) before translation (nat) within
 # a ruleset load; the legs above append in that order.
-printf '%%s' "$RULES" | cmp -s - /usr/local/etc/tuist-vmnat.loaded 2>/dev/null && exit 0
+#
+# Short-circuit only when the desired ruleset is unchanged AND the
+# anchor still holds rules. Comparing against the snapshot alone would
+# never re-converge after an external flush (precisely the failure
+# this leg hardens against) — the snapshot would still match while the
+# live anchor sat empty.
+if printf '%%s' "$RULES" | cmp -s - /usr/local/etc/tuist-vmnat.loaded 2>/dev/null \
+   && pfctl -a "com.apple/tuist.vmnat" -s nat 2>/dev/null | grep -q nat; then
+  exit 0
+fi
 printf '%%s' "$RULES" | pfctl -a "com.apple/tuist.vmnat" -f -
 mkdir -p /usr/local/etc
 printf '%%s' "$RULES" > /usr/local/etc/tuist-vmnat.loaded

--- a/infra/macos-host-bootstrap/bootstrap_test.go
+++ b/infra/macos-host-bootstrap/bootstrap_test.go
@@ -241,3 +241,27 @@ func TestHostKeyState_DetectsMidBootstrapKeyRotation(t *testing.T) {
 		t.Fatalf("mid-bootstrap key rotation should error")
 	}
 }
+
+func TestRenderVMNATScript_AssertsDefaultRouteNATLeg(t *testing.T) {
+	out := renderVMNATScript(Config{
+		VMKuraEgressCIDR: "10.96.0.0/12",
+		VMCachePNCIDR:    "172.16.0.0/22",
+	})
+	// The general-internet leg must NAT VM egress on the default-route
+	// NIC from this anchor, not rely on vmnet/InternetSharing — the
+	// 2026-06-26 outage was VMs egressing un-NAT'd (private
+	// 192.168.64.x source) after InternetSharing's separate en0 NAT
+	// anchor was clobbered, so tailscaled could never reach control.
+	if !strings.Contains(out, "route -n get default") {
+		t.Fatalf("expected default-route interface discovery\n%s", out)
+	}
+	if !strings.Contains(out, "nat on $DEFIF from 192.168.64.0/22 to any -> ($DEFIF)") {
+		t.Fatalf("expected general-internet NAT leg on the default route\n%s", out)
+	}
+	// The idempotency short-circuit must re-converge after an external
+	// anchor flush: skipping the reload purely on a snapshot match would
+	// leave a flushed anchor empty forever (the snapshot still matches).
+	if !strings.Contains(out, `pfctl -a "com.apple/tuist.vmnat" -s nat`) {
+		t.Fatalf("expected short-circuit to verify the live anchor still holds rules\n%s", out)
+	}
+}

--- a/infra/tart-kubelet/internal/nodeagent/node.go
+++ b/infra/tart-kubelet/internal/nodeagent/node.go
@@ -161,9 +161,24 @@ func (m *Maintainer) refresh(ctx context.Context) error {
 	// then update status.
 	base := node.DeepCopy()
 	m.configureNode(node, m.evalDynamicLabels(ctx))
+
+	// configureNode just set this Node's desired status (Ready=True,
+	// capacity, node info). client.Patch below replaces the in-memory node
+	// — status included — with the API server's response, which carries
+	// whatever status the node holds on the server right now. If the
+	// node-lifecycle controller has flipped Ready to Unknown (it does that
+	// on any heartbeat gap, e.g. during a kubelet restart), the Patch
+	// clobbers our Ready=True back to Unknown, and the Status().Update below
+	// then re-posts that Unknown with only a fresh LastHeartbeatTime — so
+	// the Node is stranded in Unknown forever and the heartbeat can never
+	// lift it back to Ready. Snapshot the desired status before the Patch
+	// and restore it afterward so the status update actually asserts
+	// Ready=True.
+	desiredStatus := node.Status.DeepCopy()
 	if err := m.Client.Patch(ctx, node, client.MergeFrom(base)); err != nil {
 		return err
 	}
+	node.Status = *desiredStatus
 
 	m.applyDiskPressure(ctx, node)
 	for i, c := range node.Status.Conditions {

--- a/infra/tart-kubelet/internal/nodeagent/node_test.go
+++ b/infra/tart-kubelet/internal/nodeagent/node_test.go
@@ -117,6 +117,44 @@ func TestRefreshPersistsDynamicLabels(t *testing.T) {
 	}
 }
 
+// Regression for nodes stranded in Unknown: once the node-lifecycle
+// controller flips Ready to Unknown (after a heartbeat gap, e.g. a kubelet
+// restart), a heartbeat must lift the node back to Ready=True. The bug:
+// client.Patch overwrote the in-memory node.Status (our freshly-set
+// Ready=True) with the server's Unknown before Status().Update, so the
+// heartbeat only re-posted Unknown and the node never recovered.
+func TestRefreshLiftsNodeOutOfUnknown(t *testing.T) {
+	existing := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "mac-1"},
+		Status: corev1.NodeStatus{
+			Conditions: []corev1.NodeCondition{{
+				Type:    corev1.NodeReady,
+				Status:  corev1.ConditionUnknown,
+				Reason:  "NodeStatusUnknown",
+				Message: "Kubelet stopped posting node status.",
+			}},
+		},
+	}
+	c := newNodeFakeClient(existing)
+	m := &Maintainer{Client: c, NodeName: "mac-1", Heartbeat: time.Second}
+
+	if err := m.refresh(context.Background()); err != nil {
+		t.Fatalf("refresh: %v", err)
+	}
+
+	persisted := &corev1.Node{}
+	if err := c.Get(context.Background(), types.NamespacedName{Name: "mac-1"}, persisted); err != nil {
+		t.Fatalf("get node: %v", err)
+	}
+	cond, ok := conditionByType(persisted.Status.Conditions, corev1.NodeReady)
+	if !ok {
+		t.Fatal("Ready condition missing after refresh")
+	}
+	if cond.Status != corev1.ConditionTrue {
+		t.Fatalf("Ready = %q after refresh, want True — a heartbeat must recover a node the controller marked Unknown", cond.Status)
+	}
+}
+
 func conditionByType(conds []corev1.NodeCondition, t corev1.NodeConditionType) (corev1.NodeCondition, bool) {
 	for _, c := range conds {
 		if c.Type == t {

--- a/infra/xcresult-processor-image/tailscale-up.sh
+++ b/infra/xcresult-processor-image/tailscale-up.sh
@@ -49,13 +49,25 @@ else
   if [ -n "${TAILSCALE_HOSTNAME:-}" ]; then
     HOSTNAME_FLAG="--hostname=${TAILSCALE_HOSTNAME}"
   fi
+  # --timeout is load-bearing: without it `tailscale up` blocks
+  # indefinitely when tailscaled can't reach the control plane (e.g.
+  # the 2026-06-26 incident, where a clobbered host VM-NAT left the
+  # VM unable to complete a TCP handshake to control — SYN_SENT
+  # forever). A hung `up` wedges this whole launchd chain before
+  # `exec tuist start`, so the release never boots, yet the pod still
+  # shows Running/Ready (tart-kubelet has no container probe). Bound
+  # it instead: on timeout `up` exits non-zero, we exit 1, and
+  # launchd's KeepAlive restarts the chain — so once NAT/control
+  # recovers a retry succeeds and the BEAM comes up on its own,
+  # rather than stranding the VM until a manual recycle.
   if ! ${TAILSCALE} up \
+      --timeout=60s \
       --authkey="${TAILSCALE_AUTH_KEY}" \
       --reset \
       --ssh=true \
       --accept-dns=true \
       ${HOSTNAME_FLAG}; then
-    echo "tailscale-up: tailscale up failed" >&2
+    echo "tailscale-up: tailscale up did not reach Running within timeout (control unreachable?); exiting so launchd retries" >&2
     exit 1
   fi
   TAILNET_IP=""


### PR DESCRIPTION
Three resilience fixes for the macos-fleet (tart-kubelet + Tart VMs), all surfaced by the 2026-06-26 incident where the xcresult processors silently stopped consuming for hours and a kubelet-restart storm stranded ~9 nodes in `Ready=Unknown`.

## 1. tart-kubelet: recover nodes stuck in `Unknown` after a heartbeat gap

`nodeagent.refresh()` snapshotted the desired status (`Ready=True`, capacity, nodeInfo) into the node object, then `client.Patch` **overwrote that in-memory object with the API server's response** — which, once the node-lifecycle controller had flipped Ready to `Unknown` after a heartbeat gap, meant the subsequent `Status().Update()` just re-posted `Unknown` with a fresh timestamp. The node heartbeated forever but never climbed back out of Unknown.

Latent since the dynamic-label persistence landed; it only bit when a node got marked Unknown, which a single restart usually avoids. Today's **synchronized restart of all ~11 kubelets** (the operator rolls the binary to every host at once) pushed many nodes past the grace period simultaneously → Unknown → and they could never recover.

**Fix:** snapshot `desiredStatus` before the Patch and restore it after, so the status update actually asserts `Ready=True`. New `TestRefreshLiftsNodeOutOfUnknown` fails without the fix (node stays Unknown) and passes with it.

## 2. xcresult boot chain: bound `tailscale up` so a tailnet hiccup doesn't silently wedge the VM

The processor's launchd boot chain hard-ANDs `inject-env.sh && source env && tailscale-up.sh && exec tuist start`. `tailscale up` had **no timeout**, so when tailscaled couldn't reach the control plane it blocked indefinitely → `tuist start` never ran → no BEAM, zero consumers — yet the pod still showed Running/Ready (**tart-kubelet has no container probe**, so "Ready" only means the VM booted).

**Fix:** `tailscale up --timeout=60s`. On timeout it exits non-zero, the chain fails, and launchd's KeepAlive restarts it — so once NAT/control recovers a retry succeeds and the release boots on its own, instead of stranding the VM until a manual recycle.

## 3. host NAT: assert the general-internet leg from the durable anchor

The actual root cause of the processor outage: after heavy VM churn, **InternetSharing's `en0` NAT anchor stopped translating** VM egress, so VMs sent packets to the internet with their private `192.168.64.x` source. The upstream gateway dropped them → in-VM tailscaled's SYNs to control got no SYN-ACK (`SYN_SENT` forever) → `tailscale up` hung (see #2). Confirmed at the packet level (`tcpdump` on `en0` showed un-NAT'd private sources leaving the host).

`tuist-pf-vmnat` (re-run every 60s) already owns the tailnet + PN-VLAN NAT legs but left the general-internet leg to vmnet/InternetSharing — exactly what broke.

**Fix:** assert the default-route NAT leg from the `com.apple/tuist.vmnat` anchor too. That anchor is proven-enforced (the cache legs ride it) and reloaded every 60s, so a clobbered InternetSharing NAT now re-converges within a minute. Also hardened the idempotency short-circuit to reload when the live anchor is empty, so an external flush isn't masked by a still-matching snapshot. New `TestRenderVMNATScript_AssertsDefaultRouteNATLeg` covers it.

## Validation

- `go build`, `go vet`, `gofmt`, and the full `macos-host-bootstrap` + `tart-kubelet` test suites pass.
- `tailscale-up.sh` passes `sh -n`.
- During the incident, recycling each VM (which re-triggers the host NAT init) restored service — verified the fresh VMs egress NAT-translated, join the tailnet, boot the BEAM, and resume draining the `process_xcresult` queue on both nodes.

## Deploy paths differ (note for the reviewer)

These land in one PR for review, but reach hosts via different mechanisms: the tart-kubelet fix ships in the kubelet binary roll; the `tuist-pf-vmnat` change requires re-running `macos-host-bootstrap` on the hosts; the `tailscale-up.sh` change requires rebuilding the xcresult-processor Tart image.

## Still open (separate, larger)

A real readiness signal for the processor: tart-kubelet has **no container-probe support**, so a `readinessProbe:` would be silently ignored — the fix is either implementing probe support in the kubelet or an Oban-stall alert (available jobs but no `attempted_at` for N minutes). Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
