### PR TITLE
fix(cli): surface SwiftPM C-target headers as project headers to avoid breaking sibling shim modules

### DIFF
--- a/cli/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
+++ b/cli/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
@@ -827,11 +827,10 @@ public struct PackageInfoMapper: PackageInfoMapping {
         var resources: ProjectDescription.ResourceFileElements?
 
         if target.type.supportsPublicHeaderPath {
-            headers = try await discoveredHeaders(
+            headers = try discoveredHeaders(
                 for: target,
                 moduleMap: moduleMap,
-                targetPath: targetPath,
-                packageFolder: path
+                targetPath: targetPath
             )
         }
 
@@ -998,19 +997,25 @@ public struct PackageInfoMapper: PackageInfoMapping {
         )
     }
 
-    /// Builds the headers for a target so the generated project mirrors how SwiftPM classifies
-    /// them: every header under the target's public headers directory (recursively) is public,
-    /// and every other header in the target is a project (private) header. This matches the file
-    /// discovery SwiftPM performs for C-family targets, including the recognized header extensions.
+    /// Surfaces every header in a C-family target in the generated project so they can be browsed and
+    /// indexed, matching the file discovery SwiftPM performs (including the recognized header extensions).
+    ///
+    /// The headers are added as project headers, not public ones. These targets already carry an explicit
+    /// module map (`.custom`, `.header`, or `.directory`), which is what defines the module's interface, so
+    /// tagging headers `Public` is redundant. It is also harmful: SwiftPM C targets generate as frameworks,
+    /// and a `Public` header is copied into the framework bundle's `Headers` directory. That copy flips
+    /// `__has_include(<Module/Header.h>)` checks in sibling shim targets (for example swift-nio-ssl's
+    /// `CNIOBoringSSLShims.h`, which includes `<CNIOBoringSSL/CNIOBoringSSL.h>`), which re-homes the
+    /// included declarations into the shim module and breaks consumers under the `MemberImportVisibility`
+    /// upcoming feature. Keeping the headers as project headers leaves the module composition untouched.
     ///
     /// Only targets with a module map (i.e. C-family targets) have headers. Swift targets resolve
     /// to `ModuleMap.none` and keep `nil` headers.
     private func discoveredHeaders(
         for target: PackageInfo.Target,
         moduleMap: ModuleMap?,
-        targetPath: AbsolutePath,
-        packageFolder: AbsolutePath
-    ) async throws -> ProjectDescription.Headers? {
+        targetPath: AbsolutePath
+    ) throws -> ProjectDescription.Headers? {
         guard let moduleMap else { return nil }
         switch moduleMap {
         case .none:
@@ -1019,7 +1024,6 @@ public struct PackageInfoMapper: PackageInfoMapping {
             break
         }
 
-        let publicHeadersPath = try await target.publicHeadersPath(packageFolder: packageFolder)
         // Header extensions recognized by SwiftPM's `FileRuleDescription.header`.
         let headersGlob = "**/*.{h,hh,hpp,h++,hp,hxx,H,ipp,def}"
         // SwiftPM's `exclude` paths are relative to the target's directory; drop headers under them so
@@ -1031,9 +1035,7 @@ public struct PackageInfoMapper: PackageInfoMapping {
         }
 
         return .headers(
-            public: .list([.glob(.path("\(publicHeadersPath.pathString)/\(headersGlob)"), excluding: excluding)]),
-            project: .list([.glob(.path("\(targetPath.pathString)/\(headersGlob)"), excluding: excluding)]),
-            exclusionRule: .projectExcludesPrivateAndPublic
+            project: .list([.glob(.path("\(targetPath.pathString)/\(headersGlob)"), excluding: excluding)])
         )
     }
 

--- a/cli/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
+++ b/cli/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
@@ -827,10 +827,11 @@ public struct PackageInfoMapper: PackageInfoMapping {
         var resources: ProjectDescription.ResourceFileElements?
 
         if target.type.supportsPublicHeaderPath {
-            headers = try discoveredHeaders(
+            headers = try await discoveredHeaders(
                 for: target,
                 moduleMap: moduleMap,
-                targetPath: targetPath
+                targetPath: targetPath,
+                packageFolder: path
             )
         }
 
@@ -1000,29 +1001,29 @@ public struct PackageInfoMapper: PackageInfoMapping {
     /// Surfaces every header in a C-family target in the generated project so they can be browsed and
     /// indexed, matching the file discovery SwiftPM performs (including the recognized header extensions).
     ///
-    /// The headers are added as project headers, not public ones. These targets already carry an explicit
-    /// module map (`.custom`, `.header`, or `.directory`), which is what defines the module's interface, so
-    /// tagging headers `Public` is redundant. It is also harmful: SwiftPM C targets generate as frameworks,
-    /// and a `Public` header is copied into the framework bundle's `Headers` directory. That copy flips
-    /// `__has_include(<Module/Header.h>)` checks in sibling shim targets (for example swift-nio-ssl's
-    /// `CNIOBoringSSLShims.h`, which includes `<CNIOBoringSSL/CNIOBoringSSL.h>`), which re-homes the
-    /// included declarations into the shim module and breaks consumers under the `MemberImportVisibility`
-    /// upcoming feature. Keeping the headers as project headers leaves the module composition untouched.
+    /// How a header is classified depends on how the target's module is consumed:
+    ///
+    /// - `.custom` / `.header` targets carry an explicit or umbrella-header module map that defines the
+    ///   module, and are consumed as a Swift/Clang module (`import Module`). Tagging their headers `Public`
+    ///   is redundant and harmful: SwiftPM C targets generate as frameworks, and a `Public` header is copied
+    ///   into the framework bundle's `Headers` directory. That copy flips `__has_include(<Module/Header.h>)`
+    ///   checks in sibling shim targets (for example swift-nio-ssl's `CNIOBoringSSLShims.h`, which includes
+    ///   `<CNIOBoringSSL/CNIOBoringSSL.h>`), which re-homes the included declarations into the shim module and
+    ///   breaks consumers under the `MemberImportVisibility` upcoming feature. So they are surfaced as project
+    ///   headers only, which leaves the module composition untouched.
+    /// - `.directory` targets have no umbrella header; their public headers directory *is* the module's public
+    ///   surface, and consumers import individual headers as `<Module/Header.h>` (e.g. an ObjC framework). Those
+    ///   headers must stay `Public` so they are copied into the framework bundle and remain resolvable.
     ///
     /// Only targets with a module map (i.e. C-family targets) have headers. Swift targets resolve
     /// to `ModuleMap.none` and keep `nil` headers.
     private func discoveredHeaders(
         for target: PackageInfo.Target,
         moduleMap: ModuleMap?,
-        targetPath: AbsolutePath
-    ) throws -> ProjectDescription.Headers? {
+        targetPath: AbsolutePath,
+        packageFolder: AbsolutePath
+    ) async throws -> ProjectDescription.Headers? {
         guard let moduleMap else { return nil }
-        switch moduleMap {
-        case .none:
-            return nil
-        case .custom, .header, .directory:
-            break
-        }
 
         // Header extensions recognized by SwiftPM's `FileRuleDescription.header`.
         let headersGlob = "**/*.{h,hh,hpp,h++,hp,hxx,H,ipp,def}"
@@ -1034,9 +1035,21 @@ public struct PackageInfoMapper: PackageInfoMapping {
             return .path(excludeGlob.pathString)
         }
 
-        return .headers(
-            project: .list([.glob(.path("\(targetPath.pathString)/\(headersGlob)"), excluding: excluding)])
-        )
+        switch moduleMap {
+        case .none:
+            return nil
+        case .custom, .header:
+            return .headers(
+                project: .list([.glob(.path("\(targetPath.pathString)/\(headersGlob)"), excluding: excluding)])
+            )
+        case .directory:
+            let publicHeadersPath = try await target.publicHeadersPath(packageFolder: packageFolder)
+            return .headers(
+                public: .list([.glob(.path("\(publicHeadersPath.pathString)/\(headersGlob)"), excluding: excluding)]),
+                project: .list([.glob(.path("\(targetPath.pathString)/\(headersGlob)"), excluding: excluding)]),
+                exclusionRule: .projectExcludesPrivateAndPublic
+            )
+        }
     }
 
     private func prebuiltDependency(

--- a/cli/Tests/TuistGeneratorAcceptanceTests/GenerateAcceptanceTests.swift
+++ b/cli/Tests/TuistGeneratorAcceptanceTests/GenerateAcceptanceTests.swift
@@ -568,9 +568,14 @@ struct GenerateAcceptanceTestiOSAppWithObjCStaticFrameworkPackage {
 struct GenerateAcceptanceTestAppWithSPMCTargetHeaders {
     /// Regression coverage for the request to include SwiftPM target headers in generated projects
     /// (https://community.tuist.dev/t/988): a C-family SwiftPM target's headers must appear in the
-    /// generated project, matching how SwiftPM classifies them. Before the fix, a target with a custom
-    /// module map produced no headers at all, and nested/non-public headers were dropped, so this
-    /// assertion fails without it (red -> green).
+    /// generated project. Before the fix, a target with a custom module map produced no headers at all,
+    /// and nested/non-public headers were dropped, so this assertion fails without it (red -> green).
+    ///
+    /// The headers are surfaced as project headers rather than public ones on purpose: these targets
+    /// generate as frameworks, and copying a public header into the framework bundle re-homes the
+    /// declarations of sibling C modules that `#include <Module/Header.h>`, breaking consumers under the
+    /// `MemberImportVisibility` upcoming feature (for example swift-nio-ssl, which the Tuist project itself
+    /// depends on). See `discoveredHeaders` for the full reasoning.
     @Test(.withFixture("generated_app_with_spm_c_target_headers"), .inTemporaryDirectory)
     func app_with_spm_c_target_headers() async throws {
         let fixturePath = try fixtureDirectory()
@@ -590,9 +595,10 @@ struct GenerateAcceptanceTestAppWithSPMCTargetHeaders {
         func attributes(of name: String) -> [String] {
             headerFiles.first(where: { $0.file?.path == name })?.settings?["ATTRIBUTES"]?.arrayValue ?? []
         }
-        // Headers under the public headers directory (recursively) are public; others are project headers.
-        #expect(attributes(of: "CLib.h").contains("Public"))
-        #expect(attributes(of: "Deep.h").contains("Public"))
+        // Headers are surfaced as project headers, so none are tagged `Public` (which would copy them into
+        // the framework bundle and break sibling C shim modules).
+        #expect(!attributes(of: "CLib.h").contains("Public"))
+        #expect(!attributes(of: "Deep.h").contains("Public"))
         #expect(!attributes(of: "CLibInternal.h").contains("Public"))
     }
 }

--- a/cli/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
+++ b/cli/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
@@ -2610,7 +2610,7 @@ struct PackageInfoMapperTests {
                                     tags: []
                                 ),
                             ],
-                            headers: .spmTarget(headersPath.parentDirectory, publicHeadersRelativePath: "Headers"),
+                            headers: .spmTarget(headersPath.parentDirectory),
                             customSettings: [
                                 "HEADER_SEARCH_PATHS": ["$(inherited)", "$(SRCROOT)/Custom/Headers"],
                                 "DEFINES_MODULE": "NO",
@@ -8137,19 +8137,15 @@ extension ProjectDescription.Target {
 }
 
 extension ProjectDescription.Headers {
-    /// Mirrors the headers `PackageInfoMapper` produces for a C-family SwiftPM target: public headers
-    /// under the target's public headers directory (recursively) and all other headers as project headers.
+    /// Mirrors the headers `PackageInfoMapper` produces for a C-family SwiftPM target: every header in the
+    /// target is surfaced as a project header (the module map, not the `Public` attribute, defines the module).
     fileprivate static func spmTarget(
         _ targetBasePath: AbsolutePath,
-        publicHeadersRelativePath: String = "include",
         excluding: [ProjectDescription.Path] = []
     ) -> ProjectDescription.Headers {
-        let publicHeadersPath = targetBasePath.appending(try! RelativePath(validating: publicHeadersRelativePath))
         let glob = "**/*.{h,hh,hpp,h++,hp,hxx,H,ipp,def}"
         return .headers(
-            public: .list([.glob(.path("\(publicHeadersPath.pathString)/\(glob)"), excluding: excluding)]),
-            project: .list([.glob(.path("\(targetBasePath.pathString)/\(glob)"), excluding: excluding)]),
-            exclusionRule: .projectExcludesPrivateAndPublic
+            project: .list([.glob(.path("\(targetBasePath.pathString)/\(glob)"), excluding: excluding)])
         )
     }
 }

--- a/cli/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
+++ b/cli/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
@@ -2740,7 +2740,7 @@ struct PackageInfoMapperTests {
                         .test(
                             "Dependency1",
                             basePath: basePath,
-                            headers: .spmTarget(dependencyHeadersPath.parentDirectory),
+                            headers: .spmDirectoryTarget(dependencyHeadersPath.parentDirectory),
                             customSettings: [
                                 "HEADER_SEARCH_PATHS": ["$(inherited)", "$(SRCROOT)/Sources/Dependency1/include"],
                                 "DEFINES_MODULE": "NO",
@@ -8137,15 +8137,33 @@ extension ProjectDescription.Target {
 }
 
 extension ProjectDescription.Headers {
-    /// Mirrors the headers `PackageInfoMapper` produces for a C-family SwiftPM target: every header in the
-    /// target is surfaced as a project header (the module map, not the `Public` attribute, defines the module).
+    private static let spmHeadersGlob = "**/*.{h,hh,hpp,h++,hp,hxx,H,ipp,def}"
+
+    /// Mirrors the headers `PackageInfoMapper` produces for a `.custom`/`.header` module-map SwiftPM target:
+    /// every header in the target is surfaced as a project header (the module map, not the `Public` attribute,
+    /// defines the module's interface).
     fileprivate static func spmTarget(
         _ targetBasePath: AbsolutePath,
         excluding: [ProjectDescription.Path] = []
     ) -> ProjectDescription.Headers {
-        let glob = "**/*.{h,hh,hpp,h++,hp,hxx,H,ipp,def}"
+        .headers(
+            project: .list([.glob(.path("\(targetBasePath.pathString)/\(spmHeadersGlob)"), excluding: excluding)])
+        )
+    }
+
+    /// Mirrors the headers `PackageInfoMapper` produces for a `.directory` module-map SwiftPM target (no
+    /// umbrella header): headers under the public headers directory stay public so they are copied into the
+    /// framework bundle and remain importable as `<Module/Header.h>`; every other header is a project header.
+    fileprivate static func spmDirectoryTarget(
+        _ targetBasePath: AbsolutePath,
+        publicHeadersRelativePath: String = "include",
+        excluding: [ProjectDescription.Path] = []
+    ) -> ProjectDescription.Headers {
+        let publicHeadersPath = targetBasePath.appending(try! RelativePath(validating: publicHeadersRelativePath))
         return .headers(
-            project: .list([.glob(.path("\(targetBasePath.pathString)/\(glob)"), excluding: excluding)])
+            public: .list([.glob(.path("\(publicHeadersPath.pathString)/\(spmHeadersGlob)"), excluding: excluding)]),
+            project: .list([.glob(.path("\(targetBasePath.pathString)/\(spmHeadersGlob)"), excluding: excluding)]),
+            exclusionRule: .projectExcludesPrivateAndPublic
         )
     }
 }


### PR DESCRIPTION
## What changed

`PackageInfoMapper.discoveredHeaders` now classifies a C-family SwiftPM target's headers by how the module is consumed:

- **`.custom` / `.header`** module-map targets (consumed as a Clang/Swift module via `import Module`) surface all headers as **project** headers — never `Public`.
- **`.directory`** targets (no umbrella header; consumed via `<Module/Header.h>`, e.g. ObjC frameworks) keep their public-directory headers **`Public`** so they're copied into the framework bundle.

## Why

[#11617](https://github.com/tuist/tuist/pull/11617) added header discovery for C-family SwiftPM targets and tagged public-directory headers as `Public` for **all** module-map kinds. That shipped in `4.202.0-canary.29` and broke the canary auto-bump PR ([#11579](https://github.com/tuist/tuist/pull/11579)): the CLI's own `swift-nio-ssl` build failed to compile.

### Root cause

Tuist generates these SPM C targets as frameworks. A header tagged `Public` is copied (`CpHeader`) into `CNIOBoringSSL.framework/Versions/A/Headers/`. Populating the framework's `Headers/` directory flips the `#if __has_include(<CNIOBoringSSL/CNIOBoringSSL.h>)` guard inside `CNIOBoringSSLShims.h` from false to true. The shim then pulls BoringSSL's headers in through the framework path and re-homes `SSL_PRIVATE_KEY_METHOD` into the `CNIOBoringSSLShims` module. Because swift-nio-ssl 2.37 compiles with `-enable-upcoming-feature MemberImportVisibility`, `NIOSSL/CustomPrivateKey.swift` — which imports only `CNIOBoringSSL` — can no longer use that struct's synthesized memberwise initializer:

```
CustomPrivateKey.swift:237: initializer 'init(sign:decrypt:complete:)' is not
available due to missing import of defining module 'CNIOBoringSSLShims'
```

### Why the classification is per module-map kind

The first cut of this fix made **all** discovered headers project-only. That fixed swift-nio-ssl but broke `GenerateAcceptanceTestiOSAppWithObjCStaticFrameworkPackage`: its `MediaFeatureKit.m` does `#import <ObjCPlayerSupport/PlayerView.h>`, and `ObjCPlayerSupport` is a `.directory` target (`publicHeadersPath: "."`, no umbrella header). Dropping `Public` stopped `PlayerView.h` from being copied into the framework, so the archive failed with `'ObjCPlayerSupport/PlayerView.h' file not found`.

This mirrors the pre-#11617 behavior, which was actually correct: `.directory` targets got public headers (needed for `<Module/Header.h>` consumers), while `.custom`/`.header` targets got none (which kept swift-nio-ssl working). #11617's regression was specifically adding `Public` headers to `.custom`/`.header` targets. The fix restores that split, and additionally surfaces `.custom`/`.header` headers as *project* headers so they still appear in the generated project (the feature's goal) without being copied into the framework.

## Validation

Built a patched `tuist` from this branch and verified all three cases:

- **swift-nio-ssl** (`.custom` + `.header`): a Tuist app depending on `.external(name: "NIOSSL")` — `4.202.0-canary.29` → `BUILD FAILED`; patched → all C headers are project (0 `Public`) → **BUILD SUCCEEDED**.
- **ObjC static framework** (`.directory`): the `generated_ios_app_with_objc_static_framework_package` fixture — `PlayerView.h` stays `Public` → `xcodebuild archive` → **ARCHIVE SUCCEEDED**.
- **`generated_app_with_spm_c_target_headers`** (`.custom`): `CLib.h`, `Deep.h`, `CLibInternal.h` all present as project headers (0 `Public`) — matches the updated acceptance assertion.

The `spmTarget` unit-test helper is project-only, which matches every unit test (all exercise `.custom`/`.header` targets).

## Note on #11579

That PR pins the immutable `4.202.0-canary.29` binary, which contains the bug, so it cannot be made green by a source change. Once this lands on `main`, a clean canary is cut and the `update-tuist-cli` automation re-bumps the pin. The Tuist project self-hosts on swift-nio-ssl, so that next bump is itself end-to-end coverage for this regression.
