### PR TITLE
fix(cli): avoid duplicate SwiftPM C target public headers

### DIFF
--- a/cli/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
+++ b/cli/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
@@ -753,9 +753,11 @@ public struct PackageInfoMapper: PackageInfoMapping {
 
         let targetPath = try await target.basePath(packageFolder: packageFolder)
 
+        let moduleMapModuleName: String?
         let moduleMap: ModuleMap?
         switch target.type {
         case .system:
+            moduleMapModuleName = nil
             // System library targets assume the module map is located at the source directory root
             // https://github.com/apple/swift-package-manager/blob/main/Sources/PackageLoading/ModuleMapGenerator.swift
             let packagePath = try await target.basePath(packageFolder: path)
@@ -771,9 +773,10 @@ public struct PackageInfoMapper: PackageInfoMapping {
 
             moduleMap = ModuleMap.custom(moduleMapPath, umbrellaHeaderPath: nil)
         case .regular, .test:
-            let moduleName = PackageInfoMapper.effectiveModuleName(
+            let resolvedModuleName = PackageInfoMapper.effectiveModuleName(
                 targetName: target.name, products: products, targetsByName: targetsByName
             )
+            moduleMapModuleName = resolvedModuleName
             let swiftPackageManagerScratchDirectory: AbsolutePath? = if packageType.isRemoteExternal {
                 SwiftPackageManagerPaths.scratchDirectory(containingCheckout: path)
             } else {
@@ -781,11 +784,12 @@ public struct PackageInfoMapper: PackageInfoMapping {
             }
             moduleMap = try await moduleMapGenerator.generate(
                 packageDirectory: path,
-                moduleName: moduleName,
+                moduleName: resolvedModuleName,
                 publicHeadersPath: target.publicHeadersPath(packageFolder: path),
                 swiftPackageManagerScratchDirectory: swiftPackageManagerScratchDirectory
             )
         default:
+            moduleMapModuleName = nil
             moduleMap = nil
         }
 
@@ -830,8 +834,8 @@ public struct PackageInfoMapper: PackageInfoMapping {
             headers = try await discoveredHeaders(
                 for: target,
                 moduleMap: moduleMap,
-                targetPath: targetPath,
-                packageFolder: path
+                moduleName: moduleMapModuleName,
+                targetPath: targetPath
             )
         }
 
@@ -1020,8 +1024,8 @@ public struct PackageInfoMapper: PackageInfoMapping {
     private func discoveredHeaders(
         for target: PackageInfo.Target,
         moduleMap: ModuleMap?,
-        targetPath: AbsolutePath,
-        packageFolder: AbsolutePath
+        moduleName: String?,
+        targetPath: AbsolutePath
     ) async throws -> ProjectDescription.Headers? {
         guard let moduleMap else { return nil }
 
@@ -1042,14 +1046,87 @@ public struct PackageInfoMapper: PackageInfoMapping {
             return .headers(
                 project: .list([.glob(.path("\(targetPath.pathString)/\(headersGlob)"), excluding: excluding)])
             )
-        case .directory:
-            let publicHeadersPath = try await target.publicHeadersPath(packageFolder: packageFolder)
+        case let .directory(_, publicHeadersPath):
+            let publicHeaders = try await frameworkPublicHeaders(
+                publicHeadersPath: publicHeadersPath,
+                targetPath: targetPath,
+                excluding: target.exclude,
+                moduleName: moduleName
+            )
             return .headers(
-                public: .list([.glob(.path("\(publicHeadersPath.pathString)/\(headersGlob)"), excluding: excluding)]),
+                public: publicHeaders,
                 project: .list([.glob(.path("\(targetPath.pathString)/\(headersGlob)"), excluding: excluding)]),
                 exclusionRule: .projectExcludesPrivateAndPublic
             )
         }
+    }
+
+    private func frameworkPublicHeaders(
+        publicHeadersPath: AbsolutePath,
+        targetPath: AbsolutePath,
+        excluding: [String],
+        moduleName: String?
+    ) async throws -> ProjectDescription.FileList? {
+        let headerExtensions = "h,hh,hpp,h++,hp,hxx,H,ipp,def"
+        let excludedPaths = try excluding.map {
+            targetPath.appending(try RelativePath(validating: $0))
+        }
+
+        let headers = try await fileSystem
+            .glob(directory: publicHeadersPath, include: ["**/*.{\(headerExtensions)}", "*.{\(headerExtensions)}"])
+            .collect()
+            .uniqued()
+            .filter { header in
+                excludedPaths.allSatisfy { excludedPath in
+                    if excludedPath.extension == nil {
+                        !header.isDescendantOfOrEqual(to: excludedPath)
+                    } else {
+                        header != excludedPath
+                    }
+                }
+            }
+
+        let frameworkHeaders = uniqueFrameworkPublicHeaders(
+            headers,
+            publicHeadersPath: publicHeadersPath,
+            moduleName: moduleName
+        )
+
+        guard !frameworkHeaders.isEmpty else { return nil }
+
+        return .list(frameworkHeaders.map { .glob(.path($0.pathString)) })
+    }
+
+    private func uniqueFrameworkPublicHeaders(
+        _ headers: [AbsolutePath],
+        publicHeadersPath: AbsolutePath,
+        moduleName: String?
+    ) -> [AbsolutePath] {
+        let moduleDirectory = moduleName.map { publicHeadersPath.appending(component: $0.sanitizedModuleName) }
+
+        return Dictionary(grouping: headers, by: \.basename)
+            .values
+            .compactMap { headers in
+                headers.sorted { lhs, rhs in
+                    if let moduleDirectory {
+                        let lhsIsModuleNested = lhs.isDescendant(of: moduleDirectory)
+                        let rhsIsModuleNested = rhs.isDescendant(of: moduleDirectory)
+                        if lhsIsModuleNested != rhsIsModuleNested {
+                            return lhsIsModuleNested
+                        }
+                    }
+
+                    let lhsDepth = lhs.relative(to: publicHeadersPath).components.count
+                    let rhsDepth = rhs.relative(to: publicHeadersPath).components.count
+                    if lhsDepth != rhsDepth {
+                        return lhsDepth > rhsDepth
+                    }
+
+                    return lhs.pathString < rhs.pathString
+                }
+                .first
+            }
+            .sorted()
     }
 
     private func prebuiltDependency(

--- a/cli/Tests/TuistGeneratorAcceptanceTests/GenerateAcceptanceTests.swift
+++ b/cli/Tests/TuistGeneratorAcceptanceTests/GenerateAcceptanceTests.swift
@@ -603,6 +603,51 @@ struct GenerateAcceptanceTestAppWithSPMCTargetHeaders {
     }
 }
 
+struct GenerateAcceptanceTestAppWithSPMCTargetDuplicatePublicHeaders {
+    /// Regression coverage for SwiftPM C targets whose public headers contain duplicate basenames once
+    /// flattened into an Xcode framework's `Headers` directory. The local package mirrors nanopb's layout:
+    /// top-level wrapper public headers include nested module headers with the same filenames.
+    ///
+    /// Before the fix, both the wrapper and nested headers were marked Public, so Xcode failed with
+    /// "Multiple commands produce ... nanopb.framework/Headers/pb.h". After the fix, Tuist keeps only one
+    /// public header per framework destination while preserving the rest as project headers.
+    @Test(.withFixture("generated_app_with_spm_c_target_duplicate_public_headers"), .inTemporaryDirectory)
+    func app_with_spm_c_target_duplicate_public_headers() async throws {
+        let fixturePath = try fixtureDirectory()
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let derivedDataPath = temporaryDirectory.appending(component: "DerivedData")
+
+        try await run(InstallCommand.self)
+        try await run(GenerateCommand.self)
+
+        let packageXcodeprojPath = try await TuistAcceptanceTest.xcodeprojPath(
+            in: fixturePath.appending(component: "Nanopb")
+        )
+        let xcodeproj = try XcodeProj(pathString: packageXcodeprojPath.pathString)
+        let target = try #require(xcodeproj.pbxproj.nativeTargets.first(where: { $0.name == "nanopb" }))
+        let headerFiles = target.buildPhases.compactMap { $0 as? PBXHeadersBuildPhase }.first?.files ?? []
+        let publicHeaderNames = headerFiles
+            .filter { ($0.settings?["ATTRIBUTES"]?.arrayValue ?? []).contains("Public") }
+            .compactMap { $0.file?.path }
+            .sorted()
+
+        #expect(publicHeaderNames == ["pb.h", "pb_common.h"])
+
+        try await CommandRunner().runAndWait(arguments: [
+            "/usr/bin/xcodebuild",
+            "build",
+            "-workspace",
+            fixturePath.appending(component: "App.xcworkspace").pathString,
+            "-scheme",
+            "App",
+            "-destination",
+            "platform=macOS",
+            "-derivedDataPath",
+            derivedDataPath.pathString,
+        ])
+    }
+}
+
 struct GenerateAcceptanceTestiOSAppWithMultiConfigs {
     @Test(.disabled(), .withFixture("generated_ios_app_with_multi_configs"), .inTemporaryDirectory)
     func ios_app_with_multi_configs() async throws {

--- a/cli/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
+++ b/cli/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
@@ -2740,7 +2740,10 @@ struct PackageInfoMapperTests {
                         .test(
                             "Dependency1",
                             basePath: basePath,
-                            headers: .spmDirectoryTarget(dependencyHeadersPath.parentDirectory),
+                            headers: .spmDirectoryTarget(
+                                dependencyHeadersPath.parentDirectory,
+                                publicHeaderRelativePaths: ["include/Header.h"]
+                            ),
                             customSettings: [
                                 "HEADER_SEARCH_PATHS": ["$(inherited)", "$(SRCROOT)/Sources/Dependency1/include"],
                                 "DEFINES_MODULE": "NO",
@@ -2750,6 +2753,91 @@ struct PackageInfoMapperTests {
                                 ],
                             ],
                             moduleMap: "$(SRCROOT)/Derived/Dependency1.modulemap"
+                        ),
+                    ]
+                )
+        )
+    }
+
+    @Test(
+        .inTemporaryDirectory,
+        .withMockedSwiftVersionProvider
+    ) func map_whenDirectoryPublicHeadersHaveDuplicateBasenames_prefersModuleNestedHeaders() async throws {
+        let basePath = try #require(FileSystem.temporaryTestDirectory)
+        let packagePath = basePath.appending(component: "Package")
+        let publicHeadersPath = packagePath.appending(component: "spm_headers")
+        let nestedPublicHeadersPath = publicHeadersPath.appending(component: "nanopb")
+
+        try await fileSystem.makeDirectory(at: nestedPublicHeadersPath)
+        try await fileSystem.writeText("", at: packagePath.appending(component: "pb.h"))
+        try await fileSystem.writeText("", at: packagePath.appending(component: "pb_common.h"))
+        try await fileSystem.writeText("", at: packagePath.appending(component: "pb_common.c"))
+        try await fileSystem.writeText(#"#include "nanopb/pb.h""#, at: publicHeadersPath.appending(component: "pb.h"))
+        try await fileSystem.writeText(
+            #"#include "nanopb/pb_common.h""#,
+            at: publicHeadersPath.appending(component: "pb_common.h")
+        )
+        try await fileSystem.writeText("", at: nestedPublicHeadersPath.appending(component: "pb.h"))
+        try await fileSystem.writeText("", at: nestedPublicHeadersPath.appending(component: "pb_common.h"))
+
+        let project = try await subject.map(
+            package: "Package",
+            basePath: basePath,
+            packageInfos: [
+                "Package": .test(
+                    name: "Package",
+                    products: [
+                        .init(name: "nanopb", type: .library(.automatic), targets: ["nanopb"]),
+                    ],
+                    targets: [
+                        .test(
+                            name: "nanopb",
+                            path: ".",
+                            sources: [
+                                "pb.h",
+                                "pb_common.h",
+                                "pb_common.c",
+                            ],
+                            publicHeadersPath: "spm_headers"
+                        ),
+                    ],
+                    platforms: [.ios],
+                    cLanguageStandard: nil,
+                    cxxLanguageStandard: nil,
+                    swiftLanguageVersions: nil
+                ),
+            ]
+        )
+
+        #expect(
+            project ==
+                .testWithDefaultConfigs(
+                    name: "Package",
+                    targets: [
+                        .test(
+                            "nanopb",
+                            basePath: basePath,
+                            customSources: .custom(.sourceFilesList(globs: [
+                                packagePath.appending(component: "pb.h").pathString,
+                                packagePath.appending(component: "pb_common.h").pathString,
+                                packagePath.appending(component: "pb_common.c").pathString,
+                            ])),
+                            headers: .spmDirectoryTarget(
+                                packagePath,
+                                publicHeaderRelativePaths: [
+                                    "spm_headers/nanopb/pb.h",
+                                    "spm_headers/nanopb/pb_common.h",
+                                ]
+                            ),
+                            customSettings: [
+                                "HEADER_SEARCH_PATHS": ["$(inherited)", "$(SRCROOT)/spm_headers"],
+                                "DEFINES_MODULE": "NO",
+                                "OTHER_CFLAGS": .array(["$(inherited)", "-fmodule-name=nanopb"]),
+                                "OTHER_SWIFT_FLAGS": [
+                                    "$(inherited)",
+                                ],
+                            ],
+                            moduleMap: "$(SRCROOT)/Derived/nanopb.modulemap"
                         ),
                     ]
                 )
@@ -8152,16 +8240,18 @@ extension ProjectDescription.Headers {
     }
 
     /// Mirrors the headers `PackageInfoMapper` produces for a `.directory` module-map SwiftPM target (no
-    /// umbrella header): headers under the public headers directory stay public so they are copied into the
-    /// framework bundle and remain importable as `<Module/Header.h>`; every other header is a project header.
+    /// umbrella header): public headers are explicit so Xcode gets at most one public build file per framework
+    /// header basename; every other header remains a project header.
     fileprivate static func spmDirectoryTarget(
         _ targetBasePath: AbsolutePath,
-        publicHeadersRelativePath: String = "include",
+        publicHeaderRelativePaths: [String],
         excluding: [ProjectDescription.Path] = []
     ) -> ProjectDescription.Headers {
-        let publicHeadersPath = targetBasePath.appending(try! RelativePath(validating: publicHeadersRelativePath))
+        let publicHeaders = publicHeaderRelativePaths.map {
+            targetBasePath.appending(try! RelativePath(validating: $0))
+        }
         return .headers(
-            public: .list([.glob(.path("\(publicHeadersPath.pathString)/\(spmHeadersGlob)"), excluding: excluding)]),
+            public: .list(publicHeaders.map { .glob(.path($0.pathString), excluding: excluding) }),
             project: .list([.glob(.path("\(targetBasePath.pathString)/\(spmHeadersGlob)"), excluding: excluding)]),
             exclusionRule: .projectExcludesPrivateAndPublic
         )

--- a/examples/xcode/generated_app_with_spm_c_target_duplicate_public_headers/.gitignore
+++ b/examples/xcode/generated_app_with_spm_c_target_duplicate_public_headers/.gitignore
@@ -1,0 +1,4 @@
+.build/
+Derived/
+*.xcodeproj
+*.xcworkspace

--- a/examples/xcode/generated_app_with_spm_c_target_duplicate_public_headers/Nanopb/Package.swift
+++ b/examples/xcode/generated_app_with_spm_c_target_duplicate_public_headers/Nanopb/Package.swift
@@ -1,0 +1,21 @@
+// swift-tools-version:5.9
+import PackageDescription
+
+let package = Package(
+    name: "Nanopb",
+    products: [
+        .library(name: "nanopb", targets: ["nanopb"]),
+    ],
+    targets: [
+        .target(
+            name: "nanopb",
+            path: ".",
+            sources: [
+                "pb.h",
+                "pb_common.h",
+                "pb_common.c",
+            ],
+            publicHeadersPath: "spm_headers"
+        ),
+    ]
+)

--- a/examples/xcode/generated_app_with_spm_c_target_duplicate_public_headers/Nanopb/pb.h
+++ b/examples/xcode/generated_app_with_spm_c_target_duplicate_public_headers/Nanopb/pb.h
@@ -1,0 +1,3 @@
+#pragma once
+
+#define NANOPB_INTERNAL_VALUE 42

--- a/examples/xcode/generated_app_with_spm_c_target_duplicate_public_headers/Nanopb/pb_common.c
+++ b/examples/xcode/generated_app_with_spm_c_target_duplicate_public_headers/Nanopb/pb_common.c
@@ -1,0 +1,6 @@
+#include "pb_common.h"
+
+int nanopb_value(void)
+{
+    return NANOPB_INTERNAL_VALUE;
+}

--- a/examples/xcode/generated_app_with_spm_c_target_duplicate_public_headers/Nanopb/pb_common.h
+++ b/examples/xcode/generated_app_with_spm_c_target_duplicate_public_headers/Nanopb/pb_common.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include "pb.h"
+
+int nanopb_value(void);

--- a/examples/xcode/generated_app_with_spm_c_target_duplicate_public_headers/Nanopb/spm_headers/nanopb/pb.h
+++ b/examples/xcode/generated_app_with_spm_c_target_duplicate_public_headers/Nanopb/spm_headers/nanopb/pb.h
@@ -1,0 +1,3 @@
+#pragma once
+
+#define NANOPB_PUBLIC_VALUE 42

--- a/examples/xcode/generated_app_with_spm_c_target_duplicate_public_headers/Nanopb/spm_headers/nanopb/pb_common.h
+++ b/examples/xcode/generated_app_with_spm_c_target_duplicate_public_headers/Nanopb/spm_headers/nanopb/pb_common.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include "pb.h"
+
+int nanopb_value(void);

--- a/examples/xcode/generated_app_with_spm_c_target_duplicate_public_headers/Nanopb/spm_headers/pb.h
+++ b/examples/xcode/generated_app_with_spm_c_target_duplicate_public_headers/Nanopb/spm_headers/pb.h
@@ -1,0 +1,1 @@
+#include "nanopb/pb.h"

--- a/examples/xcode/generated_app_with_spm_c_target_duplicate_public_headers/Nanopb/spm_headers/pb_common.h
+++ b/examples/xcode/generated_app_with_spm_c_target_duplicate_public_headers/Nanopb/spm_headers/pb_common.h
@@ -1,0 +1,1 @@
+#include "nanopb/pb_common.h"

--- a/examples/xcode/generated_app_with_spm_c_target_duplicate_public_headers/Project.swift
+++ b/examples/xcode/generated_app_with_spm_c_target_duplicate_public_headers/Project.swift
@@ -1,0 +1,15 @@
+import ProjectDescription
+
+let project = Project(
+    name: "App",
+    targets: [
+        .target(
+            name: "App",
+            destinations: [.mac],
+            product: .commandLineTool,
+            bundleId: "dev.tuist.App",
+            sources: ["Sources/**"],
+            dependencies: [.external(name: "nanopb")]
+        ),
+    ]
+)

--- a/examples/xcode/generated_app_with_spm_c_target_duplicate_public_headers/Sources/App/main.swift
+++ b/examples/xcode/generated_app_with_spm_c_target_duplicate_public_headers/Sources/App/main.swift
@@ -1,0 +1,3 @@
+import nanopb
+
+print(nanopb_value())

--- a/examples/xcode/generated_app_with_spm_c_target_duplicate_public_headers/Tuist.swift
+++ b/examples/xcode/generated_app_with_spm_c_target_duplicate_public_headers/Tuist.swift
@@ -1,0 +1,3 @@
+import ProjectDescription
+
+let tuist = Tuist(project: .tuist())

--- a/examples/xcode/generated_app_with_spm_c_target_duplicate_public_headers/Tuist/Package.swift
+++ b/examples/xcode/generated_app_with_spm_c_target_duplicate_public_headers/Tuist/Package.swift
@@ -1,0 +1,17 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+#if TUIST
+import ProjectDescription
+
+let packageSettings = PackageSettings(
+    productTypes: ["nanopb": .staticFramework]
+)
+#endif
+
+let package = Package(
+    name: "Deps",
+    dependencies: [
+        .package(path: "../Nanopb"),
+    ]
+)


### PR DESCRIPTION
## What changed

Backports #11638 to `releases/4.202.x`, the release branch for the latest CLI RC (`4.202.0-rc.1`).

This carries the SwiftPM C-target header fix that prevents directory-style public headers with duplicate basenames from being copied twice into the same framework `Headers` destination.

## Why

The regression can break projects that consume packages shaped like `firebase/nanopb`, where wrapper public headers and nested module headers share basenames such as `pb.h` and `pb_common.h`.

Without this fix, Xcode can fail the build with `Multiple commands produce ... nanopb.framework/Headers/pb.h`.

## Validation

- Cherry-picked cleanly onto `releases/4.202.x`.
- Main PR validation is in #11638.
- No further local validation after the backport request.
