### PR TITLE
fix(server): make backward-compat auth login resilient to transient canary 502s

### DIFF
--- a/e2e/module_cache_backward_compat.bats
+++ b/e2e/module_cache_backward_compat.bats
@@ -69,17 +69,35 @@ EOF
     echo "# Using tuist binary: $("$TUIST_EXECUTABLE" version 2>/dev/null || echo unknown)" >&3
     # The way `auth login` is pointed at a server changed across versions: older
     # CLIs take --path and read the URL from Tuist.swift, newer ones take --url.
-    # Try --url first and fall back to --path so the suite survives the pin
-    # moving across that boundary. Credentials/email/password come from env.
+    # Detect which the pinned binary supports from its --help so the suite
+    # survives the pin moving across that boundary - and, crucially, so a real
+    # login failure (e.g. a transient 502 from the canary gateway) surfaces as
+    # itself instead of being masked by an "Unknown option '--path'" from a
+    # blind `|| ... --path` fallback. Credentials/email/password come from env.
+    local login_target=(--path "$FIXTURE_DIR")
+    if "$TUIST_EXECUTABLE" auth login --help 2>&1 | grep -q -- '--url'; then
+        login_target=(--url "$TUIST_URL")
+    fi
+
+    # Retry the login: a single transient gateway blip against canary must not
+    # fail the whole production gate, mirroring the polled cache pull below.
     echo "# Logging in to ${TUIST_URL}..." >&3
-    "$TUIST_EXECUTABLE" auth login \
-        --email "$TUIST_AUTH_EMAIL" \
-        --password "$TUIST_AUTH_PASSWORD" \
-        --url "$TUIST_URL" \
-        || "$TUIST_EXECUTABLE" auth login \
+    logged_in=0
+    for attempt in 1 2 3 4 5; do
+        if "$TUIST_EXECUTABLE" auth login \
             --email "$TUIST_AUTH_EMAIL" \
             --password "$TUIST_AUTH_PASSWORD" \
-            --path "$FIXTURE_DIR"
+            "${login_target[@]}" >&3 2>&1; then
+            logged_in=1
+            break
+        fi
+        echo "# auth login attempt ${attempt} failed; retrying in 3s" >&3
+        sleep 3
+    done
+    if [ "$logged_in" -ne 1 ]; then
+        echo "# auth login to ${TUIST_URL} failed after retries" >&3
+    fi
+    [ "$logged_in" -eq 1 ]
 
     # --build-system is required non-interactively; without it the CLI prompts
     # "Which build system does your project use?" and aborts in CI. xcode is the


### PR DESCRIPTION
> Describe here the purpose of your PR.

## What changed

The **Backward-Compatibility Acceptance** production gate now tolerates a transient gateway blip during `tuist auth login`. In [`e2e/module_cache_backward_compat.bats`](https://github.com/tuist/tuist/blob/main/e2e/module_cache_backward_compat.bats):

- The supported login flag is detected once from `auth login --help` instead of a blind `--url` → `--path` fallback.
- The login is retried (5 attempts, 3s apart), mirroring the polled cache pull already in this file.

## Why it changed

The gate failed a production deploy in [run 29100396650](https://github.com/tuist/tuist/actions/runs/29100396650/job/86397592334). `setup_file` died at the login step with a chained error:

1. `tuist auth login … --url` got a **502** ("unknown Tuist response of 502") — a transient canary gateway blip, not a code regression. The identical test passed ~4 hours earlier (run 29086122509, 51s), and the HEAD acceptance suite passed in the same failing run.
2. The `|| … --path` fallback then fired and died with `Unknown option '--path'` (the pinned 4.154.2 only supports `--url`), masking the real 502 and hard-failing the whole production cascade.

## Root cause

Two design flaws turned one blip into a hard failure:

- **No retry on login**, unlike the polled cache pull further down that was added for exactly this flakiness reason (34eb85f792).
- **The `--url` → `--path` fallback fired on _any_ `--url` failure.** For a pin that only supports `--url`, a real 502 fell through to `--path`, and the resulting `Unknown option '--path'` masked the actual error.

## Why this solution over the obvious alternatives

- **Not just a re-run:** the blip is expected to recur; the gate needed to be resilient, not manually retried.
- **Detecting the flag from `--help` rather than keeping the blind fallback:** the suite must still survive the version pin crossing the `--path`/`--url` boundary, but a genuine, persistent login failure should surface as itself and still fail after the retries — a blind fallback defeats that.

## User / developer impact

A single transient canary 502 no longer blocks the production deploy cascade. No behavior change for a genuinely broken login — it still fails after the retries.

## Validation

- File parses under `bats --count` (Bats 1.11.1).
- Simulated a 4.154.2-style mock (help lists `--url`, login 502s twice then succeeds): detects `--url`, rides through both 502s, succeeds on attempt 3, never touches `--path`.
- Simulated an older mock (help lacks `--url`): correctly picks `--path`.

### How to test locally

This is a CI-only production gate (`macos` runner, canary credentials). It cannot be run meaningfully on a laptop, but the shell logic can be exercised with a mock `tuist` on `PATH` as described in the validation section. Otherwise it runs on merge to `main` via `.github/workflows/server-production-deployment.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
