### PR TITLE
fix: avoid GitHub rate-limit failures during tool setup

### DIFF
--- a/.github/actions/mise-install/action.yml
+++ b/.github/actions/mise-install/action.yml
@@ -59,5 +59,7 @@ runs:
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       env:
+        MISE_GITHUB_ATTESTATIONS: "false"
+        MISE_GITHUB_SLSA: "false"
         MISE_LOCKABLE_TOOLS: ${{ steps.split.outputs.locked }}
       run: mise install --locked $MISE_LOCKABLE_TOOLS


### PR DESCRIPTION
## What changed

The shared lockfile-backed mise installation action now disables GitHub artifact-attestation and [Supply-chain Levels for Software Artifacts](https://slsa.dev/) provenance lookups while installing pinned tools.

Both settings are scoped to the lockable-tool step. Source-built tools installed by the preceding action step keep their existing behavior.

## Why

The [server workflow on `main`](https://github.com/tuist/tuist/actions/runs/29333579746) failed before tests or asset builds started. The Test, Seed, and esbuild jobs all exhausted the GitHub rate limit while mise installed ClickHouse or aube.

The shared action is intended to install these tools from committed lockfile entries without depending on GitHub release metadata. Setup should remain reliable when several jobs start together or the shared token has already consumed its request allowance.

## Root cause

`mise install --locked` uses the direct download address and checksum from `mise.lock`, but it does not disable provenance verification. The existing `MISE_GITHUB_ATTESTATIONS` setting controls artifact attestations and does not control the separate provenance check.

That check still queried GitHub release metadata. Concurrent jobs sharing the same token received `403 Forbidden` responses and stopped during tool setup.

## Approach

Set `MISE_GITHUB_ATTESTATIONS=false` and `MISE_GITHUB_SLSA=false` only for the shared action's locked installation step. This removes both metadata lookups while retaining deterministic direct downloads and lockfile checksum verification.

## Impact

Workflows using the shared action no longer depend on remaining GitHub request capacity when installing lockfile-pinned tools. There is no application or developer migration, and downloaded artifacts continue to be checked against committed checksums.

## Validation

- Parsed `.github/actions/mise-install/action.yml` successfully.
- Confirmed both mise settings resolve to `false` from the values in the action.
- Ran a clean locked aube installation with an intentionally invalid GitHub token. The download and checksum verification succeeded without a GitHub metadata request.
- `git diff --check` passed.

### How to test locally

```sh
MISE_GITHUB_SLSA=false mise settings get github.slsa
MISE_GITHUB_ATTESTATIONS=false mise settings get github_attestations
```

Both commands should print `false`.
