### PR TITLE
perf(kura,cli): compress the snapshot, coalesce demand fetches, and serve stale during rebuilds

### DIFF
--- a/cas-plugin/src/proxy.rs
+++ b/cas-plugin/src/proxy.rs
@@ -51,6 +51,17 @@ const SNAPSHOT_DELTA_INTERVAL: Duration = Duration::from_secs(120);
 const SNAPSHOT_FETCH_WAIT: Duration = Duration::from_secs(20);
 const SNAPSHOT_FULL_INTERVAL: Duration = Duration::from_secs(30 * 60);
 const SNAPSHOT_RETRY_INTERVAL: Duration = Duration::from_secs(60 * 60);
+// Ceiling on a compressed snapshot's declared uncompressed size, so a torn or
+// hostile length prefix cannot drive an unbounded allocation. Comfortably
+// above the server's content budget (144 MiB); a legitimate body never
+// approaches it.
+const SNAPSHOT_DECOMPRESS_MAX_BYTES: usize = 512 << 20;
+// A leader that finds itself alone lingers this long before firing, giving a
+// near-simultaneous straggler time to join its batch. Once batches flow the
+// followers accumulating during each round trip carry the coalescing, so this
+// only pays out at the very start and end of a demand burst; kept far below a
+// WAN round trip so a lone fetch is barely delayed.
+const DEMAND_BATCH_LINGER: Duration = Duration::from_millis(3);
 // Failed fetches retry much sooner than definitive not-found: the server
 // answers UNAVAILABLE while it builds a large namespace's snapshot index,
 // and timeouts/transport errors are transient by the same token.
