### PR TITLE
fix(cli): handle normalized module cache bundle artifacts

### DIFF
--- a/cli/Tests/TuistCacheEETests/Storage/CacheLocalStorageTests.swift
+++ b/cli/Tests/TuistCacheEETests/Storage/CacheLocalStorageTests.swift
@@ -289,6 +289,43 @@ struct CacheLocalStorageTests {
     }
 
     @Test(.inTemporaryDirectory)
+    func fetch_whenBundleProductNameReplacesDashWithUnderscore() async throws {
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+
+        let hash = "123"
+        let cacheDirectory = temporaryDirectory.appending(component: "cache")
+        try await fileSystem.makeDirectory(at: cacheDirectory)
+
+        let cacheDirectoriesProvider = MockCacheDirectoriesProviding()
+        given(cacheDirectoriesProvider)
+            .cacheDirectory(for: .value(.binaries))
+            .willReturn(cacheDirectory)
+
+        let hashDirectory = cacheDirectory.appending(component: hash)
+        let artifactPath = hashDirectory.appending(component: "Dash_NamedBundle.bundle")
+        try await fileSystem.makeDirectory(at: artifactPath)
+
+        let artifactSigner = MockArtifactSigning()
+        given(artifactSigner).isValid(.value(artifactPath)).willReturn(true)
+
+        let subject = CacheLocalStorage(
+            cacheDirectoriesProvider: cacheDirectoriesProvider,
+            artifactSigner: artifactSigner,
+            fileSystem: fileSystem
+        )
+
+        let got = try await subject.fetch(
+            Set([.init(name: "Dash-NamedBundle", hash: hash)]), cacheCategory: .binaries
+        )
+
+        #expect(got.count == 1)
+        let artifact = try #require(got.first)
+        #expect(artifact.key.hash == hash)
+        #expect(artifact.key.name == "Dash-NamedBundle")
+        #expect(artifact.value == artifactPath)
+    }
+
+    @Test(.inTemporaryDirectory)
     func fetch_whenMacroExistsWithInvalidSignature() async throws {
         let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
 

--- a/cli/Tests/TuistCacheEETests/Storage/ModuleCacheRemoteStorageTests.swift
+++ b/cli/Tests/TuistCacheEETests/Storage/ModuleCacheRemoteStorageTests.swift
@@ -126,6 +126,39 @@ struct ModuleCacheRemoteStorageTests {
         #expect(try artifactSigner.isValid(path) == true)
     }
 
+    @Test(.inTemporaryDirectory) func fetch_when_bundle_product_name_replaces_dash_with_underscore() async throws {
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let bundlePath = temporaryDirectory.appending(component: "Dash_NamedBundle.bundle")
+        try await fileSystem.makeDirectory(at: bundlePath)
+        try await fileSystem.touch(bundlePath.appending(component: "Info.plist"))
+        let zipPath = try await makeArchive(paths: [bundlePath], name: "test")
+        let zipData = try Data(contentsOf: zipPath.url)
+
+        given(downloadModuleCacheService)
+            .downloadModuleCacheArtifact(
+                accountHandle: .value("tuist"),
+                projectHandle: .value("tuist"),
+                hash: .value("hash"),
+                name: .value("Dash-NamedBundle.zip"),
+                cacheCategory: .value("builds"),
+                serverURL: .value(Constants.URLs.production),
+                authenticationURL: .value(Constants.URLs.production),
+                serverAuthenticationController: .any
+            )
+            .willReturn(zipData)
+
+        let got = try await subject.fetch(
+            Set([.init(name: "Dash-NamedBundle", hash: "hash")]),
+            cacheCategory: .binaries
+        )
+
+        let path = try #require(
+            got[.test(name: "Dash-NamedBundle", hash: "hash", source: .remote, cacheCategory: .binaries)]
+        )
+        #expect(path.basename == "Dash_NamedBundle.bundle")
+        #expect(try artifactSigner.isValid(path) == true)
+    }
+
     @Test(.inTemporaryDirectory) func fetch_when_downloaded_archive_does_not_contain_artifact_returns_empty() async throws {
         let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
         let frameworkPath = temporaryDirectory.appending(component: "Other.framework")


### PR DESCRIPTION
## What changed
- Updated the TuistCacheEE submodule to a version that handles normalized bundle artifact names when fetching cache artifacts.
- Added CLI regression coverage for a dashed cache item name resolving to an underscored `.bundle` product name.
- Kept the existing framework, xcframework, bundle, and macro cache lookup behavior, while preserving the single-artifact fallback for bundles and macros.

Supporting submodule PR: https://github.com/tuist/TuistCacheEE/pull/70

## Why
Focused generation with `--binary-cache` can download first-party module cache artifacts successfully and then fail while unpacking or resolving the downloaded artifact. The reported crash surfaced during `ModuleCacheRemoteStorage.unzip(item:data:cacheCategory:)` after a successful HTTP 200 download, so the fetch path had to be made resilient to the artifact layout produced by first-party resource bundle products.

## Root cause
The unzip flow moved top-level archive contents into `<cache>/<hash>/...`, but it only ensured the cache root existed before moving artifacts. It also signed paths discovered later from the hash directory. That left the flow sensitive to whether the hash directory already existed.

Separately, artifact lookup expected the product basename to match the cache item name exactly. First-party resource bundle products can use an underscored product name even when the cache item and zip name are dashed, for example `Dash-NamedBundle.zip` containing `Dash_NamedBundle.bundle`. The exact-name lookup missed that valid artifact shape.

## Approach
- Ensure the hash destination directory exists idempotently before moving extracted archive contents.
- Track the actual destination paths moved or reused during unzip and sign those paths plus the hash directory.
- Resolve artifacts by checking both the original item name and a dash-to-underscore normalized candidate.
- Limit the single top-level artifact fallback to `.bundle` and `.macro`, where product names are known to differ from target/cache item names, instead of accepting arbitrary single artifacts.

## Impact
This makes first-party resource bundle artifacts consumable from the module cache when the product name uses Swift/Xcode normalization, without broadening framework matching in a way that could accidentally return the wrong binary.

## Validation
- `mise run cli:lint --fix`
- `tuist install`
- `tuist generate tuist TuistCacheEE TuistCacheEETests ProjectDescription --no-open`
- `xcodebuild test -workspace Tuist.xcworkspace -scheme TuistCacheEEUnitTests -only-testing TuistCacheEETests/ModuleCacheRemoteStorageTests -only-testing TuistCacheEETests/CacheLocalStorageTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" COMPILATION_CACHE_ENABLE_CACHING=NO`

The focused Xcode test run passed 26 tests across the two cache storage suites.
