### PR TITLE
fix(cli): avoid shard artifact upload collisions

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -996,6 +996,7 @@ var targets: [Target] = [
             "TuistHTTP",
             "TuistEnvironment",
             "TuistEnvironmentTesting",
+            fileSystemDependency,
             mockableDependency,
         ],
         path: "cli/Tests/TuistHTTPTests"

--- a/Tuist/ProjectDescriptionHelpers/Module.swift
+++ b/Tuist/ProjectDescriptionHelpers/Module.swift
@@ -2072,6 +2072,7 @@ public enum Module: String, CaseIterable {
                     .target(name: Module.environmentTesting.targetName),
                     .external(name: "OpenAPIRuntime"),
                     .external(name: "HTTPTypes"),
+                    .external(name: "FileSystem"),
                 ]
             }
         dependencies =

--- a/cli/Sources/TuistAppleArchiver/AppleArchiver.swift
+++ b/cli/Sources/TuistAppleArchiver/AppleArchiver.swift
@@ -32,6 +32,11 @@ public protocol AppleArchiving {
         relativeTo baseDirectory: AbsolutePath,
         to archivePath: AbsolutePath
     ) async throws
+    func compress(
+        subdirectories: [AbsolutePath],
+        relativeTo baseDirectory: AbsolutePath,
+        to archivePath: AbsolutePath
+    ) async throws
     func decompress(archive: AbsolutePath, to directory: AbsolutePath) async throws
 }
 
