### PR TITLE
fix(server): rewrite secure-shell GitHub submodule addresses

### DIFF
--- a/tuist_common/lib/tuist_common/git/authentication.ex
+++ b/tuist_common/lib/tuist_common/git/authentication.ex
@@ -4,7 +4,12 @@ defmodule TuistCommon.Git.Authentication do
   or process arguments.
   """
 
-  @github_rewrite_config ["-c", "url.https://github.com/.insteadOf=git@github.com:"]
+  @github_rewrite_config [
+    "-c",
+    "url.https://github.com/.insteadOf=git@github.com:",
+    "-c",
+    "url.https://github.com/.insteadOf=ssh://git@github.com/"
+  ]
   @no_prompt_env [{"GIT_TERMINAL_PROMPT", "0"}]
 
   def with_github_token(tmp_dir, token, function)

--- a/tuist_common/test/tuist_common/git/authentication_test.exs
+++ b/tuist_common/test/tuist_common/git/authentication_test.exs
@@ -3,6 +3,22 @@ defmodule TuistCommon.Git.AuthenticationTest do
 
   alias TuistCommon.Git.Authentication
 
+  test "rewrites GitHub secure shell URLs to https" do
+    for url <- [
+          "git@github.com:happn-app/AsyncOperationResult.git",
+          "ssh://git@github.com/happn-app/AsyncOperationResult.git"
+        ] do
+      {rewritten_url, 0} =
+        System.cmd(
+          "git",
+          Authentication.config_args(nil) ++ ["ls-remote", "--get-url", url]
+        )
+
+      assert String.trim(rewritten_url) ==
+               "https://github.com/happn-app/AsyncOperationResult.git"
+    end
+  end
+
   test "does not expose the token in Git command arguments or environment" do
     token = "secret-token"
     tmp_dir = Path.join(System.tmp_dir!(), "tuist-git-auth-#{System.unique_integer([:positive])}")


### PR DESCRIPTION
Fixes [TUIST-2KA](https://tuist.sentry.io/issues/TUIST-2KA).

## What changed

Git authentication now rewrites both GitHub secure-shell address forms to the authenticated web transport. The regression test asks Git to resolve both forms and covers the exact submodule address that failed in staging.

## Why

The Swift package release worker needs to fetch public submodules without depending on secure-shell host keys inside the runtime container.

## Root cause

The shared helper already rewrote the shorthand `git@github.com:...` form, but the affected package uses `ssh://git@github.com/...`. Git therefore selected secure-shell transport, and staging rejected the unknown GitHub host key before it could determine whether the repository was accessible.

After the address is rewritten, GitHub reports that this particular submodule repository is unavailable. The release worker already treats that response as permanent and skips the missing submodule.

## Approach

The existing Git `insteadOf` configuration now includes the explicit secure-shell form. This keeps transport normalization and token-backed authentication centralized instead of treating every host-key failure as a skippable package error.

## Impact

The failed `Frizlab/URLRequestOperation` release can stop retrying after deployment. Reachable submodules using the explicit form will clone through authenticated web transport, while unavailable submodules continue through the existing permanent-failure path. No configuration or data migration is required.

### How to test locally

- `cd tuist_common && mix test test/tuist_common/git/authentication_test.exs` passes 2 tests.
- `cd tuist_common && mix test --max-cases 1` passes all 162 tests.
- `cd tuist_common && mix format --check-formatted lib/tuist_common/git/authentication.ex test/tuist_common/git/authentication_test.exs` passes.
- Reproducing the affected package checkout confirms that Git rewrites the explicit secure-shell address to `https://github.com/happn-app/AsyncOperationResult.git` before GitHub returns `Repository not found`.

`mix credo` remains non-zero because the package currently reports pre-existing code-readability findings unrelated to this change.
