### PR TITLE
feat(cli): preselect xcframework slices

### DIFF
--- a/cli/Sources/TuistKit/Mappers/Factories/GraphMapperFactory.swift
+++ b/cli/Sources/TuistKit/Mappers/Factories/GraphMapperFactory.swift
@@ -199,6 +199,9 @@ public struct GraphMapperFactory: GraphMapperFactorying {
                 mappers.append(TreeShakePrunedTargetsGraphMapper())
                 mappers.append(StaticXCFrameworkModuleMapGraphMapper())
                 mappers.append(StaticXCFrameworkAppIntentsMetadataGraphMapper())
+                if ClientFeatureFlags.contains("xcframework_slice_linking") {
+                    mappers.append(PreselectedXCFrameworkSlicesGraphMapper())
+                }
             }
 
             mappers.append(FrameworkSearchPathsGraphMapper())
@@ -238,6 +241,9 @@ public struct GraphMapperFactory: GraphMapperFactorying {
                 mappers.append(TreeShakePrunedTargetsGraphMapper())
                 mappers.append(StaticXCFrameworkModuleMapGraphMapper())
                 mappers.append(StaticXCFrameworkAppIntentsMetadataGraphMapper())
+                if ClientFeatureFlags.contains("xcframework_slice_linking") {
+                    mappers.append(PreselectedXCFrameworkSlicesGraphMapper())
+                }
             }
 
             mappers.append(FrameworkSearchPathsGraphMapper())
@@ -296,6 +302,9 @@ public struct GraphMapperFactory: GraphMapperFactorying {
                 mappers.append(TreeShakePrunedTargetsGraphMapper())
                 mappers.append(StaticXCFrameworkModuleMapGraphMapper())
                 mappers.append(StaticXCFrameworkAppIntentsMetadataGraphMapper())
+                if ClientFeatureFlags.contains("xcframework_slice_linking") {
+                    mappers.append(PreselectedXCFrameworkSlicesGraphMapper())
+                }
             }
 
             mappers.append(FrameworkSearchPathsGraphMapper())
