### PR TITLE
fix(cli): locate DerivedData for spaced project names

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,11 +84,11 @@ Avoid minimal PR descriptions that only restate the code diff. The goal is that 
 - Do not add one-line comments unless you think they are really useful.
 
 ## Workflow
-- For faster builds, generate only the required targets: `tuist generate tuist ProjectDescription --no-open`
-- When compiling Swift changes, use `xcodebuild build -workspace Tuist.xcworkspace -scheme tuist CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""` instead of `swift build`
-- When testing Swift changes, use `xcodebuild test -workspace Tuist.xcworkspace -scheme Tuist-Workspace -only-testing MyTests/SuiteTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""` instead of `swift test`.
+- For faster builds, generate only the required targets before compiling or testing, for example `tuist generate tuist ProjectDescription --no-open`. If the target or test suite you need is not present in the current generated workspace, regenerate with that specific production target and test target instead of falling back to SwiftPM.
+- When compiling Swift changes, use `xcodebuild build -workspace Tuist.xcworkspace -scheme tuist CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""` instead of `swift build`.
+- When testing Swift changes, use `xcodebuild test -workspace Tuist.xcworkspace -scheme Tuist-Workspace -only-testing MyTests/SuiteTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""` or `xcsiftbuild test` instead of `swift test`.
 - Prefer running test suites or individual test cases, and not the whole test target, for performance
-- When using `swift build`, `swift test`, or `swift package resolve` always include `--replace-scm-with-registry` to avoid switching packages from registry to source control resolution
+- Do not use `swift build` or `swift test` as a fallback for CLI work. Only use SwiftPM commands when the user explicitly asks for them or when changing package-resolution behavior; in those exceptional cases, always include `--replace-scm-with-registry` to avoid switching packages from registry to source control resolution.
 
 ## Testing
 - Use Swift Testing framework with custom traits for tests that need temporary directories

--- a/cli/AGENTS.md
+++ b/cli/AGENTS.md
@@ -18,8 +18,8 @@ This node covers the Tuist CLI workspace under `cli/`. Follow downlinks for subs
 - `cli/Sources/TuistGenerator` - Monolithic generation pipeline; new generation logic should be added to smaller, focused modules.
 
 ## Building
-- To generate the Xcode project for a faster build, run `tuist generate tuist ProjectDescription --no-open` (generates only the required targets instead of the full workspace).
-- To compile, use `xcodebuild build -workspace Tuist.xcworkspace -scheme tuist CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""`.
+- To generate the Xcode project for a faster build, run `tuist generate tuist ProjectDescription --no-open` (generates only the required targets instead of the full workspace). If the target you need is not in the current generated workspace, regenerate with that specific target instead of falling back to SwiftPM.
+- To compile, use `xcodebuild build -workspace Tuist.xcworkspace -scheme tuist CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""`. Do not use `swift build` for CLI validation unless the user explicitly asks for SwiftPM.
 - Prefer the `tuist` scheme over `Tuist-Workspace` for faster iteration.
 
 ## Code Style
@@ -41,7 +41,8 @@ This node covers the Tuist CLI workspace under `cli/`. Follow downlinks for subs
   ```
 
 ### Running tests
-- Prefer `tuist generate` + `xcodebuild`/`xcsiftbuild test` over `swift test`. `swift test` is significantly slower because it rebuilds the full SPM dependency graph, and some test targets (e.g. `TuistGeneratorTests`, `TuistLoaderTests`) aren't even registered in `Package.swift` — they only exist in the Tuist-generated workspace.
+- Use `tuist generate` + `xcodebuild`/`xcsiftbuild test` instead of `swift test`. `swift test` is significantly slower because it rebuilds the full SPM dependency graph, bypasses Tuist caching, and some test targets (e.g. `TuistGeneratorTests`, `TuistLoaderTests`) aren't even registered in `Package.swift` — they only exist in the Tuist-generated workspace.
+- If the generated scheme does not include the test target, run `tuist generate tuist <ProductionTarget> <TestTarget> ProjectDescription --no-open` with the narrowest target list that covers the change, then rerun the focused `xcodebuild`/`xcsiftbuild test`.
 - Fast iteration loop for a specific test suite:
   ```bash
   tuist generate tuist TuistGenerator TuistGeneratorTests ProjectDescription --no-open

