### PR TITLE
feat(server): advertise the registry URL at a well-known route

### DIFF
--- a/infra/helm/tuist/values-managed-canary.yaml
+++ b/infra/helm/tuist/values-managed-canary.yaml
@@ -93,9 +93,11 @@ server:
     # env's config the release runs as.
     - name: TUIST_DEPLOY_ENV
       value: can
-    # Registry base URL advertised at /.well-known/tuist-registry.json.
+    # Full registry URL advertised at /.well-known/registry.json. The
+    # canary registry ingress serves /swift directly (no Worker), so it can
+    # advertise the canonical prefix already.
     - name: TUIST_REGISTRY_URL
-      value: https://registry-canary.tuist.dev
+      value: https://registry-canary.tuist.dev/swift
     # Cache remains the sole registry writer until the managed cutover.
     - name: SWIFT_REGISTRY_SYNC_ENABLED
       value: "false"

--- a/infra/helm/tuist/values-managed-canary.yaml
+++ b/infra/helm/tuist/values-managed-canary.yaml
@@ -93,6 +93,9 @@ server:
     # env's config the release runs as.
     - name: TUIST_DEPLOY_ENV
       value: can
+    # Registry base URL advertised at /.well-known/tuist-registry.json.
+    - name: TUIST_REGISTRY_URL
+      value: https://registry-canary.tuist.dev
     # Cache remains the sole registry writer until the managed cutover.
     - name: SWIFT_REGISTRY_SYNC_ENABLED
       value: "false"

--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -76,6 +76,11 @@ server:
     # env's config the release runs as.
     - name: TUIST_DEPLOY_ENV
       value: prod
+    # Registry base URL advertised at /.well-known/tuist-registry.json so
+    # the CLI configures SwiftPM against registry.tuist.dev instead of the
+    # legacy tuist.dev/api/registry path.
+    - name: TUIST_REGISTRY_URL
+      value: https://registry.tuist.dev
     # Enables the server-owned registry sync writer. Cache still writes
     # too until it is turned off as a separate step; the two coordinate
     # through the shared S3 sync lock, so dual-writing is safe.

--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -76,11 +76,15 @@ server:
     # env's config the release runs as.
     - name: TUIST_DEPLOY_ENV
       value: prod
-    # Registry base URL advertised at /.well-known/tuist-registry.json so
-    # the CLI configures SwiftPM against registry.tuist.dev instead of the
-    # legacy tuist.dev/api/registry path.
+    # Full registry URL advertised at /.well-known/registry.json so the CLI
+    # configures SwiftPM against registry.tuist.dev instead of tuist.dev.
+    # Keeps the legacy /api/registry/swift prefix for now: production's
+    # registry.tuist.dev is still fronted by the registry-router Worker
+    # against the cache origins, which only serve that prefix. Flip to
+    # https://registry.tuist.dev/swift once the Worker cuts over to the
+    # standalone frontend (which serves /swift).
     - name: TUIST_REGISTRY_URL
-      value: https://registry.tuist.dev
+      value: https://registry.tuist.dev/api/registry/swift
     # Enables the server-owned registry sync writer. Cache still writes
     # too until it is turned off as a separate step; the two coordinate
     # through the shared S3 sync lock, so dual-writing is safe.

--- a/infra/helm/tuist/values-managed-staging.yaml
+++ b/infra/helm/tuist/values-managed-staging.yaml
@@ -42,6 +42,9 @@ server:
     # env's config the release runs as.
     - name: TUIST_DEPLOY_ENV
       value: stag
+    # Registry base URL advertised at /.well-known/tuist-registry.json.
+    - name: TUIST_REGISTRY_URL
+      value: https://registry-staging.tuist.dev
     - name: TUIST_DATABASE_POOL_SIZE
       value: "15"
     - name: TUIST_OTEL_EXPORTER_OTLP_ENDPOINT

