### PR TITLE
fix(cli): avoid static framework module map copies [4.201.x backport]

### DIFF
--- a/cli/Sources/TuistGenerator/Mappers/ModuleMapMapper.swift
+++ b/cli/Sources/TuistGenerator/Mappers/ModuleMapMapper.swift
@@ -85,7 +85,7 @@ public struct ModuleMapMapper: GraphMapping { // swiftlint:disable:this type_bod
                         from: mappedSettingsDictionary[Self.modulemapFileSetting],
                         projectPath: project.path
                     ),
-                        target.product.isFramework
+                        target.product == .framework
                     {
                         // swift-build gives ExtractAPI dependency module maps explicitly and models framework module maps
                         // at `Modules/module.modulemap`. Generated Xcode projects need the same canonical framework path.

--- a/cli/Tests/TuistGeneratorAcceptanceTests/GenerateAcceptanceTests.swift
+++ b/cli/Tests/TuistGeneratorAcceptanceTests/GenerateAcceptanceTests.swift
@@ -521,6 +521,50 @@ struct GenerateAcceptanceTestiOSAppWithLocalSwiftPackage {
     }
 }
 
+struct GenerateAcceptanceTestiOSAppWithObjCStaticFrameworkPackage {
+    @Test(.withFixture("generated_ios_app_with_objc_static_framework_package"), .inTemporaryDirectory)
+    func ios_app_with_objc_static_framework_package() async throws {
+        let fixturePath = try fixtureDirectory()
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let derivedDataPath = temporaryDirectory.appending(component: "DerivedData")
+
+        try await run(InstallCommand.self)
+        try await run(GenerateCommand.self)
+
+        try await CommandRunner().runAndWait(arguments: [
+            "/usr/bin/xcodebuild",
+            "archive",
+            "-workspace",
+            fixturePath.appending(component: "App.xcworkspace").pathString,
+            "-scheme",
+            "App",
+            "-destination",
+            "generic/platform=iOS",
+            "-derivedDataPath",
+            derivedDataPath.pathString,
+            "-archivePath",
+            temporaryDirectory.appending(component: "App.xcarchive").pathString,
+            "CODE_SIGNING_ALLOWED=NO",
+            "CODE_SIGNING_REQUIRED=NO",
+            "CODE_SIGN_IDENTITY=",
+        ])
+
+        let copiedModuleMapPath = derivedDataPath.appending(
+            components: "Build",
+            "Intermediates.noindex",
+            "ArchiveIntermediates",
+            "App",
+            "BuildProductsPath",
+            "Release-iphoneos",
+            "ObjCPlayerSupport.framework",
+            "Modules",
+            "module.modulemap"
+        )
+        let copiedModuleMapExists = try await FileSystem().exists(copiedModuleMapPath)
+        #expect(!copiedModuleMapExists)
+    }
+}
+
 struct GenerateAcceptanceTestiOSAppWithMultiConfigs {
     @Test(.disabled(), .withFixture("generated_ios_app_with_multi_configs"), .inTemporaryDirectory)
     func ios_app_with_multi_configs() async throws {

--- a/cli/Tests/TuistGeneratorTests/ProjectMappers/ModuleMapMapperTests.swift
+++ b/cli/Tests/TuistGeneratorTests/ProjectMappers/ModuleMapMapperTests.swift
@@ -441,6 +441,42 @@ struct ModuleMapMapperTests {
     }
 
     @Test(.inTemporaryDirectory)
+    func removes_static_framework_modulemap_without_copy_script() throws {
+        // Given
+        let workspace = Workspace.test()
+        let projectPath = try temporaryPath().appending(component: "A")
+        let moduleMapPath = projectPath.appending(components: "A", "A.modulemap")
+        let target = Target.test(
+            name: "A",
+            product: .staticFramework,
+            settings: .test(base: [
+                "MODULEMAP_FILE": .string(moduleMapPath.pathString),
+            ])
+        )
+        let project = Project.test(
+            path: projectPath,
+            name: "A",
+            targets: [target]
+        )
+
+        // When
+        let (gotGraph, _, _) = try subject.map(
+            graph: .test(
+                workspace: workspace,
+                projects: [
+                    projectPath: project,
+                ]
+            ),
+            environment: MapperEnvironment()
+        )
+
+        // Then
+        let gotTarget = try #require(gotGraph.projects[projectPath]?.targets["A"])
+        #expect(gotTarget.settings?.base["MODULEMAP_FILE"] == nil)
+        #expect(gotTarget.scripts.isEmpty)
+    }
+
+    @Test(.inTemporaryDirectory)
     func maps_modulemap_flags_to_configurations_that_override_other_swift_flags() throws {
         // Given
         let workspace = Workspace.test()

--- a/examples/xcode/generated_ios_app_with_objc_static_framework_package/App/Project.swift
+++ b/examples/xcode/generated_ios_app_with_objc_static_framework_package/App/Project.swift
@@ -1,0 +1,18 @@
+import ProjectDescription
+
+let project = Project(
+    name: "App",
+    targets: [
+        .target(
+            name: "App",
+            destinations: .iOS,
+            product: .app,
+            bundleId: "dev.tuist.App",
+            deploymentTargets: .iOS("16.0"),
+            sources: "Sources/**",
+            dependencies: [
+                .project(target: "MediaFeatureKit", path: "../MediaFeatureKit"),
+            ]
+        ),
+    ]
+)

--- a/examples/xcode/generated_ios_app_with_objc_static_framework_package/App/Sources/AppApp.swift
+++ b/examples/xcode/generated_ios_app_with_objc_static_framework_package/App/Sources/AppApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct AppApp: App {
+    var body: some Scene {
+        WindowGroup {
+            Text("Video")
+        }
+    }
+}

--- a/examples/xcode/generated_ios_app_with_objc_static_framework_package/MediaFeatureKit/Project.swift
+++ b/examples/xcode/generated_ios_app_with_objc_static_framework_package/MediaFeatureKit/Project.swift
@@ -1,0 +1,18 @@
+import ProjectDescription
+
+let project = Project(
+    name: "MediaFeatureKit",
+    targets: [
+        .target(
+            name: "MediaFeatureKit",
+            destinations: .iOS,
+            product: .staticFramework,
+            bundleId: "dev.tuist.MediaFeatureKit",
+            deploymentTargets: .iOS("16.0"),
+            sources: "Sources/**",
+            dependencies: [
+                .external(name: "ObjCPlayerSupport"),
+            ]
+        ),
+    ]
+)

--- a/examples/xcode/generated_ios_app_with_objc_static_framework_package/MediaFeatureKit/Sources/MediaFeatureKit.m
+++ b/examples/xcode/generated_ios_app_with_objc_static_framework_package/MediaFeatureKit/Sources/MediaFeatureKit.m
@@ -1,0 +1,7 @@
+#import <Foundation/Foundation.h>
+#import <ObjCPlayerSupport/PlayerView.h>
+
+NSString *MediaFeatureKitCreatePlayerName(void)
+{
+    return [PlayerView playerName];
+}

--- a/examples/xcode/generated_ios_app_with_objc_static_framework_package/ObjCPlayerSupport/Package.swift
+++ b/examples/xcode/generated_ios_app_with_objc_static_framework_package/ObjCPlayerSupport/Package.swift
@@ -1,0 +1,22 @@
+// swift-tools-version:6.2
+
+import PackageDescription
+
+let package = Package(
+    name: "ObjCPlayerSupport",
+    platforms: [
+        .iOS(.v16),
+    ],
+    products: [
+        .library(
+            name: "ObjCPlayerSupport",
+            targets: ["ObjCPlayerSupport"]
+        ),
+    ],
+    targets: [
+        .target(
+            name: "ObjCPlayerSupport",
+            publicHeadersPath: "."
+        ),
+    ]
+)

--- a/examples/xcode/generated_ios_app_with_objc_static_framework_package/ObjCPlayerSupport/Sources/ObjCPlayerSupport/PlayerView.h
+++ b/examples/xcode/generated_ios_app_with_objc_static_framework_package/ObjCPlayerSupport/Sources/ObjCPlayerSupport/PlayerView.h
@@ -1,0 +1,7 @@
+#import <Foundation/Foundation.h>
+
+@interface PlayerView : NSObject
+
++ (NSString *)playerName;
+
+@end

--- a/examples/xcode/generated_ios_app_with_objc_static_framework_package/ObjCPlayerSupport/Sources/ObjCPlayerSupport/PlayerView.m
+++ b/examples/xcode/generated_ios_app_with_objc_static_framework_package/ObjCPlayerSupport/Sources/ObjCPlayerSupport/PlayerView.m
@@ -1,0 +1,10 @@
+#import "PlayerView.h"
+
+@implementation PlayerView
+
++ (NSString *)playerName
+{
+    return @"PlayerView";
+}
+
+@end

--- a/examples/xcode/generated_ios_app_with_objc_static_framework_package/Tuist.swift
+++ b/examples/xcode/generated_ios_app_with_objc_static_framework_package/Tuist.swift
@@ -1,0 +1,3 @@
+import ProjectDescription
+
+let tuist = Tuist(project: .tuist())

--- a/examples/xcode/generated_ios_app_with_objc_static_framework_package/Tuist/Package.swift
+++ b/examples/xcode/generated_ios_app_with_objc_static_framework_package/Tuist/Package.swift
@@ -1,0 +1,16 @@
+// swift-tools-version: 6.2
+
+import PackageDescription
+
+#if TUIST
+    import struct ProjectDescription.PackageSettings
+
+    let packageSettings = PackageSettings(productTypes: [:])
+#endif
+
+let package = Package(
+    name: "App",
+    dependencies: [
+        .package(path: "../ObjCPlayerSupport"),
+    ]
+)

--- a/examples/xcode/generated_ios_app_with_objc_static_framework_package/Workspace.swift
+++ b/examples/xcode/generated_ios_app_with_objc_static_framework_package/Workspace.swift
@@ -1,0 +1,9 @@
+import ProjectDescription
+
+let workspace = Workspace(
+    name: "App",
+    projects: [
+        "App",
+        "MediaFeatureKit",
+    ]
+)


### PR DESCRIPTION
## What changed

Backports #11588 to `releases/4.201.x` by cherry-picking the landed main commit `69b96e8b13a1d9fe08fef1c153b32a07833e4778`.

This keeps static framework targets from receiving copied product-level module maps while preserving the dynamic framework behavior covered by #11135.

## Why

The static framework path can expose the same ObjC module map through both the generated dependency module map and the copied `Framework.framework/Modules/module.modulemap`. In archive topologies where another static framework imports prefixed ObjC package headers, clang can diagnose that the umbrella already covers the same directory.

## Validation

- Cherry-picked from the landed main commit with `git cherry-pick -x`.
- Source PR #11588 passed CI on `main` before this backport.
- No additional checks were run for the backport per request.