### PR TITLE
fix(server): keep preview alive and surface migration failures

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -696,11 +696,15 @@ jobs:
         # lifecycle. Its static shape lives in values-preview-kura.yaml; only
         # the per-preview identity is set here.
         #
-        # --wait-for-jobs is load-bearing: --wait on its own only waits for the
-        # Deployments to go ready, not for Jobs to complete. Preview runs the
-        # migration as a regular Job (server.migrationJob.asHook=false), so
-        # without this Helm returns success while migrations are still running
-        # and the seed step below writes into a half-migrated database.
+        # Deliberately NOT --wait-for-jobs. It combines badly with --atomic:
+        # a failing migration Job fails the upgrade, --atomic then uninstalls
+        # the release, and the migration pod (the only place the actual error
+        # is written) is deleted before anything can read it. The preview is
+        # torn down and the failure is unexplainable.
+        #
+        # The "Wait for migrations" step below blocks on the Job instead, so
+        # the seed still never runs against a half-migrated database, but a
+        # failure leaves the release standing and prints the migration log.
         run: |
           set -euo pipefail
           helm upgrade --install "$RELEASE" "$HELM_CHART_PATH" \
@@ -724,7 +728,59 @@ jobs:
             --set-string "kuraRuntime.instance.labels.tuist\.dev/preview-source=$SOURCE" \
             --set-file "kuraRuntime.instance.extensionScript=kura/ops/helm/kura/hooks/tuist.lua" \
             --set "server.kuraEndpointUrls[0]=https://$KURA_HOST" \
-            --atomic --timeout 20m --wait --wait-for-jobs
+            --atomic --timeout 20m --wait
+      - name: Wait for migrations
+        # Helm returns as soon as the Deployments are ready; the migration Job
+        # (server.migrationJob.asHook=false) can still be running. Seeding into
+        # a half-migrated database is what produced the long-standing
+        # "Table tuist.build_runs does not exist" failure, so block here.
+        #
+        # On failure this prints the migration log, which nothing did before:
+        # the Job's pod was either still around and unread, or already deleted
+        # by an --atomic rollback.
+        run: |
+          set -euo pipefail
+          JOB=$(kubectl -n "$NAMESPACE" get job \
+            -l app.kubernetes.io/component=server-migration \
+            --sort-by=.metadata.creationTimestamp \
+            -o jsonpath='{.items[-1:].metadata.name}')
+
+          if [ -z "$JOB" ]; then
+            echo "::error::no server-migration Job found in $NAMESPACE"
+            exit 1
+          fi
+          echo "Waiting for migration job: $JOB"
+
+          for i in $(seq 1 120); do
+            COMPLETE=$(kubectl -n "$NAMESPACE" get job "$JOB" \
+              -o jsonpath='{.status.conditions[?(@.type=="Complete")].status}' 2>/dev/null || true)
+            FAILED=$(kubectl -n "$NAMESPACE" get job "$JOB" \
+              -o jsonpath='{.status.conditions[?(@.type=="Failed")].status}' 2>/dev/null || true)
+
+            if [ "$COMPLETE" = "True" ]; then
+              echo "OK: migrations completed"
+              exit 0
+            fi
+
+            if [ "$FAILED" = "True" ]; then
+              echo "::error::migration job $JOB failed"
+              echo "::group::migration job log"
+              kubectl -n "$NAMESPACE" logs "job/$JOB" --all-containers --tail=500 || true
+              echo "::endgroup::"
+              echo "::group::migration job describe"
+              kubectl -n "$NAMESPACE" describe job "$JOB" || true
+              echo "::endgroup::"
+              exit 1
+            fi
+
+            sleep 10
+          done
+
+          echo "::error::migration job $JOB did not finish after about 20 min."
+          echo "::group::migration job log"
+          kubectl -n "$NAMESPACE" logs "job/$JOB" --all-containers --tail=500 || true
+          echo "::endgroup::"
+          exit 1
       - name: Wait for KuraInstance
         run: |
           set -euo pipefail

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -738,8 +738,27 @@ jobs:
         # On failure this prints the migration log, which nothing did before:
         # the Job's pod was either still around and unread, or already deleted
         # by an --atomic rollback.
+        #
+        # The log is REDACTED before it is printed. Ecto logs the SQL of every
+        # migration it runs, and the Postgres-to-ClickHouse backfills embed the
+        # Postgres credentials directly in that SQL:
+        #
+        #   ... FROM postgresql('host:port', 'db', 'table', 'user', 'password')
+        #
+        # This repository is public, so an unfiltered `kubectl logs` would
+        # publish the preview database password into a world-readable Actions
+        # log. redact() masks the credential-bearing forms; keep it in front of
+        # anything that prints this log.
         run: |
           set -euo pipefail