--- a/infra/helm/tuist/values-managed-staging.yaml
+++ b/infra/helm/tuist/values-managed-staging.yaml
@@ -42,9 +42,11 @@ server:
     # env's config the release runs as.
     - name: TUIST_DEPLOY_ENV
       value: stag
-    # Registry base URL advertised at /.well-known/tuist-registry.json.
+    # Full registry URL advertised at /.well-known/registry.json. The
+    # staging registry ingress serves /swift directly (no Worker), so it can
+    # advertise the canonical prefix already.
     - name: TUIST_REGISTRY_URL
-      value: https://registry-staging.tuist.dev
+      value: https://registry-staging.tuist.dev/swift
     - name: TUIST_DATABASE_POOL_SIZE
       value: "15"
     - name: TUIST_OTEL_EXPORTER_OTLP_ENDPOINT

--- a/server/config/runtime.exs
+++ b/server/config/runtime.exs
@@ -654,6 +654,7 @@ swift_registry_sync_limit =
 
 config :tuist, :registry,
   bucket: System.get_env("S3_REGISTRY_BUCKET"),
+  url: System.get_env("TUIST_REGISTRY_URL"),
   swift_github_token: System.get_env("SWIFT_REGISTRY_GITHUB_TOKEN"),
   swift_sync_enabled: swift_registry_sync_enabled,
   swift_sync_allowlist: swift_registry_sync_allowlist,

--- a/server/lib/tuist/registry.ex
+++ b/server/lib/tuist/registry.ex
@@ -24,9 +24,12 @@ defmodule Tuist.Registry do
   def registry_bucket, do: Application.get_env(:tuist, :registry)[:bucket]
 
   @doc """
-  The public base URL clients use to reach the Swift package registry
-  (e.g. `https://registry.tuist.dev`). Set per environment via
-  `TUIST_REGISTRY_URL`. `nil` when the deployment exposes no registry, in
+  The full public base URL, including the API path prefix, that clients use
+  to reach the Swift package registry (e.g.
+  `https://registry.tuist.dev/api/registry/swift` today, becoming
+  `.../swift` once production traffic moves to the standalone frontend). Set
+  per environment via `TUIST_REGISTRY_URL` so ops controls the prefix as the
+  routing cutover lands. `nil` when the deployment exposes no registry, in
   which case the discovery endpoint 404s.
   """
   def url do

--- a/server/lib/tuist/registry.ex
+++ b/server/lib/tuist/registry.ex
@@ -23,6 +23,19 @@ defmodule Tuist.Registry do
 
   def registry_bucket, do: Application.get_env(:tuist, :registry)[:bucket]
 
+  @doc """
+  The public base URL clients use to reach the Swift package registry
+  (e.g. `https://registry.tuist.dev`). Set per environment via
+  `TUIST_REGISTRY_URL`. `nil` when the deployment exposes no registry, in
+  which case the discovery endpoint 404s.
+  """
+  def url do
+    case Application.get_env(:tuist, :registry)[:url] do
+      url when is_binary(url) and url != "" -> String.trim_trailing(url, "/")
+      _ -> nil
+    end
+  end
+
   def swift_registry_github_token do
     case Application.get_env(:tuist, :registry)[:swift_github_token] do
       token when is_binary(token) and token != "" -> token

--- a/server/lib/tuist_web/controllers/well_known_controller.ex
+++ b/server/lib/tuist_web/controllers/well_known_controller.ex
@@ -30,6 +30,22 @@ defmodule TuistWeb.WellKnownController do
     json(conn, AgentSkillsDiscovery.index())
   end
 
+  @doc """
+  Advertises the Swift package registry base URL for this deployment so
+  the CLI can configure SwiftPM against `registry.tuist.dev` instead of
+  hardcoding the legacy `<server>/api/registry/swift` path. 404s when the
+  deployment exposes no registry (self-hosted).
+  """
+  def swift_registry(conn, _params) do
+    case Tuist.Registry.url() do
+      nil ->
+        send_resp(conn, :not_found, "")
+
+      base ->
+        json(conn, %{"url" => base <> "/swift", "loginAPIPath" => "/swift/login"})
+    end
+  end
+
   def openai_apps_challenge(conn, _params) do
     if Environment.tuist_hosted?() do
       conn

