### PR TITLE
fix(server): handle utf16 slf strings in build logs

### DIFF
--- a/server/native/xcactivitylog_nif/Package.resolved
+++ b/server/native/xcactivitylog_nif/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "eaf0120aada03126bb2d5c22eea625b8ba0565517b1041850b9ed2c70ce15868",
+  "originHash" : "a91f206daaf42a4ffc9f5e9fc32a810ad6c53ec1c96b93b780b6db3e814a40ec",
   "pins" : [
     {
       "identity" : "1024jp.gzipswift",

--- a/server/native/xcactivitylog_nif/Package.swift
+++ b/server/native/xcactivitylog_nif/Package.swift
@@ -20,6 +20,7 @@ let package = Package(
         ),
     ],
     dependencies: [
+        .package(id: "1024jp.gzipswift", from: "5.2.0"),
         .package(id: "MobileNativeFoundation.XCLogParser", from: "0.2.48"),
         .package(id: "tuist.Path", from: "0.3.8"),
         .package(id: "tuist.FileSystem", .upToNextMajor(from: "0.16.2")),
@@ -36,6 +37,7 @@ let package = Package(
             name: "XCActivityLogParser",
             dependencies: [
                 "CASAnalyticsDatabase",
+                .product(name: "Gzip", package: "1024jp.gzipswift"),
                 .product(name: "XCLogParser", package: "MobileNativeFoundation.XCLogParser"),
                 .product(name: "Path", package: "tuist.Path"),
                 .product(name: "FileSystem", package: "tuist.FileSystem"),

--- a/server/native/xcactivitylog_nif/Sources/XCActivityLogParser/SLFLexer.swift
+++ b/server/native/xcactivitylog_nif/Sources/XCActivityLogParser/SLFLexer.swift
@@ -1,0 +1,183 @@
+import Foundation
+import XCLogParser
+
+final class SLFLexer {
+    private static let header = "SLF"
+    private static let typeDelimiters: Set<Character> = ["#", "%", "@", "\"", "^", "-", "(", "*"]
+    private static let payloadCharacters: Set<Character> = ["a", "b", "c", "d", "e", "f", "0", "1", "2", "3", "4", "5", "6", "7", "8", "9"]
+
+    private let filePath: String
+    private var classNames = [String]()
+
+    init(filePath: String) {
+        self.filePath = filePath
+    }
+
+    func tokenize(contents: String) throws -> [Token] {
+        let scanner = SLFScanner(string: contents)
+
+        guard scanner.scan(string: Self.header) else {
+            throw XCLogParserError.invalidLogHeader(filePath)
+        }
+
+        var tokens = [Token]()
+        while !scanner.isAtEnd {
+            guard let logTokens = scanSLFType(scanner: scanner), !logTokens.isEmpty else {
+                throw XCLogParserError.invalidLine(scanner.approximateLine)
+            }
+            tokens.append(contentsOf: logTokens)
+        }
+
+        return tokens
+    }
+
+    private func scanSLFType(scanner: SLFScanner) -> [Token]? {
+        let payload = scanPayload(scanner: scanner)
+
+        guard let tokenTypes = scanTypeDelimiter(scanner: scanner), !tokenTypes.isEmpty else {
+            return nil
+        }
+
+        var tokens = [Token]()
+        for tokenType in tokenTypes {
+            guard let token = scanToken(scanner: scanner, payload: payload, tokenType: tokenType) else {
+                return nil
+            }
+            tokens.append(token)
+        }
+
+        return tokens
+    }
+
+    private func scanPayload(scanner: SLFScanner) -> String {
+        scanner.scanCharacters(from: Self.payloadCharacters) ?? ""
+    }
+
+    private func scanTypeDelimiter(scanner: SLFScanner) -> [TokenType]? {
+        guard let delimiters = scanner.scanCharacters(from: Self.typeDelimiters) else {
+            return nil
+        }
+
+        if delimiters.count > 1, delimiters.first == Character(TokenType.string.rawValue) {
+            scanner.moveOffset(by: -(delimiters.count - 1))
+            return [.string]
+        }
+
+        return delimiters.compactMap { character in
+            TokenType(rawValue: String(character))
+        }
+    }
+
+    private func scanToken(scanner: SLFScanner, payload: String, tokenType: TokenType) -> Token? {
+        switch tokenType {
+        case .int:
+            return UInt64(payload).map(Token.int)
+        case .className:
+            guard let className = scanString(length: payload, scanner: scanner) else { return nil }
+            classNames.append(className)
+            return .className(className)
+        case .classNameRef:
+            guard let value = Int(payload), value > 0, value <= classNames.count else { return nil }
+            return .classNameRef(classNames[value - 1])
+        case .string:
+            return scanString(length: payload, scanner: scanner).map(Token.string)
+        case .double:
+            return hexToDouble(payload).map(Token.double)
+        case .null:
+            return .null
+        case .list:
+            return Int(payload).map(Token.list)
+        case .json:
+            return scanString(length: payload, scanner: scanner).map(Token.json)
+        }
+    }
+
+    private func scanString(length: String, scanner: SLFScanner) -> String? {
+        guard let length = Int(length) else { return nil }
+        return scanner.scanUTF16CodeUnits(count: length)
+    }
+
+    private func hexToDouble(_ input: String) -> Double? {
+        guard let beValue = UInt64(input, radix: 16) else { return nil }
+        return Double(bitPattern: beValue.byteSwapped)
+    }
+}
+
+private final class SLFScanner {
+    let string: String
+    private(set) var offset: Int
+
+    var isAtEnd: Bool {
+        offset >= string.utf16.count
+    }
+
+    var approximateLine: String {
+        let endOffset = min(offset + 21, string.utf16.count)
+        guard let start = index(atUTF16Offset: offset), let end = index(atUTF16Offset: endOffset), start <= end else {
+            return ""
+        }
+        return String(string[start..<end])
+    }
+
+    init(string: String) {
+        self.string = string
+        self.offset = 0
+    }
+
+    func scan(string value: String) -> Bool {
+        guard let start = index(atUTF16Offset: offset), string[start...].hasPrefix(value) else { return false }
+        offset += value.utf16.count
+        return true
+    }
+
+    func scanCharacters(from allowedCharacters: Set<Character>) -> String? {
+        var prefix = ""
+
+        while !isAtEnd {
+            guard let index = index(atUTF16Offset: offset) else { return nil }
+            let character = string[index]
+            guard allowedCharacters.contains(character) else { break }
+            prefix.append(character)
+            offset += character.utf16.count
+        }
+
+        return prefix
+    }
+
+    func scanUTF16CodeUnits(count: Int) -> String? {
+        let endOffset = offset + count
+        guard count >= 0,
+              endOffset <= string.utf16.count,
+              let start = index(atUTF16Offset: offset),
+              let end = index(atUTF16Offset: endOffset)
+        else {
+            return nil
+        }
+
+        let result = String(string[start..<end])
+        offset = endOffset
+        return result
+    }
+
+    func moveOffset(by value: Int) {
+        offset += value
+    }
+
+    private func index(atUTF16Offset utf16Offset: Int) -> String.Index? {
+        guard utf16Offset >= 0,
+              let utf16Index = string.utf16.index(
+                string.utf16.startIndex,
+                offsetBy: utf16Offset,
+                limitedBy: string.utf16.endIndex
+              )
+        else {
+            return nil
+        }
+
+        if utf16Index == string.utf16.endIndex {
+            return string.endIndex
+        }
+
+        return String.Index(utf16Index, within: string)
+    }
+}

--- a/server/native/xcactivitylog_nif/Sources/XCActivityLogParser/SLFLogLoader.swift
+++ b/server/native/xcactivitylog_nif/Sources/XCActivityLogParser/SLFLogLoader.swift
@@ -1,0 +1,15 @@
+import Foundation
+import Gzip
+import XCLogParser
+
+enum SLFLogLoader {
+    static func load(from url: URL) throws -> String {
+        do {
+            let data = try Data(contentsOf: url)
+            let unzipped = try data.gunzipped()
+            return String(decoding: unzipped, as: UTF8.self)
+        } catch {
+            throw LogError.invalidFile(url.path)
+        }
+    }
+}

--- a/server/native/xcactivitylog_nif/Sources/XCActivityLogParser/XCActivityLogParser.swift
+++ b/server/native/xcactivitylog_nif/Sources/XCActivityLogParser/XCActivityLogParser.swift
@@ -10,11 +10,7 @@ public struct XCActivityLogParser: Sendable {
         casAnalyticsDatabasePath: AbsolutePath,
         legacyCASMetadataPath: AbsolutePath? = nil
     ) async throws -> BuildData {
-        let activityLog = try ActivityParser().parseActivityLogInURL(
-            xcactivitylogURL,
-            redacted: false,
-            withoutBuildSpecificInformation: false
-        )
+        let activityLog = try parseActivityLog(at: xcactivitylogURL)
 
         let buildStep = try ParserBuildSteps(
             omitWarningsDetails: false,
@@ -78,6 +74,25 @@ public struct XCActivityLogParser: Sendable {
             cacheable_tasks: cacheableTasks,
             cas_outputs: casOutputs
         )
+    }
+
+    private func parseActivityLog(at url: URL) throws -> IDEActivityLog {
+        let activityParser = ActivityParser()
+        do {
+            return try activityParser.parseActivityLogInURL(
+                url,
+                redacted: false,
+                withoutBuildSpecificInformation: false
+            )
+        } catch let upstreamError {
+            do {
+                let contents = try SLFLogLoader.load(from: url)
+                let tokens = try SLFLexer(filePath: url.path).tokenize(contents: contents)
+                return try activityParser.parseIDEActiviyLogFromTokens(tokens)
+            } catch {
+                throw upstreamError
+            }
+        }
     }
 
     // MARK: - Build Steps

--- a/server/native/xcactivitylog_nif/Tests/XCActivityLogParserTests/XCActivityLogParserTests.swift
+++ b/server/native/xcactivitylog_nif/Tests/XCActivityLogParserTests/XCActivityLogParserTests.swift
@@ -2,6 +2,7 @@ import FileSystem
 import Foundation
 import Path
 import Testing
+import XCLogParser
 
 @testable import XCActivityLogParser
 
@@ -158,6 +159,24 @@ struct XCActivityLogParserTests {
             #expect(task.status != "hit_local",
                     "Upload-bearing key \(task.key) misclassified as hit_local")
         }
+    }
+
+    @Test func slfLexer_tokenizesStringsUsingUTF16Length() throws {
+        let value = "Sources/Bundle+Locali🙂"
+        let contents = "SLF0#\(value.utf16.count)\"\(value)1#"
+
+        let tokens = try SLFLexer(filePath: "test.xcactivitylog").tokenize(contents: contents)
+
+        #expect(tokens == [.int(0), .string(value), .int(1)])
+    }
+
+    @Test func slfLexer_preservesEmbeddedNullBytes() throws {
+        let value = "Sources/Bundle+Locali\u{0}zation"
+        let contents = "SLF0#\(value.utf16.count)\"\(value)1#"
+
+        let tokens = try SLFLexer(filePath: "test.xcactivitylog").tokenize(contents: contents)
+
+        #expect(tokens == [.int(0), .string(value), .int(1)])
     }
 }
 


### PR DESCRIPTION
## What changed

- Added a local SLF lexer fallback for the `xcactivitylog` NIF parser.
- Added a loader that decodes gunzipped log bytes as UTF-8 data instead of C string data, preserving embedded NUL bytes.
- Wired the fallback so normal logs still use `XCLogParser.ActivityParser.parseActivityLogInURL`, and only parser failures retry through the local tokenization path before handing tokens back to `XCLogParser`.
- Added regression tests for UTF-16 string lengths and embedded NUL content in SLF strings.

## Why

Build processing can fail on valid `.xcactivitylog` files with errors like:

```text
The line Sources/Bundle+Locali doesn't seem like a valid SLF line
```

The upstream lexer scans SLF string payloads by UTF-16 offsets, but then rejects the scanned string when `String.count` does not match the encoded length. SLF string lengths are UTF-16 code units, while `String.count` counts grapheme clusters. A valid path or diagnostic containing multi-code-unit characters can therefore desynchronize tokenization and make the worker discard the build.

The C-string loader path can also truncate valid content at embedded NUL bytes. Decoding the decompressed bytes directly avoids that truncation.

## Impact

Valid Xcode activity logs with UTF-16-length string payloads or embedded NUL bytes should process instead of being discarded by `ProcessBuildWorker`. Existing successful logs continue to take the upstream parser path first.

## Validation

- `swift test --replace-scm-with-registry --cache-path "$tmp_cache" --manifest-cache local --filter XCActivityLogParserTests/slfLexer`
- `swift test --replace-scm-with-registry --disable-automatic-resolution --filter XCActivityLogParserTests/cleanBuild_parsesSuccessfully`
- `git diff --check`