### PR TITLE
fix(kura): wait for pool headroom before a snapshot build instead of declining

### DIFF
--- a/kura/src/memory/mod.rs
+++ b/kura/src/memory/mod.rs
@@ -181,6 +181,26 @@ impl MemoryController {
         reapi_materialization_pool_bytes(self.inner.soft_limit_bytes, self.inner.hard_limit_bytes)
     }
 
+    /// Like `try_acquire_reapi_materialization`, but waits for headroom.
+    /// For background work (snapshot index builds) that should queue behind
+    /// in-flight response materialization rather than fail because of it.
+    pub async fn acquire_reapi_materialization(
+        &self,
+        requested_bytes: usize,
+    ) -> Result<Option<OwnedSemaphorePermit>, ()> {
+        if requested_bytes == 0 {
+            return Ok(None);
+        }
+        let permits = u32::try_from(requested_bytes).map_err(|_| ())?;
+        self.inner
+            .reapi_materialization_pool
+            .clone()
+            .acquire_many_owned(permits)
+            .await
+            .map(Some)
+            .map_err(|_| ())
+    }
+
     pub fn try_acquire_reapi_materialization(
         &self,
         requested_bytes: usize,

--- a/kura/src/reapi/mod.rs
+++ b/kura/src/reapi/mod.rs
@@ -625,7 +625,17 @@ impl ReapiService {
                         index.reconciled_at = Instant::now();
                         (index, Ok(()))
                     }
-                    Err((index, error)) => (index, Err(error)),
+                    Err((index, error)) => {
+                        // Background kicks drop the shared future without
+                        // awaiting it, so this is the only place a repeated
+                        // reconcile failure becomes visible.
+                        tracing::warn!(
+                            namespace_id = namespace.as_str(),
+                            error = error.as_str(),
+                            "action-cache snapshot reconcile failed"
+                        );
+                        (index, Err(error))
+                    }
                 };
             index.last_used = Instant::now();
             {

--- a/kura/src/reapi/mod.rs
+++ b/kura/src/reapi/mod.rs
@@ -583,14 +583,24 @@ impl ReapiService {
         let task = tokio::spawn(async move {
             // A build's transient memory rides the response-materialization
             // pool: holding a byte-sized permit for its duration means a node
-            // already under memory pressure declines the build (the client
-            // falls back to per-key resolves) instead of being OOM-killed.
-            // The budget adapts to small pools so tests and tiny nodes still
-            // build; the streaming reconcile keeps the real peak near it.
+            // under memory pressure defers the build instead of being
+            // OOM-killed. The build WAITS for headroom rather than declining:
+            // a stale snapshot is what causes heavy per-key traffic, per-key
+            // responses draw on this same pool, and a try-acquire under that
+            // load refused every reconcile for exactly the reason one was
+            // needed — the index parked stale indefinitely. The bounded wait
+            // still fails closed if the pool never frees. The budget adapts
+            // to small pools so tests and tiny nodes still build; the
+            // streaming reconcile keeps the real peak near it.
             let budget = SNAPSHOT_BUILD_BUDGET_BYTES
                 .min(state.memory.reapi_materialization_pool_bytes() / 2)
                 .max(1);
-            let Ok(_permit) = state.memory.try_acquire_reapi_materialization(budget) else {
+            let permit = tokio::time::timeout(
+                SNAPSHOT_BUILD_PERMIT_WAIT,
+                state.memory.acquire_reapi_materialization(budget),
+            )
+            .await;
+            let Ok(Ok(_permit)) = permit else {
                 tracing::warn!(
                     namespace_id = namespace.as_str(),
                     budget,
@@ -1836,6 +1846,12 @@ const SNAPSHOT_INDEX_MAX_ENTRIES: usize = 100_000;
 /// at ~1KB per entry of scan-buffer + current-map peak, with headroom.
 const SNAPSHOT_BUILD_BUDGET_BYTES: usize = 192 << 20;
 
+/// How long a snapshot build waits for its memory-pool permit before
+/// declining. Generous: the build is background work, and the pool drains as
+/// in-flight responses complete — declining is only right when the node is
+/// pinned at capacity for this entire window.
+const SNAPSHOT_BUILD_PERMIT_WAIT: Duration = Duration::from_secs(600);
+
 /// How old a cached snapshot index may grow before a serve kicks a
 /// background reconcile. Requests never wait on it — they get the cached
 /// view — so this bounds staleness, not latency; it composes with the
@@ -2707,6 +2723,83 @@ mod tests {
                 .all(|entry| entry.version_ms > (ENTRIES - SNAPSHOT_INDEX_MAX_ENTRIES as u64)),
             "the cap kept the newest entries"
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn snapshot_build_waits_for_pool_headroom_instead_of_declining() {
+        let context = test_context(|_| {}).await;
+        let service = ReapiService {
+            snapshot_cache: Default::default(),
+            state: context.state.clone(),
+        };
+        let store = &context.state.store;
+        let uploads = context.state.config.tmp_dir.join("uploads");
+        std::fs::create_dir_all(&uploads).expect("uploads dir should create");
+        let entry_key = format!("action_cache/{}/10", hex::encode([0x44u8; 32]));
+        let entry_path = uploads.join("entry");
+        let entry_bytes = reapi::ActionResult {
+            output_files: vec![reapi::OutputFile {
+                path: hex::encode([0xABu8, 0xCD]),
+                digest: Some(reapi::Digest {
+                    hash: hex::encode([0x11u8; 32]),
+                    size_bytes: 7,
+                }),
+                ..Default::default()
+            }],
+            ..Default::default()
+        }
+        .encode_to_vec();
+        std::fs::write(&entry_path, &entry_bytes).expect("entry should write");
+        store
+            .apply_replicated_artifact_from_path(
+                ArtifactProducer::Reapi,
+                "ios",
+                &entry_key,
+                "application/octet-stream",
+                &entry_path,
+                100,
+            )
+            .await
+            .expect("entry should persist");
+        let blob_path = uploads.join("blob");
+        std::fs::write(&blob_path, b"payload").expect("blob should write");
+        store
+            .apply_replicated_artifact_from_path(
+                ArtifactProducer::Reapi,
+                "ios",
+                &blob_key(&format!("{}/7", hex::encode([0x11u8; 32]))),
+                "application/octet-stream",
+                &blob_path,
+                100,
+            )
+            .await
+            .expect("blob should persist");
+
+        // Exhaust the pool: the old try-acquire declined the build here —
+        // which, under the per-key load a stale snapshot causes, parked the
+        // index stale indefinitely. The build must wait instead.
+        let pool = context.state.memory.reapi_materialization_pool_bytes();
+        let hog = context
+            .state
+            .memory
+            .try_acquire_reapi_materialization(pool)
+            .expect("pool should be acquirable when idle");
+        let serve = tokio::spawn({
+            let service = service.clone();
+            async move { service.serve_actioncache_snapshot("ios", 0).await }
+        });
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+        assert!(
+            !serve.is_finished(),
+            "the build waits for headroom rather than declining"
+        );
+        drop(hog);
+        let bytes = tokio::time::timeout(std::time::Duration::from_secs(30), serve)
+            .await
+            .expect("build should complete once the pool frees")
+            .expect("serve task should not panic")
+            .expect("serve should succeed");
+        assert_eq!(&bytes[..4], b"TSNP");
     }
 
     use tokio::net::TcpListener;

--- a/kura/src/reapi/mod.rs
+++ b/kura/src/reapi/mod.rs
@@ -731,6 +731,9 @@ async fn reconcile_snapshot_index(
             to_load.push((hash, version, manifest));
         }
     }
+    let changed_count = to_load.len();
+    let mut loads_failed = 0_usize;
+    let mut invalid = 0_usize;
     let mut loading =
         futures_util::stream::iter(to_load.into_iter().map(|(hash, version, manifest)| {
             let state = state.clone();
@@ -745,6 +748,7 @@ async fn reconcile_snapshot_index(
     while let Some((hash, version_ms, manifest, action_result)) = loading.next().await {
         current.insert(hash, (version_ms, manifest));
         let Some(action_result) = action_result else {
+            loads_failed += 1;
             continue;
         };
         let mut nodes = Vec::with_capacity(action_result.output_files.len());
@@ -769,6 +773,8 @@ async fn reconcile_snapshot_index(
             index
                 .entries
                 .insert(hash, SnapshotIndexEntry { version_ms, nodes });
+        } else {
+            invalid += 1;
         }
     }
     drop(loading);
@@ -826,6 +832,11 @@ async fn reconcile_snapshot_index(
     // and nothing said whether builds were running, how much they scanned, or
     // what the index held afterwards — this is the Loki breadcrumb that turns
     // that from archaeology into a query.
+    // `changed` counts entries whose scanned version differed from the cached
+    // index; a load or parse failure there silently retains the entry's OLD
+    // version, which is exactly the shape of a frozen watermark — these
+    // counters are what distinguish "nothing new was published" from "new
+    // versions were published but every reload failed".
     tracing::info!(
         namespace_id,
         entries = index.entries.len(),
@@ -836,6 +847,9 @@ async fn reconcile_snapshot_index(
             .map(|entry| entry.version_ms)
             .max()
             .unwrap_or(0),
+        changed = changed_count,
+        loads_failed,
+        invalid,
         elapsed_ms = started.elapsed().as_millis() as u64,
         "action-cache snapshot index reconciled"
     );


### PR DESCRIPTION
## What happened

After the 0.16.1 rollout, production again served a byte-identical, stale snapshot for the tuist namespace across an entire bench cycle — a pre-populate view whose watermark never advanced — while per-key lookups on the same pods hit the newer entries and every stale serve kicked a background reconcile as designed (cold-slate builds measured 521s/540s in the per-key regime as a result). This reproduced from scratch on fresh pods, so it is structural.

## Root cause (the decline feedback loop)

The snapshot build's memory budget was a **try**-acquire against the response-materialization pool — the same pool in-flight per-key responses draw on. A stale snapshot is precisely what causes heavy per-key traffic: builds that can't resolve from the snapshot hammer the per-key path, whose inlined responses hold pool permits, which makes the build's try-acquire fail, which keeps the snapshot stale, which sustains the per-key traffic. Every reconcile was refused for exactly the reason one was needed.

## The fix

The build now **waits** for pool headroom (new `acquire_reapi_materialization` on the memory controller) with a generous bounded timeout (10 minutes) instead of failing fast. It is background work — the pool drains as responses complete within milliseconds-to-seconds — so queueing behind in-flight materialization is the correct behavior, and declining remains as the fail-closed path only when a node is pinned at capacity for the entire window. The decline warning from 0.16.x stays for that case.

## Validation

- New regression test: exhaust the pool, observe the build waiting rather than declining, release, observe completion.
- Full kura suite (335 tests), clippy warnings-as-errors, rustfmt.
- The `snapshot index reconciled` log line that shipped in 0.16.x will confirm on production: after this deploys, reconciles under bench load should log with advancing watermarks.


### Update: root cause of the production staleness found — it was not permit declines

Continued diagnosis (Loki + a live probe against production) showed the reconciles under Saturday's bench load were running and succeeding, and a freshly published probe key became snapshot-visible within 2 minutes. The staleness came from cross-pod replication ordering: the sibling pod received the populate's action-cache entries ~30 minutes late because they queued behind the blob backlog in the single-FIFO outbox. That is fixed separately in https://github.com/tuist/tuist/pull/11786.

This PR remains a correct hardening on its own (a memory-pressured node should defer a snapshot build, not park the index stale), and it now also carries a second commit that logs background reconcile failures — previously the error went into a shared future no caller awaited, which was the remaining silent failure mode in this path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

