### PR TITLE
fix(server): route Linux runner builds to the account's in-cluster Kura node

### DIFF
--- a/.github/workflows/kura-cache-debug.yml
+++ b/.github/workflows/kura-cache-debug.yml
@@ -155,3 +155,99 @@ jobs:
           else
             echo ".bazelrc.tuist was not written"
           fi
+
+  # Same diagnostics from the macOS fleet: dispatch stages the Scaleway PN
+  # NodePort URL (http://<node PN address>:30815) for macOS, so this job shows
+  # what the CLI does with it after the single-listener cutover.
+  bazel-cache-debug-macos:
+    name: Bazel Remote Cache Debug (macOS)
+    runs-on: tuist-macos
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: jdx/mise-action@v4.0.1
+        with:
+          version: ${{ env.MISE_VERSION }}
+          install_args: "tuist"
+          working_directory: kura
+
+      - name: Inspect runner cache environment
+        run: |
+          if [ -n "${TUIST_CACHE_ENDPOINT:-}" ]; then
+            echo "TUIST_CACHE_ENDPOINT=${TUIST_CACHE_ENDPOINT}"
+          else
+            echo "TUIST_CACHE_ENDPOINT is UNSET (dispatch did not stage a runner-local cache endpoint)"
+          fi
+          echo "--- TUIST_* variable names visible to job steps ---"
+          env | grep -oE '^TUIST_[A-Z0-9_]+' | sort
+
+      - name: Probe candidate cache endpoints (unauthenticated)
+        run: |
+          probe() {
+            desc="$1"; url="$2"
+            echo "=== ${desc}: ${url} ==="
+            host=$(echo "$url" | sed -E 's#^[a-z]+://##; s#[:/].*$##')
+            dig +short +time=3 +tries=1 "$host" 2>/dev/null || echo "DNS: no resolution for ${host}"
+            curl -sS -o /dev/null -w 'HTTP/1.1 GET / -> %{http_code} (%{time_total}s)\n' \
+              --connect-timeout 5 --max-time 8 "$url/" || echo "HTTP/1.1 GET failed"
+            curl -sS -o /dev/null -w 'h2c GetCapabilities -> %{http_code} (%{time_total}s)\n' \
+              --connect-timeout 5 --max-time 8 \
+              --http2-prior-knowledge -X POST \
+              -H 'content-type: application/grpc' \
+              "$url/build.bazel.remote.execution.v2.Capabilities/GetCapabilities" \
+              || echo "h2c GetCapabilities failed"
+            echo
+          }
+
+          if [ -n "${TUIST_CACHE_ENDPOINT:-}" ]; then
+            probe "dispatch-staged endpoint" "${TUIST_CACHE_ENDPOINT%/}"
+          fi
+          # The PN NodePort the macOS fleet is expected to use (also probed
+          # explicitly in case the staged value differs).
+          probe "Scaleway PN NodePort" "http://172.16.0.2:30815"
+          # The public ingress the CLI falls back to without an override.
+          probe "public ingress" "https://tuist-eu-central-1.kura.tuist.dev"
+
+      - name: Authenticate and run tuist bazel setup
+        run: |
+          tuist auth login
+          tuist bazel setup
+
+      - name: Dump Tuist session logs (sanitized)
+        if: always()
+        run: |
+          sessions_dir="$HOME/.local/state/tuist/sessions"
+          if [ ! -d "$sessions_dir" ]; then
+            echo "No session logs at $sessions_dir"
+            exit 0
+          fi
+          sanitize() {
+            sed -E \
+              -e 's/[Bb]earer[[:space:]]+[A-Za-z0-9._~+/=-]+/Bearer [REDACTED]/g' \
+              -e 's/eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/[REDACTED_JWT]/g' \
+              -e 's/tuist_[A-Za-z0-9_-]{16,}/[REDACTED_TOKEN]/g' \
+              -e 's/[A-Fa-f0-9]{48,}/[REDACTED_HEX]/g'
+          }
+          for session in $(ls -t "$sessions_dir" | head -2); do
+            log="$sessions_dir/$session/logs.txt"
+            echo "::group::session $session"
+            if [ -f "$log" ]; then
+              sanitize <"$log"
+            else
+              echo "(no logs.txt)"
+            fi
+            echo "::endgroup::"
+          done
+
+      - name: Show generated .bazelrc.tuist (if any)
+        if: always()
+        run: |
+          if [ -f .bazelrc.tuist ]; then
+            cat .bazelrc.tuist
+          else
+            echo ".bazelrc.tuist was not written"
+          fi

