### PR TITLE
ci(kura): build all release binaries with Bazel (cross-compiling macOS x86_64)

### DIFF
--- a/.github/workflows/server-production-deployment.yml
+++ b/.github/workflows/server-production-deployment.yml
@@ -373,24 +373,39 @@ jobs:
     if: needs.check-releases.outputs.kura-should-release == 'true'
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 60
+    # id-token: OIDC for `tuist bazel setup`. Job permissions replace (not merge) the workflow's,
+    # so contents:read must be restated for checkout.
+    permissions:
+      contents: read
+      id-token: write
     strategy:
       fail-fast: false
       matrix:
+        # macOS x86_64 is the only non-native target (cross from the arm64 runner), and the Bazel
+        # setup has no cross C/C++ toolchain for the -sys crates (kura/MODULE.bazel), so it uses cargo.
         include:
-          - runner: ubuntu-latest
+          - runner: tuist-linux
             target: x86_64-unknown-linux-gnu
+            build: bazel
+            mise-tools: "rust bazel tuist"
           - runner: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
-          - runner: tuist-macos
-            target: x86_64-apple-darwin
+            build: bazel
+            mise-tools: "rust bazel tuist"
           - runner: tuist-macos
             target: aarch64-apple-darwin
+            build: bazel
+            mise-tools: "rust bazel tuist"
+          - runner: tuist-macos
+            target: x86_64-apple-darwin
+            build: cargo
+            mise-tools: "rust"
     steps:
       - uses: actions/checkout@v4
       - uses: jdx/mise-action@v4.0.1
         with:
           version: ${{ env.MISE_VERSION }}
-          install_args: "rust"
+          install_args: ${{ matrix.mise-tools }}
           cache: "false"
           working_directory: kura
           github_token: ${{ env.MISE_GITHUB_TOKEN }}
@@ -401,6 +416,23 @@ jobs:
           name: kura-release-metadata
           path: kura
 
+      # macOS gets clang/cmake from Xcode; this apt path is Linux-only.
+      - name: Install C/C++ toolchain for -sys crates (rocksdb/aws-lc bindgen)
+        if: matrix.build == 'bazel' && runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends build-essential clang cmake pkg-config
+      # Best-effort: continue-on-error + `.bazelrc` try-imports `.bazelrc.tuist`, so a failed setup
+      # falls back to a cold local build instead of blocking the release.
+      - name: Set up the Tuist remote cache
+        if: matrix.build == 'bazel'
+        working-directory: kura
+        run: |
+          tuist auth login
+          tuist bazel setup
+        continue-on-error: true
+      - name: Warn when the Tuist remote cache is unavailable
+        if: matrix.build == 'bazel' && hashFiles('kura/.bazelrc.tuist') == ''
+        run: echo "::warning::Tuist remote cache unavailable (.bazelrc.tuist not written); building cold against the local cache."
+
       - name: Build Kura binary
         working-directory: kura
         run: |
@@ -410,10 +442,19 @@ jobs:
 
           mkdir -p "$ARTIFACT_DIR"
 
-          env -u RUSTUP_TOOLCHAIN rustup target add "$TARGET"
-          env -u RUSTUP_TOOLCHAIN cargo build --release --locked --target "$TARGET"
+          STAGE_DIR="$(mktemp -d)"
+          if [ "${{ matrix.build }}" = "bazel" ]; then
+            # `compile` builds the host arch only (opt via kura/.bazelrc); runner/target are paired so host == $TARGET.
+            mise run --skip-tools compile
+            cp bazel-bin/kura "$STAGE_DIR/kura"
+          else
+            env -u RUSTUP_TOOLCHAIN rustup target add "$TARGET"
+            env -u RUSTUP_TOOLCHAIN cargo build --release --locked --target "$TARGET"
+            cp "target/$TARGET/release/kura" "$STAGE_DIR/kura"
+          fi
+          chmod +x "$STAGE_DIR/kura"
 
-          tar -C "target/$TARGET/release" -czf "$ARTIFACT_DIR/$ARTIFACT_NAME" kura
+          tar -C "$STAGE_DIR" -czf "$ARTIFACT_DIR/$ARTIFACT_NAME" kura
           shasum -a 256 "$ARTIFACT_DIR/$ARTIFACT_NAME" | awk '{print $1 "  " FILENAME}' FILENAME="$ARTIFACT_NAME" > "$ARTIFACT_DIR/sha256.txt"
           shasum -a 512 "$ARTIFACT_DIR/$ARTIFACT_NAME" | awk '{print $1 "  " FILENAME}' FILENAME="$ARTIFACT_NAME" > "$ARTIFACT_DIR/sha512.txt"
 

