### PR TITLE
fix(server): handle legacy Xcode builds environment filter

### DIFF
--- a/server/lib/tuist_web/live/xcode_builds_live.ex
+++ b/server/lib/tuist_web/live/xcode_builds_live.ex
@@ -92,7 +92,7 @@ defmodule TuistWeb.XcodeBuildsLive do
 
   # credo:disable-for-next-line Credo.Check.Refactor.CyclomaticComplexity
   defp assign_analytics(%{assigns: %{selected_project: project}} = socket, params) do
-    analytics_environment = params["analytics-environment"] || "any"
+    analytics_environment = analytics_environment_param(params["analytics-environment"])
     analytics_build_scheme = params["analytics-build-scheme"] || "any"
     analytics_build_configuration = params["analytics-build-configuration"] || "any"
     analytics_build_category = params["analytics-build-category"] || "any"
@@ -255,6 +255,10 @@ defmodule TuistWeb.XcodeBuildsLive do
     end
   end
 
+  defp analytics_environment_param(environment) when environment in ["ci", "local"], do: environment
+
+  defp analytics_environment_param(_environment), do: "any"
+
   defp assign_configuration_insights_options(socket, params) do
     configuration_insights_type = params["configuration-insights-type"] || "xcode-version"
 
@@ -384,6 +388,7 @@ defmodule TuistWeb.XcodeBuildsLive do
   def environment_label("ci"), do: dgettext("dashboard_builds", "CI")
   def environment_label(true), do: dgettext("dashboard_builds", "CI")
   def environment_label(false), do: dgettext("dashboard_builds", "Local")
+  def environment_label(_), do: dgettext("dashboard_builds", "Any")
 
   def configuration_insights_label("xcode-version"), do: dgettext("dashboard_builds", "Xcode version")
   def configuration_insights_label("macos-version"), do: dgettext("dashboard_builds", "macOS version")

--- a/server/priv/gettext/dashboard_builds.pot
+++ b/server/priv/gettext/dashboard_builds.pot
@@ -38,9 +38,10 @@ msgstr ""
 msgid "Additional strings"
 msgstr ""
 
-#: lib/tuist_web/live/xcode_builds_live.ex:382
-#: lib/tuist_web/live/xcode_builds_live.ex:392
-#: lib/tuist_web/live/xcode_builds_live.ex:395
+#: lib/tuist_web/live/xcode_builds_live.ex:386
+#: lib/tuist_web/live/xcode_builds_live.ex:391
+#: lib/tuist_web/live/xcode_builds_live.ex:397
+#: lib/tuist_web/live/xcode_builds_live.ex:400
 #: lib/tuist_web/live/xcode_builds_live.html.heex:41
 #: lib/tuist_web/live/xcode_builds_live.html.heex:64
 #: lib/tuist_web/live/xcode_builds_live.html.heex:89
@@ -178,8 +179,8 @@ msgstr ""
 msgid "CAS outputs:"
 msgstr ""
 
-#: lib/tuist_web/live/xcode_builds_live.ex:384
-#: lib/tuist_web/live/xcode_builds_live.ex:385
+#: lib/tuist_web/live/xcode_builds_live.ex:388
+#: lib/tuist_web/live/xcode_builds_live.ex:389
 #: lib/tuist_web/live/xcode_builds_live.html.heex:135
 #, elixir-autogen, elixir-format
 msgid "CI"
@@ -274,7 +275,7 @@ msgstr ""
 #: lib/tuist_web/live/build_run_live.html.heex:286
 #: lib/tuist_web/live/xcode_build_runs_live.ex:260
 #: lib/tuist_web/live/xcode_build_runs_live.html.heex:151
-#: lib/tuist_web/live/xcode_builds_live.ex:435
+#: lib/tuist_web/live/xcode_builds_live.ex:440
 #: lib/tuist_web/live/xcode_builds_live.html.heex:357
 #: lib/tuist_web/live/xcode_builds_live.html.heex:887
 #, elixir-autogen, elixir-format
@@ -379,7 +380,7 @@ msgid "Destinations"
 msgstr ""
 
 #: lib/tuist_web/live/xcode_build_runs_live.html.heex:187
-#: lib/tuist_web/live/xcode_builds_live.ex:390
+#: lib/tuist_web/live/xcode_builds_live.ex:395
 #: lib/tuist_web/live/xcode_builds_live.html.heex:631
 #, elixir-autogen, elixir-format
 msgid "Device"
@@ -420,7 +421,7 @@ msgid "Entitlements"
 msgstr ""
 
 #: lib/tuist_web/components/runs/module_cache_tab.ex:287
-#: lib/tuist_web/live/xcode_builds_live.ex:434
+#: lib/tuist_web/live/xcode_builds_live.ex:439
 #: lib/tuist_web/live/xcode_builds_live.html.heex:356
 #, elixir-autogen, elixir-format
 msgid "Environment"
