### PR TITLE
fix(server): detect xctest runner errors regardless of runner-process prefix

### DIFF
--- a/server/native/xcresult_nif/Sources/XCResultParser/TestSummary.swift
+++ b/server/native/xcresult_nif/Sources/XCResultParser/TestSummary.swift
@@ -39,8 +39,10 @@ public struct TestSummary: Encodable, Sendable {
 /// A run/target-level error that isn't a test failure: the test runner itself
 /// errored (e.g. a target whose `.xctest` bundle couldn't be loaded, or the app
 /// under test couldn't launch). xcresult surfaces these as synthetic
-/// "xctest (<pid>) encountered an error" cases; we lift them out of the test
-/// cases and model them the way Xcode does — as errors, keyed by target.
+/// "<runner-process> (<pid>) encountered an error" cases (the runner process is
+/// `xctest` for unit tests, the app/UI-runner target for UI tests); we lift them
+/// out of the test cases and model them the way Xcode does — as errors, keyed by
+/// target.
 public struct TestRunError: Encodable, Sendable {
     /// The test target the error belongs to, or nil for a run-level error.
     public let target: String?

--- a/server/native/xcresult_nif/Sources/XCResultParser/XCResultParser.swift
+++ b/server/native/xcresult_nif/Sources/XCResultParser/XCResultParser.swift
@@ -144,7 +144,7 @@ public struct XCResultParser: Sendable {
     ) {
         let currentModule = (node.nodeType == "Unit test bundle" || node.nodeType == "UI test bundle") ? node.name : module
 
-        if node.nodeType == "Test Case", let name = node.name, !isRunnerError(name) {
+        if node.nodeType == "Test Case", let name = node.name, !isRunnerError(node) {
             results.append(
                 TestResultStatuses.TestCaseStatus(
                     name: name,
@@ -287,23 +287,41 @@ public struct XCResultParser: Sendable {
         }
     }
 
-    /// xctest emits a synthetic "test case" when the runner itself errors —
-    /// named "xctest (<pid>) encountered an error" — when a whole target's
-    /// `.xctest` bundle can't be loaded or the app can't launch. Xcode surfaces
-    /// these in a separate "Errors" section per target, not as test cases. We do
-    /// the same: lift them out of the test cases (so they don't inflate counts,
-    /// create unbounded per-pid rows, or fire `test_case.created` webhooks) and
-    /// collect them as target-keyed errors. The pid varies per run, so we dedup
-    /// by (target, message) to land one per target like Xcode.
-    private func isRunnerError(_ name: String?) -> Bool {
-        guard let name else { return false }
-        return name.wholeMatch(of: /xctest \(\d+\) encountered an error/) != nil
+    /// xctest emits a synthetic "test case" when the runner itself errors — a
+    /// whole target whose `.xctest` bundle can't be loaded, or an app/UI-test
+    /// runner that can't launch. Xcode surfaces these in a separate "Errors"
+    /// section per target, not as test cases, so we do the same: lift them out of
+    /// the test cases (so they don't inflate counts, create unbounded per-pid
+    /// rows, or fire `test_case.created` webhooks) and collect them as
+    /// target-keyed errors. The pid varies per run, so we dedup by (target,
+    /// message) to land one per target like Xcode.
+    ///
+    /// The node is named "<runner-process> (<pid>) encountered an error", but the
+    /// runner process is only `xctest` for unit tests — for UI tests it's the
+    /// app/UI-runner target, so the prefix varies per project and can't be
+    /// hardcoded. We key on structure instead: a real test's `nodeIdentifier` is a
+    /// "Suite/method" id that differs from its display name, whereas the synthetic
+    /// node has no real identifier, so Xcode repeats the sentence there
+    /// (`nodeIdentifier == name`). We also require the machine-generated
+    /// "… encountered an error" grammar and the `Failure Message` child every
+    /// runner error carries, so a real Swift Testing case whose display name
+    /// merely ends this way is kept.
+    private func isRunnerError(_ node: TestNode) -> Bool {
+        guard node.nodeType == "Test Case",
+              let name = node.name,
+              node.nodeIdentifier == name,
+              (node.children ?? []).contains(where: { $0.nodeType == "Failure Message" })
+        else { return false }
+
+        return name.wholeMatch(of: /\S+ \(\d+\) encountered an error/) != nil
+            || name == "The test runner encountered an error"
+            || name.wholeMatch(of: /\S+ encountered an error/) != nil
     }
 
     private func extractErrors(from node: TestNode, module: String?, into errors: inout [TestRunError]) {
         let currentModule = (node.nodeType == "Unit test bundle" || node.nodeType == "UI test bundle") ? node.name : module
 
-        if node.nodeType == "Test Case", isRunnerError(node.name) {
+        if isRunnerError(node) {
             let message = (node.children ?? [])
                 .first { $0.nodeType == "Failure Message" }?.name
                 ?? node.name
@@ -371,7 +389,7 @@ public struct XCResultParser: Sendable {
         rootDirectory: AbsolutePath?,
         actionLogFailures: [String: [TestFailure]]
     ) -> TestCase? {
-        guard node.nodeType == "Test Case", let name = node.name, !isRunnerError(name) else { return nil }
+        guard node.nodeType == "Test Case", let name = node.name, !isRunnerError(node) else { return nil }
 
         let suiteName = extractSuiteName(from: node.nodeIdentifier)
 

--- a/server/native/xcresult_nif/Tests/XCResultParserTests/XCResultParserTests.swift
+++ b/server/native/xcresult_nif/Tests/XCResultParserTests/XCResultParserTests.swift
@@ -302,4 +302,111 @@ struct XCResultParserTests {
         // Errors mark the run failed even though no real test failed.
         #expect(summary.status == .failed)
     }
+
+    @Test
+    func parse_liftsRunnerErrorsRegardlessOfPrefix_andKeepsRealTestsNamedSimilarly() async throws {
+        // The runner-process name is only "xctest" for unit tests. For UI tests
+        // it's the app/UI-runner target (varies per project), it sometimes has no
+        // pid, and Xcode also emits a generic "The test runner encountered an
+        // error". All are lifted structurally (nodeIdentifier == name plus a
+        // Failure Message child), regardless of the prefix. A real test whose
+        // display name merely ends this way, but which carries a real
+        // "Suite/method" identifier, must survive as a test case.
+        let json = """
+        {
+          "testNodes": [
+            {
+              "nodeType": "Test Plan",
+              "name": "AppTests",
+              "children": [
+                {
+                  "nodeType": "UI test bundle",
+                  "name": "AppUITests",
+                  "children": [
+                    {
+                      "nodeType": "Test Case",
+                      "name": "UITestTarget (4242) encountered an error",
+                      "nodeIdentifier": "UITestTarget (4242) encountered an error",
+                      "result": "Failed",
+                      "children": [
+                        { "nodeType": "Failure Message", "name": "AppUITests-Runner failed to launch." }
+                      ]
+                    },
+                    {
+                      "nodeType": "Test Case",
+                      "name": "EMAUITests-Runner (99) encountered an error",
+                      "nodeIdentifier": "EMAUITests-Runner (99) encountered an error",
+                      "result": "Failed",
+                      "children": [
+                        { "nodeType": "Failure Message", "name": "The UI test runner failed to launch." }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "nodeType": "Unit test bundle",
+                  "name": "SnapshotTests",
+                  "children": [
+                    {
+                      "nodeType": "Test Case",
+                      "name": "SnapshotTestHost encountered an error",
+                      "nodeIdentifier": "SnapshotTestHost encountered an error",
+                      "result": "Failed",
+                      "children": [
+                        { "nodeType": "Failure Message", "name": "Failed to create a bundle instance." }
+                      ]
+                    },
+                    {
+                      "nodeType": "Test Case",
+                      "name": "The test runner encountered an error",
+                      "nodeIdentifier": "The test runner encountered an error",
+                      "result": "Failed",
+                      "children": [
+                        { "nodeType": "Failure Message", "name": "The test runner encountered an error." }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "nodeType": "Unit test bundle",
+                  "name": "RealTests",
+                  "children": [
+                    {
+                      "nodeType": "Test Case",
+                      "name": "the server encountered an error",
+                      "nodeIdentifier": "RealTests/theServerErrorIsSurfaced()",
+                      "result": "Passed"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+        """
+        let parser = XCResultParser(
+            commandRunner: RoutingXCResultToolStub(testResultsJSON: json, actionLogJSON: "")
+        )
+
+        let summary = try #require(
+            try await parser.parse(path: try AbsolutePath(validating: "/tmp/app.xcresult"), rootDirectory: nil)
+        )
+
+        // All four runner errors are lifted — an app/UI-runner target, an exotic
+        // single-token prefix, a no-pid form, and Xcode's generic string — keyed
+        // by their bundle target.
+        let lifted = Set(summary.errors.map { "\($0.target ?? "")|\($0.message)" })
+        #expect(lifted == [
+            "AppUITests|AppUITests-Runner failed to launch.",
+            "AppUITests|The UI test runner failed to launch.",
+            "SnapshotTests|Failed to create a bundle instance.",
+            "SnapshotTests|The test runner encountered an error.",
+        ])
+
+        // The real test whose display name ends the same way, but which has a
+        // real "Suite/method" identifier, is kept and no runner error leaked in.
+        #expect(summary.testCases.map(\.name) == ["the server encountered an error"])
+
+        #expect(summary.status == .failed)
+    }
 }


### PR DESCRIPTION
Follow-up to #11606.

### What changed

`isRunnerError` in the xcresult NIF parser now detects xctest runner errors structurally instead of matching a hardcoded `xctest` prefix. A `Test Case` node is treated as a runner error only when all three hold:

- `nodeIdentifier == name` — a real test carries a `Suite/method` identifier that differs from its display name, whereas the synthetic node has no real identifier so Xcode repeats the sentence there.
- the name matches the machine-generated grammar: `\S+ (\d+) encountered an error` (the unforgeable pid form), the exact string `The test runner encountered an error`, or `\S+ encountered an error` (no pid).
- it has a `Failure Message` child, which every runner error carries.

All three call sites now pass the node. Added coverage for the UI-runner target, an exotic single-token prefix, the no-pid form, and Xcode's generic string, plus a negative case: a real test whose display name ends in "encountered an error" but has a proper `Suite/method` identifier stays a test case.

### Why

#11606 modeled xctest runner errors as target-level Errors instead of test cases, which stopped the `test_case.created` webhook flood and the test-count pollution. But its detector hardcoded the `xctest` prefix:

```
name.wholeMatch(of: /xctest \(\d+\) encountered an error/)
```

xctest names these synthetic cases `<runner-process> (<pid>) encountered an error`. The runner process is only `xctest` for unit tests; for UI tests it is the app/UI-runner target, which is different in every project. Production data across 119 projects shows dozens of distinct prefixes (for example `UITestTarget`, `SnapshotTestHost`, `CabifyRider`, `EMAUITests-Runner`, `XCUITests-Runner`), so a literal-prefix match was always going to be too narrow. Xcode also emits a no-pid form and a generic `The test runner encountered an error`.

### Root cause and why this solution

The root cause is the prefix assumption baked into the original detector. Rather than extend it to a longer list of prefixes (which would reopen the same gap for the next project's runner name), the fix keys on the node structure that actually distinguishes a synthetic runner-error node from a real test: the missing `Suite/method` identifier (`nodeIdentifier == name`), the machine grammar, and the `Failure Message` child. The name-suffix alone was rejected because a suite-less Swift Testing test can have an arbitrary display name; requiring `nodeIdentifier == name` keeps any real test that merely ends with the same phrase.

### Impact

On one affected project, the `xctest (<pid>)` family stopped the moment #11606 deployed, but three other shapes kept flowing into test cases and were still being created hours later:

| Shape | Distinct test cases | Still inserting after #11606 |
| --- | --- | --- |
| `xctest (<pid>) encountered an error` | ~95,700 | no (stopped at deploy) |
| `UITestTarget (<pid>) encountered an error` | ~1,060 | yes |
| `The test runner encountered an error` | 3 | yes |
| `UITestTarget encountered an error` (no pid) | 6 | yes |

After this change all four shapes are lifted into Errors regardless of the runner-process name. A one-time cleanup of the already-ingested rows on affected projects will follow separately once this deploys; cleaning before the fix ships would let the still-uncaught shapes regenerate.

### How to test locally

```
cd server/native/xcresult_nif
swift test --replace-scm-with-registry
```

The relevant cases are `parse_liftsXctestRunnerErrorsOutOfTestCasesIntoErrors` (unchanged, guards against regression) and `parse_liftsRunnerErrorsRegardlessOfPrefix_andKeepsRealTestsNamedSimilarly` (new).
