### PR TITLE
fix(server): support member management account tokens

### DIFF
--- a/server/lib/tuist/authentication.ex
+++ b/server/lib/tuist/authentication.ex
@@ -48,7 +48,7 @@ defmodule Tuist.Authentication do
     project_token = Projects.get_project_by_full_token(token)
 
     if is_nil(project_token) do
-      case Accounts.account_token(token, preload: [:account, created_by_account: :user]) do
+      case Accounts.account_token(token, preload: [:account, :account_token_projects]) do
         {:ok, account_token} ->
           %AuthenticatedAccount{
             account: account_token.account,
@@ -56,8 +56,7 @@ defmodule Tuist.Authentication do
             all_projects: account_token.all_projects,
             project_ids: Enum.map(account_token.account_token_projects, & &1.project_id),
             token_id: account_token.id,
-            created_by_account_id: account_token.created_by_account_id,
-            issued_by: issued_by_user(account_token)
+            created_by_account_id: account_token.created_by_account_id
           }
 
         _ ->
@@ -67,9 +66,6 @@ defmodule Tuist.Authentication do
       project_token
     end
   end
-
-  defp issued_by_user(%{created_by_account: %{user: %User{} = user}}), do: user
-  defp issued_by_user(_account_token), do: nil
 
   @doc """
     Refreshes a given token, updating the account handle in the `preferred_username` claim.

--- a/server/lib/tuist/authentication.ex
+++ b/server/lib/tuist/authentication.ex
@@ -48,7 +48,7 @@ defmodule Tuist.Authentication do
     project_token = Projects.get_project_by_full_token(token)
 
     if is_nil(project_token) do
-      case Accounts.account_token(token, preload: [:account, :account_token_projects]) do
+      case Accounts.account_token(token, preload: [:account, created_by_account: :user]) do
         {:ok, account_token} ->
           %AuthenticatedAccount{
             account: account_token.account,
@@ -56,7 +56,8 @@ defmodule Tuist.Authentication do
             all_projects: account_token.all_projects,
             project_ids: Enum.map(account_token.account_token_projects, & &1.project_id),
             token_id: account_token.id,
-            created_by_account_id: account_token.created_by_account_id
+            created_by_account_id: account_token.created_by_account_id,
+            issued_by: issued_by_user(account_token)
           }
 
         _ ->
@@ -66,6 +67,9 @@ defmodule Tuist.Authentication do
       project_token
     end
   end
+
+  defp issued_by_user(%{created_by_account: %{user: %User{} = user}}), do: user
+  defp issued_by_user(_account_token), do: nil
 
   @doc """
     Refreshes a given token, updating the account handle in the `preferred_username` claim.

--- a/server/lib/tuist/authorization.ex
+++ b/server/lib/tuist/authorization.ex
@@ -354,6 +354,13 @@ defmodule Tuist.Authorization do
 
       desc("Allows users with ops access to read any organization info.")
       allow([:authenticated_as_user, :ops_access])
+
+      desc(
+        "Allows an account token with account:members:read or account:members:write scope to read organization members."
+      )
+
+      allow([:authenticated_as_account, :accounts_match, scopes_permit: "account:members:read"])
+      allow([:authenticated_as_account, :accounts_match, scopes_permit: "account:members:write"])
     end
 
     action :update do
@@ -371,6 +378,9 @@ defmodule Tuist.Authorization do
     action :create do
       desc("Allows the admin of an account to create invitations.")
       allow([:authenticated_as_user, user_role: :admin])
+
+      desc("Allows an account token with account:members:write scope to create invitations.")
+      allow([:authenticated_as_account, :accounts_match, scopes_permit: "account:members:write"])
     end
 
     action :read do
@@ -379,11 +389,18 @@ defmodule Tuist.Authorization do
 
       desc("Allows users with ops access to read any invitations.")
       allow([:authenticated_as_user, :ops_access])
