### PR TITLE
feat(server): publish MCP tool output schemas and validate structured content

### DIFF
--- a/server/lib/tuist.ex
+++ b/server/lib/tuist.ex
@@ -94,6 +94,7 @@ defmodule Tuist do
       Shards.ShardPlanTestSuite,
       Shards.ShardRun,
       MCP.Server,
+      MCP.Transport.StreamableHTTP,
       # App
       # -----
       # They are modules that are core to the Tuist domain (e.g. accounts) and that other

--- a/server/lib/tuist/mcp/components/tools/add_organization_member.ex
+++ b/server/lib/tuist/mcp/components/tools/add_organization_member.ex
@@ -1,6 +1,6 @@
 defmodule Tuist.MCP.Components.Tools.AddOrganizationMember do
   @moduledoc """
-  Add an existing Tuist user to an organization.
+  Add an existing Tuist user to an organization or update an existing member's role.
   """
 
   use Tuist.MCP.Tool,
@@ -17,22 +17,34 @@ defmodule Tuist.MCP.Components.Tools.AddOrganizationMember do
         },
         "email" => %{
           "type" => "string",
-          "description" => "The email of an existing Tuist user to add."
+          "description" => "The email of the existing Tuist user to add or update."
         },
         "role" => %{
           "type" => "string",
           "enum" => ["user", "admin"],
-          "description" => "The member role. Defaults to user."
+          "description" => "The role to assign to the new or existing member. Defaults to user."
         }
       },
       "required" => ["organization_handle", "email"]
+    },
+    output_schema: %{
+      "type" => "object",
+      "properties" => %{
+        "id" => %{"type" => "integer"},
+        "email" => %{"type" => "string"},
+        "name" => %{"type" => "string"},
+        "organization_handle" => %{"type" => "string"},
+        "role" => %{"type" => "string", "enum" => ["user", "admin"]}
+      },
+      "required" => ["id", "email", "name", "organization_handle", "role"],
+      "additionalProperties" => false
     }
 
   alias Tuist.Accounts
   alias Tuist.Authorization
 
   @impl EMCP.Tool
-  def description, do: "Add an existing Tuist user to an organization."
+  def description, do: "Add an existing Tuist user to an organization or update an existing member's role."
 
   def execute(%{assigns: %{current_user: user}}, %{"organization_handle" => organization_handle, "email" => email} = args)
       when is_binary(organization_handle) and is_binary(email) do

--- a/server/lib/tuist/mcp/components/tools/create_organization.ex
+++ b/server/lib/tuist/mcp/components/tools/create_organization.ex
@@ -16,6 +16,16 @@ defmodule Tuist.MCP.Components.Tools.CreateOrganization do
         }
       },
       "required" => ["handle"]
+    },
+    output_schema: %{
+      "type" => "object",
+      "properties" => %{
+        "id" => %{"type" => "integer"},
+        "name" => %{"type" => "string"},
+        "account_handle" => %{"type" => "string"}
+      },
+      "required" => ["id", "name", "account_handle"],
+      "additionalProperties" => false
     }
 
   alias Tuist.Accounts

--- a/server/lib/tuist/mcp/components/tools/create_project.ex
+++ b/server/lib/tuist/mcp/components/tools/create_project.ex
@@ -25,6 +25,26 @@ defmodule Tuist.MCP.Components.Tools.CreateProject do
         }
       },
       "required" => ["account_handle", "project_handle"]
+    },
+    output_schema: %{
+      "type" => "object",
+      "properties" => %{
+        "id" => %{"type" => "integer"},
+        "name" => %{"type" => "string"},
+        "account_handle" => %{"type" => "string"},
+        "full_handle" => %{"type" => "string"},
+        "build_system" => %{"type" => "string", "enum" => ["xcode", "gradle"]},
+        "default_branch" => %{"type" => "string"}
+      },
+      "required" => [
+        "id",
+        "name",
+        "account_handle",
+        "full_handle",
+        "build_system",
+        "default_branch"
+      ],
+      "additionalProperties" => false
     }
 
   alias Tuist.Accounts

--- a/server/lib/tuist/mcp/components/tools/get_bundle.ex
+++ b/server/lib/tuist/mcp/components/tools/get_bundle.ex
@@ -15,6 +15,38 @@ defmodule Tuist.MCP.Components.Tools.GetBundle do
         }
       },
       "required" => ["bundle_id"]
+    },
+    output_schema: %{
+      "type" => "object",
+      "properties" => %{
+        "id" => %{"type" => "string"},
+        "name" => %{"type" => "string"},
+        "app_bundle_id" => %{"type" => "string"},
+        "version" => %{"type" => "string"},
+        "type" => %{"type" => "string"},
+        "supported_platforms" => %{"type" => "array", "items" => %{"type" => "string"}},
+        "install_size" => %{"type" => "integer"},
+        "download_size" => %{"type" => ["integer", "null"]},
+        "git_branch" => %{"type" => ["string", "null"]},
+        "git_commit_sha" => %{"type" => ["string", "null"]},
+        "git_ref" => %{"type" => ["string", "null"]},
+        "inserted_at" => %{"type" => "string"}
+      },
+      "required" => [
+        "id",
+        "name",
+        "app_bundle_id",
+        "version",
+        "type",
+        "supported_platforms",
+        "install_size",
+        "download_size",
+        "git_branch",
+        "git_commit_sha",
+        "git_ref",
+        "inserted_at"
+      ],
+      "additionalProperties" => false
     }
 
   alias Tuist.Bundles

--- a/server/lib/tuist/mcp/components/tools/get_bundle_artifact_tree.ex
+++ b/server/lib/tuist/mcp/components/tools/get_bundle_artifact_tree.ex
@@ -15,6 +15,27 @@ defmodule Tuist.MCP.Components.Tools.GetBundleArtifactTree do
         }
       },
       "required" => ["bundle_id"]
+    },
+    output_schema: %{
+      "type" => "object",
+      "properties" => %{
+        "bundle_id" => %{"type" => "string"},
+        "artifacts" => %{
+          "type" => "array",
+          "items" => %{
+            "type" => "object",
+            "properties" => %{
+              "artifact_type" => %{"type" => "string"},
+              "path" => %{"type" => "string"},
+              "size" => %{"type" => "integer"}
+            },
+            "required" => ["artifact_type", "path", "size"],
+            "additionalProperties" => false
+          }
+        }
+      },
+      "required" => ["bundle_id", "artifacts"],
+      "additionalProperties" => false
     }
 
   alias Tuist.Bundles

--- a/server/lib/tuist/mcp/components/tools/get_cache_run.ex
+++ b/server/lib/tuist/mcp/components/tools/get_cache_run.ex
@@ -15,6 +15,44 @@ defmodule Tuist.MCP.Components.Tools.GetCacheRun do
         }
       },
       "required" => ["cache_run_id"]
+    },
+    output_schema: %{
+      "type" => "object",
+      "properties" => %{
+        "id" => %{"type" => "string"},
+        "duration" => %{"type" => "integer"},
+        "status" => %{"type" => "string"},
+        "tuist_version" => %{"type" => "string"},
+        "swift_version" => %{"type" => "string"},
+        "macos_version" => %{"type" => "string"},
+        "is_ci" => %{"type" => "boolean"},
+        "git_branch" => %{"type" => ["string", "null"]},
+        "git_commit_sha" => %{"type" => ["string", "null"]},
+        "git_ref" => %{"type" => ["string", "null"]},
+        "command_arguments" => %{"type" => ["string", "null"]},
+        "cacheable_targets" => %{"type" => "array", "items" => %{"type" => "string"}},
+        "local_cache_target_hits" => %{"type" => "array", "items" => %{"type" => "string"}},
+        "remote_cache_target_hits" => %{"type" => "array", "items" => %{"type" => "string"}},
+        "ran_at" => %{"type" => "string"}
+      },
+      "required" => [
+        "id",
+        "duration",
+        "status",
+        "tuist_version",
+        "swift_version",
+        "macos_version",
+        "is_ci",
+        "git_branch",
+        "git_commit_sha",
+        "git_ref",
+        "command_arguments",
+        "cacheable_targets",
+        "local_cache_target_hits",
+        "remote_cache_target_hits",
+        "ran_at"
+      ],
+      "additionalProperties" => false
     }
 
   alias Tuist.CommandEvents

--- a/server/lib/tuist/mcp/components/tools/get_generation.ex
+++ b/server/lib/tuist/mcp/components/tools/get_generation.ex
@@ -15,6 +15,44 @@ defmodule Tuist.MCP.Components.Tools.GetGeneration do
         }
       },
       "required" => ["generation_id"]
+    },
+    output_schema: %{
+      "type" => "object",
+      "properties" => %{
+        "id" => %{"type" => "string"},
+        "duration" => %{"type" => "integer"},
+        "status" => %{"type" => "string"},
+        "tuist_version" => %{"type" => "string"},
+        "swift_version" => %{"type" => "string"},
+        "macos_version" => %{"type" => "string"},
+        "is_ci" => %{"type" => "boolean"},
+        "git_branch" => %{"type" => ["string", "null"]},
+        "git_commit_sha" => %{"type" => ["string", "null"]},
+        "git_ref" => %{"type" => ["string", "null"]},
+        "command_arguments" => %{"type" => ["string", "null"]},
+        "cacheable_targets" => %{"type" => "array", "items" => %{"type" => "string"}},
+        "local_cache_target_hits" => %{"type" => "array", "items" => %{"type" => "string"}},
+        "remote_cache_target_hits" => %{"type" => "array", "items" => %{"type" => "string"}},
+        "ran_at" => %{"type" => "string"}
+      },
+      "required" => [
+        "id",
+        "duration",
+        "status",
+        "tuist_version",
+        "swift_version",
+        "macos_version",
+        "is_ci",
+        "git_branch",
+        "git_commit_sha",
+        "git_ref",
+        "command_arguments",
+        "cacheable_targets",
+        "local_cache_target_hits",
+        "remote_cache_target_hits",
+        "ran_at"
+      ],
+      "additionalProperties" => false
     }
 
   alias Tuist.CommandEvents

--- a/server/lib/tuist/mcp/components/tools/get_gradle_build.ex
+++ b/server/lib/tuist/mcp/components/tools/get_gradle_build.ex
@@ -15,6 +15,56 @@ defmodule Tuist.MCP.Components.Tools.GetGradleBuild do
         }
       },
       "required" => ["build_run_id"]
+    },
+    output_schema: %{
+      "type" => "object",
+      "properties" => %{
+        "id" => %{"type" => "string"},
+        "duration_ms" => %{"type" => "integer"},
+        "status" => %{"type" => "string"},
+        "gradle_version" => %{"type" => "string"},
+        "java_version" => %{"type" => "string"},
+        "is_ci" => %{"type" => "boolean"},
+        "git_branch" => %{"type" => "string"},
+        "git_commit_sha" => %{"type" => "string"},
+        "git_ref" => %{"type" => "string"},
+        "root_project_name" => %{"type" => "string"},
+        "requested_tasks" => %{"type" => "array", "items" => %{"type" => "string"}},
+        "tasks_local_hit_count" => %{"type" => "integer"},
+        "tasks_remote_hit_count" => %{"type" => "integer"},
+        "tasks_up_to_date_count" => %{"type" => "integer"},
+        "tasks_executed_count" => %{"type" => "integer"},
+        "tasks_failed_count" => %{"type" => "integer"},
+        "tasks_skipped_count" => %{"type" => "integer"},
+        "tasks_no_source_count" => %{"type" => "integer"},
+        "cacheable_tasks_count" => %{"type" => "integer"},
+        "cache_hit_rate" => %{"type" => ["number", "null"]},
+        "inserted_at" => %{"type" => "string"}
+      },
+      "required" => [
+        "id",
+        "duration_ms",
+        "status",
+        "gradle_version",
+        "java_version",
+        "is_ci",
+        "git_branch",
+        "git_commit_sha",
+        "git_ref",
+        "root_project_name",
+        "requested_tasks",
+        "tasks_local_hit_count",
+        "tasks_remote_hit_count",
+        "tasks_up_to_date_count",
+        "tasks_executed_count",
+        "tasks_failed_count",
+        "tasks_skipped_count",
+        "tasks_no_source_count",
+        "cacheable_tasks_count",
+        "cache_hit_rate",
+        "inserted_at"
+      ],
+      "additionalProperties" => false
     }
 
   alias Tuist.Gradle

