### PR TITLE
feat(infra): activate tuist_ops_ro for the Atlas DB runner

### DIFF
--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -99,17 +99,12 @@ server:
       value: tuist-server
     - name: TUIST_ATLAS_TOKEN_MAX_TTL_SECONDS
       value: "3600"
-    # The internal Atlas SQL runner can drop to the least-privilege tuist_ops_ro
-    # role via `SET LOCAL ROLE` by setting:
-    #   - name: TUIST_ATLAS_DB_READONLY_ROLE
-    #     value: tuist_ops_ro
-    # Left unset for now. The membership that permits the switch (web -> tuist_ops_ro)
-    # is now reconciled declaratively by CNPG (`managed.roles[tuist_web].inRoles`),
-    # so no manual grant is needed — but enable this only once CNPG has reconciled
-    # the membership on the cluster (verify: the tuist_web -> tuist_ops_ro row in
-    # pg_auth_members has inherit_option = false), otherwise the first Atlas DB
-    # query would raise on `SET LOCAL ROLE`. Until then the runner stays on the web
-    # role behind the read-only transaction.
+    # The internal Atlas SQL runner drops to the least-privilege tuist_ops_ro role
+    # via `SET LOCAL ROLE`, so writes are blocked by role privileges, not only by
+    # the read-only transaction. The web -> tuist_ops_ro membership that permits
+    # the switch is reconciled by CNPG (`managed.roles[tuist_web].inRoles`).
+    - name: TUIST_ATLAS_DB_READONLY_ROLE
+      value: tuist_ops_ro
     - name: TUIST_ATLAS_TOKEN_JWKS
       value: >-
         {"keys":[{"use":"sig","kty":"RSA","kid":"RlVpaMmFrqqIHY46_HT42inm4mfvqBKfwLVJiPCcl7g","alg":"RS256","n":"urnlzTgGSYHPHyc-sjXI7lzdx3ChfMpqUMpwuj1vgBMywpvdjFEKZ-5xWBBfS_GIna4q--YBau4zo21xFw0Jd-Ye8l4daXozFTwB1oOv-xOoIL7YITR8dtXsXzqeGIKx1rt90jE2vgvYQDBnkIf9ohgDIApbLICYGSAko5MfdypYhiO52KOxum8nB5dwIaKhr2-DiLQtFQbl__c6Uk2dFpW0_5u4d-uO6yspp5iVo54sc7XIlFNxPBlx2uVQZe8tvTH9Ipc_sovDjMfoKH7g0fG14q6xQU5CkQD1pNS__6J3xFvFYQEp3wXu4i_Rin65EI9GvNKtbZkH-sQ5e8jzLw","e":"AQAB"}]}


### PR DESCRIPTION
## What

Activates the least-privilege role for the internal Atlas DB query runner: sets `TUIST_ATLAS_DB_READONLY_ROLE: tuist_ops_ro` in production. The runner now does `SET LOCAL ROLE tuist_ops_ro` for operator SQL, so writes are blocked by role privileges, not only by the read-only transaction.

Final step of the series — #11519 (endpoint + hardening) and #11567 (declarative `tuist_web → tuist_ops_ro` membership) are merged.

## ⚠️ Merge/deploy only after confirming CNPG reconciled the membership

The `SET LOCAL ROLE` requires the membership #11567 added to be live on the cluster. Verify first:

```sql
SELECT g.rolname AS member, r.rolname AS role, m.inherit_option
FROM pg_auth_members m
JOIN pg_roles r ON r.oid = m.roleid
JOIN pg_roles g ON g.oid = m.member
WHERE r.rolname = 'tuist_ops_ro' AND g.rolname = 'tuist_web';
-- expect one row with inherit_option = 'f'
```

If that row isn't present yet, deploying this would make every Atlas DB query raise on `SET LOCAL ROLE`. (Rollback is trivial: revert this one value and the runner falls back to the web role behind the read-only transaction.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
