### PR TITLE
perf(server): back flaky-alert default-branch validation with a marker MV

### DIFF
--- a/server/lib/tuist/tests.ex
+++ b/server/lib/tuist/tests.ex
@@ -1585,21 +1585,27 @@ defmodule Tuist.Tests do
     |> Enum.flat_map(&fetch_validated_test_case_ids_chunk(project_id, &1, default_branch))
   end
 
+  # Reads `test_case_runs_validated_on_branch`, a ReplacingMergeTree fed by the
+  # `test_case_runs_validated_on_branch_mv` materialized view holding one marker
+  # row per `(project_id, git_branch, test_case_id)` that has ever had a
+  # successful, non-flaky run. Each test case collapses to a single row, so
+  # validating a large triggered set is a bounded primary-key point lookup
+  # instead of scanning every matching run of the raw `test_case_runs` table
+  # (which, on busy projects, read millions of rows per evaluation).
+  #
   # Binds the ids as a single `Array(UUID)` parameter via a fragment instead of
-  # `tcr.test_case_id in ^ids_chunk`. `in` expands to one bound parameter per
-  # id, which overflows ClickHouse's request limits when the triggered set is
-  # large. Chunks are disjoint, so the per-chunk `distinct` already yields a
-  # distinct union.
+  # `v.test_case_id in ^ids_chunk`. `in` expands to one bound parameter per id,
+  # which overflows ClickHouse's request limits when the triggered set is large.
+  # `distinct` collapses any not-yet-merged duplicate marker rows; the schema is
+  # borrowed from `TestCaseRun` purely to type the shared columns.
   defp fetch_validated_test_case_ids_chunk(project_id, ids_chunk, default_branch) do
     ClickHouseRepo.all(
-      from(tcr in TestCaseRun,
-        where: tcr.project_id == ^project_id,
-        where: fragment("? IN (?)", tcr.test_case_id, type(^ids_chunk, {:array, Ecto.UUID})),
-        where: tcr.git_branch == ^default_branch,
-        where: fragment("? = 'success'", tcr.status),
-        where: tcr.is_flaky == false,
+      from(v in {"test_case_runs_validated_on_branch", TestCaseRun},
+        where: v.project_id == ^project_id,
+        where: v.git_branch == ^default_branch,
+        where: fragment("? IN (?)", v.test_case_id, type(^ids_chunk, {:array, Ecto.UUID})),
         distinct: true,
-        select: tcr.test_case_id
+        select: v.test_case_id
       ),
       multipart: true
     )

--- a/server/priv/ingest_repo/migrations/20260702190000_create_test_case_runs_validated_on_branch_mv.exs
+++ b/server/priv/ingest_repo/migrations/20260702190000_create_test_case_runs_validated_on_branch_mv.exs
@@ -1,0 +1,149 @@
+defmodule Tuist.IngestRepo.Migrations.CreateTestCaseRunsValidatedOnBranchMv do
+  @moduledoc """
+  Per-`(project, branch, test_case)` "validated on this branch" marker.
+
+  `AlertEvaluationWorker.reject_unvalidated_test_cases/2` filters a flaky
+  alert's triggered test cases down to those with at least one successful,
+  non-flaky run on the project's default branch, via
+  `Tests.test_case_ids_with_successful_default_branch_run/3`. That check used to
+  scan raw `test_case_runs` for the whole triggered set — filtering by
+  `status = 'success' AND is_flaky = false AND git_branch = <default>` and
+  reading every matching run per test case, chunked 2000 ids at a time. On busy
+  projects with large triggered sets this became the single most CPU-expensive
+  ClickHouse query (multi-second raw-table scans reading millions of rows per
+  evaluation).
+
+  This collapses each `(project_id, git_branch, test_case_id)` that has ever had
+  a successful, non-flaky run into one marker row in a ReplacingMergeTree keyed
+  the same way. The validation check then becomes a bounded primary-key point
+  lookup per test case instead of a raw-run scan. The MV pre-applies the
+  `status = 'success' AND is_flaky = false` filter, so the read only needs
+  `project_id`, `git_branch`, and the `test_case_id IN (...)` set.
+
+  Mirrors the established explicit-storage-table + MV-trigger + partition
+  backfill pattern used by the other per-case aggregates.
+  """
+  use Ecto.Migration
+
+  alias Tuist.IngestRepo
+
+  require Logger
+
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  # Throttle between partition backfills to give live ClickHouse traffic
+  # (background merges, MV writes, automation queries) breathing room.
+  @chunk_throttle_ms 100
+
+  def up do
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    IngestRepo.query!("DROP VIEW IF EXISTS test_case_runs_validated_on_branch_mv")
+
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    IngestRepo.query!("""
+    CREATE TABLE IF NOT EXISTS test_case_runs_validated_on_branch (
+      project_id Int64,
+      git_branch String,
+      test_case_id UUID
+    ) ENGINE = ReplacingMergeTree
+    ORDER BY (project_id, git_branch, test_case_id)
+    """)
+
+    backfill_by_partition()
+
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    IngestRepo.query!("""
+    CREATE MATERIALIZED VIEW IF NOT EXISTS test_case_runs_validated_on_branch_mv
+    TO test_case_runs_validated_on_branch
+    AS SELECT
+      project_id,
+      git_branch,
+      assumeNotNull(test_case_id) AS test_case_id
+    FROM test_case_runs
+    WHERE test_case_id IS NOT NULL AND status = 'success' AND is_flaky = false
+    GROUP BY project_id, git_branch, test_case_id
+    """)
+  end
+
+  def down do
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    IngestRepo.query!("DROP VIEW IF EXISTS test_case_runs_validated_on_branch_mv")
+
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    IngestRepo.query!("DROP TABLE IF EXISTS test_case_runs_validated_on_branch")
+  end
+
+  defp backfill_by_partition do
+    {:ok, %{rows: partitions}} =
+      IngestRepo.query(
+        """
+        SELECT DISTINCT partition
+        FROM system.parts
+        WHERE database = currentDatabase() AND table = {table:String} AND active
+        ORDER BY partition
+        """,
+        %{table: "test_case_runs"}
+      )
+
+    for [partition] <- partitions do
+      Logger.info("Backfilling partition #{partition} into test_case_runs_validated_on_branch")
+
+      retry_on_transient_failure(fn -> backfill_partition(String.to_integer(partition)) end)
+
+      Process.sleep(@chunk_throttle_ms)
+    end
+  end
+
+  # `GROUP BY` collapses the partition's runs to distinct
+  # `(project_id, git_branch, test_case_id)` keys before insert, so the marker
+  # table stays one row per validated test case per branch rather than one per
+  # run. `max_bytes_before_external_group_by` lets the group-by spill to disk,
+  # bounding memory regardless of how many distinct keys a busy month holds.
+  defp backfill_partition(partition) do
+    IngestRepo.query!(
+      """
+      INSERT INTO test_case_runs_validated_on_branch (project_id, git_branch, test_case_id)
+      SELECT
+        project_id,
+        git_branch,
+        assumeNotNull(test_case_id) AS test_case_id
+      FROM test_case_runs
+      WHERE toYYYYMM(inserted_at) = {partition:UInt32}
+        AND test_case_id IS NOT NULL
+        AND status = 'success'
+        AND is_flaky = false
+      GROUP BY project_id, git_branch, test_case_id
+      SETTINGS
+        max_threads = 2,
+        max_memory_usage = 6000000000,
+        max_bytes_before_external_group_by = 3000000000
+      """,
+      %{partition: partition},
+      timeout: 1_200_000
+    )
+  end
+
+  defp retry_on_transient_failure(fun, attempts \\ 5) do
+    fun.()
+  rescue
+    e in Ch.Error ->
+      message = to_string(e.message)
+
+      transient? =
+        String.contains?(message, "TABLE_IS_READ_ONLY") or
+          String.contains?(message, "MEMORY_LIMIT_EXCEEDED")
+
+      if attempts > 1 and transient? do
+        Logger.warning(
+          "ClickHouse returned a transient error (#{String.slice(message, 0, 80)}...); " <>
+            "retrying in 5s (#{attempts - 1} attempts left)"
+        )
+
+        Process.sleep(to_timeout(second: 5))
+        retry_on_transient_failure(fun, attempts - 1)
+      else
+        reraise e, __STACKTRACE__
+      end
+  end
+end


### PR DESCRIPTION
> Follow-up from the ClickHouse CPU investigation. Fixes the #1 CPU-consuming query (the flaky-alert default-branch validation gate). Independent of the OOM/memory fix (already shipped in #11623).

## What

Adds `test_case_runs_validated_on_branch` — a `ReplacingMergeTree` fed by a new materialized view holding **one marker row per `(project_id, git_branch, test_case_id)`** that has ever had a successful, non-flaky run. The flaky-alert validation gate now reads that small table via a primary-key point lookup instead of scanning the raw `test_case_runs` table.

## Why

During the ClickHouse CPU investigation, the top single query by CPU (last 10 min: **704 core-seconds**) was:

```sql
SELECT DISTINCT test_case_id FROM test_case_runs
WHERE project_id = ? AND test_case_id IN (…≤2000…)
  AND git_branch = <default> AND status = 'success' AND is_flaky = false
```

This is `Tests.test_case_ids_with_successful_default_branch_run/3`, called from `AlertEvaluationWorker.reject_unvalidated_test_cases/2` to filter a flaky alert's triggered test cases down to those proven on the default branch (so brand-new/PR-only tests aren't auto-quarantined). It scanned raw `test_case_runs` for the whole triggered set on **every** evaluation.

