### PR TITLE
fix(infra): unblock tuist-ops Barman Cloud Plugin cutover

### DIFF
--- a/.github/workflows/tuist-ops-deployment.yml
+++ b/.github/workflows/tuist-ops-deployment.yml
@@ -129,6 +129,33 @@ jobs:
 
           echo "IMAGE_TAG=$IMAGE_TAG" >> "$GITHUB_ENV"
           echo "Deploying image tag $IMAGE_TAG"
+      - name: Strip leftover in-tree barmanObjectStore before plugin cutover
+        run: |
+          set -uo pipefail
+          # Only runs when the chart renders the Barman Cloud Plugin (an ObjectStore
+          # CR + spec.plugins, no barmanObjectStore). Helm 4 applies server-side, so
+          # swapping the live cluster from the in-tree barmanObjectStore to the
+          # plugin only strips the barmanObjectStore sub-fields Helm owns
+          # (destinationPath, endpointURL, s3Credentials) and leaves the
+          # operator-defaulted wal/data blocks behind. The Cluster then carries both
+          # spec.plugins and a credential-less barmanObjectStore, which the CNPG
+          # webhook rejects ("Cannot enable a WAL archiver plugin when
+          # barmanObjectStore is configured"). Remove the whole stanza up front so
+          # the plugin-only apply is clean. Idempotent: a no-op once it is gone.
+          if helm template "$HELM_RELEASE_NAME" "$HELM_CHART_PATH" \
+               -f "$HELM_CHART_PATH/values-managed-production.yaml" \
+               --set image.tag="$IMAGE_TAG" | grep -qE '^kind: ObjectStore$'; then
+            CLUSTER="$(kubectl -n "$NAMESPACE" get cluster.postgresql.cnpg.io \
+              -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)"
+            if [ -n "$CLUSTER" ] && kubectl -n "$NAMESPACE" patch cluster.postgresql.cnpg.io "$CLUSTER" \
+                 --type=json -p '[{"op":"remove","path":"/spec/backup/barmanObjectStore"}]' 2>/dev/null; then
+              echo "Removed leftover in-tree barmanObjectStore from $CLUSTER before plugin cutover."
+            else
+              echo "Plugin mode, but no in-tree barmanObjectStore to remove (already migrated or fresh install)."
+            fi
+          else
+            echo "Chart is in in-tree barmanObjectStore mode; nothing to migrate."
+          fi
       - name: helm upgrade --install
         run: |
           helm upgrade --install "$HELM_RELEASE_NAME" "$HELM_CHART_PATH" \


### PR DESCRIPTION
## What

Adds a gated, idempotent pre-apply step to `tuist-ops-deployment.yml` that strips the live `tuist-ops-pg` cluster's in-tree `barmanObjectStore` before the plugin-only apply, unblocking the tuist-ops cutover to the Barman Cloud Plugin.

## Why

The tuist-ops plugin cutover has failed on every deploy since the flag was flipped in #11564. The CNPG admission webhook rejects the apply:

```
admission webhook "vcluster.cnpg.io" denied: Cluster "tuist-ops-pg" is invalid:
  spec.plugins: Cannot enable a WAL archiver plugin when barmanObjectStore is configured
  spec.backup.barmanObjectStore: missing credentials
```

## Root cause

Helm 4 applies **server-side**. The tuist-ops `cnpg-cluster.yaml` template sets the in-tree `barmanObjectStore` **without** an explicit `wal`/`data` block, so the CNPG operator defaults those fields and *owns* them. When the chart switches to plugin mode, the render drops `barmanObjectStore` entirely, and server-side apply strips only the sub-fields **Helm** owns (`destinationPath`, `endpointURL`, `s3Credentials`) — the operator-owned `wal`/`data` blocks are left behind. The result is a Cluster carrying both `spec.plugins` and a credential-less `barmanObjectStore` stub, which the webhook rejects.

The main tuist chart cut over prod cleanly because *its* template sets `wal`/`data` explicitly, so Helm owns and removes the entire `barmanObjectStore` on cutover. The tuist-ops template never got that treatment.

## Why not a pure-template fix

It can't be fixed in a single deploy from the current (plugin-enabled) state: the plugin render omits `barmanObjectStore` altogether, so Helm never claims `wal`/`data` ownership that it could later remove. The remnant has to be removed out-of-band before the apply.

## The fix

A pre-apply step that, **only when the render is plugin mode** (detected by the chart emitting a `kind: ObjectStore`), removes the whole `barmanObjectStore` stanza from the live Cluster with a JSON patch. It's idempotent — a no-op once migrated or on a fresh install — so it's safe to leave in the deploy path permanently. CI already holds cluster write for the helm apply, so no in-cluster hook or RBAC is required.

## Impact

- tuist-ops is a single-instance internal tool (JIT elevation bot + impersonation policy); the seconds-long archive gap between removing `barmanObjectStore` and the plugin sidecar taking over is negligible, and un-archived WAL is retained (not recycled) so there's no loss risk in that window.
- No behavior change for the in-tree path (the step is skipped when the chart isn't in plugin mode).

## Validation

- Confirmed the failure and its exact webhook error in deploy run 28700161209 (Jul 4).
- Confirmed the mechanism by diffing the two chart templates: main sets `barmanObjectStore.wal`/`data`, tuist-ops does not; and the repo pins Helm 4.2.0 (server-side apply by default).
- Workflow YAML validated (parses; step gated on plugin-mode render, patch guarded against a missing/absent field).

🤖 Generated with [Claude Code](https://claude.com/claude-code)