### PR TITLE
fix(cli): suppress duplicate xcframework warnings

### DIFF
--- a/cli/Sources/TuistLoader/Models+ManifestMappers/Target+ManifestMapper.swift
+++ b/cli/Sources/TuistLoader/Models+ManifestMappers/Target+ManifestMapper.swift
@@ -20,6 +20,15 @@ public enum TargetManifestMapperError: FatalError, Equatable {
     }
 }
 
+extension XcodeGraph.TargetDependency {
+    fileprivate var isXCFrameworkDependency: Bool {
+        if case .xcframework = self {
+            return true
+        }
+        return false
+    }
+}
+
 // swiftlint:disable function_body_length
 extension XcodeGraph.Target {
     /// Maps a ProjectDescription.Target instance into a XcodeGraph.Target instance.
@@ -44,12 +53,28 @@ extension XcodeGraph.Target {
         let productName = manifest.productName
         let deploymentTargets = manifest.deploymentTargets.map { XcodeGraph.DeploymentTargets.from(manifest: $0) } ?? .empty()
 
-        let dependencies = try manifest.dependencies.flatMap {
-            try XcodeGraph.TargetDependency.from(
-                manifest: $0,
+        var dependencies: [XcodeGraph.TargetDependency] = []
+        var externalXCFrameworkDependencies = Set<XcodeGraph.TargetDependency>()
+        for manifestDependency in manifest.dependencies {
+            let mappedDependencies = try XcodeGraph.TargetDependency.from(
+                manifest: manifestDependency,
                 generatorPaths: generatorPaths,
                 externalDependencies: externalDependencies
             )
+
+            if case .external = manifestDependency {
+                for mappedDependency in mappedDependencies {
+                    guard !mappedDependency.isXCFrameworkDependency else {
+                        if externalXCFrameworkDependencies.insert(mappedDependency).inserted {
+                            dependencies.append(mappedDependency)
+                        }
+                        continue
+                    }
+                    dependencies.append(mappedDependency)
+                }
+            } else {
+                dependencies.append(contentsOf: mappedDependencies)
+            }
         }
 
         let infoPlist = try XcodeGraph.InfoPlist.from(manifest: manifest.infoPlist, generatorPaths: generatorPaths)

--- a/cli/Tests/TuistGeneratorTests/Linter/TargetLinterTests.swift
+++ b/cli/Tests/TuistGeneratorTests/Linter/TargetLinterTests.swift
@@ -452,6 +452,42 @@ final class TargetLinterTests: TuistUnitTestCase {
         )))
     }
 
+    func test_lint_when_target_has_duplicate_target_dependencies_specified() async throws {
+        let testDependency: TargetDependency = .target(name: "Library")
+
+        // Given
+        let target = Target.test(dependencies: .init(repeating: testDependency, count: 2))
+
+        // When
+        let got = try await subject.lint(target: target, options: .test())
+
+        // Then
+        XCTAssertTrue(got.contains(LintingIssue(
+            reason: "Target '\(target.name)' has duplicate target dependency specified: 'Library'",
+            severity: .warning
+        )))
+    }
+
+    func test_lint_when_target_has_duplicate_xcframework_dependencies_specified() async throws {
+        let testDependency: TargetDependency = .xcframework(
+            path: "/Frameworks/MyBinary.xcframework",
+            expectedSignature: nil,
+            status: .required
+        )
+
+        // Given
+        let target = Target.test(dependencies: .init(repeating: testDependency, count: 2))
+
+        // When
+        let got = try await subject.lint(target: target, options: .test())
+
+        // Then
+        XCTAssertTrue(got.contains(LintingIssue(
+            reason: "Target '\(target.name)' has duplicate xcframework dependency specified: 'MyBinary.xcframework'",
+            severity: .warning
+        )))
+    }
+
     func test_lint_when_target_has_non_existing_core_data_models() async throws {
         // Given
         let path = try temporaryPath()

--- a/cli/Tests/TuistLoaderTests/Models+ManifestMappers/Target+ManifestMapperTests.swift
+++ b/cli/Tests/TuistLoaderTests/Models+ManifestMappers/Target+ManifestMapperTests.swift
@@ -207,4 +207,87 @@ final class TargetManifestMapperTests: TuistUnitTestCase {
             .hash(Parameter<String>.value("generated-file-Scripts/GeneratedFile.swift"))
             .called(1)
     }
+
+    func test_from_deduplicatesIdenticalXCFrameworkDependenciesExpandedFromExternalDependencies() async throws {
+        // Given
+        let rootDirectory = try temporaryPath()
+        let generatorPaths = GeneratorPaths(
+            manifestDirectory: try temporaryPath(),
+            rootDirectory: rootDirectory
+        )
+        let xcframeworkDependency = XcodeGraph.TargetDependency.xcframework(
+            path: "/Frameworks/MyBinary.xcframework",
+            expectedSignature: nil,
+            status: .required
+        )
+        let mockContentHasher = MockContentHashing()
+
+        // When
+        let target = try await XcodeGraph.Target.from(
+            manifest: .test(
+                infoPlist: .default,
+                sources: .sourceFilesList(globs: [ProjectDescription.SourceFileGlob]()),
+                resources: .resources([]),
+                dependencies: [
+                    .external(name: "ProductA"),
+                    .external(name: "ProductB"),
+                ]
+            ),
+            generatorPaths: generatorPaths,
+            externalDependencies: [
+                "ProductA": [xcframeworkDependency],
+                "ProductB": [xcframeworkDependency],
+            ],
+            fileSystem: fileSystem,
+            contentHasher: mockContentHasher,
+            type: .local
+        )
+
+        // Then
+        XCTAssertEqual(target.dependencies, [xcframeworkDependency])
+    }
+
+    func test_from_preservesDuplicateAuthoredXCFrameworkDependencies() async throws {
+        // Given
+        let rootDirectory = try temporaryPath()
+        let generatorPaths = GeneratorPaths(
+            manifestDirectory: try temporaryPath(),
+            rootDirectory: rootDirectory
+        )
+        let manifestDependency = ProjectDescription.TargetDependency.xcframework(
+            path: "/Frameworks/MyBinary.xcframework",
+            expectedSignature: nil,
+            status: .required
+        )
+        let graphDependency = XcodeGraph.TargetDependency.xcframework(
+            path: "/Frameworks/MyBinary.xcframework",
+            expectedSignature: nil,
+            status: .required
+        )
+        let mockContentHasher = MockContentHashing()
+
+        // When
+        let target = try await XcodeGraph.Target.from(
+            manifest: .test(
+                infoPlist: .default,
+                sources: .sourceFilesList(globs: [ProjectDescription.SourceFileGlob]()),
+                resources: .resources([]),
+                dependencies: [
+                    manifestDependency,
+                    manifestDependency,
+                ]
+            ),
+            generatorPaths: generatorPaths,
+            externalDependencies: [:],
+            fileSystem: fileSystem,
+            contentHasher: mockContentHasher,
+            type: .local
+        )
+
+        // Then
+        XCTAssertEqual(target.dependencies, [
+            graphDependency,
+            graphDependency,
+        ])
+    }
 }


### PR DESCRIPTION
## What Changed

- De-duplicate identical `.xcframework` dependencies while expanding `.external` SwiftPM products into graph target dependencies.
- Restore the duplicate-dependency linter's normal behavior so authored duplicate `.xcframework` entries still warn.
- Add mapper coverage for both sides of the boundary:
  - duplicate xcframework artifacts reached through multiple external products collapse to one graph dependency
  - duplicate hand-authored xcframework dependencies are preserved for linting
- Add linter coverage proving duplicate target and xcframework graph dependencies still warn when they reach `TargetLinter`.

Fixes #11495.

## Why

`tuist generate` could warn that a target had a duplicate xcframework dependency when the same binary SwiftPM target was reached through multiple external SwiftPM products. The generated project already de-duplicated that artifact, so the warning described an intermediate expansion artifact rather than something users could fix in their consuming manifest.

The initial narrow fix was to skip duplicate `.xcframework` warnings in the linter. This PR now takes the longer-term route instead: normalize the duplicated external SwiftPM expansion before linting and generation consume the graph.

## Root Cause

`ProjectDescription.TargetDependency.external` expands to one or more `XcodeGraph.TargetDependency` values in `Target+ManifestMapper`. When two external SwiftPM products converged on the same binary target, that expansion appended two byte-identical `.xcframework` dependencies to the target.

Generation later collapsed those identical precompiled references when writing project file elements, but linting ran against the pre-normalized dependency list and therefore warned before generation's de-duplication took effect.

## Approach

The mapper now tracks `.xcframework` dependencies produced by `.external` expansion and only appends the first identical one. This keeps the graph aligned with the generated `.pbxproj` for SwiftPM convergence while preserving authored manifest duplicates:

- two external products resolving to the same `.xcframework` -> one graph dependency, no false-positive warning
- two explicit `.xcframework` entries in a manifest -> two graph dependencies, duplicate warning preserved

This avoids adding origin-blind exceptions to `TargetLinter`.

## Validation

- `tuist generate tuist TuistGenerator TuistGeneratorTests TuistLoader TuistLoaderTests ProjectDescription --no-open`
- `xcsiftbuild test -workspace Tuist.xcworkspace -scheme Tuist-Workspace -only-testing TuistLoaderTests/TargetManifestMapperTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" COMPILATION_CACHE_ENABLE_CACHING=NO`
- `xcsiftbuild test -workspace Tuist.xcworkspace -scheme Tuist-Workspace -only-testing TuistGeneratorTests/TargetLinterTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" COMPILATION_CACHE_ENABLE_CACHING=NO`

Results:

- `TargetManifestMapperTests`: 5 passed, 0 failed
- `TargetLinterTests`: 28 passed, 0 failed
