### PR TITLE
feat(infra): cut backups over to the Barman Cloud Plugin + restore-drill docs (all envs)

### DIFF
--- a/infra/cnpg/README.md
+++ b/infra/cnpg/README.md
@@ -111,20 +111,48 @@ Continuous WAL archiving + daily 03:00 UTC base backups, both targeting the per-
 
 The Tigris key used for backups is **separate** from the workload's `S3_CREDENTIALS` — a dedicated `S3_BACKUP_CREDENTIALS` item per env, scoped to the env's backup bucket only. Rotate it independently from the workload key.
 
-Restore-validation drill (run quarterly, or before any operation that depends on backups being usable):
+Restore-validation drill (run quarterly, or before any operation that depends on
+backups being usable). Build a one-shot recovery `Cluster` that replays from the
+archive, run validation queries against it, then delete it (and its PVCs). The
+recovery-source shape depends on which backup mode the cluster is in.
 
-```bash
-ENV=staging
-NAMESPACE=tuist-$ENV
-CLUSTER=tuist-tuist-pg
+**Plugin path** (`…backup.plugin.enabled: true`) — recover through
+`externalClusters[].plugin`, reusing the `ObjectStore` CR the chart already
+renders in the namespace. `serverName` is the original cluster name (the archive
+prefix), `barmanObjectName` is the rendered store (`tuist-tuist-pg-backup-store`
+for the main cluster, `tuist-ops-pg-backup-store` for tuist-ops):
 
-# Create a one-shot cluster restored to the latest available recovery
-# point. CNPG provisions a new primary, replays from the WAL archive,
-# and reports the recovery target it landed on.
-kubectl cnpg backup-status -n "$NAMESPACE" "$CLUSTER"
-# Then build a restore manifest using `kubectl cnpg restore` (see the
-# CNPG docs); destroy it once the validation queries finish.
+```yaml
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: tuist-tuist-pg-restore-check
+  namespace: tuist-staging
+spec:
+  instances: 1
+  storage:
+    size: 100Gi            # >= the source cluster's storage
+  bootstrap:
+    recovery:
+      source: source
+  externalClusters:
+    - name: source
+      plugin:
+        name: barman-cloud.cloudnative-pg.io
+        parameters:
+          barmanObjectName: tuist-tuist-pg-backup-store
+          serverName: tuist-tuist-pg
 ```
+
+**In-tree path** (`…backup.plugin.enabled: false`, the pre-cutover default) —
+same `bootstrap.recovery` + `externalClusters`, but the entry uses
+`barmanObjectStore:` (the `destinationPath` + `endpointURL` + `s3Credentials`)
+instead of `plugin:`.
+
+Apply the manifest, wait for `phase: Cluster in healthy state`, run the
+validation queries, then `kubectl delete cluster` it. Note: with the plugin,
+backup state shows in the `ObjectStore`/`Cluster` status rather than the in-tree
+`kubectl cnpg backup-status` view.
 
 ## Operator version & upgrade path
 

--- a/infra/cnpg/README.md
+++ b/infra/cnpg/README.md
@@ -221,8 +221,9 @@ in the `platform` namespace alongside the operator, which is where the plugin
 must run. It's idle until a `Cluster` opts in, so installing it changes no
 backups. Bump it like any other platform dependency: edit the pin and redeploy.
 It needs cert-manager (already a platform dependency) and adds the
-`objectstores.barmancloud.cnpg.io` CRD, the `barman-cloud` Deployment, a
-Service, and self-signed mTLS Certificates.
+`objectstores.barmancloud.cnpg.io` CRD, the `platform-plugin-barman-cloud`
+Deployment (release-prefixed as a subchart), a Service, and self-signed mTLS
+Certificates.
 
 **Cutover (per env):** with the plugin installed, flip
 `…backup.plugin.enabled` to `true` and deploy. This is an atomic change to the

--- a/infra/helm/tuist-ops/values.yaml
+++ b/infra/helm/tuist-ops/values.yaml
@@ -84,7 +84,7 @@ postgresql:
     # namespace (`platform`) — see infra/cnpg/README.md. Default off: no-op
     # until flipped after validating WAL continuity + a restore drill.
     plugin:
-      enabled: false
+      enabled: true
       name: barman-cloud.cloudnative-pg.io
 
 ingress:

--- a/infra/helm/tuist/values-managed-canary.yaml
+++ b/infra/helm/tuist/values-managed-canary.yaml
@@ -208,6 +208,11 @@ postgresql:
         memory: "8Gi"
     backup:
       destinationPath: s3://tuist-can-pg-backups/
+      # Cut over to the Barman Cloud Plugin (installed cluster-wide by the
+      # platform chart). Same bucket + serverName, so the archive prefix is
+      # unchanged. See infra/cnpg/README.md.
+      plugin:
+        enabled: true
 
 processor:
   replicaCount: 1

--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -253,6 +253,11 @@ postgresql:
         memory: "16Gi"
     backup:
       destinationPath: s3://tuist-prod-pg-backups/
+      # Cut over to the Barman Cloud Plugin (installed cluster-wide by the
+      # platform chart). Same bucket + serverName, so the archive prefix is
+      # unchanged. See infra/cnpg/README.md.
+      plugin:
+        enabled: true
 
 clickhouse:
   external:

--- a/infra/helm/tuist/values-managed-staging.yaml
+++ b/infra/helm/tuist/values-managed-staging.yaml
@@ -250,6 +250,11 @@ postgresql:
         memory: "4Gi"
     backup:
       destinationPath: s3://tuist-stag-pg-backups/
+      # Cut over to the Barman Cloud Plugin (installed cluster-wide by the
+      # platform chart). Same bucket + serverName, so the archive prefix is
+      # unchanged. See infra/cnpg/README.md.
+      plugin:
+        enabled: true
 
 processor:
   # Single replica on staging — 2-replica redundancy isn't needed for a


### PR DESCRIPTION
## What this does

Cuts every CNPG cluster's backups over from the in-tree `barmanObjectStore` to the **Barman Cloud Plugin**, and ships the matching recovery docs in the same change:

1. **Cutover** — flips `…backup.plugin.enabled` to `true` in all envs at once: `tuist` main cluster (`values-managed-{staging,canary,production}.yaml`) and `tuist-ops` (`values.yaml`).
2. **Restore-drill docs** — updates `infra/cnpg/README.md` so the restore drill recovers through the plugin (`bootstrap.recovery` + `externalClusters[].plugin` → the rendered `ObjectStore` by `barmanObjectName`, `serverName` pinned to the cluster name), with the in-tree shape kept for the transition. This is pepicrft's gating follow-up from the #11544 review — folding it in here means the recovery docs land exactly when the flip happens (closes #11563).
3. Minor: corrects the plugin deployment name in the README (`platform-plugin-barman-cloud`, release-prefixed as a subchart).

The plugin itself is already installed fleet-wide and idle (#11544, confirmed `platform-plugin-barman-cloud` Running 1/1 on canary + prod). This is the flip that puts it to work.

## What merging does

Each cluster's `Cluster` spec swaps `.spec.backup.barmanObjectStore` for `.spec.plugins` (+ an `ObjectStore` CR, `ScheduledBackup method: plugin`). That's an atomic Cluster change, so it triggers a **rolling update + primary switchover** per cluster — same shape as an operator bump. **Merge in a low-traffic window.** The production-deployment cascade flips **canary first**, runs acceptance tests, then production, so it's naturally canary-gated despite being one PR (staging flips via its own deploy path).

## Continuity & safety

- `serverName` stays pinned to the cluster name (the in-tree default) and the bucket/`destinationPath` is unchanged, so the plugin continues the **same archive prefix** — no new base backup, no orphaned PITR. Verified by `helm template`: production renders `plugins` (serverName `tuist-tuist-pg`, ObjectStore `tuist-tuist-pg-backup-store`) + `method: plugin`, no `barmanObjectStore`.
- Reversible: flip back to `false` and the in-tree path resumes (still supported on 1.29).
- Fallback: the in-tree backups taken up to the cutover remain in the same bucket.

## After merge (verify)

1. Watch canary roll, then prod — confirm instances converge with a primary elected.
2. Confirm WAL archiving continues on the plugin path: primary pod logs show `Archived WAL file` to the same `s3://…/<serverName>` path, no persistent errors, `pg_wal` not piling.
3. Run the restore-validation drill (now documented for the plugin) from a plugin-written backup.
4. Repoint backup observability: metrics rename `cnpg_collector_*` -> `barman_cloud_cloudnative_pg_io_*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