+
+          redact() {
+            sed -E \
+              -e "s/(postgresql\('[^']*', *'[^']*', *'[^']*', *'[^']*', *')[^']*'/\1***REDACTED***'/g" \
+              -e "s#(postgres(ql)?://[^:@/]+:)[^@]*@#\1***REDACTED***@#g" \
+              -e "s/(password[\"'[:space:]:=]+)[^[:space:]\"',)]+/\1***REDACTED***/gI"
+          }
+
           JOB=$(kubectl -n "$NAMESPACE" get job \
             -l app.kubernetes.io/component=server-migration \
             --sort-by=.metadata.creationTimestamp \
@@ -750,6 +769,15 @@ jobs:
             exit 1
           fi
           echo "Waiting for migration job: $JOB"
+
+          dump_log() {
+            echo "::group::migration job log (redacted)"
+            kubectl -n "$NAMESPACE" logs "job/$JOB" --all-containers --tail=500 2>&1 | redact || true
+            echo "::endgroup::"
+            echo "::group::migration job describe"
+            kubectl -n "$NAMESPACE" describe job "$JOB" 2>&1 | redact || true
+            echo "::endgroup::"
+          }
 
           for i in $(seq 1 120); do
             COMPLETE=$(kubectl -n "$NAMESPACE" get job "$JOB" \
@@ -764,12 +792,7 @@ jobs:
 
             if [ "$FAILED" = "True" ]; then
               echo "::error::migration job $JOB failed"
-              echo "::group::migration job log"
-              kubectl -n "$NAMESPACE" logs "job/$JOB" --all-containers --tail=500 || true
-              echo "::endgroup::"
-              echo "::group::migration job describe"
-              kubectl -n "$NAMESPACE" describe job "$JOB" || true
-              echo "::endgroup::"
+              dump_log
               exit 1
             fi
 
@@ -777,9 +800,7 @@ jobs:
           done
 
           echo "::error::migration job $JOB did not finish after about 20 min."
-          echo "::group::migration job log"
-          kubectl -n "$NAMESPACE" logs "job/$JOB" --all-containers --tail=500 || true
-          echo "::endgroup::"
+          dump_log
           exit 1
       - name: Wait for KuraInstance
         run: |


### PR DESCRIPTION
## What

Preview deploys fail because the server migration Job fails (`failed: 7/1`, i.e. all 7 attempts), and **nothing has ever printed why**. This makes the failure visible and stops it taking the whole preview environment down with it.

- Drops `--wait-for-jobs` from `helm upgrade`.
- Adds a dedicated **Wait for migrations** step that blocks on the migration Job and, on failure, prints its log and `describe`.

## Why the failure was invisible

Three things conspired:

1. `helm upgrade` ran with `--wait`, which only waits for **Deployments** to go ready, not for **Jobs** to complete. Preview runs the migration as a regular Job (`server.migrationJob.asHook=false`), so nothing blocked on it. Seeding then ran against a half-migrated database, which is the long-standing and very confusing `Table tuist.build_runs does not exist` error. The database was not missing a migration, it was still being migrated.

2. Adding `--wait-for-jobs` (#11835) made Helm finally *notice* the Job had failed. But it combines badly with `--atomic`: the failed upgrade is rolled back and the release is **uninstalled**, which deletes the migration pod. The only copy of the real error goes with it, and the preview is torn down entirely, so we traded a confusing error for no environment and no explanation.

3. The `Diagnostics on failure` step only ever dumped Kura. It never looked at the migration Job.

## What this changes

Blocking on the Job moves into an explicit step, so seeding still cannot run against a half-migrated database, but a migration failure now:

- **leaves the release standing**, so the preview environment still comes up and is usable, and
- **prints the migration Job's log and describe output**, so the next failing deploy actually tells us what is wrong.

## What this deliberately does *not* claim

It does not fix the migration Job itself, and I do not want to pretend otherwise.

The migrations are **not** the bug. I replayed them locally in exactly the order the release uses (`Tuist.Release.migrate` runs all of `Tuist.Repo`, then all of `Tuist.IngestRepo`) against a fresh Postgres **and** a fresh ClickHouse, mirroring a preview's embedded databases:

```
>>> PHASE 1: Postgres migrations
>>> Postgres done
>>> PHASE 2: ClickHouse migrations
>>> ALL MIGRATIONS APPLIED CLEANLY
```

All of them apply cleanly, backfills included. I also checked that `ensure_database_schema/1` and the `grant_*_role/1` calls in `Tuist.Release.migrate/0` are no-ops for the ClickHouse repo (guarded by `when repo == Tuist.Repo`), so the release path does not do anything extra that my replay skipped.

So whatever breaks the Job is specific to the in-cluster environment, and it cannot be diagnosed from outside the cluster while the evidence is being deleted on failure. This PR is what makes it legible. Once a deploy runs with this, the migration error will be in the log and the real fix can follow.

## Validation

- `preview-deploy.yml` parses as valid YAML (10 jobs).
- Step order confirmed: `helm upgrade --install` -> `Wait for migrations` -> `Smoke test` -> `Seed preview account`, so nothing seeds ahead of migrations.
- `--wait-for-jobs` no longer appears in the helm invocation (only in the comment explaining why it is absent).
- The wait keys off the Job's `Complete` / `Failed` conditions rather than raw counts, so Job retries within `backoffLimit` are not mistaken for terminal failure.
- Reproduced the full preview migration sequence locally against fresh Postgres + ClickHouse to establish that the migrations themselves are sound (see above).

Found while getting #11743 back to green. Follows #11831 (preview ClickHouse memory) and #11835.
