### PR TITLE
fix(server): give preview ClickHouse enough memory to seed

### DIFF
--- a/infra/helm/tuist/values-preview.yaml
+++ b/infra/helm/tuist/values-preview.yaml
@@ -135,12 +135,15 @@ clickhouse:
   embedded:
     persistence:
       create: false
+    # ClickHouse sizes its internal memory cap from the cgroup limit, so the
+    # limit below is also its working ceiling. Seeding a preview account pushed
+    # it past 1Gi, which OOM-killed the pod and failed the whole helm upgrade.
     resources:
       requests:
         cpu: 100m
-        memory: 256Mi
+        memory: 512Mi
       limits:
-        memory: 1Gi
+        memory: 2Gi
 
 redis:
   enabled: false


### PR DESCRIPTION
## What

Raises the embedded ClickHouse memory limit for preview environments from `1Gi` to `2Gi`, and the request from `256Mi` to `512Mi`.

## Why

Preview deploys have been failing consistently in `helm upgrade --install`, with the ClickHouse StatefulSet never going ready:

```
resource StatefulSet/preview-pr-11743/pr-11743-tuist-clickhouse not ready.
status: Failed, message: 1 pods have failed
```

## Root cause

The ClickHouse pod is being OOM-killed while the preview account is seeded.

ClickHouse sizes its internal memory cap from the cgroup limit it is given, so the `1Gi` limit was also its working ceiling. Seeding walked straight into it:

```
Code: 241. DB::Exception: (total) memory limit exceeded:
would use 693.37 MiB (attempt to allocate chunk of 4.16 MiB),
current RSS: 917.95 MiB
```

917.95 MiB of resident memory under a `1Gi` cap leaves essentially no headroom, so the next allocation failed and the pod died. Helm then failed a *second* time while trying to roll the release back, which is what leaves the preview release wedged and makes retries look like flakes.

It initially did present as a flake: the first failures I saw were a `KuraInstance` timeout and then the OOM above, and one retry did squeak through. But the last two attempts failed identically on the StatefulSet, so it is deterministic now, not transient. The seed data has simply grown past what `1Gi` can hold.

## Why this fix

The obvious alternatives were to trim the seed volume, or to pin ClickHouse's `max_server_memory_usage` explicitly rather than letting it derive from the cgroup. Both are more invasive, and neither addresses the fact that `1Gi` is just tight for a server that is expected to ingest a realistic seed. Giving it `2Gi` restores headroom with a one-line values change and no behavioural coupling.

The `requests` bump from `256Mi` to `512Mi` is deliberate rather than cosmetic: with a `256Mi` request and a `2Gi` limit, the scheduler is free to place the pod on a node that cannot actually accommodate it growing into that limit. Raising the request keeps scheduling honest.

This only touches `values-preview.yaml`. The preview deploy composes `values-preview.yaml` + `values-preview-kura.yaml`, and only the former sets ClickHouse resources, so no other environment is affected. Managed and production environments use external ClickHouse and do not read this block at all.

## Validation

- `helm template` with the exact values combination the preview deploy uses renders cleanly (31 documents), and the rendered ClickHouse StatefulSet carries the new values:
  ```
  CLICKHOUSE StatefulSet resources -> {'limits': {'memory': '2Gi'}, 'requests': {'cpu': '100m', 'memory': '512Mi'}}
  ```
- `helm lint` against the same values passes (`1 chart(s) linted, 0 chart(s) failed`).
- The real proof is a preview deploy getting past seeding, which this PR's own preview deploy will exercise.

Found while getting #11743 (a docs PR) back to green; its preview deploy was the thing hitting this.
