### PR TITLE
feat(server): cursor-only generations API + faster flaky-marking scan

### DIFF
--- a/server/lib/tuist/tests.ex
+++ b/server/lib/tuist/tests.ex
@@ -1453,7 +1453,7 @@ defmodule Tuist.Tests do
     {test_case_data, historical_flaky_runs} =
       check_cross_run_flakiness(test, test_case_data)
 
-    mark_test_case_runs_as_flaky(test.project_id, historical_flaky_runs)
+    mark_test_case_runs_as_flaky(test.project_id, test.git_commit_sha, historical_flaky_runs)
 
     test_case_data = check_new_test_cases(test, test_case_data)
 
@@ -2581,16 +2581,20 @@ defmodule Tuist.Tests do
     }
   end
 
-  defp mark_test_case_runs_as_flaky(_project_id, []), do: :ok
+  defp mark_test_case_runs_as_flaky(_project_id, _git_commit_sha, []), do: :ok
 
-  defp mark_test_case_runs_as_flaky(project_id, runs) when is_list(runs) do
+  defp mark_test_case_runs_as_flaky(project_id, git_commit_sha, runs) when is_list(runs) do
     ids = runs |> Enum.map(& &1.id) |> Enum.uniq()
     test_case_ids = runs |> Enum.map(& &1.test_case_id) |> Enum.uniq()
 
     # `test_case_runs` is `ORDER BY (project_id, test_case_id, ran_at, id)` —
     # filtering by `project_id` and `test_case_id` (both already known per
-    # `historical_flaky_runs`) lets the primary key prune granules instead
-    # of falling back to the bloom filter on `id` alone, which scales poorly.
+    # `historical_flaky_runs`) lets the primary key prune granules. That still
+    # scans the whole `ran_at` span for a high-volume test case, so we also
+    # constrain `git_commit_sha`: every historical flaky run comes from
+    # `get_existing_ci_runs_for_commit/4` for this exact commit, and the table
+    # carries a `GRANULARITY 1` bloom filter on `git_commit_sha` that prunes
+    # the range down to the handful of granules holding that commit's runs.
     # The table is also a ReplacingMergeTree, so a re-inserted run can return
     # multiple versions per id until the background merge collapses them; we
     # dedupe in Elixir so the result set stays small. `FINAL` would force a
@@ -2599,6 +2603,7 @@ defmodule Tuist.Tests do
       from(tcr in TestCaseRun,
         where: tcr.project_id == ^project_id,
         where: tcr.test_case_id in ^test_case_ids,
+        where: tcr.git_commit_sha == ^git_commit_sha,
         where: tcr.id in ^ids,
         order_by: [desc: tcr.inserted_at]
       )

--- a/server/lib/tuist_web/api/schemas/pagination_metadata.ex
+++ b/server/lib/tuist_web/api/schemas/pagination_metadata.ex
@@ -28,7 +28,8 @@ defmodule TuistWeb.API.Schemas.PaginationMetadata do
       },
       total_count: %Schema{
         type: :integer,
-        description: "Total number of items."
+        nullable: true,
+        description: "Total number of items. Always `nil` when using cursor-based pagination."
       },
       total_pages: %Schema{
         type: :integer,
@@ -47,6 +48,6 @@ defmodule TuistWeb.API.Schemas.PaginationMetadata do
           "Opaque cursor pointing at the last item of the current page. Pass it as the `after` query parameter to fetch the next page. Always `nil` when using page-based pagination."
       }
     },
-    required: [:has_next_page, :has_previous_page, :page_size, :total_count]
+    required: [:has_next_page, :has_previous_page, :page_size]
   })
 end

