### PR TITLE
fix(server): authenticate CLDR locale prefetch against the GitHub API

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -342,6 +342,8 @@ jobs:
           target: runner
           push: true
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.image_tag }}
+          secrets: |
+            github_token=${{ secrets.GITHUB_TOKEN }}
           build-args: |
             TUIST_HOSTED=1
             MIX_ENV=prod

--- a/.github/workflows/server-deployment.yml
+++ b/.github/workflows/server-deployment.yml
@@ -207,6 +207,8 @@ jobs:
           push: true
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.image_tag }}
+          secrets: |
+            github_token=${{ secrets.GITHUB_TOKEN }}
           # Shared `buildcache:server` ref, kept warm by the push-to-main
           # build in server-production-deployment.yml. `mode=max` exports
           # cache for every stage (deps.compile, builder, og-images).

--- a/.github/workflows/server-production-deployment.yml
+++ b/.github/workflows/server-production-deployment.yml
@@ -226,6 +226,8 @@ jobs:
           target: runner
           platforms: linux/amd64
           outputs: type=image,name=ghcr.io/tuist/tuist,push-by-digest=true,name-canonical=true,push=true
+          secrets: |
+            github_token=${{ secrets.GITHUB_TOKEN }}
           build-args: |
             TUIST_HOSTED=0
             TUIST_VERSION=${{ needs.check-releases.outputs.server-next-version-number }}
@@ -273,6 +275,8 @@ jobs:
           target: runner
           platforms: linux/arm64
           outputs: type=image,name=ghcr.io/tuist/tuist,push-by-digest=true,name-canonical=true,push=true
+          secrets: |
+            github_token=${{ secrets.GITHUB_TOKEN }}
           build-args: |
             TUIST_HOSTED=0
             TUIST_VERSION=${{ needs.check-releases.outputs.server-next-version-number }}
@@ -1911,6 +1915,8 @@ jobs:
           push: true
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.image_tag }}
+          secrets: |
+            github_token=${{ secrets.GITHUB_TOKEN }}
           # Shared registry layer cache. This workflow runs on every push to
           # main, so it keeps `buildcache:server` warm merge to merge;
           # server-deployment.yml reads and writes the same ref. `mode=max`

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -383,6 +383,7 @@ jobs:
             --file "$GITHUB_WORKSPACE/server/Dockerfile" \
             --target runner \
             --load \
+            --secret id=github_token,env=GITHUB_TOKEN \
             --tag tuist/tuist \
             --build-arg TUIST_HOSTED=0 \
             --build-arg TUIST_VERSION=1.24.11.11 \

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -122,7 +122,16 @@ COPY server/config/config.exs config/
 COPY server/config/prod.exs server/config/can.exs server/config/stag.exs config/
 
 RUN mix deps.compile
-RUN mise/tasks/cldr/prefetch-locale-data.sh
+# Prefetch CLDR locale JSON before the full-locale compile so ex_cldr does not
+# fall back to rate-limited raw.githubusercontent.com downloads. Authenticate
+# via a BuildKit secret (never baked into a layer) to lift the unauthenticated
+# rate ceiling; the script stays unauthenticated when no secret is mounted
+# (local builds). The `env=` secret target needs the built-in Dockerfile
+# frontend >= 1.10 (BuildKit 0.16 / Docker Engine 27.3, Sep 2024) — every CI
+# path here provisions a current BuildKit via setup-buildx-action, so no
+# `# syntax=` pin (and its Docker Hub frontend pull) is needed.
+RUN --mount=type=secret,id=github_token,env=GITHUB_TOKEN \
+    mise/tasks/cldr/prefetch-locale-data.sh
 
 # ========================================
 # Stage: OG image generator

--- a/server/mise/tasks/cldr/prefetch-locale-data.sh
+++ b/server/mise/tasks/cldr/prefetch-locale-data.sh
@@ -30,6 +30,19 @@ fi
 
 mkdir -p "${CLDR_DATA_DIR}"
 
