### PR TITLE
perf(cli,kura): refresh per-key-served entries back into the snapshot view

### DIFF
--- a/cas-plugin/examples/snapshot_probe.rs
+++ b/cas-plugin/examples/snapshot_probe.rs
@@ -1,0 +1,192 @@
+//! Diagnostic probe: publish one brand-new action-cache key and watch whether
+//! the server's snapshot watermark ever advances past it. Splits "re-publish
+//! path ignored" from "scan/reconcile never sees new rows".
+//!
+//! Env: TUIST_CAS_REMOTE_GRPC_URL, TUIST_CAS_TOKEN or
+//! TUIST_CAS_TUIST_BIN(+TUIST_CAS_SERVER_URL), TUIST_CAS_PROJECT.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use tuist_cas_plugin::reapi::{blob_digest, ManifestEntry, Remote, RemoteConfig};
+use tuist_cas_plugin::token::TokenProvider;
+
+fn decode_snapshot_header(bytes: &[u8]) -> Option<(u64, u32, Vec<[u8; 32]>)> {
+    fn take<'a>(bytes: &mut &'a [u8], n: usize) -> Option<&'a [u8]> {
+        if bytes.len() < n {
+            return None;
+        }
+        let (head, tail) = bytes.split_at(n);
+        *bytes = tail;
+        Some(head)
+    }
+    fn take_u32(bytes: &mut &[u8]) -> Option<u32> {
+        Some(u32::from_le_bytes(take(bytes, 4)?.try_into().ok()?))
+    }
+    let mut bytes = bytes;
+    if take(&mut bytes, 4)? != b"TSNP" || take(&mut bytes, 1)? != [2] {
+        return None;
+    }
+    let watermark = u64::from_le_bytes(take(&mut bytes, 8)?.try_into().ok()?);
+    let node_count = take_u32(&mut bytes)?;
+    for _ in 0..node_count {
+        let len = take(&mut bytes, 1)?[0] as usize;
+        take(&mut bytes, len + 32 + 8)?;
+    }
+    let key_count = take_u32(&mut bytes)? as usize;
+    let mut keys = Vec::with_capacity(key_count);
+    for _ in 0..key_count {
+        let action_hash: [u8; 32] = take(&mut bytes, 32)?.try_into().ok()?;
+        let entry_count = take_u32(&mut bytes)? as usize;
+        take(&mut bytes, entry_count * 4)?;
+        keys.push(action_hash);
+    }
+    Some((watermark, node_count, keys))
+}
+
+fn hex(bytes: &[u8]) -> String {
+    bytes.iter().map(|b| format!("{b:02x}")).collect()
+}
+
+fn now_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_millis() as u64
+}
+
+fn main() {
+    let config = RemoteConfig::from_env().expect("TUIST_CAS_REMOTE_GRPC_URL required");
+    let tokens = TokenProvider::from_env();
+    let remote = Remote::new(config, tokens.clone());
+
+    // A unique blob + a unique llcas digest + a unique action key, derived
+    // from the wall clock so re-runs don't collide.
+    let seed = now_ms();
+    let blob_bytes = format!("tuist-snapshot-probe-{seed}").into_bytes();
+    let blob = blob_digest(&blob_bytes);
+    let mut llcas = vec![0u8; 32];
+    llcas[..8].copy_from_slice(&seed.to_le_bytes());
+    let mut action_key = [0xabu8; 32];
+    action_key[..8].copy_from_slice(&seed.to_le_bytes());
+
+    println!("probe action key: {}", hex(&action_key));
+    println!(
+        "probe blob:       {} ({} bytes)",
+        blob.hash,
+        blob_bytes.len()
+    );
+
+    remote
+        .batch_update(vec![(blob.clone(), blob_bytes)])
+        .expect("blob upload failed");
+    println!("[{}] blob uploaded", now_ms());
+
+    let manifest = [ManifestEntry {
+        llcas_digest: llcas,
+        blob,
+        contents: None,
+    }];
+    // Taken BEFORE the call: the server stamps the entry with its own clock
+    // during the RPC, so a post-call timestamp runs a few ms ahead of the
+    // stored version and turns the watermark comparison into a false negative.
+    let published_at = now_ms();
+    remote
+        .update_action(&action_key, &manifest)
+        .expect("update_action failed");
+    println!("[{published_at}] action result published");
+
+    match remote.get_action(&action_key) {
+        Ok(Some(entries)) => println!("per-key readback: HIT ({} entries)", entries.len()),
+        Ok(None) => println!("per-key readback: MISS (!!)"),
+        Err(error) => println!("per-key readback: ERROR {error}"),
+    }
+
+    // Phase 1: poll the full snapshot until the fresh key's publish is
+    // reflected. Every serve kicks the server's background reconcile (60s
+    // interval), so within 2-3 polls a healthy index must advance the
+    // watermark past the publish.
+    if !(0..10).any(|round| {
+        std::thread::sleep(Duration::from_secs(45));
+        poll(&remote, &tokens, round, published_at)
+    }) {
+        println!("PROBE RESULT: fresh key NEVER became snapshot-visible");
+        return;
+    }
+    println!("PROBE RESULT: fresh key became snapshot-visible");
+
+    // Phase 2: RE-publish the same key with DIFFERENT content (the failing
+    // production case was existing keys whose value graphs changed) and
+    // watch whether the watermark advances past the second publish too.
+    let blob2_bytes = format!("tuist-snapshot-probe-repub-{seed}").into_bytes();
+    let blob2 = blob_digest(&blob2_bytes);
+    remote
+        .batch_update(vec![(blob2.clone(), blob2_bytes)])
+        .expect("second blob upload failed");
+    let mut llcas2 = vec![1u8; 32];
+    llcas2[..8].copy_from_slice(&seed.to_le_bytes());
+    let manifest2 = [ManifestEntry {
+        llcas_digest: llcas2,
+        blob: blob2,
+        contents: None,
+    }];
+    let republished_at = now_ms();
+    remote
+        .update_action(&action_key, &manifest2)
+        .expect("re-publish failed");
+    println!("[{republished_at}] action result RE-published (same key, new content)");
+    if (0..10).any(|round| {
+        std::thread::sleep(Duration::from_secs(45));
+        poll(&remote, &tokens, round, republished_at)
+    }) {
+        println!("PROBE RESULT: re-publish became snapshot-visible");
+    } else {
+        println!(
+            "PROBE RESULT: re-publish NEVER became snapshot-visible (frozen watermark reproduced)"
+        );
+    }
+}
+
+/// One snapshot poll: prints the view's shape and returns whether its
+/// watermark has advanced past `published_at`.
+fn poll(
+    remote: &std::sync::Arc<Remote>,
+    tokens: &std::sync::Arc<TokenProvider>,
+    round: usize,
+    published_at: u64,
+) -> bool {
+    tokens.refresh_if_expiring(Duration::from_secs(120));
+    match remote.get_snapshot(None) {
+        Ok(Some(bytes)) => match decode_snapshot_header(&bytes) {
+            Some((watermark, nodes, keys)) => {
+                println!(
+                    "[{}] round {round}: snapshot {} bytes, {} keys, {nodes} nodes, watermark {watermark} ({})",
+                    now_ms(),
+                    bytes.len(),
+                    keys.len(),
+                    if watermark >= published_at {
+                        "ADVANCED past publish"
+                    } else {
+                        "still BEHIND publish"
+                    },
+                );
+                watermark >= published_at
+            }
+            None => {
+                println!(
+                    "round {round}: snapshot decode failed ({} bytes)",
+                    bytes.len()
+                );
+                false
+            }
+        },
+        Ok(None) => {
+            println!("round {round}: no snapshot served");
+            false
+        }
+        Err(error) => {
+            println!("round {round}: snapshot fetch error: {error}");
+            false
+        }
+    }
+}

