### PR TITLE
feat(server): add configurable artifact retention

### DIFF
--- a/infra/helm/tuist/README.md
+++ b/infra/helm/tuist/README.md
@@ -45,7 +45,11 @@ object storage. Omitted families remain untouched.
 server:
   artifactRetentionDays:
     cacheArtifacts: 30
+    appPreviews: 30
     buildArchives: 60
+    runArtifacts: 30
+    testAttachments: 30
+    shardBundles: 14
 ```
 
 ## Local validation

--- a/infra/helm/tuist/README.md
+++ b/infra/helm/tuist/README.md
@@ -35,6 +35,19 @@ builds `DATABASE_URL` through Kubernetes env-var substitution, so the password
 does not appear in the rendered manifest. The Secret value for `password`
 should be URL-safe because it is interpolated into a database URL.
 
+## Artifact retention
+
+Artifact cleanup is disabled by default. Opt in by setting positive retention
+windows, in days, for the artifact families you want the server to clean from
+object storage. Omitted families remain untouched.
+
+```yaml
+server:
+  artifactRetentionDays:
+    cacheArtifacts: 30
+    buildArchives: 60
+```
+
 ## Local validation
 
 Render manifests:

--- a/infra/helm/tuist/templates/server-deployment.yaml
+++ b/infra/helm/tuist/templates/server-deployment.yaml
@@ -120,6 +120,30 @@ spec:
               value: {{ .Values.server.logLevel | quote }}
             - name: TUIST_HOSTED
               value: {{ .Values.server.hosted | ternary "1" "0" | quote }}
+            {{- with (.Values.server.artifactRetentionDays.cacheArtifacts | toString) }}
+            - name: TUIST_CACHE_ARTIFACT_RETENTION_DAYS
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with (.Values.server.artifactRetentionDays.appPreviews | toString) }}
+            - name: TUIST_APP_PREVIEW_RETENTION_DAYS
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with (.Values.server.artifactRetentionDays.buildArchives | toString) }}
+            - name: TUIST_BUILD_ARCHIVE_RETENTION_DAYS
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with (.Values.server.artifactRetentionDays.runArtifacts | toString) }}
+            - name: TUIST_RUN_ARTIFACT_RETENTION_DAYS
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with (.Values.server.artifactRetentionDays.testAttachments | toString) }}
+            - name: TUIST_TEST_ATTACHMENT_RETENTION_DAYS
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with (.Values.server.artifactRetentionDays.shardBundles | toString) }}
+            - name: TUIST_SHARD_BUNDLE_RETENTION_DAYS
+              value: {{ . | quote }}
+            {{- end }}
             - name: TUIST_SKIP_EMAIL_CONFIRMATION
               value: {{ .Values.server.skipEmailConfirmation | ternary "1" "0" | quote }}
             - name: TUIST_SELF_HOSTING_DEVELOPMENT_MODE

--- a/infra/helm/tuist/values.yaml
+++ b/infra/helm/tuist/values.yaml
@@ -114,6 +114,15 @@ server:
   appUrl: http://tuist.local
   logLevel: info
   hosted: false
+  # Opt-in object-storage cleanup windows by artifact family, in days.
+  # An empty value disables cleanup only for that artifact family.
+  artifactRetentionDays:
+    cacheArtifacts: ""
+    appPreviews: ""
+    buildArchives: ""
+    runArtifacts: ""
+    testAttachments: ""
+    shardBundles: ""
   skipEmailConfirmation: true
   secretKeyBase: ""
   # When true, the chart skips emitting DATABASE_URL / TUIST_CLICKHOUSE_URL /

--- a/server/config/runtime.exs
+++ b/server/config/runtime.exs
@@ -595,7 +595,13 @@ oban_queues =
 # lands in prod.
 mode = Tuist.Environment.mode()
 
-crontab = RuntimeConfig.crontab(mode, env, Tuist.Environment.tuist_hosted?())
+crontab =
+  RuntimeConfig.crontab(
+    mode,
+    env,
+    Tuist.Environment.tuist_hosted?(),
+    Tuist.Environment.artifact_retention_days()
+  )
 
 config :tuist, Oban,
   queues: oban_queues,

--- a/server/data-export.md
+++ b/server/data-export.md
@@ -129,8 +129,8 @@ All uploaded files associated with the account are included:
 The customer-facing summary of these windows lives in the public data retention
 guide at `server/priv/docs/en/guides/server/data-retention.md`.
 
-On Tuist Cloud, stored artifact blobs are subject to plan-based retention capped
-at 30 days. The active account plan determines the applicable window, with Air
+On the hosted Tuist server, stored artifact blobs are subject to plan-based
+retention capped at 30 days. The active account plan determines the applicable window, with Air
 used when an account has no active subscription. Retention windows, in days, by
 plan:
 
@@ -157,8 +157,8 @@ family:
 
 Each variable accepts a positive integer day window. Leaving a variable unset
 or blank disables cleanup only for that artifact family. Self-hosted windows do
-not have the Tuist Cloud 30-day cap, and these variables do not override the
-Tuist Cloud policy.
+not have the hosted 30-day cap, and these variables do not override the hosted
+policy.
 
 Once an artifact is older than the applicable window, the cleanup process
 removes its binary from object storage only. The associated PostgreSQL and
@@ -170,9 +170,9 @@ Retention status is computed when cleanup runs. Cache artifacts use the object
 storage `last_modified` timestamp, while previews, current build archives, test
 attachments, and shard bundles use their database `inserted_at` timestamp. Run
 artifacts use the command event `ran_at` timestamp. Legacy build artifacts use
-the object storage `last_modified` timestamp. On Tuist Cloud, legacy build
-artifacts whose account prefix no longer resolves to a live account use the Air
-build archive window.
+the object storage `last_modified` timestamp. On the hosted Tuist server, legacy
+build artifacts whose account prefix no longer resolves to a live account use the
+Air build archive window.
 
 Cache artifact cleanup scans instance-managed cache buckets and skips
 accounts configured with account-specific custom cache storage. Matching cache
@@ -189,7 +189,7 @@ Tuist stores per-account cleanup progress for database-backed artifact families 
 daily retention jobs can resume after previously-purged metadata rows without
 issuing repeated object-storage deletes. This is not a per-artifact purge
 ledger; retention is still derived from the timestamps and the applicable
-Tuist Cloud or self-hosted policy above. An export reflects the artifacts
+hosted or self-hosted policy above. An export reflects the artifacts
 present at export time; binaries already purged under these windows are no
 longer available, though their metadata and the account-level cleanup cursor
 are still exported.

--- a/server/data-export.md
+++ b/server/data-export.md
@@ -129,12 +129,10 @@ All uploaded files associated with the account are included:
 The customer-facing summary of these windows lives in the public data retention
 guide at `server/priv/docs/en/guides/server/data-retention.md`.
 
-Stored artifact blobs are subject to plan-based retention, capped at 30 days.
-Once an artifact is
-older than its retention window, its binary is removed from object storage by a
-daily cleanup process; the associated metadata rows (build runs, test runs,
-command events, preview records, shard plans) are kept so analytics and
-dashboards remain intact. Retention windows, in days, by plan:
+On Tuist Cloud, stored artifact blobs are subject to plan-based retention capped
+at 30 days. The active account plan determines the applicable window, with Air
+used when an account has no active subscription. Retention windows, in days, by
+plan:
 
 | Artifact | Air / Open Source | Pro | Enterprise |
 | --- | --- | --- | --- |
@@ -145,22 +143,56 @@ dashboards remain intact. Retention windows, in days, by plan:
 | Test run attachments | 30 | 30 | 30 |
 | Shard bundles | 7 | 14 | 30 |
 
+Self-hosted artifact cleanup is configured independently for each artifact
+family:
+
+| Artifact family | Environment variable |
+| --- | --- |
+| Cache artifacts, including Xcode compilation, legacy content-addressable storage, module, and Gradle files | `TUIST_CACHE_ARTIFACT_RETENTION_DAYS` |
+| App preview builds and icons | `TUIST_APP_PREVIEW_RETENTION_DAYS` |
+| Current and legacy build archives | `TUIST_BUILD_ARCHIVE_RETENTION_DAYS` |
+| Run artifacts | `TUIST_RUN_ARTIFACT_RETENTION_DAYS` |
+| Test run attachments | `TUIST_TEST_ATTACHMENT_RETENTION_DAYS` |
+| Shard bundles | `TUIST_SHARD_BUNDLE_RETENTION_DAYS` |
+
+Each variable accepts a positive integer day window. Leaving a variable unset
+or blank disables cleanup only for that artifact family. Self-hosted windows do
+not have the Tuist Cloud 30-day cap, and these variables do not override the
+Tuist Cloud policy.
+
+Once an artifact is older than the applicable window, the cleanup process
+removes its binary from object storage only. The associated PostgreSQL and
+ClickHouse metadata rows, including build runs, test runs, command events,
+preview records, and shard plans, are kept so analytics and dashboards remain
+intact. The configurable policy does not change database retention rules.
+
 Retention status is computed when cleanup runs. Cache artifacts use the object
 storage `last_modified` timestamp, while previews, current build archives, test
 attachments, and shard bundles use their database `inserted_at` timestamp. Run
 artifacts use the command event `ran_at` timestamp. Legacy build artifacts use
-the object storage `last_modified` timestamp; legacy build artifacts whose
-account prefix no longer resolves to a live account use the Air build archive
-window. The active account plan determines the applicable window, with Air used
-when an account has no active subscription.
+the object storage `last_modified` timestamp. On Tuist Cloud, legacy build
+artifacts whose account prefix no longer resolves to a live account use the Air
+build archive window.
+
+Cache artifact cleanup scans instance-managed cache buckets and skips
+accounts configured with account-specific custom cache storage. Matching cache
+objects whose prefix no longer resolves to a current account are
+cleaned with the configured window. Database-backed cleanup for app previews,
+current build archives, run artifacts, test attachments, and shard bundles
+follows the account's current storage configuration. Legacy build archive
+cleanup scans the instance-managed artifact bucket. Package registry mirror
+objects and runner log archives are not covered by these configurable
+self-hosted retention variables. Runner log archives retain their separate
+90-day policy.
 
 Tuist stores per-account cleanup progress for database-backed artifact families so
 daily retention jobs can resume after previously-purged metadata rows without
 issuing repeated object-storage deletes. This is not a per-artifact purge
-ledger; retention is still derived from the timestamps and account plan above.
-An export reflects the artifacts present at export time; binaries already
-purged under these windows are no longer available, though their metadata and
-the account-level cleanup cursor are still exported.
+ledger; retention is still derived from the timestamps and the applicable
+Tuist Cloud or self-hosted policy above. An export reflects the artifacts
+present at export time; binaries already purged under these windows are no
+longer available, though their metadata and the account-level cleanup cursor
+are still exported.
 
 ## Export Process
 

--- a/server/lib/tuist/environment.ex
+++ b/server/lib/tuist/environment.ex
@@ -18,6 +18,14 @@ defmodule Tuist.Environment do
       "jwks_uri" => "https://auth.openai.com/.well-known/jwks.json"
     }
   ]
+  @artifact_retention_environment_variables %{
+    cache_artifacts: "TUIST_CACHE_ARTIFACT_RETENTION_DAYS",
+    app_previews: "TUIST_APP_PREVIEW_RETENTION_DAYS",
+    build_archives: "TUIST_BUILD_ARCHIVE_RETENTION_DAYS",
+    run_artifacts: "TUIST_RUN_ARTIFACT_RETENTION_DAYS",
+    test_attachments: "TUIST_TEST_ATTACHMENT_RETENTION_DAYS",
+    shard_bundles: "TUIST_SHARD_BUNDLE_RETENTION_DAYS"
+  }
 
   # Every supported pod role. `mode/0` raises on any other value of
   # TUIST_MODE so a deployment-manifest typo (`processsor`, `ingest`,
@@ -235,6 +243,35 @@ defmodule Tuist.Environment do
   def tuist_hosted? do
     truthy?(System.get_env("TUIST_CLOUD_HOSTED", "0")) or
       truthy?(System.get_env("TUIST_HOSTED", "0"))
+  end
+
+  def artifact_retention_days(environment \\ System.get_env()) when is_map(environment) do
+    Enum.reduce(@artifact_retention_environment_variables, %{}, fn {resource_type, environment_variable}, acc ->
+      case parse_artifact_retention_days(Map.get(environment, environment_variable), environment_variable) do
+        nil -> acc
+        days -> Map.put(acc, resource_type, days)
+      end
+    end)
+  end
+
+  defp parse_artifact_retention_days(nil, _environment_variable), do: nil
+
+  defp parse_artifact_retention_days(value, environment_variable) when is_binary(value) do
+    value = String.trim(value)
+
+    case Integer.parse(value) do
+      _ when value == "" -> nil
+      {days, ""} when days > 0 -> days
+      _ -> raise_invalid_artifact_retention_days(environment_variable, value)
+    end
+  end
+
+  defp parse_artifact_retention_days(value, environment_variable) do
+    raise_invalid_artifact_retention_days(environment_variable, value)
+  end
+
+  defp raise_invalid_artifact_retention_days(environment_variable, value) do
+    raise "#{environment_variable} must be a positive integer number of days, got: #{inspect(value)}"
   end
 
   def test_user_login_enabled? do

--- a/server/lib/tuist/oban/runtime_config.ex
+++ b/server/lib/tuist/oban/runtime_config.ex
@@ -1,7 +1,7 @@
 defmodule Tuist.Oban.RuntimeConfig do
   @moduledoc """
   Pure functions deriving Oban runtime config from pod role, deploy env,
-  and the `tuist_hosted?` flag.
+  the `tuist_hosted?` flag, and self-hosted artifact-retention settings.
 
   Lifted out of `config/runtime.exs` so they can be unit-tested against
   every value of `Tuist.Environment.modes/0`. Without this, a future
@@ -14,6 +14,12 @@ defmodule Tuist.Oban.RuntimeConfig do
   """
 
   alias Tuist.Registry.Swift.SyncWorker
+  alias Tuist.Storage.Workers.DeleteExpiredCasCacheArtifactsWorker
+  alias Tuist.Storage.Workers.DeleteExpiredGradleCacheArtifactsWorker
+  alias Tuist.Storage.Workers.DeleteExpiredLegacyBuildArtifactsWorker
+  alias Tuist.Storage.Workers.DeleteExpiredXcodeCacheArtifactsWorker
+  alias Tuist.Storage.Workers.DeleteExpiredXcodeModuleCacheArtifactsWorker
+  alias Tuist.Storage.Workers.ScheduleExpiredArtifactsWorker
 
   @shared_crons [
     {"@hourly", Tuist.Slack.Workers.ReportWorker},
@@ -33,12 +39,6 @@ defmodule Tuist.Oban.RuntimeConfig do
     {"0 * * * 1-5", Tuist.Ops.HourlySlackReportWorker},
     {"@daily", Tuist.Accounts.Workers.UpdateAllAccountsUsageWorker},
     {"@daily", Tuist.Billing.Workers.SyncStripeMetersWorker},
-    {"30 2 * * *", Tuist.Storage.Workers.ScheduleExpiredArtifactsWorker},
-    {"0 4 * * *", Tuist.Storage.Workers.DeleteExpiredLegacyBuildArtifactsWorker},
-    {"0 3 * * *", Tuist.Storage.Workers.DeleteExpiredXcodeCacheArtifactsWorker},
-    {"15 3 * * *", Tuist.Storage.Workers.DeleteExpiredXcodeModuleCacheArtifactsWorker},
-    {"30 3 * * *", Tuist.Storage.Workers.DeleteExpiredGradleCacheArtifactsWorker},
-    {"45 3 * * *", Tuist.Storage.Workers.DeleteExpiredCasCacheArtifactsWorker},
     {"* * * * *", Tuist.Kura.Reconciler},
     {"*/5 * * * *", Tuist.Kura.Workers.ExpiredRegistrationsWorker},
     {"* * * * *", Tuist.Runners.Workers.StaleClaimsWorker},
@@ -54,29 +54,56 @@ defmodule Tuist.Oban.RuntimeConfig do
     @swift_registry_sync_cron
   ]
 
+  @hosted_artifact_retention_crons [
+    {"30 2 * * *", ScheduleExpiredArtifactsWorker},
+    {"0 4 * * *", DeleteExpiredLegacyBuildArtifactsWorker},
+    {"0 3 * * *", DeleteExpiredXcodeCacheArtifactsWorker},
+    {"15 3 * * *", DeleteExpiredXcodeModuleCacheArtifactsWorker},
+    {"30 3 * * *", DeleteExpiredGradleCacheArtifactsWorker},
+    {"45 3 * * *", DeleteExpiredCasCacheArtifactsWorker}
+  ]
+
+  @database_artifact_retention_resource_types [
+    :app_previews,
+    :build_archives,
+    :run_artifacts,
+    :test_attachments,
+    :shard_bundles
+  ]
+
+  @cache_artifact_retention_crons [
+    {"0 3 * * *", DeleteExpiredXcodeCacheArtifactsWorker},
+    {"15 3 * * *", DeleteExpiredXcodeModuleCacheArtifactsWorker},
+    {"30 3 * * *", DeleteExpiredGradleCacheArtifactsWorker},
+    {"45 3 * * *", DeleteExpiredCasCacheArtifactsWorker}
+  ]
+
   @prod_like_envs [:prod, :stag, :can]
 
   @doc """
-  Crontab for the given pod mode, deploy env, and `tuist_hosted?` flag.
+  Crontab for the given pod mode, deploy env, hosted state, and optional
+  self-hosted artifact-retention windows.
 
   Empty for any non-`:web` pod. On `:web` + prod-like env, returns
   project-level crons (alerts, automations, per-project Slack reports,
   sharded-test cleanup) — Tuist-hosted deployments additionally get the
-  internal Slack ops reports, account-usage rollup, and Stripe
-  metered-billing reconciler. Preview gets only the Swift registry sync
-  cron, regardless of hosted flag, so registry previews can exercise the
-  same queue path without running production housekeeping.
+  internal Slack ops reports, account-usage rollup, Stripe metered-billing
+  reconciliation, and plan-based artifact retention. Self-hosted deployments
+  add only the artifact-retention jobs explicitly configured by resource type.
+  Preview gets only the Swift registry sync cron, regardless of hosted flag,
+  so registry previews can exercise the same queue path without running
+  production housekeeping.
   """
-  def crontab(mode, env, tuist_hosted?) do
+  def crontab(mode, env, tuist_hosted?, artifact_retention_days \\ %{}) do
     cond do
       mode == :web and env == :preview ->
         @preview_crons
 
       mode == :web and env in @prod_like_envs ->
         if tuist_hosted? do
-          @hosted_only_crons ++ @shared_crons
+          @hosted_only_crons ++ @hosted_artifact_retention_crons ++ @shared_crons
         else
-          @shared_crons
+          self_hosted_artifact_retention_crons(artifact_retention_days) ++ @shared_crons
         end
 
       true ->
@@ -96,4 +123,46 @@ defmodule Tuist.Oban.RuntimeConfig do
   """
   def peer_eligible?(:web), do: true
   def peer_eligible?(_), do: false
+
+  defp self_hosted_artifact_retention_crons(artifact_retention_days) do
+    database_retention_days =
+      artifact_retention_days
+      |> Map.take(@database_artifact_retention_resource_types)
+      |> Map.new(fn {resource_type, days} -> {Atom.to_string(resource_type), days} end)
+
+    database_crons =
+      if map_size(database_retention_days) == 0 do
+        []
+      else
+        [
+          {"30 2 * * *", ScheduleExpiredArtifactsWorker,
+           args: %{"retention_days" => database_retention_days, "self_hosted" => true}}
+        ]
+      end
+
+    legacy_build_crons =
+      case Map.fetch(artifact_retention_days, :build_archives) do
+        {:ok, days} ->
+          [
+            {"0 4 * * *", DeleteExpiredLegacyBuildArtifactsWorker,
+             args: %{"retention_days" => days, "self_hosted" => true}}
+          ]
+
+        :error ->
+          []
+      end
+
+    cache_crons =
+      case Map.fetch(artifact_retention_days, :cache_artifacts) do
+        {:ok, days} ->
+          Enum.map(@cache_artifact_retention_crons, fn {schedule, worker} ->
+            {schedule, worker, args: %{"retention_days" => days, "self_hosted" => true}}
+          end)
+
+        :error ->
+          []
+      end
+
+    database_crons ++ legacy_build_crons ++ cache_crons
+  end
 end

--- a/server/lib/tuist/oban/runtime_config.ex
+++ b/server/lib/tuist/oban/runtime_config.ex
@@ -54,15 +54,6 @@ defmodule Tuist.Oban.RuntimeConfig do
     @swift_registry_sync_cron
   ]
 
-  @hosted_artifact_retention_crons [
-    {"30 2 * * *", ScheduleExpiredArtifactsWorker},
-    {"0 4 * * *", DeleteExpiredLegacyBuildArtifactsWorker},
-    {"0 3 * * *", DeleteExpiredXcodeCacheArtifactsWorker},
-    {"15 3 * * *", DeleteExpiredXcodeModuleCacheArtifactsWorker},
-    {"30 3 * * *", DeleteExpiredGradleCacheArtifactsWorker},
-    {"45 3 * * *", DeleteExpiredCasCacheArtifactsWorker}
-  ]
-
   @database_artifact_retention_resource_types [
     :app_previews,
     :build_archives,
@@ -71,12 +62,25 @@ defmodule Tuist.Oban.RuntimeConfig do
     :shard_bundles
   ]
 
+  @schedule_expired_artifacts_cron {"30 2 * * *", ScheduleExpiredArtifactsWorker}
+  @legacy_build_artifact_retention_cron {"0 4 * * *", DeleteExpiredLegacyBuildArtifactsWorker}
+
   @cache_artifact_retention_crons [
     {"0 3 * * *", DeleteExpiredXcodeCacheArtifactsWorker},
     {"15 3 * * *", DeleteExpiredXcodeModuleCacheArtifactsWorker},
     {"30 3 * * *", DeleteExpiredGradleCacheArtifactsWorker},
     {"45 3 * * *", DeleteExpiredCasCacheArtifactsWorker}
   ]
+
+  @hosted_artifact_retention_crons [
+                                     @schedule_expired_artifacts_cron,
+                                     @legacy_build_artifact_retention_cron
+                                   ] ++ @cache_artifact_retention_crons
+
+  # Self-hosted retention workers read their window from the environment on every run.
+  # The environment is what decides *whether* a cron is installed at boot; the days
+  # themselves are never carried in the job args.
+  @self_hosted_args %{"self_hosted" => true}
 
   @prod_like_envs [:prod, :stag, :can]
 
@@ -125,44 +129,29 @@ defmodule Tuist.Oban.RuntimeConfig do
   def peer_eligible?(_), do: false
 
   defp self_hosted_artifact_retention_crons(artifact_retention_days) do
-    database_retention_days =
-      artifact_retention_days
-      |> Map.take(@database_artifact_retention_resource_types)
-      |> Map.new(fn {resource_type, days} -> {Atom.to_string(resource_type), days} end)
-
     database_crons =
-      if map_size(database_retention_days) == 0 do
-        []
+      if Enum.any?(@database_artifact_retention_resource_types, &Map.has_key?(artifact_retention_days, &1)) do
+        [self_hosted_cron(@schedule_expired_artifacts_cron)]
       else
-        [
-          {"30 2 * * *", ScheduleExpiredArtifactsWorker,
-           args: %{"retention_days" => database_retention_days, "self_hosted" => true}}
-        ]
+        []
       end
 
     legacy_build_crons =
-      case Map.fetch(artifact_retention_days, :build_archives) do
-        {:ok, days} ->
-          [
-            {"0 4 * * *", DeleteExpiredLegacyBuildArtifactsWorker,
-             args: %{"retention_days" => days, "self_hosted" => true}}
-          ]
-
-        :error ->
-          []
+      if Map.has_key?(artifact_retention_days, :build_archives) do
+        [self_hosted_cron(@legacy_build_artifact_retention_cron)]
+      else
+        []
       end
 
     cache_crons =
-      case Map.fetch(artifact_retention_days, :cache_artifacts) do
-        {:ok, days} ->
-          Enum.map(@cache_artifact_retention_crons, fn {schedule, worker} ->
-            {schedule, worker, args: %{"retention_days" => days, "self_hosted" => true}}
-          end)
-
-        :error ->
-          []
+      if Map.has_key?(artifact_retention_days, :cache_artifacts) do
+        Enum.map(@cache_artifact_retention_crons, &self_hosted_cron/1)
+      else
+        []
       end
 
     database_crons ++ legacy_build_crons ++ cache_crons
   end
+
+  defp self_hosted_cron({schedule, worker}), do: {schedule, worker, args: @self_hosted_args}
 end

--- a/server/lib/tuist/storage/AGENTS.md
+++ b/server/lib/tuist/storage/AGENTS.md
@@ -5,6 +5,7 @@ This context owns object storage access (S3-compatible and Azure Blob).
 ## Responsibilities
 - Generate presigned URLs for upload/download (including multipart uploads).
 - Stream and upload objects, check existence, and delete by prefix.
+- Enforce Tuist Cloud and opt-in self-hosted artifact-retention windows without deleting analytics metadata.
 - Emit telemetry for storage operations.
 
 ## Boundaries

--- a/server/lib/tuist/storage/bucket_artifact_retention.ex
+++ b/server/lib/tuist/storage/bucket_artifact_retention.ex
@@ -60,19 +60,32 @@ defmodule Tuist.Storage.BucketArtifactRetention do
   defp expired_objects(objects, target) do
     plans_by_account_handle = managed_plans_by_account_handle(objects, target)
     retention_artifact_type = Map.fetch!(target, :retention_artifact_type)
+    retention_days = Map.get(target, :retention_days)
     orphaned_account_plan = Map.get(target, :orphaned_account_plan)
 
     Enum.filter(objects, fn object ->
       plan = plan_for_object(object, plans_by_account_handle) || orphaned_account_plan
 
-      if is_nil(plan) do
-        false
-      else
-        cutoff = RetentionPolicy.cutoff(retention_artifact_type, plan)
+      cond do
+        plan == :skip ->
+          false
 
-        object
-        |> last_modified()
-        |> expired?(cutoff)
+        not is_nil(retention_days) ->
+          cutoff = RetentionPolicy.cutoff(retention_artifact_type, plan || :air, retention_days)
+
+          object
+          |> last_modified()
+          |> expired?(cutoff)
+
+        is_nil(plan) ->
+          false
+
+        true ->
+          cutoff = RetentionPolicy.cutoff(retention_artifact_type, plan)
+
+          object
+          |> last_modified()
+          |> expired?(cutoff)
       end
     end)
   end
@@ -85,31 +98,33 @@ defmodule Tuist.Storage.BucketArtifactRetention do
       |> Enum.flat_map(fn account_handle -> [account_handle, normalize_account_handle(account_handle)] end)
       |> Enum.uniq()
 
-    Account
-    |> where([account], account.name in ^account_handles)
-    |> Repo.all()
-    |> maybe_reject_custom_storage_accounts(target)
-    |> then(fn accounts ->
-      plans_by_account_id = RetentionPolicy.current_plans(accounts)
+    accounts =
+      Account
+      |> where([account], account.name in ^account_handles)
+      |> Repo.all()
 
-      exact_plans_by_account_handle =
-        Map.new(accounts, fn account -> {account.name, Map.fetch!(plans_by_account_id, account.id)} end)
+    {skipped_accounts, managed_accounts} =
+      if Map.get(target, :skip_custom_storage_accounts?, false) do
+        Enum.split_with(accounts, &Account.custom_s3_storage_configured?/1)
+      else
+        {[], accounts}
+      end
 
-      normalized_plans_by_account_handle =
-        Map.new(accounts, fn account ->
-          {normalize_account_handle(account.name), Map.fetch!(plans_by_account_id, account.id)}
-        end)
+    plans_by_account_id = RetentionPolicy.current_plans(managed_accounts)
 
-      Map.merge(normalized_plans_by_account_handle, exact_plans_by_account_handle)
-    end)
+    managed_plans =
+      account_values_by_handle(managed_accounts, fn account -> Map.fetch!(plans_by_account_id, account.id) end)
+
+    skipped_plans = account_values_by_handle(skipped_accounts, fn _account -> :skip end)
+
+    Map.merge(managed_plans, skipped_plans)
   end
 
-  defp maybe_reject_custom_storage_accounts(accounts, target) do
-    if Map.get(target, :skip_custom_storage_accounts?, false) do
-      Enum.reject(accounts, &Account.custom_s3_storage_configured?/1)
-    else
-      accounts
-    end
+  defp account_values_by_handle(accounts, value) do
+    exact_values = Map.new(accounts, fn account -> {account.name, value.(account)} end)
+    normalized_values = Map.new(accounts, fn account -> {normalize_account_handle(account.name), value.(account)} end)
+
+    Map.merge(normalized_values, exact_values)
   end
 
   defp plan_for_object(object, plans_by_account_handle) do

--- a/server/lib/tuist/storage/cache_artifact_retention.ex
+++ b/server/lib/tuist/storage/cache_artifact_retention.ex
@@ -11,6 +11,7 @@ defmodule Tuist.Storage.CacheArtifactRetention do
   def delete_expired(artifact_type, opts \\ []) when artifact_type in @artifact_types do
     artifact_type
     |> retention_target()
+    |> Map.put(:retention_days, Keyword.get(opts, :retention_days))
     |> BucketArtifactRetention.delete_expired(opts)
   end
 

--- a/server/lib/tuist/storage/expired_artifacts.ex
+++ b/server/lib/tuist/storage/expired_artifacts.ex
@@ -37,7 +37,7 @@ defmodule Tuist.Storage.ExpiredArtifacts do
 
   def delete_previews(%Account{} = account, batch_size, opts \\ []) do
     plan = RetentionPolicy.current_plan(account)
-    cutoff = RetentionPolicy.cutoff(:preview_app_build, plan)
+    cutoff = RetentionPolicy.cutoff(:preview_app_build, plan, Keyword.get(opts, :retention_days))
     cursor = initial_cursor(account, :preview_app_build, opts, :utc)
 
     rows =
@@ -81,7 +81,7 @@ defmodule Tuist.Storage.ExpiredArtifacts do
 
   def delete_build_archives(%Account{} = account, batch_size, opts \\ []) do
     plan = RetentionPolicy.current_plan(account)
-    cutoff = :build_archive |> RetentionPolicy.cutoff(plan) |> DateTime.to_naive()
+    cutoff = :build_archive |> RetentionPolicy.cutoff(plan, Keyword.get(opts, :retention_days)) |> DateTime.to_naive()
     projects_by_id = projects_by_id(account)
     project_ids = Map.keys(projects_by_id)
     cursor = initial_cursor(account, :build_archive, opts, :naive)
@@ -112,7 +112,7 @@ defmodule Tuist.Storage.ExpiredArtifacts do
 
   def delete_run_artifacts(%Account{} = account, batch_size, opts \\ []) do
     plan = RetentionPolicy.current_plan(account)
-    cutoff = :run_session |> RetentionPolicy.cutoff(plan) |> DateTime.to_naive()
+    cutoff = :run_session |> RetentionPolicy.cutoff(plan, Keyword.get(opts, :retention_days)) |> DateTime.to_naive()
     projects_by_id = projects_by_id(account)
     project_ids = Map.keys(projects_by_id)
     cursor = initial_cursor(account, :run_session, opts, :naive)
@@ -151,7 +151,12 @@ defmodule Tuist.Storage.ExpiredArtifacts do
 
   def delete_test_attachments(%Account{} = account, batch_size, opts \\ []) do
     plan = RetentionPolicy.current_plan(account)
-    cutoff = :test_attachment |> RetentionPolicy.cutoff(plan) |> DateTime.to_naive()
+
+    cutoff =
+      :test_attachment
+      |> RetentionPolicy.cutoff(plan, Keyword.get(opts, :retention_days))
+      |> DateTime.to_naive()
+
     projects_by_id = projects_by_id(account)
     project_ids = Map.keys(projects_by_id)
     cursor = initial_cursor(account, :test_attachment, opts, :naive)
@@ -205,7 +210,7 @@ defmodule Tuist.Storage.ExpiredArtifacts do
 
   def delete_shard_bundles(%Account{} = account, batch_size, opts \\ []) do
     plan = RetentionPolicy.current_plan(account)
-    cutoff = :shard_bundle |> RetentionPolicy.cutoff(plan) |> DateTime.to_naive()
+    cutoff = :shard_bundle |> RetentionPolicy.cutoff(plan, Keyword.get(opts, :retention_days)) |> DateTime.to_naive()
     projects_by_id = projects_by_id(account)
     project_ids = Map.keys(projects_by_id)
     cursor = initial_cursor(account, :shard_bundle, opts, :naive)

--- a/server/lib/tuist/storage/legacy_build_artifact_retention.ex
+++ b/server/lib/tuist/storage/legacy_build_artifact_retention.ex
@@ -15,6 +15,7 @@ defmodule Tuist.Storage.LegacyBuildArtifactRetention do
         bucket_name: bucket_name(storage_provider),
         object_matches?: &legacy_build_artifact?/1,
         orphaned_account_plan: @orphaned_account_plan,
+        retention_days: Keyword.get(opts, :retention_days),
         retention_artifact_type: :build_archive,
         storage_provider: storage_provider
       },

--- a/server/lib/tuist/storage/retention_policy.ex
+++ b/server/lib/tuist/storage/retention_policy.ex
@@ -10,7 +10,7 @@ defmodule Tuist.Storage.RetentionPolicy do
 
   @default_plan :air
   @known_plans [:air, :open_source, :pro, :enterprise]
-  @maximum_retention_days 30
+  @maximum_hosted_retention_days 30
 
   @retention_days %{
     cache_artifact: %{air: 14, open_source: 14, pro: 30, enterprise: 30},
@@ -43,16 +43,26 @@ defmodule Tuist.Storage.RetentionPolicy do
     end)
   end
 
-  def retention_days(artifact_type, plan) do
+  def retention_days(artifact_type, plan, override_days \\ nil)
+
+  def retention_days(_artifact_type, _plan, override_days) when is_integer(override_days) and override_days > 0 do
+    override_days
+  end
+
+  def retention_days(artifact_type, plan, nil) do
     retention_by_plan = Map.fetch!(@retention_days, artifact_type)
 
     retention_by_plan
     |> Map.get(plan, Map.fetch!(retention_by_plan, @default_plan))
-    |> min(@maximum_retention_days)
+    |> min(@maximum_hosted_retention_days)
   end
 
-  def cutoff(artifact_type, plan) do
-    days = retention_days(artifact_type, plan)
+  def retention_days(_artifact_type, _plan, override_days) do
+    raise ArgumentError, "retention days must be a positive integer, got: #{inspect(override_days)}"
+  end
+
+  def cutoff(artifact_type, plan, override_days \\ nil) do
+    days = retention_days(artifact_type, plan, override_days)
     DateTime.add(DateTime.utc_now(), -days, :day)
   end
 

--- a/server/lib/tuist/storage/workers/artifact_retention_worker.ex
+++ b/server/lib/tuist/storage/workers/artifact_retention_worker.ex
@@ -16,6 +16,12 @@ defmodule Tuist.Storage.Workers.ArtifactRetentionWorker do
     end
   end
 
+  def put_retention_days(args, nil), do: args
+  def put_retention_days(args, retention_days), do: Map.put(args, "retention_days", retention_days)
+
+  def put_self_hosted(args, false), do: args
+  def put_self_hosted(args, true), do: Map.put(args, "self_hosted", true)
+
   def reschedule_with_args(%Oban.Job{} = job, args) do
     # Oban increments max_attempts when it snoozes a job. Setting it one below
     # the next page's budget gives every page three attempts, even when an

--- a/server/lib/tuist/storage/workers/artifact_retention_worker.ex
+++ b/server/lib/tuist/storage/workers/artifact_retention_worker.ex
@@ -1,0 +1,30 @@
+defmodule Tuist.Storage.Workers.ArtifactRetentionWorker do
+  @moduledoc false
+
+  alias Tuist.Environment
+
+  @attempts_per_page 3
+
+  def effective_retention_days(args, resource_type) do
+    if Map.get(args, "self_hosted", false) do
+      case Map.fetch(Environment.artifact_retention_days(), resource_type) do
+        {:ok, retention_days} -> {:enabled, retention_days}
+        :error -> :disabled
+      end
+    else
+      {:enabled, Map.get(args, "retention_days")}
+    end
+  end
+
+  def reschedule_with_args(%Oban.Job{} = job, args) do
+    # Oban increments max_attempts when it snoozes a job. Setting it one below
+    # the next page's budget gives every page three attempts, even when an
+    # earlier page used one or more retries.
+    max_attempts = job.attempt + @attempts_per_page - 1
+
+    case Oban.update_job(job, %{args: args, max_attempts: max_attempts}) do
+      {:ok, _job} -> {:snooze, 0}
+      error -> error
+    end
+  end
+end

--- a/server/lib/tuist/storage/workers/bucket_artifact_worker.ex
+++ b/server/lib/tuist/storage/workers/bucket_artifact_worker.ex
@@ -3,8 +3,10 @@ defmodule Tuist.Storage.Workers.BucketArtifactWorker do
 
   alias Tuist.Storage.Workers.ArtifactRetentionWorker
 
+  def options_from_args(args, nil), do: [continuation_token: Map.get(args, "continuation_token")]
+
   def options_from_args(args, retention_days) do
-    maybe_put_retention_days([continuation_token: Map.get(args, "continuation_token")], retention_days)
+    [continuation_token: Map.get(args, "continuation_token"), retention_days: retention_days]
   end
 
   def continue(nil, _job, _retention_days, _self_hosted), do: :ok
@@ -12,22 +14,9 @@ defmodule Tuist.Storage.Workers.BucketArtifactWorker do
   def continue(continuation_token, job, retention_days, self_hosted) do
     args =
       %{"continuation_token" => continuation_token}
-      |> maybe_put_retention_days(retention_days)
-      |> maybe_put_self_hosted(self_hosted)
+      |> ArtifactRetentionWorker.put_retention_days(retention_days)
+      |> ArtifactRetentionWorker.put_self_hosted(self_hosted)
 
     ArtifactRetentionWorker.reschedule_with_args(job, args)
   end
-
-  defp maybe_put_retention_days(args, nil), do: args
-
-  defp maybe_put_retention_days(args, retention_days) when is_map(args) do
-    Map.put(args, "retention_days", retention_days)
-  end
-
-  defp maybe_put_retention_days(opts, retention_days) when is_list(opts) do
-    Keyword.put(opts, :retention_days, retention_days)
-  end
-
-  defp maybe_put_self_hosted(args, false), do: args
-  defp maybe_put_self_hosted(args, true), do: Map.put(args, "self_hosted", true)
 end

--- a/server/lib/tuist/storage/workers/bucket_artifact_worker.ex
+++ b/server/lib/tuist/storage/workers/bucket_artifact_worker.ex
@@ -1,0 +1,33 @@
+defmodule Tuist.Storage.Workers.BucketArtifactWorker do
+  @moduledoc false
+
+  alias Tuist.Storage.Workers.ArtifactRetentionWorker
+
+  def options_from_args(args, retention_days) do
+    maybe_put_retention_days([continuation_token: Map.get(args, "continuation_token")], retention_days)
+  end
+
+  def continue(nil, _job, _retention_days, _self_hosted), do: :ok
+
+  def continue(continuation_token, job, retention_days, self_hosted) do
+    args =
+      %{"continuation_token" => continuation_token}
+      |> maybe_put_retention_days(retention_days)
+      |> maybe_put_self_hosted(self_hosted)
+
+    ArtifactRetentionWorker.reschedule_with_args(job, args)
+  end
+
+  defp maybe_put_retention_days(args, nil), do: args
+
+  defp maybe_put_retention_days(args, retention_days) when is_map(args) do
+    Map.put(args, "retention_days", retention_days)
+  end
+
+  defp maybe_put_retention_days(opts, retention_days) when is_list(opts) do
+    Keyword.put(opts, :retention_days, retention_days)
+  end
+
+  defp maybe_put_self_hosted(args, false), do: args
+  defp maybe_put_self_hosted(args, true), do: Map.put(args, "self_hosted", true)
+end

--- a/server/lib/tuist/storage/workers/delete_expired_build_archives_worker.ex
+++ b/server/lib/tuist/storage/workers/delete_expired_build_archives_worker.ex
@@ -3,8 +3,13 @@ defmodule Tuist.Storage.Workers.DeleteExpiredBuildArchivesWorker do
   use Oban.Worker,
     queue: :storage_retention,
     max_attempts: 3,
-    unique: [keys: [:account_id, :after_inserted_at, :after_id], states: [:available, :scheduled, :executing, :retryable]]
+    unique: [
+      keys: [:account_id],
+      period: :infinity,
+      states: [:available, :scheduled, :executing, :retryable]
+    ]
 
+  import Tuist.Storage.Workers.ArtifactRetentionWorker
   import Tuist.Storage.Workers.ExpiredArtifactWorker
 
   alias Tuist.Accounts.Account
@@ -14,17 +19,23 @@ defmodule Tuist.Storage.Workers.DeleteExpiredBuildArchivesWorker do
   @default_batch_size 500
 
   @impl Oban.Worker
-  def perform(%Oban.Job{args: %{"account_id" => account_id} = args}) do
+  def perform(%Oban.Job{args: %{"account_id" => account_id} = args} = job) do
     batch_size = Map.get(args, "batch_size", @default_batch_size)
 
-    case Repo.get(Account, account_id) do
-      nil ->
-        :ok
+    case effective_retention_days(args, :build_archives) do
+      {:enabled, retention_days} ->
+        case Repo.get(Account, account_id) do
+          nil ->
+            :ok
 
-      account ->
-        account
-        |> ExpiredArtifacts.delete_build_archives(batch_size, cursor_from_args(args))
-        |> continue(__MODULE__, account_id, batch_size)
+          account ->
+            account
+            |> ExpiredArtifacts.delete_build_archives(batch_size, cursor_from_args(args, retention_days))
+            |> continue(job, account_id, batch_size, retention_days, Map.get(args, "self_hosted", false))
+        end
+
+      :disabled ->
+        :ok
     end
   end
 end

--- a/server/lib/tuist/storage/workers/delete_expired_cas_cache_artifacts_worker.ex
+++ b/server/lib/tuist/storage/workers/delete_expired_cas_cache_artifacts_worker.ex
@@ -3,28 +3,25 @@ defmodule Tuist.Storage.Workers.DeleteExpiredCasCacheArtifactsWorker do
   use Oban.Worker,
     queue: :storage_retention,
     max_attempts: 3,
-    unique: [keys: [:continuation_token], states: [:available, :scheduled, :executing, :retryable]]
+    unique: [
+      fields: [:queue, :worker],
+      period: :infinity,
+      states: [:available, :scheduled, :executing, :retryable]
+    ]
+
+  import Tuist.Storage.Workers.ArtifactRetentionWorker
+  import Tuist.Storage.Workers.BucketArtifactWorker
 
   alias Tuist.Storage.CacheArtifactRetention
 
   @impl Oban.Worker
-  def perform(%Oban.Job{args: args}) do
-    continuation_token = Map.get(args, "continuation_token")
-
-    with {:ok, next_continuation_token} <-
-           CacheArtifactRetention.delete_expired(:cas, continuation_token: continuation_token) do
-      maybe_enqueue_next_page(next_continuation_token)
-    end
-  end
-
-  defp maybe_enqueue_next_page(nil), do: :ok
-
-  defp maybe_enqueue_next_page(continuation_token) do
-    %{"continuation_token" => continuation_token}
-    |> __MODULE__.new()
-    |> Oban.insert()
-    |> case do
-      {:ok, _job} -> :ok
+  def perform(%Oban.Job{args: args} = job) do
+    with {:enabled, retention_days} <- effective_retention_days(args, :cache_artifacts),
+         {:ok, next_continuation_token} <-
+           CacheArtifactRetention.delete_expired(:cas, options_from_args(args, retention_days)) do
+      continue(next_continuation_token, job, retention_days, Map.get(args, "self_hosted", false))
+    else
+      :disabled -> :ok
       error -> error
     end
   end

--- a/server/lib/tuist/storage/workers/delete_expired_gradle_cache_artifacts_worker.ex
+++ b/server/lib/tuist/storage/workers/delete_expired_gradle_cache_artifacts_worker.ex
@@ -3,28 +3,25 @@ defmodule Tuist.Storage.Workers.DeleteExpiredGradleCacheArtifactsWorker do
   use Oban.Worker,
     queue: :storage_retention,
     max_attempts: 3,
-    unique: [keys: [:continuation_token], states: [:available, :scheduled, :executing, :retryable]]
+    unique: [
+      fields: [:queue, :worker],
+      period: :infinity,
+      states: [:available, :scheduled, :executing, :retryable]
+    ]
+
+  import Tuist.Storage.Workers.ArtifactRetentionWorker
+  import Tuist.Storage.Workers.BucketArtifactWorker
 
   alias Tuist.Storage.CacheArtifactRetention
 
   @impl Oban.Worker
-  def perform(%Oban.Job{args: args}) do
-    continuation_token = Map.get(args, "continuation_token")
-
-    with {:ok, next_continuation_token} <-
-           CacheArtifactRetention.delete_expired(:gradle, continuation_token: continuation_token) do
-      maybe_enqueue_next_page(next_continuation_token)
-    end
-  end
-
-  defp maybe_enqueue_next_page(nil), do: :ok
-
-  defp maybe_enqueue_next_page(continuation_token) do
-    %{"continuation_token" => continuation_token}
-    |> __MODULE__.new()
-    |> Oban.insert()
-    |> case do
-      {:ok, _job} -> :ok
+  def perform(%Oban.Job{args: args} = job) do
+    with {:enabled, retention_days} <- effective_retention_days(args, :cache_artifacts),
+         {:ok, next_continuation_token} <-
+           CacheArtifactRetention.delete_expired(:gradle, options_from_args(args, retention_days)) do
+      continue(next_continuation_token, job, retention_days, Map.get(args, "self_hosted", false))
+    else
+      :disabled -> :ok
       error -> error
     end
   end

--- a/server/lib/tuist/storage/workers/delete_expired_legacy_build_artifacts_worker.ex
+++ b/server/lib/tuist/storage/workers/delete_expired_legacy_build_artifacts_worker.ex
@@ -3,28 +3,25 @@ defmodule Tuist.Storage.Workers.DeleteExpiredLegacyBuildArtifactsWorker do
   use Oban.Worker,
     queue: :storage_retention,
     max_attempts: 3,
-    unique: [keys: [:continuation_token], states: [:available, :scheduled, :executing, :retryable]]
+    unique: [
+      fields: [:queue, :worker],
+      period: :infinity,
+      states: [:available, :scheduled, :executing, :retryable]
+    ]
+
+  import Tuist.Storage.Workers.ArtifactRetentionWorker
+  import Tuist.Storage.Workers.BucketArtifactWorker
 
   alias Tuist.Storage.LegacyBuildArtifactRetention
 
   @impl Oban.Worker
-  def perform(%Oban.Job{args: args}) do
-    continuation_token = Map.get(args, "continuation_token")
-
-    with {:ok, next_continuation_token} <-
-           LegacyBuildArtifactRetention.delete_expired(continuation_token: continuation_token) do
-      maybe_enqueue_next_page(next_continuation_token)
-    end
-  end
-
-  defp maybe_enqueue_next_page(nil), do: :ok
-
-  defp maybe_enqueue_next_page(continuation_token) do
-    %{"continuation_token" => continuation_token}
-    |> __MODULE__.new()
-    |> Oban.insert()
-    |> case do
-      {:ok, _job} -> :ok
+  def perform(%Oban.Job{args: args} = job) do
+    with {:enabled, retention_days} <- effective_retention_days(args, :build_archives),
+         {:ok, next_continuation_token} <-
+           LegacyBuildArtifactRetention.delete_expired(options_from_args(args, retention_days)) do
+      continue(next_continuation_token, job, retention_days, Map.get(args, "self_hosted", false))
+    else
+      :disabled -> :ok
       error -> error
     end
   end

--- a/server/lib/tuist/storage/workers/delete_expired_preview_artifacts_worker.ex
+++ b/server/lib/tuist/storage/workers/delete_expired_preview_artifacts_worker.ex
@@ -3,8 +3,13 @@ defmodule Tuist.Storage.Workers.DeleteExpiredPreviewArtifactsWorker do
   use Oban.Worker,
     queue: :storage_retention,
     max_attempts: 3,
-    unique: [keys: [:account_id, :after_inserted_at, :after_id], states: [:available, :scheduled, :executing, :retryable]]
+    unique: [
+      keys: [:account_id],
+      period: :infinity,
+      states: [:available, :scheduled, :executing, :retryable]
+    ]
 
+  import Tuist.Storage.Workers.ArtifactRetentionWorker
   import Tuist.Storage.Workers.ExpiredArtifactWorker
 
   alias Tuist.Accounts.Account
@@ -14,17 +19,23 @@ defmodule Tuist.Storage.Workers.DeleteExpiredPreviewArtifactsWorker do
   @default_batch_size 500
 
   @impl Oban.Worker
-  def perform(%Oban.Job{args: %{"account_id" => account_id} = args}) do
+  def perform(%Oban.Job{args: %{"account_id" => account_id} = args} = job) do
     batch_size = Map.get(args, "batch_size", @default_batch_size)
 
-    case Repo.get(Account, account_id) do
-      nil ->
-        :ok
+    case effective_retention_days(args, :app_previews) do
+      {:enabled, retention_days} ->
+        case Repo.get(Account, account_id) do
+          nil ->
+            :ok
 
-      account ->
-        account
-        |> ExpiredArtifacts.delete_previews(batch_size, cursor_from_args(args))
-        |> continue(__MODULE__, account_id, batch_size)
+          account ->
+            account
+            |> ExpiredArtifacts.delete_previews(batch_size, cursor_from_args(args, retention_days))
+            |> continue(job, account_id, batch_size, retention_days, Map.get(args, "self_hosted", false))
+        end
+
+      :disabled ->
+        :ok
     end
   end
 end

--- a/server/lib/tuist/storage/workers/delete_expired_run_sessions_worker.ex
+++ b/server/lib/tuist/storage/workers/delete_expired_run_sessions_worker.ex
@@ -3,8 +3,13 @@ defmodule Tuist.Storage.Workers.DeleteExpiredRunSessionsWorker do
   use Oban.Worker,
     queue: :storage_retention,
     max_attempts: 3,
-    unique: [keys: [:account_id, :after_inserted_at, :after_id], states: [:available, :scheduled, :executing, :retryable]]
+    unique: [
+      keys: [:account_id],
+      period: :infinity,
+      states: [:available, :scheduled, :executing, :retryable]
+    ]
 
+  import Tuist.Storage.Workers.ArtifactRetentionWorker
   import Tuist.Storage.Workers.ExpiredArtifactWorker
 
   alias Tuist.Accounts.Account
@@ -14,17 +19,23 @@ defmodule Tuist.Storage.Workers.DeleteExpiredRunSessionsWorker do
   @default_batch_size 500
 
   @impl Oban.Worker
-  def perform(%Oban.Job{args: %{"account_id" => account_id} = args}) do
+  def perform(%Oban.Job{args: %{"account_id" => account_id} = args} = job) do
     batch_size = Map.get(args, "batch_size", @default_batch_size)
 
-    case Repo.get(Account, account_id) do
-      nil ->
-        :ok
+    case effective_retention_days(args, :run_artifacts) do
+      {:enabled, retention_days} ->
+        case Repo.get(Account, account_id) do
+          nil ->
+            :ok
 
-      account ->
-        account
-        |> ExpiredArtifacts.delete_run_artifacts(batch_size, cursor_from_args(args))
-        |> continue(__MODULE__, account_id, batch_size)
+          account ->
+            account
+            |> ExpiredArtifacts.delete_run_artifacts(batch_size, cursor_from_args(args, retention_days))
+            |> continue(job, account_id, batch_size, retention_days, Map.get(args, "self_hosted", false))
+        end
+
+      :disabled ->
+        :ok
     end
   end
 end

--- a/server/lib/tuist/storage/workers/delete_expired_shard_bundles_worker.ex
+++ b/server/lib/tuist/storage/workers/delete_expired_shard_bundles_worker.ex
@@ -3,8 +3,13 @@ defmodule Tuist.Storage.Workers.DeleteExpiredShardBundlesWorker do
   use Oban.Worker,
     queue: :storage_retention,
     max_attempts: 3,
-    unique: [keys: [:account_id, :after_inserted_at, :after_id], states: [:available, :scheduled, :executing, :retryable]]
+    unique: [
+      keys: [:account_id],
+      period: :infinity,
+      states: [:available, :scheduled, :executing, :retryable]
+    ]
 
+  import Tuist.Storage.Workers.ArtifactRetentionWorker
   import Tuist.Storage.Workers.ExpiredArtifactWorker
 
   alias Tuist.Accounts.Account
@@ -14,17 +19,23 @@ defmodule Tuist.Storage.Workers.DeleteExpiredShardBundlesWorker do
   @default_batch_size 500
 
   @impl Oban.Worker
-  def perform(%Oban.Job{args: %{"account_id" => account_id} = args}) do
+  def perform(%Oban.Job{args: %{"account_id" => account_id} = args} = job) do
     batch_size = Map.get(args, "batch_size", @default_batch_size)
 
-    case Repo.get(Account, account_id) do
-      nil ->
-        :ok
+    case effective_retention_days(args, :shard_bundles) do
+      {:enabled, retention_days} ->
+        case Repo.get(Account, account_id) do
+          nil ->
+            :ok
 
-      account ->
-        account
-        |> ExpiredArtifacts.delete_shard_bundles(batch_size, cursor_from_args(args))
-        |> continue(__MODULE__, account_id, batch_size)
+          account ->
+            account
+            |> ExpiredArtifacts.delete_shard_bundles(batch_size, cursor_from_args(args, retention_days))
+            |> continue(job, account_id, batch_size, retention_days, Map.get(args, "self_hosted", false))
+        end
+
+      :disabled ->
+        :ok
     end
   end
 end

--- a/server/lib/tuist/storage/workers/delete_expired_test_attachments_worker.ex
+++ b/server/lib/tuist/storage/workers/delete_expired_test_attachments_worker.ex
@@ -3,8 +3,13 @@ defmodule Tuist.Storage.Workers.DeleteExpiredTestAttachmentsWorker do
   use Oban.Worker,
     queue: :storage_retention,
     max_attempts: 3,
-    unique: [keys: [:account_id, :after_inserted_at, :after_id], states: [:available, :scheduled, :executing, :retryable]]
+    unique: [
+      keys: [:account_id],
+      period: :infinity,
+      states: [:available, :scheduled, :executing, :retryable]
+    ]
 
+  import Tuist.Storage.Workers.ArtifactRetentionWorker
   import Tuist.Storage.Workers.ExpiredArtifactWorker
 
   alias Tuist.Accounts.Account
@@ -14,17 +19,23 @@ defmodule Tuist.Storage.Workers.DeleteExpiredTestAttachmentsWorker do
   @default_batch_size 500
 
   @impl Oban.Worker
-  def perform(%Oban.Job{args: %{"account_id" => account_id} = args}) do
+  def perform(%Oban.Job{args: %{"account_id" => account_id} = args} = job) do
     batch_size = Map.get(args, "batch_size", @default_batch_size)
 
-    case Repo.get(Account, account_id) do
-      nil ->
-        :ok
+    case effective_retention_days(args, :test_attachments) do
+      {:enabled, retention_days} ->
+        case Repo.get(Account, account_id) do
+          nil ->
+            :ok
 
-      account ->
-        account
-        |> ExpiredArtifacts.delete_test_attachments(batch_size, cursor_from_args(args))
-        |> continue(__MODULE__, account_id, batch_size)
+          account ->
+            account
+            |> ExpiredArtifacts.delete_test_attachments(batch_size, cursor_from_args(args, retention_days))
+            |> continue(job, account_id, batch_size, retention_days, Map.get(args, "self_hosted", false))
+        end
+
+      :disabled ->
+        :ok
     end
   end
 end

--- a/server/lib/tuist/storage/workers/delete_expired_xcode_cache_artifacts_worker.ex
+++ b/server/lib/tuist/storage/workers/delete_expired_xcode_cache_artifacts_worker.ex
@@ -3,28 +3,25 @@ defmodule Tuist.Storage.Workers.DeleteExpiredXcodeCacheArtifactsWorker do
   use Oban.Worker,
     queue: :storage_retention,
     max_attempts: 3,
-    unique: [keys: [:continuation_token], states: [:available, :scheduled, :executing, :retryable]]
+    unique: [
+      fields: [:queue, :worker],
+      period: :infinity,
+      states: [:available, :scheduled, :executing, :retryable]
+    ]
+
+  import Tuist.Storage.Workers.ArtifactRetentionWorker
+  import Tuist.Storage.Workers.BucketArtifactWorker
 
   alias Tuist.Storage.CacheArtifactRetention
 
   @impl Oban.Worker
-  def perform(%Oban.Job{args: args}) do
-    continuation_token = Map.get(args, "continuation_token")
-
-    with {:ok, next_continuation_token} <-
-           CacheArtifactRetention.delete_expired(:xcode_cache, continuation_token: continuation_token) do
-      maybe_enqueue_next_page(next_continuation_token)
-    end
-  end
-
-  defp maybe_enqueue_next_page(nil), do: :ok
-
-  defp maybe_enqueue_next_page(continuation_token) do
-    %{"continuation_token" => continuation_token}
-    |> __MODULE__.new()
-    |> Oban.insert()
-    |> case do
-      {:ok, _job} -> :ok
+  def perform(%Oban.Job{args: args} = job) do
+    with {:enabled, retention_days} <- effective_retention_days(args, :cache_artifacts),
+         {:ok, next_continuation_token} <-
+           CacheArtifactRetention.delete_expired(:xcode_cache, options_from_args(args, retention_days)) do
+      continue(next_continuation_token, job, retention_days, Map.get(args, "self_hosted", false))
+    else
+      :disabled -> :ok
       error -> error
     end
   end

--- a/server/lib/tuist/storage/workers/delete_expired_xcode_module_cache_artifacts_worker.ex
+++ b/server/lib/tuist/storage/workers/delete_expired_xcode_module_cache_artifacts_worker.ex
@@ -3,28 +3,25 @@ defmodule Tuist.Storage.Workers.DeleteExpiredXcodeModuleCacheArtifactsWorker do
   use Oban.Worker,
     queue: :storage_retention,
     max_attempts: 3,
-    unique: [keys: [:continuation_token], states: [:available, :scheduled, :executing, :retryable]]
+    unique: [
+      fields: [:queue, :worker],
+      period: :infinity,
+      states: [:available, :scheduled, :executing, :retryable]
+    ]
+
+  import Tuist.Storage.Workers.ArtifactRetentionWorker
+  import Tuist.Storage.Workers.BucketArtifactWorker
 
   alias Tuist.Storage.CacheArtifactRetention
 
   @impl Oban.Worker
-  def perform(%Oban.Job{args: args}) do
-    continuation_token = Map.get(args, "continuation_token")
-
-    with {:ok, next_continuation_token} <-
-           CacheArtifactRetention.delete_expired(:xcode_module, continuation_token: continuation_token) do
-      maybe_enqueue_next_page(next_continuation_token)
-    end
-  end
-
-  defp maybe_enqueue_next_page(nil), do: :ok
-
-  defp maybe_enqueue_next_page(continuation_token) do
-    %{"continuation_token" => continuation_token}
-    |> __MODULE__.new()
-    |> Oban.insert()
-    |> case do
-      {:ok, _job} -> :ok
+  def perform(%Oban.Job{args: args} = job) do
+    with {:enabled, retention_days} <- effective_retention_days(args, :cache_artifacts),
+         {:ok, next_continuation_token} <-
+           CacheArtifactRetention.delete_expired(:xcode_module, options_from_args(args, retention_days)) do
+      continue(next_continuation_token, job, retention_days, Map.get(args, "self_hosted", false))
+    else
+      :disabled -> :ok
       error -> error
     end
   end

--- a/server/lib/tuist/storage/workers/expired_artifact_worker.ex
+++ b/server/lib/tuist/storage/workers/expired_artifact_worker.ex
@@ -26,17 +26,11 @@ defmodule Tuist.Storage.Workers.ExpiredArtifactWorker do
     args =
       %{"account_id" => account_id, "batch_size" => batch_size}
       |> Map.merge(cursor)
-      |> maybe_put_retention_days(retention_days)
-      |> maybe_put_self_hosted(self_hosted)
+      |> ArtifactRetentionWorker.put_retention_days(retention_days)
+      |> ArtifactRetentionWorker.put_self_hosted(self_hosted)
 
     ArtifactRetentionWorker.reschedule_with_args(job, args)
   end
 
   def continue({:error, _reason} = error, _job, _account_id, _batch_size, _retention_days, _self_hosted), do: error
-
-  defp maybe_put_retention_days(args, nil), do: args
-  defp maybe_put_retention_days(args, retention_days), do: Map.put(args, "retention_days", retention_days)
-
-  defp maybe_put_self_hosted(args, false), do: args
-  defp maybe_put_self_hosted(args, true), do: Map.put(args, "self_hosted", true)
 end

--- a/server/lib/tuist/storage/workers/expired_artifact_worker.ex
+++ b/server/lib/tuist/storage/workers/expired_artifact_worker.ex
@@ -3,29 +3,40 @@ defmodule Tuist.Storage.Workers.ExpiredArtifactWorker do
   Shared helpers for the per-account expired-artifact deletion workers.
 
   Each worker deletes one keyset-paginated batch and, when the batch was full,
-  self-enqueues the next page for the same account with the returned cursor. The
-  cursor lives in the job args (`after_inserted_at`/`after_id`) so a single
-  scheduled run walks the whole backlog instead of re-deleting the oldest batch
-  every day. Because the cursor is part of the uniqueness key, the follow-up job
-  isn't deduplicated against the currently-executing one.
+  updates and reschedules the same job with the returned cursor. The cursor lives
+  in the job args (`after_inserted_at`/`after_id`) so a single scheduled run walks
+  the whole backlog instead of re-deleting the oldest batch every day.
   """
 
-  def cursor_from_args(args) do
-    [after_inserted_at: Map.get(args, "after_inserted_at"), after_id: Map.get(args, "after_id")]
+  alias Tuist.Storage.Workers.ArtifactRetentionWorker
+
+  def cursor_from_args(args, retention_days) do
+    [
+      after_inserted_at: Map.get(args, "after_inserted_at"),
+      after_id: Map.get(args, "after_id"),
+      retention_days: retention_days
+    ]
   end
 
-  def continue({:ok, nil}, _worker, _account_id, _batch_size), do: :ok
+  def continue(result, job, account_id, batch_size, retention_days \\ nil, self_hosted \\ false)
 
-  def continue({:ok, cursor}, worker, account_id, batch_size) when is_map(cursor) do
-    %{"account_id" => account_id, "batch_size" => batch_size}
-    |> Map.merge(cursor)
-    |> worker.new()
-    |> Oban.insert()
-    |> case do
-      {:ok, _job} -> :ok
-      error -> error
-    end
+  def continue({:ok, nil}, _job, _account_id, _batch_size, _retention_days, _self_hosted), do: :ok
+
+  def continue({:ok, cursor}, job, account_id, batch_size, retention_days, self_hosted) when is_map(cursor) do
+    args =
+      %{"account_id" => account_id, "batch_size" => batch_size}
+      |> Map.merge(cursor)
+      |> maybe_put_retention_days(retention_days)
+      |> maybe_put_self_hosted(self_hosted)
+
+    ArtifactRetentionWorker.reschedule_with_args(job, args)
   end
 
-  def continue({:error, _reason} = error, _worker, _account_id, _batch_size), do: error
+  def continue({:error, _reason} = error, _job, _account_id, _batch_size, _retention_days, _self_hosted), do: error
+
+  defp maybe_put_retention_days(args, nil), do: args
+  defp maybe_put_retention_days(args, retention_days), do: Map.put(args, "retention_days", retention_days)
+
+  defp maybe_put_self_hosted(args, false), do: args
+  defp maybe_put_self_hosted(args, true), do: Map.put(args, "self_hosted", true)
 end

--- a/server/lib/tuist/storage/workers/schedule_expired_artifacts_worker.ex
+++ b/server/lib/tuist/storage/workers/schedule_expired_artifacts_worker.ex
@@ -32,12 +32,6 @@ defmodule Tuist.Storage.Workers.ScheduleExpiredArtifactsWorker do
 
   def deletion_workers, do: Enum.map(@deletion_workers, fn {_resource_type, worker} -> worker end)
 
-  def deletion_workers(retention_days) when is_map(retention_days) do
-    @deletion_workers
-    |> Enum.filter(fn {resource_type, _worker} -> Map.has_key?(retention_days, resource_type) end)
-    |> Enum.map(fn {_resource_type, worker} -> worker end)
-  end
-
   @impl Oban.Worker
   def perform(%Oban.Job{args: args} = job) do
     batch_size = Map.get(args, "batch_size")
@@ -46,7 +40,7 @@ defmodule Tuist.Storage.Workers.ScheduleExpiredArtifactsWorker do
     self_hosted = Map.get(args, "self_hosted", false)
     retention_days = effective_retention_days(Map.get(args, "retention_days"), self_hosted)
 
-    if self_hosted and deletion_workers(retention_days) == [] do
+    if configured_deletion_workers(retention_days) == [] do
       :ok
     else
       schedule_account_page(%{
@@ -83,26 +77,22 @@ defmodule Tuist.Storage.Workers.ScheduleExpiredArtifactsWorker do
         Enum.map(configured_deletion_workers(retention_days), fn {deletion_worker, days} ->
           %{"account_id" => account_id}
           |> maybe_put_batch_size(batch_size)
-          |> maybe_put_retention_days(days)
-          |> maybe_put_self_hosted(self_hosted)
+          |> ArtifactRetentionWorker.put_retention_days(job_retention_days(days, self_hosted))
+          |> ArtifactRetentionWorker.put_self_hosted(self_hosted)
           |> deletion_worker.new()
         end)
       end)
 
-    with :ok <- insert_deletion_jobs(deletion_jobs, self_hosted) do
+    with :ok <- insert_deletion_jobs(deletion_jobs) do
       schedule_next_account_page(next_account_ids, account_ids, page_size, batch_size, retention_days, self_hosted, job)
     end
   end
 
-  defp insert_deletion_jobs([], _self_hosted), do: :ok
-
-  defp insert_deletion_jobs(jobs, false) do
-    Oban.insert_all(jobs)
-    :ok
-  end
-
-  defp insert_deletion_jobs(jobs, true) do
-    # Oban's basic engine doesn't enforce worker uniqueness for bulk inserts.
+  # Oban's basic engine drops each worker's `unique:` configuration on bulk inserts,
+  # so `Oban.insert_all/1` would enqueue a second chain for an account whose deletion
+  # job from an earlier run is still walking its backlog. Uniqueness only holds when
+  # jobs are inserted one at a time.
+  defp insert_deletion_jobs(jobs) do
     Enum.reduce_while(jobs, :ok, fn job, :ok ->
       case Oban.insert(job) do
         {:ok, _job} -> {:cont, :ok}
@@ -117,23 +107,21 @@ defmodule Tuist.Storage.Workers.ScheduleExpiredArtifactsWorker do
     args =
       %{"after_id" => List.last(account_ids), "page_size" => page_size}
       |> maybe_put_batch_size(batch_size)
-      |> maybe_put_retention_config(retention_days)
-      |> maybe_put_self_hosted(self_hosted)
+      |> ArtifactRetentionWorker.put_retention_days(job_retention_days(retention_days, self_hosted))
+      |> ArtifactRetentionWorker.put_self_hosted(self_hosted)
 
     ArtifactRetentionWorker.reschedule_with_args(job, args)
   end
 
+  # Self-hosted retention workers read their window from the environment on every run,
+  # so the jobs this scheduler enqueues carry only the `self_hosted` flag. Tuist-hosted
+  # jobs carry a window only when one was passed in as a job argument; otherwise the
+  # account's plan decides.
+  defp job_retention_days(_retention_days, true), do: nil
+  defp job_retention_days(retention_days, false), do: retention_days
+
   defp maybe_put_batch_size(args, nil), do: args
   defp maybe_put_batch_size(args, batch_size), do: Map.put(args, "batch_size", batch_size)
-
-  defp maybe_put_retention_days(args, nil), do: args
-  defp maybe_put_retention_days(args, retention_days), do: Map.put(args, "retention_days", retention_days)
-
-  defp maybe_put_retention_config(args, nil), do: args
-  defp maybe_put_retention_config(args, retention_days), do: Map.put(args, "retention_days", retention_days)
-
-  defp maybe_put_self_hosted(args, false), do: args
-  defp maybe_put_self_hosted(args, true), do: Map.put(args, "self_hosted", true)
 
   defp configured_deletion_workers(nil) do
     Enum.map(@deletion_workers, fn {_resource_type, worker} -> {worker, nil} end)

--- a/server/lib/tuist/storage/workers/schedule_expired_artifacts_worker.ex
+++ b/server/lib/tuist/storage/workers/schedule_expired_artifacts_worker.ex
@@ -3,12 +3,18 @@ defmodule Tuist.Storage.Workers.ScheduleExpiredArtifactsWorker do
   use Oban.Worker,
     queue: :storage_retention,
     max_attempts: 3,
-    unique: [keys: [:after_id], states: [:available, :scheduled, :executing, :retryable]]
+    unique: [
+      fields: [:queue, :worker],
+      period: :infinity,
+      states: [:available, :scheduled, :executing, :retryable]
+    ]
 
   import Ecto.Query
 
   alias Tuist.Accounts.Account
+  alias Tuist.Environment
   alias Tuist.Repo
+  alias Tuist.Storage.Workers.ArtifactRetentionWorker
   alias Tuist.Storage.Workers.DeleteExpiredBuildArchivesWorker
   alias Tuist.Storage.Workers.DeleteExpiredPreviewArtifactsWorker
   alias Tuist.Storage.Workers.DeleteExpiredRunSessionsWorker
@@ -17,27 +23,51 @@ defmodule Tuist.Storage.Workers.ScheduleExpiredArtifactsWorker do
 
   @default_page_size 500
   @deletion_workers [
-    DeleteExpiredPreviewArtifactsWorker,
-    DeleteExpiredBuildArchivesWorker,
-    DeleteExpiredRunSessionsWorker,
-    DeleteExpiredTestAttachmentsWorker,
-    DeleteExpiredShardBundlesWorker
+    {"app_previews", DeleteExpiredPreviewArtifactsWorker},
+    {"build_archives", DeleteExpiredBuildArchivesWorker},
+    {"run_artifacts", DeleteExpiredRunSessionsWorker},
+    {"test_attachments", DeleteExpiredTestAttachmentsWorker},
+    {"shard_bundles", DeleteExpiredShardBundlesWorker}
   ]
 
-  def deletion_workers, do: @deletion_workers
+  def deletion_workers, do: Enum.map(@deletion_workers, fn {_resource_type, worker} -> worker end)
+
+  def deletion_workers(retention_days) when is_map(retention_days) do
+    @deletion_workers
+    |> Enum.filter(fn {resource_type, _worker} -> Map.has_key?(retention_days, resource_type) end)
+    |> Enum.map(fn {_resource_type, worker} -> worker end)
+  end
 
   @impl Oban.Worker
-  def perform(%Oban.Job{args: args}) do
+  def perform(%Oban.Job{args: args} = job) do
     batch_size = Map.get(args, "batch_size")
     page_size = Map.get(args, "page_size", @default_page_size)
     after_id = Map.get(args, "after_id", 0)
+    self_hosted = Map.get(args, "self_hosted", false)
+    retention_days = effective_retention_days(Map.get(args, "retention_days"), self_hosted)
 
-    schedule_account_page(%{batch_size: batch_size, page_size: page_size, after_id: after_id})
-
-    :ok
+    if self_hosted and deletion_workers(retention_days) == [] do
+      :ok
+    else
+      schedule_account_page(%{
+        batch_size: batch_size,
+        page_size: page_size,
+        after_id: after_id,
+        retention_days: retention_days,
+        self_hosted: self_hosted,
+        job: job
+      })
+    end
   end
 
-  defp schedule_account_page(%{batch_size: batch_size, page_size: page_size, after_id: after_id}) do
+  defp schedule_account_page(%{
+         batch_size: batch_size,
+         page_size: page_size,
+         after_id: after_id,
+         retention_days: retention_days,
+         self_hosted: self_hosted,
+         job: job
+       }) do
     account_ids =
       Account
       |> where([account], account.id > ^after_id)
@@ -48,27 +78,79 @@ defmodule Tuist.Storage.Workers.ScheduleExpiredArtifactsWorker do
 
     {account_ids, next_account_ids} = Enum.split(account_ids, page_size)
 
-    account_ids
-    |> Enum.flat_map(fn account_id ->
-      Enum.map(@deletion_workers, fn deletion_worker ->
-        %{"account_id" => account_id}
-        |> maybe_put_batch_size(batch_size)
-        |> deletion_worker.new()
+    deletion_jobs =
+      Enum.flat_map(account_ids, fn account_id ->
+        Enum.map(configured_deletion_workers(retention_days), fn {deletion_worker, days} ->
+          %{"account_id" => account_id}
+          |> maybe_put_batch_size(batch_size)
+          |> maybe_put_retention_days(days)
+          |> maybe_put_self_hosted(self_hosted)
+          |> deletion_worker.new()
+        end)
       end)
-    end)
-    |> insert_all()
 
-    if next_account_ids != [] do
-      %{"after_id" => List.last(account_ids), "page_size" => page_size}
-      |> maybe_put_batch_size(batch_size)
-      |> __MODULE__.new()
-      |> Oban.insert()
+    with :ok <- insert_deletion_jobs(deletion_jobs, self_hosted) do
+      schedule_next_account_page(next_account_ids, account_ids, page_size, batch_size, retention_days, self_hosted, job)
     end
   end
 
-  defp insert_all([]), do: :ok
-  defp insert_all(jobs), do: Oban.insert_all(jobs)
+  defp insert_deletion_jobs([], _self_hosted), do: :ok
+
+  defp insert_deletion_jobs(jobs, false) do
+    Oban.insert_all(jobs)
+    :ok
+  end
+
+  defp insert_deletion_jobs(jobs, true) do
+    # Oban's basic engine doesn't enforce worker uniqueness for bulk inserts.
+    Enum.reduce_while(jobs, :ok, fn job, :ok ->
+      case Oban.insert(job) do
+        {:ok, _job} -> {:cont, :ok}
+        error -> {:halt, error}
+      end
+    end)
+  end
+
+  defp schedule_next_account_page([], _account_ids, _page_size, _batch_size, _retention_days, _self_hosted, _job), do: :ok
+
+  defp schedule_next_account_page(_next_account_ids, account_ids, page_size, batch_size, retention_days, self_hosted, job) do
+    args =
+      %{"after_id" => List.last(account_ids), "page_size" => page_size}
+      |> maybe_put_batch_size(batch_size)
+      |> maybe_put_retention_config(retention_days)
+      |> maybe_put_self_hosted(self_hosted)
+
+    ArtifactRetentionWorker.reschedule_with_args(job, args)
+  end
 
   defp maybe_put_batch_size(args, nil), do: args
   defp maybe_put_batch_size(args, batch_size), do: Map.put(args, "batch_size", batch_size)
+
+  defp maybe_put_retention_days(args, nil), do: args
+  defp maybe_put_retention_days(args, retention_days), do: Map.put(args, "retention_days", retention_days)
+
+  defp maybe_put_retention_config(args, nil), do: args
+  defp maybe_put_retention_config(args, retention_days), do: Map.put(args, "retention_days", retention_days)
+
+  defp maybe_put_self_hosted(args, false), do: args
+  defp maybe_put_self_hosted(args, true), do: Map.put(args, "self_hosted", true)
+
+  defp configured_deletion_workers(nil) do
+    Enum.map(@deletion_workers, fn {_resource_type, worker} -> {worker, nil} end)
+  end
+
+  defp configured_deletion_workers(retention_days) do
+    Enum.flat_map(@deletion_workers, fn {resource_type, worker} ->
+      case Map.fetch(retention_days, resource_type) do
+        {:ok, days} -> [{worker, days}]
+        :error -> []
+      end
+    end)
+  end
+
+  defp effective_retention_days(_retention_days, true) do
+    Map.new(Environment.artifact_retention_days(), fn {resource_type, days} -> {Atom.to_string(resource_type), days} end)
+  end
+
+  defp effective_retention_days(retention_days, false), do: retention_days
 end

--- a/server/priv/docs/en/guides/server/data-retention.md
+++ b/server/priv/docs/en/guides/server/data-retention.md
@@ -28,35 +28,7 @@ The active account plan determines the Tuist Cloud retention window. If an accou
 
 ### Self-hosted instances {#self-hosted-artifact-files}
 
-Self-hosted artifact cleanup is opt-in and configured separately for each artifact type. Set an artifact type's environment variable to a positive integer number of days to enable its cleanup. Leaving a variable unset or blank disables cleanup only for that artifact type. Self-hosted windows are not capped at 30 days.
-
-The following example enables every supported artifact type with an independent retention window. Omit a variable or leave it blank to keep cleanup disabled for that artifact type.
-
-```bash
-TUIST_CACHE_ARTIFACT_RETENTION_DAYS=30
-TUIST_APP_PREVIEW_RETENTION_DAYS=30
-TUIST_BUILD_ARCHIVE_RETENTION_DAYS=60
-TUIST_RUN_ARTIFACT_RETENTION_DAYS=30
-TUIST_TEST_ATTACHMENT_RETENTION_DAYS=30
-TUIST_SHARD_BUNDLE_RETENTION_DAYS=14
-```
-
-The supported variables and their object-storage scope are:
-
-| Environment variable | Artifact files |
-| --- | --- |
-| `TUIST_CACHE_ARTIFACT_RETENTION_DAYS` | Xcode cache, legacy content-addressable storage cache, module cache, and Gradle cache files |
-| `TUIST_APP_PREVIEW_RETENTION_DAYS` | App preview builds and icons |
-| `TUIST_BUILD_ARCHIVE_RETENTION_DAYS` | Current and legacy build archives |
-| `TUIST_RUN_ARTIFACT_RETENTION_DAYS` | All objects stored under an expired run's artifact prefix, including result bundles, invocation records, and session archives |
-| `TUIST_TEST_ATTACHMENT_RETENTION_DAYS` | Test run attachments |
-| `TUIST_SHARD_BUNDLE_RETENTION_DAYS` | Test shard bundles |
-
-The cleanup jobs remove artifact blobs from object storage only. Associated PostgreSQL and ClickHouse metadata remains available for analytics and dashboards. The setting does not change database retention rules.
-
-Cache artifact cleanup scans the instance-managed cache buckets and skips accounts configured with account-specific custom cache storage. Matching cache objects whose prefix no longer resolves to a current account are cleaned with the configured window. Database-backed cleanup for app previews, current build archives, run artifacts, test attachments, and shard bundles uses the account's current storage configuration. Legacy build archive cleanup scans the instance-managed artifact bucket. Package registry mirror objects and runner log archives are outside this configurable policy. Runner log archives keep their separate 90-day retention window.
-
-See the <.localized_link href="/guides/server/self-host/server#artifact-retention">self-hosted artifact retention configuration</.localized_link> for deployment details. These variables do not override the Tuist Cloud plan-based windows.
+Self-hosted artifact cleanup is opt-in, configurable separately for each artifact type, and not capped at 30 days. See the <.localized_link href="/guides/server/self-host/server#artifact-retention">self-hosted artifact retention configuration</.localized_link> for the supported artifact types and deployment options.
 
 ## Dashboard and activity data {#dashboard-and-activity-data}
 

--- a/server/priv/docs/en/guides/server/data-retention.md
+++ b/server/priv/docs/en/guides/server/data-retention.md
@@ -7,11 +7,13 @@
 ---
 # Data retention {#data-retention}
 
-Tuist keeps downloadable artifacts for the windows below. Dashboard history and analytics can remain visible after artifact downloads expire. No artifact file is kept for more than 30 days.
+Tuist Cloud and self-hosted Tuist instances apply different artifact-retention policies. Tuist Cloud uses plan-based windows capped at 30 days. Artifact cleanup is disabled by default on self-hosted instances, where operators can opt in and configure a separate window for each supported artifact type.
 
 ## Artifact files {#artifact-files}
 
-These windows define how long artifact files remain available in Tuist.
+### Tuist Cloud {#tuist-cloud-artifact-files}
+
+These windows define how long artifact files remain available in Tuist Cloud.
 
 | Artifact | Air and Open Source | Pro | Enterprise |
 | --- | --- | --- | --- |
@@ -22,11 +24,39 @@ These windows define how long artifact files remain available in Tuist.
 | Test run attachments | 30 days | 30 days | 30 days |
 | Shard bundles | 7 days | 14 days | 30 days |
 
-The active account plan determines the retention window. If an account does not have an active subscription, Tuist uses the Air retention window. Some artifact types use shorter windows because they are expected to be regenerated.
+The active account plan determines the Tuist Cloud retention window. If an account does not have an active subscription, Tuist uses the Air retention window. Some artifact types use shorter windows because they are expected to be regenerated.
+
+### Self-hosted instances {#self-hosted-artifact-files}
+
+Self-hosted artifact cleanup is opt-in and configured separately for each artifact type. Set an artifact type's environment variable to a positive integer number of days to enable its cleanup. Leaving a variable unset or blank disables cleanup only for that artifact type. Self-hosted windows are not capped at 30 days.
+
+For example, the following configuration deletes cache artifacts after 30 days and build archives after 60 days. It does not enable cleanup for the other artifact types.
+
+```bash
+TUIST_CACHE_ARTIFACT_RETENTION_DAYS=30
+TUIST_BUILD_ARCHIVE_RETENTION_DAYS=60
+```
+
+The supported variables and their object-storage scope are:
+
+| Environment variable | Artifact files |
+| --- | --- |
+| `TUIST_CACHE_ARTIFACT_RETENTION_DAYS` | Xcode cache, legacy content-addressable storage cache, module cache, and Gradle cache files |
+| `TUIST_APP_PREVIEW_RETENTION_DAYS` | App preview builds and icons |
+| `TUIST_BUILD_ARCHIVE_RETENTION_DAYS` | Current and legacy build archives |
+| `TUIST_RUN_ARTIFACT_RETENTION_DAYS` | All objects stored under an expired run's artifact prefix, including result bundles, invocation records, and session archives |
+| `TUIST_TEST_ATTACHMENT_RETENTION_DAYS` | Test run attachments |
+| `TUIST_SHARD_BUNDLE_RETENTION_DAYS` | Test shard bundles |
+
+The cleanup jobs remove artifact blobs from object storage only. Associated PostgreSQL and ClickHouse metadata remains available for analytics and dashboards. The setting does not change database retention rules.
+
+Cache artifact cleanup scans the instance-managed cache buckets and skips accounts configured with account-specific custom cache storage. Matching cache objects whose prefix no longer resolves to a current account are cleaned with the configured window. Database-backed cleanup for app previews, current build archives, run artifacts, test attachments, and shard bundles uses the account's current storage configuration. Legacy build archive cleanup scans the instance-managed artifact bucket. Package registry mirror objects and runner log archives are outside this configurable policy. Runner log archives keep their separate 90-day retention window.
+
+See the <.localized_link href="/guides/server/self-host/server#artifact-retention">self-hosted artifact retention configuration</.localized_link> for deployment details. These variables do not override the Tuist Cloud plan-based windows.
 
 ## Dashboard and activity data {#dashboard-and-activity-data}
 
-These windows define how long selected dashboard and activity data remains available in Tuist.
+These windows define how long selected dashboard and activity data remains available in Tuist. They are independent of the configurable self-hosted artifact cleanup above.
 
 | Data | Retention |
 | --- | --- |

--- a/server/priv/docs/en/guides/server/data-retention.md
+++ b/server/priv/docs/en/guides/server/data-retention.md
@@ -30,11 +30,15 @@ The active account plan determines the Tuist Cloud retention window. If an accou
 
 Self-hosted artifact cleanup is opt-in and configured separately for each artifact type. Set an artifact type's environment variable to a positive integer number of days to enable its cleanup. Leaving a variable unset or blank disables cleanup only for that artifact type. Self-hosted windows are not capped at 30 days.
 
-For example, the following configuration deletes cache artifacts after 30 days and build archives after 60 days. It does not enable cleanup for the other artifact types.
+The following example enables every supported artifact type with an independent retention window. Omit a variable or leave it blank to keep cleanup disabled for that artifact type.
 
 ```bash
 TUIST_CACHE_ARTIFACT_RETENTION_DAYS=30
