### PR TITLE
fix(cli): emit explicit cross-package target dependency edges in generated workspaces

### DIFF
--- a/cli/Sources/TuistGenerator/Generator/CrossProjectDependencyGenerator.swift
+++ b/cli/Sources/TuistGenerator/Generator/CrossProjectDependencyGenerator.swift
@@ -4,39 +4,53 @@ import TuistCore
 import XcodeGraph
 import XcodeProj
 
-/// Wires cross-project `PBXTargetDependency` edges for consumers that depend on a
-/// `foreignBuild()` aggregate located in another project.
+/// Wires explicit cross-project `PBXTargetDependency` edges for consumers that depend on a target
+/// located in another generated project.
 ///
-/// `foreignBuild()` aggregates produce no product under `BUILT_PRODUCTS_DIR`, so Xcode's implicit
-/// dependency discovery (which walks framework references and product paths) does not pick them
-/// up across project boundaries. Without an explicit cross-project `PBXTargetDependency`, the
-/// aggregate's build script is never invoked when the consumer is built, and the consumer keeps
-/// linking the stale artifact even after the foreign sources change.
+/// `TargetGenerator` only emits `PBXTargetDependency` for dependencies within the same project
+/// (`directLocalTargetDependencies`). Cross-project dependencies are otherwise left to Xcode's
+/// implicit dependency discovery (product-name matching across the shared build products dir),
+/// which gives `swift-build` / `llbuild` no explicit ordering constraint. That ordering is then
+/// only correct by accident: on a warm compilation-cache build replayed tasks finish near-instantly
+/// and a downstream target's dependency scan can run before the upstream `.swiftmodule` exists,
+/// surfacing as `unable to resolve module dependency`.
 ///
-/// For each cross-project edge `(consumer -> foreign-build aggregate)` this generator adds the
-/// following to the consumer's pbxproj:
+/// This generator closes that gap for two cases:
+///
+/// - Each generated SPM package becomes its own external project, so a target that links a product
+///   of another package project needs an explicit edge across the package-project boundary.
+/// - `foreignBuild()` aggregates produce no product under `BUILT_PRODUCTS_DIR`, so Xcode's implicit
+///   discovery (which walks framework references and product paths) does not pick them up across
+///   project boundaries at all. Without the explicit edge the aggregate's build script is never
+///   invoked when the consumer builds, and the consumer keeps linking the stale artifact.
+///
+/// Cross-project edges between hand-written local projects are intentionally left to implicit
+/// resolution to preserve existing behavior.
+///
+/// For each cross-project edge `(consumer -> dependency)` this generator adds the following to the
+/// consumer's pbxproj:
 ///
 /// - A `PBXFileReference` to the remote `.xcodeproj` (deduplicated per remote project).
 /// - A `PBXProject.projects` entry pairing that reference with an (empty) Products `PBXGroup`.
 /// - A `PBXContainerItemProxy` with `proxyType = .nativeTarget`,
 ///   `containerPortal = .fileReference(<remote .xcodeproj ref>)`, and
-///   `remoteGlobalID = .object(<remote aggregate>)`.
+///   `remoteGlobalID = .object(<remote target>)`.
 /// - A `PBXTargetDependency` wrapping the proxy, appended to the consumer target's
 ///   `dependencies`.
 ///
 /// XcodeProj's `ReferenceGenerator` assigns deterministic UUIDs lazily at encode time. The
 /// consumer pbxproj serializes the proxy's `remoteGlobalIDString` from the remote target's
-/// reference value, so we eagerly encode each aggregate-bearing pbxproj once up front to fix
+/// reference value, so we eagerly encode each dependency-bearing pbxproj once up front to fix
 /// its UUIDs. When the writer later writes the consumer pbxproj, the proxy resolves to the
 /// stable remote UUID instead of the temporary placeholder.