--- a/server/lib/tuist_web/api/schemas/pagination_metadata.ex
+++ b/server/lib/tuist_web/api/schemas/pagination_metadata.ex
@@ -33,6 +33,18 @@ defmodule TuistWeb.API.Schemas.PaginationMetadata do
       total_pages: %Schema{
         type: :integer,
         description: "Total number of pages. Always `nil` when using cursor-based pagination."
+      },
+      start_cursor: %Schema{
+        type: :string,
+        nullable: true,
+        description:
+          "Opaque cursor pointing at the first item of the current page. Pass it as the `before` query parameter to fetch the previous page. Always `nil` when using page-based pagination."
+      },
+      end_cursor: %Schema{
+        type: :string,
+        nullable: true,
+        description:
+          "Opaque cursor pointing at the last item of the current page. Pass it as the `after` query parameter to fetch the next page. Always `nil` when using page-based pagination."
       }
     },
     required: [:has_next_page, :has_previous_page, :page_size, :total_count]

--- a/server/lib/tuist_web/controllers/api/generations_controller.ex
+++ b/server/lib/tuist_web/controllers/api/generations_controller.ex
@@ -61,12 +61,12 @@ defmodule TuistWeb.API.GenerationsController do
       ],
       page: [
         in: :query,
+        deprecated: true,
         type: %Schema{
           title: "GenerationsIndexPage",
           description:
-            "The page number to return. Page-based pagination reads every preceding row, so it degrades on deep pages; prefer the cursor parameters (`after`/`before`) for iterating large result sets.",
+            "Deprecated and ignored. Offset pagination has been removed in favor of cursor pagination; use `after`/`before`. This parameter is still accepted so older clients degrade gracefully instead of erroring.",
           type: :integer,
-          default: 1,
           minimum: 1
         }
       ],
@@ -75,7 +75,7 @@ defmodule TuistWeb.API.GenerationsController do
         type: %Schema{
           title: "GenerationsIndexAfter",
           description:
-            "Cursor for forward pagination. Pass the `end_cursor` from a previous response to fetch the next page. Takes precedence over `page`.",
+            "Cursor for forward pagination. Pass the `end_cursor` from a previous response to fetch the next (older) page. Omit both `after` and `before` to fetch the first page.",
           type: :string
         }
       ],
@@ -84,7 +84,7 @@ defmodule TuistWeb.API.GenerationsController do
         type: %Schema{
           title: "GenerationsIndexBefore",
           description:
-            "Cursor for backward pagination. Pass the `start_cursor` from a previous response to fetch the previous page. Takes precedence over `page`.",
+            "Cursor for backward pagination. Pass the `start_cursor` from a previous response to fetch the previous (newer) page.",
           type: :string
         }
       ]
@@ -155,21 +155,22 @@ defmodule TuistWeb.API.GenerationsController do
     }
   )
 
-  def index(
-        %{assigns: %{selected_project: selected_project}, params: %{page_size: page_size, page: page} = params} = conn,
-        _params
-      ) do
+  def index(%{assigns: %{selected_project: selected_project}, params: %{page_size: page_size} = params} = conn, _params) do
     filters =
       [
         %{field: :project_id, op: :==, value: selected_project.id},
         %{field: :name, op: :==, value: "generate"}
       ] ++ filters_from_params(params)
 
+    # Cursor (keyset) pagination only. Offset pagination let a client scan
+    # millions of rows by requesting a high page number; a cursor seek reads
+    # one page regardless of how far it has walked. Omitting both cursors
+    # returns the first page (`first`), which also seeds forward iteration.
     pagination =
-      cond do
-        not is_nil(Map.get(params, :before)) -> %{last: page_size, before: params.before}
-        not is_nil(Map.get(params, :after)) -> %{first: page_size, after: params.after}
-        true -> %{page: page, page_size: page_size}
+      if is_nil(Map.get(params, :before)) do
+        %{first: page_size, after: Map.get(params, :after)}
+      else
+        %{last: page_size, before: params.before}
       end
 
     {command_events, meta} =
@@ -181,9 +182,6 @@ defmodule TuistWeb.API.GenerationsController do
         })
       )
 
