### PR TITLE
fix(cache): keep production registry sync writer enabled until cutover

### DIFF
--- a/cache/config/deploy.production.yml
+++ b/cache/config/deploy.production.yml
@@ -19,16 +19,3 @@ env:
     DEPLOY_ENV: prod
     XCODE_DATABASE_INTERACTIONS_ENABLED: "false"
     POOL_SIZE: "10"
-    # Disables cache's scheduled registry sync without touching its read
-    # path: `registry_enabled?` gates both, so unsetting the bucket or the
-    # GitHub token would take reads down with it. The allowlist is matched
-    # against `owner/repo` exactly (a trailing `*` would make it a prefix),
-    # so a handle no package can have filters every package out and the
-    # SyncWorker no-ops. Same mechanism canary already uses to scope sync
-    # to one package.
-    #
-    # This is the guard for the cutover window: `main` has already removed
-    # the sync cron, but the running image predates that, so until the
-    # server-owned writer is enabled this keeps cache from being a second
-    # writer and keeps a re-added cron from silently resuming.
-    REGISTRY_SYNC_ALLOWLIST: tuist/__sync-disabled__


### PR DESCRIPTION
## What

Removes the `REGISTRY_SYNC_ALLOWLIST: tuist/__sync-disabled__` sentinel that #11761 committed to `cache/config/deploy.production.yml`.

## Why

Credit to the Codex bot on #11771 for flagging this. It is a valid P1, with one correction on the runtime state.

The sentinel disables cache's registry `SyncWorker` (an allowlist no package matches makes it no-op). #11761 committed it, but it was **never applied to the hosts**: the last successful cache deploy was 2026-06-03, and the deploy that #11761's merge triggered failed at the 1Password secrets step with production skipped. So the running cache image predates the sentinel and production is still syncing the full catalog today. The dual-write safety net that #11771 relies on is real right now.

The hazard is the divergence itself: `main` now *declares* cache disabled while we depend on it being the live writer through the dual-write window. The next successful cache deploy (someone repairs the 1Password rate limit, or any `cache/**` change lands after that) applies the sentinel. If the server-owned writer is unhealthy at that moment (the known SPI 403 at full-catalog scale), production is left with zero effective registry writers and new upstream releases stop appearing. Relying on `cache-deploy.yml` staying red is not a safety guarantee, it is the accidental safety we have been removing throughout this cutover.

## We do not lose the disable mechanism

`kamal env push` reads the local working-directory config, not `main`. So the sentinel is re-added on a branch and applied at the actual cache-disable step, once the server writer is proven healthy, without needing to carry it in `main` beforehand. This also matches the runbook in #11761, which already applied it via `kamal env push` from a branch.

## Sequencing

1. `main` reflects reality: cache is the writer (this PR).
2. Enable the server writer in production (#11771), dual-write with cache as the net.
3. Confirm the server writer keeps up and does not 403 at scale.
4. Only then re-add the sentinel on a branch and `kamal env push` to disable cache.
5. Final cutover: deploy cache from `main` (cron already removed) to make it durable.

## Validation

Removes the 13-line block added by #11761; no other change. Cache's registry read path is untouched (`registry_enabled?` still true).

🤖 Generated with [Claude Code](https://claude.com/claude-code)