### PR TITLE
Fix intermittent SIGKILL (Code Signature Invalid) of Swift macro plugin executables by replacing them atomically

### DIFF
--- a/cli/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
+++ b/cli/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
@@ -522,12 +522,20 @@ struct BuildPhaseGenerator: BuildPhaseGenerating {
             }
         }
 
-        let copyLines = executableNames.map {
-            """
-            if [[ -f "$BUILD_DIR/$CONFIGURATION/\($0)" ]]; then
+        // The executable is copied to a temporary file and moved over the destination
+        // rather than overwritten in place with `cp -f`: macOS invalidates the cached
+        // code-signature state of an executable that is modified in place, and kills
+        // subsequent spawns with SIGKILL (Code Signature Invalid), which surfaces as
+        // "external macro implementation ... produced malformed response". The atomic
+        // rename gives the destination a fresh inode, avoiding the invalidation.
+        let copyLines = executableNames.map { executableName in
+            let sourcePath = "$BUILD_DIR/$CONFIGURATION/\(executableName)"
+            let destinationPath = "$BUILD_DIR/Debug$EFFECTIVE_PLATFORM_NAME/\(executableName)"
+            return """
+            if [[ -f "\(sourcePath)" ]]; then
                 mkdir -p "$BUILD_DIR/Debug$EFFECTIVE_PLATFORM_NAME/"
-                if [[ "$BUILD_DIR/$CONFIGURATION/\($0)" != "$BUILD_DIR/Debug$EFFECTIVE_PLATFORM_NAME/\($0)" ]]; then
-                    cp -f "$BUILD_DIR/$CONFIGURATION/\($0)" "$BUILD_DIR/Debug$EFFECTIVE_PLATFORM_NAME/\($0)"
+                if [[ "\(sourcePath)" != "\(destinationPath)" ]]; then
+                    cp "\(sourcePath)" "\(destinationPath).tmp" && mv -f "\(destinationPath).tmp" "\(destinationPath)"
                 fi
             fi
             """

--- a/cli/Tests/TuistGeneratorTests/Generator/BuildPhaseGeneratorTests.swift
+++ b/cli/Tests/TuistGeneratorTests/Generator/BuildPhaseGeneratorTests.swift
@@ -2203,7 +2203,7 @@ struct BuildPhaseGeneratorTests {
         #expect(buildPhase != nil)
 
         let expectedScript =
-            "if [[ -f \"$BUILD_DIR/$CONFIGURATION/macro\" ]]; then\n    mkdir -p \"$BUILD_DIR/Debug$EFFECTIVE_PLATFORM_NAME/\"\n    if [[ \"$BUILD_DIR/$CONFIGURATION/macro\" != \"$BUILD_DIR/Debug$EFFECTIVE_PLATFORM_NAME/macro\" ]]; then\n        cp -f \"$BUILD_DIR/$CONFIGURATION/macro\" \"$BUILD_DIR/Debug$EFFECTIVE_PLATFORM_NAME/macro\"\n    fi\nfi"
+            "if [[ -f \"$BUILD_DIR/$CONFIGURATION/macro\" ]]; then\n    mkdir -p \"$BUILD_DIR/Debug$EFFECTIVE_PLATFORM_NAME/\"\n    if [[ \"$BUILD_DIR/$CONFIGURATION/macro\" != \"$BUILD_DIR/Debug$EFFECTIVE_PLATFORM_NAME/macro\" ]]; then\n        cp \"$BUILD_DIR/$CONFIGURATION/macro\" \"$BUILD_DIR/Debug$EFFECTIVE_PLATFORM_NAME/macro.tmp\" && mv -f \"$BUILD_DIR/Debug$EFFECTIVE_PLATFORM_NAME/macro.tmp\" \"$BUILD_DIR/Debug$EFFECTIVE_PLATFORM_NAME/macro\"\n    fi\nfi"
         #expect(buildPhase?.shellScript?.contains(expectedScript) == true)
         #expect(
             buildPhase?.inputPaths ==


### PR DESCRIPTION
### Problem

Projects that use Swift macros through Tuist occasionally fail to build with errors like:

```
error: external macro implementation type 'MyMacros.MyMacro' could not be found for macro 'MyMacro(_:)';
'.../Build/Products/Debug-iphonesimulator/MyMacros' produced malformed response
```

The failures are hard to reproduce: they appear out of nowhere, stick around for a few consecutive builds, and then go away on their own (or after a clean build or deleting DerivedData). Crash reports in `~/Library/Logs/DiagnosticReports/` show that the plugin executable is killed by the kernel the moment the compiler spawns it:

```
"exception" : {"signal":"SIGKILL (Code Signature Invalid)", "type":"EXC_CRASH"},
"termination" : {"namespace":"CODESIGNING","indicator":"Taskgated Invalid Signature"},
"parentProc" : "swift-frontend",
"procPath" : ".../Build/Products/Debug-iphonesimulator/MyMacros"
```

On one of our developer machines this was happening 30 to 50 times per plugin on a normal workday.

### Cause

The "Copy Swift Macro executable into $BUILT_PRODUCT_DIR" build phase copies the plugin with `cp -f`, which overwrites the destination file in place and keeps the same inode. macOS tracks code signature validity per vnode and invalidates it when an executable is modified in place. SourceKit and swift-frontend constantly spawn the plugin from `$BUILD_DIR/Debug$EFFECTIVE_PLATFORM_NAME/` while a file that expands the macro is open in the editor, so by the time the copy runs, the destination has almost always been executed at least once. The next relink and re-copy of the plugin poisons the file, and every spawn after that dies with `SIGKILL (Code Signature Invalid)`, which swift-frontend reports as "produced malformed response". The file stays broken until the copy phase happens to run again, which is why the failures come in bursts and then vanish, typically after a clean.

This is a well-known macOS pitfall: an executable should be replaced by writing a new file and renaming it over the old one, never by modifying it in place.

### Fix

Copy to a temporary file next to the destination and move it over with `mv -f`. The rename is atomic and gives the destination a fresh inode: a partially written executable is never visible, the stale signature state of the old vnode no longer matters, and plugin processes that are already running keep the old, now unlinked, inode.

```swift
let copyLines = executableNames.map { executableName in
    let sourcePath = "$BUILD_DIR/$CONFIGURATION/\(executableName)"
    let destinationPath = "$BUILD_DIR/Debug$EFFECTIVE_PLATFORM_NAME/\(executableName)"
    return """
    if [[ -f "\(sourcePath)" ]]; then
        mkdir -p "$BUILD_DIR/Debug$EFFECTIVE_PLATFORM_NAME/"
        if [[ "\(sourcePath)" != "\(destinationPath)" ]]; then
            cp "\(sourcePath)" "\(destinationPath).tmp" && mv -f "\(destinationPath).tmp" "\(destinationPath)"
        fi
    fi
    """
}
```

The change lives in `generateCopySwiftMacroExecutableScriptBuildPhase` in `cli/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift`, and the expected script in `cli/Tests/TuistGeneratorTests/Generator/BuildPhaseGeneratorTests.swift` is updated to match.
