### PR TITLE
fix(server): count test case pages with FINAL

### DIFF
--- a/server/lib/tuist/tests.ex
+++ b/server/lib/tuist/tests.ex
@@ -2012,7 +2012,17 @@ defmodule Tuist.Tests do
           apply_active_window(base_query, is_ci)
       end
 
-    Tuist.ClickHouseFlop.validate_and_run!(base_query, attrs, for: TestCase)
+    flop = Tuist.ClickHouseFlop.validate!(attrs, for: TestCase)
+    total_count = test_cases_count(base_query, flop)
+
+    Tuist.ClickHouseFlop.run(base_query, flop, for: TestCase, count: total_count)
+  end
+
+  defp test_cases_count(query, flop) do
+    query
+    |> Tuist.ClickHouseFlop.filter(flop, for: TestCase)
+    |> select([test_case], count(test_case.id))
+    |> ClickHouseRepo.one()
   end
 
   defp quarantine_filter?(filters) do

--- a/server/test/tuist/tests_test.exs
+++ b/server/test/tuist/tests_test.exs
@@ -2870,6 +2870,48 @@ defmodule Tuist.TestsTest do
       assert meta.total_pages == 2
     end
 
+    test "reports skipped test case pagination metadata past the first page" do
+      # Given
+      project = ProjectsFixtures.project_fixture()
+      ran_at = NaiveDateTime.utc_now()
+
+      test_cases =
+        for index <- 1..501 do
+          RunsFixtures.test_case_fixture(
+            project_id: project.id,
+            name: "skippedTest#{index}",
+            state: "skipped",
+            last_ran_at: ran_at,
+            inserted_at: ran_at
+          )
+        end
+
+      IngestRepo.insert_all(
+        TestCase,
+        Enum.map(test_cases, &(&1 |> Map.from_struct() |> Map.delete(:__meta__)))
+      )
+
+      attrs = %{
+        filters: [%{field: :state, op: :==, value: "skipped"}],
+        order_by: [:last_ran_at, :id],
+        order_directions: [:desc, :asc],
+        page_size: 500
+      }
+
+      # When
+      {page1, meta1} = Tests.list_test_cases(project.id, Map.put(attrs, :page, 1))
+      {page2, meta2} = Tests.list_test_cases(project.id, Map.put(attrs, :page, 2))
+
+      # Then
+      assert length(page1) == 500
+      assert length(page2) == 1
+      assert meta1.total_count == 501
+      assert meta1.total_pages == 2
+      assert meta1.has_next_page?
+      refute meta2.has_next_page?
+      assert meta2.has_previous_page?
+    end
+
     test "supports sorting by last_duration" do
       # Given
       project = ProjectsFixtures.project_fixture()


### PR DESCRIPTION
## What changed

`Tests.list_test_cases/3` now validates the Flop params once, computes `total_count` with an explicit filtered `SELECT count(id)` over the same `test_cases FINAL` base query, and passes that integer back into `Flop.run/3` through the `count:` option.

This keeps the existing page-based API response and metadata shape, but avoids letting Flop's internal count path decide how to aggregate the ClickHouse query.

I also added a regression test that creates 501 skipped test cases and verifies page size 500 still reports `total_count: 501`, `total_pages: 2`, and `has_next_page?: true` on the first page.

## Why

The CLI fetches skipped and muted test cases page by page. If the API reports `has_next_page?: false` after page 1, the CLI stops fetching and the effective category cap is 500 tests.

The list query already reads from `test_cases FINAL`, which is required because the table is a `ReplacingMergeTree` and state changes are represented as new inserted rows. The risky part was the pagination count: `ClickHouseFlop.validate_and_run!/3` delegated count metadata to Flop's automatic aggregate path. If that aggregate path does not preserve `FINAL` exactly as the data query does, pagination metadata can disagree with the rows the endpoint is actually able to return.

## Approach

The chosen fix keeps `FINAL` for now. A read-only production measurement against the affected shape showed the `FINAL` page/count queries are project-scoped and currently comfortably fast: tens to low hundreds of milliseconds server-side for the relevant project slice. Cursor pagination and an `argMax`-deduped query remain reasonable future optimizations, but they are larger API/query-shape changes than needed for this bug.

Passing a precomputed `count:` into Flop lets us preserve Flop's validation, ordering, pagination, and metadata construction while bypassing only the automatic aggregate count path.

## Validation

- `MIX_ENV=test mix compile`
- `mix format --check-formatted lib/tuist/tests.ex test/tuist/tests_test.exs`
- Direct ClickHouse-backed behavior check with `MIX_ENV=test mix run -e ...`: inserted 501 skipped `test_cases`, then verified page 1 returned 500 rows, page 2 returned 1 row, `total_count` was 501, `total_pages` was 2, and `has_next_page?` was true on page 1.
- Attempted `mix test test/tuist/tests_test.exs:2873 --trace`, but this local worktree is blocked before the test by a stale test DB backfill migration that expects the old Postgres `bundles` table.