+
+      desc("Allows an account token with account:members:read or account:members:write scope to read invitations.")
+      allow([:authenticated_as_account, :accounts_match, scopes_permit: "account:members:read"])
+      allow([:authenticated_as_account, :accounts_match, scopes_permit: "account:members:write"])
     end
 
     action :delete do
       desc("Allows the admin of an account to delete invitations.")
       allow([:authenticated_as_user, user_role: :admin])
+
+      desc("Allows an account token with account:members:write scope to delete invitations.")
+      allow([:authenticated_as_account, :accounts_match, scopes_permit: "account:members:write"])
     end
   end
 
@@ -391,11 +408,17 @@ defmodule Tuist.Authorization do
     action :update do
       desc("Allows the admin of an account to update members.")
       allow([:authenticated_as_user, user_role: :admin])
+
+      desc("Allows an account token with account:members:write scope to update members.")
+      allow([:authenticated_as_account, :accounts_match, scopes_permit: "account:members:write"])
     end
 
     action :delete do
       desc("Allows the admin of an account to delete members.")
       allow([:authenticated_as_user, user_role: :admin])
+
+      desc("Allows an account token with account:members:write scope to delete members.")
+      allow([:authenticated_as_account, :accounts_match, scopes_permit: "account:members:write"])
     end
   end
 

--- a/server/lib/tuist_web/controllers/api/invitations_controller.ex
+++ b/server/lib/tuist_web/controllers/api/invitations_controller.ex
@@ -208,5 +208,14 @@ defmodule TuistWeb.API.InvitationsController do
 
   defp inviter_from_subject(%User{} = user), do: user
   defp inviter_from_subject(%AuthenticatedAccount{issued_by: %User{} = user}), do: user
+  defp inviter_from_subject(%AuthenticatedAccount{created_by_account_id: nil}), do: nil
+
+  defp inviter_from_subject(%AuthenticatedAccount{created_by_account_id: created_by_account_id}) do
+    case Accounts.get_account_by_id(created_by_account_id) do
+      {:ok, %{user_id: user_id}} when not is_nil(user_id) -> Accounts.get_user_by_id(user_id)
+      _ -> nil
+    end
+  end
+
   defp inviter_from_subject(_subject), do: nil
 end

--- a/server/lib/tuist_web/controllers/api/invitations_controller.ex
+++ b/server/lib/tuist_web/controllers/api/invitations_controller.ex
@@ -4,6 +4,8 @@ defmodule TuistWeb.API.InvitationsController do
 
   alias OpenApiSpex.Schema
   alias Tuist.Accounts
+  alias Tuist.Accounts.AuthenticatedAccount
+  alias Tuist.Accounts.User
   alias Tuist.Authorization
   alias TuistWeb.API.Schemas.Error
   alias TuistWeb.API.Schemas.Invitation
@@ -54,12 +56,11 @@ defmodule TuistWeb.API.InvitationsController do
         %{path_params: %{"organization_name" => organization_name}, body_params: %{invitee_email: invitee_email}} = conn,
         _params
       ) do
-    user = Authentication.current_user(conn)
-    user_account = Accounts.get_account_from_user(user)
+    subject = Authentication.authenticated_subject(conn)
 
     organization = Accounts.get_organization_by_handle(organization_name)
 
-    invitee_email_valid? = Tuist.Accounts.User.email_valid?(invitee_email)
+    invitee_email_valid? = User.email_valid?(invitee_email)
 
     invitee =
       case Accounts.get_user_by_email(invitee_email) do
@@ -73,7 +74,12 @@ defmodule TuistWeb.API.InvitationsController do
         |> put_status(:not_found)
         |> json(%{message: "Organization #{organization_name} was not found."})
 
