### PR TITLE
fix(cli): propagate package base settings to macro targets

### DIFF
--- a/cli/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
+++ b/cli/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
@@ -2136,6 +2136,11 @@ extension ProjectDescription.Settings {
 
         var baseSettingsDictionary = ProjectDescription.SettingsDictionary.from(settingsDictionary: settingsDictionary)
 
+        baseSettingsDictionary.merge(
+            .from(settingsDictionary: baseSettings.base),
+            uniquingKeysWith: { _, new in new }
+        )
+
         if let userDefinedBaseSettings = targetSettings?.base {
             baseSettingsDictionary.merge(
                 .from(settingsDictionary: userDefinedBaseSettings),

--- a/cli/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
+++ b/cli/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
@@ -3565,6 +3565,7 @@ struct PackageInfoMapperTests {
                             destinations: .iOS,
                             deploymentTargets: .iOS("12.0"),
                             customSettings: [
+                                "EXCLUDED_ARCHS[sdk=iphonesimulator*]": .string("x86_64"),
                                 "OTHER_LDFLAGS": ["$(inherited)", "key1", "key2", "key3"],
                                 "OTHER_SWIFT_FLAGS": [
                                     "$(inherited)",
@@ -7438,6 +7439,46 @@ struct PackageInfoMapperTests {
             ])
         )
         #expect(target.settings?.base["OTHER_LDFLAGS"] == .array(["$(inherited)", "-lSwiftSyntax"]))
+    }
+
+    @Test(
+        .inTemporaryDirectory, .withMockedSwiftVersionProvider
+    ) func map_macroTarget_appliesBaseSettingsBaseToMacroTarget() async throws {
+        let basePath = try #require(FileSystem.temporaryTestDirectory)
+        try await fileSystem.makeDirectory(
+            at: basePath.appending(try RelativePath(validating: "Package/Sources/Library"))
+        )
+        try await fileSystem.makeDirectory(
+            at: basePath.appending(try RelativePath(validating: "Package/Sources/MyMacro"))
+        )
+
+        let project = try await subject.map(
+            package: "Package",
+            basePath: basePath,
+            packageType: .local,
+            packageInfos: [
+                "Package": .test(
+                    name: "Package",
+                    products: [
+                        .init(name: "Library", type: .library(.automatic), targets: ["Library"]),
+                    ],
+                    targets: [
+                        .test(
+                            name: "Library",
+                            dependencies: [.target(name: "MyMacro", condition: nil)]
+                        ),
+                        .test(name: "MyMacro", type: .macro),
+                    ],
+                    platforms: [.init(platformName: "macos", version: "11.0", options: [])]
+                ),
+            ],
+            packageSettings: .test(
+                baseSettings: Settings.default.with(base: ["MACOSX_DEPLOYMENT_TARGET": "15.0"])
+            )
+        )
+
+        let macroTarget = try #require(project?.targets.first(where: { $0.name == "MyMacro" }))
+        #expect(macroTarget.settings?.base["MACOSX_DEPLOYMENT_TARGET"] == .string("15.0"))
     }
 
     @Test(


### PR DESCRIPTION
Resolves <https://github.com/tuist/tuist/issues/11447>

## What changed

This pull request changes the Swift Package Manager package mapper so package-level base settings are merged into the settings generated for each package target before target-specific overrides are applied.

It also adds a regression test that maps a package with a macro target and verifies that `MACOSX_DEPLOYMENT_TARGET` from `PackageSettings.baseSettings.base` reaches the generated macro target.

## Why

Xcode 27 beta surfaces macro target build issues when the deployment target setting defined through Tuist package settings is not propagated to package targets. Tuist was already applying these settings to regular targets in the broader package mapping path, but macro targets missed the package-level base dictionary.

## Root cause

`ProjectDescription.Settings.from(...)` started from the generated platform and dependency settings and then merged target-specific base settings. It did not merge `PackageSettings.baseSettings.base`, so package-wide settings such as `MACOSX_DEPLOYMENT_TARGET` were dropped for Swift Package Manager targets produced through this path.

## Approach

The mapper now merges package-level base settings into the generated base settings dictionary before applying target-specific settings. This keeps target-specific settings as the final override while making package-wide settings available to all mapped targets, including macro targets.

## Impact

Projects that use package base settings to pin deployment targets or build settings now get those values on macro targets generated from Swift Package Manager packages. Existing target-specific settings keep precedence.

### How to test locally

The change was validated with:

- `tuist install`
- `tuist generate TuistLoaderTests --no-open`
- `xcodebuild test -workspace Tuist.xcworkspace -scheme TuistUnitTests -only-testing TuistLoaderTests/PackageInfoMapperTests -parallel-testing-enabled NO CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""`
- `git diff --check`
