### PR TITLE
fix(server): apply swift registry sync DB grants at migrate time

### DIFF
--- a/infra/cnpg/README.md
+++ b/infra/cnpg/README.md
@@ -66,7 +66,7 @@ kubectl cnpg psql -n "$NAMESPACE" "$CLUSTER" -- -d postgres -f - \
 
 Each file ends with a sanity-check `SELECT … information_schema.role_table_grants …` query that prints the exact privilege set the role holds after the run. A clean run shows write privileges on the Oban tables and read-only privileges on the lookup tables the processors use.
 
-The Tuist server deploy creates the `tuist_swift_registry_sync` role password through the chart-managed role block, but it does not apply table-level grants. Run `tuist-swift-registry-sync-grants.sql` before enabling `swiftRegistrySync.enabled` in an existing environment, and re-run it after backup restores.
+The `tuist_swift_registry_sync` role's grants are applied at migrate time by `Tuist.Release.migrate` (keyed by `TUIST_DATABASE_SWIFT_REGISTRY_SYNC_ROLE`, passed by the migration job), the same way the runtime and processor roles are handled, so a normal deploy grants them and no manual step is needed. This file is the re-runnable fallback for a fresh cluster or a backup restore where migrations haven't run yet; keep it in sync with `Release.swift_registry_sync_role_grant_statements/3` (a test enforces this).
 
 ## Why not an Ecto migration
 

--- a/infra/helm/tuist/templates/server-migration-job.yaml
+++ b/infra/helm/tuist/templates/server-migration-job.yaml
@@ -125,6 +125,8 @@ spec:
               value: {{ .Values.postgresql.cnpg.roles.web.name | quote }}
             - name: TUIST_DATABASE_PROCESSOR_ROLE
               value: {{ .Values.postgresql.cnpg.roles.processor.name | quote }}
+            - name: TUIST_DATABASE_SWIFT_REGISTRY_SYNC_ROLE
+              value: {{ .Values.postgresql.cnpg.roles.swiftRegistrySync.name | quote }}
             {{- end }}
             - name: TUIST_USE_SSL_FOR_DATABASE
               value: "0"

--- a/server/lib/tuist/environment.ex
+++ b/server/lib/tuist/environment.ex
@@ -210,6 +210,13 @@ defmodule Tuist.Environment do
     end
   end
 
+  def database_swift_registry_sync_role do
+    case System.get_env("TUIST_DATABASE_SWIFT_REGISTRY_SYNC_ROLE") do
+      role when is_binary(role) and role != "" -> role
+      _ -> nil
+    end
+  end
+
   def database_config_from_url(url) do
     parsed_url = URI.parse(url)
 

--- a/server/lib/tuist/release.ex
+++ b/server/lib/tuist/release.ex
@@ -11,6 +11,7 @@ defmodule Tuist.Release do
   @app :tuist
   @processor_write_tables ~w(oban_jobs oban_peers)
   @processor_read_tables ~w(accounts projects automation_alerts webhook_endpoints)
+  @swift_registry_sync_write_tables ~w(oban_jobs oban_peers)
 
   def migrate do
     load_app()
@@ -26,6 +27,7 @@ defmodule Tuist.Release do
           Ecto.Migrator.run(repo, :up, all: true)
           grant_runtime_role(repo)
           grant_processor_role(repo)
+          grant_swift_registry_sync_role(repo)
         end)
     end
   end
@@ -221,6 +223,57 @@ defmodule Tuist.Release do
       "GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE #{write_tables} TO #{role}",
       "GRANT USAGE, SELECT ON SEQUENCE #{quoted_schema}.oban_jobs_id_seq TO #{role}",
       "GRANT SELECT ON TABLE #{read_tables} TO #{role}"
