### PR TITLE
fix(server): Ran by filters for automated dashboard runs

### DIFF
--- a/server/lib/tuist_web/live/cache_runs_live.ex
+++ b/server/lib/tuist_web/live/cache_runs_live.ex
@@ -292,6 +292,12 @@ defmodule TuistWeb.CacheRunsLive do
         %{value: :ci, operator: op} ->
           [%{field: :is_ci, op: op, value: true}]
 
+        %{value: value, operator: :==} when not is_nil(value) ->
+          [
+            %{field: :is_ci, op: :==, value: false},
+            %{field: :user_id, op: :==, value: value}
+          ]
+
         %{value: value, operator: op} when not is_nil(value) ->
           [%{field: :user_id, op: op, value: value}]
 

--- a/server/lib/tuist_web/live/generate_runs_live.ex
+++ b/server/lib/tuist_web/live/generate_runs_live.ex
@@ -205,6 +205,12 @@ defmodule TuistWeb.GenerateRunsLive do
         %{value: :ci, operator: op} ->
           [%{field: :is_ci, op: op, value: true}]
 
+        %{value: value, operator: :==} when not is_nil(value) ->
+          [
+            %{field: :is_ci, op: :==, value: false},
+            %{field: :user_id, op: :==, value: value}
+          ]
+
         %{value: value, operator: op} when not is_nil(value) ->
           [%{field: :user_id, op: op, value: value}]
 

--- a/server/lib/tuist_web/live/gradle_build_runs_live.ex
+++ b/server/lib/tuist_web/live/gradle_build_runs_live.ex
@@ -121,6 +121,12 @@ defmodule TuistWeb.GradleBuildRunsLive do
         %{value: :ci, operator: op} ->
           [%{field: :is_ci, op: op, value: true}]
 
+        %{value: value, operator: :==} when not is_nil(value) ->
+          [
+            %{field: :is_ci, op: :==, value: false},
+            %{field: :account_id, op: :==, value: value}
+          ]
+
         %{value: value, operator: op} when not is_nil(value) ->
           [%{field: :account_id, op: op, value: value}]
 

--- a/server/lib/tuist_web/live/test_case_live.ex
+++ b/server/lib/tuist_web/live/test_case_live.ex
@@ -419,7 +419,10 @@ defmodule TuistWeb.TestCaseLive do
           [%{field: :is_ci, op: :==, value: true}]
 
         %{id: "ran_by", value: value, operator: :==} when not is_nil(value) ->
-          [%{field: :account_id, op: :==, value: value}]
+          [
+            %{field: :is_ci, op: :==, value: false},
+            %{field: :account_id, op: :==, value: value}
+          ]
 
         %{field: field, operator: op, value: value} when not is_nil(value) and value != "" ->
           [%{field: field, op: op, value: value}]

--- a/server/lib/tuist_web/live/test_runs_live.ex
+++ b/server/lib/tuist_web/live/test_runs_live.ex
@@ -425,6 +425,12 @@ defmodule TuistWeb.TestRunsLive do
         %{value: :ci, operator: op} ->
           [%{field: :is_ci, op: op, value: true}]
 
+        %{value: value, operator: :==} when not is_nil(value) ->
+          [
+            %{field: :is_ci, op: :==, value: false},
+            %{field: :account_id, op: :==, value: value}
+          ]
+
         %{value: value, operator: op} when not is_nil(value) ->
           [%{field: :account_id, op: op, value: value}]
 

--- a/server/lib/tuist_web/live/xcode_build_runs_live.ex
+++ b/server/lib/tuist_web/live/xcode_build_runs_live.ex
@@ -178,6 +178,12 @@ defmodule TuistWeb.XcodeBuildRunsLive do
         %{value: :ci, operator: op} ->
           [%{field: :is_ci, op: op, value: true}]
 
