### PR TITLE
refactor(infra): remove the in-tree barmanObjectStore backup path (plugin-only)

### DIFF
--- a/infra/cnpg/README.md
+++ b/infra/cnpg/README.md
@@ -111,14 +111,13 @@ Continuous WAL archiving + daily 03:00 UTC base backups, both targeting the per-
 
 The Tigris key used for backups is **separate** from the workload's `S3_CREDENTIALS` — a dedicated `S3_BACKUP_CREDENTIALS` item per env, scoped to the env's backup bucket only. Rotate it independently from the workload key.
 
-Restore-validation drill (run quarterly, or before any operation that depends on
-backups being usable). Build a one-shot recovery `Cluster` that replays from the
-archive, run validation queries against it, then delete it (and its PVCs). The
-recovery-source shape depends on which backup mode the cluster is in.
-
-**Plugin path** (`…backup.plugin.enabled: true`) — recover through
-`externalClusters[].plugin`, reusing the `ObjectStore` CR the chart already
-renders in the namespace. `serverName` is the original cluster name (the archive
+Restore-validation drill, automated by
+[`.github/workflows/cnpg-restore-drill.yml`](../../.github/workflows/cnpg-restore-drill.yml)
+(weekly + on-demand per env; also run it by hand before any operation that
+depends on backups being usable). It builds a one-shot recovery `Cluster` that
+replays from the archive, checks the restored data + schema against live, then
+deletes it (and its PVCs). Recover through `externalClusters[].plugin`, reusing
+the `ObjectStore` CR the chart already renders in the namespace. `serverName` is the original cluster name (the archive
 prefix), `barmanObjectName` is the rendered store (`tuist-tuist-pg-backup-store`
 for the main cluster, `tuist-ops-pg-backup-store` for tuist-ops):
 
@@ -144,15 +143,9 @@ spec:
           serverName: tuist-tuist-pg
 ```
 
-**In-tree path** (`…backup.plugin.enabled: false`, the pre-cutover default) —
-same `bootstrap.recovery` + `externalClusters`, but the entry uses
-`barmanObjectStore:` (the `destinationPath` + `endpointURL` + `s3Credentials`)
-instead of `plugin:`.
-
 Apply the manifest, wait for `phase: Cluster in healthy state`, run the
-validation queries, then `kubectl delete cluster` it. Note: with the plugin,
-backup state shows in the `ObjectStore`/`Cluster` status rather than the in-tree
-`kubectl cnpg backup-status` view.
+validation queries, then `kubectl delete cluster` it. Backup state shows in the
+`ObjectStore`/`Cluster` status.
 
 ## Operator version & upgrade path
 
@@ -199,62 +192,37 @@ Merge an operator-bump PR at the start of a low-traffic window wider than the
 deploy lag (the prod step runs after the canary deploy and acceptance tests, so
 roughly 20-40 min after merge), so the switchover lands inside the quiet period.
 
-In-tree `barmanObjectStore` backups are deprecated (since operator 1.26) in
-favor of the Barman Cloud Plugin but still work on 1.29. The plugin migration is
-wired up but gated off — see below.
+In-tree `barmanObjectStore` backups (the operator's native path, deprecated
+since 1.26) are no longer rendered; every cluster backs up through the Barman
+Cloud Plugin.
 
-## Backup: in-tree barmanObjectStore -> Barman Cloud Plugin
+## Backup: Barman Cloud Plugin
 
-In-tree Barman Cloud is deprecated (since operator 1.26) and is being phased out
-of the core operator. This chart can render backups either way, switched per
-cluster by `…backup.plugin.enabled` (default `false` = the in-tree
-`barmanObjectStore`, unchanged). When enabled, the cluster archives via the
-Barman Cloud Plugin (CNPG-I): an `ObjectStore` CR holds the bucket config and
-the `Cluster` references it through `.spec.plugins`. Value keys: the main server
-uses `postgresql.cnpg.backup.plugin.*`; tuist-ops uses `postgresql.backup.plugin.*`.
+Backups run through the Barman Cloud Plugin (CNPG-I): an `ObjectStore` CR holds
+the bucket config, the `Cluster` references it through `.spec.plugins` for WAL
+archiving, and a `ScheduledBackup` with `method: plugin` takes the daily base
+backup (03:00 UTC). Value keys: the main server uses
+`postgresql.cnpg.backup.plugin.*`; tuist-ops uses `postgresql.backup.plugin.*`.
 
-**The plugin is installed on every cluster by the platform deploy** — it's a
+**The plugin is installed on every cluster by the platform deploy.** It's a
 dependency of the platform chart (`plugin-barman-cloud`, pinned in
 [`infra/helm/platform/Chart.yaml`](../helm/platform/Chart.yaml), toggled by
 `plugin-barman-cloud.enabled`). As a subchart of the `platform` release it lands
 in the `platform` namespace alongside the operator, which is where the plugin
-must run. It's idle until a `Cluster` opts in, so installing it changes no
-backups. Bump it like any other platform dependency: edit the pin and redeploy.
+must run. Bump it like any other platform dependency: edit the pin and redeploy.
 It needs cert-manager (already a platform dependency) and adds the
 `objectstores.barmancloud.cnpg.io` CRD, the `platform-plugin-barman-cloud`
 Deployment (release-prefixed as a subchart), a Service, and self-signed mTLS
 Certificates.
 
-**Cutover (per env):** with the plugin installed, flip
-`…backup.plugin.enabled` to `true` **and set `…cnpg.primaryUpdateMethod:
-restart`** for the roll, then deploy. This is an atomic `Cluster` change (drops
-`.spec.backup.barmanObjectStore`, adds `.spec.plugins`) that recreates every
-instance to inject the plugin sidecar.
+**Archive continuity:** `serverName` is pinned to the cluster name and the
+`ObjectStore` uses the same `destinationPath` + credentials, so the plugin reads
+and writes one continuous `s3://…/<serverName>` archive; recovery replays the
+whole history. Confirm health from a primary pod's `plugin-barman-cloud` sidecar
+logs: `Archived WAL file` for the WAL stream, `Backup completed` for the daily
+base backup.
 
-**Do NOT cut over with the default `switchover` method.** The old primary has no
-sidecar yet, so it can't archive via the plugin, and CNPG's graceful switchover
-hangs indefinitely waiting for it to archive its final WAL — the operator wedges
-with no primary (this happened on canary 2026-07-04). `restart` recreates the
-primary *in place* instead, avoiding the handoff. Validated on staging, at the
-cost of a bounded **~3 min of write-downtime** while the primary pod recreates —
-so merge in a low-traffic window. Revert `primaryUpdateMethod` to the default
-(`switchover`) once the env is on the plugin, so future operator bumps keep the
-seconds-long switchover blip.
-
-**If the roll sticks anyway** (no primary, operator looping "switchover in
-progress"), recover with break-glass: force-remove the old primary and restart
-the operator — `kubectl delete pod <old-primary> --grace-period=0 --force` then
-`kubectl -n platform rollout restart deploy/platform-cloudnative-pg`. CNPG then
-promotes the caught-up sync standby, lossless (RPO 0 with quorum sync). Proven
-recovery.
-
-**Continuity invariant (verify before trusting it):** the plugin must keep
-writing to the SAME archive. `serverName` is pinned to the cluster name (the
-value the in-tree path defaulted to) and the `ObjectStore` reuses the same
-`destinationPath` + credentials, so the prefix is unchanged. After cutover,
-confirm the primary's logs show `Archived WAL file` to the same
-`s3://…/<serverName>` path, then run a restore-validation drill from a
-plugin-written backup before retiring the in-tree path elsewhere.
-
-**Observability:** backup metrics rename from `cnpg_collector_*` to
-`barman_cloud_cloudnative_pg_io_*`; repoint any panels or backup-failure alerts.
+**Observability:** the plugin reports backup freshness via
+`barman_cloud_cloudnative_pg_io_*`. The operator's `cnpg_collector_*` backup
+timestamps do NOT track plugin backups, so point backup panels and alerts at the
+`barman_cloud_*` series.

--- a/infra/helm/tuist-ops/templates/cnpg-cluster.yaml
+++ b/infra/helm/tuist-ops/templates/cnpg-cluster.yaml
@@ -47,36 +47,16 @@ spec:
     {{- toYaml .Values.postgresql.resources | nindent 4 }}
 
   {{- if .Values.postgresql.backup.enabled }}
-  {{- if .Values.postgresql.backup.plugin.enabled }}
-  # Barman Cloud Plugin (CNPG-I) path. serverName pinned to the cluster name
-  # to keep the existing archive prefix (continuity). See infra/cnpg/README.md.
+  # Barman Cloud Plugin (CNPG-I). serverName pinned to the cluster name to keep
+  # the existing archive prefix. See infra/cnpg/README.md.
   plugins:
     - name: {{ .Values.postgresql.backup.plugin.name | quote }}
       isWALArchiver: true
       parameters:
         barmanObjectName: {{ include "tuist-ops.pgClusterName" . }}-backup-store
         serverName: {{ include "tuist-ops.pgClusterName" . | quote }}
-  {{- else }}
-  backup:
-    barmanObjectStore:
-      destinationPath: {{ .Values.postgresql.backup.destinationPath | quote }}
-      endpointURL: {{ .Values.postgresql.backup.endpointURL | quote }}
-      s3Credentials:
-        accessKeyId:
-          name: {{ .Values.postgresql.backup.credentialsSecretName }}
-          key: ACCESS_KEY_ID
-        secretAccessKey:
-          name: {{ .Values.postgresql.backup.credentialsSecretName }}
-          key: ACCESS_SECRET_KEY
-      wal:
-        compression: gzip
-        maxParallel: 8
-      data:
-        compression: gzip
-    retentionPolicy: {{ .Values.postgresql.backup.retentionPolicy | quote }}
   {{- end }}
-  {{- end }}
-{{- if and .Values.postgresql.backup.enabled .Values.postgresql.backup.plugin.enabled }}
+{{- if .Values.postgresql.backup.enabled }}
 ---
 # Barman Cloud Plugin object-store config — mirrors the in-tree
 # barmanObjectStore stanza (same bucket/prefix, credentials, wal/data,
@@ -118,11 +98,9 @@ spec:
   # Daily at 03:00 UTC. Internal tool; nothing urgent to recover.
   schedule: "0 0 3 * * *"
   backupOwnerReference: self
-  {{- if .Values.postgresql.backup.plugin.enabled }}
   method: plugin
   pluginConfiguration:
     name: {{ .Values.postgresql.backup.plugin.name | quote }}
-  {{- end }}
   cluster:
     name: {{ include "tuist-ops.pgClusterName" . }}
 {{- end }}

--- a/infra/helm/tuist-ops/values.yaml
+++ b/infra/helm/tuist-ops/values.yaml
@@ -78,13 +78,10 @@ postgresql:
     # server uses. See `infra/helm/tuist/templates/postgresql-cnpg.yaml`
     # for the established pattern.
     credentialsSecretName: tuist-ops-backup-credentials
-    # Barman Cloud Plugin (CNPG-I) migration. When enabled, this cluster
-    # archives via the plugin + an ObjectStore CR instead of the in-tree
-    # barmanObjectStore. Requires the plugin installed in the operator
-    # namespace (`platform`) — see infra/cnpg/README.md. Default off: no-op
-    # until flipped after validating WAL continuity + a restore drill.
+    # Barman Cloud Plugin (CNPG-I): this cluster archives via the plugin + an
+    # ObjectStore CR. Requires the plugin installed in the operator namespace
+    # (`platform`) — see infra/cnpg/README.md.
     plugin:
-      enabled: true
       name: barman-cloud.cloudnative-pg.io
 
 ingress:

--- a/infra/helm/tuist/templates/postgresql-cnpg.yaml
+++ b/infra/helm/tuist/templates/postgresql-cnpg.yaml
@@ -185,47 +185,20 @@ spec:
         passwordSecret:
           name: {{ $opsRoSecretName }}
 
-  {{- if .Values.postgresql.cnpg.backup.plugin.enabled }}
-  # Barman Cloud Plugin (CNPG-I) path. WAL archiving + base backups run via
-  # the plugin sidecar against the ObjectStore CR below. `serverName` is
-  # pinned to the cluster name — the same value the in-tree barmanObjectStore
-  # defaulted to — so the plugin continues the EXISTING archive prefix
-  # (no new base backup, no orphaned PITR history). This is the single most
-  # important continuity invariant; verify it before trusting the cutover.
+  # Barman Cloud Plugin (CNPG-I). WAL archiving + base backups run via the
+  # plugin sidecar against the ObjectStore CR below. `serverName` is pinned to
+  # the cluster name — the value the archive prefix has always used — so the
+  # plugin reads and writes the existing PITR history.
   plugins:
     - name: {{ .Values.postgresql.cnpg.backup.plugin.name | quote }}
       isWALArchiver: true
       parameters:
         barmanObjectName: {{ $objectStoreName | quote }}
         serverName: {{ $clusterName | quote }}
-  {{- else }}
-  backup:
-    retentionPolicy: {{ .Values.postgresql.cnpg.backup.retention | quote }}
-    barmanObjectStore:
-      destinationPath: {{ .Values.postgresql.cnpg.backup.destinationPath | quote }}
-      endpointURL: {{ .Values.postgresql.cnpg.backup.endpointURL | quote }}
-      s3Credentials:
-        accessKeyId:
-          name: {{ $backupSecretName }}
-          key: ACCESS_KEY_ID
-        secretAccessKey:
-          name: {{ $backupSecretName }}
-          key: ACCESS_SECRET_KEY
-      wal:
-        compression: gzip
-        maxParallel: 4
-      data:
-        compression: gzip
-        immediateCheckpoint: false
-        jobs: 2
-  {{- end }}
-{{- if .Values.postgresql.cnpg.backup.plugin.enabled }}
 ---
-# Barman Cloud Plugin object-store config. Mirrors the in-tree
-# barmanObjectStore stanza exactly (same bucket, credentials, wal/data,
-# retention) so the plugin reads and writes the existing archive. Referenced
-# by the Cluster's plugins[].parameters.barmanObjectName above. Note:
-# retention moves from the Cluster (.spec.backup.retentionPolicy) to here.
+# Barman Cloud Plugin object-store config: bucket, credentials, wal/data
+# compression, and retention for the archive the plugin reads and writes.
+# Referenced by the Cluster's plugins[].parameters.barmanObjectName above.
 apiVersion: barmancloud.cnpg.io/v1
 kind: ObjectStore
 metadata:
@@ -251,7 +224,6 @@ spec:
     data:
       compression: gzip
       jobs: 2
-{{- end }}
 ---
 # Daily base backup at 03:00 UTC. The continuous WAL stream archived by
 # the Cluster above keeps PITR alive between base backups; the
@@ -266,11 +238,9 @@ metadata:
 spec:
   schedule: {{ .Values.postgresql.cnpg.backup.schedule | quote }}
   backupOwnerReference: self
-  {{- if .Values.postgresql.cnpg.backup.plugin.enabled }}
   method: plugin
   pluginConfiguration:
     name: {{ .Values.postgresql.cnpg.backup.plugin.name | quote }}
-  {{- end }}
   cluster:
     name: {{ $clusterName }}
   immediate: true

--- a/infra/helm/tuist/values-managed-canary.yaml
+++ b/infra/helm/tuist/values-managed-canary.yaml
@@ -217,11 +217,6 @@ postgresql:
         memory: "8Gi"
     backup:
       destinationPath: s3://tuist-can-pg-backups/
-      # Cut over to the Barman Cloud Plugin (installed cluster-wide by the
-      # platform chart). Same bucket + serverName, so the archive prefix is
-      # unchanged. See infra/cnpg/README.md.
-      plugin:
-        enabled: true
 
 processor:
   replicaCount: 1

--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -259,11 +259,6 @@ postgresql:
         memory: "16Gi"
     backup:
       destinationPath: s3://tuist-prod-pg-backups/
-      # Cut over to the Barman Cloud Plugin (installed cluster-wide by the
-      # platform chart). Same bucket + serverName, so the archive prefix is
-      # unchanged. See infra/cnpg/README.md.
-      plugin:
-        enabled: true
 
 clickhouse:
   external:

--- a/infra/helm/tuist/values-managed-staging.yaml
+++ b/infra/helm/tuist/values-managed-staging.yaml
@@ -250,11 +250,6 @@ postgresql:
         memory: "4Gi"
     backup:
       destinationPath: s3://tuist-stag-pg-backups/
-      # Cut over to the Barman Cloud Plugin (installed cluster-wide by the
-      # platform chart). Same bucket + serverName, so the archive prefix is
-      # unchanged. See infra/cnpg/README.md.
-      plugin:
-        enabled: true
 
 processor:
   # Single replica on staging — 2-replica redundancy isn't needed for a

--- a/infra/helm/tuist/values.yaml
+++ b/infra/helm/tuist/values.yaml
@@ -1809,15 +1809,11 @@ postgresql:
       # bucket name in the path; the endpoint is shared.
       destinationPath: ""
       endpointURL: "https://t3.storage.dev"
-      # Barman Cloud Plugin (CNPG-I) migration. When enabled, the cluster
-      # archives via the plugin sidecar + an ObjectStore CR instead of the
-      # in-tree barmanObjectStore (deprecated since operator 1.26). Requires
-      # the plugin-barman-cloud manifest installed in the operator namespace
-      # (`platform`) — see infra/cnpg/README.md. Default off: this is a
-      # no-op until flipped per-env after validating WAL continuity (same
-      # bucket + serverName) and a restore drill from a plugin-written backup.
+      # Barman Cloud Plugin (CNPG-I): the cluster archives via the plugin
+      # sidecar + an ObjectStore CR. Requires the plugin-barman-cloud manifest
+      # installed in the operator namespace (`platform`) — see
+      # infra/cnpg/README.md.
       plugin:
-        enabled: false
         name: barman-cloud.cloudnative-pg.io
     externalSecrets:
       refreshInterval: "1h"


### PR DESCRIPTION
## What

Burns the in-tree `barmanObjectStore` bridge now that every CNPG cluster is on the Barman Cloud Plugin. Removes the in-tree fallback branch and the `plugin.enabled` flag that gated it, so the chart renders one backup path only.

- **Both CNPG templates** (`infra/helm/tuist/templates/postgresql-cnpg.yaml`, `infra/helm/tuist-ops/templates/cnpg-cluster.yaml`): drop the `if plugin.enabled / else(barmanObjectStore) / end` gating; always render `plugins` + the `ObjectStore` CR + `ScheduledBackup` `method: plugin`.
- **Values**: remove the now-dead `plugin.enabled` flag from base + staging/canary/prod + tuist-ops (keep `plugin.name`).
- **README** (`infra/cnpg/README.md`): drop the dual-mode / migration / cutover playbook and the in-tree recovery variant; document the plugin as the single backup path.

## Why

The migration is complete and validated end-to-end, so the in-tree path and its `plugin.enabled` toggle are dead config:
- Restore drill passes against a plugin-written archive (recovery cluster reached healthy, data + schema matched live).
- Prod's daily plugin base backup completed today (`backup-20260706030000`, ~37 min, on the prefer-standby replica).
- WAL archiving is live on every cluster.

Keeping a dead in-tree branch + a flag that's `true` everywhere is exactly the kind of speculative/dead config worth removing.

## Safety

This is a **pure cleanup with no live-cluster effect**. Every env is already plugin-enabled, so removing the `else`-branch and the gating produces identical output. Verified with `helm template`: the rendered CNPG manifests (`Cluster`, `ObjectStore`, `ScheduledBackup`) are **byte-identical** to `origin/main` for all four targets (main staging/canary/prod + tuist-ops) once comments are excluded. Merging is a no-op deploy on the clusters.

## Trade-off

This removes the instant flip-back-to-in-tree rollback that the bridge provided. It's removed deliberately, after the plugin path was fully validated. A future plugin issue would be recovered by re-adding a `barmanObjectStore` stanza (a code change + deploy), not a flag flip — an acceptable cost given the validation.

## Validation

- `helm template` byte-identical manifest diff (comments stripped) for all four render targets.
- No remaining `plugin.enabled` references in `infra/helm/**` or `infra/cnpg/**`.
- Both charts render without error after the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)