@@ -130,7 +135,17 @@ public struct AppleArchiver: AppleArchiving {
         relativeTo baseDirectory: AbsolutePath,
         to archivePath: AbsolutePath
     ) async throws {
-        let relativePath = subdirectory.relative(to: baseDirectory).pathString
+        try await compress(subdirectories: [subdirectory], relativeTo: baseDirectory, to: archivePath)
+    }
+
+    public func compress(
+        subdirectories: [AbsolutePath],
+        relativeTo baseDirectory: AbsolutePath,
+        to archivePath: AbsolutePath
+    ) async throws {
+        let relativePaths = subdirectories
+            .map { $0.relative(to: baseDirectory).pathString }
+            .sorted()
 
         // writeDirectoryContents may visit the same file twice when the source
         // directory contains symlinks to sibling directories. Track seen paths
@@ -142,8 +157,10 @@ public struct AppleArchiver: AppleArchiving {
             // to it (so the walk descends that far) and prune everything else.
             // `.skip` on a directory header also prunes its descendants, so the
             // sibling bundles in the same products directory are never read.
-            let isWithinTarget = pathString == relativePath || pathString.hasPrefix("\(relativePath)/")
-            let isAncestor = relativePath.hasPrefix("\(pathString)/")
+            let isWithinTarget = relativePaths.contains { relativePath in
+                pathString == relativePath || pathString.hasPrefix("\(relativePath)/")
+            }
+            let isAncestor = relativePaths.contains { $0.hasPrefix("\(pathString)/") }
             guard isWithinTarget || isAncestor else { return .skip }
             let inserted = seenPaths.withLock { $0.insert(pathString).inserted }
             guard inserted else { return .skip }

--- a/cli/Sources/TuistHAR/HARRecordingMiddleware.swift
+++ b/cli/Sources/TuistHAR/HARRecordingMiddleware.swift
@@ -56,23 +56,13 @@ public struct HARRecordingMiddleware: ClientMiddleware {
 
             return (response, responseBodyForNext)
         } catch {
-            recorder.recordDetached { recorder in
-                let fullURL = Self.buildURL(baseURL: baseURL, path: request.path)
-                let harMetadata = await Self.retrieveHARMetadata(for: fullURL)
-
-                await recorder.recordError(
-                    url: fullURL,
-                    method: request.method.rawValue,
-                    requestHeaders: request.headerFields.map { HAR.Header(name: $0.name.rawName, value: $0.value) },
-                    requestBody: requestBodyData,
-                    error: error,
-                    startTime: harMetadata.startTime,
-                    endTime: harMetadata.endTime,
-                    timings: harMetadata.timings,
-                    httpVersion: harMetadata.httpVersion,
-                    requestHeadersSize: harMetadata.requestHeadersSize
-                )
-            }
+            await Self.recordError(
+                for: request,
+                requestBody: requestBodyData,
+                baseURL: baseURL,
+                error: error,
+                recorder: recorder
+            )
 
             throw error
         }
@@ -91,6 +81,30 @@ public struct HARRecordingMiddleware: ClientMiddleware {
             let bodyData = try await Data(collecting: body!, upTo: Int(length))
             return (bodyData, HTTPBody(bodyData))
         }
+    }
+
+    private static func recordError(
+        for request: HTTPRequest,
+        requestBody: Data?,
+        baseURL: URL,
+        error: Error,
+        recorder: HARRecorder
+    ) async {
+        let fullURL = Self.buildURL(baseURL: baseURL, path: request.path)
+        let harMetadata = await Self.retrieveHARMetadata(for: fullURL)
+
+        await recorder.recordError(
+            url: fullURL,
+            method: request.method.rawValue,
+            requestHeaders: request.headerFields.map { HAR.Header(name: $0.name.rawName, value: $0.value) },
+            requestBody: requestBody,
+            error: error,
+            startTime: harMetadata.startTime,
+            endTime: harMetadata.endTime,
+            timings: harMetadata.timings,
+            httpVersion: harMetadata.httpVersion,
+            requestHeadersSize: harMetadata.requestHeadersSize
+        )
     }
 
     private static func isBinaryContentType(_ contentType: String?) -> Bool {

--- a/cli/Sources/TuistHTTP/FileClient.swift
+++ b/cli/Sources/TuistHTTP/FileClient.swift
@@ -51,7 +51,7 @@ import Path
 
     public protocol FileClienting {
         func upload(file: AbsolutePath, hash: String, to url: URL) async throws -> Bool
-        func download(url: URL) async throws -> AbsolutePath
+        func download(url: URL, to destination: AbsolutePath) async throws -> AbsolutePath
     }
 
     public struct FileClient: FileClienting {
@@ -73,7 +73,7 @@ import Path
 
         // MARK: - Public
 
-        public func download(url: URL) async throws -> AbsolutePath {
+        public func download(url: URL, to destination: AbsolutePath) async throws -> AbsolutePath {
             let request = URLRequest(url: url)
             let session = resolvedSession()
             do {
@@ -89,7 +89,9 @@ import Path
                     await Self.recordDownload(request: request, response: httpResponse, recorder: recorder)
                 }
                 if successStatusCodeRange.contains(httpResponse.statusCode) {
-                    return try AbsolutePath(validating: localUrl.path)
+                    let downloadedPath = try AbsolutePath(validating: localUrl.path)
+                    try await fileSystem.move(from: downloadedPath, to: destination)
+                    return destination
                 } else {
                     throw FileClientError.invalidResponse(request, nil)
                 }
@@ -99,7 +101,7 @@ import Path
                 HARRecorder.recordDetached { recorder in
                     await Self.recordDownloadError(request: request, error: error, recorder: recorder)
                 }
-                throw FileClientError.urlSessionError(request, error, nil)
+                throw FileClientError.urlSessionError(request, error, destination)
             }
         }
 

--- a/cli/Sources/TuistHTTP/FileClient.swift
+++ b/cli/Sources/TuistHTTP/FileClient.swift
@@ -51,7 +51,7 @@ import Path
 
     public protocol FileClienting {
         func upload(file: AbsolutePath, hash: String, to url: URL) async throws -> Bool
-        func download(url: URL, to destination: AbsolutePath) async throws -> AbsolutePath
+        func download(url: URL, to destination: AbsolutePath) async throws
     }
 
     public struct FileClient: FileClienting {
@@ -73,7 +73,7 @@ import Path
 
         // MARK: - Public
 
-        public func download(url: URL, to destination: AbsolutePath) async throws -> AbsolutePath {
+        public func download(url: URL, to destination: AbsolutePath) async throws {
             let request = URLRequest(url: url)
             let session = resolvedSession()
             do {
@@ -91,7 +91,6 @@ import Path
                 if successStatusCodeRange.contains(httpResponse.statusCode) {
                     let downloadedPath = try AbsolutePath(validating: localUrl.path)
                     try await fileSystem.move(from: downloadedPath, to: destination)
-                    return destination
                 } else {
                     throw FileClientError.invalidResponse(request, nil)
                 }

--- a/cli/Sources/TuistKit/Services/Sharding/ShardPlanService.swift
+++ b/cli/Sources/TuistKit/Services/Sharding/ShardPlanService.swift
@@ -56,7 +56,7 @@
 
         private enum SplitArtifact {
             case shared
-            case module(AbsolutePath)
+            case module(name: String, paths: [AbsolutePath])
         }
 
         private let createShardPlanService: CreateShardPlanServicing
@@ -184,11 +184,17 @@
             Logger.current.debug("Uploading test products artifacts...")
 
             let archiveDirectory = try await fileSystem.makeTemporaryDirectory(prefix: "tuist-shard-archive")
-            let xctestPaths = try await fileSystem.glob(directory: xctestproductsPath, include: ["**/*.xctest"]).collect()
+            let xctestPaths = try await fileSystem.glob(directory: xctestproductsPath, include: ["**/*.xctest"])
+                .collect()
+                .sorted(by: { $0.pathString < $1.pathString })
+            let moduleArtifacts = Dictionary(grouping: xctestPaths, by: \.basenameWithoutExt)
+                .map { module, paths in (name: module, paths: paths.sorted(by: { $0.pathString < $1.pathString })) }
+                .sorted(by: { $0.name < $1.name })
+                .map { SplitArtifact.module(name: $0.name, paths: $0.paths) }
 
             // Each artifact (the shared bundle plus one per module) is an independent compress + upload;
             // run them concurrently, capped so a project with many modules doesn't oversubscribe the host.
-            let artifacts: [SplitArtifact] = [.shared] + xctestPaths.map(SplitArtifact.module)
+            let artifacts: [SplitArtifact] = [.shared] + moduleArtifacts
             _ = try await artifacts.concurrentMap(maxConcurrentTasks: Self.maxConcurrentArtifactUploads) { artifact in
                 switch artifact {
                 case .shared:
@@ -209,10 +215,9 @@
                         shardPlanId: shardPlanId,
                         reference: reference
                     )
-                case let .module(xctestPath):
-                    let module = xctestPath.basenameWithoutExt
+                case let .module(module, xctestPaths):
                     let moduleArchive = archiveDirectory.appending(component: "\(module).aar")
-                    try await archiveModuleProduct(xctestPath, productsPath: xctestproductsPath, to: moduleArchive)
+                    try await archiveModuleProducts(xctestPaths, productsPath: xctestproductsPath, to: moduleArchive)
                     try await uploadArtifact(
                         archivePath: moduleArchive,
                         artifact: "module:\(module)",
@@ -270,17 +275,18 @@
             )
         }
 
-        /// Archives a single module's `.xctest` preserving its path relative to the products root,
-        /// so extracting it alongside the shared artifact reconstructs the original layout. The
-        /// `.xctest` is read in place — a project with hundreds of modules would otherwise copy
-        /// every (multi-hundred-MB) test bundle into a staging directory before compressing it.
-        private func archiveModuleProduct(
-            _ xctestPath: AbsolutePath,
+        /// Archives a module's `.xctest` bundle(s) preserving their paths relative to the products
+        /// root, so extracting alongside the shared artifact reconstructs the original layout.
+        /// The `.xctest` bundles are read in place — a project with hundreds of modules would
+        /// otherwise copy every (multi-hundred-MB) test bundle into a staging directory before
+        /// compressing it.
+        private func archiveModuleProducts(
+            _ xctestPaths: [AbsolutePath],
             productsPath: AbsolutePath,
             to archivePath: AbsolutePath
         ) async throws {
             try await appleArchiver.compress(
-                subdirectory: xctestPath,
+                subdirectories: xctestPaths,
                 relativeTo: productsPath,
                 to: archivePath
             )

--- a/cli/Sources/TuistKit/Services/Sharding/ShardService.swift
+++ b/cli/Sources/TuistKit/Services/Sharding/ShardService.swift
@@ -116,14 +116,16 @@ public struct ShardService: ShardServicing {
             Logger.current.debug("Extracted local shard archive to \(resolvedTestProductsPath.pathString)")
         } else {
             let extractedTestProductsPath = try await fileSystem.makeTemporaryDirectory(prefix: "tuist-shard-unzip")
+            let downloadedArtifactsPath = try await fileSystem.makeTemporaryDirectory(prefix: "tuist-shard-downloads")
             // The shard's products are split across artifacts (a shared bundle plus one per module
             // assigned to the shard); download each and extract them into a single merged directory.
-            for downloadURLString in shard.download_urls {
+            for (downloadIndex, downloadURLString) in shard.download_urls.enumerated() {
                 guard let downloadURL = URL(string: downloadURLString) else {
                     throw ShardServiceError.invalidDownloadURL(downloadURLString)
                 }
+                let shardArchiveDestinationPath = downloadedArtifactsPath.appending(component: "artifact-\(downloadIndex).aar")
                 let shardArchivePath = try await retryProvider.runWithRetries {
-                    try await fileClient.download(url: downloadURL)
+                    try await fileClient.download(url: downloadURL, to: shardArchiveDestinationPath)
                 }
                 try await appleArchiver.decompress(archive: shardArchivePath, to: extractedTestProductsPath)
                 try? await fileSystem.remove(shardArchivePath)

--- a/cli/Sources/TuistKit/Services/Sharding/ShardService.swift
+++ b/cli/Sources/TuistKit/Services/Sharding/ShardService.swift
@@ -124,11 +124,11 @@ public struct ShardService: ShardServicing {
                     throw ShardServiceError.invalidDownloadURL(downloadURLString)
                 }
                 let shardArchiveDestinationPath = downloadedArtifactsPath.appending(component: "artifact-\(downloadIndex).aar")
-                let shardArchivePath = try await retryProvider.runWithRetries {
+                try await retryProvider.runWithRetries {
                     try await fileClient.download(url: downloadURL, to: shardArchiveDestinationPath)
                 }
-                try await appleArchiver.decompress(archive: shardArchivePath, to: extractedTestProductsPath)
-                try? await fileSystem.remove(shardArchivePath)
+                try await appleArchiver.decompress(archive: shardArchiveDestinationPath, to: extractedTestProductsPath)
+                try? await fileSystem.remove(shardArchiveDestinationPath)
             }
             Logger.current.debug("Downloaded \(shard.download_urls.count) test products artifact(s).")
             resolvedTestProductsPath = try await normalizeExtractedTestProductsPath(extractedTestProductsPath)

--- a/cli/Sources/TuistKit/Services/Sharding/ShardService.swift
+++ b/cli/Sources/TuistKit/Services/Sharding/ShardService.swift
@@ -116,19 +116,21 @@ public struct ShardService: ShardServicing {
             Logger.current.debug("Extracted local shard archive to \(resolvedTestProductsPath.pathString)")
         } else {
             let extractedTestProductsPath = try await fileSystem.makeTemporaryDirectory(prefix: "tuist-shard-unzip")
-            let downloadedArtifactsPath = try await fileSystem.makeTemporaryDirectory(prefix: "tuist-shard-downloads")
-            // The shard's products are split across artifacts (a shared bundle plus one per module
-            // assigned to the shard); download each and extract them into a single merged directory.
-            for (downloadIndex, downloadURLString) in shard.download_urls.enumerated() {
-                guard let downloadURL = URL(string: downloadURLString) else {
-                    throw ShardServiceError.invalidDownloadURL(downloadURLString)
+            try await fileSystem.runInTemporaryDirectory(prefix: "tuist-shard-downloads") { downloadedArtifactsPath in
+                // The shard's products are split across artifacts (a shared bundle plus one per module
+                // assigned to the shard); download each and extract them into a single merged directory.
+                for (downloadIndex, downloadURLString) in shard.download_urls.enumerated() {
+                    guard let downloadURL = URL(string: downloadURLString) else {
+                        throw ShardServiceError.invalidDownloadURL(downloadURLString)
+                    }
+                    let shardArchiveDestinationPath = downloadedArtifactsPath
+                        .appending(component: "artifact-\(downloadIndex).aar")
+                    try await retryProvider.runWithRetries {
+                        try await fileClient.download(url: downloadURL, to: shardArchiveDestinationPath)
+                    }
+                    try await appleArchiver.decompress(archive: shardArchiveDestinationPath, to: extractedTestProductsPath)
+                    try? await fileSystem.remove(shardArchiveDestinationPath)
                 }
-                let shardArchiveDestinationPath = downloadedArtifactsPath.appending(component: "artifact-\(downloadIndex).aar")
-                try await retryProvider.runWithRetries {
-                    try await fileClient.download(url: downloadURL, to: shardArchiveDestinationPath)
-                }
-                try await appleArchiver.decompress(archive: shardArchiveDestinationPath, to: extractedTestProductsPath)
-                try? await fileSystem.remove(shardArchiveDestinationPath)
             }
             Logger.current.debug("Downloaded \(shard.download_urls.count) test products artifact(s).")
             resolvedTestProductsPath = try await normalizeExtractedTestProductsPath(extractedTestProductsPath)

--- a/cli/Sources/TuistPlugin/PluginService.swift
+++ b/cli/Sources/TuistPlugin/PluginService.swift
@@ -289,24 +289,25 @@ public struct PluginService: PluginServicing {
         else { throw PluginServiceError.invalidURL(url) }
 
         Logger.current.debug("Cloning plugin release from \(url) @ \(gitTag)")
-        try await fileSystem.runInTemporaryDirectory { _ in
+        try await fileSystem.runInTemporaryDirectory { temporaryDirectory in
             // Download the release.
             // Currently, we assume the release path exists.
-            let downloadPath = try await fileClient.download(url: releaseURL)
-            let downloadZipPath = downloadPath.removingLastComponent().appending(component: "release.zip")
-            let fileUnarchiver = try fileArchivingFactory.makeFileUnarchiver(for: downloadZipPath)
+            let downloadZipPath = temporaryDirectory.appending(component: "release.zip")
 
             var thrownError: Error?
+            var fileUnarchiver: FileUnarchiving?
 
             do {
                 if try await fileSystem.exists(downloadZipPath) {
                     try await fileSystem.remove(downloadZipPath)
                 }
-                try await fileSystem.move(from: downloadPath, to: downloadZipPath)
+                try await fileClient.download(url: releaseURL, to: downloadZipPath)
+                let unarchiver = try fileArchivingFactory.makeFileUnarchiver(for: downloadZipPath)
+                fileUnarchiver = unarchiver
 
                 // Unzip
                 let unarchivedContents = try await fileSystem.contentsOfDirectory(
-                    try fileUnarchiver.unzip()
+                    try unarchiver.unzip()
                 )
 
                 try await fileSystem.makeDirectory(at: pluginReleaseDirectory)
@@ -327,8 +328,7 @@ public struct PluginService: PluginServicing {
                 thrownError = error
             }
 
-            try? await fileUnarchiver.delete()
-            try? await fileSystem.remove(downloadPath)
+            try? await fileUnarchiver?.delete()
             try? await fileSystem.remove(downloadZipPath)
 
             if let thrownError { throw thrownError }

--- a/cli/Sources/TuistServer/Services/MultipartUploadArtifactService.swift
+++ b/cli/Sources/TuistServer/Services/MultipartUploadArtifactService.swift
@@ -95,8 +95,6 @@ public struct MultipartUploadArtifactService: MultipartUploadArtifactServicing {
     /// holds every part in memory at once, so memory grows with the artifact and OOMs on multi-GB
     /// uploads (e.g. a large shard test-products bundle).
     private static let maxConcurrentParts = 10
-    private static let maxReadAttempts = 3
-    private static let readRetryDelayNanoseconds: UInt64 = 100_000_000
 
     private let urlSession: URLSession?
     private let fileSystem: FileSysteming
@@ -117,34 +115,25 @@ public struct MultipartUploadArtifactService: MultipartUploadArtifactServicing {
         generateUploadURL: @escaping (MultipartUploadArtifactPart) async throws -> String,
         updateProgress: @escaping (Double) -> Void
     ) async throws -> [(etag: String, partNumber: Int)] {
-        var lastReadMismatch: (expectedBytes: UInt64, readBytes: UInt64)?
+        let size = try await fileSizeInBytes(at: artifactPath)
+        let uploadResult = try await uploadParts(
+            artifactPath: artifactPath,
+            fileSize: size,
+            generateUploadURL: generateUploadURL,
+            updateProgress: updateProgress
+        )
+        let currentSize = try await fileSizeInBytes(at: artifactPath)
 
-        for attempt in 1 ... Self.maxReadAttempts {
-            let size = try await fileSizeInBytes(at: artifactPath)
-            let uploadResult = try await uploadParts(
-                artifactPath: artifactPath,
-                fileSize: size,
-                generateUploadURL: generateUploadURL,
-                updateProgress: updateProgress
+        guard uploadResult.readBytes == size, currentSize == size else {
+            throw MultipartUploadArtifactServiceError.incompleteArtifactRead(
+                artifactPath,
+                expectedBytes: currentSize,
+                readBytes: uploadResult.readBytes
             )
-            let currentSize = try await fileSizeInBytes(at: artifactPath)
-
-            if uploadResult.readBytes == size, currentSize == size {
-                return uploadResult.uploadedParts
-                    .sorted(by: { $0.partNumber < $1.partNumber })
-            }
-
-            lastReadMismatch = (expectedBytes: currentSize, readBytes: uploadResult.readBytes)
-            if attempt < Self.maxReadAttempts {
-                try await Task.sleep(nanoseconds: Self.readRetryDelayNanoseconds)
-            }
         }
 
-        throw MultipartUploadArtifactServiceError.incompleteArtifactRead(
-            artifactPath,
-            expectedBytes: lastReadMismatch?.expectedBytes ?? 0,
-            readBytes: lastReadMismatch?.readBytes ?? 0
-        )
+        return uploadResult.uploadedParts
+            .sorted(by: { $0.partNumber < $1.partNumber })
     }
 
     private func fileSizeInBytes(at path: AbsolutePath) async throws -> UInt64 {

--- a/cli/Sources/TuistServer/Services/MultipartUploadArtifactService.swift
+++ b/cli/Sources/TuistServer/Services/MultipartUploadArtifactService.swift
@@ -20,7 +20,10 @@ public struct MultipartUploadArtifactPart {
 
 enum MultipartUploadArtifactServiceError: LocalizedError {
     case cannotCreateInputStream(AbsolutePath)
+    case failedToReadArtifact(AbsolutePath, String)
+    case incompleteArtifactRead(AbsolutePath, expectedBytes: UInt64, readBytes: UInt64)
     case noURLResponse(URL?)
+    case uploadFailed(URL?, statusCode: Int, body: String)
     case missingEtag(URL?, statusCode: Int, body: String)
     case invalidMultipartUploadURL(String)
 
@@ -28,11 +31,31 @@ enum MultipartUploadArtifactServiceError: LocalizedError {
         switch self {
         case let .cannotCreateInputStream(path):
             return "Couldn't create the file stream to multi-part upload file at path \(path.pathString)"
+        case let .failedToReadArtifact(path, reason):
+            return "Failed to read artifact at path \(path.pathString) for multipart upload: \(reason)"
+        case let .incompleteArtifactRead(path, expectedBytes, readBytes):
+            return """
+            Failed to read the complete artifact at path \(path.pathString) for multipart upload:
+            - Expected bytes: \(expectedBytes)
+            - Read bytes: \(readBytes)
+            """
         case let .noURLResponse(url):
             if let url {
                 return "The response from request to URL \(url.absoluteString) doesnt' have the expected type HTTPURLResponse"
             } else {
                 return "Received a response that doesn't have the expected type HTTPURLResponse"
+            }
+        case let .uploadFailed(url, statusCode, body):
+            if let url {
+                return """
+                The multipart upload request to URL \(url.absoluteString) failed with status code \(statusCode):
+                - Body: \(body)
+                """
+            } else {
+                return """
+                The multipart upload request failed with status code \(statusCode):
+                - Body: \(body)
+                """
             }
         case let .missingEtag(url, statusCode, body):
             if let url {
@@ -72,6 +95,8 @@ public struct MultipartUploadArtifactService: MultipartUploadArtifactServicing {
     /// holds every part in memory at once, so memory grows with the artifact and OOMs on multi-GB
     /// uploads (e.g. a large shard test-products bundle).
     private static let maxConcurrentParts = 10
+    private static let maxReadAttempts = 3
+    private static let readRetryDelayNanoseconds: UInt64 = 100_000_000
 
     private let urlSession: URLSession?
     private let fileSystem: FileSysteming
@@ -92,65 +117,145 @@ public struct MultipartUploadArtifactService: MultipartUploadArtifactServicing {
         generateUploadURL: @escaping (MultipartUploadArtifactPart) async throws -> String,
         updateProgress: @escaping (Double) -> Void
     ) async throws -> [(etag: String, partNumber: Int)] {
+        var lastReadMismatch: (expectedBytes: UInt64, readBytes: UInt64)?
+
+        for attempt in 1 ... Self.maxReadAttempts {
+            let size = try await fileSizeInBytes(at: artifactPath)
+            let uploadResult = try await uploadParts(
+                artifactPath: artifactPath,
+                fileSize: size,
+                generateUploadURL: generateUploadURL,
+                updateProgress: updateProgress
+            )
+            let currentSize = try await fileSizeInBytes(at: artifactPath)
+
+            if uploadResult.readBytes == size, currentSize == size {
+                return uploadResult.uploadedParts
+                    .sorted(by: { $0.partNumber < $1.partNumber })
+            }
+
+            lastReadMismatch = (expectedBytes: currentSize, readBytes: uploadResult.readBytes)
+            if attempt < Self.maxReadAttempts {
+                try await Task.sleep(nanoseconds: Self.readRetryDelayNanoseconds)
+            }
+        }
+
+        throw MultipartUploadArtifactServiceError.incompleteArtifactRead(
+            artifactPath,
+            expectedBytes: lastReadMismatch?.expectedBytes ?? 0,
+            readBytes: lastReadMismatch?.readBytes ?? 0
+        )
+    }
+
+    private func fileSizeInBytes(at path: AbsolutePath) async throws -> UInt64 {
+        guard let metadata = try await fileSystem.fileMetadata(at: path) else { return 0 }
+        return UInt64(metadata.size)
+    }
+
+    private func uploadParts(
+        artifactPath: AbsolutePath,
+        fileSize: UInt64,
+        generateUploadURL: @escaping (MultipartUploadArtifactPart) async throws -> String,
+        updateProgress: @escaping (Double) -> Void
+    ) async throws -> (readBytes: UInt64, uploadedParts: [(etag: String, partNumber: Int)]) {
         let partSize = 10 * 1024 * 1024
         guard let inputStream = InputStream(url: URL(fileURLWithPath: artifactPath.pathString)) else {
             throw MultipartUploadArtifactServiceError.cannotCreateInputStream(artifactPath)
         }
 
-        let size = try await fileSystem.fileSizeInBytes(at: artifactPath) ?? 0
-        let numberOfParts = Int(ceil(Double(Int(size)) / Double(partSize)))
+        let numberOfParts = Int(ceil(Double(Int(fileSize)) / Double(partSize)))
 
         inputStream.open()
-
         defer { inputStream.close() }
 
         var buffer = [UInt8](repeating: 0, count: partSize)
-
+        var readBytes: UInt64 = 0
         let uploadedParts: ThreadSafe<[(etag: String, partNumber: Int)]> = ThreadSafe([])
         let partNumber = ThreadSafe(1)
 
         try await withThrowingTaskGroup(of: Void.self) { group in
             var partsInFlight = 0
-            while inputStream.hasBytesAvailable {
-                let bytesRead = inputStream.read(&buffer, maxLength: partSize)
-                guard bytesRead > 0 else { break }
-
-                // Backpressure: wait for a part to finish before reading the next once the cap is
-                // reached, so at most `maxConcurrentParts` part buffers are resident at any time.
-                // Each part copies its slice into its own `Data`; without this the loop reads the
-                // whole artifact into memory ahead of the uploads.
+            while let partData = try readPart(
+                from: inputStream,
+                buffer: &buffer,
+                maxLength: partSize,
+                artifactPath: artifactPath
+            ) {
+                readBytes += UInt64(partData.count)
                 if partsInFlight >= Self.maxConcurrentParts {
                     try await group.next()
                     partsInFlight -= 1
                 }
-
-                let partData = Data(bytes: buffer, count: bytesRead)
-                let currentPartNumber = partNumber.value
-                partNumber.mutate { $0 += 1 }
-                group.addTask {
-                    try await retryProvider.runWithRetries {
-                        let uploadURLString = try await generateUploadURL(MultipartUploadArtifactPart(
-                            number: currentPartNumber,
-                            contentLength: bytesRead
-                        ))
-                        guard let url = URL(string: uploadURLString) else {
-                            throw MultipartUploadArtifactServiceError.invalidMultipartUploadURL(uploadURLString)
-                        }
-
-                        let request = uploadRequest(url: url, fileSize: UInt64(bytesRead), data: partData)
-                        let etag = try await upload(for: request)
-                        uploadedParts.mutate { $0.append((etag: etag, partNumber: currentPartNumber)) }
-                        updateProgress(Double(uploadedParts.value.count) / Double(numberOfParts))
-                    }
-                }
+                addUploadTask(
+                    to: &group,
+                    partData: partData,
+                    partNumber: partNumber,
+                    numberOfParts: numberOfParts,
+                    uploadedParts: uploadedParts,
+                    generateUploadURL: generateUploadURL,
+                    updateProgress: updateProgress
+                )
                 partsInFlight += 1
             }
             try await group.waitForAll()
         }
 
-        return uploadedParts
-            .value
-            .sorted(by: { $0.partNumber < $1.partNumber })
+        return (readBytes: readBytes, uploadedParts: uploadedParts.value)
+    }
+
+    private func addUploadTask(
+        to group: inout ThrowingTaskGroup<Void, any Error>,
+        partData: Data,
+        partNumber: ThreadSafe<Int>,
+        numberOfParts: Int,
+        uploadedParts: ThreadSafe<[(etag: String, partNumber: Int)]>,
+        generateUploadURL: @escaping (MultipartUploadArtifactPart) async throws -> String,
+        updateProgress: @escaping (Double) -> Void
+    ) {
+        let bytesRead = partData.count
+        let currentPartNumber = partNumber.value
+        partNumber.mutate { $0 += 1 }
+        group.addTask {
+            try await retryProvider.runWithRetries {
+                let uploadURLString = try await generateUploadURL(MultipartUploadArtifactPart(
+                    number: currentPartNumber,
+                    contentLength: bytesRead
+                ))
+                guard let url = URL(string: uploadURLString) else {
+                    throw MultipartUploadArtifactServiceError.invalidMultipartUploadURL(uploadURLString)
+                }
+
+                let request = uploadRequest(url: url, fileSize: UInt64(bytesRead), data: partData)
+                let etag = try await upload(for: request)
+                uploadedParts.mutate { $0.append((etag: etag, partNumber: currentPartNumber)) }
+                updateProgress(Double(uploadedParts.value.count) / Double(numberOfParts))
+            }
+        }
+    }
+
+    private func readPart(
+        from inputStream: InputStream,
+        buffer: inout [UInt8],
+        maxLength: Int,
+        artifactPath: AbsolutePath
+    ) throws -> Data? {
+        var partData = Data()
+        partData.reserveCapacity(maxLength)
+
+        while partData.count < maxLength {
+            let remainingBytes = maxLength - partData.count
+            let bytesRead = inputStream.read(&buffer, maxLength: min(buffer.count, remainingBytes))
+
+            if bytesRead < 0 {
+                let reason = inputStream.streamError?.localizedDescription ?? "unknown stream error"
+                throw MultipartUploadArtifactServiceError.failedToReadArtifact(artifactPath, reason)
+            }
+
+            guard bytesRead > 0 else { break }
+            partData.append(buffer, count: bytesRead)
+        }
+
+        return partData.isEmpty ? nil : partData
     }
 
     private func upload(for request: URLRequest) async throws -> String {
@@ -158,6 +263,14 @@ public struct MultipartUploadArtifactService: MultipartUploadArtifactServicing {
         let (data, response) = try await urlSession.data(for: request)
         guard let urlResponse = response as? HTTPURLResponse else {
             throw MultipartUploadArtifactServiceError.noURLResponse(request.url)
+        }
+        guard (200 ..< 300).contains(urlResponse.statusCode) else {
+            let body = String(data: data, encoding: .utf8) ?? ""
+            throw MultipartUploadArtifactServiceError.uploadFailed(
+                request.url,
+                statusCode: urlResponse.statusCode,
+                body: body
+            )
         }
         guard let etag = urlResponse.value(forHTTPHeaderField: "Etag") else {
             let body = String(data: data, encoding: .utf8) ?? ""

--- a/cli/Sources/TuistTesting/HTTP/MockFileClient.swift
+++ b/cli/Sources/TuistTesting/HTTP/MockFileClient.swift
@@ -31,16 +31,16 @@ import TuistSupport
 
         public var invokedDownload = false
         public var invokedDownloadCount = 0
-        public var invokedDownloadParameters: (url: URL, Void)?
-        public var invokedDownloadParametersList = [(url: URL, Void)]()
+        public var invokedDownloadParameters: (url: URL, destination: AbsolutePath)?
+        public var invokedDownloadParametersList = [(url: URL, destination: AbsolutePath)]()
         public var stubbedDownloadResult: AbsolutePath!
 
-        public func download(url: URL) async throws -> AbsolutePath {
+        public func download(url: URL, to destination: AbsolutePath) async throws -> AbsolutePath {
             invokedDownload = true
             invokedDownloadCount += 1
-            invokedDownloadParameters = (url, ())
-            invokedDownloadParametersList.append((url, ()))
-            return stubbedDownloadResult
+            invokedDownloadParameters = (url, destination)
+            invokedDownloadParametersList.append((url, destination))
+            return stubbedDownloadResult ?? destination
         }
     }
 

--- a/cli/Sources/TuistTesting/HTTP/MockFileClient.swift
+++ b/cli/Sources/TuistTesting/HTTP/MockFileClient.swift
@@ -33,14 +33,12 @@ import TuistSupport
         public var invokedDownloadCount = 0
         public var invokedDownloadParameters: (url: URL, destination: AbsolutePath)?
         public var invokedDownloadParametersList = [(url: URL, destination: AbsolutePath)]()
-        public var stubbedDownloadResult: AbsolutePath!
 
-        public func download(url: URL, to destination: AbsolutePath) async throws -> AbsolutePath {
+        public func download(url: URL, to destination: AbsolutePath) async throws {
             invokedDownload = true
             invokedDownloadCount += 1
             invokedDownloadParameters = (url, destination)
             invokedDownloadParametersList.append((url, destination))
-            return stubbedDownloadResult ?? destination
         }
     }
 

--- a/cli/Tests/TuistAppleArchiverTests/AppleArchiverTests.swift
+++ b/cli/Tests/TuistAppleArchiverTests/AppleArchiverTests.swift
@@ -291,4 +291,47 @@ struct AppleArchiverTests {
         let metadataExists = try await fileSystem.exists(extractDir.appending(component: "run-metadata.json"))
         #expect(!metadataExists)
     }
+
+    @Test(.inTemporaryDirectory)
+    func compress_subdirectories_preservesRelativePaths_andPrunesSiblings() async throws {
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let fileSystem = FileSystem()
+
+        let productsDir = temporaryDirectory.appending(component: "MyApp.xctestproducts")
+        let firstXCTest = productsDir.appending(components: ["Binaries", "0", "Debug", "FooTests.xctest"])
+        let secondXCTest = productsDir.appending(components: ["Binaries", "1", "Debug", "FooTests.xctest"])
+        try await fileSystem.makeDirectory(at: firstXCTest)
+        try await fileSystem.makeDirectory(at: secondXCTest)
+        try await fileSystem.writeText("first", at: firstXCTest.appending(component: "FooTests"))
+        try await fileSystem.writeText("second", at: secondXCTest.appending(component: "FooTests"))
+
+        let siblingXCTest = productsDir.appending(components: ["Binaries", "1", "Debug", "BarTests.xctest"])
+        try await fileSystem.makeDirectory(at: siblingXCTest)
+        try await fileSystem.writeText("bar", at: siblingXCTest.appending(component: "BarTests"))
+
+        let archivePath = temporaryDirectory.appending(component: "FooTests.aar")
+        try await subject.compress(
+            subdirectories: [firstXCTest, secondXCTest],
+            relativeTo: productsDir,
+            to: archivePath
+        )
+
+        let extractDir = temporaryDirectory.appending(component: "extracted")
+        try await fileSystem.makeDirectory(at: extractDir)
+        try await subject.decompress(archive: archivePath, to: extractDir)
+
+        let firstContent = try await fileSystem.readTextFile(
+            at: extractDir.appending(components: ["Binaries", "0", "Debug", "FooTests.xctest", "FooTests"])
+        )
+        let secondContent = try await fileSystem.readTextFile(
+            at: extractDir.appending(components: ["Binaries", "1", "Debug", "FooTests.xctest", "FooTests"])
+        )
+        #expect(firstContent == "first")
+        #expect(secondContent == "second")
+
+        let siblingExists = try await fileSystem.exists(
+            extractDir.appending(components: ["Binaries", "1", "Debug", "BarTests.xctest"])
+        )
+        #expect(!siblingExists)
+    }
 }

--- a/cli/Tests/TuistHARTests/HARRecordingMiddlewareTests.swift
+++ b/cli/Tests/TuistHARTests/HARRecordingMiddlewareTests.swift
@@ -71,7 +71,7 @@ struct HARRecordingMiddlewareTests {
             }
         }
 
-        let entries = try await waitForEntries(recorder, count: 1)
+        let entries = await recorder.getEntries()
         #expect(entries.count == 1)
         #expect(entries[0].request.method == "GET")
         #expect(entries[0].request.url == "https://api.example.com/v1/projects")

--- a/cli/Tests/TuistHTTPTests/FileClientTests.swift
+++ b/cli/Tests/TuistHTTPTests/FileClientTests.swift
@@ -5,7 +5,7 @@
 
     @testable import TuistHTTP
 
-    @Suite(.serialized)
+    @Suite
     struct FileClientTests {
         @Test func download_moves_url_session_temporary_file_to_requested_destination() async throws {
             DownloadURLProtocol.responseData = Data("downloaded shard archive".utf8)

--- a/cli/Tests/TuistHTTPTests/FileClientTests.swift
+++ b/cli/Tests/TuistHTTPTests/FileClientTests.swift
@@ -19,13 +19,12 @@
             let destinationDirectory = try await fileSystem.makeTemporaryDirectory(prefix: "file-client-download-test")
             let destinationPath = destinationDirectory.appending(component: "shared.aar")
 
-            let downloadedPath = try await subject.download(
+            try await subject.download(
                 url: URL(string: "https://tuist.dev/artifacts/shared.aar")!,
                 to: destinationPath
             )
 
-            #expect(downloadedPath == destinationPath)
-            #expect(try await fileSystem.readTextFile(at: downloadedPath) == "downloaded shard archive")
+            #expect(try await fileSystem.readTextFile(at: destinationPath) == "downloaded shard archive")
         }
     }
 

--- a/cli/Tests/TuistHTTPTests/FileClientTests.swift
+++ b/cli/Tests/TuistHTTPTests/FileClientTests.swift
@@ -1,0 +1,58 @@
+#if os(macOS) && canImport(TuistHAR)
+    import FileSystem
+    import Foundation
+    import Testing
+
+    @testable import TuistHTTP
+
+    @Suite(.serialized)
+    struct FileClientTests {
+        @Test func download_moves_url_session_temporary_file_to_requested_destination() async throws {
+            DownloadURLProtocol.responseData = Data("downloaded shard archive".utf8)
+            DownloadURLProtocol.statusCode = 200
+
+            let configuration = URLSessionConfiguration.ephemeral
+            configuration.protocolClasses = [DownloadURLProtocol.self]
+            let session = URLSession(configuration: configuration)
+            let fileSystem = FileSystem()
+            let subject = FileClient(session: session, fileSystem: fileSystem)
+            let destinationDirectory = try await fileSystem.makeTemporaryDirectory(prefix: "file-client-download-test")
+            let destinationPath = destinationDirectory.appending(component: "shared.aar")
+
+            let downloadedPath = try await subject.download(
+                url: URL(string: "https://tuist.dev/artifacts/shared.aar")!,
+                to: destinationPath
+            )
+
+            #expect(downloadedPath == destinationPath)
+            #expect(try await fileSystem.readTextFile(at: downloadedPath) == "downloaded shard archive")
+        }
+    }
+
+    private final class DownloadURLProtocol: URLProtocol {
+        nonisolated(unsafe) static var responseData = Data()
+        nonisolated(unsafe) static var statusCode = 200
+
+        override class func canInit(with _: URLRequest) -> Bool {
+            true
+        }
+
+        override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+            request
+        }
+
+        override func startLoading() {
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: Self.statusCode,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: Self.responseData)
+            client?.urlProtocolDidFinishLoading(self)
+        }
+
+        override func stopLoading() {}
+    }
+#endif

--- a/cli/Tests/TuistKitTests/Services/Sharding/ShardPlanServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/Sharding/ShardPlanServiceTests.swift
@@ -297,8 +297,84 @@ struct ShardPlanServiceTests {
                 )
             )
 
-        let uploadRecorder = ShardUploadRecorder()
-        let appleArchiver = RecordingAppleArchiver()
+        let startedArtifacts = LockedValue<[String?]>([])
+        let uploadedArchivePaths = LockedValue<[AbsolutePath]>([])
+        let moduleArchives = LockedValue<[(subdirectories: [AbsolutePath], archivePath: AbsolutePath)]>([])
+
+        let startShardUploadService = MockStartShardUploadServicing()
+        given(startShardUploadService)
+            .startUpload(
+                fullHandle: .any,
+                serverURL: .any,
+                shardPlanId: .any,
+                reference: .any,
+                artifact: .any
+            )
+            .willProduce { _, _, _, _, artifact in
+                startedArtifacts.mutate { $0.append(artifact) }
+                return "upload-id"
+            }
+
+        let multipartUploadArtifactService = MockMultipartUploadArtifactServicing()
+        given(multipartUploadArtifactService)
+            .multipartUploadArtifact(
+                artifactPath: .any,
+                generateUploadURL: .any,
+                updateProgress: .any
+            )
+            .willProduce { archivePath, _, _ in
+                uploadedArchivePaths.mutate { $0.append(archivePath) }
+                return [(etag: "etag", partNumber: 1)]
+            }
+
+        let multipartUploadGenerateURLShardsService = MockMultipartUploadGenerateURLShardsServicing()
+        given(multipartUploadGenerateURLShardsService)
+            .generateUploadURL(
+                fullHandle: .any,
+                serverURL: .any,
+                shardPlanId: .any,
+                reference: .any,
+                uploadId: .any,
+                partNumber: .any,
+                artifact: .any
+            )
+            .willReturn("https://tuist.dev/upload")
+
+        let multipartUploadCompleteShardsService = MockMultipartUploadCompleteShardsServicing()
+        given(multipartUploadCompleteShardsService)
+            .completeUpload(
+                fullHandle: .any,
+                serverURL: .any,
+                shardPlanId: .any,
+                reference: .any,
+                uploadId: .any,
+                parts: .any,
+                artifact: .any
+            )
+            .willReturn()
+
+        let appleArchiver = MockAppleArchiving()
+        given(appleArchiver)
+            .compress(
+                directory: .any,
+                to: .any,
+                excludePatterns: .any,
+                preservesBaseDirectory: .any
+            )
+            .willProduce { _, archivePath, _, _ in
+                try Data("shared".utf8).write(to: archivePath.url)
+            }
+        given(appleArchiver)
+            .compress(
+                subdirectories: .any,
+                relativeTo: .any,
+                to: .any
+            )
+            .willProduce { subdirectories, _, archivePath in
+                moduleArchives.mutate { $0.append((subdirectories: subdirectories, archivePath: archivePath)) }
+                try Data("module".utf8).write(to: archivePath.url)
+            }
+
         let shardMatrixOutputService = MockShardMatrixOutputServicing()
         given(shardMatrixOutputService)
             .output(.any)
@@ -306,10 +382,10 @@ struct ShardPlanServiceTests {
 
         let subject = ShardPlanService(
             createShardPlanService: createShardPlanService,
-            startShardUploadService: RecordingStartShardUploadService(recorder: uploadRecorder),
-            multipartUploadArtifactService: RecordingMultipartUploadArtifactService(recorder: uploadRecorder),
-            multipartUploadGenerateURLShardsService: RecordingMultipartUploadGenerateURLShardsService(recorder: uploadRecorder),
-            multipartUploadCompleteShardsService: RecordingMultipartUploadCompleteShardsService(recorder: uploadRecorder),
+            startShardUploadService: startShardUploadService,
+            multipartUploadArtifactService: multipartUploadArtifactService,
+            multipartUploadGenerateURLShardsService: multipartUploadGenerateURLShardsService,
+            multipartUploadCompleteShardsService: multipartUploadCompleteShardsService,
             fileSystem: fileSystem,
             shardMatrixOutputService: shardMatrixOutputService,
             appleArchiver: appleArchiver
@@ -330,16 +406,16 @@ struct ShardPlanServiceTests {
             archivePath: nil
         )
 
-        let artifacts = await uploadRecorder.startedArtifacts.compactMap(\.self).sorted()
+        let artifacts = startedArtifacts.value.compactMap(\.self).sorted()
         #expect(artifacts == ["module:AppTests", "shared"])
 
-        let uploadedArchiveBasenames = await uploadRecorder.uploadedArchivePaths.map(\.basename).sorted()
+        let uploadedArchiveBasenames = uploadedArchivePaths.value.map(\.basename).sorted()
         #expect(uploadedArchiveBasenames == ["AppTests.aar", "shared.aar"])
 
-        let moduleArchives = await appleArchiver.moduleArchives
-        #expect(moduleArchives.count == 1)
-        #expect(moduleArchives.first?.archivePath.basename == "AppTests.aar")
-        #expect(moduleArchives.first?.subdirectories.map(\.pathString).sorted() == [
+        let recordedModuleArchives = moduleArchives.value
+        #expect(recordedModuleArchives.count == 1)
+        #expect(recordedModuleArchives.first?.archivePath.basename == "AppTests.aar")
+        #expect(recordedModuleArchives.first?.subdirectories.map(\.pathString).sorted() == [
             firstXCTestPath.pathString,
             secondXCTestPath.pathString,
         ])
@@ -355,7 +431,7 @@ struct ShardPlanServiceTests {
                 serverURL: .any,
                 reference: .any,
                 modules: .any,
-                testSuites: .matching { capture($0); return true },
+                testSuites: .any,
                 shardMin: .any,
                 shardMax: .any,
                 shardTotal: .any,
@@ -363,15 +439,16 @@ struct ShardPlanServiceTests {
                 shardGranularity: .any,
                 buildRunId: .any
             )
-            .willReturn(
-                Components.Schemas.ShardPlan(
+            .willProduce { _, _, _, _, testSuites, _, _, _, _, _, _ in
+                capture(testSuites)
+                return Components.Schemas.ShardPlan(
                     id: "plan-id",
                     reference: "ref",
                     shard_count: 1,
                     shards: [],
                     upload_url: "https://tuist.dev/api/projects/tuist/tuist/tests/shards/upload/start"
                 )
-            )
+            }
         return createShardPlanService
     }
 
@@ -419,119 +496,23 @@ private func plistEncoder() -> PropertyListEncoder {
     return encoder
 }
 
-private actor RecordingAppleArchiver: AppleArchiving {
-    private(set) var moduleArchives: [(subdirectories: [AbsolutePath], archivePath: AbsolutePath)] = []
+private final class LockedValue<Value>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storage: Value
 
-    func compress(
-        directory _: AbsolutePath,
-        to archivePath: AbsolutePath,
-        excludePatterns _: [String],
-        preservesBaseDirectory _: Bool
-    ) async throws {
-        try Data("shared".utf8).write(to: URL(fileURLWithPath: archivePath.pathString))
+    init(_ storage: Value) {
+        self.storage = storage
     }
 
-    func compress(
-        subdirectory: AbsolutePath,
-        relativeTo baseDirectory: AbsolutePath,
-        to archivePath: AbsolutePath
-    ) async throws {
-        try await compress(subdirectories: [subdirectory], relativeTo: baseDirectory, to: archivePath)
+    var value: Value {
+        lock.lock()
+        defer { lock.unlock() }
+        return storage
     }
 
-    func compress(
-        subdirectories: [AbsolutePath],
-        relativeTo _: AbsolutePath,
-        to archivePath: AbsolutePath
-    ) async throws {
-        moduleArchives.append((subdirectories: subdirectories, archivePath: archivePath))
-        try Data("module".utf8).write(to: URL(fileURLWithPath: archivePath.pathString))
-    }
-
-    func decompress(archive _: AbsolutePath, to _: AbsolutePath) async throws {}
-}
-
-private actor ShardUploadRecorder {
-    private(set) var startedArtifacts: [String?] = []
-    private(set) var generatedURLArtifacts: [String?] = []
-    private(set) var completedArtifacts: [String?] = []
-    private(set) var uploadedArchivePaths: [AbsolutePath] = []
-
-    func recordStartedArtifact(_ artifact: String?) {
-        startedArtifacts.append(artifact)
-    }
-
-    func recordGeneratedURLArtifact(_ artifact: String?) {
-        generatedURLArtifacts.append(artifact)
-    }
-
-    func recordCompletedArtifact(_ artifact: String?) {
-        completedArtifacts.append(artifact)
-    }
-
-    func recordUploadedArchivePath(_ path: AbsolutePath) {
-        uploadedArchivePaths.append(path)
-    }
-}
-
-private struct RecordingStartShardUploadService: StartShardUploadServicing {
-    let recorder: ShardUploadRecorder
-
-    func startUpload(
-        fullHandle _: String,
-        serverURL _: URL,
-        shardPlanId _: String?,
-        reference _: String,
-        artifact: String?
-    ) async throws -> String {
-        await recorder.recordStartedArtifact(artifact)
-        return "upload-\(artifact ?? "bundle")"
-    }
-}
-
-private struct RecordingMultipartUploadArtifactService: MultipartUploadArtifactServicing {
-    let recorder: ShardUploadRecorder
-
-    func multipartUploadArtifact(
-        artifactPath: AbsolutePath,
-        generateUploadURL: @escaping (MultipartUploadArtifactPart) async throws -> String,
-        updateProgress _: @escaping (Double) -> Void
-    ) async throws -> [(etag: String, partNumber: Int)] {
-        await recorder.recordUploadedArchivePath(artifactPath)
-        _ = try await generateUploadURL(.init(number: 1, contentLength: 6))
-        return [(etag: "etag", partNumber: 1)]
-    }
-}
-
-private struct RecordingMultipartUploadGenerateURLShardsService: MultipartUploadGenerateURLShardsServicing {
-    let recorder: ShardUploadRecorder
-
-    func generateUploadURL(
-        fullHandle _: String,
-        serverURL _: URL,
-        shardPlanId _: String?,
-        reference _: String,
-        uploadId _: String,
-        partNumber _: Int,
-        artifact: String?
-    ) async throws -> String {
-        await recorder.recordGeneratedURLArtifact(artifact)
-        return "https://tuist.dev/upload"
-    }
-}
-
-private struct RecordingMultipartUploadCompleteShardsService: MultipartUploadCompleteShardsServicing {
-    let recorder: ShardUploadRecorder
-
-    func completeUpload(
-        fullHandle _: String,
-        serverURL _: URL,
-        shardPlanId _: String?,
-        reference _: String,
-        uploadId _: String,
-        parts _: [(partNumber: Int, etag: String)],
-        artifact: String?
-    ) async throws {
-        await recorder.recordCompletedArtifact(artifact)
+    func mutate(_ transform: (inout Value) -> Void) {
+        lock.lock()
+        defer { lock.unlock() }
+        transform(&storage)
     }
 }

--- a/cli/Tests/TuistKitTests/Services/Sharding/ShardPlanServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/Sharding/ShardPlanServiceTests.swift
@@ -244,6 +244,107 @@ struct ShardPlanServiceTests {
         #expect(uploadURL == "https://tuist.dev/upload")
     }
 
+    @Test(.inTemporaryDirectory, .withMockedDependencies())
+    func plan_withRemoteUpload_groupsDuplicateXCTestBasenamesIntoOneModuleArtifact() async throws {
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let fileSystem = FileSystem()
+
+        let testProductsPath = temporaryDirectory.appending(component: "MyApp.xctestproducts")
+        try await fileSystem.makeDirectory(at: testProductsPath)
+        try await fileSystem.writeAsPlist(
+            XCTestRunFixture(
+                testConfigurations: [
+                    .init(
+                        testTargets: [
+                            .init(blueprintName: "AppTests"),
+                        ]
+                    ),
+                ]
+            ),
+            at: testProductsPath.appending(component: "MyApp.xctestrun"),
+            encoder: plistEncoder()
+        )
+
+        let firstXCTestPath = testProductsPath.appending(components: "Binaries", "0", "Debug", "AppTests.xctest")
+        let secondXCTestPath = testProductsPath.appending(components: "Binaries", "1", "Debug", "AppTests.xctest")
+        try await fileSystem.makeDirectory(at: firstXCTestPath)
+        try await fileSystem.makeDirectory(at: secondXCTestPath)
+        try await fileSystem.writeText("first", at: firstXCTestPath.appending(component: "AppTests"))
+        try await fileSystem.writeText("second", at: secondXCTestPath.appending(component: "AppTests"))
+
+        let createShardPlanService = MockCreateShardPlanServicing()
+        given(createShardPlanService)
+            .createShardPlan(
+                fullHandle: .any,
+                serverURL: .any,
+                reference: .any,
+                modules: .any,
+                testSuites: .any,
+                shardMin: .any,
+                shardMax: .any,
+                shardTotal: .any,
+                shardMaxDuration: .any,
+                shardGranularity: .any,
+                buildRunId: .any
+            )
+            .willReturn(
+                Components.Schemas.ShardPlan(
+                    id: "plan-id",
+                    reference: "ref",
+                    shard_count: 1,
+                    shards: [],
+                    upload_url: "https://tuist.dev/api/projects/tuist/tuist/tests/shards/upload/start"
+                )
+            )
+
+        let uploadRecorder = ShardUploadRecorder()
+        let appleArchiver = RecordingAppleArchiver()
+        let shardMatrixOutputService = MockShardMatrixOutputServicing()
+        given(shardMatrixOutputService)
+            .output(.any)
+            .willReturn()
+
+        let subject = ShardPlanService(
+            createShardPlanService: createShardPlanService,
+            startShardUploadService: RecordingStartShardUploadService(recorder: uploadRecorder),
+            multipartUploadArtifactService: RecordingMultipartUploadArtifactService(recorder: uploadRecorder),
+            multipartUploadGenerateURLShardsService: RecordingMultipartUploadGenerateURLShardsService(recorder: uploadRecorder),
+            multipartUploadCompleteShardsService: RecordingMultipartUploadCompleteShardsService(recorder: uploadRecorder),
+            fileSystem: fileSystem,
+            shardMatrixOutputService: shardMatrixOutputService,
+            appleArchiver: appleArchiver
+        )
+
+        _ = try await subject.plan(
+            xctestproductsPath: testProductsPath,
+            reference: "ref",
+            shardGranularity: .module,
+            shardMin: nil,
+            shardMax: nil,
+            shardTotal: 1,
+            shardMaxDuration: nil,
+            fullHandle: "tuist/tuist",
+            serverURL: try #require(URL(string: "https://tuist.dev")),
+            buildRunId: nil,
+            skipUpload: false,
+            archivePath: nil
+        )
+
+        let artifacts = await uploadRecorder.startedArtifacts.compactMap(\.self).sorted()
+        #expect(artifacts == ["module:AppTests", "shared"])
+
+        let uploadedArchiveBasenames = await uploadRecorder.uploadedArchivePaths.map(\.basename).sorted()
+        #expect(uploadedArchiveBasenames == ["AppTests.aar", "shared.aar"])
+
+        let moduleArchives = await appleArchiver.moduleArchives
+        #expect(moduleArchives.count == 1)
+        #expect(moduleArchives.first?.archivePath.basename == "AppTests.aar")
+        #expect(moduleArchives.first?.subdirectories.map(\.pathString).sorted() == [
+            firstXCTestPath.pathString,
+            secondXCTestPath.pathString,
+        ])
+    }
+
     private func mockCreateShardPlanService(
         capturingTestSuites capture: @escaping ([String]?) -> Void
     ) -> MockCreateShardPlanServicing {
@@ -316,4 +417,121 @@ private func plistEncoder() -> PropertyListEncoder {
     let encoder = PropertyListEncoder()
     encoder.outputFormat = .xml
     return encoder
+}
+
+private actor RecordingAppleArchiver: AppleArchiving {
+    private(set) var moduleArchives: [(subdirectories: [AbsolutePath], archivePath: AbsolutePath)] = []
+
+    func compress(
+        directory _: AbsolutePath,
+        to archivePath: AbsolutePath,
+        excludePatterns _: [String],
+        preservesBaseDirectory _: Bool
+    ) async throws {
+        try Data("shared".utf8).write(to: URL(fileURLWithPath: archivePath.pathString))
+    }
+
+    func compress(
+        subdirectory: AbsolutePath,
+        relativeTo baseDirectory: AbsolutePath,
+        to archivePath: AbsolutePath
+    ) async throws {
+        try await compress(subdirectories: [subdirectory], relativeTo: baseDirectory, to: archivePath)
+    }
+
+    func compress(
+        subdirectories: [AbsolutePath],
+        relativeTo _: AbsolutePath,
+        to archivePath: AbsolutePath
+    ) async throws {
+        moduleArchives.append((subdirectories: subdirectories, archivePath: archivePath))
+        try Data("module".utf8).write(to: URL(fileURLWithPath: archivePath.pathString))
+    }
+
+    func decompress(archive _: AbsolutePath, to _: AbsolutePath) async throws {}
+}
+
+private actor ShardUploadRecorder {
+    private(set) var startedArtifacts: [String?] = []
+    private(set) var generatedURLArtifacts: [String?] = []
+    private(set) var completedArtifacts: [String?] = []
+    private(set) var uploadedArchivePaths: [AbsolutePath] = []
+
+    func recordStartedArtifact(_ artifact: String?) {
+        startedArtifacts.append(artifact)
+    }
+
+    func recordGeneratedURLArtifact(_ artifact: String?) {
+        generatedURLArtifacts.append(artifact)
+    }
+
+    func recordCompletedArtifact(_ artifact: String?) {
+        completedArtifacts.append(artifact)
+    }
+
+    func recordUploadedArchivePath(_ path: AbsolutePath) {
+        uploadedArchivePaths.append(path)
+    }
+}
+
+private struct RecordingStartShardUploadService: StartShardUploadServicing {
+    let recorder: ShardUploadRecorder
+
+    func startUpload(
+        fullHandle _: String,
+        serverURL _: URL,
+        shardPlanId _: String?,
+        reference _: String,
+        artifact: String?
+    ) async throws -> String {
+        await recorder.recordStartedArtifact(artifact)
+        return "upload-\(artifact ?? "bundle")"
+    }
+}
+
+private struct RecordingMultipartUploadArtifactService: MultipartUploadArtifactServicing {
+    let recorder: ShardUploadRecorder
+
+    func multipartUploadArtifact(
+        artifactPath: AbsolutePath,
+        generateUploadURL: @escaping (MultipartUploadArtifactPart) async throws -> String,
+        updateProgress _: @escaping (Double) -> Void
+    ) async throws -> [(etag: String, partNumber: Int)] {
+        await recorder.recordUploadedArchivePath(artifactPath)
+        _ = try await generateUploadURL(.init(number: 1, contentLength: 6))
+        return [(etag: "etag", partNumber: 1)]
+    }
+}
+
+private struct RecordingMultipartUploadGenerateURLShardsService: MultipartUploadGenerateURLShardsServicing {
+    let recorder: ShardUploadRecorder
+
+    func generateUploadURL(
+        fullHandle _: String,
+        serverURL _: URL,
+        shardPlanId _: String?,
+        reference _: String,
+        uploadId _: String,
+        partNumber _: Int,
+        artifact: String?
+    ) async throws -> String {
+        await recorder.recordGeneratedURLArtifact(artifact)
+        return "https://tuist.dev/upload"
+    }
+}
+
+private struct RecordingMultipartUploadCompleteShardsService: MultipartUploadCompleteShardsServicing {
+    let recorder: ShardUploadRecorder
+
+    func completeUpload(
+        fullHandle _: String,
+        serverURL _: URL,
+        shardPlanId _: String?,
+        reference _: String,
+        uploadId _: String,
+        parts _: [(partNumber: Int, etag: String)],
+        artifact: String?
+    ) async throws {
+        await recorder.recordCompletedArtifact(artifact)
+    }
 }

--- a/cli/Tests/TuistKitTests/Services/Sharding/ShardServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/Sharding/ShardServiceTests.swift
@@ -6,6 +6,7 @@ import Path
 import Testing
 import TuistAppleArchiver
 import TuistCI
+import TuistHTTP
 import TuistLoggerTesting
 import TuistLogging
 import TuistServer
@@ -333,6 +334,105 @@ struct ShardServiceTests {
         #expect(extractedContent == "fixture")
     }
 
+    @Test(.inTemporaryDirectory, .withMockedDependencies(), .serialized)
+    func shard_withRemoteDownloadUrls_downloadsAndExtractsSplitArtifacts() async throws {
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let fileSystem = FileSystem()
+        let appleArchiver = AppleArchiver()
+
+        let sourceProductsPath = temporaryDirectory.appending(component: "MyApp.xctestproducts")
+        try await fileSystem.makeDirectory(at: sourceProductsPath)
+        try await fileSystem.writeAsPlist(
+            XCTestRunFixture(
+                testConfigurations: [
+                    .init(
+                        testTargets: [
+                            .init(blueprintName: "AppTests", testHostPath: "/path/to/host"),
+                        ]
+                    ),
+                ]
+            ),
+            at: sourceProductsPath.appending(component: "MyApp.xctestrun"),
+            encoder: plistEncoder()
+        )
+        try await fileSystem.writeText("shared", at: sourceProductsPath.appending(component: "shared.txt"))
+        let appTestsPath = sourceProductsPath.appending(component: "AppTests.xctest")
+        try await fileSystem.makeDirectory(at: appTestsPath)
+        try await fileSystem.writeText("module", at: appTestsPath.appending(component: "module.txt"))
+
+        let archiveDirectory = temporaryDirectory.appending(component: "archives")
+        try await fileSystem.makeDirectory(at: archiveDirectory)
+        let sharedArchivePath = archiveDirectory.appending(component: "shared.aar")
+        let moduleArchivePath = archiveDirectory.appending(component: "AppTests.aar")
+        try await appleArchiver.compress(
+            directory: sourceProductsPath,
+            to: sharedArchivePath,
+            excludePatterns: [".xctest/"]
+        )
+        try await appleArchiver.compress(
+            subdirectory: appTestsPath,
+            relativeTo: sourceProductsPath,
+            to: moduleArchivePath
+        )
+
+        let sharedURL = URL(string: "https://artifacts.tuist.test/shared.aar")!
+        let moduleURL = URL(string: "https://artifacts.tuist.test/AppTests.aar")!
+        ShardDownloadURLProtocol.responses = [
+            sharedURL: try await fileSystem.readFile(at: sharedArchivePath),
+            moduleURL: try await fileSystem.readFile(at: moduleArchivePath),
+        ]
+
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [ShardDownloadURLProtocol.self]
+        let fileClient = FileClient(session: URLSession(configuration: configuration), fileSystem: fileSystem)
+
+        let ciController = MockCIControlling()
+        given(ciController).ciInfo().willReturn(.test(provider: .github))
+
+        let getShardService = MockGetShardServicing()
+        given(getShardService).getShard(
+            fullHandle: .any,
+            serverURL: .any,
+            reference: .any,
+            shardIndex: .any
+        ).willReturn(
+            Components.Schemas.Shard(
+                download_url: sharedURL.absoluteString,
+                download_urls: [sharedURL.absoluteString, moduleURL.absoluteString],
+                modules: ["AppTests"],
+                shard_plan_id: "plan-123",
+                skip: [],
+                suites: .init(additionalProperties: ["AppTests": ["LoginTests"]])
+            )
+        )
+
+        let subject = ShardService(
+            getShardService: getShardService,
+            ciController: ciController,
+            fileClient: fileClient,
+            fileSystem: fileSystem,
+            appleArchiver: appleArchiver
+        )
+
+        let shard = try await subject.shard(
+            shardIndex: 0,
+            fullHandle: "org/project",
+            serverURL: URL(string: "https://tuist.dev")!,
+            reference: nil,
+            testProductsPath: nil,
+            testProductsArchivePath: nil
+        )
+
+        #expect(shard.testProductsPath.basename.hasSuffix(".xctestproducts"))
+        #expect(shard.testIdentifiers == ["AppTests/LoginTests"])
+        #expect(try await fileSystem.readTextFile(at: shard.testProductsPath.appending(component: "shared.txt")) == "shared")
+        #expect(
+            try await fileSystem.readTextFile(
+                at: shard.testProductsPath.appending(components: "AppTests.xctest", "module.txt")
+            ) == "module"
+        )
+    }
+
     // MARK: - Helpers
 
     private func makeSubjectWithLocalProducts(
@@ -424,4 +524,32 @@ private func plistEncoder() -> PropertyListEncoder {
     let encoder = PropertyListEncoder()
     encoder.outputFormat = .xml
     return encoder
+}
+
+private final class ShardDownloadURLProtocol: URLProtocol {
+    nonisolated(unsafe) static var responses = [URL: Data]()
+
+    override class func canInit(with _: URLRequest) -> Bool {
+        true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        let data = request.url.flatMap { Self.responses[$0] } ?? Data()
+        let statusCode = request.url.flatMap { Self.responses[$0] } == nil ? 404 : 200
+        let response = HTTPURLResponse(
+            url: request.url!,
+            statusCode: statusCode,
+            httpVersion: nil,
+            headerFields: nil
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: data)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
 }

--- a/cli/Tests/TuistServerTests/MultipartUploadArtifactServiceTests.swift
+++ b/cli/Tests/TuistServerTests/MultipartUploadArtifactServiceTests.swift
@@ -6,19 +6,16 @@ import Testing
 
 @testable import TuistServer
 
-@Suite(.serialized)
 struct MultipartUploadArtifactServiceTests {
     @Test(.inTemporaryDirectory)
     func multipartUploadArtifact_uploadsCompleteParts() async throws {
-        MultipartUploadURLProtocol.reset()
-        MultipartUploadURLProtocol.statusCode = 200
-
         let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
         let artifactPath = temporaryDirectory.appending(component: "artifact.aar")
         let partSize = 10 * 1024 * 1024
         let payload = Data(repeating: 7, count: partSize + 7)
         try payload.write(to: URL(fileURLWithPath: artifactPath.pathString))
 
+        let uploadServer = MultipartUploadURLProtocolServer()
         let configuration = URLSessionConfiguration.ephemeral
         configuration.protocolClasses = [MultipartUploadURLProtocol.self]
         let subject = MultipartUploadArtifactService(
@@ -31,7 +28,7 @@ struct MultipartUploadArtifactServiceTests {
             artifactPath: artifactPath,
             generateUploadURL: { part in
                 await partRecorder.record(part)
-                return "https://tuist.dev/upload?partNumber=\(part.number)"
+                return uploadServer.uploadURL(partNumber: part.number)
             },
             updateProgress: { _ in }
         )
@@ -43,7 +40,7 @@ struct MultipartUploadArtifactServiceTests {
         #expect(generatedParts.map(\.number) == [1, 2])
         #expect(generatedParts.map(\.contentLength) == [partSize, 7])
 
-        let requests = MultipartUploadURLProtocol.requests.sorted(by: { $0.partNumber < $1.partNumber })
+        let requests = uploadServer.requests.sorted(by: { $0.partNumber < $1.partNumber })
         #expect(requests.map(\.partNumber) == [1, 2])
         #expect(requests.map(\.contentLength) == [partSize, 7])
         #expect(requests[0].body.count == partSize)
@@ -52,25 +49,26 @@ struct MultipartUploadArtifactServiceTests {
 
     @Test(.inTemporaryDirectory)
     func multipartUploadArtifact_rejectsNonSuccessfulUploadResponseWithEtag() async throws {
-        MultipartUploadURLProtocol.reset()
-        MultipartUploadURLProtocol.responseData = Data("storage error".utf8)
-        MultipartUploadURLProtocol.statusCode = 500
-
         let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
         let artifactPath = temporaryDirectory.appending(component: "artifact.aar")
         try Data("payload".utf8).write(to: URL(fileURLWithPath: artifactPath.pathString))
 
+        let uploadServer = MultipartUploadURLProtocolServer(
+            responseData: Data("storage error".utf8),
+            statusCode: 500
+        )
         let configuration = URLSessionConfiguration.ephemeral
         configuration.protocolClasses = [MultipartUploadURLProtocol.self]
         let subject = MultipartUploadArtifactService(
             urlSession: URLSession(configuration: configuration),
             retryProvider: NoRetryProvider()
         )
+        let uploadURL = uploadServer.uploadURL(partNumber: 1)
 
         do {
             _ = try await subject.multipartUploadArtifact(
                 artifactPath: artifactPath,
-                generateUploadURL: { part in "https://tuist.dev/upload?partNumber=\(part.number)" },
+                generateUploadURL: { _ in uploadURL },
                 updateProgress: { _ in }
             )
             Issue.record("Expected multipart upload to reject the failed response")
@@ -79,7 +77,7 @@ struct MultipartUploadArtifactServiceTests {
                 Issue.record("Expected uploadFailed, got \(error)")
                 return
             }
-            #expect(url?.absoluteString == "https://tuist.dev/upload?partNumber=1")
+            #expect(url?.absoluteString == uploadURL)
             #expect(statusCode == 500)
             #expect(body == "storage error")
         }
@@ -87,9 +85,6 @@ struct MultipartUploadArtifactServiceTests {
 
     @Test(.inTemporaryDirectory)
     func multipartUploadArtifact_rejectsArtifactChangesWhileUploading() async throws {
-        MultipartUploadURLProtocol.reset()
-        MultipartUploadURLProtocol.statusCode = 200
-
         let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
         let artifactPath = temporaryDirectory.appending(component: "artifact.aar")
         let initialPayload = Data("initial".utf8)
@@ -100,7 +95,7 @@ struct MultipartUploadArtifactServiceTests {
 
         let lock = NSLock()
         var didAppend = false
-        MultipartUploadURLProtocol.onRequest = { _, _ in
+        let uploadServer = MultipartUploadURLProtocolServer { _, _ in
             lock.lock()
             defer { lock.unlock() }
             guard !didAppend else { return }
@@ -124,7 +119,7 @@ struct MultipartUploadArtifactServiceTests {
         do {
             _ = try await subject.multipartUploadArtifact(
                 artifactPath: artifactPath,
-                generateUploadURL: { part in "https://tuist.dev/upload?partNumber=\(part.number)" },
+                generateUploadURL: { part in uploadServer.uploadURL(partNumber: part.number) },
                 updateProgress: { _ in }
             )
             Issue.record("Expected multipart upload to reject the changing artifact")
@@ -137,7 +132,7 @@ struct MultipartUploadArtifactServiceTests {
             #expect(readBytes == UInt64(initialPayload.count))
         }
 
-        let requests = MultipartUploadURLProtocol.requests
+        let requests = uploadServer.requests
         #expect(requests.map(\.body) == [initialPayload])
     }
 }
@@ -164,27 +159,76 @@ private struct CapturedMultipartUploadRequest {
     let body: Data
 }
 
-private final class MultipartUploadURLProtocol: URLProtocol {
-    nonisolated(unsafe) static var responseData = Data()
-    nonisolated(unsafe) static var statusCode = 200
-    nonisolated(unsafe) static var onRequest: ((URLRequest, Data) -> Void)?
+private final class MultipartUploadURLProtocolServer: @unchecked Sendable {
+    private let id = UUID().uuidString
 
-    private nonisolated(unsafe) static var capturedRequests: [CapturedMultipartUploadRequest] = []
-    private nonisolated(unsafe) static let lock = NSLock()
-
-    static var requests: [CapturedMultipartUploadRequest] {
-        lock.lock()
-        defer { lock.unlock() }
-        return capturedRequests
+    init(
+        responseData: Data = Data(),
+        statusCode: Int = 200,
+        onRequest: ((URLRequest, Data) -> Void)? = nil
+    ) {
+        MultipartUploadURLProtocol.register(
+            id: id,
+            responseData: responseData,
+            statusCode: statusCode,
+            onRequest: onRequest
+        )
     }
 
-    static func reset() {
+    convenience init(onRequest: @escaping (URLRequest, Data) -> Void) {
+        self.init(responseData: Data(), statusCode: 200, onRequest: onRequest)
+    }
+
+    deinit {
+        MultipartUploadURLProtocol.unregister(id: id)
+    }
+
+    var requests: [CapturedMultipartUploadRequest] {
+        MultipartUploadURLProtocol.requests(for: id)
+    }
+
+    func uploadURL(partNumber: Int) -> String {
+        "https://tuist.dev/upload?testID=\(id)&partNumber=\(partNumber)"
+    }
+}
+
+private struct MultipartUploadURLProtocolState {
+    var responseData: Data
+    var statusCode: Int
+    var onRequest: ((URLRequest, Data) -> Void)?
+    var capturedRequests: [CapturedMultipartUploadRequest]
+}
+
+private final class MultipartUploadURLProtocol: URLProtocol {
+    private nonisolated(unsafe) static var states: [String: MultipartUploadURLProtocolState] = [:]
+    private nonisolated(unsafe) static let lock = NSLock()
+
+    static func register(
+        id: String,
+        responseData: Data,
+        statusCode: Int,
+        onRequest: ((URLRequest, Data) -> Void)?
+    ) {
         lock.lock()
         defer { lock.unlock() }
-        capturedRequests = []
-        responseData = Data()
-        statusCode = 200
-        onRequest = nil
+        states[id] = MultipartUploadURLProtocolState(
+            responseData: responseData,
+            statusCode: statusCode,
+            onRequest: onRequest,
+            capturedRequests: []
+        )
+    }
+
+    static func unregister(id: String) {
+        lock.lock()
+        defer { lock.unlock() }
+        states[id] = nil
+    }
+
+    static func requests(for id: String) -> [CapturedMultipartUploadRequest] {
+        lock.lock()
+        defer { lock.unlock() }
+        return states[id]?.capturedRequests ?? []
     }
 
     override class func canInit(with _: URLRequest) -> Bool {
@@ -197,31 +241,21 @@ private final class MultipartUploadURLProtocol: URLProtocol {
 
     override func startLoading() {
         let body = Self.bodyData(from: request)
-        Self.onRequest?(request, body)
-        let partNumber = request.url.flatMap { URLComponents(url: $0, resolvingAgainstBaseURL: false) }?
-            .queryItems?
-            .first(where: { $0.name == "partNumber" })?
-            .value
-            .flatMap(Int.init) ?? 0
+        let testID = Self.queryItem(named: "testID", in: request.url)
+        let state = Self.state(for: testID)
+        state.onRequest?(request, body)
 
-        Self.lock.lock()
-        Self.capturedRequests.append(
-            CapturedMultipartUploadRequest(
-                partNumber: partNumber,
-                contentLength: Int(request.value(forHTTPHeaderField: "Content-Length") ?? "") ?? 0,
-                body: body
-            )
-        )
-        Self.lock.unlock()
+        let partNumber = Self.queryItem(named: "partNumber", in: request.url).flatMap(Int.init) ?? 0
+        Self.recordRequest(testID: testID, request: request, body: body, partNumber: partNumber)
 
         let response = HTTPURLResponse(
             url: request.url!,
-            statusCode: Self.statusCode,
+            statusCode: state.statusCode,
             httpVersion: nil,
             headerFields: ["Etag": "etag-\(partNumber)"]
         )!
         client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
-        client?.urlProtocol(self, didLoad: Self.responseData)
+        client?.urlProtocol(self, didLoad: state.responseData)
         client?.urlProtocolDidFinishLoading(self)
     }
 
@@ -247,5 +281,45 @@ private final class MultipartUploadURLProtocol: URLProtocol {
             data.append(buffer, count: bytesRead)
         }
         return data
+    }
+
+    private static func state(for testID: String?) -> MultipartUploadURLProtocolState {
+        lock.lock()
+        defer { lock.unlock() }
+        guard let testID, let state = states[testID] else {
+            return MultipartUploadURLProtocolState(
+                responseData: Data(),
+                statusCode: 200,
+                onRequest: nil,
+                capturedRequests: []
+            )
+        }
+        return state
+    }
+
+    private static func recordRequest(
+        testID: String?,
+        request: URLRequest,
+        body: Data,
+        partNumber: Int
+    ) {
+        guard let testID else { return }
+
+        lock.lock()
+        defer { lock.unlock() }
+        states[testID]?.capturedRequests.append(
+            CapturedMultipartUploadRequest(
+                partNumber: partNumber,
+                contentLength: Int(request.value(forHTTPHeaderField: "Content-Length") ?? "") ?? 0,
+                body: body
+            )
+        )
+    }
+
+    private static func queryItem(named name: String, in url: URL?) -> String? {
+        url.flatMap { URLComponents(url: $0, resolvingAgainstBaseURL: false) }?
+            .queryItems?
+            .first(where: { $0.name == name })?
+            .value
     }
 }

--- a/cli/Tests/TuistServerTests/MultipartUploadArtifactServiceTests.swift
+++ b/cli/Tests/TuistServerTests/MultipartUploadArtifactServiceTests.swift
@@ -1,0 +1,244 @@
+import FileSystem
+import FileSystemTesting
+import Foundation
+import Path
+import Testing
+
+@testable import TuistServer
+
+@Suite(.serialized)
+struct MultipartUploadArtifactServiceTests {
+    @Test(.inTemporaryDirectory)
+    func multipartUploadArtifact_uploadsCompleteParts() async throws {
+        MultipartUploadURLProtocol.reset()
+        MultipartUploadURLProtocol.statusCode = 200
+
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let artifactPath = temporaryDirectory.appending(component: "artifact.aar")
+        let partSize = 10 * 1024 * 1024
+        let payload = Data(repeating: 7, count: partSize + 7)
+        try payload.write(to: URL(fileURLWithPath: artifactPath.pathString))
+
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [MultipartUploadURLProtocol.self]
+        let subject = MultipartUploadArtifactService(
+            urlSession: URLSession(configuration: configuration),
+            retryProvider: NoRetryProvider()
+        )
+        let partRecorder = MultipartUploadPartRecorder()
+
+        let parts = try await subject.multipartUploadArtifact(
+            artifactPath: artifactPath,
+            generateUploadURL: { part in
+                await partRecorder.record(part)
+                return "https://tuist.dev/upload?partNumber=\(part.number)"
+            },
+            updateProgress: { _ in }
+        )
+
+        #expect(parts.map(\.partNumber) == [1, 2])
+        #expect(parts.map(\.etag) == ["etag-1", "etag-2"])
+
+        let generatedParts = await partRecorder.parts
+        #expect(generatedParts.map(\.number) == [1, 2])
+        #expect(generatedParts.map(\.contentLength) == [partSize, 7])
+
+        let requests = MultipartUploadURLProtocol.requests.sorted(by: { $0.partNumber < $1.partNumber })
+        #expect(requests.map(\.partNumber) == [1, 2])
+        #expect(requests.map(\.contentLength) == [partSize, 7])
+        #expect(requests[0].body.count == partSize)
+        #expect(requests[1].body == Data(repeating: 7, count: 7))
+    }
+
+    @Test(.inTemporaryDirectory)
+    func multipartUploadArtifact_rejectsNonSuccessfulUploadResponseWithEtag() async throws {
+        MultipartUploadURLProtocol.reset()
+        MultipartUploadURLProtocol.responseData = Data("storage error".utf8)
+        MultipartUploadURLProtocol.statusCode = 500
+
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let artifactPath = temporaryDirectory.appending(component: "artifact.aar")
+        try Data("payload".utf8).write(to: URL(fileURLWithPath: artifactPath.pathString))
+
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [MultipartUploadURLProtocol.self]
+        let subject = MultipartUploadArtifactService(
+            urlSession: URLSession(configuration: configuration),
+            retryProvider: NoRetryProvider()
+        )
+
+        do {
+            _ = try await subject.multipartUploadArtifact(
+                artifactPath: artifactPath,
+                generateUploadURL: { part in "https://tuist.dev/upload?partNumber=\(part.number)" },
+                updateProgress: { _ in }
+            )
+            Issue.record("Expected multipart upload to reject the failed response")
+        } catch let error as MultipartUploadArtifactServiceError {
+            guard case let .uploadFailed(url, statusCode, body) = error else {
+                Issue.record("Expected uploadFailed, got \(error)")
+                return
+            }
+            #expect(url?.absoluteString == "https://tuist.dev/upload?partNumber=1")
+            #expect(statusCode == 500)
+            #expect(body == "storage error")
+        }
+    }
+
+    @Test(.inTemporaryDirectory)
+    func multipartUploadArtifact_retriesWhenArtifactChangesWhileUploading() async throws {
+        MultipartUploadURLProtocol.reset()
+        MultipartUploadURLProtocol.statusCode = 200
+
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let artifactPath = temporaryDirectory.appending(component: "artifact.aar")
+        let initialPayload = Data("initial".utf8)
+        let appendedPayload = Data("-appended".utf8)
+        var expectedPayload = initialPayload
+        expectedPayload.append(appendedPayload)
+        try initialPayload.write(to: URL(fileURLWithPath: artifactPath.pathString))
+
+        let lock = NSLock()
+        var didAppend = false
+        MultipartUploadURLProtocol.onRequest = { _, _ in
+            lock.lock()
+            defer { lock.unlock() }
+            guard !didAppend else { return }
+            didAppend = true
+
+            guard let handle = try? FileHandle(forWritingTo: URL(fileURLWithPath: artifactPath.pathString)) else {
+                return
+            }
+            defer { try? handle.close() }
+            try? handle.seekToEnd()
+            try? handle.write(contentsOf: appendedPayload)
+        }
+
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [MultipartUploadURLProtocol.self]
+        let subject = MultipartUploadArtifactService(
+            urlSession: URLSession(configuration: configuration),
+            retryProvider: NoRetryProvider()
+        )
+
+        let parts = try await subject.multipartUploadArtifact(
+            artifactPath: artifactPath,
+            generateUploadURL: { part in "https://tuist.dev/upload?partNumber=\(part.number)" },
+            updateProgress: { _ in }
+        )
+
+        #expect(parts.map(\.partNumber) == [1])
+        #expect(parts.map(\.etag) == ["etag-1"])
+
+        let requests = MultipartUploadURLProtocol.requests
+        #expect(requests.map(\.body) == [initialPayload, expectedPayload])
+    }
+}
+
+private actor MultipartUploadPartRecorder {
+    private(set) var parts: [MultipartUploadArtifactPart] = []
+
+    func record(_ part: MultipartUploadArtifactPart) {
+        parts.append(part)
+    }
+}
+
+private struct NoRetryProvider: RetryProviding {
+    func runWithRetries<T>(
+        operation: @Sendable @escaping () async throws -> T
+    ) async throws -> T {
+        try await operation()
+    }
+}
+
+private struct CapturedMultipartUploadRequest {
+    let partNumber: Int
+    let contentLength: Int
+    let body: Data
+}
+
+private final class MultipartUploadURLProtocol: URLProtocol {
+    nonisolated(unsafe) static var responseData = Data()
+    nonisolated(unsafe) static var statusCode = 200
+    nonisolated(unsafe) static var onRequest: ((URLRequest, Data) -> Void)?
+
+    private nonisolated(unsafe) static var capturedRequests: [CapturedMultipartUploadRequest] = []
+    private nonisolated(unsafe) static let lock = NSLock()
+
+    static var requests: [CapturedMultipartUploadRequest] {
+        lock.lock()
+        defer { lock.unlock() }
+        return capturedRequests
+    }
+
+    static func reset() {
+        lock.lock()
+        defer { lock.unlock() }
+        capturedRequests = []
+        responseData = Data()
+        statusCode = 200
+        onRequest = nil
+    }
+
+    override class func canInit(with _: URLRequest) -> Bool {
+        true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        let body = Self.bodyData(from: request)
+        Self.onRequest?(request, body)
+        let partNumber = request.url.flatMap { URLComponents(url: $0, resolvingAgainstBaseURL: false) }?
+            .queryItems?
+            .first(where: { $0.name == "partNumber" })?
+            .value
+            .flatMap(Int.init) ?? 0
+
+        Self.lock.lock()
+        Self.capturedRequests.append(
+            CapturedMultipartUploadRequest(
+                partNumber: partNumber,
+                contentLength: Int(request.value(forHTTPHeaderField: "Content-Length") ?? "") ?? 0,
+                body: body
+            )
+        )
+        Self.lock.unlock()
+
+        let response = HTTPURLResponse(
+            url: request.url!,
+            statusCode: Self.statusCode,
+            httpVersion: nil,
+            headerFields: ["Etag": "etag-\(partNumber)"]
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: Self.responseData)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+
+    private static func bodyData(from request: URLRequest) -> Data {
+        if let body = request.httpBody {
+            return body
+        }
+
+        guard let stream = request.httpBodyStream else {
+            return Data()
+        }
+
+        stream.open()
+        defer { stream.close() }
+
+        var data = Data()
+        var buffer = [UInt8](repeating: 0, count: 8192)
+        while true {
+            let bytesRead = stream.read(&buffer, maxLength: buffer.count)
+            guard bytesRead > 0 else { break }
+            data.append(buffer, count: bytesRead)
+        }
+        return data
+    }
+}

--- a/cli/Tests/TuistServerTests/MultipartUploadArtifactServiceTests.swift
+++ b/cli/Tests/TuistServerTests/MultipartUploadArtifactServiceTests.swift
@@ -86,7 +86,7 @@ struct MultipartUploadArtifactServiceTests {
     }
 
     @Test(.inTemporaryDirectory)
-    func multipartUploadArtifact_retriesWhenArtifactChangesWhileUploading() async throws {
+    func multipartUploadArtifact_rejectsArtifactChangesWhileUploading() async throws {
         MultipartUploadURLProtocol.reset()
         MultipartUploadURLProtocol.statusCode = 200
 
@@ -121,17 +121,24 @@ struct MultipartUploadArtifactServiceTests {
             retryProvider: NoRetryProvider()
         )
 
-        let parts = try await subject.multipartUploadArtifact(
-            artifactPath: artifactPath,
-            generateUploadURL: { part in "https://tuist.dev/upload?partNumber=\(part.number)" },
-            updateProgress: { _ in }
-        )
-
-        #expect(parts.map(\.partNumber) == [1])
-        #expect(parts.map(\.etag) == ["etag-1"])
+        do {
+            _ = try await subject.multipartUploadArtifact(
+                artifactPath: artifactPath,
+                generateUploadURL: { part in "https://tuist.dev/upload?partNumber=\(part.number)" },
+                updateProgress: { _ in }
+            )
+            Issue.record("Expected multipart upload to reject the changing artifact")
+        } catch let error as MultipartUploadArtifactServiceError {
+            guard case let .incompleteArtifactRead(_, expectedBytes, readBytes) = error else {
+                Issue.record("Expected incompleteArtifactRead, got \(error)")
+                return
+            }
+            #expect(expectedBytes == UInt64(expectedPayload.count))
+            #expect(readBytes == UInt64(initialPayload.count))
+        }
 
         let requests = MultipartUploadURLProtocol.requests
-        #expect(requests.map(\.body) == [initialPayload, expectedPayload])
+        #expect(requests.map(\.body) == [initialPayload])
     }
 }
 

--- a/cli/Tests/TuistXCResultServiceTests/XCResultServiceTests.swift
+++ b/cli/Tests/TuistXCResultServiceTests/XCResultServiceTests.swift
@@ -1,3 +1,4 @@
+import FileSystem
 import FileSystemTesting
 import Foundation
 import Path
@@ -6,13 +7,11 @@ import XCResultParser
 @testable import TuistXCResultService
 
 struct XCResultServiceTests {
-    private let subject = XCResultService()
-
-    @Test
+    @Test(.inTemporaryDirectory)
     func parseTestXCResult() async throws {
         // Given
-        let xcresult = try AbsolutePath(validating: #file).parentDirectory
-            .appending(try RelativePath(validating: "../Fixtures/test.xcresult"))
+        let xcresult = try await fixtureXCResult("test.xcresult")
+        let subject = XCResultService()
         let cet = TimeZone(identifier: "Europe/Berlin")!
 
         // When
@@ -40,11 +39,11 @@ struct XCResultServiceTests {
         )
     }
 
-    @Test
+    @Test(.inTemporaryDirectory)
     func parseTestWithCustomLabelXCResult() async throws {
         // Given
-        let xcresult = try AbsolutePath(validating: #file).parentDirectory
-            .appending(try RelativePath(validating: "../Fixtures/test-with-custom-label.xcresult"))
+        let xcresult = try await fixtureXCResult("test-with-custom-label.xcresult")
+        let subject = XCResultService()
         let cet = TimeZone(identifier: "Europe/Berlin")!
 
         // When
@@ -58,11 +57,11 @@ struct XCResultServiceTests {
         #expect(got.testCases.compactMap(\.duration).sorted() == [103])
     }
 
-    @Test
+    @Test(.inTemporaryDirectory)
     func parseTestWithRepetitionsXCResult() async throws {
         // Given
-        let xcresult = try AbsolutePath(validating: #file).parentDirectory
-            .appending(try RelativePath(validating: "../Fixtures/test-with-repetitions.xcresult"))
+        let xcresult = try await fixtureXCResult("test-with-repetitions.xcresult")
+        let subject = XCResultService()
 
         // When
         let got = try #require(try await subject.parse(path: xcresult, rootDirectory: nil))
@@ -95,11 +94,11 @@ struct XCResultServiceTests {
         #expect(nonFlakyTest.failures.isEmpty)
     }
 
-    @Test
+    @Test(.inTemporaryDirectory)
     func parseTestWithArgumentsXCResult() async throws {
         // Given
-        let xcresult = try AbsolutePath(validating: #file).parentDirectory
-            .appending(try RelativePath(validating: "../Fixtures/test-with-arguments.xcresult"))
+        let xcresult = try await fixtureXCResult("test-with-arguments.xcresult")
+        let subject = XCResultService()
 
         // When
         let got = try #require(try await subject.parse(path: xcresult, rootDirectory: nil))
@@ -137,10 +136,10 @@ struct XCResultServiceTests {
 
     // MARK: - parseTestStatuses
 
-    @Test
+    @Test(.inTemporaryDirectory)
     func parseTestStatuses_returnsCorrectStatuses() async throws {
-        let xcresult = try AbsolutePath(validating: #file).parentDirectory
-            .appending(try RelativePath(validating: "../Fixtures/test.xcresult"))
+        let xcresult = try await fixtureXCResult("test.xcresult")
+        let subject = XCResultService()
 
         let got = try await subject.parseTestStatuses(path: xcresult)
 
@@ -152,10 +151,10 @@ struct XCResultServiceTests {
         #expect(got.testCases.allSatisfy { $0.module == "AppTests" })
     }
 
-    @Test
+    @Test(.inTemporaryDirectory)
     func parseTestStatuses_returnsPassingModuleNames() async throws {
-        let xcresult = try AbsolutePath(validating: #file).parentDirectory
-            .appending(try RelativePath(validating: "../Fixtures/test-with-custom-label.xcresult"))
+        let xcresult = try await fixtureXCResult("test-with-custom-label.xcresult")
+        let subject = XCResultService()
 
         let got = try await subject.parseTestStatuses(path: xcresult)
 
@@ -163,15 +162,25 @@ struct XCResultServiceTests {
         #expect(got.passingModuleNames().contains("AppTests"))
     }
 
-    @Test
+    @Test(.inTemporaryDirectory)
     func parseTestStatuses_extractsModuleAndSuiteNames() async throws {
-        let xcresult = try AbsolutePath(validating: #file).parentDirectory
-            .appending(try RelativePath(validating: "../Fixtures/test.xcresult"))
+        let xcresult = try await fixtureXCResult("test.xcresult")
+        let subject = XCResultService()
 
         let got = try await subject.parseTestStatuses(path: xcresult)
 
         let modules = Set(got.testCases.compactMap(\.module))
         #expect(modules == ["AppTests"])
         #expect(got.testCases.contains { $0.testSuite != nil })
+    }
+
+    private func fixtureXCResult(_ name: String) async throws -> AbsolutePath {
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let source = try AbsolutePath(validating: #file).parentDirectory
+            .appending(try RelativePath(validating: "../Fixtures/\(name)"))
+        let destination = temporaryDirectory.appending(component: name)
+
+        try await FileSystem().copy(source, to: destination)
+        return destination
     }
 }


### PR DESCRIPTION
## What changed

- Changed `FileClienting.download` so callers pass the destination `AbsolutePath`; the method now returns `Void` because the caller already owns that path.
- Updated shard downloads to write each `.aar` into a caller-owned temporary path, extract from that path, and remove it after extraction.
- Scoped the shard `.aar` scratch directory with `fileSystem.runInTemporaryDirectory`, so any leftover downloaded archives are cleaned up even if extraction fails.
- Fixed split shard artifact production so duplicate `.xctest` basenames are grouped into one module artifact instead of racing on the same archive filename and server artifact key.
- Extended `AppleArchiver` with a multi-subdirectory compression API that preserves each bundle's path relative to the `.xctestproducts` root while pruning unrelated siblings.
- Kept multipart uploads single-pass and strict: short reads, size changes during upload, or non-2xx storage responses fail instead of being retried as a symptom workaround.

## Why

The acceptance failures for PR #11660 were happening before xcodebuild produced useful test output. The shard jobs failed while extracting remote shard artifacts with `AppleArchive.ArchiveError.ioError`, and the stored artifact from CI was already truncated. That pointed away from the PR test body and toward artifact production/transfer.

The downloader lifecycle change is still useful because the shard consumer owns when the archive is extracted and removed. The downloaded archive directory is scoped to the extraction block, while the merged extracted products directory intentionally survives because the rest of `ShardService.run` needs it for xcodebuild. The real correctness fix remains on the producer side: do not create corrupt shard artifacts in the first place.

## Root cause

`ShardPlanService.uploadSplitArtifacts` used each `.xctest` bundle's `basenameWithoutExt` as both:

- the local archive filename, for example `AppTests.aar`
- the remote artifact key, for example `module:AppTests`

Split artifacts are uploaded concurrently. When an `.xctestproducts` bundle contains two test bundles with the same basename in different directories, such as `Binaries/0/Debug/AppTests.xctest` and `Binaries/1/Debug/AppTests.xctest`, two concurrent tasks can truncate/write the same local `AppTests.aar` and complete the same `module:AppTests` upload. That explains how the final local archive can be valid while the object completed remotely is a partial snapshot.

The fix groups duplicate basenames before upload. There is now exactly one `module:AppTests` upload, and its `.aar` contains all matching `.xctest` paths preserved relative to the products root.

## Approach

- Group discovered `.xctest` bundles by basename before creating split module artifacts.
- Archive all paths in a module group into a single module archive using the new `AppleArchiver.compress(subdirectories:relativeTo:to:)` API.
- Preserve relative paths so extraction still reconstructs the original `.xctestproducts` layout.
- Remove the retry loop from multipart upload. If the input changes during upload, the uploader reports the inconsistent read; the producer code is responsible for making that impossible.
- Keep the caller-owned download destination because it makes shard archive ownership and cleanup explicit, without returning the same path back to the caller.
- Use `runInTemporaryDirectory` for downloaded `.aar` scratch files, while still deleting each archive after decompression to keep peak disk usage lower for multi-artifact shards.

## Reproduction and validation

I reproduced the CI environment with the failing PR head `346c53f3819c1684585ab37e1960096fd19e6de5`, `MISE_VERSION=2026.5.15`, and CI-installed Tuist `4.202.0-canary.32`.

This did not look like a rare test-body flake:

- In GitHub Actions, shard 0 and shard 1 failed in both attempts after build-only succeeded: 4/4 shard jobs failed.
- Locally, the same CI-installed Tuist binary failed shard 0 and shard 1 before xcodebuild with `AppleArchive.ArchiveError.ioError`.
- The stored artifact for plan `d25dd215-ad1c-4ce8-961b-3c77f16f19ae` downloaded at `18,174,143` bytes and `xcrun aa list -i` reported a truncated archive.
- Locally generated archives for the same module were valid and materially larger.

Checks run for this PR:

- `mise exec -- tuist generate TuistAppleArchiver TuistAppleArchiverTests TuistKit TuistKitTests TuistServer TuistServerTests TuistHTTP TuistHTTPTests ProjectDescription --no-open`
- `mise run cli:lint --fix`
- `mise run cli:lint`
- `xcodebuild build -workspace Tuist.xcworkspace -scheme Tuist-Workspace COMPILATION_CACHE_ENABLE_CACHING=NO COMPILATION_CACHE_ENABLE_PLUGIN=NO COMPILATION_CACHE_ENABLE_DIAGNOSTIC_REMARKS=NO CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""`
- `xcodebuild test -workspace Tuist.xcworkspace -scheme Tuist-Workspace -only-testing TuistAppleArchiverTests/AppleArchiverTests -only-testing TuistKitTests/ShardPlanServiceTests -only-testing TuistServerTests/MultipartUploadArtifactServiceTests COMPILATION_CACHE_ENABLE_CACHING=NO COMPILATION_CACHE_ENABLE_PLUGIN=NO COMPILATION_CACHE_ENABLE_DIAGNOSTIC_REMARKS=NO CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""`
- `xcodebuild test -workspace Tuist.xcworkspace -scheme Tuist-Workspace -only-testing TuistHTTPTests/FileClientTests -only-testing TuistKitTests/ShardServiceTests COMPILATION_CACHE_ENABLE_CACHING=NO COMPILATION_CACHE_ENABLE_PLUGIN=NO COMPILATION_CACHE_ENABLE_DIAGNOSTIC_REMARKS=NO CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""`
- `xcodebuild test -workspace Tuist.xcworkspace -scheme Tuist-Workspace -only-testing TuistKitTests/ShardServiceTests COMPILATION_CACHE_ENABLE_CACHING=NO COMPILATION_CACHE_ENABLE_PLUGIN=NO COMPILATION_CACHE_ENABLE_DIAGNOSTIC_REMARKS=NO CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""`

The new focused tests cover the root behavior directly: duplicate `AppTests.xctest` basenames now produce one `module:AppTests` artifact containing both bundle paths, `AppleArchiver` preserves those relative paths while pruning siblings, and `FileClienting.download` now simply materializes the requested destination without returning it.