### PR TITLE
feat(infra): add registry Grafana dashboard

### DIFF
--- a/infra/grafana-dashboards/registry-service.json
+++ b/infra/grafana-dashboards/registry-service.json
@@ -1,0 +1,1629 @@
+{
+  "apiVersion": "dashboard.grafana.app/v1",
+  "kind": "Dashboard",
+  "metadata": {
+    "name": "tuist-registry-service"
+  },
+  "spec": {
+    "annotations": {
+      "list": [
+        {
+          "builtIn": 1,
+          "datasource": {
+            "type": "grafana",
+            "uid": "-- Grafana --"
+          },
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "type": "dashboard"
+        }
+      ]
+    },
+    "description": "Service health, Swift package traffic, object-storage calls, runtime behavior, logs, and traces for the Tuist Registry service.",
+    "editable": true,
+    "fiscalYearStartMonth": 0,
+    "graphTooltip": 1,
+    "links": [
+      {
+        "icon": "external link",
+        "includeVars": false,
+        "keepTime": false,
+        "tags": [],
+        "targetBlank": true,
+        "title": "Registry operations guide",
+        "tooltip": "Open the registry service operations guide in the Tuist repository.",
+        "type": "link",
+        "url": "https://github.com/tuist/tuist/blob/main/registry/AGENTS.md"
+      }
+    ],
+    "panels": [
+      {
+        "collapsed": false,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 0
+        },
+        "id": 1,
+        "panels": [],
+        "title": "Service Health",
+        "type": "row"
+      },
+      {
+        "datasource": "$datasource",
+        "description": "Ready registry replicas across the selected managed environments.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "decimals": 0,
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "red",
+                  "value": null
+                },
+                {
+                  "color": "green",
+                  "value": 1
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 4,
+          "w": 4,
+          "x": 0,
+          "y": 1
+        },
+        "id": 2,
+        "options": {
+          "colorMode": "value",
+          "graphMode": "none",
+          "justifyMode": "auto",
+          "orientation": "auto",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "textMode": "auto",
+          "wideLayout": true
+        },
+        "targets": [
+          {
+            "datasource": "$datasource",
+            "editorMode": "code",
+            "expr": "sum(kube_deployment_status_replicas_ready{env=~\"$environment\", deployment=\"tuist-tuist-registry\"})",
+            "instant": true,
+            "range": false,
+            "refId": "A"
+          }
+        ],
+        "title": "Ready Replicas",
+        "type": "stat"
+      },
+      {
+        "datasource": "$datasource",
+        "description": "Aggregate registry request rate.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "decimals": 2,
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                }
+              ]
+            },
+            "unit": "reqps"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 4,
+          "w": 4,
+          "x": 4,
+          "y": 1
+        },
+        "id": 3,
+        "options": {
+          "colorMode": "value",
+          "graphMode": "area",
+          "justifyMode": "auto",
+          "orientation": "auto",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "textMode": "auto",
+          "wideLayout": true
+        },
+        "targets": [
+          {
+            "datasource": "$datasource",
+            "editorMode": "code",
+            "expr": "sum(rate(tuist_registry_prom_ex_phoenix_http_requests_total{env=~\"$environment\", pod=~\"$pod\"}[$__rate_interval]))",
+            "instant": true,
+            "range": false,
+            "refId": "A"
+          }
+        ],
+        "title": "Requests",
+        "type": "stat"
+      },
+      {
+        "datasource": "$datasource",
+        "description": "Share of registry requests returning server errors.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "decimals": 2,
+            "max": 100,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "yellow",
+                  "value": 1
+                },
+                {
+                  "color": "red",
+                  "value": 5
+                }
+              ]
+            },
+            "unit": "percent"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 4,
+          "w": 4,
+          "x": 8,
+          "y": 1
+        },
+        "id": 4,
+        "options": {
+          "colorMode": "value",
+          "graphMode": "area",
+          "justifyMode": "auto",
+          "orientation": "auto",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "textMode": "auto",
+          "wideLayout": true
+        },
+        "targets": [
+          {
+            "datasource": "$datasource",
+            "editorMode": "code",
+            "expr": "100 * (sum(rate(tuist_registry_prom_ex_phoenix_http_requests_total{env=~\"$environment\", pod=~\"$pod\", status_class=\"5xx\"}[$__rate_interval])) or vector(0)) / clamp_min(sum(rate(tuist_registry_prom_ex_phoenix_http_requests_total{env=~\"$environment\", pod=~\"$pod\"}[$__rate_interval])), 0.001)",
+            "instant": true,
+            "range": false,
+            "refId": "A"
+          }
+        ],
+        "title": "Server Error Rate",
+        "type": "stat"
+      },
+      {
+        "datasource": "$datasource",
+        "description": "95th percentile request latency across all registry routes.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "decimals": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "yellow",
+                  "value": 500
+                },
+                {
+                  "color": "red",
+                  "value": 2000
+                }
+              ]
+            },
+            "unit": "ms"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 4,
+          "w": 4,
+          "x": 12,
+          "y": 1
+        },
+        "id": 5,
+        "options": {
+          "colorMode": "value",
+          "graphMode": "area",
+          "justifyMode": "auto",
+          "orientation": "auto",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "textMode": "auto",
+          "wideLayout": true
+        },
+        "targets": [
+          {
+            "datasource": "$datasource",
+            "editorMode": "code",
+            "expr": "histogram_quantile(0.95, sum by (le) (rate(tuist_registry_prom_ex_phoenix_http_request_duration_milliseconds_bucket{env=~\"$environment\", pod=~\"$pod\"}[$__rate_interval])))",
+            "instant": true,
+            "range": false,
+            "refId": "A"
+          }
+        ],
+        "title": "Request p95",
+        "type": "stat"
+      },
+      {
+        "datasource": "$datasource",
+        "description": "Source-archive download redirects served during the selected time range.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "decimals": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 4,
+          "w": 4,
+          "x": 16,
+          "y": 1
+        },
+        "id": 6,
+        "options": {
+          "colorMode": "value",
+          "graphMode": "none",
+          "justifyMode": "auto",
+          "orientation": "auto",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "textMode": "auto",
+          "wideLayout": true
+        },
+        "targets": [
+          {
+            "datasource": "$datasource",
+            "editorMode": "code",
+            "expr": "sum(increase(tuist_registry_swift_download_total{env=~\"$environment\", pod=~\"$pod\"}[$__range]))",
+            "instant": true,
+            "range": false,
+            "refId": "A"
+          }
+        ],
+        "title": "Archive Downloads",
+        "type": "stat"
+      },
+      {
+        "datasource": "$datasource",
+        "description": "Package manifest responses served during the selected time range.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "decimals": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 4,
+          "w": 4,
+          "x": 20,
+          "y": 1
+        },
+        "id": 7,
+        "options": {
+          "colorMode": "value",
+          "graphMode": "none",
+          "justifyMode": "auto",
+          "orientation": "auto",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "textMode": "auto",
+          "wideLayout": true
+        },
+        "targets": [
+          {
+            "datasource": "$datasource",
+            "editorMode": "code",
+            "expr": "sum(increase(tuist_registry_swift_manifest_total{env=~\"$environment\", pod=~\"$pod\"}[$__range]))",
+            "instant": true,
+            "range": false,
+            "refId": "A"
+          }
+        ],
+        "title": "Manifest Reads",
+        "type": "stat"
+      },
+      {
+        "datasource": "$datasource",
+        "description": "Registry request rate split by managed environment.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "drawStyle": "line",
+              "fillOpacity": 10,
+              "lineInterpolation": "linear",
+              "lineWidth": 2,
+              "pointSize": 5,
+              "showPoints": "never",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              }
+            },
+            "unit": "reqps"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 5
+        },
+        "id": 8,
+        "options": {
+          "legend": {
+            "calcs": [
+              "lastNotNull",
+              "max"
+            ],
+            "displayMode": "table",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "multi",
+            "sort": "desc"
+          }
+        },
+        "targets": [
+          {
+            "datasource": "$datasource",
+            "editorMode": "code",
+            "expr": "sum by (env) (rate(tuist_registry_prom_ex_phoenix_http_requests_total{env=~\"$environment\", pod=~\"$pod\"}[$__rate_interval]))",
+            "legendFormat": "{{env}}",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "Request Rate",
+        "type": "timeseries"
+      },
+      {
+        "datasource": "$datasource",
+        "description": "Client and server error response rates by environment.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "drawStyle": "line",
+              "fillOpacity": 10,
+              "lineInterpolation": "linear",
+              "lineWidth": 2,
+              "pointSize": 5,
+              "showPoints": "never",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              }
+            },
+            "unit": "reqps"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 12,
+          "y": 5
+        },
+        "id": 9,
+        "options": {
+          "legend": {
+            "calcs": [
+              "lastNotNull",
+              "max"
+            ],
+            "displayMode": "table",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "multi",
+            "sort": "desc"
+          }
+        },
+        "targets": [
+          {
+            "datasource": "$datasource",
+            "editorMode": "code",
+            "expr": "sum by (env, status_class) (rate(tuist_registry_prom_ex_phoenix_http_requests_total{env=~\"$environment\", pod=~\"$pod\", status_class=~\"4xx|5xx\"}[$__rate_interval]))",
+            "legendFormat": "{{env}} {{status_class}}",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "Error Responses",
+        "type": "timeseries"
+      },
+      {
+        "collapsed": false,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 13
+        },
+        "id": 10,
+        "panels": [],
+        "title": "Registry Traffic",
+        "type": "row"
+      },
+      {
+        "datasource": "$datasource",
+        "description": "Request rate by normalized Phoenix route and method. Dynamic package identifiers are not used as route labels.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "drawStyle": "line",
+              "fillOpacity": 10,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "showPoints": "never",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              }
+            },
+            "unit": "reqps"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 14
+        },
+        "id": 11,
+        "options": {
+          "legend": {
+            "calcs": [
+              "lastNotNull",
+              "max"
+            ],
+            "displayMode": "table",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "multi",
+            "sort": "desc"
+          }
+        },
+        "targets": [
+          {
+            "datasource": "$datasource",
+            "editorMode": "code",
+            "expr": "sum by (method, path) (rate(tuist_registry_prom_ex_phoenix_http_requests_total{env=~\"$environment\", pod=~\"$pod\"}[$__rate_interval]))",
+            "legendFormat": "{{method}} {{path}}",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "Requests by Route",
+        "type": "timeseries"
+      },
+      {
+        "datasource": "$datasource",
+        "description": "95th percentile request latency by normalized Phoenix route.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "drawStyle": "line",
+              "fillOpacity": 10,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "showPoints": "never",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              }
+            },
+            "unit": "ms"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 12,
+          "y": 14
+        },
+        "id": 12,
+        "options": {
+          "legend": {
+            "calcs": [
+              "lastNotNull",
+              "max"
+            ],
+            "displayMode": "table",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "multi",
+            "sort": "desc"
+          }
+        },
+        "targets": [
+          {
+            "datasource": "$datasource",
+            "editorMode": "code",
+            "expr": "histogram_quantile(0.95, sum by (path, le) (rate(tuist_registry_prom_ex_phoenix_http_request_duration_milliseconds_bucket{env=~\"$environment\", pod=~\"$pod\"}[$__rate_interval])))",
+            "legendFormat": "{{path}}",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "Request Latency by Route",
+        "type": "timeseries"
+      },
+      {
+        "datasource": "$datasource",
+        "description": "Packages with the most source-archive download redirects in the selected time range.",
+        "fieldConfig": {
+          "defaults": {
+            "custom": {
+              "align": "auto",
+              "cellOptions": {
+                "type": "auto"
+              },
+              "footer": {
+                "reducers": []
+              },
+              "inspect": false
+            },
+            "decimals": 0
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 9,
+          "w": 12,
+          "x": 0,
+          "y": 22
+        },
+        "id": 13,
+        "options": {
+          "cellHeight": "sm",
+          "showHeader": true
+        },
+        "targets": [
+          {
+            "datasource": "$datasource",
+            "editorMode": "code",
+            "expr": "topk(20, sum by (scope, name) (increase(tuist_registry_swift_download_total{env=~\"$environment\", pod=~\"$pod\"}[$__range])))",
+            "format": "table",
+            "instant": true,
+            "legendFormat": "{{scope}}/{{name}}",
+            "range": false,
+            "refId": "A"
+          }
+        ],
+        "title": "Top Archive Downloads",
+        "transformations": [
+          {
+            "id": "organize",
+            "options": {
+              "excludeByName": {
+                "Time": true
+              },
+              "indexByName": {
+                "scope": 0,
+                "name": 1,
+                "Value": 2
+              },
+              "renameByName": {
+                "Value": "Downloads",
+                "name": "Package",
+                "scope": "Scope"
+              }
+            }
+          }
+        ],
+        "type": "table"
+      },
+      {
+        "datasource": "$datasource",
+        "description": "Packages with the most manifest responses in the selected time range.",
+        "fieldConfig": {
+          "defaults": {
+            "custom": {
+              "align": "auto",
+              "cellOptions": {
+                "type": "auto"
+              },
+              "footer": {
+                "reducers": []
+              },
+              "inspect": false
+            },
+            "decimals": 0
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 9,
+          "w": 12,
+          "x": 12,
+          "y": 22
+        },
+        "id": 14,
+        "options": {
+          "cellHeight": "sm",
+          "showHeader": true
+        },
+        "targets": [
+          {
+            "datasource": "$datasource",
+            "editorMode": "code",
+            "expr": "topk(20, sum by (scope, name) (increase(tuist_registry_swift_manifest_total{env=~\"$environment\", pod=~\"$pod\"}[$__range])))",
+            "format": "table",
+            "instant": true,
+            "legendFormat": "{{scope}}/{{name}}",
+            "range": false,
+            "refId": "A"
+          }
+        ],
+        "title": "Top Manifest Reads",
+        "transformations": [
+          {
+            "id": "organize",
+            "options": {
+              "excludeByName": {
+                "Time": true
+              },
+              "indexByName": {
+                "scope": 0,
+                "name": 1,
+                "Value": 2
+              },
+              "renameByName": {
+                "Value": "Reads",
+                "name": "Package",
+                "scope": "Scope"
+              }
+            }
+          }
+        ],
+        "type": "table"
+      },
+      {
+        "collapsed": false,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 31
+        },
+        "id": 15,
+        "panels": [],
+        "title": "Storage and Outbound Connections",
+        "type": "row"
+      },
+      {
+        "datasource": "$datasource",
+        "description": "Object-storage existence-check request rates split by result, including cache hits, found objects, missing objects, rate limits, and errors.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "drawStyle": "line",
+              "fillOpacity": 10,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "showPoints": "never",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              }
+            },
+            "unit": "reqps"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 32
+        },
+        "id": 16,
+        "options": {
+          "legend": {
+            "calcs": [
+              "lastNotNull",
+              "max"
+            ],
+            "displayMode": "table",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "multi",
+            "sort": "desc"
+          }
+        },
+        "targets": [
+          {
+            "datasource": "$datasource",
+            "editorMode": "code",
+            "expr": "sum by (env, result) (rate(tuist_registry_s3_head_requests_total{env=~\"$environment\", pod=~\"$pod\"}[$__rate_interval]))",
+            "legendFormat": "{{env}} {{result}}",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "Object-Storage Existence Checks",
+        "type": "timeseries"
+      },
+      {
+        "datasource": "$datasource",
+        "description": "95th percentile object-storage existence-check latency split by result.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "drawStyle": "line",
+              "fillOpacity": 10,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "showPoints": "never",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              }
+            },
+            "unit": "ms"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 12,
+          "y": 32
+        },
+        "id": 17,
+        "options": {
+          "legend": {
+            "calcs": [
+              "lastNotNull",
+              "max"
+            ],
+            "displayMode": "table",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "multi",
+            "sort": "desc"
+          }
+        },
+        "targets": [
+          {
+            "datasource": "$datasource",
+            "editorMode": "code",
+            "expr": "histogram_quantile(0.95, sum by (env, result, le) (rate(tuist_registry_s3_head_duration_milliseconds_bucket{env=~\"$environment\", pod=~\"$pod\"}[$__rate_interval])))",
+            "legendFormat": "{{env}} {{result}}",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "Object-Storage Existence-Check p95",
+        "type": "timeseries"
+      },
+      {
+        "datasource": "$datasource",
+        "description": "Share of outbound client connections currently in use for each configured origin.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "drawStyle": "line",
+              "fillOpacity": 10,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "showPoints": "never",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              }
+            },
+            "max": 100,
+            "min": 0,
+            "unit": "percent"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 40
+        },
+        "id": 18,
+        "options": {
+          "legend": {
+            "calcs": [
+              "lastNotNull",
+              "max"
+            ],
+            "displayMode": "table",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "multi",
+            "sort": "desc"
+          }
+        },
+        "targets": [
+          {
+            "datasource": "$datasource",
+            "editorMode": "code",
+            "expr": "100 * sum by (env, url) (tuist_registry_prom_ex_finch_pool_in_use_connections{env=~\"$environment\", pod=~\"$pod\"}) / clamp_min(sum by (env, url) (tuist_registry_prom_ex_finch_pool_size{env=~\"$environment\", pod=~\"$pod\"}), 1)",
+            "legendFormat": "{{env}} {{url}}",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "Outbound Connection-Pool Utilization",
+        "type": "timeseries"
+      },
+      {
+        "datasource": "$datasource",
+        "description": "95th percentile response payload size by normalized registry route.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "drawStyle": "line",
+              "fillOpacity": 10,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "showPoints": "never",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              }
+            },
+            "unit": "bytes"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 12,
+          "y": 40
+        },
+        "id": 19,
+        "options": {
+          "legend": {
+            "calcs": [
+              "lastNotNull",
+              "max"
+            ],
+            "displayMode": "table",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "multi",
+            "sort": "desc"
+          }
+        },
+        "targets": [
+          {
+            "datasource": "$datasource",
+            "editorMode": "code",
+            "expr": "histogram_quantile(0.95, sum by (path, le) (rate(tuist_registry_prom_ex_phoenix_http_response_size_bytes_bucket{env=~\"$environment\", pod=~\"$pod\"}[$__rate_interval])))",
+            "legendFormat": "{{path}}",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "Response Size p95",
+        "type": "timeseries"
+      },
+      {
+        "collapsed": false,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 48
+        },
+        "id": 20,
+        "panels": [],
+        "title": "Runtime",
+        "type": "row"
+      },
+      {
+        "datasource": "$datasource",
+        "description": "Total and process memory reported by the registry runtime.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "drawStyle": "line",
+              "fillOpacity": 10,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "showPoints": "never",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              }
+            },
+            "unit": "decbytes"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 49
+        },
+        "id": 21,
+        "options": {
+          "legend": {
+            "calcs": [
+              "lastNotNull",
+              "max"
+            ],
+            "displayMode": "table",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "multi",
+            "sort": "desc"
+          }
+        },
+        "targets": [
+          {
+            "datasource": "$datasource",
+            "editorMode": "code",
+            "expr": "tuist_registry_prom_ex_beam_memory_allocated_bytes{env=~\"$environment\", pod=~\"$pod\"}",
+            "legendFormat": "total {{env}} {{pod}}",
+            "range": true,
+            "refId": "A"
+          },
+          {
+            "datasource": "$datasource",
+            "editorMode": "code",
+            "expr": "tuist_registry_prom_ex_beam_memory_processes_total_bytes{env=~\"$environment\", pod=~\"$pod\"}",
+            "legendFormat": "processes {{env}} {{pod}}",
+            "range": true,
+            "refId": "B"
+          }
+        ],
+        "title": "Runtime Memory",
+        "type": "timeseries"
+      },
+      {
+        "datasource": "$datasource",
+        "description": "Processor cores consumed by registry containers.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "drawStyle": "line",
+              "fillOpacity": 10,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "showPoints": "never",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              }
+            },
+            "unit": "cores"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 12,
+          "y": 49
+        },
+        "id": 22,
+        "options": {
+          "legend": {
+            "calcs": [
+              "lastNotNull",
+              "max"
+            ],
+            "displayMode": "table",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "multi",
+            "sort": "desc"
+          }
+        },
+        "targets": [
+          {
+            "datasource": "$datasource",
+            "editorMode": "code",
+            "expr": "sum by (env, pod) (rate(container_cpu_usage_seconds_total{env=~\"$environment\", pod=~\"$pod\", container=\"registry\"}[$__rate_interval]))",
+            "legendFormat": "{{env}} {{pod}}",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "Container Processor Usage",
+        "type": "timeseries"
+      },
+      {
+        "datasource": "$datasource",
+        "description": "Runtime process count per registry pod.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "drawStyle": "line",
+              "fillOpacity": 10,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "showPoints": "never",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              }
+            },
+            "unit": "short"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 8,
+          "x": 0,
+          "y": 57
+        },
+        "id": 23,
+        "options": {
+          "legend": {
+            "calcs": [
+              "lastNotNull",
+              "max"
+            ],
+            "displayMode": "table",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "multi",
+            "sort": "desc"
+          }
+        },
+        "targets": [
+          {
+            "datasource": "$datasource",
+            "editorMode": "code",
+            "expr": "tuist_registry_prom_ex_beam_stats_process_count{env=~\"$environment\", pod=~\"$pod\"}",
+            "legendFormat": "{{env}} {{pod}}",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "Runtime Process Count",
+        "type": "timeseries"
+      },
+      {
+        "datasource": "$datasource",
+        "description": "Registry container restarts during the selected time range.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "decimals": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 1
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 8,
+          "x": 8,
+          "y": 57
+        },
+        "id": 24,
+        "options": {
+          "colorMode": "value",
+          "graphMode": "area",
+          "justifyMode": "auto",
+          "orientation": "auto",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "textMode": "auto",
+          "wideLayout": true
+        },
+        "targets": [
+          {
+            "datasource": "$datasource",
+            "editorMode": "code",
+            "expr": "sum(increase(kube_pod_container_status_restarts_total{env=~\"$environment\", pod=~\"$pod\", container=\"registry\"}[$__range]))",
+            "instant": true,
+            "range": false,
+            "refId": "A"
+          }
+        ],
+        "title": "Container Restarts",
+        "type": "stat"
+      },
+      {
+        "datasource": "$datasource",
+        "description": "Normal and dirty runtime tasks active in each registry pod.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "drawStyle": "line",
+              "fillOpacity": 10,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "showPoints": "never",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              }
+            },
+            "unit": "short"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 8,
+          "x": 16,
+          "y": 57
+        },
+        "id": 25,
+        "options": {
+          "legend": {
+            "calcs": [
+              "lastNotNull",
+              "max"
+            ],
+            "displayMode": "table",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "multi",
+            "sort": "desc"
+          }
+        },
+        "targets": [
+          {
+            "datasource": "$datasource",
+            "editorMode": "code",
+            "expr": "tuist_registry_prom_ex_beam_stats_active_task_count{env=~\"$environment\", pod=~\"$pod\", type=\"normal\"}",
+            "legendFormat": "normal {{env}} {{pod}}",
+            "range": true,
+            "refId": "A"
+          },
+          {
+            "datasource": "$datasource",
+            "editorMode": "code",
+            "expr": "tuist_registry_prom_ex_beam_stats_active_task_count{env=~\"$environment\", pod=~\"$pod\", type=\"dirty\"}",
+            "legendFormat": "dirty {{env}} {{pod}}",
+            "range": true,
+            "refId": "B"
+          }
+        ],
+        "title": "Active Runtime Tasks",
+        "type": "timeseries"
+      },
+      {
+        "collapsed": false,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 65
+        },
+        "id": 26,
+        "panels": [],
+        "title": "Logs and Traces",
+        "type": "row"
+      },
+      {
+        "datasource": "$logs_datasource",
+        "description": "Recent registry container logs for the selected environments and pods.",
+        "fieldConfig": {
+          "defaults": {},
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 12,
+          "w": 12,
+          "x": 0,
+          "y": 66
+        },
+        "id": 27,
+        "options": {
+          "dedupStrategy": "none",
+          "enableLogDetails": true,
+          "prettifyLogMessage": true,
+          "showCommonLabels": false,
+          "showLabels": false,
+          "showTime": true,
+          "sortOrder": "Descending",
+          "wrapLogMessage": false
+        },
+        "targets": [
+          {
+            "datasource": "$logs_datasource",
+            "editorMode": "code",
+            "expr": "{env=~\"$environment\", pod=~\"$pod\", container=\"registry\"}",
+            "queryType": "range",
+            "refId": "A"
+          }
+        ],
+        "title": "Registry Logs",
+        "type": "logs"
+      },
+      {
+        "datasource": "$traces_datasource",
+        "description": "Most recent registry traces for the selected managed environments.",
+        "fieldConfig": {
+          "defaults": {
+            "custom": {
+              "align": "auto",
+              "cellOptions": {
+                "type": "auto"
+              },
+              "footer": {
+                "reducers": []
+              },
+              "inspect": false
+            },
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 12,
+          "w": 12,
+          "x": 12,
+          "y": 66
+        },
+        "id": 28,
+        "options": {
+          "cellHeight": "sm",
+          "showHeader": true
+        },
+        "targets": [
+          {
+            "datasource": "$traces_datasource",
+            "limit": 50,
+            "query": "{ resource.service.namespace = \"tuist\" && resource.service.name = \"tuist-registry\" && resource.deployment.environment =~ \"${environment:regex}\" } with (most_recent=true)",
+            "queryType": "traceql",
+            "refId": "A",
+            "tableType": "traces"
+          }
+        ],
+        "title": "Recent Registry Traces",
+        "type": "table"
+      }
+    ],
+    "refresh": "30s",
+    "schemaVersion": 39,
+    "tags": [
+      "tuist",
+      "registry"
+    ],
+    "templating": {
+      "list": [
+        {
+          "current": {
+            "selected": false,
+            "text": "grafanacloud-tuist-prom",
+            "value": "grafanacloud-prom"
+          },
+          "hide": 0,
+          "includeAll": false,
+          "label": "Prometheus Data Source",
+          "multi": false,
+          "name": "datasource",
+          "options": [],
+          "query": "prometheus",
+          "refresh": 1,
+          "regex": "",
+          "skipUrlSync": false,
+          "type": "datasource"
+        },
+        {
+          "current": {
+            "selected": false,
+            "text": "grafanacloud-tuist-logs",
+            "value": "grafanacloud-logs"
+          },
+          "hide": 0,
+          "includeAll": false,
+          "label": "Loki Data Source",
+          "multi": false,
+          "name": "logs_datasource",
+          "options": [],
+          "query": "loki",
+          "refresh": 1,
+          "regex": "",
+          "skipUrlSync": false,
+          "type": "datasource"
+        },
+        {
+          "current": {
+            "selected": false,
+            "text": "grafanacloud-tuist-traces",
+            "value": "grafanacloud-traces"
+          },
+          "hide": 0,
+          "includeAll": false,
+          "label": "Tempo Data Source",
+          "multi": false,
+          "name": "traces_datasource",
+          "options": [],
+          "query": "tempo",
+          "refresh": 1,
+          "regex": "",
+          "skipUrlSync": false,
+          "type": "datasource"
+        },
+        {
+          "allValue": ".*",
+          "current": {
+            "selected": true,
+            "text": [
+              "production"
+            ],
+            "value": [
+              "production"
+            ]
+          },
+          "hide": 0,
+          "includeAll": true,
+          "label": "Environment",
+          "multi": true,
+          "name": "environment",
+          "options": [
+            {
+              "selected": true,
+              "text": "production",
+              "value": "production"
+            },
+            {
+              "selected": false,
+              "text": "canary",
+              "value": "canary"
+            },
+            {
+              "selected": false,
+              "text": "staging",
+              "value": "staging"
+            }
+          ],
+          "query": "production,canary,staging",
+          "queryValue": "",
+          "skipUrlSync": false,
+          "type": "custom"
+        },
+        {
+          "allValue": ".*",
+          "current": {
+            "selected": true,
+            "text": [
+              "All"
+            ],
+            "value": [
+              "$__all"
+            ]
+          },
+          "datasource": "$datasource",
+          "definition": "label_values(tuist_registry_prom_ex_beam_memory_allocated_bytes{env=~\"$environment\"}, pod)",
+          "hide": 0,
+          "includeAll": true,
+          "label": "Pod",
+          "multi": true,
+          "name": "pod",
+          "options": [],
+          "query": {
+            "qryType": 1,
+            "query": "label_values(tuist_registry_prom_ex_beam_memory_allocated_bytes{env=~\"$environment\"}, pod)",
+            "refId": "PrometheusVariableQueryEditor-VariableQuery"
+          },
+          "refresh": 1,
+          "regex": "/tuist-tuist-registry-.*/",
+          "skipUrlSync": false,
+          "sort": 1,
+          "type": "query"
+        }
+      ]
+    },
+    "time": {
+      "from": "now-6h",
+      "to": "now"
+    },
+    "timepicker": {},
+    "timezone": "browser",
+    "title": "Tuist Registry Service",
+    "uid": "tuist-registry-service",
+    "version": 1,
+    "weekStart": ""
+  }
+}

