### PR TITLE
fix(cli): avoid result bundle collisions across test schemes

### DIFF
--- a/cli/Sources/TuistKit/Services/TestService.swift
+++ b/cli/Sources/TuistKit/Services/TestService.swift
@@ -1169,30 +1169,43 @@ public struct TestService { // swiftlint:disable:this type_body_length
             uploadCacheStorage = cacheStorage
         }
 
-        do {
-            var didRunTests = false
-            for testScheme in schemes {
-                let testSchemeTargetNames = Set(
-                    testActionTargetReferences(
-                        scheme: testScheme,
-                        testPlanConfiguration: testPlanConfiguration,
-                        action: action
-                    )
-                    .map(\.name)
+        let testSchemeRuns = schemes.compactMap { testScheme -> (scheme: Scheme, testTargets: [TestIdentifier])? in
+            let testSchemeTargetNames = Set(
+                testActionTargetReferences(
+                    scheme: testScheme,
+                    testPlanConfiguration: testPlanConfiguration,
+                    action: action
                 )
-                if testSchemeTargetNames.isEmpty {
-                    continue
-                }
+                .map(\.name)
+            )
+            if testSchemeTargetNames.isEmpty {
+                return nil
+            }
 
-                let testSchemeTestTargets = testTargets.filter {
-                    testSchemeTargetNames.contains($0.target)
-                }
+            let testSchemeTestTargets = testTargets.filter {
+                testSchemeTargetNames.contains($0.target)
+            }
 
-                if !testTargets.isEmpty, testSchemeTestTargets.isEmpty {
-                    continue
-                }
+            if !testTargets.isEmpty, testSchemeTestTargets.isEmpty {
+                return nil
+            }
 
-                didRunTests = true
+            return (scheme: testScheme, testTargets: testSchemeTestTargets)
+        }
+
+        guard !testSchemeRuns.isEmpty else {
+            return false
+        }
+
+        for testSchemeRun in testSchemeRuns {
+            let testScheme = testSchemeRun.scheme
+            let testSchemeResultBundlePath = schemeResultBundlePath(
+                resultBundlePath,
+                schemeName: testScheme.name,
+                runningMultipleSchemes: testSchemeRuns.count > 1
+            )
+
+            do {
                 try await self.testScheme(
                     scheme: testScheme,
                     graphTraverser: graphTraverser,
@@ -1203,10 +1216,10 @@ public struct TestService { // swiftlint:disable:this type_body_length
                     platform: platform,
                     action: action,
                     rosetta: rosetta,
-                    resultBundlePath: resultBundlePath,
+                    resultBundlePath: testSchemeResultBundlePath,
                     derivedDataPath: derivedDataPath,
                     retryCount: retryCount,
-                    testTargets: testSchemeTestTargets,
+                    testTargets: testSchemeRun.testTargets,
                     skipTestTargets: skipTestTargets,
                     testPlanConfiguration: testPlanConfiguration,
                     passthroughXcodeBuildArguments: passthroughXcodeBuildArguments,
@@ -1214,49 +1227,33 @@ public struct TestService { // swiftlint:disable:this type_body_length
                     quarantinedTests: quarantinedTests,
                     mode: mode
                 )
-            }
-            guard didRunTests else {
-                return false
-            }
-        } catch {
-            guard action != .build, let resultBundlePath else { throw error }
-
-            guard try await fileSystem.exists(resultBundlePath) else { throw error }
-
-            let testStatuses = try await xcResultService.parseTestStatuses(path: resultBundlePath)
-            guard !testStatuses.testCases.isEmpty else { throw error }
-
-            let testTargets = testActionTargets(
-                for: schemes, testPlanConfiguration: testPlanConfiguration, graph: graph, action: action
-            )
-
-            let passingTestTargets = testTargets.filter {
-                testStatuses.passingModuleNames().contains($0.target.name)
+            } catch {
+                if try await handleTestSchemeFailure(
+                    error,
+                    scheme: testScheme,
+                    resultBundlePath: testSchemeResultBundlePath,
+                    graph: graph,
+                    mapperEnvironment: mapperEnvironment,
+                    cacheStorage: uploadCacheStorage,
+                    testPlanConfiguration: testPlanConfiguration,
+                    action: action,
+                    quarantinedTests: quarantinedTests
+                ) {
+                    continue
+                }
+                throw error
             }
 
-            try await storeSuccessfulTestHashes(
-                for: passingTestTargets,
-                graph: graph,
-                mapperEnvironment: mapperEnvironment,
-                cacheStorage: uploadCacheStorage
-            )
-
-            if testQuarantineService.onlyQuarantinedTestsFailed(testStatuses: testStatuses, quarantinedTests: quarantinedTests) {
-                return true
+            if action != .build {
+                try await storeSuccessfulTestHashes(
+                    for: testActionTargets(
+                        for: [testScheme], testPlanConfiguration: testPlanConfiguration, graph: graph, action: action
+                    ),
+                    graph: graph,
+                    mapperEnvironment: mapperEnvironment,
+                    cacheStorage: uploadCacheStorage
+                )
             }
-
-            throw error
-        }
-
-        if action != .build {
-            try await storeSuccessfulTestHashes(
-                for: testActionTargets(
-                    for: schemes, testPlanConfiguration: testPlanConfiguration, graph: graph, action: action
-                ),
-                graph: graph,
-                mapperEnvironment: mapperEnvironment,
-                cacheStorage: uploadCacheStorage
-            )
         }
 
         let verb =
@@ -1276,6 +1273,46 @@ public struct TestService { // swiftlint:disable:this type_body_length
         }
 
         return true
+    }
+
+    private func handleTestSchemeFailure(
+        _ error: Error,
+        scheme: Scheme,
+        resultBundlePath: AbsolutePath?,
+        graph: Graph,
+        mapperEnvironment: MapperEnvironment,
+        cacheStorage: CacheStoring,
+        testPlanConfiguration: TestPlanConfiguration?,
+        action: XcodeBuildTestAction,
+        quarantinedTests: [TestIdentifier]
+    ) async throws -> Bool {
+        guard action != .build, let resultBundlePath else { throw error }
+
+        guard try await fileSystem.exists(resultBundlePath) else { throw error }
+
+        let testStatuses = try await xcResultService.parseTestStatuses(path: resultBundlePath)
+        guard !testStatuses.testCases.isEmpty else { throw error }
+
+        let testTargets = testActionTargets(
+            for: [scheme], testPlanConfiguration: testPlanConfiguration, graph: graph, action: action
+        )
+
+        let passingTestTargets = testTargets.filter {
+            testStatuses.passingModuleNames().contains($0.target.name)
+        }
+
+        try await storeSuccessfulTestHashes(
+            for: passingTestTargets,
+            graph: graph,
+            mapperEnvironment: mapperEnvironment,
+            cacheStorage: cacheStorage
+        )
+
+        if testQuarantineService.onlyQuarantinedTestsFailed(testStatuses: testStatuses, quarantinedTests: quarantinedTests) {
+            return true
+        }
+
+        throw error
     }
 
     private func updateTestServiceAnalytics(
@@ -1645,6 +1682,26 @@ public struct TestService { // swiftlint:disable:this type_body_length
         }
     }
 
+    private func schemeResultBundlePath(
+        _ resultBundlePath: AbsolutePath?,
+        schemeName: String,
+        runningMultipleSchemes: Bool
+    ) -> AbsolutePath? {
+        guard runningMultipleSchemes, let resultBundlePath else {
+            return resultBundlePath
+        }
+
+        let schemePathComponent = schemeName.toValidInBundleIdentifier()
+        let pathComponent: String
+        if let pathExtension = resultBundlePath.extension {
+            pathComponent = "\(resultBundlePath.basenameWithoutExt)-\(schemePathComponent).\(pathExtension)"
+        } else {
+            pathComponent = "\(resultBundlePath.basename)-\(schemePathComponent)"
+        }
+
+        return resultBundlePath.parentDirectory.appending(component: pathComponent)
+    }
+
     // swiftlint:disable:next function_body_length
     private func testScheme(
         scheme: Scheme,
@@ -1807,6 +1864,7 @@ public struct TestService { // swiftlint:disable:this type_body_length
             projectDerivedDataDirectory: projectDerivedDataDirectory,
             config: config,
             action: action,
+            scheme: scheme.name,
             quarantinedTests: quarantinedTests,
             mode: mode
         )

--- a/cli/Tests/TuistKitTests/Services/TestServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/TestServiceTests.swift
@@ -693,6 +693,157 @@ final class TestServiceTests: TuistUnitTestCase {
         )
     }
 
+    func test_run_tests_all_project_schemes_uses_unique_result_bundle_paths_when_cloud_is_configured() async throws {
+        // Given
+        givenGenerator()
+        given(buildGraphInspector)
+            .testableSchemes(graphTraverser: .any)
+            .willReturn([])
+        given(buildGraphInspector)
+            .workspaceSchemes(graphTraverser: .any)
+            .willReturn(
+                [
+                    Scheme.test(name: "ProjectSchemeOne"),
+                    Scheme.test(name: "ProjectSchemeTwo"),
+                ]
+            )
+        given(generator)
+            .generateWithGraph(path: .any, options: .any)
+            .willProduce { path, _ in
+                (path, .test(), MapperEnvironment())
+            }
+        given(configLoader)
+            .loadConfig(path: .any)
+            .willReturn(.test(fullHandle: "tuist/tuist"))
+
+        let runsCacheDirectory = try temporaryPath()
+        given(cacheDirectoriesProvider)
+            .cacheDirectory(for: .value(.runs))
+            .willReturn(runsCacheDirectory)
+
+        let firstResultBundlePath = runsCacheDirectory
+            .appending(components: "run-id", "\(Constants.resultBundleName)-ProjectSchemeOne")
+        let secondResultBundlePath = runsCacheDirectory
+            .appending(components: "run-id", "\(Constants.resultBundleName)-ProjectSchemeTwo")
+
+        // When
+        try await testRun(
+            path: try temporaryPath()
+        )
+
+        // Then
+        verify(xcodebuildController)
+            .test(
+                .any,
+                scheme: .value("ProjectSchemeOne"),
+                clean: .any,
+                destination: .any,
+                action: .any,
+                rosetta: .any,
+                derivedDataPath: .any,
+                resultBundlePath: .value(firstResultBundlePath),
+                arguments: .any,
+                retryCount: .any,
+                testTargets: .any,
+                skipTestTargets: .any,
+                testPlanConfiguration: .any,
+                passthroughXcodeBuildArguments: .any
+            )
+            .called(1)
+        verify(xcodebuildController)
+            .test(
+                .any,
+                scheme: .value("ProjectSchemeTwo"),
+                clean: .any,
+                destination: .any,
+                action: .any,
+                rosetta: .any,
+                derivedDataPath: .any,
+                resultBundlePath: .value(secondResultBundlePath),
+                arguments: .any,
+                retryCount: .any,
+                testTargets: .any,
+                skipTestTargets: .any,
+                testPlanConfiguration: .any,
+                passthroughXcodeBuildArguments: .any
+            )
+            .called(1)
+    }
+
+    func test_run_tests_all_project_schemes_uses_unique_given_result_bundle_paths() async throws {
+        // Given
+        givenGenerator()
+        given(buildGraphInspector)
+            .testableSchemes(graphTraverser: .any)
+            .willReturn([])
+        given(buildGraphInspector)
+            .workspaceSchemes(graphTraverser: .any)
+            .willReturn(
+                [
+                    Scheme.test(name: "ProjectSchemeOne"),
+                    Scheme.test(name: "ProjectSchemeTwo"),
+                ]
+            )
+        given(generator)
+            .generateWithGraph(path: .any, options: .any)
+            .willProduce { path, _ in
+                (path, .test(), MapperEnvironment())
+            }
+        given(configLoader)
+            .loadConfig(path: .any)
+            .willReturn(.test(project: .testGeneratedProject()))
+
+        let resultBundlePath = try temporaryPath().appending(component: "results.xcresult")
+        let firstResultBundlePath = resultBundlePath.parentDirectory
+            .appending(component: "results-ProjectSchemeOne.xcresult")
+        let secondResultBundlePath = resultBundlePath.parentDirectory
+            .appending(component: "results-ProjectSchemeTwo.xcresult")
+
+        // When
+        try await testRun(
+            path: try temporaryPath(),
+            resultBundlePath: resultBundlePath
+        )
+
+        // Then
+        verify(xcodebuildController)
+            .test(
+                .any,
+                scheme: .value("ProjectSchemeOne"),
+                clean: .any,
+                destination: .any,
+                action: .any,
+                rosetta: .any,
+                derivedDataPath: .any,
+                resultBundlePath: .value(firstResultBundlePath),
+                arguments: .any,
+                retryCount: .any,
+                testTargets: .any,
+                skipTestTargets: .any,
+                testPlanConfiguration: .any,
+                passthroughXcodeBuildArguments: .any
+            )
+            .called(1)
+        verify(xcodebuildController)
+            .test(
+                .any,
+                scheme: .value("ProjectSchemeTwo"),
+                clean: .any,
+                destination: .any,
+                action: .any,
+                rosetta: .any,
+                derivedDataPath: .any,
+                resultBundlePath: .value(secondResultBundlePath),
+                arguments: .any,
+                retryCount: .any,
+                testTargets: .any,
+                skipTestTargets: .any,
+                testPlanConfiguration: .any,
+                passthroughXcodeBuildArguments: .any
+            )
+            .called(1)
+    }
+
     func test_run_uploads_to_local_cache_storage_when_no_upload() async throws {
         // Given
         givenGenerator()


### PR DESCRIPTION
Resolves <https://github.com/tuist/tuist/issues/11707>

## What changed

- Derive a scheme-specific result bundle path when `tuist test` runs more than one generated project scheme, so each `xcodebuild` invocation writes to its own bundle.
- Keep the exact requested result bundle path for single-scheme runs.
- Parse the failed scheme's own result bundle when handling failures, so quarantine checks and selective testing cache writes use the right result data.
- Pass the scheme name through the successful upload path so local test run reports remain labeled per scheme.
- Add regression coverage for both Tuist-managed run cache paths and user-provided `--result-bundle-path` values.

## Why

Tuist recently started running generated project schemes separately when the workspace scheme mixes hosted tests and hostless unit tests. That avoids the Xcode behavior that made the workspace scheme unsuitable for those projects, but it also means a single `tuist test` command can invoke `xcodebuild test` more than once.

Those invocations cannot share one result bundle path. Xcode treats the first completed result bundle as an existing package and rejects the second invocation before any tests run.

## Root cause

`TestService` resolved one result bundle path for the whole test run and passed it unchanged to every scheme. When the first scheme finished, Xcode created the bundle. The second scheme then received the same `-resultBundlePath` value and failed with the existing-file error reported in issue #11707.

## Approach

The service now computes the list of schemes that will actually run, then derives a suffixed result bundle path only when there is more than one scheme. For example, `--result-bundle-path ./results` becomes `./results-App` and `./results-Framework` for the split run, while a single-scheme run still uses `./results`.

Failure handling moved to the per-scheme loop so Tuist parses the result bundle for the scheme that just failed. Successful test hashes are stored after each scheme succeeds, preserving cache updates if a later scheme fails.

## Impact

Multi-scheme `tuist test --result-bundle-path ...` runs no longer fail when the second scheme starts. Users get one result bundle per scheme in split runs. Existing single-scheme behavior is unchanged.

## Validation

- `mise x -- swiftformat cli/Sources/TuistKit/Services/TestService.swift cli/Tests/TuistKitTests/Services/TestServiceTests.swift`
- `mise x -- tuist generate tuist TuistKitTests --no-open`
- `xcodebuild test -workspace Tuist.xcworkspace -scheme TuistUnitTests -only-testing TuistKitTests/TestServiceTests/test_run_tests_all_project_schemes -only-testing TuistKitTests/TestServiceTests/test_run_tests_all_project_schemes_uses_unique_result_bundle_paths_when_cloud_is_configured -only-testing TuistKitTests/TestServiceTests/test_run_tests_all_project_schemes_uses_unique_given_result_bundle_paths CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""`
- `xcodebuild test -workspace Tuist.xcworkspace -scheme TuistUnitTests -only-testing TuistKitTests/TestServiceTests/test_run_tests_all_project_schemes_when_fails CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""`
- `xcodebuild build -workspace Tuist.xcworkspace -scheme tuist CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""`
- Smoke run with the patched local executable: `tuist test --result-bundle-path ./results --no-selective-testing` from a temporary copy of `examples/xcode/generated_app_with_framework_and_tests`. It ran the `App` and `Framework` schemes successfully and created `results-App.xcresult` plus `results-Framework.xcresult`.
