### PR TITLE
fix(server): unbreak preview deploys by migrating ClickHouse on capability, not the hosted flag

### DIFF
--- a/server/lib/tuist/clickhouse_capabilities.ex
+++ b/server/lib/tuist/clickhouse_capabilities.ex
@@ -1,0 +1,52 @@
+defmodule Tuist.ClickHouseCapabilities do
+  @moduledoc """
+  Runtime capability checks for the ClickHouse instance a repo is connected to.
+
+  The command_events migrations used to branch on `Tuist.Environment.tuist_hosted?/0`
+  to decide whether ClickHouse features needing coordination were available. That
+  conflates two unrelated things: whether this is the Tuist-operated product, and
+  whether the ClickHouse behind it is the managed instance. Every preview
+  environment is hosted yet migrates a brand-new single-node ClickHouse with no
+  Keeper, so the assumption broke there and took the migration down with it. Ask
+  the server what it supports instead.
+  """
+
+  alias Tuist.Environment
+
+  @doc """
+  Whether `generateSerialID/1` is usable against `repo`, which requires a
+  configured ClickHouse Keeper (or ZooKeeper); without one it raises
+  `NO_ELEMENTS_IN_CONFIG`. ClickHouse only attaches `system.zookeeper_connection`
+  when coordination is configured, so its presence is the cheapest
+  side-effect-free signal.
+  """
+  def serial_ids_supported?(repo) do
+    case repo.query("SELECT count() FROM system.tables WHERE database = 'system' AND name = 'zookeeper_connection'") do
+      {:ok, %{rows: [[count]]}} ->
+        count > 0
+
+      {:error, error} ->
+        # Guessing here would reintroduce the failure this check exists to
+        # prevent: assume Keeper and the migration dies on a server without one,
+        # assume no Keeper and the managed instance quietly gets random legacy
+        # IDs instead of serial ones.
+        raise "Could not determine whether ClickHouse supports serial IDs: #{Exception.message(error)}"
+    end
+  end
+
+  @doc """
+  Whether command_events should hand out Keeper-backed serial legacy IDs.
+
+  Dev and test opt out even though their ClickHouse runs a Keeper (the local
+  server enables it so tests can use transactions): local databases stay on the
+  random default rather than taking a coordination round-trip per insert.
+  Everywhere else this follows what the server can actually do.
+  """
+  def use_serial_ids?(repo) do
+    if Environment.dev?() or Environment.test?() do
+      false
+    else
+      serial_ids_supported?(repo)
+    end
+  end
+end

--- a/server/priv/ingest_repo/migrations/20250702083710_create_command_events_clickhouse.exs
+++ b/server/priv/ingest_repo/migrations/20250702083710_create_command_events_clickhouse.exs
@@ -2,12 +2,15 @@ defmodule Tuist.ClickHouseRepo.Migrations.CreateCommandEventsClickhouse do
   use Ecto.Migration
 
   def up do
