### PR TITLE
fix(server): bound runner queue reads to prune ClickHouse partitions

### DIFF
--- a/server/lib/tuist/runners/jobs.ex
+++ b/server/lib/tuist/runners/jobs.ex
@@ -66,6 +66,22 @@ defmodule Tuist.Runners.Jobs do
 
   require Logger
 
+  # The dispatch hot path (`pick_queued/2`) and the autoscaler
+  # (`queued_count_by_fleet/1`) only care about jobs that could still
+  # be legitimately `queued`. `StaleQueuedJobsWorker` force-completes
+  # any row that stays queued past a 24h hard backstop, so a job can't
+  # remain claimable beyond that. Bounding these scans on `enqueued_at`
+  # — the column `runner_jobs` is partitioned by via `toYYYYMM` — lets
+  # ClickHouse prune to the recent partitions instead of running the
+  # `GROUP BY workflow_job_id` + argMax dedup over the fleet's full
+  # history. Without the floor that aggregation state grows with every
+  # completed job the fleet has ever run and eventually trips
+  # ClickHouse's per-query memory limit (Code 241 MEMORY_LIMIT_EXCEEDED)
+  # on the hot path. 7 days matches `StaleQueuedJobsWorker`'s lookback:
+  # far enough beyond the 24h backstop to survive worker downtime, so a
+  # still-claimable job is never pruned out of view.
+  @queued_lookback_seconds 7 * 86_400
+
   @doc """
   Latest `enqueued_at` per `requested_dispatch_label` for an account.
 
@@ -221,11 +237,17 @@ defmodule Tuist.Runners.Jobs do
   ASC)` — means two concurrent pollers see the SAME row as the
   next candidate. The actual claim race then collapses on
   Postgres uniqueness in `Claims.attempt/4`.
+
+  The scan is floored at `@queued_lookback_seconds` on `enqueued_at`
+  so ClickHouse prunes to recent partitions rather than aggregating
+  the fleet's full history — see the attribute's rationale.
   """
   def pick_queued(fleet_name, ineligible_account_ids \\ [], excluded_workflow_job_ids \\ [])
       when is_binary(fleet_name) and is_list(ineligible_account_ids) and is_list(excluded_workflow_job_ids) do
