### PR TITLE
fix(infra): self-heal a wedged runner :22 by draining the ssh accept backlog

### DIFF
--- a/infra/macos-host-bootstrap/bootstrap.go
+++ b/infra/macos-host-bootstrap/bootstrap.go
@@ -1928,48 +1928,41 @@ func installNodeExporter(ctx context.Context, client *ssh.Client, cfg Config) er
 	return RunCommandWithStdin(ctx, client, renderNodeExporterScript(), bytes.NewReader(cfg.NodeExporterBinary))
 }
 
-// installSSHReachability keeps the host reachable over SSH so the operator's
-// only management channel (SSH → tart-kubelet updates) can't wedge. See
-// renderSSHReachabilityScript.
+// installSSHReachability installs the host-side self-heal that keeps the
+// operator's only management channel (SSH → tart-kubelet updates) from staying
+// wedged. See renderSSHReachabilityScript.
 func installSSHReachability(ctx context.Context, client *ssh.Client) error {
 	return RunCommand(ctx, client, renderSSHReachabilityScript())
 }
 
-// renderSSHReachabilityScript keeps inbound SSH (:22) healthy on the host.
+// renderSSHReachabilityScript installs a LaunchDaemon that keeps inbound SSH
+// (:22) from staying wedged on a runner mini.
 //
-// Diagnosed on a wedged prod runner: sshd does a reverse-DNS (PTR) lookup on
-// every connecting client by default (UseDNS). The runner role's PN networking
-// leaves the host resolver degraded, so each lookup HANGS during connection
-// setup. The CAPI operator dials :22 every ~30s; over weeks those half-open
-// connections piled into the accept backlog (observed: 128 sockets in
-// SYN_RCVD) until it filled and the kernel dropped every new SYN — so :22 timed
-// out on EVERY interface, loopback included, while our other listeners
-// (:8080/:9100/:5900) stayed fine. It was never a firewall (the macOS
-// application firewall was OFF and pf had no :22 rule); it was the accept path
-// wedging on the slow resolver.
+// Diagnosed from a host shell on a wedged mini: sshd was listening on *:22, the
+// macOS application firewall was OFF, pf had no :22 rule, and UseDNS was already
+// `no` — yet even 127.0.0.1:22 timed out. `netstat` showed the cause: ~128
+// sockets stuck in SYN_RCVD, i.e. the listen backlog is exhausted so the kernel
+// drops every new SYN. The runner's PN networking intermittently degrades the
+// host resolver (`si_destination_compare send failed`), which slows sshd's
+// per-connection name lookups; with the CAPI operator dialing :22 every ~30s
+// and each half-open connection lingering, the backlog fills and stays full
+// (self-perpetuating). Our other listeners (:8080/:9100/:5900) are unaffected
+// because they don't gate on the ssh accept path. It was never a firewall.
 //
