### PR TITLE
feat(server): enable the Kura cache surface by default on self-hosted, and fix self-hosting docs

### DIFF
--- a/infra/helm/tuist/templates/server-deployment.yaml
+++ b/infra/helm/tuist/templates/server-deployment.yaml
@@ -279,7 +279,7 @@ spec:
                   name: {{ $secretName }}
                   key: object-storage-secret-key
             {{- end }}
-            {{- if .Values.cache.enabled }}
+            {{- if or .Values.cache.enabled .Values.server.cacheEndpointUrl }}
             - name: TUIST_CACHE_ENDPOINTS
               value: {{ .Values.server.cacheEndpointUrl | default (printf "http://%s:%v" (include "tuist.componentName" (dict "root" . "component" "cache")) .Values.cache.service.port) | quote }}
             {{- end }}

--- a/server/lib/tuist/feature_flags.ex
+++ b/server/lib/tuist/feature_flags.ex
@@ -15,14 +15,18 @@ defmodule Tuist.FeatureFlags do
   end
 
   @doc """
-  Whether the managed Kura deployment surface (the per-account Kura
-  servers and the Usage dashboard) should be visible for the given
-  account. Mirrors the inline check already used in
-  `account_settings_live` so the sidebar entry, the LiveView guard,
-  and the settings page all answer the same question.
+  Whether the Kura surface (the per-account Kura servers, the
+  self-hosted cache management, and the Usage dashboard) should be
+  visible for the given account. Self-hosted deployments (including
+  dev/test, which are also not `tuist_hosted?`) always see it, mirroring
+  `Tuist.Billing.Entitlements` where the deployment's license is the
+  entitlement; the hosted server gates it behind the `:kura` FunWithFlags
+  toggle for the actor. Callers should use this rather than checking the
+  flag inline so the sidebar entry, the LiveView guards, and the settings
+  page all answer the same question.
   """
   def kura_enabled?(account) do
-    Environment.dev?() or FunWithFlags.enabled?(:kura, for: account)
+    not Environment.tuist_hosted?() or FunWithFlags.enabled?(:kura, for: account)
   end
 
   @doc """

--- a/server/lib/tuist_web/live/account_settings_live.ex
+++ b/server/lib/tuist_web/live/account_settings_live.ex
@@ -321,6 +321,7 @@ defmodule TuistWeb.AccountSettingsLive do
     |> assign(:kura_regions, [])
     |> assign(:available_kura_regions, [])
     |> assign(:latest_kura_version, nil)
+    |> assign(:managed_kura_visible?, false)
     |> assign(:add_kura_server_form, default_kura_server_form([]))
   end
 
@@ -345,6 +346,7 @@ defmodule TuistWeb.AccountSettingsLive do
     |> assign(:kura_regions, regions)
     |> assign(:available_kura_regions, available_regions)
     |> assign(:latest_kura_version, latest)
+    |> assign(:managed_kura_visible?, servers != [] or available_regions != [])
     |> assign(:add_kura_server_form, default_kura_server_form(available_regions))
   end
 

--- a/server/lib/tuist_web/live/account_settings_live.ex
+++ b/server/lib/tuist_web/live/account_settings_live.ex
@@ -10,7 +10,7 @@ defmodule TuistWeb.AccountSettingsLive do
   alias Tuist.Accounts.Account
   alias Tuist.Accounts.AccountCacheEndpoint
   alias Tuist.Authorization
-  alias Tuist.Environment
+  alias Tuist.FeatureFlags
   alias Tuist.Kura
   alias Tuist.Kura.Regions
   alias Tuist.Kura.Server
@@ -349,7 +349,7 @@ defmodule TuistWeb.AccountSettingsLive do
   end
 
   defp kura_enabled?(account) do
-    Environment.dev?() or FunWithFlags.enabled?(:kura, for: account)
+    FeatureFlags.kura_enabled?(account)
   end
 
   defp available_kura_regions(regions, servers) do

--- a/server/lib/tuist_web/live/account_settings_live.html.heex
+++ b/server/lib/tuist_web/live/account_settings_live.html.heex
@@ -12,7 +12,7 @@
       region_form={@region_form}
       selected_account={@selected_account}
     />
-    <%= if @kura_enabled and (@kura_servers != [] or @available_kura_regions != []) do %>
+    <%= if @managed_kura_visible? do %>
       <.kura_servers_section
         kura_servers={@kura_servers}
         available_kura_regions={@available_kura_regions}
@@ -178,7 +178,7 @@
       region_form={@region_form}
       selected_account={@selected_account}
     />
-    <%= if @kura_enabled and (@kura_servers != [] or @available_kura_regions != []) do %>
+    <%= if @managed_kura_visible? do %>
       <.kura_servers_section
         kura_servers={@kura_servers}
         available_kura_regions={@available_kura_regions}

--- a/server/lib/tuist_web/live/account_settings_live.html.heex
+++ b/server/lib/tuist_web/live/account_settings_live.html.heex
@@ -12,7 +12,7 @@
       region_form={@region_form}
       selected_account={@selected_account}
     />
-    <%= if @kura_enabled do %>
+    <%= if @kura_enabled and (@kura_servers != [] or @available_kura_regions != []) do %>
       <.kura_servers_section
         kura_servers={@kura_servers}
         available_kura_regions={@available_kura_regions}
@@ -178,7 +178,7 @@
       region_form={@region_form}
       selected_account={@selected_account}
     />
-    <%= if @kura_enabled do %>
+    <%= if @kura_enabled and (@kura_servers != [] or @available_kura_regions != []) do %>
       <.kura_servers_section
         kura_servers={@kura_servers}
         available_kura_regions={@available_kura_regions}

--- a/server/lib/tuist_web/live/cache_live.ex
+++ b/server/lib/tuist_web/live/cache_live.ex
@@ -196,6 +196,7 @@ defmodule TuistWeb.CacheLive do
     |> assign(:regions, [])
     |> assign(:available_regions, [])
     |> assign(:latest_version, nil)
+    |> assign(:managed_cache_visible?, false)
     |> assign(:add_cache_server_form, default_server_form([]))
   end
 
@@ -220,6 +221,7 @@ defmodule TuistWeb.CacheLive do
     |> assign(:regions, regions)
     |> assign(:available_regions, available_regions)
     |> assign(:latest_version, latest)
+    |> assign(:managed_cache_visible?, servers != [] or available_regions != [])
     |> assign(:add_cache_server_form, default_server_form(available_regions))
   end
 
@@ -587,12 +589,6 @@ defmodule TuistWeb.CacheLive do
             disabled={is_nil(@latest_version)}
           />
         </:col>
-        <:empty_state>
-          <.table_empty_state
-            title={dgettext("dashboard_account", "No cache servers available")}
-            subtitle={dgettext("dashboard_account", "No regions are available for this account yet.")}
-          />
-        </:empty_state>
       </.table>
     </.card_section>
     """

--- a/server/lib/tuist_web/live/cache_live.ex
+++ b/server/lib/tuist_web/live/cache_live.ex
@@ -8,7 +8,7 @@ defmodule TuistWeb.CacheLive do
   alias Phoenix.HTML.Form
   alias Tuist.Authorization
   alias Tuist.Billing.Entitlements
-  alias Tuist.Environment
+  alias Tuist.FeatureFlags
   alias Tuist.Kura
   alias Tuist.Kura.Regions
   alias Tuist.Kura.Registrations
@@ -242,7 +242,7 @@ defmodule TuistWeb.CacheLive do
   end
 
   defp cache_enabled?(account) do