--- a/.github/workflows/server-production-deployment.yml
+++ b/.github/workflows/server-production-deployment.yml
@@ -381,31 +381,25 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # macOS x86_64 is the only non-native target (cross from the arm64 runner), and the Bazel
-        # setup has no cross C/C++ toolchain for the -sys crates (kura/MODULE.bazel), so it uses cargo.
+        # All targets build with Bazel and reuse the Tuist remote cache. macOS x86_64 is the only
+        # non-native target: it cross-compiles from the arm64 runner via --config=macos-x86_64-cross
+        # (apple_support supplies the cross cc toolchain for the -sys crates). The rest are native.
         include:
           - runner: tuist-linux
             target: x86_64-unknown-linux-gnu
-            build: bazel
-            mise-tools: "rust bazel tuist"
           - runner: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
-            build: bazel
-            mise-tools: "rust bazel tuist"
           - runner: tuist-macos
             target: aarch64-apple-darwin
-            build: bazel
-            mise-tools: "rust bazel tuist"
           - runner: tuist-macos
             target: x86_64-apple-darwin
-            build: cargo
-            mise-tools: "rust"
+            compile-args: "--config=macos-x86_64-cross"
     steps:
       - uses: actions/checkout@v4
       - uses: jdx/mise-action@v4.0.1
         with:
           version: ${{ env.MISE_VERSION }}
-          install_args: ${{ matrix.mise-tools }}
+          install_args: "rust bazel tuist"
           cache: "false"
           working_directory: kura
           github_token: ${{ env.MISE_GITHUB_TOKEN }}
@@ -418,19 +412,18 @@ jobs:
 
       # macOS gets clang/cmake from Xcode; this apt path is Linux-only.
       - name: Install C/C++ toolchain for -sys crates (rocksdb/aws-lc bindgen)
-        if: matrix.build == 'bazel' && runner.os == 'Linux'
+        if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y --no-install-recommends build-essential clang cmake pkg-config
       # Best-effort: continue-on-error + `.bazelrc` try-imports `.bazelrc.tuist`, so a failed setup
       # falls back to a cold local build instead of blocking the release.
       - name: Set up the Tuist remote cache
-        if: matrix.build == 'bazel'
         working-directory: kura
         run: |
           tuist auth login
           tuist bazel setup
         continue-on-error: true
       - name: Warn when the Tuist remote cache is unavailable
-        if: matrix.build == 'bazel' && hashFiles('kura/.bazelrc.tuist') == ''
+        if: hashFiles('kura/.bazelrc.tuist') == ''
         run: echo "::warning::Tuist remote cache unavailable (.bazelrc.tuist not written); building cold against the local cache."
 
       - name: Build Kura binary
@@ -442,16 +435,13 @@ jobs:
 
           mkdir -p "$ARTIFACT_DIR"
 
+          # --binary-only builds just //:kura (opt via kura/.bazelrc); //... would pull in the test
+          # target, which can't cross-compile. compile-args adds the cross --config on the macOS
+          # x86_64 leg and is empty for the native legs.
+          mise run --skip-tools compile -- --binary-only ${{ matrix.compile-args }}
+
           STAGE_DIR="$(mktemp -d)"
-          if [ "${{ matrix.build }}" = "bazel" ]; then
-            # `compile` builds the host arch only (opt via kura/.bazelrc); runner/target are paired so host == $TARGET.
-            mise run --skip-tools compile
-            cp bazel-bin/kura "$STAGE_DIR/kura"
-          else
-            env -u RUSTUP_TOOLCHAIN rustup target add "$TARGET"
-            env -u RUSTUP_TOOLCHAIN cargo build --release --locked --target "$TARGET"
-            cp "target/$TARGET/release/kura" "$STAGE_DIR/kura"
-          fi
+          cp bazel-bin/kura "$STAGE_DIR/kura"
           chmod +x "$STAGE_DIR/kura"
 
           tar -C "$STAGE_DIR" -czf "$ARTIFACT_DIR/$ARTIFACT_NAME" kura