-    # In production, these are created by Clickhouse Pipes.
-    if Tuist.Environment.dev?() || Tuist.Environment.test?() ||
-         not Tuist.Environment.tuist_hosted?() do
-      # excellent_migrations:safety-assured-for-next-line raw_sql_executed
-      execute """
-       CREATE TABLE command_events
+    # The managed production instance already has this table: ClickHouse Pipes
+    # created it when command_events was replicated over from Postgres. Every
+    # other database starts empty and needs it created here — including hosted
+    # ones, since each preview environment migrates a brand-new ClickHouse.
+    # `IF NOT EXISTS` states that directly, instead of inferring it from whether
+    # the deployment happens to be hosted.
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    execute """
+     CREATE TABLE IF NOT EXISTS command_events
        (
            `id` UUID,
            `legacy_id` UInt64 DEFAULT abs(rand64()),
@@ -48,10 +51,7 @@ defmodule Tuist.ClickHouseRepo.Migrations.CreateCommandEventsClickhouse do
       PRIMARY KEY (created_at, id)
       ORDER BY (created_at, id)
       SETTINGS index_granularity = 8192
-      """
-    else
-      :ok
-    end
+    """
   end
 
   def down do

--- a/server/priv/ingest_repo/migrations/20250708112228_make_command_events_legacy_id_serial.exs
+++ b/server/priv/ingest_repo/migrations/20250708112228_make_command_events_legacy_id_serial.exs
@@ -2,10 +2,13 @@ defmodule Tuist.ClickHouseRepo.Migrations.MakeCommandEventsLegacyIDSerial do
   use Ecto.Migration
 
   def up do
-    # This migration requires Zookeeper, which is only available in hosted deployment environments.
-    if Tuist.Environment.dev?() || Tuist.Environment.test?() || !Tuist.Environment.tuist_hosted?() do
-      :ok
-    else
+    # `generateSerialID` needs a configured Keeper, which the managed instance
+    # has and a single-node ClickHouse does not. Being hosted does not imply
+    # having one: every preview environment is hosted and runs its own
+    # Keeper-less ClickHouse, where these statements fail outright. Where serial
+    # IDs are unavailable, legacy_id keeps the random default it was created
+    # with.
+    if Tuist.ClickHouseCapabilities.use_serial_ids?(repo()) do
       # excellent_migrations:safety-assured-for-next-line raw_sql_executed
       # Set the start of our serial to the maximum legacy_id in the command_events table.
       execute """

--- a/server/priv/ingest_repo/migrations/20250715193142_change_command_events_primary_key.exs
+++ b/server/priv/ingest_repo/migrations/20250715193142_change_command_events_primary_key.exs
@@ -2,12 +2,15 @@ defmodule Tuist.ClickHouseRepo.Migrations.ChangeCommandEventsPrimaryKey do
   use Ecto.Migration
 
   def up do
+    # Serial IDs require a configured Keeper. The managed instance has one; a
+    # single-node ClickHouse (dev, test, self-hosted, and every hosted preview)
+    # does not, and would reject the default expression.
     legacy_id_default =
-      if Tuist.Environment.dev?() || Tuist.Environment.test?() ||
-           !Tuist.Environment.tuist_hosted?(),
-         do: "abs(rand64())",
-         # Serial IDs require Zookeeper, which is only available in hosted deployment environments.
-         else: "generateSerialID('command_events_legacy_id')"
+      if Tuist.ClickHouseCapabilities.use_serial_ids?(repo()) do
+        "generateSerialID('command_events_legacy_id')"
+      else
+        "abs(rand64())"
+      end
 
     execute("""
     CREATE TABLE command_events_new

--- a/server/test/tuist/clickhouse_capabilities_test.exs
+++ b/server/test/tuist/clickhouse_capabilities_test.exs
@@ -1,0 +1,61 @@
+defmodule Tuist.ClickHouseCapabilitiesTest do
+  use ExUnit.Case, async: true
+  use Mimic
+
+  alias Tuist.ClickHouseCapabilities
+  alias Tuist.Environment
+
+  defmodule KeeperRepo do
+    @moduledoc false
+    def query(_statement), do: {:ok, %{rows: [[1]]}}
+  end
+
+  defmodule KeeperlessRepo do
+    @moduledoc false
+    def query(_statement), do: {:ok, %{rows: [[0]]}}
+  end
+
+  defmodule UnreachableRepo do
+    @moduledoc false
+    def query(_statement), do: {:error, %Ch.Error{code: 210, message: "connection refused"}}
+  end
+
+  describe "serial_ids_supported?/1" do
+    test "is true when the server has coordination configured" do
+      assert ClickHouseCapabilities.serial_ids_supported?(KeeperRepo)
+    end
+
+    test "is false on a single-node server with no Keeper, like the one every preview runs" do
+      refute ClickHouseCapabilities.serial_ids_supported?(KeeperlessRepo)
+    end
+
+    test "raises rather than guessing when the server cannot answer" do
+      assert_raise RuntimeError, ~r/Could not determine/, fn ->
+        ClickHouseCapabilities.serial_ids_supported?(UnreachableRepo)
+      end
+    end
+  end
+
+  describe "use_serial_ids?/1" do
+    test "opts out in test even when the server supports serial ids" do
+      assert Environment.test?()
+
+      refute ClickHouseCapabilities.use_serial_ids?(KeeperRepo)
+    end
+
+    test "opts out in dev even when the server supports serial ids" do
+      stub(Environment, :test?, fn -> false end)
+      stub(Environment, :dev?, fn -> true end)
+
+      refute ClickHouseCapabilities.use_serial_ids?(KeeperRepo)
+    end
+
+    test "follows the server outside dev and test" do
+      stub(Environment, :test?, fn -> false end)
+      stub(Environment, :dev?, fn -> false end)
+
+      assert ClickHouseCapabilities.use_serial_ids?(KeeperRepo)
+      refute ClickHouseCapabilities.use_serial_ids?(KeeperlessRepo)
+    end
+  end
+end


### PR DESCRIPTION
Preview environments have not deployed successfully all day. Every real attempt to deploy one fails, and this fixes the cause.

### What changed

- `command_events` is now created with `CREATE TABLE IF NOT EXISTS` instead of being created only on non-hosted deployments.
- The two migrations that set up serial `legacy_id` values now ask the connected ClickHouse whether it actually supports them, through a new `Tuist.ClickHouseCapabilities` module, instead of inferring it from whether the deployment is hosted.
- Dev and test keep their existing opt-out from serial IDs, so local and test behaviour is unchanged.

### Why

"Deploying a preview" runs `preview-deploy.yml`, which brings up an ephemeral per-pull-request environment. Every non-skipped run today failed the same way: `helm upgrade --install` timed out because the `tuist-server-migrate` Job failed its 7 attempts, and the server pod crash-looped behind it, waiting on a database that was never migrated.

The migrate pod's own logs never made it into CI. `--atomic` rolls the release back and deletes the namespace resources before the diagnostics step runs, so the diagnostics only ever printed `No resources found`. The actual error was only visible by reproducing the migration locally.

### Root cause

Three `command_events` ClickHouse migrations branch on `Tuist.Environment.tuist_hosted?/0`. That flag means "this is the Tuist-operated product". The migrations were using it to mean something narrower and different: "this is the managed production ClickHouse". That second meaning carries two assumptions that only hold there:

1. The `command_events` table already exists, because ClickHouse Pipes created it when the table was replicated over from PostgreSQL.
2. A ClickHouse Keeper (the built-in coordination service, ClickHouse's replacement for [ZooKeeper](https://zookeeper.apache.org)) is configured, so `generateSerialID` works.

A preview breaks that inference. It is hosted, so `tuist_hosted?` is true, but it migrates a brand-new single-node ClickHouse that has neither Pipes nor a Keeper. So `20250702083710_create_command_events_clickhouse` skipped itself, and `20250708112228_make_command_events_legacy_id_serial` then ran straight into:

```
Code: 60. DB::Exception: Unknown table expression identifier 'command_events' (UNKNOWN_TABLE)
```

Production never noticed, because its database is not fresh and these migrations ran there long ago. Previews are the only place where a *fresh* database is migrated with `TUIST_HOSTED=1`, which is why this only ever breaks previews.

Checking against a Keeper-less server confirmed all three migrations were wrong there, not just the first one. `generateSerialID` fails outright with `DB::Exception: There is no Zookeeper configuration in server config (NO_ELEMENTS_IN_CONFIG)`, so fixing only the table creation would have moved the failure one migration further down.

### Approach

The migrations now key off what the database actually is and can do, rather than inferring it from a product flag.

`IF NOT EXISTS` says the real intent directly: production already has this table, everything else needs it created. For the serial IDs, the capability check queries whether coordination is configured, since ClickHouse only attaches `system.zookeeper_connection` when it is. That is a side-effect-free probe and it cannot drift away from the chart the way an environment flag can, which matters because self-hosted installs also run a Keeper-less ClickHouse.

An unanswerable probe raises rather than defaulting either way. Guessing is what caused this bug: assume a Keeper and the migration dies on a server without one, assume none and the managed instance quietly gets random IDs where it expects serial ones.

The alternative of adding a new environment variable (something like `TUIST_CLICKHOUSE_EMBEDDED`) was rejected: it would have to be threaded through the chart and set correctly for every managed environment, every preview, and every self-hosted install, and getting it wrong reproduces exactly this class of bug silently.

Editing the historical migrations is safe. They are already recorded as applied in production, staging and canary, so their bodies never run there again. They only execute against fresh databases, which is precisely the case being fixed.

### Impact

Preview environments deploy again. Production, staging and canary are untouched: the migrations are already applied there, and a fresh managed instance with a Keeper still gets `generateSerialID` defaults. Dev, test and self-hosted keep the random `legacy_id` default they already had.

### Validation

The release's real migrate path (`Tuist.Release.migrate`) was run against fresh databases in each shape that matters, using a local ClickHouse configured exactly like the preview one (same 26.1 image family, no Keeper):

| Shape | Before | After |
| --- | --- | --- |
| Preview (hosted, no Keeper) | fails with `UNKNOWN_TABLE` | exits 0, `legacy_id` default `abs(rand64())` |
| Production-like (hosted, Keeper) | not previously exercised | exits 0, `legacy_id` default `generateSerialID(...)` preserved |
| Dev (`mise run db:reset`) | works | unchanged, seeds fine |

Also run:

- `MIX_ENV=test mise run db:reset`, rebuilding the test database from the changed migrations, clean.
- `mix test test/tuist/clickhouse_capabilities_test.exs test/tuist/command_events_test.exs`, 75 passed.
- `mix credo lib/tuist/clickhouse_capabilities.ex`, no issues.
- `mise run format`.

### How to test locally

Add the `preview` label to this pull request and the preview deploy should reach `Seed preview account` and go green, instead of failing in `helm upgrade --install`.

To see the failure and the fix without a cluster, point the migration at a ClickHouse without a Keeper (the local dev one configures one deliberately, so it does not reproduce it):

```
MIX_ENV=prod TUIST_DEPLOY_ENV=preview TUIST_HOSTED=1 \
  DATABASE_URL=... TUIST_CLICKHOUSE_URL=... \
  mix eval "Tuist.Release.migrate()"
```

On `main` this dies on the missing `command_events` table. On this branch it completes.

### Follow-up worth doing separately

The migrate Job's logs are destroyed by the `--atomic` rollback before the diagnostics step runs, which is why this needed a local reproduction to diagnose at all. Capturing failed Job logs before the rollback would make the next preview failure self-explanatory.
