### PR TITLE
fix(infra): exclude non-Hetzner kura nodes from hcloud-csi by provider label

### DIFF
--- a/infra/k8s/mgmt/bootstrap/hcloud-csi-values.yaml
+++ b/infra/k8s/mgmt/bootstrap/hcloud-csi-values.yaml
@@ -64,10 +64,12 @@ node:
   # `provided-by=robot`) are re-declared here alongside our own
   # rules. All match expressions live in one list so they AND
   # together — a node schedules the pod only if it is none of:
-  # Hetzner root server, Robot-provisioned, in `runners-linux`, or
-  # running darwin. Our CAPI HCCM doesn't set the `is-root-server` /
-  # `provided-by` labels today (upstream chart with no Robot creds),
-  # so the pool and OS rules are what actually filter in this
+  # Hetzner root server, Robot-provisioned, in `runners-linux`,
+  # provisioned by the in-house CAPI provider on non-Hetzner infra
+  # (OVHcloud / Dedibox / Scaleway), or running darwin. Our CAPI
+  # HCCM doesn't set the `is-root-server` / `provided-by` labels
+  # today (upstream chart with no Robot creds), so the pool,
+  # instance-type, and OS rules are what actually filter in this
   # cluster; the others are forward-compat with a Syself-style HCCM
   # or a future Robot-aware upstream.
   #
@@ -81,9 +83,14 @@ node:
   # matches (= node included), so this rule only filters out nodes
   # that explicitly advertise darwin; everything else still passes.
   #
-  # Future bare-metal pools should carry the same
-  # `node.cluster.x-k8s.io/pool` label convention so this affinity
-  # can be extended with another `values:` entry.
+  # The non-Hetzner kura fleets are excluded by provider, not by
+  # per-region pool name (below). Enumerating pools is what caused
+  # the crash-loop this file exists to prevent: #11346 added the
+  # `kura-us-east` / `kura-us-west` OVH regions but the pool denylist
+  # only listed the regions that existed when it was written, so
+  # hcloud-csi-node landed on the new bare-metal boxes and
+  # CrashLoopBackOff'd (hcloud Volumes can't attach off Hetzner).
+  # A new kura region on an existing provider now needs no edit here.
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
@@ -97,22 +104,31 @@ node:
                 operator: NotIn
                 values:
                   - robot
+              # Hetzner Robot bare metal (the `runners-linux` pool).
+              # caph provisions these, so they carry no
+              # `node.cluster.x-k8s.io/instance-type` label and the
+              # provider rule below can't catch them; exclude by pool.
+              # hcloud Volumes can't attach to Robot servers.
               - key: node.cluster.x-k8s.io/pool
                 operator: NotIn
                 values:
                   - runners-linux
-                  # Scaleway Instance pool for the macOS runner
-                  # cache (kura) — not Hetzner hardware, hcloud
-                  # Volumes can't attach there. scaleway-csi serves
-                  # its PVCs instead.
-                  - kura-scw-fr-par
-                  # Dedibox bare metal (EU customer-facing kura
-                  # cache) — likewise not Hetzner; local NVMe serves
-                  # its PVCs.
-                  - kura-dedibox
-                  # OVHcloud bare metal (the ca-east kura cache region) —
-                  # not Hetzner either; local NVMe serves its PVCs.
-                  - kura-ca-east
+              # Nodes the in-house CAPI provider brings up on
+              # non-Hetzner infrastructure (OVHcloud, Dedibox,
+              # Scaleway) for the kura cache fleets. hcloud Volumes
+              # can't attach anywhere off Hetzner, so the driver only
+              # crash-loops there; the server provisions those PVCs
+              # from local NVMe instead. Keying on the provider label
+              # rather than each `pool` means every kura region on
+              # these providers is excluded automatically. Real
+              # Hetzner Cloud nodes carry no such label, so NotIn with
+              # the label absent still includes them.
+              - key: node.cluster.x-k8s.io/instance-type
+                operator: NotIn
+                values:
+                  - ovh
+                  - dedibox
+                  - scaleway
               - key: kubernetes.io/os
                 operator: NotIn
                 values:


