### PR TITLE
fix(server): require explicit newsletter confirmation

### DIFF
--- a/server/assets/app/css/pages/runner_job.css
+++ b/server/assets/app/css/pages/runner_job.css
@@ -620,8 +620,7 @@
     overflow: hidden;
 
     &[data-state="requested"] {
-      background:
-        linear-gradient(135deg, color-mix(in srgb, var(--noora-azure-500) 12%, transparent), transparent 52%),
+      background: linear-gradient(135deg, color-mix(in srgb, var(--noora-azure-500) 12%, transparent), transparent 52%),
         var(--noora-surface-background-secondary);
     }
   }

--- a/server/assets/app/js/RunnerVNCFullscreen.js
+++ b/server/assets/app/js/RunnerVNCFullscreen.js
@@ -32,9 +32,7 @@ export default {
     this.target = document.querySelector(this.el.dataset.fullscreenTarget) || this.el;
     this.label = this.button?.querySelector("span");
     this.enterLabel =
-      this.button?.dataset.fullscreenEnterLabel ||
-      this.button?.getAttribute("aria-label") ||
-      "Full screen";
+      this.button?.dataset.fullscreenEnterLabel || this.button?.getAttribute("aria-label") || "Full screen";
     this.exitLabel = this.button?.dataset.fullscreenExitLabel || "Exit full screen";
     this.onClick = () => this.toggle();
     this.onFullscreenChange = () => this.sync();

--- a/server/lib/tuist_web/marketing/controllers/marketing_controller.ex
+++ b/server/lib/tuist_web/marketing/controllers/marketing_controller.ex
@@ -20,6 +20,9 @@ defmodule TuistWeb.Marketing.MarketingController do
   plug :put_resp_header_cache_control
   plug :put_resp_header_server
 
+  @newsletter_verification_salt "newsletter_subscription"
+  @newsletter_verification_max_age 2 * 24 * 60 * 60
+
   def qa(conn, _params) do
     read_more_posts = Enum.take(Blog.get_posts(), 3)
 
@@ -307,8 +310,7 @@ defmodule TuistWeb.Marketing.MarketingController do
   def newsletter_signup(conn, %{"email" => email}) do
     email = String.trim(email)
 
-    # Create a verification token (simple base64 encoded email)
-    verification_token = Base.encode64(email)
+    verification_token = sign_newsletter_verification_token(email)
     verification_url = url(conn, ~p"/newsletter/verify?token=#{verification_token}")
 
     case Tuist.Loops.send_newsletter_confirmation(email, verification_url) do
@@ -332,76 +334,66 @@ defmodule TuistWeb.Marketing.MarketingController do
   end
 
   def newsletter_verify(conn, %{"token" => token} = _params) do
-    case Base.decode64(token) do
+    case verify_newsletter_verification_token(token) do
+      {:ok, email} ->
+        conn
+        |> assign(:head_title, dgettext("marketing", "Confirm Subscription"))
+        |> assign_newsletter_verify_head()
+        |> assign(:email, email)
+        |> assign(:verification_token, token)
+        |> assign(:subscription_confirmed, false)
+        |> assign(:error_message, nil)
+        |> render(:newsletter_verify, layout: false)
+
+      {:error, _reason} ->
+        render_newsletter_verify_error(
+          conn,
+          dgettext("marketing", "Invalid verification link. Please try signing up again.")
+        )
+    end
+  end
+
+  def newsletter_verify(conn, _params) do
+    render_newsletter_verify_error(
+      conn,
+      dgettext("marketing", "Verification link expired or invalid. Please try signing up again.")
+    )
+  end
+
+  def newsletter_confirm(conn, %{"token" => token} = _params) do
+    case verify_newsletter_verification_token(token) do
       {:ok, email} ->
         case Tuist.Loops.add_to_newsletter_list(email) do
           :ok ->
             conn
             |> assign(:head_title, dgettext("marketing", "Successfully Subscribed!"))
-            |> assign(
-              :head_image,
-              Tuist.Environment.app_url(
-                path: OpenGraph.marketing_og_image_path("/marketing/images/og/generated/tuist-digest.jpg")
-              )
-            )
-            |> assign(:head_twitter_card, "summary_large_image")
+            |> assign_newsletter_verify_head()
             |> assign(:email, email)
+            |> assign(:verification_token, nil)
+            |> assign(:subscription_confirmed, true)
             |> assign(:error_message, nil)
             |> render(:newsletter_verify, layout: false)
 
           {:error, _reason} ->
-            conn
-            |> assign(:head_title, "Newsletter Verification Failed")
-            |> assign(
-              :head_image,
-              Tuist.Environment.app_url(
-                path: OpenGraph.marketing_og_image_path("/marketing/images/og/generated/tuist-digest.jpg")
-              )
-            )
-            |> assign(:head_twitter_card, "summary_large_image")
-            |> assign(
-              :error_message,
+            render_newsletter_verify_error(
+              conn,
               dgettext("marketing", "Verification failed. Please try signing up again.")
             )
-            |> assign(:email, nil)
-            |> render(:newsletter_verify, layout: false)
         end
 
-      :error ->
-        conn
-        |> assign(:head_title, dgettext("marketing", "Newsletter Verification Failed"))
-        |> assign(
-          :head_image,
-          Tuist.Environment.app_url(
-            path: OpenGraph.marketing_og_image_path("/marketing/images/og/generated/tuist-digest.jpg")
-          )
-        )
-        |> assign(:head_twitter_card, "summary_large_image")
-        |> assign(
-          :error_message,
+      {:error, _reason} ->
+        render_newsletter_verify_error(
+          conn,
           dgettext("marketing", "Invalid verification link. Please try signing up again.")
         )
-        |> assign(:email, nil)
-        |> render(:newsletter_verify, layout: false)
     end
   end
 
-  def newsletter_verify(conn, _params) do
-    conn
-    |> assign(:head_title, dgettext("marketing", "Newsletter Verification Failed"))
-    |> assign(
-      :head_image,
-      Tuist.Environment.app_url(
-        path: OpenGraph.marketing_og_image_path("/marketing/images/og/generated/tuist-digest.jpg")
-      )
-    )
-    |> assign(:head_twitter_card, "summary_large_image")
-    |> assign(
-      :error_message,
+  def newsletter_confirm(conn, _params) do
+    render_newsletter_verify_error(
+      conn,
       dgettext("marketing", "Verification link expired or invalid. Please try signing up again.")
     )
-    |> assign(:email, nil)
-    |> render(:newsletter_verify, layout: false)
   end
 
   def newsletter_issue(%{params: params} = conn, %{"issue_number" => issue_number}) do
@@ -722,6 +714,38 @@ defmodule TuistWeb.Marketing.MarketingController do
     |> assign(:head_twitter_card, "summary_large_image")
     |> assign(:head_include_blog_rss_and_atom, true)
     |> assign(:head_include_changelog_rss_and_atom, true)
+  end
+
+  defp sign_newsletter_verification_token(email) do
+    Phoenix.Token.sign(TuistWeb.Endpoint, @newsletter_verification_salt, email)
+  end
+
+  defp verify_newsletter_verification_token(token) do
+    Phoenix.Token.verify(TuistWeb.Endpoint, @newsletter_verification_salt, token,
+      max_age: @newsletter_verification_max_age
+    )
+  end
+
+  defp assign_newsletter_verify_head(conn) do
+    conn
+    |> assign(
+      :head_image,
+      Tuist.Environment.app_url(
+        path: OpenGraph.marketing_og_image_path("/marketing/images/og/generated/tuist-digest.jpg")
+      )
+    )
+    |> assign(:head_twitter_card, "summary_large_image")
+  end
+
+  defp render_newsletter_verify_error(conn, error_message) do
+    conn
+    |> assign(:head_title, dgettext("marketing", "Newsletter Verification Failed"))
+    |> assign_newsletter_verify_head()
+    |> assign(:email, nil)
+    |> assign(:verification_token, nil)
+    |> assign(:subscription_confirmed, false)
+    |> assign(:error_message, error_message)
+    |> render(:newsletter_verify, layout: false)
   end
 
   defp put_agent_discovery_links(conn, _opts) do

--- a/server/lib/tuist_web/marketing/controllers/marketing_html/newsletter_verify.html.heex
+++ b/server/lib/tuist_web/marketing/controllers/marketing_html/newsletter_verify.html.heex
@@ -10,23 +10,59 @@
         data-part="image"
         decoding="async"
       />
-      <h1 data-part="title">{dgettext("marketing", "Successfully Subscribed!")}</h1>
-      <p data-part="description">
-        {dgettext(
-          "marketing",
-          "Great! The email %{email} has been confirmed and subscribed to Tuist Digest.",
-          email: @email
-        )}
-      </p>
+      <%= if @error_message do %>
+        <h1 data-part="title">{dgettext("marketing", "Newsletter Verification Failed")}</h1>
+        <p data-part="description">{@error_message}</p>
+      <% else %>
+        <%= if @subscription_confirmed do %>
+          <h1 data-part="title">{dgettext("marketing", "Successfully Subscribed!")}</h1>
+          <p data-part="description">
+            {dgettext(
+              "marketing",
+              "Great! The email %{email} has been confirmed and subscribed to Tuist Digest.",
+              email: @email
+            )}
+          </p>
+        <% else %>
+          <h1 data-part="title">{dgettext("marketing", "Confirm Subscription")}</h1>
+          <p data-part="description">
+            {dgettext(
+              "marketing",
+              "Please confirm that you want %{email} to receive Tuist Digest.",
+              email: @email
+            )}
+          </p>
+        <% end %>
+      <% end %>
     </header>
 
     <section data-part="content">
-      <p>
-        {dgettext(
-          "marketing",
-          "You'll receive newsletter issues every 6 weeks with the most important work happening in Tuist and our vision for the future of app development at scale."
-        )}
-      </p>
+      <%= cond do %>
+        <% @error_message -> %>
+          <p>
+            {dgettext(
+              "marketing",
+              "Open the confirmation link from the latest newsletter email, or subscribe again to receive a fresh link."
+            )}
+          </p>
+        <% @subscription_confirmed -> %>
+          <p>
+            {dgettext(
+              "marketing",
+              "You'll receive newsletter issues every 6 weeks with the most important work happening in Tuist and our vision for the future of app development at scale."
+            )}
+          </p>
+        <% true -> %>
+          <form method="post" action={~p"/newsletter/verify"}>
+            <input type="hidden" name="_csrf_token" value={get_csrf_token()} />
+            <input type="hidden" name="token" value={@verification_token} />
+            <.button
+              label={dgettext("marketing", "Confirm subscription")}
+              variant="primary"
+              type="submit"
+            />
+          </form>
+      <% end %>
     </section>
   </main>
 </TuistWeb.Marketing.Layouts.marketing>

--- a/server/lib/tuist_web/router.ex
+++ b/server/lib/tuist_web/router.ex
@@ -381,6 +381,12 @@ defmodule TuistWeb.Router do
           metadata: @marketing_route_metadata,
           private: private
 
+      post Path.join(locale_path_prefix, "/newsletter/verify"),
+           MarketingController,
+           :newsletter_confirm,
+           metadata: @marketing_route_metadata,
+           private: private
+
       get Path.join(locale_path_prefix, "/newsletter/issues/:issue_number"),
           MarketingController,
           :newsletter_issue,

--- a/server/priv/gettext/marketing.pot
+++ b/server/priv/gettext/marketing.pot
@@ -7,7 +7,7 @@
 ## date. Leave "msgstr"s empty as changing them here has no
 ## effect: edit them in PO (.po) files instead.
 #
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:127
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:130
 #, elixir-autogen, elixir-format
 msgid "\"We could solve our immediate problems and do so while maintaining a familiar"
 msgstr ""
@@ -47,7 +47,7 @@ msgstr ""
 msgid "9+"
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:630
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:622
 #, elixir-autogen, elixir-format
 msgid "<p>Our commitment to open-source and our core values shape our unique approach to pricing. Unlike many models that try to extract every dollar from you with \"contact sales\" calls, limited demos, and other sales tactics, we believe in fairness and transparency. We treat everyone equally and set prices that are fair for all. By choosing our services, you are not only getting a great product but also supporting the development of more open-source projects. We see building a thriving business as a long-term journey, not a short-term sprint filled with shady practices. You can %{read_more}  about our philosophy.</p>\n<p>By supporting Tuist, you are also supporting the development of more open-source software for the Swift ecosystem.</p>\n"
 msgstr ""
@@ -64,7 +64,7 @@ msgstr ""
 
 #: lib/tuist_web/marketing/components/marketing_layout_components/footer.html.heex:197
 #: lib/tuist_web/marketing/components/marketing_layout_components/navbar.html.heex:70
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:245
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:248
 #, elixir-autogen, elixir-format
 msgid "About"
 msgstr ""
@@ -84,7 +84,7 @@ msgstr ""
 #: lib/tuist_web/marketing/components/marketing_layout_components/header.html.heex:195
 #: lib/tuist_web/marketing/components/marketing_layout_components/navbar.html.heex:274
 #: lib/tuist_web/marketing/components/marketing_layout_components/navbar.html.heex:485
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:569
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:561
 #: lib/tuist_web/marketing/controllers/marketing_html/blog_post.html.heex:10
 #: lib/tuist_web/marketing/live/marketing_blog_live.html.heex:13
 #: lib/tuist_web/marketing/live/marketing_blog_post_live.ex:52
@@ -303,7 +303,7 @@ msgstr ""
 msgid "Developers"
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:673
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:665
 #, elixir-autogen, elixir-format
 msgid "Discover our flexible pricing plans at Tuist. Enjoy a free tier with no time limits, and pay only for what you use. Plus, it's free forever for open source projects."
 msgstr ""
@@ -313,7 +313,7 @@ msgstr ""
 msgid "Do you offer annual billing discounts?"
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:648
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:640
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:687
 #, elixir-autogen, elixir-format
 msgid "Do you offer discounts for non-profits and open-source?"
@@ -463,7 +463,7 @@ msgstr ""
 msgid "Got ideas or questions? Join the conversation in our community forum."
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_html/newsletter_verify.html.heex:15
+#: lib/tuist_web/marketing/controllers/marketing_html/newsletter_verify.html.heex:20
 #, elixir-autogen, elixir-format
 msgid "Great! The email %{email} has been confirmed and subscribed to Tuist Digest."
 msgstr ""
@@ -488,7 +488,7 @@ msgstr ""
 msgid "How can I estimate the cost for my project?"
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:638
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:630
 #, elixir-autogen, elixir-format
 msgid "How can I estimate the cost of my project?"
 msgstr ""
@@ -523,7 +523,8 @@ msgstr ""
 msgid "Instantly share your app using a URL"
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:382
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:351
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:387
 #, elixir-autogen, elixir-format
 msgid "Invalid verification link. Please try signing up again."
 msgstr ""
@@ -533,7 +534,7 @@ msgstr ""
 msgid "Is there a free trial for paid plans?"
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:643
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:635
 #, elixir-autogen, elixir-format
 msgid "Is there a free trial on paid plans?"
 msgstr ""
@@ -563,7 +564,7 @@ msgstr ""
 msgid "Join the community on Slack"
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:132
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:135
 #, elixir-autogen, elixir-format
 msgid "Jonathan Crooke, Bumble"
 msgstr ""
@@ -643,8 +644,8 @@ msgstr ""
 msgid "Newsletter"
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:372
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:391
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:742
+#: lib/tuist_web/marketing/controllers/marketing_html/newsletter_verify.html.heex:14
 #, elixir-autogen, elixir-format
 msgid "Newsletter Verification Failed"
 msgstr ""
@@ -707,7 +708,7 @@ msgstr ""
 msgid "People"
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:320
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:322
 #, elixir-autogen, elixir-format
 msgid "Please check your email to confirm your subscription."
 msgstr ""
@@ -739,7 +740,7 @@ msgstr ""
 #: lib/tuist_web/marketing/components/marketing_layout_components/header.html.heex:189
 #: lib/tuist_web/marketing/components/marketing_layout_components/navbar.html.heex:267
 #: lib/tuist_web/marketing/components/marketing_layout_components/navbar.html.heex:480
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:668
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:660
 #, elixir-autogen, elixir-format
 msgid "Pricing"
 msgstr ""
@@ -851,8 +852,8 @@ msgstr ""
 msgid "Sign up"
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:143
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:184
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:146
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:187
 #, elixir-autogen, elixir-format
 msgid "Since adopting Tuist in our iOS project, we've seen major improvements in scalability and productivity. Overall, it has made our development process faster and more efficient, allowing the team to focus on building features without being slowed down by tool limitations."
 msgstr ""
@@ -880,7 +881,7 @@ msgstr ""
 msgid "Socials"
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:329
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:331
 #, elixir-autogen, elixir-format
 msgid "Something went wrong. Please try again."
 msgstr ""
@@ -946,8 +947,8 @@ msgstr ""
 msgid "Subscribe"
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:340
-#: lib/tuist_web/marketing/controllers/marketing_html/newsletter_verify.html.heex:13
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:369
+#: lib/tuist_web/marketing/controllers/marketing_html/newsletter_verify.html.heex:18
 #, elixir-autogen, elixir-format
 msgid "Successfully Subscribed!"
 msgstr ""
@@ -957,14 +958,14 @@ msgstr ""
 msgid "Supercharge your app development"
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:267
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:270
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:214
 #: lib/tuist_web/marketing/controllers/marketing_html/support.html.heex:2
 #, elixir-autogen, elixir-format
 msgid "Support"
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:289
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:292
 #, elixir-autogen, elixir-format
 msgid "Swift Stories Newsletter"
 msgstr ""
@@ -1002,12 +1003,12 @@ msgstr ""
 msgid "That's why Tuist exists—to restore the joy of development at any scale. We enhance Apple's native tooling by bringing innovative ideas from across the development ecosystem, so teams can focus on creating exceptional apps instead of fighting their build system."
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:426
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:418
 #, elixir-autogen, elixir-format
 msgid "The newsletter issue %{issue_number} was not found."
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:418
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:410
 #, elixir-autogen, elixir-format
 msgid "The newsletter issue number %{issue_number} is not a valid number."
 msgstr ""
@@ -1037,13 +1038,13 @@ msgstr ""
 msgid "Trusted by the world's best developer teams"
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:244
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:266
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:288
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:568
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:612
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:667
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:708
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:247
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:269
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:291
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:560
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:604
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:659
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:700
 #: lib/tuist_web/marketing/live/marketing_blog_post_live.ex:51
 #, elixir-autogen, elixir-format
 msgid "Tuist"
@@ -1066,7 +1067,7 @@ msgstr ""
 msgid "Tuist Digest"
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:299
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:302
 #, elixir-autogen, elixir-format
 msgid "Tuist Digest Newsletter"
 msgstr ""
@@ -1087,17 +1088,17 @@ msgstr ""
 msgid "Tuist bridges the gaps in Apple's tooling that prevent teams from moving fast. We solve the build complexity, workflow friction, and collaboration challenges—so you can deliver exceptional apps at speed."
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:223
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:226
 #, elixir-autogen, elixir-format
 msgid "Tuist has allowed us to migrate our existing monolythic codebase to a modular one. We extracted our different domains into specific modules. It allowed us to remove extra dependencies, ease testability and made our development cycles faster than ever. It even allowed us to bring up 'Test Apps' for speeding up our development on each module."
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:157
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:160
 #, elixir-autogen, elixir-format
 msgid "Tuist has been a game-changer for our large codebase, where multiple engineers collaborate simultaneously. I've been using it since version 1, and it's been incredible to see how the product has evolved and expanded with new features over time."
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:172
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:175
 #, elixir-autogen, elixir-format
 msgid "Tuist has revolutionized our iOS development workflow at DraftKings. Its automation capabilities have streamlined project generation, build settings, and dependency management. Highly recommended for iOS teams seeking workflow optimization."
 msgstr ""
@@ -1168,17 +1169,18 @@ msgstr ""
 msgid "Usage/seat based pricing"
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:196
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:199
 #, elixir-autogen, elixir-format
 msgid "Using Tuist in our current project has been a game-changer. It has significantly de-stressed our build times and reduced conflicts within the team, allowing us to focus more on development and less on configuration issues. We're confident that it will continue to enhance our productivity and collaboration in future projects."
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:364
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:380
 #, elixir-autogen, elixir-format
 msgid "Verification failed. Please try signing up again."
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:401
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:359
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:395
 #, elixir-autogen, elixir-format
 msgid "Verification link expired or invalid. Please try signing up again."
 msgstr ""
@@ -1219,7 +1221,7 @@ msgstr ""
 msgid "We embrace standards for long-term success while respecting freedom of choice."
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:644
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:636
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:670
 #, elixir-autogen, elixir-format
 msgid "We have a generous free tier on every paid plan so you can try out the features before paying any money."
@@ -1275,12 +1277,12 @@ msgstr ""
 msgid "What we believe in"
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:626
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:618
 #, elixir-autogen, elixir-format
 msgid "Why is your pricing model more accessible compared to traditional enterprise models?"
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:211
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:214
 #, elixir-autogen, elixir-format
 msgid "With macros, external SDKs, and many SPM modules (fully modularized app) Xcode was constantly slow or stuck on my M1 device. SPM kept resolving, code completion didn't work, and swift-syntax compiled forever. It's not just for big teams with big apps. Tuist gave me back my productivity as indie developer for my side projects."
 msgstr ""
@@ -1305,7 +1307,7 @@ msgstr ""
 msgid "Yes, we do. Please reach out to contact@tuist.dev for more information."
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:649
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:641
 #, elixir-autogen, elixir-format
 msgid "Yes, we do. Please reach out to oss@tuist.io for more information."
 msgstr ""
@@ -1325,7 +1327,7 @@ msgstr ""
 msgid "You can set up the Air plan and use the features for a few days to get a usage estimate. If you need a higher limit, let us know and we can help you set up a custom plan."
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:639
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:631
 #, elixir-autogen, elixir-format
 msgid "You can set up the Air plan, and use the features for a few days to get a usage estimate. If you need a higher limit, let us know and we can help you set up a custom plan."
 msgstr ""
@@ -1335,7 +1337,7 @@ msgstr ""
 msgid "You'll be warned before reaching your plan limits. Once reached, the plan will cap interactions to prevent unexpected charges."
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_html/newsletter_verify.html.heex:25
+#: lib/tuist_web/marketing/controllers/marketing_html/newsletter_verify.html.heex:50
 #, elixir-autogen, elixir-format
 msgid "You'll receive newsletter issues every 6 weeks with the most important work happening in Tuist and our vision for the future of app development at scale."
 msgstr ""
@@ -1350,7 +1352,7 @@ msgstr ""
 msgid "Your platform team, as a service"
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:131
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:134
 #, elixir-autogen, elixir-format
 msgid "core development experience\""
 msgstr ""
@@ -1370,7 +1372,7 @@ msgstr ""
 msgid "pay as you go"
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:636
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:628
 #, elixir-autogen, elixir-format
 msgid "read more"
 msgstr ""
@@ -1527,7 +1529,7 @@ msgstr ""
 
 #: lib/tuist_web/marketing/components/marketing_layout_components/footer.html.heex:206
 #: lib/tuist_web/marketing/components/marketing_layout_components/navbar.html.heex:106
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:613
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:605
 #: lib/tuist_web/marketing/controllers/marketing_html/case_study.html.heex:10
 #: lib/tuist_web/marketing/live/marketing_customers_live.ex:71
 #: lib/tuist_web/marketing/live/marketing_customers_live.html.heex:22
@@ -2355,7 +2357,7 @@ msgstr ""
 msgid "as a service"
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:44
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:47
 #: lib/tuist_web/marketing/controllers/marketing_html/home.html.heex:27
 #, elixir-autogen, elixir-format
 msgid "Let us be your virtual companion that continuously optimizes and observes your setup, so you can focus on shipping"
@@ -2368,4 +2370,25 @@ msgstr ""
 #: lib/tuist_web/marketing/controllers/marketing_html/home.html.heex:358
 #, elixir-autogen, elixir-format
 msgid "Open the %{feature} feature page"
+msgstr ""
+
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:340
+#: lib/tuist_web/marketing/controllers/marketing_html/newsletter_verify.html.heex:27
+#, elixir-autogen, elixir-format
+msgid "Confirm Subscription"
+msgstr ""
+
+#: lib/tuist_web/marketing/controllers/marketing_html/newsletter_verify.html.heex:60
+#, elixir-autogen, elixir-format
+msgid "Confirm subscription"
+msgstr ""
+
+#: lib/tuist_web/marketing/controllers/marketing_html/newsletter_verify.html.heex:43
+#, elixir-autogen, elixir-format
+msgid "Open the confirmation link from the latest newsletter email, or subscribe again to receive a fresh link."
+msgstr ""
+
+#: lib/tuist_web/marketing/controllers/marketing_html/newsletter_verify.html.heex:29
+#, elixir-autogen, elixir-format
+msgid "Please confirm that you want %{email} to receive Tuist Digest."
 msgstr ""

--- a/server/test/tuist_web/controllers/marketing_controller_test.exs
+++ b/server/test/tuist_web/controllers/marketing_controller_test.exs
@@ -24,7 +24,13 @@ defmodule TuistWeb.Marketing.MarketingControllerTest do
       email = "test@example.com"
 
       expect(Loops, :send_newsletter_confirmation, fn ^email, verification_url ->
-        assert String.contains?(verification_url, "/newsletter/verify?token=")
+        uri = URI.parse(verification_url)
+        assert uri.path == "/newsletter/verify"
+        assert %{"token" => token} = URI.decode_query(uri.query)
+
+        assert {:ok, ^email} =
+                 Phoenix.Token.verify(TuistWeb.Endpoint, "newsletter_subscription", token, max_age: 2 * 24 * 60 * 60)
+
         :ok
       end)
 
@@ -104,14 +110,10 @@ defmodule TuistWeb.Marketing.MarketingControllerTest do
   end
 
   describe "GET /newsletter/verify" do
-    test "successfully verifies email with valid token", %{conn: conn} do
+    test "shows a confirmation page with a valid token", %{conn: conn} do
       # Given
       email = "test@example.com"
-      token = Base.encode64(email)
-
-      expect(Loops, :add_to_newsletter_list, fn ^email ->
-        :ok
-      end)
+      token = signed_newsletter_token(email)
 
       # When
       conn = get(conn, ~p"/newsletter/verify?token=#{token}")
@@ -119,8 +121,27 @@ defmodule TuistWeb.Marketing.MarketingControllerTest do
       # Then
       assert html_response(conn, 200)
       assert conn.assigns.email == email
+      assert conn.assigns.verification_token == token
+      assert conn.assigns.subscription_confirmed == false
       assert conn.assigns.error_message == nil
-      assert conn.assigns.head_title == "Successfully Subscribed!"
+      assert conn.assigns.head_title == "Confirm Subscription"
+    end
+
+    test "does not accept legacy base64 email tokens", %{conn: conn} do
+      # Given
+      token = Base.encode64("test@example.com")
+
+      # When
+      conn = get(conn, ~p"/newsletter/verify?token=#{token}")
+
+      # Then
+      assert html_response(conn, 200)
+      assert conn.assigns.email == nil
+
+      assert conn.assigns.error_message ==
+               "Invalid verification link. Please try signing up again."
+
+      assert conn.assigns.head_title == "Newsletter Verification Failed"
     end
 
     test "shows error page when token is invalid", %{conn: conn} do
@@ -153,18 +174,40 @@ defmodule TuistWeb.Marketing.MarketingControllerTest do
 
       assert conn.assigns.head_title == "Newsletter Verification Failed"
     end
+  end
+
+  describe "POST /newsletter/verify" do
+    test "subscribes email with a valid token", %{conn: conn} do
+      # Given
+      email = "test@example.com"
+      token = signed_newsletter_token(email)
+
+      expect(Loops, :add_to_newsletter_list, fn ^email ->
+        :ok
+      end)
+
+      # When
+      conn = post(conn, ~p"/newsletter/verify", %{"token" => token})
+
+      # Then
+      assert html_response(conn, 200)
+      assert conn.assigns.email == email
+      assert conn.assigns.subscription_confirmed == true
+      assert conn.assigns.error_message == nil
+      assert conn.assigns.head_title == "Successfully Subscribed!"
+    end
 
     test "shows error page when Loops API fails during verification", %{conn: conn} do
       # Given
       email = "test@example.com"
-      token = Base.encode64(email)
+      token = signed_newsletter_token(email)
 
       expect(Loops, :add_to_newsletter_list, fn ^email ->
         {:error, {:http_error, 400}}
       end)
 
       # When
-      conn = get(conn, ~p"/newsletter/verify?token=#{token}")
+      conn = post(conn, ~p"/newsletter/verify", %{"token" => token})
 
       # Then
       assert html_response(conn, 200)
@@ -172,5 +215,37 @@ defmodule TuistWeb.Marketing.MarketingControllerTest do
       assert conn.assigns.error_message == "Verification failed. Please try signing up again."
       assert conn.assigns.head_title == "Newsletter Verification Failed"
     end
+
+    test "shows error page when token is invalid", %{conn: conn} do
+      # When
+      conn = post(conn, ~p"/newsletter/verify", %{"token" => "invalid-token"})
+
+      # Then
+      assert html_response(conn, 200)
+      assert conn.assigns.email == nil
+
+      assert conn.assigns.error_message ==
+               "Invalid verification link. Please try signing up again."
+
+      assert conn.assigns.head_title == "Newsletter Verification Failed"
+    end
+
+    test "shows error page when no token provided", %{conn: conn} do
+      # When
+      conn = post(conn, ~p"/newsletter/verify", %{})
+
+      # Then
+      assert html_response(conn, 200)
+      assert conn.assigns.email == nil
+
+      assert conn.assigns.error_message ==
+               "Verification link expired or invalid. Please try signing up again."
+
+      assert conn.assigns.head_title == "Newsletter Verification Failed"
+    end
+  end
+
+  defp signed_newsletter_token(email) do
+    Phoenix.Token.sign(TuistWeb.Endpoint, "newsletter_subscription", email)
   end
 end


### PR DESCRIPTION
Resolves no tracked issue

## What changed

This changes the Tuist Digest newsletter verification flow so the confirmation link no longer subscribes the email address by itself.

- Newsletter confirmation links now carry a signed token that expires after two days.
- Opening the link renders a confirmation screen instead of calling Loops immediately.
- The final Loops subscription now happens only after the user submits the confirmation form.
- Invalid, expired, and legacy forged tokens render the failure state.
- The gettext template and controller tests cover the new strings and verification paths.

## Why

We received suspicious Loops notifications for newsletter subscribers with random-looking addresses. Production logs showed newsletter verification traffic, and the code path made those links enough to add the address to the newsletter list.

The newsletter subscriber list lives in Loops rather than in the Tuist application database, so the fix needs to happen at the verification boundary before Loops receives the subscription request.

## Root cause

The previous token was only a reversible encoding of the email address. Anyone could build a verification link for an arbitrary address, and automated link scanners could trigger the subscription because opening the link had the side effect.

## Approach

The confirmation email still sends a link, but that link now contains a signed Phoenix token. A valid token on the read route only shows the address and asks for explicit confirmation. The form posts the same token back to the server, where it is verified again before calling Loops.

This keeps the email ownership check while removing the unsafe side effect from link previews, mailbox scanners, and forged legacy links.

## Impact

New newsletter subscribers need one extra explicit click after opening the confirmation link. Existing old confirmation links stop working because their tokens were forgeable. That tradeoff is intentional for this abuse path.

No database migration, data export change, or translation file change is included.

## Screenshots

Valid signed token confirmation screen:

![Valid signed token confirmation screen](https://raw.githubusercontent.com/tuist/tuist/pr-assets-newsletter-confirmation-11732/.github/pr-screenshots/newsletter-confirmation/valid-token.png)

Invalid or forged token failure screen:

![Invalid token failure screen](https://raw.githubusercontent.com/tuist/tuist/pr-assets-newsletter-confirmation-11732/.github/pr-screenshots/newsletter-confirmation/invalid-token.png)

## Validation

- `mix format lib/tuist_web/marketing/controllers/marketing_controller.ex lib/tuist_web/marketing/controllers/marketing_html/newsletter_verify.html.heex lib/tuist_web/router.ex test/tuist_web/controllers/marketing_controller_test.exs`
- `mix test test/tuist_web/controllers/marketing_controller_test.exs:22 test/tuist_web/controllers/marketing_controller_test.exs:47 test/tuist_web/controllers/marketing_controller_test.exs:65 test/tuist_web/controllers/marketing_controller_test.exs:113 test/tuist_web/controllers/marketing_controller_test.exs:130 test/tuist_web/controllers/marketing_controller_test.exs:147 test/tuist_web/controllers/marketing_controller_test.exs:164 test/tuist_web/controllers/marketing_controller_test.exs:180 test/tuist_web/controllers/marketing_controller_test.exs:200 test/tuist_web/controllers/marketing_controller_test.exs:219 test/tuist_web/controllers/marketing_controller_test.exs:233`, which passed with 11 tests.
- `git diff --check`
- Started the Phoenix server locally with `mise exec -- mix phx.server` and captured the two screenshots above with a headless Chrome browser.

The full `marketing_controller_test.exs` file still has an existing, unrelated localized Hyperconnect route failure in this checkout.
