### PR TITLE
fix(cli): CAS proxy — verify on-disk presence for cached hits + reclaim idle caches

### DIFF
--- a/cas-plugin/src/bin/tuist-cas-proxy.rs
+++ b/cas-plugin/src/bin/tuist-cas-proxy.rs
@@ -85,6 +85,7 @@ fn main() {
         std::thread::sleep(std::time::Duration::from_secs(10));
         proxy.sweep();
         proxy.enforce_cache_bounds();
+        proxy.reclaim_idle();
         proxy.maintain_token(TOKEN_REFRESH_LEAD);
         let stats = proxy.stats_line();
         if !stats.is_empty() {

--- a/cas-plugin/src/lib.rs
+++ b/cas-plugin/src/lib.rs
@@ -788,6 +788,17 @@ pub unsafe extern "C" fn llcas_cas_prune_ondisk_data(cas: llcas_cas_t, error: *m
     let mut upstream_error: *mut c_char = std::ptr::null_mut();
     let result = prune(state.cas, &mut upstream_error);
     adopt_error(state.up, upstream_error, error);
+    // Pruning removed objects from the shared on-disk CAS in place (and a partial
+    // prune that then errored may have removed some too). Drop this process's own
+    // known-local marks, and tell the per-machine proxy to drop its marks for
+    // this path: neither store recreation nor a cached-hit presence check would
+    // otherwise notice the removed blobs, so a later resolve could skip
+    // re-fetching them and hand back a broken graph. Prune is infrequent, so the
+    // occasional re-warm from an over-broad invalidation is cheap.
+    state.known_local.lock().unwrap().clear();
+    if let (Some(client), Some(cas_dir)) = (&state.proxy, &state.cas_dir) {
+        let _ = client.invalidate(&cas_dir.to_string_lossy());
+    }
     result
 }
 

--- a/cas-plugin/src/proxy.rs
+++ b/cas-plugin/src/proxy.rs
@@ -17,8 +17,8 @@ use std::sync::{Arc, Condvar, Mutex};
 use std::time::{Duration, Instant, UNIX_EPOCH};
 
 use crate::proxy_proto::{
-    read_request, write_response, Request, OP_PUBLISH, OP_RESOLVE, STATUS_ERROR, STATUS_HIT,
-    STATUS_MISS,
+    read_request, write_response, Request, OP_INVALIDATE, OP_PUBLISH, OP_RESOLVE, STATUS_ERROR,
+    STATUS_HIT, STATUS_MISS,
 };
 use crate::prefetch::Prefetcher;
 use crate::reapi::{self, ManifestEntry, Remote, RemoteConfig};
@@ -155,6 +155,11 @@ pub struct PathState {
     // the store was deleted and recreated under this long-lived proxy, so the
     // in-memory marks below are stale and must be dropped before they are trusted.
     generation: Mutex<Option<CasGeneration>>,
+    // Monotonic counter bumped by every invalidation (a detected wipe or a prune
+    // signal). A resolve snapshots it after its wipe check and only commits its
+    // known_local / resolved writes if it is unchanged, so a resolve that began
+    // under an older store can't reinsert stale marks after the maps were cleared.
+    gen_counter: AtomicU64,
     // key digest -> resolved outcome. A local publish updates its entry, so a
     // miss cached during planning turns into a hit once the local build
     // publishes it; misses also carry a timestamp so a key another machine
@@ -199,12 +204,27 @@ impl PathState {
     /// and re-materializes the full graph rather than trusting stale in-memory
     /// marks. Content-addressed and correctness-preserving, so clearing only
     /// forces re-work, never a wrong answer.
+    ///
+    /// The counter is bumped BEFORE the maps are cleared so that a concurrent
+    /// in-flight resolve (which checks the counter while holding the same map
+    /// lock it is about to write) either sees the new counter and skips its
+    /// write, or writes first and then has it cleared here — never inserts a
+    /// stale mark that survives the clear.
     fn invalidate(&self) {
+        self.gen_counter.fetch_add(1, Ordering::SeqCst);
         self.resolved.lock().unwrap().clear();
         for shard in &self.known_local {
             shard.lock().unwrap().clear();
         }
     }
+}
+
+/// Whether writes from a resolve that observed generation `observed` may still
+/// be committed: only if no wipe or prune advanced the path's `gen_counter`
+/// since. A stale resolve's known_local / resolved inserts describe a store that
+/// has been replaced, so they must be dropped rather than trusted.
+fn committable(observed: u64, current: u64) -> bool {
+    observed == current
 }
 
 // The proxy is single-process and owns these raw handles for its lifetime;
@@ -331,6 +351,7 @@ impl Proxy {
             cas,
             cas_path: cas_path.to_string(),
             generation: Mutex::new(cas_generation(cas_path)),
+            gen_counter: AtomicU64::new(0),
             resolved: Mutex::new(HashMap::new()),
             inflight: Mutex::new(HashSet::new()),
             inflight_cvar: Condvar::new(),
@@ -413,7 +434,13 @@ impl Proxy {
                 inflight = state.inflight_cvar.wait(inflight).unwrap();
             }
         }
-        let outcome = self.resolve_uncached(remote, state, key);
+        // Re-check the generation now that we hold the single-flight slot: a wipe
+        // during the wait must be caught before resolve_uncached trusts
+        // known_local. `observed` is snapshotted here so the write guard drops
+        // this resolve's marks if a wipe/prune advances the counter mid-resolve.
+        self.check_generation(state);
+        let observed = state.gen_counter.load(Ordering::SeqCst);
+        let outcome = self.resolve_uncached(remote, state, key, observed);
         {
             let mut inflight = state.inflight.lock().unwrap();
             inflight.remove(key);
@@ -427,6 +454,7 @@ impl Proxy {
         remote: &Remote,
         state: &'static PathState,
         key: &[u8],
+        observed: u64,
     ) -> Result<Option<Vec<u8>>, String> {
         let op_start = Instant::now();
         let phase = Instant::now();
@@ -461,7 +489,7 @@ impl Proxy {
         let phase = Instant::now();
         let missing: Vec<&ManifestEntry> = manifest
             .iter()
-            .filter(|entry| !self.is_local(state, &entry.llcas_digest))
+            .filter(|entry| !self.is_local(state, observed, &entry.llcas_digest))
             .collect();
         state
             .ms_filter
@@ -525,20 +553,40 @@ impl Proxy {
                 state
                     .ms_store
                     .fetch_add(phase.elapsed().as_millis() as u64, Ordering::Relaxed);
-                state
-                    .shard(&entry.llcas_digest)
-                    .lock()
-                    .unwrap()
-                    .insert(entry.llcas_digest.clone());
+                // Mark local only while still on this generation, checked under
+                // the shard lock: a wipe/prune that clears the shards after this
+                // must not leave the freshly-fetched digest behind as a mark for
+                // a store it did not write. (invalidate bumps the counter before
+                // clearing, so a stale insert either loses the race or is cleared.)
+                {
+                    let mut shard = state.shard(&entry.llcas_digest).lock().unwrap();
+                    if committable(observed, state.gen_counter.load(Ordering::SeqCst)) {
+                        shard.insert(entry.llcas_digest.clone());
+                    }
+                }
                 state.stats_blobs_fetched.fetch_add(1, Ordering::Relaxed);
             }
         }
         let value = manifest[0].llcas_digest.clone();
-        state
-            .resolved
-            .lock()
-            .unwrap()
-            .insert(key.to_vec(), Resolution::Hit(value.clone()));
+        // Commit the Hit only if no wipe/prune advanced the generation while we
+        // were fetching. If it did, the graph we just materialized targets a
+        // store that has been replaced, so caching this value (or returning it)
+        // could hand back a graph that is not on the current disk. Drop the write
+        // and answer a miss; the next resolve re-materializes against the new
+        // store. Checked under the resolved lock, against which invalidate's
+        // clear is serialized.
+        let committed = {
+            let mut resolved = state.resolved.lock().unwrap();
+            if committable(observed, state.gen_counter.load(Ordering::SeqCst)) {
+                resolved.insert(key.to_vec(), Resolution::Hit(value.clone()));
+                true
+            } else {
+                false
+            }
+        };
+        if !committed {
+            return Ok(None);
+        }
         if let Some(analytics) = &self.analytics {
             analytics.record_keyvalue(key, "read", op_start.elapsed().as_secs_f64());
         }
@@ -564,12 +612,18 @@ impl Proxy {
         *stored = Some(current);
     }
 
-    fn is_local(&self, state: &PathState, digest: &[u8]) -> bool {
+    fn is_local(&self, state: &PathState, observed: u64, digest: &[u8]) -> bool {
         if state.shard(digest).lock().unwrap().contains(digest) {
             return true;
         }
         if self.load_present(state, digest) {
-            state.shard(digest).lock().unwrap().insert(digest.to_vec());
+            // Memoize the authoritative load only while still on this generation:
+            // a wipe/prune that cleared the shards must not have this present-now
+            // fact re-inserted for what may already be a replaced store.
+            let mut shard = state.shard(digest).lock().unwrap();
+            if committable(observed, state.gen_counter.load(Ordering::SeqCst)) {
+                shard.insert(digest.to_vec());
+            }
             true
         } else {
             false
@@ -898,6 +952,19 @@ impl Proxy {
                 }
                 write_response(&mut stream, STATUS_HIT, &[])
             }
+            OP_INVALIDATE => {
+                // A prune emptied this path's on-disk CAS in place; drop our marks
+                // so a resolve re-fetches. Only if we already track the path — an
+                // unknown path has nothing cached, and we must not open a CAS
+                // handle for it here. Bind first so the `paths` lock is released
+                // before invalidating.
+                let state = self.paths.lock().unwrap().get(&request.cas_path).copied();
+                if let Some(state) = state {
+                    state.invalidate();
+                    state.publish_cache.lock().unwrap().clear();
+                }
+                write_response(&mut stream, STATUS_HIT, &[])
+            }
             _ => write_response(&mut stream, STATUS_ERROR, b"bad op"),
         }
     }
@@ -1174,6 +1241,14 @@ mod tests {
         assert!(!generation_changed(Some(g1), Some(g1)));
         assert!(!generation_changed(None, Some(g1)), "first observation is not a change");
         assert!(!generation_changed(Some(g1), None), "a gone dir is left to reclaim_idle");
+    }
+
+    // A resolve's writes commit only if the generation it observed still holds;
+    // a wipe/prune that advanced the counter mid-resolve drops them.
+    #[test]
+    fn writes_commit_only_on_the_observed_generation() {
+        assert!(committable(7, 7));
+        assert!(!committable(7, 8), "an advanced generation must drop stale writes");
     }
 
     // Deleting and recreating a directory at the same path yields a different

--- a/cas-plugin/src/proxy.rs
+++ b/cas-plugin/src/proxy.rs
@@ -51,6 +51,48 @@ enum Resolution {
     Miss(Instant),
 }
 
+/// The pre-single-flight cache decision for a key (see `fast_path`).
+enum FastPath {
+    /// Serve this value digest: a cached Hit whose value object is still on disk.
+    Hit(Vec<u8>),
+    /// Serve a fresh negative: a cached Miss still inside NEGATIVE_TTL.
+    Miss,
+    /// Fall through to a full (re-)resolve under single-flight.
+    Resolve,
+}
+
+/// Decides what to serve for `key` from the resolved map before entering
+/// single-flight. A cached Hit is served ONLY when `present` confirms its value
+/// object is still on disk; a Hit whose object is gone (the local CAS was wiped
+/// by `xcodebuild clean` or a deleted DerivedData under this long-lived proxy)
+/// calls `invalidate` and returns `Resolve`, so the graph is re-materialized
+/// instead of handing the compiler a value whose blobs no longer exist (which
+/// surfaces as `CAS error: missing object` in the frontend). Kept free of the
+/// FFI presence load and of `PathState` so the guard is unit-testable: the map
+/// is snapshotted and its lock released before `present` runs, both so the load
+/// never serializes other keys and so a Hit can be probed off-lock.
+fn fast_path(
+    resolved: &Mutex<HashMap<Vec<u8>, Resolution>>,
+    key: &[u8],
+    present: impl FnOnce(&[u8]) -> bool,
+    invalidate: impl FnOnce(),
+) -> FastPath {
+    let value = {
+        let map = resolved.lock().unwrap();
+        match map.get(key) {
+            Some(Resolution::Hit(value)) => value.clone(),
+            Some(Resolution::Miss(at)) if at.elapsed() < NEGATIVE_TTL => return FastPath::Miss,
+            _ => return FastPath::Resolve,
+        }
+    };
+    if present(&value) {
+        FastPath::Hit(value)
+    } else {
+        invalidate();
+        FastPath::Resolve
+    }
+}
+
 /// Per-local-CAS-path state. Leaked for 'static lifetime: the proxy runs
 /// until killed.
 pub struct PathState {
@@ -86,6 +128,21 @@ pub struct PathState {
 impl PathState {
     fn shard(&self, digest: &[u8]) -> &Mutex<HashSet<Vec<u8>>> {
         &self.known_local[digest.first().copied().unwrap_or(0) as usize % 32]
+    }
+
+    /// Drops all cached knowledge of the on-disk CAS for this path: the
+    /// resolved key->value map and the known-local shard sets. Called when a
+    /// cached Hit's value object is found missing from disk (`xcodebuild clean`
+    /// or a deleted DerivedData wiped the local CAS under this long-lived
+    /// proxy), so the re-resolve re-probes every manifest entry authoritatively
+    /// and re-materializes the full graph rather than trusting stale in-memory
+    /// marks. Content-addressed and correctness-preserving, so clearing only
+    /// forces re-work, never a wrong answer.
+    fn invalidate(&self) {
+        self.resolved.lock().unwrap().clear();
+        for shard in &self.known_local {
+            shard.lock().unwrap().clear();
+        }
     }
 }
 
@@ -240,10 +297,29 @@ impl Proxy {
         key: &[u8],
     ) -> Result<Option<Vec<u8>>, String> {
         state.stats_resolves.fetch_add(1, Ordering::Relaxed);
+        // Fast path, outside single-flight so the presence load never
+        // serializes other keys: serve a cached Hit only after confirming its
+        // value object is still on disk. A long-lived proxy keeps Hits in memory
+        // across builds, but a wiped DerivedData removes the value graph; serving
+        // the stale Hit then fails the compiler with `missing object`. On absence
+        // the path's stale caches are dropped and we re-resolve below.
+        match fast_path(
+            &state.resolved,
+            key,
+            |value| self.load_present(state, value),
+            || state.invalidate(),
+        ) {
+            FastPath::Hit(value) => return Ok(Some(value)),
+            FastPath::Miss => return Ok(None),
+            FastPath::Resolve => {}
+        }
         // Single-flight: wait out a concurrent resolve of the same key.
         {
             let mut inflight = state.inflight.lock().unwrap();
             loop {
+                // Re-peek under the lock. A Hit that appears here was just
+                // materialized by the winning resolver (or a local publish), so
+                // its graph is on disk; serve it without another presence load.
                 match state.resolved.lock().unwrap().get(key) {
                     Some(Resolution::Hit(value)) => return Ok(Some(value.clone())),
                     // A fresh miss answers without a round-trip; a stale one
@@ -397,6 +473,19 @@ impl Proxy {
         if state.shard(digest).lock().unwrap().contains(digest) {
             return true;
         }
+        if self.load_present(state, digest) {
+            state.shard(digest).lock().unwrap().insert(digest.to_vec());
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Authoritative on-disk presence for `digest`: an actual llcas load, the
+    /// same call the consumer will make, bypassing the known-local cache. Used
+    /// both by `is_local` (which memoizes a positive result) and to guard a
+    /// cached Hit against a wiped local CAS, where the in-memory marks lie.
+    fn load_present(&self, state: &PathState, digest: &[u8]) -> bool {
         unsafe {
             let digest_t = llcas_digest_t { data: digest.as_ptr(), size: digest.len() };
             let mut id = llcas_objectid_t { opaque: 0 };
@@ -413,12 +502,7 @@ impl Proxy {
             if !load_error.is_null() {
                 (state.up.llcas_string_dispose)(load_error);
             }
-            if result == LLCAS_LOOKUP_RESULT_SUCCESS {
-                state.shard(digest).lock().unwrap().insert(digest.to_vec());
-                true
-            } else {
-                false
-            }
+            result == LLCAS_LOOKUP_RESULT_SUCCESS
         }
     }
 
@@ -812,4 +896,118 @@ unsafe fn encode_node_blob(
     }
     let blob = reapi::compress_frame(&reapi::encode_frame(&ref_digests, node_data));
     Ok((blob, ref_digests))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::Cell;
+
+    fn resolved_with(entries: Vec<(Vec<u8>, Resolution)>) -> Mutex<HashMap<Vec<u8>, Resolution>> {
+        let mut map = HashMap::new();
+        for (key, resolution) in entries {
+            map.insert(key, resolution);
+        }
+        Mutex::new(map)
+    }
+
+    // The reported bug: a long-lived proxy caches an action-cache Hit, the user
+    // wipes DerivedData, and the next resolve returns the stale Hit for a value
+    // graph no longer on disk (compiler fails with `missing object`). The fix
+    // makes the fast path verify presence: a Hit whose value object is gone must
+    // NOT be served, and the path's stale in-memory state must be invalidated so
+    // the re-resolve re-materializes the graph.
+    #[test]
+    fn cached_hit_with_wiped_value_reresolves_and_invalidates() {
+        let key = b"action-key".to_vec();
+        let value = b"value-digest".to_vec();
+        let resolved = resolved_with(vec![(key.clone(), Resolution::Hit(value.clone()))]);
+
+        let invalidated = Cell::new(false);
+        let decision = fast_path(
+            &resolved,
+            &key,
+            |probed| {
+                assert_eq!(probed, value.as_slice());
+                false // value object absent on disk (wiped)
+            },
+            || invalidated.set(true),
+        );
+
+        assert!(matches!(decision, FastPath::Resolve));
+        assert!(
+            invalidated.get(),
+            "a Hit whose value object is missing must invalidate the path's stale caches"
+        );
+    }
+
+    // The warm path must stay fast: a Hit whose value object is present is served
+    // directly, without invalidation.
+    #[test]
+    fn cached_hit_present_is_served() {
+        let key = b"action-key".to_vec();
+        let value = b"value-digest".to_vec();
+        let resolved = resolved_with(vec![(key.clone(), Resolution::Hit(value.clone()))]);
+
+        let decision = fast_path(
+            &resolved,
+            &key,
+            |_| true,
+            || panic!("a present Hit must not invalidate"),
+        );
+
+        match decision {
+            FastPath::Hit(served) => assert_eq!(served, value),
+            _ => panic!("expected the present Hit to be served"),
+        }
+    }
+
+    // A fresh negative is answered without a round trip and without probing disk.
+    #[test]
+    fn fresh_miss_is_served_without_probe() {
+        let key = b"action-key".to_vec();
+        let resolved = resolved_with(vec![(key.clone(), Resolution::Miss(Instant::now()))]);
+
+        let decision = fast_path(
+            &resolved,
+            &key,
+            |_| panic!("a Miss must not probe the value object"),
+            || panic!("a Miss must not invalidate"),
+        );
+
+        assert!(matches!(decision, FastPath::Miss));
+    }
+
+    // A miss older than NEGATIVE_TTL falls through to a full resolve so a key
+    // published later (by another machine) can still land.
+    #[test]
+    fn stale_miss_falls_through_to_resolve() {
+        let key = b"action-key".to_vec();
+        let stale = Instant::now() - NEGATIVE_TTL - Duration::from_secs(1);
+        let resolved = resolved_with(vec![(key.clone(), Resolution::Miss(stale))]);
+
+        let decision = fast_path(
+            &resolved,
+            &key,
+            |_| panic!("a stale Miss must not probe the value object"),
+            || panic!("a stale Miss must not invalidate"),
+        );
+
+        assert!(matches!(decision, FastPath::Resolve));
+    }
+
+    // No cache entry falls through to a full resolve.
+    #[test]
+    fn absent_key_falls_through_to_resolve() {
+        let resolved = resolved_with(vec![]);
+
+        let decision = fast_path(
+            &resolved,
+            b"unknown-key",
+            |_| panic!("an absent key must not probe the value object"),
+            || panic!("an absent key must not invalidate"),
+        );
+
+        assert!(matches!(decision, FastPath::Resolve));
+    }
 }

--- a/cas-plugin/src/proxy.rs
+++ b/cas-plugin/src/proxy.rs
@@ -43,6 +43,14 @@ const MAX_PUBLISH_CACHE: usize = 500_000;
 /// resolve past this window rather than requiring a proxy restart.
 const NEGATIVE_TTL: Duration = Duration::from_secs(60);
 
+/// How long a path may go without a request before its in-memory caches are
+/// reclaimed by the maintenance loop. Well beyond a build's internal pauses
+/// (planning gaps, incremental rebuilds), so an actively-built project is never
+/// reclaimed mid-work; a reclaimed path just re-warms from the remote on its
+/// next build. Bounds the RAM a long-lived proxy holds for projects nobody is
+/// building, which the size caps alone never release.
+const IDLE_RECLAIM: Duration = Duration::from_secs(30 * 60);
+
 /// A cached resolve outcome for a key.
 enum Resolution {
     /// A value digest, kept indefinitely (content-addressed, always valid).
@@ -93,6 +101,13 @@ fn fast_path(
     }
 }
 
+/// Whether a path's in-memory caches should be reclaimed: its on-disk CAS is
+/// gone (deleted project/worktree — it never comes back) or it has been idle
+/// past IDLE_RECLAIM. Pure so the policy is unit-testable.
+fn should_reclaim(idle: Duration, cas_dir_gone: bool) -> bool {
+    cas_dir_gone || idle > IDLE_RECLAIM
+}
+
 /// Per-local-CAS-path state. Leaked for 'static lifetime: the proxy runs
 /// until killed.
 pub struct PathState {
@@ -113,6 +128,10 @@ pub struct PathState {
     // warm build) from every connection thread.
     known_local: [Mutex<HashSet<Vec<u8>>>; 32],
     publish_cache: Mutex<HashMap<Vec<u8>, (reapi::Digest, Vec<Vec<u8>>)>>,
+    // Millis since Proxy.epoch of the last request that touched this path, for
+    // idle reclamation. Bumped once per resolve/publish (per action key, not per
+    // node), so the maintenance loop can free caches of projects nobody builds.
+    last_used: AtomicU64,
     pub stats_resolves: AtomicU64,
     pub stats_remote_hits: AtomicU64,
     pub stats_misses: AtomicU64,
@@ -156,6 +175,8 @@ pub struct Proxy {
     grpc_url: String,
     tokens: Arc<TokenProvider>,
     upstream_plugin: String,
+    // Monotonic base for per-path last-used timestamps (see PathState.last_used).
+    epoch: Instant,
     // One REAPI client per account/project instance, created on first use.
     // All share the machine's endpoint + token; only the instance the request
     // is scoped to differs. This is what lets one proxy serve every project.
@@ -185,6 +206,7 @@ impl Proxy {
             grpc_url,
             tokens,
             upstream_plugin,
+            epoch: Instant::now(),
             remotes: Mutex::new(HashMap::new()),
             path_instance: Mutex::new(path_instance),
             registry_path,
@@ -270,6 +292,7 @@ impl Proxy {
             inflight_cvar: Condvar::new(),
             known_local: std::array::from_fn(|_| Mutex::new(HashSet::new())),
             publish_cache: Mutex::new(HashMap::new()),
+            last_used: AtomicU64::new(self.epoch.elapsed().as_millis() as u64),
             stats_resolves: AtomicU64::new(0),
             stats_remote_hits: AtomicU64::new(0),
             stats_misses: AtomicU64::new(0),
@@ -297,6 +320,9 @@ impl Proxy {
         key: &[u8],
     ) -> Result<Option<Vec<u8>>, String> {
         state.stats_resolves.fetch_add(1, Ordering::Relaxed);
+        state
+            .last_used
+            .store(self.epoch.elapsed().as_millis() as u64, Ordering::Relaxed);
         // Fast path, outside single-flight so the presence load never
         // serializes other keys: serve a cached Hit only after confirming its
         // value object is still on disk. A long-lived proxy keeps Hits in memory
@@ -526,6 +552,9 @@ impl Proxy {
         let record_path = String::from_utf8_lossy(record_path).into_owned();
         let remote = self.remote_for(&instance);
         let Ok(state) = self.path_state(&cas_path) else { return };
+        state
+            .last_used
+            .store(self.epoch.elapsed().as_millis() as u64, Ordering::Relaxed);
         let Ok(bytes) = std::fs::read(&record_path) else { return };
         let Some(record) =
             PublishRecord::decode_body(&bytes, Some(std::path::PathBuf::from(&record_path)))
@@ -661,6 +690,35 @@ impl Proxy {
                 if shard.lock().unwrap().len() > MAX_KNOWN_LOCAL_PER_SHARD {
                     shard.lock().unwrap().clear();
                 }
+            }
+        }
+    }
+
+    /// Reclaims the in-memory caches (resolved map, known-local shards, publish
+    /// cache) of paths whose on-disk CAS is gone or that have been idle past
+    /// IDLE_RECLAIM. Called from the maintenance loop; complements
+    /// `enforce_cache_bounds`, which only releases memory when a single build
+    /// overruns a size cap and never for projects that simply stop being built.
+    ///
+    /// The PathState shell (llcas handle + now-empty maps, ~KB) is retained: a
+    /// later build at the same path finds it and re-warms from the remote. These
+    /// caches are correctness-preserving, so clearing only forces re-work.
+    pub fn reclaim_idle(&self) {
+        let now = self.epoch.elapsed();
+        let paths: Vec<(String, &'static PathState)> = self
+            .paths
+            .lock()
+            .unwrap()
+            .iter()
+            .map(|(cas_path, state)| (cas_path.clone(), *state))
+            .collect();
+        for (cas_path, state) in paths {
+            let last = Duration::from_millis(state.last_used.load(Ordering::Relaxed));
+            let idle = now.saturating_sub(last);
+            let cas_dir_gone = std::fs::symlink_metadata(&cas_path).is_err();
+            if should_reclaim(idle, cas_dir_gone) {
+                state.invalidate();
+                state.publish_cache.lock().unwrap().clear();
             }
         }
     }
@@ -1009,5 +1067,26 @@ mod tests {
         );
 
         assert!(matches!(decision, FastPath::Resolve));
+    }
+
+    // A present path idle less than IDLE_RECLAIM is kept.
+    #[test]
+    fn active_path_is_not_reclaimed() {
+        assert!(!should_reclaim(Duration::from_secs(0), false));
+        assert!(!should_reclaim(IDLE_RECLAIM - Duration::from_secs(1), false));
+    }
+
+    // A present path idle past IDLE_RECLAIM is reclaimed.
+    #[test]
+    fn long_idle_path_is_reclaimed() {
+        assert!(should_reclaim(IDLE_RECLAIM + Duration::from_secs(1), false));
+    }
+
+    // A path whose on-disk CAS is gone is reclaimed immediately, however recently
+    // it was used (a deleted project/worktree never comes back).
+    #[test]
+    fn gone_cas_dir_is_reclaimed_regardless_of_idle() {
+        assert!(should_reclaim(Duration::from_secs(0), true));
+        assert!(should_reclaim(IDLE_RECLAIM + Duration::from_secs(1), true));
     }
 }

--- a/cas-plugin/src/proxy.rs
+++ b/cas-plugin/src/proxy.rs
@@ -9,11 +9,12 @@
 //! before answering a resolve, so consumers' demand loads are local hits.
 
 use std::collections::{HashMap, HashSet, VecDeque};
+use std::os::unix::fs::MetadataExt;
 use std::os::unix::net::{UnixListener, UnixStream};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Condvar, Mutex};
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, UNIX_EPOCH};
 
 use crate::proxy_proto::{
     read_request, write_response, Request, OP_PUBLISH, OP_RESOLVE, STATUS_ERROR, STATUS_HIT,
@@ -108,11 +109,52 @@ fn should_reclaim(idle: Duration, cas_dir_gone: bool) -> bool {
     cas_dir_gone || idle > IDLE_RECLAIM
 }
 
+/// A cheap identity for the on-disk CAS directory. When it changes, the
+/// directory was deleted and recreated (`xcodebuild clean` / a deleted
+/// DerivedData) under this long-lived proxy, so the in-memory `known_local` and
+/// `resolved` marks now describe a store that no longer exists on disk.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+struct CasGeneration {
+    ino: u64,
+    // Birth time in nanos since the Unix epoch; 0 when the platform can't report
+    // it. Guards the (very unlikely) inode reuse when a directory is recreated.
+    birth_nanos: u128,
+}
+
+/// The CAS directory's current generation, or `None` if it does not exist
+/// (deleted and not yet recreated).
+fn cas_generation(cas_path: &str) -> Option<CasGeneration> {
+    let meta = std::fs::metadata(cas_path).ok()?;
+    let birth_nanos = meta
+        .created()
+        .ok()
+        .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    Some(CasGeneration { ino: meta.ino(), birth_nanos })
+}
+
+/// Whether the CAS directory changed identity between two observations, i.e. it
+/// was recreated (a wipe). A `None` current generation (the directory is gone)
+/// is not a change: a resolve can't run against a missing store anyway, and
+/// `reclaim_idle` drops such a path's marks; a `None` stored generation is the
+/// first observation. Pure so the wipe policy is unit-testable.
+fn generation_changed(stored: Option<CasGeneration>, current: Option<CasGeneration>) -> bool {
+    matches!((stored, current), (Some(prev), Some(now)) if prev != now)
+}
+
 /// Per-local-CAS-path state. Leaked for 'static lifetime: the proxy runs
 /// until killed.
 pub struct PathState {
     up: &'static Upstream,
     cas: llcas_cas_t,
+    // The on-disk CAS directory this state wraps, kept so a resolve can restat
+    // it for wipe detection (see `generation`).
+    cas_path: String,
+    // Identity of the CAS directory as last observed by a resolve. A change means
+    // the store was deleted and recreated under this long-lived proxy, so the
+    // in-memory marks below are stale and must be dropped before they are trusted.
+    generation: Mutex<Option<CasGeneration>>,
     // key digest -> resolved outcome. A local publish updates its entry, so a
     // miss cached during planning turns into a hit once the local build
     // publishes it; misses also carry a timestamp so a key another machine
@@ -287,6 +329,8 @@ impl Proxy {
         let state: &'static PathState = Box::leak(Box::new(PathState {
             up,
             cas,
+            cas_path: cas_path.to_string(),
+            generation: Mutex::new(cas_generation(cas_path)),
             resolved: Mutex::new(HashMap::new()),
             inflight: Mutex::new(HashSet::new()),
             inflight_cvar: Condvar::new(),
@@ -323,6 +367,12 @@ impl Proxy {
         state
             .last_used
             .store(self.epoch.elapsed().as_millis() as u64, Ordering::Relaxed);
+        // Drop stale marks if the on-disk CAS was wiped and recreated. This runs
+        // before the fast path and before resolve_uncached's manifest filter, so
+        // an uncached/changed key or a parallel build can't trust known_local
+        // marks for a store that no longer exists (which would skip re-fetching
+        // wiped nodes and hand back a value whose graph is missing on disk).
+        self.check_generation(state);
         // Fast path, outside single-flight so the presence load never
         // serializes other keys: serve a cached Hit only after confirming its
         // value object is still on disk. A long-lived proxy keeps Hits in memory
@@ -493,6 +543,25 @@ impl Proxy {
             analytics.record_keyvalue(key, "read", op_start.elapsed().as_secs_f64());
         }
         Ok(Some(value))
+    }
+
+    /// Detects a wiped-and-recreated on-disk CAS (a deleted DerivedData under
+    /// this long-lived proxy) from a change in the CAS directory's identity and
+    /// drops the now-stale in-memory marks (`resolved`, `known_local`,
+    /// `publish_cache`) so a resolve re-probes and re-materializes authoritatively.
+    /// Called at the head of every resolve, so it covers uncached/changed keys
+    /// and parallel builds, not only re-requested cached Hits. The generation
+    /// lock is held across the invalidation so a concurrent resolve can't observe
+    /// the new generation as unchanged and filter against `known_local` while it
+    /// is being cleared.
+    fn check_generation(&self, state: &PathState) {
+        let Some(current) = cas_generation(&state.cas_path) else { return };
+        let mut stored = state.generation.lock().unwrap();
+        if generation_changed(*stored, Some(current)) {
+            state.invalidate();
+            state.publish_cache.lock().unwrap().clear();
+        }
+        *stored = Some(current);
     }
 
     fn is_local(&self, state: &PathState, digest: &[u8]) -> bool {
@@ -1088,5 +1157,43 @@ mod tests {
     fn gone_cas_dir_is_reclaimed_regardless_of_idle() {
         assert!(should_reclaim(Duration::from_secs(0), true));
         assert!(should_reclaim(IDLE_RECLAIM + Duration::from_secs(1), true));
+    }
+
+    fn generation(ino: u64, birth_nanos: u128) -> CasGeneration {
+        CasGeneration { ino, birth_nanos }
+    }
+
+    // A recreated CAS directory (a wipe) is a change; a stable one, the first
+    // observation, and a disappeared directory are not.
+    #[test]
+    fn generation_change_is_detected_only_on_recreate() {
+        let g1 = generation(1, 100);
+        let g2 = generation(2, 200);
+        assert!(generation_changed(Some(g1), Some(g2)));
+        assert!(generation_changed(Some(g2), Some(g1)));
+        assert!(!generation_changed(Some(g1), Some(g1)));
+        assert!(!generation_changed(None, Some(g1)), "first observation is not a change");
+        assert!(!generation_changed(Some(g1), None), "a gone dir is left to reclaim_idle");
+    }
+
+    // Deleting and recreating a directory at the same path yields a different
+    // generation, which is the signal check_generation invalidates on. This is
+    // the exact DerivedData-wipe reproduction, at the filesystem layer.
+    #[test]
+    fn recreated_directory_has_a_new_generation() {
+        let dir = std::env::temp_dir().join(format!("cas-generation-{}", std::process::id()));
+        let path = dir.to_string_lossy().into_owned();
+
+        std::fs::create_dir_all(&dir).unwrap();
+        let before = cas_generation(&path);
+
+        std::fs::remove_dir_all(&dir).unwrap();
+        std::fs::create_dir_all(&dir).unwrap();
+        let after = cas_generation(&path);
+
+        let _ = std::fs::remove_dir_all(&dir);
+
+        assert!(before.is_some() && after.is_some());
+        assert_ne!(before, after, "a recreated CAS directory must read as a new generation");
     }
 }

--- a/cas-plugin/src/proxy_proto.rs
+++ b/cas-plugin/src/proxy_proto.rs
@@ -30,6 +30,12 @@ pub const PROTOCOL_VERSION: u8 = 1;
 
 pub const OP_RESOLVE: u8 = 1;
 pub const OP_PUBLISH: u8 = 2;
+/// The on-disk CAS at `cas_path` was pruned/emptied in place (Xcode's size
+/// management calls `llcas_cas_prune_ondisk_data`), removing objects without
+/// recreating the directory. The proxy's directory-identity wipe check can't
+/// see that, so the plugin tells it to drop the path's in-memory known-local /
+/// resolved marks, which would otherwise skip re-fetching the pruned blobs.
+pub const OP_INVALIDATE: u8 = 3;
 
 pub const STATUS_MISS: u8 = 0;
 pub const STATUS_HIT: u8 = 1;
@@ -136,6 +142,30 @@ impl ProxyClient {
             STATUS_HIT => Ok(Resolution::Hit(body)),
             STATUS_MISS => Ok(Resolution::Miss),
             _ => Err(format!("proxy error: {}", String::from_utf8_lossy(&body))),
+        }
+    }
+
+    /// Best-effort notice that the on-disk CAS at `cas_path` was pruned in place,
+    /// so the proxy should drop its in-memory marks for it. No instance is needed
+    /// (invalidation is path-scoped); the proxy no-ops if it holds no state.
+    pub fn invalidate(&self, cas_path: &str) -> Result<(), String> {
+        let mut stream = self.connect().map_err(|e| format!("proxy connect: {e}"))?;
+        write_request(
+            &mut stream,
+            &Request {
+                version: PROTOCOL_VERSION,
+                op: OP_INVALIDATE,
+                cas_path: cas_path.to_string(),
+                instance: String::new(),
+                payload: Vec::new(),
+            },
+        )
+        .map_err(|e| format!("proxy send: {e}"))?;
+        let (status, body) = read_response(&mut stream).map_err(|e| format!("proxy recv: {e}"))?;
+        if status == STATUS_HIT {
+            Ok(())
+        } else {
+            Err(format!("proxy invalidate: {}", String::from_utf8_lossy(&body)))
         }
     }
 


### PR DESCRIPTION
This PR hardens the machine-wide `tuist-cas-proxy`'s in-memory action-cache caches against a wiped on-disk CAS, and bounds the memory the long-lived proxy holds. Three related changes, sharing the `PathState::invalidate()` helper.

---

## 1. Serve a cached hit only if its value object is still on disk

### What / why

The proxy cached resolved Hits in memory (`PathState.resolved`, `Resolution::Hit(value_digest)`) keyed by `cas_path` and returned them **without** checking the value graph's blobs still exist on disk. After a user wiped DerivedData (`xcodebuild clean` or deleting the DD folder) while the long-lived proxy kept running, the next build got stale "hit" answers for objects no longer on disk, and the compiler failed with `CAS error: missing object '<digest>'` at `SwiftExplicitDependencyGeneratePcm`. Reproduced deterministically: build → wipe DD → build against the same proxy → failure; a fresh proxy fixed it, isolating the staleness to the proxy's in-memory maps.

The non-proxy path in `lib.rs` (`actioncache_get_impl`) was already correct because it does an authoritative `llcas_cas_load_object` on every get; the proxy path short-circuited on the in-memory `resolved` map first.

- Extracted `Proxy::load_present()` — an authoritative load that **bypasses** the `known_local` shard cache. `is_local` memoizes a positive result on top of it (unchanged).
- Added an FFI-free `fast_path()` gate (+ `FastPath` enum): serve a Hit only when `load_present` confirms presence; on absence, `invalidate()` and re-resolve.
- Added `PathState::invalidate()` (clears `resolved` + `known_local`).

The presence load runs outside the single-flight lock and after releasing the `resolved` lock, so it never serializes other keys — one root-object load per action key.

## 2. Make wipe detection generation-aware (not hit-only)

### What / why

Change 1 alone was **incomplete** (caught in review): it only guards the cached-Hit serve path. If the first request after a wipe is an **uncached or changed** action key — or a concurrent resolve races ahead — it reaches `resolve_uncached`, whose `is_local` filter short-circuits on the in-memory `known_local` shards with no disk check. Those shards still hold the previous build's ~1.9M digests, so nodes shared with the new key's graph are treated as local, skipped from the fetch set, and never re-materialized. A `Resolution::Hit` is then cached and returned for a graph whose blobs are missing on disk — the original failure, still reachable for changed keys and parallel builds.

Detect the wipe at the **head of every resolve**, before any manifest filtering:
- Stamp each `PathState` with its CAS directory identity (`CasGeneration { ino, birth_nanos }` via `std::fs::metadata`).
- `check_generation()` compares it each resolve; on change (directory deleted and recreated) it invalidates `resolved` + `known_local` + `publish_cache` before the fast path or `resolve_uncached` can trust them.
- The generation lock is held **across** the invalidation, so a concurrent resolve can't observe the new generation as unchanged and filter against `known_local` mid-clear.

One `stat` per resolve (per action key, not per node) — negligible. This covers every entry path (uncached, stale-miss, parallel), not just re-requested Hits. Change 1's per-Hit presence check is kept as a complementary guard for same-generation partial loss (e.g. pruning). Residual, documented: a wipe that empties the CAS *in place* without changing the directory's identity is not caught by the stamp; the per-Hit check still covers re-requested keys in that case.

## 3. Reclaim idle CAS proxy caches to bound memory

### What / why

Reviewing the fix surfaced a memory question: the proxy holds its per-path caches (`resolved`, 32 `known_local` shards, `publish_cache`) for the life of the process. `enforce_cache_bounds` only releases memory when a single build overruns a size cap — never for a project that stops being built — and `PathState` is `Box::leak`ed, so a path is never dropped. A long-lived launchd proxy therefore accumulates a few hundred MB per distinct DerivedData path it has served (dominated by `known_local`'s ~1.9M-digest warm working set), released only by a restart.

Added idle reclamation to the existing 10s maintenance loop:
- Per-path `last_used` (`AtomicU64` millis since a `Proxy.epoch`), bumped once per resolve/publish (per action key, not per node).
- `Proxy::reclaim_idle()` clears a path's caches when idle past `IDLE_RECLAIM` (30 min) **or** its on-disk CAS directory is gone (a deleted project/worktree).
- Decision factored into a pure `should_reclaim(idle, cas_dir_gone)`.

Low-risk tier: reclaims the ~99% of per-path memory in the digest maps while retaining the small `PathState` shell (llcas handle + empty maps, ~KB), so a later build re-warms from the remote. Freeing the shell + handle would require `Box::leak` → `Arc` + `Drop`, deferred until FD/handle accumulation across many paths is observed. `IDLE_RECLAIM` is a hardcoded constant like `NEGATIVE_TTL`, not a new env var.

---

## Impact

- Fixes spurious `CAS error: missing object` build failures after `xcodebuild clean` / DerivedData deletion when a long-lived proxy (`tuist setup cache` launchd agent) is running — for re-requested, changed, and uncached keys, and parallel builds.
- Bounds the proxy's steady-state RAM: projects that stop being built, and deleted DerivedData paths, no longer pin their caches until a restart.
- Warm-hit fast path adds one `stat` + one authoritative root-object load + one relaxed atomic store per action key.

## Validation

- `cargo test --manifest-path cas-plugin/Cargo.toml` — 24 lib tests + 1 integration test pass, including 10 regression tests in `proxy::tests`: wiped-hit, present-hit, fresh-miss, stale-miss, absent-key; the three `should_reclaim` policy cases; `generation_changed` policy; and a filesystem test that a recreated directory reads as a new generation (the DD-wipe reproduction at the FS layer). The correctness decisions are factored into FFI-free `fast_path()`, `should_reclaim()`, and `generation_changed()` so they are unit-testable without a live llcas handle.
- `cargo clippy` on `proxy.rs` and `bin/tuist-cas-proxy.rs` is clean. (Two pre-existing `not_unsafe_ptr_arg_deref` errors in `lib.rs:360-363` under clippy 1.94.0 are unrelated.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Update — review hardening (in-place prune + in-flight race)

Two follow-on gaps raised in review, both closed (test count now 24 → 25 lib):

### In-place prune (`llcas_cas_prune_ondisk_data`)

Xcode calls prune on the shared on-disk CAS to manage size; it removes objects **without recreating the directory**, so the change-2 generation stamp is blind to it and `known_local` keeps marking pruned blobs as local. Added an `OP_INVALIDATE` proxy op: the plugin's prune entry point clears its own `known_local` and tells the proxy to drop that path's `resolved` / `known_local` / `publish_cache`, so a later resolve re-fetches the pruned blobs. (Generation-scoped `known_local` entries alone wouldn't help, since prune doesn't change the directory identity.)

### In-flight resolve race

A resolve that observed the pre-wipe store could finish *after* another thread advanced the generation and cleared the maps, reinserting stale `known_local` / `resolved` entries for the replaced store. Added a monotonic `gen_counter` bumped by every invalidation (wipe or prune): a resolve snapshots it after its wipe check and commits a `known_local` or `resolved` write only if the counter is unchanged, checked **under the same map lock the write takes**. `invalidate()` bumps the counter **before** clearing, so a racing insert either sees the new counter and is skipped or is cleared by the invalidation. A generation change mid-resolve drops the value and returns a miss, re-materialized next resolve.

Residual: a wipe that empties the CAS in place *without* a prune call *and without* recreating the directory is still only caught for re-requested keys by the per-Hit presence check; no such path is known today (clean/delete recreate the directory; size management goes through prune).
