### PR TITLE
fix(server): wait for migrations before seeding preview accounts

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -695,6 +695,12 @@ jobs:
         # rendered into the cluster-wide `kura` namespace, so Helm owns its
         # lifecycle. Its static shape lives in values-preview-kura.yaml; only
         # the per-preview identity is set here.
+        #
+        # --wait-for-jobs is load-bearing: --wait on its own only waits for the
+        # Deployments to go ready, not for Jobs to complete. Preview runs the
+        # migration as a regular Job (server.migrationJob.asHook=false), so
+        # without this Helm returns success while migrations are still running
+        # and the seed step below writes into a half-migrated database.
         run: |
           set -euo pipefail
           helm upgrade --install "$RELEASE" "$HELM_CHART_PATH" \
@@ -718,7 +724,7 @@ jobs:
             --set-string "kuraRuntime.instance.labels.tuist\.dev/preview-source=$SOURCE" \
             --set-file "kuraRuntime.instance.extensionScript=kura/ops/helm/kura/hooks/tuist.lua" \
             --set "server.kuraEndpointUrls[0]=https://$KURA_HOST" \
-            --atomic --timeout 20m --wait
+            --atomic --timeout 20m --wait --wait-for-jobs
       - name: Wait for KuraInstance
         run: |
           set -euo pipefail


### PR DESCRIPTION
## What

Adds `--wait-for-jobs` to the `helm upgrade --install` in the preview deploy workflow.

## Why

Preview deploys fail in `Seed preview account` with:

```
** (Ch.Error) Code: 60. DB::Exception: Table tuist.build_runs does not exist.
   Maybe you meant tuist.build_files? (UNKNOWN_TABLE)
```

## Root cause

The database is not missing a migration. It is *still being migrated*. The seed step is racing the migration Job.

`helm upgrade` is invoked with `--wait`, but `--wait` only waits for Deployments to go ready. Waiting for Jobs to **complete** is a separate flag. Straight from the Helm 4 binary CI uses:

```
--wait-for-jobs   if set and --wait enabled, will wait until all Jobs have been
                  completed before marking the release as successful.
```

Preview deliberately runs the migration as a regular Job rather than a Helm hook (`server.migrationJob.asHook=false`, because a pre-install hook deadlocks against the embedded Postgres and ClickHouse), so nothing else was blocking on it either. Helm reported the release successful while the migration Job was still working through the ClickHouse migrations, and the workflow went straight on to seed.

The `Maybe you meant build_files?` hint is what gives it away. Migrations run in timestamp order, `build_files` is `20250602150450` and `build_runs` is `20260204173039`, so the seed hit a database that had been migrated only partway. A genuinely missing migration would not leave the earlier table present.

This was masked until now: seeding used to OOM the 1Gi ClickHouse pod (#11831) before it ever got far enough to touch `build_runs`. With that fixed, the deploy gets far enough to expose this race.

## Why this fix

`--wait-for-jobs` is the flag that exists for exactly this, and it fixes the cause (Helm calling the release done too early) rather than the symptom. The alternative, bolting a `kubectl wait --for=condition=complete job/...` step in front of the seed, would duplicate ordering logic in the workflow and has to reconstruct the revision-scoped Job name (`namePerRevision: true` renders `<release>-tuist-server-migrate-r<N>`), which is fragile.

It cannot hang. All three Jobs in the preview release are one-shot regular resources that terminate:

```
Job: pr-x-tuist-clickhouse-init      | (none - regular resource)
Job: pr-x-tuist-object-storage-init  | (none - regular resource)
Job: pr-x-tuist-server-migrate-r1    | (none - regular resource)
```

Being regular resources rather than pre-install hooks, they are created alongside the embedded databases their init containers wait on, which is precisely why the hook deadlock `values-preview.yaml` warns about does not apply here.

## Validation

- Confirmed against the Helm 4.2.0 binary that `--wait` alone does not wait for Job completion and that `--wait-for-jobs` is the flag that does.
- `helm upgrade --install --dry-run ... --wait --wait-for-jobs` with the preview values is accepted (reaches cluster connection, no `unknown flag`).
- Enumerated every Job the preview release renders to confirm none are long-running, so the new wait cannot deadlock.
- `preview-deploy.yml` still parses as valid YAML (10 jobs).
- End to end proof is this PR's own preview deploy getting past `Seed preview account`.

Found while getting #11743 back to green; its preview deploy surfaced this once the ClickHouse memory ceiling from #11831 was lifted.
