### PR TITLE
perf(server): tune LiveView WebSocket timeouts

### DIFF
--- a/infra/helm/tuist/values-managed-canary.yaml
+++ b/infra/helm/tuist/values-managed-canary.yaml
@@ -49,6 +49,10 @@ server:
     className: nginx
     host: canary.tuist.dev
     tlsSecretName: tuist-tls-cloudflare-origin
+    annotations:
+      nginx.ingress.kubernetes.io/proxy-connect-timeout: "10"
+      nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+      nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
 
   # Request sized so a surge pod (chart-default maxSurge: 1) co-schedules
   # alongside the live pod on the 2-worker canary nodepool. Steady-state

--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -133,6 +133,10 @@ server:
     className: nginx
     host: tuist.dev
     tlsSecretName: tuist-tls-cloudflare-origin
+    annotations:
+      nginx.ingress.kubernetes.io/proxy-connect-timeout: "10"
+      nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+      nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
 
   # Full prod resource envelope — sized against the ccx23 worker.
   resources:

--- a/infra/helm/tuist/values-managed-staging.yaml
+++ b/infra/helm/tuist/values-managed-staging.yaml
@@ -114,6 +114,10 @@ server:
     className: nginx
     host: staging.tuist.dev
     tlsSecretName: tuist-tls-cloudflare-origin
+    annotations:
+      nginx.ingress.kubernetes.io/proxy-connect-timeout: "10"
+      nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+      nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
 
   autoscaling:
     enabled: false

--- a/server/assets/app/app.js
+++ b/server/assets/app/app.js
@@ -73,13 +73,16 @@ observeThemeChanges();
 Hooks.ThemeSwitcher = ThemeSwitcher;
 Hooks.ThemeToggle = ThemeToggle;
 
-// On localhost, the WS drops every time the dev server restarts or the
+// Keep this aligned with nginx.ingress.kubernetes.io/proxy-connect-timeout.
+const liveSocketFallbackMs = 10000;
+
+// On localhost, the WebSocket drops every time the dev server restarts or the
 // live reloader fires. With longpoll fallback enabled, the client gives
-// up on WS too quickly and pins itself to longpoll, which then loops
+// up on WebSocket too quickly and pins itself to longpoll, which then loops
 // into `exceeded 10 consecutive reloads. Entering failsafe mode`. See
 // https://elixirforum.com/t/liveview-falls-back-to-longpoll-after-dev-server-restart/61736
 let liveSocket = new LiveSocket("/live", Socket, {
-  longPollFallbackMs: window.location.host.startsWith("localhost") ? undefined : 2500,
+  longPollFallbackMs: window.location.host.startsWith("localhost") ? undefined : liveSocketFallbackMs,
   params: {
     _csrf_token: csrfToken,
     _csp_nonce: cspNonce,

--- a/server/assets/docs/docs.js
+++ b/server/assets/docs/docs.js
@@ -18,8 +18,11 @@ let cspNonce = document.querySelector("meta[name='csp-nonce']").getAttribute("co
 
 observeThemeChanges();
 
+// Keep this aligned with nginx.ingress.kubernetes.io/proxy-connect-timeout.
+const liveSocketFallbackMs = 10000;
+
 let liveSocket = new LiveSocket("/live", Socket, {
-  longPollFallbackMs: 2500,
+  longPollFallbackMs: liveSocketFallbackMs,
   params: { _csrf_token: csrfToken, _csp_nonce: cspNonce },
   hooks: {
     ...Noora.Hooks,

--- a/server/assets/marketing/marketing.js
+++ b/server/assets/marketing/marketing.js
@@ -8,9 +8,11 @@ import "./marketing.css";
 
 let csrfToken = document.querySelector("meta[name='csrf-token']").getAttribute("content");
 let cspNonce = document.querySelector("meta[name='csp-nonce']").getAttribute("content");
+// Keep this aligned with nginx.ingress.kubernetes.io/proxy-connect-timeout.
+const liveSocketFallbackMs = 10000;
 
 let liveSocket = new LiveSocket("/live", Socket, {
-  longPollFallbackMs: 2500,
+  longPollFallbackMs: liveSocketFallbackMs,
   params: { _csrf_token: csrfToken, _csp_nonce: cspNonce },
   hooks: { ...Noora.Hooks, ...Hooks },
 });


### PR DESCRIPTION
Resolves no tracked issue

## What changed

This tunes the LiveView WebSocket connection path across the browser clients and managed ingress configuration:

- Raises the LiveView long polling fallback threshold from 2.5 seconds to 10 seconds for the application, marketing, and documentation bundles.
- Keeps the localhost dashboard behavior unchanged, where fallback remains disabled to avoid development server reload loops.
- Adds explicit Nginx ingress timeouts for production, canary, and staging:
  - `nginx.ingress.kubernetes.io/proxy-connect-timeout: "10"`
  - `nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"`
  - `nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"`

## Why

Brazil and other far-away client locations can occasionally see slower LiveView WebSocket establishment. The previous 2.5 second fallback was aggressive enough that a transient slow upgrade could move a browser session to long polling even when WebSockets would have connected shortly after.

The ingress configuration now makes the server-side WebSocket expectations explicit and keeps the browser fallback threshold aligned with the ingress upstream connection timeout.

## Root cause

The LiveView clients were configured to fall back to long polling after 2.5 seconds. Phoenix stores the fallback choice in browser session storage, so one slow WebSocket attempt can keep that tab on long polling for the session.

The managed server ingress did not declare WebSocket-oriented read and send timeouts, so it depended on controller defaults for upgraded connections.

## Approach

The change keeps WebSockets as the preferred transport and only gives them more time to establish before falling back. A 10 second threshold is long enough to avoid premature fallback on slower networks while still allowing long polling to take over for networks that genuinely cannot establish WebSockets.

The platform controller keepalive timeout is intentionally left unchanged because it is coupled to the Bandit backend read timeout. This change only adds per-server ingress annotations that affect connection establishment and upgraded connection idleness.

## Impact

Users on slower or higher-latency networks should be less likely to get pinned to long polling during LiveView startup. Existing localhost development behavior is preserved.

The Cloudflare cache split remains unchanged: static assets should be eligible for caching, while dynamic application routes and `/live/websocket` should stay uncached.

## Validation

- `git diff --check`
- Rendered the production server ingress with `helm template` and confirmed the three Nginx timeout annotations are present.
- Rendered the canary server ingress with `helm template` and confirmed the three Nginx timeout annotations are present.
- Rendered the staging server ingress with `helm template` and confirmed the three Nginx timeout annotations are present.
- Probed `https://tuist.dev/live/websocket` with `curl` using a WebSocket upgrade request. It returned upgrade response `101` with first byte at `0.169s`; the later `curl` timeout is expected because the upgraded socket stays open.
- Checked public routes with `curl`:
  - `/` returned `200` in about `0.31s`.
  - `/blog` returned `200` in about `0.47s`.
  - `/en/docs` returned `200` in about `0.29s`.
- Checked fingerprinted static assets with `curl` and confirmed Cloudflare cache hits for the stylesheet bundle, script bundle, and a marketing image.

### How to test locally

Run the server and confirm LiveView pages still connect through WebSockets. For the rendered ingress configuration, run:

```sh
helm template tuist infra/helm/tuist \
  -n tuist \
  -f infra/helm/tuist/values-managed-common.yaml \
  -f infra/helm/tuist/values-managed-production.yaml \
  -f infra/helm/tuist/values-ci.yaml \
  --set server.image.tag=test \
  --show-only templates/server-ingress.yaml
```
