### PR TITLE
fix(server): use the shared regional gateway for bare-metal Kura regions

### DIFF
--- a/server/lib/tuist/kura/provisioner/kubernetes_controller.ex
+++ b/server/lib/tuist/kura/provisioner/kubernetes_controller.ex
@@ -484,8 +484,18 @@ defmodule Tuist.Kura.Provisioner.KubernetesController do
   # invariant is "no public endpoint, no LoadBalancer" — a dedicated
   # gateway for a hosted-enterprise account would silently recreate
   # the public surface the region exists to avoid.
+  #
+  # Host-network (bare-metal) regions also never get a per-account gateway.
+  # The region's ingress runs as a single host-network gateway bound to the
+  # box's :80/:443; a second per-account host-network gateway can't bind the
+  # same ports on the same box, so it would sit unschedulable and its account
+  # would never serve. On bare metal every account uses the shared regional
+  # ingress class instead; account isolation there is a dedicated box, not a
+  # dedicated gateway. Dedicated gateways stay available on LoadBalancer
+  # regions, where each gets its own LB.
   defp gateway_assignment(account, %Regions{} = region) do
-    if not Regions.private?(region) and dedicated_gateway?(account, region) do
+    if not Regions.private?(region) and not gateway_host_network?(region) and
+         dedicated_gateway?(account, region) do
       gateway_name = gateway_name(account, region)
 
       %{

--- a/server/test/tuist/kura/provisioner/kubernetes_controller_test.exs
+++ b/server/test/tuist/kura/provisioner/kubernetes_controller_test.exs
@@ -373,6 +373,36 @@ defmodule Tuist.Kura.Provisioner.KubernetesControllerTest do
       refute Map.has_key?(gateway_manifest["spec"], "hostNetwork")
     end
 
+    test "uses the shared regional ingress class (no dedicated gateway) for a dedicated account on a host-network region" do
+      stub(Tuist.Environment, :app_url, fn -> "https://tuist.dev" end)
+
+      stub(Tuist.Environment, :kura_control_plane_client_id, fn ->
+        "00000000-0000-0000-0000-000000000001"
+      end)
+
+      # tuist is a dedicated-gateway account, but on a host-network (bare-metal)
+      # region a second per-account host-network gateway can't bind the box's
+      # :443, so the account falls back to the shared regional gateway.
+      region =
+        us_east_region(%{
+          gateway: :host_network,
+          dedicated_gateway_account_handles: ["tuist"]
+        })
+
+      manifest =
+        KubernetesController.manifest(
+          "kura-tuist-us-east-1",
+          "0.5.2",
+          %{name: "tuist"},
+          region,
+          %Server{},
+          "return true"
+        )
+
+      assert manifest["spec"]["ingressClassName"] == "kura-us-east"
+      refute Map.has_key?(manifest["metadata"]["annotations"], "tuist.dev/kura-gateway")
+    end
+
     test "renders a host-network gateway without Hetzner LoadBalancer annotations on bare-metal regions" do
       region =
         us_east_region(%{


### PR DESCRIPTION
## What

On bare-metal (host-network) Kura regions, stop minting a per-account **dedicated** gateway. `gateway_assignment` now returns `nil` when the region's gateway is `:host_network`, so every account uses the region's **shared** ingress class, served by the platform gateway. Dedicated gateways are unchanged on LoadBalancer regions.

## Why

A host-network region's ingress is a **single host-network gateway** bound to the box's `:80/:443` — a per-node DaemonSet (`platform-kura-<region>-ingress-nginx-controller`) deployed by the platform chart, serving the region's shared class (`kura-<region>`).

But the server *also* creates a per-account **dedicated** host-network gateway for accounts flagged `dedicated_gateway?` (the `kura_dedicated_gateway_account_handles` env allowlist or the `:dedicated_kura_gateway` entitlement). Two host-network ingress-nginx controllers **cannot both bind `:443`** on the same box. Observed live on prod eu-central after the toleration fix ([#11599](https://github.com/tuist/tuist/pull/11599)) let the dedicated gateway past the node taint:

```
platform  platform-kura-eu-central-ingress-nginx-controller   1/1 Running (holds :443 on the box)
kura      kgw-799b0dea3467-eu-central-controller              0/1 Pending  -- "no free ports for the requested pod ports"
```

The dedicated gateway sits unschedulable, and the account's `KuraInstance` — pinned to the dedicated ingress class (`kura-eu-central-kgw-...`) rather than the shared `kura-eu-central` — never serves, even though the shared platform gateway is healthy.

This is a **cloud-LB-era assumption**: on LoadBalancer regions each dedicated account got its own LB, so N per-account gateways were free. On a single host-network box they collide on the port. Account isolation on bare metal is a **dedicated box**, not a dedicated gateway.

## How

`gateway_assignment` gains `and not gateway_host_network?(region)`. With `gateway = nil`, the instance manifest's `ingressClassName` falls through to the region's shared class (`ingress_class_name/2`), and no `KuraGateway` CR / `tuist.dev/kura-gateway` annotation is produced. This also removes the `replicas: 2` host-network over-provision (that was the dedicated Deployment; the platform gateway is already a per-node DaemonSet).

Case coverage:
- host-network + dedicated account → **shared class** (the fix)
- LoadBalancer + dedicated account → dedicated gateway (unchanged)
- non-dedicated account / private region → unchanged

## Validation

Added a test: a dedicated account on a host-network region gets `ingressClassName == "kura-us-east"` and no `tuist.dev/kura-gateway` annotation. Existing dedicated-gateway (LB) and host-network gateway tests still assert the prior behavior. `mix test test/tuist/kura/provisioner/kubernetes_controller_test.exs` (running).

## Rollout note

An already-provisioned instance on a host-network region keeps its dedicated class until it re-rolls (the `@manifest_revision` skip — converged instances don't re-apply). A dashboard **Destroy → Deploy** re-renders it onto the shared class and cleans up the orphaned Pending dedicated gateway CR. This is the last step to make prod eu-central actually serve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)