### PR TITLE
fix(infra): self-heal wedged runner-cache storage across node reprovision

### DIFF
--- a/infra/cluster-api-provider-tuist/config/rbac/role.yaml
+++ b/infra/cluster-api-provider-tuist/config/rbac/role.yaml
@@ -31,3 +31,13 @@ rules:
   - apiGroups: [""]
     resources: [events]
     verbs: [create, patch]
+  # On machine (node) delete, reap PVCs bound to node-local PVs pinned to the
+  # departing box's hostname so their StatefulSets reprovision fresh volumes on
+  # the replacement node. List PVs to find those pinned to the node; delete the
+  # orphaned PVCs (the cache they back is regenerable).
+  - apiGroups: [""]
+    resources: [persistentvolumes]
+    verbs: [get, list, watch]
+  - apiGroups: [""]
+    resources: [persistentvolumeclaims]
+    verbs: [get, list, watch, delete]

--- a/infra/cluster-api-provider-tuist/controllers/linux/dediboxmachine_controller.go
+++ b/infra/cluster-api-provider-tuist/controllers/linux/dediboxmachine_controller.go
@@ -354,6 +354,14 @@ func (r *DediboxMachineReconciler) reconcileDelete(ctx context.Context, machine 
 		r.event(machine, "DeleteNodeFailed", "delete Node: %v (will retry)", err)
 		return ctrl.Result{}, err
 	}
+	// The reprovisioned box is wiped, so any node-local volume (local-path /
+	// scw-local-nvme) it hosted is gone. Delete the PVCs still bound to those
+	// dead-node PVs so their StatefulSets reprovision fresh volumes on the
+	// replacement node instead of wedging Pending forever on an unbindable PV.
+	if err := deleteNodeLocalPVCs(ctx, r.Client, machine.Name); err != nil {
+		r.event(machine, "DeletePVCsFailed", "delete node-local PVCs orphaned by reprovision: %v (will retry)", err)
+		return ctrl.Result{}, err
+	}
 	// Reinstall the box back to a clean, claimable state as the last step before
 	// dropping the finalizer — it's the only step that retries on failure, so on
 	// the happy path it fires exactly once. Fire-and-forget: the wipe + reimage