+TUIST_APP_PREVIEW_RETENTION_DAYS=30
 TUIST_BUILD_ARCHIVE_RETENTION_DAYS=60
+TUIST_RUN_ARTIFACT_RETENTION_DAYS=30
+TUIST_TEST_ATTACHMENT_RETENTION_DAYS=30
+TUIST_SHARD_BUNDLE_RETENTION_DAYS=14
 ```
 
 The supported variables and their object-storage scope are:

--- a/server/priv/docs/en/guides/server/data-retention.md
+++ b/server/priv/docs/en/guides/server/data-retention.md
@@ -7,13 +7,13 @@
 ---
 # Data retention {#data-retention}
 
-Tuist Cloud and self-hosted Tuist instances apply different artifact-retention policies. Tuist Cloud uses plan-based windows capped at 30 days. Artifact cleanup is disabled by default on self-hosted instances, where operators can opt in and configure a separate window for each supported artifact type.
+The hosted Tuist server and self-hosted Tuist instances apply different artifact-retention policies. The hosted server uses plan-based windows capped at 30 days. Artifact cleanup is disabled by default on self-hosted instances, where operators can opt in and configure a separate window for each supported artifact type.
 
 ## Artifact files {#artifact-files}
 
-### Tuist Cloud {#tuist-cloud-artifact-files}
+### Hosted Tuist server {#hosted-artifact-files}
 
-These windows define how long artifact files remain available in Tuist Cloud.
+These windows define how long artifact files remain available on the hosted Tuist server.
 
 | Artifact | Air and Open Source | Pro | Enterprise |
 | --- | --- | --- | --- |
@@ -24,7 +24,7 @@ These windows define how long artifact files remain available in Tuist Cloud.
 | Test run attachments | 30 days | 30 days | 30 days |
 | Shard bundles | 7 days | 14 days | 30 days |
 
-The active account plan determines the Tuist Cloud retention window. If an account does not have an active subscription, Tuist uses the Air retention window. Some artifact types use shorter windows because they are expected to be regenerated.
+The active account plan determines the hosted retention window. If an account does not have an active subscription, Tuist uses the Air retention window. Some artifact types use shorter windows because they are expected to be regenerated.
 
 ### Self-hosted instances {#self-hosted-artifact-files}
 

--- a/server/priv/docs/en/guides/server/self-host/server.md
+++ b/server/priv/docs/en/guides/server/self-host/server.md
@@ -291,6 +291,45 @@ For Azure Blob Storage, set `TUIST_OBJECT_STORAGE_PROVIDER=azure_blob` and confi
 
 When using the Helm chart, set `server.storage.provider=azure_blob` and fill `server.azureBlob.*`. The chart's top-level `objectStorage` settings remain S3-compatible because the optional cache and registry-mirror workloads still expect S3-compatible storage. If those workloads are disabled and the server uses Azure Blob, set `objectStorage.mode=external` and leave the external object-storage endpoint and credentials empty to avoid deploying the embedded MinIO service.
 
+#### Artifact retention {#artifact-retention}
+
+Artifact cleanup is disabled by default on self-hosted instances. Each supported artifact type has its own environment variable. Set a variable to a positive integer number of days to enable cleanup for that artifact type. Leaving a variable unset or blank disables cleanup only for its artifact type.
+
+```bash
+TUIST_CACHE_ARTIFACT_RETENTION_DAYS=30
+TUIST_BUILD_ARCHIVE_RETENTION_DAYS=60
+```
+
+With the Helm chart, configure the same windows as a map:
+
+```yaml
+server:
+  artifactRetentionDays:
+    cacheArtifacts: 30
+    buildArchives: 60
+```
+
+Only the configured artifact types are enabled. In this example, cache artifacts are deleted after 30 days and build archives after 60 days. The other artifact types are not cleaned. Self-hosted retention windows have no 30-day maximum. Configured values that are not positive integers cause the server to fail at startup.
+
+Restart the server after changing a retention variable. Every queued self-hosted cleanup batch checks the current configuration before deleting files, so unsetting or blanking a variable, or increasing its window, also protects files from pending jobs after the restart.
+
+| Environment variable | Artifact files removed from object storage |
+| --- | --- |
+| `TUIST_CACHE_ARTIFACT_RETENTION_DAYS` | Xcode cache, legacy content-addressable storage cache, module cache, and Gradle cache files |
+| `TUIST_APP_PREVIEW_RETENTION_DAYS` | App preview builds and icons |
+| `TUIST_BUILD_ARCHIVE_RETENTION_DAYS` | Current and legacy build archives |
+| `TUIST_RUN_ARTIFACT_RETENTION_DAYS` | All objects stored under an expired run's artifact prefix, including result bundles, invocation records, and session archives |
+| `TUIST_TEST_ATTACHMENT_RETENTION_DAYS` | Test run attachments |
+| `TUIST_SHARD_BUNDLE_RETENTION_DAYS` | Test shard bundles |
+
+The scheduled cleanup removes artifact blobs only. It preserves the corresponding PostgreSQL and ClickHouse rows, so build, test, run, preview, and shard metadata can remain visible in dashboards after their downloads expire. This configuration does not change ClickHouse table retention rules.
+
+Cache artifact cleanup scans the instance-managed cache buckets. It skips accounts configured with account-specific custom cache storage and does not scan those custom cache buckets. Matching cache objects whose prefix no longer resolves to a current account are cleaned with the configured window. Database-backed cleanup for app previews, current build archives, run artifacts, test attachments, and shard bundles follows the account's current storage configuration. Legacy build archive cleanup scans the instance-managed artifact bucket.
+
+Package registry mirror objects are not customer artifacts and are excluded. Runner log archives are also excluded because they have a separate 90-day cleanup policy. An unset or blank retention variable leaves only its corresponding artifact cleanup disabled.
+
+These variables apply only to self-hosted instances. Tuist Cloud continues to use the plan-based windows documented in the <.localized_link href="/guides/server/data-retention">data retention guide</.localized_link>.
+
 ### Email configuration {#email-configuration}
 
 Tuist requires email functionality for user authentication and transactional notifications (e.g., password resets, account notifications). Currently, **only Mailgun is supported** as the email provider.

--- a/server/priv/docs/en/guides/server/self-host/server.md
+++ b/server/priv/docs/en/guides/server/self-host/server.md
@@ -332,12 +332,6 @@ Restart the server after changing a retention variable. Every queued self-hosted
 
 The scheduled cleanup removes artifact blobs only. It preserves the corresponding PostgreSQL and ClickHouse rows, so build, test, run, preview, and shard metadata can remain visible in dashboards after their downloads expire. This configuration does not change ClickHouse table retention rules.
 
-Cache artifact cleanup scans the instance-managed cache buckets. It skips accounts configured with account-specific custom cache storage and does not scan those custom cache buckets. Matching cache objects whose prefix no longer resolves to a current account are cleaned with the configured window. Database-backed cleanup for app previews, current build archives, run artifacts, test attachments, and shard bundles follows the account's current storage configuration. Legacy build archive cleanup scans the instance-managed artifact bucket.
-
-Package registry mirror objects are not customer artifacts and are excluded. Runner log archives are also excluded because they have a separate 90-day cleanup policy. An unset or blank retention variable leaves only its corresponding artifact cleanup disabled.
-
-These variables apply only to self-hosted instances. Tuist Cloud continues to use the plan-based windows documented in the <.localized_link href="/guides/server/data-retention">data retention guide</.localized_link>.
-
 ### Email configuration {#email-configuration}
 
 Tuist requires email functionality for user authentication and transactional notifications (e.g., password resets, account notifications). Currently, **only Mailgun is supported** as the email provider.

--- a/server/priv/docs/en/guides/server/self-host/server.md
+++ b/server/priv/docs/en/guides/server/self-host/server.md
@@ -297,7 +297,11 @@ Artifact cleanup is disabled by default on self-hosted instances. Each supported
 
 ```bash
 TUIST_CACHE_ARTIFACT_RETENTION_DAYS=30
