### PR TITLE
fix(server): keep ClickHouse migrations from silently half-applying

### DIFF
--- a/server/lib/tuist/release.ex
+++ b/server/lib/tuist/release.ex
@@ -25,10 +25,28 @@ defmodule Tuist.Release do
         Ecto.Migrator.with_repo(repo, fn repo ->
           ensure_database_schema(repo)
           Ecto.Migrator.run(repo, :up, all: true)
+          assert_all_migrations_up(repo)
           grant_runtime_role(repo)
           grant_processor_role(repo)
           grant_swift_registry_sync_role(repo)
         end)
+    end
+  end
+
+  # A migration that brings the VM down instead of raising (an exit signal from a
+  # linked process, say) leaves `Ecto.Migrator.run/3` looking like it succeeded,
+  # so the deploy would report success and boot against a half-migrated database.
+  # Fail loudly instead of trusting the run's return value.
+  defp assert_all_migrations_up(repo) do
+    pending =
+      repo
+      |> Ecto.Migrator.migrations()
+      |> Enum.filter(fn {status, _version, _name} -> status == :down end)
+
+    if !Enum.empty?(pending) do
+      versions = Enum.map_join(pending, ", ", fn {_status, version, _name} -> version end)
+
+      raise "Migrations are still pending for #{inspect(repo)} after migrating: #{versions}"
     end
   end
 

--- a/server/mise/tasks/db/migrate.sh
+++ b/server/mise/tasks/db/migrate.sh
@@ -4,3 +4,14 @@
 set -euo pipefail
 
 mix ecto.migrate
+
+# A migration that takes the VM down (rather than raising) can leave `mix
+# ecto.migrate` exiting 0 with migrations still pending, which silently hands a
+# half-migrated database to the seeds. Fail loudly instead.
+pending="$(mix ecto.migrations | grep -E '^\s+down\s+[0-9]+' || true)"
+
+if [ -n "${pending}" ]; then
+  echo "Migrations are still pending after 'mix ecto.migrate':" >&2
+  echo "${pending}" >&2
+  exit 1
+fi

--- a/server/mise/tasks/db/migrate.sh
+++ b/server/mise/tasks/db/migrate.sh
@@ -8,7 +8,8 @@ mix ecto.migrate
 # A migration that takes the VM down (rather than raising) can leave `mix
 # ecto.migrate` exiting 0 with migrations still pending, which silently hands a
 # half-migrated database to the seeds. Fail loudly instead.
-pending="$(mix ecto.migrations | grep -E '^\s+down\s+[0-9]+' || true)"
+migration_status="$(mix ecto.migrations)"
+pending="$(printf '%s\n' "${migration_status}" | grep -E '^\s+down\s+[0-9]+' || true)"
 
 if [ -n "${pending}" ]; then
   echo "Migrations are still pending after 'mix ecto.migrate':" >&2

--- a/server/priv/ingest_repo/migrations/20251118211224_backfill_test_runs_from_command_events.exs
+++ b/server/priv/ingest_repo/migrations/20251118211224_backfill_test_runs_from_command_events.exs
@@ -11,13 +11,15 @@ defmodule Tuist.IngestRepo.Migrations.BackfillTestRunsFromCommandEvents do
   @throttle_ms 500
 
   def up do
-    # Start the PostgreSQL repo since it's not started during ClickHouse migrations
-    case Repo.start_link() do
-      {:ok, _} -> :ok
-      {:error, {:already_started, _}} -> :ok
-    end
-
-    throttle_change_in_batches(&page_query/1, &do_change/1)
+    # `Ecto.Migrator.with_repo/2` only starts the repo being migrated, so the
+    # PostgreSQL repo is down during ClickHouse migrations. Start it through the
+    # same API rather than `Repo.start_link/0`: Ecto runs each migration in a
+    # task it discards right after, and a repo linked to that task would be torn
+    # down with it, leaving later migrations to reuse a terminating supervisor.
+    {:ok, _, _} =
+      Ecto.Migrator.with_repo(Repo, fn _repo ->
+        throttle_change_in_batches(&page_query/1, &do_change/1)
+      end)
   end
 
   def down do

--- a/server/priv/ingest_repo/migrations/20260425120000_rename_legacy_quarantine_events.exs
+++ b/server/priv/ingest_repo/migrations/20260425120000_rename_legacy_quarantine_events.exs
@@ -61,23 +61,21 @@ defmodule Tuist.IngestRepo.Migrations.RenameLegacyQuarantineEvents do
     # no user-level advisory lock, so we open a Postgres transaction, take
     # `pg_advisory_xact_lock`, do the ClickHouse work, and let the transaction
     # commit release the lock. `Ecto.Migrator.with_repo` only starts the
