### PR TITLE
chore(cache): disable the registry sync cron in production

### DIFF
--- a/cache/config/deploy.production.yml
+++ b/cache/config/deploy.production.yml
@@ -19,3 +19,16 @@ env:
     DEPLOY_ENV: prod
     XCODE_DATABASE_INTERACTIONS_ENABLED: "false"
     POOL_SIZE: "10"
+    # Disables cache's scheduled registry sync without touching its read
+    # path: `registry_enabled?` gates both, so unsetting the bucket or the
+    # GitHub token would take reads down with it. The allowlist is matched
+    # against `owner/repo` exactly (a trailing `*` would make it a prefix),
+    # so a handle no package can have filters every package out and the
+    # SyncWorker no-ops. Same mechanism canary already uses to scope sync
+    # to one package.
+    #
+    # This is the guard for the cutover window: `main` has already removed
+    # the sync cron, but the running image predates that, so until the
+    # server-owned writer is enabled this keeps cache from being a second
+    # writer and keeps a re-added cron from silently resuming.
+    REGISTRY_SYNC_ALLOWLIST: tuist/__sync-disabled__


### PR DESCRIPTION
## What

Adds `REGISTRY_SYNC_ALLOWLIST: tuist/__sync-disabled__` to production's Kamal env. The deployed `SyncWorker` matches the allowlist against `owner/repo` exactly, so a handle no package can have filters every package out and the worker no-ops.

> [!CAUTION]
> **Do not merge this to apply it. Draft on purpose.** This file matches the `cache/**` push filter on `cache-deploy.yml`, and that workflow runs `kamal deploy` (a full image build and roll), not `kamal env push`. So merging to `main` would roll `main`'s cache image to canary then production. That image already has the sync cron removed (#11081), so a successful roll leaves production with **zero** registry writers while the server-owned writer is still off, plus five weeks of drift and a toolchain bump onto the ten prod nodes. The only thing stopping that today is that `cache-deploy.yml` is red, which is not a safety guarantee. Credit to the Codex review bot for catching this.
>
> **The disable is applied via `kamal env push` run from this branch** (see runbook), which writes the env to the hosts without building or rolling an image and without triggering any workflow. This PR is merged only later, as part of the forward cutover, when a full cache `kamal deploy` from `main` is the intended step and the writer has already been handed to the server.

## Why not just deploy cache from `main`?

`main` already removed the sync cron in #11081, so deploying it would disable syncing. But cache has not deployed successfully since 2026-06-03 (`751ee7db31`), so `main` is ten commits and 63 files ahead, including an Elixir/Erlang toolchain bump. That is a large, untested change landing on the ten nodes that currently serve both the CAS cache and production registry reads. Not something to do as a side effect of turning off a cron.

## Why not unset the bucket or the GitHub token?

`Cache.Config.registry_enabled?` is `registry_bucket() != nil and registry_github_token() != nil`, and it gates both `sync_worker.ex:31` and `registry_controller.ex:19`. Removing either would take cache's registry **reads** down with the writer. Production still serves all registry reads off cache today, so that is an outage, not a cutover.

## Why not pause the Oban queue over SSH?

Cache is on Oban OSS, not Pro. `Oban.pause_queue/2` is in-memory and resumes on the next container restart, node reboot, or OOM. A disable that silently re-enables itself is worse than no disable.

## Why the allowlist

It is the one existing knob that is durable, reads-preserving, and already in use: `deploy.canary.yml` scopes canary sync with `REGISTRY_SYNC_ALLOWLIST: alamofire/alamofire`. This is the same mechanism, pointed at nothing.

It also doubles as the guard for the cutover window. `main` has removed the cron, but the running image predates that. Until the server-owned writer is enabled, this keeps cache from being a second writer and keeps a re-added cron from silently resuming.

> [!WARNING]
> Do not set `REGISTRY_SYNC_ALLOWLIST` to an empty string. `Cache.Config.list_env/1` rejects empty entries, and `apply_allowlist(packages, [])` falls through to **sync everything**. Only a non-matching, non-empty value disables. Do not end the value with `*` either, since a trailing `*` turns it into a prefix match.

## Validation

Simulated `list_env/1` -> `apply_allowlist/2` -> `matches_pattern?/2` exactly as they exist in the deployed image (`751ee7db31`), against a realistic package list:

| `REGISTRY_SYNC_ALLOWLIST` | parsed | packages synced |
| --- | --- | --- |
| `tuist/__sync-disabled__` | `["tuist/__sync-disabled__"]` | **0** |
| `""` | `[]` | 5 (all) |
| unset | `nil` | 5 (all) |

Confirmed against `751ee7db31` (not `main`) that:
- `runtime.exs:158` reads `REGISTRY_SYNC_ALLOWLIST` via `Cache.Config.list_env/1`, so the running image already understands the variable. No new code ships.
- `sync_worker.ex:188` reads `Application.get_env(:cache, :registry_sync_allowlist)` at call time, not at boot, which is what makes the zero-downtime path below work.

## Runbook

Production runs **ten** cache hosts, each firing the `*/10` cron and coordinating through the S3 lock at `registry/locks/sync.json`. Any host you miss becomes the leader and keeps syncing, so every step must cover all ten.

**1. Durable half.** Writes the env file to all ten hosts. No image build, no image pull.

```
cd cache && kamal env push -d production
```

This evaluates `.kamal/secrets.production`, which shells out to `op`. Run it locally, where your own 1Password session is used rather than the rate-limited `CACHE_OP_SERVICE_ACCOUNT_TOKEN` that has been failing CI since 2026-06-03.

**2. Make it take effect.** Two options.

Zero downtime, effective on the next 10-minute tick, per host:

```
kamal app exec -d production --reuse --hosts <host> --interactive "bin/cache remote"
# then, in the IEx session:
Application.put_env(:cache, :registry_sync_allowlist, ["tuist/__sync-disabled__"])
```

Or roll the containers on the image already on the hosts:

```
kamal app version -d production          # read the running version
kamal app boot -d production --version=<that>
```

`servers.web.proxy` is `false`, so a boot stops and starts each container rather than draining through a proxy. Expect a brief per-host blip. The `put_env` path avoids that, and step 1 makes it survive the next restart anyway.

## Verification

- `registry_release` queue stops receiving new jobs; `SyncWorker` still runs every 10 minutes and returns `:ok` having synced nothing.
- No new package versions appear in `tuist-registry`.
- Reads are unaffected: `curl -s -o /dev/null -w '%{http_code}' https://registry.tuist.dev/api/registry/swift/alamofire/alamofire` still returns `200`.

## What this does not do

> [!CAUTION]
> This does not unblock the production read cutover. The deployed cache image predates #11136, so its `normalize_version` rewrites prerelease dots to plus. The production bucket really holds `apple/swift-nio@2.0.0-convergence+1..+4`, while `TuistCommon.Registry.Swift.KeyNormalizer` (used by the new read frontend at `registry_controller.ex:447`) preserves dots. Moving `registry.tuist.dev` to the new frontend before that is reconciled would 404 dotted prerelease lookups. Fix with a read-path fallback, not a bucket rewrite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
