### PR TITLE
fix(infra): emit a CiliumNetworkPolicy so cross-region kura peers can reach the peer port

### DIFF
--- a/infra/helm/tuist/templates/kura-controller.yaml
+++ b/infra/helm/tuist/templates/kura-controller.yaml
@@ -98,6 +98,13 @@ rules:
   - apiGroups: ["cert-manager.io"]
     resources: [certificates]
     verbs: [get, list, watch, create, update, patch, delete]
+  # Cross-region peers arrive SNATed as Cilium's remote-node identity, which a
+  # k8s NetworkPolicy ipBlock (world) can't admit; the controller opens the peer
+  # port with a CiliumNetworkPolicy fromEntities [remote-node, cluster]. Absent
+  # the CRD (non-Cilium cluster) reconcileCiliumPeerPolicy no-ops.
+  - apiGroups: ["cilium.io"]
+    resources: [ciliumnetworkpolicies]
+    verbs: [get, list, watch, create, update, patch, delete]
   - apiGroups: [""]
     resources: [events]
     verbs: [create, patch]

--- a/infra/kura-controller/controllers/kurainstance_controller.go
+++ b/infra/kura-controller/controllers/kurainstance_controller.go
@@ -24,6 +24,7 @@ import (
 	networkingv1 "k8s.io/api/networking/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -278,6 +279,9 @@ func (r *KuraInstanceReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{}, err
 	}
 	if err := r.reconcileNetworkPolicy(ctx, instance); err != nil {
+		return ctrl.Result{}, err
+	}
+	if err := r.reconcileCiliumPeerPolicy(ctx, instance); err != nil {
 		return ctrl.Result{}, err
 	}
 	if err := r.reconcilePodDisruptionBudget(ctx, instance); err != nil {
@@ -1985,6 +1989,72 @@ func (r *KuraInstanceReconciler) reconcileNetworkPolicy(ctx context.Context, ins
 		policy.Spec.Ingress = ingress
 		return nil
 	})
+	return err
+}
+
+// ciliumPeerPolicyGVK identifies the CiliumNetworkPolicy the controller emits to
+// open the mesh peer port to cross-provider peers.
+var ciliumPeerPolicyGVK = schema.GroupVersionKind{Group: "cilium.io", Version: "v2", Kind: "CiliumNetworkPolicy"}
+
+// reconcileCiliumPeerPolicy opens the peer port to Cilium's remote-node and
+// cluster entities for cross-region instances.
+//
+// A same-account peer in another region reaches this instance over
+// cross-provider in-cluster pod-to-pod traffic that Cilium SNATs to a node IP,
+// so its source carries the reserved `remote-node` identity. Standard k8s
+// NetworkPolicy ipBlock rules — even 0.0.0.0/0 — match only the `world` entity,
+// never `remote-node`, so no k8s NetworkPolicy (see reconcileNetworkPolicy) can
+// open the peer port for a cross-provider peer: the SYN is silently dropped and
+// the dialing region holds the peer inflight forever. A CiliumNetworkPolicy with
+// fromEntities [remote-node, cluster] is the only construct that admits it. The
+// account-CA mutual-TLS handshake stays the auth boundary, so opening the port
+// by entity grants no access on its own (same rationale as the ipBlock rule).
+//
+// Emitted only for cross-region instances and removed otherwise. Where the
+// CiliumNetworkPolicy CRD is absent (a non-Cilium cluster, or envtest), the
+// reconcile degrades to a no-op so the controller stays portable.
+func (r *KuraInstanceReconciler) reconcileCiliumPeerPolicy(ctx context.Context, instance *kurav1alpha1.KuraInstance) error {
+	policy := &unstructured.Unstructured{}
+	policy.SetGroupVersionKind(ciliumPeerPolicyGVK)
+	policy.SetNamespace(instance.Namespace)
+	policy.SetName(instance.Name + "-peer")
+
+	if !crossRegionRuntimeEnabled(instance) {
+		err := r.Delete(ctx, policy)
+		if apierrors.IsNotFound(err) || meta.IsNoMatchError(err) {
+			return nil
+		}
+		return err
+	}
+
+	matchLabels := map[string]any{}
+	for k, v := range selectorLabels(instance) {
+		matchLabels[k] = v
+	}
+	_, err := controllerutil.CreateOrUpdate(ctx, r.Client, policy, func() error {
+		if err := controllerutil.SetControllerReference(instance, policy, r.Scheme); err != nil {
+			return err
+		}
+		policy.SetLabels(labels(instance))
+		return unstructured.SetNestedMap(policy.Object, map[string]any{
+			"endpointSelector": map[string]any{"matchLabels": matchLabels},
+			"ingress": []any{
+				map[string]any{
+					"fromEntities": []any{"remote-node", "cluster"},
+					"toPorts": []any{
+						map[string]any{
+							"ports": []any{
+								map[string]any{"port": strconv.Itoa(int(peerPort)), "protocol": "TCP"},
+							},
+						},
+					},
+				},
+			},
+		}, "spec")
+	})
+	if meta.IsNoMatchError(err) {
+		return nil
+	}
 	return err
 }
 

