### PR TITLE
fix(infra): 8h runner SA token TTL so long-job metrics don't truncate

### DIFF
--- a/infra/tart-kubelet/cmd/tart-kubelet/main.go
+++ b/infra/tart-kubelet/cmd/tart-kubelet/main.go
@@ -273,9 +273,14 @@ func main() {
 		Tart:               tartClient,
 		Resolver:           resolver,
 		Store:              store,
-		TokenMinter:        &satoken.ClientMinter{Client: typedClient, ExpirationSeconds: 3600},
-		GC:                 gcCollector,
-		Recorder:           mgr.GetEventRecorderFor("tart-kubelet"),
+		// 8h TTL: minted once at boot and not rotated, the token must
+		// outlive warm-time + the whole job, because the in-VM metrics
+		// sampler reuses it to POST for the job's full duration (a 1h TTL
+		// expired mid-run on long jobs and truncated their charts). It's
+		// Pod-bound, so it dies when the Pod is reaped regardless.
+		TokenMinter: &satoken.ClientMinter{Client: typedClient, ExpirationSeconds: 28800},
+		GC:          gcCollector,
+		Recorder:    mgr.GetEventRecorderFor("tart-kubelet"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "setup pod reconciler")
 		os.Exit(1)

--- a/infra/tart-kubelet/internal/satoken/satoken.go
+++ b/infra/tart-kubelet/internal/satoken/satoken.go
@@ -13,9 +13,11 @@
 //
 // The token is bound to the Pod (via TokenRequestSpec.BoundObjectRef)
 // so the apiserver invalidates it the moment the Pod is deleted —
-// matching kubelet's automount lifecycle. TTL is short (10 min); the
-// caller is responsible for re-running this on each reconcile if
-// the Pod is long-running.
+// matching kubelet's automount lifecycle. It is minted once at VM
+// boot and not rotated, so its TTL (set at the call site) must be
+// generous enough to outlive warm-time plus the whole job: besides
+// the one-shot dispatch call, the in-VM metrics sampler reuses the
+// same token to POST samples for the job's full duration.
 //
 // The token is also audience-bound. The dispatch endpoint passes
 // the same audience to its TokenReview, so a default-audience SA
@@ -52,9 +54,11 @@ type ClientMinter struct {
 	Client kubernetes.Interface
 
 	// ExpirationSeconds is the token TTL. Real kubelets rotate the
-	// projected token every ~10 min by default; we mint once per
-	// VM boot and don't rotate (the dispatch poll runs once,
-	// minutes after boot at most), so set this generously.
+	// projected token every ~10 min by default; we mint once per VM
+	// boot and don't rotate, so set this generously — the token must
+	// outlive warm-time plus the whole job, since the in-VM metrics
+	// sampler reuses it to POST for the job's full duration, not just
+	// the one-shot dispatch call.
 	ExpirationSeconds int64
 
 	// Audiences scopes the token to specific consumers. Defaults


### PR DESCRIPTION
## What

Bumps the per-Pod runner ServiceAccount token TTL that `tart-kubelet` mints from **1h → 8h**, so long-running jobs' machine-metrics charts stop truncating partway through.

## Why

The macOS runner metrics sampler (`metrics-poll.sh`) reuses the same per-Pod dispatch SA token — staged into the VM at `/etc/tuist-sa-token` — to POST samples for the **whole job**. But `tart-kubelet` mints that token **once at VM boot** and never rotates it, with a **1h TTL** (`satoken.go`). A warm Pod ages the token while it sits idle in the pool, so by the time it claims a long job the token has little life left; once it expires the sampler's POSTs get 401, samples stop being recorded, and the chart just ends mid-job.

Confirmed against 30 recent macOS jobs: short jobs are well-covered, but long ones truncate, and sample counts fall far below `duration / 15s`. Examples: a 17-min job whose metrics stopped 10 min in; a 14-min job that stopped 4 min early.

## How

`ExpirationSeconds: 3600 → 28800` in `cmd/tart-kubelet/main.go`. `satoken.go` already advised setting this "generously" *because* the token isn't rotated — 1h was only ever correct when dispatch (a one-shot call minutes after boot) was the token's sole consumer. Now the metrics sampler reuses it for the job's full duration, so it must outlive warm-time + job.

The token is **Pod-bound** (`BoundObjectRef`), so the apiserver invalidates it the instant the Pod is reaped regardless of TTL — a longer TTL carries no real security cost, it just needs to survive the Pod's active life. Updated the stale doc comments to reflect the metrics-reuse rationale.

## Validation

- `go build ./...`, `go vet ./...`, `gofmt` all clean.
- No behavior change beyond the TTL value; the token is still audience-scoped (`tuist-runners-dispatch`), principal-checked, and Pod-bound.

## Rollout / scope

- Takes effect for Pods created **after** the `tart-kubelet` rollout; existing warm Pods keep their old 1h token until recycled.
- This fixes the **end-truncation** class. A separate **late-start** case (some jobs' metrics begin minutes in) is still under investigation — it isn't token-related (it's missing *early* samples, most likely VM clock/NTP skew at boot), and will be handled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
