### PR TITLE
fix(server, infra): runner metrics chart alignment + full-job coverage

### DIFF
--- a/infra/runner-image/dispatch-poll.sh
+++ b/infra/runner-image/dispatch-poll.sh
@@ -136,6 +136,21 @@ while true; do
         export TUIST_CACHE_ENDPOINT="${cache_endpoint}"
       fi
       echo "$(date -u +%FT%TZ) dispatch-poll: dispatched, starting runner"
+      # Force an NTP step before the job runs. A golden-base VM can be
+      # handed a job within seconds of boot — before macOS `timed` has
+      # synced the guest clock, which can start minutes behind. The
+      # GitHub runner stamps step times and metrics-poll stamps samples
+      # off this clock, so an unsynced VM lands the two on different
+      # timelines (the step timeline only drifts into alignment once
+      # `timed` catches up mid-job). `sntp -sS` steps a large offset via
+      # clock_settime (and slews a sub-50ms one); the network is already
+      # up here since dispatch just succeeded. Best-effort: on failure
+      # `timed` still converges, just later.
+      if sudo /usr/bin/sntp -sS -t 5 time.apple.com >/dev/null 2>&1; then
+        echo "$(date -u +%FT%TZ) dispatch-poll: clock stepped to NTP before runner start"
+      else
+        echo "$(date -u +%FT%TZ) dispatch-poll: WARNING NTP step failed; relying on timed"
+      fi
       # Fork the machine-metrics sampler so it runs for the job's
       # duration and POSTs CPU/memory/network/disk to the server. It
       # dies with the VM when the EXIT trap halts us after the runner

--- a/infra/tart-kubelet/cmd/tart-kubelet/main.go
+++ b/infra/tart-kubelet/cmd/tart-kubelet/main.go
@@ -273,9 +273,14 @@ func main() {
 		Tart:               tartClient,
 		Resolver:           resolver,
 		Store:              store,
-		TokenMinter:        &satoken.ClientMinter{Client: typedClient, ExpirationSeconds: 3600},
-		GC:                 gcCollector,
-		Recorder:           mgr.GetEventRecorderFor("tart-kubelet"),
+		// 8h TTL: minted once at boot and not rotated, the token must
+		// outlive warm-time + the whole job, because the in-VM metrics
+		// sampler reuses it to POST for the job's full duration (a 1h TTL
+		// expired mid-run on long jobs and truncated their charts). It's
+		// Pod-bound, so it dies when the Pod is reaped regardless.
+		TokenMinter: &satoken.ClientMinter{Client: typedClient, ExpirationSeconds: 28800},
+		GC:          gcCollector,
+		Recorder:    mgr.GetEventRecorderFor("tart-kubelet"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "setup pod reconciler")
 		os.Exit(1)

--- a/infra/tart-kubelet/internal/satoken/satoken.go
+++ b/infra/tart-kubelet/internal/satoken/satoken.go
@@ -13,9 +13,11 @@
 //
 // The token is bound to the Pod (via TokenRequestSpec.BoundObjectRef)
 // so the apiserver invalidates it the moment the Pod is deleted —
-// matching kubelet's automount lifecycle. TTL is short (10 min); the
-// caller is responsible for re-running this on each reconcile if
-// the Pod is long-running.
+// matching kubelet's automount lifecycle. It is minted once at VM
+// boot and not rotated, so its TTL (set at the call site) must be
+// generous enough to outlive warm-time plus the whole job: besides
+// the one-shot dispatch call, the in-VM metrics sampler reuses the
+// same token to POST samples for the job's full duration.
 //
 // The token is also audience-bound. The dispatch endpoint passes
 // the same audience to its TokenReview, so a default-audience SA
@@ -52,9 +54,11 @@ type ClientMinter struct {
 	Client kubernetes.Interface
 
 	// ExpirationSeconds is the token TTL. Real kubelets rotate the
-	// projected token every ~10 min by default; we mint once per
-	// VM boot and don't rotate (the dispatch poll runs once,
-	// minutes after boot at most), so set this generously.
+	// projected token every ~10 min by default; we mint once per VM
+	// boot and don't rotate, so set this generously — the token must
+	// outlive warm-time plus the whole job, since the in-VM metrics
+	// sampler reuses it to POST for the job's full duration, not just
+	// the one-shot dispatch call.
 	ExpirationSeconds int64
 
 	// Audiences scopes the token to specific consumers. Defaults

--- a/server/lib/tuist_web/live/components/runner_job_metrics_charts.ex
+++ b/server/lib/tuist_web/live/components/runner_job_metrics_charts.ex
@@ -21,6 +21,7 @@ defmodule TuistWeb.Components.RunnerJobMetricsCharts do
 
   attr :id, :string, default: "runner-job-metrics"
   attr :metrics, :list, required: true
+  attr :window, :any, default: nil
 
   def runner_job_metrics_charts(assigns) do
     assigns = assign(assigns, :series, build_series(assigns.metrics))
@@ -35,6 +36,7 @@ defmodule TuistWeb.Components.RunnerJobMetricsCharts do
             series={[%{name: dgettext("dashboard_runners", "Usage"), values: @series.cpu}]}
             y_max={100}
             unit="%"
+            window={@window}
           />
           <.metric_chart
             id={"#{@id}-memory"}
@@ -42,6 +44,7 @@ defmodule TuistWeb.Components.RunnerJobMetricsCharts do
             series={[%{name: dgettext("dashboard_runners", "Used"), values: @series.memory}]}
             y_max={@series.memory_total_gb}
             unit=" GB"
+            window={@window}
           />
           <.metric_chart
             id={"#{@id}-network"}
@@ -52,6 +55,7 @@ defmodule TuistWeb.Components.RunnerJobMetricsCharts do
             ]}
             unit=" MiB"
             show_legend
