### PR TITLE
fix(generator): avoid fatal crash on duplicate generated-project keys

### DIFF
--- a/cli/Sources/TuistGenerator/Generator/WorkspaceDescriptorGenerator.swift
+++ b/cli/Sources/TuistGenerator/Generator/WorkspaceDescriptorGenerator.swift
@@ -114,7 +114,11 @@ struct WorkspaceDescriptorGenerator: WorkspaceDescriptorGenerating {
         Logger.current.debug("Finished concurrent generation of \(projects.count) projects")
 
         Logger.current.debug("Creating generated projects dictionary")
-        let generatedProjects: [AbsolutePath: GeneratedProject] = Dictionary(uniqueKeysWithValues: projects.map { project in
+        // Multiple graph nodes can resolve to the same derived `xcodeprojPath` (e.g. an
+        // external SPM package reached via more than one graph edge). `uniqueKeysWithValues`
+        // crashes fatally on that duplicate instead of merging it, so we dedupe defensively
+        // here the same way `targets` already does a few lines below.
+        let generatedProjects: [AbsolutePath: GeneratedProject] = Dictionary(projects.map { project in
             let pbxproj = project.xcodeProj.pbxproj
             let targets = pbxproj.nativeTargets.map {
                 ($0.name, $0)
@@ -128,7 +132,7 @@ struct WorkspaceDescriptorGenerator: WorkspaceDescriptorGenerating {
                     name: project.xcodeprojPath.basename
                 )
             )
-        })
+        }, uniquingKeysWith: { $1 })
 
         // Workspace structure
         Logger.current.debug("Generating workspace structure")


### PR DESCRIPTION
This happens in `WorkspaceDescriptorGenerator.generate(graphTraverser:)`, where
the `generatedProjects` dictionary is built with `Dictionary(uniqueKeysWithValues:)`
keyed by `project.xcodeprojPath`. If more than one generated `ProjectDescriptor`
in `projects` ends up with the same `xcodeprojPath` — observed with an external
SPM package reached via multiple graph edges (e.g. several targets each
depending on different products of the same package) — this initializer
crashes the whole process instead of merging the duplicate.

Reproduced on CI runners with high core counts (more generator concurrency
increases the odds of hitting it) but not reliably locally on lower-core
machines, which made it look non-deterministic. Since it's currently a hard
crash (SIGTRAP/exit 133), there's no way to recover or even get a useful
error message pointing at the actual duplicate.

## Fix

Swap `Dictionary(uniqueKeysWithValues:)` for `Dictionary(_:uniquingKeysWith:)`,
keeping the same "last one wins" behavior Tuist already uses for `targets`
three lines below in this exact same function. A duplicate project entry is
harmless to resolve this way — both entries describe the same external
package, so generation can safely proceed with one of them instead of
crashing.

## Test plan

- [x] Applied and verified against a project graph that reliably produces two
      generated projects sharing an `xcodeprojPath` (multiple targets fanning
      into one external SPM package with several products) — generation now
      completes instead of crashing.
- [ ] Would appreciate a maintainer's guidance on whether a regression test
      belongs in `WorkspaceDescriptorGeneratorTests` for this specific
      duplicate-key scenario — happy to add one if pointed at the right
      graph-construction fixtures.