### PR DESCRIPTION
## What changed

Rewrites the `hcloud-csi-node` node-affinity denylist in `infra/k8s/mgmt/bootstrap/hcloud-csi-values.yaml` to exclude the non-Hetzner kura fleets **by provider** (`node.cluster.x-k8s.io/instance-type NotIn [ovh, dedibox, scaleway]`) instead of enumerating per-region `node.cluster.x-k8s.io/pool` names (`kura-scw-fr-par`, `kura-dedibox`, `kura-ca-east`). The `runners-linux` pool exclusion and the darwin/Robot rules are unchanged.

## Why

The CSI reconcile workflow added in #11633 cleared the CrashLoop on **canary** and **staging**, but the **production** job failed:

```
Error: UPGRADE FAILED: resource DaemonSet/kube-system/hcloud-csi-node not ready.
status: InProgress, message: Updated: 8/11 — context deadline exceeded
```

Two `hcloud-csi-node` pods were stuck in `CrashLoopBackOff` on the OVH bare-metal nodes `tuist-tuist-ovh-fleet-us-east/us-west`, so the DaemonSet never went Ready and `helm --wait` timed out. Because the hcloud step failed, the job never reached the `scaleway-csi` uninstall step, leaving the 6129-restart `scaleway-csi-node` on production alive too.

### Root cause

The affinity excluded bare-metal kura fleets by listing pool names. #11346 brought up two new OVH regions (`kura-us-east`, `kura-us-west`) that were never added to that list, so `hcloud-csi-node` scheduled onto them — and Hetzner Cloud Volumes can't attach off Hetzner, so the driver only crash-loops there. This is the **same drift class the workflow exists to prevent, one label deeper**: every new bare-metal region required a manual denylist edit, and one was missed.

### Why provider, not pool

Every node the in-house CAPI provider brings up on non-Hetzner infra carries `node.cluster.x-k8s.io/instance-type` ∈ {`ovh`, `dedibox`, `scaleway`}; real Hetzner Cloud nodes carry no such label (and `NotIn` with an absent label still includes them). Keying on the provider excludes **every** kura region on those providers automatically — a new region needs no edit here.

`kura-us-east` is deliberately **not** keyed on pool: the same pool label is still worn by the draining Hetzner Cloud node `tuist-kura-us-east-*`, which genuinely needs `hcloud-csi` for its `registry-pg-1` PVC until it is decommissioned. Keying on the provider label leaves that Hetzner node **included** and drops only the OVH box.

`runners-linux` stays a pool exclusion: Hetzner Robot boxes are caph-provisioned and carry no `instance-type` label, so only the pool name separates them.

## Validation

Rendered the DaemonSet with `helm template -f hcloud-csi-values.yaml` (valid, affinity emitted as written) and evaluated the affinity against **every live node** in canary and production using Kubernetes `NotIn` semantics:

- **Production**: `tuist-tuist-ovh-fleet-us-east`, `-us-west` (the crash-loopers), dedibox, scaleway kura, both `runners-linux`, and all tart nodes → **excluded**. All Hetzner Cloud pools (control-plane, general, egress, processor) **and** the dying `tuist-kura-us-east-*` → **included**. DaemonSet goes 11→9, all Ready ⇒ `helm --wait` succeeds ⇒ the `scaleway-csi` uninstall step runs.
- **Canary**: reconciles to its current healthy 5-pod set; `kura-ca-east`/`kura-scw-fr-par` now excluded by provider rather than pool. No regression.
- **Staging** (already green): its only `capi=-` exclusions are `runners-linux` and darwin, both still covered — cannot regress.

## Impact / rollout

Merging re-triggers **CSI Node Driver Deployment** (this file is a path trigger). Expected result: production's two OVH `hcloud-csi-node` pods drop off, the DaemonSet rolls green, and the `scaleway-csi` uninstall clears the remaining crash-loop. Then the FIRING:18 CrashLoop alert resolves for the `hcloud-csi-node` / `scaleway-csi-node` pods on `tuist-canary` (already clear) and `tuist-production`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)