-    Environment.dev?() or FunWithFlags.enabled?(:kura, for: account)
+    FeatureFlags.kura_enabled?(account)
   end
 
   defp available_regions(regions, servers) do

--- a/server/lib/tuist_web/live/cache_live.html.heex
+++ b/server/lib/tuist_web/live/cache_live.html.heex
@@ -11,7 +11,7 @@
 
   <%= if @cache_enabled do %>
     <.cache_servers_section
-      :if={@servers != [] or @available_regions != []}
+      :if={@managed_cache_visible?}
       servers={@servers}
       available_regions={@available_regions}
       add_cache_server_form={@add_cache_server_form}

--- a/server/lib/tuist_web/live/cache_live.html.heex
+++ b/server/lib/tuist_web/live/cache_live.html.heex
@@ -11,6 +11,7 @@
 
   <%= if @cache_enabled do %>
     <.cache_servers_section
+      :if={@servers != [] or @available_regions != []}
       servers={@servers}
       available_regions={@available_regions}
       add_cache_server_form={@add_cache_server_form}

--- a/server/priv/docs/en/guides/cache/self-host.md
+++ b/server/priv/docs/en/guides/cache/self-host.md
@@ -53,13 +53,20 @@ The key difference in configuration is that the **bridged** topology uses **enro
 
 ## Create a control-plane client {#control-plane-client}
 
