### PR TITLE
fix(server): fall back to the in-cluster form of the CLI-resolved Kura endpoint for runner fleets without a private cache region

### DIFF
--- a/infra/helm/tuist/values-managed-canary.yaml
+++ b/infra/helm/tuist/values-managed-canary.yaml
@@ -117,8 +117,9 @@ server:
     # Hand cluster-networked fleets the in-cluster cache endpoint. macOS
     # resolves to the node-port form (http://<node PN address>:<NodePort>
     # on scw-fr-par-runners), reached over the PN the minis attach to
-    # (macosFleet.vmCachePrivateNetwork below). linux is the default and
-    # stays inert here (canary advertises no Linux private cache region).
+    # (macosFleet.vmCachePrivateNetwork below). linux resolves through
+    # the public-region fallback — no Linux private cache region here
+    # (see values-managed-production.yaml).
     - name: TUIST_RUNNERS_CLUSTER_NETWORK_PLATFORMS
       value: linux,macos
 

--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -92,15 +92,15 @@ server:
     # Hand cluster-networked fleets the in-cluster cache endpoint. macOS
     # resolves to the node-port form (http://<node PN address>:<NodePort>
     # on scw-fr-par-runners), reached over the PN the minis attach to
-    # (macosFleet.vmCachePrivateNetwork below). linux is TEMPORARILY off
-    # this list: prod has no Linux private (in-cluster) Kura region, so
-    # gating it here only had Linux jobs fall back to the public regional
-    # ingress, which the runners' egress rules block. The Linux runners
-    # are moving to Scaleway Dedibox bare metal, where a node-local Kura
-    # will live (like the macOS fleet); re-add `linux` once that region
-    # exists so dispatch routes Linux jobs to it.
+    # (macosFleet.vmCachePrivateNetwork below). linux resolves through
+    # the public-region fallback (`runner_cache_endpoint_url/2` tier 2):
+    # prod has no Linux private cache region, and the public ingress is
+    # unreachable from runner pods (its host is a cluster node IP, which
+    # the runner egress policy's ipBlock rules never match under
+    # Cilium). Tier 1 takes over once the Linux runners get a node-local
+    # Kura region on Dedibox.
     - name: TUIST_RUNNERS_CLUSTER_NETWORK_PLATFORMS
-      value: macos
+      value: linux,macos
     # Operator project-access grants. The public key verifies grants
     # signed by ops (private half: TUIST_OPS_BOT 1P `project_access_signing_key`,
     # which MUST be stored before this deploys). The reason-form URL turns

--- a/server/lib/tuist/accounts.ex
+++ b/server/lib/tuist/accounts.ex
@@ -2108,7 +2108,13 @@ defmodule Tuist.Accounts do
     end
   end
 
-  defp kura_cache_endpoint_urls(%Account{} = account) do
+  @doc """
+  The Kura cache endpoint URLs the CLI resolves for this account.
+  Public so runner dispatch (`Tuist.Kura.runner_cache_endpoint_url/2`)
+  derives its in-cluster fallback from the exact candidate set the CLI
+  sees, rather than a parallel query that could drift.
+  """
+  def kura_cache_endpoint_urls(%Account{} = account) do
     static_urls = account |> kura_cache_endpoints() |> Enum.map(& &1.url)
     registered_urls = registered_kura_endpoint_urls(account)
 

--- a/server/lib/tuist/kura.ex
+++ b/server/lib/tuist/kura.ex
@@ -489,25 +489,27 @@ defmodule Tuist.Kura do
 
   @doc """
   In-cluster Kura URL a runner-as-a-service build on a fleet of the
-  given platform should use, or `nil` when the account has no active
-  private (runner-cache) Kura node in a region that serves that
-  platform.
+  given platform should use, or `nil` when nothing serves it.
 
-  Builds executing on a runner pool resolve their cache through this so
-  traffic stays inside the cluster, next to the runners, instead of
-  crossing the public ingress dataplane. Auth is unchanged: the same
-  Guardian JWT is verified by the same `tuist.lua` hook on the private
-  node, which carries the same `tenantID`. This reads the active
-  private `Server` row directly — `account_cache_endpoints` is
-  CLI-facing and a developer machine can't reach the in-cluster
-  endpoint.
+  Two tiers, best first: the account's active private (runner-cache)
+  node in a region serving the platform, else the in-cluster Service
+  DNS form of the managed instance the CLI itself would resolve. The
+  fallback exists because runner pods cannot reach the public ingress
+  at all: its host resolves to a cluster node IP, which Cilium
+  classifies as `remote-node` and the runner egress policy's `ipBlock`
+  rules never match. Auth is identical in both tiers (same Guardian
+  JWT, same `tuist.lua` hook, same `tenantID`).
 
-  The platform filter is the locality half of the handoff (which
-  region's node may serve which fleet — `Regions.runner_platforms`);
-  whether the fleet can reach in-cluster URLs at all is the caller's
+  Whether the fleet can reach in-cluster URLs at all is the caller's
   gate (`Catalog.fleet_on_cluster_network?/1`).
   """
