### PR TITLE
fix(infra): tart-kubelet GC must not reap a running VM (golden or orphan)

### DIFF
--- a/infra/tart-kubelet/internal/podagent/garbage.go
+++ b/infra/tart-kubelet/internal/podagent/garbage.go
@@ -60,6 +60,12 @@ type Collector struct {
 	// Now is overridable in tests; defaults to time.Now.
 	Now func() time.Time
 
+	// IsRunning probes whether a VM has a live `tart run` process, gating
+	// every reap so an in-use VM is never deleted mid-session. Overridable
+	// in tests (pgrep isn't stubbable via the Tart binary); defaults to
+	// Tart.IsRunning.
+	IsRunning func(ctx context.Context, name string) (bool, error)
+
 	mu sync.Mutex
 
 	// goldenSeen tracks the last time each golden base VM was seen
@@ -140,6 +146,10 @@ func (c *Collector) runOnce(ctx context.Context, aggressive bool) {
 				if c.keepGolden(vm.Name, expected, now, retention, aggressive) {
 					continue
 				}
+				if c.live(ctx, vm.Name) {
+					logger.Info("spared golden base: a tart run process is live", "name", vm.Name)
+					continue
+				}
 				if err := c.Tart.Delete(ctx, vm.Name); err != nil {
 					logger.Error(err, "delete stale golden base", "name", vm.Name)
 					continue
@@ -149,6 +159,10 @@ func (c *Collector) runOnce(ctx context.Context, aggressive bool) {
 				continue
 			}
 			if _, want := expected.vms[vm.Name]; want {
+				continue
+			}
+			if c.live(ctx, vm.Name) {
+				logger.Info("spared orphan VM: a tart run process is live", "name", vm.Name)
 				continue
 			}
 			if err := c.Tart.Delete(ctx, vm.Name); err != nil {
@@ -228,6 +242,27 @@ func (c *Collector) now() time.Time {
 		return c.Now()
 	}
 	return time.Now()
+}
+
+// live reports whether a VM must be spared this pass because a `tart run`
+// process is currently executing for it. A probe error counts as live
+// (fail-safe): deleting a VM that might be running is the harmful outcome,
+// so an unreadable liveness signal skips the reap and lets the next pass
+// retry — matching the reconciler, which treats an IsRunning error as
+// "assume alive." Golden bases are meant to be inert copy-on-write sources
+// that are never run in production, but the GC must not bank on that: a
+// benchmark or operator that boots one directly must not have it deleted
+// out from under a live session.
+func (c *Collector) live(ctx context.Context, name string) bool {
+	probe := c.IsRunning
+	if probe == nil {
+		probe = c.Tart.IsRunning
+	}
+	running, err := probe(ctx, name)
+	if err != nil {
+		return true
+	}
+	return running
 }
 
 // IsNoSpaceError matches the stderr signature Tart returns when a

--- a/infra/tart-kubelet/internal/podagent/garbage_test.go
+++ b/infra/tart-kubelet/internal/podagent/garbage_test.go
@@ -1,8 +1,21 @@
 package podagent
 
 import (
+	"context"
 	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/tuist/tuist/infra/tart-kubelet/internal/tart"
 )
 
 func TestIsNoSpaceError(t *testing.T) {
@@ -43,4 +56,95 @@ func TestIsNoSpaceError(t *testing.T) {
 			}
 		})
 	}
+}
+
+// A golden base with no backing Pod and past its retention window is a
+// reap candidate — but only if it isn't currently running. On the staging
+// host-Kura mini a golden was booted directly (launchd, serving
+// benchmarks); with no liveness guard the GC killed it mid-session. These
+// cases pin that the reap consults IsRunning before deleting.
+func TestRunOnceSparesRunningVMs(t *testing.T) {
+	const golden = goldenBaseVMPrefix + "deadbeef"
+	const node = "mini-1"
+	const retention = time.Hour
+	now := time.Date(2026, 7, 9, 12, 0, 0, 0, time.UTC)
+
+	newCollector := func(t *testing.T, isRunning func(context.Context, string) (bool, error)) (*Collector, string) {
+		t.Helper()
+		dir := t.TempDir()
+		deletes := filepath.Join(dir, "deletes.txt")
+		bin := filepath.Join(dir, "faketart")
+		// `list` reports one stopped local golden; `delete` records the
+		// name so the test can assert whether the reap fired.
+		body := fmt.Sprintf("#!/bin/sh\n"+
+			"if [ \"$1\" = \"list\" ]; then\n"+
+			"  printf '%%s' '[{\"Name\":\"%s\",\"Source\":\"local\",\"State\":\"stopped\",\"CPU\":4,\"Memory\":8192,\"Size\":72}]'\n"+
+			"elif [ \"$1\" = \"delete\" ]; then\n"+
+			"  printf '%%s\\n' \"$2\" >> %q\n"+
+			"fi\n", golden, deletes)
+		if err := os.WriteFile(bin, []byte(body), 0o755); err != nil {
+			t.Fatal(err)
+		}
+
+		scheme := runtime.NewScheme()
+		if err := corev1.AddToScheme(scheme); err != nil {
+			t.Fatalf("add core scheme: %v", err)
+		}
+		// No Pods scheduled here, so the golden is unreferenced.
+		k := fake.NewClientBuilder().WithScheme(scheme).
+			WithIndex(&corev1.Pod{}, "spec.nodeName", func(o client.Object) []string {
+				return []string{o.(*corev1.Pod).Spec.NodeName}
+			}).Build()
+
+		c := &Collector{
+			K8s:             k,
+			Tart:            &tart.Client{Binary: bin},
+			NodeName:        node,
+			GoldenRetention: retention,
+			Now:             func() time.Time { return now },
+			IsRunning:       isRunning,
+			// Last seen unreferenced 2h ago (retention 1h): absent the
+			// liveness guard, this golden reaps.
+			goldenSeen: map[string]time.Time{golden: now.Add(-2 * retention)},
+		}
+		return c, deletes
+	}
+
+	deleted := func(t *testing.T, deletes string) bool {
+		t.Helper()
+		b, err := os.ReadFile(deletes)
+		if errors.Is(err, os.ErrNotExist) {
+			return false
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		return strings.Contains(string(b), golden)
+	}
+
+	t.Run("running golden past retention is spared", func(t *testing.T) {
+		c, deletes := newCollector(t, func(context.Context, string) (bool, error) { return true, nil })
+		c.RunOnce(context.Background())
+		if deleted(t, deletes) {
+			t.Fatal("running golden past retention was deleted")
+		}
+	})
+
+	t.Run("stopped golden past retention is reaped", func(t *testing.T) {
+		c, deletes := newCollector(t, func(context.Context, string) (bool, error) { return false, nil })
+		c.RunOnce(context.Background())
+		if !deleted(t, deletes) {
+			t.Fatal("stopped golden past retention was not reaped")
+		}
+	})
+
+	t.Run("unreadable liveness signal spares the VM (fail-safe)", func(t *testing.T) {
+		c, deletes := newCollector(t, func(context.Context, string) (bool, error) {
+			return false, errors.New("pgrep boom")
+		})
+		c.RunOnce(context.Background())
+		if deleted(t, deletes) {
+			t.Fatal("golden was reaped despite an unreadable liveness signal")
+		}
+	})
 }

--- a/infra/tart-kubelet/internal/podagent/garbage_test.go
+++ b/infra/tart-kubelet/internal/podagent/garbage_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -147,4 +148,86 @@ func TestRunOnceSparesRunningVMs(t *testing.T) {
 			t.Fatal("golden was reaped despite an unreadable liveness signal")
 		}
 	})
