### PR TITLE
feat(registry): bring up the production read frontend

### DIFF
--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -7,9 +7,12 @@
 #     --set server.image.tag=$GIT_SHA
 
 registry:
-  # Keep production disabled until the registry cutover. Staging and
-  # canary exercise the component through values-managed-common.yaml.
-  enabled: false
+  # Brings up the read frontend, its ingress, and the DNS-01 cert. It
+  # serves no user traffic until registry.tuist.dev's Cloudflare origin
+  # is repointed at this ingress, which is a separate, revertible step.
+  # The sync writer stays disabled below: cache remains the sole writer
+  # until the cutover.
+  enabled: true
   publicHost: registry.tuist.dev
   serverUrl: https://tuist.dev
   deployEnv: prod


### PR DESCRIPTION
## What

Flips `registry.enabled` to `true` in `values-managed-production.yaml`. That brings up the standalone registry read frontend in production: deployment, service, service account, ingress, network policy, and its external secrets.

> [!IMPORTANT]
> This PR moves **zero user traffic**. `registry.tuist.dev` is Cloudflare-proxied (it resolves to `104.20.17.9` / `172.66.173.37`, the same edge as `tuist.dev`), so the origin is configured in Cloudflare, not in this chart. Merging this stands the pod up next to the current cache-served path and nothing else. The traffic switch is a separate Cloudflare change, and reverting it is a Cloudflare change too.

## Why

The registry service was extracted from cache in #11081. Staging and canary have been running the new read frontend for a while; production is the last environment still serving `registry.tuist.dev` off the legacy cache path. This is the first of the cutover steps.

The cutover has two independent axes that are easy to conflate: **who serves reads**, and **who writes packages into the bucket**. This PR only touches reads. `swiftRegistrySync` stays disabled in production, so cache remains the sole writer, exactly as `7376f8af` established this morning.

Splitting them is deliberate. If reads and writes moved in one deploy and something broke, you would not know which half caused it, and the rollback would span two systems. Standing the pod up while it serves no traffic means the risky part of this step (does it boot, does ESO resolve, does cert-manager issue) is de-risked before any user request touches it.

## Why it is safe

Three things could have made this break, and I checked each:

**Bucket parity.** The read frontend serves whatever is in `S3_REGISTRY_BUCKET`, which it resolves from `tuist-k8s-production/REGISTRY` via ESO. Cache writes to `S3_REGISTRY_BUCKET` from its own `cache` vault. Two different secret sources feeding the same variable name is exactly how you end up serving an empty catalog. Both resolve to `tuist-registry`. Confirmed identical. (Canary matches too, on `tuist-registry-canary`; staging is isolated on `tuist-registry-staging`.)

**Secret completeness.** Production's `REGISTRY` item has the full field set the chart maps (`S3_REGISTRY_BUCKET`, `S3_HOST`, `S3_ACCESS_KEY_ID`, `S3_SECRET_ACCESS_KEY`, `S3_REGION`, `sentry_dsn`), structurally identical to canary and staging. Nothing to add before merge.

**Certificate issuance.** The ingress annotates `cert-manager.io/cluster-issuer: letsencrypt-cloudflare`, a DNS-01 issuer. So `registry-tls` issues without traffic ever reaching the ingress. There is no chicken-and-egg where DNS has to move first to pass an HTTP-01 challenge.

One thing that makes the eventual traffic move safer than expected: production today serves only the legacy `/api/registry/swift/*` prefix, while the new service serves both that and the canonical `/swift/*` (with RFC 8594 deprecation headers on the legacy prefix). So the cutover **adds** a path rather than moving one. SwiftPM clients pinned to today's URLs keep resolving through the switch.

## Validation

- `helm template` with the production overlay (`values-managed-common.yaml` + `values-managed-production.yaml` + `values-ci.yaml`, matching `helm.yml`) renders clean.
- Diffed the rendered resource list against `main`. This change adds exactly seven resources, all the read frontend: `registry-deployment`, `registry-service`, `registry-serviceaccount`, `registry-ingress`, `registry-networkpolicy`, `registry-external-secrets`, `registry-app-secret`. Nothing is removed.
- `swift-registry-sync-*` templates render **zero** resources, confirming the writer stays off.
- The unrelated Docker Hub pull-through mirror (`registry-cache-*`) renders identically before and after.
- Rendered ingress: `host=registry.tuist.dev`, `tls=registry-tls`, `issuer=letsencrypt-cloudflare`.
- Verified against the live hosts that `registry.tuist.dev` currently answers `/api/registry/swift/availability` but 404s `/swift/availability`, while `registry-canary.tuist.dev` answers both. Confirms production is still on the cache path today.

## After merge

Once deployed, the pod is up and idle. Confirm before moving on:

