### PR TITLE
fix(infra): capture a final runner metric sample at job end

### DIFF
--- a/infra/runner-image/dispatch-poll.sh
+++ b/infra/runner-image/dispatch-poll.sh
@@ -176,7 +176,15 @@ while true; do
       # `Tuist.Runners.Workers.FetchLogsWorker`); the runner VM
       # writes nothing to the ingest path.
       ./run.sh --jitconfig "${jit}" --disableupdate
-      exit $?
+      rc=$?
+      # Final metrics sample before the EXIT trap halts the VM. The
+      # looping sampler is killed mid-sleep by the shutdown, so the last
+      # interval — including "Complete job" — otherwise has no data point
+      # and the chart stops short of the job's end. One synchronous
+      # sample now, while the network is still up, closes that gap.
+      # Best-effort; never affects the runner's exit code.
+      [ -x /opt/tuist/metrics-poll.sh ] && /opt/tuist/metrics-poll.sh --once || true
+      exit "${rc}"
       ;;
     204)
       # Server has nothing for us yet. Keep polling — the VM is

--- a/infra/runner-image/metrics-poll.sh
+++ b/infra/runner-image/metrics-poll.sh
@@ -89,7 +89,8 @@ delta() {
   awk -v c="$1" -v p="$2" 'BEGIN { d = c - p; if (d < 0) d = 0; printf "%d", d }'
 }
 
-while true; do
+emit_sample() {
+  local ts cpu mem_used rx tx disk_used disk_total net_in net_out payload
   ts="$(date +%s)"
   cpu="$(cpu_busy_percent)"
   mem_used="$(mem_used_bytes)"
@@ -115,6 +116,20 @@ while true; do
     --header "Content-Type: application/json" \
     --data "${payload}" \
     "${metrics_url}" || true
+}
 
+# `--once` samples a single time and exits. dispatch-poll invokes it
+# right after the runner exits — before the EXIT trap halts the VM — so
+# the job's final moments (the tail past the loop's last sample,
+# including "Complete job") get a data point and the chart reaches the
+# job's end. A one-shot has no previous counters, so its network deltas
+# report 0; end-of-job throughput is ~0 anyway.
+if [ "${1:-}" = "--once" ]; then
+  emit_sample
+  exit 0
+fi
+
+while true; do
+  emit_sample
   sleep "${interval}"
 done


### PR DESCRIPTION
## What

Captures a final machine-metrics sample at the very end of a macOS runner job, so the charts reach the job's end instead of stopping ~one interval short (the "Complete job" step currently has no corresponding data point).

## Why

`metrics-poll.sh` loops *sample → sleep 15s*, and `dispatch-poll.sh`'s EXIT trap halts the VM (`shutdown -h now`) the instant `./run.sh` returns — killing the sampler mid-sleep. So the last interval, including "Complete job" and the post steps, never gets sampled.

Confirmed on job `84735487285`:

| | time |
|---|---|
| last metric sample | 09:25:19 |
| last step end | 09:25:28 |
| job completed | 09:25:32 |

A ~13s tail (one interval) with no data.

## How

- **`metrics-poll.sh`**: factor the per-iteration sample+POST into an `emit_sample` function and add a `--once` mode (one sample, no loop).
- **`dispatch-poll.sh`**: after `./run.sh` exits, capture its rc, run `metrics-poll.sh --once` (network still up, before the VM halts), then exit with the runner's rc.

Best-effort — it never affects the runner's exit code, and a failed sample just leaves the tail as-is. The one-shot has no previous counters so its network deltas report 0, which is fine since end-of-job throughput is ~0.

## Validation

- `shellcheck` clean on `metrics-poll.sh`; `dispatch-poll.sh` shows only its two pre-existing warnings (untouched). Both pass `bash -n`.

## Scope

- macOS runner image only (this is where the observed gap is). The Linux kata sidecar has a similar, smaller tail on pod termination and can be handled separately.
- Takes effect for VMs booted from the next runner-image roll.

This is the follow-up to the now-merged runner-metrics work (#11595: axis alignment + 8h token TTL + clock sync).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
