### PR TITLE
perf(server): reduce ClickHouse CPU wait

### DIFF
--- a/infra/helm/tuist/templates/_helpers.tpl
+++ b/infra/helm/tuist/templates/_helpers.tpl
@@ -529,6 +529,22 @@ own way).
 {{- end -}}
 
 {{/*
+ClickHouse repo pool sizes are non-secret operational knobs. Render them from
+chart values so the server, migration, processor, and xcresult-processor pods
+stay aligned without relying on the runtime secret bundle.
+*/}}
+{{- define "tuist.clickhousePoolEnv" -}}
+{{- with .Values.clickhouse.poolSize }}
+- name: TUIST_CLICKHOUSE_POOL_SIZE
+  value: {{ . | quote }}
+{{- end }}
+{{- with .Values.clickhouse.bufferPoolSize }}
+- name: TUIST_CLICKHOUSE_BUFFER_POOL_SIZE
+  value: {{ . | quote }}
+{{- end }}
+{{- end -}}
+
+{{/*
 Stripe price IDs. These are not secrets (just identifiers for the products in
 Stripe), so they live in chart values as a readable plan -> category -> [ids]
 map instead of the secret store. `Tuist.Environment.stripe_prices/1` reads

--- a/infra/helm/tuist/templates/processor-deployment.yaml
+++ b/infra/helm/tuist/templates/processor-deployment.yaml
@@ -176,6 +176,7 @@ spec:
                   name: {{ $secretName }}
                   key: object-storage-secret-key
             {{- end }}
+            {{- include "tuist.clickhousePoolEnv" . | nindent 12 }}
             {{- with .Values.processor.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/infra/helm/tuist/templates/server-deployment.yaml
+++ b/infra/helm/tuist/templates/server-deployment.yaml
@@ -316,6 +316,7 @@ spec:
             - name: TUIST_KURA_PEER_FAILOVER_IPS
               value: "{{- range $i, $e := .Values.server.kuraPeerFailoverIps }}{{ if $i }},{{ end }}{{ $e.region }}={{ $e.ip }}{{- end }}"
             {{- end }}
+            {{- include "tuist.clickhousePoolEnv" . | nindent 12 }}
             {{- with .Values.server.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/infra/helm/tuist/templates/server-migration-job.yaml
+++ b/infra/helm/tuist/templates/server-migration-job.yaml
@@ -182,6 +182,7 @@ spec:
                   name: {{ $secretName }}
                   key: object-storage-secret-key
             {{- end }}
+            {{- include "tuist.clickhousePoolEnv" . | nindent 12 }}
             {{- with .Values.server.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/infra/helm/tuist/templates/xcresult-processor-deployment.yaml
+++ b/infra/helm/tuist/templates/xcresult-processor-deployment.yaml
@@ -207,6 +207,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.name
             {{- end }}
+            {{- include "tuist.clickhousePoolEnv" . | nindent 12 }}
             {{- with .Values.xcresultProcessor.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/infra/helm/tuist/values-managed-canary.yaml
+++ b/infra/helm/tuist/values-managed-canary.yaml
@@ -111,6 +111,10 @@ objectStorage:
     buckets:
       default: tuist-can-storage
 
+clickhouse:
+  poolSize: "30"
+  bufferPoolSize: "30"
+
 cache:
   extraEnv:
     - name: XCODE_DATABASE_INTERACTIONS_ENABLED

--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -261,6 +261,8 @@ postgresql:
       destinationPath: s3://tuist-prod-pg-backups/
 
 clickhouse:
+  poolSize: "15"
+  bufferPoolSize: "15"
   external:
     url: ""  # Set via helm --set at deploy time; see runbook.
 

--- a/infra/helm/tuist/values-managed-staging.yaml
+++ b/infra/helm/tuist/values-managed-staging.yaml
@@ -163,6 +163,10 @@ objectStorage:
     buckets:
       default: tuist-stag-storage
 
+clickhouse:
+  poolSize: "15"
+  bufferPoolSize: "15"
+
 cache:
   extraEnv:
     - name: XCODE_DATABASE_INTERACTIONS_ENABLED

--- a/infra/helm/tuist/values.yaml
+++ b/infra/helm/tuist/values.yaml
@@ -1841,6 +1841,11 @@ postgresql:
 
 clickhouse:
   mode: embedded
+  # Optional runtime pool sizes for the Elixir ClickHouse repos. These are
+  # operational capacity knobs, not secrets; managed deployments set them in
+  # values-managed-*.yaml so all server-release workloads render the same env.
+  poolSize: ""
+  bufferPoolSize: ""
   external:
     url: ""
     # Optional separate URL for the readiness probe ping check.

--- a/server/config/runtime.exs
+++ b/server/config/runtime.exs
@@ -264,7 +264,7 @@ if Enum.member?([:prod, :stag, :can], env) do
     queue_interval: Tuist.Environment.clickhouse_queue_interval(secrets),
     settings: [
       readonly: 1,
-      max_threads: Tuist.Environment.clickhouse_max_threads(secrets),
+      max_threads: Tuist.Environment.clickhouse_read_max_threads(secrets),
       # Per-query memory ceiling so one heavy read fails on its own with a
       # `(for query)` error (retryable) rather than driving the process to its
       # `(total)` server ceiling and killing unrelated queries. Read path only:
@@ -283,14 +283,13 @@ if Enum.member?([:prod, :stag, :can], env) do
 
   config :tuist, Tuist.IngestRepo,
     url: Tuist.Environment.clickhouse_url(secrets),
-    pool_size: Tuist.Environment.clickhouse_pool_size(secrets),
+    pool_size: Tuist.Environment.clickhouse_buffer_pool_size(secrets),
     queue_target: Tuist.Environment.clickhouse_queue_target(secrets),
     queue_interval: Tuist.Environment.clickhouse_queue_interval(secrets),
     flush_interval_ms: Tuist.Environment.clickhouse_flush_interval_ms(secrets),
     max_buffer_size: Tuist.Environment.clickhouse_max_buffer_size(secrets),
-    pool_size: Tuist.Environment.clickhouse_buffer_pool_size(secrets),
     settings: [
-      max_threads: Tuist.Environment.clickhouse_max_threads(secrets)
+      max_threads: Tuist.Environment.clickhouse_write_max_threads(secrets)
     ],
     transport_opts: [
       keepalive: true,

--- a/server/lib/tuist/automations/monitors/flaky_tests_monitor.ex
+++ b/server/lib/tuist/automations/monitors/flaky_tests_monitor.ex
@@ -332,12 +332,11 @@ defmodule Tuist.Automations.Monitors.FlakyTestsMonitor do
   defp recent_runs_column("reliability_rate"), do: "recent_successful_runs"
   defp recent_runs_column(_monitor_type), do: "recent_runs"
 
-  # Returns `{table, recent_runs_expr, run_key_expr}`. `recent_runs_expr`
-  # merges the full per-test-case aggregate; the dedup and latest-`size` slice
-  # happen downstream. `run_key_expr` maps a tuple's sort key back to a
-  # "larger = more recent" number so both encodings order the same way: the
-  # 1000-entry fallback stores `ran_at` directly, while the buckets store
-  # `-ran_at_microseconds`.
+  # Returns `{table, recent_runs_expr}`. `recent_runs_expr` merges the full
+  # per-test-case aggregate and normalizes both aggregate encodings to
+  # `(run_key_microseconds, flag)` tuples. The dedup and latest-`size` slice
+  # happen downstream. The 1000-entry fallback stores `ran_at` directly, while
+  # the buckets store `-ran_at_microseconds`.
   #
   # The bucket is chosen strictly larger than the window (`size < bucket`) so
   # de-dup has headroom: a bucket only holds `bucket` physical rows, and
@@ -350,21 +349,19 @@ defmodule Tuist.Automations.Monitors.FlakyTestsMonitor do
       nil ->
         {
           "test_case_runs_recent_per_case",
-          "groupArrayLastMerge(#{@max_rolling_window_size})(#{column})",
-          "toUnixTimestamp64Micro(tupleElement(entry, 1))"
+          "arrayMap(entry -> (toUnixTimestamp64Micro(tupleElement(entry, 1)), tupleElement(entry, 2)), groupArrayLastMerge(#{@max_rolling_window_size})(#{column}))"
         }
 
       bucket_size ->
         {
           "test_case_runs_recent_#{bucket_size}_per_case",
-          "groupArraySortedMerge(#{bucket_size})(#{column})",
-          "-tupleElement(entry, 1)"
+          "arrayMap(entry -> (-tupleElement(entry, 1), tupleElement(entry, 2)), groupArraySortedMerge(#{bucket_size})(#{column}))"
         }
     end
   end
 
   defp rolling_triggered_test_case_ids_from_recent_runs(
-         {table, recent_runs_expr, run_key_expr},
+         {table, recent_runs_expr},
          project_id,
          monitor_type,
          size,
@@ -378,35 +375,43 @@ defmodule Tuist.Automations.Monitors.FlakyTestsMonitor do
         _test_case_ids -> "AND test_case_id IN {test_case_ids:Array(UUID)}"
       end
 
-    # Expand the recent-runs array and collapse it to one row per run (keyed on
-    # `run_key`, the run's `ran_at`), keeping `max(flag)` so a run that was ever
-    # re-marked flaky / ever succeeded is represented once with the right flag.
-    # Then keep the latest `size` distinct runs and compute the rate over those,
-    # so a re-inserted run can no longer be counted more than once.
+    # Collapse the bounded per-test-case array to one tuple per run
+    # (`run_key` is the run's `ran_at` in microseconds), keeping `max(flag)` so
+    # a run that was ever re-marked flaky / ever succeeded is represented once
+    # with the right flag. Then keep the latest `size` distinct runs and compute
+    # the rate over those, so a re-inserted run can no longer be counted more
+    # than once. Keeping the work inside arrays avoids the expensive
+    # ARRAY JOIN + GROUP BY + LIMIT BY shape that multiplied each active test
+    # case into hundreds of rows.
     sql = """
     SELECT test_case_id
     FROM (
-      SELECT test_case_id, run_key, max(flag) AS flag
+      SELECT
+        test_case_id,
+        arraySlice(
+          arrayFilter(
+            (entry, position) -> position = 1,
+            sorted_runs,
+            arrayEnumerateUniq(arrayMap(entry -> tupleElement(entry, 1), sorted_runs))
+          ),
+          1,
+          #{size}
+        ) AS recent_runs
       FROM (
         SELECT
           test_case_id,
-          #{run_key_expr} AS run_key,
-          tupleElement(entry, 2) AS flag
+          arrayReverseSort(entry -> (tupleElement(entry, 1), tupleElement(entry, 2)), merged_runs) AS sorted_runs
         FROM (
-          SELECT test_case_id, #{recent_runs_expr} AS recent_runs
+          SELECT test_case_id, #{recent_runs_expr} AS merged_runs
           FROM #{table}
           WHERE project_id = {project_id:Int64}
             #{test_case_filter}
           GROUP BY test_case_id
         )
-        ARRAY JOIN recent_runs AS entry
       )
-      GROUP BY test_case_id, run_key
-      ORDER BY run_key DESC
-      LIMIT #{size} BY test_case_id
     )
-    GROUP BY test_case_id
-    HAVING #{rolling_having_expr(monitor_type)} #{rolling_comparison_op(comparison)} {threshold:Float64}
+    WHERE length(recent_runs) > 0
+      AND #{rolling_having_expr(monitor_type)} #{rolling_comparison_op(comparison)} {threshold:Float64}
     """
 
     params = maybe_put_test_case_ids(%{project_id: project_id, threshold: threshold * 1.0}, test_case_ids)
@@ -424,11 +429,13 @@ defmodule Tuist.Automations.Monitors.FlakyTestsMonitor do
     Enum.map(rows, fn [binary] -> Ecto.UUID.load!(binary) end)
   end
 
-  defp rolling_having_expr("flakiness_rate"), do: "sum(flag) * 100.0 / count()"
+  defp rolling_having_expr("flakiness_rate"),
+    do: "arraySum(entry -> tupleElement(entry, 2), recent_runs) * 100.0 / length(recent_runs)"
 
-  defp rolling_having_expr("flaky_run_count"), do: "sum(flag)"
+  defp rolling_having_expr("flaky_run_count"), do: "arraySum(entry -> tupleElement(entry, 2), recent_runs)"
 
-  defp rolling_having_expr("reliability_rate"), do: "sum(flag) * 100.0 / count()"
+  defp rolling_having_expr("reliability_rate"),
+    do: "arraySum(entry -> tupleElement(entry, 2), recent_runs) * 100.0 / length(recent_runs)"
 
   defp rolling_comparison_op("gte"), do: ">="
   defp rolling_comparison_op("gt"), do: ">"

--- a/server/lib/tuist/environment.ex
+++ b/server/lib/tuist/environment.ex
@@ -936,6 +936,20 @@ defmodule Tuist.Environment do
     end
   end
 
+  def clickhouse_read_max_threads(secrets \\ secrets()) do
+    case get([:clickhouse, :read_max_threads], secrets) do
+      max_threads when is_binary(max_threads) -> String.to_integer(max_threads)
+      _ -> clickhouse_max_threads(secrets)
+    end
+  end
+
+  def clickhouse_write_max_threads(secrets \\ secrets()) do
+    case get([:clickhouse, :write_max_threads], secrets) do
+      max_threads when is_binary(max_threads) -> String.to_integer(max_threads)
+      _ -> clickhouse_max_threads(secrets)
+    end
+  end
+
   # Per-query memory ceiling (in bytes) for the read path. ClickHouse enforces
   # this per query, so a single pathological aggregation fails on its own with
   # a `(for query)` error the caller can retry, instead of pushing the process

--- a/server/lib/tuist/environment.ex
+++ b/server/lib/tuist/environment.ex
@@ -840,10 +840,10 @@ defmodule Tuist.Environment do
     get([:clickhouse, :url], secrets)
   end
 
-  def clickhouse_pool_size(secrets \\ secrets()) do
-    case get([:clickhouse, :pool_size], secrets) do
+  def clickhouse_pool_size(_secrets \\ nil) do
+    case System.get_env("TUIST_CLICKHOUSE_POOL_SIZE") || System.get_env("TUIST_DATABASE_POOL_SIZE") do
       pool_size when is_binary(pool_size) -> String.to_integer(pool_size)
-      _ -> database_pool_size(secrets)
+      _ -> 10
     end
   end
 
@@ -922,8 +922,8 @@ defmodule Tuist.Environment do
     end
   end
 
-  def clickhouse_buffer_pool_size(secrets \\ secrets()) do
-    case get([:clickhouse, :buffer_pool_size], secrets) do
+  def clickhouse_buffer_pool_size(_secrets \\ nil) do
+    case System.get_env("TUIST_CLICKHOUSE_BUFFER_POOL_SIZE") do
       buffer_pool_size when is_binary(buffer_pool_size) -> String.to_integer(buffer_pool_size)
       _ -> 5
     end

--- a/server/lib/tuist/tests.ex
+++ b/server/lib/tuist/tests.ex
@@ -1203,7 +1203,7 @@ defmodule Tuist.Tests do
     project_ids = slim_results |> Enum.map(& &1.project_id) |> Enum.uniq()
     test_case_ids = slim_results |> Enum.map(& &1.test_case_id) |> Enum.uniq()
     {min_ran_at, max_ran_at} = ran_at_bounds(slim_results)
-    inserted_at_months = inserted_at_months(slim_results)
+    inserted_at_partition_months = inserted_at_partition_months(slim_results)
 
     # `test_case_runs` is ReplacingMergeTree; re-inserts (e.g. flaky flag
     # updates) leave multiple versions per id until background merges
@@ -1221,7 +1221,7 @@ defmodule Tuist.Tests do
       )
 
     query =
-      case inserted_at_months do
+      case inserted_at_partition_months do
         [] -> query
         months -> from(tcr in query, where: fragment("toYYYYMM(?)", tcr.inserted_at) in ^months)
       end
@@ -1251,7 +1251,7 @@ defmodule Tuist.Tests do
     end)
   end
 
-  defp inserted_at_months(slim_results) do
+  defp inserted_at_partition_months(slim_results) do
     slim_results
     |> Enum.flat_map(fn run ->
       case Map.get(run, :inserted_at) do

--- a/server/lib/tuist/tests.ex
+++ b/server/lib/tuist/tests.ex
@@ -1203,7 +1203,7 @@ defmodule Tuist.Tests do
     project_ids = slim_results |> Enum.map(& &1.project_id) |> Enum.uniq()
     test_case_ids = slim_results |> Enum.map(& &1.test_case_id) |> Enum.uniq()
     {min_ran_at, max_ran_at} = ran_at_bounds(slim_results)
-    inserted_at_partition_months = inserted_at_partition_months(slim_results)
+    inserted_at_partition_range = inserted_at_partition_range(slim_results)
 
     # `test_case_runs` is ReplacingMergeTree; re-inserts (e.g. flaky flag
     # updates) leave multiple versions per id until background merges
@@ -1221,10 +1221,7 @@ defmodule Tuist.Tests do
       )
 
     query =
-      case inserted_at_partition_months do
-        [] -> query
-        months -> from(tcr in query, where: fragment("toYYYYMM(?)", tcr.inserted_at) in ^months)
-      end
+      scope_to_inserted_at_partition(query, inserted_at_partition_range)
 
     query
     |> ClickHouseRepo.all()
@@ -1251,24 +1248,62 @@ defmodule Tuist.Tests do
     end)
   end
 
-  defp inserted_at_partition_months(slim_results) do
+  defp inserted_at_partition_range(slim_results) do
     slim_results
-    |> Enum.flat_map(fn run ->
-      case Map.get(run, :inserted_at) do
-        %NaiveDateTime{} = inserted_at ->
-          [inserted_at.year * 100 + inserted_at.month]
+    |> Enum.flat_map(&inserted_at_partition_timestamps/1)
+    |> case do
+      [] ->
+        nil
 
-        %DateTime{} = inserted_at ->
-          [inserted_at.year * 100 + inserted_at.month]
+      timestamps ->
+        {min_inserted_at, max_inserted_at} =
+          Enum.min_max_by(timestamps, &NaiveDateTime.to_gregorian_seconds/1)
 
-        _ ->
-          case uuidv7_to_yyyymm(run.id) do
-            {:ok, month} -> [month]
-            :error -> []
-          end
-      end
-    end)
-    |> Enum.uniq()
+        {month_start(min_inserted_at), next_month_start(max_inserted_at)}
+    end
+  end
+
+  defp inserted_at_partition_timestamps(run) do
+    case Map.get(run, :inserted_at) do
+      %NaiveDateTime{} = inserted_at ->
+        [inserted_at]
+
+      %DateTime{} = inserted_at ->
+        [DateTime.to_naive(inserted_at)]
+
+      _ ->
+        case uuidv7_to_inserted_at(run.id) do
+          {:ok, inserted_at} -> [inserted_at]
+          :error -> []
+        end
+    end
+  end
+
+  defp scope_to_inserted_at_partition(query, nil), do: query
+
+  defp scope_to_inserted_at_partition(query, {partition_start, partition_end}) do
+    from(tcr in query,
+      where: tcr.inserted_at >= ^partition_start,
+      where: tcr.inserted_at < ^partition_end
+    )
+  end
+
+  defp month_start(%NaiveDateTime{year: year, month: month}) do
+    month_start(year, month)
+  end
+
+  defp next_month_start(%NaiveDateTime{year: year, month: 12}) do
+    month_start(year + 1, 1)
+  end
+
+  defp next_month_start(%NaiveDateTime{year: year, month: month}) do
+    month_start(year, month + 1)
+  end
+
+  defp month_start(year, month) do
+    year
+    |> Date.new!(month, 1)
+    |> NaiveDateTime.new!(~T[00:00:00.000000])
   end
 
   # Filter precedence for routing: a narrower scope wins so we use the
@@ -1317,25 +1352,18 @@ defmodule Tuist.Tests do
 
     query =
       case Keyword.get(opts, :project_id) do
-        nil ->
-          case uuidv7_to_yyyymm(id) do
-            {:ok, month} ->
-              where(query, [tcr], fragment("toYYYYMM(?)", tcr.inserted_at) == ^month)
+        nil -> query
+        project_id -> where(query, [tcr], tcr.project_id == ^project_id)
+      end
 
-            :error ->
-              query
-          end
+    query =
+      case uuidv7_to_inserted_at(id) do
+        {:ok, inserted_at} ->
+          partition_range = {month_start(inserted_at), next_month_start(inserted_at)}
+          scope_to_inserted_at_partition(query, partition_range)
 
-        project_id ->
-          query = where(query, [tcr], tcr.project_id == ^project_id)
-
-          case uuidv7_to_yyyymm(id) do
-            {:ok, month} ->
-              where(query, [tcr], fragment("toYYYYMM(?)", tcr.inserted_at) == ^month)
-
-            :error ->
-              query
-          end
+        :error ->
+          query
       end
 
     case ClickHouseRepo.one(query) do
@@ -1353,14 +1381,14 @@ defmodule Tuist.Tests do
   # partition hint, the proj_by_id projection must check every part across all
   # monthly partitions (~93K rows read, ~2.7s p50 in production). UUIDv7 encodes
   # a millisecond timestamp in the first 48 bits, which closely matches
-  # inserted_at, so we extract the month and add a toYYYYMM filter to prune all
-  # but one partition (~8K rows read, ~35x improvement).
-  defp uuidv7_to_yyyymm(uuid_string) do
+  # inserted_at, so we derive the month range and add an inserted_at filter to
+  # prune all but one partition (~8K rows read, ~35x improvement).
+  defp uuidv7_to_inserted_at(uuid_string) do
     hex = uuid_string |> String.replace("-", "") |> String.slice(0, 12)
     timestamp_ms = String.to_integer(hex, 16)
 
     case DateTime.from_unix(timestamp_ms, :millisecond) do
-      {:ok, datetime} -> {:ok, datetime.year * 100 + datetime.month}
+      {:ok, datetime} -> {:ok, DateTime.to_naive(datetime)}
       _ -> :error
     end
   rescue

--- a/server/lib/tuist/tests.ex
+++ b/server/lib/tuist/tests.ex
@@ -1203,20 +1203,30 @@ defmodule Tuist.Tests do
     project_ids = slim_results |> Enum.map(& &1.project_id) |> Enum.uniq()
     test_case_ids = slim_results |> Enum.map(& &1.test_case_id) |> Enum.uniq()
     {min_ran_at, max_ran_at} = ran_at_bounds(slim_results)
+    inserted_at_months = inserted_at_months(slim_results)
 
     # `test_case_runs` is ReplacingMergeTree; re-inserts (e.g. flaky flag
     # updates) leave multiple versions per id until background merges
     # collapse them. Dedupe in Elixir by `desc: inserted_at` rather than
     # paying FINAL's full-part scan and in-memory merge for the page-sized
     # set of ids that the slim MV already narrowed us to.
-    from(tcr in TestCaseRun,
-      where: tcr.project_id in ^project_ids,
-      where: tcr.test_case_id in ^test_case_ids,
-      where: tcr.ran_at >= ^min_ran_at,
-      where: tcr.ran_at <= ^max_ran_at,
-      where: tcr.id in ^ids,
-      order_by: [desc: tcr.inserted_at]
-    )
+    query =
+      from(tcr in TestCaseRun,
+        where: tcr.project_id in ^project_ids,
+        where: tcr.test_case_id in ^test_case_ids,
+        where: tcr.ran_at >= ^min_ran_at,
+        where: tcr.ran_at <= ^max_ran_at,
+        where: tcr.id in ^ids,
+        order_by: [desc: tcr.inserted_at]
+      )
+
+    query =
+      case inserted_at_months do
+        [] -> query
+        months -> from(tcr in query, where: fragment("toYYYYMM(?)", tcr.inserted_at) in ^months)
+      end
+
+    query
     |> ClickHouseRepo.all()
     |> Enum.uniq_by(& &1.id)
   end
@@ -1239,6 +1249,26 @@ defmodule Tuist.Tests do
 
       {min_ran_at, max_ran_at}
     end)
+  end
+
+  defp inserted_at_months(slim_results) do
+    slim_results
+    |> Enum.flat_map(fn run ->
+      case Map.get(run, :inserted_at) do
+        %NaiveDateTime{} = inserted_at ->
+          [inserted_at.year * 100 + inserted_at.month]
+
+        %DateTime{} = inserted_at ->
+          [inserted_at.year * 100 + inserted_at.month]
+
+        _ ->
+          case uuidv7_to_yyyymm(run.id) do
+            {:ok, month} -> [month]
+            :error -> []
+          end
+      end
+    end)
+    |> Enum.uniq()
   end
 
   # Filter precedence for routing: a narrower scope wins so we use the

--- a/server/lib/tuist/tests.ex
+++ b/server/lib/tuist/tests.ex
@@ -1203,27 +1203,20 @@ defmodule Tuist.Tests do
     project_ids = slim_results |> Enum.map(& &1.project_id) |> Enum.uniq()
     test_case_ids = slim_results |> Enum.map(& &1.test_case_id) |> Enum.uniq()
     {min_ran_at, max_ran_at} = ran_at_bounds(slim_results)
-    inserted_at_partition_range = inserted_at_partition_range(slim_results)
 
     # `test_case_runs` is ReplacingMergeTree; re-inserts (e.g. flaky flag
     # updates) leave multiple versions per id until background merges
     # collapse them. Dedupe in Elixir by `desc: inserted_at` rather than
     # paying FINAL's full-part scan and in-memory merge for the page-sized
     # set of ids that the slim MV already narrowed us to.
-    query =
-      from(tcr in TestCaseRun,
-        where: tcr.project_id in ^project_ids,
-        where: tcr.test_case_id in ^test_case_ids,
-        where: tcr.ran_at >= ^min_ran_at,
-        where: tcr.ran_at <= ^max_ran_at,
-        where: tcr.id in ^ids,
-        order_by: [desc: tcr.inserted_at]
-      )
-
-    query =
-      scope_to_inserted_at_partition(query, inserted_at_partition_range)
-
-    query
+    from(tcr in TestCaseRun,
+      where: tcr.project_id in ^project_ids,
+      where: tcr.test_case_id in ^test_case_ids,
+      where: tcr.ran_at >= ^min_ran_at,
+      where: tcr.ran_at <= ^max_ran_at,
+      where: tcr.id in ^ids,
+      order_by: [desc: tcr.inserted_at]
+    )
     |> ClickHouseRepo.all()
     |> Enum.uniq_by(& &1.id)
   end
@@ -1246,64 +1239,6 @@ defmodule Tuist.Tests do
 
       {min_ran_at, max_ran_at}
     end)
-  end
-
-  defp inserted_at_partition_range(slim_results) do
-    slim_results
-    |> Enum.flat_map(&inserted_at_partition_timestamps/1)
-    |> case do
-      [] ->
-        nil
-
-      timestamps ->
-        {min_inserted_at, max_inserted_at} =
-          Enum.min_max_by(timestamps, &NaiveDateTime.to_gregorian_seconds/1)
-
-        {month_start(min_inserted_at), next_month_start(max_inserted_at)}
-    end
-  end
-
-  defp inserted_at_partition_timestamps(run) do
-    case Map.get(run, :inserted_at) do
-      %NaiveDateTime{} = inserted_at ->
-        [inserted_at]
-
-      %DateTime{} = inserted_at ->
-        [DateTime.to_naive(inserted_at)]
-
-      _ ->
-        case uuidv7_to_inserted_at(run.id) do
-          {:ok, inserted_at} -> [inserted_at]
-          :error -> []
-        end
-    end
-  end
-
-  defp scope_to_inserted_at_partition(query, nil), do: query
-
-  defp scope_to_inserted_at_partition(query, {partition_start, partition_end}) do
-    from(tcr in query,
-      where: tcr.inserted_at >= ^partition_start,
-      where: tcr.inserted_at < ^partition_end
-    )
-  end
-
-  defp month_start(%NaiveDateTime{year: year, month: month}) do
-    month_start(year, month)
-  end
-
-  defp next_month_start(%NaiveDateTime{year: year, month: 12}) do
-    month_start(year + 1, 1)
-  end
-
-  defp next_month_start(%NaiveDateTime{year: year, month: month}) do
-    month_start(year, month + 1)
-  end
-
-  defp month_start(year, month) do
-    year
-    |> Date.new!(month, 1)
-    |> NaiveDateTime.new!(~T[00:00:00.000000])
   end
 
   # Filter precedence for routing: a narrower scope wins so we use the
@@ -1352,18 +1287,25 @@ defmodule Tuist.Tests do
 
     query =
       case Keyword.get(opts, :project_id) do
-        nil -> query
-        project_id -> where(query, [tcr], tcr.project_id == ^project_id)
-      end
+        nil ->
+          case uuidv7_to_yyyymm(id) do
+            {:ok, month} ->
+              where(query, [tcr], fragment("toYYYYMM(?)", tcr.inserted_at) == ^month)
 
-    query =
-      case uuidv7_to_inserted_at(id) do
-        {:ok, inserted_at} ->
-          partition_range = {month_start(inserted_at), next_month_start(inserted_at)}
-          scope_to_inserted_at_partition(query, partition_range)
+            :error ->
+              query
+          end
 
-        :error ->
-          query
+        project_id ->
+          query = where(query, [tcr], tcr.project_id == ^project_id)
+
+          case uuidv7_to_yyyymm(id) do
+            {:ok, month} ->
+              where(query, [tcr], fragment("toYYYYMM(?)", tcr.inserted_at) == ^month)
+
+            :error ->
+              query
+          end
       end
 
     case ClickHouseRepo.one(query) do
@@ -1381,14 +1323,14 @@ defmodule Tuist.Tests do
   # partition hint, the proj_by_id projection must check every part across all
   # monthly partitions (~93K rows read, ~2.7s p50 in production). UUIDv7 encodes
   # a millisecond timestamp in the first 48 bits, which closely matches
-  # inserted_at, so we derive the month range and add an inserted_at filter to
-  # prune all but one partition (~8K rows read, ~35x improvement).
-  defp uuidv7_to_inserted_at(uuid_string) do
+  # inserted_at, so we extract the month and add a toYYYYMM filter to prune all
+  # but one partition (~8K rows read, ~35x improvement).
+  defp uuidv7_to_yyyymm(uuid_string) do
     hex = uuid_string |> String.replace("-", "") |> String.slice(0, 12)
     timestamp_ms = String.to_integer(hex, 16)
 
     case DateTime.from_unix(timestamp_ms, :millisecond) do
-      {:ok, datetime} -> {:ok, DateTime.to_naive(datetime)}
+      {:ok, datetime} -> {:ok, datetime.year * 100 + datetime.month}
       _ -> :error
     end
   rescue

--- a/server/priv/ingest_repo/migrations/20260706121835_add_id_projection_to_command_events.exs
+++ b/server/priv/ingest_repo/migrations/20260706121835_add_id_projection_to_command_events.exs
@@ -1,0 +1,39 @@
+defmodule Tuist.IngestRepo.Migrations.AddIdProjectionToCommandEvents do
+  @moduledoc """
+  Adds an id-ordered projection to `command_events`.
+
+  Production slow-query telemetry showed `get_command_event_by_id/1` issuing
+  `WHERE id = ?` lookups against `command_events` thousands of times in a
+  30-minute window. The table is ordered by `(project_id, name, ran_at)`, so an
+  id-only predicate cannot use the primary key and was reading ~1.17M rows per
+  lookup even with the existing `idx_id` bloom-filter skip index. An id-ordered
+  projection gives ClickHouse a physical layout where those lookups can read in
+  id order instead of scanning many wide granules.
+
+  `ADD PROJECTION` is metadata-only. Materialization happens in the follow-up
+  migration so the metadata change can propagate before the slower part rewrite
+  runs.
+  """
+
+  use Ecto.Migration
+
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  def up do
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    execute """
+    ALTER TABLE command_events
+    ADD PROJECTION IF NOT EXISTS proj_by_id (
+      SELECT *
+      ORDER BY id
+    )
+    SETTINGS alter_sync = 2
+    """
+  end
+
+  def down do
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    execute "ALTER TABLE command_events DROP PROJECTION IF EXISTS proj_by_id"
+  end
+end

--- a/server/priv/ingest_repo/migrations/20260706121836_materialize_id_projection_on_command_events.exs
+++ b/server/priv/ingest_repo/migrations/20260706121836_materialize_id_projection_on_command_events.exs
@@ -1,0 +1,25 @@
+defmodule Tuist.IngestRepo.Migrations.MaterializeIdProjectionOnCommandEvents do
+  @moduledoc """
+  Materializes `command_events.proj_by_id` for existing parts.
+
+  The preceding migration adds the projection metadata. This migration starts
+  the part rewrite separately to avoid racing replica metadata propagation.
+  """
+
+  use Ecto.Migration
+
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  def up do
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    execute """
+    ALTER TABLE command_events
+    MATERIALIZE PROJECTION proj_by_id
+    """
+  end
+
+  def down do
+    :ok
+  end
+end


### PR DESCRIPTION
## What changed

- Add an id-ordered `proj_by_id` projection to `command_events`, split into metadata and materialization migrations.
- Rewrite the flaky-test rolling-window query so it deduplicates bounded recent-run arrays in-place instead of expanding every run through `ARRAY JOIN`, grouping, sorting, and `LIMIT BY`.
- Split ClickHouse read/write `max_threads` config helpers and fix the duplicate `IngestRepo` `pool_size` key.
- Move ClickHouse repo pool sizes to non-secret Helm chart values and render them into the server, migration, processor, and xcresult-processor workloads.

## Why

The slow-query alert was firing for two ClickHouse queries, but the broader CPU-wait investigation showed those queries were symptoms of a strained ClickHouse instance rather than the whole cause.

Using Atlas/Grafana against production `system.query_log` and `system.metric_log`, the exact alert window (`2026-07-06 10:53-11:23 UTC`) showed the largest CPU-wait contributor was `CommandEvents.get_command_event_by_id/1`:

- 16,008 executions in 30 minutes
- ~350 GiB read
- ~12.3B rows read
- ~2,417s CPU time
- ~1,113s CPU wait

That query filters `command_events` by id only, but the table is ordered by `(project_id, name, ran_at)`. Production already has an `idx_id` bloom-filter skip index, but `EXPLAIN indexes = 1` still showed it reading 291 of 7,925 granules for a single id lookup. The projection gives ClickHouse a physical layout that matches the point lookup.

The flaky rolling query also accumulated meaningful CPU wait in the same alert window. Keeping the recent-run work inside arrays avoids multiplying each active test case into hundreds of intermediate rows.

I intentionally dropped the proposed `test_case_runs` hydration partition hint from this PR after quantifying it. That query had S3/I/O tail latency, but it was not a meaningful contributor to the CPU-wait problem and added more complexity than it justified here.

## Impact

Run detail lookups by command event id should stop repeatedly scanning wide `command_events` granules under high refresh traffic. Flaky monitor evaluations should spend less CPU on rolling windows.

The new ClickHouse config helpers keep existing `max_threads` defaults: read and write `max_threads` both fall back to `clickhouse.max_threads` unless dedicated runtime config is provided. The `pool_size` cleanup now preserves the managed ClickHouse repo pool sizes instead of quietly reducing the write buffer pool. Production and staging set both `clickhouse.poolSize` and `clickhouse.bufferPoolSize` to `15`; canary sets both to `30`. These are chart-owned operational knobs, not values sourced from the runtime secret bundle, and the chart renders them into the server, migration, processor, and xcresult-processor pods.

The `proj_by_id` projection stores a full id-ordered copy of `command_events` (`SELECT * ORDER BY id`). Production `command_events` is currently ~26.8M rows / ~5.96 GB compressed, so materialization will add storage in that same order of magnitude and each insert will pay projection-maintenance cost. Rollout should watch ClickHouse disk usage and insert latency after `MATERIALIZE PROJECTION` finishes.

## Validation

- Reproduced the Grafana alert query through Atlas. Note: the alert rule computes `p99`, while the Slack description says `p90`.
- Queried production ClickHouse metrics for the alert window and identified the dominant CPU-wait hash.
- Ran `EXPLAIN indexes = 1` for the hot `command_events WHERE id = ?` query; confirmed the existing bloom filter still read 291 granules.
- Queried production ClickHouse via Atlas; `command_events` is currently ~26.8M rows / ~5.96 GB compressed before adding the projection.
- Rendered the managed Helm chart for production, canary, and staging with server/migration/processor/xcresult-processor templates selected; confirmed the ClickHouse pool env vars render into all four workloads with production/staging `15` and canary `30`.
- Validated the rewritten rolling-window ClickHouse expression against production data:
  - tiny project: old/new result counts matched with no diff
  - 200-case sample from a large project: old/new result counts matched with no diff
- Ran `git diff --check` / `git diff --cached --check`.
- Parsed touched Elixir files with `Code.string_to_quoted!`.

Could not run `mix format --check-formatted` or Mix tests because `mix deps.get --check-locked` reports the existing lock drift `hpax 1.0.3 => 1.0.4`. I left `mix.lock` untouched because that dependency update is unrelated to this ClickHouse fix.