### PR TITLE
fix(infra): release the xcresult-processor image on baked-file changes, not commit scope

### DIFF
--- a/mise/tasks/release/check.sh
+++ b/mise/tasks/release/check.sh
@@ -22,12 +22,31 @@ emit_output() {
   fi
 }
 
+# Increment the patch of an X.Y.Z version. Used by path-triggered components
+# when the baked files changed but cliff found no feat/fix to bump on.
+patch_bump() {
+  local v=$1 a b c
+  IFS='.' read -r a b c <<< "$v"
+  printf '%s.%s.%s' "${a:-0}" "${b:-0}" "$(( ${c:-0} + 1 ))"
+}
+
+# Strip a trailing glob (/**/*, /**, /*) off an include-path so it can be used
+# as a plain git pathspec for diffing.
+pathspec_of() {
+  local p=$1
+  p="${p%/\*\*/\*}"
+  p="${p%/\*\*}"
+  p="${p%/\*}"
+  printf '%s' "$p"
+}
+
 check_component() {
-  local component=$1 tag_prefix=$2 tag_regex=$3 cliff_config=$4 initial=$5
-  shift 5
+  local component=$1 tag_prefix=$2 tag_regex=$3 cliff_config=$4 initial=$5 path_triggered=$6
+  shift 6
+  local include_paths_local=("$@")
   local include_args=()
   local p
-  for p in "$@"; do include_args+=(--include-path "$p"); done
+  for p in "${include_paths_local[@]}"; do include_args+=(--include-path "$p"); done
 
   local latest next_num latest_num
   latest=$(git -C "$REPO_ROOT" tag -l | grep -E "$tag_regex" | sort -V | tail -n1 || true)
@@ -45,11 +64,34 @@ check_component() {
   [[ -z "$next_num" ]] && next_num=$initial
   latest_num=${latest#"$tag_prefix"}
 
-  local should=false
+  local should=false greatest
   if [[ -z "$latest" ]]; then
     should=true
+  elif [[ "$path_triggered" == "true" ]]; then
+    # Path-based gate: this component bakes another component's code (the
+    # xcresult-processor image bakes a server release), so it must rebuild
+    # whenever any baked file changes, regardless of conventional-commit scope.
+    # cliff's scope parsers (which skip chore/ci/etc.) are the wrong signal
+    # here: a chore(server) change to server/lib/tuist altered baked code yet
+    # produced no version bump, drifting the image from the live DB schema.
+    local diff_paths=() pathspec changed
+    for p in "${include_paths_local[@]}"; do
+      pathspec=$(pathspec_of "$p")
+      [[ -n "$pathspec" ]] && diff_paths+=("$pathspec")
+    done
+    changed=$(git -C "$REPO_ROOT" diff --name-only "${latest}..HEAD" -- "${diff_paths[@]}" 2>/dev/null || true)
+    if [[ -n "$changed" ]]; then
+      should=true
+      # cliff found no feat/fix in range, so it didn't bump; force a patch so a
+      # chore/refactor-only change to the baked code still ships a new image.
+      greatest=$(printf '%s\n%s\n' "$latest_num" "$next_num" | sort -V | tail -n1)
+      if [[ "$next_num" == "$latest_num" || "$greatest" != "$next_num" ]]; then
+        next_num=$(patch_bump "$latest_num")
+      fi
+    else
+      next_num=$latest_num
+    fi
   else
-    local greatest
     greatest=$(printf '%s\n%s\n' "$latest_num" "$next_num" | sort -V | tail -n1)
     if [[ "$next_num" != "$latest_num" && "$greatest" == "$next_num" ]]; then
       should=true
@@ -100,15 +142,16 @@ while IFS= read -r component_json; do
   tag_regex=$(jq -r '.tag_regex' <<< "$component_json")
   cliff_config=$(jq -r '.cliff_config' <<< "$component_json")
   initial=$(jq -r '.initial_version' <<< "$component_json")
+  path_triggered=$(jq -r '.release_on_path_change // false' <<< "$component_json")
   include_paths=()
   while IFS= read -r include_path; do
     include_paths+=("$include_path")
   done < <(jq -r '.include_paths[]?' <<< "$component_json")
 
   if (( ${#include_paths[@]} > 0 )); then
-    check_component "$name" "$tag_prefix" "$tag_regex" "$cliff_config" "$initial" "${include_paths[@]}"
+    check_component "$name" "$tag_prefix" "$tag_regex" "$cliff_config" "$initial" "$path_triggered" "${include_paths[@]}"
   else
-    check_component "$name" "$tag_prefix" "$tag_regex" "$cliff_config" "$initial"
+    check_component "$name" "$tag_prefix" "$tag_regex" "$cliff_config" "$initial" "$path_triggered"
   fi
 done < <(jq -c '.components[]' "$COMPONENTS_FILE")
 

--- a/mise/tasks/release/components.json
+++ b/mise/tasks/release/components.json
@@ -122,6 +122,7 @@
       "tag_regex": "^xcresult-processor-image@[0-9]+\\.[0-9]+\\.[0-9]+$",
       "cliff_config": "infra/xcresult-processor-image/cliff.toml",
       "initial_version": "0.1.0",
+      "release_on_path_change": true,
       "include_paths": [
         "infra/xcresult-processor-image/**/*",
         "server/lib/tuist/**/*",


### PR DESCRIPTION
## What changed

The `xcresult-processor-image` release gate now triggers on **file changes** to its baked paths, not on conventional-commit **scope**. Implemented via a new per-component `release_on_path_change` flag in `mise/tasks/release/components.json` (set only for `xcresult-processor-image`) + corresponding logic in `mise/tasks/release/check.sh`. All other components are unchanged.

## Why — root cause of a prod incident

The xcresult-processor runs on a macOS Tart VM whose image **bakes a server release** (`server/lib/tuist/**`, `server/native/xcresult_nif/**`, `server/mix.exs`, `server/mix.lock`). The release gate ran `git cliff --bumped-version` over those include-paths, but cliff's `commit_parsers` `skip` `chore`/`ci`/other-scoped commits — so a `chore`-scoped change to baked code yields **no version bump and no rebuild**.

That is how **#11460** (`chore(server): source secrets from 1Password and retire Namespace`) drifted the image:
- It removed the `Namespace` code **and** dropped `accounts.namespace_tenant_id` (migration).
- The server rolled forward to the new schema; the xcresult-processor kept running the **old baked code** (`0.31.5`, built before #11460) and queried the dropped column.
- Result: `Tuist.Tests.Workers.ProcessXcresultWorker` jobs erroring/discarding (`Postgrex 42703 undefined_column`, Sentry TUIST-11S) — broken xcresult test-result processing in prod.

For an image that bakes another component's code, **scope is the wrong signal** — any change to the baked files can drift it from the live schema. The right signal is "did the baked files change."

## How

When `release_on_path_change: true`, `check.sh` decides `should-release` from `git diff --name-only <last-tag>..HEAD` over the component's `include_paths` (scope-agnostic). Version comes from cliff's bump when it produces one, else a forced patch bump (so a chore/refactor-only change to baked code still ships). Default behavior (scope-gated) is unchanged for every other component.

## Tradeoff (intentional)

The macOS image will now rebuild whenever `server/lib/tuist/**` (etc.) changes — **more often than the old scope-gated cadence**. That's the point: it keeps the xcresult-processor in lockstep with the server release it bakes rather than silently drifting. The build is async on the dedicated `vm-image-builder` Mac mini.

## Impact

Merging this makes the next production cascade's `release-xcresult-processor-image` job fire (baked paths changed since `0.31.5` via #11460), cutting `0.31.6` from current `main` (Namespace code gone), rewriting the chart tag, and deploying it — which permanently resolves TUIST-11S. (Interim mitigation already in place: `accounts.namespace_tenant_id` was manually re-added so the old image keeps working; once `0.31.6` is live the column can be dropped for good.)

## Validation

- `mise run release:check xcresult-processor-image` → `release? true`, next `0.31.6` (cliff found no feat/fix in range, patch-bump fallback applied)
- `cli` / `server` / `kura` (scope-gated) → unchanged, no crash
- `bash -n` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)