### PR TITLE
feat(cli): add cache warm no-upload flag

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -277,7 +277,9 @@ jobs:
         run: xcodebuild -downloadComponent MetalToolchain
       - name: Build tests
         id: shard
-        run: tuist test --build-only --shard-total 2 --shard-granularity suite TuistAcceptanceTests
+        run: tuist test --build-only --shard-total 2 --shard-granularity suite --shard-reference "$TUIST_ACCEPTANCE_SHARD_REFERENCE" TuistAcceptanceTests
+        env:
+          TUIST_ACCEPTANCE_SHARD_REFERENCE: github-${{ github.run_id }}-${{ github.sha }}
 
   cli-acceptance-tests:
     name: Acceptance Tests
@@ -333,9 +335,10 @@ jobs:
           security default-keychain -s $KEYCHAIN_PATH
           security unlock-keychain -p $KEYCHAIN_PASSWORD $KEYCHAIN_PATH
       - name: Run shard ${{ matrix.shard }}
-        run: tuist test --without-building --platform macOS TuistAcceptanceTests -- -retry-tests-on-failure -test-iterations 2
+        run: tuist test --without-building --platform macOS --shard-reference "$TUIST_ACCEPTANCE_SHARD_REFERENCE" TuistAcceptanceTests -- -retry-tests-on-failure -test-iterations 2
         env:
           TUIST_SHARD_INDEX: ${{ matrix.shard }}
+          TUIST_ACCEPTANCE_SHARD_REFERENCE: github-${{ github.run_id }}-${{ github.sha }}
 
   cli-acceptance-tests-fork:
     name: Acceptance Tests (Fork)

--- a/cli/Sources/TuistAppleArchiver/AppleArchiver.swift
+++ b/cli/Sources/TuistAppleArchiver/AppleArchiver.swift
@@ -104,7 +104,7 @@ public struct AppleArchiver: AppleArchiving {
             // Match exclude patterns against the path within the bundle so a
             // caller-provided pattern can't match the bundle's own basename.
             if let scopedRelativePath, !scopedRelativePath.isEmpty,
-               excludePatterns.contains(where: { scopedRelativePath.contains($0) })
+               excludePatterns.contains(where: { Self.matchesExcludePattern($0, path: scopedRelativePath) })
             {
                 return .skip
             }
@@ -151,6 +151,16 @@ public struct AppleArchiver: AppleArchiving {
         }
 
         try writeArchive(from: FilePath(baseDirectory.pathString), to: archivePath, filter: filter)
+    }
+
+    private static func matchesExcludePattern(_ pattern: String, path: String) -> Bool {
+        guard !pattern.isEmpty else { return false }
+        if path.contains(pattern) { return true }
+        guard pattern.hasSuffix("/") else { return false }
+
+        let directoryPattern = String(pattern.dropLast())
+        guard !directoryPattern.isEmpty else { return false }
+        return path.hasSuffix(directoryPattern)
     }
 
     private func writeArchive(

--- a/cli/Sources/TuistCacheCommand/CacheWarmCommand.swift
+++ b/cli/Sources/TuistCacheCommand/CacheWarmCommand.swift
@@ -56,6 +56,13 @@
         )
         var generateOnly: Bool = false
 
+        @Flag(
+            name: .long,
+            help: "When passed, the generated artifacts are stored only in the local cache and not uploaded to the remote cache.",
+            envKey: .cacheNoUpload
+        )
+        var noUpload: Bool = false
+
         @Option(
             name: .long,
             help: "Cache profile to use for warming. Accepts built-in profiles (\(BaseCacheProfile.allCases.map(\.rawValue).joined(separator: ", "))) or a custom profile name defined in your Tuist configuration. Applies the same profile-based target filtering as `tuist generate`, including base behavior, targetQueries, and exceptTargetQueries.",
@@ -93,6 +100,7 @@
                 targetsToBinaryCache: Set(targets),
                 externalOnly: externalOnly,
                 generateOnly: generateOnly,
+                noUpload: noUpload,
                 cacheProfile: cacheProfile
             )
         }