--- a/infra/cluster-api-provider-tuist/controllers/linux/node_storage.go
+++ b/infra/cluster-api-provider-tuist/controllers/linux/node_storage.go
@@ -1,0 +1,70 @@
+package linux
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// deleteNodeLocalPVCs removes the PersistentVolumeClaims bound to node-local
+// PersistentVolumes pinned (node affinity) to nodeName. A reprovisioned
+// bare-metal fleet node is wiped and rejoins under a fresh hostname, so any
+// node-local volume it hosted (local-path / scw-local-nvme) is gone and its PV's
+// kubernetes.io/hostname affinity can never be satisfied again: the bound PVC
+// stays Bound to a dead-node PV and its StatefulSet is wedged Pending forever.
+// Deleting the PVC lets the StatefulSet reprovision a fresh volume on the
+// replacement node.
+//
+// Scoped strictly to volumes pinned to THIS node's hostname, so a network volume
+// that could legitimately reattach elsewhere is never touched. The runner-cache
+// data these back is a regenerable cache, so dropping it is safe.
+func deleteNodeLocalPVCs(ctx context.Context, c client.Client, nodeName string) error {
+	var pvs corev1.PersistentVolumeList
+	if err := c.List(ctx, &pvs); err != nil {
+		return fmt.Errorf("list persistent volumes: %w", err)
+	}
+	for i := range pvs.Items {
+		pv := &pvs.Items[i]
+		if !pvPinnedToHostname(pv, nodeName) {
+			continue
+		}
+		claim := pv.Spec.ClaimRef
+		if claim == nil || claim.Name == "" {
+			continue
+		}
+		pvc := &corev1.PersistentVolumeClaim{}
+		pvc.SetName(claim.Name)
+		pvc.SetNamespace(claim.Namespace)
+		if err := c.Delete(ctx, pvc); err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("delete PVC %s/%s orphaned on node %s: %w", claim.Namespace, claim.Name, nodeName, err)
+		}
+		log.FromContext(ctx).Info("deleted node-local PVC orphaned by node reprovision",
+			"node", nodeName, "pvc", claim.Namespace+"/"+claim.Name, "pv", pv.Name)
+	}
+	return nil
+}
+
+// pvPinnedToHostname reports whether a PV's required node affinity restricts it
+// to the given kubernetes.io/hostname.
+func pvPinnedToHostname(pv *corev1.PersistentVolume, hostname string) bool {
+	if pv.Spec.NodeAffinity == nil || pv.Spec.NodeAffinity.Required == nil {
+		return false
+	}
+	for _, term := range pv.Spec.NodeAffinity.Required.NodeSelectorTerms {
+		for _, expr := range term.MatchExpressions {
+			if expr.Key != corev1.LabelHostname || expr.Operator != corev1.NodeSelectorOpIn {
+				continue
+			}
+			for _, v := range expr.Values {
+				if v == hostname {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}

--- a/infra/cluster-api-provider-tuist/controllers/linux/node_storage_test.go
+++ b/infra/cluster-api-provider-tuist/controllers/linux/node_storage_test.go
@@ -1,0 +1,94 @@
+package linux
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// When a bare-metal fleet node is reprovisioned, deleteNodeLocalPVCs must reap
+// only the PVCs bound to node-local PVs pinned to THAT node's hostname, leaving
+// volumes on other nodes and network volumes (no hostname affinity) untouched.
+func TestDeleteNodeLocalPVCs(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+
+	const (
+		deadNode = "tuist-tuist-kura-fleet-old-aaaaa"
+		liveNode = "tuist-tuist-kura-fleet-new-bbbbb"
+	)
+
+	hostPinnedPV := func(name, hostname, claimName string) *corev1.PersistentVolume {
+		return &corev1.PersistentVolume{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+			Spec: corev1.PersistentVolumeSpec{
+				ClaimRef: &corev1.ObjectReference{Kind: "PersistentVolumeClaim", Namespace: "kura", Name: claimName},
+				NodeAffinity: &corev1.VolumeNodeAffinity{Required: &corev1.NodeSelector{
+					NodeSelectorTerms: []corev1.NodeSelectorTerm{{MatchExpressions: []corev1.NodeSelectorRequirement{{
+						Key: corev1.LabelHostname, Operator: corev1.NodeSelectorOpIn, Values: []string{hostname},
+					}}}},
+				}},
+			},
+		}
+	}
+	pvc := func(name string) *corev1.PersistentVolumeClaim {
+		return &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Namespace: "kura", Name: name}}
+	}
+	networkPV := &corev1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: "pv-network"},
+		Spec:       corev1.PersistentVolumeSpec{ClaimRef: &corev1.ObjectReference{Kind: "PersistentVolumeClaim", Namespace: "kura", Name: "data-net-0"}},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+		hostPinnedPV("pv-dead", deadNode, "data-dead-0"),
+		hostPinnedPV("pv-live", liveNode, "data-live-0"),
+		networkPV,
+		pvc("data-dead-0"),
+		pvc("data-live-0"),
+		pvc("data-net-0"),
+	).Build()
+
+	if err := deleteNodeLocalPVCs(context.Background(), c, deadNode); err != nil {
+		t.Fatal(err)
+	}
+
+	get := func(name string) error {
+		return c.Get(context.Background(), types.NamespacedName{Namespace: "kura", Name: name}, &corev1.PersistentVolumeClaim{})
+	}
+	if err := get("data-dead-0"); !apierrors.IsNotFound(err) {
+		t.Fatalf("PVC on the reprovisioned node must be deleted, got %v", err)
+	}
+	if err := get("data-live-0"); err != nil {
+		t.Fatalf("PVC pinned to a different, live node must be kept, got %v", err)
+	}
+	if err := get("data-net-0"); err != nil {
+		t.Fatalf("PVC on a network (non-node-local) volume must be kept, got %v", err)
+	}
+}
+
+func TestPVPinnedToHostname(t *testing.T) {
+	pinned := &corev1.PersistentVolume{Spec: corev1.PersistentVolumeSpec{
+		NodeAffinity: &corev1.VolumeNodeAffinity{Required: &corev1.NodeSelector{
+			NodeSelectorTerms: []corev1.NodeSelectorTerm{{MatchExpressions: []corev1.NodeSelectorRequirement{{
+				Key: corev1.LabelHostname, Operator: corev1.NodeSelectorOpIn, Values: []string{"node-a"},
+			}}}},
+		}},
+	}}
+	if !pvPinnedToHostname(pinned, "node-a") {
+		t.Fatal("expected a match for the pinned hostname")
+	}
+	if pvPinnedToHostname(pinned, "node-b") {
+		t.Fatal("did not expect a match for a different hostname")
+	}
+	if pvPinnedToHostname(&corev1.PersistentVolume{}, "node-a") {
+		t.Fatal("a PV without node affinity must never match")
+	}
+}

--- a/infra/cluster-api-provider-tuist/controllers/linux/ovhdedicatedmachine_controller.go
+++ b/infra/cluster-api-provider-tuist/controllers/linux/ovhdedicatedmachine_controller.go
@@ -378,6 +378,14 @@ func (r *OVHDedicatedMachineReconciler) reconcileDelete(ctx context.Context, mac
 		r.event(machine, "DeleteNodeFailed", "delete Node: %v (will retry)", err)
 		return ctrl.Result{}, err
 	}
