### PR TITLE
ci(infra): make preview-deploy failures self-diagnosing instead of rolling back the evidence

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -57,7 +57,7 @@ run-name: "Preview ${{ inputs.action || github.event.action || 'deploy' }} ${{ i
 # That resolution is checked against GHCR before being pinned, because a
 # reachable release tag is not necessarily a pushed image. When the newest
 # candidate has no image the deploy walks back and says so; when none do, it
-# fails fast instead of ImagePullBackOff-ing behind the `--atomic` timeout.
+# fails fast instead of ImagePullBackOff-ing behind the `helm --wait` timeout.
 #
 # Required GitHub Environment secret (server-k8s-preview):
 #   KUBECONFIG  - base64 kubeconfig for the preview workload cluster.
@@ -516,8 +516,8 @@ jobs:
           # A `kura@<semver>` tag reachable from the platform ref does not imply
           # a pushed image: `release-kura-docker` publishes `kura:<semver>` only
           # when a release is cut. Pinning a tag that was never pushed leaves the
-          # pod in ImagePullBackOff until `--atomic` times out and rolls back,
-          # ~20 min after the fact. Probe the registry instead and walk back to
+          # pod in ImagePullBackOff until `helm --wait` times out, ~20 min after
+          # the fact. Probe the registry instead and walk back to
           # the newest release that has an image, so the deploy either runs a
           # real image or fails immediately with an actionable error.
           # Only a 404 means "never pushed". Treating a 5xx or an auth failure
@@ -602,7 +602,7 @@ jobs:
       - name: Verify preview platform
         # The platform chart and the cluster-wide Kura controller are owned by
         # preview-platform-reconcile.yml. Fail fast with something actionable
-        # rather than letting `helm --atomic` time out on a KuraInstance no
+        # rather than letting `helm --wait` time out on a KuraInstance no
         # controller will ever reconcile.
         run: |
           set -euo pipefail
@@ -701,6 +701,16 @@ jobs:
         # migration as a regular Job (server.migrationJob.asHook=false), so
         # without this Helm returns success while migrations are still running
         # and the seed step below writes into a half-migrated database.
+        #
+        # Deliberately NOT --atomic. On failure --atomic uninstalls the release
+        # before the `Diagnostics on failure` step runs, so diagnostics found
+        # "No resources found" and captured zero pod logs — which is what made a
+        # failing ClickHouse migration and a server boot crash look identical
+        # from CI ("server not ready, progress deadline exceeded"), each needing
+        # an off-CI reproduction to tell apart. Without it the failed pods
+        # survive for diagnostics to read, and the preview-janitor reaps the
+        # botched namespace via its stuck-create path (state=creating older than
+        # STUCK_CREATE_AGE_SECONDS), so nothing is left orphaned.
         run: |
           set -euo pipefail
           helm upgrade --install "$RELEASE" "$HELM_CHART_PATH" \
@@ -724,7 +734,7 @@ jobs:
             --set-string "kuraRuntime.instance.labels.tuist\.dev/preview-source=$SOURCE" \
             --set-file "kuraRuntime.instance.extensionScript=kura/ops/helm/kura/hooks/tuist.lua" \
             --set "server.kuraEndpointUrls[0]=https://$KURA_HOST" \
-            --atomic --timeout 20m --wait --wait-for-jobs
+            --timeout 20m --wait --wait-for-jobs
       - name: Wait for KuraInstance
         run: |
           set -euo pipefail
@@ -1085,7 +1095,9 @@ jobs:
           echo "::group::events"
           kubectl -n "$NAMESPACE" get events --sort-by=.lastTimestamp | tail -50 || true
           echo "::endgroup::"
-          for component in server registry swift-registry-sync; do
+          # server-migration first: a failing migration Job is the most common
+          # deploy blocker, and its pod logs carry the actual database error.
+          for component in server-migration server registry swift-registry-sync; do
             echo "::group::$component pods"
             kubectl -n "$NAMESPACE" describe pods -l "app.kubernetes.io/component=$component" || true
             echo "::endgroup::"
@@ -1093,6 +1105,9 @@ jobs:
             for pod in $(kubectl -n "$NAMESPACE" get pods -l "app.kubernetes.io/component=$component" -o name 2>/dev/null); do
               echo "::group::$pod logs"
               kubectl -n "$NAMESPACE" logs "$pod" --all-containers --tail=300 || true
+              # A crash-looping container's current logs are its latest restart;
+              # the failure that started the loop is in the previous instance.
+              kubectl -n "$NAMESPACE" logs "$pod" --all-containers --previous --tail=300 2>/dev/null || true
               echo "::endgroup::"
             done
           done


