### PR TITLE
fix(server): handle concurrent SCIM user creation

### DIFF
--- a/server/config/config.exs
+++ b/server/config/config.exs
@@ -221,7 +221,7 @@ config :tuist, Tuist.Vault, key: {Tuist.Environment, :secret_key_encryption, []}
 config :tuist, TuistWeb.Endpoint,
   adapter: Bandit.PhoenixAdapter,
   render_errors: [
-    formats: [html: TuistWeb.ErrorHTML, json: TuistWeb.ErrorJSON],
+    formats: [html: TuistWeb.ErrorHTML, json: TuistWeb.ErrorJSON, "scim+json": TuistWeb.SCIM.ErrorJSON],
     layout: false
   ],
   pubsub_server: Tuist.PubSub,

--- a/server/lib/tuist/scim.ex
+++ b/server/lib/tuist/scim.ex
@@ -291,7 +291,9 @@ defmodule Tuist.SCIM do
     |> Oban.insert!()
   end
 
-  defp provisionable_user(email) do
+  defp provisionable_user(email, opts \\ []) do
+    retry_after_email_taken = Keyword.get(opts, :retry_after_email_taken, true)
+
     case Accounts.get_user_by_email(email) do
       {:ok, %User{} = user} ->
         {:ok, user, :existing}
@@ -301,8 +303,11 @@ defmodule Tuist.SCIM do
           {:ok, user} ->
             {:ok, user, :created}
 
+          {:error, :email_taken} when retry_after_email_taken ->
+            provisionable_user(email, retry_after_email_taken: false)
+
           {:error, :email_taken} ->
-            provisionable_user_created_concurrently(email)
+            {:error, :email_taken}
 
           {:error, %Ecto.Changeset{} = changeset} ->
             if email_taken?(changeset), do: {:error, :email_taken}, else: {:error, changeset}
@@ -310,13 +315,6 @@ defmodule Tuist.SCIM do
           {:error, reason} ->
             {:error, reason}
         end
-    end
-  end
-
-  defp provisionable_user_created_concurrently(email) do
-    case Accounts.get_user_by_email(email) do
-      {:ok, %User{} = user} -> {:ok, user, :existing}
-      {:error, :not_found} -> {:error, :email_taken}
     end
   end
 

--- a/server/lib/tuist/scim.ex
+++ b/server/lib/tuist/scim.ex
@@ -301,9 +301,22 @@ defmodule Tuist.SCIM do
           {:ok, user} ->
             {:ok, user, :created}
 
-          {:error, changeset} ->
+          {:error, :email_taken} ->
+            provisionable_user_created_concurrently(email)
+
+          {:error, %Ecto.Changeset{} = changeset} ->
             if email_taken?(changeset), do: {:error, :email_taken}, else: {:error, changeset}
+
+          {:error, reason} ->
+            {:error, reason}
         end
+    end
+  end
+
+  defp provisionable_user_created_concurrently(email) do
+    case Accounts.get_user_by_email(email) do
+      {:ok, %User{} = user} -> {:ok, user, :existing}
+      {:error, :not_found} -> {:error, :email_taken}
     end
   end
 

--- a/server/lib/tuist_web/controllers/scim/error_json.ex
+++ b/server/lib/tuist_web/controllers/scim/error_json.ex
@@ -1,0 +1,31 @@
+defmodule TuistWeb.SCIM.ErrorJSON do
+  @moduledoc """
+  Renders Phoenix error responses as SCIM 2.0 Error resources.
+  """
+
+  alias Plug.Parsers
+  alias Tuist.SCIM.Resource
+
+  def render(template, assigns) do
+    status = Map.get(assigns, :status) || status_from_template(template)
+    {detail, scim_type} = error_detail(status, Map.get(assigns, :reason))
+
+    status
+    |> Resource.render_error(detail, scim_type)
+    |> JSON.encode!()
+  end
+
+  defp status_from_template(template) do
+    template
+    |> String.split(".")
+    |> hd()
+    |> String.to_integer()
+  rescue
+    _ -> 500
+  end
+
+  defp error_detail(400, %Parsers.ParseError{}), do: {"Invalid JSON payload", "invalidSyntax"}
+  defp error_detail(400, %Parsers.BadEncodingError{}), do: {"Invalid JSON payload", "invalidSyntax"}
+  defp error_detail(404, _reason), do: {"SCIM endpoint not found", nil}
+  defp error_detail(status, _reason), do: {Plug.Conn.Status.reason_phrase(status), nil}
+end