+	// The reprovisioned box is wiped, so any node-local volume (local-path /
+	// scw-local-nvme) it hosted is gone. Delete the PVCs still bound to those
+	// dead-node PVs so their StatefulSets reprovision fresh volumes on the
+	// replacement node instead of wedging Pending forever on an unbindable PV.
+	if err := deleteNodeLocalPVCs(ctx, r.Client, machine.Name); err != nil {
+		r.event(machine, "DeletePVCsFailed", "delete node-local PVCs orphaned by reprovision: %v (will retry)", err)
+		return ctrl.Result{}, err
+	}
 	// Reinstall the box back to a clean, claimable state as the last step before
 	// dropping the finalizer — it's the only step that retries on failure, so on
 	// the happy path it fires exactly once. Fire-and-forget: the wipe + reimage

--- a/infra/cluster-api-provider-tuist/controllers/linux/scalewayelasticmetalmachine_controller.go
+++ b/infra/cluster-api-provider-tuist/controllers/linux/scalewayelasticmetalmachine_controller.go
@@ -123,6 +123,8 @@ type ScalewayElasticMetalMachineReconciler struct {
 // +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=scalewayelasticmetalmachines,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=scalewayelasticmetalmachines/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=scalewayelasticmetalmachines/finalizers,verbs=update
+// +kubebuilder:rbac:groups="",resources=persistentvolumes,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=persistentvolumeclaims,verbs=get;list;watch;delete
 
 func (r *ScalewayElasticMetalMachineReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, err error) {
 	machine := &infrav1.ScalewayElasticMetalMachine{}
@@ -518,6 +520,15 @@ func (r *ScalewayElasticMetalMachineReconciler) reconcileDelete(ctx context.Cont
 	node.SetName(machine.Name)
 	if err := r.Delete(ctx, node); err != nil && !apierrors.IsNotFound(err) {
 		r.event(machine, "DeleteNodeFailed", "delete Node: %v (will retry)", err)
+		return ctrl.Result{}, err
+	}
+
+	// The reprovisioned box is wiped, so any node-local volume (local-path /
+	// scw-local-nvme) it hosted is gone. Delete the PVCs still bound to those
+	// dead-node PVs so their StatefulSets reprovision fresh volumes on the
+	// replacement node instead of wedging Pending forever on an unbindable PV.
+	if err := deleteNodeLocalPVCs(ctx, r.Client, machine.Name); err != nil {
+		r.event(machine, "DeletePVCsFailed", "delete node-local PVCs orphaned by reprovision: %v (will retry)", err)
 		return ctrl.Result{}, err
 	}
 

--- a/infra/cluster-api-provider-tuist/docs/scaleway-elastic-metal-support.md
+++ b/infra/cluster-api-provider-tuist/docs/scaleway-elastic-metal-support.md
@@ -142,10 +142,15 @@ attached to the caph cluster, not a ClusterClass topology entry.
   Cross-cloud nodes (Elastic Metal + macOS PN) report a reachable `InternalIP`
   but no `ExternalIP` and a Hostname the Hetzner apiserver can't resolve, so
   this is what lets the apiserver reach those kubelets for `logs`/`exec`.
-- **Node replacement**: CAPI cordons and drains a removed Machine. A
-  replacement EM node re-warms its cache (local NVMe isn't re-attachable like
-  block storage) and the per-account-CA mesh re-bootstraps onto it; the durable
-  mesh state is per-account and rebuilds, so there's no data loss.
+- **Node replacement**: on Machine delete the provider deletes the Node object
+  and reaps the PVCs bound to node-local PVs pinned to the departing box's
+  hostname (`deleteNodeLocalPVCs`, called from each Linux provider's
+  `reconcileDelete`). A node-local (local-NVMe) PV can't follow the box, so
+  without this the replacement node's cache StatefulSet would stay Pending on the
+  old node's unbindable PV; deleting the orphaned PVC lets it provision a fresh
+  volume. The cache re-warms from the per-account-CA mesh (local NVMe isn't
+  re-attachable like block storage); the durable mesh state is per-account and
+  rebuilds, so there's no data loss.
 - **Naming**: the provider binary/repo is `...-applesilicon`; with a Linux kind
   alongside Apple Silicon that's a misnomer, kept for now (a rename is broad
   churn: image, chart, RBAC, CRD group). Revisit if it keeps growing.
@@ -203,11 +208,33 @@ flag), so it no longer has to be applied by hand. The provider IAM key also need
 
 ## Remaining gaps
 
-- **Storage-class migration isn't declarative**: a StatefulSet's
-  `volumeClaimTemplates` are immutable and the controller updates in place, so
-  changing a live KuraInstance's `storageClassName` (e.g. `scw-bssd`→
-  `scw-local-nvme`) silently no-ops and needs a manual delete+recreate; the
-  controller should detect the change and recreate.
+- **Storage-class migration isn't declarative** — *fixed*: a StatefulSet's
+  `volumeClaimTemplates` are immutable, so a live KuraInstance's `storageClassName`
+  change (e.g. `scw-bssd`→`scw-local-nvme`) can't update in place. The
+  kura-controller's `reconcileStaleDataStorage` now detects a data PVC whose
+  storage class no longer matches the CR (or a volume orphaned by a reprovisioned
+  node) and recreates the StatefulSet with a fresh PVC. The cache is regenerable,
+  so the recreate is non-disruptive.
+
+- **Runner-cache readiness has no alert**: the private runner-cache regions
+  expose no public endpoint, so they skip the public HTTPS readiness probe and
+  are the instances with the *least* monitoring — a storage wedge (both gaps
+  above) ran ~34h unnoticed. There is no alert-as-code in this repo (rules live
+  in Grafana Cloud), so add one there against the remote-written
+  kube-state-metrics. The driving metrics already ship (the chart's default KSM
+  allow-list keeps `kube_statefulset_*`); only the Grafana Cloud rule is missing:
+
+  ```promql
+  # KuraRunnerCacheNotReady (severity: warning, for: 15m)
+  # A per-account Kura StatefulSet has been short of ready replicas for 15m.
+  kube_statefulset_status_replicas_ready{namespace="kura"}
+    < kube_statefulset_replicas{namespace="kura"}
+  ```
+
+  The standard kube-prometheus `KubeStatefulSetReplicasMismatch` alert would also
+  catch this if it is enabled and routed for the `kura` namespace — it was not,
+  which is why the wedge was silent. Enabling/routing that is the lighter path;
+  the scoped rule above is the explicit alternative.
 - **Stuck-`:failed` runner-cache nodes aren't auto-retried** server-side
   (`nodes_to_retry` only self-heals servers with `current_image_tag == nil`),
   so a node that deployed then failed needs an operator reset.

