### PR TITLE
fix(cli): strip CFBundleSupportedPlatforms from cached resource bundles (App Store 90542)

### DIFF
--- a/cli/Sources/TuistCache/CacheVersionFetcher.swift
+++ b/cli/Sources/TuistCache/CacheVersionFetcher.swift
@@ -38,10 +38,17 @@ enum CacheVersion: String, Equatable, Hashable {
     /// the new artifacts into a namespace those clients never resolve, so they fall back to a cache
     /// miss instead of downloading an archive they can't decompress.
     case version6 = "6"
+
+    /// Cached resource `.bundle`s are now stripped of their `CFBundleSupportedPlatforms` key, which was
+    /// stamped `[iPhoneSimulator]` because bundles are built for the simulator SDK and caused App Store
+    /// Connect to reject device archives with error 90542. Existing artifacts still carry the key, and
+    /// since the fix changes the stored bundle rather than its content hash, they must be invalidated so
+    /// they get re-warmed and normalized.
+    case version7 = "7"
 }
 
 struct CacheVersionFetcher: CacheVersionFetching {
     func version() -> CacheVersion {
-        .version6
+        .version7
     }
 }

--- a/cli/Sources/TuistCache/CachedBundlePlatformNormalizer.swift
+++ b/cli/Sources/TuistCache/CachedBundlePlatformNormalizer.swift
@@ -31,12 +31,12 @@ public struct CachedBundlePlatformNormalizer {
         ).collect()
 
         for infoPlist in Set(infoPlists) {
-            try removeSupportedPlatforms(from: infoPlist)
+            try await removeSupportedPlatforms(from: infoPlist)
         }
     }
 
