### PR TITLE
feat(cli): add generated script file list paths

### DIFF
--- a/cli/Sources/ProjectDescription/TargetScript.swift
+++ b/cli/Sources/ProjectDescription/TargetScript.swift
@@ -23,6 +23,55 @@ public struct TargetScript: Codable, Equatable, Sendable { // swiftlint:disable:
         case embedded(String)
     }
 
+    /// A target script file list path.
+    public enum FileListPath: ExpressibleByStringInterpolation, Codable, Hashable, Sendable {
+        /// File list is already present on disk before building the project.
+        case path(Path)
+
+        /// File list is generated, meaning Tuist creates an empty placeholder during generation.
+        case generated(Path)
+
+        /// File list path.
+        public var path: Path {
+            switch self {
+            case let .path(path), let .generated(path):
+                return path
+            }
+        }
+
+        /// Reference an existing file list path relative to the manifest directory.
+        public static func path(_ pathString: String) -> FileListPath {
+            FileListPath.path(Path.path(pathString))
+        }
+
+        /// Have Tuist create an empty file list placeholder relative to the manifest directory.
+        public static func generated(_ pathString: String) -> FileListPath {
+            FileListPath.generated(Path.relativeToManifest(pathString))
+        }
+
+        /// Reference a file list path relative to the file that defines the path.
+        public static func relativeToCurrentFile(
+            _ pathString: String,
+            callerPath: StaticString = #file
+        ) -> FileListPath {
+            FileListPath.path(Path.relativeToCurrentFile(pathString, callerPath: callerPath))
+        }
+
+        /// Reference a file list path relative to the manifest directory.
+        public static func relativeToManifest(_ pathString: String) -> FileListPath {
+            FileListPath.path(Path.relativeToManifest(pathString))
+        }
+
+        /// Reference a file list path relative to the closest directory that contains a Tuist or a .git directory.
+        public static func relativeToRoot(_ pathString: String) -> FileListPath {
+            FileListPath.path(Path.relativeToRoot(pathString))
+        }
+
+        public init(stringLiteral: String) {
+            self = .path(Path(stringLiteral: stringLiteral))
+        }
+    }
+
     /// Name of the build phase when the project gets generated.
     public var name: String
 
