### PR TITLE
feat(infra): recycle runners flagged "running" that never executed a job

### DIFF
--- a/infra/linux-runner-image/AGENTS.md
+++ b/infra/linux-runner-image/AGENTS.md
@@ -27,6 +27,22 @@ macOS image). Same single-shot lifecycle, much simpler substrate.
   (`TUIST_RUNNER_JIT_PATH`) and `exec`s
   `./run.sh --jitconfig <jit> --disableupdate`, or exits 0 if no
   JIT was staged (410 drain / poller abort). Holds no SA token.
+  When `TUIST_RUNNER_IDLE_TTL_SECONDS > 0` it also arms an
+  idle-registration watchdog before exec: a JIT runner that
+  registers with GitHub but is never handed a job sits
+  registered-idle for hours, freezing whatever it staged at claim
+  time (e.g. `TUIST_CACHE_ENDPOINT`). The watchdog `pkill`s the
+  `Runner.Listener` after the TTL with no job, so the Pod completes
+  and the reconciler replaces it with a fresh Pod that re-claims
+  against the current server. Unset/0 disables it (the default), so
+  the runner behaves exactly as before until the controller wires
+  the env.
+- `/usr/local/bin/job-started-hook.sh` —
+  `ACTIONS_RUNNER_HOOK_JOB_STARTED`. Runs just before a job's steps
+  and disarms the idle watchdog (kills it, drops
+  `/tmp/tuist-job-started`), so a runner that *does* get a job is
+  never recycled mid-job. Always exits 0 (a non-zero started-hook
+  fails the job).
 - `/usr/local/bin/vitals.sh` — periodic resource-vitals emitter.
   `run-job.sh` backgrounds it just before exec'ing the runner (the
   dispatch-poll rollout-bridge path does too), so it samples for the

--- a/infra/linux-runner-image/Dockerfile
+++ b/infra/linux-runner-image/Dockerfile
@@ -106,6 +106,7 @@ RUN apt-get update \
         bzip2 \
         p7zip-full \
         file \
+        procps \
         git-lfs \
         openssh-client \
         postgresql-client \
@@ -210,12 +211,16 @@ USER root
 # infra/runners-controller/AGENTS.md for the split-credential shape.
 COPY dispatch-poll.sh /usr/local/bin/dispatch-poll.sh
 COPY run-job.sh /usr/local/bin/run-job.sh
+# job-started-hook.sh is wired as ACTIONS_RUNNER_HOOK_JOB_STARTED by run-job.sh
+# when the idle-registration watchdog is armed; it disarms the watchdog the
+# instant a job starts so a runner mid-job is never recycled.
+COPY job-started-hook.sh /usr/local/bin/job-started-hook.sh
 COPY vitals.sh /usr/local/bin/vitals.sh
 # metrics-sampler.sh runs in the `metrics` native-sidecar container
 # (holds the SA token like the poller; never the runner container) and
 # POSTs the microVM's machine metrics for the job detail page.
 COPY metrics-sampler.sh /usr/local/bin/metrics-sampler.sh
-RUN chmod +x /usr/local/bin/dispatch-poll.sh /usr/local/bin/run-job.sh /usr/local/bin/vitals.sh /usr/local/bin/metrics-sampler.sh
+RUN chmod +x /usr/local/bin/dispatch-poll.sh /usr/local/bin/run-job.sh /usr/local/bin/job-started-hook.sh /usr/local/bin/vitals.sh /usr/local/bin/metrics-sampler.sh
 
 USER runner
 

--- a/infra/linux-runner-image/job-started-hook.sh
+++ b/infra/linux-runner-image/job-started-hook.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# ACTIONS_RUNNER_HOOK_JOB_STARTED — the GitHub Actions runner runs this on the
+# runner host just before a job's steps execute. A job has been assigned, so
+# this runner must NOT be recycled by the idle-registration watchdog armed in
+# run-job.sh: disarm it. Kill the watchdog process and drop the marker file the
+# watchdog also checks — belt and suspenders, so a job in flight is never
+# interrupted even if the watchdog woke in the same instant.
+#
+# Always exit 0: a non-zero ACTIONS_RUNNER_HOOK_JOB_STARTED fails the job.
+set -u
+
+marker=/tmp/tuist-job-started
+pidfile=/tmp/tuist-idle-watchdog.pid
+
+: >"${marker}" 2>/dev/null || true
+if [ -f "${pidfile}" ]; then
+  kill "$(cat "${pidfile}" 2>/dev/null)" 2>/dev/null || true
+fi
+exit 0