-  def runner_cache_endpoint_url(%Account{id: account_id}, platform) when platform in [:linux, :macos] do
+  def runner_cache_endpoint_url(%Account{} = account, platform) when platform in [:linux, :macos] do
+    private_runner_cache_url(account, platform) || public_in_cluster_runner_cache_url(account, platform)
+  end
+
+  def runner_cache_endpoint_url(%Account{}, _platform), do: nil
+
+  defp private_runner_cache_url(%Account{id: account_id}, platform) do
     # `available/0`, not `all/0`: if a private region is dropped from
     # `TUIST_KURA_AVAILABLE_REGIONS` the controller stops reconciling
     # it, and gating here too means dispatch stops handing out the now
@@ -548,7 +550,57 @@ defmodule Tuist.Kura do
     end
   end
 
-  def runner_cache_endpoint_url(%Account{}, _platform), do: nil
+  # Tier 2, interim until the Linux fleets get a node-local private
+  # region (tier 1). eu-central is hardcoded: every runner fleet is
+  # colocated with it today, so it's the instance the CLI's latency
+  # race would pick from a runner — and both URL forms route through
+  # the same pinned per-instance Service, so same pod. Without an
+  # eu-central instance the race is moot (every public form is
+  # unreachable from a runner), so the first candidate wins: a
+  # cross-region cache beats none. No readiness heartbeat needed — the
+  # in-cluster Service already drops not-ready pods. Linux-only because
+  # only cluster-CNI pods resolve Service DNS; macOS Tart VMs can't,
+  # and their public resolution works anyway.
+  defp public_in_cluster_runner_cache_url(%Account{} = account, :linux) do
+    servers = managed_cli_endpoint_servers(account)
+
+    server = Enum.find(servers, &(&1.region == "eu-central")) || List.first(servers)
+
+    in_cluster_url(server, account)
+  end
+
+  defp public_in_cluster_runner_cache_url(%Account{}, _platform), do: nil
+
+  # Candidates come from the CLI's own endpoint list so selection can't
+  # drift from what the CLI resolves. The URL match is exact by
+  # construction — the mirror writes `Server.url` verbatim
+  # (`activate_server_transaction/4`). URLs with no matching active
+  # server are registered self-hosted nodes and drop out deliberately:
+  # their hosts are external IPs the runner egress already reaches, so
+  # staging one would override the CLI's own working selection.
+  defp managed_cli_endpoint_servers(%Account{id: account_id} = account) do
+    case Accounts.kura_cache_endpoint_urls(account) do
+      [] ->
+        []
+
+      urls ->
+        Server
+        |> where([s], s.account_id == ^account_id and s.status == :active and s.url in ^urls)
+        |> order_by(asc: :region)
+        |> Repo.all()
+    end
+  end
+
+  defp in_cluster_url(nil, _account), do: nil
+
+  # The `Server.url` column holds the public URL for these rows, so the
+  # in-cluster form is rendered fresh from the region's template.
+  defp in_cluster_url(%Server{} = server, account) do
+    case Provisioner.internal_url(account, server) do
+      url when is_binary(url) and url != "" -> url
+      _ -> nil
+    end
+  end
 
   defp node_port_region_ids(private_region_ids) do
     Enum.filter(private_region_ids, fn id ->

--- a/server/lib/tuist/kura/provisioner.ex
+++ b/server/lib/tuist/kura/provisioner.ex
@@ -73,6 +73,14 @@ defmodule Tuist.Kura.Provisioner do
               String.t() | nil
 
   @doc """
+  In-cluster URL of the server, or `nil` if the region has no
+  cluster-internal form. Never handed to the CLI — only runner dispatch
+  uses it (`Tuist.Kura.runner_cache_endpoint_url/2`).
+  """
+  @callback internal_url(account_handle :: String.t(), Regions.t(), ref :: String.t()) ::
+              String.t() | nil
+
+  @doc """
   Best-effort drift check: what version is actually running on the
   node right now? Returns `{:ok, nil}` when the resource exists but
   isn't reporting a version yet. Used for reconciliation jobs and the
@@ -142,6 +150,15 @@ defmodule Tuist.Kura.Provisioner do
       region.provisioner.grpc_public_url(handle, region, ref)
     end
   end
+
+  @doc "Calls `internal_url/3` on the region's provisioner."
+  def internal_url(%Account{name: handle}, %Server{provisioner_node_ref: ref, region: region_id}) when is_binary(ref) do
+    with {:ok, region} <- Regions.fetch(region_id) do
+      region.provisioner.internal_url(handle, region, ref)
+    end
+  end
+
+  def internal_url(%Account{}, %Server{}), do: nil
 
   @doc "Calls `current_image_tag/2` on the region's provisioner."
   def current_image_tag(%Server{provisioner_node_ref: ref, region: region_id}) do

--- a/server/lib/tuist/kura/provisioner/kubernetes_controller.ex
+++ b/server/lib/tuist/kura/provisioner/kubernetes_controller.ex
@@ -96,6 +96,18 @@ defmodule Tuist.Kura.Provisioner.KubernetesController do
   end
 
   @impl true
+  # The instance's Service is named after `provisioner_node_ref`
+  # (`rollout/2` sets `metadata.name = ref`), which diverges from
+  # `instance_name/2` after a warm-handoff move (`-m` suffix) — so the
+  # ref, not the handle, is the source of truth for the in-cluster name.
+  def internal_url(_handle, %Regions{provisioner_config: config}, ref) when is_binary(ref) do
+    case config[:private_url_template] do
+      template when is_binary(template) -> String.replace(template, "{instance}", ref)
+      _ -> nil
+    end
+  end
+
+  @impl true
   def current_image_tag(name, %Regions{} = region) do
     case client_get_kura_instance(@namespace, name, region) do
       {:ok, %{"status" => %{"observedImage" => image}}} -> {:ok, image_tag_from_image(image)}

--- a/server/lib/tuist/kura/regions.ex
+++ b/server/lib/tuist/kura/regions.ex
@@ -51,6 +51,11 @@ defmodule Tuist.Kura.Regions do
   # controller's peerPort). Self-hosted nodes dial the public peer host here.
   @peer_port 7443
   @managed_region_storage_class "hcloud-volumes"
+  # In-cluster Service DNS form of a region's per-account instance.
+  # Port 4000 co-hosts the HTTP cache API and REAPI gRPC (h2c) on one
+  # listener. Never CLI-facing — only runner dispatch hands it out
+  # (`Tuist.Kura.runner_cache_endpoint_url/2`).
+  @in_cluster_url_template "http://{instance}.kura.svc.cluster.local:4000"
   # The guaranteed egress floor an enterprise tenant reserves on a shared
   # bare-metal box, requested as the tuist.dev/egress-mbps extended resource the
   # scheduler bin-packs against the node's budget. Uniform across regions — a
@@ -366,6 +371,7 @@ defmodule Tuist.Kura.Regions do
         cluster_id: spec.cluster_id,
         hetzner_location: Map.get(spec, :hetzner_location),
         public_host_template: String.replace(@managed_region_public_host_template, "{env_suffix}", host_suffix),
+        private_url_template: @in_cluster_url_template,
         grpc_public_host_template: String.replace(@managed_region_grpc_public_host_template, "{env_suffix}", host_suffix),
         peer_public_host_template: String.replace(@managed_region_peer_public_host_template, "{env_suffix}", host_suffix),
         ingress_class_name: spec.ingress_class_name,
@@ -441,7 +447,7 @@ defmodule Tuist.Kura.Regions do
         # interpolates to `instance_name(handle, region)`. Node-port
         # regions don't use it for dispatch but keep it as the
         # in-cluster debugging path.
-        private_url_template: "http://{instance}.kura.svc.cluster.local:4000",
+        private_url_template: @in_cluster_url_template,
         data_plane: Map.get(spec, :data_plane, :cluster_dns),
         client_cidrs: Map.get(spec, :client_cidrs, []),
         pod_annotations: Map.get(spec, :pod_annotations, %{}),

--- a/server/lib/tuist_web/controllers/runners_controller.ex
+++ b/server/lib/tuist_web/controllers/runners_controller.ex
@@ -133,13 +133,13 @@ defmodule TuistWeb.RunnersController do
     conn |> put_status(:bad_request) |> json(%{error: "missing fleet query param"})
   end
 
-  # Hands the polling Pod its JIT config plus, when the account runs a
-  # private runner-cache Kura node, the in-cluster URL the job should
-  # use. The runner image exports it as `TUIST_CACHE_ENDPOINT` so cache
-  # traffic stays on the cluster's internal network next to the runner
-  # instead of going through the public Kura ingress. Absent
-  # (non-runner-cache accounts), the Pod falls back to normal
-  # server-side cache resolution.
+  # Hands the polling Pod its JIT config plus, when the account has a
+  # Kura node serving the fleet's platform, the in-cluster URL the job
+  # should use (tier order in `Tuist.Kura.runner_cache_endpoint_url/2`).
+  # The runner image exports it as `TUIST_CACHE_ENDPOINT` so cache
+  # traffic stays on the cluster's internal network instead of going
+  # through the public Kura ingress. Absent (no serving node), the Pod
+  # falls back to normal server-side cache resolution.
   #
   # Only fleets on the cluster pod network get the URL: it's a
   # `*.svc.cluster.local` address, and clients treat

--- a/server/test/tuist/kura/provisioner/kubernetes_controller_test.exs
+++ b/server/test/tuist/kura/provisioner/kubernetes_controller_test.exs
@@ -862,6 +862,24 @@ defmodule Tuist.Kura.Provisioner.KubernetesControllerTest do
     end
   end
 
+  describe "internal_url/3" do
+    test "renders the ref as the in-cluster Service name" do
+      assert KubernetesController.internal_url("TUIST", scaleway_region(), "kura-tuist-scw-fr-par") ==
+               "http://kura-tuist-scw-fr-par.kura.svc.cluster.local:4000"
+    end
+
+    test "keeps a moved server's -m ref — the Service is named after the ref, not the handle" do
+      assert KubernetesController.internal_url("tuist", Regions.get("eu-central"), "kura-tuist-eu-central-1-m") ==
+               "http://kura-tuist-eu-central-1-m.kura.svc.cluster.local:4000"
+    end
+
+    test "is nil for regions without an in-cluster template" do
+      region = %Regions{id: "local-controller", provisioner_config: %{cluster_id: "local-controller"}}
+
+      assert KubernetesController.internal_url("tuist", region, "kura-tuist-local") == nil
+    end
+  end
+
   defp scaleway_region do
     %Regions{
       id: "scw-fr-par-runners",

--- a/server/test/tuist/kura_test.exs
+++ b/server/test/tuist/kura_test.exs
@@ -803,6 +803,153 @@ defmodule Tuist.KuraTest do
     end
   end
 
+  describe "runner_cache_endpoint_url/2 public in-cluster fallback" do
+    setup do
+      stub(Tuist.Environment, :dev?, fn -> false end)
+      stub(Tuist.Environment, :test?, fn -> false end)
+
+      stub(Tuist.Environment, :kura_available_region_ids, fn ->
+        ["eu-central", "us-east", "us-west", "scw-fr-par-runners"]
+      end)
+
+      stub(Tuist.FeatureFlags, :kura_cache_enabled?, fn _account -> true end)
+
+      user = AccountsFixtures.user_fixture()
+      account = Accounts.get_account_from_user(user)
+
+      %{account: account}
+    end
+
+    test "hands linux fleets the in-cluster form of the instance the CLI resolves",
+         %{account: account} do
+      activate_public_server!(account, "eu-central")
+
+      handle = String.downcase(account.name)
+
+      assert Kura.runner_cache_endpoint_url(account, :linux) ==
+               "http://kura-#{handle}-eu-central-1.kura.svc.cluster.local:4000"
+    end
+
+    test "prefers the account's eu-central instance among the CLI's candidates", %{account: account} do
+      activate_public_server!(account, "us-east")
+      activate_public_server!(account, "eu-central")
+
+      handle = String.downcase(account.name)
+
+      assert Kura.runner_cache_endpoint_url(account, :linux) ==
+               "http://kura-#{handle}-eu-central-1.kura.svc.cluster.local:4000"
+    end
+
+    test "falls back to the account's first instance when it has none in eu-central",
+         %{account: account} do
+      activate_public_server!(account, "us-west")
+      activate_public_server!(account, "us-east")
+
+      handle = String.downcase(account.name)
+
+      # "First" is stable region order: us-east sorts before us-west.
+      assert Kura.runner_cache_endpoint_url(account, :linux) ==
+               "http://kura-#{handle}-us-east-1.kura.svc.cluster.local:4000"
+    end
+
+    test "stages nothing when the CLI would not resolve Kura endpoints", %{account: account} do
+      stub(Tuist.FeatureFlags, :kura_cache_enabled?, fn _account -> false end)
+
+      activate_public_server!(account, "eu-central")
+
+      assert Kura.runner_cache_endpoint_url(account, :linux) == nil
+    end
+
+    test "never stages registered self-hosted endpoints", %{account: account} do
+      stub(Accounts, :kura_cache_endpoint_urls, fn _account ->
+        ["https://kura.customer.example.com"]
+      end)
+
+      # Externally reachable — the CLI's own selection handles them.
+      assert Kura.runner_cache_endpoint_url(account, :linux) == nil
+    end
+
+    test "excludes mirrored URLs whose server is no longer active", %{account: account} do
+      server = activate_public_server!(account, "eu-central")
+
+      Server |> Repo.get!(server.id) |> Ecto.Changeset.change(status: :failed) |> Repo.update!()
+
+      assert Kura.runner_cache_endpoint_url(account, :linux) == nil
+    end
+
+    test "keeps a moved server's -m instance name", %{account: account} do
+      server = activate_public_server!(account, "eu-central")
+
+      handle = String.downcase(account.name)
+
+      # After a warm-handoff move the Service is named after the -m ref
+      # while the mirrored customer URL — what the candidate match keys
+      # on — is unchanged.
+      Server
+      |> Repo.get!(server.id)
+      |> Ecto.Changeset.change(provisioner_node_ref: "kura-#{handle}-eu-central-1-m")
+      |> Repo.update!()
+
+      assert Kura.runner_cache_endpoint_url(account, :linux) ==
+               "http://kura-#{handle}-eu-central-1-m.kura.svc.cluster.local:4000"
+    end
+
+    test "never hands macOS fleets a cluster-DNS URL", %{account: account} do
+      activate_public_server!(account, "eu-central")
+
+      assert Kura.runner_cache_endpoint_url(account, :macos) == nil
+    end
+
+    test "macOS stays on default resolution when its private node's heartbeat is stale, despite an active public server",
+         %{account: account} do
+      {:ok, private} =
+        Kura.create_server(%{account_id: account.id, region: "scw-fr-par-runners", image_tag: "0.5.2"})
+
+      expect(Provisioner, :external_endpoint, fn %Server{} -> {:ok, "http://172.16.0.2:30815"} end)
+      {:ok, active_private} = Kura.activate_server(private, "0.5.2")
+
+      stale = ~U[2020-01-01 00:00:00Z]
+      Server |> Repo.get!(active_private.id) |> Ecto.Changeset.change(last_ready_at: stale) |> Repo.update!()
+
+      activate_public_server!(account, "eu-central")
+
+      # The Tart VMs can't resolve cluster Service DNS, so a stale private
+      # node must fail macOS over to the public cache (nil), never to the
+      # in-cluster fallback URL.
+      assert Kura.runner_cache_endpoint_url(account, :macos) == nil
+    end
+
+    test "prefers a serving private runner-cache node over the public fallback", %{account: account} do
+      stub(Tuist.Environment, :kura_available_region_ids, fn ->
+        ["eu-central", "hetzner-staging-runners"]
+      end)
+
+      activate_public_server!(account, "eu-central")
+
+      {:ok, private} =
+        Kura.create_server(%{account_id: account.id, region: "hetzner-staging-runners", image_tag: "0.5.2"})
+
+      stub(Provisioner, :public_url, fn _account, %Server{} ->
+        "http://kura-private.kura.svc.cluster.local"
+      end)
+
+      {:ok, active_private} = Kura.activate_server(private, "0.5.2")
+
+      assert Kura.runner_cache_endpoint_url(account, :linux) == active_private.url
+    end
+
+    test "requires an active, CLI-visible public server", %{account: account} do
+      {:ok, _server} =
+        Kura.create_server(%{account_id: account.id, region: "eu-central", image_tag: "0.5.2"})
+
+      assert Kura.runner_cache_endpoint_url(account, :linux) == nil
+    end
+
+    test "is nil for accounts without any server", %{account: account} do
+      assert Kura.runner_cache_endpoint_url(account, :linux) == nil
+    end
+  end
+
   describe "destroy_server/1" do
     test "marks destroying and removes the cache endpoint" do
       user = AccountsFixtures.user_fixture()
@@ -959,5 +1106,28 @@ defmodule Tuist.KuraTest do
       {:ok, _} = Kura.destroy_server(server)
       assert_receive {:kura_server, :updated, %{status: :destroying}}
     end
+  end
+
+  # A public server as `activate_server/2` leaves it: active, public
+  # `url`, and the URL mirrored into `account_cache_endpoints`. The
+  # fallback intersects mirror and active servers, so tests need both.
+  defp activate_public_server!(account, region) do
+    handle = String.downcase(account.name)
+    url = "https://#{handle}-#{region}-1.kura.tuist.dev"
+
+    {:ok, server} = Kura.create_server(%{account_id: account.id, region: region, image_tag: "0.5.2"})
+
+    server =
+      Server
+      |> Repo.get!(server.id)
+      |> Ecto.Changeset.change(status: :active, url: url)
+      |> Repo.update!()
+
+    {:ok, _} =
+      %AccountCacheEndpoint{}
+      |> AccountCacheEndpoint.create_changeset(%{account_id: account.id, url: url, technology: :kura})
+      |> Repo.insert()
+
+    server
   end
 end


### PR DESCRIPTION
## What

Adds a second tier to `Tuist.Kura.runner_cache_endpoint_url/2`, the function dispatch uses to stage `TUIST_CACHE_ENDPOINT` on runner pods: when the account has no private (runner-cache) Kura node serving the fleet's platform, dispatch now hands out the **in-cluster Service DNS form** (`http://kura-<account>-<cluster>.kura.svc.cluster.local:4000`) of the managed instance the CLI itself would resolve. Production re-enables `linux` in `TUIST_RUNNERS_CLUSTER_NETWORK_PLATFORMS`.

## Why

Production Linux runner jobs fail `tuist bazel setup` on every run of the Kura-cached workflows: no private runner-cache region serves `:linux` in prod (`scw-fr-par-runners` is macOS-only), so dispatch stages no cache endpoint and the CLI falls back to public endpoint discovery → the public regional Kura ingress. That ingress host (`tuist-eu-central-1.kura.tuist.dev`) resolves to **a cluster node's own IP** (the Dedibox node hosting the `kura-eu-central` ingress controller). Cilium classifies traffic to cluster-owned IPs as the `remote-node` identity, which the runner egress policy's `ipBlock: 0.0.0.0/0` rule never matches — CIDR selectors only match `world` traffic. The connection silently drops, the probe times out, and builds run cold.

Debug runs 28710663346 and 29110018799 (`.github/workflows/kura-cache-debug.yml` on the `tuist-runners-grpc` branch) confirmed the diagnosis from inside a runner pod: the public ingress times out on both HTTPS and h2c, while the in-cluster Service DNS form answers REAPI `GetCapabilities` in ~57ms through the existing runners-namespace egress rule (kura-namespace pods, port 4000). No network policy changes are needed.

## Root cause

The runner egress `NetworkPolicy` allows public internet (443/80 via `ipBlock`), DNS, and kura pods on 4000 — but an `ipBlock` CIDR can never match a cluster node IP under Cilium (`policy-cidr-match-mode` unset). The public Kura ingress happens to be node-hosted (hostNetwork ingress controllers on bare-metal nodes), so "public" Kura endpoints are unreachable from exactly one place: inside our own cluster.

## Design: CLI-parity by construction

The requirement is that the fallback points at the **same instance — and same pod — that the CLI's own resolution would pick**. Instead of a parallel query that could drift, tier 2 derives its candidates from the CLI's own selection path:

- `Accounts.kura_cache_endpoint_urls/1` (the exact flag-gated list the CLI's endpoint discovery returns; promoted from `defp` to `def`, body unchanged) provides the candidate URLs — inheriting the `:kura_cache` feature-flag gate, so an account the CLI wouldn't route to Kura gets no fallback either.
- Candidates are matched back to the active `kura_servers` rows the list is mirrored from (`activate_server_transaction/4` mirrors `Server.url` verbatim), so the candidate set cannot drift from what the CLI sees.
- **The account's eu-central instance wins**: every environment's runner fleets are colocated with eu-central, so from a runner it is the instance the CLI's latency race (`CacheURLStore.selectBestEndpoint`, minimum `GET /up` latency) would settle on. The region is deliberately **hardcoded** — this whole tier is an interim measure until the Linux fleets get a node-local private region (the Dedibox move) and tier 1 takes over automatically; a config surface for a temporary path isn't worth carrying. The in-cluster URL routes through the same pinned per-instance Service as the public ingress (verified against the live prod cluster: both the HTTP and gRPC Ingress backends and the internal DNS name are the `kura-<account>-<region>` Service, pinned to one StatefulSet pod) — same instance, same pod.
- **Otherwise pick-first (stable region order)**: an account with instances only in other regions gets its first instance cross-region. Every managed candidate is equally unreachable over its public form from a runner pod, so the race can't run; a cross-region in-cluster cache beats none (previously these accounts got no working cache at all on runners).
- **Registered self-hosted endpoints are never staged**: their hosts are genuinely external IPs the runner egress already reaches, so the CLI's own selection handles them — a hard override would replace a working selection.
- **The in-cluster Service name is rendered from `provisioner_node_ref`, not recomputed from the account handle** (caught in review): the instance's Service is named after the ref, and the two diverge after a warm-handoff move — `move_target_ref` ping-pongs the promoted instance onto a `-m` suffix while the customer URL (the candidate match key) stays the same. Rendering from the ref keeps the fallback pointing at the live Service for moved accounts, and closes the analogous account-rename window.

The fallback is Linux-only (cluster Service DNS only resolves on the cluster CNI). macOS is untouched: it keeps the PN NodePort tier and its stale-heartbeat failover, and never receives a cluster-DNS URL its Tart VMs cannot resolve. **No CLI code changes.**

## Alternatives considered

- **Open the egress to the public ingress** (CiliumNetworkPolicy `toEntities: [remote-node]`, or cluster-wide `policy-cidr-match-mode: nodes`): wider blast radius, hairpins cache traffic through the ingress, and keys behavior to whichever node hosts the ingress controller.
- **Front the public endpoints with a load balancer / Cloudflare** so they classify as `world`: recurring cost and an extra hop for all traffic, purchased solely for in-cluster clients; Cloudflare body-size caps also break CAS blob uploads.
- **CoreDNS rewrite of the public hostname to the ingress Service**: the kura ingress controllers are hostNetwork pods, so post-DNAT the destination is still `remote-node` — it needs the policy change anyway.
- **Stand up the Linux private runner-cache region on Dedibox** (the planned end-state): the right long-term fix; when it lands, tier 1 takes over automatically and this fallback goes dormant.

## Impact

Linux runner jobs on accounts with a managed Kura instance get a working remote cache (Bazel REAPI + HTTP cache API) with no policy or CLI changes. Auth is unchanged: the same Guardian JWT is verified by the same `tuist.lua` hook on the same pod. macOS behavior is identical to before.

## Validation

- 422 tests across the affected files pass (`kura_test.exs`, `regions_test.exs`, `kubernetes_controller_test.exs`, `runners_controller_test.exs`, `accounts_test.exs`), including new coverage for: eu-central preferred among multiple candidates, pick-first when the account has no eu-central instance, a moved server's `-m` ref preserved in the staged URL (end-to-end and at the `internal_url/3` layer), flag-off → nil, self-hosted-only → nil, stale mirror row → nil, macOS → nil in all fallback scenarios, and private node precedence over the fallback.
- In-runner network probes (debug workflow runs above) proved the exact URL shape this PR stages answers `GetCapabilities` in ~57ms from a production Linux runner pod.
- `credo` clean on the touched lib files.

## Draft because

Post-merge this needs an end-to-end check on prod: re-run the kura cache debug workflow (branch `tuist-runners-grpc`) after the deploy and confirm `TUIST_CACHE_ENDPOINT` is staged and `tuist bazel setup` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
