### PR TITLE
fix(server): avoid runner queue head blocking

### DIFF
--- a/server/lib/tuist/runners.ex
+++ b/server/lib/tuist/runners.ex
@@ -88,6 +88,7 @@ defmodule Tuist.Runners do
   # the open-loop time stagger this replaced drained on a fixed 30s
   # cadence that was far shorter than a multi-minute image pull.
   @drain_eligible_label "tuist.dev/drain-eligible"
+  @max_claim_attempts_per_dispatch 16
 
   @doc """
   Returns the raw load signals the runners-controller's autoscaler
@@ -169,30 +170,62 @@ defmodule Tuist.Runners do
   end
 
   defp claim_and_serve(namespace, sa_name, fleet_name) do
-    with {:ok, candidate} <- Jobs.pick_queued(fleet_name, []),
-         {:ok, claim} <-
-           Claims.attempt(
-             candidate.workflow_job_id,
-             candidate.account_id,
-             fleet_name,
-             sa_name
-           ) do
-      Jobs.record_claimed(candidate, sa_name, claim.claimed_at)
-      serve_claim(namespace, sa_name, fleet_name, candidate, claim)
-    else
+    excluded_workflow_job_ids = Claims.workflow_job_ids_for_fleet(fleet_name)
+    claim_and_serve(namespace, sa_name, fleet_name, excluded_workflow_job_ids, @max_claim_attempts_per_dispatch)
+  end
+
+  defp claim_and_serve(_namespace, sa_name, fleet_name, _excluded_workflow_job_ids, 0) do
+    Logger.debug("runners: claim attempts exhausted",
+      fleet: fleet_name,
+      sa: sa_name
+    )
+
+    {:error, :lost_race}
+  end
+
+  defp claim_and_serve(namespace, sa_name, fleet_name, excluded_workflow_job_ids, attempts_left) do
+    case Jobs.pick_queued(fleet_name, [], excluded_workflow_job_ids) do
+      {:ok, candidate} ->
+        case Claims.attempt(candidate.workflow_job_id, candidate.account_id, fleet_name, sa_name) do
+          {:ok, claim} ->
+            Jobs.record_claimed(candidate, sa_name, claim.claimed_at)
+            serve_claim(namespace, sa_name, fleet_name, candidate, claim)
+
+          {:error, :lost_race} ->
+            Logger.debug("runners: claim attempt lost race; trying next queued job",
+              fleet: fleet_name,
+              sa: sa_name,
+              workflow_job_id: candidate.workflow_job_id
+            )
+
+            claim_and_serve(
+              namespace,
+              sa_name,
+              fleet_name,
+              [candidate.workflow_job_id | excluded_workflow_job_ids],
+              attempts_left - 1
+            )
+
+          {:error, :pod_in_use} ->
+            Logger.debug("runners: claim attempt declined",
+              reason: :pod_in_use,
+              fleet: fleet_name,
+              sa: sa_name
+            )
+
+            {:error, :pod_in_use}
+
+          {:error, reason} ->
+            Logger.warning("runners: dispatch_for_sa failed",
+              reason: inspect(reason),
+              fleet: fleet_name
+            )
+
+            {:error, reason}
+        end
+
       {:error, :empty} ->
         {:error, :empty}
-
-      {:error, reason} when reason in [:lost_race, :pod_in_use] ->
-        # Lost the Postgres claim race (or the Pod already holds a
-        # claim). The candidate stays queued in CH for the next poll.
-        Logger.debug("runners: claim attempt declined",
-          reason: reason,
-          fleet: fleet_name,
-          sa: sa_name
-        )
-
-        {:error, reason}
 
       {:error, reason} ->
         Logger.warning("runners: dispatch_for_sa failed",
@@ -315,11 +348,10 @@ defmodule Tuist.Runners do
   #
   #   * Both succeed → row back in the queued pool immediately.
   #   * CH ok, PG delete fails / crash → CH says queued, PG
-  #     still claimed. The next poll picks the row, hits a PG
-  #     PK conflict on `Claims.attempt`, returns :lost_race
-  #     and bails — no double-mint. `StaleClaimsWorker` later
-  #     deletes the stale PG row (after 5 min) and the next
-  #     poll claims cleanly.
+  #     still claimed. The next poll skips rows already claimed
+  #     in PG (or loses the claim race once and tries the next
+  #     queued row), so later workflow_jobs can still dispatch
+  #     while `StaleClaimsWorker` cleans up the stale PG row.
   #   * CH fails → leave PG alone; the stale-worker will both
   #     drop the PG row AND re-INSERT `queued` to CH on its
   #     normal recovery path.

--- a/server/lib/tuist/runners.ex
+++ b/server/lib/tuist/runners.ex
@@ -226,14 +226,6 @@ defmodule Tuist.Runners do
 
       {:error, :empty} ->
         {:error, :empty}
-
-      {:error, reason} ->
-        Logger.warning("runners: dispatch_for_sa failed",
-          reason: inspect(reason),
-          fleet: fleet_name
-        )
-
-        {:error, reason}
     end
   end
 

--- a/server/lib/tuist/runners/claims.ex
+++ b/server/lib/tuist/runners/claims.ex
@@ -226,6 +226,17 @@ defmodule Tuist.Runners.Claims do
   end
 
   @doc """
