### PR TITLE
feat(search): surface GitHub releases in Tuist search

### DIFF
--- a/infra/helm/typesense/AGENTS.md
+++ b/infra/helm/typesense/AGENTS.md
@@ -20,6 +20,9 @@ agent search service will delegate to in a follow-up.
   (`typesense.searchKey`) on the instance using the admin key. Typesense stores
   non-bootstrap keys inside its own data, so a fresh volume needs this to accept
   the key the docs website and the `search_tuist` MCP tool present.
+- `typesense-release-indexer-bootstrap` runs after the key bootstrap on each
+  install or upgrade so the `github-releases` collection is available
+  immediately. The recurring indexer CronJob refreshes it daily afterward.
 - `Ingress` exposes `search.tuist.dev` through ingress-nginx with a
   cert-manager certificate. The production overlay annotates it
   `external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"` so external-dns
@@ -34,16 +37,16 @@ agent search service will delegate to in a follow-up.
 
 ## Collections
 
-Four collections back search, all populated in-cluster:
+Five collections back search, all populated in-cluster:
 
-- `projectdescription` (DocC API) and `github-issues` come from the
-  `typesense-indexers` CronJob (`index-docc`, `index-github`).
+- `projectdescription` (DocC API), `github-issues`, and `github-releases` come from the
+  `typesense-indexers` CronJob (`index-docc`, `index-github`, `index-github-releases`).
 - `tuist` (docs) and `forum-topics` (forum) come from the `typesense-scraper`
   CronJob (`typesense/docsearch-scraper` with the `docsearch-configs` ConfigMap).
 
 The public docs and forum search UI (`server/assets/docs/hooks/docs-search-hook.js`)
-queries `tuist` and `forum-topics`, so those two must exist on any instance that
-serves the UI. On a fresh volume the CronJobs run on their schedule; trigger them
+queries all five collections, so they must exist on any instance that serves the
+UI. On a fresh volume the CronJobs run on their schedule; trigger them
 once with `kubectl create job --from=cronjob/typesense-indexers` (and the
 scraper) to populate immediately.
 

--- a/infra/helm/typesense/AGENTS.md
+++ b/infra/helm/typesense/AGENTS.md
@@ -22,7 +22,9 @@ agent search service will delegate to in a follow-up.
   the key the docs website and the `search_tuist` MCP tool present.
 - `typesense-release-indexer-bootstrap` runs after the key bootstrap on each
   install or upgrade so the `github-releases` collection is available
-  immediately. The recurring indexer CronJob refreshes it daily afterward.
+  immediately when a GitHub token is configured. Tokenless installations skip
+  release indexing successfully. The recurring indexer CronJob refreshes it
+  daily afterward.
 - `Ingress` exposes `search.tuist.dev` through ingress-nginx with a
   cert-manager certificate. The production overlay annotates it
   `external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"` so external-dns