-Every node authenticates to Tuist with an account-scoped control-plane client.
+A node uses an account-scoped control-plane client to authenticate cache requests (token introspection), report to the dashboard, and deliver usage. It is **not** how clients are routed to your nodes (see [How clients reach your nodes](#routing)), so a single node on a trusted network can run without one.
 
-1. Open your account's **Cache** page.
+1. Open your account's **Cache** page. If you don't see it, enable the `kura` feature flag for the account. On a self-hosted Tuist server the Enterprise entitlement is granted automatically, so the flag is the only prerequisite.
 2. Choose **Generate credential**.
 3. Copy the `client_id` and the one-time `secret`.
 
 The server derives the account from this credential, so the node never asserts its own tenant. Rotate or revoke it from the same page.
+
+## How clients reach your nodes {#routing}
+
+How the Tuist CLI is pointed at your nodes depends on which server your nodes report to:
+
+- **Hosted Tuist server (`tuist.dev`).** The server routes clients to your nodes automatically from their registration heartbeats. Set `KURA_REGISTRATION_URL` and `KURA_ADVERTISED_HTTP_URL` on each node (below), and the advertised URL is handed to the CLI once the node is ready.
+- **Self-hosted Tuist server.** You tell the server which cache endpoints to advertise by setting `TUIST_CACHE_ENDPOINTS` (Helm `server.cacheEndpointUrl`) to your node's client-facing URL, comma-separated for multiple nodes. Registration heartbeats still populate the **Cache** page, but they do not drive routing on a self-hosted server.
 
 ## Bridged setup {#bridged-setup}
 
@@ -131,7 +138,10 @@ services:
       - "4000:4000"
       - "7443:7443"
     environment:
-      # Register with Tuist (dashboard, CLI routing, usage, introspection)
+      # Report to Tuist: dashboard visibility, usage, and token introspection (cache auth).
+      # On a self-hosted server these do not drive routing (see the Routing section), so the
+      # control-plane client and KURA_REGISTRATION_URL/KURA_ADVERTISED_HTTP_URL are optional
+      # there. KURA_TENANT_ID is always required.
       KURA_TENANT_ID: "<account-handle>"
       KURA_CONTROL_PLANE_URL: "https://tuist.dev"
       KURA_REGISTRATION_URL: "https://tuist.dev/_internal/kura/mesh/registrations"
@@ -143,7 +153,9 @@ services:
       KURA_NODE_URL: "https://kura-1.acme.internal:7443"
       KURA_PEERS: "https://kura-2.acme.internal:7443,https://kura-3.acme.internal:7443"
 
-      # YOU provide these certs: your CA and a leaf per node
+      # Peer mTLS secures node-to-node traffic, so it only applies with more than one node.
+      # A single node has no peers: omit these three and set KURA_NODE_URL to http://...:7443
+      # (the peer URL must be http when peer TLS is off).
       KURA_INTERNAL_TLS_CA_CERT_PATH: "/tls/ca.pem"
       KURA_INTERNAL_TLS_CERT_PATH: "/tls/tls.crt"
       KURA_INTERNAL_TLS_KEY_PATH: "/tls/tls.key"
@@ -169,22 +181,24 @@ volumes:
   kura-data: {}
 ```
 
-What you provide that the bridged path does not: your **own peer TLS** mounted at `/tls` (a CA plus a leaf certificate and key, where a single node can use a self-signed certificate while multiple nodes must share a CA so they trust each other), and `KURA_PEERS` describing your topology. A single standalone node needs no `KURA_PEERS`; it just serves and registers.
+What you provide that the bridged path does not: for a multi-node mesh, your **own peer TLS** mounted at `/tls` (a CA plus a leaf certificate and key per node, sharing a CA so the nodes trust each other) and `KURA_PEERS` describing your topology. A single standalone node needs neither: with no peers, nothing travels over the peer plane, so omit `KURA_INTERNAL_TLS_*` and `KURA_PEERS` and set `KURA_NODE_URL` to `http://...:7443`.
 
 ## What each topology requires {#requirements-summary}
 
 | You provide | Bridged | Standalone |
 |---|---|---|
-| Control-plane client (`client_id` / `secret`) | Yes | Yes |
-| `KURA_ADVERTISED_HTTP_URL` / `KURA_NODE_URL` | Yes | Yes |
+| Control-plane client (`client_id` / `secret`) | Yes | For cache auth, dashboard, and usage; optional for a trusted single node |
+| `KURA_NODE_URL` | Yes | Yes |
+| `KURA_ADVERTISED_HTTP_URL` | Yes | For dashboard registration; routing is separate (see below) |
+| Routing to the CLI | Automatic (registration) | Automatic against the hosted server; on a self-hosted server, `TUIST_CACHE_ENDPOINTS` |
 | Data + temp volume | Yes | Yes |
 | `KURA_ENROLL_ON_BOOT` | Yes | No (would return `ca_unavailable`) |
-| Peer TLS (`/tls` CA + leaf) | No, enrollment writes it | **Yes, you provide it** |
+| Peer TLS (`/tls` CA + leaf) | No, enrollment writes it | Only for a multi-node mesh |
 | `KURA_PEERS` (peer list) | No, enrollment seeds the gateway | Yes, if more than one node |
 
 ## Required configuration {#required-config}
 
-These variables are required on every node regardless of topology:
+These variables configure every node, regardless of topology (peer TLS is the exception noted below):
 
 | Variable | Description |
 |---|---|
@@ -193,10 +207,10 @@ These variables are required on every node regardless of topology:
 | `KURA_REGION` | A free-form region label (e.g. `office`, `ci`). |
 | `KURA_PORT` / `KURA_GRPC_PORT` / `KURA_INTERNAL_PORT` | HTTP cache, gRPC, and mesh peer ports (`4000` / `50051` / `7443`). |
 | `KURA_DATA_DIR` / `KURA_TMP_DIR` | On-disk artifact storage and scratch directory. |
-| `KURA_INTERNAL_TLS_CA_CERT_PATH` / `KURA_INTERNAL_TLS_CERT_PATH` / `KURA_INTERNAL_TLS_KEY_PATH` | Peer TLS files. Written by enrollment (bridged) or provided by you (standalone). |
+| `KURA_INTERNAL_TLS_CA_CERT_PATH` / `KURA_INTERNAL_TLS_CERT_PATH` / `KURA_INTERNAL_TLS_KEY_PATH` | Peer TLS files. Written by enrollment (bridged) or provided by you (multi-node standalone). Not needed for a single node; omit them and use an `http://` `KURA_NODE_URL`. |
 | `KURA_OTEL_SERVICE_NAME` / `KURA_OTEL_DEPLOYMENT_ENVIRONMENT` | Service name and environment label for telemetry. |
 
-Bridged nodes additionally set `KURA_ENROLL_ON_BOOT`, `KURA_CONTROL_PLANE_URL`, and the control-plane client credentials. Both topologies set `KURA_REGISTRATION_URL` and `KURA_ADVERTISED_HTTP_URL` to appear in the dashboard and receive traffic from the CLI.
+Bridged nodes additionally set `KURA_ENROLL_ON_BOOT`, `KURA_CONTROL_PLANE_URL`, and the control-plane client credentials. `KURA_REGISTRATION_URL` and `KURA_ADVERTISED_HTTP_URL` register a node so it appears on the **Cache** page; against the hosted server they also route the CLI to it, while a self-hosted server routes via `TUIST_CACHE_ENDPOINTS` (see [How clients reach your nodes](#routing)).
 
 ## Authentication of cache requests {#cache-auth}
 

--- a/server/priv/docs/en/guides/cache/self-host.md
+++ b/server/priv/docs/en/guides/cache/self-host.md
@@ -55,7 +55,7 @@ The key difference in configuration is that the **bridged** topology uses **enro
 
 A node uses an account-scoped control-plane client to authenticate cache requests (token introspection), report to the dashboard, and deliver usage. It is **not** how clients are routed to your nodes (see [How clients reach your nodes](#routing)), so a single node on a trusted network can run without one.
 
-1. Open your account's **Cache** page. If you don't see it, enable the `kura` feature flag for the account. On a self-hosted Tuist server the Enterprise entitlement is granted automatically, so the flag is the only prerequisite.
+1. Open your account's **Cache** page. On a self-hosted Tuist server it is available by default (the deployment's license is the entitlement). On the hosted `tuist.dev` server it requires an Enterprise plan and the `kura` feature flag.
 2. Choose **Generate credential**.
 3. Copy the `client_id` and the one-time `secret`.
 

--- a/server/priv/docs/en/guides/cache/self-host.md
+++ b/server/priv/docs/en/guides/cache/self-host.md
@@ -55,7 +55,7 @@ The key difference in configuration is that the **bridged** topology uses **enro
 
 A node uses an account-scoped control-plane client to authenticate cache requests (token introspection), report to the dashboard, and deliver usage. It is **not** how clients are routed to your nodes (see [How clients reach your nodes](#routing)), so a single node on a trusted network can run without one.
 
-1. Open your account's **Cache** page. On a self-hosted Tuist server it is available by default (the deployment's license is the entitlement). On the hosted `tuist.dev` server it requires an Enterprise plan and the `kura` feature flag.
+1. Open your account's **Cache** page. On a self-hosted Tuist server it is available by default (the deployment's license is the entitlement). On the hosted `tuist.dev` server the page requires the `kura` feature flag; generating a self-hosted-node credential there additionally requires an Enterprise plan.
 2. Choose **Generate credential**.
 3. Copy the `client_id` and the one-time `secret`.
 

--- a/server/priv/docs/en/guides/cache/self-host.md
+++ b/server/priv/docs/en/guides/cache/self-host.md
@@ -154,8 +154,9 @@ services:
       KURA_PEERS: "https://kura-2.acme.internal:7443,https://kura-3.acme.internal:7443"
 
       # Peer mTLS secures node-to-node traffic, so it only applies with more than one node.
-      # A single node has no peers: omit these three and set KURA_NODE_URL to http://...:7443
-      # (the peer URL must be http when peer TLS is off).
+      # A single node has no peers: omit these three and switch KURA_NODE_URL to
+      # http:// (keep the same host and port; the peer URL must use http, not
+      # https, when peer TLS is off).
       KURA_INTERNAL_TLS_CA_CERT_PATH: "/tls/ca.pem"
       KURA_INTERNAL_TLS_CERT_PATH: "/tls/tls.crt"
       KURA_INTERNAL_TLS_KEY_PATH: "/tls/tls.key"
@@ -181,7 +182,7 @@ volumes:
   kura-data: {}
 ```
 
-What you provide that the bridged path does not: for a multi-node mesh, your **own peer TLS** mounted at `/tls` (a CA plus a leaf certificate and key per node, sharing a CA so the nodes trust each other) and `KURA_PEERS` describing your topology. A single standalone node needs neither: with no peers, nothing travels over the peer plane, so omit `KURA_INTERNAL_TLS_*` and `KURA_PEERS` and set `KURA_NODE_URL` to `http://...:7443`.
+What you provide that the bridged path does not: for a multi-node mesh, your **own peer TLS** mounted at `/tls` (a CA plus a leaf certificate and key per node, sharing a CA so the nodes trust each other) and `KURA_PEERS` describing your topology. A single standalone node needs neither: with no peers, nothing travels over the peer plane, so omit `KURA_INTERNAL_TLS_*` and `KURA_PEERS`, and use the `http://` scheme for `KURA_NODE_URL` (peer TLS off requires `http` rather than `https`; the host and `KURA_INTERNAL_PORT` stay the same).
 
 ## What each topology requires {#requirements-summary}
 

--- a/server/priv/docs/en/guides/features/cache/self-hosting.md
+++ b/server/priv/docs/en/guides/features/cache/self-hosting.md
@@ -32,15 +32,14 @@ helm upgrade --install kura oci://ghcr.io/tuist/charts/kura \
   --set config.region=local
 ```
 
-For a self-hosted Tuist server running in the same cluster, expose the Kura service through the Tuist chart:
+For a self-hosted Tuist server running in the same cluster, tell the server which cache endpoints to hand to clients:
 
 ```yaml
 server:
-  kuraEndpointUrls:
-    - http://kura.kura.svc.cluster.local:4000
+  cacheEndpointUrl: "http://kura.kura.svc.cluster.local:4000"
 ```
 
-This renders `TUIST_KURA_ENDPOINTS` in the server pod. When clients request the Kura cache technology, the server returns those endpoints.
+This renders `TUIST_CACHE_ENDPOINTS` in the server pod. On a self-hosted server the CLI is routed to whatever `TUIST_CACHE_ENDPOINTS` lists, so point it at your Kura service. For multiple nodes, use a comma-separated list.
 
 > [!IMPORTANT]
 > Every Kura node must own its own `KURA_DATA_DIR`. Kura takes an application-level writer lock on the data directory and expects exactly one process to own it. In Kubernetes, use one persistent volume per pod. Outside Kubernetes, do not point multiple processes at the same mounted directory.
@@ -72,7 +71,7 @@ docker run -d --name kura \
 Then configure the Tuist server with the URLs that clients can reach:
 
 ```bash
-TUIST_KURA_ENDPOINTS=https://kura-1.example.com,https://kura-2.example.com
+TUIST_CACHE_ENDPOINTS=https://kura-1.example.com,https://kura-2.example.com
 ```
 
 ## Build a cache mesh {#build-a-cache-mesh}

--- a/server/priv/docs/en/guides/server/self-host/server.md
+++ b/server/priv/docs/en/guides/server/self-host/server.md
@@ -107,7 +107,7 @@ You’ll also need a solution to store files (e.g. framework and library binarie
 To use self-hosted Kura nodes with a self-hosted Tuist server:
 
 1. Deploy Kura nodes following the <.localized_link href="/guides/features/cache/self-hosting">self-hosted cache guide</.localized_link>.
-2. Set `TUIST_KURA_ENDPOINTS` to a comma-separated list of Kura URLs, or configure `server.kuraEndpointUrls` in the Helm chart.
+2. Set `TUIST_CACHE_ENDPOINTS` to a comma-separated list of your Kura node URLs, or configure `server.cacheEndpointUrl` in the Helm chart. On a self-hosted server this is what routes the CLI to your nodes.
 
 ## Configuration {#configuration}
 

--- a/server/priv/gettext/dashboard_account.pot
+++ b/server/priv/gettext/dashboard_account.pot
@@ -1918,7 +1918,7 @@ msgstr ""
 msgid "Cache servers"
 msgstr ""
 
-#: lib/tuist_web/live/cache_live.html.heex:33
+#: lib/tuist_web/live/cache_live.html.heex:34
 #, elixir-autogen, elixir-format
 msgid "Cache servers are not enabled for this account yet."
 msgstr ""

--- a/server/priv/gettext/dashboard_account.pot
+++ b/server/priv/gettext/dashboard_account.pot
@@ -72,7 +72,7 @@ msgstr ""
 msgid "All members"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:787
+#: lib/tuist_web/live/account_settings_live.ex:789
 #, elixir-autogen, elixir-format
 msgid "All regions"
 msgstr ""
@@ -99,17 +99,17 @@ msgstr ""
 msgid "Billing email"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:530
-#: lib/tuist_web/live/account_settings_live.ex:859
-#: lib/tuist_web/live/account_settings_live.ex:946
+#: lib/tuist_web/live/account_settings_live.ex:532
+#: lib/tuist_web/live/account_settings_live.ex:861
+#: lib/tuist_web/live/account_settings_live.ex:948
 #: lib/tuist_web/live/account_settings_live.html.heex:83
 #: lib/tuist_web/live/account_settings_live.html.heex:157
 #: lib/tuist_web/live/account_settings_live.html.heex:247
 #: lib/tuist_web/live/account_settings_live.html.heex:319
 #: lib/tuist_web/live/authentication_settings_live.html.heex:518
-#: lib/tuist_web/live/cache_live.ex:504
-#: lib/tuist_web/live/cache_live.ex:746
-#: lib/tuist_web/live/cache_live.ex:811
+#: lib/tuist_web/live/cache_live.ex:506
+#: lib/tuist_web/live/cache_live.ex:742
+#: lib/tuist_web/live/cache_live.ex:807
 #: lib/tuist_web/live/create_organization_live.ex:83
 #: lib/tuist_web/live/members_live.ex:166
 #: lib/tuist_web/live/members_live.ex:215
@@ -131,7 +131,7 @@ msgstr ""
 msgid "Change your subscription to fit your needs."
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:771
+#: lib/tuist_web/live/account_settings_live.ex:773
 #, elixir-autogen, elixir-format
 msgid "Choose where your artifacts, like module cache binaries, are stored for legal compliance."
 msgstr ""
@@ -219,9 +219,9 @@ msgstr ""
 msgid "Decline"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:920
-#: lib/tuist_web/live/account_settings_live.ex:954
-#: lib/tuist_web/live/account_settings_live.ex:966
+#: lib/tuist_web/live/account_settings_live.ex:922
+#: lib/tuist_web/live/account_settings_live.ex:956
+#: lib/tuist_web/live/account_settings_live.ex:968
 #: lib/tuist_web/live/account_settings_live.html.heex:165
 #: lib/tuist_web/live/account_settings_live.html.heex:327
 #, elixir-autogen, elixir-format
@@ -363,7 +363,7 @@ msgstr ""
 msgid "Enterprise"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:788
+#: lib/tuist_web/live/account_settings_live.ex:790
 #, elixir-autogen, elixir-format
 msgid "Europe"
 msgstr ""
@@ -507,8 +507,8 @@ msgid "Most Popular"
 msgstr ""
 
 #: lib/tuist_web/live/authentication_settings_live.html.heex:538
-#: lib/tuist_web/live/cache_live.ex:724
-#: lib/tuist_web/live/cache_live.ex:765
+#: lib/tuist_web/live/cache_live.ex:720
+#: lib/tuist_web/live/cache_live.ex:761
 #: lib/tuist_web/live/create_organization_live.ex:65
 #: lib/tuist_web/live/webhook_endpoint_form.ex:64
 #: lib/tuist_web/live/webhooks_live.html.heex:134
@@ -580,14 +580,14 @@ msgstr ""
 msgid "Payments for your subscription are made using the default card."
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:666
-#: lib/tuist_web/live/account_settings_live.ex:669
-#: lib/tuist_web/live/account_settings_live.ex:677
-#: lib/tuist_web/live/account_settings_live.ex:680
-#: lib/tuist_web/live/cache_live.ex:358
-#: lib/tuist_web/live/cache_live.ex:361
-#: lib/tuist_web/live/cache_live.ex:368
-#: lib/tuist_web/live/cache_live.ex:371
+#: lib/tuist_web/live/account_settings_live.ex:668
+#: lib/tuist_web/live/account_settings_live.ex:671
+#: lib/tuist_web/live/account_settings_live.ex:679
+#: lib/tuist_web/live/account_settings_live.ex:682
+#: lib/tuist_web/live/cache_live.ex:360
+#: lib/tuist_web/live/cache_live.ex:363
+#: lib/tuist_web/live/cache_live.ex:370
+#: lib/tuist_web/live/cache_live.ex:373
 #: lib/tuist_web/live/members_live.ex:290
 #, elixir-autogen, elixir-format
 msgid "Pending"
@@ -625,14 +625,14 @@ msgstr ""
 msgid "Pro"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:485
-#: lib/tuist_web/live/account_settings_live.ex:498
-#: lib/tuist_web/live/account_settings_live.ex:570
-#: lib/tuist_web/live/account_settings_live.ex:784
-#: lib/tuist_web/live/cache_live.ex:456
-#: lib/tuist_web/live/cache_live.ex:472
-#: lib/tuist_web/live/cache_live.ex:540
-#: lib/tuist_web/live/cache_live.ex:862
+#: lib/tuist_web/live/account_settings_live.ex:487
+#: lib/tuist_web/live/account_settings_live.ex:500
+#: lib/tuist_web/live/account_settings_live.ex:572
+#: lib/tuist_web/live/account_settings_live.ex:786
+#: lib/tuist_web/live/cache_live.ex:458
+#: lib/tuist_web/live/cache_live.ex:474
+#: lib/tuist_web/live/cache_live.ex:542
+#: lib/tuist_web/live/cache_live.ex:858
 #, elixir-autogen, elixir-format
 msgid "Region"
 msgstr ""
@@ -717,7 +717,7 @@ msgstr ""
 msgid "Search members..."
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:779
+#: lib/tuist_web/live/account_settings_live.ex:781
 #, elixir-autogen, elixir-format
 msgid "Select region"
 msgstr ""
@@ -750,9 +750,9 @@ msgstr ""
 msgid "Standard support: Via Slack and email"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:573
-#: lib/tuist_web/live/cache_live.ex:543
-#: lib/tuist_web/live/cache_live.ex:868
+#: lib/tuist_web/live/account_settings_live.ex:575
+#: lib/tuist_web/live/cache_live.ex:545
+#: lib/tuist_web/live/cache_live.ex:864
 #: lib/tuist_web/live/members_live.ex:288
 #: lib/tuist_web/live/webhook_event_live.html.heex:28
 #: lib/tuist_web/live/webhook_live.ex:265
@@ -761,7 +761,7 @@ msgstr ""
 msgid "Status"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:768
+#: lib/tuist_web/live/account_settings_live.ex:770
 #, elixir-autogen, elixir-format
 msgid "Storage region"
 msgstr ""
@@ -806,7 +806,7 @@ msgstr ""
 msgid "Tuist Logo"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:789
+#: lib/tuist_web/live/account_settings_live.ex:791
 #, elixir-autogen, elixir-format
 msgid "United States"
 msgstr ""
@@ -997,74 +997,74 @@ msgstr ""
 msgid "xxxx xxxx xxxx %{card_number}"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:867
+#: lib/tuist_web/live/account_settings_live.ex:869
 #, elixir-autogen, elixir-format
 msgid "Add"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:829
+#: lib/tuist_web/live/account_settings_live.ex:831
 #, elixir-autogen, elixir-format
 msgid "Add cache endpoint"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:836
+#: lib/tuist_web/live/account_settings_live.ex:838
 #: lib/tuist_web/live/webhooks_live.html.heex:35
 #, elixir-autogen, elixir-format
 msgid "Add endpoint"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:849
+#: lib/tuist_web/live/account_settings_live.ex:851
 #: lib/tuist_web/live/webhook_endpoint_form.ex:75
 #: lib/tuist_web/live/webhook_live.html.heex:71
 #, elixir-autogen, elixir-format
 msgid "Endpoint URL"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:906
+#: lib/tuist_web/live/account_settings_live.ex:908
 #: lib/tuist_web/live/webhooks_live.html.heex:137
 #, elixir-autogen, elixir-format
 msgid "URL"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:913
+#: lib/tuist_web/live/account_settings_live.ex:915
 #, elixir-autogen, elixir-format
 msgid "Delete last cache endpoint?"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:933
+#: lib/tuist_web/live/account_settings_live.ex:935
 #, elixir-autogen, elixir-format
 msgid "Removing the last custom cache endpoint will switch your organization back to Tuist-hosted caching. This affects all builds across your organization."
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:811
+#: lib/tuist_web/live/account_settings_live.ex:813
 #, elixir-autogen, elixir-format
 msgid "Cache endpoints"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:815
+#: lib/tuist_web/live/account_settings_live.ex:817
 #, elixir-autogen, elixir-format
 msgid "Configure custom cache endpoints for self-hosted cache setups. When enabled, Tuist will read from and write to these endpoints instead of the default Tuist-hosted cache."
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:883
+#: lib/tuist_web/live/account_settings_live.ex:885
 #, elixir-autogen, elixir-format
 msgid "Custom cache endpoints are disabled. Tuist will use the default Tuist-hosted cache."
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:895
+#: lib/tuist_web/live/account_settings_live.ex:897
 #, elixir-autogen, elixir-format
 msgid "No custom cache endpoints configured. Tuist will use the default Tuist-hosted cache until endpoints are added."
 msgstr ""
 
 #: lib/tuist_web/live/authentication_settings_live.html.heex:317
-#: lib/tuist_web/live/cache_live.ex:678
-#: lib/tuist_web/live/cache_live.ex:768
+#: lib/tuist_web/live/cache_live.ex:674
+#: lib/tuist_web/live/cache_live.ex:764
 #, elixir-autogen, elixir-format
 msgid "Client ID"
 msgstr ""
 
 #: lib/tuist_web/live/authentication_settings_live.html.heex:336
-#: lib/tuist_web/live/cache_live.ex:698
+#: lib/tuist_web/live/cache_live.ex:694
 #, elixir-autogen, elixir-format
 msgid "Client secret"
 msgstr ""
@@ -1198,23 +1198,23 @@ msgstr ""
 msgid "What's the name of your company or team? You can change this later in the settings"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:723
+#: lib/tuist_web/live/account_settings_live.ex:725
 #, elixir-autogen, elixir-format
 msgid "Browser default"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:733
+#: lib/tuist_web/live/account_settings_live.ex:735
 #, elixir-autogen, elixir-format
 msgid "Choose your preferred dashboard language."
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:730
+#: lib/tuist_web/live/account_settings_live.ex:732
 #, elixir-autogen, elixir-format
 msgid "Dashboard language"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:738
-#: lib/tuist_web/live/account_settings_live.ex:743
+#: lib/tuist_web/live/account_settings_live.ex:740
+#: lib/tuist_web/live/account_settings_live.ex:745
 #, elixir-autogen, elixir-format
 msgid "Language"
 msgstr ""
@@ -1282,7 +1282,7 @@ msgid "Dashboard"
 msgstr ""
 
 #: lib/tuist_web/live/authentication_settings_live.html.heex:512
-#: lib/tuist_web/live/cache_live.ex:738
+#: lib/tuist_web/live/cache_live.ex:734
 #: lib/tuist_web/live/members_live.ex:418
 #: lib/tuist_web/live/webhook_live.html.heex:404
 #: lib/tuist_web/live/webhooks_live.html.heex:104
@@ -1291,7 +1291,7 @@ msgid "Done"
 msgstr ""
 
 #: lib/tuist_web/live/authentication_settings_live.html.heex:523
-#: lib/tuist_web/live/cache_live.ex:754
+#: lib/tuist_web/live/cache_live.ex:750
 #, elixir-autogen, elixir-format
 msgid "Generate"
 msgstr ""
@@ -1421,65 +1421,65 @@ msgstr ""
 msgid "Revoke token"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:696
-#: lib/tuist_web/live/cache_live.ex:387
+#: lib/tuist_web/live/account_settings_live.ex:698
+#: lib/tuist_web/live/cache_live.ex:389
 #, elixir-autogen, elixir-format
 msgid "Active"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:548
-#: lib/tuist_web/live/account_settings_live.ex:554
-#: lib/tuist_web/live/account_settings_live.ex:616
-#: lib/tuist_web/live/cache_live.ex:522
-#: lib/tuist_web/live/cache_live.ex:528
-#: lib/tuist_web/live/cache_live.ex:582
+#: lib/tuist_web/live/account_settings_live.ex:550
+#: lib/tuist_web/live/account_settings_live.ex:556
+#: lib/tuist_web/live/account_settings_live.ex:618
+#: lib/tuist_web/live/cache_live.ex:524
+#: lib/tuist_web/live/cache_live.ex:530
+#: lib/tuist_web/live/cache_live.ex:584
 #, elixir-autogen, elixir-format
 msgid "Deploy"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:462
-#: lib/tuist_web/live/account_settings_live.ex:469
+#: lib/tuist_web/live/account_settings_live.ex:464
+#: lib/tuist_web/live/account_settings_live.ex:471
 #, elixir-autogen, elixir-format
 msgid "Deploy Kura server"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:453
+#: lib/tuist_web/live/account_settings_live.ex:455
 #, elixir-autogen, elixir-format
 msgid "Deploy regional Kura cache servers for this account. Each region can have at most one server."
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:684
-#: lib/tuist_web/live/account_settings_live.ex:694
-#: lib/tuist_web/live/cache_live.ex:375
-#: lib/tuist_web/live/cache_live.ex:385
+#: lib/tuist_web/live/account_settings_live.ex:686
+#: lib/tuist_web/live/account_settings_live.ex:696
+#: lib/tuist_web/live/cache_live.ex:377
+#: lib/tuist_web/live/cache_live.ex:387
 #, elixir-autogen, elixir-format
 msgid "Deploying"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:400
+#: lib/tuist_web/live/account_settings_live.ex:402
 #, elixir-autogen, elixir-format
 msgid "Deploying Kura in %{region}..."
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:600
-#: lib/tuist_web/live/cache_live.ex:566
+#: lib/tuist_web/live/account_settings_live.ex:602
+#: lib/tuist_web/live/cache_live.ex:568
 #, elixir-autogen, elixir-format
 msgid "Destroy"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:606
+#: lib/tuist_web/live/account_settings_live.ex:608
 #, elixir-autogen, elixir-format
 msgid "Destroy the Kura server in %{region}? This removes the account's Kura cache endpoint for that region."
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:699
-#: lib/tuist_web/live/cache_live.ex:390
+#: lib/tuist_web/live/account_settings_live.ex:701
+#: lib/tuist_web/live/cache_live.ex:392
 #, elixir-autogen, elixir-format
 msgid "Destroyed"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:698
-#: lib/tuist_web/live/cache_live.ex:389
+#: lib/tuist_web/live/account_settings_live.ex:700
+#: lib/tuist_web/live/cache_live.ex:391
 #, elixir-autogen, elixir-format
 msgid "Destroying"
 msgstr ""
@@ -1489,14 +1489,14 @@ msgstr ""
 msgid "Destroying Kura server..."
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:580
-#: lib/tuist_web/live/cache_live.ex:546
+#: lib/tuist_web/live/account_settings_live.ex:582
+#: lib/tuist_web/live/cache_live.ex:548
 #, elixir-autogen, elixir-format
 msgid "Domain"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:697
-#: lib/tuist_web/live/cache_live.ex:388
+#: lib/tuist_web/live/account_settings_live.ex:699
+#: lib/tuist_web/live/cache_live.ex:390
 #: lib/tuist_web/live/webhook_live.ex:233
 #: lib/tuist_web/live/webhook_live.ex:270
 #: lib/tuist_web/live/webhook_live.html.heex:143
@@ -1505,13 +1505,13 @@ msgstr ""
 msgid "Failed"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:410
-#: lib/tuist_web/live/account_settings_live.ex:419
+#: lib/tuist_web/live/account_settings_live.ex:412
+#: lib/tuist_web/live/account_settings_live.ex:421
 #, elixir-autogen, elixir-format
 msgid "Failed to deploy Kura: %{reason}"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:450
+#: lib/tuist_web/live/account_settings_live.ex:452
 #, elixir-autogen, elixir-format
 msgid "Kura cache servers"
 msgstr ""
@@ -1521,26 +1521,26 @@ msgstr ""
 msgid "Kura server not found."
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:517
+#: lib/tuist_web/live/account_settings_live.ex:519
 #, elixir-autogen, elixir-format
 msgid "New servers start on Kura"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:583
-#: lib/tuist_web/live/cache_live.ex:549
-#: lib/tuist_web/live/cache_live.ex:865
+#: lib/tuist_web/live/account_settings_live.ex:585
+#: lib/tuist_web/live/cache_live.ex:551
+#: lib/tuist_web/live/cache_live.ex:861
 #, elixir-autogen, elixir-format
 msgid "Version"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:519
-#: lib/tuist_web/live/cache_live.ex:493
+#: lib/tuist_web/live/account_settings_live.ex:521
+#: lib/tuist_web/live/cache_live.ex:495
 #, elixir-autogen, elixir-format
 msgid "(current deploy)."
 msgstr ""
 
 #: lib/tuist_web/live/account_settings_live.ex:251
-#: lib/tuist_web/live/account_settings_live.ex:512
+#: lib/tuist_web/live/account_settings_live.ex:514
 #, elixir-autogen, elixir-format
 msgid "No Kura runtime image is configured right now. Try again after the next server deploy."
 msgstr ""
@@ -1550,8 +1550,8 @@ msgstr ""
 msgid "Select a Kura region before deploying."
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:660
-#: lib/tuist_web/live/cache_live.ex:352
+#: lib/tuist_web/live/account_settings_live.ex:662
+#: lib/tuist_web/live/cache_live.ex:354
 #, elixir-autogen, elixir-format
 msgid "Not deployed"
 msgstr ""
@@ -1859,8 +1859,8 @@ msgstr ""
 msgid "Copy payload"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:590
-#: lib/tuist_web/live/cache_live.ex:556
+#: lib/tuist_web/live/account_settings_live.ex:592
+#: lib/tuist_web/live/cache_live.ex:558
 #, elixir-autogen, elixir-format
 msgid "Retry"
 msgstr ""
@@ -1896,8 +1896,8 @@ msgstr ""
 msgid "No invitations found"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:695
-#: lib/tuist_web/live/cache_live.ex:386
+#: lib/tuist_web/live/account_settings_live.ex:697
+#: lib/tuist_web/live/cache_live.ex:388
 #, elixir-autogen, elixir-format
 msgid "Replicating"
 msgstr ""
@@ -1913,7 +1913,7 @@ msgstr ""
 msgid "Cache server not found."
 msgstr ""
 
-#: lib/tuist_web/live/cache_live.ex:424
+#: lib/tuist_web/live/cache_live.ex:426
 #, elixir-autogen, elixir-format
 msgid "Cache servers"
 msgstr ""
@@ -1923,17 +1923,17 @@ msgstr ""
 msgid "Cache servers are not enabled for this account yet."
 msgstr ""
 
-#: lib/tuist_web/live/cache_live.ex:667
+#: lib/tuist_web/live/cache_live.ex:663
 #, elixir-autogen, elixir-format
 msgid "Client credentials"
 msgstr ""
 
-#: lib/tuist_web/live/cache_live.ex:690
+#: lib/tuist_web/live/cache_live.ex:686
 #, elixir-autogen, elixir-format
 msgid "Copy client ID"
 msgstr ""
 
-#: lib/tuist_web/live/cache_live.ex:712
+#: lib/tuist_web/live/cache_live.ex:708
 #, elixir-autogen, elixir-format
 msgid "Copy client secret"
 msgstr ""
@@ -1944,33 +1944,33 @@ msgstr ""
 msgid "Copy invite link"
 msgstr ""
 
-#: lib/tuist_web/live/cache_live.ex:670
+#: lib/tuist_web/live/cache_live.ex:666
 #, elixir-autogen, elixir-format
 msgid "Copy the secret now. It will not be shown again after you close this dialog."
 msgstr ""
 
-#: lib/tuist_web/live/cache_live.ex:626
+#: lib/tuist_web/live/cache_live.ex:622
 #, elixir-autogen, elixir-format
 msgid "Credentials"
 msgstr ""
 
-#: lib/tuist_web/live/cache_live.ex:426
+#: lib/tuist_web/live/cache_live.ex:428
 #, elixir-autogen, elixir-format
 msgid "Deploy regional cache servers managed by Tuist. Each region can have at most one server."
 msgstr ""
 
-#: lib/tuist_web/live/cache_live.ex:435
-#: lib/tuist_web/live/cache_live.ex:442
+#: lib/tuist_web/live/cache_live.ex:437
+#: lib/tuist_web/live/cache_live.ex:444
 #, elixir-autogen, elixir-format
 msgid "Deploy server"
 msgstr ""
 
-#: lib/tuist_web/live/cache_live.ex:293
+#: lib/tuist_web/live/cache_live.ex:295
 #, elixir-autogen, elixir-format
 msgid "Deploying cache server in %{region}..."
 msgstr ""
 
-#: lib/tuist_web/live/cache_live.ex:572
+#: lib/tuist_web/live/cache_live.ex:574
 #, elixir-autogen, elixir-format
 msgid "Destroy the cache server in %{region}? This removes the account's cache endpoint for that region."
 msgstr ""
@@ -1980,23 +1980,23 @@ msgstr ""
 msgid "Destroying cache server..."
 msgstr ""
 
-#: lib/tuist_web/live/cache_live.ex:859
+#: lib/tuist_web/live/cache_live.ex:855
 #, elixir-autogen, elixir-format
 msgid "Endpoint"
 msgstr ""
 
-#: lib/tuist_web/live/cache_live.ex:303
-#: lib/tuist_web/live/cache_live.ex:312
+#: lib/tuist_web/live/cache_live.ex:305
+#: lib/tuist_web/live/cache_live.ex:314
 #, elixir-autogen, elixir-format
 msgid "Failed to deploy cache server: %{reason}"
 msgstr ""
 
-#: lib/tuist_web/live/cache_live.ex:652
+#: lib/tuist_web/live/cache_live.ex:648
 #, elixir-autogen, elixir-format
 msgid "Generate credential"
 msgstr ""
 
-#: lib/tuist_web/live/cache_live.ex:836
+#: lib/tuist_web/live/cache_live.ex:832
 #, elixir-autogen, elixir-format
 msgid "Generate one to authorize your self-hosted nodes."
 msgstr ""
@@ -2011,7 +2011,7 @@ msgstr ""
 msgid "Invite"
 msgstr ""
 
-#: lib/tuist_web/live/cache_live.ex:875
+#: lib/tuist_web/live/cache_live.ex:871
 #, elixir-autogen, elixir-format
 msgid "Last heartbeat"
 msgstr ""
@@ -2021,89 +2021,79 @@ msgstr ""
 msgid "Manage where build artifacts are cached for this account: Tuist-managed cache servers and your own self-hosted nodes."
 msgstr ""
 
-#: lib/tuist_web/live/cache_live.ex:491
+#: lib/tuist_web/live/cache_live.ex:493
 #, elixir-autogen, elixir-format
 msgid "New servers start on"
 msgstr ""
 
-#: lib/tuist_web/live/cache_live.ex:592
-#, elixir-autogen, elixir-format
-msgid "No cache servers available"
-msgstr ""
-
-#: lib/tuist_web/live/cache_live.ex:834
+#: lib/tuist_web/live/cache_live.ex:830
 #, elixir-autogen, elixir-format
 msgid "No credentials yet"
 msgstr ""
 
-#: lib/tuist_web/live/cache_live.ex:593
-#, elixir-autogen, elixir-format
-msgid "No regions are available for this account yet."
-msgstr ""
-
-#: lib/tuist_web/live/cache_live.ex:880
+#: lib/tuist_web/live/cache_live.ex:876
 #, elixir-autogen, elixir-format
 msgid "No registered nodes"
 msgstr ""
 
 #: lib/tuist_web/live/cache_live.ex:74
-#: lib/tuist_web/live/cache_live.ex:486
+#: lib/tuist_web/live/cache_live.ex:488
 #, elixir-autogen, elixir-format
 msgid "No runtime image is configured right now. Try again after the next server deploy."
 msgstr ""
 
-#: lib/tuist_web/live/cache_live.ex:856
+#: lib/tuist_web/live/cache_live.ex:852
 #, elixir-autogen, elixir-format
 msgid "Node"
 msgstr ""
 
-#: lib/tuist_web/live/cache_live.ex:645
+#: lib/tuist_web/live/cache_live.ex:641
 #, elixir-autogen, elixir-format
 msgid "Node credential"
 msgstr ""
 
-#: lib/tuist_web/live/cache_live.ex:896
+#: lib/tuist_web/live/cache_live.ex:892
 #, elixir-autogen, elixir-format
 msgid "Not ready"
 msgstr ""
 
-#: lib/tuist_web/live/cache_live.ex:725
+#: lib/tuist_web/live/cache_live.ex:721
 #, elixir-autogen, elixir-format
 msgid "Production mesh"
 msgstr ""
 
-#: lib/tuist_web/live/cache_live.ex:895
+#: lib/tuist_web/live/cache_live.ex:891
 #, elixir-autogen, elixir-format
 msgid "Ready"
 msgstr ""
 
-#: lib/tuist_web/live/cache_live.ex:846
+#: lib/tuist_web/live/cache_live.ex:842
 #, elixir-autogen, elixir-format
 msgid "Registered nodes"
 msgstr ""
 
-#: lib/tuist_web/live/cache_live.ex:819
+#: lib/tuist_web/live/cache_live.ex:815
 #, elixir-autogen, elixir-format
 msgid "Revoke"
 msgstr ""
 
-#: lib/tuist_web/live/cache_live.ex:801
+#: lib/tuist_web/live/cache_live.ex:797
 #, elixir-autogen, elixir-format
 msgid "Revoke %{name}? Self-hosted nodes using it will stop authenticating."
 msgstr ""
 
-#: lib/tuist_web/live/cache_live.ex:779
-#: lib/tuist_web/live/cache_live.ex:790
+#: lib/tuist_web/live/cache_live.ex:775
+#: lib/tuist_web/live/cache_live.ex:786
 #, elixir-autogen, elixir-format
 msgid "Revoke credential"
 msgstr ""
 
-#: lib/tuist_web/live/cache_live.ex:615
+#: lib/tuist_web/live/cache_live.ex:611
 #, elixir-autogen, elixir-format
 msgid "Run your own cache nodes. Generate a credential they authenticate with, and they register themselves so the CLI can reach them directly."
 msgstr ""
 
-#: lib/tuist_web/live/cache_live.ex:771
+#: lib/tuist_web/live/cache_live.ex:767
 #, elixir-autogen, elixir-format
 msgid "Secret"
 msgstr ""
@@ -2113,17 +2103,17 @@ msgstr ""
 msgid "Select a region before deploying."
 msgstr ""
 
-#: lib/tuist_web/live/cache_live.ex:612
+#: lib/tuist_web/live/cache_live.ex:608
 #, elixir-autogen, elixir-format
 msgid "Self-hosted cache servers"
 msgstr ""
 
-#: lib/tuist_web/live/cache_live.ex:882
+#: lib/tuist_web/live/cache_live.ex:878
 #, elixir-autogen, elixir-format
 msgid "Self-hosted nodes appear here once they start sending registration heartbeats."
 msgstr ""
 
-#: lib/tuist_web/live/cache_live.ex:848
+#: lib/tuist_web/live/cache_live.ex:844
 #, elixir-autogen, elixir-format
 msgid "Self-hosted nodes reporting in via registration heartbeats. The CLI routes cache traffic to each node's endpoint, and a node drops off this list when it stops heartbeating."
 msgstr ""
@@ -2133,7 +2123,7 @@ msgstr ""
 msgid "Share this link with %{email} so they can join. You'll also find it in the invitations list."
 msgstr ""
 
-#: lib/tuist_web/live/cache_live.ex:628
+#: lib/tuist_web/live/cache_live.ex:624
 #, elixir-autogen, elixir-format
 msgid "Tenant-scoped credentials your nodes present to Tuist. A credential only authorizes this account's traffic."
 msgstr ""

--- a/server/test/tuist_web/live/cache_live_test.exs
+++ b/server/test/tuist_web/live/cache_live_test.exs
@@ -80,6 +80,40 @@ defmodule TuistWeb.CacheLiveTest do
     refute html =~ "cache-servers-table"
   end
 
+  test "is available on a self-hosted server without the kura flag", %{conn: conn, account: account} do
+    # Non-hosted deployments grant the Kura surface unconditionally, so the
+    # page and credential generation work even with the flag off.
+    stub(Environment, :dev?, fn -> false end)
+    stub(Environment, :tuist_hosted?, fn -> false end)
+    stub_cache_flag(account, false)
+    stub(Kura, :latest_versions, fn 1 -> [] end)
+
+    {:ok, _lv, html} = live(conn, ~p"/#{account.name}/cache")
+
+    refute html =~ "not enabled for this account"
+    assert html =~ "Self-hosted cache servers"
+    assert html =~ "create_self_hosted_client"
+  end
+
+  test "hides the managed cache-servers section on a self-hosted server with no regions", %{
+    conn: conn,
+    account: account
+  } do
+    # Simulate a self-hosted production server: no managed regions are
+    # available, so only the self-hosted section should render.
+    stub(Environment, :dev?, fn -> false end)
+    stub(Environment, :test?, fn -> false end)
+    stub(Environment, :tuist_hosted?, fn -> false end)
+    stub(Environment, :kura_available_region_ids, fn -> [] end)
+    stub_cache_flag(account, false)
+    stub(Kura, :latest_versions, fn 1 -> [] end)
+
+    {:ok, _lv, html} = live(conn, ~p"/#{account.name}/cache")
+
+    refute html =~ "cache-servers-table"
+    assert html =~ "Self-hosted cache servers"
+  end
+
   test "renders cache servers for cache-enabled accounts", %{conn: conn, account: account} do
     enable_cache(account)
     stub(Kura, :latest_versions, fn 1 -> [%{version: "0.5.2", released_at: DateTime.utc_now(:second)}] end)
@@ -265,6 +299,9 @@ defmodule TuistWeb.CacheLiveTest do
 
   defp disable_cache(account) do
     stub(Environment, :dev?, fn -> false end)
+    # The Cache surface is on by default on non-hosted deployments, so the
+    # only way it stays hidden is the hosted server with the flag off.
+    stub(Environment, :tuist_hosted?, fn -> true end)
     stub_cache_flag(account, false)
   end
 

--- a/server/test/tuist_web/live/cache_live_test.exs
+++ b/server/test/tuist_web/live/cache_live_test.exs
@@ -114,6 +114,21 @@ defmodule TuistWeb.CacheLiveTest do
     assert html =~ "Self-hosted cache servers"
   end
 
+  test "renders on the hosted server when the kura flag is on", %{conn: conn, account: account} do
+    # Positive coverage for the hosted branch: with tuist_hosted? true the
+    # `not tuist_hosted?()` disjunct is false, so the surface appears only
+    # because the :kura flag is on for the account.
+    stub(Environment, :dev?, fn -> false end)
+    stub(Environment, :tuist_hosted?, fn -> true end)
+    stub_cache_flag(account, true)
+    stub(Kura, :latest_versions, fn 1 -> [] end)
+
+    {:ok, _lv, html} = live(conn, ~p"/#{account.name}/cache")
+
+    refute html =~ "not enabled for this account"
+    assert html =~ "Cache servers"
+  end
+
   test "renders cache servers for cache-enabled accounts", %{conn: conn, account: account} do
     enable_cache(account)
     stub(Kura, :latest_versions, fn 1 -> [%{version: "0.5.2", released_at: DateTime.utc_now(:second)}] end)

--- a/server/test/tuist_web/live/usage_live_test.exs
+++ b/server/test/tuist_web/live/usage_live_test.exs
@@ -40,6 +40,9 @@ defmodule TuistWeb.UsageLiveTest do
 
   defp disable_kura(account) do
     stub(Environment, :dev?, fn -> false end)
+    # Kura is on by default on non-hosted deployments, so the flag only gates
+    # visibility on the hosted server.
+    stub(Environment, :tuist_hosted?, fn -> true end)
     stub_kura_flag(account, false)
   end
 

--- a/server/test/tuist_web/live/usage_live_test.exs
+++ b/server/test/tuist_web/live/usage_live_test.exs
@@ -96,6 +96,19 @@ defmodule TuistWeb.UsageLiveTest do
       assert html =~ "Ingress"
       assert html =~ "Requests"
     end
+
+    test "renders the page on the hosted server when the flag is on", %{conn: conn, account: account} do
+      # Positive coverage for the hosted branch: tuist_hosted? true disables
+      # the `not tuist_hosted?()` disjunct, so the page renders only because
+      # the :kura flag is on.
+      stub(Environment, :dev?, fn -> false end)
+      stub(Environment, :tuist_hosted?, fn -> true end)
+      stub_kura_flag(account, true)
+
+      {:ok, _lv, html} = live(conn, ~p"/#{account.name}/usage")
+
+      assert html =~ "Usage"
+    end
   end
 
   describe "rendering" do


### PR DESCRIPTION
## Purpose

Fixes the self-hosting guides where they were inaccurate/out-of-date, and removes the setup friction that surfaced while helping a customer stand up a standalone node: on a self-hosted server the Cache page was hidden behind a feature flag they couldn't easily reach.

## Behavior change: Kura on by default for self-hosted

On a self-hosted Tuist server, cache routing is driven by the operator's global `TUIST_CACHE_ENDPOINTS`, not by the per-account `:kura` rollout flag. Gating the Cache page (plus the sidebar entry, Usage page, and settings section) behind `:kura` was therefore pure friction: an operator had to reach `/ops/flags` to flip a flag before they could generate the control-plane credential, even though the deployment already grants the self-hosted-cache entitlement unconditionally.

- `FeatureFlags.kura_enabled?/1` now returns true on any non-hosted deployment (`not tuist_hosted?()`), mirroring `Billing.Entitlements` where the deployment's license is the entitlement. The hosted server stays gated behind the `:kura` toggle.
- The inline duplicates in `cache_live` and `account_settings_live` now delegate to that helper so the sidebar, LiveView guards, and settings page can't drift.
- The managed cache-server provisioning UI (inert on self-hosted: no managed regions, no Tuist-managed Kubernetes) is hidden when there are no servers and no available regions, so a self-hoster sees only credential generation and the registered-nodes list.

## Docs corrections

Tracing the CLI endpoint resolution (`Accounts.get_cache_endpoints_for_handle/2`) showed it branches on `tuist_hosted?`:
- **Hosted tuist.dev:** per-account resolution routes the CLI to self-hosted nodes from their registration heartbeats.
- **Self-hosted server:** that branch is never reached; it returns the global `TUIST_CACHE_ENDPOINTS`.

The docs instead told self-hosters to set `TUIST_KURA_ENDPOINTS` / `server.kuraEndpointUrls`, which has no consumer (`Environment.kura_endpoints/2` is never called), so that guidance was a no-op. Corrected across all three guides, plus:
- Registration is clarified as dashboard-only on a self-hosted server (routing is `TUIST_CACHE_ENDPOINTS`).
- Peer mTLS (`KURA_INTERNAL_TLS_*`) is documented as multi-node-only; a single node uses an `http://` `KURA_NODE_URL` with peer TLS off.
- The Cache page is documented as available by default on a self-hosted server.

## Scope / follow-ups

The dead `TUIST_KURA_ENDPOINTS` / `Environment.kura_endpoints/2` code and the `kuraEndpointUrls` Helm value (whose comment still says "point this at Kura instances") are left for a separate cleanup.

## Validation

- `mix compile --warnings-as-errors` passes (confirms the removed `Environment` aliases and the delegations).
- New tests in `cache_live_test`: self-hosted default-on, and the managed-section hide when no regions are available. `disable_cache`/`disable_kura` helpers now stub `tuist_hosted? -> true` (the only case the surface stays hidden). Full suite runs in CI.