--- a/server/lib/tuist/mcp/components/tools/get_test_case.ex
+++ b/server/lib/tuist/mcp/components/tools/get_test_case.ex
@@ -28,6 +28,40 @@ defmodule Tuist.MCP.Components.Tools.GetTestCase do
               "Required when not using test_case_id. Must be combined with account_handle and project_handle."
         }
       }
+    },
+    output_schema: %{
+      "type" => "object",
+      "properties" => %{
+        "id" => %{"type" => "string"},
+        "name" => %{"type" => "string"},
+        "module_name" => %{"type" => "string"},
+        "suite_name" => %{"type" => "string"},
+        "is_flaky" => %{"type" => "boolean"},
+        "state" => %{"type" => "string"},
+        "last_status" => %{"type" => "string"},
+        "last_duration" => %{"type" => "integer"},
+        "avg_duration" => %{"type" => "integer"},
+        "reliability_rate" => %{"type" => ["number", "null"]},
+        "flakiness_rate" => %{"type" => "number"},
+        "total_runs" => %{"type" => "integer"},
+        "failed_runs" => %{"type" => "integer"}
+      },
+      "required" => [
+        "id",
+        "name",
+        "module_name",
+        "suite_name",
+        "is_flaky",
+        "state",
+        "last_status",
+        "last_duration",
+        "avg_duration",
+        "reliability_rate",
+        "flakiness_rate",
+        "total_runs",
+        "failed_runs"
+      ],
+      "additionalProperties" => false
     }
 
   alias Tuist.MCP.Tool, as: MCPTool
@@ -125,6 +159,6 @@ defmodule Tuist.MCP.Components.Tools.GetTestCase do
       failed_runs: analytics.failed_count
     }
 
-    MCPTool.json_response(data)
+    MCPTool.json_response(data, __MODULE__)
   end
 end

--- a/server/lib/tuist/mcp/components/tools/get_test_case_run.ex
+++ b/server/lib/tuist/mcp/components/tools/get_test_case_run.ex
@@ -15,6 +15,73 @@ defmodule Tuist.MCP.Components.Tools.GetTestCaseRun do
         }
       },
       "required" => ["test_case_run_id"]
+    },
+    output_schema: %{
+      "type" => "object",
+      "properties" => %{
+        "id" => %{"type" => "string"},
+        "test_case_id" => %{"type" => ["string", "null"]},
+        "test_run_id" => %{"type" => "string"},
+        "name" => %{"type" => "string"},
+        "module_name" => %{"type" => "string"},
+        "suite_name" => %{"type" => "string"},
+        "status" => %{"type" => "string"},
+        "duration" => %{"type" => "integer"},
+        "is_ci" => %{"type" => "boolean"},
+        "is_flaky" => %{"type" => "boolean"},
+        "is_new" => %{"type" => "boolean"},
+        "scheme" => %{"type" => "string"},
+        "git_branch" => %{"type" => "string"},
+        "git_commit_sha" => %{"type" => "string"},
+        "ran_at" => %{"type" => "string"},
+        "failures" => %{
+          "type" => "array",
+          "items" => %{
+            "type" => "object",
+            "properties" => %{
+              "message" => %{"type" => ["string", "null"]},
+              "path" => %{"type" => ["string", "null"]},
+              "line_number" => %{"type" => "integer"},
+              "issue_type" => %{"type" => "string"}
+            },
+            "required" => ["message", "path", "line_number", "issue_type"],
+            "additionalProperties" => false
+          }
+        },
+        "repetitions" => %{
+          "type" => "array",
+          "items" => %{
+            "type" => "object",
+            "properties" => %{
+              "repetition_number" => %{"type" => "integer"},
+              "status" => %{"type" => "string"},
+              "duration" => %{"type" => "integer"}
+            },
+            "required" => ["repetition_number", "status", "duration"],
+            "additionalProperties" => false
+          }
+        }
+      },
+      "required" => [
+        "id",
+        "test_case_id",
+        "test_run_id",
+        "name",
+        "module_name",
+        "suite_name",
+        "status",
+        "duration",
+        "is_ci",
+        "is_flaky",
+        "is_new",
+        "scheme",
+        "git_branch",
+        "git_commit_sha",
+        "ran_at",
+        "failures",
+        "repetitions"
+      ],
+      "additionalProperties" => false
     }
 
   alias Tuist.MCP.Formatter

--- a/server/lib/tuist/mcp/components/tools/get_test_run.ex
+++ b/server/lib/tuist/mcp/components/tools/get_test_run.ex
@@ -15,6 +15,40 @@ defmodule Tuist.MCP.Components.Tools.GetTestRun do
         }
       },
       "required" => ["test_run_id"]
+    },
+    output_schema: %{
+      "type" => "object",
+      "properties" => %{
+        "id" => %{"type" => "string"},
+        "status" => %{"type" => "string"},
+        "duration" => %{"type" => "integer"},
+        "is_ci" => %{"type" => "boolean"},
+        "is_flaky" => %{"type" => "boolean"},
+        "scheme" => %{"type" => "string"},
+        "git_branch" => %{"type" => "string"},
+        "git_commit_sha" => %{"type" => "string"},
+        "ran_at" => %{"type" => "string"},
+        "total_test_count" => %{"type" => "integer"},
+        "failed_test_count" => %{"type" => "integer"},
+        "flaky_test_count" => %{"type" => "integer"},
+        "avg_test_duration" => %{"type" => "number"}
+      },
+      "required" => [
+        "id",
+        "status",
+        "duration",
+        "is_ci",
+        "is_flaky",
+        "scheme",
+        "git_branch",
+        "git_commit_sha",
+        "ran_at",
+        "total_test_count",
+        "failed_test_count",
+        "flaky_test_count",
+        "avg_test_duration"
+      ],
+      "additionalProperties" => false
     }
 
   alias Tuist.MCP.Formatter

--- a/server/lib/tuist/mcp/components/tools/get_xcode_build.ex
+++ b/server/lib/tuist/mcp/components/tools/get_xcode_build.ex
@@ -15,6 +15,48 @@ defmodule Tuist.MCP.Components.Tools.GetXcodeBuild do
         }
       },
       "required" => ["build_run_id"]
+    },
+    output_schema: %{
+      "type" => "object",
+      "properties" => %{
+        "id" => %{"type" => "string"},
+        "duration" => %{"type" => "integer"},
+        "status" => %{"type" => "string"},
+        "category" => %{"type" => ["string", "null"]},
+        "scheme" => %{"type" => "string"},
+        "configuration" => %{"type" => "string"},
+        "xcode_version" => %{"type" => "string"},
+        "macos_version" => %{"type" => "string"},
+        "model_identifier" => %{"type" => "string"},
+        "is_ci" => %{"type" => "boolean"},
+        "git_branch" => %{"type" => "string"},
+        "git_commit_sha" => %{"type" => "string"},
+        "git_ref" => %{"type" => "string"},
+        "cacheable_tasks_count" => %{"type" => "integer"},
+        "cacheable_task_local_hits_count" => %{"type" => "integer"},
+        "cacheable_task_remote_hits_count" => %{"type" => "integer"},
+        "inserted_at" => %{"type" => "string"}
+      },
+      "required" => [
+        "id",
+        "duration",
+        "status",
+        "category",
+        "scheme",
+        "configuration",
+        "xcode_version",
+        "macos_version",
+        "model_identifier",
+        "is_ci",
+        "git_branch",
+        "git_commit_sha",
+        "git_ref",
+        "cacheable_tasks_count",
+        "cacheable_task_local_hits_count",
+        "cacheable_task_remote_hits_count",
+        "inserted_at"
+      ],
+      "additionalProperties" => false
     }
 
   alias Tuist.Builds

--- a/server/lib/tuist/mcp/components/tools/list_bundles.ex
+++ b/server/lib/tuist/mcp/components/tools/list_bundles.ex
@@ -32,6 +32,47 @@ defmodule Tuist.MCP.Components.Tools.ListBundles do
         }
       },
       "required" => ["account_handle", "project_handle"]
+    },
+    output_schema: %{
+      "type" => "object",
+      "properties" => %{
+        "bundles" => %{
+          "type" => "array",
+          "items" => %{
+            "type" => "object",
+            "properties" => %{
+              "id" => %{"type" => "string"},
+              "name" => %{"type" => "string"},
+              "app_bundle_id" => %{"type" => "string"},
+              "version" => %{"type" => "string"},
+              "type" => %{"type" => "string"},
+              "supported_platforms" => %{"type" => "array", "items" => %{"type" => "string"}},
+              "install_size" => %{"type" => "integer"},
+              "download_size" => %{"type" => ["integer", "null"]},
+              "git_branch" => %{"type" => ["string", "null"]},
+              "git_commit_sha" => %{"type" => ["string", "null"]},
+              "inserted_at" => %{"type" => "string"}
+            },
+            "required" => [
+              "id",
+              "name",
+              "app_bundle_id",
+              "version",
+              "type",
+              "supported_platforms",
+              "install_size",
+              "download_size",
+              "git_branch",
+              "git_commit_sha",
+              "inserted_at"
+            ],
+            "additionalProperties" => false
+          }
+        },
+        "pagination_metadata" => Tuist.MCP.Tool.pagination_metadata_schema()
+      },
+      "required" => ["bundles", "pagination_metadata"],
+      "additionalProperties" => false
     }
 
   alias Tuist.Bundles

--- a/server/lib/tuist/mcp/components/tools/list_cache_runs.ex
+++ b/server/lib/tuist/mcp/components/tools/list_cache_runs.ex
@@ -36,6 +36,55 @@ defmodule Tuist.MCP.Components.Tools.ListCacheRuns do
         }
       },
       "required" => ["account_handle", "project_handle"]
+    },
+    output_schema: %{
+      "type" => "object",
+      "properties" => %{
+        "cache_runs" => %{
+          "type" => "array",
+          "items" => %{
+            "type" => "object",
+            "properties" => %{
+              "id" => %{"type" => "string"},
+              "duration" => %{"type" => "integer"},
+              "status" => %{"type" => "string"},
+              "tuist_version" => %{"type" => "string"},
+              "swift_version" => %{"type" => "string"},
+              "macos_version" => %{"type" => "string"},
+              "is_ci" => %{"type" => "boolean"},
+              "git_branch" => %{"type" => ["string", "null"]},
+              "git_commit_sha" => %{"type" => ["string", "null"]},
+              "git_ref" => %{"type" => ["string", "null"]},
+              "command_arguments" => %{"type" => ["string", "null"]},
+              "cacheable_targets" => %{"type" => "array", "items" => %{"type" => "string"}},
+              "local_cache_target_hits" => %{"type" => "array", "items" => %{"type" => "string"}},
+              "remote_cache_target_hits" => %{"type" => "array", "items" => %{"type" => "string"}},
+              "ran_at" => %{"type" => "string"}
+            },
+            "required" => [
+              "id",
+              "duration",
+              "status",
+              "tuist_version",
+              "swift_version",
+              "macos_version",
+              "is_ci",
+              "git_branch",
+              "git_commit_sha",
+              "git_ref",
+              "command_arguments",
+              "cacheable_targets",
+              "local_cache_target_hits",
+              "remote_cache_target_hits",
+              "ran_at"
+            ],
+            "additionalProperties" => false
+          }
+        },
+        "pagination_metadata" => Tuist.MCP.Tool.pagination_metadata_schema()
+      },
+      "required" => ["cache_runs", "pagination_metadata"],
+      "additionalProperties" => false
     }
 
   alias Tuist.CommandEvents

--- a/server/lib/tuist/mcp/components/tools/list_generations.ex
+++ b/server/lib/tuist/mcp/components/tools/list_generations.ex
@@ -36,6 +36,55 @@ defmodule Tuist.MCP.Components.Tools.ListGenerations do
         }
       },
       "required" => ["account_handle", "project_handle"]
