### PR TITLE
fix(cli): avoid shadowing SwiftPM public headers

### DIFF
--- a/cli/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
+++ b/cli/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
@@ -1047,18 +1047,28 @@ public struct PackageInfoMapper: PackageInfoMapping {
                 project: .list([.glob(.path("\(targetPath.pathString)/\(headersGlob)"), excluding: excluding)])
             )
         case let .directory(_, publicHeadersPath):
-            let publicHeaders = try await frameworkPublicHeaders(
+            let frameworkHeaders = try await frameworkPublicHeaders(
                 publicHeadersPath: publicHeadersPath,
                 targetPath: targetPath,
                 excluding: target.exclude,
                 moduleName: moduleName
             )
             return .headers(
-                public: publicHeaders,
-                project: .list([.glob(.path("\(targetPath.pathString)/\(headersGlob)"), excluding: excluding)]),
+                public: frameworkHeaders.public,
+                project: .list([
+                    .glob(
+                        .path("\(targetPath.pathString)/\(headersGlob)"),
+                        excluding: excluding + frameworkHeaders.shadowedPublicHeaderExclusions
+                    ),
+                ]),
                 exclusionRule: .projectExcludesPrivateAndPublic
             )
         }
+    }
+
+    private struct FrameworkPublicHeaders {
+        let `public`: ProjectDescription.FileList?
+        let shadowedPublicHeaderExclusions: [ProjectDescription.Path]
     }
 
     private func frameworkPublicHeaders(
@@ -1066,7 +1076,7 @@ public struct PackageInfoMapper: PackageInfoMapping {
         targetPath: AbsolutePath,
         excluding: [String],
         moduleName: String?
-    ) async throws -> ProjectDescription.FileList? {
+    ) async throws -> FrameworkPublicHeaders {
         let headerExtensions = "h,hh,hpp,h++,hp,hxx,H,ipp,def"
         let excludedPaths = try excluding.map {
             targetPath.appending(try RelativePath(validating: $0))
@@ -1092,9 +1102,16 @@ public struct PackageInfoMapper: PackageInfoMapping {
             moduleName: moduleName
         )
 
-        guard !frameworkHeaders.isEmpty else { return nil }
+        let frameworkHeaderSet = Set(frameworkHeaders)
+        let shadowedPublicHeaderExclusions = headers
+            .filter { !frameworkHeaderSet.contains($0) }
+            .sorted()
+            .map { ProjectDescription.Path.path($0.pathString) }
 
-        return .list(frameworkHeaders.map { .glob(.path($0.pathString)) })
+        return FrameworkPublicHeaders(
+            public: frameworkHeaders.isEmpty ? nil : .list(frameworkHeaders.map { .glob(.path($0.pathString)) }),
+            shadowedPublicHeaderExclusions: shadowedPublicHeaderExclusions
+        )
     }
 
     private func uniqueFrameworkPublicHeaders(

--- a/cli/Tests/TuistGeneratorAcceptanceTests/GenerateAcceptanceTests.swift
+++ b/cli/Tests/TuistGeneratorAcceptanceTests/GenerateAcceptanceTests.swift
@@ -610,7 +610,9 @@ struct GenerateAcceptanceTestAppWithSPMCTargetDuplicatePublicHeaders {
     ///
     /// Before the fix, both the wrapper and nested headers were marked Public, so Xcode failed with
     /// "Multiple commands produce ... nanopb.framework/Headers/pb.h". After the fix, Tuist keeps only one
-    /// public header per framework destination while preserving the rest as project headers.
+    /// public header per framework destination. A sibling C target then includes `<nanopb/pb.h>` to ensure
+    /// the remaining project headers do not shadow the real framework public header and recurse through the
+    /// top-level wrapper.
     @Test(.withFixture("generated_app_with_spm_c_target_duplicate_public_headers"), .inTemporaryDirectory)
     func app_with_spm_c_target_duplicate_public_headers() async throws {
         let fixturePath = try fixtureDirectory()
@@ -630,8 +632,13 @@ struct GenerateAcceptanceTestAppWithSPMCTargetDuplicatePublicHeaders {
             .filter { ($0.settings?["ATTRIBUTES"]?.arrayValue ?? []).contains("Public") }
             .compactMap { $0.file?.path }
             .sorted()
+        let nonPublicHeaderNames = headerFiles
+            .filter { !($0.settings?["ATTRIBUTES"]?.arrayValue ?? []).contains("Public") }
+            .compactMap { $0.file?.path }
+            .sorted()
 
         #expect(publicHeaderNames == ["pb.h", "pb_common.h"])
+        #expect(nonPublicHeaderNames == ["pb.h", "pb_common.h"])
 
         try await CommandRunner().runAndWait(arguments: [
             "/usr/bin/xcodebuild",

--- a/cli/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
+++ b/cli/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
@@ -2827,6 +2827,10 @@ struct PackageInfoMapperTests {
                                 publicHeaderRelativePaths: [
                                     "spm_headers/nanopb/pb.h",
                                     "spm_headers/nanopb/pb_common.h",
+                                ],
+                                projectExcluding: [
+                                    .path(publicHeadersPath.appending(component: "pb.h").pathString),
+                                    .path(publicHeadersPath.appending(component: "pb_common.h").pathString),
                                 ]
                             ),
                             customSettings: [
@@ -8245,14 +8249,20 @@ extension ProjectDescription.Headers {
     fileprivate static func spmDirectoryTarget(
         _ targetBasePath: AbsolutePath,
         publicHeaderRelativePaths: [String],
-        excluding: [ProjectDescription.Path] = []
+        excluding: [ProjectDescription.Path] = [],
+        projectExcluding: [ProjectDescription.Path] = []
     ) -> ProjectDescription.Headers {
         let publicHeaders = publicHeaderRelativePaths.map {
             targetBasePath.appending(try! RelativePath(validating: $0))
         }
         return .headers(
             public: .list(publicHeaders.map { .glob(.path($0.pathString), excluding: excluding) }),
-            project: .list([.glob(.path("\(targetBasePath.pathString)/\(spmHeadersGlob)"), excluding: excluding)]),
+            project: .list([
+                .glob(
+                    .path("\(targetBasePath.pathString)/\(spmHeadersGlob)"),
+                    excluding: excluding + projectExcluding
+                ),
+            ]),
             exclusionRule: .projectExcludesPrivateAndPublic
         )
     }

--- a/examples/xcode/generated_app_with_spm_c_target_duplicate_public_headers/Project.swift
+++ b/examples/xcode/generated_app_with_spm_c_target_duplicate_public_headers/Project.swift
@@ -9,7 +9,7 @@ let project = Project(
             product: .commandLineTool,
             bundleId: "dev.tuist.App",
             sources: ["Sources/**"],
-            dependencies: [.external(name: "nanopb")]
+            dependencies: [.external(name: "Transport")]
         ),
     ]
 )

--- a/examples/xcode/generated_app_with_spm_c_target_duplicate_public_headers/Sources/App/main.swift
+++ b/examples/xcode/generated_app_with_spm_c_target_duplicate_public_headers/Sources/App/main.swift
@@ -1,3 +1,3 @@
-import nanopb
+import Transport
 
-print(nanopb_value())
+print(transport_value())

--- a/examples/xcode/generated_app_with_spm_c_target_duplicate_public_headers/Transport/Package.swift
+++ b/examples/xcode/generated_app_with_spm_c_target_duplicate_public_headers/Transport/Package.swift
@@ -1,0 +1,26 @@
+// swift-tools-version:5.9
+import PackageDescription
+
+let package = Package(
+    name: "Transport",
+    products: [
+        .library(name: "Transport", targets: ["Transport"]),
+    ],
+    dependencies: [
+        .package(path: "../Nanopb"),
+    ],
+    targets: [
+        .target(
+            name: "Transport",
+            dependencies: [
+                .product(name: "nanopb", package: "Nanopb"),
+            ],
+            path: ".",
+            sources: [
+                "transport.c",
+                "generated.nanopb.h",
+            ],
+            publicHeadersPath: "include"
+        ),
+    ]
+)

--- a/examples/xcode/generated_app_with_spm_c_target_duplicate_public_headers/Transport/generated.nanopb.h
+++ b/examples/xcode/generated_app_with_spm_c_target_duplicate_public_headers/Transport/generated.nanopb.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include <nanopb/pb.h>
+
+#define TRANSPORT_GENERATED_VALUE NANOPB_PUBLIC_VALUE

--- a/examples/xcode/generated_app_with_spm_c_target_duplicate_public_headers/Transport/include/Transport.h
+++ b/examples/xcode/generated_app_with_spm_c_target_duplicate_public_headers/Transport/include/Transport.h
@@ -1,0 +1,3 @@
+#pragma once
+
+int transport_value(void);

--- a/examples/xcode/generated_app_with_spm_c_target_duplicate_public_headers/Transport/transport.c
+++ b/examples/xcode/generated_app_with_spm_c_target_duplicate_public_headers/Transport/transport.c
@@ -1,0 +1,7 @@
+#include "Transport.h"
+#include "generated.nanopb.h"
+
+int transport_value(void)
+{
+    return TRANSPORT_GENERATED_VALUE;
+}

--- a/examples/xcode/generated_app_with_spm_c_target_duplicate_public_headers/Tuist/Package.swift
+++ b/examples/xcode/generated_app_with_spm_c_target_duplicate_public_headers/Tuist/Package.swift
@@ -13,5 +13,6 @@ let package = Package(
     name: "Deps",
     dependencies: [
         .package(path: "../Nanopb"),
+        .package(path: "../Transport"),
     ]
 )


### PR DESCRIPTION
## What changed

Backports #11648 to `releases/4.202.x`.

- Keeps SwiftPM C directory-target public headers de-duplicated for framework copy destinations while also excluding shadowed duplicate headers from the generated project header glob.
- Extends the nanopb-style acceptance fixture with a sibling C package that includes `<nanopb/pb.h>` from a generated header.
- Tightens acceptance coverage so shadowed wrapper headers must not remain in the generated nanopb headers phase.

## Why it changed

The latest RC line already includes the duplicate public-header fix, but still needs the follow-up nested-include fix. Without this backport, nanopb-style wrapper headers can remain available as generated project headers, allowing module-qualified includes such as `<nanopb/pb.h>` to resolve to a wrapper that includes itself recursively in some Xcode/header-map configurations.

## Root cause

The previous fix selected only one public framework header per flattened framework destination, which avoided duplicate copy commands. The shadowed wrapper headers were no longer Public, but they were still emitted as project headers. That left the wrapper headers available to consumers even though the nested headers were the actual framework public headers.

## Approach

This is a clean cherry-pick of the merged mainline fix commit from #11648:

- Mainline merge commit: `58e514491f85c1daae6fe2742ea33939efb5150c`
- Backport commit: `96e450b8724`

## Impact

The RC should avoid both nanopb-style failure modes:

- duplicate public framework header copy commands
- recursive wrapper-header resolution when consumers include module-qualified public headers

## Validation

Backport application:

- Clean cherry-pick onto `origin/releases/4.202.x`
- `git diff --check origin/releases/4.202.x..HEAD`

Mainline validation from #11648:

- Red: temporarily reverted only the mapper implementation while keeping the new test/fixture. The focused acceptance command failed with `nonPublicHeaderNames` equal to `["pb.h", "pb.h", "pb_common.h", "pb_common.h"]` instead of `["pb.h", "pb_common.h"]`.
- Green: restored the mapper fix and reran the same focused acceptance command. It passed and built the generated app fixture.
- `xcodebuild test -workspace Tuist.xcworkspace -scheme Tuist-Workspace -only-testing TuistGeneratorAcceptanceTests/GenerateAcceptanceTestAppWithSPMCTargetDuplicatePublicHeaders -destination platform=macOS -derivedDataPath /private/tmp/tuist-nested-headers-acceptance CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" COMPILATION_CACHE_ENABLE_CACHING=NO`
- `xcodebuild test -workspace Tuist.xcworkspace -scheme Tuist-Workspace -only-testing TuistLoaderTests/PackageInfoMapperTests -destination platform=macOS -derivedDataPath /private/tmp/tuist-nested-headers-loader-red CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" COMPILATION_CACHE_ENABLE_CACHING=NO`
