### PR TITLE
fix(infra): default CNPG dashboard to the production namespace

### DIFF
--- a/infra/grafana-dashboards/postgresql-cnpg.json
+++ b/infra/grafana-dashboards/postgresql-cnpg.json
@@ -2717,10 +2717,10 @@
           "current": {
             "selected": true,
             "text": [
-              "All"
+              "tuist"
             ],
             "value": [
-              "$__all"
+              "tuist"
             ]
           },
           "datasource": "$datasource",


### PR DESCRIPTION
> Describe here the purpose of your PR.

## What changed

The Tuist PostgreSQL CNPG Grafana dashboard's `Namespace` template variable now defaults to `tuist` (production) instead of `All`. `includeAll` and `multi` are preserved, so canary/staging/All are still one click away.

## Why

With `Namespace = All`, the headline overview panels — Connection Usage gauge, Connections, Connections By State — aggregated **production + canary + staging** together. All three environments run under the same `cnpg_cluster` name (`tuist-tuist-pg`), so the `CNPG Cluster` variable can't distinguish them; only `namespace` can (`tuist` = production, `tuist-canary`, `tuist-staging`). The result was that the top-line figures reflected "whichever instance is busiest across all envs" or a cross-environment sum, rather than production — misleading when the dashboard is opened to check on prod.

Example at investigation time: the Connection Usage gauge read ~38–39%, but that was **canary's primary**, not production. Production's primary was at 31.5%.

The per-instance math in the panels was already correct (each pod's backends divided by that pod's own `max_connections`, then `max()` across pods). This change only adjusts the default scope so the dashboard opens on production.

## Context: paired alert fix (already applied live)

This came out of investigating brief, self-resolving `CNPG Connection Usage High` alerts. The alert rule had a related but more serious flaw: it computed `100 * sum(cnpg_backends_total) / max(max_connections)`, summing backends across all three clusters while dividing by 200 (only production's limit). That produced a 75–85% baseline that grazed the 85% threshold constantly and fired briefly, and its summary referenced a nonexistent `$values.B` (rendering `%!f(<nil>)%` in Slack).

That alert rule is **UI-managed in Grafana** (`__grafana_autogenerated__: true`, not provisioned from the repo), so its fix was applied directly via the Grafana alerting API — scoped to `namespace="tuist"` with a corrected summary. It is **not** part of this PR. Only the dashboard is repo-tracked.

## Reviewer notes

- Single-line intent change (`All`/`$__all` → `tuist`); JSON validated, minimal diff.
- The dashboard reaches Grafana via infra provisioning, so it takes effect on deploy — not immediately.
- Follow-up worth considering: the alert rule lives only in Grafana state. If we want it under version control alongside this dashboard, it would need to move into provisioned alerting config.

### How to test locally

Not locally testable — this is a provisioned Grafana dashboard. After deploy, open **Tuist Dashboards → Tuist PostgreSQL CNPG** and confirm the `Namespace` filter defaults to `tuist`, and that the `Namespace` dropdown still offers `tuist-canary`, `tuist-staging`, and `All`.