### PR TITLE
fix(infra): auto-recover silently-locked-up bare-metal Kura nodes so they stop wedging deploys

### DIFF
--- a/infra/cluster-api-provider-tuist/controllers/linux/linux_cloudinit.go
+++ b/infra/cluster-api-provider-tuist/controllers/linux/linux_cloudinit.go
@@ -75,6 +75,31 @@ net.bridge.bridge-nf-call-ip6tables = 1
 net.ipv4.ip_forward                 = 1
 `
 
+	// kernelHardeningSysctlContent turns a silent kernel lockup into an
+	// auto-rebooting panic instead of an indefinite freeze. A frozen bare-metal
+	// box otherwise sits Node NotReady forever (the default kernel.panic=0 never
+	// reboots), which strands its observability node-exporter DaemonSet pod below
+	// full availability, times out the observability chart's `helm --wait`, and
+	// wedges every deploy. The soft/hard lockup detectors panic on a stuck CPU;
+	// panic_on_oops promotes an oops to a panic; kernel.panic=10 reboots 10s after
+	// any panic. Applied to /etc/sysctl.d/99-tuist-hardening.conf.
+	kernelHardeningSysctlContent = `kernel.softlockup_panic = 1
+kernel.hardlockup_panic = 1
+kernel.panic_on_oops = 1
+kernel.panic = 10
+`
+
+	// watchdogDropInContent arms systemd's hardware watchdog: systemd pings
+	// /dev/watchdog every RuntimeWatchdogSec, so if PID 1 itself wedges (a total
+	// freeze that starves even the kernel lockup detectors the panic sysctls rely
+	// on) the hardware watchdog fires and resets the box. This is the backstop the
+	// panic sysctls can't provide. Boxes with no watchdog device just log and
+	// ignore it. Written to /etc/systemd/system.conf.d/10-tuist-watchdog.conf.
+	watchdogDropInContent = `[Manager]
+RuntimeWatchdogSec=30s
+RebootWatchdogSec=5min
+`
+
 	// dockerHubMirrorHostsContent is the containerd registry-host config that
 	// routes docker.io pulls through mirror.gcr.io, sidestepping Docker Hub's
 	// anonymous pull rate limit. Written to
@@ -167,6 +192,14 @@ func bootstrapBody(k8sMinor, sudo, sudoE string, writeFile func(producer, path s
 		fmt.Sprintf(`echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/%s/deb/ /"`, k8sMinor),
 		"/etc/apt/sources.list.d/kubernetes.list",
 	)
+	hardeningSysctl := writeFile(
+		"printf '%s' "+shellSingleQuote(kernelHardeningSysctlContent),
+		"/etc/sysctl.d/99-tuist-hardening.conf",
+	)
+	watchdogDropIn := writeFile(
+		"printf '%s' "+shellSingleQuote(watchdogDropInContent),
+		"/etc/systemd/system.conf.d/10-tuist-watchdog.conf",
+	)
 	return fmt.Sprintf(`%[7]s%[2]sswapoff -a
 %[2]ssed -ri '/\sswap\s/s/^/#/' /etc/fstab
 %[2]smodprobe overlay
@@ -177,6 +210,17 @@ func bootstrapBody(k8sMinor, sudo, sudoE string, writeFile func(producer, path s
 # recreates its own drop-ins after the node rejoins.
 %[2]srm -f /etc/sysctl.d/*cilium* /etc/sysctl.d/*-cilium.conf
 %[2]ssysctl --system
+# Bare-metal lockup hardening: turn a silent kernel freeze into an auto-reboot so
+# a hung box self-heals instead of sitting Node NotReady forever, which drops the
+# observability node-exporter DaemonSet below full availability and wedges every
+# deploy. The panic sysctls reboot on a detected lockup/oops; the systemd hardware
+# watchdog resets the box if PID 1 itself wedges. Both are applied tolerantly (a
+# missing knob or absent watchdog device must never abort the self-join).
+%[2]smkdir -p /etc/sysctl.d /etc/systemd/system.conf.d
+%[8]s
+%[2]ssysctl -p /etc/sysctl.d/99-tuist-hardening.conf 2>/dev/null || true
+%[9]s
+%[2]ssystemctl daemon-reexec || true
 export DEBIAN_FRONTEND=noninteractive
 %[3]sapt-get update
 %[3]sapt-get install -y apt-transport-https ca-certificates curl gpg containerd
@@ -210,7 +254,7 @@ curl -fsSL https://pkgs.k8s.io/core:/stable:/%[1]s/deb/Release.key | %[2]sgpg --
 %[2]sapt-mark hold kubelet
 %[2]ssystemctl daemon-reload
 %[2]ssystemctl enable --now kubelet`,
-		k8sMinor, sudo, sudoE, containerdConfig, aptSource, mirrorHosts, vlanSetup)
+		k8sMinor, sudo, sudoE, containerdConfig, aptSource, mirrorHosts, vlanSetup, hardeningSysctl, watchdogDropIn)
 }
 
 // vlanBringUp renders the PN-VLAN setup prepended to the bootstrap body when a