--- a/infra/kura-controller/controllers/kurainstance_controller_test.go
+++ b/infra/kura-controller/controllers/kurainstance_controller_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
+	"strconv"
 	"testing"
 	"time"
 
@@ -535,6 +536,80 @@ func meshTestScheme(t *testing.T) *runtime.Scheme {
 		t.Fatal(err)
 	}
 	return scheme
+}
+
+func meshTestSchemeWithCilium(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	scheme := meshTestScheme(t)
+	scheme.AddKnownTypeWithName(ciliumPeerPolicyGVK, &unstructured.Unstructured{})
+	listGVK := ciliumPeerPolicyGVK
+	listGVK.Kind += "List"
+	scheme.AddKnownTypeWithName(listGVK, &unstructured.UnstructuredList{})
+	return scheme
+}
+
+// A cross-region instance gets a CiliumNetworkPolicy admitting Cilium's
+// remote-node entity on the peer port. A same-account peer in another region
+// arrives SNATed as remote-node, which a k8s NetworkPolicy ipBlock (world) can
+// never match — so this is the only construct that opens cross-provider peering.
+func TestReconcileCiliumPeerPolicyAdmitsRemoteNodeOnPeerPort(t *testing.T) {
+	ctx := context.Background()
+	scheme := meshTestSchemeWithCilium(t)
+
+	instance := meshInstance("kura-tuist-scw-fr-par", "tuist")
+	instance.Spec.ExposeNodePort = true // NodePort runner-cache mesh peer, no public host
+
+	reconciler := &KuraInstanceReconciler{
+		Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(instance).WithStatusSubresource(instance).Build(),
+		Scheme: scheme,
+	}
+	if _, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: instance.Name, Namespace: instance.Namespace}}); err != nil {
+		t.Fatal(err)
+	}
+
+	cnp := &unstructured.Unstructured{}
+	cnp.SetGroupVersionKind(ciliumPeerPolicyGVK)
+	if err := reconciler.Get(ctx, types.NamespacedName{Name: instance.Name + "-peer", Namespace: instance.Namespace}, cnp); err != nil {
+		t.Fatalf("expected a CiliumNetworkPolicy for a cross-region instance: %v", err)
+	}
+	ingress, found, err := unstructured.NestedSlice(cnp.Object, "spec", "ingress")
+	if err != nil || !found || len(ingress) != 1 {
+		t.Fatalf("expected one ingress rule, got %v (found=%v err=%v)", ingress, found, err)
+	}
+	rule, _ := ingress[0].(map[string]any)
+	ents, _ := rule["fromEntities"].([]any)
+	hasRemoteNode := false
+	for _, e := range ents {
+		if e == "remote-node" {
+			hasRemoteNode = true
+		}
+	}
+	if !hasRemoteNode {
+		t.Fatalf("expected fromEntities to include remote-node, got %v", ents)
+	}
+	toPorts, _ := rule["toPorts"].([]any)
+	if len(toPorts) != 1 {
+		t.Fatalf("expected one toPorts entry, got %v", toPorts)
+	}
+	ports, _ := toPorts[0].(map[string]any)["ports"].([]any)
+	if len(ports) != 1 || ports[0].(map[string]any)["port"] != strconv.Itoa(int(peerPort)) {
+		t.Fatalf("expected the peer port %d, got %v", peerPort, ports)
+	}
+
+	// A non-cross-region instance (no Mesh, no external peer secret) gets none.
+	solo := meshInstance("kura-tuist-solo", "tuist")
+	solo.Spec.Mesh = false
+	if err := reconciler.Create(ctx, solo); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: solo.Name, Namespace: solo.Namespace}}); err != nil {
+		t.Fatal(err)
+	}
+	absent := &unstructured.Unstructured{}
+	absent.SetGroupVersionKind(ciliumPeerPolicyGVK)
+	if err := reconciler.Get(ctx, types.NamespacedName{Name: solo.Name + "-peer", Namespace: solo.Namespace}, absent); !apierrors.IsNotFound(err) {
+		t.Fatalf("expected no CiliumNetworkPolicy for a non-cross-region instance, got %v", err)
+	}
 }
 
 func TestKuraInstanceReconcilePeerTLSSecretMeshSignsLeafWithAccountCA(t *testing.T) {


### PR DESCRIPTION
## Root cause (the definitive one behind the EU-Central wedge)

Cross-region mesh peers reach each other over cross-provider in-cluster pod-to-pod traffic that Cilium **SNATs to a node IP**, so the source carries the reserved **`remote-node`** identity. A standard k8s NetworkPolicy `ipBlock` rule — even `0.0.0.0/0` (added in #11730) — matches only Cilium's **`world`** entity, never `remote-node`. So no k8s NetworkPolicy can admit a cross-provider peer: the SYN is silently dropped, and the dialing region holds that peer `inflight` forever and never reaches readiness.

Only a `CiliumNetworkPolicy` with `fromEntities: [remote-node, cluster]` opens it.

**Proven in production** (break-glass, exit-code probes since the bare-metal nodes' kubelet logs are unreachable): a same-node probe carrying the account label reached `scw-fr-par:7443` (kura listens, podSelector works), but a cross-provider probe was dropped — until a `CiliumNetworkPolicy fromEntities:[remote-node,cluster]` was applied, after which cross-provider TCP+TLS+mTLS to the peer port succeeded from both a Hetzner and a Dedibox node.

## Change

The controller now emits `<instance>-peer` `CiliumNetworkPolicy` for every cross-region instance (`crossRegionRuntimeEnabled`) and removes it otherwise. Ingress: `fromEntities: [remote-node, cluster]` → the peer port (`7443`). The account-CA mutual-TLS handshake stays the auth boundary, so opening the port by entity grants no access on its own — same rationale as the existing `ipBlock` rule.

- Portable: where the `CiliumNetworkPolicy` CRD is absent (a non-Cilium cluster, or envtest), the reconcile degrades to a no-op via `meta.IsNoMatchError`.
- RBAC: adds `ciliumnetworkpolicies.cilium.io` to the controller Role.

## Validation

`go build`, `go vet`, and the full controller suite pass, including a new test asserting a cross-region instance gets the `fromEntities:[remote-node]` CNP on the peer port and a non-cross-region instance gets none.

## Relation to the incident

This is the third and deepest of three stacked bugs behind the tuist EU-Central region wedge: `kube-dns` RBAC for `peer-demux` (#11729), the ipBlock open-peer NP (#11730), and this — the only one that actually opens cross-provider peering. A live CNP is already applied to production as the immediate fix; this makes the controller emit it durably. (A separate follow-up addresses a kura-side bug where an oversized artifact wedges the cross-region bootstrap.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)