--- a/server/lib/tuist_web/controllers/well_known_controller.ex
+++ b/server/lib/tuist_web/controllers/well_known_controller.ex
@@ -41,8 +41,9 @@ defmodule TuistWeb.WellKnownController do
       nil ->
         send_resp(conn, :not_found, "")
 
-      base ->
-        json(conn, %{"url" => base <> "/swift", "loginAPIPath" => "/swift/login"})
+      url ->
+        login_path = (URI.parse(url).path || "") <> "/login"
+        json(conn, %{"url" => url, "loginAPIPath" => login_path})
     end
   end
 

--- a/server/lib/tuist_web/controllers/well_known_controller.ex
+++ b/server/lib/tuist_web/controllers/well_known_controller.ex
@@ -31,19 +31,25 @@ defmodule TuistWeb.WellKnownController do
   end
 
   @doc """
-  Advertises the Swift package registry base URL for this deployment so
-  the CLI can configure SwiftPM against `registry.tuist.dev` instead of
-  hardcoding the legacy `<server>/api/registry/swift` path. 404s when the
+  Advertises the package registry for this deployment so the CLI can
+  configure clients against `registry.tuist.dev` instead of hardcoding a
+  `<server>/api/registry/swift` path. Keyed by ecosystem so future ones
+  (e.g. Gradle) are additive rather than a breaking reshape. 404s when the
   deployment exposes no registry (self-hosted).
   """
-  def swift_registry(conn, _params) do
+  def registry_discovery(conn, _params) do
     case Tuist.Registry.url() do
       nil ->
         send_resp(conn, :not_found, "")
 
       url ->
         login_path = (URI.parse(url).path || "") <> "/login"
-        json(conn, %{"url" => url, "loginAPIPath" => login_path})
+
+        json(conn, %{
+          "ecosystems" => %{
+            "swift" => %{"url" => url, "loginAPIPath" => login_path}
+          }
+        })
     end
   end
 

--- a/server/lib/tuist_web/router.ex
+++ b/server/lib/tuist_web/router.ex
@@ -452,7 +452,6 @@ defmodule TuistWeb.Router do
 
     get "/api-catalog", WellKnownController, :api_catalog, metadata: %{robots_txt: false}
     get "/agent-skills/index.json", WellKnownController, :agent_skills_index, metadata: %{robots_txt: false}
-    get "/tuist-registry.json", WellKnownController, :swift_registry, metadata: %{robots_txt: false}
   end
 
   scope "/.well-known", TuistWeb do
@@ -462,6 +461,7 @@ defmodule TuistWeb.Router do
     get "/oauth-protected-resource", WellKnownController, :oauth_protected_resource
     get "/oauth-protected-resource/*resource_path", WellKnownController, :oauth_protected_resource
     get "/mcp/server-card.json", WellKnownController, :mcp_server_card
+    get "/registry.json", WellKnownController, :swift_registry, metadata: %{robots_txt: false}
     get "/apple-app-site-association", WellKnownController, :apple_app_site_association
     get "/assetlinks.json", WellKnownController, :assetlinks
   end

--- a/server/lib/tuist_web/router.ex
+++ b/server/lib/tuist_web/router.ex
@@ -461,7 +461,7 @@ defmodule TuistWeb.Router do
     get "/oauth-protected-resource", WellKnownController, :oauth_protected_resource
     get "/oauth-protected-resource/*resource_path", WellKnownController, :oauth_protected_resource
     get "/mcp/server-card.json", WellKnownController, :mcp_server_card
-    get "/registry.json", WellKnownController, :swift_registry, metadata: %{robots_txt: false}
+    get "/registry.json", WellKnownController, :registry_discovery, metadata: %{robots_txt: false}
     get "/apple-app-site-association", WellKnownController, :apple_app_site_association
     get "/assetlinks.json", WellKnownController, :assetlinks
   end

