### PR TITLE
feat(cli): add --focused-targets to `tuist test` to build specific targets from source

### DIFF
--- a/cli/Sources/TuistEnvKey/EnvKey.swift
+++ b/cli/Sources/TuistEnvKey/EnvKey.swift
@@ -178,6 +178,7 @@ public enum EnvKey: String, CaseIterable {
     case testTestPlan = "TUIST_TEST_TEST_PLAN"
     case testTestTargets = "TUIST_TEST_TEST_TARGETS"
     case testSkipTestTargets = "TUIST_TEST_SKIP_TEST_TARGETS"
+    case testFocusedTargets = "TUIST_TEST_FOCUSED_TARGETS"
     case testConfigurations = "TUIST_TEST_CONFIGURATIONS"
     case testSkipConfigurations = "TUIST_TEST_SKIP_CONFIGURATIONS"
     case testGenerateOnly = "TUIST_TEST_GENERATE_ONLY"

--- a/cli/Sources/TuistKit/Services/TestService.swift
+++ b/cli/Sources/TuistKit/Services/TestService.swift
@@ -232,6 +232,7 @@ public struct TestService { // swiftlint:disable:this type_body_length
         retryCount: Int,
         testTargets: [TestIdentifier],
         skipTestTargets: [TestIdentifier],
+        focusedTargets: [TargetQuery] = [],
         testPlanConfiguration: TestPlanConfiguration?,
         validateTestTargetsParameters: Bool = true,
         ignoreBinaryCache: Bool,
@@ -339,10 +340,22 @@ public struct TestService { // swiftlint:disable:this type_body_length
             osVersion: osVersion
         )
 
+        // Test targets are always built from source. `focusedTargets` additionally
+        // focuses non-test targets (e.g. the module under test) so that source-only
+        // build steps such as code coverage instrumentation apply to them instead of
+        // linking them from the binary cache.
+        let focusedTargetStrings: Set<String> = Set(
+            focusedTargets.map { query in
+                switch query {
+                case let .named(name): return name
+                case let .tagged(tag): return "tag:\(tag)"
+                }
+            }
+        )
         let testGenerator = generatorFactory.testing(
             config: config,
             testPlan: testPlanConfiguration?.testPlan,
-            includedTargets: Set(testTargets.map(\.target)),
+            includedTargets: Set(testTargets.map(\.target)).union(focusedTargetStrings),
             excludedTargets: Set(skipTestTargets.filter { $0.class == nil }.map(\.target)),
             skipUITests: skipUITests,
             skipUnitTests: skipUnitTests,

--- a/cli/Sources/TuistTestCommand/TestRunCommand.swift
+++ b/cli/Sources/TuistTestCommand/TestRunCommand.swift
@@ -3,6 +3,7 @@
     import Foundation
     import Path
     import TuistBuildCommand
+    import TuistConfig
     import TuistCore
     import TuistEnvironment
     import TuistEnvKey
@@ -197,6 +198,15 @@
             envKey: .testSkipTestTargets
         )
         var skipTestTargets: [TestIdentifier] = []
+
+        @Option(
+            name: .long,
+            parsing: .upToNextOption,
+            help:
+            "Targets to build from source instead of linking from the binary cache, specified by name or tag query (e.g. 'tag:feature'). Their test targets are already built from source; this additionally focuses the listed targets (e.g. the module under test) so that source-only build steps such as code coverage instrumentation apply to them.",
+            envKey: .testFocusedTargets
+        )
+        var focusedTargets: [TargetQuery] = []
 
         @Option(
             name: .customLong("filter-configurations"),
@@ -417,6 +427,7 @@
                 retryCount: retryCount,
                 testTargets: testTargets,
                 skipTestTargets: skipTestTargets,
+                focusedTargets: focusedTargets,
                 testPlanConfiguration: testPlan.map { testPlan in
                     TestPlanConfiguration(
                         testPlan: testPlan,

--- a/cli/Tests/TuistKitTests/CommandEnvironmentVariables/CommandEnvironmentVariableTests.swift
+++ b/cli/Tests/TuistKitTests/CommandEnvironmentVariables/CommandEnvironmentVariableTests.swift
@@ -5,6 +5,7 @@ import Testing
 import TSCUtility
 import TuistEnvironment
 import TuistEnvKey
+import TuistConfig
 import TuistVersionCommand
 @testable import TuistAuthCommand
 @testable import TuistBuildCommand
@@ -479,6 +480,7 @@ struct CommandEnvironmentVariableTests {
         setVariable(.testRetryCount, value: "2")
         setVariable(.testTestPlan, value: "MyTestPlan")
         setVariable(.testSkipTestTargets, value: "SkipTarget1,SkipTarget2")
+        setVariable(.testFocusedTargets, value: "FocusTarget1,tag:coverage")
         setVariable(.testConfigurations, value: "Config1,Config2")
         setVariable(.testSkipConfigurations, value: "SkipConfig1,SkipConfig2")
         setVariable(.testGenerateOnly, value: "true")
@@ -511,6 +513,7 @@ struct CommandEnvironmentVariableTests {
             try TestIdentifier(string: "SkipTarget1"),
             try TestIdentifier(string: "SkipTarget2"),
         ])
+        #expect(testCommandWithEnvVars.focusedTargets == [.named("FocusTarget1"), .tagged("coverage")])
         #expect(testCommandWithEnvVars.configurations == ["Config1", "Config2"])
         #expect(testCommandWithEnvVars.skipConfigurations == ["SkipConfig1", "SkipConfig2"])
         #expect(testCommandWithEnvVars.generateOnly == true)
@@ -537,6 +540,7 @@ struct CommandEnvironmentVariableTests {
             "--retry-count", "3",
             "--test-plan", "NewTestPlan",
             "--skip-test-targets", "NewSkipTarget1", "NewSkipTarget2",
+            "--focused-targets", "NewFocusTarget1", "tag:new-coverage",
             "--filter-configurations", "NewConfig1", "NewConfig2",
             "--skip-configurations", "NewSkipConfig1", "NewSkipConfig2",
             "--no-generate-only",
@@ -565,6 +569,7 @@ struct CommandEnvironmentVariableTests {
             try TestIdentifier(string: "NewSkipTarget1"),
             try TestIdentifier(string: "NewSkipTarget2"),
         ])
+        #expect(testCommandWithArgs.focusedTargets == [.named("NewFocusTarget1"), .tagged("new-coverage")])
         #expect(testCommandWithArgs.configurations == ["NewConfig1", "NewConfig2"])
         #expect(testCommandWithArgs.skipConfigurations == ["NewSkipConfig1", "NewSkipConfig2"])
         #expect(testCommandWithArgs.generateOnly == false)

--- a/cli/Tests/TuistKitTests/Services/TestServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/TestServiceTests.swift
@@ -645,6 +645,54 @@ final class TestServiceTests: TuistUnitTestCase {
         XCTAssertEqual(testedSchemes, ["TestScheme"])
     }
 
+    func test_run_focuses_focused_targets_alongside_test_targets() async throws {
+        // Given
+        givenGenerator()
+        given(buildGraphInspector)
+            .testableSchemes(graphTraverser: .any)
+            .willReturn([Scheme.test(name: "TestScheme")])
+        given(generator)
+            .generateWithGraph(path: .any, options: .any)
+            .willProduce { path, _ in
+                (
+                    path, .test(workspace: .test(schemes: [.test(name: "TestScheme")])),
+                    MapperEnvironment()
+                )
+            }
+        given(configLoader)
+            .loadConfig(path: .any)
+            .willReturn(.test(project: .testGeneratedProject()))
+
+        // When
+        try await testRun(
+            schemeName: "TestScheme",
+            path: try temporaryPath(),
+            testTargets: [try TestIdentifier(target: "ModuleTests")],
+            focusedTargets: [.named("Module"), "tag:coverage"]
+        )
+
+        // Then: the module under test and the tag query are focused (built from
+        // source) in addition to the test target.
+        verify(generatorFactory)
+            .testing(
+                config: .any,
+                testPlan: .any,
+                includedTargets: .matching { included in
+                    included == ["ModuleTests", "Module", "tag:coverage"]
+                },
+                excludedTargets: .any,
+                skipUITests: .any,
+                skipUnitTests: .any,
+                configuration: .any,
+                ignoreBinaryCache: .any,
+                ignoreSelectiveTesting: .any,
+                cacheStorage: .any,
+                destination: .any,
+                schemeName: .any
+            )
+            .called(1)
+    }
+
     func test_run_tests_all_project_schemes() async throws {
         // Given
         givenGenerator()
@@ -5576,6 +5624,7 @@ final class TestServiceTests: TuistUnitTestCase {
         retryCount: Int = 0,
         testTargets: [TestIdentifier] = [],
         skipTestTargets: [TestIdentifier] = [],
+        focusedTargets: [TargetQuery] = [],
         testPlanConfiguration: TestPlanConfiguration? = nil,
         generateOnly: Bool = false,
         passthroughXcodeBuildArguments: [String] = [],
@@ -5611,6 +5660,7 @@ final class TestServiceTests: TuistUnitTestCase {
                 retryCount: retryCount,
                 testTargets: testTargets,
                 skipTestTargets: skipTestTargets,
+                focusedTargets: focusedTargets,
                 testPlanConfiguration: testPlanConfiguration,
                 ignoreBinaryCache: false,
                 ignoreSelectiveTesting: false,

--- a/cli/Tests/TuistKitTests/Services/TestServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/TestServiceTests.swift
@@ -693,6 +693,52 @@ final class TestServiceTests: TuistUnitTestCase {
             .called(1)
     }
 
+    func test_run_without_focused_targets_only_focuses_test_targets() async throws {
+        // Given
+        givenGenerator()
+        given(buildGraphInspector)
+            .testableSchemes(graphTraverser: .any)
+            .willReturn([Scheme.test(name: "TestScheme")])
+        given(generator)
+            .generateWithGraph(path: .any, options: .any)
+            .willProduce { path, _ in
+                (
+                    path, .test(workspace: .test(schemes: [.test(name: "TestScheme")])),
+                    MapperEnvironment()
+                )
+            }
+        given(configLoader)
+            .loadConfig(path: .any)
+            .willReturn(.test(project: .testGeneratedProject()))
+
+        // When: no focused targets are passed (the default).
+        try await testRun(
+            schemeName: "TestScheme",
+            path: try temporaryPath(),
+            testTargets: [try TestIdentifier(target: "ModuleTests")]
+        )
+
+        // Then: only the test target is focused — cache usage is unchanged.
+        verify(generatorFactory)
+            .testing(
+                config: .any,
+                testPlan: .any,
+                includedTargets: .matching { included in
+                    included == ["ModuleTests"]
+                },
+                excludedTargets: .any,
+                skipUITests: .any,
+                skipUnitTests: .any,
+                configuration: .any,
+                ignoreBinaryCache: .any,
+                ignoreSelectiveTesting: .any,
+                cacheStorage: .any,
+                destination: .any,
+                schemeName: .any
+            )
+            .called(1)
+    }
+
     func test_run_tests_all_project_schemes() async throws {
         // Given
         givenGenerator()


### PR DESCRIPTION
### Short description 📝

Adds an opt-in `--focused-targets` option to `tuist test` (env: `TUIST_TEST_FOCUSED_TARGETS`) that lets callers force specific targets to build **from source** instead of being linked from the binary cache, alongside the test targets that are already built from source.

### Motivation

`tuist test` always builds test targets from source but links their dependencies — including the module under test — from the binary cache. This breaks any build step that only works on source-compiled targets.

The concrete case that motivated this: **code coverage on cached modules reports 0%.** `-enableCodeCoverage YES` instruments code at compile time, embedding a coverage mapping (`__llvm_covmap`) into the binary. A module served from the binary cache was compiled *without* those flags, so `llvm-cov` has no mapping to attribute and reports nothing — even when the module is well covered. In a differential/PR pipeline, any test-only change (touching only `Tests/`) leaves the source target unchanged, so it's always linked from cache, so differential coverage is consistently 0% for that module.

With `--focused-targets`, a CI coverage job can focus the changed module so it compiles from source (and thus gets instrumented) while everything else still comes from cache — avoiding a full `--no-binary-cache` rebuild of the whole dependency closure.

### How it works

`tuist test` already focuses targets through the same machinery `tuist generate` uses: `TestService` passes an `includedTargets` set into `GeneratorFactory.testing(...)`, which forwards it to the automation graph mapper. Focused targets build from source; everything else cacheable is linked as a binary. Previously that set only ever contained the *test* targets.

This change unions the `--focused-targets` queries into that set. It accepts target names or `tag:` queries, mirroring `tuist generate`'s focus argument. The option defaults to empty, so **existing behavior and cache usage are unchanged unless a caller opts in.**

### Changes

- `TestRunCommand`: new `--focused-targets` `@Option` (`[TargetQuery]`), threaded into `TestService.run`.
- `TestService`: new `focusedTargets` parameter (defaults to `[]`), unioned into the test generator's `includedTargets`.
- `EnvKey`: registers `TUIST_TEST_FOCUSED_TARGETS`.
- Adds a unit test verifying focused targets reach `testing(includedTargets:)` alongside test targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