+  Returns active claim workflow_job IDs for `fleet_name`.
+
+  Dispatch uses this as an anti-list when selecting queued ClickHouse
+  rows. If ClickHouse still says a job is queued while Postgres already
+  has a live claim for it, that row must not pin the fleet's queue head.
+  """
+  def workflow_job_ids_for_fleet(fleet_name) when is_binary(fleet_name) do
+    Repo.all(from(c in Claim, where: c.fleet_name == ^fleet_name, select: c.workflow_job_id))
+  end
+
+  @doc """
   Counts active claims per account **across all fleets**. Returns
   `%{account_id => count}` — how many runners each account is
   currently using. Not fleet-scoped: an account's jobs spread

--- a/server/lib/tuist/runners/jobs.ex
+++ b/server/lib/tuist/runners/jobs.ex
@@ -130,16 +130,19 @@ defmodule Tuist.Runners.Jobs do
   `Tuist.Runners.Claims.attempt/4`.
 
   `ineligible_account_ids` is an optional set of account_ids to
-  exclude from candidate selection. Returns the candidate's full
-  metadata so we can carry it forward on the `claimed` INSERT.
+  exclude from candidate selection. `excluded_workflow_job_ids`
+  skips specific queued rows that are already claimed in Postgres or
+  that this dispatch poll already lost a claim race for. Returns the
+  candidate's full metadata so we can carry it forward on the
+  `claimed` INSERT.
 
   Deterministic ordering — `(enqueued_at ASC, workflow_job_id
   ASC)` — means two concurrent pollers see the SAME row as the
   next candidate. The actual claim race then collapses on
   Postgres uniqueness in `Claims.attempt/4`.
   """
-  def pick_queued(fleet_name, ineligible_account_ids \\ [])
-      when is_binary(fleet_name) and is_list(ineligible_account_ids) do
+  def pick_queued(fleet_name, ineligible_account_ids \\ [], excluded_workflow_job_ids \\ [])
+      when is_binary(fleet_name) and is_list(ineligible_account_ids) and is_list(excluded_workflow_job_ids) do
     from(j in Job,
       where: j.fleet_name == ^fleet_name,
       group_by: j.workflow_job_id,
@@ -160,6 +163,7 @@ defmodule Tuist.Runners.Jobs do
       }
     )
     |> exclude_accounts(ineligible_account_ids)
+    |> exclude_workflow_jobs(excluded_workflow_job_ids)
     |> order_by([j], asc: fragment("argMax(?, ?)", j.enqueued_at, j.updated_at), asc: j.workflow_job_id)
     |> limit(1)
     |> ClickHouseRepo.one()
@@ -173,6 +177,12 @@ defmodule Tuist.Runners.Jobs do
 
   defp exclude_accounts(query, account_ids) when is_list(account_ids) do
     having(query, [j], fragment("argMax(?, ?)", j.account_id, j.updated_at) not in ^account_ids)
+  end
+
+  defp exclude_workflow_jobs(query, []), do: query
+
+  defp exclude_workflow_jobs(query, workflow_job_ids) when is_list(workflow_job_ids) do
+    where(query, [j], j.workflow_job_id not in ^workflow_job_ids)
   end
 
   @doc """

--- a/server/lib/tuist/runners/workers/orphaned_runners_worker.ex
+++ b/server/lib/tuist/runners/workers/orphaned_runners_worker.ex
@@ -73,10 +73,10 @@ defmodule Tuist.Runners.Workers.OrphanedRunnersWorker do
 
     * Both succeed → row in queued pool, PG slot freed.
     * CH ok, PG delete fails / crash → CH says queued, PG still