--- a/infra/helm/tuist/templates/capi-scaleway-applesilicon.yaml
+++ b/infra/helm/tuist/templates/capi-scaleway-applesilicon.yaml
@@ -87,6 +87,17 @@ rules:
     resources: [nodes/status]
     verbs: [get, update, patch]
   - apiGroups: [""]
+    # On Machine (node) delete, the Linux reconcilers reap PVCs bound to
+    # node-local PVs pinned to the departing box's hostname so their
+    # StatefulSets reprovision fresh volumes on the replacement node. PVs are
+    # listed to find the ones pinned to the node; the orphaned PVCs are deleted
+    # (the runner cache they back is regenerable).
+    resources: [persistentvolumes]
+    verbs: [get, list, watch]
+  - apiGroups: [""]
+    resources: [persistentvolumeclaims]
+    verbs: [get, list, watch, delete]
+  - apiGroups: [""]
     # The failover-IP controller reads peer-demux pod readiness to drain the IP
     # off a box whose demux is rolling.
     resources: [pods]

--- a/infra/helm/tuist/templates/kura-controller.yaml
+++ b/infra/helm/tuist/templates/kura-controller.yaml
@@ -75,9 +75,18 @@ rules:
   - apiGroups: [""]
     resources: [pods]
     verbs: [get, list, watch]
+  # delete: self-heal a wedged instance by recreating its StatefulSet and
+  # dropping data PVCs that can never bind (storage-class drift on the immutable
+  # volumeClaimTemplate, or a node-local volume orphaned by a reprovisioned
+  # bare-metal fleet node). The cache is regenerable, so a fresh PVC is provisioned.
   - apiGroups: [""]
     resources: [persistentvolumeclaims]
-    verbs: [get, list, watch, update, patch]
+    verbs: [get, list, watch, update, patch, delete]
+  # read PVs to detect a data volume pinned (node affinity) to a node that no
+  # longer exists — the reprovisioned-node orphan case above.
+  - apiGroups: [""]
+    resources: [persistentvolumes]
+    verbs: [get, list, watch]
   - apiGroups: ["networking.k8s.io"]
     resources: [ingresses, networkpolicies]
     verbs: [get, list, watch, create, update, patch, delete]

--- a/infra/helm/tuist/templates/kura-controller.yaml
+++ b/infra/helm/tuist/templates/kura-controller.yaml
@@ -79,14 +79,13 @@ rules:
   # dropping data PVCs that can never bind (storage-class drift on the immutable
   # volumeClaimTemplate, or a node-local volume orphaned by a reprovisioned
   # bare-metal fleet node). The cache is regenerable, so a fresh PVC is provisioned.
+  # delete (namespaced): self-heal a wedged instance by recreating its
+  # StatefulSet and dropping data PVCs that can never bind. PVs are read for the
+  # same purpose but are cluster-scoped, so they live in the -node-reads
+  # ClusterRole below, not this namespaced Role.
   - apiGroups: [""]
     resources: [persistentvolumeclaims]
     verbs: [get, list, watch, update, patch, delete]