+    lookback_floor = queued_lookback_floor()
+
     from(j in Job,
-      where: j.fleet_name == ^fleet_name,
+      where: j.fleet_name == ^fleet_name and j.enqueued_at > ^lookback_floor,
       group_by: j.workflow_job_id,
       having: fragment("argMax(?, ?) = ?", j.status, j.updated_at, "queued"),
       select: %{
@@ -732,9 +754,11 @@ defmodule Tuist.Runners.Jobs do
   `queued` don't get double-counted.
   """
   def queued_count_by_fleet(fleet_name) when is_binary(fleet_name) do
+    lookback_floor = queued_lookback_floor()
+
     inner =
       from j in Job,
-        where: j.fleet_name == ^fleet_name,
+        where: j.fleet_name == ^fleet_name and j.enqueued_at > ^lookback_floor,
         group_by: j.workflow_job_id,
         having: fragment("argMax(?, ?) = ?", j.status, j.updated_at, "queued"),
         select: j.workflow_job_id
@@ -1186,6 +1210,10 @@ defmodule Tuist.Runners.Jobs do
   end
 
   # ----- internal -----
+
+  defp queued_lookback_floor do
+    DateTime.add(DateTime.utc_now(), -@queued_lookback_seconds, :second)
+  end
 
   defp latest_runner_runs_by_id(runs) do
     runs

--- a/server/test/tuist/runners/jobs_test.exs
+++ b/server/test/tuist/runners/jobs_test.exs
@@ -464,13 +464,27 @@ defmodule Tuist.Runners.JobsTest do
 
     test "skips excluded workflow_job IDs" do
       account = account_fixture()
-      older = ~U[2026-07-09 10:00:00.000000Z]
-      newer = ~U[2026-07-09 10:01:00.000000Z]
+      older = DateTime.add(DateTime.utc_now(), -120, :second)
+      newer = DateTime.add(DateTime.utc_now(), -60, :second)
 
       :ok = enqueue_fixture(account, 3101, fleet: "fleet-skip", enqueued_at: older)
       :ok = enqueue_fixture(account, 3102, fleet: "fleet-skip", enqueued_at: newer)
 
       assert {:ok, %{workflow_job_id: 3102}} = Jobs.pick_queued("fleet-skip", [], [3101])
+    end
+
+    test "ignores queued rows enqueued beyond the lookback window" do
+      account = account_fixture()
+      recent = DateTime.add(DateTime.utc_now(), -60, :second)
+      stale = DateTime.add(DateTime.utc_now(), -8 * 86_400, :second)
+
+      :ok = enqueue_fixture(account, 3201, fleet: "fleet-lookback", enqueued_at: stale)
+
+      assert {:error, :empty} = Jobs.pick_queued("fleet-lookback", [])
+
+      :ok = enqueue_fixture(account, 3202, fleet: "fleet-lookback", enqueued_at: recent)
+
+      assert {:ok, %{workflow_job_id: 3202}} = Jobs.pick_queued("fleet-lookback", [])
     end
   end
 
@@ -1016,7 +1030,19 @@ defmodule Tuist.Runners.JobsTest do
       account = account_fixture()
       old = ~U[2026-05-01 10:00:00.000000Z]
       :ok = enqueue_fixture(account, 8511, fleet: "fleet-sq-trans", enqueued_at: old)
-      {:ok, candidate} = Jobs.pick_queued("fleet-sq-trans", [])
+
+      # Transition it out of queued directly — `pick_queued/2` only
+      # surfaces jobs enqueued within its lookback window, and this
+      # row is intentionally old to sit inside the fixed
+      # `list_stale_queued/2` floor/threshold below.
+      candidate = %{
+        workflow_job_id: 8511,
+        account_id: account.id,
+        fleet_name: "fleet-sq-trans",
+        repository: "acme/cli",
+        enqueued_at: old
+      }
+
       :ok = Jobs.record_claimed(candidate, "pod-1", DateTime.utc_now())
 
       floor = ~U[2026-04-01 00:00:00.000000Z]
@@ -1052,6 +1078,17 @@ defmodule Tuist.Runners.JobsTest do
 
     test "returns 0 for an unknown fleet" do
       assert Jobs.queued_count_by_fleet("fleet-no-such") == 0
+    end
+
+    test "ignores queued rows enqueued beyond the lookback window" do
+      account = account_fixture()
+      recent = DateTime.add(DateTime.utc_now(), -60, :second)
+      stale = DateTime.add(DateTime.utc_now(), -8 * 86_400, :second)
+
+      :ok = enqueue_fixture(account, 8201, fleet: "fleet-qc-lookback", enqueued_at: recent)
+      :ok = enqueue_fixture(account, 8202, fleet: "fleet-qc-lookback", enqueued_at: stale)
+
+      assert Jobs.queued_count_by_fleet("fleet-qc-lookback") == 1
     end
   end
 


### PR DESCRIPTION
## What changed

`Tuist.Runners.Jobs.pick_queued/2` (the runner dispatch hot path) and `queued_count_by_fleet/1` (the autoscaler signal) now floor their ClickHouse scans on `enqueued_at` at 7 days, so the queries prune to recent monthly partitions instead of aggregating the fleet's full `runner_jobs` history.

## Why / root cause

Sentry [TUIST-104](https://tuist.sentry.io/issues/129883578/) — `Ch.Error: Code: 241 ... MEMORY_LIMIT_EXCEEDED` at 18 GiB, 4691 occurrences, hitting `POST /api/internal/runners/dispatch`.

`runner_jobs` is `PARTITION BY toYYYYMM(enqueued_at)` with `ORDER BY (workflow_job_id)`. Both queries did `GROUP BY workflow_job_id` + `argMax(col, updated_at)` filtered only by `fleet_name`, with **no bound on `enqueued_at`**. With no predicate on the partition-key column, ClickHouse couldn't prune partitions, so the GROUP BY aggregation state carried one `argMax` group per `workflow_job_id` the fleet had **ever** run — growing without bound as completed jobs accumulated month over month. On busy fleets this exceeded ClickHouse's per-query memory limit on every dispatch poll.

The `status` skip index can't help here: a queued job's later rows carry `claimed`/`running`/`completed`, so the GROUP BY needs every row per `workflow_job_id` to compute `argMax(status)` correctly — you can't pre-filter to `status = 'queued'` without breaking the dedup. Partition pruning on `enqueued_at` is the lever.

## Why this solution

Both queries only care about jobs that could still be legitimately `queued`. `StaleQueuedJobsWorker` force-completes any row stuck in `queued` past a **24h hard backstop**, so a job can't remain claimable beyond that. A 7-day floor:

- is far beyond the 24h backstop, so a still-claimable job is never pruned out of view — even across worker downtime (the worker would have to be down ~6 days for a stuck job to age out);
- is exactly the lookback `StaleQueuedJobsWorker` already uses (`@max_lookback_seconds`) for the same partition-pruning reason;
- mirrors the existing pattern in `list_stale_queued/2`, which already bounds on `enqueued_at`.

`enqueued_at` is stable across a workflow_job's state transitions (all rows for a job share it), so filtering pre-aggregation never splits a job's rows across the boundary. `p95_concurrent_last_hour/1` was already bounded (2h) and is unchanged.

## Impact

Dispatch polls and autoscaler ticks now scan at most ~1–2 monthly partitions per fleet instead of full history, eliminating the memory blowup on the hot path. No customer-visible behavior change: jobs older than the 24h backstop are already terminal, so they were never claimable candidates.

## Validation

- `mix test test/tuist/runners/jobs_test.exs` — 58 pass, including new lookback-window coverage for both `pick_queued/2` and `queued_count_by_fleet/1`.
- `mix test test/tuist/runners_test.exs` + runner LiveView tests — pass.
- `mix credo` — clean.

Fixes TUIST-104.

🤖 Generated with [Claude Code](https://claude.com/claude-code)