### PR TITLE
fix(infra): validate hosted previews before marking them ready

### DIFF
--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -84,6 +84,7 @@ jobs:
             "infra/helm/slack|values-ci.yaml"
             "infra/helm/noora-storybook|values-ci.yaml"
             "infra/helm/tuist|values-ci.yaml"
+            "infra/helm/tuist|values-preview.yaml values-preview-kura.yaml values-preview-ci.yaml values-ci.yaml"
             "infra/helm/tuist|values-k3s-smoke.yaml"
             "infra/helm/k8s-monitoring|"
             "infra/helm/platform|"
@@ -151,6 +152,7 @@ jobs:
             "slack (production)|infra/helm/slack|slack|values-production.yaml values-ci.yaml"
             "noora-storybook (production)|infra/helm/noora-storybook|noora-storybook|values-production.yaml values-ci.yaml"
             "tuist (production)|infra/helm/tuist|tuist|values-managed-common.yaml values-managed-production.yaml values-ci.yaml"
+            "tuist (preview)|infra/helm/tuist|preview-validation|values-preview.yaml values-preview-kura.yaml values-preview-ci.yaml values-ci.yaml"
             "k8s-monitoring (production)|infra/helm/k8s-monitoring|k8s-monitoring|values-production.yaml"
             "platform (hetzner)|infra/helm/platform|platform|values-hetzner.yaml"
             "platform (preview)|infra/helm/platform|platform|values-hetzner.yaml values-tuist-preview.yaml"
@@ -172,6 +174,20 @@ jobs:
               continue
             fi
             echo "Rendered $(wc -l <rendered.yaml) lines of manifests."
+            if [ "$name" = "tuist (preview)" ]; then
+              hosted_values="$(
+                awk '
+                  /name: TUIST_HOSTED/ {
+                    getline
+                    print
+                  }
+                ' rendered.yaml
+              )"
+              if [ -z "$hosted_values" ] || echo "$hosted_values" | grep -qv 'value: "1"'; then
+                echo "::error::The preview render must set every TUIST_HOSTED value to 1."
+                failed+=("$name (hosted configuration)")
+              fi
+            fi
             # `-strict` rejects unknown fields so typo'd keys in resource
             # specs fail the build. Built-in resources validate against
             # the upstream Kubernetes JSON schemas; CRDs (ExternalSecret,

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -618,6 +618,22 @@ jobs:
             echo "::error::No Kura controller in the preview cluster. Run the 'Preview Platform Reconcile' workflow (workflow_dispatch) before deploying previews."
             exit 1
           fi
+          controller_images="$(
+            kubectl -n kura get deployment \
+              -l app.kubernetes.io/component=kura-controller \
+              -o jsonpath='{range .items[*]}{range .spec.template.spec.containers[*]}{.image}{"\n"}{end}{end}'
+          )"
+          while IFS= read -r controller_image; do
+            case "$controller_image" in
+              *:sha-* | *@sha256:*) ;;
+              *)
+                echo "::error::The preview Kura controller is not using an immutable image reference. Run the 'Preview Platform Reconcile' workflow before deploying previews."
+                exit 1
+                ;;
+            esac
+          done <<< "$controller_images"
+          kubectl -n kura rollout status deployment \
+            -l app.kubernetes.io/component=kura-controller --timeout=1m
       - name: Checkout preview source
         uses: actions/checkout@v4
         with:
@@ -703,14 +719,6 @@ jobs:
             --set-file "kuraRuntime.instance.extensionScript=kura/ops/helm/kura/hooks/tuist.lua" \
             --set "server.kuraEndpointUrls[0]=https://$KURA_HOST" \
             --atomic --timeout 20m --wait
-      - name: Finalize namespace labels
-        run: |
-          set -euo pipefail
-          ARGS=("tuist.dev/state=ready" --overwrite)
-          if [ -n "${EXPIRES_AT:-}" ]; then
-            ARGS=("tuist.dev/expires-at=$EXPIRES_AT" "tuist.dev/state=ready" --overwrite)
-          fi
-          kubectl label namespace "$NAMESPACE" "${ARGS[@]}"
       - name: Wait for KuraInstance
         run: |
           set -euo pipefail
