### PR TITLE
chore(infra): bump CloudNativePG operator 1.27 -> 1.28 (step 3 of 4 toward 1.29)

### DIFF
--- a/infra/cnpg/README.md
+++ b/infra/cnpg/README.md
@@ -131,7 +131,8 @@ kubectl cnpg backup-status -n "$NAMESPACE" "$CLUSTER"
 The CNPG operator version is pinned by the `cloudnative-pg` dependency in
 [`infra/helm/platform/Chart.yaml`](../helm/platform/Chart.yaml). The chart
 version maps to the operator `appVersion`: chart `0.23.x` is operator `1.25.x`,
-`0.24.0` is `1.26.0`, `0.25.0` is `1.26.1`. The platform chart is re-applied by
+`0.24.0` is `1.26.0`, `0.25.0` is `1.26.1`, `0.26.1` is `1.27.1`, `0.27.1` is
+`1.28.1`, `0.28.3` is `1.29.1`. The platform chart is re-applied by
 the `platform-install` deploy job, so bumping that pin upgrades the operator on
 the next deploy.
 

--- a/infra/helm/platform/Chart.yaml
+++ b/infra/helm/platform/Chart.yaml
@@ -46,6 +46,6 @@ dependencies:
     repository: https://kubernetes-sigs.github.io/metrics-server/
     condition: metrics-server.enabled
   - name: cloudnative-pg
-    version: 0.26.1  # operator 1.27.1; step minors 1.25->1.29 one at a time (see infra/cnpg/README.md)
+    version: 0.27.1  # operator 1.28.1; step minors 1.25->1.29 one at a time (see infra/cnpg/README.md)
     repository: https://cloudnative-pg.github.io/charts
     condition: cloudnative-pg.enabled


### PR DESCRIPTION
## What this does

Bumps the CloudNativePG operator from `1.27.1` to `1.28.1` by moving the `cloudnative-pg` dependency in the platform chart from chart `0.26.1` to `0.27.1` (`infra/helm/platform/Chart.yaml`). Step 3 of the four sequential minor upgrades from EOL `1.25` to the supported `1.29` line. Also catches the `infra/cnpg/README.md` chart->operator map up through `1.29.1`.

`1.25 -> 1.26 (#11340/#11538) -> 1.27 (#11539) -> 1.28 (this PR) -> 1.29`

## BLOCKED — do not merge yet

Must stay a draft until **step 2 (1.27, #11539) is confirmed live on all envs**. CNPG only supports one-minor-at-a-time upgrades; merging this before 1.27 is actually running would jump `1.27 -> 1.28` from a `1.26` base, skipping a minor.

Once 1.27 is verified live, this merges like a normal platform change (deploys on its own now that the gate fix #11538 is in): the cascade runs, `platform-install` re-applies the platform chart, and the operator rolls to `1.28.1` with the usual brief production switchover. Merge in a low-traffic window.

## Note: 1.28 is a transit step (EOL imminent)

`1.28.x` reaches end-of-life on **2026-06-30**, and `1.28.1` is already its final patch. We still have to pass through it (no skipping minors), but we should not linger: **step 4 (-> `1.29.1`, chart `0.28.3`) should follow promptly** after this lands so production ends up on the only supported line rather than parked on an EOL one. The upgrade mechanics don't care about EOL; this is purely about not sitting on an unpatched minor.

## Notes

Operand Postgres image stays pinned and out of this PR (clean instance-manager-only roll; CNPG's webhook rejects changing image and parameters together). Same switchover behavior and verification as the prior steps: confirm operator image `1.28.1`, all CNPG instances rolled and healthy with a primary elected, and WAL archiving current on both `tuist` and `tuist-ops` (via primary pod logs, since the Backup/Cluster CRDs are blocked by view-tier RBAC). See `infra/cnpg/README.md` for the full rationale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
