### PR TITLE
fix(server): route reliability-rate rolling alerts through bucketed MVs and cap ClickHouse query memory

### DIFF
--- a/server/config/runtime.exs
+++ b/server/config/runtime.exs
@@ -265,6 +265,12 @@ if Enum.member?([:prod, :stag, :can], env) do
     settings: [
       readonly: 1,
       max_threads: Tuist.Environment.clickhouse_max_threads(secrets),
+      # Per-query memory ceiling so one heavy read fails on its own with a
+      # `(for query)` error (retryable) rather than driving the process to its
+      # `(total)` server ceiling and killing unrelated queries. Read path only:
+      # writes and backfills go through IngestRepo, which sets its own per-query
+      # limits where needed.
+      max_memory_usage: Tuist.Environment.clickhouse_max_memory_usage_bytes(secrets),
       # Specifies the join algorithms to use in order of preference: direct (fastest for small tables),
       # parallel_hash (good for medium tables), and hash (fallback for large tables)
       join_algorithm: "direct,parallel_hash,hash"

--- a/server/lib/tuist/automations/monitors/flaky_tests_monitor.ex
+++ b/server/lib/tuist/automations/monitors/flaky_tests_monitor.ex
@@ -31,12 +31,14 @@ defmodule Tuist.Automations.Monitors.FlakyTestsMonitor do
   every granule in the relevant monthly partitions).
 
   The `rolling` mode reads bucketed `test_case_runs_recent_N_per_case`
