### PR TITLE
fix(noora): normalize filter operators for Flop

### DIFF
--- a/.github/workflows/noora.yml
+++ b/.github/workflows/noora.yml
@@ -90,12 +90,16 @@ jobs:
       - uses: ./.github/actions/mise-install
         with:
           version: ${{ env.MISE_VERSION }}
-          install: "node aube"
+          install: "erlang elixir node aube"
           cache: "true"
           working-directory: noora
+      - name: Install Elixir dependencies
+        run: mix deps.get
+      - name: Run Elixir tests
+        run: mix test
       - name: Install JS dependencies
         run: aube install
-      - name: Run tests
+      - name: Run JS tests
         run: aube run test
 
   docker_build:

--- a/noora/lib/noora/filter.ex
+++ b/noora/lib/noora/filter.ex
@@ -259,16 +259,19 @@ defmodule Noora.Filter do
           nil -> value
         end
 
-      [%{field: String.to_existing_atom(id), op: operator, value: option_key}]
+      [%{field: String.to_existing_atom(id), op: to_flop_operator(operator), value: option_key}]
     end
 
     def to_flop_filter(%Filter{field: field, operator: operator, value: value}) do
-      [%{field: field, op: operator, value: value}]
+      [%{field: field, op: to_flop_operator(operator), value: value}]
     end
 
     def convert_filters_to_flop(filters) when is_list(filters) do
       Enum.flat_map(filters, &to_flop_filter/1)
     end
