### PR TITLE
fix(infra): grant kura-controller read on kube-system/kube-dns for peer-demux

### DIFF
--- a/infra/helm/tuist/templates/kura-controller.yaml
+++ b/infra/helm/tuist/templates/kura-controller.yaml
@@ -157,6 +157,46 @@ subjects:
   - kind: ServiceAccount
     name: {{ $name }}
     namespace: {{ $namespace }}
+---
+# Namespaced Role granting the controller's SA read on the single
+# kube-system/kube-dns Service. peer-demux's discoverClusterDNS reads its
+# ClusterIP to wire the per-region peer plane's in-cluster DNS, which a
+# freshly (re)provisioned instance needs before its cache pods can complete
+# peer discovery and pass readiness — without it the reconciler errors every
+# cycle ("services \"kube-dns\" is forbidden") and the fresh StatefulSet never
+# goes Ready. Scoped to kube-system as a Role rather than a ClusterRole with
+# resourceNames (which would match a kube-dns Service in any namespace); read
+# via the uncached APIReader since the manager's Services cache is namespaced.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $name }}-cluster-dns
+  namespace: kube-system
+  labels:
+    {{- include "tuist.labels" . | nindent 4 }}
+    app.kubernetes.io/component: kura-controller
+rules:
+  - apiGroups: [""]
+    resources: [services]
+    resourceNames: [kube-dns]
+    verbs: [get]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $name }}-cluster-dns
+  namespace: kube-system
+  labels:
+    {{- include "tuist.labels" . | nindent 4 }}
+    app.kubernetes.io/component: kura-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ $name }}-cluster-dns
+subjects:
+  - kind: ServiceAccount
+    name: {{ $name }}
+    namespace: {{ $namespace }}
 {{- if .Values.server.enabled }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
## Root cause

The kura-controller's `peer-demux` reconciler resolves the `kube-system/kube-dns` Service (`discoverClusterDNS`) to wire the per-region peer plane's in-cluster DNS. Its ServiceAccount (`kura:tuist-tuist-kura-controller`) had **no RBAC** for that Service — the namespaced controller Role grants `services` only in the controller's own namespace, and the `-node-reads` ClusterRole covers only `nodes`/`persistentvolumes`. Every `peer-demux` reconcile errored:

```
Reconciler error  controller=peer-demux  name=eu-central
resolving cluster DNS service kube-system/kube-dns: services "kube-dns" is
forbidden: User "system:serviceaccount:kura:tuist-tuist-kura-controller"
cannot get resource "services" in API group "" in the namespace "kube-system"
```

## Impact

A freshly (re)provisioned `KuraInstance` needs `peer-demux` to complete before its cache pods can finish peer discovery and pass readiness. With the grant missing, **fresh nodes never go Ready** — `/ready` returns 503 indefinitely and the StatefulSet stays `0/N` — while **pre-existing nodes are unaffected** because they were configured before this path was exercised.

This was a latent gap that surfaced during a cache-server **destroy → deploy** of the tuist EU-Central node: the clean node could not bootstrap, and the same trap then hit US-East on a fresh deploy. Co-tenant instances (qonto/vinted) on the same box and image stayed healthy precisely because they were not reprovisioned.

## Fix

Add a `Role` + `RoleBinding` in `kube-system` granting the controller SA `get` on the `kube-dns` Service, scoped with `resourceNames: [kube-dns]` (least privilege), read via the uncached APIReader. This mirrors the **identical grant the CAPI Apple-silicon self-join SA already carries** ([`capi-scaleway-applesilicon.yaml`](infra/helm/tuist/templates/capi-scaleway-applesilicon.yaml)), whose `discoverClusterDNS` reads the same Service. A namespaced `Role` (rather than a `ClusterRole` with `resourceNames`) keeps it from matching a `kube-dns` Service in any other namespace.

## Validation

`helm template` renders the scoped objects: `Role tuist-tuist-kura-controller-cluster-dns` in `kube-system` (`resources: [services]`, `resourceNames: [kube-dns]`, `verbs: [get]`) + `RoleBinding` to the controller SA. No other objects change.

## Rollout / recovery

Once this lands and deploys, `peer-demux` succeeds on its next reconcile and the stuck EU-Central / US-East nodes complete bootstrap and go Ready — no pod restart required. For immediate recovery ahead of a full deploy, the same two objects can be applied directly to the cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)