+    ]
+  end
+
+  # The swift_registry_sync worker (TUIST_MODE=swift_registry_sync) only
+  # touches Oban: it consumes :swift_registry_sync and inserts
+  # :swift_registry_release jobs, everything else lives in S3. So its grant
+  # is a strict subset of the processor's — the Oban tables, no
+  # accounts/projects reads. Applied here on every migrate, as the schema
+  # owner, so enabling swiftRegistrySync carries its own grants instead of
+  # the drift-prone manual `infra/cnpg/tuist-swift-registry-sync-grants.sql`
+  # runbook.
+  defp grant_swift_registry_sync_role(repo) when repo == Tuist.Repo do
+    case Environment.database_swift_registry_sync_role() do
+      role when is_binary(role) and role != "" ->
+        do_grant_swift_registry_sync_role(repo, role)
+
+      _ ->
+        :ok
+    end
+  end
+
+  defp grant_swift_registry_sync_role(_repo), do: :ok
+
+  defp do_grant_swift_registry_sync_role(repo, role) do
+    Environment.validate_postgres_identifier!(role, "TUIST_DATABASE_SWIFT_REGISTRY_SYNC_ROLE")
+
+    role = Environment.quote_postgres_identifier(role)
+    database = repo.config() |> Keyword.fetch!(:database) |> Environment.quote_postgres_identifier()
+    quoted_schema = Environment.quote_postgres_identifier(Environment.database_schema())
+
+    {:ok, :ok} =
+      repo.transaction(fn ->
+        Enum.each(
+          swift_registry_sync_role_grant_statements(role, database, quoted_schema),
+          &SQL.query!(repo, &1, [])
+        )
+
+        :ok
+      end)
+  end
+
+  @doc false
+  def swift_registry_sync_role_grant_statements(role, database, quoted_schema) do
+    write_tables = qualify_tables(quoted_schema, @swift_registry_sync_write_tables)
+
+    [
+      "REVOKE ALL ON ALL TABLES IN SCHEMA #{quoted_schema} FROM #{role}",
+      "GRANT CONNECT ON DATABASE #{database} TO #{role}",
+      "GRANT USAGE ON SCHEMA #{quoted_schema} TO #{role}",
+      "GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE #{write_tables} TO #{role}",
+      "GRANT USAGE, SELECT ON SEQUENCE #{quoted_schema}.oban_jobs_id_seq TO #{role}"
     ]
   end
 

--- a/server/test/tuist/release_test.exs
+++ b/server/test/tuist/release_test.exs
@@ -38,6 +38,37 @@ defmodule Tuist.ReleaseTest do
     end
   end
 
+  describe "swift_registry_sync_role_grant_statements/3" do
+    test "grants only the Oban surface" do
+      role = ~s("tuist_swift_registry_sync")
+      database = ~s("tuist")
+      schema = ~s("public")
+
+      assert Release.swift_registry_sync_role_grant_statements(role, database, schema) == [
+               ~s(REVOKE ALL ON ALL TABLES IN SCHEMA "public" FROM "tuist_swift_registry_sync"),
+               ~s(GRANT CONNECT ON DATABASE "tuist" TO "tuist_swift_registry_sync"),
+               ~s(GRANT USAGE ON SCHEMA "public" TO "tuist_swift_registry_sync"),
+               ~s(GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE "public".oban_jobs, "public".oban_peers TO "tuist_swift_registry_sync"),
+               ~s(GRANT USAGE, SELECT ON SEQUENCE "public".oban_jobs_id_seq TO "tuist_swift_registry_sync")
+             ]
+    end
+
+    test "keeps the CloudNativePG fallback grant list in sync" do
+      sql =
+        __DIR__
+        |> Path.join("../../../infra/cnpg/tuist-swift-registry-sync-grants.sql")
+        |> Path.expand()
+        |> File.read!()
+
+      assert sql =~
+               ~s(GRANT SELECT, INSERT, UPDATE, DELETE ON :"tuist_schema".oban_jobs, :"tuist_schema".oban_peers TO tuist_swift_registry_sync;)
+
+      assert sql =~ ~s(GRANT USAGE, SELECT ON SEQUENCE :"tuist_schema".oban_jobs_id_seq TO tuist_swift_registry_sync;)
+
+      assert sql =~ ~s(REVOKE ALL ON ALL TABLES IN SCHEMA :"tuist_schema" FROM tuist_swift_registry_sync;)
+    end
+  end
+
   defp occurrences(contents, pattern) do
     contents
     |> String.split(pattern)


