### PR TITLE
feat(cli): enable SwifterPM resolution by default

### DIFF
--- a/cli/Sources/TuistSupport/SwiftPackageManager/SwiftPackageManagerController.swift
+++ b/cli/Sources/TuistSupport/SwiftPackageManager/SwiftPackageManagerController.swift
@@ -274,7 +274,9 @@ public struct SwiftPackageManagerController: SwiftPackageManagerControlling {
     }
 
     private var swifterPMIsEnabled: Bool {
-        Environment(variables: environmentVariables()).isVariableTruthy(Constants.EnvironmentVariables.useSwifterPM)
+        let variables = environmentVariables()
+        guard variables[Constants.EnvironmentVariables.useSwifterPM] != nil else { return true }
+        return Environment(variables: variables).isVariableTruthy(Constants.EnvironmentVariables.useSwifterPM)
     }
 
     private func swifterPMRequest(

--- a/cli/Tests/TuistSupportTests/SwiftPackageManager/SwiftPackageManagerControllerTests.swift
+++ b/cli/Tests/TuistSupportTests/SwiftPackageManager/SwiftPackageManagerControllerTests.swift
@@ -45,7 +45,8 @@ final class SwiftPackageManagerControllerTests: TuistUnitTestCase {
         subject = SwiftPackageManagerController(
             fileSystem: fileSystem,
             commandRunner: { self.mockCommandRunner },
-            swifterPM: swifterPM
+            swifterPM: swifterPM,
+            environmentVariables: { [:] }
         )
     }
 
@@ -56,17 +57,9 @@ final class SwiftPackageManagerControllerTests: TuistUnitTestCase {
         super.tearDown()
     }
 
-    func test_resolve() async throws {
+    func test_resolve_usesSwifterPMByDefault() async throws {
         // Given
         let path = try temporaryPath()
-        mockCommandRunner.succeedCommand([
-            "swift",
-            "package",
-            "--package-path",
-            path.pathString,
-            "--replace-scm-with-registry",
-            "resolve",
-        ])
 
         // When
         try await subject.resolve(
@@ -74,6 +67,12 @@ final class SwiftPackageManagerControllerTests: TuistUnitTestCase {
             arguments: ["--replace-scm-with-registry"],
             printOutput: false
         )
+
+        // Then
+        XCTAssertEqual(mockCommandRunner.calls, [])
+        let request = try XCTUnwrap(swifterPM.resolveRequests.first)
+        XCTAssertEqual(request.scmToRegistryTransformation, .replaceSCMWithRegistry)
+        XCTAssertTrue(request.quiet)
     }
 
     func test_resolve_when_swifterpm_is_enabled() async throws {
@@ -128,7 +127,7 @@ final class SwiftPackageManagerControllerTests: TuistUnitTestCase {
         XCTAssertNil(request.cachedDirectoryMaterialization)
     }
 
-    func test_resolve_when_swifterpm_is_not_truthy_usesSwiftPackageManager() async throws {
+    func test_resolve_when_swifterpm_is_disabled_usesSwiftPackageManager() async throws {
         // Given
         let path = try temporaryPath()
         subject = SwiftPackageManagerController(
@@ -308,9 +307,15 @@ final class SwiftPackageManagerControllerTests: TuistUnitTestCase {
         XCTAssertNil(request.cachedDirectoryMaterialization)
     }
 
-    func test_update() async throws {
+    func test_update_when_swifterpm_is_disabled_usesSwiftPackageManager() async throws {
         // Given
         let path = try temporaryPath()
+        subject = SwiftPackageManagerController(
+            fileSystem: fileSystem,
+            commandRunner: { self.mockCommandRunner },
+            swifterPM: swifterPM,
+            environmentVariables: { ["TUIST_USE_SWIFTERPM": "0"] }
+        )
         mockCommandRunner.succeedCommand([
             "swift",
             "package",
@@ -326,6 +331,9 @@ final class SwiftPackageManagerControllerTests: TuistUnitTestCase {
             arguments: ["--replace-scm-with-registry"],
             printOutput: false
         )
+
+        // Then
+        XCTAssertTrue(swifterPM.updateRequests.isEmpty)
     }
 
     func test_setToolsVersion_specificVersion() async throws {

--- a/mise.toml
+++ b/mise.toml
@@ -36,7 +36,6 @@
     _.source = ["{{config_root}}/mise/utilities/dev_instance_env.sh", "{{config_root}}/mise/utilities/cache_ee_env.sh"]
     TUIST_CACHE_CONCURRENCY_LIMIT="none"
     TUIST_FILESYSTEM_BACKEND = "swift-file-system"
-    TUIST_USE_SWIFTERPM = "1"
     TUIST_INSPECT_TEST_MODE = "remote"
     TUIST_FEATURE_FLAG_KURA = "1"
     TUIST_HOSTED = "1"


### PR DESCRIPTION
### What changed

The Tuist [command-line interface](https://en.wikipedia.org/wiki/Command-line_interface) now uses [SwifterPM](https://github.com/tuist/swifterpm) by default for package resolution and updates. Setting `TUIST_USE_SWIFTERPM=0` keeps using Swift Package Manager, providing an explicit compatibility escape hatch.

The development environment no longer sets `TUIST_USE_SWIFTERPM=1`, since the opt-in is redundant once SwifterPM is the default.

### Why

SwifterPM resolution was introduced behind an opt-in while the integration matured. Making it the default gives every Tuist user the accelerated resolution path without requiring environment configuration, while retaining the native Swift Package Manager path for projects that need it.

### Approach

The existing environment variable remains the source of truth to avoid introducing a second configuration mechanism. An unset value now enables SwifterPM, an explicit truthy value continues to enable it, and an explicit false-like value disables it.

The controller tests use deterministic environment dictionaries and cover the new unset default plus the resolution and update opt-out paths.

### User and developer impact

Users without `TUIST_USE_SWIFTERPM` configured will start resolving packages with SwifterPM. Existing `TUIST_USE_SWIFTERPM=1` configurations remain valid, and `TUIST_USE_SWIFTERPM=0` selects Swift Package Manager without any other migration.

### How to test locally

Generate the focused workspace and run the controller tests:

```sh
tuist generate tuist TuistSupport TuistSupportTests ProjectDescription --no-open
xcodebuild test -workspace Tuist.xcworkspace -scheme Tuist-Workspace \
  -only-testing TuistSupportTests/SwiftPackageManagerControllerTests \
  CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" \
  COMPILATION_CACHE_ENABLE_CACHING=NO
```

The suite executes 14 tests with no failures. Formatting and linting also pass:

```sh
mise run cli:lint --fix
```