--- a/server/lib/tuist_web/router.ex
+++ b/server/lib/tuist_web/router.ex
@@ -452,6 +452,7 @@ defmodule TuistWeb.Router do
 
     get "/api-catalog", WellKnownController, :api_catalog, metadata: %{robots_txt: false}
     get "/agent-skills/index.json", WellKnownController, :agent_skills_index, metadata: %{robots_txt: false}
+    get "/tuist-registry.json", WellKnownController, :swift_registry, metadata: %{robots_txt: false}
   end
 
   scope "/.well-known", TuistWeb do

--- a/server/test/tuist_web/controllers/well_known_controller_test.exs
+++ b/server/test/tuist_web/controllers/well_known_controller_test.exs
@@ -102,11 +102,25 @@ defmodule TuistWeb.WellKnownControllerTest do
     end
   end
 
-  describe "GET /.well-known/tuist-registry.json" do
-    test "returns the registry base URL when configured", %{conn: conn} do
-      stub(Tuist.Registry, :url, fn -> "https://registry.tuist.dev" end)
+  describe "GET /.well-known/registry.json" do
+    test "returns the registry URL and derives the login path", %{conn: conn} do
+      stub(Tuist.Registry, :url, fn -> "https://registry.tuist.dev/api/registry/swift" end)
 
