### PR TITLE
fix(cli): align cache warm hashes with generation

### DIFF
--- a/cli/Sources/TuistKit/Mappers/Factories/GraphMapperFactory.swift
+++ b/cli/Sources/TuistKit/Mappers/Factories/GraphMapperFactory.swift
@@ -216,6 +216,15 @@ public struct GraphMapperFactory: GraphMapperFactorying {
             var mappers = self.default(config: config)
 
             if !ignoreBinaryCache {
+                mappers.append(
+                    CacheHashingGraphMapper(
+                        normalizationMappers: hashingGraphNormalizationMappers(
+                            config: config,
+                            includeWorkspaceScheme: true
+                        )
+                    )
+                )
+
                 let focusTargetsGraphMapper = TargetsToCacheBinariesGraphMapper(
                     config: config,
                     decider: CacheProfileTargetReplacementDecider(
@@ -263,6 +272,17 @@ public struct GraphMapperFactory: GraphMapperFactorying {
             )
 
             if cacheProfile != .none {
+                if !shouldPreserveHashingGraph {
+                    mappers.append(
+                        CacheHashingGraphMapper(
+                            normalizationMappers: hashingGraphNormalizationMappers(
+                                config: config,
+                                includeWorkspaceScheme: true
+                            )
+                        )
+                    )
+                }
+
                 let focusTargetsGraphMapper = TargetsToCacheBinariesGraphMapper(
                     config: config,
                     decider: CacheProfileTargetReplacementDecider(

--- a/cli/Tests/TuistCacheEEAcceptanceTests/TuistCacheEEAcceptanceTests.swift
+++ b/cli/Tests/TuistCacheEEAcceptanceTests/TuistCacheEEAcceptanceTests.swift
@@ -370,6 +370,38 @@ struct TuistCacheEEAcceptanceTests {
     }
 
     @Test(
+        .inTemporaryDirectory,
+        .withMockedEnvironment(inheritingVariables: ["PATH"]),
+        .withMockedNoora,
+        .withMockedLogger(forwardLogs: true),
+        .withFixture("generated_macos_tool_with_cached_nested_header_xcframework")
+    ) func generate_reuses_warmed_framework_wrapping_precompiled_dependencies() async throws {
+        let fixtureDirectory = try #require(TuistTest.fixtureDirectory)
+        let xcodeprojPath = fixtureDirectory.appending(component: "NestedHeaderXCFramework.xcodeproj")
+
+        try await TuistTest.run(
+            CacheCommand.self,
+            [
+                "Library",
+                "--path", fixtureDirectory.pathString,
+                "--cache-profile", "all-possible",
+            ]
+        )
+
+        try await TuistTest.run(
+            GenerateCommand.self,
+            [
+                "--no-open",
+                "--path", fixtureDirectory.pathString,
+                "--cache-profile", "all-possible",
+            ]
+        )
+
+        TuistTest.expectLogs("Using cache binaries for the following targets: Library", at: .info, <=)
+        try TuistAcceptanceTest.expectXCFrameworkLinked("Library", by: "Tool", xcodeprojPath: xcodeprojPath)
+    }
+
+    @Test(
         .disabled("Requires SPM install"),
         .inTemporaryDirectory,
         .withMockedEnvironment(inheritingVariables: ["PATH"]),

--- a/cli/Tests/TuistKitTests/Mappers/Factories/GraphMapperFactoryTests.swift
+++ b/cli/Tests/TuistKitTests/Mappers/Factories/GraphMapperFactoryTests.swift
@@ -527,6 +527,61 @@ final class GraphMapperFactoryTests: TuistUnitTestCase {
             XCTAssertEqual(preloadMapperTypes, generationMapperTypes)
         }
 
+        func test_binaryCacheWarmingPreload_appliesFrameworkSearchPathsBeforeCacheHashesAreComputed() {
+            // Given
+            let targets: Set<TargetQuery> = [.named("MyTarget")]
+
+            // When
+            let got = subject.binaryCacheWarmingPreload(
+                targetsToBinaryCache: targets,
+                config: .test()
+            )
+
+            // Then
+            XCTAssertContainsElementOfType(got, FrameworkSearchPathsGraphMapper.self)
+        }
+
+        func test_generation_preserves_cache_hashing_graph_before_cache_replacement_without_focused_targets() {
+            // Given
+            let config = Tuist.test()
+
+            // When
+            let got = subject.generation(
+                config: config,
+                cacheProfile: .allPossible,
+                cacheSources: [],
+                configuration: "Debug",
+                cacheStorage: cacheStorage
+            )
+
+            // Then
+            XCTAssertContainsElementOfType(
+                got,
+                CacheHashingGraphMapper.self,
+                before: TargetsToCacheBinariesGraphMapper.self
+            )
+        }
+
+        func test_build_preserves_cache_hashing_graph_before_cache_replacement() {
+            // Given
+            let config = Tuist.test()
+
+            // When
+            let got = subject.build(
+                config: config,
+                ignoreBinaryCache: false,
+                configuration: "Debug",
+                cacheStorage: cacheStorage
+            )
+
+            // Then
+            XCTAssertContainsElementOfType(
+                got,
+                CacheHashingGraphMapper.self,
+                before: TargetsToCacheBinariesGraphMapper.self
+            )
+        }
+
         func test_automation_contains_static_xcframework_module_map_mapper_after_cache_replacement() {
             // Given
             let config = Tuist.test()


### PR DESCRIPTION
## What changed

Backports [#11616](https://github.com/tuist/tuist/pull/11616) to `releases/4.201.x`.

This cherry-picks the landed main commit `8dc1e153f18b8d08b642a1ee79e12eaaa2771f14`, which:

- keeps the cache-warm preload graph normalized with `FrameworkSearchPathsGraphMapper`
- preserves the same normalized hashing graph before `TargetsToCacheBinariesGraphMapper` runs in generate/build flows that were not already preserving it
- adds unit coverage for mapper ordering
- adds acceptance coverage that warms a framework wrapping precompiled dependencies, then verifies `generate --cache-profile all-possible` reuses and links the warmed binary

## Why

The RC can otherwise store a warmed target under a different cache key than the one requested by `tuist generate --cache-profile all-possible`.

The regression was introduced by [#11054](https://github.com/tuist/tuist/pull/11054) (`de9b946c217`), which moved generated framework search paths into `FrameworkSearchPathsGraphMapper`. Cache warm included those generated settings in the target-settings hash, while unfocused generate/build cache replacement could request binaries using a hash computed before the same normalized graph had been preserved.

## Approach

This is a direct cherry-pick from `main`; no manual code changes were made during the backport.

The fix keeps cache warm behavior intact and instead makes generate/build preserve the same normalized hashing graph before binary replacement. That avoids reintroducing the default/focused cache reuse regression while aligning warm and consume cache keys.

## Validation

- The original PR was validated locally and passed CI on `main`.
- For this backport, I only verified that the cherry-pick applied cleanly and contains the expected files/commit. No additional local checks were run.