-      Authorization.authorize(:invitation_create, user, organization.account) != :ok ->
+      Authorization.authorize(:invitation_create, subject, organization.account) != :ok ->
+        conn
+        |> put_status(:forbidden)
+        |> json(%{message: "The authenticated subject is not authorized to perform this action"})
+
+      is_nil(inviter_from_subject(subject)) ->
         conn
         |> put_status(:forbidden)
         |> json(%{message: "The authenticated subject is not authorized to perform this action"})
@@ -101,9 +107,12 @@ defmodule TuistWeb.API.InvitationsController do
         |> json(%{message: "The invitee email address is not a valid email address."})
 
       !is_nil(organization) ->
+        inviter = inviter_from_subject(subject)
+        inviter_account = Accounts.get_account_from_user(inviter)
+
         {:ok, invitation} =
           Accounts.invite_user_to_organization(invitee_email, %{
-            inviter: user,
+            inviter: inviter,
             to: organization,
             url: &url(~p"/auth/invitations/#{&1}")
           })
@@ -114,9 +123,9 @@ defmodule TuistWeb.API.InvitationsController do
           id: invitation.id,
           invitee_email: invitation.invitee_email,
           inviter: %{
-            id: user.id,
-            email: user.email,
-            name: user_account.name
+            id: inviter.id,
+            email: inviter.email,
+            name: inviter_account.name
           },
           token: invitation.token,
           organization_id: invitation.organization_id
@@ -161,7 +170,7 @@ defmodule TuistWeb.API.InvitationsController do
         %{path_params: %{"organization_name" => organization_name}, body_params: %{invitee_email: invitee_email}} = conn,
         _params
       ) do
-    user = Authentication.current_user(conn)
+    subject = Authentication.authenticated_subject(conn)
 
     organization = Accounts.get_organization_by_handle(organization_name)
 
@@ -183,7 +192,7 @@ defmodule TuistWeb.API.InvitationsController do
           message: "The invitation with the given invitee email and organization name was not found"
         })
 
-      Authorization.authorize(:invitation_delete, user, organization.account) != :ok ->
+      Authorization.authorize(:invitation_delete, subject, organization.account) != :ok ->
         conn
         |> put_status(:forbidden)
         |> json(%{message: "The authenticated subject is not authorized to perform this action"})
@@ -196,4 +205,8 @@ defmodule TuistWeb.API.InvitationsController do
         |> json(%{})
     end
   end
+
+  defp inviter_from_subject(%User{} = user), do: user
+  defp inviter_from_subject(%AuthenticatedAccount{issued_by: %User{} = user}), do: user
+  defp inviter_from_subject(_subject), do: nil
 end

--- a/server/lib/tuist_web/controllers/api/organizations_controller.ex
+++ b/server/lib/tuist_web/controllers/api/organizations_controller.ex
@@ -232,7 +232,7 @@ defmodule TuistWeb.API.OrganizationsController do
     organization =
       Accounts.get_organization_by_handle(organization_name)
 
-    user = Authentication.current_user(conn)
+    subject = Authentication.authenticated_subject(conn)
 
     cond do
       is_nil(organization) ->
@@ -240,7 +240,7 @@ defmodule TuistWeb.API.OrganizationsController do
         |> put_status(:not_found)
         |> json(%{message: "Organization not found"})
 
-      Authorization.authorize(:organization_read, user, organization.account) != :ok ->
+      Authorization.authorize(:organization_read, subject, organization.account) != :ok ->
         conn
         |> put_status(:forbidden)
         |> json(%{message: "The authenticated subject is not authorized to perform this action"})
@@ -519,7 +519,7 @@ defmodule TuistWeb.API.OrganizationsController do
 
   def remove_member(%{path_params: %{"organization_name" => organization_name, "user_name" => user_name}} = conn, _params) do
     organization = Accounts.get_organization_by_handle(organization_name)
-    user = Authentication.current_user(conn)
+    subject = Authentication.authenticated_subject(conn)
     member_account = Accounts.get_account_by_handle(user_name)
 
     cond do