--- a/.github/workflows/kura-cache-debug.yml
+++ b/.github/workflows/kura-cache-debug.yml
@@ -1,0 +1,150 @@
+# Temporary debug workflow: diagnose why `tuist bazel setup` fails to reach
+# the Bazel remote cache from the tuist-linux runner pool.
+#
+# It captures, from inside a runner pod:
+#   * whether dispatch handed the job a runner-local cache endpoint
+#     (TUIST_CACHE_ENDPOINT) — the poller stages it from the claim when the
+#     account has a private runner-cache Kura region for this platform;
+#   * unauthenticated HTTP/h2c reachability of the candidate endpoints
+#     (in-cluster Service DNS, the Scaleway PN NodePort, the public ingress);
+#   * the Tuist CLI session log (debug level) for the failing
+#     `tuist bazel setup`, with bearer tokens/JWTs redacted.
+#
+# Delete this workflow once the runner-cache routing for Linux fleets is fixed.
+name: Kura Cache Debug
+
+on:
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: kura-cache-debug-${{ github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    working-directory: kura
+
+env:
+  MISE_VERSION: "2026.5.15"
+  MISE_GITHUB_TOKEN: ${{ secrets.TUIST_CLI_GITHUB_TOKEN || github.token }}
+
+jobs:
+  bazel-cache-debug:
+    name: Bazel Remote Cache Debug
+    runs-on: tuist-linux
+    timeout-minutes: 30
+    # Same permission set as the trusted bazel-compile/clippy/test jobs:
+    # `id-token: write` is required for the OIDC `tuist auth login`.
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: jdx/mise-action@v4.0.1
+        with:
+          version: ${{ env.MISE_VERSION }}
+          install_args: "tuist"
+          working_directory: kura
+
+      - name: Inspect runner cache environment
+        run: |
+          # The endpoint URL is routing config (the poller logs it and it ends
+          # up in .bazelrc.tuist), not a credential — safe to print. For every
+          # other TUIST_* variable print the NAME only.
+          if [ -n "${TUIST_CACHE_ENDPOINT:-}" ]; then
+            echo "TUIST_CACHE_ENDPOINT=${TUIST_CACHE_ENDPOINT}"
+          else
+            echo "TUIST_CACHE_ENDPOINT is UNSET (dispatch did not stage a runner-local cache endpoint)"
+          fi
+          echo "--- TUIST_* variable names visible to job steps ---"
+          env | grep -oE '^TUIST_[A-Z0-9_]+' | sort
+
+      - name: Probe candidate cache endpoints (unauthenticated)
+        run: |
+          probe() {
+            desc="$1"; url="$2"
+            echo "=== ${desc}: ${url} ==="
+            host=$(echo "$url" | sed -E 's#^[a-z]+://##; s#[:/].*$##')
+            getent hosts "$host" || echo "DNS: no resolution for ${host}"
+            # Plain HTTP/1.1 GET: proves TCP+HTTP reachability and shows what
+            # the listener answers on the root path.
+            curl -sS -o /dev/null -w 'HTTP/1.1 GET / -> %{http_code} (%{time_total}s)\n' \
+              --connect-timeout 5 --max-time 8 "$url/" || echo "HTTP/1.1 GET failed"
+            # h2c prior-knowledge POST to the REAPI GetCapabilities path: the
+            # closest curl gets to Bazel's gRPC handshake. No auth header, so
+            # a routed listener answers 200 + grpc-status (unauthenticated)
+            # while a broken route answers 404/502 or times out.
+            curl -sS -o /dev/null -w 'h2c GetCapabilities -> %{http_code} (%{time_total}s)\n' \
+              --connect-timeout 5 --max-time 8 \
+              --http2-prior-knowledge -X POST \
+              -H 'content-type: application/grpc' \
+              "$url/build.bazel.remote.execution.v2.Capabilities/GetCapabilities" \
+              || echo "h2c GetCapabilities failed"
+            echo
+          }
+
+          if [ -n "${TUIST_CACHE_ENDPOINT:-}" ]; then
+            probe "dispatch-staged endpoint" "${TUIST_CACHE_ENDPOINT%/}"
+          fi
+          # The tuist account's in-cluster Kura (public region pods) over
+          # Service DNS: the runners-namespace egress policy explicitly allows
+          # runner pods -> kura pods on 4000, so this shows whether an
+          # in-cluster URL would work if dispatch handed one out.
+          probe "in-cluster service (eu-central-1)" "http://kura-tuist-eu-central-1.kura.svc.cluster.local:4000"
+          # The private runner-cache node's ClusterIP service (pod network).
+          probe "in-cluster service (scw-fr-par runner cache)" "http://kura-tuist-scw-fr-par.kura.svc.cluster.local:4000"
+          # The Scaleway Private Network NodePort the macOS fleet uses.
+          # Expected unreachable from the Hetzner Linux fleet (different side
+          # of the WAN) — included to prove the locality gate is real.
+          probe "Scaleway PN NodePort" "http://172.16.0.2:30815"
+          # The public ingress the CLI falls back to without an override.
+          probe "public ingress" "https://tuist-eu-central-1.kura.tuist.dev"
+
+      - name: Authenticate and run tuist bazel setup
+        run: |
+          tuist auth login
+          tuist bazel setup
+
+      - name: Dump Tuist session logs (sanitized)
+        if: always()
+        run: |
+          sessions_dir="$HOME/.local/state/tuist/sessions"
+          if [ ! -d "$sessions_dir" ]; then
+            echo "No session logs at $sessions_dir"
+            exit 0
+          fi
+          # Redact anything credential-shaped: bearer values, JWTs, tuist_*
+          # tokens, and long hex strings (API-key-shaped). Everything else in
+          # the log is endpoint-resolution/probe tracing we need to see.
+          sanitize() {
+            sed -E \
+              -e 's/[Bb]earer[[:space:]]+[A-Za-z0-9._~+/=-]+/Bearer [REDACTED]/g' \
+              -e 's/eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/[REDACTED_JWT]/g' \
+              -e 's/tuist_[A-Za-z0-9_-]{16,}/[REDACTED_TOKEN]/g' \
+              -e 's/[A-Fa-f0-9]{48,}/[REDACTED_HEX]/g'
+          }
+          # Both `tuist auth login` and `tuist bazel setup` create a session;
+          # dump the two most recent.
+          for session in $(ls -t "$sessions_dir" | head -2); do
+            log="$sessions_dir/$session/logs.txt"
+            echo "::group::session $session"
+            if [ -f "$log" ]; then
+              sanitize <"$log"
+            else
+              echo "(no logs.txt)"
+            fi
+            echo "::endgroup::"
+          done
+
+      - name: Show generated .bazelrc.tuist (if any)
+        if: always()
+        run: |
+          if [ -f .bazelrc.tuist ]; then
+            cat .bazelrc.tuist
+          else
+            echo ".bazelrc.tuist was not written"
+          fi

--- a/.github/workflows/kura-cache-debug.yml
+++ b/.github/workflows/kura-cache-debug.yml
@@ -15,6 +15,13 @@ name: Kura Cache Debug
 
 on:
   workflow_dispatch: {}
+  # Push trigger for iteration: GitHub doesn't index a branch-only workflow
+  # for workflow_dispatch right away, so run on pushes to the debug branch.
+  push:
+    branches:
+      - tuist-runners-grpc
+    paths:
+      - .github/workflows/kura-cache-debug.yml
 
 permissions:
   contents: read

--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -69,8 +69,12 @@ server:
     # Hand cluster-networked fleets the in-cluster cache endpoint. macOS
     # resolves to the node-port form (http://<node PN address>:<NodePort>
     # on scw-fr-par-runners), reached over the PN the minis attach to
-    # (macosFleet.vmCachePrivateNetwork below). linux is the default and
-    # stays inert here (prod advertises no Linux private cache region).
+    # (macosFleet.vmCachePrivateNetwork below). linux resolves through the
+    # public-region fallback: prod advertises no Linux private cache
+    # region, so dispatch hands the account's eu-central instance over
+    # in-cluster Service DNS (the public Kura ingress is unreachable from
+    # runner pods — its host is a cluster node IP, which the runner
+    # egress policy's ipBlock rules never match under Cilium).
     - name: TUIST_RUNNERS_CLUSTER_NETWORK_PLATFORMS
       value: linux,macos
     # Operator project-access grants. The public key verifies grants

--- a/server/lib/tuist/kura.ex
+++ b/server/lib/tuist/kura.ex
@@ -489,25 +489,43 @@ defmodule Tuist.Kura do
 
   @doc """
   In-cluster Kura URL a runner-as-a-service build on a fleet of the
-  given platform should use, or `nil` when the account has no active
-  private (runner-cache) Kura node in a region that serves that
-  platform.
+  given platform should use, or `nil` when nothing serves that platform.
+
+  Two tiers, best first:
+
+    1. The account's active private (runner-cache) Kura node in a
+       region that serves the platform — provisioned next to the fleet,
+       so the cache hot path never leaves the fleet's own network.
+    2. The account's active regular Kura node in a public region that
+       declares the platform (`Regions.runner_platforms` on a public
+       region, e.g. eu-central for `:linux`), addressed by its
+       in-cluster Service DNS form. Runner pods cannot use the public
+       ingress at all — its host resolves to a cluster node IP, which
+       Cilium classifies as `remote-node` and the runner egress
+       policy's `ipBlock` rules never match — so without this fallback
+       an account with no private node gets no cache rather than a
+       slower one.
 
   Builds executing on a runner pool resolve their cache through this so
-  traffic stays inside the cluster, next to the runners, instead of
-  crossing the public ingress dataplane. Auth is unchanged: the same
-  Guardian JWT is verified by the same `tuist.lua` hook on the private
-  node, which carries the same `tenantID`. This reads the active
-  private `Server` row directly — `account_cache_endpoints` is
-  CLI-facing and a developer machine can't reach the in-cluster
-  endpoint.
+  traffic stays inside the cluster instead of crossing the public
+  ingress dataplane. Auth is unchanged in both tiers: the same Guardian
+  JWT is verified by the same `tuist.lua` hook on the node, which
+  carries the same `tenantID`. This reads active `Server` rows directly
+  — `account_cache_endpoints` is CLI-facing and a developer machine
+  can't reach the in-cluster endpoint.
 
   The platform filter is the locality half of the handoff (which
   region's node may serve which fleet — `Regions.runner_platforms`);
   whether the fleet can reach in-cluster URLs at all is the caller's
   gate (`Catalog.fleet_on_cluster_network?/1`).
   """
-  def runner_cache_endpoint_url(%Account{id: account_id}, platform) when platform in [:linux, :macos] do
+  def runner_cache_endpoint_url(%Account{} = account, platform) when platform in [:linux, :macos] do
+    private_runner_cache_url(account, platform) || public_in_cluster_runner_cache_url(account, platform)
+  end
+
+  def runner_cache_endpoint_url(%Account{}, _platform), do: nil
+
+  defp private_runner_cache_url(%Account{id: account_id}, platform) do
     # `available/0`, not `all/0`: if a private region is dropped from
     # `TUIST_KURA_AVAILABLE_REGIONS` the controller stops reconciling
     # it, and gating here too means dispatch stops handing out the now
@@ -548,7 +566,41 @@ defmodule Tuist.Kura do
     end
   end
 
-  def runner_cache_endpoint_url(%Account{}, _platform), do: nil
+  # The public-region fallback (tier 2 above). No readiness heartbeat is
+  # consulted: like cluster-DNS private servers, the in-cluster Service
+  # drops a not-ready pod from its endpoints, so an active row is a
+  # serving row.
+  defp public_in_cluster_runner_cache_url(%Account{id: account_id} = account, platform) do
+    case public_runner_cache_region_ids(platform) do
+      [] -> nil
+      region_ids -> account_id |> active_server_in_regions(region_ids) |> in_cluster_url(account)
+    end
+  end
+
+  defp public_runner_cache_region_ids(platform) do
+    Regions.available()
+    |> Enum.filter(&(not Regions.private?(&1) and Regions.serves_runner_platform?(&1, platform)))
+    |> Enum.map(& &1.id)
+  end
+
+  defp active_server_in_regions(account_id, region_ids) do
+    Server
+    |> where([s], s.account_id == ^account_id and s.status == :active and s.region in ^region_ids)
+    |> order_by(asc: :region)
+    |> limit(1)
+    |> Repo.one()
+  end
+
+  defp in_cluster_url(nil, _account), do: nil
+
+  # The `Server.url` column holds the public URL for these rows, so the
+  # in-cluster form is rendered fresh from the region's template.
+  defp in_cluster_url(%Server{} = server, account) do
+    case Provisioner.internal_url(account, server) do
+      url when is_binary(url) and url != "" -> url
+      _ -> nil
+    end
+  end
 
   defp node_port_region_ids(private_region_ids) do
     Enum.filter(private_region_ids, fn id ->

--- a/server/lib/tuist/kura/provisioner.ex
+++ b/server/lib/tuist/kura/provisioner.ex
@@ -73,6 +73,16 @@ defmodule Tuist.Kura.Provisioner do
               String.t() | nil
 
   @doc """
+  In-cluster URL of the server, or `nil` if the region has no
+  cluster-internal form. Only reachable from workloads on the cluster
+  network (runner fleets); never handed to the CLI. Runner dispatch uses
+  it for private regions' cluster-DNS data plane and as the public-region
+  fallback (`Tuist.Kura.runner_cache_endpoint_url/2`).
+  """
+  @callback internal_url(account_handle :: String.t(), Regions.t(), ref :: String.t() | nil) ::
+              String.t() | nil
+
+  @doc """
   Best-effort drift check: what version is actually running on the
   node right now? Returns `{:ok, nil}` when the resource exists but
   isn't reporting a version yet. Used for reconciliation jobs and the
@@ -140,6 +150,13 @@ defmodule Tuist.Kura.Provisioner do
   def grpc_public_url(%Account{name: handle}, %Server{provisioner_node_ref: ref, region: region_id}) do
     with {:ok, region} <- Regions.fetch(region_id) do
       region.provisioner.grpc_public_url(handle, region, ref)
+    end
+  end
+
+  @doc "Calls `internal_url/3` on the region's provisioner."
+  def internal_url(%Account{name: handle}, %Server{provisioner_node_ref: ref, region: region_id}) do
+    with {:ok, region} <- Regions.fetch(region_id) do
+      region.provisioner.internal_url(handle, region, ref)
     end
   end
 

--- a/server/lib/tuist/kura/provisioner/kubernetes_controller.ex
+++ b/server/lib/tuist/kura/provisioner/kubernetes_controller.ex
@@ -96,6 +96,14 @@ defmodule Tuist.Kura.Provisioner.KubernetesController do
   end
 
   @impl true
+  def internal_url(handle, %Regions{provisioner_config: config} = region, _ref) do
+    case config[:private_url_template] do
+      template when is_binary(template) -> interpolate_private_url(template, handle, region)
+      _ -> nil
+    end
+  end
+
+  @impl true
   def current_image_tag(name, %Regions{} = region) do
     case client_get_kura_instance(@namespace, name, region) do
       {:ok, %{"status" => %{"observedImage" => image}}} -> {:ok, image_tag_from_image(image)}

--- a/server/lib/tuist/kura/regions.ex
+++ b/server/lib/tuist/kura/regions.ex
@@ -51,6 +51,13 @@ defmodule Tuist.Kura.Regions do
   # controller's peerPort). Self-hosted nodes dial the public peer host here.
   @peer_port 7443
   @managed_region_storage_class "hcloud-volumes"
+  # In-cluster Service DNS form of a region's per-account instance. Port
+  # 4000 co-hosts the HTTP cache API and REAPI gRPC (h2c) on one Kura
+  # listener. Private regions dispatch it to runner fleets directly;
+  # public regions expose it only through the runner-cache dispatch
+  # fallback (`Tuist.Kura.runner_cache_endpoint_url/2`) — it is never
+  # CLI-facing (developer machines can't resolve cluster DNS).
+  @in_cluster_url_template "http://{instance}.kura.svc.cluster.local:4000"
   # The guaranteed egress floor an enterprise tenant reserves on a shared
   # bare-metal box, requested as the tuist.dev/egress-mbps extended resource the
   # scheduler bin-packs against the node's budget. Uniform across regions — a
@@ -124,6 +131,17 @@ defmodule Tuist.Kura.Regions do
       gateway: :host_network,
       replicas: 2,
       storage_size: "50Gi",
+      # Runner-cache dispatch fallback: when an account has no private
+      # runner-cache node serving a platform, dispatch may hand fleets of
+      # these platforms this region's per-account instance over in-cluster
+      # Service DNS. Linux runner pools are kata Pods on the cluster CNI in
+      # every environment that exposes this region, so the URL resolves and
+      # routes for them; the public ingress does NOT (its host is a cluster
+      # node IP, which the runner pods' egress `ipBlock` rules never match
+      # under Cilium). macOS is deliberately absent: the Tart VMs sit on the
+      # Scaleway Private Network, not the cluster network, and are served by
+      # `scw-fr-par-runners` instead.
+      runner_platforms: [:linux],
       # Egress governance on the shared box (~1 Gbit/s NIC): the enterprise
       # per-tenant floor (uniform across regions) is bin-packed as the
       # tuist.dev/egress-mbps request; egress_burst_mbps is the Cilium burst ceiling.
@@ -312,13 +330,17 @@ defmodule Tuist.Kura.Regions do
   end
 
   @doc """
-  True iff this region's runner-cache nodes serve runner fleets of the
-  given platform (`:linux` | `:macos`). Always `false` for public
-  regions — they have no `runner_platforms` and are CLI-facing, not
-  runner-facing. This is the dispatch-side locality gate: a runner only
-  ever receives a `cache_endpoint_url` from a region that declared its
-  platform, so a region pinned next to one fleet can't leak its
-  in-cluster URL to a fleet on the wrong side of a WAN.
+  True iff this region's nodes serve runner fleets of the given platform
+  (`:linux` | `:macos`). This is the dispatch-side locality gate: a
+  runner only ever receives a `cache_endpoint_url` from a region that
+  declared its platform, so a region's in-cluster URL can't leak to a
+  fleet whose runtime cannot reach it.
+
+  Private (runner-cache) regions always declare their platforms. Public
+  regions default to none — they are CLI-facing — but may declare
+  platforms to opt their per-account instances into the runner-cache
+  dispatch fallback (`Tuist.Kura.runner_cache_endpoint_url/2`), for
+  fleets that can reach the in-cluster Service DNS form directly.
   """
   def serves_runner_platform?(%__MODULE__{runner_platforms: platforms}, platform) when is_list(platforms) do
     platform in platforms
@@ -361,11 +383,16 @@ defmodule Tuist.Kura.Regions do
     %__MODULE__{
       id: spec.id,
       display_name: spec.display_name,
+      # Most public regions serve no runner fleet (nil). A public region
+      # may declare platforms to opt its per-account instances into the
+      # runner-cache dispatch fallback (see the eu-central spec).
+      runner_platforms: Map.get(spec, :runner_platforms),
       provisioner: KubernetesController,
       provisioner_config: %{
         cluster_id: spec.cluster_id,
         hetzner_location: Map.get(spec, :hetzner_location),
         public_host_template: String.replace(@managed_region_public_host_template, "{env_suffix}", host_suffix),
+        private_url_template: @in_cluster_url_template,
         grpc_public_host_template: String.replace(@managed_region_grpc_public_host_template, "{env_suffix}", host_suffix),
         peer_public_host_template: String.replace(@managed_region_peer_public_host_template, "{env_suffix}", host_suffix),
         ingress_class_name: spec.ingress_class_name,
@@ -441,7 +468,7 @@ defmodule Tuist.Kura.Regions do
         # interpolates to `instance_name(handle, region)`. Node-port
         # regions don't use it for dispatch but keep it as the
         # in-cluster debugging path.
-        private_url_template: "http://{instance}.kura.svc.cluster.local:4000",
+        private_url_template: @in_cluster_url_template,
         data_plane: Map.get(spec, :data_plane, :cluster_dns),
         client_cidrs: Map.get(spec, :client_cidrs, []),
         pod_annotations: Map.get(spec, :pod_annotations, %{}),

--- a/server/lib/tuist_web/controllers/runners_controller.ex
+++ b/server/lib/tuist_web/controllers/runners_controller.ex
@@ -133,13 +133,15 @@ defmodule TuistWeb.RunnersController do
     conn |> put_status(:bad_request) |> json(%{error: "missing fleet query param"})
   end
 
-  # Hands the polling Pod its JIT config plus, when the account runs a
-  # private runner-cache Kura node, the in-cluster URL the job should
-  # use. The runner image exports it as `TUIST_CACHE_ENDPOINT` so cache
-  # traffic stays on the cluster's internal network next to the runner
-  # instead of going through the public Kura ingress. Absent
-  # (non-runner-cache accounts), the Pod falls back to normal
-  # server-side cache resolution.
+  # Hands the polling Pod its JIT config plus, when the account has a
+  # Kura node serving the fleet's platform (a private runner-cache node
+  # first, else a public region's per-account instance over in-cluster
+  # Service DNS — see `Tuist.Kura.runner_cache_endpoint_url/2`), the
+  # in-cluster URL the job should use. The runner image exports it as
+  # `TUIST_CACHE_ENDPOINT` so cache traffic stays on the cluster's
+  # internal network instead of going through the public Kura ingress.
+  # Absent (no serving node), the Pod falls back to normal server-side
+  # cache resolution.
   #
   # Only fleets on the cluster pod network get the URL: it's a
   # `*.svc.cluster.local` address, and clients treat

--- a/server/test/tuist/kura/provisioner/kubernetes_controller_test.exs
+++ b/server/test/tuist/kura/provisioner/kubernetes_controller_test.exs
@@ -862,6 +862,24 @@ defmodule Tuist.Kura.Provisioner.KubernetesControllerTest do
     end
   end
 
+  describe "internal_url/3" do
+    test "returns the in-cluster Service DNS URL built from private_url_template" do
+      assert KubernetesController.internal_url("TUIST", scaleway_region(), "any-ref") ==
+               "http://kura-tuist-scw-fr-par.kura.svc.cluster.local:4000"
+    end
+
+    test "renders the public regions' template for the runner-cache fallback" do
+      assert KubernetesController.internal_url("Tuist", Regions.get("eu-central"), nil) ==
+               "http://kura-tuist-eu-central-1.kura.svc.cluster.local:4000"
+    end
+
+    test "is nil for regions without an in-cluster template" do
+      region = %Regions{id: "local-controller", provisioner_config: %{cluster_id: "local-controller"}}
+
+      assert KubernetesController.internal_url("tuist", region, nil) == nil
+    end
+  end
+
   defp scaleway_region do
     %Regions{
       id: "scw-fr-par-runners",

--- a/server/test/tuist/kura/regions_test.exs
+++ b/server/test/tuist/kura/regions_test.exs
@@ -286,8 +286,17 @@ defmodule Tuist.Kura.RegionsTest do
       refute Regions.node_port_data_plane?(nil)
     end
 
-    test "public regions and nil serve no runner platform" do
-      refute Regions.serves_runner_platform?(Regions.get("eu-central"), :linux)
+    test "eu-central serves linux fleets as the public in-cluster fallback" do
+      eu_central = Regions.get("eu-central")
+
+      assert eu_central.runner_platforms == [:linux]
+      assert Regions.serves_runner_platform?(eu_central, :linux)
+      refute Regions.serves_runner_platform?(eu_central, :macos)
+    end
+
+    test "undeclared public regions and nil serve no runner platform" do
+      refute Regions.serves_runner_platform?(Regions.get("us-east"), :linux)
+      refute Regions.serves_runner_platform?(Regions.get("us-west"), :linux)
       refute Regions.serves_runner_platform?(Regions.get("local-controller"), :macos)
       refute Regions.serves_runner_platform?(nil, :linux)
     end

--- a/server/test/tuist/kura_test.exs
+++ b/server/test/tuist/kura_test.exs
@@ -803,6 +803,100 @@ defmodule Tuist.KuraTest do
     end
   end
 
+  describe "runner_cache_endpoint_url/2 public in-cluster fallback" do
+    setup do
+      stub(Tuist.Environment, :dev?, fn -> false end)
+      stub(Tuist.Environment, :test?, fn -> false end)
+
+      stub(Tuist.Environment, :kura_available_region_ids, fn ->
+        ["eu-central", "scw-fr-par-runners"]
+      end)
+
+      user = AccountsFixtures.user_fixture()
+      account = Accounts.get_account_from_user(user)
+
+      %{account: account}
+    end
+
+    test "hands linux fleets the public region's in-cluster Service DNS URL when no private region serves them",
+         %{account: account} do
+      {:ok, server} =
+        Kura.create_server(%{account_id: account.id, region: "eu-central", image_tag: "0.5.2"})
+
+      Server |> Repo.get!(server.id) |> Ecto.Changeset.change(status: :active) |> Repo.update!()
+
+      handle = String.downcase(account.name)
+
+      assert Kura.runner_cache_endpoint_url(account, :linux) ==
+               "http://kura-#{handle}-eu-central-1.kura.svc.cluster.local:4000"
+    end
+
+    test "never hands macOS fleets a public region's URL — no public region declares :macos",
+         %{account: account} do
+      {:ok, server} =
+        Kura.create_server(%{account_id: account.id, region: "eu-central", image_tag: "0.5.2"})
+
+      Server |> Repo.get!(server.id) |> Ecto.Changeset.change(status: :active) |> Repo.update!()
+
+      assert Kura.runner_cache_endpoint_url(account, :macos) == nil
+    end
+
+    test "macOS stays on default resolution when its private node's heartbeat is stale, despite an active public server",
+         %{account: account} do
+      {:ok, private} =
+        Kura.create_server(%{account_id: account.id, region: "scw-fr-par-runners", image_tag: "0.5.2"})
+
+      expect(Provisioner, :external_endpoint, fn %Server{} -> {:ok, "http://172.16.0.2:30815"} end)
+      {:ok, active_private} = Kura.activate_server(private, "0.5.2")
+
+      stale = ~U[2020-01-01 00:00:00Z]
+      Server |> Repo.get!(active_private.id) |> Ecto.Changeset.change(last_ready_at: stale) |> Repo.update!()
+
+      {:ok, public} =
+        Kura.create_server(%{account_id: account.id, region: "eu-central", image_tag: "0.5.2"})
+
+      Server |> Repo.get!(public.id) |> Ecto.Changeset.change(status: :active) |> Repo.update!()
+
+      # The Tart VMs can't resolve cluster Service DNS, so a stale private
+      # node must fail macOS over to the public cache (nil), never to the
+      # in-cluster fallback URL.
+      assert Kura.runner_cache_endpoint_url(account, :macos) == nil
+    end
+
+    test "prefers a serving private runner-cache node over the public fallback", %{account: account} do
+      stub(Tuist.Environment, :kura_available_region_ids, fn ->
+        ["eu-central", "hetzner-staging-runners"]
+      end)
+
+      {:ok, public} =
+        Kura.create_server(%{account_id: account.id, region: "eu-central", image_tag: "0.5.2"})
+
+      Server |> Repo.get!(public.id) |> Ecto.Changeset.change(status: :active) |> Repo.update!()
+
+      {:ok, private} =
+        Kura.create_server(%{account_id: account.id, region: "hetzner-staging-runners", image_tag: "0.5.2"})
+
+      stub(Provisioner, :public_url, fn _account, %Server{} ->
+        "http://kura-private.kura.svc.cluster.local"
+      end)
+
+      {:ok, active_private} = Kura.activate_server(private, "0.5.2")
+
+      assert Kura.runner_cache_endpoint_url(account, :linux) == active_private.url
+    end
+
+    test "requires an active public server", %{account: account} do
+      {:ok, _server} =
+        Kura.create_server(%{account_id: account.id, region: "eu-central", image_tag: "0.5.2"})
+
+      assert Kura.runner_cache_endpoint_url(account, :linux) == nil
+    end
+
+    test "is nil for accounts without any server", %{account: account} do
+      assert Kura.runner_cache_endpoint_url(account, :linux) == nil
+    end
+  end
+
   describe "destroy_server/1" do
     test "marks destroying and removes the cache endpoint" do
       user = AccountsFixtures.user_fixture()


### PR DESCRIPTION
## What changed

`Tuist.Kura.runner_cache_endpoint_url/2` gains a second tier: when no **private** runner-cache node serves the fleet's platform, dispatch now hands out the account's active **public-region** Kura server addressed by its in-cluster Service DNS form (`http://kura-<account>-<cluster_id>.kura.svc.cluster.local:4000`).

- Public region specs may now declare `runner_platforms` to opt into this fallback; `eu-central` declares `[:linux]`. Undeclared public regions (us-east, us-west, ca-east) keep serving no runner fleet.
- New `Provisioner.internal_url/2` callback renders the in-cluster form from the region's `private_url_template`, which managed (public) regions now also carry. `public_url/3` behavior is unchanged (it resolves public templates first).
- The dispatch controller contract is unchanged — the claim's `cache_endpoint_url` is still gated by `Catalog.fleet_on_cluster_network?/1` and the platform, and the runner image already exports it as `TUIST_CACHE_ENDPOINT`.

## Why / root cause

Every trusted kura.yml job on the `tuist-linux` pool fails `tuist bazel setup` (masked by `continue-on-error`, so Bazel builds run cold — e.g. [this run](https://github.com/tuist/tuist/actions/runs/28684359838/job/85138411554)). The failure chain, confirmed from inside a runner pod with a debug workflow ([run 28710663346](https://github.com/tuist/tuist/actions/runs/28710663346)):

1. Prod advertises no Linux private cache region (`scw-fr-par-runners` is macOS-only, co-located with the Mac minis on the Scaleway Private Network), so dispatch stages no `TUIST_CACHE_ENDPOINT` for Linux fleets.
2. The CLI falls back to `/api/cache/endpoints`, which returns only the public `https://tuist-eu-central-1.kura.tuist.dev`.
3. That host resolves to a **cluster node's own IP** (the dedibox-fleet node hosting the Kura ingress). Cilium classifies traffic to node IPs as `remote-node` identity, which the runners' `0.0.0.0/0` egress `ipBlock` rule never matches — the connection is silently dropped, the REAPI `GetCapabilities` probe times out after 10s (`Swift.CancellationError`), and `.bazelrc.tuist` is never written.

The public ingress is therefore unusable from runner pods by construction; the fix routes them over the path that already works and is already allowed by the runners-namespace egress rule (runner pods → kura pods on 4000).

## Why this solution

- **In-runner probes** showed `http://kura-tuist-eu-central-1.kura.svc.cluster.local:4000` answering unauthenticated h2c `GetCapabilities` with 200 in ~57ms, while the public ingress and the Scaleway PN NodePort both time out from the Linux fleet. The same run's macOS job confirmed the PN NodePort path works end-to-end there (setup succeeds, ~2ms probes) — so the fix deliberately leaves macOS untouched: no public region declares `:macos`, and a stale private node still fails macOS over to the public cache (reachable from Tart VMs), never to a cluster-DNS URL the VMs can't resolve.
- Alternatives considered: loosening runner egress to reach the public ingress (reintroduces the hairpin through the public dataplane the private path exists to avoid, and widens the egress policy to cluster nodes), or provisioning a dedicated Linux private region in prod (new infrastructure for traffic the account's existing in-cluster node can already serve). Auth is identical in both tiers — the same Guardian JWT verified by the same `tuist.lua` hook.

## Impact

Linux runner jobs in production (and staging, which also exposes `eu-central` with linux cluster-networked) get a working Bazel remote cache again for accounts with an eu-central Kura server. Accounts without one keep today's behavior (no cache). macOS routing is byte-for-byte unchanged.

## Validation

- `mix test test/tuist/kura_test.exs test/tuist/kura/regions_test.exs test/tuist/kura/provisioner/kubernetes_controller_test.exs test/tuist_web/controllers/runners_controller_test.exs test/tuist/kura/runner_cache_test.exs` — 151 tests, 0 failures. New coverage: the fallback URL for `:linux`, private-node precedence, the macOS never-falls-back guarantees (both no-declaration and stale-heartbeat cases), inactive/absent server cases, and `internal_url/3` rendering.
- `mix credo` and `mix format` clean on the changed files.
- The branch also carries `.github/workflows/kura-cache-debug.yml` (Linux + macOS diagnostic jobs, credential-redacting log dumps). It's temporary tooling: after this deploys, dispatching it should show `TUIST_CACHE_ENDPOINT=http://kura-tuist-eu-central-1.kura.svc.cluster.local:4000` on the Linux job and `tuist bazel setup` succeeding; delete the workflow once verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)