### PR TITLE
fix(infra): stop requiring registry sync master key

### DIFF
--- a/infra/helm/tuist/templates/swift-registry-sync-deployment.yaml
+++ b/infra/helm/tuist/templates/swift-registry-sync-deployment.yaml
@@ -112,13 +112,6 @@ spec:
             {{- end }}
             {{- include "tuist.githubEnv" . | nindent 12 }}
             {{- include "tuist.licenseEnv" . | nindent 12 }}
-            {{- if or .Values.server.masterKey .Values.server.managedSecrets }}
-            - name: MASTER_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: {{ ternary (include "tuist.componentName" (dict "root" . "component" "server-external-secrets")) (include "tuist.componentName" (dict "root" . "component" "app-secrets")) .Values.server.managedSecrets }}
-                  key: server-master-key
-            {{- end }}
             - name: TUIST_HOSTED
               value: {{ .Values.server.hosted | ternary "1" "0" | quote }}
             - name: TUIST_LOG_LEVEL
@@ -133,8 +126,7 @@ spec:
             # Registry-specific S3 credentials (separate Tigris key with
             # policy on the registry bucket). The ex_aws config in
             # runtime.exs detects swift_registry_sync mode and uses
-            # these instead of the account-storage credentials baked
-            # into MASTER_KEY-decrypted secrets.
+            # these instead of the account-storage credentials.
             - name: S3_REGISTRY_BUCKET
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
## What changed

The Swift registry sync deployment no longer injects `MASTER_KEY` from `tuist-tuist-server-external-secrets`.

The template still imports the managed server configuration through `envFrom`, so the sync pod continues to receive the direct `TUIST_*` runtime values from `tuist-tuist-server-config-external-secrets`. Registry object-storage credentials continue to come from `tuist-tuist-swift-registry-sync-external-secrets`.

## Root cause

The managed server deployment removed the encrypted runtime secret blob and the legacy master key path. The sync deployment still referenced `server-master-key` when `server.managedSecrets` was enabled, but `tuist-tuist-server-external-secrets` does not contain that key anymore.

That made the canary rollout fail with:

```text
Error: couldn't find key server-master-key in Secret tuist-canary/tuist-tuist-server-external-secrets
```

Helm then waited for `Deployment/tuist-canary/tuist-tuist-swift-registry-sync`, hit the progress deadline, and rolled the release back.

## Approach

Remove the stale `MASTER_KEY` environment reference instead of redirecting it to another secret. The runtime code now reads secrets directly from environment variables, and the sync pod already gets those values through the consolidated server config secret in managed environments.

## Impact

This should unblock the canary server deployment by allowing the Swift registry sync pod to start without a missing secret-key reference. Self-hosted installs are unchanged in practice because the chart no longer renders or consumes `server-master-key` elsewhere.

## Validation

- `helm template tuist infra/helm/tuist --namespace tuist-canary --values infra/helm/tuist/values-managed-common.yaml --values infra/helm/tuist/values-managed-canary.yaml --show-only templates/swift-registry-sync-deployment.yaml --set runnersFleet.enabled=false --set runnersFleetLinux.enabled=false --set registry.image.tag=validation --set server.image.tag=validation --set kuraController.image.tag=validation > /tmp/tuist-swift-registry-sync-canary.yaml`
- `rg -n "MASTER_KEY|server-master-key" /tmp/tuist-swift-registry-sync-canary.yaml` returned no matches.
- `git diff --check`
