### PR TITLE
fix(server): resolve runner dispatch account by installation, not just org login

### DIFF
--- a/server/lib/tuist/runners/dispatch.ex
+++ b/server/lib/tuist/runners/dispatch.ex
@@ -16,9 +16,15 @@ defmodule Tuist.Runners.Dispatch do
 
   Flow for `queued`:
 
-    1. Parse `repository.owner.login` from the payload; look up
-       the Tuist account by that name (account `name` IS the
-       GitHub org login by convention).
+    1. Resolve the Tuist account. The authoritative link is the
+       webhook's `installation.id` → `github_app_installations`
+       row → `account_id`, so we resolve by installation first and
+       only fall back to the legacy `repository.owner.login ==
+       account.name` convention when no installation row is found.
+       The convention silently strands any customer whose Tuist
+       handle differs from their GitHub org login (the dominant
+       `no_account` webhook outcome); installation resolution has
+       no such coupling.
     2. Reject if runners aren't enabled for the customer
        (`FeatureFlags.runners_enabled?/1`, gated by the `:runners`
        flag in production).
@@ -46,6 +52,7 @@ defmodule Tuist.Runners.Dispatch do
   alias Tuist.Runners.Profiles
   alias Tuist.Runners.Telemetry
   alias Tuist.Runners.Workers.FetchLogsWorker
+  alias Tuist.VCS
 
   require Logger
 