@@ -533,7 +533,7 @@ defmodule TuistWeb.API.OrganizationsController do
         |> put_status(:not_found)
         |> json(%{message: "User #{user_name} not found."})
 
-      Authorization.authorize(:member_delete, user, organization.account) != :ok ->
+      Authorization.authorize(:member_delete, subject, organization.account) != :ok ->
         conn
         |> put_status(:forbidden)
         |> json(%{message: "The authenticated subject is not authorized to perform this action"})
@@ -603,7 +603,7 @@ defmodule TuistWeb.API.OrganizationsController do
         _params
       ) do
     organization = Accounts.get_organization_by_handle(organization_name)
-    user = Authentication.current_user(conn)
+    subject = Authentication.authenticated_subject(conn)
     member_account = Accounts.get_account_by_handle(user_name)
 
     cond do
@@ -617,7 +617,7 @@ defmodule TuistWeb.API.OrganizationsController do
         |> put_status(:not_found)
         |> json(%{message: "User #{user_name} not found."})
 
-      Authorization.authorize(:member_update, user, organization.account) != :ok ->
+      Authorization.authorize(:member_update, subject, organization.account) != :ok ->
         conn
         |> put_status(:forbidden)
         |> json(%{message: "The authenticated subject is not authorized to perform this action"})

--- a/server/test/tuist/authentication_test.exs
+++ b/server/test/tuist/authentication_test.exs
@@ -7,6 +7,7 @@ defmodule Tuist.AuthenticationTest do
   alias Tuist.Accounts.AuthenticatedAccount
   alias Tuist.Accounts.User
   alias Tuist.Authentication
+  alias Tuist.Authorization.Checks
   alias Tuist.Projects
   alias Tuist.Repo
   alias TuistTestSupport.Fixtures.AccountsFixtures
@@ -75,24 +76,31 @@ defmodule Tuist.AuthenticationTest do
     assert result.project_ids == []
   end
 
-  test "authenticated_subject includes the account token creator as issued_by" do
+  test "authenticated_subject does not use stored account token creator as issued_by" do
     # Given
     account = AccountsFixtures.organization_fixture(preload: [:account]).account
     creator = AccountsFixtures.user_fixture(preload: [:account])
+    target_organization = AccountsFixtures.organization_fixture(preload: [:account])
+    Accounts.add_user_to_organization(creator, target_organization, role: :admin)
+    target_project = ProjectsFixtures.project_fixture(account_id: target_organization.account.id)
 
     {:ok, {_, token_value}} =
       Accounts.create_account_token(%{
         account: account,
         created_by_account: creator.account,
-        scopes: ["account:members:write"],
-        name: "test-token"
+        scopes: ["project:cache:read"],
+        name: "test-token",
+        all_projects: true
       })
 
     # When
     result = Authentication.authenticated_subject(token_value)
 
     # Then
-    assert result.issued_by.id == creator.id
+    assert result.created_by_account_id == creator.account.id
+    assert result.issued_by == nil
+
+    assert Checks.scopes_permit(result, target_project, "project:cache:read") == false
   end
 
   test "authenticated_subject returns nil for account tokens owned by inactive personal users" do

--- a/server/test/tuist/authentication_test.exs
+++ b/server/test/tuist/authentication_test.exs
@@ -75,6 +75,26 @@ defmodule Tuist.AuthenticationTest do
     assert result.project_ids == []
   end
 
+  test "authenticated_subject includes the account token creator as issued_by" do
+    # Given
+    account = AccountsFixtures.organization_fixture(preload: [:account]).account
+    creator = AccountsFixtures.user_fixture(preload: [:account])
+
+    {:ok, {_, token_value}} =
+      Accounts.create_account_token(%{
+        account: account,
+        created_by_account: creator.account,
+        scopes: ["account:members:write"],
+        name: "test-token"
+      })
+
+    # When
+    result = Authentication.authenticated_subject(token_value)
+
+    # Then
+    assert result.issued_by.id == creator.id
+  end
+
   test "authenticated_subject returns nil for account tokens owned by inactive personal users" do
     # Given
     user = AccountsFixtures.user_fixture(preload: [:account])