@@ -349,6 +358,9 @@ public struct GraphMapperFactory: GraphMapperFactorying {
             mappers.append(TreeShakePrunedTargetsGraphMapper())
             mappers.append(StaticXCFrameworkModuleMapGraphMapper())
             mappers.append(StaticXCFrameworkAppIntentsMetadataGraphMapper())
+            if ClientFeatureFlags.contains("xcframework_slice_linking") {
+                mappers.append(PreselectedXCFrameworkSlicesGraphMapper())
+            }
 
             mappers.append(FrameworkSearchPathsGraphMapper())
             mappers.append(ForeignBuildSideEffectGraphMapper())

--- a/cli/Sources/TuistKit/Mappers/Graph/PreselectedXCFrameworkSlicesGraphMapper.swift
+++ b/cli/Sources/TuistKit/Mappers/Graph/PreselectedXCFrameworkSlicesGraphMapper.swift
@@ -1,0 +1,681 @@
+import FileSystem
+import Foundation
+import Path
+import TuistConstants
+import TuistCore
+import TuistSupport
+import XcodeGraph
+
+struct PreselectedXCFrameworkSlicesGraphMapper: GraphMapping {
+    private static let derivedDirectoryName = "PreselectedXCFrameworkSlices"
+    private static let frameworkSearchPathsSetting = "FRAMEWORK_SEARCH_PATHS"
+    private static let otherCFlagsSetting = "OTHER_CFLAGS"
+    private static let otherSwiftFlagsSetting = "OTHER_SWIFT_FLAGS"
+    private static let otherLinkerFlagsSetting = "OTHER_LDFLAGS"
+
+    private let fileSystem: FileSysteming
+
+    init(fileSystem: FileSysteming = FileSystem()) {
+        self.fileSystem = fileSystem
+    }
+
+    private struct TargetID: Hashable {
+        let projectPath: AbsolutePath
+        let targetName: String
+    }
+
+    private struct SDKVariant: Hashable, Comparable {
+        let sdk: String
+        let platform: XCFrameworkInfoPlist.Library.Platform
+        let platformVariant: XCFrameworkInfoPlist.Library.PlatformVariant?
+
+        static func < (lhs: SDKVariant, rhs: SDKVariant) -> Bool {
+            lhs.sdk < rhs.sdk
+        }
+    }
+
+    private struct SelectedFramework: Hashable {
+        let xcframeworkPath: AbsolutePath
+        let frameworkPath: AbsolutePath
+        let frameworkName: String
+        let linking: BinaryLinking
+    }
+
+    private struct FrameworkUse {
+        let framework: SelectedFramework
+        var linkStatus: LinkingStatus?
+        var runtime: Bool
+
+        mutating func merge(usage: Usage, status: LinkingStatus) {
+            switch usage {
+            case .searchable:
+                break
+            case .linkable:
+                linkStatus = Self.stronger(lhs: linkStatus, rhs: status)
+            case .runtime:
+                runtime = runtime || framework.linking == .dynamic
+            }
+        }
+
+        private static func stronger(lhs: LinkingStatus?, rhs: LinkingStatus) -> LinkingStatus {
+            if lhs == .required || rhs == .required { return .required }
+            if lhs == .optional || rhs == .optional { return .optional }
+            return .none
+        }
+    }
+
+    private struct SDKPlan {
+        var frameworksByName: [String: FrameworkUse] = [:]
+
+        var isEmpty: Bool {
+            frameworksByName.isEmpty
+        }
+    }
+
+    private struct TargetPlan {
+        let project: Project
+        let target: Target
+        var sdkPlans: [SDKVariant: SDKPlan] = [:]
+
+        var isEmpty: Bool {
+            sdkPlans.isEmpty
+        }
+
+        func removingFrameworks(from fallbackXCFrameworkPaths: Set<AbsolutePath>) -> Self {
+            var plan = self
+            plan.sdkPlans = Dictionary(uniqueKeysWithValues: sdkPlans.compactMap { variant, sdkPlan in
+                var sdkPlan = sdkPlan
+                sdkPlan.frameworksByName = sdkPlan.frameworksByName.filter { _, frameworkUse in
+                    !fallbackXCFrameworkPaths.contains(frameworkUse.framework.xcframeworkPath)
+                }
+                return sdkPlan.isEmpty ? nil : (variant, sdkPlan)
+            })
+            return plan
+        }
+    }
+
+    private enum Usage {
+        case searchable
+        case linkable
+        case runtime
+    }
+
+    func map(
+        graph: Graph,
+        environment: MapperEnvironment
+    ) async throws -> (Graph, [SideEffectDescriptor], MapperEnvironment) {
+        let graphTraverser = GraphTraverser(graph: graph)
+        let linkingByXCFrameworkPath = graph.linkingByXCFrameworkPath
+        var plans: [TargetID: TargetPlan] = [:]
+        var fallbackXCFrameworkPaths = Set<AbsolutePath>()
+
+        for (_, project) in graph.projects {
+            for (_, target) in project.targets {
+                let targetID = TargetID(projectPath: project.path, targetName: target.name)
+                var targetPlan = TargetPlan(project: project, target: target)
+
+                let searchableDependencies = try graphTraverser.searchablePathDependencies(
+                    path: project.path,
+                    name: target.name
+                )
+                for dependency in searchableDependencies {
+                    try await collect(
+                        dependency: dependency,
+                        usage: .searchable,
+                        target: target,
+                        project: project,
+                        linkingByXCFrameworkPath: linkingByXCFrameworkPath,
+                        targetPlan: &targetPlan,
+                        fallbackXCFrameworkPaths: &fallbackXCFrameworkPaths
+                    )
+                }
+
+                let linkableDependencies = try graphTraverser.linkableDependencies(
+                    path: project.path,
+                    name: target.name
+                )
+                for dependency in linkableDependencies {
+                    if target.product == .commandLineTool {
+                        try await collect(
+                            dependency: dependency,
+                            usage: .runtime,
+                            target: target,
+                            project: project,
+                            linkingByXCFrameworkPath: linkingByXCFrameworkPath,
+                            targetPlan: &targetPlan,
+                            fallbackXCFrameworkPaths: &fallbackXCFrameworkPaths
+                        )
+                    }
+                    try await collect(
+                        dependency: dependency,
+                        usage: .linkable,
+                        target: target,
+                        project: project,
+                        linkingByXCFrameworkPath: linkingByXCFrameworkPath,
+                        targetPlan: &targetPlan,
+                        fallbackXCFrameworkPaths: &fallbackXCFrameworkPaths
+                    )
+                }
+
+                let runtimeDependencies = graphTraverser.embeddableFrameworks(path: project.path, name: target.name)
+                for dependency in runtimeDependencies {
+                    try await collect(
+                        dependency: dependency,
+                        usage: .runtime,
+                        target: target,
+                        project: project,
+                        linkingByXCFrameworkPath: linkingByXCFrameworkPath,
+                        targetPlan: &targetPlan,
+                        fallbackXCFrameworkPaths: &fallbackXCFrameworkPaths
+                    )
+                }
+
+                if !targetPlan.isEmpty {
+                    plans[targetID] = targetPlan
+                }
+            }
+        }
+
+        plans = plans.compactMapValues { plan in
+            let filtered = plan.removingFrameworks(from: fallbackXCFrameworkPaths)
+            return filtered.isEmpty ? nil : filtered
+        }
+
+        let selectedXCFrameworkPaths = Set(
+            plans.values.flatMap { plan in
+                plan.sdkPlans.values.flatMap { sdkPlan in
+                    sdkPlan.frameworksByName.values.map(\.framework.xcframeworkPath)
+                }
+            }
+        )
+        guard !selectedXCFrameworkPaths.isEmpty else {
+            return (graph, [], environment)
+        }
+
+        var sideEffects: [SideEffectDescriptor] = []
+        var activeFilesByDirectory: [AbsolutePath: Set<AbsolutePath>] = [:]
+        var generatedDirectories = Set<AbsolutePath>()
+        var targetSettings: [TargetID: [(key: String, values: [String])]] = [:]
+        var targetRuntimeScripts: [TargetID: TargetScript] = [:]
+
+        for (targetID, plan) in plans {
+            let derivedDirectory = Self.derivedDirectory(sourceRootPath: plan.project.sourceRootPath)
+            generatedDirectories.insert(derivedDirectory)
+
+            var additions: [(key: String, values: [String])] = []
+
+            for (variant, sdkPlan) in plan.sdkPlans.sorted(by: { $0.key < $1.key }) {
+                let frameworkDirectory = Self.frameworkDirectory(
+                    sourceRootPath: plan.project.sourceRootPath,
+                    targetName: plan.target.name,
+                    sdk: variant.sdk
+                )
+                let frameworkDirectoryValue = "$(SRCROOT)/\(frameworkDirectory.relative(to: plan.project.sourceRootPath).pathString)"
+
+                for frameworkUse in sdkPlan.frameworksByName.values {
+                    let linkPath = frameworkDirectory.appending(component: "\(frameworkUse.framework.frameworkName).framework")
+                    activeFilesByDirectory[derivedDirectory, default: []].insert(linkPath)
+                    sideEffects.append(
+                        .symbolicLink(
+                            SymbolicLinkDescriptor(
+                                path: linkPath,
+                                destination: frameworkUse.framework.frameworkPath
+                            )
+                        )
+                    )
+                }
+
+                let sdkQualifier = "[sdk=\(variant.sdk)*]"
+                additions.append((
+                    "\(Self.frameworkSearchPathsSetting)\(sdkQualifier)",
+                    [frameworkDirectoryValue]
+                ))
+                additions.append((
+                    "\(Self.otherCFlagsSetting)\(sdkQualifier)",
+                    ["-F", frameworkDirectoryValue]
+                ))
+                additions.append((
+                    "\(Self.otherSwiftFlagsSetting)\(sdkQualifier)",
+                    ["-F", frameworkDirectoryValue]
+                ))
+
+                let linkedFrameworks = sdkPlan.frameworksByName.values
+                    .compactMap { frameworkUse -> (name: String, status: LinkingStatus)? in
+                        guard let linkStatus = frameworkUse.linkStatus, linkStatus != .none else { return nil }
+                        return (frameworkUse.framework.frameworkName, linkStatus)
+                    }
+                    .sorted { lhs, rhs in lhs.name < rhs.name }
+
+                if !linkedFrameworks.isEmpty {
+                    let responseFilePath = frameworkDirectory.appending(component: "\(plan.target.name)-\(variant.sdk).resp")
+                    let responseFileContents = (
+                        ["-F\(frameworkDirectory.pathString)"] +
+                            linkedFrameworks.flatMap { framework -> [String] in
+                                switch framework.status {
+                                case .required:
+                                    return ["-framework", framework.name]
+                                case .optional:
+                                    return ["-weak_framework", framework.name]
+                                case .none:
+                                    return []
+                                }
+                            }
+                    )
+                    .joined(separator: "\n")
+                        + "\n"
+                    activeFilesByDirectory[derivedDirectory, default: []].insert(responseFilePath)
+                    sideEffects.append(
+                        .file(FileDescriptor(path: responseFilePath, contents: Data(responseFileContents.utf8)))
+                    )
+                    additions.append((
+                        "\(Self.otherLinkerFlagsSetting)\(sdkQualifier)",
+                        ["\"@$(SRCROOT)/\(responseFilePath.relative(to: plan.project.sourceRootPath).pathString)\""]
+                    ))
+                }
+            }
+
+            targetSettings[targetID] = additions
+
+            if let script = runtimeScript(plan: plan) {
+                targetRuntimeScripts[targetID] = script
+            }
+        }
+
+        if !generatedDirectories.isEmpty {
+            sideEffects.insert(
+                .generatedFilesCleanup(
+                    GeneratedFilesCleanupDescriptor(
+                        directories: generatedDirectories,
+                        activeFilesByDirectory: activeFilesByDirectory,
+                        include: ["**/*.framework", "**/*.resp"]
+                    )
+                ),
+                at: 0
+            )
+        }
+
+        var graph = graph.removingXCFrameworkDependencies(at: selectedXCFrameworkPaths)
+        graph.projects = Dictionary(uniqueKeysWithValues: graph.projects.map { projectPath, project in
+            var project = project
+            project.targets = Dictionary(uniqueKeysWithValues: project.targets.map { targetName, target in
+                let targetID = TargetID(projectPath: projectPath, targetName: targetName)
+                var target = target
+                if let additions = targetSettings[targetID] {
+                    target.settings = Self.apply(
+                        additions,
+                        to: target.settings,
+                        defaultSettings: project.settings.defaultSettings
+                    )
+                }
+                if let script = targetRuntimeScripts[targetID] {
+                    target.scripts.append(script)
+                }
+                return (targetName, target)
+            })
+            return (projectPath, project)
+        })
+
+        return (graph, sideEffects, environment)
+    }
+
+    private func collect(
+        dependency: GraphDependencyReference,
+        usage: Usage,
+        target: Target,
+        project: Project,
+        linkingByXCFrameworkPath: [AbsolutePath: BinaryLinking],
+        targetPlan: inout TargetPlan,
+        fallbackXCFrameworkPaths: inout Set<AbsolutePath>
+    ) async throws {
+        guard case let .xcframework(path, _, infoPlist, status, condition) = dependency else { return }
+        guard status != .none else { return }
+        guard let linking = linkingByXCFrameworkPath[path] else {
+            fallbackXCFrameworkPaths.insert(path)
+            return
+        }
+
+        let platformFilters = condition?.platformFilters ?? target.dependencyPlatformFilters
+        guard let variants = Self.variants(platformFilters: platformFilters), !variants.isEmpty else {
+            fallbackXCFrameworkPaths.insert(path)
+            return
+        }
+
+        for variant in variants {
+            guard let selectedFramework = try await selectedFramework(
+                xcframeworkPath: path,
+                infoPlist: infoPlist,
+                variant: variant,
+                linking: linking
+            ) else {
+                fallbackXCFrameworkPaths.insert(path)
+                continue
+            }
+
+            var sdkPlan = targetPlan.sdkPlans[variant] ?? SDKPlan()
+            if var existingUse = sdkPlan.frameworksByName[selectedFramework.frameworkName] {
+                guard existingUse.framework == selectedFramework else {
+                    fallbackXCFrameworkPaths.insert(existingUse.framework.xcframeworkPath)
+                    fallbackXCFrameworkPaths.insert(selectedFramework.xcframeworkPath)
+                    continue
+                }
+                existingUse.merge(usage: usage, status: status)
+                sdkPlan.frameworksByName[selectedFramework.frameworkName] = existingUse
+            } else {
+                sdkPlan.frameworksByName[selectedFramework.frameworkName] = FrameworkUse(
+                    framework: selectedFramework,
+                    linkStatus: usage == .linkable ? status : nil,
+                    runtime: usage == .runtime && selectedFramework.linking == .dynamic
+                )
+            }
+            targetPlan.sdkPlans[variant] = sdkPlan
+        }
+    }
+
+    private static func variants(platformFilters: PlatformFilters) -> [SDKVariant]? {
+        var variants: Set<SDKVariant> = []
+        for platformFilter in platformFilters {
+            switch platformFilter {
+            case .ios:
+                variants.insert(.init(sdk: "iphoneos", platform: .iOS, platformVariant: nil))
+                variants.insert(.init(sdk: "iphonesimulator", platform: .iOS, platformVariant: .simulator))
+            case .macos:
+                variants.insert(.init(sdk: "macosx", platform: .macOS, platformVariant: nil))
+            case .tvos:
+                variants.insert(.init(sdk: "appletvos", platform: .tvOS, platformVariant: nil))
+                variants.insert(.init(sdk: "appletvsimulator", platform: .tvOS, platformVariant: .simulator))
+            case .watchos:
+                variants.insert(.init(sdk: "watchos", platform: .watchOS, platformVariant: nil))
+                variants.insert(.init(sdk: "watchsimulator", platform: .watchOS, platformVariant: .simulator))
+            case .visionos:
+                variants.insert(.init(sdk: "xros", platform: .visionOS, platformVariant: nil))
+                variants.insert(.init(sdk: "xrsimulator", platform: .visionOS, platformVariant: .simulator))
+            case .catalyst, .driverkit:
+                return nil
+            }
+        }
+        return variants.sorted()
+    }
+
+    private func selectedFramework(
+        xcframeworkPath: AbsolutePath,
+        infoPlist: XCFrameworkInfoPlist,
+        variant: SDKVariant,
+        linking: BinaryLinking
+    ) async throws -> SelectedFramework? {
+        let candidates = infoPlist.libraries.filter { library in
+            library.platform == variant.platform &&
+                library.platformVariant == variant.platformVariant &&
+                library.path.extension == "framework"
+        }
+        guard candidates.count == 1, let library = candidates.first else { return nil }
+
+        let frameworkPath = xcframeworkPath
+            .appending(component: library.identifier)
+            .appending(try! RelativePath(validating: library.path.pathString))
+        guard try await fileSystem.exists(frameworkPath, isDirectory: true) else { return nil }
+
+        return SelectedFramework(
+            xcframeworkPath: xcframeworkPath,
+            frameworkPath: frameworkPath,
+            frameworkName: library.binaryName,
+            linking: linking
+        )
+    }
+
+    private static func derivedDirectory(sourceRootPath: AbsolutePath) -> AbsolutePath {
+        sourceRootPath.appending(
+            components: Constants.DerivedDirectory.name,
+            Self.derivedDirectoryName
+        )
+    }
+
+    private static func frameworkDirectory(
+        sourceRootPath: AbsolutePath,
+        targetName: String,
+        sdk: String
+    ) -> AbsolutePath {
+        derivedDirectory(sourceRootPath: sourceRootPath)
+            .appending(components: sanitizedPathComponent(targetName), sdk)
+    }
+
+    private static func sanitizedPathComponent(_ value: String) -> String {
+        let allowed = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "-_."))
+        return String(
+            value.unicodeScalars.map { allowed.contains($0) ? Character($0) : "_" }
+        )
+    }
+
+    private struct RuntimeFramework {
+        let path: AbsolutePath
+        let name: String
+    }
+
+    private func runtimeScript(plan: TargetPlan) -> TargetScript? {
+        var runtimeFrameworksBySDK: [String: [RuntimeFramework]] = [:]
+        for (variant, sdkPlan) in plan.sdkPlans {
+            let frameworkDirectory = Self.frameworkDirectory(
+                sourceRootPath: plan.project.sourceRootPath,
+                targetName: plan.target.name,
+                sdk: variant.sdk
+            )
+            let runtimeFrameworks = sdkPlan.frameworksByName.values
+                .filter(\.runtime)
+                .map { frameworkUse in
+                    RuntimeFramework(
+                        path: frameworkDirectory.appending(component: "\(frameworkUse.framework.frameworkName).framework"),
+                        name: frameworkUse.framework.frameworkName
+                    )
+                }
+                .sorted { lhs, rhs in lhs.path.pathString < rhs.path.pathString }
+            if !runtimeFrameworks.isEmpty {
+                runtimeFrameworksBySDK[variant.sdk] = runtimeFrameworks
+            }
+        }
+        guard !runtimeFrameworksBySDK.isEmpty else { return nil }
+
+        let cases = runtimeFrameworksBySDK.keys.sorted().map { sdk -> String in
+            let installCommands = runtimeFrameworksBySDK[sdk, default: []]
+                .map { framework -> String in
+                    let relativePath = framework.path.relative(to: plan.project.sourceRootPath).pathString
+                        .replacingOccurrences(of: "\"", with: "\\\"")
+                    return "    install_framework \"$SRCROOT/\(relativePath)\""
+                }
+                .joined(separator: "\n")
+            return """
+              \(sdk))
+            \(installCommands)
+                ;;
+            """
+        }
+        .joined(separator: "\n")
+
+        let runtimeFrameworks = runtimeFrameworksBySDK.values.flatMap { $0 }
+        let inputPaths = runtimeFrameworks.flatMap { framework -> [String] in
+            let relativePath = framework.path.relative(to: plan.project.sourceRootPath).pathString
+            return [
+                "$(SRCROOT)/\(relativePath)",
+                "$(SRCROOT)/\(relativePath)/\(framework.name)",
+                "$(SRCROOT)/\(relativePath)/Info.plist",
+            ]
+        }
+        .uniqued()
+        let outputPaths = runtimeFrameworks
+            .map { framework in "${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/\(framework.name).framework" }
+            .uniqued()
+
+        return TargetScript(
+            name: "Embed Preselected XCFramework Slices",
+            order: .post,
+            script: .embedded(
+                """
+                set -euo pipefail
+
+                platform_name="${PLATFORM_NAME:-}"
+                if [ -z "$platform_name" ] && [ -n "${SDKROOT:-}" ]; then
+                  platform_name="$(basename "$SDKROOT")"
+                  platform_name="${platform_name%.sdk}"
+                  platform_name="$(printf "%s" "$platform_name" | tr '[:upper:]' '[:lower:]')"
+                fi
+
+                RSYNC_PROTECT_TMP_FILES=(--filter "P .*.??????")
+
+                install_framework() {
+                  local source="$1"
+                  if [ -L "$source" ]; then
+                    source="$(readlink "$source")"
+                  fi
+
+                  local name
+                  name="$(basename "$source")"
+                  local destination_root="$TARGET_BUILD_DIR"
+                  if [ -n "${FRAMEWORKS_FOLDER_PATH:-}" ]; then
+                    destination_root="$TARGET_BUILD_DIR/$FRAMEWORKS_FOLDER_PATH"
+                  fi
+                  mkdir -p "$destination_root"
+
+                  rsync --delete -av "${RSYNC_PROTECT_TMP_FILES[@]}" \\
+                    --filter "- CVS/" \\
+                    --filter "- .svn/" \\
+                    --filter "- .git/" \\
+                    --filter "- .hg/" \\
+                    --filter "- Headers" \\
+                    --filter "- PrivateHeaders" \\
+                    --filter "- Modules" \\
+                    "$source" "$destination_root"
+
+                  local basename
+                  basename="$(basename -s .framework "$source")"
+                  local binary="$destination_root/$name/$basename"
+                  if ! [ -r "$binary" ]; then
+                    binary="$destination_root/$basename"
+                  elif [ -L "$binary" ]; then
+                    local dirname
+                    dirname="$(dirname "$binary")"
+                    binary="$dirname/$(readlink "$binary")"
+                  fi
+
+                  if [[ "$(file "$binary")" == *"dynamically linked shared library"* ]]; then
+                    strip_invalid_archs "$binary"
+                  fi
+                  code_sign_if_enabled "$destination_root/$name"
+                }
+
+                code_sign_if_enabled() {
+                  if [ -n "${EXPANDED_CODE_SIGN_IDENTITY:-}" ] && [ "${CODE_SIGNING_REQUIRED:-}" != "NO" ] && [ "${CODE_SIGNING_ALLOWED:-}" != "NO" ]; then
+                    local code_sign_cmd="/usr/bin/codesign --force --sign ${EXPANDED_CODE_SIGN_IDENTITY} ${OTHER_CODE_SIGN_FLAGS:-} --preserve-metadata=identifier,entitlements '$1'"
+                    echo "$code_sign_cmd"
+                    eval "$code_sign_cmd"
+                  fi
+                }
+
+                strip_invalid_archs() {
+                  local binary="$1"
+                  local binary_archs
+                  binary_archs="$(lipo -info "$binary" | rev | cut -d ':' -f1 | awk '{$1=$1;print}' | rev)"
+                  local intersected_archs
+                  intersected_archs="$(echo ${ARCHS[@]} ${binary_archs[@]} | tr ' ' '\\n' | sort | uniq -d)"
+                  if [[ -z "$intersected_archs" ]]; then
+                    echo "warning: Preselected framework '$binary' contains architectures ($binary_archs) none of which match the current build architectures ($ARCHS)."
+                    return
+                  fi
+                  local stripped=""
+                  for arch in $binary_archs; do
+                    if ! [[ "${ARCHS}" == *"$arch"* ]]; then
+                      lipo -remove "$arch" -output "$binary" "$binary"
+                      stripped="$stripped $arch"
+                    fi
+                  done
+                  if [[ "$stripped" ]]; then
+                    echo "Stripped $binary of architectures:$stripped"
+                  fi
+                }
+
+                case "$platform_name" in
+                \(cases)
+                esac
+                """
+            ),
+            inputPaths: inputPaths,
+            outputPaths: outputPaths,
+            showEnvVarsInLog: false,
+            basedOnDependencyAnalysis: true,
+            shellPath: "/bin/bash"
+        )
+    }
+
+    private static func apply(
+        _ additions: [(key: String, values: [String])],
+        to settings: Settings?,
+        defaultSettings: DefaultSettings
+    ) -> Settings {
+        let settings = settings ?? Settings(base: [:], configurations: [:], defaultSettings: defaultSettings)
+        return Settings(
+            base: applied(additions, to: settings.base),
+            baseDebug: settings.baseDebug,
+            configurations: settings.configurations.mapValues { configuration in
+                guard let configuration else { return nil }
+                return configuration.with(settings: applied(additions, to: configuration.settings, onlyExistingKeys: true))
+            },
+            defaultSettings: settings.defaultSettings,
+            defaultConfiguration: settings.defaultConfiguration
+        )
+    }
+
+    private static func applied(
+        _ additions: [(key: String, values: [String])],
+        to settings: SettingsDictionary,
+        onlyExistingKeys: Bool = false
+    ) -> SettingsDictionary {
+        var settings = settings
+        for (key, values) in additions where !values.isEmpty {
+            if onlyExistingKeys, settings[key] == nil, settings[Self.rootSettingName(key)] == nil { continue }
+            settings[key] = extended(settings[key], with: values)
+        }
+        return settings
+    }
+
+    private static func extended(_ value: SettingsDictionary.Value?, with values: [String]) -> SettingsDictionary.Value {
+        switch value ?? .array(["$(inherited)"]) {
+        case let .array(existing):
+            return .array((existing + values).uniqued())
+        case let .string(existing):
+            return .array((existing.split(separator: " ").map(String.init) + values).uniqued())
+        }
+    }
+
+    private static func rootSettingName(_ key: String) -> String {
+        key.split(separator: "[").first.map(String.init) ?? key
+    }
+}
+
+private extension Graph {
+    var linkingByXCFrameworkPath: [AbsolutePath: BinaryLinking] {
+        var linkingByPath: [AbsolutePath: BinaryLinking] = [:]
+        for dependency in Set(dependencies.keys).union(dependencies.values.flatMap { $0 }) {
+            if case let .xcframework(xcframework) = dependency {
+                linkingByPath[xcframework.path] = xcframework.linking
+            }
+        }
+        return linkingByPath
+    }
+
+    func removingXCFrameworkDependencies(at paths: Set<AbsolutePath>) -> Graph {
+        var graph = self
+        graph.dependencies = Dictionary(uniqueKeysWithValues: dependencies.compactMap { dependency, dependencyValues in
+            guard !dependency.isXCFramework(at: paths) else { return nil }
+            let filteredDependencies = dependencyValues.filter { !$0.isXCFramework(at: paths) }
+            return (dependency, filteredDependencies)
+        })
+        graph.dependencyConditions = dependencyConditions.filter { edge, _ in
+            !edge.from.isXCFramework(at: paths) && !edge.to.isXCFramework(at: paths)
+        }
+        return graph
+    }
+}
+
+private extension GraphDependency {
+    func isXCFramework(at paths: Set<AbsolutePath>) -> Bool {
+        guard case let .xcframework(xcframework) = self else { return false }
+        return paths.contains(xcframework.path)
+    }
+}

