### PR TITLE
fix(server): tolerate unknown analytics-environment value in test runs

### DIFF
--- a/server/lib/tuist_web/live/test_runs_live.ex
+++ b/server/lib/tuist_web/live/test_runs_live.ex
@@ -361,9 +361,9 @@ defmodule TuistWeb.TestRunsLive do
   defp analytics_trend_label("custom"), do: dgettext("dashboard_tests", "since last period")
   defp analytics_trend_label(_), do: dgettext("dashboard_tests", "since last month")
 
-  defp analytics_environment_label("any"), do: dgettext("dashboard_tests", "Any")
   defp analytics_environment_label("local"), do: dgettext("dashboard_tests", "Local")
   defp analytics_environment_label("ci"), do: dgettext("dashboard_tests", "CI")
+  defp analytics_environment_label(_), do: dgettext("dashboard_tests", "Any")
 
   defp assign_test_runs(%{assigns: %{selected_project: project}} = socket, params) do
     filters =

--- a/server/priv/gettext/dashboard_tests.pot
+++ b/server/priv/gettext/dashboard_tests.pot
@@ -39,7 +39,7 @@ msgstr ""
 #: lib/tuist_web/live/flaky_tests_live.html.heex:10
 #: lib/tuist_web/live/test_cases_live.ex:390
 #: lib/tuist_web/live/test_cases_live.html.heex:10
-#: lib/tuist_web/live/test_runs_live.ex:364
+#: lib/tuist_web/live/test_runs_live.ex:366
 #: lib/tuist_web/live/tests_live.ex:421
 #: lib/tuist_web/live/tests_live.ex:430
 #: lib/tuist_web/live/tests_live.html.heex:17
@@ -159,7 +159,7 @@ msgstr ""
 #: lib/tuist_web/live/test_case_live.ex:135
 #: lib/tuist_web/live/test_cases_live.ex:392
 #: lib/tuist_web/live/test_cases_live.html.heex:26
-#: lib/tuist_web/live/test_runs_live.ex:366
+#: lib/tuist_web/live/test_runs_live.ex:365
 #: lib/tuist_web/live/tests_live.ex:423
 #: lib/tuist_web/live/tests_live.ex:424
 #: lib/tuist_web/live/tests_live.html.heex:48
@@ -622,7 +622,7 @@ msgstr ""
 #: lib/tuist_web/live/test_cases_live.ex:391
 #: lib/tuist_web/live/test_cases_live.html.heex:18
 #: lib/tuist_web/live/test_run_live.ex:1178
-#: lib/tuist_web/live/test_runs_live.ex:365
+#: lib/tuist_web/live/test_runs_live.ex:364
 #: lib/tuist_web/live/tests_live.ex:422
 #: lib/tuist_web/live/tests_live.ex:425
 #: lib/tuist_web/live/tests_live.html.heex:56

--- a/server/test/tuist_web/live/test_runs_live_test.exs
+++ b/server/test/tuist_web/live/test_runs_live_test.exs
@@ -97,6 +97,30 @@ defmodule TuistWeb.TestRunsLiveTest do
       assert has_element?(lv, "[data-part='test-runs-table']")
     end
 
+    test "loads with an unknown analytics-environment value", %{
+      conn: conn,
+      organization: organization,
+      project: project
+    } do
+      {:ok, _test_run} =
+        RunsFixtures.test_fixture(
+          project_id: project.id,
+          account_id: organization.account.id,
+          scheme: "App",
+          ran_at: ~N[2024-04-30 10:19:30]
+        )
+
+      # A request with an empty or unexpected analytics-environment value should
+      # not crash analytics_environment_label/1 with a FunctionClauseError.
+      assert {:ok, lv, _html} =
+               live(
+                 conn,
+                 ~p"/#{organization.account.name}/#{project.name}/tests/test-runs?analytics-environment="
+               )
+
+      assert has_element?(lv, "[data-part='test-runs-table']")
+    end
+
     test "filters runs whose branch does not contain a substring", %{
       conn: conn,
       organization: organization,


### PR DESCRIPTION
## What changed

The test-runs dashboard LiveView (`TuistWeb.TestRunsLive`) now tolerates an unexpected `analytics-environment` query param instead of crashing. `analytics_environment_label/1` previously only matched `"any"`, `"local"`, and `"ci"`; it now falls back to the "Any" label for any other value via a catch-all clause.

## Why

Sentry [TUIST-183](https://tuist.sentry.io/issues/133383996/) reported `FunctionClauseError: no function clause matching in TuistWeb.TestRunsLive.analytics_environment_label/1` in prod (argument: `""`).

**Root cause:** the environment is read straight from the query string:

```elixir
analytics_environment = params["analytics-environment"] || "any"
```

An empty string is truthy in Elixir, so a request like `?analytics-environment=` yields `""` (and any arbitrary value passes through unchanged). That value was then handed to `analytics_environment_label/1`, which had no matching clause, so the entire `handle_params` render blew up.

The neighboring `opts` `case` that maps the environment to a Flop filter already tolerated unknown values with a catch-all (`_ -> opts`, treating them as "any"). The label function was the only place assuming a closed set of inputs, so this aligns it with the existing tolerant behavior rather than adding new validation.

## User impact

Any visitor hitting the test-runs page with an empty or malformed `analytics-environment` param (bots/crawlers appending junk params, or a stale/edited URL) got a 500 instead of the page. After this change the page renders normally and defaults to the "Any" environment view.

## Validation

Added a TDD regression test that visits the page with `?analytics-environment=` and asserts it loads. It reproduced the exact `FunctionClauseError` (arg `""`) before the fix and passes after.

```
mix test test/tuist_web/live/test_runs_live_test.exs
# Result: 4 passed
```

`mix format` and `mix credo` on the changed files are clean.

### How to test locally

1. Start the server (`mise run dev`).
2. Navigate to a project's test runs page with an empty environment param, e.g. `/<account>/<project>/tests/test-runs?analytics-environment=`.
3. Before this change the page 500s with a `FunctionClauseError`; after, it renders with the "Any" environment selected.