--- a/infra/helm/tuist/values-managed-canary.yaml
+++ b/infra/helm/tuist/values-managed-canary.yaml
@@ -12,7 +12,7 @@
 registry:
   publicHost: registry-canary.tuist.dev
   serverUrl: https://canary.tuist.dev
-  deployEnv: can
+  deployEnv: canary
   sentryEnv: can
   ingress:
     host: registry-canary.tuist.dev

--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -15,7 +15,7 @@ registry:
   enabled: true
   publicHost: registry.tuist.dev
   serverUrl: https://tuist.dev
-  deployEnv: prod
+  deployEnv: production
   sentryEnv: prod
   poolSize: "10"
   ingress:

--- a/infra/helm/tuist/values-managed-staging.yaml
+++ b/infra/helm/tuist/values-managed-staging.yaml
@@ -15,7 +15,7 @@ kuraController:
 registry:
   publicHost: registry-staging.tuist.dev
   serverUrl: https://staging.tuist.dev
-  deployEnv: stag
+  deployEnv: staging
   sentryEnv: stag
   ingress:
     host: registry-staging.tuist.dev


### PR DESCRIPTION
## What changed

This adds a Grafana Git Sync dashboard for the standalone Tuist Registry service. The dashboard brings the service's existing metrics, logs, and traces into one operational view with environment and pod filters.