### PR DESCRIPTION
Preview deploys have failed twice this week for two unrelated reasons (a ClickHouse migration that skipped a table, then a server that crash-looped on boot), and in both cases the CI logs were useless: the deploy job just said "server not ready, progress deadline exceeded" and the diagnostics step printed "No resources found." Each one had to be reproduced off-CI, on a scratch namespace in the preview cluster, to find the actual error. This makes the pipeline tell us what went wrong the first time.

### What changed

- Removed `--atomic` from the deploy's `helm upgrade --install`.
- Added the migration Job's pods (`app.kubernetes.io/component=server-migration`) to the `Diagnostics on failure` step, listed first.
- Added a best-effort `kubectl logs --previous` dump so a crash-looping container's original failure is captured, not just its latest restart.
- Updated three comments elsewhere in the file that referenced `--atomic`'s timeout/rollback as rationale, so they no longer describe a flag the workflow no longer passes.

### Why

The deploy runs `helm upgrade --install ... --atomic --wait --wait-for-jobs`. `--atomic` means: on any failure, uninstall the release and roll back. The `Diagnostics on failure` step runs after helm returns, so by the time it executes, `--atomic` has already deleted every pod in the namespace. That is why every failed run captured this and nothing else:

```
##[group]server pods
No resources found in preview-sha-11835 namespace.
##[endgroup]
```

On top of that, the diagnostics loop only covered `server registry swift-registry-sync`. The migration runs as its own Job with the `server-migration` component label, so even with the pods present its logs were never dumped, and the migration is exactly where the first of the two failures lived.

### Root cause of the blind spot

Two independent gaps compounding:

1. `--atomic` destroys the evidence before diagnostics can read it. Both a `Ch.Error ... Database tuist does not exist (UNKNOWN_TABLE)` in the migrate Job and a `Kernel pid terminated` boot crash in the server container present identically at the helm layer as "Deployment not ready, progress deadline exceeded". Without the pod logs there is no way to tell them apart from CI.
2. The migration Job pods were never in the diagnostics loop, so the single place the database error was printed would not have been captured even if the pods had survived.

### Approach

`--atomic` was doing two jobs: waiting for readiness, and cleaning up on failure. `--wait` (kept) already covers the first. The cleanup is redundant here because the `preview-janitor` CronJob already reaps botched deploys: a failed deploy leaves the namespace labeled `state=creating`, and the janitor deletes `state=creating` namespaces whose `created-at` is older than `STUCK_CREATE_AGE_SECONDS` (30 min). So dropping `--atomic` leaves the failed pods up just long enough for the diagnostics step to read them, and nothing is orphaned.

Re-deploys are unaffected: a non-atomic failed `helm upgrade` leaves the release in `failed` state, which `helm upgrade --install` upgrades from normally on the next push, and deleting the namespace (janitor or teardown) removes the release secret with it.

Alternatives considered and rejected:
- Keep `--atomic` and capture logs before the rollback. Not possible: `--atomic` performs the rollback inside the same helm invocation, so there is no hook between the failure and the teardown.
- Add an explicit `helm uninstall` after diagnostics to mimic `--atomic`. Unnecessary, because the janitor's stuck-create path already handles exactly this cleanup; adding a second teardown mechanism would just be another thing to keep in sync.

### Impact

Only the failure path changes. A successful deploy behaves exactly as before (`--wait --wait-for-jobs` still gate success on readiness and Job completion). A failed deploy now leaves its pods up for the ~duration between failure and the next janitor sweep, and the workflow log contains the real migrate/server/registry pod output (current and previous instances) instead of "No resources found."

### Validation

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/preview-deploy.yml'))"` parses; all 10 jobs still present.
- Confirmed no active `--atomic` flag remains (only the explanatory comment).
- Against a live preview in the cluster, confirmed the new selector matches the migrate pods:
  ```
  $ kubectl -n preview-ondemand-mainok get pods -l app.kubernetes.io/component=server-migration
  ondemand-mainok-tuist-server-migrate-r2-5dq2t   component=server-migration
  ```
  so the migration logs will actually be collected.
- Verified against the janitor's in-cluster script that `state=creating` namespaces past `STUCK_CREATE_AGE_SECONDS` are reaped, so removing `--atomic` does not leak namespaces.

### How to test

On a PR labeled `preview`, force a deploy failure (e.g. a migration that raises) and confirm the `Deploy` job's `Diagnostics on failure` step now contains the migrate/server pod logs with the real error, rather than `No resources found`.
