### PR TITLE
feat(infra): track a per-deploy dispatch generation on RunnerPools

### DIFF
--- a/infra/helm/tuist/crds/tuist.dev_runnerpools.yaml
+++ b/infra/helm/tuist/crds/tuist.dev_runnerpools.yaml
@@ -182,6 +182,9 @@ spec:
                         minimum of 1 so a rollout always makes progress. Lower
                         keeps more of the warm pool serving during a roll at
                         the cost of a slower rollout.
+                dispatchGeneration:
+                  type: string
+                  description: Opaque token the chart stamps from the server release identifier; changes on every server deploy. The controller records when it changes in status.dispatchRolledAt.
             status:
               type: object
               properties:
@@ -197,6 +200,13 @@ spec:
                 observedImage:
                   type: string
                   description: spec.image value the controller last recorded an imageRolledAt for. Bumped together on every image change.
+                observedDispatchGeneration:
+                  type: string
+                  description: spec.dispatchGeneration value the controller last recorded a dispatchRolledAt for. Bumped together on every change, mirroring observedImage/imageRolledAt.
+                dispatchRolledAt:
+                  type: string
+                  format: date-time
+                  description: Timestamp the controller last observed spec.dispatchGeneration change (the last server deploy). A future drain uses it as the boundary before which a registered-idle Pod's claim-time dispatch config is stale.
                 imageRolledAt:
                   type: string
                   format: date-time

