### PR TITLE
fix(server): stop reporting expected webhook delivery failures to Sentry

### DIFF
--- a/server/lib/tuist/sentry_event_filter.ex
+++ b/server/lib/tuist/sentry_event_filter.ex
@@ -11,6 +11,18 @@ defmodule Tuist.SentryEventFilter do
     TuistWeb.Errors.UnauthorizedError
   ]
 
+  # Webhook deliveries fail whenever a customer's receiver misbehaves —
+  # non-2xx responses, closed connections, timeouts. Each attempt is
+  # already recorded in ClickHouse and surfaced on the dashboard, and
+  # Oban retries on the RFC schedule, so the Oban.PerformError wrapping
+  # the worker's error return carries no signal for us. Bugs inside the
+  # worker raise their own exception types and are still reported.
+  @webhook_delivery_worker inspect(Tuist.Webhooks.Workers.DeliveryWorker)
+
+  def before_send(%Sentry.Event{original_exception: %Oban.PerformError{}, tags: %{oban_worker: @webhook_delivery_worker}}) do
+    false
+  end
+
   def before_send(event) do
     TuistCommon.SentryEventFilter.before_send(event, @additional_ignored_exceptions)
   end

--- a/server/test/tuist/sentry_event_filter_test.exs
+++ b/server/test/tuist/sentry_event_filter_test.exs
@@ -1,0 +1,72 @@
+defmodule Tuist.SentryEventFilterTest do
+  use ExUnit.Case, async: true
+
+  alias Tuist.SentryEventFilter
+
+  defp event(overrides) do
+    defaults = %{
+      event_id: String.duplicate("a", 32),
+      timestamp: "2020-01-01T00:00:00Z"
+    }
+
+    struct!(Sentry.Event, Map.merge(defaults, overrides))
+  end
+
+  describe "before_send/1" do
+    test "drops Oban.PerformError events from the webhook delivery worker" do
+      event =
+        event(%{
+          original_exception: %Oban.PerformError{
+            message: "Tuist.Webhooks.Workers.DeliveryWorker failed with {:error, \"HTTP 400\"}",
+            reason: {:error, "HTTP 400"}
+          },
+          tags: %{
+            oban_worker: "Tuist.Webhooks.Workers.DeliveryWorker",
+            oban_queue: "webhooks",
+            oban_state: "failure"
+          }
+        })
+
+      assert SentryEventFilter.before_send(event) == false
+    end
+
+    test "keeps Oban.PerformError events from other workers" do
+      event =
+        event(%{
+          original_exception: %Oban.PerformError{
+            message: "SomeWorker failed with {:error, :boom}",
+            reason: {:error, :boom}
+          },
+          tags: %{oban_worker: "SomeWorker", oban_queue: "default", oban_state: "failure"}
+        })
+
+      assert SentryEventFilter.before_send(event) == event
+    end
+
+    test "keeps raised exceptions from the webhook delivery worker" do
+      event =
+        event(%{
+          original_exception: %RuntimeError{message: "boom"},
+          tags: %{
+            oban_worker: "Tuist.Webhooks.Workers.DeliveryWorker",
+            oban_queue: "webhooks",
+            oban_state: "failure"
+          }
+        })
+
+      assert SentryEventFilter.before_send(event) == event
+    end
+
+    test "drops ignored web errors" do
+      event = event(%{original_exception: %TuistWeb.Errors.NotFoundError{message: "not found"}})
+
+      assert SentryEventFilter.before_send(event) == false
+    end
+
+    test "keeps other exceptions" do
+      event = event(%{original_exception: %RuntimeError{message: "boom"}})
+
+      assert SentryEventFilter.before_send(event) == event
+    end
+  end
+end


### PR DESCRIPTION
## What changed

`Tuist.SentryEventFilter.before_send/1` now drops Sentry events whose original exception is an `Oban.PerformError` tagged with `Tuist.Webhooks.Workers.DeliveryWorker`, plus a new test suite for the server-side filter.

## Why

Two Sentry issues have been accumulating from webhook deliveries to a single customer endpoint:

- [TUIST-14Q](https://tuist.sentry.io/issues/131541607/): `DeliveryWorker failed with {:error, %Req.TransportError{reason: :closed}}` (323 events, escalating)
- [TUIST-10D](https://tuist.sentry.io/issues/130148738/): `DeliveryWorker failed with {:error, "HTTP 400"}` (~186k events in a week)

## Root cause

These are not bugs in our delivery path. The customer's receiving server either returns HTTP 400 or closes the connection. The worker already handles this correctly: every attempt is recorded in the ClickHouse `webhook_delivery_attempts` table (which powers the endpoint dashboard), and Oban retries on the RFC schedule (1m/5m/30m/2h/8h/24h, 7 attempts). The only defect is that `TuistCommon.ObanTelemetry` reports every failed attempt to Sentry as an `Oban.PerformError`, so one misbehaving customer endpoint produces hundreds of thousands of non-actionable error events.

## Why this solution

- Oban requires an `{:error, reason}` return to drive the retry schedule, so the failure can't be silenced at the worker without losing retries. Filtering has to happen at the Sentry reporting layer, and `Tuist.SentryEventFilter` is the existing home for "expected, non-actionable errors".
- The filter is scoped narrowly: `Oban.PerformError` only wraps error-tuple returns from `perform/1`, which for this worker are exactly the expected delivery outcomes (non-2xx, transport errors, SSRF-blocked URLs, deleted endpoints). A genuine bug inside the worker (e.g. a JSON encoding crash) raises its own exception type, bypasses `Oban.PerformError` entirely, and is still reported.
- Adding `Oban.PerformError` to the global ignore list was rejected as too broad: it would hide real failures from every other worker. The clause matches on the `oban_worker` tag that `TuistCommon.ObanTelemetry` stamps on each event, so other workers' failures keep flowing to Sentry.

## Impact

Sentry stops receiving an event per failed delivery attempt to customer-controlled endpoints. Delivery-failure visibility remains where it belongs: the per-endpoint dashboard (ClickHouse attempt rows) and the Oban PromEx metrics.

## Validation

- `mix test test/tuist/sentry_event_filter_test.exs` (5 tests: drops delivery-worker PerformErrors, keeps other workers' PerformErrors, keeps raised exceptions from the delivery worker, existing ignore behavior unchanged)
- `mix test test/tuist/webhooks/workers/delivery_worker_test.exs` (11 tests, unchanged, all pass)
- `mix credo lib/tuist/sentry_event_filter.ex` clean

Fixes TUIST-14Q
Fixes TUIST-10D

🤖 Generated with [Claude Code](https://claude.com/claude-code)