### PR TITLE
test(kura): de-flake namespace-clean cross-node assertions

### DIFF
--- a/kura/spec/e2e/cluster_spec.sh
+++ b/kura/spec/e2e/cluster_spec.sh
@@ -141,12 +141,20 @@ Describe 'core cluster behaviour'
       "${KURA_AP_URL}/api/cache/clean?tenant_id=acme&namespace_id=ios")"
     The variable delete_status should eq 204
 
-    cas_status="$(status_only \
-      "${KURA_US_URL}/api/cache/cas/artifact-1?tenant_id=acme&namespace_id=ios")"
+    # clean only deletes locally on the AP node and enqueues the namespace
+    # tombstone for async replication, so US/EU drop the artifacts eventually,
+    # not by the time the DELETE returns. Poll (15 attempts x 2s = 30s ceiling)
+    # rather than checking once, matching the cross-node waits the other examples use.
+    capture_into cas_status \
+      wait_for_status \
+      "${KURA_US_URL}/api/cache/cas/artifact-1?tenant_id=acme&namespace_id=ios" \
+      404 15 || return 1
     The variable cas_status should eq 404
 
-    keyvalue_status="$(status_only \
-      "${KURA_EU_URL}/api/cache/keyvalue/cas-1?tenant_id=acme&namespace_id=ios")"
+    capture_into keyvalue_status \
+      wait_for_status \
+      "${KURA_EU_URL}/api/cache/keyvalue/cas-1?tenant_id=acme&namespace_id=ios" \
+      404 15 || return 1
     The variable keyvalue_status should eq 404
   End
 


### PR DESCRIPTION
## What changed

The Kura e2e example `removes namespace artifacts across the cluster on clean` (`kura/spec/e2e/cluster_spec.sh`) now **polls** for the post-clean `404` on the US and EU nodes via `wait_for_status ... 404 15` (30s ceiling = 15 attempts × 2s) instead of doing a single one-shot `status_only` GET. A comment documents why the poll is necessary.

## Why it changed

The example intermittently failed:

```
1) core cluster behaviour removes namespace artifacts across the cluster on clean
   1.1) The variable cas_status should eq 404
        expected: 404
             got: 200
        # spec/e2e/cluster_spec.sh:146
```

## Root cause

This is a **test-side race against asynchronous replication**, not a server bug.

- The clean request hits the **AP** node. `clean_namespace` (`src/http.rs:1651`) calls `delete_namespace_and_enqueue`, which deletes the namespace locally on AP and **enqueues** the tombstone for the peers in the same RocksDB write batch (`src/store.rs:1838-1845`), then returns `204` immediately and wakes the background outbox worker via `notify_one()`.
- Propagation of the tombstone to **US** and **EU** (via `apply_replicated_namespace_delete`) happens **asynchronously** in `process_outbox`. A message leaves the outbox only after the peer acks applying it (`src/replication/mod.rs:783-798`).
- The test issued the DELETE on AP and then checked US/EU with a **single** `status_only` GET. Whenever the tombstone hadn't replicated yet, US still served `artifact-1` → `200`, failing the assertion.

Every other cross-node assertion in this spec already polls for the eventual post-condition (`wait_for_contains`, `wait_for_head_status`). The clean example was the only one checking cross-node state synchronously — that was the flake.

## Why this solution over the obvious alternative

The instinct to gate on a deterministic "replication finished" signal rather than poll a side-effect was considered and rejected:

- An outbox-depth signal does exist (`kura_outbox_messages`), and a message leaves the outbox only after the peer applies it — so AP's outbox reaching empty really does mean US/EU applied the tombstone.
- **But every HTTP-exposed view of it** (`/metrics`, `/rollout`, and the internal `runtime.outbox_depth()` write-shedding guard) is fed by a snapshot loop that refreshes only **every 5 seconds** (`src/app.rs:542`). There is no on-demand live outbox read.
- That 5s lag makes it unusable as a gate, and worse, **ambiguous**: the outbox is also `0` before the DELETE, so reading `0` right after issuing clean can be a stale pre-enqueue `0` — reintroducing the exact race, while still requiring a poll loop anyway.

Polling the artifact GET for `404` is the **direct** post-condition the test asserts (US returns 404 ⟺ US applied the tombstone), with no staleness window: US flips to 404 the instant replication lands (the peer applies synchronously inside the replicate request, before AP removes the outbox entry). It converges on the first poll in the happy path and still fails loudly if replication genuinely breaks.

## Impact

Test-only change. No production code touched; the async-enqueue clean behavior is correct and intended per the rollout-safety contract.

## Validation

Built the e2e image and ran `spec/e2e/cluster_spec.sh` **6 times** locally against a fresh 3-node mesh — **6/6 green** (`6 examples, 0 failures` each run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)