### PR TITLE
fix(server): grant id-token to the deploy legs calling server-deployment.yml

### DIFF
--- a/.github/workflows/server-production-deployment.yml
+++ b/.github/workflows/server-production-deployment.yml
@@ -1893,6 +1893,13 @@ jobs:
     # caught by skip-propagation and is itself skipped even when `build`
     # succeeded, so the whole deploy tail must re-assert success explicitly.
     if: ${{ always() && needs.build.result == 'success' && needs.check-releases.outputs.is-hotfix != 'true' }}
+    # server-deployment.yml's build-kura-runtime job requests id-token: write;
+    # a reusable workflow's permissions are validated against the caller at
+    # startup, so this leg must grant the callee's full permission union.
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
     uses: ./.github/workflows/server-deployment.yml
     with:
       environment: canary
@@ -2037,6 +2044,11 @@ jobs:
       needs.acceptance-tests.result == 'success' &&
       needs.backward-compatibility-acceptance.result == 'success' &&
       needs.check-releases.outputs.is-hotfix != 'true'
+    # See `canary` above: grant the callee's full permission union.
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
     uses: ./.github/workflows/server-deployment.yml
     with:
       environment: production
@@ -2053,6 +2065,11 @@ jobs:
   production-hotfix:
     needs: [check-releases, build]
     if: ${{ always() && needs.build.result == 'success' && needs.check-releases.outputs.is-hotfix == 'true' }}
+    # See `canary` above: grant the callee's full permission union.
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
     uses: ./.github/workflows/server-deployment.yml
     with:
       environment: production


### PR DESCRIPTION
## What changed

Grants `id-token: write` (alongside `contents: read` + `packages: write`) on the three jobs in `server-production-deployment.yml` that call the reusable `server-deployment.yml` workflow — `canary`, `production`, and `production-hotfix`.

## Why — root cause

#11536 added a `build-kura-runtime` job to the reusable `server-deployment.yml`. That job declares `id-token: write` so `tuist bazel setup` can mint an OIDC token for the Tuist remote cache.

`server-production-deployment.yml` invokes `server-deployment.yml` via `uses:` from three deploy legs. None of them granted `id-token` — the workflow-level permissions are `contents: write / pull-requests: read / statuses: write / packages: write` only.

A reusable workflow **cannot request more permission than the calling job grants**, and GitHub validates this **statically at startup, before `if` conditions are evaluated**. So even though `build-kura-runtime` is staging-only and is skipped on every cascade leg (`environment == 'staging'`), its declared `id-token: write` exceeds the caller's grant, and the entire **Server Production Deployment** run failed with `startup_failure`:

- Failed run: https://github.com/tuist/tuist/actions/runs/28389553232 (on `main`, the #11536 merge commit)

The standalone `workflow_dispatch` path was unaffected — a top-level workflow's job can freely request `id-token`; only a reusable caller caps it. That's why CI was green on the #11536 PR branch and the breakage only surfaced once it merged and the push-to-`main` cascade ran.

## Why this fix

Granting the callee's full permission union on the calling jobs is the standard requirement for reusable workflows that contain an OIDC-using job. `id-token` is never actually exercised on canary/production (the kura build doesn't run there) — the grant exists solely to satisfy startup validation.

Scoped **per-job** rather than at the workflow level so the elevated token doesn't extend to the cascade's many release jobs, mirroring how the existing `acceptance-tests` job already declares its own `id-token: write`.

## Validation

- `actionlint` clean on the edited regions (only the repo's pre-existing `tuist-*` self-hosted-label notes and unrelated SC2086 `info` notes remain).
- Permission union verified against every job in `server-deployment.yml`: `build` (packages: write), `build-kura-runtime` (packages: write + id-token: write), and the install/deploy jobs (contents: read) — all ≤ `contents: read` + `packages: write` + `id-token: write`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)