### PR TITLE
ci(cli): trigger CLI build/test and canary release on cas-plugin changes

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -20,6 +20,10 @@ on:
       # swifterpm/Sources/swifterpm is compiled into the CLI binary (SwifterPMCore
       # -> TuistSupport), so its changes must cut a canary just like cli/** does.
       - swifterpm/**
+      # cas-plugin (the Xcode CAS dylib + tuist-cas-proxy) is built by
+      # cli-build-publish and shipped inside the CLI release, so its changes must
+      # cut a canary just like cli/** does.
+      - cas-plugin/**
       - mise/tasks/cli/**
       - mise/tasks/release/components.json
       - .github/workflows/cli-release.yml

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -10,6 +10,9 @@ on:
       - "cli/Sources/**"
       - "cli/Tests/**"
       - "cli/Templates/**"
+      # cas-plugin (the Xcode CAS dylib + tuist-cas-proxy) is built and shipped
+      # inside the CLI, so its changes must run CLI build/test/acceptance.
+      - "cas-plugin/**"
       - "*.swift"
       - ".github/workflows/cli.yml"
       - "mise/tasks/cli/lint.sh"
@@ -30,6 +33,9 @@ on:
       - "cli/Sources/**"
       - "cli/Tests/**"
       - "cli/Templates/**"
+      # cas-plugin (the Xcode CAS dylib + tuist-cas-proxy) is built and shipped
+      # inside the CLI, so its changes must run CLI build/test/acceptance.
+      - "cas-plugin/**"
       - "*.swift"
       - ".github/workflows/cli.yml"
       - "mise/tasks/cli/lint.sh"


### PR DESCRIPTION
## What changed

Add `cas-plugin/**` to the path filters of both `cli.yml` (build / test / acceptance) and `cli-release.yml` (canary release).

## Why

The cas-plugin (the Xcode CAS `libtuist_cas_plugin.dylib` and `tuist-cas-proxy`) is built by `cli-build-publish.yml` and shipped inside every CLI release. But its directory was not in either CLI workflow's path filter, so a **cas-plugin-only change triggered no CLI CI and cut no canary**.

This bit us on [#11710](https://github.com/tuist/tuist/pull/11710) (a cas-plugin authz fix): it changed only `cas-plugin/src/{reapi,proxy}.rs`, so its only PR checks were CodeQL / Lint / TruffleHog — no `cargo` build/test, no Swift build, no acceptance tests — and merging it published no canary, leaving the fix in no shipped binary.

`swifterpm/**` already handles the identical situation (it too is compiled into the CLI binary) and is in `cli-release.yml` with a comment saying its changes "must cut a canary just like `cli/**` does". This change mirrors that precedent for `cas-plugin/**`.

## Impact

- Plugin changes now run CLI build/test/acceptance on PRs and pushes.
- Plugin changes now cut a canary.
- Because editing `cli-release.yml` matches that workflow's own path filter, **merging this PR cuts a canary from `main` HEAD — which finally ships #11710's fix.**

## Validation

`yq` parses both workflows; the filters gain `cas-plugin/**` (2 entries in `cli-release.yml`'s push paths, one per block in `cli.yml`'s push + pull_request paths).