### PR TITLE
fix(cli): reassemble the requested result bundle across test schemes

### DIFF
--- a/cli/Sources/TuistKit/Services/TestService.swift
+++ b/cli/Sources/TuistKit/Services/TestService.swift
@@ -114,6 +114,7 @@ public struct TestService { // swiftlint:disable:this type_body_length
     private let configLoader: ConfigLoading
     private let fileSystem: FileSysteming
     private let xcResultService: XCResultServicing
+    private let xcResultToolController: XCResultToolControlling
     private let xcodeBuildAgumentParser: XcodeBuildArgumentParsing
     private let gitController: GitControlling
     private let rootDirectoryLocator: RootDirectoryLocating
@@ -155,6 +156,7 @@ public struct TestService { // swiftlint:disable:this type_body_length
         configLoader: ConfigLoading,
         fileSystem: FileSysteming = FileSystem(),
         xcResultService: XCResultServicing = XCResultService(),
+        xcResultToolController: XCResultToolControlling = XCResultToolController(),
         xcodeBuildArgumentParser: XcodeBuildArgumentParsing = XcodeBuildArgumentParser(),
         gitController: GitControlling = GitController(),
         rootDirectoryLocator: RootDirectoryLocating = RootDirectoryLocator(),
@@ -182,6 +184,7 @@ public struct TestService { // swiftlint:disable:this type_body_length
         self.configLoader = configLoader
         self.fileSystem = fileSystem
         self.xcResultService = xcResultService
+        self.xcResultToolController = xcResultToolController
         xcodeBuildAgumentParser = xcodeBuildArgumentParser
         self.gitController = gitController
         self.rootDirectoryLocator = rootDirectoryLocator
@@ -523,6 +526,7 @@ public struct TestService { // swiftlint:disable:this type_body_length
                 action: action,
                 rosetta: rosetta,
                 resultBundlePath: resultBundlePath,
+                passedResultBundlePath: passedResultBundlePath,
                 derivedDataPath: derivedDataPath,
                 retryCount: retryCount,
                 testTargets: testTargets,
@@ -1132,6 +1136,7 @@ public struct TestService { // swiftlint:disable:this type_body_length
 
     // MARK: - Helpers
 
+    // swiftlint:disable:next function_body_length
     private func testSchemes(
         _ schemes: [Scheme],
         graph: Graph,
@@ -1146,6 +1151,7 @@ public struct TestService { // swiftlint:disable:this type_body_length
         action: XcodeBuildTestAction,
         rosetta: Bool,
         resultBundlePath: AbsolutePath?,
+        passedResultBundlePath: AbsolutePath?,
         derivedDataPath: AbsolutePath?,
         retryCount: Int,
         testTargets: [TestIdentifier],
@@ -1197,64 +1203,87 @@ public struct TestService { // swiftlint:disable:this type_body_length
             return false
         }
 
-        for testSchemeRun in testSchemeRuns {
-            let testScheme = testSchemeRun.scheme
-            let testSchemeResultBundlePath = schemeResultBundlePath(
-                resultBundlePath,
-                schemeName: testScheme.name,
-                runningMultipleSchemes: testSchemeRuns.count > 1
-            )
+        let runningMultipleSchemes = testSchemeRuns.count > 1
+        var perSchemeResultBundlePaths: [AbsolutePath] = []
 
-            do {
-                try await self.testScheme(
-                    scheme: testScheme,
-                    graphTraverser: graphTraverser,
-                    clean: clean,
-                    configuration: configuration,
-                    version: version,
-                    deviceName: deviceName,
-                    platform: platform,
-                    action: action,
-                    rosetta: rosetta,
-                    resultBundlePath: testSchemeResultBundlePath,
-                    derivedDataPath: derivedDataPath,
-                    retryCount: retryCount,
-                    testTargets: testSchemeRun.testTargets,
-                    skipTestTargets: skipTestTargets,
-                    testPlanConfiguration: testPlanConfiguration,
-                    passthroughXcodeBuildArguments: passthroughXcodeBuildArguments,
-                    config: config,
-                    quarantinedTests: quarantinedTests,
-                    mode: mode
+        do {
+            for testSchemeRun in testSchemeRuns {
+                let testScheme = testSchemeRun.scheme
+                let testSchemeResultBundlePath = schemeResultBundlePath(
+                    resultBundlePath,
+                    schemeName: testScheme.name,
+                    runningMultipleSchemes: runningMultipleSchemes
                 )
-            } catch {
-                if try await handleTestSchemeFailure(
-                    error,
-                    scheme: testScheme,
-                    resultBundlePath: testSchemeResultBundlePath,
-                    graph: graph,
-                    mapperEnvironment: mapperEnvironment,
-                    cacheStorage: uploadCacheStorage,
-                    testPlanConfiguration: testPlanConfiguration,
-                    action: action,
-                    quarantinedTests: quarantinedTests
-                ) {
-                    continue
+                if runningMultipleSchemes, let testSchemeResultBundlePath {
+                    perSchemeResultBundlePaths.append(testSchemeResultBundlePath)
                 }
-                throw error
-            }
 
-            if action != .build {
-                try await storeSuccessfulTestHashes(
-                    for: testActionTargets(
-                        for: [testScheme], testPlanConfiguration: testPlanConfiguration, graph: graph, action: action
-                    ),
-                    graph: graph,
-                    mapperEnvironment: mapperEnvironment,
-                    cacheStorage: uploadCacheStorage
-                )
+                do {
+                    try await self.testScheme(
+                        scheme: testScheme,
+                        graphTraverser: graphTraverser,
+                        clean: clean,
+                        configuration: configuration,
+                        version: version,
+                        deviceName: deviceName,
+                        platform: platform,
+                        action: action,
+                        rosetta: rosetta,
+                        resultBundlePath: testSchemeResultBundlePath,
+                        derivedDataPath: derivedDataPath,
+                        retryCount: retryCount,
+                        testTargets: testSchemeRun.testTargets,
+                        skipTestTargets: skipTestTargets,
+                        testPlanConfiguration: testPlanConfiguration,
+                        passthroughXcodeBuildArguments: passthroughXcodeBuildArguments,
+                        config: config,
+                        quarantinedTests: quarantinedTests,
+                        mode: mode
+                    )
+                } catch {
+                    if try await handleTestSchemeFailure(
+                        error,
+                        scheme: testScheme,
+                        resultBundlePath: testSchemeResultBundlePath,
+                        graph: graph,
+                        mapperEnvironment: mapperEnvironment,
+                        cacheStorage: uploadCacheStorage,
+                        testPlanConfiguration: testPlanConfiguration,
+                        action: action,
+                        quarantinedTests: quarantinedTests
+                    ) {
+                        continue
+                    }
+                    throw error
+                }
+
+                if action != .build {
+                    try await storeSuccessfulTestHashes(
+                        for: testActionTargets(
+                            for: [testScheme], testPlanConfiguration: testPlanConfiguration, graph: graph, action: action
+                        ),
+                        graph: graph,
+                        mapperEnvironment: mapperEnvironment,
+                        cacheStorage: uploadCacheStorage
+                    )
+                }
             }
+        } catch {
+            // Assemble the requested result bundle from whatever schemes produced one before
+            // rethrowing, so consumers of a fixed `--result-bundle-path` still find it on failure.
+            try? await assembleRequestedResultBundle(
+                from: perSchemeResultBundlePaths,
+                resultBundlePath: resultBundlePath,
+                passedResultBundlePath: passedResultBundlePath
+            )
+            throw error
         }
+
+        try await assembleRequestedResultBundle(
+            from: perSchemeResultBundlePaths,
+            resultBundlePath: resultBundlePath,
+            passedResultBundlePath: passedResultBundlePath
+        )
 
         let verb =
             switch action {
@@ -1700,6 +1729,53 @@ public struct TestService { // swiftlint:disable:this type_body_length
         }
 
         return resultBundlePath.parentDirectory.appending(component: pathComponent)
+    }
+
+    /// When multiple schemes run, each `xcodebuild` invocation writes to its own per-scheme result
+    /// bundle (see `schemeResultBundlePath`) to avoid xcodebuild refusing to overwrite an existing
+    /// `-resultBundlePath`. That means the exact path the user asked for via `--result-bundle-path`
+    /// is never produced, breaking downstream consumers (and Tuist's own upload) that expect a
+    /// bundle at that path. This reassembles the requested bundle from the per-scheme bundles once
+    /// every scheme has run.
+    private func assembleRequestedResultBundle(
+        from perSchemeResultBundlePaths: [AbsolutePath],
+        resultBundlePath: AbsolutePath?,
+        passedResultBundlePath: AbsolutePath?
+    ) async throws {
+        guard let passedResultBundlePath,
+              let resultBundlePath,
+              resultBundlePath == passedResultBundlePath
+        else { return }
+
+        var existingPaths: [AbsolutePath] = []
+        for path in perSchemeResultBundlePaths where try await fileSystem.exists(path) {
+            existingPaths.append(path)
+        }
+        guard !existingPaths.isEmpty else { return }
+
+        if try await fileSystem.exists(resultBundlePath) {
+            try await fileSystem.remove(resultBundlePath)
+        }
+        if try await !fileSystem.exists(resultBundlePath.parentDirectory) {
+            try await fileSystem.makeDirectory(at: resultBundlePath.parentDirectory)
+        }
+
+        if existingPaths.count == 1 {
+            try await fileSystem.copy(existingPaths[0], to: resultBundlePath)
+            return
+        }
+
+        do {
+            try await xcResultToolController.merge(existingPaths, into: resultBundlePath)
+        } catch {
+            Logger.current.warning(
+                "Failed to merge per-scheme result bundles into \(resultBundlePath.pathString): \(error). Falling back to the first scheme's result bundle."
+            )
+            if try await fileSystem.exists(resultBundlePath) {
+                try await fileSystem.remove(resultBundlePath)
+            }
+            try await fileSystem.copy(existingPaths[0], to: resultBundlePath)
+        }
     }
 
     // swiftlint:disable:next function_body_length

--- a/cli/Sources/TuistSupport/Utils/XCResultToolController.swift
+++ b/cli/Sources/TuistSupport/Utils/XCResultToolController.swift
@@ -8,6 +8,7 @@ import struct TSCUtility.Version
 public protocol XCResultToolControlling {
     func resultBundleObject(_ path: AbsolutePath) async throws -> String
     func resultBundleObject(_ path: AbsolutePath, id: String) async throws -> String
+    func merge(_ resultBundlePaths: [AbsolutePath], into resultBundlePath: AbsolutePath) async throws
 }
 
 public struct XCResultToolController: XCResultToolControlling {
@@ -53,5 +54,13 @@ public struct XCResultToolController: XCResultToolControlling {
                 ]
             )
         }
+    }
+
+    public func merge(_ resultBundlePaths: [AbsolutePath], into resultBundlePath: AbsolutePath) async throws {
+        _ = try await commandRunner.capture(
+            arguments: ["/usr/bin/xcrun", "xcresulttool", "merge"]
+                + resultBundlePaths.map(\.pathString)
+                + ["--output-path", resultBundlePath.pathString]
+        )
     }
 }

--- a/cli/Tests/TuistKitTests/Services/TestServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/TestServiceTests.swift
@@ -43,6 +43,7 @@ final class TestServiceTests: TuistUnitTestCase {
     private var runMetadataStorage: RunMetadataStorage!
     private var testedSchemes: [String] = []
     private var xcResultService: MockXCResultServicing!
+    private var xcResultToolController: MockXCResultToolControlling!
     private var xcodeBuildArgumentParser: MockXcodeBuildArgumentParsing!
     private var uploadResultBundleService: MockUploadResultBundleServicing!
     private var derivedDataLocator: MockDerivedDataLocating!
@@ -70,6 +71,7 @@ final class TestServiceTests: TuistUnitTestCase {
         cacheStorage = .init()
         runMetadataStorage = RunMetadataStorage()
         xcResultService = .init()
+        xcResultToolController = .init()
         xcodeBuildArgumentParser = MockXcodeBuildArgumentParsing()
         uploadResultBundleService = .init()
         derivedDataLocator = .init()
@@ -196,6 +198,7 @@ final class TestServiceTests: TuistUnitTestCase {
             cacheDirectoriesProvider: cacheDirectoriesProvider,
             configLoader: configLoader,
             xcResultService: xcResultService,
+            xcResultToolController: xcResultToolController,
             gitController: gitController,
             uploadResultBundleService: uploadResultBundleService,
             derivedDataLocator: derivedDataLocator,
@@ -840,6 +843,60 @@ final class TestServiceTests: TuistUnitTestCase {
                 skipTestTargets: .any,
                 testPlanConfiguration: .any,
                 passthroughXcodeBuildArguments: .any
+            )
+            .called(1)
+    }
+
+    func test_run_tests_all_project_schemes_merges_per_scheme_result_bundles_into_requested_path() async throws {
+        // Given
+        givenGenerator()
+        given(buildGraphInspector)
+            .testableSchemes(graphTraverser: .any)
+            .willReturn([])
+        given(buildGraphInspector)
+            .workspaceSchemes(graphTraverser: .any)
+            .willReturn(
+                [
+                    Scheme.test(name: "ProjectSchemeOne"),
+                    Scheme.test(name: "ProjectSchemeTwo"),
+                ]
+            )
+        given(generator)
+            .generateWithGraph(path: .any, options: .any)
+            .willProduce { path, _ in
+                (path, .test(), MapperEnvironment())
+            }
+        given(configLoader)
+            .loadConfig(path: .any)
+            .willReturn(.test(project: .testGeneratedProject()))
+        given(xcResultToolController)
+            .merge(.any, into: .any)
+            .willReturn()
+
+        let resultBundlePath = try temporaryPath().appending(component: "results.xcresult")
+        let firstResultBundlePath = resultBundlePath.parentDirectory
+            .appending(component: "results-ProjectSchemeOne.xcresult")
+        let secondResultBundlePath = resultBundlePath.parentDirectory
+            .appending(component: "results-ProjectSchemeTwo.xcresult")
+        // Simulate xcodebuild writing a per-scheme result bundle for each scheme.
+        try FileManager.default.createDirectory(
+            atPath: firstResultBundlePath.pathString, withIntermediateDirectories: true
+        )
+        try FileManager.default.createDirectory(
+            atPath: secondResultBundlePath.pathString, withIntermediateDirectories: true
+        )
+
+        // When
+        try await testRun(
+            path: try temporaryPath(),
+            resultBundlePath: resultBundlePath
+        )
+
+        // Then
+        verify(xcResultToolController)
+            .merge(
+                .value([firstResultBundlePath, secondResultBundlePath]),
+                into: .value(resultBundlePath)
             )
             .called(1)
     }


### PR DESCRIPTION
> Follow-up to #11715 / #11765, reported by a customer running `tuist test --build-only --result-bundle-path <path>` and consuming the bundle with xcbeautify.

### What changed

After every scheme has run, `TestService.testSchemes` now reassembles the bundle at the exact `--result-bundle-path` the user requested, from the per-scheme bundles that were actually produced. Two or more bundles are combined with `xcrun xcresulttool merge` (new `merge(_:into:)` on `XCResultToolControlling`); a single bundle is copied into place; if merge fails we fall back to copying the first bundle so the requested path always exists. It runs on both the success and failure paths, so a failed build still yields the bundle.

### Why it changed / root cause

#11715 fixed `xcodebuild` result bundle collisions by giving each generated-project scheme its own `-resultBundlePath` (`<name>-<Scheme>.xcresult`) when a run spans more than one scheme. That stopped the collision, but it also meant the exact path the user asked for via `--result-bundle-path` was never produced on a multi-scheme run: only the per-scheme bundles existed.

A customer runs `tuist test --build-only --result-bundle-path buildlog.xcresult ...` and then feeds `buildlog.xcresult` to xcbeautify. On the #11715 backport (4.202.1) that broke with:

```
ERROR: buildlog.xcresult: invalid xcresult bundle path
Failed to load xcresult issue summary: File or directory doesn't exist at path: buildlog.xcresult.
```

because Tuist now wrote `buildlog-<Scheme>.xcresult` per scheme and never `buildlog.xcresult`. The same gap silently affected Tuist's own multi-scheme `testSummary` / `passingTargetNames` / result-bundle copy, which all read the un-suffixed path that no longer existed.

### Why this approach

The collision fix in #11715 is correct (xcodebuild refuses to overwrite an existing `-resultBundlePath`), so keeping the per-scheme bundles and assembling the requested path afterward preserves it while restoring the pre-#11715 contract that `--result-bundle-path X` yields a bundle at `X`. The reassembly is scoped to the explicitly passed path (`resultBundlePath == passedResultBundlePath`), so Tuist's internal run bundle and the existing per-scheme uploads are untouched and there is no risk of double-analyzing results. Single-scheme runs are unchanged; they already wrote the exact path.

### User impact

Consumers that pass `--result-bundle-path` and rely on a bundle existing at that exact path (external formatters, CI post-processing, and Tuist's own summary/upload) work again on multi-scheme runs. Needs backporting to `releases/4.202.x` for a 4.202.2, the same way #11765 backported #11715.

### How to test locally

1. Run `tuist test --build-only --result-bundle-path buildlog.xcresult ...` on a workspace whose default test schemes span more than one generated project.
2. Before this change, only `buildlog-<Scheme>.xcresult` files exist. After it, `buildlog.xcresult` exists and contains every scheme's results.

Automated: `xcodebuild build-for-testing` + `test-without-building` of `TuistKitTests/TestServiceTests`. New `test_run_tests_all_project_schemes_merges_per_scheme_result_bundles_into_requested_path` passes and all 87 `TestServiceTests` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)