### PR TITLE
fix(cli): isolate host-less unit test derived data in default test runs

### DIFF
--- a/cli/Sources/TuistKit/Services/TestService.swift
+++ b/cli/Sources/TuistKit/Services/TestService.swift
@@ -1194,6 +1194,11 @@ public struct TestService { // swiftlint:disable:this type_body_length
             uploadCacheStorage = cacheStorage
         }
 
+        let passthroughDerivedDataPath = try? await xcodeBuildAgumentParser
+            .parse(passthroughXcodeBuildArguments)
+            .derivedDataPath
+        let hostlessDerivedDataBasePath = derivedDataPath ?? passthroughDerivedDataPath
+
         let passthroughSkippedTargetNames = passthroughSkippedTestTargetNames(passthroughXcodeBuildArguments)
         let testSchemeRuns = schemes.compactMap { testScheme -> (scheme: Scheme, testTargets: [TestIdentifier])? in
             let testSchemeTargetNames = Set(
@@ -1250,8 +1255,8 @@ public struct TestService { // swiftlint:disable:this type_body_length
                     testPlanConfiguration: testPlanConfiguration,
                     action: action
                 ) {
-                    if let derivedDataPath {
-                        schemeDerivedDataPath = derivedDataPath
+                    if let hostlessDerivedDataBasePath {
+                        schemeDerivedDataPath = hostlessDerivedDataBasePath
                             .appending(components: "HostlessTests", testScheme.name)
                     } else {
                         schemeDerivedDataPath = try await fileSystem
@@ -1519,11 +1524,7 @@ public struct TestService { // swiftlint:disable:this type_body_length
                 ($0.name, $0.projectPath.pathString) < ($1.name, $1.projectPath.pathString)
             }
             .compactMap { schemesByTarget[$0] }
-
-        Logger.current.debug(
-            "Workspace schemes include hosted tests and host-less unit tests; running generated project schemes separately."
-        )
-        return (projectSchemes, true)
+        return (projectSchemes, action == .test)
     }
 
     private func isCompatibleHostlessTestScheme(

--- a/cli/Sources/TuistKit/Services/TestService.swift
+++ b/cli/Sources/TuistKit/Services/TestService.swift
@@ -403,6 +403,7 @@ public struct TestService { // swiftlint:disable:this type_body_length
         )
 
         let schemes: [Scheme]
+        let isolateHostlessUnitTests: Bool
         if let schemeName {
             guard let scheme = graphTraverser.schemes().first(where: { $0.name == schemeName })
             else {
@@ -463,9 +464,10 @@ public struct TestService { // swiftlint:disable:this type_body_length
             }
 
             schemes = [scheme]
+            isolateHostlessUnitTests = false
         } else {
             let workspaceSchemes = buildGraphInspector.workspaceSchemes(graphTraverser: graphTraverser)
-            schemes = defaultSchemes(
+            (schemes, isolateHostlessUnitTests) = defaultSchemes(
                 workspaceSchemes: workspaceSchemes,
                 candidateTestSchemes: testableSchemes,
                 graphTraverser: graphTraverser,
@@ -536,6 +538,7 @@ public struct TestService { // swiftlint:disable:this type_body_length
                 passthroughXcodeBuildArguments: passthroughXcodeBuildArguments,
                 config: config,
                 quarantinedTests: mutedQuarantinedTests,
+                isolateHostlessUnitTests: isolateHostlessUnitTests,
                 mode: mode
             )
             if !didRunTests {
@@ -1175,6 +1178,7 @@ public struct TestService { // swiftlint:disable:this type_body_length
         passthroughXcodeBuildArguments: [String],
         config: Tuist,
         quarantinedTests: [TestIdentifier],
+        isolateHostlessUnitTests: Bool = false,
         mode: TestProcessingMode = .local
     ) async throws -> Bool {
         let graphTraverser = GraphTraverser(graph: graph)
@@ -1235,6 +1239,28 @@ public struct TestService { // swiftlint:disable:this type_body_length
                     perSchemeResultBundlePaths.append(testSchemeResultBundlePath)
                 }
 
+                // A host-less unit-test bundle crashes during xctest bootstrap when its build-products
+                // directory also contains the app's frameworks (e.g. swift-sharing). When such a scheme is
+                // split out of a mixed workspace scheme, run it against its own derived data so its products
+                // directory stays clean. An explicit derived data path is honored by nesting under it.
+                let schemeDerivedDataPath: AbsolutePath?
+                if isolateHostlessUnitTests, isHostlessUnitTestScheme(
+                    scheme: testScheme,
+                    graphTraverser: graphTraverser,
+                    testPlanConfiguration: testPlanConfiguration,
+                    action: action
+                ) {
+                    if let derivedDataPath {
+                        schemeDerivedDataPath = derivedDataPath
+                            .appending(components: "HostlessTests", testScheme.name)
+                    } else {
+                        schemeDerivedDataPath = try await fileSystem
+                            .makeTemporaryDirectory(prefix: "hostless-tests")
+                    }
+                } else {
+                    schemeDerivedDataPath = derivedDataPath
+                }
+
                 do {
                     try await self.testScheme(
                         scheme: testScheme,
@@ -1247,7 +1273,7 @@ public struct TestService { // swiftlint:disable:this type_body_length
                         action: action,
                         rosetta: rosetta,
                         resultBundlePath: testSchemeResultBundlePath,
-                        derivedDataPath: derivedDataPath,
+                        derivedDataPath: schemeDerivedDataPath,
                         retryCount: retryCount,
                         testTargets: testSchemeRun.testTargets,
                         skipTestTargets: skipTestTargets,
@@ -1441,7 +1467,7 @@ public struct TestService { // swiftlint:disable:this type_body_length
         graphTraverser: GraphTraversing,
         testPlanConfiguration: TestPlanConfiguration?,
         action: XcodeBuildTestAction
-    ) -> [Scheme] {
+    ) -> (schemes: [Scheme], isolatedHostlessUnitTests: Bool) {
         guard action == .test,
               containsMixedHostedAndHostlessUnitTests(
                   schemes: workspaceSchemes,
@@ -1450,7 +1476,7 @@ public struct TestService { // swiftlint:disable:this type_body_length
                   action: action
               )
         else {
-            return workspaceSchemes
+            return (workspaceSchemes, false)
         }
 
         let workspaceSchemeNames = Set(workspaceSchemes.map(\.name))
@@ -1485,14 +1511,19 @@ public struct TestService { // swiftlint:disable:this type_body_length
         )
 
         guard workspaceTargets.allSatisfy({ schemesByTarget[$0] != nil }) else {
-            return workspaceSchemes
+            return (workspaceSchemes, false)
         }
 
-        return workspaceTargets
+        let projectSchemes = workspaceTargets
             .sorted {
                 ($0.name, $0.projectPath.pathString) < ($1.name, $1.projectPath.pathString)
             }
             .compactMap { schemesByTarget[$0] }
+
+        Logger.current.debug(
+            "Workspace schemes include hosted tests and host-less unit tests; running generated project schemes separately."
+        )
+        return (projectSchemes, true)
     }
 
     private func isCompatibleHostlessTestScheme(
@@ -1526,6 +1557,34 @@ public struct TestService { // swiftlint:disable:this type_body_length
         let dependencies = graphTraverser
             .directTargetDependencies(path: graphTarget.path, name: graphTarget.target.name)
         return !dependencies.isEmpty && !dependencies.contains(where: { $0.target.product.canHostTests() })
+    }
+
+    /// A scheme is host-less when at least one of its test targets is a `.unitTests` bundle that has
+    /// dependencies but no host application. Such a bundle crashes during xctest bootstrap when it runs
+    /// against a build-products directory that also contains the app's frameworks (see swift-sharing),
+    /// so it must be isolated into its own derived data when split out of the workspace scheme.
+    private func isHostlessUnitTestScheme(
+        scheme: Scheme,
+        graphTraverser: GraphTraversing,
+        testPlanConfiguration: TestPlanConfiguration?,
+        action: XcodeBuildTestAction
+    ) -> Bool {
+        testActionTargetReferences(
+            scheme: scheme,
+            testPlanConfiguration: testPlanConfiguration,
+            action: action
+        ).contains { targetReference in
+            guard let graphTarget = graphTraverser.target(
+                path: targetReference.projectPath,
+                name: targetReference.name
+            ), graphTarget.target.product == .unitTests else {
+                return false
+            }
+
+            let dependencies = graphTraverser
+                .directTargetDependencies(path: graphTarget.path, name: graphTarget.target.name)
+            return !dependencies.isEmpty && !dependencies.contains(where: { $0.target.product.canHostTests() })
+        }
     }
 
     private func containsMixedHostedAndHostlessUnitTests(

--- a/cli/Tests/TuistKitTests/Services/TestServiceHostlessDerivedDataTests.swift
+++ b/cli/Tests/TuistKitTests/Services/TestServiceHostlessDerivedDataTests.swift
@@ -1,0 +1,386 @@
+import FileSystem
+import FileSystemTesting
+import Foundation
+import Mockable
+import Path
+import Testing
+import TuistAutomation
+import TuistCache
+import TuistCI
+import TuistConfig
+import TuistConfigLoader
+import TuistCore
+import TuistGenerator
+import TuistGit
+import TuistServer
+import TuistSupport
+import TuistXCActivityLog
+import TuistXcodeBuildProducts
+import TuistXCResultService
+import XcodeGraph
+import XCResultParser
+@testable import TuistKit
+@testable import TuistTesting
+
+struct TestServiceHostlessDerivedDataTests {
+    @Test(.inTemporaryDirectory)
+    func run_uses_passthrough_derived_data_as_hostless_isolation_base() async throws {
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let harness = try TestServiceHarness(temporaryDirectory: temporaryDirectory)
+        let graph = harness.mixedHostedAndHostlessGraph(temporaryDirectory: temporaryDirectory)
+        let derivedDataPath = temporaryDirectory.appending(component: "DerivedData")
+
+        harness.stub(graph: graph)
+        given(harness.xcodeBuildArgumentParser)
+            .parse(.any)
+            .willReturn(.test(derivedDataPath: derivedDataPath))
+
+        try await harness.run(
+            path: temporaryDirectory,
+            passthroughXcodeBuildArguments: ["-derivedDataPath", derivedDataPath.pathString]
+        )
+
+        #expect(harness.testedSchemes == ["App", "Feature"])
+        #expect(harness.derivedDataPath(for: "App") == nil)
+        #expect(
+            harness.derivedDataPath(for: "Feature") == derivedDataPath
+                .appending(components: "HostlessTests", "Feature")
+        )
+    }
+
+    @Test(.inTemporaryDirectory)
+    func run_without_building_does_not_isolate_hostless_schemes() async throws {
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let harness = try TestServiceHarness(temporaryDirectory: temporaryDirectory)
+        let graph = harness.mixedHostedAndHostlessGraph(temporaryDirectory: temporaryDirectory)
+        let derivedDataPath = temporaryDirectory.appending(component: "DerivedData")
+
+        harness.stub(graph: graph)
+
+        try await harness.run(
+            path: temporaryDirectory,
+            action: .testWithoutBuilding,
+            derivedDataPath: derivedDataPath.pathString
+        )
+
+        #expect(harness.testedSchemes == ["Sample-Workspace"])
+        #expect(harness.derivedDataPath(for: "Sample-Workspace") == derivedDataPath)
+    }
+}
+
+private final class TestServiceHarness {
+    let xcodeBuildArgumentParser = MockXcodeBuildArgumentParsing()
+
+    private let generator = MockGenerating()
+    private let generatorFactory = MockGeneratorFactorying()
+    private let xcodebuildController = MockXcodeBuildControlling()
+    private let buildGraphInspector = MockBuildGraphInspecting()
+    private let simulatorController = MockSimulatorControlling()
+    private let cacheDirectoriesProvider = MockCacheDirectoriesProviding()
+    private let configLoader = MockConfigLoading()
+    private let cacheStorageFactory = MockCacheStorageFactorying()
+    private let cacheStorage = MockCacheStoring()
+    private let xcResultService = MockXCResultServicing()
+    private let uploadResultBundleService = MockUploadResultBundleServicing()
+    private let derivedDataLocator = MockDerivedDataLocating()
+    private let createTestService = MockCreateTestServicing()
+    private let gitController = MockGitControlling()
+    private let ciController = MockCIControlling()
+    private let testQuarantineService = MockTestQuarantineServicing()
+    private let testCaseListService = MockTestCaseListServicing()
+    private let serverEnvironmentService = MockServerEnvironmentServicing()
+    private let shardPlanService = MockShardPlanServicing()
+    private let shardMatrixOutputService = MockShardMatrixOutputServicing()
+    private let shardService = MockShardServicing()
+    private let xcActivityLogController = MockXCActivityLogControlling()
+    private let uploadBuildRunService = MockUploadBuildRunServicing()
+    private let runMetadataStorage = RunMetadataStorage()
+    private let testCallCaptures: TestCallCaptures
+    private let subject: TestService
+
+    var testedSchemes: [String] {
+        testCallCaptures.testedSchemes
+    }
+
+    func derivedDataPath(for scheme: String) -> AbsolutePath? {
+        testCallCaptures.derivedDataPath(for: scheme)
+    }
+
+    init(temporaryDirectory: AbsolutePath) throws {
+        let testCallCaptures = TestCallCaptures()
+        self.testCallCaptures = testCallCaptures
+
+        given(configLoader)
+            .loadConfig(path: .any)
+            .willReturn(.test(project: .testGeneratedProject()))
+        given(generatorFactory)
+            .testing(
+                config: .any,
+                testPlan: .any,
+                includedTargets: .any,
+                excludedTargets: .any,
+                skipUITests: .any,
+                skipUnitTests: .any,
+                configuration: .any,
+                ignoreBinaryCache: .any,
+                ignoreSelectiveTesting: .any,
+                cacheStorage: .any,
+                destination: .any,
+                schemeName: .any
+            )
+            .willReturn(generator)
+        given(cacheStorageFactory)
+            .cacheStorage(config: .any)
+            .willReturn(cacheStorage)
+        given(cacheStorage)
+            .store(.any, cacheCategory: .any)
+            .willReturn([])
+        given(cacheDirectoriesProvider)
+            .cacheDirectory(for: .value(.runs))
+            .willReturn(temporaryDirectory.appending(component: "runs"))
+        given(buildGraphInspector)
+            .buildArguments(project: .any, target: .any, configuration: .any, skipSigning: .any)
+            .willReturn([])
+        given(buildGraphInspector)
+            .testableTarget(
+                scheme: .any,
+                testPlan: .any,
+                testTargets: .any,
+                skipTestTargets: .any,
+                graphTraverser: .any,
+                action: .any
+            )
+            .willReturn(.test())
+        given(simulatorController)
+            .findAvailableDevice(platform: .any, version: .any, minVersion: .any, deviceName: .any)
+            .willReturn(.test())
+        given(xcodeBuildArgumentParser)
+            .parse(.any)
+            .willReturn(.test(destination: nil))
+        given(derivedDataLocator)
+            .locate(for: .any)
+            .willReturn(temporaryDirectory.appending(component: "DefaultDerivedData"))
+        given(xcResultService)
+            .parse(path: .any, rootDirectory: .any)
+            .willReturn(nil)
+        given(xcResultService)
+            .parseTestStatuses(path: .any)
+            .willReturn(TestResultStatuses(testCases: []))
+        given(testCaseListService)
+            .listAllTestCases(fullHandle: .any, serverURL: .any, state: .any)
+            .willReturn([])
+        given(testQuarantineService)
+            .markQuarantinedTests(testSummary: .any, quarantinedTests: .any)
+            .willProduce { summary, _ in summary }
+        given(testQuarantineService)
+            .onlyQuarantinedTestsFailed(testSummary: .any)
+            .willReturn(false)
+        given(testQuarantineService)
+            .onlyQuarantinedTestsFailed(testStatuses: .any, quarantinedTests: .any)
+            .willReturn(false)
+        given(serverEnvironmentService)
+            .url(configServerURL: .any)
+            .willReturn(URL(string: "https://tuist.dev")!)
+        given(shardMatrixOutputService)
+            .output(.any)
+            .willReturn()
+        given(xcActivityLogController)
+            .mostRecentActivityLogFile(projectDerivedDataDirectory: .any, filter: .any)
+            .willReturn(nil)
+        given(xcodebuildController)
+            .test(
+                .any,
+                scheme: .any,
+                clean: .any,
+                destination: .any,
+                action: .any,
+                rosetta: .any,
+                derivedDataPath: .any,
+                resultBundlePath: .any,
+                arguments: .any,
+                retryCount: .any,
+                testTargets: .any,
+                skipTestTargets: .any,
+                testPlanConfiguration: .any,
+                passthroughXcodeBuildArguments: .any
+            )
+            .willProduce { _, scheme, _, _, _, _, derivedDataPath, _, _, _, _, _, _, _ in
+                testCallCaptures.testedSchemes.append(scheme)
+                testCallCaptures.derivedDataPathCaptures.append((scheme: scheme, derivedDataPath: derivedDataPath))
+            }
+
+        subject = TestService(
+            generatorFactory: generatorFactory,
+            cacheStorageFactory: cacheStorageFactory,
+            xcodebuildController: xcodebuildController,
+            buildGraphInspector: buildGraphInspector,
+            simulatorController: simulatorController,
+            cacheDirectoriesProvider: cacheDirectoriesProvider,
+            configLoader: configLoader,
+            xcResultService: xcResultService,
+            xcodeBuildArgumentParser: xcodeBuildArgumentParser,
+            gitController: gitController,
+            uploadResultBundleService: uploadResultBundleService,
+            derivedDataLocator: derivedDataLocator,
+            createTestService: createTestService,
+            serverEnvironmentService: serverEnvironmentService,
+            ciController: ciController,
+            testQuarantineService: testQuarantineService,
+            testCaseListService: testCaseListService,
+            shardPlanService: shardPlanService,
+            shardMatrixOutputService: shardMatrixOutputService,
+            shardService: shardService,
+            xcActivityLogController: xcActivityLogController,
+            uploadBuildRunService: uploadBuildRunService
+        )
+    }
+
+    func stub(graph: MixedHostedAndHostlessGraph) {
+        given(generator)
+            .generateWithGraph(path: .any, options: .any)
+            .willProduce { path, _ in (path, graph.graph, MapperEnvironment()) }
+        given(buildGraphInspector)
+            .testableSchemes(graphTraverser: .any)
+            .willReturn([graph.appScheme, graph.featureScheme, graph.workspaceScheme])
+        given(buildGraphInspector)
+            .workspaceSchemes(graphTraverser: .any)
+            .willReturn([graph.workspaceScheme])
+    }
+
+    func run(
+        path: AbsolutePath,
+        action: XcodeBuildTestAction = .test,
+        derivedDataPath: String? = nil,
+        passthroughXcodeBuildArguments: [String] = []
+    ) async throws {
+        try await RunMetadataStorage.$current.withValue(runMetadataStorage) {
+            try await subject.run(
+                runId: "run-id",
+                schemeName: nil,
+                clean: false,
+                noUpload: false,
+                configuration: nil,
+                path: path,
+                deviceName: nil,
+                platform: nil,
+                osVersion: nil,
+                action: action,
+                rosetta: false,
+                skipUITests: false,
+                skipUnitTests: false,
+                resultBundlePath: nil,
+                derivedDataPath: derivedDataPath,
+                retryCount: 0,
+                testTargets: [],
+                skipTestTargets: [],
+                testPlanConfiguration: nil,
+                validateTestTargetsParameters: false,
+                ignoreBinaryCache: false,
+                ignoreSelectiveTesting: false,
+                generateOnly: false,
+                passthroughXcodeBuildArguments: passthroughXcodeBuildArguments,
+                skipQuarantine: false,
+                shardReference: nil,
+                shardGranularity: .module,
+                shardMin: nil,
+                shardMax: nil,
+                shardTotal: nil,
+                shardMaxDuration: nil,
+                shardIndex: nil,
+                shardSkipUpload: false,
+                shardArchivePath: nil,
+                mode: .local
+            )
+        }
+    }
+
+    func mixedHostedAndHostlessGraph(temporaryDirectory: AbsolutePath) -> MixedHostedAndHostlessGraph {
+        let appProjectPath = temporaryDirectory.appending(component: "App")
+        let featureProjectPath = temporaryDirectory.appending(component: "Feature")
+        let app = Target.test(name: "App", product: .app)
+        let appTests = Target.test(name: "AppTests", product: .unitTests)
+        let feature = Target.test(name: "Feature", product: .framework)
+        let featureTests = Target.test(name: "FeatureTests", product: .unitTests)
+        let appTestsReference = TargetReference(projectPath: appProjectPath, name: appTests.name)
+        let featureTestsReference = TargetReference(projectPath: featureProjectPath, name: featureTests.name)
+        let appReference = TargetReference(projectPath: appProjectPath, name: app.name)
+        let featureReference = TargetReference(projectPath: featureProjectPath, name: feature.name)
+        let appScheme = Scheme.test(
+            name: "App",
+            buildAction: .test(targets: [appReference]),
+            testAction: .test(targets: [.test(target: appTestsReference)]),
+            runAction: nil,
+            archiveAction: nil,
+            profileAction: nil
+        )
+        let featureScheme = Scheme.test(
+            name: "Feature",
+            buildAction: .test(targets: [featureReference]),
+            testAction: .test(targets: [.test(target: featureTestsReference)]),
+            runAction: nil,
+            archiveAction: nil,
+            profileAction: nil
+        )
+        let workspaceScheme = Scheme.test(
+            name: "Sample-Workspace",
+            testAction: .test(
+                targets: [
+                    .test(target: appTestsReference),
+                    .test(target: featureTestsReference),
+                ]
+            )
+        )
+        let appProject = Project.test(
+            path: appProjectPath,
+            targets: [app, appTests],
+            schemes: [appScheme]
+        )
+        let featureProject = Project.test(
+            path: featureProjectPath,
+            targets: [feature, featureTests],
+            schemes: [featureScheme]
+        )
+        let graph = Graph.test(
+            workspace: .test(
+                name: "Sample",
+                projects: [appProjectPath, featureProjectPath],
+                schemes: [workspaceScheme]
+            ),
+            projects: [
+                appProjectPath: appProject,
+                featureProjectPath: featureProject,
+            ],
+            dependencies: [
+                .target(name: appTests.name, path: appProjectPath): [
+                    .target(name: app.name, path: appProjectPath),
+                ],
+                .target(name: featureTests.name, path: featureProjectPath): [
+                    .target(name: feature.name, path: featureProjectPath),
+                ],
+            ]
+        )
+
+        return MixedHostedAndHostlessGraph(
+            graph: graph,
+            appScheme: appScheme,
+            featureScheme: featureScheme,
+            workspaceScheme: workspaceScheme
+        )
+    }
+}
+
+private final class TestCallCaptures {
+    var testedSchemes: [String] = []
+    var derivedDataPathCaptures: [(scheme: String, derivedDataPath: AbsolutePath?)] = []
+
+    func derivedDataPath(for scheme: String) -> AbsolutePath? {
+        derivedDataPathCaptures.first { $0.scheme == scheme }?.derivedDataPath ?? nil
+    }
+}
+
+private struct MixedHostedAndHostlessGraph {
+    let graph: Graph
+    let appScheme: Scheme
+    let featureScheme: Scheme
+    let workspaceScheme: Scheme
+}


### PR DESCRIPTION
### Context

> [!NOTE]
> This is AI  PR - review with care :) 
> I did review it myself 

Follow-up to #11225 and the community report: https://community.tuist.dev/t/tuist-test-runs-host-less-module-unit-tests-in-the-app-launch-context-xctest-crashes-at-bootstrap/

#11225 made bare `tuist test` split a mixed workspace scheme so host-less unit tests run through their own generated project scheme instead of the app-launch aggregate. The split fixed the *scheme*, but not the *build-products directory*.

I tested `4.201.0-rc.3` against a minimal repro (app links point-free `swift-sharing` as a dynamic framework, plus a Foundation-only framework module with a host-less `.unitTests` bundle). `AppTests` runs via the App scheme, then the host-less bundle runs via the `Feature` scheme, and it still crashes with the same `exit 65`:

```
xctest encountered an error (Early unexpected exit, operation never finished bootstrapping ...
The test runner crashed while preparing to run tests: xctest at <external symbol>)
** TEST FAILED **
```

### Root cause

For bare `tuist test`, `derivedDataPath` is `nil`, so every split scheme resolves to the same per-workspace derived data. The hosted scheme runs first and populates `Build/Products/Debug-iphonesimulator` with the app's frameworks (`Sharing.framework` and its closure). The host-less `Feature` scheme then runs into that same directory, the host-less process `dlopen`s those frameworks at test discovery, and hits the Apple XCTest class-realization segfault.

Running the exact same `Feature` scheme into a clean, isolated derived data passes, which isolates the products directory as the variable:

```bash
xcodebuild test -scheme Feature -workspace Sample.xcworkspace \
  -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.4' \
  -derivedDataPath /tmp/clean-dd
# ** TEST SUCCEEDED **
```

### Change

When `tuist test` splits a mixed workspace scheme, run each split host-less scheme against its own derived data so its products directory does not contain the app's frameworks. Only host-less schemes are isolated; the hosted scheme keeps the shared derived data and its incremental builds. An explicit `--derived-data-path` is honored by nesting under it.

### Trade-offs

- The host-less module subtree builds fresh into the isolated directory. That is the module subtree, not the whole app, and correctness beats reuse here.
- Binary cache / selective-testing hashing is unaffected; only build reuse for the isolated scheme changes.

