### PR TITLE
fix(cli): backport result bundle path reassembly to 4.202.x (#11789)

### DIFF
--- a/cli/Sources/TuistKit/Services/TestService.swift
+++ b/cli/Sources/TuistKit/Services/TestService.swift
@@ -114,6 +114,7 @@ public struct TestService { // swiftlint:disable:this type_body_length
     private let configLoader: ConfigLoading
     private let fileSystem: FileSysteming
     private let xcResultService: XCResultServicing
+    private let xcResultToolController: XCResultToolControlling
     private let xcodeBuildAgumentParser: XcodeBuildArgumentParsing
     private let gitController: GitControlling
     private let rootDirectoryLocator: RootDirectoryLocating
@@ -155,6 +156,7 @@ public struct TestService { // swiftlint:disable:this type_body_length
         configLoader: ConfigLoading,
         fileSystem: FileSysteming = FileSystem(),
         xcResultService: XCResultServicing = XCResultService(),
+        xcResultToolController: XCResultToolControlling = XCResultToolController(),
         xcodeBuildArgumentParser: XcodeBuildArgumentParsing = XcodeBuildArgumentParser(),
         gitController: GitControlling = GitController(),
         rootDirectoryLocator: RootDirectoryLocating = RootDirectoryLocator(),
@@ -182,6 +184,7 @@ public struct TestService { // swiftlint:disable:this type_body_length
         self.configLoader = configLoader
         self.fileSystem = fileSystem
         self.xcResultService = xcResultService
+        self.xcResultToolController = xcResultToolController
         xcodeBuildAgumentParser = xcodeBuildArgumentParser
         self.gitController = gitController
         self.rootDirectoryLocator = rootDirectoryLocator
@@ -523,6 +526,7 @@ public struct TestService { // swiftlint:disable:this type_body_length
                 action: action,
                 rosetta: rosetta,
                 resultBundlePath: resultBundlePath,
+                passedResultBundlePath: passedResultBundlePath,
                 derivedDataPath: derivedDataPath,
                 retryCount: retryCount,
                 testTargets: testTargets,
@@ -1132,6 +1136,7 @@ public struct TestService { // swiftlint:disable:this type_body_length
 
     // MARK: - Helpers
 
+    // swiftlint:disable:next function_body_length
     private func testSchemes(
         _ schemes: [Scheme],
         graph: Graph,
@@ -1146,6 +1151,7 @@ public struct TestService { // swiftlint:disable:this type_body_length
         action: XcodeBuildTestAction,
         rosetta: Bool,
         resultBundlePath: AbsolutePath?,
+        passedResultBundlePath: AbsolutePath?,
         derivedDataPath: AbsolutePath?,
         retryCount: Int,
         testTargets: [TestIdentifier],
@@ -1197,64 +1203,87 @@ public struct TestService { // swiftlint:disable:this type_body_length
             return false
         }
 
-        for testSchemeRun in testSchemeRuns {
-            let testScheme = testSchemeRun.scheme
-            let testSchemeResultBundlePath = schemeResultBundlePath(
-                resultBundlePath,
-                schemeName: testScheme.name,
-                runningMultipleSchemes: testSchemeRuns.count > 1
-            )
+        let runningMultipleSchemes = testSchemeRuns.count > 1
+        var perSchemeResultBundlePaths: [AbsolutePath] = []
 
-            do {
-                try await self.testScheme(
-                    scheme: testScheme,
-                    graphTraverser: graphTraverser,
-                    clean: clean,
-                    configuration: configuration,
-                    version: version,
-                    deviceName: deviceName,
-                    platform: platform,
-                    action: action,
-                    rosetta: rosetta,
-                    resultBundlePath: testSchemeResultBundlePath,
-                    derivedDataPath: derivedDataPath,
-                    retryCount: retryCount,
-                    testTargets: testSchemeRun.testTargets,
-                    skipTestTargets: skipTestTargets,
-                    testPlanConfiguration: testPlanConfiguration,
-                    passthroughXcodeBuildArguments: passthroughXcodeBuildArguments,
-                    config: config,
-                    quarantinedTests: quarantinedTests,
-                    mode: mode
+        do {
+            for testSchemeRun in testSchemeRuns {
+                let testScheme = testSchemeRun.scheme
+                let testSchemeResultBundlePath = schemeResultBundlePath(
+                    resultBundlePath,
+                    schemeName: testScheme.name,
+                    runningMultipleSchemes: runningMultipleSchemes
                 )
-            } catch {
-                if try await handleTestSchemeFailure(
-                    error,
-                    scheme: testScheme,
-                    resultBundlePath: testSchemeResultBundlePath,
-                    graph: graph,
-                    mapperEnvironment: mapperEnvironment,
-                    cacheStorage: uploadCacheStorage,
-                    testPlanConfiguration: testPlanConfiguration,
-                    action: action,
-                    quarantinedTests: quarantinedTests
-                ) {
-                    continue
+                if runningMultipleSchemes, let testSchemeResultBundlePath {
+                    perSchemeResultBundlePaths.append(testSchemeResultBundlePath)
                 }
-                throw error
-            }
 
-            if action != .build {
-                try await storeSuccessfulTestHashes(
-                    for: testActionTargets(
-                        for: [testScheme], testPlanConfiguration: testPlanConfiguration, graph: graph, action: action
-                    ),
-                    graph: graph,
-                    mapperEnvironment: mapperEnvironment,
-                    cacheStorage: uploadCacheStorage
-                )
+                do {
+                    try await self.testScheme(
+                        scheme: testScheme,
+                        graphTraverser: graphTraverser,
+                        clean: clean,
+                        configuration: configuration,
+                        version: version,
+                        deviceName: deviceName,
+                        platform: platform,
+                        action: action,
+                        rosetta: rosetta,
+                        resultBundlePath: testSchemeResultBundlePath,
+                        derivedDataPath: derivedDataPath,
+                        retryCount: retryCount,
+                        testTargets: testSchemeRun.testTargets,
+                        skipTestTargets: skipTestTargets,
+                        testPlanConfiguration: testPlanConfiguration,
+                        passthroughXcodeBuildArguments: passthroughXcodeBuildArguments,
+                        config: config,
+                        quarantinedTests: quarantinedTests,
+                        mode: mode
+                    )
+                } catch {
+                    if try await handleTestSchemeFailure(
+                        error,
+                        scheme: testScheme,
+                        resultBundlePath: testSchemeResultBundlePath,
+                        graph: graph,
+                        mapperEnvironment: mapperEnvironment,
+                        cacheStorage: uploadCacheStorage,
+                        testPlanConfiguration: testPlanConfiguration,
+                        action: action,
+                        quarantinedTests: quarantinedTests
+                    ) {
+                        continue
+                    }
+                    throw error
+                }
+
+                if action != .build {
+                    try await storeSuccessfulTestHashes(
+                        for: testActionTargets(
+                            for: [testScheme], testPlanConfiguration: testPlanConfiguration, graph: graph, action: action
+                        ),
+                        graph: graph,
+                        mapperEnvironment: mapperEnvironment,
+                        cacheStorage: uploadCacheStorage
+                    )
+                }
             }
+        } catch {
+            // Assemble the requested result bundle from whatever schemes produced one before
+            // rethrowing, so consumers of a fixed `--result-bundle-path` still find it on failure.
+            try? await assembleRequestedResultBundle(
+                from: perSchemeResultBundlePaths,
+                resultBundlePath: resultBundlePath,
+                passedResultBundlePath: passedResultBundlePath
+            )
+            throw error
         }
+
+        try await assembleRequestedResultBundle(
+            from: perSchemeResultBundlePaths,
+            resultBundlePath: resultBundlePath,
+            passedResultBundlePath: passedResultBundlePath
+        )
 
         let verb =
             switch action {
@@ -1700,6 +1729,53 @@ public struct TestService { // swiftlint:disable:this type_body_length
         }
 
         return resultBundlePath.parentDirectory.appending(component: pathComponent)
+    }
+
+    /// When multiple schemes run, each `xcodebuild` invocation writes to its own per-scheme result
+    /// bundle (see `schemeResultBundlePath`) to avoid xcodebuild refusing to overwrite an existing
+    /// `-resultBundlePath`. That means the exact path the user asked for via `--result-bundle-path`
+    /// is never produced, breaking downstream consumers (and Tuist's own upload) that expect a
+    /// bundle at that path. This reassembles the requested bundle from the per-scheme bundles once
+    /// every scheme has run.
+    private func assembleRequestedResultBundle(
+        from perSchemeResultBundlePaths: [AbsolutePath],
+        resultBundlePath: AbsolutePath?,
+        passedResultBundlePath: AbsolutePath?
+    ) async throws {
+        guard let passedResultBundlePath,
+              let resultBundlePath,
+              resultBundlePath == passedResultBundlePath
+        else { return }
+
+        var existingPaths: [AbsolutePath] = []
+        for path in perSchemeResultBundlePaths where try await fileSystem.exists(path) {
+            existingPaths.append(path)
+        }
+        guard !existingPaths.isEmpty else { return }
+
+        if try await fileSystem.exists(resultBundlePath) {
+            try await fileSystem.remove(resultBundlePath)
+        }
+        if try await !fileSystem.exists(resultBundlePath.parentDirectory) {
+            try await fileSystem.makeDirectory(at: resultBundlePath.parentDirectory)
+        }
+
+        if existingPaths.count == 1 {
+            try await fileSystem.copy(existingPaths[0], to: resultBundlePath)
+            return
+        }
+
+        do {
+            try await xcResultToolController.merge(existingPaths, into: resultBundlePath)
+        } catch {
+            Logger.current.warning(
+                "Failed to merge per-scheme result bundles into \(resultBundlePath.pathString): \(error). Falling back to the first scheme's result bundle."
+            )
+            if try await fileSystem.exists(resultBundlePath) {
+                try await fileSystem.remove(resultBundlePath)
+            }
+            try await fileSystem.copy(existingPaths[0], to: resultBundlePath)
+        }
     }
 
     // swiftlint:disable:next function_body_length

--- a/cli/Sources/TuistSupport/Utils/XCResultToolController.swift
+++ b/cli/Sources/TuistSupport/Utils/XCResultToolController.swift
@@ -8,6 +8,7 @@ import struct TSCUtility.Version
 public protocol XCResultToolControlling {
     func resultBundleObject(_ path: AbsolutePath) async throws -> String
     func resultBundleObject(_ path: AbsolutePath, id: String) async throws -> String
+    func merge(_ resultBundlePaths: [AbsolutePath], into resultBundlePath: AbsolutePath) async throws
 }
 
 public struct XCResultToolController: XCResultToolControlling {
@@ -53,5 +54,13 @@ public struct XCResultToolController: XCResultToolControlling {
                 ]
             )
         }
+    }
+
+    public func merge(_ resultBundlePaths: [AbsolutePath], into resultBundlePath: AbsolutePath) async throws {
+        _ = try await commandRunner.capture(
+            arguments: ["/usr/bin/xcrun", "xcresulttool", "merge"]
+                + resultBundlePaths.map(\.pathString)
+                + ["--output-path", resultBundlePath.pathString]
+        )
     }
 }

--- a/cli/Tests/TuistKitTests/Services/TestServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/TestServiceTests.swift
@@ -43,6 +43,7 @@ final class TestServiceTests: TuistUnitTestCase {
     private var runMetadataStorage: RunMetadataStorage!
     private var testedSchemes: [String] = []
     private var xcResultService: MockXCResultServicing!
+    private var xcResultToolController: MockXCResultToolControlling!
     private var xcodeBuildArgumentParser: MockXcodeBuildArgumentParsing!
     private var uploadResultBundleService: MockUploadResultBundleServicing!
     private var derivedDataLocator: MockDerivedDataLocating!
@@ -70,6 +71,7 @@ final class TestServiceTests: TuistUnitTestCase {
         cacheStorage = .init()
         runMetadataStorage = RunMetadataStorage()
         xcResultService = .init()
+        xcResultToolController = .init()
         xcodeBuildArgumentParser = MockXcodeBuildArgumentParsing()
         uploadResultBundleService = .init()
         derivedDataLocator = .init()
@@ -196,6 +198,7 @@ final class TestServiceTests: TuistUnitTestCase {
             cacheDirectoriesProvider: cacheDirectoriesProvider,
             configLoader: configLoader,
             xcResultService: xcResultService,
+            xcResultToolController: xcResultToolController,
             gitController: gitController,
             uploadResultBundleService: uploadResultBundleService,
             derivedDataLocator: derivedDataLocator,
@@ -840,6 +843,60 @@ final class TestServiceTests: TuistUnitTestCase {
                 skipTestTargets: .any,
                 testPlanConfiguration: .any,
                 passthroughXcodeBuildArguments: .any
+            )
+            .called(1)
+    }
+
+    func test_run_tests_all_project_schemes_merges_per_scheme_result_bundles_into_requested_path() async throws {
+        // Given
+        givenGenerator()
+        given(buildGraphInspector)
+            .testableSchemes(graphTraverser: .any)
+            .willReturn([])
+        given(buildGraphInspector)
+            .workspaceSchemes(graphTraverser: .any)
+            .willReturn(
+                [
+                    Scheme.test(name: "ProjectSchemeOne"),
+                    Scheme.test(name: "ProjectSchemeTwo"),
+                ]
+            )
+        given(generator)
+            .generateWithGraph(path: .any, options: .any)
+            .willProduce { path, _ in
+                (path, .test(), MapperEnvironment())
+            }
+        given(configLoader)
+            .loadConfig(path: .any)
+            .willReturn(.test(project: .testGeneratedProject()))
+        given(xcResultToolController)
+            .merge(.any, into: .any)
+            .willReturn()
+
+        let resultBundlePath = try temporaryPath().appending(component: "results.xcresult")
+        let firstResultBundlePath = resultBundlePath.parentDirectory
+            .appending(component: "results-ProjectSchemeOne.xcresult")
+        let secondResultBundlePath = resultBundlePath.parentDirectory
+            .appending(component: "results-ProjectSchemeTwo.xcresult")
+        // Simulate xcodebuild writing a per-scheme result bundle for each scheme.
+        try FileManager.default.createDirectory(
+            atPath: firstResultBundlePath.pathString, withIntermediateDirectories: true
+        )
+        try FileManager.default.createDirectory(
+            atPath: secondResultBundlePath.pathString, withIntermediateDirectories: true
+        )
+
+        // When
+        try await testRun(
+            path: try temporaryPath(),
+            resultBundlePath: resultBundlePath
+        )
+
+        // Then
+        verify(xcResultToolController)
+            .merge(
+                .value([firstResultBundlePath, secondResultBundlePath]),
+                into: .value(resultBundlePath)
             )
             .called(1)
     }


### PR DESCRIPTION
Backports #11789 onto `releases/4.202.x`, the same way #11765 backported #11715. Together with #11765 (already on this line), this closes out the multi-scheme result bundle behavior on the 4.202 line.

### What changed

Cherry-pick of #11789 (squash `15d3ab86d8`) onto the release line. After every scheme has run, `TestService.testSchemes` reassembles the bundle at the exact `--result-bundle-path` the caller requested from the per-scheme bundles that were produced (two or more combined with `xcrun xcresulttool merge`, a single one copied, first-bundle fallback on merge failure). Runs on both success and failure paths.

### Why

#11765 (backport of #11715) fixed the result bundle collision by giving each generated-project scheme its own `-resultBundlePath` (`<name>-<Scheme>.xcresult`) on multi-scheme runs. That stopped the collision but meant the exact path the caller asked for via `--result-bundle-path` was never produced. A customer running `tuist test --build-only --result-bundle-path buildlog.xcresult ...` and feeding `buildlog.xcresult` to xcbeautify hit this on 4.202.1:

```
ERROR: buildlog.xcresult: invalid xcresult bundle path
Failed to load xcresult issue summary: File or directory doesn't exist at path: buildlog.xcresult.
```

because Tuist wrote `buildlog-<Scheme>.xcresult` per scheme and never `buildlog.xcresult`. This unblocks that customer on the stable 4.202 line via a 4.202.2 patch.

### Cherry-pick notes

- Applied with no source conflicts (clean 3-way merge against the release-line tree); all required primitives (`schemeResultBundlePath`, `handleTestSchemeFailure` from #11765) are present on this line.
- No `cli/TuistCacheEE` change is needed: the fix touches `XCResultToolControlling` (TuistSupport) and `TestService` only, not the shared cache protocol, and the EE submodule does not reference `XCResultToolControlling`. The EE pin stays frozen at the base tag.

### Validation

The identical change was compiled and exercised on `main` (via #11789): the new `test_run_tests_all_project_schemes_merges_per_scheme_result_bundles_into_requested_path` plus all 87 `TestServiceTests` pass. Local full-tree build validation of this release line is blocked by an Xcode-toolchain incompatibility unrelated to the change (the build system crashes while compiling upstream dependencies, before any Tuist source), so CI on this branch is the source of truth for the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)