### PR TITLE
fix(server): make OG image generation resilient

### DIFF
--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -243,6 +243,15 @@ jobs:
           mix-cache-key: mix-test-v2
           mix-cache-restore-key: mix-test-v2-
           restore-mix-cache: "false"
+      - name: Restore CLDR locale cache
+        uses: actions/cache@v4
+        with:
+          path: server/_build/cldr/locales
+          key: cldr-locales-v1-${{ hashFiles('server/mix.lock') }}
+          restore-keys: |
+            cldr-locales-v1-
+      - name: Prefetch CLDR locale data
+        run: mise/tasks/cldr/prefetch-locale-data.sh
       - name: Compile
         run: mix compile --warnings-as-errors
       - name: Start ClickHouse

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -63,7 +63,7 @@ WORKDIR /app
 # ========================================
 FROM ${BUILDER_IMAGE} AS deps-builder
 
-RUN apt-get update -y && apt-get upgrade -y && apt-get install -y build-essential git \
+RUN apt-get update -y && apt-get upgrade -y && apt-get install -y build-essential ca-certificates curl git \
   && apt-get clean && rm -f /var/lib/apt/lists/*_*
 
 WORKDIR /app
@@ -89,6 +89,7 @@ ENV HEX_HTTP_TIMEOUT=120
 ENV ELIXIR_ERL_OPTIONS="+S 2"
 
 COPY server/mix.exs server/mix.lock ./
+COPY server/mise/tasks/cldr mise/tasks/cldr
 RUN mkdir config
 
 # Copy path dependencies (only mix.exs/mix.lock for dep resolution)
@@ -121,6 +122,7 @@ COPY server/config/config.exs config/
 COPY server/config/prod.exs server/config/can.exs server/config/stag.exs config/
 
 RUN mix deps.compile
+RUN mise/tasks/cldr/prefetch-locale-data.sh
 
 # ========================================
 # Stage: OG image generator

--- a/server/lib/mix/og_image_renderer.ex
+++ b/server/lib/mix/og_image_renderer.ex
@@ -1,0 +1,165 @@
+defmodule Tuist.Mix.OgImageRenderer do
+  @moduledoc """
+  Build-time OG image renderer shared by the docs and marketing Mix tasks.
+  """
+  alias Tuist.Marketing.OgImageCache
+  alias Tuist.Marketing.OpenGraph
+
+  @max_pool_size 4
+  @preflight_timeout 45_000
+  @render_timeout 120_000
+  @stream_timeout @render_timeout + 10_000
+
+  def pool_size do
+    case System.get_env("TUIST_OG_IMAGE_POOL_SIZE") do
+      value when is_binary(value) ->
+        case Integer.parse(value) do
+          {pool_size, ""} when pool_size > 0 -> pool_size
+          _ -> default_pool_size()
+        end
+
+      _ ->
+        default_pool_size()
+    end
+  end
+
+  def render_timeout, do: @stream_timeout
+
+  def start_carta(pool) do
+    pool_size = pool_size()
+
+    case Browse.start_link(pool, implementation: BrowseChrome.Browser, pool_size: pool_size) do
+      {:ok, pid} ->
+        renderer = %{mode: :carta, pid: pid, pool: pool, pool_size: pool_size}
+
+        case preflight_carta(renderer) do
+          :ok ->
+            renderer
+
+          {:error, reason} ->
+            stop_pool(pid)
+            warn_fallback(reason)
+            %{renderer | mode: :fallback, pid: nil}
+        end
+
+      {:error, reason} ->
+        warn_fallback(reason)
+        %{mode: :fallback, pid: nil, pool: pool, pool_size: pool_size}
+    end
+  end
+
+  def render(renderer, html, image_path, key, label, fallback_title, opts \\ []) do
+    carta_key = key
+    fallback_key = fallback_cache_key(key)
+
+    cond do
+      OgImageCache.hit?(image_path, carta_key) ->
+        log_cached(image_path)
+
+      renderer.mode == :fallback and OgImageCache.hit?(image_path, fallback_key) ->
+        log_cached(image_path)
+
+      renderer.mode == :carta ->
+        render_with_carta(renderer, html, image_path, carta_key, fallback_key, label, fallback_title, opts)
+
+      true ->
+        render_with_libvips(image_path, fallback_key, fallback_title)
+    end
+  end
+
+  def warn_on_task_exit({:ok, _result}, _label), do: :ok
+
+  def warn_on_task_exit({:exit, reason}, label) do
+    IO.warn("Failed to generate #{label}: #{inspect(reason)}")
+  end
+
+  defp default_pool_size do
+    System.schedulers_online()
+    |> min(@max_pool_size)
+    |> max(1)
+  end
+
+  defp preflight_carta(renderer) do
+    fn ->
+      do_render_with_carta(
+        renderer.pool,
+        "<!doctype html><html><body>ok</body></html>",
+        width: 1,
+        height: 1,
+        quality: 50
+      )
+    end
+    |> run_with_timeout(@preflight_timeout)
+    |> case do
+      {:ok, _jpeg} -> :ok
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp render_with_carta(renderer, html, image_path, carta_key, fallback_key, label, fallback_title, opts) do
+    carta_opts =
+      Keyword.merge(
+        [
+          width: 1920,
+          height: 1080,
+          quality: 95
+        ],
+        opts
+      )
+
+    case run_with_timeout(fn -> do_render_with_carta(renderer.pool, html, carta_opts) end, @render_timeout) do
+      {:ok, jpeg_binary} ->
+        File.write!(image_path, jpeg_binary)
+        OgImageCache.put(image_path, carta_key)
+        log_generated(image_path)
+
+      {:error, reason} ->
+        IO.warn("Failed to generate OG image for #{label} with Carta: #{inspect(reason)}. Falling back to libvips.")
+        render_with_libvips(image_path, fallback_key, fallback_title)
+    end
+  end
+
+  defp do_render_with_carta(pool, html, opts) do
+    Carta.render(pool, html, opts)
+  rescue
+    exception -> {:error, {exception.__struct__, Exception.message(exception)}}
+  catch
+    :exit, reason -> {:error, {:exit, reason}}
+  end
+
+  defp render_with_libvips(image_path, key, fallback_title) do
+    OpenGraph.generate_og_image(fallback_title, image_path)
+    OgImageCache.put(image_path, key)
+    log_generated(image_path)
+  end
+
+  defp run_with_timeout(fun, timeout) do
+    task = Task.async(fun)
+
+    case Task.yield(task, timeout) || Task.shutdown(task, :brutal_kill) do
+      {:ok, result} -> result
+      {:exit, reason} -> {:error, {:exit, reason}}
+      nil -> {:error, :timeout}
+    end
+  end
+
+  defp fallback_cache_key(key), do: OgImageCache.key(["libvips-fallback:v1", key])
+
+  defp stop_pool(pid) do
+    if Process.alive?(pid) do
+      GenServer.stop(pid, :normal, 5_000)
+    end
+  catch
+    :exit, _reason -> :ok
+  end
+
+  defp warn_fallback(reason) do
+    IO.warn("Chrome OG image renderer unavailable: #{inspect(reason)}. Falling back to libvips.")
+  end
+
+  defp log_cached(image_path), do: IO.puts("  Cached: #{relative_path(image_path)}")
+
+  defp log_generated(image_path), do: IO.puts("  Generated: #{relative_path(image_path)}")
+
+  defp relative_path(image_path), do: Path.relative_to(image_path, File.cwd!())
+end

--- a/server/lib/mix/tasks/docs/gen/og_images.ex
+++ b/server/lib/mix/tasks/docs/gen/og_images.ex
@@ -1,6 +1,6 @@
 defmodule Mix.Tasks.Docs.Gen.OgImages do
   @moduledoc """
-  Generates open graph images for all documentation pages using Carta and BrowseChrome.
+  Generates open graph images for all documentation pages.
   """
   use Mix.Task
   use Boundary, classify_to: Tuist.Mix
@@ -9,6 +9,7 @@ defmodule Mix.Tasks.Docs.Gen.OgImages do
   alias Tuist.Docs.OgImage
   alias Tuist.Docs.Sidebar
   alias Tuist.Marketing.OgImageCache
+  alias Tuist.Mix.OgImageRenderer
 
   @pool Tuist.Docs.OgImagePool
 
@@ -26,9 +27,8 @@ defmodule Mix.Tasks.Docs.Gen.OgImages do
     logo_path =
       :tuist |> Application.app_dir("priv") |> Path.join("docs/images/logo.webp")
 
-    pool_size = max(System.schedulers_online(), 4)
-
-    {:ok, _} = Browse.start_link(@pool, implementation: BrowseChrome.Browser, pool_size: pool_size)
+    renderer = OgImageRenderer.start_carta(@pool)
+    pool_size = renderer.pool_size
 
     category_map = build_category_map()
 
@@ -51,7 +51,6 @@ defmodule Mix.Tasks.Docs.Gen.OgImages do
         filename = OgImage.slug_to_filename(slug)
         image_path = Path.join(output_dir, filename)
 
-        locale = slug |> String.split("/", trim: true) |> List.first()
         en_slug = String.replace(slug, ~r{^/[^/]+/}, "/en/")
         category = Map.get(category_map, en_slug, "Docs")
 
@@ -76,24 +75,13 @@ defmodule Mix.Tasks.Docs.Gen.OgImages do
             asset_hash
           ])
 
-        if OgImageCache.hit?(image_path, key) do
-          IO.puts("  [#{locale}] Cached: #{Path.relative_to(image_path, File.cwd!())}")
-        else
-          case Carta.render(@pool, html, width: 1920, height: 1080, quality: 95) do
-            {:ok, jpeg_binary} ->
-              File.write!(image_path, jpeg_binary)
-              OgImageCache.put(image_path, key)
-              IO.puts("  [#{locale}] Generated: #{Path.relative_to(image_path, File.cwd!())}")
-
-            {:error, reason} ->
-              IO.warn("Failed to generate OG image for #{slug}: #{inspect(reason)}")
-          end
-        end
+        OgImageRenderer.render(renderer, html, image_path, key, slug, page.title || category || "Tuist")
       end,
       max_concurrency: pool_size,
-      timeout: 30_000
+      on_timeout: :kill_task,
+      timeout: OgImageRenderer.render_timeout()
     )
-    |> Stream.run()
+    |> Enum.each(&OgImageRenderer.warn_on_task_exit(&1, "docs OG image"))
   end
 
   # This task runs without the full application supervisor (e.g. during Docker builds

--- a/server/lib/mix/tasks/marketing/gen/og_images.ex
+++ b/server/lib/mix/tasks/marketing/gen/og_images.ex
@@ -10,6 +10,7 @@ defmodule Mix.Tasks.Marketing.Gen.OgImages do
   alias Tuist.Marketing.OgImageCache
   alias Tuist.Marketing.OgImages
   alias Tuist.Marketing.OpenGraph
+  alias Tuist.Mix.OgImageRenderer
 
   # Available locales for OG image generation — must match Localization.all_locales()
   @locales ["en", "es", "ja", "ka", "ko", "ru", "yue_Hant", "zh_Hans", "zh_Hant"]
@@ -39,8 +40,7 @@ defmodule Mix.Tasks.Marketing.Gen.OgImages do
   def run(_args) do
     ensure_dependencies_started()
 
-    pool_size = max(System.schedulers_online(), 4)
-    {:ok, _} = Browse.start_link(@pool, implementation: BrowseChrome.Browser, pool_size: pool_size)
+    renderer = OgImageRenderer.start_carta(@pool)
 
     og_images_directory =
       :tuist |> Application.app_dir("priv") |> Path.join("static/marketing/images/og/generated")
@@ -55,16 +55,16 @@ defmodule Mix.Tasks.Marketing.Gen.OgImages do
     generate_posts_og_images(og_images_directory, libvips_asset_hash)
 
     # Changelog entries use their own Carta template (English-only)
-    generate_changelog_og_images(og_images_directory, asset_hash)
+    generate_changelog_og_images(og_images_directory, asset_hash, renderer)
 
     # Dynamic pages from markdown (terms, privacy, cookies, etc.)
-    generate_dynamic_pages_og_images(og_images_directory, asset_hash)
+    generate_dynamic_pages_og_images(og_images_directory, asset_hash, renderer)
 
     # Carta-based OG images for all static marketing pages, localized
-    generate_marketing_page_og_images(og_images_directory, asset_hash)
+    generate_marketing_page_og_images(og_images_directory, asset_hash, renderer)
 
     # Home page uses a special layout with phone mockup
-    generate_home_og_images(og_images_directory, asset_hash)
+    generate_home_og_images(og_images_directory, asset_hash, renderer)
   end
 
   defp compute_asset_hash do
@@ -104,7 +104,7 @@ defmodule Mix.Tasks.Marketing.Gen.OgImages do
     end)
   end
 
-  defp generate_dynamic_pages_og_images(og_images_directory, asset_hash) do
+  defp generate_dynamic_pages_og_images(og_images_directory, asset_hash, renderer) do
     dynamic_pages = Tuist.Marketing.Pages.get_pages()
 
     for locale <- @locales do
@@ -120,13 +120,14 @@ defmodule Mix.Tasks.Marketing.Gen.OgImages do
           locale,
           nil,
           :default,
-          asset_hash
+          asset_hash,
+          renderer
         )
       end)
     end
   end
 
-  defp generate_marketing_page_og_images(og_images_directory, asset_hash) do
+  defp generate_marketing_page_og_images(og_images_directory, asset_hash, renderer) do
     priv_dir = Application.app_dir(:tuist, "priv")
 
     IO.puts("Generating Carta-based OG images for #{length(@carta_pages)} pages x #{length(@locales)} locales...")
@@ -150,13 +151,14 @@ defmodule Mix.Tasks.Marketing.Gen.OgImages do
           locale,
           icon_path,
           template,
-          asset_hash
+          asset_hash,
+          renderer
         )
       end)
     end
   end
 
-  defp render_carta_page(og_images_directory, filename, title, locale, icon_path, template, asset_hash) do
+  defp render_carta_page(og_images_directory, filename, title, locale, icon_path, template, asset_hash, renderer) do
     priv_dir = Application.app_dir(:tuist, "priv")
     fonts_dir = Path.join(priv_dir, "static/fonts")
     logo_path = Path.join(priv_dir, "docs/images/logo.webp")
@@ -198,7 +200,7 @@ defmodule Mix.Tasks.Marketing.Gen.OgImages do
         asset_hash
       ])
 
-    render_with_carta(html, image_path, key, "#{filename} (#{locale})")
+    OgImageRenderer.render(renderer, html, image_path, key, "#{filename} (#{locale})", title)
   end
 
   defp render_template_html(:blog, html_opts, _priv_dir), do: OgImages.render_blog_html(html_opts)
@@ -214,7 +216,7 @@ defmodule Mix.Tasks.Marketing.Gen.OgImages do
 
   defp render_template_html(_default, html_opts, _priv_dir), do: OgImages.render_html(html_opts)
 
-  defp generate_home_og_images(og_images_directory, asset_hash) do
+  defp generate_home_og_images(og_images_directory, asset_hash, renderer) do
     priv_dir = Application.app_dir(:tuist, "priv")
     fonts_dir = Path.join(priv_dir, "static/fonts")
     logo_path = Path.join(priv_dir, "docs/images/logo.webp")
@@ -248,13 +250,13 @@ defmodule Mix.Tasks.Marketing.Gen.OgImages do
 
       key = OgImageCache.key(["home:v1", locale, title, asset_hash])
 
-      render_with_carta(html, image_path, key, "home (#{locale})")
+      OgImageRenderer.render(renderer, html, image_path, key, "home (#{locale})", title)
     end
   end
 
-  defp generate_changelog_og_images(og_images_directory, asset_hash) do
+  defp generate_changelog_og_images(og_images_directory, asset_hash, renderer) do
     entries = Tuist.Marketing.Changelog.get_entries()
-    pool_size = max(System.schedulers_online(), 4)
+    pool_size = renderer.pool_size
 
     fonts_dir = :tuist |> Application.app_dir("priv") |> Path.join("static/fonts")
     logo_path = :tuist |> Application.app_dir("priv") |> Path.join("docs/images/logo.webp")
@@ -290,12 +292,13 @@ defmodule Mix.Tasks.Marketing.Gen.OgImages do
             asset_hash
           ])
 
-        render_with_carta(html, image_path, key, "changelog #{entry.id}")
+        OgImageRenderer.render(renderer, html, image_path, key, "changelog #{entry.id}", entry.title)
       end,
       max_concurrency: pool_size,
-      timeout: 30_000
+      on_timeout: :kill_task,
+      timeout: OgImageRenderer.render_timeout()
     )
-    |> Stream.run()
+    |> Enum.each(&OgImageRenderer.warn_on_task_exit(&1, "marketing changelog OG image"))
   end
 
   defp generate_posts_og_images(og_images_directory, asset_hash) do
@@ -307,24 +310,6 @@ defmodule Mix.Tasks.Marketing.Gen.OgImages do
 
       generate_with_libvips(post.title, image_path, key)
     end)
-  end
-
-  # Render with Carta (headless Chromium) unless an existing cache key sidecar
-  # matches. Cache hits skip the multi-second screenshot entirely.
-  defp render_with_carta(html, image_path, key, label) do
-    if OgImageCache.hit?(image_path, key) do
-      IO.puts("  Cached: #{Path.relative_to(image_path, File.cwd!())}")
-    else
-      case Carta.render(@pool, html, width: 1920, height: 1080, quality: 95) do
-        {:ok, jpeg_binary} ->
-          File.write!(image_path, jpeg_binary)
-          OgImageCache.put(image_path, key)
-          IO.puts("  Generated: #{Path.relative_to(image_path, File.cwd!())}")
-
-        {:error, reason} ->
-          IO.warn("Failed to generate OG image for #{label}: #{inspect(reason)}")
-      end
-    end
   end
 
   # libvips-backed renders (newsletter / blog posts). Cheaper per call than

--- a/server/lib/tuist/marketing/open_graph.ex
+++ b/server/lib/tuist/marketing/open_graph.ex
@@ -71,7 +71,7 @@ defmodule Tuist.Marketing.OpenGraph do
       end
 
     # Save as JPEG with high quality and proper color space
-    Image.write!(image, final_path, quality: 95, strip_metadata: false)
+    Image.write!(image, final_path, write_options(final_path))
   end
 
   defp apply_locale_to_path(path, nil), do: path
@@ -81,6 +81,16 @@ defmodule Tuist.Marketing.OpenGraph do
     dirname = Path.dirname(path)
     basename = Path.basename(path)
     Path.join([dirname, locale, basename])
+  end
+
+  defp write_options(path) do
+    options = [quality: 95, strip_metadata: false]
+
+    if Path.extname(path) == "" do
+      Keyword.put(options, :suffix, ".jpg")
+    else
+      options
+    end
   end
 
   # credo:disable-for-next-line Credo.Check.Refactor.CyclomaticComplexity

--- a/server/mise/tasks/cldr/prefetch-locale-data.sh
+++ b/server/mise/tasks/cldr/prefetch-locale-data.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SERVER_DIR="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+CLDR_DATA_DIR="${TUIST_CLDR_DATA_DIR:-${SERVER_DIR}/_build/cldr/locales}"
+LOCALES=(
+  ar
+  es
+  ja
+  ka
+  ko
+  pl
+  pt
+  ru
+  tr
+  yue-Hant
+  zh-Hans
+  zh-Hant
+)
+
+cd "${SERVER_DIR}"
+
+cldr_version="$(sed -n 's/^  "ex_cldr": {:hex, :ex_cldr, "\([^"]*\)".*/\1/p' mix.lock)"
+if [ -z "${cldr_version}" ]; then
+  echo "Unable to determine ex_cldr version from mix.lock" >&2
+  exit 1
+fi
+
+mkdir -p "${CLDR_DATA_DIR}"
+
+for locale in "${LOCALES[@]}"; do
+  output="${CLDR_DATA_DIR}/${locale}.json"
+  if [ -s "${output}" ]; then
+    continue
+  fi
+
+  tmp_output="${output}.tmp"
+  rm -f "${tmp_output}"
+
+  curl --fail --silent --show-error --location \
+    --retry 5 \
+    --retry-all-errors \
+    --retry-delay 2 \
+    -H "Accept: application/vnd.github.raw" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    "https://api.github.com/repos/elixir-cldr/cldr/contents/priv/cldr/locales/${locale}.json?ref=v${cldr_version}" \
+    --output "${tmp_output}"
+
+  mv "${tmp_output}" "${output}"
+done


