### PR TITLE
fix(cli): backport result bundle collision fix to 4.202.x (#11715)

### DIFF
--- a/cli/Sources/TuistKit/Services/TestService.swift
+++ b/cli/Sources/TuistKit/Services/TestService.swift
@@ -1169,30 +1169,43 @@ public struct TestService { // swiftlint:disable:this type_body_length
             uploadCacheStorage = cacheStorage
         }
 
-        do {
-            var didRunTests = false
-            for testScheme in schemes {
-                let testSchemeTargetNames = Set(
-                    testActionTargetReferences(
-                        scheme: testScheme,
-                        testPlanConfiguration: testPlanConfiguration,
-                        action: action
-                    )
-                    .map(\.name)
+        let testSchemeRuns = schemes.compactMap { testScheme -> (scheme: Scheme, testTargets: [TestIdentifier])? in
+            let testSchemeTargetNames = Set(
+                testActionTargetReferences(
+                    scheme: testScheme,
+                    testPlanConfiguration: testPlanConfiguration,
+                    action: action
                 )
-                if testSchemeTargetNames.isEmpty {
-                    continue
-                }
+                .map(\.name)
+            )
+            if testSchemeTargetNames.isEmpty {
+                return nil
+            }
 
-                let testSchemeTestTargets = testTargets.filter {
-                    testSchemeTargetNames.contains($0.target)
-                }
+            let testSchemeTestTargets = testTargets.filter {
+                testSchemeTargetNames.contains($0.target)
+            }
 
-                if !testTargets.isEmpty, testSchemeTestTargets.isEmpty {
-                    continue
-                }
+            if !testTargets.isEmpty, testSchemeTestTargets.isEmpty {
+                return nil
+            }
 
-                didRunTests = true
+            return (scheme: testScheme, testTargets: testSchemeTestTargets)
+        }
+
+        guard !testSchemeRuns.isEmpty else {
+            return false
+        }
+
+        for testSchemeRun in testSchemeRuns {
+            let testScheme = testSchemeRun.scheme
+            let testSchemeResultBundlePath = schemeResultBundlePath(
+                resultBundlePath,
+                schemeName: testScheme.name,
+                runningMultipleSchemes: testSchemeRuns.count > 1
+            )
+
+            do {
                 try await self.testScheme(
                     scheme: testScheme,
                     graphTraverser: graphTraverser,
@@ -1203,10 +1216,10 @@ public struct TestService { // swiftlint:disable:this type_body_length
                     platform: platform,
                     action: action,
                     rosetta: rosetta,
-                    resultBundlePath: resultBundlePath,
+                    resultBundlePath: testSchemeResultBundlePath,
                     derivedDataPath: derivedDataPath,
                     retryCount: retryCount,
-                    testTargets: testSchemeTestTargets,
+                    testTargets: testSchemeRun.testTargets,
                     skipTestTargets: skipTestTargets,
                     testPlanConfiguration: testPlanConfiguration,
                     passthroughXcodeBuildArguments: passthroughXcodeBuildArguments,
@@ -1214,49 +1227,33 @@ public struct TestService { // swiftlint:disable:this type_body_length
                     quarantinedTests: quarantinedTests,
                     mode: mode
                 )
-            }
-            guard didRunTests else {
-                return false
-            }
-        } catch {
-            guard action != .build, let resultBundlePath else { throw error }
-
-            guard try await fileSystem.exists(resultBundlePath) else { throw error }
-
-            let testStatuses = try await xcResultService.parseTestStatuses(path: resultBundlePath)
-            guard !testStatuses.testCases.isEmpty else { throw error }
-
-            let testTargets = testActionTargets(
-                for: schemes, testPlanConfiguration: testPlanConfiguration, graph: graph, action: action
-            )
-
-            let passingTestTargets = testTargets.filter {
-                testStatuses.passingModuleNames().contains($0.target.name)
+            } catch {
+                if try await handleTestSchemeFailure(
+                    error,
+                    scheme: testScheme,
+                    resultBundlePath: testSchemeResultBundlePath,
+                    graph: graph,
+                    mapperEnvironment: mapperEnvironment,
+                    cacheStorage: uploadCacheStorage,
+                    testPlanConfiguration: testPlanConfiguration,
+                    action: action,
+                    quarantinedTests: quarantinedTests
+                ) {
+                    continue
+                }
+                throw error
             }
 
-            try await storeSuccessfulTestHashes(
-                for: passingTestTargets,
-                graph: graph,
-                mapperEnvironment: mapperEnvironment,
-                cacheStorage: uploadCacheStorage
-            )
-
-            if testQuarantineService.onlyQuarantinedTestsFailed(testStatuses: testStatuses, quarantinedTests: quarantinedTests) {
-                return true
+            if action != .build {
+                try await storeSuccessfulTestHashes(
+                    for: testActionTargets(
+                        for: [testScheme], testPlanConfiguration: testPlanConfiguration, graph: graph, action: action
+                    ),
+                    graph: graph,
+                    mapperEnvironment: mapperEnvironment,
+                    cacheStorage: uploadCacheStorage
+                )
             }
-
-            throw error
-        }
-
-        if action != .build {
-            try await storeSuccessfulTestHashes(
-                for: testActionTargets(
-                    for: schemes, testPlanConfiguration: testPlanConfiguration, graph: graph, action: action
-                ),
-                graph: graph,
-                mapperEnvironment: mapperEnvironment,
-                cacheStorage: uploadCacheStorage
-            )
         }
 
         let verb =
@@ -1276,6 +1273,46 @@ public struct TestService { // swiftlint:disable:this type_body_length
         }
 
         return true
+    }
+
+    private func handleTestSchemeFailure(
+        _ error: Error,
+        scheme: Scheme,
+        resultBundlePath: AbsolutePath?,
+        graph: Graph,
+        mapperEnvironment: MapperEnvironment,
+        cacheStorage: CacheStoring,
+        testPlanConfiguration: TestPlanConfiguration?,
+        action: XcodeBuildTestAction,
+        quarantinedTests: [TestIdentifier]
+    ) async throws -> Bool {
+        guard action != .build, let resultBundlePath else { throw error }
+
+        guard try await fileSystem.exists(resultBundlePath) else { throw error }
+
+        let testStatuses = try await xcResultService.parseTestStatuses(path: resultBundlePath)
+        guard !testStatuses.testCases.isEmpty else { throw error }
+
+        let testTargets = testActionTargets(
+            for: [scheme], testPlanConfiguration: testPlanConfiguration, graph: graph, action: action
+        )
+
+        let passingTestTargets = testTargets.filter {
+            testStatuses.passingModuleNames().contains($0.target.name)
+        }
+
+        try await storeSuccessfulTestHashes(
+            for: passingTestTargets,
+            graph: graph,
+            mapperEnvironment: mapperEnvironment,
+            cacheStorage: cacheStorage
+        )
+
+        if testQuarantineService.onlyQuarantinedTestsFailed(testStatuses: testStatuses, quarantinedTests: quarantinedTests) {
+            return true
+        }
+
+        throw error
     }
 
     private func updateTestServiceAnalytics(
@@ -1645,6 +1682,26 @@ public struct TestService { // swiftlint:disable:this type_body_length
         }
     }
 
+    private func schemeResultBundlePath(
+        _ resultBundlePath: AbsolutePath?,
+        schemeName: String,
+        runningMultipleSchemes: Bool
+    ) -> AbsolutePath? {
+        guard runningMultipleSchemes, let resultBundlePath else {
+            return resultBundlePath
+        }
+
+        let schemePathComponent = schemeName.toValidInBundleIdentifier()
+        let pathComponent: String
+        if let pathExtension = resultBundlePath.extension {
+            pathComponent = "\(resultBundlePath.basenameWithoutExt)-\(schemePathComponent).\(pathExtension)"
+        } else {
+            pathComponent = "\(resultBundlePath.basename)-\(schemePathComponent)"
+        }
+
+        return resultBundlePath.parentDirectory.appending(component: pathComponent)
+    }
+
     // swiftlint:disable:next function_body_length
     private func testScheme(
         scheme: Scheme,
@@ -1807,6 +1864,7 @@ public struct TestService { // swiftlint:disable:this type_body_length
             projectDerivedDataDirectory: projectDerivedDataDirectory,
             config: config,
             action: action,
+            scheme: scheme.name,
             quarantinedTests: quarantinedTests,
             mode: mode
         )

--- a/cli/Tests/TuistKitTests/Services/TestServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/TestServiceTests.swift
@@ -693,6 +693,157 @@ final class TestServiceTests: TuistUnitTestCase {
         )
     }
 
+    func test_run_tests_all_project_schemes_uses_unique_result_bundle_paths_when_cloud_is_configured() async throws {
+        // Given
+        givenGenerator()
+        given(buildGraphInspector)
+            .testableSchemes(graphTraverser: .any)
+            .willReturn([])
+        given(buildGraphInspector)
+            .workspaceSchemes(graphTraverser: .any)
+            .willReturn(
+                [
+                    Scheme.test(name: "ProjectSchemeOne"),
+                    Scheme.test(name: "ProjectSchemeTwo"),
+                ]
+            )
+        given(generator)
+            .generateWithGraph(path: .any, options: .any)
+            .willProduce { path, _ in
+                (path, .test(), MapperEnvironment())
+            }
+        given(configLoader)
+            .loadConfig(path: .any)
+            .willReturn(.test(fullHandle: "tuist/tuist"))
+
+        let runsCacheDirectory = try temporaryPath()
+        given(cacheDirectoriesProvider)
+            .cacheDirectory(for: .value(.runs))
+            .willReturn(runsCacheDirectory)
+
+        let firstResultBundlePath = runsCacheDirectory
+            .appending(components: "run-id", "\(Constants.resultBundleName)-ProjectSchemeOne")
+        let secondResultBundlePath = runsCacheDirectory
+            .appending(components: "run-id", "\(Constants.resultBundleName)-ProjectSchemeTwo")
+
+        // When
+        try await testRun(
+            path: try temporaryPath()
+        )
+
+        // Then
+        verify(xcodebuildController)
+            .test(
+                .any,
+                scheme: .value("ProjectSchemeOne"),
+                clean: .any,
+                destination: .any,
+                action: .any,
+                rosetta: .any,
+                derivedDataPath: .any,
+                resultBundlePath: .value(firstResultBundlePath),
+                arguments: .any,
+                retryCount: .any,
+                testTargets: .any,
+                skipTestTargets: .any,
+                testPlanConfiguration: .any,
+                passthroughXcodeBuildArguments: .any
+            )
+            .called(1)
+        verify(xcodebuildController)
+            .test(
+                .any,
+                scheme: .value("ProjectSchemeTwo"),
+                clean: .any,
+                destination: .any,
+                action: .any,
+                rosetta: .any,
+                derivedDataPath: .any,
+                resultBundlePath: .value(secondResultBundlePath),
+                arguments: .any,
+                retryCount: .any,
+                testTargets: .any,
+                skipTestTargets: .any,
+                testPlanConfiguration: .any,
+                passthroughXcodeBuildArguments: .any
+            )
+            .called(1)
+    }
+
+    func test_run_tests_all_project_schemes_uses_unique_given_result_bundle_paths() async throws {
+        // Given
+        givenGenerator()
+        given(buildGraphInspector)
+            .testableSchemes(graphTraverser: .any)
+            .willReturn([])
+        given(buildGraphInspector)
+            .workspaceSchemes(graphTraverser: .any)
+            .willReturn(
+                [
+                    Scheme.test(name: "ProjectSchemeOne"),
+                    Scheme.test(name: "ProjectSchemeTwo"),
+                ]
+            )
+        given(generator)
+            .generateWithGraph(path: .any, options: .any)
+            .willProduce { path, _ in
+                (path, .test(), MapperEnvironment())
+            }
+        given(configLoader)
+            .loadConfig(path: .any)
+            .willReturn(.test(project: .testGeneratedProject()))
+
+        let resultBundlePath = try temporaryPath().appending(component: "results.xcresult")
+        let firstResultBundlePath = resultBundlePath.parentDirectory
+            .appending(component: "results-ProjectSchemeOne.xcresult")
+        let secondResultBundlePath = resultBundlePath.parentDirectory
+            .appending(component: "results-ProjectSchemeTwo.xcresult")
+
+        // When
+        try await testRun(
+            path: try temporaryPath(),
+            resultBundlePath: resultBundlePath
+        )
+
+        // Then
+        verify(xcodebuildController)
+            .test(
+                .any,
+                scheme: .value("ProjectSchemeOne"),
+                clean: .any,
+                destination: .any,
+                action: .any,
+                rosetta: .any,
+                derivedDataPath: .any,
+                resultBundlePath: .value(firstResultBundlePath),
+                arguments: .any,
+                retryCount: .any,
+                testTargets: .any,
+                skipTestTargets: .any,
+                testPlanConfiguration: .any,
+                passthroughXcodeBuildArguments: .any
+            )
+            .called(1)
+        verify(xcodebuildController)
+            .test(
+                .any,
+                scheme: .value("ProjectSchemeTwo"),
+                clean: .any,
+                destination: .any,
+                action: .any,
+                rosetta: .any,
+                derivedDataPath: .any,
+                resultBundlePath: .value(secondResultBundlePath),
+                arguments: .any,
+                retryCount: .any,
+                testTargets: .any,
+                skipTestTargets: .any,
+                testPlanConfiguration: .any,
+                passthroughXcodeBuildArguments: .any
+            )
+            .called(1)
+    }
+
     func test_run_uploads_to_local_cache_storage_when_no_upload() async throws {
         // Given
         givenGenerator()


### PR DESCRIPTION
## What

Backports #11715 (`fix(cli): avoid result bundle collisions across test schemes`, commit `4eade88`) onto the `releases/4.202.x` line. Clean cherry-pick, byte-for-byte identical to the source commit; the tests from #11715 come along.

## Why

`4.202.0-rc.3` and `4.202.0` are the same commit (`8593f907`) and are missing this fix. Promoting that build to stable ships a regression to any user that runs a multi-scheme test with a fixed result-bundle path.

### Root cause

`tuist test --without-building` (e.g. a differential/sharded test phase) with `--result-bundle-path` / `TUIST_TEST_RESULT_BUNDLE_PATH` set, on a workspace that mixes hosted tests and host-less unit tests. `TestService.defaultSchemes` (introduced by #11225, first shipped in 4.201.0) splits such a run into **one `xcodebuild test-without-building` per generated project scheme**. Before this fix, every per-scheme invocation reused the **same** `-resultBundlePath`, so the first scheme creates the `.xcresult` and the second fails because xcodebuild refuses to overwrite an existing result bundle:

```
xcodebuild: error: Existing file at -resultBundlePath ".../testlog.xcresult"
```

`4.202.0-rc.3` sits in the window that has the scheme split (#11225 → 4.201.0) but not the collision fix (#11715, which first shipped in `4.203.0-canary.16`, on `main` only). A real report surfaced it: a run split into `AIForwardComposer` then `ATGVisualInsight`, both pointed at the same `testlog.xcresult`, and the second scheme errored out.

### The fix (from #11715)

`schemeResultBundlePath` makes the result-bundle path unique per scheme when more than one scheme runs (`testlog-AIForwardComposer.xcresult`, `testlog-ATGVisualInsight.xcresult`, …); a single-scheme run is unchanged, so the exact user-provided path is preserved when there's no collision to avoid. The per-scheme failure handling (`handleTestSchemeFailure`) is moved so each scheme's result bundle is inspected independently.

## Behavior note for release notes

On a multi-scheme run, a single `testlog.xcresult` becomes per-scheme `testlog-<Scheme>.xcresult`. Tuist uploads the bundles to the server itself, so dashboards are unaffected, but any downstream CI step that consumes a fixed-name result bundle should be aware.

## Validation

- Cherry-pick applied with no conflicts; the code diff is identical to `4eade88` (verified with a line-level diff against the source commit).
- All symbols the patch references (`storeSuccessfulTestHashes`, `testActionTargets`, `toValidInBundleIdentifier`, `parseTestStatuses`, `onlyQuarantinedTestsFailed(testStatuses:quarantinedTests:)`) exist on the `releases/4.202.x` base — the last was already called by the pre-fix catch block.
- Build and the backported `TestServiceTests` cases are validated by CI on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