+        %{value: value, operator: :==} when not is_nil(value) ->
+          [
+            %{field: :is_ci, op: :==, value: false},
+            %{field: :account_id, op: :==, value: value}
+          ]
+
         %{value: value, operator: op} when not is_nil(value) ->
           [%{field: :account_id, op: op, value: value}]
 

--- a/server/priv/gettext/dashboard_builds.pot
+++ b/server/priv/gettext/dashboard_builds.pot
@@ -69,9 +69,9 @@ msgstr ""
 msgid "Avg. latency writing cache keys"
 msgstr ""
 
-#: lib/tuist_web/live/generate_runs_live.ex:287
+#: lib/tuist_web/live/generate_runs_live.ex:293
 #: lib/tuist_web/live/generate_runs_live.html.heex:84
-#: lib/tuist_web/live/xcode_build_runs_live.ex:246
+#: lib/tuist_web/live/xcode_build_runs_live.ex:252
 #: lib/tuist_web/live/xcode_build_runs_live.html.heex:121
 #, elixir-autogen, elixir-format
 msgid "Branch"
@@ -272,7 +272,7 @@ msgid "Cacheable tasks:"
 msgstr ""
 
 #: lib/tuist_web/live/build_run_live.html.heex:286
-#: lib/tuist_web/live/xcode_build_runs_live.ex:254
+#: lib/tuist_web/live/xcode_build_runs_live.ex:260
 #: lib/tuist_web/live/xcode_build_runs_live.html.heex:151
 #: lib/tuist_web/live/xcode_builds_live.ex:435
 #: lib/tuist_web/live/xcode_builds_live.html.heex:357
@@ -281,14 +281,14 @@ msgstr ""
 msgid "Category"
 msgstr ""
 
-#: lib/tuist_web/live/xcode_build_runs_live.ex:259
+#: lib/tuist_web/live/xcode_build_runs_live.ex:265
 #: lib/tuist_web/live/xcode_builds_live.html.heex:105
 #, elixir-autogen, elixir-format
 msgid "Clean"
 msgstr ""
 
 #: lib/tuist_web/live/build_run_live.html.heex:209
-#: lib/tuist_web/live/generate_runs_live.ex:266
+#: lib/tuist_web/live/generate_runs_live.ex:272
 #: lib/tuist_web/live/generate_runs_live.html.heex:58
 #: lib/tuist_web/live/run_detail_live.html.heex:115
 #, elixir-autogen, elixir-format
@@ -327,7 +327,7 @@ msgid "Compressed Size (MB)"
 msgstr ""
 
 #: lib/tuist_web/live/build_run_live.html.heex:224
-#: lib/tuist_web/live/xcode_build_runs_live.ex:221
+#: lib/tuist_web/live/xcode_build_runs_live.ex:227
 #: lib/tuist_web/live/xcode_build_runs_live.html.heex:91
 #, elixir-autogen, elixir-format
 msgid "Configuration"
@@ -452,10 +452,10 @@ msgstr ""
 #: lib/tuist_web/live/build_run_live.ex:963
 #: lib/tuist_web/live/build_run_live.html.heex:245
 #: lib/tuist_web/live/build_run_live.html.heex:581
-#: lib/tuist_web/live/generate_runs_live.ex:279
+#: lib/tuist_web/live/generate_runs_live.ex:285
 #: lib/tuist_web/live/generate_runs_live.html.heex:81
 #: lib/tuist_web/live/run_detail_live.html.heex:144
-#: lib/tuist_web/live/xcode_build_runs_live.ex:236
+#: lib/tuist_web/live/xcode_build_runs_live.ex:242
 #: lib/tuist_web/live/xcode_build_runs_live.html.heex:107
 #: lib/tuist_web/live/xcode_builds_live.ex:446
 #: lib/tuist_web/live/xcode_builds_live.html.heex:864
@@ -608,13 +608,13 @@ msgid "Hit"
 msgstr ""
 
 #: lib/tuist_web/live/build_run_live.html.heex:853