--- a/server/test/tuist/authorization_test.exs
+++ b/server/test/tuist/authorization_test.exs
@@ -3,6 +3,7 @@ defmodule Tuist.AuthorizationTest do
   use Mimic
 
   alias Tuist.Accounts
+  alias Tuist.Accounts.AuthenticatedAccount
   alias Tuist.Authorization
   alias Tuist.Environment
   alias TuistTestSupport.Fixtures.AccountsFixtures
@@ -755,6 +756,28 @@ defmodule Tuist.AuthorizationTest do
              {:error, :forbidden}
   end
 
+  test "can.read.account.organization when the subject is a matching account token with members read scope" do
+    # Given
+    organization = AccountsFixtures.organization_fixture()
+    account = Accounts.get_account_from_organization(organization)
+    subject = %AuthenticatedAccount{account: account, scopes: ["account:members:read"]}
+
+    # When
+    assert Authorization.authorize(:organization_read, subject, account) == :ok
+  end
+
+  test "cannot.read.account.organization when the subject is an account token for another account" do
+    # Given
+    organization = AccountsFixtures.organization_fixture()
+    account = Accounts.get_account_from_organization(organization)
+    other_account = AccountsFixtures.organization_fixture(preload: [:account]).account
+    subject = %AuthenticatedAccount{account: other_account, scopes: ["account:members:read"]}
+
+    # When
+    assert Authorization.authorize(:organization_read, subject, account) ==
+             {:error, :forbidden}
+  end
+
   test "can.read.account.oragnization_usage when the subject is a user that is admin of an organization" do
     # Given
     organization = AccountsFixtures.organization_fixture()
@@ -890,6 +913,27 @@ defmodule Tuist.AuthorizationTest do
              {:error, :forbidden}
   end
 
+  test "can.create.account.invitation when the subject is a matching account token with members write scope" do
+    # Given
+    organization = AccountsFixtures.organization_fixture()
+    account = Accounts.get_account_from_organization(organization)
+    subject = %AuthenticatedAccount{account: account, scopes: ["account:members:write"]}
+
+    # When
+    assert Authorization.authorize(:invitation_create, subject, account) == :ok
+  end
+
+  test "cannot.create.account.invitation when the subject is a matching account token with members read scope" do
+    # Given
+    organization = AccountsFixtures.organization_fixture()
+    account = Accounts.get_account_from_organization(organization)
+    subject = %AuthenticatedAccount{account: account, scopes: ["account:members:read"]}
+
+    # When
+    assert Authorization.authorize(:invitation_create, subject, account) ==
+             {:error, :forbidden}
+  end
+
   test "can.delete.account.invitation when the subject is a user that is admin of an organization" do
     # Given
     organization = AccountsFixtures.organization_fixture()
@@ -924,6 +968,16 @@ defmodule Tuist.AuthorizationTest do
              {:error, :forbidden}
   end
 
+  test "can.delete.account.invitation when the subject is a matching account token with members write scope" do
+    # Given
+    organization = AccountsFixtures.organization_fixture()
+    account = Accounts.get_account_from_organization(organization)
+    subject = %AuthenticatedAccount{account: account, scopes: ["account:members:write"]}
+
+    # When
+    assert Authorization.authorize(:invitation_delete, subject, account) == :ok
+  end
+
   test "can.delete.account.member when the subject is a user that is admin of an organization" do
     # Given
     organization = AccountsFixtures.organization_fixture()
@@ -956,6 +1010,16 @@ defmodule Tuist.AuthorizationTest do
     assert Authorization.authorize(:member_delete, user, account) == {:error, :forbidden}
   end
 