-      claimed. The next dispatch poll picks the row, hits a PG PK
-      conflict on `Claims.attempt`, returns `:lost_race` and bails
-      cleanly. The next worker run sees the same stale PG row and
-      retries the release.
+      claimed. Dispatch skips rows already claimed in PG before
+      selecting queued work, so later workflow_jobs can keep moving.
+      The next worker run sees the same stale PG row and retries the
+      release.
     * CH fails → leave PG alone; next worker tick retries the
       whole sequence.
 

--- a/server/lib/tuist/runners/workers/stale_claims_worker.ex
+++ b/server/lib/tuist/runners/workers/stale_claims_worker.ex
@@ -26,9 +26,9 @@ defmodule Tuist.Runners.Workers.StaleClaimsWorker do
     * Both succeed → row is back in the queued pool, cap slot
       freed.
     * CH succeeds, PG delete fails / crash → CH says queued, PG
-      still claimed. The next poll picks the row, hits a PG PK
-      conflict on `Claims.attempt`, returns :lost_race and bails
-      cleanly. The next worker run sees the same stale PG row
+      still claimed. Dispatch skips rows already claimed in PG
+      before selecting queued work, so later workflow_jobs can
+      keep moving. The next worker run sees the same stale PG row
       and retries.
     * CH fails → leave PG alone; next worker run retries the
       whole sequence.

--- a/server/test/tuist/runners/claims_test.exs
+++ b/server/test/tuist/runners/claims_test.exs
@@ -128,6 +128,18 @@ defmodule Tuist.Runners.ClaimsTest do
     end
   end
 
+  describe "workflow_job_ids_for_fleet/1" do
+    test "returns active workflow_job IDs for one fleet" do
+      account = account_fixture()
+
+      {:ok, _} = Claims.attempt(6101, account.id, "fleet-a", "pod-a-1")
+      {:ok, _} = Claims.attempt(6102, account.id, "fleet-a", "pod-a-2")
+      {:ok, _} = Claims.attempt(6103, account.id, "fleet-b", "pod-b-1")
+
+      assert "fleet-a" |> Claims.workflow_job_ids_for_fleet() |> Enum.sort() == [6101, 6102]
+    end
+  end
+
   describe "complete/1" do
     test "deletes the claim regardless of handle" do
       account = account_fixture()

--- a/server/test/tuist/runners/jobs_test.exs
+++ b/server/test/tuist/runners/jobs_test.exs
@@ -187,6 +187,17 @@ defmodule Tuist.Runners.JobsTest do
 
       assert {:ok, %{workflow_job_id: 3002}} = Jobs.pick_queued("fleet-cap", [a.id])
     end
+
+    test "skips excluded workflow_job IDs" do
+      account = account_fixture()
+      older = ~U[2026-07-09 10:00:00.000000Z]
+      newer = ~U[2026-07-09 10:01:00.000000Z]
+
+      :ok = enqueue_fixture(account, 3101, fleet: "fleet-skip", enqueued_at: older)
+      :ok = enqueue_fixture(account, 3102, fleet: "fleet-skip", enqueued_at: newer)
+
+      assert {:ok, %{workflow_job_id: 3102}} = Jobs.pick_queued("fleet-skip", [], [3101])
+    end
   end
 
   describe "record_claimed/3" do

--- a/server/test/tuist/runners_test.exs
+++ b/server/test/tuist/runners_test.exs
@@ -151,13 +151,20 @@ defmodule Tuist.RunnersTest do
     # The candidate the claim path serves. `requested_dispatch_label`
     # is the only field these tests vary — everything else is just
     # enough to satisfy `serve_claim/5` + `RunnerSessions.open/1`.
-    defp candidate_with_label(account, requested_dispatch_label) do
+    defp candidate_with_label(account, requested_dispatch_label, opts \\ []) do
+      workflow_job_id = Keyword.get(opts, :workflow_job_id, 90_001)
+
       %{
-        workflow_job_id: 90_001,
+        workflow_job_id: workflow_job_id,
         account_id: account.id,
         fleet_name: "fleet-a",
         repository: "acme/cli",
+        workflow_run_id: workflow_job_id * 10,
+        run_attempt: 1,
         workflow_name: "CI",
+        job_name: "build",
+        head_branch: "main",
+        head_sha: "deadbeef",
         requested_dispatch_label: requested_dispatch_label,
         enqueued_at: DateTime.utc_now()
       }
