### PR TITLE
fix(cli): handle pruned selective test targets

### DIFF
--- a/cli/Sources/TuistKit/Mappers/FocusTargetsGraphMappers.swift
+++ b/cli/Sources/TuistKit/Mappers/FocusTargetsGraphMappers.swift
@@ -86,6 +86,16 @@ public struct FocusTargetsGraphMappers: GraphMapping {
                 excludedTargets: excludedTargets,
                 excludingExternalTargets: true
             )
+            let initialUserSpecifiedSourceTargets = environment.initialGraph.map { initialGraph in
+                let initialGraphTraverser = GraphTraverser(graph: initialGraph)
+                return initialGraphTraverser.filterIncludedTargets(
+                    basedOn: initialGraphTraverser.allTargets(),
+                    testPlan: testPlan,
+                    includedTargets: includedTargets,
+                    excludedTargets: excludedTargets,
+                    excludingExternalTargets: true
+                )
+            }
 
             let includedTargetNames: [String] = includedTargets.compactMap {
                 guard case let .named(name) = $0 else { return nil }
@@ -103,7 +113,13 @@ public struct FocusTargetsGraphMappers: GraphMapping {
                 throw FocusTargetsGraphMappersError.targetsNotFound(Array(unavailableIncludedTargets))
             }
 
-            if !includedTargets.isEmpty || !excludedTargets.isEmpty, userSpecifiedSourceTargets.isEmpty {
+            let allIncludedTargetsWerePrunedBySelectiveTesting = !includedTargets.isEmpty
+                && userSpecifiedSourceTargets.isEmpty
+                && initialUserSpecifiedSourceTargets?.isEmpty == false
+            if !includedTargets.isEmpty || !excludedTargets.isEmpty,
+               userSpecifiedSourceTargets.isEmpty,
+               !allIncludedTargetsWerePrunedBySelectiveTesting
+            {
                 throw FocusTargetsGraphMappersError.noTargetsFound
             }
 

--- a/cli/Tests/TuistKitTests/Mappers/FocusTargetsGraphMappersTests.swift
+++ b/cli/Tests/TuistKitTests/Mappers/FocusTargetsGraphMappersTests.swift
@@ -529,6 +529,39 @@ final class FocusTargetsGraphMappersTests: TuistUnitTestCase {
         XCTAssertEmpty(gotSideEffects)
     }
 
+    func test_map_when_all_included_targets_were_pruned_by_selective_testing_does_not_throw() throws {
+        // Given
+        let appTarget = Target.test(name: "App", product: .app)
+        let appTests = Target.test(name: "AppTests", product: .unitTests)
+        let libTests = Target.test(name: "LibTests", product: .unitTests)
+        let subject = FocusTargetsGraphMappers(
+            includedTargets: [.named("AppTests"), .named("LibTests")]
+        )
+        let path = try temporaryPath()
+        let initialProject = Project.test(path: path, targets: [appTarget, appTests, libTests])
+        let initialGraph = Graph.test(
+            projects: [initialProject.path: initialProject],
+            dependencies: [
+                .target(name: appTests.name, path: path): [
+                    .target(name: appTarget.name, path: path),
+                ],
+            ]
+        )
+        let project = Project.test(path: path, targets: [appTarget])
+        let graph = Graph.test(projects: [project.path: project])
+        var environment = MapperEnvironment()
+        environment.initialGraph = initialGraph
+
+        // When
+        let (gotGraph, gotSideEffects, _) = try subject.map(graph: graph, environment: environment)
+        let pruningTargets = gotGraph.projects.values.flatMap(\.targets.values).sorted()
+            .filter { $0.metadata.tags.contains("tuist:prunable") }
+
+        // Then
+        XCTAssertEmpty(gotSideEffects)
+        XCTAssertEqual(pruningTargets.map(\.name), [appTarget.name])
+    }
+
     func test_map_when_some_included_targets_were_pruned_and_others_do_not_exist_throws() throws {
         // Given
         let aTarget = Target.test(name: "App", product: .app)


### PR DESCRIPTION
## What changed

- Updated `FocusTargetsGraphMappers` so test-target filtering also evaluates the user-provided target query against `environment.initialGraph`.
- When selective testing has pruned every requested test target from the current graph, the mapper now treats the query as valid instead of throwing `No targets were found`.
- Added a regression test for the all-requested-test-targets-pruned case.

## Why

A reported `tuist test --test-targets ...` workflow behaved differently depending on selective testing. With `--no-selective-testing`, the selected test target was found and executed. With selective testing enabled, remote selective test data could prune that target before the focus mapper validated the user's query, causing the CLI to fail with:

```text
No targets were found. Ensure that the query is valid and matches targets in the graph.
```

The target query was valid; it only appeared empty because selective testing had already removed the requested targets from the generated graph.

## Root cause

`FocusTargetsGraphMappers` validated `includedTargets` only against the already-pruned graph. Existing handling covered the case where some requested targets were pruned and others remained, but not the case where every requested target had been pruned by selective testing. In that all-pruned case, `userSpecifiedSourceTargets` was empty and the mapper emitted the same error used for genuinely invalid target queries.

## Approach

The mapper now re-runs the same included/excluded target filtering against `environment.initialGraph` when it is available. If the current graph has no matching included targets but the initial graph did, the mapper recognizes that selective testing pruned the requested targets and skips the `noTargetsFound` error. Truly invalid target names still fail because they are absent from both the current and initial graphs.

## Validation

- Reproduced the failure end-to-end with a mise-installed Tuist CLI against a canary project: the selective-testing run with `--test-targets MultiPlatformTransitiveDynamicFrameworkTests` failed with `No targets were found`, while the same command with `--no-selective-testing` succeeded.
- Ran `tuist install --force-resolved-versions`.
- Ran `tuist generate tuist TuistKit TuistKitTests ProjectDescription --no-open`.
- Built the local CLI with `xcodebuild build -workspace Tuist.xcworkspace -scheme tuist CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""`.
- Used the locally built CLI against a canary e2e fixture with `--test-targets MultiPlatformTransitiveDynamicFrameworkTests`; the run completed successfully and did not hit the old graph-query error.
- Ran the focused regression test: `xcodebuild test -workspace Tuist.xcworkspace -scheme Tuist-Workspace -only-testing TuistKitTests/FocusTargetsGraphMappersTests/test_map_when_all_included_targets_were_pruned_by_selective_testing_does_not_throw CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""`.
- Ran `git diff --check`.