### PR TITLE
perf(server): speed up two slow ClickHouse analytics queries (xcode_graphs skip index + active-daily-stats dedup)

### DIFF
--- a/server/priv/ingest_repo/migrations/20260703173000_add_inserted_at_index_to_xcode_graphs.exs
+++ b/server/priv/ingest_repo/migrations/20260703173000_add_inserted_at_index_to_xcode_graphs.exs
@@ -1,0 +1,45 @@
+defmodule Tuist.IngestRepo.Migrations.AddInsertedAtIndexToXcodeGraphs do
+  @moduledoc """
+  Adds a `minmax` skip index on `xcode_graphs.inserted_at`.
+
+  `xcode_graphs` is `ORDER BY (id, inserted_at)`. `id` is a UUIDv7 (time-ordered),
+  so the table is physically clustered by insertion time, but `inserted_at` is a
+  non-leading sort key with no skip index. `build_time_analytics/1`
+  (`SELECT sum(duration), sum(binary_build_duration) FROM xcode_graphs JOIN
+  command_events ... WHERE inserted_at BETWEEN ? AND ? AND project_id = ?`) filters
+  only on `inserted_at`, which the primary key cannot prune ("generic exclusion
+  search"), so every dashboard load full-scans the whole table. The cost grows
+  unboundedly with total table size and drove the "Slow ClickHouse query" alert
+  (p90 ~1.8s).
+
+  A `minmax` index on `inserted_at` lets ClickHouse skip granules outside the
+  requested window. Because the data is time-clustered the min/max ranges are
+  tight, so a 30-day window reads ~1/6 of the granules instead of all of them
+  (validated locally: 1302/1302 -> 222/1302 granules, 11.0M -> 2.1M read rows).
+
+  `ADD INDEX` is metadata-only. `MATERIALIZE INDEX` builds the index for existing
+  parts as a background mutation and returns immediately (async), so it does not
+  block the deploy.
+  """
+
+  use Ecto.Migration
+
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  def up do
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    execute """
+    ALTER TABLE xcode_graphs
+    ADD INDEX IF NOT EXISTS idx_inserted_at inserted_at TYPE minmax GRANULARITY 4
+    """
+
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    execute "ALTER TABLE xcode_graphs MATERIALIZE INDEX idx_inserted_at"
+  end
+
+  def down do
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    execute "ALTER TABLE xcode_graphs DROP INDEX IF EXISTS idx_inserted_at"
+  end
+end

