### PR TITLE
feat(app): support custom server authentication

### DIFF
--- a/android/AGENTS.md
+++ b/android/AGENTS.md
@@ -27,7 +27,9 @@ This node covers the Tuist Android companion app under `android/`. The app provi
 
 ## Running on Emulator
 
-The debug build defaults to production (`https://tuist.dev`). In debug builds you can override the environment at launch time via an intent extra:
+The app defaults to production (`https://tuist.dev`). Users can enter a custom server address from the login screen. The normalized address is persisted and used as the origin for authentication and app requests until the user selects **Use default server**. Changing or resetting the address signs out the current user and restarts the app process so Hilt network singletons are recreated with the selected origin.
+
+In debug builds you can also override the environment at launch time via an intent extra:
 
 ```bash
 # Force-stop and launch with a specific environment
@@ -42,9 +44,9 @@ Valid environments:
 | `canary` | `https://canary.tuist.dev` | `ca49d1d6-acaf-4eaa-b866-774b799044db` |
 | `production` | `https://tuist.dev` | (from BuildConfig) |
 
-The selected environment persists in SharedPreferences across launches until explicitly changed. Switching environments signs out the current user and restarts the app process so Hilt singletons are recreated.
+The selected named environment persists in SharedPreferences across launches until explicitly changed. Switching named environments clears any custom server address, signs out the current user, and restarts the app process.
 
-For release builds, the environment is always `production`.
+For release builds, the default named environment is always `production`, but a custom server address entered by the user still takes precedence.
 
 ## Icons
 

--- a/android/app/src/main/java/dev/tuist/app/data/EnvironmentConfig.kt
+++ b/android/app/src/main/java/dev/tuist/app/data/EnvironmentConfig.kt
@@ -4,6 +4,9 @@ import android.content.Context
 import android.content.SharedPreferences
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dev.tuist.app.BuildConfig
+import java.net.URI
+import java.net.URISyntaxException
+import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -48,17 +51,109 @@ class EnvironmentConfig @Inject constructor(
             return TuistEnvironment.fromName(name) ?: DEFAULT
         }
 
-    val serverUrl: String get() = current.serverUrl
+    val customServerUrl: String?
+        get() = prefs.getString(KEY_CUSTOM_SERVER_URL, null)
+
+    val isUsingCustomServerUrl: Boolean get() = customServerUrl != null
+    val serverUrl: String get() = customServerUrl ?: current.serverUrl
     val oauthClientId: String get() = current.oauthClientId
 
     fun setEnvironment(env: TuistEnvironment): Boolean {
-        val changed = current != env
-        prefs.edit().putString(KEY_ENVIRONMENT, env.name).apply()
+        val changed = current != env || customServerUrl != null
+        prefs.edit()
+            .putString(KEY_ENVIRONMENT, env.name)
+            .remove(KEY_CUSTOM_SERVER_URL)
+            .apply()
+        return changed
+    }
+
+    fun setCustomServerUrl(value: String): Boolean {
+        val normalizedValue = normalizeServerUrl(value)
+        val changed = customServerUrl != normalizedValue
+        prefs.edit()
+            .putString(KEY_CUSTOM_SERVER_URL, normalizedValue)
+            .apply()
+        return changed
+    }
+
+    fun resetServerUrl(): Boolean {
+        val changed = customServerUrl != null
+        prefs.edit().remove(KEY_CUSTOM_SERVER_URL).apply()
         return changed
     }
 
     companion object {
         private const val KEY_ENVIRONMENT = "selected_environment"
+        private const val KEY_CUSTOM_SERVER_URL = "custom_server_url"
         private val DEFAULT = TuistEnvironment.PRODUCTION
+
+        fun normalizeServerUrl(value: String): String {
+            val trimmedValue = value.trim()
+            require(trimmedValue.isNotEmpty()) { "Enter a server address." }
+
+            val valueWithScheme = if (trimmedValue.contains("://")) {
+                trimmedValue
+            } else {
+                "https://$trimmedValue"
+            }
+
+            val uri = try {
+                URI(valueWithScheme)
+            } catch (_: URISyntaxException) {
+                throw IllegalArgumentException("$value is not a valid server address.")
+            }
+
+            val scheme = uri.scheme?.lowercase(Locale.US)
+                ?: throw IllegalArgumentException("$value is not a valid server address.")
+            val host = uri.host
+                ?.removePrefix("[")
+                ?.removeSuffix("]")
+                ?.lowercase(Locale.US)
+                ?.takeIf { it.isNotEmpty() }
+                ?: throw IllegalArgumentException("$value is not a valid server address.")
+
+            require(scheme == "http" || scheme == "https") {
+                "$scheme is not supported. Use http or https."
+            }
+            require(scheme != "http" || isLocalHost(host)) {
+                "Use https, or http for a local server."
+            }
+            require(
+                uri.rawUserInfo == null &&
+                    (uri.rawPath.isNullOrEmpty() || uri.rawPath == "/") &&
+                    uri.rawQuery == null &&
+                    uri.rawFragment == null,
+            ) {
+                "Use the root server address without a path, query, fragment, or credentials."
+            }
+            require(uri.port == -1 || uri.port in 1..65535) {
+                "$value is not a valid server address."
+            }
+
+            val port = uri.port.takeUnless {
+                it == -1 || (scheme == "http" && it == 80) || (scheme == "https" && it == 443)
+            }
+            val renderedHost = if (host.contains(':')) "[$host]" else host
+            return buildString {
+                append(scheme)
+                append("://")
+                append(renderedHost)
+                if (port != null) {
+                    append(':')
+                    append(port)
+                }
+            }
+        }
+
+        private fun isLocalHost(host: String): Boolean {
+            if (host == "localhost" || host == "::1") return true
+
+            val addressComponents = host.split('.')
+            return addressComponents.size == 4 &&
+                addressComponents.first() == "127" &&
+                addressComponents.all { component ->
+                    component.toIntOrNull() in 0..255
+                }
+        }
     }
 }

--- a/android/app/src/main/java/dev/tuist/app/ui/login/LoginScreen.kt
+++ b/android/app/src/main/java/dev/tuist/app/ui/login/LoginScreen.kt
@@ -1,11 +1,14 @@
 package dev.tuist.app.ui.login
 
 import android.app.Activity
