### PR TITLE
fix(infra): re-apply node CSI drivers on existing clusters to stop bare-metal crash-loops

### DIFF
--- a/.github/workflows/csi-deployment.yml
+++ b/.github/workflows/csi-deployment.yml
@@ -1,0 +1,113 @@
+name: CSI Node Driver Deployment
+
+# Reconcile the node CSI drivers on every managed workload cluster to
+# match the bare-metal kura topology, on push to main.
+#
+# Like HCCM (see hccm-deployment.yml), the CSI drivers live in
+# kube-system and were previously only installed during fresh-cluster
+# onboarding via `mise run k8s:bootstrap-workload`. That meant edits to
+# infra/k8s/mgmt/bootstrap/hcloud-csi-values.yaml had no effect on
+# existing clusters until someone re-ran bootstrap by hand.
+#
+# That drift caused a real incident: #11346 moved the kura cache pools
+# (kura-scw-fr-par, kura-ca-east, kura-dedibox) off Scaleway Instances
+# onto in-house bare-metal CAPI nodes and added those pools to the
+# hcloud-csi-node affinity denylist — but the running clusters kept the
+# old affinity (which only skipped `runners-linux`). hcloud-csi-node's
+# broad `operator: Exists` tolerations then landed it on the OVH /
+# Elastic Metal fleet nodes, where Hetzner Cloud Volumes can't attach
+# and the driver CrashLoopBackOff'd for days across canary + production.
+#
+# This workflow closes that gap for the node CSI drivers:
+#   1. Re-applies hcloud-csi with the pool-exclusion affinity, so its
+#      DaemonSet drops off the bare-metal fleet nodes.
+#   2. Uninstalls scaleway-csi. Every managed env's kura fleet now runs
+#      on Elastic Metal (values-managed-*.yaml: kuraFleet.machine.
+#      offerType EM-*), which can't attach scw-bssd; the server
+#      provisions cache PVCs from local NVMe (`scw-local-nvme`,
+#      server/lib/tuist/kura/regions.ex) instead. The scaleway block
+#      CSI has nothing to attach there and only crash-loops, so it is
+#      dead weight on managed clusters. Idempotent: a no-op once removed.
+#      (scaleway-csi-values.yaml is kept as reference for any cluster
+#      whose kura fleet still uses `machine.kind: instance`; none of the
+#      managed envs do, which is why editing it is not a trigger here.)
+#
+# Idempotent. The matrix runs all environments in parallel: the node CSI
+# drivers are workload-level components, blast radius is per-cluster, and
+# the change is a thin chart upgrade + uninstall — no need for a
+# canary→production cascade like the application server has.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - infra/k8s/mgmt/bootstrap/hcloud-csi-values.yaml
+      - .github/workflows/csi-deployment.yml
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  apply:
+    name: CSI (${{ matrix.environment }})
+    strategy:
+      fail-fast: false
+      matrix:
+        environment:
+          - canary
+          - staging
+          - production
+    runs-on: tuist-linux
+    environment:
+      name: server-k8s-${{ matrix.environment }}
+    # Hold the same lane as server-deployment.yml's deploy + observability
+    # jobs (and hccm-deployment.yml) so CSI upgrades and server rollouts
+    # can't race for the kube apiserver on the same cluster.
+    concurrency:
+      group: server-deploy-${{ matrix.environment }}
+      cancel-in-progress: false
+    timeout-minutes: 10
+    env:
+      KUBECONFIG: ${{ github.workspace }}/.kube/config
+    steps:
+      - uses: actions/checkout@v4
+      - uses: jdx/mise-action@v3.2.0
+        with:
+          install_args: "--locked helm kubectl"
+          cache: "false"
+      - uses: 1password/install-cli-action@v2
+      - name: Load kubeconfig from 1Password
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+        run: |
+          mkdir -p "$(dirname "$KUBECONFIG")"
+          op document get "kubeconfig: tuist-${{ matrix.environment }}" \
+            --vault "tuist-k8s-${{ matrix.environment }}" --output "$KUBECONFIG"
+          chmod 600 "$KUBECONFIG"
+      - name: Verify cluster reachability
+        # Same pre-flight as server-deployment.yml — fail fast if the
+        # 1P-stored kubeconfig points at a phantom apiserver instead
+        # of letting helm hang for the full --timeout.
+        run: |
+          set -euo pipefail
+          API="$(kubectl config view --minify --raw -o jsonpath='{.clusters[0].cluster.server}')"
+          echo "Reaching apiserver at $API"
+          kubectl --request-timeout=10s get --raw /version >/dev/null
+      - name: helm upgrade --install hcloud-csi
+        # --wait rolls the DaemonSet: pods on nodes the updated affinity
+        # no longer matches (the bare-metal kura fleet) are removed rather
+        # than made ready, so the rollout doesn't block on them.
+        run: |
+          helm repo add hcloud https://charts.hetzner.cloud >/dev/null
+          helm repo update hcloud >/dev/null
+          helm upgrade --install hcloud-csi hcloud/hcloud-csi \
+            --namespace kube-system \
+            -f infra/k8s/mgmt/bootstrap/hcloud-csi-values.yaml \
+            --wait --timeout 5m
+      - name: helm uninstall scaleway-csi (obsolete on Elastic Metal)
+        # Managed kura fleets moved to Elastic Metal, which can't attach
+        # scw-bssd; the server provisions scw-local-nvme instead. Remove
+        # the crash-looping scaleway-csi if present. Idempotent.
+        run: |
+          helm uninstall scaleway-csi --namespace kube-system --ignore-not-found --wait --timeout 3m