--- a/cli/Sources/TuistEnvKey/EnvKey.swift
+++ b/cli/Sources/TuistEnvKey/EnvKey.swift
@@ -465,6 +465,7 @@ public enum EnvKey: String, CaseIterable {
     case cacheExternalOnly = "TUIST_CACHE_EXTERNAL_ONLY"
     case cacheProfile = "TUIST_CACHE_PROFILE"
     case cacheGenerateOnly = "TUIST_CACHE_GENERATE_ONLY"
+    case cacheNoUpload = "TUIST_CACHE_NO_UPLOAD"
     case cachePrintHashes = "TUIST_CACHE_PRINT_HASHES"
     case cacheConfiguration = "TUIST_CACHE_CONFIGURATION"
     case cachePath = "TUIST_CACHE_PATH"

--- a/cli/Sources/TuistExtension/Extension.swift
+++ b/cli/Sources/TuistExtension/Extension.swift
@@ -14,6 +14,7 @@ public protocol CacheServicing {
         targetsToBinaryCache: Set<String>,
         externalOnly: Bool,
         generateOnly: Bool,
+        noUpload: Bool,
         cacheProfile: String?
     ) async throws
 }
@@ -34,6 +35,7 @@ public struct EmptyCacheService: CacheServicing {
         targetsToBinaryCache _: Set<String>,
         externalOnly _: Bool,
         generateOnly _: Bool,
+        noUpload _: Bool,
         cacheProfile _: String?
     ) async throws {
         print(

--- a/cli/Sources/TuistKit/Commands/Cache/CacheWarmCommandService.swift
+++ b/cli/Sources/TuistKit/Commands/Cache/CacheWarmCommandService.swift
@@ -47,6 +47,7 @@ import XcodeGraph
         private let fileSystem: FileSysteming
         private let contentHasher: ContentHashing
         private let cacheGraphContentHasher: CacheGraphContentHashing
+        private let cacheStorageFactory: CacheStorageFactorying
 
         public init() {
             let contentHasher = ContentHasher()
@@ -59,7 +60,9 @@ import XcodeGraph
                 xcodeProjectBuildDirectoryLocator: XcodeProjectBuildDirectoryLocator(),
                 fileSystem: FileSystem(),
                 contentHasher: contentHasher,
-                cacheGraphContentHasher: CacheGraphContentHasher(contentHasher: contentHasher)
+                cacheGraphContentHasher: CacheGraphContentHasher(contentHasher: contentHasher),
+                cacheStorageFactory: Extension.cacheStorageFactory,
+                configLoader: ConfigLoader()
             )
         }
 
@@ -72,9 +75,11 @@ import XcodeGraph
             xcodeProjectBuildDirectoryLocator: XcodeProjectBuildDirectoryLocating,
             fileSystem: FileSysteming,
             contentHasher: ContentHashing,
-            cacheGraphContentHasher: CacheGraphContentHashing
+            cacheGraphContentHasher: CacheGraphContentHashing,
+            cacheStorageFactory: CacheStorageFactorying = Extension.cacheStorageFactory,
+            configLoader: ConfigLoading = ConfigLoader()
         ) {
-            configLoader = ConfigLoader()
+            self.configLoader = configLoader
             manifestLoader = ManifestLoader.current
             pluginService = PluginService()
             self.generatorFactory = generatorFactory
@@ -86,6 +91,7 @@ import XcodeGraph
             self.fileSystem = fileSystem
             self.contentHasher = contentHasher
             self.cacheGraphContentHasher = cacheGraphContentHasher
+            self.cacheStorageFactory = cacheStorageFactory
         }
 
         // swiftlint:disable:next function_body_length
@@ -95,11 +101,12 @@ import XcodeGraph
             targetsToBinaryCache: Set<String>,
             externalOnly: Bool,
             generateOnly: Bool,
