### PR TITLE
fix(infra): cut canary over to the Barman Cloud Plugin (primaryUpdateMethod: restart)

### DIFF
--- a/infra/helm/tuist/values-managed-canary.yaml
+++ b/infra/helm/tuist/values-managed-canary.yaml
@@ -165,6 +165,12 @@ postgresql:
   mode: cnpg
   cnpg:
     instances: 2
+    # Cutover to the Barman Cloud Plugin uses `restart` (recreate the primary in
+    # place) instead of the default `switchover`, which deadlocks the cutover
+    # roll (old primary can't archive via the plugin before it has the sidecar).
+    # ~3 min write-downtime during the one cutover roll; revert to switchover
+    # once canary is on the plugin. See infra/cnpg/README.md.
+    primaryUpdateMethod: restart
     # PostgreSQL config sized against the 8 GiB memory limit below. CNPG
     # otherwise leaves Postgres on its 128 MiB shared_buffers default;
     # mirror the production tuning shape so canary catches any regression


### PR DESCRIPTION
## What this does

Adds `primaryUpdateMethod: restart` to **canary** (`values-managed-canary.yaml`), matching what #11659 already set for production. Both clusters that still need to cut over now use `restart` (recreate the primary in place) instead of the default `switchover`.

## Why

The prod cutover cascade (#11659) **failed at the canary stage**, not on prod. Canary was on the default `switchover` method, so its plugin cutover roll deadlocked (old primary can't archive via the plugin before it has the sidecar). I recovered it via break-glass, but the cluster churned so much that `helm --wait` never locked in a stable "Ready" within its 60-min timeout → `--atomic` rolled canary **back to in-tree**. Prod never got a turn.

Canary is now stable on clean in-tree again, so a fresh cutover with `restart` should be as clean as staging's was (staging cut over in ~5 min, deploy green).

## What merging does — MERGE IN A LOW-TRAFFIC WINDOW

Merging re-triggers the prod cascade. This time:
- **canary** cuts over to the plugin with `restart` — a bounded **~3 min no-writable-primary window** while its primary recreates, then archiving resumes (the clean path staging proved),
- acceptance runs,
- **production** cuts over with `restart` — another bounded **~3 min** window.

Two brief planned write-downtime blips (canary, then prod). Merge at the start of a quiet window.

## Recovery net (proven) + follow-up

If a roll ever sticks (no primary, operator looping "switchover in progress"), with break-glass: `kubectl delete pod <old-primary> --grace-period=0 --force` then `kubectl -n platform rollout restart deploy/platform-cloudnative-pg` → promotes the caught-up sync standby, lossless. After both are confirmed on the plugin, revert `primaryUpdateMethod` to the default `switchover` so future operator bumps keep their seconds-long blip.

## Validation

`helm template` renders canary with `primaryUpdateMethod: restart` + the plugin path (`plugins`/`ObjectStore`/`method: plugin`, no `barmanObjectStore`). The method itself is proven end-to-end on staging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