--- a/infra/AGENTS.md
+++ b/infra/AGENTS.md
@@ -120,6 +120,7 @@ The previous "Tailscale ACL audit log" trail no longer applies — the ACL is no
   - `.github/workflows/server-production-deployment.yml` — the monorepo release pipeline (push-on-main): releases the server + fleet/runtime images and, at its tail, runs the production deploy cascade (build → canary → acceptance tests → production, with hotfix fast-path). One serialized lane, no cross-workflow dispatch. Manual re-promotes/rollbacks of a pinned SHA go through `server-deployment.yml`'s own `workflow_dispatch`.
 - **Noora Storybook** (managed) is deployed via `.github/workflows/noora-storybook-deployment.yml` using the standalone `infra/helm/noora-storybook` chart.
 - **Slack invitation app** (managed) is deployed via `.github/workflows/slack-deployment.yml` using the standalone `infra/helm/slack` chart.
+- **kube-system add-ons** (HCCM, node CSI drivers) live in the per-workload bootstrap (`mgmt/bootstrap/`), but bootstrap only runs at cluster onboarding. Edits to their values reach existing clusters via dedicated re-apply workflows so they don't silently drift: `.github/workflows/hccm-deployment.yml` (HCCM) and `.github/workflows/csi-deployment.yml` (re-applies `hcloud-csi` with its pool-exclusion affinity and uninstalls the now-obsolete `scaleway-csi` on the Elastic Metal kura fleets). Both fan out over all envs in parallel and share the `server-deploy-<env>` concurrency lane.
 - **Registry Router** — `wrangler deploy` from `registry-router/`.
 - **Helm charts** under `helm/` target Kubernetes (managed + self-hosted).
 


### PR DESCRIPTION
### What changed

Adds `.github/workflows/csi-deployment.yml`, a re-apply workflow for the kube-system node CSI drivers that fans out over all managed envs (canary, staging, production) on push to `main` or `workflow_dispatch`. It:

1. `helm upgrade --install hcloud-csi` with the pool-exclusion affinity from `infra/k8s/mgmt/bootstrap/hcloud-csi-values.yaml`, so its DaemonSet drops off the bare-metal kura fleet nodes.
2. `helm uninstall scaleway-csi --ignore-not-found` — obsolete on the Elastic Metal fleets, idempotent.

Plus a one-line note in `infra/AGENTS.md` documenting the workflow alongside HCCM.

### Why

The **"Pod CrashLoop / Frequent Restarts"** alert has been firing across canary and production. Root cause: PR #11346 moved the kura cache pools (`kura-scw-fr-par`, `kura-ca-east`, `kura-dedibox`) off Scaleway Instances onto in-house **bare-metal** CAPI nodes (OVH + Scaleway Elastic Metal) across every managed env. Two node CSI drivers then landed on hardware they can't serve and have been CrashLoopBackOff-ing for days (6,000+ restarts on production):

- **`hcloud-csi-node`** — its broad `operator: Exists` tolerations let it schedule onto the new bare-metal fleet nodes, where Hetzner Cloud Volumes can't attach. `hcloud-csi-values.yaml` already excludes those pools (added in #11346), but it is a **bootstrap-only** values file, so existing clusters never re-applied it. The live DaemonSet still only excludes `runners-linux`.
- **`scaleway-csi-node`** — `kura-scw-fr-par` is now Elastic Metal (can't attach `scw-bssd`); the server provisions `scw-local-nvme` (local-path on NVMe) instead (`server/lib/tuist/kura/regions.ex`). The driver is dead weight on managed envs and only crash-loops.

### Why this approach

This is the exact drift class `hccm-deployment.yml` was created for — *"edits to bootstrap values had no effect on existing clusters until someone re-ran bootstrap by hand."* Rather than a one-off manual `helm` run (which drifts again on the next cluster rebuild), this mirrors the established HCCM pattern so the node CSI drivers stay reconciled to the bare-metal kura topology. The `scaleway-csi` uninstall is baked in because every managed env's kura fleet is now Elastic Metal and the server no longer provisions `scw-bssd` — its `scaleway-csi-values.yaml` is kept only as reference for `machine.kind: instance` clusters (none of the managed envs), which is why editing it is intentionally not a trigger.

Both operations are low-risk and idempotent and share the `server-deploy-<env>` concurrency lane so they can't race a server rollout — same per-cluster blast-radius reasoning as HCCM, no canary→production cascade needed.

### Impact

Merging this triggers the workflow (the push touches its own `paths` entry), which remediates all three clusters: the `hcloud-csi-node` DaemonSet drops off the bare-metal fleet nodes and `scaleway-csi` is removed, clearing the crash-loop alert. No effect on healthy Hetzner-node CSI pods.

### Validation

- Diagnosed live via read-only `kubectl` on canary + production: confirmed the crash-looping pods (`hcloud-csi-node`, `scaleway-csi-node`) are all on `kura-*`/OVH fleet nodes with the bare-metal instance-type labels, while healthy pods are all on Hetzner cloud nodes.
- Confirmed the live DaemonSet affinity lags the repo values (only excludes `runners-linux`).
- Verified the server's kura region spec uses `scw-local-nvme`, not `scw-bssd`, so uninstalling `scaleway-csi` is safe.
- `actionlint` passes (only the repo-wide `tuist-linux` custom self-hosted-runner-label warning, identical to `hccm-deployment.yml`).

### How to test locally

Not locally testable — this is a CI workflow that operates on live clusters. To exercise it, `workflow_dispatch` it against a single env, or observe the run triggered on merge; verify with `kubectl -n kube-system get pods | grep csi` that the `*-csi-node` pods on bare-metal fleet nodes are gone and no CSI pods remain in `CrashLoopBackOff`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)