### PR TITLE
fix(server): start Finch before background jobs

### DIFF
--- a/server/lib/tuist/application.ex
+++ b/server/lib/tuist/application.ex
@@ -309,10 +309,11 @@ defmodule Tuist.Application do
         Supervisor.child_spec(CASEvent.Buffer, id: CASEvent.Buffer),
         Supervisor.child_spec(DeliveryAttempt.Buffer, id: DeliveryAttempt.Buffer),
         Tuist.Vault,
+        # Queued jobs can run as soon as Oban starts, so their connection pool must already be available.
+        {Finch, name: Tuist.Finch, pools: finch_pools()},
         {Oban, Application.fetch_env!(:tuist, Oban)},
         {Cachex, [:tuist, []]},
         Cache,
-        {Finch, name: Tuist.Finch, pools: finch_pools()},
         {Phoenix.PubSub, name: Tuist.PubSub},
         {TuistWeb.RateLimit.InMemory, [clean_period: to_timeout(hour: 1)]},
         {Tuist.API.Pipeline, []},


### PR DESCRIPTION
## What changed

Finch now starts before Oban in the Tuist application supervision tree.

## Why

The standalone Swift registry synchronization pods can begin processing queued work immediately during startup. Those jobs use the shared Finch connection pool for GitHub requests.

This addresses the startup failure reported in [Sentry issue TUIST-1E7](https://tuist.sentry.io/issues/TUIST-1E7).

## Root cause

Oban previously started before Finch. When a synchronization pod had queued work waiting, a worker could make a request before `Tuist.Finch` had created its registry, producing `ArgumentError: unknown registry: Tuist.Finch`.

## Approach

Reorder the existing children so Finch is fully started before Oban can claim work. This keeps the same pool configuration and job behavior while removing the startup race for every application mode.

## Impact

Swift registry synchronization and release jobs no longer fail transiently when dedicated synchronization pods start. The ordering also protects other background jobs that use the shared connection pool during application startup. There is no migration or configuration change.

## Validation

- `mix format --check-formatted lib/tuist/application.ex`: passed.
- `mix test test/tuist/registry/swift/sync_worker_test.exs test/tuist/registry/swift/release_worker_test.exs`: 9 tests passed.
- `mix credo --strict lib/tuist/application.ex`: completed with one pre-existing design suggestion outside the changed lines.
- `git diff --check`: passed.

### How to test locally

From `server/`, run:

```sh
mix test test/tuist/registry/swift/sync_worker_test.exs test/tuist/registry/swift/release_worker_test.exs
```