@@ -36,13 +85,13 @@ public struct TargetScript: Codable, Equatable, Sendable { // swiftlint:disable:
     public var inputPaths: [FileListGlob]
 
     /// List of input filelist paths
-    public var inputFileListPaths: [Path]
+    public var inputFileListPaths: [FileListPath]
 
     /// List of output file paths
     public var outputPaths: [Path]
 
     /// List of output filelist paths
-    public var outputFileListPaths: [Path]
+    public var outputFileListPaths: [FileListPath]
 
     /// Whether to skip running this script in incremental builds, if nothing has changed
     public var basedOnDependencyAnalysis: Bool?
@@ -75,9 +124,9 @@ public struct TargetScript: Codable, Equatable, Sendable { // swiftlint:disable:
         script: Script = .embedded(""),
         order: Order,
         inputPaths: [FileListGlob] = [],
-        inputFileListPaths: [Path] = [],
+        inputFileListPaths: [FileListPath] = [],
         outputPaths: [Path] = [],
-        outputFileListPaths: [Path] = [],
+        outputFileListPaths: [FileListPath] = [],
         basedOnDependencyAnalysis: Bool? = nil,
         runForInstallBuildsOnly: Bool = false,
         shellPath: String = "/bin/sh",
@@ -118,9 +167,9 @@ public struct TargetScript: Codable, Equatable, Sendable { // swiftlint:disable:
         arguments: String...,
         name: String,
         inputPaths: [FileListGlob] = [],
-        inputFileListPaths: [Path] = [],
+        inputFileListPaths: [FileListPath] = [],
         outputPaths: [Path] = [],
-        outputFileListPaths: [Path] = [],
+        outputFileListPaths: [FileListPath] = [],
         basedOnDependencyAnalysis: Bool? = nil,
         runForInstallBuildsOnly: Bool = false,
         shellPath: String = "/bin/sh",
@@ -161,9 +210,9 @@ public struct TargetScript: Codable, Equatable, Sendable { // swiftlint:disable:
         arguments: [String],
         name: String,
         inputPaths: [FileListGlob] = [],
-        inputFileListPaths: [Path] = [],
+        inputFileListPaths: [FileListPath] = [],
         outputPaths: [Path] = [],
-        outputFileListPaths: [Path] = [],
+        outputFileListPaths: [FileListPath] = [],
         basedOnDependencyAnalysis: Bool? = nil,
         runForInstallBuildsOnly: Bool = false,
         shellPath: String = "/bin/sh",
@@ -204,9 +253,9 @@ public struct TargetScript: Codable, Equatable, Sendable { // swiftlint:disable:
         arguments: String...,
         name: String,
         inputPaths: [FileListGlob] = [],
-        inputFileListPaths: [Path] = [],
+        inputFileListPaths: [FileListPath] = [],
         outputPaths: [Path] = [],
-        outputFileListPaths: [Path] = [],
+        outputFileListPaths: [FileListPath] = [],
         basedOnDependencyAnalysis: Bool? = nil,
         runForInstallBuildsOnly: Bool = false,
         shellPath: String = "/bin/sh",
@@ -247,9 +296,9 @@ public struct TargetScript: Codable, Equatable, Sendable { // swiftlint:disable:
         arguments: [String],
         name: String,
         inputPaths: [FileListGlob] = [],
-        inputFileListPaths: [Path] = [],
+        inputFileListPaths: [FileListPath] = [],
         outputPaths: [Path] = [],
-        outputFileListPaths: [Path] = [],
+        outputFileListPaths: [FileListPath] = [],
         basedOnDependencyAnalysis: Bool? = nil,
         runForInstallBuildsOnly: Bool = false,
         shellPath: String = "/bin/sh",
@@ -292,9 +341,9 @@ public struct TargetScript: Codable, Equatable, Sendable { // swiftlint:disable:
         arguments: String...,
         name: String,
         inputPaths: [FileListGlob] = [],
-        inputFileListPaths: [Path] = [],
+        inputFileListPaths: [FileListPath] = [],
         outputPaths: [Path] = [],
-        outputFileListPaths: [Path] = [],
+        outputFileListPaths: [FileListPath] = [],
         basedOnDependencyAnalysis: Bool? = nil,
         runForInstallBuildsOnly: Bool = false,
         shellPath: String = "/bin/sh",
@@ -335,9 +384,9 @@ public struct TargetScript: Codable, Equatable, Sendable { // swiftlint:disable:
         arguments: [String],
         name: String,
         inputPaths: [FileListGlob] = [],
-        inputFileListPaths: [Path] = [],
+        inputFileListPaths: [FileListPath] = [],
         outputPaths: [Path] = [],
-        outputFileListPaths: [Path] = [],
+        outputFileListPaths: [FileListPath] = [],
         basedOnDependencyAnalysis: Bool? = nil,
         runForInstallBuildsOnly: Bool = false,
         shellPath: String = "/bin/sh",
@@ -378,9 +427,9 @@ public struct TargetScript: Codable, Equatable, Sendable { // swiftlint:disable:
         arguments: String...,
         name: String,
         inputPaths: [FileListGlob] = [],
-        inputFileListPaths: [Path] = [],
+        inputFileListPaths: [FileListPath] = [],
         outputPaths: [Path] = [],
-        outputFileListPaths: [Path] = [],
+        outputFileListPaths: [FileListPath] = [],
         basedOnDependencyAnalysis: Bool? = nil,
         runForInstallBuildsOnly: Bool = false,
         shellPath: String = "/bin/sh",
@@ -421,9 +470,9 @@ public struct TargetScript: Codable, Equatable, Sendable { // swiftlint:disable:
         arguments: [String],
         name: String,
         inputPaths: [FileListGlob] = [],
-        inputFileListPaths: [Path] = [],
+        inputFileListPaths: [FileListPath] = [],
         outputPaths: [Path] = [],
-        outputFileListPaths: [Path] = [],
+        outputFileListPaths: [FileListPath] = [],
         basedOnDependencyAnalysis: Bool? = nil,
         runForInstallBuildsOnly: Bool = false,
         shellPath: String = "/bin/sh",
@@ -465,9 +514,9 @@ public struct TargetScript: Codable, Equatable, Sendable { // swiftlint:disable:
         script: String,
         name: String,
         inputPaths: [FileListGlob] = [],
-        inputFileListPaths: [Path] = [],
+        inputFileListPaths: [FileListPath] = [],
         outputPaths: [Path] = [],
-        outputFileListPaths: [Path] = [],
+        outputFileListPaths: [FileListPath] = [],
         basedOnDependencyAnalysis: Bool? = nil,
         runForInstallBuildsOnly: Bool = false,
         shellPath: String = "/bin/sh",
@@ -506,9 +555,9 @@ public struct TargetScript: Codable, Equatable, Sendable { // swiftlint:disable:
         script: String,
         name: String,
         inputPaths: [FileListGlob] = [],
-        inputFileListPaths: [Path] = [],
+        inputFileListPaths: [FileListPath] = [],
         outputPaths: [Path] = [],
-        outputFileListPaths: [Path] = [],
+        outputFileListPaths: [FileListPath] = [],
         basedOnDependencyAnalysis: Bool? = nil,
         runForInstallBuildsOnly: Bool = false,
         shellPath: String = "/bin/sh",
@@ -522,6 +571,360 @@ public struct TargetScript: Codable, Equatable, Sendable { // swiftlint:disable:
             inputFileListPaths: inputFileListPaths,
             outputPaths: outputPaths,
             outputFileListPaths: outputFileListPaths,
+            basedOnDependencyAnalysis: basedOnDependencyAnalysis,
+            runForInstallBuildsOnly: runForInstallBuildsOnly,
+            shellPath: shellPath,
+            dependencyFile: dependencyFile
+        )
+    }
+}
+
+extension [Path] {
+    fileprivate var targetScriptFileListPaths: [TargetScript.FileListPath] {
+        map(TargetScript.FileListPath.path)
+    }
+}
+
+extension TargetScript {
+    /// Returns a target script that gets executed before the sources and resources build phase.
+    @_disfavoredOverload
+    @available(
+        *,
+        deprecated,
+        message: "Pass [TargetScript.FileListPath] instead - wrap each path with `.path(...)`, use a string literal, or use `.generated(...)`."
+    )
+    public static func pre(
+        path: Path,
+        arguments: String...,
+        name: String,
+        inputPaths: [FileListGlob] = [],
+        inputFileListPaths: [Path] = [],
+        outputPaths: [Path] = [],
+        outputFileListPaths: [Path] = [],
+        basedOnDependencyAnalysis: Bool? = nil,
+        runForInstallBuildsOnly: Bool = false,
+        shellPath: String = "/bin/sh",
+        dependencyFile: Path? = nil
+    ) -> TargetScript {
+        pre(
+            path: path,
+            arguments: arguments,
+            name: name,
+            inputPaths: inputPaths,
+            inputFileListPaths: inputFileListPaths.targetScriptFileListPaths,
+            outputPaths: outputPaths,
+            outputFileListPaths: outputFileListPaths.targetScriptFileListPaths,
+            basedOnDependencyAnalysis: basedOnDependencyAnalysis,
+            runForInstallBuildsOnly: runForInstallBuildsOnly,
+            shellPath: shellPath,
+            dependencyFile: dependencyFile
+        )
+    }
+
+    /// Returns a target script that gets executed before the sources and resources build phase.
+    @_disfavoredOverload
+    @available(
+        *,
+        deprecated,
+        message: "Pass [TargetScript.FileListPath] instead - wrap each path with `.path(...)`, use a string literal, or use `.generated(...)`."
+    )
+    public static func pre(
+        path: Path,
+        arguments: [String],
+        name: String,
+        inputPaths: [FileListGlob] = [],
+        inputFileListPaths: [Path] = [],
+        outputPaths: [Path] = [],
+        outputFileListPaths: [Path] = [],
+        basedOnDependencyAnalysis: Bool? = nil,
+        runForInstallBuildsOnly: Bool = false,
+        shellPath: String = "/bin/sh",
+        dependencyFile: Path? = nil
+    ) -> TargetScript {
+        pre(
+            path: path,
+            arguments: arguments,
+            name: name,
+            inputPaths: inputPaths,
+            inputFileListPaths: inputFileListPaths.targetScriptFileListPaths,
+            outputPaths: outputPaths,
+            outputFileListPaths: outputFileListPaths.targetScriptFileListPaths,
+            basedOnDependencyAnalysis: basedOnDependencyAnalysis,
+            runForInstallBuildsOnly: runForInstallBuildsOnly,
+            shellPath: shellPath,
+            dependencyFile: dependencyFile
+        )
+    }
+
+    /// Returns a target script that gets executed after the sources and resources build phase.
+    @_disfavoredOverload
+    @available(
+        *,
+        deprecated,
+        message: "Pass [TargetScript.FileListPath] instead - wrap each path with `.path(...)`, use a string literal, or use `.generated(...)`."
+    )
+    public static func post(
+        path: Path,
+        arguments: String...,
+        name: String,
+        inputPaths: [FileListGlob] = [],
+        inputFileListPaths: [Path] = [],
+        outputPaths: [Path] = [],
+        outputFileListPaths: [Path] = [],
+        basedOnDependencyAnalysis: Bool? = nil,
+        runForInstallBuildsOnly: Bool = false,
+        shellPath: String = "/bin/sh",
+        dependencyFile: Path? = nil
+    ) -> TargetScript {
+        post(
+            path: path,
+            arguments: arguments,
+            name: name,
+            inputPaths: inputPaths,
+            inputFileListPaths: inputFileListPaths.targetScriptFileListPaths,
+            outputPaths: outputPaths,
+            outputFileListPaths: outputFileListPaths.targetScriptFileListPaths,
+            basedOnDependencyAnalysis: basedOnDependencyAnalysis,
+            runForInstallBuildsOnly: runForInstallBuildsOnly,
+            shellPath: shellPath,
+            dependencyFile: dependencyFile
+        )
+    }
+
+    /// Returns a target script that gets executed after the sources and resources build phase.
+    @_disfavoredOverload
+    @available(
+        *,
+        deprecated,
+        message: "Pass [TargetScript.FileListPath] instead - wrap each path with `.path(...)`, use a string literal, or use `.generated(...)`."
+    )
+    public static func post(
+        path: Path,
+        arguments: [String],
+        name: String,
+        inputPaths: [FileListGlob] = [],
+        inputFileListPaths: [Path] = [],
+        outputPaths: [Path] = [],
+        outputFileListPaths: [Path] = [],
+        basedOnDependencyAnalysis: Bool? = nil,
+        runForInstallBuildsOnly: Bool = false,
+        shellPath: String = "/bin/sh",
+        dependencyFile: Path? = nil
+    ) -> TargetScript {
+        post(
+            path: path,
+            arguments: arguments,
+            name: name,
+            inputPaths: inputPaths,
+            inputFileListPaths: inputFileListPaths.targetScriptFileListPaths,
+            outputPaths: outputPaths,
+            outputFileListPaths: outputFileListPaths.targetScriptFileListPaths,
+            basedOnDependencyAnalysis: basedOnDependencyAnalysis,
+            runForInstallBuildsOnly: runForInstallBuildsOnly,
+            shellPath: shellPath,
+            dependencyFile: dependencyFile
+        )
+    }
+
+    /// Returns a target script that gets executed before the sources and resources build phase.
+    @_disfavoredOverload
+    @available(
+        *,
+        deprecated,
+        message: "Pass [TargetScript.FileListPath] instead - wrap each path with `.path(...)`, use a string literal, or use `.generated(...)`."
+    )
+    public static func pre(
+        tool: String,
+        arguments: String...,
+        name: String,
+        inputPaths: [FileListGlob] = [],
+        inputFileListPaths: [Path] = [],
+        outputPaths: [Path] = [],
+        outputFileListPaths: [Path] = [],
+        basedOnDependencyAnalysis: Bool? = nil,
+        runForInstallBuildsOnly: Bool = false,
+        shellPath: String = "/bin/sh",
+        dependencyFile: Path? = nil
+    ) -> TargetScript {
+        pre(
+            tool: tool,
+            arguments: arguments,
+            name: name,
+            inputPaths: inputPaths,
+            inputFileListPaths: inputFileListPaths.targetScriptFileListPaths,
+            outputPaths: outputPaths,
+            outputFileListPaths: outputFileListPaths.targetScriptFileListPaths,
+            basedOnDependencyAnalysis: basedOnDependencyAnalysis,
+            runForInstallBuildsOnly: runForInstallBuildsOnly,
+            shellPath: shellPath,
+            dependencyFile: dependencyFile
+        )
+    }
+
+    /// Returns a target script that gets executed before the sources and resources build phase.
+    @_disfavoredOverload
+    @available(
+        *,
+        deprecated,
+        message: "Pass [TargetScript.FileListPath] instead - wrap each path with `.path(...)`, use a string literal, or use `.generated(...)`."
+    )
+    public static func pre(
+        tool: String,
+        arguments: [String],
+        name: String,
+        inputPaths: [FileListGlob] = [],
+        inputFileListPaths: [Path] = [],
+        outputPaths: [Path] = [],
+        outputFileListPaths: [Path] = [],
+        basedOnDependencyAnalysis: Bool? = nil,
+        runForInstallBuildsOnly: Bool = false,
+        shellPath: String = "/bin/sh",
+        dependencyFile: Path? = nil
+    ) -> TargetScript {
+        pre(
+            tool: tool,
+            arguments: arguments,
+            name: name,
+            inputPaths: inputPaths,
+            inputFileListPaths: inputFileListPaths.targetScriptFileListPaths,
+            outputPaths: outputPaths,
+            outputFileListPaths: outputFileListPaths.targetScriptFileListPaths,
+            basedOnDependencyAnalysis: basedOnDependencyAnalysis,
+            runForInstallBuildsOnly: runForInstallBuildsOnly,
+            shellPath: shellPath,
+            dependencyFile: dependencyFile
+        )
+    }
+
+    /// Returns a target script that gets executed after the sources and resources build phase.
+    @_disfavoredOverload
+    @available(
+        *,
+        deprecated,
+        message: "Pass [TargetScript.FileListPath] instead - wrap each path with `.path(...)`, use a string literal, or use `.generated(...)`."
+    )
+    public static func post(
+        tool: String,
+        arguments: String...,
+        name: String,
+        inputPaths: [FileListGlob] = [],
+        inputFileListPaths: [Path] = [],
+        outputPaths: [Path] = [],
+        outputFileListPaths: [Path] = [],
+        basedOnDependencyAnalysis: Bool? = nil,
+        runForInstallBuildsOnly: Bool = false,
+        shellPath: String = "/bin/sh",
+        dependencyFile: Path? = nil
+    ) -> TargetScript {
+        post(
+            tool: tool,
+            arguments: arguments,
+            name: name,
+            inputPaths: inputPaths,
+            inputFileListPaths: inputFileListPaths.targetScriptFileListPaths,
+            outputPaths: outputPaths,
+            outputFileListPaths: outputFileListPaths.targetScriptFileListPaths,
+            basedOnDependencyAnalysis: basedOnDependencyAnalysis,
+            runForInstallBuildsOnly: runForInstallBuildsOnly,
+            shellPath: shellPath,
+            dependencyFile: dependencyFile
+        )
+    }
+
+    /// Returns a target script that gets executed after the sources and resources build phase.
+    @_disfavoredOverload
+    @available(
+        *,
+        deprecated,
+        message: "Pass [TargetScript.FileListPath] instead - wrap each path with `.path(...)`, use a string literal, or use `.generated(...)`."
+    )
+    public static func post(
+        tool: String,
+        arguments: [String],
+        name: String,
+        inputPaths: [FileListGlob] = [],
+        inputFileListPaths: [Path] = [],
+        outputPaths: [Path] = [],
+        outputFileListPaths: [Path] = [],
+        basedOnDependencyAnalysis: Bool? = nil,
+        runForInstallBuildsOnly: Bool = false,
+        shellPath: String = "/bin/sh",
+        dependencyFile: Path? = nil
+    ) -> TargetScript {
+        post(
+            tool: tool,
+            arguments: arguments,
+            name: name,
+            inputPaths: inputPaths,
+            inputFileListPaths: inputFileListPaths.targetScriptFileListPaths,
+            outputPaths: outputPaths,
+            outputFileListPaths: outputFileListPaths.targetScriptFileListPaths,
+            basedOnDependencyAnalysis: basedOnDependencyAnalysis,
+            runForInstallBuildsOnly: runForInstallBuildsOnly,
+            shellPath: shellPath,
+            dependencyFile: dependencyFile
+        )
+    }
+
+    /// Returns a target script that gets executed before the sources and resources build phase.
+    @_disfavoredOverload
+    @available(
+        *,
+        deprecated,
+        message: "Pass [TargetScript.FileListPath] instead - wrap each path with `.path(...)`, use a string literal, or use `.generated(...)`."
+    )
+    public static func pre(
+        script: String,
+        name: String,
+        inputPaths: [FileListGlob] = [],
+        inputFileListPaths: [Path] = [],
+        outputPaths: [Path] = [],
+        outputFileListPaths: [Path] = [],
+        basedOnDependencyAnalysis: Bool? = nil,
+        runForInstallBuildsOnly: Bool = false,
+        shellPath: String = "/bin/sh",
+        dependencyFile: Path? = nil
+    ) -> TargetScript {
+        pre(
+            script: script,
+            name: name,
+            inputPaths: inputPaths,
+            inputFileListPaths: inputFileListPaths.targetScriptFileListPaths,
+            outputPaths: outputPaths,
+            outputFileListPaths: outputFileListPaths.targetScriptFileListPaths,
+            basedOnDependencyAnalysis: basedOnDependencyAnalysis,
+            runForInstallBuildsOnly: runForInstallBuildsOnly,
+            shellPath: shellPath,
+            dependencyFile: dependencyFile
+        )
+    }
+
+    /// Returns a target script that gets executed after the sources and resources build phase.
+    @_disfavoredOverload
+    @available(
+        *,
+        deprecated,
+        message: "Pass [TargetScript.FileListPath] instead - wrap each path with `.path(...)`, use a string literal, or use `.generated(...)`."
+    )
+    public static func post(
+        script: String,
+        name: String,
+        inputPaths: [FileListGlob] = [],
+        inputFileListPaths: [Path] = [],
+        outputPaths: [Path] = [],
+        outputFileListPaths: [Path] = [],
+        basedOnDependencyAnalysis: Bool? = nil,
+        runForInstallBuildsOnly: Bool = false,
+        shellPath: String = "/bin/sh",
+        dependencyFile: Path? = nil
+    ) -> TargetScript {
+        post(
+            script: script,
+            name: name,
+            inputPaths: inputPaths,
+            inputFileListPaths: inputFileListPaths.targetScriptFileListPaths,
+            outputPaths: outputPaths,
+            outputFileListPaths: outputFileListPaths.targetScriptFileListPaths,
             basedOnDependencyAnalysis: basedOnDependencyAnalysis,
             runForInstallBuildsOnly: runForInstallBuildsOnly,
             shellPath: shellPath,

--- a/cli/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
+++ b/cli/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
@@ -225,8 +225,8 @@ struct BuildPhaseGenerator: BuildPhaseGenerating {
                     .map {
                         (try? AbsolutePath(validating: $0))?.relative(to: sourceRootPath).pathString ?? $0
                     },
-                inputFileListPaths: script.inputFileListPaths,
-                outputFileListPaths: script.outputFileListPaths,
+                inputFileListPaths: script.inputFileListPaths.map(\.path),
+                outputFileListPaths: script.outputFileListPaths.map(\.path),
                 shellPath: script.shellPath,
                 shellScript: try await script.shellScript(sourceRootPath: sourceRootPath),
                 runOnlyForDeploymentPostprocessing: script.runForInstallBuildsOnly,

--- a/cli/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
+++ b/cli/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
@@ -225,8 +225,8 @@ struct BuildPhaseGenerator: BuildPhaseGenerating {
                     .map {
                         (try? AbsolutePath(validating: $0))?.relative(to: sourceRootPath).pathString ?? $0
                     },
-                inputFileListPaths: script.inputFileListPaths.map(\.path),
-                outputFileListPaths: script.outputFileListPaths.map(\.path),
+                inputFileListPaths: script.inputFileListPaths.map { $0.xcodePath(sourceRootPath: sourceRootPath) },
+                outputFileListPaths: script.outputFileListPaths.map { $0.xcodePath(sourceRootPath: sourceRootPath) },
                 shellPath: script.shellPath,
                 shellScript: try await script.shellScript(sourceRootPath: sourceRootPath),
                 runOnlyForDeploymentPostprocessing: script.runForInstallBuildsOnly,

--- a/cli/Sources/TuistGenerator/Mappers/GenerateTargetScriptFileListProjectMapper.swift
+++ b/cli/Sources/TuistGenerator/Mappers/GenerateTargetScriptFileListProjectMapper.swift
@@ -1,0 +1,28 @@
+import Path
+import TuistCore
+import TuistLogging
+import XcodeGraph
+
+/// A project mapper that creates generated target script file lists.
+public struct GenerateTargetScriptFileListProjectMapper: ProjectMapping {
+    public init() {}
+
+    public func map(project: Project) throws -> (Project, [SideEffectDescriptor]) {
+        Logger.current.debug("Transforming project \(project.name): Generating target script file lists")
+
+        let fileListPaths = project.targets.values
+            .flatMap(\.scripts)
+            .flatMap { $0.inputFileListPaths + $0.outputFileListPaths }
+            .compactMap(\.generatedPlaceholderPath)
+            .reduce(into: [AbsolutePath]()) { paths, path in
+                if !paths.contains(path) {
+                    paths.append(path)
+                }
+            }
+
+        return (
+            project,
+            fileListPaths.map { SideEffectDescriptor.file(FileDescriptor(path: $0)) }
+        )
+    }
+}

--- a/cli/Sources/TuistGenerator/Mappers/GenerateTargetScriptFileListProjectMapper.swift
+++ b/cli/Sources/TuistGenerator/Mappers/GenerateTargetScriptFileListProjectMapper.swift
@@ -13,7 +13,12 @@ public struct GenerateTargetScriptFileListProjectMapper: ProjectMapping {
         let fileListPaths = project.targets.values
             .flatMap(\.scripts)
             .flatMap { $0.inputFileListPaths + $0.outputFileListPaths }
-            .compactMap(\.generatedPlaceholderPath)
+            .compactMap { fileListPath in
+                if case let .generated(path) = fileListPath {
+                    return path
+                }
+                return nil
+            }
             .reduce(into: [AbsolutePath]()) { paths, path in
                 if !paths.contains(path) {
                     paths.append(path)

--- a/cli/Sources/TuistHasher/TargetScriptsContentHasher.swift
+++ b/cli/Sources/TuistHasher/TargetScriptsContentHasher.swift
@@ -33,8 +33,24 @@ public struct TargetScriptsContentHasher: TargetScriptsContentHashing {
             var pathsToHash: [AbsolutePath] = []
             script.path.map { pathsToHash.append($0) }
 
+            let inputFileListPaths = script.inputFileListPaths.compactMap { fileListPath -> String? in
+                switch fileListPath {
+                case let .path(path):
+                    return path
+                case .generated:
+                    return nil
+                }
+            }
+            let generatedInputFileListPathStrings = script.inputFileListPaths.compactMap { fileListPath -> String? in
+                switch fileListPath {
+                case .path:
+                    return nil
+                case let .generated(path):
+                    return path.relative(to: sourceRootPath).pathString
+                }
+            }
             var dynamicPaths = resolvePathStrings(
-                script.inputPaths + script.inputFileListPaths.map(\.path),
+                script.inputPaths + inputFileListPaths,
                 sourceRootPath: sourceRootPath
             )
             .sorted()
@@ -52,13 +68,14 @@ public struct TargetScriptsContentHasher: TargetScriptsContentHashing {
                     pathsToHash.append(path)
                 }
             }
-            stringsToHash.append(contentsOf: try await pathsToHash.concurrentMap {
+            let inputPathHashes = try await pathsToHash.concurrentMap {
                 do {
                     return try await contentHasher.hash(path: $0)
                 } catch ContentHashingError.fileHashingFailed {
                     return $0.relative(to: sourceRootPath).pathString
                 }
-            }.sorted())
+            }
+            stringsToHash.append(contentsOf: (generatedInputFileListPathStrings + inputPathHashes).sorted())
             stringsToHash.append(
                 contentsOf: resolvePathStrings(
                     script.outputPaths + script.outputFileListPaths.map(\.path),

--- a/cli/Sources/TuistHasher/TargetScriptsContentHasher.swift
+++ b/cli/Sources/TuistHasher/TargetScriptsContentHasher.swift
@@ -33,8 +33,11 @@ public struct TargetScriptsContentHasher: TargetScriptsContentHashing {
             var pathsToHash: [AbsolutePath] = []
             script.path.map { pathsToHash.append($0) }
 
-            var dynamicPaths = resolvePathStrings(script.inputPaths + script.inputFileListPaths, sourceRootPath: sourceRootPath)
-                .sorted()
+            var dynamicPaths = resolvePathStrings(
+                script.inputPaths + script.inputFileListPaths.map(\.path),
+                sourceRootPath: sourceRootPath
+            )
+            .sorted()
             if let dependencyFile = script.dependencyFile {
                 dynamicPaths += [dependencyFile]
             }
@@ -57,8 +60,11 @@ public struct TargetScriptsContentHasher: TargetScriptsContentHashing {
                 }
             }.sorted())
             stringsToHash.append(
-                contentsOf: resolvePathStrings(script.outputPaths + script.outputFileListPaths, sourceRootPath: sourceRootPath)
-                    .map { $0.relative(to: sourceRootPath).pathString }
+                contentsOf: resolvePathStrings(
+                    script.outputPaths + script.outputFileListPaths.map(\.path),
+                    sourceRootPath: sourceRootPath
+                )
+                .map { $0.relative(to: sourceRootPath).pathString }
             )
 
             if let embeddedScript = script.embeddedScript {

--- a/cli/Sources/TuistKit/Mappers/Factories/ProjectMapperFactory.swift
+++ b/cli/Sources/TuistKit/Mappers/Factories/ProjectMapperFactory.swift
@@ -65,6 +65,9 @@ public struct ProjectMapperFactory: ProjectMapperFactorying {
         // Delete current derived
         mappers.append(DeleteDerivedDirectoryProjectMapper())
 
+        // Target script file lists
+        mappers.append(GenerateTargetScriptFileListProjectMapper())
+
         // Namespace generator
         mappers.append(
             SynthesizedResourceInterfaceProjectMapper(

--- a/cli/Sources/TuistLoader/Models+ManifestMappers/TargetAction+ManifestMapper.swift
+++ b/cli/Sources/TuistLoader/Models+ManifestMappers/TargetAction+ManifestMapper.swift
@@ -3,8 +3,22 @@ import Foundation
 import Path
 import ProjectDescription
 import TuistCore
+import TuistLogging
 import TuistSupport
 import XcodeGraph
+
+enum TargetScriptManifestMapperError: FatalError, Equatable {
+    case invalidGeneratedFileListPath(String)
+
+    var type: ErrorType { .abort }
+
+    var description: String {
+        switch self {
+        case let .invalidGeneratedFileListPath(path):
+            return "Generated file list paths must be relative to the manifest directory and cannot escape it: \(path)"
+        }
+    }
+}
 
 extension XcodeGraph.TargetScript {
     /// Maps a ProjectDescription.TargetAction instance into a XcodeGraph.TargetAction model.
@@ -168,7 +182,7 @@ extension XcodeGraph.TargetScript {
         try await paths.concurrentMap { fileListPath -> [XcodeGraph.TargetScript.FileListPath] in
             switch fileListPath {
             case let .generated(path):
-                return [.generated(try generatorPaths.resolve(path: path))]
+                return [.generated(try generatedFileListPath(path, generatorPaths: generatorPaths))]
 
             case .path:
                 return try await resolvePathStrings(
@@ -179,6 +193,20 @@ extension XcodeGraph.TargetScript {
                 .map(XcodeGraph.TargetScript.FileListPath.path)
             }
         }.reduce([], +)
+    }
+
+    private static func generatedFileListPath(
+        _ path: Path,
+        generatorPaths: GeneratorPaths
+    ) throws -> AbsolutePath {
+        guard path.type == .relativeToManifest,
+              !path.pathString.hasPrefix("/"),
+              !path.pathString.split(separator: "/").contains("..")
+        else {
+            throw TargetScriptManifestMapperError.invalidGeneratedFileListPath(path.pathString)
+        }
+
+        return try generatorPaths.resolve(path: path)
     }
 }
 

--- a/cli/Sources/TuistLoader/Models+ManifestMappers/TargetAction+ManifestMapper.swift
+++ b/cli/Sources/TuistLoader/Models+ManifestMappers/TargetAction+ManifestMapper.swift
@@ -166,25 +166,17 @@ extension XcodeGraph.TargetScript {
         fileSystem: FileSysteming
     ) async throws -> [XcodeGraph.TargetScript.FileListPath] {
         try await paths.concurrentMap { fileListPath -> [XcodeGraph.TargetScript.FileListPath] in
-            let paths = try await resolvePathStrings(
-                path: fileListPath.path,
-                generatorPaths: generatorPaths,
-                fileSystem: fileSystem
-            )
-
-            let generatedPlaceholderPath: AbsolutePath?
             switch fileListPath {
             case let .generated(path):
-                generatedPlaceholderPath = try generatorPaths.resolve(path: path)
-            case .path:
-                generatedPlaceholderPath = nil
-            }
+                return [.generated(try generatorPaths.resolve(path: path))]
 
-            return paths.map {
-                XcodeGraph.TargetScript.FileListPath(
-                    path: $0,
-                    generatedPlaceholderPath: generatedPlaceholderPath
+            case .path:
+                return try await resolvePathStrings(
+                    path: fileListPath.path,
+                    generatorPaths: generatorPaths,
+                    fileSystem: fileSystem
                 )
+                .map(XcodeGraph.TargetScript.FileListPath.path)
             }
         }.reduce([], +)
     }

--- a/cli/Sources/TuistLoader/Models+ManifestMappers/TargetAction+ManifestMapper.swift
+++ b/cli/Sources/TuistLoader/Models+ManifestMappers/TargetAction+ManifestMapper.swift
@@ -25,7 +25,7 @@ extension XcodeGraph.TargetScript {
             generatorPaths: generatorPaths,
             fileSystem: fileSystem
         )
-        let inputFileListPaths = try await pathStrings(
+        let inputFileListPaths = try await fileListPaths(
             for: manifest.inputFileListPaths,
             generatorPaths: generatorPaths,
             fileSystem: fileSystem
@@ -35,7 +35,7 @@ extension XcodeGraph.TargetScript {
             generatorPaths: generatorPaths,
             fileSystem: fileSystem
         )
-        let outputFileListPaths = try await pathStrings(
+        let outputFileListPaths = try await fileListPaths(
             for: manifest.outputFileListPaths,
             generatorPaths: generatorPaths,
             fileSystem: fileSystem
@@ -130,7 +130,7 @@ extension XcodeGraph.TargetScript {
         generatorPaths: GeneratorPaths,
         fileSystem: FileSysteming
     ) async throws -> [String] {
-        // For relativeToManifest paths that are not glob patterns, keep them as strings
+        // For manifest-relative paths that are not glob patterns, keep them as strings
         if path.type == .relativeToManifest, !fileSystem.isGlobPattern(path) {
             return [path.pathString]
         }
@@ -152,12 +152,41 @@ extension XcodeGraph.TargetScript {
         let base = try AbsolutePath(validating: absolutePath.dirname)
         let globResults = try await fileSystem.glob(directory: base, include: [absolutePath.basename]).collect()
 
-        // For relativeToManifest paths, convert back to relative paths
+        // For manifest-relative paths, convert back to relative paths
         if path.type == .relativeToManifest {
             return globResults.map { $0.relative(to: generatorPaths.manifestDirectory).pathString }
         } else {
             return globResults.map(\.pathString)
         }
+    }
+
+    private static func fileListPaths(
+        for paths: [ProjectDescription.TargetScript.FileListPath],
+        generatorPaths: GeneratorPaths,
+        fileSystem: FileSysteming
+    ) async throws -> [XcodeGraph.TargetScript.FileListPath] {
+        try await paths.concurrentMap { fileListPath -> [XcodeGraph.TargetScript.FileListPath] in
+            let paths = try await resolvePathStrings(
+                path: fileListPath.path,
+                generatorPaths: generatorPaths,
+                fileSystem: fileSystem
+            )
+
+            let generatedPlaceholderPath: AbsolutePath?
+            switch fileListPath {
+            case let .generated(path):
+                generatedPlaceholderPath = try generatorPaths.resolve(path: path)
+            case .path:
+                generatedPlaceholderPath = nil
+            }
+
+            return paths.map {
+                XcodeGraph.TargetScript.FileListPath(
+                    path: $0,
+                    generatedPlaceholderPath: generatedPlaceholderPath
+                )
+            }
+        }.reduce([], +)
     }
 }
 

--- a/cli/Sources/TuistLoader/Utils/ProjectDescription+TestData.swift
+++ b/cli/Sources/TuistLoader/Utils/ProjectDescription+TestData.swift
@@ -120,9 +120,9 @@ import TuistSupport
             order: Order = .pre,
             arguments: [String] = [],
             inputPaths: [FileListGlob] = [],
-            inputFileListPaths: [Path] = [],
+            inputFileListPaths: [TargetScript.FileListPath] = [],
             outputPaths: [Path] = [],
-            outputFileListPaths: [Path] = [],
+            outputFileListPaths: [TargetScript.FileListPath] = [],
             dependencyFile: Path? = nil
         ) -> TargetScript {
             TargetScript(

--- a/cli/Sources/XcodeGraph/Sources/XcodeGraph/Models/TargetScript.swift
+++ b/cli/Sources/XcodeGraph/Sources/XcodeGraph/Models/TargetScript.swift
@@ -57,43 +57,6 @@ public struct TargetScript: Equatable, Codable, Sendable {
                 return path.relative(to: sourceRootPath).pathString
             }
         }
-
-        public init(from decoder: Decoder) throws {
-            if let path = try? decoder.singleValueContainer().decode(String.self) {
-                self = .path(path)
-                return
-            }
-
-            let container = try decoder.container(keyedBy: CodingKeys.self)
-            if let generatedPath = try container.decodeIfPresent(AbsolutePath.self, forKey: .generated) {
-                self = .generated(generatedPath)
-            } else if let path = try? container.decode(String.self, forKey: .path) {
-                self = .path(path)
-            } else {
-                throw DecodingError.dataCorrupted(
-                    .init(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Expected a file list path string or generated path."
-                    )
-                )
-            }
-        }
-
-        public func encode(to encoder: Encoder) throws {
-            switch self {
-            case let .path(path):
-                var container = encoder.singleValueContainer()
-                try container.encode(path)
-            case let .generated(path):
-                var container = encoder.container(keyedBy: CodingKeys.self)
-                try container.encode(path, forKey: .generated)
-            }
-        }
-
-        private enum CodingKeys: String, CodingKey {
-            case path
-            case generated
-        }
     }
 
     /// Name of the build phase when the project gets generated

--- a/cli/Sources/XcodeGraph/Sources/XcodeGraph/Models/TargetScript.swift
+++ b/cli/Sources/XcodeGraph/Sources/XcodeGraph/Models/TargetScript.swift
@@ -24,43 +24,75 @@ public struct TargetScript: Equatable, Codable, Sendable {
     }
 
     /// A script input or output file-list path.
-    public struct FileListPath: Equatable, Codable, Sendable, ExpressibleByStringLiteral {
-        /// Path passed to Xcode for the file list.
-        public let path: String
+    public enum FileListPath: Equatable, Codable, Sendable, ExpressibleByStringLiteral {
+        /// File list path passed through as-is.
+        case path(String)
 
-        /// Absolute path Tuist should touch during generation if this is a generated file list.
-        public let generatedPlaceholderPath: AbsolutePath?
+        /// File list Tuist creates as an empty placeholder during generation.
+        case generated(AbsolutePath)
 
-        public init(
-            path: String,
-            generatedPlaceholderPath: AbsolutePath? = nil
-        ) {
-            self.path = path
-            self.generatedPlaceholderPath = generatedPlaceholderPath
+        /// Path used for hashing and import/export boundaries.
+        public var path: String {
+            switch self {
+            case let .path(path):
+                return path
+            case let .generated(path):
+                return path.pathString
+            }
+        }
+
+        public init(path: String) {
+            self = .path(path)
         }
 
         public init(stringLiteral value: String) {
-            path = value
-            generatedPlaceholderPath = nil
+            self = .path(value)
+        }
+
+        public func xcodePath(sourceRootPath: AbsolutePath) -> String {
+            switch self {
+            case let .path(path):
+                return path
+            case let .generated(path):
+                return path.relative(to: sourceRootPath).pathString
+            }
         }
 
         public init(from decoder: Decoder) throws {
             if let path = try? decoder.singleValueContainer().decode(String.self) {
-                self.path = path
-                generatedPlaceholderPath = nil
+                self = .path(path)
+                return
+            }
+
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            if let generatedPath = try container.decodeIfPresent(AbsolutePath.self, forKey: .generated) {
+                self = .generated(generatedPath)
+            } else if let path = try? container.decode(String.self, forKey: .path) {
+                self = .path(path)
             } else {
-                let container = try decoder.container(keyedBy: CodingKeys.self)
-                path = try container.decode(String.self, forKey: .path)
-                generatedPlaceholderPath = try container.decodeIfPresent(
-                    AbsolutePath.self,
-                    forKey: .generatedPlaceholderPath
+                throw DecodingError.dataCorrupted(
+                    .init(
+                        codingPath: decoder.codingPath,
+                        debugDescription: "Expected a file list path string or generated path."
+                    )
                 )
+            }
+        }
+
+        public func encode(to encoder: Encoder) throws {
+            switch self {
+            case let .path(path):
+                var container = encoder.singleValueContainer()
+                try container.encode(path)
+            case let .generated(path):
+                var container = encoder.container(keyedBy: CodingKeys.self)
+                try container.encode(path, forKey: .generated)
             }
         }
 
         private enum CodingKeys: String, CodingKey {
             case path
-            case generatedPlaceholderPath
+            case generated
         }
     }
 

--- a/cli/Sources/XcodeGraph/Sources/XcodeGraph/Models/TargetScript.swift
+++ b/cli/Sources/XcodeGraph/Sources/XcodeGraph/Models/TargetScript.swift
@@ -23,6 +23,47 @@ public struct TargetScript: Equatable, Codable, Sendable {
         case embedded(String)
     }
 
+    /// A script input or output file-list path.
+    public struct FileListPath: Equatable, Codable, Sendable, ExpressibleByStringLiteral {
+        /// Path passed to Xcode for the file list.
+        public let path: String
+
+        /// Absolute path Tuist should touch during generation if this is a generated file list.
+        public let generatedPlaceholderPath: AbsolutePath?
+
+        public init(
+            path: String,
+            generatedPlaceholderPath: AbsolutePath? = nil
+        ) {
+            self.path = path
+            self.generatedPlaceholderPath = generatedPlaceholderPath
+        }
+
+        public init(stringLiteral value: String) {
+            path = value
+            generatedPlaceholderPath = nil
+        }
+
+        public init(from decoder: Decoder) throws {
+            if let path = try? decoder.singleValueContainer().decode(String.self) {
+                self.path = path
+                generatedPlaceholderPath = nil
+            } else {
+                let container = try decoder.container(keyedBy: CodingKeys.self)
+                path = try container.decode(String.self, forKey: .path)
+                generatedPlaceholderPath = try container.decodeIfPresent(
+                    AbsolutePath.self,
+                    forKey: .generatedPlaceholderPath
+                )
+            }
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case path
+            case generatedPlaceholderPath
+        }
+    }
+
     /// Name of the build phase when the project gets generated
     public let name: String
 
@@ -74,13 +115,13 @@ public struct TargetScript: Equatable, Codable, Sendable {
     public let inputPaths: [String]
 
     /// List of input filelist paths
-    public let inputFileListPaths: [String]
+    public let inputFileListPaths: [FileListPath]
 
     /// List of output file paths
     public let outputPaths: [String]
 
     /// List of output filelist paths
-    public let outputFileListPaths: [String]
+    public let outputFileListPaths: [FileListPath]
 
     /// Show environment variables in the logs
     public var showEnvVarsInLog: Bool
@@ -117,9 +158,9 @@ public struct TargetScript: Equatable, Codable, Sendable {
         order: Order,
         script: Script = .embedded(""),
         inputPaths: [String] = [],
-        inputFileListPaths: [String] = [],
+        inputFileListPaths: [FileListPath] = [],
         outputPaths: [String] = [],
-        outputFileListPaths: [String] = [],
+        outputFileListPaths: [FileListPath] = [],
         showEnvVarsInLog: Bool = true,
         basedOnDependencyAnalysis: Bool? = nil,
         runForInstallBuildsOnly: Bool = false,
@@ -138,6 +179,38 @@ public struct TargetScript: Equatable, Codable, Sendable {
         self.runForInstallBuildsOnly = runForInstallBuildsOnly
         self.shellPath = shellPath
         self.dependencyFile = dependencyFile
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        name = try container.decode(String.self, forKey: .name)
+        script = try container.decode(Script.self, forKey: .script)
+        order = try container.decode(Order.self, forKey: .order)
+        inputPaths = try container.decode([String].self, forKey: .inputPaths)
+        inputFileListPaths = try container.decode([FileListPath].self, forKey: .inputFileListPaths)
+        outputPaths = try container.decode([String].self, forKey: .outputPaths)
+        outputFileListPaths = try container.decode([FileListPath].self, forKey: .outputFileListPaths)
+        showEnvVarsInLog = try container.decode(Bool.self, forKey: .showEnvVarsInLog)
+        basedOnDependencyAnalysis = try container.decodeIfPresent(Bool.self, forKey: .basedOnDependencyAnalysis)
+        runForInstallBuildsOnly = try container.decode(Bool.self, forKey: .runForInstallBuildsOnly)
+        shellPath = try container.decode(String.self, forKey: .shellPath)
+        dependencyFile = try container.decodeIfPresent(AbsolutePath.self, forKey: .dependencyFile)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case name
+        case script
+        case order
+        case inputPaths
+        case inputFileListPaths
+        case outputPaths
+        case outputFileListPaths
+        case showEnvVarsInLog
+        case basedOnDependencyAnalysis
+        case runForInstallBuildsOnly
+        case shellPath
+        case dependencyFile
     }
 }
 

--- a/cli/Sources/XcodeGraph/Sources/XcodeGraph/Models/TargetScript.swift
+++ b/cli/Sources/XcodeGraph/Sources/XcodeGraph/Models/TargetScript.swift
@@ -175,38 +175,6 @@ public struct TargetScript: Equatable, Codable, Sendable {
         self.shellPath = shellPath
         self.dependencyFile = dependencyFile
     }
-
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-
-        name = try container.decode(String.self, forKey: .name)
-        script = try container.decode(Script.self, forKey: .script)
-        order = try container.decode(Order.self, forKey: .order)
-        inputPaths = try container.decode([String].self, forKey: .inputPaths)
-        inputFileListPaths = try container.decode([FileListPath].self, forKey: .inputFileListPaths)
-        outputPaths = try container.decode([String].self, forKey: .outputPaths)
-        outputFileListPaths = try container.decode([FileListPath].self, forKey: .outputFileListPaths)
-        showEnvVarsInLog = try container.decode(Bool.self, forKey: .showEnvVarsInLog)
-        basedOnDependencyAnalysis = try container.decodeIfPresent(Bool.self, forKey: .basedOnDependencyAnalysis)
-        runForInstallBuildsOnly = try container.decode(Bool.self, forKey: .runForInstallBuildsOnly)
-        shellPath = try container.decode(String.self, forKey: .shellPath)
-        dependencyFile = try container.decodeIfPresent(AbsolutePath.self, forKey: .dependencyFile)
-    }
-
-    private enum CodingKeys: String, CodingKey {
-        case name
-        case script
-        case order
-        case inputPaths
-        case inputFileListPaths
-        case outputPaths
-        case outputFileListPaths
-        case showEnvVarsInLog
-        case basedOnDependencyAnalysis
-        case runForInstallBuildsOnly
-        case shellPath
-        case dependencyFile
-    }
 }
 
 extension [TargetScript] {

--- a/cli/Sources/XcodeGraph/Sources/XcodeGraphMapper/Mappers/Phases/PBXScriptsBuildPhaseMapper.swift
+++ b/cli/Sources/XcodeGraph/Sources/XcodeGraphMapper/Mappers/Phases/PBXScriptsBuildPhaseMapper.swift
@@ -59,9 +59,11 @@ struct PBXScriptsBuildPhaseMapper: PBXScriptsBuildPhaseMapping {
             order: determineScriptOrder(buildPhases: buildPhases, scriptPhase: scriptPhase),
             script: .embedded(shellScript),
             inputPaths: scriptPhase.inputPaths,
-            inputFileListPaths: scriptPhase.inputFileListPaths ?? [],
+            inputFileListPaths: (scriptPhase.inputFileListPaths ?? [])
+                .map { TargetScript.FileListPath(path: $0) },
             outputPaths: scriptPhase.outputPaths,
-            outputFileListPaths: scriptPhase.outputFileListPaths ?? [],
+            outputFileListPaths: (scriptPhase.outputFileListPaths ?? [])
+                .map { TargetScript.FileListPath(path: $0) },
             showEnvVarsInLog: scriptPhase.showEnvVarsInLog,
             basedOnDependencyAnalysis: scriptPhase.alwaysOutOfDate ? false : nil,
             runForInstallBuildsOnly: scriptPhase.runOnlyForDeploymentPostprocessing,

--- a/cli/Tests/ProjectDescriptionTests/TargetScriptTests.swift
+++ b/cli/Tests/ProjectDescriptionTests/TargetScriptTests.swift
@@ -1,13 +1,38 @@
 import Foundation
 import TuistSupportTesting
 import XCTest
-
 @testable import ProjectDescription
 
 final class TargetScriptTests: XCTestCase {
     func test_toJSON_whenPath() {
         let subject = TargetScript.post(path: "path", arguments: ["arg"], name: "name")
         XCTAssertCodable(subject)
+    }
+
+    func test_toJSON_whenGeneratedInputFileListPath() {
+        let subject = TargetScript.post(
+            path: "path",
+            arguments: ["arg"],
+            name: "name",
+            inputFileListPaths: [
+                "ExistingInputs.xcfilelist",
+                .generated("SourceryInputs.xcfilelist"),
+            ]
+        )
+        XCTAssertCodable(subject)
+    }
+
+    func test_fileListPath_whenStringLiteral() {
+        let subject: TargetScript.FileListPath = "Inputs.xcfilelist"
+
+        XCTAssertEqual(subject, .path("Inputs.xcfilelist"))
+    }
+
+    func test_fileListPath_whenGeneratedString() {
+        let subject = TargetScript.FileListPath.generated("SourceryInputs.xcfilelist")
+
+        XCTAssertEqual(subject, .generated(.relativeToManifest("SourceryInputs.xcfilelist")))
+        XCTAssertEqual(subject.path, .relativeToManifest("SourceryInputs.xcfilelist"))
     }
 
     func test_toJSON_whenTool() {

--- a/cli/Tests/TuistGeneratorTests/Generator/BuildPhaseGeneratorTests.swift
+++ b/cli/Tests/TuistGeneratorTests/Generator/BuildPhaseGeneratorTests.swift
@@ -1803,6 +1803,12 @@ struct BuildPhaseGeneratorTests {
                     name: "post",
                     order: .post,
                     script: .scriptPath(path: path.appending(component: "script.sh"), args: ["arg"]),
+                    inputFileListPaths: [
+                        .generated(path.appending(components: "Generated", "Inputs.xcfilelist")),
+                    ],
+                    outputFileListPaths: [
+                        .generated(path.appending(components: "Generated", "Outputs.xcfilelist")),
+                    ],
                     showEnvVarsInLog: false,
                     basedOnDependencyAnalysis: false,
                     runForInstallBuildsOnly: true
@@ -1856,6 +1862,8 @@ struct BuildPhaseGeneratorTests {
         #expect(postBuildPhase.name == "post")
         #expect(postBuildPhase.shellPath == "/bin/sh")
         #expect(postBuildPhase.shellScript == "\"$SRCROOT\"/script.sh arg")
+        #expect(postBuildPhase.inputFileListPaths == ["Generated/Inputs.xcfilelist"])
+        #expect(postBuildPhase.outputFileListPaths == ["Generated/Outputs.xcfilelist"])
         #expect(postBuildPhase.showEnvVarsInLog == false)
         #expect(postBuildPhase.alwaysOutOfDate == true)
         #expect(postBuildPhase.runOnlyForDeploymentPostprocessing == true)

--- a/cli/Tests/TuistGeneratorTests/ProjectMappers/GenerateTargetScriptFileListProjectMapperTests.swift
+++ b/cli/Tests/TuistGeneratorTests/ProjectMappers/GenerateTargetScriptFileListProjectMapperTests.swift
@@ -1,12 +1,12 @@
 import Path
+import Testing
 import TuistCore
 import XcodeGraph
-import XCTest
 @testable import TuistGenerator
-@testable import TuistTesting
 
-final class GenerateTargetScriptFileListProjectMapperTests: TuistUnitTestCase {
-    func test_map_returns_sideEffectsToCreateGeneratedFileLists() throws {
+struct GenerateTargetScriptFileListProjectMapperTests {
+    @Test
+    func map_returns_sideEffectsToCreateGeneratedFileLists() throws {
         // Given
         let subject = GenerateTargetScriptFileListProjectMapper()
         let fileListPath = try AbsolutePath(validating: "/Project/SourceryInputs.xcfilelist")
@@ -35,10 +35,9 @@ final class GenerateTargetScriptFileListProjectMapperTests: TuistUnitTestCase {
         let (mappedProject, sideEffects) = try subject.map(project: project)
 
         // Then
-        XCTAssertEqual(mappedProject, project)
-        XCTAssertEqual(
-            sideEffects,
-            [
+        #expect(mappedProject == project)
+        #expect(
+            sideEffects == [
                 .file(FileDescriptor(path: fileListPath)),
                 .file(FileDescriptor(path: nestedFileListPath)),
             ]

--- a/cli/Tests/TuistGeneratorTests/ProjectMappers/GenerateTargetScriptFileListProjectMapperTests.swift
+++ b/cli/Tests/TuistGeneratorTests/ProjectMappers/GenerateTargetScriptFileListProjectMapperTests.swift
@@ -15,17 +15,17 @@ final class GenerateTargetScriptFileListProjectMapperTests: TuistUnitTestCase {
             name: "Script A",
             order: .pre,
             inputFileListPaths: [
-                .init(path: "SourceryInputs.xcfilelist", generatedPlaceholderPath: fileListPath),
+                .generated(fileListPath),
             ],
             outputFileListPaths: [
-                .init(path: "Generated/Outputs.xcfilelist", generatedPlaceholderPath: nestedFileListPath),
+                .generated(nestedFileListPath),
             ]
         )
         let scriptB = TargetScript(
             name: "Script B",
             order: .post,
             inputFileListPaths: [
-                .init(path: "SourceryInputs.xcfilelist", generatedPlaceholderPath: fileListPath),
+                .generated(fileListPath),
             ]
         )
         let target = Target.test(name: "A", scripts: [scriptA, scriptB])

--- a/cli/Tests/TuistGeneratorTests/ProjectMappers/GenerateTargetScriptFileListProjectMapperTests.swift
+++ b/cli/Tests/TuistGeneratorTests/ProjectMappers/GenerateTargetScriptFileListProjectMapperTests.swift
@@ -1,0 +1,47 @@
+import Path
+import TuistCore
+import XcodeGraph
+import XCTest
+@testable import TuistGenerator
+@testable import TuistTesting
+
+final class GenerateTargetScriptFileListProjectMapperTests: TuistUnitTestCase {
+    func test_map_returns_sideEffectsToCreateGeneratedFileLists() throws {
+        // Given
+        let subject = GenerateTargetScriptFileListProjectMapper()
+        let fileListPath = try AbsolutePath(validating: "/Project/SourceryInputs.xcfilelist")
+        let nestedFileListPath = try AbsolutePath(validating: "/Project/Generated/Outputs.xcfilelist")
+        let scriptA = TargetScript(
+            name: "Script A",
+            order: .pre,
+            inputFileListPaths: [
+                .init(path: "SourceryInputs.xcfilelist", generatedPlaceholderPath: fileListPath),
+            ],
+            outputFileListPaths: [
+                .init(path: "Generated/Outputs.xcfilelist", generatedPlaceholderPath: nestedFileListPath),
+            ]
+        )
+        let scriptB = TargetScript(
+            name: "Script B",
+            order: .post,
+            inputFileListPaths: [
+                .init(path: "SourceryInputs.xcfilelist", generatedPlaceholderPath: fileListPath),
+            ]
+        )
+        let target = Target.test(name: "A", scripts: [scriptA, scriptB])
+        let project = Project.test(targets: [target])
+
+        // When
+        let (mappedProject, sideEffects) = try subject.map(project: project)
+
+        // Then
+        XCTAssertEqual(mappedProject, project)
+        XCTAssertEqual(
+            sideEffects,
+            [
+                .file(FileDescriptor(path: fileListPath)),
+                .file(FileDescriptor(path: nestedFileListPath)),
+            ]
+        )
+    }
+}

--- a/cli/Tests/TuistHasherTests/TargetScriptsContentHasherTests.swift
+++ b/cli/Tests/TuistHasherTests/TargetScriptsContentHasherTests.swift
@@ -6,7 +6,6 @@ import TuistSupport
 import TuistTesting
 import XcodeGraph
 import XCTest
-
 @testable import TuistHasher
 
 final class TargetScriptsContentHasherTests: TuistUnitTestCase {
@@ -55,9 +54,9 @@ final class TargetScriptsContentHasherTests: TuistUnitTestCase {
             order: order,
             script: .tool(path: tool, args: arguments),
             inputPaths: inputPaths,
-            inputFileListPaths: inputFileListPaths,
+            inputFileListPaths: inputFileListPaths.map { TargetScript.FileListPath(path: $0) },
             outputPaths: outputPaths,
-            outputFileListPaths: outputFileListPaths,
+            outputFileListPaths: outputFileListPaths.map { TargetScript.FileListPath(path: $0) },
             dependencyFile: dependencyFile
         )
     }

--- a/cli/Tests/TuistHasherTests/TargetScriptsContentHasherTests.swift
+++ b/cli/Tests/TuistHasherTests/TargetScriptsContentHasherTests.swift
@@ -144,6 +144,50 @@ final class TargetScriptsContentHasherTests: TuistUnitTestCase {
             .called(1)
     }
 
+    func test_hash_targetAction_whenInputFileListPathIsGenerated_hashesPathString() async throws {
+        // Given
+        let sourceRootPath = try AbsolutePath(validating: "/project")
+        let inputPath = sourceRootPath.appending(component: "Input.swift")
+        let generatedFileListPath = sourceRootPath.appending(components: "Generated", "SourceryInputs.xcfilelist")
+        given(contentHasher)
+            .hash(path: .value(inputPath))
+            .willReturn("input-hash")
+        given(contentHasher)
+            .hash(path: .value(generatedFileListPath))
+            .willReturn("generated-file-list-contents-hash")
+
+        let targetScript = TargetScript(
+            name: "Script",
+            order: .pre,
+            script: .tool(path: "tool", args: []),
+            inputPaths: ["Input.swift"],
+            inputFileListPaths: [
+                .generated(generatedFileListPath),
+            ],
+            outputPaths: [],
+            outputFileListPaths: [],
+            dependencyFile: nil
+        )
+
+        // When
+        _ = try await subject.hash(targetScripts: [targetScript], sourceRootPath: sourceRootPath)
+
+        // Then
+        let expected = [
+            "Generated/SourceryInputs.xcfilelist",
+            "input-hash",
+            "Script",
+            "tool",
+            "pre",
+        ]
+        verify(contentHasher)
+            .hash(.value(expected))
+            .called(1)
+        verify(contentHasher)
+            .hash(path: .value(generatedFileListPath))
+            .called(0)
+    }
+
     func test_hash_targetAction_when_path_nil_callsMockHasherWithExpectedStrings() async throws {
         // Given
         let inputPaths1Hash = "inputPaths1-hash"

--- a/cli/Tests/TuistKitTests/Mappers/Factories/ProjectMapperFactoryTests.swift
+++ b/cli/Tests/TuistKitTests/Mappers/Factories/ProjectMapperFactoryTests.swift
@@ -48,6 +48,18 @@ final class ProjectMapperFactoryTests: TuistUnitTestCase {
         XCTAssertContainsElementOfType(got, ResourcesProjectMapper.self, after: DeleteDerivedDirectoryProjectMapper.self)
     }
 
+    func test_default_contains_the_generate_target_script_file_list_mapper() {
+        // When
+        let got = subject.default(tuist: .default)
+
+        // Then
+        XCTAssertContainsElementOfType(
+            got,
+            GenerateTargetScriptFileListProjectMapper.self,
+            after: DeleteDerivedDirectoryProjectMapper.self
+        )
+    }
+
     func test_default_contains_the_generate_info_plist_mapper() {
         // When
         let got = subject.default(tuist: .default)

--- a/cli/Tests/TuistLoaderTests/Models+ManifestMappers/TargetScript+ManifestMapperTests.swift
+++ b/cli/Tests/TuistLoaderTests/Models+ManifestMappers/TargetScript+ManifestMapperTests.swift
@@ -302,20 +302,17 @@ final class TargetScriptManifestMapperTests: TuistUnitTestCase {
         )
 
         // Then
+        let inputFileListPath = temporaryPath.appending(component: "SourceryInputs.xcfilelist")
+        let outputFileListPath = temporaryPath.appending(components: "Generated", "SourceryOutputs.xcfilelist")
+        XCTAssertEqual(model.inputFileListPaths, [.generated(inputFileListPath)])
+        XCTAssertEqual(model.outputFileListPaths, [.generated(outputFileListPath)])
         XCTAssertEqual(
-            model.inputFileListPaths.map(\.path),
+            model.inputFileListPaths.map { $0.xcodePath(sourceRootPath: temporaryPath) },
             ["SourceryInputs.xcfilelist"]
         )
         XCTAssertEqual(
-            model.outputFileListPaths.map(\.path),
+            model.outputFileListPaths.map { $0.xcodePath(sourceRootPath: temporaryPath) },
             ["Generated/SourceryOutputs.xcfilelist"]
-        )
-        XCTAssertEqual(
-            (model.inputFileListPaths + model.outputFileListPaths).compactMap(\.generatedPlaceholderPath),
-            [
-                temporaryPath.appending(component: "SourceryInputs.xcfilelist"),
-                temporaryPath.appending(components: "Generated", "SourceryOutputs.xcfilelist"),
-            ]
         )
     }
 

--- a/cli/Tests/TuistLoaderTests/Models+ManifestMappers/TargetScript+ManifestMapperTests.swift
+++ b/cli/Tests/TuistLoaderTests/Models+ManifestMappers/TargetScript+ManifestMapperTests.swift
@@ -316,6 +316,87 @@ final class TargetScriptManifestMapperTests: TuistUnitTestCase {
         )
     }
 
+    func test_generated_file_list_path_whenAbsolutePath_throws() async throws {
+        // Given
+        let temporaryPath = try temporaryPath()
+        let generatorPaths = GeneratorPaths(
+            manifestDirectory: temporaryPath,
+            rootDirectory: temporaryPath
+        )
+        let manifest = ProjectDescription.TargetScript.test(
+            name: "GenerateSourceryInputs",
+            tool: "my_tool",
+            order: .pre,
+            inputFileListPaths: [
+                .generated(.relativeToManifest("/tmp/SourceryInputs.xcfilelist")),
+            ]
+        )
+
+        // When / Then
+        await XCTAssertThrowsSpecific(
+            try await XcodeGraph.TargetScript.from(
+                manifest: manifest,
+                generatorPaths: generatorPaths,
+                fileSystem: fileSystem
+            ),
+            TargetScriptManifestMapperError.invalidGeneratedFileListPath("/tmp/SourceryInputs.xcfilelist")
+        )
+    }
+
+    func test_generated_file_list_path_whenParentDirectoryEscape_throws() async throws {
+        // Given
+        let temporaryPath = try temporaryPath()
+        let generatorPaths = GeneratorPaths(
+            manifestDirectory: temporaryPath,
+            rootDirectory: temporaryPath
+        )
+        let manifest = ProjectDescription.TargetScript.test(
+            name: "GenerateSourceryInputs",
+            tool: "my_tool",
+            order: .pre,
+            inputFileListPaths: [
+                .generated(.relativeToManifest("../SourceryInputs.xcfilelist")),
+            ]
+        )
+
+        // When / Then
+        await XCTAssertThrowsSpecific(
+            try await XcodeGraph.TargetScript.from(
+                manifest: manifest,
+                generatorPaths: generatorPaths,
+                fileSystem: fileSystem
+            ),
+            TargetScriptManifestMapperError.invalidGeneratedFileListPath("../SourceryInputs.xcfilelist")
+        )
+    }
+
+    func test_generated_file_list_path_whenRelativeToRoot_throws() async throws {
+        // Given
+        let temporaryPath = try temporaryPath()
+        let generatorPaths = GeneratorPaths(
+            manifestDirectory: temporaryPath,
+            rootDirectory: temporaryPath
+        )
+        let manifest = ProjectDescription.TargetScript.test(
+            name: "GenerateSourceryInputs",
+            tool: "my_tool",
+            order: .pre,
+            inputFileListPaths: [
+                .generated(.relativeToRoot("SourceryInputs.xcfilelist")),
+            ]
+        )
+
+        // When / Then
+        await XCTAssertThrowsSpecific(
+            try await XcodeGraph.TargetScript.from(
+                manifest: manifest,
+                generatorPaths: generatorPaths,
+                fileSystem: fileSystem
+            ),
+            TargetScriptManifestMapperError.invalidGeneratedFileListPath("SourceryInputs.xcfilelist")
+        )
+    }
+
     func test_inputPaths_with_build_variables_are_kept_as_strings() async throws {
         // Given
         let temporaryPath = try temporaryPath()

--- a/cli/Tests/TuistLoaderTests/Models+ManifestMappers/TargetScript+ManifestMapperTests.swift
+++ b/cli/Tests/TuistLoaderTests/Models+ManifestMappers/TargetScript+ManifestMapperTests.swift
@@ -5,7 +5,6 @@ import TuistCore
 import TuistSupport
 import XcodeGraph
 import XCTest
-
 @testable import TuistLoader
 @testable import TuistTesting
 
@@ -94,7 +93,7 @@ final class TargetScriptManifestMapperTests: TuistUnitTestCase {
         XCTAssertEqual(model.script, .tool(path: "my_tool", args: ["arg1", "arg2"]))
         XCTAssertEqual(model.order, .pre)
         XCTAssertEqual(
-            model.inputFileListPaths,
+            model.inputFileListPaths.map(\.path),
             ["$(SRCROOT)/foo/bar/**/*.swift"]
         )
         XCTAssertEqual(
@@ -102,7 +101,7 @@ final class TargetScriptManifestMapperTests: TuistUnitTestCase {
             ["$(SRCROOT)/foo/bar/**/*.swift"]
         )
         XCTAssertEqual(
-            model.outputFileListPaths,
+            model.outputFileListPaths.map(\.path),
             ["$(SRCROOT)/foo/bar/**/*.swift"]
         )
     }
@@ -142,7 +141,7 @@ final class TargetScriptManifestMapperTests: TuistUnitTestCase {
         XCTAssertEqual(model.script, .tool(path: "my_tool", args: ["arg1", "arg2"]))
         XCTAssertEqual(model.order, .pre)
         XCTAssertEqual(
-            model.inputFileListPaths,
+            model.inputFileListPaths.map(\.path),
             ["foo/bar/inputPathList1.swift"]
         )
         XCTAssertEqual(
@@ -150,7 +149,7 @@ final class TargetScriptManifestMapperTests: TuistUnitTestCase {
             ["foo/bar/outputPath1.swift"]
         )
         XCTAssertEqual(
-            model.outputFileListPaths,
+            model.outputFileListPaths.map(\.path),
             ["foo/bar/outputPathList1.swift"]
         )
     }
@@ -212,7 +211,7 @@ final class TargetScriptManifestMapperTests: TuistUnitTestCase {
         XCTAssertEqual(model.script, .tool(path: "my_tool", args: ["arg1", "arg2"]))
         XCTAssertEqual(model.order, .pre)
         XCTAssertEqual(
-            model.inputFileListPaths,
+            model.inputFileListPaths.map(\.path),
             ["$(SRCROOT)/foo/bar/**/*.swift"]
         )
         XCTAssertEqual(
@@ -220,7 +219,7 @@ final class TargetScriptManifestMapperTests: TuistUnitTestCase {
             ["$(SRCROOT)/foo/bar/**/*.swift"]
         )
         XCTAssertEqual(
-            model.outputFileListPaths,
+            model.outputFileListPaths.map(\.path),
             ["$(SRCROOT)/foo/bar/**/*.swift"]
         )
     }
@@ -262,16 +261,62 @@ final class TargetScriptManifestMapperTests: TuistUnitTestCase {
 
         // Then
         // relativeToManifest paths should be kept as strings
-        XCTAssertTrue(model.inputFileListPaths.contains("relative/to/manifest.txt"))
+        XCTAssertTrue(model.inputFileListPaths.map(\.path).contains("relative/to/manifest.txt"))
         XCTAssertTrue(model.outputPaths.contains("output/manifest.txt"))
-        XCTAssertTrue(model.outputFileListPaths.contains("output_list/manifest.txt"))
+        XCTAssertTrue(model.outputFileListPaths.map(\.path).contains("output_list/manifest.txt"))
 
         // relativeToRoot and relativeToCurrentFile should be resolved to absolute paths
         let expectedRootPath = temporaryPath.appending(try RelativePath(validating: "relative/to/root.txt")).pathString
         let expectedOutputRootPath = temporaryPath.appending(try RelativePath(validating: "output/root.txt")).pathString
 
-        XCTAssertTrue(model.inputFileListPaths.contains(expectedRootPath))
+        XCTAssertTrue(model.inputFileListPaths.map(\.path).contains(expectedRootPath))
         XCTAssertTrue(model.outputPaths.contains(expectedOutputRootPath))
+    }
+
+    func test_generated_file_list_paths_are_resolved_like_manifest_paths() async throws {
+        // Given
+        let temporaryPath = try temporaryPath()
+        let rootDirectory = temporaryPath
+        let generatorPaths = GeneratorPaths(
+            manifestDirectory: temporaryPath,
+            rootDirectory: rootDirectory
+        )
+
+        let manifest = ProjectDescription.TargetScript.test(
+            name: "GenerateSourceryInputs",
+            tool: "my_tool",
+            order: .pre,
+            inputFileListPaths: [
+                .generated("SourceryInputs.xcfilelist"),
+            ],
+            outputFileListPaths: [
+                .generated("Generated/SourceryOutputs.xcfilelist"),
+            ]
+        )
+
+        // When
+        let model = try await XcodeGraph.TargetScript.from(
+            manifest: manifest,
+            generatorPaths: generatorPaths,
+            fileSystem: fileSystem
+        )
+
+        // Then
+        XCTAssertEqual(
+            model.inputFileListPaths.map(\.path),
+            ["SourceryInputs.xcfilelist"]
+        )
+        XCTAssertEqual(
+            model.outputFileListPaths.map(\.path),
+            ["Generated/SourceryOutputs.xcfilelist"]
+        )
+        XCTAssertEqual(
+            (model.inputFileListPaths + model.outputFileListPaths).compactMap(\.generatedPlaceholderPath),
+            [
+                temporaryPath.appending(component: "SourceryInputs.xcfilelist"),
+                temporaryPath.appending(components: "Generated", "SourceryOutputs.xcfilelist"),
+            ]
+        )
     }
 
     func test_inputPaths_with_build_variables_are_kept_as_strings() async throws {

--- a/cli/Tests/XcodeGraphMapperTests/MapperTests/Phases/PBXScriptsBuildPhaseMapperTests.swift
+++ b/cli/Tests/XcodeGraphMapperTests/MapperTests/Phases/PBXScriptsBuildPhaseMapperTests.swift
@@ -39,7 +39,7 @@ struct PBXScriptsBuildPhaseMapperTests {
         #expect(script.script == .embedded("echo Hello"))
         #expect(script.inputPaths == ["$(SRCROOT)/input.txt"])
         #expect(script.outputPaths == ["$(DERIVED_FILE_DIR)/output.txt"])
-        #expect(script.inputFileListPaths == ["${PODS_ROOT}/${CONFIGURATION}/file-list.xcfilelist"])
+        #expect(script.inputFileListPaths.map(\.path) == ["${PODS_ROOT}/${CONFIGURATION}/file-list.xcfilelist"])
     }
 
     @Test("Maps raw script build phases not covered by other categories")

--- a/cli/Tests/XcodeGraphTests/Models/TargetScriptTests.swift
+++ b/cli/Tests/XcodeGraphTests/Models/TargetScriptTests.swift
@@ -10,11 +10,44 @@ echo "$wd"
 """
 
 final class TargetScriptTests: XCTestCase {
-    func test_codable() {
+    func test_codable() throws {
         // Given
-        let subject = TargetScript(name: "name", order: .pre, script: .embedded(script))
+        let subject = TargetScript(
+            name: "name",
+            order: .pre,
+            script: .embedded(script),
+            inputFileListPaths: [
+                .init(
+                    path: "Generated/File.xcfilelist",
+                    generatedPlaceholderPath: try AbsolutePath(validating: "/Generated/File.xcfilelist")
+                ),
+            ]
+        )
 
         // Then
         XCTAssertCodable(subject)
+    }
+
+    func test_decoding_whenFileListPathsAreStrings() throws {
+        // Given
+        let data = try JSONSerialization.data(withJSONObject: [
+            "name": "name",
+            "script": ["embedded": ["_0": script]],
+            "order": "pre",
+            "inputPaths": [],
+            "inputFileListPaths": ["Inputs.xcfilelist"],
+            "outputPaths": [],
+            "outputFileListPaths": ["Outputs.xcfilelist"],
+            "showEnvVarsInLog": true,
+            "runForInstallBuildsOnly": false,
+            "shellPath": "/bin/sh",
+        ])
+
+        // When
+        let got = try JSONDecoder().decode(TargetScript.self, from: data)
+
+        // Then
+        XCTAssertEqual(got.inputFileListPaths, ["Inputs.xcfilelist"])
+        XCTAssertEqual(got.outputFileListPaths, ["Outputs.xcfilelist"])
     }
 }

--- a/cli/Tests/XcodeGraphTests/Models/TargetScriptTests.swift
+++ b/cli/Tests/XcodeGraphTests/Models/TargetScriptTests.swift
@@ -17,10 +17,7 @@ final class TargetScriptTests: XCTestCase {
             order: .pre,
             script: .embedded(script),
             inputFileListPaths: [
-                .init(
-                    path: "Generated/File.xcfilelist",
-                    generatedPlaceholderPath: try AbsolutePath(validating: "/Generated/File.xcfilelist")
-                ),
+                .generated(try AbsolutePath(validating: "/Generated/File.xcfilelist")),
             ]
         )
 

--- a/cli/Tests/XcodeGraphTests/Models/TargetScriptTests.swift
+++ b/cli/Tests/XcodeGraphTests/Models/TargetScriptTests.swift
@@ -24,27 +24,4 @@ final class TargetScriptTests: XCTestCase {
         // Then
         XCTAssertCodable(subject)
     }
-
-    func test_decoding_whenFileListPathsAreStrings() throws {
-        // Given
-        let data = try JSONSerialization.data(withJSONObject: [
-            "name": "name",
-            "script": ["embedded": ["_0": script]],
-            "order": "pre",
-            "inputPaths": [],
-            "inputFileListPaths": ["Inputs.xcfilelist"],
-            "outputPaths": [],
-            "outputFileListPaths": ["Outputs.xcfilelist"],
-            "showEnvVarsInLog": true,
-            "runForInstallBuildsOnly": false,
-            "shellPath": "/bin/sh",
-        ])
-
-        // When
-        let got = try JSONDecoder().decode(TargetScript.self, from: data)
-
-        // Then
-        XCTAssertEqual(got.inputFileListPaths, ["Inputs.xcfilelist"])
-        XCTAssertEqual(got.outputFileListPaths, ["Outputs.xcfilelist"])
-    }
 }


### PR DESCRIPTION
## What changed

Adds `TargetScript.FileListPath.generated(_:)` so target scripts can ask Tuist to create an empty `.xcfilelist` placeholder during project generation while still passing the file-list path to Xcode as a normal script input or output file list.

The manifest-facing API is an enum with associated values:

```swift
inputFileListPaths: [
    .generated("SourceryInputs.xcfilelist"),
]
```

String literals and existing file-list path helpers remain available for normal paths, and the previous `[Path]` overloads are kept as deprecated disfavored overloads to preserve source compatibility for callers that already pass `[Path]` variables.

## Why

Xcode requires `.xcfilelist` files to exist before a build starts, even when an earlier script phase is responsible for refreshing their contents. This makes generated file-list workflows awkward: projects either have to commit placeholder files that are immediately rewritten, or wrap `tuist generate` in extra setup logic.

The new API lets Tuist own the placeholder creation step while keeping the actual file-list contents under the build script's control.

## Approach

The generated marker is consumed while mapping `ProjectDescription` into `XcodeGraph`. In the graph, file lists are represented as an enum:

```swift
TargetScript.FileListPath.path(String)
TargetScript.FileListPath.generated(AbsolutePath)
```

That intentionally follows the existing generated-sources model: generated source files are flattened into `Target.sources` as regular `SourceFile` values whose path is already the generated file location. Similarly, generated script file lists are regular script file-list entries whose generated case carries the file Tuist must create, rather than storing an optional placeholder path alongside every entry or maintaining a separate `generatedFileListPaths` side-channel.

During project mapping, `GenerateTargetScriptFileListProjectMapper` scans the normal script file-list collections for `.generated` entries, de-duplicates them, creates parent directories, and writes empty placeholders. Xcode project generation derives source-root-relative PBX file-list strings from generated absolute paths, while normal `.path(String)` entries continue to pass through as before. Script hashing and PBX import mapping continue to consume the Xcode-facing path string.

Generated input file lists are hashed by their stable source-root-relative path string rather than by placeholder file contents, so graph hashes do not change between a clean checkout, `tuist generate`, and later builds that refresh the file-list contents.

Generated file-list placeholders are constrained in the manifest mapper before path resolution: they must use `.relativeToManifest`, must not start with `/`, and must not contain `..` path segments. That keeps placeholder creation inside the manifest-owned path space while normal file-list paths keep their existing resolution behavior.

## Impact

Projects can now declare generated input or output file lists without committing placeholder `.xcfilelist` files. Existing callers that pass string literals continue to work. Existing callers that pass `[Path]` variables continue to compile through deprecated overloads and can migrate to `[TargetScript.FileListPath]` over time.

## Validation

- `git diff --check`
- `xcodebuild -quiet build -workspace /Users/marekfort/.codex/worktrees/879d/tuist/Tuist.xcworkspace -scheme tuist CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" COMPILATION_CACHE_ENABLE_CACHING=NO`
- `tuist generate tuist TuistGenerator TuistGeneratorTests TuistLoader TuistLoaderTests XcodeGraph XcodeGraphTests XcodeGraphMapper XcodeGraphMapperTests TuistHasher TuistHasherTests ProjectDescription --no-open`
- `xcodebuild -quiet test -workspace /Users/marekfort/.codex/worktrees/879d/tuist/Tuist.xcworkspace -scheme Tuist-Workspace -only-testing:TuistLoaderTests/TargetScriptManifestMapperTests -only-testing:TuistGeneratorTests/GenerateTargetScriptFileListProjectMapperTests -only-testing:TuistGeneratorTests/BuildPhaseGeneratorTests/generateTarget_actions -only-testing:XcodeGraphTests/TargetScriptTests -only-testing:XcodeGraphMapperTests/PBXScriptsBuildPhaseMapperTests -only-testing:TuistHasherTests/TargetScriptsContentHasherTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" COMPILATION_CACHE_ENABLE_CACHING=NO`
- `xcodebuild -quiet test -workspace /Users/marekfort/.codex/worktrees/879d/tuist/Tuist.xcworkspace -scheme Tuist-Workspace -only-testing:TuistGeneratorTests/GenerateTargetScriptFileListProjectMapperTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" COMPILATION_CACHE_ENABLE_CACHING=NO`
- `xcodebuild -quiet test -workspace /Users/marekfort/.codex/worktrees/879d/tuist/Tuist.xcworkspace -scheme Tuist-Workspace -only-testing:XcodeGraphTests/TargetScriptTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" COMPILATION_CACHE_ENABLE_CACHING=NO`
- `xcodebuild -quiet test -workspace /Users/marekfort/.codex/worktrees/879d/tuist/Tuist.xcworkspace -scheme Tuist-Workspace -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO -only-testing:TuistHasherTests/TargetScriptsContentHasherTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" COMPILATION_CACHE_ENABLE_CACHING=NO`