### PR TITLE
refactor(infra): manage Atlas read-only role membership via CNPG

### DIFF
--- a/infra/cnpg/tuist-ops-ro-grants.sql
+++ b/infra/cnpg/tuist-ops-ro-grants.sql
@@ -29,12 +29,11 @@ GRANT USAGE ON SCHEMA :"tuist_schema" TO tuist_ops_ro;
 GRANT USAGE ON SCHEMA pg_catalog TO tuist_ops_ro;
 GRANT USAGE ON SCHEMA information_schema TO tuist_ops_ro;
 
--- Let the web runtime role assume tuist_ops_ro via `SET ROLE` for the internal
--- Atlas query runner (Tuist.Ops.Database.execute with role: "tuist_ops_ro"),
--- which drops to this least-privilege role before running operator-supplied
--- SQL. `INHERIT FALSE` keeps tuist_web from passively gaining pg_read_all_data
--- — it must explicitly SET ROLE. `SET TRUE` permits that switch. Requires PG16+.
-GRANT tuist_ops_ro TO tuist_web WITH INHERIT FALSE, SET TRUE;
+-- NOTE: the web runtime role's membership in tuist_ops_ro (so the internal
+-- Atlas query runner can `SET ROLE tuist_ops_ro`) is managed declaratively by
+-- CNPG via `managed.roles[tuist_web].inRoles` + `inherit: false` in
+-- infra/helm/tuist/templates/postgresql-cnpg.yaml — CNPG reconciles it, so there
+-- is no manual GRANT here.
 
 REVOKE INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER
   ON ALL TABLES IN SCHEMA :"tuist_schema" FROM tuist_ops_ro;

--- a/infra/cnpg/tuist-ops-ro-grants.sql
+++ b/infra/cnpg/tuist-ops-ro-grants.sql
@@ -29,12 +29,6 @@ GRANT USAGE ON SCHEMA :"tuist_schema" TO tuist_ops_ro;
 GRANT USAGE ON SCHEMA pg_catalog TO tuist_ops_ro;
 GRANT USAGE ON SCHEMA information_schema TO tuist_ops_ro;
 
--- NOTE: the web runtime role's membership in tuist_ops_ro (so the internal
--- Atlas query runner can `SET ROLE tuist_ops_ro`) is managed declaratively by
--- CNPG via `managed.roles[tuist_web].inRoles` + `inherit: false` in
--- infra/helm/tuist/templates/postgresql-cnpg.yaml — CNPG reconciles it, so there
--- is no manual GRANT here.
-
 REVOKE INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER
   ON ALL TABLES IN SCHEMA :"tuist_schema" FROM tuist_ops_ro;
 ALTER DEFAULT PRIVILEGES IN SCHEMA :"tuist_schema"

--- a/infra/helm/tuist/templates/postgresql-cnpg.yaml
+++ b/infra/helm/tuist/templates/postgresql-cnpg.yaml
@@ -153,6 +153,17 @@ spec:
       - name: {{ .Values.postgresql.cnpg.roles.web.name | quote }}
         ensure: present
         login: true
+        # `inherit: false` so membership in tuist_ops_ro (below) lets the web
+        # role `SET ROLE tuist_ops_ro` for the internal Atlas query runner
+        # WITHOUT passively inheriting pg_read_all_data — keeping the web role's
+        # own footprint at its direct grants. NOINHERIT is safe here: the web
+        # role's application privileges are granted directly, not via any role
+        # membership. CNPG reconciles this membership, so no manual GRANT is
+        # needed (replaces the GRANT line that used to live in
+        # infra/cnpg/tuist-ops-ro-grants.sql).
+        inherit: false
+        inRoles:
+          - {{ .Values.postgresql.cnpg.roles.opsRo.name | quote }}
         comment: "Tuist web runtime role"
         passwordSecret:
           name: {{ $webRoleSecretName }}

--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -103,12 +103,13 @@ server:
     # role via `SET LOCAL ROLE` by setting:
     #   - name: TUIST_ATLAS_DB_READONLY_ROLE
     #     value: tuist_ops_ro
