### PR TITLE
chore(infra): bump CloudNativePG operator 1.28 -> 1.29 (step 4 of 4, final)

### DIFF
--- a/infra/helm/platform/Chart.yaml
+++ b/infra/helm/platform/Chart.yaml
@@ -46,6 +46,6 @@ dependencies:
     repository: https://kubernetes-sigs.github.io/metrics-server/
     condition: metrics-server.enabled
   - name: cloudnative-pg
-    version: 0.27.1  # operator 1.28.1; step minors 1.25->1.29 one at a time (see infra/cnpg/README.md)
+    version: 0.28.3  # operator 1.29.1 (supported line; final step of the 1.25->1.29 catch-up, see infra/cnpg/README.md)
     repository: https://cloudnative-pg.github.io/charts
     condition: cloudnative-pg.enabled

--- a/infra/helm/platform/Chart.yaml
+++ b/infra/helm/platform/Chart.yaml
@@ -46,6 +46,6 @@ dependencies:
     repository: https://kubernetes-sigs.github.io/metrics-server/
     condition: metrics-server.enabled
   - name: cloudnative-pg
-    version: 0.28.3  # operator 1.29.1 (supported line; final step of the 1.25->1.29 catch-up, see infra/cnpg/README.md)
+    version: 0.28.3
     repository: https://cloudnative-pg.github.io/charts
     condition: cloudnative-pg.enabled


### PR DESCRIPTION
## What this does

Bumps the CloudNativePG operator from `1.28.1` to `1.29.1` by moving the `cloudnative-pg` dependency in the platform chart from chart `0.27.1` to `0.28.3` (`infra/helm/platform/Chart.yaml`). **This is the final step** of the four sequential minor upgrades — it lands production on `1.29.x`, the only currently-supported CNPG line, completing the catch-up off EOL `1.25`.

`1.25 -> 1.26 (#11340/#11538) -> 1.27 (#11539) -> 1.28 (#11540) -> 1.29 (this PR, final)`

## BLOCKED — do not merge yet

Must stay a draft until **step 3 (1.28, #11540) is confirmed live (operator `1.28.1`) on all envs**. The operator is on `1.27.1` until the 1.28 cascade finishes; merging this before then would jump to `1.29` and skip a minor, which CNPG does not support (sequential N->N+1 only).

This is especially worth respecting here because 1.28 itself is EOL on 2026-06-30 — the goal is to pass *through* it cleanly to 1.29, not skip it.

Once 1.28 is verified live, this merges like the prior steps (deploys on its own via the gate fix #11538): the cascade runs, `platform-install` re-applies the platform chart, and the operator rolls to `1.29.1` with the usual brief production switchover. Merge in a low-traffic window.

## After this lands

The catch-up is complete and prod sits on a supported line. Two follow-ups, both already tracked, become the remaining CNPG work:
- Update the `infra/cnpg/README.md` "catching up ... in four steps" narrative to reflect that we're now on `1.29.x` (small doc cleanup).
- The in-tree `barmanObjectStore` -> Barman Cloud Plugin migration (separate project; in-tree still works on 1.29, so no rush).

## Notes

Chart-pin only — the README chart->operator map already lists `0.28.3` = `1.29.1` (added in #11540). Operand Postgres image stays pinned and out of this PR. Same switchover behavior and verification as the prior steps: operator image `1.29.1`, all CNPG instances rolled with a primary elected, WAL archiving current on both `tuist` and `tuist-ops`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