--- a/server/lib/tuist_web/controllers/scim/error_json.ex
+++ b/server/lib/tuist_web/controllers/scim/error_json.ex
@@ -6,22 +6,12 @@ defmodule TuistWeb.SCIM.ErrorJSON do
   alias Plug.Parsers
   alias Tuist.SCIM.Resource
 
-  def render(template, assigns) do
-    status = Map.get(assigns, :status) || status_from_template(template)
+  def render(_template, %{status: status} = assigns) when is_integer(status) do
     {detail, scim_type} = error_detail(status, Map.get(assigns, :reason))
 
     status
     |> Resource.render_error(detail, scim_type)
     |> JSON.encode!()
-  end
-
-  defp status_from_template(template) do
-    template
-    |> String.split(".")
-    |> hd()
-    |> String.to_integer()
-  rescue
-    _ -> 500
   end
 
   defp error_detail(400, %Parsers.ParseError{}), do: {"Invalid JSON payload", "invalidSyntax"}

--- a/server/lib/tuist_web/endpoint.ex
+++ b/server/lib/tuist_web/endpoint.ex
@@ -62,6 +62,7 @@ defmodule TuistWeb.Endpoint do
   plug TuistCommon.OtelRequestIdPlug
   plug Plug.Telemetry, event_prefix: [:phoenix, :endpoint]
   plug TuistWeb.Plugs.RequestKindPlug
+  plug TuistWeb.Plugs.SCIMErrorFormatPlug
   plug Sentry.PlugContext
   plug TuistWeb.Plugs.CloseConnectionOnErrorPlug
 

--- a/server/lib/tuist_web/plugs/scim_error_format_plug.ex
+++ b/server/lib/tuist_web/plugs/scim_error_format_plug.ex
@@ -1,0 +1,27 @@
+defmodule TuistWeb.Plugs.SCIMErrorFormatPlug do
+  @moduledoc """
+  Forces Phoenix error rendering to use the SCIM media type for SCIM paths.
+  """
+
+  @behaviour Plug
+
+  import Plug.Conn
+
+  @impl true
+  def init(opts), do: opts
+
+  @impl true
+  def call(%Plug.Conn{path_info: ["scim", "v2" | _]} = conn, _opts) do
+    put_private(conn, :phoenix_format, "scim+json")
+  end
+
+  def call(%Plug.Conn{request_path: "/scim/v2"} = conn, _opts) do
+    put_private(conn, :phoenix_format, "scim+json")
+  end
+
+  def call(%Plug.Conn{request_path: "/scim/v2/" <> _rest} = conn, _opts) do
+    put_private(conn, :phoenix_format, "scim+json")
+  end
+
+  def call(%Plug.Conn{} = conn, _opts), do: conn
+end

--- a/server/test/tuist/scim_test.exs
+++ b/server/test/tuist/scim_test.exs
@@ -1,5 +1,6 @@
 defmodule Tuist.SCIMTest do
   use TuistTestSupport.Cases.DataCase, async: true
+  use Mimic
 
   import TuistTestSupport.Fixtures.AccountsFixtures
 
@@ -7,6 +8,8 @@ defmodule Tuist.SCIMTest do
   alias Tuist.Accounts.AccountToken
   alias Tuist.SCIM
   alias Tuist.SCIM.Workers.AttachmentNotifierWorker
+
+  setup :verify_on_exit!
 
   describe "tokens" do
     test "create_token/2 issues a usable bearer and persists only its hash" do
@@ -124,6 +127,28 @@ defmodule Tuist.SCIMTest do
         worker: AttachmentNotifierWorker,
         args: %{"user_id" => existing.id, "organization_id" => org.id}
       )
+    end
+
+    test "provision_user/2 attaches a user created concurrently after the first lookup", %{organization: org} do
+      email = "race@example.com"
+      existing = user_fixture(email: email)
+      lookup_counter = start_supervised!({Agent, fn -> 0 end})
+
+      expect(Accounts, :get_user_by_email, 2, fn ^email ->
+        Agent.get_and_update(lookup_counter, fn
+          0 -> {{:error, :not_found}, 1}
+          count -> {{:ok, existing}, count + 1}
+        end)
+      end)
+
+      expect(Accounts, :create_user, fn ^email, opts ->
+        assert Keyword.has_key?(opts, :confirmed_at)
+        {:error, :email_taken}
+      end)
+
+      assert {:ok, user} = SCIM.provision_user(org, %{user_name: email})
+      assert user.id == existing.id
+      assert Accounts.belongs_to_organization?(user, org)
     end
 
     test "provision_user/2 does not enqueue a notification when a brand-new user is created", %{organization: org} do

