### PR TITLE
chore(search): move Typesense from Kamal to the Kubernetes cluster

### DIFF
--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -80,6 +80,7 @@ jobs:
           set -uo pipefail
           configs=(
             "kura/ops/helm/kura|"
+            "infra/helm/typesense|values-ci.yaml"
             "infra/helm/slack|values-ci.yaml"
             "infra/helm/noora-storybook|values-ci.yaml"
             "infra/helm/tuist|values-ci.yaml"
@@ -146,6 +147,7 @@ jobs:
           set -uo pipefail
           configs=(
             "kura|kura/ops/helm/kura|kura|"
+            "typesense (production)|infra/helm/typesense|typesense|values-production.yaml values-ci.yaml"
             "slack (production)|infra/helm/slack|slack|values-production.yaml values-ci.yaml"
             "noora-storybook (production)|infra/helm/noora-storybook|noora-storybook|values-production.yaml values-ci.yaml"
             "tuist (production)|infra/helm/tuist|tuist|values-managed-common.yaml values-managed-production.yaml values-ci.yaml"

--- a/.github/workflows/typesense-deployment.yml
+++ b/.github/workflows/typesense-deployment.yml
@@ -1,0 +1,149 @@
+name: Typesense Deployment
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - search/**
+      - infra/helm/typesense/**
+      - .github/workflows/typesense-deployment.yml
+  workflow_dispatch:
+    inputs:
+      commit_sha:
+        description: Commit SHA to deploy (defaults to github.sha)
+        required: false
+      image_tag:
+        description: Pre-built image tag to deploy instead of building
+        required: false
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: typesense-deploy-production
+  cancel-in-progress: false
+
+env:
+  MISE_VERSION: "2026.5.15"
+  MISE_GITHUB_TOKEN: ${{ secrets.TUIST_DEPLOY_GITHUB_TOKEN || github.token }}
+  REGISTRY: ghcr.io
+  IMAGE_NAME: tuist/search
+  HELM_CHART_PATH: infra/helm/typesense
+  HELM_RELEASE_NAME: typesense
+  NAMESPACE: typesense
+  DEPLOY_SHA: ${{ inputs.commit_sha || github.sha }}
+
+jobs:
+  build:
+    name: Build and push Typesense image
+    if: inputs.image_tag == ''
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    outputs:
+      image_tag: ${{ steps.tag.outputs.image_tag }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ env.DEPLOY_SHA }}
+          submodules: false
+          persist-credentials: false
+      - id: tag
+        run: echo "image_tag=sha-${DEPLOY_SHA:0:12}" >> "$GITHUB_OUTPUT"
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v6
+        name: Build and push Typesense image
+        with:
+          context: ./search
+          file: ./search/Dockerfile
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.image_tag }}
+
+  deploy:
+    name: Deploy production
+    needs: build
+    if: always() && (needs.build.result == 'success' || needs.build.result == 'skipped')
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment:
+      name: server-k8s-production
+    env:
+      KUBECONFIG: ${{ github.workspace }}/.kube/config
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ env.DEPLOY_SHA }}
+          persist-credentials: false
+      - uses: jdx/mise-action@v4.0.1
+        with:
+          version: ${{ env.MISE_VERSION }}
+          install_args: "--locked helm kubectl"
+          cache: "false"
+      - uses: 1password/install-cli-action@v2
+      - name: Load kubeconfig from 1Password
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+        run: |
+          mkdir -p "$(dirname "$KUBECONFIG")"
+          op document get "kubeconfig: tuist-production" \
+            --vault "tuist-k8s-production" --output "$KUBECONFIG"
+          chmod 600 "$KUBECONFIG"
+      - name: Verify cluster reachability
+        run: |
+          set -euo pipefail
+          API="$(kubectl config view --minify --raw -o jsonpath='{.clusters[0].cluster.server}')"
+          echo "Reaching apiserver at $API"
+          kubectl --request-timeout=10s get --raw /version >/dev/null
+      - name: Resolve image tag
+        env:
+          INPUT_IMAGE_TAG: ${{ inputs.image_tag }}
+          BUILT_IMAGE_TAG: ${{ needs.build.outputs.image_tag }}
+        run: |
+          set -euo pipefail
+          if [ -n "${INPUT_IMAGE_TAG:-}" ]; then
+            IMAGE_TAG="$INPUT_IMAGE_TAG"
+          else
+            IMAGE_TAG="$BUILT_IMAGE_TAG"
+          fi
+
+          if [ -z "$IMAGE_TAG" ]; then
+            echo "No image tag available to deploy."
+            exit 1
+          fi
+
+          echo "IMAGE_TAG=$IMAGE_TAG" >> "$GITHUB_ENV"
+          echo "Deploying image tag $IMAGE_TAG"
+      - name: helm upgrade --install
+        run: |
+          helm upgrade --install "$HELM_RELEASE_NAME" "$HELM_CHART_PATH" \
+            --namespace "$NAMESPACE" --create-namespace \
+            -f "$HELM_CHART_PATH/values-production.yaml" \
+            --set image.tag="$IMAGE_TAG" \
+            --atomic --timeout 10m --wait
+      - name: Diagnostics on failure
+        if: failure()
+        run: |
+          set +e
+          echo "::group::helm history"
+          helm history "$HELM_RELEASE_NAME" -n "$NAMESPACE" --max 10 || true
+          echo "::endgroup::"
+          echo "::group::workload resources"
+          kubectl -n "$NAMESPACE" get deploy,svc,ingress,pvc,cronjob,externalsecret,pods \
+            -l app.kubernetes.io/instance="$HELM_RELEASE_NAME" -o wide || true
+          echo "::endgroup::"
+          echo "::group::deployment"
+          kubectl -n "$NAMESPACE" describe deploy/"$HELM_RELEASE_NAME" || true
+          echo "::endgroup::"
+          echo "::group::logs"
+          kubectl -n "$NAMESPACE" logs deploy/"$HELM_RELEASE_NAME" --tail=200 || true
+          echo "::endgroup::"
+          echo "::group::events"
+          kubectl -n "$NAMESPACE" get events --sort-by=.lastTimestamp 2>&1 | tail -100 || true
+          echo "::endgroup::"

--- a/infra/helm/typesense/AGENTS.md
+++ b/infra/helm/typesense/AGENTS.md
@@ -1,0 +1,39 @@
+# Typesense chart
+
+Standalone chart for the Tuist Typesense search engine, moved from the Kamal
+deployment in `search/` into the cluster. It powers the public docs and forum
+search that `search.tuist.dev` serves, and is the retrieval engine an in-cluster
+agent search service will delegate to in a follow-up.
+
+## Layout
+
+- `Deployment` runs the Typesense server directly (`/opt/typesense-server`) off
+  the `ghcr.io/tuist/search` image, backed by a single ReadWriteOnce PVC at
+  `/data`. `Recreate` strategy, because only one pod may mount the volume.
+- `CronJob` runs the DocC and GitHub indexers (`run-indexers.sh`) against the
+  Service. The DocSearch website scraper is not included; like the Kamal
+  deployment it runs separately because it crawls the public site.
+- `Ingress` exposes `search.tuist.dev` through ingress-nginx with a
+  cert-manager certificate; external-dns publishes the record.
+- `TYPESENSE_API_KEY` and `GITHUB_TOKEN` come from 1Password via an
+  ExternalSecret in production, or inline for CI and dev.
+
+## Cutover
+
+Merging deploys a parallel in-cluster instance without touching the Kamal box or
+DNS. `search.tuist.dev` still resolves to the Kamal node until its Cloudflare
+record is released, because external-dns will not take over a record it does not
+own. Reindex the in-cluster instance and verify the `tuist` and `forum-topics`
+collections before repointing DNS, or docs-site search breaks during the gap.
+
+## Validation
+
+```bash
+helm template infra/helm/typesense -f infra/helm/typesense/values-ci.yaml
+helm template infra/helm/typesense -f infra/helm/typesense/values-production.yaml -f infra/helm/typesense/values-ci.yaml
+```
+
+## Related Context
+
+- Parent boundary: `infra/helm/AGENTS.md`
+- Image and indexers: `search/AGENTS.md`

--- a/infra/helm/typesense/AGENTS.md
+++ b/infra/helm/typesense/AGENTS.md
@@ -18,13 +18,32 @@ agent search service will delegate to in a follow-up.
 - `TYPESENSE_API_KEY` and `GITHUB_TOKEN` come from 1Password via an
   ExternalSecret in production, or inline for CI and dev.
 
+## Collections
+
+Four collections back search, populated by two different mechanisms:
+
+- `projectdescription` (DocC API) and `github-issues` are produced by the
+  bundled indexers (`index-docc`, `index-github`) that the reindex CronJob runs.
+- `tuist` (docs) and `forum-topics` (forum) are produced by the DocSearch
+  scraper (`typesense/docsearch-scraper` with `search/config/docsearch*.json`),
+  which crawls the public site from its own container. It is not part of this
+  chart and today runs out-of-band against the Kamal box.
+
+The public docs and forum search UI (`server/assets/docs/hooks/docs-search-hook.js`)
+queries `tuist` and `forum-topics`, so those two must exist on any instance that
+serves the UI.
+
 ## Cutover
 
 Merging deploys a parallel in-cluster instance without touching the Kamal box or
-DNS. `search.tuist.dev` still resolves to the Kamal node until its Cloudflare
+DNS. `search.tuist.dev` keeps resolving to the Kamal node until its Cloudflare
 record is released, because external-dns will not take over a record it does not
-own. Reindex the in-cluster instance and verify the `tuist` and `forum-topics`
-collections before repointing DNS, or docs-site search breaks during the gap.
+own. Before repointing DNS, all four collections must be populated on the
+in-cluster instance: the CronJob covers `projectdescription` and `github-issues`,
+and the DocSearch scraper must be run against the new Service to populate `tuist`
+and `forum-topics` (migrating the scraper into the cluster is a required
+pre-cutover step). Cutting over before those two exist breaks docs-site and
+forum search.
 
 ## Validation
 

--- a/infra/helm/typesense/Chart.yaml
+++ b/infra/helm/typesense/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: typesense
+description: Standalone Helm chart for deploying the Tuist Typesense search engine.
+type: application
+version: 0.1.0
+appVersion: "27.1"

--- a/infra/helm/typesense/templates/_helpers.tpl
+++ b/infra/helm/typesense/templates/_helpers.tpl
@@ -1,0 +1,65 @@
+{{- define "typesense.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "typesense.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := include "typesense.name" . -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "typesense.labels" -}}
+app.kubernetes.io/name: {{ include "typesense.name" . }}
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- range $key, $value := .Values.global.commonLabels }}
+{{ $key }}: {{ $value | quote }}
+{{- end }}
+{{- end -}}
+
+{{- define "typesense.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "typesense.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "typesense.componentLabels" -}}
+{{ include "typesense.selectorLabels" . }}
+app.kubernetes.io/component: search
+{{- end -}}
+
+{{- define "typesense.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+  {{- default (include "typesense.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+  {{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "typesense.podScheduling" -}}
+{{- with .Values.global.imagePullSecrets }}
+imagePullSecrets:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end -}}
+
+{{- define "typesense.runtimeSecretName" -}}
+{{- default (printf "%s-runtime" (include "typesense.fullname" .)) .Values.runtimeSecrets.secretName -}}
+{{- end -}}
+
+{{- define "typesense.dataClaimName" -}}
+{{- if .Values.persistence.existingClaim -}}
+{{- .Values.persistence.existingClaim -}}
+{{- else if .Values.persistence.create -}}
+{{- printf "%s-data" (include "typesense.fullname" .) -}}
+{{- else -}}
+{{- fail "persistence.existingClaim is required when persistence.create is false" -}}
+{{- end -}}
+{{- end -}}

--- a/infra/helm/typesense/templates/cronjob.yaml
+++ b/infra/helm/typesense/templates/cronjob.yaml
@@ -1,0 +1,62 @@
+{{- if .Values.indexers.enabled }}
+{{- $imageTag := required "image.tag is required" .Values.image.tag -}}
+{{- $nodeSelector := merge (dict) (.Values.global.nodeSelector | default (dict)) (.Values.nodeSelector | default (dict)) -}}
+{{- $tolerations := concat (.Values.global.tolerations | default (list)) (.Values.tolerations | default (list)) -}}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "typesense.fullname" . }}-indexers
+  labels:
+    {{- include "typesense.labels" . | nindent 4 }}
+    app.kubernetes.io/component: search-indexer
+spec:
+  schedule: {{ .Values.indexers.schedule | quote }}
+  concurrencyPolicy: {{ .Values.indexers.concurrencyPolicy }}
+  jobTemplate:
+    spec:
+      backoffLimit: {{ .Values.indexers.backoffLimit }}
+      activeDeadlineSeconds: {{ .Values.indexers.activeDeadlineSeconds }}
+      template:
+        metadata:
+          labels:
+            {{- include "typesense.selectorLabels" . | nindent 12 }}
+            app.kubernetes.io/component: search-indexer
+        spec:
+          restartPolicy: {{ .Values.indexers.restartPolicy }}
+          serviceAccountName: {{ include "typesense.serviceAccountName" . }}
+          automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
+          {{- include "typesense.podScheduling" . | nindent 10 }}
+          {{- with .Values.podSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with $nodeSelector }}
+          nodeSelector:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with $tolerations }}
+          tolerations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          containers:
+            - name: indexers
+              image: "{{ .Values.image.repository }}:{{ $imageTag }}"
+              imagePullPolicy: {{ .Values.image.pullPolicy }}
+              command: ["/opt/docsearch/run-indexers.sh"]
+              securityContext:
+                {{- toYaml .Values.containerSecurityContext | nindent 16 }}
+              env:
+                - name: TYPESENSE_HOST
+                  value: {{ printf "http://%s:%v" (include "typesense.fullname" .) .Values.service.port | quote }}
+              envFrom:
+                - secretRef:
+                    name: {{ include "typesense.runtimeSecretName" . }}
+              resources:
+                {{- toYaml .Values.indexers.resources | nindent 16 }}
+              volumeMounts:
+                - name: tmp
+                  mountPath: /tmp
+          volumes:
+            - name: tmp
+              emptyDir: {}
+{{- end }}

--- a/infra/helm/typesense/templates/deployment.yaml
+++ b/infra/helm/typesense/templates/deployment.yaml
@@ -1,0 +1,112 @@
+{{- $imageTag := required "image.tag is required" .Values.image.tag -}}
+{{- $podLabels := merge (dict) (.Values.global.podLabels | default (dict)) (.Values.podLabels | default (dict)) -}}
+{{- $nodeSelector := merge (dict) (.Values.global.nodeSelector | default (dict)) (.Values.nodeSelector | default (dict)) -}}
+{{- $tolerations := concat (.Values.global.tolerations | default (list)) (.Values.tolerations | default (list)) -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "typesense.fullname" . }}
+  labels:
+    {{- include "typesense.labels" . | nindent 4 }}
+    app.kubernetes.io/component: search
+spec:
+  replicas: {{ .Values.replicaCount }}
+  strategy:
+    type: {{ .Values.deploymentStrategy.type }}
+  selector:
+    matchLabels:
+      {{- include "typesense.componentLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "typesense.componentLabels" . | nindent 8 }}
+        {{- with $podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      serviceAccountName: {{ include "typesense.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
+      {{- include "typesense.podScheduling" . | nindent 6 }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: typesense
+          image: "{{ .Values.image.repository }}:{{ $imageTag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          # Run the server directly. The wrapper entrypoint installs an
+          # in-container cron for indexing, which we run as a CronJob instead.
+          command: ["/opt/typesense-server"]
+          securityContext:
+            {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.targetPort }}
+          env:
+            - name: TYPESENSE_DATA_DIR
+              value: {{ .Values.typesense.dataDir | quote }}
+            - name: TYPESENSE_ENABLE_CORS
+              value: {{ .Values.typesense.enableCors | quote }}
+            - name: TYPESENSE_LISTEN_PORT
+              value: {{ printf "%v" .Values.service.targetPort | quote }}
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          envFrom:
+            - secretRef:
+                name: {{ include "typesense.runtimeSecretName" . }}
+          startupProbe:
+            httpGet:
+              path: {{ .Values.probes.startup.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.probes.startup.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.startup.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.startup.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.startup.failureThreshold }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.probes.readiness.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.readiness.failureThreshold }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.probes.liveness.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: data
+              mountPath: {{ .Values.typesense.dataDir }}
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ include "typesense.dataClaimName" . }}
+        - name: tmp
+          emptyDir: {}

--- a/infra/helm/typesense/templates/externalsecret.yaml
+++ b/infra/helm/typesense/templates/externalsecret.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.runtimeSecrets.externalSecret.enabled }}
+{{- $item := required "runtimeSecrets.externalSecret.item is required when runtimeSecrets.externalSecret.enabled is true" .Values.runtimeSecrets.externalSecret.item -}}
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ include "typesense.runtimeSecretName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "typesense.labels" . | nindent 4 }}
+    app.kubernetes.io/component: search
+spec:
+  refreshInterval: {{ .Values.runtimeSecrets.externalSecret.refreshInterval | quote }}
+  secretStoreRef:
+    name: {{ .Values.runtimeSecrets.externalSecret.storeRef.name }}
+    kind: {{ .Values.runtimeSecrets.externalSecret.storeRef.kind }}
+  target:
+    name: {{ include "typesense.runtimeSecretName" . }}
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        TYPESENSE_API_KEY: "{{ `{{ .API_KEY | trim }}` }}"
+        GITHUB_TOKEN: '{{ `{{ .GITHUB_TOKEN | default "" | trim }}` }}'
+  data:
+    - secretKey: API_KEY
+      remoteRef:
+        key: {{ printf "%s/%s" $item .Values.runtimeSecrets.externalSecret.fields.apiKey | quote }}
+    - secretKey: GITHUB_TOKEN
+      remoteRef:
+        key: {{ printf "%s/%s" $item .Values.runtimeSecrets.externalSecret.fields.githubToken | quote }}
+{{- end }}

--- a/infra/helm/typesense/templates/ingress.yaml
+++ b/infra/helm/typesense/templates/ingress.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.ingress.enabled }}
+{{- $host := required "ingress.host is required when ingress.enabled is true" .Values.ingress.host -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "typesense.fullname" . }}
+  labels:
+    {{- include "typesense.labels" . | nindent 4 }}
+    app.kubernetes.io/component: search
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . | quote }}
+  {{- end }}
+  {{- if .Values.ingress.tlsSecretName }}
+  tls:
+    - hosts:
+        - {{ $host | quote }}
+      secretName: {{ .Values.ingress.tlsSecretName | quote }}
+  {{- end }}
+  rules:
+    - host: {{ $host | quote }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "typesense.fullname" . }}
+                port:
+                  number: {{ .Values.service.port }}
+{{- end }}

--- a/infra/helm/typesense/templates/networkpolicy.yaml
+++ b/infra/helm/typesense/templates/networkpolicy.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "typesense.fullname" . }}
+  labels:
+    {{- include "typesense.labels" . | nindent 4 }}
+    app.kubernetes.io/component: search
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "typesense.componentLabels" . | nindent 6 }}
+  policyTypes: [Ingress, Egress]
+  ingress:
+    # Public docs and forum search reaches Typesense through the ingress
+    # controller. The in-cluster reindex CronJob reaches it pod-to-pod.
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.networkPolicy.ingressControllerNamespace | quote }}
+          podSelector:
+            matchLabels:
+              {{- toYaml .Values.networkPolicy.ingressControllerPodLabels | nindent 14 }}
+        - podSelector:
+            matchLabels:
+              {{- include "typesense.selectorLabels" . | nindent 14 }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.service.targetPort }}
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.networkPolicy.dnsNamespace | quote }}
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+{{- end }}

--- a/infra/helm/typesense/templates/persistentvolumeclaim.yaml
+++ b/infra/helm/typesense/templates/persistentvolumeclaim.yaml
@@ -1,0 +1,18 @@
+{{- if and .Values.persistence.create (eq .Values.persistence.existingClaim "") }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "typesense.dataClaimName" . }}
+  labels:
+    {{- include "typesense.labels" . | nindent 4 }}
+    app.kubernetes.io/component: search
+spec:
+  accessModes:
+    {{- toYaml .Values.persistence.accessModes | nindent 4 }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}
+  {{- with .Values.persistence.storageClassName }}
+  storageClassName: {{ . | quote }}
+  {{- end }}
+{{- end }}

--- a/infra/helm/typesense/templates/runtime-secret.yaml
+++ b/infra/helm/typesense/templates/runtime-secret.yaml
@@ -1,0 +1,13 @@
+{{- if not .Values.runtimeSecrets.externalSecret.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "typesense.runtimeSecretName" . }}
+  labels:
+    {{- include "typesense.labels" . | nindent 4 }}
+    app.kubernetes.io/component: search
+type: Opaque
+stringData:
+  TYPESENSE_API_KEY: {{ required "runtimeSecrets.inline.apiKey is required when runtimeSecrets.externalSecret.enabled is false" .Values.runtimeSecrets.inline.apiKey | quote }}
+  GITHUB_TOKEN: {{ .Values.runtimeSecrets.inline.githubToken | default "" | quote }}
+{{- end }}

--- a/infra/helm/typesense/templates/service.yaml
+++ b/infra/helm/typesense/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "typesense.fullname" . }}
+  labels:
+    {{- include "typesense.labels" . | nindent 4 }}
+    app.kubernetes.io/component: search
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    {{- include "typesense.componentLabels" . | nindent 4 }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP

--- a/infra/helm/typesense/templates/serviceaccount.yaml
+++ b/infra/helm/typesense/templates/serviceaccount.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "typesense.serviceAccountName" . }}
+  labels:
+    {{- include "typesense.labels" . | nindent 4 }}
+    app.kubernetes.io/component: search
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
+{{- end }}

--- a/infra/helm/typesense/values-ci.yaml
+++ b/infra/helm/typesense/values-ci.yaml
@@ -1,0 +1,7 @@
+image:
+  tag: validation
+
+runtimeSecrets:
+  inline:
+    apiKey: validation-api-key
+    githubToken: validation-github-token

--- a/infra/helm/typesense/values-production.yaml
+++ b/infra/helm/typesense/values-production.yaml
@@ -1,0 +1,34 @@
+global:
+  commonLabels:
+    tuist.dev/service: typesense
+    tuist.dev/stack: managed
+
+ingress:
+  enabled: true
+  className: nginx
+  host: search.tuist.dev
+  tlsSecretName: typesense-tls
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-cloudflare
+
+runtimeSecrets:
+  externalSecret:
+    enabled: true
+    item: SEARCH
+
+networkPolicy:
+  enabled: true
+
+persistence:
+  size: 10Gi
+
+resources:
+  requests:
+    cpu: "250m"
+    memory: "512Mi"
+  limits:
+    cpu: "1"
+    memory: "1Gi"
+
+nodeSelector:
+  node.cluster.x-k8s.io/pool: general

--- a/infra/helm/typesense/values.yaml
+++ b/infra/helm/typesense/values.yaml
@@ -1,0 +1,135 @@
+global:
+  commonLabels: {}
+  podLabels: {}
+  imagePullSecrets: []
+  nodeSelector: {}
+  tolerations: []
+
+nameOverride: ""
+fullnameOverride: ""
+
+replicaCount: 1
+
+# The image is the search wrapper (Typesense 27.1 plus the DocC and GitHub
+# indexer scripts). The Deployment runs the Typesense server directly; the
+# indexers run as a separate CronJob rather than the wrapper's in-container cron.
+image:
+  repository: ghcr.io/tuist/search
+  tag: ""
+  pullPolicy: IfNotPresent
+
+deploymentStrategy:
+  # Recreate because the data directory is a single ReadWriteOnce volume that
+  # only one pod may mount at a time.
+  type: Recreate
+
+service:
+  type: ClusterIP
+  port: 8108
+  targetPort: 8108
+
+serviceAccount:
+  create: true
+  name: ""
+  annotations: {}
+
+automountServiceAccountToken: false
+
+typesense:
+  dataDir: /data
+  enableCors: true
+
+# TYPESENSE_API_KEY and GITHUB_TOKEN. Provided inline for CI and dev, or synced
+# from 1Password via an ExternalSecret in production.
+runtimeSecrets:
+  secretName: ""
+  inline:
+    apiKey: ""
+    githubToken: ""
+  externalSecret:
+    enabled: false
+    refreshInterval: "1h"
+    storeRef:
+      kind: ClusterSecretStore
+      name: onepassword
+    item: ""
+    fields:
+      apiKey: api-key
+      githubToken: github-token
+
+persistence:
+  create: true
+  existingClaim: ""
+  storageClassName: ""
+  accessModes:
+    - ReadWriteOnce
+  size: 10Gi
+
+ingress:
+  enabled: false
+  className: ""
+  host: ""
+  tlsSecretName: ""
+  annotations: {}
+
+# Daily DocC and GitHub reindex. The DocSearch website scraper is not included;
+# like the current deployment, it runs separately because it needs to crawl the
+# public site from its own container.
+indexers:
+  enabled: true
+  schedule: "0 4 * * *"
+  concurrencyPolicy: Forbid
+  restartPolicy: Never
+  backoffLimit: 1
+  activeDeadlineSeconds: 3600
+  resources: {}
+
+resources: {}
+podSecurityContext:
+  fsGroup: 65534
+  fsGroupChangePolicy: OnRootMismatch
+  seccompProfile:
+    type: RuntimeDefault
+containerSecurityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  runAsUser: 65534
+extraEnv: []
+podAnnotations: {}
+podLabels: {}
+affinity: {}
+nodeSelector: {}
+tolerations: []
+terminationGracePeriodSeconds: 30
+
+networkPolicy:
+  enabled: false
+  ingressControllerNamespace: platform
+  ingressControllerPodLabels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/component: controller
+  dnsNamespace: kube-system
+
+probes:
+  readiness:
+    path: /health
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 3
+    failureThreshold: 3
+  liveness:
+    path: /health
+    initialDelaySeconds: 30
+    periodSeconds: 20
+    timeoutSeconds: 3
+    failureThreshold: 3
+  startup:
+    path: /health
+    initialDelaySeconds: 0
+    periodSeconds: 5
+    timeoutSeconds: 3
+    failureThreshold: 60

--- a/infra/helm/typesense/values.yaml
+++ b/infra/helm/typesense/values.yaml
@@ -72,9 +72,13 @@ ingress:
   tlsSecretName: ""
   annotations: {}
 
-# Daily DocC and GitHub reindex. The DocSearch website scraper is not included;
-# like the current deployment, it runs separately because it needs to crawl the
-# public site from its own container.
+# Daily reindex of the two collections the bundled indexers own: the DocC API
+# reference (`projectdescription`, via index-docc) and `github-issues` (via
+# index-github). The `tuist` and `forum-topics` collections that the public docs
+# and forum UI query are produced by the DocSearch scraper, not by these
+# indexers. The scraper is a separate crawler container and is not part of this
+# chart; it must be run against this service to populate those two collections
+# before the DNS cutover. See AGENTS.md.
 indexers:
   enabled: true
   schedule: "0 4 * * *"


### PR DESCRIPTION
> Describe here the purpose of your PR.

Re-scopes this PR, after review feedback from @fortmarek, to one self-contained step: move the Typesense engine that powers `search.tuist.dev` off its standalone Kamal node and into our Kubernetes cluster.

## Why

Two reasons converge here:

1. Typesense runs today as a single Kamal-managed box (`91.99.179.13`, arm64), separate from the CAPI/Hetzner clusters where the rest of the platform lives. It serves the public docs and forum search that the website queries client-side. Bringing it into the cluster gives it the same deploy, storage, secret, and failure-recovery machinery every other service already uses.
2. It unblocks the follow-up. Marek's review made the case that the generic retrieval layer (full text, vector, hybrid ranking) is the least product-specific part of an agent search feature and the most expensive to own, and that we already operate an engine that does all of it. A cluster-local Typesense lets an in-cluster service delegate retrieval to it without sharing a public single-node failure domain.

## What changes

- A standalone `infra/helm/typesense` chart: a StatefulSet with a PVC for `/data`, a Service on 8108, an ingress for `search.tuist.dev`, and the API-key secret. It is modeled on the existing `search/config/deploy.yml` Kamal definition and follows the `infra/helm/slack` chart conventions.
- The daily indexers (the DocSearch scraper, the DocC API indexer, and the GitHub issues/PRs indexer) move from the on-box cron to a Kubernetes CronJob.
- A deploy workflow, and the website's `typesense_host` cut over to the in-cluster endpoint once data is reindexed.

## Plan

This is step one of two:

1. This PR: Typesense into the cluster, with the public docs and forum search unchanged from a user's point of view.
2. Follow-up: point agent documentation and code search at that Typesense with server-side embeddings, remove the bespoke SQLite and vector retrieval code, and slim the repository-facing service down to grep and bounded source reads over the ripgrep crates, renamed since it no longer owns retrieval.

## Status

The earlier commits on this branch, the Brain retrieval service, are being removed in favor of this scope. The parts worth keeping (repository sync at a known revision, chunking, grep, and source reads) come back in the follow-up.

### How to test locally

> Document how to test your changes locally

- `helm template infra/helm/typesense -f infra/helm/typesense/values-ci.yaml` renders without error, and the Helm CI matrix in `.github/workflows/helm.yml` lint/templates it.
- Against a scratch namespace: `helm upgrade --install typesense infra/helm/typesense`, then `kubectl port-forward svc/typesense 8108` and confirm `curl -H "X-TYPESENSE-API-KEY: $KEY" localhost:8108/health` returns `{"ok":true}` and the reindex CronJob populates the `tuist` and `forum-topics` collections.