@@ -66,13 +73,13 @@ defmodule Tuist.Runners.Dispatch do
   Handle a `workflow_job` webhook payload. Branches on `action`.
   """
   def handle_webhook(%{"action" => "queued"} = payload, installation_id) when is_integer(installation_id) do
-    result = handle_queued(payload)
+    result = handle_queued(payload, installation_id)
     emit_webhook_telemetry("queued", result)
     result
   end
 
   def handle_webhook(%{"action" => "waiting"} = payload, installation_id) when is_integer(installation_id) do
-    result = handle_waiting(payload)
+    result = handle_waiting(payload, installation_id)
     emit_webhook_telemetry("waiting", result)
     result
   end
@@ -115,22 +122,22 @@ defmodule Tuist.Runners.Dispatch do
   defp webhook_outcome({:error, reason}) when is_atom(reason), do: Atom.to_string(reason)
   defp webhook_outcome(_), do: "unknown"
 
-  defp handle_queued(payload) do
-    handle_queueable(payload, &Jobs.enqueue/1)
+  defp handle_queued(payload, installation_id) do
+    handle_queueable(payload, installation_id, &Jobs.enqueue/1)
   end
 
-  defp handle_waiting(payload) do
-    handle_queueable(payload, &Jobs.enqueue_if_missing/1)
+  defp handle_waiting(payload, installation_id) do
+    handle_queueable(payload, installation_id, &Jobs.enqueue_if_missing/1)
   end
 
-  defp handle_queueable(payload, enqueue_fun) do
+  defp handle_queueable(payload, installation_id, enqueue_fun) do
     job = Map.get(payload, "workflow_job", %{})
     repo = Map.get(payload, "repository", %{})
     full_name = Map.get(repo, "full_name", "")
     {owner, _repo_name} = parse_full_name(full_name)
     requested = Map.get(job, "labels", [])
 
-    with {:ok, account} <- fetch_enabled_account(owner),
+    with {:ok, account} <- fetch_enabled_account(installation_id, owner),
          {:ok, target} <- resolve_dispatch_target(account, requested),
          :ok <- enqueue_fun.(enqueue_attrs(account, target, full_name, job)) do
       Logger.info("runners: enqueued",
@@ -144,7 +151,8 @@ defmodule Tuist.Runners.Dispatch do
       {:ok, :queued}
     else
       {:error, :no_account} ->
-        Logger.info("runners: no account match for webhook owner; ignoring",
+        Logger.info("runners: no account match for webhook installation or owner; ignoring",
+          installation_id: installation_id,
           owner: owner,
           repo: full_name,
           requested_labels: requested
@@ -412,8 +420,12 @@ defmodule Tuist.Runners.Dispatch do
     end
   end
 
-  defp fetch_enabled_account(owner) when is_binary(owner) and owner != "" do
-    case get_account_by_handle_cached(owner) do
+  # Resolve by installation first (the authoritative link the customer
+  # established at connect time), then fall back to the legacy
+  # `owner == account.name` convention. Enablement is checked once the
+  # account resolves, regardless of which path found it.
+  defp fetch_enabled_account(installation_id, owner) do
+    case resolve_account(installation_id, owner) do
       nil ->
         {:error, :no_account}
 
@@ -426,7 +438,12 @@ defmodule Tuist.Runners.Dispatch do
     end
   end
 
-  defp fetch_enabled_account(_), do: {:error, :no_account}
+  defp resolve_account(installation_id, owner) do
+    account_by_installation_cached(installation_id) || account_by_handle(owner)
+  end
+
+  defp account_by_handle(owner) when is_binary(owner) and owner != "", do: get_account_by_handle_cached(owner)
+  defp account_by_handle(_), do: nil
 
   # We deliberately do NOT cache `{:error, _}` returns from the K8s
   # client. A transient apiserver hiccup should retry on the next
@@ -450,6 +467,45 @@ defmodule Tuist.Runners.Dispatch do
 
       cached ->
         cached
+    end
+  end
+
+  # Resolves and caches the account a GitHub App installation belongs
+  # to, keyed by `installation_id`. This is the authoritative link
+  # (`github_app_installations.account_id`), so it works even when the
+  # customer's Tuist handle differs from their GitHub org login. Same
+  # caching contract as the handle cache: only successful resolutions
+  # are memoised, and enablement is re-evaluated per webhook by the
+  # caller. A nil/absent installation row falls through to the handle
+  # convention.
+  defp account_by_installation_cached(installation_id) when is_integer(installation_id) do
+    cache_key = [__MODULE__, :account_by_installation, installation_id]
+    cache_opts = [cache: __MODULE__.cache_name()]
+
+    case KeyValueStore.get(cache_key, cache_opts) do
+      nil ->
+        case account_for_installation(installation_id) do
+          nil ->
+            nil
+
+          account ->
+            KeyValueStore.put(cache_key, account, Keyword.put(cache_opts, :ttl, @account_cache_ttl_ms))
+            account
+        end
+
+      cached ->
+        cached
+    end
+  end
+
+  defp account_by_installation_cached(_), do: nil
+
+  defp account_for_installation(installation_id) do
+    with {:ok, %{account_id: account_id}} <- VCS.get_github_app_installation_by_installation_id(installation_id),
+         {:ok, account} <- Accounts.get_account_by_id(account_id) do
+      account
+    else
+      _ -> nil
     end
   end
 

--- a/server/test/tuist/runners/dispatch_test.exs
+++ b/server/test/tuist/runners/dispatch_test.exs
@@ -11,6 +11,7 @@ defmodule Tuist.Runners.DispatchTest do
   alias Tuist.Runners.Dispatch
   alias Tuist.Runners.Jobs
   alias Tuist.Runners.JobSteps
+  alias Tuist.VCS
   alias TuistTestSupport.Fixtures.AccountsFixtures
 
   setup :verify_on_exit!
@@ -19,6 +20,12 @@ defmodule Tuist.Runners.DispatchTest do
     cache = :"runners_dispatch_#{System.unique_integer([:positive])}"
     start_supervised!({Cachex, name: cache})
     stub(Dispatch, :cache_name, fn -> cache end)
+
+    # Default: no installation row for the webhook's installation_id, so
+    # resolution falls back to the legacy `owner == account.name`
+    # convention the bulk of these cases exercise. The installation-first
+    # path has its own case that overrides this stub.
+    stub(VCS, :get_github_app_installation_by_installation_id, fn _ -> {:error, :not_found} end)
 
     # Disable the macOS protected-profile auto-bootstrap globally for
     # this suite. `Accounts.create_organization` and `Accounts.create_user`
@@ -76,11 +83,55 @@ defmodule Tuist.Runners.DispatchTest do
   end
 
   describe "handle_webhook/2" do
-    test "returns {:ignored, :no_account} when the org login doesn't match a Tuist account" do
+    test "returns {:ignored, :no_account} when neither the installation nor the org login match a Tuist account" do
       stub(Accounts, :get_account_by_handle, fn _ -> nil end)
 
       assert {:ignored, :no_account} =
                Dispatch.handle_webhook(queued_payload(owner: "ghost"), 1)
+    end
+
+    test "resolves the account via the installation even when the org login doesn't match the handle" do
+      account = enabled_account()
+
+      # The customer's GitHub org login differs from their Tuist handle,
+      # so the legacy name convention can't find them — but the App
+      # installation maps straight to the account.
+      stub(Accounts, :get_account_by_handle, fn _ -> nil end)
+      stub(VCS, :get_github_app_installation_by_installation_id, fn 123_975_483 -> {:ok, %{account_id: account.id}} end)
+
+      stub(Client, :list_runner_pools, fn _ns ->
+        {:ok, [pool_cr(name: "macos-pool", label: "tuist-macos")]}
+      end)
+
+      payload = queued_payload(owner: "DigitalSolutionsPest", labels: ["tuist-macos"])
+
+      assert {:ok, :queued} = Dispatch.handle_webhook(payload, 123_975_483)
+
+      counts = Jobs.status_counts(account.id)
+      assert Map.get(counts, "queued", 0) == 1
+    end
+
+    test "prefers the installation-resolved account over the handle match" do
+      installation_account = enabled_account()
+
+      # A different account happens to share the org login; the
+      # installation link is authoritative, so we must dispatch against
+      # the account that actually connected the App.
+      stub(Accounts, :get_account_by_handle, fn _ -> enabled_account() end)
+
+      stub(VCS, :get_github_app_installation_by_installation_id, fn _ ->
+        {:ok, %{account_id: installation_account.id}}
+      end)
+
+      stub(Client, :list_runner_pools, fn _ns ->
+        {:ok, [pool_cr(name: "macos-pool", label: "tuist-macos")]}
+      end)
+
+      payload = queued_payload(owner: "shared-login", labels: ["tuist-macos"])
+
+      assert {:ok, :queued} = Dispatch.handle_webhook(payload, 555)
+
+      assert Map.get(Jobs.status_counts(installation_account.id), "queued", 0) == 1
     end
 
     test "returns {:ignored, :runners_disabled} when runners aren't enabled for the account" do


### PR DESCRIPTION
### What

Runner dispatch now resolves the owning Tuist account from the webhook's GitHub App **installation** first, falling back to the legacy `repository.owner.login == accounts.name` convention only when no installation row is found.

### Why

The `workflow_job` dispatch pipeline resolved the account **solely** by matching the GitHub org login against `accounts.name` (exact, case-insensitive). Any account whose Tuist organization handle differs from its GitHub org login is silently stranded: the webhook is received, matches no account, returns `{:ignored, :no_account}`, and the job sits on **"Waiting for a runner to pick up this job…"** indefinitely — no error surfaced anywhere the customer can see.

This surfaced from a real support case where the Tuist handle differed from the connected GitHub org login:

- Tuist account exists, `runners` flag **enabled**, GitHub App permissions granted correctly.
- The GitHub org / repo actually running CI has a **different** login than the Tuist handle.
- `get_account_by_handle(<github-org-login>)` returns `nil` → job never enqueued. Confirmed: **0** `runner_jobs` rows for the account.

It is not a rare edge. Production webhook telemetry over 14 days shows `queued/no_account` is by far the dominant outcome — **thousands dropped** vs. a handful of successful dispatches. The name convention is a systemic footgun, and the permissions the customer (correctly) enabled could never have fixed it because account resolution fails *before* any GitHub API call.

### Root cause

The account is already reliably discoverable from the webhook: the payload carries `installation.id`, and `github_app_installations` maps `installation_id → account_id` — the authoritative link established when a GitHub org is connected to a Tuist account. But the queued path threw that id away; only the `completed` path used it. Resolution fell back to the fragile `owner == account.name` coupling.

### Fix

- Thread `installation_id` into `handle_queued` / `handle_waiting` / `handle_queueable`.
- Resolve the account by installation first (`VCS.get_github_app_installation_by_installation_id/1` → `Accounts.get_account_by_id/1`), then fall back to the org-login convention when no installation row exists (GHES manifest-flow pending rows, delivery races).
- Cache the installation→account lookup by `installation_id` with the same 60s TTL and "only memoise successes" contract as the existing handle cache, so the hot webhook path stays off Postgres.
- `no_account` log line now includes `installation_id` for support triage.

### Why this approach over the alternatives

- **Rename the account's Tuist handle to match GitHub** unblocks one account but changes its project URLs / `fullHandle`, breaks tokens and config, and leaves the systemic footgun in place for the next one.
- **Substring/fuzzy matching on the org login** is ambiguous and unsafe.
- Installation resolution is the authoritative connection already established, so accounts whose handle already equals their org login resolve identically — **no behavior change for working accounts** — while the broken ones start dispatching.

### Impact

Every account whose GitHub org name differs from its Tuist handle starts dispatching without any action on its part. No migration, no config change.

> Note: this fixes the enqueue stage; the JIT-mint stage had the same handle-vs-org-login mistake and is fixed in #11817.

### How to test locally

`mix test test/tuist/runners/dispatch_test.exs`

Two new cases cover the fix:
- The installation resolves an account whose handle does **not** match the org login → `{:ok, :queued}`.
- The installation-resolved account wins over a handle match (installation link is authoritative).

Existing cases pass; `mix credo` clean.
