### PR TITLE
feat(infra): grant the JIT write tier mutate access on Kura CRs

### DIFF
--- a/infra/helm/pomerium/templates/access-tiers.yaml
+++ b/infra/helm/pomerium/templates/access-tiers.yaml
@@ -105,3 +105,25 @@ rules:
   - apiGroups: ["rbac.authorization.k8s.io"]
     resources: ["clusterroles", "clusterrolebindings", "roles", "rolebindings"]
     verbs: ["get", "list", "watch"]
+---
+# Write extension to the `edit` tier, the mutate analog of
+# `tuist-view-infra-read`. The upstream `edit` ClusterRole covers core/apps
+# resources but not custom resources, so a JIT-elevated `tuist-<env>-write`
+# identity can mutate Pods/StatefulSets/PVCs yet not the server-managed Kura
+# CRs (KuraInstance/KuraGateway). Those are reconciled from the control plane,
+# so operators normally leave them alone — but a region cutover or cleanup
+# sometimes needs to recreate them so they re-render (e.g. onto a new node
+# pool). This aggregates into `edit` so an active write elevation can do that
+# without the break-glass kubeconfig. Scoped to `kura.tuist.dev`; CAPI/infra
+# CRs stay read-only for the edit tier (scaling fleets is a heavier action).
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: tuist-edit-kura-write
+  labels:
+    {{- include "pomerium.labels" . | nindent 4 }}
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+rules:
+  - apiGroups: ["kura.tuist.dev"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete", "deletecollection"]


### PR DESCRIPTION
## What

Adds `tuist-edit-kura-write`, a ClusterRole that aggregates into the built-in `edit` role and grants the full mutate verb set (`get,list,watch,create,update,patch,delete,deletecollection`) on `kura.tuist.dev` resources (`KuraInstance`, `KuraGateway`). Lives in `infra/helm/pomerium/templates/access-tiers.yaml` alongside the existing tier bindings.

## Why

The `tuist-<env>-write` group — what a Slack/Tailscale JIT elevation grants — binds to the upstream `edit` ClusterRole. `edit` covers core and apps resources but **not** custom resources, so an elevated operator can `delete pods/statefulsets/persistentvolumeclaims` but gets `no` on `delete kurainstances`/`kuragateways`. Reads on those CRs already work, but only because they come from the separate `tuist-view-infra-read` role that aggregates into `view`.

That gap meant the only way to mutate a Kura CR in production was the break-glass `system:masters` kubeconfig. We hit exactly this while completing the eu-central bare-metal cutover: the customer instances were pinned to the old cloud node pool, and the clean fix was to delete the `KuraInstance`/`KuraGateway` CRs so the reconciler re-renders them onto the bare-metal pool. That's a routine, reason-gated maintenance action; it shouldn't require break-glass.

## How

Mirrors the existing `tuist-view-infra-read` pattern exactly, but on the write side: a ClusterRole labelled `rbac.authorization.k8s.io/aggregate-to-edit: "true"` so `edit` (and therefore every `tuist-<env>-write` binding) picks it up automatically, no new binding needed. Per-env isolation is unchanged — a prod elevation still can't touch staging.

Scope is deliberately limited to `kura.tuist.dev`. CAPI/infra CRs (`cluster.x-k8s.io`, `infrastructure.cluster.x-k8s.io`) stay read-only for the edit tier, since scaling or deleting fleet machines is a heavier action that should keep its higher bar (break-glass).

## Validation

`helm template pomerium infra/helm/pomerium --set tuistEnv=production` renders the new ClusterRole with the `aggregate-to-edit` label and the `kura.tuist.dev` rule. Once deployed, `kubectl auth can-i delete kurainstances -n kura` flips from `no` to `yes` for an identity carrying an active `tuist-<env>-write` elevation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)