### PR TITLE
chore(infra): revert prod CNPG primaryUpdateMethod to the switchover default

### DIFF
--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -183,14 +183,6 @@ postgresql:
   mode: cnpg
   cnpg:
     instances: 3
-    # Cutover to the Barman Cloud Plugin uses `restart` (recreate the primary in
-    # place) instead of the default `switchover`: the plugin sidecar isn't on the
-    # old primary yet, so a graceful switchover deadlocks waiting for it to
-    # archive (validated on staging 2026-07-04). Costs a bounded ~3 min of write
-    # downtime during the one cutover roll. Revert to the default (switchover)
-    # once prod is on the plugin, so future operator bumps keep the seconds-long
-    # switchover blip. See infra/cnpg/README.md.
-    primaryUpdateMethod: restart
     # Route the processor through the transaction-mode PgBouncer pooler.
     # Web tier stays direct on `-rw` (it holds a long-lived ~75-conn pool
     # that wouldn't benefit from session-mode bouncing); the processor's


### PR DESCRIPTION
## What

Removes the temporary `primaryUpdateMethod: restart` override from the prod CNPG cluster in `values-managed-production.yaml`, letting the chart fall back to its `switchover` default.

## Why

`restart` only existed for the one-time in-tree → Barman Cloud Plugin cutover. During that roll the plugin sidecar isn't yet on the old primary, so a graceful **switchover deadlocks** waiting for the old primary to archive its final WAL (this is exactly what wedged the first canary cutover attempt). `restart` recreates the primary in place and sidesteps that, at the cost of a bounded ~3 min write blip.

## Why it's safe to revert now

Prod is **already on the plugin** — all instances carry the `barman-cloud` sidecar and WAL archiving is healthy. Any future roll is therefore plugin → plugin, with the sidecar present on both sides, so a switchover has nothing to deadlock on. Reverting restores the seconds-long, lossless (RPO 0, 3 sync instances) switchover blip for future operator bumps instead of a multi-minute primary restart.

## Impact

- `primaryUpdateMethod` only governs *how* a future primary update is performed; changing the field does **not** itself trigger a roll, so this deploy does **not** restart the prod primary.
- **Canary** keeps `restart` — it re-cuts-over to the plugin on this same cascade (its CNPG cluster is currently back on in-tree after an earlier `--atomic` rollback).
- **Staging** already defaults to `switchover` (no override).

## Validation

- Confirmed on `origin/main` that only prod carried the `restart` override.
- Prod cutover to the plugin was already verified (deploy green = cluster reached full Ready incl. continuous archiving; `barman-cloud` sidecar injected; `tuist.dev/ready` stayed 200 with no customer-visible blip).
- Canary is healthy again after its bare-metal Dedibox fleet recovered, so this cascade's canary stage will deploy cleanly (all 5 fleets `1/1 ready`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)