-    # IngestRepo when running IngestRepo migrations, so we have to bootstrap
-    # `Tuist.Repo` ourselves — same pattern as
+    # IngestRepo when running IngestRepo migrations, so we bootstrap
+    # `Tuist.Repo` through that same API — same pattern as
     # `BackfillTestRunsFromCommandEvents`.
-    case Repo.start_link() do
-      {:ok, _} -> :ok
-      {:error, {:already_started, _}} -> :ok
-    end
+    {:ok, _, _} =
+      Ecto.Migrator.with_repo(Repo, fn _repo ->
+        Repo.transaction(
+          fn ->
+            Repo.query!("SELECT pg_advisory_xact_lock($1)", [@lock_id])
 
-    Repo.transaction(
-      fn ->
-        Repo.query!("SELECT pg_advisory_xact_lock($1)", [@lock_id])
-
-        rename_event("quarantined", "muted")
-        rename_event("unquarantined", "unmuted")
-      end,
-      timeout: :infinity
-    )
+            rename_event("quarantined", "muted")
+            rename_event("unquarantined", "unmuted")
+          end,
+          timeout: :infinity
+        )
+      end)
   end
 
   def down do

--- a/server/priv/ingest_repo/migrations/20260428120000_backfill_artifacts_from_postgres.exs
+++ b/server/priv/ingest_repo/migrations/20260428120000_backfill_artifacts_from_postgres.exs
@@ -72,14 +72,14 @@ defmodule Tuist.IngestRepo.Migrations.BackfillArtifactsFromPostgres do
   }
 
   def up do
-    # The PostgreSQL repo is not started during ClickHouse migrations.
-    case Repo.start_link() do
-      {:ok, _} -> :ok
-      {:error, {:already_started, _}} -> :ok
-    end
-
-    Logger.info("Starting artifact backfill to ClickHouse")
-    drain(0, 0)
+    # The PostgreSQL repo is not started during ClickHouse migrations, and Ecto
+    # discards the task each migration runs in, so start it through
+    # `Ecto.Migrator.with_repo/2` instead of linking it to that task.
+    {:ok, _, _} =
+      Ecto.Migrator.with_repo(Repo, fn _repo ->
+        Logger.info("Starting artifact backfill to ClickHouse")
+        drain(0, 0)
+      end)
   end
 
   def down, do: :ok

--- a/server/priv/ingest_repo/migrations/20260501120000_drop_pg_artifacts_table_and_replication_flag.exs
+++ b/server/priv/ingest_repo/migrations/20260501120000_drop_pg_artifacts_table_and_replication_flag.exs
@@ -19,22 +19,24 @@ defmodule Tuist.IngestRepo.Migrations.DropPgArtifactsTableAndReplicationFlag do
   @disable_migration_lock true
 
   def up do
-    # PostgreSQL repo is not started during ClickHouse migrations.
-    case Repo.start_link() do
-      {:ok, _} -> :ok
-      {:error, {:already_started, _}} -> :ok
-    end
-
-    Repo.query!("ALTER TABLE bundles DROP COLUMN IF EXISTS artifacts_replicated_to_ch")
-    Repo.query!("DROP TABLE IF EXISTS artifacts")
+    # The PostgreSQL repo is not started during ClickHouse migrations, and Ecto
+    # discards the task each migration runs in, so start it through
+    # `Ecto.Migrator.with_repo/2` instead of linking it to that task.
+    {:ok, _, _} =
+      Ecto.Migrator.with_repo(Repo, fn _repo ->
+        Repo.query!("ALTER TABLE bundles DROP COLUMN IF EXISTS artifacts_replicated_to_ch")
+        Repo.query!("DROP TABLE IF EXISTS artifacts")
+      end)
   end
 
   def down do
-    case Repo.start_link() do
-      {:ok, _} -> :ok
-      {:error, {:already_started, _}} -> :ok
-    end
+    {:ok, _, _} =
+      Ecto.Migrator.with_repo(Repo, fn _repo ->
+        recreate_artifacts_table()
+      end)
+  end
 
