### PR TITLE
fix(server): update echarts for security scan

### DIFF
--- a/noora/aube-lock.yaml
+++ b/noora/aube-lock.yaml
@@ -74,7 +74,7 @@ time:
   csstype@3.2.3: 2025-11-17T11:42:27.045Z
   culori@4.0.2: 2025-06-27T15:55:34.023Z
   detect-libc@2.1.2: 2025-10-05T12:46:33.077Z
-  echarts@5.6.0: 2024-12-28T07:21:42.839Z
+  echarts@6.1.0: 2026-05-19T17:52:11.076Z
   es-module-lexer@2.1.0: 2026-04-25T22:50:31.041Z
   esbuild@0.27.7: 2026-04-02T16:43:44.831Z
   estree-walker@3.0.3: 2023-01-20T02:27:12.467Z
@@ -115,7 +115,7 @@ time:
   vite@8.0.10: 2026-04-23T05:19:36.436Z
   vitest@4.1.5: 2026-04-21T11:04:03.117Z
   why-is-node-running@2.3.0: 2024-07-08T12:57:23.951Z
-  zrender@5.6.1: 2024-12-11T03:11:54.227Z
+  zrender@6.1.0: 2026-05-04T09:43:16.692Z
 
 importers:
 
@@ -179,8 +179,8 @@ importers:
         specifier: ^4.0.1
         version: 4.0.2
       echarts:
-        specifier: ^5.6.0
-        version: 5.6.0
+        specifier: ^6.1.0
+        version: 6.1.0
       vite:
         specifier: ^6.0.0 || ^7.0.0 || ^8.0.0
         version: 8.0.10(esbuild@0.27.7)
@@ -494,8 +494,8 @@ packages:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
-  echarts@5.6.0:
-    resolution: {integrity: sha512-oTbVTsXfKuEhxftHqL5xprgLoc0k7uScAwtryCgWF6hPYFLRwOUHiFmHGCBKP5NPFNkDVopOieyUqYGH8Fa3kA==}
+  echarts@6.1.0:
+    resolution: {integrity: sha512-q0yaFPggC9FUdsWH4blavRWFmxdrIodbkoKNAjJudAI6CA9gNPxHtV2RcZNEepZVlk4yvBYkOkbk6HIVpIyHZA==}
 
   es-module-lexer@2.1.0:
     resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
@@ -775,8 +775,8 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
-  zrender@5.6.1:
-    resolution: {integrity: sha512-OFXkDJKcrlx5su2XbzJvj/34Q3m6PvyCZkVPHGYpcCJ52ek4U/ymZyfuV1nKE23AyBJ51E/6Yr0mhZ7xGTO4ag==}
+  zrender@6.1.0:
+    resolution: {integrity: sha512-oEGMDB6pOP2S6OwRR4PdVv610zrjnA3Bh+JnSG12fYJlBKjtNAoEb5fSUoCOOINlH96I2fU38/A2UpRKs67xYQ==}
 
 snapshots:
 
@@ -1099,10 +1099,10 @@ snapshots:
 
   detect-libc@2.1.2: {}
 
-  echarts@5.6.0:
+  echarts@6.1.0:
     dependencies:
       tslib: 2.3.0
-      zrender: 5.6.1
+      zrender: 6.1.0
 
   es-module-lexer@2.1.0: {}
 
@@ -1266,6 +1266,6 @@ snapshots:
       siginfo: 2.0.0
       stackback: 0.0.2
 
-  zrender@5.6.1:
+  zrender@6.1.0:
     dependencies:
       tslib: 2.3.0

--- a/noora/package.json
+++ b/noora/package.json
@@ -35,7 +35,7 @@
     "@zag-js/types": "^1.8.2",
     "@zag-js/utils": "^1.8.2",
     "culori": "^4.0.1",