+TUIST_APP_PREVIEW_RETENTION_DAYS=30
 TUIST_BUILD_ARCHIVE_RETENTION_DAYS=60
+TUIST_RUN_ARTIFACT_RETENTION_DAYS=30
+TUIST_TEST_ATTACHMENT_RETENTION_DAYS=30
+TUIST_SHARD_BUNDLE_RETENTION_DAYS=14
 ```
 
 With the Helm chart, configure the same windows as a map:
@@ -306,10 +310,14 @@ With the Helm chart, configure the same windows as a map:
 server:
   artifactRetentionDays:
     cacheArtifacts: 30
+    appPreviews: 30
     buildArchives: 60
+    runArtifacts: 30
+    testAttachments: 30
+    shardBundles: 14
 ```
 
-Only the configured artifact types are enabled. In this example, cache artifacts are deleted after 30 days and build archives after 60 days. The other artifact types are not cleaned. Self-hosted retention windows have no 30-day maximum. Configured values that are not positive integers cause the server to fail at startup.
+All six keys are optional. This example enables every supported artifact type with an independent retention window. Omit a key or leave its value blank to keep cleanup disabled for that artifact type. Self-hosted retention windows have no 30-day maximum. Configured values that are not positive integers cause the server to fail at startup.
 
 Restart the server after changing a retention variable. Every queued self-hosted cleanup batch checks the current configuration before deleting files, so unsetting or blanking a variable, or increasing its window, also protects files from pending jobs after the restart.
 

