### PR TITLE
fix(infra): deploy platform-chart changes (add infra/helm/platform to deploy filter)

### DIFF
--- a/.github/workflows/server-production-deployment.yml
+++ b/.github/workflows/server-production-deployment.yml
@@ -139,7 +139,11 @@ jobs:
       - id: deployable
         # A change to any of these paths deploys the server; the build gate
         # of the production cascade ORs this with the fleet/runtime
-        # image-release flags.
+        # image-release flags. infra/helm/platform/ is included so platform
+        # chart changes (CNPG operator, cert-manager, ingress-nginx, ESO,
+        # metrics-server) deploy on merge via platform-install — without it a
+        # platform-only change skips build and the whole cascade, merging green
+        # but never reaching the cluster.
         env:
           BEFORE: ${{ github.event.before }}
         run: |
@@ -151,7 +155,7 @@ jobs:
             exit 0
           fi
           if git diff --name-only "$base" "${{ github.sha }}" \
-            | grep -qE '^(server/|tuist_common/|noora/|infra/kura-controller/|infra/helm/tuist/|infra/helm/k8s-monitoring/|\.github/workflows/(server-deployment|server-production-deployment)\.yml)'; then
+            | grep -qE '^(server/|tuist_common/|noora/|infra/kura-controller/|infra/helm/tuist/|infra/helm/platform/|infra/helm/k8s-monitoring/|\.github/workflows/(server-deployment|server-production-deployment)\.yml)'; then
             echo "deployable-changed=true" >> "$GITHUB_OUTPUT"
           else
             echo "deployable-changed=false" >> "$GITHUB_OUTPUT"

--- a/infra/cnpg/README.md
+++ b/infra/cnpg/README.md
@@ -131,8 +131,18 @@ kubectl cnpg backup-status -n "$NAMESPACE" "$CLUSTER"
 The CNPG operator version is pinned by the `cloudnative-pg` dependency in
 [`infra/helm/platform/Chart.yaml`](../helm/platform/Chart.yaml). The chart
 version maps to the operator `appVersion`: chart `0.23.x` is operator `1.25.x`,
-`0.24.0` is `1.26.0`, `0.25.0` is `1.26.1`. The platform chart is re-applied on
-every deploy, so bumping that pin upgrades the operator on the next merge.
+`0.24.0` is `1.26.0`, `0.25.0` is `1.26.1`. The platform chart is re-applied by
+the `platform-install` deploy job, so bumping that pin upgrades the operator on
+the next deploy.
+
+For that to happen on merge, `infra/helm/platform/` must be in the
+`deployable-changed` path filter in
+[`.github/workflows/server-production-deployment.yml`](../../.github/workflows/server-production-deployment.yml).
+That filter gates the `build` job, which the whole canary -> acceptance ->
+production cascade depends on. A change to a path outside the filter skips
+`build` and therefore skips every deploy job, so the run goes green without ever
+reaching a cluster. If a platform-only bump ever merges without deploying, check
+that this path is still in the filter.
 
 CNPG must be upgraded one minor at a time. The project only tests and supports
 sequential minor upgrades, not skips


### PR DESCRIPTION
## What this does

Adds `infra/helm/platform/` to the `deployable-changed` path filter in `.github/workflows/server-production-deployment.yml`, so changes to the platform chart deploy on merge. Also documents the coupling in `infra/cnpg/README.md`.

## Why (root cause)

Platform-chart-only changes were silently never deploying. The deploy cascade (canary -> acceptance -> production) depends on the `build` job, and `build` only runs when `deployable-changed == 'true'` or a fleet/runtime image release fires. `deployable-changed` is a path filter that matched `server/`, `tuist_common/`, `noora/`, `infra/kura-controller/`, `infra/helm/tuist/`, `infra/helm/k8s-monitoring/`, and the two deployment workflow files — but **not `infra/helm/platform/`**, where the CNPG operator, cert-manager, ingress-nginx, ESO, and metrics-server live.

So a platform-only commit skipped `build`, which skipped every deploy job, and the run concluded **green** because skipped is not failed. The change merged but never reached a cluster.

This is exactly what happened to #11340 (the CNPG `1.25 -> 1.26` operator bump): it merged, its production-deployment run is green, but `Build server image`, `canary`, `Acceptance Tests`, and `production` were all skipped, so `platform-install` never ran. The operator is still `1.25.0`.

## What merging this does

Two things at once:

1. **Fixes the gap permanently** — future platform chart changes (the remaining `1.27` / `1.28` / `1.29` operator steps, plus any cert-manager / ingress-nginx / ESO / metrics-server bump) deploy on merge.
2. **Deploys the pending `1.26` bump** — this PR edits `server-production-deployment.yml`, which is itself in the filter, so merging it sets `deployable-changed=true`. The cascade runs, `platform-install` re-applies the platform chart at current `main` (chart `0.25.0` = operator `1.26.1`), and the CNPG operator upgrades.

Because the operator upgrade rolls every CNPG cluster the operator manages, merging this triggers the production switchover described in #11340: a fast, lossless (RPO 0) switchover on the main `tuist` cluster (a few seconds of dropped connections / errors on the write path) and a brief restart of the single-instance `tuist-ops` cluster.

## Merge guidance (low-traffic window)

Treat this like the operator bump itself: **merge at the start of a low-traffic window wider than the deploy lag** (the prod step runs after the canary deploy and acceptance tests, roughly 20-40 min after merge), so the switchover lands inside the quiet period. Canary deploys and runs acceptance first, so it is the dress rehearsal before prod.

## Validation

- Confirmed via the #11340 run (`28286243500`) that `Build server image` / `canary` / `production` were `skipped`, tracing the cause to the `deployable-changed` filter at `server-production-deployment.yml`.
- This change adds the platform path to that same filter; `git diff` against `main` is the one path addition plus the explanatory comment and README note.
- On deploy, watch the canary CNPG cluster roll and switch over cleanly before the prod step; confirm `kubectl cnpg status` reports every instance on operator `1.26.1` and the clusters healthy.

## Notes for reviewers

Opened as a draft because merging it triggers a production CNPG switchover. Mark ready and merge in a low-traffic window. After this lands and `1.26` is confirmed live on all envs, the staged `1.26 -> 1.27` bump can proceed (it must stay a draft until then to keep the one-minor-at-a-time sequence).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
