### PR TITLE
fix(server): remove legacy registry ingress during deploy

### DIFF
--- a/.github/workflows/server-deployment.yml
+++ b/.github/workflows/server-deployment.yml
@@ -905,6 +905,18 @@ jobs:
           else
             registry_enabled=false
           fi
+          registry_ingress_host="$(
+            awk '
+              /^---/ { kind = ""; component = "" }
+              $1 == "kind:" { kind = $2 }
+              $1 == "app.kubernetes.io/component:" { component = $2; gsub(/"/, "", component) }
+              $1 == "-" && $2 == "host:" && kind == "Ingress" && component == "registry" {
+                gsub(/"/, "", $3)
+                print $3
+                exit
+              }
+            ' "$registry_render"
+          )"
           rm -f "$registry_render"
           echo "REGISTRY_ENABLED=$registry_enabled" >> "$GITHUB_ENV"
           echo "Swift registry component enabled: $registry_enabled"
@@ -914,6 +926,28 @@ jobs:
             exit 1
           fi
           registry_image_tag="${REGISTRY_IMAGE_TAG:-registry-disabled}"
+
+          if [ "$registry_enabled" = "true" ]; then
+            if [ -n "$registry_ingress_host" ]; then
+              legacy_registry_hosts="$(
+                kubectl -n registry get ingress registry \
+                  -o jsonpath='{range .spec.rules[*]}{.host}{"\n"}{end}' 2>/dev/null ||
+                  true
+              )"
+
+              if echo "$legacy_registry_hosts" | grep -Fxq "$registry_ingress_host"; then
+                echo "Deleting legacy standalone registry ingress registry/registry for host $registry_ingress_host."
+                kubectl -n registry delete ingress registry --ignore-not-found --wait=true --timeout=2m
+              elif [ -n "$legacy_registry_hosts" ]; then
+                echo "Legacy standalone registry ingress hosts do not match $registry_ingress_host; leaving it in place:"
+                echo "$legacy_registry_hosts"
+              else
+                echo "No legacy standalone registry ingress found."
+              fi
+            else
+              echo "WARNING: registry is enabled but no registry ingress host was rendered."
+            fi
+          fi
 
           helm upgrade --install "$HELM_RELEASE_NAME" "$HELM_CHART_PATH" \
             --namespace "$NAMESPACE" --create-namespace \


### PR DESCRIPTION
## What changed

- Extract the registry ingress host from the Helm render during the server deploy workflow.
- Before the main Tuist chart upgrade, delete the legacy standalone `registry/registry` ingress only when it owns the same host the main chart is about to claim.
- Leave the legacy standalone registry deployment and service untouched; this only clears the ingress admission conflict.

## Why

The canary production cascade for run 29036473443 failed in `helm upgrade --install` because ingress-nginx rejected the new main-chart registry ingress. The host `registry-canary.tuist.dev` and path `/` were already defined by the old standalone `registry/registry` ingress in the `registry` namespace.

The repo documentation now defines the managed Swift Registry as part of the main `infra/helm/tuist` chart, so this deploy path needs to handle the one-time ownership transition instead of requiring a manual cluster cleanup before every rerun.

## Root cause

Canary still had a legacy Helm release in namespace `registry` with an ingress for `registry-canary.tuist.dev`. When the main Tuist chart enabled its registry component and rendered `tuist-canary/tuist-tuist-registry` for the same host/path, the validating admission webhook denied the resource and Helm rolled the attempted release back.

## Approach

The workflow already renders the chart to detect whether the Swift registry component is enabled. This change reuses that render to find the registry ingress host. If a legacy standalone `registry/registry` ingress exists and has exactly that host, the workflow deletes just that ingress before running the Helm upgrade. If the hosts differ, or no registry ingress is rendered, the workflow logs that state and leaves the legacy ingress alone.

This is narrower than deleting the whole legacy namespace or standalone release, and it avoids special-casing canary by matching on the rendered host.

## Validation

- Parsed `.github/workflows/server-deployment.yml` with Ruby YAML loading.
- Ran `git diff --check`.
- Rendered the canary Helm values and confirmed the helper extracts `registry-canary.tuist.dev`.
- Rendered an internal-only registry configuration and confirmed the helper leaves the ingress host empty without failing.