### PR TITLE
fix(cli): backport cache target build time tracking removal to 4.193.x

### DIFF
--- a/.github/workflows/cli-backport.yml
+++ b/.github/workflows/cli-backport.yml
@@ -1,0 +1,177 @@
+name: CLI Backport Release
+
+# Cut a patch release on an older CLI line (e.g. 4.192.x) without touching main
+# or moving the "latest" pointers (GitHub "Latest" badge, Homebrew formula).
+#
+# Prerequisite (done by humans/agents, outside CI): land the fix(es) on the
+# protected release branch via PR — never a direct push. CI never cherry-picks
+# and never resolves conflicts; that happens in the PR.
+#
+#   # 1. One-time: create the line's release branch off the base tag.
+#   git switch -c releases/4.192.x 4.192.0
+#   git push -u origin releases/4.192.x
+#
+#   # 2. Cherry-pick the fix on a topic branch, then open a PR INTO the release
+#   #    branch (resolve any conflicts here). Review and merge it.
+#   git switch -c backport/<fix>-4.192.x releases/4.192.x
+#   git cherry-pick <fix-sha>
+#   git push -u origin backport/<fix>-4.192.x
+#   gh pr create --base releases/4.192.x --head backport/<fix>-4.192.x
+#
+# Then dispatch this workflow (it lives on and runs from main) with
+# branch=releases/4.192.x. It derives the next PATCH version (patch only —
+# never a minor/major bump), builds the branch HEAD, and publishes the release.
+#
+# What runs from where: this workflow YAML and the reusable build/publish
+# workflow resolve from main (current tooling), while the source and build
+# scripts (cli:bundle, bundle-linux.sh, .xcode-version-releases,
+# Package.resolved, the TuistCacheEE submodule pointer) come from the checked-out
+# branch — i.e. the version being patched builds with its own scripts. If the
+# line's pinned Xcode is not on the macos-26 runner image (or the submodule
+# pointer no longer resolves), the build fails; that means the line is too old
+# to build on current infra.
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Release branch to cut from (e.g. releases/4.192.x)"
+        required: true
+        type: string
+      version:
+        description: "Optional explicit version override (must stay on the branch's major.minor)"
+        required: false
+        type: string
+        default: ""
+
+permissions:
+  contents: write
+  pull-requests: read
+  statuses: write
+  packages: write
+  # Capped down into the reusable workflow's release-cli job (which mints an
+  # OIDC token); a called workflow's job permissions can't exceed the caller's.
+  id-token: write
+
+concurrency:
+  # Shared with cli-release.yml so a backport and a normal release never create
+  # tags or push the Homebrew formula at the same time.
+  group: cli-publish
+  cancel-in-progress: false
+
+env:
+  MISE_VERSION: "2026.5.15"
+  MISE_GITHUB_TOKEN: ${{ secrets.TUIST_RELEASE_GITHUB_TOKEN || github.token }}
+  GITHUB_TOKEN: ${{ secrets.TUIST_RELEASE_GITHUB_TOKEN || github.token }}
+  MISE_GITHUB_ATTESTATIONS: 0
+
+jobs:
+  prepare:
+    name: Resolve backport version
+    runs-on: tuist-linux
+    timeout-minutes: 10
+    outputs:
+      version: ${{ steps.resolve.outputs.version }}
+      sha: ${{ steps.resolve.outputs.sha }}
+      changelog_from: ${{ steps.resolve.outputs.changelog_from }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch }}
+          fetch-depth: 0
+          token: ${{ secrets.TUIST_RELEASE_GITHUB_TOKEN }}
+      - id: resolve
+        env:
+          BRANCH: ${{ inputs.branch }}
+          VERSION_OVERRIDE: ${{ inputs.version }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          set -euo pipefail
+
+          # 1. Guard the ref: never cut a "patch" off main / the default branch.
+          if [ "$BRANCH" = "main" ] || [ "$BRANCH" = "$DEFAULT_BRANCH" ]; then
+            echo "::error::Refusing to backport from '$BRANCH'. Dispatch with a release branch (e.g. releases/4.192.x)." >&2
+            exit 1
+          fi
+
+          # 2. The branch must follow the releases/<major>.<minor>.x convention.
+          #    The line is taken from the branch name (authoritative), not
+          #    inferred from tags — a non-matching name (typo, arbitrary branch)
+          #    must never be allowed to publish an official CLI release.
+          if ! printf '%s' "$BRANCH" | grep -qE '^releases/[0-9]+\.[0-9]+\.x$'; then
+            echo "::error::Branch must be named releases/<major>.<minor>.x (got '$BRANCH')." >&2
+            exit 1
+          fi
+          LINE=${BRANCH#releases/}; LINE=${LINE%.x}
+          MAJOR=${LINE%.*}
+          MINOR=${LINE#*.}
+
+          # 3. Highest tag on the line (must exist).
+          LATEST_ON_LINE=$(git tag -l | grep -E "^${MAJOR}\.${MINOR}\.[0-9]+$" | sort -V | tail -n1)
+          if [ -z "$LATEST_ON_LINE" ]; then
+            echo "::error::No CLI release exists on line ${LINE}." >&2
+            exit 1
+          fi
+
+          # 4. The branch HEAD must be rooted exactly on that latest patch: the
+          #    nearest semver tag reachable from HEAD must equal LATEST_ON_LINE.
+          #    git describe only considers ancestors, so equality proves HEAD
+          #    descends from the line's latest patch and no newer patch exists
+          #    that the branch is missing. This rejects both a branch cut from an
+          #    older base (would build code missing shipped patches and publish a
+          #    downgrade, e.g. 4.192.5 from 4.192.0) and a branch whose HEAD sits
+          #    on a newer/other line than its name claims (main is linear, so a
+          #    releases/4.197.x rooted on 4.198.1 would otherwise slip through).
+          BASE_TAG=$(git describe --tags --abbrev=0 --match '[0-9]*.[0-9]*.[0-9]*' HEAD 2>/dev/null || true)
+          if [ "$BASE_TAG" != "$LATEST_ON_LINE" ]; then
+            echo "::error::Branch HEAD is rooted on '${BASE_TAG:-<none>}' but the latest release on line ${LINE} is ${LATEST_ON_LINE}. Recreate or rebase the branch on top of ${LATEST_ON_LINE} so the backport stacks on every shipped patch." >&2
+            exit 1
+          fi
+
+          # 5. Force a PATCH bump off the highest tag on the line. Never use
+          #    git-cliff/--bumped-version (a feat: would bump minor/major).
+          LATEST_PATCH=${LATEST_ON_LINE##*.}
+          NEXT_VERSION="${MAJOR}.${MINOR}.$((LATEST_PATCH + 1))"
+
+          # 6. Optional explicit override, pinned to the same line and higher
+          #    than the latest existing tag on it.
+          if [ -n "$VERSION_OVERRIDE" ]; then
+            if ! printf '%s' "$VERSION_OVERRIDE" | grep -qE "^${MAJOR}\.${MINOR}\.[0-9]+$"; then
+              echo "::error::Override '$VERSION_OVERRIDE' must stay on ${MAJOR}.${MINOR}.x" >&2
+              exit 1
+            fi
+            HIGHEST=$(printf '%s\n%s\n' "$LATEST_ON_LINE" "$VERSION_OVERRIDE" | sort -V | tail -n1)
+            if [ "$HIGHEST" != "$VERSION_OVERRIDE" ] || [ "$VERSION_OVERRIDE" = "$LATEST_ON_LINE" ]; then
+              echo "::error::Override '$VERSION_OVERRIDE' must be greater than the latest tag on the line ($LATEST_ON_LINE)." >&2
+              exit 1
+            fi
+            NEXT_VERSION="$VERSION_OVERRIDE"
+          fi
+
+          # 7. The computed tag must not already exist.
+          if git rev-parse --verify --quiet "refs/tags/${NEXT_VERSION}" >/dev/null; then
+            echo "::error::Tag ${NEXT_VERSION} already exists." >&2
+            exit 1
+          fi
+
+          SHA=$(git rev-parse HEAD)
+          echo "Backporting ${LATEST_ON_LINE} -> ${NEXT_VERSION} at ${SHA} (branch ${BRANCH})"
+          {
+            echo "version=${NEXT_VERSION}"
+            echo "sha=${SHA}"
+            echo "changelog_from=${LATEST_ON_LINE}"
+          } >> "$GITHUB_OUTPUT"
+
+  build-publish:
+    name: Build and publish backport
+    needs: prepare
+    uses: ./.github/workflows/cli-build-publish.yml
+    with:
+      version: ${{ needs.prepare.outputs.version }}
+      # An immutable SHA so every job (macOS build, Linux build, publish) builds
+      # and tags the identical commit, with no branch-advance race.
+      ref: ${{ needs.prepare.outputs.sha }}
+      changelog_from: ${{ needs.prepare.outputs.changelog_from }}
+      # Backports never move GitHub's "Latest" pointer or the Homebrew formula.
+      make_latest: false
+      update_homebrew: false
+    secrets: inherit

--- a/.github/workflows/cli-build-publish.yml
+++ b/.github/workflows/cli-build-publish.yml
@@ -1,0 +1,274 @@
+name: CLI Build & Publish
+
+# Reusable build+publish pipeline for the CLI, shared by the normal release
+# (cli-release.yml) and the backport release (cli-backport.yml). The caller
+# computes the version and the exact commit to build; this workflow only builds,
+# packages, and publishes.
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: "Version string to stamp into the binary and tag (e.g. 4.192.1)"
+        required: true
+        type: string
+      ref:
+        description: "Resolved commit SHA to check out, build, and tag (not a branch name)"
+        required: true
+        type: string
+      changelog_from:
+        description: "Tag to diff release notes from; empty falls back to the latest CLI semver tag"
+        required: false
+        type: string
+        default: ""
+      make_latest:
+        description: "Whether GitHub marks this release as 'Latest'"
+        required: false
+        type: boolean
+        default: true
+      prerelease:
+        description: "Whether GitHub marks this release as a prerelease (canary/RC)"
+        required: false
+        type: boolean
+        default: false
+      update_homebrew:
+        description: "Whether to trigger the Homebrew formula update"
+        required: false
+        type: boolean
+        default: true
+
+# Top-level env does not cross the workflow_call boundary, so it is redeclared
+# here rather than inherited from the caller.
+env:
+  MISE_VERSION: "2026.5.15"
+  MISE_GITHUB_TOKEN: ${{ secrets.TUIST_RELEASE_GITHUB_TOKEN || github.token }}
+  GITHUB_TOKEN: ${{ secrets.TUIST_RELEASE_GITHUB_TOKEN || github.token }}
+  TUIST_ENABLE_CACHING: "true"
+  MISE_GITHUB_ATTESTATIONS: 0
+
+jobs:
+  release-cli:
+    name: Release CLI
+    runs-on: macos-26
+    timeout-minutes: 75
+    permissions:
+      contents: write
+      id-token: write
+      pull-requests: read
+      statuses: write
+      packages: write
+    env:
+      GITHUB_TOKEN: ${{ secrets.TUIST_RELEASE_GITHUB_TOKEN }}
+    outputs:
+      release-notes: ${{ steps.release-notes.outputs.RELEASE_NOTES }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+          fetch-depth: 0
+          token: ${{ secrets.TUIST_RELEASE_GITHUB_TOKEN }}
+      - name: Select Xcode
+        run: sudo xcode-select -switch /Applications/Xcode_$(cat .xcode-version-releases).app
+      - uses: jdx/mise-action@v4.0.1
+        with:
+          version: ${{ env.MISE_VERSION }}
+          install_args: "--locked tuist git-cliff 1password-cli"
+          cache: "false"
+          github_token: ${{ env.MISE_GITHUB_TOKEN }}
+      - name: Authenticate with Tuist
+        run: tuist auth login
+      - name: Setup Tuist
+        run: tuist setup
+      - name: Install Tuist dependencies
+        run: tuist install --force-resolved-versions
+      - name: Initialize TuistCacheEE submodule
+        env:
+          TUIST_GITHUB_TOKEN: ${{ secrets.TUIST_RELEASE_GITHUB_TOKEN }}
+        run: mise run --no-deps cli:ee
+      - name: Get release notes
+        id: release-notes
+        working-directory: cli
+        run: |
+          # Use the explicit changelog base when provided (backports pass the
+          # base tag); otherwise fall back to the latest CLI semver tag.
+          LATEST_VERSION="${{ inputs.changelog_from }}"
+          if [ -z "$LATEST_VERSION" ]; then
+            LATEST_VERSION=$(git tag -l | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -n1 || echo "0.0.0")
+          fi
+          INCLUDE_PATHS=(
+            --include-path "cli/**/*"
+            --include-path "mise/tasks/cli/**/*"
+            --include-path "mise/tasks/release/components.json"
+            --include-path ".github/workflows/cli-release.yml"
+            --include-path ".github/workflows/cli-build-publish.yml"
+            --include-path ".github/workflows/cli-rc.yml"
+            --include-path ".github/workflows/cli-promote.yml"
+            --include-path ".xcode-version-releases"
+            --include-path "Package.swift"
+            --include-path "Package.resolved"
+          )
+          echo "RELEASE_NOTES<<EOF" >> "$GITHUB_OUTPUT"
+          git cliff "${INCLUDE_PATHS[@]}" --config cliff.toml --repository "../" 2>/dev/null -- ${LATEST_VERSION}..HEAD | sed -n '/<!-- RELEASE NOTES START -->/,$p' | tail -n +2 >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
+      - name: Update version in Constants.swift
+        run: |
+          sed -i '' -e "s/@TaskLocal public static var version: String! = \".*\"/@TaskLocal public static var version: String! = \"${{ inputs.version }}\"/" "cli/Sources/TuistConstants/Constants.swift"
+
+      - name: Update CHANGELOG.md
+        working-directory: cli
+        # Use the authoritative version from the caller via --tag instead of
+        # --bump. Full-history --bump can't anchor on CLI tags that landed on
+        # non-cli commits (it filters them out), so it froze the top heading at
+        # an old version while real releases advanced.
+        run: |
+          INCLUDE_PATHS=(
+            --include-path "cli/**/*"
+            --include-path "mise/tasks/cli/**/*"
+            --include-path "mise/tasks/release/components.json"
+            --include-path ".github/workflows/cli-release.yml"
+            --include-path ".github/workflows/cli-build-publish.yml"
+            --include-path ".github/workflows/cli-rc.yml"
+            --include-path ".github/workflows/cli-promote.yml"
+            --include-path ".xcode-version-releases"
+            --include-path "Package.swift"
+            --include-path "Package.resolved"
+          )
+          git cliff "${INCLUDE_PATHS[@]}" --config cliff.toml --repository "../" --tag "${{ inputs.version }}" -o CHANGELOG.md 2>/dev/null
+
+      - name: Bundle CLI
+        run: mise run --no-deps cli:bundle
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+
+      - name: Upload CLI artifacts
+        id: upload
+        uses: actions/upload-artifact@v4
+        with:
+          name: cli-artifacts
+          path: |
+            cli/CHANGELOG.md
+            cli/Sources/TuistConstants/Constants.swift
+            mise.toml
+            build/ProjectDescription.xcframework.zip
+            build/tuist.zip
+            build/tuist.spec.json
+            build/SHASUMS256.txt
+            build/SHASUMS512.txt
+          retention-days: 1
+
+  release-cli-linux:
+    name: Release CLI (Linux ${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
+    container:
+      image: swift:6.2
+    timeout-minutes: 30
+    strategy:
+      matrix:
+        include:
+          - arch: x86_64
+            runner: ubuntu-latest
+          - arch: aarch64
+            runner: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+          token: ${{ secrets.TUIST_RELEASE_GITHUB_TOKEN }}
+
+      - name: Update version in Constants.swift
+        run: |
+          sed -i "s/@TaskLocal public static var version: String! = \".*\"/@TaskLocal public static var version: String! = \"${{ inputs.version }}\"/" "cli/Sources/TuistConstants/Constants.swift"
+
+      - name: Bundle CLI
+        run: ./mise/tasks/cli/bundle-linux.sh
+
+      - name: Upload CLI Linux artifacts
+        id: upload
+        uses: actions/upload-artifact@v4
+        with:
+          name: cli-linux-${{ matrix.arch }}-artifacts
+          path: |
+            build/tuist-linux-${{ matrix.arch }}.tar.gz
+            build/SHASUMS256.txt
+            build/SHASUMS512.txt
+          retention-days: 1
+
+  publish-cli:
+    name: Publish CLI release
+    needs: [release-cli, release-cli-linux]
+    if: needs.release-cli.result == 'success' && needs.release-cli-linux.result == 'success'
+    runs-on: tuist-linux
+    timeout-minutes: 15
+    env:
+      GITHUB_TOKEN: ${{ secrets.TUIST_RELEASE_GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+          fetch-depth: 0
+          token: ${{ secrets.TUIST_RELEASE_GITHUB_TOKEN }}
+      - uses: jdx/mise-action@v4.0.1
+        with:
+          version: ${{ env.MISE_VERSION }}
+          install_args: "--locked git-cliff"
+          cache: "false"
+          github_token: ${{ env.MISE_GITHUB_TOKEN }}
+      - name: Download CLI artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: cli-artifacts
+      - name: Download CLI Linux x86_64 artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: cli-linux-x86_64-artifacts
+          path: build-linux-x86_64
+      - name: Download CLI Linux aarch64 artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: cli-linux-aarch64-artifacts
+          path: build-linux-aarch64
+      - name: Merge Linux artifacts into build directory
+        run: |
+          # Append Linux checksums to main checksum files
+          cat build-linux-x86_64/SHASUMS256.txt >> build/SHASUMS256.txt
+          cat build-linux-x86_64/SHASUMS512.txt >> build/SHASUMS512.txt
+          cat build-linux-aarch64/SHASUMS256.txt >> build/SHASUMS256.txt
+          cat build-linux-aarch64/SHASUMS512.txt >> build/SHASUMS512.txt
+          # Move Linux tarballs to build directory
+          mv build-linux-x86_64/tuist-linux-x86_64.tar.gz build/
+          mv build-linux-aarch64/tuist-linux-aarch64.tar.gz build/
+      - name: Create CLI GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          draft: false
+          repository: tuist/tuist
+          # Pin the tag to the exact commit that was built, passed in as a
+          # resolved SHA. github.sha would resolve to the caller's triggering
+          # commit under workflow_call (main HEAD for a backport), not the
+          # release branch we actually built.
+          target_commitish: ${{ inputs.ref }}
+          # Backports publish off an older line and must not move GitHub's
+          # "Latest" pointer; the caller passes "false" for those.
+          make_latest: ${{ inputs.make_latest }}
+          # Canary and RC builds are prereleases: this is what makes package
+          # managers (mise, Homebrew) exclude them from default resolution.
+          # make_latest alone only suppresses the "Latest" badge.
+          prerelease: ${{ inputs.prerelease }}
+          name: CLI ${{ inputs.version }}
+          tag_name: ${{ inputs.version }}
+          body: ${{ needs.release-cli.outputs.release-notes }}
+          files: |
+            build/tuist.zip
+            build/tuist-linux-x86_64.tar.gz
+            build/tuist-linux-aarch64.tar.gz
+            build/SHASUMS256.txt
+            build/SHASUMS512.txt
+            build/ProjectDescription.xcframework.zip
+            build/tuist.spec.json
+      - name: Trigger Homebrew Formula Update
+        # Skipped for backports: brew install tuist must keep pointing at the
+        # true latest version, never an older patched line.
+        if: ${{ inputs.update_homebrew }}
+        run: |
+          SHA256=$(cat build/SHASUMS256.txt | grep tuist.zip | awk '{print $1}')
+          mise run --no-deps cli:release:homebrew-formula --version "${{ inputs.version }}" --github-token "${{ secrets.TUIST_RELEASE_GITHUB_TOKEN }}" --sha256 "$SHA256"

--- a/cli/Sources/TuistCore/Analytics/RunCacheTargetMetadata.swift
+++ b/cli/Sources/TuistCore/Analytics/RunCacheTargetMetadata.swift
@@ -1,20 +1,15 @@
-import Foundation
-
 public struct RunCacheTargetMetadata: Codable, Hashable {
     public let hash: String
     public let hit: RunCacheHit
-    public let buildDuration: TimeInterval?
     public let subhashes: TargetContentHashSubhashes?
 
     public init(
         hash: String,
         hit: RunCacheHit,
-        buildDuration: TimeInterval? = nil,
         subhashes: TargetContentHashSubhashes? = nil
     ) {
         self.hash = hash
         self.hit = hit
-        self.buildDuration = buildDuration
         self.subhashes = subhashes
     }
 }

--- a/cli/Sources/TuistCore/Cache/CacheItem.swift
+++ b/cli/Sources/TuistCore/Cache/CacheItem.swift
@@ -1,6 +1,3 @@
-import Foundation
-import Path
-
 public struct CacheItem: Hashable, Equatable, Codable {
     /// Cache items can either come from a local or a remote cache
     public enum Source: Hashable, Equatable, Codable {
@@ -11,20 +8,17 @@ public struct CacheItem: Hashable, Equatable, Codable {
     public let hash: String
     public let source: Source
     public let cacheCategory: RemoteCacheCategory
-    public let buildDuration: TimeInterval?
 
     public init(
         name: String,
         hash: String,
         source: Source,
-        cacheCategory: RemoteCacheCategory,
-        buildDuration: TimeInterval? = nil
+        cacheCategory: RemoteCacheCategory
     ) {
         self.name = name
         self.hash = hash
         self.source = source
         self.cacheCategory = cacheCategory
-        self.buildDuration = buildDuration
     }
 
     public func hash(into hasher: inout Hasher) {
@@ -37,15 +31,13 @@ public struct CacheItem: Hashable, Equatable, Codable {
             name: String = "Target",
             hash: String = "cache-item-hash",
             source: Source = .local,
-            cacheCategory: RemoteCacheCategory = .selectiveTests,
-            buildDuration: TimeInterval? = nil
+            cacheCategory: RemoteCacheCategory = .selectiveTests
         ) -> Self {
             .init(
                 name: name,
                 hash: hash,
                 source: source,
-                cacheCategory: cacheCategory,
-                buildDuration: buildDuration
+                cacheCategory: cacheCategory
             )
         }
     #endif

--- a/cli/Sources/TuistKit/Commands/Cache/CacheWarmCommandService.swift
+++ b/cli/Sources/TuistKit/Commands/Cache/CacheWarmCommandService.swift
@@ -14,7 +14,6 @@ import TuistLoader
 import TuistPlugin
 import TuistServer
 import TuistSupport
-import TuistXCActivityLog
 import TuistXcodeBuildProducts
 import XcodeGraph
 #if canImport(TuistCacheEE)
@@ -42,7 +41,6 @@ import XcodeGraph
         private let fileSystem: FileSysteming
         private let contentHasher: ContentHashing
         private let cacheGraphContentHasher: CacheGraphContentHashing
-        private let activityLogController: XCActivityLogControlling
 
         public init() {
             let contentHasher = ContentHasher()
@@ -55,8 +53,7 @@ import XcodeGraph
                 xcodeProjectBuildDirectoryLocator: XcodeProjectBuildDirectoryLocator(),
                 fileSystem: FileSystem(),
                 contentHasher: contentHasher,
-                cacheGraphContentHasher: CacheGraphContentHasher(contentHasher: contentHasher),
-                activityLogController: XCActivityLogController()
+                cacheGraphContentHasher: CacheGraphContentHasher(contentHasher: contentHasher)
             )
         }
 
@@ -69,8 +66,7 @@ import XcodeGraph
             xcodeProjectBuildDirectoryLocator: XcodeProjectBuildDirectoryLocating,
             fileSystem: FileSysteming,
             contentHasher: ContentHashing,
-            cacheGraphContentHasher: CacheGraphContentHashing,
-            activityLogController: XCActivityLogControlling
+            cacheGraphContentHasher: CacheGraphContentHashing
         ) {
             configLoader = ConfigLoader()
             manifestLoader = ManifestLoader.current
@@ -84,7 +80,6 @@ import XcodeGraph
             self.fileSystem = fileSystem
             self.contentHasher = contentHasher
             self.cacheGraphContentHasher = cacheGraphContentHasher
-            self.activityLogController = activityLogController
         }
 
         // swiftlint:disable:next function_body_length
@@ -230,10 +225,8 @@ import XcodeGraph
                 var artifactsToStore: [CacheGraphTargetBuiltArtifact] = []
 
                 let derivedDataPath = temporaryDirectory.appending(component: "derived-data")
-                let activityLogsDirectory = temporaryDirectory.appending(component: "activity-logs")
 
                 try await fileSystem.makeDirectory(at: derivedDataPath)
-                try await fileSystem.makeDirectory(at: activityLogsDirectory)
 
                 let xcodebuildTarget = XcodeBuildTarget(with: projectPath)
 
@@ -263,8 +256,6 @@ import XcodeGraph
                     )
                 }
 
-                try await moveActivityLogs(derivedDataPath: derivedDataPath, activityLogsDirectory: activityLogsDirectory)
-
                 for (scheme, _) in bundlesSchemes {
                     artifactsToStore.append(contentsOf: try await buildBundles(
                         scheme,
@@ -274,8 +265,6 @@ import XcodeGraph
                         cacheableTargets: hashesByTargetToBeCached
                     ))
                 }
-
-                try await moveActivityLogs(derivedDataPath: derivedDataPath, activityLogsDirectory: activityLogsDirectory)
 
                 for (scheme, _) in macroSchemes {
                     artifactsToStore.append(contentsOf: try await buildMacros(
@@ -287,8 +276,6 @@ import XcodeGraph
                         temporaryDirectory: temporaryDirectory
                     ))
                 }
-
-                try await moveActivityLogs(derivedDataPath: derivedDataPath, activityLogsDirectory: activityLogsDirectory)
 
                 Logger.current.info("Creating XCFrameworks", metadata: .section)
                 artifactsToStore.append(contentsOf: try await buildXCFrameworks(
@@ -305,11 +292,7 @@ import XcodeGraph
                 Logger.current.info("Storing binaries to speed up workflows", metadata: .section)
 
                 let successfullyStoredTargets = try await store(
-                    try await artifactsWithBuildTimes(
-                        artifacts: artifactsToStore,
-                        projectDerivedDataDirectory: derivedDataPath,
-                        activityLogsDirectory: activityLogsDirectory
-                    ),
+                    artifactsToStore,
                     cacheStorage: cacheStorage,
                     temporaryDirectory: temporaryDirectory
                 )
@@ -322,17 +305,6 @@ import XcodeGraph
                 } else {
                     Logger.current.info("\(successfullyStoredTargets.count) targets stored: \(targetsStored)")
                 }
-            }
-        }
-
-        /// xcodebuild invocations might delete old activity logs, so to prevent that from happening, we copy them into a
-        /// temporary
-        /// directory.
-        private func moveActivityLogs(derivedDataPath: AbsolutePath, activityLogsDirectory: AbsolutePath) async throws {
-            let activityLogs = try await fileSystem.glob(directory: derivedDataPath, include: ["Logs/Build/*.xcactivitylog"])
-                .collect()
-            for activityLog in activityLogs {
-                try await fileSystem.move(from: activityLog, to: activityLogsDirectory.appending(component: activityLog.basename))
             }
         }
 
@@ -793,31 +765,6 @@ import XcodeGraph
             )
         }
 
-        private func artifactsWithBuildTimes(
-            artifacts: [CacheGraphTargetBuiltArtifact],
-            projectDerivedDataDirectory _: AbsolutePath,
-            xcresultPaths _: [AbsolutePath] = [],
-            activityLogsDirectory: AbsolutePath
-        ) async throws -> [CacheGraphTargetBuiltArtifact] {
-            let activityLogs = try await fileSystem.glob(directory: activityLogsDirectory, include: ["*.xcactivitylog"]).collect()
-            let buildTimes = try await activityLogController
-                .buildTimesByTarget(activityLogPaths: activityLogs)
-            return artifacts.map { artifact in
-                if let buildTime = buildTimes[artifact.graphTarget.target.name] {
-                    var metadata = artifact.metadata
-                    metadata
-                        .buildTime = buildTime /
-                        1.5 // Divide by a factor to account for the additional time to build for multiple architectures or
-                    // destinations.
-                    var artifact = artifact
-                    artifact.metadata = metadata
-                    return artifact
-                } else {
-                    return artifact
-                }
-            }
-        }
-
         private func copyDerivedDataArtifacts(
             into: AbsolutePath,
             productsDirectory: AbsolutePath,
@@ -845,15 +792,14 @@ import XcodeGraph
             let storableTargets = Dictionary(
                 uniqueKeysWithValues: try await artifacts
                     .reduce(into: [CacheStorableTarget: [AbsolutePath]]()) { acc, next in
-                        acc[CacheStorableTarget(target: next.graphTarget, hash: next.hash, time: next.metadata.buildTime)] =
-                            [next.path]
+                        acc[CacheStorableTarget(target: next.graphTarget, hash: next.hash)] = [next.path]
                     }.concurrentMap { storableTarget, paths in
                         let metadataFilePath = temporaryDirectory.appending(
                             components: "Metadatas",
                             "\(storableTarget.name)-\(storableTarget.hash)",
                             "Metadata.plist"
                         )
-                        let metadata = CacheStorableItemMetadata(time: storableTarget.time)
+                        let metadata = CacheStorableItemMetadata()
                         try await fileSystem.makeDirectory(at: metadataFilePath.parentDirectory)
                         try await fileSystem.writeAsPlist(metadata, at: metadataFilePath)
                         var paths = paths

--- a/cli/Sources/TuistKit/Commands/TrackableCommand/CommandEventFactory.swift
+++ b/cli/Sources/TuistKit/Commands/TrackableCommand/CommandEventFactory.swift
@@ -92,7 +92,6 @@ public struct CommandEventFactory {
                         binaryCacheMetadata = RunCacheTargetMetadata(
                             hash: cacheItem.hash,
                             hit: hit,
-                            buildDuration: cacheItem.buildDuration,
                             subhashes: targetContentHashSubhashes[cacheItem.hash]
                         )
                     } else {

--- a/cli/Sources/TuistServer/CacheStoring.swift
+++ b/cli/Sources/TuistServer/CacheStoring.swift
@@ -8,13 +8,11 @@
     public struct CacheStorableTarget: Hashable, Equatable {
         public let target: GraphTarget
         public let hash: String
-        public let time: Double?
         public var name: String { target.target.name }
 
-        public init(target: GraphTarget, hash: String, time: Double? = nil) {
+        public init(target: GraphTarget, hash: String) {
             self.target = target
             self.hash = hash
-            self.time = time
         }
 
         public func hash(into hasher: inout Hasher) {
@@ -49,10 +47,7 @@
     }
 
     public struct CacheStorableItemMetadata: Hashable, Equatable, Codable {
-        public let time: Double?
-        public init(time: Double? = nil) {
-            self.time = time
-        }
+        public init() {}
     }
 
     @Mockable
@@ -96,8 +91,7 @@
                     (
                         CacheStorableItem(
                             name: target.name,
-                            hash: target.hash,
-                            metadata: CacheStorableItemMetadata(time: target.time)
+                            hash: target.hash
                         ),
                         paths
                     )

--- a/cli/Sources/TuistServer/Services/CreateCommandEventService.swift
+++ b/cli/Sources/TuistServer/Services/CreateCommandEventService.swift
@@ -127,7 +127,6 @@
                                             .miss
                                         }
                                         return .init(
-                                            build_duration: binaryCacheMetadata.buildDuration.map { Int($0) },
                                             hash: binaryCacheMetadata.hash,
                                             hit: hit,
                                             subhashes: binaryCacheMetadata.subhashes.map { subhashes in

--- a/cli/Sources/TuistXCActivityLog/XCActivityLogController.swift
+++ b/cli/Sources/TuistXCActivityLog/XCActivityLogController.swift
@@ -9,7 +9,6 @@ import TuistLogging
 import TuistRootDirectoryLocator
 import TuistSupport
 import XCActivityLogParser
-import XCLogParser
 
 enum XCActivityLogControllerError: LocalizedError, Equatable {
     case failedToParseActivityLog(path: AbsolutePath, reason: String)
@@ -33,11 +32,6 @@ public protocol XCActivityLogControlling {
         filter: @escaping (XCActivityLogFile) -> Bool
     )
         async throws -> XCActivityLogFile?
-    func buildTimesByTarget(projectDerivedDataDirectory: AbsolutePath) async throws -> [
-        String: Double
-    ]
-    func buildTimesByTarget(activityLogPaths: [AbsolutePath]) async throws
-        -> [String: Double]
     func parse(_ path: AbsolutePath) async throws -> XCActivityLog
 }
 
@@ -65,87 +59,6 @@ public struct XCActivityLogController: XCActivityLogControlling {
         self.fileSystem = fileSystem
         self.rootDirectoryLocator = rootDirectoryLocator
         self.gitController = gitController
-    }
-
-    public func buildTimesByTarget(projectDerivedDataDirectory: AbsolutePath) async throws
-        -> [String: Double]
-    {
-        let buildLogsPath = projectDerivedDataDirectory.appending(components: [
-            "Logs",
-            "Build",
-        ])
-        let logStoreManifestPlistPath = buildLogsPath.appending(components: [
-            "LogStoreManifest.plist",
-        ])
-        let logStoreManifest: XCLogStoreManifestPlist
-        do {
-            logStoreManifest = try await fileSystem.readPlistFile(
-                at: logStoreManifestPlistPath
-            )
-        } catch {
-            throw XCActivityLogControllerError.wrap(error, path: logStoreManifestPlistPath)
-        }
-
-        let activityLogPaths = logStoreManifest.logs.keys.map {
-            buildLogsPath.appending(components: ["\($0).xcactivitylog"])
-        }
-
-        return try await buildTimesByTarget(activityLogPaths: activityLogPaths)
-    }
-
-    public func buildTimesByTarget(activityLogPaths: [AbsolutePath]) async throws
-        -> [String: Double]
-    {
-        var buildTimes: [String: Double] = [:]
-        for activityLogPath in activityLogPaths {
-            let activityLog: IDEActivityLog
-            do {
-                activityLog = try XCLogParser.ActivityParser().parseActivityLogInURL(
-                    activityLogPath.url,
-                    redacted: false,
-                    withoutBuildSpecificInformation: false
-                )
-            } catch {
-                throw XCActivityLogControllerError.wrap(error, path: activityLogPath)
-            }
-            let buildStep: BuildStep
-            do {
-                buildStep = try XCLogParser.ParserBuildSteps(
-                    omitWarningsDetails: true,
-                    omitNotesDetails: true,
-                    truncLargeIssues: true
-                )
-                .parse(activityLog: activityLog)
-            } catch {
-                throw XCActivityLogControllerError.wrap(error, path: activityLogPath)
-            }
-
-            for (targetName, targetBuildDuration) in flattenedXCLogParserBuildStep([buildStep])
-                .filter({ $0.title.starts(with: "Build target") }).map({
-                    ($0.signature, $0.subSteps.reduce(into: 0) { duration, subStep in
-                        duration += subStep.compilationDuration * 1000 // From seconds to miliseconds
-                    })
-                })
-            {
-                // If a target supports multiple platforms, the time will persist is the time of the latest platform that we
-                // built.
-                buildTimes[targetName] = targetBuildDuration
-            }
-        }
-
-        return buildTimes
-    }
-
-    private func flattenedXCLogParserBuildStep(_ buildSteps: [XCLogParser.BuildStep])
-        -> [XCLogParser.BuildStep]
-    {
-        return buildSteps.flatMap { step in
-            var flattened = [step]
-            if !step.subSteps.isEmpty {
-                flattened.append(contentsOf: flattenedXCLogParserBuildStep(step.subSteps))
-            }
-            return flattened
-        }
     }
 
     public func mostRecentActivityLogFile(

--- a/cli/Tests/TuistServerTests/CacheStorableItemTests.swift
+++ b/cli/Tests/TuistServerTests/CacheStorableItemTests.swift
@@ -11,18 +11,15 @@ struct CacheStorableItemTests {
             [
                 CacheStorableItem(
                     name: "name_one",
-                    hash: "hash_one",
-                    metadata: CacheStorableItemMetadata(time: 100)
+                    hash: "hash_one"
                 ),
                 CacheStorableItem(
                     name: "name_one",
-                    hash: "hash_one",
-                    metadata: CacheStorableItemMetadata(time: 200)
+                    hash: "hash_one"
                 ),
                 CacheStorableItem(
                     name: "name_two",
-                    hash: "hash_one",
-                    metadata: CacheStorableItemMetadata(time: 100)
+                    hash: "hash_one"
                 ),
             ]
         )

--- a/cli/Tests/TuistXCActivityLogTests/XCActivityLog/XCActivityLogControllerTests.swift
+++ b/cli/Tests/TuistXCActivityLogTests/XCActivityLog/XCActivityLogControllerTests.swift
@@ -19,18 +19,6 @@ struct XCActivityLogControllerTests {
         )
     }
 
-    @Test func buildTimesByTarget() async throws {
-        // Given
-        let projectDerivedDataDirectory = try AbsolutePath(validating: #file).parentDirectory
-            .appending(try RelativePath(validating: "../../Fixtures/FrameworkDerivedDataWithActivityLog"))
-
-        // When
-        let got = try await subject.buildTimesByTarget(projectDerivedDataDirectory: projectDerivedDataDirectory)
-
-        // Then
-        #expect(got == ["Framework": 4.696011543273926])
-    }
-
     @Test func parseCleanBuildXCActivityLog() async throws {
         // Given
         let cleanBuildXCActivityLog = try AbsolutePath(validating: #file).parentDirectory


### PR DESCRIPTION
## What

Backports [#11282](https://github.com/tuist/tuist/pull/11282) ("remove cache target build time tracking") onto the `4.193.x` line so a patch release (`4.193.5`) can ship the fix without a full CLI upgrade.

Two commits:
1. **`fix(cli): remove cache target build time tracking (#11282)`** — the cherry-pick of #11282. Its CLI source applies to the `4.193.4` tree with no code conflicts. Also bumps the `cli/TuistCacheEE` submodule to a matching `4.193.x` EE backport (see below).
2. **`ci(cli): backport the CLI backport-release workflow to 4.193.x`** — adds `cli-backport.yml` and its reusable `cli-build-publish.yml`, which are absent from the `4.193.4` tree.

## Why

A team still on `4.193.4` is hitting the `.xcactivitylog` cache-warm parsing failures (more cache-fill failures than successes on some configs), worsened after moving their fleet to M4s. #11282 fixes this by removing the cache-warm path that copied and parsed `.xcactivitylog` files to infer per-target build times. They want the fix without the risk/coordination of jumping ~8 minor versions right now.

## Root cause of the failures

The removed code path parsed `.xcactivitylog` files during `tuist cache` to attribute per-target build durations. That parsing is what fails; #11282 drops the feature (and the per-target build duration it fed) entirely, since it had no other consumer.

## EE submodule coupling (why the extra backport)

#11282 removes `CacheItem.buildDuration`, `CacheStorableTarget.time`, and `CacheStorableItemMetadata.time`. The EE submodule pinned at `4.193.4`'s base (`a20d4383`) still references those, so the backported CLI would not compile as-is. The submodule is therefore bumped to a **minimal** EE backport on `tuist/TuistCacheEE` (`releases/4.193.x`, `52432bf`): it starts from `4.193.4`'s exact EE base and applies only the matching build-time removal (equivalent to EE #66), deliberately excluding the interim focused-cache-hash change (#63) to keep drift at zero beyond what this fix requires. That EE branch is already pushed so CI can resolve the pointer.

## Why this shape

- **Backport, not upgrade:** keeps the team's DX stable; they can bump to a newer minor when they have headspace.
- **Workflow ported from `releases/4.201.x`, not main:** that copy predates the `cas-plugin` build step, so dispatching `cli-backport.yml --ref releases/4.193.x` builds the `4.193.x` tree (which has no `cas-plugin/`) instead of dying on `cwd: cas-plugin does not exist` — the exact failure mode that broke dispatching a backport from main.
- **Minimal EE backport, not "point at EE HEAD":** avoids dragging four unrelated June-era EE fixes onto a May CLI tree.

## Impact

- `4.193.5` will **not** become "Latest" and will **not** touch the Homebrew formula: both workflow jobs pass `make_latest=false` and `update_homebrew=false`. mise resolves per-line (`tuist@4.193`), so this only wins its own line, never `tuist@4`.
- No behavior change for anyone not on `4.193.x`.

## Validation

- CLI source cherry-pick is byte-identical to #11282's change (verified `+/-` lines match exactly); the only cherry-pick conflict was the expected submodule gitlink.
- EE backport diff is the line-for-line semantic equivalent of EE #66 (75/15/11 deletions across the three files), with no remaining references to the removed symbols anywhere in the EE tree.
- Ported workflow files are byte-identical to the live `releases/4.201.x` versions (same YAML GitHub already runs), with no `cas-plugin` step.
- Backport-workflow guard checked locally: `git describe` on the branch resolves to `4.193.4` == highest tag on the line, so the workflow computes next version `4.193.5` and passes its rooting guard.

## Release steps (after merge)

Dispatch from the release branch (not main):

```
gh workflow run cli-backport.yml --ref releases/4.193.x -f branch=releases/4.193.x
```
