### PR TITLE
fix(cli): use native Xcode macro dependencies

### DIFF
--- a/cli/Sources/TuistCore/Graph/GraphTraverser.swift
+++ b/cli/Sources/TuistCore/Graph/GraphTraverser.swift
@@ -27,7 +27,7 @@ public class GraphTraverser: GraphTraversing {
     private let graph: Graph
     private let conditionCache = ConditionCache()
     private let conditionalTargets: Set<GraphDependency>
-    private let swiftPluginExecutablesCache = GraphCache<GraphDependency, Set<String>>()
+    private let precompiledSwiftMacroExecutablesCache = GraphCache<GraphDependency, Set<String>>()
     private let systemFrameworkMetadataProvider: SystemFrameworkMetadataProviding =
         SystemFrameworkMetadataProvider()
     private let targetDirectTargetDependenciesCache: ThreadSafe<[GraphTarget: [GraphTarget]]> =
@@ -1166,9 +1166,8 @@ public class GraphTraverser: GraphTraversing {
         return allExternalTargets.subtracting(allTargetExternalDependendedUponTargets)
     }
 
-    // swiftlint:disable:next function_body_length
-    public func allSwiftPluginExecutables(path: Path.AbsolutePath, name: String) -> Set<String> {
-        if let cached = swiftPluginExecutablesCache[.target(name: name, path: path)] {
+    public func allPrecompiledSwiftMacroExecutables(path: Path.AbsolutePath, name: String) -> Set<String> {
+        if let cached = precompiledSwiftMacroExecutablesCache[.target(name: name, path: path)] {
             return cached
         } else {
             func precompiledMacroDependencies(_ graphDependency: GraphDependency) -> Set<
@@ -1220,21 +1219,8 @@ public class GraphTraverser: GraphTraversing {
             }
             .map { "\($0.pathString)#\($0.basename.replacingOccurrences(of: ".macro", with: ""))" }
 
-            let sourceMacroPluginExecutables = allSwiftMacroTargets(path: path, name: name)
-                .flatMap { target in
-                    directSwiftMacroExecutables(path: target.project.path, name: target.target.name).map
-                        { (target, $0) }
-                }
-                .compactMap { _, dependencyReference in
-                    switch dependencyReference {
-                    case let .product(_, productName, _, _):
-                        return "$BUILD_DIR/Debug$EFFECTIVE_PLATFORM_NAME/\(productName)#\(productName)"
-                    default:
-                        return nil
-                    }
-                }
-            let result = Set(precompiledMacroPluginExecutables + sourceMacroPluginExecutables)
-            swiftPluginExecutablesCache[.target(name: name, path: path)] = result
+            let result = Set(precompiledMacroPluginExecutables)
+            precompiledSwiftMacroExecutablesCache[.target(name: name, path: path)] = result
             return result
         }
     }

--- a/cli/Sources/TuistCore/GraphTraverser/GraphTraversing.swift
+++ b/cli/Sources/TuistCore/GraphTraverser/GraphTraversing.swift
@@ -319,16 +319,11 @@ public protocol GraphTraversing {
     /// - Returns: A set containing all the direct target dependencies that are external.
     func directTargetExternalDependencies(path: AbsolutePath, name: String) -> Set<GraphTargetReference>
 
-    /// It returns all the plugin executables to use for a given target. A plugin executable can represent a Swift Macro
-    /// executable to resolve macros.
-    ///
-    /// Executables are passed through the build setting "OTHER_SWIFT_FLAGS" and the flag "-load-plugin-executable {value}"
-    ///
-    ///
+    /// Returns all precompiled Swift macro executables used by a target or its transitive dependencies.
     /// - Parameters:
     ///   - path: Path to the directory that contains the project.
     ///   - name: Target name.
-    func allSwiftPluginExecutables(path: AbsolutePath, name: String) -> Set<String>
+    func allPrecompiledSwiftMacroExecutables(path: AbsolutePath, name: String) -> Set<String>
 
     /// Given a target's project path and name, it returns all XCFramework dependencies that linked by a dynamic XCFramework.
     /// - Parameters:

--- a/cli/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
+++ b/cli/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
@@ -80,22 +80,6 @@ struct BuildPhaseGenerator: BuildPhaseGenerating {
             )
         }
 
-        // Targets that depend on a Swift Macro have the following dependency graph:
-        // - Target -> MyMacro (Static framework) -> MyMacro (Executable)
-        // - or, in some cases, they directly depend on the executable: Target -> MyMacro (Executable)
-        //
-        // The executable is compiled transitively through the static library, and we place it inside the framework to make it
-        // available to the target depending on the framework
-        // to point it with the `-load-plugin-executable $(BUILD_DIR)/$(CONFIGURATION)/ExecutableName\#ExecutableName` build
-        // setting.
-        let directSwiftMacroExecutables = graphTraverser.directSwiftMacroExecutables(path: path, name: target.name).sorted()
-        try generateCopySwiftMacroExecutableScriptBuildPhase(
-            directSwiftMacroExecutables: directSwiftMacroExecutables,
-            target: target,
-            pbxTarget: pbxTarget,
-            pbxproj: pbxproj
-        )
-
         try await generateSourcesBuildPhase(
             files: target.sources,
             coreDataModels: target.coreDataModels,
@@ -501,78 +485,6 @@ struct BuildPhaseGenerator: BuildPhaseGenerating {
         case let .buildProduct(name, _, _):
             return "2:\(name)"
         }
-    }
-
-    private func generateCopySwiftMacroExecutableScriptBuildPhase(
-        directSwiftMacroExecutables: [GraphDependencyReference],
-        target: Target,
-        pbxTarget: PBXTarget,
-        pbxproj: PBXProj
-    ) throws {
-        if directSwiftMacroExecutables.isEmpty { return }
-
-        let copySwiftMacrosBuildPhase = PBXShellScriptBuildPhase(name: "Copy Swift Macro executable into $BUILT_PRODUCT_DIR")
-
-        let executableNames = directSwiftMacroExecutables.compactMap {
-            switch $0 {
-            case let .product(_, productName, _, _):
-                return productName
-            default:
-                return nil
-            }
-        }
-
-        let copyLines = executableNames.map {
-            """
-            if [[ -f "$BUILD_DIR/$CONFIGURATION/\($0)" ]]; then
-                mkdir -p "$BUILD_DIR/Debug$EFFECTIVE_PLATFORM_NAME/"
-                if [[ "$BUILD_DIR/$CONFIGURATION/\($0)" != "$BUILD_DIR/Debug$EFFECTIVE_PLATFORM_NAME/\($0)" ]]; then
-                    cp -f "$BUILD_DIR/$CONFIGURATION/\($0)" "$BUILD_DIR/Debug$EFFECTIVE_PLATFORM_NAME/\($0)"
-                fi
-            fi
-            """
-        }
-
-        copySwiftMacrosBuildPhase.inputPaths = executableNames.flatMap {
-            [
-                "$BUILD_DIR/$CONFIGURATION/\($0)",
-                "$(OBJROOT)/UninstalledProducts/macosx/\($0)",
-            ]
-        }
-
-        if target.supports(.macOS) {
-            // Declaring the actual destination paths as outputs would collide with
-            // the macro target's `Ld` step on native macOS builds (where
-            // `$EFFECTIVE_PLATFORM_NAME` is empty and both write to
-            // `$BUILD_DIR/Debug/<exe>`). Use a stamp file under `$DERIVED_FILE_DIR`
-            // (per-target / per-configuration / per-platform) so Xcode's
-            // incremental up-to-date check still works without colliding.
-            copySwiftMacrosBuildPhase.shellScript = """
-            #  This build phase serves two purposes:
-            #  - Force Xcode build system to compile the macOS executable transitively when compiling for non-macOS destinations
-            #  - Place the artifacts in the "Debug" directory where the built artifacts for the active destination live. We default to "Debug" because otherwise the Xcode editor fails to resolve the macro references.
-            \(copyLines.joined(separator: "\n"))
-            mkdir -p "$DERIVED_FILE_DIR"
-            touch "$DERIVED_FILE_DIR/copy-swift-macro.stamp"
-            """
-            copySwiftMacrosBuildPhase.outputPaths = ["$(DERIVED_FILE_DIR)/copy-swift-macro.stamp"]
-        } else {
-            copySwiftMacrosBuildPhase.shellScript = """
-            #  This build phase serves two purposes:
-            #  - Force Xcode build system to compile the macOS executable transitively when compiling for non-macOS destinations
-            #  - Place the artifacts in the "Debug" directory where the built artifacts for the active destination live. We default to "Debug" because otherwise the Xcode editor fails to resolve the macro references.
-            \(copyLines.joined(separator: "\n"))
-            """
-            copySwiftMacrosBuildPhase.outputPaths = executableNames.flatMap { executable in
-                [
-                    "$BUILD_DIR/Debug$EFFECTIVE_PLATFORM_NAME/\(executable)",
-                    "$BUILD_DIR/Debug-$EFFECTIVE_PLATFORM_NAME/\(executable)",
-                ]
-            }
-        }
-
-        pbxproj.add(object: copySwiftMacrosBuildPhase)
-        pbxTarget.buildPhases.append(copySwiftMacrosBuildPhase)
     }
 
     private func generateResourcesBuildFile(

--- a/cli/Sources/TuistGenerator/Generator/ConfigGenerator.swift
+++ b/cli/Sources/TuistGenerator/Generator/ConfigGenerator.swift
@@ -205,7 +205,7 @@ struct ConfigGenerator: ConfigGenerating {
         settingsHelper
             .extend(
                 buildSettings: &settings,
-                with: swiftMacrosDerivedSettings(
+                with: precompiledSwiftMacrosDerivedSettings(
                     target: target,
                     graphTraverser: graphTraverser,
                     projectPath: project.path
@@ -290,6 +290,7 @@ struct ConfigGenerator: ConfigGenerating {
         ) { $1 }
         settings.merge(destinationsDerivedSettings(target: target)) { $1 }
         settings.merge(deploymentTargetDerivedSettings(target: target)) { $1 }
+        settings.merge(swiftMacroImplementationDerivedSettings(target: target)) { $1 }
         settings
             .merge(watchTargetDerivedSettings(target: target, graphTraverser: graphTraverser, projectPath: project.path)) { $1 }
     }
@@ -368,17 +369,28 @@ struct ConfigGenerator: ConfigGenerating {
         return settings
     }
 
-    private func swiftMacrosDerivedSettings(
+    private func precompiledSwiftMacrosDerivedSettings(
         target: Target,
         graphTraverser: GraphTraversing,
         projectPath: AbsolutePath
     ) -> SettingsDictionary {
-        let pluginExecutables = graphTraverser.allSwiftPluginExecutables(path: projectPath, name: target.name)
+        let macroExecutables = graphTraverser.allPrecompiledSwiftMacroExecutables(path: projectPath, name: target.name)
         var settings: SettingsDictionary = [:]
-        if pluginExecutables.isEmpty { return settings }
-        let swiftCompilerFlags = pluginExecutables.sorted().flatMap { ["-load-plugin-executable", $0] }
-        settings["OTHER_SWIFT_FLAGS"] = .array(swiftCompilerFlags)
+        if macroExecutables.isEmpty { return settings }
+        settings["SWIFT_LOAD_BINARY_MACROS"] = .array(macroExecutables.sorted())
         return settings
+    }
+
+    private func swiftMacroImplementationDerivedSettings(target: Target) -> SettingsDictionary {
+        guard target.product == .macro else { return [:] }
+        return [
+            "EAGER_COMPILATION_DISABLE": "YES",
+            "SDKROOT": "auto",
+            "SKIP_BUILDING_DOCUMENTATION": "YES",
+            "SUPPORTED_PLATFORMS": "$(HOST_PLATFORM)",
+            "SWIFT_IMPLEMENTS_MACROS_FOR_MODULE_NAMES": "$(PRODUCT_MODULE_NAME)",
+            "SWIFT_INSTALL_MODULE": "NO",
+        ]
     }
 
     private func destinationsDerivedSettings(target: Target) -> SettingsDictionary {

--- a/cli/Sources/TuistGenerator/Generator/CrossProjectTargetDependencyGenerator.swift
+++ b/cli/Sources/TuistGenerator/Generator/CrossProjectTargetDependencyGenerator.swift
@@ -4,39 +4,36 @@ import TuistCore
 import XcodeGraph
 import XcodeProj
 
-/// Wires cross-project `PBXTargetDependency` edges for consumers that depend on a
-/// `foreignBuild()` aggregate located in another project.
+/// Wires cross-project target dependencies that Xcode cannot infer from product references.
 ///
-/// `foreignBuild()` aggregates produce no product under `BUILT_PRODUCTS_DIR`, so Xcode's implicit
-/// dependency discovery (which walks framework references and product paths) does not pick them
-/// up across project boundaries. Without an explicit cross-project `PBXTargetDependency`, the
-/// aggregate's build script is never invoked when the consumer is built, and the consumer keeps
-/// linking the stale artifact even after the foreign sources change.
+/// Foreign build aggregates produce no product that Xcode can use for implicit dependency discovery.
+/// Swift macro implementations need an explicit target edge so Xcode can discover and propagate their
+/// native macro metadata. This generator adds those edges when the dependency lives in another project.
 ///
-/// For each cross-project edge `(consumer -> foreign-build aggregate)` this generator adds the
+/// For each cross-project edge this generator adds the
 /// following to the consumer's pbxproj:
 ///
 /// - A `PBXFileReference` to the remote `.xcodeproj` (deduplicated per remote project).
 /// - A `PBXProject.projects` entry pairing that reference with an (empty) Products `PBXGroup`.
 /// - A `PBXContainerItemProxy` with `proxyType = .nativeTarget`,
 ///   `containerPortal = .fileReference(<remote .xcodeproj ref>)`, and
-///   `remoteGlobalID = .object(<remote aggregate>)`.
+///   `remoteGlobalID = .object(<remote target>)`.
 /// - A `PBXTargetDependency` wrapping the proxy, appended to the consumer target's
 ///   `dependencies`.
 ///
 /// XcodeProj's `ReferenceGenerator` assigns deterministic UUIDs lazily at encode time. The
 /// consumer pbxproj serializes the proxy's `remoteGlobalIDString` from the remote target's
-/// reference value, so we eagerly encode each aggregate-bearing pbxproj once up front to fix
-/// its UUIDs. When the writer later writes the consumer pbxproj, the proxy resolves to the
+/// reference value, so we eagerly encode each dependency pbxproj once up front to fix its
+/// UUIDs. When the writer later writes the consumer pbxproj, the proxy resolves to the
 /// stable remote UUID instead of the temporary placeholder.
-protocol ForeignBuildCrossProjectDependencyGenerating {
+protocol CrossProjectTargetDependencyGenerating {
     func generate(
         graphTraverser: GraphTraversing,
         projectDescriptors: [ProjectDescriptor]
     ) throws
 }
 
-struct ForeignBuildCrossProjectDependencyGenerator: ForeignBuildCrossProjectDependencyGenerating {
+struct CrossProjectTargetDependencyGenerator: CrossProjectTargetDependencyGenerating {
     func generate(
         graphTraverser: GraphTraversing,
         projectDescriptors: [ProjectDescriptor]
@@ -45,8 +42,8 @@ struct ForeignBuildCrossProjectDependencyGenerator: ForeignBuildCrossProjectDepe
         let edges = collectEdges(graphTraverser: graphTraverser)
         guard !edges.isEmpty else { return }
 
-        let aggregateProjectPaths = Set(edges.map(\.aggregateProjectPath))
-        for path in aggregateProjectPaths.sorted() {
+        let dependencyProjectPaths = Set(edges.map(\.dependencyProjectPath))
+        for path in dependencyProjectPaths.sorted() {
             guard let descriptor = descriptorsByPath[path] else { continue }
             _ = try descriptor.xcodeProj.pbxproj.dataRepresentation(outputSettings: PBXOutputSettings())
         }
@@ -65,8 +62,8 @@ struct ForeignBuildCrossProjectDependencyGenerator: ForeignBuildCrossProjectDepe
     private struct Edge: Hashable {
         let consumerProjectPath: AbsolutePath
         let consumerTargetName: String
-        let aggregateProjectPath: AbsolutePath
-        let aggregateTargetName: String
+        let dependencyProjectPath: AbsolutePath
+        let dependencyTargetName: String
         let condition: PlatformCondition?
     }
 
@@ -82,20 +79,23 @@ struct ForeignBuildCrossProjectDependencyGenerator: ForeignBuildCrossProjectDepe
                 guard target.foreignBuild == nil else { continue }
                 for reference in graphTraverser.directTargetDependencies(path: consumerPath, name: target.name) {
                     guard reference.graphTarget.path != consumerPath else { continue }
-                    guard reference.graphTarget.target.foreignBuild != nil else { continue }
+                    guard reference.graphTarget.target.foreignBuild != nil || reference.graphTarget.target.product == .macro
+                    else {
+                        continue
+                    }
                     edges.insert(Edge(
                         consumerProjectPath: consumerPath,
                         consumerTargetName: target.name,
-                        aggregateProjectPath: reference.graphTarget.path,
-                        aggregateTargetName: reference.graphTarget.target.name,
+                        dependencyProjectPath: reference.graphTarget.path,
+                        dependencyTargetName: reference.graphTarget.target.name,
                         condition: reference.condition
                     ))
                 }
             }
         }
         return edges.sorted { lhs, rhs in
-            (lhs.consumerProjectPath, lhs.consumerTargetName, lhs.aggregateProjectPath, lhs.aggregateTargetName)
-                < (rhs.consumerProjectPath, rhs.consumerTargetName, rhs.aggregateProjectPath, rhs.aggregateTargetName)
+            (lhs.consumerProjectPath, lhs.consumerTargetName, lhs.dependencyProjectPath, lhs.dependencyTargetName)
+                < (rhs.consumerProjectPath, rhs.consumerTargetName, rhs.dependencyProjectPath, rhs.dependencyTargetName)
         }
     }
 
@@ -106,7 +106,7 @@ struct ForeignBuildCrossProjectDependencyGenerator: ForeignBuildCrossProjectDepe
         fileRefCache: inout [FileRefKey: PBXFileReference]
     ) throws {
         guard let consumerDescriptor = descriptorsByPath[edge.consumerProjectPath],
-              let aggregateDescriptor = descriptorsByPath[edge.aggregateProjectPath],
+              let dependencyDescriptor = descriptorsByPath[edge.dependencyProjectPath],
               let consumerXcodeGraphTarget = graphTraverser.target(
                   path: edge.consumerProjectPath,
                   name: edge.consumerTargetName
@@ -114,29 +114,29 @@ struct ForeignBuildCrossProjectDependencyGenerator: ForeignBuildCrossProjectDepe
         else { return }
 
         let consumerPbxproj = consumerDescriptor.xcodeProj.pbxproj
-        let aggregatePbxproj = aggregateDescriptor.xcodeProj.pbxproj
+        let dependencyPbxproj = dependencyDescriptor.xcodeProj.pbxproj
 
         guard let consumerProject = consumerPbxproj.projects.first,
               let consumerTarget = consumerPbxproj.nativeTargets
               .first(where: { $0.name == edge.consumerTargetName }),
-              let aggregateTarget = aggregateTarget(named: edge.aggregateTargetName, in: aggregatePbxproj)
+              let dependencyTarget = target(named: edge.dependencyTargetName, in: dependencyPbxproj)
         else { return }
 
         let remoteProjectRef = remoteProjectFileReference(
             consumerProject: consumerProject,
             consumerPbxproj: consumerPbxproj,
             consumerXcodeprojDirectory: consumerDescriptor.xcodeprojPath.parentDirectory,
-            remoteXcodeprojPath: aggregateDescriptor.xcodeprojPath,
+            remoteXcodeprojPath: dependencyDescriptor.xcodeprojPath,
             cacheKey: FileRefKey(
                 consumerProjectPath: edge.consumerProjectPath,
-                remoteXcodeprojPath: aggregateDescriptor.xcodeprojPath
+                remoteXcodeprojPath: dependencyDescriptor.xcodeprojPath
             ),
             cache: &fileRefCache
         )
 
         if consumerTarget.dependencies.contains(where: { dependency in
             guard let proxy = dependency.targetProxy else { return false }
-            return proxy.remoteInfo == edge.aggregateTargetName
+            return proxy.remoteInfo == edge.dependencyTargetName
                 && proxy.containerPortal == .fileReference(remoteProjectRef)
         }) {
             return
@@ -144,19 +144,19 @@ struct ForeignBuildCrossProjectDependencyGenerator: ForeignBuildCrossProjectDepe
 
         let proxy = PBXContainerItemProxy(
             containerPortal: .fileReference(remoteProjectRef),
-            remoteGlobalID: .object(aggregateTarget),
+            remoteGlobalID: .object(dependencyTarget),
             proxyType: .nativeTarget,
-            remoteInfo: edge.aggregateTargetName
+            remoteInfo: edge.dependencyTargetName
         )
         consumerPbxproj.add(object: proxy)
 
-        let dependency = PBXTargetDependency(name: edge.aggregateTargetName, targetProxy: proxy)
+        let dependency = PBXTargetDependency(name: edge.dependencyTargetName, targetProxy: proxy)
         dependency.applyCondition(edge.condition, applicableTo: consumerXcodeGraphTarget)
         consumerPbxproj.add(object: dependency)
         consumerTarget.dependencies.append(dependency)
     }
 
-    private func aggregateTarget(named name: String, in pbxproj: PBXProj) -> PBXTarget? {
+    private func target(named name: String, in pbxproj: PBXProj) -> PBXTarget? {
         if let native = pbxproj.nativeTargets.first(where: { $0.name == name }) {
             return native
         }

--- a/cli/Sources/TuistGenerator/Generator/WorkspaceDescriptorGenerator.swift
+++ b/cli/Sources/TuistGenerator/Generator/WorkspaceDescriptorGenerator.swift
@@ -49,7 +49,7 @@ struct WorkspaceDescriptorGenerator: WorkspaceDescriptorGenerating {
     private let workspaceStructureGenerator: WorkspaceStructureGenerating
     private let schemeDescriptorsGenerator: SchemeDescriptorsGenerating
     private let workspaceSettingsGenerator: WorkspaceSettingsDescriptorGenerating
-    private let foreignBuildCrossProjectDependencyGenerator: ForeignBuildCrossProjectDependencyGenerating
+    private let crossProjectTargetDependencyGenerator: CrossProjectTargetDependencyGenerating
     private let fileSystem: FileSysteming
     private let config: Config
 
@@ -71,7 +71,7 @@ struct WorkspaceDescriptorGenerator: WorkspaceDescriptorGenerating {
             workspaceStructureGenerator: WorkspaceStructureGenerator(),
             schemeDescriptorsGenerator: SchemeDescriptorsGenerator(),
             workspaceSettingsGenerator: WorkspaceSettingsDescriptorGenerator(),
-            foreignBuildCrossProjectDependencyGenerator: ForeignBuildCrossProjectDependencyGenerator(),
+            crossProjectTargetDependencyGenerator: CrossProjectTargetDependencyGenerator(),
             config: config,
             fileSystem: fileSystem
         )
@@ -82,8 +82,8 @@ struct WorkspaceDescriptorGenerator: WorkspaceDescriptorGenerating {
         workspaceStructureGenerator: WorkspaceStructureGenerating,
         schemeDescriptorsGenerator: SchemeDescriptorsGenerating,
         workspaceSettingsGenerator: WorkspaceSettingsDescriptorGenerating,
-        foreignBuildCrossProjectDependencyGenerator: ForeignBuildCrossProjectDependencyGenerating =
-            ForeignBuildCrossProjectDependencyGenerator(),
+        crossProjectTargetDependencyGenerator: CrossProjectTargetDependencyGenerating =
+            CrossProjectTargetDependencyGenerator(),
         config: Config = .default,
         fileSystem: FileSysteming = FileSystem()
     ) {
@@ -91,7 +91,7 @@ struct WorkspaceDescriptorGenerator: WorkspaceDescriptorGenerating {
         self.workspaceStructureGenerator = workspaceStructureGenerator
         self.schemeDescriptorsGenerator = schemeDescriptorsGenerator
         self.workspaceSettingsGenerator = workspaceSettingsGenerator
-        self.foreignBuildCrossProjectDependencyGenerator = foreignBuildCrossProjectDependencyGenerator
+        self.crossProjectTargetDependencyGenerator = crossProjectTargetDependencyGenerator
         self.fileSystem = fileSystem
         self.config = config
     }
@@ -118,8 +118,8 @@ struct WorkspaceDescriptorGenerator: WorkspaceDescriptorGenerating {
             .sorted(by: { $0.path < $1.path })
         Logger.current.debug("Finished concurrent generation of \(projects.count) projects")
 
-        Logger.current.debug("Wiring cross-project foreign build dependencies")
-        try foreignBuildCrossProjectDependencyGenerator.generate(
+        Logger.current.debug("Wiring explicit cross-project target dependencies")
+        try crossProjectTargetDependencyGenerator.generate(
             graphTraverser: graphTraverser,
             projectDescriptors: projects
         )

--- a/cli/Tests/TuistCoreTests/Graph/GraphTraverserTests.swift
+++ b/cli/Tests/TuistCoreTests/Graph/GraphTraverserTests.swift
@@ -5794,7 +5794,8 @@ final class GraphTraverserTests: TuistUnitTestCase {
         ]))
     }
 
-    func test_allSwiftPluginExecutables_includesAllXCFrameworkMacros_when_theyAreDirectOrTransitiveDependencies() throws {
+    func test_allPrecompiledSwiftMacroExecutables_includesAllXCFrameworkMacros_when_theyAreDirectOrTransitiveDependencies(
+    ) throws {
         // Given
         let directory = try temporaryPath()
         let appTarget = Target.test(name: "App", destinations: [.appleWatch])
@@ -5815,14 +5816,17 @@ final class GraphTraverserTests: TuistUnitTestCase {
         )
 
         // When
-        let got = GraphTraverser(graph: graph).allSwiftPluginExecutables(path: project.path, name: appTarget.name)
+        let got = GraphTraverser(graph: graph).allPrecompiledSwiftMacroExecutables(
+            path: project.path,
+            name: appTarget.name
+        )
 
         XCTAssertEqual(got.sorted(), [
             "\(macroPath.pathString)#\(macroPath.basename.replacingOccurrences(of: ".macro", with: ""))",
         ])
     }
 
-    func test_allSwiftPluginExecutables_staticFrameworksThatDependOnMacroTargets_when_theyAreDirectOrTransitiveDependencies(
+    func test_allPrecompiledSwiftMacroExecutables_excludesSourceMacroTargets(
     ) throws {
         // Given
         let directory = try temporaryPath()
@@ -5880,15 +5884,15 @@ final class GraphTraverserTests: TuistUnitTestCase {
         )
 
         // When
-        let got = GraphTraverser(graph: graph).allSwiftPluginExecutables(path: project.path, name: appTarget.name)
+        let got = GraphTraverser(graph: graph).allPrecompiledSwiftMacroExecutables(
+            path: project.path,
+            name: appTarget.name
+        )
 
-        XCTAssertEqual(got.sorted(), [
-            "$BUILD_DIR/Debug$EFFECTIVE_PLATFORM_NAME/DirectMacro#DirectMacro",
-            "$BUILD_DIR/Debug$EFFECTIVE_PLATFORM_NAME/TransitiveMacro#TransitiveMacro",
-        ])
+        XCTAssertEqual(got, [])
     }
 
-    func test_allSwiftPluginExecutables_when_staticMacroFrameworkThatDependOnMacroPrecompiledExecutable(
+    func test_allPrecompiledSwiftMacroExecutables_when_staticMacroFrameworkDependsOnPrecompiledMacroExecutable(
     ) throws {
         // Given
         let directory = try temporaryPath()
@@ -5921,7 +5925,10 @@ final class GraphTraverserTests: TuistUnitTestCase {
         )
 
         // When
-        let got = GraphTraverser(graph: graph).allSwiftPluginExecutables(path: project.path, name: appTarget.name)
+        let got = GraphTraverser(graph: graph).allPrecompiledSwiftMacroExecutables(
+            path: project.path,
+            name: appTarget.name
+        )
 
         // Then
         XCTAssertEqual(got.sorted(), [

--- a/cli/Tests/TuistGeneratorTests/Generator/BuildPhaseGeneratorTests.swift
+++ b/cli/Tests/TuistGeneratorTests/Generator/BuildPhaseGeneratorTests.swift
@@ -2164,7 +2164,7 @@ struct BuildPhaseGeneratorTests {
         .withMockedSwiftVersionProvider,
         .withMockedXcodeController,
         .inTemporaryDirectory
-    ) func generateLinks_generatesAShellScriptBuildPhase_when_targetIsAMacroFramework() async throws {
+    ) func generateBuildPhases_doesntGenerateACopyScript_when_targetDependsOnAMacro() async throws {
         // Given
         let app = Target.test(name: "app", platform: .iOS, product: .app)
         let macroFramework = Target.test(name: "framework", platform: .iOS, product: .staticFramework)
@@ -2200,33 +2200,14 @@ struct BuildPhaseGeneratorTests {
             .compactMap { $0 as? PBXShellScriptBuildPhase }
             .first(where: { $0.name() == "Copy Swift Macro executable into $BUILT_PRODUCT_DIR" })
 
-        #expect(buildPhase != nil)
-
-        let expectedScript =
-            "if [[ -f \"$BUILD_DIR/$CONFIGURATION/macro\" ]]; then\n    mkdir -p \"$BUILD_DIR/Debug$EFFECTIVE_PLATFORM_NAME/\"\n    if [[ \"$BUILD_DIR/$CONFIGURATION/macro\" != \"$BUILD_DIR/Debug$EFFECTIVE_PLATFORM_NAME/macro\" ]]; then\n        cp -f \"$BUILD_DIR/$CONFIGURATION/macro\" \"$BUILD_DIR/Debug$EFFECTIVE_PLATFORM_NAME/macro\"\n    fi\nfi"
-        #expect(buildPhase?.shellScript?.contains(expectedScript) == true)
-        #expect(
-            buildPhase?.inputPaths ==
-                [
-                    "$BUILD_DIR/$CONFIGURATION/\(macroExecutable.productName)",
-                    "$(OBJROOT)/UninstalledProducts/macosx/\(macroExecutable.productName)",
-                ]
-        )
-        #expect(
-            buildPhase?.outputPaths ==
-                [
-                    "$BUILD_DIR/Debug$EFFECTIVE_PLATFORM_NAME/\(macroExecutable.productName)",
-                    "$BUILD_DIR/Debug-$EFFECTIVE_PLATFORM_NAME/\(macroExecutable.productName)",
-                ]
-        )
-        #expect(buildPhase?.alwaysOutOfDate == false)
+        #expect(buildPhase == nil)
     }
 
     @Test(
         .withMockedSwiftVersionProvider,
         .withMockedXcodeController,
         .inTemporaryDirectory
-    ) func generateLinks_generatesStampFileShellScriptBuildPhase_when_macroFrameworkIsExclusiveToMacOS() async throws {
+    ) func generateBuildPhases_doesntGenerateACopyScript_when_macroFrameworkIsExclusiveToMacOS() async throws {
         // Given
         let app = Target.test(name: "app", platform: .macOS, product: .app)
         let macroFramework = Target.test(name: "framework", platform: .macOS, product: .staticFramework)
@@ -2262,16 +2243,14 @@ struct BuildPhaseGeneratorTests {
             .compactMap { $0 as? PBXShellScriptBuildPhase }
             .first(where: { $0.name() == "Copy Swift Macro executable into $BUILT_PRODUCT_DIR" })
 
-        #expect(buildPhase?.outputPaths == ["$(DERIVED_FILE_DIR)/copy-swift-macro.stamp"])
-        #expect(buildPhase?.alwaysOutOfDate == false)
-        #expect(buildPhase?.shellScript?.contains("touch \"$DERIVED_FILE_DIR/copy-swift-macro.stamp\"") == true)
+        #expect(buildPhase == nil)
     }
 
     @Test(
         .withMockedSwiftVersionProvider,
         .withMockedXcodeController,
         .inTemporaryDirectory
-    ) func generateLinks_generatesStampFileShellScriptBuildPhase_when_macroFrameworkIsMixedDestination() async throws {
+    ) func generateBuildPhases_doesntGenerateACopyScript_when_macroFrameworkHasMixedDestinations() async throws {
         // Given
         let app = Target.test(name: "app", destinations: [.iPhone, .mac], product: .app)
         let macroFramework = Target.test(name: "framework", destinations: [.iPhone, .mac], product: .staticFramework)
@@ -2307,9 +2286,7 @@ struct BuildPhaseGeneratorTests {
             .compactMap { $0 as? PBXShellScriptBuildPhase }
             .first(where: { $0.name() == "Copy Swift Macro executable into $BUILT_PRODUCT_DIR" })
 
-        #expect(buildPhase?.outputPaths == ["$(DERIVED_FILE_DIR)/copy-swift-macro.stamp"])
-        #expect(buildPhase?.alwaysOutOfDate == false)
-        #expect(buildPhase?.shellScript?.contains("touch \"$DERIVED_FILE_DIR/copy-swift-macro.stamp\"") == true)
+        #expect(buildPhase == nil)
     }
 
     // MARK: - Helpers

--- a/cli/Tests/TuistGeneratorTests/Generator/ConfigGeneratorTests.swift
+++ b/cli/Tests/TuistGeneratorTests/Generator/ConfigGeneratorTests.swift
@@ -1196,7 +1196,7 @@ struct ConfigGeneratorTests {
     @Test(
         .withMockedXcodeController,
         .inTemporaryDirectory
-    ) func generateTargetConfig_addsTheLoadPluginExecutableSwiftFlag_when_tagetDependsOnMacroStaticFramework(
+    ) func generateTargetConfig_doesntAddExplicitCompilerFlags_when_targetDependsOnSourceMacro(
     ) async throws {
         // Given
         let projectSettings = Settings.default
@@ -1228,18 +1228,89 @@ struct ConfigGeneratorTests {
         )
 
         // Then
-        let targetSettingsResult = pbxTarget
+        let targetSettings = pbxTarget
             .buildConfigurationList?
             .buildConfigurations
             .first { $0.name == "Debug" }?
             .buildSettings
-            .toSettings()["OTHER_SWIFT_FLAGS"]
+            .toSettings()
+        #expect(targetSettings?["OTHER_SWIFT_FLAGS"] == nil)
+        #expect(targetSettings?["SWIFT_LOAD_BINARY_MACROS"] == nil)
+    }
+
+    @Test(
+        .withMockedXcodeController,
+        .inTemporaryDirectory
+    ) func generateTargetConfig_addsNativeMacroImplementationSettings_toMacroTarget() async throws {
+        // Given
+        let projectSettings = Settings.default
+        let macro = Target.test(name: "MacroImplementation", platform: .macOS, product: .macro)
+        let project = Project.test(targets: [macro])
+        let graph = Graph.test(path: project.path, projects: [project.path: project])
+
+        // When
+        try await subject.generateTargetConfig(
+            macro,
+            project: project,
+            pbxTarget: pbxTarget,
+            pbxproj: pbxproj,
+            projectSettings: projectSettings,
+            fileElements: ProjectFileElements(),
+            graphTraverser: GraphTraverser(graph: graph),
+            sourceRootPath: try AbsolutePath(validating: "/project")
+        )
+
+        // Then
+        let targetSettings = pbxTarget
+            .buildConfigurationList?
+            .buildConfigurations
+            .first { $0.name == "Debug" }?
+            .buildSettings
+            .toSettings()
+        #expect(targetSettings?["EAGER_COMPILATION_DISABLE"] == "YES")
+        #expect(targetSettings?["SDKROOT"] == "auto")
+        #expect(targetSettings?["SKIP_BUILDING_DOCUMENTATION"] == "YES")
+        #expect(targetSettings?["SUPPORTED_PLATFORMS"] == "$(HOST_PLATFORM)")
+        #expect(targetSettings?["SWIFT_IMPLEMENTS_MACROS_FOR_MODULE_NAMES"] == "$(PRODUCT_MODULE_NAME)")
+        #expect(targetSettings?["SWIFT_INSTALL_MODULE"] == "NO")
+    }
+
+    @Test(
+        .withMockedXcodeController,
+        .inTemporaryDirectory
+    ) func generateTargetConfig_usesNativeBinaryMacroSetting_when_targetDependsOnPrecompiledMacro() async throws {
+        // Given
+        let projectSettings = Settings.default
+        let app = Target.test(name: "app", platform: .iOS, product: .app)
+        let project = Project.test(targets: [app])
+        let macroPath = try AbsolutePath(validating: "/cache/MacroImplementation.macro")
+        let graph = Graph.test(path: project.path, projects: [project.path: project], dependencies: [
+            .target(name: app.name, path: project.path): Set([.macro(path: macroPath)]),
+        ])
+
+        // When
+        try await subject.generateTargetConfig(
+            app,
+            project: project,
+            pbxTarget: pbxTarget,
+            pbxproj: pbxproj,
+            projectSettings: projectSettings,
+            fileElements: ProjectFileElements(),
+            graphTraverser: GraphTraverser(graph: graph),
+            sourceRootPath: try AbsolutePath(validating: "/project")
+        )
+
+        // Then
+        let targetSettings = pbxTarget
+            .buildConfigurationList?
+            .buildConfigurations
+            .first { $0.name == "Debug" }?
+            .buildSettings
+            .toSettings()
+        #expect(targetSettings?["OTHER_SWIFT_FLAGS"] == nil)
         #expect(
-            targetSettingsResult ==
-                .array([
-                    "-load-plugin-executable",
-                    "$BUILD_DIR/Debug$EFFECTIVE_PLATFORM_NAME/\(macroExecutable.productName)#\(macroExecutable.productName)",
-                ])
+            targetSettings?["SWIFT_LOAD_BINARY_MACROS"] ==
+                "\(macroPath.pathString)#MacroImplementation"
         )
     }
 

--- a/cli/Tests/TuistGeneratorTests/Generator/CrossProjectTargetDependencyGeneratorTests.swift
+++ b/cli/Tests/TuistGeneratorTests/Generator/CrossProjectTargetDependencyGeneratorTests.swift
@@ -6,8 +6,8 @@ import XcodeGraph
 import XcodeProj
 @testable import TuistGenerator
 
-struct ForeignBuildCrossProjectDependencyGeneratorTests {
-    private let subject = ForeignBuildCrossProjectDependencyGenerator()
+struct CrossProjectTargetDependencyGeneratorTests {
+    private let subject = CrossProjectTargetDependencyGenerator()
 
     @Test func generate_wiresCrossProjectDependencyOnConsumer() async throws {
         let consumerPath = try AbsolutePath(validating: "/Workspace/Consumer")
@@ -94,6 +94,50 @@ struct ForeignBuildCrossProjectDependencyGeneratorTests {
         )
         #expect(productsGroup.name == "Products")
         #expect(consumerPbxProject.mainGroup.children.contains(remoteRef))
+    }
+
+    @Test func generate_wiresCrossProjectMacroDependencyOnConsumer() async throws {
+        let consumerPath = try AbsolutePath(validating: "/Workspace/Consumer")
+        let macroPath = try AbsolutePath(validating: "/Workspace/Macros")
+        let macroTarget = Target.test(name: "MacroImplementation", product: .macro)
+        let consumerTarget = Target.test(
+            name: "Feature",
+            dependencies: [.project(target: macroTarget.name, path: macroPath)]
+        )
+        let macroProject = Project.test(path: macroPath, targets: [macroTarget])
+        let consumerProject = Project.test(path: consumerPath, targets: [consumerTarget])
+        let graph = Graph.test(
+            projects: [
+                macroPath: macroProject,
+                consumerPath: consumerProject,
+            ],
+            dependencies: [
+                .target(name: consumerTarget.name, path: consumerPath): Set([
+                    .target(name: macroTarget.name, path: macroPath),
+                ]),
+            ]
+        )
+
+        let macroDescriptor = makeDescriptor(path: macroPath, nativeTargets: [macroTarget.name])
+        let consumerDescriptor = makeDescriptor(path: consumerPath, nativeTargets: [consumerTarget.name])
+
+        try subject.generate(
+            graphTraverser: GraphTraverser(graph: graph),
+            projectDescriptors: [macroDescriptor, consumerDescriptor]
+        )
+
+        let generatedConsumer = try #require(
+            consumerDescriptor.xcodeProj.pbxproj.nativeTargets.first(where: { $0.name == consumerTarget.name })
+        )
+        let dependency = try #require(generatedConsumer.dependencies.first)
+        let proxy = try #require(dependency.targetProxy)
+        #expect(dependency.name == macroTarget.name)
+        #expect(proxy.remoteInfo == macroTarget.name)
+        guard case let .fileReference(remoteRef) = proxy.containerPortal else {
+            Issue.record("Expected a remote project file reference")
+            return
+        }
+        #expect(remoteRef.path == "../Macros/Macros.xcodeproj")
     }
 
     @Test func generate_dedupesFileReferenceWhenMultipleConsumersShareAggregate() async throws {


### PR DESCRIPTION
## What changed

Tuist now models source-built Swift macros through Xcode's native macro dependency mechanism.

- Macro implementation targets declare Xcode's host-build and macro implementation settings.
- Source macro consumers rely on target dependencies instead of generated compiler flags.
- Precompiled and cached macros use `SWIFT_LOAD_BINARY_MACROS`.
- Cross-project source macro dependencies receive explicit target dependency edges.
- The macro executable copy build phase has been removed.

## Why

The previous workaround copied a macro executable into a hard-coded Debug output path and pointed every consumer at that path. Release builds therefore depended on the Debug layout, multiple targets could write the same output, and script sandboxing and incremental build behavior were difficult to reason about.

## Root cause

Tuist treated source-built macros like detached binary plugins. Xcode's build system already understands source macro implementations when the producer target advertises `SWIFT_IMPLEMENTS_MACROS_FOR_MODULE_NAMES` and is reachable through the target dependency graph. Because Tuist did not emit that metadata, it compensated with a shell copy and `-load-plugin-executable`.

## Approach

The implementation follows the behavior in Apple's [Swift Build](https://github.com/swiftlang/swift-build) and [Swift Package Manager](https://github.com/swiftlang/swift-package-manager):

- Source macro targets advertise their module through native build settings and build for `$(HOST_PLATFORM)`.
- Xcode derives the executable path from the dependency target and propagates the macro implementation transitively.
- Binary-only macros remain explicit through `SWIFT_LOAD_BINARY_MACROS`.

Tuist continues to generate macro targets as command-line-tool products. A dedicated host-build-tool product was evaluated, but it made the generated macro test scheme ineligible for the local macOS destination with the current project model. Keeping the existing product type limits this change to dependency semantics.

## Impact

Source macros no longer need a shell phase, a Debug-specific path, or direct compiler flags. Debug simulator builds, Release device archives, cross-project macro propagation, script sandboxing, the documented macro test wrapper, and cached macro consumption all work locally. Cached macros use Xcode's native binary macro setting.

## Validation

- Generated the focused Tuist workspace with `tuist generate tuist TuistCore TuistCoreTests TuistGenerator TuistGeneratorTests ProjectDescription --no-open`.
- Passed 158 `GraphTraverserTests` and 99 focused generator tests with `xcodebuild test`.
- Built a three-project cross-project macro fixture for an iOS simulator in Debug with user script sandboxing enabled.
- Archived the same fixture for a generic iOS device in Release.
- Built this branch with the cache extension enabled and warmed fresh Debug and Release `MacroHost` artifacts with zero local and remote hits.
- Generated a focused `Feature` workspace where the source target had no build dependencies and `MacroHost` was available only as a cached universal executable.
- Built the cached fixture for both simulator architectures in Debug and for a generic iOS device in Release, then archived the Release framework.
- Confirmed Xcode translated `SWIFT_LOAD_BINARY_MACROS` into the configuration-specific cached executable path and that the produced binaries contained the expected `cached-native: 42` expansion.
- Passed the documented `MyMacrosTests` macOS macro test workflow.
- Ran `mise run cli:lint --fix` and `git diff --check`.
