### PR TITLE
docs(server): clarify Xcode selection on runners

### DIFF
--- a/server/priv/docs/en/guides/features/runners/getting-started.md
+++ b/server/priv/docs/en/guides/features/runners/getting-started.md
@@ -35,4 +35,11 @@ Running a job on the fleet takes three changes: connect GitHub, point `runs-on` 
          - run: tuist test
    ```
 
+   > [!IMPORTANT]
+   > **Select Xcode with the runner profile**
+   >
+   > A macOS runner image contains a single Xcode version, which Tuist selects before the job starts based on the profile. If you're migrating from GitHub-hosted runners, remove steps that use `xcode-select --switch` (or `xcode-select -s`) or other tools and actions to switch Xcode versions. Those steps commonly reference Xcode installations specific to GitHub-hosted images and can fail on Tuist Runners.
+   >
+   > To use another Xcode version, <.localized_link href="/guides/features/runners/profiles#creating-a-profile">create or choose a profile</.localized_link> with that version and update `runs-on`, for example `runs-on: tuist-xcode-26-4`. `xcodebuild`, `xcrun`, and `swift` will then use the profile's selected Xcode without any additional setup in the workflow.
+
 4. **Push and watch.** The job is queued, claimed by a runner, and streamed back to the **Runners** section of your Tuist dashboard, where you can follow its logs, steps, and machine metrics.


### PR DESCRIPTION
## What changed

- Added an important migration note to the Tuist Runners getting-started guide.
- Clarified that a macOS runner profile selects the runner image and its single Xcode version before the job starts.
- Told teams migrating from GitHub-hosted runners to remove `xcode-select --switch`/`xcode-select -s` and other Xcode-switching steps.
- Linked to profile creation and included `runs-on: tuist-xcode-26-4` as a concrete example.

## Why

GitHub-hosted macOS runners expose multiple Xcode installations, so workflows commonly switch between them during the job. Tuist Runners make that choice when routing the job through its profile instead.

The getting-started guide already showed how to change `runs-on`, but it did not explain this difference. As a result, an otherwise valid migration could retain a GitHub-hosted-specific Xcode selection step, reference an unavailable installation path, and fail before the build begins.

## Approach

The guidance is placed immediately below the first `runs-on` example, where it is visible during migration. It names the incompatible switching commands, directs version selection to runner profiles, and confirms that `xcodebuild`, `xcrun`, and `swift` use the profile-selected toolchain without additional workflow setup.

This keeps the runner model consistent: infrastructure and Xcode selection live in profiles rather than being duplicated across workflow steps.

## Impact

Teams can migrate macOS jobs with a clearer understanding of the one-Xcode-per-image model and avoid failures caused by stale GitHub-hosted runner setup steps.

## Validation

- `mix test test/tuist/docs_test.exs` — 9 tests passed.
- `git diff --check` — passed.