### PR TITLE
fix(infra): base runner Pool utilisation on live macOS host capacity

### DIFF
--- a/infra/grafana-dashboards/runners.json
+++ b/infra/grafana-dashboards/runners.json
@@ -343,7 +343,7 @@
       },
       {
         "datasource": "$datasource",
-        "description": "Mac minis where tart-kubelet's controller-runtime metrics endpoint is reachable. Bound to the tailnet IP when --node-ip-source=tailscale, scraped through the Tailscale operator's egress ProxyGroup. A drop here is a routing failure (ProxyGroup pod down, ACL drift, missing egress Service) before it's a host failure; the node_exporter scrape on :9100 is the second sanity check.",
+        "description": "Mac minis where tart-kubelet's controller-runtime metrics endpoint is reachable, scoped to the selected environment (each cluster's Alloy stamps env on the scrape). Bound to the tailnet IP when --node-ip-source=tailscale, scraped through the Tailscale operator's egress ProxyGroup. A drop here is a routing failure (ProxyGroup pod down, ACL drift, missing egress Service) before it's a host failure; the node_exporter scrape on :9100 is the second sanity check. This same count is the live capacity denominator of the Pool utilisation panel for macOS.",
         "fieldConfig": {
           "defaults": {
             "color": {
@@ -394,7 +394,7 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "count(up{job=\"tuist-macos-tart-kubelet\"} == 1)",
+            "expr": "count(up{job=\"tuist-macos-tart-kubelet\", env=\"$env\"} == 1)",
             "instant": true,
             "refId": "A"
           }
@@ -859,7 +859,7 @@
       },
       {
         "datasource": "$datasource",
-        "description": "Running claims as a fraction of the platform's concurrency ceiling. macOS pools (one per Xcode version) share a single bare-metal host budget (hostCount, 1 VM/host) and the controller's allocator caps their joint replica sum to it, so the ceiling is max(maxReplicas) across the platform's pools, NOT the sum: each macOS pool reports maxReplicas = hostCount, so summing triple-counts the shared budget and pins utilisation near 33% even at full saturation. 100% means the platform is at its host budget and further queued work can't be served until hosts are added (raising maxReplicas does not help a host-bound macOS fleet). The denominator is the fixed ceiling, not the live target, so this reads as true saturation. Caveat: the numerator is PG running claims, which can briefly include claims whose Pods just finished before the recovery sweep, so small transient overshoots above 100% are possible.",
+        "description": "Running claims as a fraction of live capacity, per platform, scoped to the selected environment. For macOS the denominator is the count of Mac minis whose tart-kubelet endpoint is currently reachable (count(up{job=\"tuist-macos-tart-kubelet\"} == 1)) — 1 VM per host today, so reachable hosts == VM slots, and this is the same number shown in the Mac minis reporting stat. This tracks REAL capacity: if a mini drops off the tailnet the ceiling falls with it, unlike the static RunnerPool maxReplicas (which the four per-Xcode macOS pools all report as the shared hostCount, so it can't be summed). 100% means every reachable host is running a build and further queued work waits for a host to free up or for more hosts to come online. Caveat: small transient overshoots above 100% are possible because the numerator is PG running claims, which can briefly include claims whose Pods just finished before the recovery sweep, and because a host can leave the reachable set while its claim is still counted. Linux has no per-host reachability signal (runners are Kata microVMs on a shared, memory-contended bare-metal pool), so its denominator stays the pool capacity ceiling max(maxReplicas).",
         "fieldConfig": {
           "defaults": {
             "color": {
@@ -949,7 +949,7 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "sum by (platform) (label_replace(max by (fleet) (tuist_runners_claims_count{fleet=~\".*$platform.*\", lifecycle_state=\"running\", env=\"$env\"}), \"platform\", \"$1\", \"fleet\", \".*runner-pool-(linux|macos).*\")) / clamp_min(max by (platform) (label_replace(max by (fleet) (tuist_runners_pool_replicas_max{fleet=~\".*$platform.*\", env=\"$env\"}), \"platform\", \"$1\", \"fleet\", \".*runner-pool-(linux|macos).*\")), 1)",
+            "expr": "sum by (platform) (label_replace(max by (fleet) (tuist_runners_claims_count{fleet=~\".*$platform.*\", lifecycle_state=\"running\", env=\"$env\"}), \"platform\", \"$1\", \"fleet\", \".*runner-pool-(linux|macos).*\")) / clamp_min(label_replace(count(up{job=\"tuist-macos-tart-kubelet\", env=\"$env\"} == 1), \"platform\", \"macos\", \"__name__\", \".*\") or max by (platform) (label_replace(max by (fleet) (tuist_runners_pool_replicas_max{fleet=~\".*linux.*\", env=\"$env\"}), \"platform\", \"$1\", \"fleet\", \".*runner-pool-(linux|macos).*\")), 1)",
             "legendFormat": "{{platform}}",
             "refId": "A"
           }


### PR DESCRIPTION
> Fixes the "Pool utilisation (running / max capacity)" panel on the **Tuist Runners** dashboard, which capped macOS at ~22% even when the fleet was fully saturated.

## What changed

Two query edits in `infra/grafana-dashboards/runners.json`:

1. **macOS utilisation denominator → live reachable hosts.** The panel now divides macOS running claims by the count of Mac minis whose tart-kubelet endpoint is currently reachable:
   ```promql
   … / clamp_min(
     label_replace(count(up{job="tuist-macos-tart-kubelet", env="$env"} == 1), "platform","macos","__name__",".*")
     or
     max by (platform)(… tuist_runners_pool_replicas_max{fleet=~".*linux.*", env="$env"} …),
   1)
   ```
2. **"Mac minis reporting" stat → env-scoped.** `count(up{job="tuist-macos-tart-kubelet"} == 1)` → `count(up{job="tuist-macos-tart-kubelet", env="$env"} == 1)`.

Both panels' descriptions were updated to match.

## Why / root cause

The old denominator was `sum by (platform)(max by (fleet)(tuist_runners_pool_replicas_max))`. There are **four** macOS pools (one per Xcode version), and each reports `maxReplicas` equal to the **shared** Mac-mini host budget (`hostCount`) — the fleet allocator caps the pools' *joint* replica sum to it, one VM per host. Summing therefore quadruple-counts a shared budget: denominator = 4 × 9 = **36**, so a fully saturated fleet read ~8/36 ≈ **22.2%** and the panel could never reach 100%.

`max` instead of `sum` is already correct for the shared budget, but this PR goes one step further per review feedback: the denominator should reflect **live** capacity, not the static CRD `maxReplicas`. The reachable-host count (`up{job="tuist-macos-tart-kubelet"} == 1`) is exactly that — at 1 VM/host it equals available VM slots, it's the same number the "Mac minis reporting" stat shows, and it drops with a mini that falls off the tailnet, so utilisation reflects real saturation rather than configured intent.

The "Mac minis reporting" stat was fleet-wide (counting staging + canary + production minis together, ~17) because the query had no `env` filter — even though every metric already carries an `env` label (each cluster's Alloy stamps it, see `infra/helm/k8s-monitoring/values-production.yaml`). Adding the filter makes the stat and the utilisation denominator consistent for the selected environment.

## Why this shape over alternatives

- **Kept `max(maxReplicas)` for Linux.** Linux runners are Kata microVMs on a shared, memory-contended bare-metal pool; there is no per-host reachability signal equivalent to tart-kubelet, so there's nothing to switch it to. The `or` union applies the reachable-host denominator only to the macOS series, and the numerator's `platform` label selects the right denominator on divide.
- **`label_replace(count(...), "platform","macos", …)`** injects the constant `platform` label onto the (otherwise label-less) `count()` result so it matches the `platform="macos"` numerator series.

## Impact

macOS pool utilisation now reads true saturation (100% when every reachable Mac mini is running a build), and the "Mac minis reporting" stat reflects the selected environment. No server/CLI/behavioural change — dashboard only.

## Validation

- Confirmed on `grafanacloud-prom` that the corrected `max`-based denominator evaluates to a flat **9** for production macOS, that the raw running-claims numerator reaches 8–9 (sustained ~35-min plateau in the busy window), and that the old `sum` denominator explains the exact 22.2% ceiling (8/36).
- Confirmed the `env` label is present on `up{job="tuist-macos-tart-kubelet"}` / `tart_kubelet_*` / `node_*` via the per-env Alloy overlay.
- JSON validated (`json.load`).
- **Not yet validated live:** the final `count(up …) or …` union expression was assembled after the Grafana connection dropped, so the exact series/label-matching should be spot-checked in Explore before/after merge.

## Note on deployment

This directory is bound to Grafana Cloud via Git Sync, but the live `tuist-runners` dashboard has been **stale for 2+ weeks** — it's still running an even older query (pre-`max`, no `env` filter) that never propagated. Merging this corrects the source of truth, but the dashboard won't render correctly until the Git Sync path is unstuck. Tracking that separately.

### How to test locally

Dashboard-only change; open the panel JSON or import the `spec` into Grafana Explore and confirm the macOS series divides running claims by the reachable-mini count (reaching 1.0 at full saturation) and that "Mac minis reporting" respects the Environment variable.