+            noUpload: Bool,
             cacheProfile: String?
         ) async throws {
             let path = try await Environment.current.pathRelativeToWorkingDirectory(directory)
             let config = try await configLoader.loadConfig(path: path)
-            let cacheStorage = try await CacheStorageFactory().cacheStorage(config: config)
+            let cacheStorage = try await cacheStorageFactory.cacheStorage(config: config)
             let requestedTargetsToBinaryCache = Set(targetsToBinaryCache.map { TargetQuery(stringLiteral: $0) })
             let generator = generatorFactory.binaryCacheWarmingPreload(
                 config: config,
@@ -191,7 +198,8 @@ import XcodeGraph
                 projectPath: projectPath,
                 configuration: configuration,
                 hashesByTargetToBeCached: cacheableTargets,
-                cacheStorage: cacheStorage,
+                cacheStorage: noUpload ? try await cacheStorageFactory.cacheLocalStorage() : cacheStorage,
+                noUpload: noUpload,
                 isReleaseConfiguration: isReleaseConfiguration
             )
 
@@ -227,6 +235,7 @@ import XcodeGraph
             configuration: String,
             hashesByTargetToBeCached: [(GraphTarget, String)],
             cacheStorage: CacheStoring,
+            noUpload _: Bool,
             isReleaseConfiguration: Bool
         ) async throws {
             let binariesSchemes = graph.workspace.schemes

--- a/cli/Tests/TuistAppleArchiverTests/AppleArchiverTests.swift
+++ b/cli/Tests/TuistAppleArchiverTests/AppleArchiverTests.swift
@@ -140,6 +140,56 @@ struct AppleArchiverTests {
             extractDir.appending(components: ["AppTests.xctest", "Contents", "MacOS", "AppTests"])
         )
         #expect(!xctestBinaryExists)
+        let xctestDirectoryExists = try await fileSystem.exists(extractDir.appending(component: "AppTests.xctest"))
+        #expect(!xctestDirectoryExists)
+    }
+
+    @Test(.inTemporaryDirectory) func splitShardArchives_extractTogetherIntoProductsBundle() async throws {
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let fileSystem = FileSystem()
+
+        let productsDir = temporaryDirectory.appending(component: "MyApp.xctestproducts")
+        try await fileSystem.makeDirectory(at: productsDir)
+        try await fileSystem.writeText("run", at: productsDir.appending(component: "MyApp.xctestrun"))
+
+        let buildDir = productsDir.appending(components: "Binaries", "Debug")
+        let appTests = buildDir.appending(component: "AppTests.xctest")
+        try await fileSystem.makeDirectory(at: appTests)
+        try await fileSystem.writeText("app-tests", at: appTests.appending(component: "AppTests"))
+        let coreTests = buildDir.appending(component: "CoreTests.xctest")
+        try await fileSystem.makeDirectory(at: coreTests)
+        try await fileSystem.writeText("core-tests", at: coreTests.appending(component: "CoreTests"))
+        let sharedFramework = buildDir.appending(component: "Shared.framework")
+        try await fileSystem.makeDirectory(at: sharedFramework)
+        try await fileSystem.writeText("shared", at: sharedFramework.appending(component: "Shared"))
+
+        let sharedArchive = temporaryDirectory.appending(component: "shared.aar")
+        try await subject.compress(directory: productsDir, to: sharedArchive, excludePatterns: [".dSYM", ".xctest/"])
+        let appTestsArchive = temporaryDirectory.appending(component: "AppTests.aar")
+        try await subject.compress(subdirectory: appTests, relativeTo: productsDir, to: appTestsArchive)
+        let coreTestsArchive = temporaryDirectory.appending(component: "CoreTests.aar")
+        try await subject.compress(subdirectory: coreTests, relativeTo: productsDir, to: coreTestsArchive)
+
+        let extractDir = temporaryDirectory.appending(component: "extracted")
+        try await fileSystem.makeDirectory(at: extractDir)
+        try await subject.decompress(archive: sharedArchive, to: extractDir)
+        try await subject.decompress(archive: appTestsArchive, to: extractDir)
+        try await subject.decompress(archive: coreTestsArchive, to: extractDir)
+
+        let xctestRunExists = try await fileSystem.exists(extractDir.appending(component: "MyApp.xctestrun"))
+        #expect(xctestRunExists)
+        let sharedFrameworkExists = try await fileSystem.exists(
+            extractDir.appending(components: "Binaries", "Debug", "Shared.framework", "Shared")
+        )
+        #expect(sharedFrameworkExists)
+        let appTestsBinary = try await fileSystem.readTextFile(
+            at: extractDir.appending(components: "Binaries", "Debug", "AppTests.xctest", "AppTests")
+        )
+        #expect(appTestsBinary == "app-tests")
+        let coreTestsBinary = try await fileSystem.readTextFile(
+            at: extractDir.appending(components: "Binaries", "Debug", "CoreTests.xctest", "CoreTests")
+        )
+        #expect(coreTestsBinary == "core-tests")
     }
 
     @Test(.inTemporaryDirectory) func compress_preservesBaseDirectory_wrapsContentsInBundleName() async throws {

--- a/cli/Tests/TuistKitTests/CommandEnvironmentVariables/CommandEnvironmentVariableTests.swift
+++ b/cli/Tests/TuistKitTests/CommandEnvironmentVariables/CommandEnvironmentVariableTests.swift
@@ -923,6 +923,7 @@ struct CommandEnvironmentVariableTests {
         setVariable(.cacheExternalOnly, value: "true")
         setVariable(.cacheProfile, value: "development")
         setVariable(.cacheGenerateOnly, value: "true")
+        setVariable(.cacheNoUpload, value: "true")
         setVariable(.cachePrintHashes, value: "true")
         setVariable(.cacheConfiguration, value: "CacheConfig")
         setVariable(.cachePath, value: "/cache/path")
@@ -932,6 +933,7 @@ struct CommandEnvironmentVariableTests {
         #expect(commandWithEnvVars.externalOnly == true)
         #expect(commandWithEnvVars.cacheProfile == "development")
         #expect(commandWithEnvVars.generateOnly == true)
+        #expect(commandWithEnvVars.noUpload == true)
         #expect(commandWithEnvVars.printHashes == true)
         #expect(commandWithEnvVars.configuration == "CacheConfig")
         #expect(commandWithEnvVars.path == "/cache/path")
@@ -941,6 +943,7 @@ struct CommandEnvironmentVariableTests {
             "--external-only",
             "--cache-profile", "development",
             "--generate-only",
+            "--no-upload",
             "--print-hashes",
             "--configuration", "CacheConfig",
             "--path", "/cache/path",
@@ -950,6 +953,7 @@ struct CommandEnvironmentVariableTests {
         #expect(commandWithArgs.externalOnly == true)
         #expect(commandWithArgs.cacheProfile == "development")
         #expect(commandWithArgs.generateOnly == true)
+        #expect(commandWithArgs.noUpload == true)
         #expect(commandWithArgs.printHashes == true)
         #expect(commandWithArgs.configuration == "CacheConfig")
         #expect(commandWithArgs.path == "/cache/path")

--- a/cli/Tests/TuistKitTests/Services/Cache/CacheWarmCommandServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/Cache/CacheWarmCommandServiceTests.swift
@@ -1,0 +1,162 @@
+#if canImport(TuistCacheEE)
+    import FileSystem
+    import FileSystemTesting
+    import Foundation
+    import Mockable
+    import Path
+    import Testing
+    import TuistAutomation
+    import TuistCache
+    import TuistConfig
+    import TuistConfigLoader
+    import TuistCore
+    import TuistHasher
+    import TuistServer
+    import TuistXcodeBuildProducts
+    import XcodeGraph
+
+    @testable import TuistCacheEE
+    @testable import TuistKit
+    @testable import TuistTesting
+
+    struct CacheWarmCommandServiceTests {
+        private let config = Tuist.test()
+        private let cacheStorage = MockCacheStoring()
+        private let localCacheStorage = MockCacheStoring()
+        private let cacheStorageFactory = MockCacheStorageFactorying()
+        private let generatorFactory = MockCacheGeneratorFactorying()
+        private let preloadGenerator = MockGenerating()
+        private let generator = MockGenerating()
+        private let defaultConfigurationFetcher = MockDefaultConfigurationFetching()
+        private let xcodeBuildController = MockXcodeBuildControlling()
+        private let simulatorController = MockSimulatorControlling()
+        private let xcodeProjectBuildDirectoryLocator = MockXcodeProjectBuildDirectoryLocating()
+        private let contentHasher = MockContentHashing()
+        private let cacheGraphContentHasher = MockCacheGraphContentHashing()
+        private let configLoader = MockConfigLoading()
+        private let fileSystem = FileSystem()
+
+        @Test(.inTemporaryDirectory) func run_usesLocalCacheStorage_whenNoUpload() async throws {
+            try await run(noUpload: true)
+
+            verify(localCacheStorage)
+                .store(.any, cacheCategory: .value(.binaries))
+                .called(1)
+            verify(cacheStorage)
+                .store(.any, cacheCategory: .any)
+                .called(0)
+            verify(cacheStorageFactory)
+                .cacheLocalStorage()
+                .called(1)
+        }
+
+        @Test(.inTemporaryDirectory) func run_usesConfiguredCacheStorage_whenUploading() async throws {
+            try await run(noUpload: false)
+
+            verify(cacheStorage)
+                .store(.any, cacheCategory: .value(.binaries))
+                .called(1)
+            verify(localCacheStorage)
+                .store(.any, cacheCategory: .any)
+                .called(0)
+            verify(cacheStorageFactory)
+                .cacheLocalStorage()
+                .called(0)
+        }
+
+        private func run(noUpload: Bool) async throws {
+            let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+            let target = Target.test(name: "Fixtures", product: .bundle)
+            let project = Project.test(path: temporaryDirectory, targets: [target], schemes: [])
+            let graphTarget = GraphTarget(path: temporaryDirectory, target: target, project: project)
+            let graph = Graph.test(
+                path: temporaryDirectory,
+                projects: [temporaryDirectory: project]
+            )
+
+            given(configLoader)
+                .loadConfig(path: .value(temporaryDirectory))
+                .willReturn(config)
+            given(cacheStorageFactory)
+                .cacheStorage(config: .value(config))
+                .willReturn(cacheStorage)
+            given(cacheStorageFactory)
+                .cacheLocalStorage()
+                .willReturn(localCacheStorage)
+            given(generatorFactory)
+                .binaryCacheWarmingPreload(
+                    config: .value(config),
+                    targetsToBinaryCache: .value([])
+                )
+                .willReturn(preloadGenerator)
+            given(preloadGenerator)
+                .load(path: .value(temporaryDirectory), options: .value(config.project.generatedProject?.generationOptions))
+                .willReturn(graph)
+            given(defaultConfigurationFetcher)
+                .fetch(
+                    configuration: .value(nil),
+                    defaultConfiguration: .value(config.project.generatedProject?.generationOptions.defaultConfiguration),
+                    graph: .value(graph)
+                )
+                .willReturn("Debug")
+            given(cacheGraphContentHasher)
+                .contentHashes(
+                    for: .value(graph),
+                    configuration: .value("Debug"),
+                    defaultConfiguration: .value(config.project.generatedProject?.generationOptions.defaultConfiguration),
+                    excludedTargets: .value([]),
+                    destination: .value(nil)
+                )
+                .willReturn([graphTarget: .test(hash: "fixtures-hash")])
+            given(cacheStorage)
+                .fetch(.any, cacheCategory: .value(.binaries))
+                .willReturn([:])
+            given(generatorFactory)
+                .binaryCacheWarming(
+                    config: .value(config),
+                    targetsToBinaryCache: .any,
+                    configuration: .value("Debug"),
+                    cacheStorage: .any
+                )
+                .willReturn(generator)
+            given(generator)
+                .generateWithGraph(
+                    path: .value(temporaryDirectory),
+                    options: .value(config.project.generatedProject?.generationOptions)
+                )
+                .willReturn((temporaryDirectory, graph, MapperEnvironment()))
+            given(cacheStorage)
+                .store(.any, cacheCategory: .value(.binaries))
+                .willReturn([])
+            given(localCacheStorage)
+                .store(.any, cacheCategory: .value(.binaries))
+                .willReturn([])
+
+            try await subject.run(
+                path: temporaryDirectory.pathString,
+                configuration: nil,
+                targetsToBinaryCache: [],
+                externalOnly: false,
+                generateOnly: false,
+                noUpload: noUpload,
+                cacheProfile: nil
+            )
+        }
+
+        private var subject: CacheWarmCommandService {
+            CacheWarmCommandService(
+                generatorFactory: generatorFactory,
+                cacheWarmGraphLinter: CacheWarmGraphLinter(),
+                defaultConfigurationFetcher: defaultConfigurationFetcher,
+                xcodeBuildController: xcodeBuildController,
+                simulatorController: simulatorController,
+                xcodeProjectBuildDirectoryLocator: xcodeProjectBuildDirectoryLocator,
+                fileSystem: fileSystem,
+                contentHasher: contentHasher,
+                cacheGraphContentHasher: cacheGraphContentHasher,
+                cacheStorageFactory: cacheStorageFactory,
+                configLoader: configLoader
+            )
+        }
+    }
+#endif


### PR DESCRIPTION
## What changed

- Added `tuist cache warm --no-upload` plus the `TUIST_CACHE_NO_UPLOAD` environment variable.
- When `--no-upload` is used, cache warming stores binaries in local cache storage and skips remote upload while keeping the existing user-facing cache-warm section logs.
- Added focused service coverage for the upload and no-upload paths.
- Tightened AppleArchive exclude matching so `.xctest/` excludes the test bundle directory itself without excluding sibling `.xctestrun` files.
- Made the CLI acceptance workflow pass an explicit shard reference derived from the workflow run id and commit SHA, so the build job and shard jobs resolve the same shard plan/artifacts.

## Why

`cache warm` needs a local-only mode for workflows that want the speed-up from warmed binaries without writing artifacts to the remote cache. The option is explicit and opt-in, leaving the existing remote-upload behavior unchanged by default.

While getting CI green, the acceptance shard logs showed `AppleArchive.ArchiveError.ioError` before xcodebuild started executing tests. The build job's printed shard plan did not match what one shard runner fetched later, which meant the runner could resolve a stale or mismatched plan/artifact set when relying only on the default CI-derived reference. Passing an explicit per-workflow/per-commit reference keeps the matrix and downloaded artifacts bound to the same plan.

## Approach

- Threaded `noUpload` from the cache command and env var into `CacheWarmCommandService`.
- Injected config loading in the cache warm service tests so EE-gated storage selection can be asserted directly.
- Preserved the original high-level cache warm log message and only added a clear skip-upload note when the flag is present.
- Kept forbidden remote-cache writes as errors; this PR does not relegate them to warnings.
- Updated AppleArchive path matching for directory-style exclude patterns and covered split shard archive extraction.
- Added an explicit `--shard-reference` to both acceptance build and shard execution jobs.

## Validation

- `TUIST_EE=1 tuist generate tuist TuistAppleArchiver TuistAppleArchiverTests TuistKit TuistKitTests ProjectDescription --no-open`
- `xcodebuild test -workspace Tuist.xcworkspace -scheme Tuist-Workspace -only-testing TuistAppleArchiverTests/AppleArchiverTests -only-testing TuistKitTests/ShardPlanServiceTests -only-testing TuistKitTests/ShardServiceTests -only-testing TuistKitTests/CacheWarmCommandServiceTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" COMPILATION_CACHE_ENABLE_CACHING=NO`
- `mise run cli:lint --fix`
- `.github/workflows/cli.yml` parsed with Ruby YAML.
