### PR TITLE
[FEAT] Added bundle support to AppClip

### DIFF
--- a/cli/Sources/TuistGenerator/Linter/GraphLinter.swift
+++ b/cli/Sources/TuistGenerator/Linter/GraphLinter.swift
@@ -548,6 +548,7 @@ public struct GraphLinter: GraphLinting {
             LintableTarget(platform: .iOS, product: .framework),
             LintableTarget(platform: .iOS, product: .staticFramework),
             LintableTarget(platform: .iOS, product: .appExtension),
+            LintableTarget(platform: .iOS, product: .bundle),
             LintableTarget(platform: .macOS, product: .macro),
         ],
         LintableTarget(platform: .iOS, product: .extensionKitExtension): [

--- a/cli/Tests/TuistGeneratorAcceptanceTests/GenerateAcceptanceTests.swift
+++ b/cli/Tests/TuistGeneratorAcceptanceTests/GenerateAcceptanceTests.swift
@@ -909,6 +909,11 @@ struct GenerateAcceptanceTestiOSAppWithAppClip {
             destination: "Debug-iphonesimulator",
             extension: "AppClip1Widgets"
         )
+        try await XCTAssertProductWithDestinationContainsResource(
+            "AppClip1.app",
+            destination: "Debug-iphonesimulator",
+            resource: "Bundle.bundle/dummy.jpg"
+        )
     }
 }
 

--- a/cli/Tests/TuistGeneratorTests/Linter/GraphLinterTests.swift
+++ b/cli/Tests/TuistGeneratorTests/Linter/GraphLinterTests.swift
@@ -368,6 +368,32 @@ struct GraphLinterTests {
         #expect(result.isEmpty == true)
     }
 
+    @Test(.inTemporaryDirectory, .withMockedXcodeController) func lint_appClip_canDependOnBundle() async throws {
+        // Given
+        let path: AbsolutePath = "/project"
+        let appClip = Target.empty(name: "app_clip", product: .appClip)
+        let bundle = Target.empty(name: "bundle", product: .bundle)
+        let project = Project.empty(path: path)
+
+        let dependencies: [GraphDependency: Set<GraphDependency>] = [
+            .target(name: appClip.name, path: path): Set([.target(name: bundle.name, path: path)]),
+            .target(name: bundle.name, path: path): Set([]),
+        ]
+
+        let graph = Graph.test(
+            path: path,
+            projects: [path: project],
+            dependencies: dependencies
+        )
+        let graphTraverser = GraphTraverser(graph: graph)
+
+        // When
+        let result = try await subject.lint(graphTraverser: graphTraverser, configGeneratedProjectOptions: .test())
+
+        // Then
+        #expect(result.isEmpty == true)
+    }
+
     @Test(.inTemporaryDirectory, .withMockedXcodeController) func lint_frameworkDependsOnBundle() async throws {
         // Given
         let path: AbsolutePath = "/project"

--- a/examples/xcode/generated_ios_app_with_appclip/Project.swift
+++ b/examples/xcode/generated_ios_app_with_appclip/Project.swift
@@ -45,6 +45,7 @@ let project = Project(
                 .target(name: "Framework"),
                 .target(name: "StaticFramework"),
                 .target(name: "AppClip1Widgets"),
+                .target(name: "Bundle"),
             ]
         ),
         .target(
@@ -86,6 +87,13 @@ let project = Project(
             dependencies: [
                 .target(name: "StaticFramework"),
             ]
+        ),
+        .target(
+            name: "Bundle",
+            destinations: .iOS,
+            product: .bundle,
+            bundleId: "dev.tuist.App.Bundle",
+            resources: "Bundle/**"
         ),
     ]
 )


### PR DESCRIPTION
Resolves 
-https://github.com/tuist/tuist/issues/11596

### Description
When declaring a .bundle target and making an .appClip depend on it, Tuist would reject the graph with a lint error — even though App Clips fully support resources and can embed bundles.

The root cause was a one-line omission in GraphLinter.swift. PR #6415 added .bundle as a valid dependency for .appExtension targets but the same entry was never added for .appClip.

The rest of the pipeline (resource embedding, Bundle.module accessor generation, canEmbedBundles) already handles .appClip correctly — only the linter was blocking it.

### How to test locally
1. Generate `appClip` target with `bundle` as dependency
2. Run `generate` command, it will be successful.
3. Open workspace and run
4. Navigate to the build products of the build, go inside the package contents

> Document how to test your changes locally
