### PR TITLE
fix(server): bump XCLogParser to 0.2.49

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -443,7 +443,7 @@
       "kind" : "registry",
       "location" : "",
       "state" : {
-        "version" : "0.2.48"
+        "version" : "0.2.49"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -1841,7 +1841,7 @@ let package = Package(
         .package(id: "grpc.grpc-swift-nio-transport", from: "2.0.0"),
         .package(id: "facebook.zstd", from: "1.5.0"),
         .package(id: "chrisaljoudi.swift-log-oslog", .upToNextMajor(from: "0.2.2")),
-        .package(id: "MobileNativeFoundation.XCLogParser", .upToNextMajor(from: "0.2.48")),
+        .package(id: "MobileNativeFoundation.XCLogParser", .upToNextMajor(from: "0.2.49")),
         .package(path: "server/native/xcactivitylog_nif"),
         .package(id: "swiftyJSON.SwiftyJSON", .upToNextMajor(from: "5.0.2")),
         .package(id: "tuist.Rosalind", .upToNextMajor(from: "0.7.22")),

--- a/server/native/xcactivitylog_nif/Package.resolved
+++ b/server/native/xcactivitylog_nif/Package.resolved
@@ -86,7 +86,7 @@
       "kind" : "registry",
       "location" : "",
       "state" : {
-        "version" : "0.2.48"
+        "version" : "0.2.49"
       }
     },
     {

--- a/server/native/xcactivitylog_nif/Package.swift
+++ b/server/native/xcactivitylog_nif/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(id: "MobileNativeFoundation.XCLogParser", from: "0.2.48"),
+        .package(id: "MobileNativeFoundation.XCLogParser", from: "0.2.49"),
         .package(id: "tuist.Path", from: "0.3.8"),
         .package(id: "tuist.FileSystem", .upToNextMajor(from: "0.16.2")),
         .package(id: "stephencelis.SQLite_swift", from: "0.16.0"),


### PR DESCRIPTION
## What changed

- Bump `MobileNativeFoundation.XCLogParser` from `0.2.48` to `0.2.49` in the root Swift package.
- Bump the same dependency in `server/native/xcactivitylog_nif`.
- Update both `Package.resolved` files to pin the registry version to `0.2.49`.

## Why

`XCLogParser` `0.2.49` includes the SLF parser and log-loader fixes from MobileNativeFoundation/XCLogParser#254. Tuist uses that parser both from the CLI activity-log code path and from the server-side xcactivitylog NIF used by build processing, so both package manifests need to agree on the new release.

## Root cause

Some valid `.xcactivitylog` payloads could fail parsing when SLF string lengths were interpreted with Swift string indices instead of UTF-8 byte offsets, and when decompressed log contents were loaded through a C string path that truncated at embedded NUL bytes. The upstream parser release fixes those cases by scanning SLF strings in bytes and decoding decompressed data as UTF-8 while preserving embedded NUL bytes.

## Approach

The upstream XCLogParser release was published as `v0.2.49`. I synced `MobileNativeFoundation/XCLogParser@v0.2.49` into the Tuist Swift package registry using `mise run registry:sync MobileNativeFoundation/XCLogParser v0.2.49 --user mfort`, then pinned Tuist to the normalized registry version `0.2.49`.

## Impact

Build processing should pick up the parser fix once the server image is built from this change. The CLI package graph is also kept in sync with the same XCLogParser version.

## Validation

- Verified `https://registry.tuist.dev/api/registry/swift/mobilenativefoundation/xclogparser` lists `0.2.49`.
- Verified `https://registry.tuist.dev/api/registry/swift/mobilenativefoundation/xclogparser/0.2.49.zip` returns `200`.
- `swift package --force-resolved-versions --skip-update resolve --replace-scm-with-registry` from `server/native/xcactivitylog_nif`.
- `swift package --force-resolved-versions --skip-update resolve --replace-scm-with-registry` from the repository root.
- `git diff --check`.