+    },
+    output_schema: %{
+      "type" => "object",
+      "properties" => %{
+        "generations" => %{
+          "type" => "array",
+          "items" => %{
+            "type" => "object",
+            "properties" => %{
+              "id" => %{"type" => "string"},
+              "duration" => %{"type" => "integer"},
+              "status" => %{"type" => "string"},
+              "tuist_version" => %{"type" => "string"},
+              "swift_version" => %{"type" => "string"},
+              "macos_version" => %{"type" => "string"},
+              "is_ci" => %{"type" => "boolean"},
+              "git_branch" => %{"type" => ["string", "null"]},
+              "git_commit_sha" => %{"type" => ["string", "null"]},
+              "git_ref" => %{"type" => ["string", "null"]},
+              "command_arguments" => %{"type" => ["string", "null"]},
+              "cacheable_targets" => %{"type" => "array", "items" => %{"type" => "string"}},
+              "local_cache_target_hits" => %{"type" => "array", "items" => %{"type" => "string"}},
+              "remote_cache_target_hits" => %{"type" => "array", "items" => %{"type" => "string"}},
+              "ran_at" => %{"type" => "string"}
+            },
+            "required" => [
+              "id",
+              "duration",
+              "status",
+              "tuist_version",
+              "swift_version",
+              "macos_version",
+              "is_ci",
+              "git_branch",
+              "git_commit_sha",
+              "git_ref",
+              "command_arguments",
+              "cacheable_targets",
+              "local_cache_target_hits",
+              "remote_cache_target_hits",
+              "ran_at"
+            ],
+            "additionalProperties" => false
+          }
+        },
+        "pagination_metadata" => Tuist.MCP.Tool.pagination_metadata_schema()
+      },
+      "required" => ["generations", "pagination_metadata"],
+      "additionalProperties" => false
     }
 
   alias Tuist.CommandEvents

--- a/server/lib/tuist/mcp/components/tools/list_gradle_build_tasks.ex
+++ b/server/lib/tuist/mcp/components/tools/list_gradle_build_tasks.ex
@@ -32,6 +32,43 @@ defmodule Tuist.MCP.Components.Tools.ListGradleBuildTasks do
         }
       },
       "required" => ["build_run_id"]
+    },
+    output_schema: %{
+      "type" => "object",
+      "properties" => %{
+        "tasks" => %{
+          "type" => "array",
+          "items" => %{
+            "type" => "object",
+            "properties" => %{
+              "id" => %{"type" => "string"},
+              "task_path" => %{"type" => "string"},
+              "task_type" => %{"type" => "string"},
+              "outcome" => %{"type" => "string"},
+              "cacheable" => %{"type" => "boolean"},
+              "duration_ms" => %{"type" => "integer"},
+              "cache_key" => %{"type" => ["string", "null"]},
+              "cache_artifact_size" => %{"type" => ["integer", "null"]},
+              "started_at" => %{"type" => ["string", "null"]}
+            },
+            "required" => [
+              "id",
+              "task_path",
+              "task_type",
+              "outcome",
+              "cacheable",
+              "duration_ms",
+              "cache_key",
+              "cache_artifact_size",
+              "started_at"
+            ],
+            "additionalProperties" => false
+          }
+        },
+        "pagination_metadata" => Tuist.MCP.Tool.pagination_metadata_schema()
+      },
+      "required" => ["tasks", "pagination_metadata"],
+      "additionalProperties" => false
     }
 
   alias Tuist.Gradle

--- a/server/lib/tuist/mcp/components/tools/list_gradle_builds.ex
+++ b/server/lib/tuist/mcp/components/tools/list_gradle_builds.ex
@@ -36,6 +36,57 @@ defmodule Tuist.MCP.Components.Tools.ListGradleBuilds do
         }
       },
       "required" => ["account_handle", "project_handle"]
+    },
+    output_schema: %{
+      "type" => "object",
+      "properties" => %{
+        "builds" => %{
+          "type" => "array",
+          "items" => %{
+            "type" => "object",
+            "properties" => %{
+              "id" => %{"type" => "string"},
+              "duration_ms" => %{"type" => "integer"},
+              "status" => %{"type" => "string"},
+              "gradle_version" => %{"type" => "string"},
+              "java_version" => %{"type" => "string"},
+              "is_ci" => %{"type" => "boolean"},
+              "git_branch" => %{"type" => "string"},
+              "git_commit_sha" => %{"type" => "string"},
+              "root_project_name" => %{"type" => "string"},
+              "requested_tasks" => %{"type" => "array", "items" => %{"type" => "string"}},
+              "tasks_local_hit_count" => %{"type" => "integer"},
+              "tasks_remote_hit_count" => %{"type" => "integer"},
+              "tasks_executed_count" => %{"type" => "integer"},
+              "cacheable_tasks_count" => %{"type" => "integer"},
+              "cache_hit_rate" => %{"type" => ["number", "null"]},
+              "inserted_at" => %{"type" => "string"}
+            },
+            "required" => [
+              "id",
+              "duration_ms",
+              "status",
+              "gradle_version",
+              "java_version",
+              "is_ci",
+              "git_branch",
+              "git_commit_sha",
+              "root_project_name",
+              "requested_tasks",
+              "tasks_local_hit_count",
+              "tasks_remote_hit_count",
+              "tasks_executed_count",
+              "cacheable_tasks_count",
+              "cache_hit_rate",
+              "inserted_at"
+            ],
+            "additionalProperties" => false
+          }
+        },
+        "pagination_metadata" => Tuist.MCP.Tool.pagination_metadata_schema()
+      },
+      "required" => ["builds", "pagination_metadata"],
+      "additionalProperties" => false
     }
 
   alias Tuist.Gradle

--- a/server/lib/tuist/mcp/components/tools/list_projects.ex
+++ b/server/lib/tuist/mcp/components/tools/list_projects.ex
@@ -1,6 +1,6 @@
 defmodule Tuist.MCP.Components.Tools.ListProjects do
   @moduledoc """
-  List all projects accessible to the authenticated user.
+  List all projects accessible to the authenticated subject.
   """
 
   use Tuist.MCP.Tool,
@@ -9,6 +9,36 @@ defmodule Tuist.MCP.Components.Tools.ListProjects do
     schema: %{
       "type" => "object",
       "properties" => %{}
+    },
+    output_schema: %{
+      "type" => "object",
+      "properties" => %{
+        "projects" => %{
+          "type" => "array",
+          "items" => %{
+            "type" => "object",
+            "properties" => %{
+              "id" => %{"type" => "integer"},
+              "name" => %{"type" => "string"},
+              "account_handle" => %{"type" => "string"},
+              "full_handle" => %{"type" => "string"},
+              "build_system" => %{"type" => "string", "enum" => ["xcode", "gradle"]},
+              "default_branch" => %{"type" => "string"}
+            },
+            "required" => [
+              "id",
+              "name",
+              "account_handle",
+              "full_handle",
+              "build_system",
+              "default_branch"
+            ],
+            "additionalProperties" => false
+          }
+        }
+      },
+      "required" => ["projects"],
+      "additionalProperties" => false
     }
 
   alias Tuist.MCP.Authorization
@@ -16,25 +46,27 @@ defmodule Tuist.MCP.Components.Tools.ListProjects do
   alias Tuist.Projects
 
   @impl EMCP.Tool
-  def description, do: "List all projects accessible to the authenticated user."
+  def description, do: "List all projects accessible to the authenticated subject."
 
   @impl EMCP.Tool
   def call(conn, _args) do
     subject = Authorization.authenticated_subject(conn.assigns)
     projects = Projects.list_accessible_projects(subject, preload: [:account])
 
-    data =
-      Enum.map(projects, fn project ->
-        %{
-          id: project.id,
-          name: project.name,
-          account_handle: project.account.name,
-          full_handle: "#{project.account.name}/#{project.name}",
-          build_system: to_string(project.build_system),
-          default_branch: project.default_branch
-        }
-      end)
+    data = %{
+      projects:
+        Enum.map(projects, fn project ->
+          %{
+            id: project.id,
+            name: project.name,
+            account_handle: project.account.name,
+            full_handle: "#{project.account.name}/#{project.name}",
+            build_system: to_string(project.build_system),
+            default_branch: project.default_branch
+          }
+        end)
+    }
 
-    MCPTool.json_response(data)
+    MCPTool.json_response(data, __MODULE__)
   end
 end

--- a/server/lib/tuist/mcp/components/tools/list_test_case_events.ex
+++ b/server/lib/tuist/mcp/components/tools/list_test_case_events.ex
@@ -1,6 +1,6 @@
 defmodule Tuist.MCP.Components.Tools.ListTestCaseEvents do
   @moduledoc """
-  List events for a test case (e.g. marked_flaky, quarantined, first_run). The test_case_id can also be a Tuist dashboard URL, e.g. https://tuist.dev/{account_handle}/{project_handle}/tests/test-cases/{test_case_id}.
+  List events for a test case (e.g. marked_flaky, muted, skipped, first_run). The test_case_id can also be a Tuist dashboard URL, e.g. https://tuist.dev/{account_handle}/{project_handle}/tests/test-cases/{test_case_id}.
   """
 
   use Tuist.MCP.Tool,
@@ -23,6 +23,35 @@ defmodule Tuist.MCP.Components.Tools.ListTestCaseEvents do
         }
       },
       "required" => ["test_case_id"]
+    },
+    output_schema: %{
+      "type" => "object",
+      "properties" => %{
+        "events" => %{
+          "type" => "array",
+          "items" => %{
+            "type" => "object",
+            "properties" => %{
+              "event_type" => %{"type" => "string"},
+              "inserted_at" => %{"type" => "string"},
+              "actor" => %{
+                "type" => ["object", "null"],
+                "properties" => %{
+                  "id" => %{"type" => "integer"},
+                  "name" => %{"type" => "string"}
+                },
+                "required" => ["id", "name"],
+                "additionalProperties" => false
+              }
+            },
+            "required" => ["event_type", "inserted_at", "actor"],
+            "additionalProperties" => false
+          }
+        },
+        "pagination_metadata" => Tuist.MCP.Tool.pagination_metadata_schema()
+      },
+      "required" => ["events", "pagination_metadata"],
+      "additionalProperties" => false
     }
 
   alias Tuist.MCP.Formatter
@@ -35,7 +64,7 @@ defmodule Tuist.MCP.Components.Tools.ListTestCaseEvents do
   @impl EMCP.Tool
   def description,
     do:
-      "List events for a test case (e.g. marked_flaky, quarantined, first_run). The test_case_id can also be a Tuist dashboard URL, e.g. #{Tuist.Environment.app_url()}/{account_handle}/{project_handle}/tests/test-cases/{test_case_id}."
+      "List events for a test case (e.g. marked_flaky, muted, skipped, first_run). The test_case_id can also be a Tuist dashboard URL, e.g. #{Tuist.Environment.app_url()}/{account_handle}/{project_handle}/tests/test-cases/{test_case_id}."
 
   @impl EMCP.Tool
   def call(conn, %{"test_case_id" => test_case_id} = args) when is_binary(test_case_id) do
@@ -51,17 +80,20 @@ defmodule Tuist.MCP.Components.Tools.ListTestCaseEvents do
         page_size = MCPTool.page_size(args)
         {events, meta} = Tests.list_test_case_events(test_case.id, %{page: page, page_size: page_size})
 
-        MCPTool.json_response(%{
-          events:
-            Enum.map(events, fn event ->
-              %{
-                event_type: event.event_type,
-                inserted_at: Formatter.iso8601(event.inserted_at, naive: :utc),
-                actor: if(event.actor, do: %{id: event.actor.id, name: event.actor.name})
-              }
-            end),
-          pagination_metadata: MCPTool.pagination_metadata(meta)
-        })
+        MCPTool.json_response(
+          %{
+            events:
+              Enum.map(events, fn event ->
+                %{
+                  event_type: event.event_type,
+                  inserted_at: Formatter.iso8601(event.inserted_at, naive: :utc),
+                  actor: if(event.actor, do: %{id: event.actor.id, name: event.actor.name})
+                }
+              end),
+            pagination_metadata: MCPTool.pagination_metadata(meta)
+          },
+          __MODULE__
+        )
 
       {:error, message} ->
         EMCP.Tool.error(message)