-    private func removeSupportedPlatforms(from infoPlistPath: AbsolutePath) throws {
-        let data = try Data(contentsOf: infoPlistPath.url)
+    private func removeSupportedPlatforms(from infoPlistPath: AbsolutePath) async throws {
+        let data = try await fileSystem.readFile(at: infoPlistPath)
 
         var format = PropertyListSerialization.PropertyListFormat.binary
         guard var dictionary = try PropertyListSerialization.propertyList(

--- a/cli/Sources/TuistCache/CachedBundlePlatformNormalizer.swift
+++ b/cli/Sources/TuistCache/CachedBundlePlatformNormalizer.swift
@@ -1,0 +1,59 @@
+import FileSystem
+import Foundation
+import Path
+
+/// Normalizes a cached resource `.bundle` so it can be embedded into a build for any destination.
+///
+/// Cache warm builds resource `.bundle` targets for the simulator SDK only, so the bundle's
+/// `Info.plist` ends up with `CFBundleSupportedPlatforms = [iPhoneSimulator]`. When that cached
+/// bundle is embedded into a device archive, App Store Connect rejects the upload with error 90542
+/// ("Invalid CFBundleSupportedPlatforms value").
+///
+/// A resource bundle carries no executable code, so the key is meaningless for it and Apple's
+/// guidance is to remove it (https://developer.apple.com/library/archive/qa/qa1964/_index.html).
+/// Stripping it makes the cached bundle valid for both device and simulator consumers regardless of
+/// which SDK it was built against.
+public struct CachedBundlePlatformNormalizer {
+    private static let supportedPlatformsKey = "CFBundleSupportedPlatforms"
+
+    private let fileSystem: FileSysteming
+
+    public init(fileSystem: FileSysteming = FileSystem()) {
+        self.fileSystem = fileSystem
+    }
+
+    /// Removes the `CFBundleSupportedPlatforms` key from every `Info.plist` inside the bundle at
+    /// `bundlePath` (the bundle's own plist and any nested bundles).
+    public func normalize(bundleAt bundlePath: AbsolutePath) async throws {
+        let infoPlists = try await fileSystem.glob(
+            directory: bundlePath,
+            include: ["Info.plist", "**/Info.plist"]
+        ).collect()
+
+        for infoPlist in Set(infoPlists) {
+            try removeSupportedPlatforms(from: infoPlist)
+        }
+    }
+
+    private func removeSupportedPlatforms(from infoPlistPath: AbsolutePath) throws {
+        let data = try Data(contentsOf: infoPlistPath.url)
+
+        var format = PropertyListSerialization.PropertyListFormat.binary
+        guard var dictionary = try PropertyListSerialization.propertyList(
+            from: data,
+            options: [],
+            format: &format
+        ) as? [String: Any],
+            dictionary[Self.supportedPlatformsKey] != nil
+        else { return }
+
+        dictionary.removeValue(forKey: Self.supportedPlatformsKey)
+
+        let normalizedData = try PropertyListSerialization.data(
+            fromPropertyList: dictionary,
+            format: format,
+            options: 0
+        )
+        try normalizedData.write(to: infoPlistPath.url)
+    }
+}

--- a/cli/Sources/TuistKit/Commands/Cache/CacheWarmCommandService.swift
+++ b/cli/Sources/TuistKit/Commands/Cache/CacheWarmCommandService.swift
@@ -482,9 +482,15 @@ import XcodeGraph
                         validating: "Build/Products/\(productsDirectory(platform: platform, configuration: configuration))"
                     )
                 )
+            let bundlePlatformNormalizer = CachedBundlePlatformNormalizer(fileSystem: fileSystem)
             for bundle in cacheableTargets.filter({ $0.0.target.product == .bundle }) {
                 let bundlePath = bundleProductsDirectory.appending(component: bundle.0.target.productNameWithExtension)
                 guard try await fileSystem.exists(bundlePath) else { continue }
+                // Bundles are built for the simulator SDK, so their Info.plist carries
+                // CFBundleSupportedPlatforms = [iPhoneSimulator]. Left in place, a device archive that
+                // embeds the cached bundle is rejected by App Store Connect with error 90542. Removing
+                // the key normalizes the bundle for both device and simulator consumers.
+                try await bundlePlatformNormalizer.normalize(bundleAt: bundlePath)
                 bundlesToStore.append(CacheGraphTargetBuiltArtifact(
                     type: .bundle,
                     graphTarget: bundle.0,

--- a/cli/Tests/TuistCacheTests/CacheGraphContentHasherIntegrationTests.swift
+++ b/cli/Tests/TuistCacheTests/CacheGraphContentHasherIntegrationTests.swift
@@ -326,8 +326,8 @@ struct ContentHashingIntegrationTests {
         )
 
         // Then
-        #expect(firstRun[framework1]?.hash == "f68b09f927c9c4ebc63eed3d9a098602")
-        #expect(firstRun[framework2]?.hash == "22bea05d7b0e1b0ac8ad0df533883009")
+        #expect(firstRun[framework1]?.hash == "22c15857bfbb35e160776d0bee674591")
+        #expect(firstRun[framework2]?.hash == "31e5e083c8d584a578ca4c5b151165af")
         #expect(firstRun[framework1]?.hash == secondRun[framework1]?.hash)
         #expect(firstRun[framework2]?.hash == secondRun[framework2]?.hash)
         #expect(firstRun[framework1]?.hash != firstRun[framework2]?.hash)

--- a/cli/Tests/TuistCacheTests/CachedBundlePlatformNormalizerTests.swift
+++ b/cli/Tests/TuistCacheTests/CachedBundlePlatformNormalizerTests.swift
@@ -1,0 +1,81 @@
+import FileSystem
+import FileSystemTesting
+import Foundation
+import Path
+import Testing
+
+@testable import TuistCache
+
+struct CachedBundlePlatformNormalizerTests {
+    private let subject = CachedBundlePlatformNormalizer()
+
+    @Test(.inTemporaryDirectory) func normalize_removes_supported_platforms_and_keeps_other_keys() async throws {
+        // Given
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let bundlePath = temporaryDirectory.appending(component: "Sharing_Sharing.bundle")
+        try FileManager.default.createDirectory(at: bundlePath.url, withIntermediateDirectories: true)
+        try writePlist(
+            [
+                "CFBundleIdentifier": "com.example.Sharing",
+                "CFBundleSupportedPlatforms": ["iPhoneSimulator"],
+            ],
+            at: bundlePath.appending(component: "Info.plist")
+        )
+
+        // When
+        try await subject.normalize(bundleAt: bundlePath)
+
+        // Then
+        let plist = try readPlist(at: bundlePath.appending(component: "Info.plist"))
+        #expect(plist["CFBundleSupportedPlatforms"] == nil)
+        #expect(plist["CFBundleIdentifier"] as? String == "com.example.Sharing")
+    }
+
+    @Test(.inTemporaryDirectory) func normalize_removes_supported_platforms_from_nested_bundles() async throws {
+        // Given
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let bundlePath = temporaryDirectory.appending(component: "Braze_Braze.bundle")
+        let nestedBundlePath = bundlePath.appending(component: "Nested.bundle")
+        try FileManager.default.createDirectory(at: nestedBundlePath.url, withIntermediateDirectories: true)
+        try writePlist(
+            ["CFBundleSupportedPlatforms": ["iPhoneSimulator"]],
+            at: bundlePath.appending(component: "Info.plist")
+        )
+        try writePlist(
+            ["CFBundleSupportedPlatforms": ["iPhoneSimulator"]],
+            at: nestedBundlePath.appending(component: "Info.plist")
+        )
+
+        // When
+        try await subject.normalize(bundleAt: bundlePath)
+
+        // Then
+        #expect(try readPlist(at: bundlePath.appending(component: "Info.plist"))["CFBundleSupportedPlatforms"] == nil)
+        #expect(
+            try readPlist(at: nestedBundlePath.appending(component: "Info.plist"))["CFBundleSupportedPlatforms"] == nil
+        )
+    }
+
+    @Test(.inTemporaryDirectory) func normalize_is_noop_when_key_is_absent() async throws {
+        // Given
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let bundlePath = temporaryDirectory.appending(component: "NoKey.bundle")
+        try FileManager.default.createDirectory(at: bundlePath.url, withIntermediateDirectories: true)
+        let infoPlistPath = bundlePath.appending(component: "Info.plist")
+        try writePlist(["CFBundleIdentifier": "com.example.NoKey"], at: infoPlistPath)
+
+        // When / Then
+        try await subject.normalize(bundleAt: bundlePath)
+        #expect(try readPlist(at: infoPlistPath)["CFBundleIdentifier"] as? String == "com.example.NoKey")
+    }
+
+    private func writePlist(_ dictionary: [String: Any], at path: AbsolutePath) throws {
+        let data = try PropertyListSerialization.data(fromPropertyList: dictionary, format: .binary, options: 0)
+        try data.write(to: path.url)
+    }
+
+    private func readPlist(at path: AbsolutePath) throws -> [String: Any] {
+        let data = try Data(contentsOf: path.url)
+        return try #require(PropertyListSerialization.propertyList(from: data, options: [], format: nil) as? [String: Any])
+    }
+}

--- a/cli/Tests/TuistCacheTests/VersionFetcherTests.swift
+++ b/cli/Tests/TuistCacheTests/VersionFetcherTests.swift
@@ -13,6 +13,6 @@ final class CacheVersionFetcherTests: TuistUnitTestCase {
         let got = subject.version()
 
         // Then
-        XCTAssertEqual(got, .version6)
+        XCTAssertEqual(got, .version7)
     }
 }


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/6083

## What changed

Cache warm builds resource `.bundle` targets (including SwiftPM external dependency resource bundles such as swift-sharing and Braze) for the **simulator SDK only**, so their `Info.plist` carries `CFBundleSupportedPlatforms = [iPhoneSimulator]`. When such a cached bundle is embedded into a **device** archive, App Store Connect rejects the upload with **error 90542** ("Invalid CFBundleSupportedPlatforms value").

This PR normalizes cached resource bundles so they are valid for both device and simulator consumers:

- **New `CachedBundlePlatformNormalizer`** (`cli/Sources/TuistCache/`) — globs every `Info.plist` inside a bundle (its own plus any nested bundles), reads each preserving the plist format, removes the `CFBundleSupportedPlatforms` key if present, and writes it back. No-op when the key is absent.
- **`CacheWarmCommandService.buildBundles`** now runs the normalizer on each cached `.bundle` immediately before storing it.
- **Cache version bumped to `7`** (`CacheVersionFetcher`).

## Why

This is the same class of bug as #6083, reported again after a 4.142.1 → 4.200.5 upgrade on a lane using focused generation (`tuist generate App Feature`) with binary caching. Regular lanes were unaffected only because they already pass `--no-binary-cache`.

Root cause is in the open-source cache warmer: `buildBundles` builds `.bundle` products with `.destination("generic/platform=iOS Simulator")`, unlike `buildBinarySchemes`, which builds both device and simulator slices for frameworks. The bundle's cache key also has no device-vs-simulator component, so a single simulator-stamped artifact is served to every consumer regardless of build destination.

The 4.201.0 change ("avoid embedding external resource bundles in cached frameworks", #11257) did not fix this: it only changes *where the external bundle lives in the graph* (keep-as-source vs. replace-from-cache) and never touches the offending platform metadata. When the bundle is reachable from a source **app** target (the common case for an app that links the dependency), it is still substituted with the simulator-stamped cached artifact.

A resource bundle carries no executable code, so `CFBundleSupportedPlatforms` is meaningless for it and Apple's guidance ([QA1964](https://developer.apple.com/library/archive/qa/qa1964/_index.html)) is to remove it. This is also the exact normalization the long-standing community workaround performs. QA1964 is already referenced elsewhere in this same file for the framework builds.

### Why the alternatives were not chosen

- **Build bundles for the device SDK instead of the simulator** would produce `[iPhoneOS]`, which is also valid, but it is a subtler behavior change for simulator dev builds and does not match Apple's "resource bundles should not carry the key" guidance.
- **Per-SDK slices** (as attempted in an unmerged branch) do not help an embedded `.bundle`: `tuist generate` produces a single on-disk bundle that cannot vary by build destination the way an xcframework can.

### Why the cache version bump

The fix changes the stored bundle **content** but not its **content hash**. Without a version bump, an already-warmed simulator-stamped bundle for a stable dependency (swift-sharing, Braze) would be re-fetched unchanged and the fix would never take effect. Bumping the cache version moves artifacts into a new namespace, forcing a one-time re-warm that runs the normalization. This mirrors the `version5` bump, which invalidated caches for the same class of bundle-content change.

**Reviewer note:** the version bump triggers a one-time full cache re-warm for every project on upgrade. That is intentional and required for the fix to reach existing caches, but it is the main thing to weigh.

## User impact

TestFlight/App Store lanes that use focused generation with binary caching no longer need `--no-binary-cache`. After upgrading, the first cache warm rebuilds artifacts once, after which cached resource bundles no longer carry `[iPhoneSimulator]`.

## Not addressed here

The pre-existing NOTE in `buildBundles` about multi-platform bundle targets keeping only the last-built SDK (iOS-vs-macOS family) is a separate latent issue. This PR normalizes the platform key but does not change which SDK's content is cached.

### How to test locally

Automated:

```
xcodebuild test -workspace Tuist.xcworkspace -scheme TuistUnitTests \
  -only-testing:TuistCacheTests/CachedBundlePlatformNormalizerTests \
  -only-testing:TuistCacheTests/CacheVersionFetcherTests \
  CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""
```

Both suites pass, and a full `Tuist-Workspace` build with `TUIST_EE=1` compiles the `CacheWarmCommandService` integration cleanly.

End-to-end: warm the cache for a project with an SPM dependency that ships a resource bundle, archive for a device, and confirm the embedded `.bundle`'s `Info.plist` no longer contains `CFBundleSupportedPlatforms`, so the App Store upload passes validation.