### PR TITLE
fix(infra): make cache nginx sidecar tunable for uploads

### DIFF
--- a/infra/helm/tuist/README.md
+++ b/infra/helm/tuist/README.md
@@ -105,6 +105,8 @@ Some cluster-specific fixes are intentionally opt-in:
 
 - `cache.podSecurityContext` is empty by default. Set `fsGroup` only if your storage class needs it.
 - `cache.nginx.clientMaxBodySize` defaults to `10m`, matching the cache application's module part size limit. Raise it only when the application limit is raised too.
+- `cache.nginx.resources` is separate from `cache.resources` because the nginx sidecar is a distinct container. Set it explicitly in clusters with strict default LimitRanger policies.
+- `cache.nginx.proxyConnectTimeout`, `cache.nginx.proxyReadTimeout`, and `cache.nginx.proxySendTimeout` default to `60s`. Increase them for slower links or larger uploads.
 - `clickhouse.embedded.service.nativePort` defaults to ClickHouse's standard `9000` service port and can be overridden for mesh or port-allocation conflicts.
 - `clickhouse.external.pingUrl` lets the migration job wait for an external ClickHouse instance through a dedicated `/ping` URL when `clickhouse.external.url` includes a database path.
 
@@ -124,6 +126,15 @@ Embedded compatibility override example:
 cache:
   nginx:
     clientMaxBodySize: 10m
+    proxyReadTimeout: 300s
+    proxySendTimeout: 300s
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        cpu: 1
+        memory: 512Mi
   podSecurityContext:
     fsGroup: 990
 

--- a/infra/helm/tuist/templates/cache-deployment.yaml
+++ b/infra/helm/tuist/templates/cache-deployment.yaml
@@ -142,6 +142,8 @@ spec:
               port: http
             initialDelaySeconds: 20
             periodSeconds: 20
+          resources:
+            {{- toYaml .Values.cache.nginx.resources | nindent 12 }}
         {{- end }}
       volumes:
         - name: storage

--- a/infra/helm/tuist/templates/cache-nginx-configmap.yaml
+++ b/infra/helm/tuist/templates/cache-nginx-configmap.yaml
@@ -20,6 +20,9 @@ data:
       server {
         listen 80;
         client_max_body_size {{ .Values.cache.nginx.clientMaxBodySize }};
+        proxy_connect_timeout {{ .Values.cache.nginx.proxyConnectTimeout }};
+        proxy_read_timeout {{ .Values.cache.nginx.proxyReadTimeout }};
+        proxy_send_timeout {{ .Values.cache.nginx.proxySendTimeout }};
 
         location /up {
           proxy_pass http://cache_upstream;

--- a/infra/helm/tuist/values.yaml
+++ b/infra/helm/tuist/values.yaml
@@ -1497,6 +1497,15 @@ cache:
     enabled: true
     # Keep this aligned with the cache application's module part size limit.
     clientMaxBodySize: "10m"
+    # Explicit upstream timeouts for upload/download paths. Defaults mirror
+    # NGINX defaults; override in values-managed-<env>.yaml for slower links
+    # or larger payloads.
+    proxyConnectTimeout: "60s"
+    proxyReadTimeout: "60s"
+    proxySendTimeout: "60s"
+    # Sidecar resources are separate from cache.resources because NGINX is a
+    # distinct container in the same pod.
+    resources: {}
     image:
       repository: nginx
       tag: "1.29-alpine"


### PR DESCRIPTION
## Summary
- add `cache.nginx.resources` to chart values and wire it into the cache Deployment so nginx sidecar CPU/memory can be tuned independently from the cache app container
- add explicit nginx timeout knobs: `cache.nginx.proxyConnectTimeout`, `cache.nginx.proxyReadTimeout`, and `cache.nginx.proxySendTimeout`
- wire timeout values into `cache-nginx-configmap` and document new knobs in the Helm chart README with an upload-oriented example

## Why
In environments with strict default LimitRanger policies, the nginx sidecar can inherit very low defaults and become the bottleneck for upload traffic (high throttling and OOM restarts) even when `cache.resources` is high. These knobs make nginx tuning explicit without forcing operators to disable nginx.

## Test plan
- [x] `helm lint infra/helm/tuist`
- [x] `helm template test infra/helm/tuist --set cache.nginx.enabled=true --set cache.nginx.resources.requests.cpu=100m --set cache.nginx.resources.requests.memory=128Mi --set cache.nginx.resources.limits.cpu=1 --set cache.nginx.resources.limits.memory=512Mi --set cache.nginx.proxyReadTimeout=300s --set cache.nginx.proxySendTimeout=300s`

Made with [Cursor](https://cursor.com)