### PR TITLE
fix(cli): backport active-architecture macro builds to 4.202.x

### DIFF
--- a/cli/Sources/TuistGenerator/Settings/DefaultSettingsProvider.swift
+++ b/cli/Sources/TuistGenerator/Settings/DefaultSettingsProvider.swift
@@ -51,6 +51,7 @@ public struct DefaultSettingsProvider: DefaultSettingsProviding {
         "SDKROOT",
         "CODE_SIGN_IDENTITY",
         "LD_RUNPATH_SEARCH_PATHS",
+        "ONLY_ACTIVE_ARCH",
         "SWIFT_OPTIMIZATION_LEVEL",
         "SWIFT_ACTIVE_COMPILATION_CONDITIONS",
         "CURRENT_PROJECT_VERSION",
@@ -287,6 +288,7 @@ public struct DefaultSettingsProvider: DefaultSettingsProviding {
             ]
         } else if target.product == .macro {
             return [
+                "ONLY_ACTIVE_ARCH": "YES",
                 "SKIP_INSTALL": "YES",
             ]
         } else {

--- a/cli/Tests/TuistAutomationAcceptanceTests/BuildAcceptanceTests.swift
+++ b/cli/Tests/TuistAutomationAcceptanceTests/BuildAcceptanceTests.swift
@@ -398,10 +398,20 @@ struct BuildAcceptanceTestSwiftPMPrebuiltMacro {
         .inTemporaryDirectory,
         .timeLimit(.minutes(2))
     )
-    func app_with_swiftpm_prebuilt_macro_dependency_generates_prebuilt_macro_settings() async throws {
+    func app_with_swiftpm_prebuilt_macro_dependency_builds_with_host_only_prebuilt_macro_support() async throws {
         let fixtureDirectory = try #require(TuistTest.fixtureDirectory)
+        let derivedDataPath = try #require(FileSystem.temporaryTestDirectory)
+        let fileSystem = FileSystem()
 
-        try await TuistTest.run(InstallCommand.self, ["--path", fixtureDirectory.pathString])
+        try await TuistTest.run(
+            InstallCommand.self,
+            ["--path", fixtureDirectory.pathString, "--force-resolved-versions"]
+        )
+        let prebuiltDirectory = fixtureDirectory.appending(
+            components: "Tuist", ".build", "prebuilts", "swift-syntax"
+        )
+        #expect(try await fileSystem.exists(prebuiltDirectory, isDirectory: true))
+
         try await TuistTest.run(GenerateCommand.self, ["--no-open", "--path", fixtureDirectory.pathString])
 
         let xcodeproj = try XcodeProj(
@@ -414,7 +424,8 @@ struct BuildAcceptanceTestSwiftPMPrebuiltMacro {
         #expect(!targetNames.contains("SwiftCompilerPlugin"))
 
         let macroTarget = try TuistAcceptanceTest.requireTarget("MacroDependencyMacros", in: xcodeproj)
-        let buildSettings = try #require(macroTarget.buildConfigurationList?.configuration(name: "Debug")?.buildSettings)
+        let buildSettings = try #require(macroTarget.buildConfigurationList?.configuration(name: "Release")?.buildSettings)
+
         let otherSwiftFlags = try #require(buildSettings["OTHER_SWIFT_FLAGS"]?.arrayValue)
         #expect(otherSwiftFlags.contains("-I"))
         #expect(otherSwiftFlags.contains(where: {
@@ -431,6 +442,41 @@ struct BuildAcceptanceTestSwiftPMPrebuiltMacro {
 
         let otherLDFlags = try #require(buildSettings["OTHER_LDFLAGS"]?.arrayValue)
         #expect(otherLDFlags.contains("-lMacroSupport"))
+
+        #if arch(arm64)
+            let nonHostModulePattern = "**/x86_64-apple-macos.*"
+        #else
+            let nonHostModulePattern = "**/arm64-apple-macos.*"
+        #endif
+
+        let nonHostModulePaths = try await fileSystem.glob(
+            directory: prebuiltDirectory,
+            include: [nonHostModulePattern]
+        ).collect()
+        for nonHostModulePath in nonHostModulePaths {
+            try await fileSystem.remove(nonHostModulePath)
+        }
+
+        try await TuistTest.run(
+            XcodeBuildBuildCommand.self,
+            [
+                "build",
+                "-workspace",
+                fixtureDirectory.appending(component: "App.xcworkspace").pathString,
+                "-scheme",
+                "App",
+                "-configuration",
+                "Release",
+                "-derivedDataPath",
+                derivedDataPath.pathString,
+                "-skipMacroValidation",
+                "CODE_SIGNING_ALLOWED=NO",
+                "CODE_SIGNING_REQUIRED=NO",
+                "CODE_SIGN_IDENTITY=",
+            ]
+        )
+
+        #expect(buildSettings["ONLY_ACTIVE_ARCH"]?.stringValue == "YES")
     }
 }
 

--- a/cli/Tests/TuistAutomationAcceptanceTests/BuildAcceptanceTests.swift
+++ b/cli/Tests/TuistAutomationAcceptanceTests/BuildAcceptanceTests.swift
@@ -412,6 +412,34 @@ struct BuildAcceptanceTestSwiftPMPrebuiltMacro {
         )
         #expect(try await fileSystem.exists(prebuiltDirectory, isDirectory: true))
 
+        // SwiftPM downloads the prebuilt swift-syntax macro libraries from download.swift.org and
+        // validates the prebuilt manifest's Apple code-signing certificate before extracting them
+        // under a `<hash>-MacroSupport` directory. When that certificate fails validation SwiftPM
+        // extracts nothing and resolves swift-syntax from source instead, and tuist wires the macro
+        // through a module map rather than the prebuilt libraries. The "Swift Package Collection:
+        // Apple Inc. - Swift" certificate signing these manifests expired on 2026-07-10, disabling
+        // the prebuilt path until Apple re-signs it (or the toolchain moves to a signed manifest).
+        //
+        // The assertions below cover the prebuilt integration, so they only apply when SwiftPM
+        // actually extracted the prebuilt libraries. Scope the tolerance narrowly so a tuist-side
+        // regression is still caught rather than masked by the skip:
+        //   - `#expect` above already fails if the prebuilt directory was never set up (e.g. tuist
+        //     stopped requesting prebuilts).
+        //   - Detect extracted `-MacroSupport` libraries across the whole prebuilts tree, not just
+        //     the expected `swift-syntax` package directory. If they were extracted but to an
+        //     unexpected location the assertions still run and fail on the expected-path checks.
+        // Only when nothing was extracted anywhere — the state SwiftPM is left in when it rejects
+        // the manifest — do we tolerate the outage and let the test self-heal once a signed
+        // manifest is available (e.g. on a toolchain whose manifest has been re-signed).
+        let prebuiltsDirectory = fixtureDirectory.appending(
+            components: "Tuist", ".build", "prebuilts"
+        )
+        let extractedPrebuiltModules = try await fileSystem.glob(
+            directory: prebuiltsDirectory,
+            include: ["**/*-MacroSupport/**/*-apple-macos.*"]
+        ).collect()
+        guard !extractedPrebuiltModules.isEmpty else { return }
+
         try await TuistTest.run(GenerateCommand.self, ["--no-open", "--path", fixtureDirectory.pathString])
 
         let xcodeproj = try XcodeProj(

--- a/cli/Tests/TuistGeneratorTests/Settings/DefaultSettingsProviderTests.swift
+++ b/cli/Tests/TuistGeneratorTests/Settings/DefaultSettingsProviderTests.swift
@@ -1131,6 +1131,7 @@ struct DefaultSettingsProvider_MacosTests {
 
     private let macroTargetEssentialDebugSettings: [String: SettingValue] = [
         "SWIFT_ACTIVE_COMPILATION_CONDITIONS": .array(["$(inherited)", "DEBUG"]),
+        "ONLY_ACTIVE_ARCH": "YES",
         "SKIP_INSTALL": "YES",
         "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
         "SWIFT_VERSION": "5",
@@ -1139,6 +1140,7 @@ struct DefaultSettingsProvider_MacosTests {
     ]
 
     private let macroTargetEssentialReleaseSettings: [String: SettingValue] = [
+        "ONLY_ACTIVE_ARCH": "YES",
         "SKIP_INSTALL": "YES",
         "SWIFT_OPTIMIZATION_LEVEL": "-O",
         "SWIFT_VERSION": "5",

--- a/examples/xcode/generated_app_with_swiftpm_prebuilt_macro_dependency/Tuist/Package.resolved
+++ b/examples/xcode/generated_app_with_swiftpm_prebuilt_macro_dependency/Tuist/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "186bf001a65f4bd7e4cf8b24ece320fd7c0088b231021a3e0828a452855b8c6e",
+  "pins" : [
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-syntax.git",
+      "state" : {
+        "revision" : "4799286537280063c85a32f09884cfbca301b1a1",
+        "version" : "602.0.0"
+      }
+    }
+  ],
+  "version" : 3
+}


### PR DESCRIPTION
## What changed

- Backport [#11668](https://github.com/tuist/tuist/pull/11668) to the `releases/4.202.x` stable line.
- Configure generated Swift macro targets with `ONLY_ACTIVE_ARCH = YES` and preserve that value in essential target settings.
- Expand the swift-syntax prebuilt macro fixture so it can validate a host-only prebuilt with a raw Release `xcodebuild`.
- Carry the test-only availability guard from [#11796](https://github.com/tuist/tuist/pull/11796), because SwiftPM currently rejects Apple's expired prebuilt-manifest certificate and falls back to source.

## Why

Macro targets are host tools, but generated Release targets inherited Xcode's standard macOS architecture behavior. On Apple Silicon that can build both arm64 and x86_64 slices. A host-only swift-syntax MacroSupport prebuilt provides the arm64 modules only, so the x86_64 macro slice fails while resolving `SwiftCompilerPlugin`.

This affects the 4.202 stable line now that it contains SwiftPM prebuilt macro support. Restricting only macro targets to the active host architecture matches SwiftPM's host-tool behavior without changing the architecture settings for apps or libraries.

## Root cause and approach

The prebuilt substitution itself is valid. The generated macro target was allowed to request a non-host architecture that the host-only prebuilt cannot satisfy.

The backport sets `ONLY_ACTIVE_ARCH = YES` only when `target.product == .macro`, then includes that value in the essential-settings allowlist so it is emitted into generated projects. Unit expectations cover both Debug and Release settings. When MacroSupport is available, the acceptance test removes the non-host module slice and verifies the Release build directly.

The availability guard is intentionally narrow: it returns early only when SwiftPM extracted no MacroSupport modules anywhere in the prebuilts tree. If prebuilts were extracted to an unexpected location, the path assertions still run and fail.

## Impact

Release builds on Apple Silicon no longer attempt an unsupported x86_64 slice for host macro targets backed by host-only prebuilt modules. Other target products keep their existing architecture behavior.

## Validation

- `mise run cli:lint --fix`
- `xcsiftbuild test -workspace Tuist.xcworkspace -scheme Tuist-Workspace -only-testing TuistGeneratorTests/DefaultSettingsProvider_MacosTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" COMPILATION_CACHE_ENABLE_CACHING=NO`
- `xcsiftbuild test -workspace Tuist.xcworkspace -scheme Tuist-Workspace -only-testing TuistAutomationAcceptanceTests/BuildAcceptanceTestSwiftPMPrebuiltMacro CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" COMPILATION_CACHE_ENABLE_CACHING=NO`

Both focused test commands exited successfully. On the current toolchain, the acceptance case exercised the source fallback because the Apple prebuilt-manifest certificate has expired; its full host-only build path automatically resumes when signed MacroSupport prebuilts are available.