### PR TITLE
fix(server): surface project creation errors

### DIFF
--- a/server/lib/tuist_web/live/projects_live.ex
+++ b/server/lib/tuist_web/live/projects_live.ex
@@ -331,7 +331,7 @@ defmodule TuistWeb.ProjectsLive do
 
   defp create_project_form(assigns) do
     ~H"""
-    <.form id={@id} for={@form} phx-submit="create-project">
+    <.form id={@id} for={@form} phx-change="validate-project" phx-submit="create-project">
       <.modal
         id={"#{@id}-modal"}
         title={dgettext("dashboard_projects", "Create project")}
@@ -360,6 +360,8 @@ defmodule TuistWeb.ProjectsLive do
             id={"#{@id}-input"}
             field={@form[:name]}
             label={dgettext("dashboard_projects", "Name")}
+            show_required
+            required
           />
           <div style="display: flex; flex-direction: column; gap: var(--noora-spacing-2);">
             <.label
@@ -390,7 +392,11 @@ defmodule TuistWeb.ProjectsLive do
               />
             </:action>
             <:action>
-              <.button label={dgettext("dashboard_projects", "Create")} type="submit" />
+              <.button
+                label={dgettext("dashboard_projects", "Create")}
+                type="submit"
+                form={@id}
+              />
             </:action>
           </.modal_footer>
         </:footer>
@@ -423,6 +429,16 @@ defmodule TuistWeb.ProjectsLive do
 
   def handle_event("select_build_system", %{"value" => [value]}, socket) do
     {:noreply, assign(socket, selected_build_system: value)}
+  end
+
+  def handle_event("validate-project", %{"project" => params}, socket) do
+    form =
+      params
+      |> Project.create_changeset()
+      |> Map.put(:action, :validate)
+      |> to_form()
+
+    {:noreply, assign(socket, form: form)}
   end
 
   def handle_event("create-project", %{"project" => %{"name" => name}}, socket) do

--- a/server/priv/gettext/dashboard_projects.pot
+++ b/server/priv/gettext/dashboard_projects.pot
@@ -756,7 +756,7 @@ msgstr ""
 #: lib/tuist_web/live/project_automations_live.html.heex:858
 #: lib/tuist_web/live/project_bundle_settings_live.html.heex:198
 #: lib/tuist_web/live/project_notifications_live.html.heex:500
-#: lib/tuist_web/live/projects_live.ex:393
+#: lib/tuist_web/live/projects_live.ex:396
 #, elixir-autogen, elixir-format
 msgid "Create"
 msgstr ""
@@ -813,13 +813,13 @@ msgid "Automations"
 msgstr ""
 
 #: lib/tuist_web/live/create_project_live.ex:99
-#: lib/tuist_web/live/projects_live.ex:372
+#: lib/tuist_web/live/projects_live.ex:374
 #, elixir-autogen, elixir-format
 msgid "Build system"
 msgstr ""
 
 #: lib/tuist_web/live/create_project_live.ex:93
-#: lib/tuist_web/live/projects_live.ex:366
+#: lib/tuist_web/live/projects_live.ex:368
 #, elixir-autogen, elixir-format
 msgid "Select build system"
 msgstr ""

--- a/server/test/tuist_web/live/projects_live_test.exs
+++ b/server/test/tuist_web/live/projects_live_test.exs
@@ -1,0 +1,58 @@
+defmodule TuistWeb.ProjectsLiveTest do
+  use TuistTestSupport.Cases.ConnCase, async: true
+  use TuistTestSupport.Cases.LiveCase, async: true
+
+  import Phoenix.LiveViewTest
+
+  alias Tuist.Projects
+  alias TuistTestSupport.Fixtures.AccountsFixtures
+
+  setup %{conn: conn} do
+    user = AccountsFixtures.user_fixture()
+
+    %{account: account} =
+      AccountsFixtures.organization_fixture(
+        creator: user,
+        preload: [:account]
+      )
+
+    conn =
+      conn
+      |> assign(:selected_account, account)
+      |> log_in_user(user)
+
+    %{conn: conn, account: account}
+  end
+
+  test "creates a project with the selected build system", %{conn: conn, account: account} do
+    {:ok, view, _html} = live(conn, ~p"/#{account.name}/projects")
+
+    render_hook(view, "select_build_system", %{"value" => ["gradle"]})
+
+    view
+    |> form("#create-project-form", project: %{name: "my-project"})
+    |> render_submit()
+
+    project = Projects.get_project_by_account_and_project_handles(account.name, "my-project")
+
+    assert project.build_system == :gradle
+  end
+
+  test "shows why a reserved project name cannot be created", %{conn: conn, account: account} do
+    {:ok, view, _html} = live(conn, ~p"/#{account.name}/projects")
+
+    render_change(view, "validate-project", %{"project" => %{"name" => "test"}})
+
+    html = view |> element("#create-project-form-modal-portal") |> render()
+
+    assert html =~ "is reserved"
+  end
+
+  test "associates the portal-rendered create button with its form", %{conn: conn, account: account} do
+    {:ok, view, _html} = live(conn, ~p"/#{account.name}/projects")
+
+    html = view |> element("#create-project-form-modal-footer-portal") |> render()
+
+    assert html =~ ~s(form="create-project-form")
+  end
+end


### PR DESCRIPTION
## What changed

The project creation modal now validates names while they are edited, marks the name as required, and explicitly associates the portal-rendered Create button with the form it submits.

Focused coverage now verifies successful creation with the selected build system, visible feedback for reserved names, and the Create button's form association.

## Why

Entering a reserved project name such as `test` and pressing Create appeared to do nothing. The modal needed to explain why creation could not proceed and reliably submit valid values.

## Root cause

`test` is intentionally blocked by the project name changeset. The form did not run that validation while the user was editing, so the reserved-name constraint was not visible before submission.

The modal footer is rendered through a portal, which means the Create button cannot rely on document nesting to identify its form. Without an explicit form association, pressing it did not reliably dispatch the project creation event.

## Approach

The form reuses `Project.create_changeset/2` for live validation, keeping browser feedback aligned with the server-side creation rules. The Create button carries the form identifier explicitly, so it remains connected after portal rendering.

## Impact

Invalid project names now receive immediate, actionable feedback. Valid names submit normally, preserve the selected build system, close the modal, and appear in the project list. No migration or configuration change is required.

## Browser verification

Before, pressing Create with the reserved name `test` produced no visible feedback:

![Create project modal before the fix](https://github.com/user-attachments/assets/9a038b39-f713-4d53-884e-e208795a0821)

After, the same value shows the reserved-name error inline:

![Create project modal showing the reserved-name error](https://github.com/user-attachments/assets/654c6152-4c9e-41a2-8854-d1c77a932820)

A valid name submits successfully and appears in the project list:

![Project list showing the newly created browser verification project](https://github.com/user-attachments/assets/7fed54d0-a3af-45f0-bc5a-3bf85f25f3cc)

## Validation

- `mise x -- mix test test/tuist_web/live/projects_live_test.exs`: 3 tests passed.
- `mise x -- mix format --check-formatted lib/tuist_web/live/projects_live.ex test/tuist_web/live/projects_live_test.exs`: passed.
- A local [headless Chrome](https://developer.chrome.com/docs/chromium/headless/) click-through confirmed both reserved-name feedback and successful creation.
