### PR TITLE
fix(infra): make the CNPG restore drill recover via the Barman Cloud Plugin

### DIFF
--- a/.github/workflows/cnpg-restore-drill.yml
+++ b/.github/workflows/cnpg-restore-drill.yml
@@ -74,11 +74,27 @@ jobs:
         run: |
           set -euo pipefail
           get() { kubectl -n "$NS" get clusters.postgresql.cnpg.io "$CLUSTER" -o jsonpath="$1"; }
-          # Pull the barman store + image straight from the source cluster so
-          # the recovery config can't drift from it (bucket paths, endpoint,
-          # and the PG image differ per env / over time).
-          echo "DEST=$(get '{.spec.backup.barmanObjectStore.destinationPath}')" >> "$GITHUB_ENV"
-          echo "ENDPOINT=$(get '{.spec.backup.barmanObjectStore.endpointURL}')" >> "$GITHUB_ENV"
+          # Pull the recovery source straight from the source cluster so the
+          # recovery config can't drift from it. The shape depends on the
+          # cluster's backup mode: the Barman Cloud Plugin recovers from the
+          # ObjectStore CR (bucket + read credentials live there), while the
+          # legacy in-tree path recovers from barmanObjectStore on the Cluster.
+          # Detect via the WAL-archiver plugin's barmanObjectName (the tuist
+          # clusters carry exactly one plugin; empty => in-tree).
+          BARMAN_OBJ=$(get '{.spec.plugins[0].parameters.barmanObjectName}')
+          if [ -n "$BARMAN_OBJ" ]; then
+            {
+              echo "MODE=plugin"
+              echo "BARMAN_OBJ=$BARMAN_OBJ"
+              echo "SERVER_NAME=$(get '{.spec.plugins[0].parameters.serverName}')"
+            } >> "$GITHUB_ENV"
+          else
+            {
+              echo "MODE=intree"
+              echo "DEST=$(get '{.spec.backup.barmanObjectStore.destinationPath}')"
+              echo "ENDPOINT=$(get '{.spec.backup.barmanObjectStore.endpointURL}')"
+            } >> "$GITHUB_ENV"
+          fi
           echo "IMG=$(get '{.spec.imageName}')" >> "$GITHUB_ENV"
           # Match the live volume size so the restore can actually hold the
           # data (and validates prod-sized recovery), not a hardcoded floor.
@@ -95,7 +111,16 @@ jobs:
       - name: Launch recovery cluster
         run: |
           set -euo pipefail
-          cat <<YAML | kubectl apply -f -
+          # Assemble the recovery source as a flow-style value so the manifest
+          # stays a single heredoc regardless of backup mode. The plugin path
+          # reuses the in-namespace ObjectStore CR (credentials + bucket live
+          # there); the in-tree path inlines the store + read credentials.
+          if [ "$MODE" = plugin ]; then
+            EXT_ENTRY="plugin: {name: barman-cloud.cloudnative-pg.io, parameters: {barmanObjectName: $BARMAN_OBJ, serverName: $SERVER_NAME}}"
+          else
+            EXT_ENTRY="barmanObjectStore: {destinationPath: $DEST, endpointURL: $ENDPOINT, s3Credentials: {accessKeyId: {name: $BACKUP_SECRET, key: ACCESS_KEY_ID}, secretAccessKey: {name: $BACKUP_SECRET, key: ACCESS_SECRET_KEY}}, wal: {compression: gzip}}"
+          fi
+          cat <<YAML | tee /dev/stderr | kubectl apply -f -
           apiVersion: postgresql.cnpg.io/v1
           kind: Cluster
           metadata:
@@ -117,13 +142,7 @@ jobs:
                 source: $CLUSTER
             externalClusters:
               - name: $CLUSTER
-                barmanObjectStore:
-                  destinationPath: $DEST
-                  endpointURL: $ENDPOINT
-                  s3Credentials:
-                    accessKeyId: { name: $BACKUP_SECRET, key: ACCESS_KEY_ID }
-                    secretAccessKey: { name: $BACKUP_SECRET, key: ACCESS_SECRET_KEY }
-                  wal: { compression: gzip }
+                $EXT_ENTRY
           YAML
 
       - name: Wait for recovery to reach healthy


### PR DESCRIPTION
## What

Makes the weekly CNPG restore drill mode-aware so it can recover plugin-backed clusters, not just in-tree ones.

## Why

The drill has failed on every run since the clusters cut over to the Barman Cloud Plugin (the last green run was Jun 29, on in-tree). It read `.spec.backup.barmanObjectStore.destinationPath` off the live cluster to build the recovery config, but plugin-backed clusters have no `barmanObjectStore`, so it built an `externalClusters[].barmanObjectStore` with an empty `destinationPath` and the CNPG webhook rejected it in ~50s:

```
The Cluster "pg-restore-drill-…" is invalid: spec.externalClusters[0].barmanObjectStore.destinationPath:
  Invalid value: "": … should be at least 1 chars long
```

The backups were fine the whole time — this was a **false red** that also Slack-alerts every Monday. It masked the one thing the drill exists to prove: that the *plugin-written* archive is restorable.

## The fix

Detect the source cluster's backup mode from the WAL-archiver plugin's `barmanObjectName`, then build the recovery source accordingly:
- **Plugin** → `externalClusters[].plugin` reusing the in-namespace `ObjectStore` CR (which already carries the bucket + read credentials, so none are repeated).
- **In-tree** → the legacy `externalClusters[].barmanObjectStore` (unchanged).

Both shapes are already documented in `infra/cnpg/README.md`; the drill now follows whichever mode the cluster is actually in, so it keeps validating across the still-present in-tree bridge and any flip-back. Also logs the rendered recovery manifest for easier debugging.

## Validation

Dispatched the fixed workflow against **staging** (on the plugin) from this branch — [run 28785440271](https://github.com/tuist/tuist/actions/runs/28785440271), **green in ~3 min**:
- Recovery cluster bootstrapped from the plugin `ObjectStore`, replayed WAL, reached `Cluster in healthy state`.
- Data + schema matched live exactly: `recovered: tables=63 accounts=11 users=8` vs `live: tables=63 accounts=11 users=8`.
- Recovery cluster + PVCs torn down; the live cluster and its backup path were never touched.

This is also the restore-validation gate for the plugin cutover: the plugin archive is provably restorable end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)