+# Authenticate against the GitHub REST API when a token is available. The
+# unauthenticated `contents` ceiling is ~60 req/hr per egress IP, which the
+# shared-egress CI runners can breach during a release cascade with concurrent
+# cache-misses; an authenticated Actions GITHUB_TOKEN raises that to 1000 req/hr
+# per repo (5000/hr for PATs) — either is miles clear of the 12 requests a build
+# makes. The header is only added when a token is present so local/dev builds
+# keep working offline.
+github_token="${GITHUB_TOKEN:-${GH_TOKEN:-}}"
+auth_header=()
+if [ -n "${github_token}" ]; then
+  auth_header=(-H "Authorization: Bearer ${github_token}")
+fi
+
 for locale in "${LOCALES[@]}"; do
   output="${CLDR_DATA_DIR}/${locale}.json"
   if [ -s "${output}" ]; then
@@ -43,6 +56,7 @@ for locale in "${LOCALES[@]}"; do
     --retry 5 \
     --retry-all-errors \
     --retry-delay 2 \
+    ${auth_header[@]+"${auth_header[@]}"} \
     -H "Accept: application/vnd.github.raw" \
     -H "X-GitHub-Api-Version: 2022-11-28" \
     "https://api.github.com/repos/elixir-cldr/cldr/contents/priv/cldr/locales/${locale}.json?ref=v${cldr_version}" \


### PR DESCRIPTION
## What changed

The CLDR locale prefetch helper added in #11678 (`server/mise/tasks/cldr/prefetch-locale-data.sh`) now authenticates against the GitHub REST API when a token is available, on both the CI and Docker build paths:

- **Script** — sends `Authorization: Bearer $GITHUB_TOKEN` (falling back to `GH_TOKEN`) only when a token is present in the environment; otherwise it stays unauthenticated so local/dev builds keep working offline. The header is applied through an empty-array-safe expansion (`${auth_header[@]+"${auth_header[@]}"}`) so it survives `set -u` on Bash 3.2 (macOS).
- **CI** — the `Test` job's prefetch step already inherits the workflow-level `GITHUB_TOKEN`, so no workflow change was needed there.
- **Docker** — the `RUN` in `server/Dockerfile` mounts the token as a BuildKit secret (`--mount=type=secret,id=github_token,env=GITHUB_TOKEN`) so it never lands in an image layer. The `github_token` secret is wired into every workflow that builds `server/Dockerfile`: the CI `docker_build` (`--secret` on the buildx CLI), the prod amd64/arm64 release builds, the main-push server image, the single-env `server-deployment`, and `preview-deploy`.

## Why

`prefetch-locale-data.sh` fetched all 12 locales from `api.github.com` with **no** `Authorization` header, so it was bound by the REST API's ~60 req/hr unauthenticated ceiling per egress IP. That's stricter than — and in a different rate-limit bucket from — the `raw.githubusercontent.com` compile-time downloads it replaced (the 429s #11678 was fixing).

On the shared-egress runners, a release cascade plus concurrent PR cache-misses can breach 60/hr, and the failure mode is a hard build break: GitHub 403 → `curl --retry-all-errors` dutifully retries the 403 → `set -e` fails the step. So the prefetch, as merged, swapped a probabilistic `raw` 429 for a probabilistic REST 403 — it narrowed the fragility but didn't remove it.

`GITHUB_TOKEN` was already present in the CI step's env (just unused), and the earlier "token variant 403'd" during development reads like an *empty*-token auth failure inside the Docker build rather than a rate limit — authenticated requests get 5000/hr, which comfortably covers a release cascade. So the fix is to authenticate, not to drop auth.

## Why this shape

- The BuildKit secret keeps the token out of image layers (vs. a `--build-arg`, which would bake it into build history). Both build paths already run under BuildKit, so this is plumbing, not an architecture change.
- The secret mount is **optional**: builds that don't pass `github_token` (and local runs with no token) still succeed unauthenticated, exactly as today — so this can't regress any existing path.

## Impact

Server release Docker builds and the full-locale CI test compile become resilient to GitHub REST rate limits during release cascades and busy CI windows, instead of hard-failing on a 403. No behavior change when no token is present.

## Validation

- Ran `prefetch-locale-data.sh` end-to-end against the **real** GitHub API both unauthenticated and with a token — all 12 locale JSON files fetched and parsed as valid JSON both ways.
- Verified the empty-array expansion under `set -euo pipefail` on Bash 3.2 (macOS system bash) with and without a token, so the local/dev path doesn't break on the `unbound variable` trap.
- `bash -n` on the script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)