### PR TITLE
Fix buildable folder support file references from settings

### DIFF
--- a/cli/Sources/TuistGenerator/Generator/ProjectFileElements.swift
+++ b/cli/Sources/TuistGenerator/Generator/ProjectFileElements.swift
@@ -67,6 +67,10 @@ class ProjectFileElements {
         "xib",
         "intentdefinition",
     ]
+    private static let buildSettingSupportFileKeys = Set([
+        "CODE_SIGN_ENTITLEMENTS",
+        "INFOPLIST_FILE",
+    ])
 
     // MARK: - Attributes
 
@@ -225,6 +229,11 @@ class ProjectFileElements {
         }
 
         if let entitlements = target.entitlements, let path = entitlements.path, !isInsideBuildableFolder(path, of: target) {
+            files.insert(path)
+        }
+
+        for path in supportFilesFromBuildSettings(target: target, sourceRootPath: project.sourceRootPath) {
+            guard !isInsideBuildableFolder(path, of: target) else { continue }
             files.insert(path)
         }
 
@@ -875,6 +884,61 @@ class ProjectFileElements {
 
     private func isInsideBuildableFolder(_ path: AbsolutePath, of target: Target) -> Bool {
         target.buildableFolders.contains { path.isDescendant(of: $0.path) }
+    }
+
+    private func supportFilesFromBuildSettings(target: Target, sourceRootPath: AbsolutePath) -> Set<AbsolutePath> {
+        guard let settings = target.settings else { return [] }
+
+        let dictionaries = [settings.base, settings.baseDebug] +
+            settings.configurations.values.compactMap { $0?.settings }
+
+        return dictionaries.reduce(into: Set<AbsolutePath>()) { paths, dictionary in
+            for (key, value) in dictionary
+                where ProjectFileElements.buildSettingSupportFileKeys.contains(baseBuildSettingKey(key))
+            {
+                paths.formUnion(resolveSupportFilePaths(value: value, sourceRootPath: sourceRootPath))
+            }
+        }
+    }
+
+    private func baseBuildSettingKey(_ key: String) -> String {
+        key.split(separator: "[", maxSplits: 1).first.map(String.init) ?? key
+    }
+
+    private func resolveSupportFilePaths(value: SettingValue, sourceRootPath: AbsolutePath) -> Set<AbsolutePath> {
+        let values: [String]
+        switch value {
+        case let .string(value):
+            values = [value]
+        case let .array(array):
+            values = array
+        }
+
+        return Set(values.compactMap { resolveSupportFilePath($0, sourceRootPath: sourceRootPath) })
+    }
+
+    private func resolveSupportFilePath(_ value: String, sourceRootPath: AbsolutePath) -> AbsolutePath? {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+            .trimmingCharacters(in: CharacterSet(charactersIn: "\"'"))
+
+        let sourceRootPrefixes = [
+            "$(SRCROOT)/",
+            "$(PROJECT_DIR)/",
+            "$(SOURCE_ROOT)/",
+        ]
+        let pathString = sourceRootPrefixes.reduce(trimmed) { current, prefix in
+            current.hasPrefix(prefix) ? String(current.dropFirst(prefix.count)) : current
+        }
+
+        if pathString.hasPrefix("/") {
+            return try? AbsolutePath(validating: pathString)
+        }
+
+        guard !pathString.contains("$("),
+              let relativePath = try? RelativePath(validating: pathString)
+        else { return nil }
+
+        return sourceRootPath.appending(relativePath)
     }
 
     func isLocalized(path: AbsolutePath) -> Bool {

--- a/cli/Tests/TuistGeneratorAcceptanceTests/GenerateAcceptanceTests.swift
+++ b/cli/Tests/TuistGeneratorAcceptanceTests/GenerateAcceptanceTests.swift
@@ -1753,6 +1753,12 @@ struct GenerateAcceptanceTestAppWithBuildableFolderMembership {
         let debugConfiguration = try #require(appTarget.buildConfigurationList?.configuration(name: "Debug"))
         #expect(debugConfiguration.baseConfiguration == nil)
         #expect(debugConfiguration.baseConfigurationReferenceRelativePath == "Supporting/Configurations/App-Debug.xcconfig")
+        #expect(debugConfiguration.buildSettings["CODE_SIGN_ENTITLEMENTS"] == "App/Supporting Files/App-Debug.entitlements")
+        #expect(debugConfiguration.buildSettings["INFOPLIST_FILE"] == "App/Supporting Files/App-Debug.plist")
+
+        let releaseConfiguration = try #require(appTarget.buildConfigurationList?.configuration(name: "Release"))
+        #expect(releaseConfiguration.buildSettings["CODE_SIGN_ENTITLEMENTS"] == "App/Supporting Files/App-Release.entitlements")
+        #expect(releaseConfiguration.buildSettings["INFOPLIST_FILE"] == "App/Supporting Files/App-Release.plist")
 
         // SharedStub.swift is added to AppTests via a foreign-target exception set, not a flat reference.
         let synchronizedGroup = try #require(
@@ -1771,6 +1777,10 @@ struct GenerateAcceptanceTestAppWithBuildableFolderMembership {
         let fileReferenceNames = pbxproj.fileReferences.compactMap(\.path) + pbxproj.fileReferences.compactMap(\.name)
         #expect(!fileReferenceNames.contains { $0.hasSuffix("App-Debug.xcconfig") })
         #expect(!fileReferenceNames.contains { $0.hasSuffix("App-Info.plist") })
+        #expect(!fileReferenceNames.contains { $0.hasSuffix("App-Debug.entitlements") })
+        #expect(!fileReferenceNames.contains { $0.hasSuffix("App-Debug.plist") })
+        #expect(!fileReferenceNames.contains { $0.hasSuffix("App-Release.entitlements") })
+        #expect(!fileReferenceNames.contains { $0.hasSuffix("App-Release.plist") })
         #expect(!fileReferenceNames.contains { $0.hasSuffix("SharedStub.swift") })
     }
 }

--- a/cli/Tests/TuistGeneratorTests/Generator/ProjectFileElementsTests.swift
+++ b/cli/Tests/TuistGeneratorTests/Generator/ProjectFileElementsTests.swift
@@ -477,6 +477,80 @@ final class ProjectFileElementsTests: TuistUnitTestCase {
         ]))
     }
 