--- a/server/priv/marketing/changelog/2026.07.10-self-hosted-artifact-retention.md
+++ b/server/priv/marketing/changelog/2026.07.10-self-hosted-artifact-retention.md
@@ -1,0 +1,18 @@
+---
+title: Configurable self-hosted artifact retention
+description: "Automatically clean up self-hosted artifacts with a separate retention window for each artifact family."
+category: "Product"
+---
+
+Self-hosted Tuist instances can now automatically clean up artifact files from object storage. Operators can set independent retention windows for cache artifacts, app previews, build archives, run artifacts, test attachments, and shard bundles.
+
+Configure the windows through the Helm chart:
+
+```yaml
+server:
+  artifactRetentionDays:
+    cacheArtifacts: 30
+    buildArchives: 60
+```
+
+Each artifact family also has its own environment variable for deployments that do not use Helm. Leaving a family unset or blank keeps its cleanup disabled. Cleanup removes artifact files only and preserves the associated PostgreSQL and ClickHouse metadata used by dashboards and analytics.

--- a/server/priv/marketing/changelog/2026.07.10-self-hosted-artifact-retention.md
+++ b/server/priv/marketing/changelog/2026.07.10-self-hosted-artifact-retention.md
@@ -12,7 +12,11 @@ Configure the windows through the Helm chart:
 server:
   artifactRetentionDays:
     cacheArtifacts: 30
