### PR TITLE
fix(server): apply swift registry sync Oban grants declaratively

### DIFF
--- a/infra/helm/tuist/templates/swift-registry-sync-grants-job.yaml
+++ b/infra/helm/tuist/templates/swift-registry-sync-grants-job.yaml
@@ -1,0 +1,116 @@
+{{- if and (eq .Values.postgresql.mode "cnpg") .Values.swiftRegistrySync.enabled .Values.swiftRegistrySync.grantsJob.enabled }}
+{{- $role := .Values.postgresql.cnpg.roles.swiftRegistrySync.name -}}
+{{- $schema := .Values.postgresql.schema -}}
+{{- $database := .Values.postgresql.cnpg.database -}}
+# Applies the least-privilege Oban grants for the swift_registry_sync
+# role as part of the deploy, so enabling swiftRegistrySync carries its
+# own table privileges. CNPG creates the role declaratively from
+# managed.roles in the Cluster CR, but it does not apply per-table
+# grants, so without this the swift-registry-sync pod's Oban producers
+# crash-loop on `permission denied for table oban_jobs`.
+#
+# The SQL mirrors infra/cnpg/tuist-swift-registry-sync-grants.sql (the
+# re-runnable file kept for backup-restore recovery). Both must stay in
+# sync; a new PG read/write in the sync or release worker means updating
+# both. This template renders the schema/role/database from values so it
+# needs no psql meta-commands.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "tuist.componentName" (dict "root" . "component" "swift-registry-sync-grants") }}
+  labels:
+    {{- include "tuist.labels" . | nindent 4 }}
+    app.kubernetes.io/component: swift-registry-sync-grants
+data:
+  grants.sql: |
+    BEGIN;
+    GRANT CONNECT ON DATABASE {{ $database }} TO {{ $role }};
+    GRANT USAGE ON SCHEMA {{ $schema }} TO {{ $role }};
+    -- Oban coordination. INSERT so the SyncWorker enqueues ReleaseWorker
+    -- jobs; DELETE for Oban.Plugins.Pruner.
+    GRANT SELECT, INSERT, UPDATE, DELETE ON {{ $schema }}.oban_jobs, {{ $schema }}.oban_peers TO {{ $role }};
+    GRANT USAGE, SELECT ON SEQUENCE {{ $schema }}.oban_jobs_id_seq TO {{ $role }};
+    -- Re-assert the intersection: any table added by a future migration
+    -- stays off-limits to this role until granted here explicitly.
+    REVOKE ALL ON ALL TABLES IN SCHEMA {{ $schema }} FROM {{ $role }};
+    GRANT SELECT, INSERT, UPDATE, DELETE ON {{ $schema }}.oban_jobs, {{ $schema }}.oban_peers TO {{ $role }};
+    COMMIT;
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  # Stable name so before-hook-creation deletes the prior Job before the
+  # new hook schedules.
+  name: {{ include "tuist.componentName" (dict "root" . "component" "swift-registry-sync-grants") }}
+  labels:
+    {{- include "tuist.labels" . | nindent 4 }}
+    app.kubernetes.io/component: swift-registry-sync-grants
+  annotations:
+    # post-* so it runs after the Cluster CR is applied and CNPG has had
+    # a chance to reconcile the role, and after the migration hook has
+    # created oban_jobs. The command retries regardless, since CNPG role
+    # reconciliation is asynchronous.
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "5"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: {{ .Values.swiftRegistrySync.grantsJob.backoffLimit }}
+  template:
+    metadata:
+      labels:
+        {{- include "tuist.componentLabels" (dict "root" . "component" "swift-registry-sync-grants") | nindent 8 }}
+        {{- with .Values.global.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      # The Job only talks to Postgres; it needs no Kubernetes API access.
+      automountServiceAccountToken: false
+      restartPolicy: Never
+      {{- include "tuist.podScheduling" . | nindent 6 }}
+      {{- with .Values.swiftRegistrySync.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.swiftRegistrySync.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+        - name: grants-sql
+          configMap:
+            name: {{ include "tuist.componentName" (dict "root" . "component" "swift-registry-sync-grants") }}
+      containers:
+        - name: grants
+          image: "{{ .Values.server.image.repository }}:{{ .Values.server.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.server.image.pullPolicy }}
+          command:
+            - /bin/sh
+            - -ec
+            - |
+              # The grants role is created asynchronously by CNPG; on a
+              # fresh cluster it may not exist the instant this hook runs.
+              # The SQL is idempotent, so retry until it applies.
+              attempts={{ .Values.swiftRegistrySync.grantsJob.retries }}
+              for i in $(seq 1 "$attempts"); do
+                if psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f /sql/grants.sql; then
+                  echo "swift_registry_sync grants applied"
+                  exit 0
+                fi
+                echo "attempt $i/$attempts failed (role may still be reconciling); retrying in 10s"
+                sleep 10
+              done
+              echo "swift_registry_sync grants did not apply after $attempts attempts"
+              exit 1
+          env:
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "tuist.cnpgAppSecretName" . }}
+                  key: uri
+          volumeMounts:
+            - name: grants-sql
+              mountPath: /sql
+              readOnly: true
+          resources:
+            {{- toYaml .Values.swiftRegistrySync.grantsJob.resources | nindent 12 }}
+{{- end }}

--- a/infra/helm/tuist/values.yaml
+++ b/infra/helm/tuist/values.yaml
@@ -495,6 +495,16 @@ swiftRegistrySync:
   replicaCount: 1
   resources: {}
   extraEnv: []
+  # Applies the role's Oban table grants as a post-upgrade hook Job when
+  # postgresql.mode == cnpg, so enabling this component carries its own
+  # privileges instead of relying on a manual psql run. Idempotent.
+  grantsJob:
+    enabled: true
+    backoffLimit: 6
+    # Retries inside the pod: CNPG reconciles the role asynchronously, so
+    # on a fresh cluster the role may not exist the instant the hook runs.
+    retries: 30
+    resources: {}
   # When true, the chart provisions an ExternalSecret pulling the
   # registry's Tigris credentials, GitHub PAT, and bucket name from
   # 1Password (the existing `REGISTRY` item used by the standalone


### PR DESCRIPTION
## What

Adds a `post-upgrade`/`post-install` hook Job that applies the `tuist_swift_registry_sync` role's Oban table grants on every deploy, plus a ConfigMap holding the SQL. Gated on `postgresql.mode == cnpg` and `swiftRegistrySync.enabled`.

## Why (an incident)

When `swiftRegistrySync.enabled` was flipped on in production (#11771), the writer pod came up `1/1 Running` and passed its deploy smoke test, but it was silently doing nothing. Its logs show the Oban producers crash-looping every few seconds:

```
(Postgrex.Error) ERROR 42501 (insufficient_privilege) permission denied for table oban_jobs
GenServer {Oban, {:producer, "swift_registry_sync"}} terminating
GenServer {Oban, {:producer, "swift_registry_release"}} terminating
```

Root cause: CNPG creates the `tuist_swift_registry_sync` role declaratively from `managed.roles`, but **it does not apply per-table grants**. Those live in `infra/cnpg/tuist-swift-registry-sync-grants.sql`, which the README documents as a manual `kubectl cnpg psql` step to run *before* enabling the component. That manual step was skipped, so the role had no privileges on `oban_jobs`, and the producers couldn't fetch or enqueue jobs.

There was no user-visible impact because cache, which runs on its own separate database, kept the registry syncing the whole time. (That is also why the cutover was sequenced writer-first with cache left on as the safety net, this is exactly the failure that ordering protects against.)

The bug isn't the missing grant, it's that "enable the writer" and "grant the writer" were two separate actions and one is easy to forget. This makes the grant part of the deploy.

## The change

- A ConfigMap renders the grant SQL with the schema/role/database substituted from values (so it needs no psql `\if`/`-v` meta-commands).
- A hook Job runs `psql -f` against the CNPG app-owner connection (`<cluster>-app` secret's `uri`, the same one the migration Job uses) and applies the grants.
- It runs `post-*` so the Cluster CR is applied and CNPG has had time to reconcile the role, and after the migration hook has created `oban_jobs`. The command retries (role reconciliation is async), and the SQL is idempotent, so re-running every deploy is safe.
- `automountServiceAccountToken: false`, the Job only talks to Postgres.

On the next production deploy this applies the grants and the crash-looping producers recover on their own.

## Why not the alternatives

The README's "Why not an Ecto migration" already rejects putting this in app migrations (role state is infra, `CREATE ROLE` is superuser-only) and `postInitApplicationSQL` (fires once, not after a restore, and runs before `oban_jobs` exists). This PR keeps the grant as infra SQL and keeps it re-runnable; it only changes the *invocation* from "a human remembers to run psql" to "the deploy runs it." CNPG has no declarative per-table-grant surface, and `inRoles` membership would over-grant (the SQL deliberately keeps this role narrower than the processor's), so a hook Job is the least-privilege declarative option.

## Tradeoff for review

The SQL now exists in two places: this template and `infra/cnpg/tuist-swift-registry-sync-grants.sql` (kept for backup-restore recovery, where no Helm deploy runs). They must stay in sync, a comment in the template says so. I inlined rather than moving the canonical file into the chart because its siblings (`tuist-processor-grants.sql`, `tuist-ops-ro-grants.sql`) live in `infra/cnpg/` too and the chart has no `.Files.Get`/`files/` convention (ConfigMaps are inlined here, e.g. `postgresql-cnpg-monitoring-queries.yaml`). If you'd prefer a single source, I can relocate all three grant files into the chart's `files/` and update the README, but that's a larger, cross-cutting change.

## Validation

- `helm template` with the production overlay renders the ConfigMap (SQL with `public` / `tuist_swift_registry_sync` / `tuist` substituted) and the Job (`post-install,post-upgrade`, weight 5, `before-hook-creation,hook-succeeded`, `DATABASE_URL` from `tuist-tuist-pg-app`/`uri`).
- Canary (writer disabled) renders **0** grants resources, confirming the gate.
- The rendered grants match `infra/cnpg/tuist-swift-registry-sync-grants.sql` line for line (minus the psql meta-commands, which are unnecessary here).

## Follow-ups (separate, not in this PR)

- The writer pod stayed `1/1 Running` with 0 restarts while broken, because the BEAM survives and only the producer GenServers restart. A readiness check that reflects "can process jobs," or extending the deploy smoke test to probe the writer and not just the read frontend, would have failed the deploy instead of shipping it broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
