### PR TITLE
Fix app archive cache configuration mismatch

### DIFF
--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -226,7 +226,7 @@ jobs:
         run: |
           sed -i '' -e "s/CFBundleVersion.*/CFBundleVersion\": \"${{ github.run_number }}\",/g" "app/Project.swift"
       - name: Generate TuistApp
-        run: mise x -- tuist generate TuistApp
+        run: mise x -- tuist generate TuistApp --configuration Release
       - name: Bundle iOS app
         if: |
           github.event_name == 'push' ||


### PR DESCRIPTION
Resolves <https://github.com/tuist/tuist/issues/11488>

The device archive workflow now generates `TuistApp` with the `Release` configuration before bundling the application. The archive task already builds `Release`, but the previous generation step did not pass a configuration, so binary cache lookup defaulted to the debug configuration. That let a `Release` archive link restored binaries produced for a different configuration, which can change the executable size reported by bundle inspection.

This keeps the binary cache profile unchanged and aligns graph restoration with the archive configuration.

### How to test locally

- `ruby -e 'require "psych"; Psych.load_file(".github/workflows/app.yml"); puts "app.yml parsed"'`
- `git diff --check origin/main..HEAD`