-  # read PVs to detect a data volume pinned (node affinity) to a node that no
-  # longer exists — the reprovisioned-node orphan case above.
-  - apiGroups: [""]
-    resources: [persistentvolumes]
-    verbs: [get, list, watch]
   - apiGroups: ["networking.k8s.io"]
     resources: [ingresses, networkpolicies]
     verbs: [get, list, watch, create, update, patch, delete]
@@ -118,6 +117,12 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: [nodes]
+    verbs: [get, list, watch]
+  # PVs are cluster-scoped too: reconcileStaleDataStorage reads a bound data
+  # PVC's PersistentVolume to detect a node-local volume pinned (node affinity)
+  # to a node that no longer exists — a reprovisioned bare-metal fleet node.
+  - apiGroups: [""]
+    resources: [persistentvolumes]
     verbs: [get, list, watch]
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/infra/kura-controller/controllers/kurainstance_controller.go
+++ b/infra/kura-controller/controllers/kurainstance_controller.go
@@ -183,7 +183,8 @@ func terminationGracePeriodSeconds() int64 {
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=nodes,verbs=get;list;watch
-// +kubebuilder:rbac:groups="",resources=persistentvolumeclaims,verbs=get;list;watch;update;patch
+// +kubebuilder:rbac:groups="",resources=persistentvolumeclaims,verbs=get;list;watch;update;patch;delete
+// +kubebuilder:rbac:groups="",resources=persistentvolumes,verbs=get;list;watch
 // +kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses;networkpolicies,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=policy,resources=poddisruptionbudgets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=cert-manager.io,resources=certificates,verbs=get;list;watch;create;update;patch;delete
@@ -210,6 +211,21 @@ func (r *KuraInstanceReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		if err := r.Update(ctx, instance); err != nil {
 			return ctrl.Result{}, err
 		}
+	}
+
+	// A StatefulSet's volumeClaimTemplates are immutable, and a node-local data
+	// volume is pinned to the box it was carved on. Two states wedge an instance
+	// Pending forever with nothing to self-heal it: a storageClassName change on
+	// the CR that the live StatefulSet silently ignores (immutable template), and
+	// a bare-metal fleet node reprovisioned out from under a node-local PV. The
+	// cache is regenerable, so recreate the StatefulSet — dropping its PVCs via the
+	// Delete retention policy — and let it provision fresh volumes on the current
+	// storage class and node. Requeue while the cleanup is in flight so the
+	// recreated StatefulSet never re-adopts a stale PVC.
+	if inProgress, err := r.reconcileStaleDataStorage(ctx, instance); err != nil {
+		return ctrl.Result{}, err
+	} else if inProgress {
+		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 	}
 
 	if err := r.reconcileConfigMap(ctx, instance); err != nil {
@@ -1542,6 +1558,125 @@ func (r *KuraInstanceReconciler) reconcileDataPersistentVolumeClaims(ctx context
 		}
 	}
 	return nil
+}
+
+// reconcileStaleDataStorage recreates the StatefulSet when its data PVCs can
+// never bind on the current infrastructure. It reports true while the cleanup is
+// still in flight; the caller requeues and skips the rest of the reconcile until
+// the stale StatefulSet and PVCs are gone, at which point the normal
+// reconcileStatefulSet path recreates them fresh.
+func (r *KuraInstanceReconciler) reconcileStaleDataStorage(ctx context.Context, instance *kurav1alpha1.KuraInstance) (bool, error) {
+	reason, err := r.staleDataStorageReason(ctx, instance)
+	if err != nil || reason == "" {
+		return false, err
+	}
+	log.FromContext(ctx).Info("recreating Kura StatefulSet for stale data storage", "reason", reason)
+
+	// Delete the StatefulSet first so it stops backing the stale PVCs, then the
+	// PVCs themselves. Both deletions are idempotent; staleDataStorageReason keeps
+	// returning a reason (so the caller keeps requeuing) until the objects are
+	// gone, which is what stops the recreated StatefulSet from adopting them.
+	sts := &appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{Name: instance.Name, Namespace: instance.Namespace}}
+	if err := r.Delete(ctx, sts, client.PropagationPolicy(metav1.DeletePropagationForeground)); err != nil && !apierrors.IsNotFound(err) {
+		return false, err
+	}
+	for ordinal := int32(0); ordinal < replicas(instance); ordinal++ {
+		pvc := &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("data-%s-%d", instance.Name, ordinal),
+			Namespace: instance.Namespace,
+		}}
+		if err := r.Delete(ctx, pvc); err != nil && !apierrors.IsNotFound(err) {
+			return false, err
+		}
+	}
+	return true, nil
+}
+
+// staleDataStorageReason returns a non-empty reason when a data PVC can never
+// bind and the StatefulSet must be recreated: it is still terminating from an
+// earlier pass, its storage class no longer matches spec.StorageClassName
+// (StatefulSet volumeClaimTemplates are immutable, so a CR change is otherwise
+// silently dropped), or it is Bound to a volume pinned to a node that no longer
+// exists (a bare-metal fleet node was reprovisioned). A still-present stale PVC
+// keeps returning a reason so the caller waits for deletion to finish before the
+// StatefulSet is recreated.
+func (r *KuraInstanceReconciler) staleDataStorageReason(ctx context.Context, instance *kurav1alpha1.KuraInstance) (string, error) {
+	desiredStorageClass := instance.Spec.StorageClassName
+	for ordinal := int32(0); ordinal < replicas(instance); ordinal++ {
+		name := fmt.Sprintf("data-%s-%d", instance.Name, ordinal)
+		pvc := &corev1.PersistentVolumeClaim{}
+		if err := r.Get(ctx, types.NamespacedName{Name: name, Namespace: instance.Namespace}, pvc); err != nil {
+			if apierrors.IsNotFound(err) {
+				continue
+			}
+			return "", err
+		}
+		if pvc.DeletionTimestamp != nil {
+			return fmt.Sprintf("data PVC %s is still terminating from a prior recreate", name), nil
+		}
+		if desiredStorageClass != "" && pvcStorageClassName(pvc) != desiredStorageClass {
+			return fmt.Sprintf("data PVC %s storage class %q no longer matches desired %q", name, pvcStorageClassName(pvc), desiredStorageClass), nil
+		}
+		if pvc.Status.Phase == corev1.ClaimBound && pvc.Spec.VolumeName != "" {
+			node, err := r.pvMissingPinnedNode(ctx, pvc.Spec.VolumeName)
+			if err != nil {
+				return "", err
+			}
+			if node != "" {
+				return fmt.Sprintf("data PVC %s is bound to a volume pinned to missing node %q", name, node), nil
+			}
+		}
+	}
+	return "", nil
+}
+
+// pvMissingPinnedNode returns the hostname a PV's required node affinity pins it
+// to when that node no longer exists, or "" when the PV isn't hostname-pinned or
+// its node is still present. A local-path (node-local) PV keeps a
+// kubernetes.io/hostname affinity that outlives the node it was carved on.
+func (r *KuraInstanceReconciler) pvMissingPinnedNode(ctx context.Context, pvName string) (string, error) {
+	pv := &corev1.PersistentVolume{}
+	if err := r.Get(ctx, types.NamespacedName{Name: pvName}, pv); err != nil {
+		if apierrors.IsNotFound(err) {
+			return "", nil
+		}
+		return "", err
+	}
+	for _, hostname := range pvRequiredHostnames(pv) {
+		node := &corev1.Node{}
+		err := r.Get(ctx, types.NamespacedName{Name: hostname}, node)
+		if apierrors.IsNotFound(err) {
+			return hostname, nil
+		}
+		if err != nil {
+			return "", err
+		}
+	}
+	return "", nil
+}
+
+func pvcStorageClassName(pvc *corev1.PersistentVolumeClaim) string {
+	if pvc.Spec.StorageClassName != nil {
+		return *pvc.Spec.StorageClassName
+	}
+	return ""
+}
+
+// pvRequiredHostnames returns the kubernetes.io/hostname values a PV's required
+// node affinity restricts it to.
+func pvRequiredHostnames(pv *corev1.PersistentVolume) []string {
+	if pv.Spec.NodeAffinity == nil || pv.Spec.NodeAffinity.Required == nil {
+		return nil
+	}
+	var hostnames []string
+	for _, term := range pv.Spec.NodeAffinity.Required.NodeSelectorTerms {
+		for _, expr := range term.MatchExpressions {
+			if expr.Key == corev1.LabelHostname && expr.Operator == corev1.NodeSelectorOpIn {
+				hostnames = append(hostnames, expr.Values...)
+			}
+		}
+	}
+	return hostnames
 }
 
 func (r *KuraInstanceReconciler) sharedSecretsResourceVersion(ctx context.Context, namespace string) (string, error) {

--- a/infra/kura-controller/controllers/kurainstance_controller_test.go
+++ b/infra/kura-controller/controllers/kurainstance_controller_test.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	kurav1alpha1 "github.com/tuist/tuist/infra/kura-controller/api/v1alpha1"
@@ -2399,4 +2400,140 @@ func TestBaseEnvKeepsTransitionalGRPCPortForPreCohostedImages(t *testing.T) {
 		}
 	}
 	t.Fatal("expected KURA_GRPC_PORT in the pod env: pre-cohosted images hard-require it and would crash-loop without it")