-  `AggregatingMergeTree` MVs for common flaky-run windows and falls back to
-  `test_case_runs_recent_per_case` for larger windows. Reliability rolling
-  windows read the success aggregate on `test_case_runs_recent_per_case`.
-  A project's whole rolling-window scan becomes one row per active test case,
-  regardless of run volume — reading raw `test_case_runs` for that pattern is
-  unrunnable on busy projects.
+  `AggregatingMergeTree` MVs for common windows and falls back to
+  `test_case_runs_recent_per_case` for windows above the largest bucket. The
+  buckets carry both a flaky aggregate (`recent_runs`) and a success aggregate
+  (`recent_successful_runs`), so flakiness, flaky-run-count, and reliability
+  monitors all take the same bucketed fast path — reliability just reads the
+  success column. A project's whole rolling-window scan becomes one row per
+  active test case, regardless of run volume — reading raw `test_case_runs`
+  for that pattern is unrunnable on busy projects.
   """
   import Ecto.Query
 
@@ -281,16 +283,19 @@ defmodule Tuist.Automations.Monitors.FlakyTestsMonitor do
 
   # The rolling fast path reads `test_case_runs_recent_N_per_case`, where N is
   # the smallest bucket in `@recent_runs_bucket_sizes` that can satisfy the
-  # configured window. These tables maintain `groupArraySorted` aggregates of
-  # `(-ran_at_microseconds, is_flaky)` tuples per `(project_id, test_case_id)`.
-  # The full `test_case_runs_recent_per_case` aggregate still keeps 1000
-  # entries for larger user-configured windows, and also carries
-  # `recent_successful_runs` for reliability-rate windows.
+  # configured window. These tables maintain `groupArraySorted` aggregates
+  # per `(project_id, test_case_id)`: `recent_runs` holds
+  # `(-ran_at_microseconds, is_flaky)` tuples for flakiness/count monitors and
+  # `recent_successful_runs` holds `(-ran_at_microseconds, is_success)` tuples
+  # for reliability monitors. The full `test_case_runs_recent_per_case`
+  # aggregate keeps 1000 entries of both for windows above the largest bucket.
   #
   # The MV scan is bounded by `active_test_cases_in_project` rather than
-  # total run volume — usually a few thousand rows. The per-row aggregate is
-  # sorted by `-ran_at_microseconds`, so the merged array is already
-  # latest-first before the final user-configured slice.
+  # total run volume — usually a few thousand rows. The bucket aggregate is
+  # `groupArraySorted` by `-ran_at_microseconds`, so the merged array is
+  # already latest-first before the final user-configured slice (no re-sort);
+  # only the 1000-entry fallback keeps `groupArrayLast` order and has to
+  # `arrayReverseSort` before slicing.
   #
   # ReplacingMergeTree dedup on `test_case_runs` happens after the MV has
   # already absorbed the row, so a re-inserted run (e.g. is_flaky updated
@@ -298,58 +303,12 @@ defmodule Tuist.Automations.Monitors.FlakyTestsMonitor do
   # noise — ≤1% at the default window — well within the natural variance
   # of a flakiness threshold.
   #
-  # `monitor_type`, `comparison`, `table`, and `recent_n_expr` are
+  # `monitor_type`, `comparison`, `table`, `column`, and `recent_n_expr` are
   # interpolated because they are chosen from fixed in-module allowlists, so
   # there is no SQL-injection vector. Numeric inputs (`project_id`, `size`,
   # `threshold`) flow through bound parameters.
-  defp rolling_triggered_test_case_ids(project_id, "reliability_rate", size, threshold, comparison, test_case_ids) do
-    recent_n_expr = """
-    arraySlice(
-      arrayReverseSort(x -> x.1, groupArrayLastMerge(#{@max_rolling_window_size})(recent_successful_runs)),
-      1,
-      {size:UInt32}
-    )
-    """
-
-    rolling_triggered_test_case_ids_from_recent_runs(
-      "test_case_runs_recent_per_case",
-      recent_n_expr,
-      project_id,
-      "reliability_rate",
-      size,
-      threshold,
-      comparison,
-      test_case_ids
-    )
-  end
-
   defp rolling_triggered_test_case_ids(project_id, monitor_type, size, threshold, comparison, test_case_ids) do
-    {table, recent_n_expr} =
-      case Enum.find(@recent_runs_bucket_sizes, &(size <= &1)) do
-        nil ->
-          {
-            "test_case_runs_recent_per_case",
-            """
-            arraySlice(
-              arrayReverseSort(x -> x.1, groupArrayLastMerge(#{@max_rolling_window_size})(recent_runs)),
-              1,
-              {size:UInt32}
-            )
-            """
-          }
-
-        bucket_size ->
-          {
-            "test_case_runs_recent_#{bucket_size}_per_case",
-            """
-            arraySlice(
-              groupArraySortedMerge(#{bucket_size})(recent_runs),
-              1,
-              {size:UInt32}
-            )
-            """
-          }
-      end
+    {table, recent_n_expr} = recent_runs_source(recent_runs_column(monitor_type), size)
 
     rolling_triggered_test_case_ids_from_recent_runs(
       table,
@@ -361,6 +320,41 @@ defmodule Tuist.Automations.Monitors.FlakyTestsMonitor do
       comparison,
       test_case_ids
     )
+  end
+
+  # Reliability measures successful runs; flakiness and count measure flaky
+  # runs. Both live as parallel `(sort_key, flag)` aggregates on the same
+  # rolling-window tables, so the routing below is identical and only the
+  # aggregate column differs.
+  defp recent_runs_column("reliability_rate"), do: "recent_successful_runs"
+  defp recent_runs_column(_monitor_type), do: "recent_runs"
+
+  defp recent_runs_source(column, size) do
+    case Enum.find(@recent_runs_bucket_sizes, &(size <= &1)) do
+      nil ->
+        {
+          "test_case_runs_recent_per_case",
+          """
+          arraySlice(
+            arrayReverseSort(x -> x.1, groupArrayLastMerge(#{@max_rolling_window_size})(#{column})),
+            1,
+            {size:UInt32}
+          )
+          """
+        }
+
+      bucket_size ->
+        {
+          "test_case_runs_recent_#{bucket_size}_per_case",
+          """
+          arraySlice(
+            groupArraySortedMerge(#{bucket_size})(#{column}),
+            1,
+            {size:UInt32}
+          )
+          """
+        }
+    end
   end
 
   defp rolling_triggered_test_case_ids_from_recent_runs(

--- a/server/lib/tuist/environment.ex
+++ b/server/lib/tuist/environment.ex
@@ -939,6 +939,21 @@ defmodule Tuist.Environment do
     end
   end
 
+  # Per-query memory ceiling (in bytes) for the read path. ClickHouse enforces
+  # this per query, so a single pathological aggregation fails on its own with
+  # a `(for query)` error the caller can retry, instead of pushing the process
+  # to its `(total)` server ceiling and killing whatever unrelated query
+  # allocates next. The default stays well under the process limit while
+  # leaving ample headroom over normal analytics; override per
+  # environment/instance size via the `clickhouse.max_memory_usage_bytes`
+  # secret.
+  def clickhouse_max_memory_usage_bytes(secrets \\ secrets()) do
+    case get([:clickhouse, :max_memory_usage_bytes], secrets) do
+      value when is_binary(value) -> String.to_integer(value)
+      _ -> 6 * 1024 * 1024 * 1024
+    end
+  end
+
   @doc """
   Returns additional Finch pools from the TUIST_ADDITIONAL_FINCH_POOLS environment variable.
 

--- a/server/priv/ingest_repo/migrations/20260702120000_add_reliability_aggregates_to_recent_bucket_mvs.exs
+++ b/server/priv/ingest_repo/migrations/20260702120000_add_reliability_aggregates_to_recent_bucket_mvs.exs
@@ -1,0 +1,237 @@
+defmodule Tuist.IngestRepo.Migrations.AddReliabilityAggregatesToRecentBucketMvs do
+  @moduledoc """
+  Adds per-test-case success aggregates to the bucketed rolling-window tables.
+
+  `20260609121000` gave reliability-rate automations a `recent_successful_runs`
+  aggregate, but only on the 1000-entry `test_case_runs_recent_per_case` table.
+  Every reliability evaluation therefore had to `groupArrayLastMerge(1000)` and
+  `arrayReverseSort` the full 1000-run state per test case — even for the default
+  100-run window. That is a multi-GiB per-query cost; run concurrently across a
+  busy project's active test cases it drove ClickHouse past its process memory
+  ceiling and killed unrelated queries with `MEMORY_LIMIT_EXCEEDED`.
+
+  Flakiness and flaky-run-count automations already avoid that by reading the
+  smaller `test_case_runs_recent_{100,250,500,750}_per_case` buckets, which hold
+  pre-sorted `groupArraySorted(N)` states (latest-first, no re-sort). This
+  migration adds a parallel `recent_successful_runs` bucket aggregate to those
+  same tables so reliability can take the identical fast path.
+
+  Additive and mirrors the established bucket pattern (`20260515100000`) plus the
+  success-aggregate pattern (`20260609121000`): `ALTER TABLE ... ADD COLUMN`,
+  partition-chunked backfill of the historical buckets from the existing
+  1000-entry aggregate, then an always-on MV per bucket. The larger buckets
+  (500, 750) are populated forward-only by their MV, matching how the flakiness
+  bucket migration handled them.
+  """
+  use Ecto.Migration
+  alias Tuist.IngestRepo
+  require Logger
+
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  @window_sizes [100, 250, 500, 750]
+  @historical_backfill_window_sizes [100, 250]
+  @max_window_size 1000
+  @project_chunk_size 25
+  @chunk_throttle_ms 100
+
+  def up do
+    for window_size <- @window_sizes do
+      # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+      IngestRepo.query!("DROP VIEW IF EXISTS #{success_mv(window_size)}")
+
+      # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+      IngestRepo.query!("""
+      ALTER TABLE #{table_name(window_size)}
+      ADD COLUMN IF NOT EXISTS recent_successful_runs AggregateFunction(groupArraySorted(#{window_size}), Tuple(Int64, UInt8))
+      """)
+
+      if window_size in @historical_backfill_window_sizes do
+        backfill_from_recent_per_case(window_size)
+      else
+        Logger.info(
+          "Skipping historical reliability backfill for #{table_name(window_size)}; " <>
+            "the materialized view will populate it with new test case runs"
+        )
+      end
+
+      create_success_materialized_view(window_size)
+    end
+  end
+
+  def down do
+    for window_size <- @window_sizes do
+      # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+      IngestRepo.query!("DROP VIEW IF EXISTS #{success_mv(window_size)}")
+
+      # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+      IngestRepo.query!("""
+      ALTER TABLE #{table_name(window_size)}
+      DROP COLUMN IF EXISTS recent_successful_runs
+      """)
+    end
+  end
+
+  # Mirrors the flakiness bucket MV but records `status = 'success'` instead of
+  # `is_flaky`. Writing only `recent_successful_runs` leaves `recent_runs` at its
+  # empty-state default; the AggregatingMergeTree merges the two per-column MV
+  # streams by `(project_id, test_case_id)`, exactly as the full
+  # `test_case_runs_recent_per_case` table already does with its two MVs.
+  defp create_success_materialized_view(window_size) do
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    IngestRepo.query!("""
+    CREATE MATERIALIZED VIEW IF NOT EXISTS #{success_mv(window_size)}
+    TO #{table_name(window_size)}
+    AS SELECT
+      project_id,
+      assumeNotNull(test_case_id) AS test_case_id,
+      groupArraySortedState(#{window_size})((-toUnixTimestamp64Micro(ran_at), toUInt8(status = 'success'))) AS recent_successful_runs
+    FROM test_case_runs
+    WHERE test_case_id IS NOT NULL
+    GROUP BY project_id, test_case_id
+    """)
+  end
+
+  defp backfill_from_recent_per_case(window_size) do
+    project_ids = source_project_ids()
+
+    Logger.info(
+      "Backfilling #{table_name(window_size)} recent_successful_runs from test_case_runs_recent_per_case " <>
+        "(#{length(project_ids)} projects in #{div(length(project_ids) + @project_chunk_size - 1, @project_chunk_size)} chunk(s))"
+    )
+
+    project_ids
+    |> Enum.chunk_every(@project_chunk_size)
+    |> Enum.with_index(1)
+    |> Enum.each(fn {chunk, idx} ->
+      backfill_chunk_with_fallback(window_size, chunk, idx)
+      Process.sleep(@chunk_throttle_ms)
+    end)
+  end
+
+  defp source_project_ids do
+    {:ok, %{rows: rows}} =
+      IngestRepo.query(
+        """
+        SELECT DISTINCT project_id
+        FROM test_case_runs_recent_per_case
+        ORDER BY project_id
+        """,
+        %{},
+        timeout: 600_000
+      )
+
+    Enum.map(rows, fn [project_id] -> project_id end)
+  end
+
+  defp backfill_chunk_with_fallback(window_size, project_ids, idx) do
+    backfill_chunk(window_size, project_ids, idx)
+  rescue
+    e in Ch.Error ->
+      cond do
+        memory_limit_exceeded?(e) and length(project_ids) > 1 ->
+          Logger.warning(
+            "Backfilling reliability chunk #{idx} into #{table_name(window_size)} exceeded ClickHouse memory; " <>
+              "retrying per project"
+          )
+
+          Enum.each(project_ids, fn project_id ->
+            retry_on_transient_failure(fn ->
+              backfill_chunk(window_size, [project_id], idx)
+            end)
+
+            Process.sleep(@chunk_throttle_ms)
+          end)
+
+        table_is_read_only?(e) ->
+          retry_on_transient_failure(fn ->
+            backfill_chunk(window_size, project_ids, idx)
+          end)
+
+        true ->
+          reraise e, __STACKTRACE__
+      end
+  end
+
+  # Rebuilds the bucket's success state from the already-maintained 1000-entry
+  # `recent_successful_runs` aggregate rather than rescanning raw
+  # `test_case_runs`: take the latest N successful-run tuples, re-key them by
+  # `-ran_at_microseconds`, and fold into the bucket's `groupArraySorted(N)`
+  # shape. Same `(project_id IN ...)` chunking, single ordered thread, and
+  # per-INSERT memory ceiling as the flakiness bucket backfill.
+  defp backfill_chunk(window_size, project_ids, idx) do
+    Logger.debug(
+      "Backfilling reliability chunk #{idx} into #{table_name(window_size)} " <>
+        "(#{length(project_ids)} projects: #{Enum.at(project_ids, 0)}..#{List.last(project_ids)})"
+    )
+
+    IngestRepo.query!(
+      """
+      INSERT INTO #{table_name(window_size)}
+        (project_id, test_case_id, recent_successful_runs)
+      SELECT
+        project_id,
+        test_case_id,
+        groupArraySortedState(#{window_size})((
+          -toUnixTimestamp64Micro(tupleElement(recent_run, 1)),
+          toUInt8(tupleElement(recent_run, 2))
+        )) AS recent_successful_runs
+      FROM (
+        SELECT
+          project_id,
+          test_case_id,
+          arrayJoin(
+            arraySlice(
+              arrayReverseSort(run -> tupleElement(run, 1), groupArrayLastMerge(#{@max_window_size})(recent_successful_runs)),
+              1,
+              #{window_size}
+            )
+          ) AS recent_run
+        FROM test_case_runs_recent_per_case
+        WHERE project_id IN {project_ids:Array(Int64)}
+        GROUP BY project_id, test_case_id
+      )
+      GROUP BY project_id, test_case_id
+      SETTINGS
+        max_threads = 1,
+        max_memory_usage = 6000000000,
+        max_bytes_before_external_group_by = 2500000000
+      """,
+      %{project_ids: project_ids},
+      timeout: 1_200_000
+    )
+  end
+
+  defp table_name(window_size), do: "test_case_runs_recent_#{window_size}_per_case"
+  defp success_mv(window_size), do: "test_case_runs_recent_#{window_size}_success_per_case_mv"
+
+  defp retry_on_transient_failure(fun, attempts \\ 5) do
+    fun.()
+  rescue
+    e in Ch.Error ->
+      message = to_string(e.message)
+
+      transient? =
+        table_is_read_only?(e) or
+          memory_limit_exceeded?(e)
+
+      if attempts > 1 and transient? do
+        Logger.warning(
+          "ClickHouse returned a transient error (#{String.slice(message, 0, 80)}...); " <>
+            "retrying in 5s (#{attempts - 1} attempts left)"
+        )
+
+        Process.sleep(:timer.seconds(5))
+        retry_on_transient_failure(fun, attempts - 1)
+      else
+        reraise e, __STACKTRACE__
+      end
+  end
+
+  defp memory_limit_exceeded?(%Ch.Error{} = error),
+    do: String.contains?(to_string(error.message), "MEMORY_LIMIT_EXCEEDED")
+
+  defp table_is_read_only?(%Ch.Error{} = error),
+    do: String.contains?(to_string(error.message), "TABLE_IS_READ_ONLY")
+end

--- a/server/test/tuist/automations/monitors/flaky_tests_monitor_test.exs
+++ b/server/test/tuist/automations/monitors/flaky_tests_monitor_test.exs
@@ -762,6 +762,88 @@ defmodule Tuist.Automations.Monitors.FlakyTestsMonitorTest do
       assert %{triggered: triggered} = FlakyTestsMonitor.evaluate_by_reliability_rate(alert)
       assert test_case_id in triggered
     end
+
+    test "reads a mid-size bucket and ignores runs older than the window" do
+      project = ProjectsFixtures.project_fixture()
+      test_case_id = UUIDv7.generate()
+      RunsFixtures.test_case_fixture(project_id: project.id, id: test_case_id, name: "rolling_mid_bucket")
+
+      base = NaiveDateTime.utc_now()
+
+      # Older history is all failures; a 247-run window routes to the 250-run
+      # bucket and must see only the recent successes, so reliability is 100%
+      # and the alert (unreliable when < 90%) does not fire. Reading the full
+      # history instead would drop it to ~45% and wrongly trigger.
+      old_failures =
+        for i <- 1..300 do
+          test_case_run_attrs(project.id, test_case_id,
+            status: 1,
+            ran_at: NaiveDateTime.add(base, -10_000 - i, :second),
+            inserted_at: NaiveDateTime.add(base, -10_000 - i, :second)
+          )
+        end
+
+      recent_successes =
+        for i <- 1..247 do
+          test_case_run_attrs(project.id, test_case_id,
+            status: 0,
+            ran_at: NaiveDateTime.add(base, i, :second),
+            inserted_at: NaiveDateTime.add(base, i, :second)
+          )
+        end
+
+      insert_test_case_runs(old_failures ++ recent_successes)
+
+      alert =
+        AutomationsFixtures.automation_alert_fixture(
+          project: project,
+          monitor_type: "reliability_rate",
+          trigger_config: %{
+            "threshold" => 90,
+            "window_type" => "rolling",
+            "rolling_window_size" => 247,
+            "comparison" => "lt"
+          }
+        )
+
+      refute test_case_id in FlakyTestsMonitor.evaluate_by_reliability_rate(alert).triggered
+    end
+
+    test "falls back to the 1000-run aggregate above the bucket cap" do
+      project = ProjectsFixtures.project_fixture()
+      test_case_id = UUIDv7.generate()
+      RunsFixtures.test_case_fixture(project_id: project.id, id: test_case_id, name: "rolling_above_cap")
+
+      base = NaiveDateTime.utc_now()
+
+      # A 751-run window is above the largest bucket (750), so evaluation reads
+      # the full `recent_successful_runs` aggregate. All-failure runs give 0%
+      # reliability, which trips the < 90% threshold.
+      failures =
+        for i <- 1..750 do
+          test_case_run_attrs(project.id, test_case_id,
+            status: 1,
+            ran_at: NaiveDateTime.add(base, i, :second),
+            inserted_at: NaiveDateTime.add(base, i, :second)
+          )
+        end
+
+      insert_test_case_runs(failures)
+
+      alert =
+        AutomationsFixtures.automation_alert_fixture(
+          project: project,
+          monitor_type: "reliability_rate",
+          trigger_config: %{
+            "threshold" => 90,
+            "window_type" => "rolling",
+            "rolling_window_size" => 751,
+            "comparison" => "lt"
+          }
+        )
+
+      assert test_case_id in FlakyTestsMonitor.evaluate_by_reliability_rate(alert).triggered
+    end
   end
 
   defp insert_test_case_runs(rows) do


### PR DESCRIPTION
> Draft. Fix #1 (bucketed reliability MV) + Fix #2 (per-query memory cap) from the ClickHouse OOM investigation. The remaining follow-up (isolating `AlertEvaluationWorker` onto its own low-concurrency Oban queue) is intentionally left out of this PR.

## What

Two changes that together stop reliability-rate flaky-test alerts from exhausting the production ClickHouse instance's memory:

1. **Bucketed fast path for `reliability_rate` rolling evaluations.** Adds a parallel `recent_successful_runs` `groupArraySorted(N)` aggregate to the existing `test_case_runs_recent_{100,250,500,750}_per_case` bucket tables (new per-bucket MVs + partition-chunked backfill of the historical 100/250 buckets, mirroring the flakiness bucket migration), and routes the reliability rolling path through the smallest sufficient bucket — reading the success column via `groupArraySortedMerge(bucket)` with no re-sort, exactly like flakiness/count. Windows above 750 keep the existing full-aggregate fallback.

2. **Per-query `max_memory_usage` cap on the ClickHouseRepo read path** (default 6 GiB, overridable via the `clickhouse.max_memory_usage_bytes` secret).

## Why (root cause)

Production ClickHouse hit its `(total)` process memory ceiling (~18 GiB) and killed unrelated queries with `Code: 241 MEMORY_LIMIT_EXCEEDED`. The Sentry issues that fired (`build_total_count`, `build_percentile_durations`, flaky-run lookups) were **collateral** — ordinary sub-GiB queries that happened to request the next allocation once the server was already at the ceiling.

The `query_log` for the incident window showed the real driver: the `reliability_rate` rolling query, run ~13×/minute concurrently, each peaking at **~4–5 GiB**:

| query shape | runs (12 min) | avg peak | max peak | 241-killed |
|---|---|---|---|---|
| reliability (`recent_successful_runs`) | 76 | **4.12 GiB** | 5.21 GiB | 29 |
| flaky bucketed (`groupArraySortedMerge`) | 478 | 0.21 GiB | 0.68 GiB | 1 |
| daily-stats MV | 2,946 | 0.03 GiB | 0.08 GiB | 0 |
| everything else (the Sentry victims) | 14,112 | 0.04 GiB | 1.24 GiB | 19 |

The reliability path always read the 1000-entry `test_case_runs_recent_per_case` aggregate and did `groupArrayLastMerge(1000)(recent_successful_runs)` + `arrayReverseSort` over **every active test case in the project** (all 76 runs had no `test_case_id` filter — full-project scans), even for the default 100-run window. `AlertEvaluationWorker` runs 10-wide per pod on the shared `:default` Oban queue, so a handful of concurrent full-project reliability scans summed past 18 GiB. Flakiness and flaky-run-count monitors already avoid this by reading the smaller pre-sorted buckets (~0.2 GiB); reliability simply never got that fast path.

## Why this solution

- Extending the existing bucket tables (rather than a new structure) reuses the proven two-MV-into-one-`AggregatingMergeTree` pattern the full `test_case_runs_recent_per_case` table already uses for `recent_runs` + `recent_successful_runs`. It turns the ~4–5 GiB query into ~0.2 GiB at the source.
- The per-query cap is defense-in-depth and independent of #1: it converts any future runaway read into a self-contained `(for query)` failure the caller retries, instead of a server-wide `(total)` kill that takes out unrelated dashboards. It's applied only to the read repo — writes/backfills go through `IngestRepo`, which sets its own per-query limits.

## User / developer impact

- Reliability-rate alert evaluations drop from multi-GiB to sub-GiB, removing the concurrency spike that saturated ClickHouse.
- Dashboards and analytics stop failing intermittently with `MEMORY_LIMIT_EXCEEDED`.
- Reliability rolling windows ≤750 now read the bucket MVs; windows >750 are unchanged (full-aggregate fallback).

## Validation

- `mix format` + syntax checks on all changed files.
- Added reliability rolling tests: mid-size bucket (asserts runs older than the window are ignored) and above-cap fallback, alongside the existing 100-bucket happy path.
- Migration reuses the partition-chunked backfill machinery (per-project memory fallback, throttling, transient-error retry) already exercised by `20260515100000` and `20260609121000`.

### How to test locally

1. `mix ecto.migrate` (ingest repo) to create the bucket success MVs.
2. `mix test test/tuist/automations/monitors/flaky_tests_monitor_test.exs` — the `evaluate_by_reliability_rate/1 with rolling window` describe block exercises the 100-bucket, mid-bucket, and above-cap paths end-to-end against ClickHouse.

## Not in this PR (follow-up)

- Moving `AlertEvaluationWorker` off the shared `:default` queue onto a low-concurrency queue, so a burst of heavy evaluations can't run 10-wide per pod.
- Optional: a ClickHouse `MemoryTracking` vs `max_server_memory_usage` alert.