+            window={@window}
           />
           <.metric_chart
             id={"#{@id}-iowait"}
@@ -59,6 +63,7 @@ defmodule TuistWeb.Components.RunnerJobMetricsCharts do
             series={[%{name: dgettext("dashboard_runners", "Wait"), values: @series.iowait}]}
             y_max={100}
             unit="%"
+            window={@window}
           />
           <.metric_chart
             id={"#{@id}-storage"}
@@ -66,6 +71,7 @@ defmodule TuistWeb.Components.RunnerJobMetricsCharts do
             series={[%{name: dgettext("dashboard_runners", "Used"), values: @series.storage}]}
             y_max={100}
             unit="%"
+            window={@window}
           />
         </.card_section>
       </.card>
@@ -75,6 +81,7 @@ defmodule TuistWeb.Components.RunnerJobMetricsCharts do
 
   attr :id, :string, default: "runner-job-metrics-overview"
   attr :metrics, :list, required: true
+  attr :window, :any, default: nil
 
   def runner_job_metrics_overview(assigns) do
     assigns = assign(assigns, :series, build_series(assigns.metrics))
@@ -88,6 +95,7 @@ defmodule TuistWeb.Components.RunnerJobMetricsCharts do
           series={[%{name: dgettext("dashboard_runners", "Usage"), values: @series.cpu}]}
           y_max={100}
           unit="%"
+          window={@window}
         />
         <.metric_chart
           id={"#{@id}-memory"}
@@ -95,6 +103,7 @@ defmodule TuistWeb.Components.RunnerJobMetricsCharts do
           series={[%{name: dgettext("dashboard_runners", "Used"), values: @series.memory}]}
           y_max={@series.memory_total_gb}
           unit=" GB"
+          window={@window}
         />
         <.metric_chart
           id={"#{@id}-network"}
@@ -105,6 +114,7 @@ defmodule TuistWeb.Components.RunnerJobMetricsCharts do
           ]}
           unit=" MiB"
           show_legend
+          window={@window}
         />
       </div>
     </div>
@@ -117,6 +127,7 @@ defmodule TuistWeb.Components.RunnerJobMetricsCharts do
   attr :unit, :string, required: true
   attr :y_max, :any, default: nil
   attr :show_legend, :boolean, default: false