--- a/infra/helm/tuist/templates/runner-pool.yaml
+++ b/infra/helm/tuist/templates/runner-pool.yaml
@@ -1,5 +1,13 @@
 {{- $labels := include "tuist.labels" . }}
 {{- /*
+Deploy-boundary token stamped on every pool: the server release identifier
+this pool's dispatch config was rendered against. It changes on every server
+deploy, so the controller can record the moment it changes in
+`status.dispatchRolledAt` — the boundary a registered-idle drain uses to
+recycle Pods whose claim-time dispatch config predates the deploy.
+*/}}
+{{- $dispatchGeneration := .Values.server.image.tag | default .Chart.AppVersion }}
+{{- /*
 RunnerPool CRs — one per entry in `runnersFleet.pools` (macOS,
 Scaleway Mac minis) and `runnersFleetLinux.pools` (Linux,
 Hetzner Cloud). Each pool is a runner image variant (Xcode
@@ -55,6 +63,7 @@ spec:
   labels: []
   replicas: {{ $replicas }}
   image: {{ $image | quote }}
+  dispatchGeneration: {{ $dispatchGeneration | quote }}
   os: darwin
   fleetSelector: {{ $hostFleetName | quote }}
   dispatchLabel: {{ $dispatchLabel | quote }}
@@ -161,6 +170,7 @@ spec:
   labels: []
   replicas: {{ $replicas }}
   image: {{ $image | quote }}
+  dispatchGeneration: {{ $dispatchGeneration | quote }}
   os: darwin
   fleetSelector: {{ $hostFleetName | quote }}
   dispatchLabel: {{ printf "shape-macos-%s" $xcodeTag | quote }}
@@ -219,6 +229,7 @@ spec:
   labels: []
   replicas: {{ $replicas }}
   image: {{ $image | quote }}
+  dispatchGeneration: {{ $dispatchGeneration | quote }}
   os: linux
   fleetSelector: {{ $hostFleetName | quote }}
   dispatchLabel: {{ $dispatchLabel | quote }}
@@ -294,6 +305,7 @@ spec:
   labels: []
   replicas: {{ dig "minWarmPoolFloor" 1 $autoscaling }}
   image: {{ $shapeImage | quote }}
+  dispatchGeneration: {{ $dispatchGeneration | quote }}
   os: linux
   fleetSelector: {{ $hostFleetName | quote }}
   dispatchLabel: {{ $dispatchLabel | quote }}

--- a/infra/runners-controller/AGENTS.md
+++ b/infra/runners-controller/AGENTS.md
@@ -328,6 +328,18 @@ customer job's runtime. macOS keeps the single-container shape (the
 Tart VM is the isolation boundary; tart-kubelet projects the token
 into it).
 
+**Deploy-boundary tracking:** the chart stamps `spec.dispatchGeneration`
+on every pool from the server release identifier
+(`.Values.server.image.tag`), and the reconciler records the moment it
+changes in `status.dispatchRolledAt`, mirroring the
+`observedImage`/`imageRolledAt` image-roll bookkeeping. This is dormant
+groundwork — nothing drains on it yet. Its purpose is to give a future
+registered-idle drain a boundary: a Pod that claimed before the last
+server deploy froze its claim-time dispatch config (the dispatch-staged
+cache endpoint, JIT extras) and must be recycled to pick up the new
+behavior. An unset generation never differs from the empty observed
+value, so the tracking is a no-op until the chart wires it.
+
 **Death-cause backstop:** the same reconciler also re-emits a
 runner's final log on an abnormal end — a non-zero/SIGKILLed exit, or
 a Pod reaped while still `Running` (the "lost communication" /

--- a/infra/runners-controller/api/v1alpha1/runnerpool_types.go
+++ b/infra/runners-controller/api/v1alpha1/runnerpool_types.go
@@ -114,6 +114,16 @@ type RunnerPoolSpec struct {
 	// Ready. Absent block = the built-in default (5%, min 1).
 	// +optional
 	Rollout *RunnerPoolRollout `json:"rollout,omitempty"`
+
+	// DispatchGeneration is an opaque token the chart stamps from the
+	// server release identifier (`.Values.server.image.tag`). It changes
+	// on every server deploy, so the controller can record the moment it
+	// changes in `status.DispatchRolledAt` — the boundary before which a
+	// registered-idle Pod's claim-time dispatch config (e.g. the
+	// dispatch-staged cache endpoint) is stale. Empty (the default)
+	// leaves the tracking inert: nothing is stamped.
+	// +optional
+	DispatchGeneration string `json:"dispatchGeneration,omitempty"`
 }
 
 // RunnerPoolAutoscaling carries the autoscaling knobs. Lives in
@@ -204,6 +214,21 @@ type RunnerPoolStatus struct {
 	// replicas and survives a restart mid-rollout.
 	// +optional
 	ImageRolledAt metav1.Time `json:"imageRolledAt,omitempty"`
+
+	// ObservedDispatchGeneration is the `spec.dispatchGeneration` value
+	// the controller last recorded a `DispatchRolledAt` for. Bumped
+	// together on every change, mirroring ObservedImage/ImageRolledAt.
+	// +optional
+	ObservedDispatchGeneration string `json:"observedDispatchGeneration,omitempty"`
+
+	// DispatchRolledAt is when the controller most recently observed
+	// `spec.dispatchGeneration` change — i.e. the last server deploy.
+	// A future drain uses it as the boundary: registered-idle Pods that
+	// claimed before this moment froze their claim-time dispatch config
+	// and are recycled so the next claim re-fetches it. Set on first
+	// observe to establish the t=0 baseline.
+	// +optional
+	DispatchRolledAt metav1.Time `json:"dispatchRolledAt,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/infra/runners-controller/api/v1alpha1/zz_generated.deepcopy.go
+++ b/infra/runners-controller/api/v1alpha1/zz_generated.deepcopy.go
@@ -112,4 +112,5 @@ func (in *RunnerPoolStatus) DeepCopyInto(out *RunnerPoolStatus) {
 		in.LastScaleDownAt.DeepCopyInto(out.LastScaleDownAt)
 	}
 	in.ImageRolledAt.DeepCopyInto(&out.ImageRolledAt)
+	in.DispatchRolledAt.DeepCopyInto(&out.DispatchRolledAt)
 }

--- a/infra/runners-controller/controllers/runnerpool_controller.go
+++ b/infra/runners-controller/controllers/runnerpool_controller.go
@@ -139,6 +139,19 @@ func (r *RunnerPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		pool.Status.ImageRolledAt = metav1.Now()
 	}
 
+	// Track dispatch-config rolls the same way. The chart stamps
+	// `spec.dispatchGeneration` from the server release identifier, so it
+	// changes on every server deploy; recording when it changes gives a
+	// future drain the boundary before which a registered-idle Pod's
+	// claim-time dispatch config (the dispatch-staged cache endpoint, the
+	// JIT extras) is stale. Empty generation (the feature unwired) never
+	// differs from the empty observed value, so this is a no-op until the
+	// chart sets it.
+	if pool.Status.ObservedDispatchGeneration != pool.Spec.DispatchGeneration {
+		pool.Status.ObservedDispatchGeneration = pool.Spec.DispatchGeneration
+		pool.Status.DispatchRolledAt = metav1.Now()
+	}
+
 	// Count Pods owned by this pool that are alive (not in a
 	// terminal phase, not being deleted). Terminal Pods aren't
 	// counted toward `replicas` — they're on their way out and a

--- a/infra/runners-controller/controllers/runnerpool_controller_test.go
+++ b/infra/runners-controller/controllers/runnerpool_controller_test.go
@@ -530,6 +530,70 @@ func TestReconcile_StampsImageRolledAtOnFirstReconcile(t *testing.T) {
 	}
 }
 
+// TestReconcile_StampsDispatchRolledAtWhenGenerationChanges covers the
+// deploy-boundary trigger: when the chart bumps spec.dispatchGeneration
+// (a new server release), the controller records ObservedDispatchGeneration
+// and stamps DispatchRolledAt — the boundary a future drain uses to recycle
+// registered-idle Pods whose claim-time dispatch config predates the deploy.
+func TestReconcile_StampsDispatchRolledAtWhenGenerationChanges(t *testing.T) {
+	scheme := mustScheme(t)
+	pool := newPool("p", "ghcr.io/tuist/tuist-runner@sha256:initial", 0)
+	pool.Spec.DispatchGeneration = "sha-abc123"
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(pool).
+		WithStatusSubresource(&tuistv1.RunnerPool{}).
+		Build()
+
+	r := &RunnerPoolReconciler{Client: c, Scheme: scheme, DispatchURL: "http://dispatch"}
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: nn(pool.Namespace, pool.Name),
+	}); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	updated := &tuistv1.RunnerPool{}
+	if err := c.Get(context.Background(), nn(pool.Namespace, pool.Name), updated); err != nil {
+		t.Fatalf("get pool: %v", err)
+	}
+	if updated.Status.ObservedDispatchGeneration != "sha-abc123" {
+		t.Fatalf("ObservedDispatchGeneration = %q, want %q", updated.Status.ObservedDispatchGeneration, "sha-abc123")
+	}
+	if updated.Status.DispatchRolledAt.IsZero() {
+		t.Fatalf("DispatchRolledAt is zero, expected stamp when generation first observed")
+	}
+}
+
+// TestReconcile_LeavesDispatchRolledAtUnsetWhenGenerationEmpty guards the
+// unwired default: with no chart-stamped generation the trigger is inert
+// (empty spec value never differs from the empty observed value).
+func TestReconcile_LeavesDispatchRolledAtUnsetWhenGenerationEmpty(t *testing.T) {
+	scheme := mustScheme(t)
+	pool := newPool("p", "ghcr.io/tuist/tuist-runner@sha256:initial", 0)
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(pool).
+		WithStatusSubresource(&tuistv1.RunnerPool{}).
+		Build()
+
+	r := &RunnerPoolReconciler{Client: c, Scheme: scheme, DispatchURL: "http://dispatch"}
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: nn(pool.Namespace, pool.Name),
+	}); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	updated := &tuistv1.RunnerPool{}
+	if err := c.Get(context.Background(), nn(pool.Namespace, pool.Name), updated); err != nil {
+		t.Fatalf("get pool: %v", err)
+	}
+	if !updated.Status.DispatchRolledAt.IsZero() {
+		t.Fatalf("DispatchRolledAt = %v, want zero (generation unset)", updated.Status.DispatchRolledAt)
+	}
+}
+
 // TestReconcile_BumpsImageRolledAtOnSpecImageChange covers the
 // digest-pin bump path. When `spec.image` flips to a new value,
 // the controller must overwrite `ObservedImage` and reset


### PR DESCRIPTION
## What

Adds a per-deploy "dispatch generation" to the RunnerPool CRD and has the controller record when it changes:

- **`spec.dispatchGeneration`** — the chart stamps this on every pool (macOS xcode pools and Linux shape pools, all render paths) from the server release identifier (`.Values.server.image.tag`), so it changes on every server deploy.
- **`status.dispatchRolledAt`** (+ `status.observedDispatchGeneration`) — the reconciler stamps the moment the generation changes, a direct mirror of the existing `observedImage`/`imageRolledAt` image-roll bookkeeping.

## Why

This is the first, **dormant** increment of a fix for registered-idle runner staleness. A runner that has claimed a job and registered with GitHub, but is still waiting for the scheduler to assign it work, sits "registered-idle" — often for hours. Everything the server staged at claim time (the JIT, and the dispatch-provided `cache_endpoint_url`) is frozen for that whole window. When a server deploy changes dispatch behavior, those pre-deploy-claimed runners keep running jobs with the **old** config.

That is exactly what happened on 2026-07-11: #11767 changed what dispatch stages; the server was correct within minutes, but jobs kept landing on runners whose claims predated the deploy and ran without the new cache endpoint for ~3 hours.

The eventual fix recycles registered-idle Pods whose claim predates the last deploy. That needs a boundary — *"when did dispatch behavior last change?"* — which is what `dispatchRolledAt` provides.

## Why this shape

`dispatchGeneration`/`dispatchRolledAt` deliberately mirror the existing `observedImage`/`imageRolledAt` pattern, so the mechanism is familiar and the future drain can reuse the same image-roll pacing machinery. Sourcing the generation from `.Values.server.image.tag` ties the boundary to **server code** deploys (which is what changes dispatch behavior), not runner-image rolls (already handled separately by the image-roll path).

## Scope / safety

Inert on its own — **no Pod is drained in this PR**. With no chart-stamped generation the spec value is empty and never differs from the empty observed value, so the controller does nothing; once the chart wires it, the controller only records a timestamp. No change to Pod lifecycle.

Intent node (`infra/runners-controller/AGENTS.md`) updated to describe the new field as dormant groundwork.

## Validation

- `go build ./...` and `go vet ./api/...` clean.
- Controller tests pass, including two new reconcile tests: stamps `dispatchRolledAt` when the generation first appears; leaves it zero when the generation is empty.
- `helm template` renders `dispatchGeneration` onto every macOS xcode pool and Linux shape pool from `.Values.server.image.tag` (verified value flows through as `sha-deadbeef` in a test render).

## Next (for context, not in this PR)

- A third-state "busy" signal so the controller can tell a registered-idle Pod from one running a job (open fork: Linux readiness probe vs server-stamped label).
- The drain itself: recycle registered-idle Pods that claimed before `dispatchRolledAt`, paced by the existing roll-concurrency cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
