### PR TITLE
perf(cli): consolidate Swift framework search paths

### DIFF
--- a/cli/Sources/TuistCore/Descriptors/SideEffectDescriptor.swift
+++ b/cli/Sources/TuistCore/Descriptors/SideEffectDescriptor.swift
@@ -17,6 +17,9 @@ public enum SideEffectDescriptor: Equatable, CustomStringConvertible {
     /// Create / remove a directory
     case directory(DirectoryDescriptor)
 
+    /// Create / remove a symbolic link
+    case symbolicLink(SymbolicLinkDescriptor)
+
     /// Perform a command
     case command(CommandDescriptor)
 
@@ -35,6 +38,8 @@ public enum SideEffectDescriptor: Equatable, CustomStringConvertible {
             return fileDescriptor.description
         case let .directory(directoryDescriptor):
             return directoryDescriptor.description
+        case let .symbolicLink(symbolicLinkDescriptor):
+            return symbolicLinkDescriptor.description
         case let .command(commandDescriptor):
             return commandDescriptor.description
         case let .testPlan(descriptor):

--- a/cli/Sources/TuistCore/Descriptors/SymbolicLinkDescriptor.swift
+++ b/cli/Sources/TuistCore/Descriptors/SymbolicLinkDescriptor.swift
@@ -1,0 +1,47 @@
+import Path
+
+/// Symbolic Link Descriptor
+///
+/// Describes a symbolic link operation that needs to take place as part of generating a project
+/// or workspace.
+///
+/// - seealso: `SideEffectDescriptor`
+public struct SymbolicLinkDescriptor: Equatable, CustomStringConvertible {
+    public enum State {
+        case present
+        case absent
+    }
+
+    /// Path to the symbolic link.
+    public var path: AbsolutePath
+
+    /// Path the symbolic link points to.
+    public var destination: AbsolutePath
+
+    /// The desired state of the symbolic link.
+    public var state: State
+
+    /// Creates a SymbolicLinkDescriptor.
+    /// - Parameters:
+    ///   - path: Path to the symbolic link.
+    ///   - destination: Path the symbolic link points to.
+    ///   - state: The desired state of the symbolic link.
+    public init(
+        path: AbsolutePath,
+        destination: AbsolutePath,
+        state: SymbolicLinkDescriptor.State = .present
+    ) {
+        self.path = path
+        self.destination = destination
+        self.state = state
+    }
+
+    public var description: String {
+        switch state {
+        case .absent:
+            return "delete symbolic link \(path.pathString)"
+        case .present:
+            return "create symbolic link \(path.pathString) -> \(destination.pathString)"
+        }
+    }
+}

--- a/cli/Sources/TuistGenerator/Descriptors/SideEffectDescriptorExecutor.swift
+++ b/cli/Sources/TuistGenerator/Descriptors/SideEffectDescriptorExecutor.swift
@@ -1,6 +1,7 @@
 import Command
 import FileSystem
 import Foundation
+import Path
 import TuistCore
 import TuistLogging
 import TuistSupport
@@ -36,6 +37,8 @@ public struct SideEffectDescriptorExecutor: SideEffectDescriptorExecuting {
                 try await process(file: fileDescriptor)
             case let .directory(directoryDescriptor):
                 try await process(directory: directoryDescriptor)
+            case let .symbolicLink(symbolicLinkDescriptor):
+                try await process(symbolicLink: symbolicLinkDescriptor)
             case let .testPlan(testPlanDescriptor):
                 try await process(testPlan: testPlanDescriptor)
             case let .generatedFilesCleanup(descriptor):
@@ -75,6 +78,30 @@ public struct SideEffectDescriptorExecutor: SideEffectDescriptorExecuting {
             if try await fileSystem.exists(directory.path) {
                 try await fileSystem.remove(directory.path)
             }
+        }
+    }
+
+    private func process(symbolicLink: SymbolicLinkDescriptor) async throws {
+        switch symbolicLink.state {
+        case .present:
+            try await fileSystem.makeDirectory(at: symbolicLink.path.parentDirectory)
+            if let destination = try? await fileSystem.resolveSymbolicLink(symbolicLink.path) {
+                if destination == symbolicLink.destination {
+                    return
+                }
+                try await removeIfPresent(symbolicLink.path)
+            } else {
+                try await removeIfPresent(symbolicLink.path)
+            }
+            try await fileSystem.createSymbolicLink(from: symbolicLink.path, to: symbolicLink.destination)
+        case .absent:
+            try await removeIfPresent(symbolicLink.path)
+        }
+    }
+
+    private func removeIfPresent(_ path: AbsolutePath) async throws {
+        if try await fileSystem.exists(path) {
+            try await fileSystem.remove(path)
         }
     }
 

--- a/cli/Sources/TuistGenerator/Descriptors/SideEffectDescriptorExecutor.swift
+++ b/cli/Sources/TuistGenerator/Descriptors/SideEffectDescriptorExecutor.swift
@@ -6,6 +6,14 @@ import TuistCore
 import TuistLogging
 import TuistSupport
 
+#if canImport(Darwin)
+    import Darwin
+#elseif canImport(Glibc)
+    import Glibc
+#elseif canImport(Musl)
+    import Musl
+#endif
+
 /// The protocol defines an interface for executing side effects.
 public protocol SideEffectDescriptorExecuting {
     /// Executes the given side effects sequentially.
@@ -89,20 +97,37 @@ public struct SideEffectDescriptorExecutor: SideEffectDescriptorExecuting {
                 if destination == symbolicLink.destination {
                     return
                 }
-                try await removeIfPresent(symbolicLink.path)
+                try await removeExistingEntry(symbolicLink.path)
             } else {
-                try await removeIfPresent(symbolicLink.path)
+                try await removeExistingEntry(symbolicLink.path)
             }
             try await fileSystem.createSymbolicLink(from: symbolicLink.path, to: symbolicLink.destination)
         case .absent:
-            try await removeIfPresent(symbolicLink.path)
+            try await removeExistingEntry(symbolicLink.path)
         }
     }
 
-    private func removeIfPresent(_ path: AbsolutePath) async throws {
+    private func removeExistingEntry(_ path: AbsolutePath) async throws {
         if try await fileSystem.exists(path) {
             try await fileSystem.remove(path)
+        } else if try await directoryContains(path) {
+            try await removeDirectoryEntry(path)
         }
+    }
+
+    private func directoryContains(_ path: AbsolutePath) async throws -> Bool {
+        guard try await fileSystem.exists(path.parentDirectory, isDirectory: true) else { return false }
+        return try await fileSystem.contentsOfDirectory(path.parentDirectory).contains(path)
+    }
+
+    private func removeDirectoryEntry(_ path: AbsolutePath) async throws {
+        #if canImport(Darwin) || canImport(Glibc) || canImport(Musl)
+            guard unlink(path.pathString) == 0 else {
+                throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+            }
+        #else
+            try await fileSystem.remove(path)
+        #endif
     }
 
     private func perform(command: CommandDescriptor) async throws {
@@ -127,7 +152,7 @@ public struct SideEffectDescriptorExecutor: SideEffectDescriptorExecuting {
             for generatedFile in generatedFiles.sorted(by: { $0.pathString < $1.pathString })
                 where !activeFiles.contains(generatedFile)
             {
-                try await fileSystem.remove(generatedFile)
+                try await removeExistingEntry(generatedFile)
             }
         }
     }

--- a/cli/Sources/TuistGenerator/Descriptors/SideEffectDescriptorExecutor.swift
+++ b/cli/Sources/TuistGenerator/Descriptors/SideEffectDescriptorExecutor.swift
@@ -148,13 +148,93 @@ public struct SideEffectDescriptorExecutor: SideEffectDescriptorExecuting {
             guard try await fileSystem.exists(directory, isDirectory: true) else { continue }
 
             let activeFiles = descriptor.activeFilesByDirectory[directory] ?? []
-            let generatedFiles = try await fileSystem.glob(directory: directory, include: descriptor.include).collect()
+            let generatedFiles = try await generatedFiles(matching: descriptor, in: directory)
             for generatedFile in generatedFiles.sorted(by: { $0.pathString < $1.pathString })
                 where !activeFiles.contains(generatedFile)
             {
+                guard try await !hasSymbolicLinkAncestor(generatedFile, under: directory) else { continue }
                 try await removeExistingEntry(generatedFile)
             }
         }
+    }
+
+    private func generatedFiles(
+        matching descriptor: GeneratedFilesCleanupDescriptor,
+        in directory: AbsolutePath
+    ) async throws -> Set<AbsolutePath> {
+        var generatedFiles: Set<AbsolutePath> = []
+        for pattern in descriptor.include {
+            let components = pattern.split(separator: "/").map(String.init)
+            generatedFiles.formUnion(try await directoryEntries(matching: components, in: directory))
+        }
+        return generatedFiles
+    }
+
+    private func directoryEntries(matching components: [String], in directory: AbsolutePath) async throws -> Set<AbsolutePath> {
+        guard let component = components.first else { return [] }
+        guard try await fileSystem.exists(directory, isDirectory: true) else { return [] }
+
+        if component == "**" {
+            var matchedEntries = try await directoryEntries(matching: Array(components.dropFirst()), in: directory)
+            for entry in try await fileSystem.contentsOfDirectory(directory) {
+                guard try await fileSystem.exists(entry, isDirectory: true),
+                      try await !isSymbolicLink(entry)
+                else { continue }
+                matchedEntries.formUnion(try await directoryEntries(matching: components, in: entry))
+            }
+            return matchedEntries
+        }
+
+        if components.count == 1 {
+            return Set(
+                try await fileSystem.contentsOfDirectory(directory)
+                    .filter { matches($0.basename, pattern: component) }
+            )
+        }
+
+        let nextComponents = Array(components.dropFirst())
+        let nextDirectories: [AbsolutePath]
+        if component.isGlobComponent {
+            nextDirectories = try await fileSystem.contentsOfDirectory(directory)
+                .filter { matches($0.basename, pattern: component) }
+        } else {
+            nextDirectories = [directory.appending(component: component)]
+        }
+
+        var matchedEntries: Set<AbsolutePath> = []
+        for nextDirectory in nextDirectories {
+            guard try await fileSystem.exists(nextDirectory, isDirectory: true),
+                  try await !isSymbolicLink(nextDirectory)
+            else { continue }
+            matchedEntries.formUnion(try await directoryEntries(matching: nextComponents, in: nextDirectory))
+        }
+        return matchedEntries
+    }
+
+    private func matches(_ value: String, pattern: String) -> Bool {
+        guard pattern.isGlobComponent else { return value == pattern }
+        let escapedPattern = NSRegularExpression.escapedPattern(for: pattern)
+            .replacingOccurrences(of: "\\*", with: ".*")
+            .replacingOccurrences(of: "\\?", with: ".")
+        return value.range(of: "^\(escapedPattern)$", options: .regularExpression) != nil
+    }
+
+    private func isSymbolicLink(_ path: AbsolutePath) async throws -> Bool {
+        guard let destination = try? await fileSystem.resolveSymbolicLink(path) else { return false }
+        return destination != path
+    }
+
+    private func hasSymbolicLinkAncestor(_ path: AbsolutePath, under directory: AbsolutePath) async throws -> Bool {
+        guard path.isDescendantOfOrEqual(to: directory) else { return false }
+
+        var ancestor = path.parentDirectory
+        while ancestor != directory, ancestor.isDescendantOfOrEqual(to: directory) {
+            if try await isSymbolicLink(ancestor) {
+                return true
+            }
+            ancestor = ancestor.parentDirectory
+        }
+        return false
     }
 }
 