Measured behavior on a busy project: it read **millions of rows per evaluation** and its per-call latency went from ~100 ms (idle cluster) to **~1.5 s under contention**, making it a top contributor to the CPU-saturation feedback loop we saw (queries slowing 5–13×, concurrency 1.1→11.3).

## How the fix works

- New MV `test_case_runs_validated_on_branch_mv` pre-applies `status = 'success' AND is_flaky = false` and groups to distinct `(project_id, git_branch, test_case_id)`, writing marker rows into the `ReplacingMergeTree`.
- The validation query drops the `status` / `is_flaky` filters and reads the marker table keyed on `(project_id, git_branch, test_case_id)` — a bounded point lookup per test case instead of a per-test-case run scan.
- One-time partition-chunked backfill (throttled, `max_memory_usage`-capped, `TABLE_IS_READ_ONLY`/`MEMORY_LIMIT_EXCEEDED` retry), matching the existing per-case aggregate migrations.

## Correctness

Semantics are identical: a marker exists **iff** a `(project, branch, test case)` had a successful, non-flaky run — exactly the predicate the old raw query used. The existing `tests_test.exs` test (`validated` / PR-only / failing-on-main / flaky-success-on-main) now exercises the MV path end-to-end and asserts only the truly-validated id is returned.

## Trade-off / note

This adds one more MV firing on `test_case_runs` inserts. It's lightweight (distinct-key marker, no array state) and insert-path CPU was already negligible in the investigation (~34 core-s vs 704 for the query it replaces), so this is a large net CPU win. A separate follow-up will trim the *unused* reliability success buckets (250/500/750) added in #11623 to cut merge write-amplification.

## Validation

- `mix format` + `Code.string_to_quoted!` on changed files.
- Existing `tests_test.exs` `test_case_ids_with_successful_default_branch_run/3` describe block covers all four cases; it runs against ClickHouse in CI with the new MV migrated in.

### How to test locally

1. `mix ecto.migrate` (ingest repo) to create the MV + backfill.
2. `mix test test/tuist/tests_test.exs -o "test_case_ids_with_successful_default_branch_run"` (or run the describe block) — inserts runs across branches/statuses and asserts only the default-branch success/non-flaky test case validates.
