### PR TITLE
fix(cli): send project-only REAPI instance_name so Kura authz grants match

### DIFF
--- a/cas-plugin/src/proxy.rs
+++ b/cas-plugin/src/proxy.rs
@@ -144,6 +144,11 @@ impl Proxy {
     }
 
     /// The REAPI client for an instance, created and cached on first use.
+    ///
+    /// `instance` is the `account/project` full handle used to key the client
+    /// map (two accounts may own like-named projects). The REAPI `instance_name`
+    /// itself is the project segment only; the account rides on the bearer token
+    /// and Kura assembles the authz identifier as `{tenant}/{instance_name}`.
     fn remote_for(&self, instance: &str) -> Arc<Remote> {
         if let Some(remote) = self.remotes.lock().unwrap().get(instance) {
             return remote.clone();
@@ -151,7 +156,7 @@ impl Proxy {
         let remote = Remote::new(
             RemoteConfig {
                 grpc_url: self.grpc_url.clone(),
-                instance: instance.to_string(),
+                instance: reapi::reapi_instance(instance).to_string(),
             },
             self.tokens.clone(),
         );

--- a/cas-plugin/src/reapi.rs
+++ b/cas-plugin/src/reapi.rs
@@ -57,17 +57,31 @@ impl OpStats {
 
 pub struct RemoteConfig {
     pub grpc_url: String,
+    /// REAPI `instance_name`: the project segment only, NOT the `account/project`
+    /// full handle. Kura derives the tenant (account) from the bearer token and
+    /// builds the authz identifier as `{tenant}/{instance_name}`, so carrying the
+    /// account here would double-count it (e.g. `tuist/tuist/tuist`, which no
+    /// principal is granted). See `reapi_instance`.
     pub instance: String,
+}
+
+/// The REAPI `instance_name` for an `account/project` full handle: the project
+/// segment only (everything after the first `/`). The account is conveyed to
+/// Kura by the bearer token, so it must not also be part of `instance_name`.
+pub fn reapi_instance(full_handle: &str) -> &str {
+    full_handle
+        .split_once('/')
+        .map(|(_account, project)| project)
+        .unwrap_or(full_handle)
 }
 
 impl RemoteConfig {
     pub fn from_env() -> Option<Self> {
         let grpc_url = std::env::var("TUIST_CAS_REMOTE_GRPC_URL").ok()?;
-        let account = std::env::var("TUIST_CAS_ACCOUNT").unwrap_or_else(|_| "tuist".into());
         let project = std::env::var("TUIST_CAS_PROJECT").unwrap_or_else(|_| "tuist".into());
         Some(Self {
             grpc_url,
-            instance: format!("{account}/{project}"),
+            instance: reapi_instance(&project).to_string(),
         })
     }
 }
@@ -543,4 +557,23 @@ pub fn compress_frame(frame: &[u8]) -> Vec<u8> {
 
 pub fn decompress_frame(blob: &[u8]) -> Option<Vec<u8>> {
     zstd::stream::decode_all(blob).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::reapi_instance;
+
+    #[test]
+    fn reapi_instance_strips_the_account_from_a_full_handle() {
+        // Kura prepends the token's tenant to instance_name, so instance_name is
+        // the project only; the full handle would become account/account/project.
+        assert_eq!(reapi_instance("tuist/tuist"), "tuist");
+        assert_eq!(reapi_instance("acme/ios-app"), "ios-app");
+    }
+
+    #[test]
+    fn reapi_instance_passes_through_a_bare_project() {
+        assert_eq!(reapi_instance("tuist"), "tuist");
+        assert_eq!(reapi_instance(""), "");
+    }
 }


### PR DESCRIPTION
## What changed

`cas-plugin` now sends the **project segment only** as the REAPI `instance_name`, instead of the full `account/project` handle. New `reapi_instance()` helper extracts the project from a full handle; both the proxy path (`Proxy::remote_for`) and the direct-endpoint path (`RemoteConfig::from_env`) use it. The proxy still keys its per-project client map by the full handle (two accounts may own like-named projects) — only the value sent on the wire is stripped.

## Why it changed (root cause)

Kura's REAPI convention is: the **account (tenant) rides on the bearer token**, and `instance_name` carries the **project/namespace**. The server assembles the authz target as `{tenant}/{instance_name}`. The plugin was sending the full handle as `instance_name`, so for `tuist/tuist` the server checked the identifier `tuist` + `tuist/tuist` = **`tuist/tuist/tuist`** — a three-segment string no principal is granted. Every `get_action` / `find_missing` was denied `403 Forbidden: project 'tuist/tuist/tuist' is not granted to this principal for read`, making the remote cache a hard **0%** against any authz-enforcing endpoint.

## Why it was hidden until now

It only manifests against an endpoint that enforces authorization. Earlier benchmarks that showed real hits ran against plaintext host/PN Kura with no principal check. And on the authenticated production endpoint, the two proxy bugs fixed in the previous PR (upstream-plugin load failure on versioned Xcode, and the tokio "no reactor running" panic) killed every request before it ever reached Kura's authz layer. Fixing those in `canary.13` is what let a request finally reach the authz check and surface this.

## Impact

The productized Kura Xcode-CAS path now authorizes and caches against authenticated production for the first time. Without this, every project's remote cache is silently 0% (the double-count affects any handle: `account/account/project`).

## Validation

Local e2e on `canary.13` (with this proxy swapped in), prod endpoint `https://tuist.dev`, account `tuist`, uploads enabled, `TUIST_FEATURE_FLAG_KURA=1`, building `examples/xcode/generated_project_with_caching_enabled`:

| Phase | Result | Proxy stats |
|---|---|---|
| 1 — populate (fresh DerivedData) | `0 hits / 124 cacheable tasks (0%)` | `misses=124, published=199` — **no** `tuist/tuist/tuist` denials |
| 2 — hit (fresh DerivedData) | **`112 hits / 124 cacheable tasks (90%)`** | `remote_hits=112, misses=11` |

Before the fix (same e2e), the proxy log carried **10,570** `Forbidden: project 'tuist/tuist/tuist'` denials and both phases were 0%. Unit tests added for `reapi_instance` (full-handle stripping + bare-project passthrough); full crate suite passes.

## Follow-up

This is the fourth and final bug in the productized Kura Xcode-CAS path found by local e2e; the first three (upstream resolution, launch-agent version pin, tokio runtime) landed in the previous PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
