### PR TITLE
fix(server): scope shard timing queries

### DIFF
--- a/server/lib/tuist/shards.ex
+++ b/server/lib/tuist/shards.ex
@@ -30,8 +30,8 @@ defmodule Tuist.Shards do
     granularity = Map.get(params, :granularity, "module")
     reference = Map.fetch!(params, :reference)
 
-    timing_data = fetch_timing_data(project, granularity)
-    units = resolve_units(project, params, granularity, timing_data)
+    units = resolve_units(project, params, granularity)
+    timing_data = fetch_timing_data(project, granularity, units)
     units_with_durations = assign_durations(units, timing_data, granularity)
 
     shard_count =
@@ -388,9 +388,9 @@ defmodule Tuist.Shards do
     )
   end
 
-  defp resolve_units(_project, params, "module", _timing_data), do: params_modules(params)
+  defp resolve_units(_project, params, "module"), do: params_modules(params)
 
-  defp resolve_units(project, params, "suite", _timing_data) do
+  defp resolve_units(project, params, "suite") do
     case Map.get(params, :test_suites) do
       [_ | _] = suites ->
         suites
@@ -509,38 +509,59 @@ defmodule Tuist.Shards do
     end
   end
 
-  defp fetch_timing_data(project, "module") do
+  defp fetch_timing_data(_project, _granularity, []), do: %{}
+
+  defp fetch_timing_data(project, "module", modules) do
     cutoff = DateTime.add(DateTime.utc_now(), -@timing_lookback_days, :day)
 
     from(mr in TestModuleRun,
       where: mr.project_id == ^project.id,
       where: mr.is_ci == true,
       where: mr.ran_at >= ^cutoff,
+      where: mr.name in ^modules,
       group_by: mr.name,
       select: %{name: mr.name, duration: fragment("quantile(?)(?)", ^@timing_quantile, mr.duration)}
     )
     |> ClickHouseRepo.all()
-    |> Map.new(fn %{name: name, duration: duration} -> {name, round(duration)} end)
+    |> Map.new(fn %{name: name, duration: duration} -> {name, round_timing_duration(duration)} end)
   end
 
-  defp fetch_timing_data(project, "suite") do
+  defp fetch_timing_data(project, "suite", units) do
     cutoff = DateTime.add(DateTime.utc_now(), -@timing_lookback_days, :day)
+    modules = units |> Enum.map(&suite_module/1) |> Enum.uniq()
 
-    from(sr in TestSuiteRun,
-      join: mr in TestModuleRun,
-      on: sr.test_module_run_id == mr.id,
-      where: sr.project_id == ^project.id,
-      where: sr.is_ci == true,
-      where: sr.ran_at >= ^cutoff,
-      group_by: fragment("concat(?, '/', ?)", mr.name, sr.name),
-      select: %{
-        name: fragment("concat(?, '/', ?)", mr.name, sr.name),
-        duration: fragment("quantile(?)(?)", ^@timing_quantile, sr.duration)
-      }
-    )
-    |> ClickHouseRepo.all()
-    |> Map.new(fn %{name: name, duration: duration} -> {name, round(duration)} end)
+    query = """
+    SELECT
+      concat(mr.name, '/', sr.name) AS name,
+      quantile({timing_quantile:Float64})(sr.duration) AS duration
+    FROM test_suite_runs AS sr
+    INNER JOIN test_module_runs AS mr ON sr.test_module_run_id = mr.id
+    WHERE sr.project_id = {project_id:Int64}
+      AND sr.is_ci = true
+      AND sr.ran_at >= {cutoff:DateTime64(6)}
+      AND mr.project_id = {project_id:Int64}
+      AND mr.is_ci = true
+      AND mr.ran_at >= {cutoff:DateTime64(6)}
+      AND mr.name IN {modules:Array(String)}
+      AND concat(mr.name, '/', sr.name) IN {units:Array(String)}
+    GROUP BY name
+    """
+
+    params = %{
+      project_id: project.id,
+      timing_quantile: @timing_quantile,
+      cutoff: cutoff,
+      modules: modules,
+      units: units
+    }
+
+    {:ok, %{rows: rows}} = ClickHouseRepo.query(query, params)
+
+    Map.new(rows, fn [name, duration] -> {name, round_timing_duration(duration)} end)
   end
+
+  defp round_timing_duration(%Decimal{} = duration), do: duration |> Decimal.to_float() |> round()
+  defp round_timing_duration(duration), do: round(duration)
 
   defp assign_durations(unit_names, timing_data, granularity) do
     known_durations = Map.values(timing_data)


### PR DESCRIPTION
## What changed

- Resolve shard-plan units before reading ClickHouse timing history.
- Scope module timing reads to the modules being planned.
- Scope suite timing reads to the exact `Module/Suite` units being planned.
- Filter both sides of the `test_suite_runs` / `test_module_runs` join by project, CI status, and lookback window.

## Why

The production ClickHouse memory alerts should be fixed where Grafana shows the memory is actually being spent. Atlas MCP / Grafana `system.query_log` showed the highest-memory query family over the last 48 hours was the suite-level shard planner timing query over `test_suite_runs` joined to `test_module_runs`, not the duration-metrics queries.

The worst observed query read suite timing history for project `1059` without module or suite filters and peaked around `4.88 GiB` of query memory.

## Production comparison

I used Atlas MCP against the production ClickHouse datasource and correlated the worst old query execution with the suite shard plan inserted immediately afterward:

- Old query execution: `2026-07-07T00:07:16Z`
- Matching shard plan: `3637ac7a-edee-42e8-82da-9a51a542a6f9`
- Shard plan inserted at: `2026-07-07T00:07:16.322301Z`
- Planned units: `32` suite units across `4` modules

The old side below is from production `system.query_log`; I did not rerun the unscoped 4.88 GiB query against production. The new side was run through Atlas MCP using the scoped query shape against the same project, cutoff, modules, and suite units.

| Query shape | Duration | Read rows | Read bytes | Peak memory | Result rows |
|---|---:|---:|---:|---:|---:|
| Old unscoped suite timing query | `4130 ms` | `23,611,895` | `910,526,436` | `4.88 GiB` | n/a |
| New scoped suite timing query | `380 ms` | `6,273,665` | `216,082,377` | `168.27 MiB` | `20` |

Observed reduction:

- Peak memory: about `29.7x` lower
- Duration: about `10.9x` faster
- Read rows: about `3.8x` fewer
- Read bytes: about `4.2x` fewer

## Root cause

Shard plan creation fetched timing data for all historical suites in a project before resolving the requested module/suite unit set. For large projects, suite-level planning could therefore scan and group far more history than the plan needed.

## Approach

The fix makes shard planning resolve the requested units first, then fetch timing data only for those units. The suite timing query now uses parameterized ClickHouse SQL so the exact `Module/Suite` unit list can be applied directly while also constraining the joined module rows.

## Impact

Suite-level shard plan creation should avoid scanning and grouping unrelated suite history, reducing peak ClickHouse memory for the query family Grafana identified. The shard assignment behavior remains covered by the existing shard tests.

## Validation

- `mix format lib/tuist/shards.ex`
- `MIX_ENV=test mix test test/tuist/shards_test.exs`
  - `34 tests, 0 failures`
- `git diff --check`

Sentry reference:

- https://tuist.sentry.io/issues/132736023/