--- a/cli/Tests/TuistKitTests/Mappers/Graph/PreselectedXCFrameworkSlicesGraphMapperTests.swift
+++ b/cli/Tests/TuistKitTests/Mappers/Graph/PreselectedXCFrameworkSlicesGraphMapperTests.swift
@@ -1,0 +1,228 @@
+import FileSystem
+import FileSystemTesting
+import Path
+import Testing
+import TuistCore
+import TuistTesting
+import XcodeGraph
+@testable import TuistKit
+
+struct PreselectedXCFrameworkSlicesGraphMapperTests {
+    private let fileSystem = FileSystem()
+    private let subject = PreselectedXCFrameworkSlicesGraphMapper()
+
+    @Test(.inTemporaryDirectory)
+    func map_preselects_unambiguous_framework_slices_for_each_supported_sdk() async throws {
+        // Given
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let projectPath = temporaryDirectory.appending(component: "Project")
+        let xcframeworkPath = projectPath.parentDirectory.appending(component: "Kit.xcframework")
+
+        try await makeFramework(named: "Kit", in: xcframeworkPath.appending(component: "ios-arm64"))
+        try await makeFramework(named: "Kit", in: xcframeworkPath.appending(component: "ios-arm64_x86_64-simulator"))
+        try await makeFramework(named: "Kit", in: xcframeworkPath.appending(component: "macos-arm64_x86_64"))
+
+        let xcframeworkDependency = GraphDependency.testXCFramework(
+            path: xcframeworkPath,
+            infoPlist: XCFrameworkInfoPlist(libraries: [
+                .test(
+                    identifier: "ios-arm64",
+                    path: try RelativePath(validating: "Kit.framework"),
+                    platform: .iOS
+                ),
+                .test(
+                    identifier: "ios-arm64_x86_64-simulator",
+                    path: try RelativePath(validating: "Kit.framework"),
+                    platform: .iOS,
+                    platformVariant: .simulator
+                ),
+                .test(
+                    identifier: "macos-arm64_x86_64",
+                    path: try RelativePath(validating: "Kit.framework"),
+                    platform: .macOS
+                ),
+            ]),
+            linking: .static
+        )
+
+        let graph = Graph.test(
+            name: "App",
+            path: projectPath,
+            projects: [
+                projectPath: .test(
+                    path: projectPath,
+                    targets: [
+                        .test(
+                            name: "App",
+                            destinations: [.iPhone, .iPad, .mac],
+                            product: .app
+                        ),
+                    ]
+                ),
+            ],
+            dependencies: [
+                .target(name: "App", path: projectPath): [
+                    xcframeworkDependency,
+                ],
+            ]
+        )
+
+        // When
+        let (gotGraph, gotSideEffects, _) = try await subject.map(graph: graph, environment: MapperEnvironment())
+
+        // Then
+        #expect(gotGraph.dependencies[.target(name: "App", path: projectPath)] == [])
+
+        let settings = try #require(gotGraph.projects[projectPath]?.targets["App"]?.settings?.base)
+        #expect(settings["FRAMEWORK_SEARCH_PATHS[sdk=iphoneos*]"] == .array([
+            "$(inherited)",
+            "$(SRCROOT)/Derived/PreselectedXCFrameworkSlices/App/iphoneos",
+        ]))
+        #expect(settings["FRAMEWORK_SEARCH_PATHS[sdk=iphonesimulator*]"] == .array([
+            "$(inherited)",
+            "$(SRCROOT)/Derived/PreselectedXCFrameworkSlices/App/iphonesimulator",
+        ]))
+        #expect(settings["FRAMEWORK_SEARCH_PATHS[sdk=macosx*]"] == .array([
+            "$(inherited)",
+            "$(SRCROOT)/Derived/PreselectedXCFrameworkSlices/App/macosx",
+        ]))
+        #expect(settings["OTHER_LDFLAGS[sdk=macosx*]"] == .array([
+            "$(inherited)",
+            "\"@$(SRCROOT)/Derived/PreselectedXCFrameworkSlices/App/macosx/App-macosx.resp\"",
+        ]))
+
+        let sourceRootPath = try #require(gotGraph.projects[projectPath]?.sourceRootPath)
+
+        #expect(
+            gotSideEffects.contains { sideEffect in
+                guard case let .symbolicLink(descriptor) = sideEffect else { return false }
+                return descriptor.path == sourceRootPath
+                    .appending(components: "Derived", "PreselectedXCFrameworkSlices", "App", "macosx", "Kit.framework") &&
+                    descriptor.destination == xcframeworkPath
+                    .appending(components: "macos-arm64_x86_64", "Kit.framework")
+            }
+        )
+        let macOSFrameworkDirectory = sourceRootPath
+            .appending(components: "Derived", "PreselectedXCFrameworkSlices", "App", "macosx")
+        let expectedResponseFileContents = "-F\(macOSFrameworkDirectory.pathString)\n-framework\nKit\n"
+        #expect(
+            gotSideEffects.contains { sideEffect in
+                guard case let .file(descriptor) = sideEffect else { return false }
+                return descriptor.path == sourceRootPath
+                    .appending(components: "Derived", "PreselectedXCFrameworkSlices", "App", "macosx", "App-macosx.resp") &&
+                    descriptor.contents.flatMap { String(data: $0, encoding: .utf8) } ==
+                    expectedResponseFileContents
+            }
+        )
+    }
+
+    @Test(.inTemporaryDirectory)
+    func map_preselects_dynamic_runtime_xcframeworks_and_embeds_selected_slices() async throws {
+        // Given
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let projectPath = temporaryDirectory.appending(component: "Project")
+        let xcframeworkPath = projectPath.parentDirectory.appending(component: "RuntimeKit.xcframework")
+
+        try await makeFramework(named: "RuntimeKit", in: xcframeworkPath.appending(component: "ios-arm64"))
+        try await makeFramework(named: "RuntimeKit", in: xcframeworkPath.appending(component: "ios-arm64_x86_64-simulator"))
+
+        let xcframeworkDependency = GraphDependency.testXCFramework(
+            path: xcframeworkPath,
+            infoPlist: XCFrameworkInfoPlist(libraries: [
+                .test(
+                    identifier: "ios-arm64",
+                    path: try RelativePath(validating: "RuntimeKit.framework"),
+                    platform: .iOS
+                ),
+                .test(
+                    identifier: "ios-arm64_x86_64-simulator",
+                    path: try RelativePath(validating: "RuntimeKit.framework"),
+                    platform: .iOS,
+                    platformVariant: .simulator
+                ),
+            ]),
+            linking: .dynamic
+        )
+
+        let graph = Graph.test(
+            name: "App",
+            path: projectPath,
+            projects: [
+                projectPath: .test(
+                    path: projectPath,
+                    targets: [
+                        .test(
+                            name: "App",
+                            destinations: [.iPhone],
+                            product: .app
+                        ),
+                    ]
+                ),
+            ],
+            dependencies: [
+                .target(name: "App", path: projectPath): [
+                    xcframeworkDependency,
+                ],
+            ]
+        )
+
+        // When
+        let (gotGraph, gotSideEffects, _) = try await subject.map(graph: graph, environment: MapperEnvironment())
+
+        // Then
+        #expect(gotGraph.dependencies[.target(name: "App", path: projectPath)] == [])
+
+        let settings = try #require(gotGraph.projects[projectPath]?.targets["App"]?.settings?.base)
+        #expect(settings["OTHER_LDFLAGS[sdk=iphoneos*]"] == .array([
+            "$(inherited)",
+            "\"@$(SRCROOT)/Derived/PreselectedXCFrameworkSlices/App/iphoneos/App-iphoneos.resp\"",
+        ]))
+
+        let scripts = try #require(gotGraph.projects[projectPath]?.targets["App"]?.scripts)
+        #expect(scripts.count == 1)
+        let script = try #require(scripts.first)
+        #expect(script.name == "Embed Preselected XCFramework Slices")
+        #expect(script.order == .post)
+        #expect(script.basedOnDependencyAnalysis == true)
+        #expect(script.inputPaths.contains(
+            "$(SRCROOT)/Derived/PreselectedXCFrameworkSlices/App/iphoneos/RuntimeKit.framework"
+        ))
+        #expect(script.inputPaths.contains(
+            "$(SRCROOT)/Derived/PreselectedXCFrameworkSlices/App/iphoneos/RuntimeKit.framework/RuntimeKit"
+        ))
+        #expect(script.inputPaths.contains(
+            "$(SRCROOT)/Derived/PreselectedXCFrameworkSlices/App/iphoneos/RuntimeKit.framework/Info.plist"
+        ))
+        #expect(script.outputPaths == [
+            "${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RuntimeKit.framework",
+        ])
+
+        let embeddedScript = try #require(script.embeddedScript)
+        #expect(embeddedScript.contains("rsync --delete -av"))
+        #expect(embeddedScript.contains("--filter \"- Headers\""))
+        #expect(embeddedScript.contains("--filter \"- PrivateHeaders\""))
+        #expect(embeddedScript.contains("--filter \"- Modules\""))
+        #expect(embeddedScript.contains("strip_invalid_archs"))
+        #expect(embeddedScript.contains("code_sign_if_enabled"))
+        #expect(embeddedScript.contains("${CODE_SIGNING_REQUIRED:-}"))
+        #expect(embeddedScript.contains("${OTHER_CODE_SIGN_FLAGS:-}"))
+        #expect(embeddedScript.contains("iphoneos)"))
+        #expect(embeddedScript.contains("iphonesimulator)"))
+
+        let sourceRootPath = try #require(gotGraph.projects[projectPath]?.sourceRootPath)
+        #expect(
+            gotSideEffects.contains { sideEffect in
+                guard case let .symbolicLink(descriptor) = sideEffect else { return false }
+                return descriptor.path == sourceRootPath
+                    .appending(components: "Derived", "PreselectedXCFrameworkSlices", "App", "iphoneos", "RuntimeKit.framework") &&
+                    descriptor.destination == xcframeworkPath
+                    .appending(components: "ios-arm64", "RuntimeKit.framework")
+            }
+        )
+    }
+
+    private func makeFramework(named name: String, in directory: AbsolutePath) async throws {
+        let frameworkPath = directory.appending(component: "\(name).framework")
+        try await fileSystem.makeDirectory(at: frameworkPath)
+    }
+}


