### PR TITLE
feat(server): add cache run date filters

### DIFF
--- a/cli/Sources/TuistServer/OpenAPI/Client.swift
+++ b/cli/Sources/TuistServer/OpenAPI/Client.swift
@@ -2263,6 +2263,13 @@ public struct Client: APIProtocol {
                     in: &request,
                     style: .form,
                     explode: true,
+                    name: "git_branch",
+                    value: input.query.git_branch
+                )
+                try converter.setQueryItemAsURI(
+                    in: &request,
+                    style: .form,
+                    explode: true,
                     name: "page",
                     value: input.query.page
                 )
@@ -2272,13 +2279,6 @@ public struct Client: APIProtocol {
                     explode: true,
                     name: "page_size",
                     value: input.query.page_size
-                )
-                try converter.setQueryItemAsURI(
-                    in: &request,
-                    style: .form,
-                    explode: true,
-                    name: "git_branch",
-                    value: input.query.git_branch
                 )
                 converter.setAcceptHeader(
                     in: &request.headerFields,
@@ -12663,6 +12663,20 @@ public struct Client: APIProtocol {
                     in: &request,
                     style: .form,
                     explode: true,
+                    name: "ran_after",
+                    value: input.query.ran_after
+                )
+                try converter.setQueryItemAsURI(
+                    in: &request,
+                    style: .form,
+                    explode: true,
+                    name: "ran_before",
+                    value: input.query.ran_before
+                )
+                try converter.setQueryItemAsURI(
+                    in: &request,
+                    style: .form,
+                    explode: true,
                     name: "page_size",
                     value: input.query.page_size
                 )
@@ -12703,6 +12717,28 @@ public struct Client: APIProtocol {
                         preconditionFailure("bestContentType chose an invalid content type.")
                     }
                     return .ok(.init(body: body))
+                case 400:
+                    let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
+                    let body: Operations.listCacheRuns.Output.BadRequest.Body
+                    let chosenContentType = try converter.bestContentType(
+                        received: contentType,
+                        options: [
+                            "application/json"
+                        ]
+                    )
+                    switch chosenContentType {
+                    case "application/json":
+                        body = try await converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: responseBody,
+                            transforming: { value in
+                                .json(value)
+                            }
+                        )
+                    default:
+                        preconditionFailure("bestContentType chose an invalid content type.")
+                    }
+                    return .badRequest(.init(body: body))
                 case 403:
                     let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
                     let body: Operations.listCacheRuns.Output.Forbidden.Body

--- a/cli/Sources/TuistServer/OpenAPI/Client.swift
+++ b/cli/Sources/TuistServer/OpenAPI/Client.swift
@@ -2263,13 +2263,6 @@ public struct Client: APIProtocol {
                     in: &request,
                     style: .form,
                     explode: true,
-                    name: "git_branch",
-                    value: input.query.git_branch
-                )
-                try converter.setQueryItemAsURI(
-                    in: &request,
-                    style: .form,
-                    explode: true,
                     name: "page",
                     value: input.query.page
                 )
