### PR TITLE
perf(infra): host-cache Tart VM disk reads (caching=cached)

### DIFF
--- a/infra/tart-kubelet/internal/tart/tart.go
+++ b/infra/tart-kubelet/internal/tart/tart.go
@@ -233,7 +233,13 @@ func (c *Client) Run(ctx context.Context, name string, sharedDirs []string) (*Ru
 		}
 	}
 
-	args := []string{"run", name, "--no-graphics"}
+	// Host-cache the VM's disk-image reads. Tart's default (caching=automatic)
+	// leaves read throughput on the table for our read/page-in-heavy build
+	// workload (compilers + dylibs paged in per task). An on-host A/B on a
+	// runner Mac mini measured ~1.8x faster warm reads with caching=cached
+	// (7.7 vs 4.2 GB/s) and no durability tradeoff — these VMs are ephemeral
+	// (cloned per Pod, discarded on exit), so host caching is pure upside.
+	args := []string{"run", name, "--no-graphics", "--root-disk-opts", "caching=cached"}
 	for _, dir := range sharedDirs {
 		args = append(args, "--dir", dir)
 	}


### PR DESCRIPTION
## What

Pass `--root-disk-opts caching=cached` to `tart run` for the ephemeral build VMs (`tart-kubelet`, `internal/tart/tart.go`) so the **host page-caches the VM disk-image reads**.

## Why

The runner Mac minis (Scaleway **M2-L** = M2 Pro 10C / **16 GB**) trail Namespace by ~60% on CAS-heavy Xcode builds. The investigation behind [runners-benchmark#1](https://github.com/tuist/runners-benchmark/pull/1) traced the gap to **runner-side per-task overhead** — both runners do *identical* work (5343 `SwiftCompile` + ~1600 CAS materializations, 0 cache errors), but tuist-macos is ~1.6× slower **per task**. Ruled out, with measurements:

- **not the cache** — the Kura node serves CAS reads at <1 ms p90;
- **not the network** — PN RTT to the node is ~2 ms (lower than Namespace's WAN, yet we're slower);
- **not hit-rate** — identical task/materialization counts, 0 errors;
- **not CPU** — ~even.

What's left is the **local read / page-in path**: the compiler + Swift dylibs are paged in from the Tart **sparse disk image** on every one of thousands of short tasks, and our disk reads were slower/variable vs Namespace's.

Tart's default disk caching is `automatic`. An **on-host A/B** on an actual runner host (guest held constant) measured warm reads:

| `--root-disk-opts` | warm read |
| --- | --- |
| `caching=automatic` (default) | 4.2 GB/s |
| **`caching=cached`** | **7.7 GB/s** (~1.8×) |
| `caching=uncached` | worst |

So the default leaves read throughput on the table, and `caching=cached` recovers ~1.8× — **keeping the VM, no hardware change**.

### Why not also `sync=none`?

Evaluated and ruled out for this workload: the build issues **no hard syncs** (zero `F_FULLFSYNC`/`fsync` across the whole CLI; CAS/cache writes are plain `data.write(to:)`, and macOS soft `fsync` is already fast on the runner). `sync=none` would be harmless for ephemeral VMs but wouldn't move this build, so it's left out to keep the change minimal.

## Safety

These VMs are **ephemeral** — cloned per Pod, discarded on exit — so host read-caching is pure upside with **no durability tradeoff**.

## Validation

- `go test ./internal/tart/...` passes; no test asserts the exact `tart run` args.
- On-host disk A/B above (1.8× warm reads on real runner hardware).
- The **build-level** effect (whether it narrows the benchmark gap) will be measured by the runner benchmark once this is live on the fleet. `caching=cached` is a strict read improvement regardless; it's validated at the disk layer, not yet at the build layer.

## Rollout

`tart-kubelet` runs as a launchd agent on each Mac mini, so this takes effect as the updated binary rolls to the hosts (not instant on merge) — gradual and reversible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)