### PR TITLE
fix(cli): avoid static framework module map copies

### DIFF
--- a/cli/Sources/TuistGenerator/Mappers/ModuleMapMapper.swift
+++ b/cli/Sources/TuistGenerator/Mappers/ModuleMapMapper.swift
@@ -85,7 +85,7 @@ public struct ModuleMapMapper: GraphMapping { // swiftlint:disable:this type_bod
                         from: mappedSettingsDictionary[Self.modulemapFileSetting],
                         projectPath: project.path
                     ),
-                        target.product.isFramework
+                        target.product == .framework
                     {
                         // swift-build gives ExtractAPI dependency module maps explicitly and models framework module maps
                         // at `Modules/module.modulemap`. Generated Xcode projects need the same canonical framework path.

--- a/cli/Tests/TuistGeneratorAcceptanceTests/GenerateAcceptanceTests.swift
+++ b/cli/Tests/TuistGeneratorAcceptanceTests/GenerateAcceptanceTests.swift
@@ -521,6 +521,50 @@ struct GenerateAcceptanceTestiOSAppWithLocalSwiftPackage {
     }
 }
 
+struct GenerateAcceptanceTestiOSAppWithObjCStaticFrameworkPackage {
+    @Test(.withFixture("generated_ios_app_with_objc_static_framework_package"), .inTemporaryDirectory)
+    func ios_app_with_objc_static_framework_package() async throws {
+        let fixturePath = try fixtureDirectory()
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let derivedDataPath = temporaryDirectory.appending(component: "DerivedData")
+
+        try await run(InstallCommand.self)
+        try await run(GenerateCommand.self)
+
+        try await CommandRunner().runAndWait(arguments: [
+            "/usr/bin/xcodebuild",
+            "archive",
+            "-workspace",
+            fixturePath.appending(component: "App.xcworkspace").pathString,
+            "-scheme",
+            "App",
+            "-destination",
+            "generic/platform=iOS",
+            "-derivedDataPath",
+            derivedDataPath.pathString,
+            "-archivePath",
+            temporaryDirectory.appending(component: "App.xcarchive").pathString,
+            "CODE_SIGNING_ALLOWED=NO",
+            "CODE_SIGNING_REQUIRED=NO",
+            "CODE_SIGN_IDENTITY=",
+        ])
+
+        let copiedModuleMapPath = derivedDataPath.appending(
+            components: "Build",
+            "Intermediates.noindex",
+            "ArchiveIntermediates",
+            "App",
+            "BuildProductsPath",
+            "Release-iphoneos",
+            "ObjCPlayerSupport.framework",
+            "Modules",
+            "module.modulemap"
+        )
+        let copiedModuleMapExists = try await FileSystem().exists(copiedModuleMapPath)
+        #expect(!copiedModuleMapExists)
+    }
+}
+
 struct GenerateAcceptanceTestiOSAppWithMultiConfigs {
     @Test(.disabled(), .withFixture("generated_ios_app_with_multi_configs"), .inTemporaryDirectory)
     func ios_app_with_multi_configs() async throws {

--- a/cli/Tests/TuistGeneratorTests/ProjectMappers/ModuleMapMapperTests.swift
+++ b/cli/Tests/TuistGeneratorTests/ProjectMappers/ModuleMapMapperTests.swift
@@ -441,6 +441,42 @@ struct ModuleMapMapperTests {
     }
 
     @Test(.inTemporaryDirectory)
+    func removes_static_framework_modulemap_without_copy_script() throws {
+        // Given
+        let workspace = Workspace.test()
+        let projectPath = try temporaryPath().appending(component: "A")
+        let moduleMapPath = projectPath.appending(components: "A", "A.modulemap")
+        let target = Target.test(
+            name: "A",
+            product: .staticFramework,
+            settings: .test(base: [
+                "MODULEMAP_FILE": .string(moduleMapPath.pathString),
+            ])
+        )
+        let project = Project.test(
+            path: projectPath,
+            name: "A",
+            targets: [target]
+        )
+
+        // When
+        let (gotGraph, _, _) = try subject.map(
+            graph: .test(
+                workspace: workspace,
+                projects: [
+                    projectPath: project,
+                ]
+            ),
+            environment: MapperEnvironment()
+        )
+
+        // Then
+        let gotTarget = try #require(gotGraph.projects[projectPath]?.targets["A"])
+        #expect(gotTarget.settings?.base["MODULEMAP_FILE"] == nil)
+        #expect(gotTarget.scripts.isEmpty)
+    }
+
+    @Test(.inTemporaryDirectory)
     func maps_modulemap_flags_to_configurations_that_override_other_swift_flags() throws {
         // Given
         let workspace = Workspace.test()

--- a/examples/xcode/generated_ios_app_with_objc_static_framework_package/App/Project.swift
+++ b/examples/xcode/generated_ios_app_with_objc_static_framework_package/App/Project.swift
@@ -1,0 +1,18 @@
+import ProjectDescription
+
+let project = Project(
+    name: "App",
+    targets: [
+        .target(
+            name: "App",
+            destinations: .iOS,
+            product: .app,
+            bundleId: "dev.tuist.App",
+            deploymentTargets: .iOS("16.0"),
+            sources: "Sources/**",
+            dependencies: [
+                .project(target: "MediaFeatureKit", path: "../MediaFeatureKit"),
+            ]
+        ),
+    ]
+)

--- a/examples/xcode/generated_ios_app_with_objc_static_framework_package/App/Sources/AppApp.swift
+++ b/examples/xcode/generated_ios_app_with_objc_static_framework_package/App/Sources/AppApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct AppApp: App {
+    var body: some Scene {
+        WindowGroup {
+            Text("Video")
+        }
+    }
+}

--- a/examples/xcode/generated_ios_app_with_objc_static_framework_package/MediaFeatureKit/Project.swift
+++ b/examples/xcode/generated_ios_app_with_objc_static_framework_package/MediaFeatureKit/Project.swift
@@ -1,0 +1,18 @@
+import ProjectDescription
+
+let project = Project(
+    name: "MediaFeatureKit",
+    targets: [
+        .target(
+            name: "MediaFeatureKit",
+            destinations: .iOS,
+            product: .staticFramework,
+            bundleId: "dev.tuist.MediaFeatureKit",
+            deploymentTargets: .iOS("16.0"),
+            sources: "Sources/**",
+            dependencies: [
+                .external(name: "ObjCPlayerSupport"),
+            ]
+        ),
+    ]
+)

--- a/examples/xcode/generated_ios_app_with_objc_static_framework_package/MediaFeatureKit/Sources/MediaFeatureKit.m
+++ b/examples/xcode/generated_ios_app_with_objc_static_framework_package/MediaFeatureKit/Sources/MediaFeatureKit.m
@@ -1,0 +1,7 @@
+#import <Foundation/Foundation.h>
+#import <ObjCPlayerSupport/PlayerView.h>
+
+NSString *MediaFeatureKitCreatePlayerName(void)
+{
+    return [PlayerView playerName];
+}

--- a/examples/xcode/generated_ios_app_with_objc_static_framework_package/ObjCPlayerSupport/Package.swift
+++ b/examples/xcode/generated_ios_app_with_objc_static_framework_package/ObjCPlayerSupport/Package.swift
@@ -1,0 +1,22 @@
+// swift-tools-version:6.2
+
+import PackageDescription
+
+let package = Package(
+    name: "ObjCPlayerSupport",
+    platforms: [
+        .iOS(.v16),
+    ],
+    products: [
+        .library(
+            name: "ObjCPlayerSupport",
+            targets: ["ObjCPlayerSupport"]
+        ),
+    ],
+    targets: [
+        .target(
+            name: "ObjCPlayerSupport",
+            publicHeadersPath: "."
+        ),
+    ]
+)

--- a/examples/xcode/generated_ios_app_with_objc_static_framework_package/ObjCPlayerSupport/Sources/ObjCPlayerSupport/PlayerView.h
+++ b/examples/xcode/generated_ios_app_with_objc_static_framework_package/ObjCPlayerSupport/Sources/ObjCPlayerSupport/PlayerView.h
@@ -1,0 +1,7 @@
+#import <Foundation/Foundation.h>
+
+@interface PlayerView : NSObject
+
++ (NSString *)playerName;
+
+@end

--- a/examples/xcode/generated_ios_app_with_objc_static_framework_package/ObjCPlayerSupport/Sources/ObjCPlayerSupport/PlayerView.m
+++ b/examples/xcode/generated_ios_app_with_objc_static_framework_package/ObjCPlayerSupport/Sources/ObjCPlayerSupport/PlayerView.m
@@ -1,0 +1,10 @@
+#import "PlayerView.h"
+
+@implementation PlayerView
+
++ (NSString *)playerName
+{
+    return @"PlayerView";
+}
+
+@end

--- a/examples/xcode/generated_ios_app_with_objc_static_framework_package/Tuist.swift
+++ b/examples/xcode/generated_ios_app_with_objc_static_framework_package/Tuist.swift
@@ -1,0 +1,3 @@
+import ProjectDescription
+
+let tuist = Tuist(project: .tuist())

--- a/examples/xcode/generated_ios_app_with_objc_static_framework_package/Tuist/Package.swift
+++ b/examples/xcode/generated_ios_app_with_objc_static_framework_package/Tuist/Package.swift
@@ -1,0 +1,16 @@
+// swift-tools-version: 6.2
+
+import PackageDescription
+
+#if TUIST
+    import struct ProjectDescription.PackageSettings
+
+    let packageSettings = PackageSettings(productTypes: [:])
+#endif
+
+let package = Package(
+    name: "App",
+    dependencies: [
+        .package(path: "../ObjCPlayerSupport"),
+    ]
+)

--- a/examples/xcode/generated_ios_app_with_objc_static_framework_package/Workspace.swift
+++ b/examples/xcode/generated_ios_app_with_objc_static_framework_package/Workspace.swift
@@ -1,0 +1,9 @@
+import ProjectDescription
+
+let workspace = Workspace(
+    name: "App",
+    projects: [
+        "App",
+        "MediaFeatureKit",
+    ]
+)


### PR DESCRIPTION
## What changed

- Stop copying module maps into static framework products while keeping dynamic framework behavior unchanged.
- Add mapper coverage for static frameworks that verifies `MODULEMAP_FILE` is removed without adding a copy script.
- Add an iOS acceptance fixture where a static ObjC framework target depends on an external ObjC Swift package product with `publicHeadersPath: "."`, then archive that fixture end to end.

## Why

A reported archive topology surfaced a separate module-map duplication failure after the static xcframework header fix. The regression was introduced by [#11135](https://github.com/tuist/tuist/pull/11135) (`3069e881b24`), which added module-map copying for framework products to support package documentation module imports, but used `target.product.isFramework` and therefore also applied the dynamic-framework copy behavior to static frameworks.

Source Swift package products represented as ObjC static frameworks already expose their module map to dependent targets through Tuist's generated dependency module map. The mapper also copied that same module map into `Framework.framework/Modules/module.modulemap` because static frameworks satisfied `target.product.isFramework`.

When a dependent ObjC static framework imported a prefixed header such as `<ObjCPlayerSupport/PlayerView.h>`, clang could discover both module maps for the same umbrella header directory and failed the archive with:

```text
Umbrella for module 'ObjCPlayerSupport' already covers this directory
```

## Approach

Dynamic frameworks still need the canonical `Framework.framework/Modules/module.modulemap` layout, so that path remains unchanged. Static frameworks do not need that product-level module map copy, and copying it creates a second module-map entry point for the same headers. The mapper now gates the copy build phase on `target.product == .framework` instead of the broader `target.product.isFramework`.

The acceptance fixture mirrors the failing shape using a local ObjC package named `ObjCPlayerSupport` and a static framework target that imports its public header with the framework prefix. The test archives the app and asserts the static framework product does not contain a copied `Modules/module.modulemap`.

## Validation

- Reproduced the old behavior end to end by re-adding the previous static-framework module-map copy script after generation; `xcodebuild archive` failed with the exact umbrella-duplication diagnostic above.
- Validated the fixed generated project end to end with `xcodebuild archive`; the archive succeeded.
- `xcodebuild test -workspace Tuist.xcworkspace -scheme TuistGeneratorAcceptanceTests -only-testing 'TuistGeneratorAcceptanceTests/GenerateAcceptanceTestiOSAppWithObjCStaticFrameworkPackage/ios_app_with_objc_static_framework_package()' ...` passed.
- `xcodebuild test -workspace Tuist.xcworkspace -scheme TuistUnitTests -only-testing 'TuistGeneratorTests/ModuleMapMapperTests/removes_static_framework_modulemap_without_copy_script()' ...` passed.
- `xcodebuild test -workspace Tuist.xcworkspace -scheme TuistUnitTests -only-testing 'TuistGeneratorTests/ModuleMapMapperTests/maps_framework_modulemap_to_modulemap_copy_script()' -only-testing 'TuistGeneratorTests/ModuleMapMapperTests/removes_static_framework_modulemap_without_copy_script()' ...` passed, covering both the original #11135 dynamic-framework behavior and the new static-framework guard.
- `git diff --check` passed for the changed files and fixture.
