### PR TITLE
fix(infra): move canary eu-central Kura cache to a healthy Start-9-M box

### DIFF
--- a/infra/helm/tuist/values-managed-canary.yaml
+++ b/infra/helm/tuist/values-managed-canary.yaml
@@ -320,19 +320,19 @@ kuraFleet:
 # reconciler adopts a pre-ordered Dedibox carrying the tuist-kura-canary tag (the
 # env boundary, since all Dedibox share the org's default project) and self-joins
 # it as the kura-dedibox pool that backs eu-central. PREREQ before merge: the
-# DEDIBOX_SCW_API 1Password item exists in the canary vault, and a Start-2-L box
-# in DC5 is delivered + tagged tuist-kura-canary; an enabled fleet with no
+# DEDIBOX_SCW_API 1Password item exists in the canary vault, and a Start-9-M box
+# in DC2 is delivered + tagged tuist-kura-canary; an enabled fleet with no
 # adoptable box hangs helm --wait.
 dediboxFleet:
   enabled: true
   machine:
     adoptTag: tuist-kura-canary
-    offer: Start-2-L
-    datacenter: DC5
+    offer: Start-9-M
+    datacenter: DC2
     os: ubuntu_24.04
-    # Node egress budget (Mbps): ~1 Gbit/s box, advertised as
+    # Node egress budget (Mbps): ~500 Mbit/s box, advertised as
     # tuist.dev/egress-mbps so eu-central's 250-Mbps-floor pods bin-pack.
-    egressBudgetMbps: 1000
+    egressBudgetMbps: 500
   scaleway:
     externalSecrets:
       item: DEDIBOX_SCW_API


### PR DESCRIPTION
## What

Repoints the canary `eu-central` Kura cache fleet from Dedibox **133116** (a `Start-2-L` in DC5) to a freshly prepared **`Start-9-M` (id 189167, DC2)**:

- `dediboxFleet.machine.offer`: `Start-2-L` → `Start-9-M`
- `dediboxFleet.machine.datacenter`: `DC5` → `DC2`
- `dediboxFleet.machine.egressBudgetMbps`: `1000` → `500` (matches the box's real link)
- Refreshed the stale prereq comment

The replacement box is already ordered, OS-installed, and tagged `tuist-kura-canary` (via `mise run baremetal:prep-dedibox 189167`), so the fleet self-joins it as soon as this deploys.

## Why

Box 133116 goes `NotReady` roughly every 5 hours. Each time, the fleet's `MachineHealthCheck` correctly marks it unhealthy and the Dedibox provider remediates the only way it can — a full wipe-and-reinstall (~1h). During that reinstall window the `tuist-tuist-dedibox-fleet` MachineDeployment is `0/1` Unavailable, and because the server deploy runs `helm upgrade --install ... --atomic --timeout 60m --wait`, which gates on that MachineDeployment, any production cascade that lands in the window wedges at the **canary deploy** and `--atomic`-rolls-back the whole rollout.

### Root cause

133116 is a known-unstable unit — it has a documented history of silent kernel lockups and it's the smallest `Start-2-L` offer on a basic support plan. It has churned 4–5×/day for **weeks** (the MHC `MachineMarkedUnhealthy` event is at cumulative count 83), so deploys hit the reinstall window frequently. Recent examples on 2026-07-14: run 29314209389 failed at `canary / Deploy → helm upgrade`, and run 29319585495 wedged there for ~84 min — both with 133116 mid-reinstall; interleaving runs passed because the box happened to be Ready.

### Why this fix

`Start-9-M` (AMD Ryzen 5 PRO 3600, 32 GB, 2×1 TB, 500 Mbps, RPNv2) is the shape already validated end-to-end on staging, on modern AMD silicon rather than the flaky Xeon-D. The controller adopts by **tag + offer + datacenter** (exact, case-insensitive), so `offer`/`datacenter` must track the new box; `Start-9-M` is DC2-only, which also cleanly excludes the old Start-2-L/DC5 box from adoption during the roll. `Start-2-L` is out of stock in DC5, so a like-for-like replacement wasn't possible anyway.

## Impact

Canary deploys stop intermittently wedging on the cache box's reinstall churn. No production data-plane change beyond the eu-central canary cache moving to a healthier node.

## Validation

- `mise run baremetal:prep-dedibox 189167` succeeded: install kicked off, box tagged `tuist-kura-canary`, reported in zone `fr-par-1`.
- **Box 189167 install is complete** — polled `GET /dedibox/v1/zones/fr-par-1/servers/189167/install` through `booting → installing → installed` (reached `installed` 2026-07-14 15:14 UTC). The box is prepared and ready to adopt, so this is safe to merge.
- `values-managed-canary.yaml` parses; `offer`/`datacenter`/`egressBudgetMbps` confirmed via `yq`.

## Deploy / follow-ups

- Box 189167 is installed and ready — the "wait for install" gate is cleared. (If it had still been installing at deploy time, the new Machine would sit in `InstallInProgress` → MD `0/1` → `helm --wait` could wedge; that risk no longer applies.)
- After 189167 is serving, **decommission 133116**: untag `tuist-kura-canary` and release/cancel it in the Scaleway console (otherwise it keeps billing and keeps looping its reinstall).
- Separate follow-up: decouple the bare-metal fleet MachineDeployments from the server deploy's `--wait` set, so a flaky cache box can never fail a production rollout again. This PR reduces how often the box churns; decoupling removes the failure mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
