### PR TITLE
fix(cli): fix Kura Xcode-CAS remote caching on dev machines (tokio runtime, Xcode upstream, agent version)

### DIFF
--- a/cas-plugin/src/bin/tuist-cas-proxy.rs
+++ b/cas-plugin/src/bin/tuist-cas-proxy.rs
@@ -39,11 +39,12 @@ fn main() {
         std::process::exit(2);
     };
     let tokens = TokenProvider::from_env();
-    let upstream_plugin = std::env::var("TUIST_CAS_UPSTREAM_PLUGIN").unwrap_or_else(|_| {
-        let developer_dir = std::env::var("DEVELOPER_DIR")
-            .unwrap_or_else(|_| "/Applications/Xcode.app/Contents/Developer".into());
-        format!("{developer_dir}/usr/lib/libToolchainCASPlugin.dylib")
-    });
+    // Resolve the upstream via the shared `upstream_path()` so the proxy gets the
+    // same `xcode-select` fallback as the plugin. The proxy is launched by
+    // launchd/`tuist cache-proxy` with no DEVELOPER_DIR, so without this it would
+    // fall back to the hardcoded `/Applications/Xcode.app` and fail to load
+    // Apple's plugin on any versioned Xcode install (every resolve then misses).
+    let upstream_plugin = tuist_cas_plugin::upstream_path();
     let registry_path = std::env::var("TUIST_CAS_PROXY_REGISTRY")
         .unwrap_or_else(|_| format!("{socket_path}.registry"));
 

--- a/cas-plugin/src/lib.rs
+++ b/cas-plugin/src/lib.rs
@@ -31,7 +31,10 @@ use upstream::Upstream;
 
 static UPSTREAM: OnceLock<Result<&'static Upstream, String>> = OnceLock::new();
 
