### PR TITLE
fix(cli): recover or fail on test targets that enumerate present-but-empty

### DIFF
--- a/cli/Sources/TuistAutomation/XcodeBuild/XCTestEnumerator.swift
+++ b/cli/Sources/TuistAutomation/XcodeBuild/XCTestEnumerator.swift
@@ -21,15 +21,33 @@
         ///   - onlyTesting: xcodebuild `-only-testing` identifiers (typically module names) restricting which
         ///     targets are enumerated. Pass an empty array to enumerate everything. Used to re-enumerate a
         ///     single module in isolation when a bulk pass drops it.
-        /// - Returns: An array of test targets, each containing the target name and its test suite names (XCTest
-        ///   classes and Swift Testing suites alike). A target that was enumerated but contains no tests is
-        ///   returned with an empty `onlyTestIdentifiers`, so callers can distinguish it from a target that
-        ///   failed to enumerate (absent entirely).
+        /// - Returns: An ``XCTestEnumeration`` with the enumerated targets and any `errors` xcodebuild
+        ///   reported. A target that was enumerated but contains no tests is returned with an empty
+        ///   `onlyTestIdentifiers`; a target xcodebuild listed but could not boot/test is *also* reported
+        ///   present-but-empty, but accompanied by an entry in `errors` — so callers can tell a genuinely
+        ///   empty target apart from one whose tests could not be discovered.
         func enumerateTests(
             testProductsPath: AbsolutePath,
             destination: String?,
             onlyTesting: [String]
-        ) async throws -> [XCTestRun.TestTarget]
+        ) async throws -> XCTestEnumeration
+    }
+
+    /// The result of an `xcodebuild -enumerate-tests` pass.
+    public struct XCTestEnumeration: Equatable {
+        /// The enumerated test targets. A target with no discovered tests is present with an empty
+        /// `onlyTestIdentifiers` rather than omitted.
+        public let targets: [XCTestRun.TestTarget]
+
+        /// Free-form errors xcodebuild reported for targets it listed but could not test (for example a
+        /// target that failed to boot). Non-empty when at least one target could not be enumerated, even
+        /// though it may still appear in `targets` as present-but-empty.
+        public let errors: [String]
+
+        public init(targets: [XCTestRun.TestTarget], errors: [String] = []) {
+            self.targets = targets
+            self.errors = errors
+        }
     }
 
     public enum XCTestEnumeratorError: LocalizedError, Equatable {
@@ -59,7 +77,7 @@
             testProductsPath: AbsolutePath,
             destination: String?,
             onlyTesting: [String]
-        ) async throws -> [XCTestRun.TestTarget] {
+        ) async throws -> XCTestEnumeration {
             try await fileSystem.runInTemporaryDirectory(prefix: "tuist-test-enumeration") { temporaryDirectory in
                 let outputPath = temporaryDirectory.appending(component: "enumeration.json")
 
@@ -105,6 +123,7 @@
 
         private struct EnumerationOutput: Decodable {
             let values: [Node]
+            let errors: [String]?
         }
 
         private struct Node: Decodable {
@@ -114,12 +133,19 @@
         }
 
         /// Parses the JSON output of `xcodebuild -enumerate-tests` (hierarchical style). The hierarchy is
-        /// `plan → target → class → test`; each `target` node becomes a `TestTarget` whose identifiers are its
-        /// `class` children (XCTest classes and Swift Testing suites are both reported with `kind == "class"`).
+        /// `plan → target → class → test`; each `target` node becomes a `TestTarget`. A target's
+        /// `-only-testing` identifiers are its direct `class` children (XCTest classes and Swift Testing
+        /// `@Suite` types, both reported as `kind == "class"`) *and* its direct `test` children (top-level
+        /// Swift Testing `@Test` functions that have no enclosing suite, reported as `kind == "test"` directly
+        /// under the target). Both forms are emitted with names that are valid `-only-testing` identifiers.
         /// Targets appearing under multiple plans are merged, preserving first-seen order and de-duplicating
-        /// suites. A target with no `class` children is reported with an empty identifier list so callers can
-        /// tell an enumerated-but-empty target apart from one that never enumerated.
-        private func parseEnumerationOutput(_ data: Data, context: String) throws -> [XCTestRun.TestTarget] {
+        /// identifiers. A target with no such children is reported with an empty identifier list so callers
+        /// can tell an enumerated-but-empty target apart from one that never enumerated.
+        ///
+        /// The top-level `errors` array — which xcodebuild populates for targets it lists but cannot boot or
+        /// test — is surfaced verbatim so callers can distinguish a genuinely empty target from one whose
+        /// tests simply could not be discovered.
+        private func parseEnumerationOutput(_ data: Data, context: String) throws -> XCTestEnumeration {
             let output: EnumerationOutput
             do {
                 output = try JSONDecoder().decode(EnumerationOutput.self, from: data)
@@ -138,7 +164,11 @@
                         order.append(node.name)
                         suitesByTarget[node.name] = []
                     }
-                    for child in node.children ?? [] where child.kind == "class" {
+                    // A target's shardable units are its direct `class` children (XCTest classes / Swift
+                    // Testing `@Suite` types) and its direct `test` children (top-level `@Test` functions with
+                    // no enclosing suite). Tests nested inside a class are intentionally not collected — we
+                    // shard at suite granularity, not individual test methods.
+                    for child in node.children ?? [] where child.kind == "class" || child.kind == "test" {
                         if !suitesByTarget[node.name]!.contains(child.name) {
                             suitesByTarget[node.name]!.append(child.name)
                         }
@@ -154,7 +184,10 @@
                 visit(node)
             }
 
-            return order.map { XCTestRun.TestTarget(blueprintName: $0, onlyTestIdentifiers: suitesByTarget[$0] ?? []) }
+            let targets = order.map {
+                XCTestRun.TestTarget(blueprintName: $0, onlyTestIdentifiers: suitesByTarget[$0] ?? [])
+            }
+            return XCTestEnumeration(targets: targets, errors: output.errors ?? [])
         }
     }
 

--- a/cli/Sources/TuistKit/Services/Sharding/ShardPlanService.swift
+++ b/cli/Sources/TuistKit/Services/Sharding/ShardPlanService.swift
@@ -191,17 +191,20 @@
         /// Enumerates the test suites in the built test products for suite-granularity sharding.
         ///
         /// The module universe is taken from the `.xctestrun` (`expectedModules`), which is deterministic.
-        /// Suite discovery via `xcodebuild -enumerate-tests` is not — a flaky bulk pass can omit modules —
-        /// so to keep the plan complete we:
+        /// Suite discovery via `xcodebuild -enumerate-tests` is not: it boots the test bundles, so a module
+        /// can be reported either missing or — more insidiously — *present-but-empty* when its target fails to
+        /// boot (e.g. a flaky simulator under load). Both look identical to a genuinely empty target except
+        /// that xcodebuild records the failure in the enumeration's `errors`. To keep the plan complete we:
         ///
         /// 1. Run one bulk enumeration pass.
-        /// 2. Re-enumerate, per module, any `expectedModules` the bulk pass never reported (isolating a
-        ///    slow/failing target instead of redoing all of them).
+        /// 2. Re-enumerate, in isolation, every `expectedModules` the bulk pass produced *no suites* for —
+        ///    whether missing entirely or present-but-empty. An isolated pass disambiguates: finding suites
+        ///    recovers the module; reporting it present-but-empty with no errors confirms it is genuinely
+        ///    empty; anything else (errors, or still missing) is a real failure.
         /// 3. Reconcile against `expectedModules`:
         ///    - modules with suites are sharded at suite granularity;
-        ///    - modules that enumerated but reported *no* tests are genuinely empty and excluded;
-        ///    - a module that never enumerated at all (even after recovery) is a genuine failure and throws,
-        ///      rather than being silently dropped from the plan.
+        ///    - modules confirmed genuinely empty are excluded;
+        ///    - any remaining module failed to enumerate and throws, rather than being silently dropped.
         private func enumerateTestSuites(
             testProductsPath: AbsolutePath,
             destination: String?,
@@ -209,11 +212,9 @@
         ) async throws -> [String] {
             let expectedModules = Set(expectedModules)
             var suitesByModule: [String: Set<String>] = [:]
-            var enumeratedModules: Set<String> = []
 
-            func ingest(_ targets: [XCTestRun.TestTarget]) {
-                for target in targets {
-                    enumeratedModules.insert(target.blueprintName)
+            func ingest(_ enumeration: XCTestEnumeration) {
+                for target in enumeration.targets {
                     let suites = target.onlyTestIdentifiers ?? []
                     guard !suites.isEmpty else { continue }
                     suitesByModule[target.blueprintName, default: []].formUnion(suites)
@@ -223,39 +224,60 @@
             // 1. Bulk pass.
             ingest(try await enumerate(testProductsPath: testProductsPath, destination: destination, onlyTesting: []))
 
-            // 2. Per-target recovery for modules the bulk pass never reported.
-            let missingAfterBulk = expectedModules.subtracting(enumeratedModules).sorted()
-            if !missingAfterBulk.isEmpty {
+            // 2. Recovery for every expected module the bulk pass produced no suites for. A present-but-empty
+            //    target is ambiguous (genuinely empty vs. failed to boot), so we re-enumerate it in isolation
+            //    and let that pass arbitrate.
+            var confirmedEmptyModules: Set<String> = []
+            var failureDetailByModule: [String: String] = [:]
+            let modulesNeedingRecovery = expectedModules.filter { suitesByModule[$0] == nil }.sorted()
+            if !modulesNeedingRecovery.isEmpty {
                 Logger.current.warning(
-                    "Test enumeration reported \(expectedModules.intersection(enumeratedModules).count) of \(expectedModules.count) module(s); recovering \(missingAfterBulk.count) module(s) individually to avoid dropping tests from the shard plan."
+                    "Test enumeration produced suites for \(suitesByModule.count) of \(expectedModules.count) module(s); re-enumerating \(modulesNeedingRecovery.count) module(s) individually to avoid dropping tests from the shard plan."
                 )
-                for module in missingAfterBulk {
+                for module in modulesNeedingRecovery {
                     for _ in 1 ... Self.maxModuleRecoveryAttempts {
-                        ingest(try await enumerate(
+                        let enumeration = try await enumerate(
                             testProductsPath: testProductsPath,
                             destination: destination,
                             onlyTesting: [module]
-                        ))
-                        if enumeratedModules.contains(module) { break }
+                        )
+                        ingest(enumeration)
+                        if suitesByModule[module] != nil { break }
+                        if enumeration.errors.isEmpty,
+                           enumeration.targets.contains(where: { $0.blueprintName == module })
+                        {
+                            // Booted and enumerated cleanly, it simply has no tests.
+                            confirmedEmptyModules.insert(module)
+                            break
+                        }
+                        failureDetailByModule[module] = enumeration.errors.first
+                            ?? "the module was not reported by `xcodebuild -enumerate-tests`"
                     }
                 }
             }
 
-            // 3. Reconcile against the deterministic `.xctestrun` universe. A module that still can't be
-            // enumerated after per-target recovery is a genuine failure (e.g. a target that won't load), so
-            // fail loudly rather than silently dropping its tests from the plan.
-            let unenumerableModules = expectedModules.subtracting(enumeratedModules).sorted()
-            guard unenumerableModules.isEmpty else {
-                throw ShardPlanServiceError.modulesFailedToEnumerate(unenumerableModules)
+            // 3. Reconcile against the deterministic `.xctestrun` universe. A module we could neither find
+            // suites for nor confirm as genuinely empty failed to enumerate (e.g. a target that won't boot),
+            // so fail loudly — with the underlying xcodebuild error — rather than silently dropping its tests.
+            let failedModules = expectedModules
+                .filter { suitesByModule[$0] == nil }
+                .subtracting(confirmedEmptyModules)
+                .sorted()
+            guard failedModules.isEmpty else {
+                let details = failedModules.compactMap { module in
+                    failureDetailByModule[module].map { "\(module): \($0)" }
+                }
+                if !details.isEmpty {
+                    Logger.current.error(
+                        "Test enumeration failed for \(failedModules.count) module(s):\n\(details.joined(separator: "\n"))"
+                    )
+                }
+                throw ShardPlanServiceError.modulesFailedToEnumerate(failedModules)
             }
 
-            let emptyModules = expectedModules
-                .intersection(enumeratedModules)
-                .subtracting(suitesByModule.keys)
-                .sorted()
-            if !emptyModules.isEmpty {
+            if !confirmedEmptyModules.isEmpty {
                 Logger.current.debug(
-                    "\(emptyModules.count) module(s) enumerated no tests and are excluded as empty: \(emptyModules.joined(separator: ", "))."
+                    "\(confirmedEmptyModules.count) module(s) enumerated no tests and are excluded as empty: \(confirmedEmptyModules.sorted().joined(separator: ", "))."
                 )
             }
 
@@ -264,14 +286,15 @@
                 .sorted()
         }
 
-        /// Runs a single enumeration pass. A failed *isolated recovery* pass (`onlyTesting` non-empty) is
-        /// non-fatal — the module stays unenumerable and is handled by the whole-module backstop — while a
-        /// failed *bulk* pass is fatal, since there would be nothing to shard.
+        /// Runs a single enumeration pass. A failed *bulk* pass is fatal — there would be nothing to shard. A
+        /// failed *isolated recovery* pass (`onlyTesting` non-empty) is non-fatal but is surfaced as an
+        /// `errors` entry for the module being recovered, so the reconcile step fails loudly instead of
+        /// silently dropping it.
         private func enumerate(
             testProductsPath: AbsolutePath,
             destination: String?,
             onlyTesting: [String]
-        ) async throws -> [XCTestRun.TestTarget] {
+        ) async throws -> XCTestEnumeration {
             do {
                 return try await xcTestEnumerator.enumerateTests(
                     testProductsPath: testProductsPath,
@@ -283,7 +306,7 @@
                 Logger.current.debug(
                     "Per-target enumeration of \(onlyTesting.joined(separator: ", ")) failed: \(error.localizedDescription)"
                 )
-                return []
+                return XCTestEnumeration(targets: [], errors: [error.localizedDescription])
             }
         }
 

--- a/cli/Tests/TuistAutomationTests/XcodeBuild/XCTestEnumeratorTests.swift
+++ b/cli/Tests/TuistAutomationTests/XcodeBuild/XCTestEnumeratorTests.swift
@@ -75,9 +75,9 @@
                 onlyTesting: []
             )
 
-            let appTests = result.first { $0.blueprintName == "AppTests" }
+            let appTests = result.targets.first { $0.blueprintName == "AppTests" }
             #expect(appTests?.onlyTestIdentifiers == ["LoginTests", "SignupTests"])
-            let coreTests = result.first { $0.blueprintName == "CoreTests" }
+            let coreTests = result.targets.first { $0.blueprintName == "CoreTests" }
             #expect(coreTests?.onlyTestIdentifiers == ["NetworkTests"])
         }
 
@@ -96,7 +96,7 @@
                 onlyTesting: []
             )
 
-            #expect(result == [XCTestRun.TestTarget(
+            #expect(result.targets == [XCTestRun.TestTarget(
                 blueprintName: "FeatureTests",
                 onlyTestIdentifiers: ["GammaSuite", "DeltaSuite"]
             )])
@@ -134,7 +134,7 @@
             )
 
             #expect(consecutive(captured.value, "-destination", "platform=iOS Simulator,name=iPhone 16"))
-            let uiTests = result.first { $0.blueprintName == "UITests" }
+            let uiTests = result.targets.first { $0.blueprintName == "UITests" }
             #expect(uiTests?.onlyTestIdentifiers == ["SnapshotTests"])
         }
 
@@ -151,7 +151,58 @@
 
             // An enumerated-but-empty target must be reported (with no identifiers) rather than dropped, so
             // callers can tell it apart from a target that failed to enumerate entirely.
-            #expect(result == [XCTestRun.TestTarget(blueprintName: "EmptyTarget", onlyTestIdentifiers: [])])
+            #expect(result.targets == [XCTestRun.TestTarget(blueprintName: "EmptyTarget", onlyTestIdentifiers: [])])
+        }
+
+        @Test(.inTemporaryDirectory)
+        func enumerateTests_capturesTopLevelSwiftTestingFunctions() async throws {
+            let testProductsPath = try #require(FileSystem.temporaryTestDirectory)
+            // A top-level `@Test` function with no enclosing `@Suite` is reported as a `test` node directly
+            // under the target (not under a `class`). It must be captured as a `-only-testing` identifier —
+            // verbatim, parentheses included — so the target is not dropped as "empty". The `test` nested
+            // inside the class (`loggedIn()`) must NOT be captured: we shard at suite granularity.
+            givenEnumeration(json: #"""
+            {"errors":[],"values":[{"kind":"plan","name":"P","children":[
+              {"kind":"target","name":"FeatureTests","children":[
+                {"kind":"class","name":"LoginSuite","children":[{"kind":"test","name":"loggedIn()"}]},
+                {"kind":"test","name":"freeStandingTest()"}
+              ]}
+            ]}]}
+            """#)
+
+            let result = try await subject.enumerateTests(
+                testProductsPath: testProductsPath,
+                destination: nil,
+                onlyTesting: []
+            )
+
+            #expect(result.targets == [XCTestRun.TestTarget(
+                blueprintName: "FeatureTests",
+                onlyTestIdentifiers: ["LoginSuite", "freeStandingTest()"]
+            )])
+        }
+
+        @Test(.inTemporaryDirectory)
+        func enumerateTests_surfacesErrorsForTargetsThatCannotBeTested() async throws {
+            let testProductsPath = try #require(FileSystem.temporaryTestDirectory)
+            // A target xcodebuild lists but cannot boot is reported present-but-empty *and* recorded in the
+            // top-level `errors` array. Both must be surfaced so callers can tell it apart from a genuinely
+            // empty target.
+            givenEnumeration(json: #"""
+            {"errors":["Cannot test target UITests on iPhone 16: simulator failed to boot."],
+             "values":[{"kind":"plan","name":"P","children":[
+               {"kind":"target","name":"UITests"}
+             ]}]}
+            """#)
+
+            let result = try await subject.enumerateTests(
+                testProductsPath: testProductsPath,
+                destination: nil,
+                onlyTesting: []
+            )
+
+            #expect(result.targets == [XCTestRun.TestTarget(blueprintName: "UITests", onlyTestIdentifiers: [])])
+            #expect(result.errors == ["Cannot test target UITests on iPhone 16: simulator failed to boot."])
         }
 
         @Test(.inTemporaryDirectory)
@@ -193,7 +244,7 @@
                 onlyTesting: []
             )
 
-            #expect(result.isEmpty)
+            #expect(result.targets.isEmpty)
         }
 
         @Test(.inTemporaryDirectory)
@@ -210,9 +261,9 @@
                 onlyTesting: []
             )
 
-            let targetA = result.first { $0.blueprintName == "TargetA" }
+            let targetA = result.targets.first { $0.blueprintName == "TargetA" }
             #expect(targetA?.onlyTestIdentifiers == ["SuiteA"])
-            let targetB = result.first { $0.blueprintName == "TargetB" }
+            let targetB = result.targets.first { $0.blueprintName == "TargetB" }
             #expect(targetB?.onlyTestIdentifiers == ["SuiteB"])
         }
 

--- a/cli/Tests/TuistKitTests/Services/Sharding/ShardPlanServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/Sharding/ShardPlanServiceTests.swift
@@ -256,9 +256,13 @@ struct ShardPlanServiceTests {
             .enumerateTests(testProductsPath: .any, destination: .any, onlyTesting: .any)
             .willProduce { _, _, onlyTesting in
                 if onlyTesting.isEmpty {
-                    return [XCTestRun.TestTarget(blueprintName: "AppTests", onlyTestIdentifiers: ["LoginTests"])]
+                    return XCTestEnumeration(targets: [
+                        XCTestRun.TestTarget(blueprintName: "AppTests", onlyTestIdentifiers: ["LoginTests"]),
+                    ])
                 }
-                return [XCTestRun.TestTarget(blueprintName: "FeatureTests", onlyTestIdentifiers: ["FeatureFlagTests"])]
+                return XCTestEnumeration(targets: [
+                    XCTestRun.TestTarget(blueprintName: "FeatureTests", onlyTestIdentifiers: ["FeatureFlagTests"]),
+                ])
             }
 
         var capturedTestSuites: [String]?
@@ -305,10 +309,10 @@ struct ShardPlanServiceTests {
         let xcTestEnumerator = MockXCTestEnumerating()
         given(xcTestEnumerator)
             .enumerateTests(testProductsPath: .any, destination: .any, onlyTesting: .any)
-            .willReturn([
+            .willReturn(XCTestEnumeration(targets: [
                 XCTestRun.TestTarget(blueprintName: "AppTests", onlyTestIdentifiers: ["LoginTests", "SignupTests"]),
                 XCTestRun.TestTarget(blueprintName: "FeatureTests", onlyTestIdentifiers: ["FeatureFlagTests"]),
-            ])
+            ]))
 
         var capturedTestSuites: [String]?
         let createShardPlanService = mockCreateShardPlanService(capturingTestSuites: { capturedTestSuites = $0 })
@@ -352,14 +356,16 @@ struct ShardPlanServiceTests {
         let testProductsPath = temporaryDirectory.appending(component: "MyApp.xctestproducts")
         try await writeXCTestProducts(modules: ["AppTests", "EmptyTests"], at: testProductsPath, fileSystem: fileSystem)
 
-        // EmptyTests enumerates but reports no tests (an empty target); AppTests reports a suite.
+        // EmptyTests enumerates but reports no tests (an empty target) with no errors; AppTests reports a
+        // suite. Because a present-but-empty target is ambiguous, EmptyTests is re-enumerated in isolation,
+        // which confirms (no errors) that it is genuinely empty.
         let xcTestEnumerator = MockXCTestEnumerating()
         given(xcTestEnumerator)
             .enumerateTests(testProductsPath: .any, destination: .any, onlyTesting: .any)
-            .willReturn([
+            .willReturn(XCTestEnumeration(targets: [
                 XCTestRun.TestTarget(blueprintName: "AppTests", onlyTestIdentifiers: ["LoginTests"]),
                 XCTestRun.TestTarget(blueprintName: "EmptyTests", onlyTestIdentifiers: []),
-            ])
+            ]))
 
         var capturedTestSuites: [String]?
         let createShardPlanService = mockCreateShardPlanService(capturingTestSuites: { capturedTestSuites = $0 })
@@ -391,8 +397,8 @@ struct ShardPlanServiceTests {
 
         // EmptyTests enumerated no tests, so it is excluded; AppTests is unaffected.
         #expect(capturedTestSuites == ["AppTests/LoginTests"])
-        // Every module enumerated (EmptyTests is simply empty), so no per-target recovery is needed.
-        verify(xcTestEnumerator).enumerateTests(testProductsPath: .any, destination: .any, onlyTesting: .any).called(1)
+        // One bulk pass plus one isolated pass that confirms EmptyTests is genuinely empty (no errors).
+        verify(xcTestEnumerator).enumerateTests(testProductsPath: .any, destination: .any, onlyTesting: .any).called(2)
     }
 
     /// A module that never enumerates — even after per-target recovery — must not be silently dropped: it is a
@@ -408,7 +414,9 @@ struct ShardPlanServiceTests {
         let xcTestEnumerator = MockXCTestEnumerating()
         given(xcTestEnumerator)
             .enumerateTests(testProductsPath: .any, destination: .any, onlyTesting: .any)
-            .willReturn([XCTestRun.TestTarget(blueprintName: "AppTests", onlyTestIdentifiers: ["LoginTests"])])
+            .willReturn(XCTestEnumeration(targets: [
+                XCTestRun.TestTarget(blueprintName: "AppTests", onlyTestIdentifiers: ["LoginTests"]),
+            ]))
 
         let createShardPlanService = mockCreateShardPlanService(capturingTestSuites: { _ in })
         let shardMatrixOutputService = MockShardMatrixOutputServicing()
@@ -443,6 +451,122 @@ struct ShardPlanServiceTests {
         // Bulk pass plus the bounded per-target recovery attempts before failing.
         verify(xcTestEnumerator)
             .enumerateTests(testProductsPath: .any, destination: .any, onlyTesting: .any).called(3)
+    }
+
+    /// A module the bulk pass reports present-but-empty *with* an accompanying enumeration error (e.g. a
+    /// target that failed to boot) is ambiguous, so it is re-enumerated in isolation. When the isolated pass
+    /// succeeds the module is recovered into the plan rather than silently dropped — the trade-me flaky-boot
+    /// scenario where a re-boot discovers the tests the bulk pass missed.
+    @Test(.inTemporaryDirectory, .withMockedDependencies())
+    func plan_suiteGranularity_recoversModuleReportedEmptyWithErrorsThatThenEnumerates() async throws {
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let fileSystem = FileSystem()
+        let testProductsPath = temporaryDirectory.appending(component: "MyApp.xctestproducts")
+        try await writeXCTestProducts(modules: ["AppTests", "UITests"], at: testProductsPath, fileSystem: fileSystem)
+
+        let xcTestEnumerator = MockXCTestEnumerating()
+        given(xcTestEnumerator)
+            .enumerateTests(testProductsPath: .any, destination: .any, onlyTesting: .any)
+            .willProduce { _, _, onlyTesting in
+                if onlyTesting.isEmpty {
+                    // Bulk pass: UITests failed to boot — present but empty, with an error.
+                    return XCTestEnumeration(
+                        targets: [
+                            XCTestRun.TestTarget(blueprintName: "AppTests", onlyTestIdentifiers: ["LoginTests"]),
+                            XCTestRun.TestTarget(blueprintName: "UITests", onlyTestIdentifiers: []),
+                        ],
+                        errors: ["Cannot test target UITests: simulator failed to boot."]
+                    )
+                }
+                // Isolated recovery pass: UITests boots and enumerates this time.
+                return XCTestEnumeration(targets: [
+                    XCTestRun.TestTarget(blueprintName: "UITests", onlyTestIdentifiers: ["SnapshotTests"]),
+                ])
+            }
+
+        var capturedTestSuites: [String]?
+        let createShardPlanService = mockCreateShardPlanService(capturingTestSuites: { capturedTestSuites = $0 })
+        let shardMatrixOutputService = MockShardMatrixOutputServicing()
+        given(shardMatrixOutputService).output(.any).willReturn()
+
+        let subject = ShardPlanService(
+            xcTestEnumerator: xcTestEnumerator,
+            createShardPlanService: createShardPlanService,
+            fileSystem: fileSystem,
+            shardMatrixOutputService: shardMatrixOutputService
+        )
+
+        _ = try await subject.plan(
+            xctestproductsPath: testProductsPath,
+            destination: "platform=macOS",
+            reference: "ref",
+            shardGranularity: .suite,
+            shardMin: nil,
+            shardMax: nil,
+            shardTotal: 1,
+            shardMaxDuration: nil,
+            fullHandle: "tuist/tuist",
+            serverURL: try #require(URL(string: "https://tuist.dev")),
+            buildRunId: nil,
+            skipUpload: true,
+            archivePath: nil
+        )
+
+        // UITests is recovered by the isolated pass rather than silently dropped as "empty".
+        #expect(capturedTestSuites?.sorted() == ["AppTests/LoginTests", "UITests/SnapshotTests"])
+    }
+
+    /// A module reported present-but-empty *with* an enumeration error on every pass (bulk and every isolated
+    /// recovery attempt) failed to enumerate — a boot failure looks like a genuinely empty target except for
+    /// the error. It must fail the plan loudly rather than being silently dropped, which is exactly the
+    /// trade-me regression (a 70-target plan shipping only the dozen that happened to boot).
+    @Test(.inTemporaryDirectory, .withMockedDependencies())
+    func plan_suiteGranularity_throwsForModuleThatAlwaysEnumeratesEmptyWithErrors() async throws {
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let fileSystem = FileSystem()
+        let testProductsPath = temporaryDirectory.appending(component: "MyApp.xctestproducts")
+        try await writeXCTestProducts(modules: ["AppTests", "UITests"], at: testProductsPath, fileSystem: fileSystem)
+
+        let xcTestEnumerator = MockXCTestEnumerating()
+        given(xcTestEnumerator)
+            .enumerateTests(testProductsPath: .any, destination: .any, onlyTesting: .any)
+            .willReturn(XCTestEnumeration(
+                targets: [
+                    XCTestRun.TestTarget(blueprintName: "AppTests", onlyTestIdentifiers: ["LoginTests"]),
+                    XCTestRun.TestTarget(blueprintName: "UITests", onlyTestIdentifiers: []),
+                ],
+                errors: ["Cannot test target UITests: simulator failed to boot."]
+            ))
+
+        let createShardPlanService = mockCreateShardPlanService(capturingTestSuites: { _ in })
+        let shardMatrixOutputService = MockShardMatrixOutputServicing()
+        given(shardMatrixOutputService).output(.any).willReturn()
+
+        let subject = ShardPlanService(
+            xcTestEnumerator: xcTestEnumerator,
+            createShardPlanService: createShardPlanService,
+            fileSystem: fileSystem,
+            shardMatrixOutputService: shardMatrixOutputService
+        )
+
+        let serverURL = try #require(URL(string: "https://tuist.dev"))
+        await #expect(throws: ShardPlanServiceError.modulesFailedToEnumerate(["UITests"])) {
+            _ = try await subject.plan(
+                xctestproductsPath: testProductsPath,
+                destination: "platform=macOS",
+                reference: "ref",
+                shardGranularity: .suite,
+                shardMin: nil,
+                shardMax: nil,
+                shardTotal: 1,
+                shardMaxDuration: nil,
+                fullHandle: "tuist/tuist",
+                serverURL: serverURL,
+                buildRunId: nil,
+                skipUpload: true,
+                archivePath: nil
+            )
+        }
     }
 
     private func mockCreateShardPlanService(


### PR DESCRIPTION
## Why

A suite-granularity shard plan could silently drop test targets. A test plan with **70 targets produced a shard plan covering only 12** — and the count swung run to run (as low as 2, as high as 69), so most targets' tests simply never ran.

## Root cause

The plan is built from `xcodebuild -enumerate-tests`, which **boots each test bundle** to discover its tests. When a runner can't launch, xcodebuild still lists the target as a `target` node **with no test children**, and records the failure in the enumeration's top-level `errors` array:

```json
"errors": [ "UITests01-Runner encountered an error. (Underlying Error: Early unexpected exit, operation never finished bootstrapping …)" ],
"values": [{ "kind": "plan", "children": [
  { "kind": "target", "name": "UITests01" },                   // present, ZERO children
  { "kind": "target", "name": "AppTests", "children": [        // booted fine
      { "kind": "class", "name": "LoginTests", … } ] } ]}]
```

`XCTestEnumerator` decoded only `values` and **ignored `errors`**, so a boot-failed target was indistinguishable from a genuinely empty one — `ShardPlanService` classified it "empty" and excluded it. No throw fired (the target is *present*, not *absent*, so the prior absent-only recovery never ran). The run-to-run variance is just *which* runners fail to launch each time.

**Reproduced locally.** A 20-target iOS fixture (10 unit + 10 UI tests, one scheme) enumerated 12× back-to-back: all 20 targets present every run, but the number returned present-but-empty swung **0 → 15 of 20** on identical inputs — the same pattern at small scale. Findings:
- The trigger is the test **runner failing to bootstrap under boot contention** (`"…Early unexpected exit, operation never finished bootstrapping…"`). It hits **unit-test targets too**, not just UI tests.
- On a real boot failure the **`errors` array is populated** (errors count ≈ empty count every run) → the classification below is sound against real failures, not just the deterministic stand-in.
- Re-enumerating a dropped target **in isolation** (`-only-testing <target>`) recovers it cleanly (suites found, 0 errors) — one-at-a-time booting removes the contention.

A secondary gap surfaced in the same investigation: top-level Swift Testing `@Test` functions (no enclosing `@Suite`) enumerate as `kind == "test"` **directly under the target**, which the parser (class-only) also missed.

## Fix

- **`XCTestEnumerator`** returns a new `XCTestEnumeration { targets, errors }` that surfaces xcodebuild's `errors`, and now collects a target's direct `class` **and** `test` children (top-level `@Test` functions), using the enumerated names verbatim — both are valid `-only-testing` identifiers (verified empirically; free functions need the trailing `()`).
- **`ShardPlanService`** re-enumerates, in isolation, every expected module the bulk pass produced **no suites** for — present-but-empty as well as absent. The isolated pass arbitrates:
  - suites found → **recovered** into the plan;
  - present-but-empty with **no errors** → genuinely empty → excluded;
  - otherwise (errors, or still missing) → **failure** → throws `modulesFailedToEnumerate` (logging the underlying xcodebuild error) instead of silently shipping an incomplete plan.

The throw is the hard guarantee: a flaky run now either recovers a complete plan or fails loudly (CI retries), never silently skips the bulk of the tests.

## Tests

Updated the existing suite-granularity tests for the new return type/semantics, plus new coverage:
- enumerator: captures top-level `@Test` functions (and still ignores nested class-test methods); surfaces `errors`.
- planner: a module reported empty-with-errors is **recovered** when an isolated pass succeeds; a module empty-with-errors on every pass **throws**.

All scoped `TuistUnitTests` (`XCTestEnumeratorTests`, `ShardPlanServiceTests`, `ShardServiceTests`) pass locally.

## Alternatives considered

- **Constrain xcodebuild's parallelism** (`-parallel-testing-enabled NO`): tested on the repro loop — **did not help** (drops stayed 0→15/20). The contention is at the simulator runner-boot level, not xcodebuild's worker cloning, so that flag isn't the lever.
- **The only effective concurrency control is targets-per-invocation** — i.e. chunking the bulk call via `-only-testing`. This PR's recovery is exactly that at the limit (K=1, proven 100% reliable in the repro), applied reactively to the targets that failed. A proactive small-batch enumeration (cap K per call from the start) is a reasonable alternative that may scale better than bulk-then-recover for very large plans, at the cost of being slower on healthy ones; easy to switch to if preferred. The throw bound keeps either approach safe.
- **Static enumeration (no boot)** is the durable fix: reading the test metadata from the built `.xctest` binaries (Mach-O ObjC metadata for XCTest + Swift Testing's test-content section; `MachOKit` is already a dependency) discovers tests with **zero runner boots**, eliminating the bootstrap flakiness entirely and making this recovery machinery a thin safety net. Out of scope here; worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