--- a/server/lib/tuist/mcp/components/tools/list_test_case_run_attachments.ex
+++ b/server/lib/tuist/mcp/components/tools/list_test_case_run_attachments.ex
@@ -15,6 +15,28 @@ defmodule Tuist.MCP.Components.Tools.ListTestCaseRunAttachments do
         }
       },
       "required" => ["test_case_run_id"]
+    },
+    output_schema: %{
+      "type" => "object",
+      "properties" => %{
+        "test_case_run_id" => %{"type" => "string"},
+        "attachments" => %{
+          "type" => "array",
+          "items" => %{
+            "type" => "object",
+            "properties" => %{
+              "id" => %{"type" => "string"},
+              "file_name" => %{"type" => "string"},
+              "type" => %{"type" => "string"},
+              "download_url" => %{"type" => "string"}
+            },
+            "required" => ["id", "file_name", "type", "download_url"],
+            "additionalProperties" => false
+          }
+        }
+      },
+      "required" => ["test_case_run_id", "attachments"],
+      "additionalProperties" => false
     }
 
   alias Tuist.MCP.Tool, as: MCPTool

--- a/server/lib/tuist/mcp/components/tools/list_test_case_runs.ex
+++ b/server/lib/tuist/mcp/components/tools/list_test_case_runs.ex
@@ -40,6 +40,51 @@ defmodule Tuist.MCP.Components.Tools.ListTestCaseRuns do
         }
       },
       "required" => ["account_handle", "project_handle"]
+    },
+    output_schema: %{
+      "type" => "object",
+      "properties" => %{
+        "test_case_runs" => %{
+          "type" => "array",
+          "items" => %{
+            "type" => "object",
+            "properties" => %{
+              "id" => %{"type" => "string"},
+              "test_case_id" => %{"type" => ["string", "null"]},
+              "test_run_id" => %{"type" => "string"},
+              "name" => %{"type" => "string"},
+              "module_name" => %{"type" => "string"},
+              "suite_name" => %{"type" => "string"},
+              "status" => %{"type" => "string"},
+              "duration" => %{"type" => "integer"},
+              "is_ci" => %{"type" => "boolean"},
+              "is_flaky" => %{"type" => "boolean"},
+              "git_branch" => %{"type" => "string"},
+              "git_commit_sha" => %{"type" => "string"},
+              "ran_at" => %{"type" => "string"}
+            },
+            "required" => [
+              "id",
+              "test_case_id",
+              "test_run_id",
+              "name",
+              "module_name",
+              "suite_name",
+              "status",
+              "duration",
+              "is_ci",
+              "is_flaky",
+              "git_branch",
+              "git_commit_sha",
+              "ran_at"
+            ],
+            "additionalProperties" => false
+          }
+        },
+        "pagination_metadata" => Tuist.MCP.Tool.pagination_metadata_schema()
+      },
+      "required" => ["test_case_runs", "pagination_metadata"],
+      "additionalProperties" => false
     }
 
   alias Tuist.MCP.Formatter

--- a/server/lib/tuist/mcp/components/tools/list_test_cases.ex
+++ b/server/lib/tuist/mcp/components/tools/list_test_cases.ex
@@ -50,6 +50,45 @@ defmodule Tuist.MCP.Components.Tools.ListTestCases do
         }
       },
       "required" => ["account_handle", "project_handle"]
+    },
+    output_schema: %{
+      "type" => "object",
+      "properties" => %{
+        "test_cases" => %{
+          "type" => "array",
+          "items" => %{
+            "type" => "object",
+            "properties" => %{
+              "id" => %{"type" => "string"},
+              "name" => %{"type" => "string"},
+              "module_name" => %{"type" => "string"},
+              "suite_name" => %{"type" => "string"},
+              "is_flaky" => %{"type" => "boolean"},
+              "state" => %{"type" => "string"},
+              "last_status" => %{"type" => "string"},
+              "last_duration" => %{"type" => "integer"},
+              "last_ran_at" => %{"type" => "string"},
+              "avg_duration" => %{"type" => "integer"}
+            },
+            "required" => [
+              "id",
+              "name",
+              "module_name",
+              "suite_name",
+              "is_flaky",
+              "state",
+              "last_status",
+              "last_duration",
+              "last_ran_at",
+              "avg_duration"
+            ],
+            "additionalProperties" => false
+          }
+        },
+        "pagination_metadata" => Tuist.MCP.Tool.pagination_metadata_schema()
+      },
+      "required" => ["test_cases", "pagination_metadata"],
+      "additionalProperties" => false
     }
 
   alias Tuist.MCP.Formatter

--- a/server/lib/tuist/mcp/components/tools/list_test_module_runs.ex
+++ b/server/lib/tuist/mcp/components/tools/list_test_module_runs.ex
@@ -27,6 +27,39 @@ defmodule Tuist.MCP.Components.Tools.ListTestModuleRuns do
         }
       },
       "required" => ["test_run_id"]
+    },
+    output_schema: %{
+      "type" => "object",
+      "properties" => %{
+        "modules" => %{
+          "type" => "array",
+          "items" => %{
+            "type" => "object",
+            "properties" => %{
+              "name" => %{"type" => "string"},
+              "status" => %{"type" => "string"},
+              "is_flaky" => %{"type" => "boolean"},
+              "duration" => %{"type" => "integer"},
+              "test_suite_count" => %{"type" => "integer"},
+              "test_case_count" => %{"type" => "integer"},
+              "avg_test_case_duration" => %{"type" => "integer"}
+            },
+            "required" => [
+              "name",
+              "status",
+              "is_flaky",
+              "duration",
+              "test_suite_count",
+              "test_case_count",
+              "avg_test_case_duration"
+            ],
+            "additionalProperties" => false
+          }
+        },
+        "pagination_metadata" => Tuist.MCP.Tool.pagination_metadata_schema()
+      },
+      "required" => ["modules", "pagination_metadata"],
+      "additionalProperties" => false
     }
 
   alias Tuist.MCP.Tool, as: MCPTool

--- a/server/lib/tuist/mcp/components/tools/list_test_runs.ex
+++ b/server/lib/tuist/mcp/components/tools/list_test_runs.ex
@@ -45,6 +45,49 @@ defmodule Tuist.MCP.Components.Tools.ListTestRuns do
         }
       },
       "required" => ["account_handle", "project_handle"]
+    },
+    output_schema: %{
+      "type" => "object",
+      "properties" => %{
+        "test_runs" => %{
+          "type" => "array",
+          "items" => %{
+            "type" => "object",
+            "properties" => %{
+              "id" => %{"type" => "string"},
+              "duration" => %{"type" => "integer"},
+              "status" => %{"type" => "string"},
+              "is_ci" => %{"type" => "boolean"},
+              "is_flaky" => %{"type" => "boolean"},
+              "scheme" => %{"type" => "string"},
+              "git_branch" => %{"type" => "string"},
+              "git_commit_sha" => %{"type" => "string"},
+              "ran_at" => %{"type" => "string"},
+              "total_test_count" => %{"type" => "integer"},
+              "ran_tests" => %{"type" => "integer"},
+              "skipped_tests" => %{"type" => "integer"}
+            },
+            "required" => [
+              "id",
+              "duration",
+              "status",
+              "is_ci",
+              "is_flaky",
+              "scheme",
+              "git_branch",
+              "git_commit_sha",
+              "ran_at",
+              "total_test_count",
+              "ran_tests",
+              "skipped_tests"
+            ],
+            "additionalProperties" => false
+          }
+        },
+        "pagination_metadata" => Tuist.MCP.Tool.pagination_metadata_schema()
+      },
+      "required" => ["test_runs", "pagination_metadata"],
+      "additionalProperties" => false
     }
 
   alias Tuist.MCP.Formatter

--- a/server/lib/tuist/mcp/components/tools/list_test_suite_runs.ex
+++ b/server/lib/tuist/mcp/components/tools/list_test_suite_runs.ex
@@ -31,6 +31,37 @@ defmodule Tuist.MCP.Components.Tools.ListTestSuiteRuns do
         }
       },
       "required" => ["test_run_id"]
+    },
+    output_schema: %{
+      "type" => "object",
+      "properties" => %{
+        "suites" => %{
+          "type" => "array",
+          "items" => %{
+            "type" => "object",
+            "properties" => %{
+              "name" => %{"type" => "string"},
+              "status" => %{"type" => "string"},
+              "is_flaky" => %{"type" => "boolean"},
+              "duration" => %{"type" => "integer"},
+              "test_case_count" => %{"type" => "integer"},
+              "avg_test_case_duration" => %{"type" => "integer"}
+            },
+            "required" => [
+              "name",
+              "status",
+              "is_flaky",
+              "duration",
+              "test_case_count",
+              "avg_test_case_duration"
+            ],
+            "additionalProperties" => false
+          }
+        },
+        "pagination_metadata" => Tuist.MCP.Tool.pagination_metadata_schema()
+      },
+      "required" => ["suites", "pagination_metadata"],
+      "additionalProperties" => false
     }
 
   alias Tuist.MCP.Tool, as: MCPTool

--- a/server/lib/tuist/mcp/components/tools/list_xcode_build_cache_tasks.ex
+++ b/server/lib/tuist/mcp/components/tools/list_xcode_build_cache_tasks.ex
@@ -33,6 +33,42 @@ defmodule Tuist.MCP.Components.Tools.ListXcodeBuildCacheTasks do
         }
       },
       "required" => ["build_run_id"]
+    },
+    output_schema: %{
+      "type" => "object",
+      "properties" => %{
+        "tasks" => %{
+          "type" => "array",
+          "items" => %{
+            "type" => "object",
+            "properties" => %{
+              "type" => %{"type" => "string", "enum" => ["clang", "swift"]},
+              "status" => %{"type" => "string", "enum" => ["hit_local", "hit_remote", "miss"]},
+              "key" => %{"type" => "string"},
+              "read_duration" => %{"type" => ["number", "null"]},
+              "write_duration" => %{"type" => ["number", "null"]},
+              "description" => %{"type" => ["string", "null"]},
+              "cas_output_node_ids" => %{
+                "type" => "array",
+                "items" => %{"type" => "string"}
+              }
+            },
+            "required" => [
+              "type",
+              "status",
+              "key",
+              "read_duration",
+              "write_duration",
+              "description",
+              "cas_output_node_ids"
+            ],
+            "additionalProperties" => false
+          }
+        },
+        "pagination_metadata" => Tuist.MCP.Tool.pagination_metadata_schema()
+      },
+      "required" => ["tasks", "pagination_metadata"],
+      "additionalProperties" => false
     }
 
   alias Tuist.Builds

--- a/server/lib/tuist/mcp/components/tools/list_xcode_build_cas_outputs.ex
+++ b/server/lib/tuist/mcp/components/tools/list_xcode_build_cas_outputs.ex
@@ -1,11 +1,11 @@
 defmodule Tuist.MCP.Components.Tools.ListXcodeBuildCASOutputs do
   @moduledoc """
-  List CAS (Content Addressable Storage) outputs for a specific Xcode build run. Only available for projects with build_system=xcode. The build_run_id can also be a Tuist dashboard URL, e.g. https://tuist.dev/{account}/{project}/builds/build-runs/{id}.
+  List content-addressable storage outputs for a specific Xcode build run. Only available for projects with build_system=xcode. The build_run_id can also be a Tuist dashboard URL, e.g. https://tuist.dev/{account}/{project}/builds/build-runs/{id}.
   """
 
   use Tuist.MCP.Tool,
     name: "list_xcode_build_cas_outputs",