-#: lib/tuist_web/live/generate_runs_live.ex:295
+#: lib/tuist_web/live/generate_runs_live.ex:301
 #: lib/tuist_web/live/generate_runs_live.html.heex:61
 #, elixir-autogen, elixir-format
 msgid "Hit rate"
 msgstr ""
 
-#: lib/tuist_web/live/xcode_build_runs_live.ex:258
+#: lib/tuist_web/live/xcode_build_runs_live.ex:264
 #: lib/tuist_web/live/xcode_builds_live.html.heex:97
 #, elixir-autogen, elixir-format
 msgid "Incremental"
@@ -763,10 +763,10 @@ msgstr ""
 #: lib/tuist_web/live/build_run_live.ex:962
 #: lib/tuist_web/live/build_run_live.html.heex:238
 #: lib/tuist_web/live/build_run_live.html.heex:576
-#: lib/tuist_web/live/generate_runs_live.ex:278
+#: lib/tuist_web/live/generate_runs_live.ex:284
 #: lib/tuist_web/live/generate_runs_live.html.heex:79
 #: lib/tuist_web/live/run_detail_live.html.heex:137
-#: lib/tuist_web/live/xcode_build_runs_live.ex:235
+#: lib/tuist_web/live/xcode_build_runs_live.ex:241
 #: lib/tuist_web/live/xcode_build_runs_live.html.heex:102
 #: lib/tuist_web/live/xcode_builds_live.ex:445
 #: lib/tuist_web/live/xcode_builds_live.html.heex:859
@@ -813,10 +813,10 @@ msgstr ""
 msgid "Ran at"
 msgstr ""
 
-#: lib/tuist_web/live/generate_runs_live.ex:322
+#: lib/tuist_web/live/generate_runs_live.ex:328
 #: lib/tuist_web/live/generate_runs_live.html.heex:87
 #: lib/tuist_web/live/run_detail_live.html.heex:152
-#: lib/tuist_web/live/xcode_build_runs_live.ex:314
+#: lib/tuist_web/live/xcode_build_runs_live.ex:320
 #: lib/tuist_web/live/xcode_build_runs_live.html.heex:130
 #: lib/tuist_web/live/xcode_builds_live.html.heex:876
 #, elixir-autogen, elixir-format
@@ -856,7 +856,7 @@ msgstr ""
 msgid "Run duration"
 msgstr ""
 
-#: lib/tuist_web/live/xcode_build_runs_live.ex:210
+#: lib/tuist_web/live/xcode_build_runs_live.ex:216
 #: lib/tuist_web/live/xcode_build_runs_live.html.heex:58
 #: lib/tuist_web/live/xcode_builds_live.ex:432
 #: lib/tuist_web/live/xcode_builds_live.html.heex:355
@@ -921,9 +921,9 @@ msgstr ""
 #: lib/tuist_web/live/build_run_live.ex:1104
 #: lib/tuist_web/live/build_run_live.html.heex:235
 #: lib/tuist_web/live/build_run_live.html.heex:1527
-#: lib/tuist_web/live/generate_runs_live.ex:274
+#: lib/tuist_web/live/generate_runs_live.ex:280
 #: lib/tuist_web/live/run_detail_live.html.heex:134
-#: lib/tuist_web/live/xcode_build_runs_live.ex:231
+#: lib/tuist_web/live/xcode_build_runs_live.ex:237
 #: lib/tuist_web/live/xcode_builds_live.ex:433
 #, elixir-autogen, elixir-format
 msgid "Status"
@@ -1235,7 +1235,7 @@ msgid "Xcode Cache"
 msgstr ""
 
 #: lib/tuist_web/live/build_run_live.html.heex:308
-#: lib/tuist_web/live/xcode_build_runs_live.ex:267
+#: lib/tuist_web/live/xcode_build_runs_live.ex:273
 #: lib/tuist_web/live/xcode_build_runs_live.html.heex:171
 #: lib/tuist_web/live/xcode_builds_live.ex:388
 #: lib/tuist_web/live/xcode_builds_live.html.heex:621