-    # Emit cursors on every response — including the default page-based one — so
-    # a client can seed forward iteration (`after`) from any page instead of
-    # deep-offset paging, which rescans every preceding row.
     {start_cursor, end_cursor} = Flop.Cursor.get_cursors(command_events, [:ran_at])
 
     json(conn, %{

--- a/server/lib/tuist_web/controllers/api/generations_controller.ex
+++ b/server/lib/tuist_web/controllers/api/generations_controller.ex
@@ -63,10 +63,29 @@ defmodule TuistWeb.API.GenerationsController do
         in: :query,
         type: %Schema{
           title: "GenerationsIndexPage",
-          description: "The page number to return.",
+          description:
+            "The page number to return. Page-based pagination reads every preceding row, so it degrades on deep pages; prefer the cursor parameters (`after`/`before`) for iterating large result sets.",
           type: :integer,
           default: 1,
           minimum: 1
+        }
+      ],
+      after: [
+        in: :query,
+        type: %Schema{
+          title: "GenerationsIndexAfter",
+          description:
+            "Cursor for forward pagination. Pass the `end_cursor` from a previous response to fetch the next page. Takes precedence over `page`.",
+          type: :string
+        }
+      ],
+      before: [
+        in: :query,
+        type: %Schema{
+          title: "GenerationsIndexBefore",
+          description:
+            "Cursor for backward pagination. Pass the `start_cursor` from a previous response to fetch the previous page. Takes precedence over `page`.",
+          type: :string
         }
       ]
     ],
@@ -146,14 +165,26 @@ defmodule TuistWeb.API.GenerationsController do
         %{field: :name, op: :==, value: "generate"}
       ] ++ filters_from_params(params)
 
+    pagination =
+      cond do
+        not is_nil(Map.get(params, :before)) -> %{last: page_size, before: params.before}
+        not is_nil(Map.get(params, :after)) -> %{first: page_size, after: params.after}
+        true -> %{page: page, page_size: page_size}
+      end
+
     {command_events, meta} =
-      CommandEvents.list_command_events(%{
-        page: page,
-        page_size: page_size,
-        filters: filters,
-        order_by: [:ran_at],
-        order_directions: [:desc]
-      })
+      CommandEvents.list_command_events(
+        Map.merge(pagination, %{
+          filters: filters,
+          order_by: [:ran_at],
+          order_directions: [:desc]
+        })
+      )
+
+    # Emit cursors on every response — including the default page-based one — so
+    # a client can seed forward iteration (`after`) from any page instead of
+    # deep-offset paging, which rescans every preceding row.
+    {start_cursor, end_cursor} = Flop.Cursor.get_cursors(command_events, [:ran_at])
 
     json(conn, %{
       generations:
@@ -195,7 +226,9 @@ defmodule TuistWeb.API.GenerationsController do
         current_page: meta.current_page,
         page_size: meta.page_size,
         total_count: meta.total_count,
-        total_pages: meta.total_pages
+        total_pages: meta.total_pages,
+        start_cursor: start_cursor,
+        end_cursor: end_cursor
       }
     })
   end

--- a/server/test/tuist_web/controllers/api/generations_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/generations_controller_test.exs
@@ -63,10 +63,17 @@ defmodule TuistWeb.API.GenerationsControllerTest do
 
       assert %{
                "generations" => [],
-               "pagination_metadata" => %{
-                 "total_count" => 0
-               }
+               "pagination_metadata" => metadata
              } = json_response(conn, 200)
+
+      # Cursor-only pagination: no offset metadata, and no rows to derive cursors from.
+      assert metadata["total_count"] == nil
+      assert metadata["current_page"] == nil
+      assert metadata["total_pages"] == nil
+      assert metadata["start_cursor"] == nil
+      assert metadata["end_cursor"] == nil
+      assert metadata["has_next_page"] == false
+      assert metadata["has_previous_page"] == false
     end
 
     test "filters by git_branch", %{conn: conn, user: user, project: project} do
@@ -109,7 +116,15 @@ defmodule TuistWeb.API.GenerationsControllerTest do
 
       first_page_ids = Enum.map(first_page, & &1["id"])
       assert first_page_ids == Enum.take(expected_ids, 2)