-    title: "List Xcode Build CAS Outputs",
+    title: "List Xcode Build Content-Addressable Storage Outputs",
     schema: %{
       "type" => "object",
       "properties" => %{
@@ -19,7 +19,7 @@ defmodule Tuist.MCP.Components.Tools.ListXcodeBuildCASOutputs do
         },
         "type" => %{
           "type" => "string",
-          "description" => "Filter by CAS output type (e.g. swift, object, dSYM)."
+          "description" => "Filter by content-addressable storage output type (e.g. swift, object, dSYM)."
         },
         "page" => %{
           "type" => "integer",
@@ -31,6 +31,39 @@ defmodule Tuist.MCP.Components.Tools.ListXcodeBuildCASOutputs do
         }
       },
       "required" => ["build_run_id"]
+    },
+    output_schema: %{
+      "type" => "object",
+      "properties" => %{
+        "outputs" => %{
+          "type" => "array",
+          "items" => %{
+            "type" => "object",
+            "properties" => %{
+              "node_id" => %{"type" => "string"},
+              "checksum" => %{"type" => "string"},
+              "size" => %{"type" => "integer"},
+              "compressed_size" => %{"type" => "integer"},
+              "duration" => %{"type" => "integer"},
+              "operation" => %{"type" => "string", "enum" => ["download", "upload"]},
+              "type" => %{"type" => "string"}
+            },
+            "required" => [
+              "node_id",
+              "checksum",
+              "size",
+              "compressed_size",
+              "duration",
+              "operation",
+              "type"
+            ],
+            "additionalProperties" => false
+          }
+        },
+        "pagination_metadata" => Tuist.MCP.Tool.pagination_metadata_schema()
+      },
+      "required" => ["outputs", "pagination_metadata"],
+      "additionalProperties" => false
     }
 
   alias Tuist.Builds
@@ -39,7 +72,7 @@ defmodule Tuist.MCP.Components.Tools.ListXcodeBuildCASOutputs do
   @impl EMCP.Tool
   def description,
     do:
-      "List CAS (Content Addressable Storage) outputs for a specific Xcode build run. Only available for projects with build_system=xcode. The build_run_id can also be a Tuist dashboard URL, e.g. #{Tuist.Environment.app_url()}/{account}/{project}/builds/build-runs/{id}."
+      "List content-addressable storage outputs for a specific Xcode build run. Only available for projects with build_system=xcode. The build_run_id can also be a Tuist dashboard URL, e.g. #{Tuist.Environment.app_url()}/{account}/{project}/builds/build-runs/{id}."
 
   def execute(conn, args) do
     build_run_id = Map.get(args, "build_run_id")

--- a/server/lib/tuist/mcp/components/tools/list_xcode_build_files.ex
+++ b/server/lib/tuist/mcp/components/tools/list_xcode_build_files.ex
@@ -35,6 +35,29 @@ defmodule Tuist.MCP.Components.Tools.ListXcodeBuildFiles do
         }
       },
       "required" => ["build_run_id"]
+    },
+    output_schema: %{
+      "type" => "object",
+      "properties" => %{
+        "files" => %{
+          "type" => "array",
+          "items" => %{
+            "type" => "object",
+            "properties" => %{
+              "type" => %{"type" => "string", "enum" => ["swift", "c"]},
+              "target" => %{"type" => "string"},
+              "project" => %{"type" => "string"},
+              "path" => %{"type" => "string"},
+              "compilation_duration" => %{"type" => "integer"}
+            },
+            "required" => ["type", "target", "project", "path", "compilation_duration"],
+            "additionalProperties" => false
+          }
+        },
+        "pagination_metadata" => Tuist.MCP.Tool.pagination_metadata_schema()
+      },
+      "required" => ["files", "pagination_metadata"],
+      "additionalProperties" => false
     }
 
   alias Tuist.Builds

--- a/server/lib/tuist/mcp/components/tools/list_xcode_build_issues.ex
+++ b/server/lib/tuist/mcp/components/tools/list_xcode_build_issues.ex
@@ -1,6 +1,6 @@
 defmodule Tuist.MCP.Components.Tools.ListXcodeBuildIssues do
   @moduledoc """
-  List build issues (warnings and errors) for a specific build run. The build_run_id can also be a Tuist dashboard URL, e.g. https://tuist.dev/{account}/{project}/builds/build-runs/{id}.
+  List build issues (warnings and errors) for a specific Xcode build run. The build_run_id can also be a Tuist dashboard URL, e.g. https://tuist.dev/{account}/{project}/builds/build-runs/{id}.
   """
 
   use Tuist.MCP.Tool,
@@ -27,6 +27,70 @@ defmodule Tuist.MCP.Components.Tools.ListXcodeBuildIssues do
         }
       },
       "required" => ["build_run_id"]
+    },
+    output_schema: %{
+      "type" => "object",
+      "properties" => %{
+        "issues" => %{
+          "type" => "array",
+          "items" => %{
+            "type" => "object",
+            "properties" => %{
+              "type" => %{"type" => "string", "enum" => ["warning", "error"]},
+              "target" => %{"type" => "string"},
+              "project" => %{"type" => "string"},
+              "title" => %{"type" => "string"},
+              "message" => %{"type" => ["string", "null"]},
+              "signature" => %{"type" => ["string", "null"]},
+              "step_type" => %{
+                "type" => "string",
+                "enum" => [
+                  "c_compilation",
+                  "swift_compilation",
+                  "script_execution",
+                  "create_static_library",
+                  "linker",
+                  "copy_swift_libs",
+                  "compile_assets_catalog",
+                  "compile_storyboard",
+                  "write_auxiliary_file",
+                  "link_storyboards",
+                  "copy_resource_file",
+                  "merge_swift_module",
+                  "xib_compilation",
+                  "swift_aggregated_compilation",
+                  "precompile_bridging_header",
+                  "other",
+                  "validate_embedded_binary",
+                  "validate"
+                ]
+              },
+              "path" => %{"type" => ["string", "null"]},
+              "starting_line" => %{"type" => "integer"},
+              "ending_line" => %{"type" => "integer"},
+              "starting_column" => %{"type" => "integer"},
+              "ending_column" => %{"type" => "integer"}
+            },
+            "required" => [
+              "type",
+              "target",
+              "project",
+              "title",
+              "message",
+              "signature",
+              "step_type",
+              "path",
+              "starting_line",
+              "ending_line",
+              "starting_column",
+              "ending_column"
+            ],
+            "additionalProperties" => false
+          }
+        }
+      },
+      "required" => ["issues"],
+      "additionalProperties" => false
     }
 
   alias Tuist.Builds
@@ -35,7 +99,7 @@ defmodule Tuist.MCP.Components.Tools.ListXcodeBuildIssues do
   @impl EMCP.Tool
   def description,
     do:
-      "List build issues (warnings and errors) for a specific build run. The build_run_id can also be a Tuist dashboard URL, e.g. #{Tuist.Environment.app_url()}/{account}/{project}/builds/build-runs/{id}."
+      "List build issues (warnings and errors) for a specific Xcode build run. The build_run_id can also be a Tuist dashboard URL, e.g. #{Tuist.Environment.app_url()}/{account}/{project}/builds/build-runs/{id}."
 
   def execute(conn, args) do
     build_run_id = Map.get(args, "build_run_id")
@@ -57,22 +121,25 @@ defmodule Tuist.MCP.Components.Tools.ListXcodeBuildIssues do
         |> maybe_filter(:step_type, Map.get(args, "step_type"))
 
       {:ok,
-       Enum.map(issues, fn issue ->
-         %{
-           type: to_string(issue.type),
-           target: issue.target,
-           project: issue.project,
-           title: issue.title,
-           message: issue.message,
-           signature: issue.signature,
-           step_type: to_string(issue.step_type),
-           path: issue.path,
-           starting_line: issue.starting_line,
-           ending_line: issue.ending_line,
-           starting_column: issue.starting_column,
-           ending_column: issue.ending_column
-         }
-       end)}
+       %{
+         issues:
+           Enum.map(issues, fn issue ->
+             %{
+               type: to_string(issue.type),
+               target: issue.target,
+               project: issue.project,
+               title: issue.title,
+               message: issue.message,
+               signature: issue.signature,
+               step_type: to_string(issue.step_type),
+               path: issue.path,
+               starting_line: issue.starting_line,
+               ending_line: issue.ending_line,
+               starting_column: issue.starting_column,
+               ending_column: issue.ending_column
+             }
+           end)
+       }}
     end
   end
 

--- a/server/lib/tuist/mcp/components/tools/list_xcode_build_targets.ex
+++ b/server/lib/tuist/mcp/components/tools/list_xcode_build_targets.ex
@@ -27,6 +27,35 @@ defmodule Tuist.MCP.Components.Tools.ListXcodeBuildTargets do
         }
       },
       "required" => ["build_run_id"]
+    },
+    output_schema: %{
+      "type" => "object",
+      "properties" => %{
+        "targets" => %{
+          "type" => "array",
+          "items" => %{
+            "type" => "object",
+            "properties" => %{
+              "name" => %{"type" => "string"},
+              "project" => %{"type" => "string"},
+              "build_duration" => %{"type" => "integer"},
+              "compilation_duration" => %{"type" => "integer"},
+              "status" => %{"type" => "string", "enum" => ["success", "failure"]}
+            },
+            "required" => [
+              "name",
+              "project",
+              "build_duration",
+              "compilation_duration",
+              "status"
+            ],
+            "additionalProperties" => false
+          }
+        },
+        "pagination_metadata" => Tuist.MCP.Tool.pagination_metadata_schema()
+      },
+      "required" => ["targets", "pagination_metadata"],
+      "additionalProperties" => false
     }
 
   alias Tuist.Builds

--- a/server/lib/tuist/mcp/components/tools/list_xcode_builds.ex
+++ b/server/lib/tuist/mcp/components/tools/list_xcode_builds.ex
@@ -44,6 +44,51 @@ defmodule Tuist.MCP.Components.Tools.ListXcodeBuilds do
         }
       },
       "required" => ["account_handle", "project_handle"]
+    },
+    output_schema: %{
+      "type" => "object",
+      "properties" => %{
+        "builds" => %{
+          "type" => "array",
+          "items" => %{
+            "type" => "object",
+            "properties" => %{
+              "id" => %{"type" => "string"},
+              "duration" => %{"type" => "integer"},
+              "status" => %{"type" => "string"},
+              "category" => %{"type" => ["string", "null"]},
+              "scheme" => %{"type" => "string"},
+              "configuration" => %{"type" => "string"},
+              "is_ci" => %{"type" => "boolean"},
+              "git_branch" => %{"type" => "string"},
+              "git_commit_sha" => %{"type" => "string"},
+              "cacheable_tasks_count" => %{"type" => "integer"},
+              "cacheable_task_local_hits_count" => %{"type" => "integer"},
+              "cacheable_task_remote_hits_count" => %{"type" => "integer"},
+              "inserted_at" => %{"type" => "string"}
+            },
+            "required" => [
+              "id",
+              "duration",
+              "status",
+              "category",
+              "scheme",
+              "configuration",
+              "is_ci",
+              "git_branch",
+              "git_commit_sha",
+              "cacheable_tasks_count",
+              "cacheable_task_local_hits_count",
+              "cacheable_task_remote_hits_count",
+              "inserted_at"
+            ],
+            "additionalProperties" => false
+          }
+        },
+        "pagination_metadata" => Tuist.MCP.Tool.pagination_metadata_schema()
+      },
+      "required" => ["builds", "pagination_metadata"],
+      "additionalProperties" => false
     }
 
   alias Tuist.Builds

--- a/server/lib/tuist/mcp/components/tools/list_xcode_module_cache_targets.ex
+++ b/server/lib/tuist/mcp/components/tools/list_xcode_module_cache_targets.ex
@@ -27,6 +27,59 @@ defmodule Tuist.MCP.Components.Tools.ListXcodeModuleCacheTargets do
         }
       },
       "required" => ["run_id"]
