### PR TITLE
ci(cli): publish the Homebrew formula for backport releases

### DIFF
--- a/.github/workflows/cli-backport.yml
+++ b/.github/workflows/cli-backport.yml
@@ -171,7 +171,12 @@ jobs:
       # and tags the identical commit, with no branch-advance race.
       ref: ${{ needs.prepare.outputs.sha }}
       changelog_from: ${{ needs.prepare.outputs.changelog_from }}
-      # Backports never move GitHub's "Latest" pointer or the Homebrew formula.
+      # Backports never move GitHub's "Latest" pointer, but they DO publish the
+      # per-version Homebrew formula (tuist@X.Y.Z) so a Homebrew-managed team
+      # pinned to the line can install the patch. This is safe: the
+      # homebrew-tuist aliases task is semver-aware, so it only advances the
+      # tuist@X.Y line alias and never repoints bare `tuist` — brew install tuist
+      # stays on the highest overall stable version regardless of publish order.
       make_latest: false
-      update_homebrew: false
+      update_homebrew: true
     secrets: inherit

--- a/.github/workflows/cli-build-publish.yml
+++ b/.github/workflows/cli-build-publish.yml
@@ -276,8 +276,10 @@ jobs:
             build/ProjectDescription.xcframework.zip
             build/tuist.spec.json
       - name: Trigger Homebrew Formula Update
-        # Skipped for backports: brew install tuist must keep pointing at the
-        # true latest version, never an older patched line.
+        # Skipped only for canary/RC prereleases (update_homebrew=false). Stable
+        # releases and backports both publish the per-version formula; the
+        # homebrew-tuist aliases task is semver-aware, so brew install tuist
+        # always resolves to the highest stable version regardless of order.
         if: ${{ inputs.update_homebrew }}
         run: |
           SHA256=$(cat build/SHASUMS256.txt | grep tuist.zip | awk '{print $1}')


### PR DESCRIPTION
## What

Makes CLI **backport** releases publish their Homebrew formula, by flipping `update_homebrew: false → true` in `cli-backport.yml`. Also refreshes a now-stale rationale comment in `cli-build-publish.yml`.

## Why

Backports skipped Homebrew entirely, so a Homebrew-managed team pinned to an older line got the GitHub release but **no installable formula**. That just bit us on `4.193.5`: the release published fine, but the customer (managing via Homebrew) couldn't `brew install` it until I dispatched the `homebrew-tuist` release manually after the fact. This makes it automatic.

## Why it's safe (the original concern doesn't hold)

The old comment claimed backports must skip Homebrew so `brew install tuist` "keeps pointing at the true latest version." That's not actually a risk. `tuist/homebrew-tuist` uses per-version formulae (`Formula/tuist@X.Y.Z.rb`) plus a **semver-aware** aliases task (`.mise/tasks/aliases`, `Semantic::Version`) that rebuilds:

- `Aliases/tuist` → highest version **overall**
- `Aliases/tuist@X` → highest on that major
- `Aliases/tuist@X.Y` → highest on that line

So publishing a backport formula only advances the `tuist@X.Y` **line** alias and can never repoint bare `tuist` (a higher minor always wins). `make_latest` stays `false` — a backport still must not grab GitHub's "Latest" badge, which is a separate surface from Homebrew resolution.

This is already the de-facto convention: the `4.192.x` backport line has per-version formulae in the tap.

## Scope of the change

| Workflow | Channel | `update_homebrew` | Change |
|---|---|---|---|
| `cli-release.yml` | canary | `false` | unchanged (prerelease, must skip) |
| `cli-rc.yml` | RC | `false` | unchanged (prerelease, must skip) |
| `cli-promote.yml` | stable | `true` | **already publishes** — no change |
| `cli-backport.yml` | backport | `false → true` | **this PR** |

So "stable releases too" was already covered; only backports needed the flip.

## Caveat for existing release branches

Backports are dispatched with `--ref releases/X.Y.x`, which runs that branch's **own** copy of these workflows. Branches cut from `main` **after** this merges pick the change up automatically. Already-existing lines (`releases/4.193.x`, `releases/4.201.x`, `releases/4.202.x`) still carry the old `update_homebrew=false`, so a backport dispatched from one of those won't publish the formula until this change is also merged onto that branch. Happy to open those follow-up PRs if you want them covered now; otherwise they can be handled the same manual way `4.193.5` was.

## Validation

- Diff is two workflow edits (one functional line + comments); no logic beyond the input flag.
- Confirmed against the live `homebrew-tuist` `aliases` task that bare `tuist` is computed as highest-semver, and verified end-to-end on `4.193.5` today: adding `tuist@4.193.5.rb` moved only `tuist@4.193` (→ 4.193.5) while `tuist` and `tuist@4` stayed at `4.202.0`.
