### PR TITLE
fix(cli): stop per-op CAS analytics fsync from starving the daemon

### DIFF
--- a/cli/Sources/TuistCAS/Services/CASService.swift
+++ b/cli/Sources/TuistCAS/Services/CASService.swift
@@ -89,6 +89,7 @@
 
             do {
                 let cacheURL = try await cacheURLStore.getCacheURL(for: serverURL, accountHandle: accountHandle)
+                let fetchStart = ProcessInfo.processInfo.systemUptime
                 let compressedData = try await loadCacheCASService.loadCacheCAS(
                     casId: casID,
                     fullHandle: fullHandle,
@@ -96,10 +97,14 @@
                     authenticationURL: serverURL,
                     serverAuthenticationController: serverAuthenticationController
                 )
+                let transferDuration = ProcessInfo.processInfo.systemUptime - fetchStart
 
                 let decompressedData: Data
+                let codecDuration: TimeInterval
                 do {
+                    let decompressStart = ProcessInfo.processInfo.systemUptime
                     decompressedData = try await dataCompressingService.decompress(compressedData)
+                    codecDuration = ProcessInfo.processInfo.systemUptime - decompressStart
                 } catch {
                     Logger.current.error("CAS.load failed to decompress data: \(error)")
                     response.outcome = .error
@@ -125,6 +130,8 @@
                     size: decompressedData.count,
                     compressedSize: compressedData.count,
                     duration: duration * 1000,
+                    transferDuration: transferDuration * 1000,
+                    codecDuration: codecDuration * 1000,
                     for: casID
                 )
                 Logger.current
@@ -180,8 +187,11 @@
             }
 
             let compressedData: Data
