### PR TITLE
chore(infra): revert canary CNPG primaryUpdateMethod to the switchover default

### DIFF
--- a/infra/helm/tuist/values-managed-canary.yaml
+++ b/infra/helm/tuist/values-managed-canary.yaml
@@ -165,12 +165,6 @@ postgresql:
   mode: cnpg
   cnpg:
     instances: 2
-    # Cutover to the Barman Cloud Plugin uses `restart` (recreate the primary in
-    # place) instead of the default `switchover`, which deadlocks the cutover
-    # roll (old primary can't archive via the plugin before it has the sidecar).
-    # ~3 min write-downtime during the one cutover roll; revert to switchover
-    # once canary is on the plugin. See infra/cnpg/README.md.
-    primaryUpdateMethod: restart
     # PostgreSQL config sized against the 8 GiB memory limit below. CNPG
     # otherwise leaves Postgres on its 128 MiB shared_buffers default;
     # mirror the production tuning shape so canary catches any regression


### PR DESCRIPTION
## What

Removes the temporary `primaryUpdateMethod: restart` override from canary's CNPG cluster in `values-managed-canary.yaml`, letting the chart fall back to its `switchover` default. Follow-up to #11669 (which did the same for prod), bringing canary in line with prod and staging.

## Why

`restart` only existed for the one-time in-tree → Barman Cloud Plugin cutover, where a graceful switchover deadlocks waiting for the old primary (which doesn't yet have the plugin sidecar) to archive its final WAL.

## Why it's safe now

Canary is already on the plugin — both instances carry the `barman-cloud` sidecar and WAL archiving is healthy (`ContinuousArchiving=True`, archiving to `s3://tuist-can-pg-backups/`). Any future roll is therefore plugin → plugin, with the sidecar on both sides, so switchover has nothing to deadlock on. This restores the seconds-long, lossless switchover blip for future operator bumps instead of a multi-minute primary restart.

## Impact

- `primaryUpdateMethod` only governs *how* a future primary update is performed; changing the field does not itself trigger a roll, so this deploy does **not** restart the canary primary.
- After this lands, all three tuist environments (staging, canary, prod) are on the `switchover` default, on the plugin.

## Validation

- Confirmed canary is on the plugin post-#11669 cascade: `2/2` pods with the sidecar, `ContinuousArchiving=True`, `barmanObjectStore` empty (no remnant), sidecar actively archiving WAL to S3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)