+  test "can.delete.account.member when the subject is a matching account token with members write scope" do
+    # Given
+    organization = AccountsFixtures.organization_fixture()
+    account = Accounts.get_account_from_organization(organization)
+    subject = %AuthenticatedAccount{account: account, scopes: ["account:members:write"]}
+
+    # When
+    assert Authorization.authorize(:member_delete, subject, account) == :ok
+  end
+
   test "can.update.account.member when the subject is a user that is admin of an organization" do
     # Given
     organization = AccountsFixtures.organization_fixture()
@@ -986,6 +1050,16 @@ defmodule Tuist.AuthorizationTest do
 
     # When
     assert Authorization.authorize(:member_update, user, account) == {:error, :forbidden}
+  end
+
+  test "can.update.account.member when the subject is a matching account token with members write scope" do
+    # Given
+    organization = AccountsFixtures.organization_fixture()
+    account = Accounts.get_account_from_organization(organization)
+    subject = %AuthenticatedAccount{account: account, scopes: ["account:members:write"]}
+
+    # When
+    assert Authorization.authorize(:member_update, subject, account) == :ok
   end
 
   test "can.create.account.token when the subject is the same account being read" do

--- a/server/test/tuist_web/controllers/api/invitations_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/invitations_controller_test.exs
@@ -37,6 +37,30 @@ defmodule TuistWeb.API.InvitationsControllerTest do
       assert response == %{}
     end
 
+    test "deletes an invitation with an account token with members write scope", %{conn: conn, user: user} do
+      # Given
+      organization = AccountsFixtures.organization_fixture(name: "tuist-org", creator: user)
+
+      Accounts.invite_user_to_organization("new@tuist.io", %{
+        inviter: user,
+        to: organization,
+        url: &url(~p"/auth/invitations/#{&1}")
+      })
+
+      token = account_token_value(organization.account, user.account, ["account:members:write"])
+
+      # When
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{token}")
+        |> put_req_header("content-type", "application/json")
+        |> delete(~p"/api/organizations/tuist-org/invitations", invitee_email: "new@tuist.io")
+
+      # Then
+      response = json_response(conn, :no_content)
+      assert response == %{}
+    end
+
     test "returns :not_found when an organization that should be invited is not found", %{
       conn: conn,
       user: user
@@ -140,6 +164,51 @@ defmodule TuistWeb.API.InvitationsControllerTest do
              }
 
       assert response["organization_id"] == organization.id
