### PR TITLE
feat(server): let self-hosted operators disable email/password and per-provider sign-in

### DIFF
--- a/server/lib/tuist/environment.ex
+++ b/server/lib/tuist/environment.ex
@@ -845,6 +845,33 @@ defmodule Tuist.Environment do
     truthy?(System.get_env("TUIST_GITHUB_AUTH_ENABLED", "1"))
   end
 
+  # Email/password sign-in and self-serve registration are built in and have no
+  # "configured?" concept, so this lever lets a self-hosted operator turn them
+  # off entirely (for example on an SSO-only instance). It gates the login form,
+  # registration, and the password-reset flow, both in the UI and server-side.
+  # There is deliberately no lockout guard: disabling this while no OAuth/SSO
+  # provider is usable leaves the instance without a login method.
+  def email_auth_enabled? do
+    truthy?(System.get_env("TUIST_EMAIL_AUTH_ENABLED", "1"))
+  end
+
+  # Google, Okta, and Apple sign-in are shown whenever the provider is
+  # configured. These levers, mirroring `github_auth_enabled?/0`, let a
+  # self-hosted operator keep a provider configured while removing it as a
+  # sign-in option (button hidden and, for the Ueberauth providers, the sign-in
+  # callback closed).
+  def google_auth_enabled? do
+    truthy?(System.get_env("TUIST_GOOGLE_AUTH_ENABLED", "1"))
+  end
+
+  def okta_auth_enabled? do
+    truthy?(System.get_env("TUIST_OKTA_AUTH_ENABLED", "1"))
+  end
+
+  def apple_auth_enabled? do
+    truthy?(System.get_env("TUIST_APPLE_AUTH_ENABLED", "1"))
+  end
+
   def github_app_configured?(secrets \\ secrets()) do
     github_app_name(secrets) != nil and github_oauth_configured?(secrets) and
       github_app_private_key(secrets) != nil

--- a/server/lib/tuist_web/controllers/api/auth_controller.ex
+++ b/server/lib/tuist_web/controllers/api/auth_controller.ex
@@ -5,6 +5,7 @@ defmodule TuistWeb.API.AuthController do
   alias OpenApiSpex.Schema
   alias Tuist.Accounts
   alias Tuist.Authentication
+  alias Tuist.Environment
   alias Tuist.OAuth.Apple
   alias Tuist.Time
   alias TuistWeb.API.Schemas.AuthenticationTokens
@@ -262,6 +263,16 @@ defmodule TuistWeb.API.AuthController do
   end
 
   def do_authenticate(%{body_params: %{email: email, password: password}} = conn, _params) do
+    if Environment.email_auth_enabled?() do
+      authenticate_with_password(conn, email, password)
+    else
+      conn
+      |> put_status(:forbidden)
+      |> json(%{message: "Email and password sign-in is disabled."})
+    end
+  end
+
+  defp authenticate_with_password(conn, email, password) do
     case Accounts.get_user_by_email_and_password(email, password) do
       {:error, :not_confirmed} ->
         conn

--- a/server/lib/tuist_web/controllers/auth_controller.ex
+++ b/server/lib/tuist_web/controllers/auth_controller.ex
@@ -129,13 +129,18 @@ defmodule TuistWeb.AuthController do
   end
 
   def callback(%{assigns: %{ueberauth_auth: auth}} = conn, _params) do
-    if auth.provider == :github and not Tuist.Environment.github_auth_enabled?() do
+    if provider_auth_enabled?(auth.provider) do
+      complete_oauth_callback(conn, auth)
+    else
       raise NotFoundError,
             dgettext("dashboard", "The authentication URL is not supported")
     end
-
-    complete_oauth_callback(conn, auth)
   end
+
+  defp provider_auth_enabled?(:github), do: Tuist.Environment.github_auth_enabled?()
+  defp provider_auth_enabled?(:google), do: Tuist.Environment.google_auth_enabled?()
+  defp provider_auth_enabled?(:apple), do: Tuist.Environment.apple_auth_enabled?()
+  defp provider_auth_enabled?(_provider), do: true
 
   defp complete_oauth_callback(conn, auth, opts \\ []) do
     auth_params = %{auth_method: auth.provider}

--- a/server/lib/tuist_web/controllers/user_session_controller.ex
+++ b/server/lib/tuist_web/controllers/user_session_controller.ex
@@ -2,6 +2,7 @@ defmodule TuistWeb.UserSessionController do
   use TuistWeb, :controller
 
   alias Tuist.Accounts
+  alias Tuist.Environment
   alias TuistWeb.Authentication
 
   def create(conn, %{"_action" => "registered"} = params) do
@@ -19,6 +20,17 @@ defmodule TuistWeb.UserSessionController do
   end
 
   defp create(conn, params, info) do
+    if Environment.email_auth_enabled?() do
+      rate_limited_create(conn, params, info)
+    else
+      conn
+      |> put_flash(:error, "Email and password sign-in is disabled.")
+      |> redirect(to: ~p"/users/log_in")
+      |> halt()
+    end
+  end
+
+  defp rate_limited_create(conn, params, info) do
     case TuistWeb.RateLimit.Auth.hit(conn) do
       {:allow, _count} ->
         do_create(conn, params, info)

--- a/server/lib/tuist_web/live/user_forgot_password_live.ex
+++ b/server/lib/tuist_web/live/user_forgot_password_live.ex
@@ -6,6 +6,7 @@ defmodule TuistWeb.UserForgotPasswordLive do
   import TuistWeb.AppAuthComponents
 
   alias Tuist.Accounts