--- a/kura/.bazelrc
+++ b/kura/.bazelrc
@@ -15,11 +15,15 @@ test --test_output=errors
 # Apply the os-specific config blocks below based on the host OS.
 build --enable_platform_specific_config
 
-# macOS host-native builds (local dev and the arm64 release binary). Bazel's autodetected darwin
-# cc toolchain defaults --macos_minimum_os to 10.11,
+# Applies to every macOS-host build (local dev plus both release binaries — arm64 native and the
+# x86_64 cross below). Bazel's darwin cc toolchain defaults --macos_minimum_os to 10.11,
 # which rules_rust feeds into the -sys build scripts' CFLAGS as -mmacosx-version-min=10.11.
 # rocksdb's bundled C++ uses C++17 aligned new/delete, which Apple clang only permits at
 # >= 10.13, so that default breaks the rocksdb build. Raise the floor (host_* covers the
 # exec-config build-script actions). Linux is unaffected: these only apply on macOS hosts.
 build:macos --macos_minimum_os=11.0
 build:macos --host_macos_minimum_os=11.0
+
+# Cross-compile the macOS x86_64 release binary on an arm64 host (apple_support supplies the cross
+# cc toolchain for the -sys crates; rules_rs already carries the x86_64-apple-darwin rust toolchain).
+build:macos-x86_64-cross --platforms=//bazel/platforms:macos_x86_64

--- a/kura/.bazelrc
+++ b/kura/.bazelrc
@@ -15,8 +15,8 @@ test --test_output=errors
 # Apply the os-specific config blocks below based on the host OS.
 build --enable_platform_specific_config
 
-# macOS-native local builds only (macOS is not a release target — see the migration
-# plan). Bazel's autodetected darwin cc toolchain defaults --macos_minimum_os to 10.11,
+# macOS host-native builds (local dev and the arm64 release binary). Bazel's autodetected darwin
+# cc toolchain defaults --macos_minimum_os to 10.11,
 # which rules_rust feeds into the -sys build scripts' CFLAGS as -mmacosx-version-min=10.11.
 # rocksdb's bundled C++ uses C++17 aligned new/delete, which Apple clang only permits at
 # >= 10.13, so that default breaks the rocksdb build. Raise the floor (host_* covers the

--- a/kura/bazel/platforms/BUILD.bazel
+++ b/kura/bazel/platforms/BUILD.bazel
@@ -1,0 +1,8 @@
+platform(
+    name = "macos_x86_64",
+    constraint_values = [
+        "@platforms//os:macos",
+        "@platforms//cpu:x86_64",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/kura/mise/tasks/compile.sh
+++ b/kura/mise/tasks/compile.sh
@@ -1,9 +1,27 @@
 #!/usr/bin/env bash
-#MISE description="Build all kura targets for the host platform (bazel build //...); pass extra bazel flags through, e.g. mise run compile -- -c opt"
+#MISE description="Build kura with Bazel (bazel build //...). Pass extra bazel flags through, e.g. mise run compile -- -c opt. Use --binary-only to build just the release binary."
+#USAGE flag "--binary-only" help="Build only the release binary //:kura instead of all targets (//...). //:kura omits the test target, which can't cross-compile — the release pipeline uses this."
+#USAGE arg "[bazel_args]" var=#true help="Extra flags forwarded verbatim to bazel build"
 set -euo pipefail
+
+# usage validates the args and sets $usage_binary_only; the raw args stay in "$@" (its own
+# capture variable mangles --flag=value pairs). Forward every token except the consumed
+# --binary-only (and a passthrough --). A word-split string keeps this bash-3.2 safe — empty
+# arrays are an unbound-variable footgun there under `set -u`.
+bazel_args=""
+for arg in "$@"; do
+  case "$arg" in
+  --binary-only | --) ;;
+  *) bazel_args="${bazel_args:+$bazel_args }$arg" ;;
+  esac
+done
+
+target="//..."
+[ "${usage_binary_only:-false}" = "true" ] && target="//:kura"
 
 # No `cd` needed: mise runs file tasks from the config root (kura/), where the bazel workspace
 # resolves.
-bazel build //... "$@"
+# shellcheck disable=SC2086 # intentional word-splitting of the collected bazel flags
+bazel build "$target" $bazel_args
 
 echo "✔ kura binary: $(pwd)/bazel-bin/kura"