+    end
+
+    test "invites user to an organization with an account token with members write scope", %{conn: conn, user: user} do
+      # Given
+      organization = AccountsFixtures.organization_fixture(name: "tuist-org", creator: user)
+      token = account_token_value(organization.account, user.account, ["account:members:write"])
+
+      # When
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{token}")
+        |> put_req_header("content-type", "application/json")
+        |> post(~p"/api/organizations/tuist-org/invitations", invitee_email: "new@tuist.io")
+
+      # Then
+      response = json_response(conn, :ok)
+
+      assert response["invitee_email"] == "new@tuist.io"
+
+      assert response["inviter"] == %{
+               "id" => user.id,
+               "email" => user.email,
+               "name" => user.account.name
+             }
+
+      assert response["organization_id"] == organization.id
+    end
+
+    test "returns :forbidden when an account token only has members read scope", %{conn: conn, user: user} do
+      # Given
+      organization = AccountsFixtures.organization_fixture(name: "tuist-org", creator: user)
+      token = account_token_value(organization.account, user.account, ["account:members:read"])
+
+      # When
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{token}")
+        |> put_req_header("content-type", "application/json")
+        |> post(~p"/api/organizations/tuist-org/invitations", invitee_email: "new@tuist.io")
+
+      # Then
+      response = json_response(conn, :forbidden)
+
+      assert response["message"] ==
+               "The authenticated subject is not authorized to perform this action"
     end
 
     test "returns an error if the invitee email is not a valid email address", %{
@@ -259,5 +328,17 @@ defmodule TuistWeb.API.InvitationsControllerTest do
     # Given
     response = json_response(conn, :not_found)
     assert response["message"] == "Organization non-existent-tuist-org was not found."
+  end
+
+  defp account_token_value(account, created_by_account, scopes) do
+    {:ok, {_, token}} =
+      Accounts.create_account_token(%{
+        account: account,
+        created_by_account: created_by_account,
+        scopes: scopes,
+        name: "token-#{TuistTestSupport.Utilities.unique_integer()}"
+      })
+
+    token
   end
 end

--- a/server/test/tuist_web/controllers/api/organizations_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/organizations_controller_test.exs
@@ -154,6 +154,53 @@ defmodule TuistWeb.API.OrganizationsControllerTest do
       assert response["plan"] == "pro"
     end
 
+    test "returns an organization with an account token with members read scope", %{conn: conn, user: user} do
+      # Given
+      organization = AccountsFixtures.organization_fixture(name: "tuist-org", creator: user)
+      member = AccountsFixtures.user_fixture(email: "tuist-member@tuist.io")
+      Accounts.add_user_to_organization(member, organization)
+
+      Accounts.invite_user_to_organization("tuist-inviter@tuist.io", %{
+        inviter: user,
+        to: organization,
+        url: fn token -> token end
+      })
+
+      token = account_token_value(organization.account, user.account, ["account:members:read"])
+
+      # When
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{token}")
+        |> get(~p"/api/organizations/tuist-org")
+
+      # Then
+      response = json_response(conn, :ok)
+
+      assert response["name"] == "tuist-org"
+      assert Enum.any?(response["members"], &(&1["name"] == "tuist-member"))
+      assert Enum.any?(response["invitations"], &(&1["invitee_email"] == "tuist-inviter@tuist.io"))
+    end
+
+    test "returns :forbidden when an account token belongs to another organization", %{conn: conn, user: user} do
+      # Given
+      organization = AccountsFixtures.organization_fixture(name: "tuist-org", creator: user)
+      other_organization = AccountsFixtures.organization_fixture()
+      token = account_token_value(other_organization.account, user.account, ["account:members:read"])
+
+      # When
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{token}")
+        |> get(~p"/api/organizations/#{organization.account.name}")
+
+      # Then
+      response = json_response(conn, :forbidden)
+
+      assert response["message"] ==
+               "The authenticated subject is not authorized to perform this action"
+    end
+
     test "returns :not_found when organization does not exist", %{conn: conn, user: user} do
       # Given
       conn = Authentication.put_current_user(conn, user)
@@ -560,6 +607,24 @@ defmodule TuistWeb.API.OrganizationsControllerTest do
       assert response == %{}
     end
 
+    test "removes a member with an account token with members write scope", %{conn: conn, user: user} do
+      # Given
+      organization = AccountsFixtures.organization_fixture(name: "tuist-org", creator: user)
+      member = AccountsFixtures.user_fixture(email: "tuist-member@tuist.io")
+      Accounts.add_user_to_organization(member, organization)
+      token = account_token_value(organization.account, user.account, ["account:members:write"])
+
+      # When
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{token}")
+        |> delete(~p"/api/organizations/tuist-org/members/tuist-member")
+
+      # Then
+      response = json_response(conn, :no_content)
+      assert response == %{}
+    end
+
     test "removes a member with a google hosted domain", %{conn: conn, user: user} do
       # Given
       conn = Authentication.put_current_user(conn, user)
@@ -646,6 +711,27 @@ defmodule TuistWeb.API.OrganizationsControllerTest do
       # When
       conn =
         conn
+        |> put_req_header("content-type", "application/json")
+        |> put(~p"/api/organizations/tuist-org/members/tuist-member", role: "admin")
+
+      # Then
+      response = json_response(conn, :ok)
+      assert response["name"] == "tuist-member"
+      assert response["role"] == "admin"
+      assert Accounts.organization_admin?(member, organization)
+    end
+
+    test "updates a member with an account token with members write scope", %{conn: conn, user: user} do
+      # Given
+      organization = AccountsFixtures.organization_fixture(name: "tuist-org", creator: user)
+      member = AccountsFixtures.user_fixture(email: "tuist-member@tuist.io")
+      Accounts.add_user_to_organization(member, organization)
+      token = account_token_value(organization.account, user.account, ["account:members:write"])
+
+      # When
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{token}")
         |> put_req_header("content-type", "application/json")
         |> put(~p"/api/organizations/tuist-org/members/tuist-member", role: "admin")
 
@@ -749,6 +835,18 @@ defmodule TuistWeb.API.OrganizationsControllerTest do
 
   defp unique_sso_domain(prefix \\ "tuist") do
     "#{prefix}-#{TuistTestSupport.Utilities.unique_integer(6)}.io"
+  end
+
+  defp account_token_value(account, created_by_account, scopes) do
+    {:ok, {_, token}} =
+      Accounts.create_account_token(%{
+        account: account,
+        created_by_account: created_by_account,
+        scopes: scopes,
+        name: "token-#{TuistTestSupport.Utilities.unique_integer()}"
+      })
+
+    token
   end
 
   defp google_oauth_identity(domain, local \\ "tuist") do


### PR DESCRIPTION
## What changed

This change wires the existing `account:members:read` and `account:members:write` scopes into organization membership authorization.

- `account:members:read` and `account:members:write` can now read organization membership and invitation data for the token's own account.
- `account:members:write` can now create/cancel invitations and update/remove organization members for the token's own account.
- Organization and invitation API controllers now authorize with the full authenticated subject instead of only `current_user`, so account-token requests are evaluated by the policy layer.
- Account-token authentication now carries the token creator as `issued_by`, letting invitation creation keep the existing invariant that invitations are attributed to a real user inviter.

## Why it changed

Headless automation needs to manage organization access without a browser-backed user session. The scopes for member management already existed on account tokens, but the relevant policies did not consume them and some controllers only passed `current_user` into authorization. That made scoped account tokens behave as unauthenticated/unauthorized for membership endpoints.

## Root cause

The buggy behavior was that account tokens minted with `account:members:read` or `account:members:write` still received `403` from endpoints such as `GET /api/organizations/:organization_name` and `POST /api/organizations/:organization_name/invitations`. The policy rules for organization, invitation, and member actions only allowed user-session admins, while token-authenticated requests were stored as `current_subject` rather than `current_user`.

## Approach

The fix keeps the existing user-admin checks intact and adds account-token checks that require both the right member-management scope and an account match. Write actions require `account:members:write`; read actions accept either `account:members:read` or `account:members:write`. Invitation creation still requires a real user attribution by resolving the user behind the token creator.

## Impact

Self-hosted and server-side integrations can now drive the same organization invite, cancel-invite, member lookup, role update, and removal flows with scoped account tokens. Tokens remain bounded to their owning account and read-only member tokens cannot perform write actions.

## Validation

Ran:

```sh
mix format lib/tuist/authentication.ex lib/tuist/authorization.ex lib/tuist_web/controllers/api/invitations_controller.ex lib/tuist_web/controllers/api/organizations_controller.ex test/tuist/authentication_test.exs test/tuist/authorization_test.exs test/tuist_web/controllers/api/invitations_controller_test.exs test/tuist_web/controllers/api/organizations_controller_test.exs
mix test test/tuist/authentication_test.exs test/tuist/authorization_test.exs test/tuist_web/controllers/api/invitations_controller_test.exs test/tuist_web/controllers/api/organizations_controller_test.exs
git diff --check
```

The focused test run completed with `196 tests, 0 failures`.