### PR TITLE
fix(server): backfill command_events_by_name_ran_at one partition at a time (fixes #11790 prod OOM)

### DIFF
--- a/server/priv/ingest_repo/migrations/20260713120000_create_command_events_by_name_ran_at_mv.exs
+++ b/server/priv/ingest_repo/migrations/20260713120000_create_command_events_by_name_ran_at_mv.exs
@@ -14,8 +14,7 @@ defmodule Tuist.IngestRepo.Migrations.CreateCommandEventsByNameRanAtMv do
 
   With `name` in the sort key, `(project_id, name)` is a contiguous range and
   `ran_at` is ordered within it, so `ran_at DESC LIMIT N` reads ~one granule via
-  reverse read-in-order regardless of how sparse the command is. The same
-  production page reads ~75K rows / ~127 MiB (~209ms) against this layout.
+  reverse read-in-order regardless of how sparse the command is.
 
   The target table is intentionally NOT partitioned. `command_events` is
   partitioned by `toYYYYMM(ran_at)`, which fans a reverse read-in-order scan
@@ -26,71 +25,79 @@ defmodule Tuist.IngestRepo.Migrations.CreateCommandEventsByNameRanAtMv do
   `ran_at`-ordered queries (e.g. ModuleCacheLive recent runs, the `/runs` API
   without a name filter), which rely on read-in-order over `ran_at` directly.
 
-  No secondary indexes are defined. `command_events_by_ran_at` carries
-  minmax/bloom indexes (is_ci, user_id, cacheable_targets_count) because its
-  `(project_id, ran_at)` working set is a whole project (millions of rows). Here
-  `(project_id, name)` already isolates a small contiguous range, so the runs
-  list's secondary filters (`is_ci`/`user_id` via "ran by", status, branch, …)
-  are cheap to apply as plain predicates over it; skip indexes would add write
-  and storage cost for negligible pruning.
+  ## Gap-free, memory-bounded backfill (no POPULATE, one partition at a time)
 
-  ## Gap-free backfill (no POPULATE)
+  `POPULATE`/a single full-table `INSERT ... SELECT *` are both avoided. The
+  first misses rows inserted while it runs; the second copies all ~27M wide rows
+  (with the large `Array(String)` columns) in one statement, which exceeded the
+  shared ClickHouse memory ceiling under live load (`Code: 241
+  MEMORY_LIMIT_EXCEEDED`). Instead:
 
-  `POPULATE` is avoided on purpose: it snapshots existing rows at CREATE time but
-  does NOT capture rows inserted while it runs, and `command_events` is ingested
-  continuously. Those rows would stay in `command_events` yet be permanently
-  absent from every name-filtered list and count once reads route here. Instead:
-
-    1. Create the empty target table (`EMPTY AS SELECT *` copies the column types
-       from `command_events` without its data, indexes, or projections).
-    2. Create the materialized view with `TO` and no `POPULATE`. From this point
-       every insert into `command_events` is written to the target synchronously.
-    3. Backfill the history with an `id` anti-join. ClickHouse evaluates the
-       outer scan and the anti-join subquery against the set of parts present
-       when the INSERT starts, so:
-         - rows inserted before the view existed → scanned, not yet in the
-           target → inserted once;
-         - rows the view already captured (created between steps 2 and 3) → in
-           the target → excluded by the anti-join;
-         - rows inserted while the backfill runs → not in the scan snapshot, but
-           captured by the view → inserted once.
-       No row is dropped and none is duplicated.
+    1. Drop any leftovers from a previous failed attempt so we start from an
+       empty, consistent table.
+    2. Create the empty target (`EMPTY AS SELECT *` copies the column types only,
+       no data, indexes, or projections).
+    3. Create the materialized view with `TO` and no `POPULATE`. From here every
+       insert into `command_events` is written to the target synchronously.
+    4. Backfill one `toYYYYMM(ran_at)` partition at a time (single-threaded), so
+       each statement's memory is bounded by one month of data rather than the
+       whole table. The per-partition `id` anti-join excludes rows the view
+       already captured since creation, so no row is dropped or duplicated even
+       while ingestion continues.
   """
 
   use Ecto.Migration
+
+  alias Tuist.IngestRepo
+
+  require Logger
 
   @disable_ddl_transaction true
   @disable_migration_lock true
 
   def up do
-    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
-    execute """
+    IngestRepo.query!("DROP VIEW IF EXISTS command_events_by_name_ran_at_mv SYNC")
+    IngestRepo.query!("DROP TABLE IF EXISTS command_events_by_name_ran_at SYNC")
+
+    IngestRepo.query!("""
     CREATE TABLE IF NOT EXISTS command_events_by_name_ran_at
     ENGINE = MergeTree
     ORDER BY (project_id, name, ran_at)
     EMPTY AS SELECT * FROM command_events
-    """
+    """)
 
-    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
-    execute """
+    IngestRepo.query!("""
     CREATE MATERIALIZED VIEW IF NOT EXISTS command_events_by_name_ran_at_mv
     TO command_events_by_name_ran_at
     AS SELECT * FROM command_events
-    """
+    """)
 
-    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
-    execute """
-    INSERT INTO command_events_by_name_ran_at
-    SELECT * FROM command_events
-    WHERE id NOT IN (SELECT id FROM command_events_by_name_ran_at)
-    """
+    %{rows: partitions} =
+      IngestRepo.query!(
+        "SELECT DISTINCT toYYYYMM(ran_at) AS partition FROM command_events ORDER BY partition"
+      )
+
+    for [partition] <- partitions, is_integer(partition) do
+      Logger.info("Backfilling command_events_by_name_ran_at partition #{partition}")
+
+      IngestRepo.query!(
+        """
+        INSERT INTO command_events_by_name_ran_at
+        SELECT * FROM command_events
+        WHERE toYYYYMM(ran_at) = #{partition}
+          AND id NOT IN (
+            SELECT id FROM command_events_by_name_ran_at WHERE toYYYYMM(ran_at) = #{partition}
+          )
+        SETTINGS max_threads = 1, max_insert_threads = 1
+        """,
+        [],
+        timeout: :infinity
+      )
+    end
   end
 
   def down do
-    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
-    execute "DROP VIEW IF EXISTS command_events_by_name_ran_at_mv SYNC"
-
-    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
-    execute "DROP TABLE IF EXISTS command_events_by_name_ran_at SYNC"
+    IngestRepo.query!("DROP VIEW IF EXISTS command_events_by_name_ran_at_mv SYNC")
+    IngestRepo.query!("DROP TABLE IF EXISTS command_events_by_name_ran_at SYNC")
   end
 end


### PR DESCRIPTION
Follow-up to #11790, which **failed its production deploy** at the migration step.

### What went wrong

The backfill in `20260713120000_create_command_events_by_name_ran_at_mv` copied all ~27M rows of `command_events` (with the large `Array(String)` columns) in **one** `INSERT ... SELECT *`, which exceeded the shared ClickHouse server memory ceiling under live load:

```
** (Ch.Error) Code: 241. DB::Exception: (total) memory limit exceeded:
   would use 18.01 GiB ... maximum: 18.00 GiB (MEMORY_LIMIT_EXCEEDED)
```

A single-statement full-table copy is **not** memory-light at this width. The sibling MVs' `POPULATE` only worked because the table was far smaller when they were created.

Because ClickHouse DDL isn't transactional and helm `--atomic` only rolls back k8s resources (not ClickHouse objects), the failed run left an **orphaned** target table (partial rows) + a live materialized view in production, while the app rolled back to the old read path. **No user-facing impact** (the old `command_events_by_ran_at` path still serves), but the orphaned view write-amplifies until this ships.

### The fix — partition-by-partition backfill

Matches the team's documented convention (see the `test_case_branch_presence` MV: *"Backfill … partition by partition"*):

1. **`DROP` any leftover table + view first** — so redeploying this migration cleans up the orphaned objects and starts from an empty, consistent table (self-healing; no manual prod surgery).
2. `CREATE TABLE ... EMPTY AS` (empty target) + `CREATE MATERIALIZED VIEW ... TO ...` (no `POPULATE`) — live inserts captured from creation.
3. Backfill **one `toYYYYMM(ran_at)` partition per `INSERT`** with `max_threads = 1, max_insert_threads = 1`, so each statement's memory is bounded by one month of data instead of the whole table. A per-partition `id` anti-join excludes rows the view already captured, so the backfill neither drops nor duplicates rows.

Runs in-migration, so reads flip to the new table only after it's fully populated (no empty-table window). Drop-first makes retries clean.

### Validation (local ClickHouse)

- Migration runs end-to-end: target is `MergeTree ORDER BY (project_id, name, ran_at)` + `TO` view.
- Partition-wise scratch backfill (rows both pre-view and view-captured, across two months): exact parity — **dup=0, missing=0, extra=0**.
- Routing + `cache_runs`/`generate_runs` LiveView tests pass (16). `mix format` + `mix credo` clean.

### Deploy note

The routing code from #11790 is already on `main` and unchanged. On deploy, this migration drops the orphaned objects, rebuilds partition-by-partition, records the migration, and reads move to the fast path. Also: #11790's first prod run hit an **unrelated** transient canary blip (`Getting latest version number` → `JSON.parse("")`); a re-run cleared it.
