### PR TITLE
fix(server, noora): apply runner metrics step-hover via Noora's chart instance

### DIFF
--- a/noora/js/Chart.js
+++ b/noora/js/Chart.js
@@ -126,12 +126,14 @@ export default {
     const theme = getTheme(option);
 
     echarts.registerTheme("noora", theme);
-    this.chart = echarts.init(
-      this.el.querySelector("[data-part='chart']"),
-      "noora",
-      { renderer: "canvas" },
-    );
+    const chartDom = this.el.querySelector("[data-part='chart']");
+    this.chart = echarts.init(chartDom, "noora", { renderer: "canvas" });
     this.chart.setOption(option);
+    // Expose the instance on the chart element so code outside this hook
+    // (and outside Noora's bundled ECharts) can drive the chart — e.g. an
+    // external hover adding a markArea — without echarts.getInstanceByDom,
+    // which only resolves instances created by the same ECharts copy.
+    chartDom.__nooraChart = this.chart;
 
     const hasClickableData =
       option.series &&
@@ -148,7 +150,6 @@ export default {
         }
       });
 
-      const chartDom = this.el.querySelector("[data-part='chart']");
       this.chart.on("mouseover", (params) => {
         if (params.data && params.data.url) {
           chartDom.style.cursor = "pointer";
@@ -171,6 +172,8 @@ export default {
     this.render({ animate: false });
   },
   destroyed() {
+    const chartDom = this.el.querySelector("[data-part='chart']");
+    if (chartDom) chartDom.__nooraChart = null;
     this.chart.dispose();
     window.removeEventListener(
       "changed-preferred-theme",

--- a/server/assets/app/js/RunnerMetricsHighlight.js
+++ b/server/assets/app/js/RunnerMetricsHighlight.js
@@ -1,15 +1,16 @@
-import * as echarts from "echarts";
-
 // Shades the hovered step's time window across every metric chart in
 // the runner-job Overview, correlating a CI step with the part of the
 // resource graphs it produced.
 //
 // The charts are owned by the NooraChart hook (one ECharts instance
-// each); we reach them via `echarts.getInstanceByDom` and add a
-// `markArea` band addressed by the step's `[start, end]` epoch-ms
-// window — which lands precisely because the charts use a time
-// x-axis. If the instance can't be resolved (e.g. a charts-less
-// render) the highlight is simply skipped.
+// each), which exposes its instance on the chart element as
+// `__nooraChart`. We use that object directly rather than
+// `echarts.getInstanceByDom`, because Noora bundles its own ECharts
+// copy — a lookup from a different copy's module-local registry would
+// never resolve the instance. We add a `markArea` band addressed by the
+// step's `[start, end]` epoch-ms window, which lands precisely because
+// the charts use a time x-axis. If a chart isn't ready the highlight is
+// simply skipped.
 // The band colour comes from Noora's overlay token so it tracks the
 // theme (incl. light/dark) instead of being hardcoded. Reading the
 // custom property directly yields the unresolved `light-dark(var(…))`
@@ -57,7 +58,7 @@ export default {
 
   charts() {
     return Array.from(this.el.querySelectorAll("[data-metrics-charts] [data-part='chart']"))
-      .map((dom) => echarts.getInstanceByDom(dom))
+      .map((dom) => dom.__nooraChart)
       .filter(Boolean);
   },
 


### PR DESCRIPTION
## What

Fixes the runner-job **step-hover correlation** — hovering a CI step on the Overview is supposed to shade that step's time window across the CPU/Memory/Network charts, but the band never appeared in production.

## Why it was broken

The `RunnerMetricsHighlight` hook resolved each chart's ECharts instance with `echarts.getInstanceByDom`, imported from the **server's** ECharts. But the charts are created by Noora's **own ECharts copy**, which is inlined into `noora.js` (a ~1.4 MB prebuilt bundle the server aliases). `getInstanceByDom` only resolves instances registered in the *calling module's* ECharts registry, so a lookup from a different copy returns nothing — the `markArea` band was never applied.

It appeared to work in some local builds only because the bundle there happened to share a single ECharts; the production asset pipeline does not.

## How

- **Noora** (`Chart.js`): expose the live instance on the chart element as `__nooraChart` (set in `render`, cleared in `destroyed`).
- **Server** (`RunnerMetricsHighlight.js`): read that object directly and call `setOption` on it, and drop the server-side `echarts` import entirely. The hover/epoch-parsing logic is unchanged — only the instance resolution.

This makes the correlation independent of how many ECharts copies a consumer bundles, and removes a redundant ECharts dependency from the app bundle.

## Validation

- Rebuilt `noora.js` (`__nooraChart` present) and confirmed the server app bundle (`priv/static/app/assets/bundle.js`, rebuilt by the esbuild watcher) now reads `__nooraChart` and no longer calls `getInstanceByDom` from the hook.
- A full live repro on the runner Overview was blocked locally by a disk-full dev environment (the Elixir compile/migrate/seed couldn't complete), so the build-level verification above stands in for the runtime check. The change is JS-only and directly addresses the confirmed two-ECharts-copies root cause; it's straightforward to confirm on staging/prod once deployed (hover a step → the band shades the matching window).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
