### PR TITLE
fix(cli): treat undecompressable module cache artifacts as cache misses

### DIFF
--- a/cli/Tests/TuistCacheEETests/Storage/ModuleCacheRemoteStorageTests.swift
+++ b/cli/Tests/TuistCacheEETests/Storage/ModuleCacheRemoteStorageTests.swift
@@ -231,10 +231,13 @@ struct ModuleCacheRemoteStorageTests {
         )
 
         // Then
-        // The undecompressable artifact is a per-item cache miss, not a fetch
-        // failure, so no "server unavailable" alert is surfaced.
+        // The undecompressable artifact is a per-item cache miss (the fetch does
+        // not fail), surfaced as a single "could not be decompressed" warning
+        // rather than the misleading "server unavailable" alert.
         #expect(got.isEmpty == true)
-        #expect(AlertController.current.warnings().isEmpty == true)
+        #expect(AlertController.current.warnings().map(\.message).map { $0.plain() } ==
+            ["These cached artifacts could not be decompressed and were rebuilt from source: target"]
+        )
         // The payload won't change on retry, so it must be downloaded only once.
         verify(downloadModuleCacheService)
             .downloadModuleCacheArtifact(
@@ -297,7 +300,6 @@ struct ModuleCacheRemoteStorageTests {
         #expect(got.count == 1)
         #expect(got[.test(name: "Valid", hash: "valid-hash", source: .remote, cacheCategory: .binaries)] != nil)
         #expect(got[.test(name: "Corrupt", hash: "corrupt-hash", source: .remote, cacheCategory: .binaries)] == nil)
-        #expect(AlertController.current.warnings().isEmpty == true)
     }
 
     // MARK: - Authentication Failure Tests (401/403)

--- a/cli/Tests/TuistCacheEETests/Storage/ModuleCacheRemoteStorageTests.swift
+++ b/cli/Tests/TuistCacheEETests/Storage/ModuleCacheRemoteStorageTests.swift
@@ -256,36 +256,52 @@ struct ModuleCacheRemoteStorageTests {
     @Test(.inTemporaryDirectory, .withMockedLogger(), .withScopedAlertController())
     func fetch_when_one_artifact_is_corrupted_still_returns_the_valid_ones() async throws {
         // Given
-        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
-        let frameworkPath = temporaryDirectory.appending(component: "Valid.framework")
-        try await fileSystem.makeDirectory(at: frameworkPath)
-        let validArchivePath = try await makeArchive(paths: [frameworkPath], name: "valid")
-        let validData = try Data(contentsOf: validArchivePath.url)
-
+        // Drive decompression through a mock archiver so the corrupt case is
+        // deterministic. Decompressing arbitrary "corrupt" bytes with the real
+        // AppleArchive has undefined behavior and is unsuitable for a fixture.
+        let appleArchiver = MockAppleArchiving()
+        let subject = ModuleCacheRemoteStorage(
+            fullHandle: fullHandle,
+            cacheURL: Constants.URLs.production,
+            serverURL: Constants.URLs.production,
+            serverAuthenticationController: serverAuthenticationController,
+            appleArchiver: appleArchiver,
+            cacheDirectoriesProvider: cacheDirectoriesProvider,
+            multipartUploadService: multipartUploadService,
+            downloadModuleCacheService: downloadModuleCacheService,
+            getCacheActionItemService: getCacheActionItemService,
+            uploadCacheActionItemService: uploadCacheActionItemService,
+            artifactSigner: artifactSigner,
+            fileSystem: fileSystem,
+            retryProvider: retryProvider,
+            concurrencyLimit: 15,
+            cacheActionItemConcurrencyLimit: 15
+        )
         given(downloadModuleCacheService)
             .downloadModuleCacheArtifact(
                 accountHandle: .any,
                 projectHandle: .any,
                 hash: .any,
-                name: .value("Valid.zip"),
+                name: .any,
                 cacheCategory: .any,
                 serverURL: .any,
                 authenticationURL: .any,
                 serverAuthenticationController: .any
             )
-            .willReturn(validData)
-        given(downloadModuleCacheService)
-            .downloadModuleCacheArtifact(
-                accountHandle: .any,
-                projectHandle: .any,
-                hash: .any,
-                name: .value("Corrupt.zip"),
-                cacheCategory: .any,
-                serverURL: .any,
-                authenticationURL: .any,
-                serverAuthenticationController: .any
-            )
-            .willReturn(Data("not-a-valid-apple-archive".utf8))
+            .willReturn(Data("payload".utf8))
+        // The valid artifact decompresses into a real framework; the corrupt one
+        // fails to decompress. The archive path is "<hash>.aar", so match on hash.
+        given(appleArchiver)
+            .decompress(archive: .matching { $0.pathString.contains("valid-hash") }, to: .any)
+            .willProduce { _, directory in
+                try FileManager.default.createDirectory(
+                    at: directory.appending(component: "Valid.framework").url,
+                    withIntermediateDirectories: true
+                )
+            }
+        given(appleArchiver)
+            .decompress(archive: .matching { $0.pathString.contains("corrupt-hash") }, to: .any)
+            .willThrow(AppleArchiverError.decompressionFailed("unsupported archive format"))
 
         // When
         let got = try await subject.fetch(

--- a/cli/Tests/TuistCacheEETests/Storage/ModuleCacheRemoteStorageTests.swift
+++ b/cli/Tests/TuistCacheEETests/Storage/ModuleCacheRemoteStorageTests.swift
@@ -187,6 +187,119 @@ struct ModuleCacheRemoteStorageTests {
         #expect(got.isEmpty == true)
     }
 
+    @Test(.inTemporaryDirectory, .withMockedLogger(), .withScopedAlertController())
+    func fetch_when_downloaded_archive_cannot_be_decompressed_is_treated_as_a_cache_miss() async throws {
+        // Given
+        let appleArchiver = MockAppleArchiving()
+        let subject = ModuleCacheRemoteStorage(
+            fullHandle: fullHandle,
+            cacheURL: Constants.URLs.production,
+            serverURL: Constants.URLs.production,
+            serverAuthenticationController: serverAuthenticationController,
+            appleArchiver: appleArchiver,
+            cacheDirectoriesProvider: cacheDirectoriesProvider,
+            multipartUploadService: multipartUploadService,
+            downloadModuleCacheService: downloadModuleCacheService,
+            getCacheActionItemService: getCacheActionItemService,
+            uploadCacheActionItemService: uploadCacheActionItemService,
+            artifactSigner: artifactSigner,
+            fileSystem: fileSystem,
+            retryProvider: retryProvider,
+            concurrencyLimit: 15,
+            cacheActionItemConcurrencyLimit: 15
+        )
+        given(downloadModuleCacheService)
+            .downloadModuleCacheArtifact(
+                accountHandle: .any,
+                projectHandle: .any,
+                hash: .any,
+                name: .any,
+                cacheCategory: .any,
+                serverURL: .any,
+                authenticationURL: .any,
+                serverAuthenticationController: .any
+            )
+            .willReturn(Data("stale-stored-zip-payload".utf8))
+        given(appleArchiver)
+            .decompress(archive: .any, to: .any)
+            .willThrow(AppleArchiverError.decompressionFailed("unsupported archive format"))
+
+        // When
+        let got = try await subject.fetch(
+            Set([.init(name: "target", hash: "hash")]),
+            cacheCategory: .binaries
+        )
+
+        // Then
+        // The undecompressable artifact is a per-item cache miss, not a fetch
+        // failure, so no "server unavailable" alert is surfaced.
+        #expect(got.isEmpty == true)
+        #expect(AlertController.current.warnings().isEmpty == true)
+        // The payload won't change on retry, so it must be downloaded only once.
+        verify(downloadModuleCacheService)
+            .downloadModuleCacheArtifact(
+                accountHandle: .any,
+                projectHandle: .any,
+                hash: .any,
+                name: .any,
+                cacheCategory: .any,
+                serverURL: .any,
+                authenticationURL: .any,
+                serverAuthenticationController: .any
+            )
+            .called(1)
+    }
+
+    @Test(.inTemporaryDirectory, .withMockedLogger(), .withScopedAlertController())
+    func fetch_when_one_artifact_is_corrupted_still_returns_the_valid_ones() async throws {
+        // Given
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let frameworkPath = temporaryDirectory.appending(component: "Valid.framework")
+        try await fileSystem.makeDirectory(at: frameworkPath)
+        let validArchivePath = try await makeArchive(paths: [frameworkPath], name: "valid")
+        let validData = try Data(contentsOf: validArchivePath.url)
+
+        given(downloadModuleCacheService)
+            .downloadModuleCacheArtifact(
+                accountHandle: .any,
+                projectHandle: .any,
+                hash: .any,
+                name: .value("Valid.zip"),
+                cacheCategory: .any,
+                serverURL: .any,
+                authenticationURL: .any,
+                serverAuthenticationController: .any
+            )
+            .willReturn(validData)
+        given(downloadModuleCacheService)
+            .downloadModuleCacheArtifact(
+                accountHandle: .any,
+                projectHandle: .any,
+                hash: .any,
+                name: .value("Corrupt.zip"),
+                cacheCategory: .any,
+                serverURL: .any,
+                authenticationURL: .any,
+                serverAuthenticationController: .any
+            )
+            .willReturn(Data("not-a-valid-apple-archive".utf8))
+
+        // When
+        let got = try await subject.fetch(
+            Set([
+                .init(name: "Valid", hash: "valid-hash"),
+                .init(name: "Corrupt", hash: "corrupt-hash"),
+            ]),
+            cacheCategory: .binaries
+        )
+
+        // Then
+        #expect(got.count == 1)
+        #expect(got[.test(name: "Valid", hash: "valid-hash", source: .remote, cacheCategory: .binaries)] != nil)
+        #expect(got[.test(name: "Corrupt", hash: "corrupt-hash", source: .remote, cacheCategory: .binaries)] == nil)
+        #expect(AlertController.current.warnings().isEmpty == true)
+    }
+
     // MARK: - Authentication Failure Tests (401/403)
 
     @Test(.inTemporaryDirectory, .withMockedLogger(), .withScopedAlertController())


### PR DESCRIPTION
## What

Delivers the module-cache corrupt-artifact fix to the CLI: bumps the `TuistCacheEE` submodule to the merged fix (tuist/TuistCacheEE#71) and adds regression tests.

## Why / root cause

A downloaded binary-cache artifact that fails AppleArchive decompression (for example a stale entry from a prior archive format whose hash space collides with the current one in dev or x.y.z builds) was mapped to `.serverNotAvailable`. That surfaced the misleading "The remote cache server is currently unavailable" alert and, when a whole build's hashes resolve to stale artifacts, discarded every hit and forced a full source rebuild. Full root cause in tuist/TuistCacheEE#71.

## Change

- Bump `cli/TuistCacheEE` to the merged fix: an undecompressable artifact is now a per-item cache miss (the remaining binaries still apply, no retry-driven re-download), surfaced as one aggregated warning listing the affected artifacts instead of the misleading outage alert. A genuinely missing artifact stays a silent miss.
- Add `TuistCacheEETests/ModuleCacheRemoteStorageTests` cases:
  - `fetch_when_downloaded_archive_cannot_be_decompressed_is_treated_as_a_cache_miss`: an undecompressable payload is a miss, surfaces the aggregated warning, download called once.
  - `fetch_when_one_artifact_is_corrupted_still_returns_the_valid_ones`: a corrupt artifact alongside a valid one still returns the valid binary (driven through a mock archiver for determinism, since the real decompressor's behavior on non-archive bytes is undefined).

## Impact

A stale or corrupt remote artifact degrades to rebuilding that one module from source, with no false outage alarm and no wasted re-download. Healthy artifacts in the same fetch are unaffected.

## Validation

Covered by the added regression tests; Unit Tests and Linux Unit Tests are green on CI.
