### PR TITLE
feat(cli): include SwiftPM C-family target headers in generated projects

### DIFF
--- a/cli/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
+++ b/cli/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
@@ -1022,10 +1022,17 @@ public struct PackageInfoMapper: PackageInfoMapping {
         let publicHeadersPath = try await target.publicHeadersPath(packageFolder: packageFolder)
         // Header extensions recognized by SwiftPM's `FileRuleDescription.header`.
         let headersGlob = "**/*.{h,hh,hpp,h++,hp,hxx,H,ipp,def}"
+        // SwiftPM's `exclude` paths are relative to the target's directory; drop headers under them so
+        // the generated target matches SwiftPM's discovery. Mirrors `SourceFilesList.from`.
+        let excluding: [ProjectDescription.Path] = try target.exclude.map {
+            let excludePath = targetPath.appending(try RelativePath(validating: $0))
+            let excludeGlob = excludePath.extension != nil ? excludePath : excludePath.appending(component: "**")
+            return .path(excludeGlob.pathString)
+        }
 
         return .headers(
-            public: .list([.glob(.path("\(publicHeadersPath.pathString)/\(headersGlob)"))]),
-            project: .list([.glob(.path("\(targetPath.pathString)/\(headersGlob)"))]),
+            public: .list([.glob(.path("\(publicHeadersPath.pathString)/\(headersGlob)"), excluding: excluding)]),
+            project: .list([.glob(.path("\(targetPath.pathString)/\(headersGlob)"), excluding: excluding)]),
             exclusionRule: .projectExcludesPrivateAndPublic
         )
     }

--- a/cli/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
+++ b/cli/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
@@ -827,7 +827,12 @@ public struct PackageInfoMapper: PackageInfoMapping {
         var resources: ProjectDescription.ResourceFileElements?
 
         if target.type.supportsPublicHeaderPath {
-            headers = try Headers.from(moduleMap: moduleMap)
+            headers = try await discoveredHeaders(
+                for: target,
+                moduleMap: moduleMap,
+                targetPath: targetPath,
+                packageFolder: path
+            )
         }
 
         if target.type.supportsSources {
@@ -990,6 +995,38 @@ public struct PackageInfoMapper: PackageInfoMapping {
             dependencies: dependencies,
             settings: settings,
             metadata: .metadata(tags: metadataTags)
+        )
+    }
+
+    /// Builds the headers for a target so the generated project mirrors how SwiftPM classifies
+    /// them: every header under the target's public headers directory (recursively) is public,
+    /// and every other header in the target is a project (private) header. This matches the file
+    /// discovery SwiftPM performs for C-family targets, including the recognized header extensions.
+    ///
+    /// Only targets with a module map (i.e. C-family targets) have headers. Swift targets resolve
+    /// to `ModuleMap.none` and keep `nil` headers.
+    private func discoveredHeaders(
+        for target: PackageInfo.Target,
+        moduleMap: ModuleMap?,
+        targetPath: AbsolutePath,
+        packageFolder: AbsolutePath
+    ) async throws -> ProjectDescription.Headers? {
+        guard let moduleMap else { return nil }
+        switch moduleMap {
+        case .none:
+            return nil
+        case .custom, .header, .directory:
+            break
+        }
+
+        let publicHeadersPath = try await target.publicHeadersPath(packageFolder: packageFolder)
+        // Header extensions recognized by SwiftPM's `FileRuleDescription.header`.
+        let headersGlob = "**/*.{h,hh,hpp,h++,hp,hxx,H,ipp,def}"
+
+        return .headers(
+            public: .list([.glob(.path("\(publicHeadersPath.pathString)/\(headersGlob)"))]),
+            project: .list([.glob(.path("\(targetPath.pathString)/\(headersGlob)"))]),
+            exclusionRule: .projectExcludesPrivateAndPublic
         )
     }
 
@@ -1966,26 +2003,6 @@ extension ProjectDescription.TargetDependency {
         }
 
         return targetDependencies + linkerDependencies
-    }
-}
-
-extension ProjectDescription.Headers {
-    fileprivate static func from(moduleMap: ModuleMap?) throws -> Self? {
-        guard let moduleMap else { return nil }
-        // As per SPM logic, headers should be added only when using the umbrella header without modulemap:
-        // https://github.com/apple/swift-package-manager/blob/9b9bed7eaf0f38eeccd0d8ca06ae08f6689d1c3f/Sources/Xcodeproj/pbxproj.swift#L588-L609
-        switch moduleMap {
-        case let .directory(moduleMapPath: _, umbrellaDirectory: umbrellaDirectory):
-            return .headers(
-                public: .list(
-                    [
-                        .glob("\(umbrellaDirectory.pathString)/*.h"),
-                    ]
-                )
-            )
-        case .none, .header, .custom:
-            return nil
-        }
     }
 }
 