@@ -1246,7 +1246,7 @@ msgstr ""
 
 #: lib/tuist_web/live/build_run_live.html.heex:314
 #: lib/tuist_web/live/run_detail_live.html.heex:202
-#: lib/tuist_web/live/xcode_build_runs_live.ex:275
+#: lib/tuist_web/live/xcode_build_runs_live.ex:281
 #: lib/tuist_web/live/xcode_build_runs_live.html.heex:179
 #: lib/tuist_web/live/xcode_builds_live.ex:389
 #: lib/tuist_web/live/xcode_builds_live.html.heex:639
@@ -1382,7 +1382,7 @@ msgstr ""
 msgid "since yesterday"
 msgstr ""
 
-#: lib/tuist_web/live/generate_runs_live.ex:303
+#: lib/tuist_web/live/generate_runs_live.ex:309
 #: lib/tuist_web/live/run_detail_live.html.heex:125
 #, elixir-autogen, elixir-format
 msgid "Cache Endpoint"
@@ -1409,7 +1409,7 @@ msgstr ""
 msgid "Tag:"
 msgstr ""
 
-#: lib/tuist_web/live/xcode_build_runs_live.ex:290
+#: lib/tuist_web/live/xcode_build_runs_live.ex:296
 #, elixir-autogen, elixir-format
 msgid "Tags"
 msgstr ""
@@ -1431,14 +1431,14 @@ msgid "Download build"
 msgstr ""
 
 #: lib/tuist_web/live/build_run_live.html.heex:252
-#: lib/tuist_web/live/xcode_build_runs_live.ex:238
+#: lib/tuist_web/live/xcode_build_runs_live.ex:244
 #: lib/tuist_web/live/xcode_build_runs_live.html.heex:117
 #, elixir-autogen, elixir-format
 msgid "Failed processing"
 msgstr ""
 
 #: lib/tuist_web/live/build_run_live.html.heex:258
-#: lib/tuist_web/live/xcode_build_runs_live.ex:237
+#: lib/tuist_web/live/xcode_build_runs_live.ex:243
 #: lib/tuist_web/live/xcode_build_runs_live.html.heex:112
 #, elixir-autogen, elixir-format
 msgid "Processing"

--- a/server/priv/gettext/dashboard_gradle.pot
+++ b/server/priv/gettext/dashboard_gradle.pot
@@ -62,7 +62,7 @@ msgid "Avg. cache hit rate"
 msgstr ""
 
 #: lib/tuist_web/live/gradle_build_live.html.heex:134
-#: lib/tuist_web/live/gradle_build_runs_live.ex:233
+#: lib/tuist_web/live/gradle_build_runs_live.ex:239
 #: lib/tuist_web/live/gradle_build_runs_live.html.heex:89
 #, elixir-autogen, elixir-format
 msgid "Branch"
@@ -79,7 +79,7 @@ msgstr ""
 msgid "Build not found."
 msgstr ""
 
-#: lib/tuist_web/live/gradle_build_runs_live.ex:253
+#: lib/tuist_web/live/gradle_build_runs_live.ex:259
 #: lib/tuist_web/live/gradle_builds_live.ex:177
 #: lib/tuist_web/live/gradle_builds_live.html.heex:26
 #: lib/tuist_web/live/gradle_cache_live.ex:208
@@ -158,7 +158,7 @@ msgid "Cancel"
 msgstr ""
 
 #: lib/tuist_web/live/gradle_build_live.html.heex:100
-#: lib/tuist_web/live/gradle_build_runs_live.ex:225
+#: lib/tuist_web/live/gradle_build_runs_live.ex:231
 #: lib/tuist_web/live/gradle_build_runs_live.html.heex:85
 #: lib/tuist_web/live/gradle_builds_live.html.heex:682
 #, elixir-autogen, elixir-format