--- a/server/test/tuist/scim_test.exs
+++ b/server/test/tuist/scim_test.exs
@@ -129,7 +129,9 @@ defmodule Tuist.SCIMTest do
       )
     end
 
-    test "provision_user/2 attaches a user created concurrently after the first lookup", %{organization: org} do
+    test "provision_user/2 attaches a user when creation reports the email was taken after lookup", %{
+      organization: org
+    } do
       email = "race@example.com"
       existing = user_fixture(email: email)
       lookup_counter = start_supervised!({Agent, fn -> 0 end})

--- a/server/test/tuist_web/controllers/scim/error_json_test.exs
+++ b/server/test/tuist_web/controllers/scim/error_json_test.exs
@@ -1,0 +1,27 @@
+defmodule TuistWeb.SCIM.ErrorJSONTest do
+  use ExUnit.Case, async: true
+
+  alias TuistWeb.SCIM.ErrorJSON
+
+  test "renders SCIM error resources" do
+    assert "500.scim+json" |> ErrorJSON.render(%{status: 500}) |> JSON.decode!() == %{
+             "schemas" => ["urn:ietf:params:scim:api:messages:2.0:Error"],
+             "status" => "500",
+             "detail" => "Internal Server Error"
+           }
+  end
+
+  test "renders malformed JSON as invalid syntax" do
+    assert "400.scim+json"
+           |> ErrorJSON.render(%{
+             status: 400,
+             reason: %Plug.Parsers.ParseError{exception: %JSON.DecodeError{}}
+           })
+           |> JSON.decode!() == %{
+             "schemas" => ["urn:ietf:params:scim:api:messages:2.0:Error"],
+             "status" => "400",
+             "detail" => "Invalid JSON payload",
+             "scimType" => "invalidSyntax"
+           }
+  end
+end

--- a/server/test/tuist_web/controllers/scim/error_rendering_test.exs
+++ b/server/test/tuist_web/controllers/scim/error_rendering_test.exs
@@ -1,0 +1,43 @@
+defmodule TuistWeb.SCIM.ErrorRenderingTest do
+  use ExUnit.Case, async: true
+
+  import Phoenix.ConnTest
+  import Plug.Conn
+
+  @endpoint TuistWeb.Endpoint
+
+  test "returns a SCIM error resource for unmatched SCIM routes" do
+    conn = get(build_conn(), "/scim/v2/Unknown")
+
+    assert [content_type] = get_resp_header(conn, "content-type")
+    assert content_type =~ "application/scim+json"
+
+    assert json_response(conn, 404) == %{
+             "schemas" => ["urn:ietf:params:scim:api:messages:2.0:Error"],
+             "status" => "404",
+             "detail" => "SCIM endpoint not found"
+           }
+  end
+
+  test "returns a SCIM error resource for malformed JSON" do
+    conn =
+      build_conn()
+      |> put_req_header("accept", "application/scim+json")
+      |> put_req_header("content-type", "application/scim+json")
+
+    {400, headers, body} =
+      assert_error_sent 400, fn ->
+        post(conn, "/scim/v2/Users", "{")
+      end
+
+    assert {"content-type", content_type} = List.keyfind(headers, "content-type", 0)
+    assert content_type =~ "application/scim+json"
+
+    assert JSON.decode!(body) == %{
+             "schemas" => ["urn:ietf:params:scim:api:messages:2.0:Error"],
+             "status" => "400",
+             "detail" => "Invalid JSON payload",
+             "scimType" => "invalidSyntax"
+           }
+  end
+end


### PR DESCRIPTION
## What changed

- Handles `{:error, :email_taken}` from `Accounts.create_user/2` while provisioning a SCIM user.
- Re-fetches the user after that conflict and treats it as an existing user when the account was created concurrently.
- Adds a SCIM-specific Phoenix error renderer for the `application/scim+json` media type.
- Tags `/scim/v2` requests early in the endpoint so fallback error rendering uses a SCIM Error resource.
- Adds regression coverage for the provisioning race and for SCIM-shaped fallback error responses.

