### PR TITLE
perf(server): compile a single locale in :test to speed up cold test builds

### DIFF
--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -216,6 +216,11 @@ jobs:
     runs-on: tuist-linux-large
     timeout-minutes: 30
     if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
+    # Local `mix test` compiles only the "en" locale for fast cold builds
+    # (Tuist.Environment.single_locale?/0). CI opts into the full ex_cldr/Gettext
+    # locale set so the `:locale`-tagged i18n tests run and are covered here.
+    env:
+      TUIST_DEV_ALL_LOCALES: "1"
     services:
       postgres:
         image: public.ecr.aws/docker/library/postgres:16

--- a/server/AGENTS.md
+++ b/server/AGENTS.md
@@ -62,6 +62,7 @@ mise run dev
 - `mix test test/path/to/specific_test.exs`
 - `mix test test/path/to/test_file.exs:line_number_of_test`
 - `mix test --only tag_name`
+- The `:test` env compiles only the `"en"` locale by default so a cold `_build/test` (e.g. a fresh worktree) doesn't generate ex_cldr code for all ten locales. Tests that assert other locales' formatting/normalization are tagged `:locale` and excluded by default. Run `TUIST_DEV_ALL_LOCALES=1 mix test` to compile the full locale set and include them (this is what CI does).
 
 **Code Quality**
 - `mix credo`

--- a/server/lib/tuist/cldr/configuration.ex
+++ b/server/lib/tuist/cldr/configuration.ex
@@ -3,7 +3,7 @@ defmodule Tuist.Cldr.Configuration do
 
   defmacro __using__(_opts) do
     locales =
-      if Tuist.Environment.dev_single_locale?() do
+      if Tuist.Environment.single_locale?() do
         ["en"]
       else
         ["ar", "en", "es", "ja", "ka", "ko", "ru", "yue-Hant", "zh-Hans", "zh-Hant"]

--- a/server/lib/tuist/environment.ex
+++ b/server/lib/tuist/environment.ex
@@ -227,7 +227,13 @@ defmodule Tuist.Environment do
 
   def dev_all_locales?, do: @dev_all_locales
 
-  def dev_single_locale?, do: dev?() and not dev_all_locales?()
+  # Both :dev and :test compile a single locale ("en") by default so the
+  # ex_cldr backend doesn't generate number/currency/datetime code for all
+  # ten locales on every cold compile. A fresh worktree's :test build paid
+  # that cost on the first `mix test`, dominating the compile time. Tests
+  # that genuinely exercise other locales are tagged `:locale` and only run
+  # when TUIST_DEV_ALL_LOCALES=1 flips this back to the full set.
+  def single_locale?, do: (dev?() or test?()) and not dev_all_locales?()
 
   def log_level do
     "TUIST_LOG_LEVEL" |> System.get_env("info") |> String.to_atom()

--- a/server/lib/tuist/locale.ex
+++ b/server/lib/tuist/locale.ex
@@ -13,7 +13,7 @@ defmodule Tuist.Locale do
     %{code: "zh_Hant", label: "Chinese (Traditional)", native: "繁體中文"}
   ]
 
