### PR TITLE
fix(infra): open kura peer port for all cross-region peers, not just public-host regions

### DIFF
--- a/infra/kura-controller/controllers/kurainstance_controller.go
+++ b/infra/kura-controller/controllers/kurainstance_controller.go
@@ -1957,14 +1957,22 @@ func (r *KuraInstanceReconciler) reconcileNetworkPolicy(ctx context.Context, ins
 				},
 			})
 		}
-		if meshManagedPeerTLS(instance) && instance.Spec.MeshPublicPeerHost != "" {
-			// The public peer plane accepts mesh connections from off-cluster
-			// self-hosted nodes through the LoadBalancer. With
-			// externalTrafficPolicy: Cluster the source is SNATed to a node IP,
-			// so no pod/namespace selector matches — allow the peer port from
-			// anywhere. The mutual-TLS client-cert check against the account CA
-			// is the auth boundary; a connection without a valid account-CA leaf
-			// fails the handshake.
+		if crossRegionRuntimeEnabled(instance) {
+			// Any instance that peers cross-region receives peer connections
+			// whose source is SNATed, so no pod/namespace selector can match —
+			// allow the peer port from anywhere. Two SNAT paths need this, not
+			// just one:
+			//   1. off-cluster self-hosted nodes reaching the public peer
+			//      LoadBalancer (externalTrafficPolicy: Cluster SNATs to a node IP);
+			//   2. same-account peers in another region whose in-cluster
+			//      pod-to-pod traffic is SNATed across the CNI/provider boundary
+			//      (e.g. a Dedibox region dialing a Scaleway NodePort region).
+			// Gating this on MeshPublicPeerHost missed case 2: a mesh region
+			// without a public host (e.g. a NodePort runner-cache node) would
+			// silently reject cross-provider peers and never finish bootstrap.
+			// The mutual-TLS client-cert check against the account CA is the auth
+			// boundary; a connection without a valid account-CA leaf fails the
+			// handshake, so opening the port by IP grants no access on its own.
 			ingress = append(ingress, networkingv1.NetworkPolicyIngressRule{
 				From: []networkingv1.NetworkPolicyPeer{
 					{IPBlock: &networkingv1.IPBlock{CIDR: "0.0.0.0/0"}},

--- a/infra/kura-controller/controllers/kurainstance_controller_test.go
+++ b/infra/kura-controller/controllers/kurainstance_controller_test.go
@@ -758,7 +758,10 @@ func TestKuraInstanceReconcileCrossRegionAccountPeerService(t *testing.T) {
 	if err := reconciler.Get(ctx, types.NamespacedName{Name: instance.Name, Namespace: instance.Namespace}, policy); err != nil {
 		t.Fatal(err)
 	}
-	if len(policy.Spec.Ingress) != 3 {
+	// 4 rules: own-pods, same-account peer (podSelector), in-cluster http, and
+	// the open peer port for SNATed cross-region peers (this instance peers
+	// cross-region, so crossRegionRuntimeEnabled adds it).
+	if len(policy.Spec.Ingress) != 4 {
 		t.Fatalf("expected NetworkPolicy to include same-account peer rule, got %d rules", len(policy.Spec.Ingress))
 	}
 	if got := policy.Spec.Ingress[1].Ports[0].Port.StrVal; got != "peer" {
@@ -766,6 +769,9 @@ func TestKuraInstanceReconcileCrossRegionAccountPeerService(t *testing.T) {
 	}
 	if got := policy.Spec.Ingress[1].From[0].PodSelector.MatchLabels["tuist.dev/account"]; got != "tuist" {
 		t.Fatalf("expected same-account NetworkPolicy peer selector, got %q", got)
+	}
+	if !peerPortOpenFromAnyIP(policy) {
+		t.Fatal("expected a cross-region peer instance to allow the peer port from any IP (SNATed peers)")
 	}
 }
 
@@ -900,6 +906,54 @@ func TestKuraInstanceReconcileMeshPublicPeerExposure(t *testing.T) {
 	}
 	if err := reconciler.Get(ctx, types.NamespacedName{Name: instancePublicPeerServiceName(instance), Namespace: instance.Namespace}, lb); err != nil {
 		t.Fatalf("expected public peer Service to survive a non-mesh sibling's reconcile, got %v", err)
+	}
+}
+
+func peerPortOpenFromAnyIP(policy *networkingv1.NetworkPolicy) bool {
+	for _, rule := range policy.Spec.Ingress {
+		for _, from := range rule.From {
+			if from.IPBlock == nil || from.IPBlock.CIDR != "0.0.0.0/0" {
+				continue
+			}
+			for _, p := range rule.Ports {
+				if p.Port != nil && p.Port.StrVal == "peer" {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+// A mesh region without a public peer host (e.g. a NodePort runner-cache node
+// that peers cross-region purely in-cluster) must still open the peer port to
+// SNATed traffic: a same-account peer in another region reaches it via
+// cross-provider in-cluster pod-to-pod traffic that is SNATed to a node IP, so
+// no pod/namespace selector matches. Regression for the wedge where such a node
+// silently rejected cross-provider peers on :7443 and never finished bootstrap.
+func TestMeshPeerNetworkPolicyOpensPeerPortWithoutPublicHost(t *testing.T) {
+	ctx := context.Background()
+	scheme := meshTestScheme(t)
+
+	instance := meshInstance("kura-tuist-scw-fr-par", "tuist")
+	instance.Spec.MeshPublicPeerHost = "" // NodePort runner-cache node: no public peer LB
+	instance.Spec.ExposeNodePort = true
+	instance.Spec.ClientCIDRs = []string{"172.16.0.0/22"}
+
+	reconciler := &KuraInstanceReconciler{
+		Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(instance).WithStatusSubresource(instance).Build(),
+		Scheme: scheme,
+	}
+	if _, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: instance.Name, Namespace: instance.Namespace}}); err != nil {
+		t.Fatal(err)
+	}
+
+	policy := &networkingv1.NetworkPolicy{}
+	if err := reconciler.Get(ctx, types.NamespacedName{Name: instance.Name, Namespace: instance.Namespace}, policy); err != nil {
+		t.Fatal(err)
+	}
+	if !peerPortOpenFromAnyIP(policy) {
+		t.Fatal("expected a mesh region without a public peer host to still allow the peer port from any IP (cross-provider in-cluster peers arrive SNATed)")
 	}
 }
 


### PR DESCRIPTION
## Root cause

The `kura-controller` NetworkPolicy that allows the mesh peer port (`7443`) from any IP is gated on `meshManagedPeerTLS(instance) && instance.Spec.MeshPublicPeerHost != ""` — i.e. **only regions that expose a public peer LoadBalancer**. The rationale: LB traffic (`externalTrafficPolicy: Cluster`) is SNATed to a node IP, so no pod/namespace selector matches and the port must be allowed by IP.

That gate misses a **second** SNAT path: same-account peers in another region reaching each other over **cross-provider in-cluster pod-to-pod** traffic (e.g. a Dedibox region dialing a Scaleway NodePort runner-cache region) are SNATed across the CNI/provider boundary. A mesh region without a public peer host (`Mesh=true`, `MeshPublicPeerHost=""`) therefore only allowed `peer` via a `podSelector` that cross-provider traffic can never match — silently dropping inbound `:7443` from its own peers.

## Production impact

The tuist **scw-fr-par** runner-cache node (mesh peer, `exposeNodePort: true`, no public host) rejected peer connections from the **eu-central** region:

- scw-fr-par → eu-central worked (it dialed out and bootstrapped both eu-central pods).
- eu-central → scw-fr-par was dropped at `:7443`, so eu-central held scw-fr-par `inflight` forever and never reached readiness.

Confirmed live from an in-cluster probe: `scw-fr-par:4000` (http) reachable, `scw-fr-par:7443` (peer) TCP-timed-out; and the two NetworkPolicies differed only by the open-peer `ipBlock: 0.0.0.0/0 → peer` rule (present on eu-central, absent on scw-fr-par). A live patch adding the rule was reverted by the controller within ~20s — hence the source fix.

## Fix

Gate the open peer-port rule on `crossRegionRuntimeEnabled(instance)` (`Mesh || external peer secret`) instead of the public-host condition. Any instance that peers cross-region serves the peer port and must accept SNATed peer connections. The account-CA **mutual-TLS** handshake is the auth boundary, so opening the TCP port by IP grants no access on its own — identical safety to the existing public-host case.

## Validation

`go build`, `go vet`, and the full controller suite pass. Updated the cross-region shared-secret test (NetworkPolicy now has 4 ingress rules) and added `TestMeshPeerNetworkPolicyOpensPeerPortWithoutPublicHost` covering a mesh region with no public host + `ExposeNodePort`/`ClientCIDRs` (the scw-fr-par shape).

## Rollout

Once the `kura-controller` image is built and deployed, it reconciles the corrected NetworkPolicy onto scw-fr-par; eu-central then completes bootstrap and reaches readiness with no pod restart. This is the second of two stacked failures on the tuist EU-Central region — the first (`kube-dns` RBAC for `peer-demux`) landed in #11729.

🤖 Generated with [Claude Code](https://claude.com/claude-code)