### PR TITLE
feat(cli): update Muted/Skipped Test Case Listing to Include All Pages

### DIFF
--- a/cli/Sources/TuistKit/Services/TestCaseListService.swift
+++ b/cli/Sources/TuistKit/Services/TestCaseListService.swift
@@ -32,21 +32,31 @@ struct TestCaseListService: TestCaseListServicing {
         serverURL: URL,
         state: Operations.listTestCases.Input.Query.statePayload
     ) async throws -> [TestIdentifier] {
-        let response = try await listTestCasesService.listTestCases(
-            fullHandle: fullHandle,
-            serverURL: serverURL,
-            flaky: nil,
-            quarantined: nil,
-            state: state,
-            page: 1,
-            pageSize: 500
-        )
-        return try response.test_cases.map { testCase in
-            try TestIdentifier(
-                target: testCase.module.name,
-                class: testCase.suite?.name,
-                method: testCase.name
+        var allIdentifiers: [TestIdentifier] = []
+        var page = 1
+        while true {
+            let response = try await listTestCasesService.listTestCases(
+                fullHandle: fullHandle,
+                serverURL: serverURL,
+                flaky: nil,
+                quarantined: nil,
+                state: state,
+                page: page,
+                pageSize: 500
             )
+            let identifiers = try response.test_cases.map { testCase in
+                try TestIdentifier(
+                    target: testCase.module.name,
+                    class: testCase.suite?.name,
+                    method: testCase.name
+                )
+            }
+            allIdentifiers.append(contentsOf: identifiers)
+            if !response.pagination_metadata.has_next_page {
+                break
+            }
+            page += 1
         }
+        return allIdentifiers
     }
 }

--- a/cli/Sources/TuistKit/Services/TestCaseListService.swift
+++ b/cli/Sources/TuistKit/Services/TestCaseListService.swift
@@ -11,7 +11,7 @@ protocol TestCaseListServicing {
     /// Throws on network, decoding, or `TestIdentifier` construction
     /// errors — call sites decide how to react (warn the user and fall
     /// back to running all tests, or surface the error directly).
-    func listTestCases(
+    func listAllTestCases(
         fullHandle: String,
         serverURL: URL,
         state: Operations.listTestCases.Input.Query.statePayload
@@ -27,7 +27,7 @@ struct TestCaseListService: TestCaseListServicing {
         self.listTestCasesService = listTestCasesService
     }
 
-    func listTestCases(
+    func listAllTestCases(
         fullHandle: String,
         serverURL: URL,
         state: Operations.listTestCases.Input.Query.statePayload

--- a/cli/Sources/TuistKit/Services/TestService.swift
+++ b/cli/Sources/TuistKit/Services/TestService.swift
@@ -611,10 +611,10 @@ public struct TestService { // swiftlint:disable:this type_body_length
             return ([], [])
         }
         let serverURL = try serverEnvironmentService.url(configServerURL: config.url)
-        async let mutedTask = testCaseListService.listTestCases(
+        async let mutedTask = testCaseListService.listAllTestCases(
             fullHandle: fullHandle, serverURL: serverURL, state: .muted
         )
-        async let skippedTask = testCaseListService.listTestCases(
+        async let skippedTask = testCaseListService.listAllTestCases(
             fullHandle: fullHandle, serverURL: serverURL, state: .skipped
         )
         let muted: [TestIdentifier]

--- a/cli/Sources/TuistKit/Services/XcodeBuild/XcodeBuildTestCommandService.swift
+++ b/cli/Sources/TuistKit/Services/XcodeBuild/XcodeBuildTestCommandService.swift
@@ -436,10 +436,10 @@ extension XcodeBuildTestCommandService {
             return ([], [])
         }
         let serverURL = try serverEnvironmentService.url(configServerURL: config.url)
-        async let mutedTask = testCaseListService.listTestCases(
+        async let mutedTask = testCaseListService.listAllTestCases(
             fullHandle: fullHandle, serverURL: serverURL, state: .muted
         )
-        async let skippedTask = testCaseListService.listTestCases(
+        async let skippedTask = testCaseListService.listAllTestCases(
             fullHandle: fullHandle, serverURL: serverURL, state: .skipped
         )
         do {

--- a/cli/Tests/TuistKitTests/Services/TestCaseListServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/TestCaseListServiceTests.swift
@@ -20,7 +20,7 @@ struct TestCaseListServiceTests {
     }
 
     @Test(.withMockedDependencies())
-    func listTestCases_propagatesFetchErrors() async throws {
+    func listAllTestCases_propagatesFetchErrors() async throws {
         let underlying = NSError(domain: "test", code: 500)
         given(listTestCasesService)
             .listTestCases(
@@ -30,14 +30,14 @@ struct TestCaseListServiceTests {
             .willThrow(underlying)
 
         await #expect(throws: NSError.self) {
-            _ = try await subject.listTestCases(
+            _ = try await subject.listAllTestCases(
                 fullHandle: fullHandle, serverURL: serverURL, state: .muted
             )
         }
     }
 
     @Test(.withMockedDependencies())
-    func listTestCases_passesStateFilterThrough_andMapsToIdentifiers() async throws {
+    func listAllTestCases_passesStateFilterThrough_andMapsToIdentifiers() async throws {
         let mutedResponse = Operations.listTestCases.Output.Ok.Body.jsonPayload(
             pagination_metadata: .init(
                 current_page: 1, has_next_page: false, has_previous_page: false,
@@ -67,7 +67,7 @@ struct TestCaseListServiceTests {
             )
             .willReturn(mutedResponse)
 
-        let result = try await subject.listTestCases(
+        let result = try await subject.listAllTestCases(
             fullHandle: fullHandle, serverURL: serverURL, state: .muted
         )
 
@@ -78,7 +78,7 @@ struct TestCaseListServiceTests {
     }
 
     @Test(.withMockedDependencies())
-    func listTestCases_paginatesThroughAllPages() async throws {
+    func listAllTestCases_paginatesThroughAllPages() async throws {
         let page1Response = Operations.listTestCases.Output.Ok.Body.jsonPayload(
             pagination_metadata: .init(
                 current_page: 1, has_next_page: true, has_previous_page: false,
@@ -141,7 +141,7 @@ struct TestCaseListServiceTests {
             )
             .willReturn(page2Response)
 
-        let result = try await subject.listTestCases(
+        let result = try await subject.listAllTestCases(
             fullHandle: fullHandle, serverURL: serverURL, state: .skipped
         )
 

--- a/cli/Tests/TuistKitTests/Services/TestCaseListServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/TestCaseListServiceTests.swift
@@ -76,4 +76,79 @@ struct TestCaseListServiceTests {
             try TestIdentifier(target: "CoreTests", class: nil, method: "testBar()"),
         ])
     }
+
+    @Test(.withMockedDependencies())
+    func listTestCases_paginatesThroughAllPages() async throws {
+        let page1Response = Operations.listTestCases.Output.Ok.Body.jsonPayload(
+            pagination_metadata: .init(
+                current_page: 1, has_next_page: true, has_previous_page: false,
+                page_size: 500, total_count: 3, total_pages: 2
+            ),
+            test_cases: [
+                .test(
+                    id: "1",
+                    module: .test(name: "AppTests"),
+                    name: "testFirst()",
+                    state: "skipped",
+                    suite: .test(name: "FirstSuite")
+                ),
+                .test(
+                    id: "2",
+                    module: .test(name: "AppTests"),
+                    name: "testSecond()",
+                    state: "skipped",
+                    suite: .test(name: "SecondSuite")
+                ),
+            ]
+        )
+        let page2Response = Operations.listTestCases.Output.Ok.Body.jsonPayload(
+            pagination_metadata: .init(
+                current_page: 2, has_next_page: false, has_previous_page: true,
+                page_size: 500, total_count: 3, total_pages: 2
+            ),
+            test_cases: [
+                .test(
+                    id: "3",
+                    module: .test(name: "CoreTests"),
+                    name: "testThird()",
+                    state: "skipped",
+                    suite: .test(name: "ThirdSuite")
+                ),
+            ]
+        )
+
+        given(listTestCasesService)
+            .listTestCases(
+                fullHandle: .value(fullHandle),
+                serverURL: .value(serverURL),
+                flaky: .value(nil),
+                quarantined: .value(nil),
+                state: .value(.skipped),
+                page: .value(1),
+                pageSize: .value(500)
+            )
+            .willReturn(page1Response)
+
+        given(listTestCasesService)
+            .listTestCases(
+                fullHandle: .value(fullHandle),
+                serverURL: .value(serverURL),
+                flaky: .value(nil),
+                quarantined: .value(nil),
+                state: .value(.skipped),
+                page: .value(2),
+                pageSize: .value(500)
+            )
+            .willReturn(page2Response)
+
+        let result = try await subject.listTestCases(
+            fullHandle: fullHandle, serverURL: serverURL, state: .skipped
+        )
+
+        #expect(result == [
+            try TestIdentifier(target: "AppTests", class: "FirstSuite", method: "testFirst()"),
+            try TestIdentifier(target: "AppTests", class: "SecondSuite", method: "testSecond()"),
+            try TestIdentifier(target: "CoreTests", class: "ThirdSuite", method: "testThird()"),
+        ])
+    }
 }

--- a/cli/Tests/TuistKitTests/Services/TestServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/TestServiceTests.swift
@@ -146,7 +146,7 @@ final class TestServiceTests: TuistUnitTestCase {
             .willReturn(URL(string: "https://tuist.dev")!)
 
         given(testCaseListService)
-            .listTestCases(fullHandle: .any, serverURL: .any, state: .any)
+            .listAllTestCases(fullHandle: .any, serverURL: .any, state: .any)
             .willReturn([])
         given(testQuarantineService)
             .markQuarantinedTests(testSummary: .any, quarantinedTests: .any)
@@ -3992,13 +3992,13 @@ final class TestServiceTests: TuistUnitTestCase {
 
         testCaseListService.reset()
         given(testCaseListService)
-            .listTestCases(fullHandle: .any, serverURL: .any, state: .value(.muted))
+            .listAllTestCases(fullHandle: .any, serverURL: .any, state: .value(.muted))
             .willReturn([
                 try TestIdentifier(target: "AppTests", class: "QuarantinedSuite", method: "testQuarantined()"),
                 try TestIdentifier(target: "CoreTests", class: nil, method: "testAnotherQuarantined()"),
             ])
         given(testCaseListService)
-            .listTestCases(fullHandle: .any, serverURL: .any, state: .value(.skipped))
+            .listAllTestCases(fullHandle: .any, serverURL: .any, state: .value(.skipped))
             .willReturn([])
         testQuarantineService.reset()
         given(testQuarantineService)
@@ -4095,12 +4095,12 @@ final class TestServiceTests: TuistUnitTestCase {
 
         testCaseListService.reset()
         given(testCaseListService)
-            .listTestCases(fullHandle: .any, serverURL: .any, state: .value(.muted))
+            .listAllTestCases(fullHandle: .any, serverURL: .any, state: .value(.muted))
             .willReturn([
                 try TestIdentifier(target: "AppTests", class: "FlakySuite", method: "testFlaky()"),
             ])
         given(testCaseListService)
-            .listTestCases(fullHandle: .any, serverURL: .any, state: .value(.skipped))
+            .listAllTestCases(fullHandle: .any, serverURL: .any, state: .value(.skipped))
             .willReturn([skippedIdentifier])
         testQuarantineService.reset()
         given(testQuarantineService)
@@ -4238,7 +4238,7 @@ final class TestServiceTests: TuistUnitTestCase {
 
         // Then — `--skip-quarantine` short-circuits the fetch entirely.
         verify(testCaseListService)
-            .listTestCases(fullHandle: .any, serverURL: .any, state: .any)
+            .listAllTestCases(fullHandle: .any, serverURL: .any, state: .any)
             .called(0)
         verify(xcodebuildController)
             .test(
@@ -4319,7 +4319,7 @@ final class TestServiceTests: TuistUnitTestCase {
 
         // Then — fullHandle is nil so the fetch is skipped entirely.
         verify(testCaseListService)
-            .listTestCases(fullHandle: .any, serverURL: .any, state: .any)
+            .listAllTestCases(fullHandle: .any, serverURL: .any, state: .any)
             .called(0)
         verify(xcodebuildController)
             .test(
@@ -4354,7 +4354,7 @@ final class TestServiceTests: TuistUnitTestCase {
 
         testCaseListService.reset()
         given(testCaseListService)
-            .listTestCases(fullHandle: .any, serverURL: .any, state: .any)
+            .listAllTestCases(fullHandle: .any, serverURL: .any, state: .any)
             .willReturn([])
         testQuarantineService.reset()
         given(testQuarantineService)
@@ -5111,10 +5111,10 @@ final class TestServiceTests: TuistUnitTestCase {
         )
         testCaseListService.reset()
         given(testCaseListService)
-            .listTestCases(fullHandle: .any, serverURL: .any, state: .value(.muted))
+            .listAllTestCases(fullHandle: .any, serverURL: .any, state: .value(.muted))
             .willReturn([])
         given(testCaseListService)
-            .listTestCases(fullHandle: .any, serverURL: .any, state: .value(.skipped))
+            .listAllTestCases(fullHandle: .any, serverURL: .any, state: .value(.skipped))
             .willReturn([skippedIdentifier])
 
         given(xcodebuildController)
@@ -5133,7 +5133,7 @@ final class TestServiceTests: TuistUnitTestCase {
         // Then — quarantine list was fetched and the skipped test landed in xcodebuild's
         // -skip-testing flags.
         verify(testCaseListService)
-            .listTestCases(fullHandle: .any, serverURL: .any, state: .value(.skipped))
+            .listAllTestCases(fullHandle: .any, serverURL: .any, state: .value(.skipped))
             .called(1)
         verify(xcodebuildController)
             .run(arguments: .matching { args in
@@ -5175,7 +5175,7 @@ final class TestServiceTests: TuistUnitTestCase {
 
         // Then
         verify(testCaseListService)
-            .listTestCases(fullHandle: .any, serverURL: .any, state: .any)
+            .listAllTestCases(fullHandle: .any, serverURL: .any, state: .any)
             .called(0)
     }
 
@@ -5197,10 +5197,10 @@ final class TestServiceTests: TuistUnitTestCase {
         )
         testCaseListService.reset()
         given(testCaseListService)
-            .listTestCases(fullHandle: .any, serverURL: .any, state: .value(.muted))
+            .listAllTestCases(fullHandle: .any, serverURL: .any, state: .value(.muted))
             .willReturn([])
         given(testCaseListService)
-            .listTestCases(fullHandle: .any, serverURL: .any, state: .value(.skipped))
+            .listAllTestCases(fullHandle: .any, serverURL: .any, state: .value(.skipped))
             .willReturn([skippedIdentifier])
 
         given(shardService)
@@ -5239,7 +5239,7 @@ final class TestServiceTests: TuistUnitTestCase {
 
         // Then
         verify(testCaseListService)
-            .listTestCases(fullHandle: .any, serverURL: .any, state: .value(.skipped))
+            .listAllTestCases(fullHandle: .any, serverURL: .any, state: .value(.skipped))
             .called(1)
         verify(xcodebuildController)
             .run(arguments: .matching { args in

--- a/cli/Tests/TuistKitTests/Services/XcodeBuildTestCommandServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/XcodeBuildTestCommandServiceTests.swift
@@ -45,7 +45,7 @@ struct XcodeBuildTestCommandServiceTests {
 
     init() {
         given(testCaseListService)
-            .listTestCases(fullHandle: .any, serverURL: .any, state: .any)
+            .listAllTestCases(fullHandle: .any, serverURL: .any, state: .any)
             .willReturn([])
         given(testQuarantineService)
             .markQuarantinedTests(testSummary: .any, quarantinedTests: .any)


### PR DESCRIPTION
Resolves issue of not being able to fetch all quarantined tests when the number of either muted or skipped tests exceeds 500 (1 page at pagesize 500). Allows running of `tuist test` without needing to pass `--skip-quarantine` for cases where there are many quarantined tests.

### How to test locally
`swift test --filter TestCaseListServiceTests --disable-sandbox`