--- a/infra/helm/typesense/templates/release-indexer-bootstrap-job.yaml
+++ b/infra/helm/typesense/templates/release-indexer-bootstrap-job.yaml
@@ -1,0 +1,62 @@
+{{- if .Values.releaseIndexerBootstrap.enabled }}
+{{- $imageTag := required "image.tag is required" .Values.image.tag -}}
+{{- $nodeSelector := merge (dict) (.Values.global.nodeSelector | default (dict)) (.Values.nodeSelector | default (dict)) -}}
+{{- $tolerations := concat (.Values.global.tolerations | default (list)) (.Values.tolerations | default (list)) -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ printf "%s-release-indexer-bootstrap" (include "typesense.fullname" .) | trunc 63 | trimSuffix "-" }}
+  labels:
+    {{- include "typesense.labels" . | nindent 4 }}
+    app.kubernetes.io/component: search-release-indexer-bootstrap
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "1"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: {{ .Values.releaseIndexerBootstrap.backoffLimit }}
+  activeDeadlineSeconds: {{ .Values.releaseIndexerBootstrap.activeDeadlineSeconds }}
+  template:
+    metadata:
+      labels:
+        {{- include "typesense.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: search-release-indexer-bootstrap
+    spec:
+      restartPolicy: Never
+      serviceAccountName: {{ include "typesense.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
+      {{- include "typesense.podScheduling" . | nindent 6 }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: release-indexer
+          image: "{{ .Values.image.repository }}:{{ $imageTag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["/opt/docsearch/index-github-releases"]
+          securityContext:
+            {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+          env:
+            - name: TYPESENSE_HOST
+              value: {{ printf "http://%s:%v" (include "typesense.fullname" .) .Values.service.port | quote }}
+          envFrom:
+            - secretRef:
+                name: {{ include "typesense.runtimeSecretName" . }}
+          resources:
+            {{- toYaml .Values.releaseIndexerBootstrap.resources | nindent 12 }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}
+{{- end }}

--- a/infra/helm/typesense/values.yaml
+++ b/infra/helm/typesense/values.yaml
@@ -52,6 +52,14 @@ keyBootstrap:
   enabled: true
   backoffLimit: 3
 
+# Populates the release collection immediately after each install or upgrade.
+# The recurring indexer below keeps the same collection current afterward.
+releaseIndexerBootstrap:
+  enabled: true
+  backoffLimit: 1
+  activeDeadlineSeconds: 600
+  resources: {}
+
 # Recurring DocSearch crawl of the public docs site and community forum into the
 # `tuist` and `forum-topics` collections. Runs the typesense/docsearch-scraper
 # image against the in-cluster Service, reading the crawl configs from the
@@ -100,9 +108,10 @@ ingress:
   tlsSecretName: ""
   annotations: {}
 
-# Daily reindex of the two collections the bundled indexers own: the DocC API
-# reference (`projectdescription`, via index-docc) and `github-issues` (via
-# index-github). The `tuist` and `forum-topics` collections that the public docs
+# Daily reindex of the three collections the bundled indexers own: the DocC API
+# reference (`projectdescription`, via index-docc), `github-issues` (via
+# index-github), and `github-releases` (via index-github-releases). The `tuist`
+# and `forum-topics` collections that the public docs
 # and forum UI query are produced by the DocSearch scraper, not by these
 # indexers. The scraper is a separate crawler container and is not part of this
 # chart; it must be run against this service to populate those two collections

--- a/infra/helm/typesense/values.yaml
+++ b/infra/helm/typesense/values.yaml
@@ -52,7 +52,8 @@ keyBootstrap:
   enabled: true
   backoffLimit: 3
 
-# Populates the release collection immediately after each install or upgrade.
+# Populates the release collection immediately after each install or upgrade
+# when a GitHub token is configured. Tokenless installations skip successfully.
 # The recurring indexer below keeps the same collection current afterward.
 releaseIndexerBootstrap:
   enabled: true

--- a/search/AGENTS.md
+++ b/search/AGENTS.md
@@ -1,17 +1,16 @@
 # Tuist Search Service (TypeSense)
 
-This service powers full-text search for Tuist documentation, API references, community forum, and GitHub issues/PRs using TypeSense.
+This service powers full-text search for Tuist documentation, API references, community forum, GitHub issues and pull requests, and GitHub releases using TypeSense.
 
 ## Key Boundaries
 - TypeSense engine: deployed to Kubernetes via `infra/helm/typesense`, served at `search.tuist.dev`
 - DocSearch scraper configs: `search/config/docsearch*.json` (single source; the deploy workflow syncs them into the `docsearch-configs` ConfigMap)
-- Python indexers: `search/bin/index-docc.py`, `search/bin/index-github.py`
-- Indexer scripts baked into the image: `search/bin/index-docc`, `search/bin/index-github`, `search/bin/run-indexers.sh`
+- Indexer scripts baked into the image: `search/bin/index-docc`, `search/bin/index-github`, `search/bin/index-github-releases`, `search/bin/run-indexers.sh`
 
 ## Architecture
 - **TypeSense** (v27.1) stores and serves search data via API
 - **DocSearch scraper** crawls tuist.dev and community.tuist.dev, feeding the `tuist` and `forum-topics` collections
-- **Custom Python indexers** index ProjectDescription DocC API docs (`projectdescription`) and GitHub issues/PRs (`github-issues`)
+- **Custom indexers** index ProjectDescription DocC API docs (`projectdescription`), GitHub issues and pull requests (`github-issues`), and published GitHub releases (`github-releases`)
 - In the cluster, the DocC/GitHub indexers run as the `typesense-indexers` CronJob and the DocSearch scraper as the `typesense-scraper` CronJob; the read-only search key is registered on each deploy by the chart's key-bootstrap Job
 
 ## Deployment

--- a/search/Dockerfile
+++ b/search/Dockerfile
@@ -6,12 +6,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 COPY bin/index-docc /opt/docsearch/index-docc
 COPY bin/index-github /opt/docsearch/index-github
+COPY bin/index-github-releases /opt/docsearch/index-github-releases
 COPY bin/run-indexers.sh /opt/docsearch/run-indexers.sh
 COPY bin/entrypoint.sh /opt/docsearch/entrypoint.sh
 COPY config/docsearch.json /opt/docsearch/docsearch.json
 COPY config/docsearch-forum.json /opt/docsearch/docsearch-forum.json
 
-RUN chmod +x /opt/docsearch/index-docc /opt/docsearch/index-github \
+RUN chmod +x /opt/docsearch/index-docc /opt/docsearch/index-github /opt/docsearch/index-github-releases \
     /opt/docsearch/run-indexers.sh /opt/docsearch/entrypoint.sh
 
 ENTRYPOINT ["/opt/docsearch/entrypoint.sh"]

--- a/search/bin/index-github-releases
+++ b/search/bin/index-github-releases
@@ -2,13 +2,21 @@
 # Indexes published GitHub releases from tuist/tuist into Typesense.
 # Drafts and screenshot-only releases are excluded. Prereleases remain indexed
 # so agent searches can opt into them, while the docs search filters them out.
-# Requires TYPESENSE_API_KEY, TYPESENSE_HOST, and GITHUB_TOKEN environment variables.
+# Requires TYPESENSE_API_KEY and TYPESENSE_HOST when GITHUB_TOKEN is configured.
+# Tokenless installations skip this indexer because unauthenticated pagination
+# cannot retrieve the repository's full release history.
 set -euo pipefail
 
 GITHUB_REPO="tuist/tuist"
+GITHUB_TOKEN="${GITHUB_TOKEN:-}"
+
+if [ -z "$GITHUB_TOKEN" ]; then
+  echo "Skipping GitHub release indexing: GITHUB_TOKEN is not configured"
+  exit 0
+fi
+
 TYPESENSE_API_KEY="${TYPESENSE_API_KEY:?TYPESENSE_API_KEY is required}"
 TYPESENSE_HOST="${TYPESENSE_HOST:?TYPESENSE_HOST is required}"
-GITHUB_TOKEN="${GITHUB_TOKEN:?GITHUB_TOKEN is required to index more than 1000 releases}"
 COLLECTION="github-releases"
 
 DOCUMENTS_FILE=$(mktemp)

--- a/search/bin/index-github-releases
+++ b/search/bin/index-github-releases
@@ -1,0 +1,170 @@
+#!/bin/bash
+# Indexes published GitHub releases from tuist/tuist into Typesense.
+# Drafts and screenshot-only releases are excluded. Prereleases remain indexed
+# so agent searches can opt into them, while the docs search filters them out.
+# Requires TYPESENSE_API_KEY, TYPESENSE_HOST, and GITHUB_TOKEN environment variables.
+set -euo pipefail
+
+GITHUB_REPO="tuist/tuist"
+TYPESENSE_API_KEY="${TYPESENSE_API_KEY:?TYPESENSE_API_KEY is required}"
+TYPESENSE_HOST="${TYPESENSE_HOST:?TYPESENSE_HOST is required}"
+GITHUB_TOKEN="${GITHUB_TOKEN:?GITHUB_TOKEN is required to index more than 1000 releases}"
+COLLECTION="github-releases"
+
+DOCUMENTS_FILE=$(mktemp)
+SPLIT_DIR=""
+
+cleanup() {
+  rm -f "$DOCUMENTS_FILE"
+  if [ -n "$SPLIT_DIR" ]; then
+    rm -rf "$SPLIT_DIR"
+  fi
+}
+trap cleanup EXIT
+
+typesense_request() {
+  local method="$1" path="$2"
+  shift 2
+  curl -sf -X "$method" "${TYPESENSE_HOST}${path}" \
+    -H "X-TYPESENSE-API-KEY: ${TYPESENSE_API_KEY}" \
+    -H "Content-Type: application/json" \
+    "$@" || true
+}
+
+echo "Fetching releases from ${GITHUB_REPO}..."
+
+url="https://api.github.com/repos/${GITHUB_REPO}/releases?per_page=100"
+total=0
+
+while [ -n "$url" ]; do
+  response_file=$(mktemp)
+  header_file=$(mktemp)
+
+  http_code=$(curl -sS -w "%{http_code}" \
+    -H "Accept: application/vnd.github+json" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    -H "User-Agent: TuistSearchIndexer/1.0" \
+    -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+    -D "$header_file" \
+    -o "$response_file" \
+    "$url") || http_code="000"
+
+  if [ "$http_code" = "403" ]; then
+    reset=$(grep -i "x-ratelimit-reset" "$header_file" | tr -d '\r' | awk '{print $2}')
+    now=$(date +%s)
+    wait=$((reset - now))
+    [ "$wait" -lt 1 ] && wait=1
+    echo "Rate limited, waiting ${wait}s..." >&2
+    sleep "$wait"
+    rm -f "$response_file" "$header_file"
+    continue
+  fi
+
+  if [ "$http_code" != "200" ]; then
+    echo "GitHub releases request failed with status ${http_code}" >&2
+    rm -f "$response_file" "$header_file"
+    exit 1
+  fi
+
+  count=$(jq 'length' "$response_file")
+  if [ "$count" -eq 0 ]; then
+    rm -f "$response_file" "$header_file"
+    break
+  fi
+
+  jq -c '
+    def product_name:
+      (.name // "") as $name
+      | if $name == "" then
+          if (.tag_name | contains("@")) then (.tag_name | split("@")[0]) else "Tuist" end
+        else
+          ($name | sub("\\s+v?[0-9][^ ]*$"; "")) as $product
+          | if $product == "" then "Tuist" else $product end
+        end;
+
+    .[]
+    | select(.draft == false)
+    | select(((.name // "") | test("^PR #[0-9]+ screenshots$") | not))
+    | ([((.body // "") | scan("https://github\\.com/tuist/tuist/pull/[0-9]+") | split("/")[-1])] | unique | sort) as $pull_requests
+    | {
+        title: (.name // .tag_name),
+        content: ((.body // "")[:10000]),
+        url: .html_url,
+        version: .tag_name,
+        product: product_name,
+        prerelease: .prerelease,
+        published_at: ((.published_at // .created_at) | fromdateiso8601),
+        published_at_iso: (.published_at // .created_at),
+        pull_request_numbers: $pull_requests,
+        release_group: (
+          if ($pull_requests | length) > 0 then
+            "pull-requests:" + ($pull_requests | join(","))
+          else
+            "release:" + .tag_name
+          end
+        ),
+        "hierarchy.lvl0": "Releases",
+        "hierarchy.lvl1": product_name,
+        "hierarchy.lvl2": (.name // .tag_name)
+      }
+  ' "$response_file" >> "$DOCUMENTS_FILE"
+
+  total=$((total + count))
+  printf "  Fetched %d releases...\r" "$total"
+
+  url=$(grep -i '^link:' "$header_file" | tr ',' '\n' | grep 'rel="next"' | sed 's/.*<\(.*\)>.*/\1/' || echo "")
+  rm -f "$response_file" "$header_file"
+done
+
+echo "  Fetched ${total} releases     "
+
+doc_count=$(wc -l < "$DOCUMENTS_FILE" | tr -d ' ')
+if [ "$doc_count" -eq 0 ]; then
+  echo "No searchable releases were found; refusing to replace '${COLLECTION}'" >&2
+  exit 1
+fi
+echo "Prepared ${doc_count} documents"
+
+typesense_request DELETE "/collections/${COLLECTION}"
+
+typesense_request POST "/collections" -d '{
+  "name": "'"${COLLECTION}"'",
+  "default_sorting_field": "published_at",
+  "fields": [
+    {"name": "title", "type": "string"},
+    {"name": "content", "type": "string"},
+    {"name": "url", "type": "string", "index": false},
+    {"name": "version", "type": "string"},
+    {"name": "product", "type": "string", "facet": true},
+    {"name": "prerelease", "type": "bool", "facet": true},
+    {"name": "published_at", "type": "int64"},
+    {"name": "published_at_iso", "type": "string", "index": false},
+    {"name": "pull_request_numbers", "type": "string[]"},
+    {"name": "release_group", "type": "string", "facet": true},
+    {"name": "hierarchy.lvl0", "type": "string", "facet": true},
+    {"name": "hierarchy.lvl1", "type": "string", "facet": true},
+    {"name": "hierarchy.lvl2", "type": "string"}
+  ]
+}'
+echo "Created collection '${COLLECTION}'"
+
+total_success=0
+SPLIT_DIR=$(mktemp -d)
+split -l 250 "$DOCUMENTS_FILE" "${SPLIT_DIR}/batch_"
+
+for batch_file in "${SPLIT_DIR}"/batch_*; do
+  [ -f "$batch_file" ] || continue
+  result=$(curl -sf -X POST "${TYPESENSE_HOST}/collections/${COLLECTION}/documents/import?action=create" \
+    -H "X-TYPESENSE-API-KEY: ${TYPESENSE_API_KEY}" \
+    -H "Content-Type: text/plain" \
+    --data-binary @"$batch_file")
+  successes=$(echo "$result" | jq -r 'select(.success == true) | 1' | wc -l | tr -d ' ')
+  total_success=$((total_success + successes))
+done
+
+if [ "$total_success" -ne "$doc_count" ]; then
+  echo "Indexed ${total_success}/${doc_count} documents into '${COLLECTION}'" >&2
+  exit 1
+fi
+
+echo "Indexed ${total_success}/${doc_count} documents into '${COLLECTION}'"

--- a/search/bin/run-indexers.sh
+++ b/search/bin/run-indexers.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-# Runs all search indexers: DocC API reference and GitHub issues/PRs.
+# Runs all search indexers: DocC API reference, GitHub issues and pull requests,
+# and GitHub releases.
 # Called by cron inside the container. DocSearch scraper is excluded
 # because it requires a separate Docker container with network access.
 set -euo pipefail
@@ -11,3 +12,7 @@ echo "==> Done with DocC indexer"
 echo "==> Indexing GitHub issues and PRs..."
 /opt/docsearch/index-github
 echo "==> Done with GitHub indexer"
+
+echo "==> Indexing GitHub releases..."
+/opt/docsearch/index-github-releases
+echo "==> Done with GitHub releases indexer"

--- a/search/mise/tasks/test.sh
+++ b/search/mise/tasks/test.sh
@@ -6,6 +6,10 @@ set -euo pipefail
 IMAGE_NAME="tuist/search:test"
 CONTAINER_NAME="search-test-$$"
 
+echo "Verifying release indexing skips without a GitHub token..."
+skip_output=$(env -u GITHUB_TOKEN -u TYPESENSE_API_KEY -u TYPESENSE_HOST ./bin/index-github-releases)
+grep -Fq "Skipping GitHub release indexing: GITHUB_TOKEN is not configured" <<< "$skip_output"
+
 cleanup() { docker rm -f "$CONTAINER_NAME" 2>/dev/null || true; }
 trap cleanup EXIT
 

--- a/server/assets/docs/hooks/docs-search-hook.js
+++ b/server/assets/docs/hooks/docs-search-hook.js
@@ -16,6 +16,18 @@ const COLLECTIONS = [
     groupBy: "url_without_anchor",
   },
   {
+    name: "github-releases",
+    label: "Releases",
+    icon: "github",
+    external: true,
+    queryBy: "title,version,product,hierarchy.lvl0,hierarchy.lvl1,hierarchy.lvl2,content",
+    queryByWeights: "127,120,100,80,60,40,5",
+    groupBy: "release_group",
+    filterBy: "prerelease:=false",
+    sortBy: "_text_match:desc,published_at:desc",
+    perPage: 3,
+  },
+  {
     name: "projectdescription",
     label: "ProjectDescription",
     icon: "swift",
@@ -294,6 +306,8 @@ class DocsSearch {
           per_page: col.perPage || DEFAULT_PER_PAGE,
           ...(col.groupBy ? { group_by: col.groupBy, group_limit: 1 } : {}),
           ...(col.name === "tuist" ? { filter_by: `tags:=${locale}` } : {}),
+          ...(col.filterBy ? { filter_by: col.filterBy } : {}),
+          ...(col.sortBy ? { sort_by: col.sortBy } : {}),
         })),
       });
 

--- a/server/lib/tuist/mcp/components/tools/search_tuist.ex
+++ b/server/lib/tuist/mcp/components/tools/search_tuist.ex
@@ -1,7 +1,7 @@
 defmodule Tuist.MCP.Components.Tools.SearchTuist do
   @moduledoc """
-  Searches Tuist's documentation, API reference, community forum, and GitHub
-  issues through the Typesense search engine.
+  Searches Tuist's documentation, API reference, release notes, community forum,
+  and GitHub issues through the Typesense search engine.
   """
 
   use Tuist.MCP.Tool,
@@ -17,9 +17,13 @@ defmodule Tuist.MCP.Components.Tools.SearchTuist do
         },
         "source" => %{
           "type" => "string",
-          "enum" => ["docs", "api_reference", "forum", "issues"],
+          "enum" => ["docs", "api_reference", "releases", "forum", "issues"],
           "description" =>
-            "Restrict results to one source: docs, api_reference, forum, or issues. Searches all when omitted."
+            "Restrict results to one source: docs, api_reference, releases, forum, or issues. Searches all when omitted."
+        },
+        "include_prereleases" => %{
+          "type" => "boolean",
+          "description" => "Include prereleases when searching release notes. Defaults to false."
         },
         "max_results" => %{
           "type" => "integer",
@@ -41,11 +45,15 @@ defmodule Tuist.MCP.Components.Tools.SearchTuist do
             "properties" => %{
               "source" => %{
                 "type" => "string",
-                "enum" => ["docs", "api_reference", "forum", "issues"]
+                "enum" => ["docs", "api_reference", "releases", "forum", "issues"]
               },
               "title" => %{"type" => "string"},
               "url" => %{"type" => "string"},
-              "snippet" => %{"type" => "string"}
+              "snippet" => %{"type" => "string"},
+              "product" => %{"type" => "string"},
+              "version" => %{"type" => "string"},
+              "published_at" => %{"type" => "string"},
+              "prerelease" => %{"type" => "boolean"}
             },
             "required" => ["source", "title", "url", "snippet"],
             "additionalProperties" => false
@@ -60,7 +68,7 @@ defmodule Tuist.MCP.Components.Tools.SearchTuist do
 
   @impl EMCP.Tool
   def description do
-    "Search Tuist's documentation, API reference, community forum, and GitHub issues."
+    "Search Tuist's documentation, API reference, release notes, community forum, and GitHub issues."
   end
 
   def execute(_conn, arguments), do: Search.search(arguments)

--- a/server/lib/tuist/mcp/search.ex
+++ b/server/lib/tuist/mcp/search.ex
@@ -1,7 +1,7 @@
 defmodule Tuist.MCP.Search do
   @moduledoc """
-  Searches Tuist's documentation, API reference, community forum, and GitHub
-  issues through the Typesense search engine that also powers the docs website.
+  Searches Tuist's documentation, API reference, release notes, community forum,
+  and GitHub issues through the Typesense search engine that also powers the docs website.
 
   The collection set and per-collection query weights mirror
   `server/assets/docs/hooks/docs-search-hook.js` so the MCP tool and the website
@@ -14,6 +14,7 @@ defmodule Tuist.MCP.Search do
   @max_snippet_characters 320
   @default_max_results 8
   @max_results 20
+  @default_max_release_results 2
 
   @collections [
     %{
@@ -23,7 +24,17 @@ defmodule Tuist.MCP.Search do
         "hierarchy.lvl0,hierarchy.lvl1,hierarchy.lvl2,hierarchy.lvl3,hierarchy.lvl4,hierarchy.lvl5,hierarchy.lvl6,content",
       query_by_weights: "127,100,80,60,40,20,10,5",
       group_by: "url_without_anchor",
-      filter_by: "tags:=en"
+      filter_by: "tags:=en",
+      sort_by: nil
+    },
+    %{
+      name: "github-releases",
+      source: "releases",
+      query_by: "title,version,product,hierarchy.lvl0,hierarchy.lvl1,hierarchy.lvl2,content",
+      query_by_weights: "127,120,100,80,60,40,5",
+      group_by: "release_group",
+      filter_by: "prerelease:=false",
+      sort_by: "_text_match:desc,published_at:desc"
     },
     %{
       name: "projectdescription",
@@ -31,7 +42,8 @@ defmodule Tuist.MCP.Search do
       query_by: "title,hierarchy.lvl0,hierarchy.lvl1,hierarchy.lvl2,content",
       query_by_weights: "127,100,80,60,5",
       group_by: nil,
-      filter_by: nil
+      filter_by: nil,
+      sort_by: nil
     },
     %{
       name: "github-issues",
@@ -39,7 +51,8 @@ defmodule Tuist.MCP.Search do
       query_by: "title,hierarchy.lvl0,hierarchy.lvl1,content",
       query_by_weights: "127,100,80,5",
       group_by: nil,
-      filter_by: nil
+      filter_by: nil,
+      sort_by: nil
     },
     %{
       name: "forum-topics",
@@ -48,7 +61,8 @@ defmodule Tuist.MCP.Search do
         "hierarchy.lvl0,hierarchy.lvl1,hierarchy.lvl2,hierarchy.lvl3,hierarchy.lvl4,hierarchy.lvl5,hierarchy.lvl6,content",
       query_by_weights: "127,100,80,60,40,20,10,5",
       group_by: "url_without_anchor",
-      filter_by: nil
+      filter_by: nil,
+      sort_by: nil
     }
   ]
 
@@ -61,7 +75,7 @@ defmodule Tuist.MCP.Search do
     max_results = clamp_max_results(arguments["max_results"])
     collections = collections_for(arguments["source"])
 
-    body = %{"searches" => Enum.map(collections, &search_clause(&1, query, max_results))}
+    body = %{"searches" => Enum.map(collections, &search_clause(&1, query, max_results, arguments))}
 
     case Req.post(Environment.typesense_host() <> "/multi_search",
            json: body,
@@ -91,12 +105,14 @@ defmodule Tuist.MCP.Search do
   defp clamp_max_results(value) when is_integer(value) and value > 0, do: min(value, @max_results)
   defp clamp_max_results(_), do: @default_max_results
 
-  defp search_clause(collection, query, max_results) do
+  defp search_clause(collection, query, max_results, arguments) do
     %{
       "collection" => collection.name,
       "q" => query,
       "query_by" => collection.query_by,
       "query_by_weights" => collection.query_by_weights,
+      "highlight_fields" => "content",
+      "highlight_affix_num_tokens" => 24,
       # Fetch up to max_results per collection (already clamped to the advertised
       # cap) so a single-source search can reach that cap, and multi-source
       # searches have a wider candidate pool to rank across.
@@ -104,8 +120,12 @@ defmodule Tuist.MCP.Search do
     }
     |> maybe_put("group_by", collection.group_by)
     |> maybe_group_limit(collection.group_by)
-    |> maybe_put("filter_by", collection.filter_by)
+    |> maybe_put("filter_by", filter_by(collection, arguments))
+    |> maybe_put("sort_by", collection.sort_by)
   end
+
+  defp filter_by(%{source: "releases"}, %{"include_prereleases" => true}), do: nil
+  defp filter_by(collection, _arguments), do: collection.filter_by
 
   defp maybe_group_limit(clause, nil), do: clause
   defp maybe_group_limit(clause, _group_by), do: Map.put(clause, "group_limit", 1)
@@ -121,8 +141,28 @@ defmodule Tuist.MCP.Search do
       result |> hits() |> Enum.map(&to_result(&1, collection))
     end)
     |> Enum.sort_by(& &1["text_match"], :desc)
+    |> cap_release_results(length(collections) > 1)
     |> Enum.take(max_results)
     |> Enum.map(&Map.delete(&1, "text_match"))
+  end
+
+  defp cap_release_results(results, false), do: results
+
+  defp cap_release_results(results, true) do
+    {results, _release_count} =
+      Enum.reduce(results, {[], 0}, fn result, {kept, release_count} ->
+        if result["source"] == "releases" do
+          if release_count < @default_max_release_results do
+            {[result | kept], release_count + 1}
+          else
+            {kept, release_count}
+          end
+        else
+          {[result | kept], release_count}
+        end
+      end)
+
+    Enum.reverse(results)
   end
 
   defp hits(%{"grouped_hits" => grouped}) when is_list(grouped),
@@ -138,10 +178,14 @@ defmodule Tuist.MCP.Search do
       "source" => collection.source,
       "title" => title_for(document, collection),
       "url" => document["url"] || document["url_without_anchor"] || "",
-      "snippet" => snippet_for(document),
+      "snippet" => snippet_for(hit, document),
       # Kept only for ranking across collections; dropped before returning.
       "text_match" => Map.get(hit, "text_match", 0)
     }
+    |> maybe_put("product", present(document["product"]))
+    |> maybe_put("version", present(document["version"]))
+    |> maybe_put("published_at", present(document["published_at_iso"]))
+    |> maybe_put("prerelease", document["prerelease"])
   end
 
   defp title_for(document, %{name: name}) when name in ["tuist", "forum-topics"],
@@ -154,13 +198,27 @@ defmodule Tuist.MCP.Search do
     Enum.find_value(6..0//-1, fn level -> present(hierarchy["lvl#{level}"]) end)
   end
 
-  defp snippet_for(document) do
-    document
-    |> Map.get("content", "")
+  defp snippet_for(hit, document) do
+    hit
+    |> highlighted_content()
+    |> Kernel.||(Map.get(document, "content", ""))
     |> to_string()
+    |> String.replace(~r/<\/?mark>/, "")
     |> String.slice(0, @max_snippet_characters)
     |> String.trim()
   end
+
+  defp highlighted_content(%{"highlights" => highlights}) when is_list(highlights) do
+    Enum.find_value(highlights, fn
+      %{"field" => "content"} = highlight -> present(highlight["snippet"]) || present(highlight["value"])
+      _highlight -> nil
+    end)
+  end
+
+  defp highlighted_content(%{"highlight" => %{"content" => highlight}}) when is_map(highlight),
+    do: present(highlight["snippet"]) || present(highlight["value"])
+
+  defp highlighted_content(_hit), do: nil
 
   defp present(value) when is_binary(value) do
     trimmed = String.trim(value)

--- a/server/lib/tuist/mcp/server.ex
+++ b/server/lib/tuist/mcp/server.ex
@@ -64,7 +64,7 @@ defmodule Tuist.MCP.Server do
   def server do
     EMCP.Server.new(
       name: "tuist",
-      version: "1.10.0",
+      version: "1.11.0",
       tools: tools(),
       prompts: @prompts
     )

--- a/server/priv/docs/en/guides/features/agentic-coding/mcp.md
+++ b/server/priv/docs/en/guides/features/agentic-coding/mcp.md
@@ -122,11 +122,11 @@ Every tool publishes a human-readable description together with explicit input a
 
 #### Documentation and community search
 
-This read-only tool searches Tuist's documentation, API reference, community forum, and GitHub issues through the same search engine that powers the docs website. It is only available on the Tuist-hosted server at `https://tuist.dev/mcp`.
+This read-only tool searches Tuist's documentation, API reference, GitHub releases, community forum, and GitHub issues through the same search engine that powers the docs website. Release results include the product, version, publication date, and prerelease status. Stable releases are searched by default, and prereleases can be included with `include_prereleases`. The tool is only available on the Tuist-hosted server at `https://tuist.dev/mcp`.
 
 | Tool | Description | Required parameters |
 |------|-------------|---------------------|
-| `search_tuist` | Search Tuist's documentation, API reference, community forum, and GitHub issues. Optionally restrict to one `source` (`docs`, `api_reference`, `forum`, `issues`). | `query` |
+| `search_tuist` | Search Tuist's documentation, API reference, GitHub releases, community forum, and GitHub issues. Optionally restrict to one `source` (`docs`, `api_reference`, `releases`, `forum`, `issues`). | `query` |
 
 #### Projects
 

--- a/server/priv/marketing/changelog/2026.07.13-search-tuist-mcp-tool.md
+++ b/server/priv/marketing/changelog/2026.07.13-search-tuist-mcp-tool.md
@@ -1,8 +1,8 @@
 ---
 title: Search Tuist docs and community from your coding agent
-description: "The hosted Tuist MCP server now offers a search_tuist tool so coding agents can search Tuist's documentation, API reference, community forum, and GitHub issues."
+description: "The hosted Tuist MCP server now offers a search_tuist tool so coding agents can search Tuist's documentation, API reference, GitHub releases, community forum, and GitHub issues."
 category: "Product"
 pull_request: 11807
 ---
 
-Coding agents connected to the hosted Tuist [MCP](/en/guides/features/agentic-coding/mcp) endpoint can now use a **`search_tuist`** tool to search Tuist's documentation, ProjectDescription API reference, community forum, and GitHub issues in one call. It is backed by the same search engine that powers the docs website, returns cited links for every result, and can be scoped to a single source. Agents get grounded answers about Tuist without relying on stale training data.
+Coding agents connected to the hosted Tuist [MCP](/en/guides/features/agentic-coding/mcp) endpoint can now use a **`search_tuist`** tool to search Tuist's documentation, ProjectDescription API reference, GitHub releases, community forum, and GitHub issues in one call. Release results include product, version, and publication details, with prereleases available when requested. The tool is backed by the same search engine that powers the docs website, returns cited links for every result, and can be scoped to a single source. Agents get grounded answers about Tuist without relying on stale training data.

--- a/server/test/tuist/mcp/components/tools/search_tuist_test.exs
+++ b/server/test/tuist/mcp/components/tools/search_tuist_test.exs
@@ -46,4 +46,43 @@ defmodule Tuist.MCP.Components.Tools.SearchTuistTest do
              "isError" => true
            } = result
   end
+
+  test "returns structured release metadata" do
+    arguments = %{"query" => "result bundle", "source" => "releases"}
+
+    expect(Search, :search, fn ^arguments ->
+      {:ok,
+       %{
+         "query" => arguments["query"],
+         "results" => [
+           %{
+             "source" => "releases",
+             "title" => "CLI 4.202.2",
+             "url" => "https://github.com/tuist/tuist/releases/tag/4.202.2",
+             "snippet" => "Reassemble the requested result bundle.",
+             "product" => "CLI",
+             "version" => "4.202.2",
+             "published_at" => "2026-07-13T16:02:02Z",
+             "prerelease" => false
+           }
+         ]
+       }}
+    end)
+
+    result = SearchTuist.call(%Plug.Conn{}, arguments)
+
+    assert %{
+             "structuredContent" => %{
+               "results" => [
+                 %{
+                   "source" => "releases",
+                   "product" => "CLI",
+                   "version" => "4.202.2",
+                   "published_at" => "2026-07-13T16:02:02Z",
+                   "prerelease" => false
+                 }
+               ]
+             }
+           } = result
+  end
 end

--- a/server/test/tuist/mcp/search_test.exs
+++ b/server/test/tuist/mcp/search_test.exs
@@ -6,15 +6,28 @@ defmodule Tuist.MCP.SearchTest do
 
   defp hit(document, text_match), do: %{"document" => document, "text_match" => text_match}
 
-  test "queries all four collections and normalizes and ranks the hits" do
+  test "queries all five collections and normalizes and ranks the hits" do
     expect(Req, :post, fn url, opts ->
       assert String.ends_with?(url, "/multi_search")
       searches = opts[:json]["searches"]
-      assert Enum.map(searches, & &1["collection"]) == ["tuist", "projectdescription", "github-issues", "forum-topics"]
+
+      assert Enum.map(searches, & &1["collection"]) == [
+               "tuist",
+               "github-releases",
+               "projectdescription",
+               "github-issues",
+               "forum-topics"
+             ]
+
       # The docs collection is grouped and locale-filtered.
       docs = Enum.find(searches, &(&1["collection"] == "tuist"))
       assert docs["group_by"] == "url_without_anchor"
       assert docs["filter_by"] == "tags:=en"
+
+      releases = Enum.find(searches, &(&1["collection"] == "github-releases"))
+      assert releases["group_by"] == "release_group"
+      assert releases["filter_by"] == "prerelease:=false"
+      assert releases["sort_by"] == "_text_match:desc,published_at:desc"
 
       body = %{
         "results" => [
@@ -30,6 +43,27 @@ defmodule Tuist.MCP.SearchTest do
                     },
                     90
                   )
+                ]
+              }
+            ]
+          },
+          %{
+            "grouped_hits" => [
+              %{
+                "hits" => [
+                  %{
+                    "title" => "CLI 4.202.2",
+                    "content" => "Bug fixes: reassemble the requested result bundle across test schemes.",
+                    "url" => "https://github.com/tuist/tuist/releases/tag/4.202.2",
+                    "product" => "CLI",
+                    "version" => "4.202.2",
+                    "published_at_iso" => "2026-07-13T16:02:02Z",
+                    "prerelease" => false
+                  }
+                  |> hit(95)
+                  |> Map.put("highlights", [
+                    %{"field" => "content", "snippet" => "reassemble the requested <mark>result bundle</mark>"}
+                  ])
                 ]
               }
             ]
@@ -64,10 +98,17 @@ defmodule Tuist.MCP.SearchTest do
 
     assert {:ok, %{"query" => "caching", "results" => results}} = Search.search(%{"query" => "caching"})
 
-    # Ranked by text_match across collections: forum (99) > docs (90) > api (50).
-    assert Enum.map(results, & &1["source"]) == ["forum", "docs", "api_reference"]
-    assert Enum.map(results, & &1["title"]) == ["Caching help", "Selective testing", "Target"]
+    # Ranked by text_match across collections: forum (99) > releases (95) > docs (90) > api (50).
+    assert Enum.map(results, & &1["source"]) == ["forum", "releases", "docs", "api_reference"]
+    assert Enum.map(results, & &1["title"]) == ["Caching help", "CLI 4.202.2", "Selective testing", "Target"]
     assert hd(results)["url"] == "https://community.tuist.dev/t/caching/1"
+
+    release = Enum.find(results, &(&1["source"] == "releases"))
+    assert release["snippet"] == "reassemble the requested result bundle"
+    assert release["product"] == "CLI"
+    assert release["version"] == "4.202.2"
+    assert release["published_at"] == "2026-07-13T16:02:02Z"
+    assert release["prerelease"] == false
     refute Enum.any?(results, &Map.has_key?(&1, "text_match"))
   end
 
@@ -90,6 +131,58 @@ defmodule Tuist.MCP.SearchTest do
     end)
 
     assert {:ok, _} = Search.search(%{"query" => "cache", "source" => "issues", "max_results" => 20})
+  end
+
+  test "prereleases can be included for release-only searches" do
+    expect(Req, :post, fn _url, opts ->
+      [search] = opts[:json]["searches"]
+      assert search["collection"] == "github-releases"
+      refute Map.has_key?(search, "filter_by")
+      {:ok, %Req.Response{status: 200, body: %{"results" => [%{"grouped_hits" => []}]}}}
+    end)
+
+    assert {:ok, _} =
+             Search.search(%{
+               "query" => "4.203.0-canary.24",
+               "source" => "releases",
+               "include_prereleases" => true
+             })
+  end
+
+  test "an all-source search returns at most two releases" do
+    expect(Req, :post, fn _url, _opts ->
+      release_groups =
+        for version <- ["4.202.2", "4.202.1", "4.202.0"] do
+          %{
+            "hits" => [
+              hit(
+                %{
+                  "title" => "CLI #{version}",
+                  "content" => "Release notes",
+                  "url" => "https://github.com/tuist/tuist/releases/tag/#{version}"
+                },
+                100
+              )
+            ]
+          }
+        end
+
+      body = %{
+        "results" => [
+          %{"grouped_hits" => []},
+          %{"grouped_hits" => release_groups},
+          %{"hits" => []},
+          %{"hits" => []},
+          %{"grouped_hits" => []}
+        ]
+      }
+
+      {:ok, %Req.Response{status: 200, body: body}}
+    end)
+
+    assert {:ok, %{"results" => results}} = Search.search(%{"query" => "release notes"})
+    assert length(results) == 2
+    assert Enum.all?(results, &(&1["source"] == "releases"))
   end
 
   test "maps a non-200 response to an error" do


### PR DESCRIPTION
Adds GitHub release notes to Typesense and exposes them through the documentation search and the hosted [Model Context Protocol](https://modelcontextprotocol.io/) search tool. This makes behavior changes and fixes that live only in release notes discoverable alongside the existing documentation, ProjectDescription reference, community discussions, and GitHub issues.

## What changed

- Added an authenticated, paginated GitHub release indexer that excludes drafts and screenshot-only releases while retaining prerelease metadata.
- Added the `github-releases` Typesense collection to the daily indexing job and a post-install and post-upgrade Helm hook that populates the collection immediately after deployment.
- Added stable release results to the documentation search, grouped by their related pull requests so component releases do not crowd out other results.
- Added a `releases` source, structured release metadata, highlighted snippets, and the optional `include_prereleases` input to `search_tuist`.
- Updated the Model Context Protocol server version, documentation, tests, search intent files, and the existing customer-facing announcement.

## Why

Release notes often contain the clearest record of when a fix or behavior change shipped, but they were outside the search surface used by both people and coding agents. Indexing them closes that gap and lets a question about a shipped change return the release that actually introduced it.

## Approach

The indexer fetches every release with authenticated pagination because the repository has more than one thousand releases. It stores product, version, publication date, prerelease state, linked pull requests, and searchable release-note content. Releases that reference the same pull request set share a result group, which prevents parallel component releases from appearing as duplicates.

Stable releases are the default in both search surfaces. Prereleases remain indexed so an agent can opt into them explicitly. General agent searches return at most two release results, while a release-only search can use the full requested result limit. The deployment hook creates the collection immediately, and the existing scheduled job keeps it current afterward.

## Impact

People searching the Tuist documentation can discover stable release notes without leaving the search dialog. Coding agents connected to the hosted Model Context Protocol endpoint can search releases directly and receive product, version, publication date, and prerelease metadata. No migration or new public credential is required.

### How to test locally

Run the search image and script checks:

```sh
cd search
bash -n bin/index-github-releases bin/run-indexers.sh
mise run test
```

Run the focused server tests and build the documentation assets:

```sh
cd server
mix test test/tuist/mcp/search_test.exs test/tuist/mcp/components/tools/search_tuist_test.exs
mise run format --check
mix assets.build
```

## Validation

- A production-shaped indexing run fetched 2,048 GitHub releases and imported all 2,047 searchable documents. A search for `result bundle` returned grouped, stable release results in relevance and publication order.
- The focused server suite passes with nine tests.
- The search container builds and passes its health check.
- Helm renders and lints successfully with the release bootstrap both enabled and disabled.
- Formatting and the documentation asset build pass.
- Browser screenshot verification was not captured because the required in-app browser connection was unavailable in this session.