+}
+
+// End-to-end regression for the substring liveness bug at the orphan
+// branch, exercising the real Tart.IsRunning (no override). A stopped
+// orphan `X` must be reaped even while a differently-named `X-2` runs —
+// before IsRunning anchored the name, pgrep's substring match reported `X`
+// live off the `X-2` process and the GC skipped it every pass. Both names
+// are valid VMNameForPod outputs.
+func TestRunOnceReapsOrphanDespiteSimilarlyNamedRunningVM(t *testing.T) {
+	if _, err := exec.LookPath("pgrep"); err != nil {
+		t.Skip("pgrep not available on this host")
+	}
+
+	const orphan = "tuist-runners-runner-team-job"
+	const running = orphan + "-2"
+	const node = "mini-1"
+
+	dir := t.TempDir()
+	deletes := filepath.Join(dir, "deletes.txt")
+	bin := filepath.Join(dir, "faketart")
+	body := fmt.Sprintf("#!/bin/sh\n"+
+		"if [ \"$1\" = \"list\" ]; then\n"+
+		"  printf '%%s' '[{\"Name\":\"%s\",\"Source\":\"local\",\"State\":\"running\",\"CPU\":4,\"Memory\":8192,\"Size\":72}]'\n"+
+		"elif [ \"$1\" = \"delete\" ]; then\n"+
+		"  printf '%%s\\n' \"$2\" >> %q\n"+
+		"fi\n", orphan, deletes)
+	if err := os.WriteFile(bin, []byte(body), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// A live `tart run <orphan>-2` decoy. The compound `-c` body keeps sh
+	// from exec-replacing itself, so the argv survives for pgrep to read.
+	decoyCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	decoy := exec.CommandContext(decoyCtx, "/bin/sh", "-c", "sleep 30; :", "tart", "run", running)
+	if err := decoy.Start(); err != nil {
+		t.Fatalf("start decoy: %v", err)
+	}
+	defer func() {
+		cancel()
+		_ = decoy.Wait()
+	}()
+
+	tartClient := &tart.Client{Binary: bin, UserDataDir: dir}
+	// Wait until the decoy is visible so the test can't pass just because
+	// pgrep hasn't caught up to the process yet.
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		isUp, err := tartClient.IsRunning(context.Background(), running)
+		if err != nil {
+			t.Fatalf("IsRunning(%q): %v", running, err)
+		}
+		if isUp {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("decoy never became visible to pgrep")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add core scheme: %v", err)
+	}
+	// No Pods scheduled here, so the orphan is unreferenced.
+	k := fake.NewClientBuilder().WithScheme(scheme).
+		WithIndex(&corev1.Pod{}, "spec.nodeName", func(o client.Object) []string {
+			return []string{o.(*corev1.Pod).Spec.NodeName}
+		}).Build()
+
+	// IsRunning left nil so live() uses the real Tart.IsRunning.
+	c := &Collector{K8s: k, Tart: tartClient, NodeName: node}
+	c.RunOnce(context.Background())
+
+	b, err := os.ReadFile(deletes)
+	if err != nil {
+		t.Fatalf("read deletes: %v", err)
+	}
+	if !strings.Contains(string(b), orphan) {
+		t.Fatalf("orphan %q was not reaped despite only %q running", orphan, running)
+	}
 }

--- a/infra/tart-kubelet/internal/tart/tart.go
+++ b/infra/tart-kubelet/internal/tart/tart.go
@@ -577,15 +577,25 @@ func parseDFCapacityPercent(out []byte) (int, error) {
 // pgrep against the actual command line is the only reading that
 // flips the moment the VM exits.
 //
+// The name is anchored to an argument boundary: pgrep -f does an
+// unanchored regex match over the whole command line, so a bare
+// `tart run <name>` query would also match a running `tart run <name>-2`
+// (both are valid VMNameForPod outputs) — reporting a stopped VM as live
+// and, in the GC, keeping its disk pinned forever. A running VM's command
+// line is `tart run <name>[ <flags>…]`, so the name is followed by
+// end-of-line or a space; `($| )` pins exactly that. QuoteMeta keeps a
+// name containing a regex metacharacter (e.g. a '.') literal.
+//
 // Returns false (no error) when no matching process exists; returns
 // an error only on unexpected pgrep failures.
 func (c *Client) IsRunning(ctx context.Context, name string) (bool, error) {
-	cmd := exec.CommandContext(ctx, "pgrep", "-f", fmt.Sprintf("tart run %s", name))
+	pattern := fmt.Sprintf(`tart run %s($| )`, regexp.QuoteMeta(name))
+	cmd := exec.CommandContext(ctx, "pgrep", "-f", pattern)
 	if err := cmd.Run(); err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 1 {
 			return false, nil
 		}
-		return false, fmt.Errorf("pgrep tart run %s: %w", name, err)
+		return false, fmt.Errorf("pgrep %q: %w", pattern, err)
 	}
 	return true, nil
 }

--- a/infra/tart-kubelet/internal/tart/tart_test.go
+++ b/infra/tart-kubelet/internal/tart/tart_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -108,6 +109,64 @@ func TestCleanupVMUserData(t *testing.T) {
 	}
 	if _, err := os.Stat(target); !os.IsNotExist(err) {
 		t.Fatalf("expected target removed, got err=%v", err)
+	}
+}
+
+// Regression for the substring liveness bug: pgrep -f matches over the
+// whole command line, so an unanchored `tart run <name>` query would also
+// match a running `tart run <name>-2` — reporting a stopped VM as live and,
+// in the GC, pinning its disk forever. Both names are valid VMNameForPod
+// outputs. IsRunning must anchor the name to an argument boundary.
+func TestIsRunningRequiresExactNameBoundary(t *testing.T) {
+	if _, err := exec.LookPath("pgrep"); err != nil {
+		t.Skip("pgrep not available on this host")
+	}
+
+	const base = "tuist-runners-runner-team-job"
+	const longer = base + "-2"
+
+	decoyCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	// Command line: `/bin/sh -c 'sleep 30; :' tart run <longer>`. The
+	// compound `-c` body keeps sh from exec-replacing itself with `sleep`,
+	// so the `tart run …` argv survives for pgrep to read.
+	decoy := exec.CommandContext(decoyCtx, "/bin/sh", "-c", "sleep 30; :", "tart", "run", longer)
+	if err := decoy.Start(); err != nil {
+		t.Fatalf("start decoy: %v", err)
+	}
+	defer func() {
+		cancel()
+		_ = decoy.Wait()
+	}()
+
+	c := &Client{}
+	ctx := context.Background()
+
+	// Wait until the decoy is visible to pgrep — this also asserts the
+	// exact longer name is correctly found (the positive boundary case).
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		running, err := c.IsRunning(ctx, longer)
+		if err != nil {
+			t.Fatalf("IsRunning(%q): %v", longer, err)
+		}
+		if running {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("decoy %q never became visible to pgrep", longer)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	// The core regression: the shorter name must NOT match the running
+	// longer-named process.
+	running, err := c.IsRunning(ctx, base)
+	if err != nil {
+		t.Fatalf("IsRunning(%q): %v", base, err)
+	}
+	if running {
+		t.Fatalf("IsRunning(%q) reported live, but only %q is running", base, longer)
 	}
 }
 


### PR DESCRIPTION
## What changed

The tart-kubelet disk garbage collector now consults VM liveness before deleting. A `live()` guard sits in front of **both** `Tart.Delete` sites in `runOnce` — the golden-base branch and the orphan-clone branch — and skips (with a log line) any VM that currently has a `tart run` process.

- A probe error is treated as **live** (fail-safe): deleting a maybe-running VM is the harmful outcome, so an unreadable liveness signal skips the reap and lets the next 5-min pass retry. This mirrors the reconciler, which already treats an `IsRunning` error as "assume Running" to avoid flapping.
- Uses `IsRunning` (pgrep against `tart run <name>`), **not** the `VM.State` field — the codebase already documents `tart list`'s `State` as unreliable for backgrounded VMs (the on-disk state file isn't updated on exit).
- `IsRunning` shells out to `pgrep` rather than the fakeable Tart binary, so a small `IsRunning func` override was added to `Collector` (defaulting to `Tart.IsRunning`), mirroring the existing `Now func` test override. Production wiring in `cmd/tart-kubelet/main.go` leaves it nil and gets the real probe unchanged.