--- a/infra/linux-runner-image/run-job.sh
+++ b/infra/linux-runner-image/run-job.sh
@@ -50,6 +50,33 @@ if [ -s "${CACHE_ENDPOINT_PATH}" ]; then
   fi
 fi
 echo "$(date -u +%FT%TZ) run-job: JIT staged, starting runner"
+# Idle-registration TTL watchdog. A JIT runner that registers with GitHub but
+# is never assigned a job sits registered-idle — for hours — freezing whatever
+# was staged at claim time (e.g. TUIST_CACHE_ENDPOINT). When
+# TUIST_RUNNER_IDLE_TTL_SECONDS > 0, arm a background timer before exec: if no
+# job has started within the TTL, SIGTERM the GitHub runner process so the Pod
+# completes (exit) and the RunnerPoolReconciler replaces it with a fresh Pod
+# that re-claims against the current server. The watchdog is disarmed the
+# instant a job starts by ACTIONS_RUNNER_HOOK_JOB_STARTED (job-started-hook.sh),
+# which kills it and drops the marker below — so an in-flight job is never
+# interrupted. Unset/0/non-numeric leaves the runner behaving exactly as before.
+IDLE_TTL=${TUIST_RUNNER_IDLE_TTL_SECONDS:-0}
+case "${IDLE_TTL}" in '' | *[!0-9]*) IDLE_TTL=0 ;; esac
+if [ "${IDLE_TTL}" -gt 0 ]; then
+  export ACTIONS_RUNNER_HOOK_JOB_STARTED=/usr/local/bin/job-started-hook.sh
+  idle_marker=/tmp/tuist-job-started
+  idle_pidfile=/tmp/tuist-idle-watchdog.pid
+  rm -f "${idle_marker}" "${idle_pidfile}"
+  (
+    sleep "${IDLE_TTL}"
+    # A job started meanwhile — the hook created the marker (and killed us,
+    # but re-check in case we woke in the same instant): nothing to recycle.
+    [ -f "${idle_marker}" ] && exit 0
+    echo "$(date -u +%FT%TZ) run-job: idle-registration TTL (${IDLE_TTL}s) exceeded with no job assigned, recycling"
+    pkill -TERM -f 'Runner.Listener run' 2>/dev/null || true
+  ) &
+  echo $! >"${idle_pidfile}"
+fi
 # Forensic vitals for this job's lifetime. Backgrounded so it
 # survives the `exec` below and keeps sampling until the container
 # (and microVM) dies; its last line before a mid-job death lands in


### PR DESCRIPTION
## The real problem: runners flagged "running" that never ran a job

The moment a workflow job is created, it makes a runner flip to **"running"** — but that flag is set when the runner is *claimed*, **not** when it actually starts a job. So a runner can be marked "running" everywhere while executing nothing, never receive a real job, and — because it *looks* busy — never get cleaned up, **even after the job that spawned it is cancelled.**

"Running" means two things, and **neither means "executing a job":**

- **Server-side:** the claim's `lifecycle_state` and the ClickHouse `runner_jobs.status` go to `running` at **JIT-mint time** (`mark_running`) — i.e. when the runner is *claimed*, not when GitHub assigns it work.
- **Kubernetes:** the pod phase is `Running` once the container/VM is up — also nothing to do with a job.

So a **registered-idle** runner (claimed, registered with GitHub, waiting for a job that GitHub gave to someone else) is flagged `running` in both places while doing nothing.

### Why cancelling doesn't clean them up

The cleanup trusts that lying flag:

- The claim is keyed to a **specific `workflow_job_id`**. Cancelling a job frees *that* job's claim — but an idle runner's claim is usually tied to a *different* job (the label scramble), one GitHub ran on a **sibling** runner.
- `OrphanedRunnersWorker` **leaves anything GitHub reports `in_progress`**, and there is **no `workflow_job.in_progress` handler** to ever downgrade the flag. So while that job runs on the sibling, the idle runner stays `running` and un-reaped.
- Net: runners flagged `running`, running nothing, never getting the real job, and cleanup skipping them because they look busy.