--- a/cli/Sources/TuistXcodeBuildProducts/DerivedDataLocator.swift
+++ b/cli/Sources/TuistXcodeBuildProducts/DerivedDataLocator.swift
@@ -47,12 +47,17 @@ public struct DerivedDataLocator: DerivedDataLocating {
             return buildRoot
         }
 
+        let name = xcodeDerivedDataPrefix(for: projectPath)
         if usesHash {
             let hash = try XcodeProjectPathHasher.hashString(for: projectPath.pathString)
-            return root.appending(component: "\(projectPath.basenameWithoutExt)-\(hash)")
+            return root.appending(component: "\(name)-\(hash)")
         } else {
-            return root.appending(component: projectPath.basenameWithoutExt)
+            return root.appending(component: name)
         }
+    }
+
+    private func xcodeDerivedDataPrefix(for projectPath: AbsolutePath) -> String {
+        projectPath.basenameWithoutExt.replacingOccurrences(of: " ", with: "_")
     }
 
     /// Extracts the derived data root from `BUILD_DIR`.

--- a/cli/Tests/TuistXcodeBuildProductsTests/Utils/DerivedDataLocatorTests.swift
+++ b/cli/Tests/TuistXcodeBuildProductsTests/Utils/DerivedDataLocatorTests.swift
@@ -88,6 +88,17 @@ struct DerivedDataLocatorTests {
         #expect(result.basename.hasPrefix("App-"))
     }
 
+    @Test(.withMockedEnvironment())
+    func locate_replaces_spaces_in_hash_based_path_prefix() async throws {
+        let projectPath = try AbsolutePath(
+            validating: "/Users/developer/Projects/Example App/Example App.xcodeproj"
+        )
+
+        let result = try await subject.locate(for: projectPath)
+
+        #expect(result.basename == "Example_App-haqlyztoonwvfngqefjfdacmpopg")
+    }
+
     @Test(.inTemporaryDirectory, .withMockedEnvironment())
     func locate_uses_workspace_name_without_hash_for_relative_location() async throws {
         let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)


### PR DESCRIPTION
## What changed

- Updated `DerivedDataLocator` to mirror Xcode's DerivedData directory prefix behavior by replacing spaces in the project/workspace name with underscores before appending the existing MD5 path hash.
- Added a regression test using a project path with a space in the filename to assert that Tuist looks under the underscore-normalized DerivedData prefix.
- Updated the agent guidance in the root and CLI `AGENTS.md` files so CLI validation regenerates a narrow Tuist workspace and uses `xcodebuild`/`xcsiftbuild` instead of falling back to SwiftPM, preserving Tuist caching.

## Why

A customer's Xcode scheme post-action could run `tuist inspect build`, but Tuist failed to find the generated `.xcactivitylog`. The project filename contained a space, so Tuist looked under a DerivedData directory prefixed with the literal name while Xcode wrote the logs under the same prefix with spaces replaced by underscores.

## Root cause

`DerivedDataLocator` used the raw `basenameWithoutExt` as the DerivedData directory prefix. Xcode sanitizes spaces in that prefix to underscores, while keeping the hash based on the full original path. Because the prefix differed, `tuist inspect build` searched the wrong DerivedData directory for projects with spaces in their names.

## Impact

Build insights collection can now locate Xcode activity logs for project/workspace names containing spaces. The guideline update also prevents future CLI work from bypassing Tuist-generated workspaces and cache usage during validation.

## Validation

- `tuist install`
- `tuist generate tuist TuistXcodeBuildProducts TuistXcodeBuildProductsTests ProjectDescription --no-open`
- `xcodebuild test -workspace Tuist.xcworkspace -scheme Tuist-Workspace -only-testing TuistXcodeBuildProductsTests/DerivedDataLocatorTests -destination platform=macOS -derivedDataPath /private/tmp/tuist-insights-derived-data CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY= COMPILATION_CACHE_ENABLE_CACHING=NO`
  - Result: `** TEST SUCCEEDED **` with 9 `DerivedDataLocatorTests` passing, including `locate_replaces_spaces_in_hash_based_path_prefix()`.
- `git diff --check -- AGENTS.md cli/AGENTS.md cli/Sources/TuistXcodeBuildProducts/DerivedDataLocator.swift cli/Tests/TuistXcodeBuildProductsTests/Utils/DerivedDataLocatorTests.swift`
