### PR TITLE
feat(cli): fail fast when the remote CAS cache is unavailable

### DIFF
--- a/cli/Sources/TuistCAS/Services/CASCircuitBreaker.swift
+++ b/cli/Sources/TuistCAS/Services/CASCircuitBreaker.swift
@@ -1,0 +1,141 @@
+#if os(macOS)
+    import Foundation
+    import Logging
+    import TuistCache
+    import TuistLogging
+
+    /// A per-process circuit breaker for the remote CAS backend.
+    ///
+    /// A build issues thousands of CAS load/save calls, many concurrently. When
+    /// the remote cache is unavailable, without a breaker every call independently
+    /// waits for its own failure/timeout before the compiler falls back to a local
+    /// build — turning a single outage into a per-request tax that can stall or
+    /// dramatically slow the whole build. The breaker lets the first few failures
+    /// trip a shared switch so every subsequent call short-circuits to a local
+    /// build instantly, and re-probes after a cooldown so caching resumes if the
+    /// backend recovers mid-build (e.g. after a pod roll).
+    ///
+    /// It never changes build output: a short-circuited load behaves like a cache
+    /// miss (the compiler builds locally) and a short-circuited save skips the
+    /// upload (the artifact is already built locally). The breaker only decides
+    /// *when to stop asking* a backend that is already answering with failures.
+    public actor CASCircuitBreaker {
+        private enum State {
+            case closed
+            case open(until: Date)
+            case halfOpen
+        }
+
+        private let failureThreshold: Int
+        private let cooldown: TimeInterval
+        private let now: @Sendable () -> Date
+        private var state: State = .closed
+        private var consecutiveFailures = 0
+        private var probeInFlight = false
+
+        /// - Parameters:
+        ///   - failureThreshold: consecutive failures before the breaker opens.
+        ///   - cooldown: how long the breaker stays open before allowing a single
+        ///     probe. Short so a long build resumes caching soon after a transient
+        ///     blip, rather than losing the remote cache for its whole duration.
+        ///   - now: injectable clock for tests.
+        public init(
+            failureThreshold: Int = 5,
+            cooldown: TimeInterval = 30,
+            now: @escaping @Sendable () -> Date = { Date() }
+        ) {
+            self.failureThreshold = failureThreshold
+            self.cooldown = cooldown
+            self.now = now
+        }
+
+        /// Whether a remote attempt should be made now. When the breaker is open
+        /// and the cooldown has not elapsed it returns `false` so the caller skips
+        /// the remote and falls back locally. When the cooldown elapses it allows a
+        /// single probe (half-open) and blocks other callers until that probe
+        /// resolves, so a recovering backend is not stampeded.
+        public func shouldAttempt() -> Bool {
+            switch state {
+            case .closed:
+                return true
+            case .halfOpen:
+                if probeInFlight { return false }
+                probeInFlight = true
+                return true
+            case let .open(until):
+                if now() >= until {
+                    state = .halfOpen
+                    probeInFlight = true
+                    return true
+                }
+                return false
+            }
+        }
+
+        /// Records a reachable backend (a hit or a miss both count): resets the
+        /// failure run and closes the breaker.
+        public func recordSuccess() {
+            let wasClosed = isClosed
+            consecutiveFailures = 0
+            probeInFlight = false
+            state = .closed
+            if !wasClosed {
+                Logger.current.info("Remote cache recovered; re-enabled for this build.")
+            }
+        }
+
+        /// Records an unavailable backend (5xx / timeout / connection / auth error).
+        /// Trips the breaker once `failureThreshold` consecutive failures accumulate,
+        /// or immediately re-opens if a half-open probe failed.
+        public func recordFailure() {
+            probeInFlight = false
+            consecutiveFailures += 1
+            switch state {
+            case .halfOpen:
+                open()
+            case .closed:
+                if consecutiveFailures >= failureThreshold {
+                    open()
+                }
+            case .open:
+                break
+            }
+        }
+
+        /// Whether the breaker is currently blocking remote attempts. Exposed for
+        /// tests and diagnostics.
+        public var isOpen: Bool {
+            if case .open = state { return true }
+            return false
+        }
+
+        private var isClosed: Bool {
+            if case .closed = state { return true }
+            return false
+        }
+
+        private func open() {
+            let alreadyOpen = !isClosed
+            state = .open(until: now().addingTimeInterval(cooldown))
+            if !alreadyOpen {
+                Logger.current.warning(
+                    "Remote cache unavailable after \(consecutiveFailures) consecutive failures; falling back to local builds for this build (retrying in \(Int(cooldown))s)."
+                )
+            }
+        }
+    }
+
+    /// Classifies a thrown CAS error as a backend-health signal. Errors that mean
+    /// "the backend answered, this particular request just can't be served" — a 404
+    /// miss, or an artifact too large to upload — leave the breaker closed; every
+    /// other error (5xx, timeout, connection failure, auth) counts as unavailable.
+    func casErrorIsBackendHealthy(_ error: Error) -> Bool {
+        if let error = error as? LoadCacheCASServiceError, case .notFound = error {
+            return true
+        }
+        if let error = error as? SaveCacheCASServiceError, case .contentTooLarge = error {
+            return true
+        }
+        return false
+    }
+#endif

--- a/cli/Sources/TuistCAS/Services/CASCircuitBreaker.swift
+++ b/cli/Sources/TuistCAS/Services/CASCircuitBreaker.swift
@@ -4,6 +4,14 @@
     import TuistCache
     import TuistLogging
 
+    /// A token for one remote attempt, tied to the breaker generation that was
+    /// current when the attempt began. Results from a superseded generation (a
+    /// request that was already in flight when the breaker opened) are ignored, so a
+    /// late straggler cannot flip the breaker state.
+    public struct CASAttempt: Sendable {
+        fileprivate let generation: Int
+    }
+
     /// A per-process circuit breaker for the remote CAS backend.
     ///
     /// A build issues thousands of CAS load/save calls, many concurrently. When
@@ -19,6 +27,12 @@
     /// miss (the compiler builds locally) and a short-circuited save skips the
     /// upload (the artifact is already built locally). The breaker only decides
     /// *when to stop asking* a backend that is already answering with failures.
