### PR TITLE
fix: stop orphaned Hetzner volumes (kura reclaim + grace-period PV reaper)

### DIFF
--- a/infra/helm/tuist/templates/kura-controller.yaml
+++ b/infra/helm/tuist/templates/kura-controller.yaml
@@ -121,9 +121,12 @@ rules:
   # PVs are cluster-scoped too: reconcileStaleDataStorage reads a bound data
   # PVC's PersistentVolume to detect a node-local volume pinned (node affinity)
   # to a node that no longer exists — a reprovisioned bare-metal fleet node.
+  # update/patch let reclaimDataVolumes flip a data PV to reclaimPolicy Delete
+  # before the operator tears its PVC down, so the CSI driver reaps the Hetzner
+  # volume instead of stranding it under the hcloud-volumes Retain default.
   - apiGroups: [""]
     resources: [persistentvolumes]
-    verbs: [get, list, watch]
+    verbs: [get, list, watch, update, patch]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/infra/helm/tuist/templates/released-pv-reaper.yaml
+++ b/infra/helm/tuist/templates/released-pv-reaper.yaml
@@ -38,7 +38,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ $name }}
-  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "tuist.labels" . | nindent 4 }}
     app.kubernetes.io/component: released-pv-reaper
@@ -77,7 +76,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ $name }}
-  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "tuist.labels" . | nindent 4 }}
     app.kubernetes.io/component: released-pv-reaper
@@ -148,7 +146,6 @@ apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ $name }}
-  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "tuist.labels" . | nindent 4 }}
     app.kubernetes.io/component: released-pv-reaper