+
+      # The default (cursorless) request returns the first page with a usable
+      # end_cursor and none of the offset metadata.
       assert is_binary(first_metadata["end_cursor"])
+      assert first_metadata["total_count"] == nil
+      assert first_metadata["current_page"] == nil
+      assert first_metadata["total_pages"] == nil
+      assert first_metadata["has_next_page"] == true
+      assert first_metadata["has_previous_page"] == false
 
       end_cursor = first_metadata["end_cursor"]
 
@@ -174,46 +189,28 @@ defmodule TuistWeb.API.GenerationsControllerTest do
       assert third_metadata["current_page"] == nil
     end
 
-    test "page-based pagination keeps page metadata and now also emits cursors", %{
-      conn: conn,
-      user: user,
-      project: project
-    } do
-      CommandEventsFixtures.command_event_fixture(
-        project_id: project.id,
-        name: "generate",
-        user_id: user.id
-      )
+    test "ignores a legacy offset page param and returns the first page", %{conn: conn, user: user, project: project} do
+      expected_ids = create_ordered_generations(user, project)
 
+      # A stale client still sending ?page=N must degrade gracefully: the unknown
+      # offset param is ignored and the first (cursor) page is returned with 200,
+      # not a 400.
       conn =
         conn
         |> Authentication.put_current_user(user)
-        |> get(~p"/api/projects/#{project.account.name}/#{project.name}/generations?page=1&page_size=20")
+        |> get(~p"/api/projects/#{project.account.name}/#{project.name}/generations?page=99&page_size=2")
 
       assert %{
-               "generations" => [_generation],
+               "generations" => generations,
                "pagination_metadata" => metadata
              } = json_response(conn, 200)
 
-      assert metadata["current_page"] == 1
-      assert metadata["total_count"] == 1
-      assert is_binary(metadata["start_cursor"])
+      assert Enum.map(generations, & &1["id"]) == Enum.take(expected_ids, 2)
+      assert metadata["current_page"] == nil
+      assert metadata["total_count"] == nil
+      assert metadata["total_pages"] == nil
       assert is_binary(metadata["end_cursor"])
-    end
-
-    test "returns nil cursors when the page is empty", %{conn: conn, user: user, project: project} do
-      conn =
-        conn
-        |> Authentication.put_current_user(user)
-        |> get(~p"/api/projects/#{project.account.name}/#{project.name}/generations")
-
-      assert %{
-               "generations" => [],
-               "pagination_metadata" => metadata
-             } = json_response(conn, 200)
-
-      assert metadata["start_cursor"] == nil
-      assert metadata["end_cursor"] == nil
+      assert metadata["has_previous_page"] == false
     end
   end
 

--- a/server/test/tuist_web/controllers/api/generations_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/generations_controller_test.exs
@@ -91,6 +91,130 @@ defmodule TuistWeb.API.GenerationsControllerTest do
       assert %{"generations" => [returned]} = json_response(conn, 200)
       assert returned["id"] == generation.id
     end
