### PR TITLE
fix(cli): quote Swift framework search paths to survive whitespace in target names

### DIFF
--- a/cli/Sources/TuistGenerator/Mappers/FrameworkSearchPathsGraphMapper.swift
+++ b/cli/Sources/TuistGenerator/Mappers/FrameworkSearchPathsGraphMapper.swift
@@ -121,8 +121,10 @@ public struct FrameworkSearchPathsGraphMapper: GraphMapping {
                     ))
                     additions.append((Self.otherCFlagsSetting, [responseFileReference]))
                     // OTHER_SWIFT_FLAGS gets -F flags instead of @file because the Xcode 26 ClangImporter and
-                    // integrated SwiftDriver mishandle a @file token.
-                    additions.append((Self.otherSwiftFlagsSetting, swiftSearchPathAdditions.flatMap { ["-F", $0] }))
+                    // integrated SwiftDriver mishandle a @file token. Each search path is quoted so paths
+                    // that contain whitespace (e.g. a target named "Notification Service") stay a single
+                    // token instead of being word-split into an unexpected input file.
+                    additions.append((Self.otherSwiftFlagsSetting, swiftSearchPathAdditions.flatMap { ["-F", "\"\($0)\""] }))
                     additions.append((Self.otherLinkerFlagsSetting, [responseFileReference]))
                 } else {
                     additions.append((

--- a/cli/Tests/TuistGeneratorTests/Mappers/FrameworkSearchPathsGraphMapperTests.swift
+++ b/cli/Tests/TuistGeneratorTests/Mappers/FrameworkSearchPathsGraphMapperTests.swift
@@ -55,8 +55,8 @@ final class FrameworkSearchPathsGraphMapperTests: TuistUnitTestCase {
         )
         let otherSwiftFlags = arrayValue(settings.base["OTHER_SWIFT_FLAGS"])
         XCTAssertTrue(otherSwiftFlags.contains("-F"))
-        XCTAssertTrue(otherSwiftFlags.contains("$(SRCROOT)/Derived/FrameworkSearchPaths/Swift/App"))
-        XCTAssertFalse(otherSwiftFlags.contains("$(SRCROOT)/Frameworks/hash0"))
+        XCTAssertTrue(otherSwiftFlags.contains("\"$(SRCROOT)/Derived/FrameworkSearchPaths/Swift/App\""))
+        XCTAssertFalse(otherSwiftFlags.contains("\"$(SRCROOT)/Frameworks/hash0\""))
         // The precompiled paths live in the response file, not in FRAMEWORK_SEARCH_PATHS.
         XCTAssertFalse(arrayValue(settings.base["FRAMEWORK_SEARCH_PATHS"]).contains { $0.contains("/Frameworks/") })
 
@@ -140,6 +140,44 @@ final class FrameworkSearchPathsGraphMapperTests: TuistUnitTestCase {
         })
     }
 
+    func test_map_quotesSwiftFrameworkSearchPaths_whenTargetNameContainsWhitespace() async throws {
+        // Given
+        let projectPath = try temporaryPath()
+        let app = Target.test(name: "Notification Service", product: .app)
+        let project = Project.test(path: projectPath, sourceRootPath: projectPath, targets: [app])
+        var xcframeworks: [GraphDependency] = []
+        for i in 0 ..< 25 {
+            xcframeworks.append(
+                .testXCFramework(
+                    path: projectPath.appending(components: "Frameworks", "hash\(i)", "Module\(i).xcframework"),
+                    linking: .dynamic
+                )
+            )
+        }
+        var dependencies: [GraphDependency: Set<GraphDependency>] = [
+            .target(name: "Notification Service", path: projectPath): Set(xcframeworks),
+        ]
+        for xcframework in xcframeworks {
+            dependencies[xcframework] = Set()
+        }
+        let graph = Graph.test(projects: [projectPath: project], dependencies: dependencies)
+
+        // When
+        let (mappedGraph, _, _) = try await subject.map(graph: graph, environment: MapperEnvironment())
+
+        // Then
+        let settings = try XCTUnwrap(mappedGraph.projects[projectPath]?.targets["Notification Service"]?.settings)
+        let otherSwiftFlags = arrayValue(settings.base["OTHER_SWIFT_FLAGS"])
+        XCTAssertTrue(otherSwiftFlags.contains("-F"))
+        // The search path is quoted so Xcode does not word-split it into two tokens.
+        XCTAssertTrue(
+            otherSwiftFlags.contains("\"$(SRCROOT)/Derived/FrameworkSearchPaths/Swift/Notification Service\"")
+        )
+        XCTAssertFalse(
+            otherSwiftFlags.contains("$(SRCROOT)/Derived/FrameworkSearchPaths/Swift/Notification Service")
+        )
+    }
+
     func test_map_deletesStaleFrameworkSearchPathResponseFiles() async throws {
         // Given
         let projectPath = try temporaryPath()
@@ -220,10 +258,10 @@ final class FrameworkSearchPathsGraphMapperTests: TuistUnitTestCase {
         // Then
         let settings = try XCTUnwrap(mappedGraph.projects[projectPath]?.targets["App"]?.settings)
         let otherSwiftFlags = arrayValue(settings.base["OTHER_SWIFT_FLAGS"])
-        XCTAssertTrue(otherSwiftFlags.contains("$(SRCROOT)/Derived/FrameworkSearchPaths/Swift/App"))
-        XCTAssertTrue(otherSwiftFlags.contains("$(SRCROOT)/Frameworks/hash0"))
-        XCTAssertTrue(otherSwiftFlags.contains("$(SRCROOT)/Frameworks/hash1"))
-        XCTAssertFalse(otherSwiftFlags.contains("$(SRCROOT)/Frameworks/hash2"))
+        XCTAssertTrue(otherSwiftFlags.contains("\"$(SRCROOT)/Derived/FrameworkSearchPaths/Swift/App\""))
+        XCTAssertTrue(otherSwiftFlags.contains("\"$(SRCROOT)/Frameworks/hash0\""))
+        XCTAssertTrue(otherSwiftFlags.contains("\"$(SRCROOT)/Frameworks/hash1\""))
+        XCTAssertFalse(otherSwiftFlags.contains("\"$(SRCROOT)/Frameworks/hash2\""))
 
         let symbolicLinks = symbolicLinkDescriptors(in: sideEffects)
         XCTAssertFalse(symbolicLinks.contains { $0.destination.basename == "Shared.xcframework" })


### PR DESCRIPTION
### What changed

`FrameworkSearchPathsGraphMapper` now wraps each Swift framework search path in double quotes when writing them into `OTHER_SWIFT_FLAGS`:

```swift
swiftSearchPathAdditions.flatMap { ["-F", "\"\($0)\""] }
```

### Why

A build failure was reported for a target named `Notification Service` (a space in the target name) that only reproduced with cached binaries — `--no-binary-cache` built fine.

In the consolidation path (targets at/above the precompiled-framework threshold, which is the cached-binary case), the mapper emitted the Swift framework search path as a bare token after `-F`:

```
-F $(SRCROOT)/Derived/FrameworkSearchPaths/Swift/Notification Service
```

Xcode word-splits `OTHER_SWIFT_FLAGS` on whitespace, so `swiftc` received `-F .../Notification` plus a stray `Service`, which it treated as a source file:

```
error: Unexpected input file: /Users/.../EtsyApp/Service
```

**Root cause:** the `-F` value was unquoted. The neighboring `-fmodule-map-file="..."` flag on the same target survived only because it was already quoted, which is why the failure looked isolated to framework search paths. This only affects the consolidation branch (`precompiledPaths.count >= consolidationThreshold`), which is why non-cached builds never hit it.

**Why this fix:** quoting matches the conventions already used in the same codebase — the `responseFileReference` in this mapper (`"@$(SRCROOT)/..."`) and `ModuleMapMapper`'s `-fmodule-map-file="..."`. Xcode strips the quotes during word-splitting, so `-F "path with spaces"` becomes a single `-F` + path token. Quoting is applied unconditionally (not just when whitespace is present), matching those existing patterns and keeping the behavior uniform.

### User impact

Targets whose names contain whitespace now build correctly with cached binaries instead of failing with `Unexpected input file`.

### Validation

- TDD: added `test_map_quotesSwiftFrameworkSearchPaths_whenTargetNameContainsWhitespace` (target `Notification Service`, 25 xcframeworks to cross the consolidation threshold) asserting the quoted `-F` token is present and the bare split-causing token is absent — red against the previous code, green after the fix.
- Updated the two existing tests that asserted the unquoted `-F` values to expect the now-quoted form.
- Verified the exact quoting transformation and escaping in isolation with `swiftc` (produces `-F` + `"$(SRCROOT)/.../Notification Service"`). The full XCTest suite was not run in this environment (no PTY); it should run in CI.

### How to test locally

1. Generate a project with a target whose name contains a space (e.g. `Notification Service`) and enough precompiled/cached framework dependencies to cross the consolidation threshold (20+).
2. Build with binary caching enabled (do **not** pass `--no-binary-cache`).
3. Before the fix the build fails with `error: Unexpected input file: .../<second word of target name>`; after the fix it builds cleanly.
