### PR TITLE
fix(infra): use Barman plugin backup metrics in CNPG dashboard

### DIFF
--- a/infra/grafana-dashboards/postgresql-cnpg.json
+++ b/infra/grafana-dashboards/postgresql-cnpg.json
@@ -411,7 +411,7 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "time() - max(cnpg_collector_last_available_backup_timestamp{namespace=~\"$namespace\", cnpg_cluster=~\"$cnpg_cluster\", pod=~\"$pod\"})",
+            "expr": "time() - max(barman_cloud_cloudnative_pg_io_last_available_backup_timestamp{namespace=~\"$namespace\", cnpg_cluster=~\"$cnpg_cluster\", pod=~\"$pod\"})",
             "instant": true,
             "range": false,
             "refId": "A"
@@ -2029,7 +2029,7 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "1000 * max(cnpg_collector_last_available_backup_timestamp{namespace=~\"$namespace\", cnpg_cluster=~\"$cnpg_cluster\", pod=~\"$pod\"})",
+            "expr": "1000 * max(barman_cloud_cloudnative_pg_io_last_available_backup_timestamp{namespace=~\"$namespace\", cnpg_cluster=~\"$cnpg_cluster\", pod=~\"$pod\"})",
             "legendFormat": "last available backup",
             "range": true,
             "refId": "A"
@@ -2037,7 +2037,7 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "1000 * max(cnpg_collector_first_recoverability_point{namespace=~\"$namespace\", cnpg_cluster=~\"$cnpg_cluster\", pod=~\"$pod\"})",
+            "expr": "1000 * max(barman_cloud_cloudnative_pg_io_first_recoverability_point{namespace=~\"$namespace\", cnpg_cluster=~\"$cnpg_cluster\", pod=~\"$pod\"})",
             "legendFormat": "first recoverability point",
             "range": true,
             "refId": "B"
@@ -2045,7 +2045,7 @@
           {
             "datasource": "$datasource",
             "editorMode": "code",
-            "expr": "1000 * max(cnpg_collector_last_failed_backup_timestamp{namespace=~\"$namespace\", cnpg_cluster=~\"$cnpg_cluster\", pod=~\"$pod\"})",
+            "expr": "1000 * max(barman_cloud_cloudnative_pg_io_last_failed_backup_timestamp{namespace=~\"$namespace\", cnpg_cluster=~\"$cnpg_cluster\", pod=~\"$pod\"})",
             "legendFormat": "last failed backup",
             "range": true,
             "refId": "C"


### PR DESCRIPTION
## What changed

- Updated the CNPG Grafana dashboard backup age panel to read `barman_cloud_cloudnative_pg_io_last_available_backup_timestamp`.
- Updated the backup timeline panel to use the Barman Cloud Plugin timestamp metrics for last available backup, first recoverability point, and last failed backup.

## Why

The managed CNPG clusters have been migrated from the in-tree `barmanObjectStore` path to the Barman Cloud Plugin. The old `cnpg_collector_*` backup timestamp metrics no longer track plugin backups, so dashboard panels based on those series can show stale backup ages even while plugin backups are healthy.

This surfaced as `CNPG Backup Age Too Old` alerts for staging, canary, and production. Live read-only checks showed plugin backups completing today and WAL archiving actively running, so the alert was reading the old metric family rather than reflecting missing backups.

## Root cause

The plugin migration updated the backup implementation, but the Git-synced CNPG dashboard still pointed backup freshness panels at the in-core CNPG collector metrics. The Barman Cloud Plugin exposes the replacement metrics under the `barman_cloud_cloudnative_pg_io_*` prefix.

## Impact

The dashboard backup freshness and timeline panels will reflect the plugin-backed backup state instead of the stale in-tree collector state. The live Grafana alert rule appears to be configured outside this repository and should be updated separately to use the same metric family.

## Validation

- Parsed `infra/grafana-dashboards/postgresql-cnpg.json` with `/usr/bin/python3 -m json.tool`.
- Ran `git diff --check`.
- Confirmed live plugin evidence via read-only Kubernetes logs:
  - staging backup completed at `2026-07-07T03:00:19Z`
  - canary backup completed at `2026-07-07T03:03:42Z`
  - production backup completed at `2026-07-07T03:37:51Z`
  - production and staging WAL archiving were active during the investigation.