### PR TITLE
chore: bump tuist CLI pin to 4.203.0-canary.14

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,7 +1,7 @@
 [tools]
     aube = "1.6.2"
     # Auto-bumped to the latest Tuist CLI release (incl. canary) by the update-tuist-cli workflow.
-    tuist = "4.202.0-canary.32"
+    tuist = "4.203.0-canary.14"
     swiftlint = "0.59.1"
     "elixir" = "1.19.5"
     "erlang" = "28.4.3"


### PR DESCRIPTION
Bumps the repo's tuist pin to `4.203.0-canary.14`, the first release with the complete Kura Xcode-CAS fix chain (#11709, #11710) shipped and CI-validated (#11711). The `update-tuist-cli` workflow would eventually auto-bump this; this does it now. No functional code change.