### PR TITLE
feat(registry): enable the server-owned sync writer in production

### DIFF
--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -76,9 +76,11 @@ server:
     # env's config the release runs as.
     - name: TUIST_DEPLOY_ENV
       value: prod
-    # Cache remains the sole registry writer until the managed cutover.
+    # Enables the server-owned registry sync writer. Cache still writes
+    # too until it is turned off as a separate step; the two coordinate
+    # through the shared S3 sync lock, so dual-writing is safe.
     - name: SWIFT_REGISTRY_SYNC_ENABLED
-      value: "false"
+      value: "true"
     - name: TUIST_DATABASE_POOL_SIZE
       value: "15"
     - name: TUIST_OTEL_EXPORTER_OTLP_ENDPOINT
@@ -384,7 +386,7 @@ processor:
   affinity: {}
 
 swiftRegistrySync:
-  enabled: false
+  enabled: true
   extraEnv:
     - name: TUIST_DEPLOY_ENV
       value: prod


### PR DESCRIPTION
## What

Enables the server-owned Swift registry sync writer in production by flipping two values in `values-managed-production.yaml`:

- `SWIFT_REGISTRY_SYNC_ENABLED: "false"` → `"true"` (the server env that gates the sync cron)
- `swiftRegistrySync.enabled: false` → `true` (the `swift-registry-sync` deployment itself)

## Why

This is the writer half of the registry cutover. The read frontend is already live in production (#11759), traffic is still on the cache path. This turns on the server-owned writer so it can take over package syncing from cache.

## This is the safe half of a deliberately split cutover

Cache's writer **stays on**. This PR does not touch it. The two writers coordinate through the same S3 sync lock (`registry/locks/sync.json`, plus per-package and per-release lock keys, all with an `If-None-Match: "*"` conditional put). `Tuist.Registry.Swift.Lock` and `Cache.Registry.Lock` are the same implementation, so they mutually exclude per package. Dual-writing is the designed transition state, not a hazard.

Running both is what lets this be low-risk: cache is a live safety net while we confirm the server writer actually keeps up at production scale. Cache is turned off only as a separate, later step (`kamal env push` of the `REGISTRY_SYNC_ALLOWLIST` sentinel from #11761), and only once this writer is proven healthy.

> [!WARNING]
> **Expect [TUIST-185](https://tuist.sentry.io/issues/133434361/) to return when this deploys.** On canary the server writer threw `{:error, {:http_error, 403}}` fetching the SwiftPackageIndex catalog, on a single-package allowlist. Production has no allowlist, so it fetches the full ~9000-package catalog and the 403 may reappear at larger scale. That is expected and it is why cache stays on: if the server writer 403s, cache still covers every write and nothing is lost. We deliberately kept this error un-silenced (#11764) so it stays visible. If it fires, it gives us a production repro to pull the raw GitHub response headers and settle rate-limit-vs-scope, which the canary events did not carry.
>
> **Do not disable cache until this writer is confirmed healthy.** Disabling cache while the server writer is 403ing would leave zero effective writers.

## Prerelease key note

Once this writer runs it stores prerelease versions in dotted form (`2.0.0-convergence.1`), while cache stored them as plus (`2.0.0-convergence+1`). During dual-write the bucket accumulates both, which is harmless. It is the reason the read-side cutover (repointing Cloudflare to the new frontend) still needs the prerelease read fallback first. That is tracked separately and does not block this change.

## Validation

- `helm template` with the production overlay (`values-managed-common.yaml` + `values-managed-production.yaml` + `values-ci.yaml`) renders clean.
- Diffed the rendered resource list against `main`: this change adds exactly `swift-registry-sync-deployment` and `swift-registry-sync-external-secrets`, removes nothing.
- Rendered server env shows `SWIFT_REGISTRY_SYNC_ENABLED: "true"`.
- Production already has the writer's secrets (`REGISTRY` item plus the separate `SWIFT_REGISTRY_SYNC_DATABASE_PASSWORD`), confirmed earlier in the cutover.

## After merge

Watch as it deploys, with cache still covering:

- `swift-registry-sync` pod comes up Ready, external secret syncs.
- Sentry: does TUIST-185 (the 403) recur at full-catalog scale?
- Does the server writer acquire the sync lock and enqueue `ReleaseWorker` jobs, and do new upstream releases start appearing in the bucket?

Only after a sustained healthy window do we proceed to disable cache's writer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