+
+    defp to_flop_operator(:"!=~"), do: :not_ilike
+    defp to_flop_operator(operator), do: operator
 
     def encode_filters_to_query(filters) when is_list(filters) do
       Enum.reduce(filters, %{}, fn filter, acc ->

--- a/noora/test/noora/filter_test.exs
+++ b/noora/test/noora/filter_test.exs
@@ -1,0 +1,23 @@
+defmodule Noora.FilterTest do
+  use ExUnit.Case, async: true
+
+  alias Noora.Filter
+  alias Noora.Filter.Operations
+
+  describe "convert_filters_to_flop/1" do
+    test "converts Noora negative text filters into Flop operators" do
+      # When
+      got =
+        Operations.convert_filters_to_flop([
+          %Filter.Filter{id: "module_name", field: :module_name, operator: :"!=~", value: "UITests"},
+          %Filter.Filter{id: "status", field: :status, operator: :==, value: "success"}
+        ])
+
+      # Then
+      assert [
+               %{field: :module_name, op: :not_ilike, value: "UITests"},
+               %{field: :status, op: :==, value: "success"}
+             ] = got
+    end
+  end
+end

--- a/noora/test/test_helper.exs
+++ b/noora/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()

--- a/server/lib/tuist_web/live/cache_runs_live.ex
+++ b/server/lib/tuist_web/live/cache_runs_live.ex
@@ -284,7 +284,6 @@ defmodule TuistWeb.CacheRunsLive do
     flop_filters =
       filters
       |> Enum.map(&normalize_command_filter/1)
-      |> Enum.map(&normalize_text_filter_operator/1)
       |> Filter.Operations.convert_filters_to_flop()
 
     ran_by_flop_filters =
@@ -313,10 +312,6 @@ defmodule TuistWeb.CacheRunsLive do
   end
 
   defp normalize_command_filter(filter), do: filter
-
-  defp normalize_text_filter_operator(%Filter.Filter{operator: :"!=~"} = filter), do: %{filter | operator: :not_ilike}
-
-  defp normalize_text_filter_operator(filter), do: filter
 
   def column_patch_sort(
         %{uri: uri, cache_runs_sort_by: cache_runs_sort_by, cache_runs_sort_order: cache_runs_sort_order} = _assigns,

--- a/server/lib/tuist_web/live/generate_runs_live.ex
+++ b/server/lib/tuist_web/live/generate_runs_live.ex
@@ -197,7 +197,6 @@ defmodule TuistWeb.GenerateRunsLive do
     flop_filters =
       filters
       |> Enum.map(&normalize_command_filter/1)
-      |> Enum.map(&normalize_text_filter_operator/1)
       |> Filter.Operations.convert_filters_to_flop()
 
     ran_by_flop_filters =
@@ -220,10 +219,6 @@ defmodule TuistWeb.GenerateRunsLive do
 
     flop_filters ++ ran_by_flop_filters
   end
-
-  defp normalize_text_filter_operator(%Filter.Filter{operator: :"!=~"} = filter), do: %{filter | operator: :not_ilike}
-
-  defp normalize_text_filter_operator(filter), do: filter
 
   defp normalize_command_filter(%Filter.Filter{id: "name", value: value} = filter) when is_binary(value) do
     %{filter | value: normalize_command_filter_value(value)}

--- a/server/lib/tuist_web/live/gradle_build_runs_live.ex
+++ b/server/lib/tuist_web/live/gradle_build_runs_live.ex
@@ -111,10 +111,7 @@ defmodule TuistWeb.GradleBuildRunsLive do
     {is_ci_filters, remaining_filters} = Enum.split_with(remaining_filters, &(&1.id == "is_ci"))
     {requested_tasks_filters, remaining_filters} = Enum.split_with(remaining_filters, &(&1.id == "requested_tasks"))
 
-    filter_flop_filters =
-      remaining_filters
-      |> Enum.map(&normalize_text_filter_operator/1)
-      |> Filter.Operations.convert_filters_to_flop()
+    filter_flop_filters = Filter.Operations.convert_filters_to_flop(remaining_filters)
 
     ran_by_flop_filters =
       Enum.flat_map(ran_by_filters, fn
@@ -191,10 +188,6 @@ defmodule TuistWeb.GradleBuildRunsLive do
     |> assign(:build_runs_page, meta.current_page)
     |> assign(:build_runs_page_count, meta.total_pages)
   end
-
-  defp normalize_text_filter_operator(%Filter.Filter{operator: :"!=~"} = filter), do: %{filter | operator: :not_ilike}
-
-  defp normalize_text_filter_operator(filter), do: filter
 
   def column_patch_sort(
         %{uri: uri, build_runs_sort_by: build_runs_sort_by, build_runs_sort_order: build_runs_sort_order},

--- a/server/lib/tuist_web/live/test_runs_live.ex
+++ b/server/lib/tuist_web/live/test_runs_live.ex
@@ -415,10 +415,7 @@ defmodule TuistWeb.TestRunsLive do
   defp build_flop_filters(filters, search) do
     {ran_by, filters} = Enum.split_with(filters, &(&1.id == "ran_by"))
 
-    flop_filters =
-      filters
-      |> Enum.map(&normalize_text_filter_operator/1)
-      |> Filter.Operations.convert_filters_to_flop()
+    flop_filters = Filter.Operations.convert_filters_to_flop(filters)
 
     ran_by_flop_filters =
       Enum.flat_map(ran_by, fn
@@ -451,8 +448,4 @@ defmodule TuistWeb.TestRunsLive do
   defp page_level_environment_filters(%{analytics_environment: "ci"}), do: [%{field: :is_ci, op: :==, value: true}]
   defp page_level_environment_filters(%{analytics_environment: "local"}), do: [%{field: :is_ci, op: :==, value: false}]
   defp page_level_environment_filters(_), do: []
-
-  defp normalize_text_filter_operator(%Filter.Filter{operator: :"!=~"} = filter), do: %{filter | operator: :not_ilike}
-
-  defp normalize_text_filter_operator(filter), do: filter
 end

--- a/server/lib/tuist_web/live/xcode_build_runs_live.ex
+++ b/server/lib/tuist_web/live/xcode_build_runs_live.ex
@@ -168,10 +168,7 @@ defmodule TuistWeb.XcodeBuildRunsLive do
     {ran_by, filters} = Enum.split_with(filters, &(&1.id == "ran_by"))
     {tags_filters, filters} = Enum.split_with(filters, &(&1.id == "custom_tags"))
 
-    flop_filters =
-      filters
-      |> Enum.map(&normalize_text_filter_operator/1)
-      |> Filter.Operations.convert_filters_to_flop()
+    flop_filters = Filter.Operations.convert_filters_to_flop(filters)
 
     ran_by_flop_filters =
       Enum.flat_map(ran_by, fn
@@ -203,10 +200,6 @@ defmodule TuistWeb.XcodeBuildRunsLive do
 
     flop_filters ++ ran_by_flop_filters ++ tag_flop_filters
   end
-
-  defp normalize_text_filter_operator(%Filter.Filter{operator: :"!=~"} = filter), do: %{filter | operator: :not_ilike}
-
-  defp normalize_text_filter_operator(filter), do: filter
 
   defp define_filters(project, schemes, configurations, tags) do
     base = [

--- a/server/priv/gettext/dashboard_builds.pot
+++ b/server/priv/gettext/dashboard_builds.pot
@@ -70,9 +70,9 @@ msgstr ""
 msgid "Avg. latency writing cache keys"
 msgstr ""
 
-#: lib/tuist_web/live/generate_runs_live.ex:293
+#: lib/tuist_web/live/generate_runs_live.ex:288
 #: lib/tuist_web/live/generate_runs_live.html.heex:84
-#: lib/tuist_web/live/xcode_build_runs_live.ex:252
+#: lib/tuist_web/live/xcode_build_runs_live.ex:245
 #: lib/tuist_web/live/xcode_build_runs_live.html.heex:121
 #, elixir-autogen, elixir-format
 msgid "Branch"
@@ -273,7 +273,7 @@ msgid "Cacheable tasks:"
 msgstr ""
 
 #: lib/tuist_web/live/build_run_live.html.heex:296
-#: lib/tuist_web/live/xcode_build_runs_live.ex:260
+#: lib/tuist_web/live/xcode_build_runs_live.ex:253
 #: lib/tuist_web/live/xcode_build_runs_live.html.heex:151
 #: lib/tuist_web/live/xcode_builds_live.ex:440
 #: lib/tuist_web/live/xcode_builds_live.html.heex:357
@@ -282,14 +282,14 @@ msgstr ""
 msgid "Category"
 msgstr ""
 
-#: lib/tuist_web/live/xcode_build_runs_live.ex:265
+#: lib/tuist_web/live/xcode_build_runs_live.ex:258
 #: lib/tuist_web/live/xcode_builds_live.html.heex:105
 #, elixir-autogen, elixir-format
 msgid "Clean"
 msgstr ""
 
 #: lib/tuist_web/live/build_run_live.html.heex:219
-#: lib/tuist_web/live/generate_runs_live.ex:272
+#: lib/tuist_web/live/generate_runs_live.ex:267
 #: lib/tuist_web/live/generate_runs_live.html.heex:58
 #: lib/tuist_web/live/run_detail_live.html.heex:115
 #, elixir-autogen, elixir-format
@@ -328,7 +328,7 @@ msgid "Compressed Size (MB)"
 msgstr ""
 
 #: lib/tuist_web/live/build_run_live.html.heex:234
-#: lib/tuist_web/live/xcode_build_runs_live.ex:227
+#: lib/tuist_web/live/xcode_build_runs_live.ex:220
 #: lib/tuist_web/live/xcode_build_runs_live.html.heex:91
 #, elixir-autogen, elixir-format
 msgid "Configuration"
@@ -454,10 +454,10 @@ msgstr ""
 #: lib/tuist_web/live/build_run_live.ex:968
 #: lib/tuist_web/live/build_run_live.html.heex:255
 #: lib/tuist_web/live/build_run_live.html.heex:591
-#: lib/tuist_web/live/generate_runs_live.ex:285
+#: lib/tuist_web/live/generate_runs_live.ex:280
 #: lib/tuist_web/live/generate_runs_live.html.heex:81
 #: lib/tuist_web/live/run_detail_live.html.heex:144
-#: lib/tuist_web/live/xcode_build_runs_live.ex:242
+#: lib/tuist_web/live/xcode_build_runs_live.ex:235
 #: lib/tuist_web/live/xcode_build_runs_live.html.heex:107
 #: lib/tuist_web/live/xcode_builds_live.ex:451
 #: lib/tuist_web/live/xcode_builds_live.html.heex:884
@@ -610,13 +610,13 @@ msgid "Hit"
 msgstr ""
 
 #: lib/tuist_web/live/build_run_live.html.heex:883
-#: lib/tuist_web/live/generate_runs_live.ex:301
+#: lib/tuist_web/live/generate_runs_live.ex:296
 #: lib/tuist_web/live/generate_runs_live.html.heex:61
 #, elixir-autogen, elixir-format
 msgid "Hit rate"
 msgstr ""
 
-#: lib/tuist_web/live/xcode_build_runs_live.ex:264
+#: lib/tuist_web/live/xcode_build_runs_live.ex:257
 #: lib/tuist_web/live/xcode_builds_live.html.heex:97
 #, elixir-autogen, elixir-format
 msgid "Incremental"
@@ -765,10 +765,10 @@ msgstr ""
 #: lib/tuist_web/live/build_run_live.ex:967
 #: lib/tuist_web/live/build_run_live.html.heex:248
 #: lib/tuist_web/live/build_run_live.html.heex:586
-#: lib/tuist_web/live/generate_runs_live.ex:284
+#: lib/tuist_web/live/generate_runs_live.ex:279
 #: lib/tuist_web/live/generate_runs_live.html.heex:79
 #: lib/tuist_web/live/run_detail_live.html.heex:137
-#: lib/tuist_web/live/xcode_build_runs_live.ex:241
+#: lib/tuist_web/live/xcode_build_runs_live.ex:234
 #: lib/tuist_web/live/xcode_build_runs_live.html.heex:102
 #: lib/tuist_web/live/xcode_builds_live.ex:450
 #: lib/tuist_web/live/xcode_builds_live.html.heex:879
@@ -815,10 +815,10 @@ msgstr ""
 msgid "Ran at"
 msgstr ""
 
-#: lib/tuist_web/live/generate_runs_live.ex:328
+#: lib/tuist_web/live/generate_runs_live.ex:323
 #: lib/tuist_web/live/generate_runs_live.html.heex:87
 #: lib/tuist_web/live/run_detail_live.html.heex:152
-#: lib/tuist_web/live/xcode_build_runs_live.ex:320
+#: lib/tuist_web/live/xcode_build_runs_live.ex:313
 #: lib/tuist_web/live/xcode_build_runs_live.html.heex:130
 #: lib/tuist_web/live/xcode_builds_live.html.heex:896
 #, elixir-autogen, elixir-format
@@ -858,7 +858,7 @@ msgstr ""
 msgid "Run duration"
 msgstr ""
 
-#: lib/tuist_web/live/xcode_build_runs_live.ex:216
+#: lib/tuist_web/live/xcode_build_runs_live.ex:209
 #: lib/tuist_web/live/xcode_build_runs_live.html.heex:58
 #: lib/tuist_web/live/xcode_builds_live.ex:437
 #: lib/tuist_web/live/xcode_builds_live.html.heex:355
@@ -923,9 +923,9 @@ msgstr ""
 #: lib/tuist_web/live/build_run_live.ex:1109
 #: lib/tuist_web/live/build_run_live.html.heex:245
 #: lib/tuist_web/live/build_run_live.html.heex:1557
-#: lib/tuist_web/live/generate_runs_live.ex:280
+#: lib/tuist_web/live/generate_runs_live.ex:275
 #: lib/tuist_web/live/run_detail_live.html.heex:134
-#: lib/tuist_web/live/xcode_build_runs_live.ex:237
+#: lib/tuist_web/live/xcode_build_runs_live.ex:230
 #: lib/tuist_web/live/xcode_builds_live.ex:438
 #, elixir-autogen, elixir-format
 msgid "Status"
@@ -1238,7 +1238,7 @@ msgid "Xcode Cache"
 msgstr ""
 
 #: lib/tuist_web/live/build_run_live.html.heex:318
-#: lib/tuist_web/live/xcode_build_runs_live.ex:273
+#: lib/tuist_web/live/xcode_build_runs_live.ex:266
 #: lib/tuist_web/live/xcode_build_runs_live.html.heex:171
 #: lib/tuist_web/live/xcode_builds_live.ex:393
 #: lib/tuist_web/live/xcode_builds_live.html.heex:631
@@ -1249,7 +1249,7 @@ msgstr ""
 
 #: lib/tuist_web/live/build_run_live.html.heex:324
 #: lib/tuist_web/live/run_detail_live.html.heex:202
-#: lib/tuist_web/live/xcode_build_runs_live.ex:281
+#: lib/tuist_web/live/xcode_build_runs_live.ex:274
 #: lib/tuist_web/live/xcode_build_runs_live.html.heex:179
 #: lib/tuist_web/live/xcode_builds_live.ex:394
 #: lib/tuist_web/live/xcode_builds_live.html.heex:649
@@ -1385,7 +1385,7 @@ msgstr ""
 msgid "since yesterday"
 msgstr ""
 
-#: lib/tuist_web/live/generate_runs_live.ex:309
+#: lib/tuist_web/live/generate_runs_live.ex:304
 #: lib/tuist_web/live/run_detail_live.html.heex:125
 #, elixir-autogen, elixir-format
 msgid "Cache Endpoint"
@@ -1412,7 +1412,7 @@ msgstr ""
 msgid "Tag:"
 msgstr ""
 
-#: lib/tuist_web/live/xcode_build_runs_live.ex:296
+#: lib/tuist_web/live/xcode_build_runs_live.ex:289
 #, elixir-autogen, elixir-format
 msgid "Tags"
 msgstr ""
@@ -1434,14 +1434,14 @@ msgid "Download build"
 msgstr ""
 
 #: lib/tuist_web/live/build_run_live.html.heex:262
-#: lib/tuist_web/live/xcode_build_runs_live.ex:244
+#: lib/tuist_web/live/xcode_build_runs_live.ex:237
 #: lib/tuist_web/live/xcode_build_runs_live.html.heex:117
 #, elixir-autogen, elixir-format
 msgid "Failed processing"
 msgstr ""
 
 #: lib/tuist_web/live/build_run_live.html.heex:268
-#: lib/tuist_web/live/xcode_build_runs_live.ex:243
+#: lib/tuist_web/live/xcode_build_runs_live.ex:236
 #: lib/tuist_web/live/xcode_build_runs_live.html.heex:112
 #, elixir-autogen, elixir-format
 msgid "Processing"

--- a/server/priv/gettext/dashboard_gradle.pot
+++ b/server/priv/gettext/dashboard_gradle.pot
@@ -62,7 +62,7 @@ msgid "Avg. cache hit rate"
 msgstr ""
 
 #: lib/tuist_web/live/gradle_build_live.html.heex:134
-#: lib/tuist_web/live/gradle_build_runs_live.ex:239
+#: lib/tuist_web/live/gradle_build_runs_live.ex:232
 #: lib/tuist_web/live/gradle_build_runs_live.html.heex:89
 #, elixir-autogen, elixir-format
 msgid "Branch"
@@ -79,7 +79,7 @@ msgstr ""
 msgid "Build not found."
 msgstr ""
 
-#: lib/tuist_web/live/gradle_build_runs_live.ex:259
+#: lib/tuist_web/live/gradle_build_runs_live.ex:252
 #: lib/tuist_web/live/gradle_builds_live.ex:177
 #: lib/tuist_web/live/gradle_builds_live.html.heex:26
 #: lib/tuist_web/live/gradle_cache_live.ex:208
@@ -158,7 +158,7 @@ msgid "Cancel"
 msgstr ""
 
 #: lib/tuist_web/live/gradle_build_live.html.heex:100
-#: lib/tuist_web/live/gradle_build_runs_live.ex:231
+#: lib/tuist_web/live/gradle_build_runs_live.ex:224
 #: lib/tuist_web/live/gradle_build_runs_live.html.heex:85
 #: lib/tuist_web/live/gradle_builds_live.html.heex:702
 #, elixir-autogen, elixir-format
@@ -202,7 +202,7 @@ msgstr ""
 
 #: lib/tuist_web/live/gradle_build_live.ex:246
 #: lib/tuist_web/live/gradle_build_live.ex:329
-#: lib/tuist_web/live/gradle_build_runs_live.ex:230
+#: lib/tuist_web/live/gradle_build_runs_live.ex:223
 #: lib/tuist_web/live/gradle_build_runs_live.html.heex:80
 #: lib/tuist_web/live/gradle_builds_live.html.heex:697
 #, elixir-autogen, elixir-format
@@ -358,7 +358,7 @@ msgstr ""
 #: lib/tuist_web/live/gradle_build_live.ex:282
 #: lib/tuist_web/live/gradle_build_live.html.heex:83
 #: lib/tuist_web/live/gradle_build_live.html.heex:593
-#: lib/tuist_web/live/gradle_build_runs_live.ex:225
+#: lib/tuist_web/live/gradle_build_runs_live.ex:218
 #: lib/tuist_web/live/gradle_build_runs_live.html.heex:72
 #, elixir-autogen, elixir-format
 msgid "Status"
@@ -481,7 +481,7 @@ msgstr ""
 #: lib/tuist_web/live/gradle_build_live.ex:286
 #: lib/tuist_web/live/gradle_build_live.html.heex:439
 #: lib/tuist_web/live/gradle_build_live.html.heex:596
-#: lib/tuist_web/live/gradle_build_runs_live.ex:260
+#: lib/tuist_web/live/gradle_build_runs_live.ex:253
 #: lib/tuist_web/live/gradle_builds_live.ex:176
 #: lib/tuist_web/live/gradle_builds_live.html.heex:18
 #: lib/tuist_web/live/gradle_cache_live.ex:207
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Configuration Insights"
 msgstr ""
 
-#: lib/tuist_web/live/gradle_build_runs_live.ex:255
+#: lib/tuist_web/live/gradle_build_runs_live.ex:248
 #: lib/tuist_web/live/gradle_cache_live.ex:234
 #: lib/tuist_web/live/gradle_cache_live.html.heex:296
 #, elixir-autogen, elixir-format
@@ -755,14 +755,14 @@ msgstr ""
 msgid "Failed builds"
 msgstr ""
 
-#: lib/tuist_web/live/gradle_build_runs_live.ex:268
+#: lib/tuist_web/live/gradle_build_runs_live.ex:261
 #: lib/tuist_web/live/gradle_builds_live.ex:241
 #: lib/tuist_web/live/gradle_builds_live.html.heex:480
 #, elixir-autogen, elixir-format
 msgid "Gradle version"
 msgstr ""
 
-#: lib/tuist_web/live/gradle_build_runs_live.ex:276
+#: lib/tuist_web/live/gradle_build_runs_live.ex:269
 #: lib/tuist_web/live/gradle_builds_live.ex:240
 #: lib/tuist_web/live/gradle_builds_live.html.heex:490
 #, elixir-autogen, elixir-format
@@ -789,7 +789,7 @@ msgstr ""
 msgid "No recent builds yet"
 msgstr ""
 
-#: lib/tuist_web/live/gradle_build_runs_live.ex:229
+#: lib/tuist_web/live/gradle_build_runs_live.ex:222
 #: lib/tuist_web/live/gradle_build_runs_live.html.heex:75
 #: lib/tuist_web/live/gradle_builds_live.html.heex:692
 #, elixir-autogen, elixir-format
@@ -900,7 +900,7 @@ msgid "Tests"
 msgstr ""
 
 #: lib/tuist_web/live/gradle_build_live.html.heex:147
-#: lib/tuist_web/live/gradle_build_runs_live.ex:247
+#: lib/tuist_web/live/gradle_build_runs_live.ex:240
 #: lib/tuist_web/live/gradle_build_runs_live.html.heex:98
 #, elixir-autogen, elixir-format
 msgid "Requested tasks"
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Machine Metrics"
 msgstr ""
 
-#: lib/tuist_web/live/gradle_build_runs_live.ex:293
+#: lib/tuist_web/live/gradle_build_runs_live.ex:286
 #, elixir-autogen, elixir-format
 msgid "Ran by"
 msgstr ""

--- a/server/test/tuist_web/live/test_cases_live_test.exs
+++ b/server/test/tuist_web/live/test_cases_live_test.exs
@@ -92,6 +92,62 @@ defmodule TuistWeb.TestCasesLiveTest do
       assert has_element?(lv, "[data-part='test-cases-table']")
     end
 
+    test "filters test cases whose module does not contain a substring", %{
+      conn: conn,
+      organization: organization,
+      project: project
+    } do
+      {:ok, _test_run} =
+        RunsFixtures.test_fixture(
+          project_id: project.id,
+          account_id: organization.account.id,
+          ran_at: NaiveDateTime.add(NaiveDateTime.utc_now(), -60),
+          test_modules: [
+            %{
+              name: "ArgonUITests",
+              status: "success",
+              duration: 100,
+              test_cases: [
+                %{
+                  name: "testQueued",
+                  test_suite_name: "QueueSuite",
+                  status: "success",
+                  duration: 100
+                }
+              ]
+            },
+            %{
+              name: "AppTests",
+              status: "success",
+              duration: 100,
+              test_cases: [
+                %{
+                  name: "testRegular",
+                  test_suite_name: "RegularSuite",
+                  status: "success",
+                  duration: 100
+                }
+              ]
+            }
+          ]
+        )
+
+      query =
+        URI.encode_query(%{
+          "filter_module_name_op" => "!=~",
+          "filter_module_name_val" => "ArgonUITests"
+        })
+
+      {:ok, lv, html} =
+        live(conn, "/#{organization.account.name}/#{project.name}/tests/test-cases?#{query}")
+
+      render_async(lv)
+
+      assert html =~ "does not contain"
+      assert has_element?(lv, "[data-part='test-cases-table']", "AppTests")
+      refute has_element?(lv, "[data-part='test-cases-table']", "ArgonUITests")
+    end
+
     test "shows analytics widgets", %{
       conn: conn,
       organization: organization,


### PR DESCRIPTION
## Motivation

The Test Cases LiveView could crash when loading a filter URL that used Noora's "does not contain" text operator. The params reached Flop as `:"!=~"`, which Flop rejects, raising `Flop.InvalidParamsError` before the page can render results.

The better boundary for this translation is Noora's Flop adapter itself. `convert_filters_to_flop/1` is already the place where Noora filter structs become Flop filter maps, so callers should not need to remember an extra normalization step.

## Approach

- Added operator normalization inside `Noora.Filter.Operations.convert_filters_to_flop/1` via the existing `to_flop_filter/1` conversion path.
- Translated Noora's `:"!=~"` operator to Flop's supported `:not_ilike` operator while leaving other operators unchanged.
- Removed the duplicated per-LiveView normalization that previously existed around cache, generate, Gradle, test-run, and Xcode build-run filters.
- Kept the Test Cases page on the normal `decode_filters_from_query/2 |> convert_filters_to_flop/1` path.
- Added a Noora unit test for the conversion behavior and a server LiveView regression test for the failing Test Cases URL-param shape.
- Added `noora/test/test_helper.exs`, which is required so Noora's ExUnit suite can start when CI runs `mix test` from the `noora/` package.
- Updated the Noora workflow's Test job to run `mix test` before the existing JS test command, so Noora ExUnit tests are covered in CI.
- Regenerated the affected dashboard gettext templates after rebasing, since removing duplicated LiveView code shifted source references.

## Root Cause

Noora's filter controls encode "does not contain" as `:"!=~"`. Several server LiveViews already worked around that by normalizing locally before calling `convert_filters_to_flop/1`, but `TestCasesLive` did not. Because `convert_filters_to_flop/1` copied the operator through unchanged, `Tests.list_test_cases/3` eventually called `Flop.validate!/2` with an unsupported operator and raised.

## Impact

All Noora filter consumers that use `convert_filters_to_flop/1` now get a Flop-compatible operator map. The server pages are simpler, and Test Cases filtering behaves consistently with the other run pages. New Noora Elixir tests will also run in CI instead of relying only on local validation.

## Validation

- First ran the new Test Cases regression before the fix and reproduced `Flop.InvalidParamsError`.
- `mix gettext.extract` from `server/`, with only `.pot` template updates kept.
- `mix test test/noora/filter_test.exs` (1 passed)
- `mix test test/tuist_web/pagination_test.exs test/tuist_web/live/test_cases_live_test.exs test/tuist_web/live/test_runs_live_test.exs test/tuist_web/live/generate_runs_live_test.exs test/tuist_web/live/cache_runs_live_test.exs test/tuist_web/live/gradle_build_runs_live_test.exs test/tuist_web/live/build_runs_live_test.exs` (44 passed)