-fn upstream_path() -> String {
+/// Resolves the path to Apple's `libToolchainCASPlugin.dylib`. Shared with the
+/// `tuist-cas-proxy` binary so the plugin and the proxy agree on how to find the
+/// upstream (including the `xcode-select` fallback for versioned Xcode installs).
+pub fn upstream_path() -> String {
     if let Ok(path) = std::env::var("TUIST_CAS_UPSTREAM_PLUGIN") {
         return path;
     }

--- a/cas-plugin/src/reapi.rs
+++ b/cas-plugin/src/reapi.rs
@@ -221,6 +221,14 @@ impl Remote {
     fn channel(&self) -> Result<Channel, String> {
         self.channel
             .get_or_init(|| {
+                // connect_lazy wires the hyper connection pool and the h2
+                // keepalive timers to the *current* Tokio runtime. This runs from
+                // a proxy handler thread (outside the runtime), so without
+                // entering the runtime here the first RPC panics with "there is
+                // no reactor running" on a detached connection task; the panic is
+                // swallowed at the FFI boundary and every resolve silently
+                // degrades to a local miss (0% remote cache).
+                let _runtime_guard = runtime().enter();
                 let mut endpoint = Endpoint::from_shared(self.config.grpc_url.clone())
                     .map_err(|e| format!("bad grpc url: {e}"))?
                     .connect_timeout(Duration::from_secs(5))

--- a/cas-plugin/tests/reactor_repro.rs
+++ b/cas-plugin/tests/reactor_repro.rs
@@ -1,0 +1,54 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use tuist_cas_plugin::reapi::{Remote, RemoteConfig};
+use tuist_cas_plugin::token::TokenProvider;
+
+// Reproduces the proxy's threading model: an RPC issued from a plain thread
+// (no ambient Tokio runtime), exactly like a proxy connection handler. The
+// tonic Channel is built via connect_lazy inside Remote::channel(); if that
+// construction happens outside the runtime context, the first RPC panics with
+// "there is no reactor running" on the hyper connection path. In production the
+// panic is swallowed at the FFI boundary and every resolve silently degrades to
+// a local miss (0% remote cache), so we catch it with a global panic hook
+// rather than relying on the call to abort.
+#[test]
+fn grpc_call_from_plain_thread_does_not_panic_no_reactor() {
+    // Reserve then release a port so connections are refused immediately: the
+    // channel is still driven far enough to trigger the panic in the buggy case,
+    // but the fixed path returns a fast transport error instead of blocking.
+    let addr = {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        listener.local_addr().unwrap()
+    };
+
+    let saw_no_reactor = Arc::new(AtomicBool::new(false));
+    let flag = saw_no_reactor.clone();
+    let previous = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        if info.to_string().contains("no reactor running") {
+            flag.store(true, Ordering::SeqCst);
+        }
+        previous(info);
+    }));
+
+    let remote = Remote::new(
+        RemoteConfig {
+            grpc_url: format!("http://{addr}"),
+            instance: "test".into(),
+        },
+        TokenProvider::from_env(),
+    );
+
+    // Issued from this plain test thread; returns Err (transport) either way.
+    let _ = remote.get_action(b"deadbeefdeadbeef");
+
+    // Let any detached connection-driver task run and (not) panic.
+    std::thread::sleep(std::time::Duration::from_millis(500));
+
+    let _ = std::panic::take_hook();
+    assert!(
+        !saw_no_reactor.load(Ordering::SeqCst),
+        "gRPC path panicked with 'no reactor running' (channel built outside the tokio runtime)"
+    );
+}

--- a/cli/Sources/TuistLaunchctl/LaunchAgentService.swift
+++ b/cli/Sources/TuistLaunchctl/LaunchAgentService.swift
@@ -152,24 +152,14 @@ public struct LaunchAgentService: LaunchAgentServicing {
             throw LaunchAgentServiceError.missingExecutablePath
         }
 
-        if currentPath.pathString.contains("/.local/share/mise/installs/tuist/") {
-            let homeDir = Environment.current.homeDirectory
-
-            let misePath = homeDir.appending(
-                components: ".local", "share", "mise", "installs", "tuist", "latest", "tuist"
-            )
-            if try await fileSystem.exists(misePath) {
-                return misePath
-            }
-
-            let oldMisePath = homeDir.appending(
-                components: ".local", "share", "mise", "installs", "tuist", "latest", "bin", "tuist"
-            )
-            if try await fileSystem.exists(oldMisePath) {
-                return oldMisePath
-            }
-        }
-
+        // Pin the launch agent to the exact binary that registered it. A mise
+        // setup previously rewrote the concrete versioned install to mise's
+        // `latest` symlink, but `latest` tracks the newest *stable* install, not
+        // the project's pinned or canary version. That silently launches a tuist
+        // predating the arguments baked into the plist (e.g. `--url`), which
+        // exits with an "unknown option" error. The mise postinstall hook
+        // re-runs `tuist setup` on every version change, so pinning the concrete
+        // path stays self-healing.
         return currentPath
     }
 

--- a/cli/Sources/TuistLaunchctl/LaunchAgentService.swift
+++ b/cli/Sources/TuistLaunchctl/LaunchAgentService.swift
@@ -152,14 +152,6 @@ public struct LaunchAgentService: LaunchAgentServicing {
             throw LaunchAgentServiceError.missingExecutablePath
         }
 
-        // Pin the launch agent to the exact binary that registered it. A mise
-        // setup previously rewrote the concrete versioned install to mise's
-        // `latest` symlink, but `latest` tracks the newest *stable* install, not
-        // the project's pinned or canary version. That silently launches a tuist
-        // predating the arguments baked into the plist (e.g. `--url`), which
-        // exits with an "unknown option" error. The mise postinstall hook
-        // re-runs `tuist setup` on every version change, so pinning the concrete
-        // path stays self-healing.
         return currentPath
     }
 

--- a/cli/Tests/TuistLaunchctlTests/LaunchAgentServiceTests.swift
+++ b/cli/Tests/TuistLaunchctlTests/LaunchAgentServiceTests.swift
@@ -226,7 +226,7 @@ struct LaunchAgentServiceTests {
     }
 
     @Test(.inTemporaryDirectory, .withMockedEnvironment())
-    func setupLaunchAgent_resolvesMiseManagedBinaryPath() async throws {
+    func setupLaunchAgent_usesConcreteMiseBinaryPathNotLatestSymlink() async throws {
         let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
         let environment = try #require(Environment.mocked)
         let currentMisePath = temporaryDirectory.appending(
@@ -234,12 +234,6 @@ struct LaunchAgentServiceTests {
         )
         environment.homeDirectory = temporaryDirectory
         environment.currentExecutablePathStub = currentMisePath
-
-        let expectedBinaryPath = temporaryDirectory.appending(
-            components: ".local", "share", "mise", "installs", "tuist", "latest", "tuist"
-        )
-        try await fileSystem.makeDirectory(at: expectedBinaryPath.parentDirectory)
-        try await fileSystem.writeText("", at: expectedBinaryPath)
 
         given(launchctlController)
             .bootstrap(plistPath: .any)
@@ -256,41 +250,8 @@ struct LaunchAgentServiceTests {
             components: "Library", "LaunchAgents", "tuist.test.plist"
         )
         let plistContent = try await fileSystem.readTextFile(at: expectedPlistPath)
-        #expect(plistContent.contains(expectedBinaryPath.pathString.replacingOccurrences(of: "/private", with: "")))
-    }
-
-    @Test(.inTemporaryDirectory, .withMockedEnvironment())
-    func setupLaunchAgent_resolvesMiseManagedOldBinaryPath() async throws {
-        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
-        let environment = try #require(Environment.mocked)
-        let currentMisePath = temporaryDirectory.appending(
-            components: ".local", "share", "mise", "installs", "tuist", "4.0.0", "bin", "tuist"
-        )
-        environment.homeDirectory = temporaryDirectory
-        environment.currentExecutablePathStub = currentMisePath
-
-        let expectedBinaryPath = temporaryDirectory.appending(
-            components: ".local", "share", "mise", "installs", "tuist", "latest", "bin", "tuist"
-        )
-        try await fileSystem.makeDirectory(at: expectedBinaryPath.parentDirectory)
-        try await fileSystem.writeText("", at: expectedBinaryPath)
-
-        given(launchctlController)
-            .bootstrap(plistPath: .any)
-            .willReturn()
-
-        try await subject.setupLaunchAgent(
-            label: "tuist.test",
-            plistFileName: "tuist.test.plist",
-            programArguments: ["test-start"]
-        )
-
-        let homeDirectory = Environment.current.homeDirectory
-        let expectedPlistPath = homeDirectory.appending(
-            components: "Library", "LaunchAgents", "tuist.test.plist"
-        )
-        let plistContent = try await fileSystem.readTextFile(at: expectedPlistPath)
-        #expect(plistContent.contains(expectedBinaryPath.pathString.replacingOccurrences(of: "/private", with: "")))
+        #expect(plistContent.contains(currentMisePath.pathString))
+        #expect(!plistContent.contains("/installs/tuist/latest/"))
     }
 
     @Test(.inTemporaryDirectory, .withMockedEnvironment())


### PR DESCRIPTION
## What changed

Three bugs in the Kura Xcode-CAS path, all surfaced by local end-to-end validation of CLI `4.203.0-canary.11` (the first release carrying the productized `cas-plugin`) on a machine with a **versioned** Xcode install (`/Applications/Xcode-26.5.0.app`) and a mise-pinned canary CLI. None of them are exercised by CI, which uses the legacy CAS daemon and a default `/Applications/Xcode.app`.

1. **REAPI gRPC channel built outside the tokio runtime → 0% remote cache.** `Remote::channel()` builds the tonic `Channel` via `Endpoint::connect_lazy()` from a proxy connection-handler thread, *outside* the runtime (each RPC is separately wrapped in `runtime().block_on(...)`). `connect_lazy` and the hyper h2-keepalive timers it wires up bind to the current Tokio runtime, so with no runtime in context the first RPC panics `there is no reactor running` on the hyper connection path. The plugin's FFI `catch_unwind` swallows the panic, so every resolve silently degrades to a local miss. Fix: enter the runtime while constructing the channel.

2. **`tuist-cas-proxy` could not load Apple's plugin on a versioned Xcode.** The proxy resolved `libToolchainCASPlugin.dylib` via `TUIST_CAS_UPSTREAM_PLUGIN` → `DEVELOPER_DIR` → a hardcoded `/Applications/Xcode.app/Contents/Developer`, with no `xcode-select` fallback of its own (the plugin dylib already had one; the proxy binary had its own inline resolution that did not). Fix: make `upstream_path()` public and have the proxy binary share it.

3. **The cache launch agent ran the wrong tuist on pinned/canary setups.** `LaunchAgentService.determineTuistBinaryPath` rewrote the concrete mise install to mise's `latest` symlink. Fix: pin the agent to the exact binary that registered it.

## Why it changed (root cause)

**gRPC runtime context (fix 1).** The panic (`hyper-util rt/tokio.rs`) lands on a detached hyper connection task and is swallowed at the FFI boundary, so there is no hard error — the build just gets no remote cache. In the e2e a cold build reported `0 hits / 124 cacheable tasks (0%)` while the proxy log filled with the panic and `proxy stats: resolves=22 remote_hits=0 misses=0`. The channel captures the runtime at construction time; constructing it on a handler thread with no runtime in context is what breaks it.

**Upstream resolution (fix 2).** The proxy is started by `launchd` (via `tuist cache-proxy`), which provides neither `DEVELOPER_DIR` nor `TUIST_CAS_UPSTREAM_PLUGIN`. On any non-default Xcode install it therefore fell through to the hardcoded `/Applications/Xcode.app`, which does not exist, so loading the upstream failed and every resolve degraded to a local miss. `execv` already preserves any `DEVELOPER_DIR` the launcher has, so the only missing piece was the `xcode-select` fallback inside the proxy.

**Launch-agent version (fix 3).** mise's `latest` symlink tracks the newest *stable* install, not the project's pinned or canary version. With a canary pinned in `mise.toml`, `latest` pointed at an older stable tuist (`4.200.5`), so the agent launched a binary that predated the proxy's `--url` argument and exited 64. The plist is rewritten by `tuist setup` on every mise install (postinstall hook), and mise keeps old version dirs around, so pinning the concrete binary is self-healing — the `latest` indirection bought nothing here and actively broke pinned/canary setups.

## Why this approach

- **Fix 1:** entering the runtime around channel construction is the minimal, idiomatic remedy for the tonic/hyper "`connect_lazy` outside a runtime" footgun; it preserves the intentional `connect_lazy` reconnect semantics.
- **Fix 2:** sharing the plugin's `upstream_path()` keeps a single source of truth for upstream resolution. The launcher does not also need to pass `DEVELOPER_DIR`/`TUIST_CAS_UPSTREAM_PLUGIN`: the proxy now resolves it itself, and `execv` forwards any explicit selection the launcher already has.
- **Fix 3:** pinning the concrete binary restores the correct invariant — *the agent runs the code that knows how to talk to it* — and stays correct for non-mise installs, which were already returned verbatim.

## Impact

- Developer machines on the Kura path (`TUIST_FEATURE_FLAG_KURA=1`) now get a working remote Xcode cache instead of a silent 0% hit rate, an unloadable upstream on versioned Xcode, or an exit-64 agent crash-loop.
- Fix 3 also affects the machine-metrics/insights launch agent (shared `determineTuistBinaryPath`); it is now likewise pinned to the concrete binary (same self-healing behavior).

## Validation

- **gRPC runtime (fix 1):** added `cas-plugin/tests/reactor_repro.rs`, which drives the real `Remote` gRPC path from a plain (non-runtime) thread and asserts it does not panic with `no reactor running`. It **fails** with the exact `hyper-util rt/tokio.rs` panic without the fix and **passes** with it (~0.5s). Full crate suite: 12 unit tests + the regression test pass.
- **Proxy upstream (fix 2):** on this machine `xcode-select -p` → `/Applications/Xcode-26.5.0.app/...` where the plugin **exists**; the hardcoded `/Applications/Xcode.app/...` plugin is **absent**. The rebuilt proxy, launched with neither `DEVELOPER_DIR` nor `TUIST_CAS_UPSTREAM_PLUGIN`, loads the upstream cleanly (no resolve-failure log lines) instead of missing every object.
- **Launch agent (fix 3):** updated `LaunchAgentServiceTests` to assert the plist `Program` is the concrete `.../installs/tuist/<version>/bin/tuist` and never `.../installs/tuist/latest/...`.
- Full Swift build + unit tests run in CI (no generated workspace / no PTY locally for `xcodebuild test`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