+}
+
+func TestReconcileStaleDataStorage(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := kurav1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+
+	const (
+		instanceName = "kura-acme-scw-fr-par"
+		namespace    = "kura"
+	)
+	pvcName := "data-" + instanceName + "-0"
+
+	newInstance := func() *kurav1alpha1.KuraInstance {
+		return &kurav1alpha1.KuraInstance{
+			ObjectMeta: metav1.ObjectMeta{Name: instanceName, Namespace: namespace},
+			Spec: kurav1alpha1.KuraInstanceSpec{
+				Replicas:         ptr(int32(1)),
+				StorageClassName: "scw-local-nvme",
+			},
+		}
+	}
+	newSTS := func() *appsv1.StatefulSet {
+		return &appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{Name: instanceName, Namespace: namespace}}
+	}
+	boundPVC := func(storageClass, volumeName string) *corev1.PersistentVolumeClaim {
+		sc := storageClass
+		return &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{Name: pvcName, Namespace: namespace},
+			Spec:       corev1.PersistentVolumeClaimSpec{StorageClassName: &sc, VolumeName: volumeName},
+			Status:     corev1.PersistentVolumeClaimStatus{Phase: corev1.ClaimBound},
+		}
+	}
+	pvPinnedTo := func(name, hostname string) *corev1.PersistentVolume {
+		return &corev1.PersistentVolume{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+			Spec: corev1.PersistentVolumeSpec{NodeAffinity: &corev1.VolumeNodeAffinity{Required: &corev1.NodeSelector{
+				NodeSelectorTerms: []corev1.NodeSelectorTerm{{MatchExpressions: []corev1.NodeSelectorRequirement{{
+					Key: corev1.LabelHostname, Operator: corev1.NodeSelectorOpIn, Values: []string{hostname},
+				}}}},
+			}}},
+		}
+	}
+	node := func(name string) *corev1.Node { return &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: name}} }
+
+	exists := func(t *testing.T, c interface {
+		Get(context.Context, types.NamespacedName, client.Object, ...client.GetOption) error
+	}, obj client.Object) bool {
+		t.Helper()
+		err := c.Get(context.Background(), types.NamespacedName{Name: obj.GetName(), Namespace: obj.GetNamespace()}, obj)
+		if err == nil {
+			return true
+		}
+		if apierrors.IsNotFound(err) {
+			return false
+		}
+		t.Fatalf("unexpected get error: %v", err)
+		return false
+	}
+
+	t.Run("recreates on storage class drift", func(t *testing.T) {
+		c := fake.NewClientBuilder().WithScheme(scheme).
+			WithObjects(newInstance(), newSTS(), boundPVC("scw-bssd", "pv-old")).Build()
+		r := &KuraInstanceReconciler{Client: c, Scheme: scheme}
+		inProgress, err := r.reconcileStaleDataStorage(context.Background(), newInstance())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !inProgress {
+			t.Fatal("expected recreate in progress for storage-class drift")
+		}
+		if exists(t, c, &appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{Name: instanceName, Namespace: namespace}}) {
+			t.Fatal("expected StatefulSet deleted")
+		}
+		if exists(t, c, &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Name: pvcName, Namespace: namespace}}) {
+			t.Fatal("expected data PVC deleted")
+		}
+	})
+
+	t.Run("recreates on node-orphaned volume", func(t *testing.T) {
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+			newInstance(), newSTS(), boundPVC("scw-local-nvme", "pv-1"), pvPinnedTo("pv-1", "dead-node"),
+		).Build()
+		r := &KuraInstanceReconciler{Client: c, Scheme: scheme}
+		inProgress, err := r.reconcileStaleDataStorage(context.Background(), newInstance())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !inProgress {
+			t.Fatal("expected recreate in progress for a volume pinned to a missing node")
+		}
+		if exists(t, c, &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Name: pvcName, Namespace: namespace}}) {
+			t.Fatal("expected data PVC deleted")
+		}
+	})
+
+	t.Run("leaves a healthy instance untouched", func(t *testing.T) {
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+			newInstance(), newSTS(), boundPVC("scw-local-nvme", "pv-1"), pvPinnedTo("pv-1", "live-node"), node("live-node"),
+		).Build()
+		r := &KuraInstanceReconciler{Client: c, Scheme: scheme}
+		inProgress, err := r.reconcileStaleDataStorage(context.Background(), newInstance())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if inProgress {
+			t.Fatal("healthy instance should not be recreated")
+		}
+		if !exists(t, c, &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Name: pvcName, Namespace: namespace}}) {
+			t.Fatal("healthy data PVC must not be deleted")
+		}
+		if !exists(t, c, &appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{Name: instanceName, Namespace: namespace}}) {
+			t.Fatal("healthy StatefulSet must not be deleted")
+		}
+	})
+
+	t.Run("ignores an unbound PVC on the correct storage class", func(t *testing.T) {
+		pending := &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{Name: pvcName, Namespace: namespace},
+			Spec:       corev1.PersistentVolumeClaimSpec{StorageClassName: ptr("scw-local-nvme")},
+			Status:     corev1.PersistentVolumeClaimStatus{Phase: corev1.ClaimPending},
+		}
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(newInstance(), pending).Build()
+		r := &KuraInstanceReconciler{Client: c, Scheme: scheme}
+		reason, err := r.staleDataStorageReason(context.Background(), newInstance())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if reason != "" {
+			t.Fatalf("a pending PVC on the desired storage class is not stale, got reason %q", reason)
+		}
+	})
 }