@@ -169,6 +176,8 @@ defmodule Tuist.RunnersTest do
     # for real against the sandboxed repo.
     defp stub_dispatch_path(account, candidate, test_pid, opts \\ []) do
       pod_name = Keyword.get(opts, :pod_name, "pod-1")
+      excluded_workflow_job_ids = Keyword.get(opts, :excluded_workflow_job_ids, [])
+      workflow_job_id = candidate.workflow_job_id
 
       expect(K8sClient, :get_service_account, fn "tuist-runners", ^pod_name ->
         {:ok, sa_with_pool_label(pod_name, "fleet-a")}
@@ -179,9 +188,11 @@ defmodule Tuist.RunnersTest do
         {:error, :not_found}
       end)
 
-      expect(Jobs, :pick_queued, fn "fleet-a", _ineligible -> {:ok, candidate} end)
+      expect(Claims, :workflow_job_ids_for_fleet, fn "fleet-a" -> excluded_workflow_job_ids end)
 
-      expect(Claims, :attempt, fn 90_001, _account_id, "fleet-a", ^pod_name ->
+      expect(Jobs, :pick_queued, fn "fleet-a", [], ^excluded_workflow_job_ids -> {:ok, candidate} end)
+
+      expect(Claims, :attempt, fn ^workflow_job_id, _account_id, "fleet-a", ^pod_name ->
         {:ok, %{claimed_at: DateTime.utc_now()}}
       end)
 
@@ -204,13 +215,13 @@ defmodule Tuist.RunnersTest do
         {:ok, %{encoded_jit_config: "jit-blob", runner_name: runner_name}}
       end)
 