- `registry` pods Ready, external secret synced, `registry-tls` issued by cert-manager.
- Hit the ingress directly (Host header, bypassing Cloudflare) and check `/swift/availability` returns 200 and a known package resolves.

> [!NOTE]
> **Next steps, in this order.** Reads and writes are separate axes and the ordering below is load bearing.
>
> 1. **Move traffic.** Repoint `registry.tuist.dev`'s Cloudflare origin at this ingress, weighted if the config supports it. Canary's registry ingress mostly sees deploy smoke traffic, so we have good evidence the pod answers and weak evidence it holds up under real SwiftPM resolution load. Ramp rather than flip.
> 2. **Enable the server writer in production** (`SWIFT_REGISTRY_SYNC_ENABLED=true`, `swiftRegistrySync.enabled: true`), and revert the canary lines from `7376f8af` rather than applying them, since at that point we are going forward, not holding. Both writers run concurrently for a while, which is fine (see below).
> 3. **Only then stop cache from writing**, via `REGISTRY_SYNC_ALLOWLIST` (#11761), not by repairing `cache-deploy.yml`.
> 4. Delete cache's registry code.

> [!WARNING]
> **Do not disable cache's writer before enabling the server's.** Dual-writing is safe by design: `Cache.Registry.Lock` and `Tuist.Registry.Swift.Lock` are the same implementation, same bucket, same `registry/locks/...` keys, same `If-None-Match: "*"` conditional put. They mutually exclude through S3. The server's moduledoc calls this out explicitly as "the transitional period when cache's SyncWorker still runs alongside this one".
>
> Zero-writing is the state nothing protects. No pod crashes, no alert fires, `registry.tuist.dev` keeps returning 200 for everything already in the bucket. New package versions just stop appearing.

> [!CAUTION]
> **`cache-deploy.yml` is currently a trap.** #11081 removed `{"*/10 * * * *", Cache.Registry.SyncWorker}` from `cache/config/config.exs` on 2026-07-09. Cache has not deployed successfully since **2026-06-03** (last green run, `751ee7db31`), so the running image is five weeks older than the removal and still has the cron. That accident, not any deliberate switch, is the only reason production still syncs.
>
> The workflow was never disabled. It reports `state=active`, has no `if:` gate, and its triggers have not changed since #8640. It only fires on `cache/**` and `tuist_common/**` changes, which is why a month of red went unnoticed.
>
> There are two distinct failures, not one. Runs from 2026-06-03 through 2026-07-08 died in `Deploy with Kamal`: the `op` CLI returns `Too many requests. Your client has been rate-limited`, `SECRETS` resolves to empty, and Kamal aborts with `Could not read password from KAMAL_REGISTRY_PASSWORD in the cache 1Password vault`. Only the most recent run (2026-07-09) died earlier, in `1password/install-cli-action@v2` with `SyntaxError: Unexpected end of JSON input`. Both are 1Password-side. The service-account rate limit is the persistent one, and fixing only the install action would not make the deploy green.
>
> Anyone who repairs those failures, for any unrelated reason, ships the cron removal to production and leaves the registry with no scheduled writer. Following the order above closes this window (step 2 lands the replacement writer before step 3 removes the old one). Until step 2 lands, treat a green `cache-deploy.yml` as a hazard.
>
> Note also that not deploying is not the same as having turned it off. If a cache node reboots and Kamal restarts the container from the same image, sync resumes on its own. Pausing the `registry_sync` Oban queue over SSH does not stick either: cache is on Oban OSS, so a queue pause is in-memory and resumes on restart.

> [!NOTE]
> **We are not going to repair `cache-deploy.yml` to turn sync off.** Deploying `main` would disable the cron, but it would also ship ten commits and 63 files of drift, including an Elixir/Erlang toolchain bump, onto the ten nodes that serve both the CAS cache and every production registry read today. That is too large a change to make as a side effect of switching off a cron, and the 1Password rate limit behind the CI failure is a separate problem with its own fix.
>
> Instead we disable cache's writer with the `REGISTRY_SYNC_ALLOWLIST` env variable (#11761), pointed at a handle no package can have so `apply_allowlist/2` filters everything out and `SyncWorker` no-ops. The running image already reads it (`runtime.exs:158`), so no new code ships, and `sync_worker.ex:188` reads it through `Application.get_env/2` at call time, so it can take effect without a restart. `deploy.canary.yml` already uses the same knob to scope canary sync to one package.
>
> Crucially this leaves the read path alone. `Cache.Config.registry_enabled?` gates the sync worker and the read controller together, so unsetting `S3_REGISTRY_BUCKET` or `REGISTRY_GITHUB_TOKEN` would have taken production's registry reads down alongside the writer.
>
> `cache-deploy.yml` stays red for now. That is a known, accepted state, not an oversight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
