### PR TITLE
fix(registry): keep cache as sync writer until cutover (hotfix)

### DIFF
--- a/infra/helm/tuist/values-managed-canary.yaml
+++ b/infra/helm/tuist/values-managed-canary.yaml
@@ -93,6 +93,9 @@ server:
     # env's config the release runs as.
     - name: TUIST_DEPLOY_ENV
       value: can
+    # Cache remains the sole registry writer until the managed cutover.
+    - name: SWIFT_REGISTRY_SYNC_ENABLED
+      value: "false"
     # Single web replica shares this pool between request handling and the
     # in-node Oban queues (default: 10). Sized well above the default-queue
     # concurrency so the steady AlertEvaluationWorker load can't starve web
@@ -253,10 +256,11 @@ processor:
       cpu: "1000m"
       memory: "1Gi"
 
-# Scope sync to a single package on canary so we can bake the pod
-# end-to-end without spending the GitHub-PAT rate-limit budget on the
-# full SwiftPackageIndex catalog. Remove this to mirror production.
+# Cache remains the sole registry writer until the managed cutover. The
+# standalone registry continues exercising the read path against the
+# same bucket.
 swiftRegistrySync:
+  enabled: false
   syncAllowlist: alamofire/alamofire
   extraEnv:
     - name: TUIST_DEPLOY_ENV

--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -73,6 +73,9 @@ server:
     # env's config the release runs as.
     - name: TUIST_DEPLOY_ENV
       value: prod
+    # Cache remains the sole registry writer until the managed cutover.
+    - name: SWIFT_REGISTRY_SYNC_ENABLED
+      value: "false"
     - name: TUIST_DATABASE_POOL_SIZE
       value: "15"
     - name: TUIST_OTEL_EXPORTER_OTLP_ENDPOINT

--- a/registry/AGENTS.md
+++ b/registry/AGENTS.md
@@ -2,10 +2,15 @@
 
 This directory contains the standalone Tuist package registry service
 deployed at `https://registry.tuist.dev`. **The pod is a stateless read
-frontend.** All write/sync work lives in the server under
-`Tuist.Registry.Swift.*` and runs in a separate `TUIST_MODE=swift_registry_sync`
-pod (see `server/AGENTS.md` and
-`infra/helm/tuist/templates/swift-registry-sync-deployment.yaml`).
+frontend.** The server-owned writer lives under `Tuist.Registry.Swift.*`
+and runs in a separate `TUIST_MODE=swift_registry_sync` pod (see
+`server/AGENTS.md` and
+`infra/helm/tuist/templates/swift-registry-sync-deployment.yaml`). During
+the managed cutover, the currently deployed legacy cache release remains
+the sole scheduled writer for canary and production while staging and
+previews exercise the server-owned writer. Do not redeploy cache from the
+current main branch before cutover because its registry cron has already
+been removed.
 
 The service is multi-ecosystem by design: each ecosystem mounts its own
 protocol-compliant API surface under a path prefix that names the
@@ -80,8 +85,9 @@ Responses on the legacy prefix carry RFC 8594 `Deprecation: true` and
   1Password (`REGISTRY` item in `tuist-k8s-<env>` vault).
 - Normal deploys run through `.github/workflows/server-deployment.yml`,
   which builds and deploys the registry read image together with the