### PR DESCRIPTION
## What changed

`release-kura-binaries` in `server-production-deployment.yml` now builds **every** kura release binary with **Bazel**, reusing the Tuist remote cache like the rest of Kura CI. The cargo path is gone entirely — including `x86_64-apple-darwin`, which now **cross-compiles from the arm64 `tuist-macos` runner**.

| Target | Runner | Build |
|---|---|---|
| `x86_64-unknown-linux-gnu` | `tuist-linux` | Bazel (native) |
| `aarch64-unknown-linux-gnu` | `ubuntu-24.04-arm` | Bazel (native) |
| `aarch64-apple-darwin` | `tuist-macos` (arm64) | Bazel (native) |
| `x86_64-apple-darwin` | `tuist-macos` (arm64) | Bazel (**cross**, `--config=macos-x86_64-cross`) |

This is the follow-up #11533 deferred: *"The `release-kura-docker` job (still cargo `--release`, multi-arch) is migrated in a separate PR."*

## Why

`release-kura-binaries` was the last cargo step of the kura release path. It ran `cargo build --release` with no cache, **cold-compiling the `-sys` crates (rocksdb, aws-lc) from source on every release** with zero reuse of the Tuist remote cache that `bazel-compile`/`test`/`clippy` and the e2e image (#11530) already share — and the `-sys` C/C++ is exactly the expensive part that cache exists to amortize.

## How

- **Bazel builds the binary on every leg** via `mise run --skip-tools compile -- --binary-only`, with `id-token: write` + best-effort `tuist bazel setup` (continue-on-error; `.bazelrc` try-imports `.bazelrc.tuist`, so a cache miss falls back to a cold local build instead of blocking the release).
- **macOS x86_64 cross-compiles, no `MODULE.bazel` change.** `apple_support` (already transitive via rules_rs) supplies a cross `darwin_x86_64` cc toolchain for the `-sys` crates, and rules_rs already carries the `x86_64-apple-darwin` rust toolchain (it's in `platform_triples`). A `//bazel/platforms:macos_x86_64` platform + a `build:macos-x86_64-cross` `.bazelrc` config (`--platforms=…`) are all that's needed.
- **The release builds `//:kura`, not `//...`.** The wildcard pulls in the test target, which can't cross-compile (no test toolchain for a non-host target platform). To keep the shared `mise` task as the entrypoint, `compile.sh` gains a `--binary-only` usage flag (`//:kura` instead of `//...`) while still forwarding arbitrary bazel flags — the cross `--config` and `kura.yml`'s existing `--define` — through `"$@"`. (The `[bazel_args] var=#true` arg only *declares* that passthrough; its captured value is read from `"$@"` because usage's own capture var duplicates `--key=value` tokens and `double_dash` isn't supported in this mise version.)
- **Docker assembly unchanged.** `release-kura-docker` consumes the same `kura-binary-*-artifacts` (same tar layout) via `Dockerfile.release` — untouched. The job id stayed `release-kura-binaries`, so all downstream `needs`/`result` gates are intact.

### Why cross-compile rather than drop macOS x86_64

This supersedes the open question on the earlier revision (which left x86_64 on cargo). The latest macOS — Tahoe (26) — still runs on Intel, so the target has a live audience this cycle; cross-compiling keeps it **and** removes the cargo special-case, leaving the job uniform. apple_support makes it essentially free, so there's no longer a reason to special-case or drop it.

### `--compilation_mode=opt`

Already on `main` via #11530 / #11533 (the binary must match the optimized binary that ships, and one mode keeps every Bazel job on a single warm cache keyspace), so this PR doesn't re-add it. The `kura/.bazelrc` macOS comment is updated to note both release binaries (arm64 native + x86_64 cross) now build there.

## Validation

- Verified locally on an arm64 Mac through the real task: `mise run --skip-tools compile -- --binary-only` → `Mach-O … arm64`; `… -- --binary-only --config=macos-x86_64-cross` → `Mach-O … x86_64` (full rocksdb/aws-lc `-sys` stack compiles clean under the cross toolchain).
- `actionlint` clean apart from the expected `tuist-linux`/`tuist-macos` self-hosted-label notes shared by every existing Bazel job in `kura.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