--- a/cli/Sources/TuistGenerator/Mappers/FrameworkSearchPathsGraphMapper.swift
+++ b/cli/Sources/TuistGenerator/Mappers/FrameworkSearchPathsGraphMapper.swift
@@ -163,7 +163,7 @@ public struct FrameworkSearchPathsGraphMapper: GraphMapping {
                     GeneratedFilesCleanupDescriptor(
                         directories: Set(activeFrameworkLinksByDirectory.keys),
                         activeFilesByDirectory: activeFrameworkLinksByDirectory,
-                        include: ["**/*.framework", "**/*.xcframework"]
+                        include: ["Swift/*/*.framework", "Swift/*/*.xcframework"]
                     )
                 )
             )

--- a/cli/Sources/TuistGenerator/Mappers/FrameworkSearchPathsGraphMapper.swift
+++ b/cli/Sources/TuistGenerator/Mappers/FrameworkSearchPathsGraphMapper.swift
@@ -17,7 +17,7 @@ import XcodeGraph
 /// once written — the same way `ModuleMapMapper` writes the dependency module maps.
 public struct FrameworkSearchPathsGraphMapper: GraphMapping {
     /// Targets with at least this many unique precompiled framework search paths get those paths
-    /// consolidated into a response file to keep C/ObjC compilation and linking under ARG_MAX.
+    /// consolidated into a response file to keep C, Objective-C, and linking command lines short.
     private static let consolidationThreshold = 20
 
     private static let frameworkSearchPathsSetting = "FRAMEWORK_SEARCH_PATHS"
@@ -28,6 +28,18 @@ public struct FrameworkSearchPathsGraphMapper: GraphMapping {
     private struct TargetID: Hashable {
         let projectPath: AbsolutePath
         let targetName: String
+    }
+
+    private struct PrecompiledArtifact: Hashable {
+        let path: AbsolutePath
+
+        var searchPath: LinkGeneratorPath {
+            .absolutePath(path.removingLastComponent())
+        }
+
+        var canBeLinkedIntoSwiftSearchPath: Bool {
+            path.extension == "framework" || path.extension == "xcframework"
+        }
     }
 
     public init() {}
@@ -42,8 +54,10 @@ public struct FrameworkSearchPathsGraphMapper: GraphMapping {
 
         var settingsByTarget: [TargetID: [(key: String, values: [String])]] = [:]
         var generatedFileSideEffects: [SideEffectDescriptor] = []
+        var generatedSymbolicLinkSideEffects: [SideEffectDescriptor] = []
         var generatedResponseFileDirectories: Set<AbsolutePath> = []
         var activeFilesByDirectory: [AbsolutePath: Set<AbsolutePath>] = [:]
+        var activeFrameworkLinksByDirectory: [AbsolutePath: Set<AbsolutePath>] = [:]
 
         for (_, project) in graph.projects {
             let responseFileDirectory = project.sourceRootPath.appending(
@@ -56,8 +70,8 @@ public struct FrameworkSearchPathsGraphMapper: GraphMapping {
                 let linkableModules = try graphTraverser
                     .searchablePathDependencies(path: project.path, name: target.name).sorted()
 
-                let precompiledPaths = Set(linkableModules.compactMap(\.precompiledPath)
-                    .map { LinkGeneratorPath.absolutePath($0.removingLastComponent()) })
+                let precompiledArtifacts = Set(linkableModules.compactMap(\.precompiledPath).map(PrecompiledArtifact.init))
+                let precompiledPaths = Set(precompiledArtifacts.map(\.searchPath))
                 let sdkPaths = Set(linkableModules.compactMap { (dependency: GraphDependencyReference) -> LinkGeneratorPath? in
                     if case let GraphDependencyReference.sdk(_, _, source, _) = dependency {
                         return source.frameworkSearchPath.map { LinkGeneratorPath.string($0) }
@@ -87,17 +101,28 @@ public struct FrameworkSearchPathsGraphMapper: GraphMapping {
                     )
 
                     let responseFileReference = "\"@$(SRCROOT)/\(responseFilePath.relative(to: project.sourceRootPath))\""
-                    // FRAMEWORK_SEARCH_PATHS keeps only the SDK paths; clang and ld read the precompiled
-                    // paths from the response file via @file to stay under ARG_MAX.
+                    let swiftFrameworkSearchPath = responseFileDirectory.appending(
+                        components: "Swift",
+                        target.name
+                    )
+                    let swiftSearchPathAdditions = swiftSearchPathValues(
+                        precompiledArtifacts: precompiledArtifacts,
+                        swiftFrameworkSearchPath: swiftFrameworkSearchPath,
+                        cleanupDirectory: responseFileDirectory,
+                        sourceRootPath: project.sourceRootPath,
+                        activeFrameworkLinksByDirectory: &activeFrameworkLinksByDirectory,
+                        generatedSymbolicLinkSideEffects: &generatedSymbolicLinkSideEffects
+                    )
+                    // FRAMEWORK_SEARCH_PATHS keeps only platform framework paths; Clang and the linker read the
+                    // precompiled paths from the response file via @file to keep command lines short.
                     additions.append((
                         Self.frameworkSearchPathsSetting,
                         xcodeValues(of: sdkPaths, sourceRootPath: project.sourceRootPath)
                     ))
                     additions.append((Self.otherCFlagsSetting, [responseFileReference]))
-                    // OTHER_SWIFT_FLAGS gets inline -F flags instead of @file: Swift has no ARG_MAX
-                    // problem here and the Xcode 26 ClangImporter / integrated SwiftDriver mishandle a
-                    // @file token.
-                    additions.append((Self.otherSwiftFlagsSetting, precompiledXcodeValues.flatMap { ["-F", $0] }))
+                    // OTHER_SWIFT_FLAGS gets -F flags instead of @file because the Xcode 26 ClangImporter and
+                    // integrated SwiftDriver mishandle a @file token.
+                    additions.append((Self.otherSwiftFlagsSetting, swiftSearchPathAdditions.flatMap { ["-F", $0] }))
                     additions.append((Self.otherLinkerFlagsSetting, [responseFileReference]))
                 } else {
                     additions.append((
@@ -132,12 +157,75 @@ public struct FrameworkSearchPathsGraphMapper: GraphMapping {
                 )
             ),
         ]
+        if !activeFrameworkLinksByDirectory.isEmpty {
+            sideEffects.append(
+                .generatedFilesCleanup(
+                    GeneratedFilesCleanupDescriptor(
+                        directories: Set(activeFrameworkLinksByDirectory.keys),
+                        activeFilesByDirectory: activeFrameworkLinksByDirectory,
+                        include: ["**/*.framework", "**/*.xcframework"]
+                    )
+                )
+            )
+        }
         sideEffects.append(contentsOf: generatedFileSideEffects)
+        sideEffects.append(contentsOf: generatedSymbolicLinkSideEffects)
         return (graph, sideEffects, environment)
     }
 
     private func xcodeValues(of paths: Set<LinkGeneratorPath>, sourceRootPath: AbsolutePath) -> [String] {
         paths.map { $0.xcodeValue(sourceRootPath: sourceRootPath) }.uniqued().sorted()
+    }
+
+    private func swiftSearchPathValues(
+        precompiledArtifacts: Set<PrecompiledArtifact>,
+        swiftFrameworkSearchPath: AbsolutePath,
+        cleanupDirectory: AbsolutePath,
+        sourceRootPath: AbsolutePath,
+        activeFrameworkLinksByDirectory: inout [AbsolutePath: Set<AbsolutePath>],
+        generatedSymbolicLinkSideEffects: inout [SideEffectDescriptor]
+    ) -> [String] {
+        let frameworkArtifacts = precompiledArtifacts.filter(\.canBeLinkedIntoSwiftSearchPath)
+        let frameworkArtifactsByBasename = Dictionary(grouping: frameworkArtifacts, by: \.path.basename)
+
+        let linkableArtifacts = frameworkArtifactsByBasename.values
+            .filter { $0.count == 1 }
+            .compactMap(\.first)
+            .sorted { $0.path.pathString < $1.path.pathString }
+        let conflictingFrameworkSearchPaths = frameworkArtifactsByBasename.values
+            .filter { $0.count > 1 }
+            .flatMap { $0.map(\.searchPath) }
+        let unsupportedSearchPaths = precompiledArtifacts
+            .filter { !$0.canBeLinkedIntoSwiftSearchPath }
+            .map(\.searchPath)
+
+        var values: [String] = []
+        if !linkableArtifacts.isEmpty {
+            values.append(LinkGeneratorPath.absolutePath(swiftFrameworkSearchPath).xcodeValue(sourceRootPath: sourceRootPath))
+            let linkPaths = Set(linkableArtifacts.map { artifact in
+                swiftFrameworkSearchPath.appending(component: artifact.path.basename)
+            })
+            activeFrameworkLinksByDirectory[cleanupDirectory, default: []].formUnion(linkPaths)
+            generatedSymbolicLinkSideEffects.append(
+                contentsOf: linkableArtifacts.map { artifact in
+                    .symbolicLink(
+                        SymbolicLinkDescriptor(
+                            path: swiftFrameworkSearchPath.appending(component: artifact.path.basename),
+                            destination: artifact.path
+                        )
+                    )
+                }
+            )
+        }
+
+        values.append(
+            contentsOf: xcodeValues(
+                of: Set(conflictingFrameworkSearchPaths + unsupportedSearchPaths),
+                sourceRootPath: sourceRootPath
+            )
+        )
+
+        return values
     }
 
     /// Applies the settings to the target's base settings and to any configuration that already

--- a/cli/Tests/TuistGeneratorTests/Descriptors/SideEffectDescriptorExecutorTests.swift
+++ b/cli/Tests/TuistGeneratorTests/Descriptors/SideEffectDescriptorExecutorTests.swift
@@ -126,7 +126,7 @@ struct SideEffectDescriptorExecutorTests {
                 GeneratedFilesCleanupDescriptor(
                     directories: [directory],
                     activeFilesByDirectory: [directory: [activeLink]],
-                    include: ["**/*.framework"]
+                    include: ["Swift/*/*.framework"]
                 )
             ),
         ])
@@ -136,6 +136,30 @@ struct SideEffectDescriptorExecutorTests {
             try await fileSystem.resolveSymbolicLink(staleLink)
         }
         #expect(try await !fileSystem.contentsOfDirectory(staleLink.parentDirectory).contains(staleLink))
+    }
+
+    @Test(.inTemporaryDirectory) func execute_doesNotCleanFilesInsideActiveGeneratedSymbolicLink() async throws {
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let directory = temporaryDirectory.appending(component: "FrameworkSearchPaths")
+        let artifact = temporaryDirectory.appending(components: "Artifacts", "Module.xcframework")
+        let nestedFramework = artifact.appending(components: "ios-arm64", "Module.framework")
+        let activeLink = directory.appending(components: "Swift", "App", "Module.xcframework")
+        try await fileSystem.makeDirectory(at: nestedFramework)
+        try await fileSystem.makeDirectory(at: activeLink.parentDirectory)
+        try await fileSystem.createSymbolicLink(from: activeLink, to: artifact)
+
+        try await subject.execute(sideEffects: [
+            .generatedFilesCleanup(
+                GeneratedFilesCleanupDescriptor(
+                    directories: [directory],
+                    activeFilesByDirectory: [directory: [activeLink]],
+                    include: ["**/*.framework", "**/*.xcframework"]
+                )
+            ),
+        ])
+
+        #expect(try await fileSystem.resolveSymbolicLink(activeLink) == artifact)
+        #expect(try await fileSystem.exists(nestedFramework, isDirectory: true))
     }
 
     private func modificationDate(at path: AbsolutePath) throws -> Date {

--- a/cli/Tests/TuistGeneratorTests/Descriptors/SideEffectDescriptorExecutorTests.swift
+++ b/cli/Tests/TuistGeneratorTests/Descriptors/SideEffectDescriptorExecutorTests.swift
@@ -63,6 +63,24 @@ struct SideEffectDescriptorExecutorTests {
         #expect(try await fileSystem.resolveSymbolicLink(link) == destination)
     }
 
+    @Test(.inTemporaryDirectory) func execute_replacesDanglingSymbolicLink() async throws {
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let oldDestination = temporaryDirectory.appending(components: "Artifacts", "old", "Module.xcframework")
+        let newDestination = temporaryDirectory.appending(components: "Artifacts", "new", "Module.xcframework")
+        let link = temporaryDirectory.appending(components: "Derived", "FrameworkSearchPaths", "Module.xcframework")
+        try await fileSystem.makeDirectory(at: oldDestination)
+        try await fileSystem.makeDirectory(at: newDestination)
+        try await fileSystem.makeDirectory(at: link.parentDirectory)
+        try await fileSystem.createSymbolicLink(from: link, to: oldDestination)
+        try await fileSystem.remove(oldDestination)
+
+        try await subject.execute(sideEffects: [
+            .symbolicLink(SymbolicLinkDescriptor(path: link, destination: newDestination)),
+        ])
+
+        #expect(try await fileSystem.resolveSymbolicLink(link) == newDestination)
+    }
+
     @Test(.inTemporaryDirectory) func execute_cleansStaleGeneratedFiles() async throws {
         let directory = try #require(FileSystem.temporaryTestDirectory).appending(component: "ModuleMaps")
         let activeFile = directory.appending(component: "App-deps.modulemap")
@@ -101,6 +119,7 @@ struct SideEffectDescriptorExecutorTests {
         try await fileSystem.makeDirectory(at: staleLink.parentDirectory)
         try await fileSystem.createSymbolicLink(from: activeLink, to: activeDestination)
         try await fileSystem.createSymbolicLink(from: staleLink, to: staleDestination)
+        try await fileSystem.remove(staleDestination)
 
         try await subject.execute(sideEffects: [
             .generatedFilesCleanup(
@@ -116,6 +135,7 @@ struct SideEffectDescriptorExecutorTests {
         await #expect(throws: FileSystemError.absentSymbolicLink(staleLink)) {
             try await fileSystem.resolveSymbolicLink(staleLink)
         }
+        #expect(try await !fileSystem.contentsOfDirectory(staleLink.parentDirectory).contains(staleLink))
     }
 
     private func modificationDate(at path: AbsolutePath) throws -> Date {

--- a/cli/Tests/TuistGeneratorTests/Descriptors/SideEffectDescriptorExecutorTests.swift
+++ b/cli/Tests/TuistGeneratorTests/Descriptors/SideEffectDescriptorExecutorTests.swift
@@ -50,6 +50,19 @@ struct SideEffectDescriptorExecutorTests {
         #expect(try modificationDate(at: path) > oldDate)
     }
 
+    @Test(.inTemporaryDirectory) func execute_createsSymbolicLink() async throws {
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let destination = temporaryDirectory.appending(components: "Artifacts", "Module.xcframework")
+        let link = temporaryDirectory.appending(components: "Derived", "FrameworkSearchPaths", "Module.xcframework")
+        try await fileSystem.makeDirectory(at: destination)
+
+        try await subject.execute(sideEffects: [
+            .symbolicLink(SymbolicLinkDescriptor(path: link, destination: destination)),
+        ])
+
+        #expect(try await fileSystem.resolveSymbolicLink(link) == destination)
+    }
+
     @Test(.inTemporaryDirectory) func execute_cleansStaleGeneratedFiles() async throws {
         let directory = try #require(FileSystem.temporaryTestDirectory).appending(component: "ModuleMaps")
         let activeFile = directory.appending(component: "App-deps.modulemap")
@@ -73,6 +86,36 @@ struct SideEffectDescriptorExecutorTests {
         #expect(try await fileSystem.exists(activeFile))
         #expect(try await !fileSystem.exists(staleFile))
         #expect(try await fileSystem.exists(preservedFile))
+    }
+
+    @Test(.inTemporaryDirectory) func execute_cleansStaleGeneratedSymbolicLinks() async throws {
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let directory = temporaryDirectory.appending(component: "FrameworkSearchPaths")
+        let activeDestination = temporaryDirectory.appending(components: "Artifacts", "Active.framework")
+        let staleDestination = temporaryDirectory.appending(components: "Artifacts", "Stale.framework")
+        let activeLink = directory.appending(components: "Swift", "App", "Active.framework")
+        let staleLink = directory.appending(components: "Swift", "Deleted", "Stale.framework")
+        try await fileSystem.makeDirectory(at: activeDestination)
+        try await fileSystem.makeDirectory(at: staleDestination)
+        try await fileSystem.makeDirectory(at: activeLink.parentDirectory)
+        try await fileSystem.makeDirectory(at: staleLink.parentDirectory)
+        try await fileSystem.createSymbolicLink(from: activeLink, to: activeDestination)
+        try await fileSystem.createSymbolicLink(from: staleLink, to: staleDestination)
+
+        try await subject.execute(sideEffects: [
+            .generatedFilesCleanup(
+                GeneratedFilesCleanupDescriptor(
+                    directories: [directory],
+                    activeFilesByDirectory: [directory: [activeLink]],
+                    include: ["**/*.framework"]
+                )
+            ),
+        ])
+
+        #expect(try await fileSystem.resolveSymbolicLink(activeLink) == activeDestination)
+        await #expect(throws: FileSystemError.absentSymbolicLink(staleLink)) {
+            try await fileSystem.resolveSymbolicLink(staleLink)
+        }
     }
 
     private func modificationDate(at path: AbsolutePath) throws -> Date {

--- a/cli/Tests/TuistGeneratorTests/Mappers/FrameworkSearchPathsGraphMapperTests.swift
+++ b/cli/Tests/TuistGeneratorTests/Mappers/FrameworkSearchPathsGraphMapperTests.swift
@@ -70,7 +70,10 @@ final class FrameworkSearchPathsGraphMapperTests: TuistUnitTestCase {
         XCTAssertTrue(contents.contains("-F\(projectPath.appending(components: "Frameworks", "hash0").pathString)"))
 
         let swiftSearchPathCleanupDescriptor = try XCTUnwrap(
-            generatedFilesCleanupDescriptor(in: sideEffects, include: ["**/*.framework", "**/*.xcframework"])
+            generatedFilesCleanupDescriptor(
+                in: sideEffects,
+                include: ["Swift/*/*.framework", "Swift/*/*.xcframework"]
+            )
         )
         let swiftSearchPathDirectory = projectPath.appending(components: "Derived", "FrameworkSearchPaths")
         XCTAssertTrue(swiftSearchPathCleanupDescriptor.directories.contains(swiftSearchPathDirectory))

--- a/cli/Tests/TuistGeneratorTests/Mappers/FrameworkSearchPathsGraphMapperTests.swift
+++ b/cli/Tests/TuistGeneratorTests/Mappers/FrameworkSearchPathsGraphMapperTests.swift
@@ -55,7 +55,8 @@ final class FrameworkSearchPathsGraphMapperTests: TuistUnitTestCase {
         )
         let otherSwiftFlags = arrayValue(settings.base["OTHER_SWIFT_FLAGS"])
         XCTAssertTrue(otherSwiftFlags.contains("-F"))
-        XCTAssertTrue(otherSwiftFlags.contains("$(SRCROOT)/Frameworks/hash0"))
+        XCTAssertTrue(otherSwiftFlags.contains("$(SRCROOT)/Derived/FrameworkSearchPaths/Swift/App"))
+        XCTAssertFalse(otherSwiftFlags.contains("$(SRCROOT)/Frameworks/hash0"))
         // The precompiled paths live in the response file, not in FRAMEWORK_SEARCH_PATHS.
         XCTAssertFalse(arrayValue(settings.base["FRAMEWORK_SEARCH_PATHS"]).contains { $0.contains("/Frameworks/") })
 
@@ -67,6 +68,32 @@ final class FrameworkSearchPathsGraphMapperTests: TuistUnitTestCase {
         }.first)
         let contents = try XCTUnwrap(String(data: try XCTUnwrap(responseFile.contents), encoding: .utf8))
         XCTAssertTrue(contents.contains("-F\(projectPath.appending(components: "Frameworks", "hash0").pathString)"))
+
+        let swiftSearchPathCleanupDescriptor = try XCTUnwrap(
+            generatedFilesCleanupDescriptor(in: sideEffects, include: ["**/*.framework", "**/*.xcframework"])
+        )
+        let swiftSearchPathDirectory = projectPath.appending(components: "Derived", "FrameworkSearchPaths")
+        XCTAssertTrue(swiftSearchPathCleanupDescriptor.directories.contains(swiftSearchPathDirectory))
+        XCTAssertTrue(
+            swiftSearchPathCleanupDescriptor.activeFilesByDirectory[swiftSearchPathDirectory]?.contains(
+                projectPath.appending(components: "Derived", "FrameworkSearchPaths", "Swift", "App", "Module0.xcframework")
+            ) ?? false
+        )
+
+        XCTAssertTrue(
+            symbolicLinkDescriptors(in: sideEffects).contains(
+                SymbolicLinkDescriptor(
+                    path: projectPath.appending(
+                        components: "Derived",
+                        "FrameworkSearchPaths",
+                        "Swift",
+                        "App",
+                        "Module0.xcframework"
+                    ),
+                    destination: projectPath.appending(components: "Frameworks", "hash0", "Module0.xcframework")
+                )
+            )
+        )
     }
 
     func test_map_quotesResponseFileReference_whenTargetNameContainsWhitespace() async throws {
@@ -153,6 +180,53 @@ final class FrameworkSearchPathsGraphMapperTests: TuistUnitTestCase {
         )
     }
 
+    func test_map_keepsConflictingFrameworkNamesInline_whenConsolidatingSwiftSearchPaths() async throws {
+        // Given
+        let projectPath = try temporaryPath()
+        let app = Target.test(name: "App", product: .app)
+        let project = Project.test(path: projectPath, sourceRootPath: projectPath, targets: [app])
+        var xcframeworks: [GraphDependency] = [
+            .testXCFramework(
+                path: projectPath.appending(components: "Frameworks", "hash0", "Shared.xcframework"),
+                linking: .dynamic
+            ),
+            .testXCFramework(
+                path: projectPath.appending(components: "Frameworks", "hash1", "Shared.xcframework"),
+                linking: .dynamic
+            ),
+        ]
+        for i in 2 ..< 25 {
+            xcframeworks.append(
+                .testXCFramework(
+                    path: projectPath.appending(components: "Frameworks", "hash\(i)", "Module\(i).xcframework"),
+                    linking: .dynamic
+                )
+            )
+        }
+        var dependencies: [GraphDependency: Set<GraphDependency>] = [
+            .target(name: "App", path: projectPath): Set(xcframeworks),
+        ]
+        for xcframework in xcframeworks {
+            dependencies[xcframework] = Set()
+        }
+        let graph = Graph.test(projects: [projectPath: project], dependencies: dependencies)
+
+        // When
+        let (mappedGraph, sideEffects, _) = try await subject.map(graph: graph, environment: MapperEnvironment())
+
+        // Then
+        let settings = try XCTUnwrap(mappedGraph.projects[projectPath]?.targets["App"]?.settings)
+        let otherSwiftFlags = arrayValue(settings.base["OTHER_SWIFT_FLAGS"])
+        XCTAssertTrue(otherSwiftFlags.contains("$(SRCROOT)/Derived/FrameworkSearchPaths/Swift/App"))
+        XCTAssertTrue(otherSwiftFlags.contains("$(SRCROOT)/Frameworks/hash0"))
+        XCTAssertTrue(otherSwiftFlags.contains("$(SRCROOT)/Frameworks/hash1"))
+        XCTAssertFalse(otherSwiftFlags.contains("$(SRCROOT)/Frameworks/hash2"))
+
+        let symbolicLinks = symbolicLinkDescriptors(in: sideEffects)
+        XCTAssertFalse(symbolicLinks.contains { $0.destination.basename == "Shared.xcframework" })
+        XCTAssertTrue(symbolicLinks.contains { $0.destination.basename == "Module2.xcframework" })
+    }
+
     func test_map_keepsFrameworkSearchPaths_whenFewPrecompiledFrameworks() async throws {
         // Given
         let projectPath = try temporaryPath()
@@ -202,12 +276,20 @@ final class FrameworkSearchPathsGraphMapperTests: TuistUnitTestCase {
         }
     }
 
+    private func symbolicLinkDescriptors(in sideEffects: [SideEffectDescriptor]) -> [SymbolicLinkDescriptor] {
+        sideEffects.compactMap { sideEffect in
+            guard case let .symbolicLink(descriptor) = sideEffect else { return nil }
+            return descriptor
+        }
+    }
+
     private func generatedFilesCleanupDescriptor(
-        in sideEffects: [SideEffectDescriptor]
+        in sideEffects: [SideEffectDescriptor],
+        include: [String] = ["*.resp"]
     ) -> GeneratedFilesCleanupDescriptor? {
         sideEffects.compactMap { sideEffect in
             guard case let .generatedFilesCleanup(descriptor) = sideEffect else { return nil }
-            return descriptor
+            return descriptor.include == include ? descriptor : nil
         }.first
     }
 }


### PR DESCRIPTION
## What changed

Tuist now consolidates Swift framework search paths for targets that depend on many cached or external precompiled frameworks.

The mapper creates a generated per-target search directory under `Derived/FrameworkSearchPaths/Swift/<target>`, adds symbolic links for uniquely named `.framework` and `.xcframework` artifacts, and passes that single directory through `OTHER_SWIFT_FLAGS`.

It also adds side-effect support for symbolic links and cleans stale generated framework links when the graph changes.

## Why

A reproduction showed that large projects can emit hundreds of Swift `-F` entries when cached frameworks are restored into separate artifact directories. Swift import resolution walks those search paths while resolving imports, so every additional generated framework directory adds repeated filesystem work during clean builds.

## Root cause

`FrameworkSearchPathsGraphMapper` already consolidated the framework paths used by Clang and the linker into response files, but Swift still received every precompiled framework directory inline. That avoided an Xcode 26 issue where the ClangImporter and integrated SwiftDriver mishandle an `@file` token in Swift flags, but it left Swift with the full generated search-path list.

## Approach

This keeps the response-file behavior for Clang and linking unchanged, then gives Swift a separate generated lookup root.

Only artifacts with unique basenames are linked into the generated Swift search directory. Conflicting framework names stay inline so lookup behavior remains deterministic, and unsupported precompiled artifact paths also stay inline.

## Impact

Targets with many precompiled frameworks pass far fewer Swift framework search paths, which reduces the filesystem work during import resolution. Smaller targets below the existing consolidation threshold keep the previous `FRAMEWORK_SEARCH_PATHS` behavior.

## Validation

- `mise run cli:lint --fix`
- `tuist generate tuist TuistGenerator TuistGeneratorTests ProjectDescription --no-open`
- `xcodebuild test -workspace Tuist.xcworkspace -scheme Tuist-Workspace -only-testing TuistGeneratorTests/FrameworkSearchPathsGraphMapperTests -only-testing TuistGeneratorTests/SideEffectDescriptorExecutorTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" COMPILATION_CACHE_ENABLE_CACHING=NO`