+
+    test "paginates forward with the after cursor", %{conn: conn, user: user, project: project} do
+      expected_ids = create_ordered_generations(user, project)
+
+      # The real client flow: fetch the first page without any cursor, then reuse
+      # the returned end_cursor as `after` to walk forward.
+      first_conn =
+        conn
+        |> Authentication.put_current_user(user)
+        |> get(~p"/api/projects/#{project.account.name}/#{project.name}/generations?page_size=2")
+
+      assert %{
+               "generations" => first_page,
+               "pagination_metadata" => first_metadata
+             } = json_response(first_conn, 200)
+
+      first_page_ids = Enum.map(first_page, & &1["id"])
+      assert first_page_ids == Enum.take(expected_ids, 2)
+      assert is_binary(first_metadata["end_cursor"])
+
+      end_cursor = first_metadata["end_cursor"]
+
+      second_conn =
+        build_conn()
+        |> Authentication.put_current_user(user)
+        |> assign(:selected_project, project)
+        |> get(~p"/api/projects/#{project.account.name}/#{project.name}/generations?page_size=2&after=#{end_cursor}")
+
+      assert %{
+               "generations" => second_page,
+               "pagination_metadata" => second_metadata
+             } = json_response(second_conn, 200)
+
+      second_page_ids = Enum.map(second_page, & &1["id"])
+
+      # The second page holds the next (older) distinct events, with no overlap with page one.
+      assert second_page_ids == expected_ids |> Enum.drop(2) |> Enum.take(2)
+      assert second_page_ids -- first_page_ids == second_page_ids
+      assert second_metadata["has_next_page"] == true
+      assert second_metadata["has_previous_page"] == true
+      assert second_metadata["current_page"] == nil
+      assert second_metadata["total_pages"] == nil
+      assert is_binary(second_metadata["start_cursor"])
+      assert is_binary(second_metadata["end_cursor"])
+    end
+
+    test "paginates backward with the before cursor", %{conn: conn, user: user, project: project} do
+      expected_ids = create_ordered_generations(user, project)
+
+      first_conn =
+        conn
+        |> Authentication.put_current_user(user)
+        |> get(~p"/api/projects/#{project.account.name}/#{project.name}/generations?page_size=2")
+
+      assert %{"pagination_metadata" => %{"end_cursor" => end_cursor}} = json_response(first_conn, 200)
+
+      # Step forward to the second page to grab its start_cursor.
+      second_conn =
+        build_conn()
+        |> Authentication.put_current_user(user)
+        |> assign(:selected_project, project)
+        |> get(~p"/api/projects/#{project.account.name}/#{project.name}/generations?page_size=2&after=#{end_cursor}")
+
+      assert %{"pagination_metadata" => %{"start_cursor" => start_cursor}} = json_response(second_conn, 200)
+      assert is_binary(start_cursor)
+
+      # Walking back from the second page returns the first page again.
+      third_conn =
+        build_conn()
+        |> Authentication.put_current_user(user)
+        |> assign(:selected_project, project)
+        |> get(~p"/api/projects/#{project.account.name}/#{project.name}/generations?page_size=2&before=#{start_cursor}")
+
+      assert %{
+               "generations" => third_page,
+               "pagination_metadata" => third_metadata
+             } = json_response(third_conn, 200)
+
+      assert Enum.map(third_page, & &1["id"]) == Enum.take(expected_ids, 2)
+      assert third_metadata["has_next_page"] == true
+      assert third_metadata["current_page"] == nil
+    end
+
+    test "page-based pagination keeps page metadata and now also emits cursors", %{
+      conn: conn,
+      user: user,
+      project: project
+    } do
+      CommandEventsFixtures.command_event_fixture(
+        project_id: project.id,
+        name: "generate",
+        user_id: user.id
+      )
+
+      conn =
+        conn
+        |> Authentication.put_current_user(user)
+        |> get(~p"/api/projects/#{project.account.name}/#{project.name}/generations?page=1&page_size=20")
+
+      assert %{
+               "generations" => [_generation],
+               "pagination_metadata" => metadata
+             } = json_response(conn, 200)
+
+      assert metadata["current_page"] == 1
+      assert metadata["total_count"] == 1
+      assert is_binary(metadata["start_cursor"])
+      assert is_binary(metadata["end_cursor"])
+    end
+
+    test "returns nil cursors when the page is empty", %{conn: conn, user: user, project: project} do
+      conn =
+        conn
+        |> Authentication.put_current_user(user)
+        |> get(~p"/api/projects/#{project.account.name}/#{project.name}/generations")
+
+      assert %{
+               "generations" => [],
+               "pagination_metadata" => metadata
+             } = json_response(conn, 200)
+
+      assert metadata["start_cursor"] == nil
+      assert metadata["end_cursor"] == nil
+    end
   end
 
   describe "GET /api/projects/:account_handle/:project_handle/generations/:generation_id" do
