### PR TITLE
fix(server): build the xctest runner-error regex inline instead of a shared static

### DIFF
--- a/server/native/xcresult_nif/Sources/XCResultParser/XCResultParser.swift
+++ b/server/native/xcresult_nif/Sources/XCResultParser/XCResultParser.swift
@@ -295,11 +295,14 @@ public struct XCResultParser: Sendable {
     /// create unbounded per-pid rows, or fire `test_case.created` webhooks) and
     /// collect them as target-keyed errors. The pid varies per run, so we dedup
     /// by (target, message) to land one per target like Xcode.
-    nonisolated(unsafe) private static let xctestRunnerErrorRegex = /xctest \(\d+\) encountered an error/
-
     private func isRunnerError(_ name: String?) -> Bool {
-        guard let name else { return false }
-        return name.wholeMatch(of: Self.xctestRunnerErrorRegex) != nil
+        let prefix = "xctest ("
+        let suffix = ") encountered an error"
+        guard let name, name.hasPrefix(prefix), name.hasSuffix(suffix) else { return false }
+        // The `<pid>` between the parentheses must be one or more digits, matching the
+        // `xctest (<pid>) encountered an error` shape without a shared, non-Sendable regex.
+        let pid = name.dropFirst(prefix.count).dropLast(suffix.count)
+        return !pid.isEmpty && pid.allSatisfy { $0.isASCII && $0.isNumber }
     }
 
     private func extractErrors(from node: TestNode, module: String?, into errors: inout [TestRunError]) {

--- a/server/native/xcresult_nif/Sources/XCResultParser/XCResultParser.swift
+++ b/server/native/xcresult_nif/Sources/XCResultParser/XCResultParser.swift
@@ -296,13 +296,11 @@ public struct XCResultParser: Sendable {
     /// collect them as target-keyed errors. The pid varies per run, so we dedup
     /// by (target, message) to land one per target like Xcode.
     private func isRunnerError(_ name: String?) -> Bool {
-        let prefix = "xctest ("
-        let suffix = ") encountered an error"
-        guard let name, name.hasPrefix(prefix), name.hasSuffix(suffix) else { return false }
-        // The `<pid>` between the parentheses must be one or more digits, matching the
-        // `xctest (<pid>) encountered an error` shape without a shared, non-Sendable regex.
-        let pid = name.dropFirst(prefix.count).dropLast(suffix.count)
-        return !pid.isEmpty && pid.allSatisfy { $0.isASCII && $0.isNumber }
+        guard let name else { return false }
+        // Built inline rather than cached in a `static let`: `Regex` isn't `Sendable`, so a shared static
+        // needs `nonisolated(unsafe)`. The per-call cost is negligible next to xcresult parsing
+        // (`xcresulttool` subprocess + JSON decoding), so we skip the shared state entirely.
+        return name.wholeMatch(of: /xctest \(\d+\) encountered an error/) != nil
     }
 
     private func extractErrors(from node: TestNode, module: String?, into errors: inout [TestRunError]) {

--- a/server/native/xcresult_nif/Sources/XCResultParser/XCResultParser.swift
+++ b/server/native/xcresult_nif/Sources/XCResultParser/XCResultParser.swift
@@ -295,7 +295,7 @@ public struct XCResultParser: Sendable {
     /// create unbounded per-pid rows, or fire `test_case.created` webhooks) and
     /// collect them as target-keyed errors. The pid varies per run, so we dedup
     /// by (target, message) to land one per target like Xcode.
-    private static let xctestRunnerErrorRegex = /xctest \(\d+\) encountered an error/
+    nonisolated(unsafe) private static let xctestRunnerErrorRegex = /xctest \(\d+\) encountered an error/
 
     private func isRunnerError(_ name: String?) -> Bool {
         guard let name else { return false }

--- a/server/native/xcresult_nif/Sources/XCResultParser/XCResultParser.swift
+++ b/server/native/xcresult_nif/Sources/XCResultParser/XCResultParser.swift
@@ -297,9 +297,6 @@ public struct XCResultParser: Sendable {
     /// by (target, message) to land one per target like Xcode.
     private func isRunnerError(_ name: String?) -> Bool {
         guard let name else { return false }
-        // Built inline rather than cached in a `static let`: `Regex` isn't `Sendable`, so a shared static
-        // needs `nonisolated(unsafe)`. The per-call cost is negligible next to xcresult parsing
-        // (`xcresulttool` subprocess + JSON decoding), so we skip the shared state entirely.
         return name.wholeMatch(of: /xctest \(\d+\) encountered an error/) != nil
     }
 


### PR DESCRIPTION
## What changed

`XCResultParser.isRunnerError` keeps matching the synthetic `xctest (<pid>) encountered an error` name with the same `/xctest \(\d+\) encountered an error/` regex, but builds it inline instead of caching it in a `private static let`.

## Why

`Regex<Substring>` isn't `Sendable`, so the shared `static let xctestRunnerErrorRegex` (added by #11606) tripped Swift 6 concurrency checking:

```
static property 'xctestRunnerErrorRegex' is not concurrency-safe because
non-'Sendable' type 'Regex<Substring>' may have shared mutable state
```

That failed the `SwiftPM Build` check on `main` (the package compiles in Swift 6 language mode). The problem was the *shared static*, not the regex itself — `nonisolated(unsafe)` would only silence the checker rather than remove the shared mutable global.

Building the regex inline in `isRunnerError` sidesteps the shared state entirely: no `unsafe`, nothing to prove `Sendable`, and the declarative pattern stays. `isRunnerError` runs per "Test Case" node, but the per-call cost is negligible next to xcresult parsing (`xcresulttool` subprocess + JSON decoding), which dominates.

## Validation

- Compiles clean under `-swift-version 6`.
- Behavior is unchanged — it's the same regex and `wholeMatch`, just not cached.

Once merged this restores the `SwiftPM Build` check on `main`.