### PR TITLE
test(cli): always run the suite-sharding acceptance test end to end

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -271,7 +271,7 @@ jobs:
         run: xcodebuild -downloadComponent MetalToolchain
       - name: Build tests
         id: shard
-        run: tuist test --build-only --shard-total 2 --shard-granularity suite TuistAcceptanceTests
+        run: tuist test --build-only --shard-total 2 --shard-granularity suite --no-selective-testing TuistAcceptanceTests
 
   cli-acceptance-tests:
     name: Acceptance Tests
@@ -327,7 +327,7 @@ jobs:
           security default-keychain -s $KEYCHAIN_PATH
           security unlock-keychain -p $KEYCHAIN_PASSWORD $KEYCHAIN_PATH
       - name: Run shard ${{ matrix.shard }}
-        run: tuist test --without-building --platform macOS TuistAcceptanceTests -- -retry-tests-on-failure -test-iterations 2
+        run: tuist test --without-building --platform macOS --no-selective-testing TuistAcceptanceTests -- -retry-tests-on-failure -test-iterations 2
         env:
           TUIST_SHARD_INDEX: ${{ matrix.shard }}
 


### PR DESCRIPTION
> Follow-up validation for #11635 (the suite catch-all download fix).

## What & why

The `TuistAcceptanceTests` suite-sharding acceptance job ran with selective testing enabled. On any commit where the acceptance targets are cached, selective testing yields an **empty shard matrix**, so the `Acceptance Tests (N)` shard jobs are **skipped** and the run goes green without ever exercising the sharding path. That's how the catch-all `Missing test product` regression reached `main` unnoticed, and why a plain re-run can't reproduce it.

This disables selective testing for the suite-sharding acceptance build **and** run commands, so every run:
- builds the full `TuistAcceptanceTests` suite (all test-target modules), and
- actually runs the shards — including the catch-all, which must download every module's products.

This doubles as the reliable `--suite` granularity acceptance coverage that was requested, and it validates #11635 against the now-deployed server: the catch-all shard should download all module products and pass instead of failing with `Missing test product`.

## Validation

The signal is this PR's own **`Acceptance Tests (1)`** (the catch-all shard) going green with a non-empty matrix. If we don't want the added CI time on every run, we can scope this to a schedule instead — but given sharding e2e coverage is exactly what selective testing was silently skipping, running it every time is the point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
