### PR TITLE
docs(infra): restore drill for the Barman Cloud Plugin recovery path

### DIFF
--- a/infra/cnpg/README.md
+++ b/infra/cnpg/README.md
@@ -111,20 +111,48 @@ Continuous WAL archiving + daily 03:00 UTC base backups, both targeting the per-
 
 The Tigris key used for backups is **separate** from the workload's `S3_CREDENTIALS` — a dedicated `S3_BACKUP_CREDENTIALS` item per env, scoped to the env's backup bucket only. Rotate it independently from the workload key.
 
-Restore-validation drill (run quarterly, or before any operation that depends on backups being usable):
+Restore-validation drill (run quarterly, or before any operation that depends on
+backups being usable). Build a one-shot recovery `Cluster` that replays from the
+archive, run validation queries against it, then delete it (and its PVCs). The
+recovery-source shape depends on which backup mode the cluster is in.
 
-```bash
-ENV=staging
-NAMESPACE=tuist-$ENV
-CLUSTER=tuist-tuist-pg
+**Plugin path** (`…backup.plugin.enabled: true`) — recover through
+`externalClusters[].plugin`, reusing the `ObjectStore` CR the chart already
+renders in the namespace. `serverName` is the original cluster name (the archive
+prefix), `barmanObjectName` is the rendered store (`tuist-tuist-pg-backup-store`
+for the main cluster, `tuist-ops-pg-backup-store` for tuist-ops):
 
-# Create a one-shot cluster restored to the latest available recovery
-# point. CNPG provisions a new primary, replays from the WAL archive,
-# and reports the recovery target it landed on.
-kubectl cnpg backup-status -n "$NAMESPACE" "$CLUSTER"
-# Then build a restore manifest using `kubectl cnpg restore` (see the
-# CNPG docs); destroy it once the validation queries finish.
+```yaml
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: tuist-tuist-pg-restore-check
+  namespace: tuist-staging
+spec:
+  instances: 1
+  storage:
+    size: 100Gi            # >= the source cluster's storage
+  bootstrap:
+    recovery:
+      source: source
+  externalClusters:
+    - name: source
+      plugin:
+        name: barman-cloud.cloudnative-pg.io
+        parameters:
+          barmanObjectName: tuist-tuist-pg-backup-store
+          serverName: tuist-tuist-pg
 ```
+
+**In-tree path** (`…backup.plugin.enabled: false`, the pre-cutover default) —
+same `bootstrap.recovery` + `externalClusters`, but the entry uses
+`barmanObjectStore:` (the `destinationPath` + `endpointURL` + `s3Credentials`)
+instead of `plugin:`.
+
+Apply the manifest, wait for `phase: Cluster in healthy state`, run the
+validation queries, then `kubectl delete cluster` it. Note: with the plugin,
+backup state shows in the `ObjectStore`/`Cluster` status rather than the in-tree
+`kubectl cnpg backup-status` view.
 
 ## Operator version & upgrade path
 


### PR DESCRIPTION
Follow-up to the approving review on #11544 (pepicrft): before flipping `…backup.plugin.enabled` in any env, the restore-validation drill needs to recover through the plugin, not in-tree `barmanObjectStore`.

Updates `infra/cnpg/README.md` so the drill documents the plugin recovery shape: `bootstrap.recovery` + `externalClusters[].plugin` referencing the chart-rendered `ObjectStore` by `barmanObjectName`, with `serverName` pinned to the cluster name (the archive prefix). Keeps the in-tree shape too, since the flag is per-cluster during the transition.

Docs-only (restore is an ad-hoc operator action, not chart-rendered), so no deploy impact. This is the prerequisite the review flagged for the cutover; the plugin install itself (#11544) is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)