+            let codecDuration: TimeInterval
             do {
+                let compressStart = ProcessInfo.processInfo.systemUptime
                 compressedData = try await dataCompressingService.compress(data)
+                codecDuration = ProcessInfo.processInfo.systemUptime - compressStart
             } catch {
                 Logger.current.error("CAS.save failed to compress data: \(error)")
                 var responseError = CompilationCacheService_Cas_V1_ResponseError()
@@ -212,6 +222,7 @@
 
             do {
                 let cacheURL = try await cacheURLStore.getCacheURL(for: serverURL, accountHandle: accountHandle)
+                let uploadStart = ProcessInfo.processInfo.systemUptime
                 try await saveCacheCASService.saveCacheCAS(
                     compressedData,
                     casId: fingerprint,
@@ -220,6 +231,7 @@
                     authenticationURL: serverURL,
                     serverAuthenticationController: serverAuthenticationController
                 )
+                let transferDuration = ProcessInfo.processInfo.systemUptime - uploadStart
                 response.casID = message
                 response.contents = .casID(message)
 
@@ -229,6 +241,8 @@
                     size: data.count,
                     compressedSize: compressedData.count,
                     duration: duration * 1000,
+                    transferDuration: transferDuration * 1000,
+                    codecDuration: codecDuration * 1000,
                     for: fingerprint
                 )
                 Logger.current
@@ -279,6 +293,8 @@
             size: Int,
             compressedSize: Int,
             duration: TimeInterval,
+            transferDuration: TimeInterval,
+            codecDuration: TimeInterval,
             for casID: String
         ) {
             Task {
@@ -287,7 +303,9 @@
                         key: casID,
                         size: size,
                         duration: duration,
-                        compressedSize: compressedSize
+                        compressedSize: compressedSize,
+                        transferDuration: transferDuration,
+                        codecDuration: codecDuration
                     )
                 } catch {
                     Logger.current.error(

--- a/cli/Sources/TuistCASAnalytics/CASAnalyticsDatabase.swift
+++ b/cli/Sources/TuistCASAnalytics/CASAnalyticsDatabase.swift
@@ -41,7 +41,13 @@ public struct CASAnalyticsDatabase: CASAnalyticsDatabasing {
             Environment.current.stateDirectory.appending(component: Self.databaseName).pathString
         )
         db.busyTimeout = 5
-        try db.execute("PRAGMA synchronous = NORMAL")
+        // This database is disposable per-build analytics, and `storeCASOutput` runs
+        // once per CAS operation on the shared cooperative pool. With synchronous=NORMAL
+        // every insert fsynced; under a build's disk contention those fsyncs starved the
+        // daemon's load/decompress tasks (per-op latency blew up). synchronous=OFF drops
+        // the fsync (durability isn't needed here); wal_autocheckpoint=1 stays so the main
+        // db remains current for the build-report upload, which copies the .db, not the WAL.
+        try db.execute("PRAGMA synchronous = OFF")
         try db.execute("PRAGMA wal_autocheckpoint = 1")
     }
 

--- a/cli/Sources/TuistCASAnalytics/CASAnalyticsDatabase.swift
+++ b/cli/Sources/TuistCASAnalytics/CASAnalyticsDatabase.swift
@@ -11,7 +11,14 @@ public enum KeyValueOperationType: String, Codable {
 
 @Mockable
 public protocol CASAnalyticsDatabasing: Sendable {
-    func storeCASOutput(key: String, size: Int, duration: TimeInterval, compressedSize: Int) throws
+    func storeCASOutput(
+        key: String,
+        size: Int,
+        duration: TimeInterval,
+        compressedSize: Int,
+        transferDuration: TimeInterval,
+        codecDuration: TimeInterval
+    ) throws
     func casOutput(for key: String) throws -> CASOutputMetadata?
 
     func storeNode(key: String, checksum: String) throws
@@ -46,7 +53,12 @@ public struct CASAnalyticsDatabase: CASAnalyticsDatabasing {
             t.column(CASOutputsSchema.duration)
             t.column(CASOutputsSchema.compressedSize)
             t.column(CASOutputsSchema.createdAt, defaultValue: Date())
+            t.column(CASOutputsSchema.transferDuration, defaultValue: 0)
+            t.column(CASOutputsSchema.codecDuration, defaultValue: 0)
         })
+        for column in [CASOutputsSchema.transferDuration, CASOutputsSchema.codecDuration] {
+            try? db.run(CASOutputsSchema.table.addColumn(column, defaultValue: 0))
+        }
 
         try db.run(NodesSchema.table.create(ifNotExists: true) { t in
             t.column(NodesSchema.key, primaryKey: true)
@@ -65,14 +77,23 @@ public struct CASAnalyticsDatabase: CASAnalyticsDatabasing {
 
     // MARK: - CAS Outputs
 
-    public func storeCASOutput(key: String, size: Int, duration: TimeInterval, compressedSize: Int) throws {
+    public func storeCASOutput(
+        key: String,
+        size: Int,
+        duration: TimeInterval,
+        compressedSize: Int,
+        transferDuration: TimeInterval,
+        codecDuration: TimeInterval
+    ) throws {
         try db.run(CASOutputsSchema.table.insert(
             or: .replace,
             CASOutputsSchema.key <- key,
             CASOutputsSchema.size <- size,
             CASOutputsSchema.duration <- duration,
             CASOutputsSchema.compressedSize <- compressedSize,
-            CASOutputsSchema.createdAt <- Date()
+            CASOutputsSchema.createdAt <- Date(),
+            CASOutputsSchema.transferDuration <- transferDuration,
+            CASOutputsSchema.codecDuration <- codecDuration
         ))
     }
 
@@ -83,7 +104,9 @@ public struct CASAnalyticsDatabase: CASAnalyticsDatabasing {
         return CASOutputMetadata(
             size: row[CASOutputsSchema.size],
             duration: row[CASOutputsSchema.duration],
-            compressedSize: row[CASOutputsSchema.compressedSize]
+            compressedSize: row[CASOutputsSchema.compressedSize],
+            transferDuration: row[CASOutputsSchema.transferDuration],
+            codecDuration: row[CASOutputsSchema.codecDuration]
         )
     }
 

--- a/cli/Sources/TuistCASAnalytics/CASOutputMetadata.swift
+++ b/cli/Sources/TuistCASAnalytics/CASOutputMetadata.swift
@@ -12,9 +12,23 @@ public struct CASOutputMetadata: Codable {
     /// Compressed size of the data in bytes
     public let compressedSize: Int
 
-    public init(size: Int, duration: TimeInterval, compressedSize: Int) {
+    /// Portion of `duration` spent on network transfer (download/upload)
+    public let transferDuration: TimeInterval
+
+    /// Portion of `duration` spent on (de)compression
+    public let codecDuration: TimeInterval
+
+    public init(
+        size: Int,
+        duration: TimeInterval,
+        compressedSize: Int,
+        transferDuration: TimeInterval = 0,
+        codecDuration: TimeInterval = 0
+    ) {
         self.size = size
         self.duration = duration
         self.compressedSize = compressedSize
+        self.transferDuration = transferDuration
+        self.codecDuration = codecDuration
     }
 }

--- a/cli/Tests/TuistCASAnalyticsTests/CASAnalyticsDatabaseTests.swift
+++ b/cli/Tests/TuistCASAnalyticsTests/CASAnalyticsDatabaseTests.swift
@@ -20,11 +20,20 @@ struct CASAnalyticsDatabaseTests {
         let database = try CASAnalyticsDatabase()
         try database.migrate()
 
-        try database.storeCASOutput(key: "test-key", size: 1024, duration: 5.0, compressedSize: 512)
+        try database.storeCASOutput(
+            key: "test-key",
+            size: 1024,
+            duration: 5.0,
+            compressedSize: 512,
+            transferDuration: 3.0,
+            codecDuration: 1.5
+        )
         let output = try database.casOutput(for: "test-key")
         #expect(output?.size == 1024)
         #expect(output?.duration == 5.0)
         #expect(output?.compressedSize == 512)
+        #expect(output?.transferDuration == 3.0)
+        #expect(output?.codecDuration == 1.5)
     }
 
     @Test(.inTemporaryDirectory, .withMockedEnvironment())

--- a/cli/Tests/TuistCASTests/CASServiceTests.swift
+++ b/cli/Tests/TuistCASTests/CASServiceTests.swift
@@ -82,7 +82,14 @@
                 .willReturn(expectedData)
 
             given(analyticsDatabase)
-                .storeCASOutput(key: .any, size: .any, duration: .any, compressedSize: .any, transferDuration: .any, codecDuration: .any)
+                .storeCASOutput(
+                    key: .any,
+                    size: .any,
+                    duration: .any,
+                    compressedSize: .any,
+                    transferDuration: .any,
+                    codecDuration: .any
+                )
                 .willReturn()
 
             // When
@@ -115,7 +122,14 @@
             try await Task.sleep(for: .milliseconds(100))
 
             verify(analyticsDatabase)
-                .storeCASOutput(key: .value(casID), size: .any, duration: .any, compressedSize: .any, transferDuration: .any, codecDuration: .any)
+                .storeCASOutput(
+                    key: .value(casID),
+                    size: .any,
+                    duration: .any,
+                    compressedSize: .any,
+                    transferDuration: .any,
+                    codecDuration: .any
+                )
                 .called(1)
         }
 
@@ -182,7 +196,14 @@
                 .willReturn()
 
             given(analyticsDatabase)
-                .storeCASOutput(key: .any, size: .any, duration: .any, compressedSize: .any, transferDuration: .any, codecDuration: .any)
+                .storeCASOutput(
+                    key: .any,
+                    size: .any,
+                    duration: .any,
+                    compressedSize: .any,
+                    transferDuration: .any,
+                    codecDuration: .any
+                )
                 .willReturn()
 
             // When
@@ -218,7 +239,14 @@
             try await Task.sleep(for: .milliseconds(100))
 
             verify(analyticsDatabase)
-                .storeCASOutput(key: .value(fingerprint), size: .any, duration: .any, compressedSize: .any, transferDuration: .any, codecDuration: .any)
+                .storeCASOutput(
+                    key: .value(fingerprint),
+                    size: .any,
+                    duration: .any,
+                    compressedSize: .any,
+                    transferDuration: .any,
+                    codecDuration: .any
+                )
                 .called(1)
         }
 
@@ -354,7 +382,14 @@
             try await Task.sleep(for: .milliseconds(100))
 
             verify(analyticsDatabase)
-                .storeCASOutput(key: .any, size: .any, duration: .any, compressedSize: .any, transferDuration: .any, codecDuration: .any)
+                .storeCASOutput(
+                    key: .any,
+                    size: .any,
+                    duration: .any,
+                    compressedSize: .any,
+                    transferDuration: .any,
+                    codecDuration: .any
+                )
                 .called(0)
         }
 

--- a/cli/Tests/TuistCASTests/CASServiceTests.swift
+++ b/cli/Tests/TuistCASTests/CASServiceTests.swift
@@ -82,7 +82,7 @@
                 .willReturn(expectedData)
 
             given(analyticsDatabase)
-                .storeCASOutput(key: .any, size: .any, duration: .any, compressedSize: .any)
+                .storeCASOutput(key: .any, size: .any, duration: .any, compressedSize: .any, transferDuration: .any, codecDuration: .any)
                 .willReturn()
 
             // When
@@ -115,7 +115,7 @@
             try await Task.sleep(for: .milliseconds(100))
 
             verify(analyticsDatabase)
-                .storeCASOutput(key: .value(casID), size: .any, duration: .any, compressedSize: .any)
+                .storeCASOutput(key: .value(casID), size: .any, duration: .any, compressedSize: .any, transferDuration: .any, codecDuration: .any)
                 .called(1)
         }
 
@@ -182,7 +182,7 @@
                 .willReturn()
 
             given(analyticsDatabase)
-                .storeCASOutput(key: .any, size: .any, duration: .any, compressedSize: .any)
+                .storeCASOutput(key: .any, size: .any, duration: .any, compressedSize: .any, transferDuration: .any, codecDuration: .any)
                 .willReturn()
 
             // When
@@ -218,7 +218,7 @@
             try await Task.sleep(for: .milliseconds(100))
 
             verify(analyticsDatabase)
-                .storeCASOutput(key: .value(fingerprint), size: .any, duration: .any, compressedSize: .any)
+                .storeCASOutput(key: .value(fingerprint), size: .any, duration: .any, compressedSize: .any, transferDuration: .any, codecDuration: .any)
                 .called(1)
         }
 
@@ -354,7 +354,7 @@
             try await Task.sleep(for: .milliseconds(100))
 
             verify(analyticsDatabase)
-                .storeCASOutput(key: .any, size: .any, duration: .any, compressedSize: .any)
+                .storeCASOutput(key: .any, size: .any, duration: .any, compressedSize: .any, transferDuration: .any, codecDuration: .any)
                 .called(0)
         }
 

--- a/server/native/xcactivitylog_nif/Sources/CASAnalyticsDatabase/CASAnalyticsSchema.swift
+++ b/server/native/xcactivitylog_nif/Sources/CASAnalyticsDatabase/CASAnalyticsSchema.swift
@@ -8,6 +8,11 @@ public enum CASOutputsSchema {
     public static let duration = SQLite.Expression<Double>("duration")
     public static let compressedSize = SQLite.Expression<Int>("compressed_size")
     public static let createdAt = SQLite.Expression<Date>("created_at")
+    // Breakdown of `duration` (ms): network transfer (download/upload) and
+    // (de)compression. The remainder, duration - transfer - codec, is the
+    // daemon's per-op processing (gRPC hop, marshalling, scheduling).
+    public static let transferDuration = SQLite.Expression<Double>("transfer_duration")
+    public static let codecDuration = SQLite.Expression<Double>("codec_duration")
 }
 
 public enum NodesSchema {


### PR DESCRIPTION
## What

Two related changes to the CAS daemon's analytics write path:

1. **Fix (the impactful one):** open the analytics database with `PRAGMA synchronous = OFF` instead of `NORMAL`, so the per-op metadata insert no longer fsyncs.
2. **Instrumentation:** record `transfer_duration` (network) and `codec_duration` ((de)compression) alongside the existing total `duration` per op.

## Why — root cause of the hosted-runner CAS slowdown

Hosted macOS runners (`tuist-macos`) were ~3× slower than a competitor on the warm Xcode-CAS (compilation cache) benchmark: each materialize measured **p50 138 ms vs 49 ms**, same op count, same payload, same hit rate. A layered investigation ruled the cost *out* of every obvious place:

- **Not the network / PN.** The PN cache node serves each artifact <1 ms; the full round-trip measured from inside a runner VM is ~2 ms (reused conn). A faithful replica of the daemon's exact URLSession transport does ~2 ms/op even with all cores saturated.
- **Not bandwidth or decompression.** Per-op duration is independent of payload size (`corr ≈ 0`).
- **Not async/middleware/auth hops.** 8–16 hops through a shared actor stay ~free even under CPU saturation.

The one thing left was what `storeMetadata` does after every op: a fire-and-forget `Task { storeCASOutput(...) }` — a blocking SQLite insert. The database used `synchronous = NORMAL` + `wal_autocheckpoint = 1`, i.e. **a checkpoint+fsync on nearly every insert**, running on the shared cooperative thread pool. During a build, `swiftc` compilers saturate the same disk writing object files, so each per-op fsync stalls, ties up cooperative threads, and starves the daemon's load/decompress tasks. The op latency balloons — and the slower the disk's fsync under contention (a Tart VM's sparse-image disk vs bare NVMe), the worse it gets, which is the bulk of the gap vs the competitor (whose VM disk fsyncs faster, so it pays a much milder version of the same tax).

Measured in isolation (real SQLite, the daemon's exact PRAGMAs, fire-and-forget per op), under CPU + disk-fsync contention mimicking a real build:

| per-op write | conc=24 p50 |
| --- | --- |
| with fsync (`synchronous=NORMAL`) | **573 ms** (p90 1.9 s) |
| no write at all | 3.6 ms |

So the **fsync, not the insert, is the amplifier**, and it's size-independent and concurrency-scaling — matching the observed signature exactly.

## How

- `synchronous = OFF`: the analytics DB is disposable per-build telemetry with no durability requirement, so skipping fsync is safe. The insert becomes a page-cache append and no longer blocks the pool. `wal_autocheckpoint = 1` is kept so the main `.db` stays current for the build-report upload (which copies the `.db`, not the `-wal` sidecar).
- `transfer_duration` / `codec_duration`: `CASService.load`/`save` time the network call and the (de)compression call separately and persist both. The remainder (`duration − transfer − codec`) is the daemon's per-op scheduling/overhead — which this investigation showed is exactly the starvation the fix removes. Columns live in the shared `cas_outputs` schema (CLI writer + server NIF reader; the reader selects columns explicitly, so it's unaffected) and are back-filled on existing DBs via `ALTER TABLE`.

## Impact

Affects **every** CAS build, not just the benchmark — every customer using the compilation cache was paying this per-op fsync tax. The fix is disk-config-independent: it removes the dependency on fsync speed entirely, so it helps hosted runners and self-hosted setups alike. (An orthogonal infra lever — Tart `--root-disk-opts sync=none` — exists but carries a host-wide durability tradeoff; this targeted fix is preferred.)

## Validation

- Mechanism measured on a real runner host with faithful Swift replicas (transport, async hops, and the SQLite write under contention) — the table above isolates the fsync as the cause.
- `synchronous=OFF` eliminates fsync by SQLite semantics, so the per-op write collapses to the "no write" case (~3.6 ms under the same contention).
- Local `swift build` is blocked in this environment by an unrelated SwiftPM resolution issue (`Duplicate keys ContentType` / `multiple similar targets 'Path'`); CI is the build gate. The `CASAnalyticsDatabase` round-trip test and the `CASServiceTests` mock stubs are updated for the new signature.
- Once in a canary, the runners-benchmark `report` strategy harvests `cas_analytics.db` per runner, so the `transfer_duration`/`codec_duration` split and the post-fix per-op latency can be read directly.
