### PR TITLE
fix(cli): ignore local external package test targets

### DIFF
--- a/cli/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
+++ b/cli/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
@@ -91,7 +91,7 @@ public enum PackageType {
 
     fileprivate var includesTestTargets: Bool {
         switch self {
-        case .local, .external(origin: .local, artifactPaths: _, packagePrebuilts: _, derivedXCFrameworksPath: _):
+        case .local:
             return true
         case .external:
             return false

--- a/cli/Tests/TuistDependenciesAcceptanceTests/DependenciesAcceptanceTests.swift
+++ b/cli/Tests/TuistDependenciesAcceptanceTests/DependenciesAcceptanceTests.swift
@@ -258,6 +258,22 @@ struct DependenciesAcceptanceTestIosAppWithLocalSPMPackageGenerate {
     }
 }
 
+struct DependenciesAcceptanceTestCommandLineToolWithLocalSPMTestOnlyDependencies {
+    @Test(
+        .withFixture("generated_command_line_tool_with_local_spm_test_only_dependencies"),
+        .inTemporaryDirectory,
+        .timeLimit(.minutes(1))
+    )
+    func install_then_generate_ignores_local_package_test_only_dependencies() async throws {
+        let fixtureDirectory = try #require(TuistTest.fixtureDirectory)
+        try await TuistTest.run(
+            InstallCommand.self,
+            ["--path", fixtureDirectory.pathString, "--force-resolved-versions"]
+        )
+        try await TuistTest.run(GenerateCommand.self, ["--no-open", "--path", fixtureDirectory.pathString])
+    }
+}
+
 struct DependenciesAcceptanceTestAppAlamofire {
     @Test(.disabled(), .withFixture("generated_app_with_alamofire"), .inTemporaryDirectory)
     func app_with_alamofire() async throws {

--- a/cli/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
+++ b/cli/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
@@ -5361,7 +5361,7 @@ struct PackageInfoMapperTests {
     @Test(
         .inTemporaryDirectory,
         .withMockedSwiftVersionProvider
-    ) func map_whenExternalLocalSwiftPackageHasTestTarget() async throws {
+    ) func map_whenExternalLocalSwiftPackageHasTestTarget_ignoresTestTarget() async throws {
         // Given
         let basePath = try #require(FileSystem.temporaryTestDirectory)
         let sourcesPath = basePath.appending(components: ["Package", "Sources", "Target"])
@@ -5395,10 +5395,7 @@ struct PackageInfoMapperTests {
 
         // Then
         #expect(project != nil)
-        #expect(Set(project?.targets.map(\.name) ?? []) == Set(["Target", "TargetTests"]))
-        let testTarget = project?.targets.first { $0.name == "TargetTests" }
-        #expect(testTarget?.product == .unitTests)
-        #expect(testTarget?.metadata.tags.contains(TargetTags.localSwiftPackageTest) == true)
+        #expect(Set(project?.targets.map(\.name) ?? []) == Set(["Target"]))
     }
 
     @Test(
@@ -7808,7 +7805,7 @@ struct PackageInfoMapperTests {
 
     @Test(
         .inTemporaryDirectory, .withMockedSwiftVersionProvider
-    ) func map_whenTestTargetOnlyDependsOnPluginTarget_keepsPrebuiltProductAsSourceDependency() async throws {
+    ) func map_whenExternalLocalTestTargetOnlyDependsOnPluginTarget_ignoresTestTarget() async throws {
         let basePath = try #require(FileSystem.temporaryTestDirectory)
 
         try await fileSystem.makeDirectory(
@@ -7861,11 +7858,7 @@ struct PackageInfoMapperTests {
             ]
         )
 
-        let target = try #require(project?.targets.first(where: { $0.name == "PluginTests" }))
-        #expect(target.dependencies.contains(.external(name: "SwiftSyntax", condition: nil)))
-        #expect(target.settings?.base["OTHER_SWIFT_FLAGS"] == .array(["$(inherited)"]))
-        #expect(target.settings?.base["LIBRARY_SEARCH_PATHS"] == nil)
-        #expect(target.settings?.base["OTHER_LDFLAGS"] == nil)
+        #expect(project == nil)
     }
 
     @Test(

--- a/examples/xcode/generated_command_line_tool_with_local_spm_test_only_dependencies/Project.swift
+++ b/examples/xcode/generated_command_line_tool_with_local_spm_test_only_dependencies/Project.swift
@@ -1,0 +1,18 @@
+import ProjectDescription
+
+let project = Project(
+    name: "CommandLineTool",
+    targets: [
+        .target(
+            name: "CommandLineTool",
+            destinations: [.mac],
+            product: .commandLineTool,
+            bundleId: "dev.tuist.CommandLineTool",
+            infoPlist: .default,
+            sources: ["main.swift"],
+            dependencies: [
+                .external(name: "RuntimeLib"),
+            ]
+        ),
+    ]
+)

--- a/examples/xcode/generated_command_line_tool_with_local_spm_test_only_dependencies/RuntimePackage/Package.swift
+++ b/examples/xcode/generated_command_line_tool_with_local_spm_test_only_dependencies/RuntimePackage/Package.swift
@@ -1,0 +1,23 @@
+// swift-tools-version: 5.10
+import PackageDescription
+
+let package = Package(
+    name: "RuntimePackage",
+    platforms: [.macOS(.v13)],
+    products: [
+        .library(name: "RuntimeLib", targets: ["RuntimeLib"]),
+    ],
+    dependencies: [
+        .package(path: "../TestSupportPackage"),
+    ],
+    targets: [
+        .target(name: "RuntimeLib"),
+        .testTarget(
+            name: "RuntimeLibTests",
+            dependencies: [
+                "RuntimeLib",
+                .product(name: "TestSupport", package: "TestSupportPackage"),
+            ]
+        ),
+    ]
+)

--- a/examples/xcode/generated_command_line_tool_with_local_spm_test_only_dependencies/RuntimePackage/Sources/RuntimeLib/RuntimeLib.swift
+++ b/examples/xcode/generated_command_line_tool_with_local_spm_test_only_dependencies/RuntimePackage/Sources/RuntimeLib/RuntimeLib.swift
@@ -1,0 +1,7 @@
+public struct RuntimeLib {
+    public init() {}
+
+    public var message: String {
+        "runtime"
+    }
+}

--- a/examples/xcode/generated_command_line_tool_with_local_spm_test_only_dependencies/RuntimePackage/Tests/RuntimeLibTests/RuntimeLibTests.swift
+++ b/examples/xcode/generated_command_line_tool_with_local_spm_test_only_dependencies/RuntimePackage/Tests/RuntimeLibTests/RuntimeLibTests.swift
@@ -1,0 +1,9 @@
+import RuntimeLib
+import TestSupport
+import XCTest
+
+final class RuntimeLibTests: XCTestCase {
+    func testMessage() {
+        XCTAssertEqual(RuntimeLib().message, TestSupport.expectedMessage)
+    }
+}

--- a/examples/xcode/generated_command_line_tool_with_local_spm_test_only_dependencies/TestSupportPackage/Package.swift
+++ b/examples/xcode/generated_command_line_tool_with_local_spm_test_only_dependencies/TestSupportPackage/Package.swift
@@ -1,0 +1,13 @@
+// swift-tools-version: 5.10
+import PackageDescription
+
+let package = Package(
+    name: "TestSupportPackage",
+    platforms: [.macOS(.v13)],
+    products: [
+        .library(name: "TestSupport", targets: ["TestSupport"]),
+    ],
+    targets: [
+        .target(name: "TestSupport"),
+    ]
+)

--- a/examples/xcode/generated_command_line_tool_with_local_spm_test_only_dependencies/TestSupportPackage/Sources/TestSupport/TestSupport.swift
+++ b/examples/xcode/generated_command_line_tool_with_local_spm_test_only_dependencies/TestSupportPackage/Sources/TestSupport/TestSupport.swift
@@ -1,0 +1,3 @@
+public enum TestSupport {
+    public static let expectedMessage = "runtime"
+}

--- a/examples/xcode/generated_command_line_tool_with_local_spm_test_only_dependencies/Tuist.swift
+++ b/examples/xcode/generated_command_line_tool_with_local_spm_test_only_dependencies/Tuist.swift
@@ -1,0 +1,3 @@
+import ProjectDescription
+
+let tuist = Tuist(project: .tuist())

--- a/examples/xcode/generated_command_line_tool_with_local_spm_test_only_dependencies/Tuist/Package.swift
+++ b/examples/xcode/generated_command_line_tool_with_local_spm_test_only_dependencies/Tuist/Package.swift
@@ -1,0 +1,19 @@
+// swift-tools-version: 5.10
+import PackageDescription
+
+#if TUIST
+    import struct ProjectDescription.PackageSettings
+
+    let packageSettings = PackageSettings(
+        productTypes: [
+            "RuntimeLib": .staticFramework,
+        ]
+    )
+#endif
+
+let package = Package(
+    name: "CommandLineToolDependencies",
+    dependencies: [
+        .package(path: "../RuntimePackage"),
+    ]
+)

--- a/examples/xcode/generated_command_line_tool_with_local_spm_test_only_dependencies/main.swift
+++ b/examples/xcode/generated_command_line_tool_with_local_spm_test_only_dependencies/main.swift
@@ -1,0 +1,3 @@
+import RuntimeLib
+
+print(RuntimeLib().message)


### PR DESCRIPTION
## What changed

- Added an acceptance fixture where a root Tuist project depends on a local Swift package product, and that local package has a dependency that is used only by its test target.
- Updated the dependency acceptance test to run `tuist install --force-resolved-versions` before `tuist generate` for that fixture.
- Changed Swift package mapping so only packages loaded as `.local` include test targets. Packages loaded as `.external`, including local path packages installed through Tuist dependencies, now ignore test targets just like remote external packages.
- Updated the focused `PackageInfoMapper` unit expectation for external local packages to assert that test targets are not emitted.

## Why

Issue #11407 happens because Tuist maps local path packages as generated external projects. Unlike remote packages, those local external packages were still including their test targets. If one of those test targets depended on another package/product that was not declared in the root Tuist package settings, graph loading tried to validate that test-only product as a configured external dependency and failed generation.

Rather than recursively resolving every nested local package during `tuist install`, this keeps installation and graph loading centered on the root dependency graph. That avoids making installs noticeably slower and avoids introducing a second independent resolution surface for subpackages. It also brings local external packages closer to Xcode/SwiftPM's integration behavior for app projects: package tests are not part of the consuming project dependency graph unless the package itself is being worked on as a local package.

## Local vs local-origin external packages

The important distinction is the role the package has in Tuist's graph, not only where its files live:

- `.local` is used when Tuist discovers a package as an editable package project in the workspace/project tree. Those packages are part of the local workspace surface, so their test targets are still generated.
- `.external(origin: .local, ...)` is used when a package comes from the SwiftPM dependency graph and SwiftPM reports that dependency as local/path-based. It is still consumed as an external dependency; the `origin: .local` value only says the dependency source is local.

In #11407, `LocalOnlyPackage` is `.external(origin: .local, ...)`, not `.local`, because it enters through `DemoKit/Tuist/Package.swift`:

```swift
.package(path: "../LocalOnlyPackage")
```

That is also the Xcode-aligned behavior this PR models: when an app/project consumes a local Swift package product, the package's own test targets are not part of the app target's dependency graph. If a package is opened or included as an editable package project, then treating it as `.local` and keeping its tests remains appropriate.

## Root cause

`PackageType.includesTestTargets` returned `true` for `.external(origin: .local, ...)`. That meant test targets from installed local path packages were mapped into the generated external project. In the repro fixture, `RuntimePackage` exposes only `RuntimeLib` to the root project, but its `RuntimeLibTests` target depends on `TestSupport`. Because `TestSupport` is test-only and not configured at the root, `tuist generate` failed with:

```text
`TestSupport` is not a valid configured external dependency
```

## Impact

Projects can consume local Swift package products without also needing to install or configure packages that are only required by those local packages' tests. This keeps dependency installation scoped to the root Tuist package while fixing generation for local package graphs that contain test-only helper dependencies.

## Validation

- Ran `tuist install --force-resolved-versions`.
- Confirmed the new acceptance test failed before the fix with ``TestSupport` is not a valid configured external dependency`.
- Reran the focused acceptance test after the fix:
  - `xcodebuild test -quiet -workspace Tuist.xcworkspace -scheme Tuist-Workspace -only-testing TuistDependenciesAcceptanceTests/DependenciesAcceptanceTestCommandLineToolWithLocalSPMTestOnlyDependencies -destination platform=macOS,arch=arm64 -derivedDataPath /private/tmp/tuist-local-spm-green-dd CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""`
- Reran the focused mapper unit test:
  - `xcodebuild test -quiet -workspace Tuist.xcworkspace -scheme Tuist-Workspace -only-testing TuistLoaderTests/PackageInfoMapperTests/map_whenExternalLocalSwiftPackageHasTestTarget_ignoresTestTarget -destination platform=macOS,arch=arm64 -derivedDataPath /private/tmp/tuist-local-spm-green-dd CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""`
- Ran `git diff --check`.

Closes #11407.
