### PR TITLE
feat(kura): inline every action output blob on GetActionResult wildcard

### DIFF
--- a/kura/src/reapi/mod.rs
+++ b/kura/src/reapi/mod.rs
@@ -545,26 +545,57 @@ impl ActionCache for ReapiService {
             action_result.stderr_raw = bytes;
         }
         if !request.get_ref().inline_output_files.is_empty() {
+            // `"*"` is a Kura extension to the REAPI `inline_output_files`
+            // hint: inline the contents of every output file the response
+            // budget affords. It exists for clients (the Xcode CAS plugin)
+            // whose output-file paths are digests unknown before this
+            // response, collapsing the action lookup + blob fetch into one
+            // round-trip. Best-effort by design: a file the budget cannot
+            // afford stays un-inlined and the client falls back to
+            // BatchReadBlobs for it, so mixed client/server versions
+            // interoperate unchanged (an old server matches no literal `"*"`
+            // path and inlines nothing).
+            let inline_all = request
+                .get_ref()
+                .inline_output_files
+                .iter()
+                .any(|path| path == "*");
             for output_file in &mut action_result.output_files {
-                if !request
-                    .get_ref()
-                    .inline_output_files
-                    .iter()
-                    .any(|path| path == &output_file.path)
+                if !inline_all
+                    && !request
+                        .get_ref()
+                        .inline_output_files
+                        .iter()
+                        .any(|path| path == &output_file.path)
                 {
                     continue;
                 }
-                if output_file.contents.is_empty()
-                    && let Some(digest) = &output_file.digest
-                    && let Some(bytes) = maybe_read_cas_bytes(
-                        &self.state,
-                        namespace_id,
-                        digest,
-                        Some(&mut materialization_budget),
-                    )
-                    .await?
+                if !output_file.contents.is_empty() {
+                    continue;
+                }
+                let Some(digest) = &output_file.digest else {
+                    continue;
+                };
+                match maybe_read_cas_bytes(
+                    &self.state,
+                    namespace_id,
+                    digest,
+                    Some(&mut materialization_budget),
+                )
+                .await
                 {
-                    output_file.contents = bytes;
+                    Ok(Some(bytes)) => output_file.contents = bytes,
+                    Ok(None) => {}
+                    // Wildcard inlining degrades to partial rather than
+                    // failing the lookup; a later, smaller file may still fit
+                    // the remaining budget. Explicitly requested paths keep
+                    // the hard error.
+                    Err(status)
+                        if inline_all && status.code() == tonic::Code::ResourceExhausted =>
+                    {
+                        continue;
+                    }
+                    Err(status) => return Err(status),
                 }
             }
         }
