### PR TITLE
fix(cli): avoid shadowing SwiftPM public headers

### DIFF
--- a/cli/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
+++ b/cli/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
@@ -1047,18 +1047,28 @@ public struct PackageInfoMapper: PackageInfoMapping {
                 project: .list([.glob(.path("\(targetPath.pathString)/\(headersGlob)"), excluding: excluding)])
             )
         case let .directory(_, publicHeadersPath):
-            let publicHeaders = try await frameworkPublicHeaders(
+            let frameworkHeaders = try await frameworkPublicHeaders(
                 publicHeadersPath: publicHeadersPath,
                 targetPath: targetPath,
                 excluding: target.exclude,
                 moduleName: moduleName
             )
             return .headers(
-                public: publicHeaders,
-                project: .list([.glob(.path("\(targetPath.pathString)/\(headersGlob)"), excluding: excluding)]),
+                public: frameworkHeaders.public,
+                project: .list([
+                    .glob(
+                        .path("\(targetPath.pathString)/\(headersGlob)"),
+                        excluding: excluding + frameworkHeaders.shadowedPublicHeaderExclusions
+                    ),
+                ]),
                 exclusionRule: .projectExcludesPrivateAndPublic
             )
         }
+    }
+
+    private struct FrameworkPublicHeaders {
+        let `public`: ProjectDescription.FileList?
+        let shadowedPublicHeaderExclusions: [ProjectDescription.Path]
     }
 
     private func frameworkPublicHeaders(
@@ -1066,7 +1076,7 @@ public struct PackageInfoMapper: PackageInfoMapping {
         targetPath: AbsolutePath,
         excluding: [String],
         moduleName: String?
-    ) async throws -> ProjectDescription.FileList? {
+    ) async throws -> FrameworkPublicHeaders {
         let headerExtensions = "h,hh,hpp,h++,hp,hxx,H,ipp,def"
         let excludedPaths = try excluding.map {
             targetPath.appending(try RelativePath(validating: $0))
@@ -1092,9 +1102,16 @@ public struct PackageInfoMapper: PackageInfoMapping {
             moduleName: moduleName
         )
 
-        guard !frameworkHeaders.isEmpty else { return nil }
+        let frameworkHeaderSet = Set(frameworkHeaders)
+        let shadowedPublicHeaderExclusions = headers
+            .filter { !frameworkHeaderSet.contains($0) }
+            .sorted()
+            .map { ProjectDescription.Path.path($0.pathString) }
 
-        return .list(frameworkHeaders.map { .glob(.path($0.pathString)) })
+        return FrameworkPublicHeaders(
+            public: frameworkHeaders.isEmpty ? nil : .list(frameworkHeaders.map { .glob(.path($0.pathString)) }),
+            shadowedPublicHeaderExclusions: shadowedPublicHeaderExclusions
+        )
     }
 
     private func uniqueFrameworkPublicHeaders(

--- a/cli/Tests/TuistGeneratorAcceptanceTests/GenerateAcceptanceTests.swift
+++ b/cli/Tests/TuistGeneratorAcceptanceTests/GenerateAcceptanceTests.swift
@@ -610,7 +610,9 @@ struct GenerateAcceptanceTestAppWithSPMCTargetDuplicatePublicHeaders {
     ///
     /// Before the fix, both the wrapper and nested headers were marked Public, so Xcode failed with
     /// "Multiple commands produce ... nanopb.framework/Headers/pb.h". After the fix, Tuist keeps only one
-    /// public header per framework destination while preserving the rest as project headers.
+    /// public header per framework destination. A sibling C target then includes `<nanopb/pb.h>` to ensure
+    /// the remaining project headers do not shadow the real framework public header and recurse through the
+    /// top-level wrapper.
     @Test(.withFixture("generated_app_with_spm_c_target_duplicate_public_headers"), .inTemporaryDirectory)
     func app_with_spm_c_target_duplicate_public_headers() async throws {
         let fixturePath = try fixtureDirectory()
@@ -630,8 +632,13 @@ struct GenerateAcceptanceTestAppWithSPMCTargetDuplicatePublicHeaders {
             .filter { ($0.settings?["ATTRIBUTES"]?.arrayValue ?? []).contains("Public") }
             .compactMap { $0.file?.path }
             .sorted()
+        let nonPublicHeaderNames = headerFiles
+            .filter { !($0.settings?["ATTRIBUTES"]?.arrayValue ?? []).contains("Public") }
+            .compactMap { $0.file?.path }
+            .sorted()
 
         #expect(publicHeaderNames == ["pb.h", "pb_common.h"])
+        #expect(nonPublicHeaderNames == ["pb.h", "pb_common.h"])
 
         try await CommandRunner().runAndWait(arguments: [
             "/usr/bin/xcodebuild",

--- a/cli/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
+++ b/cli/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
@@ -2827,6 +2827,10 @@ struct PackageInfoMapperTests {
                                 publicHeaderRelativePaths: [
                                     "spm_headers/nanopb/pb.h",
                                     "spm_headers/nanopb/pb_common.h",
+                                ],
+                                projectExcluding: [
+                                    .path(publicHeadersPath.appending(component: "pb.h").pathString),
+                                    .path(publicHeadersPath.appending(component: "pb_common.h").pathString),
                                 ]
                             ),
                             customSettings: [
@@ -8245,14 +8249,20 @@ extension ProjectDescription.Headers {
     fileprivate static func spmDirectoryTarget(
         _ targetBasePath: AbsolutePath,
         publicHeaderRelativePaths: [String],
-        excluding: [ProjectDescription.Path] = []
+        excluding: [ProjectDescription.Path] = [],
+        projectExcluding: [ProjectDescription.Path] = []
     ) -> ProjectDescription.Headers {
         let publicHeaders = publicHeaderRelativePaths.map {
             targetBasePath.appending(try! RelativePath(validating: $0))
         }
         return .headers(
             public: .list(publicHeaders.map { .glob(.path($0.pathString), excluding: excluding) }),
-            project: .list([.glob(.path("\(targetBasePath.pathString)/\(spmHeadersGlob)"), excluding: excluding)]),
+            project: .list([
+                .glob(
+                    .path("\(targetBasePath.pathString)/\(spmHeadersGlob)"),
+                    excluding: excluding + projectExcluding
+                ),
+            ]),
             exclusionRule: .projectExcludesPrivateAndPublic
         )
     }

--- a/examples/xcode/generated_app_with_spm_c_target_duplicate_public_headers/Project.swift
+++ b/examples/xcode/generated_app_with_spm_c_target_duplicate_public_headers/Project.swift
@@ -9,7 +9,7 @@ let project = Project(
             product: .commandLineTool,
             bundleId: "dev.tuist.App",
             sources: ["Sources/**"],
-            dependencies: [.external(name: "nanopb")]
+            dependencies: [.external(name: "Transport")]
         ),
     ]
 )

--- a/examples/xcode/generated_app_with_spm_c_target_duplicate_public_headers/Sources/App/main.swift
+++ b/examples/xcode/generated_app_with_spm_c_target_duplicate_public_headers/Sources/App/main.swift
@@ -1,3 +1,3 @@
-import nanopb
+import Transport
 
-print(nanopb_value())
+print(transport_value())

--- a/examples/xcode/generated_app_with_spm_c_target_duplicate_public_headers/Transport/Package.swift
+++ b/examples/xcode/generated_app_with_spm_c_target_duplicate_public_headers/Transport/Package.swift
@@ -1,0 +1,26 @@
+// swift-tools-version:5.9
+import PackageDescription
+
+let package = Package(
+    name: "Transport",
+    products: [
+        .library(name: "Transport", targets: ["Transport"]),
+    ],
+    dependencies: [
+        .package(path: "../Nanopb"),
+    ],
+    targets: [
+        .target(
+            name: "Transport",
+            dependencies: [
+                .product(name: "nanopb", package: "Nanopb"),
+            ],
+            path: ".",
+            sources: [
+                "transport.c",
+                "generated.nanopb.h",
+            ],
+            publicHeadersPath: "include"
+        ),
+    ]
+)

--- a/examples/xcode/generated_app_with_spm_c_target_duplicate_public_headers/Transport/generated.nanopb.h
+++ b/examples/xcode/generated_app_with_spm_c_target_duplicate_public_headers/Transport/generated.nanopb.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include <nanopb/pb.h>
+
+#define TRANSPORT_GENERATED_VALUE NANOPB_PUBLIC_VALUE

--- a/examples/xcode/generated_app_with_spm_c_target_duplicate_public_headers/Transport/include/Transport.h
+++ b/examples/xcode/generated_app_with_spm_c_target_duplicate_public_headers/Transport/include/Transport.h
@@ -1,0 +1,3 @@
+#pragma once
+
+int transport_value(void);

--- a/examples/xcode/generated_app_with_spm_c_target_duplicate_public_headers/Transport/transport.c
+++ b/examples/xcode/generated_app_with_spm_c_target_duplicate_public_headers/Transport/transport.c
@@ -1,0 +1,7 @@
+#include "Transport.h"
+#include "generated.nanopb.h"
+
+int transport_value(void)
+{
+    return TRANSPORT_GENERATED_VALUE;
+}

--- a/examples/xcode/generated_app_with_spm_c_target_duplicate_public_headers/Tuist/Package.swift
+++ b/examples/xcode/generated_app_with_spm_c_target_duplicate_public_headers/Tuist/Package.swift
@@ -13,5 +13,6 @@ let package = Package(
     name: "Deps",
     dependencies: [
         .package(path: "../Nanopb"),
+        .package(path: "../Transport"),
     ]
 )


### PR DESCRIPTION
## What changed

- Keeps SwiftPM C directory-target public headers de-duplicated for framework copy destinations while also excluding the shadowed duplicate headers from the generated project header glob.
- Extends the existing nanopb-style acceptance fixture with a sibling C package that includes `<nanopb/pb.h>` from a generated header, matching the include pattern that exposed the nested-include regression.
- Tightens the acceptance assertion so the generated nanopb target may only keep the real framework public headers plus the package-root project headers. Shadowed wrapper headers must not remain in the headers phase.
- Updates the package mapper unit expectation so top-level wrapper headers such as `spm_headers/pb.h` and `spm_headers/pb_common.h` are not emitted as project headers once their nested module equivalents are selected as framework public headers.

## Why it changed

The previous duplicate-header fix stopped copying both nanopb wrapper headers and their nested module headers into the framework `Headers` directory, which resolved the `Multiple commands produce ... nanopb.framework/Headers/pb.h` failure. However, the top-level wrapper headers were still available through the generated project headers.

That meant projects could still expose the shadowed wrapper headers alongside the nested real public headers. In configurations where module-qualified includes resolve through framework/header-map paths, `<nanopb/pb.h>` can land on the top-level wrapper `spm_headers/pb.h`; that wrapper includes `"nanopb/pb.h"`, so resolution can recurse and fail with `#include nested too deeply`.

## Approach

For `.directory` SwiftPM C targets, Tuist now tracks both:

- the headers selected as framework public headers after destination de-duplication
- the public-directory headers shadowed by that selection

The shadowed headers are appended to the project-header glob exclusions. This preserves the real nested public headers for framework consumers while preventing wrapper headers with the same basename from shadowing them through project headers.

## Impact

SwiftPM C targets with nanopb-style wrapper headers should avoid both failure modes:

- duplicate public framework header copy commands
- recursive wrapper-header resolution when consumers include module-qualified public headers

## Validation

- Red: temporarily reverted only the mapper implementation while keeping the new test/fixture. The focused acceptance command failed with `nonPublicHeaderNames` equal to `["pb.h", "pb.h", "pb_common.h", "pb_common.h"]` instead of `["pb.h", "pb_common.h"]`, proving the old behavior still emitted the shadowed wrappers.
- Green: restored the mapper fix and reran the same focused acceptance command. It passed and built the generated app fixture.
- `xcodebuild test -workspace Tuist.xcworkspace -scheme Tuist-Workspace -only-testing TuistGeneratorAcceptanceTests/GenerateAcceptanceTestAppWithSPMCTargetDuplicatePublicHeaders -destination platform=macOS -derivedDataPath /private/tmp/tuist-nested-headers-acceptance CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" COMPILATION_CACHE_ENABLE_CACHING=NO`
- `xcodebuild test -workspace Tuist.xcworkspace -scheme Tuist-Workspace -only-testing TuistLoaderTests/PackageInfoMapperTests -destination platform=macOS -derivedDataPath /private/tmp/tuist-nested-headers-loader-red CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" COMPILATION_CACHE_ENABLE_CACHING=NO`
- `git diff --check`
