### PR TITLE
fix(search): point the Typesense ExternalSecret at the real 1Password items

### DIFF
--- a/infra/helm/typesense/AGENTS.md
+++ b/infra/helm/typesense/AGENTS.md
@@ -16,7 +16,12 @@ agent search service will delegate to in a follow-up.
 - `Ingress` exposes `search.tuist.dev` through ingress-nginx with a
   cert-manager certificate; external-dns publishes the record.
 - `TYPESENSE_API_KEY` and `GITHUB_TOKEN` come from 1Password via an
-  ExternalSecret in production, or inline for CI and dev.
+  ExternalSecret in production (or inline for CI and dev). The ExternalSecret
+  reads two items through the per-env `onepassword` ClusterSecretStore, which is
+  scoped to the `tuist-k8s-<env>` vault: `TYPESENSE_API_KEY/password` and
+  `SEARCH_GITHUB_TOKEN/password`. These mirror the item names in the `cache`
+  vault that the Kamal deployment reads directly; copy them into the per-env
+  vault (do not move them while the Kamal box is still live).
 
 ## Collections
 

--- a/infra/helm/typesense/templates/externalsecret.yaml
+++ b/infra/helm/typesense/templates/externalsecret.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.runtimeSecrets.externalSecret.enabled }}
-{{- $item := required "runtimeSecrets.externalSecret.item is required when runtimeSecrets.externalSecret.enabled is true" .Values.runtimeSecrets.externalSecret.item -}}
+{{- $apiKeyRef := required "runtimeSecrets.externalSecret.apiKeyRef is required when runtimeSecrets.externalSecret.enabled is true" .Values.runtimeSecrets.externalSecret.apiKeyRef -}}
+{{- $githubTokenRef := required "runtimeSecrets.externalSecret.githubTokenRef is required when runtimeSecrets.externalSecret.enabled is true" .Values.runtimeSecrets.externalSecret.githubTokenRef -}}
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
@@ -24,8 +25,8 @@ spec:
   data:
     - secretKey: API_KEY
       remoteRef:
-        key: {{ printf "%s/%s" $item .Values.runtimeSecrets.externalSecret.fields.apiKey | quote }}
+        key: {{ $apiKeyRef | quote }}
     - secretKey: GITHUB_TOKEN
       remoteRef:
-        key: {{ printf "%s/%s" $item .Values.runtimeSecrets.externalSecret.fields.githubToken | quote }}
+        key: {{ $githubTokenRef | quote }}
 {{- end }}

--- a/infra/helm/typesense/values-production.yaml
+++ b/infra/helm/typesense/values-production.yaml
@@ -14,7 +14,6 @@ ingress:
 runtimeSecrets:
   externalSecret:
     enabled: true
-    item: SEARCH
 
 networkPolicy:
   enabled: true

--- a/infra/helm/typesense/values.yaml
+++ b/infra/helm/typesense/values.yaml
@@ -52,10 +52,11 @@ runtimeSecrets:
     storeRef:
       kind: ClusterSecretStore
       name: onepassword
-    item: ""
-    fields:
-      apiKey: api-key
-      githubToken: github-token
+    # 1Password item/field paths. The vault comes from the store (the per-env
+    # `tuist-k8s-<env>` vault), so these mirror the item names already used in
+    # the `cache` vault: two items, each with a `password` field.
+    apiKeyRef: "TYPESENSE_API_KEY/password"
+    githubTokenRef: "SEARCH_GITHUB_TOKEN/password"
 
 persistence:
   create: true


### PR DESCRIPTION
> Describe here the purpose of your PR.

Follow-up to #11762. The first production deploy of the in-cluster Typesense failed at `helm upgrade`, and this fixes the cause.

## Root cause

The deploy rolled back because the ExternalSecret could not resolve from 1Password:

```
ExternalSecret/typesense/typesense-runtime not ready: could not get secret data from provider
Deployment/typesense not ready: Available: 0/1
```

No secret meant the pod never received `TYPESENSE_API_KEY`, so the Deployment stayed at 0/1 and the atomic release was uninstalled.

The chart guessed a single `SEARCH` 1Password item with `api-key`/`github-token` fields. The real secrets are two separate items, each with a `password` field, the same names the Kamal deployment reads from the `cache` vault: `TYPESENSE_API_KEY` and `SEARCH_GITHUB_TOKEN`.

## What changed

- The ExternalSecret now reads `TYPESENSE_API_KEY/password` and `SEARCH_GITHUB_TOKEN/password`, using the same `item/field` remoteRef key format the working slack ExternalSecret uses.
- `values.yaml` replaces the single-item `item`/`fields` model with two explicit refs (`apiKeyRef`, `githubTokenRef`); `values-production.yaml` drops the stale `item: SEARCH`.
- The chart AGENTS.md documents that these two items must be copied into the per-env `tuist-k8s-<env>` vault (the scope of the `onepassword` ClusterSecretStore), not moved out of `cache` while the Kamal box is still live.

## Required before re-deploy (not code)

1. Copy `TYPESENSE_API_KEY` (field `password`) and `SEARCH_GITHUB_TOKEN` (field `password`) from the `cache` vault into `tuist-k8s-production`. Keep the `cache` copies; the live Kamal search still reads them.
2. Set the `ghcr.io/tuist/search` package visibility to Public, otherwise the pod cannot pull the image (the chart configures no pull secrets).

## Validation

`helm lint` and `helm template` for both `values-ci.yaml` and `values-production.yaml` render cleanly; the rendered ExternalSecret pulls the two items above and templates them into `TYPESENSE_API_KEY` and `GITHUB_TOKEN`.