### PR DESCRIPTION
## What changed

- Added a shared `Tuist.Mix.OgImageRenderer` for build-time docs and marketing OG image generation.
- Centralized Carta/BrowseChrome startup, cache checks, render timeouts, and task-exit warning handling.
- Added a Chrome preflight and libvips fallback so server image builds can still produce OG images when Chromium DevTools startup is unavailable or stalls.
- Made the libvips fallback explicitly write JPEGs when the target path has no normal extension, covering docs root slugs such as `/en` that render to `en/.jpg`.
- Reused the shared renderer from both `mix docs.gen.og_images` and `mix marketing.gen.og_images`.
- Added a shared CLDR locale prefetch helper used by both the server test job and the Docker build.
- Cache the prefetched CLDR locale JSON directory across CI runs.
- Prefetch CLDR locale JSON in the Docker deps stage before the main builder and `og-images` stages compile.

## Why

The server image release jobs were failing in the `og-images` Docker stage while running `mix docs.gen.og_images`. The original logs showed repeated BrowseChrome pool initialization failures with `:devtools_timeout`, followed by the docs generator's `Task.async_stream` timing out after 30 seconds. After adding the fallback, the next CI run showed the fallback path being exercised but crashing on the docs home page image.

## Root cause

The docs and marketing OG image tasks assumed BrowseChrome would always start successfully and that every Carta render would complete within the async stream's 30-second timeout. In the failing Docker build, Chromium never became reachable over DevTools quickly enough, so worker initialization kept timing out and the stream killed the docs render task.