+    },
+    output_schema: %{
+      "type" => "object",
+      "properties" => %{
+        "targets" => %{
+          "type" => "array",
+          "items" => %{
+            "type" => "object",
+            "properties" => %{
+              "name" => %{"type" => "string"},
+              "cache_status" => %{"type" => "string"},
+              "cache_hash" => %{"type" => "string"},
+              "product" => %{"type" => ["string", "null"]},
+              "bundle_id" => %{"type" => ["string", "null"]},
+              "product_name" => %{"type" => ["string", "null"]},
+              "subhashes" => %{
+                "type" => "object",
+                "properties" => %{
+                  "sources" => %{"type" => "string"},
+                  "resources" => %{"type" => "string"},
+                  "copy_files" => %{"type" => "string"},
+                  "core_data_models" => %{"type" => "string"},
+                  "target_scripts" => %{"type" => "string"},
+                  "environment" => %{"type" => "string"},
+                  "headers" => %{"type" => "string"},
+                  "deployment_target" => %{"type" => "string"},
+                  "info_plist" => %{"type" => "string"},
+                  "entitlements" => %{"type" => "string"},
+                  "dependencies" => %{"type" => "string"},
+                  "project_settings" => %{"type" => "string"},
+                  "target_settings" => %{"type" => "string"},
+                  "buildable_folders" => %{"type" => "string"},
+                  "external" => %{"type" => "string"}
+                },
+                "additionalProperties" => false
+              }
+            },
+            "required" => [
+              "name",
+              "cache_status",
+              "cache_hash",
+              "product",
+              "bundle_id",
+              "product_name",
+              "subhashes"
+            ],
+            "additionalProperties" => false
+          }
+        },
+        "pagination_metadata" => Tuist.MCP.Tool.pagination_metadata_schema()
+      },
+      "required" => ["targets", "pagination_metadata"],
+      "additionalProperties" => false
     }
 
   alias Tuist.CommandEvents

--- a/server/lib/tuist/mcp/components/tools/list_xcode_selective_testing_targets.ex
+++ b/server/lib/tuist/mcp/components/tools/list_xcode_selective_testing_targets.ex
@@ -27,6 +27,27 @@ defmodule Tuist.MCP.Components.Tools.ListXcodeTestTargets do
         }
       },
       "required" => ["test_run_id"]
+    },
+    output_schema: %{
+      "type" => "object",
+      "properties" => %{
+        "targets" => %{
+          "type" => "array",
+          "items" => %{
+            "type" => "object",
+            "properties" => %{
+              "name" => %{"type" => "string"},
+              "hit_status" => %{"type" => "string"},
+              "hash" => %{"type" => "string"}
+            },
+            "required" => ["name", "hit_status", "hash"],
+            "additionalProperties" => false
+          }
+        },
+        "pagination_metadata" => Tuist.MCP.Tool.pagination_metadata_schema()
+      },
+      "required" => ["targets", "pagination_metadata"],
+      "additionalProperties" => false
     }
 
   alias Tuist.CommandEvents

--- a/server/lib/tuist/mcp/components/tools/update_test_case.ex
+++ b/server/lib/tuist/mcp/components/tools/update_test_case.ex
@@ -38,6 +38,19 @@ defmodule Tuist.MCP.Components.Tools.UpdateTestCase do
           "description" => "Whether to mark the test case as flaky."
         }
       }
+    },
+    output_schema: %{
+      "type" => "object",
+      "properties" => %{
+        "id" => %{"type" => "string"},
+        "name" => %{"type" => "string"},
+        "module_name" => %{"type" => "string"},
+        "suite_name" => %{"type" => "string"},
+        "is_flaky" => %{"type" => "boolean"},
+        "state" => %{"type" => "string"}
+      },
+      "required" => ["id", "name", "module_name", "suite_name", "is_flaky", "state"],
+      "additionalProperties" => false
     }
 
   alias Tuist.Accounts.AuthenticatedAccount
@@ -100,7 +113,7 @@ defmodule Tuist.MCP.Components.Tools.UpdateTestCase do
     actor_id = conn.assigns |> Authorization.authenticated_subject() |> subject_account_id()
 
     case Tests.update_test_case(test_case_id, attrs, actor_id: actor_id) do
-      {:ok, updated} -> MCPTool.json_response(reply_payload(updated))
+      {:ok, updated} -> MCPTool.json_response(reply_payload(updated), __MODULE__)
       {:error, :not_found} -> EMCP.Tool.error("Test case not found: #{test_case_id}")
     end
   end

--- a/server/lib/tuist/mcp/server.ex
+++ b/server/lib/tuist/mcp/server.ex
@@ -3,7 +3,7 @@ defmodule Tuist.MCP.Server do
 
   use EMCP.Server,
     name: "tuist",
-    version: "1.8.0",
+    version: "1.9.0",
     tools: [
       Tuist.MCP.Components.Tools.CreateOrganization,
       Tuist.MCP.Components.Tools.CreateProject,

--- a/server/lib/tuist/mcp/tool.ex
+++ b/server/lib/tuist/mcp/tool.ex
@@ -4,6 +4,8 @@ defmodule Tuist.MCP.Tool do
   alias Tuist.MCP.Authorization
   alias Tuist.Projects
 
+  require Logger
+
   # --- Macro ---
 
   defmacro __using__(opts) do
@@ -23,7 +25,8 @@ defmodule Tuist.MCP.Tool do
                 args,
                 unquote(action),
                 unquote(category),
-                &execute/3
+                &execute/3,
+                __MODULE__
               )
             end
           end
@@ -32,7 +35,7 @@ defmodule Tuist.MCP.Tool do
           quote do
             @impl EMCP.Tool
             def call(conn, args) do
-              Tuist.MCP.Tool.respond(execute(conn, args))
+              Tuist.MCP.Tool.respond(execute(conn, args), __MODULE__)
             end
           end
       end
@@ -42,6 +45,11 @@ defmodule Tuist.MCP.Tool do
 
       @mcp_tool_name Keyword.fetch!(unquote(opts), :name)
       @mcp_tool_schema Keyword.fetch!(unquote(opts), :schema)
+      @mcp_tool_output_schema Tuist.MCP.Tool.validate_output_schema!(
+                                @mcp_tool_name,
+                                Keyword.fetch!(unquote(opts), :output_schema)
+                              )
+      @mcp_tool_resolved_output_schema ExJsonSchema.Schema.resolve(@mcp_tool_output_schema)
       @mcp_tool_title Keyword.fetch!(unquote(opts), :title)
       @mcp_tool_read_only_hint Keyword.get(unquote(opts), :read_only_hint, true)
       @mcp_tool_open_world_hint Keyword.get(unquote(opts), :open_world_hint, false)
@@ -52,6 +60,10 @@ defmodule Tuist.MCP.Tool do
 
       @impl EMCP.Tool
       def input_schema, do: @mcp_tool_schema
+
+      def output_schema, do: @mcp_tool_output_schema
+
+      def resolved_output_schema, do: @mcp_tool_resolved_output_schema
 
       @impl EMCP.Tool
       def annotations do
@@ -71,13 +83,13 @@ defmodule Tuist.MCP.Tool do
 
   # --- Call dispatchers ---
 
-  def respond({:ok, data}), do: json_response(data)
-  def respond({:error, message}) when is_binary(message), do: EMCP.Tool.error(message)
-  def respond({:error, other}), do: EMCP.Tool.error(inspect(other))
+  def respond({:ok, data}, module), do: json_response(data, module)
+  def respond({:error, message}, _module) when is_binary(message), do: EMCP.Tool.error(message)
+  def respond({:error, other}, _module), do: EMCP.Tool.error(inspect(other))
 
-  def call_with_project(conn, args, action, category, execute_fn) do
+  def call_with_project(conn, args, action, category, execute_fn, module) do
     case resolve_and_authorize_project(args, conn.assigns, action, category) do
-      {:ok, project} -> respond(execute_fn.(conn, args, project))
+      {:ok, project} -> respond(execute_fn.(conn, args, project), module)
       {:error, message} -> EMCP.Tool.error(message)
     end
   end
@@ -121,8 +133,67 @@ defmodule Tuist.MCP.Tool do
 
   # --- Response helpers ---
 
-  def json_response(data) do
-    EMCP.Tool.response([%{"type" => "text", "text" => JSON.encode!(data)}])
+  def json_response(data, module) when is_map(data) do
+    encoded = JSON.encode!(data)
+    structured_content = JSON.decode!(encoded)
+
+    validate_structured_content(module, structured_content)
+
+    %{
+      "content" => [%{"type" => "text", "text" => encoded}],
+      "structuredContent" => structured_content
+    }
+  end
+
+  def json_response(data, module) do
+    raise ArgumentError,
+          "MCP tool #{module.name()} must return a map as structured content, got: #{inspect(data)}"
+  end
+
+  def descriptor(module) do
+    module
+    |> EMCP.Tool.to_map()
+    |> Map.put("outputSchema", module.output_schema())
+  end
+
+  @doc """
+  Asserts at compile time that a tool declares an object output schema. Tools that
+  violate this would otherwise only fail once a client requested `tools/list`, taking
+  down tool discovery for every other tool along with them.
+  """
+  def validate_output_schema!(name, schema) do
+    if not is_map(schema) or (schema["type"] not in ["object", :object] and schema[:type] not in ["object", :object]) do
+      raise ArgumentError, "MCP tool #{name} must provide an object output schema"
+    end
+
+    schema
+  end
+
+  @doc """
+  The output schema fragment describing `pagination_metadata/1`. Shared so the schema
+  and the payload it describes cannot drift apart.
+  """
+  def pagination_metadata_schema do
+    %{
+      "type" => "object",
+      "properties" => %{
+        "has_next_page" => %{"type" => "boolean"},
+        "has_previous_page" => %{"type" => "boolean"},
+        "total_count" => %{"type" => "integer"},
+        "total_pages" => %{"type" => "integer"},
+        "current_page" => %{"type" => "integer"},
+        "page_size" => %{"type" => "integer"}
+      },
+      "required" => [
+        "has_next_page",
+        "has_previous_page",
+        "total_count",
+        "total_pages",
+        "current_page",
+        "page_size"
+      ],
+      "additionalProperties" => false
+    }
   end
 
   @max_page_size 100
@@ -154,6 +225,27 @@ defmodule Tuist.MCP.Tool do
   end
 
   # --- Internal helpers ---
+
+  # Schema drift is a bug in the tool's declared output schema, not in the caller's
+  # request. Raise where a test or a developer will see it, but never turn a
+  # successful query into a 500 for a client that could have used the response.
+  # Logged at :error so the Sentry handler, which only captures :error, reports it.
+  defp validate_structured_content(module, structured_content) do
+    case ExJsonSchema.Validator.validate(module.resolved_output_schema(), structured_content) do
+      :ok ->
+        :ok
+
+      {:error, errors} ->
+        message = "MCP tool #{module.name()} returned invalid structured content: #{inspect(errors)}"
+
+        if Tuist.Environment.dev?() or Tuist.Environment.test?() do
+          raise message
+        else
+          Logger.error(message)
+          :ok
+        end
+    end
+  end
 
   defp load_resource({:ok, resource}, _message), do: {:ok, resource}
   defp load_resource({:error, :not_found}, message), do: {:error, message}