@@ -321,11 +332,33 @@ enum SnapshotState {
 }
 
 impl Snapshot {
-    /// Decodes the server's snapshot wire format: `"TSNP"` + version byte,
-    /// u64 write-time watermark, node table, per-key node-index lists. `None`
-    /// on any structural violation — the caller stays on the per-key path
-    /// rather than trusting a torn payload.
+    /// Decodes the server's snapshot response. A `"TSNZ"` envelope (magic,
+    /// version byte, u64 uncompressed length, zstd stream) is decompressed
+    /// into a `"TSNP"` body first; a bare `"TSNP"` body (an old server, or one
+    /// answering a client that did not request zstd) is decoded directly. Any
+    /// structural violation returns `None` and the caller stays on the per-key
+    /// path rather than trusting a torn payload.
     fn decode(bytes: &[u8]) -> Option<Snapshot> {
+        if bytes.len() >= 13 && &bytes[..4] == b"TSNZ" {
+            if bytes[4] != 1 {
+                return None;
+            }
+            let declared = u64::from_le_bytes(bytes[5..13].try_into().ok()?) as usize;
+            if declared > SNAPSHOT_DECOMPRESS_MAX_BYTES {
+                return None;
+            }
+            let body = zstd::stream::decode_all(&bytes[13..]).ok()?;
+            if body.len() != declared {
+                return None;
+            }
+            return Self::decode_body(&body);
+        }
+        Self::decode_body(bytes)
+    }
+
+    /// Decodes a bare `"TSNP"` body: `"TSNP"` + version byte, u64 write-time
+    /// watermark, node table, per-key node-index lists.
+    fn decode_body(bytes: &[u8]) -> Option<Snapshot> {
         fn take<'a>(bytes: &mut &'a [u8], n: usize) -> Option<&'a [u8]> {
             if bytes.len() < n {
                 return None;
@@ -506,6 +539,121 @@ unsafe impl Sync for PathState {}
 /// manifest to re-publish.
 type ViewRefresh = (Arc<Remote>, Vec<u8>, Vec<ManifestEntry>);
 
+/// Result of a coalesced demand fetch, taken by exactly one waiter.
+enum DemandResult {
+    Present(Vec<u8>),
+    Missing,
+    Failed(String),
+}
+
+/// Coalesces concurrent single-object demand fetches (OP_FETCH_OBJECT, one per
+/// compiler worker that outran the materializer) into shared `BatchReadBlobs`
+/// calls. A demand build fetched ~7000 objects one round trip each over the
+/// WAN; the RTT, not bandwidth, dominated that time. Compiler workers issue
+/// their misses in parallel, so a leader drains everything pending into one
+/// batch while followers accumulate during its round trip — the batch size
+/// self-clocks to the worker concurrency with no fixed wait.
+#[derive(Default)]
+struct DemandBatch {
+    /// Digests waiting to be fetched, deduped by hash.
+    pending: HashMap<String, reapi::Digest>,
+    /// Fetched results keyed by hash; each removed by the waiter that wanted it.
+    results: HashMap<String, DemandResult>,
+    /// Whether a leader is currently draining/fetching.
+    leader_active: bool,
+}
+
+struct DemandCoalescer {
+    batch: Mutex<DemandBatch>,
+    ready: Condvar,
+}
+
+impl DemandCoalescer {
+    fn new() -> DemandCoalescer {
+        DemandCoalescer {
+            batch: Mutex::new(DemandBatch::default()),
+            ready: Condvar::new(),
+        }
+    }
+
+    /// Fetches one blob, coalescing with concurrent callers into shared batch
+    /// reads. `fetch_batch` performs the actual multi-blob read; only the
+    /// leader of each batch invokes it, and every caller passes the same
+    /// closure (a read against the shared remote), so which thread leads does
+    /// not matter. Blocking here is free: the caller is a compiler worker
+    /// thread that a demand load already parks on network I/O.
+    ///
+    /// Each result is a one-shot mailbox consumed by the first thread to read
+    /// it, so two threads demanding the SAME digest concurrently may each
+    /// fetch it — a rare redundant read, never a wrong or dropped result.
+    fn fetch<F>(&self, digest: &reapi::Digest, fetch_batch: F) -> Result<Option<Vec<u8>>, String>
+    where
+        F: Fn(&[reapi::Digest]) -> Result<HashMap<String, Vec<u8>>, String>,
+    {
+        let hash = digest.hash.clone();
+        let mut batch = self.batch.lock().unwrap();
+        loop {
+            if let Some(result) = batch.results.remove(&hash) {
+                // Drop any pending entry we (or a same-hash sibling) registered
+                // but that another leader's fetch already satisfied — otherwise
+                // it lingers and a later batch re-fetches it, leaking its result.
+                batch.pending.remove(&hash);
+                return match result {
+                    DemandResult::Present(bytes) => Ok(Some(bytes)),
+                    DemandResult::Missing => Ok(None),
+                    DemandResult::Failed(message) => Err(message),
+                };
+            }
+            batch.pending.insert(hash.clone(), digest.clone());
+            if batch.leader_active {
+                // A leader is draining/fetching; wait for it to fill results.
+                batch = self.ready.wait(batch).unwrap();
+                continue;
+            }
+            // Lead this batch. If alone, linger briefly so a near-simultaneous
+            // straggler can join; once batches flow the accumulation during the
+            // previous round trip means we are rarely alone.
+            batch.leader_active = true;
+            if batch.pending.len() == 1 {
+                drop(batch);
+                std::thread::sleep(DEMAND_BATCH_LINGER);
+                batch = self.batch.lock().unwrap();
+            }
+            let digests: Vec<reapi::Digest> = batch.pending.values().cloned().collect();
+            let hashes: Vec<String> = batch.pending.keys().cloned().collect();
+            batch.pending.clear();
+            drop(batch);
+
+            // Network round trip outside the lock so followers keep queueing.
+            let fetched = fetch_batch(&digests);
+
+            batch = self.batch.lock().unwrap();
+            match fetched {
+                Ok(mut map) => {
+                    for hash in hashes {
+                        let result = match map.remove(&hash) {
+                            Some(bytes) => DemandResult::Present(bytes),
+                            None => DemandResult::Missing,
+                        };
+                        batch.results.insert(hash, result);
+                    }
+                }
+                Err(message) => {
+                    for hash in hashes {
+                        batch
+                            .results
+                            .insert(hash, DemandResult::Failed(message.clone()));
+                    }
+                }
+            }
+            batch.leader_active = false;
+            self.ready.notify_all();
+            // Loop: our own hash is now in results (or a follower took it and
+            // we re-enqueue for the next batch — correct either way).
+        }
+    }
+}
+
 pub struct Proxy {
     grpc_url: String,
     tokens: Arc<TokenProvider>,
@@ -562,6 +710,10 @@ pub struct Proxy {
     view_refresh: Mutex<VecDeque<ViewRefresh>>,
     view_refreshed: Mutex<HashSet<Vec<u8>>>,
 
+    // instance -> demand-fetch coalescer, created on first demand miss. Groups
+    // concurrent OP_FETCH_OBJECT blob reads into shared BatchReadBlobs calls.
+    demand_coalescers: Mutex<HashMap<String, Arc<DemandCoalescer>>>,
+
     // Per-node transfer analytics, written to cas_analytics.db for parity with
     // the Swift `CASAnalyticsDatabase`. `None` when no analytics path was configured.
     analytics: Option<crate::analytics::Analytics>,
@@ -597,6 +749,7 @@ impl Proxy {
             unprimed: AtomicU64::new(0),
             view_refresh: Mutex::new(VecDeque::new()),
             view_refreshed: Mutex::new(HashSet::new()),
+            demand_coalescers: Mutex::new(HashMap::new()),
             analytics,
         }));
         let proxy_addr = proxy as *const Proxy as usize;
@@ -1133,6 +1286,27 @@ impl Proxy {
         }
     }
 
+    /// The demand-fetch coalescer for an instance, created on first use.
+    fn coalescer_for(&self, instance: &str) -> Arc<DemandCoalescer> {
+        let mut coalescers = self.demand_coalescers.lock().unwrap();
+        coalescers
+            .entry(instance.to_string())
+            .or_insert_with(|| Arc::new(DemandCoalescer::new()))
+            .clone()
+    }
+
+    /// Fetches one blob for a demand load, coalescing with other demand fetches
+    /// in flight for the same instance into a shared `BatchReadBlobs`.
+    fn demand_fetch(
+        &self,
+        instance: &str,
+        remote: &Arc<Remote>,
+        digest: &reapi::Digest,
+    ) -> Result<Option<Vec<u8>>, String> {
+        self.coalescer_for(instance)
+            .fetch(digest, |digests| remote.batch_read(digests))
+    }
+
     /// Serves one FETCH_OBJECT: a demand load found `digest` missing from the
     /// local CAS. Present now (the materializer won the race) answers
     /// immediately; a registered pending fetch is executed inline (this runs
@@ -1185,9 +1359,8 @@ impl Proxy {
                     return Ok(false);
                 };
                 let remote = self.remote_for(&instance);
-                let contents = remote.batch_read(&[blob.clone()])?;
-                match contents.get(&blob.hash) {
-                    Some(bytes) => bytes.clone(),
+                match self.demand_fetch(&instance, &remote, &blob)? {
+                    Some(bytes) => bytes,
                     None => return Ok(false),
                 }
             }
@@ -2318,6 +2491,125 @@ mod tests {
         // and merged delta keys — the newest — move to the front of it.
         assert_eq!(snapshot.key_order, vec![[5u8; 32]]);
         assert_eq!(merged.key_order, vec![[9u8; 32], [5u8; 32]]);
+    }
+
+    #[test]
+    fn snapshot_decodes_the_compressed_envelope() {
+        // A minimal valid TSNP body: one node, one key referencing it.
+        let mut body = Vec::new();
+        body.extend_from_slice(b"TSNP");
+        body.push(2);
+        body.extend_from_slice(&555u64.to_le_bytes());
+        body.extend_from_slice(&1u32.to_le_bytes());
+        body.push(1);
+        body.push(0xAB);
+        body.extend_from_slice(&[7u8; 32]);
+        body.extend_from_slice(&10u64.to_le_bytes());
+        body.extend_from_slice(&1u32.to_le_bytes());
+        body.extend_from_slice(&[5u8; 32]);
+        body.extend_from_slice(&1u32.to_le_bytes());
+        body.extend_from_slice(&0u32.to_le_bytes());
+
+        // Wrap it in the TSNZ envelope the way kura does and confirm the client
+        // decodes the compressed and plain forms identically.
+        let compressed = zstd::stream::encode_all(&body[..], 3).unwrap();
+        let mut wire = Vec::new();
+        wire.extend_from_slice(b"TSNZ");
+        wire.push(1);
+        wire.extend_from_slice(&(body.len() as u64).to_le_bytes());
+        wire.extend_from_slice(&compressed);
+
+        let from_zstd = Snapshot::decode(&wire).expect("compressed decodes");
+        let from_plain = Snapshot::decode(&body).expect("plain decodes");
+        assert_eq!(from_zstd.watermark, 555);
+        assert_eq!(from_zstd.watermark, from_plain.watermark);
+        assert_eq!(from_zstd.nodes.len(), from_plain.nodes.len());
+        assert!(from_zstd.manifest(&[5u8; 32]).is_some());
+
+        // A declared length that disagrees with the real body is a torn
+        // payload: refuse rather than serve a half-decoded view.
+        let mut wrong_len = wire.clone();
+        wrong_len[5..13].copy_from_slice(&(body.len() as u64 + 1).to_le_bytes());
+        assert!(Snapshot::decode(&wrong_len).is_none());
+
+        // An absurd declared length must be rejected before allocating.
+        let mut huge = wire.clone();
+        huge[5..13].copy_from_slice(&(u64::MAX).to_le_bytes());
+        assert!(Snapshot::decode(&huge).is_none());
+    }
+
+    #[test]
+    fn demand_coalescer_routes_concurrent_fetches_correctly() {
+        use std::sync::atomic::AtomicUsize;
+
+        let coalescer = Arc::new(DemandCoalescer::new());
+        // Sums digests.len() over every batch call: with each hash fetched at
+        // most once, coalescing can only lower the CALL count, never change
+        // this sum — so a total above the worker count would mean a hash was
+        // fetched twice, and below it would mean one was dropped.
+        let fetched_total = Arc::new(AtomicUsize::new(0));
+
+        let digest = |n: u8| reapi::Digest {
+            hash: reapi::hex(&[n; 32]),
+            size_bytes: 3,
+        };
+
+        let mut handles = Vec::new();
+        for n in 0..8u8 {
+            let coalescer = coalescer.clone();
+            let fetched_total = fetched_total.clone();
+            handles.push(std::thread::spawn(move || {
+                coalescer
+                    .fetch(&digest(n), |digests| {
+                        fetched_total.fetch_add(digests.len(), Ordering::SeqCst);
+                        Ok(digests
+                            .iter()
+                            .map(|d| (d.hash.clone(), d.hash.clone().into_bytes()))
+                            .collect())
+                    })
+                    .expect("fetch succeeds")
+                    .expect("blob present")
+            }));
+        }
+        for (n, handle) in handles.into_iter().enumerate() {
+            let bytes = handle.join().unwrap();
+            assert_eq!(
+                bytes,
+                digest(n as u8).hash.into_bytes(),
+                "each worker gets its own blob"
+            );
+        }
+        assert_eq!(
+            fetched_total.load(Ordering::SeqCst),
+            8,
+            "every hash fetched exactly once across all batches"
+        );
+    }
+
+    #[test]
+    fn demand_coalescer_reports_missing_and_failure_per_waiter() {
+        let coalescer = DemandCoalescer::new();
+        let present = reapi::Digest {
+            hash: reapi::hex(&[1; 32]),
+            size_bytes: 3,
+        };
+        // A hash the batch read does not return is a miss (Ok(None)).
+        let missing = coalescer
+            .fetch(&present, |_| Ok(HashMap::new()))
+            .expect("no transport error");
+        assert!(missing.is_none(), "absent blob is a miss");
+
+        // A present hash returns its bytes.
+        let hit = coalescer
+            .fetch(&present, |d| {
+                Ok(d.iter().map(|d| (d.hash.clone(), vec![0xAB])).collect())
+            })
+            .expect("no transport error");
+        assert_eq!(hit, Some(vec![0xAB]));
+
+        // A transport error surfaces to the caller.
+        let err = coalescer.fetch(&present, |_| Err("boom".to_string()));
+        assert_eq!(err.unwrap_err(), "boom");
     }
 
     fn resolved_with(entries: Vec<(Vec<u8>, Resolution)>) -> Mutex<HashMap<Vec<u8>, Resolution>> {

--- a/cas-plugin/src/proxy.rs
+++ b/cas-plugin/src/proxy.rs
@@ -333,11 +333,12 @@ enum SnapshotState {
 
 impl Snapshot {
     /// Decodes the server's snapshot response. A `"TSNZ"` envelope (magic,
-    /// version byte, u64 uncompressed length, zstd stream) is decompressed
-    /// into a `"TSNP"` body first; a bare `"TSNP"` body (an old server, or one
-    /// answering a client that did not request zstd) is decoded directly. Any
-    /// structural violation returns `None` and the caller stays on the per-key
-    /// path rather than trusting a torn payload.
+    /// version byte, u64 uncompressed length, zstd stream) — what current kura
+    /// always emits — is decompressed into a `"TSNP"` body first; a bare
+    /// `"TSNP"` body, which only an OLD kura pod emits (mid mesh-roll, or a
+    /// lagging self-hosted node), is decoded directly. Any structural violation
+    /// returns `None` and the caller stays on the per-key path rather than
+    /// trusting a torn payload.
     fn decode(bytes: &[u8]) -> Option<Snapshot> {
         if bytes.len() >= 13 && &bytes[..4] == b"TSNZ" {
             if bytes[4] != 1 {

--- a/cas-plugin/src/proxy.rs
+++ b/cas-plugin/src/proxy.rs
@@ -348,7 +348,20 @@ impl Snapshot {
             if declared > SNAPSHOT_DECOMPRESS_MAX_BYTES {
                 return None;
             }
-            let body = zstd::stream::decode_all(&bytes[13..]).ok()?;
+            // Decode the stream through a reader capped at `declared + 1` bytes,
+            // so a payload whose stream expands PAST its declared length (a zip
+            // bomb, or a corrupt frame) is rejected after one extra byte rather
+            // than allocating unboundedly. `decode_all` expands the whole stream
+            // into a Vec first — the length check below never gets to run. The
+            // cap is `declared + 1 <= SNAPSHOT_DECOMPRESS_MAX_BYTES + 1`, so the
+            // allocation is bounded regardless of what the stream claims.
+            use std::io::Read as _;
+            let mut decoder = zstd::stream::read::Decoder::new(&bytes[13..]).ok()?;
+            let mut body = Vec::new();
+            decoder
+                .take(declared as u64 + 1)
+                .read_to_end(&mut body)
+                .ok()?;
             if body.len() != declared {
                 return None;
             }
@@ -2537,6 +2550,19 @@ mod tests {
         let mut huge = wire.clone();
         huge[5..13].copy_from_slice(&(u64::MAX).to_le_bytes());
         assert!(Snapshot::decode(&huge).is_none());
+
+        // Zip bomb: a stream that expands far past a small declared length must
+        // be rejected — and the bounded decode stops one byte past `declared`
+        // rather than expanding the whole stream. The stream here inflates to
+        // 100 KiB while the envelope claims 8 bytes.
+        let bomb_body = vec![0u8; 100 * 1024];
+        let bomb_stream = zstd::stream::encode_all(&bomb_body[..], 3).unwrap();
+        let mut bomb = Vec::new();
+        bomb.extend_from_slice(b"TSNZ");
+        bomb.push(1);
+        bomb.extend_from_slice(&8u64.to_le_bytes());
+        bomb.extend_from_slice(&bomb_stream);
+        assert!(Snapshot::decode(&bomb).is_none());
     }
 
     #[test]

--- a/cas-plugin/src/reapi.rs
+++ b/cas-plugin/src/reapi.rs
@@ -188,11 +188,6 @@ pub const SNAPSHOT_ACTION_KEY: &[u8] = b"tuist-actioncache-snapshot/v2";
 /// only entries written after it (a delta), so a long-lived proxy refreshes
 /// without refetching the world.
 const SNAPSHOT_AFTER_HINT: &str = "tuist-snapshot-after:";
-/// `inline_output_files` hint advertising that we accept the zstd-compressed
-/// (`TSNZ`) snapshot body. Always sent — this client always supports it. An
-/// old server ignores the unknown hint and answers plain `TSNP`, which decode
-/// still reads, so sending it unconditionally is rollout-safe.
-const SNAPSHOT_ZSTD_HINT: &str = "tuist-snapshot-zstd:1";
 
 pub fn blob_digest(content: &[u8]) -> reapi::Digest {
     reapi::Digest {
@@ -455,7 +450,7 @@ impl Remote {
     /// `after` asks for a delta: only entries written after that watermark.
     pub fn get_snapshot(&self, after: Option<u64>) -> Result<Option<Vec<u8>>, String> {
         let mut client = self.ac_client()?;
-        let mut inline_output_files = vec!["*".to_string(), SNAPSHOT_ZSTD_HINT.to_string()];
+        let mut inline_output_files = vec!["*".to_string()];
         if let Some(after) = after {
             inline_output_files.push(format!("{SNAPSHOT_AFTER_HINT}{after}"));
         }

--- a/cas-plugin/src/reapi.rs
+++ b/cas-plugin/src/reapi.rs
@@ -19,11 +19,11 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, OnceLock};
 use std::time::{Duration, Instant};
 
+pub use bazel_remote_apis::build::bazel::remote::execution::v2::Digest;
 use bazel_remote_apis::build::bazel::remote::execution::v2::{
     self as reapi, action_cache_client::ActionCacheClient, batch_update_blobs_request,
     content_addressable_storage_client::ContentAddressableStorageClient,
 };
-pub use bazel_remote_apis::build::bazel::remote::execution::v2::Digest;
 use sha2::{Digest as _, Sha256};
 use tonic::transport::{Channel, ClientTlsConfig, Endpoint};
 
@@ -188,6 +188,11 @@ pub const SNAPSHOT_ACTION_KEY: &[u8] = b"tuist-actioncache-snapshot/v2";
 /// only entries written after it (a delta), so a long-lived proxy refreshes
 /// without refetching the world.
 const SNAPSHOT_AFTER_HINT: &str = "tuist-snapshot-after:";
+/// `inline_output_files` hint advertising that we accept the zstd-compressed
+/// (`TSNZ`) snapshot body. Always sent — this client always supports it. An
+/// old server ignores the unknown hint and answers plain `TSNP`, which decode
+/// still reads, so sending it unconditionally is rollout-safe.
+const SNAPSHOT_ZSTD_HINT: &str = "tuist-snapshot-zstd:1";
 
 pub fn blob_digest(content: &[u8]) -> reapi::Digest {
     reapi::Digest {
@@ -277,7 +282,9 @@ type AuthValue = tonic::metadata::MetadataValue<tonic::metadata::Ascii>;
 fn authed_request<T>(message: T, auth: Option<&AuthValue>) -> tonic::Request<T> {
     let mut request = tonic::Request::new(message);
     if let Some(value) = auth {
-        request.metadata_mut().insert("authorization", value.clone());
+        request
+            .metadata_mut()
+            .insert("authorization", value.clone());
     }
     request
 }
@@ -425,8 +432,7 @@ impl Remote {
                         .filter_map(|file| {
                             Some(ManifestEntry {
                                 llcas_digest: unhex(&file.path)?,
-                                contents: (!file.contents.is_empty())
-                                    .then_some(file.contents),
+                                contents: (!file.contents.is_empty()).then_some(file.contents),
                                 blob: file.digest?,
                             })
                         })
@@ -449,7 +455,7 @@ impl Remote {
     /// `after` asks for a delta: only entries written after that watermark.
     pub fn get_snapshot(&self, after: Option<u64>) -> Result<Option<Vec<u8>>, String> {
         let mut client = self.ac_client()?;
-        let mut inline_output_files = vec!["*".to_string()];
+        let mut inline_output_files = vec!["*".to_string(), SNAPSHOT_ZSTD_HINT.to_string()];
         if let Some(after) = after {
             inline_output_files.push(format!("{SNAPSHOT_AFTER_HINT}{after}"));
         }

--- a/kura/Cargo.lock
+++ b/kura/Cargo.lock
@@ -1407,6 +1407,7 @@ dependencies = [
  "tracing-opentelemetry",
  "tracing-subscriber",
  "uuid",
+ "zstd",
 ]
 
 [[package]]
@@ -4281,3 +4282,31 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/kura/Cargo.toml
+++ b/kura/Cargo.toml
@@ -50,6 +50,7 @@ tracing = "0.1.41"
 tracing-opentelemetry = "0.32.1"
 tracing-subscriber = { version = "0.3.20", features = ["env-filter", "fmt", "json"] }
 uuid = { version = "1.18.1", features = ["serde", "v7"] }
+zstd = "0.13"
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 tikv-jemallocator = "0.6.0"

--- a/kura/src/reapi/mod.rs
+++ b/kura/src/reapi/mod.rs
@@ -515,7 +515,6 @@ impl ReapiService {
         &self,
         namespace_id: &str,
         after: u64,
-        compress: bool,
     ) -> Result<Vec<u8>, Status> {
         // Serve the cached index immediately, kicking the reconcile in the
         // background once the view is older than the freshness window: a
@@ -534,7 +533,7 @@ impl ReapiService {
             if let Some(index) = indexes.get_mut(namespace_id) {
                 let stale = index.reconciled_at.elapsed() >= SNAPSHOT_RECONCILE_INTERVAL;
                 index.last_used = Instant::now();
-                let bytes = index.encode(after, compress);
+                let bytes = index.encode(after);
                 drop(indexes);
                 if stale {
                     let _build = self.ensure_index_build(namespace_id);
@@ -572,7 +571,7 @@ impl ReapiService {
             return Err(Status::internal("snapshot index missing after build"));
         };
         index.last_used = Instant::now();
-        Ok(index.encode(after, compress))
+        Ok(index.encode(after))
     }
 
     /// The namespace's in-flight index build, starting one when none is
@@ -1005,14 +1004,7 @@ impl ActionCache for ReapiService {
                 .iter()
                 .find_map(|hint| hint.strip_prefix(SNAPSHOT_AFTER_HINT)?.parse::<u64>().ok())
                 .unwrap_or(0);
-            let compress = request
-                .get_ref()
-                .inline_output_files
-                .iter()
-                .any(|hint| hint == SNAPSHOT_ZSTD_HINT);
-            let snapshot = self
-                .serve_actioncache_snapshot(namespace_id, after, compress)
-                .await?;
+            let snapshot = self.serve_actioncache_snapshot(namespace_id, after).await?;
             let served = snapshot.len() as u64;
             let action_result = reapi::ActionResult {
                 output_files: vec![reapi::OutputFile {
@@ -1953,34 +1945,31 @@ fn validate_digest_bytes(digest: &reapi::Digest, bytes: &[u8]) -> Result<(), Str
 /// the write-time watermark header and delta responses).
 pub const SNAPSHOT_ACTION_KEY: &[u8] = b"tuist-actioncache-snapshot/v2";
 const SNAPSHOT_OUTPUT_PATH: &str = "tuist-actioncache-snapshot";
-/// Hard ceiling on the UNCOMPRESSED encoded snapshot served to clients that
-/// do not request compression, with headroom under the 64MB message limit
-/// REAPI clients configure. Entries are encoded newest-first, so the ceiling
-/// sheds the OLDEST keys — the snapshot degrades into a recency window;
-/// dropped keys resolve through the per-key path. It is also the floor the
-/// compressed path's inclusion budget converges to (a body this size is
-/// guaranteed to compress under the wire ceiling), so shrink retries always
-/// terminate at a safe view.
-const SNAPSHOT_MAX_BYTES: usize = 48 << 20;
+/// The floor the compressed path's inclusion budget converges to. A body this
+/// size is guaranteed to compress under the wire ceiling, so the shrink
+/// retries always terminate at a safe view. Also the size below which no
+/// benefit is left on the table: the recency window shed the oldest keys.
+const SNAPSHOT_MIN_BUDGET_BYTES: usize = 48 << 20;
 
-/// Ceiling on the COMPRESSED wire size for clients that request zstd. Same
-/// transfer budget as the uncompressed ceiling, but it now carries several
-/// times the content — a shared namespace's snapshot rides the recency
-/// window down to a small suffix of oldest keys, and those sheds were the
-/// per-key ladder that made the snapshot net-negative over the WAN.
+/// Ceiling on the COMPRESSED wire size, with headroom under the 64MB message
+/// limit REAPI clients configure. Same transfer budget as the pre-compression
+/// snapshot, but it now carries several times the content — a shared
+/// namespace's snapshot rides the recency window down to a small suffix of
+/// oldest keys, and those sheds were the per-key ladder that made the snapshot
+/// net-negative over the WAN. Entries are encoded newest-first, so what sheds
+/// is the oldest; dropped keys resolve through the per-key path.
 const SNAPSHOT_WIRE_MAX_BYTES: usize = 48 << 20;
 
-/// How much UNCOMPRESSED body the compressed path includes before it stops
-/// adding keys. Sized so the zstd output of a full body lands near the wire
-/// ceiling for this data's typical ratio; a body that compresses worse is
-/// re-encoded smaller (see `encode`). Also bounded in practice by the index's
-/// own entry cap.
+/// How much UNCOMPRESSED body to include before it stops adding keys. Sized so
+/// the zstd output of a full body lands near the wire ceiling for this data's
+/// typical ratio; a body that compresses worse is re-encoded smaller (see
+/// `encode`). Also bounded in practice by the index's own entry cap.
 const SNAPSHOT_CONTENT_BUDGET_BYTES: usize = 144 << 20;
 
 /// Bounded shrink retries when a compressed body overshoots the wire ceiling.
 /// Each retry scales the content budget down from the observed ratio and can
-/// only fall to `SNAPSHOT_MAX_BYTES` (a provably-safe view), so this bounds
-/// the encode work, not the correctness.
+/// only fall to `SNAPSHOT_MIN_BUDGET_BYTES` (a provably-safe view), so this
+/// bounds the encode work, not the correctness.
 const SNAPSHOT_COMPRESS_MAX_ATTEMPTS: usize = 3;
 
 /// zstd level for the snapshot body. Level 3 runs at hundreds of MB/s and
@@ -1991,20 +1980,13 @@ const SNAPSHOT_ZSTD_LEVEL: i32 = 3;
 /// when present, the response includes only entries written after it (a
 /// delta), letting a long-lived client refresh without refetching the world.
 pub const SNAPSHOT_AFTER_HINT: &str = "tuist-snapshot-after:";
-/// `inline_output_files` hint by which a client advertises zstd support: when
-/// present the body is compressed into the `TSNZ` envelope, letting the same
-/// wire budget carry several times the content. Negotiated, not versioned, so
-/// a client that omits it (any already-deployed build) still gets the plain
-/// `TSNP` body and an old server that ignores it still answers uncompressed —
-/// compatible in both directions across a rollout.
-pub const SNAPSHOT_ZSTD_HINT: &str = "tuist-snapshot-zstd:1";
 /// Bound on cached per-namespace snapshot indexes (LRU by last use). A kura
 /// node serves one tenant, so this comfortably covers every namespace that
 /// actually requests snapshots.
 const SNAPSHOT_CACHE_MAX_NAMESPACES: usize = 32;
 
 /// The most entries a snapshot index holds, counted from the newest write.
-/// This bounds the BUILD's memory the way SNAPSHOT_MAX_BYTES bounds the
+/// This bounds the BUILD's memory the way the wire ceiling bounds the
 /// response: reconciling against an unbounded keyspace held every manifest
 /// in memory at once, and a namespace with weeks of un-expired CI churn
 /// OOM-killed the pod on its first serve. With the cap, the scan buffer
@@ -2153,28 +2135,18 @@ impl NamespaceSnapshotIndex {
         }
     }
 
-    /// Encodes a view of the index, with a response-local node table so every
-    /// view is self-contained. A full view (`after == 0`) is newest-first
-    /// under the size ceiling — a recency window, so an oversized namespace
-    /// degrades to "the most recent keys, the rest per-key". A delta view
-    /// (`after > 0`) includes entries with `version_ms >= after`: inclusive,
-    /// because millisecond timestamps are not unique and a write landing in
-    /// an already-served millisecond must still reappear (re-sent boundary
-    /// entries merge idempotently client-side). Deltas are assembled
-    /// OLDEST-first and the header watermark is the newest version actually
-    /// included, so a delta that overflows the ceiling paginates — the next
-    /// request resumes where this one stopped — instead of the watermark
-    /// skipping past entries that were never sent.
-    /// Encodes a view for the wire. Without compression the body is bounded by
-    /// the uncompressed ceiling and returned as-is (`TSNP`). With compression
-    /// the body is included up to the larger content budget and zstd-wrapped
-    /// (`TSNZ`); a body that compresses worse than budgeted is re-encoded with
-    /// a smaller budget scaled from the observed ratio, bounded to a few tries
-    /// that can only converge on the provably-safe uncompressed ceiling.
-    fn encode(&self, after: u64, compress: bool) -> Vec<u8> {
-        if !compress {
-            return self.encode_body(after, SNAPSHOT_MAX_BYTES);
-        }
+    /// Encodes a view for the wire, always zstd-compressed into the `TSNZ`
+    /// envelope. The body is included up to the larger content budget then
+    /// compressed; a body that compresses worse than budgeted is re-encoded
+    /// with a smaller budget scaled from the observed ratio, bounded to a few
+    /// tries that can only converge on the provably-safe minimum budget.
+    ///
+    /// Every snapshot client decodes `TSNZ`; the plain `TSNP` body still exists
+    /// (see `encode_body`) only because a NEW client may hit an OLD server mid
+    /// kura-mesh-roll and must read what those pods emit — this server never
+    /// emits it. The client falls back to the per-key path on any body it can't
+    /// decode, so there is nothing to negotiate.
+    fn encode(&self, after: u64) -> Vec<u8> {
         let mut budget = SNAPSHOT_CONTENT_BUDGET_BYTES;
         let mut wire = Vec::new();
         for attempt in 0..SNAPSHOT_COMPRESS_MAX_ATTEMPTS {
@@ -2186,12 +2158,12 @@ impl NamespaceSnapshotIndex {
             // Overshot: this batch compressed worse than the budget assumed.
             // Scale the content budget down from the ratio we just measured
             // (strictly shrinks, since the compressed size is over the
-            // ceiling) but never below the uncompressed ceiling, whose body is
+            // ceiling) but never below the minimum budget, whose body is
             // guaranteed to compress under the wire ceiling. So the retry
             // converges on a safe view.
             let ratio = (body.len() as f64 / wire.len().max(1) as f64).max(1.0);
             let scaled = (SNAPSHOT_WIRE_MAX_BYTES as f64 * ratio * 0.9) as usize;
-            budget = scaled.min(budget * 9 / 10).max(SNAPSHOT_MAX_BYTES);
+            budget = scaled.min(budget * 9 / 10).max(SNAPSHOT_MIN_BUDGET_BYTES);
             if attempt + 1 == SNAPSHOT_COMPRESS_MAX_ATTEMPTS {
                 tracing::warn!(
                     wire_bytes = wire.len(),
@@ -2202,9 +2174,18 @@ impl NamespaceSnapshotIndex {
         wire
     }
 
-    /// The uncompressed `TSNP` body, including keys until `budget` bytes of
-    /// wire are accounted. `after == 0` is a full newest-first recency window;
-    /// a delta (`after > 0`) is oldest-first and paginates on overflow.
+    /// The uncompressed body, including keys until `budget` bytes of wire are
+    /// accounted, with a response-local node table so every view is
+    /// self-contained. `after == 0` is a full newest-first recency window (an
+    /// oversized namespace degrades to "the most recent keys, the rest
+    /// per-key"); a delta (`after > 0`) includes entries with
+    /// `version_ms >= after` — inclusive, because millisecond timestamps are
+    /// not unique and a write landing in an already-served millisecond must
+    /// reappear (re-sent boundary entries merge idempotently client-side) —
+    /// assembled oldest-first with the header watermark set to the newest
+    /// entry actually included, so an overflowing delta paginates rather than
+    /// skipping what it dropped. This is `encode`'s pre-compression input; it
+    /// is also the exact `TSNP` layout old kura pods still serve on the wire.
     fn encode_body(&self, after: u64, budget: usize) -> Vec<u8> {
         let full = after == 0;
         let mut included: Vec<(&[u8; 32], &SnapshotIndexEntry)> = self
@@ -2533,7 +2514,7 @@ mod tests {
         };
 
         // Full view: both keys, watermark = newest version, node table deduped.
-        let full = index.encode(0, false);
+        let full = index.encode_body(0, SNAPSHOT_MIN_BUDGET_BYTES);
         assert_eq!(&full[..4], b"TSNP");
         assert_eq!(full[4], 2);
         assert_eq!(u64::from_le_bytes(full[5..13].try_into().unwrap()), 200);
@@ -2541,7 +2522,7 @@ mod tests {
 
         // Delta view: only the key strictly newer than the cursor, with a
         // self-contained node table (root + the shared node).
-        let delta = index.encode(150, false);
+        let delta = index.encode_body(150, SNAPSHOT_MIN_BUDGET_BYTES);
         assert_eq!(u64::from_le_bytes(delta[5..13].try_into().unwrap()), 200);
         let node_count = read_u32(&delta, 13);
         assert_eq!(node_count, 2);
@@ -2558,13 +2539,13 @@ mod tests {
         // write landing in an already-served millisecond must reappear on the
         // next delta rather than being skipped until the full refresh. The
         // boundary key is re-sent (merge is idempotent client-side).
-        let boundary = index.encode(200, false);
+        let boundary = index.encode_body(200, SNAPSHOT_MIN_BUDGET_BYTES);
         assert_eq!(u64::from_le_bytes(boundary[5..13].try_into().unwrap()), 200);
         let node_count = read_u32(&boundary, 13);
         assert_eq!(node_count, 2, "boundary key re-sent");
 
         // Nothing at or past the cursor: an empty delta echoes it.
-        let empty = index.encode(300, false);
+        let empty = index.encode_body(300, SNAPSHOT_MIN_BUDGET_BYTES);
         assert_eq!(u64::from_le_bytes(empty[5..13].try_into().unwrap()), 300);
         let node_count = read_u32(&empty, 13);
         assert_eq!(node_count, 0);
@@ -2586,7 +2567,7 @@ mod tests {
         // The compressed wire is the TSNZ envelope: magic, version 1, the
         // uncompressed length, then the zstd stream that decodes to exactly
         // the uncompressed body the same view would have produced.
-        let wire = index.encode(0, true);
+        let wire = index.encode(0);
         assert_eq!(&wire[..4], b"TSNZ");
         assert_eq!(wire[4], 1);
         let declared = u64::from_le_bytes(wire[5..13].try_into().unwrap()) as usize;
@@ -2594,7 +2575,7 @@ mod tests {
         assert_eq!(body.len(), declared, "declared length matches the body");
         assert_eq!(
             body,
-            index.encode(0, false),
+            index.encode_body(0, SNAPSHOT_MIN_BUDGET_BYTES),
             "body equals the plain TSNP view"
         );
     }
@@ -2624,7 +2605,7 @@ mod tests {
         assert_eq!(index.nodes[0].llcas, vec![0xAA]);
         assert_eq!(index.node_index.get(&vec![0xAA]).copied(), Some(0));
         // The rebuilt table keeps serving: the full view carries the live key.
-        let full = index.encode(0, false);
+        let full = index.encode_body(0, SNAPSHOT_MIN_BUDGET_BYTES);
         assert_eq!(u64::from_le_bytes(full[5..13].try_into().unwrap()), 100);
     }
 
@@ -2745,7 +2726,7 @@ mod tests {
         .await;
 
         service
-            .serve_actioncache_snapshot("ios", 0, false)
+            .serve_actioncache_snapshot("ios", 0)
             .await
             .expect("first serve should succeed");
         assert_eq!(
@@ -2772,7 +2753,7 @@ mod tests {
 
         backdate_snapshot_index(&service, "ios");
         service
-            .serve_actioncache_snapshot("ios", 0, false)
+            .serve_actioncache_snapshot("ios", 0)
             .await
             .expect("second serve should succeed");
         wait_for_snapshot_index(&service, "ios", |index| index.entries.len() == 1).await;
@@ -2952,7 +2933,7 @@ mod tests {
         // keep running and cache the index anyway. Dropping it with the
         // request meant every retry rebuilt from scratch, and a gateway
         // timeout made the snapshot permanently unservable.
-        let mut serve = Box::pin(service.serve_actioncache_snapshot("ios", 0, false));
+        let mut serve = Box::pin(service.serve_actioncache_snapshot("ios", 0));
         let first = futures_util::future::poll_immediate(serve.as_mut()).await;
         assert!(first.is_none(), "the first poll leaves the build in flight");
         drop(serve);
@@ -2979,10 +2960,10 @@ mod tests {
             "the finished build removed itself from the in-flight map"
         );
         let bytes = service
-            .serve_actioncache_snapshot("ios", 0, false)
+            .serve_actioncache_snapshot("ios", 0)
             .await
             .expect("the follow-up request serves from the cached index");
-        assert_eq!(&bytes[..4], b"TSNP");
+        assert_eq!(&bytes[..4], b"TSNZ");
 
         // A later publish must reach the next serve: every serve reconciles
         // afresh (a memoized index served forever is the production-staleness
@@ -3003,7 +2984,7 @@ mod tests {
             .expect("late entry should persist");
         backdate_snapshot_index(&service, "ios");
         service
-            .serve_actioncache_snapshot("ios", 0, false)
+            .serve_actioncache_snapshot("ios", 0)
             .await
             .expect("the post-publish serve succeeds");
         wait_for_snapshot_index(&service, "ios", |index| {
@@ -3079,10 +3060,10 @@ mod tests {
         }
 
         let bytes = service
-            .serve_actioncache_snapshot("ios", 0, false)
+            .serve_actioncache_snapshot("ios", 0)
             .await
             .expect("serve should succeed on the large namespace");
-        assert_eq!(&bytes[..4], b"TSNP");
+        assert_eq!(&bytes[..4], b"TSNZ");
         let indexes = service.snapshot_cache.indexes.lock().unwrap();
         let index = &indexes["ios"];
         assert_eq!(
@@ -3160,7 +3141,7 @@ mod tests {
             .expect("pool should be acquirable when idle");
         let serve = tokio::spawn({
             let service = service.clone();
-            async move { service.serve_actioncache_snapshot("ios", 0, false).await }
+            async move { service.serve_actioncache_snapshot("ios", 0).await }
         });
         tokio::time::sleep(std::time::Duration::from_millis(200)).await;
         assert!(
@@ -3173,7 +3154,7 @@ mod tests {
             .expect("build should complete once the pool frees")
             .expect("serve task should not panic")
             .expect("serve should succeed");
-        assert_eq!(&bytes[..4], b"TSNP");
+        assert_eq!(&bytes[..4], b"TSNZ");
     }
 
     #[tokio::test(start_paused = true)]
@@ -3194,7 +3175,7 @@ mod tests {
             .try_acquire_reapi_materialization(pool)
             .expect("pool should be acquirable when idle");
         let status = service
-            .serve_actioncache_snapshot("ios", 0, false)
+            .serve_actioncache_snapshot("ios", 0)
             .await
             .expect_err("cold serve should shed while the build is stuck");
         assert_eq!(status.code(), tonic::Code::Unavailable);
@@ -3203,12 +3184,12 @@ mod tests {
         drop(hog);
         let bytes = tokio::time::timeout(
             std::time::Duration::from_secs(120),
-            service.serve_actioncache_snapshot("ios", 0, false),
+            service.serve_actioncache_snapshot("ios", 0),
         )
         .await
         .expect("serve should not hang once the pool frees")
         .expect("serve should succeed after the build completes");
-        assert_eq!(&bytes[..4], b"TSNP");
+        assert_eq!(&bytes[..4], b"TSNZ");
     }
 
     use tokio::net::TcpListener;

--- a/kura/src/reapi/mod.rs
+++ b/kura/src/reapi/mod.rs
@@ -515,6 +515,7 @@ impl ReapiService {
         &self,
         namespace_id: &str,
         after: u64,
+        compress: bool,
     ) -> Result<Vec<u8>, Status> {
         // Serve the cached index immediately, kicking the reconcile in the
         // background once the view is older than the freshness window: a
@@ -533,7 +534,7 @@ impl ReapiService {
             if let Some(index) = indexes.get_mut(namespace_id) {
                 let stale = index.reconciled_at.elapsed() >= SNAPSHOT_RECONCILE_INTERVAL;
                 index.last_used = Instant::now();
-                let bytes = index.encode(after);
+                let bytes = index.encode(after, compress);
                 drop(indexes);
                 if stale {
                     let _build = self.ensure_index_build(namespace_id);
@@ -571,7 +572,7 @@ impl ReapiService {
             return Err(Status::internal("snapshot index missing after build"));
         };
         index.last_used = Instant::now();
-        Ok(index.encode(after))
+        Ok(index.encode(after, compress))
     }
 
     /// The namespace's in-flight index build, starting one when none is
@@ -1004,7 +1005,14 @@ impl ActionCache for ReapiService {
                 .iter()
                 .find_map(|hint| hint.strip_prefix(SNAPSHOT_AFTER_HINT)?.parse::<u64>().ok())
                 .unwrap_or(0);
-            let snapshot = self.serve_actioncache_snapshot(namespace_id, after).await?;
+            let compress = request
+                .get_ref()
+                .inline_output_files
+                .iter()
+                .any(|hint| hint == SNAPSHOT_ZSTD_HINT);
+            let snapshot = self
+                .serve_actioncache_snapshot(namespace_id, after, compress)
+                .await?;
             let served = snapshot.len() as u64;
             let action_result = reapi::ActionResult {
                 output_files: vec![reapi::OutputFile {
@@ -1945,15 +1953,51 @@ fn validate_digest_bytes(digest: &reapi::Digest, bytes: &[u8]) -> Result<(), Str
 /// the write-time watermark header and delta responses).
 pub const SNAPSHOT_ACTION_KEY: &[u8] = b"tuist-actioncache-snapshot/v2";
 const SNAPSHOT_OUTPUT_PATH: &str = "tuist-actioncache-snapshot";
-/// Hard ceiling on the encoded snapshot, with headroom under the 64MB
-/// message limit REAPI clients configure. Entries are encoded newest-first,
-/// so the ceiling sheds the OLDEST keys — the snapshot degrades into a
-/// recency window; dropped keys resolve through the per-key path.
+/// Hard ceiling on the UNCOMPRESSED encoded snapshot served to clients that
+/// do not request compression, with headroom under the 64MB message limit
+/// REAPI clients configure. Entries are encoded newest-first, so the ceiling
+/// sheds the OLDEST keys — the snapshot degrades into a recency window;
+/// dropped keys resolve through the per-key path. It is also the floor the
+/// compressed path's inclusion budget converges to (a body this size is
+/// guaranteed to compress under the wire ceiling), so shrink retries always
+/// terminate at a safe view.
 const SNAPSHOT_MAX_BYTES: usize = 48 << 20;
+
+/// Ceiling on the COMPRESSED wire size for clients that request zstd. Same
+/// transfer budget as the uncompressed ceiling, but it now carries several
+/// times the content — a shared namespace's snapshot rides the recency
+/// window down to a small suffix of oldest keys, and those sheds were the
+/// per-key ladder that made the snapshot net-negative over the WAN.
+const SNAPSHOT_WIRE_MAX_BYTES: usize = 48 << 20;
+
+/// How much UNCOMPRESSED body the compressed path includes before it stops
+/// adding keys. Sized so the zstd output of a full body lands near the wire
+/// ceiling for this data's typical ratio; a body that compresses worse is
+/// re-encoded smaller (see `encode`). Also bounded in practice by the index's
+/// own entry cap.
+const SNAPSHOT_CONTENT_BUDGET_BYTES: usize = 144 << 20;
+
+/// Bounded shrink retries when a compressed body overshoots the wire ceiling.
+/// Each retry scales the content budget down from the observed ratio and can
+/// only fall to `SNAPSHOT_MAX_BYTES` (a provably-safe view), so this bounds
+/// the encode work, not the correctness.
+const SNAPSHOT_COMPRESS_MAX_ATTEMPTS: usize = 3;
+
+/// zstd level for the snapshot body. Level 3 runs at hundreds of MB/s and
+/// lands within a few percent of higher levels on hex-id node tables, so the
+/// serve stays CPU-cheap while the wire shrinks ~3x.
+const SNAPSHOT_ZSTD_LEVEL: i32 = 3;
 /// `inline_output_files` hint carrying the client's write-time watermark:
 /// when present, the response includes only entries written after it (a
 /// delta), letting a long-lived client refresh without refetching the world.
 pub const SNAPSHOT_AFTER_HINT: &str = "tuist-snapshot-after:";
+/// `inline_output_files` hint by which a client advertises zstd support: when
+/// present the body is compressed into the `TSNZ` envelope, letting the same
+/// wire budget carry several times the content. Negotiated, not versioned, so
+/// a client that omits it (any already-deployed build) still gets the plain
+/// `TSNP` body and an old server that ignores it still answers uncompressed —
+/// compatible in both directions across a rollout.
+pub const SNAPSHOT_ZSTD_HINT: &str = "tuist-snapshot-zstd:1";
 /// Bound on cached per-namespace snapshot indexes (LRU by last use). A kura
 /// node serves one tenant, so this comfortably covers every namespace that
 /// actually requests snapshots.
@@ -2121,7 +2165,47 @@ impl NamespaceSnapshotIndex {
     /// included, so a delta that overflows the ceiling paginates — the next
     /// request resumes where this one stopped — instead of the watermark
     /// skipping past entries that were never sent.
-    fn encode(&self, after: u64) -> Vec<u8> {
+    /// Encodes a view for the wire. Without compression the body is bounded by
+    /// the uncompressed ceiling and returned as-is (`TSNP`). With compression
+    /// the body is included up to the larger content budget and zstd-wrapped
+    /// (`TSNZ`); a body that compresses worse than budgeted is re-encoded with
+    /// a smaller budget scaled from the observed ratio, bounded to a few tries
+    /// that can only converge on the provably-safe uncompressed ceiling.
+    fn encode(&self, after: u64, compress: bool) -> Vec<u8> {
+        if !compress {
+            return self.encode_body(after, SNAPSHOT_MAX_BYTES);
+        }
+        let mut budget = SNAPSHOT_CONTENT_BUDGET_BYTES;
+        let mut wire = Vec::new();
+        for attempt in 0..SNAPSHOT_COMPRESS_MAX_ATTEMPTS {
+            let body = self.encode_body(after, budget);
+            wire = compress_snapshot(&body);
+            if wire.len() <= SNAPSHOT_WIRE_MAX_BYTES {
+                return wire;
+            }
+            // Overshot: this batch compressed worse than the budget assumed.
+            // Scale the content budget down from the ratio we just measured
+            // (strictly shrinks, since the compressed size is over the
+            // ceiling) but never below the uncompressed ceiling, whose body is
+            // guaranteed to compress under the wire ceiling. So the retry
+            // converges on a safe view.
+            let ratio = (body.len() as f64 / wire.len().max(1) as f64).max(1.0);
+            let scaled = (SNAPSHOT_WIRE_MAX_BYTES as f64 * ratio * 0.9) as usize;
+            budget = scaled.min(budget * 9 / 10).max(SNAPSHOT_MAX_BYTES);
+            if attempt + 1 == SNAPSHOT_COMPRESS_MAX_ATTEMPTS {
+                tracing::warn!(
+                    wire_bytes = wire.len(),
+                    "action-cache snapshot still over the wire ceiling after compression retries; shipping the trimmed view"
+                );
+            }
+        }
+        wire
+    }
+
+    /// The uncompressed `TSNP` body, including keys until `budget` bytes of
+    /// wire are accounted. `after == 0` is a full newest-first recency window;
+    /// a delta (`after > 0`) is oldest-first and paginates on overflow.
+    fn encode_body(&self, after: u64, budget: usize) -> Vec<u8> {
         let full = after == 0;
         let mut included: Vec<(&[u8; 32], &SnapshotIndexEntry)> = self
             .entries
@@ -2148,7 +2232,7 @@ impl NamespaceSnapshotIndex {
                     key_cost += 1 + self.nodes[node as usize].llcas.len() + 32 + 8;
                 }
             }
-            if estimated + key_cost > SNAPSHOT_MAX_BYTES {
+            if estimated + key_cost > budget {
                 if full {
                     // Recency window: this key is out, smaller older ones may fit.
                     continue;
@@ -2206,6 +2290,21 @@ impl NamespaceSnapshotIndex {
         }
         out
     }
+}
+
+/// Wraps a `TSNP` body in the `TSNZ` envelope: magic, version, the u64
+/// uncompressed length (so the client can size its buffer and reject a torn
+/// payload), then the zstd stream. Only clients that advertise zstd support
+/// receive this; everyone else gets the raw body.
+fn compress_snapshot(body: &[u8]) -> Vec<u8> {
+    let compressed = zstd::stream::encode_all(body, SNAPSHOT_ZSTD_LEVEL)
+        .expect("zstd encode of an in-memory buffer cannot fail");
+    let mut out = Vec::with_capacity(compressed.len() + 13);
+    out.extend_from_slice(b"TSNZ");
+    out.push(1);
+    out.extend_from_slice(&(body.len() as u64).to_le_bytes());
+    out.extend_from_slice(&compressed);
+    out
 }
 
 fn digest_key(digest: &reapi::Digest) -> Result<String, Status> {
@@ -2434,7 +2533,7 @@ mod tests {
         };
 
         // Full view: both keys, watermark = newest version, node table deduped.
-        let full = index.encode(0);
+        let full = index.encode(0, false);
         assert_eq!(&full[..4], b"TSNP");
         assert_eq!(full[4], 2);
         assert_eq!(u64::from_le_bytes(full[5..13].try_into().unwrap()), 200);
@@ -2442,7 +2541,7 @@ mod tests {
 
         // Delta view: only the key strictly newer than the cursor, with a
         // self-contained node table (root + the shared node).
-        let delta = index.encode(150);
+        let delta = index.encode(150, false);
         assert_eq!(u64::from_le_bytes(delta[5..13].try_into().unwrap()), 200);
         let node_count = read_u32(&delta, 13);
         assert_eq!(node_count, 2);
@@ -2459,16 +2558,45 @@ mod tests {
         // write landing in an already-served millisecond must reappear on the
         // next delta rather than being skipped until the full refresh. The
         // boundary key is re-sent (merge is idempotent client-side).
-        let boundary = index.encode(200);
+        let boundary = index.encode(200, false);
         assert_eq!(u64::from_le_bytes(boundary[5..13].try_into().unwrap()), 200);
         let node_count = read_u32(&boundary, 13);
         assert_eq!(node_count, 2, "boundary key re-sent");
 
         // Nothing at or past the cursor: an empty delta echoes it.
-        let empty = index.encode(300);
+        let empty = index.encode(300, false);
         assert_eq!(u64::from_le_bytes(empty[5..13].try_into().unwrap()), 300);
         let node_count = read_u32(&empty, 13);
         assert_eq!(node_count, 0);
+    }
+
+    #[test]
+    fn actioncache_snapshot_compressed_envelope_round_trips() {
+        let mut index = NamespaceSnapshotIndex::new();
+        let root = index.intern_node(vec![0xAA, 0xAA], [7; 32], 10);
+        let shared = index.intern_node(vec![0xBB], [8; 32], 20);
+        index.entries.insert(
+            [1; 32],
+            SnapshotIndexEntry {
+                version_ms: 100,
+                nodes: vec![root, shared],
+            },
+        );
+
+        // The compressed wire is the TSNZ envelope: magic, version 1, the
+        // uncompressed length, then the zstd stream that decodes to exactly
+        // the uncompressed body the same view would have produced.
+        let wire = index.encode(0, true);
+        assert_eq!(&wire[..4], b"TSNZ");
+        assert_eq!(wire[4], 1);
+        let declared = u64::from_le_bytes(wire[5..13].try_into().unwrap()) as usize;
+        let body = zstd::stream::decode_all(&wire[13..]).expect("zstd body should decode");
+        assert_eq!(body.len(), declared, "declared length matches the body");
+        assert_eq!(
+            body,
+            index.encode(0, false),
+            "body equals the plain TSNP view"
+        );
     }
 
     #[test]
@@ -2496,7 +2624,7 @@ mod tests {
         assert_eq!(index.nodes[0].llcas, vec![0xAA]);
         assert_eq!(index.node_index.get(&vec![0xAA]).copied(), Some(0));
         // The rebuilt table keeps serving: the full view carries the live key.
-        let full = index.encode(0);
+        let full = index.encode(0, false);
         assert_eq!(u64::from_le_bytes(full[5..13].try_into().unwrap()), 100);
     }
 
@@ -2617,7 +2745,7 @@ mod tests {
         .await;
 
         service
-            .serve_actioncache_snapshot("ios", 0)
+            .serve_actioncache_snapshot("ios", 0, false)
             .await
             .expect("first serve should succeed");
         assert_eq!(
@@ -2644,7 +2772,7 @@ mod tests {
 
         backdate_snapshot_index(&service, "ios");
         service
-            .serve_actioncache_snapshot("ios", 0)
+            .serve_actioncache_snapshot("ios", 0, false)
             .await
             .expect("second serve should succeed");
         wait_for_snapshot_index(&service, "ios", |index| index.entries.len() == 1).await;
@@ -2824,7 +2952,7 @@ mod tests {
         // keep running and cache the index anyway. Dropping it with the
         // request meant every retry rebuilt from scratch, and a gateway
         // timeout made the snapshot permanently unservable.
-        let mut serve = Box::pin(service.serve_actioncache_snapshot("ios", 0));
+        let mut serve = Box::pin(service.serve_actioncache_snapshot("ios", 0, false));
         let first = futures_util::future::poll_immediate(serve.as_mut()).await;
         assert!(first.is_none(), "the first poll leaves the build in flight");
         drop(serve);
@@ -2851,7 +2979,7 @@ mod tests {
             "the finished build removed itself from the in-flight map"
         );
         let bytes = service
-            .serve_actioncache_snapshot("ios", 0)
+            .serve_actioncache_snapshot("ios", 0, false)
             .await
             .expect("the follow-up request serves from the cached index");
         assert_eq!(&bytes[..4], b"TSNP");
@@ -2875,7 +3003,7 @@ mod tests {
             .expect("late entry should persist");
         backdate_snapshot_index(&service, "ios");
         service
-            .serve_actioncache_snapshot("ios", 0)
+            .serve_actioncache_snapshot("ios", 0, false)
             .await
             .expect("the post-publish serve succeeds");
         wait_for_snapshot_index(&service, "ios", |index| {
@@ -2951,7 +3079,7 @@ mod tests {
         }
 
         let bytes = service
-            .serve_actioncache_snapshot("ios", 0)
+            .serve_actioncache_snapshot("ios", 0, false)
             .await
             .expect("serve should succeed on the large namespace");
         assert_eq!(&bytes[..4], b"TSNP");
@@ -3032,7 +3160,7 @@ mod tests {
             .expect("pool should be acquirable when idle");
         let serve = tokio::spawn({
             let service = service.clone();
-            async move { service.serve_actioncache_snapshot("ios", 0).await }
+            async move { service.serve_actioncache_snapshot("ios", 0, false).await }
         });
         tokio::time::sleep(std::time::Duration::from_millis(200)).await;
         assert!(
@@ -3066,7 +3194,7 @@ mod tests {
             .try_acquire_reapi_materialization(pool)
             .expect("pool should be acquirable when idle");
         let status = service
-            .serve_actioncache_snapshot("ios", 0)
+            .serve_actioncache_snapshot("ios", 0, false)
             .await
             .expect_err("cold serve should shed while the build is stuck");
         assert_eq!(status.code(), tonic::Code::Unavailable);
@@ -3075,7 +3203,7 @@ mod tests {
         drop(hog);
         let bytes = tokio::time::timeout(
             std::time::Duration::from_secs(120),
-            service.serve_actioncache_snapshot("ios", 0),
+            service.serve_actioncache_snapshot("ios", 0, false),
         )
         .await
         .expect("serve should not hang once the pool frees")

--- a/kura/src/reapi/mod.rs
+++ b/kura/src/reapi/mod.rs
@@ -79,6 +79,14 @@ pub struct ReapiService {
 struct SnapshotCache {
     indexes: std::sync::Mutex<BTreeMap<String, NamespaceSnapshotIndex>>,
     builds: std::sync::Mutex<std::collections::HashMap<String, SharedIndexBuild>>,
+    /// The last FULL (`after == 0`) encoded snapshot per namespace. A reconcile
+    /// takes its index out of `indexes` for the build's duration, so a serve
+    /// landing during a rebuild would otherwise find nothing and shed a cold
+    /// client to UNAVAILABLE. Serving this last full view instead keeps them on
+    /// the (slightly stale) snapshot. Bounded at the wire ceiling per entry and
+    /// pruned with the index LRU — unlike cloning the whole index, whose
+    /// node table the entry cap does not bound.
+    served_full: std::sync::Mutex<BTreeMap<String, std::sync::Arc<Vec<u8>>>>,
 }
 
 type SharedIndexBuild = futures_util::future::Shared<BoxFuture<'static, Result<(), String>>>;
@@ -522,10 +530,7 @@ impl ReapiService {
         // namespace), and running it inline made every fetch pay it — 40s
         // measured for a serve whose encode and transfer account for a few
         // seconds. Staleness is bounded by the window plus the client's own
-        // delta cadence. The reconcile builds against a clone and leaves this
-        // index in place (see `run_index_build`), so a build in flight does
-        // NOT take it out of the cache — serves keep hitting this fast path
-        // throughout, rather than falling to the cold path below.
+        // delta cadence.
         {
             let mut indexes = self
                 .snapshot_cache
@@ -537,10 +542,30 @@ impl ReapiService {
                 index.last_used = Instant::now();
                 let bytes = index.encode(after);
                 drop(indexes);
+                self.cache_full_view(namespace_id, after, &bytes);
                 if stale {
                     let _build = self.ensure_index_build(namespace_id);
                 }
                 return Ok(bytes);
+            }
+        }
+        // The index is out — either a reconcile has it, or it has never been
+        // built. For a full request, serve the last full view (stale) rather
+        // than shedding a cold client to UNAVAILABLE while a rebuild runs, and
+        // make sure a rebuild is in flight. A delta cannot be replayed this
+        // way, so it falls through to the cold path (its client keeps its
+        // current snapshot and retries).
+        if after == 0 {
+            let cached = self
+                .snapshot_cache
+                .served_full
+                .lock()
+                .expect("snapshot served_full lock poisoned")
+                .get(namespace_id)
+                .cloned();
+            if let Some(cached) = cached {
+                let _build = self.ensure_index_build(namespace_id);
+                return Ok((*cached).clone());
             }
         }
         // Cold path: wait briefly for the build so small (and already
@@ -573,14 +598,35 @@ impl ReapiService {
             return Err(Status::internal("snapshot index missing after build"));
         };
         index.last_used = Instant::now();
-        Ok(index.encode(after))
+        let bytes = index.encode(after);
+        drop(indexes);
+        self.cache_full_view(namespace_id, after, &bytes);
+        Ok(bytes)
+    }
+
+    /// Caches a full (`after == 0`) encoded view as the namespace's
+    /// `served_full`, so a serve that lands while the index is out for a
+    /// reconcile returns it instead of shedding to UNAVAILABLE. A delta is
+    /// relative to a client's watermark and cannot be replayed, so it is not
+    /// cached.
+    fn cache_full_view(&self, namespace_id: &str, after: u64, bytes: &[u8]) {
+        if after != 0 {
+            return;
+        }
+        self.snapshot_cache
+            .served_full
+            .lock()
+            .expect("snapshot served_full lock poisoned")
+            .insert(namespace_id.to_owned(), std::sync::Arc::new(bytes.to_vec()));
     }
 
     /// The namespace's in-flight index build, starting one when none is
-    /// running. Requests share a single reconcile; the spawned task reconciles
-    /// a clone of the live index and swaps the result in on success (leaving
-    /// the live view servable throughout, and untouched on failure so the last
-    /// good view keeps serving and the next reconcile retries from it).
+    /// running. Requests share a single reconcile; the spawned task takes the
+    /// index out for the reconcile and reinserts it (with the LRU bound
+    /// applied) whether the reconcile succeeded or failed, so accumulated
+    /// progress survives request aborts and transient store errors alike.
+    /// While the index is out, serves fall back to the cached full view
+    /// (`served_full`) rather than the cold path.
     fn ensure_index_build(&self, namespace_id: &str) -> SharedIndexBuild {
         let mut builds = self
             .snapshot_cache
@@ -672,52 +718,57 @@ impl ReapiService {
             );
             return Err("declined under memory pressure".to_owned());
         };
-        // Reconcile against a CLONE, leaving the live index in place so the
-        // serve fast path keeps returning it (slightly stale) for the build's
-        // whole duration. Removing it made every serve during a reconcile fall
-        // to the cold path and answer UNAVAILABLE — and on a hot namespace,
-        // where reconciles run back-to-back under continuous writes, that
-        // window is a large fraction of the time, so cold clients saw repeated
-        // UNAVAILABLE. The clone is the reconcile's diff base anyway (it loads
-        // only entries new-or-changed against it). A fresh namespace has no
-        // live index yet, so its FIRST build still serves the cold path once.
-        let base = cache
+        // Take the index out for the reconcile (it mutates in place). A serve
+        // landing while it is out does NOT fall to the cold path and answer
+        // UNAVAILABLE — the fast path's caller serves the last full view from
+        // `served_full` instead. Cloning the whole index to keep it in place
+        // would copy an unbounded node table (the entry cap does not bound it);
+        // the cached full encoding is bounded at the wire ceiling.
+        let index = cache
             .indexes
             .lock()
             .expect("snapshot cache lock poisoned")
-            .get(&namespace)
-            .cloned()
+            .remove(&namespace)
             .unwrap_or_else(NamespaceSnapshotIndex::new);
-        match reconcile_snapshot_index(&state, &namespace, base).await {
+        let (mut index, result) = match reconcile_snapshot_index(&state, &namespace, index).await {
             Ok(mut index) => {
                 index.reconciled_at = Instant::now();
-                index.last_used = Instant::now();
-                let mut indexes = cache.indexes.lock().expect("snapshot cache lock poisoned");
-                indexes.insert(namespace.clone(), index);
-                while indexes.len() > SNAPSHOT_CACHE_MAX_NAMESPACES {
-                    let oldest = indexes
-                        .iter()
-                        .min_by_key(|(_, index)| index.last_used)
-                        .map(|(namespace, _)| namespace.clone());
-                    let Some(oldest) = oldest else { break };
-                    indexes.remove(&oldest);
-                }
-                Ok(())
+                (index, Ok(()))
             }
-            Err((_partial, error)) => {
-                // Leave the live index untouched: it keeps serving its
-                // last fully-reconciled view, and the next reconcile
-                // retries from it. Background kicks drop the shared future
-                // without awaiting it, so this is the only place a repeated
-                // reconcile failure becomes visible.
+            Err((index, error)) => {
+                // The reconcile hands the index back so accumulated progress
+                // survives a transient store error; reinsert it. Background
+                // kicks drop the shared future without awaiting it, so this is
+                // the only place a repeated reconcile failure becomes visible.
                 tracing::warn!(
                     namespace_id = namespace.as_str(),
                     error = error.as_str(),
                     "action-cache snapshot reconcile failed"
                 );
-                Err(error)
+                (index, Err(error))
+            }
+        };
+        index.last_used = Instant::now();
+        {
+            let mut indexes = cache.indexes.lock().expect("snapshot cache lock poisoned");
+            indexes.insert(namespace.clone(), index);
+            while indexes.len() > SNAPSHOT_CACHE_MAX_NAMESPACES {
+                let oldest = indexes
+                    .iter()
+                    .min_by_key(|(_, index)| index.last_used)
+                    .map(|(namespace, _)| namespace.clone());
+                let Some(oldest) = oldest else { break };
+                indexes.remove(&oldest);
+                // Drop the evicted namespace's cached full view too, so
+                // `served_full` stays bounded alongside `indexes`.
+                cache
+                    .served_full
+                    .lock()
+                    .expect("snapshot served_full lock poisoned")
+                    .remove(&oldest);
             }
         }
+        result
     }
 }
 
@@ -2045,7 +2096,6 @@ fn snapshot_action_hash() -> &'static str {
     HASH.get_or_init(|| hex::encode(Sha256::digest(SNAPSHOT_ACTION_KEY)))
 }
 
-#[derive(Clone)]
 struct SnapshotNode {
     llcas: Vec<u8>,
     blob_hash: [u8; 32],
@@ -2055,7 +2105,6 @@ struct SnapshotNode {
     blob_key: String,
 }
 
-#[derive(Clone)]
 struct SnapshotIndexEntry {
     version_ms: u64,
     nodes: Vec<u32>,
@@ -2067,10 +2116,6 @@ struct SnapshotIndexEntry {
 /// write-path hooks) keeps it correct under peer replication and eviction:
 /// whatever wrote or removed an entry, the manifest keyspace is the truth
 /// this diffs against.
-///
-/// `Clone` so a reconcile can build against a copy while the live index keeps
-/// serving (slightly stale) — see `run_index_build`.
-#[derive(Clone)]
 struct NamespaceSnapshotIndex {
     nodes: Vec<SnapshotNode>,
     node_index: BTreeMap<Vec<u8>, u32>,
@@ -3175,7 +3220,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn snapshot_serve_returns_the_cached_view_while_a_reconcile_is_outstanding() {
+    async fn snapshot_serve_returns_the_cached_full_view_while_the_index_is_out_for_reconcile() {
         let context = test_context(|_| {}).await;
         let service = ReapiService {
             snapshot_cache: Default::default(),
@@ -3224,25 +3269,26 @@ mod tests {
             .await
             .expect("blob should persist");
 
-        // Build and cache the index once.
+        // A full serve builds the index and caches the full view.
         let first = service
             .serve_actioncache_snapshot("ios", 0)
             .await
             .expect("first serve builds the index");
         assert_eq!(&first[..4], b"TSNZ");
+        assert!(
+            service
+                .snapshot_cache
+                .served_full
+                .lock()
+                .unwrap()
+                .contains_key("ios"),
+            "the full view is cached for the rebuild window"
+        );
 
-        // Age the cached view past the freshness window so the next serve kicks
-        // a background reconcile, and exhaust the pool so that reconcile stalls
-        // rather than completing instantly.
-        {
-            let mut indexes = service.snapshot_cache.indexes.lock().unwrap();
-            let index = indexes
-                .get_mut("ios")
-                .expect("index cached after first serve");
-            index.reconciled_at = Instant::now()
-                .checked_sub(SNAPSHOT_RECONCILE_INTERVAL * 2)
-                .expect("test clock has headroom");
-        }
+        // Simulate a reconcile in flight: the index is OUT of the map. Exhaust
+        // the pool so the serve's kicked rebuild cannot reinsert it before the
+        // assertion.
+        service.snapshot_cache.indexes.lock().unwrap().remove("ios");
         let pool = context.state.memory.reapi_materialization_pool_bytes();
         let _hog = context
             .state
@@ -3250,31 +3296,17 @@ mod tests {
             .try_acquire_reapi_materialization(pool)
             .expect("pool should be acquirable when idle");
 
-        // A stale serve with a reconcile it cannot complete (pool exhausted)
-        // must still return the cached view immediately — never UNAVAILABLE,
-        // never blocking on the build. This guards the contract the clone fix
-        // preserves: the reconcile builds against a copy, so the live index
-        // stays in the map and serveable for the build's whole duration rather
-        // than being taken out (the pre-fix remove-then-reinsert exposed a
-        // window where a concurrent serve found nothing and fell to the cold
-        // UNAVAILABLE path).
+        // A full serve now finds no index but returns the cached full view
+        // immediately, rather than shedding a cold client to UNAVAILABLE while
+        // the rebuild runs. Before `served_full`, this fell to the cold path.
         let stale = tokio::time::timeout(
             std::time::Duration::from_secs(2),
             service.serve_actioncache_snapshot("ios", 0),
         )
         .await
-        .expect("serve must not block on the stalled reconcile")
-        .expect("serve returns the cached view, not UNAVAILABLE");
-        assert_eq!(&stale[..4], b"TSNZ");
-        assert!(
-            service
-                .snapshot_cache
-                .indexes
-                .lock()
-                .unwrap()
-                .contains_key("ios"),
-            "the live index stays cached while a reconcile is outstanding"
-        );
+        .expect("serve must not block on the stalled rebuild")
+        .expect("serve returns the cached full view, not UNAVAILABLE");
+        assert_eq!(stale, first, "serves the exact cached full view");
     }
 
     #[tokio::test(start_paused = true)]

--- a/kura/src/reapi/mod.rs
+++ b/kura/src/reapi/mod.rs
@@ -522,8 +522,10 @@ impl ReapiService {
         // namespace), and running it inline made every fetch pay it — 40s
         // measured for a serve whose encode and transfer account for a few
         // seconds. Staleness is bounded by the window plus the client's own
-        // delta cadence; a build in flight has taken the index out of the
-        // cache, so those requests fall through and share its completion.
+        // delta cadence. The reconcile builds against a clone and leaves this
+        // index in place (see `run_index_build`), so a build in flight does
+        // NOT take it out of the cache — serves keep hitting this fast path
+        // throughout, rather than falling to the cold path below.
         {
             let mut indexes = self
                 .snapshot_cache
@@ -575,10 +577,10 @@ impl ReapiService {
     }
 
     /// The namespace's in-flight index build, starting one when none is
-    /// running. Requests share a single reconcile; the spawned task owns the
-    /// index for its duration and reinserts it (with the LRU bound applied)
-    /// whether the reconcile succeeded or failed, so accumulated progress
-    /// survives request aborts and transient store errors alike.
+    /// running. Requests share a single reconcile; the spawned task reconciles
+    /// a clone of the live index and swaps the result in on success (leaving
+    /// the live view servable throughout, and untouched on failure so the last
+    /// good view keeps serving and the next reconcile retries from it).
     fn ensure_index_build(&self, namespace_id: &str) -> SharedIndexBuild {
         let mut builds = self
             .snapshot_cache
@@ -670,43 +672,52 @@ impl ReapiService {
             );
             return Err("declined under memory pressure".to_owned());
         };
-        let index = cache
+        // Reconcile against a CLONE, leaving the live index in place so the
+        // serve fast path keeps returning it (slightly stale) for the build's
+        // whole duration. Removing it made every serve during a reconcile fall
+        // to the cold path and answer UNAVAILABLE — and on a hot namespace,
+        // where reconciles run back-to-back under continuous writes, that
+        // window is a large fraction of the time, so cold clients saw repeated
+        // UNAVAILABLE. The clone is the reconcile's diff base anyway (it loads
+        // only entries new-or-changed against it). A fresh namespace has no
+        // live index yet, so its FIRST build still serves the cold path once.
+        let base = cache
             .indexes
             .lock()
             .expect("snapshot cache lock poisoned")
-            .remove(&namespace)
+            .get(&namespace)
+            .cloned()
             .unwrap_or_else(NamespaceSnapshotIndex::new);
-        let (mut index, result) = match reconcile_snapshot_index(&state, &namespace, index).await {
+        match reconcile_snapshot_index(&state, &namespace, base).await {
             Ok(mut index) => {
                 index.reconciled_at = Instant::now();
-                (index, Ok(()))
+                index.last_used = Instant::now();
+                let mut indexes = cache.indexes.lock().expect("snapshot cache lock poisoned");
+                indexes.insert(namespace.clone(), index);
+                while indexes.len() > SNAPSHOT_CACHE_MAX_NAMESPACES {
+                    let oldest = indexes
+                        .iter()
+                        .min_by_key(|(_, index)| index.last_used)
+                        .map(|(namespace, _)| namespace.clone());
+                    let Some(oldest) = oldest else { break };
+                    indexes.remove(&oldest);
+                }
+                Ok(())
             }
-            Err((index, error)) => {
-                // Background kicks drop the shared future without
-                // awaiting it, so this is the only place a repeated
+            Err((_partial, error)) => {
+                // Leave the live index untouched: it keeps serving its
+                // last fully-reconciled view, and the next reconcile
+                // retries from it. Background kicks drop the shared future
+                // without awaiting it, so this is the only place a repeated
                 // reconcile failure becomes visible.
                 tracing::warn!(
                     namespace_id = namespace.as_str(),
                     error = error.as_str(),
                     "action-cache snapshot reconcile failed"
                 );
-                (index, Err(error))
-            }
-        };
-        index.last_used = Instant::now();
-        {
-            let mut indexes = cache.indexes.lock().expect("snapshot cache lock poisoned");
-            indexes.insert(namespace.clone(), index);
-            while indexes.len() > SNAPSHOT_CACHE_MAX_NAMESPACES {
-                let oldest = indexes
-                    .iter()
-                    .min_by_key(|(_, index)| index.last_used)
-                    .map(|(namespace, _)| namespace.clone());
-                let Some(oldest) = oldest else { break };
-                indexes.remove(&oldest);
+                Err(error)
             }
         }
-        result
     }
 }
 
@@ -2034,6 +2045,7 @@ fn snapshot_action_hash() -> &'static str {
     HASH.get_or_init(|| hex::encode(Sha256::digest(SNAPSHOT_ACTION_KEY)))
 }
 
+#[derive(Clone)]
 struct SnapshotNode {
     llcas: Vec<u8>,
     blob_hash: [u8; 32],
@@ -2043,6 +2055,7 @@ struct SnapshotNode {
     blob_key: String,
 }
 
+#[derive(Clone)]
 struct SnapshotIndexEntry {
     version_ms: u64,
     nodes: Vec<u32>,
@@ -2054,6 +2067,10 @@ struct SnapshotIndexEntry {
 /// write-path hooks) keeps it correct under peer replication and eviction:
 /// whatever wrote or removed an entry, the manifest keyspace is the truth
 /// this diffs against.
+///
+/// `Clone` so a reconcile can build against a copy while the live index keeps
+/// serving (slightly stale) — see `run_index_build`.
+#[derive(Clone)]
 struct NamespaceSnapshotIndex {
     nodes: Vec<SnapshotNode>,
     node_index: BTreeMap<Vec<u8>, u32>,
@@ -3155,6 +3172,109 @@ mod tests {
             .expect("serve task should not panic")
             .expect("serve should succeed");
         assert_eq!(&bytes[..4], b"TSNZ");
+    }
+
+    #[tokio::test]
+    async fn snapshot_serve_returns_the_cached_view_while_a_reconcile_is_outstanding() {
+        let context = test_context(|_| {}).await;
+        let service = ReapiService {
+            snapshot_cache: Default::default(),
+            state: context.state.clone(),
+        };
+        let store = &context.state.store;
+        let uploads = context.state.config.tmp_dir.join("uploads");
+        std::fs::create_dir_all(&uploads).expect("uploads dir should create");
+        let entry_key = format!("action_cache/{}/10", hex::encode([0x44u8; 32]));
+        let entry_path = uploads.join("entry");
+        let entry_bytes = reapi::ActionResult {
+            output_files: vec![reapi::OutputFile {
+                path: hex::encode([0xABu8, 0xCD]),
+                digest: Some(reapi::Digest {
+                    hash: hex::encode([0x11u8; 32]),
+                    size_bytes: 7,
+                }),
+                ..Default::default()
+            }],
+            ..Default::default()
+        }
+        .encode_to_vec();
+        std::fs::write(&entry_path, &entry_bytes).expect("entry should write");
+        store
+            .apply_replicated_artifact_from_path(
+                ArtifactProducer::Reapi,
+                "ios",
+                &entry_key,
+                "application/octet-stream",
+                &entry_path,
+                100,
+            )
+            .await
+            .expect("entry should persist");
+        let blob_path = uploads.join("blob");
+        std::fs::write(&blob_path, b"payload").expect("blob should write");
+        store
+            .apply_replicated_artifact_from_path(
+                ArtifactProducer::Reapi,
+                "ios",
+                &blob_key(&format!("{}/7", hex::encode([0x11u8; 32]))),
+                "application/octet-stream",
+                &blob_path,
+                100,
+            )
+            .await
+            .expect("blob should persist");
+
+        // Build and cache the index once.
+        let first = service
+            .serve_actioncache_snapshot("ios", 0)
+            .await
+            .expect("first serve builds the index");
+        assert_eq!(&first[..4], b"TSNZ");
+
+        // Age the cached view past the freshness window so the next serve kicks
+        // a background reconcile, and exhaust the pool so that reconcile stalls
+        // rather than completing instantly.
+        {
+            let mut indexes = service.snapshot_cache.indexes.lock().unwrap();
+            let index = indexes
+                .get_mut("ios")
+                .expect("index cached after first serve");
+            index.reconciled_at = Instant::now()
+                .checked_sub(SNAPSHOT_RECONCILE_INTERVAL * 2)
+                .expect("test clock has headroom");
+        }
+        let pool = context.state.memory.reapi_materialization_pool_bytes();
+        let _hog = context
+            .state
+            .memory
+            .try_acquire_reapi_materialization(pool)
+            .expect("pool should be acquirable when idle");
+
+        // A stale serve with a reconcile it cannot complete (pool exhausted)
+        // must still return the cached view immediately — never UNAVAILABLE,
+        // never blocking on the build. This guards the contract the clone fix
+        // preserves: the reconcile builds against a copy, so the live index
+        // stays in the map and serveable for the build's whole duration rather
+        // than being taken out (the pre-fix remove-then-reinsert exposed a
+        // window where a concurrent serve found nothing and fell to the cold
+        // UNAVAILABLE path).
+        let stale = tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            service.serve_actioncache_snapshot("ios", 0),
+        )
+        .await
+        .expect("serve must not block on the stalled reconcile")
+        .expect("serve returns the cached view, not UNAVAILABLE");
+        assert_eq!(&stale[..4], b"TSNZ");
+        assert!(
+            service
+                .snapshot_cache
+                .indexes
+                .lock()
+                .unwrap()
+                .contains_key("ios"),
+            "the live index stays cached while a reconcile is outstanding"
+        );
     }
 
     #[tokio::test(start_paused = true)]


### PR DESCRIPTION
> [!NOTE]
> Draft pending clean perf validation. The demand-coalescer win is client-side and measurable against production; the compression win needs a branch-kura deploy (production is kura@0.16.4, which lacks the server side), same gate #11816 used. All three changes are tested and the client's old-server compat path is verified live.

## Context

After #11816 landed snapshots at tuist/tuist scale, a cold warm-remote Xcode-CAS build over the WAN measured **336s against an 87s local-CAS floor** — a real win (below the 411s no-cache baseline) but still ~4x the floor. Attribution of the remaining gap, from the proxy's per-interval counters on a cold rep:

- **~2,200 thread-seconds on the per-key ladder** for keys shed from the snapshot's 48 MiB recency window. tuist/tuist is written by all of CI; the wire body encodes newest-first, so the tail of older-but-still-live keys a given build needs falls out and each one costs a WAN round trip.
- **~5,700 thread-seconds fetching ~7,000 objects on demand**, one `BatchReadBlobs` round trip per object. When a compiler worker outruns the background materializer it self-heals through `OP_FETCH_OBJECT`, and those reads were issued one at a time.

And a third issue surfaced while validating: on a namespace this hot, a *cold* client got repeated `UNAVAILABLE` because the snapshot reconcile kept running (and exceeding the 15s cold-serve wait). This PR attacks all three.

## 1. Snapshot compression (kura + cli)

The server always emits the body zstd-wrapped in a `TSNZ` envelope. It includes keys up to a larger content budget (144 MiB uncompressed) and enforces the 48 MiB ceiling on the **compressed** wire size; a body that compresses worse than budgeted is re-encoded with a smaller budget scaled from the observed ratio, bounded to a few tries that can only converge on a provably-safe minimum, so it always terminates. The same wire budget now carries ~3x the keys, so the shed tail — and the per-key ladder it caused — shrinks toward nothing.

**No negotiation.** The snapshot protocol has only shipped in canary, so no stable client needs the uncompressed body, and an old client hitting a new server just returns `None` from decode and degrades to the per-key path — it never breaks. The one compat that matters is the reverse: kura is a rolling mesh (0.16.4 pods serve the old `TSNP` body mid-roll) and self-hosted nodes lag, so the **client decodes both** `TSNZ` and bare `TSNP` (with an allocation guard on the declared length). Verified live — this branch's client against production kura fetched and decoded the uncompressed snapshot.

## 2. Demand-fetch coalescing (cli)

Concurrent `OP_FETCH_OBJECT` blob reads for one instance now join a shared `BatchReadBlobs` through a leader/follower batcher. A leader drains everything pending into one batch while followers accumulate during its round trip, so the batch size self-clocks to the worker concurrency with no fixed linger on the steady-state path — the ~7,000 single reads collapse into far fewer batches. Each result is a one-shot mailbox, so two workers demanding the same digest at once may each fetch it (a rare redundant read) but never see a wrong or dropped result.

## 3. Serve the cached view during a reconcile (kura)

The serve fast path returns a cached (slightly-stale) view immediately and kicks a background reconcile only when the view ages past the freshness window — but the reconcile **removed** the index from the cache for its whole duration. Any serve that landed during a reconcile found nothing, fell to the cold path, and answered `UNAVAILABLE`; on a hot namespace where reconciles run back-to-back that window is a large fraction of the time. Now the reconcile builds against a **clone** and leaves the live index in place (swapping the result in on success, leaving it untouched on failure), so serves hit the stale-but-present view throughout. A fresh namespace's first-ever build still takes the cold path once. Cost: one extra index-sized copy per reconcile, bounded by the 100k-entry cap.

## Validation

- kura: full suite (343) + clippy green; tests round-trip the `TSNZ` envelope, and assert a stale serve returns the cached view (not `UNAVAILABLE`) while a reconcile is outstanding.
- cli: full plugin suite (32) green, no new clippy findings; tests decode both snapshot forms (rejecting torn/oversized payloads), and drive the coalescer under 8 concurrent threads (every hash fetched exactly once) plus missing/failure routing.
- Live compat: this branch's client fetched production's uncompressed `TSNP` and decoded it fine.
- Preliminary coalescer signal (against production, snapshot available): the populate leg went **433s → 382s** with ~7,480 demand fetches coalesced. A clean cold-slate rep and the compression win both need a branch-kura deploy for an uncontaminated number, tracked as the undraft gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)