### PR TITLE
fix(ci): drop jq github-attestations provenance from mise.lock to restore deploys

### DIFF
--- a/mise.lock
+++ b/mise.lock
@@ -310,37 +310,30 @@ backend = "aqua:jqlang/jq"
 [tools.jq."platforms.linux-arm64"]
 checksum = "sha256:6bc62f25981328edd3cfcfe6fe51b073f2d7e7710d7ef7fcdac28d4e384fc3d4"
 url = "https://github.com/jqlang/jq/releases/download/jq-1.8.1/jq-linux-arm64"
-provenance = "github-attestations"
 
 [tools.jq."platforms.linux-arm64-musl"]
 checksum = "sha256:6bc62f25981328edd3cfcfe6fe51b073f2d7e7710d7ef7fcdac28d4e384fc3d4"
 url = "https://github.com/jqlang/jq/releases/download/jq-1.8.1/jq-linux-arm64"
-provenance = "github-attestations"
 
 [tools.jq."platforms.linux-x64"]
 checksum = "sha256:020468de7539ce70ef1bceaf7cde2e8c4f2ca6c3afb84642aabc5c97d9fc2a0d"
 url = "https://github.com/jqlang/jq/releases/download/jq-1.8.1/jq-linux-amd64"
-provenance = "github-attestations"
 
 [tools.jq."platforms.linux-x64-musl"]
 checksum = "sha256:020468de7539ce70ef1bceaf7cde2e8c4f2ca6c3afb84642aabc5c97d9fc2a0d"
 url = "https://github.com/jqlang/jq/releases/download/jq-1.8.1/jq-linux-amd64"
-provenance = "github-attestations"
 
 [tools.jq."platforms.macos-arm64"]
 checksum = "sha256:a9fe3ea2f86dfc72f6728417521ec9067b343277152b114f4e98d8cb0e263603"
 url = "https://github.com/jqlang/jq/releases/download/jq-1.8.1/jq-macos-arm64"
-provenance = "github-attestations"
 
 [tools.jq."platforms.macos-x64"]
 checksum = "sha256:e80dbe0d2a2597e3c11c404f03337b981d74b4a8504b70586c354b7697a7c27f"
 url = "https://github.com/jqlang/jq/releases/download/jq-1.8.1/jq-macos-amd64"
-provenance = "github-attestations"
 
 [tools.jq."platforms.windows-x64"]
 checksum = "sha256:23cb60a1354eed6bcc8d9b9735e8c7b388cd1fdcb75726b93bc299ef22dd9334"
 url = "https://github.com/jqlang/jq/releases/download/jq-1.8.1/jq-windows-amd64.exe"
-provenance = "github-attestations"
 
 [[tools.kubectl]]
 version = "1.36.1"


### PR DESCRIPTION
## What changed

Removes the seven `provenance = "github-attestations"` lines from the `jq` entries in the root `mise.lock`.

## Why (root cause)

The toolchain bump in #11705 regenerated `mise.lock` and, as an incidental side-effect, recorded `provenance = "github-attestations"` on all seven `jq` platform entries. **jq's version was unchanged at 1.8.1** — this is a lockfile regen artifact, not a deliberate supply-chain pin (#11705's intent was the Elixir 1.19.5→1.20.2 / Erlang 28.4.3→29.0.3 bump).

Every release/CI workflow runs with `MISE_GITHUB_ATTESTATIONS: 0` (attestation verification is deliberately disabled across 10+ workflows, to avoid the GitHub-API rate-limit/auth path). With that setting off, `mise install --locked jq` now hard-fails:

```
Failed to install aqua:jqlang/jq@1.8.1: Lockfile requires github-attestations
provenance for aqua:jqlang/jq@1.8.1 but the corresponding verification setting
is disabled. This may indicate a downgrade attack. Enable the setting or update
the lockfile.
```

That command is the first step of the `Check for releasable changes` job at the head of the **Server Production Deployment** cascade. When it fails, the whole release + deploy chain (`release-*`, `build`, `canary`, `acceptance-tests`, `production`) skips.

## Impact

Every production deploy since #11705 has failed identically at this step. The last successful production deploy was #11721; prod has not shipped in ~16h and multiple merges are stacked undeployed — including #11719 (the warm-WAN Xcode-cache fix), whose kura fleet roll this blocks.

## Fix rationale

The two self-consistent states are (a) lock demands attestation provenance **and** verification is enabled, or (b) neither. CI's established posture is (b) — attestations off in 10+ workflows to dodge GitHub API rate limits. So the lock must not demand attestation provenance. jq is still integrity-checked by its sha256 `checksum` (unchanged), so this does not weaken what CI actually verifies.

`sops`' `provenance.slsa` sub-tables are a **different** mechanism (SLSA, not gated by `MISE_GITHUB_ATTESTATIONS`), predate #11705, and deployed fine — left intact.

## Validation

Reproduced and fixed locally (isolated `HOME` + fresh `MISE_DATA_DIR`, `MISE_GITHUB_ATTESTATIONS=0`, matching CI):

| lock state | result |
|---|---|
| current `main` (jq provenance present) | `mise install --locked jq` → **exit 1**, identical `github-attestations ... downgrade attack` error |
| this PR (provenance removed) | `mise install --locked jq` → **exit 0**, jq 1.8.1 downloaded + checksum-verified + runs (`jq-1.8.1`) |

## Follow-up (not in this PR)

A local `mise install` / `mise up` on a machine where attestation verification is available will re-add the provenance and reintroduce this breakage. Worth pinning the attestations posture in mise config so the lock can't silently drift back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)