### PR TITLE
fix(server): discard transient GitHub blips in the registry sync worker

### DIFF
--- a/server/lib/tuist/registry/swift/sync_worker.ex
+++ b/server/lib/tuist/registry/swift/sync_worker.ex
@@ -72,10 +72,31 @@ defmodule Tuist.Registry.Swift.SyncWorker do
         end
 
       {:error, reason} ->
-        Logger.error("Failed to fetch SPI package list: #{inspect(reason)}")
-        {:error, reason}
+        if transient_fetch_error?(reason) do
+          # A transport/protocol blip talking to GitHub (connection closed
+          # mid-flight, timeout, DNS hiccup). This is a cron worker that
+          # fires every 10 minutes, so the next tick retries for free.
+          # Retrying the Oban job instead just replays the same failure up
+          # to max_attempts and pages Sentry each time for something
+          # un-actionable. Discard quietly; the warning keeps it in logs.
+          Logger.warning("Skipping SPI package list fetch after transient error: #{inspect(reason)}")
+          {:discard, reason}
+        else
+          # HTTP-status failures (403 rate/abuse limit, 5xx, an auth or
+          # scope problem) can be persistent and are worth surfacing, so
+          # they stay a hard error that retries and reports.
+          Logger.error("Failed to fetch SPI package list: #{inspect(reason)}")
+          {:error, reason}
+        end
     end
   end
+
+  # Transport and protocol errors arrive as Req exception structs; a real
+  # HTTP response maps to a `{:http_error, status}` tuple upstream and is
+  # deliberately excluded here so 403s and 5xx keep surfacing.
+  defp transient_fetch_error?(%Req.TransportError{}), do: true
+  defp transient_fetch_error?(%Req.HTTPError{}), do: true
+  defp transient_fetch_error?(_reason), do: false
 
   defp sync_package(%{scope: scope, name: name, repository_full_handle: full_handle}, token) do
     lock_key = {:package, scope, name}

--- a/server/test/tuist/registry/swift/sync_worker_test.exs
+++ b/server/test/tuist/registry/swift/sync_worker_test.exs
@@ -153,4 +153,17 @@ defmodule Tuist.Registry.Swift.SyncWorkerTest do
       }
     )
   end
+
+  test "discards the job on a transient transport error instead of failing" do
+    reason = %Req.HTTPError{protocol: :http2, reason: :closed_for_writing}
+    expect(SwiftPackageIndex, :list_packages, fn "token" -> {:error, reason} end)
+
+    assert {:discard, ^reason} = SyncWorker.perform(%Oban.Job{args: %{}})
+  end
+
+  test "surfaces an HTTP status error as a hard failure" do
+    expect(SwiftPackageIndex, :list_packages, fn "token" -> {:error, {:http_error, 403}} end)
+
+    assert {:error, {:http_error, 403}} = SyncWorker.perform(%Oban.Job{args: %{}})
+  end
 end


### PR DESCRIPTION
## What

`Tuist.Registry.Swift.SyncWorker` now discards its Oban job on a transient GitHub transport error instead of failing it. HTTP-status failures still fail loudly.

## Why

The worker is cron-driven every 10 minutes: it fetches the SwiftPackageIndex catalog and enqueues `ReleaseWorker` jobs for missing tags. When `SwiftPackageIndex.list_packages/1` hit a transport blip, `sync_packages/2` returned `{:error, reason}`. Oban treats that as a job failure, retries up to `max_attempts` (20) with backoff, and reports every attempt to Sentry.

That is the wrong shape for a cron worker. The next scheduled tick retries the whole catalog for free ten minutes later, so replaying the failing job 20 times buys nothing and pages Sentry for something no one can act on.

Concretely, [TUIST-187](https://tuist.sentry.io/issues/133471308/) on canary:

```
Oban.PerformError: Tuist.Registry.Swift.SyncWorker failed with
  {:error, %Req.HTTPError{protocol: :http2, reason: :closed_for_writing}}
```

`:closed_for_writing` is an HTTP/2 connection shutting down mid-flight. It fired once, Oban retried, it cleared. Un-actionable by definition.

## The change

Classify the failure in the one `list_packages` error branch:

- **Transport / protocol errors** arrive as Req exception structs (`Req.TransportError`, `Req.HTTPError`): connection closed, timeout, DNS hiccup. These are transient, so `{:discard, reason}` plus a `Logger.warning`. No retry, no Sentry.
- **HTTP-status failures** map to a `{:http_error, status}` tuple upstream in `TuistCommon.GitHub.get_file_content/5` (see the `{:ok, %{status: status}} -> {:error, {:http_error, status}}` branch). These stay `{:error, reason}`: retried and reported.

That split is deliberate and it is the important part of this PR.

> [!IMPORTANT]
> This intentionally does **not** silence [TUIST-185](https://tuist.sentry.io/issues/133434361/), the `{:error, {:http_error, 403}}` storm on canary. A 403 on an authenticated request to a public file is a rate or scope problem, and it can be persistent. Discarding it would turn "the registry silently stopped syncing" into a non-event, which is exactly the failure mode we do not want. It keeps paging until it is understood and fixed. Only errors that are transient by construction (a socket dies mid-request) are discarded here.

The pattern mirrors what already exists in the codebase: `Tuist.Tests.Workers.ProcessXcresultWorker` discards a known-unactionable reason set with `{:discard, reason}` and lets everything else error, and `Tuist.Webhooks.Workers.DeliveryWorker` keeps transient receiver failures out of Sentry because they carry no signal.

## What this does not cover

A discarded tick is invisible to Sentry, which is correct for a one-off blip but would also hide a *persistent* transport failure (say GitHub unreachable for an hour). Error-absence is the wrong thing to alert on for a cron worker anyway. The right guard is a positive freshness signal ("no new registry releases in N hours"), which does not exist yet and is out of scope here. Worth a follow-up.

## Validation

`mix test test/tuist/registry/swift/sync_worker_test.exs` — 5 passed, including two new cases:

- a `Req.HTTPError{reason: :closed_for_writing}` from `list_packages` yields `{:discard, reason}`
- a `{:http_error, 403}` from `list_packages` yields `{:error, {:http_error, 403}}`

Confirmed `Req.TransportError` and `Req.HTTPError` are the real struct names in the pinned Req 0.5.17 (`deps/req/lib/req/{transport_error,http_error}.ex`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