-protocol ForeignBuildCrossProjectDependencyGenerating {
+protocol CrossProjectDependencyGenerating {
     func generate(
         graphTraverser: GraphTraversing,
         projectDescriptors: [ProjectDescriptor]
     ) throws
 }
 
-struct ForeignBuildCrossProjectDependencyGenerator: ForeignBuildCrossProjectDependencyGenerating {
+struct CrossProjectDependencyGenerator: CrossProjectDependencyGenerating {
     func generate(
         graphTraverser: GraphTraversing,
         projectDescriptors: [ProjectDescriptor]
@@ -45,8 +59,8 @@ struct ForeignBuildCrossProjectDependencyGenerator: ForeignBuildCrossProjectDepe
         let edges = collectEdges(graphTraverser: graphTraverser)
         guard !edges.isEmpty else { return }
 
-        let aggregateProjectPaths = Set(edges.map(\.aggregateProjectPath))
-        for path in aggregateProjectPaths.sorted() {
+        let dependencyProjectPaths = Set(edges.map(\.dependencyProjectPath))
+        for path in dependencyProjectPaths.sorted() {
             guard let descriptor = descriptorsByPath[path] else { continue }
             _ = try descriptor.xcodeProj.pbxproj.dataRepresentation(outputSettings: PBXOutputSettings())
         }
@@ -65,8 +79,8 @@ struct ForeignBuildCrossProjectDependencyGenerator: ForeignBuildCrossProjectDepe
     private struct Edge: Hashable {
         let consumerProjectPath: AbsolutePath
         let consumerTargetName: String
-        let aggregateProjectPath: AbsolutePath
-        let aggregateTargetName: String
+        let dependencyProjectPath: AbsolutePath
+        let dependencyTargetName: String
         let condition: PlatformCondition?
     }
 
@@ -82,21 +96,31 @@ struct ForeignBuildCrossProjectDependencyGenerator: ForeignBuildCrossProjectDepe
                 guard target.foreignBuild == nil else { continue }
                 for reference in graphTraverser.directTargetDependencies(path: consumerPath, name: target.name) {
                     guard reference.graphTarget.path != consumerPath else { continue }
-                    guard reference.graphTarget.target.foreignBuild != nil else { continue }
+                    guard shouldWireCrossProjectDependency(to: reference.graphTarget) else { continue }
                     edges.insert(Edge(
                         consumerProjectPath: consumerPath,
                         consumerTargetName: target.name,
-                        aggregateProjectPath: reference.graphTarget.path,
-                        aggregateTargetName: reference.graphTarget.target.name,
+                        dependencyProjectPath: reference.graphTarget.path,
+                        dependencyTargetName: reference.graphTarget.target.name,
                         condition: reference.condition
                     ))
                 }
             }
         }
         return edges.sorted { lhs, rhs in
-            (lhs.consumerProjectPath, lhs.consumerTargetName, lhs.aggregateProjectPath, lhs.aggregateTargetName)
-                < (rhs.consumerProjectPath, rhs.consumerTargetName, rhs.aggregateProjectPath, rhs.aggregateTargetName)
+            (lhs.consumerProjectPath, lhs.consumerTargetName, lhs.dependencyProjectPath, lhs.dependencyTargetName)
+                < (rhs.consumerProjectPath, rhs.consumerTargetName, rhs.dependencyProjectPath, rhs.dependencyTargetName)
         }
+    }
+
+    /// Whether a cross-project dependency on the given target should be wired explicitly. We only
+    /// wire dependencies on generated SPM package projects (external) and `foreignBuild()`
+    /// aggregates; cross-project edges between hand-written local projects keep relying on Xcode's
+    /// implicit dependency resolution.
+    private func shouldWireCrossProjectDependency(to graphTarget: GraphTarget) -> Bool {
+        if graphTarget.target.foreignBuild != nil { return true }
+        if case .external = graphTarget.project.type { return true }
+        return false
     }
 
     private func wire(
@@ -106,7 +130,7 @@ struct ForeignBuildCrossProjectDependencyGenerator: ForeignBuildCrossProjectDepe
         fileRefCache: inout [FileRefKey: PBXFileReference]
     ) throws {
         guard let consumerDescriptor = descriptorsByPath[edge.consumerProjectPath],
-              let aggregateDescriptor = descriptorsByPath[edge.aggregateProjectPath],
+              let dependencyDescriptor = descriptorsByPath[edge.dependencyProjectPath],
               let consumerXcodeGraphTarget = graphTraverser.target(
                   path: edge.consumerProjectPath,
                   name: edge.consumerTargetName
@@ -114,29 +138,29 @@ struct ForeignBuildCrossProjectDependencyGenerator: ForeignBuildCrossProjectDepe
         else { return }
 
         let consumerPbxproj = consumerDescriptor.xcodeProj.pbxproj
-        let aggregatePbxproj = aggregateDescriptor.xcodeProj.pbxproj
+        let dependencyPbxproj = dependencyDescriptor.xcodeProj.pbxproj
 
         guard let consumerProject = consumerPbxproj.projects.first,
               let consumerTarget = consumerPbxproj.nativeTargets
               .first(where: { $0.name == edge.consumerTargetName }),
-              let aggregateTarget = aggregateTarget(named: edge.aggregateTargetName, in: aggregatePbxproj)
+              let remoteTarget = remoteTarget(named: edge.dependencyTargetName, in: dependencyPbxproj)
         else { return }
 
         let remoteProjectRef = remoteProjectFileReference(
             consumerProject: consumerProject,
             consumerPbxproj: consumerPbxproj,
             consumerXcodeprojDirectory: consumerDescriptor.xcodeprojPath.parentDirectory,
-            remoteXcodeprojPath: aggregateDescriptor.xcodeprojPath,
+            remoteXcodeprojPath: dependencyDescriptor.xcodeprojPath,
             cacheKey: FileRefKey(
                 consumerProjectPath: edge.consumerProjectPath,
-                remoteXcodeprojPath: aggregateDescriptor.xcodeprojPath
+                remoteXcodeprojPath: dependencyDescriptor.xcodeprojPath
             ),
             cache: &fileRefCache
         )
 
         if consumerTarget.dependencies.contains(where: { dependency in
             guard let proxy = dependency.targetProxy else { return false }
-            return proxy.remoteInfo == edge.aggregateTargetName
+            return proxy.remoteInfo == edge.dependencyTargetName
                 && proxy.containerPortal == .fileReference(remoteProjectRef)
         }) {
             return
@@ -144,19 +168,19 @@ struct ForeignBuildCrossProjectDependencyGenerator: ForeignBuildCrossProjectDepe
 
         let proxy = PBXContainerItemProxy(
             containerPortal: .fileReference(remoteProjectRef),
-            remoteGlobalID: .object(aggregateTarget),
+            remoteGlobalID: .object(remoteTarget),
             proxyType: .nativeTarget,
-            remoteInfo: edge.aggregateTargetName
+            remoteInfo: edge.dependencyTargetName
         )
         consumerPbxproj.add(object: proxy)
 
-        let dependency = PBXTargetDependency(name: edge.aggregateTargetName, targetProxy: proxy)
+        let dependency = PBXTargetDependency(name: edge.dependencyTargetName, targetProxy: proxy)
         dependency.applyCondition(edge.condition, applicableTo: consumerXcodeGraphTarget)
         consumerPbxproj.add(object: dependency)
         consumerTarget.dependencies.append(dependency)
     }
 
-    private func aggregateTarget(named name: String, in pbxproj: PBXProj) -> PBXTarget? {
+    private func remoteTarget(named name: String, in pbxproj: PBXProj) -> PBXTarget? {
         if let native = pbxproj.nativeTargets.first(where: { $0.name == name }) {
             return native
         }

--- a/cli/Sources/TuistGenerator/Generator/WorkspaceDescriptorGenerator.swift
+++ b/cli/Sources/TuistGenerator/Generator/WorkspaceDescriptorGenerator.swift
@@ -49,7 +49,7 @@ struct WorkspaceDescriptorGenerator: WorkspaceDescriptorGenerating {
     private let workspaceStructureGenerator: WorkspaceStructureGenerating
     private let schemeDescriptorsGenerator: SchemeDescriptorsGenerating
     private let workspaceSettingsGenerator: WorkspaceSettingsDescriptorGenerating
-    private let foreignBuildCrossProjectDependencyGenerator: ForeignBuildCrossProjectDependencyGenerating
+    private let crossProjectDependencyGenerator: CrossProjectDependencyGenerating
     private let fileSystem: FileSysteming
     private let config: Config
 
@@ -71,7 +71,7 @@ struct WorkspaceDescriptorGenerator: WorkspaceDescriptorGenerating {
             workspaceStructureGenerator: WorkspaceStructureGenerator(),
             schemeDescriptorsGenerator: SchemeDescriptorsGenerator(),
             workspaceSettingsGenerator: WorkspaceSettingsDescriptorGenerator(),
-            foreignBuildCrossProjectDependencyGenerator: ForeignBuildCrossProjectDependencyGenerator(),
+            crossProjectDependencyGenerator: CrossProjectDependencyGenerator(),
             config: config,
             fileSystem: fileSystem
         )
@@ -82,8 +82,8 @@ struct WorkspaceDescriptorGenerator: WorkspaceDescriptorGenerating {
         workspaceStructureGenerator: WorkspaceStructureGenerating,
         schemeDescriptorsGenerator: SchemeDescriptorsGenerating,
         workspaceSettingsGenerator: WorkspaceSettingsDescriptorGenerating,
-        foreignBuildCrossProjectDependencyGenerator: ForeignBuildCrossProjectDependencyGenerating =
-            ForeignBuildCrossProjectDependencyGenerator(),
+        crossProjectDependencyGenerator: CrossProjectDependencyGenerating =
+            CrossProjectDependencyGenerator(),
         config: Config = .default,
         fileSystem: FileSysteming = FileSystem()
     ) {
@@ -91,7 +91,7 @@ struct WorkspaceDescriptorGenerator: WorkspaceDescriptorGenerating {
         self.workspaceStructureGenerator = workspaceStructureGenerator
         self.schemeDescriptorsGenerator = schemeDescriptorsGenerator
         self.workspaceSettingsGenerator = workspaceSettingsGenerator
-        self.foreignBuildCrossProjectDependencyGenerator = foreignBuildCrossProjectDependencyGenerator
+        self.crossProjectDependencyGenerator = crossProjectDependencyGenerator
         self.fileSystem = fileSystem
         self.config = config
     }
@@ -118,8 +118,8 @@ struct WorkspaceDescriptorGenerator: WorkspaceDescriptorGenerating {
             .sorted(by: { $0.path < $1.path })
         Logger.current.debug("Finished concurrent generation of \(projects.count) projects")
 
-        Logger.current.debug("Wiring cross-project foreign build dependencies")
-        try foreignBuildCrossProjectDependencyGenerator.generate(
+        Logger.current.debug("Wiring cross-project target dependencies")
+        try crossProjectDependencyGenerator.generate(
             graphTraverser: graphTraverser,
             projectDescriptors: projects
         )

--- a/cli/Tests/TuistGeneratorTests/Generator/CrossProjectDependencyGeneratorTests.swift
+++ b/cli/Tests/TuistGeneratorTests/Generator/CrossProjectDependencyGeneratorTests.swift
@@ -6,8 +6,8 @@ import XcodeGraph
 import XcodeProj
 @testable import TuistGenerator
 
-struct ForeignBuildCrossProjectDependencyGeneratorTests {
-    private let subject = ForeignBuildCrossProjectDependencyGenerator()
+struct CrossProjectDependencyGeneratorTests {
+    private let subject = CrossProjectDependencyGenerator()
 
     @Test func generate_wiresCrossProjectDependencyOnConsumer() async throws {
         let consumerPath = try AbsolutePath(validating: "/Workspace/Consumer")
@@ -94,6 +94,99 @@ struct ForeignBuildCrossProjectDependencyGeneratorTests {
         )
         #expect(productsGroup.name == "Products")
         #expect(consumerPbxProject.mainGroup.children.contains(remoteRef))
+    }
+
+    @Test func generate_wiresCrossPackageProductDependency() async throws {
+        // Two SPM packages generated as separate external projects: package B links a product of
+        // package A. Without an explicit cross-project PBXTargetDependency the build description has
+        // no ordering edge and warm cached builds race on the missing .swiftmodule.
+        let packageAPath = try AbsolutePath(validating: "/Workspace/.build/checkouts/PackageA")
+        let packageBPath = try AbsolutePath(validating: "/Workspace/.build/checkouts/PackageB")
+
+        let libraryA = Target.test(name: "LibraryA", product: .framework)
+        let libraryB = Target.test(
+            name: "LibraryB",
+            product: .framework,
+            dependencies: [.project(target: "LibraryA", path: packageAPath)]
+        )
+        let packageAModel = Project.test(path: packageAPath, targets: [libraryA], type: .external(hash: "a"))
+        let packageBModel = Project.test(path: packageBPath, targets: [libraryB], type: .external(hash: "b"))
+        let graph = Graph.test(
+            projects: [
+                packageAPath: packageAModel,
+                packageBPath: packageBModel,
+            ],
+            dependencies: [
+                .target(name: "LibraryB", path: packageBPath):
+                    Set([.target(name: "LibraryA", path: packageAPath)]),
+            ]
+        )
+
+        let packageADescriptor = makeDescriptor(path: packageAPath, nativeTargets: ["LibraryA"])
+        let packageBDescriptor = makeDescriptor(path: packageBPath, nativeTargets: ["LibraryB"])
+
+        try subject.generate(
+            graphTraverser: GraphTraverser(graph: graph),
+            projectDescriptors: [packageADescriptor, packageBDescriptor]
+        )
+
+        let consumerPbxproj = packageBDescriptor.xcodeProj.pbxproj
+        let consumerTarget = try #require(consumerPbxproj.nativeTargets.first(where: { $0.name == "LibraryB" }))
+        let dependency = try #require(consumerTarget.dependencies.first)
+        let proxy = try #require(dependency.targetProxy)
+
+        #expect(dependency.name == "LibraryA")
+        #expect(proxy.proxyType == .nativeTarget)
+        #expect(proxy.remoteInfo == "LibraryA")
+
+        let remoteTarget = try #require(
+            packageADescriptor.xcodeProj.pbxproj.nativeTargets.first(where: { $0.name == "LibraryA" })
+        )
+        guard case let .object(remoteObject) = proxy.remoteGlobalID else {
+            Issue.record("Expected remoteGlobalID to point at the remote target object")
+            return
+        }
+        #expect(remoteObject.uuid == remoteTarget.uuid)
+        #expect(!remoteTarget.uuid.hasPrefix("TEMP_"))
+    }
+
+    @Test func generate_skipsLocalCrossProjectDependency() async throws {
+        // Cross-project edges between hand-written local projects keep relying on Xcode implicit
+        // dependency resolution; only package (external) product edges are wired explicitly.
+        let appPath = try AbsolutePath(validating: "/Workspace/App")
+        let featurePath = try AbsolutePath(validating: "/Workspace/Feature")
+
+        let feature = Target.test(name: "Feature", product: .framework)
+        let app = Target.test(
+            name: "App",
+            dependencies: [.project(target: "Feature", path: featurePath)]
+        )
+        let appModel = Project.test(path: appPath, targets: [app], type: .local)
+        let featureModel = Project.test(path: featurePath, targets: [feature], type: .local)
+        let graph = Graph.test(
+            projects: [
+                appPath: appModel,
+                featurePath: featureModel,
+            ],
+            dependencies: [
+                .target(name: "App", path: appPath):
+                    Set([.target(name: "Feature", path: featurePath)]),
+            ]
+        )
+
+        let appDescriptor = makeDescriptor(path: appPath, nativeTargets: ["App"])
+        let featureDescriptor = makeDescriptor(path: featurePath, nativeTargets: ["Feature"])
+
+        try subject.generate(
+            graphTraverser: GraphTraverser(graph: graph),
+            projectDescriptors: [appDescriptor, featureDescriptor]
+        )
+
+        let appTarget = try #require(
+            appDescriptor.xcodeProj.pbxproj.nativeTargets.first(where: { $0.name == "App" })
+        )
+        #expect(appTarget.dependencies.isEmpty)
+        #expect(appDescriptor.xcodeProj.pbxproj.projects.first?.projects.isEmpty == true)
     }
 
     @Test func generate_dedupesFileReferenceWhenMultipleConsumersShareAggregate() async throws {


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/11770

### What changed

Generation now emits explicit cross-project `PBXTargetDependency` edges when a target links a product of another generated SPM **package (external)** project. The existing `ForeignBuildCrossProjectDependencyGenerator` — the only code that ever wired cross-project container proxies — is generalized into `CrossProjectDependencyGenerator`; `foreignBuild()` aggregate handling is preserved as a subset.

### Why it changed / root cause

Tuist generates each SPM package as its own `.xcodeproj`. `TargetGenerator.generateTargetDependencies` only wires `PBXTargetDependency` for **same-project** dependencies (`GraphTraverser.directLocalTargetDependencies`, filtered by `$0.path == path`). A target in package B that depends on a product of package A was left entirely to Xcode's implicit dependency discovery (product-name matching across the shared build products dir), so the build description swift-build/llbuild derives had **zero** ordering edges between package projects.

That ordering was only correct by accident. On a cold build compilation is slow and wide, so upstream products tend to exist by the time downstream planning looks for them. On a **warm compilation-cache build** the timing collapses: replayed tasks finish near-instantly and a downstream target's dependency scan can run before the upstream package's `.swiftmodule` exists on disk, surfacing as `unable to resolve module dependency`. This was hit directly while evaluating swift-build's remote-cache machinery in #11768. The CAS plugin's read-through masks it (scan tasks get answers from the cache), but any timing shift can expose it again.

### Why this solution

The cross-project `PBXContainerItemProxy` + `PBXTargetDependency` machinery already existed and was correct; it was just gated to `foreignBuild()` aggregates. Generalizing it (rather than adding a parallel path) reuses the UUID-stabilization logic that eagerly encodes each dependency-bearing pbxproj so the consumer's proxy resolves to a stable remote UUID instead of a `TEMP_` placeholder.

Scope is deliberately limited to dependencies on **external** (SPM package) projects plus `foreignBuild()` aggregates. Cross-project edges between hand-written **local** projects keep relying on Xcode's implicit resolution, preserving existing behavior and avoiding churn to unrelated generated project structure.

### User/developer impact

Warm cached builds of workspaces with cross-package product dependencies no longer race on missing `.swiftmodule`s; the build description carries real ordering constraints instead of relying on implicit product-name resolution.

### How to test locally

Unit tests:

```
tuist generate TuistGenerator TuistGeneratorTests --no-open
xcodebuild test -workspace Tuist.xcworkspace -scheme Tuist-Workspace \
  -only-testing "TuistGeneratorTests/CrossProjectDependencyGeneratorTests" \
  CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""
```

New coverage: `generate_wiresCrossPackageProductDependency` (external package B → product of package A wires an explicit edge) and `generate_skipsLocalCrossProjectDependency` (local↔local stays implicit). All existing foreignBuild cases still pass.

End-to-end: build the `tuist` scheme, regenerate the CLI workspace, and inspect a package project:

```
grep -c "isa = PBXTargetDependency" \
  .build/registry/downloads/apple/swift-nio-ssl/2.37.0/swift-nio-ssl.xcodeproj/project.pbxproj
```

Before this change: `swift-nio-ssl.xcodeproj` had no cross-project edges. After: 8 explicit `PBXTargetDependency` edges (proxyType nativeTarget) to `swift-nio.xcodeproj` targets (NIO, NIOCore, CNIOBoringSSL, …) with stabilized remote UUIDs.

### Validation run

- All 335 `TuistGeneratorTests` pass (incl. the new external-package case and the local-stays-implicit guard).
- End-to-end regeneration of the Tuist CLI workspace confirmed the 8 new cross-project edges above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)