### PR TITLE
fix(infra): tolerate the kura-cache taint on bare-metal Kura gateways

### DIFF
--- a/infra/helm/tuist/crds/kura.tuist.dev_kuragateways.yaml
+++ b/infra/helm/tuist/crds/kura.tuist.dev_kuragateways.yaml
@@ -82,6 +82,11 @@ spec:
                     type: string
                 hostNetwork:
                   type: boolean
+                tolerations:
+                  type: array
+                  items:
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
             status:
               type: object
               properties:

--- a/infra/kura-controller/api/v1alpha1/kuragateway_types.go
+++ b/infra/kura-controller/api/v1alpha1/kuragateway_types.go
@@ -19,6 +19,12 @@ type KuraGatewaySpec struct {
 	// Bare-metal nodes (Dedibox) have no Hetzner LB, so the gateway binds
 	// the node's public IP directly.
 	HostNetwork bool `json:"hostNetwork,omitempty"`
+	// Tolerations let the gateway nginx schedule onto tainted nodes. Bare-metal
+	// cache nodes carry tuist.dev/kura-cache=true:NoSchedule to keep general
+	// workloads off the box; the host-network gateway has to run there (it binds
+	// the node's public IP), so it needs the matching toleration or it never
+	// schedules and the region has no ingress.
+	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
 }
 
 type KuraGatewayStatus struct {

--- a/infra/kura-controller/api/v1alpha1/zz_generated.deepcopy.go
+++ b/infra/kura-controller/api/v1alpha1/zz_generated.deepcopy.go
@@ -77,6 +77,12 @@ func (in *KuraGatewaySpec) DeepCopyInto(out *KuraGatewaySpec) {
 			out.LoadBalancerAnnotations[key] = value
 		}
 	}
+	if in.Tolerations != nil {
+		out.Tolerations = make([]corev1.Toleration, len(in.Tolerations))
+		for i := range in.Tolerations {
+			in.Tolerations[i].DeepCopyInto(&out.Tolerations[i])
+		}
+	}
 }
 
 func (in *KuraGatewaySpec) DeepCopy() *KuraGatewaySpec {

--- a/infra/kura-controller/controllers/gateway_host_network_test.go
+++ b/infra/kura-controller/controllers/gateway_host_network_test.go
@@ -42,6 +42,25 @@ func TestGatewayPodTemplateDefaultNetwork(t *testing.T) {
 	}
 }
 
+// A bare-metal cache node carries tuist.dev/kura-cache=true:NoSchedule, and the
+// host-network gateway is pinned to that node (it binds the box's public IP), so
+// the pod template must carry the toleration or the gateway never schedules and
+// the region has no ingress.
+func TestGatewayPodTemplatePropagatesTolerations(t *testing.T) {
+	gateway := gatewayFixture(true)
+	gateway.Spec.Tolerations = []corev1.Toleration{{
+		Key:      "tuist.dev/kura-cache",
+		Operator: corev1.TolerationOpExists,
+		Effect:   corev1.TaintEffectNoSchedule,
+	}}
+	pod := gatewayPodTemplate(gateway, defaultGatewayServiceAccount)
+	if !slices.ContainsFunc(pod.Spec.Tolerations, func(tol corev1.Toleration) bool {
+		return tol.Key == "tuist.dev/kura-cache" && tol.Effect == corev1.TaintEffectNoSchedule
+	}) {
+		t.Errorf("gateway pod must carry the kura-cache toleration, got %+v", pod.Spec.Tolerations)
+	}
+}
+
 // A host-network gateway has no LoadBalancer to prepend a PROXY header, so
 // proxy-protocol must be off (it would mangle every connection); LB-fronted
 // gateways keep it on.