--- a/infra/helm/tuist/templates/released-pv-reaper.yaml
+++ b/infra/helm/tuist/templates/released-pv-reaper.yaml
@@ -1,0 +1,176 @@
+{{- if .Values.pvReaper.enabled }}
+{{- /*
+Grace-period garbage collector for orphaned Hetzner block volumes.
+
+The hcloud-volumes StorageClass provisions PVs with reclaimPolicy Retain (see
+infra/k8s/mgmt/bootstrap/hcloud-csi-values.yaml) — a deliberately conservative
+default so a botched operator action can't destroy data. The cost is that any
+operator that deletes a PVC (CNPG on a cluster rebuild/restore/failover, a
+StatefulSet teardown, a namespace removal) strands the underlying Hetzner volume
+forever: the PV goes Released and nothing reaps the block storage. That is how
+this project accumulated ~36 TB / ~€2k-per-month of dead volumes.
+
+The kura-controller now reaps its own volumes at teardown, but we don't own
+CNPG's code, so Postgres (and any future operator) needs an out-of-band sweep.
+This CronJob is that backstop: once per run it reaps every PV that has been
+Released for longer than graceHours by flipping its reclaim policy to Delete and
+deleting it, which lets the CSI driver delete the Hetzner volume.
+
+Why this is safe:
+  * A PV only becomes Released when its PVC was actually deleted. A scaled-down
+    but still-wanted volume keeps its PVC Bound (StatefulSet whenScaled: Retain),
+    so it is never Released and never touched here.
+  * The grace window is the recovery window: within graceHours a Released Retain
+    PV can still be re-bound by hand, so an accidental PVC deletion is
+    recoverable. Only volumes abandoned for longer are reaped.
+  * Scoped to storageClass hcloud-volumes and reclaimPolicy Retain, so it never
+    touches node-local (scw-local-nvme, already Delete) or non-CSI volumes.
+  * dryRun (default) only logs what it would reap. Review a run's logs in Loki /
+    Grafana Cloud, then set pvReaper.dryRun=false per env to arm it.
+
+There is intentionally no PrometheusRule here: managed clusters have no
+Prometheus Operator (they scrape via Alloy into Grafana Cloud). Alert on the
+reaper's log lines or on kube_persistentvolume_status_phase{phase="Released"} in
+Grafana Cloud instead.
+*/ -}}
+{{- $name := include "tuist.componentName" (dict "root" . "component" "released-pv-reaper") }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "tuist.labels" . | nindent 4 }}
+    app.kubernetes.io/component: released-pv-reaper
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "tuist.labels" . | nindent 4 }}
+    app.kubernetes.io/component: released-pv-reaper
+rules:
+  # List Released PVs, flip a stale one's reclaim policy to Delete, and delete
+  # it so the CSI driver reaps the backing Hetzner volume. PVs are cluster-scoped.
+  - apiGroups: [""]
+    resources: [persistentvolumes]
+    verbs: [get, list, watch, update, patch, delete]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "tuist.labels" . | nindent 4 }}
+    app.kubernetes.io/component: released-pv-reaper
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ $name }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ $name }}
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "tuist.labels" . | nindent 4 }}
+    app.kubernetes.io/component: released-pv-reaper
+data:
+  reap.sh: |-
+    #!/bin/sh
+    set -eu
+    grace_seconds=$(( GRACE_HOURS * 3600 ))
+    echo "released-pv-reaper: storageClass=${STORAGE_CLASS} graceHours=${GRACE_HOURS} dryRun=${DRY_RUN}"
+    # A PV is reapable only if it is Released (its PVC was deleted), still Retain
+    # (not already being reaped), on the target StorageClass, and has carried a
+    # phase-transition timestamp older than the grace window. A PV missing that
+    # timestamp is skipped, never assumed old.
+    pvs=$(kubectl get pv -o json | jq -r \
+      --arg sc "$STORAGE_CLASS" --argjson grace "$grace_seconds" '
+      .items[]
+      | select(.status.phase == "Released")
+      | select(.spec.persistentVolumeReclaimPolicy == "Retain")
+      | select(.spec.storageClassName == $sc)
+      | select(.status.lastPhaseTransitionTime != null)
+      | select((.status.lastPhaseTransitionTime | fromdateiso8601) < (now - $grace))
+      | .metadata.name')
+    count=$(printf '%s\n' "$pvs" | grep -c . || true)
+    echo "released-pv-reaper: ${count} PV(s) Released longer than ${GRACE_HOURS}h"
+    if [ "$count" -eq 0 ]; then
+      exit 0
+    fi
+    printf '%s\n' "$pvs" | while IFS= read -r pv; do
+      [ -z "$pv" ] && continue
+      claim=$(kubectl get pv "$pv" -o jsonpath='{.spec.claimRef.namespace}/{.spec.claimRef.name}' 2>/dev/null || echo '?')
+      if [ "$DRY_RUN" = "true" ]; then
+        echo "released-pv-reaper: [dry-run] would reap ${pv} (was ${claim})"
+      else
+        echo "released-pv-reaper: reaping ${pv} (was ${claim})"
+        kubectl patch pv "$pv" --type merge -p '{"spec":{"persistentVolumeReclaimPolicy":"Delete"}}'
+        kubectl delete pv "$pv" --wait=false
+      fi
+    done
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ $name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "tuist.labels" . | nindent 4 }}
+    app.kubernetes.io/component: released-pv-reaper
+spec:
+  schedule: {{ .Values.pvReaper.schedule | quote }}
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      activeDeadlineSeconds: 300
+      template:
+        metadata:
+          labels:
+            {{- include "tuist.labels" . | nindent 12 }}
+            app.kubernetes.io/component: released-pv-reaper
+        spec:
+          serviceAccountName: {{ $name }}
+          restartPolicy: Never
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65534
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: reaper
+              image: {{ .Values.pvReaper.image | quote }}
+              imagePullPolicy: IfNotPresent
+              command: ["/bin/sh", "/scripts/reap.sh"]
+              env:
+                - name: GRACE_HOURS
+                  value: {{ .Values.pvReaper.graceHours | quote }}
+                - name: DRY_RUN
+                  value: {{ .Values.pvReaper.dryRun | quote }}
+                - name: STORAGE_CLASS
+                  value: {{ .Values.pvReaper.storageClass | quote }}
+              volumeMounts:
+                - name: script
+                  mountPath: /scripts
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                capabilities:
+                  drop: [ALL]
+              resources:
+                {{- toYaml .Values.pvReaper.resources | nindent 16 }}
+          volumes:
+            - name: script
+              configMap:
+                name: {{ $name }}
+{{- end }}