-  @languages (if Tuist.Environment.dev_single_locale?() do
+  @languages (if Tuist.Environment.single_locale?() do
                 Enum.filter(@all_languages, &(&1.code == "en"))
               else
                 @all_languages

--- a/server/lib/tuist_web/gettext/configuration.ex
+++ b/server/lib/tuist_web/gettext/configuration.ex
@@ -3,7 +3,7 @@ defmodule TuistWeb.Gettext.Configuration do
 
   defmacro __using__(_opts) do
     allowed_locales =
-      if Tuist.Environment.dev_single_locale?() do
+      if Tuist.Environment.single_locale?() do
         ["en"]
       else
         ~w(ar en es ja ka ko pl pt ru tr yue_Hant zh_Hans zh_Hant)

--- a/server/test/test_helper.exs
+++ b/server/test/test_helper.exs
@@ -180,6 +180,13 @@ end
   {&TuistTestSupport.LoggerFilters.filter_db_connection_sandbox_teardown/2, []}
 )
 
-ExUnit.start(capture_log: true, exclude: [:skip])
+# The :test env compiles only the "en" locale by default (see
+# Tuist.Environment.single_locale?/0) to keep cold compiles fast. Tests tagged
+# `:locale` assert behaviour of the other locales' ex_cldr/Gettext data, which
+# isn't compiled in that mode, so exclude them unless TUIST_DEV_ALL_LOCALES=1
+# built the full locale set.
+locale_exclude = if Tuist.Environment.dev_all_locales?(), do: [], else: [:locale]
+
+ExUnit.start(capture_log: true, exclude: [:skip] ++ locale_exclude)
 Sandbox.mode(Tuist.Repo, :manual)
 Sandbox.mode(Tuist.IngestRepo, :manual)

--- a/server/test/tuist/accounts/user_test.exs
+++ b/server/test/tuist/accounts/user_test.exs
@@ -65,6 +65,8 @@ defmodule Tuist.Accounts.UserTest do
   end
 
   describe "preferred_locale_changeset/2" do
+    # "es" is only a valid supported locale when TUIST_DEV_ALL_LOCALES=1.
+    @tag :locale
     test "accepts a supported locale" do
       got = User.preferred_locale_changeset(%User{}, %{preferred_locale: "es"})
 

--- a/server/test/tuist/accounts_test.exs
+++ b/server/test/tuist/accounts_test.exs
@@ -4138,6 +4138,8 @@ defmodule Tuist.AccountsTest do
   end
 
   describe "update_user_preferred_locale/2" do
+    # "es"/"ja" are only valid supported locales when TUIST_DEV_ALL_LOCALES=1.
+    @tag :locale
     test "sets a supported locale" do
       # Given
       user = AccountsFixtures.user_fixture()
@@ -4149,6 +4151,7 @@ defmodule Tuist.AccountsTest do
       assert updated_user.preferred_locale == "es"
     end
 
+    @tag :locale
     test "clears the locale when set to nil" do
       # Given
       user = AccountsFixtures.user_fixture()

--- a/server/test/tuist_web/helpers/cldr_helpers_test.exs
+++ b/server/test/tuist_web/helpers/cldr_helpers_test.exs
@@ -3,9 +3,9 @@ defmodule TuistWeb.CldrHelpersTest do
 
   # Formats numbers/money/percentages in non-en locales, whose ex_cldr data is
   # only compiled when TUIST_DEV_ALL_LOCALES=1.
-  @moduletag :locale
-
   import TuistWeb.CldrHelpers
+
+  @moduletag :locale
 
   test "formats numbers using the current locale" do
     Gettext.put_locale(TuistWeb.Gettext, "es")

--- a/server/test/tuist_web/helpers/cldr_helpers_test.exs
+++ b/server/test/tuist_web/helpers/cldr_helpers_test.exs
@@ -1,6 +1,10 @@
 defmodule TuistWeb.CldrHelpersTest do
   use ExUnit.Case, async: true
 
+  # Formats numbers/money/percentages in non-en locales, whose ex_cldr data is
+  # only compiled when TUIST_DEV_ALL_LOCALES=1.
+  @moduletag :locale
+
   import TuistWeb.CldrHelpers
 
   test "formats numbers using the current locale" do

--- a/server/test/tuist_web/locale_test.exs
+++ b/server/test/tuist_web/locale_test.exs
@@ -4,14 +4,14 @@ defmodule TuistWeb.LocaleTest do
 
   # Normalization filters candidates through Tuist.Locale.supported_locales/0,
   # which only lists non-en locales when TUIST_DEV_ALL_LOCALES=1.
-  @moduletag :locale
-
   alias Phoenix.LiveView
   alias Tuist.Accounts
   alias TuistTestSupport.Fixtures.AccountsFixtures
   alias TuistWeb.Gettext, as: GettextBackend
   alias TuistWeb.Locale
   alias TuistWeb.Plugs.LocalePlug
+
+  @moduletag :locale
 
   describe "normalize_locale/1" do
     test "normalizes language and region locales" do

--- a/server/test/tuist_web/locale_test.exs
+++ b/server/test/tuist_web/locale_test.exs
@@ -2,6 +2,10 @@ defmodule TuistWeb.LocaleTest do
   use TuistTestSupport.Cases.ConnCase, async: true
   use TuistTestSupport.Cases.LiveCase
 
+  # Normalization filters candidates through Tuist.Locale.supported_locales/0,
+  # which only lists non-en locales when TUIST_DEV_ALL_LOCALES=1.
+  @moduletag :locale
+
   alias Phoenix.LiveView
   alias Tuist.Accounts
   alias TuistTestSupport.Fixtures.AccountsFixtures

--- a/server/test/tuist_web/localization_test.exs
+++ b/server/test/tuist_web/localization_test.exs
@@ -359,6 +359,10 @@ defmodule TuistWeb.Marketing.LocalizationTest do
   # end
 
   describe "docs URL localization" do
+    # Rewriting between non-en locale segments relies on Tuist.Locale.languages/0,
+    # which is trimmed to "en" unless TUIST_DEV_ALL_LOCALES=1.
+    @describetag :locale
+
     test "places the locale before the path" do
       Gettext.put_locale(TuistWeb.Gettext, "ko")
 


### PR DESCRIPTION
> Speeds up a cold `mix test` in a fresh worktree by not compiling all ten ex_cldr locales in the `:test` environment.

## What changed

`Tuist.Environment.dev_single_locale?/0` is renamed to `single_locale?/0` and widened from `dev?() and not dev_all_locales?()` to `(dev?() or test?()) and not dev_all_locales?()`. Both `:dev` and `:test` now compile only the `"en"` locale by default. The three compile-time consumers were updated: the ex_cldr backend ([`Tuist.Cldr.Configuration`](server/lib/tuist/cldr/configuration.ex)), the Gettext backend ([`TuistWeb.Gettext.Configuration`](server/lib/tuist_web/gettext/configuration.ex)), and the supported-language list ([`Tuist.Locale`](server/lib/tuist/locale.ex)).

The existing `TUIST_DEV_ALL_LOCALES=1` escape hatch still compiles the full set. Tests that assert non-`en` behaviour are tagged `:locale` and excluded by default (via [`test_helper.exs`](server/test/test_helper.exs)) unless the full set was compiled:

- [`TuistWeb.CldrHelpersTest`](server/test/tuist_web/helpers/cldr_helpers_test.exs) — asserts `es`/`zh_Hant` number, money, and percent formatting.
- [`TuistWeb.LocaleTest`](server/test/tuist_web/locale_test.exs) — `normalize_locale/1` filters candidates through `Tuist.Locale.supported_locales/0`.
- The docs-URL describe block in [`TuistWeb.Marketing.LocalizationTest`](server/test/tuist_web/localization_test.exs) — rewrites between non-`en` locale segments.
- The `preferred_locale` tests in [`accounts_test.exs`](server/test/tuist/accounts_test.exs) / [`user_test.exs`](server/test/tuist/accounts/user_test.exs) — the changeset validates inclusion against `supported_locales/0`.

CI's `test` job now sets `TUIST_DEV_ALL_LOCALES=1` ([`server.yml`](.github/workflows/server.yml)) so it compiles the full locale set and runs the `:locale` tests, keeping i18n coverage unchanged in CI.

## Why

`:test` fell into the all-locales branch of the gate while `:dev` compiled one, so a fresh worktree with a cold `_build/test` regenerated the ex_cldr code for all ten locales on the first `mix test`, whereas the long-running dev server stayed fast on its single-locale build and masked the discrepancy. This was a dev/test inconsistency, not an inherent cost: production (`MIX_ENV=prod`) is unaffected and still compiles every locale.

## Measured impact

Anchored to real CI timings, since CI runs the repo-pinned Elixir 1.19.5. On `main` today the `Test` job — which already compiles all ten locales — breaks down roughly as:

| Step | Duration |
| --- | --- |
| Compile (all 10 locales, incl. deps) | ~283s |
| Setup database | ~159s |
| Run tests | ~305s |
| **Total** | **~880s (~14.7 min)** |

So compiling all ten locales is a modest slice of a ~15-minute job — localization is not the CI bottleneck. This PR keeps CI on all locales, so **CI cost is unchanged**. The win is local: a fresh worktree's first `mix test` no longer regenerates the ex_cldr backend for all ten locales.

Caveat on an earlier local number: I first measured a ~16-min all-locales `cldr.ex` compile, but that shell was running Elixir **1.20.1** (pulled from a global mise `latest` pin), not the repo-pinned **1.19.5** that CI uses. 1.20.1's type checker appears to choke on the large generated cldr module. On the pinned toolchain the all-locales compile is a few minutes (per the CI table), so the local saving from this change is on the order of a couple of minutes off a cold compile, not fifteen.

## Root cause vs. alternatives

The compiled locale set is a compile-time decision (ex_cldr generates code per locale via a macro), so the fast/full split has to be a compile-time flag. Keeping `Application.compile_env` (rather than reading the env var directly) is deliberate: it makes Mix raise a clear "recompile your project" error if the build and the flag disagree, instead of silently running the `:locale` tests against a single-locale build. The trade-off is that toggling the flag on an already-built worktree needs a recompile; a fresh build with the flag set — CI, or a dev's first run — just works.

## User/developer impact

- Default `cd server && mix test` compiles one locale; the `:locale` tests are reported as excluded.
- No production behaviour change; managed builds compile all locales as before.
- CI behaviour is unchanged (still all locales, all tests).

## How to test locally

Default fast path (single locale):

```
cd server && mix test
```

The `:locale`-tagged tests show as excluded and the cold `_build/test` compile no longer generates the full locale set.

Full i18n coverage (what CI runs) — set the flag on a fresh test build:

```
cd server
TUIST_DEV_ALL_LOCALES=1 mix test
```

If you flip the flag on an already-built worktree, Mix will (correctly) refuse with a `:dev_all_locales` compile-env mismatch; force the recompile first, e.g. `touch config/config.exs`, then rerun.

## Functional validation

- `cd server && mix test test/tuist_web/helpers/cldr_helpers_test.exs test/tuist/accounts/user_test.exs` on a cold single-locale build: **9 passed, 5 excluded** — the `:locale` tests are skipped and the rest pass.
- Confirmed the single-locale `_build/test` generates only `Tuist.Cldr for 2 locales [:en, :und]`, and that `TUIST_DEV_ALL_LOCALES=1` regenerates `Tuist.Cldr for 14 locales` for the opt-in path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)