### PR TITLE
fix(cli): expose tuist test run help

### DIFF
--- a/cli/Sources/TuistTestCommand/TestCommand.swift
+++ b/cli/Sources/TuistTestCommand/TestCommand.swift
@@ -8,6 +8,8 @@ public struct TestCommand: AsyncParsableCommand {
         CommandConfiguration(
             commandName: "test",
             abstract: "Tests a project",
+            discussion:
+            "Use 'tuist help test run' to see options for executing tests. The 'run' subcommand is the default, so 'tuist test --clean' and 'tuist test run --clean' are equivalent.",
             subcommands: subcommands,
             defaultSubcommand: defaultSubcommand
         )

--- a/cli/Sources/TuistTestCommand/TestRunCommand.swift
+++ b/cli/Sources/TuistTestCommand/TestRunCommand.swift
@@ -60,8 +60,8 @@
                 abstract: "Tests a project",
                 usage:
                 "tuist test [<options>] [<scheme>] -- [<passthrough-xcode-build-arguments> ...]",
-                discussion: "Use 'tuist test case' to manage test cases.",
-                shouldDisplay: false
+                discussion:
+                "This is the default subcommand, so 'tuist test --clean' and 'tuist test run --clean' are equivalent."
             )
         }
 


### PR DESCRIPTION
## What changed

- Exposes the hidden `tuist test run` subcommand in the `tuist help test` subcommand list.
- Adds root `tuist test` help discussion pointing users to `tuist help test run` for execution options.
- Updates `tuist test run` discussion to clarify that `tuist test --clean` and `tuist test run --clean` are equivalent.

## Why

Users looking at `tuist help test` could only see test-run inspection and management commands, even though the executable test options such as `--clean`, `-d`, and `-T` live on the default `run` subcommand. That made the command discoverability confusing.

## Root cause

`TestRunCommand` was registered as the default subcommand for `tuist test`, but it also had `shouldDisplay: false`, so ArgumentParser omitted it from the root test help menu.

## Impact

The existing shorthand invocation remains unchanged, while the help menu now points users toward the command that documents the test execution flags.

## Validation

Not run locally. Per maintainer guidance for this small help metadata change, local compilation was intentionally skipped because the generated Xcode build is expensive for this worktree.
