### PR TITLE
fix(server): skip inaccessible registry submodules

### DIFF
--- a/server/lib/tuist/registry/swift/release_worker.ex
+++ b/server/lib/tuist/registry/swift/release_worker.ex
@@ -30,6 +30,7 @@ defmodule Tuist.Registry.Swift.ReleaseWorker do
     "repository not found",
     "does not appear to be a git repository",
     "the requested url returned error: 404",
+    "write access to repository not granted",
     "fatal: could not read username for",
     "not our ref",
     "did not contain",
@@ -351,7 +352,8 @@ defmodule Tuist.Registry.Swift.ReleaseWorker do
       String.starts_with?(nested_submodule_path, submodule_path <> "/")
   end
 
-  defp skippable_submodule_failure?(output) do
+  @doc false
+  def skippable_submodule_failure?(output) do
     Enum.any?(
       @skippable_submodule_failure_markers,
       &(output |> String.downcase() |> String.contains?(&1))

--- a/server/test/tuist/registry/swift/release_worker_test.exs
+++ b/server/test/tuist/registry/swift/release_worker_test.exs
@@ -249,6 +249,15 @@ defmodule Tuist.Registry.Swift.ReleaseWorkerTest do
              })
   end
 
+  test "treats a GitHub private repository permission error as a skippable submodule failure" do
+    output = """
+    remote: Write access to repository not granted.
+    fatal: unable to access 'https://github.com/tuist/TuistCacheEE/': The requested URL returned error: 403
+    """
+
+    assert ReleaseWorker.skippable_submodule_failure?(output)
+  end
+
   defp write_basic_zipball(archive_path) do
     tmp = Path.join(Path.dirname(archive_path), "zipball_content")
     top_dir = Path.join(tmp, "repo-v1.0.0")


### PR DESCRIPTION
Resolves <https://tuist.sentry.io/issues/TUIST-21B>

## What changed

The Swift registry release worker now recognizes GitHub's `Write access to repository not granted` response as a permanent, skippable submodule failure. It removes the inaccessible submodule from the source archive and continues publishing the public release.

A regression test covers the exact response reported by Sentry.

## Why

Historical Tuist releases reference the private `tuist/TuistCacheEE` submodule. The registry mirrors public package sources and should not require access to that private repository, but these releases repeatedly failed instead of being archived without the private submodule.

Each failure remained unknown to the registry metadata and could be enqueued again by later synchronization passes, adding unnecessary work and error noise.

## Root cause

The registry token can clone the public `tuist/tuist` repository but cannot access `tuist/TuistCacheEE`. GitHub returns status `403` with `Write access to repository not granted` for that submodule.

The worker already skips permanent failures such as missing repositories and status `404`, but it did not recognize this permission-denied wording. The failure therefore followed the retryable path and exhausted repeated worker attempts.

## Approach

The fix adds the specific GitHub response to the existing permanent-failure markers and makes the classifier directly testable. This preserves the current behavior for transient failures while routing this known inaccessible-submodule case through the established cleanup path.

The registry token remains restricted. Granting it access to the private repository could place private sources in a publicly served package archive, so broadening credentials is intentionally avoided.

## Impact

Affected releases can complete registry synchronization without the private submodule, and the worker no longer spends repeated attempts on a permanent permission failure. There are no configuration, database, or migration changes.

## Validation

- `mix test test/tuist/registry/swift/release_worker_test.exs`: 5 tests passed.
- `mix format --check-formatted lib/tuist/registry/swift/release_worker.ex test/tuist/registry/swift/release_worker_test.exs`: passed.
- `mix credo --strict lib/tuist/registry/swift/release_worker.ex test/tuist/registry/swift/release_worker_test.exs`: no issues.
- `git diff --check`: passed.

### How to test locally

From `server/`, run:

```sh
mix test test/tuist/registry/swift/release_worker_test.exs
```
