### PR TITLE
fix(server): count each run once in rolling flaky/reliability alert evaluation

### DIFF
--- a/server/lib/tuist/automations/monitors/flaky_tests_monitor.ex
+++ b/server/lib/tuist/automations/monitors/flaky_tests_monitor.ex
@@ -312,12 +312,10 @@ defmodule Tuist.Automations.Monitors.FlakyTestsMonitor do
   # no SQL-injection vector. `project_id` and `threshold` flow through bound
   # parameters.
   defp rolling_triggered_test_case_ids(project_id, monitor_type, size, threshold, comparison, test_case_ids) do
-    {table, recent_runs_expr, run_key_expr} = recent_runs_source(recent_runs_column(monitor_type), size)
+    source = recent_runs_source(recent_runs_column(monitor_type), size)
 
     rolling_triggered_test_case_ids_from_recent_runs(
-      table,
-      recent_runs_expr,
-      run_key_expr,
+      source,
       project_id,
       monitor_type,
       size,
@@ -366,9 +364,7 @@ defmodule Tuist.Automations.Monitors.FlakyTestsMonitor do
   end
 
   defp rolling_triggered_test_case_ids_from_recent_runs(
-         table,
-         recent_runs_expr,
-         run_key_expr,
+         {table, recent_runs_expr, run_key_expr},
          project_id,
          monitor_type,
          size,

--- a/server/lib/tuist/automations/monitors/flaky_tests_monitor.ex
+++ b/server/lib/tuist/automations/monitors/flaky_tests_monitor.ex
@@ -297,22 +297,27 @@ defmodule Tuist.Automations.Monitors.FlakyTestsMonitor do
   # only the 1000-entry fallback keeps `groupArrayLast` order and has to
   # `arrayReverseSort` before slicing.
   #
-  # ReplacingMergeTree dedup on `test_case_runs` happens after the MV has
-  # already absorbed the row, so a re-inserted run (e.g. is_flaky updated
-  # later) appears twice in the bounded recent-runs array. That's bounded
-  # noise — ≤1% at the default window — well within the natural variance
-  # of a flakiness threshold.
+  # `test_case_runs` is a ReplacingMergeTree and flaky detection re-inserts a
+  # run to set `is_flaky` after ingestion, so the MV can absorb the same
+  # logical run several times. Those duplicates concentrate on flaky/failed
+  # runs — a passing run is never re-marked — so counting raw array entries
+  # inflates flakiness and deflates reliability for exactly the runs a
+  # threshold reacts to. `rolling_triggered_test_case_ids_from_recent_runs`
+  # collapses the array to one row per run (keyed on `ran_at`) before
+  # computing a rate.
   #
-  # `monitor_type`, `comparison`, `table`, `column`, and `recent_n_expr` are
-  # interpolated because they are chosen from fixed in-module allowlists, so
-  # there is no SQL-injection vector. Numeric inputs (`project_id`, `size`,
-  # `threshold`) flow through bound parameters.
+  # `monitor_type`, `comparison`, `table`, `recent_runs_expr`, and
+  # `run_key_expr` are interpolated because they are chosen from fixed
+  # in-module allowlists (or are validated integers via `size`), so there is
+  # no SQL-injection vector. `project_id` and `threshold` flow through bound
+  # parameters.
   defp rolling_triggered_test_case_ids(project_id, monitor_type, size, threshold, comparison, test_case_ids) do
-    {table, recent_n_expr} = recent_runs_source(recent_runs_column(monitor_type), size)
+    {table, recent_runs_expr, run_key_expr} = recent_runs_source(recent_runs_column(monitor_type), size)
 
     rolling_triggered_test_case_ids_from_recent_runs(
       table,
-      recent_n_expr,
+      recent_runs_expr,
+      run_key_expr,
       project_id,
       monitor_type,
       size,
@@ -329,37 +334,34 @@ defmodule Tuist.Automations.Monitors.FlakyTestsMonitor do
   defp recent_runs_column("reliability_rate"), do: "recent_successful_runs"
   defp recent_runs_column(_monitor_type), do: "recent_runs"
 
+  # Returns `{table, recent_runs_expr, run_key_expr}`. `recent_runs_expr`
+  # merges the full per-test-case aggregate; the dedup and latest-`size` slice
+  # happen downstream. `run_key_expr` maps a tuple's sort key back to a
+  # "larger = more recent" number so both encodings order the same way: the
+  # 1000-entry fallback stores `ran_at` directly, while the buckets store
+  # `-ran_at_microseconds`.
   defp recent_runs_source(column, size) do
     case Enum.find(@recent_runs_bucket_sizes, &(size <= &1)) do
       nil ->
         {
           "test_case_runs_recent_per_case",
-          """
-          arraySlice(
-            arrayReverseSort(x -> x.1, groupArrayLastMerge(#{@max_rolling_window_size})(#{column})),
-            1,
-            {size:UInt32}
-          )
-          """
+          "groupArrayLastMerge(#{@max_rolling_window_size})(#{column})",
+          "toUnixTimestamp64Micro(tupleElement(entry, 1))"
         }
 
       bucket_size ->
         {
           "test_case_runs_recent_#{bucket_size}_per_case",
-          """
-          arraySlice(
-            groupArraySortedMerge(#{bucket_size})(#{column}),
-            1,
-            {size:UInt32}
-          )
-          """
+          "groupArraySortedMerge(#{bucket_size})(#{column})",
+          "-tupleElement(entry, 1)"
         }
     end
   end
 
   defp rolling_triggered_test_case_ids_from_recent_runs(
          table,
-         recent_n_expr,
+         recent_runs_expr,
+         run_key_expr,
          project_id,
          monitor_type,
          size,
@@ -373,22 +375,38 @@ defmodule Tuist.Automations.Monitors.FlakyTestsMonitor do
         _test_case_ids -> "AND test_case_id IN {test_case_ids:Array(UUID)}"
       end
 
+    # Expand the recent-runs array and collapse it to one row per run (keyed on
+    # `run_key`, the run's `ran_at`), keeping `max(flag)` so a run that was ever
+    # re-marked flaky / ever succeeded is represented once with the right flag.
+    # Then keep the latest `size` distinct runs and compute the rate over those,
+    # so a re-inserted run can no longer be counted more than once.
     sql = """
     SELECT test_case_id
     FROM (
-      SELECT
-        test_case_id,
-        #{recent_n_expr} AS recent_n
-      FROM #{table}
-      WHERE project_id = {project_id:Int64}
-        #{test_case_filter}
-      GROUP BY test_case_id
+      SELECT test_case_id, run_key, max(flag) AS flag
+      FROM (
+        SELECT
+          test_case_id,
+          #{run_key_expr} AS run_key,
+          tupleElement(entry, 2) AS flag
+        FROM (
+          SELECT test_case_id, #{recent_runs_expr} AS recent_runs
+          FROM #{table}
+          WHERE project_id = {project_id:Int64}
+            #{test_case_filter}
+          GROUP BY test_case_id
+        )
+        ARRAY JOIN recent_runs AS entry
+      )
+      GROUP BY test_case_id, run_key
+      ORDER BY run_key DESC
+      LIMIT #{size} BY test_case_id
     )
-    WHERE length(recent_n) > 0
-      AND #{rolling_having_expr(monitor_type)} #{rolling_comparison_op(comparison)} {threshold:Float64}
+    GROUP BY test_case_id
+    HAVING #{rolling_having_expr(monitor_type)} #{rolling_comparison_op(comparison)} {threshold:Float64}
     """
 
-    params = maybe_put_test_case_ids(%{project_id: project_id, size: size, threshold: threshold * 1.0}, test_case_ids)
+    params = maybe_put_test_case_ids(%{project_id: project_id, threshold: threshold * 1.0}, test_case_ids)
 
     # Raise on ClickHouse errors instead of swallowing them. If the MV is
     # missing or the query fails transiently, returning `[]` would tell the
@@ -403,11 +421,11 @@ defmodule Tuist.Automations.Monitors.FlakyTestsMonitor do
     Enum.map(rows, fn [binary] -> Ecto.UUID.load!(binary) end)
   end
 
-  defp rolling_having_expr("flakiness_rate"), do: "arraySum(x -> toFloat64(x.2), recent_n) * 100.0 / length(recent_n)"
+  defp rolling_having_expr("flakiness_rate"), do: "sum(flag) * 100.0 / count()"
 
-  defp rolling_having_expr("flaky_run_count"), do: "arraySum(x -> toFloat64(x.2), recent_n)"
+  defp rolling_having_expr("flaky_run_count"), do: "sum(flag)"
 
-  defp rolling_having_expr("reliability_rate"), do: "arraySum(x -> toFloat64(x.2), recent_n) * 100.0 / length(recent_n)"
+  defp rolling_having_expr("reliability_rate"), do: "sum(flag) * 100.0 / count()"
 
   defp rolling_comparison_op("gte"), do: ">="
   defp rolling_comparison_op("gt"), do: ">"

--- a/server/lib/tuist/automations/monitors/flaky_tests_monitor.ex
+++ b/server/lib/tuist/automations/monitors/flaky_tests_monitor.ex
@@ -340,8 +340,15 @@ defmodule Tuist.Automations.Monitors.FlakyTestsMonitor do
   # "larger = more recent" number so both encodings order the same way: the
   # 1000-entry fallback stores `ran_at` directly, while the buckets store
   # `-ran_at_microseconds`.
+  #
+  # The bucket is chosen strictly larger than the window (`size < bucket`) so
+  # de-dup has headroom: a bucket only holds `bucket` physical rows, and
+  # re-inserted runs consume slots, so a window equal to the bucket could
+  # yield fewer than `size` distinct runs after de-dup. Reading the next tier
+  # up keeps enough physical rows to recover `size` distinct runs. Windows
+  # above the largest bucket fall through to the 1000-entry aggregate.
   defp recent_runs_source(column, size) do
-    case Enum.find(@recent_runs_bucket_sizes, &(size <= &1)) do
+    case Enum.find(@recent_runs_bucket_sizes, &(size < &1)) do
       nil ->
         {
           "test_case_runs_recent_per_case",

--- a/server/test/tuist/automations/monitors/flaky_tests_monitor_test.exs
+++ b/server/test/tuist/automations/monitors/flaky_tests_monitor_test.exs
@@ -952,6 +952,54 @@ defmodule Tuist.Automations.Monitors.FlakyTestsMonitorTest do
       # 7/10 = 70% and wrongly skips a healthy test.
       refute test_case_id in FlakyTestsMonitor.evaluate_by_reliability_rate(alert).triggered
     end
+
+    test "reads a bucket larger than the window so duplication cannot shrink it below the window" do
+      project = ProjectsFixtures.project_fixture()
+      test_case_id = UUIDv7.generate()
+      RunsFixtures.test_case_fixture(project_id: project.id, id: test_case_id, name: "boundary")
+
+      base = NaiveDateTime.utc_now()
+
+      stable_rows =
+        for i <- 1..100 do
+          ran_at = NaiveDateTime.add(base, -i, :second)
+          test_case_run_attrs(project.id, test_case_id, is_flaky: false, ran_at: ran_at, inserted_at: ran_at)
+        end
+
+      # One flaky run re-marked far more times than production ever would, so
+      # the effect is observable at the size-100 bucket boundary. A size-100
+      # source would be filled entirely by these copies and evict every stable
+      # run; reading the next bucket up keeps them, so de-dup still recovers the
+      # 100 distinct runs.
+      flaky_run_id = UUIDv7.generate()
+
+      flaky_rows =
+        for _ <- 1..101 do
+          %{
+            test_case_run_attrs(project.id, test_case_id, is_flaky: true, ran_at: base, inserted_at: base)
+            | id: flaky_run_id
+          }
+        end
+
+      insert_test_case_runs(stable_rows ++ flaky_rows)
+
+      alert =
+        AutomationsFixtures.automation_alert_fixture(
+          project: project,
+          monitor_type: "flakiness_rate",
+          trigger_config: %{
+            "threshold" => 50,
+            "window_type" => "rolling",
+            "rolling_window_size" => 100,
+            "comparison" => "gte"
+          }
+        )
+
+      # True flakiness is 1/101 ≈ 1%. Only if the window collapsed onto the
+      # duplicate copies of the single flaky run (a source no larger than the
+      # window) would it read as 100% and fire.
+      refute test_case_id in FlakyTestsMonitor.evaluate(alert).triggered
+    end
   end
 
   # One flaky run (most recent), re-inserted the way flaky detection does: the

--- a/server/test/tuist/automations/monitors/flaky_tests_monitor_test.exs
+++ b/server/test/tuist/automations/monitors/flaky_tests_monitor_test.exs
@@ -846,6 +846,147 @@ defmodule Tuist.Automations.Monitors.FlakyTestsMonitorTest do
     end
   end
 
+  describe "rolling window de-duplicates re-inserted runs" do
+    # `test_case_runs` is a ReplacingMergeTree and flaky detection re-inserts a
+    # run when it sets `is_flaky` after ingestion. The recent-runs MVs record
+    # every physical insert, so one logical run can appear several times in the
+    # rolling aggregate. Because the duplicates land only on flaky/failed runs
+    # (successes are never re-marked), they inflate flakiness and deflate
+    # reliability for the exact runs the thresholds care about. The monitor must
+    # count each run once.
+    test "flakiness_rate does not double-count a re-inserted flaky run" do
+      project = ProjectsFixtures.project_fixture()
+      test_case_id = UUIDv7.generate()
+      RunsFixtures.test_case_fixture(project_id: project.id, id: test_case_id, name: "occasionally_flaky")
+
+      insert_run_with_reinserted_flaky_tail(project.id, test_case_id)
+
+      alert =
+        AutomationsFixtures.automation_alert_fixture(
+          project: project,
+          monitor_type: "flakiness_rate",
+          trigger_config: %{
+            "threshold" => 25,
+            "window_type" => "rolling",
+            "rolling_window_size" => 5,
+            "comparison" => "gte"
+          }
+        )
+
+      # Last 5 distinct runs hold 1 flaky run → 20%, below the 25% threshold.
+      # Counting the re-inserted run three times reports 3/5 = 60% and wrongly
+      # mutes a healthy test.
+      refute test_case_id in FlakyTestsMonitor.evaluate(alert).triggered
+    end
+
+    test "flakiness_rate still counts a re-inserted flaky run once (keeps the flaky mark)" do
+      project = ProjectsFixtures.project_fixture()
+      test_case_id = UUIDv7.generate()
+      RunsFixtures.test_case_fixture(project_id: project.id, id: test_case_id, name: "occasionally_flaky")
+
+      insert_run_with_reinserted_flaky_tail(project.id, test_case_id)
+
+      alert =
+        AutomationsFixtures.automation_alert_fixture(
+          project: project,
+          monitor_type: "flakiness_rate",
+          trigger_config: %{
+            "threshold" => 15,
+            "window_type" => "rolling",
+            "rolling_window_size" => 5,
+            "comparison" => "gte"
+          }
+        )
+
+      # De-duplicating must not drop the flaky mark: the run is still flaky
+      # (the re-marks set is_flaky=true), so 1/5 = 20% clears the 15% threshold.
+      assert test_case_id in FlakyTestsMonitor.evaluate(alert).triggered
+    end
+
+    test "reliability_rate does not double-count a re-inserted failing run" do
+      project = ProjectsFixtures.project_fixture()
+      test_case_id = UUIDv7.generate()
+      RunsFixtures.test_case_fixture(project_id: project.id, id: test_case_id, name: "mostly_reliable")
+
+      base = NaiveDateTime.utc_now()
+
+      for i <- 1..9 do
+        ran_at = NaiveDateTime.add(base, -i, :minute)
+
+        RunsFixtures.test_case_run_fixture(
+          project_id: project.id,
+          test_case_id: test_case_id,
+          status: "success",
+          ran_at: ran_at,
+          inserted_at: ran_at
+        )
+      end
+
+      failing_run_id = UUIDv7.generate()
+
+      for _ <- 1..3 do
+        RunsFixtures.test_case_run_fixture(
+          id: failing_run_id,
+          project_id: project.id,
+          test_case_id: test_case_id,
+          status: "failure",
+          ran_at: base,
+          inserted_at: base
+        )
+      end
+
+      alert =
+        AutomationsFixtures.automation_alert_fixture(
+          project: project,
+          monitor_type: "reliability_rate",
+          trigger_config: %{
+            "threshold" => 85,
+            "window_type" => "rolling",
+            "rolling_window_size" => 10,
+            "comparison" => "lt"
+          }
+        )
+
+      # Last 10 distinct runs hold 1 failure → 90% reliable, above the 85%
+      # threshold. Counting the re-inserted failure three times reports
+      # 7/10 = 70% and wrongly skips a healthy test.
+      refute test_case_id in FlakyTestsMonitor.evaluate_by_reliability_rate(alert).triggered
+    end
+  end
+
+  # One flaky run (most recent), re-inserted the way flaky detection does: the
+  # original ingestion writes is_flaky=false, then later re-marks re-insert the
+  # SAME run (same id + ran_at) with is_flaky=true. Preceded by four older
+  # stable runs.
+  defp insert_run_with_reinserted_flaky_tail(project_id, test_case_id) do
+    base = NaiveDateTime.utc_now()
+
+    for i <- 1..4 do
+      ran_at = NaiveDateTime.add(base, -i, :minute)
+
+      RunsFixtures.test_case_run_fixture(
+        project_id: project_id,
+        test_case_id: test_case_id,
+        is_flaky: false,
+        ran_at: ran_at,
+        inserted_at: ran_at
+      )
+    end
+
+    flaky_run_id = UUIDv7.generate()
+
+    for is_flaky <- [false, true, true] do
+      RunsFixtures.test_case_run_fixture(
+        id: flaky_run_id,
+        project_id: project_id,
+        test_case_id: test_case_id,
+        is_flaky: is_flaky,
+        ran_at: base,
+        inserted_at: base
+      )
+    end
+  end
+
   defp insert_test_case_runs(rows) do
     IngestRepo.insert_all(TestCaseRun, rows)
   end


### PR DESCRIPTION
# fix(server): de-duplicate re-inserted runs in rolling flaky/reliability alert evaluation

## What changed

The rolling-window path of the flaky-test automations (`FlakyTestsMonitor`) now collapses the per-test-case recent-runs aggregate to **one entry per run** before computing a rate. Previously it summed raw array entries and divided by a fixed slot count, so a run that appears more than once in the aggregate was counted more than once.

Applies to all three rolling monitors: `flakiness_rate`, `flaky_run_count`, and `reliability_rate`, across both the bucketed MV fast path (`test_case_runs_recent_{100,250,500,750}_per_case`) and the 1000-entry fallback (`test_case_runs_recent_per_case`).

## Why

`test_case_runs` is a ReplacingMergeTree, and flaky detection **re-inserts** a run to set `is_flaky` after ingestion (the commit-based and hash-based detectors both do this). The recent-runs materialized views record every physical insert, so a single logical run lands in the rolling aggregate 2-4 times. Crucially the duplicates are **concentrated on flaky/failed runs** (a passing run is never re-marked), so they:

- **inflate** `flakiness_rate` / `flaky_run_count` (numerator over-counts flaky runs), and
- **deflate** `reliability_rate` (the fixed-size denominator stays while extra failure entries fill the window),

for exactly the runs a threshold reacts to. A pre-existing code comment acknowledged the duplication but assumed it was "bounded noise ≤1%"; that is wrong because the noise is not uniform, it is the signal.

### Observed impact

On a customer project (`reliability_rate < 97%` and `flakiness_rate ≥ 2%`, both rolling-75), a burst on 2026-07-02 auto-skipped **615 distinct test cases** and muted others that were genuinely healthy. Verified examples:

- A 100%-reliable test (8 failures in 15,195 runs, all old) was skipped: its 8 recent flaky failures appeared **24 times** in `recent_successful_runs`, dragging the windowed reliability below threshold.
- A 0.1%-flaky test was muted: at mute time its true last-75 window held **exactly 1** flaky run (1.33%), but the run was counted **3×** → 4%, over the 2% threshold.

## The fix

`rolling_triggered_test_case_ids_from_recent_runs` now:

1. `ARRAY JOIN`s the recent-runs array,
2. groups by `(test_case_id, run_key)` where `run_key` is the run's `ran_at` (`toUnixTimestamp64Micro(ran_at)` for the big table, `-tupleElement(entry,1)` for the negated-key buckets), keeping `max(flag)` so a run that was ever marked flaky / ever succeeded is represented once with the correct flag,
3. takes the latest `size` **distinct** runs via `ORDER BY run_key DESC LIMIT size BY test_case_id`,
4. computes the rate as `sum(flag) * 100.0 / count()` (or `sum(flag)` for `flaky_run_count`) over those distinct runs.

This is a read-time correction; it does not require re-backfilling the aggregates or changing the MV schema, and it keeps the same bounded per-test-case scan (no full `test_case_runs` walk).

### Validated against production data

The exact generated query for both code paths was run read-only against the production aggregates: the two wrongly-skipped tests now evaluate to 100% reliability over 75 **distinct** runs, and the wrongly-muted test to 0% flakiness, matching their dashboard rates.

## Tests

TDD: added three tests to `flaky_tests_monitor_test.exs` that re-insert a single run the way flaky detection does (same id + `ran_at`, inserted multiple times) and assert:

- `flakiness_rate` does not mute a healthy test (20% real vs 60% double-counted),
- de-duplication still keeps the flaky mark, so a genuinely flaky run is counted once (fires at a 15% threshold),
- `reliability_rate` does not skip a healthy test (90% real vs 70% double-counted).

## De-dup headroom (bucket selection)

De-dup collapses re-inserted runs *after* the bounded aggregate is merged, so a window equal to its source bucket (e.g. the default `rolling_window_size = 100`, which reads the size-100 bucket) could yield fewer than `size` distinct runs once duplicates consume slots. The duplicates are ongoing (the live MV re-fires on every `is_flaky` re-mark, ~1.4 copies per flaky run — verified on same-day production data), so this does not age out.

Fix: `recent_runs_source` now picks a bucket **strictly larger** than the window (`size < bucket`), guaranteeing headroom. This is a no-op for every rolling alert in use today (all `size = 75`, already reading the 100 bucket); only windows `≥ 100` read one tier up, and only windows `≥ 750` reach the 1000-entry aggregate. Added a boundary test that would collapse to 100% flaky under a size-equal bucket and reads correctly (~1%) with the larger one.

Run identity note: de-dup keys on `ran_at` (microsecond), not the run `id`, which the aggregates do not carry. Two distinct executions sharing a `ran_at` would merge; measured 0 such collisions across busy test cases (incl. a parallel-testing one). Carrying `id` would need re-backfilling the aggregates and is deferred unless collisions appear.

## Scope / follow-up

The `last_days` (calendar-window) path aggregates daily `run_count` / `successful_run_count` / `flaky_run_count`, which are also incremented by re-inserts. The effect there is milder (the denominator grows too) and out of scope for this fix; tracked as a follow-up. A separate cleanup could also de-duplicate at write time (dedupe the flaky re-mark before it reaches the MVs) so the stored aggregates stay clean.