+  attr :window, :any, default: nil
 
   defp metric_chart(assigns) do
     ~H"""
@@ -149,26 +160,44 @@ defmodule TuistWeb.Components.RunnerJobMetricsCharts do
       |> Map.merge(if(assigns.unit == "%", do: %{interval: 25}, else: %{splitNumber: 4}))
       |> maybe_put(:max, assigns.y_max)
 
+    {x_min, x_max, x_labels} = x_axis_bounds(assigns)
+
+    x_axis =
+      %{
+        type: "time",
+        boundaryGap: false,
+        axisLabel: %{
+          color: "var:noora-surface-label-secondary",
+          customValues: x_labels,
+          hideOverlap: true,
+          padding: [10, 0, 0, 0],
+          formatter: "fn:toLocaleTime"
+        }
+      }
+      |> maybe_put(:min, x_min)
+      |> maybe_put(:max, x_max)
+
     maybe_put_legend(
       %{
         grid: %{left: "3%", right: "8%", bottom: bottom_padding(assigns.show_legend), top: "8%", containLabel: true},
-        xAxis: %{
-          type: "time",
-          boundaryGap: false,
-          axisLabel: %{
-            color: "var:noora-surface-label-secondary",
-            customValues: label_values(assigns.series),
-            hideOverlap: true,
-            padding: [10, 0, 0, 0],
-            formatter: "fn:toLocaleTime"
-          }
-        },
+        xAxis: x_axis,
         yAxis: y_axis,
         tooltip: %{valueFormat: "{value}#{assigns.unit}", dateFormat: "minute"}
       },
       assigns.show_legend
     )
   end
+
+  # Anchor the time axis to the job's step window (first step start ->
+  # last step end) so the step-hover bands line up with where the steps
+  # actually ran. Without this the axis auto-scales to the metric-sample
+  # extent, which starts before the first step (pod boot) and can end
+  # before the job does (a truncated sampler run), so steps drift out of
+  # alignment. Falls back to the sample extent when no window is given.
+  defp x_axis_bounds(%{window: %{min: min, max: max}}) when is_integer(min) and is_integer(max) and max > min,
+    do: {min, max, [min, max]}
+
+  defp x_axis_bounds(assigns), do: {nil, nil, label_values(assigns.series)}
 
   defp bottom_padding(true), do: "25%"
   defp bottom_padding(false), do: "10%"

--- a/server/lib/tuist_web/live/runner_job_live.ex
+++ b/server/lib/tuist_web/live/runner_job_live.ex
@@ -253,6 +253,24 @@ defmodule TuistWeb.RunnerJobLive do
   def step_epoch_ms(_), do: nil
 
   @doc """