+    func test_targetFiles_whenBuildSettingSupportFilesAreOutsideBuildableFolder() throws {
+        // Given
+        let debugInfoPlist = try AbsolutePath(validating: "/project/Supporting Files/App-Debug.plist")
+        let releaseInfoPlist = try AbsolutePath(validating: "/project/Supporting Files/App-Release.plist")
+        let entitlements = try AbsolutePath(validating: "/project/Supporting Files/App.entitlements")
+        let target = Target.test(
+            settings: Settings(
+                base: [
+                    "CODE_SIGN_ENTITLEMENTS[sdk=iphoneos*]": "$(SRCROOT)/Supporting Files/App.entitlements",
+                ],
+                configurations: [
+                    .debug: Configuration(settings: ["INFOPLIST_FILE": "Supporting Files/App-Debug.plist"]),
+                    .release: Configuration(settings: ["INFOPLIST_FILE": "$(PROJECT_DIR)/Supporting Files/App-Release.plist"]),
+                ]
+            )
+        )
+        let project = Project.test(
+            path: "/project",
+            sourceRootPath: "/project",
+            xcodeProjPath: "/project/Project.xcodeproj",
+            targets: [target]
+        )
+
+        // When
+        let files = try subject.targetFiles(target: target, project: project)
+
+        // Then
+        XCTAssertTrue(files.isSuperset(of: [
+            GroupFileElement.file(path: debugInfoPlist, group: target.filesGroup),
+            GroupFileElement.file(path: releaseInfoPlist, group: target.filesGroup),
+            GroupFileElement.file(path: entitlements, group: target.filesGroup),
+        ]))
+    }
+
+    func test_targetFiles_whenBuildSettingSupportFilesAreInsideBuildableFolder() throws {
+        // Given
+        let debugInfoPlist = try AbsolutePath(validating: "/project/App/Supporting Files/App-Debug.plist")
+        let releaseInfoPlist = try AbsolutePath(validating: "/project/App/Supporting Files/App-Release.plist")
+        let entitlements = try AbsolutePath(validating: "/project/App/Supporting Files/App.entitlements")
+        let target = Target.test(
+            settings: Settings(
+                base: [
+                    "CODE_SIGN_ENTITLEMENTS": "App/Supporting Files/App.entitlements",
+                ],
+                configurations: [
+                    .debug: Configuration(settings: ["INFOPLIST_FILE": "App/Supporting Files/App-Debug.plist"]),
+                    .release: Configuration(settings: ["INFOPLIST_FILE": "App/Supporting Files/App-Release.plist"]),
+                ]
+            ),
+            buildableFolders: [
+                BuildableFolder(
+                    path: "/project/App",
+                    exceptions: BuildableFolderExceptions(exceptions: []),
+                    resolvedFiles: []
+                ),
+            ]
+        )
+        let project = Project.test(
+            path: "/project",
+            sourceRootPath: "/project",
+            xcodeProjPath: "/project/Project.xcodeproj",
+            targets: [target]
+        )
+
+        // When
+        let files = try subject.targetFiles(target: target, project: project)
+
+        // Then
+        XCTAssertFalse(files.contains(GroupFileElement.file(path: debugInfoPlist, group: target.filesGroup)))
+        XCTAssertFalse(files.contains(GroupFileElement.file(path: releaseInfoPlist, group: target.filesGroup)))
+        XCTAssertFalse(files.contains(GroupFileElement.file(path: entitlements, group: target.filesGroup)))
+        XCTAssertTrue(files.contains(GroupFileElement.synchronizedFolder(path: "/project/App", group: target.filesGroup)))
+    }
+
     func test_generateProduct() throws {
         // Given
         let pbxproj = PBXProj()

--- a/examples/xcode/generated_app_with_buildable_folder_membership/App/Supporting Files/App-Debug.entitlements
+++ b/examples/xcode/generated_app_with_buildable_folder_membership/App/Supporting Files/App-Debug.entitlements
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict/>
+</plist>

--- a/examples/xcode/generated_app_with_buildable_folder_membership/App/Supporting Files/App-Debug.plist
+++ b/examples/xcode/generated_app_with_buildable_folder_membership/App/Supporting Files/App-Debug.plist
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict/>
+</plist>

--- a/examples/xcode/generated_app_with_buildable_folder_membership/App/Supporting Files/App-Release.entitlements
+++ b/examples/xcode/generated_app_with_buildable_folder_membership/App/Supporting Files/App-Release.entitlements
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict/>
+</plist>

--- a/examples/xcode/generated_app_with_buildable_folder_membership/App/Supporting Files/App-Release.plist
+++ b/examples/xcode/generated_app_with_buildable_folder_membership/App/Supporting Files/App-Release.plist
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict/>
+</plist>

--- a/examples/xcode/generated_app_with_buildable_folder_membership/Project.swift
+++ b/examples/xcode/generated_app_with_buildable_folder_membership/Project.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 let project = Project(
     name: "App",
     targets: [
-        // The App target's buildable folder holds its xcconfigs and Info.plist (which must not be duplicated as flat
+        // The App target's buildable folder holds its support files (which must not be duplicated as flat
         // root-level references) and SharedStub.swift, which is also a member of the AppTests target.
         .target(
             name: "App",
@@ -14,13 +14,33 @@ let project = Project(
             buildableFolders: [
                 .folder("App", exceptions: [
                     .exception(excluded: ["Supporting/App-Info.plist"]),
+                    .exception(excluded: [
+                        "Supporting Files/App-Debug.entitlements",
+                        "Supporting Files/App-Debug.plist",
+                        "Supporting Files/App-Release.entitlements",
+                        "Supporting Files/App-Release.plist",
+                    ]),
                     .exception(target: "AppTests", included: ["SharedStub.swift"]),
                 ]),
             ],
             settings: .settings(
                 configurations: [
-                    .debug(name: "Debug", xcconfig: "App/Supporting/Configurations/App-Debug.xcconfig"),
-                    .release(name: "Release", xcconfig: "App/Supporting/Configurations/App-Release.xcconfig"),
+                    .debug(
+                        name: "Debug",
+                        settings: [
+                            "CODE_SIGN_ENTITLEMENTS": "App/Supporting Files/App-Debug.entitlements",
+                            "INFOPLIST_FILE": "App/Supporting Files/App-Debug.plist",
+                        ],
+                        xcconfig: "App/Supporting/Configurations/App-Debug.xcconfig"
+                    ),
+                    .release(
+                        name: "Release",
+                        settings: [
+                            "CODE_SIGN_ENTITLEMENTS": "App/Supporting Files/App-Release.entitlements",
+                            "INFOPLIST_FILE": "App/Supporting Files/App-Release.plist",
+                        ],
+                        xcconfig: "App/Supporting/Configurations/App-Release.xcconfig"
+                    ),
                 ]
             )
         ),


### PR DESCRIPTION
Resolves <https://github.com/tuist/tuist/issues/11571>

## What changed

This updates project file generation so support files referenced through build settings are handled consistently with support files declared on the target.

The generator now looks at the `CODE_SIGN_ENTITLEMENTS` and `INFOPLIST_FILE` build settings, including per-configuration and conditional keys, resolves paths relative to the project source root, and only adds normal Xcode file references when those files are outside a buildable folder.

The buildable-folder fixture now includes per-configuration entitlements and information property list files, with regression coverage that verifies those files do not appear as duplicate root-level references.

## Why

Buildable folders already make their nested files visible through Xcode synchronized groups. When Tuist adds a second root-level reference for the same file, generated projects become noisy and diverge from the expected Xcode navigator structure.

## Root cause

The previous fix covered target-level information property list, entitlements, and configuration files. It did not cover the same files when users supplied them directly through build settings, so those build-setting paths bypassed the buildable-folder guard.

## Approach

The generator extracts the relevant support file paths from target settings, handles common source-root prefixes, ignores unresolved paths that still contain build-setting variables, and reuses the existing buildable-folder check before creating file references.

## Impact

Projects that keep per-configuration information property list or entitlements files inside buildable folders no longer get duplicate root-level file references. Projects that reference those files outside buildable folders still get normal file references so the files remain visible in Xcode.

### How to test locally

```sh
tuist generate tuist TuistGenerator TuistGeneratorTests TuistGeneratorAcceptanceTests ProjectDescription --no-open
xcodebuild test -workspace Tuist.xcworkspace -scheme Tuist-Workspace -only-testing TuistGeneratorTests/ProjectFileElementsTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""
xcodebuild test -quiet -workspace Tuist.xcworkspace -scheme Tuist-Workspace -only-testing TuistGeneratorAcceptanceTests/GenerateAcceptanceTestAppWithBuildableFolderMembership CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""
mise run cli:lint --fix
git diff --check
```