-  server image so the read frontend and `swift_registry_sync` writer roll
-  from the same commit.
+  server image. In managed canary and production, the
+  `swift_registry_sync` writer remains disabled until cache sync is turned
+  off as a separate, deliberate cutover step.
 
 ### Cluster prereqs
 The chart assumes these are installed in the target cluster (they

--- a/server/config/runtime.exs
+++ b/server/config/runtime.exs
@@ -595,7 +595,19 @@ oban_queues =
 # lands in prod.
 mode = Tuist.Environment.mode()
 
-crontab = RuntimeConfig.crontab(mode, env, Tuist.Environment.tuist_hosted?())
+swift_registry_sync_enabled =
+  "SWIFT_REGISTRY_SYNC_ENABLED"
+  |> System.get_env("true")
+  |> String.downcase()
+  |> Kernel.in(["1", "true"])
+
+crontab =
+  RuntimeConfig.crontab(
+    mode,
+    env,
+    Tuist.Environment.tuist_hosted?(),
+    swift_registry_sync_enabled
+  )
 
 config :tuist, Oban,
   queues: oban_queues,
@@ -642,8 +654,7 @@ swift_registry_sync_limit =
 config :tuist, :registry,
   bucket: System.get_env("S3_REGISTRY_BUCKET"),
   swift_github_token: System.get_env("SWIFT_REGISTRY_GITHUB_TOKEN"),
-  swift_sync_enabled:
-    "SWIFT_REGISTRY_SYNC_ENABLED" |> System.get_env("true") |> String.downcase() |> Kernel.in(["1", "true"]),
+  swift_sync_enabled: swift_registry_sync_enabled,
   swift_sync_allowlist: swift_registry_sync_allowlist,
   swift_sync_limit: swift_registry_sync_limit
 

--- a/server/lib/tuist/oban/runtime_config.ex
+++ b/server/lib/tuist/oban/runtime_config.ex
@@ -1,7 +1,7 @@
 defmodule Tuist.Oban.RuntimeConfig do
   @moduledoc """
   Pure functions deriving Oban runtime config from pod role, deploy env,
-  and the `tuist_hosted?` flag.
+  the `tuist_hosted?` flag, and registry sync ownership.
 
   Lifted out of `config/runtime.exs` so they can be unit-tested against
   every value of `Tuist.Environment.modes/0`. Without this, a future
@@ -46,12 +46,7 @@ defmodule Tuist.Oban.RuntimeConfig do
     {"* * * * *", Tuist.Runners.Workers.OrphanedStampedPodsWorker},
     {"* * * * *", Tuist.Runners.Workers.ExpireInteractiveSessionsWorker},
     {"*/5 * * * *", Tuist.Runners.Workers.WebhookRedeliveryWorker},
-    {"*/5 * * * *", Tuist.Runners.Workers.StaleQueuedJobsWorker},
-    # Cron fires on the :web leader; the resulting `:swift_registry_sync`
-    # job is consumed by the swift-registry-sync pod
-    # (`TUIST_MODE=swift_registry_sync`). Hosted-only because the
-    # registry mirror is a hosted-only feature.
-    @swift_registry_sync_cron
+    {"*/5 * * * *", Tuist.Runners.Workers.StaleQueuedJobsWorker}
   ]
 
   @prod_like_envs [:prod, :stag, :can]
@@ -64,17 +59,25 @@ defmodule Tuist.Oban.RuntimeConfig do
   sharded-test cleanup) — Tuist-hosted deployments additionally get the
   internal Slack ops reports, account-usage rollup, and Stripe
   metered-billing reconciler. Preview gets only the Swift registry sync
-  cron, regardless of hosted flag, so registry previews can exercise the
-  same queue path without running production housekeeping.
+  cron when registry sync is enabled, regardless of hosted flag, so
+  registry previews can exercise the same queue path without running
+  production housekeeping.
   """
-  def crontab(mode, env, tuist_hosted?) do
+  def crontab(mode, env, tuist_hosted?, swift_registry_sync_enabled? \\ true) do
     cond do
       mode == :web and env == :preview ->
-        @preview_crons
+        if swift_registry_sync_enabled?, do: @preview_crons, else: []
 
       mode == :web and env in @prod_like_envs ->
         if tuist_hosted? do
-          @hosted_only_crons ++ @shared_crons
+          hosted_crons =
+            if swift_registry_sync_enabled? do
+              @hosted_only_crons ++ [@swift_registry_sync_cron]
+            else
+              @hosted_only_crons
+            end
+
+          hosted_crons ++ @shared_crons
         else
           @shared_crons
         end

--- a/server/test/tuist/oban/runtime_config_test.exs
+++ b/server/test/tuist/oban/runtime_config_test.exs
@@ -132,5 +132,20 @@ defmodule Tuist.Oban.RuntimeConfigTest do
         assert StaleQueuedJobsWorker in workers
       end
     end
+
+    test "omits registry sync without removing other crons when sync is disabled" do
+      for env <- [:prod, :stag, :can] do
+        workers =
+          :web
+          |> RuntimeConfig.crontab(env, true, false)
+          |> Enum.map(fn {_cron, worker} -> worker end)
+
+        refute SyncWorker in workers
+        assert AutomationScheduler in workers
+        assert UpdateAllAccountsUsageWorker in workers
+      end
+
+      assert RuntimeConfig.crontab(:web, :preview, true, false) == []
+    end
   end
 end

--- a/server/test/tuist/registry/swift/release_worker_test.exs
+++ b/server/test/tuist/registry/swift/release_worker_test.exs
@@ -117,6 +117,57 @@ defmodule Tuist.Registry.Swift.ReleaseWorkerTest do
              })
   end
 