### PR DESCRIPTION
## What changed

This adds a feature-flagged graph mapper that preselects concrete framework slices from cache-provided XCFrameworks before Xcode sees the generated project.

When `TUIST_FEATURE_FLAG_XCFRAMEWORK_SLICE_LINKING=1` is enabled, cached XCFramework dependencies that can be resolved unambiguously are rewritten into SDK-qualified framework inputs:

- creates generated symlinks under `Derived/PreselectedXCFrameworkSlices/<target>/<sdk>` pointing at the selected `.framework` slices
- injects SDK-qualified `FRAMEWORK_SEARCH_PATHS`, `OTHER_CFLAGS`, `OTHER_SWIFT_FLAGS`, and `OTHER_LDFLAGS`
- writes linker response files so the target links concrete frameworks directly
- removes the selected `.xcframework` graph dependencies so Xcode does not run `ProcessXCFramework` for them
- adds an SDK-switching embed phase for selected dynamic runtime frameworks, preserving the important native embed behaviors: filtered copy without `Headers` / `PrivateHeaders` / `Modules`, invalid-architecture stripping, code signing with Xcode's normal signing gates, and script inputs/outputs
- falls back to the current XCFramework path whenever slice selection is ambiguous, unsupported, missing, or non-framework-based

The dynamic path follows the same split that Bazel's Apple rules use for imported dynamic XCFrameworks: select the effective framework library for the target platform/architecture, use that selected binary/framework directory for linking, and separately propagate the selected framework files for bundling.