## Why

The GC decided reaps purely from Pod-reference + age. A golden base with no Pod referencing its digest and past `GoldenRetention` (24h) was deleted; a non-golden local VM with no backing Pod was deleted immediately. Neither branch checked whether a VM was actually running.

### Root cause

On the staging host-Kura mini (`m1@62.210.195.110`), `/var/log/tart-kubelet.log` showed the GC delete `tuist-golden-6fdcd0674dda678d` while it was in active use — booted directly by launchd and serving benchmarks — killing it and removing its directory mid-session. That golden had no k8s Pod on the node referencing its digest, so it was absent from the expected set, its in-memory retention clock had elapsed, and `keepGolden` returned "reap". The reconciler's design comment "the golden is never run; it's a stable copy-on-write base" is the assumption that made deletion safe in production. The benchmark harness violates it, and the GC had no defense — process state was simply never an input to the reap decision.

The fix is scoped to point (a) of the review: **never delete a running VM regardless of name**. It also hardens the orphan-clone branch, where a still-running orphan means the reconciler crashed mid-Stop and a hard delete is equally wrong.

## Not in scope (follow-ups from the same review)

- **(b)** Pinning a golden referenced by a pool/warm-pool spec that has no currently-scheduled Pod (the GC reads Pods + Store, not pool specs; today such a golden is protected only by the 24h retention).
- **(c)** A wall-clock min-age floor. Note this would not have prevented the incident — a running golden older than 24h still needs the liveness guard.
- `isNotFound` (in `internal/tart`) matches `"not found"` but not the `"does not exist"` string seen in the staging logs, which is why an absent golden surfaced as a "warm-path probe failed" rather than a clean cold-path miss. Worth reconciling against the deployed tart version separately.

## Validation

- New `TestRunOnceSparesRunningVMs` drives a real `runOnce` against a fake `tart` binary, with the golden seeded past its retention window so it *would* reap absent the guard:
  - running golden → spared
  - stopped golden → reaped
  - probe error → spared (fail-safe)
- `go build ./...`, `go vet ./internal/podagent/`, and `gofmt` clean.
- Full `internal/podagent` suite passes, including the untouched `TestKeepGolden` / `TestExpectedSet` regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)