### PR TITLE
fix(server): enforce dashboard authorization

### DIFF
--- a/server/lib/tuist/authorization.ex
+++ b/server/lib/tuist/authorization.ex
@@ -100,6 +100,11 @@ defmodule Tuist.Authorization do
       allow([:authenticated_as_account, scopes_permit: "project:bundles:read"])
       allow([:authenticated_as_account, scopes_permit: "project:bundles:write"])
     end
+
+    action :delete do
+      desc("Allows the admin of a project to delete a bundle.")
+      allow([:authenticated_as_user, user_role: :admin])
+    end
   end
 
   object :account do

--- a/server/lib/tuist_web/live/bundle_live.ex
+++ b/server/lib/tuist_web/live/bundle_live.ex
@@ -11,6 +11,7 @@ defmodule TuistWeb.BundleLive do
 
   alias Noora.Filter
   alias Tuist.Bundles
+  alias Tuist.Authorization
   alias Tuist.Projects
   alias Tuist.Utilities.ByteFormatter
   alias TuistWeb.Errors.NotFoundError
@@ -19,7 +20,7 @@ defmodule TuistWeb.BundleLive do
   @table_page_size 20
 
   def mount(%{"bundle_id" => bundle_id}, _session, %{assigns: %{selected_project: selected_project}} = socket) do
-    bundle = get_selected_bundle(bundle_id)
+    bundle = get_selected_bundle(bundle_id, selected_project.id)
 
     all_artifacts = flatten_artifacts(bundle.artifacts)
 
@@ -551,7 +552,9 @@ defmodule TuistWeb.BundleLive do
     {:noreply, socket}
   end
 