-      expect(Claims, :mark_running, fn 90_001, runner_name ->
+      expect(Claims, :mark_running, fn ^workflow_job_id, runner_name ->
         assert String.starts_with?(runner_name, String.slice(pod_name, 0, 55))
         assert byte_size(runner_name) <= 64
         :ok
       end)
 
-      expect(Jobs, :record_running, fn 90_001, runner_name ->
+      expect(Jobs, :record_running, fn ^workflow_job_id, runner_name ->
         assert String.starts_with?(runner_name, String.slice(pod_name, 0, 55))
         assert byte_size(runner_name) <= 64
         :ok
@@ -258,6 +269,76 @@ defmodule Tuist.RunnersTest do
 
       assert_receive {:jit_labels, labels}
       assert "shape-linux-4vcpu-16gb" in labels
+    end
+
+    test "excludes workflow jobs that already have active Postgres claims before picking queued work" do
+      account = account_fixture()
+      candidate = candidate_with_label(account, "tuist-default", workflow_job_id: 90_002)
+      stub_dispatch_path(account, candidate, self(), excluded_workflow_job_ids: [90_001])
+
+      assert {:ok, %{workflow_job_id: 90_002}} = Runners.dispatch_for_sa("tuist-runners", "pod-1")
+    end
+
+    test "tries the next queued job after losing a claim race" do
+      account = account_fixture()
+      stale_candidate = candidate_with_label(account, "tuist-default", workflow_job_id: 90_001)
+      candidate = candidate_with_label(account, "tuist-default", workflow_job_id: 90_002)
+      pod_name = "pod-1"
+      test_pid = self()
+
+      expect(K8sClient, :get_service_account, fn "tuist-runners", ^pod_name ->
+        {:ok, sa_with_pool_label(pod_name, "fleet-a")}
+      end)
+
+      expect(K8sClient, :get_runner_pool, fn "tuist-runners", "fleet-a" ->
+        {:error, :not_found}
+      end)
+
+      expect(Claims, :workflow_job_ids_for_fleet, fn "fleet-a" -> [] end)
+
+      expect(Jobs, :pick_queued, fn "fleet-a", [], [] -> {:ok, stale_candidate} end)
+
+      expect(Claims, :attempt, fn 90_001, _account_id, "fleet-a", ^pod_name ->
+        {:error, :lost_race}
+      end)
+
+      expect(Jobs, :pick_queued, fn "fleet-a", [], [90_001] -> {:ok, candidate} end)
+
+      expect(Claims, :attempt, fn 90_002, _account_id, "fleet-a", ^pod_name ->
+        {:ok, %{claimed_at: DateTime.utc_now()}}
+      end)
+
+      expect(Jobs, :record_claimed, fn ^candidate, ^pod_name, _claimed_at -> :ok end)
+
+      expect(Dispatch, :pool_summary_by_name, fn "fleet-a" ->
+        {:ok, %{dispatch_label: "shape-linux-4vcpu-16gb", runner_labels: ["self-hosted", "Linux", "X64"]}}
+      end)
+
+      stub(K8sClient, :patch_pod, fn _ns, _pod, _patch -> {:ok, %{}} end)
+
+      stub(VCS, :get_github_app_installation_for_account, fn account_id ->
+        assert account_id == account.id
+        {:ok, %{installation_id: 42, client_url: "https://github.com"}}
+      end)
+
+      expect(GitHubClient, :generate_jit_config, fn _installation, _login, %{labels: labels, name: runner_name} ->
+        send(test_pid, {:jit_labels, labels})
+        {:ok, %{encoded_jit_config: "jit-blob", runner_name: runner_name}}
+      end)
+
+      expect(Claims, :mark_running, fn 90_002, runner_name ->
+        assert String.starts_with?(runner_name, pod_name)
+        :ok
+      end)
+
+      expect(Jobs, :record_running, fn 90_002, runner_name ->
+        assert String.starts_with?(runner_name, pod_name)
+        :ok
+      end)
+
+      assert {:ok, %{workflow_job_id: 90_002}} = Runners.dispatch_for_sa("tuist-runners", pod_name)
+      assert_receive {:jit_labels, labels}
+      assert "tuist-default" in labels
     end
 
     test "retries the owner-label stamp on a transient patch failure and still dispatches" do


### PR DESCRIPTION
## What changed

- Added a Postgres-backed anti-list of active runner claim workflow job IDs per fleet.
- Taught the ClickHouse queued-job picker to exclude specific workflow job IDs.
- Updated dispatch so a polling runner skips already-claimed queued rows and, if it loses a claim race, tries the next queued job before returning no work.
- Refreshed recovery-worker documentation to match the new dispatch behavior.
- Added focused regression tests for already-active Postgres claims and mid-dispatch `:lost_race` retries.

## Why

On July 9, 2026, the default `tuist-linux` pool became head-of-line blocked. GitHub and ClickHouse still saw workflow job `86148965657` as queued, while Postgres had a stale `runner_claims` row for that same workflow job in `running` state. Every polling pod selected that oldest ClickHouse queued row, hit the Postgres primary-key conflict, returned no work, and never reached later queued jobs.

That left unrelated queued work, including the production observability chart job `86150674607`, waiting even though warm runner pods existed.

## Root cause

`Tuist.Runners.claim_and_serve/3` selected only one queued candidate from ClickHouse. If `Claims.attempt/4` returned `:lost_race`, dispatch stopped for that poll. That behavior is correct for normal concurrent claim races, but it made a cross-store inconsistency fatal for the whole fleet: one queued ClickHouse row with an active Postgres claim could pin every poller to the same unusable candidate.

## Approach

The fix keeps Postgres as the claim source of truth and preserves the existing unique constraint. Instead of weakening claim safety, dispatch now excludes workflow jobs that already have active Postgres claims before asking ClickHouse for queued work. It also carries a per-poll exclusion list so an unexpected `:lost_race` causes dispatch to try the next queued candidate, bounded by a small attempt limit.

This lets later jobs continue dispatching while the existing stale-claim/orphaned-runner workers reconcile the inconsistent row.

## Impact

A single stale or inconsistently re-queued workflow job can no longer freeze an entire runner fleet. The affected job remains protected from double-minting by the Postgres claim table, while subsequent queued jobs can still be assigned to available runners.

## Validation

- `mix format lib/tuist/runners.ex lib/tuist/runners/claims.ex lib/tuist/runners/jobs.ex test/tuist/runners_test.exs test/tuist/runners/claims_test.exs test/tuist/runners/jobs_test.exs`
- `mix format lib/tuist/runners/workers/stale_claims_worker.ex lib/tuist/runners/workers/orphaned_runners_worker.ex`
- `MIX_ENV=test mix test test/tuist/runners/claims_test.exs test/tuist/runners/jobs_test.exs test/tuist/runners_test.exs`
  - `85 tests, 0 failures`
- `git diff --check`

Operationally, after manually releasing the stale claim, the previously blocked production observability job completed successfully and the older cancelled Noora run reached a cancelled terminal state.