-      conn = get(conn, "/.well-known/tuist-registry.json")
+      conn = get(conn, "/.well-known/registry.json")
+
+      assert json_response(conn, 200) == %{
+               "url" => "https://registry.tuist.dev/api/registry/swift",
+               "loginAPIPath" => "/api/registry/swift/login"
+             }
+    end
+
+    test "serves JSON to clients that send an application/json Accept header", %{conn: conn} do
+      stub(Tuist.Registry, :url, fn -> "https://registry.tuist.dev/swift" end)
+
+      conn =
+        conn
+        |> put_req_header("accept", "application/json")
+        |> get("/.well-known/registry.json")
 
       assert json_response(conn, 200) == %{
                "url" => "https://registry.tuist.dev/swift",
@@ -117,7 +131,7 @@ defmodule TuistWeb.WellKnownControllerTest do
     test "404s when the deployment exposes no registry", %{conn: conn} do
       stub(Tuist.Registry, :url, fn -> nil end)
 
-      conn = get(conn, "/.well-known/tuist-registry.json")
+      conn = get(conn, "/.well-known/registry.json")
 
       assert response(conn, 404) == ""
     end

--- a/server/test/tuist_web/controllers/well_known_controller_test.exs
+++ b/server/test/tuist_web/controllers/well_known_controller_test.exs
@@ -103,14 +103,18 @@ defmodule TuistWeb.WellKnownControllerTest do
   end
 
   describe "GET /.well-known/registry.json" do
-    test "returns the registry URL and derives the login path", %{conn: conn} do
+    test "advertises the swift ecosystem and derives its login path", %{conn: conn} do
       stub(Tuist.Registry, :url, fn -> "https://registry.tuist.dev/api/registry/swift" end)
 
       conn = get(conn, "/.well-known/registry.json")
 
       assert json_response(conn, 200) == %{
-               "url" => "https://registry.tuist.dev/api/registry/swift",
-               "loginAPIPath" => "/api/registry/swift/login"
+               "ecosystems" => %{
+                 "swift" => %{
+                   "url" => "https://registry.tuist.dev/api/registry/swift",
+                   "loginAPIPath" => "/api/registry/swift/login"
+                 }
+               }
              }
     end
 
@@ -123,8 +127,12 @@ defmodule TuistWeb.WellKnownControllerTest do
         |> get("/.well-known/registry.json")
 
       assert json_response(conn, 200) == %{
-               "url" => "https://registry.tuist.dev/swift",
-               "loginAPIPath" => "/swift/login"
+               "ecosystems" => %{
+                 "swift" => %{
+                   "url" => "https://registry.tuist.dev/swift",
+                   "loginAPIPath" => "/swift/login"
+                 }
+               }
              }
     end
 

--- a/server/test/tuist_web/controllers/well_known_controller_test.exs
+++ b/server/test/tuist_web/controllers/well_known_controller_test.exs
@@ -102,6 +102,27 @@ defmodule TuistWeb.WellKnownControllerTest do
     end
   end
 
+  describe "GET /.well-known/tuist-registry.json" do
+    test "returns the registry base URL when configured", %{conn: conn} do
+      stub(Tuist.Registry, :url, fn -> "https://registry.tuist.dev" end)
+
+      conn = get(conn, "/.well-known/tuist-registry.json")
+
+      assert json_response(conn, 200) == %{
+               "url" => "https://registry.tuist.dev/swift",
+               "loginAPIPath" => "/swift/login"
+             }
+    end
+
+    test "404s when the deployment exposes no registry", %{conn: conn} do
+      stub(Tuist.Registry, :url, fn -> nil end)
+
+      conn = get(conn, "/.well-known/tuist-registry.json")
+
+      assert response(conn, 404) == ""
+    end
+  end
+
   describe "GET /.well-known/mcp/server-card.json" do
     test "returns the MCP server card", %{conn: conn} do
       conn = get(conn, "/.well-known/mcp/server-card.json")


### PR DESCRIPTION
## What

Adds `GET /.well-known/tuist-registry.json`, which advertises the Swift package registry base URL for the deployment so the CLI can stop hardcoding the legacy `<server>/api/registry/swift` path.

Response:
```json
{ "url": "https://registry.tuist.dev/swift", "loginAPIPath": "/swift/login" }
```

## Why

Clients today get `tuist.dev/api/registry/swift` baked into their SwiftPM `registries.json` because the CLI builds it from `serverURL`. We want them on `registry.tuist.dev` (the new standalone read frontend), but the CLI can't just hardcode that: even on Cloud there are per-env hosts (`registry.tuist.dev`, `registry-canary.tuist.dev`, `registry-staging.tuist.dev`), and self-hosted deployments have no registry at all.

A well-known discovery endpoint solves all of that: each server advertises its own registry host, so the CLI reads it and writes the right URL for whatever server it's pointed at, no hostname string-munging. A server with no registry (self-hosted) 404s, and the CLI can say "this server has no registry" instead of writing something broken.

This follows the existing `WellKnownController` pattern (`/.well-known/api-catalog`, `/.well-known/oauth-*`, `/.well-known/mcp/server-card.json`).

## Changes

- `TUIST_REGISTRY_URL` env → `Tuist.Registry.url/0` (nil when unset).
- `WellKnownController.swift_registry/2` + route in the `non_authenticated` `.well-known` scope; returns `url` + `loginAPIPath`, 404s when unset.
- Per-env Helm values: prod `https://registry.tuist.dev`, canary `https://registry-canary.tuist.dev`, staging `https://registry-staging.tuist.dev`.

The response includes `loginAPIPath` and the `/swift` prefix so the server owns the path contract; a future prefix change needs no CLI release.

## Validation

- `mix test test/tuist_web/controllers/well_known_controller_test.exs` — 18 passed (2 new: returns URL when configured, 404s when not).
- `helm template` (prod overlay) renders `TUIST_REGISTRY_URL: https://registry.tuist.dev`.
- `mix format --check-formatted` clean.

## Follow-ups (this is one of several PRs)

- CLI: read this endpoint in `registry setup`/`login`/`logout` instead of building `serverURL/api/registry/swift`; update the launch blog.
- Infra: give the production registry a dedicated cluster origin and repoint the `registry-router` Worker at it (keeps `tuist.dev/api/registry/*` compat working).
- Server: the prerelease read fallback (gates the actual traffic move).

🤖 Generated with [Claude Code](https://claude.com/claude-code)