The follow-up Docker failure happened because the docs root slug `/en` maps to `en/.jpg`. Carta writes raw JPEG bytes and did not care about that hidden filename shape, but the libvips fallback infers the output type from `Path.extname/1`; for `.jpg` as a basename, that extension is empty, so `Image.write!/3` could not infer an image type.

The server `Test` job also failed once before tests ran because `ex_cldr` downloaded locale JSON from unauthenticated `raw.githubusercontent.com` during the full-locale compile and received HTTP 429 for `pl` and `pt`. After caching that path in the workflow, the Docker build still failed in `RUN mix compile --warnings-as-errors` for the same reason: the builder stage had no prefetched CLDR files, so it tried to download `pl`, `tr`, `yue-Hant`, and `zh-Hans` from `raw.githubusercontent.com` and hit 429s.

## Approach

The new renderer keeps Carta as the primary path, but treats Chrome availability as something to verify before the bulk render. If preflight or an individual render fails, it logs the problem and falls back to the existing libvips-based OpenGraph renderer. The fallback uses a separate cache key prefix, so a degraded Chrome build does not poison the normal Carta cache. The shared renderer also caps default concurrency at 4, supports `TUIST_OG_IMAGE_POOL_SIZE`, and extends per-render task timeouts to avoid killing slow-but-healthy renders too aggressively.