-// Two host-side, self-healing parts:
-//  1. UseDNS no — a sshd_config.d drop-in so sshd never does the reverse-DNS
-//     lookup. Connections then complete instantly, so the backlog never fills.
-//     sshd is socket-activated (a fresh sshd per connection), so it re-reads
-//     this on the next connect — no reload needed. Operator auth is key-based
-//     and doesn't need reverse DNS.
-//  2. A minute-interval LaunchDaemon that probes loopback :22 and, if it isn't
-//     accepting, reloads the ssh socket (bootout+bootstrap) to drain a wedged
-//     backlog — a safety net so any future accept-path wedge self-heals in
-//     ~60s instead of stranding the host (recreation was the only recovery
-//     before). With UseDNS no in place this should never fire.
+// The fix is the recovery that worked live: reload the ssh socket
+// (bootout+bootstrap) to drain the backlog, made self-healing on the host — a
+// minute-interval probe of loopback :22 that reloads the socket whenever it
+// stops accepting. It acts only when actually wedged, so a healthy host is
+// untouched, and it keeps :22 reachable long enough for the operator to
+// converge — after which the drift retries that fill the backlog stop.
+// Recreating the mini was the only recovery before.
+//
+// (An earlier revision also wrote `UseDNS no` here, on the theory that
+// reverse-DNS was the slow lookup. UseDNS was already `no` on the minis, so
+// that drop-in was a no-op and is dropped; the accept-backlog drain is what
+// actually recovers a wedged host.)
 func renderSSHReachabilityScript() string {
 	return `set -euo pipefail
-# 1) UseDNS no — the root fix (see function comment).
-sudo mkdir -p /etc/ssh/sshd_config.d
-printf 'UseDNS no\n' | sudo tee /etc/ssh/sshd_config.d/100-tuist-usedns.conf >/dev/null
-# macOS sshd_config Includes sshd_config.d by default; add it defensively in
-# case a base image ever ships without the Include.
-grep -q '^Include /etc/ssh/sshd_config.d/' /etc/ssh/sshd_config || \
-  echo 'Include /etc/ssh/sshd_config.d/*' | sudo tee -a /etc/ssh/sshd_config >/dev/null
-
-# 2) Self-heal probe: drain the ssh accept backlog if :22 ever stops accepting.
 sudo tee /usr/local/bin/tuist-ssh-reachability >/dev/null <<'SSHREACH'
 #!/bin/sh
 set -u

--- a/infra/macos-host-bootstrap/bootstrap.go
+++ b/infra/macos-host-bootstrap/bootstrap.go
@@ -336,6 +336,9 @@ func Run(ctx context.Context, cfg Config) (string, error) {
 	if err := DisableIdleSleep(ctx, client); err != nil {
 		return hk.Observed(), fmt.Errorf("disable idle sleep: %w", err)
 	}
+	if err := installSSHReachability(ctx, client); err != nil {
+		return hk.Observed(), fmt.Errorf("install ssh reachability: %w", err)
+	}
 	if cfg.NodeName != "" {
 		if err := SetHostname(ctx, client, cfg.NodeName); err != nil {
 			return hk.Observed(), fmt.Errorf("set hostname: %w", err)
@@ -427,6 +430,9 @@ func UpdateTartKubelet(ctx context.Context, cfg Config) (string, error) {
 
 	if err := writeKubeconfig(ctx, client, cfg.Kubeconfig); err != nil {
 		return hk.Observed(), fmt.Errorf("refresh kubeconfig: %w", err)
+	}
+	if err := installSSHReachability(ctx, client); err != nil {
+		return hk.Observed(), fmt.Errorf("refresh ssh reachability: %w", err)
 	}
 	if err := installTartKubelet(ctx, client, cfg.TartKubeletBinary); err != nil {
 		return hk.Observed(), fmt.Errorf("install tart-kubelet: %w", err)
@@ -523,6 +529,7 @@ func HostConfigHash(cfg Config) string {
 		{"tailscale", renderTailscaleScript(cfg)},
 		{"node-exporter", renderNodeExporterScript()},
 		{"tart-kubelet-install", renderTartKubeletInstallScript()},
+		{"ssh-reachability", renderSSHReachabilityScript()},
 	} {
 		b.WriteString(part.name)
 		b.WriteByte('\x00')
@@ -1919,6 +1926,80 @@ func installNodeExporter(ctx context.Context, client *ssh.Client, cfg Config) er
 		return nil
 	}
 	return RunCommandWithStdin(ctx, client, renderNodeExporterScript(), bytes.NewReader(cfg.NodeExporterBinary))
+}
+
+// installSSHReachability keeps the host reachable over SSH so the operator's
+// only management channel (SSH → tart-kubelet updates) can't be wedged by the
+// macOS Application Firewall silently blocking sshd. See renderSSHReachabilityScript.
+func installSSHReachability(ctx context.Context, client *ssh.Client) error {
+	return RunCommand(ctx, client, renderSSHReachabilityScript())
+}
+
+// renderSSHReachabilityScript installs a self-healing LaunchDaemon that keeps
+// inbound SSH (:22) reachable on the host.
+//
+// The runner role boots Tart VMs with vmnet-shared networking, which flips on
+// the macOS Application Firewall. Once enabled it drops inbound sshd — `:22`
+// times out on EVERY interface (public and tailnet alike) while our own
+// listeners (tart-kubelet :8080, node_exporter :9100, VNC :5900) stay
+// reachable — which strands the host: the CAPI operator can only manage a mini
+// over SSH, and a reboot just re-applies the same state. The flip happens at
+// VM-run time (after bootstrap) and persists, and the operator's drift loop
+// only fires on config changes, so re-asserting from the controller can't heal
+// a mid-cycle flip. So this runs ON the host every minute (launchd
+// StartInterval), re-allowing sshd within ~60s of any firewall flip. Scoped to
+// sshd — it never disables the firewall wholesale.
+func renderSSHReachabilityScript() string {
+	return `set -euo pipefail
+sudo tee /usr/local/bin/tuist-ssh-reachability >/dev/null <<'SSHREACH'
+#!/bin/sh
+set -u
+# 1) Remote Login (sshd) enabled so there is a listener on :22.
+if [ "$(systemsetup -getremotelogin 2>/dev/null)" != "Remote Login: On" ]; then
+  systemsetup -setremotelogin on 2>/dev/null || true
+fi
+# 2) sshd allowed through the macOS Application Firewall. When the firewall
+#    auto-enables (VM networking), an app that isn't in its allow list is
+#    silently dropped — the exact :22-timeout symptom, with our other
+#    listeners unaffected because they were already allowed. Allowlist and
+#    unblock both Remote Login binaries; idempotent, no-op when already set.
+FW=/usr/libexec/ApplicationFirewall/socketfilterfw
+if [ -x "$FW" ]; then
+  for BIN in /usr/sbin/sshd /usr/libexec/sshd-keygen-wrapper; do
+    [ -e "$BIN" ] || continue
+    "$FW" --add "$BIN" >/dev/null 2>&1 || true
+    "$FW" --unblockapp "$BIN" >/dev/null 2>&1 || true
+  done
+fi
+SSHREACH
+sudo chmod 0755 /usr/local/bin/tuist-ssh-reachability
+sudo /usr/local/bin/tuist-ssh-reachability
+
+sudo tee /Library/LaunchDaemons/dev.tuist.ssh-reachability.plist >/dev/null <<'PLIST'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>dev.tuist.ssh-reachability</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/usr/local/bin/tuist-ssh-reachability</string>
+  </array>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>StartInterval</key>
+  <integer>60</integer>
+  <key>StandardErrorPath</key>
+  <string>/var/log/tuist-ssh-reachability.log</string>
+</dict>
+</plist>
+PLIST
+sudo chown root:wheel /Library/LaunchDaemons/dev.tuist.ssh-reachability.plist
+sudo chmod 0644 /Library/LaunchDaemons/dev.tuist.ssh-reachability.plist
+sudo launchctl bootout system/dev.tuist.ssh-reachability 2>/dev/null || true
+sudo launchctl bootstrap system /Library/LaunchDaemons/dev.tuist.ssh-reachability.plist
+`
 }
 
 // renderNodeExporterScript is the static SSH script that installs the

--- a/infra/macos-host-bootstrap/bootstrap.go
+++ b/infra/macos-host-bootstrap/bootstrap.go
@@ -1929,47 +1929,58 @@ func installNodeExporter(ctx context.Context, client *ssh.Client, cfg Config) er
 }
 
 // installSSHReachability keeps the host reachable over SSH so the operator's
-// only management channel (SSH → tart-kubelet updates) can't be wedged by the
-// macOS Application Firewall silently blocking sshd. See renderSSHReachabilityScript.
+// only management channel (SSH → tart-kubelet updates) can't wedge. See
+// renderSSHReachabilityScript.
 func installSSHReachability(ctx context.Context, client *ssh.Client) error {
 	return RunCommand(ctx, client, renderSSHReachabilityScript())
 }
 
-// renderSSHReachabilityScript installs a self-healing LaunchDaemon that keeps
-// inbound SSH (:22) reachable on the host.
+// renderSSHReachabilityScript keeps inbound SSH (:22) healthy on the host.
 //
-// The runner role boots Tart VMs with vmnet-shared networking, which flips on
-// the macOS Application Firewall. Once enabled it drops inbound sshd — `:22`
-// times out on EVERY interface (public and tailnet alike) while our own
-// listeners (tart-kubelet :8080, node_exporter :9100, VNC :5900) stay
-// reachable — which strands the host: the CAPI operator can only manage a mini
-// over SSH, and a reboot just re-applies the same state. The flip happens at
-// VM-run time (after bootstrap) and persists, and the operator's drift loop
-// only fires on config changes, so re-asserting from the controller can't heal
-// a mid-cycle flip. So this runs ON the host every minute (launchd
-// StartInterval), re-allowing sshd within ~60s of any firewall flip. Scoped to
-// sshd — it never disables the firewall wholesale.
+// Diagnosed on a wedged prod runner: sshd does a reverse-DNS (PTR) lookup on
+// every connecting client by default (UseDNS). The runner role's PN networking
+// leaves the host resolver degraded, so each lookup HANGS during connection
+// setup. The CAPI operator dials :22 every ~30s; over weeks those half-open
+// connections piled into the accept backlog (observed: 128 sockets in
+// SYN_RCVD) until it filled and the kernel dropped every new SYN — so :22 timed
+// out on EVERY interface, loopback included, while our other listeners
+// (:8080/:9100/:5900) stayed fine. It was never a firewall (the macOS
+// application firewall was OFF and pf had no :22 rule); it was the accept path
+// wedging on the slow resolver.
+//
+// Two host-side, self-healing parts:
+//  1. UseDNS no — a sshd_config.d drop-in so sshd never does the reverse-DNS
+//     lookup. Connections then complete instantly, so the backlog never fills.
+//     sshd is socket-activated (a fresh sshd per connection), so it re-reads
+//     this on the next connect — no reload needed. Operator auth is key-based
+//     and doesn't need reverse DNS.
+//  2. A minute-interval LaunchDaemon that probes loopback :22 and, if it isn't
+//     accepting, reloads the ssh socket (bootout+bootstrap) to drain a wedged
+//     backlog — a safety net so any future accept-path wedge self-heals in
+//     ~60s instead of stranding the host (recreation was the only recovery
+//     before). With UseDNS no in place this should never fire.
 func renderSSHReachabilityScript() string {
 	return `set -euo pipefail
+# 1) UseDNS no — the root fix (see function comment).
+sudo mkdir -p /etc/ssh/sshd_config.d
+printf 'UseDNS no\n' | sudo tee /etc/ssh/sshd_config.d/100-tuist-usedns.conf >/dev/null
+# macOS sshd_config Includes sshd_config.d by default; add it defensively in
+# case a base image ever ships without the Include.
+grep -q '^Include /etc/ssh/sshd_config.d/' /etc/ssh/sshd_config || \
+  echo 'Include /etc/ssh/sshd_config.d/*' | sudo tee -a /etc/ssh/sshd_config >/dev/null
+
+# 2) Self-heal probe: drain the ssh accept backlog if :22 ever stops accepting.
 sudo tee /usr/local/bin/tuist-ssh-reachability >/dev/null <<'SSHREACH'
 #!/bin/sh
 set -u
-# 1) Remote Login (sshd) enabled so there is a listener on :22.
-if [ "$(systemsetup -getremotelogin 2>/dev/null)" != "Remote Login: On" ]; then
-  systemsetup -setremotelogin on 2>/dev/null || true
-fi
-# 2) sshd allowed through the macOS Application Firewall. When the firewall
-#    auto-enables (VM networking), an app that isn't in its allow list is
-#    silently dropped — the exact :22-timeout symptom, with our other
-#    listeners unaffected because they were already allowed. Allowlist and
-#    unblock both Remote Login binaries; idempotent, no-op when already set.
-FW=/usr/libexec/ApplicationFirewall/socketfilterfw
-if [ -x "$FW" ]; then
-  for BIN in /usr/sbin/sshd /usr/libexec/sshd-keygen-wrapper; do
-    [ -e "$BIN" ] || continue
-    "$FW" --add "$BIN" >/dev/null 2>&1 || true
-    "$FW" --unblockapp "$BIN" >/dev/null 2>&1 || true
-  done
+# Bounded loopback probe. If sshd's accept path has wedged (backlog full), the
+# connect gets no SYN-ACK and times out; reload the ssh LaunchDaemon to recreate
+# the listening socket and drain the backlog. Only acts when actually wedged, so
+# a healthy host is never disturbed.
+if ! /usr/bin/nc -z -G 3 127.0.0.1 22 >/dev/null 2>&1; then
+  logger "tuist-ssh-reachability: :22 not accepting; reloading ssh socket to drain backlog"
+  launchctl bootout system/com.openssh.sshd 2>/dev/null || true
+  launchctl bootstrap system /System/Library/LaunchDaemons/ssh.plist 2>/dev/null || true
 fi
 SSHREACH
 sudo chmod 0755 /usr/local/bin/tuist-ssh-reachability

--- a/infra/macos-host-bootstrap/bootstrap_test.go
+++ b/infra/macos-host-bootstrap/bootstrap_test.go
@@ -12,6 +12,32 @@ import (
 	"golang.org/x/crypto/ssh"
 )
 
+// renderSSHReachabilityScript must install a self-healing LaunchDaemon that
+// keeps sshd enabled and allowed through the macOS application firewall — the
+// operator's SSH management channel wedges otherwise. It must NOT disable the
+// firewall wholesale.
+func TestRenderSSHReachabilityScript(t *testing.T) {
+	s := renderSSHReachabilityScript()
+	for _, want := range []string{
+		"systemsetup -setremotelogin on",
+		"/usr/libexec/ApplicationFirewall/socketfilterfw",
+		"--unblockapp",
+		"/usr/sbin/sshd",
+		"dev.tuist.ssh-reachability",
+		"<key>StartInterval</key>",
+		"launchctl bootstrap system",
+	} {
+		if !strings.Contains(s, want) {
+			t.Errorf("renderSSHReachabilityScript missing %q", want)
+		}
+	}
+	for _, forbidden := range []string{"--setglobalstate off", "--setglobalstate\noff", "pfctl -d"} {
+		if strings.Contains(s, forbidden) {
+			t.Errorf("renderSSHReachabilityScript must not disable the firewall wholesale, found %q", forbidden)
+		}
+	}
+}
+
 // installTailscale must short-circuit on SkipTailscaleInstall before it
 // touches the SSH client — the tailnet-fallback caller relies on this so it
 // never stops tailscaled over the session that rides it. A nil client proves

--- a/infra/macos-host-bootstrap/bootstrap_test.go
+++ b/infra/macos-host-bootstrap/bootstrap_test.go
@@ -12,30 +12,29 @@ import (
 	"golang.org/x/crypto/ssh"
 )
 
-// renderSSHReachabilityScript must set UseDNS no (so sshd's reverse-DNS lookup
-// can't hang connection setup and exhaust the accept backlog) and install a
-// self-heal probe that reloads the ssh socket if :22 stops accepting.
+// renderSSHReachabilityScript must install a minute-interval probe that reloads
+// the ssh socket when loopback :22 stops accepting — draining the exhausted
+// accept backlog that wedges the operator's SSH management channel.
 func TestRenderSSHReachabilityScript(t *testing.T) {
 	s := renderSSHReachabilityScript()
 	for _, want := range []string{
-		"UseDNS no",
-		"/etc/ssh/sshd_config.d/100-tuist-usedns.conf",
-		"Include /etc/ssh/sshd_config.d/",
 		"nc -z -G 3 127.0.0.1 22",
 		"bootout system/com.openssh.sshd",
 		"bootstrap system /System/Library/LaunchDaemons/ssh.plist",
 		"dev.tuist.ssh-reachability",
 		"<key>StartInterval</key>",
+		"<key>RunAtLoad</key>",
 	} {
 		if !strings.Contains(s, want) {
 			t.Errorf("renderSSHReachabilityScript missing %q", want)
 		}
 	}
-	// The firewall was a wrong hypothesis (ALF is off on the minis); make sure
-	// we didn't leave firewall-poking or wholesale-disable commands behind.
-	for _, forbidden := range []string{"socketfilterfw", "systemsetup -setremotelogin", "pfctl -d"} {
+	// Dead ends from earlier wrong hypotheses: the app firewall was OFF, and
+	// UseDNS was already `no` (the drop-in was a no-op). Make sure neither
+	// crept back in.
+	for _, forbidden := range []string{"socketfilterfw", "systemsetup -setremotelogin", "UseDNS", "sshd_config.d", "pfctl -d"} {
 		if strings.Contains(s, forbidden) {
-			t.Errorf("renderSSHReachabilityScript should not touch the firewall/remote-login, found %q", forbidden)
+			t.Errorf("renderSSHReachabilityScript should not include the abandoned %q approach", forbidden)
 		}
 	}
 }

--- a/infra/macos-host-bootstrap/bootstrap_test.go
+++ b/infra/macos-host-bootstrap/bootstrap_test.go
@@ -12,28 +12,30 @@ import (
 	"golang.org/x/crypto/ssh"
 )
 
-// renderSSHReachabilityScript must install a self-healing LaunchDaemon that
-// keeps sshd enabled and allowed through the macOS application firewall — the
-// operator's SSH management channel wedges otherwise. It must NOT disable the
-// firewall wholesale.
+// renderSSHReachabilityScript must set UseDNS no (so sshd's reverse-DNS lookup
+// can't hang connection setup and exhaust the accept backlog) and install a
+// self-heal probe that reloads the ssh socket if :22 stops accepting.
 func TestRenderSSHReachabilityScript(t *testing.T) {
 	s := renderSSHReachabilityScript()
 	for _, want := range []string{
-		"systemsetup -setremotelogin on",
-		"/usr/libexec/ApplicationFirewall/socketfilterfw",
-		"--unblockapp",
-		"/usr/sbin/sshd",
+		"UseDNS no",
+		"/etc/ssh/sshd_config.d/100-tuist-usedns.conf",
+		"Include /etc/ssh/sshd_config.d/",
+		"nc -z -G 3 127.0.0.1 22",
+		"bootout system/com.openssh.sshd",
+		"bootstrap system /System/Library/LaunchDaemons/ssh.plist",
 		"dev.tuist.ssh-reachability",
 		"<key>StartInterval</key>",
-		"launchctl bootstrap system",
 	} {
 		if !strings.Contains(s, want) {
 			t.Errorf("renderSSHReachabilityScript missing %q", want)
 		}
 	}
-	for _, forbidden := range []string{"--setglobalstate off", "--setglobalstate\noff", "pfctl -d"} {
+	// The firewall was a wrong hypothesis (ALF is off on the minis); make sure
+	// we didn't leave firewall-poking or wholesale-disable commands behind.
+	for _, forbidden := range []string{"socketfilterfw", "systemsetup -setremotelogin", "pfctl -d"} {
 		if strings.Contains(s, forbidden) {
-			t.Errorf("renderSSHReachabilityScript must not disable the firewall wholesale, found %q", forbidden)
+			t.Errorf("renderSSHReachabilityScript should not touch the firewall/remote-login, found %q", forbidden)
 		}
 	}
 }


### PR DESCRIPTION
## What

Installs a minute-interval `dev.tuist.ssh-reachability` LaunchDaemon on each mini that probes loopback `:22` and, **only if it isn't accepting**, reloads the ssh socket (`launchctl bootout com.openssh.sshd` + `bootstrap … ssh.plist`) to drain a wedged accept backlog. Rides first-boot `Run` and drift `UpdateTartKubelet`; folded into `HostConfigHash`.

## Why (diagnosed from a host shell on a wedged mini)

The cache-volume rollout (#11788) never reached the prod runner fleet because the CAPI controller couldn't SSH to the runners — `:22` timed out on every interface. Ground truth:

- App firewall **OFF**, pf has **no `:22` rule**, sshd **listening on `*:22`**, `UseDNS` already **`no`** — yet even `127.0.0.1:22` times out.
- `netstat`: **~128 sockets in `SYN_RCVD`** → the accept backlog is exhausted, so the kernel drops every new SYN.
- The runner PN networking intermittently degrades the host resolver (`si_destination_compare send failed`), slowing sshd's per-connection lookups; with the controller dialing `:22` every ~30s and half-open connections lingering, the backlog fills and stays full (self-perpetuating). Our `:8080/:9100/:5900` listeners are unaffected because they don't gate on the ssh accept path.

**It was never a firewall or reverse-DNS.** Reloading the ssh socket **drains the backlog and `:22` recovers immediately** — verified live on canary (loopback + tailnet + public all reachable, and the operator then converged the mini so `/Volumes/tuist-runner-cache` provisioned).

## Correction from review

An earlier revision of this branch set `UseDNS no`, on the theory that reverse-DNS was the slow lookup. Review (Codex) correctly noted `UseDNS` was **already `no`** on the minis (`sshd -T` confirms; main-config `UseDNS` is commented), so that drop-in was a **no-op** and didn't address the wedge. Dropped it (and with it the drop-in precedence / fail-closed concerns, which were about that no-op). The accept-backlog **drain** is what actually recovers a wedged host, and is robust to whichever lookup is slow.

## Rollout

- Keeps future/recreated minis (and any that converge) self-healing: a wedge drains within ~60s instead of stranding the host (recreation was the only recovery before).
- Existing wedged minis are unblocked by draining the socket once (via the Scaleway console) — then the operator converges them and installs this daemon.