### PR TITLE
fix(server): unblock deploys from regional ingress webhooks

### DIFF
--- a/infra/cluster-api-provider-tuist/api/v1alpha1/dediboxmachine_types.go
+++ b/infra/cluster-api-provider-tuist/api/v1alpha1/dediboxmachine_types.go
@@ -8,8 +8,8 @@ import (
 
 // DediboxMachineSpec is the desired state of one Scaleway Dedibox dedicated
 // server. Structurally it mirrors the OVH kind — a customer-facing public box
-// that adopts a pre-ordered server, installs on claim, self-joins over its
-// public IP, and (monthly contract) is not terminated on delete. It is driven
+// that adopts a pre-ordered, installed server, self-joins over its public IP,
+// and is reinstalled back to a clean, claimable state on delete. It is driven
 // through the Scaleway Dedibox API with a default-project IAM key (every Dedibox
 // in the org shares the default project — a Dedibox cannot be assigned to
 // another one — so the project can't isolate environments; a per-fleet tag

--- a/infra/cluster-api-provider-tuist/controllers/linux/dediboxmachine_controller.go
+++ b/infra/cluster-api-provider-tuist/controllers/linux/dediboxmachine_controller.go
@@ -48,6 +48,11 @@ const (
 	// dediboxInstanceType is the node.cluster.x-k8s.io/instance-type label value
 	// the self-join stamps.
 	dediboxInstanceType = "dedibox"
+
+	dediboxReleaseReinstallStartedAnnotation  = "dedibox.cluster.x-k8s.io/release-reinstall-started"
+	dediboxReleaseReinstallObservedAnnotation = "dedibox.cluster.x-k8s.io/release-reinstall-observed"
+
+	dediboxInstallPollInterval = time.Minute
 )
 
 // DediboxMachineReconciler reconciles a DediboxMachine: it adopts a pre-ordered
@@ -189,14 +194,23 @@ func (r *DediboxMachineReconciler) reconcileNormal(ctx context.Context, machine 
 		if getErr != nil {
 			return ctrl.Result{}, getErr
 		}
+		installState, installErr := r.DediboxClient.InstallState(ctx, machine.Status.Zone, serverID)
+		if installErr != nil {
+			return ctrl.Result{}, fmt.Errorf("get Dedibox install state: %w", installErr)
+		}
+		if installState != dedibox.InstallDone {
+			conditions.MarkFalse(machine, shared.ProvisionedCondition, "InstallInProgress",
+				clusterv1.ConditionSeverityInfo, "Dedibox server %d install is %s", serverID, installState)
+			machine.Status.Phase = "Installing"
+			logger.Info("waiting for Dedibox install before bootstrap", "id", machine.Status.ServerID, "state", installState.String())
+			return ctrl.Result{RequeueAfter: dediboxInstallPollInterval}, nil
+		}
 		// Adoption is claim + self-join, never install. The operator prepares the
 		// box (Ubuntu + the fleet key + tuist passwordless sudo) before tagging it
-		// into the pool, so a claimed box is already reachable — the same shape as a
-		// Scaleway mini that is already up. Keeping the OS install off this path is
-		// what makes adoption a ~2-5 min self-join, so the fleet MachineDeployment
-		// goes Ready quickly and never wedges helm --wait; the reinstall that wipes a
-		// box back to a clean, claimable state lives on the release path
-		// (reconcileDelete).
+		// into the pool, so a claimed box is expected to be reachable — the same
+		// shape as a Scaleway mini that is already up. The install-state gate above
+		// keeps a box that is still being release-reinstalled out of the SSH path
+		// until Scaleway reports the clean OS is back.
 		host := server.PublicIP
 		if host == "" {
 			machine.Status.Phase = "Provisioning"
@@ -246,11 +260,9 @@ func (r *DediboxMachineReconciler) reconcileNormal(ctx context.Context, machine 
 		}
 		if bootErr != nil {
 			if errors.Is(bootErr, bootstrap.ErrHostKeyMismatch) {
-				// Reinstall-on-release race: reinstallToPool is fire-and-forget,
-				// so a fresh claim can dial the box mid-reimage and pin a key the
-				// completed reinstall then rotates. Clear the stale pin so the next
-				// dial re-TOFUs the reinstalled key. Bounded to bootstrap — a
-				// Provisioned box is never re-dialed.
+				// A prior controller version or manual reinstall may leave a stale
+				// TOFU pin for a host that has since been reimaged. Clear it so the
+				// next bootstrap attempt can pin the freshly installed host key.
 				if perr := r.CredentialsManager.SetMachineHostFingerprint(ctx, machine.Name, ""); perr != nil {
 					logger.Error(perr, "clear stale host fingerprint after reinstall; will retry")
 				}
@@ -334,7 +346,6 @@ func (r *DediboxMachineReconciler) claimedServerIDs(ctx context.Context, self *i
 // removes the finalizer. Reinstalling on release (rather than on adoption) is what
 // keeps adoption a fast self-join.
 func (r *DediboxMachineReconciler) reconcileDelete(ctx context.Context, machine *infrav1.DediboxMachine) (ctrl.Result, error) {
-	logger := log.FromContext(ctx)
 	machine.Status.Phase = "Deleting"
 	if err := r.CredentialsManager.DeleteNodeIdentity(ctx, machine.Name); err != nil {
 		r.event(machine, "DeleteIdentityFailed", "delete node identity: %v (will retry)", err)
@@ -362,26 +373,64 @@ func (r *DediboxMachineReconciler) reconcileDelete(ctx context.Context, machine 
 		r.event(machine, "DeletePVCsFailed", "delete node-local PVCs orphaned by reprovision: %v (will retry)", err)
 		return ctrl.Result{}, err
 	}
-	// Reinstall the box back to a clean, claimable state as the last step before
-	// dropping the finalizer — it's the only step that retries on failure, so on
-	// the happy path it fires exactly once. Fire-and-forget: the wipe + reimage
-	// (Ubuntu + fleet key + tuist login) finishes after the Machine is gone,
-	// leaving a box the next claim self-joins.
 	if machine.Status.ServerID != 0 {
-		if err := r.reinstallToPool(ctx, machine); err != nil {
-			r.event(machine, "ReleaseReinstallFailed", "reinstall on release: %v (will retry)", err)
-			return ctrl.Result{}, err
+		result, done, err := r.reconcileReleaseReinstall(ctx, machine)
+		if err != nil || !done {
+			return result, err
 		}
-		r.event(machine, "ReleasedToPool", "Reinstalling Dedibox server %d to a clean, claimable state", machine.Status.ServerID)
-		logger.Info("reinstalling Dedibox box on release", "id", machine.Status.ServerID)
 	}
 	controllerutil.RemoveFinalizer(machine, DediboxMachineFinalizer)
 	return ctrl.Result{}, nil
 }
 
+func (r *DediboxMachineReconciler) reconcileReleaseReinstall(ctx context.Context, machine *infrav1.DediboxMachine) (ctrl.Result, bool, error) {
+	logger := log.FromContext(ctx)
+	if machine.Annotations == nil {
+		machine.Annotations = map[string]string{}
+	}
+
+	serverID := uint64(machine.Status.ServerID)
+	if machine.Annotations[dediboxReleaseReinstallStartedAnnotation] != "true" {
+		if err := r.reinstallToPool(ctx, machine); err != nil {
+			r.event(machine, "ReleaseReinstallFailed", "reinstall on release: %v (will retry)", err)
+			return ctrl.Result{}, false, err
+		}
+		machine.Annotations[dediboxReleaseReinstallStartedAnnotation] = "true"
+		machine.Status.Phase = "Reinstalling"
+		r.event(machine, "ReleasedToPool", "Reinstalling Dedibox server %d to a clean, claimable state", machine.Status.ServerID)
+		logger.Info("started Dedibox reinstall on release", "id", machine.Status.ServerID)
+		return ctrl.Result{RequeueAfter: dediboxInstallPollInterval}, false, nil
+	}
+
+	state, err := r.DediboxClient.InstallState(ctx, machine.Status.Zone, serverID)
+	if err != nil {
+		r.event(machine, "ReleaseReinstallPollFailed", "poll reinstall on release: %v (will retry)", err)
+		logger.Error(err, "poll Dedibox reinstall on release", "id", machine.Status.ServerID)
+		return ctrl.Result{RequeueAfter: dediboxInstallPollInterval}, false, nil
+	}
+	if state != dedibox.InstallDone {
+		machine.Annotations[dediboxReleaseReinstallObservedAnnotation] = "true"
+		machine.Status.Phase = "Reinstalling"
+		conditions.MarkFalse(machine, shared.ProvisionedCondition, "ReleaseReinstalling",
+			clusterv1.ConditionSeverityInfo, "Dedibox server %d release reinstall is %s", serverID, state)
+		logger.Info("waiting for Dedibox release reinstall", "id", machine.Status.ServerID, "state", state.String())
+		return ctrl.Result{RequeueAfter: dediboxInstallPollInterval}, false, nil
+	}
+	if machine.Annotations[dediboxReleaseReinstallObservedAnnotation] != "true" {
+		machine.Status.Phase = "Reinstalling"
+		logger.Info("waiting for Dedibox release reinstall to report in progress before accepting done", "id", machine.Status.ServerID)
+		return ctrl.Result{RequeueAfter: dediboxInstallPollInterval}, false, nil
+	}
+
+	r.event(machine, "ReleasedToPool", "Reinstalled Dedibox server %d to a clean, claimable state", machine.Status.ServerID)
+	logger.Info("Dedibox release reinstall completed", "id", machine.Status.ServerID)
+	return ctrl.Result{}, true, nil
+}
+
 // reinstallToPool wipes the adopted box back to a clean Ubuntu install with the
 // fleet key authorized and the tuist login, so the next claim self-joins it
-// without operator prep. Fire-and-forget: it kicks the install off and returns.
+// without operator prep. It kicks the install off and returns; reconcileDelete
+// keeps the Machine finalizer until InstallState observes the reinstall complete.
 func (r *DediboxMachineReconciler) reinstallToPool(ctx context.Context, machine *infrav1.DediboxMachine) error {
 	fleet := firstNonEmpty(machine.Spec.FleetName, machine.Namespace+"-"+machine.Name)
 	privateKey, keyErr := r.CredentialsManager.EnsureFleetSSHKey(ctx, fleet)

--- a/infra/cluster-api-provider-tuist/internal/dedibox/client.go
+++ b/infra/cluster-api-provider-tuist/internal/dedibox/client.go
@@ -202,12 +202,14 @@ type AdoptParams struct {
 	HostnamePrefix string
 }
 
-// FindAdoptableServer claims a pre-ordered server for the fleet: the first
-// server in the project matching Tag + Offer + Datacenter that no sibling
-// Machine has already claimed (claimed = the IDs on sibling CR statuses). The
-// server-list summary omits tags, so a candidate matching offer + datacenter is
-// confirmed against its tags via GetServer. Returns nil when the pool is
-// exhausted so the caller requeues and the operator pre-orders more capacity.
+// FindAdoptableServer claims a pre-ordered, already-installed server for the
+// fleet: the first server in the project matching Tag + Offer + Datacenter that
+// no sibling Machine has already claimed (claimed = the IDs on sibling CR
+// statuses). The server-list summary omits tags, so a candidate matching offer +
+// datacenter is confirmed against its tags via GetServer. Servers with a
+// pending/running install are skipped so release reinstalls can't be re-adopted
+// mid-wipe. Returns nil when the pool is exhausted so the caller requeues and
+// the operator pre-orders more capacity.
 func (c *Client) FindAdoptableServer(ctx context.Context, p AdoptParams, claimed map[uint64]bool) (*Server, error) {
 	for _, zone := range dediboxZones {
 		summaries, err := c.listServers(ctx, zone)
@@ -236,7 +238,14 @@ func (c *Client) FindAdoptableServer(ctx context.Context, p AdoptParams, claimed
 				if !hasTag(full.Tags, p.Tag) {
 					continue
 				}
-				return full, nil
+				server = full
+			}
+			state, stateErr := c.InstallState(ctx, zone, summary.ID)
+			if stateErr != nil {
+				return nil, fmt.Errorf("check install state for dedibox server %d: %w", summary.ID, stateErr)
+			}
+			if state != InstallDone {
+				continue
 			}
 			return server, nil
 		}
@@ -508,6 +517,21 @@ const (
 	// InstallFailed means the install errored terminally.
 	InstallFailed
 )
+
+func (s InstallState) String() string {
+	switch s {
+	case InstallPending:
+		return "pending"
+	case InstallRunning:
+		return "running"
+	case InstallDone:
+		return "done"
+	case InstallFailed:
+		return "failed"
+	default:
+		return fmt.Sprintf("unknown(%d)", int(s))
+	}
+}
 
 // InstallState polls the server's install resource and maps it to the coarse
 // lifecycle. `installed` is done; a missing install resource or `unknown` status

--- a/infra/cluster-api-provider-tuist/internal/dedibox/client_test.go
+++ b/infra/cluster-api-provider-tuist/internal/dedibox/client_test.go
@@ -68,6 +68,9 @@ func TestFindAdoptableServerByTag(t *testing.T) {
 		},
 		"/dedibox/v1/zones/fr-par-1/servers/1": scwdedibox.Server{Zone: "fr-par-1", ID: 1, Tags: []string{"tuist-kura-prod"}},
 		"/dedibox/v1/zones/fr-par-1/servers/2": scwdedibox.Server{Zone: "fr-par-1", ID: 2, Tags: []string{"tuist-kura-staging"}},
+		"/dedibox/v1/zones/fr-par-1/servers/2/install": scwdedibox.ServerInstall{
+			Status: scwdedibox.ServerInstallStatusInstalled,
+		},
 	}}
 	c := &Client{t: f, ProjectID: "proj"}
 
@@ -111,6 +114,9 @@ func TestFindAdoptableServerClaimedSkipped(t *testing.T) {
 			},
 		},
 		"/dedibox/v1/zones/fr-par-1/servers/6": scwdedibox.Server{Zone: "fr-par-1", ID: 6, Tags: []string{"tuist-kura-staging"}},
+		"/dedibox/v1/zones/fr-par-1/servers/6/install": scwdedibox.ServerInstall{
+			Status: scwdedibox.ServerInstallStatusInstalled,
+		},
 	}}
 	c := &Client{t: f, ProjectID: "proj"}
 
@@ -120,6 +126,54 @@ func TestFindAdoptableServerClaimedSkipped(t *testing.T) {
 	}
 	if got == nil || got.ID != 6 {
 		t.Fatalf("FindAdoptableServer = %+v, want server 6 (5 already claimed)", got)
+	}
+}
+
+func TestFindAdoptableServerSkipsInstallingServer(t *testing.T) {
+	f := &fakeTransport{gets: map[string]any{
+		"/dedibox/v1/zones/fr-par-1/servers": scwdedibox.ListServersResponse{
+			Servers: []*scwdedibox.ServerSummary{
+				{ID: 1, OfferName: "Start-1-M-SSD", DatacenterName: "DC2", Zone: "fr-par-1"},
+				{ID: 2, OfferName: "Start-1-M-SSD", DatacenterName: "DC2", Zone: "fr-par-1"},
+			},
+		},
+		"/dedibox/v1/zones/fr-par-1/servers/1": scwdedibox.Server{Zone: "fr-par-1", ID: 1, Tags: []string{"tuist-kura-staging"}},
+		"/dedibox/v1/zones/fr-par-1/servers/1/install": scwdedibox.ServerInstall{
+			Status: scwdedibox.ServerInstallStatusInstalling,
+		},
+		"/dedibox/v1/zones/fr-par-1/servers/2": scwdedibox.Server{Zone: "fr-par-1", ID: 2, Tags: []string{"tuist-kura-staging"}},
+		"/dedibox/v1/zones/fr-par-1/servers/2/install": scwdedibox.ServerInstall{
+			Status: scwdedibox.ServerInstallStatusInstalled,
+		},
+	}}
+	c := &Client{t: f, ProjectID: "proj"}
+
+	got, err := c.FindAdoptableServer(context.Background(), AdoptParams{Tag: "tuist-kura-staging"}, map[uint64]bool{})
+	if err != nil {
+		t.Fatalf("FindAdoptableServer: %v", err)
+	}
+	if got == nil || got.ID != 2 {
+		t.Fatalf("FindAdoptableServer = %+v, want server 2 (server 1 still installing)", got)
+	}
+}
+
+func TestFindAdoptableServerSkipsBareServer(t *testing.T) {
+	f := &fakeTransport{gets: map[string]any{
+		"/dedibox/v1/zones/fr-par-1/servers": scwdedibox.ListServersResponse{
+			Servers: []*scwdedibox.ServerSummary{
+				{ID: 1, OfferName: "Start-1-M-SSD", DatacenterName: "DC2", Zone: "fr-par-1"},
+			},
+		},
+		"/dedibox/v1/zones/fr-par-1/servers/1": scwdedibox.Server{Zone: "fr-par-1", ID: 1, Tags: []string{"tuist-kura-staging"}},
+	}}
+	c := &Client{t: f, ProjectID: "proj"}
+
+	got, err := c.FindAdoptableServer(context.Background(), AdoptParams{Tag: "tuist-kura-staging"}, map[uint64]bool{})
+	if err != nil {
+		t.Fatalf("FindAdoptableServer: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("FindAdoptableServer = %+v, want nil (tagged box has no installed OS)", got)
 	}
 }
 

--- a/infra/helm/platform/values.yaml
+++ b/infra/helm/platform/values.yaml
@@ -90,6 +90,14 @@ kura-eu-central-ingress-nginx:
       type: LoadBalancer
       externalTrafficPolicy: Local
       annotations: {}
+    # ingress-nginx admission webhooks are cluster-wide, not scoped to one
+    # IngressClass. A regional Kura controller can legitimately have zero pods
+    # while its bare-metal fleet is absent or being replaced; if its webhook is
+    # registered, every Ingress update in the cluster blocks on that empty
+    # Service. Keep admission on the main ingress-nginx controller only; it runs
+    # the same validator for the Kura Ingress annotations.
+    admissionWebhooks: &kuraGatewayAdmissionWebhooks
+      enabled: false
     # Anchored so all three regional Kura gateways share ONE nginx config
     # source. The e2e throughput test (kura/test/e2e/grpc-upload-throughput)
     # derives its patched nginx config from the window keys here, and the
@@ -131,6 +139,7 @@ kura-ca-east-ingress-nginx:
       type: LoadBalancer
       externalTrafficPolicy: Local
       annotations: {}
+    admissionWebhooks: *kuraGatewayAdmissionWebhooks
     # Shares the one anchored regional Kura nginx config (defined in the
     # eu-central block above); see TestGatewayNginxConfigMatchesChart on why
     # these cannot drift from the dedicated-gateway ConfigMap.
@@ -153,6 +162,7 @@ kura-us-east-ingress-nginx:
       type: LoadBalancer
       externalTrafficPolicy: Local
       annotations: {}
+    admissionWebhooks: *kuraGatewayAdmissionWebhooks
     config: *kuraGatewayNginxConfig
     metrics:
       enabled: true
@@ -172,6 +182,7 @@ kura-us-west-ingress-nginx:
       type: LoadBalancer
       externalTrafficPolicy: Local
       annotations: {}
+    admissionWebhooks: *kuraGatewayAdmissionWebhooks
     config: *kuraGatewayNginxConfig
     metrics:
       enabled: true

--- a/infra/helm/tuist/templates/dedibox-fleet.yaml
+++ b/infra/helm/tuist/templates/dedibox-fleet.yaml
@@ -99,9 +99,11 @@ node-exporter DaemonSet below full availability, and wedges every deploy.
 unhealthyRange "[0-1]" remediates a single dead box but never reinstalls a whole
 region at once: a cluster-wide blip that NotReadies every replica is left for an
 operator rather than mass-reinstalled. nodeStartupTimeout must clear the FULL
-bare-metal OS reinstall + boot — a Scaleway Dedibox install runs 45-60 min before
-sshd comes up. Set it below that and the health check culls the box mid-install,
-the provider wipes and reinstalls it, and the ~50 min clock restarts from zero:
+bare-metal OS reinstall + boot — a Scaleway Dedibox install can take 60-90+ min
+before sshd comes up, and the controller waits for the release reinstall to be
+observed complete before handing the box back to the pool. Set it below that and
+the health check culls the box mid-install, the provider wipes and reinstalls it,
+and the clock restarts from zero:
 an endless reinstall loop that never lets the box join and wedges helm --wait on
 the MachineDeployment (the node never reaches Ready, so this only gates the
 initial startup window — a box that dies after joining is still remediated by the
@@ -118,7 +120,7 @@ metadata:
     tuist.dev/fleet: {{ $fleetName }}
 spec:
   clusterName: {{ $clusterName }}
-  nodeStartupTimeout: 90m
+  nodeStartupTimeout: 150m
   unhealthyRange: "[0-1]"
   selector:
     matchLabels:

--- a/infra/helm/tuist/templates/dedibox-fleet.yaml
+++ b/infra/helm/tuist/templates/dedibox-fleet.yaml
@@ -99,11 +99,9 @@ node-exporter DaemonSet below full availability, and wedges every deploy.
 unhealthyRange "[0-1]" remediates a single dead box but never reinstalls a whole
 region at once: a cluster-wide blip that NotReadies every replica is left for an
 operator rather than mass-reinstalled. nodeStartupTimeout must clear the FULL
-bare-metal OS reinstall + boot — a Scaleway Dedibox install can take 60-90+ min
-before sshd comes up, and the controller waits for the release reinstall to be
-observed complete before handing the box back to the pool. Set it below that and
-the health check culls the box mid-install, the provider wipes and reinstalls it,
-and the clock restarts from zero:
+bare-metal OS reinstall + boot — a Scaleway Dedibox install runs 45-60 min before
+sshd comes up. Set it below that and the health check culls the box mid-install,
+the provider wipes and reinstalls it, and the ~50 min clock restarts from zero:
 an endless reinstall loop that never lets the box join and wedges helm --wait on
 the MachineDeployment (the node never reaches Ready, so this only gates the
 initial startup window — a box that dies after joining is still remediated by the
@@ -120,7 +118,7 @@ metadata:
     tuist.dev/fleet: {{ $fleetName }}
 spec:
   clusterName: {{ $clusterName }}
-  nodeStartupTimeout: 150m
+  nodeStartupTimeout: 90m
   unhealthyRange: "[0-1]"
   selector:
     matchLabels:

--- a/infra/mise/tasks/k8s/install-platform.sh
+++ b/infra/mise/tasks/k8s/install-platform.sh
@@ -132,28 +132,13 @@ KUBECONFIG="$WL_KUBECONFIG" kubectl -n platform delete job \
   --ignore-not-found --cascade=foreground --timeout=2m || true
 
 HELM_EXTRA_ARGS=()
+
+# The regional Kura ingress-nginx aliases intentionally run without admission
+# webhooks. The upstream webhook is not IngressClass-scoped, so a regional
+# controller with zero endpoints would block unrelated Ingress updates (for
+# example the server Ingress) across the whole cluster. Only the main
+# ingress-nginx admission secret is expected here.
 ADMISSION_SECRETS=(platform-ingress-nginx-admission)
-case "$CLUSTER_NAME" in
-  tuist)
-    ADMISSION_SECRETS+=(
-      platform-kura-eu-central-ingress-nginx-admission
-      platform-kura-us-east-ingress-nginx-admission
-      platform-kura-us-west-ingress-nginx-admission
-    )
-    ;;
-  tuist-canary)
-    ADMISSION_SECRETS+=(
-      platform-kura-eu-central-ingress-nginx-admission
-      platform-kura-ca-east-ingress-nginx-admission
-    )
-    ;;
-  tuist-staging)
-    ADMISSION_SECRETS+=(
-      platform-kura-eu-central-ingress-nginx-admission
-      platform-kura-ca-east-ingress-nginx-admission
-    )
-    ;;
-esac
 
 if KUBECONFIG="$WL_KUBECONFIG" helm status platform --namespace platform >/dev/null 2>&1; then
   HAVE_ALL_ADMISSION_SECRETS=true

--- a/infra/mise/tasks/k8s/install-platform.sh
+++ b/infra/mise/tasks/k8s/install-platform.sh
@@ -133,11 +133,6 @@ KUBECONFIG="$WL_KUBECONFIG" kubectl -n platform delete job \
 
 HELM_EXTRA_ARGS=()
 
-# The regional Kura ingress-nginx aliases intentionally run without admission
-# webhooks. The upstream webhook is not IngressClass-scoped, so a regional
-# controller with zero endpoints would block unrelated Ingress updates (for
-# example the server Ingress) across the whole cluster. Only the main
-# ingress-nginx admission secret is expected here.
 ADMISSION_SECRETS=(platform-ingress-nginx-admission)
 
 if KUBECONFIG="$WL_KUBECONFIG" helm status platform --namespace platform >/dev/null 2>&1; then


### PR DESCRIPTION
## What changed

- Disabled admission webhooks on the regional Kura ingress-nginx chart aliases.
- Kept the main ingress-nginx admission webhook enabled so Ingress validation still runs through the primary controller.
- Updated `k8s:install-platform` to only require the main ingress admission secret when deciding whether platform hooks can be skipped.
- Hardened Dedibox adoption so the controller only adopts tagged servers whose install state is complete, skipping bare or actively reinstalling boxes.
- Changed Dedibox release deletion from a fire-and-forget reinstall to an observed lifecycle: the Machine finalizer stays until the release reinstall has been observed in progress and then complete.
- Added a bootstrap-side install-state gate so a claimed Dedibox server is not SSH-bootstrapped while Scaleway still reports its OS install as pending/running.

## Why

The server production deployment failed during canary at `helm upgrade --install` while patching the server Ingress. The Kubernetes API server attempted to call the regional Kura ingress-nginx admission webhook service and failed before Helm could finish the upgrade or rollback.

Failed run: [Server Production Deployment / canary deploy](https://github.com/tuist/tuist/actions/runs/28867435022/job/85635968337#step:11:246).

Regional Kura ingress-nginx controllers are still part of the data plane where regional fleets are present. The problem was the admission webhook surface, not the controller pods themselves: ingress-nginx admission webhooks are cluster-wide and are not scoped to only the IngressClass served by that controller.

The failing regional webhook had no endpoints because the canary Dedibox-backed regional pool temporarily had zero Ready nodes. That exposed a second issue: the Dedibox release path could hand a physical box back to the pool immediately after starting a reinstall, allowing a replacement Machine to re-adopt the same box while Scaleway was still reinstalling it.

## Root cause

In canary, `platform-kura-eu-central-ingress-nginx-controller-admission` existed as a ClusterIP Service with no endpoints because the corresponding regional DaemonSet had zero desired pods. Since that admission webhook was registered globally, unrelated Ingress updates such as the Tuist server Ingress were blocked on an empty regional admission Service.

The regional pool reached that empty state because the Dedibox Machine lifecycle treated release reinstall as asynchronous cleanup after the Machine was gone. The replacement controller could see the same tagged server as available before the reinstall had completed, then repeatedly try to bootstrap while the physical host was still transitioning through reinstall states.

## Impact

Server deploys no longer depend on every regional Kura ingress fleet having live admission endpoints. Regional Kura ingress-nginx dataplane pods continue to render and run normally; only their redundant global validating webhook registrations are removed.

Dedibox-backed Kura regions now avoid re-adopting boxes mid-reinstall and wait for a clean OS before bootstrap. This should prevent the canary Dedibox pool from collapsing to zero Ready nodes during a normal release/re-adoption cycle.

## Validation

- `bash -n infra/mise/tasks/k8s/install-platform.sh`
- `helm template` for canary, staging, and production platform overlays
- `helm lint` for canary, staging, and production platform overlays
- Confirmed rendered platform manifests keep the main ingress-nginx admission resources and omit regional Kura admission resources
- Read-only live checks confirmed the failing canary regional admission Service had no endpoints, while regional Kura ingress-nginx pods are still used where fleets are present
- `/Users/marekfort/.local/share/mise/installs/go/1.26.4/bin/go test ./internal/dedibox ./controllers/linux`
- `/Users/marekfort/.local/share/mise/installs/go/1.26.4/bin/go test ./...`
- `git diff --check`
