### PR TITLE
fix(cli): resolve local package dependencies

### DIFF
--- a/cli/Sources/TuistKit/Services/InstallService.swift
+++ b/cli/Sources/TuistKit/Services/InstallService.swift
@@ -13,6 +13,7 @@ import TuistLoader
 import TuistLogging
 import TuistPlugin
 import TuistSupport
+import XcodeGraph
 
 @Mockable
 protocol InstallServicing {
@@ -28,6 +29,7 @@ struct InstallService: InstallServicing {
     private let configLoader: ConfigLoading
     private let swiftPackageManagerController: SwiftPackageManagerControlling
     private let swiftPackageManagerScratchDirectoryLocator: SwiftPackageManagerScratchDirectoryLocator
+    private let manifestLoader: ManifestLoading
     private let manifestFilesLocator: ManifestFilesLocating
     private let fileSystem: FileSysteming
 
@@ -37,6 +39,7 @@ struct InstallService: InstallServicing {
         swiftPackageManagerController: SwiftPackageManagerControlling = SwiftPackageManagerController(),
         swiftPackageManagerScratchDirectoryLocator: SwiftPackageManagerScratchDirectoryLocator =
             SwiftPackageManagerScratchDirectoryLocator(),
+        manifestLoader: ManifestLoading = ManifestLoader.current,
         fileSystem: FileSysteming = FileSystem(),
         manifestFilesLocator: ManifestFilesLocating = ManifestFilesLocator()
     ) {
@@ -44,6 +47,7 @@ struct InstallService: InstallServicing {
         self.configLoader = configLoader
         self.swiftPackageManagerController = swiftPackageManagerController
         self.swiftPackageManagerScratchDirectoryLocator = swiftPackageManagerScratchDirectoryLocator
+        self.manifestLoader = manifestLoader
         self.fileSystem = fileSystem
         self.manifestFilesLocator = manifestFilesLocator
     }
@@ -112,6 +116,15 @@ struct InstallService: InstallServicing {
             at: packageManifestPath.parentDirectory,
             scratchDirectory: scratchDirectory
         )
+        var visitedPackageFolders: Set<String> = []
+        var knownPackageIdentities: Set<String> = []
+        try await resolveLocalPackageDependencies(
+            scratchDirectory: scratchDirectory,
+            update: update,
+            arguments: SwiftPackageManagerArguments.removingCustomScratchPathArguments(mergedArguments),
+            knownPackageIdentities: &knownPackageIdentities,
+            visitedPackageFolders: &visitedPackageFolders
+        )
     }
 
     private func arguments(config: Tuist, passthroughArguments: [String]) -> [String] {
@@ -150,5 +163,113 @@ struct InstallService: InstallServicing {
             try await fileSystem.remove(destinationPath)
         }
         try await fileSystem.copy(sourcePath, to: destinationPath)
+    }
+
+    private func resolveLocalPackageDependencies(
+        scratchDirectory: AbsolutePath,
+        update: Bool,
+        arguments: [String],
+        knownPackageIdentities: inout Set<String>,
+        visitedPackageFolders: inout Set<String>
+    ) async throws {
+        guard let workspaceState = try await workspaceState(scratchDirectory: scratchDirectory) else {
+            return
+        }
+        knownPackageIdentities.formUnion(
+            workspaceState.object.dependencies.map { $0.packageRef.identity.lowercased() }
+        )
+
+        for dependency in workspaceState.object.dependencies
+            where isLocalDependencyKind(dependency.packageRef.kind)
+        {
+            guard let packageFolder = localPackageFolder(for: dependency, scratchDirectory: scratchDirectory),
+                  visitedPackageFolders.insert(packageFolder.pathString).inserted
+            else {
+                continue
+            }
+
+            let localPackageInfo = try await manifestLoader.loadPackage(
+                at: packageFolder,
+                disableSandbox: true
+            )
+            let shouldResolveLocalPackage = shouldResolveLocalPackage(
+                packageInfo: localPackageInfo,
+                knownPackageIdentities: knownPackageIdentities
+            )
+
+            let localScratchDirectory = try await swiftPackageManagerScratchDirectory(
+                packagePath: packageFolder,
+                arguments: arguments
+            )
+            if shouldResolveLocalPackage {
+                if update {
+                    try await swiftPackageManagerController.update(
+                        at: packageFolder,
+                        arguments: arguments,
+                        printOutput: true
+                    )
+                } else {
+                    try await swiftPackageManagerController.resolve(
+                        at: packageFolder,
+                        arguments: arguments,
+                        printOutput: true
+                    )
+                }
+
+                try await savePackageResolved(at: packageFolder, scratchDirectory: localScratchDirectory)
+            }
+            try await resolveLocalPackageDependencies(
+                scratchDirectory: localScratchDirectory,
+                update: update,
+                arguments: arguments,
+                knownPackageIdentities: &knownPackageIdentities,
+                visitedPackageFolders: &visitedPackageFolders
+            )
+        }
+    }
+
+    private func shouldResolveLocalPackage(
+        packageInfo: PackageInfo,
+        knownPackageIdentities: Set<String>
+    ) -> Bool {
+        let missingPackageDependencies = Set(packageInfo.dependencies.map { $0.identity.lowercased() })
+            .subtracting(knownPackageIdentities)
+        let hasRemoteBinaryTargets = packageInfo.targets.contains { $0.url != nil }
+
+        return !missingPackageDependencies.isEmpty || hasRemoteBinaryTargets
+    }
+
+    private func workspaceState(scratchDirectory: AbsolutePath) async throws -> SwiftPackageManagerWorkspaceState? {
+        let workspaceStatePath = scratchDirectory.appending(component: "workspace-state.json")
+        guard try await fileSystem.exists(workspaceStatePath) else {
+            return nil
+        }
+
+        return try JSONDecoder().decode(
+            SwiftPackageManagerWorkspaceState.self,
+            from: try await fileSystem.readFile(at: workspaceStatePath)
+        )
+    }
+
+    private func localPackageFolder(
+        for dependency: SwiftPackageManagerWorkspaceState.Dependency,
+        scratchDirectory: AbsolutePath
+    ) -> AbsolutePath? {
+        guard let path = dependency.packageRef.path ?? dependency.packageRef.location else {
+            return nil
+        }
+        return try? AbsolutePath(
+            validating: sanitizedSwiftPackageManagerPath(path),
+            relativeTo: scratchDirectory
+        )
+    }
+
+    private func isLocalDependencyKind(_ kind: String) -> Bool {
+        ["local", "fileSystem", "localSourceControl"].contains(kind)
+    }
+
+    private func sanitizedSwiftPackageManagerPath(_ path: String) -> String {
+        String(path.unicodeScalars.filter { !CharacterSet.controlCharacters.contains($0) })
+            .replacingOccurrences(of: "/private/var", with: "/var")
     }
 }

--- a/cli/Sources/TuistKit/Services/InstallService.swift
+++ b/cli/Sources/TuistKit/Services/InstallService.swift
@@ -165,6 +165,14 @@ struct InstallService: InstallServicing {
         try await fileSystem.copy(sourcePath, to: destinationPath)
     }
 
+    /// Recursively resolves the external dependencies declared by local path packages.
+    ///
+    /// SwiftPM prunes a path dependency's test-only external dependencies from the root resolution,
+    /// so those products are missing from the root `workspace-state.json` even though Tuist loads the
+    /// local package's full manifest. To make them available, each local package is resolved as its own
+    /// root in its own scratch directory (its default `.build`), which is why the custom
+    /// `--scratch-path`/`--build-path` are stripped from `arguments`. As a result, SwiftPM state
+    /// (`.build`, `Package.resolved`) is created inside each local package directory.
     private func resolveLocalPackageDependencies(
         scratchDirectory: AbsolutePath,
         update: Bool,
@@ -172,7 +180,10 @@ struct InstallService: InstallServicing {
         knownPackageIdentities: inout Set<String>,
         visitedPackageFolders: inout Set<String>
     ) async throws {
-        guard let workspaceState = try await workspaceState(scratchDirectory: scratchDirectory) else {
+        guard let workspaceState = try await SwiftPackageManagerWorkspaceState.load(
+            from: scratchDirectory,
+            fileSystem: fileSystem
+        ) else {
             return
         }
         knownPackageIdentities.formUnion(
@@ -180,9 +191,9 @@ struct InstallService: InstallServicing {
         )
 
         for dependency in workspaceState.object.dependencies
-            where isLocalDependencyKind(dependency.packageRef.kind)
+            where SwiftPackageManagerWorkspaceState.isLocalDependencyKind(dependency.packageRef.kind)
         {
-            guard let packageFolder = localPackageFolder(for: dependency, scratchDirectory: scratchDirectory),
+            guard let packageFolder = dependency.localPackageFolder(relativeTo: scratchDirectory),
                   visitedPackageFolders.insert(packageFolder.pathString).inserted
             else {
                 continue
@@ -237,39 +248,5 @@ struct InstallService: InstallServicing {
         let hasRemoteBinaryTargets = packageInfo.targets.contains { $0.url != nil }
 
         return !missingPackageDependencies.isEmpty || hasRemoteBinaryTargets
-    }
-
-    private func workspaceState(scratchDirectory: AbsolutePath) async throws -> SwiftPackageManagerWorkspaceState? {
-        let workspaceStatePath = scratchDirectory.appending(component: "workspace-state.json")
-        guard try await fileSystem.exists(workspaceStatePath) else {
-            return nil
-        }
-
-        return try JSONDecoder().decode(
-            SwiftPackageManagerWorkspaceState.self,
-            from: try await fileSystem.readFile(at: workspaceStatePath)
-        )
-    }
-
-    private func localPackageFolder(
-        for dependency: SwiftPackageManagerWorkspaceState.Dependency,
-        scratchDirectory: AbsolutePath
-    ) -> AbsolutePath? {
-        guard let path = dependency.packageRef.path ?? dependency.packageRef.location else {
-            return nil
-        }
-        return try? AbsolutePath(
-            validating: sanitizedSwiftPackageManagerPath(path),
-            relativeTo: scratchDirectory
-        )
-    }
-
-    private func isLocalDependencyKind(_ kind: String) -> Bool {
-        ["local", "fileSystem", "localSourceControl"].contains(kind)
-    }
-
-    private func sanitizedSwiftPackageManagerPath(_ path: String) -> String {
-        String(path.unicodeScalars.filter { !CharacterSet.controlCharacters.contains($0) })
-            .replacingOccurrences(of: "/private/var", with: "/var")
     }
 }

--- a/cli/Sources/TuistLoader/Loaders/SwiftPackageManagerGraphLoader.swift
+++ b/cli/Sources/TuistLoader/Loaders/SwiftPackageManagerGraphLoader.swift
@@ -99,12 +99,13 @@ public struct SwiftPackageManagerGraphLoader: SwiftPackageManagerGraphLoading {
         // a `swift package` invocation on the same scratch directory deadlocks.
         let workspaceState = try await swiftPackageManagerLock
             .withLock(scratchDirectory: scratchDirectory) {
-                let workspacePath = scratchDirectory.appending(component: "workspace-state.json")
-                if try await !fileSystem.exists(workspacePath) {
+                guard let workspaceState = try await SwiftPackageManagerWorkspaceState.load(
+                    from: scratchDirectory,
+                    fileSystem: fileSystem
+                ) else {
                     throw SwiftPackageManagerGraphGeneratorError.installRequired
                 }
-                return try JSONDecoder()
-                    .decode(SwiftPackageManagerWorkspaceState.self, from: try await fileSystem.readFile(at: workspacePath))
+                return workspaceState
             }
         return try await loadUnsafe(
             packagePath: packagePath,
@@ -125,7 +126,6 @@ public struct SwiftPackageManagerGraphLoader: SwiftPackageManagerGraphLoading {
         scratchDirectory: AbsolutePath,
         workspaceState: SwiftPackageManagerWorkspaceState
     ) async throws -> (TuistLoader.DependenciesGraph, [LintingIssue]) {
-        let path = scratchDirectory
         let packageInfoCache = await SwifterPMPackageInfoCache.load(
             scratchDirectory: scratchDirectory,
             fileSystem: fileSystem
@@ -194,7 +194,7 @@ public struct SwiftPackageManagerGraphLoader: SwiftPackageManagerGraphLoading {
         })
         .compactMap { _, groupedPackageInfos in
             if let localPackage = groupedPackageInfos.first(where: {
-                Self.isLocalDependencyKind($0.kind)
+                SwiftPackageManagerWorkspaceState.isLocalDependencyKind($0.kind)
             }) {
                 return localPackage
             } else if let registryPackage = groupedPackageInfos.first(where: { $0.kind == "registry" }) {
@@ -239,7 +239,7 @@ public struct SwiftPackageManagerGraphLoader: SwiftPackageManagerGraphLoading {
         }
 
         let externalDependencies = try await packageInfoMapper.resolveExternalDependencies(
-            path: path,
+            path: scratchDirectory,
             packagePath: packagePath.parentDirectory,
             packageInfos: packageInfoDictionary,
             packageToFolder: packageToFolder,
@@ -281,7 +281,7 @@ public struct SwiftPackageManagerGraphLoader: SwiftPackageManagerGraphLoading {
             .reduce(into: [:]) { result, item in
                 let (packageInfo, hash, projectManifest) = item
                 if let projectManifest {
-                    let swiftPackageManagerScratchDirectory: Path? = if Self.isLocalDependencyKind(packageInfo.kind) {
+                    let swiftPackageManagerScratchDirectory: Path? = if SwiftPackageManagerWorkspaceState.isLocalDependencyKind(packageInfo.kind) {
                         nil
                     } else {
                         SwiftPackageManagerPaths
@@ -376,10 +376,6 @@ public struct SwiftPackageManagerGraphLoader: SwiftPackageManagerGraphLoading {
             }
     }
 
-    private static func isLocalDependencyKind(_ kind: String) -> Bool {
-        ["local", "fileSystem", "localSourceControl"].contains(kind)
-    }
-
     private func workspaceStates(
         rootWorkspaceState: SwiftPackageManagerWorkspaceState,
         rootScratchDirectory: AbsolutePath,
@@ -400,9 +396,9 @@ public struct SwiftPackageManagerGraphLoader: SwiftPackageManagerGraphLoading {
             scratchDirectory: AbsolutePath
         ) async throws {
             for dependency in workspaceState.object.dependencies
-                where Self.isLocalDependencyKind(dependency.packageRef.kind)
+                where SwiftPackageManagerWorkspaceState.isLocalDependencyKind(dependency.packageRef.kind)
             {
-                guard let packageFolder = localPackageFolder(for: dependency, scratchDirectory: scratchDirectory),
+                guard let packageFolder = dependency.localPackageFolder(relativeTo: scratchDirectory),
                       visitedPackageFolders.insert(packageFolder.pathString).inserted
                 else {
                     continue
@@ -412,15 +408,13 @@ public struct SwiftPackageManagerGraphLoader: SwiftPackageManagerGraphLoading {
                     packagePath: packageFolder,
                     arguments: localPackageArguments
                 )
-                let localWorkspaceStatePath = localScratchDirectory.appending(component: "workspace-state.json")
-                guard try await fileSystem.exists(localWorkspaceStatePath) else {
+                guard let localWorkspaceState = try await SwiftPackageManagerWorkspaceState.load(
+                    from: localScratchDirectory,
+                    fileSystem: fileSystem
+                ) else {
                     continue
                 }
 
-                let localWorkspaceState = try JSONDecoder().decode(
-                    SwiftPackageManagerWorkspaceState.self,
-                    from: try await fileSystem.readFile(at: localWorkspaceStatePath)
-                )
                 workspaceStates.append(
                     SwiftPackageManagerResolvedWorkspaceState(
                         workspaceState: localWorkspaceState,
@@ -439,21 +433,8 @@ public struct SwiftPackageManagerGraphLoader: SwiftPackageManagerGraphLoading {
         return workspaceStates
     }
 
-    private func localPackageFolder(
-        for dependency: SwiftPackageManagerWorkspaceState.Dependency,
-        scratchDirectory: AbsolutePath
-    ) -> AbsolutePath? {
-        guard let path = dependency.packageRef.path ?? dependency.packageRef.location else {
-            return nil
-        }
-        return try? AbsolutePath(
-            validating: sanitizedSwiftPackageManagerPath(path),
-            relativeTo: scratchDirectory
-        )
-    }
-
     private static func packageOrigin(for kind: String) -> PackageType.ExternalOrigin {
-        isLocalDependencyKind(kind) ? .local : .remote
+        SwiftPackageManagerWorkspaceState.isLocalDependencyKind(kind) ? .local : .remote
     }
 
     static func enabledTraits(
@@ -777,8 +758,7 @@ private struct SwifterPMPackageInfoCache {
 }
 
 private func sanitizedSwiftPackageManagerPath(_ path: String) -> String {
-    String(path.unicodeScalars.filter { !CharacterSet.controlCharacters.contains($0) })
-        .replacingOccurrences(of: "/private/var", with: "/var")
+    SwiftPackageManagerWorkspaceState.sanitizedPath(path)
 }
 
 extension ProjectDescription.Platform {

--- a/cli/Sources/TuistLoader/Loaders/SwiftPackageManagerGraphLoader.swift
+++ b/cli/Sources/TuistLoader/Loaders/SwiftPackageManagerGraphLoader.swift
@@ -110,6 +110,7 @@ public struct SwiftPackageManagerGraphLoader: SwiftPackageManagerGraphLoading {
             packagePath: packagePath,
             packageSettings: packageSettings,
             disableSandbox: disableSandbox,
+            swiftPackageManagerArguments: swiftPackageManagerArguments,
             scratchDirectory: scratchDirectory,
             workspaceState: workspaceState
         )
@@ -120,11 +121,11 @@ public struct SwiftPackageManagerGraphLoader: SwiftPackageManagerGraphLoading {
         packagePath: AbsolutePath,
         packageSettings: TuistCore.PackageSettings,
         disableSandbox: Bool,
+        swiftPackageManagerArguments: [String],
         scratchDirectory: AbsolutePath,
         workspaceState: SwiftPackageManagerWorkspaceState
     ) async throws -> (TuistLoader.DependenciesGraph, [LintingIssue]) {
         let path = scratchDirectory
-        let checkoutsFolder = path.appending(component: "checkouts")
         let packageInfoCache = await SwifterPMPackageInfoCache.load(
             scratchDirectory: scratchDirectory,
             fileSystem: fileSystem
@@ -138,66 +139,38 @@ public struct SwiftPackageManagerGraphLoader: SwiftPackageManagerGraphLoading {
             try await manifestLoader.loadPackage(at: packagePath.parentDirectory, disableSandbox: disableSandbox)
         }
 
-        var packageInfos: [SwiftPackageManagerResolvedPackageInfo] = try await workspaceState.object.dependencies
-            .concurrentMap { dependency in
-                let name = dependency.packageRef.name
-                let packageFolder: AbsolutePath
-                let hash: String?
-                switch dependency.packageRef.kind {
-                case "remote", "remoteSourceControl":
-                    packageFolder = checkoutsFolder.appending(component: sanitizedSwiftPackageManagerPath(dependency.subpath))
-                    hash = dependency.state?.checkoutState?.revision
-                case "local", "fileSystem", "localSourceControl":
-                    // Depending on the swift version, the information is available either in `path` or in `location`
-                    guard let path = dependency.packageRef.path ?? dependency.packageRef.location else {
-                        throw SwiftPackageManagerGraphGeneratorError.missingPathInLocalSwiftPackage(name)
-                    }
-                    // There's a bug in the `relative` implementation that produces the wrong path when using a symbolic link.
-                    // This leads to nonexisting path in the `ModuleMapMapper` that relies on that method.
-                    // To get around this, we're aligning paths from `workspace-state.json` with the /var temporary directory.
-                    // Anchor against `scratchDirectory` so swifterpm's relative-path encoding resolves correctly;
-                    // absolute paths from older swifterpm output pass through unchanged.
-                    packageFolder = try AbsolutePath(
-                        validating: sanitizedSwiftPackageManagerPath(path),
-                        relativeTo: scratchDirectory
-                    )
-                    hash = nil
-                case "registry":
-                    let registryFolder = path.appending(try RelativePath(validating: "registry/downloads"))
-                    packageFolder = registryFolder.appending(
-                        try RelativePath(validating: sanitizedSwiftPackageManagerPath(dependency.subpath))
-                    )
-                    hash = try dependency.state?.version.map { try contentHasher.hash([dependency.packageRef.identity, $0]) }
-                default:
-                    throw SwiftPackageManagerGraphGeneratorError.unsupportedDependencyKind(dependency.packageRef.kind)
-                }
+        let workspaceStates = try await workspaceStates(
+            rootWorkspaceState: workspaceState,
+            rootScratchDirectory: scratchDirectory,
+            swiftPackageManagerArguments: swiftPackageManagerArguments
+        )
 
-                let packageInfo = if let packageInfoCache,
-                                     let cachedPackageInfo = packageInfoCache.packageInfo(for: packageFolder)
-                {
-                    cachedPackageInfo
-                } else {
-                    try await manifestLoader.loadPackage(at: packageFolder, disableSandbox: disableSandbox)
-                }
-                let targetToArtifactPaths = try workspaceState.object.artifacts
-                    .filter { $0.packageRef.identity == dependency.packageRef.identity }
-                    .reduce(into: [:]) { result, artifact in
-                        result[artifact.targetName] = try AbsolutePath(
-                            validating: sanitizedSwiftPackageManagerPath(artifact.path),
-                            relativeTo: scratchDirectory
-                        )
-                    }
+        var packageInfos: [SwiftPackageManagerResolvedPackageInfo] = []
+        var prebuilts: [SwiftPackageManagerResolvedPrebuilt] = []
 
-                return SwiftPackageManagerResolvedPackageInfo(
-                    id: dependency.packageRef.identity.lowercased(),
-                    name: name,
-                    folder: packageFolder,
-                    targetToArtifactPaths: targetToArtifactPaths,
-                    info: packageInfo,
-                    hash: hash,
-                    kind: dependency.packageRef.kind
+        for workspaceState in workspaceStates {
+            let statePackageInfoCache = if workspaceState.scratchDirectory == scratchDirectory {
+                packageInfoCache
+            } else {
+                await SwifterPMPackageInfoCache.load(
+                    scratchDirectory: workspaceState.scratchDirectory,
+                    fileSystem: fileSystem
                 )
             }
+
+            let statePackageInfos = try await resolvedPackageInfos(
+                from: workspaceState.workspaceState,
+                scratchDirectory: workspaceState.scratchDirectory,
+                packageInfoCache: statePackageInfoCache,
+                disableSandbox: disableSandbox
+            )
+            packageInfos.append(contentsOf: statePackageInfos)
+            prebuilts.append(
+                contentsOf: workspaceState.workspaceState.object.prebuilts.map {
+                    SwiftPackageManagerResolvedPrebuilt(prebuilt: $0, scratchDirectory: workspaceState.scratchDirectory)
+                }
+            )
+        }
 
         // When the same package appears from multiple sources (e.g. local path, registry, or source control),
         // we keep a single entry to avoid duplicates. Selection is based on the following precedence:
@@ -238,8 +211,7 @@ public struct SwiftPackageManagerGraphLoader: SwiftPackageManagerGraphLoading {
         })
         let packagePrebuilts = try mapPackagePrebuilts(
             packageInfos: packageInfos,
-            prebuilts: workspaceState.object.prebuilts,
-            scratchDirectory: scratchDirectory
+            prebuilts: prebuilts
         )
 
         var mutablePackageModuleAliases: [String: [String: String]] = [:]
@@ -333,8 +305,151 @@ public struct SwiftPackageManagerGraphLoader: SwiftPackageManagerGraphLoading {
         )
     }
 
+    private func resolvedPackageInfos(
+        from workspaceState: SwiftPackageManagerWorkspaceState,
+        scratchDirectory: AbsolutePath,
+        packageInfoCache: SwifterPMPackageInfoCache?,
+        disableSandbox: Bool
+    ) async throws -> [SwiftPackageManagerResolvedPackageInfo] {
+        let checkoutsFolder = scratchDirectory.appending(component: "checkouts")
+
+        return try await workspaceState.object.dependencies
+            .concurrentMap { dependency in
+                let name = dependency.packageRef.name
+                let packageFolder: AbsolutePath
+                let hash: String?
+                switch dependency.packageRef.kind {
+                case "remote", "remoteSourceControl":
+                    packageFolder = checkoutsFolder.appending(component: sanitizedSwiftPackageManagerPath(dependency.subpath))
+                    hash = dependency.state?.checkoutState?.revision
+                case "local", "fileSystem", "localSourceControl":
+                    // Depending on the swift version, the information is available either in `path` or in `location`
+                    guard let path = dependency.packageRef.path ?? dependency.packageRef.location else {
+                        throw SwiftPackageManagerGraphGeneratorError.missingPathInLocalSwiftPackage(name)
+                    }
+                    // There's a bug in the `relative` implementation that produces the wrong path when using a symbolic link.
+                    // This leads to nonexisting path in the `ModuleMapMapper` that relies on that method.
+                    // To get around this, we're aligning paths from `workspace-state.json` with the /var temporary directory.
+                    // Anchor against `scratchDirectory` so swifterpm's relative-path encoding resolves correctly;
+                    // absolute paths from older swifterpm output pass through unchanged.
+                    packageFolder = try AbsolutePath(
+                        validating: sanitizedSwiftPackageManagerPath(path),
+                        relativeTo: scratchDirectory
+                    )
+                    hash = nil
+                case "registry":
+                    let registryFolder = scratchDirectory
+                        .appending(try RelativePath(validating: "registry/downloads"))
+                    packageFolder = registryFolder.appending(
+                        try RelativePath(validating: sanitizedSwiftPackageManagerPath(dependency.subpath))
+                    )
+                    hash = try dependency.state?.version.map { try contentHasher.hash([dependency.packageRef.identity, $0]) }
+                default:
+                    throw SwiftPackageManagerGraphGeneratorError.unsupportedDependencyKind(dependency.packageRef.kind)
+                }
+
+                let packageInfo = if let packageInfoCache,
+                                     let cachedPackageInfo = packageInfoCache.packageInfo(for: packageFolder)
+                {
+                    cachedPackageInfo
+                } else {
+                    try await manifestLoader.loadPackage(at: packageFolder, disableSandbox: disableSandbox)
+                }
+                let targetToArtifactPaths = try workspaceState.object.artifacts
+                    .filter { $0.packageRef.identity == dependency.packageRef.identity }
+                    .reduce(into: [:]) { result, artifact in
+                        result[artifact.targetName] = try AbsolutePath(
+                            validating: sanitizedSwiftPackageManagerPath(artifact.path),
+                            relativeTo: scratchDirectory
+                        )
+                    }
+
+                return SwiftPackageManagerResolvedPackageInfo(
+                    id: dependency.packageRef.identity.lowercased(),
+                    name: name,
+                    folder: packageFolder,
+                    targetToArtifactPaths: targetToArtifactPaths,
+                    info: packageInfo,
+                    hash: hash,
+                    kind: dependency.packageRef.kind
+                )
+            }
+    }
+
     private static func isLocalDependencyKind(_ kind: String) -> Bool {
         ["local", "fileSystem", "localSourceControl"].contains(kind)
+    }
+
+    private func workspaceStates(
+        rootWorkspaceState: SwiftPackageManagerWorkspaceState,
+        rootScratchDirectory: AbsolutePath,
+        swiftPackageManagerArguments: [String]
+    ) async throws -> [SwiftPackageManagerResolvedWorkspaceState] {
+        var workspaceStates: [SwiftPackageManagerResolvedWorkspaceState] = [
+            SwiftPackageManagerResolvedWorkspaceState(
+                workspaceState: rootWorkspaceState,
+                scratchDirectory: rootScratchDirectory
+            ),
+        ]
+        var visitedPackageFolders: Set<String> = []
+        let localPackageArguments = SwiftPackageManagerArguments
+            .removingCustomScratchPathArguments(swiftPackageManagerArguments)
+
+        func visit(
+            workspaceState: SwiftPackageManagerWorkspaceState,
+            scratchDirectory: AbsolutePath
+        ) async throws {
+            for dependency in workspaceState.object.dependencies
+                where Self.isLocalDependencyKind(dependency.packageRef.kind)
+            {
+                guard let packageFolder = localPackageFolder(for: dependency, scratchDirectory: scratchDirectory),
+                      visitedPackageFolders.insert(packageFolder.pathString).inserted
+                else {
+                    continue
+                }
+
+                let localScratchDirectory = try await self.swiftPackageManagerScratchDirectory(
+                    packagePath: packageFolder,
+                    arguments: localPackageArguments
+                )
+                let localWorkspaceStatePath = localScratchDirectory.appending(component: "workspace-state.json")
+                guard try await fileSystem.exists(localWorkspaceStatePath) else {
+                    continue
+                }
+
+                let localWorkspaceState = try JSONDecoder().decode(
+                    SwiftPackageManagerWorkspaceState.self,
+                    from: try await fileSystem.readFile(at: localWorkspaceStatePath)
+                )
+                workspaceStates.append(
+                    SwiftPackageManagerResolvedWorkspaceState(
+                        workspaceState: localWorkspaceState,
+                        scratchDirectory: localScratchDirectory
+                    )
+                )
+                try await visit(
+                    workspaceState: localWorkspaceState,
+                    scratchDirectory: localScratchDirectory
+                )
+            }
+        }
+
+        try await visit(workspaceState: rootWorkspaceState, scratchDirectory: rootScratchDirectory)
+
+        return workspaceStates
+    }
+
+    private func localPackageFolder(
+        for dependency: SwiftPackageManagerWorkspaceState.Dependency,
+        scratchDirectory: AbsolutePath
+    ) -> AbsolutePath? {
+        guard let path = dependency.packageRef.path ?? dependency.packageRef.location else {
+            return nil
+        }
+        return try? AbsolutePath(
+            validating: sanitizedSwiftPackageManagerPath(path),
+            relativeTo: scratchDirectory
+        )
     }
 
     private static func packageOrigin(for kind: String) -> PackageType.ExternalOrigin {
@@ -453,13 +568,22 @@ private struct SwiftPackageManagerResolvedPackageInfo {
     let kind: String
 }
 
+private struct SwiftPackageManagerResolvedWorkspaceState {
+    let workspaceState: SwiftPackageManagerWorkspaceState
+    let scratchDirectory: AbsolutePath
+}
+
+private struct SwiftPackageManagerResolvedPrebuilt {
+    let prebuilt: SwiftPackageManagerWorkspaceState.Prebuilt
+    let scratchDirectory: AbsolutePath
+}
+
 private func mapPackagePrebuilts(
     packageInfos: [SwiftPackageManagerResolvedPackageInfo],
-    prebuilts: [SwiftPackageManagerWorkspaceState.Prebuilt],
-    scratchDirectory: AbsolutePath
+    prebuilts: [SwiftPackageManagerResolvedPrebuilt]
 ) throws -> [String: [String: SwiftPackageManagerPrebuilt]] {
     try packageInfos.reduce(into: [:]) { result, packageInfo in
-        let packagePrebuilts = prebuilts.filter { $0.identity.lowercased() == packageInfo.id.lowercased() }
+        let packagePrebuilts = prebuilts.filter { $0.prebuilt.identity.lowercased() == packageInfo.id.lowercased() }
         guard !packagePrebuilts.isEmpty else { return }
 
         let packageKeys = Set([
@@ -470,20 +594,21 @@ private func mapPackagePrebuilts(
             packageInfo.folder.basename.lowercased(),
         ])
 
-        for prebuilt in packagePrebuilts {
+        for resolvedPrebuilt in packagePrebuilts {
+            let prebuilt = resolvedPrebuilt.prebuilt
             let mappedPrebuilt = SwiftPackageManagerPrebuilt(
                 identity: prebuilt.identity,
                 version: prebuilt.version,
                 libraryName: prebuilt.libraryName,
                 path: try AbsolutePath(
                     validating: sanitizedSwiftPackageManagerPath(prebuilt.path),
-                    relativeTo: scratchDirectory
+                    relativeTo: resolvedPrebuilt.scratchDirectory
                 ),
                 checkoutPath: try prebuilt.checkoutPath
                     .map {
                         try AbsolutePath(
                             validating: sanitizedSwiftPackageManagerPath($0),
-                            relativeTo: scratchDirectory
+                            relativeTo: resolvedPrebuilt.scratchDirectory
                         )
                     },
                 products: prebuilt.products,

--- a/cli/Sources/TuistLoader/Models/SwiftPackageManagerWorkspaceState+Helpers.swift
+++ b/cli/Sources/TuistLoader/Models/SwiftPackageManagerWorkspaceState+Helpers.swift
@@ -1,0 +1,46 @@
+import FileSystem
+import Foundation
+import Path
+
+extension SwiftPackageManagerWorkspaceState {
+    /// The dependency kinds SwiftPM uses for local (path-based) packages across Swift versions.
+    public static func isLocalDependencyKind(_ kind: String) -> Bool {
+        ["local", "fileSystem", "localSourceControl"].contains(kind)
+    }
+
+    /// Strips control characters and aligns `/private/var` with `/var` so paths encoded in
+    /// `workspace-state.json` resolve correctly relative to a scratch directory.
+    public static func sanitizedPath(_ path: String) -> String {
+        String(path.unicodeScalars.filter { !CharacterSet.controlCharacters.contains($0) })
+            .replacingOccurrences(of: "/private/var", with: "/var")
+    }
+
+    /// Decodes the `workspace-state.json` file in the given scratch directory, or `nil` when absent.
+    public static func load(
+        from scratchDirectory: AbsolutePath,
+        fileSystem: FileSysteming
+    ) async throws -> SwiftPackageManagerWorkspaceState? {
+        let workspaceStatePath = scratchDirectory.appending(component: "workspace-state.json")
+        guard try await fileSystem.exists(workspaceStatePath) else {
+            return nil
+        }
+        return try JSONDecoder().decode(
+            SwiftPackageManagerWorkspaceState.self,
+            from: try await fileSystem.readFile(at: workspaceStatePath)
+        )
+    }
+}
+
+extension SwiftPackageManagerWorkspaceState.Dependency {
+    /// The absolute path to a local package dependency's folder, resolved relative to `scratchDirectory`.
+    public func localPackageFolder(relativeTo scratchDirectory: AbsolutePath) -> AbsolutePath? {
+        // Depending on the Swift version, the path is available either in `path` or in `location`.
+        guard let path = packageRef.path ?? packageRef.location else {
+            return nil
+        }
+        return try? AbsolutePath(
+            validating: SwiftPackageManagerWorkspaceState.sanitizedPath(path),
+            relativeTo: scratchDirectory
+        )
+    }
+}

--- a/cli/Sources/TuistLoader/Models/SwiftPackageManagerWorkspaceState.swift
+++ b/cli/Sources/TuistLoader/Models/SwiftPackageManagerWorkspaceState.swift
@@ -2,19 +2,19 @@
 /// It decodes data encoded from WorkspaceState.swift: https://github.com/apple/swift-package-manager/blob/ce50cb0de101c2d9a5742aaf70efc7c21e8f249b/Sources/Workspace/WorkspaceState.swift
 /// In particular, we are interested in the ManagedDependency.swift: https://github.com/apple/swift-package-manager/blob/ce50cb0de101c2d9a5742aaf70efc7c21e8f249b/Sources/Workspace/ManagedDependency.swift
 /// Fields not needed by tuist are commented out and not decoded at all.
-struct SwiftPackageManagerWorkspaceState: Decodable, Equatable {
+public struct SwiftPackageManagerWorkspaceState: Decodable, Equatable {
     /// The products declared in the manifest.
-    let object: Object
+    public let object: Object
 
-    struct Object: Decodable, Equatable {
+    public struct Object: Decodable, Equatable {
         /// The list of SPM dependencies
-        let dependencies: [Dependency]
+        public let dependencies: [Dependency]
 
         /// The list of SPM artifacts
-        let artifacts: [Artifact]
+        public let artifacts: [Artifact]
 
         /// The list of SPM prebuilts
-        let prebuilts: [Prebuilt]
+        public let prebuilts: [Prebuilt]
 
         private enum CodingKeys: String, CodingKey {
             case dependencies
@@ -22,7 +22,7 @@ struct SwiftPackageManagerWorkspaceState: Decodable, Equatable {
             case prebuilts
         }
 
-        init(from decoder: Decoder) throws {
+        public init(from decoder: Decoder) throws {
             let container = try decoder.container(keyedBy: CodingKeys.self)
             dependencies = try container.decode([Dependency].self, forKey: .dependencies)
             artifacts = try container.decode([Artifact].self, forKey: .artifacts)
@@ -30,76 +30,76 @@ struct SwiftPackageManagerWorkspaceState: Decodable, Equatable {
         }
     }
 
-    struct Dependency: Decodable, Equatable {
-        struct State: Decodable, Equatable {
-            struct CheckoutState: Decodable, Equatable {
-                let revision: String?
+    public struct Dependency: Decodable, Equatable {
+        public struct State: Decodable, Equatable {
+            public struct CheckoutState: Decodable, Equatable {
+                public let revision: String?
             }
 
             /// The revision a package has been resolved to.
-            let checkoutState: CheckoutState?
+            public let checkoutState: CheckoutState?
 
             /// The version a package has been resolved to.
-            let version: String?
+            public let version: String?
         }
 
         /// The package reference of the dependency
-        let packageRef: PackageRef
+        public let packageRef: PackageRef
 
         /// The path of the remote dependency, relative to the checkouts folder
-        let subpath: String
+        public let subpath: String
 
         /// The state of the dependency.
-        let state: State?
+        public let state: State?
     }
 
-    struct Artifact: Decodable, Equatable {
+    public struct Artifact: Decodable, Equatable {
         /// The package reference of the artifact
-        let packageRef: PackageRef
+        public let packageRef: PackageRef
 
         /// The absolute path to the artifact (in local file system)
-        let path: String
+        public let path: String
 
         /// Name of the target to which this artifact belongs
-        let targetName: String
+        public let targetName: String
     }
 
-    struct Prebuilt: Decodable, Equatable {
+    public struct Prebuilt: Decodable, Equatable {
         /// Identity of the package the prebuilt belongs to.
-        let identity: String
+        public let identity: String
 
         /// Version of the package the prebuilt was built from.
-        let version: String
+        public let version: String
 
         /// Name of the prebuilt library.
-        let libraryName: String
+        public let libraryName: String
 
         /// Absolute path to the extracted prebuilt artifacts.
-        let path: String
+        public let path: String
 
         /// Absolute path to the source checkout associated with the prebuilt.
-        let checkoutPath: String?
+        public let checkoutPath: String?
 
         /// Products represented by this prebuilt library.
-        let products: [String]
+        public let products: [String]
 
         /// Include paths relative to the checkout path.
-        let includePath: [String]?
+        public let includePath: [String]?
 
         /// C modules with include directories in the prebuilt artifact.
-        let cModules: [String]
+        public let cModules: [String]
     }
 
-    struct PackageRef: Decodable, Equatable {
+    public struct PackageRef: Decodable, Equatable {
         /// Identity of the dependency
-        let identity: String
+        public let identity: String
         /// The name of the dependency
-        let name: String
+        public let name: String
         /// The king of the dependency (either local or remote)
-        let kind: String
+        public let kind: String
         /// The path of the local dependency, no longer available since Swift 5.5
-        let path: String?
+        public let path: String?
         /// The location of the dependency
-        let location: String?
+        public let location: String?
     }
 }

--- a/cli/Sources/TuistSupport/SwiftPackageManager/SwiftPackageManagerArguments.swift
+++ b/cli/Sources/TuistSupport/SwiftPackageManager/SwiftPackageManagerArguments.swift
@@ -1,0 +1,26 @@
+public enum SwiftPackageManagerArguments {
+    public static func removingCustomScratchPathArguments(_ arguments: [String]) -> [String] {
+        var result: [String] = []
+        var skipNext = false
+
+        for argument in arguments {
+            if skipNext {
+                skipNext = false
+                continue
+            }
+
+            if argument == "--scratch-path" || argument == "--build-path" {
+                skipNext = true
+                continue
+            }
+
+            if argument.hasPrefix("--scratch-path=") || argument.hasPrefix("--build-path=") {
+                continue
+            }
+
+            result.append(argument)
+        }
+
+        return result
+    }
+}

--- a/cli/Tests/TuistKitTests/Services/InstallServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/InstallServiceTests.swift
@@ -317,6 +317,62 @@ final class InstallServiceTests: TuistUnitTestCase {
             .called(0)
     }
 
+    func test_run_when_localPackageHasRemoteBinaryTargetWithoutMissingDependencies_resolvesLocalPackage() async throws {
+        // Given
+        let stubbedPath = try temporaryPath()
+        let tuistPackagePath = stubbedPath.appending(components: "Tuist", "Package.swift")
+        let localPackagePath = stubbedPath.appending(component: "LocalOnlyPackage")
+
+        given(manifestFilesLocator)
+            .locatePackageManifest(at: .any)
+            .willReturn(tuistPackagePath)
+        given(swiftPackageManagerController)
+            .resolve(at: .any, arguments: .any, printOutput: .any)
+            .willReturn()
+        given(configLoader)
+            .loadConfig(path: .any)
+            .willReturn(
+                Tuist.test(project: .generated(.test()))
+            )
+        given(manifestLoader)
+            .loadPackage(at: .value(localPackagePath), disableSandbox: .value(true))
+            .willReturn(
+                packageInfo(
+                    name: "LocalOnlyPackage",
+                    binaryTargetURL: "https://example.com/Binary.xcframework.zip"
+                )
+            )
+
+        pluginService.fetchRemotePluginsStub = { _ in }
+
+        try await fileSystem.makeDirectory(at: tuistPackagePath.parentDirectory)
+        try await fileSystem.touch(tuistPackagePath)
+        try await fileSystem.writeText(
+            "resolved",
+            at: tuistPackagePath.parentDirectory.appending(component: Constants.SwiftPackageManager.packageResolvedName)
+        )
+        try await fileSystem.makeDirectory(at: localPackagePath)
+        try await writeLocalPackageWorkspaceState(
+            scratchDirectory: tuistPackagePath.parentDirectory.appending(component: ".build"),
+            packagePath: localPackagePath
+        )
+        try await writeEmptyWorkspaceState(
+            scratchDirectory: localPackagePath.appending(component: ".build")
+        )
+
+        // When
+        try await subject.run(
+            path: stubbedPath.pathString,
+            update: false,
+            passthroughArguments: []
+        )
+
+        // Then
+        verify(swiftPackageManagerController)
+            .resolve(at: .value(localPackagePath), arguments: .value([]), printOutput: .any)
+            .called(1)
+    }
+
     func test_run_when_installing_dependencies_passing_additional_arguments() async throws {
         // Given
         let stubbedPath = try temporaryPath()
@@ -697,7 +753,8 @@ final class InstallServiceTests: TuistUnitTestCase {
 
     private func packageInfo(
         name: String,
-        dependencies: [PackageDependency] = []
+        dependencies: [PackageDependency] = [],
+        binaryTargetURL: String? = nil
     ) -> PackageInfo {
         PackageInfo(
             name: name,
@@ -706,13 +763,13 @@ final class InstallServiceTests: TuistUnitTestCase {
                 PackageInfo.Target(
                     name: "\(name)Target",
                     path: nil,
-                    url: nil,
+                    url: binaryTargetURL,
                     sources: nil,
                     resources: [],
                     exclude: [],
                     dependencies: [],
                     publicHeadersPath: nil,
-                    type: .regular,
+                    type: binaryTargetURL == nil ? .regular : .binary,
                     settings: [],
                     checksum: nil
                 ),

--- a/cli/Tests/TuistKitTests/Services/InstallServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/InstallServiceTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Mockable
+import Path
 import TuistConfig
 import TuistConfigLoader
 import TuistConstants
@@ -8,14 +9,15 @@ import TuistLoader
 import TuistPlugin
 import TuistSupport
 import TuistTesting
+import XcodeGraph
 import XCTest
-
 @testable import TuistKit
 
 final class InstallServiceTests: TuistUnitTestCase {
     private var pluginService: MockPluginService!
     private var configLoader: MockConfigLoading!
     private var swiftPackageManagerController: MockSwiftPackageManagerControlling!
+    private var manifestLoader: MockManifestLoading!
     private var manifestFilesLocator: MockManifestFilesLocating!
 
     private var subject: InstallService!
@@ -26,12 +28,14 @@ final class InstallServiceTests: TuistUnitTestCase {
         pluginService = MockPluginService()
         configLoader = MockConfigLoading()
         swiftPackageManagerController = MockSwiftPackageManagerControlling()
+        manifestLoader = MockManifestLoading()
         manifestFilesLocator = MockManifestFilesLocating()
 
         subject = InstallService(
             pluginService: pluginService,
             configLoader: configLoader,
             swiftPackageManagerController: swiftPackageManagerController,
+            manifestLoader: manifestLoader,
             manifestFilesLocator: manifestFilesLocator
         )
     }
@@ -42,6 +46,7 @@ final class InstallServiceTests: TuistUnitTestCase {
         pluginService = nil
         configLoader = nil
         swiftPackageManagerController = nil
+        manifestLoader = nil
         manifestFilesLocator = nil
 
         super.tearDown()
@@ -176,6 +181,140 @@ final class InstallServiceTests: TuistUnitTestCase {
             .resolve(at: .any, arguments: .any, printOutput: .any)
             .called(1)
         XCTAssertEqual(savedPackageResolvedContents, "resolved")
+    }
+
+    func test_run_when_installingDependenciesWithLocalPackage_resolvesLocalPackageDependencies() async throws {
+        // Given
+        let stubbedPath = try temporaryPath()
+        let tuistPackagePath = stubbedPath.appending(components: "Tuist", "Package.swift")
+        let localPackagePath = stubbedPath.appending(component: "LocalOnlyPackage")
+
+        given(manifestFilesLocator)
+            .locatePackageManifest(at: .any)
+            .willReturn(tuistPackagePath)
+        given(swiftPackageManagerController)
+            .resolve(at: .any, arguments: .any, printOutput: .any)
+            .willReturn()
+        given(configLoader)
+            .loadConfig(path: .any)
+            .willReturn(
+                Tuist.test(project: .generated(.test()))
+            )
+        given(manifestLoader)
+            .loadPackage(at: .value(localPackagePath), disableSandbox: .value(true))
+            .willReturn(
+                packageInfo(
+                    name: "LocalOnlyPackage",
+                    dependencies: [
+                        PackageDependency(identity: "swift-algorithms", traits: []),
+                    ]
+                )
+            )
+
+        pluginService.fetchRemotePluginsStub = { _ in }
+
+        try await fileSystem.makeDirectory(at: tuistPackagePath.parentDirectory)
+        try await fileSystem.touch(tuistPackagePath)
+        try await fileSystem.writeText(
+            "resolved",
+            at: tuistPackagePath.parentDirectory.appending(component: Constants.SwiftPackageManager.packageResolvedName)
+        )
+        try await fileSystem.makeDirectory(at: localPackagePath)
+        try await fileSystem.writeText(
+            "local-resolved",
+            at: localPackagePath.appending(component: Constants.SwiftPackageManager.packageResolvedName)
+        )
+        try await writeLocalPackageWorkspaceState(
+            scratchDirectory: tuistPackagePath.parentDirectory.appending(component: ".build"),
+            packagePath: localPackagePath
+        )
+        try await writeEmptyWorkspaceState(
+            scratchDirectory: localPackagePath.appending(component: ".build")
+        )
+
+        // When
+        try await subject.run(
+            path: stubbedPath.pathString,
+            update: false,
+            passthroughArguments: []
+        )
+
+        let savedLocalPackageResolvedPath = localPackagePath.appending(components: [
+            ".build",
+            "Derived",
+            Constants.SwiftPackageManager.packageResolvedName,
+        ])
+        let savedLocalPackageResolvedContents = try await fileSystem.readTextFile(at: savedLocalPackageResolvedPath)
+
+        // Then
+        verify(swiftPackageManagerController)
+            .resolve(at: .any, arguments: .any, printOutput: .any)
+            .called(2)
+        verify(swiftPackageManagerController)
+            .resolve(at: .value(localPackagePath), arguments: .value([]), printOutput: .any)
+            .called(1)
+        XCTAssertEqual(savedLocalPackageResolvedContents, "local-resolved")
+    }
+
+    func test_run_when_installingDependenciesWithLocalPackageDependenciesAlreadyResolved_skipsLocalPackageResolution()
+        async throws
+    {
+        // Given
+        let stubbedPath = try temporaryPath()
+        let tuistPackagePath = stubbedPath.appending(components: "Tuist", "Package.swift")
+        let localPackagePath = stubbedPath.appending(component: "LocalOnlyPackage")
+
+        given(manifestFilesLocator)
+            .locatePackageManifest(at: .any)
+            .willReturn(tuistPackagePath)
+        given(swiftPackageManagerController)
+            .resolve(at: .any, arguments: .any, printOutput: .any)
+            .willReturn()
+        given(configLoader)
+            .loadConfig(path: .any)
+            .willReturn(
+                Tuist.test(project: .generated(.test()))
+            )
+        given(manifestLoader)
+            .loadPackage(at: .value(localPackagePath), disableSandbox: .value(true))
+            .willReturn(
+                packageInfo(
+                    name: "LocalOnlyPackage",
+                    dependencies: [
+                        PackageDependency(identity: "swift-algorithms", traits: []),
+                    ]
+                )
+            )
+
+        pluginService.fetchRemotePluginsStub = { _ in }
+
+        try await fileSystem.makeDirectory(at: tuistPackagePath.parentDirectory)
+        try await fileSystem.touch(tuistPackagePath)
+        try await fileSystem.writeText(
+            "resolved",
+            at: tuistPackagePath.parentDirectory.appending(component: Constants.SwiftPackageManager.packageResolvedName)
+        )
+        try await fileSystem.makeDirectory(at: localPackagePath)
+        try await writeLocalPackageWorkspaceState(
+            scratchDirectory: tuistPackagePath.parentDirectory.appending(component: ".build"),
+            packagePath: localPackagePath,
+            includeAlgorithmsDependency: true
+        )
+
+        // When
+        try await subject.run(
+            path: stubbedPath.pathString,
+            update: false,
+            passthroughArguments: []
+        )
+
+        // Then
+        verify(swiftPackageManagerController)
+            .resolve(at: .any, arguments: .any, printOutput: .any)
+            .called(1)
+        verify(swiftPackageManagerController)
+            .resolve(at: .value(localPackagePath), arguments: .any, printOutput: .any)
+            .called(0)
     }
 
     func test_run_when_installing_dependencies_passing_additional_arguments() async throws {
@@ -478,5 +617,113 @@ final class InstallServiceTests: TuistUnitTestCase {
         verify(swiftPackageManagerController)
             .resolve(at: .any, arguments: .any, printOutput: .any)
             .called(0)
+    }
+
+    private func writeLocalPackageWorkspaceState(
+        scratchDirectory: AbsolutePath,
+        packagePath: AbsolutePath,
+        includeAlgorithmsDependency: Bool = false
+    ) async throws {
+        let workspaceStatePath = scratchDirectory.appending(component: "workspace-state.json")
+        let algorithmsDependency: String
+        if includeAlgorithmsDependency {
+            algorithmsDependency = """
+                              ,
+                              {
+                                "basedOn" : null,
+                                "packageRef" : {
+                                  "identity" : "swift-algorithms",
+                                  "kind" : "remoteSourceControl",
+                                  "location" : "https://github.com/apple/swift-algorithms",
+                                  "name" : "swift-algorithms"
+                                },
+                                "state" : {
+                                  "checkoutState" : {
+                                    "revision" : "abcdef1234567890"
+                                  },
+                                  "name" : "sourceControlCheckout"
+                                },
+                                "subpath" : "swift-algorithms"
+                              }
+            """
+        } else {
+            algorithmsDependency = ""
+        }
+        try await fileSystem.makeDirectory(at: workspaceStatePath.parentDirectory)
+        try await fileSystem.writeText(
+            """
+            {
+              "object" : {
+                "artifacts" : [],
+                "dependencies" : [
+                  {
+                    "basedOn" : null,
+                    "packageRef" : {
+                      "identity" : "localonlypackage",
+                      "kind" : "fileSystem",
+                      "location" : "\(packagePath.pathString)",
+                      "name" : "LocalOnlyPackage"
+                    },
+                    "state" : {
+                      "name" : "fileSystem",
+                      "path" : "\(packagePath.pathString)"
+                    },
+                    "subpath" : "localonlypackage"
+                  }
+            \(algorithmsDependency)
+                ]
+              }
+            }
+            """,
+            at: workspaceStatePath
+        )
+    }
+
+    private func writeEmptyWorkspaceState(scratchDirectory: AbsolutePath) async throws {
+        let workspaceStatePath = scratchDirectory.appending(component: "workspace-state.json")
+        try await fileSystem.makeDirectory(at: workspaceStatePath.parentDirectory)
+        try await fileSystem.writeText(
+            """
+            {
+              "object" : {
+                "artifacts" : [],
+                "dependencies" : []
+              }
+            }
+            """,
+            at: workspaceStatePath
+        )
+    }
+
+    private func packageInfo(
+        name: String,
+        dependencies: [PackageDependency] = []
+    ) -> PackageInfo {
+        PackageInfo(
+            name: name,
+            products: [],
+            targets: [
+                PackageInfo.Target(
+                    name: "\(name)Target",
+                    path: nil,
+                    url: nil,
+                    sources: nil,
+                    resources: [],
+                    exclude: [],
+                    dependencies: [],
+                    publicHeadersPath: nil,
+                    type: .regular,
+                    settings: [],
+                    checksum: nil
+                ),
+            ],
+            traits: nil,
+            dependencies: dependencies,
+            platforms: [],
+            cLanguageStandard: nil,
+            cxxLanguageStandard: nil,
+            swiftLanguageVersions: nil,
+            toolsVersion: XcodeGraph.Version(5, 9, 0)
+        )
     }
 }

--- a/cli/Tests/TuistLoaderTests/Loaders/SwiftPackageManagerGraphLoaderTests.swift
+++ b/cli/Tests/TuistLoaderTests/Loaders/SwiftPackageManagerGraphLoaderTests.swift
@@ -932,6 +932,71 @@ struct SwiftPackageManagerGraphLoaderTests {
     }
 
     @Test(.inTemporaryDirectory, .withMockedDependencies())
+    func load_whenLocalPackageHasItsOwnResolvedDependencies_includesThoseDependencies() async throws {
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+
+        let rootScratchDirectory = temporaryDirectory.appending(component: ".build")
+        let localPackagePath = temporaryDirectory.appending(component: "LocalOnlyPackage")
+        let localScratchDirectory = localPackagePath.appending(component: ".build")
+        let algorithmsPackagePath = localScratchDirectory.appending(components: "checkouts", "swift-algorithms")
+
+        try await writeLocalPackageWorkspaceState(
+            scratchDirectory: rootScratchDirectory,
+            packagePath: localPackagePath,
+            identity: "localonlypackage",
+            name: "LocalOnlyPackage"
+        )
+        try await writeRemoteWorkspaceState(
+            scratchDirectory: localScratchDirectory,
+            identity: "swift-algorithms",
+            name: "swift-algorithms",
+            subpath: "swift-algorithms",
+            revision: "swift-algorithms-revision"
+        )
+
+        given(manifestLoader)
+            .loadPackage(at: .value(localPackagePath), disableSandbox: .value(true))
+            .willReturn(.test(name: "LocalOnlyPackage"))
+        given(manifestLoader)
+            .loadPackage(at: .value(algorithmsPackagePath), disableSandbox: .value(true))
+            .willReturn(.test(name: "swift-algorithms"))
+        given(packageInfoMapper)
+            .resolveExternalDependencies(
+                path: .any,
+                packagePath: .any,
+                packageInfos: .any,
+                packageToFolder: .any,
+                packageToTargetsToArtifactPaths: .any,
+                packageModuleAliases: .any,
+                packageSettings: .any
+            )
+            .willReturn([:])
+
+        _ = try await subject.load(
+            packagePath: temporaryDirectory.appending(component: "Package.swift"),
+            packageSettings: .test(),
+            disableSandbox: true
+        )
+
+        verify(packageInfoMapper)
+            .resolveExternalDependencies(
+                path: .value(rootScratchDirectory),
+                packagePath: .value(temporaryDirectory),
+                packageInfos: .matching {
+                    Set($0.keys) == Set(["LocalOnlyPackage", "swift-algorithms"])
+                },
+                packageToFolder: .matching {
+                    $0["LocalOnlyPackage"] == localPackagePath &&
+                        $0["swift-algorithms"] == algorithmsPackagePath
+                },
+                packageToTargetsToArtifactPaths: .any,
+                packageModuleAliases: .any,
+                packageSettings: .any
+            )
+            .called(1)
+    }
+
+    @Test(.inTemporaryDirectory, .withMockedDependencies())
     func load_when_dependency_via_local_registry_and_scm() async throws {
         let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
 
@@ -1180,6 +1245,81 @@ struct SwiftPackageManagerGraphLoaderTests {
                       "version" : "5.10.2"
                     },
                     "subpath" : "\(dependencySubpath)"
+                  }
+                ]
+              }
+            }
+            """,
+            at: workspacePath
+        )
+    }
+
+    private func writeLocalPackageWorkspaceState(
+        scratchDirectory: Path.AbsolutePath,
+        packagePath: Path.AbsolutePath,
+        identity: String,
+        name: String
+    ) async throws {
+        let workspacePath = scratchDirectory.appending(component: "workspace-state.json")
+        try await fileSystem.makeDirectory(at: workspacePath.parentDirectory)
+        try await fileSystem.writeText(
+            """
+            {
+              "object" : {
+                "artifacts" : [],
+                "dependencies" : [
+                  {
+                    "basedOn" : null,
+                    "packageRef" : {
+                      "identity" : "\(identity)",
+                      "kind" : "fileSystem",
+                      "location" : "\(packagePath.pathString)",
+                      "name" : "\(name)"
+                    },
+                    "state" : {
+                      "name" : "fileSystem",
+                      "path" : "\(packagePath.pathString)"
+                    },
+                    "subpath" : "\(identity)"
+                  }
+                ]
+              }
+            }
+            """,
+            at: workspacePath
+        )
+    }
+
+    private func writeRemoteWorkspaceState(
+        scratchDirectory: Path.AbsolutePath,
+        identity: String,
+        name: String,
+        subpath: String,
+        revision: String
+    ) async throws {
+        let workspacePath = scratchDirectory.appending(component: "workspace-state.json")
+        try await fileSystem.makeDirectory(at: workspacePath.parentDirectory)
+        try await fileSystem.writeText(
+            """
+            {
+              "object" : {
+                "artifacts" : [],
+                "dependencies" : [
+                  {
+                    "basedOn" : null,
+                    "packageRef" : {
+                      "identity" : "\(identity)",
+                      "kind" : "remoteSourceControl",
+                      "location" : "https://github.com/example/\(identity)",
+                      "name" : "\(name)"
+                    },
+                    "state" : {
+                      "checkoutState" : {
+                        "revision" : "\(revision)"
+                      },
+                      "name" : "sourceControlCheckout"
+                    },
+                    "subpath" : "\(subpath)"
                   }
                 ]
               }


### PR DESCRIPTION
## What changed

Closes #11407.

This updates SwiftPM dependency installation and graph loading so dependencies declared only by a local Swift package are still available to Tuist-generated projects.

- Recursively prepares local Swift package workspace state during `tuist install` / `tuist update` when the local package has dependencies missing from the known workspace state, or when it declares remote binary targets.
- Keeps `generate` / graph loading as a consumer of installed SwiftPM state instead of invoking `swift package resolve` from the loader path.
- Reads nested local package `workspace-state.json` files and resolves paths relative to each package's own scratch directory, including artifacts and prebuilts.
- Filters custom root `--scratch-path` / `--build-path` arguments when resolving nested local packages so local packages do not overwrite the root scratch state.
- Adds focused regression coverage for recursively resolving local package dependencies and skipping unnecessary local resolves when the root state already contains the dependency.

## Why

The bug happens when the root `Tuist/Package.swift` depends on a local path package, and that local package declares its own external dependency. SwiftPM records that dependency in the local package's workspace state, not necessarily in the root Tuist workspace state. Tuist previously built its external dependency graph from the root workspace state only, so the local package's external dependency could be missing unless users re-declared it at the root.

The fix keeps the SwiftPM side effects in `install` / `update`, then lets graph loading merge the prepared root and nested workspace states. This preserves the existing install/generate boundary and avoids making generation perform networked SwiftPM resolution.