+  defp recreate_artifacts_table do
     Repo.query!("""
     CREATE TABLE artifacts (
       id uuid PRIMARY KEY,

--- a/server/priv/ingest_repo/migrations/20260504120001_backfill_bundles_from_postgres.exs
+++ b/server/priv/ingest_repo/migrations/20260504120001_backfill_bundles_from_postgres.exs
@@ -90,14 +90,14 @@ defmodule Tuist.IngestRepo.Migrations.BackfillBundlesFromPostgres do
   }
 
   def up do
-    # The PostgreSQL repo is not started during ClickHouse migrations.
-    case Repo.start_link() do
-      {:ok, _} -> :ok
-      {:error, {:already_started, _}} -> :ok
-    end
-
-    Logger.info("Starting bundle backfill to ClickHouse")
-    drain(0)
+    # The PostgreSQL repo is not started during ClickHouse migrations, and Ecto
+    # discards the task each migration runs in, so start it through
+    # `Ecto.Migrator.with_repo/2` instead of linking it to that task.
+    {:ok, _, _} =
+      Ecto.Migrator.with_repo(Repo, fn _repo ->
+        Logger.info("Starting bundle backfill to ClickHouse")
+        drain(0)
+      end)
   end
 
   def down, do: :ok

--- a/server/priv/ingest_repo/migrations/20260505120000_drop_pg_bundles_table_and_replication_flag.exs
+++ b/server/priv/ingest_repo/migrations/20260505120000_drop_pg_bundles_table_and_replication_flag.exs
@@ -19,21 +19,23 @@ defmodule Tuist.IngestRepo.Migrations.DropPgBundlesTableAndReplicationFlag do
   @disable_migration_lock true
 
   def up do
-    # PostgreSQL repo is not started during ClickHouse migrations.
-    case Repo.start_link() do
-      {:ok, _} -> :ok
-      {:error, {:already_started, _}} -> :ok
-    end
-
-    Repo.query!("DROP TABLE IF EXISTS bundles")
+    # The PostgreSQL repo is not started during ClickHouse migrations, and Ecto
+    # discards the task each migration runs in, so start it through
+    # `Ecto.Migrator.with_repo/2` instead of linking it to that task.
+    {:ok, _, _} =
+      Ecto.Migrator.with_repo(Repo, fn _repo ->
+        Repo.query!("DROP TABLE IF EXISTS bundles")
+      end)
   end
 
   def down do
-    case Repo.start_link() do
-      {:ok, _} -> :ok
-      {:error, {:already_started, _}} -> :ok
-    end
+    {:ok, _, _} =
+      Ecto.Migrator.with_repo(Repo, fn _repo ->
+        recreate_bundles_table()
+      end)
+  end
 
+  defp recreate_bundles_table do
     Repo.query!("""
     CREATE TABLE bundles (
       id uuid PRIMARY KEY,

--- a/server/priv/ingest_repo/migrations/20260601120000_drop_pg_build_runs_table.exs
+++ b/server/priv/ingest_repo/migrations/20260601120000_drop_pg_build_runs_table.exs
@@ -20,13 +20,13 @@ defmodule Tuist.IngestRepo.Migrations.DropPgBuildRunsTable do
   @disable_migration_lock true
 
   def up do
-    # PostgreSQL repo is not started during ClickHouse migrations.
-    case Repo.start_link() do
-      {:ok, _} -> :ok
-      {:error, {:already_started, _}} -> :ok
-    end
-
-    Repo.query!("DROP TABLE IF EXISTS build_runs CASCADE")
+    # The PostgreSQL repo is not started during ClickHouse migrations, and Ecto
+    # discards the task each migration runs in, so start it through
+    # `Ecto.Migrator.with_repo/2` instead of linking it to that task.
+    {:ok, _, _} =
+      Ecto.Migrator.with_repo(Repo, fn _repo ->
+        Repo.query!("DROP TABLE IF EXISTS build_runs CASCADE")
+      end)
   end
 
   def down do


### PR DESCRIPTION
`mise run install` in `server/` started failing while seeding, with `No such column project_id in table cas_outputs`. The seed failure turned out to be a symptom: the local ClickHouse database had only 164 of 197 ingest migrations applied, yet `mise run install` sailed straight past `db:migrate` into `db:seed` as if migrating had succeeded.

The same code path runs in production and on self-hosted installs, so this is not a local-only annoyance.

## Root cause

Seven ClickHouse migrations need to touch PostgreSQL. They are the backfill-then-drop steps from the PostgreSQL to ClickHouse cutovers for `artifacts`, `bundles` and `build_runs`, and they live in the ingest migrations folder so that the cross-database ordering can be expressed as timestamp ordering. Each one bootstrapped the PostgreSQL repo itself:

```elixir
case Repo.start_link() do
  {:ok, _} -> :ok
  {:error, {:already_started, _}} -> :ok
end
```

Ecto runs every migration inside a `Task.async` process that it discards as soon as the migration returns (`Ecto.Migrator.async_migrate_maybe_in_transaction/7` in `ecto_sql`). So `Repo.start_link/0` linked the PostgreSQL repo supervisor to a process that dies moments later, and the supervisor shut itself down when its parent went away. A later migration then hit `{:error, {:already_started, pid}}` for a supervisor that was already terminating, queried a dying connection pool, and the resulting exit signal took the whole virtual machine down. Because that is an exit signal rather than a raised exception, it never became a non-zero exit status.

The net effect is a migrate run that stops partway through and still reports success, which is what let the seeds run against a database missing `cas_outputs.project_id`.

Reproduced from scratch against a clean PostgreSQL and ClickHouse pair:

- `mix ecto.migrate` applies 153 of 197 ingest migrations and exits 0.
- `Tuist.Release.migrate()` (the path used by the deployment migrate job and by self-hosted installs) applies 153 of 197 and exits 0.

So a fresh self-hosted bootstrap would report a successful migrate job and then boot the server against a half-migrated ClickHouse schema.

## What changed

- The seven cross-database ingest migrations now start the PostgreSQL repo with `Ecto.Migrator.with_repo/2` instead of `Repo.start_link/0`. Two `down/0` bodies were extracted into named private functions so they stay readable inside the closure.
- `Tuist.Release.migrate/0` asserts that no migrations remain pending after each repository's run, and raises if any are.
- The local `db:migrate` mise task performs the equivalent check, so the seeds can never again run against a half-migrated database.

## Approach

`Ecto.Migrator.with_repo/2` is the documented interface for using a repository that is not currently running: it starts the repository, runs the given function, and then stops it again if it was the one that started it. It is already what `Tuist.Release` uses for the repositories it migrates. Because the teardown is deterministic and synchronous, no migration can inherit a supervisor that is on its way out.

The first fix I tried was to `Process.unlink/1` the repository after starting it, so it would outlive the disposable migration task. It does make the failure go away, but it leaves an orphaned, unsupervised connection pool alive for the rest of the run, owned by nobody and never shut down cleanly. It trades "the repository dies too early" for "the repository never dies", so it was dropped in favour of the supported lifecycle.

The guards are deliberately belt and braces. The lesson from this bug is that a migration can bring the virtual machine down without producing a failing exit code, so neither the deployment nor the local bootstrap should trust the exit status alone. Both now verify the end state instead.

A deeper cleanup is worth doing separately: per the widely cited [Safe Ecto Migrations](https://fly.io/phoenix-files/backfilling-data/) guidance, a cross-database data backfill and a PostgreSQL `DROP TABLE` do not belong in a ClickHouse schema migration stream at all. Every fresh database replays a backfill that has nothing to back fill, and the cross-database ordering constraint is hidden inside a filename timestamp. Moving them to a separate data-migrations path is an operations-coordinated change, because self-hosted installs still upgrade through these migrations, so it is left as follow-up rather than folded into this fix.

## Impact

- Fresh worktrees can run `mise run install` in `server/` again.
- Fresh self-hosted and managed bootstraps now apply all ClickHouse migrations, and a migrate run that dies partway now fails the job instead of quietly reporting success.
- No schema change and no new migration. Environments that already applied these migrations are unaffected, since the migrations are only made robust, not altered in what they do.

## Validation

Against a throwaway PostgreSQL plus ClickHouse pair, bootstrapped exactly the way `install.sh` does:

- Before the fix: `mix run --no-start -e 'Tuist.Release.migrate()'` exits 0 with 153 of 197 ingest migrations applied.
- After the fix: the same command applies all 197 ingest migrations and 309 PostgreSQL migrations, exits 0, and `cas_outputs.project_id` exists.
- The pending-migration guard was checked against the real output of `Ecto.Migrator.migrations/1` (`{:down, 20250528130330, "add_build_issues_table"}`), and against `mix ecto.migrations` for the shell task.
- `mise run install` in `server/` completes with exit code 0 and a full seed, including 16,415 seeded `cas_outputs` rows carrying `project_id`.
- `mix test test/tuist/release_test.exs` passes (4 tests), `mix credo` reports no issues, and the project compiles without warnings.

### How to test locally

From `server/`, point at throwaway databases and run the deployment migrate path from zero:

```sh
export TUIST_SERVER_POSTGRES_DB=tuist_scratch TUIST_SERVER_CLICKHOUSE_DB=tuist_scratch
mix ecto.create -r Tuist.Repo
mix ecto.create -r Tuist.IngestRepo
mix run --no-start -e 'Tuist.Release.migrate()'
```

Then confirm every ingest migration landed:

```sh
curl -s http://127.0.0.1:8123 --data-binary \
  "SELECT count() FROM tuist_scratch.schema_migrations"   # 197
curl -s http://127.0.0.1:8123 --data-binary \
  "SELECT count() FROM system.columns WHERE database='tuist_scratch' AND table='cas_outputs' AND name='project_id'"  # 1
```

On `main` the first command stops at 153 while still exiting 0.
