### PR TITLE
fix(server): improve xcresult timeout diagnostics

### DIFF
--- a/server/native/xcresult_nif/Sources/XCResultNIF/XCResultNIF.swift
+++ b/server/native/xcresult_nif/Sources/XCResultNIF/XCResultNIF.swift
@@ -16,8 +16,9 @@ public func parseXCResult(
         XCResultParserError.failedToParseOutput(try! AbsolutePath(validating: path))
     )
     let semaphore = DispatchSemaphore(value: 0)
+    let progress = XCResultParserProgress()
 
-    Task { @Sendable in
+    let parseTask = Task { @Sendable in
         do {
             let xcresultPath = try AbsolutePath(validating: path)
             let rootDirectory = try AbsolutePath(validating: rootDir)
@@ -29,7 +30,8 @@ public func parseXCResult(
             guard let parsed = try await XCResultParser().parse(
                 path: xcresultPath,
                 rootDirectory: rootDirectory,
-                attachmentsDirectory: rootDirectory
+                attachmentsDirectory: rootDirectory,
+                progress: progress
             ) else {
                 result = .failure(XCResultParserError.failedToParseOutput(xcresultPath))
                 semaphore.signal()
@@ -45,7 +47,14 @@ public func parseXCResult(
     let timeoutSeconds = 600
     let timeout = semaphore.wait(timeout: .now() + .seconds(timeoutSeconds))
     if timeout == .timedOut {
-        result = .failure(XCResultParserError.timedOut(try! AbsolutePath(validating: path), seconds: timeoutSeconds))
+        parseTask.cancel()
+        result = .failure(
+            XCResultParserError.timedOut(
+                try! AbsolutePath(validating: path),
+                seconds: timeoutSeconds,
+                stage: progress.currentStage
+            )
+        )
     }
 
     switch result {

--- a/server/native/xcresult_nif/Sources/XCResultParser/XCResultParser.swift
+++ b/server/native/xcresult_nif/Sources/XCResultParser/XCResultParser.swift
@@ -2,20 +2,40 @@ import Command
 import FileSystem
 import Foundation
 import Path
+import Synchronization
 
 public enum XCResultParserError: LocalizedError, Equatable {
     case failedToParseOutput(AbsolutePath)
-    case timedOut(AbsolutePath, seconds: Int)
+    case timedOut(AbsolutePath, seconds: Int, stage: String? = nil)
     case decodingFailed(step: String, path: AbsolutePath, detail: String)
 
     public var errorDescription: String? {
         switch self {
         case let .failedToParseOutput(path):
             return "Failed to parse xcresult output at \(path.pathString)"
-        case let .timedOut(path, seconds):
-            return "xcresult parsing timed out after \(seconds)s at \(path.pathString)"
+        case let .timedOut(_, seconds, stage):
+            if let stage, !stage.isEmpty {
+                return "xcresult parsing timed out after \(seconds)s while \(stage)"
+            }
+            return "xcresult parsing timed out after \(seconds)s"
         case let .decodingFailed(step, path, detail):
             return "Failed to decode xcresult \(step) at \(path.pathString): \(detail)"
+        }
+    }
+}
+
+public final class XCResultParserProgress: Sendable {
+    private let stage = Mutex<String?>(nil)
+
+    public init() {}
+
+    public var currentStage: String? {
+        stage.withLock { $0 }
+    }
+
+    public func setStage(_ newStage: String) {
+        stage.withLock { stage in
+            stage = newStage
         }
     }
 }
@@ -87,14 +107,16 @@ public struct XCResultParser: Sendable {
     public func parse(
         path: AbsolutePath,
         rootDirectory: AbsolutePath?,
-        attachmentsDirectory: AbsolutePath? = nil
+        attachmentsDirectory: AbsolutePath? = nil,
+        progress: XCResultParserProgress? = nil
     ) async throws -> TestSummary? {
-        let testOutput = try await loadTestOutput(path: path)
+        let testOutput = try await loadTestOutput(path: path, progress: progress)
         return try await parseTestOutput(
             testOutput,
             rootDirectory: rootDirectory,
             attachmentsDirectory: attachmentsDirectory,
-            xcresultPath: path
+            xcresultPath: path,
+            progress: progress
         )
     }
 
@@ -109,7 +131,11 @@ public struct XCResultParser: Sendable {
         return TestResultStatuses(testCases: results)
     }
 
-    private func loadTestOutput(path: AbsolutePath) async throws -> XCResultTestOutput {
+    private func loadTestOutput(
+        path: AbsolutePath,
+        progress: XCResultParserProgress? = nil
+    ) async throws -> XCResultTestOutput {
+        progress?.setStage("loading test results")
         try await fileSystem
             .runInTemporaryDirectory(prefix: "xcresult-test-results") { temporaryDirectory in
                 let tempFile = temporaryDirectory.appending(component: "test-results.json")
@@ -126,6 +152,7 @@ public struct XCResultParser: Sendable {
                 guard let jsonData = jsonString.data(using: .utf8) else {
                     throw XCResultParserError.failedToParseOutput(path)
                 }
+                progress?.setStage("decoding test results")
                 do {
                     return try JSONDecoder().decode(XCResultTestOutput.self, from: jsonData)
                 } catch {
@@ -204,9 +231,10 @@ public struct XCResultParser: Sendable {
         _ output: XCResultTestOutput,
         rootDirectory: AbsolutePath?,
         attachmentsDirectory: AbsolutePath?,
-        xcresultPath: AbsolutePath
+        xcresultPath: AbsolutePath,
+        progress: XCResultParserProgress? = nil
     ) async throws -> TestSummary {
-        let actionLog = try await actionLog(from: xcresultPath)
+        let actionLog = try await actionLog(from: xcresultPath, progress: progress)
         let failuresFromActionLog = actionLog.extractTestFailures(rootDirectory: rootDirectory)
             .reduce(into: [String: [TestFailure]]()) { result, entry in
                 let key = normalizeTestIdentifier(entry.key)
@@ -238,7 +266,8 @@ public struct XCResultParser: Sendable {
 
         let extractedAttachments = await attachmentsByTestIdentifiers(
             from: xcresultPath,
-            attachmentsDirectory: attachmentsDirectory
+            attachmentsDirectory: attachmentsDirectory,
+            progress: progress
         )
 
         allTestCases = allTestCases.map { testCase in
@@ -594,7 +623,11 @@ public struct XCResultParser: Sendable {
         return (updatedTestCases, suiteDurations, modules, overall)
     }
 
-    private func actionLog(from xcresultPath: AbsolutePath) async throws -> ActionLogSection {
+    private func actionLog(
+        from xcresultPath: AbsolutePath,
+        progress: XCResultParserProgress? = nil
+    ) async throws -> ActionLogSection {
+        progress?.setStage("loading action log")
         try await fileSystem.runInTemporaryDirectory(prefix: "xcresult-action-log") { temporaryDirectory in
             let tempFile = temporaryDirectory.appending(component: "action-log.json")
 
@@ -612,6 +645,7 @@ public struct XCResultParser: Sendable {
             // locations, so treat its absence as empty rather than failing the
             // whole parse with an opaque decode error.
             guard !logData.isEmpty else { return .empty }
+            progress?.setStage("decoding action log")
             do {
                 return try JSONDecoder().decode(ActionLogSection.self, from: logData)
             } catch {
@@ -682,11 +716,13 @@ public struct XCResultParser: Sendable {
 
     private func attachmentsByTestIdentifiers(
         from xcresultPath: AbsolutePath,
-        attachmentsDirectory: AbsolutePath?
+        attachmentsDirectory: AbsolutePath?,
+        progress: XCResultParserProgress? = nil
     ) async -> (crashReports: [String: CrashReport], attachments: [String: [TestAttachment]]) {
         do {
             let temporaryDirectory = try await attachmentsExportDirectory(in: attachmentsDirectory)
 
+            progress?.setStage("exporting attachments")
             _ = try await commandRunner.run(
                 arguments: [
                     "/bin/sh", "-c",
@@ -699,14 +735,17 @@ public struct XCResultParser: Sendable {
                 return ([:], [:])
             }
 
+            progress?.setStage("decoding attachment manifest")
             let manifestData = try await fileSystem.readFile(at: manifestPath)
             let manifestEntries = try JSONDecoder().decode([AttachmentManifest].self, from: manifestData)
 
             var crashReportsByTestIdentifier: [String: CrashReport] = [:]
             var attachmentsByTestIdentifier: [String: [TestAttachment]] = [:]
 
+            progress?.setStage("converting PNG attachments")
             await convertCgBIPNGs(in: temporaryDirectory, manifestEntries: manifestEntries)
 
+            progress?.setStage("processing attachments")
             for entry in manifestEntries {
                 guard let testIdentifier = entry.testIdentifier else { continue }
                 let normalizedIdentifier = normalizeTestIdentifier(testIdentifier)

--- a/server/native/xcresult_nif/Tests/XCResultParserTests/XCResultParserTests.swift
+++ b/server/native/xcresult_nif/Tests/XCResultParserTests/XCResultParserTests.swift
@@ -80,6 +80,22 @@ struct XCResultParserTests {
     }
 
     @Test
+    func timeoutErrorDescriptionDoesNotIncludeThePerRunTemporaryDirectory() throws {
+        let path = try AbsolutePath(validating: "/tmp/tuist_xcresult_processor_1234/AppTests.xcresult")
+        let error = XCResultParserError.timedOut(path, seconds: 600)
+
+        #expect(error.localizedDescription == "xcresult parsing timed out after 600s")
+    }
+
+    @Test
+    func timeoutErrorDescriptionCanIncludeStableParserStage() throws {
+        let path = try AbsolutePath(validating: "/tmp/tuist_xcresult_processor_1234/AppTests.xcresult")
+        let error = XCResultParserError.timedOut(path, seconds: 600, stage: "exporting attachments")
+
+        #expect(error.localizedDescription == "xcresult parsing timed out after 600s while exporting attachments")
+    }
+
+    @Test
     func parse_populatesRunDestinationsFromTheXcresultDevicesArray() async throws {
         let zipPath = try fixtureZipPath("test-with-arguments.xcresult")
 


### PR DESCRIPTION
## What changed

- Cancels the Swift parsing task when the 600 second NIF watchdog fires, instead of returning a timeout while leaving the parser work running in the background.
- Makes timeout errors stable by removing the per-run temporary `.xcresult` path from the message.
- Tracks the active parser stage and includes it in timeout errors when available, for example `xcresult parsing timed out after 600s while exporting attachments`.
- Adds focused coverage for the stable timeout message and the stage-specific timeout message.

## Why

Sentry was reporting a cluster of `ProcessXcresultWorker` failures where xcresult parsing timed out after 600 seconds. The error message included the temporary bundle path, which fragmented issue grouping and made it harder to see whether failures shared one root cause.

The timeout also did not say which `xcresulttool` phase was active. The parser currently does three expensive-ish external steps: loading test results, loading the action log, and exporting attachments. Without stage information, each timeout required manual artifact recovery and local repro work.

## Investigation

I profiled one sampled production result bundle locally with Xcode 26.5.0. The uploaded file had a `.zip` suffix but was actually an Apple Archive stream, which matches the server's existing non-PKZIP extraction path.

Measured locally:

```text
AppleArchive extract:                  ~0.05s
xcresulttool get test-results tests:    ~0.06s
xcresulttool get log --type action:     ~0.07s
xcresulttool export attachments:        ~3.51s
```

The bundle was small: roughly 25 MB extracted, 67 test cases, 7 exported attachments, and no PNG attachments to convert. That artifact did not reproduce a 600 second parse locally, which suggests the production failures are more likely a worker or `xcresulttool` wedge under load than an inherently huge artifact.

## Root Cause

The immediate bug in our handling was diagnostic and operational:

- Timeout errors were keyed by random temp paths, fragmenting Sentry grouping.
- The watchdog returned a timeout without cancelling the underlying Swift task.
- Timeout events did not identify the active parser stage, so the slow or stuck operation was invisible.

This PR does not claim to fix the underlying `xcresulttool` hang, but it makes the next occurrence grouped and actionable.

## Validation

- Ran `swiftc -parse` for `Sources/XCResultParser/XCResultParser.swift`.
- Ran `swiftc -parse` for `Sources/XCResultNIF/XCResultNIF.swift`.
- Ran `git diff --check` and `git diff --cached --check`.
- Full `swift test` for `server/native/xcresult_nif` is currently blocked in this worktree by the existing SwiftPM registry/source resolution issue around duplicate package identities.