@@ -160,5 +284,24 @@ defmodule TuistWeb.API.GenerationsControllerTest do
 
       assert %{"message" => "Generation not found."} = json_response(conn, 404)
     end
+  end
+
+  # Creates five generate command events with distinct ran_at values and returns
+  # their ids ordered newest-first, matching the controller's ran_at desc ordering.
+  defp create_ordered_generations(user, project) do
+    base = ~U[2024-06-01 12:00:00Z]
+
+    0..4
+    |> Enum.map(fn index ->
+      CommandEventsFixtures.command_event_fixture(
+        project_id: project.id,
+        name: "generate",
+        user_id: user.id,
+        created_at: DateTime.add(base, index, :minute),
+        ran_at: DateTime.add(base, index, :minute)
+      )
+    end)
+    |> Enum.reverse()
+    |> Enum.map(& &1.id)
   end
 end


### PR DESCRIPTION
Two ClickHouse read-path fixes for **"Slow ClickHouse query"** Grafana alerts (p90 > 1s), profiled against production `system.query_log` and validated against prod data + the local test suite.

## 1. ⚠️ Generations API is now cursor-only (breaking)

`GET .../generations` (`listGenerations`) paginated with `page`/`page_size` (offset). A consumer requesting a high page number (e.g. `page ~320` → `LIMIT 32000, 100`) with the `name = 'generate'` filter made ClickHouse **scan ~2.8M rows / 3.7 GB / 2.8 GB RAM to return 100 rows**, and the cost grows with page depth — anyone could strain ClickHouse just by incrementing `page`.

This PR **removes offset pagination** from the endpoint in favor of **cursor (keyset) pagination**:

- Paginate with `after` / `before` cursors from `pagination_metadata` (`end_cursor` / `start_cursor`). Omitting both returns the first page.
- A cursor seek reads **~64K rows / 2 MB / 35 MB** for a page, **flat regardless of depth**, and runs **no `count` query**.
- The `page` parameter is **deprecated and ignored** (kept as an accepted no-op because the endpoint's strict validation would otherwise 400 on it — so older clients degrade gracefully to the first page rather than erroring).
- `total_count` / `current_page` / `total_pages` are **`nil`** for this endpoint (cursor pagination can't compute them cheaply). `total_count` is relaxed to nullable/non-required in the shared `PaginationMetadata` schema; the ~20 offset-based endpoints still populate it.

**BREAKING CHANGE** — see the commit footer. Consumers iterating generations must switch from `page` to the `after`/`before` cursors.

> Follow-up (not in this PR): the CLI's `tuist generation list` uses this endpoint's offset pagination + `total_pages` for its interactive table, so it will degrade to first-page-only until migrated to cursors. It is **not** the source of the abusive deep paging (it uses `page_size=10`, loads on demand); the abuser is an external/direct API client. A separate PR should move the CLI to cursors.

## 2. Prune the flaky-marking scan with a `git_commit_sha` bloom filter

`mark_test_case_runs_as_flaky` re-fetched full rows filtering only `project_id + test_case_id + id`, still scanning the entire `ran_at` span of a high-volume test case (**up to ~888K rows**). Every historical flaky run comes from `get_existing_ci_runs_for_commit/4` for one commit, so we now also constrain `git_commit_sha`, engaging the table's `GRANULARITY 1` bloom filter to prune the scan to the granules holding that commit's runs (6→2 granules on the profiled sample).

### How to test locally

```
cd server
mix test test/tuist_web/controllers/api/generations_controller_test.exs
mix test test/tuist/tests_test.exs   # cross-run flakiness back-marking
```

Generations controller tests cover forward (`after`) / backward (`before`) cursor iteration, the default first page (non-nil cursors, nil `total_count`/`current_page`/`total_pages`), and graceful handling of a legacy `?page=N` request (200 + first page). The cross-run flakiness tests exercise the `git_commit_sha`-filtered back-marking path. `mix compile --warnings-as-errors`, `mix format`, `mix credo --strict` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
