### PR TITLE
fix(server): retry transient ClickHouse read-only errors

### DIFF
--- a/server/lib/tuist/clickhouse_retry.ex
+++ b/server/lib/tuist/clickhouse_retry.ex
@@ -1,7 +1,8 @@
 defmodule Tuist.ClickHouseRetry do
   @moduledoc """
   Retry helper for ClickHouse driver operations that can transiently
-  fail with `Mint.TransportError` or `DBConnection.ConnectionError`.
+  fail with `Mint.TransportError`, `DBConnection.ConnectionError`, or
+  ClickHouse's transient table-shutdown response.
 
   The xcresult-processor pods on Scaleway Mac minis reach ClickHouse
   Cloud over public-internet HTTPS, where idle pool sockets get
@@ -21,22 +22,43 @@ defmodule Tuist.ClickHouseRetry do
   require Logger
 
   @max_retries 3
+  @table_is_read_only_code 242
 
   def with_retry(fun, retries_left \\ @max_retries) do
     fun.()
   rescue
     e in [Mint.TransportError, DBConnection.ConnectionError] ->
-      if retries_left > 0 do
-        delay = Integer.pow(2, @max_retries - retries_left) * 100
+      retry_or_reraise(e, __STACKTRACE__, fun, retries_left)
 
-        Logger.warning(
-          "ClickHouse operation failed (#{Exception.message(e)}), retrying in #{delay}ms (#{retries_left} retries left)"
-        )
-
-        Process.sleep(delay)
-        with_retry(fun, retries_left - 1)
+    e in Ch.Error ->
+      if transient_clickhouse_error?(e) do
+        retry_or_reraise(e, __STACKTRACE__, fun, retries_left)
       else
         reraise e, __STACKTRACE__
       end
   end
+
+  defp retry_or_reraise(exception, stacktrace, fun, retries_left) do
+    if retries_left > 0 do
+      delay = Integer.pow(2, @max_retries - retries_left) * 100
+
+      Logger.warning(
+        "ClickHouse operation failed (#{Exception.message(exception)}), retrying in #{delay}ms (#{retries_left} retries left)"
+      )
+
+      Process.sleep(delay)
+      with_retry(fun, retries_left - 1)
+    else
+      reraise exception, stacktrace
+    end
+  end
+
+  defp transient_clickhouse_error?(%Ch.Error{code: @table_is_read_only_code}), do: true
+
+  defp transient_clickhouse_error?(%Ch.Error{message: message}) when is_binary(message) do
+    String.contains?(message, "TABLE_IS_READ_ONLY") or
+      message |> String.downcase() |> String.contains?("table is shutting down")
+  end
+
+  defp transient_clickhouse_error?(_error), do: false
 end

--- a/server/test/tuist/clickhouse_retry_test.exs
+++ b/server/test/tuist/clickhouse_retry_test.exs
@@ -61,6 +61,42 @@ defmodule Tuist.ClickHouseRetryTest do
       assert :counters.get(counter, 1) == 2
     end
 
+    test "retries on transient ClickHouse table shutdown errors" do
+      counter = :counters.new(1, [])
+
+      log =
+        capture_log(fn ->
+          assert ClickHouseRetry.with_retry(fn ->
+                   :counters.add(counter, 1, 1)
+
+                   if :counters.get(counter, 1) < 2 do
+                     raise %Ch.Error{
+                       code: 242,
+                       message: "Table is in readonly mode while shutting down (TABLE_IS_READ_ONLY)"
+                     }
+                   end
+
+                   :ok
+                 end) == :ok
+        end)
+
+      assert :counters.get(counter, 1) == 2
+      assert log =~ "ClickHouse operation failed"
+    end
+
+    test "lets non-transient ClickHouse errors propagate without retry" do
+      counter = :counters.new(1, [])
+
+      assert_raise Ch.Error, fn ->
+        ClickHouseRetry.with_retry(fn ->
+          :counters.add(counter, 1, 1)
+          raise %Ch.Error{code: 60, message: "Unknown table"}
+        end)
+      end
+
+      assert :counters.get(counter, 1) == 1
+    end
+
     test "reraises Mint.TransportError after exhausting retries" do
       counter = :counters.new(1, [])
 


### PR DESCRIPTION
## What Changed

- Extended `Tuist.ClickHouseRetry` to retry transient ClickHouse `Ch.Error` failures when ClickHouse reports `TABLE_IS_READ_ONLY`, error code `242`, or a table-shutdown message.
- Kept non-transient `Ch.Error` failures as immediate exceptions so schema/query bugs still surface normally.
- Added regression coverage for both the retryable table-shutdown case and a non-retryable ClickHouse error.

## Why

A production Sentry issue pointed at a ClickHouse failure. The private Sentry event could not be read from the local session because Sentry required sign-in, so the investigation focused on the ClickHouse retry and migration paths in the server code.

The codebase already documents ClickHouse Cloud's transient `TABLE_IS_READ_ONLY` / table-shutdown race in ClickHouse migrations, but the shared retry helper only retried transport and `DBConnection` failures. Any repo operation wrapped by `Tuist.ClickHouseRetry` would therefore surface this transient ClickHouse response directly instead of retrying like the migration-local helpers do.

## Root Cause

`Tuist.ClickHouseRetry.with_retry/2` handled `Mint.TransportError` and `DBConnection.ConnectionError`, but not retryable `Ch.Error` responses from ClickHouse itself. When ClickHouse briefly marks a table read-only while it is shutting down or swapping parts, the operation can be retried safely, but the helper treated it as a permanent application error.

## Approach

The fix keeps the retry policy intentionally narrow:

- Retry only ClickHouse table-shutdown/read-only signals (`code: 242`, `TABLE_IS_READ_ONLY`, or `table is shutting down`).
- Reuse the existing exponential backoff and retry budget.
- Continue to re-raise all other `Ch.Error` values immediately.

This avoids masking real ClickHouse query or schema issues while making the shared retry behavior cover the transient condition already handled elsewhere.

## Impact

Transient ClickHouse Cloud table-shutdown/read-only races should no longer surface as Sentry errors for operations covered by `Tuist.ClickHouseRetry`. Non-transient ClickHouse errors remain visible.

## Validation

TDD flow:

1. Added a failing regression test for a transient `Ch.Error` table-shutdown response.
2. Implemented the retry handling.
3. Re-ran the focused test suite successfully.

Checks run:

```sh
mix test test/tuist/clickhouse_retry_test.exs
mix format lib/tuist/clickhouse_retry.ex test/tuist/clickhouse_retry_test.exs
git diff --check -- server/lib/tuist/clickhouse_retry.ex server/test/tuist/clickhouse_retry_test.exs
```

Result: `7 tests, 0 failures`.
