### PR TITLE
fix(server): format runner job assets

### DIFF
--- a/server/assets/app/css/pages/runner_job.css
+++ b/server/assets/app/css/pages/runner_job.css
@@ -620,8 +620,7 @@
     overflow: hidden;
 
     &[data-state="requested"] {
-      background:
-        linear-gradient(135deg, color-mix(in srgb, var(--noora-azure-500) 12%, transparent), transparent 52%),
+      background: linear-gradient(135deg, color-mix(in srgb, var(--noora-azure-500) 12%, transparent), transparent 52%),
         var(--noora-surface-background-secondary);
     }
   }

--- a/server/assets/app/js/RunnerVNCFullscreen.js
+++ b/server/assets/app/js/RunnerVNCFullscreen.js
@@ -32,9 +32,7 @@ export default {
     this.target = document.querySelector(this.el.dataset.fullscreenTarget) || this.el;
     this.label = this.button?.querySelector("span");
     this.enterLabel =
-      this.button?.dataset.fullscreenEnterLabel ||
-      this.button?.getAttribute("aria-label") ||
-      "Full screen";
+      this.button?.dataset.fullscreenEnterLabel || this.button?.getAttribute("aria-label") || "Full screen";
     this.exitLabel = this.button?.dataset.fullscreenExitLabel || "Exit full screen";
     this.onClick = () => this.toggle();
     this.onFullscreenChange = () => this.sync();


### PR DESCRIPTION
## What changed

- Applied Prettier formatting to the runner job page stylesheet.
- Applied Prettier formatting to the runner VNC fullscreen hook.

## Why it changed

The `Format` GitHub Actions job for run `29021059014` failed on `prettier --check assets` after reporting style issues in `server/assets/app/css/pages/runner_job.css` and `server/assets/app/js/RunnerVNCFullscreen.js`.

## Root cause

The affected CSS and JavaScript had line wrapping that did not match the repository's configured Prettier output, so the check detected the files as unformatted even though the underlying behavior was unchanged.

## Impact

This restores the asset formatting check without changing runtime behavior.

## Validation

- `MISE_TRUSTED_CONFIG_PATHS=/Users/marekfort/.codex/worktrees/618d/tuist prettier --check assets`