## Why

Okta SCIM provisioning can race with SSO account creation when SSO and SCIM are configured as separate Okta apps. In that flow, the SCIM request can check for a user, find none, then lose the create race because the SSO path created the user first.

The reported failure surfaced to Okta as `Bad Gateway` plus a non-JSON body that started with plain text. Okta then failed again while trying to parse the remote error response as JSON. Even when the root race is fixed, SCIM endpoints should return parseable SCIM error resources for fallback failures so the identity provider receives something it understands.

## Root cause

`SCIM.provisionable_user/1` expected `Accounts.create_user/2` failures to be changesets. `Accounts.create_user/2` normalizes unique email conflicts to `{:error, :email_taken}`, so the SCIM code passed an atom into `email_taken?/1`, which only accepts an `Ecto.Changeset`. That could raise before the SCIM controller had a chance to return a structured SCIM response. A retry then worked because the user already existed.

Phoenix also only had `html` and `json` fallback error renderers configured globally. Known SCIM controller errors already used `send_scim_error/4`, but exceptions, unmatched SCIM routes, and parser-level failures could bypass those helpers and fall back to a non-SCIM response shape.

## Approach

The provisioning fix keeps the existing SCIM behavior but makes the create path race-tolerant:

- If user creation succeeds, continue with the newly created user.
- If user creation returns `:email_taken`, re-read by email.
- If the re-read finds a user, attach that existing user to the organization.
- If the re-read still cannot find a user, preserve the existing `:email_taken` error path.
- If another non-changeset error appears, return it instead of crashing through the changeset-only helper.

The response-shape fix adds `TuistWeb.SCIM.ErrorJSON`, configured for `scim+json`, and a narrow endpoint plug that marks `/scim/v2` requests with the SCIM format before later fallback error rendering. That keeps ordinary web/API error rendering unchanged while ensuring SCIM fallbacks produce bodies like:

```json
{
  "schemas": ["urn:ietf:params:scim:api:messages:2.0:Error"],
  "status": "500",
  "detail": "Internal Server Error"
}
```

Malformed JSON requests that negotiate `application/scim+json` are returned as `400` with `scimType: invalidSyntax`.

## Alternatives considered

- Keep the separate Okta SSO and SCIM apps: still a valid operational setup, especially because current Okta custom OIDC integrations do not expose SCIM provisioning in the same app. This PR makes that setup reliable by handling the expected race and returning SCIM-shaped fallback errors.
- Move to a single Okta app through SAML + SCIM: possible if Tuist adds SAML SSO support. Okta custom SAML apps can enable SCIM provisioning in the same integration, but that is a larger product surface area than this bug fix.
- Submit a combined Okta Integration Network app: a better long-term distribution path for a polished OIDC/SAML + SCIM app, but it requires Okta review and does not remove the need for server-side race handling and SCIM error responses.
- Use a database upsert or transaction around lookup/create/attach: heavier than necessary here and would require touching account creation semantics shared outside SCIM. Re-reading on `:email_taken` is narrower and matches the existing `provisionable_user/1` control flow.
- Catch the exception only at the controller boundary: would hide this specific crash but still fail the first provisioning attempt, and it would not cover parser/no-route fallback errors.

## Impact

SCIM user creation becomes idempotent across the common SSO/provisioning race. First-attempt provisioning should attach the account that was just created by the SSO path instead of returning a transient gateway-style failure.

When a SCIM fallback error does occur, the response is now parseable as a SCIM Error resource with `application/scim+json`, so Okta should report the actual status/detail instead of failing to parse a plain-text upstream error.

## Validation

- `git diff --check HEAD~1..HEAD` for the SCIM error-rendering commit.
- `mix run --no-start -e 'Mix.Tasks.Test.run(["test/tuist_web/controllers/scim/error_json_test.exs", "test/tuist_web/controllers/scim/error_rendering_test.exs"])'` passed with `4 tests, 0 failures`.
- Earlier targeted SCIM controller/context validation passed with `44 tests, 0 failures` after the race fix.
- A later full targeted SCIM rerun could not complete in this worktree because ClickHouse is unavailable locally (`Mint.TransportError connection refused` / `Tuist.IngestRepo` queue timeout).