### PR TITLE
fix(server): filter cache/generate runs by name = (not IN) so read-in-order engages

### DIFF
--- a/server/lib/tuist_web/live/cache_runs_live.ex
+++ b/server/lib/tuist_web/live/cache_runs_live.ex
@@ -249,7 +249,7 @@ defmodule TuistWeb.CacheRunsLive do
   defp list_cache_runs(project_id, attrs) do
     flop_filters = [
       %{field: :project_id, op: :==, value: project_id},
-      %{field: :name, op: :in, value: ["cache"]}
+      %{field: :name, op: :==, value: "cache"}
       | build_flop_filters(Keyword.get(attrs, :filters, []))
     ]
 

--- a/server/lib/tuist_web/live/generate_runs_live.ex
+++ b/server/lib/tuist_web/live/generate_runs_live.ex
@@ -165,7 +165,7 @@ defmodule TuistWeb.GenerateRunsLive do
     options = %{
       filters: [
         %{field: :project_id, op: :==, value: project_id},
-        %{field: :name, op: :in, value: ["generate"]}
+        %{field: :name, op: :==, value: "generate"}
         | build_flop_filters(Keyword.get(attrs, :filters, []))
       ],
       order_by: [Keyword.get(attrs, :order_by, :ran_at)],


### PR DESCRIPTION
Final piece of the `command_events_by_name_ran_at` work (#11790 / #11811). The new table + backfill are live in prod, but the runs-list queries were **still slow** — this fixes that.

### Root cause

The cache/generate runs lists route to `command_events_by_name_ran_at`, sorted `(project_id, name, ran_at)`, so a `ran_at DESC LIMIT N` page should read ~one granule via reverse read-in-order. But the two LiveViews passed the name filter as `op: :in, value: ["cache"]`, which Ecto renders as **`name IN ('cache')`**.

ClickHouse does **not** apply read-in-order for `name IN (...)` on a sort-key prefix — **even a single-element `IN`** — so the query reads the entire `(project_id, name)` range and sorts it. (This is exactly what the original `20260302` migration warned about.) I benched the sort-key change with `name = 'x'` and wrongly assumed the app emitted the same; it emits `IN`, so in production the new table delivered no speedup.

### Fix

Switch the two LiveViews to `op: :==, value: "cache"` → renders `name = 'cache'`, which engages read-in-order. Measured on the **production** table (project 2289, `ORDER BY ran_at DESC LIMIT 21`):

| filter | rows read | bytes | time |
|---|---|---|---|
| `name IN ('generate')` | 1,316,982 | 54 MiB (wide ~20 GiB) | 31ms (wide 10–12s) |
| `name = 'generate'` | **32,241** | **1.30 MiB** | **10ms** |

vs. the original slow path (16M rows / 12 GiB / p90 7.6s), the fully-fixed page reads ~32K rows in ~10ms.

The MCP tools (`list_cache_runs`, `list_generations`) and the `/runs` API already use `op: :==`; only these two LiveViews used `IN`.

### Validation

`cache_runs_live` + `generate_runs_live` tests pass (15). Read-in-order confirmed against prod with the faithful cast form `name = _CAST('generate','String')` (32,241 rows / 10ms).
