### PR TITLE
feat(infra): let Members self-approve production elevations in the JIT bot

### DIFF
--- a/tuist-ops/lib/tuist_ops/jit/approvals.ex
+++ b/tuist-ops/lib/tuist_ops/jit/approvals.ex
@@ -132,12 +132,11 @@ defmodule TuistOps.JIT.Approvals do
                 not Policy.self_approval_allowed?(actor_email, req.target_group) ->
               Repo.rollback(:cannot_self_approve)
 
-            # Second-human path. Even though the approver is a
-            # different person from the requester, we still gate on
-            # role: an engineer must not approve another engineer's
-            # production write. `approver_allowed?` returns true for
-            # Owner/Admin on any env and for Member on staging/
-            # canary, matching the self-approve policy's trust tiers.
+            # Second-human path (approver != requester). Gate on
+            # role: `approver_allowed?` returns true for any
+            # engineering role (Owner/Admin/Member) on any env,
+            # matching the self-approve policy. Non-engineering and
+            # off-tailnet approvers are rejected.
             req.requester_slack_id != actor_slack_id and
                 not Policy.approver_allowed?(actor_email, req.target_group) ->
               Repo.rollback(:approver_not_authorized)

--- a/tuist-ops/lib/tuist_ops/jit/policy.ex
+++ b/tuist-ops/lib/tuist_ops/jit/policy.ex
@@ -5,14 +5,16 @@ defmodule TuistOps.JIT.Policy do
   fetched via `TuistOps.JIT.TailscaleClient.user_role/1`):
 
     * `self_approval_allowed?/2` — can the requester approve their
-      own elevation? Owner/Admin roles can self-approve any env;
-      Member can self-approve `staging` and `canary` only.
+      own elevation? Owner/Admin and Member roles can all
+      self-approve any env, production included: a member may
+      self-service a production elevation without a second human.
 
     * `approver_allowed?/2` — can a second human (whoever clicked
-      Approve) authorize this elevation? Owner/Admin can approve
-      any env; Member can approve `staging` and `canary`. Production
-      always requires an Owner/Admin to click Approve, regardless of
-      whether the requester is the same person or someone else.
+      Approve) authorize this elevation? Owner/Admin and Member can
+      all approve any env, production included. (Once members can
+      self-approve production, gating the second-human path tighter
+      buys nothing — a member could always self-approve instead of
+      asking another member to click Approve.)
 
   Source of truth = the Tailscale tailnet role (`Owner`, `Admin`,
   `Member` etc. as shown in the admin console Users page). Nothing
@@ -37,10 +39,6 @@ defmodule TuistOps.JIT.Policy do
     "group:tuist-production-write" => "production"
   }
 
-  # Roles that map to the "engineer / member" tier — staging and
-  # canary self-approve / approve, but not production.
-  @member_envs ~w(staging canary)
-
   @doc """
   Returns true if `actor_email` is allowed to approve their own
   elevation request for `target_group`. Unknown target groups
@@ -48,9 +46,9 @@ defmodule TuistOps.JIT.Policy do
   """
   def self_approval_allowed?(actor_email, target_group)
       when is_binary(actor_email) and is_binary(target_group) do
-    with env when not is_nil(env) <- Map.get(@group_to_env, target_group),
+    with true <- Map.has_key?(@group_to_env, target_group),
          {:ok, role} <- TailscaleClient.user_role(actor_email) do
-      allow_for_env?(role, env)
+      engineering_role?(role)
     else
       _ -> false
     end
@@ -60,16 +58,15 @@ defmodule TuistOps.JIT.Policy do
 
   @doc """
   Returns true if `approver_email` is allowed to be the second
-  human on the request — i.e. their tailnet role is high enough
-  for the env they're approving. Used in the "second-human" path
-  (`actor != requester`) to keep an engineer from approving
-  another engineer's production write.
+  human on the request — i.e. they hold an engineering tailnet
+  role (Owner/Admin/Member), which clears any env. Used in the
+  "second-human" path (`actor != requester`).
   """
   def approver_allowed?(approver_email, target_group)
       when is_binary(approver_email) and is_binary(target_group) do
-    with env when not is_nil(env) <- Map.get(@group_to_env, target_group),
+    with true <- Map.has_key?(@group_to_env, target_group),
          {:ok, role} <- TailscaleClient.user_role(approver_email) do
-      allow_for_env?(role, env)
+      engineering_role?(role)
     else
       _ -> false
     end