@@ -202,7 +202,7 @@ msgstr ""
 
 #: lib/tuist_web/live/gradle_build_live.ex:246
 #: lib/tuist_web/live/gradle_build_live.ex:329
-#: lib/tuist_web/live/gradle_build_runs_live.ex:224
+#: lib/tuist_web/live/gradle_build_runs_live.ex:230
 #: lib/tuist_web/live/gradle_build_runs_live.html.heex:80
 #: lib/tuist_web/live/gradle_builds_live.html.heex:677
 #, elixir-autogen, elixir-format
@@ -358,7 +358,7 @@ msgstr ""
 #: lib/tuist_web/live/gradle_build_live.ex:282
 #: lib/tuist_web/live/gradle_build_live.html.heex:83
 #: lib/tuist_web/live/gradle_build_live.html.heex:593
-#: lib/tuist_web/live/gradle_build_runs_live.ex:219
+#: lib/tuist_web/live/gradle_build_runs_live.ex:225
 #: lib/tuist_web/live/gradle_build_runs_live.html.heex:72
 #, elixir-autogen, elixir-format
 msgid "Status"
@@ -481,7 +481,7 @@ msgstr ""
 #: lib/tuist_web/live/gradle_build_live.ex:286
 #: lib/tuist_web/live/gradle_build_live.html.heex:439
 #: lib/tuist_web/live/gradle_build_live.html.heex:596
-#: lib/tuist_web/live/gradle_build_runs_live.ex:254
+#: lib/tuist_web/live/gradle_build_runs_live.ex:260
 #: lib/tuist_web/live/gradle_builds_live.ex:176
 #: lib/tuist_web/live/gradle_builds_live.html.heex:18
 #: lib/tuist_web/live/gradle_cache_live.ex:207
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Configuration Insights"
 msgstr ""
 
-#: lib/tuist_web/live/gradle_build_runs_live.ex:249
+#: lib/tuist_web/live/gradle_build_runs_live.ex:255
 #: lib/tuist_web/live/gradle_cache_live.ex:234
 #: lib/tuist_web/live/gradle_cache_live.html.heex:288
 #, elixir-autogen, elixir-format
@@ -755,14 +755,14 @@ msgstr ""
 msgid "Failed builds"
 msgstr ""
 
-#: lib/tuist_web/live/gradle_build_runs_live.ex:262
+#: lib/tuist_web/live/gradle_build_runs_live.ex:268
 #: lib/tuist_web/live/gradle_builds_live.ex:241
 #: lib/tuist_web/live/gradle_builds_live.html.heex:470
 #, elixir-autogen, elixir-format
 msgid "Gradle version"
 msgstr ""
 
-#: lib/tuist_web/live/gradle_build_runs_live.ex:270
+#: lib/tuist_web/live/gradle_build_runs_live.ex:276
 #: lib/tuist_web/live/gradle_builds_live.ex:240
 #: lib/tuist_web/live/gradle_builds_live.html.heex:480
 #, elixir-autogen, elixir-format
@@ -789,7 +789,7 @@ msgstr ""
 msgid "No recent builds yet"
 msgstr ""
 
-#: lib/tuist_web/live/gradle_build_runs_live.ex:223
+#: lib/tuist_web/live/gradle_build_runs_live.ex:229
 #: lib/tuist_web/live/gradle_build_runs_live.html.heex:75
 #: lib/tuist_web/live/gradle_builds_live.html.heex:672
 #, elixir-autogen, elixir-format
@@ -900,7 +900,7 @@ msgid "Tests"
 msgstr ""
 
 #: lib/tuist_web/live/gradle_build_live.html.heex:147
-#: lib/tuist_web/live/gradle_build_runs_live.ex:241
+#: lib/tuist_web/live/gradle_build_runs_live.ex:247
 #: lib/tuist_web/live/gradle_build_runs_live.html.heex:98
 #, elixir-autogen, elixir-format
 msgid "Requested tasks"
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Machine Metrics"
 msgstr ""
 
