### PR TITLE
fix(cli): build macro targets for active architecture

### DIFF
--- a/cli/Sources/TuistGenerator/Settings/DefaultSettingsProvider.swift
+++ b/cli/Sources/TuistGenerator/Settings/DefaultSettingsProvider.swift
@@ -51,6 +51,7 @@ public struct DefaultSettingsProvider: DefaultSettingsProviding {
         "SDKROOT",
         "CODE_SIGN_IDENTITY",
         "LD_RUNPATH_SEARCH_PATHS",
+        "ONLY_ACTIVE_ARCH",
         "SWIFT_OPTIMIZATION_LEVEL",
         "SWIFT_ACTIVE_COMPILATION_CONDITIONS",
         "CURRENT_PROJECT_VERSION",
@@ -287,6 +288,7 @@ public struct DefaultSettingsProvider: DefaultSettingsProviding {
             ]
         } else if target.product == .macro {
             return [
+                "ONLY_ACTIVE_ARCH": "YES",
                 "SKIP_INSTALL": "YES",
             ]
         } else {

--- a/cli/Tests/TuistAutomationAcceptanceTests/BuildAcceptanceTests.swift
+++ b/cli/Tests/TuistAutomationAcceptanceTests/BuildAcceptanceTests.swift
@@ -398,10 +398,20 @@ struct BuildAcceptanceTestSwiftPMPrebuiltMacro {
         .inTemporaryDirectory,
         .timeLimit(.minutes(2))
     )
-    func app_with_swiftpm_prebuilt_macro_dependency_generates_prebuilt_macro_settings() async throws {
+    func app_with_swiftpm_prebuilt_macro_dependency_builds_with_host_only_prebuilt_macro_support() async throws {
         let fixtureDirectory = try #require(TuistTest.fixtureDirectory)
+        let derivedDataPath = try #require(FileSystem.temporaryTestDirectory)
+        let fileSystem = FileSystem()
 
-        try await TuistTest.run(InstallCommand.self, ["--path", fixtureDirectory.pathString])
+        try await TuistTest.run(
+            InstallCommand.self,
+            ["--path", fixtureDirectory.pathString, "--force-resolved-versions"]
+        )
+        let prebuiltDirectory = fixtureDirectory.appending(
+            components: "Tuist", ".build", "prebuilts", "swift-syntax"
+        )
+        #expect(try await fileSystem.exists(prebuiltDirectory, isDirectory: true))
+
         try await TuistTest.run(GenerateCommand.self, ["--no-open", "--path", fixtureDirectory.pathString])
 
         let xcodeproj = try XcodeProj(
@@ -414,7 +424,8 @@ struct BuildAcceptanceTestSwiftPMPrebuiltMacro {
         #expect(!targetNames.contains("SwiftCompilerPlugin"))
 
         let macroTarget = try TuistAcceptanceTest.requireTarget("MacroDependencyMacros", in: xcodeproj)
-        let buildSettings = try #require(macroTarget.buildConfigurationList?.configuration(name: "Debug")?.buildSettings)
+        let buildSettings = try #require(macroTarget.buildConfigurationList?.configuration(name: "Release")?.buildSettings)
+
         let otherSwiftFlags = try #require(buildSettings["OTHER_SWIFT_FLAGS"]?.arrayValue)
         #expect(otherSwiftFlags.contains("-I"))
         #expect(otherSwiftFlags.contains(where: {
@@ -431,6 +442,41 @@ struct BuildAcceptanceTestSwiftPMPrebuiltMacro {
 
         let otherLDFlags = try #require(buildSettings["OTHER_LDFLAGS"]?.arrayValue)
         #expect(otherLDFlags.contains("-lMacroSupport"))
+
+        #if arch(arm64)
+            let nonHostModulePattern = "**/x86_64-apple-macos.*"
+        #else
+            let nonHostModulePattern = "**/arm64-apple-macos.*"
+        #endif
+
+        let nonHostModulePaths = try await fileSystem.glob(
+            directory: prebuiltDirectory,
+            include: [nonHostModulePattern]
+        ).collect()
+        for nonHostModulePath in nonHostModulePaths {
+            try await fileSystem.remove(nonHostModulePath)
+        }
+
+        try await TuistTest.run(
+            XcodeBuildBuildCommand.self,
+            [
+                "build",
+                "-workspace",
+                fixtureDirectory.appending(component: "App.xcworkspace").pathString,
+                "-scheme",
+                "App",
+                "-configuration",
+                "Release",
+                "-derivedDataPath",
+                derivedDataPath.pathString,
+                "-skipMacroValidation",
+                "CODE_SIGNING_ALLOWED=NO",
+                "CODE_SIGNING_REQUIRED=NO",
+                "CODE_SIGN_IDENTITY=",
+            ]
+        )
+
+        #expect(buildSettings["ONLY_ACTIVE_ARCH"]?.stringValue == "YES")
     }
 }
 

--- a/cli/Tests/TuistGeneratorTests/Settings/DefaultSettingsProviderTests.swift
+++ b/cli/Tests/TuistGeneratorTests/Settings/DefaultSettingsProviderTests.swift
@@ -1131,6 +1131,7 @@ struct DefaultSettingsProvider_MacosTests {
 
     private let macroTargetEssentialDebugSettings: [String: SettingValue] = [
         "SWIFT_ACTIVE_COMPILATION_CONDITIONS": .array(["$(inherited)", "DEBUG"]),
+        "ONLY_ACTIVE_ARCH": "YES",
         "SKIP_INSTALL": "YES",
         "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
         "SWIFT_VERSION": "5",
@@ -1139,6 +1140,7 @@ struct DefaultSettingsProvider_MacosTests {
     ]
 
     private let macroTargetEssentialReleaseSettings: [String: SettingValue] = [
+        "ONLY_ACTIVE_ARCH": "YES",
         "SKIP_INSTALL": "YES",
         "SWIFT_OPTIMIZATION_LEVEL": "-O",
         "SWIFT_VERSION": "5",

--- a/examples/xcode/generated_app_with_swiftpm_prebuilt_macro_dependency/Tuist/Package.resolved
+++ b/examples/xcode/generated_app_with_swiftpm_prebuilt_macro_dependency/Tuist/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "186bf001a65f4bd7e4cf8b24ece320fd7c0088b231021a3e0828a452855b8c6e",
+  "pins" : [
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-syntax.git",
+      "state" : {
+        "revision" : "4799286537280063c85a32f09884cfbca301b1a1",
+        "version" : "602.0.0"
+      }
+    }
+  ],
+  "version" : 3
+}


### PR DESCRIPTION
## What changed

- Configure generated Swift macro targets with `ONLY_ACTIVE_ARCH = YES`.
- Preserve that setting in essential target settings so it is emitted in generated projects.
- Expand the swift-syntax prebuilt macro acceptance test so it runs `tuist install --force-resolved-versions`, verifies prebuilt substitution, trims the temp prebuilt down to host-only module slices, and builds with raw `xcodebuild`.
- Pin the fixture's `Package.resolved` so forced resolved versions keep the acceptance test deterministic and fast.

## Why

Macro targets are host tools. When Tuist substitutes the swift-syntax prebuilt for macro-only package graphs, the generated macro target could still build for all standard macOS architectures in Release. On Apple Silicon, a host-only prebuilt can then be consumed by an x86_64 macro build slice, which fails because the prebuilt Swift modules do not provide a compatible `SwiftCompilerPlugin` module for that target.

Constraining macro targets to the active host architecture matches SwiftPM's host-only macro build behavior while still allowing app/library targets to keep their normal architecture settings.

## Root cause

The prebuilt swift-syntax substitution was valid for the macro dependency graph, but the generated Xcode macro target inherited Release architecture behavior that attempted both arm64 and x86_64. A host-arch-only MacroSupport prebuilt cannot satisfy the non-host macro slice, so compilation fails while resolving `SwiftCompilerPlugin`.

## Validation

- Reproduced directly with the mise-installed Tuist by generating the fixture, trimming the temporary swift-syntax prebuilt to host-only module files, and observing raw `xcodebuild` fail on the non-host macro architecture.
- Confirmed the same damaged host-only prebuilt succeeds once the macro target has `ONLY_ACTIVE_ARCH = YES`.
- Temporarily removed the generator fix and ran the focused acceptance test: red, exit 65.
- Restored the fix and reran the focused acceptance test: green, exit 0.
- Ran focused generator unit tests for macOS macro settings: green, exit 0.