## Why

The module-cache hot path is already giving Xcode binary artifacts, but Xcode still spends build time resolving `*.xcframework` inputs through `ProcessXCFramework`. In the fully cached `tuist` CLI case, that meant the build still paid per-build XCFramework processing and duplicated link setup even though the slices were already available locally.

This mapper moves that work into generation for the cases where Tuist can select the slice deterministically. The generated project then points Swift, Clang, and the linker at normal framework directories, which is closer to the shape used by Apple-oriented Bazel rules: resolve/cache at module granularity, then present Xcode/toolchain actions with concrete framework slices.

The change is behind a feature flag so the rollout can collect feedback before changing the default project shape.

## Measured impact

On the local `tuist` CLI benchmark with the module cache already warm and universal `arm64+x86_64` output, this PR removes the XCFramework processing work from the build graph:

| Build shape | `ProcessXCFramework` actions | Xcode elapsed | Wall time |
| --- | ---: | ---: | ---: |
| Before this change, no Xcode CAS | 205 | `12.131s` | `13.30s` |
| Slice preselection enabled, no Xcode CAS | 0 | `8.724s` | `9.62s` |
| Slice preselection enabled, warm local Xcode CAS | 0 | `4.150s` | `5.55s` |

The direct improvement from this PR in the no-CAS build shape is `3.407s` Xcode elapsed and `3.68s` wall-clock, roughly 28% faster. The linker bucket also drops from `2.302s` to `1.429s` because the target links directly against the selected framework directories and response file instead of the XCFramework-expanded build products.