@@ -794,6 +802,86 @@ jobs:
           RELEASE_NAME: ${{ env.RELEASE }}
         run: |
           mise -C infra run preview:seed-account --namespace "$NAMESPACE"
+      - name: Verify marketing and test-user login
+        env:
+          PREVIEW_USER_EMAIL: tuistrocks@tuist.dev
+          PREVIEW_USER_PASSWORD: tuistrocks
+        run: |
+          set -euo pipefail
+
+          verification_dir="$(mktemp -d)"
+          trap 'rm -rf "$verification_dir"' EXIT
+
+          marketing_status="$(
+            curl -sS -o "$verification_dir/marketing.html" \
+              -w '%{http_code}' "https://${HOST}/"
+          )"
+          if [ "$marketing_status" != "200" ]; then
+            echo "::error::The marketing root returned response status $marketing_status instead of 200."
+            exit 1
+          fi
+
+          curl -fsS \
+            -c "$verification_dir/cookies.txt" \
+            "https://${HOST}/users/log_in" \
+            -o "$verification_dir/login.html"
+
+          form_token="$(
+            grep -o 'name="_csrf_token" value="[^"]*"' "$verification_dir/login.html" \
+              | head -1 \
+              | sed 's/^name="_csrf_token" value="//; s/"$//'
+          )"
+          if [ -z "$form_token" ]; then
+            echo "::error::The login page did not contain a form token."
+            exit 1
+          fi
+
+          login_status="$(
+            curl -sS \
+              -b "$verification_dir/cookies.txt" \
+              -c "$verification_dir/cookies.txt" \
+              -D "$verification_dir/login-headers.txt" \
+              -o /dev/null \
+              -w '%{http_code}' \
+              --data-urlencode "_csrf_token=$form_token" \
+              --data-urlencode "user[email]=$PREVIEW_USER_EMAIL" \
+              --data-urlencode "user[password]=$PREVIEW_USER_PASSWORD" \
+              "https://${HOST}/users/log_in"
+          )"
+          if [ "$login_status" != "302" ]; then
+            echo "::error::The test-user login returned response status $login_status instead of 302."
+            exit 1
+          fi
+
+          login_location="$(
+            awk 'tolower($1) == "location:" {print $2}' "$verification_dir/login-headers.txt" \
+              | tr -d '\r' \
+              | tail -1
+          )"
+          case "$login_location" in
+            /users/log_in* | "")
+              echo "::error::The test-user login redirected back to the login page."
+              exit 1
+              ;;
+            /*)
+              curl -fsS \
+                -b "$verification_dir/cookies.txt" \
+                "https://${HOST}${login_location}" \
+                -o /dev/null
+              ;;
+            *)
+              echo "::error::The test-user login returned an unexpected redirect: $login_location"
+              exit 1
+              ;;
+          esac
+      - name: Finalize namespace labels
+        run: |
+          set -euo pipefail
+          ARGS=("tuist.dev/state=ready" --overwrite)
+          if [ -n "${EXPIRES_AT:-}" ]; then
+            ARGS=("tuist.dev/expires-at=$EXPIRES_AT" "tuist.dev/state=ready" --overwrite)
+          fi
+          kubectl label namespace "$NAMESPACE" "${ARGS[@]}"
       - name: Diagnostics on failure
         if: failure()
         run: |

--- a/infra/helm/tuist/values-preview-ci.yaml
+++ b/infra/helm/tuist/values-preview-ci.yaml
@@ -1,0 +1,24 @@
+# Placeholder hostnames and content used only to render the complete preview
+# overlay during continuous integration. The deploy workflow supplies the real
+# per-preview values at runtime.
+server:
+  appUrl: https://preview-validation.preview.tuist.dev
+  ingress:
+    enabled: true
+    host: preview-validation.preview.tuist.dev
+
+registry:
+  publicHost: registry-preview-validation.preview.tuist.dev
+  serverUrl: https://preview-validation.preview.tuist.dev
+  ingress:
+    enabled: true
+    host: registry-preview-validation.preview.tuist.dev
+
+kuraRuntime:
+  instance:
+    name: preview-validation-kura
+    publicHost: kura-preview-validation.preview.tuist.dev
+    extensionScript: |
+      function authenticate()
+        return { deny = { status = 401, message = "Validation only" } }
+      end

--- a/infra/helm/tuist/values-preview.yaml
+++ b/infra/helm/tuist/values-preview.yaml
@@ -25,6 +25,10 @@ global:
     tuist.dev/environment: preview
 
 server:
+  # Previews exercise the hosted product and the public marketing site. Leaving
+  # this at the chart's self-hosted default redirects every public route to the
+  # login page.
+  hosted: true
   replicaCount: 1
   autoscaling:
     enabled: false


### PR DESCRIPTION
## What changed

Preview deployments now enable the hosted Tuist experience, verify the shared Kura controller before creating preview resources, and validate both the marketing root and documented test-user login before marking a namespace ready.

The Helm checks also render the complete preview overlay and assert that every rendered `TUIST_HOSTED` value is enabled.

## Why

The `once-blog-post` preview became publicly reachable even though the deployment had not completed successfully. Its marketing root redirected to login, the documented test account did not exist, and the Cloudflare records remained because the namespace looked ready to the preview janitor.

## Root cause

The preview values inherited the chart's self-hosted default, which redirected public marketing routes to login.

Separately, the shared Kura controller had regressed to a mutable `latest` image and was unavailable. The deployment timed out while waiting for Kura, so the account seed never ran. The workflow had already marked the namespace ready immediately after the Helm upgrade, before Kura readiness, smoke checks, registry synchronization, or account seeding. That ready label prevented the stuck-preview cleanup path from removing the namespace and its public records.

## Approach

The preview overlay now explicitly enables hosted mode. Before checking out or creating preview resources, the deployment requires the Kura controller to use a commit-pinned image and complete its rollout.

After deployment, the workflow seeds the account, requests the marketing root, submits the documented test credentials with a real form token and cookie jar, and follows the authenticated redirect. Only then does it label the namespace ready. A failed deployment remains in the creating state, so the existing janitor removes it after 30 minutes and the platform record synchronizer removes its Cloudflare records.

The chart workflow renders the same preview overlay with validation-only hostnames, preventing hosted-mode regressions from reaching a deployment.

## Impact

Successful previews expose the marketing site and support the documented test-user login. Broken platform state now fails before a preview namespace is created, while failures after creation remain eligible for automatic cleanup instead of appearing ready until their normal expiry.

No database migration or customer data storage change is included.

## Screenshots

Before, the deployed preview redirected the marketing root to login and the documented test-user credentials failed:

![Preview login failure before the fix](https://raw.githubusercontent.com/tuist/tuist/pr-assets-hosted-preview-11804/.github/pr-screenshots/hosted-preview-readiness/before-login-failure.png)

After, the same hosted configuration renders the marketing homepage:

![Preview marketing homepage after the fix](https://raw.githubusercontent.com/tuist/tuist/pr-assets-hosted-preview-11804/.github/pr-screenshots/hosted-preview-readiness/after-marketing.png)

The documented test-user button also reaches the authenticated project overview:

![Authenticated project overview after test-user login](https://raw.githubusercontent.com/tuist/tuist/pr-assets-hosted-preview-11804/.github/pr-screenshots/hosted-preview-readiness/after-test-user-login.png)

## Validation

- `helm lint infra/helm/tuist -f infra/helm/tuist/values-preview.yaml -f infra/helm/tuist/values-preview-kura.yaml -f infra/helm/tuist/values-preview-ci.yaml -f infra/helm/tuist/values-ci.yaml`
- Rendered the complete preview chart and confirmed all three `TUIST_HOSTED` values are `1`, the test-user login setting is present, and the Kura instance is rendered.
- `mise x actionlint@1.7.12 -- actionlint -ignore 'label "tuist-linux(-large)?" is unknown' .github/workflows/preview-deploy.yml .github/workflows/helm.yml`
- `git diff --check`
- Started the server locally and verified with a headless Chrome browser that the marketing root returns status 200 and the test-user button reaches `/tuist/public` successfully.