--- a/infra/helm/tuist/templates/released-pv-reaper.yaml
+++ b/infra/helm/tuist/templates/released-pv-reaper.yaml
@@ -90,24 +90,44 @@ data:
     # A PV is reapable only if it is Released (its PVC was deleted), still Retain
     # (not already being reaped), on the target StorageClass, and has carried a
     # phase-transition timestamp older than the grace window. A PV missing that
-    # timestamp is skipped, never assumed old.
-    pvs=$(kubectl get pv -o json | jq -r \
-      --arg sc "$STORAGE_CLASS" --argjson grace "$grace_seconds" '
-      .items[]
-      | select(.status.phase == "Released")
+    # timestamp is skipped, never assumed old. The same predicate is applied
+    # twice: once to pick candidates, once to re-validate each PV immediately
+    # before acting.
+    predicate='
+      select(.status.phase == "Released")
       | select(.spec.persistentVolumeReclaimPolicy == "Retain")
       | select(.spec.storageClassName == $sc)
       | select(.status.lastPhaseTransitionTime != null)
-      | select((.status.lastPhaseTransitionTime | fromdateiso8601) < (now - $grace))
-      | .metadata.name')
-    count=$(printf '%s\n' "$pvs" | grep -c . || true)
+      | select((.status.lastPhaseTransitionTime | fromdateiso8601) < (now - $grace))'
+    # Candidates as "<name> <uid>" pairs; the UID lets us detect a PV that was
+    # deleted and recreated under the same name between scan and action.
+    candidates=$(kubectl get pv -o json | jq -r \
+      --arg sc "$STORAGE_CLASS" --argjson grace "$grace_seconds" \
+      ".items[] | ${predicate} | \"\(.metadata.name) \(.metadata.uid)\"")
+    count=$(printf '%s\n' "$candidates" | grep -c . || true)
     echo "released-pv-reaper: ${count} PV(s) Released longer than ${GRACE_HOURS}h"
     if [ "$count" -eq 0 ]; then
       exit 0
     fi
-    printf '%s\n' "$pvs" | while IFS= read -r pv; do
+    printf '%s\n' "$candidates" | while IFS=' ' read -r pv uid; do
       [ -z "$pv" ] && continue
-      claim=$(kubectl get pv "$pv" -o jsonpath='{.spec.claimRef.namespace}/{.spec.claimRef.name}' 2>/dev/null || echo '?')
+      # Re-fetch and re-validate right before acting. kubectl delete performs no
+      # resource-version check, so a PV recovered (re-bound) or replaced since the
+      # scan could otherwise be wrongly deleted. Skip unless it is the same object
+      # (UID) and still matches every reap condition.
+      current=$(kubectl get pv "$pv" -o json 2>/dev/null || true)
+      if [ -z "$current" ]; then
+        echo "released-pv-reaper: skip ${pv} (gone since scan)"
+        continue
+      fi
+      still=$(printf '%s' "$current" | jq -r \
+        --arg sc "$STORAGE_CLASS" --argjson grace "$grace_seconds" --arg uid "$uid" \
+        "select(.metadata.uid == \$uid) | ${predicate} | .metadata.name" 2>/dev/null || true)
+      if [ "$still" != "$pv" ]; then
+        echo "released-pv-reaper: skip ${pv} (changed since scan)"
+        continue
+      fi
+      claim=$(printf '%s' "$current" | jq -r '((.spec.claimRef.namespace // "?") + "/" + (.spec.claimRef.name // "?"))')
       if [ "$DRY_RUN" = "true" ]; then
         echo "released-pv-reaper: [dry-run] would reap ${pv} (was ${claim})"
       else

--- a/infra/helm/tuist/templates/released-pv-reaper.yaml
+++ b/infra/helm/tuist/templates/released-pv-reaper.yaml
@@ -83,8 +83,11 @@ metadata:
     app.kubernetes.io/component: released-pv-reaper
 data:
   reap.sh: |-
-    #!/bin/sh
-    set -eu
+    #!/usr/bin/env bash
+    # pipefail so a failed `kubectl get pv` in a pipeline aborts the run instead
+    # of feeding jq empty input and logging a healthy-looking "0 PV(s)" — the
+    # logs are this job's only observability channel.
+    set -euo pipefail
     grace_seconds=$(( GRACE_HOURS * 3600 ))
     echo "released-pv-reaper: storageClass=${STORAGE_CLASS} graceHours=${GRACE_HOURS} dryRun=${DRY_RUN}"
     # A PV is reapable only if it is Released (its PVC was deleted), still Retain
@@ -127,13 +130,17 @@ data:
         echo "released-pv-reaper: skip ${pv} (changed since scan)"
         continue
       fi
-      claim=$(printf '%s' "$current" | jq -r '((.spec.claimRef.namespace // "?") + "/" + (.spec.claimRef.name // "?"))')
+      claim=$(printf '%s' "$current" | jq -r '((.spec.claimRef.namespace // "?") + "/" + (.spec.claimRef.name // "?"))' 2>/dev/null || echo '?/?')
       if [ "$DRY_RUN" = "true" ]; then
         echo "released-pv-reaper: [dry-run] would reap ${pv} (was ${claim})"
       else
         echo "released-pv-reaper: reaping ${pv} (was ${claim})"
+        # Order matters: set Delete BEFORE deleting the PV, otherwise a Retain PV
+        # deletion would strand the volume with no PV referencing it. Once the PV
+        # is Released + Delete the reclaim controller may remove it on its own, so
+        # the explicit delete is best-effort and idempotent (--ignore-not-found).
         kubectl patch pv "$pv" --type merge -p '{"spec":{"persistentVolumeReclaimPolicy":"Delete"}}'
-        kubectl delete pv "$pv" --wait=false
+        kubectl delete pv "$pv" --ignore-not-found --wait=false
       fi
     done
 ---
@@ -171,7 +178,7 @@ spec:
             - name: reaper
               image: {{ .Values.pvReaper.image | quote }}
               imagePullPolicy: IfNotPresent
-              command: ["/bin/sh", "/scripts/reap.sh"]
+              command: ["/bin/bash", "/scripts/reap.sh"]
               env:
                 - name: GRACE_HOURS
                   value: {{ .Values.pvReaper.graceHours | quote }}

--- a/infra/helm/tuist/values.yaml
+++ b/infra/helm/tuist/values.yaml
@@ -8,6 +8,32 @@ global:
   nodeSelector: {}
   tolerations: []
 
+# Grace-period garbage collector for orphaned Hetzner block volumes (PVs left
+# Released by CNPG rebuilds, StatefulSet teardowns, etc. under the hcloud-volumes
+# Retain default). Ships to every cluster the chart is applied to. Safe to leave
+# on: dryRun only logs. After reviewing a run's logs in Grafana Cloud, set
+# dryRun=false (per env) to arm actual reaping. See templates/released-pv-reaper.yaml.
+pvReaper:
+  enabled: true
+  # dryRun logs the PVs it would reap without deleting anything. Flip to false
+  # per environment once the dry-run logs look right.
+  dryRun: true
+  schedule: "0 3 * * *"
+  # Only reap PVs that have been Released longer than this. The grace window is
+  # the recovery window for an accidental PVC deletion (default 7 days).
+  graceHours: 168
+  # Scoped to this StorageClass so node-local (scw-local-nvme) and non-CSI
+  # volumes are never touched.
+  storageClass: hcloud-volumes
+  # kubectl + jq in one image (Docker Hub, same registry as other chart images).
+  image: alpine/k8s:1.31.1
+  resources:
+    requests:
+      cpu: "25m"
+      memory: "32Mi"
+    limits:
+      memory: "64Mi"
+
 kuraController:
   enabled: false
   namespace: kura

--- a/infra/kura-controller/controllers/kurainstance_controller.go
+++ b/infra/kura-controller/controllers/kurainstance_controller.go
@@ -184,7 +184,7 @@ func terminationGracePeriodSeconds() int64 {
 // +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=nodes,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=persistentvolumeclaims,verbs=get;list;watch;update;patch;delete
-// +kubebuilder:rbac:groups="",resources=persistentvolumes,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=persistentvolumes,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses;networkpolicies,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=policy,resources=poddisruptionbudgets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=cert-manager.io,resources=certificates,verbs=get;list;watch;create;update;patch;delete
@@ -202,6 +202,15 @@ func (r *KuraInstanceReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	}
 
 	if !instance.DeletionTimestamp.IsZero() {
+		// The StatefulSet's Delete retention policy drops the data PVCs when the
+		// StatefulSet is garbage-collected with the instance, but the default
+		// hcloud-volumes StorageClass retains the underlying Hetzner volume. Flip
+		// the bound PVs to Delete first so the CSI driver reaps the block storage
+		// instead of stranding it. Must run before the finalizer is removed, while
+		// the PVCs still exist to resolve their PVs.
+		if err := r.reclaimDataVolumes(ctx, instance); err != nil {
+			return ctrl.Result{}, err
+		}
 		controllerutil.RemoveFinalizer(instance, KuraInstanceFinalizer)
 		return ctrl.Result{}, r.Update(ctx, instance)
 	}
@@ -1560,6 +1569,46 @@ func (r *KuraInstanceReconciler) reconcileDataPersistentVolumeClaims(ctx context
 	return nil
 }
 
+// reclaimDataVolumes flips the bound PersistentVolume of each of the instance's
+// data PVCs to reclaimPolicy Delete, so the CSI driver reaps the underlying
+// volume when the PVC is later removed. The cluster-default hcloud-volumes
+// StorageClass provisions PVs with reclaimPolicy Retain (a deliberately
+// conservative default that expects the owning operator to garbage-collect
+// explicitly). Without this, every operator-driven teardown of a data PVC — on
+// instance deletion and on a stale-storage recreate — orphans a Hetzner block
+// volume that keeps billing forever. Kura data is a regenerable cache, so
+// reclaiming the volume is safe. Node-local (scw-local-nvme) PVs are already
+// Delete, so the patch is a no-op there.
+func (r *KuraInstanceReconciler) reclaimDataVolumes(ctx context.Context, instance *kurav1alpha1.KuraInstance) error {
+	pvcs := &corev1.PersistentVolumeClaimList{}
+	if err := r.List(ctx, pvcs, client.InNamespace(instance.Namespace), client.MatchingLabels(selectorLabels(instance))); err != nil {
+		return err
+	}
+	dataPrefix := fmt.Sprintf("data-%s-", instance.Name)
+	for i := range pvcs.Items {
+		pvc := &pvcs.Items[i]
+		if !strings.HasPrefix(pvc.Name, dataPrefix) || pvc.Spec.VolumeName == "" {
+			continue
+		}
+		pv := &corev1.PersistentVolume{}
+		if err := r.Get(ctx, types.NamespacedName{Name: pvc.Spec.VolumeName}, pv); err != nil {
+			if apierrors.IsNotFound(err) {
+				continue
+			}
+			return err
+		}
+		if pv.Spec.PersistentVolumeReclaimPolicy == corev1.PersistentVolumeReclaimDelete {
+			continue
+		}
+		before := pv.DeepCopy()
+		pv.Spec.PersistentVolumeReclaimPolicy = corev1.PersistentVolumeReclaimDelete
+		if err := r.Patch(ctx, pv, client.MergeFrom(before)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // reconcileStaleDataStorage recreates the StatefulSet when its data PVCs can
 // never bind on the current infrastructure. It reports true while the cleanup is
 // still in flight; the caller requeues and skips the rest of the reconcile until
@@ -1578,6 +1627,12 @@ func (r *KuraInstanceReconciler) reconcileStaleDataStorage(ctx context.Context, 
 	// gone, which is what stops the recreated StatefulSet from adopting them.
 	sts := &appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{Name: instance.Name, Namespace: instance.Namespace}}
 	if err := r.Delete(ctx, sts, client.PropagationPolicy(metav1.DeletePropagationForeground)); err != nil && !apierrors.IsNotFound(err) {
+		return false, err
+	}
+	// Reap the backing volumes rather than strand them: the default
+	// hcloud-volumes StorageClass retains the Hetzner volume when its PVC is
+	// deleted, so flip each bound PV to Delete before removing the PVC below.
+	if err := r.reclaimDataVolumes(ctx, instance); err != nil {
 		return false, err
 	}
 	for ordinal := int32(0); ordinal < replicas(instance); ordinal++ {

--- a/infra/kura-controller/controllers/kurainstance_controller.go
+++ b/infra/kura-controller/controllers/kurainstance_controller.go
@@ -1621,18 +1621,24 @@ func (r *KuraInstanceReconciler) reconcileStaleDataStorage(ctx context.Context, 
 	}
 	log.FromContext(ctx).Info("recreating Kura StatefulSet for stale data storage", "reason", reason)
 
-	// Delete the StatefulSet first so it stops backing the stale PVCs, then the
-	// PVCs themselves. Both deletions are idempotent; staleDataStorageReason keeps
+	// Reap the backing volumes rather than strand them: the default
+	// hcloud-volumes StorageClass retains the Hetzner volume when its PVC is
+	// deleted, so flip each bound PV to Delete first. This must run BEFORE the
+	// StatefulSet delete: whenDeleted: Delete owner-references the PVCs to the
+	// StatefulSet, so a foreground delete can garbage-collect the PVCs (and
+	// release their PVs under Retain) before reclaimDataVolumes lists them,
+	// which would strand exactly the volumes this is meant to reclaim. Flipping
+	// while the PVCs are still Bound guarantees the CSI driver deletes the
+	// Hetzner volume once the PVC is removed.
+	if err := r.reclaimDataVolumes(ctx, instance); err != nil {
+		return false, err
+	}
+	// Delete the StatefulSet so it stops backing the stale PVCs, then the PVCs
+	// themselves. Both deletions are idempotent; staleDataStorageReason keeps
 	// returning a reason (so the caller keeps requeuing) until the objects are
 	// gone, which is what stops the recreated StatefulSet from adopting them.
 	sts := &appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{Name: instance.Name, Namespace: instance.Namespace}}
 	if err := r.Delete(ctx, sts, client.PropagationPolicy(metav1.DeletePropagationForeground)); err != nil && !apierrors.IsNotFound(err) {
-		return false, err
-	}
-	// Reap the backing volumes rather than strand them: the default
-	// hcloud-volumes StorageClass retains the Hetzner volume when its PVC is
-	// deleted, so flip each bound PV to Delete before removing the PVC below.
-	if err := r.reclaimDataVolumes(ctx, instance); err != nil {
 		return false, err
 	}
 	for ordinal := int32(0); ordinal < replicas(instance); ordinal++ {

--- a/infra/kura-controller/controllers/kurainstance_controller_test.go
+++ b/infra/kura-controller/controllers/kurainstance_controller_test.go
@@ -1759,6 +1759,141 @@ func TestKuraInstanceReconcileDoesNotShrinkPVCs(t *testing.T) {
 	}
 }
 
+func TestKuraInstanceReconcileDeletionReclaimsDataVolumes(t *testing.T) {
+	ctx := context.Background()
+	scheme := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := kurav1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+
+	replicas := int32(1)
+	now := metav1.Now()
+	instance := &kurav1alpha1.KuraInstance{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "kura-tuist-eu-1",
+			Namespace:         "kura",
+			Finalizers:        []string{KuraInstanceFinalizer},
+			DeletionTimestamp: &now,
+		},
+		Spec: kurav1alpha1.KuraInstanceSpec{
+			AccountHandle: "tuist",
+			TenantID:      "tuist",
+			Region:        "eu",
+			Image:         "ghcr.io/tuist/kura:0.5.3",
+			Replicas:      &replicas,
+			StorageSize:   "20Gi",
+		},
+	}
+	pvc := dataPersistentVolumeClaim(instance, 0, "20Gi")
+	pvc.Spec.VolumeName = "pvc-hcloud-retain"
+	pvc.Status.Phase = corev1.ClaimBound
+	pv := &corev1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: "pvc-hcloud-retain"},
+		Spec: corev1.PersistentVolumeSpec{
+			PersistentVolumeReclaimPolicy: corev1.PersistentVolumeReclaimRetain,
+		},
+	}
+
+	reconciler := &KuraInstanceReconciler{
+		Client: fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(instance, pvc, pv).
+			WithStatusSubresource(instance).
+			Build(),
+		Scheme: scheme,
+	}
+
+	if _, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: instance.Name, Namespace: instance.Namespace}}); err != nil {
+		t.Fatal(err)
+	}
+
+	updatedPV := &corev1.PersistentVolume{}
+	if err := reconciler.Get(ctx, types.NamespacedName{Name: pv.Name}, updatedPV); err != nil {
+		t.Fatal(err)
+	}
+	if got := updatedPV.Spec.PersistentVolumeReclaimPolicy; got != corev1.PersistentVolumeReclaimDelete {
+		t.Fatalf("expected data PV to be reclaimed with Delete on instance deletion, got %q", got)
+	}
+}
+
+func TestKuraInstanceReconcileStaleStorageReclaimsOldVolume(t *testing.T) {
+	ctx := context.Background()
+	scheme := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := kurav1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+
+	replicas := int32(1)
+	instance := &kurav1alpha1.KuraInstance{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "kura-tuist-eu-1",
+			Namespace:  "kura",
+			Finalizers: []string{KuraInstanceFinalizer},
+		},
+		Spec: kurav1alpha1.KuraInstanceSpec{
+			AccountHandle:    "tuist",
+			TenantID:         "tuist",
+			Region:           "eu",
+			Image:            "ghcr.io/tuist/kura:0.5.3",
+			Replicas:         &replicas,
+			StorageSize:      "20Gi",
+			StorageClassName: "scw-local-nvme",
+		},
+	}
+	sts := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{Name: instance.Name, Namespace: instance.Namespace},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas:             &replicas,
+			Selector:             &metav1.LabelSelector{MatchLabels: selectorLabels(instance)},
+			Template:             podTemplate(instance, "", "production", ""),
+			VolumeClaimTemplates: []corev1.PersistentVolumeClaim{dataVolumeClaim(instance)},
+		},
+	}
+	oldClass := "hcloud-volumes"
+	pvc := dataPersistentVolumeClaim(instance, 0, "200Gi")
+	pvc.Spec.StorageClassName = &oldClass
+	pvc.Spec.VolumeName = "pvc-hcloud-old"
+	pvc.Status.Phase = corev1.ClaimBound
+	pv := &corev1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: "pvc-hcloud-old"},
+		Spec: corev1.PersistentVolumeSpec{
+			PersistentVolumeReclaimPolicy: corev1.PersistentVolumeReclaimRetain,
+		},
+	}
+
+	reconciler := &KuraInstanceReconciler{
+		Client: fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(instance, sts, pvc, pv).
+			WithStatusSubresource(instance).
+			Build(),
+		Scheme: scheme,
+	}
+
+	if _, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: instance.Name, Namespace: instance.Namespace}}); err != nil {
+		t.Fatal(err)
+	}
+
+	updatedPV := &corev1.PersistentVolume{}
+	if err := reconciler.Get(ctx, types.NamespacedName{Name: pv.Name}, updatedPV); err != nil {
+		t.Fatal(err)
+	}
+	if got := updatedPV.Spec.PersistentVolumeReclaimPolicy; got != corev1.PersistentVolumeReclaimDelete {
+		t.Fatalf("expected stale data PV to be reclaimed with Delete before recreation, got %q", got)
+	}
+	leftover := &corev1.PersistentVolumeClaim{}
+	err := reconciler.Get(ctx, types.NamespacedName{Name: pvc.Name, Namespace: pvc.Namespace}, leftover)
+	if !apierrors.IsNotFound(err) {
+		t.Fatalf("expected stale data PVC to be deleted, got err=%v", err)
+	}
+}
+
 func TestKuraInstanceSpecSupportsLocalWorkloadOverrides(t *testing.T) {
 	replicas := int32(1)
 	instance := &kurav1alpha1.KuraInstance{


### PR DESCRIPTION
Stops the tuist-workloads Hetzner project from accumulating orphaned block volumes, which had grown to ~36 TB / ~€2k per month (~95% of the project's storage bill). This PR is the prevention; the pre-existing debris was cleaned up out-of-band (documented at the end).

Two complementary code changes.

## 1. kura-controller: reclaim data volumes at teardown

The kura-controller now flips each of an instance's data PVs to `reclaimPolicy: Delete` before it tears the PVC down (new `reclaimDataVolumes` helper), called from both teardown paths:
- the deletion finalizer branch (instance removed → StatefulSet GC'd → `whenDeleted: Delete`), and
- `reconcileStaleDataStorage` (storage-class / size / pinned-node change → StatefulSet + PVCs recreated). Reclamation runs *before* the StatefulSet delete here: `whenDeleted: Delete` owner-references the PVCs to the StatefulSet, so a foreground delete could GC them (and release their PVs) before we list them.

Adds the `persistentvolumes` `update;patch` RBAC the flip needs (kubebuilder marker + the `*-node-reads` ClusterRole).

## 2. Chart: grace-period reaper for orphaned Retain PVs

The kura fix only covers kura. CNPG (and any operator we don't own) still deletes PVCs on rebuild/restore/failover and leaves the `hcloud-volumes` PV `Released` under the `Retain` default — that is how the tuist Postgres cluster's June rebuilds left ~2 TB of orphaned 100 GB volumes. `templates/released-pv-reaper.yaml` is a CronJob (shipped to every cluster) that reaps PVs which have been `Released` longer than `graceHours` by flipping reclaim to `Delete` and deleting them, so the CSI driver deletes the backing Hetzner volume.

Safe by construction:
- A PV is only `Released` once its PVC is actually deleted; a scaled-down but still-wanted volume keeps its PVC `Bound` (StatefulSet `whenScaled: Retain`) and is never touched.
- The grace window (default 7d) is the recovery window for an accidental deletion — a `Released`/`Retain` PV can still be re-bound by hand within it.
- Scoped to `reclaimPolicy: Retain` + `storageClass: hcloud-volumes`, so node-local (`scw-local-nvme`, already `Delete`) and non-CSI volumes are never touched.
- Each candidate is re-fetched and re-validated (full predicate + UID) immediately before acting, so a PV recovered or replaced between the scan and the delete is skipped (`kubectl delete` does no resource-version check).
- `dryRun` (default `true`) only logs what it would reap; arm per-env after reviewing a run's logs.

`Retain` stays the cluster default so a botched database operation is still recoverable — this just stops the debris accumulating forever, rather than the riskier alternative of making the StorageClass `Delete`.

No `PrometheusRule`: managed clusters run no Prometheus Operator (they scrape via Alloy into Grafana Cloud), so a CRD would break the render; alert on the reaper's log lines or `kube_persistentvolume_status_phase{phase="Released"}` in Grafana Cloud instead.

## Why not just flip the StorageClass to Delete

Tempting one-liner, but wrong for databases: `Retain` is the safety net that keeps data around after a botched CNPG failover/restore. `Delete` would destroy it the instant the PVC is removed. Keeping `Retain` + reaping deliberately after a grace period preserves the safety net while ending the accumulation.

## One-time cleanup already performed (out-of-band)

The ~249 pre-existing orphans were deleted manually before this prevention landed. Method and result, for the record:

- **Cross-checked every detached volume against all 7 CAPI clusters** in the project (tuist, tuist-canary, tuist-staging, tuist-preview, atlas-production, hive-production, once-production — each backs its own CSI volumes in the shared Hetzner project). A volume was only deleted if its PV was bound to no PVC in any of the seven.
- **249 volumes deleted, 0 failures; project 265 → 16.** All 16 remaining map to a live Bound PVC (15 attached + one scaled-down-but-bound Postgres replica).
- **~36 TB reclaimed, ~€2,083/month (~€25k/year).**
- Done in batches by risk: per-account kura cache meshes (169), scaled-down staging dev meshes needing PVC/PV cleanup first (12), verified database orphans incl. the tuist Postgres relics (51), and the separate-cluster set once those clusters were reachable (17).
- **Retroactive safety check: zero live PVCs across all 7 clusters reference any deleted volume** — confirming nothing live was reaped.

## Validation

- `go build`, `go vet`, full `go test ./...` kura-controller suite pass. New tests: `TestKuraInstanceReconcileDeletionReclaimsDataVolumes`, `TestKuraInstanceReconcileStaleStorageReclaimsOldVolume`.
- `helm template` renders the whole chart and the reaper cleanly; `enabled: false` gate verified.
- Reaper filter + UID re-validation unit-tested against mock PVs: reaps only the old `Released`/`Retain`/`hcloud-volumes` PV, and keeps `Bound`, recently-released, `Delete`-policy, other-StorageClass, missing-timestamp, and stale-UID (recovered/recreated) PVs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)