### PR TITLE
fix: print test dashboard URL when run metadata upload fails

### DIFF
--- a/cli/Sources/TuistKit/Commands/TrackableCommand/TrackableCommand.swift
+++ b/cli/Sources/TuistKit/Commands/TrackableCommand/TrackableCommand.swift
@@ -232,10 +232,25 @@ public class TrackableCommand {
             }
         } catch let error as ClientError {
             Logger.current.warning("Failed to upload run metadata: \(String(describing: error.underlyingError))")
+            await logFallbackTestRunURLIfAvailable(
+                fullHandle: fullHandle,
+                serverURL: serverURL,
+                runMetadataStorage: runMetadataStorage
+            )
         } catch let error as TrackableCommandUploadError {
             Logger.current.warning("Failed to upload run metadata: \(error.localizedDescription)")
+            await logFallbackTestRunURLIfAvailable(
+                fullHandle: fullHandle,
+                serverURL: serverURL,
+                runMetadataStorage: runMetadataStorage
+            )
         } catch {
             Logger.current.warning("Failed to upload run metadata: \(String(describing: error))")
+            await logFallbackTestRunURLIfAvailable(
+                fullHandle: fullHandle,
+                serverURL: serverURL,
+                runMetadataStorage: runMetadataStorage
+            )
         }
     }
 
@@ -272,6 +287,45 @@ public class TrackableCommand {
             throw TrackableCommandUploadError.bestEffortUploadTimedOut
         }
         return serverCommandEvent
+    }
+
+    private func logFallbackTestRunURLIfAvailable(
+        fullHandle: String,
+        serverURL: URL,
+        runMetadataStorage: RunMetadataStorage
+    ) async {
+        guard let testRunId = await runMetadataStorage.testRunId,
+              let testRunURL = testRunURL(
+                  fullHandle: fullHandle,
+                  serverURL: serverURL,
+                  testRunId: testRunId
+              )
+        else { return }
+
+        Logger.current.info("View the analyzed test at \(testRunURL.absoluteString)")
+    }
+
+    private func testRunURL(
+        fullHandle: String,
+        serverURL: URL,
+        testRunId: String
+    ) -> URL? {
+        let parts = fullHandle.split(
+            separator: "/",
+            maxSplits: 1,
+            omittingEmptySubsequences: true
+        )
+        guard parts.count == 2 else { return nil }
+
+        let accountHandle = String(parts[0])
+        let projectHandle = String(parts[1])
+
+        return serverURL
+            .appendingPathComponent(accountHandle)
+            .appendingPathComponent(projectHandle)
+            .appendingPathComponent("tests")
+            .appendingPathComponent("test-runs")
+            .appendingPathComponent(testRunId)
     }
 
     private func analyticsCommandMetadata(

--- a/cli/Tests/TuistKitTests/CommandTracking/TrackableCommandTests.swift
+++ b/cli/Tests/TuistKitTests/CommandTracking/TrackableCommandTests.swift
@@ -248,6 +248,58 @@ final class TrackableCommandTests: TuistTestCase {
         )
     }
 
+    func test_whenRunMetadataUploadTimesOut_andTestRunExists_printsFallbackTestRunURL() async throws {
+        // Given
+        uploadAnalyticsService.reset()
+        given(uploadAnalyticsService)
+            .upload(commandEvent: .any, fullHandle: .any, serverURL: .any, sessionDirectory: .any)
+            .willThrow(URLError(.timedOut))
+        try makeSubject(
+            command: TestRunIdCommand(testRunId: "test-run-id"),
+            commandArguments: ["test"]
+        )
+
+        // When
+        try await subject.run(
+            fullHandle: "tuist/tuist",
+            serverURL: .test(),
+            shouldTrackAnalytics: true
+        )
+
+        // Then
+        XCTAssertPrinterContains(
+            "View the analyzed test at https://test.tuist.io/tuist/tuist/tests/test-runs/test-run-id",
+            at: .info,
+            <=
+        )
+    }
+
+    func test_whenRunMetadataUploadTimesOut_andFullHandleInvalid_doesNotPrintFallbackTestRunURL() async throws {
+        // Given
+        uploadAnalyticsService.reset()
+        given(uploadAnalyticsService)
+            .upload(commandEvent: .any, fullHandle: .any, serverURL: .any, sessionDirectory: .any)
+            .willThrow(URLError(.timedOut))
+        try makeSubject(
+            command: TestRunIdCommand(testRunId: "test-run-id"),
+            commandArguments: ["test"]
+        )
+
+        // When
+        try await subject.run(
+            fullHandle: "invalid-handle",
+            serverURL: .test(),
+            shouldTrackAnalytics: true
+        )
+
+        // Then
+        XCTAssertPrinterNotContains(
+            "View the analyzed test at",
+            at: .info,
+            <=
+        )
+    }
+
     func test_whenRunMetadataCreationFails_doesNotFailCommand() async throws {
         // Given
         gitController.reset()
@@ -517,5 +569,18 @@ private struct ResolvedMetadataCommand: TrackableParsableCommand, AsyncParsableC
                 commandArguments: ["xcodebuild", "build", "-workspace", "App.xcworkspace"]
             )
         )
+    }
+}
+
+private struct TestRunIdCommand: TrackableParsableCommand, AsyncParsableCommand {
+    static var configuration: CommandConfiguration {
+        CommandConfiguration(commandName: "test")
+    }
+
+    var testRunId: String
+    var analyticsRequired: Bool { true }
+
+    func run() async throws {
+        await RunMetadataStorage.current.update(testRunId: testRunId)
     }
 }


### PR DESCRIPTION
## Summary
- print a fallback `View the analyzed test at .../tests/test-runs/<id>` URL when run metadata upload fails in `TrackableCommand`
- derive the URL from `fullHandle + serverURL + RunMetadataStorage.testRunId`
- keep behavior unchanged when upload succeeds
- add tests for valid/invalid full-handle fallback behavior

## Why
`tuist test --inspect-mode local` can create test runs but fail to upload run metadata/session artifacts. In that case, logs currently show only `Failed to upload run metadata` and omit dashboard URLs.

## Test
- Added unit tests in `TrackableCommandTests` for fallback URL emission and invalid-handle guard.
- Note: local full `swift test` execution in this environment is blocked by an existing package graph conflict unrelated to this change:\n  `multiple packages ('command', 'tuist.Command') declare products with a conflicting name: 'Command'`.