They also freeze whatever they staged at claim time (`TUIST_CACHE_ENDPOINT`, the JIT), so a server deploy that changes dispatch behavior (#11767) keeps landing jobs on stale runners for hours.

### Why external cleanup can't fix it

The only place that knows *"is this runner actually executing a job?"* is **inside the pod**: the `job-started` marker, written by the runner's own job-start hook (`ACTIONS_RUNNER_HOOK_JOB_STARTED`) the instant it accepts work. Nothing external has it — the server's `running` is really "claimed," k8s `Running` is really "booted." So any external actor (a cleanup worker, the controller, a blind delete) reasons from a flag that can't tell idle-registered from busy. **The decision has to be made in-pod, where the truth lives.**

## The solution

Three parts, all consistent with "the truth is in-pod":

**1. Register for real work only** *(server)* — a runner should transition warm→registered only when a job is actually **dispatchable** (`queued`), not while it's `waiting` on a human approval. Today `waiting` jobs are enqueued as claimable demand (`server/lib/tuist/runners/dispatch.ex:123`), minting runners for jobs that *can't run* — the worst, days-long zombies. Stop claiming `waiting`; register only once the job flips to `queued`. The warm→registered transition is ~seconds (the warm pool pre-pays the boot), so deferring registration until the job is ready costs almost nothing in latency.

**2. Keep the autoscaler driving desired** *(unchanged)* — `desired = f(dispatchable jobs) + warm slack`. With (1), `Claimed` reflects real demand instead of approval-gated phantoms, so the number actually falls back to the warm floor when work drains.

**3. Recycle runners that aren't executing a job, on release** — bump a **generation** (`dispatchGeneration`, un-shelving #11842) on every server/runner release; that triggers a **paced** recycle in the controller. Because the `running` flag lies, the controller **cannot** pick "the idle ones" — so it recycles **by generation** (stale = claimed before the release), blindly, and the **in-pod marker decides the outcome**: a runner actually executing a job finishes it; an idle one exits immediately. The controller/delete is only the trigger; the pod is the decider.

## The in-pod primitive: `terminate-if-idle`

Everything rides on one atom: *check the `job-started` marker; exit only if it's absent.* The marker (writer: the GitHub runner via our hook) is the single source of truth for "actually running a job." Any trigger — a release generation, a controller delete/SIGTERM, or a timer — just *invokes* it; the safety logic is the same and lives in the pod.

## What's in this PR today

The `terminate-if-idle` foundation, on the Linux runner image:
- `job-started-hook.sh` — the marker (wired as `ACTIONS_RUNNER_HOOK_JOB_STARTED`).
- the watchdog in `run-job.sh` + `procps` for the signal.

Currently wired to a TTL timer as trigger #1; the generation trigger + the controller-paced recycle land next.

## Next (per the plan above)

- *(server)* **Layer 1** — stop claiming `waiting` jobs; register only on `queued`.
- *(controller)* **generation trigger** — un-shelve #11842's `dispatchGeneration`/`DispatchRolledAt`, bumped per server/runner release, and a **paced** recycle of stale-generation pods (reusing `rollConcurrencyCap`).
- *(images)* a **PID-1 SIGTERM handler** in `run-job.sh` (ours, not GitHub's `run.sh`) so a controller delete finishes a busy job (under a long grace) and exits an idle one; set `terminationGracePeriodSeconds` to cover job duration.
- *(spike)* **macOS** — confirm tart-kubelet delivers SIGTERM into the Tart VM and honors the grace; if not, the pod-pull generation-poll (self-exit inside `dispatch-poll.sh`) is the macOS-safe delivery. Also confirm an idle runner unregisters cleanly on SIGTERM.
- *(core — attribution linchpin)* a **`workflow_job.in_progress` handler**. Its payload carries `runner_name` (already stored on the claim at `mark_running`), so the server can learn which runner GitHub *actually* assigned each job to — closing the claim↔execution mismatch at its source. That one signal corrects all three symptoms in #11862: **reaping** (know the real busy/idle), **concurrency accounting** (#11836 — charge the real execution, not a phantom claim, so an account isn't throttled below its limit by mis-attributed claims), and **machine-metrics attribution** (record samples against the executed job, not the claimed one). The in-pod `job_running` marker complements it (cheap, webhook-latency-free busy/idle), but `in_progress` is what maps runner→*actual job*.

## Validation

- `bash -n` + `shellcheck -S style` clean; a local harness confirms the marker recycles an idle runner at the trigger and the disarm keeps a busy one alive.
- As the pieces land: controller tests for the generation trigger + paced recycle; a server test for register-on-`queued`-not-`waiting`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