When the generated project is paired with a warm local Xcode compilation cache, the floor drops further to Xcode `4.150s` / wall `5.55s`. In that run, `SwiftCompile` falls to `0.080s` through replay cache hits, leaving mostly `Ld` and `SwiftDriver` orchestration as the remaining work.

## Active architecture follow-up

I also benchmarked `ARCHS=arm64` with the same module-cache + warm Xcode compilation-cache setup. It removes one `SwiftDriver`, one `Ld`, and the universal binary step:

- universal `arm64+x86_64`: `real 5.55s`, Xcode `4.150s`
- `arm64` only: `real 5.03s`, Xcode `3.596s`

That is useful signal, but this PR intentionally kicks that can down the road. Changing whether generated command-line builds are universal or active-arch-only is a separate product/build policy decision from resolving XCFramework slices earlier.

## Validation

- `git diff --check`
- `env -u TUIST_ENABLE_CACHING TUIST_EE=1 /tmp/tuist-cli-local-dd/Build/Products/Debug/tuist generate TuistKitTests --no-open --configuration Debug`
- `env -u TUIST_ENABLE_CACHING tuist generate run TuistKit TuistKitTests --no-open --no-binary-cache`
- `env -u TUIST_ENABLE_CACHING xcodebuild test -workspace Tuist.xcworkspace -scheme TuistUnitTests -only-testing:TuistKitTests/PreselectedXCFrameworkSlicesGraphMapperTests -destination 'platform=macOS' -derivedDataPath /tmp/tuist-preselected-test-dd-source CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY= COMPILATION_CACHE_ENABLE_CACHING=NO -quiet`
- CI: [XCFramework Slice Acceptance](https://github.com/tuist/tuist/actions/runs/28866191011) passed with `TUIST_FEATURE_FLAG_XCFRAMEWORK_SLICE_LINKING=1` on a temporary workflow commit. The run completed `Build Acceptance Tests`, `Acceptance Tests (0)`, and `Acceptance Tests (1)` successfully; the temporary workflow file was removed from the PR branch after the run.

Benchmarking performed while developing this change:

- `tuist cache warm tuist --configuration Debug --cache-profile all-possible` confirmed the local module cache was warm with 238 local hits and 0 misses
- flagged generation produced no `.xcframework` references in the generated project and created 205 preselected framework symlinks
- warm local Xcode compilation cache on the flagged universal build reached `real 5.55s` / Xcode `4.150s`, with `SwiftCompile` reduced to `0.080s` through replay cache hits
