### PR TITLE
chore(server): take Linux runners off the in-cluster (PN) Kura cache

### DIFF
--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -69,10 +69,15 @@ server:
     # Hand cluster-networked fleets the in-cluster cache endpoint. macOS
     # resolves to the node-port form (http://<node PN address>:<NodePort>
     # on scw-fr-par-runners), reached over the PN the minis attach to
-    # (macosFleet.vmCachePrivateNetwork below). linux is the default and
-    # stays inert here (prod advertises no Linux private cache region).
+    # (macosFleet.vmCachePrivateNetwork below). linux is TEMPORARILY off
+    # this list: prod has no Linux private (in-cluster) Kura region, so
+    # gating it here only had Linux jobs fall back to the public regional
+    # ingress, which the runners' egress rules block. The Linux runners
+    # are moving to Scaleway Dedibox bare metal, where a node-local Kura
+    # will live (like the macOS fleet); re-add `linux` once that region
+    # exists so dispatch routes Linux jobs to it.
     - name: TUIST_RUNNERS_CLUSTER_NETWORK_PLATFORMS
-      value: linux,macos
+      value: macos
     # Operator project-access grants. The public key verifies grants
     # signed by ops (private half: TUIST_OPS_BOT 1P `project_access_signing_key`,
     # which MUST be stored before this deploys). The reason-form URL turns

--- a/infra/k8s/clusters/README.md
+++ b/infra/k8s/clusters/README.md
@@ -31,10 +31,17 @@ clusters/
 
 | Cluster | CP | Workers |
 |---|---|---|
-| `tuist-staging` | 3× cpx22 | md-0: 2× cpx31 |
-| `tuist-canary` | 3× cpx22 | md-0: 2× cpx32; kura: 3× ccx13 (`pool=kura`) |
-| `tuist` (production) | 3× cpx22 | md-0: 3× ccx23 (`pool=general`); md-processor: 2× cpx62 (`pool=processor`, autoscaled 2→6); kura: 3× ccx13 (`pool=kura`, autoscaled 3→12); kura-us-east: 3× ccx13 in `ash` (`pool=kura-us-east`, autoscaled 3→32); kura-us-west: 3× ccx13 in `hil` (`pool=kura-us-west`, autoscaled 3→12) |
+| `tuist-staging` | 3× cpx22 | md-0: 2× cpx32; md-egress: 2× cpx22 (`pool=egress`, HA stable-egress gateway); kura: 3× ccx13 (`pool=kura`, autoscaled 3→12); runners-linux: bare-metal Robot (`pool=runners-linux`) |
+| `tuist-canary` | 3× cpx22 | md-0: 2× cpx32; md-egress: 2× cpx22 (`pool=egress`, HA stable-egress gateway); kura: 3× ccx13 (`pool=kura`); runners-linux: bare-metal Robot (`pool=runners-linux`) |
+| `tuist` (production) | 3× cpx22 | md-0: 3× ccx23 (`pool=general`); md-egress: 2× cpx22 (`pool=egress`, HA stable-egress gateway); md-processor: 2× cpx62 (`pool=processor`, autoscaled 2→6); kura: 3× ccx13 (`pool=kura`, autoscaled 3→12); kura-us-east: 3× ccx13 in `ash` (`pool=kura-us-east`, autoscaled 3→32); kura-us-west: 3× ccx13 in `hil` (`pool=kura-us-west`, autoscaled 3→12); runners-linux: 2× AX162-R bare-metal Robot in `fsn1` (`pool=runners-linux`) |
 | `tuist-preview` | 1× cpx22 | md-0: 1× cpx42 |
+
+The `md-egress` pool is the HA (≥2 node) stable-egress gateway: the
+production Phoenix server's public egress is SNAT'd through the active
+node's Hetzner Floating IP, with the failover controller keeping the IP +
+active label on one Ready candidate. It exists on staging/canary too so
+the failover path is exercised down the deployment cascade before
+production. See the pool comment in `cluster-production.yaml`.
 
 Variables exposed by the ClusterClass: control plane replicas + machine
 type, per-pool machine type, region (default `fsn1`), SSH key name,


### PR DESCRIPTION
## What

Two prod-cluster changes:

1. **Take Linux runners off the in-cluster (PN) Kura cache** — remove `linux` from `TUIST_RUNNERS_CLUSTER_NETWORK_PLATFORMS` in the production values (`linux,macos` → `macos`).
2. **Refresh the cluster chart** in `infra/k8s/clusters/README.md` to match the live CAPI manifests.

## Why (1) — the Linux runner cache change

`TUIST_RUNNERS_CLUSTER_NETWORK_PLATFORMS` gates which runner platforms dispatch may hand an in-cluster (`*.svc.cluster.local`) Kura cache URL (`runners_controller.ex` `dispatch_response` → `Catalog.fleet_on_cluster_network?/1`). Production listed `linux`, but there is **no Linux private (in-cluster) Kura region** — the only private region wired into prod is `scw-fr-par-runners`, which serves macOS only. So `Kura.runner_cache_endpoint_url(account, :linux)` always returned `nil`, dispatch handed Linux jobs no cache endpoint, and the CLI fell back to public endpoint discovery → the public regional Kura ingress. The Linux runners' egress rules block the public Internet, so that fallback can't connect: Linux runner builds ran with no working remote cache.

We're **not** standing up a Hetzner Cloud PN Kura pool for Linux, because the Linux runners are moving to **Scaleway Dedibox bare metal**, where a node-local Kura will live (mirroring the macOS Scaleway Elastic Metal fleet). Until then, this makes the config honest — Linux is deliberately off the PN Kura path — and is the switch to flip back (re-add `linux`) once that region exists.

**Behavioural impact today: none.** Because there was never a Linux private region, dispatch already handed Linux no in-cluster URL; this just stops advertising a path that doesn't exist. Linux runners remain without a working remote cache until the Dedibox node-local Kura lands (unchanged from current prod). This is intentionally the minimal, reversible interim step, not a fix for the missing cache.

## Why (2) — the chart refresh

The "Target shape per cluster" table had drifted from the manifests: it was missing the `md-egress` HA pools (added after the 2026-06-14 egress-SPOF outage) and the `runners-linux` bare-metal pools, and listed staging `md-0` as `cpx31` when it is `cpx32`. Updated to match `cluster-*.yaml`.

## Validation

- Both files parse (YAML).
- Config/docs only — no application code paths altered.

## Draft because

Flagging for review before the Dedibox move lands — confirm we're happy leaving Linux runner cache off in the interim rather than silencing the public-cache connection errors some other way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