--- a/server/lib/tuist/mcp/transport/streamable_http.ex
+++ b/server/lib/tuist/mcp/transport/streamable_http.ex
@@ -1,0 +1,126 @@
+defmodule Tuist.MCP.Transport.StreamableHTTP do
+  @moduledoc false
+
+  @behaviour Plug
+
+  import Plug.Conn
+
+  alias EMCP.Transport.StreamableHTTP
+
+  @latest_protocol_version "2025-06-18"
+  @supported_protocol_versions [@latest_protocol_version, "2025-03-26"]
+
+  # Only these methods carry anything we decorate. Every other method (notably
+  # `tools/call`, the hot path, whose bodies carry full structuredContent payloads)
+  # is passed through without decoding and re-encoding the response body.
+  @decorated_methods ["initialize", "tools/list"]
+
+  @impl Plug
+  def init(opts), do: StreamableHTTP.init(opts)
+
+  @impl Plug
+  def call(conn, opts) do
+    case validate_protocol_version_header(conn) do
+      :ok ->
+        negotiated_protocol_version = negotiated_protocol_version(conn)
+        method = request_method(conn)
+
+        conn
+        |> register_before_send(&decorate_response(&1, opts, negotiated_protocol_version, method))
+        |> StreamableHTTP.call(opts)
+
+      {:error, version} ->
+        conn
+        |> put_resp_content_type("application/json")
+        |> send_resp(
+          400,
+          JSON.encode!(%{
+            "error" => "Unsupported MCP protocol version: #{version}",
+            "supported" => @supported_protocol_versions
+          })
+        )
+        |> halt()
+    end
+  end
+
+  defp validate_protocol_version_header(conn) do
+    case get_req_header(conn, "mcp-protocol-version") do
+      [] -> :ok
+      [version] when version in @supported_protocol_versions -> :ok
+      [version] -> {:error, version}
+      versions -> {:error, Enum.join(versions, ", ")}
+    end
+  end
+
+  defp negotiated_protocol_version(%Plug.Conn{
+         body_params: %{"method" => "initialize", "params" => %{"protocolVersion" => requested_version}}
+       }) do
+    if requested_version in @supported_protocol_versions,
+      do: requested_version,
+      else: @latest_protocol_version
+  end
+
+  defp negotiated_protocol_version(_conn), do: nil
+
+  defp request_method(%Plug.Conn{body_params: %{"method" => method}}) when is_binary(method), do: method
+  defp request_method(_conn), do: nil
+
+  # An unrecognized method (a batch request, or a body Plug did not parse) falls back
+  # to decorating, so we can never silently stop attaching output schemas.
+  defp decorates_response?(nil), do: true
+  defp decorates_response?(method), do: method in @decorated_methods
+
+  defp decorate_response(%Plug.Conn{resp_body: body} = conn, opts, negotiated_protocol_version, method)
+       when not is_nil(body) do
+    if decorates_response?(method) do
+      decode_and_decorate(conn, body, opts, negotiated_protocol_version)
+    else
+      conn
+    end
+  end
+
+  defp decorate_response(conn, _opts, _negotiated_protocol_version, _method), do: conn
+
+  defp decode_and_decorate(conn, body, opts, negotiated_protocol_version) do
+    case body |> IO.iodata_to_binary() |> JSON.decode() do
+      {:ok, response} ->
+        response =
+          response
+          |> put_negotiated_protocol_version(negotiated_protocol_version)
+          |> add_output_schemas(opts)
+
+        conn
+        |> delete_resp_header("content-length")
+        |> Map.put(:resp_body, JSON.encode!(response))
+
+      _ ->
+        conn
+    end
+  end
+
+  defp put_negotiated_protocol_version(
+         %{"result" => %{"protocolVersion" => _current_version} = result} = response,
+         negotiated_protocol_version
+       )
+       when is_binary(negotiated_protocol_version) do
+    put_in(response, ["result"], Map.put(result, "protocolVersion", negotiated_protocol_version))
+  end
+
+  defp put_negotiated_protocol_version(response, _negotiated_protocol_version), do: response
+
+  defp add_output_schemas(%{"result" => %{"tools" => tools} = result} = response, opts) when is_list(tools) do
+    modules = opts |> Keyword.fetch!(:server) |> apply(:server, []) |> Map.fetch!(:tools)
+
+    descriptors =
+      Enum.map(tools, fn %{"name" => name} = tool ->
+        case Map.fetch(modules, name) do
+          {:ok, module} -> Tuist.MCP.Tool.descriptor(module)
+          :error -> tool
+        end
+      end)
+
+    put_in(response, ["result"], Map.put(result, "tools", descriptors))
+  end
+
+  defp add_output_schemas(response, _opts), do: response
+end

--- a/server/lib/tuist_web/router.ex
+++ b/server/lib/tuist_web/router.ex
@@ -474,7 +474,7 @@ defmodule TuistWeb.Router do
   scope "/" do
     pipe_through [:mcp]
 
-    forward "/mcp", EMCP.Transport.StreamableHTTP, server: Tuist.MCP.Server
+    forward "/mcp", Tuist.MCP.Transport.StreamableHTTP, server: Tuist.MCP.Server
   end
 
   scope "/scim/v2", TuistWeb.SCIM do

--- a/server/mix.exs
+++ b/server/mix.exs
@@ -125,6 +125,7 @@ defmodule Tuist.MixProject do
       # Pinned to the open upstream fix for intermittent missing tool-call
       # responses. Revert to a Hex version once the fix is released.
       {:emcp, github: "addstar34/emcp", ref: "c687e279cf4f550f69934549a1303312ed3a23b5", override: true},
+      {:ex_json_schema, "~> 0.11"},
       {:ua_parser, "~> 1.8"},
       {:money, "~> 1.12"},
       {:image, "~> 0.60"},

--- a/server/priv/docs/en/guides/features/agentic-coding/mcp.md
+++ b/server/priv/docs/en/guides/features/agentic-coding/mcp.md
@@ -118,13 +118,15 @@ If your agent supports `auth.md`, you can connect without opening a browser. Dep
 
 The following tools are available through the Tuist MCP server:
 
+Every tool publishes a human-readable description together with explicit input and output schemas. Successful calls return structured content that conforms to the advertised output schema, plus the same result serialized as text for clients that do not yet consume structured content.
+
 #### Projects
 
 | Tool | Description | Required parameters |
 |------|-------------|---------------------|
 | `create_organization` | Create a Tuist organization for the authenticated user. | `handle` |
 | `create_project` | Create a Tuist project under an account the authenticated user can access. | `account_handle`, `project_handle` |
-| `add_organization_member` | Add an existing Tuist user to an organization. | `organization_handle`, `email` |
+| `add_organization_member` | Add an existing Tuist user to an organization or update an existing member's role. | `organization_handle`, `email` |
 | `list_projects` | List all projects accessible to the authenticated user. | None |
 
 #### Xcode builds
@@ -160,6 +162,9 @@ The following tools are available through the Tuist MCP server:
 | `list_test_case_runs` | List test case runs, optionally filtered by test case or test run. | `account_handle`, `project_handle` |
 | `get_test_case_run` | Get failure details and repetitions for a specific test case run. | `test_case_run_id` |
 | `list_test_case_run_attachments` | List attachments for a test case run. Each attachment includes a temporary download URL. | `test_case_run_id` |
+| `list_test_case_events` | List state changes for a test case, such as muting or skipping it. | `test_case_id` |
+| `update_test_case` | Update a test case's state or flaky classification. | `test_case_id` or `identifier` + `account_handle` + `project_handle` |
+| `list_xcode_test_targets` | List selective-testing target results for a test run. | `test_run_id` |
 
 #### Bundles
 

--- a/server/test/tuist/mcp/components/tools/list_projects_test.exs
+++ b/server/test/tuist/mcp/components/tools/list_projects_test.exs
@@ -14,17 +14,24 @@ defmodule Tuist.MCP.Components.Tools.ListProjectsTest do
 
       result = ListProjects.call(conn, %{})
 
-      assert %{"content" => [%{"type" => "text", "text" => text}]} = result
+      assert %{
+               "content" => [%{"type" => "text", "text" => text}],
+               "structuredContent" => structured_content
+             } = result
 
-      assert [
-               %{
-                 "account_handle" => account_handle,
-                 "build_system" => "xcode",
-                 "full_handle" => full_handle,
-                 "id" => project_id,
-                 "name" => project_name
-               }
-             ] = JSON.decode!(text)
+      assert %{
+               "projects" => [
+                 %{
+                   "account_handle" => account_handle,
+                   "build_system" => "xcode",
+                   "full_handle" => full_handle,
+                   "id" => project_id,
+                   "name" => project_name
+                 }
+               ]
+             } = JSON.decode!(text)
+
+      assert structured_content == JSON.decode!(text)
 
       assert account_handle == user.account.name
       assert full_handle == "#{user.account.name}/#{project.name}"

--- a/server/test/tuist/mcp/components/tools/xcode_build_tools_test.exs
+++ b/server/test/tuist/mcp/components/tools/xcode_build_tools_test.exs
@@ -232,8 +232,8 @@ defmodule Tuist.MCP.Components.Tools.XcodeBuildToolsTest do
 
       assert %{"content" => [%{"type" => "text", "text" => text}]} = result
       result = JSON.decode!(text)
-      assert length(result) == 1
-      assert hd(result)["title"] == "Type mismatch"
+      assert length(result["issues"]) == 1
+      assert hd(result["issues"])["title"] == "Type mismatch"
     end
   end
 

--- a/server/test/tuist/mcp/server_test.exs
+++ b/server/test/tuist/mcp/server_test.exs
@@ -42,11 +42,25 @@ defmodule Tuist.MCP.ServerTest do
       assert "list_projects" in tool_names
     end
 
-    test "every tool exposes a human-readable title and explicit review hints" do
+    test "every tool exposes descriptions, schemas, a human-readable title, and explicit review hints" do
       server = Server.server()
 
       for {name, module} <- server.tools do
+        descriptor = Tuist.MCP.Tool.descriptor(module)
         annotations = module.annotations()
+
+        assert is_binary(descriptor["description"]) and descriptor["description"] != "",
+               "tool #{name} is missing a non-empty description"
+
+        assert descriptor["inputSchema"] == module.input_schema()
+        assert descriptor["outputSchema"] == module.output_schema()
+        assert descriptor["outputSchema"]["type"] == "object"
+        assert is_map(descriptor["outputSchema"]["properties"])
+
+        assert descriptor["outputSchema"]["additionalProperties"] == false,
+               "tool #{name} must reject undeclared output properties"
+
+        ExJsonSchema.Schema.resolve(descriptor["outputSchema"])
 
         assert is_binary(annotations[:title]) and annotations[:title] != "",
                "tool #{name} is missing a non-empty :title annotation"

--- a/server/test/tuist/mcp/tool_test.exs
+++ b/server/test/tuist/mcp/tool_test.exs
@@ -1,0 +1,130 @@
+defmodule Tuist.MCP.ToolTest do
+  use ExUnit.Case, async: true
+  use Mimic
+
+  import ExUnit.CaptureLog
+
+  alias Tuist.MCP.Components.Tools.ListBundles
+  alias Tuist.MCP.Tool
+
+  defp valid_payload do
+    %{
+      bundles: [
+        %{
+          id: "bundle-id",
+          name: "App",
+          app_bundle_id: "dev.tuist.app",
+          version: "1.0.0",
+          type: "app",
+          supported_platforms: ["ios"],
+          install_size: 1000,
+          download_size: 900,
+          git_branch: "main",
+          git_commit_sha: "abc123",
+          inserted_at: "2026-07-10T00:00:00Z"
+        }
+      ],
+      pagination_metadata:
+        Tool.pagination_metadata(%{
+          has_next_page?: false,
+          has_previous_page?: false,
+          total_count: 1,
+          total_pages: 1,
+          current_page: 1,
+          page_size: 20
+        })
+    }
+  end
+
+  describe "json_response/2" do
+    test "returns both the encoded text content and the structured content" do
+      response = Tool.json_response(valid_payload(), ListBundles)
+
+      assert [%{"type" => "text", "text" => text}] = response["content"]
+      assert JSON.decode!(text) == response["structuredContent"]
+      assert response["structuredContent"]["bundles"] |> hd() |> Map.get("id") == "bundle-id"
+    end
+
+    test "raises in dev and test so schema drift fails loudly for developers" do
+      payload = put_in(valid_payload(), [:bundles, Access.at(0), :install_size], nil)
+
+      assert_raise RuntimeError, ~r/list_bundles returned invalid structured content/, fn ->
+        Tool.json_response(payload, ListBundles)
+      end
+    end
+
+    test "logs an error and still serves the payload outside dev and test" do
+      stub(Tuist.Environment, :dev?, fn -> false end)
+      stub(Tuist.Environment, :test?, fn -> false end)
+
+      payload = put_in(valid_payload(), [:bundles, Access.at(0), :install_size], nil)
+
+      log =
+        capture_log(fn ->
+          response = Tool.json_response(payload, ListBundles)
+
+          assert response["structuredContent"]["bundles"] |> hd() |> Map.get("install_size") == nil
+        end)
+
+      assert log =~ "list_bundles returned invalid structured content"
+      assert log =~ "[error]"
+    end
+
+    test "raises a descriptive error when a tool returns a payload that is not a map" do
+      assert_raise ArgumentError, ~r/list_bundles must return a map as structured content/, fn ->
+        Tool.json_response([1, 2, 3], ListBundles)
+      end
+    end
+  end
+
+  describe "descriptor/1" do
+    test "attaches the output schema without validating it at request time" do
+      descriptor = Tool.descriptor(ListBundles)
+
+      assert descriptor["outputSchema"] == ListBundles.output_schema()
+      assert descriptor["name"] == "list_bundles"
+    end
+  end
+
+  describe "validate_output_schema!/2" do
+    test "rejects a schema that does not describe an object" do
+      assert_raise ArgumentError, ~r/must provide an object output schema/, fn ->
+        Tool.validate_output_schema!("bad_tool", %{"type" => "array"})
+      end
+    end
+
+    test "returns the schema untouched when it describes an object" do
+      schema = %{"type" => "object", "properties" => %{}}
+
+      assert Tool.validate_output_schema!("good_tool", schema) == schema
+    end
+  end
+
+  describe "pagination_metadata_schema/0" do
+    test "accepts exactly what pagination_metadata/1 emits" do
+      payload =
+        %{
+          has_next_page?: true,
+          has_previous_page?: false,
+          total_count: 42,
+          total_pages: 3,
+          current_page: 1,
+          page_size: 20
+        }
+        |> Tool.pagination_metadata()
+        |> JSON.encode!()
+        |> JSON.decode!()
+
+      assert :ok = ExJsonSchema.Validator.validate(Tool.pagination_metadata_schema(), payload)
+    end
+  end
+
+  describe "resolved_output_schema/0" do
+    test "every tool pre-resolves its output schema at compile time" do
+      for {name, module} <- Tuist.MCP.Server.server().tools do
+        assert is_struct(module.resolved_output_schema(), ExJsonSchema.Schema.Root),
+               "tool #{name} does not pre-resolve its output schema"
+      end
+    end
+  end
+end

