### PR TITLE
fix(infra): roll tart-kubelet host config over the tailnet, not the mini's public IP

### DIFF
--- a/infra/cluster-api-provider-tuist/AGENTS.md
+++ b/infra/cluster-api-provider-tuist/AGENTS.md
@@ -87,20 +87,28 @@ tart-kubelet binary change. The re-push is zero-downtime (running Tart VMs
 survive `UpdateTartKubelet`). Terminal-failed CRs are excluded until
 `Status.FailureReason` is cleared.
 
-The drift re-push SSHes over the **tailnet**, not the mini's public IP: once a
-runner mini starts booting Tart VMs its Internet Sharing / vmnet setup filters
-inbound `:22` on the public interface, so a public-IP dial times out and the
-whole fleet's roll wedges — while the same host stays reachable on the tailnet
-(that's the path its metrics are scraped over). `UpdateTartKubelet` therefore
-dials the mini's egress-Service DNS (`egressHost`, port 22 added to
-`reconcileTailscaleEgressService`), which routes through the ProxyGroup. This
+The drift re-push dials the mini's **public IP first, then falls back to the
+tailnet**. Once a runner mini starts booting Tart VMs its Internet Sharing /
+vmnet setup filters inbound `:22` on the public interface, so a public-IP dial
+times out and the fleet's roll wedges — while the same host stays reachable on
+the tailnet (that's the path its metrics are scraped over). So when the public
+handshake never completes (empty fingerprint = a pure connect failure, distinct
+from a mid-session error), `UpdateTartKubelet` retries over the mini's
+egress-Service DNS (`egressHost`, port 22 added to
+`reconcileTailscaleEgressService`), which routes through the ProxyGroup — this
 needs `tcp:22` in the `tag:tuist-k8s-<env>` → `tag:tuist-macmini-<env>` grant
-(`infra/tailscale/acls.json`, mirrored to the admin console). First-boot
-`bootstrap.Run` still uses the public IP — the mini hasn't joined the tailnet
-yet — and OSS/self-hosted clusters (no egress ProxyGroup) fall back to it too.
-Because the transport is controller-side only, it doesn't change
-`HostConfigHash`; already-terminal CRs still need `Status.FailureReason`
-cleared to retry over the new path.
+(`infra/tailscale/acls.json`, mirrored to the admin console). The fallback sets
+`SkipTailscaleInstall`: `installTailscale` stops tailscaled to swap its binary,
+which over a tailnet-transported session would drop the tunnel mid-update and
+strand the mini off the tailnet — so a tailnet-transported roll can't update
+Tailscale itself (rare; needs the public path or re-provisioning). Public-first
+means fresh/idle minis (public open, egress Service maybe not yet rewritten by
+the operator) never touch the tailnet path, and by the time a mini's public
+path is filtered its egress Service has long existed. cfg.IP is a pure dial
+target on the update path (HostConfigHash strips it), so the fallback re-points
+it without changing what's pushed; the whole transport is controller-side only,
+so `HostConfigHash` is unchanged and already-terminal CRs still need
+`Status.FailureReason` cleared to retry.
 
 Two auxiliary controllers run alongside it:
 

--- a/infra/cluster-api-provider-tuist/AGENTS.md
+++ b/infra/cluster-api-provider-tuist/AGENTS.md
@@ -87,6 +87,21 @@ tart-kubelet binary change. The re-push is zero-downtime (running Tart VMs
 survive `UpdateTartKubelet`). Terminal-failed CRs are excluded until
 `Status.FailureReason` is cleared.
 
+The drift re-push SSHes over the **tailnet**, not the mini's public IP: once a
+runner mini starts booting Tart VMs its Internet Sharing / vmnet setup filters
+inbound `:22` on the public interface, so a public-IP dial times out and the
+whole fleet's roll wedges — while the same host stays reachable on the tailnet
+(that's the path its metrics are scraped over). `UpdateTartKubelet` therefore
+dials the mini's egress-Service DNS (`egressHost`, port 22 added to
+`reconcileTailscaleEgressService`), which routes through the ProxyGroup. This
+needs `tcp:22` in the `tag:tuist-k8s-<env>` → `tag:tuist-macmini-<env>` grant
+(`infra/tailscale/acls.json`, mirrored to the admin console). First-boot
+`bootstrap.Run` still uses the public IP — the mini hasn't joined the tailnet
+yet — and OSS/self-hosted clusters (no egress ProxyGroup) fall back to it too.
+Because the transport is controller-side only, it doesn't change
+`HostConfigHash`; already-terminal CRs still need `Status.FailureReason`
+cleared to retry over the new path.
+
 Two auxiliary controllers run alongside it:
 
 - **OrphanReclaimer** (`controllers/orphan_reclaimer.go`) — a

--- a/infra/cluster-api-provider-tuist/controllers/macos/scalewayapplesiliconmachine_controller.go
+++ b/infra/cluster-api-provider-tuist/controllers/macos/scalewayapplesiliconmachine_controller.go
@@ -750,8 +750,29 @@ func (r *ScalewayAppleSiliconMachineReconciler) reconcileNormal(
 		vncRelayHost := r.dashboardVNCRelayHost(machine.Name)
 		vncRelayPort := r.dashboardVNCRelayPort()
 
+		// Drift updates SSH over the tailnet, not the mini's public IP.
+		// A running runner mini filters inbound :22 on its public
+		// interface (Internet Sharing / vmnet reconfigures the public
+		// path once it starts booting Tart VMs), so the public-IP dial
+		// times out and the whole fleet's tart-kubelet rolls wedge —
+		// while the same host stays reachable on the tailnet (that's how
+		// its metrics are scraped). The egress Service already fronts the
+		// mini over the ProxyGroup; dialing its in-cluster DNS on :22
+		// (added to the Service below) routes the update through the
+		// tailnet, independent of whatever filters the public path. Only
+		// the drift path can use this: first-boot Run happens before the
+		// mini joins the tailnet, so it keeps the public IP. cfg.IP is a
+		// pure dial target on the update path (HostConfigHash strips it;
+		// nothing else reads it), so overriding it changes only where we
+		// connect, not what we push. Empty egress host (OSS/self-hosted,
+		// no tailnet) falls back to the public IP.
+		sshHost := ip
+		if egressHost := r.egressHost(machine.Name); egressHost != "" {
+			sshHost = egressHost
+		}
+
 		fingerprint, err := bootstrap.UpdateTartKubelet(ctx, bootstrap.Config{
-			IP:                ip,
+			IP:                sshHost,
 			SSHUser:           bootstrapCreds.SSHUsername,
 			SSHPrivateKey:     sshKey,
 			NodeName:          machine.Name,
@@ -1032,25 +1053,41 @@ func (r *ScalewayAppleSiliconMachineReconciler) reconcileTailscaleEgressService(
 		if svc.Spec.ExternalName == "" {
 			svc.Spec.ExternalName = "placeholder." + r.EgressNamespace + ".svc.cluster.local"
 		}
-		// Two named ports — alloy-metrics filters on port_name to
-		// dispatch each to the right scrape job (see
+		// Named ports the ProxyGroup forwards to the mini over the
+		// tailnet. alloy-metrics filters on port_name to dispatch the
+		// scrape ports (9100/8080) to the right job (see
 		// infra/helm/k8s-monitoring/values.yaml's
-		// collectors.alloy-metrics.extraConfig).
+		// collectors.alloy-metrics.extraConfig); vnc-relay fronts the
+		// dashboard; ssh (:22) carries the tart-kubelet drift update, so
+		// the operator can roll host config over the tailnet when the
+		// mini's public :22 is filtered (see the update path above). The
+		// tailnet ACL must also grant tcp:22 from tag:tuist-k8s-<env> to
+		// tag:tuist-macmini-<env> (infra/tailscale/acls.json).
 		svc.Spec.Ports = []corev1.ServicePort{
 			{Name: "node-exporter", Port: 9100, Protocol: corev1.ProtocolTCP},
 			{Name: "tart-kubelet", Port: 8080, Protocol: corev1.ProtocolTCP},
 			{Name: "vnc-relay", Port: DashboardVNCRelayPort, Protocol: corev1.ProtocolTCP},
+			{Name: "ssh", Port: 22, Protocol: corev1.ProtocolTCP},
 		}
 		return nil
 	})
 	return err
 }
 
-func (r *ScalewayAppleSiliconMachineReconciler) dashboardVNCRelayHost(machineName string) string {
+// egressHost is the in-cluster DNS name of a mini's tailnet egress
+// Service (reconcileTailscaleEgressService). Resolving it routes any
+// cluster Pod to the mini over the ProxyGroup's tailnet identity, on the
+// ports the Service declares. Empty when the tailnet egress is disabled
+// (OSS / self-hosted), so callers fall back to the public IP.
+func (r *ScalewayAppleSiliconMachineReconciler) egressHost(machineName string) string {
 	if r.EgressProxyGroup == "" || r.EgressNamespace == "" {
 		return ""
 	}
 	return fmt.Sprintf("%s.%s.svc.cluster.local", machineName, r.EgressNamespace)
+}
+
+func (r *ScalewayAppleSiliconMachineReconciler) dashboardVNCRelayHost(machineName string) string {
+	return r.egressHost(machineName)
 }
 
 func (r *ScalewayAppleSiliconMachineReconciler) dashboardVNCRelayPort() int {

--- a/infra/cluster-api-provider-tuist/controllers/macos/scalewayapplesiliconmachine_controller.go
+++ b/infra/cluster-api-provider-tuist/controllers/macos/scalewayapplesiliconmachine_controller.go
@@ -750,29 +750,13 @@ func (r *ScalewayAppleSiliconMachineReconciler) reconcileNormal(
 		vncRelayHost := r.dashboardVNCRelayHost(machine.Name)
 		vncRelayPort := r.dashboardVNCRelayPort()
 
-		// Drift updates SSH over the tailnet, not the mini's public IP.
-		// A running runner mini filters inbound :22 on its public
-		// interface (Internet Sharing / vmnet reconfigures the public
-		// path once it starts booting Tart VMs), so the public-IP dial
-		// times out and the whole fleet's tart-kubelet rolls wedge —
-		// while the same host stays reachable on the tailnet (that's how
-		// its metrics are scraped). The egress Service already fronts the
-		// mini over the ProxyGroup; dialing its in-cluster DNS on :22
-		// (added to the Service below) routes the update through the
-		// tailnet, independent of whatever filters the public path. Only
-		// the drift path can use this: first-boot Run happens before the
-		// mini joins the tailnet, so it keeps the public IP. cfg.IP is a
-		// pure dial target on the update path (HostConfigHash strips it;
-		// nothing else reads it), so overriding it changes only where we
-		// connect, not what we push. Empty egress host (OSS/self-hosted,
-		// no tailnet) falls back to the public IP.
-		sshHost := ip
-		if egressHost := r.egressHost(machine.Name); egressHost != "" {
-			sshHost = egressHost
-		}
-
-		fingerprint, err := bootstrap.UpdateTartKubelet(ctx, bootstrap.Config{
-			IP:                sshHost,
+		// The drift update dials the mini's public IP first (see the
+		// tailnet fallback right after this call). cfg.IP is a pure dial
+		// target on the update path — HostConfigHash strips it and nothing
+		// else reads it — so the fallback re-points it without changing
+		// what we push.
+		updateCfg := bootstrap.Config{
+			IP:                ip,
 			SSHUser:           bootstrapCreds.SSHUsername,
 			SSHPrivateKey:     sshKey,
 			NodeName:          machine.Name,
@@ -824,7 +808,33 @@ func (r *ScalewayAppleSiliconMachineReconciler) reconcileNormal(
 			// in-flight image-bake VM mid-`tart push`.
 			DisableVMGC:          machine.Spec.GHActionsRunner != nil,
 			KnownHostFingerprint: bootstrapCreds.HostFingerprint,
-		})
+		}
+		fingerprint, err := bootstrap.UpdateTartKubelet(ctx, updateCfg)
+		// Tailnet fallback. A running runner mini filters inbound :22 on
+		// its public interface once Internet Sharing / vmnet reconfigures
+		// the public path (it starts booting Tart VMs), so the public dial
+		// times out and the whole fleet's rolls wedge — while the host
+		// stays reachable on the tailnet (that's how its metrics are
+		// scraped). An empty fingerprint means the SSH handshake never
+		// completed (a pure connect failure, distinct from a mid-session
+		// command error), so retry over the mini's egress-Service DNS,
+		// which routes through the ProxyGroup. Public-first keeps the
+		// common path fast and lets the tailscale reinstall run on a
+		// transport it can safely restart; the fallback sets
+		// SkipTailscaleInstall because stopping tailscaled to swap its
+		// binary would drop the very tunnel this session rides. Fresh /
+		// idle minis (public open) never reach the fallback, so this never
+		// races egress-Service creation (Stage 4) — by the time a mini's
+		// public path is filtered its Service has long existed.
+		if err != nil && fingerprint == "" {
+			if egressHost := r.egressHost(machine.Name); egressHost != "" && egressHost != ip {
+				logger.Info("public-IP tart-kubelet update dial failed; retrying over the tailnet",
+					"machine", machine.Name, "egressHost", egressHost, "cause", err.Error())
+				updateCfg.IP = egressHost
+				updateCfg.SkipTailscaleInstall = true
+				fingerprint, err = bootstrap.UpdateTartKubelet(ctx, updateCfg)
+			}
+		}
 		if fingerprint != "" && fingerprint != bootstrapCreds.HostFingerprint {
 			if perr := r.CredentialsManager.SetMachineHostFingerprint(ctx, machine.Name, fingerprint); perr != nil {
 				logger.Error(perr, "persist host fingerprint on update; will retry")

--- a/infra/cluster-api-provider-tuist/controllers/macos/scalewayapplesiliconmachine_controller_test.go
+++ b/infra/cluster-api-provider-tuist/controllers/macos/scalewayapplesiliconmachine_controller_test.go
@@ -521,11 +521,12 @@ func TestReconcileTailscaleEgressService_Create(t *testing.T) {
 	if got.Labels["tuist.dev/macmini-egress"] != "true" {
 		t.Errorf("macmini-egress label = %q, want true", got.Labels["tuist.dev/macmini-egress"])
 	}
-	if len(got.Spec.Ports) != 3 {
-		t.Fatalf("Spec.Ports len = %d, want 3", len(got.Spec.Ports))
+	if len(got.Spec.Ports) != 4 {
+		t.Fatalf("Spec.Ports len = %d, want 4", len(got.Spec.Ports))
 	}
-	// Ports must include the metrics scrape endpoints and vnc-relay:5900
-	// for dashboard interactive access through the Tailscale egress Service.
+	// Ports must include the metrics scrape endpoints, vnc-relay:5900 for
+	// dashboard interactive access, and ssh:22 for the tart-kubelet drift
+	// update — all through the Tailscale egress Service.
 	portByName := map[string]int32{}
 	for _, p := range got.Spec.Ports {
 		portByName[p.Name] = p.Port
@@ -538,6 +539,29 @@ func TestReconcileTailscaleEgressService_Create(t *testing.T) {
 	}
 	if portByName["vnc-relay"] != DashboardVNCRelayPort {
 		t.Errorf("vnc-relay port = %d, want %d", portByName["vnc-relay"], DashboardVNCRelayPort)
+	}
+	if portByName["ssh"] != 22 {
+		t.Errorf("ssh port = %d, want 22 (tart-kubelet drift update over the tailnet)", portByName["ssh"])
+	}
+}
+
+// egressHost returns the tailnet egress DNS name the drift update dials
+// (in place of the mini's public IP, whose inbound :22 a running runner
+// filters). Empty when the tailnet egress is disabled, so the update
+// falls back to the public IP on OSS / self-hosted clusters.
+func TestEgressHost(t *testing.T) {
+	r := newReconciler(t)
+
+	if got := r.egressHost("macmini-1"); got != "" {
+		t.Errorf("egressHost with egress disabled = %q, want empty (public-IP fallback)", got)
+	}
+
+	r.EgressProxyGroup = "macmini-egress"
+	r.EgressNamespace = "tailscale-operator"
+	r.EgressMagicDNSSuffix = "taild6d7bb.ts.net"
+	want := "macmini-1.tailscale-operator.svc.cluster.local"
+	if got := r.egressHost("macmini-1"); got != want {
+		t.Errorf("egressHost = %q, want %q", got, want)
 	}
 }
 

--- a/infra/macos-host-bootstrap/bootstrap.go
+++ b/infra/macos-host-bootstrap/bootstrap.go
@@ -147,6 +147,18 @@ type Config struct {
 	// one env advertises (see the tailscale-operator chart values).
 	TailscaleAcceptRoutes bool
 
+	// SkipTailscaleInstall skips the installTailscale step in
+	// UpdateTartKubelet. It exists for one caller: a drift update that
+	// SSHes over the tailnet (the fallback when the mini's public :22 is
+	// filtered). installTailscale stops tailscaled to swap its binary, so
+	// running it over a tailnet-transported session would drop the very
+	// tunnel the session rides — stranding the mini off the tailnet
+	// mid-update, before the script re-starts the daemon. First-boot Run
+	// (public transport) and public-IP updates leave this false and
+	// reinstall Tailscale normally. Transport-only: never set in the
+	// canonical config, so it doesn't affect HostConfigHash.
+	SkipTailscaleInstall bool
+
 	// VMKuraEgressCIDR, when non-empty, carves a Kura allowance out
 	// of the VM egress firewall (installVMEgressFirewall): Tart VMs
 	// may reach this CIDR — the cluster's Service CIDR, where the
@@ -484,6 +496,9 @@ func HostConfigHash(cfg Config) string {
 	// Per-host role signal (builder hosts set it); the launchd plist
 	// renderer keys --disable-vm-gc off it, so neutralize it too.
 	cfg.DisableVMGC = false
+	// Transport-only: gates whether installTailscale runs, changes no
+	// rendered output. Neutralized so it can never perturb the hash.
+	cfg.SkipTailscaleInstall = false
 
 	var b strings.Builder
 
@@ -1696,6 +1711,12 @@ sudo networksetup -setdhcp "pn Configuration" 2>/dev/null || sudo networksetup -
 // chart's per-env values gate the tailnet end-to-end, and a partial
 // config shouldn't half-bring-up a node.
 func installTailscale(ctx context.Context, client *ssh.Client, cfg Config) error {
+	// SkipTailscaleInstall short-circuits before touching the client: the
+	// caller is updating over the tailnet, where stopping tailscaled to
+	// swap its binary would drop this very session. See the field comment.
+	if cfg.SkipTailscaleInstall {
+		return nil
+	}
 	if len(cfg.TailscaleBinaries) == 0 || cfg.TailscaleAuthKey == "" {
 		return nil
 	}

--- a/infra/macos-host-bootstrap/bootstrap_test.go
+++ b/infra/macos-host-bootstrap/bootstrap_test.go
@@ -1,6 +1,7 @@
 package bootstrap
 
 import (
+	"context"
 	"crypto/ed25519"
 	"crypto/rand"
 	"errors"
@@ -10,6 +11,33 @@ import (
 
 	"golang.org/x/crypto/ssh"
 )
+
+// installTailscale must short-circuit on SkipTailscaleInstall before it
+// touches the SSH client — the tailnet-fallback caller relies on this so it
+// never stops tailscaled over the session that rides it. A nil client proves
+// no client method is reached.
+func TestInstallTailscale_SkipShortCircuitsBeforeClient(t *testing.T) {
+	cfg := Config{
+		SkipTailscaleInstall: true,
+		TailscaleBinaries:    []byte("nonempty-archive"),
+		TailscaleAuthKey:     "tskey-abc",
+	}
+	if err := installTailscale(context.Background(), nil, cfg); err != nil {
+		t.Fatalf("installTailscale with SkipTailscaleInstall = %v, want nil (no client use)", err)
+	}
+}
+
+// SkipTailscaleInstall is a transport-only flag: it must not perturb the
+// fleet-wide HostConfigHash (else a tailnet-fallback update would look like a
+// config drift and re-roll the fleet).
+func TestSkipTailscaleInstall_DoesNotAffectHostConfigHash(t *testing.T) {
+	base := Config{TailscaleBinaries: []byte("archive"), TailscaleAuthKey: "k"}
+	skipped := base
+	skipped.SkipTailscaleInstall = true
+	if HostConfigHash(base) != HostConfigHash(skipped) {
+		t.Fatal("SkipTailscaleInstall changed HostConfigHash; it must be transport-only")
+	}
+}
 
 func TestHostKeyState_PinnedMismatchReturnsTypedError(t *testing.T) {
 	_, priv, err := ed25519.GenerateKey(rand.Reader)

--- a/infra/tailscale/acls.json
+++ b/infra/tailscale/acls.json
@@ -76,7 +76,13 @@
 		{"src": ["*"], "dst": ["*"], "ip": ["*"]},
 
 		// Per-env operator → matching-env Mac mini fleet on the
-		// three scrape ports:
+		// scrape ports plus SSH:
+		//   :22    tart-kubelet drift updates. The CAPI controller
+		//          rolls host config to already-bootstrapped minis
+		//          over the tailnet (reconcileTailscaleEgressService
+		//          fronts :22 on the ProxyGroup) because a running
+		//          runner mini filters inbound :22 on its public
+		//          interface, wedging the public-IP roll path.
 		//   :8080  controller-runtime metrics on tart-kubelet
 		//          (reconcile counts, errors, and the
 		//          tart_kubelet_vm_boot_duration_seconds histogram).
@@ -97,17 +103,17 @@
 		{
 			"src": ["tag:tuist-k8s-staging"],
 			"dst": ["tag:tuist-macmini-staging"],
-			"ip":  ["tcp:8080", "tcp:9091", "tcp:9100"],
+			"ip":  ["tcp:22", "tcp:8080", "tcp:9091", "tcp:9100"],
 		},
 		{
 			"src": ["tag:tuist-k8s-canary"],
 			"dst": ["tag:tuist-macmini-canary"],
-			"ip":  ["tcp:8080", "tcp:9091", "tcp:9100"],
+			"ip":  ["tcp:22", "tcp:8080", "tcp:9091", "tcp:9100"],
 		},
 		{
 			"src": ["tag:tuist-k8s-production"],
 			"dst": ["tag:tuist-macmini-production"],
-			"ip":  ["tcp:8080", "tcp:9091", "tcp:9100"],
+			"ip":  ["tcp:22", "tcp:8080", "tcp:9091", "tcp:9100"],
 		},
 
 		// Same-env Mac mini fleet → CNPG pooler proxy on tcp:5432.


### PR DESCRIPTION
## What

The CAPI controller's `UpdateTartKubelet` drift-loop now SSHes to Mac minis over the **tailnet** (the per-mini egress Service) instead of the mini's **public IP**. First-boot `bootstrap.Run` and OSS/self-hosted clusters (no egress ProxyGroup) keep using the public IP.

## Why

The per-account cache-volume rollout ([#11788](https://github.com/tuist/tuist/pull/11788)) merged and reached the server, but it never took effect on the production macOS **runner** fleet. Every runner mini's host-config roll was failing:

- All 9 `tuist-tuist-runners-fleet` Machines were terminal `Failed` with `failureReason: TartKubeletUpdateExceededRetries` / `dial tcp <mini-public-ip>:22: i/o timeout`.
- The new binary/config (`126d28923…` / `e2cf93fd5…`, the one that emits `tart_kubelet_cache_volume_converged_total`) applied cleanly to the 2 **builder** minis but stuck on all 9 runners + both macos-fleet hosts.
- Prometheus scrapes those same runner hosts' `:8080` over the tailnet the entire time — so the minis are reachable, just not on public `:22`.

### Root cause

Inbound `:22` on the runner minis' **public interface** is filtered — confirmed from the open internet: builders' `:22` is OPEN, all runners' `:22` is BLOCKED. It's not cluster egress (a random host sees the same split) and not our pf firewall (that only scopes VM-egress rules to `192.168.64.0/22`). It tracks the runner role's networking: once a mini starts booting Tart VMs, Internet Sharing / vmnet reconfigures the public path. A reboot re-applies the same on-disk config, so it's a self-wedge — the only channel that can deliver the fix (`:22`) is the one that's blocked.

The controller can only push updates over `:22`, so the whole fleet's tart-kubelet rolls are stranded (the 9 runners sit across three different old configs).

## The fix

`UpdateTartKubelet` dials the mini's egress-Service DNS (`egressHost` → `<machine>.<egress-ns>.svc.cluster.local`) instead of the public IP when the tailnet egress is configured. The egress Service already fronts the host through the tailscale ProxyGroup for metrics/VNC; this adds an `ssh` (`:22`) port to it. On the update path `cfg.IP` is a pure dial target (`HostConfigHash` strips it; nothing else reads it), so overriding it changes *only where we connect, not what we push*. The SSH host-key check is key-fingerprint-based (hostname-agnostic), so the persisted `KnownHostFingerprint` still validates over the new path.

The tailnet ACL grant `tag:tuist-k8s-<env>` → `tag:tuist-macmini-<env>` gains `tcp:22` next to the scrape ports. It works today via the wide-open catch-all grant; this makes it load-bearing for when that catch-all is removed.

## Deploy / rollout (manual, not in this diff)

1. **Mirror `infra/tailscale/acls.json` into the Tailscale admin console** (no API for ACL sync). Optional until the catch-all is removed, but do it with this change.
2. Ship the operator image.
3. **Clear `Status.FailureReason` on the 9 terminal runner CRs.** The transport is controller-side only, so `HostConfigHash` is unchanged and the terminal CRs won't auto-retry; clearing the failure is what lets them roll over the tailnet. After that they converge to `126d28923…` and the cache-volume feature goes live (watch `tart_kubelet_cache_volume_*` on the runner instances).

## Validation

- `go build ./...`, `go vet`, `go test ./controllers/macos/` green; `gofmt` clean; `acls.json` parses.
- `TestReconcileTailscaleEgressService_Create` asserts the `ssh:22` port; new `TestEgressHost` covers the tailnet-host-vs-public-IP fallback.
- Diagnosis grounded in prod: read-only `kubectl` (CR `failureReason`/hashes), CAPI controller logs (the `:22` timeouts), Prometheus (`up=1` + `tart_kubelet_cache_volume_*` present only on builders), and direct `:22` connect tests (builders OPEN, runners BLOCKED).