-#: lib/tuist_web/live/gradle_build_runs_live.ex:287
+#: lib/tuist_web/live/gradle_build_runs_live.ex:293
 #, elixir-autogen, elixir-format
 msgid "Ran by"
 msgstr ""

--- a/server/priv/gettext/dashboard_tests.pot
+++ b/server/priv/gettext/dashboard_tests.pot
@@ -63,7 +63,7 @@ msgstr ""
 msgid "Attachments"
 msgstr ""
 
-#: lib/tuist_web/live/test_case_live.ex:500
+#: lib/tuist_web/live/test_case_live.ex:503
 #, elixir-autogen, elixir-format
 msgid "Automatically by Tuist"
 msgstr ""
@@ -282,7 +282,7 @@ msgstr ""
 msgid "Environment:"
 msgstr ""
 
-#: lib/tuist_web/live/test_case_live.ex:493
+#: lib/tuist_web/live/test_case_live.ex:496
 #, elixir-autogen, elixir-format
 msgid "Event"
 msgstr ""
@@ -434,7 +434,7 @@ msgstr ""
 msgid "Filter"
 msgstr ""
 
-#: lib/tuist_web/live/test_case_live.ex:486
+#: lib/tuist_web/live/test_case_live.ex:489
 #, elixir-autogen, elixir-format
 msgid "First run of this test"
 msgstr ""
@@ -645,7 +645,7 @@ msgstr ""
 msgid "Mac device"
 msgstr ""
 
-#: lib/tuist_web/live/test_case_live.ex:502
+#: lib/tuist_web/live/test_case_live.ex:505
 #, elixir-autogen, elixir-format
 msgid "Manually by @%{name}"
 msgstr ""
@@ -655,7 +655,7 @@ msgstr ""
 msgid "Mark as flaky"
 msgstr ""
 
-#: lib/tuist_web/live/test_case_live.ex:487
+#: lib/tuist_web/live/test_case_live.ex:490
 #, elixir-autogen, elixir-format
 msgid "Marked as flaky"
 msgstr ""
@@ -998,8 +998,8 @@ msgstr ""
 #: lib/tuist_web/live/quarantined_tests_live.html.heex:383
 #: lib/tuist_web/live/shards_live.html.heex:583
 #: lib/tuist_web/live/test_case_live.ex:96
-#: lib/tuist_web/live/test_case_live.ex:461
-#: lib/tuist_web/live/test_case_live.ex:491
+#: lib/tuist_web/live/test_case_live.ex:464
+#: lib/tuist_web/live/test_case_live.ex:494
 #: lib/tuist_web/live/test_case_live.html.heex:84
 #: lib/tuist_web/live/test_case_live.html.heex:170
 #: lib/tuist_web/live/test_case_live.html.heex:546
@@ -1350,7 +1350,7 @@ msgstr ""
 msgid "Unmark as flaky"
 msgstr ""
 
-#: lib/tuist_web/live/test_case_live.ex:488
+#: lib/tuist_web/live/test_case_live.ex:491
 #, elixir-autogen, elixir-format
 msgid "Unmarked as flaky"
 msgstr ""
@@ -1692,9 +1692,9 @@ msgstr ""
 msgid "The 10,000 entry limit has been reached, data is only included up to %{date}. Try filtering to narrow down the dataset."
 msgstr ""
 
-#: lib/tuist_web/live/test_case_live.ex:462
-#: lib/tuist_web/live/test_case_live.ex:490
-#: lib/tuist_web/live/test_case_live.ex:492
+#: lib/tuist_web/live/test_case_live.ex:465
+#: lib/tuist_web/live/test_case_live.ex:493
+#: lib/tuist_web/live/test_case_live.ex:495
 #: lib/tuist_web/live/test_case_live.html.heex:66
 #, elixir-autogen, elixir-format
 msgid "Enabled"