@@ -1397,7 +1428,7 @@ mod tests {
     use crate::{
         artifact::producer::ArtifactProducer,
         failpoints::{FailpointAction, FailpointName},
-        test_support::{test_context, test_context_with_extension},
+        test_support::{TestContext, test_context, test_context_with_extension},
     };
 
     // Serves the REAPI routes over a plaintext h2c listener for the tests
@@ -2228,6 +2259,150 @@ end
             .expect_err("inline expansion should respect the materialization budget");
 
         assert_eq!(error.code(), tonic::Code::ResourceExhausted);
+    }
+
+    async fn persist_output_file_blob(context: &TestContext, bytes: &[u8]) -> reapi::Digest {
+        let digest = reapi::Digest {
+            hash: hex::encode(Sha256::digest(bytes)),
+            size_bytes: bytes.len() as i64,
+        };
+        let key = blob_key(&digest_key(&digest).expect("digest key should build"));
+        context
+            .state
+            .store
+            .persist_artifact_from_bytes(
+                ArtifactProducer::Reapi,
+                DEFAULT_INSTANCE_NAME,
+                &key,
+                "application/octet-stream",
+                bytes,
+            )
+            .await
+            .expect("output blob should persist");
+        digest
+    }
+
+    async fn persist_action_result_with_outputs(
+        context: &TestContext,
+        output_files: Vec<reapi::OutputFile>,
+    ) -> reapi::Digest {
+        let action_result = reapi::ActionResult {
+            output_files,
+            ..Default::default()
+        };
+        let action_bytes = action_result.encode_to_vec();
+        let action_digest = reapi::Digest {
+            hash: hex::encode(Sha256::digest(&action_bytes)),
+            size_bytes: action_bytes.len() as i64,
+        };
+        let action_key =
+            action_cache_key(&digest_key(&action_digest).expect("digest key should build"));
+        context
+            .state
+            .store
+            .persist_inline_artifact_from_bytes(
+                ArtifactProducer::Reapi,
+                DEFAULT_INSTANCE_NAME,
+                &action_key,
+                "application/x-protobuf",
+                &action_bytes,
+            )
+            .await
+            .expect("action result should persist");
+        action_digest
+    }
+
+    #[tokio::test]
+    async fn action_cache_wildcard_inlines_every_output_file() {
+        let context = test_context(|_| {}).await;
+        let service = ReapiService {
+            state: context.state.clone(),
+        };
+        let first_bytes = b"first output".to_vec();
+        let second_bytes = b"second output".to_vec();
+        let first_digest = persist_output_file_blob(&context, &first_bytes).await;
+        let second_digest = persist_output_file_blob(&context, &second_bytes).await;
+        let action_digest = persist_action_result_with_outputs(
+            &context,
+            vec![
+                reapi::OutputFile {
+                    path: "aaaa".into(),
+                    digest: Some(first_digest),
+                    ..Default::default()
+                },
+                reapi::OutputFile {
+                    path: "bbbb".into(),
+                    digest: Some(second_digest),
+                    ..Default::default()
+                },
+            ],
+        )
+        .await;
+
+        let response = service
+            .get_action_result(Request::new(reapi::GetActionResultRequest {
+                instance_name: DEFAULT_INSTANCE_NAME.into(),
+                action_digest: Some(action_digest),
+                inline_output_files: vec!["*".into()],
+                digest_function: reapi::digest_function::Value::Sha256 as i32,
+                ..Default::default()
+            }))
+            .await
+            .expect("wildcard inline should succeed");
+
+        let output_files = &response.get_ref().output_files;
+        assert_eq!(output_files[0].contents, first_bytes);
+        assert_eq!(output_files[1].contents, second_bytes);
+    }
+
+    #[tokio::test]
+    async fn action_cache_wildcard_inline_degrades_to_partial_when_budget_is_exceeded() {
+        let context = test_context(|config| {
+            config.memory_soft_limit_bytes = 32 * 1024 * 1024;
+            config.memory_hard_limit_bytes = 64 * 1024 * 1024;
+        })
+        .await;
+        let service = ReapiService {
+            state: context.state.clone(),
+        };
+        // Larger than the response budget under this memory config (the same
+        // sizing the explicit-inline rejection test relies on), listed FIRST
+        // to prove a rejected file does not stop later ones from inlining.
+        let large_bytes = vec![b'x'; 9 * 1024 * 1024];
+        let small_bytes = b"small output".to_vec();
+        let large_digest = persist_output_file_blob(&context, &large_bytes).await;
+        let small_digest = persist_output_file_blob(&context, &small_bytes).await;
+        let action_digest = persist_action_result_with_outputs(
+            &context,
+            vec![
+                reapi::OutputFile {
+                    path: "large".into(),
+                    digest: Some(large_digest),
+                    ..Default::default()
+                },
+                reapi::OutputFile {
+                    path: "small".into(),
+                    digest: Some(small_digest),
+                    ..Default::default()
+                },
+            ],
+        )
+        .await;
+
+        let response = service
+            .get_action_result(Request::new(reapi::GetActionResultRequest {
+                instance_name: DEFAULT_INSTANCE_NAME.into(),
+                action_digest: Some(action_digest),
+                inline_output_files: vec!["*".into()],
+                digest_function: reapi::digest_function::Value::Sha256 as i32,
+                ..Default::default()
+            }))
+            .await
+            .expect("wildcard inline should degrade to partial, not fail");
+
+        let output_files = &response.get_ref().output_files;
+        assert!(output_files[0].contents.is_empty());
+        assert_eq!(output_files[1].contents, small_bytes);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What changed

`GetActionResult` now accepts `"*"` in the standard REAPI `inline_output_files` hint, meaning "inline the contents of every output file the response budget affords". Inlined bytes ride the existing `OutputFile.contents` field. Two behaviors distinguish the wildcard from explicitly listed paths:

- **Best-effort**: a blob the `MaterializationBudget` cannot afford is skipped (later, smaller files may still fit) instead of failing the RPC. Explicitly listed paths keep today's hard `resource_exhausted` error.
- Everything else (authz target, metrics, budget accounting, `maybe_read_cas_bytes`) is the existing inlining machinery.

## Why

The Xcode CAS plugin's action results are closure manifests: one `OutputFile` per value-graph node, whose `path` is a digest the client cannot know before the response. Standard path-matched inlining is therefore unusable for it, and every remote cache hit costs **two WAN round-trips**: `GetActionResult` for the manifest, then `BatchReadBlobs` for the blobs. The compiler issues these lookups synchronously, so on a local dev machine building against a remote region (~28ms RTT) the second trip is pure serialized latency across thousands of resolves per warm build.

With the wildcard, the value-graph blobs ride the `GetActionResult` response — one round-trip per hit.

## Rollout safety

Additive and negotiated, per the mixed-version rules:

- **Old client + new server**: no `"*"` is ever sent; behavior unchanged.
- **New client + old server**: `"*"` matches no literal path, nothing is inlined, and the client falls back to `BatchReadBlobs` — today's behavior exactly.
- Partial inlining (budget exhaustion) degrades to the same fallback per-blob.

No wire-format, storage, or replication changes.

## Validation

- Two new unit tests: wildcard inlines every output file; wildcard degrades to partial (large-first ordering proves a rejected file doesn't stop later ones) under a constrained memory config. Existing explicit-path budget-rejection test unchanged and passing.
- `mise run clippy` and `mise run format -- --check` pass.
- End-to-end against a local kura built from this branch, with the companion CLI change and a +28ms-RTT latency relay, building the tuist CLI scheme (2,638 cacheable tasks, fully populated cache, fresh DerivedData, identical conditions for both runs):

| client | wall | hits | proxy op time |
|---|---|---|---|
| current (get + batch-read, 2 RTT) | 160s | 100% | action 157s + fetch 161s = 318s |
| inline (this + companion PR, 1 RTT) | **138s** | 100% | action 175s + fetch **0** = 175s |

The local-CAS floor for this fixture is ~143s: with inlining, the +28ms round-trip cost disappears into the compiler's own concurrency instead of serializing. `inlined=145,846 / blobs=0` in the proxy stats confirms every blob rode the action response.

Caveat for production expectations: in this simulation the old path's fetch leg is ~30ms/resolve, while against production eu-central it measured ~316ms/resolve (real transfer + server time). Inlining removes the per-resolve round-trip serialization; the byte transfer itself still flows (now overlapped with the action response). Production numbers require this to ship in a kura release and roll out to the fleet first.

## Rollout order

Land + release + deploy this before the companion CLI PR pays off; the CLI change is safe to land in any order (it falls back to batch-reads against servers without the extension).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