@@ -2279,6 +2272,13 @@ public struct Client: APIProtocol {
                     explode: true,
                     name: "page_size",
                     value: input.query.page_size
+                )
+                try converter.setQueryItemAsURI(
+                    in: &request,
+                    style: .form,
+                    explode: true,
+                    name: "git_branch",
+                    value: input.query.git_branch
                 )
                 converter.setAcceptHeader(
                     in: &request.headerFields,
@@ -12661,17 +12661,10 @@ public struct Client: APIProtocol {
                 )
                 try converter.setQueryItemAsURI(
                     in: &request,
-                    style: .form,
+                    style: .deepObject,
                     explode: true,
-                    name: "ran_after",
-                    value: input.query.ran_after
-                )
-                try converter.setQueryItemAsURI(
-                    in: &request,
-                    style: .form,
-                    explode: true,
-                    name: "ran_before",
-                    value: input.query.ran_before
+                    name: "ran_at",
+                    value: input.query.ran_at
                 )
                 try converter.setQueryItemAsURI(
                     in: &request,

--- a/cli/Sources/TuistServer/OpenAPI/Types.swift
+++ b/cli/Sources/TuistServer/OpenAPI/Types.swift
@@ -18323,6 +18323,10 @@ public enum Operations {
             public var path: Operations.listBundles.Input.Path
             /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/bundles/GET/query`.
             public struct Query: Sendable, Hashable {
+                /// Filter bundles by git branch.
+                ///
+                /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/bundles/GET/query/git_branch`.
+                public var git_branch: Swift.String?
                 /// Page number for pagination.
                 ///
                 /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/bundles/GET/query/page`.
@@ -18331,24 +18335,20 @@ public enum Operations {
                 ///
                 /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/bundles/GET/query/page_size`.
                 public var page_size: Swift.Int?
-                /// Filter bundles by git branch.
-                ///
-                /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/bundles/GET/query/git_branch`.
-                public var git_branch: Swift.String?
                 /// Creates a new `Query`.
                 ///
                 /// - Parameters:
+                ///   - git_branch: Filter bundles by git branch.
                 ///   - page: Page number for pagination.
                 ///   - page_size: Number of items per page.
-                ///   - git_branch: Filter bundles by git branch.
                 public init(
+                    git_branch: Swift.String? = nil,
                     page: Swift.Int? = nil,
-                    page_size: Swift.Int? = nil,
-                    git_branch: Swift.String? = nil
+                    page_size: Swift.Int? = nil
                 ) {
+                    self.git_branch = git_branch
                     self.page = page
                     self.page_size = page_size
-                    self.git_branch = git_branch
                 }
             }
             public var query: Operations.listBundles.Input.Query
@@ -46903,6 +46903,14 @@ public enum Operations {
                 ///
                 /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/cache-runs/GET/query/git_commit_sha`.
                 public var git_commit_sha: Swift.String?
+                /// Return cache runs that executed at or after this timestamp. Accepts Unix seconds or a timestamp string such as 2026-01-15T10:00:00Z.
+                ///
+                /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/cache-runs/GET/query/ran_after`.
+                public var ran_after: Swift.String?
+                /// Return cache runs that executed at or before this timestamp. Accepts Unix seconds or a timestamp string such as 2026-01-15T10:00:00Z.
+                ///
+                /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/cache-runs/GET/query/ran_before`.
+                public var ran_before: Swift.String?
                 ///
                 ///
                 /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/cache-runs/GET/query/page_size`.
@@ -46917,18 +46925,24 @@ public enum Operations {
                 ///   - git_ref: Filter by git ref.
                 ///   - git_branch: Filter by git branch.
                 ///   - git_commit_sha: Filter by git commit SHA.
+                ///   - ran_after: Return cache runs that executed at or after this timestamp. Accepts Unix seconds or a timestamp string such as 2026-01-15T10:00:00Z.
+                ///   - ran_before: Return cache runs that executed at or before this timestamp. Accepts Unix seconds or a timestamp string such as 2026-01-15T10:00:00Z.
                 ///   - page_size:
                 ///   - page:
                 public init(
                     git_ref: Swift.String? = nil,
                     git_branch: Swift.String? = nil,
                     git_commit_sha: Swift.String? = nil,
+                    ran_after: Swift.String? = nil,
+                    ran_before: Swift.String? = nil,
                     page_size: Swift.Int? = nil,
                     page: Swift.Int? = nil
                 ) {
                     self.git_ref = git_ref
                     self.git_branch = git_branch
                     self.git_commit_sha = git_commit_sha
+                    self.ran_after = ran_after
+                    self.ran_before = ran_before
                     self.page_size = page_size
                     self.page = page
                 }
@@ -47207,6 +47221,57 @@ public enum Operations {
                     default:
                         try throwUnexpectedResponseStatus(
                             expectedStatus: "ok",
+                            response: self
+                        )
+                    }
+                }
+            }
+            public struct BadRequest: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/cache-runs/GET/responses/400/content`.
+                @frozen public enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/cache-runs/GET/responses/400/content/application\/json`.
+                    case json(Components.Schemas._Error)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    public var json: Components.Schemas._Error {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                public var body: Operations.listCacheRuns.Output.BadRequest.Body
+                /// Creates a new `BadRequest`.
+                ///
+                /// - Parameters:
+                ///   - body: Received HTTP response body
+                public init(body: Operations.listCacheRuns.Output.BadRequest.Body) {
+                    self.body = body
+                }
+            }
+            /// The request was invalid
+            ///
+            /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/cache-runs/get(listCacheRuns)/responses/400`.
+            ///
+            /// HTTP response code: `400 badRequest`.
+            case badRequest(Operations.listCacheRuns.Output.BadRequest)
+            /// The associated value of the enum case if `self` is `.badRequest`.
+            ///
+            /// - Throws: An error if `self` is not `.badRequest`.
+            /// - SeeAlso: `.badRequest`.
+            public var badRequest: Operations.listCacheRuns.Output.BadRequest {
+                get throws {
+                    switch self {
+                    case let .badRequest(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "badRequest",
                             response: self
                         )
                     }

--- a/cli/Sources/TuistServer/OpenAPI/Types.swift
+++ b/cli/Sources/TuistServer/OpenAPI/Types.swift
@@ -18323,10 +18323,6 @@ public enum Operations {
             public var path: Operations.listBundles.Input.Path
             /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/bundles/GET/query`.
             public struct Query: Sendable, Hashable {
-                /// Filter bundles by git branch.
-                ///
-                /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/bundles/GET/query/git_branch`.
-                public var git_branch: Swift.String?
                 /// Page number for pagination.
                 ///
                 /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/bundles/GET/query/page`.
@@ -18335,20 +18331,24 @@ public enum Operations {
                 ///
                 /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/bundles/GET/query/page_size`.
                 public var page_size: Swift.Int?
+                /// Filter bundles by git branch.
+                ///
+                /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/bundles/GET/query/git_branch`.
+                public var git_branch: Swift.String?
                 /// Creates a new `Query`.
                 ///
                 /// - Parameters:
-                ///   - git_branch: Filter bundles by git branch.
                 ///   - page: Page number for pagination.
                 ///   - page_size: Number of items per page.
+                ///   - git_branch: Filter bundles by git branch.
                 public init(
-                    git_branch: Swift.String? = nil,
                     page: Swift.Int? = nil,
-                    page_size: Swift.Int? = nil
+                    page_size: Swift.Int? = nil,
+                    git_branch: Swift.String? = nil
                 ) {
-                    self.git_branch = git_branch
                     self.page = page
                     self.page_size = page_size
+                    self.git_branch = git_branch
                 }
             }
             public var query: Operations.listBundles.Input.Query
@@ -46903,14 +46903,70 @@ public enum Operations {
                 ///
                 /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/cache-runs/GET/query/git_commit_sha`.
                 public var git_commit_sha: Swift.String?
-                /// Return cache runs that executed at or after this timestamp. Accepts Unix seconds or a timestamp string such as 2026-01-15T10:00:00Z.
+                /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/cache-runs/GET/query/ran_at`.
+                public struct ran_atPayload: Codable, Hashable, Sendable {
+                    /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/cache-runs/GET/query/ran_at/gt`.
+                    public var gt: Swift.Int64?
+                    /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/cache-runs/GET/query/ran_at/gte`.
+                    public var gte: Swift.Int64?
+                    /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/cache-runs/GET/query/ran_at/lt`.
+                    public var lt: Swift.Int64?
+                    /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/cache-runs/GET/query/ran_at/lte`.
+                    public var lte: Swift.Int64?
+                    /// Creates a new `ran_atPayload`.
+                    ///
+                    /// - Parameters:
+                    ///   - gt:
+                    ///   - gte:
+                    ///   - lt:
+                    ///   - lte:
+                    public init(
+                        gt: Swift.Int64? = nil,
+                        gte: Swift.Int64? = nil,
+                        lt: Swift.Int64? = nil,
+                        lte: Swift.Int64? = nil
+                    ) {
+                        self.gt = gt
+                        self.gte = gte
+                        self.lt = lt
+                        self.lte = lte
+                    }
+                    public enum CodingKeys: String, CodingKey {
+                        case gt
+                        case gte
+                        case lt
+                        case lte
+                    }
+                    public init(from decoder: any Decoder) throws {
+                        let container = try decoder.container(keyedBy: CodingKeys.self)
+                        self.gt = try container.decodeIfPresent(
+                            Swift.Int64.self,
+                            forKey: .gt
+                        )
+                        self.gte = try container.decodeIfPresent(
+                            Swift.Int64.self,
+                            forKey: .gte
+                        )
+                        self.lt = try container.decodeIfPresent(
+                            Swift.Int64.self,
+                            forKey: .lt
+                        )
+                        self.lte = try container.decodeIfPresent(
+                            Swift.Int64.self,
+                            forKey: .lte
+                        )
+                        try decoder.ensureNoAdditionalProperties(knownKeys: [
+                            "gt",
+                            "gte",
+                            "lt",
+                            "lte"
+                        ])
+                    }
+                }
+                /// Filter by execution time using ran_at[gt], ran_at[gte], ran_at[lt], or ran_at[lte] Unix seconds.
                 ///
-                /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/cache-runs/GET/query/ran_after`.
-                public var ran_after: Swift.String?
-                /// Return cache runs that executed at or before this timestamp. Accepts Unix seconds or a timestamp string such as 2026-01-15T10:00:00Z.
-                ///
-                /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/cache-runs/GET/query/ran_before`.
-                public var ran_before: Swift.String?
+                /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/cache-runs/GET/query/ran_at`.
+                public var ran_at: Operations.listCacheRuns.Input.Query.ran_atPayload?
                 ///
                 ///
                 /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/cache-runs/GET/query/page_size`.
@@ -46925,24 +46981,21 @@ public enum Operations {
                 ///   - git_ref: Filter by git ref.
                 ///   - git_branch: Filter by git branch.
                 ///   - git_commit_sha: Filter by git commit SHA.
-                ///   - ran_after: Return cache runs that executed at or after this timestamp. Accepts Unix seconds or a timestamp string such as 2026-01-15T10:00:00Z.
-                ///   - ran_before: Return cache runs that executed at or before this timestamp. Accepts Unix seconds or a timestamp string such as 2026-01-15T10:00:00Z.
+                ///   - ran_at: Filter by execution time using ran_at[gt], ran_at[gte], ran_at[lt], or ran_at[lte] Unix seconds.
                 ///   - page_size:
                 ///   - page:
                 public init(
                     git_ref: Swift.String? = nil,
                     git_branch: Swift.String? = nil,
                     git_commit_sha: Swift.String? = nil,
-                    ran_after: Swift.String? = nil,
-                    ran_before: Swift.String? = nil,
+                    ran_at: Operations.listCacheRuns.Input.Query.ran_atPayload? = nil,
                     page_size: Swift.Int? = nil,
                     page: Swift.Int? = nil
                 ) {
                     self.git_ref = git_ref
                     self.git_branch = git_branch
                     self.git_commit_sha = git_commit_sha
-                    self.ran_after = ran_after
-                    self.ran_before = ran_before
+                    self.ran_at = ran_at
                     self.page_size = page_size
                     self.page = page
                 }

--- a/cli/Sources/TuistServer/OpenAPI/server.yml
+++ b/cli/Sources/TuistServer/OpenAPI/server.yml
@@ -8730,14 +8730,6 @@ paths:
       callbacks: {}
       operationId: listBundles
       parameters:
-        - description: Filter bundles by git branch.
-          in: query
-          name: git_branch
-          required: false
-          schema:
-            type: string
-            x-struct:
-            x-validate:
         - description: Page number for pagination.
           in: query
           name: page
@@ -8760,6 +8752,14 @@ paths:
           required: false
           schema:
             type: integer
+            x-struct:
+            x-validate:
+        - description: Filter bundles by git branch.
+          in: query
+          name: git_branch
+          required: false
+          schema:
+            type: string
             x-struct:
             x-validate:
         - description: The handle of the project.
@@ -17561,22 +17561,38 @@ paths:
             type: string
             x-struct:
             x-validate:
-        - description: Return cache runs that executed at or after this timestamp. Accepts Unix seconds or a timestamp string such as 2026-01-15T10:00:00Z.
+        - description: Filter by execution time using ran_at[gt], ran_at[gte], ran_at[lt], or ran_at[lte] Unix seconds.
+          explode: true
           in: query
-          name: ran_after
+          name: ran_at
           required: false
           schema:
-            type: string
+            additionalProperties: false
+            properties:
+              gt:
+                format: int64
+                type: integer
+                x-struct:
+                x-validate:
+              gte:
+                format: int64
+                type: integer
+                x-struct:
+                x-validate:
+              lt:
+                format: int64
+                type: integer
+                x-struct:
+                x-validate:
+              lte:
+                format: int64
+                type: integer
+                x-struct:
+                x-validate:
+            type: object
             x-struct:
             x-validate:
-        - description: Return cache runs that executed at or before this timestamp. Accepts Unix seconds or a timestamp string such as 2026-01-15T10:00:00Z.
-          in: query
-          name: ran_before
-          required: false
-          schema:
-            type: string
-            x-struct:
-            x-validate:
+          style: deepObject
         - description: ''
           in: query
           name: page_size

--- a/cli/Sources/TuistServer/OpenAPI/server.yml
+++ b/cli/Sources/TuistServer/OpenAPI/server.yml
@@ -8730,6 +8730,14 @@ paths:
       callbacks: {}
       operationId: listBundles
       parameters:
+        - description: Filter bundles by git branch.
+          in: query
+          name: git_branch
+          required: false
+          schema:
+            type: string
+            x-struct:
+            x-validate:
         - description: Page number for pagination.
           in: query
           name: page
@@ -8752,14 +8760,6 @@ paths:
           required: false
           schema:
             type: integer
-            x-struct:
-            x-validate:
-        - description: Filter bundles by git branch.
-          in: query
-          name: git_branch
-          required: false
-          schema:
-            type: string
             x-struct:
             x-validate:
         - description: The handle of the project.
@@ -17561,6 +17561,22 @@ paths:
             type: string
             x-struct:
             x-validate:
+        - description: Return cache runs that executed at or after this timestamp. Accepts Unix seconds or a timestamp string such as 2026-01-15T10:00:00Z.
+          in: query
+          name: ran_after
+          required: false
+          schema:
+            type: string
+            x-struct:
+            x-validate:
+        - description: Return cache runs that executed at or before this timestamp. Accepts Unix seconds or a timestamp string such as 2026-01-15T10:00:00Z.
+          in: query
+          name: ran_before
+          required: false
+          schema:
+            type: string
+            x-struct:
+            x-validate:
         - description: ''
           in: query
           name: page_size
@@ -17732,6 +17748,12 @@ paths:
                 x-struct:
                 x-validate:
           description: List of cache runs
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: The request was invalid
         '403':
           content:
             application/json:

--- a/cli/Sources/TuistServer/Services/ListBundlesService.swift
+++ b/cli/Sources/TuistServer/Services/ListBundlesService.swift
@@ -63,9 +63,9 @@ public struct ListBundlesService: ListBundlesServicing {
                     project_handle: handles.projectHandle
                 ),
                 query: .init(
+                    git_branch: gitBranch,
                     page: page,
-                    page_size: pageSize,
-                    git_branch: gitBranch
+                    page_size: pageSize
                 )
             )
         )

--- a/cli/Sources/TuistServer/Services/ListBundlesService.swift
+++ b/cli/Sources/TuistServer/Services/ListBundlesService.swift
@@ -63,9 +63,9 @@ public struct ListBundlesService: ListBundlesServicing {
                     project_handle: handles.projectHandle
                 ),
                 query: .init(
-                    git_branch: gitBranch,
                     page: page,
-                    page_size: pageSize
+                    page_size: pageSize,
+                    git_branch: gitBranch
                 )
             )
         )

--- a/cli/Sources/TuistServer/Services/ListCacheRunsService.swift
+++ b/cli/Sources/TuistServer/Services/ListCacheRunsService.swift
@@ -18,13 +18,14 @@ public protocol ListCacheRunsServicing: Sendable {
 
 enum ListCacheRunsServiceError: LocalizedError {
     case unknownError(Int)
+    case badRequest(String)
     case forbidden(String)
 
     var errorDescription: String? {
         switch self {
         case let .unknownError(statusCode):
             return "The cache runs could not be listed due to an unknown Tuist response of \(statusCode)."
-        case let .forbidden(message):
+        case let .badRequest(message), let .forbidden(message):
             return message
         }
     }
@@ -70,6 +71,11 @@ public struct ListCacheRunsService: ListCacheRunsServicing {
             switch okResponse.body {
             case let .json(json):
                 return json
+            }
+        case let .badRequest(badRequest):
+            switch badRequest.body {
+            case let .json(error):
+                throw ListCacheRunsServiceError.badRequest(error.message)
             }
         case let .forbidden(forbidden):
             switch forbidden.body {

--- a/server/lib/tuist/command_events/event.ex
+++ b/server/lib/tuist/command_events/event.ex
@@ -19,7 +19,8 @@ defmodule Tuist.CommandEvents.Event do
       :user_id,
       :hit_rate,
       :cacheable_targets_count,
-      :cache_endpoint
+      :cache_endpoint,
+      :ran_at
     ],
     sortable: [:created_at, :ran_at, :duration, :hit_rate]
   }

--- a/server/lib/tuist_web/controllers/api/cache_runs_controller.ex
+++ b/server/lib/tuist_web/controllers/api/cache_runs_controller.ex
@@ -48,17 +48,21 @@ defmodule TuistWeb.API.CacheRunsController do
         type: :string,
         description: "Filter by git commit SHA."
       ],
-      ran_after: [
+      ran_at: [
         in: :query,
-        type: :string,
-        description:
-          "Return cache runs that executed at or after this timestamp. Accepts Unix seconds or a timestamp string such as 2026-01-15T10:00:00Z."
-      ],
-      ran_before: [
-        in: :query,
-        type: :string,
-        description:
-          "Return cache runs that executed at or before this timestamp. Accepts Unix seconds or a timestamp string such as 2026-01-15T10:00:00Z."
+        style: :deepObject,
+        explode: true,
+        type: %Schema{
+          type: :object,
+          additionalProperties: false,
+          properties: %{
+            gt: %Schema{type: :integer, format: :int64},
+            gte: %Schema{type: :integer, format: :int64},
+            lt: %Schema{type: :integer, format: :int64},
+            lte: %Schema{type: :integer, format: :int64}
+          }
+        },
+        description: "Filter by execution time using ran_at[gt], ran_at[gte], ran_at[lt], or ran_at[lte] Unix seconds."
       ],
       page_size: [
         in: :query,
@@ -332,69 +336,34 @@ defmodule TuistWeb.API.CacheRunsController do
     end
   end
 
-  defp ran_at_filters_from_params(params) do
-    with {:ok, ran_after_filter} <- ran_at_filter_from_params(params, :ran_after, :>=),
-         {:ok, ran_before_filter} <- ran_at_filter_from_params(params, :ran_before, :<=) do
-      {:ok, Enum.reject([ran_after_filter, ran_before_filter], &is_nil/1)}
-    end
+  defp ran_at_filters_from_params(%{ran_at: ran_at}) when is_map(ran_at) do
+    Enum.reduce_while([{:gt, :>}, {:gte, :>=}, {:lt, :<}, {:lte, :<=}], {:ok, []}, fn {param, op}, {:ok, filters} ->
+      case Map.get(ran_at, param) do
+        nil ->
+          {:cont, {:ok, filters}}
+
+        value ->
+          case parse_unix_timestamp(value) do
+            {:ok, datetime} ->
+              {:cont, {:ok, filters ++ [%{field: :ran_at, op: op, value: datetime}]}}
+
+            :error ->
+              {:halt, {:error, "`ran_at[#{param}]` must be a valid Unix timestamp."}}
+          end
+      end
+    end)
   end
 
-  defp ran_at_filter_from_params(params, param, op) do
-    case Map.get(params, param) do
-      nil ->
-        {:ok, nil}
+  defp ran_at_filters_from_params(_params), do: {:ok, []}
 
-      value ->
-        case parse_datetime_filter(value) do
-          {:ok, datetime} ->
-            {:ok, %{field: :ran_at, op: op, value: datetime}}
-
-          :error ->
-            {:error, "`#{param}` must be a valid Unix timestamp or timestamp string such as 2026-01-15T10:00:00Z."}
-        end
-    end
-  end
-
-  defp parse_datetime_filter(value) when is_integer(value), do: parse_unix_timestamp(value)
-
-  defp parse_datetime_filter(value) when is_binary(value) do
-    value = String.trim(value)
-
-    cond do
-      value == "" ->
-        :error
-
-      Regex.match?(~r/^-?\d+$/, value) ->
-        value
-        |> String.to_integer()
-        |> parse_unix_timestamp()
-
-      true ->
-        parse_timestamp_string(value)
-    end
-  end
-
-  defp parse_datetime_filter(_), do: :error
-
-  defp parse_unix_timestamp(value) do
+  defp parse_unix_timestamp(value) when is_integer(value) and value >= 0 do
     case DateTime.from_unix(value) do
       {:ok, datetime} -> {:ok, DateTime.to_naive(datetime)}
       _ -> :error
     end
   end
 
-  defp parse_timestamp_string(value) do
-    case DateTime.from_iso8601(value) do
-      {:ok, datetime, _offset} ->
-        {:ok, DateTime.to_naive(datetime)}
-
-      _ ->
-        case NaiveDateTime.from_iso8601(value) do
-          {:ok, datetime} -> {:ok, datetime}
-          _ -> :error
-        end
-    end
-  end
+  defp parse_unix_timestamp(_value), do: :error
 
   defp date_to_unix(%DateTime{} = datetime), do: DateTime.to_unix(datetime)
 

--- a/server/lib/tuist_web/controllers/api/cache_runs_controller.ex
+++ b/server/lib/tuist_web/controllers/api/cache_runs_controller.ex
@@ -48,6 +48,18 @@ defmodule TuistWeb.API.CacheRunsController do
         type: :string,
         description: "Filter by git commit SHA."
       ],
+      ran_after: [
+        in: :query,
+        type: :string,
+        description:
+          "Return cache runs that executed at or after this timestamp. Accepts Unix seconds or a timestamp string such as 2026-01-15T10:00:00Z."
+      ],
+      ran_before: [
+        in: :query,
+        type: :string,
+        description:
+          "Return cache runs that executed at or before this timestamp. Accepts Unix seconds or a timestamp string such as 2026-01-15T10:00:00Z."
+      ],
       page_size: [
         in: :query,
         type: %Schema{
@@ -132,6 +144,7 @@ defmodule TuistWeb.API.CacheRunsController do
            },
            required: [:cache_runs, :pagination_metadata]
          }},
+      bad_request: {"The request was invalid", "application/json", Error},
       forbidden: {"You don't have permission to access this resource", "application/json", Error}
     }
   )
@@ -140,64 +153,69 @@ defmodule TuistWeb.API.CacheRunsController do
         %{assigns: %{selected_project: selected_project}, params: %{page_size: page_size, page: page} = params} = conn,
         _params
       ) do
-    filters =
-      [
-        %{field: :project_id, op: :==, value: selected_project.id},
-        %{field: :name, op: :==, value: "cache"}
-      ] ++ filters_from_params(params)
+    case filters_from_params(params) do
+      {:ok, params_filters} ->
+        filters =
+          [
+            %{field: :project_id, op: :==, value: selected_project.id},
+            %{field: :name, op: :==, value: "cache"}
+          ] ++ params_filters
 
-    {command_events, meta} =
-      CommandEvents.list_command_events(%{
-        page: page,
-        page_size: page_size,
-        filters: filters,
-        order_by: [:ran_at],
-        order_directions: [:desc]
-      })
+        {command_events, meta} =
+          CommandEvents.list_command_events(%{
+            page: page,
+            page_size: page_size,
+            filters: filters,
+            order_by: [:ran_at],
+            order_directions: [:desc]
+          })
 
-    json(conn, %{
-      cache_runs:
-        Enum.map(command_events, fn event ->
-          ran_by =
-            if event.user_account_name,
-              do: %{handle: event.user_account_name}
+        json(conn, %{
+          cache_runs:
+            Enum.map(command_events, fn event ->
+              ran_by =
+                if event.user_account_name,
+                  do: %{handle: event.user_account_name}
 
-          event
-          |> Map.take([
-            :id,
-            :duration,
-            :tuist_version,
-            :swift_version,
-            :macos_version,
-            :git_ref,
-            :git_commit_sha,
-            :git_branch,
-            :command_arguments,
-            :cacheable_targets,
-            :local_cache_target_hits,
-            :remote_cache_target_hits
-          ])
-          |> Map.put(:status, status_to_string(event.status))
-          |> Map.put(:is_ci, event.is_ci)
-          |> Map.put(
-            :url,
-            ~p"/#{selected_project.account.name}/#{selected_project.name}/runs/#{event.id}"
-          )
-          |> Map.put(
-            :ran_at,
-            event.created_at |> DateTime.from_naive!("Etc/UTC") |> DateTime.to_unix()
-          )
-          |> Map.put(:ran_by, ran_by)
-        end),
-      pagination_metadata: %{
-        has_next_page: meta.has_next_page?,
-        has_previous_page: meta.has_previous_page?,
-        current_page: meta.current_page,
-        page_size: meta.page_size,
-        total_count: meta.total_count,
-        total_pages: meta.total_pages
-      }
-    })
+              event
+              |> Map.take([
+                :id,
+                :duration,
+                :tuist_version,
+                :swift_version,
+                :macos_version,
+                :git_ref,
+                :git_commit_sha,
+                :git_branch,
+                :command_arguments,
+                :cacheable_targets,
+                :local_cache_target_hits,
+                :remote_cache_target_hits
+              ])
+              |> Map.put(:status, status_to_string(event.status))
+              |> Map.put(:is_ci, event.is_ci)
+              |> Map.put(
+                :url,
+                ~p"/#{selected_project.account.name}/#{selected_project.name}/runs/#{event.id}"
+              )
+              |> Map.put(:ran_at, date_to_unix(event.ran_at))
+              |> Map.put(:ran_by, ran_by)
+            end),
+          pagination_metadata: %{
+            has_next_page: meta.has_next_page?,
+            has_previous_page: meta.has_previous_page?,
+            current_page: meta.current_page,
+            page_size: meta.page_size,
+            total_count: meta.total_count,
+            total_pages: meta.total_pages
+          }
+        })
+
+      {:error, message} ->
+        conn
+        |> put_status(:bad_request)
+        |> json(%{message: message})
+    end
   end
 
   operation(:show,
@@ -287,7 +305,7 @@ defmodule TuistWeb.API.CacheRunsController do
             cacheable_targets: event.cacheable_targets,
             local_cache_target_hits: event.local_cache_target_hits,
             remote_cache_target_hits: event.remote_cache_target_hits,
-            ran_at: event.created_at |> DateTime.from_naive!("Etc/UTC") |> DateTime.to_unix(),
+            ran_at: date_to_unix(event.ran_at),
             url: ~p"/#{selected_project.account.name}/#{selected_project.name}/runs/#{event.id}"
           })
         else