--- a/infra/kura-controller/controllers/kuragateway_controller.go
+++ b/infra/kura-controller/controllers/kuragateway_controller.go
@@ -286,6 +286,7 @@ func gatewayPodTemplate(gateway *kurav1alpha1.KuraGateway, serviceAccountName st
 			DNSPolicy:          gatewayDNSPolicy(gateway),
 			ServiceAccountName: serviceAccountName,
 			NodeSelector:       gateway.Spec.PodNodeSelector(),
+			Tolerations:        gateway.Spec.Tolerations,
 			Containers: []corev1.Container{{
 				Name:            "controller",
 				Image:           gatewayControllerImage(gateway),

--- a/server/lib/tuist/kura/provisioner/kubernetes_controller.ex
+++ b/server/lib/tuist/kura/provisioner/kubernetes_controller.ex
@@ -267,6 +267,7 @@ defmodule Tuist.Kura.Provisioner.KubernetesController do
           "controllerImage" => gateway_controller_image(region),
           "replicas" => gateway_replicas(region),
           "nodeSelector" => node_selector(region),
+          "tolerations" => tolerations(region),
           "loadBalancerAnnotations" => gateway_load_balancer_annotations(gateway_name, region)
         }
         |> maybe_put_host_network(region)

--- a/server/test/tuist/kura/provisioner/kubernetes_controller_test.exs
+++ b/server/test/tuist/kura/provisioner/kubernetes_controller_test.exs
@@ -391,6 +391,30 @@ defmodule Tuist.Kura.Provisioner.KubernetesControllerTest do
       refute Map.has_key?(gateway_manifest["spec"], "loadBalancerAnnotations")
     end
 
+    test "propagates the region tolerations onto the gateway so it schedules on tainted bare-metal nodes" do
+      tolerations = [%{"key" => "tuist.dev/kura-cache", "operator" => "Exists", "effect" => "NoSchedule"}]
+
+      gateway_manifest =
+        KubernetesController.gateway_manifest(
+          %{name: "kgw-test-us-east", ingress_class_name: "kura-us-east-kgw-test-us-east"},
+          %{name: "tuist"},
+          us_east_region(%{gateway: :host_network, tolerations: tolerations})
+        )
+
+      assert gateway_manifest["spec"]["tolerations"] == tolerations
+    end
+
+    test "omits gateway tolerations when the region declares none" do
+      gateway_manifest =
+        KubernetesController.gateway_manifest(
+          %{name: "kgw-test-us-east", ingress_class_name: "kura-us-east-kgw-test-us-east"},
+          %{name: "tuist"},
+          us_east_region(%{gateway: :host_network})
+        )
+
+      refute Map.has_key?(gateway_manifest["spec"], "tolerations")
+    end
+
     test "uses the region-configured Tuist server URL for managed eu-central Kura instances" do
       stub(Tuist.Environment, :app_url, fn -> "https://tuist.dev" end)
 


### PR DESCRIPTION
## What

Gives the host-network regional Kura gateway the `tuist.dev/kura-cache` toleration so it can schedule onto the bare-metal cache node, mirroring how the cache instance pods already get it.

## Why

Bare-metal cache nodes (Dedibox/OVH) carry `tuist.dev/kura-cache=true:NoSchedule` to keep general workloads off the box. The cache **instance** pods tolerate it — `regions.ex` puts the toleration in `provisioner_config`, and `kubernetes_controller.ex` threads it into the KuraInstance manifest (`"tolerations" => tolerations(region)`), so they schedule and run.

The **gateway** never got the same treatment:
- `gateway_manifest` set `nodeSelector` and `hostNetwork` but not tolerations.
- `KuraGatewaySpec` had no `Tolerations` field, and `gatewayPodTemplate` never set one.

So on a bare-metal region the ingress-nginx gateway is pinned (correctly) to the one `kura-dedibox` node — it must run there to bind the box's public IP — but can't tolerate that node's taint. Result observed in production after the eu-central cutover:

```
kgw-...-eu-central-controller   0/2   FailedScheduling
0/28 nodes are available: 20 node(s) had untolerated taint(s),
7 node(s) didn't match Pod's node affinity/selector.
```

Both replicas sit unschedulable, the region has no ingress, and the public cache endpoint never serves — even though the cache StatefulSet pods are healthy on the same node. This affects **every public bare-metal region** (eu-central, us-east, us-west), and it also keeps the server's activation check from confirming the endpoint, so the dashboard stays stuck at "Deploying".

There is no durable workaround: patching the ingress-nginx Deployment directly is reverted by the kura-controller on its next reconcile, and the CR had no field to carry the intent. It needs the code fix.

## How

Mirrors the existing cache-pod path exactly:

- **kura-controller**
  - `KuraGatewaySpec` gains `Tolerations []corev1.Toleration` (`json:"tolerations,omitempty"`).
  - `gatewayPodTemplate` sets `Tolerations: gateway.Spec.Tolerations`.
  - deepcopy + the hand-maintained CRD schema (`kura.tuist.dev_kuragateways.yaml`) updated to match.
- **server**
  - `gateway_manifest` threads `"tolerations" => tolerations(region)` — the same helper (`tolerations/1`) the KuraInstance manifest already uses. `nil` is dropped by the existing `Enum.reject`, so cloud/LB regions are unaffected.

Since `regions.ex` already declares the `tuist.dev/kura-cache` toleration in `provisioner_config` for the managed regions, no region config change is needed — the gateway now simply picks up what the cache pods already had.

## Validation

- `go build ./...`, `go vet`, and the kura-controller gateway tests pass, including a new `TestGatewayPodTemplatePropagatesTolerations`.
- New Elixir tests assert `gateway_manifest` carries the toleration on a bare-metal region and omits it when the region declares none. (Local `mix test` run is pending; the Go side and static checks are green.)
- CRD `tolerations` schema mirrors the kurainstances CRD (`type: array` / `items: object` with `x-kubernetes-preserve-unknown-fields`).

Once deployed (kura-controller image + server), the eu-central gateway schedules onto the Dedibox box and the region serves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)