### PR TITLE
fix(cli): generate scheme code coverage references for local Swift package targets

### DIFF
--- a/cli/Sources/TuistCore/Graph/ModelExtensions/Scheme+Core.swift
+++ b/cli/Sources/TuistCore/Graph/ModelExtensions/Scheme+Core.swift
@@ -2,12 +2,19 @@ import XcodeGraph
 
 extension Scheme {
     public func targetDependencies() -> [TargetReference] {
+        let targets = (nonCodeCoverageTargetDependencies() + (testAction?.codeCoverageTargets ?? [])).uniqued()
+        return targets.sorted { $0.name < $1.name }
+    }
+
+    /// Returns the target references used by the scheme actions, excluding the test action's
+    /// code coverage targets, which can reference targets that are not part of the graph
+    /// (e.g. local Swift package targets).
+    public func nonCodeCoverageTargetDependencies() -> [TargetReference] {
         let targetSources: [[TargetReference]?] = [
             buildAction?.targets,
             buildAction?.preActions.compactMap(\.target),
             buildAction?.postActions.compactMap(\.target),
             testAction?.targets.map(\.target),
-            testAction?.codeCoverageTargets,
             testAction?.preActions.compactMap(\.target),
             testAction?.postActions.compactMap(\.target),
             runAction?.executable.map { [$0] },

--- a/cli/Sources/TuistGenerator/Generator/SchemeDescriptorsGenerator.swift
+++ b/cli/Sources/TuistGenerator/Generator/SchemeDescriptorsGenerator.swift
@@ -420,7 +420,7 @@ struct SchemeDescriptorsGenerator: SchemeDescriptorsGenerating {
             environments = environmentVariables(arguments.environmentVariables)
         }
 
-        let localPackagePaths = localPackagePaths(graphTraverser: graphTraverser)
+        let localPackageProducts = graphTraverser.consumedLocalPackageProducts()
         let codeCoverageTargets = try testAction.codeCoverageTargets
             .compactMap { (target: TargetReference) -> XCScheme.BuildableReference? in
                 if let graphTarget = graphTraverser.target(
@@ -433,10 +433,11 @@ struct SchemeDescriptorsGenerator: SchemeDescriptorsGenerating {
                         rootPath: rootPath
                     )
                 }
-                // Coverage targets can reference targets of local Swift packages, which are
+                // Coverage targets can reference products of local Swift packages, which are
                 // not part of the graph. Xcode resolves them through the package directory
-                // used as the referenced container.
-                if localPackagePaths.contains(target.projectPath) {
+                // used as the referenced container. Only names matching a consumed package
+                // product are emitted; other names would produce an empty coverage report.
+                if localPackageProducts[target.projectPath]?.contains(target.name) == true {
                     return packageTargetBuildableReference(target: target, rootPath: rootPath)
                 }
                 return nil
@@ -1103,27 +1104,13 @@ struct SchemeDescriptorsGenerator: SchemeDescriptorsGenerating {
         )
     }
 
-    /// Returns the paths of the local Swift packages declared by the graph projects.
-    ///
-    /// - Parameter graphTraverser: Tuist graph traverser.
-    /// - Returns: Set of local package directories.
-    private func localPackagePaths(graphTraverser: GraphTraversing) -> Set<AbsolutePath> {
-        Set(
-            graphTraverser.projects.values
-                .flatMap(\.packages)
-                .compactMap { package -> AbsolutePath? in
-                    guard case let .local(path) = package else { return nil }
-                    return path
-                }
-        )
-    }
-
-    /// Creates a buildable reference for a target that belongs to a local Swift package.
-    /// Package targets are not part of the generated projects, so the reference points to
-    /// the package directory the same way Xcode does when the target is selected manually.
+    /// Creates a buildable reference for a product of a local Swift package.
+    /// Package products are not part of the generated projects, so the reference points to
+    /// the package directory the same way Xcode does when the product is selected manually.
     ///
     /// - Parameters:
-    ///     - target: The target reference, with the package directory as its project path.
+    ///     - target: The target reference, with the package directory as its project path
+    ///       and a package product as its name.
     ///     - rootPath: Path to the project or workspace.
     private func packageTargetBuildableReference(
         target: TargetReference,

--- a/cli/Sources/TuistGenerator/Generator/SchemeDescriptorsGenerator.swift
+++ b/cli/Sources/TuistGenerator/Generator/SchemeDescriptorsGenerator.swift
@@ -420,18 +420,26 @@ struct SchemeDescriptorsGenerator: SchemeDescriptorsGenerating {
             environments = environmentVariables(arguments.environmentVariables)
         }
 
+        let localPackagePaths = localPackagePaths(graphTraverser: graphTraverser)
         let codeCoverageTargets = try testAction.codeCoverageTargets
             .compactMap { (target: TargetReference) -> XCScheme.BuildableReference? in
-                guard let graphTarget = graphTraverser.target(
+                if let graphTarget = graphTraverser.target(
                     path: target.projectPath, name: target.name
-                )
-                else { return nil }
-                return try testCoverageTargetReferences(
-                    graphTarget: graphTarget,
-                    graphTraverser: graphTraverser,
-                    generatedProjects: generatedProjects,
-                    rootPath: rootPath
-                )
+                ) {
+                    return try testCoverageTargetReferences(
+                        graphTarget: graphTarget,
+                        graphTraverser: graphTraverser,
+                        generatedProjects: generatedProjects,
+                        rootPath: rootPath
+                    )
+                }
+                // Coverage targets can reference targets of local Swift packages, which are
+                // not part of the graph. Xcode resolves them through the package directory
+                // used as the referenced container.
+                if localPackagePaths.contains(target.projectPath) {
+                    return packageTargetBuildableReference(target: target, rootPath: rootPath)
+                }
+                return nil
             }
 
         var macroExpansion: XCScheme.BuildableReference?
@@ -1092,6 +1100,40 @@ struct SchemeDescriptorsGenerator: SchemeDescriptorsGenerating {
             buildableName: target.productNameWithExtension,
             blueprintName: target.name,
             buildableIdentifier: "primary"
+        )
+    }
+
+    /// Returns the paths of the local Swift packages declared by the graph projects.
+    ///
+    /// - Parameter graphTraverser: Tuist graph traverser.
+    /// - Returns: Set of local package directories.
+    private func localPackagePaths(graphTraverser: GraphTraversing) -> Set<AbsolutePath> {
+        Set(
+            graphTraverser.projects.values
+                .flatMap(\.packages)
+                .compactMap { package -> AbsolutePath? in
+                    guard case let .local(path) = package else { return nil }
+                    return path
+                }
+        )
+    }
+
+    /// Creates a buildable reference for a target that belongs to a local Swift package.
+    /// Package targets are not part of the generated projects, so the reference points to
+    /// the package directory the same way Xcode does when the target is selected manually.
+    ///
+    /// - Parameters:
+    ///     - target: The target reference, with the package directory as its project path.
+    ///     - rootPath: Path to the project or workspace.
+    private func packageTargetBuildableReference(
+        target: TargetReference,
+        rootPath: AbsolutePath
+    ) -> XCScheme.BuildableReference {
+        XCScheme.BuildableReference(
+            referencedContainer: "container:\(target.projectPath.relative(to: rootPath).pathString)",
+            blueprintIdentifier: target.name,
+            buildableName: target.name,
+            blueprintName: target.name
         )
     }
 

--- a/cli/Sources/TuistGenerator/Linter/GraphLinter.swift
+++ b/cli/Sources/TuistGenerator/Linter/GraphLinter.swift
@@ -1,5 +1,6 @@
 import FileSystem
 import Foundation
+import Path
 import struct TSCUtility.Version
 import TuistConfig
 import TuistCore
@@ -69,12 +70,28 @@ public struct GraphLinter: GraphLinting {
 
     private func lintSchemesUnknownTargets(graphTraverser: GraphTraversing) -> [LintingIssue] {
         let targets = graphTraverser.targets()
+        let localPackagePaths = Set(
+            graphTraverser.projects.values
+                .flatMap(\.packages)
+                .compactMap { package -> AbsolutePath? in
+                    guard case let .local(path) = package else { return nil }
+                    return path
+                }
+        )
         return graphTraverser.schemes().compactMap { scheme in
+            let codeCoverageTargets = Set(scheme.testAction?.codeCoverageTargets ?? [])
             let unknownTargets = scheme
                 .targetDependencies()
                 .filter { targetReference in
                     if let target = targets[targetReference.projectPath],
                        target.keys.contains(targetReference.name)
+                    {
+                        return false
+                    }
+                    // Code coverage targets can reference targets of local Swift packages,
+                    // which are not part of the graph but are resolvable by Xcode.
+                    if codeCoverageTargets.contains(targetReference),
+                       localPackagePaths.contains(targetReference.projectPath)
                     {
                         return false
                     }

--- a/cli/Sources/TuistGenerator/Linter/GraphLinter.swift
+++ b/cli/Sources/TuistGenerator/Linter/GraphLinter.swift
@@ -79,7 +79,7 @@ public struct GraphLinter: GraphLinting {
                 }
         )
         return graphTraverser.schemes().compactMap { scheme in
-            let codeCoverageTargets = Set(scheme.testAction?.codeCoverageTargets ?? [])
+            let nonCodeCoverageDependencies = Set(scheme.nonCodeCoverageTargetDependencies())
             let unknownTargets = scheme
                 .targetDependencies()
                 .filter { targetReference in
@@ -88,10 +88,11 @@ public struct GraphLinter: GraphLinting {
                     {
                         return false
                     }
-                    // Code coverage targets can reference targets of local Swift packages,
-                    // which are not part of the graph but are resolvable by Xcode.
-                    if codeCoverageTargets.contains(targetReference),
-                       localPackagePaths.contains(targetReference.projectPath)
+                    // References used exclusively as code coverage targets can point to
+                    // targets of local Swift packages, which are not part of the graph
+                    // but are resolvable by Xcode.
+                    if localPackagePaths.contains(targetReference.projectPath),
+                       !nonCodeCoverageDependencies.contains(targetReference)
                     {
                         return false
                     }

--- a/cli/Sources/TuistGenerator/Linter/GraphLinter.swift
+++ b/cli/Sources/TuistGenerator/Linter/GraphLinter.swift
@@ -1,6 +1,5 @@
 import FileSystem
 import Foundation
-import Path
 import struct TSCUtility.Version
 import TuistConfig
 import TuistCore
@@ -70,14 +69,7 @@ public struct GraphLinter: GraphLinting {
 
     private func lintSchemesUnknownTargets(graphTraverser: GraphTraversing) -> [LintingIssue] {
         let targets = graphTraverser.targets()
-        let localPackagePaths = Set(
-            graphTraverser.projects.values
-                .flatMap(\.packages)
-                .compactMap { package -> AbsolutePath? in
-                    guard case let .local(path) = package else { return nil }
-                    return path
-                }
-        )
+        let localPackageProducts = graphTraverser.consumedLocalPackageProducts()
         return graphTraverser.schemes().compactMap { scheme in
             let nonCodeCoverageDependencies = Set(scheme.nonCodeCoverageTargetDependencies())
             let unknownTargets = scheme
@@ -89,9 +81,9 @@ public struct GraphLinter: GraphLinting {
                         return false
                     }
                     // References used exclusively as code coverage targets can point to
-                    // targets of local Swift packages, which are not part of the graph
+                    // products of local Swift packages, which are not part of the graph
                     // but are resolvable by Xcode.
-                    if localPackagePaths.contains(targetReference.projectPath),
+                    if localPackageProducts[targetReference.projectPath]?.contains(targetReference.name) == true,
                        !nonCodeCoverageDependencies.contains(targetReference)
                     {
                         return false

--- a/cli/Sources/TuistGenerator/Linter/SchemeLinter.swift
+++ b/cli/Sources/TuistGenerator/Linter/SchemeLinter.swift
@@ -166,7 +166,7 @@ struct SchemeLinter: SchemeLinting {
     private func projectSchemeCantReferenceRemoteTargets(scheme: Scheme, project: Project) -> [LintingIssue] {
         var issues: [LintingIssue] = []
 
-        for targetDependency in nonCodeCoverageTargetDependencies(scheme: scheme)
+        for targetDependency in scheme.nonCodeCoverageTargetDependencies()
             where targetDependency.projectPath != project.path
         {
             issues.append(.init(
@@ -176,23 +176,5 @@ struct SchemeLinter: SchemeLinting {
         }
 
         return issues
-    }
-
-    private func nonCodeCoverageTargetDependencies(scheme: Scheme) -> [TargetReference] {
-        let targetSources: [[TargetReference]?] = [
-            scheme.buildAction?.targets,
-            scheme.buildAction?.preActions.compactMap(\.target),
-            scheme.buildAction?.postActions.compactMap(\.target),
-            scheme.testAction?.targets.map(\.target),
-            scheme.testAction?.preActions.compactMap(\.target),
-            scheme.testAction?.postActions.compactMap(\.target),
-            scheme.runAction?.executable.map { [$0] },
-            scheme.archiveAction?.preActions.compactMap(\.target),
-            scheme.archiveAction?.postActions.compactMap(\.target),
-            scheme.profileAction?.executable.map { [$0] },
-        ]
-
-        let targets = targetSources.compactMap { $0 }.flatMap { $0 }.uniqued()
-        return targets.sorted { $0.name < $1.name }
     }
 }

--- a/cli/Sources/TuistGenerator/Utils/GraphTraversing+LocalPackageProducts.swift
+++ b/cli/Sources/TuistGenerator/Utils/GraphTraversing+LocalPackageProducts.swift
@@ -1,0 +1,31 @@
+import Path
+import TuistCore
+import XcodeGraph
+
+extension GraphTraversing {
+    /// Returns, for every local Swift package declared by a graph project, the names of the
+    /// package products consumed by that project's targets. These are the buildables Xcode
+    /// can gather code coverage for, so scheme code coverage references pointing at a local
+    /// package are validated against them.
+    func consumedLocalPackageProducts() -> [AbsolutePath: Set<String>] {
+        var result: [AbsolutePath: Set<String>] = [:]
+        for project in projects.values {
+            let localPackagePaths = project.packages.compactMap { package -> AbsolutePath? in
+                guard case let .local(path) = package else { return nil }
+                return path
+            }
+            guard !localPackagePaths.isEmpty else { continue }
+
+            let products = project.targets.values
+                .flatMap(\.dependencies)
+                .compactMap { dependency -> String? in
+                    guard case let .package(product, _, _) = dependency else { return nil }
+                    return product
+                }
+            for path in localPackagePaths {
+                result[path, default: []].formUnion(products)
+            }
+        }
+        return result
+    }
+}

--- a/cli/Sources/TuistKit/Utils/LocalPackageCoverageTargetsValidator.swift
+++ b/cli/Sources/TuistKit/Utils/LocalPackageCoverageTargetsValidator.swift
@@ -1,0 +1,91 @@
+import Mockable
+import Path
+import TuistCore
+import TuistLoader
+import XcodeGraph
+
+@Mockable
+protocol LocalPackageCoverageTargetsValidating {
+    /// Validates the scheme code coverage references that point at local Swift packages,
+    /// checking the referenced name against the products of the referenced package.
+    /// Invalid references are removed from the returned graph, with a warning for each,
+    /// so that coverage falls back to all targets instead of producing an empty report.
+    /// - Parameters:
+    ///   - graph: The graph whose schemes should be validated.
+    ///   - disableSandbox: Whether the sandbox should be disabled when dumping the package.
+    func validate(graph: Graph, disableSandbox: Bool) async throws -> (Graph, [LintingIssue])
+}
+
+struct LocalPackageCoverageTargetsValidator: LocalPackageCoverageTargetsValidating {
+    private let packageInfoLoader: PackageInfoLoading
+
+    init(packageInfoLoader: PackageInfoLoading = PackageInfoLoader()) {
+        self.packageInfoLoader = packageInfoLoader
+    }
+
+    func validate(graph: Graph, disableSandbox: Bool) async throws -> (Graph, [LintingIssue]) {
+        let localPackagePaths = Set(
+            graph.projects.values
+                .flatMap(\.packages)
+                .compactMap { package -> AbsolutePath? in
+                    guard case let .local(path) = package else { return nil }
+                    return path
+                }
+        )
+        guard !localPackagePaths.isEmpty else { return (graph, []) }
+
+        var graph = graph
+        var issues: [LintingIssue] = []
+        var productsCache: [AbsolutePath: Set<String>] = [:]
+
+        func products(at path: AbsolutePath) async throws -> Set<String> {
+            if let cached = productsCache[path] { return cached }
+            let packageInfo = try await packageInfoLoader.loadPackageInfo(at: path, disableSandbox: disableSandbox)
+            let products = Set(packageInfo.products.map(\.name))
+            productsCache[path] = products
+            return products
+        }
+
+        func validate(scheme: Scheme) async throws -> Scheme {
+            guard let testAction = scheme.testAction, !testAction.codeCoverageTargets.isEmpty else { return scheme }
+            var scheme = scheme
+            var validReferences: [TargetReference] = []
+            for reference in testAction.codeCoverageTargets {
+                if graph.projects[reference.projectPath]?.targets[reference.name] != nil
+                    || !localPackagePaths.contains(reference.projectPath)
+                {
+                    validReferences.append(reference)
+                    continue
+                }
+                if try await products(at: reference.projectPath).contains(reference.name) {
+                    validReferences.append(reference)
+                } else {
+                    issues.append(LintingIssue(
+                        reason: "The target '\(reference.name)' specified in \(scheme.name) code coverage targets list isn't a product of the package at '\(reference.projectPath.relative(to: graph.path).pathString)'. The reference will be ignored.",
+                        severity: .warning
+                    ))
+                }
+            }
+            scheme.testAction?.codeCoverageTargets = validReferences
+            return scheme
+        }
+
+        for (path, project) in graph.projects {
+            var project = project
+            var schemes: [Scheme] = []
+            for scheme in project.schemes {
+                schemes.append(try await validate(scheme: scheme))
+            }
+            project.schemes = schemes
+            graph.projects[path] = project
+        }
+
+        var workspaceSchemes: [Scheme] = []
+        for scheme in graph.workspace.schemes {
+            workspaceSchemes.append(try await validate(scheme: scheme))
+        }
+        graph.workspace.schemes = workspaceSchemes
+
+        return (graph, issues)
+    }
+}

--- a/cli/Sources/TuistKit/Utils/ManifestGraphLoader.swift
+++ b/cli/Sources/TuistKit/Utils/ManifestGraphLoader.swift
@@ -46,6 +46,7 @@ public struct ManifestGraphLoader: ManifestGraphLoading {
     private let graphMapper: GraphMapping
     private let packageSettingsLoader: PackageSettingsLoading
     private let manifestFilesLocator: ManifestFilesLocating
+    private let localPackageCoverageTargetsValidator: LocalPackageCoverageTargetsValidating
 
     public init(
         manifestLoader: ManifestLoading,
@@ -84,7 +85,8 @@ public struct ManifestGraphLoader: ManifestGraphLoading {
         workspaceMapper: WorkspaceMapping,
         graphMapper: GraphMapping,
         packageSettingsLoader: PackageSettingsLoading,
-        manifestFilesLocator: ManifestFilesLocating
+        manifestFilesLocator: ManifestFilesLocating,
+        localPackageCoverageTargetsValidator: LocalPackageCoverageTargetsValidating = LocalPackageCoverageTargetsValidator()
     ) {
         self.configLoader = configLoader
         self.manifestLoader = manifestLoader
@@ -99,6 +101,7 @@ public struct ManifestGraphLoader: ManifestGraphLoading {
         self.graphMapper = graphMapper
         self.packageSettingsLoader = packageSettingsLoader
         self.manifestFilesLocator = manifestFilesLocator
+        self.localPackageCoverageTargetsValidator = localPackageCoverageTargetsValidator
     }
 
     public func load(
@@ -224,11 +227,17 @@ public struct ManifestGraphLoader: ManifestGraphLoading {
             environment: MapperEnvironment()
         )
 
+        // Validate scheme code coverage references pointing at local Swift packages
+        let (validatedGraph, coverageLintingIssues) = try await localPackageCoverageTargetsValidator.validate(
+            graph: mappedGraph,
+            disableSandbox: disableSandbox
+        )
+
         return (
-            mappedGraph,
+            validatedGraph,
             modelMapperSideEffects + graphMapperSideEffects,
             environment,
-            lintingIssues
+            lintingIssues + coverageLintingIssues
         )
     }
 

--- a/cli/Tests/TuistGeneratorAcceptanceTests/GenerateAcceptanceTests.swift
+++ b/cli/Tests/TuistGeneratorAcceptanceTests/GenerateAcceptanceTests.swift
@@ -538,7 +538,8 @@ struct GenerateAcceptanceTestiOSAppWithLocalSwiftPackage {
         let coverageBuildables = try #require(scheme.testAction?.codeCoverageTargets)
 
         // The product name is a valid coverage buildable and is kept. The name of the
-        // package target backing it is not, so it is dropped.
+        // package target backing it and a product of another package referenced through
+        // this package's path are not, so they are dropped.
         #expect(coverageBuildables.count == 1)
         let reference = try #require(coverageBuildables.first)
         #expect(reference.blueprintName == "LibraryC")

--- a/cli/Tests/TuistGeneratorAcceptanceTests/GenerateAcceptanceTests.swift
+++ b/cli/Tests/TuistGeneratorAcceptanceTests/GenerateAcceptanceTests.swift
@@ -519,6 +519,33 @@ struct GenerateAcceptanceTestiOSAppWithLocalSwiftPackage {
         try await run(GenerateCommand.self)
         try await run(BuildCommand.self)
     }
+
+    @Test(.withFixture("generated_ios_app_with_local_swift_package"), .inTemporaryDirectory)
+    func ios_app_with_local_swift_package_product_code_coverage() async throws {
+        // Given
+        let fixtureDirectory = try #require(TuistTest.fixtureDirectory)
+        let xcodeprojPath = fixtureDirectory.appending(component: "App.xcodeproj")
+
+        // When
+        try await run(GenerateCommand.self)
+
+        // Then
+        let xcodeproj = try XcodeProj(pathString: xcodeprojPath.pathString)
+        let scheme = try #require(
+            xcodeproj.sharedData?.schemes.first { $0.name == "AppWithPackageCoverage" }
+        )
+        #expect(scheme.testAction?.onlyGenerateCoverageForSpecifiedTargets == true)
+        let coverageBuildables = try #require(scheme.testAction?.codeCoverageTargets)
+
+        // The product name is a valid coverage buildable and is kept. The name of the
+        // package target backing it is not, so it is dropped.
+        #expect(coverageBuildables.count == 1)
+        let reference = try #require(coverageBuildables.first)
+        #expect(reference.blueprintName == "LibraryC")
+        #expect(reference.buildableName == "LibraryC")
+        #expect(reference.blueprintIdentifier == "LibraryC")
+        #expect(reference.referencedContainer == "container:Packages/PackageA")
+    }
 }
 
 struct GenerateAcceptanceTestiOSAppWithObjCStaticFrameworkPackage {

--- a/cli/Tests/TuistGeneratorTests/Generator/SchemeDescriptorsGeneratorTests.swift
+++ b/cli/Tests/TuistGeneratorTests/Generator/SchemeDescriptorsGeneratorTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Path
+import Testing
 import TuistCore
 import TuistSupport
 import XcodeGraph
@@ -876,95 +877,6 @@ final class SchemeDescriptorsGeneratorTests: XCTestCase {
         XCTAssertEqual(result.onlyGenerateCoverageForSpecifiedTargets, true)
         XCTAssertEqual(codeCoverageTargetsBuildableReference.count, 1)
         XCTAssertEqual(codeCoverageTargetsBuildableReference.first?.buildableName, "App.app")
-    }
-
-    func test_schemeTestAction_with_codeCoverageTargets_fromLocalPackage() throws {
-        // Given
-        let projectPath = try AbsolutePath(validating: "/somepath/Project")
-        let packagePath = try AbsolutePath(validating: "/somepath/Package")
-
-        let target = Target.test(name: "App", product: .app)
-        let testTarget = Target.test(name: "AppTests", product: .unitTests)
-
-        let testAction = TestAction.test(
-            targets: [TestableTarget(target: TargetReference(projectPath: projectPath, name: "AppTests"))],
-            coverage: true,
-            codeCoverageTargets: [TargetReference(projectPath: packagePath, name: "PackageTarget")]
-        )
-        let buildAction = BuildAction.test(targets: [TargetReference(projectPath: projectPath, name: "App")])
-
-        let scheme = Scheme.test(name: "AppTests", shared: true, buildAction: buildAction, testAction: testAction)
-
-        let project = Project.test(
-            path: projectPath,
-            targets: [target, testTarget],
-            packages: [.local(path: packagePath)]
-        )
-        let graph = Graph.test(
-            projects: [project.path: project]
-        )
-        let graphTraverser = GraphTraverser(graph: graph)
-
-        // When
-        let got = try subject.schemeTestAction(
-            scheme: scheme,
-            graphTraverser: graphTraverser,
-            rootPath: try AbsolutePath(validating: "/somepath/Workspace"),
-            generatedProjects: createGeneratedProjects(projects: [project])
-        )
-
-        // Then
-        let result = try XCTUnwrap(got)
-        XCTAssertEqual(result.onlyGenerateCoverageForSpecifiedTargets, true)
-        let references = try XCTUnwrap(result.codeCoverageTargets)
-        XCTAssertEqual(references.count, 1)
-        let reference = try XCTUnwrap(references.first)
-        XCTAssertEqual(reference.referencedContainer, "container:../Package")
-        XCTAssertEqual(reference.blueprintIdentifier, "PackageTarget")
-        XCTAssertEqual(reference.buildableName, "PackageTarget")
-        XCTAssertEqual(reference.blueprintName, "PackageTarget")
-        XCTAssertEqual(reference.buildableIdentifier, "primary")
-    }
-
-    func test_schemeTestAction_with_codeCoverageTargets_notInGraphNorPackages() throws {
-        // Given
-        let projectPath = try AbsolutePath(validating: "/somepath/Project")
-
-        let target = Target.test(name: "App", product: .app)
-        let testTarget = Target.test(name: "AppTests", product: .unitTests)
-
-        let testAction = TestAction.test(
-            targets: [TestableTarget(target: TargetReference(projectPath: projectPath, name: "AppTests"))],
-            coverage: true,
-            codeCoverageTargets: [
-                TargetReference(
-                    projectPath: try AbsolutePath(validating: "/somepath/Unknown"),
-                    name: "UnknownTarget"
-                ),
-            ]
-        )
-        let buildAction = BuildAction.test(targets: [TargetReference(projectPath: projectPath, name: "App")])
-
-        let scheme = Scheme.test(name: "AppTests", shared: true, buildAction: buildAction, testAction: testAction)
-
-        let project = Project.test(path: projectPath, targets: [target, testTarget])
-        let graph = Graph.test(
-            projects: [project.path: project]
-        )
-        let graphTraverser = GraphTraverser(graph: graph)
-
-        // When
-        let got = try subject.schemeTestAction(
-            scheme: scheme,
-            graphTraverser: graphTraverser,
-            rootPath: try AbsolutePath(validating: "/somepath/Workspace"),
-            generatedProjects: createGeneratedProjects(projects: [project])
-        )
-
-        // Then
-        let result = try XCTUnwrap(got)
-        let references = try XCTUnwrap(result.codeCoverageTargets)
-        XCTAssertEqual(references.count, 0)
     }
 
     func test_schemeTestAction_when_notTestsTarget() throws {
@@ -2667,5 +2579,116 @@ final class SchemeDescriptorsGeneratorTests: XCTestCase {
             runAction: runAction,
             profileAction: profileAction
         )
+    }
+}
+
+struct SchemeDescriptorsGeneratorCodeCoverageTests {
+    private let subject = SchemeDescriptorsGenerator()
+
+    @Test func schemeTestAction_with_codeCoverageTargets_fromLocalPackage() throws {
+        // Given
+        let projectPath = try AbsolutePath(validating: "/somepath/Project")
+        let packagePath = try AbsolutePath(validating: "/somepath/Package")
+
+        let target = Target.test(name: "App", product: .app)
+        let testTarget = Target.test(name: "AppTests", product: .unitTests)
+
+        let testAction = TestAction.test(
+            targets: [TestableTarget(target: TargetReference(projectPath: projectPath, name: "AppTests"))],
+            coverage: true,
+            codeCoverageTargets: [TargetReference(projectPath: packagePath, name: "PackageTarget")]
+        )
+        let buildAction = BuildAction.test(targets: [TargetReference(projectPath: projectPath, name: "App")])
+
+        let scheme = Scheme.test(name: "AppTests", shared: true, buildAction: buildAction, testAction: testAction)
+
+        let project = Project.test(
+            path: projectPath,
+            targets: [target, testTarget],
+            packages: [.local(path: packagePath)]
+        )
+        let graph = Graph.test(
+            projects: [project.path: project]
+        )
+        let graphTraverser = GraphTraverser(graph: graph)
+
+        // When
+        let got = try subject.schemeTestAction(
+            scheme: scheme,
+            graphTraverser: graphTraverser,
+            rootPath: try AbsolutePath(validating: "/somepath/Workspace"),
+            generatedProjects: createGeneratedProjects(projects: [project])
+        )
+
+        // Then
+        let result = try #require(got)
+        #expect(result.onlyGenerateCoverageForSpecifiedTargets == true)
+        let references = try #require(result.codeCoverageTargets)
+        let reference = try #require(references.first)
+        #expect(references.count == 1)
+        #expect(reference.referencedContainer == "container:../Package")
+        #expect(reference.blueprintIdentifier == "PackageTarget")
+        #expect(reference.buildableName == "PackageTarget")
+        #expect(reference.blueprintName == "PackageTarget")
+        #expect(reference.buildableIdentifier == "primary")
+    }
+
+    @Test func schemeTestAction_with_codeCoverageTargets_notInGraphNorPackages() throws {
+        // Given
+        let projectPath = try AbsolutePath(validating: "/somepath/Project")
+
+        let target = Target.test(name: "App", product: .app)
+        let testTarget = Target.test(name: "AppTests", product: .unitTests)
+
+        let testAction = TestAction.test(
+            targets: [TestableTarget(target: TargetReference(projectPath: projectPath, name: "AppTests"))],
+            coverage: true,
+            codeCoverageTargets: [
+                TargetReference(
+                    projectPath: try AbsolutePath(validating: "/somepath/Unknown"),
+                    name: "UnknownTarget"
+                ),
+            ]
+        )
+        let buildAction = BuildAction.test(targets: [TargetReference(projectPath: projectPath, name: "App")])
+
+        let scheme = Scheme.test(name: "AppTests", shared: true, buildAction: buildAction, testAction: testAction)
+
+        let project = Project.test(path: projectPath, targets: [target, testTarget])
+        let graph = Graph.test(
+            projects: [project.path: project]
+        )
+        let graphTraverser = GraphTraverser(graph: graph)
+
+        // When
+        let got = try subject.schemeTestAction(
+            scheme: scheme,
+            graphTraverser: graphTraverser,
+            rootPath: try AbsolutePath(validating: "/somepath/Workspace"),
+            generatedProjects: createGeneratedProjects(projects: [project])
+        )
+
+        // Then
+        let result = try #require(got)
+        let references = try #require(result.codeCoverageTargets)
+        #expect(references.isEmpty)
+    }
+
+    private func createGeneratedProjects(projects: [Project]) -> [AbsolutePath: GeneratedProject] {
+        Dictionary(uniqueKeysWithValues: projects.map { project in
+            var pbxTargets: [String: PBXTarget] = [:]
+            for target in project.targets.values {
+                pbxTargets[target.name] = PBXNativeTarget(name: target.name)
+            }
+            return (
+                project.xcodeProjPath,
+                GeneratedProject(
+                    pbxproj: .init(),
+                    path: project.xcodeProjPath,
+                    targets: pbxTargets,
+                    name: project.xcodeProjPath.basename
+                )
+            )
+        })
     }
 }

--- a/cli/Tests/TuistGeneratorTests/Generator/SchemeDescriptorsGeneratorTests.swift
+++ b/cli/Tests/TuistGeneratorTests/Generator/SchemeDescriptorsGeneratorTests.swift
@@ -2590,13 +2590,17 @@ struct SchemeDescriptorsGeneratorCodeCoverageTests {
         let projectPath = try AbsolutePath(validating: "/somepath/Project")
         let packagePath = try AbsolutePath(validating: "/somepath/Package")
 
-        let target = Target.test(name: "App", product: .app)
+        let target = Target.test(
+            name: "App",
+            product: .app,
+            dependencies: [.package(product: "PackageProduct", type: .runtime)]
+        )
         let testTarget = Target.test(name: "AppTests", product: .unitTests)
 
         let testAction = TestAction.test(
             targets: [TestableTarget(target: TargetReference(projectPath: projectPath, name: "AppTests"))],
             coverage: true,
-            codeCoverageTargets: [TargetReference(projectPath: packagePath, name: "PackageTarget")]
+            codeCoverageTargets: [TargetReference(projectPath: packagePath, name: "PackageProduct")]
         )
         let buildAction = BuildAction.test(targets: [TargetReference(projectPath: projectPath, name: "App")])
 
@@ -2627,10 +2631,57 @@ struct SchemeDescriptorsGeneratorCodeCoverageTests {
         let reference = try #require(references.first)
         #expect(references.count == 1)
         #expect(reference.referencedContainer == "container:../Package")
-        #expect(reference.blueprintIdentifier == "PackageTarget")
-        #expect(reference.buildableName == "PackageTarget")
-        #expect(reference.blueprintName == "PackageTarget")
+        #expect(reference.blueprintIdentifier == "PackageProduct")
+        #expect(reference.buildableName == "PackageProduct")
+        #expect(reference.blueprintName == "PackageProduct")
         #expect(reference.buildableIdentifier == "primary")
+    }
+
+    @Test func schemeTestAction_with_codeCoverageTargets_notMatchingALocalPackageProduct() throws {
+        // Given
+        let projectPath = try AbsolutePath(validating: "/somepath/Project")
+        let packagePath = try AbsolutePath(validating: "/somepath/Package")
+
+        let target = Target.test(
+            name: "App",
+            product: .app,
+            dependencies: [.package(product: "PackageProduct", type: .runtime)]
+        )
+        let testTarget = Target.test(name: "AppTests", product: .unitTests)
+
+        let testAction = TestAction.test(
+            targets: [TestableTarget(target: TargetReference(projectPath: projectPath, name: "AppTests"))],
+            coverage: true,
+            // The name of the package target backing the product, not the product itself.
+            codeCoverageTargets: [TargetReference(projectPath: packagePath, name: "PackageProductCore")]
+        )
+        let buildAction = BuildAction.test(targets: [TargetReference(projectPath: projectPath, name: "App")])
+
+        let scheme = Scheme.test(name: "AppTests", shared: true, buildAction: buildAction, testAction: testAction)
+
+        let project = Project.test(
+            path: projectPath,
+            targets: [target, testTarget],
+            packages: [.local(path: packagePath)]
+        )
+        let graph = Graph.test(
+            projects: [project.path: project]
+        )
+        let graphTraverser = GraphTraverser(graph: graph)
+
+        // When
+        let got = try subject.schemeTestAction(
+            scheme: scheme,
+            graphTraverser: graphTraverser,
+            rootPath: try AbsolutePath(validating: "/somepath/Workspace"),
+            generatedProjects: createGeneratedProjects(projects: [project])
+        )
+
+        // Then
+        let result = try #require(got)
+        let references = try #require(result.codeCoverageTargets)
+        #expect(references.isEmpty)
+        #expect(result.onlyGenerateCoverageForSpecifiedTargets == nil)
     }
 
     @Test func schemeTestAction_with_codeCoverageTargets_notInGraphNorPackages() throws {

--- a/cli/Tests/TuistGeneratorTests/Generator/SchemeDescriptorsGeneratorTests.swift
+++ b/cli/Tests/TuistGeneratorTests/Generator/SchemeDescriptorsGeneratorTests.swift
@@ -878,6 +878,95 @@ final class SchemeDescriptorsGeneratorTests: XCTestCase {
         XCTAssertEqual(codeCoverageTargetsBuildableReference.first?.buildableName, "App.app")
     }
 
+    func test_schemeTestAction_with_codeCoverageTargets_fromLocalPackage() throws {
+        // Given
+        let projectPath = try AbsolutePath(validating: "/somepath/Project")
+        let packagePath = try AbsolutePath(validating: "/somepath/Package")
+
+        let target = Target.test(name: "App", product: .app)
+        let testTarget = Target.test(name: "AppTests", product: .unitTests)
+
+        let testAction = TestAction.test(
+            targets: [TestableTarget(target: TargetReference(projectPath: projectPath, name: "AppTests"))],
+            coverage: true,
+            codeCoverageTargets: [TargetReference(projectPath: packagePath, name: "PackageTarget")]
+        )
+        let buildAction = BuildAction.test(targets: [TargetReference(projectPath: projectPath, name: "App")])
+
+        let scheme = Scheme.test(name: "AppTests", shared: true, buildAction: buildAction, testAction: testAction)
+
+        let project = Project.test(
+            path: projectPath,
+            targets: [target, testTarget],
+            packages: [.local(path: packagePath)]
+        )
+        let graph = Graph.test(
+            projects: [project.path: project]
+        )
+        let graphTraverser = GraphTraverser(graph: graph)
+
+        // When
+        let got = try subject.schemeTestAction(
+            scheme: scheme,
+            graphTraverser: graphTraverser,
+            rootPath: try AbsolutePath(validating: "/somepath/Workspace"),
+            generatedProjects: createGeneratedProjects(projects: [project])
+        )
+
+        // Then
+        let result = try XCTUnwrap(got)
+        XCTAssertEqual(result.onlyGenerateCoverageForSpecifiedTargets, true)
+        let references = try XCTUnwrap(result.codeCoverageTargets)
+        XCTAssertEqual(references.count, 1)
+        let reference = try XCTUnwrap(references.first)
+        XCTAssertEqual(reference.referencedContainer, "container:../Package")
+        XCTAssertEqual(reference.blueprintIdentifier, "PackageTarget")
+        XCTAssertEqual(reference.buildableName, "PackageTarget")
+        XCTAssertEqual(reference.blueprintName, "PackageTarget")
+        XCTAssertEqual(reference.buildableIdentifier, "primary")
+    }
+
+    func test_schemeTestAction_with_codeCoverageTargets_notInGraphNorPackages() throws {
+        // Given
+        let projectPath = try AbsolutePath(validating: "/somepath/Project")
+
+        let target = Target.test(name: "App", product: .app)
+        let testTarget = Target.test(name: "AppTests", product: .unitTests)
+
+        let testAction = TestAction.test(
+            targets: [TestableTarget(target: TargetReference(projectPath: projectPath, name: "AppTests"))],
+            coverage: true,
+            codeCoverageTargets: [
+                TargetReference(
+                    projectPath: try AbsolutePath(validating: "/somepath/Unknown"),
+                    name: "UnknownTarget"
+                ),
+            ]
+        )
+        let buildAction = BuildAction.test(targets: [TargetReference(projectPath: projectPath, name: "App")])
+
+        let scheme = Scheme.test(name: "AppTests", shared: true, buildAction: buildAction, testAction: testAction)
+
+        let project = Project.test(path: projectPath, targets: [target, testTarget])
+        let graph = Graph.test(
+            projects: [project.path: project]
+        )
+        let graphTraverser = GraphTraverser(graph: graph)
+
+        // When
+        let got = try subject.schemeTestAction(
+            scheme: scheme,
+            graphTraverser: graphTraverser,
+            rootPath: try AbsolutePath(validating: "/somepath/Workspace"),
+            generatedProjects: createGeneratedProjects(projects: [project])
+        )
+
+        // Then
+        let result = try XCTUnwrap(got)
+        let references = try XCTUnwrap(result.codeCoverageTargets)
+        XCTAssertEqual(references.count, 0)
+    }
+
     func test_schemeTestAction_when_notTestsTarget() throws {
         // Given
         let scheme = Scheme.test()

--- a/cli/Tests/TuistGeneratorTests/Linter/GraphLinterTests.swift
+++ b/cli/Tests/TuistGeneratorTests/Linter/GraphLinterTests.swift
@@ -190,6 +190,120 @@ struct GraphLinterTests {
         )
     }
 
+    @Test(
+        .inTemporaryDirectory,
+        .withMockedXcodeController
+    ) func lint_when_scheme_codeCoverageTarget_references_localPackage() async throws {
+        // Given
+        let path: AbsolutePath = "/project"
+        let packagePath: AbsolutePath = "/package"
+
+        let scheme = Scheme.test(
+            name: "SomeScheme",
+            buildAction: .init(targets: [TargetReference(projectPath: path, name: "App")]),
+            testAction: .test(
+                targets: [TestableTarget(target: TargetReference(projectPath: path, name: "AppTests"))],
+                coverage: true,
+                codeCoverageTargets: [TargetReference(projectPath: packagePath, name: "PackageTarget")]
+            ),
+            runAction: nil,
+            archiveAction: nil,
+            profileAction: nil,
+            analyzeAction: nil
+        )
+        let project = Project.test(
+            path: path,
+            name: "TuistProject",
+            targets: [
+                Target.test(name: "App"),
+                Target.test(name: "AppTests"),
+            ],
+            packages: [.local(path: packagePath)]
+        )
+
+        let workspace = Workspace.test(
+            path: path,
+            name: "TuistWorkspace",
+            projects: [path],
+            schemes: [scheme]
+        )
+
+        let graph = Graph.test(
+            path: path,
+            workspace: workspace,
+            projects: [path: project]
+        )
+
+        let graphTraverser = GraphTraverser(graph: graph)
+
+        // When
+        let result = try await subject.lint(graphTraverser: graphTraverser, configGeneratedProjectOptions: .test())
+
+        // Then
+        #expect(
+            result ==
+                []
+        )
+    }
+
+    @Test(
+        .inTemporaryDirectory,
+        .withMockedXcodeController
+    ) func lint_when_scheme_codeCoverageTarget_references_unknown_target() async throws {
+        // Given
+        let path: AbsolutePath = "/project"
+
+        let scheme = Scheme.test(
+            name: "SomeScheme",
+            buildAction: .init(targets: [TargetReference(projectPath: path, name: "App")]),
+            testAction: .test(
+                targets: [TestableTarget(target: TargetReference(projectPath: path, name: "AppTests"))],
+                coverage: true,
+                codeCoverageTargets: [TargetReference(projectPath: path, name: "UnknownTarget")]
+            ),
+            runAction: nil,
+            archiveAction: nil,
+            profileAction: nil,
+            analyzeAction: nil
+        )
+        let project = Project.test(
+            path: path,
+            name: "TuistProject",
+            targets: [
+                Target.test(name: "App"),
+                Target.test(name: "AppTests"),
+            ]
+        )
+
+        let workspace = Workspace.test(
+            path: path,
+            name: "TuistWorkspace",
+            projects: [path],
+            schemes: [scheme]
+        )
+
+        let graph = Graph.test(
+            path: path,
+            workspace: workspace,
+            projects: [path: project]
+        )
+
+        let graphTraverser = GraphTraverser(graph: graph)
+
+        // When
+        let result = try await subject.lint(graphTraverser: graphTraverser, configGeneratedProjectOptions: .test())
+
+        // Then
+        #expect(
+            result ==
+                [LintingIssue(
+                    reason: "Cannot find targets UnknownTarget (.)  defined in SomeScheme",
+                    severity: .warning,
+                    category: .schemeTargetNotFound
+                )]
+        )
+    }
+
     @Test(.inTemporaryDirectory, .withMockedXcodeController) func lint_when_no_version_available() async throws {
         // Given
         let path: AbsolutePath = "/project"

--- a/cli/Tests/TuistGeneratorTests/Linter/GraphLinterTests.swift
+++ b/cli/Tests/TuistGeneratorTests/Linter/GraphLinterTests.swift
@@ -249,6 +249,70 @@ struct GraphLinterTests {
     @Test(
         .inTemporaryDirectory,
         .withMockedXcodeController
+    ) func lint_when_localPackage_reference_is_not_exclusive_to_codeCoverage() async throws {
+        // Given
+        let path: AbsolutePath = "/project"
+        let packagePath: AbsolutePath = "/package"
+        let packageTargetReference = TargetReference(projectPath: packagePath, name: "PackageTarget")
+
+        let scheme = Scheme.test(
+            name: "SomeScheme",
+            buildAction: .init(targets: [
+                TargetReference(projectPath: path, name: "App"),
+                packageTargetReference,
+            ]),
+            testAction: .test(
+                targets: [TestableTarget(target: TargetReference(projectPath: path, name: "AppTests"))],
+                coverage: true,
+                codeCoverageTargets: [packageTargetReference]
+            ),
+            runAction: nil,
+            archiveAction: nil,
+            profileAction: nil,
+            analyzeAction: nil
+        )
+        let project = Project.test(
+            path: path,
+            name: "TuistProject",
+            targets: [
+                Target.test(name: "App"),
+                Target.test(name: "AppTests"),
+            ],
+            packages: [.local(path: packagePath)]
+        )
+
+        let workspace = Workspace.test(
+            path: path,
+            name: "TuistWorkspace",
+            projects: [path],
+            schemes: [scheme]
+        )
+
+        let graph = Graph.test(
+            path: path,
+            workspace: workspace,
+            projects: [path: project]
+        )
+
+        let graphTraverser = GraphTraverser(graph: graph)
+
+        // When
+        let result = try await subject.lint(graphTraverser: graphTraverser, configGeneratedProjectOptions: .test())
+
+        // Then
+        #expect(
+            result ==
+                [LintingIssue(
+                    reason: "Cannot find targets PackageTarget (../package)  defined in SomeScheme",
+                    severity: .warning,
+                    category: .schemeTargetNotFound
+                )]
+        )
+    }
+
+    @Test(
+        .inTemporaryDirectory,
+        .withMockedXcodeController
     ) func lint_when_scheme_codeCoverageTarget_references_unknown_target() async throws {
         // Given
         let path: AbsolutePath = "/project"

--- a/cli/Tests/TuistGeneratorTests/Linter/GraphLinterTests.swift
+++ b/cli/Tests/TuistGeneratorTests/Linter/GraphLinterTests.swift
@@ -215,7 +215,7 @@ struct GraphLinterTests {
             path: path,
             name: "TuistProject",
             targets: [
-                Target.test(name: "App"),
+                Target.test(name: "App", dependencies: [.package(product: "PackageTarget", type: .runtime)]),
                 Target.test(name: "AppTests"),
             ],
             packages: [.local(path: packagePath)]
@@ -249,6 +249,67 @@ struct GraphLinterTests {
     @Test(
         .inTemporaryDirectory,
         .withMockedXcodeController
+    ) func lint_when_scheme_codeCoverageTarget_is_not_a_consumed_localPackage_product() async throws {
+        // Given
+        let path: AbsolutePath = "/project"
+        let packagePath: AbsolutePath = "/package"
+
+        let scheme = Scheme.test(
+            name: "SomeScheme",
+            buildAction: .init(targets: [TargetReference(projectPath: path, name: "App")]),
+            testAction: .test(
+                targets: [TestableTarget(target: TargetReference(projectPath: path, name: "AppTests"))],
+                coverage: true,
+                // The name of the package target backing the product, not the product itself.
+                codeCoverageTargets: [TargetReference(projectPath: packagePath, name: "PackageTargetCore")]
+            ),
+            runAction: nil,
+            archiveAction: nil,
+            profileAction: nil,
+            analyzeAction: nil
+        )
+        let project = Project.test(
+            path: path,
+            name: "TuistProject",
+            targets: [
+                Target.test(name: "App", dependencies: [.package(product: "PackageTarget", type: .runtime)]),
+                Target.test(name: "AppTests"),
+            ],
+            packages: [.local(path: packagePath)]
+        )
+
+        let workspace = Workspace.test(
+            path: path,
+            name: "TuistWorkspace",
+            projects: [path],
+            schemes: [scheme]
+        )
+
+        let graph = Graph.test(
+            path: path,
+            workspace: workspace,
+            projects: [path: project]
+        )
+
+        let graphTraverser = GraphTraverser(graph: graph)
+
+        // When
+        let result = try await subject.lint(graphTraverser: graphTraverser, configGeneratedProjectOptions: .test())
+
+        // Then
+        #expect(
+            result ==
+                [LintingIssue(
+                    reason: "Cannot find targets PackageTargetCore (../package)  defined in SomeScheme",
+                    severity: .warning,
+                    category: .schemeTargetNotFound
+                )]
+        )
+    }
+
+    @Test(
+        .inTemporaryDirectory,
+        .withMockedXcodeController
     ) func lint_when_localPackage_reference_is_not_exclusive_to_codeCoverage() async throws {
         // Given
         let path: AbsolutePath = "/project"
@@ -275,7 +336,7 @@ struct GraphLinterTests {
             path: path,
             name: "TuistProject",
             targets: [
-                Target.test(name: "App"),
+                Target.test(name: "App", dependencies: [.package(product: "PackageTarget", type: .runtime)]),
                 Target.test(name: "AppTests"),
             ],
             packages: [.local(path: packagePath)]

--- a/cli/Tests/TuistKitTests/Utils/LocalPackageCoverageTargetsValidatorTests.swift
+++ b/cli/Tests/TuistKitTests/Utils/LocalPackageCoverageTargetsValidatorTests.swift
@@ -1,0 +1,210 @@
+import Mockable
+import Path
+import Testing
+import TuistCore
+import TuistLoader
+import XcodeGraph
+
+@testable import TuistKit
+
+struct LocalPackageCoverageTargetsValidatorTests {
+    private let packageInfoLoader = MockPackageInfoLoading()
+    private let subject: LocalPackageCoverageTargetsValidator
+
+    init() {
+        subject = LocalPackageCoverageTargetsValidator(packageInfoLoader: packageInfoLoader)
+    }
+
+    @Test func validate_keeps_references_to_graph_targets_without_loading_packages() async throws {
+        // Given
+        let path: AbsolutePath = "/project"
+        let graph = graph(
+            projectPath: path,
+            packages: [.local(path: "/packageA")],
+            codeCoverageTargets: [TargetReference(projectPath: path, name: "App")]
+        )
+
+        // When
+        let (got, issues) = try await subject.validate(graph: graph, disableSandbox: false)
+
+        // Then
+        #expect(issues.isEmpty)
+        #expect(
+            got.projects[path]?.schemes.first?.testAction?.codeCoverageTargets ==
+                [TargetReference(projectPath: path, name: "App")]
+        )
+        verify(packageInfoLoader)
+            .loadPackageInfo(at: .any, disableSandbox: .any)
+            .called(0)
+    }
+
+    @Test func validate_keeps_references_matching_a_package_product() async throws {
+        // Given
+        let path: AbsolutePath = "/project"
+        let packagePath: AbsolutePath = "/packageA"
+        let reference = TargetReference(projectPath: packagePath, name: "LibraryA")
+        let graph = graph(
+            projectPath: path,
+            packages: [.local(path: packagePath)],
+            codeCoverageTargets: [reference]
+        )
+        given(packageInfoLoader)
+            .loadPackageInfo(at: .value(packagePath), disableSandbox: .any)
+            .willReturn(.test(products: [
+                PackageInfo.Product(name: "LibraryA", type: .library(.automatic), targets: ["LibraryACore"]),
+            ]))
+
+        // When
+        let (got, issues) = try await subject.validate(graph: graph, disableSandbox: false)
+
+        // Then
+        #expect(issues.isEmpty)
+        #expect(got.projects[path]?.schemes.first?.testAction?.codeCoverageTargets == [reference])
+    }
+
+    @Test func validate_drops_references_not_matching_a_package_product() async throws {
+        // Given
+        let path: AbsolutePath = "/project"
+        let packagePath: AbsolutePath = "/packageA"
+        let graph = graph(
+            projectPath: path,
+            packages: [.local(path: packagePath)],
+            // The name of the package target backing the product, not the product itself.
+            codeCoverageTargets: [TargetReference(projectPath: packagePath, name: "LibraryACore")]
+        )
+        given(packageInfoLoader)
+            .loadPackageInfo(at: .value(packagePath), disableSandbox: .any)
+            .willReturn(.test(products: [
+                PackageInfo.Product(name: "LibraryA", type: .library(.automatic), targets: ["LibraryACore"]),
+            ]))
+
+        // When
+        let (got, issues) = try await subject.validate(graph: graph, disableSandbox: false)
+
+        // Then
+        #expect(got.projects[path]?.schemes.first?.testAction?.codeCoverageTargets == [])
+        #expect(
+            issues ==
+                [LintingIssue(
+                    reason: "The target 'LibraryACore' specified in SomeScheme code coverage targets list isn't a product of the package at '../packageA'. The reference will be ignored.",
+                    severity: .warning
+                )]
+        )
+    }
+
+    @Test func validate_drops_references_to_a_product_of_another_package() async throws {
+        // Given
+        let path: AbsolutePath = "/project"
+        let packageAPath: AbsolutePath = "/packageA"
+        let packageBPath: AbsolutePath = "/packageB"
+        let graph = graph(
+            projectPath: path,
+            packages: [.local(path: packageAPath), .local(path: packageBPath)],
+            // A product of package B referenced through package A's path.
+            codeCoverageTargets: [TargetReference(projectPath: packageAPath, name: "LibraryB")]
+        )
+        given(packageInfoLoader)
+            .loadPackageInfo(at: .value(packageAPath), disableSandbox: .any)
+            .willReturn(.test(products: [
+                PackageInfo.Product(name: "LibraryA", type: .library(.automatic), targets: ["LibraryACore"]),
+            ]))
+
+        // When
+        let (got, issues) = try await subject.validate(graph: graph, disableSandbox: false)
+
+        // Then
+        #expect(got.projects[path]?.schemes.first?.testAction?.codeCoverageTargets == [])
+        #expect(
+            issues ==
+                [LintingIssue(
+                    reason: "The target 'LibraryB' specified in SomeScheme code coverage targets list isn't a product of the package at '../packageA'. The reference will be ignored.",
+                    severity: .warning
+                )]
+        )
+    }
+
+    @Test func validate_keeps_references_that_are_not_local_packages() async throws {
+        // Given
+        let path: AbsolutePath = "/project"
+        let unknownReference = TargetReference(projectPath: "/unknown", name: "Unknown")
+        let graph = graph(
+            projectPath: path,
+            packages: [.local(path: "/packageA")],
+            codeCoverageTargets: [unknownReference]
+        )
+
+        // When
+        let (got, issues) = try await subject.validate(graph: graph, disableSandbox: false)
+
+        // Then
+        #expect(issues.isEmpty)
+        #expect(got.projects[path]?.schemes.first?.testAction?.codeCoverageTargets == [unknownReference])
+        verify(packageInfoLoader)
+            .loadPackageInfo(at: .any, disableSandbox: .any)
+            .called(0)
+    }
+
+    @Test func validate_workspace_schemes() async throws {
+        // Given
+        let path: AbsolutePath = "/project"
+        let packagePath: AbsolutePath = "/packageA"
+        var graph = graph(
+            projectPath: path,
+            packages: [.local(path: packagePath)],
+            codeCoverageTargets: []
+        )
+        graph.workspace.schemes = [
+            scheme(
+                projectPath: path,
+                codeCoverageTargets: [TargetReference(projectPath: packagePath, name: "LibraryACore")]
+            ),
+        ]
+        given(packageInfoLoader)
+            .loadPackageInfo(at: .value(packagePath), disableSandbox: .any)
+            .willReturn(.test(products: [
+                PackageInfo.Product(name: "LibraryA", type: .library(.automatic), targets: ["LibraryACore"]),
+            ]))
+
+        // When
+        let (got, issues) = try await subject.validate(graph: graph, disableSandbox: false)
+
+        // Then
+        #expect(got.workspace.schemes.first?.testAction?.codeCoverageTargets == [])
+        #expect(issues.count == 1)
+    }
+
+    private func graph(
+        projectPath: AbsolutePath,
+        packages: [Package],
+        codeCoverageTargets: [TargetReference]
+    ) -> Graph {
+        let project = Project.test(
+            path: projectPath,
+            targets: [
+                Target.test(name: "App"),
+                Target.test(name: "AppTests"),
+            ],
+            packages: packages,
+            schemes: [scheme(projectPath: projectPath, codeCoverageTargets: codeCoverageTargets)]
+        )
+        return Graph.test(
+            path: projectPath,
+            projects: [projectPath: project]
+        )
+    }
+
+    private func scheme(
+        projectPath: AbsolutePath,
+        codeCoverageTargets: [TargetReference]
+    ) -> Scheme {
+        Scheme.test(
+            name: "SomeScheme",
+            buildAction: .init(targets: [TargetReference(projectPath: projectPath, name: "App")]),
+            testAction: .test(
+                targets: [TestableTarget(target: TargetReference(projectPath: projectPath, name: "AppTests"))],
+                coverage: true,
+                codeCoverageTargets: codeCoverageTargets
+            )
+        )
+    }
+}

--- a/examples/xcode/generated_ios_app_with_local_swift_package/Packages/PackageA/Package.swift
+++ b/examples/xcode/generated_ios_app_with_local_swift_package/Packages/PackageA/Package.swift
@@ -15,6 +15,12 @@ let package = Package(
             name: "LibraryB",
             targets: ["LibraryB"]
         ),
+        // A product whose name differs from the target backing it, used to validate
+        // scheme code coverage references against product names.
+        .library(
+            name: "LibraryC",
+            targets: ["LibraryCCore"]
+        ),
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
@@ -32,6 +38,10 @@ let package = Package(
         ),
         .target(
             name: "LibraryB",
+            dependencies: []
+        ),
+        .target(
+            name: "LibraryCCore",
             dependencies: []
         ),
     ]

--- a/examples/xcode/generated_ios_app_with_local_swift_package/Packages/PackageA/Sources/LibraryCCore/LibraryCCoreClass.swift
+++ b/examples/xcode/generated_ios_app_with_local_swift_package/Packages/PackageA/Sources/LibraryCCore/LibraryCCoreClass.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+public class LibraryCCoreClass {
+    public init() {}
+
+    public func hello() -> String {
+        "LibraryCCore"
+    }
+}

--- a/examples/xcode/generated_ios_app_with_local_swift_package/Packages/PackageB/Package.swift
+++ b/examples/xcode/generated_ios_app_with_local_swift_package/Packages/PackageB/Package.swift
@@ -1,0 +1,20 @@
+// swift-tools-version:6.2
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "PackageB",
+    products: [
+        .library(
+            name: "OtherLibrary",
+            targets: ["OtherLibraryCore"]
+        ),
+    ],
+    targets: [
+        .target(
+            name: "OtherLibraryCore",
+            dependencies: []
+        ),
+    ]
+)

--- a/examples/xcode/generated_ios_app_with_local_swift_package/Packages/PackageB/Sources/OtherLibraryCore/OtherLibraryCoreClass.swift
+++ b/examples/xcode/generated_ios_app_with_local_swift_package/Packages/PackageB/Sources/OtherLibraryCore/OtherLibraryCoreClass.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+public class OtherLibraryCoreClass {
+    public init() {}
+
+    public func hello() -> String {
+        "OtherLibraryCore"
+    }
+}

--- a/examples/xcode/generated_ios_app_with_local_swift_package/Project.swift
+++ b/examples/xcode/generated_ios_app_with_local_swift_package/Project.swift
@@ -4,6 +4,7 @@ let project = Project(
     name: "App",
     packages: [
         .package(path: "Packages/PackageA"),
+        .package(path: "Packages/PackageB"),
     ],
     targets: [
         .target(
@@ -22,6 +23,7 @@ let project = Project(
                 .package(product: "LibraryA"),
                 .package(product: "LibraryB"),
                 .package(product: "LibraryC"),
+                .package(product: "OtherLibrary"),
             ]
         ),
         .target(
@@ -50,6 +52,9 @@ let project = Project(
                         // Invalid: the name of the package target backing the product.
                         // It is not a coverage buildable, so it is dropped with a warning.
                         .project(path: "Packages/PackageA", target: "LibraryCCore"),
+                        // Invalid: a product of PackageB referenced through PackageA's path.
+                        // It is dropped with a warning.
+                        .project(path: "Packages/PackageA", target: "OtherLibrary"),
                     ]
                 )
             )

--- a/examples/xcode/generated_ios_app_with_local_swift_package/Project.swift
+++ b/examples/xcode/generated_ios_app_with_local_swift_package/Project.swift
@@ -21,6 +21,7 @@ let project = Project(
                 .project(target: "FrameworkA", path: "Frameworks/FrameworkA"),
                 .package(product: "LibraryA"),
                 .package(product: "LibraryB"),
+                .package(product: "LibraryC"),
             ]
         ),
         .target(
@@ -33,6 +34,25 @@ let project = Project(
             dependencies: [
                 .target(name: "App"),
             ]
+        ),
+    ],
+    schemes: [
+        .scheme(
+            name: "AppWithPackageCoverage",
+            buildAction: .buildAction(targets: ["App"]),
+            testAction: .targets(
+                ["AppTests"],
+                options: .options(
+                    coverage: true,
+                    codeCoverageTargets: [
+                        // Valid: the name of a package product consumed by the App target.
+                        .project(path: "Packages/PackageA", target: "LibraryC"),
+                        // Invalid: the name of the package target backing the product.
+                        // It is not a coverage buildable, so it is dropped with a warning.
+                        .project(path: "Packages/PackageA", target: "LibraryCCore"),
+                    ]
+                )
+            )
         ),
     ]
 )


### PR DESCRIPTION
Follow-up to #11399.

## Summary

#11399 allowed `codeCoverageTargets` in project schemes to reference targets from other projects, so `tuist generate` no longer fails linting for schemes that gather coverage for local Swift package targets (native SPM integration via `packages: [.local(path:)]`). However, two gaps remained for that scenario:

1. **The reference never reached the generated scheme.** `SchemeDescriptorsGenerator` resolves coverage targets through the graph, and local package targets are not part of it, so the reference was silently dropped. The generated scheme ended up with `codeCoverageEnabled = "YES"` but no `<CodeCoverageTargets>` list, meaning coverage was gathered for *all* targets instead of only the specified ones.
2. **`GraphLinter` still warned.** `lintSchemesUnknownTargets` uses `Scheme.targetDependencies()`, which includes `codeCoverageTargets`, producing a `Cannot find targets X (..) defined in Scheme` warning for perfectly valid references. This is the same root cause #11399 fixed in `SchemeLinter` via `nonCodeCoverageTargetDependencies`.

## Changes

- `SchemeDescriptorsGenerator`: when a coverage target is not found in the graph but its `projectPath` matches a local Swift package declared by a graph project, emit a package-style `XCScheme.BuildableReference`, with `ReferencedContainer` pointing at the package directory (relative to the workspace) and `BlueprintIdentifier`/`BuildableName`/`BlueprintName` set to the reference name. This matches what Xcode writes when the package product is selected manually in the scheme editor.
- `LocalPackageCoverageTargetsValidator` (new, part of `ManifestGraphLoader`): coverage references pointing at a declared local package path are validated against the actual products of that specific package, obtained by dumping its manifest (memoized per package, and only when such references exist, so there is no cost for projects that don't use this). Xcode exposes package coverage buildables by product name, so a name that is not a product of the referenced package, such as the backing target's name, a typo, a product of another package referenced through the wrong path, or a remote product under a local package path, is removed from the graph with a warning, and coverage falls back to all targets instead of producing a silently empty report.
- `GraphLinter.lintSchemesUnknownTargets`: skip references used *exclusively* as code coverage targets whose name matches a consumed product of a local package. A local package reference that also appears in another scheme action (build, run, etc.) keeps the warning, since the generator cannot resolve it there. This check, together with the equivalent one in the generator, acts as a backstop for graphs that don't go through manifest loading.
- `Scheme+Core` (TuistCore): `nonCodeCoverageTargetDependencies()` moved here from `SchemeLinter` (where #11399 introduced it as a private helper), so both `SchemeLinter` and `GraphLinter` share the same implementation, and `targetDependencies()` is now built on top of it.

## Testing

- `LocalPackageCoverageTargetsValidatorTests`: graph target references are kept without dumping packages, product references are kept, non-product names are dropped with a warning, a product of another package referenced through the wrong path is dropped with a warning, references outside local packages are left for the linter, and workspace schemes are validated too.
- `SchemeDescriptorsGeneratorCodeCoverageTests` (Swift Testing): the buildable reference emitted for a consumed product (`container:../Package`, blueprint identifier/name equal to the product name, `primary` buildable identifier); non-product names and references matching neither the graph nor a package are dropped.
- `GraphLinterTests`: no issues for a coverage reference naming a consumed product of a local package; the warning is preserved for non-product names, for local package references also used in other scheme actions, and for unknown targets.
- End-to-end: the `generated_ios_app_with_local_swift_package` fixture now has a product whose name differs from its backing target (`LibraryC` -> `LibraryCCore`) and a second package (`PackageB` with product `OtherLibrary`). The scheme references the product, the backing target name, and the other package's product through the wrong path. The `ios_app_with_local_swift_package_product_code_coverage` acceptance test asserts the generated `.xcscheme` keeps only the `LibraryC` product reference (`container:Packages/PackageA`).
- Validated against a real project using native SPM integration (`Project(packages: [.local(path: "../")])` with `codeCoverageTargets: [.project(path: "..", target: "MyPackageProduct")]`): `tuist generate` emits no warning and the generated `.xcscheme` contains the `<CodeCoverageTargets>` entry with `ReferencedContainer = "container:.."`.
