### PR TITLE
fix(server): allow private SSO URLs for self-hosted

### DIFF
--- a/server/lib/tuist/accounts/organization.ex
+++ b/server/lib/tuist/accounts/organization.ex
@@ -168,7 +168,7 @@ defmodule Tuist.Accounts.Organization do
     end
   end
 
-  defp valid_oauth2_url?(url), do: Tuist.URL.public_url?(url)
+  defp valid_oauth2_url?(url), do: Tuist.URL.sso_url?(url)
 
   defp normalize_oauth2_endpoint_urls(changeset) do
     Enum.reduce(@oauth2_endpoint_fields, changeset, fn field, changeset ->

--- a/server/lib/tuist/oauth2/sso_client.ex
+++ b/server/lib/tuist/oauth2/sso_client.ex
@@ -2,16 +2,16 @@ defmodule Tuist.OAuth2.SSOClient do
   @moduledoc ~S"""
   HTTP client for SSO OAuth2 token exchange and userinfo retrieval.
 
-  Uses Req/Finch with SSRF-safe pinned URLs via `SSRFGuard.pin/1`.
-  Each request is made against a pre-resolved public IP with Mint's
-  `:hostname` connect option preserving TLS SNI + cert validation for
-  the original hostname.
+  Tuist-hosted deployments use Req/Finch with SSRF-safe pinned URLs via
+  `SSRFGuard.pin/1`. Self-hosted deployments call the configured URL directly
+  because the operator controls the private network the server runs in.
   """
 
+  alias Tuist.Environment
   alias Tuist.OAuth2.SSRFGuard
 
   def exchange_token(token_url, code, redirect_uri, client_id, client_secret) do
-    with {:ok, pinned_url, hostname} <- SSRFGuard.pin(token_url) do
+    with {:ok, request_url, request_options} <- request_url_and_options(token_url) do
       body =
         URI.encode_query(%{
           grant_type: "authorization_code",
@@ -19,16 +19,18 @@ defmodule Tuist.OAuth2.SSOClient do
           redirect_uri: redirect_uri
         })
 
-      case Req.post(pinned_url,
-             body: body,
-             headers: [
-               {"content-type", "application/x-www-form-urlencoded"},
-               {"accept", "application/json"},
-               {"authorization", "Basic " <> Base.encode64("#{client_id}:#{client_secret}")}
-             ],
-             connect_options: SSRFGuard.connect_options(hostname),
-             decode_body: false
-           ) do
+      request_options =
+        Keyword.merge(request_options,
+          body: body,
+          headers: [
+            {"content-type", "application/x-www-form-urlencoded"},
+            {"accept", "application/json"},
+            {"authorization", "Basic " <> Base.encode64("#{client_id}:#{client_secret}")}
+          ],
+          decode_body: false
+        )
+
+      case Req.post(request_url, request_options) do
         {:ok, %Req.Response{status: status, body: body}} when status in 200..299 ->
           {:ok, decode_json(body)}
 
@@ -42,15 +44,17 @@ defmodule Tuist.OAuth2.SSOClient do
   end
 
   def fetch_userinfo(user_info_url, access_token) do
-    with {:ok, pinned_url, hostname} <- SSRFGuard.pin(user_info_url) do
-      case Req.get(pinned_url,
-             headers: [
-               {"authorization", "Bearer #{access_token}"},
-               {"accept", "application/json"}
-             ],
-             connect_options: SSRFGuard.connect_options(hostname),
-             decode_body: false
-           ) do
+    with {:ok, request_url, request_options} <- request_url_and_options(user_info_url) do
+      request_options =
+        Keyword.merge(request_options,
+          headers: [
+            {"authorization", "Bearer #{access_token}"},
+            {"accept", "application/json"}
+          ],
+          decode_body: false
+        )
+
+      case Req.get(request_url, request_options) do
         {:ok, %Req.Response{status: 200, body: body}} ->
           {:ok, decode_json(body)}
 
@@ -60,6 +64,16 @@ defmodule Tuist.OAuth2.SSOClient do
         {:error, reason} ->
           {:error, reason}
       end
+    end
+  end
+
+  defp request_url_and_options(url) do
+    if Environment.tuist_hosted?() do
+      with {:ok, pinned_url, hostname} <- SSRFGuard.pin(url) do
+        {:ok, pinned_url, connect_options: SSRFGuard.connect_options(hostname)}
+      end
+    else
+      {:ok, url, []}
     end
   end
 

--- a/server/lib/tuist/url.ex
+++ b/server/lib/tuist/url.ex
@@ -4,17 +4,45 @@ defmodule Tuist.URL do
   """
 
   def public_url?(url) when is_binary(url) do
-    case URI.parse(url) do
-      %URI{scheme: scheme, host: host, query: nil, fragment: nil}
-      when is_binary(host) and host != "" ->
-        scheme_allowed?(scheme) and not private_host?(host)
-
-      _ ->
-        false
+    case parse_http_url(url) do
+      {:ok, %URI{host: host}} -> not private_host?(host)
+      :error -> false
     end
   end
 
   def public_url?(_), do: false
+
+  @doc """
+  Validates an SSO URL using the network policy for the current deployment.
+
+  Tuist-hosted deployments only accept public URLs to protect the multi-tenant
+  service from SSRF. Self-hosted deployments allow private network hosts while
+  keeping the same scheme, query, and fragment rules.
+  """
+  def sso_url?(url) when is_binary(url) do
+    if Tuist.Environment.tuist_hosted?() do
+      public_url?(url)
+    else
+      http_url?(url)
+    end
+  end
+
+  def sso_url?(_), do: false
+
+  defp http_url?(url) do
+    match?({:ok, %URI{}}, parse_http_url(url))
+  end
+
+  defp parse_http_url(url) do
+    case URI.parse(url) do
+      %URI{scheme: scheme, host: host, query: nil, fragment: nil} = uri
+      when is_binary(host) and host != "" ->
+        if scheme_allowed?(scheme), do: {:ok, uri}, else: :error
+
+      _ ->
+        :error
+    end
+  end
 
   defp scheme_allowed?("https"), do: true
   defp scheme_allowed?("http"), do: Tuist.Environment.dev?() or Tuist.Environment.test?()

--- a/server/lib/tuist_web/controllers/auth_controller.ex
+++ b/server/lib/tuist_web/controllers/auth_controller.ex
@@ -413,7 +413,7 @@ defmodule TuistWeb.AuthController do
         &String.starts_with?(&1, "http")
       )
 
-    if Enum.all?(urls, &Tuist.URL.public_url?/1) do
+    if Enum.all?(urls, &Tuist.URL.sso_url?/1) do
       :ok
     else
       {:error, :unsafe_sso_url}

--- a/server/lib/tuist_web/live/authentication_settings_live.ex
+++ b/server/lib/tuist_web/live/authentication_settings_live.ex
@@ -230,8 +230,9 @@ defmodule TuistWeb.AuthenticationSettingsLive do
   end
 
   defp save_oauth2_sso(%{assigns: %{organization: organization, selected_provider: selected_provider}} = socket, params) do
+    form_params = params["sso"] || %{}
     sso_provider = String.to_existing_atom(selected_provider)
-    attrs = build_oauth2_attrs(selected_provider, params["sso"] || %{}, socket.assigns.sso_enforced)
+    attrs = build_oauth2_attrs(selected_provider, form_params, socket.assigns.sso_enforced)
 
     case Accounts.update_sso_configuration(organization.id, sso_provider, attrs) do
       {:ok, updated_organization} ->
@@ -243,7 +244,18 @@ defmodule TuistWeb.AuthenticationSettingsLive do
          |> assign(flash_message: nil, field_errors: %{})}
 
       {:error, changeset} ->
-        {:noreply, assign(socket, field_errors: changeset_to_field_errors(changeset, selected_provider))}
+        form_params =
+          default_form_data()
+          |> Map.merge(form_params)
+          |> Map.put("provider", selected_provider)
+
+        {:noreply,
+         socket
+         |> assign(current_form_params: form_params)
+         |> assign(form: to_form(form_params, as: "sso"))
+         |> assign(field_errors: changeset_to_field_errors(changeset, selected_provider))
+         |> compute_form_valid()
+         |> compute_has_changes()}
     end
   end
 

--- a/server/priv/gettext/dashboard_account.pot
+++ b/server/priv/gettext/dashboard_account.pot
@@ -1104,7 +1104,7 @@ msgstr ""
 msgid "Single Sign-On"
 msgstr ""
 
-#: lib/tuist_web/live/authentication_settings_live.ex:342
+#: lib/tuist_web/live/authentication_settings_live.ex:354
 #, elixir-autogen, elixir-format
 msgid "You must be authenticated with Google using an email tied to this domain. Please sign in with Google first."
 msgstr ""
@@ -1178,7 +1178,7 @@ msgstr ""
 msgid "When enabled, organization members will not be able to log in with email and password. They must use SSO instead."
 msgstr ""
 
-#: lib/tuist_web/live/authentication_settings_live.ex:328
+#: lib/tuist_web/live/authentication_settings_live.ex:340
 #, elixir-autogen, elixir-format
 msgid "You must authenticate with the SSO provider before enforcing SSO. Please sign in with your SSO provider first."
 msgstr ""

--- a/server/test/tuist/accounts/organization_test.exs
+++ b/server/test/tuist/accounts/organization_test.exs
@@ -3,6 +3,7 @@ defmodule Tuist.OrganizationTest do
   use Mimic
 
   alias Tuist.Accounts.Organization
+  alias Tuist.Environment
 
   @okta_attrs %{
     sso_provider: :okta,
@@ -99,6 +100,38 @@ defmodule Tuist.OrganizationTest do
       assert changeset.valid? == true
     end
 
+    test "accepts an oauth2 issuer URL with a path" do
+      changeset =
+        Organization.create_changeset(
+          %Organization{},
+          Map.merge(@oauth2_attrs, %{
+            sso_organization_id: "https://keycloak.example.com/realms/master",
+            oauth2_authorize_url: "https://keycloak.example.com/realms/master/protocol/openid-connect/auth",
+            oauth2_token_url: "https://keycloak.example.com/realms/master/protocol/openid-connect/token",
+            oauth2_user_info_url: "https://keycloak.example.com/realms/master/protocol/openid-connect/userinfo"
+          })
+        )
+
+      assert changeset.valid? == true
+    end
+
+    test "accepts private oauth2 URLs on self-hosted installations" do
+      stub(Environment, :tuist_hosted?, fn -> false end)
+
+      changeset =
+        Organization.create_changeset(
+          %Organization{},
+          Map.merge(@oauth2_attrs, %{
+            sso_organization_id: "https://10.0.0.1/realms/master",
+            oauth2_authorize_url: "https://10.0.0.1/realms/master/protocol/openid-connect/auth",
+            oauth2_token_url: "https://10.0.0.1/realms/master/protocol/openid-connect/token",
+            oauth2_user_info_url: "https://10.0.0.1/realms/master/protocol/openid-connect/userinfo"
+          })
+        )
+
+      assert changeset.valid? == true
+    end
+
     test "normalizes the oauth2 site on create" do
       changeset =
         Organization.create_changeset(
@@ -146,6 +179,8 @@ defmodule Tuist.OrganizationTest do
     end
 
     test "rejects private IP addresses in oauth2 URLs" do
+      stub(Environment, :tuist_hosted?, fn -> true end)
+
       for private_url <- [
             "https://127.0.0.1/authorize",
             "https://10.0.0.1/authorize",
@@ -171,6 +206,8 @@ defmodule Tuist.OrganizationTest do
     end
 
     test "rejects private addresses in sso_organization_id for oauth2" do
+      stub(Environment, :tuist_hosted?, fn -> true end)
+
       changeset =
         Organization.create_changeset(
           %Organization{},

--- a/server/test/tuist/oauth2/sso_client_test.exs
+++ b/server/test/tuist/oauth2/sso_client_test.exs
@@ -2,11 +2,13 @@ defmodule Tuist.OAuth2.SSOClientTest do
   use ExUnit.Case, async: true
   use Mimic
 
+  alias Tuist.Environment
   alias Tuist.OAuth2.SSOClient
   alias Tuist.OAuth2.SSRFGuard
 
   describe "exchange_token/5" do
     test "returns decoded JSON body on a successful 200 response" do
+      tuist_hosted()
       expect(SSRFGuard, :pin, fn url -> {:ok, url, "idp.example.com"} end)
       expect(SSRFGuard, :connect_options, fn "idp.example.com" -> [] end)
 
@@ -34,6 +36,7 @@ defmodule Tuist.OAuth2.SSOClientTest do
     end
 
     test "uses Basic Auth with the client credentials" do
+      tuist_hosted()
       expect(SSRFGuard, :pin, fn url -> {:ok, url, "idp.example.com"} end)
       expect(SSRFGuard, :connect_options, fn _ -> [] end)
 
@@ -50,6 +53,7 @@ defmodule Tuist.OAuth2.SSOClientTest do
     end
 
     test "returns an error tuple when the token endpoint returns a non-2xx status" do
+      tuist_hosted()
       expect(SSRFGuard, :pin, fn url -> {:ok, url, "idp.example.com"} end)
       expect(SSRFGuard, :connect_options, fn _ -> [] end)
 
@@ -62,6 +66,7 @@ defmodule Tuist.OAuth2.SSOClientTest do
     end
 
     test "propagates SSRFGuard pin errors" do
+      tuist_hosted()
       expect(SSRFGuard, :pin, fn _url -> {:error, :private_ip_resolved} end)
 
       assert {:error, :private_ip_resolved} =
@@ -69,6 +74,7 @@ defmodule Tuist.OAuth2.SSOClientTest do
     end
 
     test "propagates Req transport errors" do
+      tuist_hosted()
       expect(SSRFGuard, :pin, fn url -> {:ok, url, "idp.example.com"} end)
       expect(SSRFGuard, :connect_options, fn _ -> [] end)
       expect(Req, :post, fn _url, _opts -> {:error, %Mint.TransportError{reason: :timeout}} end)
@@ -76,10 +82,26 @@ defmodule Tuist.OAuth2.SSOClientTest do
       assert {:error, %Mint.TransportError{reason: :timeout}} =
                SSOClient.exchange_token("https://idp.example.com/token", "code", "https://cb", "id", "secret")
     end
+
+    test "does not pin token requests on self-hosted installations" do
+      self_hosted()
+      reject(&SSRFGuard.pin/1)
+      reject(&SSRFGuard.connect_options/1)
+
+      expect(Req, :post, fn "https://10.0.0.1/token", opts ->
+        refute Keyword.has_key?(opts, :connect_options)
+
+        {:ok, %Req.Response{status: 200, body: ~s({"access_token":"tok"})}}
+      end)
+
+      assert {:ok, %{"access_token" => "tok"}} =
+               SSOClient.exchange_token("https://10.0.0.1/token", "code", "https://cb", "id", "secret")
+    end
   end
 
   describe "fetch_userinfo/2" do
     test "returns decoded JSON body on a successful 200 response" do
+      tuist_hosted()
       expect(SSRFGuard, :pin, fn url -> {:ok, url, "idp.example.com"} end)
       expect(SSRFGuard, :connect_options, fn "idp.example.com" -> [] end)
 
@@ -99,6 +121,7 @@ defmodule Tuist.OAuth2.SSOClientTest do
     end
 
     test "returns an error tuple when the userinfo endpoint returns a non-200 status" do
+      tuist_hosted()
       expect(SSRFGuard, :pin, fn url -> {:ok, url, "idp.example.com"} end)
       expect(SSRFGuard, :connect_options, fn _ -> [] end)
 
@@ -111,10 +134,19 @@ defmodule Tuist.OAuth2.SSOClientTest do
     end
 
     test "propagates SSRFGuard pin errors" do
+      tuist_hosted()
       expect(SSRFGuard, :pin, fn _url -> {:error, :dns_failure} end)
 
       assert {:error, :dns_failure} =
                SSOClient.fetch_userinfo("https://nope.invalid/userinfo", "token")
     end
+  end
+
+  defp tuist_hosted do
+    stub(Environment, :tuist_hosted?, fn -> true end)
+  end
+
+  defp self_hosted do
+    stub(Environment, :tuist_hosted?, fn -> false end)
   end
 end

--- a/server/test/tuist/url_test.exs
+++ b/server/test/tuist/url_test.exs
@@ -2,6 +2,7 @@ defmodule Tuist.URLTest do
   use TuistTestSupport.Cases.DataCase, async: true
   use Mimic
 
+  alias Tuist.Environment
   alias Tuist.URL
 
   describe "public_url?/1" do
@@ -15,8 +16,8 @@ defmodule Tuist.URLTest do
     end
 
     test "rejects http URLs outside of dev and test environments" do
-      stub(Tuist.Environment, :dev?, fn -> false end)
-      stub(Tuist.Environment, :test?, fn -> false end)
+      stub(Environment, :dev?, fn -> false end)
+      stub(Environment, :test?, fn -> false end)
 
       refute URL.public_url?("http://sso.company.org/userinfo")
       assert URL.public_url?("https://sso.company.org/userinfo")
@@ -85,6 +86,23 @@ defmodule Tuist.URLTest do
 
     test "rejects unspecified address" do
       refute URL.public_url?("https://0.0.0.0/authorize")
+    end
+  end
+
+  describe "sso_url?/1" do
+    test "uses public URL validation on Tuist-hosted installations" do
+      stub(Environment, :tuist_hosted?, fn -> true end)
+
+      assert URL.sso_url?("https://keycloak.example.com/realms/master")
+      refute URL.sso_url?("https://10.0.0.1/realms/master")
+    end
+
+    test "allows private SSO URLs on self-hosted installations" do
+      stub(Environment, :tuist_hosted?, fn -> false end)
+
+      assert URL.sso_url?("https://10.0.0.1/realms/master")
+      refute URL.sso_url?("ftp://10.0.0.1/realms/master")
+      refute URL.sso_url?("https://10.0.0.1/realms/master?tenant=acme")
     end
   end
 end

--- a/server/test/tuist_web/live/authentication_settings_live_test.exs
+++ b/server/test/tuist_web/live/authentication_settings_live_test.exs
@@ -6,6 +6,7 @@ defmodule TuistWeb.AuthenticationSettingsLiveTest do
   import Phoenix.LiveViewTest
 
   alias Tuist.Accounts
+  alias Tuist.Environment
   alias Tuist.SCIM
   alias TuistTestSupport.Fixtures.AccountsFixtures
 
@@ -184,6 +185,42 @@ defmodule TuistWeb.AuthenticationSettingsLiveTest do
         |> render_submit()
 
       assert html =~ "must be a valid URL"
+
+      document = Floki.parse_fragment!(html)
+
+      assert Floki.attribute(document, "#sso_oauth2_site", "value") == ["not-a-url"]
+      assert Floki.attribute(document, "#sso_oauth2_authorize_url", "value") == ["not-a-url"]
+      assert Floki.attribute(document, "#sso_oauth2_token_url", "value") == ["not-a-url"]
+      assert Floki.attribute(document, "#sso_oauth2_user_info_url", "value") == ["not-a-url"]
+    end
+
+    test "configures OAuth2 SSO with private Keycloak-style URLs on self-hosted installations", %{
+      conn: conn,
+      account: account
+    } do
+      stub(Environment, :tuist_hosted?, fn -> false end)
+
+      {:ok, lv, _html} = live(conn, ~p"/#{account.name}/settings/authentication")
+
+      render_hook(lv, "toggle_sso")
+      render_hook(lv, "select_provider", %{"value" => ["oauth2"]})
+
+      html =
+        lv
+        |> form("#sso-form", %{
+          "sso" => %{
+            "oauth2_site" => "https://10.0.0.1/realms/master",
+            "oauth2_client_id" => "test_client_id",
+            "oauth2_client_secret" => "test_client_secret",
+            "oauth2_authorize_url" => "https://10.0.0.1/realms/master/protocol/openid-connect/auth",
+            "oauth2_token_url" => "https://10.0.0.1/realms/master/protocol/openid-connect/token",
+            "oauth2_user_info_url" => "https://10.0.0.1/realms/master/protocol/openid-connect/userinfo"
+          }
+        })
+        |> render_submit()
+
+      refute html =~ "must be a valid URL"
+      assert html =~ "Enable Single Sign-On"
     end
   end
 


### PR DESCRIPTION
## What changed

- Added an SSO-specific URL validation policy that keeps public-only validation for Tuist-hosted deployments while allowing private-network HTTP(S) URLs on self-hosted deployments.
- Updated OAuth2 SSO configuration validation and runtime callback URL checks to use the new SSO policy.
- Updated the OAuth2 SSO client so hosted deployments still use SSRF pinning, while self-hosted deployments call configured IdP URLs directly.
- Preserved submitted OAuth2 settings form values when validation fails.

## Why

Self-hosted installations may run their identity provider inside the same private network as the Tuist server. The previous validation path reused `public_url?/1`, which treats hosts resolving to private IP ranges as invalid. That made otherwise valid internal OIDC endpoints fail with a generic "must be a valid URL" message.

## Root cause

The settings changeset and runtime SSO callback validation both used the generic public URL validator. That validator is appropriate for Tuist-hosted multi-tenant SSRF protection, but it is too strict for self-hosted deployments where private IdP endpoints are expected and operator-controlled.

## Approach

The new `Tuist.URL.sso_url?/1` keeps the existing scheme, query, and fragment constraints. It branches only on deployment mode: hosted deployments continue to require public URLs, while self-hosted deployments allow private hosts. The SSO HTTP client mirrors that policy by keeping SSRF pinning for hosted deployments and bypassing it for self-hosted deployments.

## Impact

Self-hosted operators can configure internal OAuth2/OIDC providers such as Keycloak without disabling validation entirely. Hosted deployments retain the existing SSRF protections.

## Validation

- `mix test test/tuist/url_test.exs test/tuist/accounts/organization_test.exs test/tuist/oauth2/sso_client_test.exs test/tuist_web/live/authentication_settings_live_test.exs`
- Result: `73 tests, 0 failures`