@@ -304,9 +322,86 @@ defmodule TuistWeb.API.CacheRunsController do
   end
 
   defp filters_from_params(params) do
-    [:git_ref, :git_branch, :git_commit_sha]
-    |> Enum.map(&%{field: &1, op: :==, value: Map.get(params, &1)})
-    |> Enum.filter(&(&1.value != nil))
+    with {:ok, ran_at_filters} <- ran_at_filters_from_params(params) do
+      filters =
+        [:git_ref, :git_branch, :git_commit_sha]
+        |> Enum.map(&%{field: &1, op: :==, value: Map.get(params, &1)})
+        |> Enum.filter(&(&1.value != nil))
+
+      {:ok, filters ++ ran_at_filters}
+    end
+  end
+
+  defp ran_at_filters_from_params(params) do
+    with {:ok, ran_after_filter} <- ran_at_filter_from_params(params, :ran_after, :>=),
+         {:ok, ran_before_filter} <- ran_at_filter_from_params(params, :ran_before, :<=) do
+      {:ok, Enum.reject([ran_after_filter, ran_before_filter], &is_nil/1)}
+    end
+  end
+
+  defp ran_at_filter_from_params(params, param, op) do
+    case Map.get(params, param) do
+      nil ->
+        {:ok, nil}
+
+      value ->
+        case parse_datetime_filter(value) do
+          {:ok, datetime} ->
+            {:ok, %{field: :ran_at, op: op, value: datetime}}
+
+          :error ->
+            {:error, "`#{param}` must be a valid Unix timestamp or timestamp string such as 2026-01-15T10:00:00Z."}
+        end
+    end
+  end
+
+  defp parse_datetime_filter(value) when is_integer(value), do: parse_unix_timestamp(value)
+
+  defp parse_datetime_filter(value) when is_binary(value) do
+    value = String.trim(value)
+
+    cond do
+      value == "" ->
+        :error
+
+      Regex.match?(~r/^-?\d+$/, value) ->
+        value
+        |> String.to_integer()
+        |> parse_unix_timestamp()
+
+      true ->
+        parse_timestamp_string(value)
+    end
+  end
+
+  defp parse_datetime_filter(_), do: :error
+
+  defp parse_unix_timestamp(value) do
+    case DateTime.from_unix(value) do
+      {:ok, datetime} -> {:ok, DateTime.to_naive(datetime)}
+      _ -> :error
+    end
+  end
+
+  defp parse_timestamp_string(value) do
+    case DateTime.from_iso8601(value) do
+      {:ok, datetime, _offset} ->
+        {:ok, DateTime.to_naive(datetime)}
+
+      _ ->
+        case NaiveDateTime.from_iso8601(value) do
+          {:ok, datetime} -> {:ok, datetime}
+          _ -> :error
+        end
+    end
+  end
+
+  defp date_to_unix(%DateTime{} = datetime), do: DateTime.to_unix(datetime)
+
+  defp date_to_unix(%NaiveDateTime{} = datetime) do
+    datetime
+    |> DateTime.from_naive!("Etc/UTC")
+    |> DateTime.to_unix()
   end
 
   defp status_to_string(0), do: "success"