-    "echarts": "^5.6.0"
+    "echarts": "^6.1.0"
   },
   "devDependencies": {
     "esbuild": "^0.27.0",

--- a/server/package.json
+++ b/server/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "dependencies": {
     "@scalar/api-reference": "^1.52.0",
-    "echarts": "^5.6.0",
+    "echarts": "^6.1.0",
     "prettier-plugin-css-order": "^2.2.0",
     "typesense": "^3.0.5",
     "vanilla-cookieconsent": "3.1.0"

--- a/server/pnpm-lock.yaml
+++ b/server/pnpm-lock.yaml
@@ -29,12 +29,14 @@ time:
   '@protobufjs/utf8@1.1.1': 2026-04-27T20:31:28.490Z
   axios@1.16.0: 2026-05-02T15:04:00.274Z
   dompurify@3.4.11: 2026-06-17T10:33:28.065Z
+  echarts@6.1.0: 2026-05-19T17:52:11.076Z
   fast-uri@3.1.2: 2026-05-05T08:31:31.849Z
   form-data@4.0.6: 2026-06-12T17:37:53.689Z
   hasown@2.0.4: 2026-05-28T18:11:39.940Z
   protobufjs@7.6.4: 2026-06-12T12:10:59.442Z
   shell-quote@1.8.4: 2026-05-22T13:13:48.633Z
   ts-deepmerge@8.0.0: 2026-05-22T00:15:00.073Z
+  zrender@6.1.0: 2026-05-04T09:43:16.692Z
 
 importers:
 
@@ -47,8 +49,8 @@ importers:
         specifier: ^1.52.0
         version: 1.52.0
       echarts:
-        specifier: ^5.6.0
-        version: 5.6.0
+        specifier: ^6.1.0
+        version: 6.1.0
       prettier:
         specifier: 3.x
         version: 3.5.3
@@ -711,8 +713,8 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
-  echarts@5.6.0:
-    resolution: {integrity: sha512-oTbVTsXfKuEhxftHqL5xprgLoc0k7uScAwtryCgWF6hPYFLRwOUHiFmHGCBKP5NPFNkDVopOieyUqYGH8Fa3kA==}
+  echarts@6.1.0:
+    resolution: {integrity: sha512-q0yaFPggC9FUdsWH4blavRWFmxdrIodbkoKNAjJudAI6CA9gNPxHtV2RcZNEepZVlk4yvBYkOkbk6HIVpIyHZA==}
 
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
@@ -1501,8 +1503,8 @@ packages:
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
-  zrender@5.6.1:
-    resolution: {integrity: sha512-OFXkDJKcrlx5su2XbzJvj/34Q3m6PvyCZkVPHGYpcCJ52ek4U/ymZyfuV1nKE23AyBJ51E/6Yr0mhZ7xGTO4ag==}
+  zrender@6.1.0:
+    resolution: {integrity: sha512-oEGMDB6pOP2S6OwRR4PdVv610zrjnA3Bh+JnSG12fYJlBKjtNAoEb5fSUoCOOINlH96I2fU38/A2UpRKs67xYQ==}
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -2453,10 +2455,10 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
-  echarts@5.6.0:
+  echarts@6.1.0:
     dependencies:
       tslib: 2.3.0
-      zrender: 5.6.1
+      zrender: 6.1.0
 
   entities@6.0.1: {}
 
@@ -3504,7 +3506,7 @@ snapshots:
 
   zod@4.3.6: {}
 
-  zrender@5.6.1:
+  zrender@6.1.0:
     dependencies:
       tslib: 2.3.0
 


### PR DESCRIPTION
## What changed

Updated ECharts from `5.6.0` to `6.1.0` in both places that pin the chart runtime:

- `server/package.json` and `server/pnpm-lock.yaml`
- `noora/package.json` and `noora/aube-lock.yaml`

This also updates the transitive renderer package `zrender` from `5.6.1` to `6.1.0`.

## Why it changed

The Server workflow security job for PR #11587 failed during the Trivy filesystem scan. Trivy reported `CVE-2026-45249` against `echarts@5.6.0` in `server/pnpm-lock.yaml`, with `6.1.0` listed as the fixed version.

The server lockfile update resolves the failing scan. Noora is included because the actual bundled chart hook imports ECharts from Noora's dependency graph, so updating only the server lock would remove the CI finding while leaving the bundled chart runtime on the vulnerable version.

## Root cause

The server and Noora dependency locks still resolved ECharts `5.6.0`. Once Trivy's vulnerability database included `CVE-2026-45249`, the server security job began failing even though the application code in PR #11587 was unrelated to the dependency.

## Validation

- `trivy fs --exit-code 1 --skip-files "mix.exs,mix.lock" --skip-dirs "priv/static,node_modules,deps,_build" ./` from `server/`
- `aube check` from `server/`
- `aube check` from `noora/`
- `aube run build` from `noora/`
- `mise run security` from `server/`
