### PR TITLE
chore(infra): bump CloudNativePG operator 1.26 -> 1.27 (step 2 of 4 toward 1.29)

### DIFF
--- a/infra/helm/platform/Chart.yaml
+++ b/infra/helm/platform/Chart.yaml
@@ -46,6 +46,6 @@ dependencies:
     repository: https://kubernetes-sigs.github.io/metrics-server/
     condition: metrics-server.enabled
   - name: cloudnative-pg
-    version: 0.25.0  # operator 1.26.1; step minors 1.25->1.29 one at a time (see infra/cnpg/README.md)
+    version: 0.26.1  # operator 1.27.1; step minors 1.25->1.29 one at a time (see infra/cnpg/README.md)
     repository: https://cloudnative-pg.github.io/charts
     condition: cloudnative-pg.enabled


### PR DESCRIPTION
## What this does

Bumps the CloudNativePG operator from `1.26.1` to `1.27.1` by moving the `cloudnative-pg` dependency in the platform chart from chart `0.25.0` to `0.26.1` (`infra/helm/platform/Chart.yaml`). This is step 2 of the four sequential minor upgrades from EOL `1.25` to the supported `1.29` line.

`1.25 -> 1.26 (#11340) -> 1.27 (this PR) -> 1.28 -> 1.29`

## BLOCKED — do not merge yet

This must stay a draft until **both**:

1. **#11538 has merged** — the platform deploy-gate fix. Without it, platform-chart changes do not trigger a deploy at all (the `deployable-changed` filter omitted `infra/helm/platform/`), so this bump would merge green and never reach a cluster, same as #11340 did.
2. **Operator `1.26` is confirmed live on all envs.** CNPG only supports one-minor-at-a-time upgrades. Merging this before `1.26` is actually running would jump `1.25 -> 1.27`, skipping a minor, which is unsupported.

Once both hold, this merges like a normal platform change (after #11538): the deploy cascade runs, `platform-install` re-applies the platform chart, and the operator rolls to `1.27.1` with the usual brief production switchover. Merge in a low-traffic window.

## Notes

Chart-pin only by design — the README mapping line gets `0.26.1` = `1.27.1` appended on rebase after #11538 lands, to avoid a guaranteed conflict with that PR's README edit. Operand Postgres image stays pinned and out of this PR (keeps it a clean instance-manager-only roll; CNPG's webhook rejects changing image and parameters together). See `infra/cnpg/README.md` for the full upgrade-path rationale and switchover behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