+  alias Tuist.Environment
 
   def render(assigns) do
     ~H"""
@@ -88,10 +89,22 @@ defmodule TuistWeb.UserForgotPasswordLive do
   end
 
   def mount(_params, _session, socket) do
-    {:ok, assign(socket, form: to_form(%{}, as: "user"), success: false)}
+    if Environment.email_auth_enabled?() do
+      {:ok, assign(socket, form: to_form(%{}, as: "user"), success: false)}
+    else
+      {:ok, redirect(socket, to: ~p"/users/log_in")}
+    end
   end
 
   def handle_event("send_email", %{"user" => %{"email" => email}}, socket) do
+    if Environment.email_auth_enabled?() do
+      send_reset_email(email, socket)
+    else
+      {:noreply, redirect(socket, to: ~p"/users/log_in")}
+    end
+  end
+
+  defp send_reset_email(email, socket) do
     email = String.trim(email)
 
     case Accounts.get_user_by_email(email) do

--- a/server/lib/tuist_web/live/user_login_live.ex
+++ b/server/lib/tuist_web/live/user_login_live.ex
@@ -18,11 +18,12 @@ defmodule TuistWeb.UserLoginLive do
       |> assign(:head_title, "#{dgettext("dashboard_auth", "Log in")} · Tuist")
       |> assign(:form, form)
       |> assign(:github_configured?, Environment.github_oauth_configured?() and Environment.github_auth_enabled?())
-      |> assign(:google_configured?, Environment.google_oauth_configured?())
-      |> assign(:okta_configured?, Environment.okta_oauth_configured?())
-      |> assign(:apple_configured?, Environment.apple_oauth_configured?())
+      |> assign(:google_configured?, Environment.google_oauth_configured?() and Environment.google_auth_enabled?())
+      |> assign(:okta_configured?, Environment.okta_oauth_configured?() and Environment.okta_auth_enabled?())
+      |> assign(:apple_configured?, Environment.apple_oauth_configured?() and Environment.apple_auth_enabled?())
       |> assign(:sso_configured?, Accounts.sso_configured?())
       |> assign(:tuist_hosted?, Environment.tuist_hosted?())
+      |> assign(:email_auth_enabled?, Environment.email_auth_enabled?())
       |> assign(:test_user_login_enabled?, Environment.test_user_login_enabled?())
 
     {
@@ -112,7 +113,7 @@ defmodule TuistWeb.UserLoginLive do
               </.button>
             </div>
           </div>
-          <.line_divider :if={oauth_configured?(assigns)} text="OR" />
+          <.line_divider :if={oauth_configured?(assigns) and @email_auth_enabled?} text="OR" />
           <.alert
             :if={Flash.get(@flash, :info)}
             id="flash"
@@ -122,6 +123,7 @@ defmodule TuistWeb.UserLoginLive do
             title={Flash.get(@flash, :info)}
           />
           <.form
+            :if={@email_auth_enabled?}
             data-part="form"
             for={@form}
             id="login_form"
@@ -201,7 +203,7 @@ defmodule TuistWeb.UserLoginLive do
             </button>
           </form>
         </div>
-        <div data-part="bottom-link">
+        <div :if={@email_auth_enabled?} data-part="bottom-link">
           <span>{dgettext("dashboard_auth", "Don't have an account?")}</span>
           <.link_button
             navigate={~p"/users/register"}

--- a/server/lib/tuist_web/live/user_registration_live.ex
+++ b/server/lib/tuist_web/live/user_registration_live.ex
@@ -241,8 +241,10 @@ defmodule TuistWeb.UserRegistrationLive do
   end
 
   defp oauth_configured? do
-    Environment.github_oauth_configured?() || Environment.google_oauth_configured?() ||
-      Environment.okta_oauth_configured?() || Environment.apple_oauth_configured?()
+    (Environment.github_oauth_configured?() and Environment.github_auth_enabled?()) ||
+      (Environment.google_oauth_configured?() and Environment.google_auth_enabled?()) ||
+      (Environment.okta_oauth_configured?() and Environment.okta_auth_enabled?()) ||
+      (Environment.apple_oauth_configured?() and Environment.apple_auth_enabled?())
   end
 
   defp format_password_error(errors) do
@@ -259,28 +261,40 @@ defmodule TuistWeb.UserRegistrationLive do
   end
 
   def mount(_params, _session, socket) do
-    form =
-      to_form(%{}, as: "user")
+    if Environment.email_auth_enabled?() do
+      form =
+        to_form(%{}, as: "user")
 
-    socket =
-      socket
-      |> assign(:head_title, "#{dgettext("dashboard_auth", "Sign up")} · Tuist")
-      |> assign(:form, form)
-      |> assign(:success, false)
-      |> assign(:errors, %{})
-      |> assign(:github_configured?, Environment.github_oauth_configured?())
-      |> assign(:google_configured?, Environment.google_oauth_configured?())
-      |> assign(:okta_configured?, Environment.okta_oauth_configured?())
-      |> assign(:apple_configured?, Environment.apple_oauth_configured?())
+      socket =
+        socket
+        |> assign(:head_title, "#{dgettext("dashboard_auth", "Sign up")} · Tuist")
+        |> assign(:form, form)
+        |> assign(:success, false)
+        |> assign(:errors, %{})
+        |> assign(:github_configured?, Environment.github_oauth_configured?() and Environment.github_auth_enabled?())
+        |> assign(:google_configured?, Environment.google_oauth_configured?() and Environment.google_auth_enabled?())
+        |> assign(:okta_configured?, Environment.okta_oauth_configured?() and Environment.okta_auth_enabled?())
+        |> assign(:apple_configured?, Environment.apple_oauth_configured?() and Environment.apple_auth_enabled?())
 
-    {
-      :ok,
-      socket,
-      temporary_assigns: [form: nil]
-    }
+      {
+        :ok,
+        socket,
+        temporary_assigns: [form: nil]
+      }
+    else
+      {:ok, redirect(socket, to: ~p"/users/log_in")}
+    end
   end
 
   def handle_event("save", %{"user" => user_params}, socket) do
+    if Environment.email_auth_enabled?() do
+      save_user(user_params, socket)
+    else
+      {:noreply, redirect(socket, to: ~p"/users/log_in")}
+    end
+  end
+
+  defp save_user(user_params, socket) do
     case user_params
          |> Map.get("email", "")
          |> String.trim()

--- a/server/lib/tuist_web/live/user_reset_password_live.ex
+++ b/server/lib/tuist_web/live/user_reset_password_live.ex
@@ -6,6 +6,7 @@ defmodule TuistWeb.UserResetPasswordLive do
   import TuistWeb.AppAuthComponents
 
   alias Tuist.Accounts
+  alias Tuist.Environment
   alias TuistWeb.Endpoint
 
   def render(assigns) do
@@ -77,16 +78,20 @@ defmodule TuistWeb.UserResetPasswordLive do
   end
 
   def mount(params, _session, socket) do
-    password = Phoenix.Flash.get(socket.assigns.flash, :password)
-    form = to_form(%{"password" => password}, as: "user")
+    if Environment.email_auth_enabled?() do
+      password = Phoenix.Flash.get(socket.assigns.flash, :password)
+      form = to_form(%{"password" => password}, as: "user")
 
-    {
-      :ok,
-      socket
-      |> assign_user_and_token(params)
-      |> assign(:form, form),
-      temporary_assigns: [form: form]
-    }
+      {
+        :ok,
+        socket
+        |> assign_user_and_token(params)
+        |> assign(:form, form),
+        temporary_assigns: [form: form]
+      }
+    else
+      {:ok, redirect(socket, to: ~p"/users/log_in")}
+    end
   end
 
   # Do not log in the user after reset password to avoid a

--- a/server/priv/docs/en/guides/server/self-host/server.md
+++ b/server/priv/docs/en/guides/server/self-host/server.md
@@ -210,9 +210,6 @@ By default, a provider appears as a sign-in option whenever it is configured. To
 | `TUIST_OKTA_AUTH_ENABLED` | Whether the configured Okta provider appears as a sign-in option | No | `1` | `0` |
 | `TUIST_APPLE_AUTH_ENABLED` | Whether Apple can be used to sign in | No | `1` | `0` |
 
-> [!NOTE]
-> `TUIST_OKTA_AUTH_ENABLED` hides Okta from the login and sign-up pages. Organizations that have configured Okta as their SSO provider in their settings continue to use it, including when SSO is enforced.
-
 #### GitHub {#github}
 
 We recommend authenticating using a [GitHub App](https://docs.github.com/en/apps/creating-github-apps/about-creating-github-apps/about-creating-github-apps) but you can also use the [OAuth App](https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/creating-an-oauth-app). Make sure to include all essential environment variables specified by GitHub in the server environment. Absent variables will cause Tuist to overlook the GitHub authentication. To properly set up the GitHub app:

--- a/server/priv/docs/en/guides/server/self-host/server.md
+++ b/server/priv/docs/en/guides/server/self-host/server.md
@@ -195,9 +195,6 @@ We facilitate authentication through [identity providers (IdP)](https://en.wikip
 
 Email and password sign-in and self-serve registration are built in and enabled by default. On an instance where you want to require an identity provider (for example, when enforcing SSO), you can turn them off entirely. This removes the email/password form, the sign-up link, and the password-reset flow from the login experience, and closes every matching server-side endpoint, including the email/password endpoint the CLI uses (`tuist auth`).
 
-> [!WARNING]
-> There is no lockout guard. If you disable email and password sign-in while no other provider (GitHub, Google, Okta, Apple, or SSO) is configured and enabled, the instance will have no available login method.
-
 | Environment variable | Description | Required | Default | Example |
 | --- | --- | --- | --- | --- |
 | `TUIST_EMAIL_AUTH_ENABLED` | Whether email and password can be used to sign in and register. Set to `0` to remove the email/password form, the sign-up link, and the password-reset flow from the login page and close the matching server-side endpoints | No | `1` | `0` |

--- a/server/priv/docs/en/guides/server/self-host/server.md
+++ b/server/priv/docs/en/guides/server/self-host/server.md
@@ -191,6 +191,31 @@ ALTER ROLE <runtime_role> IN DATABASE <database> SET search_path = tuist;
 
 We facilitate authentication through [identity providers (IdP)](https://en.wikipedia.org/wiki/Identity_provider). To utilize this, ensure all necessary environment variables for the chosen provider are present in the server's environment. **Missing variables** will result in Tuist bypassing that provider.
 
+#### Email and password {#email-and-password}
+
+Email and password sign-in and self-serve registration are built in and enabled by default. On an instance where you want to require an identity provider (for example, when enforcing SSO), you can turn them off entirely. This removes the email/password form, the sign-up link, and the password-reset flow from the login experience, and closes every matching server-side endpoint, including the email/password endpoint the CLI uses (`tuist auth`).
+
+> [!WARNING]
+> There is no lockout guard. If you disable email and password sign-in while no other provider (GitHub, Google, Okta, Apple, or SSO) is configured and enabled, the instance will have no available login method.
+
+| Environment variable | Description | Required | Default | Example |
+| --- | --- | --- | --- | --- |
+| `TUIST_EMAIL_AUTH_ENABLED` | Whether email and password can be used to sign in and register. Set to `0` to remove the email/password form, the sign-up link, and the password-reset flow from the login page and close the matching server-side endpoints | No | `1` | `0` |
+
+#### Disabling a configured identity provider {#disabling-a-configured-identity-provider}
+
+By default, a provider appears as a sign-in option whenever it is configured. To keep a provider configured (its credentials remain set) while removing it from the login and sign-up pages, set the matching lever to `0`. For GitHub, Google, and Apple this also closes the sign-in callback, so the method is unavailable end to end.
+
+| Environment variable | Description | Required | Default | Example |
+| --- | --- | --- | --- | --- |
+| `TUIST_GITHUB_AUTH_ENABLED` | Whether GitHub can be used to sign in (see the [GitHub](#github) section for why the App shares its credentials with sign-in) | No | `1` | `0` |
+| `TUIST_GOOGLE_AUTH_ENABLED` | Whether Google can be used to sign in | No | `1` | `0` |
+| `TUIST_OKTA_AUTH_ENABLED` | Whether the configured Okta provider appears as a sign-in option | No | `1` | `0` |
+| `TUIST_APPLE_AUTH_ENABLED` | Whether Apple can be used to sign in | No | `1` | `0` |
+
+> [!NOTE]
+> `TUIST_OKTA_AUTH_ENABLED` hides Okta from the login and sign-up pages. Organizations that have configured Okta as their SSO provider in their settings continue to use it, including when SSO is enforced.
+
 #### GitHub {#github}
 
 We recommend authenticating using a [GitHub App](https://docs.github.com/en/apps/creating-github-apps/about-creating-github-apps/about-creating-github-apps) but you can also use the [OAuth App](https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/creating-an-oauth-app). Make sure to include all essential environment variables specified by GitHub in the server environment. Absent variables will cause Tuist to overlook the GitHub authentication. To properly set up the GitHub app:

--- a/server/priv/gettext/dashboard.pot
+++ b/server/priv/gettext/dashboard.pot
@@ -340,7 +340,7 @@ msgid "The account you are looking for doesn't exist or has been moved."
 msgstr ""
 
 #: lib/tuist_web/controllers/auth_controller.ex:30
-#: lib/tuist_web/controllers/auth_controller.ex:134
+#: lib/tuist_web/controllers/auth_controller.ex:136
 #, elixir-autogen, elixir-format
 msgid "The authentication URL is not supported"
 msgstr ""
@@ -433,7 +433,7 @@ msgstr ""
 msgid "You need to be authenticated to access this page."
 msgstr ""
 
-#: lib/tuist_web/controllers/user_session_controller.ex:28
+#: lib/tuist_web/controllers/user_session_controller.ex:40
 #, elixir-autogen, elixir-format
 msgid "You've exceeded the rate limit. Try again later."
 msgstr ""
@@ -522,8 +522,8 @@ msgstr ""
 msgid "Authentication failed"
 msgstr ""
 
-#: lib/tuist_web/controllers/auth_controller.ex:346
-#: lib/tuist_web/controllers/auth_controller.ex:518
+#: lib/tuist_web/controllers/auth_controller.ex:351
+#: lib/tuist_web/controllers/auth_controller.ex:523
 #, elixir-autogen, elixir-format
 msgid "Your identity provider denied access. Please ask your organization admin to assign you to the Tuist application."
 msgstr ""
@@ -534,42 +534,42 @@ msgstr ""
 msgid "Shards"
 msgstr ""
 
-#: lib/tuist_web/controllers/auth_controller.ex:355
+#: lib/tuist_web/controllers/auth_controller.ex:360
 #, elixir-autogen, elixir-format
 msgid "Authentication with the identity provider failed. Please try again."
 msgstr ""
 
-#: lib/tuist_web/controllers/auth_controller.ex:602
+#: lib/tuist_web/controllers/auth_controller.ex:607
 #, elixir-autogen, elixir-format
 msgid "Failed to authenticate with the SSO provider. Please try again."
 msgstr ""
 
-#: lib/tuist_web/controllers/auth_controller.ex:497
+#: lib/tuist_web/controllers/auth_controller.ex:502
 #, elixir-autogen, elixir-format
 msgid "SSO is not fully configured for this organization. Ask an organization admin to review the SSO settings."
 msgstr ""
 
-#: lib/tuist_web/controllers/auth_controller.ex:560
+#: lib/tuist_web/controllers/auth_controller.ex:565
 #, elixir-autogen, elixir-format
 msgid "The SSO authorization code is invalid or expired. Please restart the sign-in flow."
 msgstr ""
 
-#: lib/tuist_web/controllers/auth_controller.ex:532
+#: lib/tuist_web/controllers/auth_controller.ex:537
 #, elixir-autogen, elixir-format
 msgid "The SSO provider callback is missing an authorization code. Please restart the sign-in flow."
 msgstr ""
 
-#: lib/tuist_web/controllers/auth_controller.ex:483
+#: lib/tuist_web/controllers/auth_controller.ex:488
 #, elixir-autogen, elixir-format
 msgid "The SSO request is missing an organization identifier. Please start the sign-in flow again from the login page."
 msgstr ""
 
-#: lib/tuist_web/controllers/auth_controller.ex:511
+#: lib/tuist_web/controllers/auth_controller.ex:516
 #, elixir-autogen, elixir-format
 msgid "The SSO response could not be validated because the request state did not match. Please try again."
 msgstr ""
 
-#: lib/tuist_web/controllers/auth_controller.ex:539
+#: lib/tuist_web/controllers/auth_controller.ex:544
 #, elixir-autogen, elixir-format
 msgid "The configured SSO endpoints are invalid. Ask your organization admin to review the SSO settings."
 msgstr ""
@@ -579,52 +579,52 @@ msgstr ""
 msgid "Tuist Ops"
 msgstr ""
 
-#: lib/tuist_web/controllers/auth_controller.ex:546
+#: lib/tuist_web/controllers/auth_controller.ex:551
 #, elixir-autogen, elixir-format
 msgid "Tuist couldn't exchange the authorization code with your identity provider. Ask your organization admin to verify the SSO credentials and callback URL."
 msgstr ""
 
-#: lib/tuist_web/controllers/auth_controller.ex:553
+#: lib/tuist_web/controllers/auth_controller.ex:558
 #, elixir-autogen, elixir-format
 msgid "Tuist couldn't fetch your profile from your identity provider. Ask your organization admin to verify the user info endpoint and configured scopes."
 msgstr ""
 
-#: lib/tuist_web/controllers/auth_controller.ex:595
+#: lib/tuist_web/controllers/auth_controller.ex:600
 #, elixir-autogen, elixir-format
 msgid "We couldn't complete the SSO callback for this request. Please try again."
 msgstr ""
 
-#: lib/tuist_web/controllers/auth_controller.ex:490
+#: lib/tuist_web/controllers/auth_controller.ex:495
 #, elixir-autogen, elixir-format
 msgid "We couldn't find the organization for this SSO request. Please verify that you are using the correct SSO link."
 msgstr ""
 
-#: lib/tuist_web/controllers/auth_controller.ex:588
+#: lib/tuist_web/controllers/auth_controller.ex:593
 #, elixir-autogen, elixir-format
 msgid "We couldn't start the SSO flow for this organization. Please verify the SSO configuration and try again."
 msgstr ""
 
-#: lib/tuist_web/controllers/auth_controller.ex:504
+#: lib/tuist_web/controllers/auth_controller.ex:509
 #, elixir-autogen, elixir-format
 msgid "Your SSO session has expired. Please restart the sign-in flow from the login page."
 msgstr ""
 
-#: lib/tuist_web/controllers/auth_controller.ex:581
+#: lib/tuist_web/controllers/auth_controller.ex:586
 #, elixir-autogen, elixir-format
 msgid "Your Tuist account already exists, but it isn't a member of this organization. Ask an organization admin to add you, then sign in with SSO again."
 msgstr ""
 
-#: lib/tuist_web/controllers/auth_controller.ex:567
+#: lib/tuist_web/controllers/auth_controller.ex:572
 #, elixir-autogen, elixir-format
 msgid "Your identity provider response is missing a stable user identifier. Ask your organization admin to review the user info claims."
 msgstr ""
 
-#: lib/tuist_web/controllers/auth_controller.ex:574
+#: lib/tuist_web/controllers/auth_controller.ex:579
 #, elixir-autogen, elixir-format
 msgid "Your identity provider response is missing an email address. Ask your organization admin to include the email claim."
 msgstr ""
 
-#: lib/tuist_web/controllers/auth_controller.ex:525
+#: lib/tuist_web/controllers/auth_controller.ex:530
 #, elixir-autogen, elixir-format
 msgid "Your identity provider returned an authentication error. Please try again or contact your organization admin."
 msgstr ""

--- a/server/priv/gettext/dashboard_auth.pot
+++ b/server/priv/gettext/dashboard_auth.pot
@@ -16,12 +16,12 @@ msgstr ""
 msgid "Account confirmed!"
 msgstr ""
 
-#: lib/tuist_web/live/user_registration_live.ex:297
+#: lib/tuist_web/live/user_registration_live.ex:311
 #, elixir-autogen, elixir-format
 msgid "Account created successfully! Please log in."
 msgstr ""
 
-#: lib/tuist_web/live/user_registration_live.ex:309
+#: lib/tuist_web/live/user_registration_live.ex:323
 #, elixir-autogen, elixir-format
 msgid "Account name is already taken"
 msgstr ""
@@ -36,7 +36,7 @@ msgstr ""
 msgid "Already set up your Tuist project? Skip setup and go to the dashboard."
 msgstr ""
 
-#: lib/tuist_web/live/user_forgot_password_live.ex:75
+#: lib/tuist_web/live/user_forgot_password_live.ex:76
 #, elixir-autogen, elixir-format
 msgid "Back to log in"
 msgstr ""
@@ -46,12 +46,12 @@ msgstr ""
 msgid "Binary caching"
 msgstr ""
 
-#: lib/tuist_web/live/user_reset_password_live.ex:34
+#: lib/tuist_web/live/user_reset_password_live.ex:35
 #, elixir-autogen, elixir-format
 msgid "Change your password"
 msgstr ""
 
-#: lib/tuist_web/live/user_forgot_password_live.ex:43
+#: lib/tuist_web/live/user_forgot_password_live.ex:44
 #, elixir-autogen, elixir-format
 msgid "Check your email"
 msgstr ""
@@ -66,7 +66,7 @@ msgstr ""
 msgid "Choose a username"
 msgstr ""
 
-#: lib/tuist_web/live/user_reset_password_live.ex:55
+#: lib/tuist_web/live/user_reset_password_live.ex:56
 #, elixir-autogen, elixir-format
 msgid "Confirm password"
 msgstr ""
@@ -121,20 +121,20 @@ msgstr ""
 msgid "Discover how selective testing is reducing your test time."
 msgstr ""
 
-#: lib/tuist_web/live/user_login_live.ex:205
+#: lib/tuist_web/live/user_login_live.ex:207
 #, elixir-autogen, elixir-format
 msgid "Don't have an account?"
 msgstr ""
 
 #: lib/tuist_web/live/sso_login_live.ex:89
-#: lib/tuist_web/live/user_forgot_password_live.ex:55
-#: lib/tuist_web/live/user_login_live.ex:142
+#: lib/tuist_web/live/user_forgot_password_live.ex:56
+#: lib/tuist_web/live/user_login_live.ex:144
 #: lib/tuist_web/live/user_registration_live.ex:149
 #, elixir-autogen, elixir-format
 msgid "Email address"
 msgstr ""
 
-#: lib/tuist_web/live/user_registration_live.ex:312
+#: lib/tuist_web/live/user_registration_live.ex:326
 #, elixir-autogen, elixir-format
 msgid "Email is already taken"
 msgstr ""
@@ -149,17 +149,17 @@ msgstr ""
 msgid "Explore how binary caching is enhancing your build times."
 msgstr ""
 
-#: lib/tuist_web/live/user_login_live.ex:174
+#: lib/tuist_web/live/user_login_live.ex:176
 #, elixir-autogen, elixir-format
 msgid "Forgot password?"
 msgstr ""
 
-#: lib/tuist_web/live/user_forgot_password_live.ex:32
+#: lib/tuist_web/live/user_forgot_password_live.ex:33
 #, elixir-autogen, elixir-format
 msgid "Forgot your password?"
 msgstr ""
 
-#: lib/tuist_web/live/user_forgot_password_live.ex:45
+#: lib/tuist_web/live/user_forgot_password_live.ex:46
 #, elixir-autogen, elixir-format
 msgid "If your email exists in our records, you'll receive reset instructions shortly."
 msgstr ""
@@ -179,21 +179,21 @@ msgstr ""
 msgid "Interested in SSO?"
 msgstr ""
 
-#: lib/tuist_web/live/user_login_live.ex:167
+#: lib/tuist_web/live/user_login_live.ex:169
 #, elixir-autogen, elixir-format
 msgid "Keep me logged in"
 msgstr ""
 
 #: lib/tuist_web/live/sso_login_live.ex:97
 #: lib/tuist_web/live/user_login_live.ex:18
-#: lib/tuist_web/live/user_login_live.ex:180
+#: lib/tuist_web/live/user_login_live.ex:182
 #: lib/tuist_web/live/user_registration_live.ex:194
 #, elixir-autogen, elixir-format
 msgid "Log in"
 msgstr ""
 
 #: lib/tuist_web/live/sso_login_live.ex:72
-#: lib/tuist_web/live/user_login_live.ex:51
+#: lib/tuist_web/live/user_login_live.ex:52
 #, elixir-autogen, elixir-format
 msgid "Log in to Tuist"
 msgstr ""
@@ -203,7 +203,7 @@ msgstr ""
 msgid "Log in to your enterprise account via SSO"
 msgstr ""
 
-#: lib/tuist_web/live/user_reset_password_live.ex:47
+#: lib/tuist_web/live/user_reset_password_live.ex:48
 #, elixir-autogen, elixir-format
 msgid "New password"
 msgstr ""
@@ -218,13 +218,13 @@ msgstr ""
 msgid "OR"
 msgstr ""
 
-#: lib/tuist_web/live/user_login_live.ex:153
+#: lib/tuist_web/live/user_login_live.ex:155
 #: lib/tuist_web/live/user_registration_live.ex:159
 #, elixir-autogen, elixir-format
 msgid "Password"
 msgstr ""
 
-#: lib/tuist_web/live/user_reset_password_live.ex:101
+#: lib/tuist_web/live/user_reset_password_live.ex:106
 #, elixir-autogen, elixir-format
 msgid "Password reset successfully."
 msgstr ""
@@ -239,8 +239,8 @@ msgstr ""
 msgid "Project Ready? Proceed to dashboard"
 msgstr ""
 
-#: lib/tuist_web/live/user_forgot_password_live.ex:64
-#: lib/tuist_web/live/user_reset_password_live.ex:62
+#: lib/tuist_web/live/user_forgot_password_live.ex:65
+#: lib/tuist_web/live/user_reset_password_live.ex:63
 #, elixir-autogen, elixir-format
 msgid "Reset password"
 msgstr ""
@@ -260,9 +260,9 @@ msgstr ""
 msgid "Selective testing"
 msgstr ""
 
-#: lib/tuist_web/live/user_login_live.ex:210
+#: lib/tuist_web/live/user_login_live.ex:212
 #: lib/tuist_web/live/user_registration_live.ex:183
-#: lib/tuist_web/live/user_registration_live.ex:267
+#: lib/tuist_web/live/user_registration_live.ex:270
 #, elixir-autogen, elixir-format
 msgid "Sign up"
 msgstr ""
@@ -286,11 +286,11 @@ msgstr ""
 #: lib/tuist_web/live/device_codes_success_live.ex:28
 #: lib/tuist_web/live/sso_login_live.ex:63
 #: lib/tuist_web/live/user_confirmation_live.ex:18
-#: lib/tuist_web/live/user_forgot_password_live.ex:23
-#: lib/tuist_web/live/user_login_live.ex:42
+#: lib/tuist_web/live/user_forgot_password_live.ex:24
+#: lib/tuist_web/live/user_login_live.ex:43
 #: lib/tuist_web/live/user_registration_live.ex:67
 #: lib/tuist_web/live/user_registration_live.ex:212
-#: lib/tuist_web/live/user_reset_password_live.ex:25
+#: lib/tuist_web/live/user_reset_password_live.ex:26
 #, elixir-autogen, elixir-format
 msgid "Tuist Logo"
 msgstr ""
@@ -337,12 +337,12 @@ msgstr ""
 msgid "Waiting for connection"
 msgstr ""
 
-#: lib/tuist_web/live/user_forgot_password_live.ex:34
+#: lib/tuist_web/live/user_forgot_password_live.ex:35
 #, elixir-autogen, elixir-format
 msgid "We'll send a password reset link to your inbox"
 msgstr ""
 
-#: lib/tuist_web/live/user_login_live.ex:53
+#: lib/tuist_web/live/user_login_live.ex:54
 #, elixir-autogen, elixir-format
 msgid "Welcome back! Please log in to continue"
 msgstr ""
@@ -382,7 +382,7 @@ msgstr ""
 msgid "Your account has been confirmed. You will be redirected shortly..."
 msgstr ""
 
-#: lib/tuist_web/live/user_reset_password_live.ex:36
+#: lib/tuist_web/live/user_reset_password_live.ex:37
 #, elixir-autogen, elixir-format
 msgid "Your new password must be different to previously used passwords."
 msgstr ""
@@ -424,7 +424,7 @@ msgstr ""
 msgid "and"
 msgstr ""
 
-#: lib/tuist_web/live/user_login_live.ex:200
+#: lib/tuist_web/live/user_login_live.ex:202
 #, elixir-autogen, elixir-format
 msgid "Log in as test user"
 msgstr ""
@@ -434,7 +434,7 @@ msgstr ""
 msgid "Choose a username for your account"
 msgstr ""
 
-#: lib/tuist_web/live/user_login_live.ex:107
+#: lib/tuist_web/live/user_login_live.ex:108
 #, elixir-autogen, elixir-format
 msgid "Log in with SSO"
 msgstr ""
@@ -444,7 +444,7 @@ msgstr ""
 msgid "No SSO organization is configured for this email. Check the address and ask your organization admin to verify the SSO domain setup."
 msgstr ""
 
-#: lib/tuist_web/controllers/auth_controller.ex:335
+#: lib/tuist_web/controllers/auth_controller.ex:340
 #, elixir-autogen, elixir-format
 msgid "An account with this email already exists. Please log in instead."
 msgstr ""

--- a/server/test/tuist_web/controllers/api/auth_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/auth_controller_test.exs
@@ -411,6 +411,23 @@ defmodule TuistWeb.API.AuthControllerTest do
       assert refresh_token_claims["preferred_username"] == user.account.name
     end
 
+    test "returns forbidden when email auth is disabled", %{conn: conn} do
+      # Given
+      stub(Tuist.Environment, :email_auth_enabled?, fn -> false end)
+      password = UUIDv7.generate()
+      user = AccountsFixtures.user_fixture(password: password)
+
+      # When
+      conn =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> post("/api/auth", %{email: user.email, password: password})
+
+      # Then
+      response = json_response(conn, :forbidden)
+      assert response == %{"message" => "Email and password sign-in is disabled."}
+    end
+
     test "returns unauthorized when the password is invalid", %{conn: conn} do
       # Given
       password = UUIDv7.generate()

--- a/server/test/tuist_web/controllers/auth_controller_test.exs
+++ b/server/test/tuist_web/controllers/auth_controller_test.exs
@@ -8,6 +8,7 @@ defmodule TuistWeb.AuthControllerTest do
   alias Tuist.Accounts.Oauth2Identity
   alias Tuist.OAuth2.SSOClient
   alias TuistTestSupport.Fixtures.AccountsFixtures
+  alias TuistWeb.Errors.NotFoundError
   alias Ueberauth.Auth.Info
 
   describe "GET /auth/cli/:device_code" do
@@ -858,7 +859,41 @@ defmodule TuistWeb.AuthControllerTest do
 
       conn = conn |> init_test_session(%{}) |> assign(:ueberauth_auth, auth)
 
-      assert_raise TuistWeb.Errors.NotFoundError, fn ->
+      assert_raise NotFoundError, fn ->
+        TuistWeb.AuthController.callback(conn, %{})
+      end
+    end
+
+    test "rejects the Google callback when Google auth is disabled", %{conn: conn} do
+      stub(Tuist.Environment, :google_auth_enabled?, fn -> false end)
+
+      auth = %Ueberauth.Auth{
+        provider: :google,
+        uid: "google-uid-123",
+        info: %Info{email: "google-user@example.com"},
+        extra: %{raw_info: %{user: %{"hd" => nil}}}
+      }
+
+      conn = conn |> init_test_session(%{}) |> assign(:ueberauth_auth, auth)
+
+      assert_raise NotFoundError, fn ->
+        TuistWeb.AuthController.callback(conn, %{})
+      end
+    end
+
+    test "rejects the Apple callback when Apple auth is disabled", %{conn: conn} do
+      stub(Tuist.Environment, :apple_auth_enabled?, fn -> false end)
+
+      auth = %Ueberauth.Auth{
+        provider: :apple,
+        uid: "apple-uid-123",
+        info: %Info{email: "apple-user@example.com"},
+        extra: %{raw_info: %{user: %{}}}
+      }
+
+      conn = conn |> init_test_session(%{}) |> assign(:ueberauth_auth, auth)
+
+      assert_raise NotFoundError, fn ->
         TuistWeb.AuthController.callback(conn, %{})
       end
     end

--- a/server/test/tuist_web/controllers/user_session_controller_test.exs
+++ b/server/test/tuist_web/controllers/user_session_controller_test.exs
@@ -47,6 +47,19 @@ defmodule TuistWeb.UserSessionControllerTest do
       assert redirected_to(conn) == ~p"/#{user.account.name}/projects"
     end
 
+    test "does not log the user in when email auth is disabled", %{conn: conn, user: user} do
+      stub(Tuist.Environment, :email_auth_enabled?, fn -> false end)
+
+      conn =
+        post(conn, ~p"/users/log_in", %{
+          "user" => %{"email" => user.email, "password" => valid_user_password()}
+        })
+
+      refute get_session(conn, :user_token)
+      assert redirected_to(conn) == ~p"/users/log_in"
+      assert Phoenix.Flash.get(conn.assigns.flash, :error) =~ "disabled"
+    end
+
     test "logs the user in with remember me", %{conn: conn, user: user} do
       conn =
         post(conn, ~p"/users/log_in", %{

--- a/server/test/tuist_web/live/user_forgot_password_live_test.exs
+++ b/server/test/tuist_web/live/user_forgot_password_live_test.exs
@@ -18,6 +18,13 @@ defmodule TuistWeb.UserForgotPasswordLiveTest do
       assert html =~ "Forgot your password?"
     end
 
+    test "redirects to log in when email auth is disabled", %{conn: conn} do
+      stub(Environment, :email_auth_enabled?, fn -> false end)
+
+      assert {:error, {:redirect, %{to: to}}} = live(conn, ~p"/users/reset_password")
+      assert to == ~p"/users/log_in"
+    end
+
     test "redirects if already logged in", %{conn: conn} do
       user = user_fixture(preload: [:account])
 

--- a/server/test/tuist_web/live/user_login_live_test.exs
+++ b/server/test/tuist_web/live/user_login_live_test.exs
@@ -98,6 +98,63 @@ defmodule TuistWeb.UserLoginLiveTest do
       assert has_element?(lv, "input#email")
       assert has_element?(lv, "input#password")
     end
+
+    test "hides the password form and sign-up link when email auth is disabled", %{conn: conn} do
+      stub(Tuist.Environment, :email_auth_enabled?, fn -> false end)
+
+      {:ok, lv, html} = live(conn, ~p"/users/log_in")
+
+      refute has_element?(lv, "#login_form")
+      refute has_element?(lv, "input#password")
+      refute html =~ "Sign up"
+    end
+
+    test "still renders the SSO button when email auth is disabled", %{conn: conn} do
+      stub(Tuist.Environment, :email_auth_enabled?, fn -> false end)
+      stub(Tuist.Environment, :okta_oauth_configured?, fn -> true end)
+      stub(Tuist.Environment, :tuist_hosted?, fn -> false end)
+
+      {:ok, _lv, html} = live(conn, ~p"/users/log_in")
+
+      assert html =~ "SSO"
+    end
+
+    test "renders the Google button when Google is configured and enabled", %{conn: conn} do
+      stub(Tuist.Environment, :google_oauth_configured?, fn -> true end)
+
+      {:ok, lv, _html} = live(conn, ~p"/users/log_in")
+
+      assert has_element?(lv, "a[href='/users/auth/google']")
+    end
+
+    test "hides the Google button when Google auth is disabled", %{conn: conn} do
+      stub(Tuist.Environment, :google_oauth_configured?, fn -> true end)
+      stub(Tuist.Environment, :google_auth_enabled?, fn -> false end)
+
+      {:ok, lv, _html} = live(conn, ~p"/users/log_in")
+
+      refute has_element?(lv, "a[href='/users/auth/google']")
+    end
+
+    test "hides the Apple button when Apple auth is disabled", %{conn: conn} do
+      stub(Tuist.Environment, :apple_oauth_configured?, fn -> true end)
+      stub(Tuist.Environment, :apple_auth_enabled?, fn -> false end)
+
+      {:ok, lv, _html} = live(conn, ~p"/users/log_in")
+
+      refute has_element?(lv, "a[href='/users/auth/apple']")
+    end
+
+    test "drops Okta from the SSO button when Okta auth is disabled", %{conn: conn} do
+      stub(Tuist.Environment, :okta_oauth_configured?, fn -> true end)
+      stub(Tuist.Environment, :okta_auth_enabled?, fn -> false end)
+      stub(Tuist.Environment, :tuist_hosted?, fn -> false end)
+      stub(Tuist.Accounts, :sso_configured?, fn -> false end)
+
+      {:ok, _lv, html} = live(conn, ~p"/users/log_in")
+
+      refute html =~ "Log in with SSO"
+    end
   end
 
   describe "user login" do

--- a/server/test/tuist_web/live/user_registration_live_test.exs
+++ b/server/test/tuist_web/live/user_registration_live_test.exs
@@ -13,6 +13,39 @@ defmodule TuistWeb.UserRegistrationLiveTest do
       assert html =~ "Create an account"
     end
 
+    test "redirects to log in when email auth is disabled", %{conn: conn} do
+      stub(Tuist.Environment, :email_auth_enabled?, fn -> false end)
+
+      assert {:error, {:redirect, %{to: to}}} = live(conn, ~p"/users/register")
+      assert to == ~p"/users/log_in"
+    end
+
+    test "renders the Google button when Google is configured and enabled", %{conn: conn} do
+      stub(Tuist.Environment, :google_oauth_configured?, fn -> true end)
+
+      {:ok, lv, _html} = live(conn, ~p"/users/register")
+
+      assert has_element?(lv, "a[href='/users/auth/google']")
+    end
+
+    test "hides the Google button when Google auth is disabled", %{conn: conn} do
+      stub(Tuist.Environment, :google_oauth_configured?, fn -> true end)
+      stub(Tuist.Environment, :google_auth_enabled?, fn -> false end)
+
+      {:ok, lv, _html} = live(conn, ~p"/users/register")
+
+      refute has_element?(lv, "a[href='/users/auth/google']")
+    end
+
+    test "hides the Okta button when Okta auth is disabled", %{conn: conn} do
+      stub(Tuist.Environment, :okta_oauth_configured?, fn -> true end)
+      stub(Tuist.Environment, :okta_auth_enabled?, fn -> false end)
+
+      {:ok, lv, _html} = live(conn, ~p"/users/register")
+
+      refute has_element?(lv, "a[href='/users/auth/okta']")
+    end
+
     test "redirects if already logged in", %{conn: conn} do
       user = user_fixture(preload: [:account])
 

--- a/server/test/tuist_web/live/user_reset_password_live_test.exs
+++ b/server/test/tuist_web/live/user_reset_password_live_test.exs
@@ -30,6 +30,13 @@ defmodule TuistWeb.UserResetPasswordLiveTest do
       assert html =~ "New password"
     end
 
+    test "redirects to log in when email auth is disabled", %{conn: conn, token: token} do
+      stub(Tuist.Environment, :email_auth_enabled?, fn -> false end)
+
+      assert {:error, {:redirect, %{to: to}}} = live(conn, ~p"/users/reset_password/#{token}")
+      assert to == ~p"/users/log_in"
+    end
+
     test "does not render reset password with invalid token", %{conn: conn} do
       {:error, {:redirect, to}} = live(conn, ~p"/users/reset_password/invalid")
 


### PR DESCRIPTION
> Describe here the purpose of your PR.

## What & why

Self-hosted operators enforcing SSO reported that the login page still showed the email/password form and the **Sign up** link. Enforce SSO is applied at the dashboard boundary (`require_sso_authentication/2`), so those methods were never actually usable for an enforced org, but the UI didn't reflect that and there was no way to narrow the login page. On top of that, sign-in options were driven purely by "is the provider configured?", with no explicit way to keep a provider configured while removing it as a sign-in option (only GitHub had a lever).

This adds explicit enable/disable levers, **all defaulting to on**, so existing deployments are unchanged.

| Env var | Effect when `0` |
| --- | --- |
| `TUIST_EMAIL_AUTH_ENABLED` | Hides the password form, **Sign up**, **Forgot password?**, and the **OR** divider; closes the login `POST`, the registration/forgot/reset LiveViews (mount + events redirect to `/users/log_in`), and the CLI email/password endpoint `POST /api/auth` (403). |
| `TUIST_GOOGLE_AUTH_ENABLED` | Hides the Google button and closes the Ueberauth sign-in callback. |
| `TUIST_APPLE_AUTH_ENABLED` | Hides the Apple button and closes the Ueberauth sign-in callback. |
| `TUIST_OKTA_AUTH_ENABLED` | Hides Okta from the login and sign-up pages (see note below). |
| `TUIST_GITHUB_AUTH_ENABLED` | Unchanged; now also honored on the sign-up page (see fix below). |

## Design notes / why this shape

- **Server-side, not cosmetic.** A UI-only hide would leave self-serve registration and the CLI token endpoint (`POST /api/auth`) fully open, which defeats the point on an SSO-only instance. Every lever closes the underlying path, mirroring how `TUIST_GITHUB_AUTH_ENABLED` already gates the callback rather than only hiding the button.
- **Okta is deliberately narrower.** Okta is not a Ueberauth provider; its only sign-in path is the per-org SSO flow an org admin configures in settings. So `TUIST_OKTA_AUTH_ENABLED` hides Okta from the login/sign-up pages but intentionally does **not** touch that flow — an org that enforces Okta SSO keeps working.
- **Pre-existing bug fixed.** `TUIST_GITHUB_AUTH_ENABLED` was honored on the login page but not on the registration page; all four providers are now consistent across both.
- **No lockout guard**, matching `TUIST_GITHUB_AUTH_ENABLED`. Disabling email/password with no other usable provider is the operator's responsibility.

Root cause of the original report: enforcement lives in `TuistWeb.Authentication.require_sso_authentication/2` (account-level redirect), never in the login-page UI — so the form was visible but non-functional for enforced orgs. These levers give operators explicit control over the login surface.

## User/operator impact

Opt-in only. Default behavior is identical to today. Operators can now present an SSO-only (or any narrowed) login page via environment variables, documented under [self-host → Authentication](server/priv/docs/en/guides/server/self-host/server.md).

### How to test locally

- Start the server with `TUIST_EMAIL_AUTH_ENABLED=0` and open `/users/log_in`: the password form, **Sign up**, and **Forgot password?** are gone; `POST /users/log_in`, `/users/register`, `/users/reset_password`, and `POST /api/auth` (`tuist auth`) are all closed.
- Set `TUIST_GOOGLE_AUTH_ENABLED=0` (or Apple/GitHub) with the provider configured: the button disappears and the OAuth callback returns "not supported".
- Set `TUIST_OKTA_AUTH_ENABLED=0`: Okta disappears from the login/sign-up pages while any org that enforces Okta SSO still logs in.

Automated: `mix compile --warnings-as-errors`, `mix credo`, `mix format` all clean; touched test files pass (118 tests) covering UI hiding, the login `POST` + CLI 403 gates, the registration/forgot/reset redirects, and the Google/Apple callback rejections.