-  def handle_event("delete_bundle", _params, %{assigns: %{bundle: bundle, selected_project: selected_project}} = socket) do
+  def handle_event("delete_bundle", _params, %{assigns: %{bundle: bundle, selected_project: selected_project, current_user: current_user}} = socket) do
+    :ok = Authorization.authorize(:bundle_delete, current_user, selected_project)
+
     Bundles.delete_bundle!(bundle)
 
     {
@@ -841,8 +844,8 @@ defmodule TuistWeb.BundleLive do
   defp to_atom(input) when is_binary(input), do: String.to_existing_atom(input)
   defp to_atom(input) when is_atom(input), do: input
 
-  defp get_selected_bundle(bundle_id) do
-    case Bundles.get_bundle(bundle_id, preload: :uploaded_by_account) do
+  defp get_selected_bundle(bundle_id, project_id) do
+    case Bundles.get_bundle(bundle_id, project_id: project_id, preload: :uploaded_by_account) do
       {:error, :not_found} ->
         raise NotFoundError, dgettext("dashboard_cache", "Bundle not found.")
 

--- a/server/lib/tuist_web/live/members_live.ex
+++ b/server/lib/tuist_web/live/members_live.ex
@@ -11,6 +11,11 @@ defmodule TuistWeb.MembersLive do
 
   @impl true
   def mount(_params, _session, %{assigns: %{selected_account: account}} = socket) do
+    if Authorization.authorize(:organization_read, socket.assigns.current_user, account) != :ok do
+      raise TuistWeb.Errors.UnauthorizedError,
+        dgettext("dashboard_account", "You are not authorized to perform this action.")
+    end
+
     socket =
       socket
       |> assign(
@@ -578,6 +583,8 @@ defmodule TuistWeb.MembersLive do
   end
 
   def handle_event("save-member-role", %{"member-id" => member_id}, %{assigns: %{organization: organization}} = socket) do
+    :ok = Authorization.authorize(:member_update, socket.assigns.current_user, socket.assigns.selected_account)
+
     member_id_int = String.to_integer(member_id)
     {^member_id_int, new_role} = socket.assigns.managing_member
 
@@ -614,6 +621,8 @@ defmodule TuistWeb.MembersLive do
   # end
 
   def handle_event("invite-members", %{"invitation" => %{"invitee_email" => email}}, socket) do
+    :ok = Authorization.authorize(:invitation_create, socket.assigns.current_user, socket.assigns.selected_account)
+
     email = String.trim(email)
 
     # NOTE: Enable this when tag-input is used.

--- a/server/lib/tuist_web/live/project_automations_live.ex
+++ b/server/lib/tuist_web/live/project_automations_live.ex
@@ -395,6 +395,8 @@ defmodule TuistWeb.ProjectAutomationsLive do
   end
 
   def handle_event("save_automation", _params, %{assigns: assigns} = socket) do
+    :ok = Authorization.authorize(:automation_alert_create, assigns.current_user, assigns.selected_project)
+
     attrs = build_automation_attrs(assigns.selected_project.id, assigns)
 
     result =
@@ -403,6 +405,7 @@ defmodule TuistWeb.ProjectAutomationsLive do
           Automations.create_alert(attrs)
 
         id ->
+          :ok = Authorization.authorize(:automation_alert_update, assigns.current_user, assigns.selected_project)
           with {:ok, automation} <- Automations.get_alert(id) do
             Automations.update_alert(automation, attrs)
           end
@@ -424,6 +427,8 @@ defmodule TuistWeb.ProjectAutomationsLive do
   end
 
   def handle_event("toggle_automation_enabled", %{"id" => id}, %{assigns: %{selected_project: project}} = socket) do
+    :ok = Authorization.authorize(:automation_alert_update, socket.assigns.current_user, project)
+
     with {:ok, automation} <- Automations.get_alert(id),
          true <- automation.project_id == project.id,
          {:ok, _} <- Automations.update_alert(automation, %{enabled: not automation.enabled}) do
@@ -434,6 +439,8 @@ defmodule TuistWeb.ProjectAutomationsLive do
   end
 
   def handle_event("delete_automation", %{"id" => id}, %{assigns: %{selected_project: project}} = socket) do
+    :ok = Authorization.authorize(:automation_alert_delete, socket.assigns.current_user, project)
+
     with {:ok, automation} <- Automations.get_alert(id),
          true <- automation.project_id == project.id,
          {:ok, _} <- Automations.delete_alert(automation) do

--- a/server/lib/tuist_web/live/test_case_live.ex
+++ b/server/lib/tuist_web/live/test_case_live.ex
@@ -11,6 +11,7 @@ defmodule TuistWeb.TestCaseLive do
 
   alias Noora.Filter
   alias Tuist.Accounts
+  alias Tuist.Authorization
   alias Tuist.Tests
   alias Tuist.Tests.Analytics
   alias Tuist.Utilities.DateFormatter
@@ -258,8 +259,9 @@ defmodule TuistWeb.TestCaseLive do
   def handle_event(
         "unmark-as-flaky",
         _params,
-        %{assigns: %{test_case_id: test_case_id, test_case_detail: test_case_detail, current_user: current_user}} = socket
+        %{assigns: %{test_case_id: test_case_id, test_case_detail: test_case_detail, current_user: current_user, selected_project: project}} = socket
       ) do
+    :ok = Authorization.authorize(:test_update, current_user, project)
     {:ok, updated_test_case} =
       Tests.update_test_case(
         test_case_id,
@@ -276,8 +278,9 @@ defmodule TuistWeb.TestCaseLive do
   def handle_event(
         "mark-as-flaky",
         _params,
-        %{assigns: %{test_case_id: test_case_id, test_case_detail: test_case_detail, current_user: current_user}} = socket
+        %{assigns: %{test_case_id: test_case_id, test_case_detail: test_case_detail, current_user: current_user, selected_project: project}} = socket
       ) do
+    :ok = Authorization.authorize(:test_update, current_user, project)
     {:ok, updated_test_case} =
       Tests.update_test_case(
         test_case_id,
@@ -296,9 +299,10 @@ defmodule TuistWeb.TestCaseLive do
   def handle_event(
         "set-state",
         %{"data" => new_state},
-        %{assigns: %{test_case_id: test_case_id, test_case_detail: test_case_detail, current_user: current_user}} = socket
+        %{assigns: %{test_case_id: test_case_id, test_case_detail: test_case_detail, current_user: current_user, selected_project: project}} = socket
       )
       when new_state in ["enabled", "muted", "skipped"] do
+    :ok = Authorization.authorize(:test_update, current_user, project)
     {:ok, updated_test_case} =
       Tests.update_test_case(
         test_case_id,

--- a/server/test/tuist_web/live/members_live_test.exs
+++ b/server/test/tuist_web/live/members_live_test.exs
@@ -59,6 +59,21 @@ defmodule TuistWeb.MembersLiveTest do
     end
   end
 
+  describe "authorization" do
+    test "does not allow a user from another organization to open the members page", %{
+      conn: conn,
+      account: account
+    } do
+      other_user = AccountsFixtures.user_fixture()
+
+      conn = log_in_user(conn, other_user)
+
+      assert_raise TuistWeb.Errors.UnauthorizedError, fn ->
+        live(conn, ~p"/#{account.name}/members")
+      end
+    end
+  end
+
   describe "resend_invite" do
     test "does not allow resending an invitation belonging to a different organization", %{
       conn: conn,


### PR DESCRIPTION
## What changed

- Scope bundle lookups to the selected project.
- Require project administrator authorization for bundle deletion.
- Require organization read authorization before loading the members page.
- Enforce invitation and member-role authorization in dashboard event handlers.
- Enforce test update authorization for test-case mutations.
- Enforce create, update, and delete authorization for automation mutations.
- Add a regression test for cross-organization members-page access.

## Why

The dashboard did not consistently apply the same project and organization authorization rules as the public interface. This allowed confirmed cross-project bundle reads and cross-organization member disclosure through normal dashboard routes.

## Root cause

Several LiveViews trusted route parameters or selected account state without checking the corresponding authorization policy. Some mutation handlers relied on the visibility of dashboard controls instead of enforcing authorization when events were received.

## Impact

The same fixes protect bundle data, organization member data, test metadata, and automation configuration. No destructive action was executed during validation.

## Approach

The existing authorization policy is reused at the dashboard boundaries. Bundle reads are additionally constrained by project identifier so a valid bundle identifier from another project cannot satisfy the lookup.

## Validation

- Headless Chrome reproduced the unpatched behavior:
  - A private bundle from `tuist/tuist` loaded at `tuist/public` and exposed the Delete bundle control.
  - An unrelated user opened `tuist/members` and saw member emails, roles, and management controls.
- With the fixes restored, the same browser sessions received Bundle not found and You are not authorized to perform this action.
- `mix test test/tuist_web/live/bundle_live_test.exs test/tuist_web/live/members_live_test.exs test/tuist_web/live/test_case_live_test.exs test/tuist_web/live/project_automations_live_test.exs`
- Result: 50 tests passed.
- `git diff --check`

## Advisory

[GHSA-557v-9rcm-gmh6](https://github.com/tuist/tuist/security/advisories/GHSA-557v-9rcm-gmh6)
