### PR TITLE
fix(cli): release the routing lock before a demand fetch resolves its path

### DIFF
--- a/cas-plugin/src/proxy.rs
+++ b/cas-plugin/src/proxy.rs
@@ -2046,7 +2046,18 @@ impl Proxy {
                 // produce pruned objects (fetch_object reconstructs the
                 // instruction from the instance snapshot). An unroutable
                 // request stays a miss without opening a CAS handle.
-                let state = match self.paths.lock().unwrap().get(&request.cas_path).copied() {
+                //
+                // The lookup MUST release the `paths` guard before the match
+                // runs: a match scrutinee's temporary lives across every arm,
+                // and the fallback arm re-enters `path_state` — a self-
+                // deadlock on the non-reentrant `paths` mutex — and takes
+                // `path_instance` while holding `paths`, inverting the
+                // resolve path's lock order. One unroutable demand fetch
+                // wedged the whole proxy permanently (165 threads parked,
+                // every build on the machine silently degraded to cache-less
+                // compiles).
+                let known = self.paths.lock().unwrap().get(&request.cas_path).copied();
+                let state = match known {
                     Some(state) => Ok(Some(state)),
                     None if self
                         .resolve_instance(&request.cas_path, &request.instance)


### PR DESCRIPTION
### What

One-statement fix in the proxy's `OP_FETCH_OBJECT` handler: bind the `paths` lookup to a local before matching on it, so the mutex guard drops at the statement end instead of living across the match arms.

### Why (P1: the proxy can wedge permanently, and it ships in current canaries)

During the #11787 validation bench, the cold build silently degraded to a full recompile (~80 minutes, zero cache engagement) while the proxy looked healthy — process alive, socket accepting, 142 plugin connections open. A `sample` of the process showed **165 threads, every one parked on a mutex, with no live holder**:

- ~120 threads waiting on `paths` inside `path_state`
- ~35 threads waiting on `path_instance` inside connection routing
- the snapshot warm, the maintenance tick (which is why the stats log froze), and every publish/resolve behind them

The cause: the match scrutinee `match self.paths.lock().unwrap().get(...)` keeps its guard alive for **all** arms. The fallback arm for a not-yet-opened path then:

1. calls `path_state`, which locks `paths` again on the same thread — a self-deadlock on the non-reentrant `std::sync::Mutex`, permanent by construction; and
2. calls `resolve_instance`, which takes `path_instance` while `paths` is held — inverting the lock order the resolve path uses, an ABBA deadlock even without (1).

The trigger is ordinary, not exotic: a compiler demand fetch (`OP_FETCH_OBJECT`) for a CAS path arriving before that path's first resolve — for example the pooled DerivedData paths a warm-index build touches early, or any ⌘B build after a proxy restart (the exact case the fallback arm exists to serve). One such request wedges the proxy for good; every build on the machine from then on runs cache-less with no error anywhere.

The neighboring `OP_INVALIDATE` arm already binds first, with a comment explaining exactly this hazard — this arm just missed the same treatment.

### Validation

- Full cas-plugin suite passes; release build clean.
- Audited the remaining `match`/`if let` lock-in-scrutinee sites (`snapshot_ready`, `remote_for`, `path_state`): all either confine arm work to the guarded state or return immediately — no cross-lock work under a scrutinee guard.
- The wedged process sample (165-thread pileup) is preserved for reference; after this fix the same bench sequence is being re-run with the locally built proxy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