@@ -457,7 +458,7 @@ msgstr ""
 #: lib/tuist_web/live/run_detail_live.html.heex:144
 #: lib/tuist_web/live/xcode_build_runs_live.ex:242
 #: lib/tuist_web/live/xcode_build_runs_live.html.heex:107
-#: lib/tuist_web/live/xcode_builds_live.ex:446
+#: lib/tuist_web/live/xcode_builds_live.ex:451
 #: lib/tuist_web/live/xcode_builds_live.html.heex:864
 #, elixir-autogen, elixir-format
 msgid "Failed"
@@ -642,8 +643,8 @@ msgstr ""
 #: lib/tuist_web/live/run_detail_live.ex:338
 #: lib/tuist_web/live/run_detail_live.ex:371
 #: lib/tuist_web/live/test_run_live.ex:1101
-#: lib/tuist_web/live/xcode_builds_live.ex:383
-#: lib/tuist_web/live/xcode_builds_live.ex:386
+#: lib/tuist_web/live/xcode_builds_live.ex:387
+#: lib/tuist_web/live/xcode_builds_live.ex:390
 #: lib/tuist_web/live/xcode_builds_live.html.heex:127
 #, elixir-autogen, elixir-format
 msgid "Local"
@@ -768,7 +769,7 @@ msgstr ""
 #: lib/tuist_web/live/run_detail_live.html.heex:137
 #: lib/tuist_web/live/xcode_build_runs_live.ex:241
 #: lib/tuist_web/live/xcode_build_runs_live.html.heex:102
-#: lib/tuist_web/live/xcode_builds_live.ex:445
+#: lib/tuist_web/live/xcode_builds_live.ex:450
 #: lib/tuist_web/live/xcode_builds_live.html.heex:859
 #, elixir-autogen, elixir-format
 msgid "Passed"
@@ -858,7 +859,7 @@ msgstr ""
 
 #: lib/tuist_web/live/xcode_build_runs_live.ex:216
 #: lib/tuist_web/live/xcode_build_runs_live.html.heex:58
-#: lib/tuist_web/live/xcode_builds_live.ex:432
+#: lib/tuist_web/live/xcode_builds_live.ex:437
 #: lib/tuist_web/live/xcode_builds_live.html.heex:355
 #: lib/tuist_web/live/xcode_builds_live.html.heex:848
 #, elixir-autogen, elixir-format
@@ -924,7 +925,7 @@ msgstr ""
 #: lib/tuist_web/live/generate_runs_live.ex:280
 #: lib/tuist_web/live/run_detail_live.html.heex:134
 #: lib/tuist_web/live/xcode_build_runs_live.ex:237
-#: lib/tuist_web/live/xcode_builds_live.ex:433
+#: lib/tuist_web/live/xcode_builds_live.ex:438
 #, elixir-autogen, elixir-format
 msgid "Status"
 msgstr ""
@@ -1101,9 +1102,9 @@ msgstr ""
 #: lib/tuist_web/live/xcode_build_runs_live.html.heex:182
 #: lib/tuist_web/live/xcode_build_runs_live.html.heex:190
 #: lib/tuist_web/live/xcode_build_runs_live.html.heex:193
-#: lib/tuist_web/live/xcode_builds_live.ex:405
-#: lib/tuist_web/live/xcode_builds_live.ex:439
-#: lib/tuist_web/live/xcode_builds_live.ex:442
+#: lib/tuist_web/live/xcode_builds_live.ex:410
+#: lib/tuist_web/live/xcode_builds_live.ex:444
+#: lib/tuist_web/live/xcode_builds_live.ex:447
 #: lib/tuist_web/live/xcode_builds_live.html.heex:851
 #: lib/tuist_web/live/xcode_builds_live.html.heex:871
 #: lib/tuist_web/live/xcode_builds_live.html.heex:891
@@ -1237,7 +1238,7 @@ msgstr ""
 #: lib/tuist_web/live/build_run_live.html.heex:308
 #: lib/tuist_web/live/xcode_build_runs_live.ex:273
 #: lib/tuist_web/live/xcode_build_runs_live.html.heex:171
-#: lib/tuist_web/live/xcode_builds_live.ex:388
+#: lib/tuist_web/live/xcode_builds_live.ex:393
 #: lib/tuist_web/live/xcode_builds_live.html.heex:621
 #: lib/tuist_web/live/xcode_builds_live.html.heex:868
 #, elixir-autogen, elixir-format
@@ -1248,7 +1249,7 @@ msgstr ""
 #: lib/tuist_web/live/run_detail_live.html.heex:202
 #: lib/tuist_web/live/xcode_build_runs_live.ex:281
 #: lib/tuist_web/live/xcode_build_runs_live.html.heex:179