+    appPreviews: 30
     buildArchives: 60
+    runArtifacts: 30
+    testAttachments: 30
+    shardBundles: 14
 ```
 
 Each artifact family also has its own environment variable for deployments that do not use Helm. Leaving a family unset or blank keeps its cleanup disabled. Cleanup removes artifact files only and preserves the associated PostgreSQL and ClickHouse metadata used by dashboards and analytics.

--- a/server/priv/static/server/self-host/.env.example
+++ b/server/priv/static/server/self-host/.env.example
@@ -14,6 +14,16 @@ GOOGLE_CLIENT_SECRET=
 TUIST_OKTA_1_CLIENT_ID=
 TUIST_OKTA_1_CLIENT_SECRET=
 
+# Optional artifact cleanup. Each variable independently enables cleanup for
+# one artifact family and must contain a positive integer number of days. An
+# unset or blank variable disables cleanup only for its artifact family.
+# TUIST_CACHE_ARTIFACT_RETENTION_DAYS=30
+# TUIST_APP_PREVIEW_RETENTION_DAYS=30
+# TUIST_BUILD_ARCHIVE_RETENTION_DAYS=60
+# TUIST_RUN_ARTIFACT_RETENTION_DAYS=30
+# TUIST_TEST_ATTACHMENT_RETENTION_DAYS=30
+# TUIST_SHARD_BUNDLE_RETENTION_DAYS=30
+
 # Optional image overrides.
 TUIST_IMAGE=ghcr.io/tuist/tuist:latest
 KURA_IMAGE=ghcr.io/tuist/kura:latest

--- a/server/test/tuist/environment_test.exs
+++ b/server/test/tuist/environment_test.exs
@@ -280,6 +280,51 @@ defmodule Tuist.EnvironmentTest do
     end
   end
 
+  describe "artifact_retention_days/1" do
+    test "returns an empty map when artifact retention is not configured" do
+      assert Environment.artifact_retention_days(%{}) == %{}
+
+      assert Environment.artifact_retention_days(%{
+               "TUIST_CACHE_ARTIFACT_RETENTION_DAYS" => "",
+               "TUIST_BUILD_ARCHIVE_RETENTION_DAYS" => "  \n\t"
+             }) == %{}
+    end
+
+    test "parses retention days for every supported artifact resource type" do
+      environment = %{
+        "TUIST_CACHE_ARTIFACT_RETENTION_DAYS" => "14",
+        "TUIST_APP_PREVIEW_RETENTION_DAYS" => "30",
+        "TUIST_BUILD_ARCHIVE_RETENTION_DAYS" => "45",
+        "TUIST_RUN_ARTIFACT_RETENTION_DAYS" => "60",
+        "TUIST_TEST_ATTACHMENT_RETENTION_DAYS" => "75",
+        "TUIST_SHARD_BUNDLE_RETENTION_DAYS" => "90"
+      }
+
+      assert Environment.artifact_retention_days(environment) == %{
+               cache_artifacts: 14,
+               app_previews: 30,
+               build_archives: 45,
+               run_artifacts: 60,
+               test_attachments: 75,
+               shard_bundles: 90
+             }
+    end
+
+    test "accepts a partial artifact retention configuration" do
+      assert Environment.artifact_retention_days(%{"TUIST_BUILD_ARCHIVE_RETENTION_DAYS" => " 45 "}) == %{
+               build_archives: 45
+             }
+    end
+
+    test "rejects non-positive and non-integer retention days" do
+      for value <- ["0", "-1", "1.5", "30 days", 30] do
+        assert_raise RuntimeError, ~r/TUIST_CACHE_ARTIFACT_RETENTION_DAYS must be a positive integer/, fn ->
+          Environment.artifact_retention_days(%{"TUIST_CACHE_ARTIFACT_RETENTION_DAYS" => value})
+        end
+      end
+    end
+  end
+
   describe "quote_postgres_identifier/1" do
     test "quotes identifiers used in SQL and startup parameters" do
       assert Environment.quote_postgres_identifier("tuist") == ~s("tuist")

--- a/server/test/tuist/oban/runtime_config_test.exs
+++ b/server/test/tuist/oban/runtime_config_test.exs
@@ -23,6 +23,13 @@ defmodule Tuist.Oban.RuntimeConfigTest do
   alias Tuist.Storage.Workers.ScheduleExpiredArtifactsWorker
   alias Tuist.Tests.Workers.ExpireStaleTestRunsWorker
 
+  @cache_retention_workers [
+    DeleteExpiredCasCacheArtifactsWorker,
+    DeleteExpiredGradleCacheArtifactsWorker,
+    DeleteExpiredXcodeCacheArtifactsWorker,
+    DeleteExpiredXcodeModuleCacheArtifactsWorker
+  ]
+
   describe "peer_eligible?/1" do
     test ":web is leader-eligible" do
       assert RuntimeConfig.peer_eligible?(:web)
@@ -144,7 +151,7 @@ defmodule Tuist.Oban.RuntimeConfigTest do
       end
     end
 
-    test ":web + prod-like env, self-hosted: database-backed families share one scheduler with their days" do
+    test ":web + prod-like env, self-hosted: database-backed families share one scheduler" do
       artifact_retention_days = %{
         app_previews: 30,
         build_archives: 45,
@@ -155,39 +162,51 @@ defmodule Tuist.Oban.RuntimeConfigTest do
 
       crontab = RuntimeConfig.crontab(:web, :prod, false, artifact_retention_days)
 
-      assert {"30 2 * * *", ScheduleExpiredArtifactsWorker,
-              args: %{
-                "retention_days" => %{
-                  "app_previews" => 30,
-                  "build_archives" => 45,
-                  "run_artifacts" => 60,
-                  "test_attachments" => 75,
-                  "shard_bundles" => 90
-                },
-                "self_hosted" => true
-              }} in crontab
+      assert {"30 2 * * *", ScheduleExpiredArtifactsWorker, args: %{"self_hosted" => true}} in crontab
 
       assert Enum.count(crontab, &(cron_worker(&1) == ScheduleExpiredArtifactsWorker)) == 1
 
-      assert {"0 4 * * *", DeleteExpiredLegacyBuildArtifactsWorker,
-              args: %{"retention_days" => 45, "self_hosted" => true}} in crontab
+      assert {"0 4 * * *", DeleteExpiredLegacyBuildArtifactsWorker, args: %{"self_hosted" => true}} in crontab
     end
 
-    test ":web + prod-like env, self-hosted: cache retention configures all cache workers with the same days" do
+    test ":web + prod-like env, self-hosted: cron args carry no retention window" do
+      artifact_retention_days = %{app_previews: 30, build_archives: 45, cache_artifacts: 21}
+
+      for {_schedule, _worker, opts} <- RuntimeConfig.crontab(:web, :prod, false, artifact_retention_days) do
+        refute Map.has_key?(opts[:args], "retention_days"),
+               "self-hosted retention workers read their window from the environment on every " <>
+                 "run, so a window in the job args is dead payload that shadows the real source"
+      end
+    end
+
+    test ":web + prod-like env, self-hosted: cache retention configures all cache workers" do
       crontab = RuntimeConfig.crontab(:web, :prod, false, %{cache_artifacts: 21})
 
-      assert {"0 3 * * *", DeleteExpiredXcodeCacheArtifactsWorker, args: %{"retention_days" => 21, "self_hosted" => true}} in crontab
-
-      assert {"15 3 * * *", DeleteExpiredXcodeModuleCacheArtifactsWorker,
-              args: %{"retention_days" => 21, "self_hosted" => true}} in crontab
-
-      assert {"30 3 * * *", DeleteExpiredGradleCacheArtifactsWorker,
-              args: %{"retention_days" => 21, "self_hosted" => true}} in crontab
-
-      assert {"45 3 * * *", DeleteExpiredCasCacheArtifactsWorker, args: %{"retention_days" => 21, "self_hosted" => true}} in crontab
+      assert {"0 3 * * *", DeleteExpiredXcodeCacheArtifactsWorker, args: %{"self_hosted" => true}} in crontab
+      assert {"15 3 * * *", DeleteExpiredXcodeModuleCacheArtifactsWorker, args: %{"self_hosted" => true}} in crontab
+      assert {"30 3 * * *", DeleteExpiredGradleCacheArtifactsWorker, args: %{"self_hosted" => true}} in crontab
+      assert {"45 3 * * *", DeleteExpiredCasCacheArtifactsWorker, args: %{"self_hosted" => true}} in crontab
 
       refute Enum.any?(crontab, &(cron_worker(&1) == ScheduleExpiredArtifactsWorker))
       refute Enum.any?(crontab, &(cron_worker(&1) == DeleteExpiredLegacyBuildArtifactsWorker))
+    end
+
+    test ":web + prod-like env, Tuist-hosted and self-hosted share the cache retention schedules" do
+      hosted_cache_crons =
+        :web
+        |> RuntimeConfig.crontab(:prod, true, %{})
+        |> Enum.filter(&(cron_worker(&1) in @cache_retention_workers))
+        |> Enum.map(fn {schedule, worker} -> {schedule, worker} end)
+        |> Enum.sort()
+
+      self_hosted_cache_crons =
+        :web
+        |> RuntimeConfig.crontab(:prod, false, %{cache_artifacts: 21})
+        |> Enum.filter(&(cron_worker(&1) in @cache_retention_workers))
+        |> Enum.map(fn {schedule, worker, _opts} -> {schedule, worker} end)
+        |> Enum.sort()
+
+      assert hosted_cache_crons == self_hosted_cache_crons
     end
 
     test ":web + prod-like env, Tuist-hosted: hosted-only entries plus shared crons" do

--- a/server/test/tuist/oban/runtime_config_test.exs
+++ b/server/test/tuist/oban/runtime_config_test.exs
@@ -38,13 +38,14 @@ defmodule Tuist.Oban.RuntimeConfigTest do
     end
   end
 
-  describe "crontab/3" do
+  describe "crontab/4" do
     test "empty for every non-web mode in every prod-like env, regardless of hosted state" do
       for mode <- Environment.modes(),
           mode != :web,
           env <- [:prod, :stag, :can],
-          tuist_hosted? <- [true, false] do
-        assert RuntimeConfig.crontab(mode, env, tuist_hosted?) == [],
+          tuist_hosted? <- [true, false],
+          artifact_retention_days <- [%{}, %{cache_artifacts: 30, app_previews: 30}] do
+        assert RuntimeConfig.crontab(mode, env, tuist_hosted?, artifact_retention_days) == [],
                "expected empty crontab for mode=#{inspect(mode)} env=#{inspect(env)} hosted=#{inspect(tuist_hosted?)}"
       end
     end
@@ -52,34 +53,37 @@ defmodule Tuist.Oban.RuntimeConfigTest do
     test "empty for :web in non-prod-like envs, except previews" do
       for env <- [:dev, :test, :preview], tuist_hosted? <- [true, false] do
         if env == :preview do
-          assert [{"* * * * *", SyncWorker}] = RuntimeConfig.crontab(:web, env, tuist_hosted?)
+          assert [{"* * * * *", SyncWorker}] =
+                   RuntimeConfig.crontab(:web, env, tuist_hosted?, %{cache_artifacts: 30})
         else
-          assert RuntimeConfig.crontab(:web, env, tuist_hosted?) == []
+          assert RuntimeConfig.crontab(:web, env, tuist_hosted?, %{cache_artifacts: 30}) == []
         end
       end
     end
 
     test ":web + preview only runs the Swift registry sync cron" do
       for tuist_hosted? <- [true, false] do
-        assert RuntimeConfig.crontab(:web, :preview, tuist_hosted?) == [{"* * * * *", SyncWorker}]
+        assert RuntimeConfig.crontab(:web, :preview, tuist_hosted?, %{cache_artifacts: 30}) == [
+                 {"* * * * *", SyncWorker}
+               ]
       end
 
       for mode <- Environment.modes(), mode != :web do
-        assert RuntimeConfig.crontab(mode, :preview, true) == []
+        assert RuntimeConfig.crontab(mode, :preview, true, %{cache_artifacts: 30}) == []
       end
     end
 
     test ":web + non-preview non-prod-like envs stay empty" do
       for env <- [:dev, :test], tuist_hosted? <- [true, false] do
-        assert RuntimeConfig.crontab(:web, env, tuist_hosted?) == []
+        assert RuntimeConfig.crontab(:web, env, tuist_hosted?, %{cache_artifacts: 30}) == []
       end
     end
 
-    test ":web + prod-like env, self-hosted: shared crons only, no hosted-only entries" do
+    test ":web + prod-like env, self-hosted without retention configuration: shared crons only" do
       for env <- [:prod, :stag, :can] do
         workers =
           :web
-          |> RuntimeConfig.crontab(env, false)
+          |> RuntimeConfig.crontab(env, false, %{})
           |> Enum.map(fn {_cron, worker} -> worker end)
 
         assert AutomationScheduler in workers
@@ -104,11 +108,93 @@ defmodule Tuist.Oban.RuntimeConfigTest do
       end
     end
 
+    test ":web + prod-like env, self-hosted: each configured family enables only its retention workers" do
+      cases = [
+        {%{cache_artifacts: 14},
+         [
+           DeleteExpiredCasCacheArtifactsWorker,
+           DeleteExpiredGradleCacheArtifactsWorker,
+           DeleteExpiredXcodeCacheArtifactsWorker,
+           DeleteExpiredXcodeModuleCacheArtifactsWorker
+         ]},
+        {%{app_previews: 30}, [ScheduleExpiredArtifactsWorker]},
+        {%{build_archives: 45}, [ScheduleExpiredArtifactsWorker, DeleteExpiredLegacyBuildArtifactsWorker]},
+        {%{run_artifacts: 60}, [ScheduleExpiredArtifactsWorker]},
+        {%{test_attachments: 75}, [ScheduleExpiredArtifactsWorker]},
+        {%{shard_bundles: 90}, [ScheduleExpiredArtifactsWorker]}
+      ]
+
+      retention_workers = [
+        ScheduleExpiredArtifactsWorker,
+        DeleteExpiredCasCacheArtifactsWorker,
+        DeleteExpiredGradleCacheArtifactsWorker,
+        DeleteExpiredLegacyBuildArtifactsWorker,
+        DeleteExpiredXcodeCacheArtifactsWorker,
+        DeleteExpiredXcodeModuleCacheArtifactsWorker
+      ]
+
+      for {artifact_retention_days, expected_workers} <- cases do
+        configured_workers =
+          :web
+          |> RuntimeConfig.crontab(:prod, false, artifact_retention_days)
+          |> Enum.map(&cron_worker/1)
+          |> Enum.filter(&(&1 in retention_workers))
+
+        assert Enum.sort(configured_workers) == Enum.sort(expected_workers)
+      end
+    end
+
+    test ":web + prod-like env, self-hosted: database-backed families share one scheduler with their days" do
+      artifact_retention_days = %{
+        app_previews: 30,
+        build_archives: 45,
+        run_artifacts: 60,
+        test_attachments: 75,
+        shard_bundles: 90
+      }
+
+      crontab = RuntimeConfig.crontab(:web, :prod, false, artifact_retention_days)
+
+      assert {"30 2 * * *", ScheduleExpiredArtifactsWorker,
+              args: %{
+                "retention_days" => %{
+                  "app_previews" => 30,
+                  "build_archives" => 45,
+                  "run_artifacts" => 60,
+                  "test_attachments" => 75,
+                  "shard_bundles" => 90
+                },
+                "self_hosted" => true
+              }} in crontab
+
+      assert Enum.count(crontab, &(cron_worker(&1) == ScheduleExpiredArtifactsWorker)) == 1
+
+      assert {"0 4 * * *", DeleteExpiredLegacyBuildArtifactsWorker,
+              args: %{"retention_days" => 45, "self_hosted" => true}} in crontab
+    end
+
+    test ":web + prod-like env, self-hosted: cache retention configures all cache workers with the same days" do
+      crontab = RuntimeConfig.crontab(:web, :prod, false, %{cache_artifacts: 21})
+
+      assert {"0 3 * * *", DeleteExpiredXcodeCacheArtifactsWorker, args: %{"retention_days" => 21, "self_hosted" => true}} in crontab
+
+      assert {"15 3 * * *", DeleteExpiredXcodeModuleCacheArtifactsWorker,
+              args: %{"retention_days" => 21, "self_hosted" => true}} in crontab
+
+      assert {"30 3 * * *", DeleteExpiredGradleCacheArtifactsWorker,
+              args: %{"retention_days" => 21, "self_hosted" => true}} in crontab
+
+      assert {"45 3 * * *", DeleteExpiredCasCacheArtifactsWorker, args: %{"retention_days" => 21, "self_hosted" => true}} in crontab
+
+      refute Enum.any?(crontab, &(cron_worker(&1) == ScheduleExpiredArtifactsWorker))
+      refute Enum.any?(crontab, &(cron_worker(&1) == DeleteExpiredLegacyBuildArtifactsWorker))
+    end
+
     test ":web + prod-like env, Tuist-hosted: hosted-only entries plus shared crons" do
-      for env <- [:prod, :stag, :can] do
+      for env <- [:prod, :stag, :can], artifact_retention_days <- [%{}, %{cache_artifacts: 21}] do
         workers =
           :web
-          |> RuntimeConfig.crontab(env, true)
+          |> RuntimeConfig.crontab(env, true, artifact_retention_days)
           |> Enum.map(fn {_cron, worker} -> worker end)
 
         assert AutomationScheduler in workers
@@ -133,4 +219,7 @@ defmodule Tuist.Oban.RuntimeConfigTest do
       end
     end
   end
+
+  defp cron_worker({_schedule, worker}), do: worker
+  defp cron_worker({_schedule, worker, _opts}), do: worker
 end

--- a/server/test/tuist/storage/cache_artifact_retention_test.exs
+++ b/server/test/tuist/storage/cache_artifact_retention_test.exs
@@ -10,7 +10,7 @@ defmodule Tuist.Storage.CacheArtifactRetentionTest do
   alias Tuist.Storage.CacheArtifactRetention
 
   describe "delete_expired/2" do
-    test "deletes expired objects for the requested cache artifact type" do
+    test "deletes objects using an explicit retention window" do
       expired_xcode_key = "tuist/app/xcode/AB/CD/ABCD"
       recent_xcode_key = "tuist/app/xcode/EF/GH/EFGH"
       expired_gradle_key = "tuist/app/gradle/AB/CD/ABCD"
@@ -23,9 +23,9 @@ defmodule Tuist.Storage.CacheArtifactRetentionTest do
          %{
            body: %{
              contents: [
-               %{key: expired_xcode_key, last_modified: DateTime.add(DateTime.utc_now(), -15, :day)},
-               %{key: recent_xcode_key, last_modified: DateTime.add(DateTime.utc_now(), -13, :day)},
-               %{key: expired_gradle_key, last_modified: DateTime.add(DateTime.utc_now(), -15, :day)}
+               %{key: expired_xcode_key, last_modified: DateTime.add(DateTime.utc_now(), -61, :day)},
+               %{key: recent_xcode_key, last_modified: DateTime.add(DateTime.utc_now(), -59, :day)},
+               %{key: expired_gradle_key, last_modified: DateTime.add(DateTime.utc_now(), -61, :day)}
              ],
              is_truncated: true,
              next_continuation_token: "next-page"
@@ -37,7 +37,7 @@ defmodule Tuist.Storage.CacheArtifactRetentionTest do
 
       expect_delete_objects([expired_xcode_key], "xcode-cache-bucket")
 
-      assert CacheArtifactRetention.delete_expired(:xcode_cache) == {:ok, "next-page"}
+      assert CacheArtifactRetention.delete_expired(:xcode_cache, retention_days: 60) == {:ok, "next-page"}
     end
 
     test "deletes expired legacy CAS objects from the cache bucket" do
@@ -174,6 +174,32 @@ defmodule Tuist.Storage.CacheArtifactRetentionTest do
       assert CacheArtifactRetention.delete_expired(:xcode_cache) == {:ok, nil}
     end
 
+    test "applies an explicit retention window to orphaned cache objects" do
+      expired_orphan_key = "deleted-account/app/xcode/AB/CD/ABCD"
+      recent_orphan_key = "renamed-account/app/xcode/EF/GH/EFGH"
+
+      expect(Environment, :cache_xcode_s3_bucket_name, fn -> "xcode-cache-bucket" end)
+
+      expect(Storage, :list_objects_from_bucket, fn "xcode-cache-bucket",
+                                                    [prefix: "", max_keys: 1000, continuation_token: nil] ->
+        {:ok,
+         %{
+           body: %{
+             contents: [
+               %{key: expired_orphan_key, last_modified: DateTime.add(DateTime.utc_now(), -31, :day)},
+               %{key: recent_orphan_key, last_modified: DateTime.add(DateTime.utc_now(), -29, :day)}
+             ],
+             is_truncated: false
+           }
+         }}
+      end)
+
+      expect(Repo, :all, fn _query -> [] end)
+      expect_delete_objects([expired_orphan_key], "xcode-cache-bucket")
+
+      assert CacheArtifactRetention.delete_expired(:xcode_cache, retention_days: 30) == {:ok, nil}
+    end
+
     test "skips objects for accounts with custom S3 storage configured" do
       custom_storage_key = "custom-storage-account/app/xcode/AB/CD/ABCD"
       managed_storage_key = "managed-storage-account/app/xcode/EF/GH/EFGH"
@@ -207,7 +233,7 @@ defmodule Tuist.Storage.CacheArtifactRetentionTest do
 
       expect_delete_objects([managed_storage_key], "xcode-cache-bucket")
 
-      assert CacheArtifactRetention.delete_expired(:xcode_cache) == {:ok, nil}
+      assert CacheArtifactRetention.delete_expired(:xcode_cache, retention_days: 30) == {:ok, nil}
     end
 
     test "resolves mixed-case object account handles to managed accounts" do

--- a/server/test/tuist/storage/legacy_build_artifact_retention_test.exs
+++ b/server/test/tuist/storage/legacy_build_artifact_retention_test.exs
@@ -44,6 +44,32 @@ defmodule Tuist.Storage.LegacyBuildArtifactRetentionTest do
       assert LegacyBuildArtifactRetention.delete_expired() == {:ok, "next-page"}
     end
 
+    test "uses an explicit retention window" do
+      expired_legacy_key = "tuist/app/builds/0123456789abcdef0123456789abcdef/App"
+      recent_legacy_key = "tuist/app/builds/fedcba9876543210fedcba9876543210/App"
+
+      expect(Environment, :s3_bucket_name, fn -> "storage-bucket" end)
+
+      expect(Storage, :list_objects_from_bucket, fn "storage-bucket",
+                                                    [prefix: "", max_keys: 1000, continuation_token: nil] ->
+        {:ok,
+         %{
+           body: %{
+             contents: [
+               %{key: expired_legacy_key, last_modified: DateTime.add(DateTime.utc_now(), -61, :day)},
+               %{key: recent_legacy_key, last_modified: DateTime.add(DateTime.utc_now(), -59, :day)}
+             ],
+             is_truncated: false
+           }
+         }}
+      end)
+
+      expect_accounts_and_plans([%Account{id: 1, name: "tuist"}])
+      expect_delete_objects([expired_legacy_key], "storage-bucket")
+
+      assert LegacyBuildArtifactRetention.delete_expired(retention_days: 60) == {:ok, nil}
+    end
+
     test "deletes legacy build artifacts older than 30 days for paid and free accounts" do
       pro_key = "pro-account/app/builds/0123456789abcdef0123456789abcdef/App"
       air_key = "air-account/app/builds/fedcba9876543210fedcba9876543210/App"

--- a/server/test/tuist/storage/retention_policy_test.exs
+++ b/server/test/tuist/storage/retention_policy_test.exs
@@ -43,6 +43,17 @@ defmodule Tuist.Storage.RetentionPolicyTest do
   end
 
   describe "retention_days/2" do
+    test "uses an explicit retention window without the hosted maximum" do
+      assert RetentionPolicy.retention_days(:cache_artifact, :air, 120) == 120
+      assert RetentionPolicy.retention_days(:shard_bundle, :air, 365) == 365
+    end
+
+    test "rejects invalid explicit retention windows" do
+      assert_raise ArgumentError, fn -> RetentionPolicy.retention_days(:cache_artifact, :air, 0) end
+      assert_raise ArgumentError, fn -> RetentionPolicy.retention_days(:cache_artifact, :air, -1) end
+      assert_raise ArgumentError, fn -> RetentionPolicy.retention_days(:cache_artifact, :air, "30") end
+    end
+
     test "returns cache artifact retention capped at 30 days" do
       assert RetentionPolicy.retention_days(:cache_artifact, :air) == 14
       assert RetentionPolicy.retention_days(:cache_artifact, :open_source) == 14
@@ -105,6 +116,17 @@ defmodule Tuist.Storage.RetentionPolicyTest do
       cutoff = RetentionPolicy.cutoff(:cache_artifact, :enterprise)
 
       after_cutoff = DateTime.add(DateTime.utc_now(), -30, :day)
+
+      assert DateTime.compare(cutoff, before_cutoff) in [:gt, :eq]
+      assert DateTime.compare(cutoff, after_cutoff) in [:lt, :eq]
+    end
+
+    test "subtracts an explicit retention window from now" do
+      before_cutoff = DateTime.add(DateTime.utc_now(), -120, :day)
+
+      cutoff = RetentionPolicy.cutoff(:cache_artifact, :air, 120)
+
+      after_cutoff = DateTime.add(DateTime.utc_now(), -120, :day)
 
       assert DateTime.compare(cutoff, before_cutoff) in [:gt, :eq]
       assert DateTime.compare(cutoff, after_cutoff) in [:lt, :eq]

--- a/server/test/tuist/storage/workers/delete_expired_artifact_workers_test.exs
+++ b/server/test/tuist/storage/workers/delete_expired_artifact_workers_test.exs
@@ -13,6 +13,7 @@ defmodule Tuist.Storage.Workers.DeleteExpiredArtifactWorkersTest do
   alias Tuist.AppBuilds.AppBuild
   alias Tuist.Builds
   alias Tuist.CommandEvents
+  alias Tuist.Environment
   alias Tuist.Repo
   alias Tuist.Shards
   alias Tuist.Storage
@@ -25,10 +26,11 @@ defmodule Tuist.Storage.Workers.DeleteExpiredArtifactWorkersTest do
   alias Tuist.Tests
 
   describe "perform/1" do
-    test "the preview worker deletes expired previews according to the account plan" do
+    test "the preview worker uses an explicit retention window" do
       project = project_fixture()
       account = project.account
       subscription_fixture(account_id: account.id, plan: :air)
+      stub(Environment, :artifact_retention_days, fn -> %{app_previews: 60} end)
 
       expired_app_build =
         app_build_fixture(
@@ -36,10 +38,11 @@ defmodule Tuist.Storage.Workers.DeleteExpiredArtifactWorkersTest do
           inserted_at: DateTime.add(DateTime.utc_now(), -61, :day)
         )
 
-      app_build_fixture(
-        preview: preview_fixture(project: project),
-        inserted_at: DateTime.add(DateTime.utc_now(), -59, :day)
-      )
+      retained_app_build =
+        app_build_fixture(
+          preview: preview_fixture(project: project),
+          inserted_at: DateTime.add(DateTime.utc_now(), -59, :day)
+        )
 
       expired_app_build_key =
         AppBuilds.storage_key(%{account_handle: account.name, project_handle: project.name, app_build: expired_app_build})
@@ -51,6 +54,13 @@ defmodule Tuist.Storage.Workers.DeleteExpiredArtifactWorkersTest do
           preview_id: expired_app_build.preview_id
         })
 
+      retained_app_build_key =
+        AppBuilds.storage_key(%{
+          account_handle: account.name,
+          project_handle: project.name,
+          app_build: retained_app_build
+        })
+
       stub(Storage, :delete_objects, fn object_keys, %{id: account_id} ->
         assert account_id == account.id
         send(self(), {:deleted, object_keys})
@@ -60,12 +70,15 @@ defmodule Tuist.Storage.Workers.DeleteExpiredArtifactWorkersTest do
       assert :ok =
                perform_job(DeleteExpiredPreviewArtifactsWorker, %{
                  "account_id" => account.id,
-                 "batch_size" => 20
+                 "batch_size" => 20,
+                 "retention_days" => 30,
+                 "self_hosted" => true
                })
 
       assert_received {:deleted, object_keys}
       assert expired_app_build_key in object_keys
       assert expired_icon_key in object_keys
+      refute retained_app_build_key in object_keys
     end
 
     test "the preview worker persists progress across scheduled runs" do
@@ -114,7 +127,7 @@ defmodule Tuist.Storage.Workers.DeleteExpiredArtifactWorkersTest do
       assert second_keys == []
     end
 
-    test "a full batch self-enqueues the next page and the cursor advances past the oldest rows" do
+    test "a full batch reschedules the next page and the cursor advances past the oldest rows" do
       project = project_fixture()
       account = project.account
       subscription_fixture(account_id: account.id, plan: :air)
@@ -142,27 +155,33 @@ defmodule Tuist.Storage.Workers.DeleteExpiredArtifactWorkersTest do
         :ok
       end)
 
-      assert :ok =
-               perform_job(DeleteExpiredPreviewArtifactsWorker, %{"account_id" => account.id, "batch_size" => 1})
+      job =
+        insert_job(DeleteExpiredPreviewArtifactsWorker, %{
+          "account_id" => account.id,
+          "batch_size" => 1,
+          "retention_days" => 60
+        })
+
+      assert {:snooze, 0} = DeleteExpiredPreviewArtifactsWorker.perform(job)
 
       assert_received {:deleted, first_keys}
       assert older_key in first_keys
       refute newer_key in first_keys
 
-      assert_enqueued(
-        worker: DeleteExpiredPreviewArtifactsWorker,
-        args: %{"account_id" => account.id, "batch_size" => 1, "after_id" => older.id}
-      )
+      assert [continuation_job] = all_enqueued(worker: DeleteExpiredPreviewArtifactsWorker)
+
+      assert continuation_job.args == %{
+               "account_id" => account.id,
+               "batch_size" => 1,
+               "after_id" => older.id,
+               "after_inserted_at" => DateTime.to_iso8601(Repo.get(AppBuild, older.id).inserted_at),
+               "retention_days" => 60
+             }
 
       cursor_inserted_at = Repo.get(AppBuild, older.id).inserted_at
 
-      assert :ok =
-               perform_job(DeleteExpiredPreviewArtifactsWorker, %{
-                 "account_id" => account.id,
-                 "batch_size" => 1,
-                 "after_inserted_at" => DateTime.to_iso8601(cursor_inserted_at),
-                 "after_id" => older.id
-               })
+      assert continuation_job.args["after_inserted_at"] == DateTime.to_iso8601(cursor_inserted_at)
+      assert {:snooze, 0} = DeleteExpiredPreviewArtifactsWorker.perform(continuation_job)
 
       assert_received {:deleted, second_keys}
       assert newer_key in second_keys
@@ -203,13 +222,15 @@ defmodule Tuist.Storage.Workers.DeleteExpiredArtifactWorkersTest do
         :ok
       end)
 
-      assert :ok =
-               perform_job(DeleteExpiredPreviewArtifactsWorker, %{
-                 "account_id" => account.id,
-                 "batch_size" => 1,
-                 "after_inserted_at" => older_inserted_at |> DateTime.add(-1, :second) |> DateTime.to_iso8601(),
-                 "after_id" => "00000000-0000-0000-0000-000000000000"
-               })
+      job =
+        insert_job(DeleteExpiredPreviewArtifactsWorker, %{
+          "account_id" => account.id,
+          "batch_size" => 1,
+          "after_inserted_at" => older_inserted_at |> DateTime.add(-1, :second) |> DateTime.to_iso8601(),
+          "after_id" => "00000000-0000-0000-0000-000000000000"
+        })
+
+      assert {:snooze, 0} = DeleteExpiredPreviewArtifactsWorker.perform(job)
 
       assert_received {:deleted, _object_keys}
 
@@ -366,29 +387,23 @@ defmodule Tuist.Storage.Workers.DeleteExpiredArtifactWorkersTest do
         :ok
       end)
 
-      assert :ok =
-               perform_job(DeleteExpiredRunSessionsWorker, %{"account_id" => account.id, "batch_size" => 1})
+      job = insert_job(DeleteExpiredRunSessionsWorker, %{"account_id" => account.id, "batch_size" => 1})
+
+      assert {:snooze, 0} = DeleteExpiredRunSessionsWorker.perform(job)
 
       assert_received {:deleted, ^older_run_artifact_prefix}
       refute_received {:deleted, ^newer_run_artifact_prefix}
 
-      assert_enqueued(
-        worker: DeleteExpiredRunSessionsWorker,
-        args: %{
-          "account_id" => account.id,
-          "batch_size" => 1,
-          "after_inserted_at" => NaiveDateTime.to_iso8601(older_run.ran_at),
-          "after_id" => older_run.id
-        }
-      )
+      assert [continuation_job] = all_enqueued(worker: DeleteExpiredRunSessionsWorker)
 
-      assert :ok =
-               perform_job(DeleteExpiredRunSessionsWorker, %{
-                 "account_id" => account.id,
-                 "batch_size" => 1,
-                 "after_inserted_at" => NaiveDateTime.to_iso8601(older_run.ran_at),
-                 "after_id" => older_run.id
-               })
+      assert continuation_job.args == %{
+               "account_id" => account.id,
+               "batch_size" => 1,
+               "after_inserted_at" => NaiveDateTime.to_iso8601(older_run.ran_at),
+               "after_id" => older_run.id
+             }
+
+      assert {:snooze, 0} = DeleteExpiredRunSessionsWorker.perform(continuation_job)
 
       assert_received {:deleted, ^newer_run_artifact_prefix}
     end
@@ -529,5 +544,10 @@ defmodule Tuist.Storage.Workers.DeleteExpiredArtifactWorkersTest do
       assert_received {:deleted, object_keys}
       assert expired_shard_key in object_keys
     end
+  end
+
+  defp insert_job(worker, args) do
+    assert {:ok, job} = args |> worker.new() |> Oban.insert()
+    job
   end
 end

--- a/server/test/tuist/storage/workers/delete_expired_cache_artifact_workers_test.exs
+++ b/server/test/tuist/storage/workers/delete_expired_cache_artifact_workers_test.exs
@@ -1,5 +1,5 @@
 defmodule Tuist.Storage.Workers.DeleteExpiredCacheArtifactWorkersTest do
-  use TuistTestSupport.Cases.DataCase, async: false
+  use TuistTestSupport.Cases.DataCase, async: true
   use Mimic
 
   import Ecto.Query

--- a/server/test/tuist/storage/workers/delete_expired_cache_artifact_workers_test.exs
+++ b/server/test/tuist/storage/workers/delete_expired_cache_artifact_workers_test.exs
@@ -2,8 +2,13 @@ defmodule Tuist.Storage.Workers.DeleteExpiredCacheArtifactWorkersTest do
   use TuistTestSupport.Cases.DataCase, async: false
   use Mimic
 
+  import Ecto.Query
+
+  alias Tuist.Environment
+  alias Tuist.Repo
   alias Tuist.Storage.CacheArtifactRetention
   alias Tuist.Storage.LegacyBuildArtifactRetention
+  alias Tuist.Storage.Workers.ArtifactRetentionWorker
   alias Tuist.Storage.Workers.DeleteExpiredCasCacheArtifactsWorker
   alias Tuist.Storage.Workers.DeleteExpiredGradleCacheArtifactsWorker
   alias Tuist.Storage.Workers.DeleteExpiredLegacyBuildArtifactsWorker
@@ -11,25 +16,79 @@ defmodule Tuist.Storage.Workers.DeleteExpiredCacheArtifactWorkersTest do
   alias Tuist.Storage.Workers.DeleteExpiredXcodeModuleCacheArtifactsWorker
 
   describe "perform/1" do
-    test "the Xcode cache worker deletes expired Xcode cache artifacts and schedules the next page" do
-      expect(CacheArtifactRetention, :delete_expired, fn :xcode_cache, [continuation_token: "cursor"] ->
+    test "bucket workers keep active jobs unique until completion" do
+      workers = [
+        DeleteExpiredXcodeCacheArtifactsWorker,
+        DeleteExpiredXcodeModuleCacheArtifactsWorker,
+        DeleteExpiredGradleCacheArtifactsWorker,
+        DeleteExpiredCasCacheArtifactsWorker,
+        DeleteExpiredLegacyBuildArtifactsWorker
+      ]
+
+      Enum.each(workers, fn worker ->
+        unique = worker.new(%{}).changes.unique
+
+        assert unique.fields == [:queue, :worker]
+        assert unique.period == :infinity
+        assert unique.states == [:available, :scheduled, :executing, :retryable]
+      end)
+    end
+
+    test "bucket worker uniqueness blocks a different window or continuation while another replica executes it" do
+      assert {:ok, first_job} =
+               %{"retention_days" => 30}
+               |> DeleteExpiredXcodeCacheArtifactsWorker.new()
+               |> Oban.insert()
+
+      {1, _jobs} =
+        Repo.update_all(from(job in Oban.Job, where: job.id == ^first_job.id), set: [state: "executing"])
+
+      assert {:ok, second_job} =
+               %{"continuation_token" => "next", "retention_days" => 90}
+               |> DeleteExpiredXcodeCacheArtifactsWorker.new()
+               |> Oban.insert()
+
+      assert second_job.conflict?
+      assert second_job.id == first_job.id
+    end
+
+    test "rescheduling renews the retry budget for the next page" do
+      job = insert_job(DeleteExpiredXcodeCacheArtifactsWorker, %{})
+
+      assert {:snooze, 0} =
+               ArtifactRetentionWorker.reschedule_with_args(%{job | attempt: 7}, %{"continuation_token" => "next"})
+
+      assert [updated_job] = all_enqueued(worker: DeleteExpiredXcodeCacheArtifactsWorker)
+      assert updated_job.args == %{"continuation_token" => "next"}
+      assert updated_job.max_attempts == 9
+    end
+
+    test "the Xcode cache worker deletes expired Xcode cache artifacts and reschedules the next page" do
+      expect(CacheArtifactRetention, :delete_expired, fn :xcode_cache, opts ->
+        assert opts[:continuation_token] == "cursor"
+        assert opts[:retention_days] == 60
         {:ok, "next-cursor"}
       end)
 
-      assert :ok = perform_job(DeleteExpiredXcodeCacheArtifactsWorker, %{"continuation_token" => "cursor"})
+      job =
+        insert_job(DeleteExpiredXcodeCacheArtifactsWorker, %{"continuation_token" => "cursor", "retention_days" => 60})
+
+      assert {:snooze, 0} = DeleteExpiredXcodeCacheArtifactsWorker.perform(job)
 
       assert_enqueued(
         worker: DeleteExpiredXcodeCacheArtifactsWorker,
-        args: %{"continuation_token" => "next-cursor"}
+        args: %{"continuation_token" => "next-cursor", "retention_days" => 60}
       )
     end
 
-    test "the Xcode module cache worker deletes expired module cache artifacts and schedules the next page" do
+    test "the Xcode module cache worker deletes expired module cache artifacts and reschedules the next page" do
       expect(CacheArtifactRetention, :delete_expired, fn :xcode_module, [continuation_token: "cursor"] ->
         {:ok, "next-cursor"}
       end)
 
-      assert :ok = perform_job(DeleteExpiredXcodeModuleCacheArtifactsWorker, %{"continuation_token" => "cursor"})
+      job = insert_job(DeleteExpiredXcodeModuleCacheArtifactsWorker, %{"continuation_token" => "cursor"})
+
+      assert {:snooze, 0} = DeleteExpiredXcodeModuleCacheArtifactsWorker.perform(job)
 
       assert_enqueued(
         worker: DeleteExpiredXcodeModuleCacheArtifactsWorker,
@@ -37,12 +96,14 @@ defmodule Tuist.Storage.Workers.DeleteExpiredCacheArtifactWorkersTest do
       )
     end
 
-    test "the Gradle cache worker deletes expired Gradle cache artifacts and schedules the next page" do
+    test "the Gradle cache worker deletes expired Gradle cache artifacts and reschedules the next page" do
       expect(CacheArtifactRetention, :delete_expired, fn :gradle, [continuation_token: "cursor"] ->
         {:ok, "next-cursor"}
       end)
 
-      assert :ok = perform_job(DeleteExpiredGradleCacheArtifactsWorker, %{"continuation_token" => "cursor"})
+      job = insert_job(DeleteExpiredGradleCacheArtifactsWorker, %{"continuation_token" => "cursor"})
+
+      assert {:snooze, 0} = DeleteExpiredGradleCacheArtifactsWorker.perform(job)
 
       assert_enqueued(
         worker: DeleteExpiredGradleCacheArtifactsWorker,
@@ -50,12 +111,14 @@ defmodule Tuist.Storage.Workers.DeleteExpiredCacheArtifactWorkersTest do
       )
     end
 
-    test "the CAS cache worker deletes expired legacy CAS artifacts and schedules the next page" do
+    test "the CAS cache worker deletes expired legacy CAS artifacts and reschedules the next page" do
       expect(CacheArtifactRetention, :delete_expired, fn :cas, [continuation_token: "cursor"] ->
         {:ok, "next-cursor"}
       end)
 
-      assert :ok = perform_job(DeleteExpiredCasCacheArtifactsWorker, %{"continuation_token" => "cursor"})
+      job = insert_job(DeleteExpiredCasCacheArtifactsWorker, %{"continuation_token" => "cursor"})
+
+      assert {:snooze, 0} = DeleteExpiredCasCacheArtifactsWorker.perform(job)
 
       assert_enqueued(
         worker: DeleteExpiredCasCacheArtifactsWorker,
@@ -63,16 +126,24 @@ defmodule Tuist.Storage.Workers.DeleteExpiredCacheArtifactWorkersTest do
       )
     end
 
-    test "the legacy build artifact worker deletes expired legacy build artifacts and schedules the next page" do
-      expect(LegacyBuildArtifactRetention, :delete_expired, fn [continuation_token: "cursor"] ->
+    test "the legacy build artifact worker deletes expired legacy build artifacts and reschedules the next page" do
+      expect(LegacyBuildArtifactRetention, :delete_expired, fn opts ->
+        assert opts[:continuation_token] == "cursor"
+        assert opts[:retention_days] == 90
         {:ok, "next-cursor"}
       end)
 
-      assert :ok = perform_job(DeleteExpiredLegacyBuildArtifactsWorker, %{"continuation_token" => "cursor"})
+      job =
+        insert_job(DeleteExpiredLegacyBuildArtifactsWorker, %{
+          "continuation_token" => "cursor",
+          "retention_days" => 90
+        })
+
+      assert {:snooze, 0} = DeleteExpiredLegacyBuildArtifactsWorker.perform(job)
 
       assert_enqueued(
         worker: DeleteExpiredLegacyBuildArtifactsWorker,
-        args: %{"continuation_token" => "next-cursor"}
+        args: %{"continuation_token" => "next-cursor", "retention_days" => 90}
       )
     end
 
@@ -85,5 +156,48 @@ defmodule Tuist.Storage.Workers.DeleteExpiredCacheArtifactWorkersTest do
 
       refute_enqueued(worker: DeleteExpiredGradleCacheArtifactsWorker)
     end
+
+    test "self-hosted workers use the current window for every page" do
+      stub(Environment, :artifact_retention_days, fn -> %{cache_artifacts: 90} end)
+
+      assert {:ok, pending_job} =
+               %{"retention_days" => 30, "self_hosted" => true}
+               |> DeleteExpiredXcodeCacheArtifactsWorker.new()
+               |> Oban.insert()
+
+      expect(CacheArtifactRetention, :delete_expired, fn :xcode_cache, opts ->
+        assert opts[:retention_days] == 90
+        {:ok, "next-cursor"}
+      end)
+
+      assert {:snooze, 0} = DeleteExpiredXcodeCacheArtifactsWorker.perform(pending_job)
+
+      assert [continuation_job] = all_enqueued(worker: DeleteExpiredXcodeCacheArtifactsWorker)
+      assert continuation_job.id == pending_job.id
+
+      assert continuation_job.args == %{
+               "continuation_token" => "next-cursor",
+               "retention_days" => 90,
+               "self_hosted" => true
+             }
+    end
+
+    test "self-hosted workers stop when their resource type is disabled" do
+      stub(Environment, :artifact_retention_days, fn -> %{} end)
+      reject(&CacheArtifactRetention.delete_expired/2)
+
+      assert :ok =
+               perform_job(DeleteExpiredXcodeCacheArtifactsWorker, %{
+                 "retention_days" => 30,
+                 "self_hosted" => true
+               })
+
+      refute_enqueued(worker: DeleteExpiredXcodeCacheArtifactsWorker)
+    end
+  end
+
+  defp insert_job(worker, args) do
+    assert {:ok, job} = args |> worker.new() |> Oban.insert()
+    job
   end
 end

--- a/server/test/tuist/storage/workers/schedule_expired_artifacts_worker_test.exs
+++ b/server/test/tuist/storage/workers/schedule_expired_artifacts_worker_test.exs
@@ -1,33 +1,57 @@
 defmodule Tuist.Storage.Workers.ScheduleExpiredArtifactsWorkerTest do
-  use TuistTestSupport.Cases.DataCase, async: true
+  use TuistTestSupport.Cases.DataCase, async: false
+  use Mimic
 
   import Ecto.Query
   import TuistTestSupport.Fixtures.AccountsFixtures
 
   alias Tuist.Accounts.Account
+  alias Tuist.Environment
   alias Tuist.Repo
+  alias Tuist.Storage.Workers.DeleteExpiredBuildArchivesWorker
+  alias Tuist.Storage.Workers.DeleteExpiredPreviewArtifactsWorker
+  alias Tuist.Storage.Workers.DeleteExpiredRunSessionsWorker
+  alias Tuist.Storage.Workers.DeleteExpiredShardBundlesWorker
+  alias Tuist.Storage.Workers.DeleteExpiredTestAttachmentsWorker
   alias Tuist.Storage.Workers.ScheduleExpiredArtifactsWorker
 
   describe "perform/1" do
-    test "enqueues one deletion job per account and artifact type and schedules the next page" do
+    test "scheduler and account workers keep active jobs unique until completion" do
+      scheduler_unique = ScheduleExpiredArtifactsWorker.new(%{}).changes.unique
+
+      assert scheduler_unique.fields == [:queue, :worker]
+      assert scheduler_unique.period == :infinity
+      assert scheduler_unique.states == [:available, :scheduled, :executing, :retryable]
+
+      Enum.each(ScheduleExpiredArtifactsWorker.deletion_workers(), fn worker ->
+        unique = worker.new(%{}).changes.unique
+
+        assert unique.keys == [:account_id]
+        assert unique.period == :infinity
+        assert unique.states == [:available, :scheduled, :executing, :retryable]
+      end)
+    end
+
+    test "enqueues one deletion job per account and artifact type and reschedules the next page" do
       after_id = max_account_id()
       first_account = account_fixture()
       second_account = account_fixture()
       [first_account_id, _second_account_id] = Enum.sort([first_account.id, second_account.id])
+      args = %{"after_id" => after_id, "batch_size" => 10, "page_size" => 1}
 
-      assert :ok =
-               perform_job(ScheduleExpiredArtifactsWorker, %{
-                 "after_id" => after_id,
-                 "batch_size" => 10,
-                 "page_size" => 1
-               })
+      assert {:ok, pending_job} = args |> ScheduleExpiredArtifactsWorker.new() |> Oban.insert()
+      assert {:snooze, 0} = ScheduleExpiredArtifactsWorker.perform(pending_job)
 
       assert_deletion_jobs_enqueued(first_account_id)
 
-      assert_enqueued(
-        worker: ScheduleExpiredArtifactsWorker,
-        args: %{"after_id" => first_account_id, "page_size" => 1, "batch_size" => 10}
-      )
+      assert [continuation_job] = all_enqueued(worker: ScheduleExpiredArtifactsWorker)
+      assert continuation_job.id == pending_job.id
+
+      assert continuation_job.args == %{
+               "after_id" => first_account_id,
+               "page_size" => 1,
+               "batch_size" => 10
+             }
     end
 
     test "continues from the provided account cursor" do
@@ -45,12 +69,105 @@ defmodule Tuist.Storage.Workers.ScheduleExpiredArtifactsWorkerTest do
       assert_deletion_jobs_enqueued(second_account_id)
     end
 
+    test "enqueues only configured resource types and preserves their windows across account pages" do
+      after_id = max_account_id()
+      first_account = account_fixture()
+      _second_account = account_fixture()
+      queued_retention_days = %{"app_previews" => 30, "build_archives" => 30}
+      current_retention_days = %{"app_previews" => 45, "run_artifacts" => 60}
+
+      stub(Environment, :artifact_retention_days, fn -> %{app_previews: 45, run_artifacts: 60} end)
+
+      args = %{
+        "after_id" => after_id,
+        "batch_size" => 10,
+        "page_size" => 1,
+        "retention_days" => queued_retention_days,
+        "self_hosted" => true
+      }
+
+      assert {:ok, pending_job} = args |> ScheduleExpiredArtifactsWorker.new() |> Oban.insert()
+      assert {:snooze, 0} = ScheduleExpiredArtifactsWorker.perform(pending_job)
+
+      assert_enqueued(
+        worker: DeleteExpiredPreviewArtifactsWorker,
+        args: %{
+          "account_id" => first_account.id,
+          "batch_size" => 10,
+          "retention_days" => 45,
+          "self_hosted" => true
+        }
+      )
+
+      assert_enqueued(
+        worker: DeleteExpiredRunSessionsWorker,
+        args: %{
+          "account_id" => first_account.id,
+          "batch_size" => 10,
+          "retention_days" => 60,
+          "self_hosted" => true
+        }
+      )
+
+      refute_enqueued(worker: DeleteExpiredBuildArchivesWorker)
+      refute_enqueued(worker: DeleteExpiredTestAttachmentsWorker)
+      refute_enqueued(worker: DeleteExpiredShardBundlesWorker)
+
+      assert_enqueued(
+        worker: ScheduleExpiredArtifactsWorker,
+        args: %{
+          "after_id" => first_account.id,
+          "page_size" => 1,
+          "batch_size" => 10,
+          "retention_days" => current_retention_days,
+          "self_hosted" => true
+        }
+      )
+    end
+
     test "does not enqueue deletion jobs for an empty account page" do
       assert :ok = perform_job(ScheduleExpiredArtifactsWorker, %{"after_id" => max_account_id(), "page_size" => 1})
 
       Enum.each(ScheduleExpiredArtifactsWorker.deletion_workers(), fn deletion_worker ->
         refute_enqueued(worker: deletion_worker)
       end)
+    end
+
+    test "self-hosted scheduling enforces deletion job uniqueness" do
+      after_id = max_account_id()
+      account = account_fixture()
+
+      stub(Environment, :artifact_retention_days, fn -> %{app_previews: 30} end)
+
+      args = %{
+        "after_id" => after_id,
+        "page_size" => 500,
+        "retention_days" => %{"app_previews" => 30},
+        "self_hosted" => true
+      }
+
+      assert :ok = perform_job(ScheduleExpiredArtifactsWorker, args)
+      assert :ok = perform_job(ScheduleExpiredArtifactsWorker, args)
+
+      assert [job] = all_enqueued(worker: DeleteExpiredPreviewArtifactsWorker)
+      assert job.args["account_id"] == account.id
+    end
+
+    test "a queued self-hosted scheduler stops when no account artifacts are configured" do
+      _account = account_fixture()
+      stub(Environment, :artifact_retention_days, fn -> %{cache_artifacts: 30} end)
+
+      assert :ok =
+               perform_job(ScheduleExpiredArtifactsWorker, %{
+                 "retention_days" => %{"app_previews" => 30},
+                 "self_hosted" => true
+               })
+
+      Enum.each(ScheduleExpiredArtifactsWorker.deletion_workers(), fn deletion_worker ->
+        refute_enqueued(worker: deletion_worker)
+      end)
+
+      refute_enqueued(worker: ScheduleExpiredArtifactsWorker)
     end
   end
 

--- a/server/test/tuist/storage/workers/schedule_expired_artifacts_worker_test.exs
+++ b/server/test/tuist/storage/workers/schedule_expired_artifacts_worker_test.exs
@@ -1,5 +1,5 @@
 defmodule Tuist.Storage.Workers.ScheduleExpiredArtifactsWorkerTest do
-  use TuistTestSupport.Cases.DataCase, async: false
+  use TuistTestSupport.Cases.DataCase, async: true
   use Mimic
 
   import Ecto.Query

--- a/server/test/tuist/storage/workers/schedule_expired_artifacts_worker_test.exs
+++ b/server/test/tuist/storage/workers/schedule_expired_artifacts_worker_test.exs
@@ -69,44 +69,26 @@ defmodule Tuist.Storage.Workers.ScheduleExpiredArtifactsWorkerTest do
       assert_deletion_jobs_enqueued(second_account_id)
     end
 
-    test "enqueues only configured resource types and preserves their windows across account pages" do
+    test "self-hosted enqueues only the resource types configured in the environment" do
       after_id = max_account_id()
       first_account = account_fixture()
       _second_account = account_fixture()
-      queued_retention_days = %{"app_previews" => 30, "build_archives" => 30}
-      current_retention_days = %{"app_previews" => 45, "run_artifacts" => 60}
 
       stub(Environment, :artifact_retention_days, fn -> %{app_previews: 45, run_artifacts: 60} end)
 
-      args = %{
-        "after_id" => after_id,
-        "batch_size" => 10,
-        "page_size" => 1,
-        "retention_days" => queued_retention_days,
-        "self_hosted" => true
-      }
+      args = %{"after_id" => after_id, "batch_size" => 10, "page_size" => 1, "self_hosted" => true}
 
       assert {:ok, pending_job} = args |> ScheduleExpiredArtifactsWorker.new() |> Oban.insert()
       assert {:snooze, 0} = ScheduleExpiredArtifactsWorker.perform(pending_job)
 
       assert_enqueued(
         worker: DeleteExpiredPreviewArtifactsWorker,
-        args: %{
-          "account_id" => first_account.id,
-          "batch_size" => 10,
-          "retention_days" => 45,
-          "self_hosted" => true
-        }
+        args: %{"account_id" => first_account.id, "batch_size" => 10, "self_hosted" => true}
       )
 
       assert_enqueued(
         worker: DeleteExpiredRunSessionsWorker,
-        args: %{
-          "account_id" => first_account.id,
-          "batch_size" => 10,
-          "retention_days" => 60,
-          "self_hosted" => true
-        }
+        args: %{"account_id" => first_account.id, "batch_size" => 10, "self_hosted" => true}
       )
 
       refute_enqueued(worker: DeleteExpiredBuildArchivesWorker)
@@ -119,10 +101,28 @@ defmodule Tuist.Storage.Workers.ScheduleExpiredArtifactsWorkerTest do
           "after_id" => first_account.id,
           "page_size" => 1,
           "batch_size" => 10,
-          "retention_days" => current_retention_days,
           "self_hosted" => true
         }
       )
+    end
+
+    test "self-hosted jobs carry no retention window, since workers read it from the environment" do
+      after_id = max_account_id()
+      _account = account_fixture()
+      _next_account = account_fixture()
+
+      stub(Environment, :artifact_retention_days, fn -> %{app_previews: 45} end)
+
+      args = %{"after_id" => after_id, "page_size" => 1, "self_hosted" => true}
+
+      assert {:ok, pending_job} = args |> ScheduleExpiredArtifactsWorker.new() |> Oban.insert()
+      assert {:snooze, 0} = ScheduleExpiredArtifactsWorker.perform(pending_job)
+
+      assert [deletion_job] = all_enqueued(worker: DeleteExpiredPreviewArtifactsWorker)
+      refute Map.has_key?(deletion_job.args, "retention_days")
+
+      assert [continuation_job] = all_enqueued(worker: ScheduleExpiredArtifactsWorker)
+      refute Map.has_key?(continuation_job.args, "retention_days")
     end
 
     test "does not enqueue deletion jobs for an empty account page" do
@@ -139,12 +139,7 @@ defmodule Tuist.Storage.Workers.ScheduleExpiredArtifactsWorkerTest do
 
       stub(Environment, :artifact_retention_days, fn -> %{app_previews: 30} end)
 
-      args = %{
-        "after_id" => after_id,
-        "page_size" => 500,
-        "retention_days" => %{"app_previews" => 30},
-        "self_hosted" => true
-      }
+      args = %{"after_id" => after_id, "page_size" => 500, "self_hosted" => true}
 
       assert :ok = perform_job(ScheduleExpiredArtifactsWorker, args)
       assert :ok = perform_job(ScheduleExpiredArtifactsWorker, args)
@@ -153,15 +148,26 @@ defmodule Tuist.Storage.Workers.ScheduleExpiredArtifactsWorkerTest do
       assert job.args["account_id"] == account.id
     end
 
+    test "Tuist-hosted scheduling enforces deletion job uniqueness" do
+      after_id = max_account_id()
+      account = account_fixture()
+
+      args = %{"after_id" => after_id, "page_size" => 500}
+
+      assert :ok = perform_job(ScheduleExpiredArtifactsWorker, args)
+      assert :ok = perform_job(ScheduleExpiredArtifactsWorker, args)
+
+      Enum.each(ScheduleExpiredArtifactsWorker.deletion_workers(), fn deletion_worker ->
+        assert [job] = all_enqueued(worker: deletion_worker)
+        assert job.args["account_id"] == account.id
+      end)
+    end
+
     test "a queued self-hosted scheduler stops when no account artifacts are configured" do
       _account = account_fixture()
       stub(Environment, :artifact_retention_days, fn -> %{cache_artifacts: 30} end)
 
-      assert :ok =
-               perform_job(ScheduleExpiredArtifactsWorker, %{
-                 "retention_days" => %{"app_previews" => 30},
-                 "self_hosted" => true
-               })
+      assert :ok = perform_job(ScheduleExpiredArtifactsWorker, %{"self_hosted" => true})
 
       Enum.each(ScheduleExpiredArtifactsWorker.deletion_workers(), fn deletion_worker ->
         refute_enqueued(worker: deletion_worker)


### PR DESCRIPTION
Self-hosted Tuist operators can now opt into automatic artifact cleanup and choose a separate retention window for each supported artifact family.

## What changed

The server now reads six independently optional retention variables for cache artifacts, app previews, build archives, run artifacts, test attachments, and shard bundles. A grouped `server.artifactRetentionDays` Helm value renders those variables individually and leaves them absent when a family is not configured.

The existing retention workers now schedule only the configured artifact families and remove files from object storage without deleting the associated PostgreSQL or ClickHouse metadata. The public data-retention guide, self-hosting guide, data-export reference, deployment example, Helm documentation, and product changelog describe the new behavior and its exact scope.

## Why

Self-hosted instances could accumulate artifacts indefinitely even though the public retention guide described a maximum 30-day hosted window. Operators had no built-in way to apply their own storage policy and had to manage object cleanup outside Tuist.

## Root cause

Artifact-retention schedules were part of the hosted-only Oban configuration. Their windows were derived from hosted account plans and capped at 30 days, so self-hosted web processes never scheduled the cleanup workers.

## Approach

The implementation reuses the existing cleanup paths instead of introducing a second deletion system. Self-hosted schedules are opt-in by artifact family, while the hosted Tuist server continues using its plan-based policy unchanged.

The environment decides *whether* a retention cron is installed at boot. It does not travel in the job args: every self-hosted batch re-reads the current variables before deleting files, so removing a variable or widening a window protects files from already-queued work once the server restarts. An earlier revision of this branch also serialized the window into the cron args, which was dead payload that shadowed the real source of truth, so those args now carry only the `self_hosted` flag.

Paginated scans update and reschedule the same unique Oban job, which prevents multiple server replicas from branching the scan, and each page receives a fresh retry budget.

Cache cleanup covers instance-managed cache buckets, including matching objects whose account prefix no longer resolves to a current account. Accounts using account-specific custom cache storage remain excluded.

### Deletion-job uniqueness

The per-account deletion workers declare `unique: [keys: [:account_id], period: :infinity, states: [...]]` so that an account with a large expired backlog gets exactly one deletion chain walking it, however many nightly runs elapse while that chain is in flight.

While building the self-hosted path it became clear that `Oban.insert_all/1` does not honor that declaration. Oban's basic engine (the open-source one we run; bulk unique inserts are an Oban Pro feature) merges `on_conflict: :nothing` into a plain `Ecto.Repo.insert_all/3` and never takes the advisory lock that `Oban.insert/1` uses to run the uniqueness query. So the declared uniqueness silently did nothing on the bulk path.

The self-hosted branch was written to avoid this with per-job `Oban.insert/1`, but the hosted branch kept the pre-existing `Oban.insert_all/1`. That left the guarantee holding on one path and not the other. Both now insert one job at a time.

The alternative considered was keeping the bulk insert and pre-filtering each page against the in-flight jobs with an extra query. It would preserve one round trip per page instead of one per job, but it reimplements Oban's uniqueness check in application code and is only race-free because the scheduler happens to be a singleton today, which is an invariant nothing enforces. Inserting one at a time is what Oban's own documentation prescribes for the basic engine, and the cost is bounded: a page is at most `page_size` accounts times five workers, and the resulting jobs are each a database round trip anyway when they execute.

## Impact

The change is inert by default. When all retention variables are absent or blank, self-hosted deployments schedule no artifact-retention jobs and Helm emits no retention variables.

Once configured, artifact files older than their family window are deleted. Dashboard and analytics metadata remains available because PostgreSQL and ClickHouse rows are preserved. Package registry mirror objects, runner log archives, and account-specific custom cache buckets remain outside this policy.

On the hosted Tuist server, backlogged accounts no longer accumulate duplicate deletion chains issuing redundant object-storage deletes and database scans against the same rows.

## Validation

- Focused server, worker, documentation, and changelog tests: 134 passed.
- `MIX_ENV=test mix compile --warnings-as-errors`: passed.
- `mix format --check-formatted` for all changed Elixir files: passed.
- `mix credo`: no issues across 1,519 source files.
- `helm lint infra/helm/tuist`: passed.
- Helm rendering verified the default configuration emits zero retention variables, a partial configuration emits two, and a complete configuration emits all six.
- The uniqueness regression is pinned by a test on each path (`Tuist-hosted scheduling enforces deletion job uniqueness` and its self-hosted twin). Both were confirmed to fail when the insert is reverted to `Oban.insert_all/1`, which is what let us verify the bug was real rather than theoretical.

### How to test locally

1. Set one retention variable, such as `TUIST_CACHE_ARTIFACT_RETENTION_DAYS=30`, or configure the matching `server.artifactRetentionDays.cacheArtifacts` Helm value.
2. Restart a self-hosted web server in a production-like environment.
3. Confirm the cache-retention workers are present in the Oban schedule and workers for omitted families are absent.
4. Run the configured worker against an instance-managed bucket containing an object older than the window and one newer object.
5. Confirm only the expired object is removed and its associated database metadata remains available.