-    # Left unset on purpose: that switch requires `GRANT tuist_ops_ro TO
-    # tuist_web` from infra/cnpg/tuist-ops-ro-grants.sql, which is a manual CNPG
-    # bootstrap/restore step — NOT applied by the Helm deploy. Enabling the env
-    # var before the grant is (re-)applied would make every Atlas DB query raise
-    # on `SET LOCAL ROLE`. Until then the runner stays on the web role behind the
-    # read-only transaction; flip this on in a follow-up once the grant has run.
+    # Left unset for now. The membership that permits the switch (web -> tuist_ops_ro)
+    # is now reconciled declaratively by CNPG (`managed.roles[tuist_web].inRoles`),
+    # so no manual grant is needed — but enable this only once CNPG has reconciled
+    # the membership on the cluster (verify: the tuist_web -> tuist_ops_ro row in
+    # pg_auth_members has inherit_option = false), otherwise the first Atlas DB
+    # query would raise on `SET LOCAL ROLE`. Until then the runner stays on the web
+    # role behind the read-only transaction.
     - name: TUIST_ATLAS_TOKEN_JWKS
       value: >-
         {"keys":[{"use":"sig","kty":"RSA","kid":"RlVpaMmFrqqIHY46_HT42inm4mfvqBKfwLVJiPCcl7g","alg":"RS256","n":"urnlzTgGSYHPHyc-sjXI7lzdx3ChfMpqUMpwuj1vgBMywpvdjFEKZ-5xWBBfS_GIna4q--YBau4zo21xFw0Jd-Ye8l4daXozFTwB1oOv-xOoIL7YITR8dtXsXzqeGIKx1rt90jE2vgvYQDBnkIf9ohgDIApbLICYGSAko5MfdypYhiO52KOxum8nB5dwIaKhr2-DiLQtFQbl__c6Uk2dFpW0_5u4d-uO6yspp5iVo54sc7XIlFNxPBlx2uVQZe8tvTH9Ipc_sovDjMfoKH7g0fG14q6xQU5CkQD1pNS__6J3xFvFYQEp3wXu4i_Rin65EI9GvNKtbZkH-sQ5e8jzLw","e":"AQAB"}]}


### PR DESCRIPTION
## What

Follow-up to #11519. Moves the `tuist_web → tuist_ops_ro` role **membership** (which lets the internal Atlas query runner `SET ROLE tuist_ops_ro`) from the manually-run `infra/cnpg/tuist-ops-ro-grants.sql` into the **CNPG managed-roles** spec, so the operator reconciles it automatically.

- `managed.roles[tuist_web]` gains `inRoles: [tuist_ops_ro]` + `inherit: false`.
- Drops the `GRANT tuist_ops_ro TO tuist_web …` line from the grants `.sql` (the object grants — CONNECT/USAGE/REVOKE — stay there; CNPG can't manage those).

## Why

The grants file is a manual `kubectl cnpg psql` bootstrap/restore step, not applied by the Helm deploy. Making the membership declarative removes that manual step and the deploy-ordering footgun: CNPG keeps the membership present, so enabling `TUIST_ATLAS_DB_READONLY_ROLE` later can't land before the grant exists.

`inherit: false` (role-level NOINHERIT) is what keeps `tuist_web` from *passively* inheriting `pg_read_all_data` — it must explicitly `SET ROLE`. In PG16, a membership granted to a NOINHERIT role defaults to non-inheriting. NOINHERIT is safe here because the web role's application privileges are **direct** grants, not via any role membership.

## Verify after reconcile

`tuist_web → tuist_ops_ro` should be non-inheriting:

```sql
SELECT g.rolname AS member, r.rolname AS role, m.inherit_option
FROM pg_auth_members m
JOIN pg_roles r ON r.oid = m.roleid
JOIN pg_roles g ON g.oid = m.member
WHERE r.rolname = 'tuist_ops_ro' AND g.rolname = 'tuist_web';
-- inherit_option should be 'f'
```

Once confirmed, flip on `TUIST_ATLAS_DB_READONLY_ROLE: tuist_ops_ro` in `values-managed-production.yaml` to activate the least-privilege role for the Atlas runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