-#: lib/tuist_web/live/xcode_builds_live.ex:389
+#: lib/tuist_web/live/xcode_builds_live.ex:394
 #: lib/tuist_web/live/xcode_builds_live.html.heex:639
 #, elixir-autogen, elixir-format
 msgid "macOS version"
@@ -1314,17 +1315,17 @@ msgstr ""
 msgid "p99 latency writing cache keys"
 msgstr ""
 
-#: lib/tuist_web/live/xcode_builds_live.ex:380
+#: lib/tuist_web/live/xcode_builds_live.ex:384
 #, elixir-autogen, elixir-format
 msgid "since last month"
 msgstr ""
 
-#: lib/tuist_web/live/xcode_builds_live.ex:377
+#: lib/tuist_web/live/xcode_builds_live.ex:381
 #, elixir-autogen, elixir-format
 msgid "since last week"
 msgstr ""
 
-#: lib/tuist_web/live/xcode_builds_live.ex:378
+#: lib/tuist_web/live/xcode_builds_live.ex:382
 #, elixir-autogen, elixir-format
 msgid "since last year"
 msgstr ""
@@ -1372,12 +1373,12 @@ msgstr ""
 msgid "Last 7 days"
 msgstr ""
 
-#: lib/tuist_web/live/xcode_builds_live.ex:379
+#: lib/tuist_web/live/xcode_builds_live.ex:383
 #, elixir-autogen, elixir-format
 msgid "since last period"
 msgstr ""
 
-#: lib/tuist_web/live/xcode_builds_live.ex:376
+#: lib/tuist_web/live/xcode_builds_live.ex:380
 #, elixir-autogen, elixir-format
 msgid "since yesterday"
 msgstr ""
@@ -1388,7 +1389,7 @@ msgstr ""
 msgid "Cache Endpoint"
 msgstr ""
 
-#: lib/tuist_web/live/xcode_builds_live.ex:398
+#: lib/tuist_web/live/xcode_builds_live.ex:403
 #: lib/tuist_web/live/xcode_builds_live.html.heex:11
 #, elixir-autogen, elixir-format
 msgid "All"

--- a/server/test/tuist_web/live/builds_live_test.exs
+++ b/server/test/tuist_web/live/builds_live_test.exs
@@ -118,4 +118,16 @@ defmodule TuistWeb.BuildsLiveTest do
 
     assert has_element?(lv, "#builds-analytics-scheme-dropdown [data-part='search-input']")
   end
+
+  test "renders with legacy analytics environment all query parameter", %{
+    conn: conn,
+    project: project
+  } do
+    {:ok, lv, _html} =
+      live(conn, ~p"/#{project.account.name}/#{project.name}/builds?analytics-environment=all")
+
+    render_async(lv, @render_async_timeout)
+
+    assert has_element?(lv, "#builds-analytics-environment-dropdown")
+  end
 end


### PR DESCRIPTION
## What changed

- Normalizes the Xcode builds analytics environment query parameter so only `ci` and `local` are preserved; missing, legacy, or malformed values fall back to `any`.
- Adds a defensive fallback to `TuistWeb.XcodeBuildsLive.environment_label/1` so unexpected values render as `Any` instead of raising.
- Adds a LiveView regression test for `?analytics-environment=all`.
- Regenerates `server/priv/gettext/dashboard_builds.pot` with `mix gettext.extract` so the dashboard builds gettext template stays in sync.

## Why

Sentry reported `TUIST-12H`, a production `FunctionClauseError` in `TuistWeb.XcodeBuildsLive.environment_label/1` while rendering the Xcode builds page. The label helper only handled `"any"`, `"local"`, `"ci"`, and boolean values, while the filtering path already treated `"all"` as an unfiltered value.

## Root cause

The page could receive a legacy or malformed analytics environment value that was safe for filtering but unsafe for rendering. When that value reached the environment dropdown label, the function had no matching clause and the LiveView render crashed.

## Impact

Users with legacy or unexpected environment query values can load the Xcode builds dashboard normally. Unknown values behave like the default `Any` filter rather than taking down the page.

## Validation

- `git diff --check origin/main..HEAD`
- `MIX_ENV=test mix gettext.extract` from `server/` to regenerate `dashboard_builds.pot`
- In the original workspace, in-memory compilation of `TuistWeb.XcodeBuildsLive` against the existing test build passed.
- In the original workspace, smoke-checked `TuistWeb.XcodeBuildsLive.environment_label("all") == "Any"` with minimal Gettext config.
- GitHub Actions on PR #11578 passed for all non-skipped checks at `5429b70f7`: Server (`Format`, `Gettext`, `Test`, `Docker build`, `Seed`, `Credo`, `Security`, `esbuild`, `Swift Tests (XCActivityLogParser)`), CodeQL, Gradle Cache Acceptance, Secret Scanning, CLA, and Review.

Fixes TUIST-12H