### PR DESCRIPTION
## What

Applies the `tuist_swift_registry_sync` role's Oban grants at migrate time in `Tuist.Release.migrate`, keyed by a new `TUIST_DATABASE_SWIFT_REGISTRY_SYNC_ROLE` env passed by the migration job. Mirrors how the runtime and processor roles are already handled.

## Why (an incident)

When `swiftRegistrySync.enabled` was turned on in production (#11771), the writer pod came up `1/1 Running` and passed its deploy smoke test but was silently doing nothing. Its logs show the Oban producers crash-looping:

```
(Postgrex.Error) ERROR 42501 (insufficient_privilege) permission denied for table oban_jobs
GenServer {Oban, {:producer, "swift_registry_sync"}} terminating
```

CNPG creates the role declaratively, but its per-table grants lived only in `infra/cnpg/tuist-swift-registry-sync-grants.sql`, which the README documented as a manual `kubectl cnpg psql` step to run before enabling the component. That step was skipped, so the role had no privileges on `oban_jobs`.

No user-visible impact: cache runs on its own separate database and kept the registry syncing throughout. That's also why the cutover was sequenced writer-first with cache left on as the safety net.

## Why this shape (following precedent)

This is the exact problem #11602 already solved for the `tuist_processor` role: it moved grants out of the manual runbook and into `Tuist.Release.migrate`, applied as the schema owner on every migrate, with a code comment spelling out that the manual runbook drifts and that's what let tables reach the ingestion path ungranted. The runtime role is handled the same way. This change extends that established pattern to the third role instead of inventing a parallel one.

Concretely:

- `Environment.database_swift_registry_sync_role/0` reads `TUIST_DATABASE_SWIFT_REGISTRY_SYNC_ROLE` (nil when unset, so non-cnpg/self-hosted deployments are untouched).
- `Release.migrate` calls `grant_swift_registry_sync_role/1`, which runs the grants in a transaction via `SQL.query!` as the migration/owner role.
- The grant set is a strict subset of the processor's: `oban_jobs` / `oban_peers` write plus the sequence, no `accounts` / `projects` reads (the worker only touches Oban; everything else is S3).
- `server-migration-job.yaml` passes the role name from `postgresql.cnpg.roles.swiftRegistrySync.name`, alongside the existing runtime/processor role env.

On the next production deploy, migrate applies the grants and the crash-looping producers recover.

## What this replaces

Supersedes #11778, which fixed the same bug with a bespoke `post-upgrade` hook Job + ConfigMap + psql. That worked but introduced a second grant mechanism (the other two grant files are applied at migrate time) and duplicated the SQL into the chart. This follows the in-house pattern instead. I'll close #11778.

## Kept in sync

`infra/cnpg/tuist-swift-registry-sync-grants.sql` stays as the fresh-cluster / backup-restore fallback (where migrations haven't run yet), exactly like `tuist-processor-grants.sql`. A test asserts the Elixir statements and the SQL file don't drift, matching the processor's sync test.

## Validation

- `mix test test/tuist/release_test.exs` — 4 passed (2 existing processor, 2 new: exact statement list + SQL-file sync guard).
- `helm template` (prod overlay) renders `TUIST_DATABASE_SWIFT_REGISTRY_SYNC_ROLE: "tuist_swift_registry_sync"` in the migration job.
- `mix format --check-formatted` clean.

## Follow-up (separate)

The writer pod stayed `1/1 Running` with 0 restarts while broken, because only the Oban producer GenServers crashed, not the BEAM, so k8s and `--atomic` both saw it as healthy. A readiness check that reflects "can process jobs," or a deploy smoke test that probes the writer and not just the read frontend, would fail such a deploy instead of shipping it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)