### PR TITLE
fix(cli): resolve renamed macro cache artifacts

### DIFF
--- a/cli/Tests/TuistCacheEETests/Storage/CacheLocalStorageTests.swift
+++ b/cli/Tests/TuistCacheEETests/Storage/CacheLocalStorageTests.swift
@@ -251,6 +251,44 @@ struct CacheLocalStorageTests {
     }
 
     @Test(.inTemporaryDirectory)
+    func fetch_whenMacroProductNameDiffersFromTargetNameWithValidSignature() async throws {
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+
+        let hash = "123"
+        let cacheDirectory = temporaryDirectory.appending(component: "cache")
+        try await fileSystem.makeDirectory(at: cacheDirectory)
+
+        let cacheDirectoriesProvider = MockCacheDirectoriesProviding()
+        given(cacheDirectoriesProvider)
+            .cacheDirectory(for: .value(.binaries))
+            .willReturn(cacheDirectory)
+
+        let hashDirectory = cacheDirectory.appending(component: hash)
+        let artifactPath = hashDirectory.appending(component: "MacroProduct.macro")
+        try await fileSystem.makeDirectory(at: hashDirectory)
+        try await fileSystem.touch(artifactPath)
+
+        let artifactSigner = MockArtifactSigning()
+        given(artifactSigner).isValid(.value(artifactPath)).willReturn(true)
+
+        let subject = CacheLocalStorage(
+            cacheDirectoriesProvider: cacheDirectoriesProvider,
+            artifactSigner: artifactSigner,
+            fileSystem: fileSystem
+        )
+
+        let got = try await subject.fetch(
+            Set([.init(name: "MacroTarget", hash: hash)]), cacheCategory: .binaries
+        )
+
+        #expect(got.count == 1)
+        let artifact = try #require(got.first)
+        #expect(artifact.key.hash == hash)
+        #expect(artifact.key.name == "MacroTarget")
+        #expect(artifact.value == artifactPath)
+    }
+
+    @Test(.inTemporaryDirectory)
     func fetch_whenMacroExistsWithInvalidSignature() async throws {
         let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
 

--- a/cli/Tests/TuistCacheEETests/Storage/CacheRemoteStorageTests.swift
+++ b/cli/Tests/TuistCacheEETests/Storage/CacheRemoteStorageTests.swift
@@ -118,6 +118,35 @@ struct CacheRemoteStorageTests {
         #expect(try artifactSigner.isValid(path) == true)
     }
 
+    @Test(.inTemporaryDirectory) func fetch_when_macro_product_name_differs_from_target_name() async throws {
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let macroPath = temporaryDirectory.appending(component: "MacroProduct.macro")
+        try await fileSystem.touch(macroPath)
+        let zipPath = try await FileArchiver(paths: [macroPath]).zip(name: "test")
+
+        let serverCacheArtifact = ServerCacheArtifact.test()
+
+        given(getCacheService).getCache(
+            serverURL: .value(Constants.URLs.production),
+            projectId: .value(fullHandle),
+            hash: .value("hash"),
+            name: .value("MacroTarget"),
+            cacheCategory: .value(.binaries)
+        ).willReturn(serverCacheArtifact)
+        given(downloader).download(item: .any, url: .value(serverCacheArtifact.url)).willReturn(zipPath)
+
+        let got = try await subject.fetch(
+            Set([.init(name: "MacroTarget", hash: "hash")]),
+            cacheCategory: .binaries
+        )
+
+        let path = try #require(
+            got[.test(name: "MacroTarget", hash: "hash", source: .remote, cacheCategory: .binaries)]
+        )
+        #expect(path.basename == "MacroProduct.macro")
+        #expect(try artifactSigner.isValid(path) == true)
+    }
+
     @Test(.inTemporaryDirectory) func fetch_when_framework_artifact_exists() async throws {
         // Given
         let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)

--- a/cli/Tests/TuistCacheEETests/Storage/ModuleCacheRemoteStorageTests.swift
+++ b/cli/Tests/TuistCacheEETests/Storage/ModuleCacheRemoteStorageTests.swift
@@ -74,6 +74,66 @@ struct ModuleCacheRemoteStorageTests {
         )
     }
 