--- a/cli/Tests/TuistGeneratorAcceptanceTests/GenerateAcceptanceTests.swift
+++ b/cli/Tests/TuistGeneratorAcceptanceTests/GenerateAcceptanceTests.swift
@@ -582,13 +582,13 @@ struct GenerateAcceptanceTestAppWithSPMCTargetHeaders {
             pathString: fixturePath.appending(components: "CLibPkg", "CLibPkg.xcodeproj").pathString
         )
         let target = try #require(xcodeproj.pbxproj.nativeTargets.first(where: { $0.name == "CLib" }))
-        let headerFiles = try target.headersBuildPhase()?.files ?? []
+        let headerFiles = target.buildPhases.compactMap { $0 as? PBXHeadersBuildPhase }.first?.files ?? []
         let headerNames = Set(headerFiles.compactMap { $0.file?.path })
 
         #expect(headerNames.isSuperset(of: ["CLib.h", "Deep.h", "CLibInternal.h"]))
 
         func attributes(of name: String) -> [String] {
-            headerFiles.first(where: { $0.file?.path == name })?.attributes ?? []
+            headerFiles.first(where: { $0.file?.path == name })?.settings?["ATTRIBUTES"]?.arrayValue ?? []
         }
         // Headers under the public headers directory (recursively) are public; others are project headers.
         #expect(attributes(of: "CLib.h").contains("Public"))