+  The job's step window as `%{min: start_ms, max: end_ms}` — the first
+  step's start to the last step's end. The metric charts anchor their
+  time axis to this so the step-hover bands line up with where the steps
+  ran, rather than auto-scaling to the metric-sample extent (which
+  starts before the first step during Pod boot and can end before the
+  job does when the sampler run is truncated). Returns `nil` when no
+  step carries timestamps.
+  """
+  def step_window(steps) do
+    starts = steps |> Enum.map(&step_epoch_ms(&1.started_at)) |> Enum.reject(&is_nil/1)
+    ends = steps |> Enum.map(&step_epoch_ms(&1.completed_at)) |> Enum.reject(&is_nil/1)
+
+    if starts != [] and ends != [] do
+      %{min: Enum.min(starts), max: Enum.max(ends)}
+    end
+  end
+
+  @doc """
   Whether the job has any machine-metrics samples to chart. Drives
   the Metrics tab's empty state and gates the Overview chart row.
   """

--- a/server/lib/tuist_web/live/runner_job_live.html.heex
+++ b/server/lib/tuist_web/live/runner_job_live.html.heex
@@ -163,6 +163,7 @@
       <.runner_job_metrics_overview
         :if={TuistWeb.RunnerJobLive.has_machine_metrics?(@machine_metrics)}
         metrics={@machine_metrics}
+        window={TuistWeb.RunnerJobLive.step_window(@steps)}
       />
     </.card>
 
@@ -346,6 +347,7 @@
     <.runner_job_metrics_charts
       :if={TuistWeb.RunnerJobLive.has_machine_metrics?(@machine_metrics)}
       metrics={@machine_metrics}
+      window={TuistWeb.RunnerJobLive.step_window(@steps)}
     />
     <.card
       :if={not TuistWeb.RunnerJobLive.has_machine_metrics?(@machine_metrics)}

--- a/server/test/tuist_web/live/runner_job_live_test.exs
+++ b/server/test/tuist_web/live/runner_job_live_test.exs
@@ -694,4 +694,23 @@ defmodule TuistWeb.RunnerJobLiveTest do
       live(conn, ~p"/#{account.name}/runners/runs/312010/jobs/notanumber")
     end
   end
+
+  describe "step_window/1" do
+    test "spans the first step's start to the last step's end in epoch ms" do
+      steps = [
+        %{started_at: ~U[2026-05-28 10:00:00Z], completed_at: ~U[2026-05-28 10:00:05Z]},
+        %{started_at: ~U[2026-05-28 10:00:05Z], completed_at: ~U[2026-05-28 10:01:00Z]}
+      ]
+
+      assert TuistWeb.RunnerJobLive.step_window(steps) == %{
+               min: DateTime.to_unix(~U[2026-05-28 10:00:00Z], :millisecond),
+               max: DateTime.to_unix(~U[2026-05-28 10:01:00Z], :millisecond)
+             }
+    end
+
+    test "returns nil when there are no steps with timestamps" do
+      assert TuistWeb.RunnerJobLive.step_window([]) == nil
+      assert TuistWeb.RunnerJobLive.step_window([%{started_at: nil, completed_at: nil}]) == nil
+    end
+  end
 end


### PR DESCRIPTION
## What

Three fixes that make the runner-job **machine-metrics charts** trustworthy — the step↔chart correlation, and metric coverage for the whole job. Originally split across #11595/#11600/#11601; folded here into one.

## 1. Step ↔ chart axis alignment (server)

`fix(server): anchor runner metrics chart axis to the job's step window`

Hovering a step highlighted the wrong part of the chart because the axis auto-scaled to the metric-sample extent, which drifts from the job's step timeline. Anchor the chart x-axis to the job's `[min step start, max step end]` window so the step bands and the metric line share one timeline. Covered by a LiveView test.

## 2. Long-job truncation — SA token TTL (infra / tart-kubelet)

`fix(infra): give runner SA tokens an 8h TTL so long-job metrics don't truncate`

The macOS sampler reuses the per-Pod dispatch SA token to POST for the whole job, but `tart-kubelet` mints it **once at boot** with a **1h TTL** and never rotates it. A warm Pod ages the token before claiming, so long jobs expired mid-run → 401 → charts cut off partway (a 17-min job whose metrics stopped 10 min in). Bump `ExpirationSeconds 3600 → 28800`. The token is Pod-bound, so a longer TTL has no real security cost.

## 3. Step/metric timeline mismatch — clock skew (infra / runner-image)

`fix(infra): NTP-step the macOS runner clock before the job starts`

Some jobs' step timestamps were minutes early relative to the metrics. Root cause: a golden-base VM can be handed a job seconds after boot, before macOS `timed` has synced a clock that started minutes behind. The GitHub runner and `metrics-poll.sh` both stamp off that clock while `timed` corrects it mid-run, so the two land on different timelines. Diagnosed on job `84477965485`: the runner truly started ~07:30:56 (claim, first server-received POST, and accurate-clock samples all agree), yet GitHub steps claim `07:27:12 → 07:33:18` — 3m44s early at the start, ~5s at the end (the fingerprint of a boot-skewed clock correcting mid-run). Force `sudo sntp -sS -t 5 time.apple.com` right after dispatch succeeds (network up) and before the runner + sampler start. macOS-only.

## Validation

- **Server**: LiveView test for the step-window axis; `mix compile --warnings-as-errors` / `credo` clean; formatted.
- **tart-kubelet (Go)**: `go build ./...`, `go vet`, `gofmt` clean.
- **runner-image (shell)**: `shellcheck` / `bash -n` clean; `sntp` flags confirmed against `man sntp`.

## Rollout notes

- Server axis fix ships with the next server deploy.
- Token TTL takes effect for Pods created after the `tart-kubelet` roll; the clock sync for VMs booted from the next runner-image roll — both apply as the fleet turns over, not instantly.
- One assumption to confirm: the macOS VM can reach `time.apple.com` over UDP/123. It's fail-open (falls back to `timed`), but if egress is locked down we'd point it at an in-cluster NTP source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