@@ -91,13 +88,14 @@ defmodule TuistOps.JIT.Policy do
   deciding whether to inject the elevated impersonation header.
   """
   def env_access(role, env) when is_atom(role) and is_binary(env) do
-    if allow_for_env?(role, env), do: {:ok, env}, else: :deny
+    if engineering_role?(role), do: {:ok, env}, else: :deny
   end
 
-  # Owner/Admin → any env. Member → staging + canary. Everything
-  # else (Auditor, Billing admin, etc., and unrecognized roles)
-  # falls through to deny.
-  defp allow_for_env?(role, _env) when role in [:owner, :admin], do: true
-  defp allow_for_env?(:member, env) when env in @member_envs, do: true
-  defp allow_for_env?(_role, _env), do: false
+  # Every engineering identity (Owner, Admin, Member) is cleared for
+  # every env, production included — members may self-service a prod
+  # elevation without a second human. Role still shapes the base
+  # impersonation group elsewhere (tuist-eng vs tuist-admins; see
+  # TuistOpsWeb.PolicyController). Non-engineering roles (Auditor,
+  # Billing admin, unrecognized) are not cleared.
+  defp engineering_role?(role), do: role in [:owner, :admin, :member]
 end

--- a/tuist-ops/lib/tuist_ops_web/controllers/slack_controller.ex
+++ b/tuist-ops/lib/tuist_ops_web/controllers/slack_controller.ex
@@ -158,8 +158,9 @@ defmodule TuistOpsWeb.SlackController do
             SlackClient.ephemeral(
               channel_id,
               actor_slack_id,
-              ":no_entry: A second human has to click Approve for this env. " <>
-                "(Production writes always require a second approver, even for engineers.)"
+              ":no_entry: Your Tailscale role can't self-approve elevations — " <>
+                "self-approval is limited to engineering roles (Owner, Admin, or Member). " <>
+                "Ask an Owner, Admin, or Member to click Approve."
             )
 
             send_resp(conn, 200, "")
@@ -177,8 +178,9 @@ defmodule TuistOpsWeb.SlackController do
             SlackClient.ephemeral(
               channel_id,
               actor_slack_id,
-              ":no_entry: Your Tailscale role doesn't allow approving this env. " <>
-                "Production approvals require an Owner or Admin role; engineers can only approve staging and canary."
+              ":no_entry: Your Tailscale role can't approve elevations. " <>
+                "Only engineering roles (Owner, Admin, or Member) can approve; " <>
+                "Auditor/Billing-admin and off-tailnet identities can't."
             )
 
             send_resp(conn, 200, "")

--- a/tuist-ops/test/jit/approvals_test.exs
+++ b/tuist-ops/test/jit/approvals_test.exs
@@ -103,8 +103,8 @@ defmodule TuistOps.JIT.ApprovalsTest do
     end
   end
 
-  describe "approve/2 — approver trust tier (second-human path)" do
-    test "rejects a Member approving another engineer's production request" do
+  describe "approve/2 — self-approval" do
+    test "Owner self-approves their own production request -> elevation created" do
       stub_default_roles()
       stub(SlackClient, :update_message, fn _, _, _ -> :ok end)
 
@@ -115,17 +115,79 @@ defmodule TuistOps.JIT.ApprovalsTest do
           target_group: "group:tuist-production-write"
         })
 
-      assert {:error, :approver_not_authorized} =
+      assert {:ok, %Request{status: "approved"}, %Elevation{status: "active"}} =
+               Approvals.approve(req.id, %{slack_id: "U_MAREK", email: "marek@tuist.dev"})
+
+      assert Repo.get_by(Elevation, request_id: req.id)
+    end
+
+    test "Member self-approves their own production request -> elevation created" do
+      # The behaviour this change restores: a Member self-services a
+      # production elevation without needing a second human.
+      stub_default_roles()
+      stub(SlackClient, :update_message, fn _, _, _ -> :ok end)
+
+      req =
+        insert_request!(%{
+          requester_email: "eduardo.ext@tuist.dev",
+          requester_slack_id: "U_EDUARDO",
+          target_group: "group:tuist-production-write"
+        })
+
+      assert {:ok, %Request{status: "approved"}, %Elevation{status: "active"}} =
                Approvals.approve(req.id, %{
                  slack_id: "U_EDUARDO",
                  email: "eduardo.ext@tuist.dev"
                })
 
-      # No Elevation row created when the approver gate trips.
+      assert Repo.get_by(Elevation, request_id: req.id)
+    end
+
+    test "requester whose role can't self-approve is rejected (:cannot_self_approve)" do
+      # A non-engineering requester (Auditor) clicking Approve on
+      # their own request hits the self-approve gate: no elevation,
+      # request stays pending for an engineering-role approver.
+      stub(TailscaleClient, :user_role, fn
+        "auditor@tuist.dev" -> {:ok, :auditor}
+        _ -> {:error, :not_found}
+      end)
+
+      stub(SlackClient, :update_message, fn _, _, _ -> :ok end)
+
+      req =
+        insert_request!(%{
+          requester_email: "auditor@tuist.dev",
+          requester_slack_id: "U_AUDITOR",
+          target_group: "group:tuist-staging-write"
+        })
+
+      assert {:error, :cannot_self_approve} =
+               Approvals.approve(req.id, %{slack_id: "U_AUDITOR", email: "auditor@tuist.dev"})
+
       assert Repo.get_by(Elevation, request_id: req.id) == nil
-      # And the Request stays pending so an Owner/Admin can still
-      # come along and approve.
       assert %Request{status: "pending"} = Repo.get!(Request, req.id)
+    end
+  end
+
+  describe "approve/2 — approver trust tier (second-human path)" do
+    test "allows a Member to approve another engineer's production request" do
+      stub_default_roles()
+      stub(SlackClient, :update_message, fn _, _, _ -> :ok end)
+
+      req =
+        insert_request!(%{
+          requester_email: "marek@tuist.dev",
+          requester_slack_id: "U_MAREK",
+          target_group: "group:tuist-production-write"
+        })
+
+      assert {:ok, %Request{status: "approved"}, %Elevation{status: "active"}} =
+               Approvals.approve(req.id, %{
+                 slack_id: "U_EDUARDO",
+                 email: "eduardo.ext@tuist.dev"
+               })
+
+      assert Repo.get_by(Elevation, request_id: req.id)
     end
 
     test "rejects an off-tailnet approver for any env" do

--- a/tuist-ops/test/jit/policy_test.exs
+++ b/tuist-ops/test/jit/policy_test.exs
@@ -48,17 +48,13 @@ defmodule TuistOps.JIT.PolicyTest do
       end
     end
 
-    test "Member can self-approve staging and canary" do
+    test "Member can self-approve any env, production included" do
       stub_roles(%{@member => :member})
 
-      assert Policy.self_approval_allowed?(@member, @staging)
-      assert Policy.self_approval_allowed?(@member, @canary)
-    end
-
-    test "Member cannot self-approve production" do
-      stub_roles(%{@member => :member})
-
-      refute Policy.self_approval_allowed?(@member, @prod)
+      for grp <- [@staging, @canary, @prod] do
+        assert Policy.self_approval_allowed?(@member, grp),
+               "expected Member #{@member} to self-approve #{grp}"
+      end
     end
 
     test "admin-flavor roles outside Owner/Admin cannot self-approve any env" do
@@ -128,14 +124,15 @@ defmodule TuistOps.JIT.PolicyTest do
       end
     end
 
-    test "Member can approve staging and canary but NOT production" do
-      # This is the new gate: an engineer approving another
-      # engineer's production write is rejected.
+    test "Member can approve any env, production included" do
+      # Members are trusted for production now that they can
+      # self-approve it; the second-human path matches that tier.
       stub_roles(%{@member => :member})
 
-      assert Policy.approver_allowed?(@member, @staging)
-      assert Policy.approver_allowed?(@member, @canary)
-      refute Policy.approver_allowed?(@member, @prod)
+      for grp <- [@staging, @canary, @prod] do
+        assert Policy.approver_allowed?(@member, grp),
+               "expected Member #{@member} to approve #{grp}"
+      end
     end
 
     test "off-tailnet identities cannot approve any env" do

--- a/tuist-ops/test/tuist_ops_web/controllers/policy_controller_test.exs
+++ b/tuist-ops/test/tuist_ops_web/controllers/policy_controller_test.exs
@@ -214,14 +214,14 @@ defmodule TuistOpsWeb.PolicyControllerTest do
       assert impersonate_groups(c) == ["tuist-eng", "tuist-canary-write"]
     end
 
-    test "Member + active PROD elevation → NO write group (Policy denies prod for Member)",
+    test "Member + active PROD elevation → tuist-eng + tuist-production-write",
          %{conn: conn} do
       stub_role(@member, :member)
       insert_active_elevation!(@member, "group:tuist-production-write")
 
       c = policy_get(conn, "kube-prod.tuist.dev", [{"x-pomerium-claim-email", @member}])
       assert c.status == 200
-      assert impersonate_groups(c) == ["tuist-eng"]
+      assert impersonate_groups(c) == ["tuist-eng", "tuist-production-write"]
     end
 
     test "elevation for wrong env is ignored (staging elevation, prod call)", %{conn: conn} do

--- a/tuist-ops/test/tuist_ops_web/controllers/slack_controller_test.exs
+++ b/tuist-ops/test/tuist_ops_web/controllers/slack_controller_test.exs
@@ -270,7 +270,7 @@ defmodule TuistOpsWeb.SlackControllerTest do
       stub(Approvals, :approve, fn _, _ -> {:error, :cannot_self_approve} end)
 
       expect(SlackClient, :ephemeral, fn _channel, _user, msg ->
-        assert msg =~ "second human"
+        assert msg =~ "self-approve"
         :ok
       end)
 


### PR DESCRIPTION
## What changed

The `/elevate` JIT elevation bot (`tuist-ops`) now lets **any engineering tailnet role — Owner, Admin, or Member — self-approve an elevation for any environment, production included.** Previously a Member could only self-approve `staging`/`canary`; a production request required an Owner/Admin as the second human.

The single edit that does this is in `TuistOps.JIT.Policy`: the shared role×env gate now clears every env for `:owner`, `:admin`, and `:member`. Non-engineering roles (Auditor, Billing admin, unknown) and off-tailnet identities still default-deny.

## Why

Starting point: it turned out self-approval was **not actually broken** — Owner/Admin/Member could already self-approve their allowed envs, and git history shows the JIT policy had only ever had one commit. The only thing blocked was the deliberate **two-human rule for production** for the Member tier. This PR intentionally lifts that specific restriction.

## Why the change lives in the shared predicate

`allow_for_env?/2` was the single source of truth for **three** call sites:

1. `self_approval_allowed?/2` — the requester clicking Approve on their own request
2. `approver_allowed?/2` — the second-human path (`approver != requester`)
3. `env_access/2` — read by `PolicyController` to decide whether a kubectl call gets the elevated impersonation group

Point 3 is load-bearing: a Member's self-approved production elevation is only *usable* if `env_access` also clears it at request time. Relaxing only the self-approval predicate would have produced a **cosmetic approval that still gets denied at the gateway**. So the change belongs in the shared predicate, which fixes all three consistently. As a consequence a Member can also be the second human on another engineer's prod request — which adds no real control, since a Member can always self-approve instead.

## Refactor (behavior-preserving)

With env no longer affecting the decision, the leaf predicate collapsed from three clauses (two with identical bodies, `env` ignored everywhere) to a role-only `engineering_role?/1`, and the two callers' group validation simplified from `env when not is_nil(env) <- Map.get(...)` to `Map.has_key?/2`.

## Also in this PR

A follow-up review caught text that my policy change had made false:
- Two user-facing Slack error messages (`:cannot_self_approve`, `:approver_not_authorized`) that still told users "production always requires a second approver, even for engineers" / "engineers can only approve staging and canary."
- An inline comment in `approvals.ex` describing the removed rule.

All corrected to describe the new tier. Added integration coverage for the Member prod self-approval **success** path and the non-engineering self-approval **denial** path (the branch whose message was wrong).

## ⚠️ Security impact — please review deliberately

This **removes two-person control for production for the entire Member tier.** Any identity with tailnet role `Member` can now unilaterally grant itself production kubectl write via `/elevate`, with no second human. Mitigations that remain:
- Base impersonation group still differs by role (`tuist-eng` vs `tuist-admins`).
- Elevation still requires an active `/elevate` grant with a TTL (no standing prod access; auto-reverts).
- Non-engineering / off-tailnet identities are still fully denied.

If two-person integrity for production must be retained, the narrower option is to keep `self_approval_allowed?` strict for `member` + `production` while leaving `approver_allowed?` loose — happy to switch to that.

## Validation

- Full `tuist-ops` suite: **183 tests, 0 failures.**
- `mix format` clean, `mix credo` clean, `mix compile --warnings-as-errors` clean.
- Tests updated to assert the new policy across all role×env combinations (`policy_test`), the elevation-grant path (`policy_controller_test`), and the approve flow (`approvals_test`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)