+  test "returns an error so Oban retries when release metadata is locked" do
+    expect(Lock, :try_acquire, fn {:release, "apple", "swift-argument-parser", "1.0.0"}, _ ->
+      {:ok, :acquired}
+    end)
+
+    expect(Metadata, :get_package, fn "apple", "swift-argument-parser", [fresh: true] ->
+      {:error, :not_found}
+    end)
+
+    expect(TuistCommon.GitHub, :list_repository_contents, fn "apple/swift-argument-parser", "token", "v1.0.0", _ ->
+      {:ok, [%{"path" => "Package.swift", "type" => "file"}]}
+    end)
+
+    expect(TuistCommon.GitHub, :get_file_content, 2, fn
+      "apple/swift-argument-parser", "token", "Package.swift", "v1.0.0", _ ->
+        {:ok, @default_manifest_content}
+
+      "apple/swift-argument-parser", "token", ".gitmodules", "v1.0.0", _ ->
+        {:error, :not_found}
+    end)
+
+    expect(TuistCommon.GitHub, :download_zipball, fn "apple/swift-argument-parser", "token", "v1.0.0", archive_path, _ ->
+      write_basic_zipball(archive_path)
+      :ok
+    end)
+
+    expect(Upload, :stream_file, fn path -> [File.read!(path)] end)
+
+    expect(ExAws.S3, :upload, fn _stream, "test-bucket", key, _opts ->
+      %S3{http_method: :put, bucket: "test-bucket", path: key}
+    end)
+
+    expect(ExAws, :request, 2, fn _operation ->
+      {:ok, %{status_code: 200, body: ""}}
+    end)
+
+    expect(Lock, :try_acquire, fn {:package, "apple", "swift-argument-parser"}, _ ->
+      {:error, :already_locked}
+    end)
+
+    assert {:error, {:release_metadata_locked, "apple", "swift-argument-parser", "1.0.0"}} =
+             ReleaseWorker.perform(%Oban.Job{
+               args: %{
+                 "scope" => "apple",
+                 "name" => "swift-argument-parser",
+                 "repository_full_handle" => "apple/swift-argument-parser",
+                 "tag" => "v1.0.0"
+               }
+             })
+  end
+
   test "deduplicates manifest metadata by Swift tools version" do
     expect(Lock, :try_acquire, fn {:release, "apple", "swift-argument-parser", "1.0.0"}, _ ->
       {:ok, :acquired}


### PR DESCRIPTION
## What changed

This keeps the currently deployed cache service as the sole Swift registry writer in canary and production until the explicit cutover.

The server registry cron now respects `SWIFT_REGISTRY_SYNC_ENABLED`, and the managed canary and production values disable both the cron and the standalone sync deployment. Preview and staging synchronization remain unchanged. A focused regression test confirms that metadata lock contention returns an error so the server release job is retried instead of being marked successful with missing metadata.

## Why

The production registry contained the `frazer-rbsn/OrderedSet` 2.0.0 archive and manifest, but its package metadata had an empty releases map. Cold pipeline runners therefore received a 404 while runners with a restored source cache continued to pass.

Keeping one writer during the transition avoids overlapping cache and server synchronization while the read service is evaluated independently.

## Root cause

The existing cache release worker can finish uploading release artifacts while the package metadata lock is still held by the package synchronization worker. That path records the job as successful without adding the release to metadata, leaving artifacts that cannot be discovered through the registry response.

The live `OrderedSet` metadata was repaired under the production package lock without deploying or restarting cache. The temporary repair job and secret were deleted after verification.

## Approach

This change does not deploy new cache code. Cache remains the managed canary and production writer until a separate cutover enables the server-owned synchronization worker.

The server implementation already returns an error when metadata is locked. The added test preserves that behavior so its job runner retries after cutover.

## Impact

The public registry once again serves `frazer-rbsn.OrderedSet` 2.0.0 with the expected checksum. Canary and production cannot accidentally start a second scheduled writer from the server deployment.

## Validation

- Public package listing returns release `2.0.0`.
- Public release metadata returns checksum `91427e4136b1f99cd9322b5e8ac0ec22d31305f50b759b07241488f90a18c338`.
- Downloaded archive bytes match that checksum.
- The default manifest returns `swift-tools-version:5.6`.
- `mise x -- mix test --no-compile test/tuist/registry/swift/release_worker_test.exs`
- `mise x -- mix test --no-compile test/tuist/oban/runtime_config_test.exs`
- Managed canary and production Helm renders contain `SWIFT_REGISTRY_SYNC_ENABLED=false` and no Swift registry sync deployment.
- The previously failing lint job was rerun successfully, including dependency installation: https://github.com/tuist/tuist/actions/runs/29091784991/job/86373835234
- `git diff --check`
