### PR TITLE
fix(infra): rebuild xcresult-processor image against current server

### DIFF
--- a/infra/xcresult-processor-image/AGENTS.md
+++ b/infra/xcresult-processor-image/AGENTS.md
@@ -111,3 +111,34 @@ one artifact, runtime selection. `TUIST_DEPLOY_ENV` picks which encrypted
 secrets bundle to decrypt with `MASTER_KEY`; everything else is
 configuration the Pod spec injects. A new env requires zero image
 changes — only a new Pod with new env vars.
+
+> **Note:** the env table and the `MASTER_KEY` / encrypted-blob description
+> above predate the #11460 secrets migration, which removed the blob and moved
+> the processor onto the ESO config Secret. They need a separate accurate
+> update — left out of this change to keep it a clean rebuild trigger.
+
+## Releasing this image & schema drift
+
+This image **bakes a full server release**, so its baked code can drift from the
+live DB schema if it isn't rebuilt when the server changes. The release gate
+(`mise/tasks/release/components.json` → `xcresult-processor-image`, evaluated by
+`git cliff` in `mise/tasks/release/check.sh`) is **scope-gated**: it cuts a new
+version only for conventional commits it doesn't skip — it skips `chore`, `ci`,
+and other-scoped commits — that touch `server/lib/tuist/**`, the xcresult NIF,
+`server/mix.{exs,lock}`, or this directory. That gate is intentionally
+conservative: the build runs Packer on a single bare-metal Mac mini and is
+expensive, so we deliberately do **not** rebuild on every server change.
+
+The tradeoff: a server change merged under a **skipped scope** (e.g. a
+`chore(server)` that also drops a column) won't auto-rebuild this image, so the
+baked release keeps running old code against the new schema. That happened once
+and took production down — the processor queried a column a migration had just
+dropped.
+
+**Runbook — when a schema- or runtime-affecting server change lands under a
+skipped scope:** cut a manual release so the image rebuilds against current
+`main`. The simplest way is a `fix`/`docs`-scoped commit touching this directory
+(this very commit is one), which makes `git cliff` bump the version and the
+`release-xcresult-processor-image` job rebuild + retag `:<version>` + `:latest`
+and rewrite the chart tag. To smoke-test image contents without cutting a
+version, dispatch `xcresult-processor-image.yml` for a throwaway `:<sha>` build.


### PR DESCRIPTION
## What

A trivial `fix(infra)`-scoped change to `infra/xcresult-processor-image/AGENTS.md` whose purpose is to **cut a fresh, versioned rebuild** of the xcresult-processor image so it bakes current `main`. git-cliff bumps it to `xcresult-processor-image@0.31.6`, and the `release-xcresult-processor-image` job rebuilds + retags `:0.31.6`/`:latest` and rewrites the chart's `xcresultProcessor` tag.

It also documents, in that AGENTS.md, the scope-gate drift gap + a manual-rebuild runbook, and flags that the env table there is stale post-#11460.

## Why — root cause

The xcresult-processor image **bakes a full server release**. Its release gate is scope-gated via git-cliff and **skips `chore`/`ci`/other-scoped commits**. #11460 (`chore(server)`) removed the Namespace code *and* dropped `accounts.namespace_tenant_id`, but produced no version bump for this image — so the deployed processor (`0.31.5`, built 2026-06-27 *before* #11460) kept running old code that queried the dropped column against the migrated schema, crash-looping. That was part of the production incident on 06-27.

`0.31.5` is the newest tag and predates #11460; there is no existing image with the fix, so one has to be built. This commit triggers that build off current `main` (verified: `Tuist.Namespace` is gone, 0 refs to `namespace_tenant_id` in `server/lib`).

## Why this and not a gate change (supersedes #11554)

#11554 proposed making the gate **path-based** (rebuild whenever any baked file under `server/lib/tuist/**` changes). That's more robust against drift, but it would rebuild the image on ~every server change — and the Packer build runs on a **single bare-metal Mac mini** and is expensive. We'd rather keep the gate conservative and trigger a rebuild **manually** when a schema/runtime-affecting server change lands under a skipped scope. This PR does exactly that and documents the procedure, so #11554 can be closed.

## Impact

- A new `0.31.6` image baking post-#11460 server code → the processor stops querying the dropped column. After it's live, the manually re-added `namespace_tenant_id` column can be dropped for good.
- No release-cadence change; the gate is unchanged.

## Validation

Locally, after this commit, `mise run release:check xcresult-processor-image` → `release? true`, `next: xcresult-processor-image@0.31.6` (via git-cliff's bump, no special-casing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)