### PR TITLE
feat(server): require account tokens to have a name

### DIFF
--- a/server/priv/repo/migrations/20260710120000_require_account_token_name.exs
+++ b/server/priv/repo/migrations/20260710120000_require_account_token_name.exs
@@ -1,0 +1,20 @@
+defmodule Tuist.Repo.Migrations.RequireAccountTokenName do
+  use Ecto.Migration
+
+  def change do
+    # Backfill legacy tokens that predate the `name` column (mostly `account:registry:read`
+    # tokens created by `tuist registry login`) with a generated, per-row-unique name
+    # derived from the token id, so the NOT NULL constraint below holds. New tokens always
+    # get a name — every creation path goes through a changeset that requires it.
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    execute(
+      "UPDATE account_tokens SET name = 'token-' || right(replace(id::text, '-', ''), 12) WHERE name IS NULL",
+      "SELECT 1"
+    )
+
+    alter table(:account_tokens) do
+      # excellent_migrations:safety-assured-for-next-line not_null_added column_type_changed
+      modify :name, :string, null: false, from: {:string, null: true}
+    end
+  end
+end


### PR DESCRIPTION
### What changed

Adds a migration that makes `account_tokens.name` `NOT NULL`, backfilling any existing nameless tokens first.

- **Backfill**: `UPDATE account_tokens SET name = 'token-' || right(replace(id::text, '-', ''), 12) WHERE name IS NULL` — names legacy tokens with a per-row-unique `token-<last-12-hex-of-id>` value (same `token-*` shape the API's `generate_token_name/0` already produces, ≤32 chars, valid format, and globally unique so it can't collide on the `(account_id, name)` unique index).
- **Constraint**: `modify :name, :string, null: false, from: {:string, null: true}` (reversible).

### Why

Account tokens are revocable **by name only** — `tuist account tokens revoke <account> <name>` maps to `DELETE .../account_tokens/{token_name}`, resolved via `Accounts.get_account_token_by_name/2`. There is no revoke-by-id path, even though `tuist account tokens list` shows an `ID` column.

Tokens created by older `tuist registry login` versions predate the `name` column and have `name = NULL`. Because revoke is name-based, those tokens can't be targeted at all, so customers can't clear their old registry tokens (this came up in support: a customer with two nameless `account:registry:read` tokens who couldn't revoke them by id).

### Root cause / why this fix

Every token-creation path already guarantees a name:
- API controller defaults to `generate_token_name/0` when none is provided
- Agent auth passes `name: token_name()`
- Both `create_changeset` and `scim_changeset` `validate_required([..., :name])`

So no nameless token can be created today — the only nameless rows are legacy, pre-`name`-column ones. The migration backfills those and the `NOT NULL` makes "every token has a name" a durable DB-level invariant, so name-based revoke can always target any token. The Ecto side is already enforced by `validate_required`, so no changeset changes were needed.

### Reviewer notes

- Follows existing safe-migration precedent in this repo (raw-SQL backfill annotated `raw_sql_executed`; reversible `not_null_added` via `modify ... from:`), matching `MakeAccountsBillingEmailNonOptional` and the earlier `account_tokens` scopes migration.
- On deploy, the backfill will also name any **other** accounts' legacy nameless registry tokens — those customers will start seeing generated `token-…` names on tokens that previously showed no name. Intended (those tokens were otherwise unmanageable), just noting the user-visible effect.
- No `server/data-export.md` change: this adds no new stored data, only constrains an existing column.

### How to test locally

1. Insert a token with a `NULL` name directly (bypassing the changeset), then run `mix ecto.migrate` — it gets a generated `token-<suffix>` name.
2. Confirm the column is `NOT NULL` (`\d account_tokens`) and that inserting a `NULL` name is rejected.
3. `mix ecto.rollback` drops the constraint cleanly; re-`mix ecto.migrate` re-applies it.

Validation run: SQL semantics verified on a temp table; migration applied on a dev DB (backfill + `NOT NULL`, null insert rejected, rollback + re-migrate clean); `mix excellent_migrations.check_safety` and `mix credo` clean; account-tokens controller + SCIM tests pass (43).

🤖 Generated with [Claude Code](https://claude.com/claude-code)