--- a/infra/cluster-api-provider-tuist/controllers/linux/linux_cloudinit_test.go
+++ b/infra/cluster-api-provider-tuist/controllers/linux/linux_cloudinit_test.go
@@ -100,6 +100,36 @@ func TestRenderLinuxCloudInit_DockerHubMirror(t *testing.T) {
 	}
 }
 
+func TestRenderLinux_LockupHardening(t *testing.T) {
+	// Both render forms must harden bare-metal boxes so a silent kernel lockup
+	// auto-reboots instead of stranding the node NotReady forever (which drops the
+	// observability node-exporter DaemonSet below full availability and wedges every
+	// deploy). Assert the panic sysctls and the systemd hardware watchdog land in
+	// the cloud-init (Instance) and SSH (Elastic Metal) forms alike, since both
+	// share bootstrapBody.
+	cloudInit := renderLinuxCloudInit("node-a", "apiVersion: v1\nkind: Config\n", "v1.34", nil)
+	script := renderLinuxBootstrapScript(linuxCloudInitOptions{
+		NodeName:       "node-a",
+		KubeconfigYAML: "apiVersion: v1\nkind: Config\n",
+		K8sMinor:       "v1.34",
+		BootstrapUser:  "ubuntu",
+	})
+	for _, out := range []string{cloudInit, script} {
+		for _, want := range []string{
+			"/etc/sysctl.d/99-tuist-hardening.conf",
+			"kernel.softlockup_panic = 1",
+			"kernel.panic = 10",
+			"/etc/systemd/system.conf.d/10-tuist-watchdog.conf",
+			"RuntimeWatchdogSec=30s",
+			"systemctl daemon-reexec",
+		} {
+			if !strings.Contains(out, want) {
+				t.Fatalf("expected lockup hardening to contain %q, got:\n%s", want, out)
+			}
+		}
+	}
+}
+
 func TestRenderLinuxCloudInit_ClusterDNS(t *testing.T) {
 	with := renderLinuxCloudInitWithOptions(linuxCloudInitOptions{
 		NodeName:       "node-a",

--- a/infra/helm/tuist/templates/dedibox-fleet.yaml
+++ b/infra/helm/tuist/templates/dedibox-fleet.yaml
@@ -85,4 +85,44 @@ spec:
         apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
         kind: DediboxMachineTemplate
         name: {{ $fleetName }}
+---
+{{- /*
+MachineHealthCheck — the auto-remediation backstop for a box that stays dead.
+The in-box bootstrap hardening (systemd hardware watchdog + panic sysctls) reboots
+a silently-locked-up box in ~30s without touching the OS, so this only fires when
+that self-heal fails: a Node NotReady for 10 continuous minutes is remediated. The
+provider has no reboot API for Dedibox — its only release path is a wipe-and-
+reinstall — so remediation reinstalls the box and re-adopts it once it comes back
+clean. Without this, a frozen box sits NotReady forever, drops the observability
+node-exporter DaemonSet below full availability, and wedges every deploy.
+
+unhealthyRange "[0-1]" remediates a single dead box but never reinstalls a whole
+region at once: a cluster-wide blip that NotReadies every replica is left for an
+operator rather than mass-reinstalled. nodeStartupTimeout is generous because a
+bare-metal reinstall + boot is slow.
+*/ -}}
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineHealthCheck
+metadata:
+  name: {{ $fleetName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "tuist.labels" . | nindent 4 }}
+    app.kubernetes.io/component: dedibox-fleet
+    tuist.dev/fleet: {{ $fleetName }}
+spec:
+  clusterName: {{ $clusterName }}
+  nodeStartupTimeout: 30m
+  unhealthyRange: "[0-1]"
+  selector:
+    matchLabels:
+      cluster.x-k8s.io/cluster-name: {{ $clusterName }}
+      tuist.dev/fleet: {{ $fleetName }}
+  unhealthyConditions:
+    - type: Ready
+      status: Unknown
+      timeout: 600s
+    - type: Ready
+      status: "False"
+      timeout: 600s
 {{- end }}

--- a/infra/helm/tuist/templates/kura-fleet.yaml
+++ b/infra/helm/tuist/templates/kura-fleet.yaml
@@ -87,4 +87,44 @@ spec:
         apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
         kind: ScalewayElasticMetalMachineTemplate
         name: {{ $fleetName }}
+---
+{{- /*
+MachineHealthCheck — the auto-remediation backstop for a box that stays dead.
+The in-box bootstrap hardening (systemd hardware watchdog + panic sysctls) reboots
+a silently-locked-up box in ~30s without touching the OS, so this only fires when
+that self-heal fails: a Node NotReady for 10 continuous minutes is remediated. The
+provider's release path is a wipe-and-reinstall, so remediation reinstalls the box
+and re-adopts it once it comes back clean. Without this, a frozen box sits NotReady
+forever, drops the observability node-exporter DaemonSet below full availability,
+and wedges every deploy.
+
+unhealthyRange "[0-1]" remediates a single dead box but never reinstalls a whole
+region at once: a cluster-wide blip that NotReadies every replica is left for an
+operator rather than mass-reinstalled. nodeStartupTimeout is generous because a
+bare-metal reinstall + boot is slow.
+*/ -}}
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineHealthCheck
+metadata:
+  name: {{ $fleetName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "tuist.labels" . | nindent 4 }}
+    app.kubernetes.io/component: kura-fleet
+    tuist.dev/fleet: {{ $fleetName }}
+spec:
+  clusterName: {{ $clusterName }}
+  nodeStartupTimeout: 30m
+  unhealthyRange: "[0-1]"
+  selector:
+    matchLabels:
+      cluster.x-k8s.io/cluster-name: {{ $clusterName }}
+      tuist.dev/fleet: {{ $fleetName }}
+  unhealthyConditions:
+    - type: Ready
+      status: Unknown
+      timeout: 600s
+    - type: Ready
+      status: "False"
+      timeout: 600s
 {{- end }}

--- a/infra/helm/tuist/templates/ovh-fleet.yaml
+++ b/infra/helm/tuist/templates/ovh-fleet.yaml
@@ -85,4 +85,44 @@ spec:
         apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
         kind: OVHDedicatedMachineTemplate
         name: {{ $fleetName }}
+---
+{{- /*
+MachineHealthCheck — the auto-remediation backstop for a box that stays dead.
+The in-box bootstrap hardening (systemd hardware watchdog + panic sysctls) reboots
+a silently-locked-up box in ~30s without touching the OS, so this only fires when
+that self-heal fails: a Node NotReady for 10 continuous minutes is remediated. The
+provider has no reboot API for OVH — its only release path is a wipe-and-reinstall
+— so remediation reinstalls the box and re-adopts it once it comes back clean.
+Without this, a frozen box sits NotReady forever, drops the observability
+node-exporter DaemonSet below full availability, and wedges every deploy.
+
+unhealthyRange "[0-1]" remediates a single dead box but never reinstalls a whole
+region at once: a cluster-wide blip that NotReadies every replica is left for an
+operator rather than mass-reinstalled. nodeStartupTimeout is generous because a
+bare-metal reinstall + boot is slow.
+*/ -}}
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineHealthCheck
+metadata:
+  name: {{ $fleetName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "tuist.labels" . | nindent 4 }}
+    app.kubernetes.io/component: ovh-fleet
+    tuist.dev/fleet: {{ $fleetName }}
+spec:
+  clusterName: {{ $clusterName }}
+  nodeStartupTimeout: 30m
+  unhealthyRange: "[0-1]"
+  selector:
+    matchLabels:
+      cluster.x-k8s.io/cluster-name: {{ $clusterName }}
+      tuist.dev/fleet: {{ $fleetName }}
+  unhealthyConditions:
+    - type: Ready
+      status: Unknown
+      timeout: 600s
+    - type: Ready
+      status: "False"
+      timeout: 600s
 {{- end }}


### PR DESCRIPTION
## What & why

A silent kernel lockup on a single-box bare-metal Kura region (Dedibox / OVH / Scaleway Elastic Metal) leaves its Node `NotReady` **indefinitely**, which silently wedges **every** production deploy.

Mechanism: the default `kernel.panic=0` never reboots a frozen box, and a self-joined node with a foreign providerID is never GC'd. A stuck node keeps its DaemonSet slot, so the observability `node-exporter` DaemonSet can never reach full availability (`Available: 8/9`), the observability chart's `helm upgrade --wait` times out at N-1/N, the canary job fails, and the whole production cascade fails **before it reaches prod** — unrelated to whatever is being deployed.

This just recurred twice within two days on the same canary Dedibox box ([run 28572967459](https://github.com/tuist/tuist/actions/runs/28572967459) and the newer main-push run `28575415298`), each time with no auto-recovery — a human had to IPMI-reset the box. This PR makes the box recover itself.

## Root cause

Two gaps compound:
1. A frozen kernel with `panic=0` and no watchdog **never reboots** — it sits dead forever.
2. There is **no auto-remediation** for the in-house CAPI provider's Linux bare-metal fleets. The caph/Hetzner ClusterClass has MachineHealthChecks; the Dedibox/OVH/Scaleway-EM fleets have none, so nothing notices a dead box.

## The fix — two layers

**1. Bootstrap hardening (primary, non-destructive self-heal)** — `infra/cluster-api-provider-tuist/controllers/linux/linux_cloudinit.go`

In the shared `bootstrapBody` (so every Linux fleet, and both the cloud-init and SSH render forms, get it):
- systemd hardware watchdog: `/etc/systemd/system.conf.d/10-tuist-watchdog.conf` (`RuntimeWatchdogSec=30s`) + `daemon-reexec`.
- panic sysctls: `/etc/sysctl.d/99-tuist-hardening.conf` (`kernel.softlockup_panic` / `hardlockup_panic` / `panic_on_oops=1` + `panic=10`).

A detected lockup becomes a **~30s auto-reboot**; the hardware watchdog catches a total freeze that starves the softlockup detector. Applied tolerantly (`|| true`) so a missing knob or an absent watchdog device can never abort the self-join.

Crucially, a reboot **preserves the warm cache**: `/var/cache/kura` is a local-path PVC on the box's persistent `/data` NVMe disk, and the StatefulSet pod is pinned by the local PV's nodeAffinity, so it re-mounts the same store on the same node after the reset. (`netconsole` from the original prevention plan was dropped — it needs an off-box log receiver we don't have; a target-less netconsole is a no-op.)

**2. MachineHealthCheck per fleet (backstop)** — `infra/helm/tuist/templates/{dedibox,ovh,kura}-fleet.yaml`

A standalone `cluster.x-k8s.io/v1beta1` MachineHealthCheck (the workload cluster where these fleets' Machines live serves only core v1beta1 — v1beta2 is on the separate caph mgmt cluster) remediates a Node `NotReady` for 10 continuous minutes — covering a box that can't self-reboot (dead watchdog / hardware fault). Applies to **existing** boxes immediately once deployed.

## Why this shape (and the trade-off to review)

The provider has **no reboot API** for Dedibox/OVH (Scaleway EM has one but it's unwired); `reconcileDelete` is a **destructive wipe-and-reinstall** that re-adopts the same box, with no auto-order. So MHC remediation is a ~15-30min reinstall that wipes the (regenerable, `reclaimPolicy: Delete`) cache. That is exactly why the caph bare-metal ClusterClass deliberately uses `unhealthyInRange: "[0-0]"` (operator investigates).

Chosen anyway, with guardrails: `unhealthyRange: "[0-1]"` remediates a single dead box but never mass-reinstalls a whole region on a cluster-wide blip, and `nodeStartupTimeout: 30m` avoids remediating a box that's still provisioning. The layering means the destructive reinstall is a genuine last resort: Layer 1 self-reboots the common case in ~30s with the cache intact; Layer 2 only fires when self-reboot fails. Silently wedging every deploy forever is strictly worse than a rare reinstall. **If you'd prefer the MHC start opt-in / alert-only, it's a small change — flag it.**

Layer 1 protects boxes provisioned after this change; Layer 2 protects existing boxes immediately. `helm --wait` does not track MachineHealthCheck (a custom kind), so the added CR cannot itself wedge the deploy — only a schema-invalid CR could, which is why the schema was validated.

## Impact

- Bare-metal Kura regions self-recover from a silent lockup in ~30s (cache preserved) instead of sitting dead until a human IPMI-resets them.
- Production deploys stop being gated by a single frozen bare-metal box.
- Forward-looking hardening applies on each box's next (re)provision; the MHC applies to existing boxes on deploy.

Note: this fix cannot deploy itself until the currently-frozen canary box is unblocked (it's gated behind the same observability wedge). The immediate unblock (IPMI reset, or `kubectl delete node`) is still a manual step; this change prevents recurrence.

## How to test locally

- `cd infra/cluster-api-provider-tuist && go test ./controllers/linux/` — includes a new `TestRenderLinux_LockupHardening` asserting the watchdog + panic sysctls land in both render forms.
- Render the fleet templates and confirm each emits a MachineHealthCheck alongside its MachineDeployment:
  `helm template tuist infra/helm/tuist -f infra/helm/tuist/values-managed-common.yaml -f infra/helm/tuist/values-managed-canary.yaml --show-only templates/dedibox-fleet.yaml`

## Validation run

- `gofmt`/`go vet` clean; `go build ./...` and the linux package tests (incl. the new hardening test) pass.
- All three MHCs render clean via `helm template`; the v1beta1 MHC schema was confirmed field-by-field against the served CRD with `kubectl explain machinehealthcheck.spec --api-version=cluster.x-k8s.io/v1beta1`.