--- a/server/priv/ingest_repo/migrations/20260703180000_recreate_active_daily_stats_as_replacing.exs
+++ b/server/priv/ingest_repo/migrations/20260703180000_recreate_active_daily_stats_as_replacing.exs
@@ -1,0 +1,188 @@
+defmodule Tuist.IngestRepo.Migrations.RecreateActiveDailyStatsAsReplacing do
+  @moduledoc """
+  Recreates `test_case_runs_active_daily_stats` as a `ReplacingMergeTree` so
+  duplicate presence rows collapse on merge.
+
+  The table stores one presence row per `(project_id, date, is_ci,
+  test_case_id)`, but its `MergeTree` engine never deduplicates: the MV only
+  groups within a single insert block, so every insert block that touches a
+  test case on a given day writes another identical presence row. In production
+  this reached a ~155x duplication factor for busy projects (project 2382: a
+  14-day window held 56.8M presence rows for only 366K distinct
+  `(project, date, is_ci, test_case_id)` tuples / 35.8K distinct test cases).
+
+  `active_test_cases_count/5` (`Tuist.Tests.Analytics`) counts distinct active
+  test cases over the trailing 14-day window at every chart bucket, so each call
+  scanned tens of millions of duplicate rows (~1.4 GiB read) and drove the
+  "Slow ClickHouse query" alert (p90 ~1.5s). The reader already `GROUP BY
+  test_case_id`, so it stays correct against un-merged parts — the engine change
+  only reduces how many rows it has to read.
+
+  `ReplacingMergeTree` with `ORDER BY (project_id, date, is_ci, test_case_id)`
+  (every column is a sort key) collapses exact-duplicate presence rows on merge.
+  Validated locally: identical result (35,771), 57.5M -> 371K rows read, 1.39
+  GiB -> 9.2 MiB, ~18x faster.
+
+  ## Migration strategy
+
+  Mirrors `RecreateActiveDailyStatsWithExactPresence` (replacement table + live
+  capture MV + EXCHANGE swap), with two differences:
+
+    * the replacement table is a `ReplacingMergeTree`, and
+    * the historical bulk backfill reads the EXISTING presence table
+      (~836M rows / 2.6 GiB, deduped per monthly partition) instead of raw
+      `test_case_runs` (~5.8B rows). Reading the already-aggregated presence
+      table is far lighter and keeps the deploy off the raw fact table.
+
+  The replacement MV is created before the backfill so live writes during the
+  partition loop are captured. Duplicate presence rows across the backfill, the
+  replacement MV, and the post-swap catch-up are harmless — `ReplacingMergeTree`
+  collapses them and the reader groups by `test_case_id` regardless.
+  """
+  use Ecto.Migration
+  alias Tuist.IngestRepo
+  require Logger
+
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  @table "test_case_runs_active_daily_stats"
+  @mv @table <> "_mv"
+  @replacement_table @table <> "_replacement"
+  @replacement_mv @mv <> "_replacement"
+
+  def up do
+    swap_engine("ReplacingMergeTree", DateTime.utc_now())
+  end
+
+  def down do
+    swap_engine("MergeTree", DateTime.utc_now())
+  end
+
+  defp swap_engine(engine, migration_started_at) do
+    IngestRepo.query!("DROP VIEW IF EXISTS #{@replacement_mv}")
+    IngestRepo.query!("DROP TABLE IF EXISTS #{@replacement_table}")
+
+    create_presence_table(@replacement_table, engine)
+    create_presence_mv(@replacement_mv, @replacement_table)
+    backfill_history(@replacement_table)
+
+    IngestRepo.query!("DROP VIEW IF EXISTS #{@mv}")
+    IngestRepo.query!("DROP VIEW IF EXISTS #{@replacement_mv}")
+    IngestRepo.query!("EXCHANGE TABLES #{@table} AND #{@replacement_table}")
+    create_presence_mv(@mv, @table)
+    catch_up(@table, migration_started_at)
+    IngestRepo.query!("DROP TABLE IF EXISTS #{@replacement_table}")
+  end
+
+  defp create_presence_table(table, engine) do
+    IngestRepo.query!("""
+    CREATE TABLE IF NOT EXISTS #{table} (
+      project_id Int64,
+      date Date,
+      is_ci Bool,
+      test_case_id UUID
+    ) ENGINE = #{engine}
+    PARTITION BY toYYYYMM(date)
+    ORDER BY (project_id, date, is_ci, test_case_id)
+    """)
+  end
+
+  defp create_presence_mv(view_name, target_table) do
+    IngestRepo.query!("""
+    CREATE MATERIALIZED VIEW IF NOT EXISTS #{view_name}
+    TO #{target_table}
+    AS SELECT
+      project_id,
+      date,
+      is_ci,
+      test_case_id
+    FROM (
+      SELECT
+        project_id,
+        toDate(ran_at) AS date,
+        is_ci,
+        assumeNotNull(test_case_id) AS test_case_id
+      FROM test_case_runs
+      WHERE test_case_id IS NOT NULL
+    )
+    GROUP BY project_id, date, is_ci, test_case_id
+    """)
+  end
+
+  # Bulk history from the existing presence table, one monthly partition at a
+  # time. The source is sorted by exactly the GROUP BY keys, so the dedup is a
+  # streaming aggregation with bounded memory.
+  defp backfill_history(target_table) do
+    {:ok, %{rows: partitions}} =
+      IngestRepo.query(
+        """
+        SELECT DISTINCT partition
+        FROM system.parts
+        WHERE database = currentDatabase() AND table = {table:String} AND active
+        ORDER BY partition
+        """,
+        %{table: @table}
+      )
+
+    for [partition] <- partitions do
+      Logger.info("Backfilling partition #{partition} into #{target_table}")
+
+      retry_on_shutting_down(fn ->
+        IngestRepo.query!(
+          """
+          INSERT INTO #{target_table}
+          SELECT project_id, date, is_ci, test_case_id
+          FROM #{@table}
+          WHERE toYYYYMM(date) = {partition:UInt32}
+          GROUP BY project_id, date, is_ci, test_case_id
+          """,
+          %{partition: String.to_integer(partition)},
+          timeout: 1_200_000
+        )
+      end)
+    end
+  end
+
+  # Covers writes during the DDL/backfill window from the source of truth.
+  # Recent-only (`inserted_at >= migration_started_at`), so it is bounded and
+  # does not scan the raw fact table's history.
+  defp catch_up(target_table, migration_started_at) do
+    Logger.info("Catch-up backfill into #{target_table}")
+
+    retry_on_shutting_down(fn ->
+      IngestRepo.query!(
+        """
+        INSERT INTO #{target_table}
+        SELECT project_id, date, is_ci, test_case_id
+        FROM (
+          SELECT
+            project_id,
+            toDate(ran_at) AS date,
+            is_ci,
+            assumeNotNull(test_case_id) AS test_case_id
+          FROM test_case_runs
+          WHERE inserted_at >= parseDateTime64BestEffort({migration_started_at:String}, 6)
+            AND test_case_id IS NOT NULL
+        )
+        GROUP BY project_id, date, is_ci, test_case_id
+        """,
+        %{migration_started_at: DateTime.to_iso8601(migration_started_at)},
+        timeout: 1_200_000
+      )
+    end)
+  end
+
+  defp retry_on_shutting_down(fun, attempts \\ 5) do
+    fun.()
+  rescue
+    e in Ch.Error ->
+      if attempts > 1 and String.contains?(to_string(e.message), "TABLE_IS_READ_ONLY") do
+        Logger.warning("Table is shutting down, retrying in 5s (#{attempts - 1} attempts left)")
+        Process.sleep(:timer.seconds(5))
+        retry_on_shutting_down(fun, attempts - 1)
+      else
+        reraise e, __STACKTRACE__
+      end
+  end
+end