+    @Test(.inTemporaryDirectory) func fetch_when_macro_product_name_differs_from_target_name() async throws {
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let macroPath = temporaryDirectory.appending(component: "MacroProduct.macro")
+        try await fileSystem.touch(macroPath)
+        let zipPath = try await FileArchiver(paths: [macroPath]).zip(name: "test")
+        let zipData = try Data(contentsOf: zipPath.url)
+
+        given(downloadModuleCacheService)
+            .downloadModuleCacheArtifact(
+                accountHandle: .value("tuist"),
+                projectHandle: .value("tuist"),
+                hash: .value("hash"),
+                name: .value("MacroTarget.zip"),
+                cacheCategory: .value("builds"),
+                serverURL: .value(Constants.URLs.production),
+                authenticationURL: .value(Constants.URLs.production),
+                serverAuthenticationController: .any
+            )
+            .willReturn(zipData)
+
+        let got = try await subject.fetch(
+            Set([.init(name: "MacroTarget", hash: "hash")]),
+            cacheCategory: .binaries
+        )
+
+        let path = try #require(
+            got[.test(name: "MacroTarget", hash: "hash", source: .remote, cacheCategory: .binaries)]
+        )
+        #expect(path.basename == "MacroProduct.macro")
+        #expect(try artifactSigner.isValid(path) == true)
+    }
+
+    @Test(.inTemporaryDirectory) func fetch_when_downloaded_archive_does_not_contain_artifact_returns_empty() async throws {
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let frameworkPath = temporaryDirectory.appending(component: "Other.framework")
+        try await fileSystem.makeDirectory(at: frameworkPath)
+        let zipPath = try await FileArchiver(paths: [frameworkPath]).zip(name: "test")
+        let zipData = try Data(contentsOf: zipPath.url)
+
+        given(downloadModuleCacheService)
+            .downloadModuleCacheArtifact(
+                accountHandle: .value("tuist"),
+                projectHandle: .value("tuist"),
+                hash: .value("hash"),
+                name: .value("Target.zip"),
+                cacheCategory: .value("builds"),
+                serverURL: .value(Constants.URLs.production),
+                authenticationURL: .value(Constants.URLs.production),
+                serverAuthenticationController: .any
+            )
+            .willReturn(zipData)
+
+        let got = try await subject.fetch(
+            Set([.init(name: "Target", hash: "hash")]),
+            cacheCategory: .binaries
+        )
+
+        #expect(got.isEmpty == true)
+    }
+
     // MARK: - Authentication Failure Tests (401/403)
 
     @Test(.inTemporaryDirectory, .withMockedLogger(), .withScopedAlertController())


### PR DESCRIPTION
## What changed

This parent change points the cache package submodule at the storage-layer fix and adds coverage for macro cache artifacts whose product name differs from the target name. It also covers the module-cache path where a downloaded archive does not contain a usable artifact.

## Related pull requests

- Cache package implementation: https://github.com/tuist/TuistCacheEE/pull/67

## Why

There is already a storage fetch step that decides whether a cache artifact is present before the graph is mutated. The issue was that this step looked for macro artifacts using the target name only, while Swift macro artifacts can be named after the macro product instead.

## Root cause

For packages such as Point-Free's dependencies package, the cache item can be keyed by a target like `DependenciesMacrosPlugin`, while the restored executable artifact is named after the macro product, for example `DependenciesMacros.macro`. The storage layer treated that present artifact as missing because it only searched for `DependenciesMacrosPlugin.macro`.

## Approach

The cache package keeps the exact artifact-name lookup first. If that lookup fails, it accepts a single `.macro` artifact in the restored directory or archive. When the module-cache archive does not contain a matching artifact at all, it now returns the normal cache miss path instead of force-unwrapping a missing value.

## Impact

Renamed macro artifacts are restored and used correctly. If a macro artifact is genuinely absent, the existing cache miss behavior keeps the affected targets on sources instead of producing a generated project that references an unusable artifact.

## Validation

- `mise run cli:lint --fix`
- `xcodebuild test -workspace Tuist.xcworkspace -scheme TuistCacheEEUnitTests -destination 'platform=macOS' '-only-testing:TuistCacheEETests/CacheLocalStorageTests/fetch_whenMacroProductNameDiffersFromTargetNameWithValidSignature()' '-only-testing:TuistCacheEETests/CacheRemoteStorageTests/fetch_when_macro_product_name_differs_from_target_name()' '-only-testing:TuistCacheEETests/ModuleCacheRemoteStorageTests/fetch_when_macro_product_name_differs_from_target_name()' '-only-testing:TuistCacheEETests/ModuleCacheRemoteStorageTests/fetch_when_downloaded_archive_does_not_contain_artifact_returns_empty()' CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" COMPILATION_CACHE_ENABLE_CACHING=NO`
- `git diff --check`
- `git -C cli/TuistCacheEE diff --check`