--- a/cli/Tests/TuistGeneratorAcceptanceTests/GenerateAcceptanceTests.swift
+++ b/cli/Tests/TuistGeneratorAcceptanceTests/GenerateAcceptanceTests.swift
@@ -566,11 +566,11 @@ struct GenerateAcceptanceTestiOSAppWithObjCStaticFrameworkPackage {
 }
 
 struct GenerateAcceptanceTestAppWithSPMCTargetHeaders {
-    // Regression coverage for the request to include SwiftPM target headers in generated projects
-    // (https://community.tuist.dev/t/988): a C-family SwiftPM target's headers must appear in the
-    // generated project, matching how SwiftPM classifies them. Before the fix, a target with a custom
-    // module map produced no headers at all, and nested/non-public headers were dropped, so this
-    // assertion fails without it (red -> green).
+    /// Regression coverage for the request to include SwiftPM target headers in generated projects
+    /// (https://community.tuist.dev/t/988): a C-family SwiftPM target's headers must appear in the
+    /// generated project, matching how SwiftPM classifies them. Before the fix, a target with a custom
+    /// module map produced no headers at all, and nested/non-public headers were dropped, so this
+    /// assertion fails without it (red -> green).
     @Test(.withFixture("generated_app_with_spm_c_target_headers"), .inTemporaryDirectory)
     func app_with_spm_c_target_headers() async throws {
         let fixturePath = try fixtureDirectory()

--- a/cli/Tests/TuistGeneratorAcceptanceTests/GenerateAcceptanceTests.swift
+++ b/cli/Tests/TuistGeneratorAcceptanceTests/GenerateAcceptanceTests.swift
@@ -565,6 +565,38 @@ struct GenerateAcceptanceTestiOSAppWithObjCStaticFrameworkPackage {
     }
 }
 
+struct GenerateAcceptanceTestAppWithSPMCTargetHeaders {
+    // Regression coverage for the request to include SwiftPM target headers in generated projects
+    // (https://community.tuist.dev/t/988): a C-family SwiftPM target's headers must appear in the
+    // generated project, matching how SwiftPM classifies them. Before the fix, a target with a custom
+    // module map produced no headers at all, and nested/non-public headers were dropped, so this
+    // assertion fails without it (red -> green).
+    @Test(.withFixture("generated_app_with_spm_c_target_headers"), .inTemporaryDirectory)
+    func app_with_spm_c_target_headers() async throws {
+        let fixturePath = try fixtureDirectory()
+
+        try await run(InstallCommand.self)
+        try await run(GenerateCommand.self)
+
+        let xcodeproj = try XcodeProj(
+            pathString: fixturePath.appending(components: "CLibPkg", "CLibPkg.xcodeproj").pathString
+        )
+        let target = try #require(xcodeproj.pbxproj.nativeTargets.first(where: { $0.name == "CLib" }))
+        let headerFiles = try target.headersBuildPhase()?.files ?? []
+        let headerNames = Set(headerFiles.compactMap { $0.file?.path })
+
+        #expect(headerNames.isSuperset(of: ["CLib.h", "Deep.h", "CLibInternal.h"]))
+
+        func attributes(of name: String) -> [String] {
+            headerFiles.first(where: { $0.file?.path == name })?.attributes ?? []
+        }
+        // Headers under the public headers directory (recursively) are public; others are project headers.
+        #expect(attributes(of: "CLib.h").contains("Public"))
+        #expect(attributes(of: "Deep.h").contains("Public"))
+        #expect(!attributes(of: "CLibInternal.h").contains("Public"))
+    }
+}
+
 struct GenerateAcceptanceTestiOSAppWithMultiConfigs {
     @Test(.disabled(), .withFixture("generated_ios_app_with_multi_configs"), .inTemporaryDirectory)
     func ios_app_with_multi_configs() async throws {

--- a/cli/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
+++ b/cli/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
@@ -2068,6 +2068,7 @@ struct PackageInfoMapperTests {
                         .test(
                             "Target1",
                             basePath: basePath,
+                            headers: .spmTarget(headersPath.parentDirectory),
                             customSettings: [
                                 "HEADER_SEARCH_PATHS": ["$(inherited)", "$(SRCROOT)/Sources/Target1/include"],
                                 "DEFINES_MODULE": "NO",
@@ -2125,6 +2126,7 @@ struct PackageInfoMapperTests {
                             "target-with-dashes",
                             basePath: basePath,
                             customProductName: "target_with_dashes",
+                            headers: .spmTarget(headersPath.parentDirectory),
                             customSettings: [
                                 "HEADER_SEARCH_PATHS": ["$(inherited)", "$(SRCROOT)/Sources/target-with-dashes/include"],
                                 "DEFINES_MODULE": "NO",
@@ -2273,6 +2275,7 @@ struct PackageInfoMapperTests {
                         .test(
                             "Target1",
                             basePath: basePath,
+                            headers: .spmTarget(headersPath.parentDirectory),
                             customSettings: [
                                 "HEADER_SEARCH_PATHS": ["$(inherited)", "$(SRCROOT)/Sources/Target1/include"],
                                 "MODULEMAP_FILE": .string("$(SRCROOT)/Derived/Target1.modulemap"),
@@ -2339,6 +2342,7 @@ struct PackageInfoMapperTests {
                         .test(
                             "Target1",
                             basePath: basePath,
+                            headers: .spmTarget(target1HeadersPath.parentDirectory),
                             dependencies: [.target(name: "Dependency1")],
                             customSettings: [
                                 "HEADER_SEARCH_PATHS": [
@@ -2356,6 +2360,7 @@ struct PackageInfoMapperTests {
                         .test(
                             "Dependency1",
                             basePath: basePath,
+                            headers: .spmTarget(dependency1HeadersPath.parentDirectory),
                             dependencies: [.target(name: "Dependency2")],
                             customSettings: [
                                 "HEADER_SEARCH_PATHS": [
@@ -2373,6 +2378,7 @@ struct PackageInfoMapperTests {
                         .test(
                             "Dependency2",
                             basePath: basePath,
+                            headers: .spmTarget(dependency2HeadersPath.parentDirectory),
                             customSettings: [
                                 "HEADER_SEARCH_PATHS": [
                                     "$(inherited)",
@@ -2471,6 +2477,7 @@ struct PackageInfoMapperTests {
                         .test(
                             "Target1",
                             basePath: basePath,
+                            headers: .spmTarget(target1HeadersPath.parentDirectory),
                             dependencies: [.external(name: "Dependency1", condition: nil)],
                             customSettings: [
                                 "HEADER_SEARCH_PATHS": [
@@ -2553,6 +2560,7 @@ struct PackageInfoMapperTests {
                                     tags: []
                                 ),
                             ],
+                            headers: .spmTarget(headersPath.parentDirectory, publicHeadersRelativePath: "Headers"),
                             customSettings: [
                                 "HEADER_SEARCH_PATHS": ["$(inherited)", "$(SRCROOT)/Custom/Headers"],
                                 "DEFINES_MODULE": "NO",
@@ -2682,11 +2690,7 @@ struct PackageInfoMapperTests {
                         .test(
                             "Dependency1",
                             basePath: basePath,
-                            headers: .headers(
-                                public: .list(
-                                    [.glob(.path("\(dependencyHeadersPath.pathString)/*.h"))]
-                                )
-                            ),
+                            headers: .spmTarget(dependencyHeadersPath.parentDirectory),
                             customSettings: [
                                 "HEADER_SEARCH_PATHS": ["$(inherited)", "$(SRCROOT)/Sources/Dependency1/include"],
                                 "DEFINES_MODULE": "NO",
@@ -7263,6 +7267,7 @@ struct PackageInfoMapperTests {
                             "Singular",
                             basePath: basePath,
                             customProductName: "SingularWrapper",
+                            headers: .spmTarget(headersPath.parentDirectory),
                             dependencies: [.xcframework(path: .path(
                                 basePath
                                     .appending(try RelativePath(validating: "Singular.xcframework"))
@@ -8076,6 +8081,23 @@ extension ProjectDescription.Target {
                 with: customSettings,
                 moduleMap: moduleMap
             )
+        )
+    }
+}
+
+extension ProjectDescription.Headers {
+    /// Mirrors the headers `PackageInfoMapper` produces for a C-family SwiftPM target: public headers
+    /// under the target's public headers directory (recursively) and all other headers as project headers.
+    fileprivate static func spmTarget(
+        _ targetBasePath: AbsolutePath,
+        publicHeadersRelativePath: String = "include"
+    ) -> ProjectDescription.Headers {
+        let publicHeadersPath = targetBasePath.appending(try! RelativePath(validating: publicHeadersRelativePath))
+        let glob = "**/*.{h,hh,hpp,h++,hp,hxx,H,ipp,def}"
+        return .headers(
+            public: .list([.glob(.path("\(publicHeadersPath.pathString)/\(glob)"))]),
+            project: .list([.glob(.path("\(targetBasePath.pathString)/\(glob)"))]),
+            exclusionRule: .projectExcludesPrivateAndPublic
         )
     }
 }

--- a/cli/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
+++ b/cli/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
@@ -2117,36 +2117,19 @@ struct PackageInfoMapperTests {
                 ),
             ]
         )
+        // A target's `exclude` paths must also drop matching headers, matching SwiftPM's discovery.
+        let target = try #require(project?.targets.first)
         #expect(
-            project ==
-                .testWithDefaultConfigs(
-                    name: "Package",
-                    targets: [
-                        .test(
-                            "Target1",
-                            basePath: basePath,
-                            headers: .spmTarget(
-                                headersPath.parentDirectory,
-                                excluding: [
-                                    .path(
-                                        basePath
-                                            .appending(try RelativePath(validating: "Package/Sources/Target1/Excluded/**"))
-                                            .pathString
-                                    ),
-                                ]
-                            ),
-                            customSettings: [
-                                "HEADER_SEARCH_PATHS": ["$(inherited)", "$(SRCROOT)/Sources/Target1/include"],
-                                "DEFINES_MODULE": "NO",
-                                "OTHER_CFLAGS": .array(["$(inherited)", "-fmodule-name=Target1"]),
-                                "OTHER_SWIFT_FLAGS": [
-                                    "$(inherited)",
-                                ],
-                            ],
-                            moduleMap: "$(SRCROOT)/Sources/Target1/include/module.modulemap"
-                        ),
-                    ]
-                )
+            target.headers == .spmTarget(
+                headersPath.parentDirectory,
+                excluding: [
+                    .path(
+                        basePath
+                            .appending(try RelativePath(validating: "Package/Sources/Target1/Excluded/**"))
+                            .pathString
+                    ),
+                ]
+            )
         )
     }
 

--- a/cli/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
+++ b/cli/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
@@ -2084,6 +2084,72 @@ struct PackageInfoMapperTests {
         )
     }
 
+    @Test(.inTemporaryDirectory, .withMockedSwiftVersionProvider) func map_whenHasHeadersWithExclude() async throws {
+        let basePath = try #require(FileSystem.temporaryTestDirectory)
+        let headersPath = basePath.appending(try RelativePath(validating: "Package/Sources/Target1/include"))
+        let moduleMapPath = headersPath.appending(component: "module.modulemap")
+        let headerPath = headersPath.appending(component: "AnHeader.h")
+        try await fileSystem.makeDirectory(at: headersPath)
+        try await fileSystem.writeText("", at: moduleMapPath)
+        try await fileSystem.writeText("", at: headerPath)
+
+        let project = try await subject.map(
+            package: "Package",
+            basePath: basePath,
+            packageInfos: [
+                "Package": .test(
+                    name: "Package",
+                    products: [
+                        .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
+                    ],
+                    targets: [
+                        .test(
+                            name: "Target1",
+                            exclude: [
+                                "Excluded",
+                            ]
+                        ),
+                    ],
+                    platforms: [.ios],
+                    cLanguageStandard: nil,
+                    cxxLanguageStandard: nil,
+                    swiftLanguageVersions: nil
+                ),
+            ]
+        )
+        #expect(
+            project ==
+                .testWithDefaultConfigs(
+                    name: "Package",
+                    targets: [
+                        .test(
+                            "Target1",
+                            basePath: basePath,
+                            headers: .spmTarget(
+                                headersPath.parentDirectory,
+                                excluding: [
+                                    .path(
+                                        basePath
+                                            .appending(try RelativePath(validating: "Package/Sources/Target1/Excluded/**"))
+                                            .pathString
+                                    ),
+                                ]
+                            ),
+                            customSettings: [
+                                "HEADER_SEARCH_PATHS": ["$(inherited)", "$(SRCROOT)/Sources/Target1/include"],
+                                "DEFINES_MODULE": "NO",
+                                "OTHER_CFLAGS": .array(["$(inherited)", "-fmodule-name=Target1"]),
+                                "OTHER_SWIFT_FLAGS": [
+                                    "$(inherited)",
+                                ],
+                            ],
+                            moduleMap: "$(SRCROOT)/Sources/Target1/include/module.modulemap"
+                        ),
+                    ]
+                )
+        )
+    }
+
     @Test(
         .inTemporaryDirectory,
         .withMockedSwiftVersionProvider
@@ -8090,13 +8156,14 @@ extension ProjectDescription.Headers {
     /// under the target's public headers directory (recursively) and all other headers as project headers.
     fileprivate static func spmTarget(
         _ targetBasePath: AbsolutePath,
-        publicHeadersRelativePath: String = "include"
+        publicHeadersRelativePath: String = "include",
+        excluding: [ProjectDescription.Path] = []
     ) -> ProjectDescription.Headers {
         let publicHeadersPath = targetBasePath.appending(try! RelativePath(validating: publicHeadersRelativePath))
         let glob = "**/*.{h,hh,hpp,h++,hp,hxx,H,ipp,def}"
         return .headers(
-            public: .list([.glob(.path("\(publicHeadersPath.pathString)/\(glob)"))]),
-            project: .list([.glob(.path("\(targetBasePath.pathString)/\(glob)"))]),
+            public: .list([.glob(.path("\(publicHeadersPath.pathString)/\(glob)"), excluding: excluding)]),
+            project: .list([.glob(.path("\(targetBasePath.pathString)/\(glob)"), excluding: excluding)]),
             exclusionRule: .projectExcludesPrivateAndPublic
         )
     }

--- a/examples/xcode/generated_app_with_spm_c_target_headers/.gitignore
+++ b/examples/xcode/generated_app_with_spm_c_target_headers/.gitignore
@@ -1,0 +1,4 @@
+.build/
+Derived/
+*.xcodeproj
+*.xcworkspace

--- a/examples/xcode/generated_app_with_spm_c_target_headers/CLibPkg/Package.swift
+++ b/examples/xcode/generated_app_with_spm_c_target_headers/CLibPkg/Package.swift
@@ -1,0 +1,7 @@
+// swift-tools-version:5.9
+import PackageDescription
+let package = Package(
+    name: "CLibPkg",
+    products: [.library(name: "CLib", targets: ["CLib"])],
+    targets: [.target(name: "CLib")]
+)

--- a/examples/xcode/generated_app_with_spm_c_target_headers/CLibPkg/Sources/CLib/CLib.c
+++ b/examples/xcode/generated_app_with_spm_c_target_headers/CLibPkg/Sources/CLib/CLib.c
@@ -1,0 +1,4 @@
+#include "CLib.h"
+#include "CLibInternal.h"
+void clib_public(void) {}
+void clib_internal(void) {}

--- a/examples/xcode/generated_app_with_spm_c_target_headers/CLibPkg/Sources/CLib/CLibInternal.h
+++ b/examples/xcode/generated_app_with_spm_c_target_headers/CLibPkg/Sources/CLib/CLibInternal.h
@@ -1,0 +1,2 @@
+#pragma once
+void clib_internal(void);

--- a/examples/xcode/generated_app_with_spm_c_target_headers/CLibPkg/Sources/CLib/include/CLib.h
+++ b/examples/xcode/generated_app_with_spm_c_target_headers/CLibPkg/Sources/CLib/include/CLib.h
@@ -1,0 +1,2 @@
+#pragma once
+void clib_public(void);

--- a/examples/xcode/generated_app_with_spm_c_target_headers/CLibPkg/Sources/CLib/include/Sub/Deep.h
+++ b/examples/xcode/generated_app_with_spm_c_target_headers/CLibPkg/Sources/CLib/include/Sub/Deep.h
@@ -1,0 +1,2 @@
+#pragma once
+void clib_deep(void);

--- a/examples/xcode/generated_app_with_spm_c_target_headers/CLibPkg/Sources/CLib/include/module.modulemap
+++ b/examples/xcode/generated_app_with_spm_c_target_headers/CLibPkg/Sources/CLib/include/module.modulemap
@@ -1,0 +1,4 @@
+module CLib {
+    header "CLib.h"
+    export *
+}

--- a/examples/xcode/generated_app_with_spm_c_target_headers/Project.swift
+++ b/examples/xcode/generated_app_with_spm_c_target_headers/Project.swift
@@ -1,0 +1,14 @@
+import ProjectDescription
+let project = Project(
+    name: "App",
+    targets: [
+        .target(
+            name: "App",
+            destinations: [.mac],
+            product: .commandLineTool,
+            bundleId: "dev.tuist.App",
+            sources: ["Sources/**"],
+            dependencies: [.external(name: "CLib")]
+        ),
+    ]
+)

--- a/examples/xcode/generated_app_with_spm_c_target_headers/Sources/App/main.swift
+++ b/examples/xcode/generated_app_with_spm_c_target_headers/Sources/App/main.swift
@@ -1,0 +1,2 @@
+import CLib
+print("hi")

--- a/examples/xcode/generated_app_with_spm_c_target_headers/Tuist.swift
+++ b/examples/xcode/generated_app_with_spm_c_target_headers/Tuist.swift
@@ -1,0 +1,2 @@
+import ProjectDescription
+let tuist = Tuist(project: .tuist())

--- a/examples/xcode/generated_app_with_spm_c_target_headers/Tuist/Package.swift
+++ b/examples/xcode/generated_app_with_spm_c_target_headers/Tuist/Package.swift
@@ -1,0 +1,16 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+#if TUIST
+import ProjectDescription
+let packageSettings = PackageSettings(
+    productTypes: ["CLib": .staticFramework]
+)
+#endif
+
+let package = Package(
+    name: "Deps",
+    dependencies: [
+        .package(path: "../CLibPkg"),
+    ]
+)


### PR DESCRIPTION
## What changed

Generated projects now surface a C-family SwiftPM target's headers the way SwiftPM itself classifies them:

- Every header under the target's public headers directory (default `include`, matched **recursively**) becomes a **public** header.
- Every other header in the target becomes a **project** (private) header.
- The recognized header extensions match SwiftPM's own `FileRuleDescription.header` (`h`, `hh`, `hpp`, `h++`, `hp`, `hxx`, `H`, `ipp`, `def`).

Concretely, `Headers.from(moduleMap:)` is replaced by `PackageInfoMapper.discoveredHeaders`, which globs the public and project headers and leans on the `Headers` exclusion rule (`.projectExcludesPrivateAndPublic`) to de-duplicate so a header is never both public and project.

Addresses the community request: https://community.tuist.dev/t/feature-request-include-swiftpm-target-headers-in-generated-xcode-projects/988

## Why

When a SwiftPM C-family target is integrated into a generated Xcode project, its headers need to be present in the target so downstream code (and the module) can `#include` them. Without them, consumers of the package see missing headers in the generated project even though the sources compile under `swift build`. This is one of the Tuist gaps blocking OpenSwiftUI from generating its project with Tuist.

## Root cause

The previous implementation (`Headers.from(moduleMap:)`) only produced headers for a single, narrow case: the generated **umbrella-directory** module map, and only for top-level `include/*.h`. That means:

- Targets with a **custom** `module.modulemap` produced **no headers at all**.
- Targets with an **umbrella header** produced no headers.
- **Nested** headers (e.g. `include/Sub/Deep.h`) were dropped.
- **Non-`.h`** headers (`.hpp`, `.hxx`, etc.) were dropped.
- **Private/project** headers (those outside `include`) were never emitted.

So the generated project silently diverged from what SwiftPM classifies for the same target.

## Why this approach

Rather than extend the special-cased umbrella-directory branch with more special cases, the fix mirrors SwiftPM's own file-discovery model directly: public = everything under the public headers directory (recursively), project = everything else in the target, with the recognized header extension set. The exclusion rule keeps a public header from also being listed as a project header, so the classification stays a single source of truth instead of two hand-maintained branches. This generalizes across the custom-module-map, umbrella-header, and generated-module-map cases uniformly.

## Impact

- Generated projects that consume C-family SwiftPM targets now include the target's headers with correct public/project visibility, including nested and non-`.h` headers.
- No change for Swift-only targets: they resolve to `ModuleMap.none` and keep `nil` headers.

## Validation

- **Acceptance test (red -> green):** new `generated_app_with_spm_c_target_headers` fixture and `GenerateAcceptanceTestAppWithSPMCTargetHeaders`. The fixture is a C target (`CLib`) with a custom `module.modulemap`, a nested public header (`include/Sub/Deep.h`), and a private header (`CLibInternal.h`). The test generates the project and asserts the header build phase contains `CLib.h`, `Deep.h`, and `CLibInternal.h`, with `CLib.h`/`Deep.h` marked `Public` and `CLibInternal.h` not. Without the fix the target has no headers, so the assertion fails.
- **Unit tests:** `PackageInfoMapperTests` updated to assert the SwiftPM-matching headers via a `Headers.spmTarget(...)` helper across the existing C-target scenarios (custom module map, umbrella header, dashed target name, transitive/external dependencies, etc.).

## Notes

Opening as a draft for early review/direction from the Tuist team, per the discussion on 988.