### PR DESCRIPTION
Two ClickHouse optimizations, each fixing a distinct "Slow ClickHouse query" alert. Both are `priv/ingest_repo` migrations on ClickHouse tables; there are no app query changes (the existing Ecto queries stay correct and just read far less).

## 1. minmax skip index on `xcode_graphs.inserted_at`

**Alert:** `build_time_analytics/1` (Xcode overview dashboard), p90 ~1.8s and growing.

**Root cause:** the query joins `xcode_graphs` to `command_events` and filters only on `xcode_graphs.inserted_at`. That column is the *non-leading* key of `ORDER BY (id, inserted_at)` with no partition or skip index, so ClickHouse can't prune granules ("generic exclusion search") and every dashboard load full-scans the whole table. The cost grows unbounded with table size.

**Fix:** `id` is a UUIDv7, so the table is physically clustered by insertion time — a `minmax` index on `inserted_at` has tight per-granule ranges and skips almost everything outside the window. `ADD INDEX` is metadata-only; `MATERIALIZE INDEX` runs as an async background mutation, so the migration doesn't block the deploy.

**Validated locally** (10.7M-row table, project + 30-day window): granules 1302 → 222, read rows 11.0M → 2.1M, identical result; confirmed the result is unchanged with `use_skip_indexes=0`.

## 2. `test_case_runs_active_daily_stats` → ReplacingMergeTree

**Alert:** `active_test_cases_count/5` (distinct active test cases over a trailing 14-day window, run once per chart bucket), p90 ~1.5s.

**Root cause:** the presence table (one row per `(project_id, date, is_ci, test_case_id)`) is a plain `MergeTree` that never deduplicates. The feeding MV only groups within a single insert block, so every insert block that touches a test case that day writes another identical presence row. In production this reached **~155x duplication** for a busy project — a 14-day window held **56.8M rows for 366K distinct tuples / 35.8K distinct test cases** — so the reader scanned tens of millions of duplicate rows (~1.4 GiB) per bucket.

**Fix:** recreate the table as `ReplacingMergeTree` (same `ORDER BY`, all four columns), which collapses exact-duplicate presence rows on merge. The reader already `GROUP BY test_case_id`, so it stays correct against un-merged parts — the engine change only reduces rows read.

**Validated locally:** identical result, **57.5M → 371K rows read, 1.39 GiB → 9.2 MiB, ~18x faster**. Also ran the full migration sequence end-to-end (replacement table → live-capture MV → per-partition backfill → EXCHANGE → recreate MV → catch-up) and confirmed rows collapse, the reader stays correct with un-merged duplicates, and new writes flow through the recreated MV.

**Migration strategy:** mirrors the proven `RecreateActiveDailyStatsWithExactPresence` recreate flow (replacement table + live-capture MV + `EXCHANGE TABLES` swap + recent catch-up), with two changes: the replacement engine is `ReplacingMergeTree`, and the historical bulk backfill reads the existing **836M-row presence table** (deduped per monthly partition) instead of the **5.8B-row raw `test_case_runs`** — keeping the deploy off the raw fact table.

## Deploy notes

- Migration 1 is lightweight (metadata `ADD INDEX` + async `MATERIALIZE`).
- Migration 2 is heavier — it recreates an 836M-row table with an MV swap — but the backfill reads the already-aggregated presence table (~2.6 GiB), per-partition with `retry_on_shutting_down` + 20-min timeouts, both `@disable_ddl_transaction`. If we'd rather run the historical backfill fully out-of-band (migration only creates + swaps), it's an easy restructure — happy to split it.

## Not in this PR

- A third alert (`SELECT DISTINCT project_id FROM test_case_runs WHERE test_run_id = …`, 21s) turned out to be an ad-hoc Grafana Explore query, not an app path — every app `test_run_id` read already uses the `test_case_runs_by_test_run` MV (point lookup). To stop ad-hoc queries tripping the alert, the "Slow ClickHouse query" rule was scoped to app queries only (`http_user_agent LIKE 'ch/%'`) directly in Grafana — no repo change.

### How to test locally

- `mise run db:reset` (or `mix ecto.migrate` for the ingest repo) applies both migrations against local ClickHouse.
- Load an Xcode overview dashboard for a project with binary-cache data and a Test Cases analytics chart for a project with many test runs; both should render without the multi-second ClickHouse latency.
- `EXPLAIN indexes=1` on the `build_time_analytics` query shows `xcode_graphs` granules pruned via `idx_inserted_at`; `SELECT count() FROM test_case_runs_active_daily_stats` after an `OPTIMIZE … FINAL` shows the deduplicated row count.