+import android.content.Intent
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
@@ -16,6 +19,10 @@ import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Snackbar
@@ -24,7 +31,10 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -47,6 +57,7 @@ fun LoginScreen(
 ) {
     val activity = LocalContext.current as Activity
     val snackbarHostState = remember { SnackbarHostState() }
+    var isServerSettingsPresented by remember { mutableStateOf(false) }
 
     LaunchedEffect(Unit) {
         viewModel.messages.collect { message ->
@@ -121,6 +132,13 @@ fun LoginScreen(
                         .padding(bottom = NooraSpacing.Spacing9 + WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()),
                 ) {
                     Column {
+                        ServerButton(
+                            serverUrl = viewModel.serverUrl,
+                            onClick = { isServerSettingsPresented = true },
+                        )
+
+                        Spacer(Modifier.height(NooraSpacing.Spacing5))
+
                         SocialSignInButton(
                             title = stringResource(R.string.sign_in_tuist),
                             style = SignInButtonStyle.PRIMARY,
@@ -159,4 +177,85 @@ fun LoginScreen(
             }
         }
     }
+
+    if (isServerSettingsPresented) {
+        ServerSettingsDialog(
+            serverUrl = viewModel.serverUrl,
+            isUsingCustomServerUrl = viewModel.isUsingCustomServerUrl,
+            onSave = { value ->
+                viewModel.updateServerUrl(value).fold(
+                    onSuccess = { changed ->
+                        isServerSettingsPresented = false
+                        if (changed) restartApplication(activity)
+                        null
+                    },
+                    onFailure = { error ->
+                        error.localizedMessage ?: error.toString()
+                    },
+                )
+            },
+            onReset = {
+                isServerSettingsPresented = false
+                if (viewModel.resetServerUrl()) restartApplication(activity)
+            },
+            onDismiss = { isServerSettingsPresented = false },
+        )
+    }
+}
+
+@Composable
+private fun ServerButton(
+    serverUrl: String,
+    onClick: () -> Unit,
+) {
+    val shape = RoundedCornerShape(NooraSpacing.Spacing4)
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(shape)
+            .background(NooraTheme.colors.buttonSecondaryBackground)
+            .border(NooraSpacing.Spacing1, Color.Black.copy(alpha = 0.08f), shape)
+            .clickable(onClick = onClick)
+            .padding(horizontal = NooraSpacing.Spacing6, vertical = NooraSpacing.Spacing5),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(
+            imageVector = Icons.Default.Settings,
+            contentDescription = null,
+            tint = NooraTheme.colors.surfaceLabelSecondary,
+        )
+
+        Column(
+            modifier = Modifier
+                .weight(1f)
+                .padding(horizontal = NooraSpacing.Spacing5),
+        ) {
+            Text(
+                text = stringResource(R.string.server_title),
+                style = MaterialTheme.typography.labelMedium,
+                color = NooraTheme.colors.surfaceLabelPrimary,
+            )
+            Text(
+                text = serverUrl,
+                style = MaterialTheme.typography.bodySmall,
+                color = NooraTheme.colors.surfaceLabelSecondary,
+                maxLines = 1,
+            )
+        }
+
+        Icon(
+            imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+            contentDescription = null,
+            tint = NooraTheme.colors.surfaceLabelSecondary,
+        )
+    }
+}
+
+private fun restartApplication(activity: Activity) {
+    val restartIntent = activity.packageManager.getLaunchIntentForPackage(activity.packageName) ?: return
+    restartIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
+    activity.startActivity(restartIntent)
+    activity.finishAffinity()
+    Runtime.getRuntime().exit(0)
 }

--- a/android/app/src/main/java/dev/tuist/app/ui/login/LoginViewModel.kt
+++ b/android/app/src/main/java/dev/tuist/app/ui/login/LoginViewModel.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dev.tuist.app.data.EnvironmentConfig
 import dev.tuist.app.data.auth.AuthEvent
 import dev.tuist.app.data.auth.AuthEventBus
 import dev.tuist.app.data.auth.AuthRepository
@@ -16,6 +17,7 @@ import javax.inject.Inject
 class LoginViewModel @Inject constructor(
     private val authRepository: AuthRepository,
     private val authEventBus: AuthEventBus,
+    private val environmentConfig: EnvironmentConfig,
 ) : ViewModel() {
 
     private val _messages = Channel<String>(Channel.BUFFERED)
@@ -46,5 +48,21 @@ class LoginViewModel @Inject constructor(
 
     fun signInWithGitHub(activity: Activity) {
         authRepository.startOAuthFlow(activity, "/oauth2/github")
+    }
+
+    val serverUrl: String
+        get() = environmentConfig.serverUrl
+
+    val isUsingCustomServerUrl: Boolean
+        get() = environmentConfig.isUsingCustomServerUrl
+
+    fun updateServerUrl(value: String): Result<Boolean> = runCatching {
+        environmentConfig.setCustomServerUrl(value).also { changed ->
+            if (changed) authRepository.signOut()
+        }
+    }
+
+    fun resetServerUrl(): Boolean = environmentConfig.resetServerUrl().also { changed ->
+        if (changed) authRepository.signOut()
     }
 }

--- a/android/app/src/main/java/dev/tuist/app/ui/login/ServerSettingsDialog.kt
+++ b/android/app/src/main/java/dev/tuist/app/ui/login/ServerSettingsDialog.kt
@@ -1,0 +1,80 @@
+package dev.tuist.app.ui.login
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.KeyboardType
+import dev.tuist.app.R
+import dev.tuist.app.ui.noora.NooraSpacing
+
+@Composable
+fun ServerSettingsDialog(
+    serverUrl: String,
+    isUsingCustomServerUrl: Boolean,
+    onSave: (String) -> String?,
+    onReset: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    var serverUrlString by rememberSaveable(serverUrl) { mutableStateOf(serverUrl) }
+    var errorMessage by remember { mutableStateOf<String?>(null) }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = {
+            Text(stringResource(R.string.server_title))
+        },
+        text = {
+            Column {
+                OutlinedTextField(
+                    value = serverUrlString,
+                    onValueChange = {
+                        serverUrlString = it
+                        errorMessage = null
+                    },
+                    modifier = Modifier.fillMaxWidth(),
+                    label = { Text(stringResource(R.string.server_address)) },
+                    supportingText = {
+                        Text(errorMessage ?: stringResource(R.string.server_address_help))
+                    },
+                    isError = errorMessage != null,
+                    singleLine = true,
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Uri),
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(
+                onClick = {
+                    errorMessage = onSave(serverUrlString)
+                },
+            ) {
+                Text(stringResource(R.string.save))
+            }
+        },
+        dismissButton = {
+            TextButton(
+                onClick = onReset,
+                enabled = isUsingCustomServerUrl,
+                modifier = Modifier.padding(end = NooraSpacing.Spacing2),
+            ) {
+                Text(stringResource(R.string.use_default_server))
+            }
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(R.string.cancel))
+            }
+        },
+    )
+}

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -7,6 +7,11 @@
     <string name="sign_in_apple">Sign in with Apple</string>
     <string name="sign_in_google">Sign in with Google</string>
     <string name="sign_in_github">Sign in with GitHub</string>
+    <string name="server_title">Server</string>
+    <string name="server_address">Server address</string>
+    <string name="server_address_help">Use the root address of your Tuist server.</string>
+    <string name="use_default_server">Use default server</string>
+    <string name="save">Save</string>
     <string name="projects_title">Projects</string>
     <string name="previews_title">Previews</string>
     <string name="sign_out">Sign out</string>

--- a/android/app/src/test/java/dev/tuist/app/data/EnvironmentConfigTest.kt
+++ b/android/app/src/test/java/dev/tuist/app/data/EnvironmentConfigTest.kt
@@ -1,0 +1,136 @@
+package dev.tuist.app.data
+
+import android.content.Context
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+@RunWith(RobolectricTestRunner::class)
+class EnvironmentConfigTest {
+    private lateinit var context: Context
+
+    @Before
+    fun setUp() {
+        context = RuntimeEnvironment.getApplication()
+        clearPreferences()
+    }
+
+    @After
+    fun tearDown() {
+        clearPreferences()
+    }
+
+    @Test
+    fun `uses production server by default`() {
+        val subject = EnvironmentConfig(context)
+
+        assertEquals("https://tuist.dev", subject.serverUrl)
+        assertNull(subject.customServerUrl)
+    }
+
+    @Test
+    fun `persists normalized custom server and resets it`() {
+        val subject = EnvironmentConfig(context)
+
+        subject.setCustomServerUrl("  EXAMPLE.com:443/  ")
+
+        assertEquals("https://example.com", subject.serverUrl)
+        assertEquals("https://example.com", EnvironmentConfig(context).customServerUrl)
+
+        EnvironmentConfig(context).resetServerUrl()
+
+        assertEquals("https://tuist.dev", subject.serverUrl)
+        assertNull(subject.customServerUrl)
+    }
+
+    @Test
+    fun `custom server takes precedence over selected debug environment`() {
+        val subject = EnvironmentConfig(context)
+        subject.setEnvironment(TuistEnvironment.STAGING)
+
+        subject.setCustomServerUrl("https://example.com")
+
+        assertEquals("https://example.com", subject.serverUrl)
+        assertEquals(TuistEnvironment.STAGING, subject.current)
+    }
+
+    @Test
+    fun `selecting named environment clears custom server`() {
+        val subject = EnvironmentConfig(context)
+        subject.setCustomServerUrl("https://example.com")
+
+        val changed = subject.setEnvironment(TuistEnvironment.CANARY)
+
+        assertTrue(changed)
+        assertNull(subject.customServerUrl)
+        assertEquals("https://canary.tuist.dev", subject.serverUrl)
+        assertFalse(subject.setEnvironment(TuistEnvironment.CANARY))
+    }
+
+    @Test
+    fun `normalizes secure server addresses`() {
+        val addresses = mapOf(
+            "example.com" to "https://example.com",
+            "HTTPS://EXAMPLE.COM" to "https://example.com",
+            "https://example.com/" to "https://example.com",
+            "https://example.com:443" to "https://example.com",
+            "https://example.com:8443" to "https://example.com:8443",
+        )
+
+        addresses.forEach { (input, expected) ->
+            assertEquals(expected, EnvironmentConfig.normalizeServerUrl(input))
+        }
+    }
+
+    @Test
+    fun `allows cleartext loopback servers`() {
+        val addresses = mapOf(
+            "http://localhost:8080" to "http://localhost:8080",
+            "http://LOCALHOST:80/" to "http://localhost",
+            "http://127.0.0.1:8080" to "http://127.0.0.1:8080",
+            "http://127.255.255.255" to "http://127.255.255.255",
+            "http://[::1]:8080" to "http://[::1]:8080",
+        )
+
+        addresses.forEach { (input, expected) ->
+            assertEquals(expected, EnvironmentConfig.normalizeServerUrl(input))
+        }
+    }
+
+    @Test
+    fun `rejects invalid server addresses`() {
+        val addresses = listOf(
+            "",
+            "http://example.com",
+            "http://127.0.0.1.example.com",
+            "ftp://example.com",
+            "https://example.com/path",
+            "https://example.com?query=value",
+            "https://example.com#fragment",
+            "https://user:password@example.com",
+            "https://example.com:99999",
+            "not a host",
+        )
+
+        addresses.forEach { input ->
+            assertThrows(IllegalArgumentException::class.java) {
+                EnvironmentConfig.normalizeServerUrl(input)
+            }
+        }
+    }
+
+    private fun clearPreferences() {
+        context.getSharedPreferences("tuist_environment", Context.MODE_PRIVATE)
+            .edit()
+            .clear()
+            .commit()
+    }
+}

--- a/app/Project.swift
+++ b/app/Project.swift
@@ -226,6 +226,7 @@ let project = Project(
             deploymentTargets: .iOS("18.0"),
             sources: ["Sources/TuistErrorHandling/**"],
             dependencies: [
+                .target(name: "TuistAuthentication"),
                 .project(target: "TuistServer", path: "../"),
                 .project(target: "TuistLogging", path: "../"),
                 .project(target: "TuistHTTP", path: "../"),

--- a/app/Sources/TuistApp/TuistApp.swift
+++ b/app/Sources/TuistApp/TuistApp.swift
@@ -24,7 +24,7 @@ import TuistServer
         var body: some Scene {
             appDelegate.menuBarExtra = FluidMenuBarExtra(title: "Tuist", image: "MenuBarIcon") {
                 ServerCredentialsStore.$current.withValue(
-                    ServerCredentialsStore(backend: .keychain)
+                    appDelegate.credentialsStore
                 ) {
                     CachedValueStore.$current.withValue(CachedValueStore(backend: .inSystemProcess)) {
                         MenuBarView(
@@ -62,13 +62,19 @@ import TuistServer
 
     @main
     struct TuistApp: App {
+        private let credentialsStore: ServerCredentialsStoring
+
+        init() {
+            credentialsStore = ServerCredentialsStore(backend: .keychain)
+        }
+
         var body: some Scene {
             WindowGroup {
                 ServerCredentialsStore.$current.withValue(
-                    ServerCredentialsStore(backend: .keychain)
+                    credentialsStore
                 ) {
                     CachedValueStore.$current.withValue(CachedValueStore(backend: .inSystemProcess)) {
-                        RootView()
+                        RootView(credentialsStore: credentialsStore)
                     }
                 }
             }
@@ -76,13 +82,23 @@ import TuistServer
     }
 
     private struct RootView: View {
-        @StateObject private var authenticationService = AuthenticationService()
+        @StateObject private var authenticationService: AuthenticationService
+        @StateObject private var errorHandling: ErrorHandling
         @State private var activeTab = TabIdentifier.previews
+
+        init(credentialsStore: ServerCredentialsStoring) {
+            _authenticationService = StateObject(
+                wrappedValue: AuthenticationService(credentialsStore: credentialsStore)
+            )
+            _errorHandling = StateObject(
+                wrappedValue: ErrorHandling(credentialsStore: credentialsStore)
+            )
+        }
 
         var body: some View {
             content
                 .environmentObject(authenticationService)
-                .withErrorHandling()
+                .withErrorHandling(errorHandling)
                 .task {
                     TuistSDK(
                         fullHandle: "tuist/tuist",
@@ -95,7 +111,7 @@ import TuistServer
         @ViewBuilder
         private var content: some View {
             switch authenticationService.authenticationState {
-            case let .loggedIn(account):
+            case let .loggedIn(account, serverURL):
                 TabView(selection: $activeTab) {
                     PreviewsView()
                         .tabItem {
@@ -112,6 +128,7 @@ import TuistServer
                         }
                         .tag(TabIdentifier.profile)
                 }
+                .id(serverURL)
                 .onOpenURL { _ in
                     activeTab = .previews
                 }

--- a/app/Sources/TuistAuthentication/AppServerEnvironmentService.swift
+++ b/app/Sources/TuistAuthentication/AppServerEnvironmentService.swift
@@ -1,0 +1,149 @@
+import Foundation
+import TuistAppStorage
+import TuistServer
+
+public struct AppServerURLKey: AppStorageKey {
+    public static let key = "serverURL"
+    public static let defaultValue: String? = nil
+}
+
+public enum AppServerEnvironmentServiceError: LocalizedError, Equatable {
+    case cannotChangeServerURL
+    case emptyServerURL
+    case insecureServerURL
+    case invalidServerURL(String)
+    case serverURLMustBeRoot
+    case unsupportedServerURLScheme(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .cannotChangeServerURL:
+            return "The server address cannot be changed from this context."
+        case .emptyServerURL:
+            return "Enter a server address."
+        case .insecureServerURL:
+            return "Use https, or http for a local server."
+        case let .invalidServerURL(value):
+            return "\(value) is not a valid server address."
+        case .serverURLMustBeRoot:
+            return "Use the root server address without a path, query, or fragment."
+        case let .unsupportedServerURLScheme(scheme):
+            return "\(scheme) is not supported. Use http or https."
+        }
+    }
+}
+
+public protocol AppServerEnvironmentConfiguring: ServerEnvironmentServicing {
+    func customURL() -> URL?
+    func defaultURL() -> URL
+    func setCustomURL(_ url: URL?) throws
+}
+
+public struct AppServerEnvironmentService: AppServerEnvironmentConfiguring {
+    private let appStorage: AppStoring
+    private let defaultServerEnvironmentService: ServerEnvironmentServicing
+
+    public init(
+        appStorage: AppStoring = AppStorage(),
+        defaultServerEnvironmentService: ServerEnvironmentServicing = ServerEnvironmentService()
+    ) {
+        self.appStorage = appStorage
+        self.defaultServerEnvironmentService = defaultServerEnvironmentService
+    }
+
+    public func url() -> URL {
+        return customURL() ?? defaultURL()
+    }
+
+    public func defaultURL() -> URL {
+        return defaultServerEnvironmentService.url()
+    }
+
+    public func customURL() -> URL? {
+        guard let storedValue = try? appStorage.get(AppServerURLKey.self) else {
+            return nil
+        }
+        return try? Self.normalizedURL(from: storedValue)
+    }
+
+    public func setCustomURL(_ url: URL?) throws {
+        let normalizedURL = try url.map { try Self.normalizedURL(from: $0.absoluteString) }
+        try appStorage.set(AppServerURLKey.self, value: normalizedURL?.absoluteString)
+    }
+
+    public func oauthClientId() -> String {
+        return defaultServerEnvironmentService.oauthClientId()
+    }
+
+    public func url(configServerURL: URL) throws -> URL {
+        if let customURL = customURL() {
+            return customURL
+        }
+
+        return try defaultServerEnvironmentService.url(configServerURL: configServerURL)
+    }
+
+    public static func normalizedURL(from value: String) throws -> URL {
+        let trimmedValue = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedValue.isEmpty else {
+            throw AppServerEnvironmentServiceError.emptyServerURL
+        }
+
+        let valueWithScheme = if trimmedValue.contains("://") {
+            trimmedValue
+        } else {
+            "https://\(trimmedValue)"
+        }
+
+        guard var components = URLComponents(string: valueWithScheme),
+              let scheme = components.scheme?.lowercased(),
+              let host = components.host,
+              !host.isEmpty
+        else {
+            throw AppServerEnvironmentServiceError.invalidServerURL(value)
+        }
+
+        guard scheme == "http" || scheme == "https" else {
+            throw AppServerEnvironmentServiceError.unsupportedServerURLScheme(scheme)
+        }
+
+        if scheme == "http", !isLocalHost(host) {
+            throw AppServerEnvironmentServiceError.insecureServerURL
+        }
+
+        guard components.user == nil,
+              components.password == nil,
+              components.path.isEmpty || components.path == "/",
+              components.query == nil,
+              components.fragment == nil
+        else {
+            throw AppServerEnvironmentServiceError.serverURLMustBeRoot
+        }
+
+        components.scheme = scheme
+        components.host = host.lowercased()
+        components.path = ""
+        if (scheme == "http" && components.port == 80) ||
+            (scheme == "https" && components.port == 443)
+        {
+            components.port = nil
+        }
+
+        guard let url = components.url else {
+            throw AppServerEnvironmentServiceError.invalidServerURL(value)
+        }
+
+        return url
+    }
+
+    private static func isLocalHost(_ host: String) -> Bool {
+        let host = host.lowercased().trimmingCharacters(in: CharacterSet(charactersIn: "[]"))
+        let addressComponents = host.split(separator: ".", omittingEmptySubsequences: false)
+        let isIPv4Loopback = addressComponents.count == 4 &&
+            addressComponents.first == "127" &&
+            addressComponents.allSatisfy { UInt8($0) != nil }
+        return host == "localhost" ||
+            isIPv4Loopback ||
+            host == "::1"
+    }
+}

--- a/app/Sources/TuistAuthentication/AuthenticationService.swift
+++ b/app/Sources/TuistAuthentication/AuthenticationService.swift
@@ -36,62 +36,74 @@ public enum AuthenticationError: LocalizedError {
     }
 }
 
+@MainActor
 public final class AuthenticationService: ObservableObject {
     @Published public var authenticationState: AuthenticationState
+    @Published public private(set) var serverURL: URL
 
     private let serverEnvironmentService: ServerEnvironmentServicing
     private let appStorage: AppStoring
+    private let credentialsStore: ServerCredentialsStoring
     private var credentialsListenerTask: Task<Void, Never>?
+    private var credentialsRefreshTask: Task<Void, Never>?
+    private var authenticationRefreshGeneration = 0
     private let presentationContextProvider = ASWebAuthenticationPresentationContextProvider()
     private let redirectURI = "tuist://oauth-callback"
     private let deleteAccountService: DeleteAccountServicing
 
     public init(
-        serverEnvironmentService: ServerEnvironmentServicing = ServerEnvironmentService(),
+        serverEnvironmentService: ServerEnvironmentServicing? = nil,
         appStorage: AppStoring = AppStorage(),
+        credentialsStore: ServerCredentialsStoring? = nil,
         deleteAccountService: DeleteAccountServicing = DeleteAccountService()
     ) {
+        let serverEnvironmentService = serverEnvironmentService ?? AppServerEnvironmentService(appStorage: appStorage)
+        let serverURL = serverEnvironmentService.url()
         self.serverEnvironmentService = serverEnvironmentService
         self.appStorage = appStorage
+        self.credentialsStore = credentialsStore ?? ServerCredentialsStore.current
         self.deleteAccountService = deleteAccountService
 
-        authenticationState = (try? appStorage.get(AuthenticationStateKey.self)) ?? .loggedOut
+        self.serverURL = serverURL
+        authenticationState = Self.authenticationState(
+            from: (try? appStorage.get(AuthenticationStateKey.self)) ?? .loggedOut,
+            matching: serverURL
+        )
         Logger.current.notice(
             "Initialized authentication service with state: \(authenticationState.logDescription)"
         )
 
         startCredentialsListener()
+        Task {
+            await refreshAuthenticationStateForActiveServer()
+        }
     }
 
     deinit {
         credentialsListenerTask?.cancel()
+        credentialsRefreshTask?.cancel()
     }
 
     private func startCredentialsListener() {
-        credentialsListenerTask = Task {
-            for await credentials in ServerCredentialsStore.current.credentialsChanged {
-                await MainActor.run {
-                    do {
-                        Logger.current.notice(
-                            "Received credentials change: hasCredentials=\(credentials != nil)"
-                        )
-                        try updateAuthenticationState(with: credentials)
-                    } catch {
-                        Logger.current.error(
-                            "Failed to update authentication state from credentials change: \(error.localizedDescription)"
-                        )
-                        authenticationState = .loggedOut
-                        try? appStorage.set(AuthenticationStateKey.self, value: .loggedOut)
-                    }
-                }
+        let credentialsChanged = credentialsStore.credentialsChanged
+        credentialsListenerTask = Task { [weak self] in
+            for await credentials in credentialsChanged {
+                guard let self else { return }
+                Logger.current.notice(
+                    "Received credentials change: hasCredentials=\(credentials != nil)"
+                )
+                scheduleAuthenticationRefresh()
             }
         }
     }
 
-    private func updateAuthenticationState(with credentials: ServerCredentials?) throws {
+    private func updateAuthenticationState(
+        with credentials: ServerCredentials?,
+        serverURL: URL
+    ) throws {
         if let credentials {
             let account = try extractAccount(from: credentials.accessToken)
-            authenticationState = .loggedIn(account: account)
+            authenticationState = .loggedIn(account: account, serverURL: serverURL)
             Logger.current.notice("Authentication state updated to logged in")
         } else {
             authenticationState = .loggedOut
@@ -113,29 +125,150 @@ public final class AuthenticationService: ObservableObject {
         return Account(email: email, handle: handle)
     }
 
+    public func refreshAuthenticationStateForActiveServer() async {
+        let refresh = beginAuthenticationRefresh()
+        credentialsRefreshTask?.cancel()
+        await performAuthenticationRefresh(
+            serverURL: refresh.serverURL,
+            generation: refresh.generation
+        )
+    }
+
+    private func scheduleAuthenticationRefresh() {
+        let refresh = beginAuthenticationRefresh()
+        credentialsRefreshTask?.cancel()
+        credentialsRefreshTask = Task { [weak self] in
+            await self?.performAuthenticationRefresh(
+                serverURL: refresh.serverURL,
+                generation: refresh.generation
+            )
+        }
+    }
+
+    private func beginAuthenticationRefresh() -> (serverURL: URL, generation: Int) {
+        authenticationRefreshGeneration += 1
+        return (serverURL: serverURL, generation: authenticationRefreshGeneration)
+    }
+
+    private func performAuthenticationRefresh(
+        serverURL: URL,
+        generation refreshGeneration: Int
+    ) async {
+        do {
+            let credentials = try await credentialsStore.read(serverURL: serverURL)
+            guard refreshGeneration == authenticationRefreshGeneration,
+                  Self.normalizedURLString(self.serverURL) == Self.normalizedURLString(serverURL)
+            else {
+                return
+            }
+
+            do {
+                try updateAuthenticationState(with: credentials, serverURL: serverURL)
+            } catch {
+                authenticationState = .loggedOut
+                try? appStorage.set(AuthenticationStateKey.self, value: .loggedOut)
+            }
+        } catch {
+            guard refreshGeneration == authenticationRefreshGeneration,
+                  Self.normalizedURLString(self.serverURL) == Self.normalizedURLString(serverURL)
+            else {
+                return
+            }
+
+            authenticationState = .loggedOut
+            try? appStorage.set(AuthenticationStateKey.self, value: .loggedOut)
+        }
+    }
+
+    private static func authenticationState(
+        from storedAuthenticationState: AuthenticationState,
+        matching serverURL: URL
+    ) -> AuthenticationState {
+        guard case let .loggedIn(account, storedServerURL) = storedAuthenticationState,
+              normalizedURLString(storedServerURL) == normalizedURLString(serverURL)
+        else {
+            return .loggedOut
+        }
+
+        return .loggedIn(account: account, serverURL: serverURL)
+    }
+
+    private static func normalizedURLString(_ url: URL) -> String {
+        return (try? AppServerEnvironmentService.normalizedURL(from: url.absoluteString).absoluteString) ??
+            url.absoluteString
+    }
+
     public func signOut() async {
+        let serverURL = serverURL
+        await signOut(serverURL: serverURL)
+    }
+
+    private func signOut(serverURL: URL) async {
+        if Self.normalizedURLString(self.serverURL) == Self.normalizedURLString(serverURL) {
+            authenticationRefreshGeneration += 1
+            credentialsRefreshTask?.cancel()
+        }
         Logger.current.notice(
-            "Signing out and deleting credentials for server: \(serverEnvironmentService.url().absoluteString)"
+            "Signing out and deleting credentials for server: \(serverURL.absoluteString)"
         )
         do {
-            try await ServerCredentialsStore.current.delete(serverURL: serverEnvironmentService.url())
+            try await credentialsStore.delete(serverURL: serverURL)
         } catch {
             Logger.current.error(
                 "Failed to delete credentials when signing out: \(error.localizedDescription)"
             )
         }
 
-        await MainActor.run {
-            try? updateAuthenticationState(with: nil)
+        guard Self.normalizedURLString(self.serverURL) == Self.normalizedURLString(serverURL) else {
+            return
         }
+        authenticationRefreshGeneration += 1
+        credentialsRefreshTask?.cancel()
+        try? updateAuthenticationState(with: nil, serverURL: serverURL)
     }
 
     public func deleteAccount(_ account: Account) async throws {
+        let serverURL = serverURL
         try await deleteAccountService.deleteAccount(
             handle: account.handle,
-            serverURL: serverEnvironmentService.url()
+            serverURL: serverURL
         )
-        await signOut()
+        await signOut(serverURL: serverURL)
+    }
+
+    @MainActor
+    public func updateServerURL(_ value: String) async throws {
+        guard let serverEnvironmentService = serverEnvironmentService as? AppServerEnvironmentConfiguring else {
+            throw AppServerEnvironmentServiceError.cannotChangeServerURL
+        }
+
+        let serverURL = try AppServerEnvironmentService.normalizedURL(from: value)
+        try serverEnvironmentService.setCustomURL(serverURL)
+        self.serverURL = serverEnvironmentService.url()
+        await refreshAuthenticationStateForActiveServer()
+    }
+
+    @MainActor
+    public func resetServerURL() async throws {
+        guard let serverEnvironmentService = serverEnvironmentService as? AppServerEnvironmentConfiguring else {
+            throw AppServerEnvironmentServiceError.cannotChangeServerURL
+        }
+
+        try serverEnvironmentService.setCustomURL(nil)
+        serverURL = serverEnvironmentService.url()
+        await refreshAuthenticationStateForActiveServer()
+    }
+
+    public func setPresentationAnchor(_ presentationAnchor: ASPresentationAnchor?) {
+        presentationContextProvider.presentationAnchor = presentationAnchor
+    }
+
+    public var isUsingCustomServerURL: Bool {
+        guard let serverEnvironmentService = serverEnvironmentService as? AppServerEnvironmentConfiguring else {
+            return false
+        }
+
+        return serverEnvironmentService.customURL() != nil
     }
 
     public func signIn() async throws {
@@ -167,7 +300,8 @@ public final class AuthenticationService: ObservableObject {
     }
 
     public func signInWithEmailAndPassword(email: String, password: String) async throws {
-        let url = serverEnvironmentService.url().appending(path: "api/auth")
+        let serverURL = serverURL
+        let url = serverURL.appending(path: "api/auth")
 
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
@@ -190,7 +324,7 @@ public final class AuthenticationService: ObservableObject {
         }
 
         if httpResponse.statusCode == 200 {
-            try await handleTokenResponse(data)
+            try await handleTokenResponse(data, serverURL: serverURL)
         } else {
             Logger.current.error(
                 """
@@ -207,7 +341,8 @@ public final class AuthenticationService: ObservableObject {
         identityToken: String,
         authorizationCode: String
     ) async throws {
-        let url = serverEnvironmentService.url().appending(path: "api/auth/apple")
+        let serverURL = serverURL
+        let url = serverURL.appending(path: "api/auth/apple")
 
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
@@ -230,7 +365,7 @@ public final class AuthenticationService: ObservableObject {
         }
 
         if httpResponse.statusCode == 200 {
-            try await handleTokenResponse(data)
+            try await handleTokenResponse(data, serverURL: serverURL)
         } else {
             Logger.current.error(
                 """
@@ -244,8 +379,9 @@ public final class AuthenticationService: ObservableObject {
     }
 
     private func startOAuth2Flow(with path: String) async throws {
+        let serverURL = serverURL
         var urlComponents = URLComponents(
-            url: serverEnvironmentService.url().appending(path: path),
+            url: serverURL.appending(path: path),
             resolvingAgainstBaseURL: false
         )!
 
@@ -261,7 +397,8 @@ public final class AuthenticationService: ObservableObject {
 
         try await authenticate(
             with: urlComponents.url!,
-            codeVerifier: codeVerifier
+            codeVerifier: codeVerifier,
+            serverURL: serverURL
         )
     }
 
@@ -279,7 +416,8 @@ public final class AuthenticationService: ObservableObject {
 
     private func authenticate(
         with authURL: URL,
-        codeVerifier: String
+        codeVerifier: String,
+        serverURL: URL
     ) async throws {
         let code: String? = try await withCheckedThrowingContinuation { continuation in
             let authSession = ASWebAuthenticationSession(
@@ -318,15 +456,16 @@ public final class AuthenticationService: ObservableObject {
             }
         }
         if let code {
-            try await exchangeCodeForToken(code, codeVerifier: codeVerifier)
+            try await exchangeCodeForToken(code, codeVerifier: codeVerifier, serverURL: serverURL)
         }
     }
 
     private func exchangeCodeForToken(
         _ code: String,
-        codeVerifier: String
+        codeVerifier: String,
+        serverURL: URL
     ) async throws {
-        let url = serverEnvironmentService.url().appending(path: "oauth2/token")
+        let url = serverURL.appending(path: "oauth2/token")
 
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
@@ -355,7 +494,7 @@ public final class AuthenticationService: ObservableObject {
         }
 
         if httpResponse.statusCode == 200 {
-            try await handleTokenResponse(data)
+            try await handleTokenResponse(data, serverURL: serverURL)
         } else {
             Logger.current.error(
                 """
@@ -368,7 +507,10 @@ public final class AuthenticationService: ObservableObject {
         }
     }
 
-    private func handleTokenResponse(_ data: Data) async throws {
+    private func handleTokenResponse(
+        _ data: Data,
+        serverURL: URL
+    ) async throws {
         guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
             throw AuthenticationError.invalidTokenResponse
         }
@@ -379,12 +521,12 @@ public final class AuthenticationService: ObservableObject {
             throw AuthenticationError.missingTokens
         }
 
-        try await ServerCredentialsStore.current.store(
+        try await credentialsStore.store(
             credentials: ServerCredentials(
                 accessToken: accessToken,
                 refreshToken: refreshToken
             ),
-            serverURL: serverEnvironmentService.url()
+            serverURL: serverURL
         )
         Logger.current.notice("Stored authentication credentials from token response")
     }
@@ -404,8 +546,10 @@ extension AuthenticationState {
 private final class ASWebAuthenticationPresentationContextProvider: NSObject,
     ASWebAuthenticationPresentationContextProviding
 {
+    weak var presentationAnchor: ASPresentationAnchor?
+
     func presentationAnchor(for _: ASWebAuthenticationSession) -> ASPresentationAnchor {
-        return ASPresentationAnchor()
+        return presentationAnchor ?? ASPresentationAnchor()
     }
 }
 

--- a/app/Sources/TuistAuthentication/AuthenticationState.swift
+++ b/app/Sources/TuistAuthentication/AuthenticationState.swift
@@ -1,5 +1,6 @@
 import Foundation
 import TuistAppStorage
+import TuistServer
 
 public struct Account: Equatable, Codable {
     public let email: String
@@ -12,8 +13,57 @@ public struct Account: Equatable, Codable {
 }
 
 public enum AuthenticationState: Equatable, Codable {
-    case loggedIn(account: Account)
+    case loggedIn(account: Account, serverURL: URL)
     case loggedOut
+
+    private enum CodingKeys: String, CodingKey {
+        case loggedIn
+        case loggedOut
+    }
+
+    private enum LoggedInCodingKeys: String, CodingKey {
+        case account
+        case serverURL
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        if container.contains(.loggedOut) {
+            self = .loggedOut
+            return
+        }
+
+        if container.contains(.loggedIn) {
+            let loggedInContainer = try container.nestedContainer(
+                keyedBy: LoggedInCodingKeys.self,
+                forKey: .loggedIn
+            )
+            let account = try loggedInContainer.decode(Account.self, forKey: .account)
+            let serverURL = try loggedInContainer.decodeIfPresent(URL.self, forKey: .serverURL) ??
+                ServerEnvironmentService().url()
+            self = .loggedIn(account: account, serverURL: serverURL)
+            return
+        }
+
+        self = .loggedOut
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+
+        switch self {
+        case let .loggedIn(account, serverURL):
+            var loggedInContainer = container.nestedContainer(
+                keyedBy: LoggedInCodingKeys.self,
+                forKey: .loggedIn
+            )
+            try loggedInContainer.encode(account, forKey: .account)
+            try loggedInContainer.encode(serverURL, forKey: .serverURL)
+        case .loggedOut:
+            try container.encode([String: String](), forKey: .loggedOut)
+        }
+    }
 }
 
 public struct AuthenticationStateKey: AppStorageKey {

--- a/app/Sources/TuistAuthentication/ServerSettingsView.swift
+++ b/app/Sources/TuistAuthentication/ServerSettingsView.swift
@@ -1,0 +1,88 @@
+import SwiftUI
+
+public struct ServerSettingsView: View {
+    @ObservedObject private var authenticationService: AuthenticationService
+    @Environment(\.dismiss) private var dismiss
+    @State private var serverURLString: String
+    @State private var errorMessage: String?
+
+    public init(authenticationService: AuthenticationService) {
+        self.authenticationService = authenticationService
+        _serverURLString = State(initialValue: authenticationService.serverURL.absoluteString)
+    }
+
+    public var body: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    TextField("Server address", text: $serverURLString)
+                    #if os(iOS)
+                        .keyboardType(.URL)
+                        .textInputAutocapitalization(.never)
+                    #endif
+                        .autocorrectionDisabled()
+
+                    if let errorMessage {
+                        Text(errorMessage)
+                            .font(.footnote)
+                            .foregroundStyle(.red)
+                    }
+                } footer: {
+                    Text("Use the root address of your Tuist server.")
+                }
+
+                Section {
+                    Button("Save") {
+                        Task {
+                            await save()
+                        }
+                    }
+
+                    Button("Use default server") {
+                        Task {
+                            await reset()
+                        }
+                    }
+                    .disabled(!authenticationService.isUsingCustomServerURL)
+                }
+            }
+            .navigationTitle("Server")
+            #if os(iOS)
+                .navigationBarTitleDisplayMode(.inline)
+            #endif
+                .toolbar {
+                    ToolbarItem(placement: .cancellationAction) {
+                        Button("Cancel") {
+                            dismiss()
+                        }
+                    }
+                }
+        }
+        #if os(macOS)
+        .frame(minWidth: 360, minHeight: 240)
+        #endif
+        .onReceive(authenticationService.$serverURL) { serverURL in
+            serverURLString = serverURL.absoluteString
+        }
+    }
+
+    @MainActor
+    private func save() async {
+        do {
+            try await authenticationService.updateServerURL(serverURLString)
+            dismiss()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    @MainActor
+    private func reset() async {
+        do {
+            try await authenticationService.resetServerURL()
+            dismiss()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+}

--- a/app/Sources/TuistErrorHandling/ErrorHandling.swift
+++ b/app/Sources/TuistErrorHandling/ErrorHandling.swift
@@ -1,5 +1,6 @@
 import OpenAPIRuntime
 import SwiftUI
+import TuistAuthentication
 import TuistHTTP
 import TuistLogging
 import TuistServer
@@ -12,18 +13,28 @@ struct ErrorAlert: Identifiable {
 
 public final class ErrorHandling: ObservableObject {
     @Published var currentAlert: ErrorAlert?
+    private let credentialsStore: ServerCredentialsStoring
+
+    public init(credentialsStore: ServerCredentialsStoring = ServerCredentialsStore.current) {
+        self.credentialsStore = credentialsStore
+    }
 
     @MainActor
-    public func handle(error: Error) {
+    public func handle(error: Error, serverURL: URL? = nil) {
         if let clientError = error as? ClientError {
             if clientError.underlyingError is ClientAuthenticationError {
+                guard let serverURL else {
+                    Logger.current.error(
+                        "Client authentication error received without a server address. Preserving stored credentials."
+                    )
+                    currentAlert = ErrorAlert(message: clientError.underlyingError.localizedDescription)
+                    return
+                }
                 Logger.current.error(
-                    "Client authentication error received. Deleting stored credentials. Error: \(clientError.underlyingError.localizedDescription)"
+                    "Client authentication error received. Deleting stored credentials for \(serverURL.absoluteString)."
                 )
                 Task {
-                    try await ServerCredentialsStore.current.delete(
-                        serverURL: ServerEnvironmentService().url()
-                    )
+                    try await credentialsStore.delete(serverURL: serverURL)
                 }
                 return
             }
@@ -40,7 +51,7 @@ public final class ErrorHandling: ObservableObject {
 }
 
 struct HandleErrorsByShowingAlertViewModifier: ViewModifier {
-    @StateObject var errorHandling = ErrorHandling()
+    @ObservedObject var errorHandling: ErrorHandling
 
     func body(content: Content) -> some View {
         content
@@ -64,18 +75,21 @@ struct HandleErrorsByShowingAlertViewModifier: ViewModifier {
 }
 
 extension View {
-    public func withErrorHandling() -> some View {
-        modifier(HandleErrorsByShowingAlertViewModifier())
+    public func withErrorHandling(_ errorHandling: ErrorHandling = ErrorHandling()) -> some View {
+        modifier(HandleErrorsByShowingAlertViewModifier(errorHandling: errorHandling))
     }
 }
 
 extension ErrorHandling {
     public func fireAndHandleError(_ action: @escaping () async throws -> Void) {
+        let serverURL = AppServerEnvironmentService().url()
         Task {
             do {
-                try await action()
+                try await ServerCredentialsStore.$current.withValue(credentialsStore) {
+                    try await action()
+                }
             } catch {
-                await handle(error: error)
+                await handle(error: error, serverURL: serverURL)
             }
         }
     }

--- a/app/Sources/TuistMenuBar/AppDelegate.swift
+++ b/app/Sources/TuistMenuBar/AppDelegate.swift
@@ -2,14 +2,53 @@ import AppKit
 import Combine
 import FluidMenuBarExtra
 import Foundation
+import TuistAuthentication
+import TuistServer
 
 @MainActor
 public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
     public var menuBarExtra: FluidMenuBarExtra?
+    public let credentialsStore: ServerCredentialsStoring
+
+    let authenticationService: AuthenticationService
+    let errorHandling: ErrorHandling
 
     let onChangeOfURLs = PassthroughSubject<[URL], Never>()
+    private var cancellables = Set<AnyCancellable>()
+    private lazy var loginWindowController = LoginWindowController(
+        authenticationService: authenticationService,
+        errorHandling: errorHandling
+    )
+
+    override public init() {
+        let credentialsStore = ServerCredentialsStore(backend: .keychain)
+        self.credentialsStore = credentialsStore
+        authenticationService = AuthenticationService(credentialsStore: credentialsStore)
+        errorHandling = ErrorHandling(credentialsStore: credentialsStore)
+        super.init()
+    }
+
+    public func applicationDidFinishLaunching(_: Notification) {
+        authenticationService.$authenticationState
+            .sink { [weak self] authenticationState in
+                let isLoggedOut = authenticationState == .loggedOut
+                Task { @MainActor [weak self] in
+                    guard let self else { return }
+                    if isLoggedOut {
+                        presentLoginWindow()
+                    } else {
+                        loginWindowController.dismiss()
+                    }
+                }
+            }
+            .store(in: &cancellables)
+    }
 
     public func application(_: NSApplication, open urls: [URL]) {
         onChangeOfURLs.send(urls)
+    }
+
+    func presentLoginWindow() {
+        loginWindowController.present()
     }
 }

--- a/app/Sources/TuistMenuBar/Authentication/LoginWindowController.swift
+++ b/app/Sources/TuistMenuBar/Authentication/LoginWindowController.swift
@@ -1,0 +1,43 @@
+import AppKit
+import SwiftUI
+import TuistAuthentication
+
+@MainActor
+final class LoginWindowController: NSWindowController {
+    init(
+        authenticationService: AuthenticationService,
+        errorHandling: ErrorHandling
+    ) {
+        let contentView = MacLogInView()
+            .environmentObject(authenticationService)
+            .environmentObject(errorHandling)
+        let hostingController = NSHostingController(rootView: contentView)
+        let window = NSWindow(contentViewController: hostingController)
+        window.title = "Tuist"
+        window.titleVisibility = .hidden
+        window.titlebarAppearsTransparent = true
+        window.styleMask = [.titled, .closable, .miniaturizable, .fullSizeContentView]
+        window.setContentSize(NSSize(width: 480, height: 680))
+        window.isReleasedWhenClosed = false
+        window.collectionBehavior = [.moveToActiveSpace]
+        window.center()
+        authenticationService.setPresentationAnchor(window)
+
+        super.init(window: window)
+    }
+
+    @available(*, unavailable)
+    required init?(coder _: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func present() {
+        showWindow(nil)
+        window?.makeKeyAndOrderFront(nil)
+        NSApplication.shared.activate(ignoringOtherApps: true)
+    }
+
+    func dismiss() {
+        window?.orderOut(nil)
+    }
+}

--- a/app/Sources/TuistMenuBar/Authentication/MacLogInView.swift
+++ b/app/Sources/TuistMenuBar/Authentication/MacLogInView.swift
@@ -1,0 +1,274 @@
+import AppKit
+import AuthenticationServices
+import SwiftUI
+import TuistAuthentication
+
+struct MacLogInView: View {
+    @EnvironmentObject private var authenticationService: AuthenticationService
+    @EnvironmentObject private var errorHandling: ErrorHandling
+    @State private var appleSignInDelegate: MacAppleSignInDelegate?
+    @State private var isServerSettingsPresented = false
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Spacer(minLength: 64)
+
+            Image("TuistRoundedIcon")
+                .resizable()
+                .frame(width: 68, height: 68)
+                .padding(.bottom, 24)
+
+            Text("Welcome to Tuist")
+                .font(.system(size: 30, weight: .medium))
+                .foregroundStyle(.primary)
+                .padding(.bottom, 12)
+
+            Text("Sign in to access your projects and\ncollaborate with your team")
+                .font(.system(size: 15))
+                .multilineTextAlignment(.center)
+                .foregroundStyle(.secondary)
+
+            Spacer(minLength: 52)
+
+            VStack(spacing: 12) {
+                serverButton
+
+                MacSocialButton(
+                    title: "Sign in with Tuist",
+                    style: .primary,
+                    icon: "TuistLogo"
+                ) {
+                    errorHandling.fireAndHandleError {
+                        try await authenticationService.signIn()
+                    }
+                }
+
+                MacSocialButton(
+                    title: "Sign in with Apple",
+                    style: .secondary,
+                    icon: "AppleLogo"
+                ) {
+                    signInWithApple()
+                }
+
+                MacSocialButton(
+                    title: "Sign in with Google",
+                    style: .secondary,
+                    icon: "GoogleLogo"
+                ) {
+                    errorHandling.fireAndHandleError {
+                        try await authenticationService.signInWithGoogle()
+                    }
+                }
+
+                MacSocialButton(
+                    title: "Sign in with GitHub",
+                    style: .secondary,
+                    icon: "GitHubLogo"
+                ) {
+                    errorHandling.fireAndHandleError {
+                        try await authenticationService.signInWithGitHub()
+                    }
+                }
+            }
+            .padding(.horizontal, 44)
+            .padding(.top, 28)
+            .padding(.bottom, 32)
+            .frame(maxWidth: .infinity)
+            .background(
+                UnevenRoundedRectangle(
+                    topLeadingRadius: 32,
+                    bottomLeadingRadius: 0,
+                    bottomTrailingRadius: 0,
+                    topTrailingRadius: 32
+                )
+                .fill(.ultraThinMaterial)
+                .overlay {
+                    UnevenRoundedRectangle(
+                        topLeadingRadius: 32,
+                        bottomLeadingRadius: 0,
+                        bottomTrailingRadius: 0,
+                        topTrailingRadius: 32
+                    )
+                    .stroke(.white.opacity(0.35), lineWidth: 1)
+                }
+            )
+        }
+        .frame(width: 480, height: 680)
+        .background {
+            Image("LaunchScreenBackground")
+                .resizable()
+                .aspectRatio(contentMode: .fill)
+                .ignoresSafeArea()
+        }
+        .sheet(isPresented: $isServerSettingsPresented) {
+            ServerSettingsView(authenticationService: authenticationService)
+        }
+    }
+
+    private var serverButton: some View {
+        Button {
+            isServerSettingsPresented = true
+        } label: {
+            HStack(spacing: 12) {
+                Image(systemName: "server.rack")
+                    .font(.system(size: 15))
+                    .foregroundStyle(.secondary)
+
+                VStack(alignment: .leading, spacing: 3) {
+                    Text("Server")
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundStyle(.primary)
+                    Text(authenticationService.serverURL.absoluteString)
+                        .font(.system(size: 12))
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                        .foregroundStyle(.secondary)
+                }
+
+                Spacer()
+
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(.secondary)
+            }
+            .padding(.vertical, 12)
+            .padding(.horizontal, 16)
+            .background(.regularMaterial)
+            .clipShape(RoundedRectangle(cornerRadius: 8))
+            .overlay {
+                RoundedRectangle(cornerRadius: 8)
+                    .stroke(.primary.opacity(0.08), lineWidth: 1)
+            }
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func signInWithApple() {
+        let request = ASAuthorizationAppleIDProvider().createRequest()
+        request.requestedScopes = [.fullName, .email]
+
+        let controller = ASAuthorizationController(authorizationRequests: [request])
+        appleSignInDelegate = MacAppleSignInDelegate(
+            authenticationService: authenticationService,
+            errorHandling: errorHandling
+        )
+        controller.delegate = appleSignInDelegate
+        controller.presentationContextProvider = appleSignInDelegate
+        controller.performRequests()
+    }
+}
+
+private struct MacSocialButton: View {
+    enum Style {
+        case primary
+        case secondary
+    }
+
+    @Environment(\.colorScheme) private var colorScheme
+    let title: String
+    let style: Style
+    let icon: String
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 6) {
+                Image(icon)
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(width: 20, height: 20)
+
+                Text(title)
+                    .font(.system(size: 15, weight: .medium))
+                    .padding(.horizontal, 8)
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 12)
+            .background(background)
+            .foregroundStyle(foregroundColor)
+            .clipShape(RoundedRectangle(cornerRadius: 8))
+            .overlay {
+                RoundedRectangle(cornerRadius: 8)
+                    .stroke(borderColor, lineWidth: 1)
+            }
+            .shadow(color: .black.opacity(0.08), radius: 2, y: 1)
+        }
+        .buttonStyle(.plain)
+    }
+
+    @ViewBuilder
+    private var background: some View {
+        switch style {
+        case .primary:
+            ZStack {
+                Color(red: 102 / 255, green: 27 / 255, blue: 1)
+                LinearGradient(
+                    colors: [.white.opacity(0.16), .clear],
+                    startPoint: .top,
+                    endPoint: .bottom
+                )
+            }
+        case .secondary:
+            ZStack {
+                colorScheme == .dark ? Color(white: 0.12) : .white
+                LinearGradient(
+                    colors: [.clear, .gray.opacity(0.06)],
+                    startPoint: .top,
+                    endPoint: .bottom
+                )
+            }
+        }
+    }
+
+    private var foregroundColor: Color {
+        switch style {
+        case .primary:
+            return .white
+        case .secondary:
+            return .primary
+        }
+    }
+
+    private var borderColor: Color {
+        switch style {
+        case .primary:
+            return Color(red: 95 / 255, green: 1 / 255, blue: 229 / 255).opacity(0.9)
+        case .secondary:
+            return .primary.opacity(0.1)
+        }
+    }
+}
+
+@MainActor
+private final class MacAppleSignInDelegate: NSObject, ASAuthorizationControllerDelegate,
+    ASAuthorizationControllerPresentationContextProviding
+{
+    private let authenticationService: AuthenticationService
+    private let errorHandling: ErrorHandling
+
+    init(
+        authenticationService: AuthenticationService,
+        errorHandling: ErrorHandling
+    ) {
+        self.authenticationService = authenticationService
+        self.errorHandling = errorHandling
+    }
+
+    func authorizationController(
+        controller _: ASAuthorizationController,
+        didCompleteWithAuthorization authorization: ASAuthorization
+    ) {
+        errorHandling.fireAndHandleError {
+            try await self.authenticationService.signInWithApple(authorization: authorization)
+        }
+    }
+
+    func authorizationController(controller _: ASAuthorizationController, didCompleteWithError error: Error) {
+        errorHandling.handle(error: error)
+    }
+
+    func presentationAnchor(for _: ASAuthorizationController) -> ASPresentationAnchor {
+        return NSApplication.shared.keyWindow ?? NSApplication.shared.windows.first(where: \.isVisible) ?? NSWindow()
+    }
+}

--- a/app/Sources/TuistMenuBar/Utilities/ErrorHandling.swift
+++ b/app/Sources/TuistMenuBar/Utilities/ErrorHandling.swift
@@ -1,26 +1,38 @@
 import AppKit
 import Foundation
 import OpenAPIRuntime
+import TuistAuthentication
 import TuistHTTP
 import TuistLogging
 import TuistServer
 import TuistSupport
 
 final class ErrorHandling: ObservableObject, Sendable {
-    func handle(error: Error) {
-        let handle = handle
+    private let credentialsStore: ServerCredentialsStoring
+
+    init(credentialsStore: ServerCredentialsStoring = ServerCredentialsStore.current) {
+        self.credentialsStore = credentialsStore
+    }
+
+    func handle(error: Error, serverURL: URL? = nil) {
         DispatchQueue.main.async {
             let alert = NSAlert()
             if let error = error as? FatalError {
                 alert.messageText = error.description
             } else if error is ClientAuthenticationError {
                 // When we fail to authenticate, we sign out the user and force them to sign in again.
+                guard let serverURL else {
+                    alert.messageText = error.localizedDescription
+                    alert.alertStyle = .warning
+                    alert.runModal()
+                    return
+                }
                 Task {
-                    try await ServerCredentialsStore.current.delete(serverURL: ServerEnvironmentService().url())
+                    try await self.credentialsStore.delete(serverURL: serverURL)
                 }
                 return
             } else if let error = error as? ClientError {
-                handle(error.underlyingError)
+                self.handle(error: error.underlyingError, serverURL: serverURL)
                 return
             } else {
                 alert.messageText = error.localizedDescription
@@ -33,11 +45,14 @@ final class ErrorHandling: ObservableObject, Sendable {
 
 extension ErrorHandling {
     func fireAndHandleError(_ action: @escaping () async throws -> Void) {
+        let serverURL = AppServerEnvironmentService().url()
         Task {
             do {
-                try await action()
+                try await ServerCredentialsStore.$current.withValue(credentialsStore) {
+                    try await action()
+                }
             } catch {
-                handle(error: error)
+                handle(error: error, serverURL: serverURL)
             }
         }
     }

--- a/app/Sources/TuistMenuBar/Views/AppPreviews/AppPreviewsViewModel.swift
+++ b/app/Sources/TuistMenuBar/Views/AppPreviews/AppPreviewsViewModel.swift
@@ -6,8 +6,18 @@ import TuistServer
 import TuistSimulator
 import TuistSupport
 
+struct AppPreviewsCache: Codable, Equatable {
+    let serverURL: URL
+    let appPreviews: [AppPreview]
+}
+
 struct AppPreviewsKey: AppStorageKey {
     static let key = "appPreviews"
+    static let defaultValue: AppPreviewsCache? = nil
+}
+
+struct LegacyAppPreviewsKey: AppStorageKey {
+    static let key = AppPreviewsKey.key
     static let defaultValue: [AppPreview] = []
 }
 
@@ -34,13 +44,17 @@ enum AppPreviewsModelError: FatalError, Equatable {
 final class AppPreviewsViewModel: Sendable {
     private(set) var appPreviews: [AppPreview] = [] {
         didSet {
-            try? appStorage.set(AppPreviewsKey.self, value: appPreviews)
+            try? appStorage.set(
+                AppPreviewsKey.self,
+                value: AppPreviewsCache(serverURL: serverURL, appPreviews: appPreviews)
+            )
         }
     }
 
     private let listProjectsService: ListProjectsServicing
     private let listPreviewsService: ListPreviewsServicing
-    private let serverEnvironmentService: ServerEnvironmentServicing
+    private let serverURL: URL
+    private let isDefaultServerURL: Bool
     private let deviceService: any DeviceServicing
     private let appStorage: AppStoring
 
@@ -48,18 +62,36 @@ final class AppPreviewsViewModel: Sendable {
         deviceService: any DeviceServicing,
         listProjectsService: ListProjectsServicing = ListProjectsService(),
         listPreviewsService: ListPreviewsServicing = ListPreviewsService(),
-        serverEnvironmentService: ServerEnvironmentServicing = ServerEnvironmentService(),
+        serverEnvironmentService: ServerEnvironmentServicing = AppServerEnvironmentService(),
         appStorage: AppStoring = AppStorage()
     ) {
         self.deviceService = deviceService
         self.listProjectsService = listProjectsService
         self.listPreviewsService = listPreviewsService
-        self.serverEnvironmentService = serverEnvironmentService
+        serverURL = serverEnvironmentService.url()
+        let defaultServerURL = (serverEnvironmentService as? AppServerEnvironmentConfiguring)?.defaultURL() ??
+            ServerEnvironmentService().url()
+        isDefaultServerURL = Self.normalizedURLString(serverURL) == Self.normalizedURLString(defaultServerURL)
         self.appStorage = appStorage
     }
 
     func loadAppPreviewsFromCache() {
-        appPreviews = (try? appStorage.get(AppPreviewsKey.self)) ?? []
+        do {
+            let cache = try appStorage.get(AppPreviewsKey.self)
+            guard let cache,
+                  Self.normalizedURLString(cache.serverURL) == Self.normalizedURLString(serverURL)
+            else {
+                appPreviews = []
+                return
+            }
+            appPreviews = cache.appPreviews
+        } catch {
+            guard isDefaultServerURL else {
+                appPreviews = []
+                return
+            }
+            appPreviews = (try? appStorage.get(LegacyAppPreviewsKey.self)) ?? []
+        }
     }
 
     func onAppear() async throws {
@@ -67,7 +99,6 @@ final class AppPreviewsViewModel: Sendable {
     }
 
     private func updatePreviews() async throws {
-        let serverURL = serverEnvironmentService.url()
         let projects = try await listProjectsService.listProjects(serverURL: serverURL)
         let listPreviewsService = listPreviewsService
         appPreviews = try await projects.concurrentMap { project in
@@ -79,7 +110,7 @@ final class AppPreviewsViewModel: Sendable {
                 pageSize: nil,
                 distinctField: .bundleIdentifier,
                 fullHandle: project.fullName,
-                serverURL: serverURL
+                serverURL: self.serverURL
             )
             .previews
             .compactMap { preview in
@@ -98,6 +129,11 @@ final class AppPreviewsViewModel: Sendable {
         .sorted(by: { $0.displayName < $1.displayName })
     }
 
+    private static func normalizedURLString(_ url: URL) -> String {
+        return (try? AppServerEnvironmentService.normalizedURL(from: url.absoluteString).absoluteString) ??
+            url.absoluteString
+    }
+
     private static func preferredPlatformName(from platforms: [DestinationType]) -> String? {
         for platform in platforms {
             switch platform {
@@ -111,8 +147,6 @@ final class AppPreviewsViewModel: Sendable {
     }
 
     func launchAppPreview(_ appPreview: AppPreview) async throws {
-        let serverURL = serverEnvironmentService.url()
-
         let previews = try await listPreviewsService.listPreviews(
             displayName: nil,
             specifier: "latest",

--- a/app/Sources/TuistMenuBar/Views/MenuBarLoginView.swift
+++ b/app/Sources/TuistMenuBar/Views/MenuBarLoginView.swift
@@ -1,50 +1,36 @@
 import SwiftUI
-import TuistAuthentication
 
 struct MenuBarLoginView: View {
-    @EnvironmentObject var errorHandling: ErrorHandling
-    @EnvironmentObject var authenticationService: AuthenticationService
+    let openLoginWindow: () -> Void
 
     var body: some View {
-        VStack(alignment: .center, spacing: 0) {
-            HStack {
-                Spacer()
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(spacing: 10) {
                 Image("TuistIcon")
                     .resizable()
                     .aspectRatio(contentMode: .fit)
-                    .frame(width: 50, height: 50)
-                Spacer()
-            }
-            .padding(.top, 20)
-            .padding(.bottom, 16)
+                    .frame(width: 36, height: 36)
 
-            Text("Welcome to Tuist")
-                .font(.title2)
-                .fontWeight(.medium)
-                .padding(.bottom, 6)
-
-            Text("Sign in to run previews")
-                .font(.caption)
-                .foregroundColor(.secondary)
-                .multilineTextAlignment(.center)
-                .padding(.bottom, 16)
-
-            Button(action: {
-                errorHandling.fireAndHandleError {
-                    try await authenticationService.signIn()
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Welcome to Tuist")
+                        .font(.headline)
+                    Text("Sign in to run previews")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
                 }
-            }) {
+            }
+
+            Button(action: openLoginWindow) {
                 Text("Sign in")
-                    .frame(width: 168)
-                    .padding(.vertical, 6)
-                    .padding(.horizontal, 42)
-                    .background(Color(red: 111 / 255, green: 44 / 255, blue: 1.0))
-                    .foregroundColor(.white)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 7)
+                    .background(Color(red: 111 / 255, green: 44 / 255, blue: 1))
+                    .foregroundStyle(.white)
                     .cornerRadius(6)
             }
             .buttonStyle(.plain)
-            .padding(.bottom, 16)
-            .padding(.horizontal, 12)
         }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
     }
 }

--- a/app/Sources/TuistMenuBar/Views/MenuBarView/MenuBarView.swift
+++ b/app/Sources/TuistMenuBar/Views/MenuBarView/MenuBarView.swift
@@ -3,14 +3,16 @@ import Foundation
 import Sparkle
 import SwiftUI
 import TuistAuthentication
+import TuistServer
 
 public struct MenuBarView: View {
     @State var isExpanded = false
     @State var canCheckForUpdates = false
+    @State private var isServerSettingsPresented = false
     private let errorHandling: ErrorHandling
     private let deviceService: DeviceService
-    @StateObject
-    private var authenticationService = AuthenticationService()
+    private let openLoginWindow: () -> Void
+    @ObservedObject private var authenticationService: AuthenticationService
     @State var viewModel: MenuBarViewModel
     private var cancellables = Set<AnyCancellable>()
     private let taskStatusReporter: TaskStatusReporter
@@ -20,6 +22,11 @@ public struct MenuBarView: View {
         appDelegate: AppDelegate,
         updaterController: SPUStandardUpdaterController
     ) {
+        let authenticationService = appDelegate.authenticationService
+        self.authenticationService = authenticationService
+        openLoginWindow = { [weak appDelegate] in
+            appDelegate?.presentLoginWindow()
+        }
         let viewModel = MenuBarViewModel()
         self.viewModel = viewModel
         let taskStatusRepoter = TaskStatusReporter()
@@ -30,7 +37,8 @@ public struct MenuBarView: View {
         )
         self.deviceService = deviceService
 
-        let errorHandling = ErrorHandling()
+        let credentialsStore = appDelegate.credentialsStore
+        let errorHandling = appDelegate.errorHandling
         self.errorHandling = errorHandling
 
         // We can't rely on SwiftUI views to be rendered before a deeplink is triggered.
@@ -38,11 +46,18 @@ public struct MenuBarView: View {
         // that's eagerly set up in this `init` on startup.
         appDelegate.onChangeOfURLs.sink { urls in
             guard let url = urls.first else { return }
+            let serverURL = URLComponents(url: url, resolvingAgainstBaseURL: false)?
+                .queryItems?
+                .first(where: { $0.name == "server_url" })?
+                .value
+                .flatMap { URL(string: $0) }
             Task {
                 do {
-                    try await deviceService.launchPreviewDeeplink(with: url)
+                    try await ServerCredentialsStore.$current.withValue(credentialsStore) {
+                        try await deviceService.launchPreviewDeeplink(with: url)
+                    }
                 } catch {
-                    errorHandling.handle(error: error)
+                    errorHandling.handle(error: error, serverURL: serverURL)
                 }
             }
         }
@@ -68,7 +83,7 @@ public struct MenuBarView: View {
     public var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             switch authenticationService.authenticationState {
-            case let .loggedIn(account):
+            case let .loggedIn(account, serverURL):
                 MenuHeader(
                     accountHandle: account.handle
                 )
@@ -78,6 +93,7 @@ public struct MenuBarView: View {
                         deviceService: deviceService
                     )
                 )
+                .id(serverURL)
                 .padding(.horizontal, 8)
                 .padding(.top, 4)
                 .padding(.bottom, 8)
@@ -86,7 +102,7 @@ public struct MenuBarView: View {
                     viewModel: DevicesViewModel(deviceService: deviceService)
                 )
             case .loggedOut:
-                MenuBarLoginView()
+                MenuBarLoginView(openLoginWindow: openLoginWindow)
             }
 
             Divider()
@@ -104,6 +120,13 @@ public struct MenuBarView: View {
                     .menuItemStyle()
                     .padding(.horizontal, 8)
                 }
+
+                Button("Server: \(serverDisplayName)") {
+                    isServerSettingsPresented = true
+                }
+                .padding(.vertical, 2)
+                .menuItemStyle()
+                .padding(.horizontal, 8)
 
                 Button("Check for updates", action: {
                     updater.checkForUpdates()
@@ -126,5 +149,18 @@ public struct MenuBarView: View {
         .environmentObject(deviceService)
         .environmentObject(taskStatusReporter)
         .environmentObject(authenticationService)
+        .sheet(isPresented: $isServerSettingsPresented) {
+            ServerSettingsView(authenticationService: authenticationService)
+        }
+    }
+
+    private var serverDisplayName: String {
+        guard let host = authenticationService.serverURL.host() else {
+            return authenticationService.serverURL.absoluteString
+        }
+        if let port = authenticationService.serverURL.port {
+            return "\(host):\(port)"
+        }
+        return host
     }
 }

--- a/app/Sources/TuistOnboarding/LogInView.swift
+++ b/app/Sources/TuistOnboarding/LogInView.swift
@@ -9,6 +9,7 @@ public struct LogInView: View {
     @EnvironmentObject private var authenticationService: AuthenticationService
     @Environment(\.colorScheme) private var colorScheme
     @State private var appleSignInDelegate: AppleSignInDelegate?
+    @State private var isServerSettingsPresented = false
 
     public init() {}
 
@@ -35,6 +36,38 @@ public struct LogInView: View {
             Spacer()
 
             VStack(spacing: Noora.Spacing.spacing5) {
+                Button {
+                    isServerSettingsPresented = true
+                } label: {
+                    HStack(spacing: Noora.Spacing.spacing3) {
+                        Image(systemName: "server.rack")
+                            .font(.body)
+                            .foregroundColor(Noora.Colors.surfaceLabelSecondary)
+
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("Server")
+                                .font(.caption.weight(.medium))
+                                .foregroundColor(Noora.Colors.surfaceLabelPrimary)
+                            Text(authenticationService.serverURL.absoluteString)
+                                .font(.caption)
+                                .lineLimit(1)
+                                .truncationMode(.middle)
+                                .foregroundColor(Noora.Colors.surfaceLabelSecondary)
+                        }
+
+                        Spacer()
+
+                        Image(systemName: "chevron.right")
+                            .font(.caption.weight(.semibold))
+                            .foregroundColor(Noora.Colors.surfaceLabelSecondary)
+                    }
+                    .padding(.vertical, Noora.Spacing.spacing4)
+                    .padding(.horizontal, Noora.Spacing.spacing5)
+                    .background(Color(light: .white.opacity(0.7), dark: Color(hex: 0x181818)))
+                    .clipShape(RoundedRectangle(cornerRadius: 8))
+                }
+                .buttonStyle(.plain)
+
                 SocialButton(
                     title: "Sign in with Tuist",
                     style: .primary,
@@ -107,6 +140,9 @@ public struct LogInView: View {
                 .aspectRatio(contentMode: .fill)
                 .ignoresSafeArea()
         )
+        .sheet(isPresented: $isServerSettingsPresented) {
+            ServerSettingsView(authenticationService: authenticationService)
+        }
     }
 }
 

--- a/app/Sources/TuistPreviews/PreviewView/PreviewViewModel.swift
+++ b/app/Sources/TuistPreviews/PreviewView/PreviewViewModel.swift
@@ -1,11 +1,12 @@
 import Foundation
 import SwiftUI
+import TuistAuthentication
 import TuistServer
 
 @Observable
 final class PreviewViewModel: Sendable {
     private let deletePreviewService: DeletePreviewServicing
-    private let serverEnvironmentService: ServerEnvironmentServicing
+    private let serverURL: URL
     private let getPreviewService: GetPreviewServicing
 
     private(set) var preview: ServerPreview?
@@ -43,7 +44,7 @@ final class PreviewViewModel: Sendable {
         isLoading _: Bool,
         fullHandle: String,
         deletePreviewService: DeletePreviewServicing = DeletePreviewService(),
-        serverEnvironmentService: ServerEnvironmentServicing = ServerEnvironmentService(),
+        serverEnvironmentService: ServerEnvironmentServicing = AppServerEnvironmentService(),
         getPreviewService: GetPreviewServicing = GetPreviewService()
     ) {
         self.preview = preview
@@ -51,7 +52,7 @@ final class PreviewViewModel: Sendable {
         isLoading = false
         self.fullHandle = fullHandle
         self.deletePreviewService = deletePreviewService
-        self.serverEnvironmentService = serverEnvironmentService
+        serverURL = serverEnvironmentService.url()
         self.getPreviewService = getPreviewService
     }
 
@@ -64,7 +65,7 @@ final class PreviewViewModel: Sendable {
             getPreviewService.getPreview(
                 previewId,
                 fullHandle: fullHandle,
-                serverURL: serverEnvironmentService.url()
+                serverURL: serverURL
             )
         )
     }
@@ -73,7 +74,7 @@ final class PreviewViewModel: Sendable {
         try await deletePreviewService.deletePreview(
             preview.id,
             fullHandle: fullHandle,
-            serverURL: serverEnvironmentService.url()
+            serverURL: serverURL
         )
     }
 }

--- a/app/Sources/TuistPreviews/PreviewsView/PreviewsViewModel.swift
+++ b/app/Sources/TuistPreviews/PreviewsView/PreviewsViewModel.swift
@@ -1,10 +1,21 @@
 import Foundation
 import SwiftUI
 import TuistAppStorage
+import TuistAuthentication
 import TuistServer
+
+struct SelectedProjectCache: Codable, Equatable {
+    let serverURL: URL
+    let fullHandle: String
+}
 
 struct SelectedProjectFullHandleKey: AppStorageKey {
     static let key = "selectedProjectFullHandle"
+    static let defaultValue: SelectedProjectCache? = nil
+}
+
+private struct LegacySelectedProjectFullHandleKey: AppStorageKey {
+    static let key = SelectedProjectFullHandleKey.key
     static let defaultValue: String? = nil
 }
 
@@ -12,7 +23,8 @@ struct SelectedProjectFullHandleKey: AppStorageKey {
 final class PreviewsViewModel: Sendable {
     private let listProjectsService: ListProjectsServicing
     private let listPreviewsService: ListPreviewsServicing
-    private let serverEnvironmentService: ServerEnvironmentServicing
+    private let serverURL: URL
+    private let isDefaultServerURL: Bool
     private let appStorage: AppStoring
 
     private(set) var projects: [ServerProject] = []
@@ -29,12 +41,15 @@ final class PreviewsViewModel: Sendable {
     init(
         listProjectsService: ListProjectsServicing = ListProjectsService(),
         listPreviewsService: ListPreviewsServicing = ListPreviewsService(),
-        serverEnvironmentService: ServerEnvironmentServicing = ServerEnvironmentService(),
+        serverEnvironmentService: ServerEnvironmentServicing = AppServerEnvironmentService(),
         appStorage: AppStoring = AppStorage()
     ) {
         self.listProjectsService = listProjectsService
         self.listPreviewsService = listPreviewsService
-        self.serverEnvironmentService = serverEnvironmentService
+        serverURL = serverEnvironmentService.url()
+        let defaultServerURL = (serverEnvironmentService as? AppServerEnvironmentConfiguring)?.defaultURL() ??
+            ServerEnvironmentService().url()
+        isDefaultServerURL = Self.normalizedURLString(serverURL) == Self.normalizedURLString(defaultServerURL)
         self.appStorage = appStorage
     }
 
@@ -50,7 +65,10 @@ final class PreviewsViewModel: Sendable {
 
     func selectProject(_ project: ServerProject) async throws {
         selectedProject = project
-        try? appStorage.set(SelectedProjectFullHandleKey.self, value: selectedProject?.fullName)
+        try? appStorage.set(
+            SelectedProjectFullHandleKey.self,
+            value: SelectedProjectCache(serverURL: serverURL, fullHandle: project.fullName)
+        )
         try await loadPreviews(for: project)
     }
 
@@ -127,9 +145,9 @@ final class PreviewsViewModel: Sendable {
     }
 
     private func loadProjects() async throws {
-        projects = try await listProjectsService.listProjects(serverURL: serverEnvironmentService.url())
+        projects = try await listProjectsService.listProjects(serverURL: serverURL)
 
-        if let selectedProjectFullHandle = try? appStorage.get(SelectedProjectFullHandleKey.self),
+        if let selectedProjectFullHandle = storedSelectedProjectFullHandle(),
            let storedProject = projects.first(where: { $0.fullName == selectedProjectFullHandle })
         {
             selectedProject = storedProject
@@ -149,7 +167,7 @@ final class PreviewsViewModel: Sendable {
             pageSize: 20,
             distinctField: nil,
             fullHandle: project.fullName,
-            serverURL: serverEnvironmentService.url()
+            serverURL: serverURL
         )
 
         if previewsPage.paginationMetadata.currentPage == 1 {
@@ -160,5 +178,32 @@ final class PreviewsViewModel: Sendable {
 
         currentPage = previewsPage.paginationMetadata.currentPage ?? 1
         hasMorePreviews = previewsPage.paginationMetadata.hasNextPage
+    }
+
+    private func storedSelectedProjectFullHandle() -> String? {
+        do {
+            guard let selectedProject = try appStorage.get(SelectedProjectFullHandleKey.self),
+                  Self.normalizedURLString(selectedProject.serverURL) == Self.normalizedURLString(serverURL)
+            else {
+                return nil
+            }
+            return selectedProject.fullHandle
+        } catch {
+            guard isDefaultServerURL,
+                  let fullHandle = try? appStorage.get(LegacySelectedProjectFullHandleKey.self)
+            else {
+                return nil
+            }
+            try? appStorage.set(
+                SelectedProjectFullHandleKey.self,
+                value: SelectedProjectCache(serverURL: serverURL, fullHandle: fullHandle)
+            )
+            return fullHandle
+        }
+    }
+
+    private static func normalizedURLString(_ url: URL) -> String {
+        return (try? AppServerEnvironmentService.normalizedURL(from: url.absoluteString).absoluteString) ??
+            url.absoluteString
     }
 }

--- a/app/Sources/TuistProfile/ProfileView.swift
+++ b/app/Sources/TuistProfile/ProfileView.swift
@@ -10,6 +10,7 @@ public struct ProfileView: View {
     @EnvironmentObject private var authenticationService: AuthenticationService
     private let deleteAccountService: DeleteAccountServicing = DeleteAccountService()
     @State private var showDeleteConfirmation = false
+    @State private var isServerSettingsPresented = false
 
     private let account: Account
 
@@ -44,6 +45,27 @@ public struct ProfileView: View {
                     Text(account.email)
                         .font(.body)
                         .foregroundColor(Noora.Colors.surfaceLabelSecondary)
+                }
+            }
+
+            Section {
+                Button {
+                    isServerSettingsPresented = true
+                } label: {
+                    HStack {
+                        Text("Server")
+                            .font(.body)
+                            .foregroundColor(Noora.Colors.surfaceLabelPrimary)
+                        Spacer()
+                        Text(authenticationService.serverURL.absoluteString)
+                            .font(.body)
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                            .foregroundColor(Noora.Colors.surfaceLabelSecondary)
+                        Image(systemName: "chevron.right")
+                            .font(.footnote.weight(.semibold))
+                            .foregroundColor(Noora.Colors.surfaceLabelSecondary)
+                    }
                 }
             }
 
@@ -112,6 +134,9 @@ public struct ProfileView: View {
             }
         } message: {
             Text("Are you sure you want to delete your account? This action cannot be undone.")
+        }
+        .sheet(isPresented: $isServerSettingsPresented) {
+            ServerSettingsView(authenticationService: authenticationService)
         }
     }
 }

--- a/app/Tests/TuistMenuBarTests/Authentication/AuthenticationServiceTests.swift
+++ b/app/Tests/TuistMenuBarTests/Authentication/AuthenticationServiceTests.swift
@@ -1,3 +1,5 @@
+import FileSystem
+import FileSystemTesting
 import Foundation
 import Path
 import Testing
@@ -8,34 +10,54 @@ import TuistServer
 @Suite struct AuthenticationServiceTests {
     private let serverURL = URL(string: "https://tuist.dev")!
 
-    @Test func deleting_credentials_logs_the_user_out() async throws {
-        let store = makeCredentialsStore()
+    @Test(.inTemporaryDirectory) func deleting_credentials_logs_the_user_out() async throws {
+        let store = try makeCredentialsStore()
+        let account = Account(email: "tuist@tuist.dev", handle: "tuist")
+        try await store.store(
+            credentials: makeCredentials(email: account.email, handle: account.handle),
+            serverURL: serverURL
+        )
         let appStorage = TestAppStorage(
-            authenticationState: .loggedIn(account: Account(email: "tuist@tuist.dev", handle: "tuist"))
+            authenticationState: .loggedIn(
+                account: account,
+                serverURL: serverURL
+            )
         )
         let subject = await makeAuthenticationService(
             store: store,
             appStorage: appStorage
         )
+        await subject.refreshAuthenticationStateForActiveServer()
+        #expect(await subject.authenticationState == .loggedIn(account: account, serverURL: serverURL))
 
         try await store.delete(serverURL: serverURL)
         try await waitUntil {
-            subject.authenticationState == .loggedOut
+            await subject.authenticationState == .loggedOut
         }
 
-        #expect(subject.authenticationState == .loggedOut)
+        #expect(await subject.authenticationState == .loggedOut)
         #expect(try appStorage.get(AuthenticationStateKey.self) == .loggedOut)
     }
 
-    @Test func storing_credentials_without_account_claims_logs_the_user_out() async throws {
-        let store = makeCredentialsStore()
+    @Test(.inTemporaryDirectory) func storing_credentials_without_account_claims_logs_the_user_out() async throws {
+        let store = try makeCredentialsStore()
+        let account = Account(email: "tuist@tuist.dev", handle: "tuist")
+        try await store.store(
+            credentials: makeCredentials(email: account.email, handle: account.handle),
+            serverURL: serverURL
+        )
         let appStorage = TestAppStorage(
-            authenticationState: .loggedIn(account: Account(email: "tuist@tuist.dev", handle: "tuist"))
+            authenticationState: .loggedIn(
+                account: account,
+                serverURL: serverURL
+            )
         )
         let subject = await makeAuthenticationService(
             store: store,
             appStorage: appStorage
         )
+        await subject.refreshAuthenticationStateForActiveServer()
+        #expect(await subject.authenticationState == .loggedIn(account: account, serverURL: serverURL))
 
         try await store.store(
             credentials: makeCredentials(
@@ -52,31 +74,45 @@ import TuistServer
         )
 
         try await waitUntil {
-            subject.authenticationState == .loggedOut
+            await subject.authenticationState == .loggedOut
         }
 
-        #expect(subject.authenticationState == .loggedOut)
+        #expect(await subject.authenticationState == .loggedOut)
         #expect(try appStorage.get(AuthenticationStateKey.self) == .loggedOut)
     }
 
-    @Test func separate_store_instances_with_shared_storage_leave_the_original_service_stale() async throws {
-        let sharedConfigDirectory = makeTemporaryDirectory()
-        let rootStore = makeCredentialsStore(configDirectory: sharedConfigDirectory)
-        let loginStore = makeCredentialsStore(configDirectory: sharedConfigDirectory)
+    @Test(.inTemporaryDirectory) func separate_store_instances_with_shared_storage_leave_the_original_service_stale()
+        async throws
+    {
+        let sharedConfigDirectory = try makeTemporaryDirectory()
+        let rootStore = try makeCredentialsStore(configDirectory: sharedConfigDirectory)
+        let loginStore = try makeCredentialsStore(configDirectory: sharedConfigDirectory)
         let rootAppStorage = TestAppStorage(authenticationState: .loggedOut)
         let loginAppStorage = TestAppStorage(authenticationState: .loggedOut)
-        let rootService = await makeAuthenticationService(
-            store: rootStore,
-            appStorage: rootAppStorage
-        )
-        let loginService = await makeAuthenticationService(
-            store: loginStore,
-            appStorage: loginAppStorage
-        )
         let account = Account(email: "tuist@tuist.dev", handle: "tuist")
         let credentials = try makeCredentials(
             email: account.email,
             handle: account.handle
+        )
+        try await rootStore.store(
+            credentials: credentials,
+            serverURL: serverURL
+        )
+        let rootService = await makeAuthenticationService(
+            store: rootStore,
+            appStorage: rootAppStorage
+        )
+        try await waitUntil {
+            await rootService.authenticationState == .loggedIn(account: account, serverURL: serverURL)
+        }
+        try await rootStore.delete(serverURL: serverURL)
+        try await waitUntil {
+            await rootService.authenticationState == .loggedOut
+        }
+
+        let loginService = await makeAuthenticationService(
+            store: loginStore,
+            appStorage: loginAppStorage
         )
 
         try await loginStore.store(
@@ -85,7 +121,7 @@ import TuistServer
         )
 
         try await waitUntil {
-            loginService.authenticationState == .loggedIn(account: account)
+            await loginService.authenticationState == .loggedIn(account: account, serverURL: serverURL)
         }
 
         let storedCredentials = try #require(
@@ -98,32 +134,272 @@ import TuistServer
         }
 
         #expect(storedCredentials == credentials)
-        #expect(loginService.authenticationState == .loggedIn(account: account))
-        #expect(rootService.authenticationState == .loggedOut)
+        #expect(await loginService.authenticationState == .loggedIn(account: account, serverURL: serverURL))
+        #expect(await rootService.authenticationState == .loggedOut)
+    }
+
+    @Test(.inTemporaryDirectory) func updating_the_server_url_restores_credentials_bound_to_that_url() async throws {
+        let customServerURL = URL(string: "https://custom.tuist.dev")!
+        let store = try makeCredentialsStore()
+        let appStorage = TestAppStorage(authenticationState: .loggedOut)
+        let account = Account(email: "custom@tuist.dev", handle: "custom")
+        let credentials = try makeCredentials(
+            email: account.email,
+            handle: account.handle
+        )
+        try await store.store(credentials: credentials, serverURL: customServerURL)
+        let subject = await makeAuthenticationService(
+            store: store,
+            appStorage: appStorage
+        )
+
+        try await subject.updateServerURL(customServerURL.absoluteString)
+        try await waitUntil {
+            await subject.authenticationState == .loggedIn(account: account, serverURL: customServerURL)
+        }
+
+        #expect(await subject.serverURL == customServerURL)
+        #expect(await subject.authenticationState == .loggedIn(account: account, serverURL: customServerURL))
+        #expect(try appStorage.get(AppServerURLKey.self) == customServerURL.absoluteString)
+    }
+
+    @Test(.inTemporaryDirectory) func stored_authentication_state_for_another_server_starts_logged_out() async throws {
+        let customServerURL = URL(string: "https://custom.tuist.dev")!
+        let account = Account(email: "custom@tuist.dev", handle: "custom")
+        let appStorage = TestAppStorage(
+            authenticationState: .loggedIn(account: account, serverURL: customServerURL)
+        )
+        let store = try makeCredentialsStore()
+
+        let subject = await makeAuthenticationService(
+            store: store,
+            appStorage: appStorage
+        )
+
+        #expect(await subject.authenticationState == .loggedOut)
+    }
+
+    @Test(.inTemporaryDirectory) func resetting_the_server_url_restores_default_server_credentials() async throws {
+        let customServerURL = URL(string: "https://custom.tuist.dev")!
+        let defaultAccount = Account(email: "default@tuist.dev", handle: "default")
+        let customAccount = Account(email: "custom@tuist.dev", handle: "custom")
+        let store = try makeCredentialsStore()
+        try await store.store(
+            credentials: makeCredentials(email: defaultAccount.email, handle: defaultAccount.handle),
+            serverURL: serverURL
+        )
+        try await store.store(
+            credentials: makeCredentials(email: customAccount.email, handle: customAccount.handle),
+            serverURL: customServerURL
+        )
+        let appStorage = TestAppStorage(
+            authenticationState: .loggedOut,
+            serverURLString: customServerURL.absoluteString
+        )
+        let subject = await makeAuthenticationService(store: store, appStorage: appStorage)
+        await subject.refreshAuthenticationStateForActiveServer()
+
+        try await subject.resetServerURL()
+        try await waitUntil {
+            await subject.authenticationState == .loggedIn(account: defaultAccount, serverURL: serverURL)
+        }
+
+        #expect(await subject.serverURL == serverURL)
+        #expect(await subject.authenticationState == .loggedIn(account: defaultAccount, serverURL: serverURL))
+        #expect(try appStorage.get(AppServerURLKey.self) == nil)
+    }
+
+    @Test(.inTemporaryDirectory) func signing_out_removes_only_the_active_server_credentials() async throws {
+        let customServerURL = URL(string: "https://custom.tuist.dev")!
+        let defaultCredentials = try makeCredentials(email: "default@tuist.dev", handle: "default")
+        let customCredentials = try makeCredentials(email: "custom@tuist.dev", handle: "custom")
+        let store = try makeCredentialsStore()
+        try await store.store(credentials: defaultCredentials, serverURL: serverURL)
+        try await store.store(credentials: customCredentials, serverURL: customServerURL)
+        let appStorage = TestAppStorage(
+            authenticationState: .loggedOut,
+            serverURLString: customServerURL.absoluteString
+        )
+        let subject = await makeAuthenticationService(store: store, appStorage: appStorage)
+        await subject.refreshAuthenticationStateForActiveServer()
+
+        await subject.signOut()
+
+        #expect(try await store.read(serverURL: customServerURL) == nil)
+        #expect(try await store.read(serverURL: serverURL) == defaultCredentials)
+        #expect(await subject.authenticationState == .loggedOut)
+    }
+
+    @Test(.timeLimit(.minutes(1))) func stale_refresh_does_not_restore_credentials_after_sign_out() async throws {
+        let account = Account(email: "tuist@tuist.dev", handle: "tuist")
+        let store = SuspendingReadCredentialsStore(
+            credentials: try makeCredentials(email: account.email, handle: account.handle),
+            notifiesWhenDeleting: false
+        )
+        let appStorage = TestAppStorage(authenticationState: .loggedOut)
+        let subject = await makeAuthenticationService(store: store, appStorage: appStorage)
+        try await waitUntil {
+            await subject.authenticationState == .loggedIn(account: account, serverURL: serverURL)
+        }
+
+        await store.suspendNextRead()
+        let refreshTask = Task {
+            await subject.refreshAuthenticationStateForActiveServer()
+        }
+        try await waitUntil {
+            await store.readIsSuspended()
+        }
+
+        await subject.signOut()
+        await store.resumeSuspendedRead()
+        await refreshTask.value
+
+        #expect(await subject.authenticationState == .loggedOut)
+        #expect(try appStorage.get(AuthenticationStateKey.self) == .loggedOut)
+    }
+
+    @Test(.timeLimit(.minutes(1))) func credential_change_invalidates_a_suspended_refresh() async throws {
+        let account = Account(email: "tuist@tuist.dev", handle: "tuist")
+        let store = SuspendingReadCredentialsStore(
+            credentials: try makeCredentials(email: account.email, handle: account.handle),
+            notifiesWhenDeleting: true
+        )
+        let appStorage = TestAppStorage(authenticationState: .loggedOut)
+        let subject = await makeAuthenticationService(store: store, appStorage: appStorage)
+        try await waitUntil {
+            await subject.authenticationState == .loggedIn(account: account, serverURL: serverURL)
+        }
+
+        await store.suspendNextRead()
+        let refreshTask = Task {
+            await subject.refreshAuthenticationStateForActiveServer()
+        }
+        try await waitUntil {
+            await store.readIsSuspended()
+        }
+
+        await store.delete(serverURL: serverURL)
+        try await waitUntil {
+            await subject.authenticationState == .loggedOut
+        }
+        await store.resumeSuspendedRead()
+        await refreshTask.value
+
+        #expect(await subject.authenticationState == .loggedOut)
+        #expect(try appStorage.get(AuthenticationStateKey.self) == .loggedOut)
+    }
+
+    @Test(.inTemporaryDirectory, .timeLimit(.minutes(1)))
+    func deleting_an_account_does_not_sign_out_a_newly_selected_server() async throws {
+        let customServerURL = URL(string: "https://custom.tuist.dev")!
+        let defaultAccount = Account(email: "default@tuist.dev", handle: "default")
+        let customAccount = Account(email: "custom@tuist.dev", handle: "custom")
+        let defaultCredentials = try makeCredentials(email: defaultAccount.email, handle: defaultAccount.handle)
+        let customCredentials = try makeCredentials(email: customAccount.email, handle: customAccount.handle)
+        let store = try makeCredentialsStore()
+        try await store.store(credentials: defaultCredentials, serverURL: serverURL)
+        try await store.store(credentials: customCredentials, serverURL: customServerURL)
+        let deleteAccountService = SuspendingDeleteAccountService()
+        let appStorage = TestAppStorage(authenticationState: .loggedOut)
+        let subject = await makeAuthenticationService(
+            store: store,
+            appStorage: appStorage,
+            deleteAccountService: deleteAccountService
+        )
+        await subject.refreshAuthenticationStateForActiveServer()
+
+        let deletionTask = Task {
+            try await subject.deleteAccount(defaultAccount)
+        }
+        try await waitUntil {
+            await deleteAccountService.deletionHasStarted()
+        }
+        try await subject.updateServerURL(customServerURL.absoluteString)
+        try await waitUntil {
+            await subject.authenticationState == .loggedIn(account: customAccount, serverURL: customServerURL)
+        }
+        await deleteAccountService.completeDeletion()
+        try await deletionTask.value
+
+        #expect(await deleteAccountService.requestedServerURL() == serverURL)
+        #expect(try await store.read(serverURL: serverURL) == nil)
+        #expect(try await store.read(serverURL: customServerURL) == customCredentials)
+        #expect(await subject.authenticationState == .loggedIn(account: customAccount, serverURL: customServerURL))
+    }
+
+    @Test func normalized_server_url_adds_https_scheme() throws {
+        let url = try AppServerEnvironmentService.normalizedURL(from: "custom.tuist.dev")
+
+        #expect(url.absoluteString == "https://custom.tuist.dev")
+    }
+
+    @Test func normalized_server_url_rejects_unsupported_schemes() throws {
+        #expect(throws: AppServerEnvironmentServiceError.unsupportedServerURLScheme("ftp")) {
+            try AppServerEnvironmentService.normalizedURL(from: "ftp://custom.tuist.dev")
+        }
+    }
+
+    @Test func normalized_server_url_allows_clear_text_localhost() throws {
+        let url = try AppServerEnvironmentService.normalizedURL(from: "http://localhost:8080/")
+
+        #expect(url.absoluteString == "http://localhost:8080")
+    }
+
+    @Test func normalized_server_url_allows_clear_text_internet_protocol_version_six_loopback() throws {
+        let url = try AppServerEnvironmentService.normalizedURL(from: "http://[::1]:8080")
+
+        #expect(url.absoluteString == "http://[::1]:8080")
+    }
+
+    @Test func normalized_server_url_canonicalizes_the_host_and_default_port() throws {
+        let url = try AppServerEnvironmentService.normalizedURL(from: "HTTPS://CUSTOM.TUIST.DEV:443/")
+
+        #expect(url.absoluteString == "https://custom.tuist.dev")
+    }
+
+    @Test func normalized_server_url_rejects_clear_text_remote_hosts() {
+        #expect(throws: AppServerEnvironmentServiceError.insecureServerURL) {
+            try AppServerEnvironmentService.normalizedURL(from: "http://custom.tuist.dev")
+        }
+        #expect(throws: AppServerEnvironmentServiceError.insecureServerURL) {
+            try AppServerEnvironmentService.normalizedURL(from: "http://127.example.com")
+        }
+    }
+
+    @Test func normalized_server_url_rejects_non_root_paths() {
+        #expect(throws: AppServerEnvironmentServiceError.serverURLMustBeRoot) {
+            try AppServerEnvironmentService.normalizedURL(from: "https://custom.tuist.dev/api")
+        }
     }
 
     private func makeAuthenticationService(
-        store: ServerCredentialsStore,
-        appStorage: TestAppStorage
+        store: ServerCredentialsStoring,
+        appStorage: TestAppStorage,
+        deleteAccountService: DeleteAccountServicing = DeleteAccountService()
     ) async -> AuthenticationService {
-        await ServerCredentialsStore.$current.withValue(store) {
-            AuthenticationService(appStorage: appStorage)
-        }
+        return await AuthenticationService(
+            serverEnvironmentService: AppServerEnvironmentService(
+                appStorage: appStorage,
+                defaultServerEnvironmentService: TestServerEnvironmentService(serverURL: serverURL)
+            ),
+            appStorage: appStorage,
+            credentialsStore: store,
+            deleteAccountService: deleteAccountService
+        )
     }
 
     private func makeCredentialsStore(
         configDirectory: AbsolutePath? = nil
-    ) -> ServerCredentialsStore {
-        ServerCredentialsStore(
+    ) throws -> ServerCredentialsStore {
+        return ServerCredentialsStore(
             backend: .fileSystem,
-            configDirectory: configDirectory ?? makeTemporaryDirectory()
+            configDirectory: try configDirectory ?? makeTemporaryDirectory()
         )
     }
 
-    private func makeTemporaryDirectory() -> AbsolutePath {
-        let path = FileManager.default.temporaryDirectory
-            .appendingPathComponent(UUID().uuidString)
-        return try! AbsolutePath(validating: path.path)
+    private func makeTemporaryDirectory() throws -> AbsolutePath {
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        return temporaryDirectory.appending(component: UUID().uuidString)
     }
 
     private func makeCredentials(
@@ -157,28 +433,141 @@ import TuistServer
     }
 
     private func waitUntil(
-        _ predicate: () -> Bool
+        _ predicate: () async -> Bool
     ) async throws {
         for _ in 0 ..< 100 {
-            if predicate() {
+            if await predicate() {
                 return
             }
             await Task.yield()
             try await Task.sleep(nanoseconds: 10_000_000)
         }
+        throw AuthenticationServiceTestError.timedOut
+    }
+}
+
+private enum AuthenticationServiceTestError: Error {
+    case timedOut
+}
+
+private actor SuspendingReadCredentialsStore: ServerCredentialsStoring {
+    nonisolated let credentialsChanged: AsyncStream<ServerCredentials?>
+
+    private let credentialsChangedContinuation: AsyncStream<ServerCredentials?>.Continuation
+    private let notifiesWhenDeleting: Bool
+    private var credentials: ServerCredentials?
+    private var shouldSuspendNextRead = false
+    private var isReadSuspended = false
+    private var suspendedReadContinuation: CheckedContinuation<Void, Never>?
+
+    init(
+        credentials: ServerCredentials?,
+        notifiesWhenDeleting: Bool
+    ) {
+        let stream = AsyncStream<ServerCredentials?>.makeStream()
+        credentialsChanged = stream.stream
+        credentialsChangedContinuation = stream.continuation
+        self.credentials = credentials
+        self.notifiesWhenDeleting = notifiesWhenDeleting
+    }
+
+    func store(credentials: ServerCredentials, serverURL _: URL) {
+        self.credentials = credentials
+        credentialsChangedContinuation.yield(credentials)
+    }
+
+    func get(serverURL _: URL) throws -> ServerCredentials {
+        guard let credentials else {
+            throw SuspendingReadCredentialsStoreError.credentialsNotFound
+        }
+        return credentials
+    }
+
+    func read(serverURL _: URL) async -> ServerCredentials? {
+        let credentials = credentials
+        guard shouldSuspendNextRead else {
+            return credentials
+        }
+
+        shouldSuspendNextRead = false
+        isReadSuspended = true
+        await withCheckedContinuation { continuation in
+            suspendedReadContinuation = continuation
+        }
+        return credentials
+    }
+
+    func delete(serverURL _: URL) {
+        credentials = nil
+        if notifiesWhenDeleting {
+            credentialsChangedContinuation.yield(nil)
+        }
+    }
+
+    func suspendNextRead() {
+        shouldSuspendNextRead = true
+    }
+
+    func readIsSuspended() -> Bool {
+        return isReadSuspended
+    }
+
+    func resumeSuspendedRead() {
+        isReadSuspended = false
+        suspendedReadContinuation?.resume()
+        suspendedReadContinuation = nil
+    }
+}
+
+private enum SuspendingReadCredentialsStoreError: Error {
+    case credentialsNotFound
+}
+
+private actor SuspendingDeleteAccountService: DeleteAccountServicing {
+    private var deletionContinuation: CheckedContinuation<Void, Never>?
+    private var deletionStarted = false
+    private var serverURL: URL?
+
+    func deleteAccount(handle _: String, serverURL: URL) async throws {
+        self.serverURL = serverURL
+        deletionStarted = true
+        await withCheckedContinuation { continuation in
+            deletionContinuation = continuation
+        }
+    }
+
+    func deletionHasStarted() -> Bool {
+        return deletionStarted
+    }
+
+    func completeDeletion() {
+        deletionContinuation?.resume()
+        deletionContinuation = nil
+    }
+
+    func requestedServerURL() -> URL? {
+        return serverURL
     }
 }
 
 private final class TestAppStorage: AppStoring, @unchecked Sendable {
     private var authenticationState: AuthenticationState
+    private var serverURLString: String?
 
-    init(authenticationState: AuthenticationState) {
+    init(
+        authenticationState: AuthenticationState,
+        serverURLString: String? = nil
+    ) {
         self.authenticationState = authenticationState
+        self.serverURLString = serverURLString
     }
 
     func get<Key: AppStorageKey>(_ key: Key.Type) throws -> Key.Value {
         if key.key == AuthenticationStateKey.key {
             return authenticationState as! Key.Value
+        }
+        if key.key == AppServerURLKey.key {
+            return (serverURLString as String?) as! Key.Value
         }
         return key.defaultValue
     }
@@ -189,5 +578,24 @@ private final class TestAppStorage: AppStoring, @unchecked Sendable {
         {
             authenticationState = value
         }
+        if key.key == AppServerURLKey.key {
+            serverURLString = value as? String
+        }
+    }
+}
+
+private struct TestServerEnvironmentService: ServerEnvironmentServicing {
+    let serverURL: URL
+
+    func url() -> URL {
+        serverURL
+    }
+
+    func oauthClientId() -> String {
+        "test-client-id"
+    }
+
+    func url(configServerURL _: URL) throws -> URL {
+        serverURL
     }
 }

--- a/app/Tests/TuistMenuBarTests/Authentication/AuthenticationStateTests.swift
+++ b/app/Tests/TuistMenuBarTests/Authentication/AuthenticationStateTests.swift
@@ -1,0 +1,40 @@
+import Foundation
+import Testing
+import TuistAuthentication
+import TuistServer
+
+@Suite struct AuthenticationStateTests {
+    @Test func logged_in_state_round_trips_its_server_url() throws {
+        let state = AuthenticationState.loggedIn(
+            account: Account(email: "tuist@tuist.dev", handle: "tuist"),
+            serverURL: URL(string: "https://custom.tuist.dev")!
+        )
+
+        let data = try JSONEncoder().encode(state)
+        let decodedState = try JSONDecoder().decode(AuthenticationState.self, from: data)
+
+        #expect(decodedState == state)
+    }
+
+    @Test func legacy_logged_in_state_uses_the_default_server_url() throws {
+        let data = Data(
+            #"{"loggedIn":{"account":{"email":"tuist@tuist.dev","handle":"tuist"}}}"#.utf8
+        )
+
+        let state = try JSONDecoder().decode(AuthenticationState.self, from: data)
+
+        #expect(
+            state == .loggedIn(
+                account: Account(email: "tuist@tuist.dev", handle: "tuist"),
+                serverURL: ServerEnvironmentService().url()
+            )
+        )
+    }
+
+    @Test func logged_out_state_round_trips() throws {
+        let data = try JSONEncoder().encode(AuthenticationState.loggedOut)
+        let state = try JSONDecoder().decode(AuthenticationState.self, from: data)
+
+        #expect(state == .loggedOut)
+    }
+}

--- a/app/Tests/TuistMenuBarTests/ViewModels/AppPreviewsViewModelTests.swift
+++ b/app/Tests/TuistMenuBarTests/ViewModels/AppPreviewsViewModelTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Mockable
+import Synchronization
 import Testing
 import TuistAppStorage
 import TuistAuthentication
@@ -17,11 +18,20 @@ import TuistTesting
     private let serverEnvironmentService: MockServerEnvironmentServicing
 
     init() {
-        appStorage = MockAppStoring()
-        deviceService = MockDeviceServicing()
-        listPreviewsService = MockListPreviewsServicing()
-        listProjectsService = MockListProjectsServicing()
-        serverEnvironmentService = MockServerEnvironmentServicing()
+        let appStorage = MockAppStoring()
+        let deviceService = MockDeviceServicing()
+        let listPreviewsService = MockListPreviewsServicing()
+        let listProjectsService = MockListProjectsServicing()
+        let serverEnvironmentService = MockServerEnvironmentServicing()
+        self.appStorage = appStorage
+        self.deviceService = deviceService
+        self.listPreviewsService = listPreviewsService
+        self.listProjectsService = listProjectsService
+        self.serverEnvironmentService = serverEnvironmentService
+
+        given(serverEnvironmentService)
+            .url()
+            .willReturn(.test())
 
         subject = AppPreviewsViewModel(
             deviceService: deviceService,
@@ -40,17 +50,13 @@ import TuistTesting
                     )
                 )
             )
-
-        given(serverEnvironmentService)
-            .url()
-            .willReturn(.test())
     }
 
     @Test func load_app_previews_from_cache() {
         // Given
         given(appStorage)
             .get(.any as Parameter<AppPreviewsKey.Type>)
-            .willReturn([.test()])
+            .willReturn(AppPreviewsCache(serverURL: .test(), appPreviews: [.test()]))
 
         given(appStorage)
             .set(.any as Parameter<AppPreviewsKey.Type>, value: .any)
@@ -61,6 +67,71 @@ import TuistTesting
 
         // Then
         #expect(subject.appPreviews == [.test()])
+    }
+
+    @Test func load_app_previews_from_cache_ignores_another_server() {
+        let otherServerPreview: AppPreview = .test(displayName: "Other server")
+        given(appStorage)
+            .get(.any as Parameter<AppPreviewsKey.Type>)
+            .willReturn(
+                AppPreviewsCache(
+                    serverURL: URL(string: "https://other.tuist.dev")!,
+                    appPreviews: [otherServerPreview]
+                )
+            )
+        given(appStorage)
+            .set(.any as Parameter<AppPreviewsKey.Type>, value: .any)
+            .willReturn()
+
+        subject.loadAppPreviewsFromCache()
+
+        #expect(subject.appPreviews.isEmpty)
+    }
+
+    @Test func load_app_previews_from_cache_migrates_legacy_previews() {
+        let legacyPreview: AppPreview = .test(displayName: "Legacy")
+        let appStorage = LegacyAppPreviewsStorage(appPreviews: [legacyPreview])
+        let serverEnvironmentService = AppServerEnvironmentService(
+            appStorage: appStorage,
+            defaultServerEnvironmentService: TestServerEnvironmentService(serverURL: .test())
+        )
+        let subject = AppPreviewsViewModel(
+            deviceService: deviceService,
+            listProjectsService: listProjectsService,
+            listPreviewsService: listPreviewsService,
+            serverEnvironmentService: serverEnvironmentService,
+            appStorage: appStorage
+        )
+
+        subject.loadAppPreviewsFromCache()
+
+        #expect(subject.appPreviews == [legacyPreview])
+        #expect(appStorage.cache == AppPreviewsCache(serverURL: .test(), appPreviews: [legacyPreview]))
+    }
+
+    @Test func load_app_previews_from_cache_discards_legacy_previews_for_a_custom_server() {
+        let customServerURL = URL(string: "https://custom.tuist.dev")!
+        let legacyPreview: AppPreview = .test(displayName: "Legacy")
+        let appStorage = LegacyAppPreviewsStorage(
+            appPreviews: [legacyPreview],
+            serverURLString: customServerURL.absoluteString
+        )
+        let serverEnvironmentService = AppServerEnvironmentService(
+            appStorage: appStorage,
+            defaultServerEnvironmentService: TestServerEnvironmentService(serverURL: .test())
+        )
+        let subject = AppPreviewsViewModel(
+            deviceService: deviceService,
+            listProjectsService: listProjectsService,
+            listPreviewsService: listPreviewsService,
+            serverEnvironmentService: serverEnvironmentService,
+            appStorage: appStorage
+        )
+
+        subject.loadAppPreviewsFromCache()
+
+        #expect(subject.appPreviews.isEmpty)
+        #expect(appStorage.cache == AppPreviewsCache(serverURL: customServerURL, appPreviews: []))
     }
 
     @Test func on_appear_updates_app_previews() async throws {
@@ -128,7 +199,7 @@ import TuistTesting
         let appPreview: AppPreview = .test()
         given(appStorage)
             .get(.any as Parameter<AppPreviewsKey.Type>)
-            .willReturn([appPreview])
+            .willReturn(AppPreviewsCache(serverURL: .test(), appPreviews: [appPreview]))
 
         given(appStorage)
             .set(.any as Parameter<AppPreviewsKey.Type>, value: .any)
@@ -160,7 +231,7 @@ import TuistTesting
         let appPreview: AppPreview = .test()
         given(appStorage)
             .get(.any as Parameter<AppPreviewsKey.Type>)
-            .willReturn([appPreview])
+            .willReturn(AppPreviewsCache(serverURL: .test(), appPreviews: [appPreview]))
 
         given(appStorage)
             .set(.any as Parameter<AppPreviewsKey.Type>, value: .any)
@@ -219,5 +290,68 @@ import TuistTesting
                 serverURL: .any
             )
             .called(1)
+    }
+}
+
+private final class LegacyAppPreviewsStorage: AppStoring {
+    private struct State {
+        var cache: AppPreviewsCache?
+        let appPreviews: [AppPreview]
+        let serverURLString: String?
+    }
+
+    private let state: Mutex<State>
+
+    init(
+        appPreviews: [AppPreview],
+        serverURLString: String? = nil
+    ) {
+        state = Mutex(State(cache: nil, appPreviews: appPreviews, serverURLString: serverURLString))
+    }
+
+    var cache: AppPreviewsCache? {
+        return state.withLock(\.cache)
+    }
+
+    func get<Key: AppStorageKey>(_ key: Key.Type) throws -> Key.Value {
+        if ObjectIdentifier(key) == ObjectIdentifier(AppPreviewsKey.self) {
+            throw LegacyAppPreviewsStorageError.legacyValue
+        }
+        if ObjectIdentifier(key) == ObjectIdentifier(LegacyAppPreviewsKey.self) {
+            return state.withLock(\.appPreviews) as! Key.Value
+        }
+        if ObjectIdentifier(key) == ObjectIdentifier(AppServerURLKey.self) {
+            return state.withLock(\.serverURLString) as! Key.Value
+        }
+        return key.defaultValue
+    }
+
+    func set<Key: AppStorageKey>(_ key: Key.Type, value: Key.Value) throws {
+        guard ObjectIdentifier(key) == ObjectIdentifier(AppPreviewsKey.self),
+              let cache = value as? AppPreviewsCache
+        else {
+            return
+        }
+        state.withLock { $0.cache = cache }
+    }
+}
+
+private enum LegacyAppPreviewsStorageError: Error {
+    case legacyValue
+}
+
+private struct TestServerEnvironmentService: ServerEnvironmentServicing {
+    let serverURL: URL
+
+    func url() -> URL {
+        return serverURL
+    }
+
+    func oauthClientId() -> String {
+        return "test-client-id"
+    }
+
+    func url(configServerURL _: URL) throws -> URL {
+        return serverURL
     }
 }


### PR DESCRIPTION
This lets the native Tuist apps sign in to a custom Tuist deployment while keeping authentication and cached application data isolated by server.

## What changed

The iOS, macOS, and Android apps can now switch between `tuist.dev` and a custom Tuist server from their signed-out experiences. The Apple apps also expose server selection from the profile and menu experiences. Authentication state, credentials, previews, projects, and cached selections are scoped to the selected server.

The macOS signed-out experience now opens a dedicated login window that mirrors the mobile sign-in options, while the menu bar popover remains a compact launcher.

On Android, entering or resetting a server address signs out the current account and restarts the app so every network client is recreated with the selected origin.

## Screenshots

These captures come from running debug builds and show both the signed-out experience and the server-entry interface on each platform.

| Platform | Login | Server entry |
| --- | --- | --- |
| iOS | <img src="https://github.com/user-attachments/assets/0e11f6f6-4e70-4c1d-a085-fde48e2c73aa" width="280" alt="iOS login screen"> | <img src="https://github.com/user-attachments/assets/6934768f-ec09-4bec-81ae-6fefeeec2b09" width="280" alt="iOS server entry screen"> |
| macOS | <img src="https://github.com/user-attachments/assets/3f4e6c96-de54-4e38-abad-34d871804f5a" width="280" alt="macOS login window"> | <img src="https://github.com/user-attachments/assets/d748d663-fe46-4416-bebf-c253b83d5a93" width="280" alt="macOS server entry sheet"> |
| Android | <img src="https://github.com/user-attachments/assets/326ea0bf-3026-43f3-b936-793124dd6255" width="280" alt="Android login screen"> | <img src="https://github.com/user-attachments/assets/87467dc3-5e65-42ad-a7f0-9ba601c8c0dc" width="280" alt="Android server entry dialog"> |

## Why

The native apps previously assumed `tuist.dev`, which prevented users from signing in to another Tuist deployment. Server selection also requires strict isolation so credentials and cached content from one server never appear while another server is active.

The macOS menu bar popover did not have enough space for the complete sign-in experience available on mobile.

## Root cause

Server selection was resolved independently by several Apple app services, authentication state did not record its server, and cached preview and project data was not tagged with its origin. Separate credential-store instances and overlapping asynchronous refresh, sign-out, and account-deletion work could also leave stale authentication state behind.

Android only supported a fixed set of debug environments and constructed its network clients once from that fixed configuration. It had no user-facing way to enter, persist, or reset an arbitrary server address.

## Approach

Each platform now validates, normalizes, and persists the selected root server address. The saved address becomes the origin for authentication and application requests across relaunches and sign-outs. It remains active until the user explicitly selects **Use default server**.

The Apple apps own one credential store and inject it through authentication, error handling, and request execution. Authentication and request work capture the active server before starting, stale refreshes are discarded, and persisted state is migrated only for the default server.

Android stores the normalized address in shared preferences. Saving or resetting it clears the current credentials and restarts the process so the dependency-injected network singletons use the new origin from construction.

## Impact

Existing users continue using `tuist.dev`, with compatible migration for legacy Apple authentication and cached data. Users can select another encrypted server address, or a clear-text loopback address for local development, and switch back to the default server at any time.

Cached Apple previews and project selections are isolated by server. Switching servers refreshes the relevant views on Apple platforms and recreates the Android application session with the selected origin.

## Validation

### How to test locally

- Generated the focused Apple app workspace with `tuist generate TuistApp TuistMenuBarTests --no-open`.
- Ran 27 focused authentication-state, authentication-service, and preview-cache tests successfully with `xcodebuild test -workspace TuistApp.xcworkspace -scheme TuistApp-Workspace -destination 'platform=macOS' -only-testing:TuistMenuBarTests/AuthenticationServiceTests -only-testing:TuistMenuBarTests/AuthenticationStateTests -only-testing:TuistMenuBarTests/AppPreviewsViewModelTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY='' -quiet`.
- Built the macOS app with `xcodebuild build -workspace TuistApp.xcworkspace -scheme TuistApp -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY='' -quiet`.
- Built the mobile simulator app with `xcodebuild build -workspace TuistApp.xcworkspace -scheme TuistApp -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY='' -quiet`.
- Built the Android debug app with `./gradlew assembleDebug`.
- Ran the complete Android unit test task with `./gradlew testDebugUnitTest`.
- Ran Android lint with `./gradlew lintDebug`.
- Launched all three apps and captured the login and server-entry interfaces shown above.
- Ran `mise x -- swiftformat app --lint` successfully.
- Ran `git diff --check` successfully.
