### PR TITLE
fix(cli): restore SwifterPM package submodules

### DIFF
--- a/swifterpm/Sources/swifterpm/Restore.swift
+++ b/swifterpm/Sources/swifterpm/Restore.swift
@@ -626,14 +626,13 @@ enum WorkspaceRestorer {
 
     static func ensureSource(cache: Cache, pin: ResolvedPin) async throws -> URL {
         let destination = try cache.sourcePath(pin: pin)
-        let manifest = destination.appendingPathComponent("Package.swift")
-        if try await fileSystem.exists(manifest.absolutePath) {
+        if try await cachedSourceIsUsable(destination) {
             return destination
         }
 
         let lock = try await cache.lock(namespace: "sources", key: destination.path)
         _ = lock
-        if try await fileSystem.exists(manifest.absolutePath) {
+        if try await cachedSourceIsUsable(destination) {
             return destination
         }
         if try await fileSystem.exists(destination.absolutePath) {
@@ -654,7 +653,7 @@ enum WorkspaceRestorer {
             do {
                 try await fileSystem.move(from: temp.absolutePath, to: destination.absolutePath, options: [])
             } catch {
-                if try await fileSystem.exists(manifest.absolutePath) {
+                if try await cachedSourceIsUsable(destination) {
                     try? await fileSystem.remove(temp.absolutePath)
                     return destination
                 }
@@ -665,6 +664,29 @@ enum WorkspaceRestorer {
             throw error
         }
         return destination
+    }
+
+    private static func cachedSourceIsUsable(_ source: URL) async throws -> Bool {
+        guard try await fileSystem.exists(
+            source.appendingPathComponent("Package.swift").absolutePath
+        ) else {
+            return false
+        }
+        return try await submodulesAreMaterialized(in: source)
+    }
+
+    private static func submodulesAreMaterialized(in source: URL) async throws -> Bool {
+        for path in try await submodulePaths(in: source) {
+            let submodule = source.appendingPathComponent(path)
+            guard fileSystem.isDirectoryAndNotSymlink(submodule) else {
+                return false
+            }
+            let entries = try await fileSystem.contentsOfDirectory(at: submodule)
+            if entries.allSatisfy({ $0.lastPathComponent == ".git" }) {
+                return false
+            }
+        }
+        return true
     }
 
     static func ensureRegistrySource(cache: Cache, registryConfig: RegistryConfig, pin: ResolvedPin)
@@ -793,6 +815,8 @@ enum WorkspaceRestorer {
 
     private static func shallowFetchCheckout(pin: ResolvedPin, destination: URL) async throws {
         let revision = try pin.revision()
+        let isLocalSourceControlPackage =
+            try await PackageResolver.localSourceControlPackageLocation(pin.location) != nil
         var attempts: [(candidate: String, error: any Error)] = []
         for location in SourceControlLocations.fetchCandidates(pin.location) {
             do {
@@ -811,8 +835,13 @@ enum WorkspaceRestorer {
                 try await SystemProcess.run(
                     "/usr/bin/git", ["-C", destination.path, "checkout", "--detach", "FETCH_HEAD"]
                 )
+                try await updateSubmodulesIfNeeded(
+                    in: destination,
+                    gitConfigArguments: authArguments,
+                    allowFileProtocol: isLocalSourceControlPackage
+                )
                 let gitDir = destination.appendingPathComponent(".git")
-                if try await PackageResolver.localSourceControlPackageLocation(pin.location) == nil,
+                if !isLocalSourceControlPackage,
                    try await fileSystem.exists(gitDir.absolutePath)
                 {
                     try await fileSystem.remove(gitDir.absolutePath)
@@ -823,6 +852,52 @@ enum WorkspaceRestorer {
             }
         }
         throw GitFetchFailure.error(location: pin.location, attempts: attempts)
+    }
+
+    private static func updateSubmodulesIfNeeded(
+        in destination: URL,
+        gitConfigArguments: [String],
+        allowFileProtocol: Bool
+    ) async throws {
+        guard try await !submodulePaths(in: destination).isEmpty else {
+            return
+        }
+        var arguments = ["-C", destination.path] + gitConfigArguments
+        if allowFileProtocol {
+            arguments.append(contentsOf: ["-c", "protocol.file.allow=always"])
+        }
+        arguments.append(contentsOf: ["submodule", "update", "--init", "--recursive"])
+        try await SystemProcess.run(
+            "/usr/bin/git",
+            arguments,
+            environment: SystemProcess.nonInteractiveGitEnvironment
+        )
+    }
+
+    private static func submodulePaths(in source: URL) async throws -> [String] {
+        let gitmodules = source.appendingPathComponent(".gitmodules")
+        guard try await fileSystem.exists(gitmodules.absolutePath) else {
+            return []
+        }
+
+        let output: String
+        do {
+            output = try await SystemProcess.output(
+                "/usr/bin/git",
+                ["config", "-f", gitmodules.path, "--get-regexp", #"submodule\..*\.path"#]
+            )
+        } catch {
+            return []
+        }
+
+        return output.split(separator: "\n").compactMap { line in
+            guard let separatorIndex = line.firstIndex(where: { $0.isWhitespace }) else {
+                return nil
+            }
+            let path = String(line[line.index(after: separatorIndex)...])
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            return path.isEmpty ? nil : path
+        }
     }
 
     private static func rejectArchiveWithSubmodules(_ destination: URL) async throws {

--- a/swifterpm/Tests/swifterpmTests/RestoreTests.swift
+++ b/swifterpm/Tests/swifterpmTests/RestoreTests.swift
@@ -54,6 +54,99 @@ struct RestoreTests {
     }
 
     @Test
+    func restorePackageInitializesRequiredGitSubmodules() async throws {
+        try await withTemporaryDirectory { root in
+            let repo = root.appendingPathComponent("libwebp-Xcode")
+            let submodule = root.appendingPathComponent("libwebp")
+            let scratch = root.appendingPathComponent("scratch")
+            let cache = try await Cache(root: root.appendingPathComponent("cache"))
+            let revision = try await writeGitPackageWithRequiredSubmodule(
+                packageRepo: repo,
+                submoduleRepo: submodule
+            )
+            let pin = ResolvedPin(
+                identity: "libwebp-xcode",
+                kind: "localSourceControl",
+                location: repo.path,
+                state: ResolvedState(branch: nil, revision: revision, version: nil)
+            )
+            let resolved = ResolvedPins(originHash: "origin", pins: [pin], version: 3)
+
+            try await WorkspaceRestorer.restorePackage(
+                scratchDir: scratch,
+                cache: cache,
+                registryConfig: RegistryConfig(),
+                resolved: resolved,
+                progress: nil,
+                disableSandbox: true
+            )
+
+            let checkout = scratch.appendingPathComponent("checkouts/libwebp-Xcode")
+            #expect(
+                try await fileSystem.exists(
+                    checkout.appendingPathComponent("libwebp/src/decode.c").absolutePath
+                ))
+            #expect(
+                try await fileSystem.exists(
+                    checkout.appendingPathComponent("libwebp/sharpyuv/sharpyuv.c").absolutePath
+                ))
+        }
+    }
+
+    @Test
+    func restorePackageRefreshesCachedSourceWhenSubmodulesAreMissing() async throws {
+        try await withTemporaryDirectory { root in
+            let repo = root.appendingPathComponent("libwebp-Xcode")
+            let submodule = root.appendingPathComponent("libwebp")
+            let scratch = root.appendingPathComponent("scratch")
+            let cache = try await Cache(root: root.appendingPathComponent("cache"))
+            let revision = try await writeGitPackageWithRequiredSubmodule(
+                packageRepo: repo,
+                submoduleRepo: submodule
+            )
+            let pin = ResolvedPin(
+                identity: "libwebp-xcode",
+                kind: "localSourceControl",
+                location: repo.path,
+                state: ResolvedState(branch: nil, revision: revision, version: nil)
+            )
+            let cachedSource = try cache.sourcePath(pin: pin)
+            try await fileSystem.makeDirectory(
+                at: cachedSource.absolutePath,
+                options: [.createTargetParentDirectories]
+            )
+            try await fileSystem.write(
+                await fileSystem.readFile(
+                    at: repo.appendingPathComponent("Package.swift").absolutePath
+                ),
+                to: cachedSource.appendingPathComponent("Package.swift")
+            )
+            try await fileSystem.write(
+                await fileSystem.readFile(
+                    at: repo.appendingPathComponent(".gitmodules").absolutePath
+                ),
+                to: cachedSource.appendingPathComponent(".gitmodules")
+            )
+            let resolved = ResolvedPins(originHash: "origin", pins: [pin], version: 3)
+
+            try await WorkspaceRestorer.restorePackage(
+                scratchDir: scratch,
+                cache: cache,
+                registryConfig: RegistryConfig(),
+                resolved: resolved,
+                progress: nil,
+                disableSandbox: true
+            )
+
+            let checkout = scratch.appendingPathComponent("checkouts/libwebp-Xcode")
+            #expect(
+                try await fileSystem.exists(
+                    checkout.appendingPathComponent("libwebp/src/decode.c").absolutePath
+                ))
+        }
+    }
+
+    @Test
     func writeWorkspaceStateWritesSourceControlAndRegistryDependencies() async throws {
         try await withTemporaryDirectory { root in
             let package = root.appendingPathComponent("Package")
@@ -542,6 +635,92 @@ struct RestoreTests {
             #expect(artifacts.count == 1)
             #expect(artifact["path"] as? String == artifactPath.path)
         }
+    }
+
+    private func writeGitPackageWithRequiredSubmodule(
+        packageRepo: URL,
+        submoduleRepo: URL
+    ) async throws -> String {
+        try await fileSystem.makeDirectory(
+            at: submoduleRepo.appendingPathComponent("src").absolutePath,
+            options: [.createTargetParentDirectories]
+        )
+        try await fileSystem.makeDirectory(
+            at: submoduleRepo.appendingPathComponent("sharpyuv").absolutePath,
+            options: [.createTargetParentDirectories]
+        )
+        try await fileSystem.atomicWrite(
+            "void webp_decode(void) {}\n",
+            to: submoduleRepo.appendingPathComponent("src/decode.c")
+        )
+        try await fileSystem.atomicWrite(
+            "void webp_sharpyuv(void) {}\n",
+            to: submoduleRepo.appendingPathComponent("sharpyuv/sharpyuv.c")
+        )
+        try await SystemProcess.run(
+            "/usr/bin/git", ["init", "-q"], workingDirectory: submoduleRepo
+        )
+        try await commitAll(in: submoduleRepo, message: "initial")
+
+        try await fileSystem.makeDirectory(
+            at: packageRepo.appendingPathComponent("include").absolutePath,
+            options: [.createTargetParentDirectories]
+        )
+        try await fileSystem.atomicWrite(
+            """
+            // swift-tools-version:5.0
+            import PackageDescription
+
+            let package = Package(
+                name: "libwebp",
+                products: [
+                    .library(name: "libwebp", targets: ["libwebp"]),
+                ],
+                targets: [
+                    .target(
+                        name: "libwebp",
+                        path: ".",
+                        sources: ["libwebp/src", "libwebp/sharpyuv"],
+                        publicHeadersPath: "include"
+                    ),
+                ]
+            )
+            """,
+            to: packageRepo.appendingPathComponent("Package.swift")
+        )
+        try await fileSystem.atomicWrite(
+            "void webp_decode(void);\n",
+            to: packageRepo.appendingPathComponent("include/webp.h")
+        )
+        try await SystemProcess.run(
+            "/usr/bin/git", ["init", "-q"], workingDirectory: packageRepo
+        )
+        try await SystemProcess.run(
+            "/usr/bin/git",
+            [
+                "-c", "protocol.file.allow=always",
+                "submodule", "add", "-q", submoduleRepo.path, "libwebp",
+            ],
+            workingDirectory: packageRepo
+        )
+        try await commitAll(in: packageRepo, message: "initial")
+        return try await SystemProcess.output(
+            "/usr/bin/git", ["rev-parse", "HEAD"], workingDirectory: packageRepo
+        )
+        .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private func commitAll(in repo: URL, message: String) async throws {
+        try await SystemProcess.run("/usr/bin/git", ["add", "."], workingDirectory: repo)
+        try await SystemProcess.run(
+            "/usr/bin/git",
+            [
+                "-c", "user.name=Repro",
+                "-c", "user.email=repro@example.com",
+                "commit", "-q", "-m", message,
+            ],
+            workingDirectory: repo
+        )
     }
 
     private func writeGitPackageWithBrokenSubmodule(at repo: URL) async throws -> String {


### PR DESCRIPTION
## What changed

- Initialize Git submodules when SwifterPM falls back to a shallow Git checkout.
- Treat cached source checkouts with missing submodule contents as stale instead of accepting them just because `Package.swift` exists.
- Add regression coverage for packages whose target sources live inside a required submodule, modeled after `libwebp-Xcode`.

## Why

A reported SwifterPM install generated a checkout for `SDWebImage/libwebp-Xcode` `1.3.1`, but Tuist graph loading later failed with invalid source globs for `libwebp/src/**` and `libwebp/sharpyuv/**`.

The upstream package declares those source folders in `Package.swift`, while the actual folders live inside the `libwebp` Git submodule. SwifterPM correctly rejected GitHub source archives for repositories with `.gitmodules` and fell back to Git, but the fallback checkout did not initialize submodules. The cache then considered that incomplete checkout valid because the manifest file existed, so retries after `tuist clean` could keep reusing the bad cached source.

## Impact

SwifterPM restores source-control packages with required submodules fully enough for Tuist to map package target sources. Existing incomplete cache entries are refreshed automatically the next time the package is restored.

## Validation

All validation was run from the clean PR worktree based on `origin/main`:

1. `git diff --check`
   - Confirmed the final patch has no whitespace errors.
2. `swift test --replace-scm-with-registry --filter RestoreTests`
   - Built SwifterPM from the PR branch.
   - Ran the focused `RestoreTests` suite.
   - Passed 13 tests, including the new coverage for initializing required Git submodules and refreshing stale cached sources with missing submodule contents.