@@ -1713,8 +1713,8 @@ msgstr ""
 
 #: lib/tuist_web/live/quarantined_tests_live.ex:63
 #: lib/tuist_web/live/quarantined_tests_live.html.heex:340
-#: lib/tuist_web/live/test_case_live.ex:460
-#: lib/tuist_web/live/test_case_live.ex:489
+#: lib/tuist_web/live/test_case_live.ex:463
+#: lib/tuist_web/live/test_case_live.ex:492
 #: lib/tuist_web/live/test_case_live.html.heex:75
 #: lib/tuist_web/live/test_cases_live.ex:75
 #: lib/tuist_web/live/test_cases_live.html.heex:572
@@ -1792,7 +1792,7 @@ msgstr ""
 msgid "Skipped tests"
 msgstr ""
 
-#: lib/tuist_web/live/test_case_live.ex:498
+#: lib/tuist_web/live/test_case_live.ex:501
 #, elixir-autogen, elixir-format
 msgid "By automation %{name}"
 msgstr ""

--- a/server/test/tuist_web/live/build_runs_live_test.exs
+++ b/server/test/tuist_web/live/build_runs_live_test.exs
@@ -90,6 +90,36 @@ defmodule TuistWeb.BuildRunsLiveTest do
     refute has_element?(lv, "[data-part='build-runs-table'] span", "Framework")
   end
 
+  test "filters build runs by ran_by user without including continuous integration runs", %{
+    conn: conn,
+    user: user,
+    organization: organization,
+    project: project
+  } do
+    RunsFixtures.build_fixture(
+      project_id: project.id,
+      user_id: user.account.id,
+      scheme: "local-user-build",
+      is_ci: false
+    )
+
+    RunsFixtures.build_fixture(
+      project_id: project.id,
+      user_id: user.account.id,
+      scheme: "ci-user-build",
+      is_ci: true
+    )
+
+    {:ok, lv, _html} =
+      live(
+        conn,
+        ~p"/#{organization.account.name}/#{project.name}/builds/build-runs?filter_ran_by_op===&filter_ran_by_val=#{user.account.id}"
+      )
+
+    assert has_element?(lv, "[data-part='build-runs-table'] span", "local-user-build")
+    refute has_element?(lv, "[data-part='build-runs-table'] span", "ci-user-build")
+  end
+
   test "filters build runs whose branch does not contain a substring", %{
     conn: conn,
     organization: organization,

--- a/server/test/tuist_web/live/cache_runs_live_test.exs
+++ b/server/test/tuist_web/live/cache_runs_live_test.exs
@@ -134,6 +134,14 @@ defmodule TuistWeb.CacheRunsLiveTest do
         command_arguments: ["cache", "OtherUserApp"]
       )
 