### PR DESCRIPTION
## What changed

Prevents recurrence of the staging PN runner-cache outage where **all 11** `scw-fr-par-runners` KuraInstances sat `Pending` for 34h+ after a bare-metal fleet node was reprovisioned, so staging served no private-network runner cache. Three layers:

- **A — kura-controller self-heal** (`infra/kura-controller`): a new `reconcileStaleDataStorage` step recreates a wedged instance's StatefulSet + data PVCs when a PVC can never bind — storage-class drift, a node-orphaned volume, or a still-terminating PVC from a prior pass — then requeues until they're gone so the recreate never re-adopts a stale PVC.
- **B — CAPI provider node-local PVC GC** (`infra/cluster-api-provider-tuist`): a shared `deleteNodeLocalPVCs` reaps PVCs bound to PVs pinned to a departing box's hostname, called from `reconcileDelete` of the Elastic Metal, Dedibox, and OVH Linux providers, so a replacement node reprovisions fresh instead of wedging.
- **C — readiness alert (docs)**: documents the missing runner-cache readiness alert; the private regions expose no public endpoint and skip the HTTPS readiness probe, so they had the least monitoring. Metrics already ship — only a Grafana Cloud rule is needed.

## Why / root cause

Two documented gaps compounded, and nothing self-healed or paged:

1. **Immutable `volumeClaimTemplates`.** The region config was migrated `scw-bssd` → `scw-local-nvme`, but a StatefulSet's `volumeClaimTemplates` are immutable, so the live StatefulSets silently kept `scw-bssd` — which the Elastic Metal pool has no CSI to attach at all. 10/11 instances were stranded.
2. **Node reprovision orphans node-local PVs.** The bare-metal box was wiped and rejoined under a new hostname. Local-path PVs keep a `kubernetes.io/hostname` affinity to the dead node, so the Bound PVCs could never schedule — orphaning even the one correctly-migrated `scw-local-nvme` instance.

The kura-controller can't mutate an immutable template and the provider's `reconcileDelete` deleted the Node object but not the storage it orphaned, so the wedge was permanent. Both were already listed as gaps in `docs/scaleway-elastic-metal-support.md`.

## Why this approach

- **Self-heal in the kura-controller** (A) is the durable fix: it owns these StatefulSets, knows the data is a regenerable cache, and reconciles continuously — so it recovers from *any* cause of the bad state (provider reprovision, MHC remediation, a node crash-and-replace), not just provider-initiated deletes. It reuses the existing `whenDeleted: Delete` retention + a requeue-until-gone gate to avoid re-adopting a stale PVC.
- **Provider GC** (B) makes node replacement re-warm *proactively* (shrinking the downtime window to zero) and covers all three bare-metal kinds. Scoped strictly to hostname-pinned volumes so a network volume that could legitimately move is never touched.
- **Alert** (C) is docs-only because there is no alert-as-code in this repo (rules live in Grafana Cloud) and the driving `kube_statefulset_*` metrics already ship via the default KSM allow-list.

## RBAC (both deployed roles updated)

- kura-controller: `persistentvolumeclaims` delete in the namespaced Role; `persistentvolumes` read in the `-node-reads` **ClusterRole** (PVs are cluster-scoped, so they can't live in the Role) — `infra/helm/tuist/templates/kura-controller.yaml`.
- CAPI provider: `persistentvolumes` read + `persistentvolumeclaims` delete added to the **deployed** ClusterRole `infra/helm/tuist/templates/capi-scaleway-applesilicon.yaml` (the hand-scaffolded `config/rbac/role.yaml` is not the deployed source). Verified with `helm template`.

## Impact

- Wedged runner-cache instances recover automatically instead of needing a manual break-glass StatefulSet delete.
- Storage-class migrations become effectively declarative (the controller reconciles the change by recreating).
- No behavior change for healthy instances (the detection only fires on genuinely unbindable PVCs).

## Validation

- `go build` + `go test` green for both `infra/kura-controller` and `infra/cluster-api-provider-tuist`; `go vet` and `gofmt` clean.
- New unit tests: storage-class drift, node-orphaned volume, healthy-instance-untouched, pending-PVC-not-stale (kura-controller); dead-node PVC reaped while live-node and network PVCs are kept (provider).
- `helm template` renders both RBAC templates with PV under the ClusterRole(s) and PVC under the namespaced Role / provider ClusterRole.
- The equivalent manual remediation (delete StatefulSets → controller recreates on `scw-local-nvme`) was already run on staging and restored all 11 instances to Ready.

## Follow-ups

- **C requires a Grafana Cloud action** — create/enable `KuraRunnerCacheNotReady`, or enable+route the standard `KubeStatefulSetReplicasMismatch` for the `kura` namespace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)