+    ///
+    /// Every attempt is scoped to a generation. Opening the breaker bumps the
+    /// generation, so results from requests that were already in flight at that
+    /// moment are discarded rather than allowed to close it — otherwise, with many
+    /// concurrent requests, one late hit could re-enable the remote before the
+    /// cooldown and defeat the "trip once, short-circuit the rest" guarantee.
     public actor CASCircuitBreaker {
         private enum State {
             case closed
@@ -32,6 +46,7 @@
         private var state: State = .closed
         private var consecutiveFailures = 0
         private var probeInFlight = false
+        private var generation = 0
 
         /// - Parameters:
         ///   - failureThreshold: consecutive failures before the breaker opens.
@@ -49,32 +64,35 @@
             self.now = now
         }
 
-        /// Whether a remote attempt should be made now. When the breaker is open
-        /// and the cooldown has not elapsed it returns `false` so the caller skips
-        /// the remote and falls back locally. When the cooldown elapses it allows a
-        /// single probe (half-open) and blocks other callers until that probe
-        /// resolves, so a recovering backend is not stampeded.
-        public func shouldAttempt() -> Bool {
+        /// Begins a remote attempt, returning a token when one is allowed and `nil`
+        /// when the breaker is open (the caller then skips the remote and falls back
+        /// locally). When the cooldown elapses it allows a single probe (half-open)
+        /// and blocks other callers until that probe resolves, so a recovering
+        /// backend is not stampeded. Callers must feed the token back into exactly
+        /// one of `recordSuccess`, `recordFailure`, or `release`.
+        public func attempt() -> CASAttempt? {
             switch state {
             case .closed:
-                return true
+                return CASAttempt(generation: generation)
             case .halfOpen:
-                if probeInFlight { return false }
+                if probeInFlight { return nil }
                 probeInFlight = true
-                return true
+                return CASAttempt(generation: generation)
             case let .open(until):
                 if now() >= until {
                     state = .halfOpen
                     probeInFlight = true
-                    return true
+                    return CASAttempt(generation: generation)
                 }
-                return false
+                return nil
             }
         }
 
-        /// Records a reachable backend (a hit or a miss both count): resets the
-        /// failure run and closes the breaker.
-        public func recordSuccess() {
+        /// Records a reachable backend for this attempt (a hit or a miss both
+        /// count): resets the failure run and closes the breaker. A stale result
+        /// (from a superseded generation) is ignored.
+        public func recordSuccess(_ attempt: CASAttempt) {
+            guard attempt.generation == generation else { return }
             let wasClosed = isClosed
             consecutiveFailures = 0
             probeInFlight = false
@@ -84,10 +102,12 @@
             }
         }
 
-        /// Records an unavailable backend (5xx / timeout / connection / auth error).
-        /// Trips the breaker once `failureThreshold` consecutive failures accumulate,
-        /// or immediately re-opens if a half-open probe failed.
-        public func recordFailure() {
+        /// Records an unavailable backend for this attempt (5xx / timeout /
+        /// connection / auth error). Trips the breaker once `failureThreshold`
+        /// consecutive failures accumulate, or immediately re-opens if a half-open
+        /// probe failed. A stale result (from a superseded generation) is ignored.
+        public func recordFailure(_ attempt: CASAttempt) {
+            guard attempt.generation == generation else { return }
             probeInFlight = false
             consecutiveFailures += 1
             switch state {
@@ -102,8 +122,17 @@
             }
         }
 
+        /// Releases an attempt that was abandoned before reaching the backend (e.g.
+        /// a local error), freeing a half-open probe slot without recording a
+        /// backend-health outcome.
+        public func release(_ attempt: CASAttempt) {
+            guard attempt.generation == generation else { return }
+            probeInFlight = false
+        }
+
         /// Whether the breaker is currently blocking remote attempts. Exposed for
-        /// tests and diagnostics.
+        /// tests and diagnostics; gating goes through `attempt()`, which also
+        /// advances an elapsed cooldown.
         public var isOpen: Bool {
             if case .open = state { return true }
             return false
@@ -116,6 +145,7 @@
 
         private func open() {
             let alreadyOpen = !isClosed
+            generation += 1
             state = .open(until: now().addingTimeInterval(cooldown))
             if !alreadyOpen {
                 Logger.current.warning(

--- a/cli/Sources/TuistCAS/Services/CASService.swift
+++ b/cli/Sources/TuistCAS/Services/CASService.swift
@@ -206,6 +206,33 @@
                 Logger.current.debug("CAS.save starting - data size: \(data.count) bytes")
             }
 
+            // The fingerprint is derived from the raw data, so compute it first
+            // (cheap) and only compress (expensive) once we know an upload will
+            // actually be attempted. When there is nothing to upload to — upload
+            // disabled, or the circuit open because the remote cache is unavailable
+            // — the artifact is already built locally, so paying the zstd
+            // compression per artifact would defeat the fast fallback.
+            let dataWithVersion = data + "cache-v1".data(using: .utf8)!
+            let hash = SHA256.hash(data: dataWithVersion)
+            let fingerprint = hash.compactMap { String(format: "%02X", $0) }.joined()
+
+            var message = CompilationCacheService_Cas_V1_CASDataID()
+            message.id = fingerprint.data(using: .utf8)!
+
+            if !upload {
+                Logger.current.debug("CAS.save skipping upload (upload disabled) for fingerprint: \(fingerprint)")
+                response.casID = message
+                response.contents = .casID(message)
+                return response
+            }
+
+            if await circuitBreaker.isOpen {
+                Logger.current.debug("CAS.save skipping upload (circuit open) for fingerprint: \(fingerprint)")
+                response.casID = message
+                response.contents = .casID(message)
+                return response
+            }
+
             let compressedData: Data
             let codecDuration: TimeInterval
             do {
@@ -221,25 +248,13 @@
                 return response
             }
 
-            let dataWithVersion = data + "cache-v1".data(using: .utf8)!
-            let hash = SHA256.hash(data: dataWithVersion)
-            let fingerprint = hash.compactMap { String(format: "%02X", $0) }.joined()
-
-            var message = CompilationCacheService_Cas_V1_CASDataID()
-            message.id = fingerprint.data(using: .utf8)!
-
             Logger.current
                 .debug(
                     "CAS.save computed fingerprint: \(fingerprint), original size: \(data.count) bytes, compressed size: \(compressedData.count) bytes"
                 )
 
-            if !upload {
-                Logger.current.debug("CAS.save skipping upload (upload disabled) for fingerprint: \(fingerprint)")
-                response.casID = message
-                response.contents = .casID(message)
-                return response
-            }
-
+            // Claim the (possibly half-open) probe slot right before the upload, so a
+            // recovering backend is exercised by exactly one artifact.
             guard await circuitBreaker.shouldAttempt() else {
                 Logger.current.debug("CAS.save skipping upload (circuit open) for fingerprint: \(fingerprint)")
                 response.casID = message

--- a/cli/Sources/TuistCAS/Services/CASService.swift
+++ b/cli/Sources/TuistCAS/Services/CASService.swift
@@ -20,6 +20,7 @@
         private let dataCompressingService: DataCompressingServicing
         private let serverAuthenticationController: ServerAuthenticationControlling
         private let upload: Bool
+        private let circuitBreaker: CASCircuitBreaker
 
         private var accountHandle: String? {
             fullHandle.split(separator: "/").first.map(String.init)
@@ -42,6 +43,7 @@
             dataCompressingService = DataCompressingService()
             self.analyticsDatabase = analyticsDatabase
             serverAuthenticationController = ServerAuthenticationController()
+            circuitBreaker = CASCircuitBreaker()
         }
 
         init(
@@ -54,7 +56,8 @@
             dataCompressingService: DataCompressingServicing,
             analyticsDatabase: CASAnalyticsDatabasing,
             serverAuthenticationController: ServerAuthenticationControlling,
-            upload: Bool = true
+            upload: Bool = true,
+            circuitBreaker: CASCircuitBreaker = CASCircuitBreaker()
         ) {
             self.fullHandle = fullHandle
             self.serverURL = serverURL
@@ -66,6 +69,7 @@
             self.dataCompressingService = dataCompressingService
             self.serverAuthenticationController = serverAuthenticationController
             self.upload = upload
+            self.circuitBreaker = circuitBreaker
         }
 
         public func load(
@@ -87,6 +91,16 @@
 
             Logger.current.debug("CAS.load starting - casID: \(casID)")
 
+            guard await circuitBreaker.shouldAttempt() else {
+                Logger.current.debug("CAS.load skipping remote cache (circuit open) - casID: \(casID)")
+                response.outcome = .error
+                var responseError = CompilationCacheService_Cas_V1_ResponseError()
+                responseError.description_p = "Remote cache unavailable; building locally."
+                response.error = responseError
+                response.contents = .error(responseError)
+                return response
+            }
+
             do {
                 let cacheURL = try await cacheURLStore.getCacheURL(for: serverURL, accountHandle: accountHandle)
                 let fetchStart = ProcessInfo.processInfo.systemUptime
@@ -98,6 +112,7 @@
                     serverAuthenticationController: serverAuthenticationController
                 )
                 let transferDuration = ProcessInfo.processInfo.systemUptime - fetchStart
+                await circuitBreaker.recordSuccess()
 
                 let decompressedData: Data
                 let codecDuration: TimeInterval
@@ -139,6 +154,11 @@
                         "CAS.load completed successfully in \(String(format: "%.3f", duration))s - loaded \(compressedData.count) compressed bytes, decompressed to \(decompressedData.count) bytes for casID: \(casID)"
                     )
             } catch {
+                if casErrorIsBackendHealthy(error) {
+                    await circuitBreaker.recordSuccess()
+                } else {
+                    await circuitBreaker.recordFailure()
+                }
                 response.outcome = .error
                 var responseError = CompilationCacheService_Cas_V1_ResponseError()
                 responseError.description_p = error.userFriendlyDescription()
@@ -220,6 +240,13 @@
                 return response
             }
 
+            guard await circuitBreaker.shouldAttempt() else {
+                Logger.current.debug("CAS.save skipping upload (circuit open) for fingerprint: \(fingerprint)")
+                response.casID = message
+                response.contents = .casID(message)
+                return response
+            }
+
             do {
                 let cacheURL = try await cacheURLStore.getCacheURL(for: serverURL, accountHandle: accountHandle)
                 let uploadStart = ProcessInfo.processInfo.systemUptime
@@ -232,6 +259,7 @@
                     serverAuthenticationController: serverAuthenticationController
                 )
                 let transferDuration = ProcessInfo.processInfo.systemUptime - uploadStart
+                await circuitBreaker.recordSuccess()
                 response.casID = message
                 response.contents = .casID(message)
 
@@ -250,6 +278,11 @@
                         "CAS.save completed successfully in \(String(format: "%.3f", duration))s for fingerprint: \(fingerprint)"
                     )
             } catch {
+                if casErrorIsBackendHealthy(error) {
+                    await circuitBreaker.recordSuccess()
+                } else {
+                    await circuitBreaker.recordFailure()
+                }
                 var responseError = CompilationCacheService_Cas_V1_ResponseError()
                 responseError.description_p = error.userFriendlyDescription()
                 response.error = responseError

--- a/cli/Sources/TuistCAS/Services/CASService.swift
+++ b/cli/Sources/TuistCAS/Services/CASService.swift
@@ -91,7 +91,7 @@
 
             Logger.current.debug("CAS.load starting - casID: \(casID)")
 
-            guard await circuitBreaker.shouldAttempt() else {
+            guard let attempt = await circuitBreaker.attempt() else {
                 Logger.current.debug("CAS.load skipping remote cache (circuit open) - casID: \(casID)")
                 response.outcome = .error
                 var responseError = CompilationCacheService_Cas_V1_ResponseError()
@@ -112,7 +112,7 @@
                     serverAuthenticationController: serverAuthenticationController
                 )
                 let transferDuration = ProcessInfo.processInfo.systemUptime - fetchStart
-                await circuitBreaker.recordSuccess()
+                await circuitBreaker.recordSuccess(attempt)
 
                 let decompressedData: Data
                 let codecDuration: TimeInterval
@@ -155,9 +155,9 @@
                     )
             } catch {
                 if casErrorIsBackendHealthy(error) {
-                    await circuitBreaker.recordSuccess()
+                    await circuitBreaker.recordSuccess(attempt)
                 } else {
-                    await circuitBreaker.recordFailure()
+                    await circuitBreaker.recordFailure(attempt)
                 }
                 response.outcome = .error
                 var responseError = CompilationCacheService_Cas_V1_ResponseError()
@@ -226,7 +226,12 @@
                 return response
             }
 
-            if await circuitBreaker.isOpen {
+            // Claim an attempt before compressing: when the circuit is open (remote
+            // cache unavailable) the artifact is already built locally, so skip both
+            // the expensive compression and the upload. `attempt()` also advances an
+            // elapsed cooldown, so a save-only workload re-probes and recovers rather
+            // than skipping uploads forever, and in half-open it gates to one probe.
+            guard let attempt = await circuitBreaker.attempt() else {
                 Logger.current.debug("CAS.save skipping upload (circuit open) for fingerprint: \(fingerprint)")
                 response.casID = message
                 response.contents = .casID(message)
@@ -240,6 +245,8 @@
                 compressedData = try await dataCompressingService.compress(data)
                 codecDuration = ProcessInfo.processInfo.systemUptime - compressStart
             } catch {
+                // Never reached the backend: release the (possibly half-open) probe.
+                await circuitBreaker.release(attempt)
                 Logger.current.error("CAS.save failed to compress data: \(error)")
                 var responseError = CompilationCacheService_Cas_V1_ResponseError()
                 responseError.description_p = "Failed to compress data: \(error.localizedDescription)"
@@ -253,15 +260,6 @@
                     "CAS.save computed fingerprint: \(fingerprint), original size: \(data.count) bytes, compressed size: \(compressedData.count) bytes"
                 )
 
-            // Claim the (possibly half-open) probe slot right before the upload, so a
-            // recovering backend is exercised by exactly one artifact.
-            guard await circuitBreaker.shouldAttempt() else {
-                Logger.current.debug("CAS.save skipping upload (circuit open) for fingerprint: \(fingerprint)")
-                response.casID = message
-                response.contents = .casID(message)
-                return response
-            }
-
             do {
                 let cacheURL = try await cacheURLStore.getCacheURL(for: serverURL, accountHandle: accountHandle)
                 let uploadStart = ProcessInfo.processInfo.systemUptime
@@ -274,7 +272,7 @@
                     serverAuthenticationController: serverAuthenticationController
                 )
                 let transferDuration = ProcessInfo.processInfo.systemUptime - uploadStart
-                await circuitBreaker.recordSuccess()
+                await circuitBreaker.recordSuccess(attempt)
                 response.casID = message
                 response.contents = .casID(message)
 
@@ -294,9 +292,9 @@
                     )
             } catch {
                 if casErrorIsBackendHealthy(error) {
-                    await circuitBreaker.recordSuccess()
+                    await circuitBreaker.recordSuccess(attempt)
                 } else {
-                    await circuitBreaker.recordFailure()
+                    await circuitBreaker.recordFailure(attempt)
                 }
                 var responseError = CompilationCacheService_Cas_V1_ResponseError()
                 responseError.description_p = error.userFriendlyDescription()

--- a/cli/Sources/TuistCache/Client/Client+Cache.swift
+++ b/cli/Sources/TuistCache/Client/Client+Cache.swift
@@ -10,14 +10,18 @@ extension Client {
     ///   - cacheURL: The cache service URL
     ///   - authenticationURL: The main server URL for authentication (token refresh, validation)
     ///   - serverAuthenticationController: Controller for server authentication
+    ///   - session: Optional URLSession override. The CAS path passes a
+    ///     short-timeout session so a hung backend fails fast; other callers use
+    ///     the shared session.
     public static func authenticated(
         cacheURL: URL,
         authenticationURL: URL,
-        serverAuthenticationController: ServerAuthenticationControlling
+        serverAuthenticationController: ServerAuthenticationControlling,
+        session: URLSession? = nil
     ) -> Client {
         .init(
             serverURL: cacheURL,
-            transport: TuistURLSessionTransport(),
+            transport: TuistURLSessionTransport(session: session),
             middlewares: HARRecordingMiddlewareFactory.middlewares() + [
                 RequestIdMiddleware(),
                 CacheClientAuthenticationMiddleware(

--- a/cli/Sources/TuistCache/Services/LoadCacheCASService.swift
+++ b/cli/Sources/TuistCache/Services/LoadCacheCASService.swift
@@ -61,7 +61,8 @@ public struct LoadCacheCASService: LoadCacheCASServicing {
         let client = Client.authenticated(
             cacheURL: serverURL,
             authenticationURL: authenticationURL,
-            serverAuthenticationController: serverAuthenticationController
+            serverAuthenticationController: serverAuthenticationController,
+            session: .tuistCAS
         )
         let handles = try fullHandleService.parse(fullHandle)
 

--- a/cli/Sources/TuistCache/Services/SaveCacheCASService.swift
+++ b/cli/Sources/TuistCache/Services/SaveCacheCASService.swift
@@ -69,7 +69,8 @@ public struct SaveCacheCASService: SaveCacheCASServicing {
         let client = Client.authenticated(
             cacheURL: serverURL,
             authenticationURL: authenticationURL,
-            serverAuthenticationController: serverAuthenticationController
+            serverAuthenticationController: serverAuthenticationController,
+            session: .tuistCAS
         )
         let handles = try fullHandleService.parse(fullHandle)
         let response = try await client.saveCASArtifact(

--- a/cli/Sources/TuistHTTP/URLSession+Tuist.swift
+++ b/cli/Sources/TuistHTTP/URLSession+Tuist.swift
@@ -107,6 +107,24 @@ func invalidateSharedTuistURLSession() {
     sharedTuistURLSession.invalidate()
 }
 
+private let sharedTuistCASURLSession: URLSession = {
+    let configuration = tuistURLSessionConfigurationResolved(
+        useEnvironmentProxy: HTTPSettings.current.useEnvironmentProxy
+    )
+    // The CAS hot path fires thousands of requests per build. Use a short
+    // inactivity timeout so a hung cache backend surfaces in seconds (the CAS
+    // circuit breaker then skips it for the rest of the build) instead of every
+    // compilation unit stalling on the default 90s. The resource timeout stays
+    // generous so a large but progressing artifact transfer is not cut off.
+    configuration.timeoutIntervalForRequest = 15
+    configuration.timeoutIntervalForResource = 300
+    #if canImport(TuistHAR)
+        return URLSession(configuration: configuration, delegate: URLSessionMetricsDelegate.shared, delegateQueue: nil)
+    #else
+        return URLSession(configuration: configuration)
+    #endif
+}()
+
 extension URLSession {
     public static var tuistShared: URLSession {
         sharedTuistURLSession.resolve(useEnvironmentProxy: HTTPSettings.current.useEnvironmentProxy)
@@ -114,6 +132,12 @@ extension URLSession {
 
     public static func tuistShared(useEnvironmentProxy: Bool) -> URLSession {
         makeTuistURLSession(useEnvironmentProxy: useEnvironmentProxy)
+    }
+
+    /// A shared session tuned for the CAS hot path: a short inactivity timeout so
+    /// a hung backend fails fast rather than stalling every compilation unit.
+    public static var tuistCAS: URLSession {
+        sharedTuistCASURLSession
     }
 }
 

--- a/cli/Sources/TuistHTTP/URLSession+Tuist.swift
+++ b/cli/Sources/TuistHTTP/URLSession+Tuist.swift
@@ -68,9 +68,14 @@ private func makeTuistURLSession(useEnvironmentProxy: Bool) -> URLSession {
 }
 
 private final class SharedTuistURLSession: @unchecked Sendable {
+    private let make: @Sendable (Bool) -> URLSession
     private let lock = NSLock()
     private var useEnvironmentProxy: Bool?
     private var session: URLSession?
+
+    init(make: @escaping @Sendable (Bool) -> URLSession) {
+        self.make = make
+    }
 
     func resolve(useEnvironmentProxy: Bool) -> URLSession {
         let sessionToInvalidate: URLSession?
@@ -82,7 +87,7 @@ private final class SharedTuistURLSession: @unchecked Sendable {
         }
 
         sessionToInvalidate = session
-        let session = makeTuistURLSession(useEnvironmentProxy: useEnvironmentProxy)
+        let session = make(useEnvironmentProxy)
         self.useEnvironmentProxy = useEnvironmentProxy
         self.session = session
         lock.unlock()
@@ -101,21 +106,13 @@ private final class SharedTuistURLSession: @unchecked Sendable {
     }
 }
 
-private let sharedTuistURLSession = SharedTuistURLSession()
-
-func invalidateSharedTuistURLSession() {
-    sharedTuistURLSession.invalidate()
-}
-
-private let sharedTuistCASURLSession: URLSession = {
-    let configuration = tuistURLSessionConfigurationResolved(
-        useEnvironmentProxy: HTTPSettings.current.useEnvironmentProxy
-    )
-    // The CAS hot path fires thousands of requests per build. Use a short
-    // inactivity timeout so a hung cache backend surfaces in seconds (the CAS
-    // circuit breaker then skips it for the rest of the build) instead of every
-    // compilation unit stalling on the default 90s. The resource timeout stays
-    // generous so a large but progressing artifact transfer is not cut off.
+/// The CAS hot path fires thousands of requests per build. A short inactivity
+/// timeout makes a hung cache backend surface in seconds (the CAS circuit breaker
+/// then skips it for the rest of the build) instead of every compilation unit
+/// stalling on the default 90s; the resource timeout stays generous so a large but
+/// progressing artifact transfer is not cut off.
+private func makeTuistCASURLSession(useEnvironmentProxy: Bool) -> URLSession {
+    let configuration = tuistURLSessionConfigurationResolved(useEnvironmentProxy: useEnvironmentProxy)
     configuration.timeoutIntervalForRequest = 15
     configuration.timeoutIntervalForResource = 300
     #if canImport(TuistHAR)
@@ -123,7 +120,15 @@ private let sharedTuistCASURLSession: URLSession = {
     #else
         return URLSession(configuration: configuration)
     #endif
-}()
+}
+
+private let sharedTuistURLSession = SharedTuistURLSession { makeTuistURLSession(useEnvironmentProxy: $0) }
+private let sharedTuistCASURLSession = SharedTuistURLSession { makeTuistCASURLSession(useEnvironmentProxy: $0) }
+
+func invalidateSharedTuistURLSession() {
+    sharedTuistURLSession.invalidate()
+    sharedTuistCASURLSession.invalidate()
+}
 
 extension URLSession {
     public static var tuistShared: URLSession {
@@ -136,8 +141,10 @@ extension URLSession {
 
     /// A shared session tuned for the CAS hot path: a short inactivity timeout so
     /// a hung backend fails fast rather than stalling every compilation unit.
+    /// Resolves the current proxy setting like `tuistShared`, so a proxy change is
+    /// picked up rather than pinned to first use.
     public static var tuistCAS: URLSession {
-        sharedTuistCASURLSession
+        sharedTuistCASURLSession.resolve(useEnvironmentProxy: HTTPSettings.current.useEnvironmentProxy)
     }
 }
 

--- a/cli/Tests/TuistCASTests/CASCircuitBreakerTests.swift
+++ b/cli/Tests/TuistCASTests/CASCircuitBreakerTests.swift
@@ -1,0 +1,101 @@
+#if os(macOS)
+    import Foundation
+    import Testing
+    import TuistCache
+    @testable import TuistCAS
+
+    private final class TestClock: @unchecked Sendable {
+        private let lock = NSLock()
+        private var current: Date
+        init(_ start: Date = Date(timeIntervalSince1970: 1_000_000)) {
+            current = start
+        }
+
+        func now() -> Date {
+            lock.lock(); defer { lock.unlock() }; return current
+        }
+
+        func advance(_ interval: TimeInterval) {
+            lock.lock(); current += interval; lock.unlock()
+        }
+    }
+
+    struct CASCircuitBreakerTests {
+        @Test func closed_breaker_allows_attempts() async {
+            let breaker = CASCircuitBreaker()
+            #expect(await breaker.shouldAttempt())
+            #expect(await breaker.shouldAttempt())
+            #expect(await breaker.isOpen == false)
+        }
+
+        @Test func opens_after_threshold_consecutive_failures() async {
+            let breaker = CASCircuitBreaker(failureThreshold: 3, cooldown: 30)
+            await breaker.recordFailure()
+            await breaker.recordFailure()
+            #expect(await breaker.isOpen == false) // below threshold
+            await breaker.recordFailure()
+            #expect(await breaker.isOpen)
+            #expect(await breaker.shouldAttempt() == false) // within cooldown
+        }
+
+        @Test func success_resets_the_failure_run() async {
+            let breaker = CASCircuitBreaker(failureThreshold: 3)
+            await breaker.recordFailure()
+            await breaker.recordFailure()
+            await breaker.recordSuccess() // backend reachable again
+            await breaker.recordFailure()
+            await breaker.recordFailure()
+            #expect(await breaker.isOpen == false) // counter reset, only 2 since success
+        }
+
+        @Test func success_never_opens_the_breaker() async {
+            let breaker = CASCircuitBreaker(failureThreshold: 1)
+            for _ in 0 ..< 10 {
+                await breaker.recordSuccess()
+            }
+            #expect(await breaker.isOpen == false)
+            #expect(await breaker.shouldAttempt())
+        }
+
+        @Test func half_open_after_cooldown_allows_a_single_probe() async {
+            let clock = TestClock()
+            let breaker = CASCircuitBreaker(failureThreshold: 1, cooldown: 30, now: { clock.now() })
+            await breaker.recordFailure() // opens
+            #expect(await breaker.shouldAttempt() == false)
+
+            clock.advance(31) // cooldown elapsed
+            #expect(await breaker.shouldAttempt()) // one probe allowed
+            #expect(await breaker.shouldAttempt() == false) // probe already in flight
+
+            await breaker.recordSuccess() // probe succeeded -> closed
+            #expect(await breaker.isOpen == false)
+            #expect(await breaker.shouldAttempt())
+        }
+
+        @Test func half_open_probe_failure_reopens() async {
+            let clock = TestClock()
+            let breaker = CASCircuitBreaker(failureThreshold: 1, cooldown: 30, now: { clock.now() })
+            await breaker.recordFailure() // opens
+            clock.advance(31)
+            #expect(await breaker.shouldAttempt()) // probe
+            await breaker.recordFailure() // probe failed -> reopen
+            #expect(await breaker.isOpen)
+            #expect(await breaker.shouldAttempt() == false) // cooldown restarted
+            clock.advance(31)
+            #expect(await breaker.shouldAttempt()) // probes again after the new cooldown
+        }
+
+        @Test func classifies_miss_and_too_large_as_backend_healthy() {
+            #expect(casErrorIsBackendHealthy(LoadCacheCASServiceError.notFound("miss")))
+            #expect(casErrorIsBackendHealthy(SaveCacheCASServiceError.contentTooLarge("too big")))
+        }
+
+        @Test func classifies_server_and_transport_errors_as_unavailable() {
+            #expect(casErrorIsBackendHealthy(LoadCacheCASServiceError.unknownError(503)) == false)
+            #expect(casErrorIsBackendHealthy(LoadCacheCASServiceError.unauthorized("nope")) == false)
+            #expect(casErrorIsBackendHealthy(SaveCacheCASServiceError.internalServerError("boom")) == false)
+            #expect(casErrorIsBackendHealthy(URLError(.timedOut)) == false)
+            #expect(casErrorIsBackendHealthy(URLError(.cannotConnectToHost)) == false)
+        }
+    }
+#endif

--- a/cli/Tests/TuistCASTests/CASCircuitBreakerTests.swift
+++ b/cli/Tests/TuistCASTests/CASCircuitBreakerTests.swift
@@ -23,66 +23,85 @@
     struct CASCircuitBreakerTests {
         @Test func closed_breaker_allows_attempts() async {
             let breaker = CASCircuitBreaker()
-            #expect(await breaker.shouldAttempt())
-            #expect(await breaker.shouldAttempt())
+            #expect(await breaker.attempt() != nil)
+            #expect(await breaker.attempt() != nil)
             #expect(await breaker.isOpen == false)
         }
 
-        @Test func opens_after_threshold_consecutive_failures() async {
+        @Test func opens_after_threshold_consecutive_failures() async throws {
             let breaker = CASCircuitBreaker(failureThreshold: 3, cooldown: 30)
-            await breaker.recordFailure()
-            await breaker.recordFailure()
+            for _ in 0 ..< 2 {
+                await breaker.recordFailure(try #require(await breaker.attempt()))
+            }
             #expect(await breaker.isOpen == false) // below threshold
-            await breaker.recordFailure()
+            await breaker.recordFailure(try #require(await breaker.attempt()))
             #expect(await breaker.isOpen)
-            #expect(await breaker.shouldAttempt() == false) // within cooldown
+            #expect(await breaker.attempt() == nil) // within cooldown
         }
 
-        @Test func success_resets_the_failure_run() async {
+        @Test func success_resets_the_failure_run() async throws {
             let breaker = CASCircuitBreaker(failureThreshold: 3)
-            await breaker.recordFailure()
-            await breaker.recordFailure()
-            await breaker.recordSuccess() // backend reachable again
-            await breaker.recordFailure()
-            await breaker.recordFailure()
+            for _ in 0 ..< 2 {
+                await breaker.recordFailure(try #require(await breaker.attempt()))
+            }
+            await breaker.recordSuccess(try #require(await breaker.attempt())) // backend reachable again
+            for _ in 0 ..< 2 {
+                await breaker.recordFailure(try #require(await breaker.attempt()))
+            }
             #expect(await breaker.isOpen == false) // counter reset, only 2 since success
         }
 
-        @Test func success_never_opens_the_breaker() async {
-            let breaker = CASCircuitBreaker(failureThreshold: 1)
-            for _ in 0 ..< 10 {
-                await breaker.recordSuccess()
-            }
-            #expect(await breaker.isOpen == false)
-            #expect(await breaker.shouldAttempt())
-        }
-
-        @Test func half_open_after_cooldown_allows_a_single_probe() async {
-            let clock = TestClock()
-            let breaker = CASCircuitBreaker(failureThreshold: 1, cooldown: 30, now: { clock.now() })
-            await breaker.recordFailure() // opens
-            #expect(await breaker.shouldAttempt() == false)
-
-            clock.advance(31) // cooldown elapsed
-            #expect(await breaker.shouldAttempt()) // one probe allowed
-            #expect(await breaker.shouldAttempt() == false) // probe already in flight
-
-            await breaker.recordSuccess() // probe succeeded -> closed
-            #expect(await breaker.isOpen == false)
-            #expect(await breaker.shouldAttempt())
-        }
-
-        @Test func half_open_probe_failure_reopens() async {
-            let clock = TestClock()
-            let breaker = CASCircuitBreaker(failureThreshold: 1, cooldown: 30, now: { clock.now() })
-            await breaker.recordFailure() // opens
-            clock.advance(31)
-            #expect(await breaker.shouldAttempt()) // probe
-            await breaker.recordFailure() // probe failed -> reopen
+        /// A late result from a request that was already in flight when the breaker
+        /// opened must not close it — otherwise one straggler re-enables the remote
+        /// before the cooldown and defeats the short-circuit.
+        @Test func stale_success_from_a_superseded_generation_is_ignored() async throws {
+            let breaker = CASCircuitBreaker(failureThreshold: 2, cooldown: 30)
+            await breaker.recordFailure(try #require(await breaker.attempt())) // 1 failure, still closed
+            let stale = try #require(await breaker.attempt()) // in-flight, obtained before open
+            await breaker.recordFailure(try #require(await breaker.attempt())) // 2 failures -> opens
             #expect(await breaker.isOpen)
-            #expect(await breaker.shouldAttempt() == false) // cooldown restarted
+
+            await breaker.recordSuccess(stale) // stale success must not close it
+            #expect(await breaker.isOpen)
+            #expect(await breaker.attempt() == nil) // still within cooldown
+        }
+
+        @Test func attempt_advances_cooldown_and_allows_a_single_probe() async throws {
+            let clock = TestClock()
+            let breaker = CASCircuitBreaker(failureThreshold: 1, cooldown: 30, now: { clock.now() })
+            await breaker.recordFailure(try #require(await breaker.attempt())) // opens
+            #expect(await breaker.attempt() == nil) // within cooldown
+
             clock.advance(31)
-            #expect(await breaker.shouldAttempt()) // probes again after the new cooldown
+            let probe = try #require(await breaker.attempt()) // cooldown elapsed -> one probe
+            #expect(await breaker.attempt() == nil) // probe already in flight
+
+            await breaker.recordSuccess(probe) // probe succeeded -> closed
+            #expect(await breaker.isOpen == false)
+            #expect(await breaker.attempt() != nil)
+        }
+
+        @Test func half_open_probe_failure_reopens() async throws {
+            let clock = TestClock()
+            let breaker = CASCircuitBreaker(failureThreshold: 1, cooldown: 30, now: { clock.now() })
+            await breaker.recordFailure(try #require(await breaker.attempt())) // opens
+            clock.advance(31)
+            await breaker.recordFailure(try #require(await breaker.attempt())) // probe failed -> reopen
+            #expect(await breaker.isOpen)
+            #expect(await breaker.attempt() == nil) // cooldown restarted
+            clock.advance(31)
+            #expect(await breaker.attempt() != nil) // probes again after the new cooldown
+        }
+
+        @Test func release_frees_the_half_open_probe_slot() async throws {
+            let clock = TestClock()
+            let breaker = CASCircuitBreaker(failureThreshold: 1, cooldown: 30, now: { clock.now() })
+            await breaker.recordFailure(try #require(await breaker.attempt())) // opens
+            clock.advance(31)
+            let probe = try #require(await breaker.attempt())
+            #expect(await breaker.attempt() == nil) // probe in flight
+            await breaker.release(probe) // abandoned before reaching the backend
+            #expect(await breaker.attempt() != nil) // slot freed for the next attempt
         }
 
         @Test func classifies_miss_and_too_large_as_backend_healthy() {

--- a/cli/Tests/TuistCASTests/CASServiceTests.swift
+++ b/cli/Tests/TuistCASTests/CASServiceTests.swift
@@ -433,6 +433,105 @@
                 #expect(Bool(false), "Expected error, but contents is nil")
             }
         }
+
+        @Test
+        func load_opens_circuit_and_skips_remote_after_failures() async throws {
+            // Given
+            let breaker = CASCircuitBreaker(failureThreshold: 1)
+            let subject = CASService(
+                fullHandle: fullHandle,
+                serverURL: serverURL,
+                cacheURLStore: cacheURLStore,
+                saveCacheCASService: saveCacheCASService,
+                loadCacheCASService: loadCacheCASService,
+                fileSystem: FileSystem(),
+                dataCompressingService: dataCompressingService,
+                analyticsDatabase: analyticsDatabase,
+                serverAuthenticationController: serverAuthenticationController,
+                circuitBreaker: breaker
+            )
+
+            var request = CompilationCacheService_Cas_V1_CASLoadRequest()
+            request.casID.id = "cas-id".data(using: .utf8)!
+            let context = ServerContext.test()
+
+            given(loadCacheCASService)
+                .loadCacheCAS(
+                    casId: .any,
+                    fullHandle: .any,
+                    serverURL: .any,
+                    authenticationURL: .any,
+                    serverAuthenticationController: .any
+                )
+                .willThrow(LoadCacheCASServiceError.unknownError(503))
+
+            // When: the first load hits the remote and trips the breaker;
+            // the second finds the circuit open and skips the remote entirely.
+            _ = try await subject.load(request: request, context: context)
+            let second = try await subject.load(request: request, context: context)
+
+            // Then
+            #expect(await breaker.isOpen)
+            #expect(second.outcome == .error)
+            verify(loadCacheCASService)
+                .loadCacheCAS(
+                    casId: .any,
+                    fullHandle: .any,
+                    serverURL: .any,
+                    authenticationURL: .any,
+                    serverAuthenticationController: .any
+                )
+                .called(1)
+        }
+
+        @Test
+        func load_miss_keeps_circuit_closed() async throws {
+            // Given
+            let breaker = CASCircuitBreaker(failureThreshold: 1)
+            let subject = CASService(
+                fullHandle: fullHandle,
+                serverURL: serverURL,
+                cacheURLStore: cacheURLStore,
+                saveCacheCASService: saveCacheCASService,
+                loadCacheCASService: loadCacheCASService,
+                fileSystem: FileSystem(),
+                dataCompressingService: dataCompressingService,
+                analyticsDatabase: analyticsDatabase,
+                serverAuthenticationController: serverAuthenticationController,
+                circuitBreaker: breaker
+            )
+
+            var request = CompilationCacheService_Cas_V1_CASLoadRequest()
+            request.casID.id = "cas-id".data(using: .utf8)!
+            let context = ServerContext.test()
+
+            given(loadCacheCASService)
+                .loadCacheCAS(
+                    casId: .any,
+                    fullHandle: .any,
+                    serverURL: .any,
+                    authenticationURL: .any,
+                    serverAuthenticationController: .any
+                )
+                .willThrow(LoadCacheCASServiceError.notFound("miss"))
+
+            // When: a 404 is a healthy backend (a normal miss), so it must not
+            // trip the breaker — the remote keeps being consulted.
+            _ = try await subject.load(request: request, context: context)
+            _ = try await subject.load(request: request, context: context)
+
+            // Then
+            #expect(await breaker.isOpen == false)
+            verify(loadCacheCASService)
+                .loadCacheCAS(
+                    casId: .any,
+                    fullHandle: .any,
+                    serverURL: .any,
+                    authenticationURL: .any,
+                    serverAuthenticationController: .any
+                )
+                .called(2)
+        }
     }
 
     extension ServerContext {

--- a/cli/Tests/TuistCASTests/CASServiceTests.swift
+++ b/cli/Tests/TuistCASTests/CASServiceTests.swift
@@ -537,7 +537,7 @@
         func save_skips_compression_and_upload_when_circuit_open() async throws {
             // Given: an already-open breaker (remote cache unavailable).
             let breaker = CASCircuitBreaker(failureThreshold: 1)
-            await breaker.recordFailure()
+            await breaker.recordFailure(try #require(await breaker.attempt()))
             #expect(await breaker.isOpen)
 
             let subject = CASService(

--- a/cli/Tests/TuistCASTests/CASServiceTests.swift
+++ b/cli/Tests/TuistCASTests/CASServiceTests.swift
@@ -532,6 +532,54 @@
                 )
                 .called(2)
         }
+
+        @Test
+        func save_skips_compression_and_upload_when_circuit_open() async throws {
+            // Given: an already-open breaker (remote cache unavailable).
+            let breaker = CASCircuitBreaker(failureThreshold: 1)
+            await breaker.recordFailure()
+            #expect(await breaker.isOpen)
+
+            let subject = CASService(
+                fullHandle: fullHandle,
+                serverURL: serverURL,
+                cacheURLStore: cacheURLStore,
+                saveCacheCASService: saveCacheCASService,
+                loadCacheCASService: loadCacheCASService,
+                fileSystem: FileSystem(),
+                dataCompressingService: dataCompressingService,
+                analyticsDatabase: analyticsDatabase,
+                serverAuthenticationController: serverAuthenticationController,
+                circuitBreaker: breaker
+            )
+
+            var request = CompilationCacheService_Cas_V1_CASSaveRequest()
+            request.data.blob.data = Data("artifact".utf8)
+            let context = ServerContext.test()
+
+            // When
+            let response = try await subject.save(request: request, context: context)
+
+            // Then: the fingerprint is still returned, but neither the expensive
+            // compression nor the upload runs while the circuit is open.
+            switch response.contents {
+            case .casID:
+                break
+            default:
+                #expect(Bool(false), "Expected casID content")
+            }
+            verify(dataCompressingService).compress(.any).called(0)
+            verify(saveCacheCASService)
+                .saveCacheCAS(
+                    .any,
+                    casId: .any,
+                    fullHandle: .any,
+                    serverURL: .any,
+                    authenticationURL: .any,
+                    serverAuthenticationController: .any
+                )
+                .called(0)
+        }
     }
 
     extension ServerContext {


### PR DESCRIPTION
## What

Adds a per-process **circuit breaker** for the remote CAS (compilation) cache, so a remote-cache outage degrades to a fast local-compile fallback instead of stalling the build.

- **`CASCircuitBreaker`** (actor) — after N consecutive failures it opens; every subsequent `load`/`save` short-circuits to a local build **instantly** instead of re-discovering the outage. Re-probes after a short cooldown (half-open, single probe) so caching resumes if the backend recovers mid-build.
- **Health classification** — a 404 miss (and a too-large save) mean the backend is reachable, so they reset the breaker; 5xx / timeout / connection / auth errors count toward opening it.
- **Short-timeout CAS session** — a dedicated `URLSession.tuistCAS` with a 15s inactivity timeout (vs the shared 90s) so a *hung* backend surfaces in seconds; the resource timeout stays generous so a large but progressing artifact transfer isn't cut off.

Wired into `CASService.load`/`save`; `LoadCacheCASService`/`SaveCacheCASService` thread the short-timeout session through the cache client.

## Why

A build fires **thousands** of CAS load/save calls, many concurrently. When the remote cache is unavailable — a Kura pod roll, a box loss, a network blip — every call today independently waits for its own failure/timeout before the compiler falls back to a local build. On the CAS path there's no retry (good) but also **no shared failure state and a 90s timeout**, so one outage becomes a per-request tax: with thousands of units the build slows to a crawl, or stalls entirely if the backend hangs, even though builds still *succeed*.

The breaker makes one unit's discovery of the outage benefit all the others: the first few failures trip a shared switch, and the rest short-circuit to local compilation with no network round-trip. This is what makes the cache's fail-open guarantee **performance-safe**, not just correctness-safe.

Investigation notes: the CAS load path already collapses a 404 miss and a 5xx into the same `outcome = .error`, which Xcode treats as "compile locally" (that's how normal cold-cache misses work) — so fail-open is already *correct*. This PR only fixes how *fast* the fallback happens under a real outage.

## Safety

- **Never changes build output.** A short-circuited load behaves exactly like a cache miss (compiler builds locally); a short-circuited save reuses the existing "skip upload" path (the artifact is already built locally). The breaker only decides *when to stop asking* a backend that's already failing.
- Per-process (per build) — a new build starts fresh and re-probes; no stale state persists.
- No config knobs (hard-coded threshold/cooldown, per project convention).

## Tests

- **`CASCircuitBreakerTests`** — the state machine: opens after threshold, success/miss reset the run, half-open allows a single probe after cooldown, probe failure re-opens, and the error classifier (miss/too-large = healthy; 5xx/auth/`URLError` = unavailable).
- **`CASServiceTests`** (2 added) — a 503 run trips the breaker and the *next* `load` skips the remote entirely (asserts the remote stub is called once); a 404 miss keeps the breaker closed (remote still consulted).
- `swift build` of `TuistCAS` and `TuistCASTests` is green locally.

## Context

This is item #3 of the Kura production-readiness work: it de-risks the customer-plane 503 window during primary-pod rolls (a separate finding — the customer Service currently targets only the primary pod) by making the client tolerate *any* remote-cache unavailability gracefully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)