The libvips writer now adds `suffix: ".jpg"` only when the target path has no extension, preserving the existing filenames while making output type detection explicit.

For the full-locale compiles, the workflow restores a narrow Actions cache for `_build/cldr/locales` and a shared shell helper prefetches any missing CLDR locale JSON files required by the full Gettext locale set through the GitHub API with retries. That keeps `ex_cldr` from falling back to rate-limited `raw.githubusercontent.com` downloads during compile while avoiding the broader Mix build cache that the test job intentionally disables. The Dockerfile copies and runs the same helper in the shared `deps-builder` stage, so both the main release builder and the parallel `og-images` stage inherit the prefetched CLDR data before they compile.

## Impact

Server release Docker builds should no longer fail solely because headless Chromium cannot initialize DevTools during build-time OG generation. The normal high-fidelity Carta path remains the default when Chrome is healthy, while the fallback keeps the build producing usable OG images when Chrome is not.

The full-locale test compile and the Docker release image compile should also be less sensitive to GitHub raw rate limits on fresh CI runners.

## Validation

- `mix format lib/tuist/marketing/open_graph.ex`
- `mix format --check-formatted lib/tuist/marketing/open_graph.ex`
- CLDR prefetch script exercised locally against the GitHub API for all required locales.
- Confirmed the CI token-authenticated prefetch variant failed with HTTP 403, then switched to the unauthenticated GitHub API endpoint with retries.
- Confirmed the latest Docker failure moved to CLDR locale downloads in the builder stage, then moved the prefetch into the Docker deps stage.
- `bash -n server/mise/tasks/cldr/prefetch-locale-data.sh`
- Fresh temp-dir CLDR prefetch produced all 12 required locale JSON files.
- `MIX_ENV=prod mix compile`
- Hidden-filename fallback smoke test generated `/private/tmp/tuist-og-hidden/.jpg` through `Tuist.Marketing.OpenGraph.generate_og_image/2`.
- `MIX_ENV=test TUIST_DEV_ALL_LOCALES=1 mix compile --warnings-as-errors`
- `git diff --check`

I could not run the full Docker build locally because the Docker daemon is not available in this environment.