The dashboard includes:

- Service readiness, request rate, server errors, and request latency.
- Archive download and manifest-read totals, route breakdowns, and top packages.
- Object-storage existence checks, outbound connection-pool utilization, and response sizes.
- Runtime memory, processor usage, process counts, active tasks, and container restarts.
- Grafana Loki logs and Grafana Tempo traces alongside the metric panels.

## Why

The registry already exports telemetry and the managed clusters already forward it to Grafana Cloud, but there was no registry-specific dashboard. Investigating the service required reconstructing queries manually across metrics, logs, traces, and Kubernetes workload state.

This dashboard gives the registry the same first-stop operational view as the cache, processor, runner, and Kura services.

## Approach

The dashboard follows the existing Grafana Git Sync resource format under `infra/grafana-dashboards/`. Its metadata name matches the stable dashboard identifier so Grafana can reconcile it predictably after merge.

The queries use the labels already attached by the managed monitoring stack:

- Production, canary, and staging are selectable through the shared environment label.
- Individual registry pods can be selected for instance-level investigation.
- Prometheus, Grafana Loki, and Grafana Tempo remain selectable data sources.
- Storage panels query only the existence-check metrics the registry currently exports. They do not present unexported metadata-read events as if data were available.
- The log panel reads the registry's plain-text output without applying a structured-log parser.

## Impact

After merge, Grafana Git Sync will add `Tuist Registry Service` to the managed `Tuist Dashboards` folder. The change does not modify the registry runtime, deployment, traffic routing, or telemetry collection.

## Validation

- Parsed the dashboard document successfully.
- Verified the resource version, kind, metadata name, and dashboard identifier.
- Verified all 28 panel identifiers are unique, all panels stay within the 24-column grid, and every data panel has complete query targets.
- Verified the dashboard resource name is unique across `infra/grafana-dashboards/`.
- `git diff --cached --check`

### How to test locally

Run:

```sh
jq empty infra/grafana-dashboards/registry-service.json
git diff --check origin/main...HEAD
```

After merge, open the `Tuist Registry Service` dashboard in Grafana Cloud and select production, canary, or staging from the environment filter.