--- a/server/test/tuist_web/controllers/mcp_controller_test.exs
+++ b/server/test/tuist_web/controllers/mcp_controller_test.exs
@@ -6,7 +6,7 @@ defmodule TuistWeb.MCPControllerTest do
   alias TuistWeb.RateLimit
 
   @initialize_params %{
-    "protocolVersion" => "2025-03-26",
+    "protocolVersion" => "2025-06-18",
     "capabilities" => %{},
     "clientInfo" => %{"name" => "test", "version" => "0.1.0"}
   }
@@ -45,8 +45,70 @@ defmodule TuistWeb.MCPControllerTest do
       assert response["jsonrpc"] == "2.0"
       assert response["id"] == 1
       assert is_map(response["result"])
-      assert is_binary(response["result"]["protocolVersion"])
+      assert response["result"]["protocolVersion"] == "2025-06-18"
       assert is_map(response["result"]["capabilities"])
+    end
+
+    test "negotiates the legacy protocol version when requested", %{conn: conn} do
+      user = AccountsFixtures.user_fixture()
+      stub(RateLimit.MCP, :hit, fn _conn -> {:allow, 1} end)
+
+      initialize_params = Map.put(@initialize_params, "protocolVersion", "2025-03-26")
+
+      conn =
+        conn
+        |> authenticated_mcp_conn(user.token)
+        |> post_mcp(%{
+          "jsonrpc" => "2.0",
+          "id" => 1,
+          "method" => "initialize",
+          "params" => initialize_params
+        })
+
+      response = json_response(conn, 200)
+      assert response["result"]["protocolVersion"] == "2025-03-26"
+    end
+
+    test "returns the latest supported protocol version for an unsupported initialization version", %{
+      conn: conn
+    } do
+      user = AccountsFixtures.user_fixture()
+      stub(RateLimit.MCP, :hit, fn _conn -> {:allow, 1} end)
+
+      initialize_params = Map.put(@initialize_params, "protocolVersion", "2099-01-01")
+
+      conn =
+        conn
+        |> authenticated_mcp_conn(user.token)
+        |> post_mcp(%{
+          "jsonrpc" => "2.0",
+          "id" => 1,
+          "method" => "initialize",
+          "params" => initialize_params
+        })
+
+      response = json_response(conn, 200)
+      assert response["result"]["protocolVersion"] == "2025-06-18"
+    end
+
+    test "rejects an unsupported protocol version header", %{conn: conn} do
+      user = AccountsFixtures.user_fixture()
+      stub(RateLimit.MCP, :hit, fn _conn -> {:allow, 1} end)
+
+      conn =
+        conn
+        |> authenticated_mcp_conn(user.token)
+        |> put_req_header("mcp-protocol-version", "2099-01-01")
+        |> post_mcp(%{
+          "jsonrpc" => "2.0",
+          "id" => 2,
+          "method" => "tools/list",
+          "params" => %{}
+        })
+
+      response = json_response(conn, 400)
+      assert response["error"] == "Unsupported MCP protocol version: 2099-01-01"
+      assert response["supported"] == ["2025-06-18", "2025-03-26"]
     end
 
     test "returns error when session is not initialized", %{conn: conn} do
@@ -90,6 +152,7 @@ defmodule TuistWeb.MCPControllerTest do
         build_conn()
         |> authenticated_mcp_conn(user.token)
         |> put_req_header("mcp-session-id", session_id)
+        |> put_req_header("mcp-protocol-version", "2025-06-18")
         |> post_mcp(%{
           "jsonrpc" => "2.0",
           "method" => "notifications/initialized",
@@ -162,6 +225,7 @@ defmodule TuistWeb.MCPControllerTest do
         build_conn()
         |> authenticated_mcp_conn(user.token)
         |> put_req_header("mcp-session-id", session_id)
+        |> put_req_header("mcp-protocol-version", "2025-06-18")
         |> post_mcp(%{
           "jsonrpc" => "2.0",
           "id" => 2,
@@ -173,7 +237,48 @@ defmodule TuistWeb.MCPControllerTest do
 
       assert response["jsonrpc"] == "2.0"
       assert response["id"] == 2
-      assert is_list(response["result"]["tools"])
+
+      tools = response["result"]["tools"]
+      assert length(tools) == 34
+
+      for tool <- tools do
+        assert is_binary(tool["description"]) and tool["description"] != ""
+        assert tool["outputSchema"]["type"] == "object"
+        assert is_map(tool["outputSchema"]["properties"])
+      end
+    end
+
+    test "serves methods that skip response decoration", %{conn: conn} do
+      user = AccountsFixtures.user_fixture()
+      stub(RateLimit.MCP, :hit, fn _conn -> {:allow, 1} end)
+
+      init_conn =
+        conn
+        |> authenticated_mcp_conn(user.token)
+        |> post_mcp(%{
+          "jsonrpc" => "2.0",
+          "id" => 1,
+          "method" => "initialize",
+          "params" => @initialize_params
+        })
+
+      [session_id] = get_resp_header(init_conn, "mcp-session-id")
+
+      conn =
+        build_conn()
+        |> authenticated_mcp_conn(user.token)
+        |> put_req_header("mcp-session-id", session_id)
+        |> put_req_header("mcp-protocol-version", "2025-06-18")
+        |> post_mcp(%{
+          "jsonrpc" => "2.0",
+          "id" => 2,
+          "method" => "prompts/list",
+          "params" => %{}
+        })
+
+      response = json_response(conn, 200)
+      assert response["id"] == 2
+      assert is_list(response["result"]["prompts"])
     end
 
     test "assigns a session ID on first request", %{conn: conn} do


### PR DESCRIPTION
Every tool exposed by the Tuist Model Context Protocol ([MCP](https://modelcontextprotocol.io)) server now advertises an output schema and returns structured content that conforms to it, so agents can rely on the shape of a tool result instead of parsing a JSON string out of a text block.

## What changed

- All 34 MCP tool modules declare an `output_schema` next to their existing input schema.
- Successful tool calls return `structuredContent` alongside the existing text serialization, so clients that do not consume structured content yet are unaffected.
- A new `Tuist.MCP.Transport.StreamableHTTP` plug wraps the upstream transport. It attaches `outputSchema` to each entry in `tools/list` and negotiates the protocol version.
- Output schemas are validated and resolved once at compile time.
- The pagination metadata schema fragment, previously copy-pasted byte-for-byte across 18 tool modules, is now a single shared `Tuist.MCP.Tool.pagination_metadata_schema/0`.
- Documentation notes the schemas, and lists three tools that were registered but undocumented: `list_test_case_events`, `update_test_case`, and `list_xcode_test_targets`.

## Why

Without an output schema, an MCP client has no contract for what a tool returns. It gets a text blob and has to guess. Publishing schemas and structured content lets agents validate and navigate results directly, which is what the specification's `outputSchema` and `structuredContent` fields exist for.

## Approach

Three decisions are worth explaining, because the obvious implementation of each is wrong in a way that only shows up in production.

**Validation failures do not fail the request.** The first cut raised on any mismatch between a tool's payload and its declared schema. There are 276 hand-maintained required non-nullable fields across the 34 tools. Any one of them drifting from reality, such as a column that turns out to be nullable, would have turned a successful query into a 500 for that tool. Schema drift is a bug in our declared schema, not in the caller's request, so it now raises in dev and test, where a developer or continuous integration sees it immediately, and is logged at `:error` in production while the payload is still served. The level matters: Sentry's logger handler only captures `:error`, so a warning would have been silent.

**Schema problems are caught at compile time.** `descriptor/1` originally validated each tool while building the `tools/list` response, so a single tool with a malformed or non-object schema would have raised and blanked tool discovery for all 34 tools at once. That check moved into the `use Tuist.MCP.Tool` macro, so a bad tool fails the build. `descriptor/1` is now pure, and the tool lookup degrades to passing the original entry through rather than raising.

**Only the methods that need decoration pay for it.** Decorating originally decoded and re-encoded the body of every response, including large paginated `tools/call` payloads that contain nothing to decorate. It now skips decoding entirely for undecorated methods, and falls back to decorating when the method is unrecognized so it can never silently stop attaching schemas.

## Impact

MCP clients gain a machine-readable contract for every tool result. Clients that ignore `structuredContent` see no change, since the text content is still present and unchanged.

Two measured wins on the tool-call hot path, taken on a 100-item `list_bundles` payload:

- Resolving each schema once at compile time instead of on every call removes **781 microseconds per tool call**, which is 68% of total validation time.
- Skipping the decode and re-encode for undecorated methods removes **607 microseconds per response**.

Adds one dependency, `ex_json_schema`.

## Validation

- `mix test test/tuist/mcp/ test/tuist_web/controllers/mcp_controller_test.exs test/tuist_web/rate_limit/mcp_test.exs` passes, 100 tests. This includes a new `test/tuist/mcp/tool_test.exs` covering the raise-in-test path, the log-and-serve production path, the non-map payload error, the compile-time guard, and agreement between `pagination_metadata/1` and its schema.
- `mix credo` and `mix format --check-formatted` are clean on the touched files; both `MIX_ENV=dev` and `MIX_ENV=test` compile.
- Confirmed at runtime that a non-object schema and a schema with a bad `$ref` now both fail at compile time.
- Audited all 276 required non-nullable fields against the live ClickHouse column types to look for existing drift. None found. Worth recording for future readers: in these migrations `null: false` is a no-op, and a column is nullable only when its type is explicitly `Nullable(...)`. A non-nullable `String` reads back as `""`, never `nil`. Reasoning from the presence or absence of `null: false` gives the wrong answer.

### How to test locally

Point an MCP client at a local server and inspect a `tools/list` response; each entry now carries an `outputSchema`. Then call any tool, for example `list_bundles`, and confirm the result carries both `structuredContent` and the text content.

```
mix test test/tuist/mcp/ test/tuist_web/controllers/mcp_controller_test.exs
```

To see the compile-time guard, change any tool's `output_schema` to `%{"type" => "array"}` and run `mix compile`. The build fails instead of the failure surfacing at request time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