--- a/cas-plugin/src/bin/tuist-cas-proxy.rs
+++ b/cas-plugin/src/bin/tuist-cas-proxy.rs
@@ -93,6 +93,7 @@ fn main() {
         proxy.reclaim_idle();
         proxy.maintain_token(TOKEN_REFRESH_LEAD);
         proxy.refresh_snapshots();
+        proxy.refresh_view_keys();
         let stats = proxy.stats_line();
         if !stats.is_empty() {
             tuist_cas_plugin::log_line(&format!("proxy stats: {stats}"));

--- a/cas-plugin/src/proxy.rs
+++ b/cas-plugin/src/proxy.rs
@@ -16,12 +16,11 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Condvar, Mutex};
 use std::time::{Duration, Instant, UNIX_EPOCH};
 
+use crate::prefetch::Prefetcher;
 use crate::proxy_proto::{
     read_request, write_response, Request, OP_FETCH_OBJECT, OP_INVALIDATE, OP_PUBLISH, OP_RESOLVE,
-    STATUS_ERROR,
-    STATUS_HIT, STATUS_MISS,
+    STATUS_ERROR, STATUS_HIT, STATUS_MISS,
 };
-use crate::prefetch::Prefetcher;
 use crate::reapi::{self, ManifestEntry, Remote, RemoteConfig};
 use crate::token::TokenProvider;
 use crate::types::*;
@@ -58,6 +57,13 @@ const SNAPSHOT_MAX_INSTANCES: usize = 8;
 // Sized past the largest closure a single build replays (~37.5k on the CLI
 // fixture) so a right-sized namespace still warms completely.
 const PREMATERIALIZE_MAX_NODES: usize = 60_000;
+// View refresh: per-key hits taken while a snapshot was Ready get their
+// manifests re-published in the background (see Proxy.view_refresh). The
+// per-tick batch keeps a full cold build's backlog (~10k keys) draining in
+// well under an hour without contending with the build's own traffic; the
+// queue cap bounds memory if the server never accepts them.
+const VIEW_REFRESH_PER_TICK: usize = 100;
+const VIEW_REFRESH_MAX_QUEUE: usize = 50_000;
 
 /// How long a cached miss is served before it is re-resolved. Positive results
 /// are content-addressed and kept forever; only negatives expire, so a key
@@ -152,7 +158,10 @@ fn cas_generation(cas_path: &str) -> Option<CasGeneration> {
         .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
         .map(|d| d.as_nanos())
         .unwrap_or(0);
-    Some(CasGeneration { ino: meta.ino(), birth_nanos })
+    Some(CasGeneration {
+        ino: meta.ino(),
+        birth_nanos,
+    })
 }
 
 /// Whether the CAS directory changed identity between two observations, i.e. it
@@ -481,6 +490,10 @@ fn committable(observed: u64, current: u64) -> bool {
 unsafe impl Send for PathState {}
 unsafe impl Sync for PathState {}
 
+/// One queued view refresh: the instance's client, the action key, and the
+/// manifest to re-publish.
+type ViewRefresh = (Arc<Remote>, Vec<u8>, Vec<ManifestEntry>);
+
 pub struct Proxy {
     grpc_url: String,
     tokens: Arc<TokenProvider>,
@@ -524,6 +537,19 @@ pub struct Proxy {
     // when the server has none) resolves use the per-key path.
     snapshots: Mutex<HashMap<String, SnapshotState>>,
 
+    // Keys answered by a per-key lookup while a snapshot was Ready: they fell
+    // out of the server's size-capped wire view, which ranks by version — a
+    // rank publish-dedup never refreshes, so a project's stable keys decay
+    // out of the view and every cold machine pays a WAN round trip per key
+    // (measured 165 of 10,676 resolves snapshot-served on a fresh index).
+    // Re-publishing the fetched manifest bumps the entry back into the view,
+    // so each cold build heals the view for the next machine. Drained a batch
+    // per maintenance tick; deduped for the proxy's lifetime; the server damps
+    // identical re-publishes of entries fresher than a day, so a fleet of
+    // cold machines cannot stampede version bumps.
+    view_refresh: Mutex<VecDeque<ViewRefresh>>,
+    view_refreshed: Mutex<HashSet<Vec<u8>>>,
+
     // Per-node transfer analytics, written to cas_analytics.db for parity with
     // the Swift `CASAnalyticsDatabase`. `None` when no analytics path was configured.
     analytics: Option<crate::analytics::Analytics>,
@@ -537,7 +563,10 @@ impl Proxy {
         registry_path: Option<PathBuf>,
         analytics: Option<crate::analytics::Analytics>,
     ) -> &'static Proxy {
-        let path_instance = registry_path.as_deref().map(load_registry).unwrap_or_default();
+        let path_instance = registry_path
+            .as_deref()
+            .map(load_registry)
+            .unwrap_or_default();
         let proxy: &'static Proxy = Box::leak(Box::new(Proxy {
             grpc_url,
             tokens,
@@ -554,7 +583,8 @@ impl Proxy {
             job_counter: AtomicU64::new(0),
             snapshots: Mutex::new(HashMap::new()),
             unprimed: AtomicU64::new(0),
-
+            view_refresh: Mutex::new(VecDeque::new()),
+            view_refreshed: Mutex::new(HashSet::new()),
             analytics,
         }));
         let proxy_addr = proxy as *const Proxy as usize;
@@ -617,7 +647,9 @@ impl Proxy {
     }
 
     fn persist_registry(&self, map: &HashMap<String, String>) {
-        let Some(path) = &self.registry_path else { return };
+        let Some(path) = &self.registry_path else {
+            return;
+        };
         let mut body = String::new();
         for (cas_path, instance) in map {
             if !cas_path.contains(['\t', '\n']) && !instance.contains(['\t', '\n']) {
@@ -749,9 +781,7 @@ impl Proxy {
                     // A fresh miss answers without a round-trip; a stale one
                     // falls through to re-resolve so a key published later
                     // (by another machine) can still land.
-                    Some(Resolution::Miss(at)) if at.elapsed() < NEGATIVE_TTL => {
-                        return Ok(None)
-                    }
+                    Some(Resolution::Miss(at)) if at.elapsed() < NEGATIVE_TTL => return Ok(None),
                     _ => None,
                 };
                 if let Some(value) = peeked {
@@ -772,7 +802,7 @@ impl Proxy {
         // this resolve's marks if a wipe/prune advances the counter mid-resolve.
         self.check_generation(state);
         let observed = state.gen_counter.load(Ordering::SeqCst);
-        let outcome = self.resolve_uncached(remote, state, key, observed);
+        let outcome = self.resolve_uncached(remote, state, key, observed, snapshot.is_some());
         {
             let mut inflight = state.inflight.lock().unwrap();
             inflight.remove(key);
@@ -787,6 +817,7 @@ impl Proxy {
         state: &'static PathState,
         key: &[u8],
         observed: u64,
+        snapshot_ready: bool,
     ) -> Result<Option<Vec<u8>>, String> {
         let op_start = Instant::now();
         let phase = Instant::now();
@@ -814,6 +845,14 @@ impl Proxy {
             }
         };
         state.stats_remote_hits.fetch_add(1, Ordering::Relaxed);
+        // A per-key hit with a Ready snapshot means this key exists remotely
+        // but fell out of the snapshot's size-capped view; queue its manifest
+        // for a background re-publish so it ranks back in for the next cold
+        // machine. Without a snapshot, per-key is just the normal path and
+        // says nothing about view membership.
+        if snapshot_ready {
+            self.queue_view_refresh(remote, key, &manifest);
+        }
         let action_ms = phase.elapsed().as_millis() as u64;
         state.ms_action.fetch_add(action_ms, Ordering::Relaxed);
 
@@ -1028,8 +1067,11 @@ impl Proxy {
                 } else {
                     state.stats_blobs_fetched.fetch_add(1, Ordering::Relaxed);
                 }
-                if let Some(instruction) =
-                    state.pending_objects.lock().unwrap().get_mut(&entry.llcas_digest)
+                if let Some(instruction) = state
+                    .pending_objects
+                    .lock()
+                    .unwrap()
+                    .get_mut(&entry.llcas_digest)
                 {
                     instruction.contents = None;
                 }
@@ -1060,14 +1102,18 @@ impl Proxy {
     }
 
     fn materialize_job(&self, item: &[u8]) {
-        let Ok(id_bytes) = <[u8; 8]>::try_from(item) else { return };
+        let Ok(id_bytes) = <[u8; 8]>::try_from(item) else {
+            return;
+        };
         let job = self
             .materialize_jobs
             .lock()
             .unwrap()
             .remove(&u64::from_be_bytes(id_bytes));
         let Some(job) = job else { return };
-        let Ok(state) = self.path_state(&job.cas_path) else { return };
+        let Ok(state) = self.path_state(&job.cas_path) else {
+            return;
+        };
         if let Err(message) =
             self.materialize_manifest(&job.remote, state, &job.manifest, job.observed)
         {
@@ -1102,7 +1148,10 @@ impl Proxy {
                 .lock()
                 .unwrap()
                 .get(digest)
-                .map(|(blob, _refs)| PendingFetch { blob: blob.clone(), contents: None })
+                .map(|(blob, _refs)| PendingFetch {
+                    blob: blob.clone(),
+                    contents: None,
+                })
         });
         // Third source: the instance's snapshot node table. A restarted proxy
         // has empty maps while Apple's persistent local action cache keeps
@@ -1113,7 +1162,9 @@ impl Proxy {
             Some(pending) => Some(pending),
             None => self.snapshot_fetch_instruction(cas_path, declared_instance, digest),
         };
-        let Some(pending) = pending else { return Ok(false) };
+        let Some(pending) = pending else {
+            return Ok(false);
+        };
         let blob = pending.blob.clone();
         let blob_bytes = match pending.contents {
             Some(bytes) => bytes,
@@ -1145,7 +1196,10 @@ impl Proxy {
             .unwrap()
             .entry(digest.to_vec())
             .and_modify(|instruction| instruction.contents = None)
-            .or_insert(PendingFetch { blob, contents: None });
+            .or_insert(PendingFetch {
+                blob,
+                contents: None,
+            });
         state.stats_demand_fetched.fetch_add(1, Ordering::Relaxed);
         Ok(true)
     }
@@ -1180,7 +1234,10 @@ impl Proxy {
         };
         let index = *snapshot.node_index.get(digest)?;
         let (_, blob) = &snapshot.nodes[index as usize];
-        Some(PendingFetch { blob: blob.clone(), contents: None })
+        Some(PendingFetch {
+            blob: blob.clone(),
+            contents: None,
+        })
     }
 
     /// Detects a wiped-and-recreated on-disk CAS (a deleted DerivedData under
@@ -1193,7 +1250,9 @@ impl Proxy {
     /// the new generation as unchanged and filter against `known_local` while it
     /// is being cleared.
     fn check_generation(&self, state: &PathState) {
-        let Some(current) = cas_generation(&state.cas_path) else { return };
+        let Some(current) = cas_generation(&state.cas_path) else {
+            return;
+        };
         let mut stored = state.generation.lock().unwrap();
         if generation_changed(*stored, Some(current)) {
             state.invalidate();
@@ -1226,7 +1285,10 @@ impl Proxy {
     /// cached Hit against a wiped local CAS, where the in-memory marks lie.
     fn load_present(&self, state: &PathState, digest: &[u8]) -> bool {
         unsafe {
-            let digest_t = llcas_digest_t { data: digest.as_ptr(), size: digest.len() };
+            let digest_t = llcas_digest_t {
+                data: digest.as_ptr(),
+                size: digest.len(),
+            };
             let mut id = llcas_objectid_t { opaque: 0 };
             let mut error: *mut std::ffi::c_char = std::ptr::null_mut();
             if (state.up.llcas_cas_get_objectid)(state.cas, digest_t, &mut id, &mut error) {
@@ -1263,17 +1325,25 @@ impl Proxy {
     }
 
     fn publish_item(&self, item: &[u8]) {
-        let Some((instance, rest)) = take_u16_field(item) else { return };
-        let Some((cas_path, record_path)) = take_u16_field(rest) else { return };
+        let Some((instance, rest)) = take_u16_field(item) else {
+            return;
+        };
+        let Some((cas_path, record_path)) = take_u16_field(rest) else {
+            return;
+        };
         let instance = String::from_utf8_lossy(instance).into_owned();
         let cas_path = String::from_utf8_lossy(cas_path).into_owned();
         let record_path = String::from_utf8_lossy(record_path).into_owned();
         let remote = self.remote_for(&instance);
-        let Ok(state) = self.path_state(&cas_path) else { return };
+        let Ok(state) = self.path_state(&cas_path) else {
+            return;
+        };
         state
             .last_used
             .store(self.epoch.elapsed().as_millis() as u64, Ordering::Relaxed);
-        let Ok(bytes) = std::fs::read(&record_path) else { return };
+        let Ok(bytes) = std::fs::read(&record_path) else {
+            return;
+        };
         let Some(record) =
             PublishRecord::decode_body(&bytes, Some(std::path::PathBuf::from(&record_path)))
         else {
@@ -1296,11 +1366,10 @@ impl Proxy {
             Ok(()) => {
                 let _ = std::fs::remove_file(&record_path);
                 state.stats_published.fetch_add(1, Ordering::Relaxed);
-                state
-                    .resolved
-                    .lock()
-                    .unwrap()
-                    .insert(record.key.clone(), Resolution::Hit(record.value_digest.clone()));
+                state.resolved.lock().unwrap().insert(
+                    record.key.clone(),
+                    Resolution::Hit(record.value_digest.clone()),
+                );
             }
             Err(reason) => {
                 crate::log_line(&format!("proxy publish failed ({reason}); record kept"));
@@ -1335,7 +1404,11 @@ impl Proxy {
             if let Some((blob_digest, children)) =
                 state.publish_cache.lock().unwrap().get(&digest).cloned()
             {
-                entries.push(ManifestEntry { llcas_digest: digest, blob: blob_digest, contents: None });
+                entries.push(ManifestEntry {
+                    llcas_digest: digest,
+                    blob: blob_digest,
+                    contents: None,
+                });
                 blobs.push(None);
                 pending.extend(children);
                 continue;
@@ -1347,7 +1420,11 @@ impl Proxy {
                 .lock()
                 .unwrap()
                 .insert(digest.clone(), (blob_digest.clone(), children.clone()));
-            entries.push(ManifestEntry { llcas_digest: digest, blob: blob_digest, contents: None });
+            entries.push(ManifestEntry {
+                llcas_digest: digest,
+                blob: blob_digest,
+                contents: None,
+            });
             blobs.push(Some(blob));
             pending.extend(children);
         }
@@ -1371,9 +1448,16 @@ impl Proxy {
             };
             if self.analytics.is_some() {
                 let (size, data) = reapi::decompress_frame(&bytes)
-                    .and_then(|frame| reapi::decode_frame(&frame).map(|node| (frame.len(), node.data)))
+                    .and_then(|frame| {
+                        reapi::decode_frame(&frame).map(|node| (frame.len(), node.data))
+                    })
                     .unwrap_or((bytes.len(), Vec::new()));
-                upload_meta.push((entry.llcas_digest.clone(), size as i64, entry.blob.size_bytes, data));
+                upload_meta.push((
+                    entry.llcas_digest.clone(),
+                    size as i64,
+                    entry.blob.size_bytes,
+                    data,
+                ));
             }
             uploads.push((entry.blob.clone(), bytes));
         }
@@ -1467,14 +1551,17 @@ impl Proxy {
                 continue;
             };
             let spool = std::path::Path::new(&cas_path).join("tuist-spool");
-            let Ok(entries) = std::fs::read_dir(&spool) else { continue };
+            let Ok(entries) = std::fs::read_dir(&spool) else {
+                continue;
+            };
             for entry in entries.flatten() {
                 if let Some(name) = entry.file_name().to_str() {
                     // Claims are ours alone now; reclaim anything.
                     let base = name.split_once(".claim-").map(|(b, _)| b.to_string());
                     let path = match base {
                         Some(base) => {
-                            let claimed = spool.join(format!("{base}.claim-{}", std::process::id()));
+                            let claimed =
+                                spool.join(format!("{base}.claim-{}", std::process::id()));
                             if std::fs::rename(entry.path(), &claimed).is_err() {
                                 continue;
                             }
@@ -1496,6 +1583,54 @@ impl Proxy {
         self.tokens.refresh_if_expiring(lead);
     }
 
+    /// Queues a per-key-served manifest for a background re-publish (see
+    /// `Proxy.view_refresh`). Inlined contents are stripped: the refresh only
+    /// re-sends the llcas→blob mapping, and the blobs are already on the
+    /// server (the per-key hit proved the entry serveable).
+    fn queue_view_refresh(&self, remote: &Arc<Remote>, key: &[u8], manifest: &[ManifestEntry]) {
+        {
+            let mut refreshed = self.view_refreshed.lock().unwrap();
+            if refreshed.len() >= VIEW_REFRESH_MAX_QUEUE || !refreshed.insert(key.to_vec()) {
+                return;
+            }
+        }
+        let stripped: Vec<ManifestEntry> = manifest
+            .iter()
+            .map(|entry| ManifestEntry {
+                llcas_digest: entry.llcas_digest.clone(),
+                blob: entry.blob.clone(),
+                contents: None,
+            })
+            .collect();
+        let mut queue = self.view_refresh.lock().unwrap();
+        if queue.len() < VIEW_REFRESH_MAX_QUEUE {
+            queue.push_back((remote.clone(), key.to_vec(), stripped));
+        }
+    }
+
+    /// Drains a batch of queued view refreshes, one small UpdateActionResult
+    /// each. Best-effort: a failure drops the batch's remainder — the next
+    /// cold build that pays the per-key round trip re-queues the key.
+    pub fn refresh_view_keys(&self) {
+        let mut sent = 0_usize;
+        while sent < VIEW_REFRESH_PER_TICK {
+            let Some((remote, key, manifest)) = self.view_refresh.lock().unwrap().pop_front()
+            else {
+                break;
+            };
+            if remote.update_action(&key, &manifest).is_err() {
+                break;
+            }
+            sent += 1;
+        }
+        if sent > 0 {
+            let remaining = self.view_refresh.lock().unwrap().len();
+            crate::log_line(&format!(
+                "view refresh: {sent} keys re-published ({remaining} queued)"
+            ));
+        }
+    }
+
     /// Kicks off snapshot fetches for every instance the persisted registry
     /// knows. Called once at proxy startup, so a machine's first build after
     /// a restart already has the snapshot (and its bulk warm) in flight
@@ -1503,8 +1638,13 @@ impl Proxy {
     /// start on the first resolve, which put the transfer and the server's
     /// first index build inside the build the user was waiting on.
     pub fn prefetch_known_snapshots(&self) {
-        let instances: std::collections::HashSet<String> =
-            self.path_instance.lock().unwrap().values().cloned().collect();
+        let instances: std::collections::HashSet<String> = self
+            .path_instance
+            .lock()
+            .unwrap()
+            .values()
+            .cloned()
+            .collect();
         for instance in instances {
             let remote = self.remote_for(&instance);
             self.ensure_snapshot(&instance, &remote);
@@ -1556,13 +1696,19 @@ impl Proxy {
                     crate::log_line(&format!(
                         "snapshot: undecodable payload for {instance}; staying on the per-key path"
                     ));
-                    SnapshotState::Absent { checked: Instant::now() }
+                    SnapshotState::Absent {
+                        checked: Instant::now(),
+                    }
                 }
             },
-            Ok(None) => SnapshotState::Absent { checked: Instant::now() },
+            Ok(None) => SnapshotState::Absent {
+                checked: Instant::now(),
+            },
             Err(message) => {
                 crate::log_line(&format!("snapshot fetch failed for {instance}: {message}"));
-                SnapshotState::Absent { checked: Instant::now() }
+                SnapshotState::Absent {
+                    checked: Instant::now(),
+                }
             }
         }
     }
@@ -1614,7 +1760,9 @@ impl Proxy {
                         ..
                     } => {
                         if now.duration_since(*full_at) > SNAPSHOT_FULL_INTERVAL {
-                            plans.push(Plan::Full { instance: instance.clone() });
+                            plans.push(Plan::Full {
+                                instance: instance.clone(),
+                            });
                         } else if now.duration_since(*refreshed_at) > SNAPSHOT_DELTA_INTERVAL {
                             plans.push(Plan::Delta {
                                 instance: instance.clone(),
@@ -1625,7 +1773,9 @@ impl Proxy {
                     SnapshotState::Absent { checked }
                         if now.duration_since(*checked) > SNAPSHOT_RETRY_INTERVAL =>
                     {
-                        plans.push(Plan::Full { instance: instance.clone() });
+                        plans.push(Plan::Full {
+                            instance: instance.clone(),
+                        });
                     }
                     _ => {}
                 }
@@ -1638,11 +1788,16 @@ impl Proxy {
                     let outcome = self.fetch_full_snapshot(&instance, &remote);
                     self.snapshots.lock().unwrap().insert(instance, outcome);
                 }
-                Plan::Delta { instance, watermark } => {
+                Plan::Delta {
+                    instance,
+                    watermark,
+                } => {
                     let remote = self.remote_for(&instance);
                     match remote.get_snapshot(Some(watermark)) {
                         Ok(Some(bytes)) => {
-                            let Some(delta) = Snapshot::decode(&bytes) else { continue };
+                            let Some(delta) = Snapshot::decode(&bytes) else {
+                                continue;
+                            };
                             let warm = {
                                 let mut snapshots = self.snapshots.lock().unwrap();
                                 let Some(SnapshotState::Ready {
@@ -1719,7 +1874,9 @@ impl Proxy {
             .collect();
         let remote = self.remote_for(instance);
         for cas_path in cas_paths {
-            let Ok(state) = self.path_state(&cas_path) else { continue };
+            let Ok(state) = self.path_state(&cas_path) else {
+                continue;
+            };
             let observed = state.gen_counter.load(Ordering::SeqCst);
             // Warm newest-first (the wire order) and stop at the node budget:
             // a shared namespace's snapshot carries every project's history,
@@ -1730,7 +1887,9 @@ impl Proxy {
             let mut budget = PREMATERIALIZE_MAX_NODES;
             let mut enqueued = 0usize;
             for key_hash in &snapshot.key_order {
-                let Some(manifest) = snapshot.manifest(key_hash) else { continue };
+                let Some(manifest) = snapshot.manifest(key_hash) else {
+                    continue;
+                };
                 budget = budget.saturating_sub(manifest.len());
                 let id = self.job_counter.fetch_add(1, Ordering::Relaxed);
                 self.materialize_jobs.lock().unwrap().insert(
@@ -1759,7 +1918,11 @@ impl Proxy {
 
     fn snapshot_ready(&self, instance: &str) -> Option<Arc<Snapshot>> {
         match self.snapshots.lock().unwrap().get_mut(instance) {
-            Some(SnapshotState::Ready { snapshot, last_used, .. }) => {
+            Some(SnapshotState::Ready {
+                snapshot,
+                last_used,
+                ..
+            }) => {
                 *last_used = Instant::now();
                 Some(snapshot.clone())
             }
@@ -1820,7 +1983,11 @@ impl Proxy {
         // A plugin from a different CLI version speaks a different frame layout;
         // reject rather than misparse, so the plugin degrades to a local miss.
         if request.version != crate::proxy_proto::PROTOCOL_VERSION {
-            return write_response(&mut stream, STATUS_ERROR, b"proxy protocol version mismatch");
+            return write_response(
+                &mut stream,
+                STATUS_ERROR,
+                b"proxy protocol version mismatch",
+            );
         }
         match request.op {
             OP_RESOLVE => {
@@ -1836,11 +2003,9 @@ impl Proxy {
                 let remote = self.remote_for(&instance);
                 self.ensure_snapshot(&instance, &remote);
                 let snapshot = self.snapshot_ready(&instance);
-                let outcome = self
-                    .path_state(&request.cas_path)
-                    .and_then(|state| {
-                        self.resolve(&remote, state, &request.payload, snapshot.as_deref())
-                    });
+                let outcome = self.path_state(&request.cas_path).and_then(|state| {
+                    self.resolve(&remote, state, &request.payload, snapshot.as_deref())
+                });
                 match outcome {
                     Ok(Some(value)) => write_response(&mut stream, STATUS_HIT, &value),
                     Ok(None) => write_response(&mut stream, STATUS_MISS, &[]),
@@ -1853,7 +2018,8 @@ impl Proxy {
             OP_PUBLISH => {
                 // Ack even when unprimed: the record stays spooled for a later
                 // sweep once a build primes the instance.
-                if let Some(instance) = self.resolve_instance(&request.cas_path, &request.instance) {
+                if let Some(instance) = self.resolve_instance(&request.cas_path, &request.instance)
+                {
                     let record_path = String::from_utf8_lossy(&request.payload).into_owned();
                     self.enqueue_publish(&request.cas_path, &instance, &record_path);
                 } else {
@@ -1942,8 +2108,7 @@ fn load_registry(path: &Path) -> HashMap<String, String> {
 
 unsafe fn open_cas(up: &'static Upstream, path: &str) -> Result<llcas_cas_t, String> {
     let options = (up.llcas_cas_options_create)();
-    let c_path =
-        std::ffi::CString::new(path).map_err(|_| "bad cas path".to_string())?;
+    let c_path = std::ffi::CString::new(path).map_err(|_| "bad cas path".to_string())?;
     (up.llcas_cas_options_set_client_version)(options, 0, 1);
     (up.llcas_cas_options_set_ondisk_path)(options, c_path.as_ptr());
     let mut error: *mut std::ffi::c_char = std::ptr::null_mut();
@@ -1953,7 +2118,9 @@ unsafe fn open_cas(up: &'static Upstream, path: &str) -> Result<llcas_cas_t, Str
         let message = if error.is_null() {
             "cas_create failed".to_string()
         } else {
-            let text = std::ffi::CStr::from_ptr(error).to_string_lossy().into_owned();
+            let text = std::ffi::CStr::from_ptr(error)
+                .to_string_lossy()
+                .into_owned();
             (up.llcas_string_dispose)(error);
             text
         };
@@ -1965,7 +2132,10 @@ unsafe fn open_cas(up: &'static Upstream, path: &str) -> Result<llcas_cas_t, Str
 unsafe fn store_node(state: &PathState, node: &reapi::Node) -> Result<(), String> {
     let mut ref_ids = Vec::with_capacity(node.refs.len());
     for reference in &node.refs {
-        let digest = llcas_digest_t { data: reference.as_ptr(), size: reference.len() };
+        let digest = llcas_digest_t {
+            data: reference.as_ptr(),
+            size: reference.len(),
+        };
         let mut id = llcas_objectid_t { opaque: 0 };
         let mut error: *mut std::ffi::c_char = std::ptr::null_mut();
         if (state.up.llcas_cas_get_objectid)(state.cas, digest, &mut id, &mut error) {
@@ -2003,7 +2173,10 @@ unsafe fn encode_node_blob(
     state: &PathState,
     digest: &[u8],
 ) -> Result<(Vec<u8>, Vec<Vec<u8>>), String> {
-    let digest_t = llcas_digest_t { data: digest.as_ptr(), size: digest.len() };
+    let digest_t = llcas_digest_t {
+        data: digest.as_ptr(),
+        size: digest.len(),
+    };
     let mut id = llcas_objectid_t { opaque: 0 };
     let mut id_error: *mut std::ffi::c_char = std::ptr::null_mut();
     if (state.up.llcas_cas_get_objectid)(state.cas, digest_t, &mut id, &mut id_error) {
@@ -2073,7 +2246,10 @@ mod tests {
         assert!(snapshot.manifest(&[6u8; 32]).is_none());
         // The per-node lookup fetch_object's snapshot fallback uses: llcas
         // digest -> the node's blob digest.
-        let index = *snapshot.node_index.get(&vec![0xCCu8]).expect("node indexed");
+        let index = *snapshot
+            .node_index
+            .get(&vec![0xCCu8])
+            .expect("node indexed");
         assert_eq!(snapshot.nodes[index as usize].1.size_bytes, 20);
         assert!(!snapshot.node_index.contains_key(&vec![0xFFu8]));
 
@@ -2229,7 +2405,10 @@ mod tests {
     #[test]
     fn active_path_is_not_reclaimed() {
         assert!(!should_reclaim(Duration::from_secs(0), false));
-        assert!(!should_reclaim(IDLE_RECLAIM - Duration::from_secs(1), false));
+        assert!(!should_reclaim(
+            IDLE_RECLAIM - Duration::from_secs(1),
+            false
+        ));
     }
 
     // A present path idle past IDLE_RECLAIM is reclaimed.
@@ -2259,8 +2438,14 @@ mod tests {
         assert!(generation_changed(Some(g1), Some(g2)));
         assert!(generation_changed(Some(g2), Some(g1)));
         assert!(!generation_changed(Some(g1), Some(g1)));
-        assert!(!generation_changed(None, Some(g1)), "first observation is not a change");
-        assert!(!generation_changed(Some(g1), None), "a gone dir is left to reclaim_idle");
+        assert!(
+            !generation_changed(None, Some(g1)),
+            "first observation is not a change"
+        );
+        assert!(
+            !generation_changed(Some(g1), None),
+            "a gone dir is left to reclaim_idle"
+        );
     }
 
     // A resolve's writes commit only if the generation it observed still holds;
@@ -2268,7 +2453,10 @@ mod tests {
     #[test]
     fn writes_commit_only_on_the_observed_generation() {
         assert!(committable(7, 7));
-        assert!(!committable(7, 8), "an advanced generation must drop stale writes");
+        assert!(
+            !committable(7, 8),
+            "an advanced generation must drop stale writes"
+        );
     }
 
     // Keylog lines round-trip: lowercase hex parses back to the raw key; blank
@@ -2292,6 +2480,9 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
 
         assert!(before.is_some() && after.is_some());
-        assert_ne!(before, after, "a recreated CAS directory must read as a new generation");
+        assert_ne!(
+            before, after,
+            "a recreated CAS directory must read as a new generation"
+        );
     }
 }

--- a/kura/src/constants.rs
+++ b/kura/src/constants.rs
@@ -45,6 +45,13 @@ pub const DEFAULT_MULTIPART_JANITOR_INTERVAL_MS: u64 = 10 * 60 * 1000;
 pub const REAPI_ACTION_CACHE_TTL_MS: u64 = 30 * 24 * 60 * 60 * 1000;
 pub const REAPI_ACTION_CACHE_EXPIRY_INTERVAL_MS: u64 = 6 * 60 * 60 * 1000;
 pub const REAPI_ACTION_CACHE_EXPIRY_MAX_DELETES: usize = 100_000;
+// Clients re-publish an entry's unchanged manifest when a per-key lookup
+// reveals it fell out of the snapshot's size-capped wire view (the view ranks
+// by version, which publish-dedup never refreshes). The damping window keeps
+// a fleet of cold machines from stampeding version bumps for the same entry:
+// an identical re-publish only applies when the stored version has aged past
+// it — one refresh per entry per window fleet-wide.
+pub const REAPI_ACTION_CACHE_REFRESH_DAMPING_MS: u64 = 24 * 60 * 60 * 1000;
 // Not a cap on total bootstrap runtime — it is the maximum time a bootstrap may
 // go *without forward progress* (a fetched page or applied artifact) before it
 // is abandoned and retried. A large cold pull that keeps making progress runs to

--- a/kura/src/reapi/mod.rs
+++ b/kura/src/reapi/mod.rs
@@ -1133,10 +1133,10 @@ impl ActionCache for ReapiService {
         let principal = self.authorize_request(&request, extension.clone()).await?;
         let bytes = action_result.encode_to_vec();
         let targets = replication_targets(&self.state).await;
-        let manifest = self
+        let (manifest, applied) = self
             .state
             .store
-            .persist_inline_artifact_from_bytes_and_enqueue(
+            .persist_inline_artifact_from_bytes_damped_and_enqueue(
                 ArtifactProducer::Reapi,
                 namespace_id,
                 &key,
@@ -1157,7 +1157,11 @@ impl ActionCache for ReapiService {
         // update is billed: an action result is a mutable entry whose content
         // changes across updates, so there is no CAS-style "already present"
         // dedupe — matching the HTTP key-value path, which bills each put.
-        self.record_reapi_upload(request.metadata(), namespace_id, manifest.size);
+        // A damped refresh (identical bytes, fresh version) applies nothing
+        // and bills nothing.
+        if applied {
+            self.record_reapi_upload(request.metadata(), namespace_id, manifest.size);
+        }
         Ok(response)
     }
 }

--- a/kura/src/store.rs
+++ b/kura/src/store.rs
@@ -33,13 +33,13 @@ use crate::{
     constants::{
         CAS_CAPACITY_DEFAULT_DISK_PERCENT, CAS_CAPACITY_MAX_DISK_PERCENT, DESIRED_CURRENT_SEGMENTS,
         DESIRED_NEW_SEGMENTS, DESIRED_OLD_SEGMENTS, MAX_DESIRED_SEGMENTS, MAX_MODULE_TOTAL_BYTES,
-        MAX_SEGMENT_BYTES, ROCKSDB_BYTES_PER_SYNC, ROCKSDB_CF_KEY_VALUE, ROCKSDB_CF_MANIFESTS,
-        ROCKSDB_CF_MULTIPART_UPLOADS, ROCKSDB_CF_NAMESPACE_ARTIFACTS,
-        ROCKSDB_CF_NAMESPACE_TOMBSTONES, ROCKSDB_CF_OUTBOX, ROCKSDB_CF_SEGMENT_ARTIFACTS,
-        ROCKSDB_CF_SEGMENT_STATE, ROCKSDB_CF_USAGE_OUTBOX, ROCKSDB_HARD_PENDING_COMPACTION_BYTES,
-        ROCKSDB_LEVEL0_SLOWDOWN_TRIGGER, ROCKSDB_LEVEL0_STOP_TRIGGER,
-        ROCKSDB_SOFT_PENDING_COMPACTION_BYTES, ROCKSDB_WAL_BYTES_PER_SYNC,
-        SEGMENT_FREE_SPACE_MARGIN,
+        MAX_SEGMENT_BYTES, REAPI_ACTION_CACHE_REFRESH_DAMPING_MS, ROCKSDB_BYTES_PER_SYNC,
+        ROCKSDB_CF_KEY_VALUE, ROCKSDB_CF_MANIFESTS, ROCKSDB_CF_MULTIPART_UPLOADS,
+        ROCKSDB_CF_NAMESPACE_ARTIFACTS, ROCKSDB_CF_NAMESPACE_TOMBSTONES, ROCKSDB_CF_OUTBOX,
+        ROCKSDB_CF_SEGMENT_ARTIFACTS, ROCKSDB_CF_SEGMENT_STATE, ROCKSDB_CF_USAGE_OUTBOX,
+        ROCKSDB_HARD_PENDING_COMPACTION_BYTES, ROCKSDB_LEVEL0_SLOWDOWN_TRIGGER,
+        ROCKSDB_LEVEL0_STOP_TRIGGER, ROCKSDB_SOFT_PENDING_COMPACTION_BYTES,
+        ROCKSDB_WAL_BYTES_PER_SYNC, SEGMENT_FREE_SPACE_MARGIN,
     },
     failpoints::{FailpointName, FailpointSet},
     io::{IoController, PersistentFile},
@@ -1856,6 +1856,44 @@ impl Store {
                 "artifact write for {producer:?}/{namespace_id}/{key} was rejected by a newer tombstone"
             )),
         }
+    }
+
+    /// Persist an inline artifact, treating a byte-identical re-publish of an
+    /// entry whose stored version is younger than the refresh damping window
+    /// as already applied (returns the existing manifest, writes and
+    /// replicates nothing). Clients refresh action-cache entries back into
+    /// the snapshot's ranked wire view by re-publishing their unchanged
+    /// manifests; without damping, every cold machine in a fleet would bump
+    /// the same entries' versions (and replicate the rewrites) on the same
+    /// day.
+    pub async fn persist_inline_artifact_from_bytes_damped_and_enqueue(
+        &self,
+        producer: ArtifactProducer,
+        namespace_id: &str,
+        key: &str,
+        content_type: &str,
+        bytes: &[u8],
+        replication_targets: &[String],
+    ) -> Result<(ArtifactManifest, bool), String> {
+        let artifact_id = artifact_storage_id(producer, &self.tenant_id, namespace_id, key);
+        if let Some(existing) = self.manifest_from_db(&artifact_id)?
+            && existing.inline
+            && manifest_version_ms(&existing).saturating_add(REAPI_ACTION_CACHE_REFRESH_DAMPING_MS)
+                > now_ms()
+            && self.inline_bytes(&artifact_id)?.as_deref() == Some(bytes)
+        {
+            return Ok((existing, false));
+        }
+        self.persist_inline_artifact_from_bytes_and_enqueue(
+            producer,
+            namespace_id,
+            key,
+            content_type,
+            bytes,
+            replication_targets,
+        )
+        .await
+        .map(|manifest| (manifest, true))
     }
 
     pub async fn persist_inline_artifact_from_bytes_and_enqueue(
@@ -3924,6 +3962,70 @@ mod tests {
             "segment store held {segments_bytes} bytes, expected ~{artifact_len} (one copy); \
              concurrent same-key applies amplified on-disk data"
         );
+    }
+
+    #[tokio::test]
+    async fn damped_persist_skips_identical_republish_of_a_fresh_entry() {
+        let (_temp_dir, _config, store) = temp_store();
+        let day = 24 * 60 * 60 * 1000;
+
+        // Seed the entry with an aged version (a replicated apply preserves
+        // the origin's version), so the first damped refresh applies.
+        store
+            .apply_replicated_inline_artifact_from_bytes(
+                ArtifactProducer::Reapi,
+                "ios",
+                "action_cache/aa/10",
+                "application/x-protobuf",
+                b"graph",
+                now_ms() - 2 * day,
+            )
+            .await
+            .expect("seed should persist");
+
+        let (refreshed, applied) = store
+            .persist_inline_artifact_from_bytes_damped_and_enqueue(
+                ArtifactProducer::Reapi,
+                "ios",
+                "action_cache/aa/10",
+                "application/x-protobuf",
+                b"graph",
+                &[],
+            )
+            .await
+            .expect("aged refresh should persist");
+        assert!(applied, "an aged identical re-publish applies");
+
+        let (damped, applied) = store
+            .persist_inline_artifact_from_bytes_damped_and_enqueue(
+                ArtifactProducer::Reapi,
+                "ios",
+                "action_cache/aa/10",
+                "application/x-protobuf",
+                b"graph",
+                &[],
+            )
+            .await
+            .expect("damped refresh should succeed");
+        assert!(
+            !applied,
+            "an identical re-publish inside the window is damped"
+        );
+        assert_eq!(damped.version_ms, refreshed.version_ms);
+
+        let (changed, applied) = store
+            .persist_inline_artifact_from_bytes_damped_and_enqueue(
+                ArtifactProducer::Reapi,
+                "ios",
+                "action_cache/aa/10",
+                "application/x-protobuf",
+                b"graph-v2",
+                &[],
+            )
+            .await
+            .expect("changed publish should persist");
+        assert!(applied, "changed content always applies");
+        assert!(changed.version_ms >= refreshed.version_ms);
     }
 
     #[tokio::test]


### PR DESCRIPTION
### What

Keeps a namespace's actively used action-cache entries inside the snapshot's size-capped wire view:

- **Proxy** (`cas-plugin`): a per-key lookup that hits while a snapshot is Ready is itself proof the key fell out of the view (the snapshot is consulted first). The proxy queues the fetched manifest and re-publishes it in the background — one small `UpdateActionResult` per key, no blob uploads (the per-key hit proved the blobs are on the server). Drained 100 per maintenance tick, deduped per proxy lifetime, queue capped.
- **Kura**: damps the fleet: a byte-identical re-publish of an entry whose stored version is younger than 24h returns the existing manifest without writing, replicating, or billing. One version bump per entry per window fleet-wide, however many cold machines refresh it.
- Adds `cas-plugin/examples/snapshot_probe.rs`, the diagnostic used to validate the production snapshot lifecycle end to end.

### Why

The snapshot wire view ranks entries by version and truncates the oldest past the 48MiB ceiling. Publish-dedup means a stable key's version never refreshes, so on a long-lived namespace the keys a build actually needs decay out of the view while newer-published (but irrelevant) keys fill it. Measured on production with a verifiably fresh index: **165 of a cold build's 10,676 resolves came from the snapshot**; the remaining ~10.5k fell back to per-key WAN round trips, turning a fully warm cold-slate build into ~725s. The same mechanism explains the runners' flat cache-less-looking times on the shared namespace.

Live probes (the committed example) confirmed the snapshot machinery itself is healthy — a fresh publish and a changed re-publish each became snapshot-visible within two reconcile cycles — so view membership, not staleness, is the problem.

### Why this shape

Considered and rejected:

- **Server-side last-used tracking** (touch entries on reads, rank by recency): cold machines resolve from the snapshot without any per-key server traffic, so the server never sees the strongest use signal; it would also add a manifest schema field and writes on the read path.
- **Raising the ceiling**: 48→128MiB covers today's 100k entries but grows the fetch (40s for 48MiB over WAN was already worth engineering away) and only defers the decay.

The per-key-hit signal needs no new state, no wire or schema changes, and is precisely targeted: only keys a build actually used and actually missed in the view get refreshed, and version remains the single ranking dimension everywhere (view, index cap, 30d TTL expiry — which this also protects from deleting hot-but-stable entries, since refreshes bump the version the sweep keys on).

Self-correcting dynamics: the first cold build after this ships pays the per-key ladder once and re-publishes what it used; the next cold machine finds those keys in the view. Steady state is a trickle of refreshes for keys newly displaced past the ceiling.

### Validation

- kura: new `damped_persist_skips_identical_republish_of_a_fresh_entry` (aged identical re-publish applies; identical inside the window is damped with version unchanged; changed content always applies). Full suite 336 passed, clippy warnings-as-errors clean.
- cas-plugin: full suite passes; release build clean.
- End-to-end validation after deploy: two consecutive production cold-slate reps — the first heals the view (expect ~165 snapshot hits and a `view refresh` log trail), the second should serve the build's keys from the snapshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