+      CommandEventsFixtures.command_event_fixture(
+        project_id: project.id,
+        user_id: user.id,
+        name: "cache",
+        command_arguments: ["cache", "ContinuousIntegrationUserApp"],
+        is_ci: true
+      )
+
       {:ok, lv, _html} =
         live(
           conn,
@@ -142,6 +150,7 @@ defmodule TuistWeb.CacheRunsLiveTest do
 
       assert has_element?(lv, "span", "tuist cache UserApp")
       refute has_element?(lv, "span", "tuist cache OtherUserApp")
+      refute has_element?(lv, "span", "tuist cache ContinuousIntegrationUserApp")
     end
 
     test "filters cache runs by displayed command", %{

--- a/server/test/tuist_web/live/generate_runs_live_test.exs
+++ b/server/test/tuist_web/live/generate_runs_live_test.exs
@@ -128,6 +128,14 @@ defmodule TuistWeb.GenerateRunsLiveTest do
         command_arguments: ["generate", "OtherUserApp"]
       )
 
+      CommandEventsFixtures.command_event_fixture(
+        project_id: project.id,
+        user_id: user.id,
+        name: "generate",
+        command_arguments: ["generate", "ContinuousIntegrationUserApp"],
+        is_ci: true
+      )
+
       {:ok, lv, _html} =
         live(
           conn,
@@ -136,6 +144,7 @@ defmodule TuistWeb.GenerateRunsLiveTest do
 
       assert has_element?(lv, "span", "generate UserApp")
       refute has_element?(lv, "span", "generate OtherUserApp")
+      refute has_element?(lv, "span", "generate ContinuousIntegrationUserApp")
     end
 
     test "filters generate runs by displayed command", %{

--- a/server/test/tuist_web/live/gradle_build_runs_live_test.exs
+++ b/server/test/tuist_web/live/gradle_build_runs_live_test.exs
@@ -178,6 +178,13 @@ defmodule TuistWeb.GradleBuildRunsLiveTest do
       is_ci: false
     )
 
+    GradleFixtures.build_fixture(
+      project_id: project.id,
+      account_id: user.account.id,
+      root_project_name: "user-continuous-integration-build",
+      is_ci: true
+    )
+
     {:ok, lv, _html} =
       live(
         conn,
@@ -186,6 +193,7 @@ defmodule TuistWeb.GradleBuildRunsLiveTest do
 
     assert has_element?(lv, "span", "user-build")
     refute has_element?(lv, "span", "other-user-build")
+    refute has_element?(lv, "span", "user-continuous-integration-build")
   end
 
   test "filters build runs by ran_by CI", %{


### PR DESCRIPTION
## What changed

This updates the dashboard `Ran by` filters so choosing a user only returns local runs for that user. Automated continuous integration rows keep using the dedicated continuous integration option instead of appearing under a user when they carry the same account or user identifier.

The same filter semantics now apply across Xcode build runs, Gradle build runs, generate runs, cache runs, test runs, and test-case run listings. The change also adds regression coverage for the visible build-runs issue and strengthens the sibling filters that already had user-filter tests.

## Why

The filter is expected to answer who initiated a run. Mixing automated rows into a user-filtered result makes the table harder to trust, especially when the user is checking whether a specific person ran something locally.

## Root cause

The user branch of the filter only matched the selected account identifier. It did not also require the row to be a local, non-automated run, so automated rows associated with the same account could pass the filter.

## Approach

The existing filter model stays in place. The user filter path now adds the same non-automated constraint everywhere the dashboard supports `Ran by`, while the dedicated continuous integration filter remains responsible for automated rows.

This keeps the fix close to the query layer and avoids changing table rendering, badges, or how filter values are encoded in the address bar.

## Impact

Dashboard users get cleaner `Ran by` results. Automated rows remain visible through the continuous integration option. There are no database, migration, or data export changes.

## Validation

- `mix test test/tuist_web/live/build_runs_live_test.exs:93`
  - Reproduced the bug before the fix: the automated row was still visible for a user filter.
- `mix test test/tuist_web/live/build_runs_live_test.exs:93 test/tuist_web/live/gradle_build_runs_live_test.exs:158 test/tuist_web/live/generate_runs_live_test.exs:108 test/tuist_web/live/cache_runs_live_test.exs:114`
  - Passed after the fix.
- `git diff --check`
  - Passed.
- Headless Chrome browser verification against a local test server:
  - Before: the filtered table showed both `browser-local-user-build` and `browser-continuous-integration-build`.
  - After: the same filtered table showed `browser-local-user-build` and did not show `browser-continuous-integration-build`.

## Screenshots

Before, the user filter still included the automated row:

![Before screenshot showing both local and automated rows](https://gist.githubusercontent.com/pepicrft/c1698f684230e58ecad4aecebde0842d/raw/ran-by-filter-before.png)

After, the same user filter only includes the local row:

![After screenshot showing only the local row](https://gist.githubusercontent.com/pepicrft/c1698f684230e58ecad4aecebde0842d/raw/ran-by-filter-after.png)
