### PR TITLE
feat(infra): cut prod backups over to the Barman Cloud Plugin (primaryUpdateMethod: restart)

### DIFF
--- a/infra/cnpg/README.md
+++ b/infra/cnpg/README.md
@@ -226,10 +226,27 @@ Deployment (release-prefixed as a subchart), a Service, and self-signed mTLS
 Certificates.
 
 **Cutover (per env):** with the plugin installed, flip
-`…backup.plugin.enabled` to `true` and deploy. This is an atomic change to the
-`Cluster` (drops `.spec.backup.barmanObjectStore`, adds `.spec.plugins`), so it
-triggers a rolling update + switchover — merge it in a low-traffic window like
-an operator bump.
+`…backup.plugin.enabled` to `true` **and set `…cnpg.primaryUpdateMethod:
+restart`** for the roll, then deploy. This is an atomic `Cluster` change (drops
+`.spec.backup.barmanObjectStore`, adds `.spec.plugins`) that recreates every
+instance to inject the plugin sidecar.
+
+**Do NOT cut over with the default `switchover` method.** The old primary has no
+sidecar yet, so it can't archive via the plugin, and CNPG's graceful switchover
+hangs indefinitely waiting for it to archive its final WAL — the operator wedges
+with no primary (this happened on canary 2026-07-04). `restart` recreates the
+primary *in place* instead, avoiding the handoff. Validated on staging, at the
+cost of a bounded **~3 min of write-downtime** while the primary pod recreates —
+so merge in a low-traffic window. Revert `primaryUpdateMethod` to the default
+(`switchover`) once the env is on the plugin, so future operator bumps keep the
+seconds-long switchover blip.
+
+**If the roll sticks anyway** (no primary, operator looping "switchover in
+progress"), recover with break-glass: force-remove the old primary and restart
+the operator — `kubectl delete pod <old-primary> --grace-period=0 --force` then
+`kubectl -n platform rollout restart deploy/platform-cloudnative-pg`. CNPG then
+promotes the caught-up sync standby, lossless (RPO 0 with quorum sync). Proven
+recovery.
 
 **Continuity invariant (verify before trusting it):** the plugin must keep
 writing to the SAME archive. `serverName` is pinned to the cluster name (the

--- a/infra/helm/tuist/templates/postgresql-cnpg.yaml
+++ b/infra/helm/tuist/templates/postgresql-cnpg.yaml
@@ -42,7 +42,7 @@ spec:
   instances: {{ .Values.postgresql.cnpg.instances }}
   imageName: {{ .Values.postgresql.cnpg.image.repository }}:{{ .Values.postgresql.cnpg.image.tag }}
   primaryUpdateStrategy: unsupervised
-  primaryUpdateMethod: switchover
+  primaryUpdateMethod: {{ .Values.postgresql.cnpg.primaryUpdateMethod | default "switchover" }}
 
   # Synchronous replication: the primary holds a COMMIT's ack until a
   # standby has the WAL durably (`ANY 1` quorum), so an acknowledged

--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -183,6 +183,14 @@ postgresql:
   mode: cnpg
   cnpg:
     instances: 3
+    # Cutover to the Barman Cloud Plugin uses `restart` (recreate the primary in
+    # place) instead of the default `switchover`: the plugin sidecar isn't on the
+    # old primary yet, so a graceful switchover deadlocks waiting for it to
+    # archive (validated on staging 2026-07-04). Costs a bounded ~3 min of write
+    # downtime during the one cutover roll. Revert to the default (switchover)
+    # once prod is on the plugin, so future operator bumps keep the seconds-long
+    # switchover blip. See infra/cnpg/README.md.
+    primaryUpdateMethod: restart
     # Route the processor through the transaction-mode PgBouncer pooler.
     # Web tier stays direct on `-rw` (it holds a long-lived ~75-conn pool
     # that wouldn't benefit from session-mode bouncing); the processor's


### PR DESCRIPTION
## What this does

Cuts the **production** main CNPG cluster (`tuist-tuist-pg`, 3 instances) over from in-tree `barmanObjectStore` to the **Barman Cloud Plugin**, using **`primaryUpdateMethod: restart`** for the roll instead of the default `switchover`.

- Templates `primaryUpdateMethod` in the chart (default `switchover`, unchanged for every other cluster).
- Sets `postgresql.cnpg.primaryUpdateMethod: restart` in `values-managed-production.yaml`. Prod already has `plugin.enabled: true` (from #11564), so this is the piece that makes the cutover actually work.

## Why `restart` (this is the whole point)

The default `switchover` **deadlocked the canary cutover** on 2026-07-04: flipping to the plugin changes the primary's archive command to the plugin immediately, but the old primary pod has no sidecar yet, so it can't archive — and CNPG's graceful switchover hangs indefinitely waiting for it to archive its final WAL. The operator wedged with no primary for ~25 min (canary DB write-down); recovery needed break-glass.

`restart` recreates the primary **in place** (no handoff to a replica, so nothing to gate on archiving). **Validated on staging** (2026-07-04): the replica rolled to get its sidecar, the primary was recreated in place, the cluster re-elected a primary, and `Working WAL archiving` went green — no deadlock.

## What merging does — MERGE IN A LOW-TRAFFIC WINDOW

Merging triggers the prod cascade (canary → acceptance → production). Canary is already on the plugin, so its deploy is a no-op. **Production then cuts over**, and the restart roll causes a **bounded ~3 min window with no writable primary** while the primary pod recreates. Treat it like a planned maintenance blip — merge at the start of a quiet window. Draft until you pick the window.

## Recovery net (proven)

If the roll sticks anyway (no primary, operator looping "switchover in progress"), with the break-glass kubeconfig:

```bash
kubectl -n tuist delete pod <old-primary> --grace-period=0 --force
kubectl -n platform rollout restart deploy/platform-cloudnative-pg
```

CNPG then promotes the caught-up sync standby — lossless (RPO 0, quorum sync). This is exactly how canary was recovered.

## Follow-ups

- After prod is confirmed on the plugin (archiving green + a restore drill), **revert `primaryUpdateMethod` back to the default `switchover`** so future operator bumps keep their seconds-long blip instead of a ~3 min restart.
- `tuist-ops` (single-instance, prod-only, separate chart) is out of scope here — it has no replica to switch to, so it just restarts its one pod and can't hit this deadlock; it'll cut over safely on its own next deploy.

## Validation

`helm template` renders prod with `primaryUpdateMethod: restart` + the plugin path (`plugins`/`ObjectStore`/`method: plugin`, no `barmanObjectStore`); every other env still renders `switchover`. Staging proved the method end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
