### PR TITLE
fix(infra): allow registry deploy smoke traffic

### DIFF
--- a/.github/workflows/server-deployment.yml
+++ b/.github/workflows/server-deployment.yml
@@ -1034,6 +1034,7 @@ jobs:
           if [ "${REGISTRY_ENABLED:-false}" = "true" ]; then
             kubectl -n "$NAMESPACE" rollout status deploy/tuist-tuist-registry --timeout=10m
             kubectl -n "$NAMESPACE" run registry-smoke-$RANDOM --rm -i --restart=Never --image=curlimages/curl \
+              --labels=app.kubernetes.io/name=tuist,app.kubernetes.io/instance=tuist,app.kubernetes.io/component=registry-smoke \
               --command -- curl -fsS "http://tuist-tuist-registry/up"
           else
             echo "Swift registry component disabled; skipping registry smoke test."

--- a/infra/helm/tuist/templates/registry-networkpolicy.yaml
+++ b/infra/helm/tuist/templates/registry-networkpolicy.yaml
@@ -19,6 +19,14 @@ spec:
           podSelector:
             matchLabels:
               {{- toYaml .Values.registry.networkPolicy.ingressControllerPodLabels | nindent 14 }}
+    - from:
+        - podSelector:
+            matchLabels:
+              {{- include "tuist.selectorLabels" . | nindent 14 }}
+              app.kubernetes.io/component: registry-smoke
+      ports:
+        - protocol: TCP
+          port: http
     {{- if and .Values.registry.metrics.enabled .Values.registry.networkPolicy.observabilityNamespace }}
     - from:
         - namespaceSelector:


### PR DESCRIPTION
## What changed

The server deployment workflow now labels the temporary Swift registry smoke pod with the release and component labels expected by the chart.

The registry NetworkPolicy now admits HTTP traffic from pods in the same namespace with those labels and `app.kubernetes.io/component=registry-smoke`.

## Why

The canary deploy was failing after Helm completed and both the server and registry deployments rolled out. The registry Service existed, had endpoints, and the public `/up` endpoint was healthy, but the in-cluster smoke pod could not connect to `tuist-tuist-registry:80`.

## Root cause

`tuist-tuist-registry:80` is the expected in-cluster Service address. The name comes from the Helm release `tuist`, chart name `tuist`, and component `registry`; the Service exposes HTTP on port 80 and forwards to the registry container's `http` port.

The failure was the registry NetworkPolicy. It only allowed ingress from the ingress controller and observability. The workflow-created `registry-smoke-*` pod had no labels that matched an allowed peer, so Kubernetes dropped the connection.

## Approach

Keep the internal Service smoke test, but make the smoke pod identifiable and allow only that labeled same-namespace traffic through the registry NetworkPolicy. This avoids parsing rendered YAML in the workflow and keeps the registry policy narrow.

## Impact

Canary and staging registry deploys should be able to verify the internal registry Service without weakening ingress access for arbitrary pods. Production continues to skip the registry smoke while the production registry component is disabled.

## Validation

- Read-only canary inspection confirmed:
  - `tuist-tuist-registry` is a ClusterIP Service on port 80
  - it has endpoint `192.168.31.143:4000`
  - the registry NetworkPolicy did not allow the old unlabeled smoke pod
- Rendered the managed Helm chart locally for staging and canary and confirmed the `registry-smoke` NetworkPolicy peer renders.
- Rendered production and confirmed the registry policy is not rendered because the production registry component is disabled.
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/server-deployment.yml")'`
- `mise x actionlint -- actionlint -ignore 'label "tuist-linux" is unknown' .github/workflows/server-deployment.yml`
- `git diff --check`