--- a/server/test/tuist_web/controllers/api/cache_runs_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/cache_runs_controller_test.exs
@@ -96,7 +96,7 @@ defmodule TuistWeb.API.CacheRunsControllerTest do
       assert returned["id"] == cache_run.id
     end
 
-    test "filters by ran_after and ran_before", %{conn: conn, user: user, project: project} do
+    test "filters by ran_at gte and lte", %{conn: conn, user: user, project: project} do
       CommandEventsFixtures.command_event_fixture(
         project_id: project.id,
         name: "cache",
@@ -118,8 +118,8 @@ defmodule TuistWeb.API.CacheRunsControllerTest do
 
       query =
         URI.encode_query(%{
-          ran_after: DateTime.to_unix(~U[2026-01-12 00:00:00Z]),
-          ran_before: DateTime.to_iso8601(~U[2026-01-16 00:00:00Z])
+          "ran_at[gte]" => DateTime.to_unix(~U[2026-01-12 00:00:00Z]),
+          "ran_at[lte]" => DateTime.to_unix(~U[2026-01-16 00:00:00Z])
         })
 
       conn =
@@ -132,14 +132,16 @@ defmodule TuistWeb.API.CacheRunsControllerTest do
       assert returned["ran_at"] == DateTime.to_unix(~U[2026-01-15 10:00:00Z])
     end
 
-    test "returns bad request for invalid ran_after", %{conn: conn, user: user, project: project} do
+    test "returns bad request for invalid ran_at operator", %{conn: conn, user: user, project: project} do
+      query = URI.encode_query(%{"ran_at[gte]" => -1})
+
       conn =
         conn
         |> Authentication.put_current_user(user)
-        |> get(~p"/api/projects/#{project.account.name}/#{project.name}/cache-runs?ran_after=invalid")
+        |> get(~p"/api/projects/#{project.account.name}/#{project.name}/cache-runs" <> "?#{query}")
 
       assert %{
-               "message" => "`ran_after` must be a valid Unix timestamp or timestamp string such as 2026-01-15T10:00:00Z."
+               "message" => "`ran_at[gte]` must be a valid Unix timestamp."
              } = json_response(conn, 400)
     end
   end

--- a/server/test/tuist_web/controllers/api/cache_runs_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/cache_runs_controller_test.exs
@@ -16,6 +16,9 @@ defmodule TuistWeb.API.CacheRunsControllerTest do
 
   describe "GET /api/projects/:account_handle/:project_handle/cache-runs" do
     test "returns a list of cache runs", %{conn: conn, user: user, project: project} do
+      created_at = ~U[2026-01-14 10:00:00Z]
+      ran_at = ~U[2026-01-15 10:00:00Z]
+
       cache_run =
         CommandEventsFixtures.command_event_fixture(
           project_id: project.id,
@@ -26,7 +29,9 @@ defmodule TuistWeb.API.CacheRunsControllerTest do
           git_branch: "main",
           cacheable_targets: ["TargetA", "TargetB", "TargetC"],
           local_cache_target_hits: [],
-          remote_cache_target_hits: []
+          remote_cache_target_hits: [],
+          created_at: created_at,
+          ran_at: ran_at
         )
 
       conn =
@@ -46,6 +51,7 @@ defmodule TuistWeb.API.CacheRunsControllerTest do
       assert returned_cache_run["status"] == "success"
       assert returned_cache_run["is_ci"] == true
       assert returned_cache_run["cacheable_targets"] == ["TargetA", "TargetB", "TargetC"]
+      assert returned_cache_run["ran_at"] == DateTime.to_unix(ran_at)
     end
 
     test "returns empty list when no cache runs exist", %{conn: conn, user: user, project: project} do
@@ -88,6 +94,53 @@ defmodule TuistWeb.API.CacheRunsControllerTest do
 
       assert %{"cache_runs" => [returned]} = json_response(conn, 200)
       assert returned["id"] == cache_run.id
+    end
+
+    test "filters by ran_after and ran_before", %{conn: conn, user: user, project: project} do
+      CommandEventsFixtures.command_event_fixture(
+        project_id: project.id,
+        name: "cache",
+        ran_at: ~U[2026-01-10 10:00:00Z]
+      )
+
+      cache_run =
+        CommandEventsFixtures.command_event_fixture(
+          project_id: project.id,
+          name: "cache",
+          ran_at: ~U[2026-01-15 10:00:00Z]
+        )
+
+      CommandEventsFixtures.command_event_fixture(
+        project_id: project.id,
+        name: "cache",
+        ran_at: ~U[2026-01-20 10:00:00Z]
+      )
+
+      query =
+        URI.encode_query(%{
+          ran_after: DateTime.to_unix(~U[2026-01-12 00:00:00Z]),
+          ran_before: DateTime.to_iso8601(~U[2026-01-16 00:00:00Z])
+        })
+
+      conn =
+        conn
+        |> Authentication.put_current_user(user)
+        |> get(~p"/api/projects/#{project.account.name}/#{project.name}/cache-runs" <> "?#{query}")
+
+      assert %{"cache_runs" => [returned]} = json_response(conn, 200)
+      assert returned["id"] == cache_run.id
+      assert returned["ran_at"] == DateTime.to_unix(~U[2026-01-15 10:00:00Z])
+    end
+
+    test "returns bad request for invalid ran_after", %{conn: conn, user: user, project: project} do
+      conn =
+        conn
+        |> Authentication.put_current_user(user)
+        |> get(~p"/api/projects/#{project.account.name}/#{project.name}/cache-runs?ran_after=invalid")
+
+      assert %{
+               "message" => "`ran_after` must be a valid Unix timestamp or timestamp string such as 2026-01-15T10:00:00Z."
+             } = json_response(conn, 400)
     end
   end
 


### PR DESCRIPTION
> Adds field-scoped date range filtering to the cache runs endpoint so reporting clients can request runs within a specific execution window without walking the full history.

## What changed
- Added a `ran_at` query filter object to the cache runs listing endpoint.
- Supports `ran_at[gt]`, `ran_at[gte]`, `ran_at[lt]`, and `ran_at[lte]` with Unix timestamps in seconds.
- Invalid negative or out-of-range timestamp filters now return a bad request response with a concrete message.
- Cache run responses now serialize `ran_at` from the stored `ran_at` value instead of deriving it from `created_at`.
- Regenerated the server contract and Swift command-line client files, including handling for the new bad request response.

## Why
Cache hit-rate reporting needs to ask for cache runs inside a time window. Without a date range filter, clients have to paginate through all cache run history and bound the result set themselves.

## Approach
The filter shape follows the field-scoped operator style used by Stripe list filters. Applying the operator to `ran_at` keeps the parameter explicit today and leaves room to add other date fields later without introducing new top-level names for every range.

## Impact
Clients can request cache runs by execution window while existing git reference, branch, commit, and pagination filters keep working. The generated Swift client now exposes a typed `ran_at` query payload and surfaces validation failures from the server.

## Screenshots
Not applicable. This changes a JSON endpoint and generated command-line client files, with no browser-rendered surface to capture before and after.

### How to test locally
- `mix test test/tuist_web/controllers/api/cache_runs_controller_test.exs`
- `mise run generate-api-cli-code`
- `tuist generate tuist ProjectDescription --no-open`
- `xcodebuild build -workspace Tuist.xcworkspace -scheme tuist CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""`
- `git diff --check`
