### PR TITLE
perf(kura): promote old-segment artifacts in the background instead of on the read path

### DIFF
--- a/kura/src/app.rs
+++ b/kura/src/app.rs
@@ -197,6 +197,7 @@ async fn run_with_config(
     spawn_multipart_janitor_task(state.clone());
     spawn_tmp_dir_metrics_task(state.clone());
     spawn_geoip_refresh_task(state.clone());
+    spawn_segment_promotion_task(state.clone());
 
     // When the node enrolled on boot, keep its peer certificate fresh in-process
     // so a short leaf does not require a restart.
@@ -451,6 +452,18 @@ async fn shutdown_signal() {
     let terminate = std::future::pending::<()>();
 
     wait_for_shutdown_signal(ctrl_c, terminate).await;
+}
+
+// Drains the store's read-path promotion queue: artifacts served from an
+// Old-generation segment are rewritten into the current segment here instead
+// of inline on the read path (see Store::run_promotion_worker).
+fn spawn_segment_promotion_task(state: Arc<AppState>) {
+    tokio::spawn(
+        async move {
+            state.store.run_promotion_worker().await;
+        }
+        .in_current_span(),
+    );
 }
 
 fn spawn_snapshot_task(state: Arc<AppState>) {

--- a/kura/src/store.rs
+++ b/kura/src/store.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{BTreeMap, HashMap},
+    collections::{BTreeMap, HashMap, HashSet, VecDeque},
     path::{Path, PathBuf},
     pin::Pin,
     sync::{
@@ -18,7 +18,7 @@ use rocksdb::{
 use serde::{Deserialize, Serialize};
 use tokio::{
     io::{AsyncRead, AsyncWriteExt, ReadBuf},
-    sync::Mutex,
+    sync::{Mutex, Notify},
 };
 use uuid::Uuid;
 
@@ -102,8 +102,31 @@ pub struct Store {
     // once) can't each append their own copy to a segment and orphan all but the
     // last. Striped by artifact id so different keys still write concurrently.
     artifact_write_locks: [Mutex<()>; ARTIFACT_WRITE_LOCK_STRIPES],
+    // Artifacts served from an Old-generation segment queue here for background
+    // promotion into the current segment instead of refreshing inline on the
+    // read path: one value-graph read can touch thousands of tiny old
+    // artifacts, and per-read refreshes serialize them all on
+    // `segment_refresh_lock` (measured 3.9ms per 200-byte artifact, turning an
+    // 800KB batch read into 15s). Promotion stays best-effort: a dropped entry
+    // only means the artifact may be reclaimed with its segment later, the same
+    // outcome as the pre-existing memory-pressure skip.
+    promotion_queue: StdMutex<PromotionQueue>,
+    promotion_notify: Notify,
     failpoints: Arc<FailpointSet>,
 }
+
+/// Pending read-path promotions: FIFO order plus a membership set so a hot
+/// old artifact read thousands of times enqueues once.
+#[derive(Default)]
+struct PromotionQueue {
+    order: VecDeque<String>,
+    pending: HashSet<String>,
+}
+
+/// Backstop so an unbounded burst of old-artifact reads cannot grow the
+/// promotion queue without limit; far above what one build's value graphs
+/// enqueue (tens of thousands of artifacts).
+const MAX_PENDING_PROMOTIONS: usize = 262_144;
 
 pub struct StoreSnapshot {
     pub outbox_messages: usize,
@@ -429,6 +452,8 @@ impl Store {
             ),
             multipart_locks: std::array::from_fn(|_| Mutex::new(())),
             artifact_write_locks: std::array::from_fn(|_| Mutex::new(())),
+            promotion_queue: StdMutex::new(PromotionQueue::default()),
+            promotion_notify: Notify::new(),
             failpoints: Arc::new(FailpointSet::default()),
         };
         // `load_segment_state_from_db` needs `&self`, so the store must be fully
@@ -950,7 +975,75 @@ impl Store {
         if self.segment_generation(segment_id)? != Some(SegmentGeneration::Old) {
             return Ok(Some(manifest));
         }
-        self.maybe_refresh_manifest(manifest).await
+        // Serve straight from the Old segment and promote in the background.
+        // Refreshing inline here serialized every reader of old data on
+        // `segment_refresh_lock`, one artifact at a time; serving without the
+        // refresh is already the store's behavior under memory pressure (see
+        // maybe_refresh_manifest), so the only change is when the promotion
+        // happens, not whether serving old data is allowed. The read itself is
+        // safe against a concurrent reclaim: segments are unlinked, never
+        // truncated, so an open handle stays readable, and a lost race simply
+        // degrades that lookup to a miss as before.
+        self.enqueue_promotion(&manifest.artifact_id);
+        Ok(Some(manifest))
+    }
+
+    /// Queues an artifact served from an Old segment for background promotion
+    /// (see [`Store::run_promotion_worker`]). Deduplicated and bounded;
+    /// dropping an entry is safe because promotion is a best-effort keep-alive.
+    fn enqueue_promotion(&self, artifact_id: &str) {
+        {
+            let mut queue = self.promotion_queue.lock().expect("promotion queue lock");
+            if queue.pending.len() >= MAX_PENDING_PROMOTIONS
+                || !queue.pending.insert(artifact_id.to_owned())
+            {
+                return;
+            }
+            queue.order.push_back(artifact_id.to_owned());
+        }
+        self.promotion_notify.notify_one();
+    }
+
+    /// Drains the read-path promotion queue, rewriting each artifact from its
+    /// Old segment into the current one (the same refresh the serving path
+    /// used to run inline). Runs for the life of the process; spawned once at
+    /// boot.
+    pub async fn run_promotion_worker(&self) {
+        loop {
+            let next = {
+                let mut queue = self.promotion_queue.lock().expect("promotion queue lock");
+                match queue.order.pop_front() {
+                    Some(artifact_id) => {
+                        queue.pending.remove(&artifact_id);
+                        Some(artifact_id)
+                    }
+                    None => None,
+                }
+            };
+            let Some(artifact_id) = next else {
+                self.promotion_notify.notified().await;
+                continue;
+            };
+            if let Err(error) = self.promote_artifact(&artifact_id).await {
+                tracing::debug!(artifact_id, error, "segment promotion failed");
+            }
+        }
+    }
+
+    /// Promotes one artifact out of an Old segment, re-validating that the
+    /// manifest still exists and still lives in an Old segment (it may have
+    /// been promoted by a writer, replaced, or reclaimed since it was queued).
+    async fn promote_artifact(&self, artifact_id: &str) -> Result<(), String> {
+        let Some(manifest) = self.manifest(artifact_id)? else {
+            return Ok(());
+        };
+        let Some(segment_id) = manifest.segment_id.as_deref() else {
+            return Ok(());
+        };
+        if self.segment_generation(segment_id)? != Some(SegmentGeneration::Old) {
+            return Ok(());
+        }
+        self.maybe_refresh_manifest(manifest).await.map(|_| ())
     }
 
     async fn maybe_refresh_manifest(
@@ -4249,6 +4342,130 @@ mod tests {
             fetched
         );
         assert_eq!(store.segment_handles.lock().await.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn serving_defers_old_segment_promotion_off_the_read_path() {
+        let (_temp_dir, _config, store) = temp_store();
+
+        let manifest = store
+            .persist_artifact_from_bytes(
+                ArtifactProducer::Xcode,
+                "ios",
+                "artifact-1",
+                "application/octet-stream",
+                b"hello",
+            )
+            .await
+            .expect("failed to persist artifact");
+        let original_segment_id = manifest
+            .segment_id
+            .clone()
+            .expect("segment-backed artifact should have a segment id");
+        store
+            .save_segment_state(&SegmentState {
+                old: vec![SegmentReference::new(original_segment_id.clone(), 1)],
+                current: Vec::new(),
+                new: vec![SegmentReference::new("fresh-segment".into(), 2)],
+            })
+            .expect("failed to seed segment state");
+
+        // The serving path answers straight from the Old segment (no inline
+        // refresh) and queues the artifact for background promotion.
+        let served = store
+            .fetch_artifact_for_serving(ArtifactProducer::Xcode, "ios", "artifact-1")
+            .await
+            .expect("failed to fetch artifact for serving")
+            .expect("artifact should still exist");
+        assert_eq!(served.segment_id, Some(original_segment_id.clone()));
+        assert_eq!(read_manifest_bytes(&store, &served).await, b"hello");
+        {
+            let queue = store.promotion_queue.lock().expect("queue lock");
+            assert_eq!(queue.order.len(), 1);
+            assert!(queue.pending.contains(&served.artifact_id));
+        }
+
+        // A second read of the same artifact does not enqueue it twice.
+        store
+            .fetch_artifact_for_serving(ArtifactProducer::Xcode, "ios", "artifact-1")
+            .await
+            .expect("failed to fetch artifact for serving")
+            .expect("artifact should still exist");
+        assert_eq!(
+            store
+                .promotion_queue
+                .lock()
+                .expect("queue lock")
+                .order
+                .len(),
+            1
+        );
+
+        // Applying the queued promotion rewrites the artifact into the current
+        // segment, exactly like the refresh the read path used to run inline.
+        store
+            .promote_artifact(&served.artifact_id)
+            .await
+            .expect("promotion should succeed");
+        let promoted = store
+            .manifest(&served.artifact_id)
+            .expect("failed to load manifest")
+            .expect("promoted manifest should exist");
+        assert_ne!(promoted.segment_id, Some(original_segment_id));
+        assert_eq!(read_manifest_bytes(&store, &promoted).await, b"hello");
+    }
+
+    #[tokio::test]
+    async fn promotion_worker_drains_reads_queued_from_old_segments() {
+        let (_temp_dir, _config, store) = temp_store();
+        let store = Arc::new(store);
+
+        let manifest = store
+            .persist_artifact_from_bytes(
+                ArtifactProducer::Xcode,
+                "ios",
+                "artifact-1",
+                "application/octet-stream",
+                b"hello",
+            )
+            .await
+            .expect("failed to persist artifact");
+        let original_segment_id = manifest
+            .segment_id
+            .clone()
+            .expect("segment-backed artifact should have a segment id");
+        store
+            .save_segment_state(&SegmentState {
+                old: vec![SegmentReference::new(original_segment_id.clone(), 1)],
+                current: Vec::new(),
+                new: vec![SegmentReference::new("fresh-segment".into(), 2)],
+            })
+            .expect("failed to seed segment state");
+
+        let worker_store = Arc::clone(&store);
+        tokio::spawn(async move { worker_store.run_promotion_worker().await });
+
+        store
+            .fetch_artifact_for_serving(ArtifactProducer::Xcode, "ios", "artifact-1")
+            .await
+            .expect("failed to fetch artifact for serving")
+            .expect("artifact should still exist");
+
+        let promoted = tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                let manifest = store
+                    .manifest(&manifest.artifact_id)
+                    .expect("failed to load manifest")
+                    .expect("manifest should exist");
+                if manifest.segment_id != Some(original_segment_id.clone()) {
+                    return manifest;
+                }
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            }
+        })
+        .await
+        .expect("worker should promote the artifact");
+        assert_eq!(read_manifest_bytes(&store, &promoted).await, b"hello");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What changed

Serving an artifact that lives in an **Old-generation segment** no longer refreshes it inline on the read path. The serving path now answers straight from the Old segment and queues the artifact for a **background promotion worker** (new, spawned at boot alongside the other maintenance tasks), which runs the exact same refresh — re-validating existence and generation first — off the read path. The queue is deduplicated and bounded; dropping an entry is safe because promotion is a best-effort keep-alive (the same outcome as the pre-existing memory-pressure skip). The non-serving `fetch_artifact` path keeps its inline refresh.

## Root cause / why

Every read of an old-segment artifact ran `maybe_refresh_manifest`: a copy of that one artifact into the current segment plus a synchronous RocksDB write, **serialized on the store-global `segment_refresh_lock`, once per artifact**. One Xcode value-graph batch read can touch thousands of tiny old artifacts, so a single `BatchReadBlobs` paid thousands of serialized read+append+fsync cycles — and `batch_read_blobs`' own 16-way read buffering couldn't help, because all readers converge on the same lock.

This is the dominant term in warm Xcode-cache builds from dev machines over WAN against eu-central. Per-resolve instrumentation of a real warm build showed the top 10% of resolves (giant module-scan manifests, 3,500–15,000 entries of ~200-byte blobs) carrying **75% of all fetch time** at ~10.6ms/blob, while the p50 resolve was a healthy 70ms. Isolated probes exonerated everything else first: server reads of *fresh* blobs run at ~0.1ms/blob, concurrency and bandwidth (240 Mbps through kura) are fine — the cost appears exactly when the data has aged into the Old generation, which for a shared node happens within hours.

## Reproduction (local, deterministic)

Fresh local kura, author 4,000 × 200B blobs first, upload filler until the ring ages their segment to Old (`kura_segment_generation_count{generation="old"} 1`), then batch-read them:

| | read 4,000 tiny blobs from Old segment | promotions |
|---|---|---|
| before | **15.7s** (3.9 ms/blob; 0.05s when fresh) | 4,000 inline, `segment_refresh_duration_seconds_sum` = 250s of lock queueing |
| after | **0.2s**, all 4,000 blobs served | 4,000 in background, drained in ~30s |

A post-promotion read stays fast, and `kura_segment_refreshes_total` confirms the keep-alive still happens (4,000 refreshes either way — only *when* changed).

## Rollout safety

- Node-local behavior change only: response bytes/headers unchanged, no wire-format, storage-format, or replication changes; safe under mixed versions.
- Serving old-segment data without an inline refresh is the store's existing behavior under memory pressure (`allow_segment_refresh() == false`), so this generalizes an already-exercised path rather than introducing a new one.
- Reads racing a concurrent segment reclaim are safe as before: segments are unlinked, never truncated, so open handles stay readable, and a lost race degrades that lookup to a miss.
- The worker holds `segment_refresh_lock` per promotion exactly as the read path did, so write-path interactions are unchanged.

## Validation

- New unit tests: serving from an Old segment returns the old-segment manifest and enqueues (deduplicated) promotion; applying the promotion rewrites into the current segment; an end-to-end worker test (spawned worker + notify) promotes a served artifact within the timeout. Existing `fetch_artifact` inline-refresh test unchanged and passing (54 store tests total).
- `mise run clippy` and `mise run format -- --check` pass.
- Live validation on a local node with the shipped REAPI client, exactly the reproduction above, including verifying all 4,000 blobs were actually served (`found=4000/4000`) — an earlier iteration of the harness was invalidated by evicted blobs reading as fast empty responses, so the final numbers assert payload presence.

## Relation to other work

Complements #11719 (one-round-trip value-graph fetch): that PR removes the per-resolve WAN round-trip on the healthy p50 body; this one removes the old-data tail that instrumentation showed was ~75% of warm-build fetch time. Both are needed for warm Xcode-cache builds over WAN to approach the local-CAS floor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
